### PR TITLE
fix(tui): guard markdown highlight retry

### DIFF
--- a/runtime/src/tui/components/markdown/HighlightedCodeFallback.tsx
+++ b/runtime/src/tui/components/markdown/HighlightedCodeFallback.tsx
@@ -161,7 +161,11 @@ function Highlighted(t0) {
           logForDebugging(`Language not supported while highlighting code, falling back to markdown: ${e}`);
           let t4;
           if ($[5] !== codeWithSpaces || $[6] !== hl) {
-            t4 = cachedHighlight(hl, codeWithSpaces, "markdown");
+            try {
+              t4 = cachedHighlight(hl, codeWithSpaces, "markdown");
+            } catch {
+              t4 = codeWithSpaces;
+            }
             $[5] = codeWithSpaces;
             $[6] = hl;
             $[7] = t4;

--- a/runtime/tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
@@ -210,6 +210,40 @@ describe('HighlightedCodeFallback coverage swarm row 031', () => {
     )
   })
 
+  test('falls back to unhighlighted code when the markdown retry also fails', async () => {
+    const code = 'let row031_markdown_retry_fails = true;'
+    highlightMock.highlight.mockImplementation(
+      (_receivedCode: string, options: { readonly language: string }) => {
+        if (options.language === 'rs') {
+          throw new Error('Unknown language: rs')
+        }
+        if (options.language === 'markdown') {
+          throw new Error('markdown failed')
+        }
+        return `highlighted:${options.language}:${code}`
+      },
+    )
+
+    const output = await renderToText(
+      <HighlightedCodeFallback code={code} filePath="fixture.rs" />,
+      code,
+      { afterExpected: () => highlightMock.highlight.mock.calls.length >= 2 },
+    )
+
+    expect(output).toContain(code)
+    expect(highlightMock.supportsLanguage).toHaveBeenCalledWith('rs')
+    expect(highlightMock.highlight).toHaveBeenCalledTimes(2)
+    expect(highlightMock.highlight).toHaveBeenNthCalledWith(1, code, {
+      language: 'rs',
+    })
+    expect(highlightMock.highlight).toHaveBeenNthCalledWith(2, code, {
+      language: 'markdown',
+    })
+    expect(highlightMock.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('falling back to markdown: Error: Unknown language: rs'),
+    )
+  })
+
   test('falls back to unhighlighted code when highlighting fails for a non-language reason', async () => {
     const code = 'const row031GenericError = true'
     highlightMock.highlight.mockImplementation(() => {


### PR DESCRIPTION
## Summary
- fall back to raw code when markdown highlighting also fails after an unknown-language retry
- add a regression test for the double-failure highlight path

## Test plan
- npm test -- tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
- npm test -- tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx tests/tui/components/markdown/HighlightedCodeFallback.coverage.test.tsx tests/tui/components/markdown/HighlightedCodeFallback.wave200-080.coverage.test.tsx tests/tui/components/markdown/markdown-rendering.test.tsx
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm run check:unused:production still reports the existing unused-export baseline: 30 unused exports and 4 tag hints