### PR TITLE
fix(tui): let footer leave final task row

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -848,18 +848,22 @@ function PromptInput({
   function navigateFooter(delta: 1 | -1, exitAtStart = false): boolean {
     if (tasksSelected && !isTeammateMode && coordinatorTaskCount > 0) {
       if (delta > 0) {
-        setCoordinatorTaskIndex(i => Math.min(coordinatorTaskCount - 1, i + 1));
-        return true;
+        if (coordinatorTaskIndex < coordinatorTaskCount - 1) {
+          setCoordinatorTaskIndex(i => Math.min(coordinatorTaskCount - 1, i + 1));
+          return true;
+        }
+        // Already at the last coordinator row; fall through so normal footer
+        // navigation can move to the next visible footer item.
       }
-      if (coordinatorTaskIndex > minCoordinatorIndex) {
+      if (delta < 0 && coordinatorTaskIndex > minCoordinatorIndex) {
         setCoordinatorTaskIndex(i => Math.max(minCoordinatorIndex, i - 1));
         return true;
       }
-      if (exitAtStart) {
+      if (delta < 0 && exitAtStart) {
         selectFooterItem(null);
         return true;
       }
-      return false;
+      if (delta < 0) return false;
     }
 
     const idx = footerItemSelected ? footerItems.indexOf(footerItemSelected) : -1;

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1826,6 +1826,40 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('moves from the last coordinator task row to the next footer item', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.appState.teamContext = {
+      teamName: 'runtime',
+      teammates: {
+        builder: { color: 'cyan', name: 'builder' },
+        'team-lead': { color: 'purple', name: 'team-lead' },
+      },
+    }
+    harness.appState.footerSelection = 'tasks'
+    harness.appState.coordinatorTaskIndex = 1
+    harness.coordinatorTaskCount = 2
+    harness.visibleAgentTasks = [{ id: 'agent-1', status: 'running' }]
+
+    const rendered = await renderPromptInput({ input: 'footer' })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['footer:next']?.()
+
+      expect(harness.appState.coordinatorTaskIndex).toBe(1)
+      expect(harness.appState.footerSelection).toBe('teams')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('types through selected footer and handles help escape shortcuts', async () => {
     harness.isBackgroundTask.mockImplementation(
       task => (task as { background?: boolean }).background === true,


### PR DESCRIPTION
## Summary
- Let footer forward navigation fall through when the selected coordinator task row is already the last row
- Add a regression covering movement from the final task row to the Teams footer item

## Tests
- `npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "moves from the last coordinator task row"`
- `npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx tests/tui/components/PromptInput/PromptInputFooter.render.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx`
- `npm run typecheck`
- `npm run test:coverage:tui` from `runtime`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Notes
- `npm run check:unused:production` from `runtime` still fails on the existing unrelated baseline: 30 unused exports and 4 tag hints.