### PR TITLE
fix(tui): clear explicit workbench diff ids

### DIFF
--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -78,7 +78,7 @@ export function workbenchReducer(
     case "openDiff":
       return {
         ...openSurface(state, "diff", command.focus ?? true),
-        openDiffId: command.diffId ?? state.openDiffId,
+        openDiffId: command.diffId === undefined ? state.openDiffId : command.diffId,
       };
     case "openShell":
       return {

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -557,6 +557,26 @@ describe("workbenchReducer", () => {
     expect(transcript.activeSurfaceMode).toBe("transcript");
   });
 
+  it("clears stale diff ids when openDiff receives an explicit null", () => {
+    const approvalDiff = workbenchReducer(undefined, {
+      type: "openDiff",
+      diffId: "approval-1",
+    });
+    const genericDiff = workbenchReducer(approvalDiff, {
+      type: "openDiff",
+    });
+    const clearedDiff = workbenchReducer(approvalDiff, {
+      type: "openDiff",
+      diffId: null,
+    });
+
+    expect(genericDiff.openDiffId).toBe("approval-1");
+    expect(clearedDiff).toMatchObject({
+      activeSurfaceMode: "diff",
+      openDiffId: null,
+    });
+  });
+
   it("clears stale selected search match ids when opening a new query", () => {
     const first = workbenchReducer(undefined, {
       type: "openSearch",


### PR DESCRIPTION
## Summary
- Make workbench openDiff distinguish omitted diff ids from explicit null clears.
- Add reducer regression coverage for clearing stale approval diff ids without changing generic openDiff preservation behavior.

## Test plan
- npx vitest run tests/tui/workbench/reducer.test.ts -t "clears stale diff ids"
- npx vitest run tests/tui/workbench/reducer.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/workbench/render.test.tsx
- npx vitest run tests/tui/workbench/reducer.test.ts --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/workbench/reducer.ts' --coverage.reportsDirectory=coverage/workbench-diff-id
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing baseline failure: 30 unused exports, 4 tag hints; no changed files listed)