### PR TITLE
fix(tui): replace full trigger token on accept

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -174,12 +174,18 @@ export function applyShellSuggestion(suggestion: SuggestionItem, input: string, 
   setCursorOffset(wordStart + replacementText.length);
 }
 const DM_MEMBER_RE = /(^|\s)@[\w-]*$/;
-function applyTriggerSuggestion(suggestion: SuggestionItem, input: string, cursorOffset: number, triggerRe: RegExp, onInputChange: (value: string) => void, setCursorOffset: (offset: number) => void): void {
+const DM_MEMBER_TAIL_RE = /^[\w-]*/;
+const HASH_CHANNEL_TAIL_RE = /^[a-z0-9_-]*/;
+function applyTriggerSuggestion(suggestion: SuggestionItem, input: string, cursorOffset: number, triggerRe: RegExp, tailRe: RegExp, onInputChange: (value: string) => void, setCursorOffset: (offset: number) => void): void {
   const m = input.slice(0, cursorOffset).match(triggerRe);
   if (!m || m.index === undefined) return;
   const prefixStart = m.index + (m[1]?.length ?? 0);
   const before = input.slice(0, prefixStart);
-  const newInput = before + suggestion.displayText + ' ' + input.slice(cursorOffset);
+  const afterCursor = input.slice(cursorOffset);
+  const afterToken = afterCursor.slice(afterCursor.match(tailRe)?.[0].length ?? 0);
+  const hasExistingSeparator = /^\s/.test(afterToken);
+  const separator = hasExistingSeparator ? '' : ' ';
+  const newInput = before + suggestion.displayText + separator + afterToken;
   onInputChange(newInput);
   setCursorOffset(before.length + suggestion.displayText.length + 1);
 }
@@ -1033,13 +1039,13 @@ export function useTypeahead({
       } else if (suggestionType === 'agent' && suggestions.length > 0 && suggestions[index]?.id?.startsWith('dm-')) {
         const suggestion = suggestions[index];
         if (suggestion) {
-          applyTriggerSuggestion(suggestion, input, cursorOffset, DM_MEMBER_RE, onInputChange, setCursorOffset);
+          applyTriggerSuggestion(suggestion, input, cursorOffset, DM_MEMBER_RE, DM_MEMBER_TAIL_RE, onInputChange, setCursorOffset);
           clearSuggestions();
         }
       } else if (suggestionType === 'slack-channel' && suggestions.length > 0) {
         const suggestion = suggestions[index];
         if (suggestion) {
-          applyTriggerSuggestion(suggestion, input, cursorOffset, HASH_CHANNEL_RE, onInputChange, setCursorOffset);
+          applyTriggerSuggestion(suggestion, input, cursorOffset, HASH_CHANNEL_RE, HASH_CHANNEL_TAIL_RE, onInputChange, setCursorOffset);
           clearSuggestions();
         }
       } else if (suggestionType === 'file' && suggestions.length > 0) {
@@ -1210,12 +1216,12 @@ export function useTypeahead({
         clearSuggestions();
       }
     } else if (suggestionType === 'agent' && selectedSuggestion < suggestions.length && suggestion?.id?.startsWith('dm-')) {
-      applyTriggerSuggestion(suggestion, input, cursorOffset, DM_MEMBER_RE, onInputChange, setCursorOffset);
+      applyTriggerSuggestion(suggestion, input, cursorOffset, DM_MEMBER_RE, DM_MEMBER_TAIL_RE, onInputChange, setCursorOffset);
       debouncedFetchFileSuggestions.cancel();
       clearSuggestions();
     } else if (suggestionType === 'slack-channel' && selectedSuggestion < suggestions.length) {
       if (suggestion) {
-        applyTriggerSuggestion(suggestion, input, cursorOffset, HASH_CHANNEL_RE, onInputChange, setCursorOffset);
+        applyTriggerSuggestion(suggestion, input, cursorOffset, HASH_CHANNEL_RE, HASH_CHANNEL_TAIL_RE, onInputChange, setCursorOffset);
         debouncedFetchSlackChannels.cancel();
         clearSuggestions();
       }

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -592,6 +592,57 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('accepting trigger suggestions replaces the whole token at the cursor', async () => {
+    harness.appState.agentNameRegistry.set('Planner', 'agent-planner')
+    harness.appState.tasks = {
+      'agent-planner': { status: 'idle' },
+    }
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      cursorOffset: '@Pla'.length,
+      input: '@Planner now',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'agent',
+        'mid-token agent suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('@Planner now')
+      expect(setCursorOffset).toHaveBeenCalledWith('@Planner '.length)
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      harness.appState.agentNameRegistry = new Map()
+      harness.appState.mcp = {
+        clients: [{ name: 'slack' }],
+        resources: [],
+      }
+      harness.slackSuggestions = [
+        { displayText: '#general', id: 'slack-general', description: 'channel' },
+      ]
+      rendered.rerender({
+        cursorOffset: '#gen'.length,
+        input: '#general now',
+      })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'slack-channel',
+        'mid-token Slack suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('#general now')
+      expect(setCursorOffset).toHaveBeenCalledWith('#general '.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('handles directory command completion and resume title execution', async () => {
     harness.directorySuggestions = [
       {


### PR DESCRIPTION
## Summary
- replace the full teammate or Slack trigger token when accepting a suggestion with the cursor inside the token
- preserve following text without leaving the old token suffix or duplicating an existing separator
- add a regression covering mid-token `@` and `#` accepts

## Test plan
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx -t \"accepting trigger suggestions replaces the whole token at the cursor\"
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/hooks/useTypeahead.tsx' --coverage.reportsDirectory=coverage/typeahead-trigger-token
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known unrelated backlog: 30 unused exports, 4 tag hints)