### PR TITLE
fix(tui): keep cycled permission mode consistent

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1975,14 +1975,15 @@ function PromptInput({
     // call cyclePermissionMode to apply side effects (e.g. strip
     // dangerous permissions, activate classifier)
     const {
+      nextMode: preparedNextMode,
       context: preparedContext
     } = cyclePermissionMode(toolPermissionContext, teamContext);
     logEvent('agenc_mode_cycle', {
-      to: nextMode as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+      to: preparedNextMode as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
     });
 
     // Track when user enters plan mode
-    if (nextMode === 'plan') {
+    if (preparedNextMode === 'plan') {
       saveGlobalConfig(current => ({
         ...current,
         lastPlanModeUse: Date.now()
@@ -1997,16 +1998,16 @@ function PromptInput({
       ...prev,
       toolPermissionContext: {
         ...preparedContext,
-        mode: nextMode
+        mode: preparedNextMode
       }
     }));
     setToolPermissionContext({
       ...preparedContext,
-      mode: nextMode
+      mode: preparedNextMode
     });
 
     // If this is a teammate, update config.json so team lead sees the change
-    syncTeammateMode(nextMode, teamContext?.teamName);
+    syncTeammateMode(preparedNextMode, teamContext?.teamName);
 
     // Close help tips if they're open when mode is cycled
     if (helpOpen) {

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -106,6 +106,7 @@ const harness = vi.hoisted(() => {
     keybindingRegistrations: [] as Array<Record<string, unknown>>,
     modelPickerProps: undefined as undefined | Record<string, unknown>,
     nextPermissionMode: 'plan',
+    cyclePermissionModeNextMode: null as null | string,
     platform: 'linux',
     quickOpenProps: undefined as undefined | Record<string, unknown>,
     runningTeammates: [] as unknown[],
@@ -213,6 +214,7 @@ const harness = vi.hoisted(() => {
       harness.keybindingRegistrations = []
       harness.modelPickerProps = undefined
       harness.nextPermissionMode = 'plan'
+      harness.cyclePermissionModeNextMode = null
       harness.platform = 'linux'
       harness.quickOpenProps = undefined
       harness.runningTeammates = []
@@ -553,7 +555,10 @@ vi.mock('../../../utils/permissions/autoModeState.js', () => ({
 }))
 
 vi.mock('../../../utils/permissions/getNextPermissionMode.js', () => ({
-  cyclePermissionMode: (context: unknown) => ({ context }),
+  cyclePermissionMode: (context: unknown) => ({
+    context,
+    nextMode: harness.cyclePermissionModeNextMode ?? harness.nextPermissionMode,
+  }),
   getNextPermissionMode: () => harness.nextPermissionMode,
 }))
 
@@ -1096,6 +1101,31 @@ describe('PromptInput render surface', () => {
         expect.objectContaining({
           key: 'no-image-in-clipboard',
         }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('commits the permission mode returned with the cycled context', async () => {
+    harness.nextPermissionMode = 'plan'
+    harness.cyclePermissionModeNextMode = 'default'
+    const setToolPermissionContext = vi.fn()
+    const rendered = await renderPromptInput({ setToolPermissionContext })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['chat:cycleMode']?.()
+
+      expect(setToolPermissionContext).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'default' }),
+      )
+      expect(harness.appState.toolPermissionContext.mode).toBe('default')
+      expect(harness.saveGlobalConfig).not.toHaveBeenCalled()
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_mode_cycle',
+        expect.objectContaining({ to: 'default' }),
       )
     } finally {
       await rendered.dispose()

--- a/runtime/tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx
@@ -103,6 +103,7 @@ const harness = vi.hoisted(() => {
     logEvent: vi.fn(),
     modelPickerProps: undefined as undefined | Record<string, unknown>,
     nextPermissionMode: 'plan',
+    cyclePermissionModeNextMode: null as null | string,
     onRender: vi.fn(),
     platform: 'linux',
     promptInputFooterProps: undefined as undefined | Record<string, unknown>,
@@ -202,6 +203,7 @@ const harness = vi.hoisted(() => {
       harness.logEvent.mockClear()
       harness.modelPickerProps = undefined
       harness.nextPermissionMode = 'plan'
+      harness.cyclePermissionModeNextMode = null
       harness.onRender.mockClear()
       harness.platform = 'linux'
       harness.promptInputFooterProps = undefined
@@ -585,7 +587,10 @@ vi.mock('../../utils/permissions/autoModeState.js', () => ({
 }))
 
 vi.mock('../../utils/permissions/getNextPermissionMode.js', () => ({
-  cyclePermissionMode: (context: unknown) => ({ context }),
+  cyclePermissionMode: (context: unknown) => ({
+    context,
+    nextMode: harness.cyclePermissionModeNextMode ?? harness.nextPermissionMode,
+  }),
   getNextPermissionMode: () => harness.nextPermissionMode,
 }))
 


### PR DESCRIPTION
## Summary
- commit PromptInput permission-mode cycles using the `nextMode` returned by `cyclePermissionMode()`
- keep analytics, plan-mode tracking, app state, permission context, and teammate sync aligned with the context actually prepared for the transition
- add a regression for mismatched precomputed/cycled mode values

## Test plan
- npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/PromptInput/PromptInput.tsx' --coverage.reportsDirectory=coverage/prompt-input-cycle-mode
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing backlog: 30 unused exports and 4 tag hints)