### PR TITLE
fix(tui): clear stale select image focus

### DIFF
--- a/runtime/src/tui/components/CustomSelect/select.tsx
+++ b/runtime/src/tui/components/CustomSelect/select.tsx
@@ -232,6 +232,16 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
   const inlineDescriptions = t6 === undefined ? false : t6;
   const [imagesSelected, setImagesSelected] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  useEffect(() => {
+    if (!imagesSelected) return;
+    const imageCount = pastedContents ? count(Object.values(pastedContents), _temp2) : 0;
+    if (imageCount === 0) {
+      setImagesSelected(false);
+      setSelectedImageIndex(0);
+    } else if (selectedImageIndex >= imageCount) {
+      setSelectedImageIndex(imageCount - 1);
+    }
+  }, [imagesSelected, pastedContents, selectedImageIndex]);
   let t7;
   if ($[0] !== options) {
     t7 = () => {

--- a/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
@@ -175,6 +175,11 @@ describe('Select input option coverage', () => {
               type: 'image',
               content: 'image-bytes',
             },
+            8: {
+              id: 8,
+              type: 'image',
+              content: 'second-image',
+            },
           }}
         />,
       )
@@ -182,10 +187,42 @@ describe('Select input option coverage', () => {
       expect(selectInputHookMock.props?.onEnterImageSelection?.()).toBe(true)
       await waitForRender()
       expect(latestInputOption().imagesSelected).toBe(true)
-      expect(latestInputOption().selectedImageIndex).toBe(0)
+      expect(latestInputOption().selectedImageIndex).toBe(1)
 
       latestInputOption().onSubmit('')
       expect(onChange).toHaveBeenLastCalledWith('prompt')
+
+      await view.rerender(
+        <Select
+          options={options}
+          defaultFocusValue="prompt"
+          onCancel={onCancel}
+          onChange={onChange}
+          pastedContents={{
+            7: {
+              id: 7,
+              type: 'image',
+              content: 'image-bytes',
+            },
+          }}
+        />,
+      )
+      await waitForRender()
+      expect(latestInputOption().imagesSelected).toBe(true)
+      expect(latestInputOption().selectedImageIndex).toBe(0)
+
+      await view.rerender(
+        <Select
+          options={options}
+          defaultFocusValue="prompt"
+          onCancel={onCancel}
+          onChange={onChange}
+          pastedContents={{}}
+        />,
+      )
+      await waitForRender()
+      expect(latestInputOption().imagesSelected).toBe(false)
+      expect(latestInputOption().selectedImageIndex).toBe(0)
     } finally {
       view.unmount()
     }


### PR DESCRIPTION
## Summary
- clear CustomSelect image-selection state when pasted images are removed
- clamp the selected image index when the pasted image list shrinks
- add regression coverage for stale image-selection state after pasted content changes

## Test plan
- npm test -- tests/tui/components/CustomSelect/select.coverage2.test.tsx
- npm test -- tests/tui/components/CustomSelect/select.coverage2.test.tsx tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx tests/tui/components/CustomSelect/select.render.test.tsx tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/components/CustomSelect/select-input-option.render.test.tsx tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx tests/tui/components/CustomSelect/use-select-input.coverage.test.ts tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts tests/tui/components/CustomSelect/use-select-input.wave200-034.coverage.test.ts
- npm test -- tests/tui/components/CustomSelect
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm run check:unused:production still reports the existing unused-export baseline: 30 unused exports and 4 tag hints