### PR TITLE
fix(tui): drop stale ink raw writes

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -1471,6 +1471,7 @@ export default class Ink {
   // cascades through useContext → <AlternateScreen>'s useLayoutEffect dep
   // array → spurious exit+re-enter of the alt screen on every SIGWINCH.
   private writeRaw(data: string): void {
+    if (this.isUnmounted || this.isPaused) return;
     this.options.stdout.write(data);
   }
   private setCursorDeclaration: CursorDeclarationSetter = (decl, clearIfNode) => {

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -10,8 +10,10 @@ import type { Frame } from './frame.ts'
 import instances from './instances.ts'
 import { createRoot, type Root } from './root.ts'
 import { CellWidth, cellAt } from './screen.ts'
+import { BEL } from './termio/ansi.ts'
 import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.ts'
 import { ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN } from './termio/dec.ts'
+import { useTerminalNotification } from './useTerminalNotification.ts'
 
 const clipboardMock = vi.hoisted(() => ({
   logError: vi.fn(),
@@ -77,6 +79,20 @@ function textNode(children: React.ReactNode): React.ReactElement {
     },
     children,
   )
+}
+
+function CaptureTerminalBell({
+  onReady,
+}: {
+  onReady: (notifyBell: () => void) => void
+}): React.ReactElement {
+  const { notifyBell } = useTerminalNotification()
+
+  React.useEffect(() => {
+    onReady(notifyBell)
+  }, [notifyBell, onReady])
+
+  return textNode('ready')
 }
 
 function createTestStreams(options: {
@@ -321,6 +337,44 @@ describe('Ink instance rendering paths', () => {
       expect(writes).not.toContain(ERASE_SCREEN + CURSOR_HOME)
       expect(harness.instance.frontFrame.screen.width).toBe(widthBeforeDetach)
       expect(harness.instance.frontFrame.screen.height).toBe(heightBeforeDetach)
+    } finally {
+      instances.delete(harness.stdout as unknown as NodeJS.WriteStream)
+      harness.stdin.end()
+      harness.stdout.end()
+      harness.stderr.end()
+      await sleep(25)
+    }
+  })
+
+  test('drops stale raw terminal writes while paused or unmounted', async () => {
+    const harness = await createHarness({ columns: 20, rows: 5 })
+    let notifyBell: (() => void) | undefined
+
+    try {
+      harness.root.render(
+        <CaptureTerminalBell
+          onReady={callback => {
+            notifyBell = callback
+          }}
+        />,
+      )
+      await sleep(10)
+      expect(notifyBell).toEqual(expect.any(Function))
+
+      harness.stdoutWrites.length = 0
+      notifyBell?.()
+      expect(harness.stdoutWrites.join('')).toContain(BEL)
+
+      harness.instance.pause()
+      harness.stdoutWrites.length = 0
+      notifyBell?.()
+      expect(harness.stdoutWrites.join('')).not.toContain(BEL)
+      harness.instance.resume()
+
+      harness.root.unmount()
+      harness.stdoutWrites.length = 0
+      notifyBell?.()
+      expect(harness.stdoutWrites.join('')).not.toContain(BEL)
     } finally {
       instances.delete(harness.stdout as unknown as NodeJS.WriteStream)
       harness.stdin.end()


### PR DESCRIPTION
## Summary
- Drop raw terminal writes from stale `TerminalWriteProvider` callbacks once Ink is paused or unmounted.
- Prevent delayed terminal notifications, bells, progress writes, tab status writes, or similar raw callbacks from writing into an external editor handoff or the shell after teardown.
- Add a regression that proves active Ink still allows raw terminal notification writes while paused and unmounted Ink instances suppress them.

## Test plan
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "drops stale raw terminal writes while paused or unmounted"` (failed before fix, passed after)
- `npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/ink/ink.tsx' --coverage.reportsDirectory=coverage/ink-drop-stale-raw-writes`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)