### PR TITLE
fix(tui): type themed box color wrapper

### DIFF
--- a/runtime/src/tui/components/design-system/ThemedBox.tsx
+++ b/runtime/src/tui/components/design-system/ThemedBox.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { c as _c } from "react-compiler-runtime";
 import React, { type PropsWithChildren } from 'react';
 import Box from '../../ink/components/Box.js';
 import type { DOMElement } from '../../ink/dom.js';
@@ -9,7 +7,7 @@ import type { FocusEvent } from '../../ink/events/focus-event.js';
 import type { KeyboardEvent } from '../../ink/events/keyboard-event.js';
 import type { Styles } from '../../ink/styles.js';
 import { getTheme } from '../../../utils/theme.js'; // upstream-import: keep target is owned by another Z-PURGE item
-import { useTheme } from './ThemeProvider';
+import { useTheme } from './ThemeProvider.js';
 import { resolveThemedColor, type ThemedColor } from './resolveThemedColor.js';
 
 // Color props that accept theme keys
@@ -42,100 +40,36 @@ export type Props = BaseStylesWithoutColors & ThemedColorProps & {
  * Theme-aware Box component that resolves theme color keys to raw colors.
  * This wraps the base Box component with theme resolution for border colors.
  */
-function ThemedBoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
-  const $ = _c(33);
-  let backgroundColor;
-  let borderBottomColor;
-  let borderColor;
-  let borderLeftColor;
-  let borderRightColor;
-  let borderTopColor;
-  let children;
-  let rest;
-  if ($[0] !== t0) {
-    ({
-      borderColor,
-      borderTopColor,
-      borderBottomColor,
-      borderLeftColor,
-      borderRightColor,
-      backgroundColor,
-      children,
-      ...rest
-    } = t0);
-    $[0] = t0;
-    $[1] = backgroundColor;
-    $[2] = borderBottomColor;
-    $[3] = borderColor;
-    $[4] = borderLeftColor;
-    $[5] = borderRightColor;
-    $[6] = borderTopColor;
-    $[7] = children;
-    $[8] = rest;
-  } else {
-    backgroundColor = $[1];
-    borderBottomColor = $[2];
-    borderColor = $[3];
-    borderLeftColor = $[4];
-    borderRightColor = $[5];
-    borderTopColor = $[6];
-    children = $[7];
-    rest = $[8];
-  }
+function ThemedBoxInner(
+  {
+    borderColor,
+    borderTopColor,
+    borderBottomColor,
+    borderLeftColor,
+    borderRightColor,
+    backgroundColor,
+    children,
+    ...rest
+  }: PropsWithChildren<Props>,
+  ref: React.ForwardedRef<DOMElement>,
+): React.ReactElement {
   const [themeName] = useTheme();
-  let resolvedBorderBottomColor;
-  let resolvedBorderColor;
-  let resolvedBorderLeftColor;
-  let resolvedBorderRightColor;
-  let resolvedBorderTopColor;
-  let t1;
-  if ($[10] !== backgroundColor || $[11] !== borderBottomColor || $[12] !== borderColor || $[13] !== borderLeftColor || $[14] !== borderRightColor || $[15] !== borderTopColor || $[16] !== themeName) {
-    const theme = getTheme(themeName);
-    resolvedBorderColor = resolveThemedColor(borderColor, theme);
-    resolvedBorderTopColor = resolveThemedColor(borderTopColor, theme);
-    resolvedBorderBottomColor = resolveThemedColor(borderBottomColor, theme);
-    resolvedBorderLeftColor = resolveThemedColor(borderLeftColor, theme);
-    resolvedBorderRightColor = resolveThemedColor(borderRightColor, theme);
-    t1 = resolveThemedColor(backgroundColor, theme);
-    $[10] = backgroundColor;
-    $[11] = borderBottomColor;
-    $[12] = borderColor;
-    $[13] = borderLeftColor;
-    $[14] = borderRightColor;
-    $[15] = borderTopColor;
-    $[16] = themeName;
-    $[17] = resolvedBorderBottomColor;
-    $[18] = resolvedBorderColor;
-    $[19] = resolvedBorderLeftColor;
-    $[20] = resolvedBorderRightColor;
-    $[21] = resolvedBorderTopColor;
-    $[22] = t1;
-  } else {
-    resolvedBorderBottomColor = $[17];
-    resolvedBorderColor = $[18];
-    resolvedBorderLeftColor = $[19];
-    resolvedBorderRightColor = $[20];
-    resolvedBorderTopColor = $[21];
-    t1 = $[22];
-  }
-  const resolvedBackgroundColor = t1;
-  let t2;
-  if ($[23] !== children || $[24] !== ref || $[25] !== resolvedBackgroundColor || $[26] !== resolvedBorderBottomColor || $[27] !== resolvedBorderColor || $[28] !== resolvedBorderLeftColor || $[29] !== resolvedBorderRightColor || $[30] !== resolvedBorderTopColor || $[31] !== rest) {
-    t2 = <Box ref={ref} borderColor={resolvedBorderColor} borderTopColor={resolvedBorderTopColor} borderBottomColor={resolvedBorderBottomColor} borderLeftColor={resolvedBorderLeftColor} borderRightColor={resolvedBorderRightColor} backgroundColor={resolvedBackgroundColor} {...rest}>{children}</Box>;
-    $[23] = children;
-    $[24] = ref;
-    $[25] = resolvedBackgroundColor;
-    $[26] = resolvedBorderBottomColor;
-    $[27] = resolvedBorderColor;
-    $[28] = resolvedBorderLeftColor;
-    $[29] = resolvedBorderRightColor;
-    $[30] = resolvedBorderTopColor;
-    $[31] = rest;
-    $[32] = t2;
-  } else {
-    t2 = $[32];
-  }
-  return t2;
+  const theme = getTheme(themeName);
+
+  return (
+    <Box
+      ref={ref}
+      borderColor={resolveThemedColor(borderColor, theme)}
+      borderTopColor={resolveThemedColor(borderTopColor, theme)}
+      borderBottomColor={resolveThemedColor(borderBottomColor, theme)}
+      borderLeftColor={resolveThemedColor(borderLeftColor, theme)}
+      borderRightColor={resolveThemedColor(borderRightColor, theme)}
+      backgroundColor={resolveThemedColor(backgroundColor, theme)}
+      {...rest}
+    >
+      {children}
+    </Box>
+  );
 }
 const ThemedBox = React.forwardRef<DOMElement, PropsWithChildren<Props>>(ThemedBoxInner);
 ThemedBox.displayName = 'ThemedBox';

--- a/runtime/tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx
@@ -77,7 +77,7 @@ async function waitFor(assertion: () => void): Promise<void> {
   throw lastError
 }
 
-async function renderNode(node: React.ReactNode): Promise<void> {
+async function renderNode(node: React.ReactNode): Promise<MountedRoot> {
   const { stderr, stdin, stdout } = createStreams()
   const root = await createRoot({
     patchConsole: false,
@@ -88,6 +88,7 @@ async function renderNode(node: React.ReactNode): Promise<void> {
 
   mountedRoots.push({ root, stdin, stdout })
   root.render(node)
+  return { root, stdin, stdout }
 }
 
 afterEach(async () => {
@@ -226,5 +227,57 @@ describe('ThemedBox coverage swarm row 135', () => {
     expect(ref.current?.style.borderLeftColor).toBeUndefined()
     expect(ref.current?.style.borderRightColor).toBeUndefined()
     expect(ref.current?.style.borderTopColor).toBeUndefined()
+  })
+
+  test('updates resolved theme colors and forwarded props on rerender', async () => {
+    const ref = React.createRef<DOMElement>()
+    const darkTheme = getTheme('dark')
+    const lightTheme = getTheme('light')
+
+    const mounted = await renderNode(
+      <ThemeProvider key="dark" initialState="dark" onThemeSave={vi.fn()}>
+        <ThemedBox
+          ref={ref}
+          backgroundColor="surfaceBackground"
+          borderColor="success"
+          paddingX={1}
+          width={10}
+        >
+          dark
+        </ThemedBox>
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => {
+      expect(ref.current?.style).toMatchObject({
+        backgroundColor: darkTheme.surfaceBackground,
+        borderColor: darkTheme.success,
+        paddingX: 1,
+        width: 10,
+      })
+    })
+
+    mounted.root.render(
+      <ThemeProvider key="light" initialState="light" onThemeSave={vi.fn()}>
+        <ThemedBox
+          ref={ref}
+          backgroundColor="agencWash"
+          borderColor="error"
+          paddingX={3}
+          width={18}
+        >
+          light
+        </ThemedBox>
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => {
+      expect(ref.current?.style).toMatchObject({
+        backgroundColor: lightTheme.agencWash,
+        borderColor: lightTheme.error,
+        paddingX: 3,
+        width: 18,
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Replace the generated React Compiler cache wrapper in `ThemedBox` with typed direct rendering.
- Remove `@ts-nocheck`, which exposed and fixes the invalid NodeNext extensionless `ThemeProvider` import.
- Add rerender coverage for theme color resolution and forwarded layout prop updates.

## Test plan
- `npm test -- tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx`
- `npx vitest run tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/design-system/ThemedBox.tsx' --coverage.reportsDirectory=coverage/themed-box-audit`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)
