### PR TITLE
fix(tui): paste text against current drafts

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1661,6 +1661,8 @@ function PromptInput({
   }, [input, updatePastedContentsAndRef]);
   function onTextPaste(rawText: string) {
     pendingSpaceAfterPillRef.current = false;
+    const currentInput = lastInternalInputRef.current;
+    const currentCursorOffset = cursorOffsetRef.current;
     // Clean up pasted text - strip ANSI escape codes and normalize line endings and tabs
     let text = stripAnsi(rawText).replace(/\r/g, '\n').replaceAll('\t', '    ');
 
@@ -1675,13 +1677,13 @@ function PromptInput({
         .map(p => (p.includes(' ') || p.includes(':') ? `@"${p}"` : `@${p}`))
         .join(' ');
       // Ensure spacing around the mention(s) relative to existing input
-      const charBefore = input[cursorOffset - 1];
+      const charBefore = currentInput[currentCursorOffset - 1];
       const prefix = charBefore && !/\s/.test(charBefore) ? ' ' : '';
       text = prefix + mentions + ' ';
     }
 
     // Match typed/auto-suggest: `!cmd` pasted into empty input enters bash mode.
-    if (input.length === 0) {
+    if (currentInput.length === 0) {
       const pastedMode = getModeFromInput(text);
       if (pastedMode !== 'prompt') {
         onModeChange(pastedMode);

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1529,6 +1529,68 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('separates dragged file mentions after image paste before parent rerender', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'dragged-image',
+      mediaType: 'image/png',
+    })
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      ;(baseProps.onPaste as (value: string) => void)('/dragged/file:b')
+
+      expect(onInputChange).toHaveBeenCalledWith(
+        '[Image #1] @"/dragged/file:b" ',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('does not enter bash mode from text paste after current image drafts', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'bash-paste-image',
+      mediaType: 'image/png',
+    })
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      onModeChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+      onModeChange.mockClear()
+
+      ;(baseProps.onPaste as (value: string) => void)('!echo hi')
+
+      expect(onModeChange).not.toHaveBeenCalledWith('bash')
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]!echo hi')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('allocates image paste IDs after existing draft paste references', async () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue({
       base64: 'png-data',


### PR DESCRIPTION
## Summary
- use the live internal input and cursor refs when handling text paste
- keep dragged file mention spacing correct after image paste before parent rerender
- avoid accidentally entering bash mode when text is pasted after a current image draft

## Tests
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "separates dragged file mentions after image paste|does not enter bash mode from text paste after current image drafts"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing baseline: 30 unused exports, 4 tag hints)

## Coverage
- Statements: 95.71% (33701/35209)
- Branches: 89.82% (24281/27032)
- Functions: 96.09% (4849/5046)
- Lines: 96.58% (31562/32678)