### PR TITLE
fix(tui): ignore stale ink resume signals

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -304,7 +304,7 @@ export default class Ink {
     }
   }
   private handleResume = () => {
-    if (!this.options.stdout.isTTY) {
+    if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) {
       return;
     }
 

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -52,6 +52,7 @@ type TestStdin = PassThrough & {
 
 type InkInternals = Ink & {
   frontFrame: Frame
+  handleResume: () => void
   prevFrameContaminated: boolean
   rootNode: DOMElement
   selection: Ink['selection']
@@ -250,6 +251,50 @@ describe('Ink instance rendering paths', () => {
       harness.stdout.end()
       harness.stderr.end()
       await sleep(25)
+    }
+  })
+
+  test('ignores stale terminal resume after unmounting or while paused', async () => {
+    const unmounted = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      unmounted.instance.setAltScreenActive(true, true)
+      unmounted.root.render(textNode('ready'))
+      await sleep(10)
+
+      unmounted.root.unmount()
+      unmounted.stdoutWrites.length = 0
+
+      unmounted.instance.handleResume()
+
+      const writes = unmounted.stdoutWrites.join('')
+      expect(writes).not.toContain(ENABLE_MOUSE_TRACKING)
+      expect(writes).not.toContain(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME)
+    } finally {
+      unmounted.stdin.end()
+      unmounted.stdout.end()
+      unmounted.stderr.end()
+      await sleep(25)
+    }
+
+    const paused = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      paused.instance.setAltScreenActive(true, true)
+      paused.root.render(textNode('ready'))
+      await sleep(10)
+
+      paused.instance.pause()
+      paused.stdoutWrites.length = 0
+
+      paused.instance.handleResume()
+
+      const writes = paused.stdoutWrites.join('')
+      expect(writes).not.toContain(ENABLE_MOUSE_TRACKING)
+      expect(writes).not.toContain(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME)
+      paused.instance.resume()
+    } finally {
+      await paused.dispose()
     }
   })
 


### PR DESCRIPTION
## Summary
- Prevent stale SIGCONT/resume handling from re-entering alt-screen after Ink has unmounted.
- Avoid clearing/reasserting terminal modes while Ink is paused for an external TUI handoff.
- Add regressions for unmounted and paused stale resume paths.

## Test plan
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "ignores stale terminal resume"` (failed before fix, passed after)
- `npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/ink/ink.tsx' --coverage.reportsDirectory=coverage/ink-ignore-stale-resume`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)