### PR TITLE
fix(tui): honor falsy select focus values

### DIFF
--- a/runtime/src/tui/components/CustomSelect/use-select-navigation.ts
+++ b/runtime/src/tui/components/CustomSelect/use-select-navigation.ts
@@ -537,7 +537,7 @@ export function useSelectNavigation<T>({
     {
       visibleOptionCount,
       options,
-      initialFocusValue: focusValue || initialFocusValue,
+      initialFocusValue: focusValue ?? initialFocusValue,
     } as Parameters<typeof createDefaultState<T>>[0],
     createDefaultState<T>,
   )

--- a/runtime/tests/tui/coverage-swarm/swarm-101-components-CustomSelect-use-select-navigation.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-101-components-CustomSelect-use-select-navigation.test.ts
@@ -30,6 +30,12 @@ type Snapshot = {
   visibleValues: string[]
 }
 
+type NumberSnapshot = {
+  focusedIndex: number
+  focusedValue: number | undefined
+  visibleValues: number[]
+}
+
 function createTestStreams(): TestStreams {
   const stdout = new PassThrough()
   const stdin = new PassThrough() as TestStreams['stdin']
@@ -61,6 +67,16 @@ function snapshotOf(navigation: SelectNavigation<string>): Snapshot {
     isInInput: navigation.isInInput,
     visibleFromIndex: navigation.visibleFromIndex,
     visibleToIndex: navigation.visibleToIndex,
+    visibleValues: navigation.visibleOptions.map(option => option.value),
+  }
+}
+
+function numberSnapshotOf(
+  navigation: SelectNavigation<number>,
+): NumberSnapshot {
+  return {
+    focusedIndex: navigation.focusedIndex,
+    focusedValue: navigation.focusedValue,
     visibleValues: navigation.visibleOptions.map(option => option.value),
   }
 }
@@ -99,6 +115,50 @@ async function waitForNavigation(
   )
 }
 
+async function waitForNumberNavigation(
+  controlsRef: { current: SelectNavigation<number> | null },
+  expected: Partial<NumberSnapshot & Pick<Snapshot, 'visibleFromIndex' | 'visibleToIndex'>>,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    const current = controlsRef.current
+    if (current) {
+      const snapshot = {
+        ...numberSnapshotOf(current),
+        visibleFromIndex: current.visibleFromIndex,
+        visibleToIndex: current.visibleToIndex,
+      }
+      const matches = Object.entries(expected).every(([key, value]) => {
+        const actual = snapshot[key as keyof typeof snapshot]
+        return Array.isArray(value)
+          ? JSON.stringify(actual) === JSON.stringify(value)
+          : actual === value
+      })
+
+      if (matches) {
+        return
+      }
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+
+  const latest = controlsRef.current
+    ? {
+        ...numberSnapshotOf(controlsRef.current),
+        visibleFromIndex: controlsRef.current.visibleFromIndex,
+        visibleToIndex: controlsRef.current.visibleToIndex,
+      }
+    : null
+  throw new Error(
+    `Timed out waiting for numeric select navigation ${JSON.stringify({
+      expected,
+      latest,
+    })}`,
+  )
+}
+
 function Harness({
   controlsRef,
   focusValue,
@@ -121,6 +181,33 @@ function Harness({
     options: optionItems,
     visibleOptionCount,
   })
+
+  return null
+}
+
+function NumberHarness({
+  controlsRef,
+  focusSnapshots,
+  focusValue,
+  onFocus,
+  optionItems,
+  visibleOptionCount,
+}: {
+  controlsRef: { current: SelectNavigation<number> | null }
+  focusSnapshots: NumberSnapshot[]
+  focusValue?: number
+  onFocus?: (value: number) => void
+  optionItems: OptionWithDescription<number>[]
+  visibleOptionCount?: number
+}): null {
+  const navigation = useSelectNavigation({
+    focusValue,
+    onFocus,
+    options: optionItems,
+    visibleOptionCount,
+  })
+  controlsRef.current = navigation
+  focusSnapshots.push(numberSnapshotOf(navigation))
 
   return null
 }
@@ -158,6 +245,44 @@ async function renderNavigation(
       stdout.end()
     },
     rerender: render,
+  }
+}
+
+async function renderNumberNavigation(
+  props: Omit<
+    React.ComponentProps<typeof NumberHarness>,
+    'controlsRef' | 'focusSnapshots'
+  >,
+): Promise<{
+  controlsRef: { current: SelectNavigation<number> | null }
+  dispose: () => void
+  focusSnapshots: NumberSnapshot[]
+}> {
+  const controlsRef = { current: null as SelectNavigation<number> | null }
+  const focusSnapshots: NumberSnapshot[] = []
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(
+    React.createElement(NumberHarness, {
+      ...props,
+      controlsRef,
+      focusSnapshots,
+    }),
+  )
+
+  return {
+    controlsRef,
+    focusSnapshots,
+    dispose: () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    },
   }
 }
 
@@ -307,6 +432,39 @@ describe('useSelectNavigation coverage swarm row 101', () => {
         visibleToIndex: 0,
         visibleValues: [],
       })
+    } finally {
+      rendered.dispose()
+    }
+  })
+
+  test('honors falsy controlled focus values on the initial render', async () => {
+    const onFocus = vi.fn()
+    const rendered = await renderNumberNavigation({
+      focusValue: 0,
+      onFocus,
+      optionItems: [
+        { value: 1, label: 'one' },
+        { value: 0, label: 'zero' },
+        { value: 2, label: 'two' },
+      ],
+      visibleOptionCount: 2,
+    })
+
+    try {
+      await waitForNumberNavigation(rendered.controlsRef, {
+        focusedIndex: 2,
+        focusedValue: 0,
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+        visibleValues: [1, 0],
+      })
+
+      expect(rendered.focusSnapshots[0]).toEqual({
+        focusedIndex: 2,
+        focusedValue: 0,
+        visibleValues: [1, 0],
+      })
+      expect(onFocus.mock.calls.map(([value]) => value)).toEqual([0])
     } finally {
       rendered.dispose()
     }


### PR DESCRIPTION
Summary:
- initialize CustomSelect navigation with `focusValue ?? initialFocusValue` so valid falsy values are not discarded
- prevent controlled numeric focus values like `0` from first rendering the wrong row and firing a wrong focus notification
- cover the first-render controlled focus path with number-valued select options

Test plan:
- `npx vitest run tests/tui/coverage-swarm/swarm-101-components-CustomSelect-use-select-navigation.test.ts -t "honors falsy controlled focus values on the initial render"`
- `npx vitest run tests/tui/coverage-swarm/swarm-101-components-CustomSelect-use-select-navigation.test.ts tests/tui/coverage-swarm/swarm-241-components-CustomSelect-use-select-state.test.ts tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts tests/tui/components/CustomSelect/use-select-input.wave200-034.coverage.test.ts tests/tui/components/CustomSelect/select.render.test.tsx tests/tui/components/CustomSelect/select.coverage2.test.tsx tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx`
- `git diff --check`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (fails on existing unrelated Knip baseline: 30 unused exports, 4 tag hints)