### PR TITLE
fix(tui): make workbench transcript scrollable

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -36,6 +36,7 @@
     "test:tui-yolo-openclaude-parity": "vitest run tests/tui/components/PromptInput/permissionModeChrome.test.ts tests/tui/components/FullscreenLayout.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.runtime-coverage.test.tsx tests/permissions/permission-mode.test.ts tests/app-server-client/index.test.ts --reporter=dot",
     "check:tui-command-visual-smoke": "node scripts/check-tui-command-visual-smoke.mjs",
     "check:tui-workbench-visual-smoke": "node scripts/check-tui-workbench-visual-smoke.mjs",
+    "check:tui-workbench-transcript-scroll": "node scripts/check-tui-workbench-transcript-scroll.mjs",
     "check:tui-v2-design-audit": "npm run build && vitest run tests/tui/components/v2/designStateSmoke.test.tsx && node scripts/check-tui-command-visual-smoke.mjs",
     "check:llm-pipeline": "node scripts/check-llm-pipeline/runner.mjs",
     "check:daemon-errors": "node scripts/check-daemon-errors/runner.mjs",

--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -247,16 +247,29 @@ export function renderPtyRows(raw, { cols = 140, rows = 40 } = {}) {
   let row = 0;
   let col = 0;
   let wrapPending = false;
+  let scrollTop = 0;
+  let scrollBottom = rows - 1;
 
   const scrollUp = (count = 1) => {
     for (let idx = 0; idx < count; idx += 1) {
-      grid.shift();
-      grid.push(Array.from({ length: cols }, () => " "));
+      for (let y = scrollTop; y < scrollBottom; y += 1) {
+        grid[y] = grid[y + 1] ?? Array.from({ length: cols }, () => " ");
+      }
+      grid[scrollBottom] = Array.from({ length: cols }, () => " ");
+    }
+  };
+
+  const scrollDown = (count = 1) => {
+    for (let idx = 0; idx < count; idx += 1) {
+      for (let y = scrollBottom; y > scrollTop; y -= 1) {
+        grid[y] = grid[y - 1] ?? Array.from({ length: cols }, () => " ");
+      }
+      grid[scrollTop] = Array.from({ length: cols }, () => " ");
     }
   };
 
   const lineFeed = () => {
-    if (row >= rows - 1) {
+    if (row >= scrollBottom) {
       scrollUp();
     } else {
       row += 1;
@@ -343,6 +356,21 @@ export function renderPtyRows(raw, { cols = 140, rows = 40 } = {}) {
           else if (mode === 2) clearLine(row, 0, cols - 1);
         } else if (final === "S") {
           scrollUp(first);
+        } else if (final === "T") {
+          scrollDown(first);
+        } else if (final === "r") {
+          if (sequence === "r" || params.every((param) => param === 0)) {
+            scrollTop = 0;
+            scrollBottom = rows - 1;
+          } else {
+            const top = clamp((params[0] || 1) - 1, 0, rows - 1);
+            const bottom = clamp((params[1] || rows) - 1, 0, rows - 1);
+            if (bottom > top) {
+              scrollTop = top;
+              scrollBottom = bottom;
+            }
+          }
+          moveCursor(0, 0);
         }
         i = end;
         continue;

--- a/runtime/scripts/check-tui-workbench-transcript-scroll.mjs
+++ b/runtime/scripts/check-tui-workbench-transcript-scroll.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { TuiSession, renderPtyRows } from "./check-tui-e2e/harness.mjs";
+
+const DIMENSIONS = [
+  { cols: 148, rows: 40 },
+  { cols: 100, rows: 28 },
+  { cols: 80, rows: 24 },
+];
+
+const WORKBENCH_ENV = {
+  AGENC_NO_FLICKER: "1",
+  AGENC_TUI_GLYPHS: "ascii",
+  AGENC_TUI_WORKBENCH: "1",
+};
+
+const LONG_OUTPUT_COMMAND = "!seq -f WBANCHOR-%03g 1 120 #";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fail(message, details = {}) {
+  const suffix = Object.entries(details)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ");
+  throw new Error(suffix ? `${message} (${suffix})` : message);
+}
+
+function frameRows(session, dimension) {
+  return renderPtyRows(session.raw, dimension);
+}
+
+function frameText(session, dimension) {
+  return frameRows(session, dimension).join("\n");
+}
+
+function assertFrameShape(session, dimension, label) {
+  const rows = frameRows(session, dimension);
+  if (rows.every((row) => row.trim().length === 0)) {
+    fail("blank workbench transcript frame", { label });
+  }
+  for (const [index, row] of rows.entries()) {
+    if (row.length > dimension.cols) {
+      fail("workbench transcript row overflow", {
+        label,
+        row: index + 1,
+        width: row.length,
+        cols: dimension.cols,
+      });
+    }
+  }
+  const frame = rows.join("\n");
+  if (!frame.includes("TRANSCRIPT")) {
+    fail("transcript title absent from frame", {
+      label,
+      frame: JSON.stringify(frame.slice(0, 1200)),
+    });
+  }
+}
+
+async function waitForFrame(session, dimension, predicate, label, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  let lastFrame = "";
+  while (Date.now() - startedAt < timeoutMs) {
+    lastFrame = frameText(session, dimension);
+    if (predicate(lastFrame)) return;
+    await sleep(100);
+  }
+  fail("timed out waiting for transcript frame state", {
+    label,
+    frame: JSON.stringify(lastFrame.slice(-800)),
+  });
+}
+
+async function sendRepeated(session, bytes, count, pauseMs = 70) {
+  for (let index = 0; index < count; index += 1) {
+    session.send(bytes);
+    await sleep(pauseMs);
+  }
+}
+
+async function runOne(dimension) {
+  const session = new TuiSession({
+    cols: dimension.cols,
+    rows: dimension.rows,
+    env: WORKBENCH_ENV,
+    useTempHome: true,
+  });
+  const label = `${dimension.cols}x${dimension.rows}`;
+
+  try {
+    await session.start({ firstPaintMs: 1_000, postReplyMs: 1_000 });
+    await session.waitForPrompt({ timeout: 20_000 });
+    assertFrameShape(session, dimension, `${label} cold start`);
+
+    await session.submit(LONG_OUTPUT_COMMAND);
+    await session.waitFor(/WBANCHOR-120/, {
+      timeout: 20_000,
+      label: `${label} tail anchor`,
+    });
+    await session.waitForIdle({ idleWindow: 1_000, timeout: 20_000 });
+    assertFrameShape(session, dimension, `${label} long output tail`);
+    await waitForFrame(
+      session,
+      dimension,
+      (frame) => frame.includes("WBANCHOR-120"),
+      `${label} tail visible`,
+    );
+
+    await sendRepeated(session, "\x1b[5~", 18);
+    await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
+    assertFrameShape(session, dimension, `${label} scrolled up`);
+    await waitForFrame(
+      session,
+      dimension,
+      (frame) => /WBANCHOR-00[1-9]|WBANCHOR-01[0-9]|WBANCHOR-02[0-9]/u.test(frame),
+      `${label} old anchor visible`,
+    );
+
+    await sendRepeated(session, "\x1b[6~", 18);
+    await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
+    assertFrameShape(session, dimension, `${label} scrolled down`);
+    await waitForFrame(
+      session,
+      dimension,
+      (frame) => frame.includes("WBANCHOR-120"),
+      `${label} tail restored`,
+    );
+
+    session.assertNoCrash();
+  } finally {
+    session.kill();
+    await session.cleanup();
+  }
+}
+
+async function main() {
+  const failures = [];
+  for (const dimension of DIMENSIONS) {
+    const label = `${dimension.cols}x${dimension.rows}`;
+    process.stdout.write(`workbench transcript scroll: ${label} ... `);
+    try {
+      await runOne(dimension);
+      process.stdout.write("ok\n");
+    } catch (error) {
+      process.stdout.write("failed\n");
+      failures.push({ label, error });
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error?.stack ?? error?.message ?? String(error));
+  process.exit(1);
+});

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -109,6 +109,7 @@ import {
   stopAgenCDaemonPromptAgent,
 } from "../app-server-client/index.js";
 import {
+  emitLocalTuiEvent,
   emitLocalTuiPhaseEvent,
   emitLocalTuiSlashResult,
 } from "./tui-local-events.js";
@@ -2259,6 +2260,7 @@ type TuiSessionShape = {
   ) => Promise<void>;
   enqueueIdleInput?: (input: unknown) => number;
   subscribeToEvents?: (cb: (event: unknown) => void) => () => void;
+  emit?: (event: unknown) => void;
   emitPhaseEvent?: (event: PhaseEvent) => void;
   clearDaemonSession?: () => Promise<void>;
   getDaemonSessionSnapshot?: () => Promise<unknown>;
@@ -2463,6 +2465,10 @@ async function createDeferredDaemonPromptTuiSession(params: {
   };
 
   const base = params.baseSession as Record<string, unknown>;
+  const originalEmit =
+    typeof base.emit === "function"
+      ? (base.emit as (event: unknown) => void).bind(base)
+      : undefined;
   const session: TuiSessionShape & Record<string, unknown> = {
     ...base,
     // The Ink TUI's slash dispatcher in `App.tsx` calls `dispatchSlashCommand`
@@ -2553,6 +2559,14 @@ async function createDeferredDaemonPromptTuiSession(params: {
     emitPhaseEvent: (event) => {
       emitLocalTuiPhaseEvent(liveSession, subscribers, event);
     },
+    emit: (event) => {
+      if (typeof liveSession?.emit === "function") {
+        liveSession.emit(event);
+        return;
+      }
+      originalEmit?.(event);
+      emitLocalTuiEvent(subscribers, event);
+    },
     subscribeToEvents: (cb) => {
       subscribers.add(cb);
       if (liveSession !== null) {
@@ -2642,6 +2656,7 @@ function wrapDaemonTuiSessionWithPromptPreparation<
       opts?: { readonly displayUserMessage?: string | null },
     ) => Promise<void>;
     subscribeToEvents?: (cb: (event: unknown) => void) => () => void;
+    emit?: (event: unknown) => void;
     emitPhaseEvent?: (event: PhaseEvent) => void;
   },
 >(
@@ -2657,6 +2672,7 @@ function wrapDaemonTuiSessionWithPromptPreparation<
   const originalSubmit = session.submit?.bind(session);
   if (originalSubmit === undefined) return session;
   const originalSubscribe = session.subscribeToEvents?.bind(session);
+  const originalEmit = session.emit?.bind(session);
   const originalEmitPhaseEvent = session.emitPhaseEvent?.bind(session);
   const localSubscribers = new Set<(event: unknown) => void>();
   let wrapped!: Session;
@@ -2690,6 +2706,10 @@ function wrapDaemonTuiSessionWithPromptPreparation<
         unsubscribeOriginal?.();
       };
     }) as Session["subscribeToEvents"],
+    emit: ((event: unknown) => {
+      originalEmit?.(event);
+      emitLocalTuiEvent(localSubscribers, event);
+    }) as Session["emit"],
     emitPhaseEvent: ((event: PhaseEvent) => {
       emitLocalTuiPhaseEvent(
         { emitPhaseEvent: originalEmitPhaseEvent },

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -15,7 +15,8 @@ import { CostThresholdDialog } from "./dialogs/CostThresholdDialog.js";
 import { FullscreenLayout } from "./FullscreenLayout.js";
 import { WorkbenchLayout } from "../workbench/WorkbenchLayout.js";
 import { ApprovalSurfaceBridge } from "../workbench/approvals/ApprovalSurfaceBridge.js";
-import { applyWorkbenchCommand, isWorkbenchEnabled } from "../workbench/state.js";
+import { applyWorkbenchCommand, getWorkbenchStateFromAppState, isWorkbenchEnabled } from "../workbench/state.js";
+import { shouldEnableTranscriptScrollKeybindings } from "../workbench/transcriptScroll.js";
 import { ScrollKeybindingHandler } from "./ScrollKeybindingHandler.js";
 import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
 import { AlternateScreen } from "../ink/components/AlternateScreen.js";
@@ -82,6 +83,7 @@ import {
   readCompletionPipelineState,
   type CompletionPipelineState,
 } from "../completion-pipeline.js";
+export { shouldEnableTranscriptScrollKeybindings } from "../workbench/transcriptScroll.js";
 export type McpFieldValue = string | number | boolean | readonly string[];
 const EMPTY_MCP_CLIENTS: readonly MCPServerConnection[] = [];
 const EMPTY_MCP_TOOLS: readonly unknown[] = [];
@@ -1403,6 +1405,7 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
   const modalScrollRef = useRef<ScrollBoxHandle | null>(null);
   const fullscreen = isFullscreenEnvEnabled();
   const workbenchEnabled = fullscreen && isWorkbenchEnabled();
+  const workbenchState = useAppState(getWorkbenchStateFromAppState);
   // SpinnerWithVerb wall-clock timer state. Refs (not state) so the spinner's
   // 50ms animation tick doesn't re-render AgenCTuiShell — SpinnerAnimationRow
   // owns the per-frame clock and reads these refs directly.
@@ -2406,14 +2409,20 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
   const body = <>
       <AnimatedTerminalTitle isAnimating={titleIsAnimating} title={title} />
       <GlobalKeybindingHandlers screen={screen as any} setScreen={setScreen as any} showAllInTranscript={showAllInTranscript} setShowAllInTranscript={setShowAllInTranscript} messageCount={transcript.messages.length} />
-      <ScrollKeybindingHandler scrollRef={modalToolJSX !== null ? modalScrollRef : scrollRef} isActive={fullscreen && !workbenchEnabled && permissionRequests.length === 0} />
+      <ScrollKeybindingHandler scrollRef={modalToolJSX !== null ? modalScrollRef : scrollRef} isActive={shouldEnableTranscriptScrollKeybindings({
+        fullscreen,
+        workbenchEnabled,
+        permissionRequestCount: permissionRequests.length,
+        modalVisible: modalToolJSX !== null,
+        activeSurfaceMode: workbenchState.activeSurfaceMode
+      })} isModal={modalToolJSX !== null} />
       <CancelRequestHandler
     // Daemon-mode no-op: permission requests are owned by the daemon
     // and resolved via session.cancelTurn cascade.
     setToolUseConfirmQueue={() => {}} onCancel={handleTurnCancel} onAgentsKilled={handleAgentsKilled} isMessageSelectorVisible={isMessageSelectorVisible} screen={screen as never} {...turnAbortController !== null ? {
       abortSignal: turnAbortController.signal
     } : {}} isSearchingHistory={isSearchingHistory} isHelpOpen={helpOpen} inputMode={mode as never} inputValue={input} streamMode={cancelStreamMode as never} />
-      {workbenchEnabled ? <WorkbenchLayout transcript={scrollableContent} composer={bottomContent} overlay={overlayContent ?? undefined} modal={modalToolJSX !== null ? <Box flexDirection="column" width="100%">{modalToolJSX}</Box> : undefined} pendingApproval={permissionRequests[0] ?? null} /> : <FullscreenLayout scrollRef={scrollRef} scrollable={scrollableContent} bottom={bottomContent} overlay={overlayContent ?? undefined} modal={modalToolJSX !== null ? <Box flexDirection="column" width="100%">{modalToolJSX}</Box> : undefined} modalScrollRef={modalScrollRef} />}
+      {workbenchEnabled ? <WorkbenchLayout transcript={scrollableContent} composer={bottomContent} overlay={overlayContent ?? undefined} modal={modalToolJSX !== null ? <Box flexDirection="column" width="100%">{modalToolJSX}</Box> : undefined} modalScrollRef={modalScrollRef} pendingApproval={permissionRequests[0] ?? null} scrollRef={scrollRef} /> : <FullscreenLayout scrollRef={scrollRef} scrollable={scrollableContent} bottom={bottomContent} overlay={overlayContent ?? undefined} modal={modalToolJSX !== null ? <Box flexDirection="column" width="100%">{modalToolJSX}</Box> : undefined} modalScrollRef={modalScrollRef} />}
       {showCostDialog ? <CostThresholdDialog onDone={handleCostThresholdDone} /> : null}
       {exitFlow}
       {isMessageSelectorVisible ? <MessageSelector messages={transcript.messages as any[]} onPreRestore={() => {}} onRestoreMessage={handleRestoreMessage} onRestoreCode={handleRestoreCode} onSummarize={handleSummarize} onClose={handleCloseMessageSelector} /> : null}

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -2488,7 +2488,11 @@ export function useSessionTranscript(
       dispatch({ kind: "append", event });
     });
     const unsubscribePhase = session.subscribeToEvents?.((event) => {
-      if (event && typeof event === "object" && "type" in event) {
+      if (
+        event &&
+        typeof event === "object" &&
+        ("type" in event || "msg" in event)
+      ) {
         dispatch({ kind: "append", event: event as SessionTranscriptEvent });
       }
     });

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -1,7 +1,9 @@
 // @ts-nocheck
-import React, { useMemo } from "react";
+import React, { useMemo, type RefObject } from "react";
 
 import { Box, Text } from "../ink.js";
+import { ModalContext } from "../context/modalContext.js";
+import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
 import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { useKeybindings } from "../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../keybindings/KeybindingContext.js";
@@ -22,7 +24,9 @@ type Props = {
   readonly composer: React.ReactNode;
   readonly overlay?: React.ReactNode;
   readonly modal?: React.ReactNode;
+  readonly modalScrollRef?: RefObject<ScrollBoxHandle | null>;
   readonly pendingApproval?: PendingRequest | null;
+  readonly scrollRef?: RefObject<ScrollBoxHandle | null>;
 };
 
 export function WorkbenchLayout({
@@ -30,7 +34,9 @@ export function WorkbenchLayout({
   composer,
   overlay,
   modal,
+  modalScrollRef,
   pendingApproval,
+  scrollRef,
 }: Props): React.ReactElement {
   const { columns, rows } = useTerminalSize();
   const workbench = useWorkbenchState();
@@ -68,7 +74,7 @@ export function WorkbenchLayout({
       {rows >= 8 ? <WorkbenchStatusBar columns={columns} /> : null}
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
         {showExplorer ? <ProjectExplorer focused={focusedPane === "explorer"} width={explorerWidth} /> : null}
-        <ActiveWorkSurface focused={focusedPane === "surface"} transcript={transcript} pendingApproval={pendingApproval} />
+        <ActiveWorkSurface focused={focusedPane === "surface"} transcript={transcript} pendingApproval={pendingApproval} scrollRef={scrollRef} />
         {showAgents ? <AgentsRail focused={focusedPane === "agents"} width={agentsWidth} /> : null}
       </Box>
       {overlay ? (
@@ -95,9 +101,15 @@ export function WorkbenchLayout({
         </Box>
       ) : null}
       {modal ? (
-        <Box position="absolute" left={0} right={0} bottom={0} flexDirection="column" opaque borderTop borderColor="gray" paddingX={1}>
-          {modal}
-        </Box>
+        <ModalContext value={{
+          rows: Math.max(0, rows - 4),
+          columns: Math.max(0, columns - 2),
+          scrollRef: modalScrollRef ?? null,
+        }}>
+          <Box position="absolute" left={0} right={0} bottom={0} flexDirection="column" opaque borderTop borderColor="gray" paddingX={1}>
+            {modal}
+          </Box>
+        </ModalContext>
       ) : null}
       {workbench.pendingBlockedOverlay ? (
         <Box position="absolute" left={0} right={0} top={1} flexDirection="column" opaque borderColor="warning" borderBottom paddingX={1}>

--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -1,7 +1,8 @@
 // @ts-nocheck
-import React from "react";
+import React, { type RefObject } from "react";
 
 import { Box } from "../../ink.js";
+import type { ScrollBoxHandle } from "../../ink/components/ScrollBox.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import type { PendingRequest } from "../../permission-requests.js";
@@ -20,6 +21,7 @@ export type WorkbenchSurfaceRenderProps = {
   readonly focused: boolean;
   readonly transcript: React.ReactNode;
   readonly pendingApproval?: PendingRequest | null;
+  readonly scrollRef?: RefObject<ScrollBoxHandle | null>;
 };
 
 export type WorkbenchSurfaceDescriptor = {
@@ -37,7 +39,7 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
     title: () => "TRANSCRIPT",
     keybindings: ["q"],
     footerHints: "Surface: ctrl+w h explorer  ctrl+w j composer  ctrl+w d diff",
-    renderBody: ({ transcript }) => <TranscriptSurface>{transcript}</TranscriptSurface>,
+    renderBody: ({ transcript, scrollRef }) => <TranscriptSurface scrollRef={scrollRef}>{transcript}</TranscriptSurface>,
   },
   {
     mode: "preview",
@@ -102,10 +104,12 @@ export function ActiveWorkSurface({
   focused,
   transcript,
   pendingApproval,
+  scrollRef,
 }: {
   readonly focused: boolean;
   readonly transcript: React.ReactNode;
   readonly pendingApproval?: PendingRequest | null;
+  readonly scrollRef?: RefObject<ScrollBoxHandle | null>;
 }): React.ReactElement {
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
@@ -120,7 +124,7 @@ export function ActiveWorkSurface({
 
   return (
     <Box flexDirection="column" flexGrow={1} height="100%" overflow="hidden" paddingX={1}>
-      {descriptor.renderBody({ focused, transcript, pendingApproval })}
+      {descriptor.renderBody({ focused, transcript, pendingApproval, scrollRef })}
     </Box>
   );
 }

--- a/runtime/src/tui/workbench/surfaces/TranscriptSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TranscriptSurface.tsx
@@ -1,21 +1,32 @@
 // @ts-nocheck
-import React from "react";
+import React, { type RefObject } from "react";
 
 import { Box, Text } from "../../ink.js";
+import ScrollBox, { type ScrollBoxHandle } from "../../ink/components/ScrollBox.js";
 
 export function TranscriptSurface({
   children,
+  scrollRef,
 }: {
   readonly children: React.ReactNode;
+  readonly scrollRef?: RefObject<ScrollBoxHandle | null>;
 }): React.ReactElement {
+  const body = scrollRef ? (
+    <ScrollBox ref={scrollRef} flexGrow={1} flexDirection="column" width="100%" stickyScroll={true}>
+      {children}
+    </ScrollBox>
+  ) : (
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      {children}
+    </Box>
+  );
+
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
       <Box height={1} flexShrink={0}>
         <Text color="text2">TRANSCRIPT</Text>
       </Box>
-      <Box flexDirection="column" flexGrow={1} overflow="hidden">
-        {children}
-      </Box>
+      {body}
     </Box>
   );
 }

--- a/runtime/src/tui/workbench/transcriptScroll.ts
+++ b/runtime/src/tui/workbench/transcriptScroll.ts
@@ -1,0 +1,19 @@
+import type { ActiveSurfaceMode } from "./types.js";
+
+export type TranscriptScrollKeybindingOptions = {
+  readonly fullscreen: boolean;
+  readonly workbenchEnabled: boolean;
+  readonly permissionRequestCount: number;
+  readonly modalVisible: boolean;
+  readonly activeSurfaceMode: ActiveSurfaceMode;
+};
+
+export function shouldEnableTranscriptScrollKeybindings(
+  options: TranscriptScrollKeybindingOptions,
+): boolean {
+  if (!options.fullscreen) return false;
+  if (options.permissionRequestCount > 0) return false;
+  if (!options.workbenchEnabled) return true;
+  if (options.modalVisible) return true;
+  return options.activeSurfaceMode === "transcript";
+}

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1883,6 +1883,84 @@ describe("main() smoke", () => {
     }
   });
 
+  it("bootTUIEntry publishes deferred local transcript events before daemon startup", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-tui-local-emit-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-tui-local-emit-cwd-"));
+    const prevArgv = process.argv;
+    const prevEnv = { ...process.env };
+
+    process.argv = ["node", "agenc", "--provider", "grok", "--model", "grok-4.3"];
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.XAI_API_KEY = "stub-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+    const daemon = installDaemonCliDepsForTest({
+      agentId: "agent_tui_local_emit",
+      sessionId: "session_tui_local_emit",
+      cwd: tmpCwd,
+    });
+
+    let resolveExit: (() => void) | null = null;
+    const waitUntilExit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExit = resolve;
+        }),
+    );
+    const unmount = vi.fn();
+    let capturedSession: {
+      emit?: (event: unknown) => void;
+      subscribeToEvents?: (cb: (event: unknown) => void) => () => void;
+    } | null = null;
+    vi.doMock("../tui/main.js", () => ({
+      bootTUI: vi.fn(async (opts: { session: typeof capturedSession }) => {
+        capturedSession = opts.session as typeof capturedSession;
+        return { unmount, waitUntilExit };
+      }),
+    }));
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      const pending = bootTUIEntry({});
+      const session = await waitForValue(
+        "deferred TUI session",
+        () => capturedSession,
+      );
+      const localEvents: unknown[] = [];
+      const unsubscribe = session.subscribeToEvents?.((event) => {
+        localEvents.push(event);
+      });
+      const event = {
+        id: "local-bash-output",
+        msg: {
+          type: "user_message",
+          payload: {
+            message: "<bash-stdout>WBANCHOR-001</bash-stdout>",
+            displayText: "<bash-stdout>WBANCHOR-001</bash-stdout>",
+          },
+        },
+      };
+
+      session.emit?.(event);
+      unsubscribe?.();
+
+      resolveExit?.();
+      const code = await pending;
+      expect(code).toBe(0);
+      expect(daemon.startPromptAgent).not.toHaveBeenCalled();
+      expect(localEvents).toEqual([event]);
+    } finally {
+      vi.doUnmock("../tui/main.js");
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      process.argv = prevArgv;
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
   it.each(["/help", "/permissions"])(
     "bootTUIEntry does not send first %s input as a daemon prompt",
     async (slashInput) => {

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -29,6 +29,10 @@ let mockHasConsoleBillingAccess = false;
 let mockWorktreeSession: unknown = null;
 let mockGlobalConfig: Record<string, unknown> = {};
 const mockTuiCommandList = vi.hoisted(() => [] as Array<Record<string, any>>);
+const fullscreenProbe = vi.hoisted(() => ({
+  fullscreen: false,
+  mouseTracking: false,
+}));
 const apiKeyVerificationProbe = vi.hoisted(() => ({
   reverify: vi.fn(async () => {}),
   status: "valid" as "loading" | "valid" | "invalid" | "missing" | "error",
@@ -49,6 +53,8 @@ const providerProbe = {
   messageSelectorProps: [] as Array<Record<string, unknown>>,
   mcpConnectivityProps: [] as Array<Record<string, unknown>>,
   fullscreenLayoutProps: [] as Array<Record<string, React.ReactNode>>,
+  scrollKeybindingProps: [] as Array<Record<string, unknown>>,
+  workbenchLayoutProps: [] as Array<Record<string, React.ReactNode>>,
   spinnerProps: [] as Array<Record<string, unknown>>,
   promptSubmits: [] as Array<(input: string, helpers: {
     clearBuffer(): void;
@@ -259,9 +265,9 @@ vi.mock("../../utils/envUtils.js", () => ({
 }));
 
 vi.mock("../../utils/fullscreen.js", () => ({
-  isFullscreenEnvEnabled: () => false,
+  isFullscreenEnvEnabled: () => fullscreenProbe.fullscreen,
   isMouseClicksDisabled: () => true,
-  isMouseTrackingEnabled: () => false,
+  isMouseTrackingEnabled: () => fullscreenProbe.mouseTracking,
 }));
 
 vi.mock("../../utils/log.js", () => ({
@@ -478,6 +484,38 @@ vi.mock("./FullscreenLayout.js", async () => {
   };
 });
 
+vi.mock("./ScrollKeybindingHandler.js", async () => {
+  const React = await import("react");
+  return {
+    ScrollKeybindingHandler: (props: Record<string, unknown>) => {
+      providerProbe.scrollKeybindingProps.push(props);
+      return React.createElement(React.Fragment, null);
+    },
+  };
+});
+
+vi.mock("../workbench/WorkbenchLayout.js", async () => {
+  const React = await import("react");
+  return {
+    WorkbenchLayout: (props: {
+      transcript?: React.ReactNode;
+      composer?: React.ReactNode;
+      overlay?: React.ReactNode;
+      modal?: React.ReactNode;
+    } & Record<string, unknown>) => {
+      providerProbe.workbenchLayoutProps.push(props);
+      return React.createElement(
+        React.Fragment,
+        null,
+        props.transcript,
+        props.composer,
+        props.overlay,
+        props.modal,
+      );
+    },
+  };
+});
+
 vi.mock("./dialogs/CostThresholdDialog.js", async () => {
   const React = await import("react");
   return {
@@ -621,6 +659,8 @@ function resetShellSurfaceProbe(): void {
   providerProbe.messageProps.length = 0;
   providerProbe.mcpConnectivityProps.length = 0;
   providerProbe.fullscreenLayoutProps.length = 0;
+  providerProbe.scrollKeybindingProps.length = 0;
+  providerProbe.workbenchLayoutProps.length = 0;
   providerProbe.spinnerProps.length = 0;
   providerProbe.promptProps.length = 0;
   providerProbe.promptSubmits.length = 0;
@@ -634,6 +674,9 @@ function resetShellSurfaceProbe(): void {
   mockHasConsoleBillingAccess = false;
   mockWorktreeSession = null;
   mockGlobalConfig = {};
+  fullscreenProbe.fullscreen = false;
+  fullscreenProbe.mouseTracking = false;
+  delete process.env.AGENC_TUI_WORKBENCH;
 }
 
 function containsElementNamed(node: React.ReactNode, name: string): boolean {
@@ -846,7 +889,10 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
   });
 
   test("gates prompt input when another TUI surface owns input", async () => {
-    const { shouldShowPromptInputState } = await import("./App.js");
+    const {
+      shouldEnableTranscriptScrollKeybindings,
+      shouldShowPromptInputState,
+    } = await import("./App.js");
 
     expect(
       shouldShowPromptInputState({
@@ -897,6 +943,49 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         toolShouldHidePromptInput: true,
       }),
     ).toBe(false);
+
+    expect(shouldEnableTranscriptScrollKeybindings({
+      fullscreen: false,
+      workbenchEnabled: false,
+      permissionRequestCount: 0,
+      modalVisible: false,
+      activeSurfaceMode: "transcript",
+    })).toBe(false);
+    expect(shouldEnableTranscriptScrollKeybindings({
+      fullscreen: true,
+      workbenchEnabled: false,
+      permissionRequestCount: 0,
+      modalVisible: false,
+      activeSurfaceMode: "preview",
+    })).toBe(true);
+    expect(shouldEnableTranscriptScrollKeybindings({
+      fullscreen: true,
+      workbenchEnabled: true,
+      permissionRequestCount: 1,
+      modalVisible: false,
+      activeSurfaceMode: "transcript",
+    })).toBe(false);
+    expect(shouldEnableTranscriptScrollKeybindings({
+      fullscreen: true,
+      workbenchEnabled: true,
+      permissionRequestCount: 0,
+      modalVisible: true,
+      activeSurfaceMode: "preview",
+    })).toBe(true);
+    expect(shouldEnableTranscriptScrollKeybindings({
+      fullscreen: true,
+      workbenchEnabled: true,
+      permissionRequestCount: 0,
+      modalVisible: false,
+      activeSurfaceMode: "preview",
+    })).toBe(false);
+    expect(shouldEnableTranscriptScrollKeybindings({
+      fullscreen: true,
+      workbenchEnabled: true,
+      permissionRequestCount: 0,
+      modalVisible: false,
+      activeSurfaceMode: "transcript",
+    })).toBe(true);
   });
 
   test("parses MCP primitive field edge cases", async () => {
@@ -1095,6 +1184,41 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         setVimMode: expect.any(Function),
       }),
     );
+  });
+
+  test("connects fullscreen workbench transcript to the scroll owner", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    resetShellSurfaceProbe();
+    fullscreenProbe.fullscreen = true;
+    process.env.AGENC_TUI_WORKBENCH = "1";
+
+    await renderApp(
+      <AgenCTuiApp
+        session={createSession()}
+        configStore={{}}
+        isInteractive={false}
+      />,
+    );
+
+    const messageScrollRef = providerProbe.messageProps.at(-1)?.scrollRef;
+    const workbenchProps = providerProbe.workbenchLayoutProps.at(-1);
+    const scrollProps = providerProbe.scrollKeybindingProps.at(-1);
+
+    expect(messageScrollRef).toBeDefined();
+    expect(workbenchProps).toEqual(
+      expect.objectContaining({
+        scrollRef: messageScrollRef,
+        modalScrollRef: expect.any(Object),
+      }),
+    );
+    expect(scrollProps).toEqual(
+      expect.objectContaining({
+        scrollRef: messageScrollRef,
+        isActive: true,
+        isModal: false,
+      }),
+    );
+    expect(providerProbe.fullscreenLayoutProps).toHaveLength(0);
   });
 
   test("passes API key verification status into PromptInput and verifies on startup", async () => {

--- a/runtime/tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts
@@ -600,11 +600,15 @@ describe("session transcript coverage swarm row 003", () => {
 
       eventLogCallback?.(evt("log-event", "user_message", { message: "from log" }));
       phaseCallback?.({ type: "context_compacted" });
+      phaseCallback?.(evt("phase-msg-event", "user_message", {
+        message: "from msg envelope",
+      }));
       phaseCallback?.(null);
       await flushEffects();
 
       expect(JSON.stringify(harness.latest().messages)).toContain("from log");
       expect(JSON.stringify(harness.latest().messages)).toContain("Context compacted");
+      expect(JSON.stringify(harness.latest().messages)).toContain("from msg envelope");
 
       await harness.render(propertySession);
 

--- a/runtime/tests/tui/workbench/active-work-surface.test.tsx
+++ b/runtime/tests/tui/workbench/active-work-surface.test.tsx
@@ -58,8 +58,8 @@ vi.mock("../../../src/tui/workbench/surfaces/TestSurface.js", () => ({
 }));
 
 vi.mock("../../../src/tui/workbench/surfaces/TranscriptSurface.js", () => ({
-  TranscriptSurface: ({ children }: { readonly children: React.ReactNode }) => {
-    activeSurfaceHarness.renderCalls.push({ name: "transcript", props: {} });
+  TranscriptSurface: ({ children, scrollRef }: { readonly children: React.ReactNode; readonly scrollRef?: unknown }) => {
+    activeSurfaceHarness.renderCalls.push({ name: "transcript", props: { scrollRef } });
     return React.createElement(React.Fragment, null, children);
   },
 }));
@@ -105,12 +105,18 @@ describe("ActiveWorkSurface", () => {
           focused={true}
           transcript={<Text>transcript body</Text>}
           pendingApproval={pendingApproval as never}
+          scrollRef={{ current: null }}
         />
       </AppStateProvider>,
       100,
     );
 
     expect(activeSurfaceHarness.renderCalls.at(-1)?.name).toBe(mode);
+    if (mode === "transcript") {
+      expect(activeSurfaceHarness.renderCalls.at(-1)?.props).toEqual({
+        scrollRef: { current: null },
+      });
+    }
     if (mode !== "transcript") {
       expect(activeSurfaceHarness.renderCalls.at(-1)?.props).toMatchObject({
         focused: true,

--- a/runtime/tests/tui/workbench/transcript-scroll.test.tsx
+++ b/runtime/tests/tui/workbench/transcript-scroll.test.tsx
@@ -1,0 +1,280 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { Text } from "../../../src/tui/ink.js";
+import type { DOMElement } from "../../../src/tui/ink/dom.js";
+import instances from "../../../src/tui/ink/instances.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+import type { ScrollBoxHandle } from "../../../src/tui/ink/components/ScrollBox.js";
+import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { useModalOrTerminalSize, useModalScrollRef } from "../../../src/tui/context/modalContext.js";
+import { TranscriptSurface } from "../../../src/tui/workbench/surfaces/TranscriptSurface.js";
+import { WorkbenchLayout } from "../../../src/tui/workbench/WorkbenchLayout.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createTestStreams(columns = 120, rows = 30): {
+  output: () => string;
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  let rendered = "";
+  const stdout = new PassThrough();
+  stdout.on("data", (chunk) => {
+    rendered += chunk.toString();
+  });
+  (stdout as unknown as { columns: number }).columns = columns;
+  (stdout as unknown as { rows: number }).rows = rows;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  const stdin = new PassThrough() as TestStdin;
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+
+  return { output: () => rendered, stdin, stdout };
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+  if (!instance?.rootNode) throw new Error("Ink root node not found");
+  return instance.rootNode;
+}
+
+function findScrollBox(node: DOMElement): DOMElement | null {
+  if (
+    node.nodeName === "ink-box" &&
+    node.style.overflowX === "scroll" &&
+    node.style.overflowY === "scroll"
+  ) {
+    return node;
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === "#text") continue;
+    const found = findScrollBox(child);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+function ModalProbe({
+  expectedRef,
+}: {
+  readonly expectedRef: React.RefObject<ScrollBoxHandle | null>;
+}): React.ReactElement {
+  const size = useModalOrTerminalSize({ rows: -1, columns: -1 });
+  const modalRef = useModalScrollRef();
+
+  return (
+    <Text>
+      modal-size-{size.rows}x{size.columns}-ref-{modalRef === expectedRef ? "ok" : "missing"}
+    </Text>
+  );
+}
+
+describe("workbench transcript scroll ownership", () => {
+  test("TranscriptSurface owns a sticky ScrollBox when given a scroll ref", async () => {
+    const scrollRef = React.createRef<ScrollBoxHandle>();
+    const { output, stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    let mounted = true;
+
+    try {
+      root.render(
+        <TranscriptSurface scrollRef={scrollRef}>
+          <Text>transcript-scroll-anchor</Text>
+        </TranscriptSurface>,
+      );
+
+      await waitForCondition(
+        () => scrollRef.current !== null && findScrollBox(getRootNode(stdout)) !== null,
+        "TranscriptSurface did not attach its ScrollBox",
+      );
+
+      const scrollBox = findScrollBox(getRootNode(stdout));
+      expect(scrollRef.current).not.toBeNull();
+      expect(scrollBox).not.toBeNull();
+      expect(scrollBox?.style.flexGrow).toBe(1);
+      expect(scrollBox?.style.flexDirection).toBe("column");
+      expect(scrollBox?.attributes.stickyScroll).toBe(true);
+      expect(output()).toContain("TRANSCRIPT");
+      expect(output()).toContain("transcript-scroll-anchor");
+
+      root.unmount();
+      mounted = false;
+      await sleep();
+      expect(scrollRef.current).toBeNull();
+    } finally {
+      if (mounted) root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("TranscriptSurface keeps a bounded fallback viewport without a scroll ref", async () => {
+    const { output, stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <TranscriptSurface>
+          <Text>transcript-fallback-anchor</Text>
+        </TranscriptSurface>,
+      );
+
+      await waitForCondition(
+        () => output().includes("transcript-fallback-anchor"),
+        "TranscriptSurface fallback body did not render",
+      );
+
+      expect(findScrollBox(getRootNode(stdout))).toBeNull();
+      expect(output()).toContain("TRANSCRIPT");
+      expect(output()).toContain("transcript-fallback-anchor");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("WorkbenchLayout wires its transcript scroll ref into the active surface", async () => {
+    const scrollRef = React.createRef<ScrollBoxHandle>();
+    const { output, stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    let mounted = true;
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              agentsVisible: false,
+              explorerVisible: false,
+              activeSurfaceMode: "transcript",
+            },
+          }}
+        >
+          <WorkbenchLayout
+            transcript={<Text>workbench-scroll-anchor</Text>}
+            composer={<Text>composer-anchor</Text>}
+            scrollRef={scrollRef}
+          />
+        </AppStateProvider>,
+      );
+
+      await waitForCondition(
+        () => scrollRef.current !== null && findScrollBox(getRootNode(stdout)) !== null,
+        "WorkbenchLayout did not attach the transcript ScrollBox",
+      );
+
+      expect(scrollRef.current).not.toBeNull();
+      expect(output()).toContain("TRANSCRIPT");
+      expect(output()).toContain("workbench-scroll-anchor");
+      expect(output()).toContain("composer-anchor");
+
+      root.unmount();
+      mounted = false;
+      await sleep();
+      expect(scrollRef.current).toBeNull();
+    } finally {
+      if (mounted) root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("WorkbenchLayout gives modal content the modal scroll owner and bounded size", async () => {
+    const scrollRef = React.createRef<ScrollBoxHandle>();
+    const modalScrollRef = React.createRef<ScrollBoxHandle>();
+    const { output, stdin, stdout } = createTestStreams(100, 12);
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              agentsVisible: false,
+              explorerVisible: false,
+              activeSurfaceMode: "transcript",
+            },
+          }}
+        >
+          <WorkbenchLayout
+            transcript={<Text>modal-transcript-anchor</Text>}
+            composer={<Text>modal-composer-anchor</Text>}
+            modal={<ModalProbe expectedRef={modalScrollRef} />}
+            modalScrollRef={modalScrollRef}
+            scrollRef={scrollRef}
+          />
+        </AppStateProvider>,
+      );
+
+      await waitForCondition(
+        () => output().includes("modal-size-8x98-ref-ok"),
+        "WorkbenchLayout modal context did not reach modal content",
+      );
+
+      expect(output()).toContain("modal-transcript-anchor");
+      expect(output()).toContain("modal-composer-anchor");
+      expect(output()).toContain("modal-size-8x98-ref-ok");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Wire the workbench transcript surface to the same ScrollBox owner used by fullscreen mode.
- Enable transcript scroll keybindings in workbench transcript mode and preserve modal scroll ownership.
- Persist local bash transcript events into the subscribed transcript stream before/after daemon attachment.
- Add deterministic PTY coverage for long workbench transcript output, scroll up/down anchors, row bounds, and multiple terminal sizes.

## Test plan
- npm run typecheck
- npm run check:unused:production --workspace=@tetsuo-ai/runtime
- npm exec --workspace=@tetsuo-ai/runtime -- vitest run tests/tui/workbench/transcript-scroll.test.tsx tests/tui/workbench/active-work-surface.test.tsx tests/tui/components/App.render.test.tsx --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/tui/workbench/transcriptScroll.ts' --coverage.include='src/tui/workbench/surfaces/TranscriptSurface.tsx' --coverage.exclude='src/**/*.d.ts'
- npm run check:tui-workbench-visual-smoke --workspace=@tetsuo-ai/runtime
- npm run check:tui-workbench-transcript-scroll --workspace=@tetsuo-ai/runtime
- npm run build
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-workbench-transcript