### PR TITLE
fix(tui): pass current transcript to skills

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1906,10 +1906,9 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
             parsedDollarSkill,
             command,
             getToolUseContext(
-              transcript.messages as any[],
+              transcriptMessagesRef.current as any[],
               [],
               new AbortController(),
-              mainLoopModel,
             ) as PromptInputContext,
           );
           props.session.enqueueIdleInput?.(loaded.metadata);

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -232,6 +232,7 @@ vi.mock("../../utils/commitAttribution.js", () => ({
 vi.mock("../../utils/permissions/permissionSetup.js", () => ({
   createDisabledBypassPermissionsContext: (context: unknown) => context,
   isBypassPermissionsModeDisabled: () => false,
+  parseToolListFromCLI: (tools: string[] = []) => tools,
 }));
 
 vi.mock("../../utils/settings/applySettingsChange.js", () => ({
@@ -240,6 +241,7 @@ vi.mock("../../utils/settings/applySettingsChange.js", () => ({
 
 vi.mock("../../utils/settings/settings.js", () => ({
   getInitialSettings: () => ({}),
+  getSettingsForSource: () => null,
   getSettings_DEPRECATED: () => ({}),
 }));
 
@@ -535,6 +537,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       providerProbe.promptSubmits.push(onSubmit);
       providerProbe.promptProps.push({
         input,
+        onSubmit,
         onShowMessageSelector,
         onMessageActionsEnter,
         onExit,
@@ -1309,6 +1312,88 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         expect(output()).toContain("$skill-name");
       },
     );
+  });
+
+  test("passes current transcript messages to dollar skill commands", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    resetShellSurfaceProbe();
+    const getPromptForCommand = vi.fn(async (_args: string, context: unknown) => {
+      const messages = (context as { messages?: readonly unknown[] }).messages ?? [];
+      return [{ type: "text", text: `message-count:${messages.length}` }];
+    });
+    mockTuiCommandList.push({
+      name: "reviewer",
+      type: "prompt",
+      loadedFrom: "skills",
+      progressMessage: "Loading reviewer",
+      contentLength: 1,
+      getPromptForCommand,
+    });
+    const session = {
+      ...createSession(),
+      getInitialTranscriptEvents: () => [
+        {
+          id: "prior-turn",
+          type: "turn_complete",
+          payload: {
+            turnId: "prior-turn",
+            lastAgentMessage: "Previous response",
+          },
+        },
+      ],
+      enqueueIdleInput: vi.fn(() => 1),
+      submit: vi.fn(async () => {}),
+    } satisfies AgenCBridgeSession;
+    const helpers = {
+      clearBuffer: vi.fn(),
+      resetHistory: vi.fn(),
+      setCursorOffset: vi.fn(),
+    };
+    const { stdout, stdin } = createTestStreams();
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    });
+
+    try {
+      root.render(
+        <AgenCTuiApp
+          session={session}
+          configStore={{}}
+          isInteractive={false}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(providerProbe.messageProps.at(-1)?.messages).toHaveLength(1);
+      expect(providerProbe.promptProps.at(-1)?.commands).toContainEqual(
+        expect.objectContaining({ name: "reviewer", type: "prompt" }),
+      );
+
+      const onSubmit = providerProbe.promptProps.at(-1)?.onSubmit as
+        | ((input: string, helpers: typeof helpers) => Promise<void>)
+        | undefined;
+      expect(onSubmit).toBeDefined();
+
+      await onSubmit!("$reviewer audit this", helpers);
+
+      expect(getPromptForCommand).toHaveBeenCalledWith(
+        "audit this",
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({ type: "assistant" }),
+          ]),
+        }),
+      );
+      expect(session.submit).toHaveBeenCalledWith("", {
+        displayUserMessage: "$reviewer audit this",
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
   });
 
   test("keeps unknown dollar skills out of model submit", async () => {


### PR DESCRIPTION
## Summary
- fix the dollar-skill submit path so it no longer evaluates an undefined model variable before loading a skill
- pass the live transcript message ref into skill command context
- add an App render regression covering prior transcript messages during dollar-skill submit

## Verification
- npm test -- tests/tui/components/App.render.test.tsx -t "passes current transcript messages to dollar skill commands"
- npm test -- tests/tui/components/App.render.test.tsx
- npm test -- tests/tui/components/App.render.test.tsx tests/tui/components/App.coverage2.test.tsx tests/tui/components/App.completion-pipeline.test.tsx tests/tui/components/App.local-agents.test.tsx tests/tui/components/App.wave200-002.coverage.test.tsx tests/tui/parity/App.no-runningtoolprogress.parity.test.tsx tests/tui/parity/App.tooljsx-state.parity.test.tsx tests/tui/parity/App.tooljsx-gating.parity.test.tsx tests/tui/parity/App.streaming-tool-use.parity.test.tsx tests/tui/coverage-swarm/swarm-002-components-App.test.tsx
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)