### PR TITLE
fix(tui): hide indexes on custom select inputs

### DIFF
--- a/runtime/src/tui/components/CustomSelect/SelectMulti.tsx
+++ b/runtime/src/tui/components/CustomSelect/SelectMulti.tsx
@@ -146,7 +146,7 @@ export function SelectMulti<T>(t0: SelectMultiProps<T>) {
       const i = state.visibleFromIndex + index + 1;
       if (option.type === "input") {
         const inputValue = state.inputValues.get(option.value) || "";
-        return <Box key={String(option.value)} gap={1}><SelectInputOption option={option} isFocused={isOptionFocused} isSelected={false} shouldShowDownArrow={areMoreOptionsBelow && isLastVisibleOption} shouldShowUpArrow={areMoreOptionsAbove && isFirstVisibleOption} maxIndexWidth={maxIndexWidth} index={i} inputValue={inputValue} onInputChange={(value: string) => {
+        return <Box key={String(option.value)} gap={1}><SelectInputOption option={option} isFocused={isOptionFocused} isSelected={false} shouldShowDownArrow={areMoreOptionsBelow && isLastVisibleOption} shouldShowUpArrow={areMoreOptionsAbove && isFirstVisibleOption} maxIndexWidth={maxIndexWidth} index={i} hideIndex={hideIndexes} inputValue={inputValue} onInputChange={(value: string) => {
             state.updateInputValue(option.value, value);
           }} onSubmit={_temp} onExit={() => {
             onCancel();

--- a/runtime/src/tui/components/CustomSelect/select-input-option.tsx
+++ b/runtime/src/tui/components/CustomSelect/select-input-option.tsx
@@ -25,6 +25,7 @@ type Props<T> = {
   shouldShowUpArrow: boolean;
   maxIndexWidth: number;
   index: number;
+  hideIndex?: boolean;
   inputValue: string;
   onInputChange: (value: string) => void;
   onSubmit: (value: string) => void;
@@ -78,10 +79,10 @@ type Props<T> = {
    */
   onSelectedImageIndexChange?: (index: number) => void;
 };
-export function computeSelectInputColumns(columns: number, maxIndexWidth: number, showLabel: boolean, label: ReactNode, separator = ', '): number {
+export function computeSelectInputColumns(columns: number, maxIndexWidth: number, showLabel: boolean, label: ReactNode, separator = ', ', hideIndex = false): number {
   const safeColumns = Math.max(1, Math.floor(columns || 0));
   const safeMaxIndexWidth = Math.max(0, Math.floor(maxIndexWidth || 0));
-  const indexReserve = safeMaxIndexWidth + 2;
+  const indexReserve = hideIndex ? 0 : safeMaxIndexWidth + 2;
   const labelReserve = showLabel && typeof label === 'string' ? stringWidth(label) + stringWidth(separator) : 0;
   return Math.max(1, safeColumns - indexReserve - labelReserve - 2);
 }
@@ -95,6 +96,7 @@ export function SelectInputOption<T>(t0: Props<T>) {
     shouldShowUpArrow,
     maxIndexWidth,
     index,
+    hideIndex,
     inputValue,
     onInputChange,
     onSubmit,
@@ -128,7 +130,7 @@ export function SelectInputOption<T>(t0: Props<T>) {
   const {
     columns
   } = useTerminalSize();
-  const inputColumns = computeSelectInputColumns(columns, maxIndexWidth, showLabel, option.label, option.labelValueSeparator ?? ", ");
+  const inputColumns = computeSelectInputColumns(columns, maxIndexWidth, showLabel, option.label, option.labelValueSeparator ?? ", ", hideIndex === true);
   const [cursorOffset, setCursorOffset] = useState(inputValue.length);
   const isUserEditing = useRef(false);
   let t5;
@@ -369,26 +371,10 @@ export function SelectInputOption<T>(t0: Props<T>) {
     t27 = $[53];
   }
   useEffect(t26, t27);
-  const descriptionPaddingLeft = layout === "expanded" ? maxIndexWidth + 3 : maxIndexWidth + 4;
+  const indexDescriptionOffset = hideIndex === true ? 0 : maxIndexWidth;
+  const descriptionPaddingLeft = layout === "expanded" ? indexDescriptionOffset + 3 : indexDescriptionOffset + 4;
   const t28 = layout === "compact" ? 0 : undefined;
-  const t29 = `${index}.`;
-  let t30;
-  if ($[54] !== maxIndexWidth || $[55] !== t29) {
-    t30 = t29.padEnd(maxIndexWidth + 2);
-    $[54] = maxIndexWidth;
-    $[55] = t29;
-    $[56] = t30;
-  } else {
-    t30 = $[56];
-  }
-  let t31;
-  if ($[57] !== t30) {
-    t31 = <Text dimColor={true}>{t30}</Text>;
-    $[57] = t30;
-    $[58] = t31;
-  } else {
-    t31 = $[58];
-  }
+  const t31 = hideIndex === true ? null : <Text dimColor={true}>{`${index}.`.padEnd(maxIndexWidth + 2)}</Text>;
   let t32;
   if ($[59] !== cursorOffset || $[60] !== imagesSelected || $[61] !== inputColumns || $[62] !== inputValue || $[63] !== isFocused || $[64] !== onExit || $[65] !== onImagePaste || $[66] !== onInputChange || $[67] !== onSubmit || $[68] !== option || $[69] !== showLabel) {
     t32 = showLabel ? <><Text color={isFocused ? "suggestion" : undefined}>{option.label}</Text>{isFocused ? <><Text color="suggestion">{option.labelValueSeparator ?? ", "}</Text><TextInput value={inputValue} onChange={(value: string) => {

--- a/runtime/src/tui/components/CustomSelect/select.tsx
+++ b/runtime/src/tui/components/CustomSelect/select.tsx
@@ -398,7 +398,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
             const isSelected = state.value === option_1.value;
             if (option_1.type === "input") {
               const inputValue = inputValues.get(option_1.value) ?? option_1.initialValue ?? "";
-              return <SelectInputOption key={String(option_1.value)} option={option_1} isFocused={isFocused} isSelected={isSelected} shouldShowDownArrow={areMoreOptionsBelow && isLastVisibleOption} shouldShowUpArrow={areMoreOptionsAbove && isFirstVisibleOption} maxIndexWidth={maxIndexWidth} index={i} inputValue={inputValue} onInputChange={(value: string) => {
+              return <SelectInputOption key={String(option_1.value)} option={option_1} isFocused={isFocused} isSelected={isSelected} shouldShowDownArrow={areMoreOptionsBelow && isLastVisibleOption} shouldShowUpArrow={areMoreOptionsAbove && isFirstVisibleOption} maxIndexWidth={maxIndexWidth} index={i} hideIndex={hideIndexes} inputValue={inputValue} onInputChange={(value: string) => {
                 setInputValues((prev_0: Map<T, string>) => {
                   const next_0 = new Map(prev_0);
                   next_0.set(option_1.value, value);
@@ -447,7 +447,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
             const isSelected_0 = state.value === option_2.value;
             if (option_2.type === "input") {
               const inputValue_0 = inputValues.get(option_2.value) ?? option_2.initialValue ?? "";
-              return <SelectInputOption key={String(option_2.value)} option={option_2} isFocused={isFocused_0} isSelected={isSelected_0} shouldShowDownArrow={areMoreOptionsBelow_0 && isLastVisibleOption_0} shouldShowUpArrow={areMoreOptionsAbove_0 && isFirstVisibleOption_0} maxIndexWidth={maxIndexWidth_0} index={i_0} inputValue={inputValue_0} onInputChange={(value_1: string) => {
+              return <SelectInputOption key={String(option_2.value)} option={option_2} isFocused={isFocused_0} isSelected={isSelected_0} shouldShowDownArrow={areMoreOptionsBelow_0 && isLastVisibleOption_0} shouldShowUpArrow={areMoreOptionsAbove_0 && isFirstVisibleOption_0} maxIndexWidth={maxIndexWidth_0} index={i_0} hideIndex={hideIndexes} inputValue={inputValue_0} onInputChange={(value_1: string) => {
                 setInputValues((prev_1: Map<T, string>) => {
                   const next_1 = new Map(prev_1);
                   next_1.set(option_2.value, value_1);
@@ -567,7 +567,7 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
           const i_2 = state.visibleFromIndex + index_4 + 1;
           const isFocused_2 = !isDisabled && state.focusedValue === option_4.value;
           const isSelected_2 = state.value === option_4.value;
-          return <SelectInputOption key={String(option_4.value)} option={option_4} isFocused={isFocused_2} isSelected={isSelected_2} shouldShowDownArrow={areMoreOptionsBelow_2 && isLastVisibleOption_2} shouldShowUpArrow={areMoreOptionsAbove_2 && isFirstVisibleOption_2} maxIndexWidth={maxIndexWidth_1} index={i_2} inputValue={inputValue_1} onInputChange={(value_3: string) => {
+          return <SelectInputOption key={String(option_4.value)} option={option_4} isFocused={isFocused_2} isSelected={isSelected_2} shouldShowDownArrow={areMoreOptionsBelow_2 && isLastVisibleOption_2} shouldShowUpArrow={areMoreOptionsAbove_2 && isFirstVisibleOption_2} maxIndexWidth={maxIndexWidth_1} index={i_2} hideIndex={hideIndexes} inputValue={inputValue_1} onInputChange={(value_3: string) => {
             setInputValues((prev_2: Map<T, string>) => {
               const next_2 = new Map(prev_2);
               next_2.set(option_4.value, value_3);

--- a/runtime/tests/tui/components/CustomSelect/select-input-option.render.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select-input-option.render.test.tsx
@@ -311,6 +311,29 @@ describe("SelectInputOption rendering", () => {
     expect(onRemoveImage).toHaveBeenCalledWith(4);
   });
 
+  test("omits the numeric index when hidden", async () => {
+    const output = await renderOptionToText(
+      <SelectInputOption
+        option={makeInputOption()}
+        isFocused
+        isSelected={false}
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={2}
+        index={7}
+        hideIndex
+        inputValue="draft"
+        onInputChange={() => {}}
+        onSubmit={() => {}}
+        layout="compact"
+      />,
+    );
+
+    expect(output).toContain("Prompt");
+    expect(output).toContain("draft");
+    expect(output).not.toContain("7.");
+  });
+
   test("clears image selection when focus leaves the input", async () => {
     const onImagesSelectedChange = vi.fn();
 

--- a/runtime/tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx
@@ -22,6 +22,7 @@ type CapturedSelectOptionProps = {
 
 type CapturedInputOptionProps = {
   imagesSelected?: boolean
+  hideIndex?: boolean
   inputValue: string
   isFocused: boolean
   isSelected: boolean
@@ -376,6 +377,43 @@ describe('Select coverage swarm row 011', () => {
       expect(latestInputOption()).toMatchObject({
         imagesSelected: true,
         selectedImageIndex: 1,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('propagates hidden indexes to compact input rows', async () => {
+    const options: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        initialValue: 'draft',
+        onChange: () => {},
+      },
+      {
+        value: 'plain',
+        label: 'Plain option',
+      },
+    ]
+
+    const rendered = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="prompt"
+        hideIndexes={true}
+      />,
+    )
+
+    try {
+      expect(latestInputOption()).toMatchObject({
+        hideIndex: true,
+        inputValue: 'draft',
+        isFocused: true,
+      })
+      expect(harness.selectInputProps).toMatchObject({
+        disableSelection: 'numeric',
       })
     } finally {
       await rendered.dispose()


### PR DESCRIPTION
## Summary
- Honor `hideIndexes` for CustomSelect input rows in single and multi-select render paths.
- Add `hideIndex` support to `SelectInputOption`, including input width reservation and description/image indentation.
- Add regressions proving Select propagates hidden indexes to input rows and the rendered input option omits the numeric index.

## Test plan
- `npm test -- tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx -t "propagates hidden indexes"`
- `npm test -- tests/tui/components/CustomSelect/select-input-option.render.test.tsx -t "omits the numeric index"`
- `npm test -- tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/components/CustomSelect/select-input-option.render.test.tsx tests/tui/components/CustomSelect/select.render.test.tsx tests/tui/components/CustomSelect/select.coverage2.test.tsx tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx`
- `npm test -- tests/tui/components/CustomSelect tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx tests/tui/coverage-swarm/swarm-134-components-CustomSelect-SelectMulti.test.tsx`
- `npm run typecheck`
- `git diff --check`
- `npx vitest run tests/tui/components/CustomSelect tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx tests/tui/coverage-swarm/swarm-134-components-CustomSelect-SelectMulti.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/CustomSelect/*.{ts,tsx}' --coverage.reportsDirectory=coverage/custom-select-hide-indexes`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)