### PR TITLE
fix(tui): harden coordinator agent status rendering

### DIFF
--- a/runtime/src/tui/components/CoordinatorAgentStatus.tsx
+++ b/runtime/src/tui/components/CoordinatorAgentStatus.tsx
@@ -87,9 +87,11 @@ export function CoordinatorTaskPanel(): React.ReactNode {
   const coordinatorTaskIndex = useAppState(s_2 => s_2.coordinatorTaskIndex);
   const footerSelection = useAppState(s_3 => s_3.footerSelection);
   const tasksSelected = footerSelection === 'tasks';
-  const selectedIndex = tasksSelected ? coordinatorTaskIndex : undefined;
   const setAppState = useSetAppState();
   const visibleTasks = getVisibleAgentTasks(tasks);
+  const selectedIndex = tasksSelected
+    ? Math.max(0, Math.min(coordinatorTaskIndex, visibleTasks.length))
+    : undefined;
   const hasTasks = Object.values(tasks).some(isPanelAgentTask);
   const visibilityKey = getCoordinatorTaskPanelVisibilityKey(visibleTasks);
   const visibilityKeyRef = React.useRef('');
@@ -189,10 +191,15 @@ function taskStatusColor(task: LocalAgentTaskState): 'agenc' | 'worker' | 'muted
 }
 
 function taskLastAction(task: LocalAgentTaskState): string {
-  return task.progress?.summary
+  const error = typeof task.error === 'string' && task.error.trim().length > 0
+    ? task.error.trim()
+    : undefined;
+  const description = task.description.trim();
+  return error
+    ?? task.progress?.summary
     ?? task.progress?.lastActivity?.activityDescription
     ?? task.progress?.lastActivity?.toolName
-    ?? task.description
+    ?? (description.length > 0 ? description : undefined)
     ?? 'idle';
 }
 
@@ -245,7 +252,7 @@ function FleetRow({
   readonly age: string;
   readonly lastAction: string;
   readonly nameRole: string;
-  readonly onClick?: () => void;
+  readonly onClick: () => void;
   readonly selected?: boolean;
   readonly status: string;
   readonly statusColor: 'agenc' | 'worker' | 'muted3';
@@ -272,7 +279,6 @@ function FleetRow({
       <Box width={ageWidth}><ThemedText color="muted3" wrap="truncate-end">{age}</ThemedText></Box>
     </ThemedBox>
   );
-  if (!onClick) return row;
   return <Box onClick={onClick} onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>{row}</Box>;
 }
 
@@ -327,7 +333,7 @@ type AgentLineProps = {
   name?: string;
   isSelected?: boolean;
   isViewed?: boolean;
-  onClick?: () => void;
+  onClick: () => void;
 };
 function AgentLine(t0) {
   const {

--- a/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
@@ -71,6 +71,7 @@ type AgentTask = {
   description: string;
   diskLoaded: boolean;
   endTime?: number;
+  error?: string;
   evictAfter?: number;
   id: string;
   isBackgrounded: boolean;
@@ -81,14 +82,20 @@ type AgentTask = {
     lastActivity?: Record<string, unknown>;
     summary?: string;
     tokenCount?: number;
+    toolUseCount?: number;
   };
   prompt: string;
   retain: boolean;
   retrieved: boolean;
+  selectedAgent?: {
+    memory?: string;
+    source?: string;
+  };
   startTime: number;
-  status: "completed" | "failed" | "killed" | "running";
+  status: "completed" | "failed" | "killed" | "pending" | "running";
   totalPausedMs?: number;
   type: "local_agent";
+  worktreePath?: string;
 };
 
 function createStreams(): {
@@ -194,6 +201,19 @@ describe("CoordinatorTaskPanel rendering", () => {
     }
   });
 
+  test("renders nothing and skips the eviction interval when no agent tasks exist", async () => {
+    harness.state.tasks = {};
+    const rendered = await renderPanel();
+
+    try {
+      await sleep(1_075);
+      expect(rendered.output().trim()).toBe("");
+      expect(harness.evicted).toEqual([]);
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
   test("renders visible agents with names, progress, queued counts, and selection hints", async () => {
     harness.state.footerSelection = "tasks";
     harness.state.coordinatorTaskIndex = 1;
@@ -249,6 +269,73 @@ describe("CoordinatorTaskPanel rendering", () => {
     }
   });
 
+  test("falls back to generic role and idle action when agent metadata is sparse", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 1;
+    harness.state.tasks = {
+      "agent-sparse": task("agent-sparse", {
+        agentType: "unmapped-role",
+        description: "   ",
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("agent-sparse · Agent");
+      expect(output).toContain("idle");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("shows active tool progress in the focused agent block", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 1;
+    harness.state.tasks = {
+      "agent-tools": task("agent-tools", {
+        progress: {
+          summary: "using a tool",
+          toolUseCount: 2,
+        },
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("progress ◐ 2 tools");
+      expect(output).toContain("using a tool");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("omits the focused block when main row is selected with a stale viewed agent id", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 0;
+    harness.state.viewingAgentTaskId = "missing-agent";
+    harness.state.tasks = {
+      "agent-a": task("agent-a", {
+        progress: { summary: "visible row remains" },
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("AGENT FLEET");
+      expect(output).toContain("visible row remains");
+      expect(output).not.toContain("scope session");
+      expect(output).not.toContain("last output");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
   test("uses viewed-agent styling without action hints and truncates narrow descriptions", async () => {
     harness.columns = 46;
     harness.state.footerSelection = "tasks";
@@ -271,6 +358,89 @@ describe("CoordinatorTaskPanel rendering", () => {
       expect(output).toContain("last output");
       expect(output).not.toContain("x to stop");
       expect(output).not.toContain("require truncation in a narrow panel");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("keeps a focused agent block when the selected footer index is stale", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 99;
+    harness.state.agentNameRegistry = new Map([
+      ["First", "agent-a"],
+      ["FocusedLast", "agent-b"],
+    ]);
+    harness.state.tasks = {
+      "agent-a": task("agent-a", {
+        startTime: 990_000,
+      }),
+      "agent-b": task("agent-b", {
+        description: "focused fallback agent",
+        progress: { summary: "selected from stale index" },
+        selectedAgent: { memory: "repo-memory" },
+        startTime: 995_000,
+        worktreePath: "/tmp/focused-agent",
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("FocusedLast · Runner");
+      expect(output).toContain("scope repo-memory");
+      expect(output).toContain("worktree /tmp/focused-agent");
+      expect(output).toContain("selected from stale index");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("surfaces failed agent errors as the current action", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 1;
+    harness.state.agentNameRegistry = new Map([["Verifier", "agent-failed"]]);
+    harness.state.tasks = {
+      "agent-failed": task("agent-failed", {
+        description: "generic failure task",
+        endTime: 999_000,
+        error: "tool exploded while applying patch",
+        status: "failed",
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("Verifier · Runner");
+      expect(output).toContain("failed");
+      expect(output).toContain("tool exploded while applying patch");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("focuses the viewed pending agent when the footer is not selected", async () => {
+    harness.state.footerSelection = "none";
+    harness.state.viewingAgentTaskId = "agent-pending";
+    harness.state.agentNameRegistry = new Map([["Planner", "agent-pending"]]);
+    harness.state.tasks = {
+      "agent-pending": task("agent-pending", {
+        description: "queued analysis",
+        selectedAgent: { source: "project-agent" },
+        status: "pending",
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("Planner · Runner");
+      expect(output).toContain("pending");
+      expect(output).toContain("scope project-agent");
+      expect(output).toContain("queued analysis");
     } finally {
       await rendered.dispose();
     }
@@ -306,6 +476,27 @@ describe("CoordinatorTaskPanel rendering", () => {
     try {
       await sleep(1_075);
       expect(harness.evicted).toEqual(["expired"]);
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("keeps completed agents without an eviction deadline visible after the panel tick", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.tasks = {
+      retained: task("retained", {
+        endTime: undefined,
+        evictAfter: undefined,
+        status: "completed",
+      }),
+    };
+    const rendered = await renderPanel();
+
+    try {
+      await sleep(1_075);
+      expect(harness.evicted).toEqual([]);
+      expect(rendered.output()).toContain("retained · Runner");
+      expect(rendered.output()).toContain("● completed");
     } finally {
       await rendered.dispose();
     }


### PR DESCRIPTION
## Summary
- Clamp selected coordinator agent index to visible task bounds so stale footer selection still focuses a valid agent.
- Surface failed agent error messages as the current action and fall back blank descriptions to idle.
- Expand CoordinatorAgentStatus render coverage for stale selection, failed errors, pending viewed agents, sparse metadata, no-agent ticks, terminal retention, and focused tool progress.

## Coverage
- Focused CoordinatorAgentStatus branch coverage: 100% (135/135 branches).
- Full TUI coverage: 96.17% statements, 90.59% branches, 96.60% functions, 96.98% lines.

## Validation
- npx vitest run tests/tui/components/CoordinatorAgentStatus.test.ts tests/tui/components/CoordinatorAgentStatus.render.test.tsx tests/tui/components/CoordinatorAgentStatus.render.runtime-coverage.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/components/CoordinatorAgentStatus.tsx' --coverage.reportsDirectory=coverage/coordinator-agent-status-audit --reporter=dot
- npx vitest run tests/tui/components/CoordinatorAgentStatus.test.ts tests/tui/components/CoordinatorAgentStatus.render.test.tsx tests/tui/components/CoordinatorAgentStatus.render.runtime-coverage.test.tsx tests/tui/components/tasks/BackgroundTaskStatus.test.tsx tests/tui/components/tasks/BackgroundTaskStatus.coverage.test.tsx tests/tui/components/tasks/BackgroundTaskStatus.layout.test.ts tests/tui/components/tasks/BackgroundTasksPanel.test.tsx tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx tests/tui/workbench/agent-surface.test.tsx tests/tui/state/collabAgentTaskSync.test.ts tests/agents tests/session/agent-task-lifecycle.test.ts
- npm run test:coverage:tui
- npm run typecheck
- git diff --check
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm run check:unused:production (known baseline remains: 30 unused exports, 4 tag hints)