### PR TITLE
fix(tui): harden destructive approval risk

### DIFF
--- a/runtime/src/permissions/risk.ts
+++ b/runtime/src/permissions/risk.ts
@@ -1,4 +1,19 @@
+import { matchedDangerousShellCommandLabel } from "./dangerous-patterns.js";
+
 export type ApprovalRiskTier = "low" | "medium" | "destructive";
+
+const SHELL_COMMAND_FRAGMENT = String.raw`[^;&|\n]*`;
+const RECURSIVE_FORCE_RM_BUNDLED_FLAGS = new RegExp(
+  [
+    String.raw`\brm\b${SHELL_COMMAND_FRAGMENT}\s+-[a-z]*r[a-z]*f[a-z]*\b`,
+    String.raw`\brm\b${SHELL_COMMAND_FRAGMENT}\s+-[a-z]*f[a-z]*r[a-z]*\b`,
+  ].join("|"),
+  "iu",
+);
+const RECURSIVE_FORCE_RM_SPLIT_FLAGS = new RegExp(
+  String.raw`\brm\b(?=${SHELL_COMMAND_FRAGMENT}\s+(?:-[a-z]*r[a-z]*\b|--recursive\b))(?=${SHELL_COMMAND_FRAGMENT}\s+(?:-[a-z]*f[a-z]*\b|--force\b))`,
+  "iu",
+);
 
 export function classifyApprovalRisk(input: {
   readonly request?: { readonly ctx?: { readonly toolName?: unknown } };
@@ -20,7 +35,10 @@ export function classifyApprovalRisk(input: {
     .join(" ")
     .toLowerCase();
 
-  if (/\b(rm\s+-rf|delete|destroy|wipe|format|mainnet|settle|stake|transfer|slash|escrow)\b/u.test(haystack)) {
+  if (commandLooksDestructive(input.command)) {
+    return "destructive";
+  }
+  if (/\b(delete|destroy|wipe|format|mainnet|settle|stake|transfer|slash|escrow)\b/u.test(haystack)) {
     return "destructive";
   }
   if (/\b(write|edit|patch|chmod|chown|mv|deploy|install|network|curl|wget)\b/u.test(haystack)) {
@@ -39,6 +57,35 @@ export function typedConfirmationWordForRisk(input: {
   if (/\bsettle\b/u.test(haystack)) return "settle";
   if (/\bstake\b/u.test(haystack)) return "stake";
   if (/\btransfer\b/u.test(haystack)) return "transfer";
-  if (/\bdelete|destroy|wipe|rm\s+-rf\b/u.test(haystack)) return "delete";
+  if (/\bdelete|destroy|wipe\b/u.test(haystack)) return "delete";
+  if (input.command && commandLooksLikeRemoval(input.command)) return "delete";
   return "approve";
+}
+
+function dangerousShellCommandLabel(command: string | undefined): string | null {
+  return command ? matchedDangerousShellCommandLabel(command) : null;
+}
+
+function commandLooksDestructive(command: string | undefined): boolean {
+  if (!command) return false;
+  return (
+    dangerousShellCommandLabel(command) !== null ||
+    containsRecursiveForceRemovalText(command)
+  );
+}
+
+function commandLooksLikeRemoval(command: string): boolean {
+  const label = dangerousShellCommandLabel(command);
+  if (label === "rm -rf" || label === "rm -f") return true;
+  return (
+    (/\brm\b/u.test(command.toLowerCase()) && label !== null) ||
+    containsRecursiveForceRemovalText(command)
+  );
+}
+
+function containsRecursiveForceRemovalText(command: string): boolean {
+  return (
+    RECURSIVE_FORCE_RM_BUNDLED_FLAGS.test(command) ||
+    RECURSIVE_FORCE_RM_SPLIT_FLAGS.test(command)
+  );
 }

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -261,4 +261,46 @@ describe("permission request overlay coverage", () => {
       await sleep();
     }
   });
+
+  test("requires typed confirmation for equivalent forced recursive removal forms", async () => {
+    const resolved: ReviewDecision[] = [];
+    const request = createPendingRequest(
+      decision => {
+        resolved.push(decision);
+      },
+      {
+        id: "request-delete-permuted",
+        input: { command: "rm", args: ["-fr", "/tmp/agenc-danger"] },
+        description: "Remove generated path",
+      },
+    );
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<AgenCPermissionOverlay request={request} tools={[{ name: "Bash" }]} />);
+      await sleep();
+
+      const frame = stripAnsi(extractLastFrame(output()));
+      const compactFrame = frame.replace(/\s+/gu, "");
+      expect(compactFrame).toContain("high-riskapproval");
+      expect(compactFrame).toContain("rm-fr/tmp/agenc-danger");
+      expect(compactFrame).toContain("type'delete'toapprove");
+      expect(resolved).toEqual([]);
+
+      stdin.write("\r");
+      await sleep();
+
+      expect(resolved).toEqual([]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
 });

--- a/runtime/tests/tui/workbench/risk.test.ts
+++ b/runtime/tests/tui/workbench/risk.test.ts
@@ -10,11 +10,23 @@ describe("approval risk helpers", () => {
     expect(classifyApprovalRisk({ toolName: "Read", command: "cat README.md" })).toBe("low");
     expect(classifyApprovalRisk({ toolName: "Bash", command: "npm install" })).toBe("medium");
     expect(classifyApprovalRisk({ toolName: "Bash", command: "rm -rf /tmp/project" })).toBe("destructive");
+    expect(classifyApprovalRisk({ toolName: "Bash", command: `bash {"script":"rm -rf /tmp/project"}` })).toBe("destructive");
+  });
+
+  it.each([
+    "rm -fr /tmp/project",
+    "rm -r -f /tmp/project",
+    "rm --recursive --force /tmp/project",
+    "bash -lc 'rm -fr /tmp/project'",
+  ])("classifies equivalent forced recursive removals as destructive: %s", (command) => {
+    expect(classifyApprovalRisk({ toolName: "Bash", command })).toBe("destructive");
   });
 
   it("requires specific confirmation words for destructive actions", () => {
     expect(typedConfirmationWordForRisk({ risk: "destructive", command: "transfer tokens" })).toBe("transfer");
     expect(typedConfirmationWordForRisk({ risk: "destructive", command: "delete branch" })).toBe("delete");
+    expect(typedConfirmationWordForRisk({ risk: "destructive", command: "rm -fr /tmp/project" })).toBe("delete");
+    expect(typedConfirmationWordForRisk({ risk: "destructive", command: `bash {"script":"rm -rf /tmp/project"}` })).toBe("delete");
     expect(typedConfirmationWordForRisk({ risk: "medium", command: "npm install" })).toBe("yes");
   });
 });


### PR DESCRIPTION
## Summary
- Classify approval requests through the shared dangerous shell command detector so permuted recursive forced removals are destructive.
- Preserve destructive classification for structured approval input that serializes embedded removal scripts.
- Require typed delete confirmation for equivalent recursive forced removal forms.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/risk.test.ts tests/tui/workbench/approval-input-text.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/workbench/diff-surface.test.tsx tests/tui/permission-requests.coverage.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/permissions/dangerous-patterns.test.ts
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/risk.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/permission-requests.coverage.test.tsx tests/permissions/dangerous-patterns.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- branding scan over runtime/src and runtime/tests: no matches
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production reports the known baseline only: 1 unused file, 30 unused exports, 4 tag hints