### PR TITLE
fix(tui): ignore canceled history matches

### DIFF
--- a/runtime/src/tui/hooks/useHistorySearch.ts
+++ b/runtime/src/tui/hooks/useHistorySearch.ts
@@ -51,6 +51,11 @@ export function useHistorySearch(
   const seenPrompts = useRef<Set<string>>(new Set())
   const searchAbortController = useRef<AbortController | null>(null)
 
+  const abortSearch = useCallback((): void => {
+    searchAbortController.current?.abort()
+    searchAbortController.current = null
+  }, [])
+
   const closeHistoryReader = useCallback((): void => {
     if (historyReader.current) {
       // Must explicitly call .return() to trigger the finally block in readLinesReverse,
@@ -61,6 +66,7 @@ export function useHistorySearch(
   }, [])
 
   const reset = useCallback((): void => {
+    abortSearch()
     setIsSearching(false)
     setHistoryQuery('')
     setHistoryFailedMatch(false)
@@ -71,7 +77,7 @@ export function useHistorySearch(
     setHistoryMatch(undefined)
     closeHistoryReader()
     seenPrompts.current.clear()
-  }, [setIsSearching, closeHistoryReader])
+  }, [setIsSearching, closeHistoryReader, abortSearch])
 
   const searchHistory = useCallback(
     async (resume: boolean, signal?: AbortSignal): Promise<void> => {
@@ -118,6 +124,9 @@ export function useHistorySearch(
           closeHistoryReader()
           return
         }
+        if (signal?.aborted) {
+          return
+        }
         if (item.done) {
           // No match found - keep last match but mark as failed
           setHistoryFailedMatch(true)
@@ -161,8 +170,19 @@ export function useHistorySearch(
     ],
   )
 
+  const runSearchHistory = useCallback(
+    (resume: boolean): void => {
+      searchAbortController.current?.abort()
+      const controller = new AbortController()
+      searchAbortController.current = controller
+      void searchHistory(resume, controller.signal)
+    },
+    [searchHistory],
+  )
+
   // Handler: Start history search (when not searching)
   const handleStartSearch = useCallback(() => {
+    abortSearch()
     setIsSearching(true)
     setOriginalInput(currentInput)
     setOriginalCursorOffset(currentCursorOffset)
@@ -176,12 +196,13 @@ export function useHistorySearch(
     currentCursorOffset,
     currentMode,
     currentPastedContents,
+    abortSearch,
   ])
 
   // Handler: Find next match (when searching)
   const handleNextMatch = useCallback(() => {
-    void searchHistory(true)
-  }, [searchHistory])
+    runSearchHistory(true)
+  }, [runSearchHistory])
 
   // Handler: Accept current match and exit search
   const handleAccept = useCallback(() => {

--- a/runtime/tests/tui/hooks/useHistorySearch.test.tsx
+++ b/runtime/tests/tui/hooks/useHistorySearch.test.tsx
@@ -21,6 +21,7 @@ const harness = vi.hoisted(() => ({
     next: ReturnType<typeof vi.fn>;
     return: ReturnType<typeof vi.fn>;
   }>,
+  nextDelays: [] as Array<Promise<void>>,
   readerError: null as Error | null,
   logError: vi.fn(),
   reset() {
@@ -30,6 +31,7 @@ const harness = vi.hoisted(() => ({
     harness.keybinding = new Map();
     harness.keybindings = new Map();
     harness.readers = [];
+    harness.nextDelays = [];
     harness.readerError = null;
     harness.logError.mockClear();
   },
@@ -49,6 +51,8 @@ vi.mock("../history/history.js", () => ({
     let index = 0;
     const reader = {
       next: vi.fn(async () => {
+        const delay = harness.nextDelays.shift();
+        if (delay) await delay;
         if (harness.readerError) throw harness.readerError;
         if (index >= harness.entries.length) {
           return { done: true, value: undefined };
@@ -356,6 +360,50 @@ describe("useHistorySearch", () => {
       expect(rendered.callbacks.onInputChange).not.toHaveBeenCalledWith(
         "needle",
       );
+      expect(rendered.result().historyMatch).toBeUndefined();
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("ignores a match that resolves after history search is canceled", async () => {
+    let releaseNext: () => void = () => {};
+    harness.nextDelays = [
+      new Promise<void>(resolve => {
+        releaseNext = resolve;
+      }),
+    ];
+    harness.entries = [
+      { display: "late needle match", pastedContents: { late: true } },
+    ];
+    const rendered = await renderHistoryHarness({
+      currentInput: "keep original",
+      currentCursorOffset: 6,
+      currentPastedContents: { original: true },
+    });
+
+    try {
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      rendered.result().setHistoryQuery("needle");
+      await sleep();
+
+      harness.keybindings.get("historySearch:cancel")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(false));
+      expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith(
+        "keep original",
+      );
+      expect(rendered.callbacks.onCursorChange).toHaveBeenLastCalledWith(6);
+
+      releaseNext();
+      await sleep(50);
+
+      expect(rendered.callbacks.onInputChange).not.toHaveBeenCalledWith(
+        "late needle match",
+      );
+      expect(rendered.callbacks.setPastedContents).not.toHaveBeenCalledWith({
+        late: true,
+      });
       expect(rendered.result().historyMatch).toBeUndefined();
     } finally {
       await rendered.dispose();


### PR DESCRIPTION
## Summary
- abort active history searches when search state resets or restarts
- re-check cancellation after async history reads resolve before applying prompt state
- add a delayed-reader regression for canceling an in-flight history search

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useHistorySearch.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useHistorySearch.runtime-coverage.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useHistorySearch.test.tsx tests/tui/hooks/useHistorySearch.runtime-coverage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/hooks/useHistorySearch.ts' --coverage.reportsDirectory=coverage/runtime-tui-history-search-focused
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored" (expected no matches)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known existing unused baseline: 1 file, 30 exports, 4 tag hints)
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core