### PR TITLE
test(tui): assert configured terminal title

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/52-status-line.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/52-status-line.mjs
@@ -1,24 +1,35 @@
 /**
- * Footer status line scenario.
+ * Terminal status scenario.
  *
  * The terminal title shows the configured provider/model on cold start.
  */
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+const EXPECTED_PROVIDER = "grok";
+const EXPECTED_MODEL = "grok-4.20-0309-non-reasoning";
+const EXPECTED_TITLE = `AgenC ${EXPECTED_PROVIDER}/${EXPECTED_MODEL}`;
+
 export const meta = {
   description: "Terminal title includes the configured model name.",
+  args: ["--provider", EXPECTED_PROVIDER, "--model", EXPECTED_MODEL],
   timeoutMs: 30_000,
 };
+
+function terminalTitles(raw) {
+  return Array.from(
+    raw.matchAll(/\x1b\](?:0|2);([\s\S]*?)(?:\x07|\x1b\\)/g),
+    (match) => match[1] ?? "",
+  );
+}
 
 export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await sleep(500);
-  // Configured model is qwen3.6-35b-a3b-fp8 — its short name appears in
-  // the OSC title, not necessarily in the latest rendered workbench frame.
-  if (!/qwen/i.test(session.plainText)) {
+  const titles = terminalTitles(session.raw);
+  if (!titles.some((title) => title.includes(EXPECTED_TITLE))) {
     throw new Error(
-      `terminal title doesn't mention configured model 'qwen'; captured: ${session.plainText.slice(-300)}`,
+      `terminal title doesn't mention configured provider/model '${EXPECTED_TITLE}'; titles: ${titles.join(" | ") || "(none)"}; latest frame: ${session.latestFrame.slice(-300)}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- make the status-line E2E scenario configure an explicit provider/model for the run
- assert the actual OSC terminal title instead of matching stale rendered text

## Test plan
- git diff --check
- npm run build --workspace=@tetsuo-ai/runtime
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 52-status-line
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run check:daemon-errors
- npm --workspace=@tetsuo-ai/runtime run check:llm-pipeline