### PR TITLE
fix(tui): stop capped workbench searches

### DIFF
--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -13,6 +13,8 @@ import type { SearchMatch } from "../types.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { clampSurfaceSelection } from "./selection.js";
 
+const SEARCH_RESULT_LIMIT = 500;
+
 export function SearchSurface({ focused }: { readonly focused: boolean }): React.ReactElement {
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
@@ -49,10 +51,17 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
         (lines) => {
           if (controller.signal.aborted) return;
           for (const line of lines) {
+            if (next.length >= SEARCH_RESULT_LIMIT) break;
             const match = parseWorkbenchRipgrepJsonLine(line, cwd);
             if (match) next.push(match);
+            if (next.length >= SEARCH_RESULT_LIMIT) {
+              setMatches(next.slice(0, SEARCH_RESULT_LIMIT));
+              setLoading(false);
+              controller.abort();
+              return;
+            }
           }
-          setMatches(next.slice(0, 500));
+          setMatches(next.slice(0, SEARCH_RESULT_LIMIT));
         },
       )
         .then(() => {
@@ -185,7 +194,7 @@ export function SearchSurfaceView({
       {loading ? <Text dimColor wrap="truncate-end">searching...</Text> : null}
       {error ? <Text color="error" wrap="truncate-end">{error}</Text> : null}
       {!loading && !error && matches.length === 0 ? <Text dimColor wrap="truncate-end">No results</Text> : null}
-      {matches.length >= 500 ? <Text color="warning" wrap="truncate-end">Results truncated at 500 matches</Text> : null}
+      {matches.length >= SEARCH_RESULT_LIMIT ? <Text color="warning" wrap="truncate-end">Results truncated at 500 matches</Text> : null}
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {rows.map((row) =>
           row.kind === "file" ? (

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -532,6 +532,50 @@ describe("SearchSurface", () => {
       stdout.end();
     }
   });
+
+  it("aborts the active ripgrep stream once the visible result cap is reached", async () => {
+    searchHarness.autoFlush = false;
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "needle",
+            },
+          }}
+        >
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep(180);
+
+      expect(searchHarness.calls).toHaveLength(1);
+      const call = searchHarness.calls[0]!;
+      call.onLines(
+        Array.from({ length: 501 }, (_, index) =>
+          jsonMatchLine("src/many.ts", index + 1, `needle ${index + 1}`),
+        ),
+      );
+      await sleep(50);
+
+      expect(call.signal.aborted).toBe(true);
+      expect(compact(output())).toContain("truncatedat500matches");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
 
 function compact(value: string): string {


### PR DESCRIPTION
## Summary
- stop the workbench search ripgrep stream as soon as the visible result cap is reached
- share the 500-result cap between stream handling and the truncation notice
- add a mounted SearchSurface regression for the abort signal at the cap

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/search-surface.test.tsx` failed before the fix on the new truncation abort regression
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/search-model.test.ts tests/tui/workbench/reducer.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-surface.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/workbench/surfaces/SearchSurface.tsx' --coverage.reportsDirectory=coverage/runtime-tui-focused`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- branding scan over `runtime/src` and `runtime/tests`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known pre-existing check failure
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing Knip baseline: one unused file, 30 unused exports, and 4 tag hints.