### PR TITLE
fix(tui): restore ultrareview trigger handling

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -90,7 +90,7 @@ import { isInProcessTeammate } from '../../../utils/teammateContext.js';
 import { writeToMailbox } from '../../../utils/teammateMailbox.js';
 import type { TextHighlight } from '../../../utils/textHighlighting.js';
 import type { Theme } from '../../../utils/theme.js';
-import { findThinkingTriggerPositions, getRainbowColor, isUltrathinkEnabled } from '../../../utils/thinking.js';
+import { findThinkingTriggerPositions, findUltrareviewTriggerPositions, getRainbowColor, isUltrathinkEnabled } from '../../../utils/thinking.js';
 import { escapeXml } from '../../../utils/xml.js';
 import { findTokenBudgetPositions } from '../../../conversation/token-budget.js';
 
@@ -1139,8 +1139,10 @@ function PromptInput({
         priority: 'immediate',
         timeoutMs: 5000
       });
+    } else {
+      removeNotification('ultrareview-active');
     }
-  }, [addNotification, ultrareviewTriggers.length]);
+  }, [addNotification, removeNotification, ultrareviewTriggers.length]);
 
   // Track input length for stash hint
   const prevInputLengthRef = useRef(input.length);

--- a/runtime/src/utils/thinking.ts
+++ b/runtime/src/utils/thinking.ts
@@ -14,6 +14,18 @@ export type ThinkingConfig =
   | { type: 'enabled'; budgetTokens: number }
   | { type: 'disabled' }
 
+type TriggerPosition = { word: string; start: number; end: number }
+
+const OPEN_TO_CLOSE: Record<string, string> = {
+  '`': '`',
+  '"': '"',
+  '<': '>',
+  '{': '}',
+  '[': ']',
+  '(': ')',
+  "'": "'",
+}
+
 /**
  * Build-time gate (feature) + runtime gate (GrowthBook). The build flag
  * controls code inclusion in external builds; the GB flag controls rollout.
@@ -57,6 +69,63 @@ export function findThinkingTriggerPositions(text: string): Array<{
   }
 
   return positions
+}
+
+function findKeywordTriggerPositions(
+  text: string,
+  keyword: string,
+): TriggerPosition[] {
+  const re = new RegExp(keyword, 'i')
+  if (!re.test(text)) return []
+  if (text.startsWith('/')) return []
+
+  const quotedRanges: Array<{ start: number; end: number }> = []
+  let openQuote: string | null = null
+  let openAt = 0
+  const isWord = (ch: string | undefined) => !!ch && /[\p{L}\p{N}_]/u.test(ch)
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!
+    if (openQuote) {
+      if (openQuote === '[' && ch === '[') {
+        openAt = i
+        continue
+      }
+      if (ch !== OPEN_TO_CLOSE[openQuote]) continue
+      if (openQuote === "'" && isWord(text[i + 1])) continue
+      quotedRanges.push({ start: openAt, end: i + 1 })
+      openQuote = null
+    } else if (
+      (ch === '<' && i + 1 < text.length && /[a-zA-Z/]/.test(text[i + 1]!)) ||
+      (ch === "'" && !isWord(text[i - 1])) ||
+      (ch !== '<' && ch !== "'" && ch in OPEN_TO_CLOSE)
+    ) {
+      openQuote = ch
+      openAt = i
+    }
+  }
+
+  const positions: TriggerPosition[] = []
+  const wordRe = new RegExp(`\\b${keyword}\\b`, 'gi')
+  const matches = text.matchAll(wordRe)
+  for (const match of matches) {
+    if (match.index === undefined) continue
+    const start = match.index
+    const end = start + match[0].length
+    if (quotedRanges.some(r => start >= r.start && start < r.end)) continue
+    const before = text[start - 1]
+    const after = text[end]
+    if (before === '/' || before === '\\' || before === '-') continue
+    if (after === '/' || after === '\\' || after === '-' || after === '?')
+      continue
+    if (after === '.' && isWord(text[end + 1])) continue
+    positions.push({ word: match[0], start, end })
+  }
+  return positions
+}
+
+export function findUltrareviewTriggerPositions(text: string): TriggerPosition[] {
+  return findKeywordTriggerPositions(text, 'ultrareview')
 }
 
 const RAINBOW_COLORS: Array<keyof Theme> = [

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -133,6 +133,7 @@ const harness = vi.hoisted(() => {
       suggestionType: undefined as undefined | string,
       suggestions: [] as Array<{ description?: string; label: string }>,
     },
+    ultrareviewConfig: null as null | Record<string, unknown>,
     visibleAgentTasks: [] as Array<{ id: string; status?: string }>,
     viewedTeammate: undefined as
       | undefined
@@ -234,6 +235,7 @@ const harness = vi.hoisted(() => {
       harness.teamsDialogProps = undefined
       harness.terminal = undefined
       harness.thinkingToggleProps = undefined
+      harness.ultrareviewConfig = null
       harness.typeahead = {
         commandArgumentHint: undefined,
         inlineGhostText: undefined,
@@ -274,7 +276,13 @@ vi.mock('../../../services/analytics/index.js', () => ({
 }))
 
 vi.mock('../../../services/analytics/growthbook.js', () => ({
-  getFeatureValue_CACHED_MAY_BE_STALE: () => null,
+  getFeatureValue_CACHED_MAY_BE_STALE: (
+    name: string,
+    fallback: unknown,
+  ) =>
+    name === 'agenc_review_bughunter_config'
+      ? harness.ultrareviewConfig
+      : fallback,
 }))
 
 vi.mock('../../../services/PromptSuggestion/promptSuggestion.js', () => ({
@@ -651,6 +659,12 @@ vi.mock('../../../utils/teammateMailbox.js', () => ({
 
 vi.mock('../../../utils/thinking.js', () => ({
   findThinkingTriggerPositions: () => [],
+  findUltrareviewTriggerPositions: (text: string) =>
+    Array.from(text.matchAll(/\bultrareview\b/gi), match => ({
+      word: match[0],
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + match[0].length,
+    })),
   getRainbowColor: () => 'suggestion',
   isUltrathinkEnabled: () => false,
 }))
@@ -2835,6 +2849,37 @@ describe('PromptInput render surface', () => {
           key: 'option-meta-hint',
           priority: 'immediate',
         }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clears ultrareview notification when the trigger leaves the input', async () => {
+    harness.ultrareviewConfig = { enabled: true }
+    const rendered = await renderPromptInput({
+      input: 'please ultrareview this change',
+    })
+
+    try {
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'ultrareview-active',
+        }),
+      )
+
+      harness.baseProps = undefined
+      rendered.root.render(
+        <PromptInput
+          {...(basePromptInputProps({
+            input: 'please review this change',
+          }) as never)}
+        />,
+      )
+      await waitForPromptInputProps()
+
+      expect(harness.removeNotification).toHaveBeenCalledWith(
+        'ultrareview-active',
       )
     } finally {
       await rendered.dispose()


### PR DESCRIPTION
## Summary
- Restore the missing ultrareview trigger-position helper used by PromptInput when the remote review feature flag is enabled.
- Clear the ultrareview active notification when the trigger leaves the input or the feature is disabled.
- Add a regression that enables the feature flag, verifies the notification appears, then rerenders without the trigger and verifies cleanup.

## Test plan
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "clears ultrareview notification"`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known baseline: 30 unused exports and 4 tag hints; no touched files)
