### PR TITLE
fix(tui): normalize global search inserted paths

### DIFF
--- a/runtime/src/tui/components/GlobalSearchDialog.tsx
+++ b/runtime/src/tui/components/GlobalSearchDialog.tsx
@@ -7,6 +7,7 @@ import { useRegisterOverlay } from '../context/overlayContext';
 import { useTerminalSize } from '../hooks/useTerminalSize';
 import { useOptionalSetAppState } from '../state/AppState.js';
 import { openPreviewCommand } from '../workbench/commands.js';
+import { normalizeWorkspacePathForReferences } from '../workbench/pathReferences.js';
 import { applyWorkbenchCommand, isWorkbenchEnabled } from '../workbench/state.js';
 import { stringWidth } from '../ink/stringWidth.js';
 import { Text } from '../ink.js';
@@ -332,7 +333,7 @@ function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearch
       }
       parsed.push({
         ...m_1,
-        file: displayPathRelativeToBase(cwd, m_1.file)
+        file: normalizeWorkspacePathForReferences(displayPathRelativeToBase(cwd, m_1.file))
       });
     }
     if (!parsed.length) {

--- a/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
@@ -490,4 +490,28 @@ describe('GlobalSearchDialog render and interactions', () => {
       await rendered.dispose()
     }
   })
+
+  it('normalizes backslash result paths before inserting prompt text', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      await searchFor('needle', [
+        jsonMatchLine('src\\nested\\app.ts', 6, 'Needle alpha'),
+      ])
+      await waitFor(
+        () => pickerProps().items.length === 1 && pickerProps().matchLabel === '1 matches',
+        'Global search result did not render for backslash insert test',
+      )
+
+      const match = pickerProps().items[0]
+
+      pickerProps().onTab?.handler(match)
+      expect(rendered.onInsert).toHaveBeenCalledWith('@src/nested/app.ts#L6 ')
+
+      pickerProps().onShiftTab?.handler(match)
+      expect(rendered.onInsert).toHaveBeenCalledWith('src/nested/app.ts:6 ')
+    } finally {
+      await rendered.dispose()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Normalize global search result paths before preview, open, and prompt insertion handlers consume them.
- Prevent Tab and Shift+Tab insertions from emitting backslash workspace paths.
- Add a regression for backslash ripgrep paths inserting as forward-slash workspace references.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/GlobalSearchDialog.render.test.tsx tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/search-model.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- branding scan over runtime/src and runtime/tests: no matches
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production reports known baseline only: 1 unused file, 30 unused exports, 4 tag hints