### PR TITLE
fix(tui): clear image spacing on prompt newline

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1771,11 +1771,9 @@ function PromptInput({
 
   // Handler for chat:newline - insert a newline at the cursor position
   const handleNewline = useCallback(() => {
-    pushToBuffer(input, cursorOffset, pastedContents);
-    const newInput = input.slice(0, cursorOffset) + '\n' + input.slice(cursorOffset);
-    trackAndSetInput(newInput);
-    setCursorOffset(cursorOffset + 1);
-  }, [input, cursorOffset, trackAndSetInput, setCursorOffset, pushToBuffer, pastedContents]);
+    pendingSpaceAfterPillRef.current = false;
+    insertTextAtCursor('\n');
+  }, [insertTextAtCursor]);
 
   // Handler for chat:externalEditor - edit in $EDITOR
   const handleExternalEditor = useCallback(async () => {

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1259,6 +1259,51 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('disarms image pill lazy spacing when newline is inserted', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'jpeg-data',
+      mediaType: 'image/jpeg',
+    })
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      harness.baseProps = undefined
+      rendered.root.render(
+        <PromptInput
+          {...(basePromptInputProps({
+            input: '[Image #1]',
+            onInputChange,
+            pastedContents: pastedContents.current,
+            setPastedContents: pastedContents.setPastedContents,
+          }) as never)}
+        />,
+      )
+      const baseProps = await waitForPromptInputProps()
+
+      harness.keybindings['chat:newline']?.()
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]\n')
+
+      const inputFilter = baseProps.inputFilter as (
+        input: string,
+        key: Record<string, boolean>,
+      ) => string
+      expect(inputFilter('caption', {})).toBe('caption')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('allocates image paste IDs after existing draft paste references', async () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue({
       base64: 'png-data',


### PR DESCRIPTION
## Summary
- Clear pending image-pill lazy spacing when the newline shortcut inserts a line break.
- Route newline insertion through the same ref-based cursor insertion path used by paste/mention insertion.
- Add a regression test for image paste followed by newline and a typed word.

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"disarms image pill\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing unused-export baseline)