### PR TITLE
fix(tui): guard API key verification races

### DIFF
--- a/runtime/src/tui/hooks/useApiKeyVerification.ts
+++ b/runtime/src/tui/hooks/useApiKeyVerification.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { getIsNonInteractiveSession } from '../../bootstrap/state'
 import { verifyApiKey } from '../../services/api/anthropic' // branding-scan: allow upstream mirror import path pending purge
 import {
@@ -45,10 +45,12 @@ export function useApiKeyVerification(): ApiKeyVerificationResult {
     getInitialVerificationStatus,
   )
   const [error, setError] = useState<Error | null>(null)
+  const verificationRequestIdRef = useRef(0)
   const anthropicVerificationEnabled =
     isAnthropicAuthEnabled() && !isAgenCAISubscriber()
 
   useEffect(() => {
+    verificationRequestIdRef.current += 1
     const nextStatus = anthropicVerificationEnabled
       ? getInitialVerificationStatus()
       : 'valid'
@@ -61,14 +63,30 @@ export function useApiKeyVerification(): ApiKeyVerificationResult {
     }
   }, [anthropicVerificationEnabled])
 
+  useEffect(() => {
+    return () => {
+      verificationRequestIdRef.current += 1
+    }
+  }, [])
+
   const verify = useCallback(async (): Promise<void> => {
+    const requestId = verificationRequestIdRef.current + 1
+    verificationRequestIdRef.current = requestId
+    const isCurrentRequest = () =>
+      requestId === verificationRequestIdRef.current
+
     if (!isAnthropicAuthEnabled() || isAgenCAISubscriber()) {
+      setError(null)
       setStatus('valid')
       return
     }
     // Warm the apiKeyHelper cache (no-op if not configured), then read from
     // all sources. getAnthropicApiKeyWithSource() reads the now-warm cache.
     await getApiKeyFromApiKeyHelper(getIsNonInteractiveSession())
+    if (!isCurrentRequest()) {
+      return
+    }
+
     const { key: apiKey, source } = getAnthropicApiKeyWithSource()
     if (!apiKey) {
       if (source === 'apiKeyHelper') {
@@ -77,16 +95,26 @@ export function useApiKeyVerification(): ApiKeyVerificationResult {
         return
       }
       const newStatus = 'missing'
+      setError(null)
       setStatus(newStatus)
       return
     }
 
     try {
       const isValid = await verifyApiKey(apiKey, false)
+      if (!isCurrentRequest()) {
+        return
+      }
+
       const newStatus = isValid ? 'valid' : 'invalid'
+      setError(null)
       setStatus(newStatus)
       return
     } catch (error) {
+      if (!isCurrentRequest()) {
+        return
+      }
+
       // This happens when there an error response from the API but it's not an invalid API key error
       // In this case, we still mark the API key as invalid - but we also log the error so we can
       // display it to the user to be more helpful

--- a/runtime/tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
@@ -108,6 +108,21 @@ async function waitForCondition(
   throw new Error(message)
 }
 
+function deferred<T>(): {
+  readonly promise: Promise<T>
+  readonly reject: (error: unknown) => void
+  readonly resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, reject, resolve }
+}
+
 async function renderVerificationHook(): Promise<{
   readonly cleanup: () => Promise<void>
   readonly getLatest: () => HookResult
@@ -300,6 +315,85 @@ describe('useApiKeyVerification coverage swarm row 089', () => {
           rendered.getLatest().error === null,
         'Timed out waiting for disabled auth to clear verifier error',
       )
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+
+  test('keeps the newest verifier result when rechecks resolve out of order', async () => {
+    authHarness.state.key = 'sk-ant-test'
+    authHarness.state.source = 'environment'
+    const stale = deferred<boolean>()
+    const latest = deferred<boolean>()
+    authHarness.verifyApiKey
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(latest.promise)
+    const rendered = await renderVerificationHook()
+
+    try {
+      await waitForCondition(
+        () => rendered.getLatest().status === 'loading',
+        'Timed out waiting for loading initial status',
+      )
+
+      const staleRun = rendered.getLatest().reverify()
+      await waitForCondition(
+        () => authHarness.verifyApiKey.mock.calls.length === 1,
+        'Timed out waiting for first verifier call',
+      )
+      const latestRun = rendered.getLatest().reverify()
+      await waitForCondition(
+        () => authHarness.verifyApiKey.mock.calls.length === 2,
+        'Timed out waiting for second verifier call',
+      )
+
+      latest.resolve(true)
+      await latestRun
+      await waitForCondition(
+        () => rendered.getLatest().status === 'valid',
+        'Timed out waiting for latest verifier status',
+      )
+
+      stale.resolve(false)
+      await staleRun
+      await sleep()
+
+      expect(rendered.getLatest().status).toBe('valid')
+      expect(rendered.getLatest().error).toBeNull()
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+
+  test('clears a previous verifier error when a later recheck succeeds', async () => {
+    authHarness.state.key = 'sk-ant-test'
+    authHarness.state.source = 'environment'
+    authHarness.verifyApiKey.mockRejectedValueOnce(new Error('network failed'))
+    const rendered = await renderVerificationHook()
+
+    try {
+      await waitForCondition(
+        () => rendered.getLatest().status === 'loading',
+        'Timed out waiting for loading initial status',
+      )
+
+      await rendered.getLatest().reverify()
+      await waitForCondition(
+        () =>
+          rendered.getLatest().status === 'error' &&
+          rendered.getLatest().error?.message === 'network failed',
+        'Timed out waiting for verifier error status',
+      )
+
+      authHarness.verifyApiKey.mockResolvedValueOnce(true)
+      await rendered.getLatest().reverify()
+
+      await waitForCondition(
+        () => rendered.getLatest().status === 'valid',
+        'Timed out waiting for recovered verifier status',
+      )
+
+      expect(rendered.getLatest().error).toBeNull()
     } finally {
       await rendered.cleanup()
     }


### PR DESCRIPTION
## Summary
- Guard API key reverification so stale async results cannot overwrite newer status.
- Clear stale verification errors when a later non-error outcome wins.
- Add regressions for out-of-order API key checks and stale error cleanup.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx tests/tui/hooks/useApiKeyVerification.test.tsx
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)