### PR TITLE
fix(tui): ignore stale keybinding actions

### DIFF
--- a/runtime/src/tui/keybindings/loadUserBindings.ts
+++ b/runtime/src/tui/keybindings/loadUserBindings.ts
@@ -20,6 +20,7 @@ import { parseBindings } from './parser.js'
 import type { KeybindingBlock, ParsedBinding } from './types.js'
 import {
   checkDuplicateKeysInJson,
+  sanitizeBindingsForRuntime,
   type KeybindingWarning,
   validateBindings,
 } from './validate.js'
@@ -157,7 +158,8 @@ export async function loadKeybindings(): Promise<KeybindingsLoadResult> {
       }
     }
 
-    const userParsed = parseBindings(userBlocks)
+    const runtimeUserBlocks = sanitizeBindingsForRuntime(userBlocks)
+    const userParsed = parseBindings(runtimeUserBlocks)
     logForDebugging(
       `[keybindings] Loaded ${userParsed.length} user bindings from ${userPath}`,
     )
@@ -279,7 +281,8 @@ export function loadKeybindingsSyncWithWarnings(): KeybindingsLoadResult {
       return { bindings: cachedBindings, warnings: cachedWarnings }
     }
 
-    const userParsed = parseBindings(userBlocks)
+    const runtimeUserBlocks = sanitizeBindingsForRuntime(userBlocks)
+    const userParsed = parseBindings(runtimeUserBlocks)
     logForDebugging(
       `[keybindings] Loaded ${userParsed.length} user bindings from ${userPath}`,
     )

--- a/runtime/src/tui/keybindings/validate.ts
+++ b/runtime/src/tui/keybindings/validate.ts
@@ -9,7 +9,7 @@ import type {
   KeybindingContextName,
   ParsedBinding,
 } from './types.js'
-import { KEYBINDING_CONTEXT_NAMES } from './types.js'
+import { KEYBINDING_ACTION_NAMES, KEYBINDING_CONTEXT_NAMES } from './types.js'
 
 /**
  * Build a `${context}::${normalizedKey}` → action lookup for the runtime
@@ -88,12 +88,21 @@ function isKeybindingBlockArray(arr: unknown): arr is KeybindingBlock[] {
  */
 const VALID_CONTEXTS: readonly KeybindingContextName[] =
   KEYBINDING_CONTEXT_NAMES
+const VALID_ACTIONS = new Set<string>(KEYBINDING_ACTION_NAMES)
+const COMMAND_BINDING_RE = /^command:[a-zA-Z0-9:\-_]+$/
 
 /**
  * Type guard to check if a string is a valid context name.
  */
 function isValidContext(value: string): value is KeybindingContextName {
   return (VALID_CONTEXTS as readonly string[]).includes(value)
+}
+
+function isValidAction(value: unknown): value is string | null {
+  if (value === null) return true
+  if (typeof value !== 'string') return false
+  if (value.startsWith('command:')) return COMMAND_BINDING_RE.test(value)
+  return VALID_ACTIONS.has(value)
 }
 
 /**
@@ -206,7 +215,7 @@ function validateBlock(
       })
     } else if (typeof action === 'string' && action.startsWith('command:')) {
       // Validate command binding format
-      if (!/^command:[a-zA-Z0-9:\-_]+$/.test(action)) {
+      if (!COMMAND_BINDING_RE.test(action)) {
         warnings.push({
           type: 'invalid_action',
           severity: 'warning',
@@ -228,6 +237,16 @@ function validateBlock(
           suggestion: 'Move this binding to a block with "context": "Chat"',
         })
       }
+    } else if (typeof action === 'string' && !VALID_ACTIONS.has(action)) {
+      warnings.push({
+        type: 'invalid_action',
+        severity: 'error',
+        message: `Unknown action "${action}" for "${key}"`,
+        key,
+        context: contextName,
+        action,
+        suggestion: 'Remove this binding or replace it with a supported action from the default keybindings.',
+      })
     }
   }
 
@@ -315,6 +334,37 @@ export function validateUserConfig(userBlocks: unknown): KeybindingWarning[] {
   }
 
   return warnings
+}
+
+/**
+ * Drop structurally valid but runtime-unsafe entries before merging user
+ * bindings with defaults. Validation warnings are still reported from the
+ * original file, but unknown actions cannot shadow default handlers.
+ */
+export function sanitizeBindingsForRuntime(
+  userBlocks: KeybindingBlock[],
+): KeybindingBlock[] {
+  const sanitized: KeybindingBlock[] = []
+
+  for (const block of userBlocks) {
+    if (!isValidContext(block.context)) continue
+
+    const bindings: KeybindingBlock['bindings'] = {}
+    for (const [key, action] of Object.entries(block.bindings)) {
+      if (isValidAction(action)) {
+        bindings[key] = action
+      }
+    }
+
+    if (Object.keys(bindings).length > 0) {
+      sanitized.push({
+        context: block.context,
+        bindings,
+      })
+    }
+  }
+
+  return sanitized
 }
 
 /**

--- a/runtime/tests/tui/keybindings/loadUserBindings.test.ts
+++ b/runtime/tests/tui/keybindings/loadUserBindings.test.ts
@@ -38,6 +38,7 @@ import {
   resetKeybindingLoaderForTesting,
   subscribeToKeybindingChanges,
 } from './loadUserBindings.ts'
+import { resolveKey } from './resolver.ts'
 
 const originalConfigDir = process.env.AGENC_CONFIG_DIR
 const tempDirs: string[] = []
@@ -56,6 +57,31 @@ async function writeKeybindings(content: string): Promise<void> {
 
 function findAction(bindings: { action: string | null }[], action: string): boolean {
   return bindings.some(binding => binding.action === action)
+}
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    backspace: false,
+    ctrl: false,
+    delete: false,
+    downArrow: false,
+    end: false,
+    escape: false,
+    home: false,
+    leftArrow: false,
+    meta: false,
+    pageDown: false,
+    pageUp: false,
+    return: false,
+    rightArrow: false,
+    shift: false,
+    super: false,
+    tab: false,
+    upArrow: false,
+    wheelDown: false,
+    wheelUp: false,
+    ...overrides,
+  } as never
 }
 
 beforeEach(() => {
@@ -187,6 +213,76 @@ describe('loadUserBindings', () => {
         type: 'parse_error',
       }),
     ])
+  })
+
+  test('drops unknown user actions before they can shadow default handlers', async () => {
+    await createConfigDir()
+    await writeKeybindings(`{
+      "bindings": [
+        {
+          "context": "Autocomplete",
+          "bindings": {
+            "enter": "chat:acceptSuggestion"
+          }
+        },
+        {
+          "context": "Confirmation",
+          "bindings": {
+            "enter": "modal:confirm",
+            "escape": "modal:cancel"
+          }
+        },
+        {
+          "context": "Chat",
+          "bindings": {
+            "up": "history:prev",
+            "ctrl+y": "command:insert-template"
+          }
+        }
+      ]
+    }`)
+
+    const result = loadKeybindingsSyncWithWarnings()
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'chat:acceptSuggestion',
+          context: 'Autocomplete',
+          key: 'enter',
+          severity: 'error',
+          type: 'invalid_action',
+        }),
+        expect.objectContaining({
+          action: 'modal:confirm',
+          context: 'Confirmation',
+          key: 'enter',
+          severity: 'error',
+          type: 'invalid_action',
+        }),
+        expect.objectContaining({
+          action: 'history:prev',
+          context: 'Chat',
+          key: 'up',
+          severity: 'error',
+          type: 'invalid_action',
+        }),
+      ]),
+    )
+    expect(findAction(result.bindings, 'chat:acceptSuggestion')).toBe(false)
+    expect(findAction(result.bindings, 'modal:confirm')).toBe(false)
+    expect(findAction(result.bindings, 'history:prev')).toBe(false)
+    expect(findAction(result.bindings, 'command:insert-template')).toBe(true)
+
+    expect(
+      resolveKey('', key({ return: true }), ['Autocomplete', 'Chat', 'Global'], result.bindings),
+    ).toEqual({ type: 'match', action: 'autocomplete:confirm' })
+    expect(
+      resolveKey('', key({ return: true }), ['Confirmation', 'Chat', 'Global'], result.bindings),
+    ).toEqual({ type: 'match', action: 'confirm:yes' })
+    expect(
+      resolveKey('', key({ upArrow: true }), ['Chat', 'Global'], result.bindings),
+    ).toEqual({ type: 'match', action: 'history:previous' })
   })
 
   test('starts, emits, deletes, and disposes the keybinding watcher', async () => {

--- a/runtime/tests/tui/keybindings/validate.test.ts
+++ b/runtime/tests/tui/keybindings/validate.test.ts
@@ -65,6 +65,7 @@ describe("keybinding validation", () => {
           " ": "chat:submit",
           a: 42,
           b: "command:bad command",
+          c: "modal:confirm",
         },
       },
       {
@@ -97,6 +98,13 @@ describe("keybinding validation", () => {
           action: "command:bad command",
           key: "b",
           severity: "warning",
+          type: "invalid_action",
+        }),
+        expect.objectContaining({
+          action: "modal:confirm",
+          key: "c",
+          message: 'Unknown action "modal:confirm" for "c"',
+          severity: "error",
           type: "invalid_action",
         }),
         expect.objectContaining({


### PR DESCRIPTION
## Summary
- reject unknown keybinding action names with validation errors
- ignore invalid user keybinding actions at runtime so stale configs cannot shadow default handlers
- cover autocomplete Enter, confirmation Enter, and history Up fallback resolution with stale custom bindings

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/keybindings/loadUserBindings.test.ts tests/tui/keybindings/validate.test.ts tests/tui/keybindings/defaultBindings.test.ts tests/tui/keybindings/KeybindingProviderSetup.test.tsx --reporter=verbose
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-keybinding-action-guard
- live PTY repro: @PL Enter inserted @PLAN.md without submitting
- git diff --check
- npm run check:agent-surface-contract