### PR TITLE
fix(tui): ignore stale path completions

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -340,7 +340,7 @@ export function useTypeahead({
   // Track previous input to detect actual text changes vs. callback recreations
   const prevInputRef = useRef('');
   // Track the latest path token to discard stale results from path completion
-  const latestPathTokenRef = useRef('');
+  const latestPathTokenRef = useRef<string | null>(null);
   // Track command-argument async lookups to discard stale results.
   const latestCommandDirectoryArgsRef = useRef<string | null>(null);
   const latestResumeTitleArgsRef = useRef<string | null>(null);
@@ -468,6 +468,7 @@ export function useTypeahead({
   const updateSuggestions = useCallback(async (value: string, inputCursorOffset?: number): Promise<void> => {
     // Use provided cursor offset or fall back to ref (avoids dependency on cursorOffset)
     const effectiveCursorOffset = inputCursorOffset ?? cursorOffsetRef.current;
+    latestPathTokenRef.current = null;
     const parsedCommandForInvalidation = mode === 'prompt' && isCommandInput(value) ? extractCommandNameAndArgs(value) : null;
     if (parsedCommandForInvalidation?.commandName !== 'add-dir') {
       latestCommandDirectoryArgsRef.current = null;

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -211,7 +211,10 @@ import type { SuggestionItem } from '../components/PromptInput/PromptInputFooter
 import type { PromptInputMode } from '../../types/textInputTypes.js'
 import { useTypeahead } from './useTypeahead.js'
 import { generateUnifiedSuggestions } from './unifiedSuggestions'
-import { getDirectoryCompletions } from '../../utils/suggestions/directoryCompletion.js'
+import {
+  getDirectoryCompletions,
+  getPathCompletions,
+} from '../../utils/suggestions/directoryCompletion.js'
 import { searchSessionsByCustomTitle } from '../../utils/sessionStorage.js'
 
 type SuggestionsState = {
@@ -233,6 +236,7 @@ function sleep(ms: number): Promise<void> {
 
 const generateUnifiedSuggestionsMock = vi.mocked(generateUnifiedSuggestions)
 const getDirectoryCompletionsMock = vi.mocked(getDirectoryCompletions)
+const getPathCompletionsMock = vi.mocked(getPathCompletions)
 const searchSessionsByCustomTitleMock = vi.mocked(searchSessionsByCustomTitle)
 
 function createKey(
@@ -752,6 +756,59 @@ describe('useTypeahead hook paths', () => {
           metadata: { type: 'directory' },
         },
       ])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores stale @ path completions after input leaves the path token', async () => {
+    let resolveSlowPathCompletion: (items: unknown[]) => void = () => {}
+    harness.directoryCompletionResponses.set(
+      '/tm',
+      new Promise(resolve => {
+        resolveSlowPathCompletion = resolve
+      }),
+    )
+    harness.unifiedSuggestions = [
+      {
+        displayText: 'plain.md',
+        id: 'plain.md',
+        description: 'file',
+      },
+    ]
+    const rendered = await renderHookHarness({
+      input: '@/tm',
+      cursorOffset: '@/tm'.length,
+    })
+
+    try {
+      await waitFor(
+        () => getPathCompletionsMock.mock.calls.some(call => call[0] === '/tm'),
+        'initial delayed path completion request',
+      )
+
+      rendered.rerender({
+        input: '@plain',
+        cursorOffset: '@plain'.length,
+      })
+      await waitFor(
+        () =>
+          rendered.getSnapshot().suggestionType === 'file' &&
+          rendered.getSnapshot().suggestions[0]?.id === 'plain.md',
+        'newer file suggestions',
+      )
+
+      resolveSlowPathCompletion([
+        {
+          displayText: '/tmp/project',
+          id: '/tmp/project',
+          metadata: { type: 'directory' },
+        },
+      ])
+      await sleep(50)
+
+      expect(rendered.getSnapshot().suggestionType).toBe('file')
+      expect(rendered.getSnapshot().suggestions[0]?.id).toBe('plain.md')
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
Summary:
- invalidate pending path-completion lookups whenever the current input leaves the path-completion branch
- prevent slow `@/…` completions from overwriting newer file suggestions after the user types a non-path token
- cover a delayed `@/tm` path completion resolving after `@plain` suggestions

Test plan:
- `npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx -t "ignores stale @ path completions after input leaves the path token"`
- `npx vitest run tests/tui/hooks/useTypeahead.test.ts tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/fileSuggestions.test.ts tests/tui/hooks/fileSuggestions.runtime-coverage.test.ts tests/tui/hooks/fileSuggestions.coverage2.test.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (fails on existing unrelated Knip baseline: 30 unused exports, 4 tag hints)