### PR TITLE
fix(tui): keep workbench attachments from accepting suggestions

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -1384,7 +1384,7 @@ function PromptInput({
     // Only in leader view — promptSuggestion is leader-context, not teammate.
     const suggestionText = promptSuggestionState.text;
     const inputMatchesSuggestion = inputParam.trim() === '' || inputParam === suggestionText;
-    if (inputMatchesSuggestion && suggestionText && !hasImages && !state.viewingAgentTaskId) {
+    if (inputMatchesSuggestion && suggestionText && !hasImages && !hasWorkbenchAttachments && !state.viewingAgentTaskId) {
       // If speculation is active, inject messages immediately as they stream
       if (speculation.status === 'active') {
         markAccepted();

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -2098,6 +2098,63 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('submits workbench attachments without auto-accepting an empty prompt suggestion', async () => {
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: 'generation-attachments',
+      promptId: 'prompt-attachments',
+      shownAt: 100,
+      text: 'run the unrelated suggestion',
+    }
+    harness.appState.workbench = {
+      ...getDefaultWorkbenchState(),
+      attachments: [
+        {
+          id: 'file:src/app.ts',
+          kind: 'file',
+          label: 'src/app.ts',
+          path: 'src/app.ts',
+        },
+      ],
+      composerAttachmentIds: ['file:src/app.ts'],
+    }
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({ input: '', onSubmit })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('')
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        '@src/app.ts\n\n',
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+          setCursorOffset: expect.any(Function),
+        }),
+        undefined,
+        expect.objectContaining({
+          mode: 'prompt',
+        }),
+      )
+      expect(harness.promptSuggestionLogEvent).toHaveBeenCalledWith(
+        'agenc_prompt_suggestion',
+        expect.objectContaining({
+          outcome: 'ignored',
+          prompt_id: 'prompt-attachments',
+        }),
+      )
+      expect(harness.appState.workbench).toEqual(
+        expect.objectContaining({
+          attachments: [],
+          composerAttachmentIds: [],
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('executes bash-mode input locally and emits transcript events', async () => {
     const emitted: unknown[] = []
     const setToolJSX = vi.fn()


### PR DESCRIPTION
## Summary
- Prevent empty PromptInput submissions with workbench attachments from auto-accepting visible prompt suggestions.
- Keep image and workbench attachment-only submissions aligned: attached context wins over unrelated suggestion text.
- Add regression coverage for empty input plus workbench attachment plus visible suggestion, including ignored suggestion analytics and attachment cleanup.

## Test plan
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx -t "submits workbench attachments"`
- `npm test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)
