### PR TITLE
fix(tui): normalize workbench path references

### DIFF
--- a/runtime/src/tui/workbench/pathReferences.ts
+++ b/runtime/src/tui/workbench/pathReferences.ts
@@ -8,12 +8,13 @@ export function renameWorkspacePathReference(
   toPath: string,
 ): string | null {
   if (!value) return value;
+  const normalizedValue = normalizeWorkspacePathForReferences(value);
   const normalizedFromPath = normalizeWorkspacePathForReferences(fromPath);
   const normalizedToPath = normalizeWorkspacePathForReferences(toPath);
   if (!normalizedFromPath) return value;
-  if (value === normalizedFromPath) return normalizedToPath;
-  if (value.startsWith(`${normalizedFromPath}/`)) {
-    return `${normalizedToPath}${value.slice(normalizedFromPath.length)}`;
+  if (normalizedValue === normalizedFromPath) return normalizedToPath;
+  if (normalizedValue.startsWith(`${normalizedFromPath}/`)) {
+    return `${normalizedToPath}${normalizedValue.slice(normalizedFromPath.length)}`;
   }
   return value;
 }
@@ -23,10 +24,11 @@ export function containsWorkspacePathReference(
   targetPath: string,
 ): boolean {
   if (!value) return false;
+  const normalizedValue = normalizeWorkspacePathForReferences(value);
   const normalizedTargetPath = normalizeWorkspacePathForReferences(targetPath);
   if (!normalizedTargetPath) return false;
   return (
-    value === normalizedTargetPath ||
-    value.startsWith(`${normalizedTargetPath}/`)
+    normalizedValue === normalizedTargetPath ||
+    normalizedValue.startsWith(`${normalizedTargetPath}/`)
   );
 }

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -667,7 +667,7 @@ beforeAll(async () => {
   installElicitationResolvers = app.installElicitationResolvers;
   settlePendingOnSubmit = app.settlePendingOnSubmit;
   visibleCancelStreamMode = app.visibleCancelStreamMode;
-});
+}, 30_000);
 
 async function renderApp(node: React.ReactNode): Promise<string> {
   const { stdout, stdin, output } = createTestStreams();

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -274,6 +274,39 @@ describe("workbenchReducer", () => {
     ]);
   });
 
+  it("normalizes backslash path references before renaming active paths and attachments", () => {
+    const state = {
+      ...getDefaultWorkbenchState(),
+      activeFilePath: "src\\nested\\app.ts",
+      attachments: [
+        {
+          id: "file-range:src\\nested\\app.ts:12-15",
+          kind: "file-range" as const,
+          label: "src\\nested\\app.ts:12-15",
+          path: "src\\nested\\app.ts",
+          line: 12,
+          endLine: 15,
+        },
+      ],
+      composerAttachmentIds: ["file-range:src\\nested\\app.ts:12-15"],
+    };
+    const next = workbenchReducer(state, {
+      type: "renamePathReferences",
+      fromPath: "src",
+      toPath: "lib",
+    });
+
+    expect(next.activeFilePath).toBe("lib/nested/app.ts");
+    expect(next.attachments[0]).toMatchObject({
+      id: "file-range:lib/nested/app.ts:12-15",
+      label: "lib/nested/app.ts:12-15",
+      path: "lib/nested/app.ts",
+    });
+    expect(next.composerAttachmentIds).toEqual([
+      "file-range:lib/nested/app.ts:12-15",
+    ]);
+  });
+
   it("opens the buffer only when rename changes the current active path", () => {
     const affected = workbenchReducer({
       ...getDefaultWorkbenchState(),
@@ -356,6 +389,50 @@ describe("workbenchReducer", () => {
       },
     ]);
     expect(next.composerAttachmentIds).toEqual(["file:src-old/app.ts"]);
+  });
+
+  it("normalizes backslash path references before deleting active paths and attachments", () => {
+    const state = {
+      ...getDefaultWorkbenchState(),
+      activeFilePath: "src\\nested\\app.ts",
+      activeFileLine: 12,
+      attachments: [
+        {
+          id: "file-range:src\\nested\\app.ts:12-15",
+          kind: "file-range" as const,
+          label: "src\\nested\\app.ts:12-15",
+          path: "src\\nested\\app.ts",
+          line: 12,
+          endLine: 15,
+        },
+        {
+          id: "file:src-old\\app.ts",
+          kind: "file" as const,
+          label: "src-old\\app.ts",
+          path: "src-old\\app.ts",
+        },
+      ],
+      composerAttachmentIds: [
+        "file-range:src\\nested\\app.ts:12-15",
+        "file:src-old\\app.ts",
+      ],
+    };
+    const next = workbenchReducer(state, {
+      type: "deletePathReferences",
+      path: "src",
+    });
+
+    expect(next.activeFilePath).toBeNull();
+    expect(next.activeFileLine).toBeNull();
+    expect(next.attachments).toEqual([
+      {
+        id: "file:src-old\\app.ts",
+        kind: "file",
+        label: "src-old\\app.ts",
+        path: "src-old\\app.ts",
+      },
+    ]);
+    expect(next.composerAttachmentIds).toEqual(["file:src-old\\app.ts"]);
   });
 
   it("closes the active surface only when delete clears the current active path", () => {


### PR DESCRIPTION
## Summary
- Normalize stored workbench path references before rename/delete matching so backslash-form active paths and attachments are rewritten or removed correctly.
- Add reducer regressions for backslash active file paths, file-range attachments, and sibling paths that must survive deletes.
- Give the App render test dynamic-import hook the same 30s budget as normal tests so full TUI coverage can complete under instrumentation.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/reducer.test.ts` (failed before the fix on the two new backslash regressions, passed after)
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/reducer.test.ts --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.include='src/tui/workbench/reducer.ts' --coverage.include='src/tui/workbench/pathReferences.ts' --coverage.reportsDirectory=coverage/runtime-tui-path-references-focused`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/App.render.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- `git diff -- runtime/src runtime/tests | rg -n "Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored"` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known unrelated baseline
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unused-code backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.