### PR TITLE
fix(tui): flush select input submit text

### DIFF
--- a/runtime/src/tui/components/CustomSelect/select.tsx
+++ b/runtime/src/tui/components/CustomSelect/select.tsx
@@ -407,6 +407,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
               }} onSubmit={(value_0: string) => {
                 const hasImageAttachments = pastedContents && Object.values(pastedContents).some(_temp5);
                 if (value_0.trim() || hasImageAttachments || option_1.allowEmptySubmitToCancel) {
+                  option_1.onChange(value_0);
                   onChange?.(option_1.value);
                 } else {
                   onCancel?.();
@@ -455,6 +456,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
               }} onSubmit={(value_2: string) => {
                 const hasImageAttachments_0 = pastedContents && Object.values(pastedContents).some(_temp6);
                 if (value_2.trim() || hasImageAttachments_0 || option_2.allowEmptySubmitToCancel) {
+                  option_2.onChange(value_2);
                   onChange?.(option_2.value);
                 } else {
                   onCancel?.();
@@ -574,6 +576,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
           }} onSubmit={(value_4: string) => {
             const hasImageAttachments_1 = pastedContents && Object.values(pastedContents).some(_temp9);
             if (value_4.trim() || hasImageAttachments_1 || option_4.allowEmptySubmitToCancel) {
+              option_4.onChange(value_4);
               onChange?.(option_4.value);
             } else {
               onCancel?.();

--- a/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
@@ -227,4 +227,38 @@ describe('Select input option coverage', () => {
       view.unmount()
     }
   })
+
+  test('flushes current input option text before selecting on submit', async () => {
+    const optionTextChange = vi.fn()
+    const onChange = vi.fn()
+    const options: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'feedback',
+        label: 'Feedback',
+        initialValue: 'old feedback',
+        onChange: optionTextChange,
+      },
+    ]
+
+    const view = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="feedback"
+        onChange={onChange}
+      />,
+    )
+
+    try {
+      latestInputOption().onSubmit('new feedback')
+
+      expect(optionTextChange).toHaveBeenCalledWith('new feedback')
+      expect(onChange).toHaveBeenCalledWith('feedback')
+      expect(optionTextChange.mock.invocationCallOrder[0]).toBeLessThan(
+        onChange.mock.invocationCallOrder[0]!,
+      )
+    } finally {
+      view.unmount()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Flush input option submitted text through the option-level text callback before selecting the input option.
- Covers compact, compact-vertical, and expanded Select input-row submit paths.
- Adds a regression for submitting a newer text value before selection callbacks read state.

## Test plan
- npm test -- tests/tui/components/CustomSelect/select.coverage2.test.tsx -t \"flushes current input option text\"
- npm test -- tests/tui/components/CustomSelect/select.coverage2.test.tsx tests/tui/components/CustomSelect/select.render.test.tsx tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/components/CustomSelect/use-select-input.coverage.test.ts tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts tests/tui/components/CustomSelect/use-select-input.wave200-034.coverage.test.ts tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)