### PR TITLE
fix(tui): submit add-dir with directory suggestions

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -1331,11 +1331,12 @@ export function useTypeahead({
     } else if (suggestionType === 'directory' && selectedSuggestion < suggestions.length) {
       if (suggestion) {
         // In command context (e.g., /add-dir), Enter submits the command
-        // rather than applying the directory suggestion. Just clear
-        // suggestions and let the submit handler process the current input.
+        // rather than applying the directory suggestion. Autocomplete already
+        // consumed Enter, so submit explicitly after clearing the picker.
         if (isCommandInput(input)) {
           debouncedFetchFileSuggestions.cancel();
           clearSuggestions();
+          onSubmit(input, /* isSubmittingSlashCommand */ true);
           return;
         }
 

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -882,6 +882,36 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('submits add-dir commands on enter while directory suggestions are visible', async () => {
+    harness.directorySuggestions = [
+      {
+        displayText: 'src',
+        id: 'src',
+        metadata: { type: 'directory' },
+      },
+    ]
+    const onSubmit = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '/add-dir s',
+      onSubmit,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'directory',
+        'directory suggestions',
+      )
+
+      const enter = createKey('return')
+      rendered.getSnapshot().handleKeyDown(enter)
+
+      expect(enter.defaultPrevented).toBe(true)
+      expect(onSubmit).toHaveBeenCalledWith('/add-dir s', true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('ignores stale /add-dir directory completions that resolve out of order', async () => {
     let resolveSlowCompletion: (items: unknown[]) => void = () => {}
     harness.directoryCompletionResponses.set(


### PR DESCRIPTION
## Summary
- Submit `/add-dir` when Enter is pressed while directory suggestions are visible.
- Keep Enter from applying the directory suggestion in command context, matching the existing behavior comment.
- Add a focused regression that proves the consumed autocomplete Enter still calls the slash-command submit handler.

## Root Cause
`consumeAutocompleteEnterKey()` prevents default and stops propagation before `handleEnter()` runs. The `/add-dir` directory branch then cleared suggestions and returned, relying on a submit handler that could no longer see the event. Enter dismissed the picker instead of submitting the command.

## Verification
- `npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx -t "submits add-dir"` failed before the fix with zero `onSubmit` calls.
- `npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx -t "submits add-dir"`
- `npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/hooks/useTypeahead.test.ts`
- `npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/hooks/useTypeahead.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/hooks/useTypeahead.tsx' --coverage.reportsDirectory=coverage/typeahead-add-dir-enter-submit`
- Focused `useTypeahead.tsx` coverage: statements 88.08%, branches 80.80%, functions 95.16%, lines 88.55%.
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui` passed: statements 96.05%, branches 90.25%, functions 96.31%, lines 96.88%.
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` still reports the known backlog: 30 unused exports and 4 tag hints.
