### PR TITLE
fix(tui): normalize search result paths

### DIFF
--- a/runtime/src/tui/workbench/search/model.ts
+++ b/runtime/src/tui/workbench/search/model.ts
@@ -1,5 +1,6 @@
 import { relativePath } from "../../../utils/permissions/filesystem.js";
 import { isRelativePathOutsideBase } from "../../pathDisplay.js";
+import { normalizeWorkspacePathForReferences } from "../pathReferences.js";
 import type { SearchGroup, SearchMatch } from "../types.js";
 
 export function parseWorkbenchRipgrepJsonLine(line: string, cwd: string): SearchMatch | null {
@@ -47,7 +48,7 @@ export function parseWorkbenchRipgrepJsonLine(line: string, cwd: string): Search
 
 function normalizeWorkbenchSearchPath(rawFile: string, cwd: string): string {
   const rel = isAbsoluteLike(rawFile) ? relativePath(cwd, rawFile) : rawFile;
-  return isRelativePathOutsideBase(rel) ? rawFile : rel;
+  return normalizeWorkspacePathForReferences(isRelativePathOutsideBase(rel) ? rawFile : rel);
 }
 
 function isAbsoluteLike(value: string): boolean {

--- a/runtime/tests/tui/workbench/search-model.test.ts
+++ b/runtime/tests/tui/workbench/search-model.test.ts
@@ -46,6 +46,15 @@ describe("workbench search model", () => {
     expect(parseWorkbenchRipgrepJsonLine(JSON.stringify({ type: "begin" }), "/repo")).toBeNull();
   });
 
+  it("normalizes backslash search result paths before they become workbench references", () => {
+    expect(parseWorkbenchRipgrepJsonLine(jsonMatchLine("src\\nested\\app.ts", 6, "needle"), "/repo")).toEqual({
+      id: "src/nested/app.ts:6:needle",
+      file: "src/nested/app.ts",
+      line: 6,
+      text: "needle",
+    });
+  });
+
   it("groups matches by file and exposes visible header rows", () => {
     const groups = groupSearchMatches([
       { id: "a:1:x", file: "a.ts", line: 1, text: "x" },

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -318,6 +318,55 @@ describe("SearchSurface", () => {
     }
   });
 
+  it("opens backslash search result paths as normalized workspace paths", async () => {
+    searchHarness.autoFlush = false;
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "needle",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep(180);
+
+      expect(searchHarness.calls).toHaveLength(1);
+      const call = searchHarness.calls[0]!;
+      call.onLines([
+        jsonMatchLine("src\\nested\\app.ts", 6, "const needle = true"),
+      ]);
+      call.resolve();
+      await sleep(50);
+      searchHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/nested/app.ts",
+        activeFileLine: 6,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("does not restore the requested search match after manual navigation during streaming", async () => {
     searchHarness.autoFlush = false;
     const changes: AppState[] = [];


### PR DESCRIPTION
## Summary
- Normalize workbench search result paths at the ripgrep model boundary so backslash paths become slash-normalized workspace references.
- Add a model regression for backslash ripgrep paths.
- Add a mounted search surface regression proving opening a backslash result dispatches a normalized buffer path.

## Test plan
- Focused model regression failed before the fix and passed after: `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-model.test.ts -t \"normalizes backslash search result paths\"`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-model.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-surface.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- Branding scan over `runtime/src` and `runtime/tests` returned no matches
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` fails on the existing baseline: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints