### PR TITLE
fix(tui): preserve agent activity paths

### DIFF
--- a/runtime/src/tasks/app-state-bridge.ts
+++ b/runtime/src/tasks/app-state-bridge.ts
@@ -14,7 +14,9 @@ function stringMetadata(
   key: string,
 ): string | undefined {
   const value = metadata?.[key];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function localAgentTaskFromSnapshot(
@@ -28,6 +30,11 @@ function localAgentTaskFromSnapshot(
   const threadName = stringMetadata(snapshot.metadata, "threadName");
   const agentRole = stringMetadata(snapshot.metadata, "agentRole");
   const model = stringMetadata(snapshot.metadata, "model");
+  const cwd = stringMetadata(snapshot.metadata, "cwd") ?? previousAgent?.cwd;
+  const worktreePath =
+    stringMetadata(snapshot.metadata, "worktreePath") ??
+    previousAgent?.worktreePath;
+  const path = stringMetadata(snapshot.metadata, "path") ?? previousAgent?.path;
   return {
     id: snapshot.id,
     type: "local_agent",
@@ -42,6 +49,9 @@ function localAgentTaskFromSnapshot(
     agentId: snapshot.id,
     prompt: snapshot.description,
     agentType: agentRole ?? previousAgent?.agentType ?? "agent",
+    ...(cwd !== undefined ? { cwd } : {}),
+    ...(worktreePath !== undefined ? { worktreePath } : {}),
+    ...(path !== undefined ? { path } : {}),
     ...(model !== undefined ? { model } : {}),
     ...(snapshot.error !== undefined ? { error: snapshot.error } : {}),
     ...(progress !== undefined ? { progress } : {}),

--- a/runtime/src/tasks/types.ts
+++ b/runtime/src/tasks/types.ts
@@ -78,6 +78,9 @@ export interface AgentProgress {
 export interface LocalAgentTaskState extends TaskStateBase<"local_agent"> {
   readonly agentId: string;
   readonly prompt: string;
+  readonly cwd?: string;
+  readonly worktreePath?: string;
+  readonly path?: string;
   readonly selectedAgent?: unknown;
   readonly agentType: string;
   readonly model?: string;

--- a/runtime/src/tui/workbench/agents/activity.ts
+++ b/runtime/src/tui/workbench/agents/activity.ts
@@ -39,15 +39,15 @@ export function inFlightPathsFromTasks(
 
 export function taskPathLabel(task: TaskState): string | null {
   const record = task as unknown as Record<string, unknown>;
-  for (const key of ["cwd", "worktreePath", "path", "outputFile"]) {
+  for (const key of ["cwd", "worktreePath", "path"]) {
     const value = record[key];
-    if (typeof value === "string" && value.trim().length > 0) return value;
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
   }
   const metadata = record.remoteTaskMetadata;
   if (metadata && typeof metadata === "object") {
     for (const key of ["cwd", "worktreePath", "path"]) {
       const value = (metadata as Record<string, unknown>)[key];
-      if (typeof value === "string" && value.trim().length > 0) return value;
+      if (typeof value === "string" && value.trim().length > 0) return value.trim();
     }
   }
   return null;
@@ -58,6 +58,7 @@ function taskSearchStrings(task: TaskState): string[] {
   const values: unknown[] = [
     task.id,
     task.description,
+    taskPathLabel(task) ?? "",
     "command" in task && typeof task.command === "string" ? task.command : "",
     "prompt" in task && typeof task.prompt === "string" ? task.prompt : "",
     "title" in task && typeof task.title === "string" ? task.title : "",
@@ -86,7 +87,7 @@ function stringifyInput(input: unknown): string {
 }
 
 function normalizePath(value: string): string {
-  return value.replace(/\\/gu, "/").replace(/^\.\//u, "");
+  return value.trim().replace(/\\\\/gu, "/").replace(/\\/gu, "/").replace(/^\.\//u, "");
 }
 
 function containsPathReference(value: string, pathValue: string): boolean {

--- a/runtime/tests/tasks/app-state-bridge.test.ts
+++ b/runtime/tests/tasks/app-state-bridge.test.ts
@@ -19,6 +19,8 @@ function snapshot(
       threadName: "reviewer",
       agentRole: "worker",
       model: "qwen3.6-35b-a3b-fp8",
+      cwd: "  /repo/current  ",
+      worktreePath: "  /repo/worktree  ",
     },
     progress: {
       toolUseCount: 2,
@@ -51,6 +53,8 @@ describe("syncBackgroundTaskSnapshotToAppState", () => {
           prompt: "inspect the repo",
           agentType: "worker",
           model: "qwen3.6-35b-a3b-fp8",
+          cwd: "/repo/current",
+          worktreePath: "/repo/worktree",
           isBackgrounded: true,
           progress: {
             toolUseCount: 2,
@@ -105,6 +109,52 @@ describe("syncBackgroundTaskSnapshotToAppState", () => {
           retain: true,
           diskLoaded: true,
           messages: [{ type: "assistant" }],
+        },
+      },
+    });
+  });
+
+  it("preserves previous display paths when later lifecycle snapshots omit metadata", () => {
+    let appState: unknown = {
+      tasks: {
+        "agent-1": {
+          id: "agent-1",
+          type: "local_agent",
+          status: "running",
+          description: "old",
+          startTime: 1,
+          outputFile: "old",
+          outputOffset: 0,
+          notified: false,
+          agentId: "agent-1",
+          prompt: "old prompt",
+          agentType: "worker",
+          cwd: "/repo/current",
+          worktreePath: "/repo/worktree",
+          retrieved: false,
+          lastReportedToolCount: 0,
+          lastReportedTokenCount: 0,
+          isBackgrounded: true,
+          pendingMessages: [],
+          retain: false,
+          diskLoaded: false,
+        },
+      },
+    };
+    syncBackgroundTaskSnapshotToAppState(
+      {
+        setAppState(updater) {
+          appState = updater(appState);
+        },
+      },
+      snapshot({ metadata: undefined }),
+    );
+
+    expect(appState).toMatchObject({
+      tasks: {
+        "agent-1": {
+          cwd: "/repo/current",
+          worktreePath: "/repo/worktree",
         },
       },
     });

--- a/runtime/tests/tui/workbench/agents.test.ts
+++ b/runtime/tests/tui/workbench/agents.test.ts
@@ -93,7 +93,28 @@ describe("workbench agents rail model", () => {
     } as any;
 
     expect(formatTaskElapsed(task, 66_500)).toBe("1m05s");
+    expect(formatTaskElapsed({ ...task, endTime: 3_661_000 }, 99_999_999)).toBe("1h00m");
+    expect(formatTaskElapsed({ ...task, totalPausedMs: undefined }, 61_000)).toBe("1m00s");
     expect(taskPathLabel(task)).toBe("/repo/worktree");
+    expect(taskPathLabel({ ...task, cwd: "  /repo/trimmed  " })).toBe("/repo/trimmed");
+    expect(taskPathLabel({
+      ...task,
+      cwd: undefined,
+      outputFile: "urn:agenc:task:agent-1:output",
+    })).toBe(null);
+    expect(taskPathLabel({
+      ...task,
+      cwd: undefined,
+      remoteTaskMetadata: {
+        cwd: "",
+        worktreePath: "  /repo/remote-worktree  ",
+      },
+    })).toBe("/repo/remote-worktree");
+    expect(taskPathLabel({
+      ...task,
+      cwd: undefined,
+      remoteTaskMetadata: null,
+    })).toBe(null);
   });
 
   it("identifies in-flight paths from active agent activity", () => {
@@ -115,6 +136,78 @@ describe("workbench agents rail model", () => {
 
     expect(taskMayReferencePath(task, "src/app.ts")).toBe(true);
     expect(inFlightPathsFromTasks([task], ["src/app.ts", "src/other.ts"])).toEqual(["src/app.ts"]);
+  });
+
+  it("rejects empty path candidates before searching task activity", () => {
+    const task = {
+      id: "agent-1",
+      type: "local_agent",
+      status: "running",
+      description: "editing src/app.ts",
+      startTime: 0,
+      outputFile: "urn:agenc:task:agent-1:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+
+    expect(taskMayReferencePath(task, null)).toBe(false);
+    expect(taskMayReferencePath(task, undefined)).toBe(false);
+    expect(taskMayReferencePath(task, "./")).toBe(false);
+    expect(taskMayReferencePath(task, "  src/app.ts  ")).toBe(true);
+    expect(inFlightPathsFromTasks([{ ...task, type: "local_bash" }], ["src/app.ts"])).toEqual([]);
+  });
+
+  it("searches command, prompt, title, path metadata, and tool inputs for path references", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const remoteTask = {
+      id: "agent-remote",
+      type: "remote_agent",
+      status: "running",
+      description: "remote work",
+      startTime: 0,
+      outputFile: "urn:agenc:task:agent-remote:output",
+      outputOffset: 0,
+      notified: false,
+      command: "review src/command.ts",
+      title: "inspect src/title.ts",
+      remoteTaskMetadata: {
+        path: "src/metadata.ts",
+      },
+      progress: {
+        lastActivity: {
+          toolName: "Read",
+          activityDescription: "read src/activity.ts",
+          input: { file_path: "C:\\repo\\src\\windows.ts" },
+        },
+        recentActivities: [
+          { toolName: "Edit", input: "src/string-input.ts" },
+          { toolName: "Noop", input: null },
+          { toolName: "Circular", input: circular },
+        ],
+      },
+    } as any;
+    const localTask = {
+      id: "agent-local",
+      type: "local_agent",
+      status: "running",
+      description: "local work",
+      startTime: 0,
+      outputFile: "urn:agenc:task:agent-local:output",
+      outputOffset: 0,
+      notified: false,
+      prompt: "change src/prompt.ts",
+      worktreePath: "src/worktree.ts",
+    } as any;
+
+    expect(taskMayReferencePath(remoteTask, "src/command.ts")).toBe(true);
+    expect(taskMayReferencePath(remoteTask, "src/title.ts")).toBe(true);
+    expect(taskMayReferencePath(remoteTask, "src/metadata.ts")).toBe(true);
+    expect(taskMayReferencePath(remoteTask, "src/activity.ts")).toBe(true);
+    expect(taskMayReferencePath(remoteTask, "src/windows.ts")).toBe(true);
+    expect(taskMayReferencePath(remoteTask, "src/string-input.ts")).toBe(true);
+    expect(taskMayReferencePath(localTask, "src/prompt.ts")).toBe(true);
+    expect(taskMayReferencePath(localTask, "src/worktree.ts")).toBe(true);
   });
 
   it("ignores missing or non-string task search fields", () => {


### PR DESCRIPTION
## Summary
- stop the workbench agent surface from rendering task output URIs as path labels
- preserve trimmed lifecycle path metadata on local agent AppState tasks
- cover agent activity path matching edge cases, including metadata paths and escaped Windows-style tool-input paths

## Test plan
- npm test -- tests/tui/workbench/agents.test.ts tests/tasks/app-state-bridge.test.ts
- npx vitest run tests/tui/workbench/agents.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/workbench/agents/activity.ts' --coverage.reportsDirectory=coverage/activity-audit
- npm run test:coverage:tui
- npm run typecheck
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core