### PR TITLE
fix(tui): run bash completion on raw tab

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -1454,12 +1454,17 @@ export function useTypeahead({
       if (suggestions.length > 0 || effectiveGhostText) {
         return;
       }
-      // MD-NEW9: ALWAYS consume Tab in prompt mode so the raw byte (or its
+      // MD-NEW9: ALWAYS consume raw Tab here so the byte (or its
       // escape-sequence tail) never falls through to the text input. Without
       // this, edge cases like "cursor inside an @ token but picker briefly
       // empty" leak the Tab as a stray `l`/`e` character in the composer.
       e.preventDefault();
       e.stopImmediatePropagation();
+
+      if (mode === 'bash') {
+        void handleTab();
+        return;
+      }
 
       // Accept prompt suggestion if it exists in AppState
       const suggestionText = promptSuggestion.text;

--- a/runtime/tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
@@ -714,4 +714,38 @@ describe('useTypeahead coverage swarm row 009', () => {
       await rendered.dispose()
     }
   })
+
+  test('runs bash shell completion from raw tab when the picker is empty', async () => {
+    harness.shellCompletions = [
+      {
+        displayText: 'git',
+        id: 'git',
+        metadata: { completionType: 'command' },
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: 'g',
+      mode: 'bash',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      const tab = createKey('tab')
+      rendered.getSnapshot().handleKeyDown(tab)
+
+      expect(tab.defaultPrevented).toBe(true)
+      await waitFor(
+        () => onInputChange.mock.calls.length === 1,
+        'raw tab shell completion',
+      )
+      expect(onInputChange).toHaveBeenCalledWith('git ')
+      expect(setCursorOffset).toHaveBeenCalledWith('git '.length)
+      expect(harness.addNotification).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Route raw Tab fallback events in bash mode through the existing `handleTab()` shell-completion path.
- Keep raw Tab consumed so terminal escape-sequence tails still do not leak into the composer.
- Add a focused regression that proves bash Tab completion runs when the autocomplete picker is empty.

## Root Cause
`useTypeahead.handleKeyDown()` consumed raw Tab when no autocomplete list or ghost text was visible, then only handled prompt/file fallback behavior. In bash mode that swallowed Tab before `handleTab()` could request shell completions.

## Verification
- `npx vitest run tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx -t "raw tab"` failed before the fix by timing out waiting for shell completion.
- `npx vitest run tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx -t "raw tab"`
- `npx vitest run tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts`
- `npx vitest run tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/hooks/useTypeahead.tsx' --coverage.reportsDirectory=coverage/typeahead-raw-bash-tab`
- Focused `useTypeahead.tsx` coverage: statements 88.07%, branches 80.80%, functions 95.16%, lines 88.54%.
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui` passed: statements 96.05%, branches 90.25%, functions 96.31%, lines 96.88%.
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` still reports the known backlog: 30 unused exports and 4 tag hints.
