### PR TITLE
fix(tui): drop non-tty stdin resume state

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -1447,6 +1447,8 @@ export default class Ink {
     }
     const stdin = this.options.stdin;
     if (!stdin.isTTY) {
+      this.stdinListeners = [];
+      this.wasRawMode = false;
       return;
     }
 

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -533,6 +533,33 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('drops suspended stdin state when resume sees non-tty stdin', async () => {
+    const harness = await createHarness({ stdinIsRaw: true })
+    const readableListener = vi.fn()
+
+    try {
+      harness.stdin.on('readable', readableListener)
+
+      harness.instance.suspendStdin()
+      expect(harness.stdin.listeners('readable')).not.toContain(readableListener)
+      expect(harness.rawModes).toEqual([false])
+
+      harness.stdin.isTTY = false
+      harness.instance.resumeStdin()
+
+      expect(harness.stdin.listeners('readable')).not.toContain(readableListener)
+      expect(harness.rawModes).toEqual([false])
+
+      harness.stdin.isTTY = true
+      harness.instance.resumeStdin()
+
+      expect(harness.stdin.listeners('readable')).not.toContain(readableListener)
+      expect(harness.rawModes).toEqual([false])
+    } finally {
+      await harness.dispose()
+    }
+  })
+
   test('drops stale stdin resumes after detach or unmount', async () => {
     const detached = await createHarness({ stdinIsRaw: true })
     const detachedReadable = vi.fn()


### PR DESCRIPTION
## Summary
- Clear suspended stdin listeners and raw-mode state when resume sees stdin is no longer a TTY.
- Add an Ink renderer regression that proves stale readable listeners and raw mode are not revived by a later resume.

## Test plan
- npm run test -- tests/tui/ink/ink.render.test.tsx -t 'drops suspended stdin state when resume sees non-tty stdin'
- npm run test -- tests/tui/ink/ink.render.test.tsx
- npm run test -- tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx
- npm run typecheck
- npm run test:coverage:tui
- git diff --check
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)