### PR TITLE
fix(tui): preserve drafts when popping queued commands

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1737,12 +1737,16 @@ function PromptInput({
 
   // Function to get the queued command for editing. Returns true if commands were popped.
   const popAllCommandsFromQueue = useCallback((): boolean => {
-    const result = popAllEditable(input, cursorOffset);
+    const result = popAllEditable(
+      lastInternalInputRef.current,
+      cursorOffsetRef.current,
+    );
     if (!result) {
       return false;
     }
     trackAndSetInput(result.text);
     onModeChange('prompt'); // Always prompt mode for queued commands
+    cursorOffsetRef.current = result.cursorOffset;
     setCursorOffset(result.cursorOffset);
 
     // Restore images from queued commands to pastedContents
@@ -1758,7 +1762,7 @@ function PromptInput({
       });
     }
     return true;
-  }, [trackAndSetInput, onModeChange, input, cursorOffset, updatePastedContentsAndRef]);
+  }, [trackAndSetInput, onModeChange, updatePastedContentsAndRef]);
 
   // Insert the at-mentioned reference (the file and, optionally, a line range) when
   // we receive an at-mentioned notification the IDE.

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -3,6 +3,7 @@ import { PassThrough } from 'node:stream'
 import React from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { PastedContent } from '../../../utils/config.js'
+import { enqueue, resetCommandQueue } from '../../../utils/messageQueueManager.js'
 
 const harness = vi.hoisted(() => {
   const appState = {
@@ -930,6 +931,7 @@ async function renderPromptInput(overrides: Record<string, unknown> = {}) {
 describe('PromptInput render surface', () => {
   beforeEach(() => {
     harness.reset()
+    resetCommandQueue()
     vi.mocked(getImageFromClipboard).mockReset()
     vi.mocked(getImageFromClipboard).mockResolvedValue(null)
     vi.mocked(cacheImagePath).mockClear()
@@ -1388,6 +1390,51 @@ describe('PromptInput render surface', () => {
       expect(onInputChange).toHaveBeenCalledWith('')
       expect(pastedContents.current).toEqual({})
     } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('pops queued commands after current image paste drafts before parent rerender', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'queued-draft-image',
+      mediaType: 'image/png',
+    })
+    const queuedCommand = {
+      value: 'queued command',
+      mode: 'prompt' as const,
+    }
+    enqueue(queuedCommand)
+    harness.commandQueue = [queuedCommand]
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      ;(baseProps.onHistoryUp as () => void)()
+
+      expect(onInputChange).toHaveBeenCalledWith(
+        'queued command\n[Image #1]',
+      )
+      expect(pastedContents.current).toEqual({
+        1: expect.objectContaining({
+          content: 'queued-draft-image',
+          id: 1,
+          mediaType: 'image/png',
+          type: 'image',
+        }),
+      })
+    } finally {
+      resetCommandQueue()
       await rendered.dispose()
     }
   })


### PR DESCRIPTION
## Summary
- pop editable queued commands from the current PromptInput draft refs instead of stale rendered props
- keep cursor refs synchronized after queue-pop restore
- add regression coverage for image paste drafts followed by queued-command edit before parent rerender

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"pops queued commands after current image paste drafts|stashes image paste drafts\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline failure: 30 unused exports, 4 tag hints; no touched-file findings)