### PR TITLE
fix(tui): stop resolved hook progress

### DIFF
--- a/runtime/src/tui/message-renderers/HookProgressMessage.tsx
+++ b/runtime/src/tui/message-renderers/HookProgressMessage.tsx
@@ -1,4 +1,3 @@
-import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import type { HookEvent } from '../../entrypoints/agentSdkTypes.js';
 import type { buildMessageLookups } from '../../utils/messages.js';
@@ -22,114 +21,71 @@ export function getHookProgressRunningLabel(
 export function getHookProgressTranscriptRunningLabel(inProgressHookCount: number): string {
   return inProgressHookCount === 1 ? ' hook running' : ' hooks running';
 }
-export function HookProgressMessage(t0) {
-  const $ = _c(22);
-  const {
-    hookEvent,
-    lookups,
-    toolUseID,
-    isTranscriptMode
-  } = t0;
-  let t1;
-  if ($[0] !== hookEvent || $[1] !== lookups.inProgressHookCounts || $[2] !== toolUseID) {
-    t1 = lookups.inProgressHookCounts.get(toolUseID)?.get(hookEvent) ?? 0;
-    $[0] = hookEvent;
-    $[1] = lookups.inProgressHookCounts;
-    $[2] = toolUseID;
-    $[3] = t1;
-  } else {
-    t1 = $[3];
-  }
-  const inProgressHookCount = t1;
-  const resolvedHookCount = lookups.resolvedHookCounts.get(toolUseID)?.get(hookEvent) ?? 0;
-  if (inProgressHookCount === 0) {
+
+function HookProgressRow({
+  hookEvent,
+  suffix,
+}: {
+  hookEvent: HookEvent;
+  suffix: string;
+}): React.ReactElement {
+  return (
+    <MessageResponse>
+      <Box flexDirection="row">
+        <Text dimColor={true}>Running </Text>
+        <Text dimColor={true} bold={true}>{hookEvent}</Text>
+        <Text dimColor={true}>{suffix}</Text>
+      </Box>
+    </MessageResponse>
+  );
+}
+
+export function HookProgressMessage({
+  hookEvent,
+  lookups,
+  toolUseID,
+  isTranscriptMode,
+}: Props): React.ReactElement | null {
+  const inProgressHookCount =
+    lookups.inProgressHookCounts.get(toolUseID)?.get(hookEvent) ?? 0;
+
+  if (inProgressHookCount <= 0) {
     return null;
   }
-  if (hookEvent === "PreToolUse" || hookEvent === "PostToolUse") {
+
+  if (hookEvent === 'PreToolUse' || hookEvent === 'PostToolUse') {
     if (isTranscriptMode) {
-      let t2;
-      if ($[4] !== inProgressHookCount) {
-        t2 = <Text dimColor={true}>{inProgressHookCount} </Text>;
-        $[4] = inProgressHookCount;
-        $[5] = t2;
-      } else {
-        t2 = $[5];
-      }
-      let t3;
-      if ($[6] !== hookEvent) {
-        t3 = <Text dimColor={true} bold={true}>{hookEvent}</Text>;
-        $[6] = hookEvent;
-        $[7] = t3;
-      } else {
-        t3 = $[7];
-      }
-      const t4 = getHookProgressTranscriptRunningLabel(inProgressHookCount);
-      let t5;
-      if ($[8] !== t4) {
-        t5 = <Text dimColor={true}>{t4}</Text>;
-        $[8] = t4;
-        $[9] = t5;
-      } else {
-        t5 = $[9];
-      }
-      let t6;
-      if ($[10] !== t2 || $[11] !== t3 || $[12] !== t5) {
-        t6 = <MessageResponse><Box flexDirection="row">{t2}{t3}{t5}</Box></MessageResponse>;
-        $[10] = t2;
-        $[11] = t3;
-        $[12] = t5;
-        $[13] = t6;
-      } else {
-        t6 = $[13];
-      }
-      return t6;
+      return (
+        <MessageResponse>
+          <Box flexDirection="row">
+            <Text dimColor={true}>{inProgressHookCount} </Text>
+            <Text dimColor={true} bold={true}>{hookEvent}</Text>
+            <Text dimColor={true}>
+              {getHookProgressTranscriptRunningLabel(inProgressHookCount)}
+            </Text>
+          </Box>
+        </MessageResponse>
+      );
     }
-    const hookLabel = getHookProgressRunningLabel(inProgressHookCount);
+
     return (
-      <MessageResponse>
-        <Box flexDirection="row">
-          <Text dimColor={true}>Running </Text>
-          <Text dimColor={true} bold={true}>{hookEvent}</Text>
-          <Text dimColor={true}>{hookLabel}</Text>
-        </Box>
-      </MessageResponse>
+      <HookProgressRow
+        hookEvent={hookEvent}
+        suffix={getHookProgressRunningLabel(inProgressHookCount)}
+      />
     );
   }
-  if (resolvedHookCount === inProgressHookCount) {
+
+  const resolvedHookCount =
+    lookups.resolvedHookCounts.get(toolUseID)?.get(hookEvent) ?? 0;
+  if (resolvedHookCount >= inProgressHookCount) {
     return null;
   }
-  let t2;
-  if ($[14] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = <Text dimColor={true}>Running </Text>;
-    $[14] = t2;
-  } else {
-    t2 = $[14];
-  }
-  let t3;
-  if ($[15] !== hookEvent) {
-    t3 = <Text dimColor={true} bold={true}>{hookEvent}</Text>;
-    $[15] = hookEvent;
-    $[16] = t3;
-  } else {
-    t3 = $[16];
-  }
-  const t4 = getHookProgressRunningLabel(inProgressHookCount);
-  let t5;
-  if ($[17] !== t4) {
-    t5 = <Text dimColor={true}>{t4}</Text>;
-    $[17] = t4;
-    $[18] = t5;
-  } else {
-    t5 = $[18];
-  }
-  let t6;
-  if ($[19] !== t3 || $[20] !== t5) {
-    t6 = <MessageResponse><Box flexDirection="row">{t2}{t3}{t5}</Box></MessageResponse>;
-    $[19] = t3;
-    $[20] = t5;
-    $[21] = t6;
-  } else {
-    t6 = $[21];
-  }
-  return t6;
+
+  return (
+    <HookProgressRow
+      hookEvent={hookEvent}
+      suffix={getHookProgressRunningLabel(inProgressHookCount)}
+    />
+  );
 }

--- a/runtime/tests/tui/coverage-swarm/swarm-110-message-renderers-HookProgressMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-110-message-renderers-HookProgressMessage.test.tsx
@@ -125,4 +125,28 @@ describe('HookProgressMessage swarm-110 coverage', () => {
 
     expect(activeNonToolHook).toContain('Running Notification hook...')
   })
+
+  test('omits non-tool hooks when resolved count reaches or exceeds active count', async () => {
+    const equalResolved = await renderHookProgress({
+      hookEvent: 'Notification',
+      toolUseID: 'toolu-equal-resolved',
+      lookups: createLookups({
+        inProgress: [['toolu-equal-resolved', { Notification: 2 }]],
+        resolved: [['toolu-equal-resolved', { Notification: 2 }]],
+      }),
+    })
+
+    expect(equalResolved).toBe('\n')
+
+    const overResolved = await renderHookProgress({
+      hookEvent: 'Notification',
+      toolUseID: 'toolu-over-resolved',
+      lookups: createLookups({
+        inProgress: [['toolu-over-resolved', { Notification: 1 }]],
+        resolved: [['toolu-over-resolved', { Notification: 2 }]],
+      }),
+    })
+
+    expect(overResolved).toBe('\n')
+  })
 })

--- a/runtime/tests/tui/parity/HookProgressMessage.live.parity.test.ts
+++ b/runtime/tests/tui/parity/HookProgressMessage.live.parity.test.ts
@@ -12,16 +12,17 @@ describe("HookProgressMessage live rendering", () => {
   test("PreToolUse and PostToolUse hooks render progress outside transcript mode", () => {
     const source = readSource();
     const branchStart = source.indexOf(
-      'if (hookEvent === "PreToolUse" || hookEvent === "PostToolUse")',
+      "if (hookEvent === 'PreToolUse' || hookEvent === 'PostToolUse')",
     );
     expect(branchStart).toBeGreaterThanOrEqual(0);
-    const branchEnd = source.indexOf("if (resolvedHookCount === inProgressHookCount)", branchStart);
+    const branchEnd = source.indexOf("const resolvedHookCount", branchStart);
     expect(branchEnd).toBeGreaterThan(branchStart);
     const branch = source.slice(branchStart, branchEnd);
 
     expect(branch).toContain("isTranscriptMode");
     expect(branch).toContain("<MessageResponse>");
-    expect(branch).toContain("Running ");
+    expect(branch).toContain("<HookProgressRow");
+    expect(source).toContain("<Text dimColor={true}>Running </Text>");
     expect(branch).not.toMatch(/return\s+null\s*;/);
   });
 });


### PR DESCRIPTION
## Summary
- route non-tool hook progress through the same resolved-count invariant used by shared hook lookup logic
- stop rendering non-tool hook progress when resolved counts reach or exceed active counts
- remove generated React compiler cache code from `HookProgressMessage` and add focused equal/over-resolved coverage

## Test Plan
- `npx vitest run tests/tui/message-renderers/HookProgressMessage.coverage.test.tsx tests/tui/coverage-swarm/swarm-110-message-renderers-HookProgressMessage.test.tsx tests/tui/parity/HookProgressMessage.live.parity.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/message-renderers/HookProgressMessage.tsx' --coverage.reportsDirectory=coverage/hook-progress-audit`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`