### PR TITLE
fix(tui): refresh typeahead from replaced token

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -1077,10 +1077,15 @@ export function useTypeahead({
             isQuoted: completionToken.isQuoted,
             isComplete: false // partial completion
           });
+          const updatedInput =
+            input.slice(0, completionToken.startPos) +
+            replacementValue +
+            input.slice(completionToken.startPos + completionToken.token.length);
+          const updatedCursorOffset = completionToken.startPos + replacementValue.length;
           applyFileSuggestion(replacementValue, input, completionToken.token, completionToken.startPos, onInputChange, setCursorOffset);
           // Don't clear suggestions so user can continue typing or select a specific option
           // Instead, update for the new prefix
-          void updateSuggestions(input.replace(completionToken.token, replacementValue), cursorOffset);
+          void updateSuggestions(updatedInput, updatedCursorOffset);
         } else if (index < suggestions.length) {
           // Otherwise, apply the selected suggestion
           const suggestion = suggestions[index];

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -1195,6 +1195,49 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('tab refreshes common-prefix file suggestions from the replaced token', async () => {
+    harness.unifiedSuggestions = [
+      {
+        id: 'src/app.ts',
+        displayText: 'src/app.ts',
+        description: 'file',
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@sr some filler text @sr',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestions',
+      )
+
+      generateUnifiedSuggestionsMock.mockClear()
+      harness.keybindings['autocomplete:accept']?.()
+
+      expect(onInputChange).toHaveBeenCalledWith(
+        '@sr some filler text @src/app.ts',
+      )
+      expect(setCursorOffset).toHaveBeenCalledWith(
+        '@sr some filler text @src/app.ts'.length,
+      )
+      await waitFor(
+        () =>
+          generateUnifiedSuggestionsMock.mock.calls.some(
+            call => call[0] === 'src/app.ts',
+          ),
+        'common-prefix refresh uses replaced token',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('tab handles directory suggestions in command and general path contexts', async () => {
     harness.directorySuggestions = [
       {


### PR DESCRIPTION
## Summary
- refresh common-prefix file suggestions from the exact token span that was replaced
- add a regression for repeated @ tokens separated by other text

## Test plan
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx -t \"tab refreshes common-prefix file suggestions from the replaced token\"
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/hooks/useTypeahead.tsx' --coverage.reportsDirectory=coverage/typeahead-common-prefix-refresh
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known unrelated backlog: 30 unused exports, 4 tag hints)