### PR TITLE
fix(tui): make bash transcript fallback ids unique

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1447,9 +1447,10 @@ function PromptInput({
       };
       const session = ctx.session;
       const emit = typeof session?.emit === 'function' ? session.emit.bind(session) : undefined;
+      let fallbackSubId = 0;
       const nextId = typeof session?.nextInternalSubId === 'function'
         ? session.nextInternalSubId.bind(session)
-        : (() => `bash-${Date.now()}`);
+        : (() => `bash-${Date.now()}-${fallbackSubId++}`);
       const emitTranscriptText = (text: string) => {
         emit?.({
           id: nextId(),

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1683,6 +1683,7 @@ describe('PromptInput render surface', () => {
 
   test('emits bash stderr when local bash execution throws', async () => {
     const emitted: unknown[] = []
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(123456)
     const getToolUseContext = vi.fn(() => ({
       session: {
         emit: (event: unknown) => emitted.push(event),
@@ -1705,6 +1706,7 @@ describe('PromptInput render surface', () => {
 
       expect(emitted).toEqual([
         expect.objectContaining({
+          id: 'bash-123456-0',
           msg: expect.objectContaining({
             payload: expect.objectContaining({
               message: '<bash-input>explode</bash-input>',
@@ -1712,6 +1714,7 @@ describe('PromptInput render surface', () => {
           }),
         }),
         expect.objectContaining({
+          id: 'bash-123456-1',
           msg: expect.objectContaining({
             payload: expect.objectContaining({
               message: '<bash-stderr>shell failed</bash-stderr>',
@@ -1722,6 +1725,7 @@ describe('PromptInput render surface', () => {
       expect(onInputChange).toHaveBeenCalledWith('')
       expect(onModeChange).toHaveBeenCalledWith('prompt')
     } finally {
+      dateNow.mockRestore()
       await rendered.dispose()
     }
   })


### PR DESCRIPTION
## Summary
- make PromptInput bash transcript fallback IDs monotonic when no session sub-ID generator is available
- add a regression that freezes Date.now() and verifies bash input/error transcript events still get unique IDs

## Test plan
- npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/PromptInput/PromptInput.tsx' --coverage.reportsDirectory=coverage/prompt-input-fallback-ids
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing backlog: 30 unused exports and 4 tag hints)