### PR TITLE
fix(tui): clear custom select initial input

### DIFF
--- a/runtime/src/tui/components/CustomSelect/select.tsx
+++ b/runtime/src/tui/components/CustomSelect/select.tsx
@@ -237,7 +237,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
     t7 = () => {
       const initialMap = new Map<T, string>();
       options.forEach(option => {
-        if (option.type === "input" && option.initialValue) {
+        if (option.type === "input" && option.initialValue !== undefined) {
           initialMap.set(option.value, option.initialValue);
         }
       });
@@ -262,10 +262,10 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
   if ($[3] !== inputValues || $[4] !== options) {
     t9 = () => {
       for (const option_0 of options) {
-        if (option_0.type === "input" && option_0.initialValue !== undefined) {
+        if (option_0.type === "input") {
           const lastInitial = lastInitialValues.current.get(option_0.value) ?? "";
           const currentValue = inputValues.get(option_0.value) ?? "";
-          const newInitial = option_0.initialValue;
+          const newInitial = option_0.initialValue ?? "";
           if (newInitial !== lastInitial && currentValue === lastInitial) {
             setInputValues((prev: Map<T, string>) => {
               const next = new Map(prev);

--- a/runtime/tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx
@@ -69,7 +69,7 @@ async function waitForRender(): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, 30))
 }
 
-function inputOption(initialValue: string): OptionWithDescription<string> {
+function inputOption(initialValue?: string): OptionWithDescription<string> {
   return {
     type: 'input',
     value: 'prompt',
@@ -154,6 +154,25 @@ describe('Select input initial value coverage', () => {
       expect(selectInputHookMock.props?.inputValues?.get('prompt')).toBe(
         'draft two',
       )
+
+      await view.rerender(
+        <Select
+          options={[inputOption()]}
+          defaultFocusValue="prompt"
+        />,
+      )
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('')
+      expect(selectInputHookMock.props?.inputValues?.get('prompt')).toBe('')
+
+      await view.rerender(
+        <Select
+          options={[inputOption('draft three')]}
+          defaultFocusValue="prompt"
+        />,
+      )
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('draft three')
 
       latestInputOption().onInputChange('user override')
       await waitForRender()


### PR DESCRIPTION
## Summary
- clear untouched CustomSelect input state when a parent removes an input option initialValue
- keep user-overridden input values from being overwritten by later initialValue changes
- add a regression covering defined-to-undefined initial value sync and re-sync after clearing

## Test plan
- `npx vitest run tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx -t "syncs changed initial values"`
- `npx vitest run tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/components/CustomSelect/select.coverage2.test.tsx tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx tests/tui/components/CustomSelect/select.render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/components/CustomSelect/select.tsx" --coverage.reportsDirectory=coverage/custom-select-initial-clear`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (fails on known unrelated baseline: 30 unused exports, 4 tag hints)