### PR TITLE
fix(tui): normalize workbench error navigation

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useEffect, useMemo, useState } from "react";
 
 import { logError } from "../../../utils/log.js";
@@ -9,7 +8,7 @@ import { useAppState } from "../../state/AppState.js";
 import { useSetAppState } from "../../state/AppState.js";
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
-import { attachTaskErrorCommand } from "../commands.js";
+import { attachTaskErrorCommand, openBufferCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import { resolveWorkbenchShellTask } from "../tasks/shellTasks.js";
 import { stopWorkbenchTask, workbenchStopActionForTask } from "../tasks/stopActions.js";
@@ -65,12 +64,7 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
   const jumpToFirstLocation = () => {
     const location = locations[0];
     if (location) {
-      dispatch({
-        type: "openBuffer",
-        path: location.file,
-        line: location.line,
-        focus: true,
-      });
+      dispatch(openBufferCommand(location.file, location.line, true));
     }
   };
   useKeybindings(

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useEffect, useMemo, useState } from "react";
 
 import { logError } from "../../../utils/log.js";
@@ -8,7 +7,7 @@ import { Box, Text } from "../../ink.js";
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
 import { useAppState } from "../../state/AppState.js";
-import { attachTaskErrorCommand } from "../commands.js";
+import { attachTaskErrorCommand, openBufferCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import { resolveWorkbenchShellTask } from "../tasks/shellTasks.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
@@ -65,12 +64,11 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   useRegisterKeybindingContext("Surface", focused);
   const jumpToSelectedFailure = (focus = true) => {
     if (selectedFailure?.location) {
-      dispatch({
-        type: "openBuffer",
-        path: selectedFailure.location.file,
-        line: selectedFailure.location.line,
+      dispatch(openBufferCommand(
+        selectedFailure.location.file,
+        selectedFailure.location.line,
         focus,
-      });
+      ));
     }
   };
   useKeybindings(

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
 }));
 
 vi.mock("../../../src/utils/task/diskOutput.js", () => ({
+  evictTaskOutput: vi.fn(),
   getTaskOutputPath: (taskId: string) => `/tmp/${taskId}.log`,
 }));
 
@@ -117,6 +118,7 @@ describe("ShellSurface", () => {
   });
 
   it("shows an empty shell state instead of rendering a selected agent task", async () => {
+    const changes: AppState[] = [];
     const output = await renderToString(
       <AppStateProvider
         initialState={{
@@ -139,6 +141,7 @@ describe("ShellSurface", () => {
             selectedShellTaskId: "agent-1",
           },
         }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
       >
         <ShellSurface focused={true} />
       </AppStateProvider>,
@@ -147,6 +150,9 @@ describe("ShellSurface", () => {
 
     expect(output).toContain("No shell task selected");
     expect(output).not.toContain("agent work");
+
+    shellHarness.handlers["surface:stop"]?.();
+    expect(changes).toHaveLength(0);
   });
 
   it("falls back to the running newest shell task after stale selection", async () => {
@@ -192,6 +198,136 @@ describe("ShellSurface", () => {
 
     expect(output).toContain("SHELL - running - new running shell");
     expect(output).not.toContain("old completed shell");
+  });
+
+  it("normalizes shell output paths when opening and attaching errors", async () => {
+    shellHarness.tails["shell-1"] = [
+      "shell failed",
+      "src\\nested\\shell.test.ts:12:3",
+    ].join("\n");
+    const changes: AppState[] = [];
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            "shell-1": {
+              ...shellTask("shell-1", "unused", "running"),
+              description: undefined,
+            } as any,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "shell",
+            selectedShellTaskId: "shell-1",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <ShellSurface focused={true} />
+      </AppStateProvider>,
+      120,
+    );
+
+    expect(output).toContain("SHELL - running - shell-1");
+    expect(output).toContain("x stop");
+
+    shellHarness.handlers["surface:open"]?.();
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/nested/shell.test.ts",
+      activeFileLine: 12,
+      focusedPane: "surface",
+    });
+
+    shellHarness.handlers["surface:attach"]?.();
+    expect(changes.at(-1)?.workbench.attachments.at(-1)).toMatchObject({
+      id: "task-error:shell-1:src/nested/shell.test.ts:12",
+      kind: "task-error",
+      path: "src/nested/shell.test.ts",
+      line: 12,
+      taskId: "shell-1",
+    });
+
+    shellHarness.handlers["surface:stop"]?.();
+    expect(changes.at(-1)?.tasks["shell-1"]?.status).toBe("killed");
+
+    shellHarness.handlers["workbench:closeSurface"]?.();
+    expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
+  });
+
+  it("does not dispatch location actions when no shell output location is parsed", async () => {
+    shellHarness.tails["shell-1"] = "plain output without locations";
+    const changes: AppState[] = [];
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            "shell-1": shellTask("shell-1", "plain shell", "completed"),
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "shell",
+            selectedShellTaskId: "shell-1",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <ShellSurface focused={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    shellHarness.handlers["surface:open"]?.();
+    shellHarness.handlers["surface:top"]?.();
+    shellHarness.handlers["surface:attach"]?.();
+    shellHarness.handlers["surface:stop"]?.();
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("ignores tail reads that resolve after unmount", async () => {
+    shellHarness.deferredTaskIds.add("shell-1");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-1": shellTask("shell-1", "current shell", "completed"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "shell",
+              selectedShellTaskId: "shell-1",
+            },
+          }}
+        >
+          <ShellSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      const resolveRead = shellHarness.pendingReads.get("shell-1");
+      expect(resolveRead).toBeTypeOf("function");
+
+      root.unmount();
+      resolveRead?.({ content: "src/late.ts:1:1" });
+      await sleep();
+
+      expect(shellHarness.logError).not.toHaveBeenCalled();
+    } finally {
+      stdin.end();
+      stdout.end();
+    }
   });
 
   it("clears stale tail content immediately when switching selected shell tasks", async () => {

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -198,6 +198,41 @@ describe("TestSurface", () => {
     expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
   });
 
+  it("normalizes test failure paths when opening buffers", async () => {
+    keybindingHarness.tails["shell-windows"] = [
+      "FAIL windows-style failure",
+      "src\\nested\\first.test.ts:4:1",
+      "first message",
+    ].join("\n");
+    const changes: AppState[] = [];
+    await renderTestSurface({
+      selectedShellTaskId: "shell-windows",
+      tasks: {
+        "shell-windows": shellTask("shell-windows", "windows path test", "completed"),
+      },
+      onChange: changes,
+      workbench: {
+        focusedPane: "composer",
+      },
+    });
+
+    keybindingHarness.handlers["surface:openKeepFocus"]?.();
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/nested/first.test.ts",
+      activeFileLine: 4,
+      focusedPane: "composer",
+    });
+
+    keybindingHarness.handlers["surface:open"]?.();
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/nested/first.test.ts",
+      activeFileLine: 4,
+      focusedPane: "surface",
+    });
+  });
+
   it("ignores attach and open commands when the selected failure has no location", async () => {
     keybindingHarness.tails["shell-no-location"] = [
       "FAIL failure without location",


### PR DESCRIPTION
## Summary
- Route Shell and Test error opens through `openBufferCommand` so parsed source paths use the same path normalization as attachments and other workbench surfaces.
- Remove `@ts-nocheck` from both ShellSurface and TestSurface after typing the changed paths.
- Add regression coverage for Windows-style parsed paths, shell stop/close/no-location handlers, stale tail reads after unmount, and Shell/Test surface command branches.

## Validation
- `npx vitest run tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/shell-tasks.test.ts tests/tui/workbench/test-surface.test.tsx tests/tui/workbench/output-parsers.test.ts tests/tui/workbench/commands.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/workbench/surfaces/ShellSurface.tsx' --coverage.include='src/tui/workbench/surfaces/TestSurface.tsx' --coverage.reportsDirectory=coverage/shell-surface-audit`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- marker scan for TODO/FIXME/HACK/suppression/generated-cache leftovers

## Coverage
- ShellSurface: 100% statements, 100% branches, 100% functions, 100% lines
- TestSurface: 100% statements, 100% branches, 100% functions, 100% lines
- Full TUI: 95.52% statements, 89.26% branches, 96.06% functions, 96.36% lines