### PR TITLE
fix(tui): report sync keybinding parse failures

### DIFF
--- a/runtime/src/tui/keybindings/loadUserBindings.ts
+++ b/runtime/src/tui/keybindings/loadUserBindings.ts
@@ -298,10 +298,23 @@ export function loadKeybindingsSyncWithWarnings(): KeybindingsLoadResult {
     }
 
     return { bindings: cachedBindings, warnings: cachedWarnings }
-  } catch {
-    // File doesn't exist or error - use defaults (user can run /keybindings to create)
+  } catch (error) {
+    // File doesn't exist - use defaults (user can run /keybindings to create)
     cachedBindings = defaultBindings
-    cachedWarnings = []
+    if (isFileNotFoundError(error)) {
+      cachedWarnings = []
+    } else {
+      logForDebugging(
+        `[keybindings] Error loading ${userPath}: ${formatErrorMessage(error)}`,
+      )
+      cachedWarnings = [
+        {
+          type: 'parse_error',
+          severity: 'error',
+          message: `Failed to parse keybindings.json: ${formatErrorMessage(error)}`,
+        },
+      ]
+    }
     return { bindings: cachedBindings, warnings: cachedWarnings }
   }
 }

--- a/runtime/tests/tui/keybindings/loadUserBindings.test.ts
+++ b/runtime/tests/tui/keybindings/loadUserBindings.test.ts
@@ -176,6 +176,17 @@ describe('loadUserBindings', () => {
         type: 'parse_error',
       }),
     ])
+
+    resetKeybindingLoaderForTesting()
+    await writeKeybindings('{')
+    const malformed = loadKeybindingsSyncWithWarnings()
+    expect(malformed.warnings).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('Failed to parse keybindings.json:'),
+        severity: 'error',
+        type: 'parse_error',
+      }),
+    ])
   })
 
   test('starts, emits, deletes, and disposes the keybinding watcher', async () => {


### PR DESCRIPTION
## Summary
- Report malformed or unreadable keybinding config files during synchronous initial TUI load.
- Keep missing keybinding config files as a quiet default-bindings fallback.
- Add a regression covering malformed JSON in the sync loader.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/keybindings/loadUserBindings.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/keybindings tests/tui/coverage-swarm/swarm-081-keybindings-loadUserBindings.test.ts tests/tui/coverage-swarm/swarm-049-keybindings-KeybindingProviderSetup.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)