### PR TITLE
fix(tui): honor ascii ide status glyphs

### DIFF
--- a/runtime/src/tui/components/IdeStatusIndicator.tsx
+++ b/runtime/src/tui/components/IdeStatusIndicator.tsx
@@ -1,59 +1,48 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { c as _c } from "react-compiler-runtime";
 import { basename } from 'path';
-import * as React from 'react';
-import { useIdeConnectionStatus } from '../hooks/useIdeConnectionStatus';
-import type { IDESelection } from '../hooks/useIdeSelection';
+import type React from 'react';
+
+import type { MCPServerConnection } from '../../services/mcp/types.js';
+import { selectAgenCTuiGlyphs } from '../glyphs.js';
+import { useIdeConnectionStatus } from '../hooks/useIdeConnectionStatus.js';
+import type { IDESelection } from '../hooks/useIdeSelection.js';
 import { Text } from '../ink.js';
-import type { MCPServerConnection } from '../../services/mcp/types';
+
 type IdeStatusIndicatorProps = {
   ideSelection: IDESelection | undefined;
   mcpClients?: MCPServerConnection[];
 };
-export function IdeStatusIndicator(t0) {
-  const $ = _c(7);
-  const {
-    ideSelection,
-    mcpClients
-  } = t0;
-  const {
-    status: ideStatus
-  } = useIdeConnectionStatus(mcpClients);
-  const shouldShowIdeSelection = ideStatus === "connected" && (ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
-  if (ideStatus === null || !shouldShowIdeSelection || !ideSelection) {
+
+export function IdeStatusIndicator({
+  ideSelection,
+  mcpClients,
+}: IdeStatusIndicatorProps): React.ReactNode {
+  const { status: ideStatus } = useIdeConnectionStatus(mcpClients);
+  const shouldShowIdeSelection =
+    ideStatus === 'connected' &&
+    Boolean(
+      ideSelection?.filePath ||
+        (ideSelection?.text && ideSelection.lineCount > 0),
+    );
+
+  if (!shouldShowIdeSelection || !ideSelection) {
     return null;
   }
+
+  const ideSelectionGlyph = selectAgenCTuiGlyphs().ideSelection;
+
   if (ideSelection.text && ideSelection.lineCount > 0) {
-    const t1 = ideSelection.lineCount === 1 ? "line" : "lines";
-    let t2;
-    if ($[0] !== ideSelection.lineCount || $[1] !== t1) {
-      t2 = <Text color="ide" key="selection-indicator" wrap="truncate">⧉ {ideSelection.lineCount}{" "}{t1} selected</Text>;
-      $[0] = ideSelection.lineCount;
-      $[1] = t1;
-      $[2] = t2;
-    } else {
-      t2 = $[2];
-    }
-    return t2;
+    const lineLabel = ideSelection.lineCount === 1 ? 'line' : 'lines';
+
+    return (
+      <Text color="ide" key="selection-indicator" wrap="truncate">
+        {ideSelectionGlyph} {ideSelection.lineCount} {lineLabel} selected
+      </Text>
+    );
   }
-  if (ideSelection.filePath) {
-    let t1;
-    if ($[3] !== ideSelection.filePath) {
-      t1 = basename(ideSelection.filePath);
-      $[3] = ideSelection.filePath;
-      $[4] = t1;
-    } else {
-      t1 = $[4];
-    }
-    let t2;
-    if ($[5] !== t1) {
-      t2 = <Text color="ide" key="selection-indicator" wrap="truncate">⧉ In {t1}</Text>;
-      $[5] = t1;
-      $[6] = t2;
-    } else {
-      t2 = $[6];
-    }
-    return t2;
-  }
+
+  return (
+    <Text color="ide" key="selection-indicator" wrap="truncate">
+      {ideSelectionGlyph} In {basename(ideSelection.filePath ?? '')}
+    </Text>
+  );
 }

--- a/runtime/src/tui/glyphs.ts
+++ b/runtime/src/tui/glyphs.ts
@@ -10,6 +10,7 @@ export interface AgenCTuiGlyphs {
   readonly enter: string;
   readonly ellipsis: string;
   readonly horizontal: string;
+  readonly ideSelection: string;
   readonly modalDivider: string;
   readonly mcpResource: string;
   readonly pointer: string;
@@ -44,6 +45,7 @@ const ASCII_GLYPHS: AgenCTuiGlyphs = {
   enter: "Enter",
   ellipsis: "...",
   horizontal: "-",
+  ideSelection: "[]",
   modalDivider: "-",
   mcpResource: "*",
   pointer: ">",
@@ -78,6 +80,7 @@ const UNICODE_GLYPHS: AgenCTuiGlyphs = {
   enter: "↵",
   ellipsis: "…",
   horizontal: "─",
+  ideSelection: "⧉",
   modalDivider: "▔",
   mcpResource: "◇",
   pointer: figures.pointer,

--- a/runtime/tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx
+++ b/runtime/tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import type { MCPServerConnection } from "../../services/mcp/types.js";
 import { renderToString } from "../../utils/staticRender.js";
@@ -19,6 +19,16 @@ function ideClient(type: MCPServerConnection["type"]): MCPServerConnection {
 }
 
 describe("IdeStatusIndicator coverage", () => {
+  const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+  });
+
   test("renders selection context only when the IDE client is connected", async () => {
     expect(
       (
@@ -85,5 +95,28 @@ describe("IdeStatusIndicator coverage", () => {
         80,
       ),
     ).resolves.toContain("In app.tsx");
+  });
+
+  test("uses an ASCII-safe IDE glyph when glyph mode is ASCII", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const selectedText = await renderToString(
+      <IdeStatusIndicator
+        ideSelection={{ text: "selected", lineCount: 1 }}
+        mcpClients={[ideClient("connected")]}
+      />,
+      80,
+    );
+    const fileContext = await renderToString(
+      <IdeStatusIndicator
+        ideSelection={{ filePath: "/repo/src/app.tsx", lineCount: 0 }}
+        mcpClients={[ideClient("connected")]}
+      />,
+      80,
+    );
+
+    expect(selectedText).toContain("[] 1 line selected");
+    expect(fileContext).toContain("[] In app.tsx");
+    expect(`${selectedText}\n${fileContext}`).not.toContain("⧉");
   });
 });

--- a/runtime/tests/tui/glyphs.test.ts
+++ b/runtime/tests/tui/glyphs.test.ts
@@ -14,6 +14,7 @@ describe("AgenC TUI glyph selection", () => {
     expect(selectAgenCTuiGlyphs({}).pointer).not.toBe(">");
     expect(selectAgenCTuiGlyphs({}).ellipsis).toBe("…");
     expect(selectAgenCTuiGlyphs({}).horizontal).toBe("─");
+    expect(selectAgenCTuiGlyphs({}).ideSelection).toBe("⧉");
     expect(selectAgenCTuiGlyphs({}).responseGutter).toBe("⎿");
     expect(selectAgenCTuiGlyphs({}).spinnerFrames).toEqual([
       "·",
@@ -48,6 +49,7 @@ describe("AgenC TUI glyph selection", () => {
       enter: "Enter",
       ellipsis: "...",
       horizontal: "-",
+      ideSelection: "[]",
       modalDivider: "-",
       mcpResource: "*",
       pointer: ">",


### PR DESCRIPTION
## Summary
- Add an IDE selection glyph to the central TUI glyph table.
- Render `IdeStatusIndicator` with the active glyph mode so ASCII mode no longer shows `⧉`.
- Replace the generated `@ts-nocheck` wrapper in `IdeStatusIndicator` with typed direct rendering and `.js` imports.

## Test plan
- `npm test -- tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx -t "ASCII-safe"` (failed before fix, passed after)
- `npm test -- tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx tests/tui/coverage-swarm/swarm-186-components-IdeStatusIndicator.test.tsx tests/tui/glyphs.test.ts`
- `npx vitest run tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx tests/tui/coverage-swarm/swarm-186-components-IdeStatusIndicator.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/IdeStatusIndicator.tsx' --coverage.include='src/tui/glyphs.ts' --coverage.reportsDirectory=coverage/ide-status-ascii-glyph`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)