### PR TITLE
fix(tui): drop stale typeahead tab completions

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -334,6 +334,23 @@ export function useTypeahead({
   // We only want to re-fetch suggestions when the actual search token changes
   const cursorOffsetRef = useRef(cursorOffset);
   cursorOffsetRef.current = cursorOffset;
+  const currentInputStateRef = useRef({ cursorOffset, input, mode });
+  currentInputStateRef.current = { cursorOffset, input, mode };
+  const isCurrentInputState = useCallback(
+    (
+      expectedInput: string,
+      expectedCursorOffset: number,
+      expectedMode: PromptInputMode,
+    ) => {
+      const current = currentInputStateRef.current;
+      return (
+        current.input === expectedInput &&
+        current.cursorOffset === expectedCursorOffset &&
+        current.mode === expectedMode
+      );
+    },
+    [],
+  );
 
   // Track the latest search token to discard stale results from slow async operations
   const latestSearchTokenRef = useRef<string | null>(null);
@@ -1112,12 +1129,18 @@ export function useTypeahead({
         }
       }
     } else if (input.trim() !== '') {
+      const requestInput = input;
+      const requestCursorOffset = cursorOffset;
+      const requestMode = mode;
       let suggestionType: SuggestionType;
       let suggestionItems: SuggestionItem[];
       if (mode === 'bash') {
         suggestionType = 'shell';
         // This should be very fast, taking <10ms
         const bashSuggestions = await generateBashSuggestions(input, cursorOffset);
+        if (!isCurrentInputState(requestInput, requestCursorOffset, requestMode)) {
+          return;
+        }
         if (bashSuggestions.length === 1) {
           // If single suggestion, apply it immediately
           const suggestion = bashSuggestions[0];
@@ -1142,9 +1165,15 @@ export function useTypeahead({
           try {
             suggestionItems = await generateUnifiedSuggestions(searchToken, mcpResources, agents, isAtSymbol);
           } catch (error) {
+            if (!isCurrentInputState(requestInput, requestCursorOffset, requestMode)) {
+              return;
+            }
             logError(error);
             clearSuggestions();
             suggestionItems = [];
+          }
+          if (!isCurrentInputState(requestInput, requestCursorOffset, requestMode)) {
+            return;
           }
         } else {
           suggestionItems = [];
@@ -1161,7 +1190,7 @@ export function useTypeahead({
         setMaxColumnWidth(undefined);
       }
     }
-  }, [suggestions, selectedSuggestion, input, suggestionType, commands, mode, onInputChange, setCursorOffset, onSubmit, clearSuggestions, cursorOffset, updateSuggestions, mcpResources, setSuggestionsState, agents, debouncedFetchFileSuggestions, debouncedFetchSlackChannels, effectiveGhostText]);
+  }, [suggestions, selectedSuggestion, input, suggestionType, commands, mode, onInputChange, setCursorOffset, onSubmit, clearSuggestions, cursorOffset, updateSuggestions, mcpResources, setSuggestionsState, agents, debouncedFetchFileSuggestions, debouncedFetchSlackChannels, effectiveGhostText, isCurrentInputState]);
 
   // Handle enter key press - apply and execute suggestions
   const handleEnter = useCallback(() => {

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -211,6 +211,7 @@ import type { SuggestionItem } from '../components/PromptInput/PromptInputFooter
 import type { PromptInputMode } from '../../types/textInputTypes.js'
 import { useTypeahead } from './useTypeahead.js'
 import { generateUnifiedSuggestions } from './unifiedSuggestions'
+import { getShellCompletions } from '../../utils/bash/shellCompletion.js'
 import {
   getDirectoryCompletions,
   getPathCompletions,
@@ -235,6 +236,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 const generateUnifiedSuggestionsMock = vi.mocked(generateUnifiedSuggestions)
+const getShellCompletionsMock = vi.mocked(getShellCompletions)
 const getDirectoryCompletionsMock = vi.mocked(getDirectoryCompletions)
 const getPathCompletionsMock = vi.mocked(getPathCompletions)
 const searchSessionsByCustomTitleMock = vi.mocked(searchSessionsByCustomTitle)
@@ -383,6 +385,20 @@ async function waitFor(predicate: () => boolean, label: string): Promise<void> {
   throw new Error(`Timed out waiting for ${label}`)
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>
+  reject: (reason?: unknown) => void
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, reject, resolve }
+}
+
 const command = (name: string, aliases: readonly string[] = []) => ({
   aliases,
   description: `${name} command`,
@@ -395,6 +411,7 @@ describe('useTypeahead hook paths', () => {
   beforeEach(() => {
     harness.reset()
     generateUnifiedSuggestionsMock.mockClear()
+    getShellCompletionsMock.mockClear()
     getDirectoryCompletionsMock.mockClear()
     searchSessionsByCustomTitleMock.mockClear()
   })
@@ -487,6 +504,79 @@ describe('useTypeahead hook paths', () => {
         () => rendered.getSnapshot().suggestions.some(item => item.id === 'src/app.ts'),
         'file suggestions',
       )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('drops stale Tab-fetched file suggestions after the input changes', async () => {
+    const staleSuggestions = createDeferred<SuggestionItem[]>()
+    generateUnifiedSuggestionsMock.mockImplementationOnce(
+      async () => staleSuggestions.promise,
+    )
+    const rendered = await renderHookHarness({
+      cursorOffset: 'old'.length,
+      input: 'old',
+    })
+
+    try {
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => generateUnifiedSuggestionsMock.mock.calls.length === 1,
+        'Tab-triggered file suggestion fetch',
+      )
+
+      rendered.rerender({ cursorOffset: 'new'.length, input: 'new' })
+      staleSuggestions.resolve([
+        {
+          id: 'file-old-path.ts',
+          displayText: 'old/path.ts',
+          description: 'file',
+        },
+      ])
+      await sleep(25)
+
+      expect(rendered.getSnapshot().suggestionType).toBe('none')
+      expect(rendered.getSnapshot().suggestions).toEqual([])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('does not apply stale single shell completion after the input changes', async () => {
+    const staleCompletions = createDeferred<SuggestionItem[]>()
+    getShellCompletionsMock.mockImplementationOnce(
+      async () => staleCompletions.promise,
+    )
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      cursorOffset: 'g'.length,
+      input: 'g',
+      mode: 'bash',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => getShellCompletionsMock.mock.calls.length === 1,
+        'Tab-triggered shell completion fetch',
+      )
+
+      rendered.rerender({ cursorOffset: 'gi'.length, input: 'gi', mode: 'bash' })
+      staleCompletions.resolve([
+        {
+          displayText: 'git',
+          id: 'git',
+          metadata: { completionType: 'command' },
+        },
+      ])
+      await sleep(25)
+
+      expect(onInputChange).not.toHaveBeenCalled()
+      expect(setCursorOffset).not.toHaveBeenCalled()
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Guard async Tab-triggered typeahead fetches against input/cursor/mode changes before applying shell completions or showing file suggestions.
- Add regressions for stale single shell completions and stale Tab-fetched file suggestions.

## Test plan
- npm test -- tests/tui/hooks/useTypeahead.hook.test.tsx -t \"does not apply stale single shell completion|drops stale Tab-fetched file suggestions\"
- npm test -- tests/tui/hooks/useTypeahead.hook.test.tsx
- npm test -- tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/components/PromptInput/slashTypeaheadExactMatch.test.ts
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)