### PR TITLE
fix(tui): separate IDE mentions after image pills

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1744,10 +1744,15 @@ function PromptInput({
     } else {
       atMentionedText = `@${relativePath} `;
     }
-    const cursorChar = input[cursorOffset - 1] ?? ' ';
+    // IDE events can arrive before the parent rerenders after a paste, so make
+    // the spacing decision from the same fresh refs used for insertion.
+    const currentInput = lastInternalInputRef.current;
+    const currentOffset = cursorOffsetRef.current;
+    const cursorChar = currentInput[currentOffset - 1] ?? ' ';
     if (!/\s/.test(cursorChar)) {
       atMentionedText = ` ${atMentionedText}`;
     }
+    pendingSpaceAfterPillRef.current = false;
     insertTextAtCursor(atMentionedText);
   };
   useIdeAtMentioned(mcpClients, onIdeAtMentioned);

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1223,6 +1223,42 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('separates IDE mentions after image pills and clears lazy spacing', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'jpeg-data',
+      mediaType: 'image/jpeg',
+    })
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      harness.ideAtMentionedHandler?.({
+        filePath: '/repo/src/file.ts',
+      })
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1] @src/file.ts ')
+
+      const inputFilter = baseProps.inputFilter as (
+        input: string,
+        key: Record<string, boolean>,
+      ) => string
+      expect(inputFilter('caption', {})).toBe('caption')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('allocates image paste IDs after existing draft paste references', async () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue({
       base64: 'png-data',


### PR DESCRIPTION
## Summary
- Fix PromptInput IDE at-mention spacing after an image pill is inserted before the parent rerenders.
- Clear the image-pill lazy-space state after IDE mentions so the next typed word is not prefixed again.
- Add a regression test for image paste followed by an IDE at-mention.

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"separates IDE mentions\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing unused-export baseline)