### PR TITLE
fix(tui): keep auto mode dialog modal

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -799,10 +799,10 @@ function PromptInput({
   const [showFastModePicker, setShowFastModePicker] = useState(false);
   const [showThinkingToggle, setShowThinkingToggle] = useState(false);
   const [showModeSwitcher, setShowModeSwitcher] = useState(false);
-  const promptModalOverlayActive =
-    upstreamModalOverlayActive || showModeSwitcher || Boolean(showBashesDialog);
-  const promptKeyboardActive = composerInputEnabled && !promptModalOverlayActive;
   const [showAutoModeOptIn, setShowAutoModeOptIn] = useState(false);
+  const promptModalOverlayActive =
+    upstreamModalOverlayActive || showModeSwitcher || showAutoModeOptIn || Boolean(showBashesDialog);
+  const promptKeyboardActive = composerInputEnabled && !promptModalOverlayActive;
   const [previousModeBeforeAuto, setPreviousModeBeforeAuto] = useState<PermissionMode | null>(null);
   const autoModeOptInTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const modeSwitcherTimeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -2850,6 +2850,29 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('keeps prompt input unfocused while auto-mode opt-in dialog remains open', async () => {
+    harness.features.TRANSCRIPT_CLASSIFIER = true
+    harness.hasAutoModeOptIn = false
+    harness.nextPermissionMode = 'auto'
+    const rendered = await renderPromptInput()
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      expect(baseProps.focus).toBe(true)
+
+      harness.keybindings['chat:cycleMode']?.()
+      await sleep(450)
+      expect(harness.autoModeOptInProps).toBeDefined()
+      expect(harness.baseProps?.focus).toBe(false)
+
+      await sleep(2700)
+      expect(harness.autoModeOptInProps).toBeDefined()
+      expect(harness.baseProps?.focus).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('routes footer close through viewed-agent typing and task dismissal paths', async () => {
     harness.isBackgroundTask.mockImplementation(
       task => (task as { background?: boolean }).background === true,


### PR DESCRIPTION
## Summary
- Treat the auto-mode opt-in dialog as a prompt modal overlay while it remains open.
- Add a regression that keeps the prompt text input unfocused after the transient mode-switcher banner expires.

## Test plan
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t \"keeps prompt input unfocused while auto-mode opt-in dialog remains open\"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)