### PR TITLE
fix(tui): preserve prompt paste and bash output state

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2767,12 +2767,18 @@ function PromptInput({
  * Compute the next paste ID after every ID already visible to the current
  * prompt, including resumed messages and restored draft paste references.
  */
-function getNextPasteIdAfter(
+export function getNextPasteIdAfter(
   messages: Message[],
   pastedContents: Record<number, PastedContent> = {},
   input = '',
 ): number {
   let maxId = 0;
+  const scanReferences = (text: string) => {
+    const refs = parseReferences(text);
+    for (const ref of refs) {
+      if (ref.id > maxId) maxId = ref.id;
+    }
+  };
   for (const message of messages) {
     if (message.type === 'user') {
       // Check image paste IDs
@@ -2782,21 +2788,18 @@ function getNextPasteIdAfter(
         }
       }
       // Check text paste references in message content
-      if (Array.isArray(message.message.content)) {
+      if (typeof message.message.content === 'string') {
+        scanReferences(message.message.content);
+      } else if (Array.isArray(message.message.content)) {
         for (const block of message.message.content) {
           if (block.type === 'text') {
-            const refs = parseReferences(block.text);
-            for (const ref of refs) {
-              if (ref.id > maxId) maxId = ref.id;
-            }
+            scanReferences(block.text);
           }
         }
       }
     }
   }
-  for (const ref of parseReferences(input)) {
-    if (ref.id > maxId) maxId = ref.id;
-  }
+  scanReferences(input);
   for (const [key, content] of Object.entries(pastedContents)) {
     const keyId = Number(key);
     if (Number.isFinite(keyId) && keyId > maxId) maxId = keyId;
@@ -2809,10 +2812,16 @@ function extractUserMessageText(m: unknown): string | null {
     ?? (m as { content?: unknown }).content;
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return null;
+  let firstText: string | null = null;
   for (const block of content) {
-    if (block?.type === 'text' && typeof block.text === 'string') return block.text;
+    if (block?.type === 'text' && typeof block.text === 'string') {
+      firstText ??= block.text;
+      if (block.text.startsWith('<bash-stdout') || block.text.startsWith('<bash-stderr')) {
+        return block.text;
+      }
+    }
   }
-  return null;
+  return firstText;
 }
 function buildBorderText(showFastIcon: boolean, showFastIconHint: boolean, fastModeCooldown: boolean): BorderTextOptions | undefined {
   if (!showFastIcon) return undefined;

--- a/runtime/tests/tui/components/PromptInput/PromptInput.helpers.test.ts
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../utils/config.js', () => ({
+  getGlobalConfig: () => ({}),
+  saveGlobalConfig: () => {},
+}))
+
+vi.mock('../../../utils/env.js', () => ({
+  env: {
+    isSSH: () => false,
+    terminal: undefined,
+  },
+}))
+
+import { getNextPasteIdAfter } from './PromptInput.js'
+
+describe('PromptInput helper behavior', () => {
+  test('allocates after paste ids in current input, saved contents, and array-form messages', () => {
+    expect(
+      getNextPasteIdAfter(
+        [
+          {
+            type: 'assistant',
+            message: { content: 'ignored [Image #99]' },
+          },
+          {
+            type: 'user',
+            imagePasteIds: [3],
+            message: {
+              content: [
+                { type: 'text', text: 'array [Pasted text #8]' },
+                { type: 'image', source: { type: 'base64', data: 'ignored' } },
+              ],
+            },
+          },
+        ],
+        {
+          9: { id: 4, type: 'image', content: 'base64' },
+          bad: { id: 10, type: 'text', content: 'stored' },
+        },
+        'draft [Image #6]',
+      ),
+    ).toBe(11)
+  })
+
+  test('allocates after paste references in string-form resumed messages', () => {
+    expect(
+      getNextPasteIdAfter([
+        {
+          type: 'user',
+          message: {
+            content: 'previous [Image #7] and [Pasted text #11 +3 lines]',
+          },
+        },
+      ]),
+    ).toBe(12)
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1545,6 +1545,7 @@ describe('PromptInput render surface', () => {
         nextInternalSubId: vi.fn()
           .mockReturnValueOnce('bash-input-id')
           .mockReturnValueOnce('bash-stdout-id')
+          .mockReturnValueOnce('bash-late-stdout-id')
           .mockReturnValueOnce('bash-stderr-id'),
       },
       setToolJSX,
@@ -1563,6 +1564,15 @@ describe('PromptInput render surface', () => {
           message: {
             content: [
               { text: '<ignored>nope</ignored>', type: 'text' },
+            ],
+          },
+          type: 'user',
+        },
+        {
+          message: {
+            content: [
+              { text: '<ignored>metadata</ignored>', type: 'text' },
+              { text: '<bash-stdout>late</bash-stdout>', type: 'text' },
             ],
           },
           type: 'user',
@@ -1616,6 +1626,14 @@ describe('PromptInput render surface', () => {
           msg: expect.objectContaining({
             payload: expect.objectContaining({
               message: '<bash-stdout>ok</bash-stdout>',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          id: 'bash-late-stdout-id',
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-stdout>late</bash-stdout>',
             }),
           }),
         }),
@@ -1959,6 +1977,47 @@ describe('PromptInput render surface', () => {
         expect.objectContaining({
           content: 'png-data',
           id: 8,
+          type: 'image',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('allocates pasted image IDs after prior string transcript references', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'png-data',
+      mediaType: 'image/png',
+    })
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      messages: [
+        {
+          message: {
+            content: 'old string ref [Image #9]',
+          },
+          type: 'user',
+        },
+      ],
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #10]')
+      expect(pastedContents.current[10]).toEqual(
+        expect.objectContaining({
+          content: 'png-data',
+          id: 10,
           type: 'image',
         }),
       )


### PR DESCRIPTION
## Summary
- Fix PromptInput paste ID allocation so resumed string-form user messages are scanned for existing `[Image #N]` and `[Pasted text #N]` references.
- Fix bash-mode transcript emission so bash stdout/stderr text blocks are not dropped when metadata text appears earlier in the same content array.
- Add focused helper and render regressions for both paths.

## Root Causes
- `getNextPasteIdAfter()` only scanned array-form `message.content`, but runtime user message content can also be a string. Resuming a transcript with string-form paste references could reuse an existing paste ID.
- `extractUserMessageText()` returned the first text block from array-form content before the caller filtered for `<bash-stdout>` / `<bash-stderr>`. If a metadata block appeared first, the actual bash output block was skipped.

## Coverage
- Focused PromptInput coverage: 84.13% statements, 70.01% branches, 83.41% functions, 85.20% lines.
- Full TUI coverage: 95.47% statements, 89.17% branches, 96.00% functions, 96.32% lines.

## Validation
- `npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "executes bash-mode"`
- `npx vitest run tests/tui/components/PromptInput/PromptInput.helpers.test.ts tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "string transcript|helper behavior"`
- `npx vitest run tests/tui/components/PromptInput/PromptInput*.test.ts tests/tui/components/PromptInput/PromptInput*.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/PromptInput/PromptInput.tsx' --coverage.reportsDirectory=coverage/prompt-input-audit`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`

## Known Existing Backlog
- `npm --prefix runtime run check:unused:production` still fails on the existing unrelated Knip backlog: 30 unused exports and 4 unused tag hints.