### PR TITLE
fix(tui): type highlighted code fallback

### DIFF
--- a/runtime/src/tui/components/markdown/HighlightedCodeFallback.tsx
+++ b/runtime/src/tui/components/markdown/HighlightedCodeFallback.tsx
@@ -1,198 +1,125 @@
-// @ts-nocheck
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { c as _c } from "react-compiler-runtime";
-import { extname } from 'path';
-import React, { Suspense, use, useMemo } from 'react';
-import { Ansi, Text } from '../../ink.js';
-import { getCliHighlightPromise } from '../../../utils/cliHighlight.js';
-import { logForDebugging } from '../../../utils/debug.js';
-import { convertLeadingTabsToSpaces } from '../../../utils/file.js';
-import { hashPair } from '../../../utils/hash.js';
-type Props = {
-  code: string;
-  filePath: string;
-  dim?: boolean;
-  skipColoring?: boolean;
-};
+import { extname } from 'path'
+import { Suspense, use, type ReactNode } from 'react'
 
-// Module-level highlight cache — hl.highlight() is the hot cost on virtual-
-// scroll remounts. useMemo doesn't survive unmount→remount. Keyed by hash
+import { Ansi, Text } from '../../ink.js'
+import { getCliHighlightPromise } from '../../../utils/cliHighlight.js'
+import { logForDebugging } from '../../../utils/debug.js'
+import { convertLeadingTabsToSpaces } from '../../../utils/file.js'
+import { hashPair } from '../../../utils/hash.js'
+
+type Props = {
+  code: string
+  filePath: string
+  dim?: boolean
+  skipColoring?: boolean
+}
+
+type CliHighlighter = NonNullable<
+  Awaited<ReturnType<typeof getCliHighlightPromise>>
+>
+
+// Module-level highlight cache - hl.highlight() is the hot cost on virtual
+// scroll remounts. useMemo doesn't survive unmount->remount. Keyed by hash
 // of code+language to avoid retaining full source strings (#24180 RSS fix).
-const HL_CACHE_MAX = 500;
-const hlCache = new Map<string, string>();
-function cachedHighlight(hl: NonNullable<Awaited<ReturnType<typeof getCliHighlightPromise>>>, code: string, language: string): string {
-  const key = hashPair(language, code);
-  const hit = hlCache.get(key);
+const HL_CACHE_MAX = 500
+const hlCache = new Map<string, string>()
+
+function cachedHighlight(
+  hl: CliHighlighter,
+  code: string,
+  language: string,
+): string {
+  const key = hashPair(language, code)
+  const hit = hlCache.get(key)
   if (hit !== undefined) {
-    hlCache.delete(key);
-    hlCache.set(key, hit);
-    return hit;
+    hlCache.delete(key)
+    hlCache.set(key, hit)
+    return hit
   }
-  const out = hl.highlight(code, {
-    language
-  });
+  const out = hl.highlight(code, { language })
   if (hlCache.size >= HL_CACHE_MAX) {
-    const first = hlCache.keys().next().value;
-    if (first !== undefined) hlCache.delete(first);
+    const first = hlCache.keys().next().value
+    hlCache.delete(first!)
   }
-  hlCache.set(key, out);
-  return out;
+  hlCache.set(key, out)
+  return out
 }
-export function HighlightedCodeFallback(t0) {
-  const $ = _c(20);
-  const {
-    code,
-    filePath,
-    dim: t1,
-    skipColoring: t2
-  } = t0;
-  const dim = t1 === undefined ? false : t1;
-  const skipColoring = t2 === undefined ? false : t2;
-  let t3;
-  if ($[0] !== code) {
-    t3 = convertLeadingTabsToSpaces(code);
-    $[0] = code;
-    $[1] = t3;
-  } else {
-    t3 = $[1];
-  }
-  const codeWithSpaces = t3;
+
+export function HighlightedCodeFallback({
+  code,
+  filePath,
+  dim = false,
+  skipColoring = false,
+}: Props): ReactNode {
+  const codeWithSpaces = convertLeadingTabsToSpaces(code)
+
   if (skipColoring) {
-    let t4;
-    if ($[2] !== codeWithSpaces) {
-      t4 = <Ansi>{codeWithSpaces}</Ansi>;
-      $[2] = codeWithSpaces;
-      $[3] = t4;
-    } else {
-      t4 = $[3];
-    }
-    let t5;
-    if ($[4] !== dim || $[5] !== t4) {
-      t5 = <Text dimColor={dim}>{t4}</Text>;
-      $[4] = dim;
-      $[5] = t4;
-      $[6] = t5;
-    } else {
-      t5 = $[6];
-    }
-    return t5;
+    return (
+      <Text dimColor={dim}>
+        <Ansi>{codeWithSpaces}</Ansi>
+      </Text>
+    )
   }
-  let t4;
-  if ($[7] !== filePath) {
-    t4 = extname(filePath).slice(1);
-    $[7] = filePath;
-    $[8] = t4;
-  } else {
-    t4 = $[8];
-  }
-  const language = t4;
-  let t5;
-  if ($[9] !== codeWithSpaces) {
-    t5 = <Ansi>{codeWithSpaces}</Ansi>;
-    $[9] = codeWithSpaces;
-    $[10] = t5;
-  } else {
-    t5 = $[10];
-  }
-  let t6;
-  if ($[11] !== codeWithSpaces || $[12] !== language) {
-    t6 = <Highlighted codeWithSpaces={codeWithSpaces} language={language} />;
-    $[11] = codeWithSpaces;
-    $[12] = language;
-    $[13] = t6;
-  } else {
-    t6 = $[13];
-  }
-  let t7;
-  if ($[14] !== t5 || $[15] !== t6) {
-    t7 = <Suspense fallback={t5}>{t6}</Suspense>;
-    $[14] = t5;
-    $[15] = t6;
-    $[16] = t7;
-  } else {
-    t7 = $[16];
-  }
-  let t8;
-  if ($[17] !== dim || $[18] !== t7) {
-    t8 = <Text dimColor={dim}>{t7}</Text>;
-    $[17] = dim;
-    $[18] = t7;
-    $[19] = t8;
-  } else {
-    t8 = $[19];
-  }
-  return t8;
+
+  const language = extname(filePath).slice(1)
+  const fallback = <Ansi>{codeWithSpaces}</Ansi>
+
+  return (
+    <Text dimColor={dim}>
+      <Suspense fallback={fallback}>
+        <Highlighted codeWithSpaces={codeWithSpaces} language={language} />
+      </Suspense>
+    </Text>
+  )
 }
-function Highlighted(t0) {
-  const $ = _c(10);
-  const {
-    codeWithSpaces,
-    language
-  } = t0;
-  let t1;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = getCliHighlightPromise();
-    $[0] = t1;
-  } else {
-    t1 = $[0];
+
+function Highlighted({
+  codeWithSpaces,
+  language,
+}: {
+  codeWithSpaces: string
+  language: string
+}): ReactNode {
+  const hl = use(getCliHighlightPromise())
+  const out = highlightCode(hl, codeWithSpaces, language)
+  return <Ansi>{out}</Ansi>
+}
+
+function highlightCode(
+  hl: Awaited<ReturnType<typeof getCliHighlightPromise>>,
+  codeWithSpaces: string,
+  language: string,
+): string {
+  if (!hl) return codeWithSpaces
+
+  let highlightLang = 'markdown'
+  if (language) {
+    if (hl.supportsLanguage(language)) {
+      highlightLang = language
+    } else {
+      logForDebugging(
+        `Language not supported while highlighting code, falling back to markdown: ${language}`,
+      )
+    }
   }
-  const hl = use(t1);
-  let t2;
-  if ($[1] !== codeWithSpaces || $[2] !== hl || $[3] !== language) {
-    bb0: {
-      if (!hl) {
-        t2 = codeWithSpaces;
-        break bb0;
-      }
-      let highlightLang = "markdown";
-      if (language) {
-        if (hl.supportsLanguage(language)) {
-          highlightLang = language;
-        } else {
-          logForDebugging(`Language not supported while highlighting code, falling back to markdown: ${language}`);
-        }
-      }
-      ;
+
+  try {
+    return cachedHighlight(hl, codeWithSpaces, highlightLang)
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes('Unknown language')
+    ) {
+      logForDebugging(
+        `Language not supported while highlighting code, falling back to markdown: ${error}`,
+      )
       try {
-        t2 = cachedHighlight(hl, codeWithSpaces, highlightLang);
-      } catch (t3) {
-        const e = t3;
-        if (e instanceof Error && e.message.includes("Unknown language")) {
-          logForDebugging(`Language not supported while highlighting code, falling back to markdown: ${e}`);
-          let t4;
-          if ($[5] !== codeWithSpaces || $[6] !== hl) {
-            try {
-              t4 = cachedHighlight(hl, codeWithSpaces, "markdown");
-            } catch {
-              t4 = codeWithSpaces;
-            }
-            $[5] = codeWithSpaces;
-            $[6] = hl;
-            $[7] = t4;
-          } else {
-            t4 = $[7];
-          }
-          t2 = t4;
-          break bb0;
-        }
-        t2 = codeWithSpaces;
+        return cachedHighlight(hl, codeWithSpaces, 'markdown')
+      } catch {
+        return codeWithSpaces
       }
     }
-    $[1] = codeWithSpaces;
-    $[2] = hl;
-    $[3] = language;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
+    return codeWithSpaces
   }
-  const out = t2;
-  let t3;
-  if ($[8] !== out) {
-    t3 = <Ansi>{out}</Ansi>;
-    $[8] = out;
-    $[9] = t3;
-  } else {
-    t3 = $[9];
-  }
-  return t3;
 }

--- a/runtime/tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
@@ -179,6 +179,27 @@ describe('HighlightedCodeFallback coverage swarm row 031', () => {
     expect(highlightMock.highlight).not.toHaveBeenCalled()
   })
 
+  test('uses markdown highlighting directly for extensionless paths', async () => {
+    const code = 'row031 extensionless note'
+    const expected = `highlighted:markdown:${code}`
+
+    const output = await renderToText(
+      <HighlightedCodeFallback code={code} filePath="README" />,
+      expected,
+    )
+
+    expect(output).toContain(expected)
+    expect(highlightMock.supportsLanguage).not.toHaveBeenCalled()
+    expect(highlightMock.highlight).toHaveBeenCalledWith(code, {
+      language: 'markdown',
+    })
+    expect(
+      highlightMock.logForDebugging.mock.calls.some(([message]) =>
+        String(message).includes('Language not supported'),
+      ),
+    ).toBe(false)
+  })
+
   test('retries markdown highlighting when the supported language throws an unknown-language error', async () => {
     const code = 'let row031_retry = true;'
     const expected = `highlighted:markdown:${code}`
@@ -266,5 +287,43 @@ describe('HighlightedCodeFallback coverage swarm row 031', () => {
         String(message).includes('falling back to markdown'),
       ),
     ).toBe(false)
+  })
+
+  test('evicts the oldest highlighted entry after cache pressure', async () => {
+    const codes = Array.from(
+      { length: 505 },
+      (_, index) => `const row031_cache_pressure_${index} = true`,
+    )
+    const lastCode = codes.at(-1)!
+
+    await renderToText(
+      <>
+        {codes.map(code => (
+          <HighlightedCodeFallback
+            key={code}
+            code={code}
+            filePath="fixture.js"
+          />
+        ))}
+      </>,
+      `highlighted:js:${lastCode}`,
+      {
+        afterExpected: () => highlightMock.highlight.mock.calls.length >= 505,
+      },
+    )
+
+    highlightMock.highlight.mockClear()
+    await renderToText(
+      <HighlightedCodeFallback code={codes[0]!} filePath="fixture.js" />,
+      `highlighted:js:${codes[0]!}`,
+      {
+        afterExpected: () => highlightMock.highlight.mock.calls.length === 1,
+      },
+    )
+
+    expect(highlightMock.highlight).toHaveBeenCalledTimes(1)
+    expect(highlightMock.highlight).toHaveBeenCalledWith(codes[0], {
+      language: 'js',
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Replace the generated React Compiler wrapper in `HighlightedCodeFallback` with typed direct rendering.
- Preserve skip-coloring, Suspense fallback, highlighter-null, unsupported-language, unknown-language retry, generic-error, and module highlight-cache behavior.
- Add regression coverage for extensionless markdown highlighting and cache eviction under remount pressure.

## Test plan
- `npx vitest run tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx tests/tui/components/markdown/HighlightedCodeFallback.coverage.test.tsx tests/tui/components/markdown/HighlightedCodeFallback.wave200-080.coverage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/markdown/HighlightedCodeFallback.tsx' --coverage.reportsDirectory=coverage/highlighted-code-fallback-after`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)
