### PR TITLE
fix(tui): stabilize transcript fallback event keys

### DIFF
--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -77,6 +77,8 @@ export interface AdaptedTranscript {
 const SYNTHETIC_MODEL = "agenc";
 const GLOB_NO_FILES_TEXT = "No files found";
 const GLOB_TRUNCATION_PREFIX = "(Results are truncated.";
+const fallbackEventKeys = new WeakMap<SessionTranscriptEvent, string>();
+let fallbackEventKeyCounter = 0;
 
 /**
  * Allow-list of `warning` event causes that are surfaced to the
@@ -450,7 +452,12 @@ function eventKey(event: SessionTranscriptEvent): string {
   try {
     return JSON.stringify(event);
   } catch {
-    return `${event.type}:${Math.random()}`;
+    const existing = fallbackEventKeys.get(event);
+    if (existing !== undefined) return existing;
+    const fallback = `${event.type}:object:${fallbackEventKeyCounter}`;
+    fallbackEventKeyCounter += 1;
+    fallbackEventKeys.set(event, fallback);
+    return fallback;
   }
 }
 

--- a/runtime/tests/tui/parity/session-transcript.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.test.ts
@@ -410,6 +410,23 @@ describe("AgenC TUI session transcript", () => {
     expect(transcript.streamingToolUses).toEqual([]);
   });
 
+  test("deduplicates non-serializable fallback events by object identity", () => {
+    const payload: Record<string, unknown> = {
+      cause: "mode_changed",
+      message: "Mode changed",
+    };
+    payload.self = payload;
+    const event = { type: "warning", payload };
+
+    const state = createSessionTranscriptStateForTesting([event, event]);
+    expect(state.events).toHaveLength(1);
+
+    const transcript = adaptTranscriptEvents([event, event]);
+    expect(transcript.messages.map((message) => message.content)).toEqual([
+      "Mode changed",
+    ]);
+  });
+
   test("orders sequenced reset events before adapting transcript boundaries", () => {
     const transcript = adaptTranscriptEvents([
       {


### PR DESCRIPTION
## Summary
- replace random transcript event fallback keys with WeakMap-backed object identity keys
- cover duplicate circular warning events through reducer state and direct transcript adaptation

## Test plan
- npx vitest run tests/tui/parity/session-transcript.test.ts -t "deduplicates non-serializable fallback events"
- npx vitest run tests/tui/parity/session-transcript.test.ts tests/tui/parity/session-transcript.contract.test.ts tests/tui/parity/session-transcript.thinking.parity.test.ts tests/tui/parity/session-transcript.streaming-tool-use.parity.test.ts tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts tests/tui/session-transcript.coverage2.test.ts tests/tui/session-transcript.wave200-003.coverage.test.ts
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing unrelated Knip baseline: 30 unused exports, 4 tag hints)