### PR TITLE
refactor(tui): type shell time display

### DIFF
--- a/runtime/src/tui/components/shell/ShellTimeDisplay.tsx
+++ b/runtime/src/tui/components/shell/ShellTimeDisplay.tsx
@@ -1,77 +1,35 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { c as _c } from "react-compiler-runtime";
-import React from 'react';
-import { Text } from '../../ink.js';
-import { formatDuration } from '../../../utils/format.js'; // upstream-import: keep target is owned by another Z-PURGE item
-import { selectAgenCTuiGlyphs } from '../../glyphs.js';
+import React from 'react'
+
+import { formatDuration } from '../../../utils/format.js' // upstream-import: keep target is owned by another Z-PURGE item
+import { selectAgenCTuiGlyphs } from '../../glyphs.js'
+import { Text } from '../../ink.js'
+
 type Props = {
-  elapsedTimeSeconds?: number;
-  timeoutMs?: number;
-};
-export function ShellTimeDisplay(t0) {
-  const $ = _c(10);
-  const {
-    elapsedTimeSeconds,
-    timeoutMs
-  } = t0;
+  elapsedTimeSeconds?: number
+  timeoutMs?: number
+}
+
+export function ShellTimeDisplay({
+  elapsedTimeSeconds,
+  timeoutMs,
+}: Props): React.ReactNode {
   if (elapsedTimeSeconds === undefined && !timeoutMs) {
-    return null;
+    return null
   }
-  let t1;
-  if ($[0] !== timeoutMs) {
-    t1 = timeoutMs ? formatDuration(timeoutMs, {
-      hideTrailingZeros: true
-    }) : undefined;
-    $[0] = timeoutMs;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  const timeout = t1;
+
+  const timeout = timeoutMs
+    ? formatDuration(timeoutMs, { hideTrailingZeros: true })
+    : undefined
+
   if (elapsedTimeSeconds === undefined) {
-    const t2 = `(timeout ${timeout})`;
-    let t3;
-    if ($[2] !== t2) {
-      t3 = <Text dimColor={true}>{t2}</Text>;
-      $[2] = t2;
-      $[3] = t3;
-    } else {
-      t3 = $[3];
-    }
-    return t3;
+    return <Text dimColor>{`(timeout ${timeout})`}</Text>
   }
-  const t2 = elapsedTimeSeconds * 1000;
-  let t3;
-  if ($[4] !== t2) {
-    t3 = formatDuration(t2);
-    $[4] = t2;
-    $[5] = t3;
-  } else {
-    t3 = $[5];
-  }
-  const elapsed = t3;
+
+  const elapsed = formatDuration(elapsedTimeSeconds * 1000)
   if (timeout) {
-    const separator = selectAgenCTuiGlyphs().separator;
-    const t4 = `(${elapsed} ${separator} timeout ${timeout})`;
-    let t5;
-    if ($[6] !== t4) {
-      t5 = <Text dimColor={true}>{t4}</Text>;
-      $[6] = t4;
-      $[7] = t5;
-    } else {
-      t5 = $[7];
-    }
-    return t5;
+    const separator = selectAgenCTuiGlyphs().separator
+    return <Text dimColor>{`(${elapsed} ${separator} timeout ${timeout})`}</Text>
   }
-  const t4 = `(${elapsed})`;
-  let t5;
-  if ($[8] !== t4) {
-    t5 = <Text dimColor={true}>{t4}</Text>;
-    $[8] = t4;
-    $[9] = t5;
-  } else {
-    t5 = $[9];
-  }
-  return t5;
+
+  return <Text dimColor>{`(${elapsed})`}</Text>
 }


### PR DESCRIPTION
## Summary
- Replace the generated React Compiler cache wrapper in `ShellTimeDisplay` with a typed direct component.
- Remove `@ts-nocheck` from this display path while preserving existing timeout and elapsed-time rendering behavior.
- Move focused `ShellTimeDisplay` coverage from generated cache branches to 100% meaningful behavior coverage.

## Verification
- `npx vitest run tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/components/shell/ShellTimeDisplay.tsx' --coverage.reportsDirectory=coverage/shell-time-display-typed`
- Focused `ShellTimeDisplay.tsx` coverage: 100% statements, branches, functions, and lines.
- `npx vitest run tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx tests/tui/coverage-swarm/swarm-074-components-shell-ShellProgressMessage.test.tsx tests/tui/components/shell/ShellProgressMessage.coverage.test.tsx tests/tui/components/shell/ShellProgressMessage.wave200-104.coverage.test.tsx`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui` passed: 764 files, 3571 tests; 96.01% statements, 90.21% branches, 96.31% functions, 96.83% lines.
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` failed only with known unrelated backlog: 30 unused exports and 4 tag hints.