### PR TITLE
test(tui): cover active work surface routing

### DIFF
--- a/runtime/tests/tui/workbench/active-work-surface.test.tsx
+++ b/runtime/tests/tui/workbench/active-work-surface.test.tsx
@@ -1,0 +1,215 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const activeSurfaceHarness = vi.hoisted(() => ({
+  keybindingCalls: [] as Array<{
+    handlers: Record<string, () => void>;
+    options?: Record<string, unknown>;
+  }>,
+  renderCalls: [] as Array<{
+    name: string;
+    props: Record<string, unknown>;
+  }>,
+}));
+
+function surfaceMock(name: string): (props: Record<string, unknown>) => React.ReactElement {
+  return (props) => {
+    activeSurfaceHarness.renderCalls.push({ name, props });
+    return React.createElement(React.Fragment);
+  };
+}
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options?: Record<string, unknown>,
+  ) => {
+    activeSurfaceHarness.keybindingCalls.push({ handlers, options });
+  },
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/AgentSurface.js", () => ({
+  AgentSurface: surfaceMock("agent"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/BufferSurface.js", () => ({
+  BufferSurface: surfaceMock("buffer"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/DiffSurface.js", () => ({
+  DiffSurface: surfaceMock("diff"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/PreviewSurface.js", () => ({
+  PreviewSurface: surfaceMock("preview"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/SearchSurface.js", () => ({
+  SearchSurface: surfaceMock("search"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/ShellSurface.js", () => ({
+  ShellSurface: surfaceMock("shell"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/TestSurface.js", () => ({
+  TestSurface: surfaceMock("test"),
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/TranscriptSurface.js", () => ({
+  TranscriptSurface: ({ children }: { readonly children: React.ReactNode }) => {
+    activeSurfaceHarness.renderCalls.push({ name: "transcript", props: {} });
+    return React.createElement(React.Fragment, null, children);
+  },
+}));
+
+import { Text } from "../../../src/tui/ink.js";
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import {
+  ActiveWorkSurface,
+  descriptorForSurface,
+  footerHintsForSurface,
+  WORKBENCH_SURFACES,
+} from "../../../src/tui/workbench/surfaces/ActiveWorkSurface.js";
+import type { ActiveSurfaceMode } from "../../../src/tui/workbench/types.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("ActiveWorkSurface", () => {
+  it.each([
+    "transcript",
+    "preview",
+    "buffer",
+    "diff",
+    "shell",
+    "test",
+    "search",
+    "agent",
+  ] as const)("routes %s mode to its surface renderer", async (mode) => {
+    activeSurfaceHarness.keybindingCalls = [];
+    activeSurfaceHarness.renderCalls = [];
+    const pendingApproval = { id: "approval-1" };
+
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: mode,
+            activeFilePath: "src/app.ts",
+          },
+        }}
+      >
+        <ActiveWorkSurface
+          focused={true}
+          transcript={<Text>transcript body</Text>}
+          pendingApproval={pendingApproval as never}
+        />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(activeSurfaceHarness.renderCalls.at(-1)?.name).toBe(mode);
+    if (mode !== "transcript") {
+      expect(activeSurfaceHarness.renderCalls.at(-1)?.props).toMatchObject({
+        focused: true,
+      });
+    }
+    if (mode === "diff") {
+      expect(activeSurfaceHarness.renderCalls.at(-1)?.props).toMatchObject({
+        pendingApproval,
+      });
+    }
+  });
+
+  it("closes non-buffer surfaces through the surface close keybinding", async () => {
+    activeSurfaceHarness.keybindingCalls = [];
+    const changes: AppState[] = [];
+
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "preview",
+            focusedPane: "surface",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <ActiveWorkSurface focused={true} transcript={<Text>transcript body</Text>} />
+      </AppStateProvider>,
+      100,
+    );
+
+    const surfaceKeybindings = activeSurfaceHarness.keybindingCalls.find(
+      (call) => call.options?.context === "Surface",
+    );
+
+    expect(surfaceKeybindings?.options).toMatchObject({
+      context: "Surface",
+      isActive: true,
+    });
+
+    surfaceKeybindings?.handlers["workbench:closeSurface"]?.();
+
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "transcript",
+      focusedPane: "surface",
+    });
+  });
+
+  it("leaves parent surface close keybindings inactive for buffer mode", async () => {
+    activeSurfaceHarness.keybindingCalls = [];
+
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "buffer",
+            focusedPane: "surface",
+          },
+        }}
+      >
+        <ActiveWorkSurface focused={true} transcript={<Text>transcript body</Text>} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(activeSurfaceHarness.keybindingCalls.find(
+      (call) => call.options?.context === "Surface",
+    )?.options).toMatchObject({
+      context: "Surface",
+      isActive: false,
+    });
+  });
+
+  it("keeps descriptor titles and fallback surface routing explicit", () => {
+    const state = getDefaultAppState().workbench;
+
+    expect(WORKBENCH_SURFACES.map((surface) => surface.title(state))).toEqual([
+      "TRANSCRIPT",
+      "PREVIEW",
+      "BUFFER",
+      "DIFF",
+      "SHELL",
+      "TEST",
+      "SEARCH",
+      "AGENT",
+    ]);
+    expect(descriptorForSurface("preview").title({
+      ...state,
+      activeFilePath: "src/app.ts",
+    })).toBe("src/app.ts");
+    expect(descriptorForSurface("buffer").title({
+      ...state,
+      activeFilePath: "src/app.ts",
+    })).toBe("src/app.ts");
+    expect(descriptorForSurface("unknown" as ActiveSurfaceMode).mode).toBe("transcript");
+    expect(footerHintsForSurface("unknown" as ActiveSurfaceMode)).toBe(WORKBENCH_SURFACES[0]?.footerHints);
+  });
+});


### PR DESCRIPTION
## Summary
- Add render-level coverage for every ActiveWorkSurface descriptor render path.
- Cover the parent close-surface keybinding, buffer close exclusion, descriptor titles, and fallback routing/hints.
- Push ActiveWorkSurface.tsx to 100% line, statement, function, and branch coverage.

## Verification
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/active-work-surface.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/active-work-surface.test.tsx tests/tui/workbench/render.test.tsx tests/tui/workbench/keybindings.test.ts
- git diff --check
- branding scan over runtime/src and runtime/tests diff
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui: 758 files, 3304 tests; 94.61% lines, 93.59% statements, 92.99% functions, 86.87% branches
- TUI validate skipped as expected because this branch changes tests only

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing unrelated Knip backlog: 30 unused exports and 4 unused @internal tag hints.