### PR TITLE
fix(tui): wire API key status into app

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -32,6 +32,7 @@ import { setGlobalCommandRegistry } from "../../commands/types.js";
 import { PromptOverlayProvider } from "../context/promptOverlayContext.js";
 import { KeybindingSetup } from "../keybindings/KeybindingProviderSetup.js";
 import { CancelRequestHandler } from "../hooks/useCancelRequest.js";
+import { useApiKeyVerification } from "../hooks/useApiKeyVerification.js";
 import { addToHistory } from "../history/history.js";
 import { GlobalKeybindingHandlers } from "../hooks/useGlobalKeybindings.js";
 import { type AppState, AppStateProvider, getDefaultAppState, useAppState, useAppStateStore, useSetAppState } from "../state/AppState.js";
@@ -1376,6 +1377,13 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
   );
   const backpressureWarning = formatTuiBackpressureWarning(backpressureSnapshot);
   const { addNotification } = useNotifications();
+  const {
+    status: apiKeyStatus,
+    reverify
+  } = useApiKeyVerification();
+  useEffect(() => {
+    void reverify();
+  }, [reverify]);
   const [completionPipelineState, setCompletionPipelineState] =
     useState<CompletionPipelineState>(() => readCompletionPipelineState());
   useEffect(() => {
@@ -1580,7 +1588,8 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
     mcpClients,
     setAppState,
     setMessages: () => {},
-  }) as any, [appStateStore, commands, availableTools, mcpClients, props.session, refreshAvailableTools, toolPermissionContext, setToolJSX, setAppState]);
+    onChangeAPIKey: reverify,
+  }) as any, [appStateStore, commands, availableTools, mcpClients, props.session, refreshAvailableTools, toolPermissionContext, setToolJSX, setAppState, reverify]);
 
   // Transient-message helper for local slash-command results.
   const transientResultTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -2291,7 +2300,7 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
       {toolJSX !== null ? <Box flexDirection="column" width="100%">
           {toolJSX.jsx}
         </Box> : null}
-      <PromptInput debug={false} ideSelection={undefined} toolPermissionContext={toolPermissionContext as any} setToolPermissionContext={setToolPermissionContext as any} apiKeyStatus={"valid" as any} commands={EMPTY_ONBOARDING_COMMANDS} agents={agents as any} isLoading={false} verbose={false} messages={transcript.messages as any[]} onAutoUpdaterResult={() => {}} autoUpdaterResult={null} input={input} onInputChange={setInput} mode={mode} onModeChange={setMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={handleShowMessageSelector} mcpClients={mcpClients as never} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onExit={handleExit} getToolUseContext={getToolUseContext} onSubmit={async (value_0, helpers) => {
+      <PromptInput debug={false} ideSelection={undefined} toolPermissionContext={toolPermissionContext as any} setToolPermissionContext={setToolPermissionContext as any} apiKeyStatus={apiKeyStatus} commands={EMPTY_ONBOARDING_COMMANDS} agents={agents as any} isLoading={false} verbose={false} messages={transcript.messages as any[]} onAutoUpdaterResult={() => {}} autoUpdaterResult={null} input={input} onInputChange={setInput} mode={mode} onModeChange={setMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={handleShowMessageSelector} mcpClients={mcpClients as never} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onExit={handleExit} getToolUseContext={getToolUseContext} onSubmit={async (value_0, helpers) => {
         if (isExitSlashCommand(value_0)) {
           setInput("");
           helpers.clearBuffer();
@@ -2358,7 +2367,7 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
     completionPipelineOwnsPrompt: completionPipelineActive,
     toolShouldHidePromptInput: toolJSX?.shouldHidePromptInput === true
   });
-  const promptInputElement = showPromptInput ? <PromptInput debug={false} ideSelection={undefined} toolPermissionContext={toolPermissionContext as any} setToolPermissionContext={setToolPermissionContext as any} apiKeyStatus={"valid" as any} commands={commands as unknown as Command[]} agents={agents as any} isLoading={effectiveInputBusy} verbose={false} messages={transcript.messages as any[]} onAutoUpdaterResult={() => {}} autoUpdaterResult={null} input={input} onInputChange={setInput} mode={mode} onModeChange={setMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={handleShowMessageSelector} mcpClients={mcpClients as never} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onExit={handleExit} getToolUseContext={getToolUseContext} isLocalJSXCommandActive={isLocalJSXCommandActive} onSubmit={async (value_1, helpers_0) => {
+  const promptInputElement = showPromptInput ? <PromptInput debug={false} ideSelection={undefined} toolPermissionContext={toolPermissionContext as any} setToolPermissionContext={setToolPermissionContext as any} apiKeyStatus={apiKeyStatus} commands={commands as unknown as Command[]} agents={agents as any} isLoading={effectiveInputBusy} verbose={false} messages={transcript.messages as any[]} onAutoUpdaterResult={() => {}} autoUpdaterResult={null} input={input} onInputChange={setInput} mode={mode} onModeChange={setMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={handleShowMessageSelector} mcpClients={mcpClients as never} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onExit={handleExit} getToolUseContext={getToolUseContext} isLocalJSXCommandActive={isLocalJSXCommandActive} onSubmit={async (value_1, helpers_0) => {
     if (isLocalJSXCommandActive) {
       return;
     }

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -29,6 +29,10 @@ let mockHasConsoleBillingAccess = false;
 let mockWorktreeSession: unknown = null;
 let mockGlobalConfig: Record<string, unknown> = {};
 const mockTuiCommandList = vi.hoisted(() => [] as Array<Record<string, any>>);
+const apiKeyVerificationProbe = vi.hoisted(() => ({
+  reverify: vi.fn(async () => {}),
+  status: "valid" as "loading" | "valid" | "invalid" | "missing" | "error",
+}));
 
 const providerProbe = {
   fpsGetters: [] as unknown[],
@@ -184,6 +188,14 @@ vi.mock("../hooks/useEffectEventCompat.js", () => ({
 
 vi.mock("../hooks/useSettingsChange.js", () => ({
   useSettingsChange: () => {},
+}));
+
+vi.mock("../hooks/useApiKeyVerification.js", () => ({
+  useApiKeyVerification: () => ({
+    error: null,
+    reverify: apiKeyVerificationProbe.reverify,
+    status: apiKeyVerificationProbe.status,
+  }),
 }));
 
 vi.mock("../../services/PromptSuggestion/promptSuggestion.js", () => ({
@@ -491,6 +503,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       onInputChange,
       isLoading,
       isLocalJSXCommandActive,
+      apiKeyStatus,
       pastedContents,
       setPastedContents,
       mode,
@@ -513,6 +526,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       onInputChange?: (input: string) => void;
       isLoading?: boolean;
       isLocalJSXCommandActive?: boolean;
+      apiKeyStatus?: unknown;
       pastedContents?: unknown;
       setPastedContents?: unknown;
       mode?: unknown;
@@ -532,6 +546,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
         onInputChange,
         isLoading,
         isLocalJSXCommandActive,
+        apiKeyStatus,
         pastedContents,
         setPastedContents,
         mode,
@@ -1067,6 +1082,35 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         setVimMode: expect.any(Function),
       }),
     );
+  });
+
+  test("passes API key verification status into PromptInput and verifies on startup", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    const previousStatus = apiKeyVerificationProbe.status;
+    apiKeyVerificationProbe.status = "missing";
+    apiKeyVerificationProbe.reverify.mockClear();
+    providerProbe.promptProps.length = 0;
+
+    try {
+      await renderApp(
+        <AgenCTuiApp
+          session={createSession()}
+          configStore={{}}
+          isInteractive={false}
+          initialComposerText="draft"
+        />,
+      );
+
+      expect(providerProbe.promptProps.at(-1)).toEqual(
+        expect.objectContaining({
+          apiKeyStatus: "missing",
+        }),
+      );
+      expect(apiKeyVerificationProbe.reverify).toHaveBeenCalledTimes(1);
+    } finally {
+      apiKeyVerificationProbe.status = previousStatus;
+      apiKeyVerificationProbe.reverify.mockClear();
+    }
   });
 
   test("hydrates the TUI app state with registered agent roles", async () => {


### PR DESCRIPTION
## Summary
- Feed the live API key verification status from the App shell into PromptInput.
- Start API key reverification on TUI startup so missing or invalid keys can surface in footer notifications.
- Add a render regression that fails if App hard-codes the prompt API key status again.

## Tests
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/App.render.test.tsx
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/App.render.test.tsx tests/tui/components/App.coverage2.test.tsx tests/tui/components/App.wave200-002.coverage.test.tsx tests/tui/coverage-swarm/swarm-002-components-App.test.tsx tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, and 4 tag hints)