### PR TITLE
fix(tui): ignore stale command completions

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -335,6 +335,9 @@ export function useTypeahead({
   const prevInputRef = useRef('');
   // Track the latest path token to discard stale results from path completion
   const latestPathTokenRef = useRef('');
+  // Track command-argument async lookups to discard stale results.
+  const latestCommandDirectoryArgsRef = useRef<string | null>(null);
+  const latestResumeTitleArgsRef = useRef<string | null>(null);
   // Track the latest bash input to discard stale results from history completion
   const latestBashInputRef = useRef('');
   // Track the latest slack channel token to discard stale results from MCP
@@ -459,6 +462,13 @@ export function useTypeahead({
   const updateSuggestions = useCallback(async (value: string, inputCursorOffset?: number): Promise<void> => {
     // Use provided cursor offset or fall back to ref (avoids dependency on cursorOffset)
     const effectiveCursorOffset = inputCursorOffset ?? cursorOffsetRef.current;
+    const parsedCommandForInvalidation = mode === 'prompt' && isCommandInput(value) ? extractCommandNameAndArgs(value) : null;
+    if (parsedCommandForInvalidation?.commandName !== 'add-dir') {
+      latestCommandDirectoryArgsRef.current = null;
+    }
+    if (parsedCommandForInvalidation?.commandName !== 'resume') {
+      latestResumeTitleArgsRef.current = null;
+    }
     if (suppressSuggestions) {
       debouncedFetchFileSuggestions.cancel();
       clearSuggestions();
@@ -603,17 +613,25 @@ export function useTypeahead({
 
         // Clear suggestions if args end with whitespace (user is done with path)
         if (args.match(/\s+$/)) {
+          latestCommandDirectoryArgsRef.current = null;
           debouncedFetchFileSuggestions.cancel();
           clearSuggestions();
           return;
         }
+        latestCommandDirectoryArgsRef.current = args;
         let dirSuggestions: SuggestionItem[];
         try {
           dirSuggestions = await getDirectoryCompletions(args);
         } catch (error) {
+          if (latestCommandDirectoryArgsRef.current !== args) {
+            return;
+          }
           logError(error);
           debouncedFetchFileSuggestions.cancel();
           clearSuggestions();
+          return;
+        }
+        if (latestCommandDirectoryArgsRef.current !== args) {
           return;
         }
         if (dirSuggestions.length > 0) {
@@ -639,14 +657,21 @@ export function useTypeahead({
         } = parsedCommand;
 
         // Get custom title suggestions using partial match
+        latestResumeTitleArgsRef.current = args;
         let matches;
         try {
           matches = await searchSessionsByCustomTitle(args, {
             limit: 10
           });
         } catch (error) {
+          if (latestResumeTitleArgsRef.current !== args) {
+            return;
+          }
           logError(error);
           clearSuggestions();
+          return;
+        }
+        if (latestResumeTitleArgsRef.current !== args) {
           return;
         }
         const suggestions = matches.map(log => {

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -24,8 +24,10 @@ const harness = vi.hoisted(() => ({
     viewingAgentTaskId: null as string | null,
   },
   directorySuggestions: [] as unknown[],
+  directoryCompletionResponses: new Map<string, unknown[] | Promise<unknown[]>>(),
   keybindings: {} as Record<string, () => unknown>,
   sessionTitleMatches: [] as unknown[],
+  sessionTitleResponses: new Map<string, unknown[] | Promise<unknown[]>>(),
   shellCompletions: [] as unknown[],
   shellHistoryCompletion: null as null | {
     fullCommand: string
@@ -48,8 +50,10 @@ const harness = vi.hoisted(() => ({
     harness.appState.teamContext = undefined
     harness.appState.viewingAgentTaskId = null
     harness.directorySuggestions = []
+    harness.directoryCompletionResponses = new Map()
     harness.keybindings = {}
     harness.sessionTitleMatches = []
+    harness.sessionTitleResponses = new Map()
     harness.shellCompletions = []
     harness.shellHistoryCompletion = null
     harness.slackSuggestions = []
@@ -131,12 +135,27 @@ vi.mock('../../utils/bash/shellCompletion.js', () => ({
 vi.mock('../../utils/sessionStorage.js', () => ({
   getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
     log.sessionId ?? 'session-1',
-  searchSessionsByCustomTitle: vi.fn(async () => harness.sessionTitleMatches),
+  searchSessionsByCustomTitle: vi.fn(async (query: string) => {
+    if (harness.sessionTitleResponses.has(query)) {
+      return await harness.sessionTitleResponses.get(query)
+    }
+    return harness.sessionTitleMatches
+  }),
 }))
 
 vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({
-  getDirectoryCompletions: vi.fn(async () => harness.directorySuggestions),
-  getPathCompletions: vi.fn(async () => harness.directorySuggestions),
+  getDirectoryCompletions: vi.fn(async (query: string) => {
+    if (harness.directoryCompletionResponses.has(query)) {
+      return await harness.directoryCompletionResponses.get(query)
+    }
+    return harness.directorySuggestions
+  }),
+  getPathCompletions: vi.fn(async (query: string) => {
+    if (harness.directoryCompletionResponses.has(query)) {
+      return await harness.directoryCompletionResponses.get(query)
+    }
+    return harness.directorySuggestions
+  }),
   isPathLikeToken: (token: string) =>
     token.startsWith('/') || token.startsWith('./') || token.startsWith('~/'),
 }))
@@ -192,6 +211,8 @@ import type { SuggestionItem } from '../components/PromptInput/PromptInputFooter
 import type { PromptInputMode } from '../../types/textInputTypes.js'
 import { useTypeahead } from './useTypeahead.js'
 import { generateUnifiedSuggestions } from './unifiedSuggestions'
+import { getDirectoryCompletions } from '../../utils/suggestions/directoryCompletion.js'
+import { searchSessionsByCustomTitle } from '../../utils/sessionStorage.js'
 
 type SuggestionsState = {
   commandArgumentHint?: string
@@ -211,6 +232,8 @@ function sleep(ms: number): Promise<void> {
 }
 
 const generateUnifiedSuggestionsMock = vi.mocked(generateUnifiedSuggestions)
+const getDirectoryCompletionsMock = vi.mocked(getDirectoryCompletions)
+const searchSessionsByCustomTitleMock = vi.mocked(searchSessionsByCustomTitle)
 
 function createKey(
   name: string,
@@ -368,6 +391,8 @@ describe('useTypeahead hook paths', () => {
   beforeEach(() => {
     harness.reset()
     generateUnifiedSuggestionsMock.mockClear()
+    getDirectoryCompletionsMock.mockClear()
+    searchSessionsByCustomTitleMock.mockClear()
   })
 
   test('generates slash command suggestions and navigates them with autocomplete keybindings', async () => {
@@ -617,6 +642,123 @@ describe('useTypeahead hook paths', () => {
       expect(onInputChange).toHaveBeenCalledWith('/resume session-42')
       expect(setCursorOffset).toHaveBeenCalledWith('/resume session-42'.length)
       expect(onSubmit).toHaveBeenCalledWith('/resume session-42', true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores stale /add-dir directory completions that resolve out of order', async () => {
+    let resolveSlowCompletion: (items: unknown[]) => void = () => {}
+    harness.directoryCompletionResponses.set(
+      's',
+      new Promise(resolve => {
+        resolveSlowCompletion = resolve
+      }),
+    )
+    harness.directoryCompletionResponses.set('lib', [
+      {
+        displayText: 'lib',
+        id: 'lib',
+        metadata: { type: 'directory' },
+      },
+    ])
+    const rendered = await renderHookHarness({
+      input: '/add-dir s',
+      cursorOffset: '/add-dir s'.length,
+    })
+
+    try {
+      await waitFor(
+        () => getDirectoryCompletionsMock.mock.calls.some(call => call[0] === 's'),
+        'initial delayed directory completion request',
+      )
+
+      rendered.rerender({
+        input: '/add-dir lib',
+        cursorOffset: '/add-dir lib'.length,
+      })
+      await waitFor(
+        () =>
+          rendered.getSnapshot().suggestionType === 'directory' &&
+          rendered.getSnapshot().suggestions[0]?.id === 'lib',
+        'newer directory completion result',
+      )
+
+      resolveSlowCompletion([
+        {
+          displayText: 'src',
+          id: 'src',
+          metadata: { type: 'directory' },
+        },
+      ])
+      await sleep(50)
+
+      expect(rendered.getSnapshot().suggestionType).toBe('directory')
+      expect(rendered.getSnapshot().suggestions).toEqual([
+        {
+          displayText: 'lib',
+          id: 'lib',
+          metadata: { type: 'directory' },
+        },
+      ])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores stale /resume title completions that resolve out of order', async () => {
+    let resolveSlowTitle: (items: unknown[]) => void = () => {}
+    harness.sessionTitleResponses.set(
+      'Old',
+      new Promise(resolve => {
+        resolveSlowTitle = resolve
+      }),
+    )
+    harness.sessionTitleResponses.set('New', [
+      {
+        customTitle: 'New sprint',
+        messageCount: 7,
+        modified: new Date('2026-05-21T00:00:00.000Z'),
+        sessionId: 'session-new',
+      },
+    ])
+    const rendered = await renderHookHarness({
+      input: '/resume Old',
+      cursorOffset: '/resume Old'.length,
+    })
+
+    try {
+      await waitFor(
+        () => searchSessionsByCustomTitleMock.mock.calls.some(call => call[0] === 'Old'),
+        'initial delayed title completion request',
+      )
+
+      rendered.rerender({
+        input: '/resume New',
+        cursorOffset: '/resume New'.length,
+      })
+      await waitFor(
+        () =>
+          rendered.getSnapshot().suggestionType === 'custom-title' &&
+          rendered.getSnapshot().suggestions[0]?.displayText === 'New sprint',
+        'newer title completion result',
+      )
+
+      resolveSlowTitle([
+        {
+          customTitle: 'Old sprint',
+          messageCount: 4,
+          modified: new Date('2026-05-20T00:00:00.000Z'),
+          sessionId: 'session-old',
+        },
+      ])
+      await sleep(50)
+
+      expect(rendered.getSnapshot().suggestionType).toBe('custom-title')
+      expect(rendered.getSnapshot().suggestions[0]).toMatchObject({
+        displayText: 'New sprint',
+        metadata: { sessionId: 'session-new' },
+      })
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- discard stale `/add-dir` directory completion responses when a newer argument lookup wins
- discard stale `/resume` title completion responses when a newer query wins
- add delayed async regressions for both command-completion paths

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useTypeahead.hook.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useTypeahead.test.ts tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/hooks/useTypeahead.tsx' --coverage.reportsDirectory=coverage/runtime-tui-typeahead-focused
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored" (expected no matches)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known existing unused baseline: 1 file, 30 exports, 4 tag hints)
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core