### PR TITLE
fix(tui): harden agents rail display

### DIFF
--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -26,9 +26,8 @@ export function AgentsRail({
   const { selectedId, selectedIndex, selectedTask } = resolveAgentSelection(taskList, workbench.selectedAgentTaskId);
   const selectByDelta = (delta: number) => {
     if (taskList.length === 0) return;
-    const base = selectedIndex < 0 ? 0 : selectedIndex;
-    const next = Math.max(0, Math.min(taskList.length - 1, base + delta));
-    dispatch({ type: "selectAgent", taskId: taskList[next]?.id ?? null });
+    const next = Math.max(0, Math.min(taskList.length - 1, selectedIndex + delta));
+    dispatch({ type: "selectAgent", taskId: taskList[next].id });
   };
 
   useRegisterKeybindingContext("Agents", focused);
@@ -87,10 +86,10 @@ export function resolveAgentSelection(tasks: readonly any[], selectedId: string 
   }
   const selectedIndex = orderedTasks.findIndex((task: any) => task.id === selectedId);
   const resolvedIndex = selectedIndex >= 0 ? selectedIndex : 0;
-  const selectedTask = orderedTasks[resolvedIndex] ?? null;
+  const selectedTask = orderedTasks[resolvedIndex];
   return {
-    selectedId: selectedTask?.id ?? null,
-    selectedIndex: selectedTask ? resolvedIndex : -1,
+    selectedId: selectedTask.id,
+    selectedIndex: resolvedIndex,
     selectedTask,
   };
 }
@@ -138,13 +137,18 @@ function AgentRailRow({
   readonly selected: boolean;
 }): React.ReactElement {
   const progress = task.progress ?? {};
-  const activity = progress.lastActivity?.activityDescription ?? progress.lastActivity?.toolName ?? task.status;
+  const activity =
+    nonBlankString(progress.lastActivity?.activityDescription) ??
+    nonBlankString(progress.lastActivity?.toolName) ??
+    nonBlankString(task.status) ??
+    "unknown";
+  const description = nonBlankString(task.description) ?? nonBlankString(task.id) ?? "agent";
   const stopAction = workbenchStopActionForTask(task);
   const diffCount = progress.diffCount ?? task.diffCount;
   const approvalPending = task.approvalPending === true || task.pendingApproval === true;
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <Text color={selected ? "suggestion" : undefined} wrap="truncate-end">{statusMarker(task.status)} {task.description ?? task.id}</Text>
+      <Text color={selected ? "suggestion" : undefined} wrap="truncate-end">{statusMarker(task.status)} {description}</Text>
       <Text dimColor wrap="truncate-end">{activity}</Text>
       <Text dimColor wrap="truncate-end">
         {formatTaskElapsed(task)} · tools {progress.toolUseCount ?? 0} tokens {progress.tokenCount ?? 0}
@@ -154,6 +158,10 @@ function AgentRailRow({
       </Text>
     </Box>
   );
+}
+
+function nonBlankString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
 function statusMarker(status: string): string {

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const keybindingHarness = vi.hoisted(() => ({
   handlers: {} as Record<string, () => void>,
@@ -17,6 +17,167 @@ import { AgentsRail } from "../../../src/tui/workbench/agents/AgentsRail.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
 describe("AgentsRail", () => {
+  beforeEach(() => {
+    keybindingHarness.handlers = {};
+  });
+
+  it("renders remote task counts and empty local task states", async () => {
+    const remoteOnly = await renderAgentsRail({
+      remoteBackgroundTaskCount: 3,
+    });
+    const emptyFocusedOut = await renderAgentsRail({
+      focused: false,
+      width: 32,
+    });
+
+    expect(remoteOnly.output).toContain("remote tasks: 3");
+    expect(remoteOnly.output).not.toContain("No background agents");
+    expect(emptyFocusedOut.output).toContain("No background agents");
+  });
+
+  it("routes focus, selection, open, and stop keybindings through workbench state", async () => {
+    const runningNewest = agentTask("agent-new", "running", {
+      description: "new running agent",
+      startTime: 2_000,
+    });
+    const runningOldest = agentTask("agent-old", "running", {
+      description: "old running agent",
+      startTime: 1_000,
+    });
+    const completed = agentTask("agent-done", "completed", {
+      description: "done agent",
+      startTime: 3_000,
+    });
+    const { changes } = await renderAgentsRail({
+      tasks: [runningOldest, runningNewest, completed],
+      selectedAgentTaskId: "agent-new",
+    });
+
+    keybindingHarness.handlers["workbench:focusSurface"]?.();
+    expect(changes.at(-1)?.workbench.focusedPane).toBe("surface");
+
+    keybindingHarness.handlers["agents:down"]?.();
+    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-old");
+
+    keybindingHarness.handlers["agents:up"]?.();
+    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-new");
+
+    keybindingHarness.handlers["agents:open"]?.();
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "agent",
+      focusedPane: "surface",
+      selectedAgentTaskId: "agent-new",
+    });
+
+    keybindingHarness.handlers["agents:stop"]?.();
+    expect(changes.at(-1)?.tasks["agent-new"]).toMatchObject({
+      status: "killed",
+    });
+  });
+
+  it("ignores navigation, open, and stop keybindings when there is no selected task", async () => {
+    const { changes } = await renderAgentsRail();
+
+    keybindingHarness.handlers["agents:up"]?.();
+    keybindingHarness.handlers["agents:down"]?.();
+    keybindingHarness.handlers["agents:open"]?.();
+    keybindingHarness.handlers["agents:stop"]?.();
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("treats missing task dictionaries as empty", async () => {
+    const { output } = await renderAgentsRail({
+      rawTasks: undefined,
+    });
+
+    expect(output).toContain("No background agents");
+  });
+
+  it("renders active/background rows, row badges, and resilient empty text fallbacks", async () => {
+    const output = (await renderAgentsRail({
+      tasks: [
+        agentTask("agent-blank", "", {
+          description: " ",
+          progress: {
+            lastActivity: {
+              activityDescription: "",
+              toolName: "",
+            },
+          },
+          startTime: 5_000,
+        }),
+        agentTask("", "failed", {
+          description: " ",
+          startTime: 4_500,
+        }),
+        agentTask("agent-pending", "pending", {
+          description: "pending agent",
+          progress: {
+            toolUseCount: 2,
+            tokenCount: 120,
+            diffCount: 3,
+            lastActivity: { toolName: "edit" },
+          },
+          pendingApproval: true,
+          startTime: 4_000,
+        }),
+        agentTask("agent-failed", "failed", {
+          description: "failed agent",
+          diffCount: 1,
+          startTime: 3_000,
+        }),
+        agentTask("agent-complete", "completed", {
+          description: "completed agent",
+          startTime: 2_000,
+        }),
+        agentTask("agent-killed", "killed", {
+          description: "killed agent",
+          startTime: 1_000,
+        }),
+        {
+          ...agentTask("shell-hidden", "running", {
+            description: "hidden shell",
+          }),
+          type: "local_bash",
+        },
+      ],
+      selectedAgentTaskId: "agent-pending",
+      width: 90,
+    })).output;
+
+    expect(output).toContain("active");
+    expect(output).toContain("- agent-blank");
+    expect(output).toContain("unknown");
+    expect(output).toContain("! agent");
+    expect(output).toContain("- pending agent");
+    expect(output).toContain("edit");
+    expect(output).toContain("tools 2 tokens 120");
+    expect(output).toContain("diffs 3");
+    expect(output).toContain("approval");
+    expect(output).toContain("x stop");
+    expect(output).toContain("background");
+    expect(output).toContain("! failed agent");
+    expect(output).toContain("diffs 1");
+    expect(output).toContain("ok completed agent");
+    expect(output).toContain("x killed agent");
+    expect(output).not.toContain("hidden shell");
+  });
+
+  it("does not advertise stop shortcuts for remote agents that cannot be stopped locally", async () => {
+    const output = (await renderAgentsRail({
+      tasks: [{
+        ...agentTask("remote-running", "running", {
+          description: "remote running",
+        }),
+        type: "remote_agent",
+      }],
+    })).output;
+
+    expect(output).toContain("* remote running");
+    expect(output).not.toContain("x stop");
+  });
+
   it("opens the first live agent when the selected agent id is stale", async () => {
     const changes: AppState[] = [];
     const liveAgent = {
@@ -108,3 +269,54 @@ describe("AgentsRail", () => {
     });
   });
 });
+
+function agentTask(id: string, status: string, overrides: Record<string, unknown> = {}): any {
+  return {
+    id,
+    type: "local_agent",
+    status,
+    description: id,
+    startTime: 1_000,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    retain: true,
+    ...overrides,
+  };
+}
+
+async function renderAgentsRail(options: {
+  readonly tasks?: readonly any[];
+  readonly rawTasks?: Record<string, any> | undefined;
+  readonly selectedAgentTaskId?: string | null;
+  readonly remoteBackgroundTaskCount?: number;
+  readonly focused?: boolean;
+  readonly width?: number;
+} = {}): Promise<{
+  readonly output: string;
+  readonly changes: AppState[];
+}> {
+  const changes: AppState[] = [];
+  const tasks = Object.prototype.hasOwnProperty.call(options, "rawTasks")
+    ? options.rawTasks
+    : Object.fromEntries((options.tasks ?? []).map((task) => [task.id, task]));
+  const output = await renderToString(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        tasks: tasks as any,
+        remoteBackgroundTaskCount: options.remoteBackgroundTaskCount ?? 0,
+        workbench: {
+          ...getDefaultAppState().workbench,
+          selectedAgentTaskId: options.selectedAgentTaskId ?? null,
+        },
+      }}
+      onChangeAppState={({ newState }) => changes.push(newState)}
+    >
+      <AgentsRail focused={options.focused ?? true} width={options.width ?? 40} />
+    </AppStateProvider>,
+    100,
+  );
+
+  return { output, changes };
+}

--- a/runtime/tests/tui/workbench/agents.test.ts
+++ b/runtime/tests/tui/workbench/agents.test.ts
@@ -6,7 +6,7 @@ import {
   taskMayReferencePath,
   taskPathLabel,
 } from "../../../src/tui/workbench/agents/activity.js";
-import { partitionAgentTasks, resolveAgentSelection } from "../../../src/tui/workbench/agents/AgentsRail.js";
+import { orderAgentTasks, partitionAgentTasks, resolveAgentSelection } from "../../../src/tui/workbench/agents/AgentsRail.js";
 
 describe("workbench agents rail model", () => {
   it("groups active and background agent tasks", () => {
@@ -55,6 +55,27 @@ describe("workbench agents rail model", () => {
       selectedIndex: 0,
       selectedTask: tasks[1],
     });
+  });
+
+  it("orders active agents before background agents and sorts equal groups by newest start time", () => {
+    const tasks = [
+      { id: "completed-new", type: "local_agent", status: "completed", startTime: 3_000 },
+      { id: "running-old", type: "local_agent", status: "running", startTime: 1_000 },
+      { id: "pending-new", type: "remote_agent", status: "pending", startTime: 2_000 },
+      { id: "failed-missing-start", type: "local_agent", status: "failed" },
+    ];
+
+    expect(orderAgentTasks(tasks).map((task) => task.id)).toEqual([
+      "pending-new",
+      "running-old",
+      "completed-new",
+      "failed-missing-start",
+    ]);
+
+    expect(orderAgentTasks([
+      { id: "failed-a", type: "local_agent", status: "failed" },
+      { id: "failed-b", type: "local_agent", status: "failed" },
+    ]).map((task) => task.id)).toEqual(["failed-a", "failed-b"]);
   });
 
   it("formats elapsed runtime and extracts task paths", () => {


### PR DESCRIPTION
## Summary
- Treat blank agent descriptions and activity text as missing so the rail falls back to useful status/id labels.
- Simplify agents rail selection once the resolver has a nonempty ordered task list.
- Add coverage for rail keybindings, empty/missing task state, remote task counts, local stop affordances, row badges, ordering, and blank-text fallbacks.

## Coverage
- Full TUI coverage: statements 94.39%, branches 87.78%, functions 95.04%, lines 95.27%.
- AgentsRail: 100% statements, branches, functions, and lines.

## Test plan
- npx vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx --reporter=dot
- npx vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=text-summary --coverage.include='src/tui/workbench/agents/AgentsRail.tsx' --coverage.reportsDirectory=coverage/agents-rail-audit
- npm run test:coverage:tui
- npm run typecheck
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check