### PR TITLE
fix(tui): prune stale select input drafts

### DIFF
--- a/runtime/src/tui/components/CustomSelect/select.tsx
+++ b/runtime/src/tui/components/CustomSelect/select.tsx
@@ -271,20 +271,34 @@ export function Select<T>(t0: SelectProps<T>): React.ReactNode {
   let t9;
   if ($[3] !== inputValues || $[4] !== options) {
     t9 = () => {
+      const inputOptionValues = new Set<T>();
+      let nextInputValues: Map<T, string> | undefined;
       for (const option_0 of options) {
         if (option_0.type === "input") {
+          inputOptionValues.add(option_0.value);
           const lastInitial = lastInitialValues.current.get(option_0.value) ?? "";
           const currentValue = inputValues.get(option_0.value) ?? "";
           const newInitial = option_0.initialValue ?? "";
           if (newInitial !== lastInitial && currentValue === lastInitial) {
-            setInputValues((prev: Map<T, string>) => {
-              const next = new Map(prev);
-              next.set(option_0.value, newInitial);
-              return next;
-            });
+            nextInputValues ??= new Map(inputValues);
+            nextInputValues.set(option_0.value, newInitial);
           }
           lastInitialValues.current.set(option_0.value, newInitial);
         }
+      }
+      for (const value of inputValues.keys()) {
+        if (!inputOptionValues.has(value)) {
+          nextInputValues ??= new Map(inputValues);
+          nextInputValues.delete(value);
+        }
+      }
+      for (const value of Array.from(lastInitialValues.current.keys())) {
+        if (!inputOptionValues.has(value)) {
+          lastInitialValues.current.delete(value);
+        }
+      }
+      if (nextInputValues) {
+        setInputValues(nextInputValues);
       }
     };
     t10 = [options, inputValues];

--- a/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
@@ -261,4 +261,66 @@ describe('Select input option coverage', () => {
       view.unmount()
     }
   })
+
+  test('drops draft values when an input option leaves the option set', async () => {
+    const firstOptions: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        initialValue: 'seed',
+        onChange: () => {},
+      },
+    ]
+    const textOnlyOptions: OptionWithDescription<string>[] = [
+      {
+        value: 'other',
+        label: 'Other',
+      },
+    ]
+    const reintroducedOptions: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        onChange: () => {},
+      },
+    ]
+
+    const view = await renderSelect(
+      <Select
+        options={firstOptions}
+        defaultFocusValue="prompt"
+      />,
+    )
+
+    try {
+      expect(latestInputOption().inputValue).toBe('seed')
+
+      latestInputOption().onInputChange('draft')
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('draft')
+
+      const inputRenderCount = selectInputOptionMock.props.length
+      await view.rerender(
+        <Select
+          options={textOnlyOptions}
+          defaultFocusValue="other"
+        />,
+      )
+      expect(selectInputOptionMock.props).toHaveLength(inputRenderCount)
+
+      await view.rerender(
+        <Select
+          options={reintroducedOptions}
+          defaultFocusValue="prompt"
+        />,
+      )
+      await waitForRender()
+
+      expect(latestInputOption().inputValue).toBe('')
+    } finally {
+      view.unmount()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- prune Select input draft state when an input option leaves the option set
- keep initial-value synchronization for still-present input options in a single state update
- add a regression for removing an input option and reintroducing it with the same value

## Test plan
- npx vitest run tests/tui/components/CustomSelect/select.coverage2.test.tsx --testNamePattern 'drops draft values'
- npx vitest run tests/tui/components/CustomSelect/select.coverage2.test.tsx tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx tests/tui/components/CustomSelect/select.render.test.tsx tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts
- git diff --check
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing baseline: 30 unused exports, 4 tag hints)