### PR TITLE
fix(tui): resolve legacy gray theme colors

### DIFF
--- a/runtime/src/tui/components/design-system/ThemedBox.tsx
+++ b/runtime/src/tui/components/design-system/ThemedBox.tsx
@@ -7,18 +7,19 @@ import type { DOMElement } from '../../ink/dom.js';
 import type { ClickEvent } from '../../ink/events/click-event.js';
 import type { FocusEvent } from '../../ink/events/focus-event.js';
 import type { KeyboardEvent } from '../../ink/events/keyboard-event.js';
-import type { Color, Styles } from '../../ink/styles.js';
-import { getTheme, type Theme } from '../../../utils/theme.js'; // upstream-import: keep target is owned by another Z-PURGE item
+import type { Styles } from '../../ink/styles.js';
+import { getTheme } from '../../../utils/theme.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { useTheme } from './ThemeProvider';
+import { resolveThemedColor, type ThemedColor } from './resolveThemedColor.js';
 
 // Color props that accept theme keys
 type ThemedColorProps = {
-  readonly borderColor?: keyof Theme | Color;
-  readonly borderTopColor?: keyof Theme | Color;
-  readonly borderBottomColor?: keyof Theme | Color;
-  readonly borderLeftColor?: keyof Theme | Color;
-  readonly borderRightColor?: keyof Theme | Color;
-  readonly backgroundColor?: keyof Theme | Color;
+  readonly borderColor?: ThemedColor;
+  readonly borderTopColor?: ThemedColor;
+  readonly borderBottomColor?: ThemedColor;
+  readonly borderLeftColor?: ThemedColor;
+  readonly borderRightColor?: ThemedColor;
+  readonly backgroundColor?: ThemedColor;
 };
 
 // Base Styles without color props (they'll be overridden)
@@ -36,19 +37,6 @@ export type Props = BaseStylesWithoutColors & ThemedColorProps & {
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
 };
-
-/**
- * Resolves a color value that may be a theme key to a raw Color.
- */
-function resolveColor(color: keyof Theme | Color | undefined, theme: Theme): Color | undefined {
-  if (!color) return undefined;
-  // Check if it's a raw color (starts with rgb(, #, ansi256(, or ansi:)
-  if (color.startsWith('rgb(') || color.startsWith('#') || color.startsWith('ansi256(') || color.startsWith('ansi:')) {
-    return color as Color;
-  }
-  // It's a theme key - resolve it
-  return theme[color as keyof Theme] as Color;
-}
 
 /**
  * Theme-aware Box component that resolves theme color keys to raw colors.
@@ -103,12 +91,12 @@ function ThemedBoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
   let t1;
   if ($[10] !== backgroundColor || $[11] !== borderBottomColor || $[12] !== borderColor || $[13] !== borderLeftColor || $[14] !== borderRightColor || $[15] !== borderTopColor || $[16] !== themeName) {
     const theme = getTheme(themeName);
-    resolvedBorderColor = resolveColor(borderColor, theme);
-    resolvedBorderTopColor = resolveColor(borderTopColor, theme);
-    resolvedBorderBottomColor = resolveColor(borderBottomColor, theme);
-    resolvedBorderLeftColor = resolveColor(borderLeftColor, theme);
-    resolvedBorderRightColor = resolveColor(borderRightColor, theme);
-    t1 = resolveColor(backgroundColor, theme);
+    resolvedBorderColor = resolveThemedColor(borderColor, theme);
+    resolvedBorderTopColor = resolveThemedColor(borderTopColor, theme);
+    resolvedBorderBottomColor = resolveThemedColor(borderBottomColor, theme);
+    resolvedBorderLeftColor = resolveThemedColor(borderLeftColor, theme);
+    resolvedBorderRightColor = resolveThemedColor(borderRightColor, theme);
+    t1 = resolveThemedColor(backgroundColor, theme);
     $[10] = backgroundColor;
     $[11] = borderBottomColor;
     $[12] = borderColor;

--- a/runtime/src/tui/components/design-system/ThemedText.tsx
+++ b/runtime/src/tui/components/design-system/ThemedText.tsx
@@ -7,15 +7,16 @@ import Text from '../../ink/components/Text.js';
 import type { Color, Styles } from '../../ink/styles.js';
 import { getTheme, type Theme } from '../../../utils/theme.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { useTheme } from './ThemeProvider';
+import { resolveThemedColor, type ThemedColor } from './resolveThemedColor.js';
 
 /** Colors uncolored ThemedText in the subtree. Precedence: explicit `color` >
  *  this > dimColor. Crosses Box boundaries (Ink's style cascade doesn't). */
-export const TextHoverColorContext = React.createContext<keyof Theme | undefined>(undefined);
+export const TextHoverColorContext = React.createContext<ThemedColor | undefined>(undefined);
 export type Props = {
   /**
    * Change text color. Accepts a theme key or raw color value.
    */
-  readonly color?: keyof Theme | Color;
+  readonly color?: ThemedColor;
 
   /**
    * Same as `color`, but for background. Must be a theme key.
@@ -63,19 +64,6 @@ export type Props = {
 };
 
 /**
- * Resolves a color value that may be a theme key to a raw Color.
- */
-function resolveColor(color: keyof Theme | Color | undefined, theme: Theme): Color | undefined {
-  if (!color) return undefined;
-  // Check if it's a raw color (starts with rgb(, #, ansi256(, or ansi:)
-  if (color.startsWith('rgb(') || color.startsWith('#') || color.startsWith('ansi256(') || color.startsWith('ansi:')) {
-    return color as Color;
-  }
-  // It's a theme key - resolve it
-  return theme[color as keyof Theme] as Color;
-}
-
-/**
  * Theme-aware Text component that resolves theme color keys to raw colors.
  * This wraps the base Text component with theme resolution.
  */
@@ -103,7 +91,7 @@ export default function ThemedText(t0) {
   const [themeName] = useTheme();
   const theme = getTheme(themeName);
   const hoverColor = useContext(TextHoverColorContext);
-  const resolvedColor = !color && hoverColor ? resolveColor(hoverColor, theme) : dimColor ? theme.inactive as Color : resolveColor(color, theme);
+  const resolvedColor = !color && hoverColor ? resolveThemedColor(hoverColor, theme) : dimColor ? theme.inactive as Color : resolveThemedColor(color, theme);
   const resolvedBackgroundColor = backgroundColor ? theme[backgroundColor] as Color : undefined;
   let t8;
   if ($[0] !== bold || $[1] !== children || $[2] !== inverse || $[3] !== italic || $[4] !== resolvedBackgroundColor || $[5] !== resolvedColor || $[6] !== strikethrough || $[7] !== underline || $[8] !== wrap) {

--- a/runtime/src/tui/components/design-system/resolveThemedColor.ts
+++ b/runtime/src/tui/components/design-system/resolveThemedColor.ts
@@ -1,0 +1,35 @@
+import type { Color } from '../../ink/styles.js'
+import type { Theme } from '../../../utils/theme.js'
+
+export type LegacyColorName = 'gray' | 'grey'
+export type ThemedColor = keyof Theme | Color | LegacyColorName
+
+const LEGACY_COLOR_ALIASES: Record<LegacyColorName, keyof Theme> = {
+  gray: 'inactive',
+  grey: 'inactive',
+}
+
+function isRawColor(color: string): color is Color {
+  return (
+    color.startsWith('rgb(') ||
+    color.startsWith('#') ||
+    color.startsWith('ansi256(') ||
+    color.startsWith('ansi:')
+  )
+}
+
+function isThemeKey(color: string, theme: Theme): color is keyof Theme {
+  return Object.prototype.hasOwnProperty.call(theme, color)
+}
+
+export function resolveThemedColor(
+  color: ThemedColor | undefined,
+  theme: Theme,
+): Color | undefined {
+  if (!color) return undefined
+  if (isRawColor(color)) return color
+  if (isThemeKey(color, theme)) return theme[color] as Color
+
+  const alias = LEGACY_COLOR_ALIASES[color as LegacyColorName]
+  return alias ? (theme[alias] as Color) : undefined
+}

--- a/runtime/tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx
@@ -175,6 +175,30 @@ describe('ThemedBox coverage swarm row 135', () => {
     })
   })
 
+  test('maps legacy gray color names to the inactive theme color', async () => {
+    const ref = React.createRef<DOMElement>()
+    const theme = getTheme('dark')
+
+    await renderNode(
+      <ThemedBox
+        ref={ref}
+        backgroundColor="grey"
+        borderColor="gray"
+      >
+        legacy gray
+      </ThemedBox>,
+    )
+
+    await waitFor(() => {
+      expect(ref.current).not.toBeNull()
+    })
+
+    expect(ref.current?.style).toMatchObject({
+      backgroundColor: theme.inactive,
+      borderColor: theme.inactive,
+    })
+  })
+
   test('leaves omitted color props undefined while forwarding layout props', async () => {
     const ref = React.createRef<DOMElement>()
 

--- a/runtime/tests/tui/coverage-swarm/swarm-245-components-design-system-ThemedText.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-245-components-design-system-ThemedText.test.tsx
@@ -244,6 +244,20 @@ describe('ThemedText coverage swarm row 245', () => {
     expect(findSegment(segments, 'ansi').styles.color).toBe('ansi:yellow')
   })
 
+  test('maps legacy gray foreground names to the inactive theme color', async () => {
+    const theme = getTheme('dark')
+    const rendered = await renderText(
+      <>
+        <ThemedText color="gray">gray</ThemedText>
+        <ThemedText color="grey">grey</ThemedText>
+      </>,
+    )
+    const segments = rendered.segments()
+
+    expect(findSegment(segments, 'gray').styles.color).toBe(theme.inactive)
+    expect(findSegment(segments, 'grey').styles.color).toBe(theme.inactive)
+  })
+
   test('uses hover context for uncolored text and inactive color for dimmed text', async () => {
     const theme = getTheme('dark')
     const rendered = await renderText(


### PR DESCRIPTION
## Summary
- share themed color resolution between ThemedBox and ThemedText
- map legacy gray/grey color names to the inactive theme color so existing workbench borders and muted labels do not resolve to undefined
- add regression coverage for both themed wrappers

## Test plan
- npm test -- tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx tests/tui/coverage-swarm/swarm-245-components-design-system-ThemedText.test.tsx
- npm test -- tests/tui/workbench/render.test.tsx tests/tui/workbench/agents-rail.test.tsx tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/project-explorer-interactions.test.tsx
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing baseline: 30 unused exports, 4 tag hints)