### PR TITLE
fix(tui): refresh typeahead sources

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -370,6 +370,7 @@ export function useTypeahead({
   const latestResumeTitleArgsRef = useRef<string | null>(null);
   // Track the latest bash input to discard stale results from history completion
   const latestBashInputRef = useRef('');
+  const prevSuggestionSourcesRef = useRef({ agents, mcpResources });
   // Track the latest slack channel token to discard stale results from MCP
   const latestSlackTokenRef = useRef('');
   // Track suggestions via ref to avoid updateSuggestions being recreated on selection changes
@@ -960,14 +961,19 @@ export function useTypeahead({
     // When the actual input text changes (not just updateSuggestions being recreated),
     // reset the search token ref so the same query can be re-fetched.
     // This fixes: type @readme.md, clear, retype @readme.md → no suggestions.
-    if (prevInputRef.current !== input) {
+    const previousSources = prevSuggestionSourcesRef.current;
+    const suggestionSourcesChanged =
+      previousSources.agents !== agents ||
+      previousSources.mcpResources !== mcpResources;
+    if (prevInputRef.current !== input || suggestionSourcesChanged) {
       prevInputRef.current = input;
+      prevSuggestionSourcesRef.current = { agents, mcpResources };
       latestSearchTokenRef.current = null;
     }
     // Clear the dismissed state when input changes
     dismissedForInputRef.current = null;
     void updateSuggestions(input);
-  }, [input, updateSuggestions]);
+  }, [agents, input, mcpResources, updateSuggestions]);
 
   // Handle tab key press - complete suggestions or trigger file suggestions
   const handleTab = useCallback(async () => {

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -1064,6 +1064,54 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('refreshes @ suggestions when MCP resources change without editing input', async () => {
+    harness.unifiedSuggestions = [
+      {
+        displayText: 'old-doc.md',
+        id: 'old-doc.md',
+      },
+    ]
+    const rendered = await renderHookHarness({
+      input: '@doc',
+    })
+
+    try {
+      await waitFor(
+        () =>
+          rendered.getSnapshot().suggestionType === 'file' &&
+          rendered.getSnapshot().suggestions[0]?.id === 'old-doc.md',
+        'initial file suggestions',
+      )
+      expect(generateUnifiedSuggestionsMock).toHaveBeenCalledTimes(1)
+
+      harness.appState.mcp = {
+        clients: [],
+        resources: [{ name: 'docs' }],
+      }
+      harness.unifiedSuggestions = [
+        {
+          displayText: 'docs://latest',
+          id: 'mcp-resource-docs-latest',
+        },
+      ]
+      rendered.rerender({ input: '@doc' })
+
+      await waitFor(
+        () => generateUnifiedSuggestionsMock.mock.calls.length === 2,
+        'refetched suggestions after MCP resources changed',
+      )
+      await waitFor(
+        () =>
+          rendered.getSnapshot().suggestionType === 'file' &&
+          rendered.getSnapshot().suggestions[0]?.id ===
+            'mcp-resource-docs-latest',
+        'fresh MCP resource suggestions',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('drops @ path completions after the mode changes', async () => {
     let resolveSlowPathCompletion: (items: unknown[]) => void = () => {}
     harness.directoryCompletionResponses.set(


### PR DESCRIPTION
## Summary
- invalidate duplicate `@token` autocomplete cache when MCP resources or agent sources change
- keep the existing same-input duplicate-query guard for unchanged source sets
- add a regression for refreshed MCP resource suggestions without editing the input

## Test plan
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx --testNamePattern 'refreshes @ suggestions'
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/typeaheadKeyHandling.test.ts
- git diff --check
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reporter=text --coverage.include='src/tui/hooks/useTypeahead.tsx' --coverage.reportsDirectory=coverage/typeahead-source-refresh
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (expected existing baseline: 30 unused exports, 4 tag hints)