### PR TITLE
test(tui): cover snip boundary message

### DIFF
--- a/runtime/tests/tui/message-renderers/SnipBoundaryMessage.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/SnipBoundaryMessage.render.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { SnipBoundaryMessage } from "./SnipBoundaryMessage.js";
+
+describe("SnipBoundaryMessage rendering", () => {
+  test("renders the compacted-conversation boundary independently of message payload", async () => {
+    const output = await renderToString(
+      <SnipBoundaryMessage message={{ subtype: "unexpected", content: "hidden" }} />,
+      80,
+    );
+
+    expect(output).toContain("Earlier conversation snipped");
+    expect(output).not.toContain("hidden");
+  });
+});


### PR DESCRIPTION
## Summary
- Add direct render coverage for the compacted-conversation boundary renderer.
- Verify the renderer uses its fixed boundary copy and does not leak message payload content.
- Move SnipBoundaryMessage.tsx from 0% to 100% coverage across all metrics.

## Verification
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/message-renderers/SnipBoundaryMessage.render.test.tsx
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/message-renderers/SnipBoundaryMessage.render.test.tsx tests/tui/components/Message.render.test.tsx tests/tui/components/Message.coverage.test.tsx
- git diff --check
- branding scan over runtime/src and runtime/tests diff
- npm --workspace=@tetsuo-ai/runtime run typecheck
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core: skipped as expected for test-only diff
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui: 759 files, 3309 tests; 94.72% lines, 93.73% statements, 93.43% functions, 86.95% branches

## Coverage
- SnipBoundaryMessage.tsx: 100% lines, statements, functions, and branches

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing unrelated Knip backlog: 30 unused exports and 4 unused @internal tag hints.