### PR TITLE
fix(tui): show task activity fallbacks

### DIFF
--- a/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
+++ b/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 import {
   isBackgroundTask,
   isTaskType,
+  type InProcessTeammateTaskState,
+  type LocalAgentTaskState,
   type TaskState,
 } from "../../../tasks/types.js";
 import { tailFile } from "../../../utils/fsOperations.js";
@@ -30,7 +32,7 @@ type TaskDetailRow = {
   readonly section: string;
   readonly label: string;
   readonly value: string;
-  readonly color?: ThemeColor;
+  readonly color: ThemeColor;
 };
 
 type ShellOutputTail = {
@@ -52,15 +54,30 @@ function formatBackgroundAgentRole(roleName: string | undefined): string {
   return agentRolePresentation(roleName)?.label ?? "Agent";
 }
 
+function formatLocalAgentIdentity(
+  task: LocalAgentTaskState,
+  nameByAgentId: ReadonlyMap<string, string>,
+): string {
+  const displayName =
+    nameByAgentId.get(task.id) ??
+    nameByAgentId.get(task.agentId) ??
+    task.agentId;
+  return `${displayName} · ${formatBackgroundAgentRole(task.agentType)}`;
+}
+
+function formatTeammateIdentity(task: InProcessTeammateTaskState): string {
+  return `${task.identity.agentName} · ${formatBackgroundAgentRole(agentRoleFromDefinition(task.selectedAgent))}`;
+}
+
 function formatBackgroundAgentIdentity(
   task: TaskState,
   nameByAgentId: ReadonlyMap<string, string>,
 ): string | null {
   if (task.type === "local_agent") {
-    return `${nameByAgentId.get(task.id) ?? nameByAgentId.get(task.agentId) ?? task.agentId} · ${formatBackgroundAgentRole(task.agentType)}`;
+    return formatLocalAgentIdentity(task, nameByAgentId);
   }
   if (task.type === "in_process_teammate") {
-    return `${task.identity.agentName} · ${formatBackgroundAgentRole(agentRoleFromDefinition(task.selectedAgent))}`;
+    return formatTeammateIdentity(task);
   }
   return null;
 }
@@ -75,10 +92,11 @@ function taskTitle(task: TaskState): string {
   if ("prompt" in task && typeof task.prompt === "string" && task.prompt.trim()) {
     return task.prompt;
   }
-  return task.description || task.id;
+  const description = task.description.trim();
+  return description || task.id;
 }
 
-function taskStatusColor(status: string): "success" | "error" | "agenc" | "inactive" | "subtle" {
+function taskStatusColor(status: TaskState["status"]): "success" | "error" | "agenc" {
   switch (status) {
     case "completed":
       return "success";
@@ -88,8 +106,6 @@ function taskStatusColor(status: string): "success" | "error" | "agenc" | "inact
     case "running":
     case "pending":
       return "agenc";
-    default:
-      return "subtle";
   }
 }
 
@@ -106,8 +122,6 @@ function taskKindIcon(task: TaskState): string {
       return "$";
     case "local_agent":
       return "◇";
-    default:
-      return "·";
   }
 }
 
@@ -121,8 +135,6 @@ function taskKindLabel(task: TaskState): string {
       return "bash";
     case "local_agent":
       return "local";
-    default:
-      return "task";
   }
 }
 
@@ -134,7 +146,7 @@ function taskKindColor(task: TaskState): "worker" | "agenc" | "text2" | "subtle"
       return "agenc";
     case "local_bash":
       return "text2";
-    default:
+    case "local_agent":
       return "subtle";
   }
 }
@@ -157,24 +169,6 @@ function taskDetailStatusLabel(task: TaskState): string {
   return task.status === "completed" ? "completed" : taskStatusLabel(task.status);
 }
 
-function taskDetail(task: TaskState): string | null {
-  const progress = "progress" in task ? task.progress : undefined;
-  const parts: string[] = [];
-  if (progress?.toolUseCount !== undefined) {
-    parts.push(`${formatNumber(progress.toolUseCount)} tools`);
-  }
-  if (progress?.tokenCount !== undefined) {
-    parts.push(`${formatNumber(progress.tokenCount)} tokens`);
-  }
-  if (progress?.lastActivity?.activityDescription) {
-    parts.push(progress.lastActivity.activityDescription);
-  }
-  if ("error" in task && typeof task.error === "string" && task.error.trim()) {
-    parts.push(task.error);
-  }
-  return parts.length > 0 ? parts.join(" · ") : null;
-}
-
 function taskTarget(task: TaskState): string {
   switch (task.type) {
     case "remote_agent":
@@ -185,8 +179,6 @@ function taskTarget(task: TaskState): string {
       return "local shell";
     case "local_agent":
       return "self";
-    default:
-      return "background";
   }
 }
 
@@ -225,12 +217,41 @@ function stringifyUnknown(value: unknown): string {
   }
 }
 
+function formatProgressActivity(activity: {
+  readonly activityDescription?: string;
+  readonly toolName?: string;
+  readonly input?: unknown;
+}): string {
+  return activity.activityDescription ?? [activity.toolName, stringifyUnknown(activity.input)].filter(Boolean).join(" ");
+}
+
+function taskDetail(task: TaskState): string | null {
+  const progress = "progress" in task ? task.progress : undefined;
+  const parts: string[] = [];
+  if (progress?.toolUseCount !== undefined) {
+    parts.push(`${formatNumber(progress.toolUseCount)} tools`);
+  }
+  if (progress?.tokenCount !== undefined) {
+    parts.push(`${formatNumber(progress.tokenCount)} tokens`);
+  }
+  if (progress?.lastActivity) {
+    const activity = formatProgressActivity(progress.lastActivity);
+    if (activity) {
+      parts.push(activity);
+    }
+  }
+  if ("error" in task && typeof task.error === "string" && task.error.trim()) {
+    parts.push(task.error);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
 function addDetailRows(
   rows: TaskDetailRow[],
   section: string,
   label: string,
   value: unknown,
-  color?: ThemeColor,
+  color: ThemeColor = "text2",
 ): void {
   const text = stringifyUnknown(value).trim();
   if (!text) {
@@ -239,7 +260,7 @@ function addDetailRows(
   for (const line of text.split(/\r?\n/u)) {
     const trimmed = line.trimEnd();
     if (trimmed) {
-      rows.push({ section, label, value: trimmed, ...(color ? { color } : {}) });
+      rows.push({ section, label, value: trimmed, color });
     }
   }
 }
@@ -256,14 +277,12 @@ function addProgressRows(rows: TaskDetailRow[], task: TaskState): void {
     ].filter(Boolean);
     addDetailRows(rows, "progress", "usage", parts.join(" · "), "text2");
   }
-  if (lastActivity?.activityDescription) {
-    addDetailRows(rows, "progress", "latest", lastActivity.activityDescription, "subtle");
+  if (lastActivity) {
+    addDetailRows(rows, "progress", "latest", formatProgressActivity(lastActivity), "subtle");
   }
   if (recentActivities && recentActivities.length > 0) {
     recentActivities.forEach((activity, index) => {
-      const description =
-        activity.activityDescription ??
-        [activity.toolName, stringifyUnknown(activity.input)].filter(Boolean).join(" ");
+      const description = formatProgressActivity(activity);
       addDetailRows(rows, "progress", `activity ${index + 1}`, description, "subtle");
     });
   }
@@ -289,7 +308,6 @@ function buildTaskDetailRows(
   nameByAgentId: ReadonlyMap<string, string> = new Map(),
 ): readonly TaskDetailRow[] {
   const rows: TaskDetailRow[] = [];
-  const agentIdentity = formatBackgroundAgentIdentity(task, nameByAgentId);
   addDetailRows(rows, "task", "status", taskDetailStatusLabel(task), taskStatusColor(task.status));
   addDetailRows(rows, "task", "type", `${taskKindLabel(task)} · ${task.type}`, taskKindColor(task));
   addDetailRows(rows, "task", "title", taskTitle(task), "text2");
@@ -316,7 +334,7 @@ function buildTaskDetailRows(
       }
       break;
     case "local_agent":
-      addDetailRows(rows, "agent", "agent", agentIdentity ?? `${task.agentId} · Agent`, "worker");
+      addDetailRows(rows, "agent", "agent", formatLocalAgentIdentity(task, nameByAgentId), "worker");
       addDetailRows(rows, "agent", "model", task.model, "inactive");
       addDetailRows(rows, "agent", "prompt", task.prompt, "text2");
       addMessageRows(rows, "agent", "pending", task.pendingMessages);
@@ -325,7 +343,7 @@ function buildTaskDetailRows(
       addDetailRows(rows, "agent", "result", task.result, "subtle");
       break;
     case "in_process_teammate":
-      addDetailRows(rows, "teammate", "identity", agentIdentity ?? `${task.identity.agentName} · Agent`, "worker");
+      addDetailRows(rows, "teammate", "identity", formatTeammateIdentity(task), "worker");
       addDetailRows(rows, "teammate", "id", task.identity.agentId, "inactive");
       addDetailRows(rows, "teammate", "team", task.identity.teamName, "inactive");
       addDetailRows(rows, "teammate", "mode", task.permissionMode, "subtle");
@@ -358,15 +376,7 @@ function buildTaskDetailRows(
       break;
   }
 
-  return rows.length > 0
-    ? rows
-    : [{ section: "task", label: "empty", value: "No detail available", color: "inactive" }];
-}
-
-function taskActionLabel(task: TaskState): string {
-  const stopAction = tuiStopActionForTask(task);
-  if (stopAction === "remote-unavailable") return "Stop unavailable";
-  return stopAction ? "Stop" : "View output";
+  return rows;
 }
 
 function isBackgroundDialogTask(task: unknown): task is TaskState {
@@ -472,7 +482,6 @@ export function BackgroundTasksPanel({
     () => selectedTask ? buildTaskDetailRows(selectedTask, selectedShellOutputTail, nameByAgentId) : [],
     [nameByAgentId, selectedShellOutputTail, selectedTask],
   );
-  const selectedTaskDetail = selectedTask ? taskDetail(selectedTask) : null;
   const selectedTaskStopAction = tuiStopActionForTask(selectedTask);
   const selectedTaskCanStop =
     selectedTaskStopAction !== null && selectedTaskStopAction !== "remote-unavailable";
@@ -520,24 +529,16 @@ export function BackgroundTasksPanel({
   }, [showDetail, selectedTask?.id, selectedTask?.status, selectedTask?.type]);
   const selectRelative = React.useCallback(
     (delta: number) => {
-      if (sorted.length === 0) {
-        return;
-      }
       const nextIndex = (selectedIndex + delta + sorted.length) % sorted.length;
       setSelectedTaskId(sorted[nextIndex]!.id);
     },
     [selectedIndex, sorted],
   );
   const stopSelectedTask = React.useCallback(() => {
-    if (selectedTask) {
-      stopTuiTask(selectedTask, setAppState);
-    }
+    stopTuiTask(selectedTask!, setAppState);
   }, [selectedTask, setAppState]);
   const selectDetailRelative = React.useCallback(
     (delta: number) => {
-      if (detailRows.length === 0) {
-        return;
-      }
       setDetailIndex((current) =>
         Math.min(Math.max(0, current + delta), Math.max(0, detailRows.length - 1)),
       );
@@ -641,7 +642,7 @@ export function BackgroundTasksPanel({
           <ThemedText key="label" color={active ? "agenc" : "subtle"} wrap="truncate-end">
             {row.label}
           </ThemedText>,
-          <ThemedText key="value" color={row.color ?? "text2"} wrap="truncate-end">
+          <ThemedText key="value" color={row.color} wrap="truncate-end">
             {truncateToWidth(row.value, detailValueWidth)}
           </ThemedText>,
         ]}
@@ -649,49 +650,52 @@ export function BackgroundTasksPanel({
     );
   }
 
+  const listSelectedTask = selectedTask!;
+  const listSelectedTaskDetail = taskDetail(listSelectedTask);
+  const listSelectedTaskStopAction = tuiStopActionForTask(listSelectedTask);
+  const listSelectedTaskCanStop =
+    listSelectedTaskStopAction !== null && listSelectedTaskStopAction !== "remote-unavailable";
+
   return (
     <MenuModal
       title="background tasks"
       count={summary}
       summary="unified background panel"
-      headerRight={selectedTaskCanStop ? "↑↓ select · ⏎ open · x stop" : "↑↓ select · ⏎ open"}
+      headerRight={listSelectedTaskCanStop ? "↑↓ select · ⏎ open · x stop" : "↑↓ select · ⏎ open"}
       columns={[2, 8, 18, 28, 18, 12, 8, 8]}
       headers={["", "kind", "id · status", "label", "target", "progress", "elapsed", "cost"]}
       items={sorted}
       activeIndex={selectedIndex}
       footer={[
         { keyName: "⏎", label: "open" },
-        ...(selectedTaskCanStop ? [{ keyName: "x", label: "stop" }] : []),
+        ...(listSelectedTaskCanStop ? [{ keyName: "x", label: "stop" }] : []),
         { keyName: "l", label: "detail" },
       ]}
-      hint={truncateToWidth(
-        showDetail ? "detail open · ←/b returns to list" : "kinds · remote · teammate · bash · local",
-        taskTextWidth,
-      )}
-      preview={selectedTask ? (
+      hint={truncateToWidth("kinds · remote · teammate · bash · local", taskTextWidth)}
+      preview={
         <Box flexDirection="column">
-          <ThemedText color={taskStatusColor(selectedTask.status)} bold={true}>
+          <ThemedText color={taskStatusColor(listSelectedTask.status)} bold={true}>
             Task details
           </ThemedText>
           <ThemedText color="text2" wrap="truncate-end">
-            {truncateToWidth(`${selectedTask.status} · ${selectedTask.type} · ${formatBackgroundAgentIdentity(selectedTask, nameByAgentId) ?? taskTitle(selectedTask)}`, taskTextWidth)}
+            {truncateToWidth(`${listSelectedTask.status} · ${listSelectedTask.type} · ${formatBackgroundAgentIdentity(listSelectedTask, nameByAgentId) ?? taskTitle(listSelectedTask)}`, taskTextWidth)}
           </ThemedText>
-          <ThemedText color="inactive">{truncateToWidth(`id: ${selectedTask.id}`, taskTextWidth)}</ThemedText>
-          {selectedTaskDetail ? (
-            <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(selectedTaskDetail, taskTextWidth)}</ThemedText>
+          <ThemedText color="inactive">{truncateToWidth(`id: ${listSelectedTask.id}`, taskTextWidth)}</ThemedText>
+          {listSelectedTaskDetail ? (
+            <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(listSelectedTaskDetail, taskTextWidth)}</ThemedText>
           ) : null}
-          {"command" in selectedTask && selectedTask.command ? (
-            <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(`command: ${selectedTask.command}`, taskTextWidth)}</ThemedText>
+          {"command" in listSelectedTask && listSelectedTask.command ? (
+            <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(`command: ${listSelectedTask.command}`, taskTextWidth)}</ThemedText>
           ) : null}
-          {"prompt" in selectedTask && selectedTask.prompt ? (
-            <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(`prompt: ${selectedTask.prompt}`, taskTextWidth)}</ThemedText>
+          {"prompt" in listSelectedTask && listSelectedTask.prompt ? (
+            <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(`prompt: ${listSelectedTask.prompt}`, taskTextWidth)}</ThemedText>
           ) : null}
-          <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(`view output: ${selectedTask.outputFile}`, taskTextWidth)}</ThemedText>
-          {taskActionLabel(selectedTask) === "Stop unavailable" ? (
+          <ThemedText color="subtle" wrap="truncate-end">{truncateToWidth(`view output: ${listSelectedTask.outputFile}`, taskTextWidth)}</ThemedText>
+          {listSelectedTaskStopAction === "remote-unavailable" ? (
             <ThemedText color="inactive">Remote task stop is not available from this session.</ThemedText>
           ) : null}
         </Box>
-      ) : null}
+      }
       renderRow={(task, _index, active) => [
         <ThemedText key="icon" color={taskKindColor(task)}>{taskKindIcon(task)}</ThemedText>,
         <ThemedText key="kind" color={taskKindColor(task)}>{taskKindLabel(task)}</ThemedText>,

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage3.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage3.test.tsx
@@ -1,0 +1,495 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createRoot } from '../../ink.js'
+import { renderToString } from '../../../utils/staticRender.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: { tasks: {} } as Record<string, unknown>,
+  setAppState: vi.fn(),
+}))
+
+const inputHandler = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | ((input: string, key: Record<string, boolean>) => void),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 120, rows: 32 },
+}))
+
+const killTaskMock = vi.hoisted(() => vi.fn())
+const killAsyncAgentMock = vi.hoisted(() => vi.fn())
+const requestTeammateShutdownMock = vi.hoisted(() => vi.fn())
+const tailFileMock = vi.hoisted(() => vi.fn())
+const getTaskOutputPathMock = vi.hoisted(() =>
+  vi.fn((taskId: string) => `/tmp/${taskId}.log`),
+)
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../../ink.js')>(
+    '../../ink.js',
+  )
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      inputHandler.current = handler
+    },
+  }
+})
+
+vi.mock('../../../tasks/LocalShellTask/killShellTasks.js', () => ({
+  killTask: killTaskMock,
+}))
+
+vi.mock('../../../tasks/LocalAgentTask/LocalAgentTask.js', () => ({
+  killAsyncAgent: killAsyncAgentMock,
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  requestTeammateShutdown: requestTeammateShutdownMock,
+}))
+
+vi.mock('../../../utils/fsOperations.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/fsOperations.js')>()
+  return {
+    ...actual,
+    tailFile: tailFileMock,
+  }
+})
+
+vi.mock('../../../utils/task/diskOutput.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../utils/task/diskOutput.js')>()
+  return {
+    ...actual,
+    getTaskOutputPath: getTaskOutputPathMock,
+  }
+})
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    ...overrides,
+  }
+}
+
+function makeShellTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'shell-task',
+    type: 'local_bash',
+    status: 'running',
+    description: 'Run shell task',
+    startTime: Date.now() - 2_000,
+    outputFile: 'urn:agenc:task:shell-task:output',
+    outputOffset: 0,
+    notified: false,
+    command: 'npm run test',
+    kind: 'bash',
+    isBackgrounded: true,
+    ...overrides,
+  }
+}
+
+function makeLocalAgentTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'local-agent-task',
+    type: 'local_agent',
+    status: 'running',
+    description: 'Local agent task',
+    startTime: Date.now() - 5_000,
+    outputFile: 'urn:agenc:task:local-agent-task:output',
+    outputOffset: 0,
+    notified: false,
+    agentId: 'agent-local',
+    agentType: 'worker',
+    model: 'local-model',
+    prompt: 'Check the task panel',
+    retrieved: false,
+    pendingMessages: [],
+    messages: [],
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    isBackgrounded: true,
+    retain: false,
+    diskLoaded: false,
+    ...overrides,
+  }
+}
+
+function makeTeammateTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'teammate-task',
+    type: 'in_process_teammate',
+    status: 'running',
+    description: 'Teammate task',
+    startTime: Date.now() - 4_000,
+    outputFile: 'urn:agenc:task:teammate-task:output',
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: 'agent-teammate',
+      agentName: 'Reviewer',
+      teamName: 'runtime',
+      planModeRequired: false,
+      parentSessionId: 'parent-session',
+    },
+    prompt: 'Audit branches',
+    model: 'teammate-model',
+    selectedAgent: { agentType: 'explorer' },
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    pendingUserMessages: [],
+    messages: [],
+    isIdle: true,
+    shutdownRequested: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    ...overrides,
+  }
+}
+
+describe('BackgroundTasksPanel branch coverage', () => {
+  beforeEach(() => {
+    appStateMock.state = { tasks: {}, agentNameRegistry: new Map() }
+    appStateMock.setAppState.mockClear()
+    inputHandler.current = undefined
+    terminalSizeMock.size = { columns: 120, rows: 32 }
+    killTaskMock.mockClear()
+    killAsyncAgentMock.mockClear()
+    requestTeammateShutdownMock.mockClear()
+    tailFileMock.mockReset()
+    tailFileMock.mockResolvedValue({ content: 'tail output', bytesTotal: 11 })
+    getTaskOutputPathMock.mockClear()
+  })
+
+  it('renders tool-only current activity and registered local agent names', async () => {
+    appStateMock.state = {
+      agentNameRegistry: new Map([['Navigator', 'local-agent-task']]),
+      tasks: {
+        local: makeLocalAgentTask({
+          progress: {
+            toolUseCount: 1,
+            lastActivity: {
+              toolName: 'Edit',
+              input: { file: 'src/tui/App.tsx' },
+            },
+          },
+          messages: ['first note\n\nsecond note'],
+          error: 'preview error',
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+    const listOutput = await renderToString(<BackgroundTasksPanel />, 120)
+    const detailOutput = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="local-agent-task" />,
+      120,
+    )
+    const output = `${listOutput}\n${detailOutput}`
+
+    expect(output).toContain('Navigator · Runner')
+    expect(output).toContain('Edit {"file":"src/tui/App.tsx"}')
+    expect(output).toContain('preview error')
+    expect(output).toContain('first note')
+    expect(output).toContain('second note')
+  })
+
+  it('renders selected teammate roles, idle state, and token-only usage', async () => {
+    appStateMock.state = {
+      tasks: {
+        teammate: makeTeammateTask({
+          progress: {
+            tokenCount: 77,
+            lastActivity: {
+              toolName: 'Read',
+              input: 'notes.md',
+            },
+          },
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="teammate-task" />,
+      120,
+    )
+
+    expect(output).toContain('Reviewer · Scanner')
+    expect(output).toContain('idle')
+    expect(output).toContain('77 tokens')
+    expect(output).toContain('Read notes.md')
+  })
+
+  it('falls back for blank titles, missing timestamps, empty activity, and unknown selected-agent roles', async () => {
+    appStateMock.state = {
+      tasks: {
+        blankRemote: {
+          id: 'blank-title-task',
+          type: 'remote_agent',
+          status: 'completed',
+          description: '   ',
+          startTime: undefined,
+          outputFile: 'urn:agenc:task:blank-title-task:output',
+          outputOffset: 0,
+          notified: false,
+          remoteTaskType: 'remote-agent',
+          sessionId: 'remote-session',
+          command: '',
+          title: '',
+          todoList: [],
+          log: [],
+          pollStartedAt: Date.now(),
+        },
+        teammate: makeTeammateTask({
+          id: 'teammate-no-role',
+          status: 'completed',
+          startTime: undefined,
+          selectedAgent: { agentType: 42 },
+          progress: {
+            lastActivity: {},
+          },
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+    const listOutput = await renderToString(<BackgroundTasksPanel />, 120)
+    const detailOutput = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="teammate-no-role" />,
+      120,
+    )
+    const output = `${listOutput}\n${detailOutput}`
+
+    expect(output).toContain('blank-title-task')
+    expect(output).toContain('Reviewer · Agent')
+    expect(output).toContain('—')
+
+    appStateMock.state = {
+      tasks: {
+        teammate: makeTeammateTask({
+          progress: {
+            lastActivity: {},
+          },
+        }),
+      },
+    }
+    const emptyActivityOutput = await renderToString(<BackgroundTasksPanel />, 120)
+    expect(emptyActivityOutput).toContain('teammate-task')
+  })
+
+  it('renders completed shell success details with empty output tails', async () => {
+    tailFileMock.mockResolvedValue({
+      content: '',
+      bytesTotal: 0,
+    })
+    appStateMock.state = {
+      tasks: {
+        shell: makeShellTask({
+          id: 'completed-shell',
+          status: 'completed',
+          command: 'true',
+          result: { code: 0, interrupted: false },
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="completed-shell" />,
+      120,
+    )
+
+    expect(output).toContain('code 0')
+    expect(output).toContain('no')
+    expect(output).toContain('(no output)')
+    expect(tailFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores shell tail completion after the detail view unmounts', async () => {
+    let resolveTail:
+      | undefined
+      | ((value: { content: string; bytesTotal: number }) => void)
+    tailFileMock.mockReturnValue(
+      new Promise(resolve => {
+        resolveTail = resolve
+      }),
+    )
+    appStateMock.state = {
+      tasks: {
+        shell: makeShellTask({
+          id: 'running-shell',
+          command: 'npm run watch',
+        }),
+      },
+    }
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+      root.render(<BackgroundTasksPanel initialDetailTaskId="running-shell" />)
+      await sleep()
+      root.unmount()
+      resolveTail?.({ content: 'late shell output', bytesTotal: 17 })
+      await sleep()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(tailFileMock).toHaveBeenCalledWith('/tmp/running-shell.log', 8192)
+  })
+
+  it('covers list and detail keyboard navigation branches', async () => {
+    appStateMock.state = {
+      tasks: {
+        finished: makeShellTask({
+          id: 'finished-shell',
+          status: 'completed',
+          command: 'echo done',
+          startTime: Date.now() - 3_000,
+        }),
+        running: makeShellTask({
+          id: 'running-shell',
+          command: 'npm run watch',
+          startTime: Date.now() - 1_000,
+        }),
+      },
+    }
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+    await renderToString(<BackgroundTasksPanel />, 120)
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('', key({ upArrow: true }))
+    inputHandler.current('', key({ downArrow: true }))
+    inputHandler.current('', key({ rightArrow: true }))
+    inputHandler.current('', key({ return: true }))
+    inputHandler.current('l', key())
+    inputHandler.current('z', key())
+
+    inputHandler.current = undefined
+    await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="running-shell" />,
+      120,
+    )
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel detail did not register input handling')
+    }
+    inputHandler.current('', key({ leftArrow: true }))
+    inputHandler.current('b', key())
+    inputHandler.current('h', key())
+    inputHandler.current('', key({ upArrow: true }))
+    inputHandler.current('k', key())
+    inputHandler.current('', key({ downArrow: true }))
+    inputHandler.current('j', key())
+    inputHandler.current('z', key())
+
+    expect(killTaskMock).not.toHaveBeenCalled()
+  })
+
+  it('applies mounted detail scroll updates', async () => {
+    appStateMock.state = {
+      tasks: {
+        local: makeLocalAgentTask({
+          messages: ['one', 'two', 'three'],
+        }),
+      },
+    }
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+      root.render(<BackgroundTasksPanel initialDetailTaskId="local-agent-task" />)
+      await sleep()
+      if (!inputHandler.current) {
+        throw new Error('BackgroundTasksPanel did not register mounted input handling')
+      }
+      inputHandler.current('', key({ downArrow: true }))
+      await sleep()
+      inputHandler.current('', key({ upArrow: true }))
+      await sleep()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(killTaskMock).not.toHaveBeenCalled()
+  })
+
+  it('handles app state without a tasks object', async () => {
+    appStateMock.state = {
+      agentNameRegistry: new Map(),
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+    const output = await renderToString(<BackgroundTasksPanel />, 120)
+
+    expect(output).toContain('No background tasks')
+  })
+})
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 32
+  ;(stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 20): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
## Summary
- Render BackgroundTasksPanel current activity from tool name/input when no activityDescription is present.
- Trim blank task descriptions before falling back to task ids.
- Remove unreachable private fallback branches now guaranteed by task filtering and add focused branch coverage for list/detail rendering, shell tails, keyboard paths, and role/name fallbacks.

## Test plan
- npx vitest run tests/tui/components/tasks/BackgroundTasksPanel.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage2.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage3.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.wave200-017.coverage.test.tsx tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx --coverage --coverage.include=src/tui/components/tasks/BackgroundTasksPanel.tsx --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reportsDirectory=coverage/background-tasks-panel-audit --reporter=dot
- npx vitest run tests/tui/components/tasks tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/components/PromptInput/PromptInputFooter.render.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx tests/tui/components/CoordinatorAgentStatus.test.ts tests/tui/components/CoordinatorAgentStatus.render.test.tsx tests/tui/components/CoordinatorAgentStatus.render.runtime-coverage.test.tsx tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx tests/tui/workbench/agent-surface.test.tsx tests/tui/state/collabAgentTaskSync.test.ts tests/agents tests/session/agent-task-lifecycle.test.ts --reporter=dot
- npm run typecheck -- --pretty false
- git diff --check
- npm run test:coverage:tui
- npm run check:unused:production
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Coverage
- BackgroundTasksPanel.tsx: 100% statements, 100% branches, 100% functions, 100% lines in focused coverage.
- Full TUI coverage after this change: 96.29% statements, 90.88% branches, 96.66% functions, 97.11% lines.

## Notes
- npm run check:unused:production still reports the existing accepted baseline of 30 unused exports and 4 tag hints.