### PR TITLE
fix(tui): preserve project tree expansion state

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -268,6 +268,7 @@ export class ProjectTreeStore {
       }
       await mkdir(path.dirname(target.absolutePath), { recursive: true });
       await rename(source.absolutePath, target.absolutePath);
+      this.#renameExpandedPaths(source.relativePath, target.relativePath);
       await this.refresh();
       this.reveal(target.relativePath);
       return { ok: true, path: target.relativePath };
@@ -282,6 +283,7 @@ export class ProjectTreeStore {
 
     try {
       await rm(target.absolutePath, { recursive: true });
+      this.#deleteExpandedPaths(target.relativePath);
       await this.refresh();
       this.reveal(parentPath(target.relativePath));
       return { ok: true, path: target.relativePath };
@@ -292,6 +294,28 @@ export class ProjectTreeStore {
 
   #rowForPath(pathValue: string): ProjectTreeRow | null {
     return this.#snapshot.rows.find((row) => row.path === pathValue) ?? null;
+  }
+
+  #renameExpandedPaths(fromPath: string, toPath: string): void {
+    const next = new Set<string>();
+    for (const expandedPath of this.#expandedPaths) {
+      if (expandedPath === fromPath) {
+        next.add(toPath);
+      } else if (isDescendantPath(expandedPath, fromPath)) {
+        next.add(`${toPath}${expandedPath.slice(fromPath.length)}`);
+      } else {
+        next.add(expandedPath);
+      }
+    }
+    this.#expandedPaths = next;
+  }
+
+  #deleteExpandedPaths(pathValue: string): void {
+    for (const expandedPath of [...this.#expandedPaths]) {
+      if (expandedPath === pathValue || isDescendantPath(expandedPath, pathValue)) {
+        this.#expandedPaths.delete(expandedPath);
+      }
+    }
   }
 
   #emit(): void {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -386,6 +386,37 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("carries expanded directory state across renamed subtrees", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-rename-expanded-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "src", "nested"), { recursive: true });
+      await writeFile(join(repo, "src", "nested", "app.ts"), "app\n", "utf8");
+      await store.refresh();
+      store.reveal("src/nested/app.ts");
+
+      expect([...store.getSnapshot().expandedPaths].sort()).toEqual(["src", "src/nested"]);
+
+      await expect(store.renamePath("src", "lib")).resolves.toEqual({
+        ok: true,
+        path: "lib",
+      });
+
+      const snapshot = store.getSnapshot();
+      const rowPaths = snapshot.rows.map((row) => row.path);
+
+      expect([...snapshot.expandedPaths].sort()).toEqual(["lib", "lib/nested"]);
+      expect(rowPaths).toContain("lib/nested/app.ts");
+      expect(rowPaths).not.toContain("src");
+      expect(snapshot.expandedPaths).not.toContain("src");
+      expect(snapshot.expandedPaths).not.toContain("src/nested");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("deletes files and rejects paths outside the workspace", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-delete-"));
     const store = new ProjectTreeStore(repo, 0);
@@ -403,6 +434,32 @@ describe("project tree helpers", () => {
 
       await expect(readFile(join(repo, "src", "gone.ts"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
       expect(store.getSnapshot().rows.map((row) => row.path)).not.toContain("src/gone.ts");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("prunes expanded directory state when deleting a subtree", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-delete-expanded-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "src", "nested"), { recursive: true });
+      await writeFile(join(repo, "src", "nested", "app.ts"), "app\n", "utf8");
+      await writeFile(join(repo, "README.md"), "readme\n", "utf8");
+      await store.refresh();
+      store.reveal("src/nested/app.ts");
+
+      expect([...store.getSnapshot().expandedPaths].sort()).toEqual(["src", "src/nested"]);
+
+      await expect(store.deletePath("src")).resolves.toEqual({ ok: true, path: "src" });
+
+      const snapshot = store.getSnapshot();
+
+      expect(snapshot.expandedPaths).toEqual([]);
+      expect(snapshot.rows.map((row) => row.path)).not.toContain("src");
+      expect(snapshot.cursorPath).toBe("README.md");
     } finally {
       store.dispose();
       await rm(repo, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Preserve expanded project-tree subpaths when renaming a directory subtree.
- Prune expanded project-tree paths when deleting a directory subtree.
- Add regressions for rename/delete expansion state so stale paths cannot survive workspace mutations.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/workbench/project-tree/ProjectTreeStore.ts' --coverage.include='src/tui/workbench/project-tree/ProjectExplorer.tsx' --coverage.include='src/tui/workbench/project-tree/buildTree.ts' --coverage.reportsDirectory=coverage/runtime-tui-project-tree-focused`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- `git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored"` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known unrelated baseline
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unused-code backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.