### PR TITLE
fix(tui): honor ascii tool approval glyphs

### DIFF
--- a/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx
@@ -1,5 +1,4 @@
 import { feature } from 'bun:bundle';
-import figures from 'figures';
 import * as React from 'react';
 import { SentryErrorBoundary } from '../../components/SentryErrorBoundary.js';
 import { Box, Text, useTheme } from '../../ink.js';
@@ -10,6 +9,7 @@ import { deleteClassifierApproval, getClassifierApproval, getYoloClassifierAppro
 import { extractTag, type buildMessageLookups } from '../../../utils/messages.js';
 import { MessageResponse } from '../../components/MessageResponse';
 import { HookProgressMessage } from '../HookProgressMessage';
+import { selectAgenCTuiGlyphs } from '../../glyphs.js';
 type Props = {
   message: NormalizedUserMessage;
   lookups: ReturnType<typeof buildMessageLookups>;
@@ -68,6 +68,7 @@ export function UserToolSuccessMessage({
   isTranscriptMode
 }: Props): React.ReactNode {
   const [theme] = useTheme();
+  const glyphs = selectAgenCTuiGlyphs();
   // Hook stays inside feature() ternary so external builds don't pay a
   // per-scrollback-message store subscription — same pattern as
   // UserPromptMessage.tsx.
@@ -90,8 +91,8 @@ export function UserToolSuccessMessage({
             <Text>{fallbackContent}</Text>
             {feature('BASH_CLASSIFIER') ? classifierRule && <MessageResponse height={1}>
                     <Text dimColor>
-                      <Text color="success">{figures.tick}</Text>
-                      {' Auto-approved · matched '}
+                      <Text color="success">{glyphs.statusSuccess}</Text>
+                      {` Auto-approved ${glyphs.separator} matched `}
                       {`"${classifierRule}"`}
                     </Text>
                   </MessageResponse> : null}
@@ -116,8 +117,8 @@ export function UserToolSuccessMessage({
             <Text>{fallbackContent}</Text>
             {feature('BASH_CLASSIFIER') ? classifierRule && <MessageResponse height={1}>
                     <Text dimColor>
-                      <Text color="success">{figures.tick}</Text>
-                      {' Auto-approved · matched '}
+                      <Text color="success">{glyphs.statusSuccess}</Text>
+                      {` Auto-approved ${glyphs.separator} matched `}
                       {`"${classifierRule}"`}
                     </Text>
                   </MessageResponse> : null}
@@ -156,8 +157,8 @@ export function UserToolSuccessMessage({
         {renderedMessage}
         {feature('BASH_CLASSIFIER') ? classifierRule && <MessageResponse height={1}>
                 <Text dimColor>
-                  <Text color="success">{figures.tick}</Text>
-                  {' Auto-approved \u00b7 matched '}
+                  <Text color="success">{glyphs.statusSuccess}</Text>
+                  {` Auto-approved ${glyphs.separator} matched `}
                   {`"${classifierRule}"`}
                 </Text>
               </MessageResponse> : null}

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx
@@ -28,6 +28,16 @@ function createLookups(toolUseID: string) {
 }
 
 describe('UserToolSuccessMessage wave200-060 coverage', () => {
+  const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
   test('renders parsed successful output with filtered progress, input, approval, and hook status', async () => {
     const toolUseID = 'toolu_success_wave200_060'
     setClassifierApproval(toolUseID, 'Bash(ls:*)')
@@ -121,5 +131,77 @@ describe('UserToolSuccessMessage wave200-060 coverage', () => {
     expect(output).toContain('"Bash(ls:*)"')
     expect(output).toContain('Running PostToolUse hook')
     expect(output).not.toContain('fallback should stay hidden')
+  })
+
+  test('uses ASCII glyphs for auto-approval rows when glyph mode is ASCII', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+    const toolUseID = 'toolu_success_ascii_approval'
+    const fallbackToolUseID = 'toolu_success_ascii_fallback_approval'
+    setClassifierApproval(toolUseID, 'Bash(cat:*)')
+    setClassifierApproval(fallbackToolUseID, 'Bash(echo:*)')
+
+    const tool = {
+      renderToolResultMessage: () => <Text>ascii tool result</Text>,
+      userFacingName: () => 'ASCII tool',
+    } as unknown as Tool
+
+    const output = await renderToString(
+      <UserToolSuccessMessage
+        message={{
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: toolUseID,
+                content: 'fallback should stay hidden',
+              },
+            ],
+          },
+          toolUseResult: { ok: true },
+        } as never}
+        lookups={createLookups(toolUseID)}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[]}
+        tool={tool}
+        tools={[tool] as Tools}
+        verbose={false}
+        width={72}
+      />,
+      { columns: 100, rows: 12 },
+    )
+    const fallbackOutput = await renderToString(
+      <UserToolSuccessMessage
+        message={{
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: fallbackToolUseID,
+                content: '<persisted-output>ascii fallback output</persisted-output>',
+              },
+            ],
+          },
+          toolUseResult: null,
+        } as never}
+        lookups={createLookups(fallbackToolUseID)}
+        toolUseID={fallbackToolUseID}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={false}
+        width={72}
+      />,
+      { columns: 100, rows: 12 },
+    )
+
+    expect(output).toContain('OK Auto-approved - matched "Bash(cat:*)"')
+    expect(fallbackOutput).toContain('ascii fallback output')
+    expect(fallbackOutput).toContain(
+      'OK Auto-approved - matched "Bash(echo:*)"',
+    )
+    expect(`${output}\n${fallbackOutput}`).not.toMatch(/[✓✔·]/u)
   })
 })


### PR DESCRIPTION
## Summary
- Render BASH_CLASSIFIER auto-approval rows through the active TUI glyph table.
- Fix ASCII glyph mode for tool success approval rows in both delegated result and recovered fallback rendering.
- Add a regression proving ASCII mode uses `OK` and `-` instead of Unicode tick/middle-dot markers.

## Test plan
- `npm test -- tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx -t "ASCII glyphs"` (failed before fix, passed after)
- `npm test -- tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx`
- `npx vitest run tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx' --coverage.reportsDirectory=coverage/tool-success-ascii-approval`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)
