### PR TITLE
fix(tui): restore neovim buffer escape and color

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -80,8 +80,9 @@ Required behavior:
 
 - discover usable `nvim`
 - reject unsupported or missing `nvim` with a clear fallback reason
-- spawn `nvim --embed --clean` by default unless config explicitly opts into a
-  user init
+- prefer `nvim --embed` with user init by default so normal Neovim behavior is
+  available; allow config to force `nvim --embed --clean -n` for hermetic mode
+  and fall back to clean mode when default user-init startup fails
 - implement msgpack-RPC request/response/notification handling
 - attach as a Neovim UI with a bounded grid matching the BUFFER pane
 - maintain grid cells, highlights, cursor, mode, command line, popup menu, and

--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -12,7 +12,12 @@ supervision, pane rendering, file safety, and lifecycle cleanup.
 - `AGENC_BUFFER_PROVIDER=external` selects the explicit external-editor handoff provider.
 - `AGENC_BUFFER_NVIM=/path/to/nvim` overrides executable discovery.
 - `AGENC_BUFFER_NVIM_TIMEOUT_MS=1200` controls the discovery probe timeout.
-- `AGENC_BUFFER_NVIM_USE_INIT=1` allows user init loading. The default is clean embedded mode: `nvim --embed --clean -n`.
+- By default, embedded BUFFER prefers user init loading so your normal Neovim
+  configuration, plugins, and syntax behavior are available.
+- `AGENC_BUFFER_NVIM_USE_INIT=0` disables user init loading and starts clean
+  embedded mode: `nvim --embed --clean -n`.
+- When the default user-init probe fails, AgenC falls back to clean embedded
+  mode so BUFFER remains usable and reports the selected provider in the header.
 
 Inline mode is a basic fallback. It keeps file editing available when embedded
 Neovim cannot start, and it does not claim exact Vim behavior. External editor

--- a/parity/embedded-neovim-buffer.json
+++ b/parity/embedded-neovim-buffer.json
@@ -3,16 +3,16 @@
   "scope": "Embedded Neovim BUFFER implementation from TODO.md",
   "generatedAt": "2026-05-25T06:09:59.650Z",
   "sourceRoot": "..",
-  "sourceSnapshotHash": "bf4cd31b229feebfe4d592926e391e0f10ff5aa95294d96b0708d33ecd8b456f",
+  "sourceSnapshotHash": "f0380bab91ebba576750a06caee5eee189680c7a0d82e357cf930b0917914e1f",
   "targetRoot": "..",
   "sourceFiles": [
     {
       "path": "TODO.md",
-      "sha256": "932a77d5811f7d44452e97e31bfae3bbd6b2da1e128fc660b5208ff62eaa527e"
+      "sha256": "98914df3601009bd29409e571df73cfc9465e9bb40dd964321f2a269f5b2c4ca"
     },
     {
       "path": "runtime/src/tui/workbench/surfaces/BufferSurface.tsx",
-      "sha256": "563aec769d187f1ae4ba133ca7ddeb99c942db79c17ea9e4f96ef3209e9ae8fd"
+      "sha256": "99fbe56a7848335743ce6b3d5bd06567975feef0e8542ecc8a445ee2eb629aae"
     },
     {
       "path": "runtime/src/tui/workbench/buffer/BufferStore.ts",
@@ -153,14 +153,15 @@
         "executes the candidate with a bounded version probe and parses the reported version",
         "accepts only binaries that support embedded mode",
         "returns structured fallback reasons for missing executables, failed probes, timeouts, and unsupported versions",
-        "builds default spawn arguments with embedded clean mode unless configuration permits user init loading"
+        "prefers user init loading for default embedded spawn arguments and falls back to embedded clean mode when default startup fails"
       ],
       "edgeCases": [
         "an empty configured executable is treated as absent and PATH discovery is still attempted",
         "a probe that exits nonzero records stderr in the fallback reason without throwing",
         "a probe that hangs past the timeout kills the probe process and returns a timeout result",
         "a version line with extra suffix text still parses the numeric major minor patch values",
-        "user init loading is disabled by default and enabled only by explicit configuration"
+        "clean embedded mode is selected when configuration disables user init loading",
+        "default user init loading falls back to clean embedded mode when the initial embedded startup probe fails"
       ],
       "tests": [
         "runtime/tests/tui/workbench/buffer-neovim-discovery.contract.test.ts"
@@ -251,7 +252,7 @@
       "requiredBehaviors": [
         "translates printable input, named keys, escape, control keys, alt keys, shift modified keys, paste, mouse, focus, and resize into Neovim input or UI calls",
         "routes editor-owned keys to the active provider before workbench or composer keybindings handle them",
-        "keeps global escape and surface switching behavior explicit and conflict free",
+        "keeps global escape, BUFFER escape hatches, and surface switching behavior explicit and conflict free",
         "routes mouse wheel and clicks only to the pane under the pointer",
         "sends resize events to Neovim when the BUFFER pane dimensions change",
         "delegates colon command input such as :wq to embedded Neovim instead of parsing it through the inline Vim command layer"
@@ -263,7 +264,8 @@
         "mouse wheel over BUFFER does not scroll the workspace explorer",
         "mouse wheel events without parseable pointer coordinates do not get captured by BUFFER",
         "click outside the BUFFER pane does not call provider click and can be handled by the pane under the pointer",
-        "workbench surface-switching chords while BUFFER is focused do not move workbench focus away from the editor",
+        "Workbench surface-switching chords while BUFFER is focused do not move workbench focus away from the editor",
+        "BUFFER escape-hatch chords while embedded Neovim owns keys can return focus to composer, explorer, or agents",
         "embedded command input for :wq forwards colon, letters, and enter to Neovim exactly as editor input",
         "resize to one row and one column sends a valid Neovim resize request"
       ],
@@ -291,7 +293,7 @@
       "runtime/scripts/check-tui-e2e/scenarios/122-workbench-buffer-neovim-kill-cleanup.mjs"
     ],
       "requiredBehaviors": [
-        "opens a file in supervised embedded Neovim and attaches UI before accepting input",
+        "opens a file in supervised embedded Neovim, configures embedded editing defaults, and attaches UI before accepting input",
         "implements save, force save, quit, force quit, dirty close prevention, surface switch cleanup, app exit cleanup, and crash cleanup",
         "tracks dirty state from Neovim buffer options and write events",
         "prevents orphaned Neovim child processes after normal close, parent exit, and test failure",
@@ -301,6 +303,7 @@
         "dirty quit returns a refusal status while keeping the provider alive",
         "force quit discards edits and resolves cleanup after Neovim exits",
         "process exit before UI attach rejects open and clears pending requests",
+      "embedded startup enables true-color, syntax, and filetype behavior before dirty tracking begins",
       "double close waits on one cleanup path and does not send duplicate quit commands",
       "startup failure after spawn but before UI attach completes kills the spawned child process",
       "dirty surface switch is refused before BUFFER unmount cleanup can discard embedded Neovim edits",
@@ -409,13 +412,14 @@
       "requiredBehaviors": [
         "renders provider snapshots inside the bounded BUFFER pane only",
         "keeps explorer, agents rail, transcript, editor, and composer render regions visually isolated",
-        "renders cursor, mode, command line, status, errors, fallback reason, and provider identity truthfully",
+        "renders cursor, mode, command line, status, errors, fallback reason, provider identity, and Neovim cell highlights truthfully",
         "handles narrow and short terminals without overlapping adjacent panes",
         "does not rely on inline document state when the embedded Neovim provider is active"
       ],
       "edgeCases": [
         "a long Neovim line is clipped to the pane width without extending into the agents rail",
         "a command line longer than the pane width truncates inside the BUFFER footer",
+        "a Neovim line with highlight attributes renders cell foreground, background, and emphasis styles instead of dropping color",
         "a one column pane renders without throwing and without negative widths",
         "an inactive BUFFER pane shows provider status without stealing composer focus",
         "long provider fallback, status, and error text truncates inside the BUFFER pane",
@@ -599,7 +603,7 @@
       "edgeCases": [
         "documentation states missing executable behavior without suggesting exact Vim behavior in inline mode",
         "documentation states unsupported version behavior with the user-facing fallback message",
-        "documentation states how to opt into user init loading without changing the default clean mode",
+        "documentation states how to disable user init loading while preserving the default user config preference",
         "documentation states process cleanup behavior after a TUI crash",
         "documentation lists the contract checker and PTY validation commands"
       ],

--- a/parity/embedded-neovim-buffer.reviews/buffer-lifecycle.json
+++ b/parity/embedded-neovim-buffer.reviews/buffer-lifecycle.json
@@ -6,7 +6,7 @@
   "verdict": "APPROVED",
   "behaviorCoverage": {
     "behaviorsAudited": [
-      "opens a file in supervised embedded Neovim and attaches UI before accepting input",
+      "opens a file in supervised embedded Neovim, configures embedded editing defaults, and attaches UI before accepting input",
       "implements save, force save, quit, force quit, dirty close prevention, surface switch cleanup, app exit cleanup, and crash cleanup",
       "tracks dirty state from Neovim buffer options and write events",
       "prevents orphaned Neovim child processes after normal close, parent exit, and test failure",
@@ -19,6 +19,7 @@
       "dirty quit returns a refusal status while keeping the provider alive",
       "force quit discards edits and resolves cleanup after Neovim exits",
       "process exit before UI attach rejects open and clears pending requests",
+      "embedded startup enables true-color, syntax, and filetype behavior before dirty tracking begins",
       "double close waits on one cleanup path and does not send duplicate quit commands",
       "startup failure after spawn but before UI attach completes kills the spawned child process",
       "dirty surface switch is refused before BUFFER unmount cleanup can discard embedded Neovim edits",

--- a/parity/embedded-neovim-buffer.reviews/docs-config.json
+++ b/parity/embedded-neovim-buffer.reviews/docs-config.json
@@ -18,7 +18,7 @@
     "edgeCasesAudited": [
       "documentation states missing executable behavior without suggesting exact Vim behavior in inline mode",
       "documentation states unsupported version behavior with the user-facing fallback message",
-      "documentation states how to opt into user init loading without changing the default clean mode",
+      "documentation states how to disable user init loading while preserving the default user config preference",
       "documentation states process cleanup behavior after a TUI crash",
       "documentation lists the contract checker and PTY validation commands"
     ],

--- a/parity/embedded-neovim-buffer.reviews/input-routing.json
+++ b/parity/embedded-neovim-buffer.reviews/input-routing.json
@@ -8,7 +8,7 @@
     "behaviorsAudited": [
       "translates printable input, named keys, escape, control keys, alt keys, shift modified keys, paste, mouse, focus, and resize into Neovim input or UI calls",
       "routes editor-owned keys to the active provider before workbench or composer keybindings handle them",
-      "keeps global escape and surface switching behavior explicit and conflict free",
+      "keeps global escape, BUFFER escape hatches, and surface switching behavior explicit and conflict free",
       "routes mouse wheel and clicks only to the pane under the pointer",
       "sends resize events to Neovim when the BUFFER pane dimensions change",
       "delegates colon command input such as :wq to embedded Neovim instead of parsing it through the inline Vim command layer"
@@ -23,7 +23,8 @@
       "mouse wheel over BUFFER does not scroll the workspace explorer",
       "mouse wheel events without parseable pointer coordinates do not get captured by BUFFER",
       "click outside the BUFFER pane does not call provider click and can be handled by the pane under the pointer",
-      "workbench surface-switching chords while BUFFER is focused do not move workbench focus away from the editor",
+      "Workbench surface-switching chords while BUFFER is focused do not move workbench focus away from the editor",
+      "BUFFER escape-hatch chords while embedded Neovim owns keys can return focus to composer, explorer, or agents",
       "embedded command input for :wq forwards colon, letters, and enter to Neovim exactly as editor input",
       "resize to one row and one column sends a valid Neovim resize request"
     ],

--- a/parity/embedded-neovim-buffer.reviews/neovim-discovery.json
+++ b/parity/embedded-neovim-buffer.reviews/neovim-discovery.json
@@ -10,7 +10,7 @@
       "executes the candidate with a bounded version probe and parses the reported version",
       "accepts only binaries that support embedded mode",
       "returns structured fallback reasons for missing executables, failed probes, timeouts, and unsupported versions",
-      "builds default spawn arguments with embedded clean mode unless configuration permits user init loading"
+      "prefers user init loading for default embedded spawn arguments and falls back to embedded clean mode when default startup fails"
     ],
     "missingBehaviors": []
   },
@@ -20,7 +20,8 @@
       "a probe that exits nonzero records stderr in the fallback reason without throwing",
       "a probe that hangs past the timeout kills the probe process and returns a timeout result",
       "a version line with extra suffix text still parses the numeric major minor patch values",
-      "user init loading is disabled by default and enabled only by explicit configuration"
+      "clean embedded mode is selected when configuration disables user init loading",
+      "default user init loading falls back to clean embedded mode when the initial embedded startup probe fails"
     ],
     "missingEdgeCases": []
   },

--- a/parity/embedded-neovim-buffer.reviews/workbench-rendering.json
+++ b/parity/embedded-neovim-buffer.reviews/workbench-rendering.json
@@ -8,7 +8,7 @@
     "behaviorsAudited": [
       "renders provider snapshots inside the bounded BUFFER pane only",
       "keeps explorer, agents rail, transcript, editor, and composer render regions visually isolated",
-      "renders cursor, mode, command line, status, errors, fallback reason, and provider identity truthfully",
+      "renders cursor, mode, command line, status, errors, fallback reason, provider identity, and Neovim cell highlights truthfully",
       "handles narrow and short terminals without overlapping adjacent panes",
       "does not rely on inline document state when the embedded Neovim provider is active"
     ],
@@ -18,6 +18,7 @@
     "edgeCasesAudited": [
       "a long Neovim line is clipped to the pane width without extending into the agents rail",
       "a command line longer than the pane width truncates inside the BUFFER footer",
+      "a Neovim line with highlight attributes renders cell foreground, background, and emphasis styles instead of dropping color",
       "a one column pane renders without throwing and without negative widths",
       "an inactive BUFFER pane shows provider status without stealing composer focus",
       "long provider fallback, status, and error text truncates inside the BUFFER pane",

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -1,6 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
+import { renderPtyRows } from "../harness.mjs";
+
 const execFileAsync = promisify(execFile);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -16,6 +18,21 @@ export function workspaceSnapshot(text) {
     .slice(0, 12)
     .map((entry) => entry.trim())
     .join("\n");
+}
+
+export function frameText(session) {
+  return renderPtyRows(session.raw, { cols: session.cols, rows: session.rows }).join("\n");
+}
+
+export async function waitForFrameText(session, pattern, label, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let frame = "";
+  while (Date.now() < deadline) {
+    frame = frameText(session);
+    if (pattern.test(frame)) return;
+    await sleep(100);
+  }
+  throw new Error(`${label} did not render in the latest PTY frame: ${frame.slice(-1200)}`);
 }
 
 export async function listNeovimPids() {

--- a/runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs
@@ -6,6 +6,7 @@ import { renderPtyRows } from "../harness.mjs";
 import {
   listDescendantNeovimPids,
   waitForPidsGone,
+  waitForFrameText,
   waitForScreen,
   workspaceSnapshot,
 } from "../helpers/workbench-buffer-neovim.mjs";
@@ -43,6 +44,8 @@ export default async function (session) {
       timeout: 20_000,
       label: "embedded Neovim ready",
     });
+    await waitForFrameText(session, /alpha[\s\S]*beta/u, "loaded target.txt in embedded Neovim", 20_000);
+    await waitForFrameText(session, /NORMAL[\s\S]*(ready|target\.txt)|target\.txt[\s\S]*NORMAL/u, "normal Neovim file frame", 20_000);
     const neovimPids = await listDescendantNeovimPids(session.term?.pid);
     if (neovimPids.length === 0) {
       throw new Error("embedded Neovim process was not a child of the TUI");
@@ -54,6 +57,7 @@ export default async function (session) {
     await sleep(80);
     await session.type("E2E_MARK", { perCharMs: 20 });
     session.send("\x1b");
+    await waitForFrameText(session, /NORMAL/u, "normal mode after E2E_MARK insert", 10_000);
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     session.send(":");
     await sleep(80);
@@ -78,10 +82,7 @@ export default async function (session) {
       throw new Error(`Neovim undo did not remove marker before write: ${undoSaved}`);
     }
     session.send("\x1b");
-    await waitForScreen(session, /NORMAL\s+:w/i, {
-      timeout: 10_000,
-      label: "normal mode after first write",
-    });
+    await waitForFrameText(session, /NORMAL[\s\S]*(ready|written|target\.txt)|target\.txt[\s\S]*NORMAL/u, "normal mode after first write", 10_000);
 
     await session.type("gg", { perCharMs: 60 });
     await sleep(80);
@@ -96,7 +97,7 @@ export default async function (session) {
     await session.type("o", { perCharMs: 60 });
     await session.type("REGISTER_MARK", { perCharMs: 15 });
     session.send("\x1b");
-    await sleep(80);
+    await waitForFrameText(session, /NORMAL/u, "normal mode after register marker insert", 10_000);
     await session.type("\"ayy", { perCharMs: 60 });
     await sleep(120);
     await session.type("G", { perCharMs: 60 });
@@ -111,7 +112,7 @@ export default async function (session) {
     await session.type("o", { perCharMs: 60 });
     await session.type("MACRO_MARK", { perCharMs: 15 });
     session.send("\x1b");
-    await sleep(80);
+    await waitForFrameText(session, /NORMAL/u, "normal mode before stopping macro recording", 10_000);
     await session.type("q", { perCharMs: 60 });
     await sleep(80);
     await session.type("@a", { perCharMs: 60 });
@@ -128,6 +129,7 @@ export default async function (session) {
       await session.type("_AFTER", { perCharMs: 15 });
       await waitForFrameText(session, /RESIZE_MARK_AFTER/u, "resized Neovim grid");
       session.send("\x1b");
+      await waitForFrameText(session, /NORMAL/u, "normal mode after resized insert", 10_000);
       await session.waitForIdle({ idleWindow: 400, timeout: 10_000 });
       await waitForFrameText(session, /NORMAL[\s\S]*RESIZE_MARK_AFTER|RESIZE_MARK_AFTER[\s\S]*NORMAL/u, "normal mode after resized grid");
       session.send(":");
@@ -178,6 +180,7 @@ export default async function (session) {
     }
     await session.type("iCLICK_ROUTE_", { perCharMs: 15 });
     session.send("\x1b");
+    await waitForFrameText(session, /NORMAL/u, "normal mode after click-route insert", 10_000);
     await session.waitForIdle({ idleWindow: 400, timeout: 10_000 });
 
     session.send(":");
@@ -229,6 +232,7 @@ export default async function (session) {
     await sleep(80);
     await session.type("DIRTY_MARK", { perCharMs: 20 });
     session.send("\x1b");
+    await waitForFrameText(session, /NORMAL/u, "normal mode after dirty marker insert", 10_000);
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     session.send(":");
     await sleep(80);
@@ -256,21 +260,6 @@ export default async function (session) {
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
-}
-
-function frameText(session) {
-  return renderPtyRows(session.raw, { cols: session.cols, rows: session.rows }).join("\n");
-}
-
-async function waitForFrameText(session, pattern, label, timeoutMs = 10_000) {
-  const deadline = Date.now() + timeoutMs;
-  let frame = "";
-  while (Date.now() < deadline) {
-    frame = frameText(session);
-    if (pattern.test(frame)) return;
-    await sleep(100);
-  }
-  throw new Error(`${label} did not render in the latest PTY frame: ${frame.slice(-1200)}`);
 }
 
 function findFrameCell(session, text) {

--- a/runtime/scripts/check-tui-e2e/scenarios/122-workbench-buffer-neovim-kill-cleanup.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/122-workbench-buffer-neovim-kill-cleanup.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import {
   listDescendantNeovimPids,
   waitForPidsGone,
+  waitForFrameText,
   waitForScreen,
 } from "../helpers/workbench-buffer-neovim.mjs";
 
@@ -40,6 +41,7 @@ export default async function (session) {
       timeout: 20_000,
       label: "embedded Neovim ready",
     });
+    await waitForFrameText(session, /kill-cleanup/u, "loaded target.txt in embedded Neovim", 20_000);
     const neovimPids = await listDescendantNeovimPids(session.term?.pid);
     if (neovimPids.length === 0) {
       throw new Error("embedded Neovim process was not a child of the TUI before kill");
@@ -49,10 +51,7 @@ export default async function (session) {
     session.send("o");
     await sleep(80);
     await session.type("KILL_DIRTY_MARK", { perCharMs: 15 });
-    await waitForScreen(session, /KILL_DIRTY_MARK/u, {
-      timeout: 10_000,
-      label: "dirty Neovim edit before kill",
-    });
+    await waitForFrameText(session, /KILL_DIRTY_MARK/u, "dirty Neovim edit before kill", 10_000);
     session.kill();
     await waitForPidsGone(neovimPids, 8_000, "TUI-killed embedded Neovim");
     const saved = await readFile(join(cwd, "target.txt"), "utf8");

--- a/runtime/scripts/check-tui-workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-workbench-buffer-neovim.mjs
@@ -15,6 +15,7 @@ const result = spawnSync(
     env: {
       ...process.env,
       AGENC_TUI_WORKBENCH: "1",
+      AGENC_BUFFER_NVIM_USE_INIT: "0",
     },
   },
 );

--- a/runtime/src/tui/keybindings/defaultBindings.ts
+++ b/runtime/src/tui/keybindings/defaultBindings.ts
@@ -401,6 +401,10 @@ export const DEFAULT_BINDINGS: KeybindingBlock[] = [
   {
     context: 'Buffer',
     bindings: {
+      'shift+tab': 'workbench:focusComposer',
+      'ctrl+x h': 'workbench:focusExplorer',
+      'ctrl+x j': 'workbench:focusComposer',
+      'ctrl+x l': 'workbench:focusAgents',
       'ctrl+s': 'buffer:save',
       'ctrl+x y': 'buffer:redo',
       'ctrl+x r': 'buffer:revert',

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimDiscovery.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimDiscovery.ts
@@ -82,25 +82,27 @@ export async function discoverNeovim(
     };
   }
 
-  const useUserInit = config.useUserInit === true;
-  const args = buildNeovimEmbedArgs(useUserInit);
-  const embedProbe = await probeNeovimEmbed(executable, args, config.timeoutMs ?? DEFAULT_TIMEOUT_MS);
-  if (embedProbe.type === "failed") {
-    return {
-      usable: false,
-      reasonCode: "probe-failed",
-      reason: `Embedded Neovim is unavailable because ${executable} failed the embedded mode probe: ${embedProbe.message}`,
-      executable,
-      version: probe.version,
-    };
+  let failedEmbedMessage: string | null = null;
+  for (const candidate of embedArgCandidates(config.useUserInit)) {
+    const embedProbe = await probeNeovimEmbed(executable, candidate.args, config.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    if (embedProbe.type === "ok") {
+      return {
+        usable: true,
+        executable,
+        version: probe.version,
+        useUserInit: candidate.useUserInit,
+        args: candidate.args,
+      };
+    }
+    failedEmbedMessage = embedProbe.message;
   }
 
   return {
-    usable: true,
+    usable: false,
+    reasonCode: "probe-failed",
+    reason: `Embedded Neovim is unavailable because ${executable} failed the embedded mode probe: ${failedEmbedMessage ?? "embedded mode did not start"}`,
     executable,
     version: probe.version,
-    useUserInit,
-    args,
   };
 }
 
@@ -120,6 +122,22 @@ export function buildNeovimEmbedArgs(useUserInit: boolean): readonly string[] {
   return useUserInit
     ? ["--embed"]
     : ["--embed", "--clean", "-n"];
+}
+
+function embedArgCandidates(useUserInit: boolean | undefined): readonly {
+  readonly useUserInit: boolean;
+  readonly args: readonly string[];
+}[] {
+  if (useUserInit === true) {
+    return [{ useUserInit: true, args: buildNeovimEmbedArgs(true) }];
+  }
+  if (useUserInit === false) {
+    return [{ useUserInit: false, args: buildNeovimEmbedArgs(false) }];
+  }
+  return [
+    { useUserInit: true, args: buildNeovimEmbedArgs(true) },
+    { useUserInit: false, args: buildNeovimEmbedArgs(false) },
+  ];
 }
 
 export function parseNeovimVersion(output: string): NeovimVersion | null {

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -155,6 +155,7 @@ export async function startEmbeddedNeovim(
   try {
     await ui.attach();
     await editFile(rpc, options.filePath, options.line, options.column);
+    await configureEmbeddedEditing(rpc);
     await installDirtyAutocmds(rpc);
   } catch (error) {
     ui.dispose();
@@ -181,6 +182,16 @@ async function editFile(
   const escaped = await rpc.request("nvim_call_function", ["fnameescape", [filePath]]);
   await rpc.request("nvim_command", [`edit ${stringValue(escaped)}`]);
   await rpc.request("nvim_win_set_cursor", [0, [Math.max(1, line), Math.max(0, column)]]);
+}
+
+async function configureEmbeddedEditing(rpc: NeovimRpcTransport): Promise<void> {
+  for (const command of [
+    "set termguicolors",
+    "syntax enable",
+    "filetype plugin indent on",
+  ]) {
+    await rpc.request("nvim_command", [command]);
+  }
 }
 
 async function installDirtyAutocmds(rpc: NeovimRpcTransport): Promise<void> {

--- a/runtime/src/tui/workbench/buffer/providers/selectBufferEditorProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/selectBufferEditorProvider.ts
@@ -84,7 +84,7 @@ export function bufferProviderConfigFromEnv(env: NodeJS.ProcessEnv = process.env
   return {
     mode: parseMode(env.AGENC_BUFFER_PROVIDER),
     executable: env.AGENC_BUFFER_NVIM,
-    useUserInit: env.AGENC_BUFFER_NVIM_USE_INIT === "1" || env.AGENC_BUFFER_NVIM_USE_INIT === "true",
+    useUserInit: parseUseUserInit(env.AGENC_BUFFER_NVIM_USE_INIT),
     timeoutMs: parsePositiveInteger(env.AGENC_BUFFER_NVIM_TIMEOUT_MS),
   };
 }
@@ -98,4 +98,12 @@ function parsePositiveInteger(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseUseUserInit(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") return true;
+  if (normalized === "0" || normalized === "false" || normalized === "no") return false;
+  return undefined;
 }

--- a/runtime/src/tui/workbench/buffer/render.tsx
+++ b/runtime/src/tui/workbench/buffer/render.tsx
@@ -2,10 +2,11 @@ import React from "react";
 
 import { getGraphemeSegmenter } from "../../../utils/intl.js";
 import { Ansi, Box, Text } from "../../ink.js";
+import type { Color } from "../../ink/styles.js";
 import { stringWidth } from "../../ink/stringWidth.js";
 import { nextGraphemeOffset, selectionBounds } from "./editing.js";
 import type { BufferVisibleLine, WorkbenchBufferSnapshot } from "./BufferStore.js";
-import type { NeovimRenderSnapshot } from "./neovim/NeovimGrid.js";
+import type { NeovimCell, NeovimHighlight, NeovimRenderSnapshot } from "./neovim/NeovimGrid.js";
 
 export function BufferLine({
   line,
@@ -58,7 +59,7 @@ export function NeovimGridView({
       {terminal.lines.map((line, row) => (
         <Box key={row} height={1}>
           <Text wrap="truncate-end">
-            {renderTerminalLine(line, row, terminal.cursor.row, terminal.cursor.column, focused, maxWidth)}
+            {renderTerminalCells(terminalLineCells(terminal, row), terminal.highlights, row, terminal.cursor.row, terminal.cursor.column, focused, maxWidth)}
           </Text>
         </Box>
       ))}
@@ -150,24 +151,123 @@ function renderCursorText(text: string, displayFrom: number, cursorOffset: numbe
   );
 }
 
-function renderTerminalLine(
-  line: string,
+function renderTerminalCells(
+  cells: readonly NeovimCell[],
+  highlights: readonly NeovimHighlight[],
   row: number,
   cursorRow: number,
   cursorColumn: number,
   focused: boolean,
   width: number,
 ): React.ReactNode {
-  const text = truncateByWidth(line, width);
-  if (!focused || row !== cursorRow) return text;
-  const column = Math.max(0, Math.min(cursorColumn, text.length));
+  const highlightMap = new Map(highlights.map((highlight) => [highlight.id, highlight]));
+  const parts: React.ReactNode[] = [];
+  let renderedWidth = 0;
+  for (let column = 0; column < cells.length && renderedWidth < width; column += 1) {
+    const cell = cells[column]!;
+    if (cell.width === 0) continue;
+    if (renderedWidth + cell.width > width) break;
+    const cursor = focused && row === cursorRow && column === cursorColumn;
+    const text = cell.text.length > 0 ? cell.text : " ";
+    const style = terminalTextStyle(highlightMap.get(cell.highlightId), cursor);
+    parts.push(renderTerminalCellText(text, style, `${column}:${cell.highlightId}:${cursor ? "cursor" : "text"}`));
+    renderedWidth += cell.width;
+  }
+  if (focused && row === cursorRow && cursorColumn >= cells.length && renderedWidth < width) {
+    parts.push(<Text key="cursor-end" inverse> </Text>);
+  }
+  return <>{parts}</>;
+}
+
+type TerminalTextStyle = {
+  readonly color?: Color;
+  readonly backgroundColor?: Color;
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly underline?: boolean;
+  readonly strikethrough?: boolean;
+  readonly inverse?: boolean;
+};
+
+function renderTerminalCellText(
+  text: string,
+  style: TerminalTextStyle,
+  key: string,
+): React.ReactNode {
+  if (!hasTerminalTextStyle(style)) return <React.Fragment key={key}>{text}</React.Fragment>;
   return (
-    <>
-      {text.slice(0, column)}
-      <Text inverse>{text[column] ?? " "}</Text>
-      {text.slice(column + 1)}
-    </>
+    <Text
+      key={key}
+      color={style.color}
+      backgroundColor={style.backgroundColor}
+      bold={style.bold}
+      italic={style.italic}
+      underline={style.underline}
+      strikethrough={style.strikethrough}
+      inverse={style.inverse}
+    >
+      {text}
+    </Text>
   );
+}
+
+function terminalTextStyle(
+  highlight: NeovimHighlight | undefined,
+  cursor: boolean,
+): TerminalTextStyle {
+  const attributes = highlight?.attributes ?? {};
+  const style: TerminalTextStyle = {
+    color: rgbNumberToHex(attributes.foreground),
+    backgroundColor: rgbNumberToHex(attributes.background),
+    bold: attributes.bold === true ? true : undefined,
+    italic: attributes.italic === true ? true : undefined,
+    underline: attributes.underline === true || attributes.undercurl === true ? true : undefined,
+    strikethrough: attributes.strikethrough === true ? true : undefined,
+    inverse: cursor || attributes.reverse === true ? true : undefined,
+  };
+  return style;
+}
+
+function hasTerminalTextStyle(style: TerminalTextStyle): boolean {
+  return style.color !== undefined ||
+    style.backgroundColor !== undefined ||
+    style.bold === true ||
+    style.italic === true ||
+    style.underline === true ||
+    style.strikethrough === true ||
+    style.inverse === true;
+}
+
+function rgbNumberToHex(value: NeovimHighlight["attributes"][string]): Color | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const rgb = Math.max(0, Math.min(0xFFFFFF, Math.floor(value)));
+  const red = (rgb >> 16) & 0xFF;
+  const green = (rgb >> 8) & 0xFF;
+  const blue = rgb & 0xFF;
+  return `#${hexByte(red)}${hexByte(green)}${hexByte(blue)}` as Color;
+}
+
+function hexByte(value: number): string {
+  return value.toString(16).padStart(2, "0");
+}
+
+function terminalLineCells(terminal: NeovimRenderSnapshot, row: number): readonly NeovimCell[] {
+  const cells = terminal.cells[row] ?? [];
+  const line = terminal.lines[row] ?? "";
+  if (cellsHaveVisibleText(cells) || line.trimEnd().length === 0) return cells;
+  return lineToCells(line);
+}
+
+function cellsHaveVisibleText(cells: readonly NeovimCell[]): boolean {
+  return cells.some((cell) => cell.text.trim().length > 0);
+}
+
+function lineToCells(line: string): readonly NeovimCell[] {
+  return [...line].map((text) => ({
+    text,
+    width: Math.max(1, stringWidth(text)),
+    highlightId: 0,
+  }));
 }
 
 export function truncateByWidth(text: string, maxWidth: number): string {

--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -51,8 +51,8 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
   {
     mode: "buffer",
     title: (state) => state.activeFilePath ?? "BUFFER",
-    keybindings: ["ctrl+s", "ctrl+x ctrl+e", "ctrl+x q", "ctrl+x x"],
-    footerHints: "Buffer: embedded nvim  ctrl+s save  ctrl+x ctrl+e external  ctrl+x q close",
+    keybindings: ["shift+tab", "ctrl+x h", "ctrl+x j", "ctrl+x ctrl+e", "ctrl+x q"],
+    footerHints: "Buffer: embedded nvim  shift+tab composer  ctrl+x h explorer  ctrl+x ctrl+e external  ctrl+x q close",
     renderBody: ({ focused }) => <BufferSurface focused={focused} />,
   },
   {

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -190,7 +190,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
           {terminal
             ? terminal.commandLine !== null
               ? `${terminal.mode.toUpperCase()}  :${terminal.commandLine}`
-              : `${terminal.mode.toUpperCase()}  :w/:q owned by Neovim  ctrl+s save  ctrl+x ctrl+e external`
+              : `${terminal.mode.toUpperCase()}  shift+tab composer  ctrl+x h explorer  ctrl+x ctrl+e external`
             : snapshot.vimCommandLine !== null
             ? `:${snapshot.vimCommandLine}`
             : snapshot.vimMode === "VISUAL"
@@ -260,6 +260,15 @@ export function createBufferSurfaceKeyHandlers({
   return {
     "buffer:save": () => {
       void store.save({ hasInFlightAgent });
+    },
+    "workbench:focusExplorer": () => {
+      dispatch({ type: "focus", pane: "explorer" });
+    },
+    "workbench:focusAgents": () => {
+      dispatch({ type: "focus", pane: "agents" });
+    },
+    "workbench:focusComposer": () => {
+      dispatch({ type: "focus", pane: "composer" });
     },
     "buffer:revert": () => snapshot.provider.capabilities.terminalUi ? false : store.revert(),
     "buffer:close": async () => {

--- a/runtime/tests/tui/workbench/buffer-docs-config.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-docs-config.contract.test.ts
@@ -15,7 +15,9 @@ describe("embedded Neovim BUFFER docs and config", () => {
     expect(text).toContain("selects the explicit external-editor handoff provider");
     expect(text).toContain("AGENC_BUFFER_NVIM=/path/to/nvim");
     expect(text).toContain("AGENC_BUFFER_NVIM_TIMEOUT_MS=1200");
-    expect(text).toContain("AGENC_BUFFER_NVIM_USE_INIT=1");
+    expect(text).toContain("AGENC_BUFFER_NVIM_USE_INIT=0");
+    expect(text).toContain("prefers user init");
+    expect(text).toContain("falls back to clean embedded");
     expect(text).toContain("nvim --embed --clean -n");
     expect(text).toContain("basic fallback");
     expect(text).toContain("does not claim exact Vim behavior");

--- a/runtime/tests/tui/workbench/buffer-neovim-discovery.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-discovery.contract.test.ts
@@ -40,12 +40,12 @@ describe("embedded Neovim discovery", () => {
     expect(parseNeovimVersion("not neovim")).toBeNull();
   });
 
-  it("builds clean embedded args by default and plain embedded args with user init", () => {
+  it("builds clean embedded args for hermetic mode and plain embedded args with user init", () => {
     expect(buildNeovimEmbedArgs(false)).toEqual(["--embed", "--clean", "-n"]);
     expect(buildNeovimEmbedArgs(true)).toEqual(["--embed"]);
   });
 
-  it("accepts a probe script that prints a supported Neovim version", async () => {
+  it("prefers user init by default when a supported Neovim starts embedded mode", async () => {
     const executable = join(dir, "nvim-probe");
     await writeFile(executable, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then printf 'NVIM v0.12.0-dev\\n'; exit 0; fi\nexit 0\n", "utf8");
     await chmod(executable, 0o755);
@@ -55,8 +55,27 @@ describe("embedded Neovim discovery", () => {
     expect(result.usable).toBe(true);
     if (result.usable) {
       expect(result.executable).toBe(executable);
-      expect(result.args).toEqual(["--embed", "--clean", "-n"]);
+      expect(result.args).toEqual(["--embed"]);
+      expect(result.useUserInit).toBe(true);
     }
+  });
+
+  it("falls back to clean embedded mode when default user init cannot start", async () => {
+    const executable = join(dir, "nvim-user-init-fails");
+    await writeFile(
+      executable,
+      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then printf 'NVIM v0.12.0\\n'; exit 0; fi\nif [ \"$2\" = \"--clean\" ]; then exit 0; fi\necho 'init boom' >&2\nexit 5\n",
+      "utf8",
+    );
+    await chmod(executable, 0o755);
+
+    const result = await discoverNeovim({ executable, timeoutMs: 500 });
+
+    expect(result).toMatchObject({
+      usable: true,
+      args: ["--embed", "--clean", "-n"],
+      useUserInit: false,
+    });
   });
 
   it("uses the default probe timeout when no timeout is configured", async () => {
@@ -126,7 +145,7 @@ describe("embedded Neovim discovery", () => {
     await expect(readFile(marker)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("honors user init config and rejects unsupported or malformed probe output", async () => {
+  it("honors explicit user init config and rejects unsupported or malformed probe output", async () => {
     const oldExecutable = join(dir, "nvim-old");
     const badExecutable = join(dir, "nvim-bad");
     const initExecutable = join(dir, "nvim-init");
@@ -152,6 +171,20 @@ describe("embedded Neovim discovery", () => {
       usable: true,
       args: ["--embed"],
       useUserInit: true,
+    });
+  });
+
+  it("honors explicit clean init config", async () => {
+    const executable = join(dir, "nvim-clean");
+    await writeFile(executable, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then printf 'NVIM v0.12.0\\n'; exit 0; fi\nif [ \"$2\" = \"--clean\" ]; then exit 0; fi\nexit 9\n", "utf8");
+    await chmod(executable, 0o755);
+
+    const result = await discoverNeovim({ executable, timeoutMs: 500, useUserInit: false });
+
+    expect(result).toMatchObject({
+      usable: true,
+      args: ["--embed", "--clean", "-n"],
+      useUserInit: false,
     });
   });
 

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -35,9 +35,11 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(missingFallback).toContain("Inline BUFFER is available as the basic fallback");
     expect(killCleanup).toContain("session.kill()");
     expect(killCleanup).toContain("KILL_DIRTY_MARK");
+    expect(killCleanup).toContain("waitForFrameText");
     expect(killCleanup).toContain("TUI-killed embedded Neovim");
     expect(helpers).toContain("listDescendantNeovimPids");
     expect(helpers).toContain("waitForPidsGone");
+    expect(helpers).toContain("waitForFrameText");
     expect(helpers).toContain("workspaceSnapshot");
     expect(helpers).toContain("ps");
     expect(wrapper).toContain("workbench-buffer-neovim");

--- a/runtime/tests/tui/workbench/buffer-neovim-input.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-input.contract.test.ts
@@ -5,6 +5,7 @@ import { nodeCache } from "../../../src/tui/ink/node-cache.js";
 import { createChordInputHandler } from "../../../src/tui/keybindings/KeybindingProviderSetup.js";
 import { DEFAULT_BINDINGS } from "../../../src/tui/keybindings/defaultBindings.js";
 import { parseBindings } from "../../../src/tui/keybindings/parser.js";
+import type { ParsedKeystroke } from "../../../src/tui/keybindings/types.js";
 import {
   translateKeyToNeovimInput,
   translatePasteToNeovimInput,
@@ -114,6 +115,44 @@ describe("embedded Neovim input translation", () => {
     expect(save).toHaveBeenCalledTimes(1);
     expect(capture).not.toHaveBeenCalled();
     expect(event.didStopImmediatePropagation()).toBe(true);
+  });
+
+  it("routes BUFFER escape-hatch focus chords before raw Neovim capture", () => {
+    const focusComposer = vi.fn();
+    const focusExplorer = vi.fn();
+    const capture = vi.fn(() => true);
+    const pendingChordRef: { current: ParsedKeystroke[] | null } = { current: null };
+    const handler = createChordInputHandler({
+      bindings: parseBindings(DEFAULT_BINDINGS),
+      pendingChordRef,
+      setPendingChord: vi.fn((pending) => {
+        pendingChordRef.current = pending;
+      }),
+      activeContexts: new Set(["Buffer"]),
+      handlerRegistryRef: {
+        current: new Map([
+          ["workbench:focusComposer", new Set([{ action: "workbench:focusComposer", context: "Buffer" as const, handler: focusComposer }])],
+          ["workbench:focusExplorer", new Set([{ action: "workbench:focusExplorer", context: "Buffer" as const, handler: focusExplorer }])],
+        ]),
+      },
+      inputCaptureRegistryRef: { current: new Set([{ context: "Buffer" as const, handler: capture }]) },
+    });
+
+    const shiftTab = createInputEvent(key({ tab: true, shift: true }));
+    handler("", key({ tab: true, shift: true }), shiftTab as any);
+    expect(focusComposer).toHaveBeenCalledTimes(1);
+    expect(capture).not.toHaveBeenCalled();
+    expect(shiftTab.didStopImmediatePropagation()).toBe(true);
+
+    const prefix = createInputEvent(key({ ctrl: true }));
+    handler("x", key({ ctrl: true }), prefix as any);
+    const explorer = createInputEvent(key({}));
+    handler("h", key({}), explorer as any);
+
+    expect(focusExplorer).toHaveBeenCalledTimes(1);
+    expect(capture).not.toHaveBeenCalled();
+    expect(prefix.didStopImmediatePropagation()).toBe(true);
+    expect(explorer.didStopImmediatePropagation()).toBe(true);
   });
 
   it("forwards escape and wheel events to active BUFFER capture instead of global surface handlers", () => {

--- a/runtime/tests/tui/workbench/buffer-provider-boundary.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-provider-boundary.contract.test.ts
@@ -145,7 +145,7 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     expect(old.reason).toContain("requires nvim");
   });
 
-  it("parses provider configuration from environment with conservative defaults", () => {
+  it("parses provider configuration from environment with user-init default preference", () => {
     expect(bufferProviderConfigFromEnv({
       AGENC_BUFFER_PROVIDER: "neovim",
       AGENC_BUFFER_NVIM: "custom-nvim",
@@ -162,6 +162,7 @@ describe("embedded Neovim BUFFER provider boundary", () => {
       AGENC_BUFFER_PROVIDER: "external",
     } as NodeJS.ProcessEnv)).toMatchObject({
       mode: "external",
+      useUserInit: undefined,
     });
 
     expect(bufferProviderConfigFromEnv({

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -205,6 +205,9 @@ describe("BufferSurface", () => {
     });
 
     handlers["buffer:save"]?.();
+    handlers["workbench:focusExplorer"]?.();
+    handlers["workbench:focusAgents"]?.();
+    handlers["workbench:focusComposer"]?.();
     await handlers["buffer:revert"]?.();
     await handlers["buffer:close"]?.();
     await handlers["buffer:closeDiscard"]?.();
@@ -232,6 +235,9 @@ describe("BufferSurface", () => {
     await flush();
 
     expect(store.save).toHaveBeenCalledWith({ hasInFlightAgent: true });
+    expect(dispatch).toHaveBeenCalledWith({ type: "focus", pane: "explorer" });
+    expect(dispatch).toHaveBeenCalledWith({ type: "focus", pane: "agents" });
+    expect(dispatch).toHaveBeenCalledWith({ type: "focus", pane: "composer" });
     expect(store.close).toHaveBeenCalledWith();
     expect(store.close).toHaveBeenCalledWith({ discard: true });
     expect(dispatch).toHaveBeenCalledWith({ type: "closeSurface" });
@@ -1191,7 +1197,8 @@ describe("BufferSurface", () => {
       const frame = output();
       expect(frame).toContain("embedded Neovim test");
       expect(frame).toContain("alpha");
-      expect(frame).toContain("ctrl+ssave");
+      expect(frame).toContain("shift+tabcomposer");
+      expect(frame).toContain("ctrl+xhexplorer");
 
       terminalCommandLine = "set number relativenumber wrapscan";
       providerListener?.();

--- a/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
@@ -104,6 +104,37 @@ describe("BUFFER workbench rendering", () => {
     expect(output).not.toContain("abc\x1B[7md\x1B[27mef");
   });
 
+  it("renders Neovim highlight attributes as terminal color instead of dropping them", async () => {
+    const terminal = {
+      ...createNeovimRenderSnapshot(1, 16),
+      lines: ["const x = 1;"],
+      cells: [[
+        { text: "c", width: 1, highlightId: 3 },
+        { text: "o", width: 1, highlightId: 3 },
+        { text: "n", width: 1, highlightId: 3 },
+        { text: "s", width: 1, highlightId: 3 },
+        { text: "t", width: 1, highlightId: 3 },
+        { text: " ", width: 1, highlightId: 0 },
+        { text: "x", width: 1, highlightId: 4 },
+      ]],
+      highlights: [
+        { id: 3, attributes: { foreground: 0xFF5F87, bold: true } },
+        { id: 4, attributes: { foreground: 0x5FD7FF, italic: true, underline: true } },
+      ],
+    };
+
+    const output = await renderToAnsiString(
+      <Box flexDirection="column" width={16}>
+        <NeovimGridView terminal={terminal} focused={false} width={16} />
+      </Box>,
+      { columns: 16, color: true },
+    );
+
+    expect(output).toContain("\x1B[38;2;255;95;135m");
+    expect(output).toContain("\x1B[38;2;95;215;255m");
+    expect(output).toContain("const");
+  });
+
   it("renders inline buffer cursor and selection boundary cases", async () => {
     const line = { number: 1, text: "abcdef", from: 0, to: 6 };
 
@@ -315,6 +346,8 @@ describe("BUFFER workbench rendering", () => {
     const descriptor = WORKBENCH_SURFACES.find((surface) => surface.mode === "buffer");
 
     expect(descriptor?.footerHints).toContain("embedded nvim");
+    expect(descriptor?.footerHints).toContain("shift+tab composer");
+    expect(descriptor?.footerHints).toContain("ctrl+x h explorer");
     expect(descriptor?.footerHints).toContain("ctrl+x ctrl+e external");
     expect(descriptor?.footerHints).toContain("ctrl+x q close");
   });

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -130,10 +130,13 @@ describe("workbench keybinding contract", () => {
       x: "surface:stop",
     });
     expect(byContext.get("Buffer")).toMatchObject({
-      enter: "buffer:externalEditor",
+      "shift+tab": "workbench:focusComposer",
+      "ctrl+x h": "workbench:focusExplorer",
+      "ctrl+x j": "workbench:focusComposer",
+      "ctrl+x l": "workbench:focusAgents",
       "ctrl+s": "buffer:save",
-      "ctrl+w q": "buffer:close",
-      "ctrl+w x": "buffer:closeDiscard",
+      "ctrl+x q": "buffer:close",
+      "ctrl+x x": "buffer:closeDiscard",
     });
     expect(byContext.get("Buffer")).not.toHaveProperty("q");
     expect(byContext.get("Buffer")).not.toHaveProperty("ctrl+z");


### PR DESCRIPTION
## Summary
- add BUFFER-local escape hatches so embedded Neovim can return focus to composer, explorer, or agents
- render Neovim grid cell highlights instead of flattening the terminal buffer to plain text
- prefer user Neovim init by default, keep clean embedded mode for hermetic gates, and make PTY scenarios wait for rendered Neovim readiness

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-neovim-discovery.contract.test.ts tests/tui/workbench/buffer-provider-boundary.contract.test.ts tests/tui/workbench/buffer-neovim-input.contract.test.ts tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-docs-config.contract.test.ts tests/tui/workbench/keybindings.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-buffer-neovim
- npm run typecheck
- npm run check:unused:production --workspace=@tetsuo-ai/runtime
- npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-visual-smoke
- npm run build
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core --full
- node scripts/check-embedded-neovim-buffer.mjs --command-timeout-ms 240000