### PR TITLE
fix(tui): normalize workbench command paths

### DIFF
--- a/runtime/src/tui/workbench/commands.ts
+++ b/runtime/src/tui/workbench/commands.ts
@@ -1,11 +1,12 @@
 import type { SearchMatch, WorkbenchAttachment, WorkbenchCommand } from "./types.js";
+import { normalizeWorkspacePathForReferences } from "./pathReferences.js";
 
 export function openPreviewCommand(
   path: string,
   line?: number,
   focus = true,
 ): WorkbenchCommand {
-  return { type: "openPreview", path, line, focus };
+  return { type: "openPreview", path: normalizeCommandPath(path), line, focus };
 }
 
 export function openBufferCommand(
@@ -13,17 +14,18 @@ export function openBufferCommand(
   line?: number,
   focus = true,
 ): WorkbenchCommand {
-  return { type: "openBuffer", path, line, focus };
+  return { type: "openBuffer", path: normalizeCommandPath(path), line, focus };
 }
 
 export function attachFileCommand(path: string): WorkbenchCommand {
+  const normalizedPath = normalizeCommandPath(path);
   return {
     type: "attach",
     attachment: {
-      id: `file:${path}`,
+      id: `file:${normalizedPath}`,
       kind: "file",
-      path,
-      label: path,
+      path: normalizedPath,
+      label: normalizedPath,
     },
   };
 }
@@ -57,15 +59,16 @@ export function attachFileRangeCommand(
   line: number,
   endLine = line,
 ): WorkbenchCommand {
+  const normalizedPath = normalizeCommandPath(path);
   return {
     type: "attach",
     attachment: {
-      id: `file-range:${path}:${line}-${endLine}`,
+      id: `file-range:${normalizedPath}:${line}-${endLine}`,
       kind: "file-range",
-      path,
+      path: normalizedPath,
       line,
       endLine,
-      label: `${path}:${line}${endLine !== line ? `-${endLine}` : ""}`,
+      label: `${normalizedPath}:${line}${endLine !== line ? `-${endLine}` : ""}`,
     },
   };
 }
@@ -83,15 +86,21 @@ export function attachTaskErrorCommand(input: {
   readonly line?: number;
   readonly label?: string;
 }): WorkbenchCommand {
+  const file = normalizeCommandPath(input.file);
   return {
     type: "attach",
     attachment: {
-      id: `task-error:${input.taskId}:${input.file}:${input.line ?? 1}`,
+      id: `task-error:${input.taskId}:${file}:${input.line ?? 1}`,
       kind: "task-error",
-      path: input.file,
+      path: file,
       line: input.line,
       taskId: input.taskId,
-      label: input.label ?? `${input.file}${input.line ? `:${input.line}` : ""}`,
+      label: normalizePathBackedLabel(
+        input.label,
+        input.file,
+        file,
+        `${file}${input.line ? `:${input.line}` : ""}`,
+      ),
     },
   };
 }
@@ -101,40 +110,48 @@ export function attachDiffHunkCommand(input: {
   readonly line?: number;
   readonly label?: string;
 }): WorkbenchCommand {
+  const path = normalizeCommandPath(input.path);
   return {
     type: "attach",
     attachment: {
-      id: `diff-hunk:${input.path}:${input.line ?? 1}`,
+      id: `diff-hunk:${path}:${input.line ?? 1}`,
       kind: "diff-hunk",
-      path: input.path,
+      path,
       line: input.line,
-      label: input.label ?? `${input.path}${input.line ? `:${input.line}` : ""}`,
+      label: normalizePathBackedLabel(
+        input.label,
+        input.path,
+        path,
+        `${path}${input.line ? `:${input.line}` : ""}`,
+      ),
     },
   };
 }
 
 export function searchMatchAttachment(query: string, match: SearchMatch): WorkbenchAttachment {
+  const file = normalizeCommandPath(match.file);
   return {
-    id: `search-result:${match.id}`,
+    id: `search-result:${replaceFirst(match.id, match.file, file)}`,
     kind: "search-result",
-    path: match.file,
+    path: file,
     line: match.line,
     query,
-    label: `${match.file}:${match.line}`,
+    label: `${file}:${match.line}`,
   };
 }
 
 export function attachmentPromptMention(attachment: WorkbenchAttachment): string | null {
   if (!attachment.path) return null;
+  const path = normalizeCommandPath(attachment.path);
   switch (attachment.kind) {
     case "file":
-      return `@${attachment.path}`;
+      return `@${path}`;
     case "file-range":
-      return `@${attachment.path}#L${attachment.line ?? 1}${attachment.endLine && attachment.endLine !== attachment.line ? `-${attachment.endLine}` : ""}`;
+      return `@${path}#L${attachment.line ?? 1}${attachment.endLine && attachment.endLine !== attachment.line ? `-${attachment.endLine}` : ""}`;
     case "search-result":
     case "diff-hunk":
     case "task-error":
-      return `@${attachment.path}${attachment.line ? `#L${attachment.line}` : ""}`;
+      return `@${path}${attachment.line ? `#L${attachment.line}` : ""}`;
   }
 }
 
@@ -151,4 +168,25 @@ export function materializeAttachmentMentions(
     );
   if (mentions.length === 0) return input;
   return `${mentions.join(" ")}\n\n${input}`;
+}
+
+function normalizeCommandPath(path: string): string {
+  return normalizeWorkspacePathForReferences(path);
+}
+
+function normalizePathBackedLabel(
+  label: string | undefined,
+  originalPath: string,
+  normalizedPath: string,
+  defaultLabel: string,
+): string {
+  if (label === undefined) return defaultLabel;
+  return replaceFirst(label, originalPath, normalizedPath);
+}
+
+function replaceFirst(value: string, needle: string, replacement: string): string {
+  if (!needle || needle === replacement) return value;
+  const index = value.indexOf(needle);
+  if (index < 0) return value;
+  return `${value.slice(0, index)}${replacement}${value.slice(index + needle.length)}`;
 }

--- a/runtime/tests/tui/workbench/commands.test.ts
+++ b/runtime/tests/tui/workbench/commands.test.ts
@@ -7,6 +7,7 @@ import {
   attachFileRangeCommand,
   materializeAttachmentMentions,
   openBufferCommand,
+  openPreviewCommand,
   attachTaskErrorCommand,
   searchMatchAttachment,
 } from "../../../src/tui/workbench/commands.js";
@@ -20,6 +21,68 @@ describe("workbench command helpers", () => {
       line: 9,
       focus: false,
     });
+  });
+
+  it("normalizes path-backed commands before they update workbench state", () => {
+    expect(openBufferCommand("src\\nested\\app.ts", 9, false)).toMatchObject({
+      path: "src/nested/app.ts",
+    });
+    expect(openPreviewCommand("src\\nested\\app.ts", 9, false)).toMatchObject({
+      path: "src/nested/app.ts",
+    });
+    expect(attachFileCommand("src\\nested\\app.ts")).toMatchObject({
+      attachment: {
+        id: "file:src/nested/app.ts",
+        path: "src/nested/app.ts",
+        label: "src/nested/app.ts",
+      },
+    });
+    expect(attachFileRangeCommand("src\\nested\\app.ts", 4, 7)).toMatchObject({
+      attachment: {
+        id: "file-range:src/nested/app.ts:4-7",
+        path: "src/nested/app.ts",
+        label: "src/nested/app.ts:4-7",
+      },
+    });
+    expect(attachDiffHunkCommand({
+      path: "src\\nested\\app.ts",
+      line: 9,
+      label: "src\\nested\\app.ts diff",
+    })).toMatchObject({
+      attachment: {
+        id: "diff-hunk:src/nested/app.ts:9",
+        path: "src/nested/app.ts",
+        label: "src/nested/app.ts diff",
+      },
+    });
+    expect(attachTaskErrorCommand({
+      taskId: "test-1",
+      file: "src\\nested\\app.test.ts",
+      line: 12,
+      label: "src\\nested\\app.test.ts failure",
+    })).toMatchObject({
+      attachment: {
+        id: "task-error:test-1:src/nested/app.test.ts:12",
+        path: "src/nested/app.test.ts",
+        label: "src/nested/app.test.ts failure",
+      },
+    });
+    expect(searchMatchAttachment("needle", {
+      id: "src\\nested\\app.ts:6:needle",
+      file: "src\\nested\\app.ts",
+      line: 6,
+      text: "needle",
+    })).toMatchObject({
+      id: "search-result:src/nested/app.ts:6:needle",
+      path: "src/nested/app.ts",
+      label: "src/nested/app.ts:6",
+    });
+    expect(attachmentPromptMention({
+      id: "file:src\\nested\\app.ts",
+      kind: "file",
+      label: "src\\nested\\app.ts",
+      path: "src\\nested\\app.ts",
+    })).toBe("@src/nested/app.ts");
   });
 
   it("materializes composer attachments as prompt mentions", () => {


### PR DESCRIPTION
## Summary
- Normalize path-backed workbench command helpers before they update workbench state or attachments.
- Normalize labels and prompt mentions when they are derived from path-backed command inputs.
- Add command-helper regressions covering buffer/preview opens, file/range/diff/task/search attachments, and prompt mentions with backslash paths.

## Test plan
- Focused command regression failed before the fix and passed after: `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/commands.test.ts -t \"normalizes path-backed commands\"`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/commands.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx tests/tui/workbench/preview-surface.test.tsx tests/tui/workbench/project-explorer-interactions.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `git diff --check`
- Branding scan over `runtime/src` and `runtime/tests` returned no matches
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` fails on the existing baseline: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints