### PR TITLE
fix(tui): restore question mark history entries

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1203,11 +1203,14 @@ function PromptInput({
     submitCount,
     viewingAgentName
   });
-  const onChange = useCallback((value: string) => {
+  const onChange = useCallback((value: string, options?: {
+    interpretShortcuts?: boolean;
+  }) => {
+    const interpretShortcuts = options?.interpretShortcuts ?? true;
     const currentInput = lastInternalInputRef.current;
     const currentCursorOffset = cursorOffsetRef.current;
     const currentPastedContents = pastedContentsRef.current;
-    if (value === '?') {
+    if (interpretShortcuts && value === '?') {
       logEvent('agenc_help_toggled', {});
       setHelpOpen(v => !v);
       return;
@@ -1225,11 +1228,11 @@ function PromptInput({
     // mode itself is shown via the prompt prefix in the UI. Without this,
     // typing `!` into empty input would enter bash mode but leave the literal
     // `!` in the buffer (issue #662).
-    const modeEntry = detectModeEntry({
+    const modeEntry = interpretShortcuts ? detectModeEntry({
       value,
       prevInputLength: currentInput.length,
       cursorOffset: currentCursorOffset,
-    });
+    }) : null;
     if (modeEntry) {
       onModeChange(modeEntry.mode);
       const cleaned = modeEntry.strippedValue.replaceAll('\t', '    ');
@@ -1259,7 +1262,9 @@ function PromptInput({
     dismissSearchHint,
     historyIndex
   } = useArrowKeyHistory((value: string, historyMode: HistoryMode, pastedContents: Record<number, PastedContent>) => {
-    onChange(value);
+    onChange(value, {
+      interpretShortcuts: false
+    });
     onModeChange(historyMode);
     setPastedContentsAndRef(pastedContents);
   }, input, pastedContents, setCurrentCursorOffset, mode);

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -91,6 +91,13 @@ const harness = vi.hoisted(() => {
           display: string
           pastedContents: Record<number, PastedContent>
         }) => void),
+    historySetInput: undefined as
+      | undefined
+      | ((
+          value: string,
+          mode: string,
+          pastedContents: Record<number, PastedContent>,
+        ) => void),
     ideAtMentionedHandler: undefined as
       | undefined
       | ((atMentioned: {
@@ -204,6 +211,7 @@ const harness = vi.hoisted(() => {
       harness.history.setHistoryQuery.mockClear()
       harness.historySearchProps = undefined
       harness.historySearchSelect = undefined
+      harness.historySetInput = undefined
       harness.ideAtMentionedHandler = undefined
       harness.isAgentSwarmsEnabled = false
       harness.isBackgroundTask.mockReset()
@@ -318,13 +326,22 @@ vi.mock('../../hooks/useIdeAtMentioned.js', () => ({
 }))
 
 vi.mock('../../hooks/useArrowKeyHistory.js', () => ({
-  useArrowKeyHistory: () => ({
-    dismissSearchHint: harness.history.dismissSearchHint,
-    historyIndex: harness.history.historyIndex,
-    onHistoryDown: harness.history.onHistoryDown,
-    onHistoryUp: harness.history.onHistoryUp,
-    resetHistory: harness.history.resetHistory,
-  }),
+  useArrowKeyHistory: (
+    onSetInput: (
+      value: string,
+      mode: string,
+      pastedContents: Record<number, PastedContent>,
+    ) => void,
+  ) => {
+    harness.historySetInput = onSetInput
+    return {
+      dismissSearchHint: harness.history.dismissSearchHint,
+      historyIndex: harness.history.historyIndex,
+      onHistoryDown: harness.history.onHistoryDown,
+      onHistoryUp: harness.history.onHistoryUp,
+      resetHistory: harness.history.resetHistory,
+    }
+  },
 }))
 
 vi.mock('../../hooks/useDoublePress.js', () => ({
@@ -2893,6 +2910,33 @@ describe('PromptInput render surface', () => {
       expect(harness.history.onHistoryDown).not.toHaveBeenCalled()
     } finally {
       await guarded.dispose()
+    }
+  })
+
+  test('restores a literal question mark from history without toggling help', async () => {
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const setPastedContents = vi.fn()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      onModeChange,
+      setHelpOpen,
+      setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.historySetInput?.('?', 'prompt', {})
+
+      expect(onInputChange).toHaveBeenCalledWith('?')
+      expect(onModeChange).toHaveBeenCalledWith('prompt')
+      expect(setPastedContents).toHaveBeenCalledWith({})
+      expect(setHelpOpen).not.toHaveBeenCalledWith(expect.any(Function))
+    } finally {
+      await rendered.dispose()
     }
   })
 


### PR DESCRIPTION
## Summary
- Prevent history restore from treating a literal ? entry as the help shortcut
- Keep normal typed ? shortcut behavior intact
- Add a PromptInput regression that exercises the history callback directly

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "literal question mark"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails known baseline: 30 unused exports, 4 tag hints)