### PR TITLE
fix(tui): drop clipboard OSC after ink stops

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -1057,7 +1057,9 @@ export default class Ink {
       // Raw OSC 52, or DCS-passthrough-wrapped OSC 52 inside tmux (tmux
       // drops it silently unless allow-passthrough is on — no regression).
       void setClipboard(text).then(raw => {
-        if (raw) this.options.stdout.write(raw);
+        if (raw && !this.isUnmounted && !this.isPaused) {
+          this.options.stdout.write(raw);
+        }
       }).catch(logError);
     }
     return text;

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -309,6 +309,89 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('writes delayed clipboard OSC while the instance is still active', async () => {
+    const rawClipboard = '\u001b]52;c;YWxwaGE=\u0007'
+    clipboardMock.setClipboard.mockResolvedValueOnce(rawClipboard)
+    const harness = await createHarness({ columns: 40, rows: 6 })
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(textNode('alpha beta'))
+      await sleep(10)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.handleMultiClick(1, 0, 2)
+      expect(harness.instance.copySelectionNoClear()).toBe('alpha')
+      await sleep(10)
+
+      expect(harness.stdoutWrites.join('')).toContain(rawClipboard)
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('does not write delayed clipboard OSC after unmounting', async () => {
+    let resolveClipboard: (raw: string) => void = () => {}
+    clipboardMock.setClipboard.mockReturnValueOnce(
+      new Promise<string>(resolve => {
+        resolveClipboard = resolve
+      }),
+    )
+    const harness = await createHarness({ columns: 40, rows: 6 })
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(textNode('alpha beta'))
+      await sleep(10)
+
+      harness.instance.handleMultiClick(1, 0, 2)
+      expect(harness.instance.copySelectionNoClear()).toBe('alpha')
+
+      harness.root.unmount()
+      harness.stdoutWrites.length = 0
+
+      resolveClipboard('\u001b]52;c;YWxwaGE=\u0007')
+      await sleep(10)
+
+      expect(harness.stdoutWrites.join('')).not.toContain('\u001b]52;')
+    } finally {
+      harness.stdin.end()
+      harness.stdout.end()
+      harness.stderr.end()
+      await sleep(25)
+    }
+  })
+
+  test('does not write delayed clipboard OSC while paused for external handoff', async () => {
+    let resolveClipboard: (raw: string) => void = () => {}
+    clipboardMock.setClipboard.mockReturnValueOnce(
+      new Promise<string>(resolve => {
+        resolveClipboard = resolve
+      }),
+    )
+    const harness = await createHarness({ columns: 40, rows: 6 })
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(textNode('alpha beta'))
+      await sleep(10)
+
+      harness.instance.handleMultiClick(1, 0, 2)
+      expect(harness.instance.copySelectionNoClear()).toBe('alpha')
+
+      harness.instance.pause()
+      harness.stdoutWrites.length = 0
+
+      resolveClipboard('\u001b]52;c;YWxwaGE=\u0007')
+      await sleep(10)
+
+      expect(harness.stdoutWrites.join('')).not.toContain('\u001b]52;')
+      harness.instance.resume()
+    } finally {
+      await harness.dispose()
+    }
+  })
+
   test('looks up rendered hyperlinks, dispatches hit-tested mouse events, and opens mutable hyperlink handlers', async () => {
     const harness = await createHarness({ columns: 40, rows: 6 })
     const clicks: Array<{ localCol?: number; localRow?: number }> = []


### PR DESCRIPTION
## Summary
- Drop delayed OSC 52 clipboard writes once Ink is unmounted or paused for an external terminal handoff.
- Preserve the active-instance clipboard path so copy-on-select still emits raw clipboard control data when Ink is live.
- Add regressions for active, unmounted, and paused delayed clipboard resolution.

## Test plan
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "delayed clipboard"` (failed before fix, passed after)
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "clipboard OSC"`
- `npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/ink/ink.tsx' --coverage.reportsDirectory=coverage/ink-clipboard-unmount`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)