### PR TITLE
fix(tui): ignore stale preview git failures

### DIFF
--- a/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
@@ -98,8 +98,9 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
         if (mounted) setGitStateState({ path: statusPath, status: status.get(statusPath) ?? "clean" });
       })
       .catch((error) => {
+        if (!mounted) return;
         logError(error);
-        if (mounted) setGitStateState({ path: statusPath, status: null });
+        setGitStateState({ path: statusPath, status: null });
       });
     return () => {
       mounted = false;

--- a/runtime/tests/tui/workbench/preview-surface-git-state.test.tsx
+++ b/runtime/tests/tui/workbench/preview-surface-git-state.test.tsx
@@ -169,6 +169,49 @@ describe("PreviewSurface git state", () => {
     }
   });
 
+  it("ignores stale git status failures after switching preview targets", async () => {
+    let setPreviewTarget: ((filePath: string) => void) | null = null;
+    const staleError = new Error("old status failed");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "preview",
+              activeFilePath: "old.ts",
+              activeFileLine: 1,
+            },
+          }}
+        >
+          <PreviewTargetController onReady={(setter) => { setPreviewTarget = setter; }} />
+          <PreviewSurface focused={false} />
+        </AppStateProvider>,
+      );
+
+      const oldStatusRead = await waitForStatusRead(0);
+      setPreviewTarget?.("new.ts");
+      await waitForStatusRead(1);
+
+      oldStatusRead.reject(staleError);
+      await sleep();
+
+      expect(previewHarness.logError).not.toHaveBeenCalledWith(staleError);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("logs git status refresh failures without showing stale status", async () => {
     const statusError = new Error("status unavailable");
     const { stdin, stdout } = createStreams();


### PR DESCRIPTION
## Summary
- Ignore rejected git status refreshes after PreviewSurface has switched targets or unmounted.
- Add a regression covering stale status failures after preview target changes.

## Test plan
- npm run test -- tests/tui/workbench/preview-surface-git-state.test.tsx -t 'ignores stale git status failures after switching preview targets'
- npm run test -- tests/tui/workbench/preview-surface.test.tsx tests/tui/workbench/preview-surface-git-state.test.tsx tests/tui/workbench/preview-surface-clamped-content.test.tsx tests/tui/workbench/preview-surface-scroll.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)