### PR TITLE
fix(tui): preserve spaced project tree paths

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -427,13 +427,13 @@ function resolveWorkspaceRelativePath(
   inputPath: string,
   options: { readonly requireFilePath?: boolean } = {},
 ): { readonly ok: true; readonly relativePath: string; readonly absolutePath: string } | { readonly ok: false; readonly error: string } {
-  const trimmed = inputPath.trim().replace(/\\/gu, "/");
-  if (!trimmed) return { ok: false, error: "Enter a workspace-relative path." };
-  if (path.posix.isAbsolute(trimmed) || path.isAbsolute(trimmed)) {
+  const input = inputPath.replace(/\\/gu, "/");
+  if (input.trim().length === 0) return { ok: false, error: "Enter a workspace-relative path." };
+  if (path.posix.isAbsolute(input) || path.isAbsolute(input)) {
     return { ok: false, error: "Use a workspace-relative path, not an absolute path." };
   }
 
-  const normalizedPath = path.posix.normalize(trimmed).replace(/^\.\//u, "");
+  const normalizedPath = path.posix.normalize(input).replace(/^\.\//u, "");
   if (options.requireFilePath && normalizedPath.endsWith("/")) {
     return { ok: false, error: "Enter a file path, not a directory path." };
   }

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -315,6 +315,31 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("preserves leading and trailing spaces in tree mutation paths", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-space-paths-"));
+    const store = new ProjectTreeStore(repo, 0);
+    const leading = " leading.ts";
+    const trailing = "trailing.ts ";
+    const renamed = " renamed.ts ";
+
+    try {
+      await writeFile(join(repo, leading), "leading\n", "utf8");
+      await writeFile(join(repo, trailing), "trailing\n", "utf8");
+      await store.refresh();
+
+      await expect(store.renamePath(trailing, renamed)).resolves.toEqual({ ok: true, path: renamed });
+      await expect(store.deletePath(leading)).resolves.toEqual({ ok: true, path: leading });
+
+      expect(await readFile(join(repo, renamed), "utf8")).toBe("trailing\n");
+      await expect(readFile(join(repo, leading), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      expect(store.getSnapshot().rows.map((row) => row.path)).toContain(renamed);
+      expect(store.getSnapshot().rows.map((row) => row.path)).not.toContain(leading);
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("returns canonical tree paths when renaming to a trailing slash target", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-rename-slash-"));
     const store = new ProjectTreeStore(repo, 0);


### PR DESCRIPTION
## Summary
- Preserve meaningful leading and trailing spaces when resolving project tree mutation paths.
- Add a regression covering rename and delete for space-bearing workspace paths.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-tree.test.ts
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx tests/tui/workbench/reducer.test.ts
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

Known pre-existing issue:
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing Knip backlog.