### PR TITLE
fix(tui): normalize project tree path state

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -4,6 +4,7 @@ import { globby } from "globby";
 
 import { buildProjectTreeRows, visibleTreePaths } from "./buildTree.js";
 import { collectGitStatus, listGitFiles, type GitStatusByPath } from "./gitStatus.js";
+import { normalizeWorkspacePathForReferences } from "../pathReferences.js";
 import type { ProjectTreeRow, ProjectTreeSnapshot } from "../types.js";
 
 type Listener = () => void;
@@ -122,29 +123,30 @@ export class ProjectTreeStore {
   }
 
   setActivePath(pathValue: string | null): void {
-    this.#activePath = pathValue;
-    if (pathValue) {
-      this.reveal(pathValue);
+    const nextPath = normalizeProjectTreeReference(pathValue);
+    this.#activePath = nextPath;
+    if (nextPath) {
+      this.reveal(nextPath);
     }
     this.#emit();
   }
 
   setAttachedPaths(paths: Iterable<string>): void {
-    const next = new Set(paths);
+    const next = normalizedPathSet(paths);
     if (sameSet(this.#attachedPaths, next)) return;
     this.#attachedPaths = next;
     this.#emit();
   }
 
   setSearchHitPaths(paths: Iterable<string>): void {
-    const next = new Set(paths);
+    const next = normalizedPathSet(paths);
     if (sameSet(this.#searchHitPaths, next)) return;
     this.#searchHitPaths = next;
     this.#emit();
   }
 
   setInFlightPaths(paths: Iterable<string>): void {
-    const next = new Set(paths);
+    const next = normalizedPathSet(paths);
     if (sameSet(this.#inFlightPaths, next)) return;
     this.#inFlightPaths = next;
     this.#emit();
@@ -185,51 +187,55 @@ export class ProjectTreeStore {
   }
 
   toggle(pathValue = this.#cursorPath): void {
-    if (!pathValue) return;
-    const row = this.#rowForPath(pathValue);
+    const normalizedPath = normalizeProjectTreeReference(pathValue);
+    if (!normalizedPath) return;
+    const row = this.#rowForPath(normalizedPath);
     if (!row || row.kind !== "directory") return;
-    if (this.#expandedPaths.has(pathValue)) {
-      this.#expandedPaths.delete(pathValue);
-      if (this.#cursorPath && isDescendantPath(this.#cursorPath, pathValue)) {
-        this.#cursorPath = pathValue;
+    if (this.#expandedPaths.has(normalizedPath)) {
+      this.#expandedPaths.delete(normalizedPath);
+      if (this.#cursorPath && isDescendantPath(this.#cursorPath, normalizedPath)) {
+        this.#cursorPath = normalizedPath;
       }
     } else {
-      this.#expandedPaths.add(pathValue);
+      this.#expandedPaths.add(normalizedPath);
     }
     this.#emit();
   }
 
   expand(pathValue = this.#cursorPath): void {
-    if (!pathValue) return;
-    const row = this.#rowForPath(pathValue);
+    const normalizedPath = normalizeProjectTreeReference(pathValue);
+    if (!normalizedPath) return;
+    const row = this.#rowForPath(normalizedPath);
     if (!row || row.kind !== "directory") return;
-    this.#expandedPaths.add(pathValue);
+    this.#expandedPaths.add(normalizedPath);
     this.#emit();
   }
 
   collapse(pathValue = this.#cursorPath): void {
-    if (!pathValue) return;
-    const row = this.#rowForPath(pathValue);
-    if (row?.kind === "directory" && this.#expandedPaths.has(pathValue)) {
-      this.#expandedPaths.delete(pathValue);
-      if (this.#cursorPath && isDescendantPath(this.#cursorPath, pathValue)) {
-        this.#cursorPath = pathValue;
+    const normalizedPath = normalizeProjectTreeReference(pathValue);
+    if (!normalizedPath) return;
+    const row = this.#rowForPath(normalizedPath);
+    if (row?.kind === "directory" && this.#expandedPaths.has(normalizedPath)) {
+      this.#expandedPaths.delete(normalizedPath);
+      if (this.#cursorPath && isDescendantPath(this.#cursorPath, normalizedPath)) {
+        this.#cursorPath = normalizedPath;
       }
     } else {
-      const parent = parentPath(pathValue);
+      const parent = parentPath(normalizedPath);
       if (parent !== null) this.#cursorPath = parent;
     }
     this.#emit();
   }
 
   reveal(pathValue: string | null = this.#activePath): void {
-    if (!pathValue) return;
-    let parent = parentPath(pathValue);
+    const normalizedPath = normalizeProjectTreeReference(pathValue);
+    if (!normalizedPath) return;
+    let parent = parentPath(normalizedPath);
     while (parent !== null) {
       this.#expandedPaths.add(parent);
       parent = parentPath(parent);
     }
-    this.#cursorPath = pathValue;
+    this.#cursorPath = normalizedPath;
     this.#emit();
   }
 
@@ -392,6 +398,14 @@ function sameSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean
     if (!right.has(value)) return false;
   }
   return true;
+}
+
+function normalizeProjectTreeReference(pathValue: string | null): string | null {
+  return pathValue === null ? null : normalizeWorkspacePathForReferences(pathValue);
+}
+
+function normalizedPathSet(paths: Iterable<string>): Set<string> {
+  return new Set([...paths].map((pathValue) => normalizeWorkspacePathForReferences(pathValue)));
 }
 
 function firstFilePath(paths: readonly string[]): string | null {

--- a/runtime/src/tui/workbench/project-tree/buildTree.ts
+++ b/runtime/src/tui/workbench/project-tree/buildTree.ts
@@ -178,7 +178,7 @@ function compareNodes(left: TreeNode, right: TreeNode): number {
 }
 
 function normalizeRelativePath(value: string): string {
-  return value.split(path.sep).join("/");
+  return value.replace(/\\/gu, "/").split(path.sep).join("/");
 }
 
 function emptyRows(options: BuildProjectTreeOptions): ProjectTreeRow[] {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -248,6 +248,34 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("normalizes backslash active and attached paths before matching tree rows", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-backslash-state-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "src", "nested"), { recursive: true });
+      await writeFile(join(repo, "src", "nested", "app.ts"), "app\n", "utf8");
+
+      await store.refresh();
+      store.setActivePath("src\\nested\\app.ts");
+      store.setAttachedPaths(["src\\nested\\app.ts"]);
+
+      const snapshot = store.getSnapshot();
+      const activeRow = snapshot.rows.find((row) => row.path === "src/nested/app.ts");
+
+      expect(snapshot.cursorPath).toBe("src/nested/app.ts");
+      expect([...snapshot.expandedPaths].sort()).toEqual(["src", "src/nested"]);
+      expect(activeRow).toMatchObject({
+        active: true,
+        attached: true,
+        selected: true,
+      });
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("keeps ignored-only fallback directories out of non-git workspaces", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-ignored-only-"));
     const store = new ProjectTreeStore(repo, 0);


### PR DESCRIPTION
## Summary
- Normalize project tree active, attached, search-hit, in-flight, and reveal/toggle path inputs before matching rows.
- Normalize backslash paths while building tree nodes so Windows-style workspace references align with slash-normalized row paths.
- Add a regression covering backslash active and attached paths revealing and marking the same row.

## Test plan
- Focused regression failed before the fix and passed after: `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts -t \"normalizes backslash active\"`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-explorer-interactions.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- Branding scan over `runtime/src` and `runtime/tests` returned no matches
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` fails on the existing baseline: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints