### PR TITLE
fix(tui): reject drive-qualified tree paths

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -468,7 +468,7 @@ function resolveWorkspaceRelativePath(
 ): { readonly ok: true; readonly relativePath: string; readonly absolutePath: string } | { readonly ok: false; readonly error: string } {
   const input = inputPath.replace(/\\/gu, "/");
   if (input.trim().length === 0) return { ok: false, error: "Enter a workspace-relative path." };
-  if (path.posix.isAbsolute(input) || path.isAbsolute(input)) {
+  if (isWindowsDriveQualifiedPath(input) || path.posix.isAbsolute(input) || path.isAbsolute(input)) {
     return { ok: false, error: "Use a workspace-relative path, not an absolute path." };
   }
 
@@ -497,6 +497,10 @@ function resolveWorkspaceRelativePath(
 
 function stripTrailingSlashes(value: string): string {
   return value.replace(/\/+$/u, "");
+}
+
+function isWindowsDriveQualifiedPath(value: string): boolean {
+  return /^[A-Za-z]:/u.test(value);
 }
 
 async function pathExists(absolutePath: string): Promise<boolean> {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -468,6 +468,41 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("rejects drive-qualified Windows paths for workspace mutations", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-drive-path-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await writeFile(join(repo, "source.ts"), "source\n", "utf8");
+      await store.refresh();
+
+      await expect(store.createFile("C:\\Users\\me\\outside.ts")).resolves.toEqual({
+        ok: false,
+        error: "Use a workspace-relative path, not an absolute path.",
+      });
+      await expect(store.renamePath("source.ts", "D:/tmp/renamed.ts")).resolves.toEqual({
+        ok: false,
+        error: "Use a workspace-relative path, not an absolute path.",
+      });
+      await expect(store.deletePath("E:\\tmp\\gone.ts")).resolves.toEqual({
+        ok: false,
+        error: "Use a workspace-relative path, not an absolute path.",
+      });
+      await expect(store.createFile("F:drive-relative.ts")).resolves.toEqual({
+        ok: false,
+        error: "Use a workspace-relative path, not an absolute path.",
+      });
+
+      await expect(readFile(join(repo, "source.ts"), "utf8")).resolves.toBe("source\n");
+      await expect(readFile(join(repo, "C:", "Users", "me", "outside.ts"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("prunes expanded directory state when deleting a subtree", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-delete-expanded-"));
     const store = new ProjectTreeStore(repo, 0);


### PR DESCRIPTION
## Summary
- Reject Windows drive-qualified paths at the project tree mutation resolver boundary.
- Prevent create, rename, and delete actions from treating `C:/...`, `E:\\...`, or `F:relative` inputs as workspace-relative paths.
- Add a regression proving existing workspace files are preserved and no `C:` subtree is created under the workspace.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts -t "rejects drive-qualified"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx
- npm --workspace=@tetsuo-ai/runtime run typecheck
- git diff --check
- branding scan over runtime/src and runtime/tests: no matches
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production reports known baseline only: 1 unused file, 30 unused exports, 4 tag hints