### PR TITLE
refactor(tui): simplify bash output rendering

### DIFF
--- a/runtime/src/tui/message-renderers/UserBashOutputMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserBashOutputMessage.tsx
@@ -1,53 +1,28 @@
-import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import BashToolResultMessage from '../../tools/BashTool/BashToolResultMessage';
+import type { Out as BashOut } from '../../tools/BashTool/BashTool.js';
 import { extractTag } from '../../utils/messages';
-export function UserBashOutputMessage(t0) {
-  const $ = _c(10);
-  const {
-    content,
-    verbose
-  } = t0;
-  let t1;
-  if ($[0] !== content) {
-    const rawStdout = extractTag(content, "bash-stdout") ?? "";
-    t1 = extractTag(rawStdout, "persisted-output") ?? rawStdout;
-    $[0] = content;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  const stdout = t1;
-  let t2;
-  if ($[2] !== content) {
-    t2 = extractTag(content, "bash-stderr") ?? "";
-    $[2] = content;
-    $[3] = t2;
-  } else {
-    t2 = $[3];
-  }
-  const stderr = t2;
-  let t3;
-  if ($[4] !== stderr || $[5] !== stdout) {
-    t3 = {
-      stdout,
-      stderr
-    };
-    $[4] = stderr;
-    $[5] = stdout;
-    $[6] = t3;
-  } else {
-    t3 = $[6];
-  }
-  const t4 = !!verbose;
-  let t5;
-  if ($[7] !== t3 || $[8] !== t4) {
-    t5 = <BashToolResultMessage content={t3} verbose={t4} />;
-    $[7] = t3;
-    $[8] = t4;
-    $[9] = t5;
-  } else {
-    t5 = $[9];
-  }
-  return t5;
+
+type Props = {
+  content: string;
+  verbose?: boolean;
+};
+
+type BashResultContent = Omit<BashOut, 'interrupted'>;
+
+function extractStdout(content: string): string {
+  const rawStdout = extractTag(content, 'bash-stdout') ?? '';
+  return extractTag(rawStdout, 'persisted-output') ?? rawStdout;
+}
+
+export function UserBashOutputMessage({
+  content,
+  verbose,
+}: Props): React.ReactElement {
+  const bashContent: BashResultContent = {
+    stdout: extractStdout(content),
+    stderr: extractTag(content, 'bash-stderr') ?? '',
+  };
+
+  return <BashToolResultMessage content={bashContent} verbose={Boolean(verbose)} />;
 }


### PR DESCRIPTION
## Summary
- replace the generated React compiler cache wrapper in UserBashOutputMessage with direct typed rendering logic
- keep bash stdout/stderr and persisted-output extraction semantics unchanged
- move UserBashOutputMessage to 100% coverage across statements, branches, functions, and lines

## Test plan
- npx vitest run tests/tui/message-renderers/UserBashOutputMessage.coverage.test.tsx tests/tui/coverage-swarm/swarm-169-message-renderers-UserBashOutputMessage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/message-renderers/UserBashOutputMessage.tsx' --coverage.reportsDirectory=coverage/user-bash-output-audit
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core