### PR TITLE
fix(tui): close embedded neovim buffer on runtime exit

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/123-workbench-buffer-neovim-runtime-exit.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/123-workbench-buffer-neovim-runtime-exit.mjs
@@ -1,0 +1,76 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  frameText,
+  listDescendantNeovimPids,
+  waitForFrameText,
+  waitForPidsGone,
+  waitForScreen,
+} from "../helpers/workbench-buffer-neovim.mjs";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const meta = {
+  description: "Workbench BUFFER embedded Neovim keeps real normal-mode keys in Neovim and exits the BUFFER surface after :q!.",
+  timeoutMs: 35_000,
+  env: {
+    AGENC_TUI_WORKBENCH: "1",
+    AGENC_BUFFER_PROVIDER: "auto",
+    AGENC_BUFFER_NVIM_USE_INIT: "0",
+    AGENC_OAUTH_TOKEN: "test-workbench-buffer-runtime-exit-token",
+  },
+};
+
+export default async function (session) {
+  const cwd = await mkdtemp(join(tmpdir(), "agenc-buffer-neovim-runtime-exit-"));
+  try {
+    await writeFile(join(cwd, "target.txt"), "alpha\nbeta\n", "utf8");
+    session.cwd = cwd;
+    await session.start();
+    await session.waitForPrompt({ timeout: 20_000 });
+    await sleep(300);
+
+    session.send("\x17h");
+    await session.waitForIdle({ idleWindow: 300, timeout: 10_000 });
+    session.send("\r");
+    await session.waitFor(/BUFFER/i, { timeout: 20_000, label: "BUFFER open" });
+    await waitForScreen(session, /embedded\s*Neovim|NORMAL/i, {
+      timeout: 20_000,
+      label: "embedded Neovim ready",
+    });
+    await waitForFrameText(session, /alpha[\s\S]*beta/u, "loaded target.txt in embedded Neovim", 20_000);
+    await waitForFrameText(session, /NORMAL/u, "normal-mode Neovim frame", 20_000);
+
+    const neovimPids = await listDescendantNeovimPids(session.term?.pid);
+    if (neovimPids.length === 0) {
+      throw new Error("embedded Neovim process was not a child of the TUI");
+    }
+
+    session.send("jklh");
+    await sleep(150);
+    session.send(":");
+    await sleep(80);
+    await session.type("w", { perCharMs: 80 });
+    session.send("\r");
+    await session.waitForIdle({ idleWindow: 800, timeout: 15_000 });
+    const afterMovement = await readFile(join(cwd, "target.txt"), "utf8");
+    if (afterMovement !== "alpha\nbeta\n") {
+      throw new Error(`normal-mode movement keys modified the file: ${JSON.stringify(afterMovement)}`);
+    }
+
+    session.send(":");
+    await sleep(80);
+    await session.type("q!", { perCharMs: 80 });
+    session.send("\r");
+    await waitForPidsGone(neovimPids, 8_000, "embedded Neovim after :q!");
+    await waitForFrameText(session, /TRANSCRIPT/u, "Workbench transcript after embedded Neovim :q!", 8_000);
+    const frame = frameText(session);
+    if (/Buffer:\s*embedded nvim|embedded Neovim|BUFFER/u.test(frame)) {
+      throw new Error(`Workbench stayed on BUFFER after embedded Neovim :q!:\n${frame.slice(-1200)}`);
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}

--- a/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
+++ b/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
@@ -129,8 +129,9 @@ export class BufferProviderController {
     key: BufferProviderInput["key"],
     context: BufferProviderInput["context"],
     onInlineCommand?: (command: BufferVimCommand) => void,
+    isPaste = false,
   ): boolean {
-    return this.#provider?.handleInput({ input, key, context, onInlineCommand }) ?? false;
+    return this.#provider?.handleInput({ input, key, isPaste, context, onInlineCommand }) ?? false;
   }
 
   click(row: number, column: number): boolean {

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -8,7 +8,7 @@ import {
 } from "../../fileSnapshot.js";
 import { startEmbeddedNeovim, type EmbeddedNeovimSession, type StartEmbeddedNeovimOptions } from "../../neovim/NeovimLifecycle.js";
 import type { NeovimDiscoveryResult } from "../../neovim/NeovimDiscovery.js";
-import { translateKeyToNeovimInput, translatePasteToNeovimInput } from "../../neovim/NeovimInput.js";
+import { translateKeyToNeovimInput } from "../../neovim/NeovimInput.js";
 import { createNeovimRenderSnapshot, type NeovimRenderSnapshot } from "../../neovim/NeovimGrid.js";
 import type { BufferMove } from "../../editing.js";
 import type {
@@ -244,17 +244,13 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   handleInput(event: BufferProviderInput): boolean {
     const session = this.#session;
     if (!session) return false;
-    if (event.input.length > 1 && !hasSpecialKey(event.key)) {
-      for (const translated of translatePasteToNeovimInput(event.input)) {
-        if (translated.type === "keys") void session.input(translated.keys);
-        if (translated.type === "paste") void session.paste(translated.text);
-      }
-      void this.#refreshDirty();
+    if (event.isPaste === true) {
+      void session.paste(event.input).catch((error) => this.#setInputError(error));
       return true;
     }
     const keys = translateKeyToNeovimInput(event.input, event.key);
     if (!keys) return false;
-    void session.input(keys).then(() => this.#refreshDirty());
+    void this.#sendInput(session, keys);
     return true;
   }
 
@@ -302,6 +298,14 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     this.#dirty = await this.#readCurrentDirtyState();
     if (!this.#dirty) await this.#refreshFileSnapshot();
     this.#emitSnapshot();
+  }
+
+  async #sendInput(session: EmbeddedNeovimSession, keys: string): Promise<void> {
+    await session.input(keys).catch((error) => this.#setInputError(error));
+  }
+
+  #setInputError(error: unknown): void {
+    this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
   }
 
   async #readCurrentDirtyState(): Promise<boolean> {
@@ -408,10 +412,4 @@ function neovimModeToVimMode(mode: string): BufferProviderSnapshot["vimMode"] {
   if (mode.startsWith("insert")) return "INSERT";
   if (mode.startsWith("visual") || mode === "v" || mode === "V") return "VISUAL";
   return "NORMAL";
-}
-
-function hasSpecialKey(key: BufferProviderInput["key"]): boolean {
-  return key.upArrow || key.downArrow || key.leftArrow || key.rightArrow || key.pageDown || key.pageUp ||
-    key.home || key.end || key.return || key.escape || key.tab || key.backspace || key.delete ||
-    key.wheelUp || key.wheelDown;
 }

--- a/runtime/src/tui/workbench/buffer/providers/types.ts
+++ b/runtime/src/tui/workbench/buffer/providers/types.ts
@@ -66,6 +66,7 @@ export type BufferProviderInputContext = {
 export type BufferProviderInput = {
   readonly input: string;
   readonly key: Key;
+  readonly isPaste?: boolean;
   readonly context: BufferProviderInputContext;
   readonly onInlineCommand?: (command: BufferVimCommand) => void;
 };

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -84,6 +84,14 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
     };
   }, [focused, store]);
 
+  useEffect(() => {
+    if (!focused) return;
+    if (workbench.activeSurfaceMode !== "buffer") return;
+    if (snapshot.provider.kind !== "neovim") return;
+    if (snapshot.providerStatus !== "closed") return;
+    dispatch({ type: "closeSurface" });
+  }, [dispatch, focused, snapshot.provider.kind, snapshot.providerStatus, workbench.activeSurfaceMode]);
+
   useEffect(() => () => {
     void store.cleanup();
   }, [store]);
@@ -126,6 +134,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
             rows: Math.max(1, rows - 9),
           },
           executeVimCommand,
+          event.keypress.isPasted,
         );
       },
       [columns, executeVimCommand, rows, store],

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -7,6 +7,7 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     const scenario = await readFile("scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs", "utf8");
     const missingFallback = await readFile("scripts/check-tui-e2e/scenarios/121-workbench-buffer-neovim-missing-fallback.mjs", "utf8");
     const killCleanup = await readFile("scripts/check-tui-e2e/scenarios/122-workbench-buffer-neovim-kill-cleanup.mjs", "utf8");
+    const runtimeExit = await readFile("scripts/check-tui-e2e/scenarios/123-workbench-buffer-neovim-runtime-exit.mjs", "utf8");
     const helpers = await readFile("scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs", "utf8");
     const wrapper = await readFile("scripts/check-tui-workbench-buffer-neovim.mjs", "utf8");
     const visualSmoke = await readFile("scripts/check-tui-workbench-visual-smoke.mjs", "utf8");
@@ -37,6 +38,10 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(killCleanup).toContain("KILL_DIRTY_MARK");
     expect(killCleanup).toContain("waitForFrameText");
     expect(killCleanup).toContain("TUI-killed embedded Neovim");
+    expect(runtimeExit).toContain("jklh");
+    expect(runtimeExit).toContain("normal-mode movement keys modified the file");
+    expect(runtimeExit).toContain("Workbench transcript after embedded Neovim :q!");
+    expect(runtimeExit).toContain("Workbench stayed on BUFFER after embedded Neovim :q!");
     expect(helpers).toContain("listDescendantNeovimPids");
     expect(helpers).toContain("waitForPidsGone");
     expect(helpers).toContain("waitForFrameText");

--- a/runtime/tests/tui/workbench/buffer-neovim-input.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-input.contract.test.ts
@@ -282,9 +282,15 @@ describe("embedded Neovim input translation", () => {
 
     expect(provider.handleInput({ input: "alpha\nbeta", key: key({}), context: { rows: 8, columns: 40 } })).toBe(true);
     await flush();
-    expect(session.input).toHaveBeenCalledWith("<PasteStart>");
+    expect(session.input).toHaveBeenCalledWith("alpha\nbeta");
+    expect(session.paste).not.toHaveBeenCalled();
+
+    session.input.mockClear();
+    session.paste.mockClear();
+    expect(provider.handleInput({ input: "alpha\nbeta", key: key({}), isPaste: true, context: { rows: 8, columns: 40 } })).toBe(true);
+    await flush();
     expect(session.paste).toHaveBeenCalledWith("alpha\nbeta");
-    expect(session.input).toHaveBeenCalledWith("<PasteEnd>");
+    expect(session.input).not.toHaveBeenCalled();
 
     expect(provider.handleInput({ input: "", key: key({ escape: true }), context: { rows: 8, columns: 40 } })).toBe(true);
     expect(provider.handleInput({ input: "", key: key({ wheelDown: true }), context: { rows: 8, columns: 40 } })).toBe(true);

--- a/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
@@ -69,11 +69,27 @@ describe("embedded Neovim BUFFER provider", () => {
     await flush();
     expect(harness.session.input).toHaveBeenLastCalledWith("i");
 
+    harness.session.isDirty.mockClear();
+    expect(provider.handleInput({ input: "o", key: baseKey(), context: { rows: 8, columns: 40 } })).toBe(true);
+    expect(provider.handleInput({ input: "K", key: baseKey(), context: { rows: 8, columns: 40 } })).toBe(true);
+    await flush();
+    expect(harness.session.input).toHaveBeenCalledWith("o");
+    expect(harness.session.input).toHaveBeenCalledWith("K");
+    expect(harness.session.isDirty).not.toHaveBeenCalled();
+
+    harness.session.input.mockClear();
+    harness.session.paste.mockClear();
     expect(provider.handleInput({ input: "hello", key: baseKey(), context: { rows: 8, columns: 40 } })).toBe(true);
     await flush();
-    expect(harness.session.input).toHaveBeenCalledWith("<PasteStart>");
+    expect(harness.session.input).toHaveBeenCalledWith("hello");
+    expect(harness.session.paste).not.toHaveBeenCalled();
+
+    harness.session.input.mockClear();
+    harness.session.paste.mockClear();
+    expect(provider.handleInput({ input: "hello", key: baseKey(), isPaste: true, context: { rows: 8, columns: 40 } })).toBe(true);
+    await flush();
     expect(harness.session.paste).toHaveBeenCalledWith("hello");
-    expect(harness.session.input).toHaveBeenCalledWith("<PasteEnd>");
+    expect(harness.session.input).not.toHaveBeenCalled();
 
     expect(provider.handleInput({ input: "", key: { ...baseKey(), escape: true }, context: { rows: 8, columns: 40 } })).toBe(true);
     await flush();

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -1213,6 +1213,118 @@ describe("BufferSurface", () => {
     }
   });
 
+  it("returns to the transcript when embedded Neovim exits from inside BUFFER", async () => {
+    await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
+    let providerListener: (() => void) | null = null;
+    let providerStatus: "ready" | "closed" = "ready";
+    let providerMessage: string | null = null;
+    const identity = {
+      kind: "neovim" as const,
+      label: "embedded Neovim test",
+      fallbackReason: null,
+      capabilities: NEOVIM_BUFFER_CAPABILITIES,
+    };
+    const provider = {
+      identity,
+      subscribe: vi.fn((listener: () => void) => {
+        providerListener = listener;
+        return () => {};
+      }),
+      getSnapshot: vi.fn(() => ({
+        ...emptyProviderSnapshot(identity),
+        status: providerStatus === "closed" ? "idle" as const : "ready" as const,
+        providerStatus,
+        providerMessage,
+        filePath: "target.ts",
+        absolutePath: join(dir, "target.ts"),
+        terminal: {
+          ...createNeovimRenderSnapshot(4, 24),
+          lines: ["alpha", "beta", "", ""],
+          mode: "normal",
+          commandLine: null,
+          cursor: { grid: 1, row: 0, column: 0 },
+        },
+        vimMode: "NORMAL" as const,
+        position: { line: 1, column: 0, offset: 0 },
+      })),
+      getVisibleLines: vi.fn(() => []),
+      open: vi.fn(async () => {}),
+      save: vi.fn(async () => true),
+      revert: vi.fn(async () => {}),
+      close: vi.fn(async () => true),
+      openExternalEditor: vi.fn(async () => false),
+      undo: vi.fn(() => false),
+      redo: vi.fn(() => false),
+      move: vi.fn(() => false),
+      requestHover: vi.fn(async () => null),
+      goToDefinition: vi.fn(async () => false),
+      handleInput: vi.fn(() => true),
+      click: vi.fn(() => true),
+      resize: vi.fn(),
+      focus: vi.fn(),
+      cleanup: vi.fn(async () => {}),
+    };
+    getWorkbenchBufferProviderController().setSelectionFactoryForTesting(async () => ({
+      kind: "neovim",
+      provider,
+      discovery: {
+        usable: true,
+        executable: "nvim",
+        version: { major: 0, minor: 12, patch: 0, raw: "NVIM v0.12.0" },
+        args: ["--embed", "--clean", "-n"],
+        useUserInit: false,
+      },
+    }));
+    const changes: ReturnType<typeof getDefaultAppState>[] = [];
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 1,
+                focusedPane: "surface",
+              },
+            }}
+            onChangeAppState={({ newState }) => {
+              changes.push(newState);
+            }}
+          >
+            <KeybindingSetup>
+              <WorkbenchLayout transcript={<Text>transcript after close</Text>} composer={<Text>composer</Text>} />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      expect(output()).toContain("embedded Neovim test");
+
+      providerStatus = "closed";
+      providerMessage = "Embedded Neovim exited.";
+      providerListener?.();
+      await sleep();
+
+      expect(changes.some((state) => state.workbench.activeSurfaceMode === "transcript")).toBe(true);
+      expect(output()).toContain("transcript after close");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("routes mouse clicks only from inside the BUFFER content pane", async () => {
     await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
     const identity = {


### PR DESCRIPTION
## Summary
- Return the Workbench to TRANSCRIPT when embedded Neovim exits itself from BUFFER.
- Treat PTY paste as paste only when Ink marks it pasted, so batched normal-mode keys like jklh are routed as Neovim input instead of file text.
- Add provider, surface, and PTY E2E coverage for runtime exit and batched movement keys.

## Test plan
- git diff --check
- npm run typecheck
- npx vitest run tests/tui/workbench/buffer-neovim-provider.contract.test.ts tests/tui/workbench/buffer-neovim-input.contract.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-neovim-e2e-contract.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 123-workbench-buffer-neovim-runtime-exit
- npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-buffer-neovim
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core --full