### PR TITLE
fix(tui): buffer current paste drafts

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1188,6 +1188,9 @@ function PromptInput({
     viewingAgentName
   });
   const onChange = useCallback((value: string) => {
+    const currentInput = lastInternalInputRef.current;
+    const currentCursorOffset = cursorOffsetRef.current;
+    const currentPastedContents = pastedContentsRef.current;
     if (value === '?') {
       logEvent('agenc_help_toggled', {});
       setHelpOpen(v => !v);
@@ -1208,22 +1211,23 @@ function PromptInput({
     // `!` in the buffer (issue #662).
     const modeEntry = detectModeEntry({
       value,
-      prevInputLength: input.length,
-      cursorOffset,
+      prevInputLength: currentInput.length,
+      cursorOffset: currentCursorOffset,
     });
     if (modeEntry) {
       onModeChange(modeEntry.mode);
       const cleaned = modeEntry.strippedValue.replaceAll('\t', '    ');
-      pushToBuffer(input, cursorOffset, pastedContents);
+      pushToBuffer(currentInput, currentCursorOffset, currentPastedContents);
       trackAndSetInput(cleaned);
+      cursorOffsetRef.current = cleaned.length;
       setCursorOffset(cleaned.length);
       return;
     }
     const processedValue = value.replaceAll('\t', '    ');
 
     // Push current state to buffer before making changes
-    if (input !== processedValue) {
-      pushToBuffer(input, cursorOffset, pastedContents);
+    if (currentInput !== processedValue) {
+      pushToBuffer(currentInput, currentCursorOffset, currentPastedContents);
     }
 
     // Deselect footer items when user types
@@ -1232,7 +1236,7 @@ function PromptInput({
       footerSelection: null
     });
     trackAndSetInput(processedValue);
-  }, [trackAndSetInput, onModeChange, input, cursorOffset, pushToBuffer, pastedContents, dismissStashHint, setAppState]);
+  }, [trackAndSetInput, onModeChange, pushToBuffer, dismissStashHint, setAppState]);
   const {
     resetHistory,
     onHistoryUp,
@@ -1624,6 +1628,8 @@ function PromptInput({
     // Store image to disk in background
     void storeImage(newContent);
 
+    const bufferPastedContents = pastedContentsRef.current;
+
     // Update UI
     updatePastedContentsAndRef(prev => ({
       ...prev,
@@ -1633,7 +1639,7 @@ function PromptInput({
     // armed, the previous pill's lazy space fires now (before this pill)
     // rather than being lost.
     const prefix = pendingSpaceAfterPillRef.current ? ' ' : '';
-    insertTextAtCursor(prefix + formatImageRef(pasteId));
+    insertTextAtCursor(prefix + formatImageRef(pasteId), bufferPastedContents);
     pendingSpaceAfterPillRef.current = true;
   }
 
@@ -1699,11 +1705,15 @@ function PromptInput({
         type: 'text',
         content: text
       };
+      const bufferPastedContents = pastedContentsRef.current;
       updatePastedContentsAndRef(prev => ({
         ...prev,
         [pasteId]: newContent
       }));
-      insertTextAtCursor(formatPastedTextRef(pasteId, numLines));
+      insertTextAtCursor(
+        formatPastedTextRef(pasteId, numLines),
+        bufferPastedContents,
+      );
     } else {
       // For shorter pastes, just insert the text normally
       insertTextAtCursor(text);
@@ -1720,13 +1730,16 @@ function PromptInput({
   const cursorOffsetRef = useRef(cursorOffset);
   cursorOffsetRef.current = cursorOffset;
 
-  function insertTextAtCursor(text: string) {
+  function insertTextAtCursor(
+    text: string,
+    bufferPastedContents = pastedContentsRef.current,
+  ) {
     // Use refs for input/cursor so back-to-back calls in the same event
     // (e.g. onImagePaste loop for multiple dragged images) chain correctly
     // instead of each reading the same stale closure values.
     const currentInput = lastInternalInputRef.current;
     const currentOffset = cursorOffsetRef.current;
-    pushToBuffer(currentInput, currentOffset, pastedContents);
+    pushToBuffer(currentInput, currentOffset, bufferPastedContents);
     const newInput = currentInput.slice(0, currentOffset) + text + currentInput.slice(currentOffset);
     trackAndSetInput(newInput);
     const newOffset = currentOffset + text.length;
@@ -1810,9 +1823,12 @@ function PromptInput({
   const handleExternalEditor = useCallback(async () => {
     logEvent('agenc_external_editor_used', {});
     setIsExternalEditorActive(true);
+    const currentInput = lastInternalInputRef.current;
+    const currentCursorOffset = cursorOffsetRef.current;
+    const currentPastedContents = pastedContentsRef.current;
     try {
       // Pass pastedContents to expand collapsed text references
-      const result = await editPromptInEditor(input, pastedContents);
+      const result = await editPromptInEditor(currentInput, currentPastedContents);
       if (result.error) {
         addNotification({
           key: 'external-editor-error',
@@ -1821,10 +1837,11 @@ function PromptInput({
           priority: 'high'
         });
       }
-      if (result.content !== null && result.content !== input) {
+      if (result.content !== null && result.content !== currentInput) {
         // Push current state to buffer before making changes
-        pushToBuffer(input, cursorOffset, pastedContents);
+        pushToBuffer(currentInput, currentCursorOffset, currentPastedContents);
         trackAndSetInput(result.content);
+        cursorOffsetRef.current = result.content.length;
         setCursorOffset(result.content.length);
       }
     } catch (err) {
@@ -1840,7 +1857,7 @@ function PromptInput({
     } finally {
       setIsExternalEditorActive(false);
     }
-  }, [input, cursorOffset, pastedContents, pushToBuffer, trackAndSetInput, addNotification]);
+  }, [pushToBuffer, trackAndSetInput, addNotification]);
 
   // Handler for chat:stash - stash/unstash prompt
   const handleStash = useCallback(() => {

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -779,6 +779,7 @@ import { createRoot } from '../../ink/root.js'
 import { getImageFromClipboard } from '../../../utils/imagePaste.js'
 import { cacheImagePath, storeImage } from '../../../utils/imageStore.js'
 import { logError } from '../../../utils/log.js'
+import { editPromptInEditor } from '../../../utils/promptEditor.js'
 import { getDefaultWorkbenchState } from '../../../../src/tui/workbench/reducer.js'
 import PromptInput from './PromptInput.js'
 
@@ -937,6 +938,7 @@ describe('PromptInput render surface', () => {
     vi.mocked(cacheImagePath).mockClear()
     vi.mocked(storeImage).mockClear()
     vi.mocked(logError).mockClear()
+    vi.mocked(editPromptInEditor).mockClear()
   })
 
   test('wires base text input props for the idle prompt surface', async () => {
@@ -1013,7 +1015,7 @@ describe('PromptInput render surface', () => {
       expect(onInputChange).toHaveBeenCalledWith('echo hi')
 
       ;(baseProps.onPaste as (value: string) => void)('short\tpaste')
-      expect(onInputChange).toHaveBeenCalledWith('short    pasteecho hi')
+      expect(onInputChange).toHaveBeenCalledWith('echo hishort    paste')
 
       ;(baseProps.onPaste as (value: string) => void)('x'.repeat(40))
       expect(setPastedContents).toHaveBeenCalled()
@@ -1435,6 +1437,94 @@ describe('PromptInput render surface', () => {
       })
     } finally {
       resetCommandQueue()
+      await rendered.dispose()
+    }
+  })
+
+  test('buffers current image paste contents before newline insertion rerender', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'undo-buffer-image',
+      mediaType: 'image/png',
+    })
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+      harness.pushToBuffer.mockClear()
+
+      harness.keybindings['chat:newline']?.()
+
+      expect(harness.pushToBuffer).toHaveBeenCalledWith(
+        '[Image #1]',
+        '[Image #1]'.length,
+        {
+          1: expect.objectContaining({
+            content: 'undo-buffer-image',
+            id: 1,
+            mediaType: 'image/png',
+            type: 'image',
+          }),
+        },
+      )
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]\n')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('opens external editor with current image paste drafts before parent rerender', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'editor-image',
+      mediaType: 'image/jpeg',
+    })
+    harness.editPromptResult = { content: 'edited image draft', error: null }
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+      harness.pushToBuffer.mockClear()
+
+      await harness.keybindings['chat:externalEditor']?.()
+
+      const expectedPastedContents = {
+        1: expect.objectContaining({
+          content: 'editor-image',
+          id: 1,
+          mediaType: 'image/jpeg',
+          type: 'image',
+        }),
+      }
+      expect(editPromptInEditor).toHaveBeenCalledWith(
+        '[Image #1]',
+        expectedPastedContents,
+      )
+      expect(harness.pushToBuffer).toHaveBeenCalledWith(
+        '[Image #1]',
+        '[Image #1]'.length,
+        expectedPastedContents,
+      )
+      expect(onInputChange).toHaveBeenCalledWith('edited image draft')
+    } finally {
       await rendered.dispose()
     }
   })


### PR DESCRIPTION
## Summary
- buffer PromptInput undo/editor state from current draft refs instead of stale rendered props
- preserve current pasted contents when inserting after image paste before parent rerender
- keep mode-entry cursor refs current so immediate paste appends at the stripped command cursor

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"buffers current image paste contents|opens external editor with current image paste drafts|updates mode, text\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline failure: 30 unused exports, 4 tag hints; no touched-file findings)