### PR TITLE
fix(tui): accept numeric mcp completion ids

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -784,7 +784,7 @@ export function subscribeToMcpUrlCompletions(session: Partial<Pick<AgenCTuiElici
         readonly elicitationId?: unknown;
       };
     };
-    if (record.type !== "mcp_elicitation_complete" || typeof record.payload?.serverName !== "string" || typeof record.payload.elicitationId !== "string") {
+    if (record.type !== "mcp_elicitation_complete" || typeof record.payload?.serverName !== "string" || (typeof record.payload.elicitationId !== "string" && typeof record.payload.elicitationId !== "number")) {
       return;
     }
     controller.completeMcpUrl(record.payload.serverName, record.payload.elicitationId, createMcpUrlCompletionResponse());

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -1020,6 +1020,16 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       expect.objectContaining({ action: "accept" }),
     );
 
+    listener?.({
+      type: "mcp_elicitation_complete",
+      payload: { serverName: "srv", elicitationId: 42 },
+    });
+    expect(completeMcpUrl).toHaveBeenCalledWith(
+      "srv",
+      42,
+      expect.objectContaining({ action: "accept" }),
+    );
+
     stop();
     expect(unsubscribe).toHaveBeenCalledTimes(1);
     expect(


### PR DESCRIPTION
## Summary
- accept numeric MCP elicitation ids from the session event completion path
- keep the session event path aligned with the event-log MCP completion resolver
- add a regression for numeric `mcp_elicitation_complete` ids

## Test plan
- npx vitest run tests/tui/components/App.render.test.tsx -t "subscribes to MCP URL completion events from session events"
- npx vitest run tests/tui/components/App.render.test.tsx tests/tui/components/App.coverage2.test.tsx tests/tui/components/App.local-agents.test.tsx tests/tui/components/App.wave200-002.coverage.test.tsx tests/tui/parity/App.no-runningtoolprogress.parity.test.tsx tests/tui/parity/App.tooljsx-gating.parity.test.tsx tests/tui/parity/App.tooljsx-state.parity.test.tsx tests/tui/parity/App.streaming-tool-use.parity.test.tsx tests/tui/coverage-swarm/swarm-002-components-App.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/components/App.tsx" --coverage.reportsDirectory=coverage/app-numeric-mcp-completion
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known unrelated baseline: 30 unused exports, 4 tag hints)