### PR TITLE
fix(tui): honor selection line moves

### DIFF
--- a/runtime/src/tui/workbench/buffer/editing.ts
+++ b/runtime/src/tui/workbench/buffer/editing.ts
@@ -214,9 +214,9 @@ export function moveBufferCursor(
   let target = selection.head;
   let preferredColumn = document.preferredColumn;
 
-  if (!options.extend && from !== to) {
+  if (!options.extend && from !== to && (move === "left" || move === "right")) {
     if (move === "left") target = from;
-    else if (move === "right") target = to;
+    else target = to;
     preferredColumn = null;
   } else if (move === "left") {
     target = previousGraphemeOffset(bufferText(document), selection.head);

--- a/runtime/tests/tui/workbench/buffer-editing.test.ts
+++ b/runtime/tests/tui/workbench/buffer-editing.test.ts
@@ -66,4 +66,17 @@ describe("buffer editing model", () => {
     document = moveBufferCursor(document, "down");
     expect(documentPosition(document)).toMatchObject({ line: 3, column: 1 });
   });
+
+  it("honors explicit line and document moves while collapsing selections", () => {
+    let document = createBufferDocument("alpha\nbeta\ngamma");
+    document = moveBufferCursor(document, "right");
+    document = moveBufferCursor(document, "right", { extend: true });
+
+    document = moveBufferCursor(document, "lineEnd");
+    expect(documentPosition(document)).toMatchObject({ line: 1, column: 5 });
+
+    document = moveBufferCursor(document, "left", { extend: true });
+    document = moveBufferCursor(document, "bottom");
+    expect(documentPosition(document)).toMatchObject({ line: 3, column: 5 });
+  });
 });


### PR DESCRIPTION
## Summary
- Let explicit line/document cursor moves run while collapsing an active buffer selection.
- Keep left/right selection collapse behavior unchanged.
- Add a regression for Home/End-style and document-boundary moves after selection.

## Test plan
- `npx vitest run tests/tui/workbench/buffer-editing.test.ts --testNamePattern "honors explicit line"`
- `npx vitest run tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-surface-handlers.test.tsx tests/tui/workbench/buffer-highlight.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-external-editor.test.ts`
- `npx vitest run tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-surface-handlers.test.tsx tests/tui/workbench/buffer-highlight.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-external-editor.test.ts --coverage --coverage.provider=v8 --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.include='src/tui/workbench/buffer/editing.ts' --coverage.reportsDirectory=coverage/buffer-selection-moves`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm run check:unused:production` (known baseline: 30 unused exports, 4 tag hints)