### PR TITLE
fix(tui): match tool result fallback ids

### DIFF
--- a/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx
@@ -46,9 +46,14 @@ function formatRecoveredToolResultContent(content: unknown): string | null {
   return String(content);
 }
 
-export function getToolResultFallbackContent(messageContent: unknown): string | null {
+export function getToolResultFallbackContent(messageContent: unknown, toolUseID?: string): string | null {
   if (!Array.isArray(messageContent)) return null;
-  const toolResultBlock = messageContent.find(block => block && typeof block === 'object' && 'type' in block && block.type === 'tool_result');
+  const toolResultBlock = messageContent.find(block => {
+    if (!block || typeof block !== 'object' || !('type' in block) || block.type !== 'tool_result') {
+      return false;
+    }
+    return toolUseID === undefined || ('tool_use_id' in block && block.tool_use_id === toolUseID);
+  });
   if (!toolResultBlock || !('content' in toolResultBlock)) {
     return null;
   }
@@ -84,7 +89,7 @@ export function UserToolSuccessMessage({
     deleteClassifierApproval(toolUseID);
   }, [toolUseID]);
 
-  const fallbackContent = React.useMemo(() => getToolResultFallbackContent(message.message.content), [message.message.content]);
+  const fallbackContent = React.useMemo(() => getToolResultFallbackContent(message.message.content, toolUseID), [message.message.content, toolUseID]);
   if (isToolUseResultMissing(message.toolUseResult) || !tool) {
     return fallbackContent !== null ? <Box flexDirection="column">
           <Box flexDirection="column" width={width}>

--- a/runtime/tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx
@@ -103,6 +103,46 @@ describe('UserToolSuccessMessage swarm-044 coverage', () => {
     expect(output).toContain('1 PostToolUse hook running')
   })
 
+  test('recovers fallback output from the matching tool result block', async () => {
+    const firstToolUseID = 'toolu_swarm_044_first'
+    const secondToolUseID = 'toolu_swarm_044_second'
+
+    const output = await renderToString(
+      <UserToolSuccessMessage
+        message={{
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: firstToolUseID,
+                content: '<persisted-output>first fallback output</persisted-output>',
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: secondToolUseID,
+                content:
+                  '<persisted-output>second fallback output</persisted-output>',
+              },
+            ],
+          },
+          toolUseResult: null,
+        } as never}
+        lookups={createLookups(secondToolUseID)}
+        toolUseID={secondToolUseID}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={false}
+        width={60}
+      />,
+      { columns: 90, rows: 12 },
+    )
+
+    expect(output).toContain('second fallback output')
+    expect(output).not.toContain('first fallback output')
+  })
+
   test('falls back instead of delegating when output schema validation fails', async () => {
     const toolUseID = 'toolu_swarm_044_invalid_schema'
     const renderToolResultMessage = vi.fn(() => <Text>delegated result</Text>)

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx
@@ -52,6 +52,26 @@ describe("UserToolSuccessMessage fallback recovery", () => {
     ).toBe("first\nsecond");
   });
 
+  test("recovers persisted output for a matching tool result id", () => {
+    expect(
+      getToolResultFallbackContent(
+        [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_first",
+            content: "<persisted-output>first output</persisted-output>",
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_second",
+            content: "<persisted-output>second output</persisted-output>",
+          },
+        ],
+        "toolu_second",
+      ),
+    ).toBe("second output");
+  });
+
   test("only treats nullish toolUseResult values as missing", () => {
     expect(isToolUseResultMissing(undefined)).toBe(true);
     expect(isToolUseResultMissing(null)).toBe(true);


### PR DESCRIPTION
## Summary
- Match recovered tool-result fallback content by the active `toolUseID`.
- Preserve the old first-tool-result fallback behavior for helper callers that do not pass an ID.
- Add rendered and pure helper regressions for multi-tool-result messages.

## Root Cause
`UserToolSuccessMessage` recovered fallback output by scanning the whole user message for the first `tool_result` block. Resumed messages can contain multiple tool results, so a missing or invalid result for the second tool could display the first tool's persisted output.

## Verification
- `npx vitest run tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx -t "matching tool result block"` failed before the fix with `first fallback output` rendered for the second tool ID.
- `npx vitest run tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx -t "matching tool result block"`
- `npx vitest run tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx -t "matching tool result id"`
- `npx vitest run tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx`
- `npx vitest run tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.test.tsx tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx' --coverage.reportsDirectory=coverage/tool-success-fallback-id`
- Focused `UserToolSuccessMessage.tsx` coverage: statements 91.11%, branches 80.72%, functions 90.90%, lines 90.00%.
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui` passed: statements 96.05%, branches 90.24%, functions 96.31%, lines 96.88%.
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` still reports the known unrelated backlog: 30 unused exports and 4 tag hints.
