### PR TITLE
fix(tui): separate quick search after image pills

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2604,7 +2604,10 @@ function PromptInput({
   }
   if (feature('QUICK_SEARCH')) {
     const insertWithSpacing = (text: string) => {
-      const cursorChar = input[cursorOffset - 1] ?? ' ';
+      const currentInput = lastInternalInputRef.current;
+      const currentOffset = cursorOffsetRef.current;
+      const cursorChar = currentInput[currentOffset - 1] ?? ' ';
+      pendingSpaceAfterPillRef.current = false;
       insertTextAtCursor(/\s/.test(cursorChar) ? text : ` ${text}`);
     };
     if (showQuickOpen) {

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1304,6 +1304,50 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('separates quick-open insertions after image pills', async () => {
+    harness.features.QUICK_SEARCH = true
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'jpeg-data',
+      mediaType: 'image/jpeg',
+    })
+    const onInputChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setHelpOpen,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      harness.keybindings['app:quickOpen']?.()
+      await sleep(25)
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(harness.quickOpenProps).toBeDefined()
+
+      ;(harness.quickOpenProps?.onInsert as (text: string) => void)(
+        '@src/app.ts',
+      )
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1] @src/app.ts')
+
+      const inputFilter = baseProps.inputFilter as (
+        input: string,
+        key: Record<string, boolean>,
+      ) => string
+      expect(inputFilter('caption', {})).toBe('caption')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('allocates image paste IDs after existing draft paste references', async () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue({
       base64: 'png-data',


### PR DESCRIPTION
## Summary
- Fix Quick Open/Global Search insertion spacing after an image pill is inserted before the parent input rerenders.
- Clear pending image-pill lazy spacing when quick-search insertion consumes the next insertion point.
- Add a regression test for image paste followed by Quick Open insertion.

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"separates quick-open\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing unused-export baseline)