### PR TITLE
fix(tui): honor forced buffer saves

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -204,7 +204,7 @@ export class WorkbenchBufferStore {
     await this.#load(file.absolutePath, this.#position().line, true, file.filePath);
   }
 
-  async save(options: { readonly hasInFlightAgent?: boolean } = {}): Promise<boolean> {
+  async save(options: { readonly hasInFlightAgent?: boolean; readonly force?: boolean } = {}): Promise<boolean> {
     const file = this.#file;
     const document = this.#document;
     if (!file || !document) return false;
@@ -226,7 +226,7 @@ export class WorkbenchBufferStore {
     this.#emit();
 
     try {
-      const nextFile = await saveBufferFileSnapshot(file, bufferText(document));
+      const nextFile = await saveBufferFileSnapshot(file, bufferText(document), { force: options.force });
       this.#file = nextFile;
       this.#status = "ready";
       this.#error = null;

--- a/runtime/src/tui/workbench/buffer/fileSnapshot.ts
+++ b/runtime/src/tui/workbench/buffer/fileSnapshot.ts
@@ -119,16 +119,21 @@ async function readCurrentContent(snapshot: BufferFileSnapshot): Promise<string>
 export async function saveBufferFileSnapshot(
   snapshot: BufferFileSnapshot,
   content: string,
+  options: { readonly force?: boolean } = {},
 ): Promise<BufferFileSnapshot> {
+  const force = options.force === true;
   await stat(snapshot.absolutePath).catch((error: unknown) => {
     const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" && force) return;
     if (code === "ENOENT") throw new BufferSaveConflictError(snapshot.filePath);
     throw error;
   });
 
-  const currentContent = await readCurrentContent(snapshot);
-  if (currentContent !== snapshot.content && currentContent !== content) {
-    throw new BufferSaveConflictError(snapshot.filePath);
+  if (!force) {
+    const currentContent = await readCurrentContent(snapshot);
+    if (currentContent !== snapshot.content && currentContent !== content) {
+      throw new BufferSaveConflictError(snapshot.filePath);
+    }
   }
 
   await mkdir(dirname(snapshot.absolutePath), { recursive: true });

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -110,14 +110,14 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
     (command: BufferVimCommand): void => {
       switch (command.type) {
         case "save":
-          void store.save({ hasInFlightAgent: Boolean(inFlightAgent) });
+          void store.save({ hasInFlightAgent: Boolean(inFlightAgent), force: command.force });
           break;
         case "quit":
           if (store.close({ discard: command.discard })) dispatch({ type: "closeSurface" });
           break;
         case "saveQuit":
           void (async () => {
-            const saved = await store.save({ hasInFlightAgent: Boolean(inFlightAgent) });
+            const saved = await store.save({ hasInFlightAgent: Boolean(inFlightAgent), force: command.force });
             if (saved && store.close()) dispatch({ type: "closeSurface" });
           })();
           break;

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -677,6 +677,7 @@ describe("WorkbenchBufferStore", () => {
     store.insert("draft ");
 
     await expect(store.save({ hasInFlightAgent: true })).resolves.toBe(false);
+    await expect(store.save({ hasInFlightAgent: true, force: true })).resolves.toBe(false);
     expect(store.getSnapshot()).toMatchObject({
       status: "conflict",
       conflictKind: "agent",

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -485,6 +485,64 @@ describe("BufferSurface", () => {
     }
   });
 
+  it("honors forced vim writes when the file changed on disk", async () => {
+    const file = join(dir, "target.ts");
+    await writeFile(file, "const value = 1;\n", "utf8");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 1,
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface focused={true} />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const store = getWorkbenchBufferStore();
+      await writeFile(file, "external change\n", "utf8");
+      store.insert("draft ");
+
+      stdin.write(":");
+      await sleep();
+      stdin.write("w");
+      await sleep();
+      stdin.write("!");
+      await sleep();
+      stdin.write("\r");
+      await sleep();
+
+      expect(await readFile(file, "utf8")).toBe("draft const value = 1;\n");
+      expect(store.getSnapshot()).toMatchObject({
+        status: "ready",
+        conflictKind: null,
+        dirty: false,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("extends the buffer selection with shifted arrow keybindings", async () => {
     await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
     const { stdin, stdout } = createStreams();


### PR DESCRIPTION
## Summary
- plumb forced Vim writes through the buffer surface, store, and file snapshot writer
- allow forced saves to overwrite disk drift or recreate a deleted file while preserving normal conflict behavior for non-forced saves
- keep the active agent-edit guard unconditional, even for forced saves

## Test Plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored"
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known Issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog: one unused file, 30 unused exports, and 4 unused tag hints.