### PR TITLE
fix(tui): ignore detached ink resize events

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -333,6 +333,7 @@ export default class Ink {
   // blank→paint flicker). useVirtualScroll's height scaling already bounds
   // the per-resize cost; synchronous handling keeps dimensions consistent.
   private handleResize = () => {
+    if (this.isUnmounted) return;
     const cols = this.options.stdout.columns || 80;
     const rows = this.options.stdout.rows || 24;
     // Terminals often emit 2+ resize events for one user action (window

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -298,6 +298,38 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('ignores resize events after shutdown detach', async () => {
+    const harness = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      harness.instance.setAltScreenActive(true, true)
+      harness.root.render(textNode('ready'))
+      await sleep(10)
+
+      const widthBeforeDetach = harness.instance.frontFrame.screen.width
+      const heightBeforeDetach = harness.instance.frontFrame.screen.height
+      harness.instance.detachForShutdown()
+      harness.stdoutWrites.length = 0
+
+      harness.stdout.columns = 32
+      harness.stdout.rows = 9
+      harness.stdout.emit('resize')
+      await sleep(10)
+
+      const writes = harness.stdoutWrites.join('')
+      expect(writes).not.toContain(ENABLE_MOUSE_TRACKING)
+      expect(writes).not.toContain(ERASE_SCREEN + CURSOR_HOME)
+      expect(harness.instance.frontFrame.screen.width).toBe(widthBeforeDetach)
+      expect(harness.instance.frontFrame.screen.height).toBe(heightBeforeDetach)
+    } finally {
+      instances.delete(harness.stdout as unknown as NodeJS.WriteStream)
+      harness.stdin.end()
+      harness.stdout.end()
+      harness.stderr.end()
+      await sleep(25)
+    }
+  })
+
   test('suspends and resumes stdin listeners and raw mode around external TUI handoff', async () => {
     const harness = await createHarness({ stdinIsRaw: true })
     const readableListener = vi.fn()


### PR DESCRIPTION
## Summary
- Ignore late resize events once Ink has been detached for shutdown.
- Prevent post-detach resize from re-enabling mouse tracking, resetting alt-screen frames, or re-rendering after terminal cleanup has begun.
- Add a regression that exercises the real detachForShutdown() path and retained stdout resize listener.

## Test plan
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "ignores resize events after shutdown detach"` (failed before fix, passed after)
- `npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/ink/ink.tsx' --coverage.reportsDirectory=coverage/ink-ignore-detached-resize`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)