### PR TITLE
fix(tui): preserve slash glob arguments

### DIFF
--- a/runtime/src/tui/slash/argument-substitution.ts
+++ b/runtime/src/tui/slash/argument-substitution.ts
@@ -34,10 +34,11 @@ export function parseArguments(args: string): string[] {
     return args.split(/\s+/).filter(Boolean);
   }
 
-  // Filter to only string tokens (ignore shell operators, etc.)
-  return result.tokens.filter(
-    (token): token is string => typeof token === "string",
-  );
+  return result.tokens.flatMap((token) => {
+    if (typeof token === "string") return [token];
+    if ("pattern" in token) return [token.pattern];
+    return [];
+  });
 }
 
 /**

--- a/runtime/tests/tui/slash/argument-substitution.test.ts
+++ b/runtime/tests/tui/slash/argument-substitution.test.ts
@@ -24,6 +24,13 @@ describe("parseArguments", () => {
     ]);
   });
 
+  it("preserves unquoted glob patterns as literal arguments", () => {
+    expect(parseArguments("src/**/*.ts *.md")).toEqual([
+      "src/**/*.ts",
+      "*.md",
+    ]);
+  });
+
   it("falls back to whitespace splitting when shell parsing throws", () => {
     expect(parseArguments("foo ${")).toEqual(["foo", "${"]);
   });
@@ -71,6 +78,14 @@ describe("substituteArguments", () => {
     expect(
       substituteArguments("missing=$topic idx=$2", "value", true, ["topic"]),
     ).toBe("missing=value idx=");
+  });
+
+  it("substitutes glob arguments without dropping them", () => {
+    expect(
+      substituteArguments("glob=$0 named=$pattern", "*.ts", true, [
+        "pattern",
+      ]),
+    ).toBe("glob=*.ts named=*.ts");
   });
 
   it("appends arguments when no placeholders are present", () => {

--- a/runtime/tests/tui/slash/shell-quote.test.ts
+++ b/runtime/tests/tui/slash/shell-quote.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { tryParseShellCommand } from "./shell-quote.js";
+
+describe("tryParseShellCommand", () => {
+  it("returns parsed shell tokens on success", () => {
+    expect(tryParseShellCommand("alpha beta")).toEqual({
+      success: true,
+      tokens: ["alpha", "beta"],
+    });
+  });
+
+  it("returns Error messages from parser failures", () => {
+    expect(
+      tryParseShellCommand("alpha $BROKEN", () => {
+        throw new Error("bad environment");
+      }),
+    ).toEqual({
+      success: false,
+      error: "bad environment",
+    });
+  });
+
+  it("returns a generic message for non-Error parser failures", () => {
+    expect(
+      tryParseShellCommand("alpha $BROKEN", () => {
+        throw "bad environment";
+      }),
+    ).toEqual({
+      success: false,
+      error: "Unknown parse error",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve shell-quote glob tokens as literal slash-command arguments instead of dropping them.
- Add regression coverage for glob substitution and shell-quote wrapper error paths.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/slash/argument-substitution.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/slash/argument-substitution.test.ts tests/tui/slash/shell-quote.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/slash tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated unused baseline failure only)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core