### PR TITLE
fix(tui): enable first undo step

### DIFF
--- a/runtime/src/tui/hooks/useInputBuffer.ts
+++ b/runtime/src/tui/hooks/useInputBuffer.ts
@@ -114,13 +114,13 @@ export function useInputBuffer({
       return undefined
     }
 
-    const targetIndex = Math.max(0, currentIndex - 1)
+    const targetIndex = currentIndex
     const entry = buffer[targetIndex]
 
     if (entry) {
       setBufferState(prevState => ({
         ...prevState,
-        currentIndex: Math.min(targetIndex, prevState.buffer.length - 1),
+        currentIndex: Math.min(targetIndex - 1, prevState.buffer.length - 1),
       }))
       return entry
     }
@@ -137,7 +137,7 @@ export function useInputBuffer({
     }
   }, [lastPushTime, pendingPush])
 
-  const canUndo = currentIndex > 0 && buffer.length > 1
+  const canUndo = currentIndex >= 0 && buffer.length > 0
 
   return {
     pushToBuffer,

--- a/runtime/tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
@@ -168,13 +168,21 @@ describe('useInputBuffer coverage swarm 202', () => {
       })
       await flushEffects()
 
-      expect(rendered.latest().canUndo).toBe(false)
+      expect(rendered.latest().canUndo).toBe(true)
 
       await advanceTimers(50)
       expect(rendered.latest().canUndo).toBe(true)
 
       await advanceTimers(50)
       await rendered.push('delta')
+
+      await expect(rendered.undo()).resolves.toEqual(
+        expect.objectContaining({
+          cursorOffset: 5,
+          pastedContents: {},
+          text: 'delta',
+        }),
+      )
 
       await expect(rendered.undo()).resolves.toEqual(
         expect.objectContaining({
@@ -199,7 +207,7 @@ describe('useInputBuffer coverage swarm 202', () => {
       await rendered.clear()
       await rendered.push('after-clear')
 
-      expect(rendered.latest().canUndo).toBe(false)
+      expect(rendered.latest().canUndo).toBe(true)
       await expect(rendered.undo()).resolves.toEqual(
         expect.objectContaining({
           cursorOffset: 'after-clear'.length,

--- a/runtime/tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx
@@ -87,6 +87,28 @@ async function push(
 }
 
 describe('useInputBuffer coverage', () => {
+  test('enables undo after the first captured previous state', async () => {
+    const rendered = await renderHookHarness({
+      debounceMs: 0,
+      maxBufferSize: 10,
+    })
+
+    try {
+      await push(rendered, 'before edit')
+
+      expect(rendered.latest().canUndo).toBe(true)
+      expect(rendered.latest().undo()).toEqual(
+        expect.objectContaining({
+          cursorOffset: 'before edit'.length,
+          pastedContents: {},
+          text: 'before edit',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('keeps undo history coherent across capped entries, branch edits, debounced clears, and duplicate pushes', async () => {
     const capped = await renderHookHarness({
       debounceMs: 0,
@@ -100,14 +122,20 @@ describe('useInputBuffer coverage', () => {
 
       expect(capped.latest().undo()).toEqual(
         expect.objectContaining({
-          cursorOffset: 3,
+          cursorOffset: 5,
           pastedContents: {},
-          text: 'two',
+          text: 'three',
         }),
       )
       await sleep()
 
       await push(capped, 'branch')
+      expect(capped.latest().undo()).toEqual(
+        expect.objectContaining({
+          text: 'branch',
+        }),
+      )
+      await sleep()
       expect(capped.latest().undo()).toEqual(
         expect.objectContaining({
           text: 'two',
@@ -144,6 +172,12 @@ describe('useInputBuffer coverage', () => {
       await push(duplicates, 'beta')
       await push(duplicates, 'beta')
 
+      expect(duplicates.latest().undo()).toEqual(
+        expect.objectContaining({
+          text: 'beta',
+        }),
+      )
+      await sleep()
       expect(duplicates.latest().undo()).toEqual(
         expect.objectContaining({
           text: 'alpha',


### PR DESCRIPTION
## Summary
- Treat the input buffer as a stack of previous prompt states
- Make canUndo true as soon as one previous state is available
- Update hook coverage for single-step undo, capped history, duplicate pushes, and debounced entries

## Test plan
- npm test -- tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx -t "first captured previous state"
- npm test -- tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails known baseline: 30 unused exports, 4 tag hints)