### PR TITLE
fix(tui): preserve parenthesized output locations

### DIFF
--- a/runtime/src/tui/workbench/surfaces/outputParsers.ts
+++ b/runtime/src/tui/workbench/surfaces/outputParsers.ts
@@ -11,11 +11,17 @@ export type TestFailure = {
   readonly message: string;
 };
 
+const SOURCE_EXTENSION_PATTERN = String.raw`[cm]?[jt]sx?|py|rs|go|java|c|cc|cpp|h|hpp`;
+const SOURCE_PATH_PATTERN = String.raw`(?:(?:[A-Za-z]:[\\/]|\.{1,2}[\\/]|~[\\/]|[\\/])[^:\r\n]*?|[^\s():\\/\r\n]+[\\/][^:\r\n]*?|[^\s():\\/\r\n]+?)\.(?:${SOURCE_EXTENSION_PATTERN})`;
+const SOURCE_LOCATION_PATTERN = new RegExp(
+  String.raw`(^|[\s([{"'])(${SOURCE_PATH_PATTERN}):(\d+)(?::(\d+))?(?=$|[\s)\]}",'])`,
+  "gu",
+);
+
 export function parseSourceLocations(output: string): SourceLocation[] {
   const seen = new Set<string>();
   const locations: SourceLocation[] = [];
-  const pattern = /(^|[\s([{"'])((?:[A-Za-z]:[\\/]|\.{1,2}[\\/]|~[\\/]|[\\/])?[^\s():\r\n][^():\r\n]*?\.(?:[cm]?[jt]sx?|py|rs|go|java|c|cc|cpp|h|hpp)):(\d+)(?::(\d+))?(?=$|[\s)\]}",'])/gu;
-  for (const match of output.matchAll(pattern)) {
+  for (const match of output.matchAll(SOURCE_LOCATION_PATTERN)) {
     const file = match[2]!;
     const line = Number.parseInt(match[3]!, 10);
     const columnText = match[4];

--- a/runtime/tests/tui/workbench/output-parsers.test.ts
+++ b/runtime/tests/tui/workbench/output-parsers.test.ts
@@ -26,6 +26,17 @@ describe("workbench output parsers", () => {
     ]);
   });
 
+  it("keeps source paths that contain parenthesized segments", () => {
+    expect(
+      parseSourceLocations(
+        "src/app/(admin)/page.test.tsx:31:5\n" +
+          "    at render (src/app/(admin)/page.test.tsx:31:5)",
+      ),
+    ).toEqual([
+      { file: "src/app/(admin)/page.test.tsx", line: 31, column: 5 },
+    ]);
+  });
+
   it("extracts Vitest-style failure summaries", () => {
     const failures = parseVitestFailures(`
  FAIL  tests/app.test.ts > renders app
@@ -55,6 +66,23 @@ describe("workbench output parsers", () => {
         id: "tests/app with spaces.test.ts > renders app:tests/app with spaces.test.ts:42",
         name: "tests/app with spaces.test.ts > renders app",
         location: { file: "tests/app with spaces.test.ts", line: 42, column: 7 },
+        message: "AssertionError: expected false to be true",
+      },
+    ]);
+  });
+
+  it("extracts Vitest failure locations whose paths contain parenthesized segments", () => {
+    const failures = parseVitestFailures(`
+ FAIL  tests/app/(admin)/page.test.tsx > renders app route
+ AssertionError: expected false to be true
+ tests/app/(admin)/page.test.tsx:42:7
+`);
+
+    expect(failures).toEqual([
+      {
+        id: "tests/app/(admin)/page.test.tsx > renders app route:tests/app/(admin)/page.test.tsx:42",
+        name: "tests/app/(admin)/page.test.tsx > renders app route",
+        location: { file: "tests/app/(admin)/page.test.tsx", line: 42, column: 7 },
         message: "AssertionError: expected false to be true",
       },
     ]);


### PR DESCRIPTION
## Summary
- Preserve workbench output locations that include parenthesized path segments, such as route folders like `src/app/(admin)/page.test.tsx`.
- Keep stack-frame parsing from absorbing function-name prefixes while allowing parentheses after real path segments.
- Add parser regressions for raw source locations and Vitest failure locations.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/output-parsers.test.ts
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/output-parsers.test.ts --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/workbench/surfaces/outputParsers.ts' --coverage.reportsDirectory=coverage/runtime-tui-focused
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/output-parsers.test.ts tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored" (no matches; exit 1)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog: one unused file, 30 unused exports, and 4 unused tag hints.