### PR TITLE
fix(tui): drop stale stdin resumes

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -1409,6 +1409,7 @@ export default class Ink {
   }> = [];
   private wasRawMode = false;
   suspendStdin(): void {
+    if (this.isUnmounted) return;
     const stdin = this.options.stdin;
     if (!stdin.isTTY) {
       return;
@@ -1439,6 +1440,11 @@ export default class Ink {
     }
   }
   resumeStdin(): void {
+    if (this.isUnmounted) {
+      this.stdinListeners = [];
+      this.wasRawMode = false;
+      return;
+    }
     const stdin = this.options.stdin;
     if (!stdin.isTTY) {
       return;

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -533,6 +533,56 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('drops stale stdin resumes after detach or unmount', async () => {
+    const detached = await createHarness({ stdinIsRaw: true })
+    const detachedReadable = vi.fn()
+
+    try {
+      detached.stdin.on('readable', detachedReadable)
+
+      detached.instance.suspendStdin()
+      expect(detached.stdin.listeners('readable')).not.toContain(detachedReadable)
+      expect(detached.rawModes).toEqual([false])
+
+      detached.instance.detachForShutdown()
+      const rawModesAfterDetach = [...detached.rawModes]
+      detached.instance.resumeStdin()
+
+      expect(detached.stdin.listeners('readable')).not.toContain(detachedReadable)
+      expect(detached.rawModes).toEqual(rawModesAfterDetach)
+    } finally {
+      instances.delete(detached.stdout as unknown as NodeJS.WriteStream)
+      detached.stdin.end()
+      detached.stdout.end()
+      detached.stderr.end()
+      await sleep(25)
+    }
+
+    const unmounted = await createHarness({ stdinIsRaw: true })
+    const unmountedReadable = vi.fn()
+
+    try {
+      unmounted.stdin.on('readable', unmountedReadable)
+
+      unmounted.instance.suspendStdin()
+      expect(unmounted.stdin.listeners('readable')).not.toContain(unmountedReadable)
+      expect(unmounted.rawModes).toEqual([false])
+
+      unmounted.root.unmount()
+      const rawModesAfterUnmount = [...unmounted.rawModes]
+      unmounted.instance.resumeStdin()
+
+      expect(unmounted.stdin.listeners('readable')).not.toContain(unmountedReadable)
+      expect(unmounted.rawModes).toEqual(rawModesAfterUnmount)
+    } finally {
+      instances.delete(unmounted.stdout as unknown as NodeJS.WriteStream)
+      unmounted.stdin.end()
+      unmounted.stdout.end()
+      unmounted.stderr.end()
+      await sleep(25)
+    }
+  })
+
   test('copies, clears, and extends alt-screen text selection without native clipboard access', async () => {
     const harness = await createHarness({ columns: 40, rows: 6 })
     const selectionChanges: string[] = []


### PR DESCRIPTION
## Summary
- Guard Ink stdin suspension once the instance is unmounted.
- Drop stored stdin listener/raw-mode resume state instead of restoring it after unmount or shutdown detach.
- Add regression coverage for stale `resumeStdin()` after both `detachForShutdown()` and `root.unmount()`.

## Verification
- npx vitest run tests/tui/ink/ink.render.test.tsx -t "drops stale stdin resumes after detach or unmount"
- npx vitest run tests/tui/ink/ink.render.test.tsx
- npx vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include="src/tui/ink/ink.tsx" --coverage.reportsDirectory=coverage/ink-stale-stdin-resume
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing Knip baseline: 30 unused exports, 4 tag hints)

## Coverage
- Full TUI coverage: 95.95% statements, 90.11% branches, 96.25% functions, 96.81% lines.
- Focused Ink coverage: 80.50% statements, 65.40% branches, 80.26% functions, 82.56% lines.