### PR TITLE
fix(tui): ignore disabled selects in overlay tracking

### DIFF
--- a/runtime/src/tui/components/CustomSelect/use-select-input.ts
+++ b/runtime/src/tui/components/CustomSelect/use-select-input.ts
@@ -96,9 +96,9 @@ export const useSelectInput = <T>({
   imagesSelected = false,
   onEnterImageSelection,
 }: UseSelectProps<T>) => {
-  // Automatically register as an overlay when onCancel is provided.
+  // Automatically register as an overlay when an enabled cancelable select is active.
   // This ensures CancelRequestHandler won't intercept Escape when the select is active.
-  useRegisterOverlay('select', !!state.onCancel)
+  useRegisterOverlay('select', !isDisabled && !!state.onCancel)
 
   // Determine if the focused option is an input type
   const isInInput = useMemo(() => {

--- a/runtime/tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts
@@ -227,6 +227,32 @@ describe('useSelectInput coverage swarm row 036', () => {
     }
   })
 
+  test('does not register disabled selects as active overlays when cancel exists', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+    ]
+    const state = createSelectState(options)
+    const unmount = await renderHarness({
+      isDisabled: true,
+      options,
+      state,
+    })
+
+    try {
+      expect(overlayMock.useRegisterOverlay).toHaveBeenCalledWith(
+        'select',
+        false,
+      )
+      expect(keybindingMock.current?.options).toEqual({
+        context: 'Select',
+        isActive: false,
+      })
+      expect(inputMock.current?.options).toEqual({ isActive: false })
+    } finally {
+      unmount()
+    }
+  })
+
   test('drives keybinding navigation, boundary callbacks, accept guards, and cancel', async () => {
     const options: OptionWithDescription<string>[] = [
       { value: 'alpha', label: 'Alpha' },


### PR DESCRIPTION
## Summary
- Prevent disabled CustomSelect instances from registering as active overlays when they have an onCancel handler.
- Add regression coverage for disabled cancelable selects keeping overlay tracking inactive while hook handlers stay disabled.

## Test plan
- npx vitest run tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts -t "does not register disabled selects as active overlays when cancel exists"
- npx vitest run tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/components/CustomSelect/select.coverage2.test.tsx
- npx vitest run tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/components/CustomSelect/use-select-input.ts' --coverage.reportsDirectory=coverage/select-disabled-overlay
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing baseline failure: 30 unused exports, 4 tag hints; no changed files listed)