### PR TITLE
fix(tui): confirm autocomplete with enter

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2201,12 +2201,10 @@ function PromptInput({
     }
   }, [addNotification, onImagePaste]);
 
-  // Register chat:submit handler directly in the handler registry (not via
-  // useKeybindings) so that only the ChordInterceptor can invoke it for chord
-  // completions (e.g., "ctrl+e s"). The default Enter binding for submit is
-  // handled by TextInput directly (via onSubmit prop) and useTypeahead (for
-  // autocomplete acceptance). Using useKeybindings would cause
-  // stopImmediatePropagation on Enter, blocking autocomplete from seeing the key.
+  // Register chat:submit with the shared handler registry instead of a local
+  // useKeybindings hook. The top-level chord interceptor owns normal submit
+  // routing, while Autocomplete's higher-priority Enter binding owns suggestion
+  // confirmation whenever the picker is active.
   const keybindingContext = useOptionalKeybindingContext();
   useEffect(() => {
     if (!keybindingContext || !promptKeyboardActive) return;

--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -1483,6 +1483,11 @@ export function useTypeahead({
     void handleTab();
   }, [handleTab]);
 
+  // Handler for autocomplete:confirm - confirms the highlighted suggestion via Enter.
+  const handleAutocompleteConfirm = useCallback(() => {
+    handleEnter();
+  }, [handleEnter]);
+
   // Handler for autocomplete:dismiss - clears suggestions and prevents re-triggering
   const handleAutocompleteDismiss = useCallback(() => {
     debouncedFetchFileSuggestions.cancel();
@@ -1519,10 +1524,11 @@ export function useTypeahead({
   // Autocomplete context keybindings - only active when suggestions are visible
   const autocompleteHandlers = useMemo(() => ({
     'autocomplete:accept': handleAutocompleteAccept,
+    'autocomplete:confirm': handleAutocompleteConfirm,
     'autocomplete:dismiss': handleAutocompleteDismiss,
     'autocomplete:previous': handleAutocompletePrevious,
     'autocomplete:next': handleAutocompleteNext
-  }), [handleAutocompleteAccept, handleAutocompleteDismiss, handleAutocompletePrevious, handleAutocompleteNext]);
+  }), [handleAutocompleteAccept, handleAutocompleteConfirm, handleAutocompleteDismiss, handleAutocompletePrevious, handleAutocompleteNext]);
 
   // Register autocomplete as an overlay so CancelRequestHandler defers ESC handling
   // This ensures ESC dismisses autocomplete before canceling running tasks

--- a/runtime/src/tui/keybindings/defaultBindings.ts
+++ b/runtime/src/tui/keybindings/defaultBindings.ts
@@ -97,6 +97,7 @@ export const DEFAULT_BINDINGS: KeybindingBlock[] = [
     context: 'Autocomplete',
     bindings: {
       tab: 'autocomplete:accept',
+      enter: 'autocomplete:confirm',
       escape: 'autocomplete:dismiss',
       up: 'autocomplete:previous',
       down: 'autocomplete:next',

--- a/runtime/src/tui/keybindings/types.ts
+++ b/runtime/src/tui/keybindings/types.ts
@@ -57,6 +57,7 @@ export const KEYBINDING_ACTION_NAMES = [
   'chat:imagePaste',
   'chat:messageActions',
   'autocomplete:accept',
+  'autocomplete:confirm',
   'autocomplete:dismiss',
   'autocomplete:previous',
   'autocomplete:next',

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -1889,6 +1889,36 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('autocomplete confirm keybinding applies file suggestions from an @ token', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'src/app.ts', displayText: 'src/app.ts', description: 'file' },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@sr',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestion',
+      )
+
+      harness.keybindings['autocomplete:confirm']?.()
+      expect(onInputChange).toHaveBeenCalledWith('@src/app.ts ')
+      expect(setCursorOffset).toHaveBeenCalledWith('@src/app.ts '.length)
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'cleared file suggestion',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('enter applies general path directory suggestions outside slash commands', async () => {
     harness.directorySuggestions = [
       {

--- a/runtime/tests/tui/keybindings/KeybindingProviderSetup.test.tsx
+++ b/runtime/tests/tui/keybindings/KeybindingProviderSetup.test.tsx
@@ -250,4 +250,19 @@ describe("KeybindingProviderSetup", () => {
       ),
     ).toEqual({ type: "match", action: "footer:openSelected" });
   });
+
+  test("resolves enter to autocomplete before chat submit while suggestions are active", () => {
+    const bindings = parseBindings(DEFAULT_BINDINGS);
+    const event = parseInputEvent("\r");
+
+    expect(
+      resolveKeyWithChordState(
+        event.input,
+        event.key,
+        ["Autocomplete", "Chat", "Global"],
+        bindings,
+        null,
+      ),
+    ).toEqual({ type: "match", action: "autocomplete:confirm" });
+  });
 });

--- a/runtime/tests/tui/keybindings/defaultBindings.test.ts
+++ b/runtime/tests/tui/keybindings/defaultBindings.test.ts
@@ -28,6 +28,11 @@ describe("default keybindings", () => {
       "ctrl+shift+c": "selection:copy",
       "cmd+c": "selection:copy",
     });
+
+    expect(bindingsFor("Autocomplete")).toMatchObject({
+      enter: "autocomplete:confirm",
+      tab: "autocomplete:accept",
+    });
   });
 
   test("enables user customization in AgenC without remote feature gates", () => {


### PR DESCRIPTION
## Summary
- Route bare Enter through the Autocomplete keybinding context while suggestions are visible.
- Add regression coverage for keybinding resolution and @ file suggestion confirmation.
- Refresh the nearby PromptInput comment to match the current routing model.

## Test Plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/keybindings/defaultBindings.test.ts tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/typeaheadKeyHandling.test.ts --reporter=dot
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check