### PR TITLE
test(tui): enable yolo search tool coverage

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -571,6 +571,7 @@ export class TuiSession {
   async submit(text = "") {
     if (text) await this.type(text);
     await sleep(80);
+    this.mark();
     this.term.write("\r");
   }
 
@@ -666,12 +667,27 @@ export class TuiSession {
    * marker. This proves the tool actually ran without relying on the model
    * to repeat stdout in the assistant's final message.
    */
-  async assertRolloutToolOutput(marker, { label = "tool output" } = {}) {
+  async assertRolloutToolOutput(marker, { label = "tool output", toolName } = {}) {
     const items = await this.readRolloutItems();
+    const startedToolsByCallId = new Map();
     for (const item of items) {
       const msg = item?.payload?.msg;
+      if (msg?.type === "tool_call_started") {
+        const payload = msg.payload ?? {};
+        if (typeof payload.callId === "string" && typeof payload.toolName === "string") {
+          startedToolsByCallId.set(payload.callId, payload.toolName);
+        }
+        continue;
+      }
       if (msg?.type !== "tool_call_completed") continue;
       const payload = msg.payload ?? {};
+      const completedToolName =
+        typeof payload.toolName === "string"
+          ? payload.toolName
+          : typeof payload.callId === "string"
+            ? startedToolsByCallId.get(payload.callId)
+            : undefined;
+      if (toolName !== undefined && completedToolName !== toolName) continue;
       const stdout =
         typeof payload.metadata?.stdout === "string" ? payload.metadata.stdout : "";
       const result = typeof payload.result === "string" ? payload.result : "";
@@ -679,7 +695,8 @@ export class TuiSession {
         return;
       }
     }
-    throw new Error(`${label}: no completed rollout tool output contained "${marker}"`);
+    const suffix = toolName === undefined ? "" : ` for ${toolName}`;
+    throw new Error(`${label}: no completed rollout tool output${suffix} contained "${marker}"`);
   }
 
   /**

--- a/runtime/scripts/check-tui-e2e/scenarios/11-yolo-tool-read.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/11-yolo-tool-read.mjs
@@ -1,39 +1,35 @@
 /**
  * Yolo + Read tool round-trip.
  *
- * Asks the model to read a known small file via the Read tool and verifies
- * a unique substring of the file content appears in the transcript. We
- * point at /etc/hostname because it exists on every Linux dev machine and
- * the content is short and unique-enough to grep for.
+ * Asks the model to read a known small file inside the scenario workspace
+ * via the Read tool and verifies the completed rollout contains a unique
+ * substring of the file content. The assertion is on rollout tool output,
+ * not assistant echo behavior.
  */
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
 export const meta = {
-  description: "--yolo: model uses Read on /etc/hostname, content renders.",
+  description: "--yolo: model uses Read on workspace file, content is recorded.",
   args: ["--yolo"],
-  timeoutMs: 180_000,
+  timeoutMs: 90_000,
   slimCwd: true,
-  // Yolo permission bypass IS verified (the LLM pipeline gate's
-  // 03-yolo-sets-approvalPolicy-never proves this end-to-end via the
-  // rollout JSONL). The model just takes >150s to actually invoke
-  // FileRead and surface the content with the LMStudio + qwen3.6
-  // configuration. This isn't a TUI bug — it's a model-performance
-  // ceiling. Filed as GAP-TEST-MODEL-PERF for revisit when a faster
-  // model is the gate's deterministic provider (Phase B fake provider
-  // — GAP-TEST-13).
-  skip: "model perf ceiling on yolo + Read; bypass proven by LLM pipeline gate",
+  useTempHome: true,
 };
 
 export default async function (session) {
+  const marker = `agenc-read-e2e-${Date.now()}`;
+  const filePath = path.join(session.cwd, "read-target.txt");
+  await writeFile(filePath, `Read marker: ${marker}\n`, "utf8");
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.type(
-    "Use the Read tool to read /etc/hostname and tell me what it contains.",
+    `Use the Read tool to read ${filePath} and report the file contents.`,
   );
   await session.submit();
-  // The hostname appears in the captured buffer once Read returns.
-  // Test runs on tetsuo's machine; if hostname changes, this string changes.
-  await session.waitFor(/tetsuo-corporation/, {
-    timeout: 150_000,
-    label: "hostname content",
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.assertRolloutToolOutput(marker, {
+    label: "Read output",
+    toolName: "FileRead",
   });
-  await session.waitForIdle({ timeout: 30_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/12-yolo-tool-grep.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/12-yolo-tool-grep.mjs
@@ -1,30 +1,34 @@
 /**
  * Yolo + Grep tool round-trip.
  *
- * Asks the model to grep a unique pattern from /etc/os-release. The pattern
- * "PRETTY_NAME" appears in /etc/os-release on Ubuntu/Debian/Pop! variants;
- * we assert the matched line shows up in the transcript.
+ * Asks the model to grep a unique pattern from a file inside the scenario
+ * workspace and verifies the completed rollout contains the matched line.
+ * This avoids false positives from matching the typed prompt itself.
  */
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
 export const meta = {
-  description: "--yolo: model uses Grep, matched line renders in transcript.",
+  description: "--yolo: model uses Grep, matched line is recorded.",
   args: ["--yolo"],
-  timeoutMs: 180_000,
+  timeoutMs: 90_000,
   slimCwd: true,
-  // Same model-perf ceiling as 11 (and the bypass is verified by the
-  // LLM pipeline gate). See GAP-TEST-MODEL-PERF.
-  skip: "model perf ceiling on yolo + Grep; bypass proven by LLM pipeline gate",
+  useTempHome: true,
 };
 
 export default async function (session) {
+  const marker = `AGENC_GREP_E2E_${Date.now()}`;
+  const filePath = path.join(session.cwd, "grep-target.txt");
+  await writeFile(filePath, `alpha\n${marker}=present\nomega\n`, "utf8");
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.type(
-    "Use the Grep tool to search /etc/os-release for the pattern 'PRETTY_NAME'.",
+    `Use the Grep tool with output_mode "content" to search ${filePath} for the pattern '${marker}'.`,
   );
   await session.submit();
-  await session.waitFor(/PRETTY_NAME/, {
-    timeout: 150_000,
-    label: "grep match",
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.assertRolloutToolOutput(marker, {
+    label: "Grep output",
+    toolName: "Grep",
   });
-  await session.waitForIdle({ timeout: 30_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/13-yolo-tool-glob.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/13-yolo-tool-glob.mjs
@@ -1,28 +1,34 @@
 /**
  * Yolo + Glob tool round-trip.
  *
- * Asks the model to glob the agenc-core runtime/src/bin directory. The
- * file `agenc.ts` is guaranteed to exist there, so we assert its name
- * appears in the captured transcript.
+ * Asks the model to glob a file created inside the scenario workspace and
+ * verifies the completed rollout contains the filename. This keeps the
+ * scenario inside the tool allowlist instead of relying on repo paths
+ * outside the spawned cwd.
  */
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
 export const meta = {
-  description: "--yolo: model uses Glob, matched filename renders.",
+  description: "--yolo: model uses Glob, matched filename is recorded.",
   args: ["--yolo"],
-  timeoutMs: 180_000,
+  timeoutMs: 90_000,
   slimCwd: true,
-  skip: "model perf ceiling on yolo + Glob; bypass proven by LLM pipeline gate",
+  useTempHome: true,
 };
 
 export default async function (session) {
+  const fileName = `agenc-e2e-glob-${Date.now()}.ts`;
+  await writeFile(path.join(session.cwd, fileName), "export const marker = true;\n", "utf8");
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.type(
-    "Use the Glob tool to list TypeScript files under /home/tetsuo/git/AgenC/agenc-core/runtime/src/bin/ matching the pattern 'agenc*.ts'.",
+    `Use the Glob tool to list files in ${session.cwd} matching the pattern 'agenc-e2e-glob-*.ts'.`,
   );
   await session.submit();
-  await session.waitFor(/agenc\.ts/, {
-    timeout: 150_000,
-    label: "glob match",
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.assertRolloutToolOutput(fileName, {
+    label: "Glob output",
+    toolName: "Glob",
   });
-  await session.waitForIdle({ timeout: 30_000 });
 }


### PR DESCRIPTION
## Summary
- Unskip yolo `Read`, `Grep`, and `Glob` TUI E2E scenarios.
- Keep scenario fixtures inside the spawned workspace so search tools stay inside their allowed roots.
- Mark submit boundaries in the TUI harness so post-submit assertions cannot pass by matching the typed prompt.
- Let rollout assertions require the completed tool name as well as output markers.

## Test plan
- [x] `git diff --check`
- [x] `npm run build --workspace=@tetsuo-ai/runtime`
- [x] `CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --range 11-13`
- [x] `CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e`
- [x] `npm run check:agent-surface-contract`
- [x] `npm --workspace=@tetsuo-ai/runtime run check:daemon-errors`
- [x] `npm --workspace=@tetsuo-ai/runtime run check:llm-pipeline`