### PR TITLE
fix(tui): use ascii shell time separator

### DIFF
--- a/runtime/src/tui/components/shell/ShellTimeDisplay.tsx
+++ b/runtime/src/tui/components/shell/ShellTimeDisplay.tsx
@@ -4,6 +4,7 @@ import { c as _c } from "react-compiler-runtime";
 import React from 'react';
 import { Text } from '../../ink.js';
 import { formatDuration } from '../../../utils/format.js'; // upstream-import: keep target is owned by another Z-PURGE item
+import { selectAgenCTuiGlyphs } from '../../glyphs.js';
 type Props = {
   elapsedTimeSeconds?: number;
   timeoutMs?: number;
@@ -51,7 +52,8 @@ export function ShellTimeDisplay(t0) {
   }
   const elapsed = t3;
   if (timeout) {
-    const t4 = `(${elapsed} · timeout ${timeout})`;
+    const separator = selectAgenCTuiGlyphs().separator;
+    const t4 = `(${elapsed} ${separator} timeout ${timeout})`;
     let t5;
     if ($[6] !== t4) {
       t5 = <Text dimColor={true}>{t4}</Text>;

--- a/runtime/tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx
@@ -1,10 +1,20 @@
 import React from "react";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import { ShellTimeDisplay } from "../../../src/tui/components/shell/ShellTimeDisplay.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
 describe("ShellTimeDisplay coverage swarm row 151", () => {
+  const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+  });
+
   test("renders nothing when neither elapsed time nor timeout is available", async () => {
     const output = await renderToString(<ShellTimeDisplay />);
 
@@ -34,5 +44,16 @@ describe("ShellTimeDisplay coverage swarm row 151", () => {
 
     expect(output).toContain("(1m 5s");
     expect(output).toContain("timeout 2m)");
+  });
+
+  test("uses the ASCII separator in elapsed timeout metadata when glyphs are ASCII", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderToString(
+      <ShellTimeDisplay elapsedTimeSeconds={65} timeoutMs={120_000} />,
+    );
+
+    expect(output).toBe("(1m 5s - timeout 2m)");
+    expect(output).not.toContain("·");
   });
 });


### PR DESCRIPTION
Summary:
- render shell elapsed+timeout metadata with the shared TUI glyph separator
- prevent `AGENC_TUI_GLYPHS=ascii` shell progress timing text from leaking the Unicode middle dot
- cover elapsed+timeout ShellTimeDisplay output in ASCII glyph mode

Test plan:
- `npx vitest run tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx -t "uses the ASCII separator"`
- `npx vitest run tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx tests/tui/coverage-swarm/swarm-074-components-shell-ShellProgressMessage.test.tsx tests/tui/components/shell/ShellProgressMessage.coverage.test.tsx tests/tui/components/shell/ShellProgressMessage.wave200-104.coverage.test.tsx`
- `git diff --check`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (fails on existing unrelated Knip baseline: 30 unused exports, 4 tag hints)