### PR TITLE
fix(tui): skip typeahead prewarm in tests

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -419,7 +419,7 @@ export function useTypeahead({
   // subsequent tests in the shard. The subscriber still registers so
   // fileSuggestions tests that trigger a refresh directly work correctly.
   useEffect(() => {
-    if ("production" !== 'test') {
+    if (process.env.NODE_ENV !== 'test') {
       startBackgroundCacheRefresh();
     }
     return onIndexBuildComplete(() => {

--- a/runtime/tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx
@@ -149,6 +149,7 @@ vi.mock('./unifiedSuggestions', () => ({
 
 import { createRoot } from '../ink/root.js'
 import type { SuggestionItem } from '../components/PromptInput/PromptInputFooterSuggestions.js'
+import { startBackgroundCacheRefresh } from './fileSuggestions'
 import { useTypeahead } from './useTypeahead.js'
 
 type SuggestionsState = {
@@ -232,6 +233,35 @@ function tabKeypress(): ParsedKeyForTest {
 }
 
 describe('useTypeahead useInput bridge', () => {
+  test('does not start background file prewarm under NODE_ENV=test', async () => {
+    const previousNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'test'
+    vi.mocked(startBackgroundCacheRefresh).mockClear()
+    const { stdin, stdout } = createTestStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(<TypeaheadHarness />)
+      await sleep(25)
+
+      expect(startBackgroundCacheRefresh).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previousNodeEnv
+      }
+      await sleep(25)
+    }
+  })
+
   test('stops the original Ink input event when the adapted keyboard event is consumed', async () => {
     const { stdin, stdout } = createTestStreams()
     const root = await createRoot({


### PR DESCRIPTION
## Summary
- Restore the intended NODE_ENV=test guard around typeahead file-index prewarm
- Prevent hook-mounting tests from starting background git/file indexing work
- Add a useTypeahead regression for the test environment guard

## Test plan
- npm test -- tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx -t "background file prewarm"
- npm test -- tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/components/PromptInput/slashTypeaheadExactMatch.test.ts
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (fails known baseline: 30 unused exports, 4 tag hints)