### PR TITLE
fix(tui): keep vim normal cursor on graphemes

### DIFF
--- a/runtime/src/tui/hooks/useVimInput.ts
+++ b/runtime/src/tui/hooks/useVimInput.ts
@@ -71,13 +71,14 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
     // (unless at beginning of line or at offset 0)
     const offset = textInput.offset
     if (offset > 0 && textInput.value[offset - 1] !== '\n') {
-      textInput.setOffset(offset - 1)
+      const cursor = TextCursor.fromText(textInput.value, props.columns, offset)
+      textInput.setOffset(cursor.left().offset)
     }
 
     vimStateRef.current = { mode: 'NORMAL', command: { type: 'idle' } }
     setMode('NORMAL')
     onModeChange?.('NORMAL')
-  }, [onModeChange, textInput])
+  }, [onModeChange, props.columns, textInput])
 
   function createOperatorContext(
     cursor: TextCursor,

--- a/runtime/tests/tui/hooks/useVimInput.coverage.test.ts
+++ b/runtime/tests/tui/hooks/useVimInput.coverage.test.ts
@@ -224,4 +224,24 @@ describe('useVimInput coverage', () => {
       await rendered.dispose()
     }
   })
+
+  test('leaves insert mode on a grapheme boundary before normal edits', async () => {
+    const rendered = await renderHookHarness()
+
+    try {
+      await rendered.send('😀')
+      expect(rendered.latest().value).toBe('😀')
+      expect(rendered.latest().offset).toBe('😀'.length)
+
+      await rendered.send('', { escape: true })
+      expect(rendered.latest().mode).toBe('NORMAL')
+      expect(rendered.latest().offset).toBe(0)
+
+      await rendered.send('x')
+      expect(rendered.latest().value).toBe('')
+      expect(rendered.latest().offset).toBe(0)
+    } finally {
+      await rendered.dispose()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- move Vim insert-to-normal cursor adjustment through TextCursor.left()
- prevent normal-mode edits from landing inside multi-code-unit graphemes
- cover emoji insert, Escape, and normal-mode delete behavior

## Test plan
- npx vitest run tests/tui/hooks/useVimInput.coverage.test.ts -t "leaves insert mode on a grapheme boundary"
- npx vitest run tests/tui/hooks/useVimInput.coverage.test.ts tests/tui/hooks/useVimInput.wave200-062.coverage.test.ts tests/tui/coverage-swarm/swarm-033-hooks-useVimInput.test.ts tests/tui/vim/operators.test.ts tests/tui/input/processTextPrompt.test.ts tests/tui/coverage-swarm/swarm-088-input-processTextPrompt.test.ts
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing unrelated Knip baseline: 30 unused exports, 4 tag hints)