### PR TITLE
fix(tui): restart project tree after dispose

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -88,6 +88,7 @@ export class ProjectTreeStore {
   getSnapshot = (): ProjectTreeSnapshot => this.#snapshot;
 
   dispose(): void {
+    this.#started = false;
     if (this.#refreshTimer !== null) {
       clearInterval(this.#refreshTimer);
       this.#refreshTimer = null;

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { buildProjectTreeRows } from "../../../src/tui/workbench/project-tree/buildTree.js";
 import { collectGitStatus, listGitFiles, parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
@@ -171,6 +172,27 @@ describe("project tree helpers", () => {
     });
 
     store.dispose();
+  });
+
+  it("restarts project tree refresh after dispose", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-restart-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await writeFile(join(repo, "first.ts"), "first\n", "utf8");
+
+      store.start();
+      await waitForTreePaths(store, ["first.ts"]);
+
+      store.dispose();
+      await writeFile(join(repo, "second.ts"), "second\n", "utf8");
+
+      store.start();
+      await waitForTreePaths(store, ["first.ts", "second.ts"]);
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 
   it("normalizes hidden cursor paths to the nearest visible row", async () => {
@@ -409,3 +431,18 @@ describe("project tree helpers", () => {
     }
   });
 });
+
+async function waitForTreePaths(
+  store: ProjectTreeStore,
+  expectedPaths: readonly string[],
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const snapshot = store.getSnapshot();
+    const paths = snapshot.rows.map((row) => row.path);
+    if (!snapshot.loading && expectedPaths.every((path) => paths.includes(path))) {
+      return;
+    }
+    await delay(10);
+  }
+  throw new Error(`Timed out waiting for project tree paths: ${expectedPaths.join(", ")}`);
+}


### PR DESCRIPTION
## Summary
- reset the project tree store lifecycle gate when the store is disposed
- add a regression that starts the store, disposes it, mutates the workspace, and starts it again

## Test Plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-tree.test.ts
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx tests/tui/workbench/reducer.test.ts
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored"
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known Issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog: one unused file, 30 unused exports, and 4 unused tag hints.