### PR TITLE
fix(tui): type footer input against current drafts

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2357,8 +2357,11 @@ function PromptInput({
         // When the selected row IS the viewed agent, 'x' types into the
         // steering input. Any other row — dismiss it.
         if (viewSelectionMode === 'viewing-agent' && task.id === viewingAgentTaskId) {
-          onChange(input.slice(0, cursorOffset) + 'x' + input.slice(cursorOffset));
-          setCursorOffset(cursorOffset + 1);
+          const currentInput = lastInternalInputRef.current;
+          const currentOffset = cursorOffsetRef.current;
+          onChange(currentInput.slice(0, currentOffset) + 'x' + currentInput.slice(currentOffset));
+          cursorOffsetRef.current = currentOffset + 1;
+          setCursorOffset(currentOffset + 1);
           return;
         }
         stopOrDismissAgent(task.id, setAppState);
@@ -2411,8 +2414,11 @@ function PromptInput({
     // above, so anything reaching here is genuinely not a footer action.
     // onChange clears footerSelection, so no explicit deselect.
     if (footerItemSelected && char && !key.ctrl && !key.meta && !key.escape && !key.return) {
-      onChange(input.slice(0, cursorOffset) + char + input.slice(cursorOffset));
-      setCursorOffset(cursorOffset + char.length);
+      const currentInput = lastInternalInputRef.current;
+      const currentOffset = cursorOffsetRef.current;
+      onChange(currentInput.slice(0, currentOffset) + char + currentInput.slice(currentOffset));
+      cursorOffsetRef.current = currentOffset + char.length;
+      setCursorOffset(currentOffset + char.length);
       return;
     }
 

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -2270,6 +2270,48 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('types through selected footer against current image draft before parent rerender', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'footer-type-image',
+      mediaType: 'image/png',
+    })
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.appState.footerSelection = 'tasks'
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]')
+
+      latestInputHandler()('x', {
+        ctrl: false,
+        escape: false,
+        meta: false,
+        return: false,
+      })
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]x')
+      expect(harness.appState.footerSelection).toBeNull()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('drives model and thinking picker callbacks from chat keybindings', async () => {
     harness.fastMode.enabled = true
     harness.fastMode.available = true


### PR DESCRIPTION
## Summary
- Type-through from a selected footer item now uses the live input and cursor refs instead of stale rendered props.
- Footer close typing for the currently viewed agent uses the same live draft state.
- Adds a regression covering image paste followed by footer type-through before the parent rerenders the controlled input.

## Validation
- `git diff --check`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "types through selected footer against current image draft before parent rerender"`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx`
- `npm test -- tests/tui/components/PromptInput`
- `npm run typecheck`
- `npm run test:coverage:tui` - statements 95.72%, branches 89.82%, functions 96.11%, lines 96.58%
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` - fails with existing baseline: 30 unused exports, 4 tag hints
