### PR TITLE
fix(tui): preserve approval command fallback text

### DIFF
--- a/runtime/src/tui/approval-input-text.ts
+++ b/runtime/src/tui/approval-input-text.ts
@@ -88,7 +88,8 @@ function textValue(value: unknown): string | null {
 
 function fallbackText(value: unknown, options: ApprovalInputTextOptions): string {
   try {
-    return JSON.stringify(value, null, options.prettyJson ? 2 : undefined) ?? "";
+    const json = JSON.stringify(value, null, options.prettyJson ? 2 : undefined);
+    return json ?? String(value);
   } catch {
     return String(value);
   }

--- a/runtime/tests/tui/workbench/approval-input-text.test.ts
+++ b/runtime/tests/tui/workbench/approval-input-text.test.ts
@@ -3,6 +3,27 @@ import { describe, expect, it } from "vitest";
 import { approvalInputText } from "../../../src/tui/workbench/approvals/inputText.js";
 
 describe("approvalInputText", () => {
+  it("renders empty, primitive, and direct text values", () => {
+    expect(approvalInputText(null)).toBe("");
+    expect(approvalInputText(undefined)).toBe("");
+    expect(approvalInputText("raw input")).toBe("raw input");
+    expect(approvalInputText(42)).toBe("42");
+    expect(approvalInputText(false)).toBe("false");
+    expect(approvalInputText(12n)).toBe("12");
+  });
+
+  it("uses the first non-empty text key when no command is present", () => {
+    expect(
+      approvalInputText({
+        input: "",
+        query: "rg target",
+        path: "src/ignored.ts",
+      }),
+    ).toBe("rg target");
+    expect(approvalInputText({ path: "src/app.ts" })).toBe("src/app.ts");
+    expect(approvalInputText({ file_path: "src/file.ts" })).toBe("src/file.ts");
+  });
+
   it("renders split shell command and args as one command line", () => {
     expect(
       approvalInputText({
@@ -28,5 +49,52 @@ describe("approvalInputText", () => {
         args: [{ script: "rm -rf /tmp/agenc-danger" }],
       }),
     ).toContain("rm -rf /tmp/agenc-danger");
+  });
+
+  it("renders command aliases and non-string command array parts", () => {
+    expect(
+      approvalInputText({
+        cmd: "echo",
+        args: [1, true, 3n],
+      }),
+    ).toBe("echo 1 true 3");
+    expect(
+      approvalInputText({
+        command: ["tool", Symbol("unsafe")],
+      }),
+    ).toBe("tool Symbol(unsafe)");
+  });
+
+  it("does not hide command arguments that JSON cannot represent", () => {
+    expect(
+      approvalInputText({
+        command: "tool",
+        args: [Symbol("unsafe")],
+      }),
+    ).toBe("tool Symbol(unsafe)");
+  });
+
+  it("renders scalar arrays and falls back for empty or structured arrays", () => {
+    expect(approvalInputText(["echo", 1, false, 2n])).toBe("echo 1 false 2");
+    expect(approvalInputText([])).toBe("[]");
+    expect(approvalInputText([{ path: "src/app.ts" }])).toBe('[{"path":"src/app.ts"}]');
+  });
+
+  it("renders fallback objects with optional pretty JSON", () => {
+    expect(approvalInputText({ nested: { value: 1 } })).toBe('{"nested":{"value":1}}');
+    expect(approvalInputText({ nested: { value: 1 } }, { prettyJson: true })).toBe([
+      "{",
+      '  "nested": {',
+      '    "value": 1',
+      "  }",
+      "}",
+    ].join("\n"));
+  });
+
+  it("falls back to String when JSON serialization throws", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(approvalInputText(circular)).toBe("[object Object]");
   });
 });


### PR DESCRIPTION
## Summary
- Preserve approval command argument text when JSON serialization returns no representation for a value.
- Expand direct approval input text coverage for primitives, text-key fallback, command aliases, arrays, pretty JSON, circular values, and non-JSON command arguments.
- Move `approval-input-text.ts` to 100% lines/statements/functions/branches.

## Validation
- `npm --prefix runtime test -- tests/tui/workbench/approval-input-text.test.ts`
- `npm --prefix runtime run test:coverage:tui`
- `npm --prefix runtime run typecheck`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --prefix runtime run check:unused -- --include files`
- `git diff --check`

## Coverage
- TUI total: lines 94.85%, statements 93.88%, functions 93.97%, branches 87.11%.
- `approval-input-text.ts`: 100% lines/statements/functions/branches.