### PR TITLE
fix(tui): cancel buffer commands with ctrl-c

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -407,7 +407,7 @@ export class WorkbenchBufferStore {
   }
 
   #handleVimCommandLineInput(input: string, key: Key, onCommand?: BufferVimCommandHandler): boolean {
-    if (key.escape) {
+    if (key.escape || (key.ctrl && input.toLowerCase() === "c")) {
       this.#vimCommandLine = null;
       this.#emit();
       return true;

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -651,6 +651,26 @@ describe("WorkbenchBufferStore", () => {
     });
   });
 
+  it("cancels the vim command line on Ctrl+C", async () => {
+    const file = join(dir, "target.txt");
+    await writeFile(file, "alpha\n", "utf8");
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    store.handleVimInput(":", key({ shift: true }), 80);
+    store.handleVimInput("w", key(), 80);
+
+    expect(store.getSnapshot().vimCommandLine).toBe("w");
+    expect(store.handleVimInput("c", key({ ctrl: true }), 80)).toBe(true);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "ready",
+      error: null,
+      vimCommandLine: null,
+    });
+    expect(store.getText()).toBe("alpha\n");
+  });
+
   it("refuses to overwrite disk changes made after open", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\n", "utf8");


### PR DESCRIPTION
## Summary
- Cancel the inline buffer Vim command prompt when Ctrl+C is pressed.
- Add a regression covering `:` command input followed by Ctrl+C.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/workbench/buffer/BufferStore.ts' --coverage.include='src/tui/workbench/surfaces/BufferSurface.tsx' --coverage.reportsDirectory=coverage/runtime-tui-buffer-focused`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- branding scan over `runtime/src` and `runtime/tests`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known baseline
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unused baseline: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.