### PR TITLE
fix(tui): ignore stale IDE notifications

### DIFF
--- a/runtime/src/tui/hooks/useIdeAtMentioned.ts
+++ b/runtime/src/tui/hooks/useIdeAtMentioned.ts
@@ -38,6 +38,10 @@ export function useIdeAtMentioned(
 ): void {
   const ideClientRef = useRef<ConnectedMCPServer | undefined>(undefined)
 
+  useEffect(() => () => {
+    ideClientRef.current = undefined
+  }, [])
+
   useEffect(() => {
     // Find the IDE client from the MCP clients list
     const ideClient = getConnectedIdeClient(mcpClients)

--- a/runtime/src/tui/hooks/useIdeSelection.ts
+++ b/runtime/src/tui/hooks/useIdeSelection.ts
@@ -70,6 +70,11 @@ export function useIdeSelection(
     onSelectRef.current = onSelect
   }, [onSelect])
 
+  useEffect(() => () => {
+    currentIDERef.current = null
+    handlersRegistered.current = false
+  }, [])
+
   useEffect(() => {
     // Find the IDE client from the MCP clients list
     const ideClient = getConnectedIdeClient(mcpClients)

--- a/runtime/tests/tui/coverage-swarm/swarm-066-hooks-useIdeAtMentioned.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-066-hooks-useIdeAtMentioned.test.ts
@@ -245,6 +245,27 @@ describe('useIdeAtMentioned coverage swarm 066', () => {
     }
   })
 
+  test('ignores IDE notifications after unmount', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const onAtMentioned = vi.fn()
+    const rendered = await renderHookHarness({
+      mcpClients: [{ id: 'ide' }],
+      onAtMentioned,
+    })
+
+    expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+
+    await rendered.dispose()
+
+    ideClient.emit({
+      filePath: '/workspace/src/after-unmount.ts',
+      lineStart: 0,
+    })
+
+    expect(onAtMentioned).not.toHaveBeenCalled()
+  })
+
   test('logs notification handler errors instead of surfacing callback failures', async () => {
     const ideClient = createIdeClient()
     fixture.ideClient = ideClient

--- a/runtime/tests/tui/coverage-swarm/swarm-175-hooks-useIdeSelection.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-175-hooks-useIdeSelection.test.ts
@@ -343,6 +343,32 @@ describe('useIdeSelection coverage swarm 175', () => {
     }
   })
 
+  test('ignores selection notifications after unmount', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const onSelect = vi.fn()
+    const rendered = await renderHookHarness({
+      mcpClients: [{ name: 'ide' }],
+      onSelect,
+    })
+
+    expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+    onSelect.mockClear()
+
+    await rendered.dispose()
+
+    ideClient.emit({
+      selection: {
+        start: { line: 4, character: 1 },
+        end: { line: 4, character: 6 },
+      },
+      text: 'after unmount',
+      filePath: '/workspace/src/after-unmount.ts',
+    })
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
   test('logs notification handler errors instead of surfacing callback failures', async () => {
     const ideClient = createIdeClient()
     fixture.ideClient = ideClient


### PR DESCRIPTION
## Summary
- Invalidate IDE notification hook refs on unmount.
- Prevent at-mention and selection notifications from invoking stale component callbacks after unmount.
- Add regressions for post-unmount IDE notification delivery.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-066-hooks-useIdeAtMentioned.test.ts tests/tui/coverage-swarm/swarm-175-hooks-useIdeSelection.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-066-hooks-useIdeAtMentioned.test.ts tests/tui/coverage-swarm/swarm-175-hooks-useIdeSelection.test.ts tests/tui/hooks/useIdeSelection.wave200-087.coverage.test.tsx tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)