### PR TITLE
fix(tui): clear auto mode timer on prompt unmount

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -808,6 +808,10 @@ function PromptInput({
   const modeSwitcherTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => () => {
+    if (autoModeOptInTimeoutRef.current) {
+      clearTimeout(autoModeOptInTimeoutRef.current);
+      autoModeOptInTimeoutRef.current = null;
+    }
     if (modeSwitcherTimeoutRef.current) {
       clearTimeout(modeSwitcherTimeoutRef.current);
       modeSwitcherTimeoutRef.current = null;

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -2826,6 +2826,30 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('clears pending auto-mode opt-in timer on unmount', async () => {
+    vi.useFakeTimers()
+    harness.features.TRANSCRIPT_CLASSIFIER = true
+    harness.hasAutoModeOptIn = false
+    harness.nextPermissionMode = 'auto'
+    const rendered = await renderPromptInput()
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['chat:cycleMode']?.()
+      expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+      rendered.root.unmount()
+      rendered.stdin.end()
+      rendered.stdout.end()
+
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
   test('routes footer close through viewed-agent typing and task dismissal paths', async () => {
     harness.isBackgroundTask.mockImplementation(
       task => (task as { background?: boolean }).background === true,


### PR DESCRIPTION
## Summary
- Clear the delayed auto-mode opt-in timer when PromptInput unmounts.
- Add a regression that verifies no pending auto-mode timer survives unmount.

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"clears pending auto-mode opt-in timer\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)