### PR TITLE
fix(tui): normalize dot path references

### DIFF
--- a/runtime/src/tui/workbench/pathReferences.ts
+++ b/runtime/src/tui/workbench/pathReferences.ts
@@ -1,5 +1,9 @@
+import path from "node:path";
+
 export function normalizeWorkspacePathForReferences(value: string): string {
-  return value.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  const slashPath = value.replace(/\\/gu, "/");
+  if (!slashPath) return slashPath;
+  return path.posix.normalize(slashPath).replace(/\/+$/u, "");
 }
 
 export function renameWorkspacePathReference(

--- a/runtime/tests/tui/workbench/path-references.test.ts
+++ b/runtime/tests/tui/workbench/path-references.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  containsWorkspacePathReference,
+  normalizeWorkspacePathForReferences,
+  renameWorkspacePathReference,
+} from "../../../src/tui/workbench/pathReferences.js";
+
+describe("workbench path references", () => {
+  it("canonicalizes separators and dot segments without trimming file names", () => {
+    expect(normalizeWorkspacePathForReferences("")).toBe("");
+    expect(normalizeWorkspacePathForReferences("./src//nested/../app.ts/")).toBe("src/app.ts");
+    expect(normalizeWorkspacePathForReferences("src\\nested\\app.ts")).toBe("src/nested/app.ts");
+    expect(normalizeWorkspacePathForReferences(" leading.ts ")).toBe(" leading.ts ");
+  });
+
+  it("renames exact and descendant references without touching empty or sibling paths", () => {
+    expect(renameWorkspacePathReference(null, "src", "lib")).toBeNull();
+    expect(renameWorkspacePathReference("src/app.ts", "", "lib")).toBe("src/app.ts");
+    expect(renameWorkspacePathReference("src", "src", "lib")).toBe("lib");
+    expect(renameWorkspacePathReference("./src//nested/app.ts", "src", "lib")).toBe("lib/nested/app.ts");
+    expect(renameWorkspacePathReference("src-old/app.ts", "src", "lib")).toBe("src-old/app.ts");
+  });
+
+  it("detects exact and descendant references without matching empty or sibling paths", () => {
+    expect(containsWorkspacePathReference(null, "src")).toBe(false);
+    expect(containsWorkspacePathReference("src/app.ts", "")).toBe(false);
+    expect(containsWorkspacePathReference("./src//nested/app.ts", "src")).toBe(true);
+    expect(containsWorkspacePathReference("src", "src")).toBe(true);
+    expect(containsWorkspacePathReference("src-old/app.ts", "src")).toBe(false);
+  });
+});

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  attachTaskErrorCommand,
+  openBufferCommand,
+} from "../../../src/tui/workbench/commands.js";
+import {
   getDefaultWorkbenchState,
   visibleWorkbenchPane,
   workbenchReducer,
@@ -307,6 +311,37 @@ describe("workbenchReducer", () => {
     ]);
   });
 
+  it("normalizes dot-segment references before renaming active paths and attachments", () => {
+    const opened = workbenchReducer(
+      undefined,
+      openBufferCommand("./test/foo.test.tsx", 8, true),
+    );
+    const state = workbenchReducer(opened, attachTaskErrorCommand({
+      taskId: "test-1",
+      file: "./test/foo.test.tsx",
+      line: 8,
+      label: "./test/foo.test.tsx failure",
+    }));
+    const next = workbenchReducer(state, {
+      type: "renamePathReferences",
+      fromPath: "test",
+      toPath: "spec",
+    });
+
+    expect(next.activeFilePath).toBe("spec/foo.test.tsx");
+    expect(next.attachments).toEqual([
+      {
+        id: "task-error:test-1:spec/foo.test.tsx:8",
+        kind: "task-error",
+        label: "spec/foo.test.tsx failure",
+        path: "spec/foo.test.tsx",
+        line: 8,
+        taskId: "test-1",
+      },
+    ]);
+    expect(next.composerAttachmentIds).toEqual(["task-error:test-1:spec/foo.test.tsx:8"]);
+  });
+
   it("opens the buffer only when rename changes the current active path", () => {
     const affected = workbenchReducer({
       ...getDefaultWorkbenchState(),
@@ -433,6 +468,27 @@ describe("workbenchReducer", () => {
       },
     ]);
     expect(next.composerAttachmentIds).toEqual(["file:src-old\\app.ts"]);
+  });
+
+  it("normalizes dot-segment references before deleting active paths and attachments", () => {
+    const opened = workbenchReducer(
+      undefined,
+      openBufferCommand("./test/foo.test.tsx", 8, true),
+    );
+    const state = workbenchReducer(opened, attachTaskErrorCommand({
+      taskId: "test-1",
+      file: "./test/foo.test.tsx",
+      line: 8,
+    }));
+    const next = workbenchReducer(state, {
+      type: "deletePathReferences",
+      path: "test",
+    });
+
+    expect(next.activeFilePath).toBeNull();
+    expect(next.activeFileLine).toBeNull();
+    expect(next.attachments).toEqual([]);
+    expect(next.composerAttachmentIds).toEqual([]);
   });
 
   it("closes the active surface only when delete clears the current active path", () => {


### PR DESCRIPTION
## Summary
- Canonicalize workbench path references with POSIX normalization so `./` and duplicate separator paths match explorer rename/delete operations.
- Add reducer regressions for shell/test-style `./test/foo.test.tsx` active paths and attachments.
- Add direct coverage for null, empty, exact, descendant, sibling, dot-segment, duplicate-separator, backslash, and space-preserving path reference cases.

## Test plan
- `npx vitest run tests/tui/workbench/reducer.test.ts -t \"dot-segment\"` failed before the fix and passes after it.
- `npx vitest run tests/tui/workbench/path-references.test.ts tests/tui/workbench/reducer.test.ts`
- `npx vitest run tests/tui/workbench/path-references.test.ts tests/tui/workbench/reducer.test.ts tests/tui/workbench/commands.test.ts tests/tui/workbench/search-model.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/workbench/pathReferences.ts' --coverage.reportsDirectory=coverage/workbench-path-references-dot`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` fails only on the known unrelated Knip backlog: 30 unused exports and 4 tag hints; no touched files are listed.