### PR TITLE
fix(tui): refresh dismissed typeahead sources

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -375,7 +375,14 @@ export function useTypeahead({
   const latestBashInputRef = useRef('');
   const currentMcpClientsRef = useRef(mcpClients);
   currentMcpClientsRef.current = mcpClients;
-  const prevSuggestionSourcesRef = useRef({ agents, mcpResources });
+  const prevSuggestionSourcesRef = useRef({
+    agentNameRegistry,
+    agents,
+    mcpClients,
+    mcpResources,
+    tasks,
+    teamContext
+  });
   // Track the latest slack channel token to discard stale results from MCP
   const latestSlackTokenRef = useRef('');
   const latestSlackRequestIdRef = useRef(0);
@@ -975,26 +982,54 @@ export function useTypeahead({
   // shouldn't re-trigger suggestions. The cursorOffsetRef is used to get the current
   // position when needed without causing re-renders.
   useEffect(() => {
-    // If suggestions were dismissed for this exact input, don't re-trigger
-    if (dismissedForInputRef.current === input) {
-      return;
-    }
     // When the actual input text changes (not just updateSuggestions being recreated),
     // reset the search token ref so the same query can be re-fetched.
     // This fixes: type @readme.md, clear, retype @readme.md → no suggestions.
     const previousSources = prevSuggestionSourcesRef.current;
+    const textBeforeCursor = input.substring(0, cursorOffsetRef.current);
+    const atMentionMatch = mode !== 'bash'
+      ? textBeforeCursor.match(/(^|\s)@([\w-]*)$/)
+      : null;
+    const hasAtCompletionToken = mode !== 'bash' && HAS_AT_SYMBOL_RE.test(textBeforeCursor);
+    const hasHashChannelToken = mode === 'prompt' && HASH_CHANNEL_RE.test(textBeforeCursor);
+    const atMentionPartial = (atMentionMatch?.[2] ?? '').toLowerCase();
+    const hasMatchingRegisteredAgent =
+      atMentionMatch !== null &&
+      Array.from(agentNameRegistry.keys()).some(name =>
+        name.toLowerCase().startsWith(atMentionPartial)
+      );
     const suggestionSourcesChanged =
-      previousSources.agents !== agents ||
-      previousSources.mcpResources !== mcpResources;
+      (hasAtCompletionToken && (
+        previousSources.agents !== agents ||
+        previousSources.mcpResources !== mcpResources
+      )) ||
+      (atMentionMatch !== null && (
+        previousSources.agentNameRegistry !== agentNameRegistry ||
+        previousSources.teamContext !== teamContext ||
+        (hasMatchingRegisteredAgent && previousSources.tasks !== tasks)
+      )) ||
+      (hasHashChannelToken && previousSources.mcpClients !== mcpClients);
+    // If suggestions were dismissed for this exact input, don't re-trigger unless
+    // the backing suggestion sources changed and the old dismissal is stale.
+    if (dismissedForInputRef.current === input && !suggestionSourcesChanged) {
+      return;
+    }
     if (prevInputRef.current !== input || suggestionSourcesChanged) {
       prevInputRef.current = input;
-      prevSuggestionSourcesRef.current = { agents, mcpResources };
+      prevSuggestionSourcesRef.current = {
+        agentNameRegistry,
+        agents,
+        mcpClients,
+        mcpResources,
+        tasks,
+        teamContext
+      };
       latestSearchTokenRef.current = null;
     }
     // Clear the dismissed state when input changes
     dismissedForInputRef.current = null;
     void updateSuggestions(input);
-  }, [agents, input, mcpResources, updateSuggestions]);
+  }, [agentNameRegistry, agents, input, mcpClients, mcpResources, tasks, teamContext, updateSuggestions]);
 
   // Handle tab key press - complete suggestions or trigger file suggestions
   const handleTab = useCallback(async () => {

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -1646,6 +1646,86 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('dismissed @ suggestions refresh when MCP resources change for the same input', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'doc-old.md', displayText: 'doc-old.md', description: 'file' },
+    ]
+    const rendered = await renderHookHarness({ input: '@doc', cursorOffset: 4 })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'initial file suggestions',
+      )
+
+      harness.keybindings['autocomplete:dismiss']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'dismissed suggestions',
+      )
+
+      generateUnifiedSuggestionsMock.mockClear()
+      harness.appState.mcp = {
+        clients: [],
+        resources: [{ name: 'docs' }],
+      }
+      harness.unifiedSuggestions = [
+        {
+          displayText: 'docs://latest',
+          id: 'mcp-resource-docs-latest',
+          description: 'resource',
+        },
+      ]
+      rendered.rerender({ input: '@doc', cursorOffset: 4 })
+
+      await waitFor(
+        () => generateUnifiedSuggestionsMock.mock.calls.length > 0,
+        'refetch after MCP resources change',
+      )
+      await waitFor(
+        () =>
+          rendered.getSnapshot().suggestionType === 'file' &&
+          rendered.getSnapshot().suggestions[0]?.id ===
+            'mcp-resource-docs-latest',
+        'fresh MCP resource suggestions after dismissal',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('dismissed @ file suggestions stay dismissed on unrelated task changes', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'doc-old.md', displayText: 'doc-old.md', description: 'file' },
+    ]
+    const rendered = await renderHookHarness({ input: '@doc', cursorOffset: 4 })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'initial file suggestions',
+      )
+
+      harness.keybindings['autocomplete:dismiss']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'dismissed suggestions',
+      )
+
+      generateUnifiedSuggestionsMock.mockClear()
+      harness.appState.tasks = {
+        'agent-other': { status: 'running' },
+      }
+      rendered.rerender({ input: '@doc', cursorOffset: 4 })
+      await sleep(25)
+
+      expect(generateUnifiedSuggestionsMock).not.toHaveBeenCalled()
+      expect(rendered.getSnapshot().suggestionType).toBe('none')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('logs file suggestion provider failures and fails closed', async () => {
     const error = new Error('unified suggestions failed')
     generateUnifiedSuggestionsMock.mockRejectedValueOnce(error)


### PR DESCRIPTION
## Summary
- let dismissed autocomplete refresh when the active suggestion source changes for the same input
- scope dismissal invalidation to sources relevant to the current @ or # trigger
- cover MCP resource refresh after dismissal and unrelated task churn staying dismissed

## Test plan
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx --testNamePattern 'dismiss remembers|dismissed @ suggestions refresh|dismissed @ file suggestions stay dismissed'
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx
- npx vitest run tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx tests/tui/hooks/typeaheadKeyHandling.test.ts tests/tui/coverage-swarm/swarm-191-hooks-typeaheadTokens.test.ts
- npm run typecheck
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline failure: 30 unused exports + 4 tag hints)