### PR TITLE
fix(tui): mark mcp event log completions

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -749,7 +749,11 @@ export function installElicitationResolvers(session: Pick<AgenCTuiElicitationSes
   };
   const unsubscribeCompletion = session.eventLog?.subscribe(event => {
     if (event.msg.type !== "mcp_elicitation_complete") return;
-    completeMcpUrl(event.msg.payload.serverName, event.msg.payload.elicitationId);
+    const payload = event.msg.payload;
+    if (typeof payload?.serverName !== "string" || (typeof payload.elicitationId !== "string" && typeof payload.elicitationId !== "number")) {
+      return;
+    }
+    completeMcpUrl(payload.serverName, payload.elicitationId, createMcpUrlCompletionResponse());
   });
   return {
     submit(value) {

--- a/runtime/tests/tui/coverage-swarm/swarm-002-components-App.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-002-components-App.test.tsx
@@ -5,6 +5,7 @@ import type {
   McpPrimitiveSchemaDefinition,
   RequestUserInputEvent,
 } from "../../elicitation/types.js";
+import { isMcpUrlCompletionResponse } from "../../elicitation/url-completion.js";
 import { getCommandQueue, resetCommandQueue } from "../../utils/messageQueueManager.js";
 import {
   createElicitationQueue,
@@ -261,7 +262,7 @@ describe("App coverage swarm row 002", () => {
       | ((event: {
           msg: {
             type?: unknown;
-            payload: { serverName: string; elicitationId: string };
+            payload?: { serverName?: unknown; elicitationId?: unknown };
           };
         }) => void)
       | undefined;
@@ -317,6 +318,16 @@ describe("App coverage swarm row 002", () => {
     await Promise.resolve();
     expect(resolved).toBe(false);
 
+    expect(() => {
+      eventListener?.({
+        msg: {
+          type: "mcp_elicitation_complete",
+        },
+      });
+    }).not.toThrow();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
     eventListener?.({
       msg: {
         type: "mcp_elicitation_complete",
@@ -324,7 +335,9 @@ describe("App coverage swarm row 002", () => {
       },
     });
 
-    await expect(pendingUrl).resolves.toEqual({ action: "accept" });
+    const completionResponse = await pendingUrl;
+    expect(completionResponse).toEqual({ action: "accept" });
+    expect(isMcpUrlCompletionResponse(completionResponse)).toBe(true);
     expect(prompted.at(-1)).toBeNull();
 
     controller.cleanup();


### PR DESCRIPTION
## Summary
- guard MCP event-log completion payloads before resolving pending URL prompts
- resolve event-log MCP URL completions with the completion marker so daemon sessions do not send duplicate responses
- add regression coverage for malformed completion events and completion-marker preservation

## Test plan
- `npx vitest run tests/tui/coverage-swarm/swarm-002-components-App.test.tsx -t "resolvers handle pre-aborted signals"`
- `npx vitest run tests/tui/coverage-swarm/swarm-002-components-App.test.tsx tests/tui/components/App.coverage2.test.tsx tests/tui/components/App.wave200-002.coverage.test.tsx tests/tui/components/App.render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/components/App.tsx" --coverage.reportsDirectory=coverage/app-mcp-completion-marker`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (fails on known unrelated baseline: 30 unused exports, 4 tag hints)