### PR TITLE
chore(runtime): fix production unused gate

### DIFF
--- a/runtime/knip.config.mjs
+++ b/runtime/knip.config.mjs
@@ -187,6 +187,7 @@ const sessionContractExportFiles = [
   'src/session/run-turn.ts',
   'src/session/session-store.ts',
   'src/session/session.ts',
+  'src/session/startup-prewarm.ts',
   'src/session/tasks.ts',
   'src/session/turn-context.ts',
 ];
@@ -437,8 +438,17 @@ const binConfigTaskOnboardingContractExportFiles = [
   // CLI bootstrap ingress helpers, config schema/compatibility helpers,
   // onboarding flows, and task registry surfaces are covered by focused tests
   // or consumed through dynamic runtime paths outside this Knip graph.
+  'src/bin/_deps/current-session.ts',
   'src/bin/_deps/session-ingress-auth.ts',
   'src/bin/_deps/session-storage.ts',
+  'src/bin/bootstrap-services.ts',
+  'src/bin/mcp-cli.ts',
+  'src/bin/providers-cli.ts',
+  'src/bin/slash.ts',
+  'src/bin/structured-output-tool.ts',
+  'src/bin/task-store.ts',
+  'src/bin/tui-local-events.ts',
+  'src/bin/web-fetch-preapproved.ts',
   'src/config/init.ts',
   'src/config/loader.ts',
   'src/config/profiles.ts',
@@ -497,6 +507,17 @@ const intentionalConversationRecoveryStateShellIssueIgnores = Object.fromEntries
     file,
     ['exports'],
   ]),
+);
+const transactionGuardContractExportFiles = [
+  // Transaction guard internals are exercised by focused contract tests while
+  // production reaches only the narrower runtime entrypoints.
+  'src/transaction-guard/config.ts',
+  'src/transaction-guard/docket.ts',
+  'src/transaction-guard/errors.ts',
+  'src/transaction-guard/ollama-courtguard.ts',
+];
+const intentionalTransactionGuardIssueIgnores = Object.fromEntries(
+  transactionGuardContractExportFiles.map((file) => [file, ['exports']]),
 );
 const remainingRuntimeContractExportFiles = [
   // The final cleanup tranche leaves only daemon/client protocol, command,
@@ -615,6 +636,7 @@ export default {
     ...intentionalAppAgentErrorIssueIgnores,
     ...intentionalBinConfigTaskOnboardingIssueIgnores,
     ...intentionalConversationRecoveryStateShellIssueIgnores,
+    ...intentionalTransactionGuardIssueIgnores,
     ...intentionalRemainingRuntimeIssueIgnores,
   },
   ignoreBinaries: [

--- a/runtime/src/entrypoints/agentSdkTypes.ts
+++ b/runtime/src/entrypoints/agentSdkTypes.ts
@@ -268,7 +268,6 @@ export async function forkSession(
 
 /**
  * A scheduled task from `<dir>/.agenc/scheduled_tasks.json`.
- * @internal
  */
 export type CronTask = {
   id: string
@@ -296,7 +295,6 @@ export type CronJitterConfig = {
 
 /**
  * Event yielded by `watchScheduledTasks()`.
- * @internal
  */
 export type ScheduledTaskEvent =
   | { type: 'fire'; task: CronTask }
@@ -352,7 +350,6 @@ export function buildMissedTaskNotification(_missed: CronTask[]): string {
 
 /**
  * A user message typed on agenc.tech, extracted from the bridge WS.
- * @internal
  */
 export type InboundPrompt = {
   content: string | unknown[]

--- a/runtime/src/utils/messages.ts
+++ b/runtime/src/utils/messages.ts
@@ -30,6 +30,7 @@ import {
 } from 'src/services/analytics/index.js'
 import { sanitizeToolNameForAnalytics } from 'src/services/analytics/metadata.js'
 import type { AgentId } from 'src/types/ids.js'
+import { projectSnippedView } from '../services/compact/snipProjection.js'
 // Retired intro attachments render empty text for old transcripts.
 const companionIntroText = (_name: string, _species: string): string => ''
 import { NO_CONTENT_MESSAGE } from '../constants/messages.js'
@@ -4628,10 +4629,6 @@ export function getMessagesAfterCompactBoundary<
   const boundaryIndex = findLastCompactBoundaryIndex(messages)
   const sliced = boundaryIndex === -1 ? messages : messages.slice(boundaryIndex)
   if (!options?.includeSnipped && feature('HISTORY_SNIP')) {
-    /* eslint-disable @typescript-eslint/no-require-imports */
-    const { projectSnippedView } =
-      require('../services/compact/snipProjection.js') as typeof import('../services/compact/snipProjection.js')
-    /* eslint-enable @typescript-eslint/no-require-imports */
     return projectSnippedView(sliced as Message[]) as T[]
   }
   return sliced

--- a/runtime/src/utils/swarm/teamHelpers.ts
+++ b/runtime/src/utils/swarm/teamHelpers.ts
@@ -125,7 +125,7 @@ export function getTeamFilePath(teamName: string): string {
 
 /**
  * Reads a team file by name (sync — for sync contexts like React render paths)
- * @internal Exported for team discovery UI
+ * Exported for team discovery UI.
  */
 // sync IO: called from sync context
 export function readTeamFile(teamName: string): TeamFile | null {


### PR DESCRIPTION
## Summary
- record focused bin/CLI, startup prewarm, and transaction guard contract exports in the production Knip config
- make the snip projection dependency statically visible to Knip
- remove stale internal JSDoc tags from exported SDK/team helper surfaces

## Verification
- npm run check:unused:production
- npm run typecheck
- npx vitest run tests/bin/bootstrap-services.test.ts tests/bin/mcp-cli.test.ts tests/bin/mcp-cli-management.test.ts tests/bin/providers-cli.test.ts tests/bin/slash.test.ts tests/bin/structured-output-tool.test.ts tests/bin/task-store.test.ts tests/bin/tui-local-events.test.ts tests/bin/web-fetch-preapproved.test.ts tests/mcp/server/start.test.ts tests/tools/tasks/task-tools.test.ts tests/transaction-guard/transaction-guard.test.ts tests/conversation/thread-manager.contract.test.ts --reporter=dot