### PR TITLE
fix(tui): show sdk compact progress

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -2109,13 +2109,19 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
     });
   }, []);
   const setCompactSDKStatus = useCallback((status: "compacting" | null) => {
-    if (status === null) {
+    if (status === "compacting") {
       setCompactProgress({
-        status: "idle",
-        label: null,
+        status: "compacting",
+        label: "Compacting conversation",
         responseLength: 0
       });
+      return;
     }
+    setCompactProgress({
+      status: "idle",
+      label: null,
+      responseLength: 0
+    });
   }, []);
   useEffect(() => installCompactProgressControls(props.session, {
     setStreamMode: setCompactStreamMode,

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -2026,6 +2026,13 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         expect(session.onCompactProgress).toEqual(expect.any(Function));
         expect(session.setSDKStatus).toEqual(expect.any(Function));
 
+        session.setSDKStatus?.("compacting");
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        expect(output()).toMatch(/Compacting[\s\S]*conversation/);
+
+        session.setSDKStatus?.(null);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+
         session.onCompactProgress?.({ type: "compact_start" });
         await new Promise((resolve) => setTimeout(resolve, 25));
         expect(output()).toMatch(/Compacting[\s\S]*conversation/);


### PR DESCRIPTION
## Summary
- show compact progress when the compact SDK status flips to `compacting`
- keep the existing `null` status reset path
- add App render coverage for SDK-driven compact progress controls

## Verification
- npm test -- tests/tui/components/App.render.test.tsx -t "installs compact progress controls and restores them on unmount"
- npm test -- tests/tui/components/App.render.test.tsx tests/tui/components/App.coverage2.test.tsx tests/tui/components/App.completion-pipeline.test.tsx tests/tui/components/App.local-agents.test.tsx tests/tui/components/App.wave200-002.coverage.test.tsx tests/tui/parity/App.no-runningtoolprogress.parity.test.tsx tests/tui/parity/App.tooljsx-state.parity.test.tsx tests/tui/parity/App.tooljsx-gating.parity.test.tsx tests/tui/parity/App.streaming-tool-use.parity.test.tsx tests/tui/coverage-swarm/swarm-002-components-App.test.tsx
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)