### PR TITLE
fix(tui): refresh effect events before layout

### DIFF
--- a/runtime/src/tui/hooks/useEffectEventCompat.ts
+++ b/runtime/src/tui/hooks/useEffectEventCompat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 
 /**
  * React 18-compatible replacement for React 19's useEffectEvent.
@@ -7,10 +7,7 @@ export function useEffectEventCompat<Args extends unknown[], Return>(
   fn: (...args: Args) => Return,
 ): (...args: Args) => Return {
   const fnRef = useRef(fn)
-
-  useLayoutEffect(() => {
-    fnRef.current = fn
-  }, [fn])
+  fnRef.current = fn
 
   return useCallback((...args: Args) => fnRef.current(...args), [])
 }

--- a/runtime/tests/tui/hooks/useEffectEventCompat.test.tsx
+++ b/runtime/tests/tui/hooks/useEffectEventCompat.test.tsx
@@ -1,0 +1,101 @@
+import { PassThrough } from "node:stream";
+
+import React, { useLayoutEffect } from "react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createRoot } from "../ink/root.js";
+import { useEffectEventCompat } from "./useEffectEventCompat.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+const cleanupRoots: Array<() => void> = [];
+
+function createStreams(): { readonly stdin: TestStdin; readonly stdout: PassThrough } {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function Child({
+  onLayout,
+}: {
+  readonly onLayout: () => void;
+}): null {
+  useLayoutEffect(() => {
+    onLayout();
+  });
+  return null;
+}
+
+function Harness({
+  identities,
+  label,
+  snapshots,
+}: {
+  readonly identities?: Array<() => void>;
+  readonly label: string;
+  readonly snapshots: string[];
+}): React.ReactElement {
+  const onLayout = useEffectEventCompat(() => {
+    snapshots.push(label);
+  });
+  useLayoutEffect(() => {
+    identities?.push(onLayout);
+  });
+  return <Child onLayout={onLayout} />;
+}
+
+async function createHarness(snapshots: string[], identities?: Array<() => void>): Promise<{
+  readonly render: (label: string) => Promise<void>;
+}> {
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  });
+  cleanupRoots.push(() => {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+  });
+
+  return {
+    render: async (label: string) => {
+      root.render(<Harness identities={identities} label={label} snapshots={snapshots} />);
+      await sleep();
+    },
+  };
+}
+
+afterEach(() => {
+  for (const cleanup of cleanupRoots.splice(0)) cleanup();
+});
+
+describe("useEffectEventCompat", () => {
+  test("stable callbacks see the latest render state during descendant layout effects", async () => {
+    const snapshots: string[] = [];
+    const identities: Array<() => void> = [];
+    const { render } = await createHarness(snapshots, identities);
+
+    await render("first");
+    await render("second");
+
+    expect(snapshots).toEqual(["first", "second"]);
+    expect(identities).toHaveLength(2);
+    expect(identities[1]).toBe(identities[0]);
+  });
+});


### PR DESCRIPTION
## Summary
- Refresh the `useEffectEventCompat` callback ref during render so stable handlers see the latest render state before descendant layout effects run.
- Add a focused regression proving the callback identity remains stable while same-commit descendant layout effects observe updated state.

## Test plan
- `npx vitest run tests/tui/hooks/useEffectEventCompat.test.tsx` failed before the fix with `[\"first\", \"first\"]` instead of `[\"first\", \"second\"]`, and passes after the fix.
- `npx vitest run tests/tui/hooks/useEffectEventCompat.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/hooks/useEffectEventCompat.ts' --coverage.reportsDirectory=coverage/use-effect-event-compat`
- `npx vitest run tests/tui/hooks/useEffectEventCompat.test.tsx tests/tui/state/AppState.test.tsx tests/tui/coverage-swarm/swarm-100-state-AppState.test.tsx tests/tui/coverage-swarm/swarm-230-hooks-useSettingsChange.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` fails only on the known unrelated Knip backlog: 30 unused exports and 4 tag hints; no touched files are listed.