### PR TITLE
fix(tui): prioritize failed tool loader state

### DIFF
--- a/runtime/src/tui/components/ToolUseLoader.tsx
+++ b/runtime/src/tui/components/ToolUseLoader.tsx
@@ -1,28 +1,20 @@
-import { c as _c } from "react-compiler-runtime";
 import type React from 'react';
 import { Box, Text } from '../ink.js';
+
 type Props = {
   isError: boolean;
   isUnresolved: boolean;
   shouldAnimate: boolean;
 };
-export function ToolUseLoader(t0: Props): React.ReactNode {
-  const $ = _c(4);
-  const {
-    isError,
-    isUnresolved,
-  } = t0;
-  const color = isUnresolved ? undefined : isError ? "error" : "success";
-  const glyph = isUnresolved ? "◐" : isError ? "✕" : "●";
-  let t2;
-  if ($[0] !== color || $[1] !== glyph || $[2] !== isUnresolved) {
-    t2 = <Text color={color} dimColor={isUnresolved}>{glyph}</Text>;
-    $[0] = color;
-    $[1] = glyph;
-    $[2] = isUnresolved;
-    $[3] = t2;
-  } else {
-    t2 = $[3];
-  }
-  return <Box minWidth={2}>{t2}</Box>;
+export function ToolUseLoader({
+  isError,
+  isUnresolved,
+}: Props): React.ReactNode {
+  const color = isError ? "error" : isUnresolved ? undefined : "success";
+  const glyph = isError ? "✕" : isUnresolved ? "◐" : "●";
+  return (
+    <Box minWidth={2}>
+      <Text color={color} dimColor={!isError && isUnresolved}>{glyph}</Text>
+    </Box>
+  );
 }

--- a/runtime/tests/tui/components/ToolUseLoader.test.tsx
+++ b/runtime/tests/tui/components/ToolUseLoader.test.tsx
@@ -32,6 +32,13 @@ describe('ToolUseLoader', () => {
       ),
     ).resolves.toContain('✕')
 
+    await expect(
+      renderToString(
+        <ToolUseLoader isError isUnresolved shouldAnimate />,
+        20,
+      ),
+    ).resolves.toContain('✕')
+
     await expect(renderToString(<RerenderLoader />, 20)).resolves.toContain('●')
   })
 })


### PR DESCRIPTION
## Summary
- Make `ToolUseLoader` render the failed glyph/color when a tool is both errored and still marked unresolved.
- Add coverage for the errored-unresolved lifecycle state.

## Test plan
- `npx vitest run tests/tui/components/ToolUseLoader.test.tsx`
- `npx vitest run tests/tui/components/ToolUseLoader.test.tsx tests/tui/components/visual-contract.test.ts tests/tui/message-renderers/AdvisorMessage.coverage.test.tsx tests/tui/message-renderers/AssistantToolUseMessage.test.tsx tests/tui/message-renderers/AssistantToolUseMessage.coverage.test.tsx tests/tui/message-renderers/AssistantToolUseMessage.coverage2.test.tsx tests/tui/message-renderers/AssistantToolUseMessage.wave200-047.coverage.test.tsx tests/tui/message-renderers/CollapsedReadSearchContent.test.tsx tests/tui/message-renderers/CollapsedReadSearchContent.render.test.tsx tests/tui/message-renderers/CollapsedReadSearchContent.wave200-059.coverage.test.tsx tests/tui/message-renderers/GroupedToolUseContent.test.ts tests/tui/message-renderers/GroupedToolUseContent.coverage.test.tsx`
- `npx vitest run tests/tui/components/ToolUseLoader.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.include='src/tui/components/ToolUseLoader.tsx' --coverage.reportsDirectory=coverage/tool-use-loader-error-state`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known baseline: 30 unused exports, 4 tag hints)