### PR TITLE
fix(tui): respect composer attachment selection

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -106,6 +106,7 @@ import { ModelPicker } from '../ModelPicker.js';
 import { QuickOpenDialog } from '../QuickOpenDialog.js';
 import { materializeAttachmentMentions } from '../../workbench/commands.js';
 import { useWorkbenchComposerFocus } from '../../workbench/composerFocusContext.js';
+import { composerAttachmentsForState } from '../../workbench/reducer.js';
 import { applyWorkbenchCommand, isWorkbenchEnabled } from '../../workbench/state.js';
 import { ThinkingToggle } from '../ThinkingToggle.js';
 import { BackgroundTasksPanel } from '../tasks/BackgroundTasksPanel.js';
@@ -1292,7 +1293,9 @@ function PromptInput({
     // same "still visible?" derivation as footerItemSelected so a stale
     // selection (pill disappeared) doesn't swallow Enter.
     const state = store.getState();
-    const workbenchAttachments = isWorkbenchEnabled() ? state.workbench?.attachments ?? [] : [];
+    const workbenchAttachments = isWorkbenchEnabled() && state.workbench
+      ? composerAttachmentsForState(state.workbench)
+      : [];
     const hasWorkbenchAttachments = workbenchAttachments.length > 0;
     if (state.footerSelection && footerItems.includes(state.footerSelection)) {
       return;

--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -3,17 +3,18 @@ import React from "react";
 
 import { Box, Text } from "../ink.js";
 import { footerHintsForSurface } from "./surfaces/ActiveWorkSurface.js";
-import { visibleWorkbenchPane } from "./reducer.js";
+import { composerAttachmentsForState, visibleWorkbenchPane } from "./reducer.js";
 import { useWorkbenchState } from "./state.js";
 
 export function WorkbenchFooter(): React.ReactElement {
   const workbench = useWorkbenchState();
   const hints = hintsForPane(visibleWorkbenchPane(workbench), workbench.activeSurfaceMode);
+  const composerAttachments = composerAttachmentsForState(workbench);
   return (
     <Box height={1} width="100%">
       <Text dimColor wrap="truncate-end">{hints}</Text>
-      {workbench.attachments.length > 0 ? (
-        <Text color="suggestion" wrap="truncate-end"> | context {workbench.attachments.map((item) => item.label).join(", ")}</Text>
+      {composerAttachments.length > 0 ? (
+        <Text color="suggestion" wrap="truncate-end"> | context {composerAttachments.map((item) => item.label).join(", ")}</Text>
       ) : null}
     </Box>
   );

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -174,6 +174,21 @@ export function visibleWorkbenchPane(state: WorkbenchState): WorkbenchPane {
   return state.focusedPane;
 }
 
+export function composerAttachmentsForState(
+  state: WorkbenchState,
+): readonly WorkbenchAttachment[] {
+  const attachmentsById = new Map(state.attachments.map((item) => [item.id, item]));
+  const seen = new Set<string>();
+  const attachments: WorkbenchAttachment[] = [];
+  for (const id of state.composerAttachmentIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const attachment = attachmentsById.get(id);
+    if (attachment) attachments.push(attachment);
+  }
+  return attachments;
+}
+
 function openSurface(
   state: WorkbenchState,
   mode: ActiveSurfaceMode,

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -34,6 +34,7 @@ const harness = vi.hoisted(() => {
     },
     viewingAgentTaskId: null,
     viewSelectionMode: null,
+    workbench: undefined as unknown,
   }
 
   return {
@@ -176,6 +177,7 @@ const harness = vi.hoisted(() => {
       }
       appState.viewingAgentTaskId = null
       appState.viewSelectionMode = null
+      appState.workbench = undefined
       harness.updateSettingsForSource.mockClear()
       harness.activeAgent = { type: 'leader' }
       harness.autoModeOptInProps = undefined
@@ -771,6 +773,7 @@ import { createRoot } from '../../ink/root.js'
 import { getImageFromClipboard } from '../../../utils/imagePaste.js'
 import { cacheImagePath, storeImage } from '../../../utils/imageStore.js'
 import { logError } from '../../../utils/log.js'
+import { getDefaultWorkbenchState } from '../../../../src/tui/workbench/reducer.js'
 import PromptInput from './PromptInput.js'
 
 function sleep(ms: number): Promise<void> {
@@ -1093,6 +1096,43 @@ describe('PromptInput render surface', () => {
         expect.objectContaining({
           key: 'no-image-in-clipboard',
         }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('submits only composer-selected workbench attachments', async () => {
+    harness.appState.workbench = {
+      ...getDefaultWorkbenchState(),
+      attachments: [
+        {
+          id: 'file:src/active.ts',
+          kind: 'file',
+          label: 'src/active.ts',
+          path: 'src/active.ts',
+        },
+        {
+          id: 'file:src/stale.ts',
+          kind: 'file',
+          label: 'src/stale.ts',
+          path: 'src/stale.ts',
+        },
+      ],
+      composerAttachmentIds: ['file:src/active.ts'],
+    }
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({ input: 'review', onSubmit })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('review')
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        '@src/active.ts\n\nreview',
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ mode: 'prompt' }),
       )
     } finally {
       await rendered.dispose()

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -307,6 +307,11 @@ describe("workbench render contract", () => {
           kind: "file" as const,
           label: "src/app.ts",
           path: "src/app.ts",
+        }, {
+          id: "file:src/stale.ts",
+          kind: "file" as const,
+          label: "src/stale.ts",
+          path: "src/stale.ts",
         }],
         composerAttachmentIds: ["file:src/app.ts"],
       },
@@ -321,6 +326,7 @@ describe("workbench render contract", () => {
 
     expect(output).toContain("Preview:");
     expect(output).toContain("context src/app.ts");
+    expect(output).not.toContain("src/stale.ts");
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- Select workbench context attachments through `composerAttachmentIds` before rendering footer context or materializing prompt mentions.
- Avoid submitting or displaying stale attachment payloads that are still present in workbench state but not selected for the composer.
- Add regressions for footer display and PromptInput submission with mixed selected/stale attachment state.

## Failure reproduced
- Footer rendered `src/stale.ts` even though only `src/app.ts` was selected in `composerAttachmentIds`.
- PromptInput submitted `@src/active.ts @src/stale.ts` even though only `file:src/active.ts` was selected.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "submits only composer-selected"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/render.test.tsx -t "changes footer hints"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/workbench/render.test.tsx tests/tui/workbench/reducer.test.ts tests/tui/workbench/keybindings.test.ts
- git diff --check
- diff branding scan
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known baseline remains: src/tui/workbench/keymap.ts, 30 unused exports, 4 internal tag hints)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Coverage
- Lines: 94.53% (31748/33583)
- Statements: 93.51% (33779/36121)
- Functions: 92.49% (4648/5025)
- Branches: 86.8% (23905/27540)