### PR TITLE
fix(tui): reject project tree descendant renames

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -269,6 +269,12 @@ export class ProjectTreeStore {
     if (!target.ok) return target;
 
     try {
+      if (isDescendantPath(target.relativePath, source.relativePath)) {
+        return {
+          ok: false,
+          error: `Cannot rename ${source.relativePath} to ${target.relativePath}: target is inside the source path.`,
+        };
+      }
       if (await pathExists(target.absolutePath)) {
         return { ok: false, error: `Cannot rename to ${target.relativePath}: path already exists.` };
       }

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -439,6 +439,30 @@ describe("project tree helpers", () => {
       expect(rowPaths).not.toContain("src");
       expect(snapshot.expandedPaths).not.toContain("src");
       expect(snapshot.expandedPaths).not.toContain("src/nested");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects renaming a directory into its own descendant without mutating it", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-rename-descendant-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "src"), { recursive: true });
+      await writeFile(join(repo, "src", "app.ts"), "app\n", "utf8");
+      await store.refresh();
+
+      const result = await store.renamePath("src", "src/nested/new-src");
+
+      expect(result).toEqual({
+        ok: false,
+        error: "Cannot rename src to src/nested/new-src: target is inside the source path.",
+      });
+      expect(await readdir(join(repo, "src"))).toEqual(["app.ts"]);
+      expect(await readFile(join(repo, "src", "app.ts"), "utf8")).toBe("app\n");
+      expect(store.getSnapshot().rows.map((row) => row.path)).not.toContain("src/nested");
     } finally {
       store.dispose();
       await rm(repo, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Reject project tree rename targets that are inside the source path before creating target parent directories.
- Prevent failed descendant renames such as `src -> src/nested/new-src` from leaving new directories behind.
- Add a regression that proves the source tree remains unchanged after the rejected rename.

## Failure reproduced
- Before the fix, `renamePath("src", "src/nested/new-src")` returned a raw `EINVAL` and left `src/nested` behind.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts -t "rejects renaming a directory into its own descendant"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx
- git diff --check
- diff branding scan
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known baseline remains: src/tui/workbench/keymap.ts, 30 unused exports, 4 internal tag hints)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Coverage
- Lines: 94.53% (31750/33585)
- Statements: 93.51% (33781/36123)
- Functions: 92.49% (4648/5025)
- Branches: 86.8% (23907/27542)