### PR TITLE
fix(tui): keep shell completion after whitespace boundaries

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -157,8 +157,8 @@ export function formatReplacementValue(options: {
  */
 export function applyShellSuggestion(suggestion: SuggestionItem, input: string, cursorOffset: number, onInputChange: (value: string) => void, setCursorOffset: (offset: number) => void, completionType: ShellCompletionType | undefined): void {
   const beforeCursor = input.slice(0, cursorOffset);
-  const lastSpaceIndex = beforeCursor.lastIndexOf(' ');
-  const wordStart = lastSpaceIndex + 1;
+  const currentWord = beforeCursor.match(/\S*$/);
+  const wordStart = currentWord?.index ?? beforeCursor.length;
 
   // Prepare the replacement text based on completion type
   let replacementText: string;

--- a/runtime/tests/tui/hooks/useTypeahead.test.ts
+++ b/runtime/tests/tui/hooks/useTypeahead.test.ts
@@ -218,6 +218,23 @@ describe('applyShellSuggestion', () => {
     expect(setCursorOffset).toHaveBeenCalledWith('echo $PATH '.length);
   });
 
+  it('treats shell whitespace as word boundaries', () => {
+    const onInputChange = vi.fn();
+    const setCursorOffset = vi.fn();
+
+    applyShellSuggestion(
+      { id: 'PATH', displayText: 'PATH' },
+      'echo\tPA',
+      'echo\tPA'.length,
+      onInputChange,
+      setCursorOffset,
+      'variable',
+    );
+
+    expect(onInputChange).toHaveBeenCalledWith('echo\t$PATH ');
+    expect(setCursorOffset).toHaveBeenCalledWith('echo\t$PATH '.length);
+  });
+
   it('leaves default path completions unspaced', () => {
     const onInputChange = vi.fn();
     const setCursorOffset = vi.fn();


### PR DESCRIPTION
## Summary
- Treat tabs and other shell whitespace as completion word boundaries in `applyShellSuggestion`
- Add a regression test for tab-separated bash input so completions preserve the command prefix

## Tests
- `npx vitest run tests/tui/hooks/useTypeahead.test.ts`
- `npx vitest run tests/tui/hooks/useTypeahead.test.ts tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/coverage-swarm/swarm-191-hooks-typeaheadTokens.test.ts`
- `npm run typecheck`
- `npm run test:coverage:tui` from `runtime`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Notes
- `npm run check:unused:production` from `runtime` still fails on the existing baseline: 30 unused exports and 4 tag hints.