### PR TITLE
fix(tui): clamp test surface navigation

### DIFF
--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -75,10 +75,10 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   };
   useKeybindings(
     {
-      "surface:up": () => setSelected((value) => Math.max(0, value - 1)),
-      "surface:down": () => setSelected((value) => Math.min(Math.max(0, failures.length - 1), value + 1)),
-      "surface:pageUp": () => setSelected((value) => Math.max(0, value - 10)),
-      "surface:pageDown": () => setSelected((value) => Math.min(Math.max(0, failures.length - 1), value + 10)),
+      "surface:up": () => setSelected((value) => Math.max(0, clampSurfaceSelection(value, failures.length) - 1)),
+      "surface:down": () => setSelected((value) => Math.min(Math.max(0, failures.length - 1), clampSurfaceSelection(value, failures.length) + 1)),
+      "surface:pageUp": () => setSelected((value) => Math.max(0, clampSurfaceSelection(value, failures.length) - 10)),
+      "surface:pageDown": () => setSelected((value) => Math.min(Math.max(0, failures.length - 1), clampSurfaceSelection(value, failures.length) + 10)),
       "surface:top": () => setSelected(0),
       "surface:bottom": () => setSelected(Math.max(0, failures.length - 1)),
       "surface:open": () => jumpToSelectedFailure(true),

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -98,6 +98,23 @@ describe("TestSurface", () => {
     expect(output).toContain("second message");
   });
 
+  it("renders missing task and empty parsed output states", async () => {
+    const missingTaskOutput = await renderTestSurface({
+      selectedShellTaskId: null,
+      tasks: {},
+    });
+    keybindingHarness.tails["shell-empty"] = "all tests passed\nno failure details";
+    const emptyOutput = await renderTestSurface({
+      selectedShellTaskId: "shell-empty",
+      tasks: {
+        "shell-empty": shellTask("shell-empty", "empty test", "completed"),
+      },
+    });
+
+    expect(missingTaskOutput).toContain("No test task selected");
+    expect(emptyOutput).toContain("No parsed test failures");
+  });
+
   it("keeps top navigation separate from opening the selected failure", async () => {
     const changes: AppState[] = [];
     const output = await renderToString(
@@ -144,6 +161,213 @@ describe("TestSurface", () => {
       activeFileLine: 4,
       focusedPane: "surface",
     });
+  });
+
+  it("routes surface open, attach, and close keybindings", async () => {
+    const changes: AppState[] = [];
+    await renderTestSurface({
+      selectedShellTaskId: "shell-1",
+      tasks: {
+        "shell-1": shellTask("shell-1", "current test", "completed"),
+      },
+      onChange: changes,
+      workbench: {
+        focusedPane: "composer",
+      },
+    });
+
+    keybindingHarness.handlers["surface:openKeepFocus"]?.();
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/first.ts",
+      activeFileLine: 4,
+      focusedPane: "composer",
+    });
+
+    keybindingHarness.handlers["surface:attach"]?.();
+    expect(changes.at(-1)?.workbench.attachments.at(-1)).toMatchObject({
+      id: "task-error:shell-1:src/first.ts:4",
+      kind: "task-error",
+      path: "src/first.ts",
+      line: 4,
+      taskId: "shell-1",
+      label: "first failure",
+    });
+
+    keybindingHarness.handlers["workbench:closeSurface"]?.();
+    expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
+  });
+
+  it("ignores attach and open commands when the selected failure has no location", async () => {
+    keybindingHarness.tails["shell-no-location"] = [
+      "FAIL failure without location",
+      "expected true to be false",
+    ].join("\n");
+    const changes: AppState[] = [];
+    const output = await renderTestSurface({
+      selectedShellTaskId: "shell-no-location",
+      tasks: {
+        "shell-no-location": shellTask("shell-no-location", "test without location", "completed"),
+      },
+      onChange: changes,
+    });
+
+    expect(output).toContain("failure without location");
+
+    keybindingHarness.handlers["surface:open"]?.();
+    keybindingHarness.handlers["surface:openKeepFocus"]?.();
+    keybindingHarness.handlers["surface:attach"]?.();
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("navigates from the clamped visible failure after output shrinks", async () => {
+    keybindingHarness.tails["shell-1"] = numberedFailureTail(12);
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-1": shellTask("shell-1", "current test", "running"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "test",
+              selectedShellTaskId: "shell-1",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <TestSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      keybindingHarness.handlers["surface:pageDown"]?.();
+      await sleep();
+      keybindingHarness.tails["shell-1"] = numberedFailureTail(2);
+      await sleep(1_200);
+
+      expect(compact(screenText(stdout))).toContain("failure2");
+
+      keybindingHarness.handlers["surface:up"]?.();
+      await sleep();
+      keybindingHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/failure-1.ts",
+        activeFileLine: 1,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("routes bottom, page-up, and down navigation from the visible selection", async () => {
+    keybindingHarness.tails["shell-1"] = numberedFailureTail(12);
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-1": shellTask("shell-1", "current test", "completed"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "test",
+              selectedShellTaskId: "shell-1",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <TestSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      keybindingHarness.handlers["surface:bottom"]?.();
+      await sleep();
+      keybindingHarness.handlers["surface:pageUp"]?.();
+      await sleep();
+      keybindingHarness.handlers["surface:down"]?.();
+      await sleep();
+      keybindingHarness.handlers["surface:open"]?.();
+
+      expect(compact(screenText(stdout))).toContain("failure3");
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/failure-3.ts",
+        activeFileLine: 3,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("ignores tail reads that resolve after unmount", async () => {
+    keybindingHarness.deferredTaskIds.add("shell-1");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-1": shellTask("shell-1", "current test", "completed"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "test",
+              selectedShellTaskId: "shell-1",
+            },
+          }}
+        >
+          <TestSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      const resolveRead = keybindingHarness.pendingReads.get("shell-1");
+      expect(resolveRead).toBeTypeOf("function");
+
+      root.unmount();
+      resolveRead?.({ content: defaultTestTail() });
+      await sleep();
+
+      expect(keybindingHarness.logError).not.toHaveBeenCalled();
+    } finally {
+      stdin.end();
+      stdout.end();
+    }
   });
 
   it("clears stale failure output immediately when switching selected test tasks", async () => {
@@ -263,6 +487,33 @@ function TestTaskSelector({
   return null;
 }
 
+async function renderTestSurface(options: {
+  readonly selectedShellTaskId: string | null;
+  readonly tasks: AppState["tasks"];
+  readonly onChange?: AppState[];
+  readonly workbench?: Partial<NonNullable<AppState["workbench"]>>;
+  readonly focused?: boolean;
+}): Promise<string> {
+  return renderToString(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        tasks: options.tasks,
+        workbench: {
+          ...getDefaultAppState().workbench,
+          activeSurfaceMode: "test",
+          selectedShellTaskId: options.selectedShellTaskId,
+          ...options.workbench,
+        },
+      }}
+      onChangeAppState={({ newState }) => options.onChange?.push(newState)}
+    >
+      <TestSurface focused={options.focused ?? true} />
+    </AppStateProvider>,
+    100,
+  );
+}
+
 function defaultTestTail(): string {
   return [
     "FAIL first failure",
@@ -272,6 +523,18 @@ function defaultTestTail(): string {
     "src/second.ts:9:1",
     "second message",
   ].join("\n");
+}
+
+function numberedFailureTail(count: number): string {
+  const lines: string[] = [];
+  for (let index = 1; index <= count; index += 1) {
+    lines.push(
+      `FAIL failure ${index}`,
+      `src/failure-${index}.ts:${index}:1`,
+      `message ${index}`,
+    );
+  }
+  return lines.join("\n");
 }
 
 function shellTask(


### PR DESCRIPTION
## Summary
- Clamp TestSurface navigation from the live visible selection so up/page-up/down/page-down recover correctly after parsed failures shrink.
- Add mounted regressions for output shrinkage, missing/empty states, open/attach/close commands, no-location no-ops, and late tail reads after unmount.

## Coverage
- Full TUI coverage: statements 94.60%, branches 87.99%, functions 95.36%, lines 95.47%.
- TestSurface: 100% statements, branches, functions, and lines.

## Test plan
- npx vitest run tests/tui/workbench/test-surface.test.tsx --reporter=dot
- npx vitest run tests/tui/workbench/test-surface.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=text-summary --coverage.include='src/tui/workbench/surfaces/TestSurface.tsx' --coverage.reportsDirectory=coverage/test-surface-audit
- npm run test:coverage:tui
- npm run typecheck
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check
