### PR TITLE
fix(tui): repaint embedded neovim visual highlights

### DIFF
--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -12,8 +12,11 @@ export function workspaceAnchor(text) {
 }
 
 export function workspaceSnapshot(text) {
+  const workspaceColumnWidth = 21;
   return text
     .split(/\n/u)
+    .map((entry) => entry.slice(0, workspaceColumnWidth).trimEnd())
+    .filter((entry) => !/^AgenC Workbench/u.test(entry))
     .filter((entry) => /WORKSPACE|target\.txt|agenc|README|package|docs|runtime/u.test(entry))
     .slice(0, 12)
     .map((entry) => entry.trim())

--- a/runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs
@@ -19,6 +19,7 @@ export const meta = {
   env: {
     AGENC_TUI_WORKBENCH: "1",
     AGENC_BUFFER_PROVIDER: "auto",
+    AGENC_BUFFER_NVIM_USE_INIT: "0",
     AGENC_OAUTH_TOKEN: "test-workbench-buffer-token",
   },
 };
@@ -215,16 +216,13 @@ export default async function (session) {
     await session.type("MACRO_MARK", { perCharMs: 15 });
     session.send("\r");
     await sleep(200);
-    const searchBefore = session.text;
+    await waitForFrameText(session, /MACRO_MARK/u, "search target visible before navigation", 10_000);
+    const rawBeforeN = session.raw.length;
     session.send("n");
-    await sleep(120);
-    const searchAfterN = session.text;
+    await waitForStyledSearchPaint(session, rawBeforeN, "next search navigation");
+    const rawBeforeShiftN = session.raw.length;
     session.send("N");
-    await sleep(120);
-    const searchAfterShiftN = session.text;
-    if (searchBefore === searchAfterN || searchAfterN === searchAfterShiftN) {
-      throw new Error("search navigation did not visibly change the BUFFER screen");
-    }
+    await waitForStyledSearchPaint(session, rawBeforeShiftN, "previous search navigation");
     session.send("\x1b");
     await session.waitForIdle({ idleWindow: 300, timeout: 10_000 });
 
@@ -239,12 +237,20 @@ export default async function (session) {
     session.send("q");
     await sleep(80);
     session.send("\r");
-    await session.waitFor(/E37: No write since last change|Unsaved Neovim edits/i, { timeout: 10_000, label: "dirty quit refusal" });
+    await sleep(600);
+    const afterDirtyQuitPids = await listDescendantNeovimPids(session.term?.pid);
+    if (!neovimPids.some((pid) => afterDirtyQuitPids.includes(pid))) {
+      throw new Error("dirty quit closed embedded Neovim instead of keeping the editor alive");
+    }
+    const afterDirtyQuit = await readFile(join(cwd, "target.txt"), "utf8");
+    if (afterDirtyQuit.includes("DIRTY_MARK")) {
+      throw new Error(`dirty quit wrote dirty text that should have stayed unsaved: ${afterDirtyQuit}`);
+    }
     if (!/BUFFER/i.test(session.text)) {
       throw new Error("dirty :q closed BUFFER instead of keeping the editor alive");
     }
 
-    session.send("\r");
+    session.send("\x1b");
     await sleep(120);
     session.send(":");
     await sleep(80);
@@ -276,4 +282,17 @@ function findFrameCell(session, text) {
 
 function sgrClick(column, row) {
   return `\x1b[<0;${column};${row}M\x1b[<0;${column};${row}m`;
+}
+
+async function waitForStyledSearchPaint(session, rawStart, label) {
+  const deadline = Date.now() + 3_000;
+  let chunk = "";
+  while (Date.now() < deadline) {
+    chunk = session.raw.slice(rawStart);
+    const hasStyledSearchCell = /\x1b\[[0-9;]*7[0-9;]*m[A-Z_]/u.test(chunk) ||
+      /\x1b\[48;(?:2|5);[0-9;]*m[A-Z_]/u.test(chunk);
+    if (hasStyledSearchCell) return;
+    await sleep(50);
+  }
+  throw new Error(`${label} did not repaint a styled search match: ${JSON.stringify(chunk.slice(-400))}`);
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/124-workbench-buffer-neovim-visual-render.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/124-workbench-buffer-neovim-visual-render.mjs
@@ -1,0 +1,85 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  frameText,
+  listDescendantNeovimPids,
+  waitForFrameText,
+  waitForPidsGone,
+  waitForScreen,
+} from "../helpers/workbench-buffer-neovim.mjs";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const meta = {
+  description: "Workbench BUFFER embedded Neovim visibly repaints visual selections without full-screen flicker.",
+  timeoutMs: 35_000,
+  env: {
+    AGENC_TUI_WORKBENCH: "1",
+    AGENC_BUFFER_PROVIDER: "auto",
+    AGENC_BUFFER_NVIM_USE_INIT: "0",
+    AGENC_OAUTH_TOKEN: "test-workbench-buffer-visual-token",
+  },
+};
+
+export default async function (session) {
+  const cwd = await mkdtemp(join(tmpdir(), "agenc-buffer-neovim-visual-"));
+  try {
+    await writeFile(join(cwd, "target.txt"), "alpha beta gamma\nsecond line\n", "utf8");
+    session.cwd = cwd;
+    await session.start();
+    await session.waitForPrompt({ timeout: 20_000 });
+    await sleep(300);
+
+    session.send("\x17h");
+    await session.waitForIdle({ idleWindow: 300, timeout: 10_000 });
+    session.send("\r");
+    await session.waitFor(/BUFFER/i, { timeout: 20_000, label: "BUFFER open" });
+    await waitForScreen(session, /embedded\s*Neovim|NORMAL/i, {
+      timeout: 20_000,
+      label: "embedded Neovim ready",
+    });
+    await waitForFrameText(session, /alpha beta gamma[\s\S]*second line/u, "loaded visual target in embedded Neovim", 20_000);
+    await waitForFrameText(session, /NORMAL/u, "normal-mode Neovim visual-render frame", 20_000);
+
+    const neovimPids = await listDescendantNeovimPids(session.term?.pid);
+    if (neovimPids.length === 0) {
+      throw new Error("embedded Neovim process was not a child of the TUI");
+    }
+
+    await session.type("gg0", { perCharMs: 60 });
+    await waitForFrameText(session, /alpha beta gamma/u, "top visual selection line before highlight", 10_000);
+    const rawBeforeVisual = session.raw.length;
+    session.send("v");
+    await sleep(120);
+    session.send("$");
+    await waitForFrameText(session, /visual|VISUAL/u, "visual selection mode", 10_000);
+    await sleep(250);
+
+    const visualChunk = session.raw.slice(rawBeforeVisual);
+    const alphaIndex = visualChunk.indexOf("alpha");
+    if (alphaIndex < 0) {
+      throw new Error(`visible selection highlight did not repaint the selected line:\n${frameText(session).slice(-1200)}`);
+    }
+    const alphaPrefix = visualChunk.slice(Math.max(0, alphaIndex - 120), alphaIndex);
+    const selectedStyle = /\x1b\[[0-9;]*7[0-9;]*m/u.test(alphaPrefix) ||
+      /\x1b\[48;(?:2|5);[0-9;]/u.test(alphaPrefix);
+    if (!selectedStyle) {
+      throw new Error(`visible selection highlight repainted text without selection style: ${JSON.stringify(visualChunk.slice(Math.max(0, alphaIndex - 120), alphaIndex + 40))}`);
+    }
+    if (/\x1b\[(?:2|3)J/u.test(visualChunk)) {
+      throw new Error("visual selection highlight caused a full-screen clear/flicker");
+    }
+
+    session.send("\x1b");
+    await waitForFrameText(session, /NORMAL/u, "normal mode after visual-render selection", 10_000);
+    session.send(":");
+    await sleep(80);
+    await session.type("q!", { perCharMs: 80 });
+    session.send("\r");
+    await waitForPidsGone(neovimPids, 8_000, "embedded Neovim after visual-render :q!");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}

--- a/runtime/src/tui/workbench/buffer/render.tsx
+++ b/runtime/src/tui/workbench/buffer/render.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { getGraphemeSegmenter } from "../../../utils/intl.js";
-import { Ansi, Box, Text } from "../../ink.js";
+import { Ansi, Box, RawAnsi, Text } from "../../ink.js";
 import type { Color } from "../../ink/styles.js";
 import { stringWidth } from "../../ink/stringWidth.js";
 import { nextGraphemeOffset, selectionBounds } from "./editing.js";
@@ -54,15 +54,10 @@ export function NeovimGridView({
   readonly width: number;
 }): React.ReactElement {
   const maxWidth = Math.max(1, width);
+  const terminalLines = terminalAnsiLines(terminal, focused, maxWidth);
   return (
     <>
-      {terminal.lines.map((line, row) => (
-        <Box key={row} height={1}>
-          <Text wrap="truncate-end">
-            {renderTerminalCells(terminalLineCells(terminal, row), terminal.highlights, row, terminal.cursor.row, terminal.cursor.column, focused, maxWidth)}
-          </Text>
-        </Box>
-      ))}
+      <RawAnsi lines={terminalLines} width={maxWidth} />
       {terminal.messages.map((message, index) => (
         <Box key={`message-${index}`} height={1}>
           <Text color="warning" wrap="truncate-end">{truncateByWidth(message, maxWidth)}</Text>
@@ -76,6 +71,25 @@ export function NeovimGridView({
         </Box>
       ) : null}
     </>
+  );
+}
+
+export function terminalAnsiLines(
+  terminal: NeovimRenderSnapshot,
+  focused: boolean,
+  width: number,
+): string[] {
+  const maxWidth = Math.max(1, width);
+  return terminal.lines.map((_line, row) =>
+    renderTerminalCellsToAnsi(
+      terminalLineCells(terminal, row),
+      terminal.highlights,
+      row,
+      terminal.cursor.row,
+      terminal.cursor.column,
+      focused,
+      maxWidth,
+    ),
   );
 }
 
@@ -151,7 +165,7 @@ function renderCursorText(text: string, displayFrom: number, cursorOffset: numbe
   );
 }
 
-function renderTerminalCells(
+function renderTerminalCellsToAnsi(
   cells: readonly NeovimCell[],
   highlights: readonly NeovimHighlight[],
   row: number,
@@ -159,10 +173,11 @@ function renderTerminalCells(
   cursorColumn: number,
   focused: boolean,
   width: number,
-): React.ReactNode {
+): string {
   const highlightMap = new Map(highlights.map((highlight) => [highlight.id, highlight]));
-  const parts: React.ReactNode[] = [];
+  let output = "";
   let renderedWidth = 0;
+  let activeStyleKey = "";
   for (let column = 0; column < cells.length && renderedWidth < width; column += 1) {
     const cell = cells[column]!;
     if (cell.width === 0) continue;
@@ -170,13 +185,26 @@ function renderTerminalCells(
     const cursor = focused && row === cursorRow && column === cursorColumn;
     const text = cell.text.length > 0 ? cell.text : " ";
     const style = terminalTextStyle(highlightMap.get(cell.highlightId), cursor);
-    parts.push(renderTerminalCellText(text, style, `${column}:${cell.highlightId}:${cursor ? "cursor" : "text"}`));
+    const nextStyleKey = terminalTextStyleKey(style);
+    if (nextStyleKey !== activeStyleKey) {
+      if (activeStyleKey.length > 0) output += "\x1b[0m";
+      const nextAnsi = terminalTextStyleAnsi(style);
+      if (nextAnsi.length > 0) output += nextAnsi;
+      activeStyleKey = nextStyleKey;
+    }
+    output += text;
     renderedWidth += cell.width;
   }
   if (focused && row === cursorRow && cursorColumn >= cells.length && renderedWidth < width) {
-    parts.push(<Text key="cursor-end" inverse> </Text>);
+    if (activeStyleKey !== "inverse") {
+      if (activeStyleKey.length > 0) output += "\x1b[0m";
+      output += "\x1b[7m";
+      activeStyleKey = "inverse";
+    }
+    output += " ";
   }
-  return <>{parts}</>;
+  if (activeStyleKey.length > 0) output += "\x1b[0m";
+  return output;
 }
 
 type TerminalTextStyle = {
@@ -188,28 +216,6 @@ type TerminalTextStyle = {
   readonly strikethrough?: boolean;
   readonly inverse?: boolean;
 };
-
-function renderTerminalCellText(
-  text: string,
-  style: TerminalTextStyle,
-  key: string,
-): React.ReactNode {
-  if (!hasTerminalTextStyle(style)) return <React.Fragment key={key}>{text}</React.Fragment>;
-  return (
-    <Text
-      key={key}
-      color={style.color}
-      backgroundColor={style.backgroundColor}
-      bold={style.bold}
-      italic={style.italic}
-      underline={style.underline}
-      strikethrough={style.strikethrough}
-      inverse={style.inverse}
-    >
-      {text}
-    </Text>
-  );
-}
 
 function terminalTextStyle(
   highlight: NeovimHighlight | undefined,
@@ -228,16 +234,6 @@ function terminalTextStyle(
   return style;
 }
 
-function hasTerminalTextStyle(style: TerminalTextStyle): boolean {
-  return style.color !== undefined ||
-    style.backgroundColor !== undefined ||
-    style.bold === true ||
-    style.italic === true ||
-    style.underline === true ||
-    style.strikethrough === true ||
-    style.inverse === true;
-}
-
 function rgbNumberToHex(value: NeovimHighlight["attributes"][string]): Color | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   const rgb = Math.max(0, Math.min(0xFFFFFF, Math.floor(value)));
@@ -245,6 +241,49 @@ function rgbNumberToHex(value: NeovimHighlight["attributes"][string]): Color | u
   const green = (rgb >> 8) & 0xFF;
   const blue = rgb & 0xFF;
   return `#${hexByte(red)}${hexByte(green)}${hexByte(blue)}` as Color;
+}
+
+function rgbNumberToSgr(value: Color | undefined, mode: 38 | 48): string | null {
+  if (!value?.startsWith("#") || value.length !== 7) return null;
+  const red = Number.parseInt(value.slice(1, 3), 16);
+  const green = Number.parseInt(value.slice(3, 5), 16);
+  const blue = Number.parseInt(value.slice(5, 7), 16);
+  if (![red, green, blue].every(Number.isFinite)) return null;
+  return `${mode};2;${red};${green};${blue}`;
+}
+
+function terminalTextStyleAnsi(style: TerminalTextStyle): string {
+  const codes: string[] = [];
+  const foreground = rgbNumberToSgr(style.color, 38);
+  const background = rgbNumberToSgr(style.backgroundColor, 48);
+  if (foreground) codes.push(foreground);
+  if (background) codes.push(background);
+  if (style.bold === true) codes.push("1");
+  if (style.italic === true) codes.push("3");
+  if (style.underline === true) codes.push("4");
+  if (style.strikethrough === true) codes.push("9");
+  if (style.inverse === true) codes.push("7");
+  return codes.length > 0 ? `\x1b[${codes.join(";")}m` : "";
+}
+
+function terminalTextStyleKey(style: TerminalTextStyle): string {
+  const hasStyle = style.color !== undefined ||
+    style.backgroundColor !== undefined ||
+    style.bold === true ||
+    style.italic === true ||
+    style.underline === true ||
+    style.strikethrough === true ||
+    style.inverse === true;
+  if (!hasStyle) return "";
+  return [
+    style.color ?? "",
+    style.backgroundColor ?? "",
+    style.bold === true ? "b" : "",
+    style.italic === true ? "i" : "",
+    style.underline === true ? "u" : "",
+    style.strikethrough === true ? "s" : "",
+    style.inverse === true ? "inverse" : "",
+  ].join("|");
 }
 
 function hexByte(value: number): string {

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -1,5 +1,6 @@
 import { PassThrough } from 'node:stream'
 
+import chalk from 'chalk'
 import React from 'react'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -267,6 +268,51 @@ describe('Ink instance rendering paths', () => {
       harness.stdout.end()
       harness.stderr.end()
       await sleep(25)
+    }
+  })
+
+  test('repaints same-text rows when only text style changes', async () => {
+    const harness = await createHarness({ columns: 20, rows: 5 })
+    const previousChalkLevel = chalk.level
+    chalk.level = 3
+
+    try {
+      harness.root.render(
+        React.createElement(
+          'ink-text',
+          {
+            style: RAW_TEXT_STYLE,
+            textStyles: {},
+          },
+          'alpha',
+        ),
+      )
+      await sleep(25)
+      expect(harness.stdoutWrites.join('')).toContain('alpha')
+
+      harness.stdoutWrites.length = 0
+      harness.root.render(
+        React.createElement(
+          'ink-text',
+          {
+            style: RAW_TEXT_STYLE,
+            textStyles: { inverse: true },
+          },
+          'alpha',
+        ),
+      )
+      await sleep(25)
+      expect(requireElement(harness.stdout, 'ink-text').textStyles).toEqual({
+        inverse: true,
+      })
+      expect(cellAt(harness.instance.frontFrame.screen, 0, 0)?.styleId).not.toBe(0)
+
+      const writes = harness.stdoutWrites.join('')
+      expect(writes).toContain('\x1b[7m')
+      expect(writes).toContain('alpha')
+    } finally {
+      chalk.level = previousChalkLevel
+      await harness.dispose()
     }
   })
 

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -8,12 +8,14 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     const missingFallback = await readFile("scripts/check-tui-e2e/scenarios/121-workbench-buffer-neovim-missing-fallback.mjs", "utf8");
     const killCleanup = await readFile("scripts/check-tui-e2e/scenarios/122-workbench-buffer-neovim-kill-cleanup.mjs", "utf8");
     const runtimeExit = await readFile("scripts/check-tui-e2e/scenarios/123-workbench-buffer-neovim-runtime-exit.mjs", "utf8");
+    const visualRender = await readFile("scripts/check-tui-e2e/scenarios/124-workbench-buffer-neovim-visual-render.mjs", "utf8");
     const helpers = await readFile("scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs", "utf8");
     const wrapper = await readFile("scripts/check-tui-workbench-buffer-neovim.mjs", "utf8");
     const visualSmoke = await readFile("scripts/check-tui-workbench-visual-smoke.mjs", "utf8");
 
     expect(scenario).toContain("AGENC_TUI_WORKBENCH");
     expect(scenario).toContain("AGENC_BUFFER_PROVIDER");
+    expect(scenario).toContain("AGENC_BUFFER_NVIM_USE_INIT");
     expect(scenario).toContain("AGENC_OAUTH_TOKEN");
     expect(missingFallback).toContain("AGENC_OAUTH_TOKEN");
     expect(killCleanup).toContain("AGENC_OAUTH_TOKEN");
@@ -27,7 +29,8 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(scenario).toContain("RESIZE_MARK_AFTER");
     expect(scenario).toContain("resize-cursor.txt");
     expect(scenario).toContain("DIRTY_MARK");
-    expect(scenario).toContain("search navigation did not visibly change");
+    expect(scenario).toContain("waitForStyledSearchPaint");
+    expect(scenario).toContain("dirty quit closed embedded Neovim");
     expect(scenario).toContain("force quit wrote dirty text");
     expect(scenario).toContain("workspaceSnapshot");
     expect(scenario).toContain("term.resize");
@@ -42,6 +45,10 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(runtimeExit).toContain("normal-mode movement keys modified the file");
     expect(runtimeExit).toContain("Workbench transcript after embedded Neovim :q!");
     expect(runtimeExit).toContain("Workbench stayed on BUFFER after embedded Neovim :q!");
+    expect(visualRender).toContain("visible selection highlight");
+    expect(visualRender).toContain("visualChunk");
+    expect(visualRender).toContain("full-screen clear/flicker");
+    expect(visualRender).toContain("alpha beta gamma");
     expect(helpers).toContain("listDescendantNeovimPids");
     expect(helpers).toContain("waitForPidsGone");
     expect(helpers).toContain("waitForFrameText");

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -7,6 +7,7 @@ import { encode } from "@msgpack/msgpack";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { discoverNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimDiscovery.js";
+import type { NeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
 import { dirtyFlagFromRpcNotificationParams, EmbeddedNeovimSession, startEmbeddedNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
 import { cleanupTrackedNeovimProcesses, getTrackedNeovimProcessCountForTesting, killNeovimChild, normalizeNeovimPid, runTrackedNeovimProcessExitCleanupForTesting, spawnNeovimProcess, waitForNeovimExit } from "../../../src/tui/workbench/buffer/neovim/NeovimProcess.js";
 
@@ -299,7 +300,7 @@ describe("embedded Neovim lifecycle", () => {
       line: 1,
       column: 0,
       cwd: dir,
-      size: { rows: 8, columns: 40 },
+      size: { rows: 21, columns: 116 },
       onSnapshot: (snapshot) => {
         snapshots.push([...snapshot.lines]);
       },
@@ -333,6 +334,52 @@ describe("embedded Neovim lifecycle", () => {
     expect(snapshots.length).toBeGreaterThan(0);
     expect(await readFile(filePath, "utf8")).not.toContain("more");
     expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it("reports visible grid highlight cells for visual selections", async () => {
+    const discovery = await discoverNeovim({ timeoutMs: 1000, useUserInit: false });
+    if (!discovery.usable) {
+      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
+      return;
+    }
+    const filePath = join(dir, "target.txt");
+    await writeFile(filePath, "alpha beta gamma\nsecond line\n", "utf8");
+    const snapshots: NeovimRenderSnapshot[] = [];
+
+    const session = await startEmbeddedNeovim({
+      executable: discovery.executable,
+      args: discovery.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 8, columns: 40 },
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+      onError: (error) => {
+        throw error;
+      },
+      onExit: () => {},
+    });
+
+    try {
+      await session.input("gg0");
+      await waitForSnapshot(snapshots, (snapshot) => snapshot.cursor.row === 0 && snapshot.cursor.column === 0);
+      await session.input("v$");
+      const visual = await waitForSnapshot(snapshots, (snapshot) => snapshot.mode.startsWith("visual"));
+      const highlightsById = new Map(visual.highlights.map((highlight) => [highlight.id, highlight.attributes]));
+      const selectedCells = visual.cells[0]?.filter((cell) => {
+        const attributes = highlightsById.get(cell.highlightId);
+        return attributes?.reverse === true || typeof attributes?.background === "number";
+      }) ?? [];
+
+      expect(visual.lines[0]).toContain("alpha beta gamma");
+      expect(selectedCells.length).toBeGreaterThan(0);
+    } finally {
+      await session.quit(true);
+      await session.cleanup();
+    }
   });
 });
 
@@ -384,4 +431,19 @@ async function waitUntilDead(pid: number): Promise<void> {
   while (Date.now() < deadline && isProcessAlive(pid)) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
+}
+
+async function waitForSnapshot<T>(
+  snapshots: readonly T[],
+  predicate: (snapshot: T) => boolean,
+): Promise<T> {
+  const deadline = Date.now() + 1500;
+  let last = snapshots.at(-1);
+  while (Date.now() < deadline) {
+    const match = snapshots.findLast(predicate);
+    if (match) return match;
+    last = snapshots.at(-1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for embedded Neovim snapshot; last=${JSON.stringify(last)}`);
 }

--- a/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
@@ -40,7 +40,7 @@ import { Box, Text } from "../../../src/tui/ink.js";
 import { nodeCache } from "../../../src/tui/ink/node-cache.js";
 import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
 import { createNeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
-import { BufferLine, NeovimGridView, truncateByWidth } from "../../../src/tui/workbench/buffer/render.js";
+import { BufferLine, NeovimGridView, terminalAnsiLines, truncateByWidth } from "../../../src/tui/workbench/buffer/render.js";
 import {
   getWorkbenchBufferProviderController,
   resetWorkbenchBufferProviderControllerForTesting,
@@ -133,6 +133,30 @@ describe("BUFFER workbench rendering", () => {
     expect(output).toContain("\x1B[38;2;255;95;135m");
     expect(output).toContain("\x1B[38;2;95;215;255m");
     expect(output).toContain("const");
+  });
+
+  it("serializes Neovim visual selections into styled terminal rows", () => {
+    const text = "alpha beta gamma";
+    const terminal = {
+      ...createNeovimRenderSnapshot(1, 24),
+      lines: [text],
+      cells: [[...text].map((cellText, index) => ({
+        text: cellText,
+        width: 1,
+        highlightId: index < "alpha beta".length ? 9 : 0,
+      }))],
+      highlights: [
+        { id: 9, attributes: { reverse: true } },
+      ],
+      mode: "visual",
+    };
+
+    const renderedLine = terminalAnsiLines(terminal, true, 24)[0] ?? "";
+
+    expect(renderedLine).toContain("\x1B[7m");
+    expect(renderedLine).toContain("alpha beta");
+    expect(renderedLine.indexOf("\x1B[7m")).toBeLessThan(renderedLine.indexOf("alpha"));
+    expect(renderedLine).toContain("\x1B[0m gamma");
   });
 
   it("renders inline buffer cursor and selection boundary cases", async () => {


### PR DESCRIPTION
## Summary
- Render embedded Neovim grid rows through RawAnsi so style-only cell changes repaint visible rows.
- Add built-PTY coverage for visual selection repaint and no full-screen clear/flicker.
- Harden embedded-Neovim Workbench PTY assertions around styled search repaint and workspace rail snapshots.

## Test plan
- npx vitest run tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx tests/tui/workbench/buffer-neovim-e2e-contract.test.ts tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts tests/tui/ink/ink.render.test.tsx --reporter=dot
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 124-workbench-buffer-neovim-visual-render
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 120-workbench-buffer-neovim
- npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-buffer-neovim
- npm run typecheck
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core --full