### PR TITLE
fix(tui): ignore stale ink interactions

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -1206,6 +1206,7 @@ export default class Ink {
    * edge. Supplies screen.width for the col-reset-on-clamp boundary.
    */
   shiftSelectionForScroll(dRow: number, minRow: number, maxRow: number): void {
+    if (this.isUnmounted || this.isPaused) return;
     const hadSel = hasSelection(this.selection);
     shiftSelection(this.selection, dRow, minRow, maxRow, this.frontFrame.screen.width);
     // shiftSelection clears when both endpoints overshoot the same edge
@@ -1226,7 +1227,7 @@ export default class Ink {
    * char mode. No-op outside alt-screen or without an active selection.
    */
   moveSelectionFocus(move: FocusMove): void {
-    if (!this.altScreenActive) return;
+    if (!this.altScreenActive || this.isUnmounted || this.isPaused) return;
     const {
       focus
     } = this.selection;
@@ -1298,15 +1299,16 @@ export default class Ink {
    * nodeCache rects map 1:1 to terminal cells (no scrollback offset).
    */
   dispatchClick(col: number, row: number): boolean {
-    if (!this.altScreenActive) return false;
+    if (!this.altScreenActive || this.isUnmounted || this.isPaused) return false;
     const blank = isEmptyCellAt(this.frontFrame.screen, col, row);
     return dispatchClick(this.rootNode, col, row, blank);
   }
   dispatchHover(col: number, row: number): void {
-    if (!this.altScreenActive) return;
+    if (!this.altScreenActive || this.isUnmounted || this.isPaused) return;
     dispatchHover(this.rootNode, col, row, this.hoveredNodes);
   }
   dispatchKeyboardEvent(parsedKey: ParsedKey): void {
+    if (this.isUnmounted || this.isPaused) return;
     const target = this.focusManager.activeElement ?? this.rootNode;
     const event = new KeyboardEvent(parsedKey);
     dispatcher.dispatchDiscrete(target, event);
@@ -1331,7 +1333,7 @@ export default class Ink {
    * the browser-open action via a timer.
    */
   getHyperlinkAt(col: number, row: number): string | undefined {
-    if (!this.altScreenActive) return undefined;
+    if (!this.altScreenActive || this.isUnmounted || this.isPaused) return undefined;
     const screen = this.frontFrame.screen;
     const cell = cellAt(screen, col, row);
     let url = cell?.hyperlink;
@@ -1355,6 +1357,7 @@ export default class Ink {
    * the mutable field at call time — not the undefined-at-render value.
    */
   openHyperlink(url: string): void {
+    if (this.isUnmounted || this.isPaused) return;
     this.onHyperlinkClick?.(url);
   }
 
@@ -1366,7 +1369,7 @@ export default class Ink {
    * char-mode startSelection if the click lands on a noSelect cell.
    */
   handleMultiClick(col: number, row: number, count: 2 | 3): void {
-    if (!this.altScreenActive) return;
+    if (!this.altScreenActive || this.isUnmounted || this.isPaused) return;
     const screen = this.frontFrame.screen;
     // selectWordAt/selectLineAt no-op on noSelect/out-of-bounds. Seed with
     // a char-mode selection so the press still starts a drag even if the
@@ -1386,7 +1389,7 @@ export default class Ink {
    * altScreenActive for the same reason as dispatchClick.
    */
   handleSelectionDrag(col: number, row: number): void {
-    if (!this.altScreenActive) return;
+    if (!this.altScreenActive || this.isUnmounted || this.isPaused) return;
     const sel = this.selection;
     if (sel.anchorSpan) {
       extendSelection(sel, this.frontFrame.screen, col, row);

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -384,6 +384,51 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('ignores stale terminal interactions while paused or unmounted', async () => {
+    const harness = await createHarness({ columns: 40, rows: 6 })
+    const clicks: Array<{ localCol?: number; localRow?: number }> = []
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(
+        React.createElement(
+          'ink-box',
+          {
+            onClick: (event: { localCol?: number; localRow?: number }) => {
+              clicks.push({
+                localCol: event.localCol,
+                localRow: event.localRow,
+              })
+            },
+            style: { height: 1, width: 12 },
+          },
+          textNode('alpha beta'),
+        ),
+      )
+      await sleep(10)
+
+      harness.instance.pause()
+      expect(harness.instance.dispatchClick(1, 0)).toBe(false)
+      harness.instance.handleMultiClick(1, 0, 2)
+      harness.instance.handleSelectionDrag(9, 0)
+      harness.instance.moveSelectionFocus('right')
+      expect(clicks).toEqual([])
+      expect(harness.instance.hasTextSelection()).toBe(false)
+      harness.instance.resume()
+
+      harness.root.unmount()
+      harness.instance.handleMultiClick(1, 0, 2)
+      harness.instance.handleSelectionDrag(9, 0)
+      expect(harness.instance.hasTextSelection()).toBe(false)
+    } finally {
+      instances.delete(harness.stdout as unknown as NodeJS.WriteStream)
+      harness.stdin.end()
+      harness.stdout.end()
+      harness.stderr.end()
+      await sleep(25)
+    }
+  })
+
   test('suspends and resumes stdin listeners and raw mode around external TUI handoff', async () => {
     const harness = await createHarness({ stdinIsRaw: true })
     const readableListener = vi.fn()


### PR DESCRIPTION
## Summary
- Ignore stale Ink click, hover, keyboard, hyperlink, and selection interaction entry points once Ink is paused or unmounted.
- Prevent delayed terminal mouse/selection callbacks from firing UI actions or mutating selection during external editor handoff or after teardown.
- Add a regression that first failed with a click dispatch while paused and now proves paused/unmounted interactions are dropped.

## Test plan
- `npx vitest run tests/tui/ink/ink.render.test.tsx -t "ignores stale terminal interactions while paused or unmounted"` (failed before fix, passed after)
- `npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/ink/ink.tsx' --coverage.reportsDirectory=coverage/ink-ignore-stale-interactions`
- `npm run typecheck`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- `npm run check:unused:production` (known unrelated baseline: 30 unused exports and 4 tag hints; no touched files)