### PR TITLE
fix(tui): route auto mode cancellation through decline

### DIFF
--- a/runtime/src/tui/components/AutoModeOptInDialog.tsx
+++ b/runtime/src/tui/components/AutoModeOptInDialog.tsx
@@ -1,4 +1,3 @@
-import { c as _c } from "react-compiler-runtime";
 import React from 'react';
 import { logEvent } from '../../services/analytics/index.js';
 import { Box, Link, Text } from '../ink.js';
@@ -14,128 +13,83 @@ type Props = {
   // Startup gate: decline exits the process, so relabel accordingly.
   declineExits?: boolean;
 };
-export function AutoModeOptInDialog(t0: Props) {
-  const $ = _c(18);
-  const {
-    onAccept,
-    onDecline,
-    declineExits
-  } = t0;
-  let t1: [];
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [];
-    $[0] = t1;
-  } else {
-    t1 = $[0];
-  }
-  React.useEffect(_temp, t1);
-  let t2;
-  if ($[1] !== onAccept || $[2] !== onDecline) {
-    t2 = function onChange(value: 'accept' | 'accept-default' | 'decline') {
-      bb3: switch (value) {
-        case "accept":
-          {
-            logEvent("agenc_auto_mode_opt_in_dialog_accept", {});
-            updateSettingsForSource("userSettings", {
-              skipAutoPermissionPrompt: true
-            });
-            onAccept();
-            break bb3;
-          }
-        case "accept-default":
-          {
-            logEvent("agenc_auto_mode_opt_in_dialog_accept_default", {});
-            updateSettingsForSource("userSettings", {
-              skipAutoPermissionPrompt: true,
-              permissions: {
-                defaultMode: "auto"
-              }
-            });
-            onAccept();
-            break bb3;
-          }
-        case "decline":
-          {
-            logEvent("agenc_auto_mode_opt_in_dialog_decline", {});
-            onDecline();
-          }
-      }
-    };
-    $[1] = onAccept;
-    $[2] = onDecline;
-    $[3] = t2;
-  } else {
-    t2 = $[3];
-  }
-  const onChange = t2;
-  let t3;
-  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = <Box flexDirection="column" gap={1}><Text>{AUTO_MODE_DESCRIPTION}</Text><Link url="https://agenc.tech/docs/en/security" /></Box>;
-    $[4] = t3;
-  } else {
-    t3 = $[4];
-  }
-  let t4;
-  if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-    t4 = true ? [{
-      label: "Yes, and make it my default mode",
-      value: "accept-default" as const
-    }] : [];
-    $[5] = t4;
-  } else {
-    t4 = $[5];
-  }
-  let t5;
-  if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-    t5 = {
-      label: "Yes, enable auto mode",
-      value: "accept" as const
-    };
-    $[6] = t5;
-  } else {
-    t5 = $[6];
-  }
-  const t6 = declineExits ? "No, exit" : "No, go back";
-  let t7;
-  if ($[7] !== t6) {
-    t7 = [...t4, t5, {
-      label: t6,
-      value: "decline" as const
-    }];
-    $[7] = t6;
-    $[8] = t7;
-  } else {
-    t7 = $[8];
-  }
-  let t8;
-  if ($[9] !== onChange) {
-    t8 = (value_0: string) => onChange(value_0 as 'accept' | 'accept-default' | 'decline');
-    $[9] = onChange;
-    $[10] = t8;
-  } else {
-    t8 = $[10];
-  }
-  let t9;
-  if ($[11] !== onDecline || $[12] !== t7 || $[13] !== t8) {
-    t9 = <Select options={t7} onChange={t8} onCancel={onDecline} />;
-    $[11] = onDecline;
-    $[12] = t7;
-    $[13] = t8;
-    $[14] = t9;
-  } else {
-    t9 = $[14];
-  }
-  let t10;
-  if ($[15] !== onDecline || $[16] !== t9) {
-    t10 = <Dialog title="Enable auto mode?" color="warning" onCancel={onDecline}>{t3}{t9}</Dialog>;
-    $[15] = onDecline;
-    $[16] = t9;
-    $[17] = t10;
-  } else {
-    t10 = $[17];
-  }
-  return t10;
+
+type AutoModeDecision = 'accept' | 'accept-default' | 'decline';
+
+const ACCEPT_DEFAULT_OPTION = {
+  label: 'Yes, and make it my default mode',
+  value: 'accept-default',
+} as const;
+
+const ACCEPT_OPTION = {
+  label: 'Yes, enable auto mode',
+  value: 'accept',
+} as const;
+
+function logShown(): void {
+  logEvent('agenc_auto_mode_opt_in_dialog_shown', {});
 }
-function _temp() {
-  logEvent("agenc_auto_mode_opt_in_dialog_shown", {});
+
+export function AutoModeOptInDialog({
+  onAccept,
+  onDecline,
+  declineExits,
+}: Props) {
+  React.useEffect(logShown, []);
+
+  const handleDecline = React.useCallback(() => {
+    logEvent('agenc_auto_mode_opt_in_dialog_decline', {});
+    onDecline();
+  }, [onDecline]);
+
+  const handleChange = React.useCallback(
+    (value: AutoModeDecision) => {
+      switch (value) {
+        case 'accept':
+          logEvent('agenc_auto_mode_opt_in_dialog_accept', {});
+          updateSettingsForSource('userSettings', {
+            skipAutoPermissionPrompt: true,
+          });
+          onAccept();
+          return;
+        case 'accept-default':
+          logEvent('agenc_auto_mode_opt_in_dialog_accept_default', {});
+          updateSettingsForSource('userSettings', {
+            skipAutoPermissionPrompt: true,
+            permissions: {
+              defaultMode: 'auto',
+            },
+          });
+          onAccept();
+          return;
+        case 'decline':
+          handleDecline();
+          return;
+      }
+    },
+    [handleDecline, onAccept],
+  );
+
+  const options = [
+    ACCEPT_DEFAULT_OPTION,
+    ACCEPT_OPTION,
+    {
+      label: declineExits ? 'No, exit' : 'No, go back',
+      value: 'decline',
+    } as const,
+  ];
+
+  return (
+    <Dialog title="Enable auto mode?" color="warning" onCancel={handleDecline}>
+      <Box flexDirection="column" gap={1}>
+        <Text>{AUTO_MODE_DESCRIPTION}</Text>
+        <Link url="https://agenc.tech/docs/en/security" />
+      </Box>
+      <Select<AutoModeDecision>
+        options={options}
+        onChange={handleChange}
+        onCancel={handleDecline}
+      />
+    </Dialog>
+  );
 }

--- a/runtime/tests/tui/components/AutoModeOptInDialog.coverage.test.tsx
+++ b/runtime/tests/tui/components/AutoModeOptInDialog.coverage.test.tsx
@@ -98,10 +98,10 @@ describe("AutoModeOptInDialog coverage", () => {
     );
     expect(harness.dialogProps).toMatchObject({
       color: "warning",
-      onCancel: onDecline,
       title: "Enable auto mode?",
     });
-    expect(harness.selectProps?.onCancel).toBe(onDecline);
+    expect(harness.dialogProps?.onCancel).toEqual(expect.any(Function));
+    expect(harness.selectProps?.onCancel).toEqual(expect.any(Function));
     expect(harness.selectProps?.options).toEqual([
       {
         label: "Yes, and make it my default mode",
@@ -151,6 +151,24 @@ describe("AutoModeOptInDialog coverage", () => {
       {},
     );
     expect(onDecline).toHaveBeenCalledTimes(1);
+
+    harness.logEvent.mockClear();
+    harness.selectProps?.onCancel();
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_decline",
+      {},
+    );
+    expect(onDecline).toHaveBeenCalledTimes(2);
+
+    harness.logEvent.mockClear();
+    harness.dialogProps?.onCancel();
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_decline",
+      {},
+    );
+    expect(onDecline).toHaveBeenCalledTimes(3);
 
     await renderToString(
       <AutoModeOptInDialog onAccept={onAccept} onDecline={onDecline} />,

--- a/runtime/tests/tui/coverage-swarm/swarm-107-components-AutoModeOptInDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-107-components-AutoModeOptInDialog.test.tsx
@@ -125,9 +125,9 @@ describe("AutoModeOptInDialog coverage swarm row 107", () => {
     ]);
     expect(harness.dialogProps.at(-1)).toMatchObject({
       color: "warning",
-      onCancel: onDecline,
       title: "Enable auto mode?",
     });
+    expect(harness.dialogProps.at(-1)?.onCancel).toEqual(expect.any(Function));
     expect(harness.logEvent).toHaveBeenCalledWith(
       "agenc_auto_mode_opt_in_dialog_shown",
       {},
@@ -203,5 +203,28 @@ describe("AutoModeOptInDialog coverage swarm row 107", () => {
     expect(harness.updateSettingsForSource).not.toHaveBeenCalled();
     expect(onAccept).not.toHaveBeenCalled();
     expect(onDecline).toHaveBeenCalledOnce();
+  });
+
+  test("routes select and dialog cancellation through decline handling", async () => {
+    const onDecline = vi.fn();
+    await renderDialog({ onDecline });
+
+    harness.logEvent.mockClear();
+    latestSelectProps().onCancel();
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_decline",
+      {},
+    );
+    expect(onDecline).toHaveBeenCalledOnce();
+
+    harness.logEvent.mockClear();
+    harness.dialogProps.at(-1)?.onCancel();
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_decline",
+      {},
+    );
+    expect(onDecline).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- route AutoModeOptInDialog select/dialog cancellation through the same decline handler as the explicit No option
- remove the generated React compiler cache layer from the dialog and keep the decision path typed directly
- cover cancel handling and bring AutoModeOptInDialog to 100% focused coverage

## Test plan
- npx vitest run tests/tui/components/AutoModeOptInDialog.coverage.test.tsx tests/tui/coverage-swarm/swarm-107-components-AutoModeOptInDialog.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/AutoModeOptInDialog.tsx' --coverage.reportsDirectory=coverage/auto-mode-dialog-audit
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core