### PR TITLE
fix(tui): preserve spaced output locations

### DIFF
--- a/runtime/src/tui/workbench/surfaces/outputParsers.ts
+++ b/runtime/src/tui/workbench/surfaces/outputParsers.ts
@@ -14,13 +14,12 @@ export type TestFailure = {
 export function parseSourceLocations(output: string): SourceLocation[] {
   const seen = new Set<string>();
   const locations: SourceLocation[] = [];
-  const pattern = /((?:\.{0,2}\/)?[^\s():]+?\.(?:[cm]?[jt]sx?|tsx|ts|jsx|js|py|rs|go|java|c|cc|cpp|h|hpp)):(\d+)(?::(\d+))?/gu;
+  const pattern = /(^|[\s([{"'])((?:[A-Za-z]:[\\/]|\.{1,2}[\\/]|~[\\/]|[\\/])?[^\s():\r\n][^():\r\n]*?\.(?:[cm]?[jt]sx?|py|rs|go|java|c|cc|cpp|h|hpp)):(\d+)(?::(\d+))?(?=$|[\s)\]}",'])/gu;
   for (const match of output.matchAll(pattern)) {
-    const file = match[1];
-    const line = Number.parseInt(match[2] ?? "", 10);
-    const columnText = match[3];
+    const file = match[2]!;
+    const line = Number.parseInt(match[3]!, 10);
+    const columnText = match[4];
     const column = columnText ? Number.parseInt(columnText, 10) : undefined;
-    if (!file || !Number.isFinite(line)) continue;
     const key = `${file}:${line}:${column ?? ""}`;
     if (seen.has(key)) continue;
     seen.add(key);
@@ -37,10 +36,10 @@ export function parseVitestFailures(output: string): TestFailure[] {
   const lines = output.split(/\r?\n/u);
   const failures: TestFailure[] = [];
   for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
+    const line = lines[index]!;
     const nameMatch = /^\s*(?:FAIL|\u00d7|\u2715)\s+(.+?)\s*$/u.exec(line);
     if (!nameMatch) continue;
-    const name = nameMatch[1]?.trim() ?? "test failure";
+    const name = nameMatch[1]!.trim();
     const following = lines.slice(index + 1, index + 8).join("\n");
     const [location] = parseSourceLocations(following);
     const message =

--- a/runtime/tests/tui/workbench/output-parsers.test.ts
+++ b/runtime/tests/tui/workbench/output-parsers.test.ts
@@ -13,6 +13,19 @@ describe("workbench output parsers", () => {
     ]);
   });
 
+  it("keeps source paths that contain spaces", () => {
+    expect(
+      parseSourceLocations(
+        "Error: packages/app with spaces/src/render app.test.tsx:27:9\n" +
+          "    at render (packages/app with spaces/src/render app.test.tsx:27:9)\n" +
+          "C:\\Users\\AgenC Project\\src\\app.test.ts:10:2",
+      ),
+    ).toEqual([
+      { file: "packages/app with spaces/src/render app.test.tsx", line: 27, column: 9 },
+      { file: "C:\\Users\\AgenC Project\\src\\app.test.ts", line: 10, column: 2 },
+    ]);
+  });
+
   it("extracts Vitest-style failure summaries", () => {
     const failures = parseVitestFailures(`
  FAIL  tests/app.test.ts > renders app
@@ -26,6 +39,35 @@ describe("workbench output parsers", () => {
         name: "tests/app.test.ts > renders app",
         location: { file: "tests/app.test.ts", line: 42, column: 7 },
         message: "AssertionError: expected false to be true",
+      },
+    ]);
+  });
+
+  it("extracts Vitest failure locations whose paths contain spaces", () => {
+    const failures = parseVitestFailures(`
+ FAIL  tests/app with spaces.test.ts > renders app
+ AssertionError: expected false to be true
+ tests/app with spaces.test.ts:42:7
+`);
+
+    expect(failures).toEqual([
+      {
+        id: "tests/app with spaces.test.ts > renders app:tests/app with spaces.test.ts:42",
+        name: "tests/app with spaces.test.ts > renders app",
+        location: { file: "tests/app with spaces.test.ts", line: 42, column: 7 },
+        message: "AssertionError: expected false to be true",
+      },
+    ]);
+  });
+
+  it("keeps Vitest failures that do not include source locations", () => {
+    const failures = parseVitestFailures(" FAIL  tests/app.test.ts > fails before stack");
+
+    expect(failures).toEqual([
+      {
+        id: "tests/app.test.ts > fails before stack:0:0",
+        name: "tests/app.test.ts > fails before stack",
+        message: "FAIL  tests/app.test.ts > fails before stack",
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- Preserve full source-location paths containing spaces in workbench output parsing.
- Keep Windows-style drive paths with spaces and Vitest failures without source locations covered explicitly.
- Remove unreachable parser fallbacks that hid branch coverage gaps after regex matches.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/output-parsers.test.ts
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/output-parsers.test.ts --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/workbench/surfaces/outputParsers.ts' --coverage.reportsDirectory=coverage/runtime-tui-focused
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/output-parsers.test.ts tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored" (no matches; exit 1)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog: one unused file, 30 unused exports, and 4 unused tag hints.