### PR TITLE
fix(tui): handle teams dialog config failures

### DIFF
--- a/runtime/src/tui/components/teams/TeamsDialog.tsx
+++ b/runtime/src/tui/components/teams/TeamsDialog.tsx
@@ -140,13 +140,28 @@ export function TeamsDialog({
 
   // Handler for confirm:cycleMode - cycle teammate permission modes
   const handleCycleMode = useCallback(() => {
+    setActionNotice(null);
     if (dialogLevel.type === 'teammateDetail' && currentTeammate) {
       // Detail view: cycle just this teammate
-      cycleTeammateMode(currentTeammate, dialogLevel.teamName, isBypassAvailable);
+      const result = cycleTeammateMode(currentTeammate, dialogLevel.teamName, isBypassAvailable);
+      if (!result.ok) {
+        setActionNotice({
+          kind: 'error',
+          message: result.message
+        });
+        return;
+      }
       setRefreshKey(k => k + 1);
     } else if (dialogLevel.type === 'teammateList' && teammateStatuses.length > 0) {
       // List view: cycle all teammates in tandem
-      cycleAllTeammateModes(teammateStatuses, dialogLevel.teamName, isBypassAvailable);
+      const result = cycleAllTeammateModes(teammateStatuses, dialogLevel.teamName, isBypassAvailable);
+      if (!result.ok) {
+        setActionNotice({
+          kind: 'error',
+          message: result.message
+        });
+        return;
+      }
       setRefreshKey(k => k + 1);
     }
   }, [dialogLevel, currentTeammate, teammateStatuses, isBypassAvailable]);
@@ -574,7 +589,14 @@ async function killTeammate(paneId: string, backendType: PaneBackendType | undef
   }
 
   // Remove from team config file
-  if (!removeMemberFromTeam(teamName, paneId)) {
+  let removedFromTeam: boolean;
+  try {
+    removedFromTeam = removeMemberFromTeam(teamName, paneId);
+  } catch (error) {
+    logError(error);
+    return fail(`Killed @${teammateName}, but could not remove it from team ${teamName}: ${errorMessage(error)}`);
+  }
+  if (!removedFromTeam) {
     return fail(`Killed @${teammateName}, but could not remove it from team ${teamName}.`);
   }
 
@@ -736,12 +758,22 @@ async function showTeammate(teammate: TeammateStatus, teamName: string): Promise
  * Send a mode change message to a single teammate
  * Also updates config.json directly so the UI reflects the change immediately
  */
-function sendModeChangeToTeammate(teammateName: string, teamName: string, targetMode: PermissionMode): void {
+function sendModeChangeToTeammate(teammateName: string, teamName: string, targetMode: PermissionMode): TeamActionResult {
   // Update config.json directly so UI shows the change immediately
-  setMemberMode(teamName, teammateName, targetMode);
+  let updatedMode: boolean;
+  try {
+    updatedMode = setMemberMode(teamName, teammateName, targetMode);
+  } catch (error) {
+    logError(error);
+    return fail(`Cannot change @${teammateName} mode: ${errorMessage(error)}`);
+  }
+  if (!updatedMode) {
+    return fail(`Cannot change @${teammateName} mode: could not update team config.`);
+  }
 
   sendModeChangeMailboxMessage(teammateName, teamName, targetMode);
   logForDebugging(`[TeamsDialog] Sent mode change to ${teammateName}: ${targetMode}`);
+  return ok();
 }
 
 function sendModeChangeMailboxMessage(teammateName: string, teamName: string, targetMode: PermissionMode): void {
@@ -762,7 +794,7 @@ function sendModeChangeMailboxMessage(teammateName: string, teamName: string, ta
 /**
  * Cycle a single teammate's mode
  */
-function cycleTeammateMode(teammate: TeammateStatus, teamName: string, isBypassAvailable: boolean): void {
+function cycleTeammateMode(teammate: TeammateStatus, teamName: string, isBypassAvailable: boolean): TeamActionResult {
   const currentMode = teammate.mode ? permissionModeFromString(teammate.mode) : 'default';
   const context = {
     ...getEmptyToolPermissionContext(),
@@ -770,7 +802,7 @@ function cycleTeammateMode(teammate: TeammateStatus, teamName: string, isBypassA
     isBypassPermissionsModeAvailable: isBypassAvailable
   };
   const nextMode = getNextPermissionMode(context);
-  sendModeChangeToTeammate(teammate.name, teamName, nextMode);
+  return sendModeChangeToTeammate(teammate.name, teamName, nextMode);
 }
 
 /**
@@ -779,8 +811,8 @@ function cycleTeammateMode(teammate: TeammateStatus, teamName: string, isBypassA
  * If same, cycle all to next mode
  * Uses batch update to avoid race conditions
  */
-function cycleAllTeammateModes(teammates: TeammateStatus[], teamName: string, isBypassAvailable: boolean): void {
-  if (teammates.length === 0) return;
+function cycleAllTeammateModes(teammates: TeammateStatus[], teamName: string, isBypassAvailable: boolean): TeamActionResult {
+  if (teammates.length === 0) return ok();
   const modes = teammates.map(t => t.mode ? permissionModeFromString(t.mode) : 'default');
   const allSame = modes.every(m => m === modes[0]);
 
@@ -796,11 +828,21 @@ function cycleAllTeammateModes(teammates: TeammateStatus[], teamName: string, is
     memberName: t.name,
     mode: targetMode
   }));
-  setMultipleMemberModes(teamName, modeUpdates);
+  let updatedModes: boolean;
+  try {
+    updatedModes = setMultipleMemberModes(teamName, modeUpdates);
+  } catch (error) {
+    logError(error);
+    return fail(`Cannot change team ${teamName} modes: ${errorMessage(error)}`);
+  }
+  if (!updatedModes) {
+    return fail(`Cannot change team ${teamName} modes: could not update team config.`);
+  }
 
   // Send mailbox messages to each teammate
   for (const teammate of teammates) {
     sendModeChangeMailboxMessage(teammate.name, teamName, targetMode);
   }
   logForDebugging(`[TeamsDialog] Sent mode change to all ${teammates.length} teammates: ${targetMode}`);
+  return ok();
 }

--- a/runtime/tests/tui/components/teams/TeamsDialog.coverage2.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.coverage2.test.tsx
@@ -216,7 +216,9 @@ beforeEach(() => {
   teamHelpersMock.removeHiddenPaneId.mockClear();
   teamHelpersMock.removeMemberFromTeam.mockClear();
   teamHelpersMock.setMemberMode.mockClear();
+  teamHelpersMock.setMemberMode.mockReturnValue(true);
   teamHelpersMock.setMultipleMemberModes.mockClear();
+  teamHelpersMock.setMultipleMemberModes.mockReturnValue(true);
   execFileNoThrowMock.mockClear();
 });
 

--- a/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
@@ -333,7 +333,9 @@ beforeEach(() => {
   teamHelpersMock.removeHiddenPaneId.mockClear();
   teamHelpersMock.removeMemberFromTeam.mockClear();
   teamHelpersMock.setMemberMode.mockClear();
+  teamHelpersMock.setMemberMode.mockReturnValue(true);
   teamHelpersMock.setMultipleMemberModes.mockClear();
+  teamHelpersMock.setMultipleMemberModes.mockReturnValue(true);
   execFileNoThrowMock.mockReset();
   execFileNoThrowMock.mockResolvedValue({ code: 0, stderr: "", error: "" });
 });
@@ -672,6 +674,27 @@ describe("TeamsDialog rendering", () => {
       );
     } finally {
       failureHarness.unmount();
+    }
+  });
+
+  test("surfaces team config removal exceptions during kill actions", async () => {
+    const error = new Error("team file locked");
+    teamHelpersMock.removeMemberFromTeam.mockImplementationOnce(() => {
+      throw error;
+    });
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("k", {}, 80);
+
+      expect(harness.getText()).toContain(
+        "Killed @Fixer, but could not remove it from team alpha: team file locked",
+      );
+      expect(logMock.logError).toHaveBeenCalledWith(error);
+    } finally {
+      harness.unmount();
     }
   });
 

--- a/runtime/tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
@@ -348,7 +348,9 @@ beforeEach(() => {
   teamHelpersMock.removeMemberFromTeam.mockReset();
   teamHelpersMock.removeMemberFromTeam.mockReturnValue(true);
   teamHelpersMock.setMemberMode.mockReset();
+  teamHelpersMock.setMemberMode.mockReturnValue(true);
   teamHelpersMock.setMultipleMemberModes.mockReset();
+  teamHelpersMock.setMultipleMemberModes.mockReturnValue(true);
   execFileNoThrowMock.mockReset();
   execFileNoThrowMock.mockResolvedValue({ code: 0, stderr: "", error: "" });
   detectionMock.insideTmux = false;
@@ -436,6 +438,46 @@ describe("TeamsDialog coverage-swarm detail actions", () => {
       );
       expect(mailboxMock.writeToMailbox).toHaveBeenCalledTimes(2);
       expect(logMock.logError).toHaveBeenCalledWith(error);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("surfaces detail mode config exceptions without sending mailbox messages", async () => {
+    const error = new Error("team file locked");
+    teamHelpersMock.setMemberMode.mockImplementationOnce(() => {
+      throw error;
+    });
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+
+      expect(() => keybindingMock.handlers.get("confirm:cycleMode")?.()).not.toThrow();
+      await settle();
+
+      expect(harness.getText()).toContain(
+        "Cannot change @Fixer mode: team file locked",
+      );
+      expect(mailboxMock.writeToMailbox).not.toHaveBeenCalled();
+      expect(logMock.logError).toHaveBeenCalledWith(error);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("surfaces bulk mode config failures without sending mailbox messages", async () => {
+    teamHelpersMock.setMultipleMemberModes.mockReturnValueOnce(false);
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      keybindingMock.handlers.get("confirm:cycleMode")?.();
+      await settle();
+
+      expect(harness.getText()).toContain(
+        "Cannot change team alpha modes: could not update team config.",
+      );
+      expect(mailboxMock.writeToMailbox).not.toHaveBeenCalled();
     } finally {
       harness.unmount();
     }


### PR DESCRIPTION
## Summary
- Normalize team-config cleanup exceptions during teammate kill actions so the dialog renders a retryable error instead of leaking a rejection.
- Stop mode-cycling notifications when the local team config update throws or returns false.
- Add mounted regressions for kill and mode-cycling failure paths.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/teams/TeamsDialog.test.tsx tests/tui/components/teams/TeamsDialog.coverage2.test.tsx tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/teams tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx tests/tui/coverage-swarm/swarm-201-components-teams-TeamsDialog-layout.test.ts tests/tui/coverage-swarm/swarm-144-components-teams-TeamStatus.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)
