### PR TITLE
fix(tui): preserve slash hash arguments

### DIFF
--- a/runtime/src/tui/slash/argument-substitution.ts
+++ b/runtime/src/tui/slash/argument-substitution.ts
@@ -28,7 +28,10 @@ export function parseArguments(args: string): string[] {
   }
 
   // Return $KEY to preserve variable syntax literally (don't expand variables)
-  const result = tryParseShellCommand(args, (key) => `$${key}`);
+  const result = tryParseShellCommand(
+    escapeUnquotedHashLiterals(args),
+    (key) => `$${key}`,
+  );
   if (!result.success) {
     // Fall back to simple whitespace split if parsing fails
     return args.split(/\s+/).filter(Boolean);
@@ -148,4 +151,58 @@ export function substituteArguments(
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Slash arguments are prompt data, so unquoted # should remain literal instead
+// of being consumed by shell-quote's shell-comment parser.
+function escapeUnquotedHashLiterals(value: string): string {
+  let out = "";
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  let inBracedVariable = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+
+    if (escaped) {
+      out += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\" && quote !== "'") {
+      out += char;
+      escaped = true;
+      continue;
+    }
+
+    if (inBracedVariable) {
+      out += char;
+      if (char === "}") inBracedVariable = false;
+      continue;
+    }
+
+    if (quote === undefined && char === "$" && value[i + 1] === "{") {
+      out += "${";
+      inBracedVariable = true;
+      i++;
+      continue;
+    }
+
+    if (char === "'" && quote !== '"') {
+      quote = quote === "'" ? undefined : "'";
+      out += char;
+      continue;
+    }
+
+    if (char === '"' && quote !== "'") {
+      quote = quote === '"' ? undefined : '"';
+      out += char;
+      continue;
+    }
+
+    out += quote === undefined && char === "#" ? "\\#" : char;
+  }
+
+  return out;
 }

--- a/runtime/tests/skills/local-loader.test.ts
+++ b/runtime/tests/skills/local-loader.test.ts
@@ -323,14 +323,14 @@ All=$ARGUMENTS
 
     const rendered = await services.skillsManager.renderSkill?.({
       name: "explain",
-      args: '"rendering hooks" docs',
+      args: '"rendering hooks" #123',
       sessionId: "session-2",
     });
 
     expect(rendered?.content).toContain("Topic=rendering hooks");
     expect(rendered?.content).toContain("First=rendering hooks");
-    expect(rendered?.content).toContain("Second=docs");
-    expect(rendered?.content).toContain('All="rendering hooks" docs');
+    expect(rendered?.content).toContain("Second=#123");
+    expect(rendered?.content).toContain('All="rendering hooks" #123');
   });
 
   it("renders skills with base directory, arguments, and AgenC placeholders", async () => {

--- a/runtime/tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts
@@ -8,12 +8,14 @@ import {
 } from 'src/tui/slash/argument-substitution.js'
 
 describe('argument substitution coverage edges', () => {
-  test('parses blank input and filters non-string shell tokens', () => {
+  test('parses blank input, filters shell operators, and preserves hash literals', () => {
     expect(parseArguments('')).toEqual([])
     expect(parseArguments('   \t  ')).toEqual([])
     expect(parseArguments('build && test # trailing')).toEqual([
       'build',
       'test',
+      '#',
+      'trailing',
     ])
   })
 

--- a/runtime/tests/tui/slash/argument-substitution.test.ts
+++ b/runtime/tests/tui/slash/argument-substitution.test.ts
@@ -31,6 +31,31 @@ describe("parseArguments", () => {
     ]);
   });
 
+  it("preserves unquoted hash arguments instead of treating them as comments", () => {
+    expect(parseArguments("issue #123 literal#hash color=#fff")).toEqual([
+      "issue",
+      "#123",
+      "literal#hash",
+      "color=#fff",
+    ]);
+  });
+
+  it("keeps hashes inside braced variables literal", () => {
+    expect(parseArguments("${TAG#prefix} $TAG#suffix")).toEqual([
+      "$TAG#prefix",
+      "$TAG#suffix",
+    ]);
+  });
+
+  it("preserves escaped and quoted hash arguments", () => {
+    expect(parseArguments(String.raw`escaped\#hash "#quoted" '\#single'`))
+      .toEqual([
+        "escaped#hash",
+        "#quoted",
+        "\\#single",
+      ]);
+  });
+
   it("falls back to whitespace splitting when shell parsing throws", () => {
     expect(parseArguments("foo ${")).toEqual(["foo", "${"]);
   });
@@ -86,6 +111,14 @@ describe("substituteArguments", () => {
         "pattern",
       ]),
     ).toBe("glob=*.ts named=*.ts");
+  });
+
+  it("substitutes hash arguments without dropping them", () => {
+    expect(
+      substituteArguments("ticket=$0 color=$1 named=$ticket", "#123 #fff", true, [
+        "ticket",
+      ]),
+    ).toBe("ticket=#123 color=#fff named=#123");
   });
 
   it("appends arguments when no placeholders are present", () => {


### PR DESCRIPTION
## Summary
- Preserve unquoted hash arguments like `#123`, `literal#hash`, and `color=#fff` in slash/skill argument parsing.
- Protect braced variable forms such as `${TAG#prefix}` while avoiding `shell-quote` comment-token drops.
- Add focused utility, coverage-swarm, local-loader, and plugin-registration regression coverage.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/slash/argument-substitution.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/skills/local-loader.test.ts tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts tests/tui/slash tests/plugins/registration.test.ts
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/slash/argument-substitution.test.ts tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/slash/argument-substitution.ts' --coverage.reportsDirectory=coverage/runtime-tui-focused
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated unused baseline failure only)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core