### PR TITLE
fix(tui): clear autoupdater state after unmount

### DIFF
--- a/runtime/src/tui/components/AutoUpdater.tsx
+++ b/runtime/src/tui/components/AutoUpdater.tsx
@@ -60,8 +60,8 @@ export function AutoUpdater({
   isUpdatingRef.current = isUpdating;
   const checkForUpdates = React.useCallback(async () => {
     let didStartUpdating = false;
-    const stopUpdatingAfterFailure = () => {
-      if (didStartUpdating && mountedRef.current) {
+    const finishStartedUpdate = () => {
+      if (didStartUpdating) {
         onChangeIsUpdating(false);
         didStartUpdating = false;
       }
@@ -117,12 +117,14 @@ export function AutoUpdater({
           await removeInstalledSymlink();
         }
         if (!mountedRef.current) {
+          finishStartedUpdate();
           return;
         }
 
         // Detect actual running installation type
         const installationType = await getCurrentInstallationType();
         if (!mountedRef.current) {
+          finishStartedUpdate();
           return;
         }
         logForDebugging(`AutoUpdater: Detected installation type: ${installationType}`);
@@ -130,8 +132,7 @@ export function AutoUpdater({
         // Skip update for development builds
         if (installationType === 'development') {
           logForDebugging('AutoUpdater: Cannot auto-update development build');
-          onChangeIsUpdating(false);
-          didStartUpdating = false;
+          finishStartedUpdate();
           return;
         }
 
@@ -151,8 +152,7 @@ export function AutoUpdater({
         } else if (installationType === 'native') {
           // This shouldn't happen - native should use NativeAutoUpdater
           logForDebugging('AutoUpdater: Unexpected native installation in non-native updater');
-          onChangeIsUpdating(false);
-          didStartUpdating = false;
+          finishStartedUpdate();
           return;
         } else {
           // Fallback to config-based detection for unknown types
@@ -166,10 +166,10 @@ export function AutoUpdater({
           }
         }
         if (!mountedRef.current) {
+          finishStartedUpdate();
           return;
         }
-        onChangeIsUpdating(false);
-        didStartUpdating = false;
+        finishStartedUpdate();
         if (installStatus === 'success') {
           logEvent('tengu_auto_updater_success', {
             fromVersion: currentVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
@@ -195,7 +195,7 @@ export function AutoUpdater({
       }
     } catch (error) {
       logError(error);
-      stopUpdatingAfterFailure();
+      finishStartedUpdate();
     }
     // isUpdating intentionally omitted from deps; we read isUpdatingRef
     // instead so the guard is always current without changing callback

--- a/runtime/tests/tui/coverage-swarm/swarm-050-components-AutoUpdater.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-050-components-AutoUpdater.test.tsx
@@ -401,6 +401,38 @@ describe("AutoUpdater coverage swarm row 050", () => {
     }
   });
 
+  test("clears the parent updating flag when unmounted after starting an update", async () => {
+    let resolveInstall!: (status: "success") => void;
+    const installPromise = new Promise<"success">(resolve => {
+      resolveInstall = resolve;
+    });
+    harness.getCurrentInstallationType.mockResolvedValue("npm-global");
+    harness.installGlobalPackage.mockReturnValueOnce(installPromise);
+    const onChangeIsUpdating = vi.fn();
+    const rendered = await renderInRoot(
+      <AutoUpdater
+        autoUpdaterResult={null}
+        isUpdating={false}
+        onAutoUpdaterResult={() => {}}
+        onChangeIsUpdating={onChangeIsUpdating}
+        showSuccessMessage={true}
+        verbose={true}
+      />,
+    );
+
+    await waitFor(
+      () => onChangeIsUpdating.mock.calls.some(([value]) => value === true),
+      "update start",
+    );
+    await rendered.cleanup();
+    resolveInstall("success");
+    await sleep(20);
+
+    expect(onChangeIsUpdating).toHaveBeenNthCalledWith(1, true);
+    expect(onChangeIsUpdating).toHaveBeenLastCalledWith(false);
+    expect(harness.logEvent).not.toHaveBeenCalled();
+  });
+
   test("installs with the npm-local path and records migrated success", async () => {
     harness.getCurrentInstallationType.mockResolvedValue("npm-local");
     const rendered = await renderInRoot(<StatefulAutoUpdater />);


### PR DESCRIPTION
## Summary
- clear the parent updating flag on every AutoUpdater return path after an update starts
- cover the mid-update unmount path that previously left `isUpdating` stuck true

## Test plan
- npm test -- tests/tui/coverage-swarm/swarm-050-components-AutoUpdater.test.tsx
- npm test -- tests/tui/components/AutoUpdater.wave200-039.coverage.test.tsx tests/tui/components/AutoUpdater.ascii.test.tsx tests/tui/coverage-swarm/swarm-050-components-AutoUpdater.test.tsx
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing baseline: 30 unused exports, 4 tag hints)