### PR TITLE
fix(tui): suppress mode reassert after ink unmount

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -931,7 +931,7 @@ export default class Ink {
    * handleResize.
    */
   reassertTerminalModes = (includeAltScreen = false): void => {
-    if (!this.options.stdout.isTTY) return;
+    if (!this.options.stdout.isTTY || this.isUnmounted) return;
     // Don't touch the terminal during an editor handoff — re-enabling kitty
     // keyboard here would undo enterAlternateScreen's disable and nano would
     // start seeing CSI-u sequences again.

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -229,6 +229,30 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('does not reassert terminal modes after unmounting', async () => {
+    const harness = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      harness.instance.setAltScreenActive(true, true)
+      harness.root.render(textNode('ready'))
+      await sleep(10)
+
+      harness.root.unmount()
+      harness.stdoutWrites.length = 0
+
+      harness.instance.reassertTerminalModes(true)
+
+      const writes = harness.stdoutWrites.join('')
+      expect(writes).not.toContain(ENABLE_MOUSE_TRACKING)
+      expect(writes).not.toContain(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME)
+    } finally {
+      harness.stdin.end()
+      harness.stdout.end()
+      harness.stderr.end()
+      await sleep(25)
+    }
+  })
+
   test('suspends and resumes stdin listeners and raw mode around external TUI handoff', async () => {
     const harness = await createHarness({ stdinIsRaw: true })
     const readableListener = vi.fn()


### PR DESCRIPTION
## Summary
- Prevent stale Ink terminal-mode reassert callbacks from writing after the instance has unmounted.
- Add a regression for the alt-screen + mouse-tracking path that previously re-entered alt-screen after unmount.

## Test plan
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "does not reassert terminal modes after unmounting"` (failed before fix, passed after)
- `npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/ink/ink.tsx' --coverage.reportsDirectory=coverage/ink-detached-mode-reassert`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)