### PR TITLE
fix(tui): preserve direct message attachments

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -15,7 +15,7 @@ import stripAnsi from 'strip-ansi';
 import { type Command, hasCommand } from '../../../commands.js';
 import { useIsModalOverlayActive, useRegisterOverlay } from '../../context/overlayContext.js';
 import { useSetPromptOverlayDialog } from '../../context/promptOverlayContext.js';
-import { formatImageRef, formatPastedTextRef, getPastedTextRefNumLines, parseReferences } from '../../history/history.js';
+import { expandPastedTextRefs, formatImageRef, formatPastedTextRef, getPastedTextRefNumLines, parseReferences } from '../../history/history.js';
 import type { VerificationStatus } from '../../hooks/useApiKeyVerification.js';
 import { type HistoryMode, useArrowKeyHistory } from '../../hooks/useArrowKeyHistory.js';
 import { useDoublePress } from '../../hooks/useDoublePress.js';
@@ -1420,8 +1420,14 @@ function PromptInput({
     // Handle @name direct message
     if (isAgentSwarmsEnabled()) {
       const directMessage = parseDirectMemberMessage(inputParam);
-      if (directMessage) {
-        const result = await sendDirectMemberMessage(directMessage.recipientName, directMessage.message, teamContext, writeToMailbox);
+      const directMessageRefs = directMessage ? parseReferences(inputParam) : [];
+      const directMessageHasUnsupportedAttachments = hasWorkbenchAttachments || directMessageRefs.some(ref => {
+        const content = pastedContentsRef.current[ref.id];
+        return content?.type === 'image' || ref.match.startsWith('[Image');
+      });
+      if (directMessage && !directMessageHasUnsupportedAttachments) {
+        const directMessageText = expandPastedTextRefs(directMessage.message, pastedContentsRef.current);
+        const result = await sendDirectMemberMessage(directMessage.recipientName, directMessageText, teamContext, writeToMailbox);
         if (result.success) {
           addNotification({
             key: 'direct-message-sent',
@@ -1431,6 +1437,7 @@ function PromptInput({
           });
           trackAndSetInput('');
           setCurrentCursorOffset(0);
+          setPastedContentsAndRef({});
           clearBuffer();
           resetHistory();
           return;
@@ -1580,7 +1587,7 @@ function PromptInput({
     if (hasWorkbenchAttachments) {
       setAppState(prev => applyWorkbenchCommand(prev, { type: 'clearAttachments' }));
     }
-  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, removeNotification, vimMode, mode, getToolUseContext, messages, mainLoopModel, trackAndSetInput, onModeChange, isLoading, addNotification, setCurrentCursorOffset]);
+  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, removeNotification, vimMode, mode, getToolUseContext, messages, mainLoopModel, trackAndSetInput, onModeChange, isLoading, addNotification, setCurrentCursorOffset, setPastedContentsAndRef]);
   const {
     suggestions,
     selectedSuggestion,

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -824,6 +824,7 @@ vi.mock('./utils.js', async importOriginal => {
 })
 
 import { createRoot } from '../../ink/root.js'
+import { sendDirectMemberMessage } from '../../../utils/directMemberMessage.js'
 import { getImageFromClipboard } from '../../../utils/imagePaste.js'
 import { cacheImagePath, storeImage } from '../../../utils/imageStore.js'
 import { logError } from '../../../utils/log.js'
@@ -985,6 +986,7 @@ describe('PromptInput render surface', () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue(null)
     vi.mocked(cacheImagePath).mockClear()
     vi.mocked(storeImage).mockClear()
+    vi.mocked(sendDirectMemberMessage).mockClear()
     vi.mocked(logError).mockClear()
     vi.mocked(editPromptInEditor).mockClear()
   })
@@ -2879,6 +2881,111 @@ describe('PromptInput render surface', () => {
       expect(onInputChange).toHaveBeenCalledWith('')
       expect(harness.clearBuffer).toHaveBeenCalled()
       expect(harness.history.resetHistory).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('expands pasted text refs before sending direct member messages', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.directMessage = {
+      message: 'review [Pasted text #4]',
+      recipientName: 'teammate',
+    }
+    harness.directMessageResult = {
+      recipientName: 'teammate',
+      success: true,
+    }
+    harness.appState.teamContext = {
+      teamName: 'alpha',
+      teammates: {
+        teammate: { name: 'teammate' },
+      },
+    }
+    const onSubmit = vi.fn(async () => {})
+    const pastedContents = createPastedContentsState({
+      4: {
+        content: 'expanded pasted text',
+        id: 4,
+        type: 'text',
+      },
+    })
+    const rendered = await renderPromptInput({
+      input: '@teammate review [Pasted text #4]',
+      onSubmit,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)(
+        '@teammate review [Pasted text #4]',
+      )
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(sendDirectMemberMessage).toHaveBeenCalledWith(
+        'teammate',
+        'review expanded pasted text',
+        expect.anything(),
+        expect.any(Function),
+      )
+      expect(pastedContents.current).toEqual({})
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('falls through to leader submit when direct-looking input references an image', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.directMessage = {
+      message: 'review [Image #2]',
+      recipientName: 'teammate',
+    }
+    harness.directMessageResult = {
+      recipientName: 'teammate',
+      success: true,
+    }
+    harness.appState.teamContext = {
+      teamName: 'alpha',
+      teammates: {
+        teammate: { name: 'teammate' },
+      },
+    }
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({
+      input: '@teammate review [Image #2]',
+      onSubmit,
+      pastedContents: {
+        2: {
+          content: 'png-data',
+          id: 2,
+          mediaType: 'image/png',
+          type: 'image',
+        },
+      },
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)(
+        '@teammate review [Image #2]',
+      )
+
+      expect(sendDirectMemberMessage).not.toHaveBeenCalled()
+      expect(onSubmit).toHaveBeenCalledWith(
+        '@teammate review [Image #2]',
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+          setCursorOffset: expect.any(Function),
+        }),
+        undefined,
+        expect.objectContaining({
+          mode: 'prompt',
+          vimRoutingState: expect.objectContaining({ enabled: false }),
+        }),
+      )
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Expand pasted text references before sending direct teammate mailbox messages.
- Fall through to normal prompt submission when a direct-looking message carries image or workbench attachments that mailbox text cannot preserve.
- Clear consumed pasted content after a successful direct send.

## Test plan
- npx vitest run tests/tui/components/PromptInput/PromptInput.render.test.tsx --testNamePattern "expands pasted text refs|falls through to leader submit when direct-looking input references an image"
- npx vitest run tests/tui/components/PromptInput/PromptInput*.test.ts tests/tui/components/PromptInput/PromptInput*.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx
- npm run typecheck
- git diff --check
- npm run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline: 30 unused exports, 4 tag hints)