### PR TITLE
fix(tui): emit all bash transcript outputs

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1477,10 +1477,9 @@ function PromptInput({
         );
         for (const m of result.messages) {
           if (m?.type !== 'user') continue;
-          const text = extractUserMessageText(m);
-          if (text === null) continue;
-          if (!text.startsWith('<bash-stdout') && !text.startsWith('<bash-stderr')) continue;
-          emitTranscriptText(text);
+          for (const text of extractUserMessageBashOutputTexts(m)) {
+            emitTranscriptText(text);
+          }
         }
       } catch (err) {
         const errText = err instanceof Error ? err.message : String(err);
@@ -2807,21 +2806,23 @@ export function getNextPasteIdAfter(
   }
   return maxId + 1;
 }
-function extractUserMessageText(m: unknown): string | null {
+function isBashOutputText(text: string): boolean {
+  return text.startsWith('<bash-stdout') || text.startsWith('<bash-stderr');
+}
+function extractUserMessageBashOutputTexts(m: unknown): string[] {
   const content = (m as { message?: { content?: unknown }; content?: unknown }).message?.content
     ?? (m as { content?: unknown }).content;
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return null;
-  let firstText: string | null = null;
+  if (typeof content === 'string') return isBashOutputText(content) ? [content] : [];
+  if (!Array.isArray(content)) return [];
+  const outputs: string[] = [];
   for (const block of content) {
     if (block?.type === 'text' && typeof block.text === 'string') {
-      firstText ??= block.text;
-      if (block.text.startsWith('<bash-stdout') || block.text.startsWith('<bash-stderr')) {
-        return block.text;
+      if (isBashOutputText(block.text)) {
+        outputs.push(block.text);
       }
     }
   }
-  return firstText;
+  return outputs;
 }
 function buildBorderText(showFastIcon: boolean, showFastIconHint: boolean, fastModeCooldown: boolean): BorderTextOptions | undefined {
   if (!showFastIcon) return undefined;

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1546,6 +1546,8 @@ describe('PromptInput render surface', () => {
           .mockReturnValueOnce('bash-input-id')
           .mockReturnValueOnce('bash-stdout-id')
           .mockReturnValueOnce('bash-late-stdout-id')
+          .mockReturnValueOnce('bash-combined-stdout-id')
+          .mockReturnValueOnce('bash-combined-stderr-id')
           .mockReturnValueOnce('bash-stderr-id'),
       },
       setToolJSX,
@@ -1573,6 +1575,15 @@ describe('PromptInput render surface', () => {
             content: [
               { text: '<ignored>metadata</ignored>', type: 'text' },
               { text: '<bash-stdout>late</bash-stdout>', type: 'text' },
+            ],
+          },
+          type: 'user',
+        },
+        {
+          message: {
+            content: [
+              { text: '<bash-stdout>combined</bash-stdout>', type: 'text' },
+              { text: '<bash-stderr>combined warn</bash-stderr>', type: 'text' },
             ],
           },
           type: 'user',
@@ -1634,6 +1645,22 @@ describe('PromptInput render surface', () => {
           msg: expect.objectContaining({
             payload: expect.objectContaining({
               message: '<bash-stdout>late</bash-stdout>',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          id: 'bash-combined-stdout-id',
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-stdout>combined</bash-stdout>',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          id: 'bash-combined-stderr-id',
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-stderr>combined warn</bash-stderr>',
             }),
           }),
         }),


### PR DESCRIPTION
## Summary
- extract every bash stdout/stderr text block from PromptInput bash transcript user messages
- keep non-bash transcript metadata filtered out of emitted transcript events
- add a render regression for stdout and stderr returned in the same user message

## Test plan
- npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/PromptInput/PromptInput.tsx' --coverage.reportsDirectory=coverage/prompt-input-bash
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing backlog: 30 unused exports and 4 tag hints)