### PR TITLE
fix(tui): keep retained agent footer selectable

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -812,7 +812,7 @@ function PromptInput({
   // Panel shows retained-completed agents too (getVisibleAgentTasks), so the
   // pill must stay navigable whenever the panel has rows — not just when
   // something is running.
-  const tasksFooterVisible = runningTaskCount > 0 && !shouldHideTasksFooter(tasks, showSpinnerTree);
+  const tasksFooterVisible = (runningTaskCount > 0 || coordinatorTaskCount > 0) && !shouldHideTasksFooter(tasks, showSpinnerTree);
   const teamsFooterVisible = cachedTeams.length > 0;
   const footerItems = useMemo(() => [tasksFooterVisible && 'tasks', teamsFooterVisible && 'teams'].filter(Boolean) as FooterItem[], [tasksFooterVisible, teamsFooterVisible]);
 

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1804,6 +1804,28 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('keeps completed coordinator agent rows selectable after background status ends', async () => {
+    harness.appState.tasks = {
+      agent1: { id: 'agent-1', type: 'local_agent', status: 'completed' },
+    }
+    harness.appState.footerSelection = 'tasks'
+    harness.appState.coordinatorTaskIndex = 1
+    harness.coordinatorTaskCount = 2
+    harness.visibleAgentTasks = [{ id: 'agent-1', status: 'completed' }]
+
+    const rendered = await renderPromptInput({ input: 'follow up' })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      expect(baseProps.focus).toBe(false)
+      await sleep(25)
+      expect(harness.appState.footerSelection).toBe('tasks')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('types through selected footer and handles help escape shortcuts', async () => {
     harness.isBackgroundTask.mockImplementation(
       task => (task as { background?: boolean }).background === true,


### PR DESCRIPTION
## Summary
- keep the tasks footer target active while coordinator agent rows are still visible
- preserve row selection and prompt focus behavior after a background agent task transitions out of running status
- add a regression for completed retained coordinator agent rows

## Test plan
- npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "keeps completed coordinator agent rows selectable"
- npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/components/PromptInput/PromptInput.tsx" --coverage.reportsDirectory=coverage/prompt-input-retained-agent-footer
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known unrelated baseline: 30 unused exports, 4 tag hints)