### PR TITLE
fix(tui): preserve fullscreen hyperlink handlers

### DIFF
--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -656,6 +656,11 @@ function DesignBottomChrome({ columns }: { columns: number }): React.ReactNode {
     ]} />;
 }
 
+const fullscreenHyperlinkOwners = new WeakMap<object, {
+  base: ((url: string) => void) | undefined;
+  handlers: Array<(url: string) => void>;
+}>();
+
 // Slack-style pill. Absolute overlay at bottom={0} of the scrollwrap — floats
 // over the ScrollBox's last content row, only obscuring the centered pill
 // text (the rest of the row shows ScrollBox content). Scroll-smear from
@@ -671,9 +676,27 @@ function _temp3() {
   if (!ink) {
     return;
   }
-  ink.onHyperlinkClick = _temp2;
+  const ownerState = fullscreenHyperlinkOwners.get(ink) ?? {
+    base: ink.onHyperlinkClick,
+    handlers: [],
+  };
+  fullscreenHyperlinkOwners.set(ink, ownerState);
+  const handler = (url: string) => {
+    _temp2(url);
+  };
+  ownerState.handlers.push(handler);
+  ink.onHyperlinkClick = handler;
   return () => {
-    ink.onHyperlinkClick = undefined;
+    const index = ownerState.handlers.indexOf(handler);
+    if (index !== -1) {
+      ownerState.handlers.splice(index, 1);
+    }
+    if (ink.onHyperlinkClick === handler) {
+      ink.onHyperlinkClick = ownerState.handlers.at(-1) ?? ownerState.base;
+    }
+    if (ownerState.handlers.length === 0) {
+      fullscreenHyperlinkOwners.delete(ink);
+    }
   };
 }
 function openFullscreenHyperlinkTarget(result, failureMessage) {

--- a/runtime/tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
@@ -417,4 +417,147 @@ describe('FullscreenLayout coverage swarm 019', () => {
       await sleep()
     }
   })
+
+  test('restores only its own fullscreen hyperlink handler on unmount', async () => {
+    const previousHandler = vi.fn()
+    const replacementHandler = vi.fn()
+    const fakeInk = {
+      onHyperlinkClick: previousHandler,
+    } as { onHyperlinkClick?: (url: string) => void }
+    setInkInstance(process.stdout, fakeInk as never)
+
+    try {
+      await withFullscreenEnv(async () => {
+        const first = createStreams({ columns: 90, rows: 12 })
+        first.stdout.resume()
+        const firstRoot = await createRoot({
+          patchConsole: false,
+          stdin: first.stdin as unknown as NodeJS.ReadStream,
+          stdout: first.stdout as unknown as NodeJS.WriteStream,
+        })
+        try {
+          firstRoot.render(
+            <FullscreenLayout
+              scrollable={<Text>link body</Text>}
+              bottom={<Text>prompt body</Text>}
+            />,
+          )
+          await sleep()
+
+          expect(fakeInk.onHyperlinkClick).toEqual(expect.any(Function))
+          expect(fakeInk.onHyperlinkClick).not.toBe(previousHandler)
+
+          fakeInk.onHyperlinkClick = replacementHandler
+          firstRoot.unmount()
+          await sleep()
+
+          expect(fakeInk.onHyperlinkClick).toBe(replacementHandler)
+        } finally {
+          firstRoot.unmount()
+          first.stdin.end()
+          first.stdout.end()
+        }
+
+        const second = createStreams({ columns: 90, rows: 12 })
+        second.stdout.resume()
+        const secondRoot = await createRoot({
+          patchConsole: false,
+          stdin: second.stdin as unknown as NodeJS.ReadStream,
+          stdout: second.stdout as unknown as NodeJS.WriteStream,
+        })
+        fakeInk.onHyperlinkClick = previousHandler
+        try {
+          secondRoot.render(
+            <FullscreenLayout
+              scrollable={<Text>link body</Text>}
+              bottom={<Text>prompt body</Text>}
+            />,
+          )
+          await sleep()
+
+          secondRoot.unmount()
+          await sleep()
+
+          expect(fakeInk.onHyperlinkClick).toBe(previousHandler)
+        } finally {
+          secondRoot.unmount()
+          second.stdin.end()
+          second.stdout.end()
+        }
+      })
+    } finally {
+      deleteInkInstance(process.stdout)
+      await sleep()
+    }
+  })
+
+  test('keeps nested fullscreen hyperlink handlers stacked', async () => {
+    const previousHandler = vi.fn()
+    const fakeInk = {
+      onHyperlinkClick: previousHandler,
+    } as { onHyperlinkClick?: (url: string) => void }
+    setInkInstance(process.stdout, fakeInk as never)
+
+    try {
+      await withFullscreenEnv(async () => {
+        const first = createStreams({ columns: 90, rows: 12 })
+        const second = createStreams({ columns: 90, rows: 12 })
+        first.stdout.resume()
+        second.stdout.resume()
+        const firstRoot = await createRoot({
+          patchConsole: false,
+          stdin: first.stdin as unknown as NodeJS.ReadStream,
+          stdout: first.stdout as unknown as NodeJS.WriteStream,
+        })
+        const secondRoot = await createRoot({
+          patchConsole: false,
+          stdin: second.stdin as unknown as NodeJS.ReadStream,
+          stdout: second.stdout as unknown as NodeJS.WriteStream,
+        })
+
+        try {
+          firstRoot.render(
+            <FullscreenLayout
+              scrollable={<Text>first link body</Text>}
+              bottom={<Text>first prompt body</Text>}
+            />,
+          )
+          await sleep()
+          const firstHandler = fakeInk.onHyperlinkClick
+          expect(firstHandler).toEqual(expect.any(Function))
+
+          secondRoot.render(
+            <FullscreenLayout
+              scrollable={<Text>second link body</Text>}
+              bottom={<Text>second prompt body</Text>}
+            />,
+          )
+          await sleep()
+          const secondHandler = fakeInk.onHyperlinkClick
+          expect(secondHandler).toEqual(expect.any(Function))
+          expect(secondHandler).not.toBe(firstHandler)
+
+          firstRoot.unmount()
+          await sleep()
+
+          expect(fakeInk.onHyperlinkClick).toBe(secondHandler)
+
+          secondRoot.unmount()
+          await sleep()
+
+          expect(fakeInk.onHyperlinkClick).toBe(previousHandler)
+        } finally {
+          firstRoot.unmount()
+          secondRoot.unmount()
+          first.stdin.end()
+          first.stdout.end()
+          second.stdin.end()
+          second.stdout.end()
+        }
+      })
+    } finally {
+      deleteInkInstance(process.stdout)
+      await sleep()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Track FullscreenLayout hyperlink handler ownership per Ink instance.
- Restore the previous handler only when the unmounting layout still owns the shared slot.
- Add regressions for replacement and nested fullscreen hyperlink handlers.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx tests/tui/components/FullscreenLayout.test.tsx tests/tui/components/FullscreenLayout.render-branches.test.tsx tests/tui/components/FullscreenLayout.coverage2.test.tsx tests/tui/components/FullscreenLayout.wave200-018.coverage.test.tsx tests/tui/ink/ink.render.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)