### PR TITLE
fix(tui): include structured approval args

### DIFF
--- a/runtime/src/tui/approval-input-text.ts
+++ b/runtime/src/tui/approval-input-text.ts
@@ -31,7 +31,7 @@ export function approvalInputText(
 
 function commandText(record: Record<string, unknown>): string | null {
   const args = Array.isArray(record.args)
-    ? (scalarArrayParts(record.args) ?? [])
+    ? commandArrayParts(record.args)
     : [];
   for (const key of COMMAND_KEYS) {
     const command = commandParts(record[key]);
@@ -43,9 +43,18 @@ function commandText(record: Record<string, unknown>): string | null {
 }
 
 function commandParts(value: unknown): readonly string[] {
-  if (Array.isArray(value)) return scalarArrayParts(value) ?? [];
+  if (Array.isArray(value)) return commandArrayParts(value);
   const text = textValue(value);
   return text === null ? [] : [text];
+}
+
+function commandArrayParts(value: readonly unknown[]): readonly string[] {
+  const parts: string[] = [];
+  for (const item of value) {
+    const text = textValue(item);
+    parts.push(text ?? fallbackText(item, { prettyJson: false }));
+  }
+  return parts;
 }
 
 function scalarArrayText(value: readonly unknown[]): string | null {

--- a/runtime/tests/tui/workbench/approval-input-text.test.ts
+++ b/runtime/tests/tui/workbench/approval-input-text.test.ts
@@ -20,4 +20,13 @@ describe("approvalInputText", () => {
       }),
     ).toBe("bash -lc rm -rf /tmp/agenc-danger");
   });
+
+  it("does not hide structured command arguments", () => {
+    expect(
+      approvalInputText({
+        command: "bash",
+        args: [{ script: "rm -rf /tmp/agenc-danger" }],
+      }),
+    ).toContain("rm -rf /tmp/agenc-danger");
+  });
 });

--- a/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
+++ b/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
@@ -63,6 +63,25 @@ describe("ApprovalSurfaceBridge", () => {
     expect(output).toContain("risk destructive");
   });
 
+  it("classifies destructive approval risk from structured command arguments", async () => {
+    const request = pendingRequest({
+      id: "approval-structured-argv",
+      description: "Run shell command",
+      input: { command: "bash", args: [{ script: "rm -rf /tmp/agenc-danger" }] },
+      toolName: "Bash",
+    });
+
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <ApprovalSurfaceBridge request={request} />
+      </AppStateProvider>,
+      80,
+    );
+
+    expect(output).toContain("Approval pending: Run shell command");
+    expect(output).toContain("risk destructive");
+  });
+
   it("opens the diff surface for the active approval request", async () => {
     const changes: AppState[] = [];
     const request = pendingRequest({


### PR DESCRIPTION
## Summary
- preserve structured command and argument entries in approval input text as compact JSON
- prevent approval risk classification from seeing only the command name when destructive details are nested in args
- add formatter and approval bridge regressions for structured arguments

## Test Plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/approval-input-text.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/approval-input-text.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/workbench/risk.test.ts tests/tui/workbench/diff-surface.test.tsx tests/tui/permission-requests.coverage.test.tsx tests/tui/permission-requests.wave200-038.coverage.test.tsx
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored"
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known Issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog: one unused file, 30 unused exports, and 4 unused tag hints.