### PR TITLE
fix(tui): normalize empty local command output

### DIFF
--- a/runtime/src/tui/message-renderers/UserLocalCommandOutputMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserLocalCommandOutputMessage.tsx
@@ -1,167 +1,115 @@
-import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import { DIAMOND_FILLED, DIAMOND_OPEN } from '../../constants/figures.js';
 import { NO_CONTENT_MESSAGE } from '../../constants/messages.js';
+import { LOCAL_COMMAND_STDERR_TAG, LOCAL_COMMAND_STDOUT_TAG } from '../../constants/xml.js';
 import { Box, Text } from '../ink.js';
 import { extractTag } from '../../utils/messages.js';
 import { Markdown } from '../components/markdown/Markdown.js';
 import FullWidthRow from '../components/design-system/FullWidthRow';
 import { MessageResponse } from '../components/MessageResponse';
+
 type Props = {
   content: string;
 };
-export function UserLocalCommandOutputMessage(t0) {
-  const $ = _c(4);
-  const {
-    content
-  } = t0;
-  let lines;
-  let t1;
-  if ($[0] !== content) {
-    t1 = Symbol.for("react.early_return_sentinel");
-    bb0: {
-      const stdout = extractTag(content, "local-command-stdout");
-      const stderr = extractTag(content, "local-command-stderr");
-      if (!stdout && !stderr) {
-        let t2;
-        if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
-          t2 = <MessageResponse><Text dimColor={true}>{NO_CONTENT_MESSAGE}</Text></MessageResponse>;
-          $[3] = t2;
-        } else {
-          t2 = $[3];
-        }
-        t1 = t2;
-        break bb0;
-      }
-      lines = [];
-      if (stdout?.trim()) {
-        lines.push(<IndentedContent key="stdout">{stdout.trim()}</IndentedContent>);
-      }
-      if (stderr?.trim()) {
-        lines.push(<IndentedContent key="stderr">{stderr.trim()}</IndentedContent>);
-      }
-    }
-    $[0] = content;
-    $[1] = lines;
-    $[2] = t1;
-  } else {
-    lines = $[1];
-    t1 = $[2];
+
+type IndentedContentProps = {
+  children: string;
+};
+
+const tagMatcherCache = new Map<string, RegExp>();
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function closedTagMatcher(tagName: string): RegExp {
+  const cached = tagMatcherCache.get(tagName);
+  if (cached) {
+    cached.lastIndex = 0;
+    return cached;
   }
-  if (t1 !== Symbol.for("react.early_return_sentinel")) {
-    return t1;
+
+  const escapedTag = escapeRegExp(tagName);
+  const matcher = new RegExp(
+    `<${escapedTag}(?:\\s+[^>]*)?>[\\s\\S]*?<\\/${escapedTag}>`,
+    'i',
+  );
+  tagMatcherCache.set(tagName, matcher);
+  return matcher;
+}
+
+function extractLocalCommandTag(content: string, tagName: string): string | null {
+  const extracted = extractTag(content, tagName);
+  if (extracted !== null) {
+    return extracted;
+  }
+
+  return closedTagMatcher(tagName).test(content) ? '' : null;
+}
+
+export function UserLocalCommandOutputMessage({
+  content,
+}: Props): React.ReactNode {
+  const stdout = extractLocalCommandTag(content, LOCAL_COMMAND_STDOUT_TAG);
+  const stderr = extractLocalCommandTag(content, LOCAL_COMMAND_STDERR_TAG);
+
+  if (stdout === null && stderr === null) {
+    return (
+      <MessageResponse>
+        <Text dimColor={true}>{NO_CONTENT_MESSAGE}</Text>
+      </MessageResponse>
+    );
+  }
+
+  const lines: React.ReactNode[] = [];
+  if (stdout?.trim()) {
+    lines.push(<IndentedContent key="stdout">{stdout.trim()}</IndentedContent>);
+  }
+  if (stderr?.trim()) {
+    lines.push(<IndentedContent key="stderr">{stderr.trim()}</IndentedContent>);
   }
   return lines;
 }
-function IndentedContent(t0) {
-  const $ = _c(5);
-  const {
-    children
-  } = t0;
+
+function IndentedContent({ children }: IndentedContentProps): React.ReactElement {
   if (children.startsWith(`${DIAMOND_OPEN} `) || children.startsWith(`${DIAMOND_FILLED} `)) {
-    let t1;
-    if ($[0] !== children) {
-      t1 = <CloudLaunchContent>{children}</CloudLaunchContent>;
-      $[0] = children;
-      $[1] = t1;
-    } else {
-      t1 = $[1];
-    }
-    return t1;
+    return <CloudLaunchContent>{children}</CloudLaunchContent>;
   }
-  let t1;
-  if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <Text dimColor={true}>{"  \u23BF  "}</Text>;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  let t2;
-  if ($[3] !== children) {
-    t2 = <FullWidthRow>{t1}<Box flexDirection="column" flexGrow={1}><Markdown>{children}</Markdown></Box></FullWidthRow>;
-    $[3] = children;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  return t2;
+
+  return (
+    <FullWidthRow>
+      <Text dimColor={true}>{'  ⎿  '}</Text>
+      <Box flexDirection="column" flexGrow={1}>
+        <Markdown>{children}</Markdown>
+      </Box>
+    </FullWidthRow>
+  );
 }
-function CloudLaunchContent(t0) {
-  const $ = _c(19);
-  const {
-    children
-  } = t0;
+
+function CloudLaunchContent({
+  children,
+}: IndentedContentProps): React.ReactElement {
   const diamond = children[0];
-  let label;
-  let rest;
-  let t1;
-  if ($[0] !== children) {
-    const nl = children.indexOf("\n");
-    const header = nl === -1 ? children.slice(2) : children.slice(2, nl);
-    rest = nl === -1 ? "" : children.slice(nl + 1).trim();
-    const sep = header.indexOf(" \xB7 ");
-    label = sep === -1 ? header : header.slice(0, sep);
-    t1 = sep === -1 ? "" : header.slice(sep);
-    $[0] = children;
-    $[1] = label;
-    $[2] = rest;
-    $[3] = t1;
-  } else {
-    label = $[1];
-    rest = $[2];
-    t1 = $[3];
-  }
-  const suffix = t1;
-  let t2;
-  if ($[4] !== diamond) {
-    t2 = <Text color="background">{diamond} </Text>;
-    $[4] = diamond;
-    $[5] = t2;
-  } else {
-    t2 = $[5];
-  }
-  let t3;
-  if ($[6] !== label) {
-    t3 = <Text bold={true}>{label}</Text>;
-    $[6] = label;
-    $[7] = t3;
-  } else {
-    t3 = $[7];
-  }
-  let t4;
-  if ($[8] !== suffix) {
-    t4 = suffix && <Text dimColor={true}>{suffix}</Text>;
-    $[8] = suffix;
-    $[9] = t4;
-  } else {
-    t4 = $[9];
-  }
-  let t5;
-  if ($[10] !== t2 || $[11] !== t3 || $[12] !== t4) {
-    t5 = <Text>{t2}{t3}{t4}</Text>;
-    $[10] = t2;
-    $[11] = t3;
-    $[12] = t4;
-    $[13] = t5;
-  } else {
-    t5 = $[13];
-  }
-  let t6;
-  if ($[14] !== rest) {
-    t6 = rest && <FullWidthRow><Text dimColor={true}>{"  \u23BF  "}</Text><Text dimColor={true}>{rest}</Text></FullWidthRow>;
-    $[14] = rest;
-    $[15] = t6;
-  } else {
-    t6 = $[15];
-  }
-  let t7;
-  if ($[16] !== t5 || $[17] !== t6) {
-    t7 = <Box flexDirection="column">{t5}{t6}</Box>;
-    $[16] = t5;
-    $[17] = t6;
-    $[18] = t7;
-  } else {
-    t7 = $[18];
-  }
-  return t7;
+  const newlineIndex = children.indexOf('\n');
+  const header = newlineIndex === -1 ? children.slice(2) : children.slice(2, newlineIndex);
+  const rest = newlineIndex === -1 ? '' : children.slice(newlineIndex + 1).trim();
+  const separatorIndex = header.indexOf(' · ');
+  const label = separatorIndex === -1 ? header : header.slice(0, separatorIndex);
+  const suffix = separatorIndex === -1 ? '' : header.slice(separatorIndex);
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color="background">{diamond} </Text>
+        <Text bold={true}>{label}</Text>
+        {suffix && <Text dimColor={true}>{suffix}</Text>}
+      </Text>
+      {rest && (
+        <FullWidthRow>
+          <Text dimColor={true}>{'  ⎿  '}</Text>
+          <Text dimColor={true}>{rest}</Text>
+        </FullWidthRow>
+      )}
+    </Box>
+  );
 }

--- a/runtime/tests/tui/message-renderers/UserLocalCommandOutputMessage.wave200-125.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserLocalCommandOutputMessage.wave200-125.coverage.test.tsx
@@ -27,4 +27,19 @@ describe('UserLocalCommandOutputMessage wave200-125 coverage', () => {
     expect(output).not.toContain('local-command-stdout')
     expect(output).not.toContain('local-command-stderr')
   })
+
+  test('treats empty closed local command tags as empty output', async () => {
+    const output = await renderToString(
+      <UserLocalCommandOutputMessage
+        content={[
+          '<local-command-stdout data-kind="local"></local-command-stdout>',
+          '<local-command-stderr></local-command-stderr>',
+        ].join('\n')}
+      />,
+      { columns: 80, rows: 6 },
+    )
+
+    expect(output.trim()).toBe('')
+    expect(output).not.toContain(NO_CONTENT_MESSAGE)
+  })
 })


### PR DESCRIPTION
## Summary
- Removed the React Compiler cache layer from `UserLocalCommandOutputMessage.tsx` and rewrote the renderer as direct typed React logic.
- Preserved ordinary output and cloud-launch formatting behavior while covering the file at 100%.
- Fixed empty closed `<local-command-stdout>` / `<local-command-stderr>` tags so they render as empty command output instead of the no-content fallback.

## Coverage
- Focused `UserLocalCommandOutputMessage.tsx`: 100% statements, 100% branches, 100% functions, 100% lines.
- Full TUI coverage: 95.19% statements, 88.86% branches, 95.78% functions, 96.08% lines.

## Validation
- `git diff --check`
- `npx vitest run tests/tui/message-renderers/UserLocalCommandOutputMessage*.test.tsx tests/tui/coverage-swarm/swarm-051-message-renderers-UserLocalCommandOutputMessage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/message-renderers/UserLocalCommandOutputMessage.tsx' --coverage.reportsDirectory=coverage/local-command-output-audit`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`