### PR TITLE
fix(tui): keep reactivated agents visible

### DIFF
--- a/runtime/src/tui/components/CoordinatorAgentStatus.tsx
+++ b/runtime/src/tui/components/CoordinatorAgentStatus.tsx
@@ -115,7 +115,7 @@ export function CoordinatorTaskPanel(): React.ReactNode {
     const interval = setInterval((tasksRef_0, setAppState_0, setTick_0) => {
       const now = Date.now();
       for (const t of Object.values(tasksRef_0.current)) {
-        if (isPanelAgentTask(t) && (t.evictAfter ?? Infinity) <= now) {
+        if (isPanelAgentTask(t) && isTerminalStatus(t.status) && (t.evictAfter ?? Infinity) <= now) {
           evictTerminalTask(t.id, setAppState_0);
         }
       }

--- a/runtime/src/tui/state/collabAgentTaskSync.ts
+++ b/runtime/src/tui/state/collabAgentTaskSync.ts
@@ -238,7 +238,7 @@ function applyPatch(
   const evictAfter =
     ended && previousAgent?.retain !== true
       ? previousAgent?.evictAfter ?? now + PANEL_GRACE_MS
-      : previousAgent?.evictAfter;
+      : undefined;
   return {
     id: patch.id,
     type: "local_agent",
@@ -247,7 +247,7 @@ function applyPatch(
     startTime: previousAgent?.startTime ?? now,
     outputFile: previousAgent?.outputFile ?? outputUri(patch.id),
     outputOffset: previousAgent?.outputOffset ?? 0,
-    notified: ended ? true : previousAgent?.notified ?? false,
+    notified: ended ? true : false,
     agentId: patch.id,
     prompt,
     agentType: patch.role ?? previousAgent?.agentType ?? "agent",
@@ -263,18 +263,14 @@ function applyPatch(
     diskLoaded: previousAgent?.diskLoaded ?? false,
     selectedAgent: previousAgent?.selectedAgent ?? { name: title },
     ...(previousAgent?.progress !== undefined ? { progress: previousAgent.progress } : {}),
-    ...(ended
-      ? { endTime: previousAgent?.endTime ?? now }
-      : previousAgent?.endTime !== undefined
-        ? { endTime: previousAgent.endTime }
-        : {}),
+    ...(ended ? { endTime: previousAgent?.endTime ?? now } : {}),
     ...(previousAgent?.abortController !== undefined
       ? { abortController: previousAgent.abortController }
       : {}),
     ...(previousAgent?.unregisterCleanup !== undefined
       ? { unregisterCleanup: previousAgent.unregisterCleanup }
       : {}),
-    ...(previousAgent?.result !== undefined ? { result: previousAgent.result } : {}),
+    ...(ended && previousAgent?.result !== undefined ? { result: previousAgent.result } : {}),
     ...(evictAfter !== undefined ? { evictAfter } : {}),
   };
 }

--- a/runtime/tests/tui/components/CoordinatorAgentStatus.render.runtime-coverage.test.tsx
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.render.runtime-coverage.test.tsx
@@ -204,7 +204,7 @@ describe("CoordinatorTaskPanel rendering", () => {
     vi.useFakeTimers();
     vi.setSystemTime(20_000);
     coordinatorMock.appState.tasks = {
-      expired: makeTask("expired", { evictAfter: 19_000 }),
+      expired: makeTask("expired", { endTime: 18_000, evictAfter: 19_000, status: "completed" }),
       retained: makeTask("retained", { evictAfter: undefined }),
     };
 

--- a/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
@@ -310,4 +310,25 @@ describe("CoordinatorTaskPanel rendering", () => {
       await rendered.dispose();
     }
   });
+
+  test("does not evict reactivated running agents with stale terminal deadlines", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.tasks = {
+      reactivated: task("reactivated", {
+        endTime: 999_000,
+        evictAfter: 999_999,
+        progress: { summary: "running after a follow-up message" },
+        status: "running",
+      }),
+    };
+    const rendered = await renderPanel();
+
+    try {
+      await sleep(1_075);
+      expect(harness.evicted).toEqual([]);
+      expect(rendered.output()).toContain("running after a follow-up message");
+    } finally {
+      await rendered.dispose();
+    }
+  });
 });

--- a/runtime/tests/tui/state/collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it } from "vitest";
 import { syncCollabAgentEventToAppState } from "./collabAgentTaskSync.js";
 import type { AppState } from "./AppStateStore.js";
 
-function applyEvent(state: AppState, event: unknown): AppState {
+function applyEvent(state: AppState, event: unknown, now = 1234): AppState {
   let next = state;
   syncCollabAgentEventToAppState(
     event,
     (updater) => {
       next = updater(next as never) as AppState;
     },
-    1234,
+    now,
   );
   return next;
 }
@@ -205,6 +205,57 @@ describe("syncCollabAgentEventToAppState", () => {
       notified: true,
     });
     expect(completed.tasks.agent_1).not.toHaveProperty("evictAfter");
+  });
+
+  it("reactivates terminal agents without stale terminal-only metadata", () => {
+    const spawned = applyEvent(baseState(), {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent_1",
+        newAgentNickname: "Librarian",
+        status: { status: "running" },
+      },
+    }, 1_000);
+    const completed = applyEvent(spawned, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        status: "completed",
+      },
+    }, 2_000);
+    const completedWithResult = {
+      ...completed,
+      tasks: {
+        ...completed.tasks,
+        agent_1: {
+          ...completed.tasks.agent_1!,
+          result: { final: "old result" },
+        },
+      },
+    };
+
+    const runningAgain = applyEvent(completedWithResult, {
+      type: "collab_agent_interaction_begin",
+      payload: {
+        receiverThreadId: "agent_1",
+        prompt: "continue investigating",
+        receiverAgentRoleDisplayName: "Default",
+      },
+    }, 40_000);
+
+    expect(runningAgain.tasks.agent_1).toMatchObject({
+      status: "running",
+      description: "Librarian",
+      prompt: "continue investigating",
+      agentType: "Default",
+      startTime: 1_000,
+      notified: false,
+    });
+    expect(runningAgain.tasks.agent_1).not.toHaveProperty("endTime");
+    expect(runningAgain.tasks.agent_1).not.toHaveProperty("evictAfter");
+    expect(runningAgain.tasks.agent_1).not.toHaveProperty("result");
   });
 
   it("updates spawned agents from collab wait completion summaries", () => {


### PR DESCRIPTION
## Summary
- clear terminal-only metadata when collab agent events reactivate a local agent
- prevent the coordinator panel eviction tick from removing non-terminal agent rows
- add regression coverage for state reactivation and end-to-end panel rendering

## Test plan
- npx vitest run tests/tui/state/collabAgentTaskSync.test.ts tests/tui/components/CoordinatorAgentStatus.render.test.tsx
- npx vitest run tests/agents tests/session/agent-task-lifecycle.test.ts tests/tui/state/collabAgentTaskSync.test.ts tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx tests/tui/workbench/agent-surface.test.tsx tests/tui/components/CoordinatorAgentStatus.test.ts tests/tui/components/CoordinatorAgentStatus.render.test.tsx tests/tui/components/CoordinatorAgentStatus.render.runtime-coverage.test.tsx tests/tui/components/tasks/BackgroundTaskStatus.test.tsx tests/tui/components/tasks/BackgroundTaskStatus.coverage.test.tsx tests/tui/components/tasks/BackgroundTaskStatus.layout.test.ts tests/tui/components/tasks/BackgroundTasksPanel.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage2.test.tsx tests/tui/components/App.local-agents.test.tsx
- npm run test:coverage:tui
- npm run typecheck
- git diff --check
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline remains: 30 unused exports, 4 tag hints)