### PR TITLE
fix(tui): reset buffer preferred column on collapse

### DIFF
--- a/runtime/src/tui/workbench/buffer/editing.ts
+++ b/runtime/src/tui/workbench/buffer/editing.ts
@@ -217,6 +217,7 @@ export function moveBufferCursor(
   if (!options.extend && from !== to) {
     if (move === "left") target = from;
     else if (move === "right") target = to;
+    preferredColumn = null;
   } else if (move === "left") {
     target = previousGraphemeOffset(bufferText(document), selection.head);
     preferredColumn = null;

--- a/runtime/tests/tui/workbench/buffer-editing.test.ts
+++ b/runtime/tests/tui/workbench/buffer-editing.test.ts
@@ -54,4 +54,16 @@ describe("buffer editing model", () => {
     document = moveBufferCursor(document, "down");
     expect(documentPosition(document)).toMatchObject({ line: 3, column: 2 });
   });
+
+  it("resets stale preferred column after collapsing a vertical selection", () => {
+    let document = createBufferDocument("abcd\nx\nabcdef");
+    document = moveBufferCursor(document, "lineEnd");
+    document = moveBufferCursor(document, "down", { extend: true });
+
+    document = moveBufferCursor(document, "right");
+    expect(documentPosition(document)).toMatchObject({ line: 2, column: 1 });
+
+    document = moveBufferCursor(document, "down");
+    expect(documentPosition(document)).toMatchObject({ line: 3, column: 1 });
+  });
 });


### PR DESCRIPTION
## Summary
- Clear the buffer editor's preferred vertical column when a non-extended selection collapses.
- Add a regression for stale preferred-column jumps after collapsing a vertical selection.

## Test plan
- `npx vitest run tests/tui/workbench/buffer-editing.test.ts --testNamePattern "resets stale preferred column"`
- `npx vitest run tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-surface-handlers.test.tsx tests/tui/workbench/buffer-highlight.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-external-editor.test.ts`
- `npx vitest run tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-surface-handlers.test.tsx tests/tui/workbench/buffer-highlight.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-external-editor.test.ts --coverage --coverage.provider=v8 --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.include='src/tui/workbench/buffer/editing.ts' --coverage.reportsDirectory=coverage/buffer-editing-adjacent`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known baseline: 30 unused exports, 4 tag hints)