### PR TITLE
fix(tui): retain duplicate keybinding contexts

### DIFF
--- a/runtime/src/tui/keybindings/KeybindingProviderSetup.tsx
+++ b/runtime/src/tui/keybindings/KeybindingProviderSetup.tsx
@@ -175,11 +175,22 @@ export function KeybindingSetup({
   // Using a ref instead of state for synchronous updates - input handlers need
   // to see the current value immediately, not after a React render cycle.
   const activeContextsRef = useRef<Set<KeybindingContextName>>(new Set());
+  const activeContextCountsRef = useRef<Map<KeybindingContextName, number>>(new Map());
   const registerActiveContext = useCallback((context: KeybindingContextName) => {
+    activeContextCountsRef.current.set(
+      context,
+      (activeContextCountsRef.current.get(context) ?? 0) + 1,
+    );
     activeContextsRef.current.add(context);
   }, []);
-  const unregisterActiveContext = useCallback((context_0: KeybindingContextName) => {
-    activeContextsRef.current.delete(context_0);
+  const unregisterActiveContext = useCallback((context: KeybindingContextName) => {
+    const currentCount = activeContextCountsRef.current.get(context) ?? 0;
+    if (currentCount <= 1) {
+      activeContextCountsRef.current.delete(context);
+      activeContextsRef.current.delete(context);
+      return;
+    }
+    activeContextCountsRef.current.set(context, currentCount - 1);
   }, []);
 
   // Clear chord timeout when component unmounts or chord changes

--- a/runtime/tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx
+++ b/runtime/tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx
@@ -5,7 +5,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import Text from "../ink/components/Text.js";
 import { createRoot } from "../ink/root.js";
-import { useKeybindingContext } from "./KeybindingContext.js";
+import {
+  useKeybindingContext,
+  useRegisterKeybindingContext,
+} from "./KeybindingContext.js";
 import { KeybindingSetup } from "./KeybindingProviderSetup.js";
 import { parseBindings } from "./parser.js";
 
@@ -106,6 +109,43 @@ function Probe({ displays }: { displays: string[] }): React.ReactNode {
   }, [displays, keybindings]);
 
   return <Text>keybinding setup</Text>;
+}
+
+function DuplicateContextChild(): React.ReactNode {
+  useRegisterKeybindingContext("Surface", true);
+
+  return <Text>duplicate child</Text>;
+}
+
+function ActiveContextProbe({
+  snapshots,
+}: {
+  snapshots: boolean[];
+}): React.ReactNode {
+  const keybindings = useKeybindingContext();
+
+  React.useLayoutEffect(() => {
+    snapshots.push(keybindings.activeContexts.has("Surface"));
+  });
+
+  return <Text>active context probe</Text>;
+}
+
+function DuplicateContextHarness({
+  childMounted,
+  snapshots,
+}: {
+  childMounted: boolean;
+  snapshots: boolean[];
+}): React.ReactNode {
+  useRegisterKeybindingContext("Surface", true);
+
+  return (
+    <>
+      {childMounted ? <DuplicateContextChild /> : null}
+      <ActiveContextProbe snapshots={snapshots} />
+    </>
+  );
 }
 
 describe("KeybindingProviderSetup coverage", () => {
@@ -222,5 +262,56 @@ describe("KeybindingProviderSetup coverage", () => {
       () => unsubscribe.mock.calls.length === 1,
       "KeybindingSetup did not unsubscribe on unmount",
     );
+  });
+
+  test("keeps an active context while any duplicate owner is still mounted", async () => {
+    const snapshots: boolean[] = [];
+    const { stdout, stdin } = createTestStreams();
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    });
+
+    loadKeybindingsSyncWithWarnings.mockReturnValue({
+      bindings: [],
+      warnings: [],
+    });
+
+    try {
+      root.render(
+        <KeybindingSetup>
+          <DuplicateContextHarness
+            childMounted={true}
+            snapshots={snapshots}
+          />
+        </KeybindingSetup>,
+      );
+
+      await waitForCondition(
+        () => snapshots.includes(true),
+        "duplicate context registration did not become active",
+      );
+
+      root.render(
+        <KeybindingSetup>
+          <DuplicateContextHarness
+            childMounted={false}
+            snapshots={snapshots}
+          />
+        </KeybindingSetup>,
+      );
+
+      await waitForCondition(
+        () => snapshots.length >= 2,
+        "duplicate context cleanup did not rerender the probe",
+      );
+
+      expect(snapshots.at(-1)).toBe(true);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- keep active keybinding contexts registered until every duplicate owner has unmounted
- add a provider-level regression for overlapping `Surface` registrations

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx` failed before the fix on the duplicate-owner regression
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx tests/tui/keybindings/KeybindingContext.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/keybindings/KeybindingProviderSetup.tsx' --coverage.reportsDirectory=coverage/runtime-tui-focused`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- branding scan over `runtime/src` and `runtime/tests`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known pre-existing check failure
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing Knip baseline: one unused file, 30 unused exports, and 4 tag hints.