### PR TITLE
fix(tui): refresh token warning mode changes

### DIFF
--- a/runtime/src/tui/cost/TokenWarning.tsx
+++ b/runtime/src/tui/cost/TokenWarning.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { c as _c } from "react-compiler-runtime";
 import { feature } from 'bun:bundle';
 import * as React from 'react';
 import { Box, Text } from '../ink.js';
@@ -13,46 +11,21 @@ type Props = {
   tokenUsage: number;
   model: string;
 };
-export function TokenWarning(t0) {
-  const $ = _c(13);
-  const {
-    tokenUsage,
-    model
-  } = t0;
-  let t1;
-  if ($[0] !== model || $[1] !== tokenUsage) {
-    t1 = calculateTokenWarningState(tokenUsage, model);
-    $[0] = model;
-    $[1] = tokenUsage;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
+export function TokenWarning({
+  tokenUsage,
+  model
+}: Props): React.ReactElement | null {
   const {
     percentLeft,
     isAboveWarningThreshold,
     isAboveErrorThreshold
-  } = t1;
+  } = calculateTokenWarningState(tokenUsage, model);
   const suppressWarning = useCompactWarningSuppression();
   if (!isAboveWarningThreshold || suppressWarning) {
     return null;
   }
-  let t2;
-  if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = isAutoCompactEnabled();
-    $[3] = t2;
-  } else {
-    t2 = $[3];
-  }
-  const showAutoCompactWarning = t2;
-  let t3;
-  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = getUpgradeMessage("warning");
-    $[4] = t3;
-  } else {
-    t3 = $[4];
-  }
-  const upgradeMessage = t3;
+  const showAutoCompactWarning = isAutoCompactEnabled();
+  const upgradeMessage = getUpgradeMessage("warning");
   let displayPercentLeft = percentLeft;
   let reactiveOnlyMode = false;
   let collapseMode = false;
@@ -68,27 +41,26 @@ export function TokenWarning(t0) {
   }
   if (reactiveOnlyMode || collapseMode) {
     const effectiveWindow = getEffectiveContextWindowSize(model);
-    let t4;
-    if ($[5] !== effectiveWindow || $[6] !== tokenUsage) {
-      t4 = Math.round((effectiveWindow - tokenUsage) / effectiveWindow * 100);
-      $[5] = effectiveWindow;
-      $[6] = tokenUsage;
-      $[7] = t4;
-    } else {
-      t4 = $[7];
-    }
-    displayPercentLeft = Math.max(0, t4);
+    displayPercentLeft = Math.max(
+      0,
+      Math.round((effectiveWindow - tokenUsage) / effectiveWindow * 100),
+    );
   }
   const autocompactLabel = reactiveOnlyMode ? `${100 - displayPercentLeft}% context used` : `${displayPercentLeft}% until auto-compact`;
-  let t4;
-  if ($[9] !== autocompactLabel || $[10] !== isAboveErrorThreshold || $[11] !== percentLeft) {
-    t4 = <Box flexDirection="row">{showAutoCompactWarning ? <Text dimColor={true} wrap="truncate">{upgradeMessage ? `${autocompactLabel} \u00b7 ${upgradeMessage}` : autocompactLabel}</Text> : <Text color={isAboveErrorThreshold ? "error" : "warning"} wrap="truncate">{upgradeMessage ? `Context low (${percentLeft}% remaining) \u00b7 ${upgradeMessage}` : `Context low (${percentLeft}% remaining) \u00b7 Run /compact to compact & continue`}</Text>}</Box>;
-    $[9] = autocompactLabel;
-    $[10] = isAboveErrorThreshold;
-    $[11] = percentLeft;
-    $[12] = t4;
-  } else {
-    t4 = $[12];
-  }
-  return t4;
+
+  return (
+    <Box flexDirection="row">
+      {showAutoCompactWarning ? (
+        <Text dimColor={true} wrap="truncate">
+          {upgradeMessage ? `${autocompactLabel} · ${upgradeMessage}` : autocompactLabel}
+        </Text>
+      ) : (
+        <Text color={isAboveErrorThreshold ? "error" : "warning"} wrap="truncate">
+          {upgradeMessage
+            ? `Context low (${percentLeft}% remaining) · ${upgradeMessage}`
+            : `Context low (${percentLeft}% remaining) · Run /compact to compact & continue`}
+        </Text>
+      )}
+    </Box>
+  );
 }

--- a/runtime/tests/tui/cost/TokenWarning.coverage.test.tsx
+++ b/runtime/tests/tui/cost/TokenWarning.coverage.test.tsx
@@ -1,3 +1,5 @@
+import { PassThrough } from "node:stream";
+
 import React from "react";
 import { describe, expect, test, vi } from "vitest";
 
@@ -41,6 +43,9 @@ vi.mock("../../utils/model/contextWindowUpgradeCheck.js", () => ({
 }));
 
 import { renderToString } from "../../utils/staticRender.js";
+import { createRoot } from "../ink.js";
+import { getInkInstance } from "../ink/instances.js";
+import { cellAt } from "../ink/screen.js";
 import { TokenWarning } from "./TokenWarning.js";
 
 describe("TokenWarning coverage", () => {
@@ -54,4 +59,83 @@ describe("TokenWarning coverage", () => {
     expect(output).toContain("/model sonnet[1m]");
     expect(output).not.toContain("Run /compact to compact & continue");
   });
+
+  test("refreshes manual and auto compact warning text on rerender", async () => {
+    harness.autoCompactEnabled = false;
+    harness.percentLeft = 7;
+    harness.upgradeMessage = null;
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<TokenWarning tokenUsage={193_000} model="sonnet" />);
+      await sleep();
+
+      expect(screenText(stdout)).toContain("Context low (7% remaining)");
+
+      harness.autoCompactEnabled = true;
+      root.render(<TokenWarning tokenUsage={193_000} model="sonnet" />);
+      await sleep();
+
+      expect(screenText(stdout)).toContain("7% until auto-compact");
+      expect(screenText(stdout)).not.toContain("Context low (7% remaining)");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
 });
+
+function sleep(ms = 0): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function screenText(stdout: PassThrough): string {
+  const instance = getInkInstance(stdout);
+  const screen = instance?.frontFrame?.screen;
+  if (!screen) return "";
+  const lines: string[] = [];
+  for (let y = 0; y < screen.height; y++) {
+    let line = "";
+    for (let x = 0; x < screen.width; x++) {
+      line += cellAt(screen, x, y)?.char ?? " ";
+    }
+    lines.push(line.trimEnd());
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- replace the generated React compiler cache in `TokenWarning` with direct typed React logic
- refresh manual versus auto-compact warning text on rerender when compact mode changes
- add an Ink rerender regression covering stale warning text

## Test plan
- `npx vitest run tests/tui/cost/TokenWarning.coverage.test.tsx --testNamePattern "refreshes manual and auto compact warning text on rerender"`
- `npx vitest run tests/tui/cost/TokenWarning.coverage.test.tsx tests/tui/cost/TokenWarning.wave200-131.coverage.test.tsx tests/tui/coverage-swarm/swarm-120-cost-TokenWarning.test.tsx`
- `npx vitest run tests/tui/cost/TokenWarning.coverage.test.tsx tests/tui/cost/TokenWarning.wave200-131.coverage.test.tsx tests/tui/coverage-swarm/swarm-120-cost-TokenWarning.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.include='src/tui/cost/TokenWarning.tsx' --coverage.reportsDirectory=coverage/token-warning-audit`
- `npm run test:coverage:tui`
- `npm run typecheck`
- `git diff --check`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known baseline: 30 unused exports, 4 tag hints)
