### PR TITLE
test(tui): enable yolo bash coverage

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -23,7 +23,7 @@
  *     accumulate in the daemon. Phase B will introduce per-scenario
  *     temp-HOME isolation.
  */
-import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile, realpath } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -175,6 +175,52 @@ async function teardownTempHome(home) {
   } catch {
     // best-effort
   }
+}
+
+async function walkFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walkFiles(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function latestRolloutFilesForHome(home) {
+  const projectsDir = path.join(home, ".agenc", "projects");
+  let files = [];
+  try {
+    files = await walkFiles(projectsDir);
+  } catch {
+    return [];
+  }
+  const rolloutFiles = files.filter((file) => {
+    const basename = path.basename(file);
+    return basename.startsWith("rollout-") && basename.endsWith(".jsonl");
+  });
+  const withStats = await Promise.all(
+    rolloutFiles.map(async (file) => ({ file, mtimeMs: (await stat(file)).mtimeMs })),
+  );
+  return withStats
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .map((entry) => entry.file);
+}
+
+async function readRolloutItemsForHome(home) {
+  const files = await latestRolloutFilesForHome(home);
+  const items = [];
+  for (const file of files) {
+    const lines = (await readFile(file, "utf8")).split("\n").filter(Boolean);
+    for (const line of lines) {
+      items.push(JSON.parse(line));
+    }
+  }
+  return items;
 }
 
 // Same async-reply bytes the startup smoke injects. The TUI sends an
@@ -604,6 +650,36 @@ export class TuiSession {
    */
   async waitForPrompt(opts = {}) {
     return this.waitForIdle(opts);
+  }
+
+  /**
+   * Read rollout entries for this scenario's HOME. Temp-HOME scenarios use
+   * their isolated daemon state; default-HOME scenarios fall back to the
+   * operator's HOME, so callers should use unique markers.
+   */
+  async readRolloutItems() {
+    return readRolloutItemsForHome(this.tempHome ?? homedir());
+  }
+
+  /**
+   * Assert that a completed tool call recorded stdout/result containing a
+   * marker. This proves the tool actually ran without relying on the model
+   * to repeat stdout in the assistant's final message.
+   */
+  async assertRolloutToolOutput(marker, { label = "tool output" } = {}) {
+    const items = await this.readRolloutItems();
+    for (const item of items) {
+      const msg = item?.payload?.msg;
+      if (msg?.type !== "tool_call_completed") continue;
+      const payload = msg.payload ?? {};
+      const stdout =
+        typeof payload.metadata?.stdout === "string" ? payload.metadata.stdout : "";
+      const result = typeof payload.result === "string" ? payload.result : "";
+      if (payload.isError === false && (stdout.includes(marker) || result.includes(marker))) {
+        return;
+      }
+    }
+    throw new Error(`${label}: no completed rollout tool output contained "${marker}"`);
   }
 
   /**

--- a/runtime/scripts/check-tui-e2e/scenarios/10-yolo-tool-bash.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/10-yolo-tool-bash.mjs
@@ -6,19 +6,14 @@
  * appears in the captured buffer. This is the most-traveled tool path:
  * if Bash round-trip is broken, every multi-step task is broken.
  *
- * Note on flakiness: the model has to decide to call Bash. Qwen3 with the
- * explicit "use Bash" instruction reliably does so in our config; if a
- * future model change breaks that, this scenario gates the regression.
+ * Note on flakiness: the model has to decide to call Bash. The explicit
+ * "use Bash" instruction reliably does so in the current gate config; if
+ * a future model change breaks that, this scenario gates the regression.
  */
 export const meta = {
   description: "--yolo: model uses Bash, command output renders in transcript.",
   args: ["--yolo"],
   timeoutMs: 90_000,
-  // Same model-perf ceiling as 11/12/13. The bypass + Bash dispatch is
-  // verified end-to-end by check-llm-pipeline scenario 04-tool-call-shape,
-  // which exercises Bash via -p mode and inspects the rollout for
-  // tool_call_started / tool_call_completed evidence.
-  skip: "model perf ceiling on yolo + Bash; bypass+dispatch proven by LLM pipeline gate scenario 04",
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/31-permission-accept.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/31-permission-accept.mjs
@@ -2,9 +2,9 @@
  * Permission overlay accept scenario.
  *
  * Default mode (no --yolo). Submits a prompt that triggers Bash, accepts the
- * approval, then verifies the command actually ran by checking the Bash stdout
- * marker. This keeps the scenario scoped to tool approval rather than sandbox
- * file-write policy.
+ * approval, then verifies the command actually ran by checking the rollout's
+ * completed Bash stdout marker. This keeps the scenario scoped to tool
+ * approval rather than sandbox file-write policy or assistant echo behavior.
  */
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -37,9 +37,6 @@ export default async function (session) {
   await session.submit();
   await session.waitForPermissionOverlay({ timeout: 60_000 });
   await session.acceptPermissionOverlay();
-  await session.waitFor(new RegExp(marker), {
-    timeout: 90_000,
-    label: "approved Bash output",
-  });
-  await session.waitForIdle({ timeout: 30_000 });
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.assertRolloutToolOutput(marker, { label: "approved Bash output" });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/33-permission-always.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/33-permission-always.mjs
@@ -1,15 +1,19 @@
 /**
  * Permission overlay "always allow" scenario.
  *
- * Default mode. Triggers Bash, hits the overlay, sends "2\\r" to accept
- * + record "always allow for this tool/path". The harness uses temp
- * HOME isolation so the policy entry doesn't leak.
+ * Default mode. Triggers Bash, hits the overlay, sends "2" to accept
+ * for the current session. The harness uses temp HOME isolation so the
+ * session-scoped policy entry doesn't leak.
  *
  * Uses a SLIM cwd (mkdtemp under /tmp with a single trivial file) so
  * the daemon's project-context auto-load doesn't bloat the token
  * budget. With agenc-core's runtime/ as cwd, AGENC.md and surrounding
  * files pushed >237k tokens and starved compaction; in /tmp/<empty>
  * the budget fits comfortably.
+ *
+ * The assertion reads the temp HOME rollout so it proves Bash actually
+ * completed without depending on the model echoing stdout in its final
+ * assistant message.
  */
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -42,9 +46,6 @@ export default async function (session) {
   await session.submit();
   await session.waitForPermissionOverlay({ timeout: 60_000 });
   await session.alwaysAllowPermissionOverlay();
-  await session.waitFor(new RegExp(marker), {
-    timeout: 90_000,
-    label: "session-approved Bash output",
-  });
-  await session.waitForIdle({ idleWindow: 4_000, timeout: 30_000 });
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.assertRolloutToolOutput(marker, { label: "session-approved Bash output" });
 }


### PR DESCRIPTION
## Summary
- Unskip `10-yolo-tool-bash` so the yolo Bash path runs in the TUI E2E gate.
- Add rollout-output assertions to the harness so scenarios can prove Bash completed without depending on assistant final-message echo behavior.
- Update permission accept/always scenarios to verify completed Bash stdout from rollout records.

## Test plan
- [x] `git diff --check`
- [x] `npm run build --workspace=@tetsuo-ai/runtime`
- [x] `CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 10-yolo-tool-bash`
- [x] `CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --range 31-35`
- [x] `CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e`
- [x] `npm run check:agent-surface-contract`
- [x] `npm --workspace=@tetsuo-ai/runtime run check:daemon-errors`
- [x] `npm --workspace=@tetsuo-ai/runtime run check:llm-pipeline`