### PR TITLE
fix(tui): use current prompt state for shortcuts

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2413,26 +2413,27 @@ function PromptInput({
 
     // NOTE: ctrl+_, ctrl+g, ctrl+s are handled via Chat context keybindings above
 
+    const currentInput = lastInternalInputRef.current;
+    const currentOffset = cursorOffsetRef.current;
+
     // Type-to-exit footer: printable chars while a pill is selected refocus
     // the input and type the char. Nav keys are captured by useKeybindings
     // above, so anything reaching here is genuinely not a footer action.
     // onChange clears footerSelection, so no explicit deselect.
     if (footerItemSelected && char && !key.ctrl && !key.meta && !key.escape && !key.return) {
-      const currentInput = lastInternalInputRef.current;
-      const currentOffset = cursorOffsetRef.current;
       onChange(currentInput.slice(0, currentOffset) + char + currentInput.slice(currentOffset));
       setCurrentCursorOffset(currentOffset + char.length);
       return;
     }
 
     // Exit special modes when backspace/escape/delete/ctrl+u is pressed at cursor position 0
-    if (cursorOffset === 0 && (key.escape || key.backspace || key.delete || key.ctrl && char === 'u')) {
+    if (currentOffset === 0 && (key.escape || key.backspace || key.delete || key.ctrl && char === 'u')) {
       onModeChange('prompt');
       setHelpOpen(false);
     }
 
     // Exit help mode when backspace is pressed and input is empty
-    if (helpOpen && input === '' && (key.backspace || key.delete)) {
+    if (helpOpen && currentInput === '' && (key.backspace || key.delete)) {
       setHelpOpen(false);
     }
 
@@ -2470,7 +2471,7 @@ function PromptInput({
         void popAllCommandsFromQueue();
         return;
       }
-      if (messages.length > 0 && !input && !isLoading) {
+      if (messages.length > 0 && currentInput === '' && !isLoading) {
         doublePressEscFromEmpty();
       }
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1101,6 +1101,42 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('handles escape/backspace shortcuts against current text input state before rerender', async () => {
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const onShowMessageSelector = vi.fn()
+    const rendered = await renderPromptInput({
+      input: 'abc',
+      messages: [{ type: 'assistant' }],
+      mode: 'bash',
+      onInputChange,
+      onModeChange,
+      onShowMessageSelector,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onChangeCursorOffset as (offset: number) => void)(0)
+      latestInputHandler()('', {
+        backspace: true,
+        ctrl: false,
+        delete: false,
+        escape: false,
+      })
+
+      expect(onModeChange).toHaveBeenCalledWith('prompt')
+
+      ;(baseProps.onChange as (value: string) => void)('')
+      latestInputHandler()('', { escape: true })
+
+      expect(onInputChange).toHaveBeenCalledWith('')
+      expect(onShowMessageSelector).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('handles mode cycle, image paste miss, and empty prompt submission guards', async () => {
     const onSubmit = vi.fn(async () => {})
     const setToolPermissionContext = vi.fn()


### PR DESCRIPTION
## Summary
- Read PromptInput's live input and cursor refs in the general input handler before handling escape/backspace shortcuts.
- Keep mode-exit, help-close, and empty-prompt message-selector routing aligned with cursor/text changes that happen before React commits a rerender.
- Add a regression for cursor movement to offset 0 followed by Backspace, plus clearing input followed immediately by Escape.

## Validation
- Focused regression failed before the fix and passed after the fix.
- `git diff --check`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "handles escape/backspace shortcuts against current text input state before rerender"`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx`
- `npm test -- tests/tui/components/PromptInput`
- `npm run typecheck`
- `npm run test:coverage:tui`
  - Statements: 95.75% (33716/35211)
  - Branches: 89.86% (24293/27034)
  - Functions: 96.15% (4852/5046)
  - Lines: 96.61% (31575/32681)
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` failed on the known unrelated baseline: 30 unused exports and 4 tag hints.
