### PR TITLE
fix(tui): clear stale buffer state on same-file reopen

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -775,6 +775,10 @@ export class WorkbenchBufferStore {
     if (this.#file?.absolutePath === absolutePath && !allowDirtyReplace) {
       if (this.#document) {
         this.#document = moveBufferCursorToLine(this.#document, line);
+        this.#status = "ready";
+        this.#error = null;
+        this.#conflictKind = null;
+        this.#hoverText = null;
         this.#ensureCursorVisible();
         this.#emit();
         return true;

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -457,6 +457,37 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getText()).toBe("alpha\nomega\n");
   });
 
+  it("clears transient buffer state when reopening the current file at another line", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\nomega\n", "utf8");
+    lspHarness.requestBufferHover.mockResolvedValue("alpha hover");
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+    await expect(store.requestHover()).resolves.toBe("alpha hover");
+
+    store.handleVimInput(":", key({ shift: true }), 80);
+    for (const char of "nope") {
+      store.handleVimInput(char, key(), 80);
+    }
+    store.handleVimInput("", key({ return: true }), 80);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "error",
+      hoverText: "alpha hover",
+    });
+
+    await runWithCwdOverride(dir, () => store.open("target.txt", 2));
+
+    expect(store.getSnapshot()).toMatchObject({
+      status: "ready",
+      filePath: "target.txt",
+      position: { line: 2 },
+      error: null,
+      conflictKind: null,
+      hoverText: null,
+    });
+    expect(store.getText()).toBe("alpha\nomega\n");
+  });
+
   it("requires inline edits to be saved or reverted before opening the external editor", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\n", "utf8");


### PR DESCRIPTION
## Summary
- clear stale buffer status, error, conflict, and hover state when reopening the current buffer at another line
- add a regression test covering same-file reopen after hover and command-error state

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts -t \"clears transient buffer state\" (failed before fix, passed after fix)
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- git diff -- runtime/src runtime/tests | rg -n \"Claude|claude|OpenClaude|openclaude|Codex|codex|Generated with|Co-Authored\" (no matches)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known baseline
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unused-code baseline: src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused tag hints.