### PR TITLE
fix(tui): avoid prompt paste id collisions

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -701,7 +701,17 @@ function PromptInput({
   // so guard with a lazy-init pattern to run it exactly once.
   const nextPasteIdRef = useRef(-1);
   if (nextPasteIdRef.current === -1) {
-    nextPasteIdRef.current = getInitialPasteId(messages);
+    nextPasteIdRef.current = getNextPasteIdAfter(messages, pastedContents, input);
+  }
+  const pastedContentsRef = useRef(pastedContents);
+  pastedContentsRef.current = pastedContents;
+  function allocatePasteId(): number {
+    const nextPasteId = Math.max(
+      nextPasteIdRef.current,
+      getNextPasteIdAfter(messages, pastedContentsRef.current, lastInternalInputRef.current),
+    );
+    nextPasteIdRef.current = nextPasteId + 1;
+    return nextPasteId;
   }
   // Armed by onImagePaste; if the very next keystroke is a non-space
   // printable, inputFilter prepends a space before it. Any other input
@@ -1562,7 +1572,7 @@ function PromptInput({
   function onImagePaste(image: string, mediaType?: string, filename?: string, dimensions?: ImageDimensions, sourcePath?: string) {
     logEvent('agenc_paste_image', {});
     onModeChange('prompt');
-    const pasteId = nextPasteIdRef.current++;
+    const pasteId = allocatePasteId();
     const newContent: PastedContent = {
       id: pasteId,
       type: 'image',
@@ -1649,7 +1659,7 @@ function PromptInput({
     // Use special handling for long pasted text (>PASTE_THRESHOLD chars)
     // or if it exceeds the number of lines we want to show
     if (text.length > PASTE_THRESHOLD || numLines > maxLines) {
-      const pasteId = nextPasteIdRef.current++;
+      const pasteId = allocatePasteId();
       const newContent: PastedContent = {
         id: pasteId,
         type: 'text',
@@ -2751,10 +2761,14 @@ function PromptInput({
 }
 
 /**
- * Compute the initial paste ID by finding the max ID used in existing messages.
- * This handles --continue/--resume scenarios where we need to avoid ID collisions.
+ * Compute the next paste ID after every ID already visible to the current
+ * prompt, including resumed messages and restored draft paste references.
  */
-function getInitialPasteId(messages: Message[]): number {
+function getNextPasteIdAfter(
+  messages: Message[],
+  pastedContents: Record<number, PastedContent> = {},
+  input = '',
+): number {
   let maxId = 0;
   for (const message of messages) {
     if (message.type === 'user') {
@@ -2776,6 +2790,14 @@ function getInitialPasteId(messages: Message[]): number {
         }
       }
     }
+  }
+  for (const ref of parseReferences(input)) {
+    if (ref.id > maxId) maxId = ref.id;
+  }
+  for (const [key, content] of Object.entries(pastedContents)) {
+    const keyId = Number(key);
+    if (Number.isFinite(keyId) && keyId > maxId) maxId = keyId;
+    if (content.id > maxId) maxId = content.id;
   }
   return maxId + 1;
 }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1153,6 +1153,86 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('allocates image paste IDs after existing draft paste references', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'png-data',
+      mediaType: 'image/png',
+      dimensions: { width: 320, height: 200 },
+    })
+    const onInputChange = vi.fn()
+    const textPaste: PastedContent = {
+      id: 1,
+      type: 'text',
+      content: 'history paste',
+    }
+    const pastedContents = createPastedContentsState({
+      1: textPaste,
+    })
+    const rendered = await renderPromptInput({
+      input: '[Pasted text #1]',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      expect(onInputChange).toHaveBeenCalledWith('[Pasted text #1][Image #2]')
+      expect(pastedContents.current).toEqual({
+        1: textPaste,
+        2: expect.objectContaining({
+          content: 'png-data',
+          dimensions: { width: 320, height: 200 },
+          id: 2,
+          mediaType: 'image/png',
+          type: 'image',
+        }),
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('allocates text paste IDs after existing draft image references', async () => {
+    const onInputChange = vi.fn()
+    const imagePaste: PastedContent = {
+      id: 1,
+      type: 'image',
+      content: 'existing-image',
+      mediaType: 'image/png',
+      filename: 'existing.png',
+    }
+    const pastedContents = createPastedContentsState({
+      1: imagePaste,
+    })
+    const rendered = await renderPromptInput({
+      input: '[Image #1]',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onPaste as (value: string) => void)('x'.repeat(40))
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1][Pasted text #2]')
+      expect(pastedContents.current).toEqual({
+        1: imagePaste,
+        2: {
+          id: 2,
+          type: 'text',
+          content: 'x'.repeat(40),
+        },
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('logs rejected clipboard image shortcut lookups without routing image paste', async () => {
     const error = new Error('clipboard read failed')
     vi.mocked(getImageFromClipboard).mockRejectedValueOnce(error)


### PR DESCRIPTION
## Summary
- Allocate prompt paste IDs after IDs already present in messages, the current draft, and current pasted contents.
- Preserve restored draft paste contents when adding a new image or long-text paste.
- Add regressions for restored text-then-image and image-then-text paste ID collisions.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "allocates image paste IDs"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "allocates .* paste IDs"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx tests/tui/components/PromptInput/PromptInput.busyPolicy.test.ts
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known baseline remains: src/tui/workbench/keymap.ts, 30 unused exports, 4 internal tag hints)
- git diff --check
- diff branding scan
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Coverage
- Lines: 94.52% (31736/33573)
- Statements: 93.5% (33764/36108)
- Functions: 92.47% (4645/5023)
- Branches: 86.79% (23899/27536)