### PR TITLE
fix(tui): drop stale external alt-screen handoffs

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -391,6 +391,7 @@ export default class Ink {
    * Call `exitAlternateScreen()` when done to restore Ink.
    */
   enterAlternateScreen(): void {
+    if (this.isUnmounted || this.isPaused) return;
     this.pause();
     this.suspendStdin();
     this.options.stdout.write(
@@ -426,6 +427,7 @@ export default class Ink {
    * returns, fullscreen scroll is dead.
    */
   exitAlternateScreen(): void {
+    if (this.isUnmounted || !this.isPaused) return;
     this.options.stdout.write((this.altScreenActive ? ENTER_ALT_SCREEN : '') +
     // re-enter alt — vim's rmcup dropped us to main
     '\x1b[2J' +

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -384,6 +384,90 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('drops stale external alternate-screen handoffs after detach or unmount', async () => {
+    const enterAfterDetach = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      enterAfterDetach.root.render(textNode('ready'))
+      await sleep(10)
+
+      enterAfterDetach.instance.detachForShutdown()
+      enterAfterDetach.stdoutWrites.length = 0
+
+      enterAfterDetach.instance.enterAlternateScreen()
+
+      expect(enterAfterDetach.stdoutWrites.join('')).toBe('')
+    } finally {
+      instances.delete(enterAfterDetach.stdout as unknown as NodeJS.WriteStream)
+      enterAfterDetach.stdin.end()
+      enterAfterDetach.stdout.end()
+      enterAfterDetach.stderr.end()
+      await sleep(25)
+    }
+
+    const enterAfterUnmount = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      enterAfterUnmount.root.render(textNode('ready'))
+      await sleep(10)
+
+      enterAfterUnmount.root.unmount()
+      enterAfterUnmount.stdoutWrites.length = 0
+
+      enterAfterUnmount.instance.enterAlternateScreen()
+
+      expect(enterAfterUnmount.stdoutWrites.join('')).toBe('')
+    } finally {
+      instances.delete(enterAfterUnmount.stdout as unknown as NodeJS.WriteStream)
+      enterAfterUnmount.stdin.end()
+      enterAfterUnmount.stdout.end()
+      enterAfterUnmount.stderr.end()
+      await sleep(25)
+    }
+
+    const detached = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      detached.root.render(textNode('ready'))
+      await sleep(10)
+
+      detached.instance.enterAlternateScreen()
+      detached.instance.detachForShutdown()
+      detached.stdoutWrites.length = 0
+
+      detached.instance.exitAlternateScreen()
+
+      expect(detached.stdoutWrites.join('')).toBe('')
+    } finally {
+      instances.delete(detached.stdout as unknown as NodeJS.WriteStream)
+      detached.stdin.end()
+      detached.stdout.end()
+      detached.stderr.end()
+      await sleep(25)
+    }
+
+    const unmounted = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      unmounted.root.render(textNode('ready'))
+      await sleep(10)
+
+      unmounted.instance.enterAlternateScreen()
+      unmounted.root.unmount()
+      unmounted.stdoutWrites.length = 0
+
+      unmounted.instance.exitAlternateScreen()
+
+      expect(unmounted.stdoutWrites.join('')).toBe('')
+    } finally {
+      instances.delete(unmounted.stdout as unknown as NodeJS.WriteStream)
+      unmounted.stdin.end()
+      unmounted.stdout.end()
+      unmounted.stderr.end()
+      await sleep(25)
+    }
+  })
+
   test('ignores stale terminal interactions while paused or unmounted', async () => {
     const harness = await createHarness({ columns: 40, rows: 6 })
     const clicks: Array<{ localCol?: number; localRow?: number }> = []


### PR DESCRIPTION
## Summary
- Guard Ink external alternate-screen entry once the instance is unmounted or already paused.
- Guard external alternate-screen exit once the instance is unmounted or no longer in the paused handoff state.
- Add regression coverage for stale handoff entry and exit after shutdown detach and unmount.

## Verification
- npx vitest run tests/tui/ink/ink.render.test.tsx -t "drops stale external alternate-screen handoffs after detach or unmount"
- npx vitest run tests/tui/ink/ink.render.test.tsx
- npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/ink/ink.tsx" --coverage.reportsDirectory=coverage/ink-alt-handoff-stale
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing Knip baseline: 30 unused exports, 4 tag hints)

## Coverage
- Full TUI coverage: 95.95% statements, 90.11% branches, 96.25% functions, 96.81% lines.
- Focused Ink coverage: 80.47% statements, 65.31% branches, 80.26% functions, 82.39% lines.