### PR TITLE
fix(tui): guard task store fetch races

### DIFF
--- a/runtime/src/tui/hooks/useTasksV2.ts
+++ b/runtime/src/tui/hooks/useTasksV2.ts
@@ -46,6 +46,8 @@ class TasksV2Store {
   #changed = createSignal()
   #subscriberCount = 0
   #started = false
+  #generation = 0
+  #fetchRequestId = 0
 
   /**
    * useSyncExternalStore snapshot. Returns the same Task[] reference between
@@ -64,10 +66,13 @@ class TasksV2Store {
     this.#subscriberCount++
     if (!this.#started) {
       this.#started = true
-      this.#unsubscribeTasksUpdated = onTasksUpdated(this.#debouncedFetch)
+      const generation = ++this.#generation
+      this.#unsubscribeTasksUpdated = onTasksUpdated(() => {
+        this.#debouncedFetch(generation)
+      })
       // Fire-and-forget: subscribe is called post-commit (not in render),
       // and the store notifies subscribers when the fetch resolves.
-      this.#fetchAndLog()
+      this.#fetchAndLog(generation)
     }
     let unsubscribed = false
     return () => {
@@ -83,20 +88,38 @@ class TasksV2Store {
     this.#changed.emit()
   }
 
+  #isCurrentGeneration(generation: number): boolean {
+    return (
+      this.#started &&
+      this.#subscriberCount > 0 &&
+      generation === this.#generation
+    )
+  }
+
+  #isCurrentFetch(generation: number, requestId: number): boolean {
+    return (
+      this.#isCurrentGeneration(generation) &&
+      requestId === this.#fetchRequestId
+    )
+  }
+
   /**
    * Point the file watcher at the current tasks directory. Called on start
    * and whenever #fetch detects the task list ID has changed (e.g. when
    * TeamCreateTool sets leaderTeamName mid-session).
    */
-  #rewatch(dir: string): void {
+  #rewatch(dir: string, generation: number): void {
     // Retry even on same dir if the previous watch attempt failed (dir
     // didn't exist yet). Once the watcher is established, same-dir is a no-op.
+    if (!this.#isCurrentGeneration(generation)) return
     if (dir === this.#watchedDir && this.#watcher !== null) return
     this.#watcher?.close()
     this.#watcher = null
     this.#watchedDir = dir
     try {
-      this.#watcher = watch(dir, this.#debouncedFetch)
+      this.#watcher = watch(dir, () => {
+        this.#debouncedFetch(generation)
+      })
       this.#watcher.unref()
     } catch {
       // Directory may not exist yet (ensureTasksDir is called by writers).
@@ -105,26 +128,34 @@ class TasksV2Store {
     }
   }
 
-  #debouncedFetch = (): void => {
+  #debouncedFetch = (generation: number = this.#generation): void => {
+    if (!this.#isCurrentGeneration(generation)) return
     if (this.#debounceTimer) clearTimeout(this.#debounceTimer)
-    this.#debounceTimer = setTimeout(this.#fetchAndLog, DEBOUNCE_MS)
+    this.#debounceTimer = setTimeout(() => {
+      this.#fetchAndLog(generation)
+    }, DEBOUNCE_MS)
     this.#debounceTimer.unref()
   }
 
-  #fetchAndLog = (): void => {
-    void this.#fetch().catch(error => {
+  #fetchAndLog = (generation: number = this.#generation): void => {
+    if (!this.#isCurrentGeneration(generation)) return
+    const requestId = ++this.#fetchRequestId
+    void this.#fetch(generation, requestId).catch(error => {
+      if (!this.#isCurrentFetch(generation, requestId)) return
       logError(error instanceof Error ? error : new Error(String(error)))
     })
   }
 
-  #fetch = async (): Promise<void> => {
+  #fetch = async (generation: number, requestId: number): Promise<void> => {
+    if (!this.#isCurrentGeneration(generation)) return
     const taskListId = getTaskListId()
     // Task list ID can change mid-session (TeamCreateTool sets
     // leaderTeamName) — point the watcher at the current dir.
-    this.#rewatch(getTasksDir(taskListId))
+    this.#rewatch(getTasksDir(taskListId), generation)
     const current = (await listTasks(taskListId)).filter(
       t => !t.metadata?._internal,
     )
+    if (!this.#isCurrentFetch(generation, requestId)) return
     this.#tasks = current
 
     const hasIncomplete = current.some(t => t.status !== 'completed')
@@ -136,7 +167,7 @@ class TasksV2Store {
     } else if (this.#hideTimer === null && !this.#hidden) {
       // All tasks just became completed — schedule clear
       this.#hideTimer = setTimeout(
-        this.#onHideTimerFired.bind(this, taskListId),
+        this.#onHideTimerFired.bind(this, taskListId, generation),
         HIDE_DELAY_MS,
       )
       this.#hideTimer.unref()
@@ -153,29 +184,35 @@ class TasksV2Store {
       this.#pollTimer = null
     }
     if (hasIncomplete) {
-      this.#pollTimer = setTimeout(this.#debouncedFetch, FALLBACK_POLL_MS)
+      this.#pollTimer = setTimeout(() => {
+        this.#debouncedFetch(generation)
+      }, FALLBACK_POLL_MS)
       this.#pollTimer.unref()
     }
   }
 
-  #onHideTimerFired(scheduledForTaskListId: string): void {
+  #onHideTimerFired(scheduledForTaskListId: string, generation: number): void {
     this.#hideTimer = null
+    if (!this.#isCurrentGeneration(generation)) return
     // Bail if the task list ID changed since scheduling (team created/deleted
     // during the 5s window) — don't reset the wrong list.
     const currentId = getTaskListId()
     if (currentId !== scheduledForTaskListId) return
     // Verify all tasks are still completed before clearing
     void listTasks(currentId).then(async tasksToCheck => {
+      if (!this.#isCurrentGeneration(generation)) return
       const allStillCompleted =
         tasksToCheck.length > 0 &&
         tasksToCheck.every(t => t.status === 'completed')
       if (allStillCompleted) {
         await resetTaskList(currentId)
+        if (!this.#isCurrentGeneration(generation)) return
         this.#tasks = []
         this.#hidden = true
       }
       this.#notify()
     }).catch(error => {
+      if (!this.#isCurrentGeneration(generation)) return
       logError(error instanceof Error ? error : new Error(String(error)))
       this.#notify()
     })
@@ -194,6 +231,7 @@ class TasksV2Store {
    * subsequent re-subscribe renders the last known state immediately.
    */
   #stop(): void {
+    this.#generation++
     this.#watcher?.close()
     this.#watcher = null
     this.#watchedDir = null

--- a/runtime/tests/tui/hooks/useTasksV2.test.tsx
+++ b/runtime/tests/tui/hooks/useTasksV2.test.tsx
@@ -426,6 +426,68 @@ describe('useTasksV2', () => {
     expect(fixture.state.watchers[0]?.close).toHaveBeenCalledTimes(1)
   })
 
+  test('does not recreate timers when an in-flight fetch resolves after final unsubscribe', async () => {
+    let resolveListTasks: ((tasks: Task[]) => void) | undefined
+    fixture.listTasks.mockImplementationOnce(
+      () =>
+        new Promise<Task[]>(resolve => {
+          resolveListTasks = resolve
+        }),
+    )
+
+    const mounted = await mountUseTasksV2()
+    expect(fixture.listTasks).toHaveBeenCalledTimes(1)
+    expect(fixture.watch).toHaveBeenCalledWith('/tasks/list-a', expect.any(Function))
+
+    mounted.dispose()
+
+    expect(fixture.state.watchers[0]?.close).toHaveBeenCalledTimes(1)
+    expect(fixture.state.taskListeners).toHaveLength(0)
+    expect(activeTimers()).toHaveLength(0)
+
+    resolveListTasks?.([task('1', 'pending')])
+    await flushPromises()
+
+    expect(activeTimers()).toHaveLength(0)
+  })
+
+  test('ignores stale fetch results when a newer fetch resolves first', async () => {
+    let resolveInitialFetch: ((tasks: Task[]) => void) | undefined
+    let resolveRefreshFetch: ((tasks: Task[]) => void) | undefined
+    fixture.listTasks
+      .mockImplementationOnce(
+        () =>
+          new Promise<Task[]>(resolve => {
+            resolveInitialFetch = resolve
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Task[]>(resolve => {
+            resolveRefreshFetch = resolve
+          }),
+      )
+
+    const mounted = await mountUseTasksV2()
+    expect(fixture.listTasks).toHaveBeenCalledTimes(1)
+
+    for (const listener of [...fixture.state.taskListeners]) {
+      listener()
+    }
+    await fireNextTimer(50)
+    expect(fixture.listTasks).toHaveBeenCalledTimes(2)
+
+    resolveRefreshFetch?.([task('new', 'pending')])
+    await flushPromises()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['new'])
+
+    resolveInitialFetch?.([task('old', 'completed')])
+    await flushPromises()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['new'])
+  })
+
   test('resets and hides completed tasks after the completion delay, then shows new work', async () => {
     fixture.state.tasksByList.set('list-a', [task('1', 'completed')])
     const mounted = await mountUseTasksV2()


### PR DESCRIPTION
## Summary
- Guard the Tasks V2 external store with a subscription generation so stale async fetch work cannot mutate state or recreate timers after final unsubscribe.
- Guard concurrent fetches with a latest-request id so older task snapshots cannot overwrite newer results when reads resolve out of order.
- Add regressions for post-unsubscribe fetch completion and out-of-order fetch completion.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useTasksV2.test.tsx
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useTasksV2.test.tsx tests/tui/coverage-swarm/swarm-222-hooks-useTasksV2.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)