### PR TITLE
fix(tui): keep mode cycling active during overlays

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -806,6 +806,11 @@ function PromptInput({
   const [previousModeBeforeAuto, setPreviousModeBeforeAuto] = useState<PermissionMode | null>(null);
   const autoModeOptInTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const modeSwitcherTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const modeCycleKeybindingActive =
+    composerInputEnabled &&
+    !upstreamModalOverlayActive &&
+    !Boolean(showBashesDialog) &&
+    (promptKeyboardActive || showModeSwitcher || showAutoModeOptIn || Boolean(autoModeOptInTimeoutRef.current));
 
   useEffect(() => () => {
     if (autoModeOptInTimeoutRef.current) {
@@ -2216,12 +2221,18 @@ function PromptInput({
     'chat:stash': handleStash,
     'chat:modelPicker': handleModelPicker,
     'chat:thinkingToggle': handleThinkingToggle,
-    'chat:cycleMode': handleCycleMode,
     'chat:imagePaste': handleImagePaste
-  }), [handleUndo, handleNewline, handleExternalEditor, handleStash, handleModelPicker, handleThinkingToggle, handleCycleMode, handleImagePaste]);
+  }), [handleUndo, handleNewline, handleExternalEditor, handleStash, handleModelPicker, handleThinkingToggle, handleImagePaste]);
   useKeybindings(chatHandlers, {
     context: 'Chat',
     isActive: promptKeyboardActive
+  });
+
+  // Keep mode cycling active while its own status/dialog overlays are visible,
+  // without re-enabling ordinary prompt editing behind those overlays.
+  useKeybinding('chat:cycleMode', handleCycleMode, {
+    context: 'Chat',
+    isActive: modeCycleKeybindingActive
   });
 
   // Shift+↑ enters message-actions cursor. Separate isActive so ctrl+r search

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -423,10 +423,27 @@ vi.mock('../../keybindings/shortcutFormat.js', () => ({
 }))
 
 vi.mock('../../keybindings/useKeybinding.js', () => ({
-  useKeybinding: (action: string, handler: () => unknown) => {
+  useKeybinding: (
+    action: string,
+    handler: () => unknown,
+    options?: { isActive?: boolean },
+  ) => {
+    if (options?.isActive === false) {
+      delete harness.keybindings[action]
+      return
+    }
     harness.keybindings[action] = handler
   },
-  useKeybindings: (handlers: Record<string, () => unknown>) => {
+  useKeybindings: (
+    handlers: Record<string, () => unknown>,
+    options?: { isActive?: boolean },
+  ) => {
+    if (options?.isActive === false) {
+      for (const action of Object.keys(handlers)) {
+        delete harness.keybindings[action]
+      }
+      return
+    }
     Object.assign(harness.keybindings, handlers)
   },
 }))
@@ -2868,6 +2885,37 @@ describe('PromptInput render surface', () => {
       await sleep(2700)
       expect(harness.autoModeOptInProps).toBeDefined()
       expect(harness.baseProps?.focus).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('keeps mode cycling active while its temporary overlays are shown', async () => {
+    harness.features.TRANSCRIPT_CLASSIFIER = true
+    harness.hasAutoModeOptIn = false
+    harness.nextPermissionMode = 'auto'
+    const rendered = await renderPromptInput()
+
+    try {
+      await waitForPromptInputProps()
+
+      expect(harness.keybindings['chat:cycleMode']).toEqual(expect.any(Function))
+      harness.keybindings['chat:cycleMode']?.()
+      await sleep(450)
+
+      expect(harness.autoModeOptInProps).toBeDefined()
+      expect(harness.keybindings['chat:cycleMode']).toEqual(expect.any(Function))
+
+      harness.nextPermissionMode = 'default'
+      harness.cyclePermissionModeNextMode = 'default'
+      harness.keybindings['chat:cycleMode']?.()
+      await sleep(0)
+
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_auto_mode_opt_in_dialog_decline',
+        {},
+      )
+      expect(harness.appState.toolPermissionContext.mode).toBe('default')
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- keep the Shift+Tab mode-cycle keybinding active while the mode switcher or auto-mode opt-in overlay is visible
- keep normal prompt editing disabled behind those overlays
- make the PromptInput render harness honor keybinding isActive flags and cover cycling away from auto-mode opt-in

## Verification
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "keeps mode cycling active while its temporary overlays are shown"
- npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints; none in changed files)