### PR TITLE
fix(tui): search current paste drafts

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2251,7 +2251,7 @@ function PromptInput({
       if (isWorkbenchEnabled()) {
         setAppState(prev => applyWorkbenchCommand(prev, {
           type: 'openSearch',
-          query: input.trim(),
+          query: lastInternalInputRef.current.trim(),
         }));
         setHelpOpen(false);
         return;
@@ -2681,12 +2681,13 @@ function PromptInput({
     }
   }
   if (feature('HISTORY_PICKER') && showHistoryPicker) {
-    return <HistorySearchDialog initialQuery={input} onSelect={entry => {
+    return <HistorySearchDialog initialQuery={lastInternalInputRef.current} onSelect={entry => {
       const entryMode = getModeFromInput(entry.display);
       const value = getValueFromInput(entry.display);
       onModeChange(entryMode);
       trackAndSetInput(value);
       setPastedContentsAndRef(entry.pastedContents);
+      cursorOffsetRef.current = value.length;
       setCursorOffset(value.length);
       setShowHistoryPicker(false);
     }} onCancel={() => setShowHistoryPicker(false)} />;

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1355,6 +1355,67 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('opens workbench global search against current paste draft before parent rerender', async () => {
+    harness.features.QUICK_SEARCH = true
+    const onInputChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      setHelpOpen,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onPaste as (text: string) => void)('search term')
+      expect(onInputChange).toHaveBeenCalledWith('search term')
+
+      harness.keybindings['app:globalSearch']?.()
+
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(harness.appState.workbench).toEqual(
+        expect.objectContaining({
+          activeSurfaceMode: 'search',
+          focusedPane: 'surface',
+          searchQuery: 'search term',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('opens history search against current paste draft before parent rerender', async () => {
+    harness.features.HISTORY_PICKER = true
+    const onInputChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      setHelpOpen,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onPaste as (text: string) => void)('recent query')
+      expect(onInputChange).toHaveBeenCalledWith('recent query')
+
+      harness.keybindings['history:search']?.()
+      await sleep(25)
+
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(harness.historySearchProps).toEqual(
+        expect.objectContaining({
+          initialQuery: 'recent query',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('stashes image paste drafts before the parent input rerenders', async () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue({
       base64: 'jpeg-data',


### PR DESCRIPTION
## Summary
- Workbench global search now seeds its query from the live prompt draft instead of stale rendered input.
- History search now opens with the live prompt draft after paste and keeps the cursor ref synchronized after selecting a history entry.
- Adds regressions for paste followed by search before the parent controlled input rerenders.

## Validation
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "opens (workbench global search|history search) against current paste draft before parent rerender"` - failed before the fix, passes after
- `git diff --check`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx`
- `npm test -- tests/tui/components/PromptInput`
- `npm run typecheck`
- `npm run test:coverage:tui` - statements 95.73%, branches 89.83%, functions 96.13%, lines 96.59%
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` - fails with existing baseline: 30 unused exports, 4 tag hints
