### PR TITLE
fix(tui): submit current paste drafts

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1344,7 +1344,7 @@ function PromptInput({
     }
 
     // Check for images early - we need this for suggestion logic below
-    const hasImages = Object.values(pastedContents).some(c => c.type === 'image');
+    const hasImages = Object.values(pastedContentsRef.current).some(c => c.type === 'image');
 
     // If input is empty OR matches the suggestion, submit it
     // But if there are images attached, don't auto-accept the suggestion -
@@ -1548,7 +1548,7 @@ function PromptInput({
     if (hasWorkbenchAttachments) {
       setAppState(prev => applyWorkbenchCommand(prev, { type: 'clearAttachments' }));
     }
-  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, pastedContents, removeNotification, vimMode, mode, getToolUseContext, messages, mainLoopModel, trackAndSetInput, onModeChange, isLoading, addNotification]);
+  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, removeNotification, vimMode, mode, getToolUseContext, messages, mainLoopModel, trackAndSetInput, onModeChange, isLoading, addNotification]);
   const {
     suggestions,
     selectedSuggestion,
@@ -2185,10 +2185,10 @@ function PromptInput({
       action: 'chat:submit',
       context: 'Chat',
       handler: () => {
-        void onSubmit(input);
+        void onSubmit(lastInternalInputRef.current);
       }
     });
-  }, [keybindingContext, promptKeyboardActive, onSubmit, input]);
+  }, [keybindingContext, promptKeyboardActive, onSubmit]);
 
   // Chat context keybindings for editing shortcuts
   // Note: history:previous/history:next are NOT handled here. They are passed as

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -2423,6 +2423,47 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('registered chat submit handler submits current image draft before parent rerender', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'registered-submit-image',
+      mediaType: 'image/png',
+    })
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn(async () => {})
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      onSubmit,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+      const registration = harness.keybindingRegistrations.find(
+        item => item.action === 'chat:submit',
+      )
+      expect(registration).toBeDefined()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]')
+
+      ;(registration?.handler as () => void)()
+      await sleep(25)
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        '[Image #1]',
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ mode: 'prompt' }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('allocates pasted image IDs after prior transcript references', async () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue({
       base64: 'png-data',


### PR DESCRIPTION
## Summary
- submit registered chat keybinding from the live internal prompt draft
- use live pasted-content refs when deciding whether image drafts are submittable
- cover image-paste submit before parent controlled input rerender

## Tests
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "registered chat submit handler submits current image draft before parent rerender"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm test -- tests/tui/components/PromptInput
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails on existing baseline: 30 unused exports, 4 tag hints)

## Coverage
- Statements: 95.71% (33702/35209)
- Branches: 89.82% (24281/27032)
- Functions: 96.11% (4850/5046)
- Lines: 96.58% (31562/32678)