### PR TITLE
fix(tui): flush numbered select input submits

### DIFF
--- a/runtime/src/tui/components/CustomSelect/use-select-input.ts
+++ b/runtime/src/tui/components/CustomSelect/use-select-input.ts
@@ -266,10 +266,12 @@ export const useSelectInput = <T>({
               const currentValue = inputValues?.get(selectedOption.value) ?? ''
               if (currentValue.trim()) {
                 // Pre-filled input: auto-submit (user can Tab to edit instead)
+                selectedOption.onChange(currentValue)
                 state.onChange?.(selectedOption.value)
                 return
               }
               if (selectedOption.allowEmptySubmitToCancel) {
+                selectedOption.onChange(currentValue)
                 state.onChange?.(selectedOption.value)
                 return
               }

--- a/runtime/tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts
+++ b/runtime/tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts
@@ -169,6 +169,18 @@ describe('useSelectInput numeric shortcuts', () => {
 
   test('routes number keys through input option submit and focus rules', async () => {
     const state = createSelectState(options)
+    const promptOption = options[1] as Extract<
+      OptionWithDescription<string>,
+      { type: 'input' }
+    >
+    const cancelEmptyOption = options[2] as Extract<
+      OptionWithDescription<string>,
+      { type: 'input' }
+    >
+    const emptyPromptOption = options[3] as Extract<
+      OptionWithDescription<string>,
+      { type: 'input' }
+    >
     const inputValues = new Map<string, string>([
       ['prompt', 'ready to submit'],
       ['cancel-empty', ''],
@@ -190,15 +202,18 @@ describe('useSelectInput numeric shortcuts', () => {
       expect(state.focusOption).not.toHaveBeenCalled()
 
       pressKey('2')
+      expect(promptOption.onChange).toHaveBeenCalledWith('ready to submit')
       expect(state.onChange).toHaveBeenCalledWith('prompt')
       expect(state.focusOption).not.toHaveBeenCalled()
 
       pressKey('3')
+      expect(cancelEmptyOption.onChange).toHaveBeenCalledWith('')
       expect(state.onChange).toHaveBeenNthCalledWith(2, 'cancel-empty')
       expect(state.focusOption).not.toHaveBeenCalled()
 
       pressKey('4')
       expect(state.focusOption).toHaveBeenCalledWith('empty-prompt')
+      expect(emptyPromptOption.onChange).not.toHaveBeenCalled()
       expect(state.onChange).toHaveBeenCalledTimes(2)
 
       pressKey('1')


### PR DESCRIPTION
## Summary
- Flush input-option text before number-key selection for prefilled Select input rows
- Preserve empty-allowed input option submit behavior while updating the option-level text callback first
- Extend numeric shortcut coverage for prefilled, empty-allowed, and empty-cancel input rows

## Verification
- npm test -- tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts -t "routes number keys through input option submit" (failed before fix, passed after)
- npm test -- tests/tui/components/CustomSelect
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)