### PR TITLE
fix(tui): cancel terminal probe after unmount

### DIFF
--- a/runtime/src/tui/ink/components/App.tsx
+++ b/runtime/src/tui/ink/components/App.tsx
@@ -118,6 +118,7 @@ export default class App extends PureComponent<Props, State> {
   keyParseState = INITIAL_STATE;
   // Timer for flushing incomplete escape sequences
   incompleteEscapeTimer: NodeJS.Timeout | null = null;
+  terminalIdentityProbeImmediate: ReturnType<typeof setImmediate> | null = null;
   // Default to readable-mode stdin (compatibility Ink behavior). The data-mode path
   // is kept as an explicit opt-in because some terminals can enter a state
   // where startup input appears frozen when data mode is the default.
@@ -205,6 +206,10 @@ export default class App extends PureComponent<Props, State> {
       clearTimeout(this.pendingHyperlinkTimer);
       this.pendingHyperlinkTimer = null;
     }
+    if (this.terminalIdentityProbeImmediate) {
+      clearImmediate(this.terminalIdentityProbeImmediate);
+      this.terminalIdentityProbeImmediate = null;
+    }
     // ignore calling setRawMode on an handle stdin it cannot be called
     if (this.isRawModeSupported()) {
       this.handleSetRawMode(false);
@@ -267,7 +272,8 @@ export default class App extends PureComponent<Props, State> {
         // Delayed to next tick so it fires AFTER the current synchronous
         // init sequence completes — avoids interleaving with alt-screen/mouse
         // tracking enable writes that may happen in the same render cycle.
-        setImmediate(() => {
+        this.terminalIdentityProbeImmediate = setImmediate(() => {
+          this.terminalIdentityProbeImmediate = null;
           void Promise.all([this.querier.send(xtversion()), this.querier.flush()]).then(([r]) => {
             if (r) {
               setXtversionName(r.name);

--- a/runtime/tests/tui/coverage-swarm/swarm-010-ink-components-App.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-010-ink-components-App.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import App, { handleMouseEvent } from "../../../src/tui/ink/components/App.js";
 import type { ParsedMouse } from "../../../src/tui/ink/parse-keypress.js";
 import { createSelectionState } from "../../../src/tui/ink/selection.js";
+import { SHOW_CURSOR } from "../../../src/tui/ink/termio/dec.js";
 import { FOCUS_IN, FOCUS_OUT } from "../../../src/tui/ink/termio/csi.js";
 import {
   getTerminalFocused,
@@ -11,6 +12,13 @@ import {
 } from "../../../src/tui/ink/terminal-focus-state.js";
 
 type TestStream = NodeJS.ReadStream & NodeJS.WriteStream;
+type TestTtyStream = TestStream & {
+  isRaw?: boolean;
+  writes: string[];
+  ref: ReturnType<typeof vi.fn>;
+  setRawMode: ReturnType<typeof vi.fn>;
+  unref: ReturnType<typeof vi.fn>;
+};
 type AppProps = ConstructorParameters<typeof App>[0];
 
 function stream(): TestStream {
@@ -18,6 +26,29 @@ function stream(): TestStream {
   s.isTTY = false;
   s.write = vi.fn(() => true) as never;
   return s;
+}
+
+function ttyStream(): TestTtyStream {
+  const s = new PassThrough() as TestTtyStream;
+  s.isTTY = true;
+  s.isRaw = false;
+  s.writes = [];
+  s.ref = vi.fn();
+  s.unref = vi.fn();
+  s.setRawMode = vi.fn((mode: boolean) => {
+    s.isRaw = mode;
+  });
+  s.write = vi.fn((chunk: string | Uint8Array) => {
+    s.writes.push(String(chunk));
+    return true;
+  }) as never;
+  return s;
+}
+
+async function flushImmediateTicks(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve));
+  }
 }
 
 function mouse(
@@ -259,5 +290,25 @@ describe("Ink App coverage swarm row 010", () => {
         sequence: "a",
       }),
     );
+  });
+
+  test("cancels delayed terminal identity probes after raw mode unmount", async () => {
+    const stdin = ttyStream();
+    const stdout = ttyStream();
+    const app = createApp({
+      stdin,
+      stdout,
+    });
+
+    app.handleSetRawMode(true);
+    app.componentWillUnmount();
+    stdout.writes.length = 0;
+
+    await flushImmediateTicks(60);
+
+    expect(stdout.writes.join("")).toBe("");
+    expect(stdout.write).toHaveBeenCalledWith(SHOW_CURSOR);
+    expect(stdin.setRawMode).toHaveBeenNthCalledWith(1, true);
+    expect(stdin.setRawMode).toHaveBeenNthCalledWith(2, false);
   });
 });


### PR DESCRIPTION
## Summary
- Cancel the delayed terminal identity probe when the Ink app unmounts before the probe runs.
- Prevent XTVERSION/DA1 query bytes from being written after raw mode has been released.
- Add a regression for rapid raw-mode enable/unmount before the delayed probe tick.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-010-ink-components-App.test.tsx tests/tui/ink/components/App.wave200-011.coverage.test.tsx tests/tui/ink/components/App.coverage2.test.tsx tests/tui/ink/terminal-querier.test.ts tests/tui/coverage-swarm/swarm-055-ink-terminal-querier.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)