### PR TITLE
fix(tui): ignore stale virtual list jumps

### DIFF
--- a/runtime/src/tui/components/VirtualMessageList.tsx
+++ b/runtime/src/tui/components/VirtualMessageList.tsx
@@ -698,7 +698,9 @@ export function VirtualMessageList({
     // Non-search jump (sticky header click, etc). No scan, no positions.
     jumpToIndex: (i: number) => {
       const s = scrollRef.current;
-      if (s) s.scrollTo(targetFor(i));
+      const js = jumpState.current;
+      if (!s || i < 0 || i >= js.messages.length) return;
+      s.scrollTo(targetFor(i));
     },
     setSearchQuery: (q: string) => {
       // New search invalidates everything.

--- a/runtime/tests/tui/components/VirtualMessageList.test.tsx
+++ b/runtime/tests/tui/components/VirtualMessageList.test.tsx
@@ -482,6 +482,44 @@ describe('VirtualMessageList', () => {
     }
   })
 
+  test('ignores stale non-search jump indices', async () => {
+    const messages = [
+      userMessage('u-1', 'first prompt'),
+      assistantMessage('a-1', 'assistant reply'),
+    ]
+    virtualScroll.range = [0, messages.length]
+    virtualScroll.offsets = [0, 10, 20]
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 2)
+      virtualScroll.itemTops.set(index, index * 10)
+      virtualScroll.elements.set(index, fakeElement(2))
+    })
+
+    const jumpRef = React.createRef<JumpHandle | null>()
+    const scrollHandle = createScrollHandle(12)
+    const scrollTo = vi.mocked(scrollHandle.scrollTo)
+    const rendered = await renderList({
+      jumpRef,
+      messages,
+      scrollHandle,
+    })
+
+    try {
+      expect(jumpRef.current).not.toBeNull()
+
+      jumpRef.current?.jumpToIndex(1)
+      expect(scrollTo).toHaveBeenLastCalledWith(7)
+
+      scrollTo.mockClear()
+      jumpRef.current?.jumpToIndex(-1)
+      jumpRef.current?.jumpToIndex(messages.length)
+
+      expect(scrollTo).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('tracks sticky prompts and jump-to-prompt correction paths', async () => {
     const stickyPrompts: unknown[] = []
     const messages = [


### PR DESCRIPTION
## Summary
- Guard VirtualMessageList non-search jumpToIndex against stale negative or out-of-range indices
- Add a regression proving invalid jump indices no longer scroll the transcript to the top

## Verification
- npm test -- tests/tui/components/VirtualMessageList.test.tsx -t "ignores stale non-search jump indices" (failed before fix, passed after)
- npm test -- tests/tui/components/VirtualMessageList.test.tsx tests/tui/components/VirtualMessageList.coverage.test.tsx tests/tui/components/VirtualMessageList.coverage2.test.tsx tests/tui/components/VirtualMessageList.wave200-016.coverage.test.tsx tests/tui/coverage-swarm/swarm-014-components-VirtualMessageList.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)