### PR TITLE
fix(tui): route array tool error controls

### DIFF
--- a/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.tsx
@@ -1,4 +1,3 @@
-import { c as _c } from "react-compiler-runtime";
 import { feature } from 'bun:bundle';
 import * as React from 'react';
 import { BULLET_OPERATOR } from '../../../constants/figures.js';
@@ -20,86 +19,68 @@ type Props = {
   verbose: boolean;
   isTranscriptMode?: boolean;
 };
-export function UserToolErrorMessage(t0) {
-  const $ = _c(14);
-  const {
-    progressMessagesForMessage,
-    tool,
-    tools,
-    param,
-    verbose,
-    isTranscriptMode
-  } = t0;
+
+function getTextToolResultContent(
+  content: AgenCToolResultBlockParam['content'],
+): string | undefined {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  const textParts: string[] = [];
+  for (const block of content) {
+    if (typeof block === 'string') {
+      textParts.push(block);
+    } else if (block && typeof block === 'object' && typeof block.text === 'string') {
+      textParts.push(block.text);
+    }
+  }
+
+  return textParts.length > 0 ? textParts.join('\n') : undefined;
+}
+
+export function UserToolErrorMessage({
+  progressMessagesForMessage,
+  tool,
+  tools,
+  param,
+  verbose,
+  isTranscriptMode,
+}: Props): React.ReactNode {
   if (isPermissionDeniedToolResult(param.content)) {
     return <MessageResponse height={1}><Text dimColor={true}>{PERMISSION_DENIED_TOOL_RESULT_MESSAGE}</Text></MessageResponse>;
   }
-  if (typeof param.content === "string" && param.content.includes(INTERRUPT_MESSAGE_FOR_TOOL_USE)) {
-    let t1;
-    if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-      t1 = <MessageResponse height={1}><InterruptedByUser /></MessageResponse>;
-      $[0] = t1;
-    } else {
-      t1 = $[0];
-    }
-    return t1;
+
+  const textContent = getTextToolResultContent(param.content);
+  if (textContent?.includes(INTERRUPT_MESSAGE_FOR_TOOL_USE)) {
+    return <MessageResponse height={1}><InterruptedByUser /></MessageResponse>;
   }
-  if (typeof param.content === "string" && param.content.startsWith(PLAN_REJECTION_PREFIX)) {
-    let t1;
-    if ($[1] !== param.content) {
-      t1 = param.content.substring(PLAN_REJECTION_PREFIX.length);
-      $[1] = param.content;
-      $[2] = t1;
-    } else {
-      t1 = $[2];
-    }
-    const planContent = t1;
-    let t2;
-    if ($[3] !== planContent) {
-      t2 = <RejectedPlanMessage plan={planContent} />;
-      $[3] = planContent;
-      $[4] = t2;
-    } else {
-      t2 = $[4];
-    }
-    return t2;
+  if (textContent?.startsWith(PLAN_REJECTION_PREFIX)) {
+    const planContent = textContent.substring(PLAN_REJECTION_PREFIX.length);
+    return <RejectedPlanMessage plan={planContent} />;
   }
-  if (typeof param.content === "string" && param.content.startsWith(REJECT_MESSAGE_WITH_REASON_PREFIX)) {
-    let t1;
-    if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-      t1 = <RejectedToolUseMessage />;
-      $[5] = t1;
-    } else {
-      t1 = $[5];
-    }
-    return t1;
+  if (textContent?.startsWith(REJECT_MESSAGE_WITH_REASON_PREFIX)) {
+    return <RejectedToolUseMessage />;
   }
-  if (feature("TRANSCRIPT_CLASSIFIER") && typeof param.content === "string" && isClassifierDenial(param.content)) {
-    let t1;
-    if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-      t1 = <MessageResponse height={1}><Text dimColor={true}>Denied by auto mode classifier {BULLET_OPERATOR} /feedback if incorrect</Text></MessageResponse>;
-      $[6] = t1;
-    } else {
-      t1 = $[6];
-    }
-    return t1;
+  if (feature("TRANSCRIPT_CLASSIFIER") && textContent !== undefined && isClassifierDenial(textContent)) {
+    return (
+      <MessageResponse height={1}>
+        <Text dimColor={true}>
+          Denied by auto mode classifier {BULLET_OPERATOR} /feedback if incorrect
+        </Text>
+      </MessageResponse>
+    );
   }
-  let t1;
-  if ($[7] !== isTranscriptMode || $[8] !== param.content || $[9] !== progressMessagesForMessage || $[10] !== tool || $[11] !== tools || $[12] !== verbose) {
-    t1 = tool?.renderToolUseErrorMessage?.(param.content, {
+
+  return (
+    tool?.renderToolUseErrorMessage?.(param.content, {
       progressMessagesForMessage: filterToolProgressMessages(progressMessagesForMessage),
       tools,
       verbose,
       isTranscriptMode
-    }) ?? <FallbackToolUseErrorMessage result={param.content} verbose={verbose} />;
-    $[7] = isTranscriptMode;
-    $[8] = param.content;
-    $[9] = progressMessagesForMessage;
-    $[10] = tool;
-    $[11] = tools;
-    $[12] = verbose;
-    $[13] = t1;
-  } else {
-    t1 = $[13];
-  }
-  return t1;
+    }) ?? <FallbackToolUseErrorMessage result={param.content} verbose={verbose} />
+  );
 }

--- a/runtime/tests/tui/coverage-swarm/swarm-138-message-renderers-UserToolResultMessage-UserToolErrorMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-138-message-renderers-UserToolResultMessage-UserToolErrorMessage.test.tsx
@@ -116,6 +116,82 @@ describe('UserToolErrorMessage swarm-138 coverage', () => {
     expect(featureOnOutput).not.toContain('command looked unsafe')
   })
 
+  test('routes text-bearing array content through control-message renderers', async () => {
+    featureFlags.add('TRANSCRIPT_CLASSIFIER')
+
+    const output = await renderToString(
+      <>
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult([
+            { type: 'text', text: `before ${INTERRUPT_MESSAGE_FOR_TOOL_USE}` },
+          ])}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult([
+            {
+              type: 'text',
+              text: `${PLAN_REJECTION_PREFIX}Array-form plan content.`,
+            },
+          ])}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult([
+            {
+              type: 'text',
+              text: `${REJECT_MESSAGE_WITH_REASON_PREFIX}Array-form rejection.`,
+            },
+          ])}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult([
+            'Permission for this action has been denied. Reason: array classifier',
+          ])}
+          verbose={false}
+        />
+      </>,
+      { columns: 120, rows: 20 },
+    )
+
+    expect(output).toContain('Interrupted')
+    expect(output).toContain('Array-form plan content.')
+    expect(output).toContain('Tool use rejected')
+    expect(output).toContain('Denied by auto mode classifier')
+    expect(output).not.toContain('array classifier')
+  })
+
+  test('falls back for missing or non-text error content', async () => {
+    const output = await renderToString(
+      <>
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(undefined)}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult([{ type: 'image', source: 'ignored' }])}
+          verbose={false}
+        />
+      </>,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output.match(/Tool execution failed/g)).toHaveLength(2)
+  })
+
   test('delegates tool errors with filtered progress and transcript options', async () => {
     const toolProgress = {
       uuid: 'tool-progress',


### PR DESCRIPTION
## Summary
- replace generated React compiler cache code in `UserToolErrorMessage` with typed direct rendering
- normalize text-bearing tool-result array content before control-message routing
- render array-form interrupt, plan rejection, rejection-with-reason, and classifier-denial errors through the same specialized UI paths as string content

## Test Plan
- `npx vitest run tests/tui/coverage-swarm/swarm-138-message-renderers-UserToolResultMessage-UserToolErrorMessage.test.tsx tests/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.wave200-049.coverage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.tsx' --coverage.reportsDirectory=coverage/user-tool-error-audit`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`