### PR TITLE
fix(tui): ignore stale background task detail id

### DIFF
--- a/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
+++ b/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
@@ -432,7 +432,7 @@ export function BackgroundTasksPanel({
     () => initialDetailTaskId ?? sorted[0]?.id ?? null,
   );
   const [showDetail, setShowDetail] = React.useState(
-    () => Boolean(initialDetailTaskId),
+    () => Boolean(initialDetailTaskId && sorted.some((task) => task.id === initialDetailTaskId)),
   );
   const [detailIndex, setDetailIndex] = React.useState(0);
   const [shellOutputTails, setShellOutputTails] = React.useState<
@@ -443,6 +443,9 @@ export function BackgroundTasksPanel({
       setSelectedTaskId(initialDetailTaskId);
       setShowDetail(true);
       return;
+    }
+    if (initialDetailTaskId) {
+      setShowDetail(false);
     }
     setSelectedTaskId((current) =>
       current && sorted.some((task) => task.id === current)

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.test.tsx
@@ -170,6 +170,28 @@ describe('BackgroundTasksPanel', () => {
     expect(output).toContain('← back')
   })
 
+  it('falls back to the task list when the requested detail task no longer exists', async () => {
+    appStateMock.state = {
+      tasks: {
+        b1: makeShellTask(),
+        r1: makeRemoteTask(),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="missing-task" />,
+      100,
+    )
+
+    expect(output).toContain('BACKGROUND TASKS')
+    expect(output).toContain('b1')
+    expect(output).toContain('r1')
+    expect(output).not.toContain('TASK DETAIL')
+    expect(output).not.toContain('← back')
+  })
+
   it('keeps terminal background tasks visible while the dialog is open', async () => {
     appStateMock.state = {
       tasks: {


### PR DESCRIPTION
## Summary
- fall back to the background task list when an initial detail task id is no longer present
- avoid opening another task detail surface for stale task ids
- add a regression covering missing initial detail ids

## Test plan
- npx vitest run tests/tui/components/tasks/BackgroundTasksPanel.test.tsx -t "falls back to the task list"
- npx vitest run tests/tui/components/tasks/BackgroundTasksPanel.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage2.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.wave200-017.coverage.test.tsx tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/components/tasks/BackgroundTasksPanel.tsx" --coverage.reportsDirectory=coverage/background-tasks-stale-detail
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known unrelated baseline: 30 unused exports, 4 tag hints)