### PR TITLE
fix(tui): guard buffer side effects

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -184,7 +184,8 @@ export class WorkbenchBufferStore {
       return false;
     }
     this.#openGeneration += 1;
-    if (this.#file) notifyBufferLspClosed(this.#file.absolutePath);
+    const closedFile = this.#file;
+    if (closedFile) safeNotifyBufferLsp(() => notifyBufferLspClosed(closedFile.absolutePath));
     this.#file = null;
     this.#document = null;
     this.#status = "idle";
@@ -231,7 +232,7 @@ export class WorkbenchBufferStore {
       this.#error = null;
       this.#conflictKind = null;
       this.#hoverText = null;
-      notifyBufferLspSaved(nextFile.absolutePath);
+      safeNotifyBufferLsp(() => notifyBufferLspSaved(nextFile.absolutePath));
       this.#emit();
       return true;
     } catch (error) {
@@ -253,7 +254,14 @@ export class WorkbenchBufferStore {
     }
 
     const line = this.#position().line;
-    const opened = this.#openExternalEditor(file.absolutePath, line);
+    let opened: boolean;
+    try {
+      opened = this.#openExternalEditor(file.absolutePath, line);
+    } catch (error) {
+      logError(error);
+      this.#setProblem("error", `Failed to open external editor: ${errorMessage(error)}`, null);
+      return false;
+    }
     if (!opened) {
       this.#setProblem("error", "No external editor is available for BUFFER. Set $VISUAL or $EDITOR, or install nvim/vim.", null);
       return false;
@@ -750,7 +758,8 @@ export class WorkbenchBufferStore {
     this.#ensureCursorVisible();
     const nextText = bufferText(next);
     if (notifyLsp && nextText !== previousText && this.#file) {
-      notifyBufferLspChanged(this.#file.absolutePath, nextText);
+      const file = this.#file;
+      if (file) safeNotifyBufferLsp(() => notifyBufferLspChanged(file.absolutePath, nextText));
     }
     this.#emit();
   }
@@ -801,7 +810,9 @@ export class WorkbenchBufferStore {
         displayPath,
       });
       if (generation !== this.#openGeneration) return false;
-      if (previousPath && previousPath !== snapshot.absolutePath) notifyBufferLspClosed(previousPath);
+      if (previousPath && previousPath !== snapshot.absolutePath) {
+        safeNotifyBufferLsp(() => notifyBufferLspClosed(previousPath));
+      }
       this.#file = snapshot;
       this.#document = createBufferDocument(snapshot.content, line);
       this.#resetVimState();
@@ -810,7 +821,7 @@ export class WorkbenchBufferStore {
       this.#conflictKind = null;
       this.#hoverText = null;
       this.#ensureCursorVisible();
-      notifyBufferLspOpened(snapshot.absolutePath, snapshot.content);
+      safeNotifyBufferLsp(() => notifyBufferLspOpened(snapshot.absolutePath, snapshot.content));
       this.#emit();
       return true;
     } catch (error) {
@@ -910,6 +921,14 @@ function displayPathForAbsolute(absolutePath: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function safeNotifyBufferLsp(notify: () => void): void {
+  try {
+    notify();
+  } catch (error) {
+    logError(error);
+  }
 }
 
 function normalizeVimNormalInput(input: string, key: Key): string | null {

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -108,6 +108,29 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getSnapshot().dirty).toBe(false);
   });
 
+  it("logs failed save notifications without failing the save", async () => {
+    const file = join(dir, "target.txt");
+    await writeFile(file, "alpha\n", "utf8");
+    const error = new Error("save notification failed");
+    lspHarness.notifyBufferLspSaved.mockImplementation(() => {
+      throw error;
+    });
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+    store.insert("draft ");
+
+    await expect(store.save()).resolves.toBe(true);
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "ready",
+      filePath: "target.txt",
+      dirty: false,
+      error: null,
+    });
+    expect(await readFile(file, "utf8")).toBe("draft alpha\n");
+  });
+
   it("reverts explicit unsaved edits from disk", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\n", "utf8");
@@ -144,6 +167,26 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getText()).toBe("");
   });
 
+  it("logs failed close notifications without blocking buffer close", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    const error = new Error("close notification failed");
+    lspHarness.notifyBufferLspClosed.mockImplementation(() => {
+      throw error;
+    });
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    expect(store.close()).toBe(true);
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "idle",
+      filePath: null,
+      error: null,
+    });
+    expect(store.getText()).toBe("");
+  });
+
   it("opens the current file in the external editor and reloads after it exits", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\nomega\n", "utf8");
@@ -166,6 +209,47 @@ describe("WorkbenchBufferStore", () => {
       filePath: "target.txt",
       position: { line: 2 },
     });
+  });
+
+  it("logs external editor launcher exceptions without rejecting", async () => {
+    const file = join(dir, "target.txt");
+    await writeFile(file, "alpha\n", "utf8");
+    const error = new Error("editor crashed");
+    const store = new WorkbenchBufferStore({
+      openExternalEditor: () => {
+        throw error;
+      },
+    });
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    await expect(store.openExternalEditor()).resolves.toBe(false);
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "error",
+      filePath: "target.txt",
+      error: "Failed to open external editor: editor crashed",
+    });
+    expect(store.getText()).toBe("alpha\n");
+  });
+
+  it("logs failed open notifications without blocking the loaded buffer", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    const error = new Error("open notification failed");
+    lspHarness.notifyBufferLspOpened.mockImplementation(() => {
+      throw error;
+    });
+    const store = new WorkbenchBufferStore();
+
+    await expect(runWithCwdOverride(dir, () => store.open("target.txt"))).resolves.toBeUndefined();
+
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "ready",
+      filePath: "target.txt",
+      error: null,
+    });
+    expect(store.getText()).toBe("alpha\n");
   });
 
   it("ignores stale hover responses after switching files", async () => {
@@ -205,6 +289,27 @@ describe("WorkbenchBufferStore", () => {
       status: "ready",
     });
     expect(store.getText()).toBe("alpha\n");
+  });
+
+  it("logs failed change notifications without rejecting edits", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    const error = new Error("change notification failed");
+    lspHarness.notifyBufferLspChanged.mockImplementation(() => {
+      throw error;
+    });
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    expect(() => store.insert("draft ")).not.toThrow();
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "ready",
+      filePath: "target.txt",
+      dirty: true,
+      error: null,
+    });
+    expect(store.getText()).toBe("draft alpha\n");
   });
 
   it("ignores stale definition responses after switching files", async () => {


### PR DESCRIPTION
## Summary
- Guard buffer LSP notification side effects so synchronous notify failures are logged without breaking open, edit, save, or close behavior.
- Convert external editor launcher exceptions into logged buffer errors with a `false` result instead of rejected promises.
- Add focused regressions for failed open/change/save/close notifications and launcher exceptions.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-store.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-external-editor.test.ts tests/tui/workbench/buffer-highlight.test.ts --reporter=dot
- git diff --check
- branding/attribution diff scan
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated Knip backlog still fails)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core