### PR TITLE
fix(tui): support session approval shortcut

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -628,23 +628,21 @@ export class TuiSession {
   }
 
   /**
-   * Reject the permission overlay (No). Sends "3" then Enter, the
-   * documented one-shot reject path.
+   * Reject the permission overlay (No). Sends the documented numeric
+   * reject shortcut.
    */
   async denyPermissionOverlay() {
     this.term.write("3");
-    await sleep(80);
-    this.term.write("\r");
+    await sleep(120);
   }
 
   /**
-   * "Always allow" — accept and stop prompting for this tool/path. Sends
-   * "2" then Enter.
+   * "Always allow" for the current session. Sends the documented numeric
+   * session-approval shortcut.
    */
   async alwaysAllowPermissionOverlay() {
     this.term.write("2");
-    await sleep(80);
-    this.term.write("\r");
+    await sleep(120);
   }
 
   /**

--- a/runtime/scripts/check-tui-e2e/scenarios/31-permission-accept.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/31-permission-accept.mjs
@@ -2,11 +2,11 @@
  * Permission overlay accept scenario.
  *
  * Default mode (no --yolo). Submits a prompt that triggers Bash, accepts the
- * approval, then verifies the command actually ran by checking a marker file
- * in an isolated cwd. This avoids coupling the assertion to whether the
- * workbench diff surface or transcript currently owns the visible frame.
+ * approval, then verifies the command actually ran by checking the Bash stdout
+ * marker. This keeps the scenario scoped to tool approval rather than sandbox
+ * file-write policy.
  */
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -14,47 +14,13 @@ const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-permission-"));
 writeFileSync(path.join(slimCwd, "README.md"), "permission accept cwd\n", "utf8");
 
 const marker = "agenc-permission-accept-marker-3a9c";
-const markerFile = "permission-accept-output.txt";
-const markerPath = path.join(slimCwd, markerFile);
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const prompt = [
+  "Use the Bash tool to run exactly:",
+  `printf '%s\\n' ${shellQuote(marker)}`,
+].join(" ");
 
 function shellQuote(value) {
   return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-async function waitForMarkerFile({ timeout = 60_000 } = {}) {
-  const started = Date.now();
-  while (Date.now() - started < timeout) {
-    if (existsSync(markerPath)) {
-      const text = readFileSync(markerPath, "utf8");
-      if (text.includes(marker)) return true;
-    }
-    await sleep(100);
-  }
-  return false;
-}
-
-async function acceptUntilMarkerFile(session, { timeout = 90_000 } = {}) {
-  const started = Date.now();
-  let approvals = 0;
-  let lastApprovalAt = 0;
-
-  while (Date.now() - started < timeout) {
-    if (await waitForMarkerFile({ timeout: 100 })) return;
-
-    const frame = session.text;
-    const approvalVisible =
-      /enter approve|NEEDS APPROVAL|pending low approval - y approve/i.test(frame);
-    const approvalSettled = Date.now() - lastApprovalAt > 1_000;
-    if (approvalVisible && approvalSettled && approvals < 6) {
-      await session.acceptPermissionOverlay();
-      approvals++;
-      lastApprovalAt = Date.now();
-    }
-
-    await sleep(150);
-  }
 }
 
 export const meta = {
@@ -67,15 +33,13 @@ export const meta = {
 export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
-  await session.type(
-    `Use the Bash tool to run exactly: printf '%s\\n' ${shellQuote(marker)} > ${shellQuote(markerFile)}`,
-  );
+  await session.type(prompt);
   await session.submit();
   await session.waitForPermissionOverlay({ timeout: 60_000 });
-  await acceptUntilMarkerFile(session, { timeout: 90_000 });
-  if (await waitForMarkerFile({ timeout: 100 })) {
-    await session.waitForIdle({ timeout: 30_000 });
-    return;
-  }
-  throw new Error(`approved Bash command did not write marker file: ${markerPath}`);
+  await session.acceptPermissionOverlay();
+  await session.waitFor(new RegExp(marker), {
+    timeout: 90_000,
+    label: "approved Bash output",
+  });
+  await session.waitForIdle({ timeout: 30_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/33-permission-always.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/33-permission-always.mjs
@@ -15,33 +15,36 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-slim-"));
-writeFileSync(path.join(slimCwd, "README.md"), "test cwd\n", "utf8");
+const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-always-"));
+writeFileSync(path.join(slimCwd, "README.md"), "permission always cwd\n", "utf8");
+
+const marker = "agenc-permission-always-marker-bc42";
+const prompt = [
+  "Use the Bash tool to run exactly:",
+  `printf '%s\\n' ${shellQuote(marker)}`,
+].join(" ");
+
+function shellQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 export const meta = {
-  description: "Permission overlay (default mode): always-allow runs the tool.",
+  description: "Permission overlay (default mode): session approval runs the tool.",
   timeoutMs: 120_000,
   useTempHome: true,
   cwd: slimCwd,
-  // 31-permission-accept and 32-permission-deny verify the overlay
-  // path. 33's always-allow exercise needs the model to actually
-  // re-run the tool after the policy update, which has the same
-  // model-perf ceiling as the yolo-tool round-trips.
-  skip: "model perf ceiling on always-allow re-execution",
 };
 
 export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
-  await session.type(
-    "Use the Bash tool to run: echo agenc-permission-always-marker-bc42",
-  );
+  await session.type(prompt);
   await session.submit();
   await session.waitForPermissionOverlay({ timeout: 60_000 });
   await session.alwaysAllowPermissionOverlay();
-  // After always-allow, the TUI keeps repainting the busy title-bar OSC
-  // sequence while the model finishes its post-tool turn, which keeps the
-  // idle window from closing on a 1.2s default. Bump the window to 4s so
-  // the spinner-paint cadence registers as idle.
-  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.waitFor(new RegExp(marker), {
+    timeout: 90_000,
+    label: "session-approved Bash output",
+  });
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 30_000 });
 }

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1112,7 +1112,7 @@ export function ApprovalCard({
             </Box>
           </ThemedBox>
         ) : (
-          <ThemedText color="muted3">scope remember option · this session</ThemedText>
+          <ThemedText color="muted3">[1] approve once · [2] approve for session · [3] deny</ThemedText>
         )}
         <Box flexDirection="row" gap={2}>
           <ThemedBox borderStyle="single" borderColor={variantColor[variant]} paddingX={1}>

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -157,6 +157,12 @@ export function buildToolUseConfirm(
         permissionUpdates.length > 0 ? APPROVED_FOR_SESSION : APPROVED,
       );
     },
+    onAllowForSession(updatedInput: unknown) {
+      if (request.ctx.toolName === ASK_USER_QUESTION_TOOL_NAME) {
+        recordAskUserQuestionUpdatedInput(request.ctx.callId, updatedInput);
+      }
+      request.resolve(APPROVED_FOR_SESSION);
+    },
     onReject(feedback?: string) {
       if (request.ctx.toolName === ASK_USER_QUESTION_TOOL_NAME) {
         const action = planInterviewActionFromFeedback(feedback);
@@ -190,6 +196,7 @@ type ProjectedToolUseConfirm = NonNullable<ReturnType<typeof buildToolUseConfirm
     permissionUpdates?: readonly unknown[],
     feedback?: string,
   ): void;
+  onAllowForSession(updatedInput: unknown): void;
   onReject(feedback?: string): void;
   onAbort(): void;
 };
@@ -316,6 +323,10 @@ function AgenCApprovalOverlay({
   const approve = useCallback(() => {
     toolUseConfirm.onAllow(toolUseConfirm.input, []);
   }, [toolUseConfirm]);
+  const approveForSession = useCallback(() => {
+    if (destructive) return;
+    toolUseConfirm.onAllowForSession(toolUseConfirm.input);
+  }, [destructive, toolUseConfirm]);
   const reject = useCallback(() => {
     toolUseConfirm.onReject();
   }, [toolUseConfirm]);
@@ -333,6 +344,26 @@ function AgenCApprovalOverlay({
       "app:interrupt": abort,
     },
     { context: "Confirmation" },
+  );
+
+  useInput(
+    (input, _key, event) => {
+      if (input === "1") {
+        event.stopImmediatePropagation();
+        approve();
+        return;
+      }
+      if (input === "2") {
+        event.stopImmediatePropagation();
+        approveForSession();
+        return;
+      }
+      if (input === "3") {
+        event.stopImmediatePropagation();
+        reject();
+      }
+    },
+    { isActive: !destructive },
   );
 
   useInput(
@@ -381,7 +412,11 @@ function AgenCApprovalOverlay({
           { label: "confirmation", value: destructive ? `type ${requiredWord}` : "enter" },
         ]}
         note={toolUseConfirm.description}
-        confirmLabel={destructive ? `type '${requiredWord}' to approve` : "enter approve"}
+        confirmLabel={
+          destructive
+            ? `type '${requiredWord}' to approve`
+            : "enter approve · 2 session · 3 deny"
+        }
         requireTypedConfirmation={destructive}
         typedConfirmationValue={typed}
         typedConfirmationTarget={requiredWord}

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -5,7 +5,11 @@ import stripAnsi from "strip-ansi";
 import { describe, expect, test, vi } from "vitest";
 
 import type { ReviewDecision } from "../permissions/review-decision.js";
-import { APPROVED } from "../permissions/review-decision.js";
+import {
+  APPROVED,
+  APPROVED_FOR_SESSION,
+  DENIED,
+} from "../permissions/review-decision.js";
 import type { ApprovalCtx } from "../tools/orchestrator.js";
 import { createRoot } from "./ink.js";
 import type { PendingRequest } from "./permission-requests.js";
@@ -254,6 +258,64 @@ describe("permission request overlay coverage", () => {
       expect(compactFrame).toContain("rm-rf/tmp/agenc-danger");
       expect(compactFrame).toContain("type'delete'toapprove");
       expect(resolved).toEqual([]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("handles numeric low-risk approval shortcuts", async () => {
+    const sessionResolved: ReviewDecision[] = [];
+    const denyResolved: ReviewDecision[] = [];
+    const sessionRequest = createPendingRequest(
+      decision => {
+        sessionResolved.push(decision);
+      },
+      {
+        id: "request-session-pwd",
+        input: { command: "pwd" },
+        description: "Print working directory",
+      },
+    );
+    const denyRequest = createPendingRequest(
+      decision => {
+        denyResolved.push(decision);
+      },
+      {
+        id: "request-deny-pwd",
+        input: { command: "pwd" },
+        description: "Print working directory",
+      },
+    );
+    const tools = [{ name: "Bash" }];
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<AgenCPermissionOverlay request={sessionRequest} tools={tools} />);
+      await sleep();
+
+      expect(stripAnsi(extractLastFrame(output())).replace(/\s+/gu, "")).toContain(
+        "2session",
+      );
+      stdin.write("2");
+      await sleep();
+
+      expect(sessionResolved).toEqual([APPROVED_FOR_SESSION]);
+      expect(denyResolved).toEqual([]);
+
+      root.render(<AgenCPermissionOverlay request={denyRequest} tools={tools} />);
+      await sleep();
+      stdin.write("3");
+      await sleep();
+
+      expect(denyResolved).toEqual([DENIED]);
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- wire numeric permission shortcuts so 2 approves for the current session and 3 denies
- show the session approval choice in the approval overlay
- unskip the session approval E2E and decouple permission approval scenarios from sandbox file-write policy

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/permission-requests.coverage.test.tsx tests/tui/daemon-session.contract.test.ts -- --reporter=verbose
- npm run build --workspace=@tetsuo-ai/runtime
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 33-permission-always
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --range 31-35
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-permission-always-e2e
- git diff --check