### PR TITLE
test(tui): enable yolo write edit coverage

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -700,6 +700,37 @@ export class TuiSession {
   }
 
   /**
+   * Assert that a tool completed successfully in rollout, even when its
+   * success payload does not include the file contents being verified.
+   */
+  async assertRolloutToolCompleted({ label = "tool completion", toolName } = {}) {
+    const items = await this.readRolloutItems();
+    const startedToolsByCallId = new Map();
+    for (const item of items) {
+      const msg = item?.payload?.msg;
+      if (msg?.type === "tool_call_started") {
+        const payload = msg.payload ?? {};
+        if (typeof payload.callId === "string" && typeof payload.toolName === "string") {
+          startedToolsByCallId.set(payload.callId, payload.toolName);
+        }
+        continue;
+      }
+      if (msg?.type !== "tool_call_completed") continue;
+      const payload = msg.payload ?? {};
+      const completedToolName =
+        typeof payload.toolName === "string"
+          ? payload.toolName
+          : typeof payload.callId === "string"
+            ? startedToolsByCallId.get(payload.callId)
+            : undefined;
+      if (toolName !== undefined && completedToolName !== toolName) continue;
+      if (payload.isError === false) return;
+    }
+    const suffix = toolName === undefined ? "" : ` for ${toolName}`;
+    throw new Error(`${label}: no successful rollout tool completion${suffix}`);
+  }
+
+  /**
    * Wait for the permission overlay to appear in the captured output. The
    * workbench approval card renders the current prompt as "needs approval"
    * / "enter approve" rather than the old numbered prompt copy.

--- a/runtime/scripts/check-tui-e2e/scenarios/34-yolo-tool-write.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/34-yolo-tool-write.mjs
@@ -1,50 +1,38 @@
 /**
  * Yolo + Write tool round-trip.
  *
- * Asks the model to write a unique marker into a /tmp file, then reads
- * the file back from disk to confirm Write ran. The file path is
- * randomized per run.
- *
- * Cleans up after itself: deletes the file even on test failure.
+ * Asks the model to write a unique marker into a workspace-local file,
+ * then reads the file back from disk to confirm Write ran.
  */
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
-
-const dir = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-write-"));
-const targetFile = path.join(dir, "marker.txt");
-const marker = "agenc-write-marker-" + Math.random().toString(36).slice(2, 10);
 
 export const meta = {
   description: "--yolo: model uses Write, file content verifiable on disk.",
   args: ["--yolo"],
-  timeoutMs: 240_000,
+  timeoutMs: 90_000,
   slimCwd: true,
-  skip: "model perf ceiling on yolo + Write; bypass proven by LLM pipeline gate",
+  useTempHome: true,
 };
 
 export default async function (session) {
-  try {
-    await session.start();
-    await session.waitForPrompt({ timeout: 15_000 });
-    await session.type(
-      `Use the Write tool to write the exact text "${marker}" to the file ${targetFile}`,
+  const marker = `agenc-write-marker-${Date.now()}`;
+  const targetFile = path.join(session.cwd, "write-target.txt");
+  await session.start();
+  await session.waitForPrompt({ timeout: 15_000 });
+  await session.type(
+    `Use the Write tool to write the exact text "${marker}" to the file ${targetFile}`,
+  );
+  await session.submit();
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 90_000 });
+  await session.assertRolloutToolCompleted({
+    label: "Write completion",
+    toolName: "Write",
+  });
+  const content = await readFile(targetFile, "utf8");
+  if (!content.includes(marker)) {
+    throw new Error(
+      `Write produced wrong content. expected to contain "${marker}", got: "${content.slice(0, 200)}"`,
     );
-    await session.submit();
-    await session.waitForIdle({ timeout: 200_000 });
-    // Verify the file was actually written with the expected content.
-    let content = "";
-    try {
-      content = readFileSync(targetFile, "utf8");
-    } catch (error) {
-      throw new Error(`Write did not produce ${targetFile}: ${error.message}`);
-    }
-    if (!content.includes(marker)) {
-      throw new Error(
-        `Write produced wrong content. expected to contain "${marker}", got: "${content.slice(0, 200)}"`,
-      );
-    }
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/35-yolo-tool-edit.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/35-yolo-tool-edit.mjs
@@ -1,43 +1,44 @@
 /**
  * Yolo + Edit tool round-trip.
  *
- * Pre-creates a /tmp file with a known string, asks the model to Edit it
- * by replacing one substring with another, then reads the file back.
+ * Pre-creates a workspace-local file with a known string, asks the model
+ * to Read and then Edit it, then reads the file back.
  */
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-
-const dir = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-edit-"));
-const targetFile = path.join(dir, "edit-target.txt");
-const oldStr = "agenc-edit-old-" + Math.random().toString(36).slice(2, 10);
-const newStr = "agenc-edit-new-" + Math.random().toString(36).slice(2, 10);
-writeFileSync(targetFile, `start ${oldStr} end\n`, "utf8");
 
 export const meta = {
   description: "--yolo: model uses Edit, file content updated on disk.",
   args: ["--yolo"],
-  timeoutMs: 240_000,
+  timeoutMs: 120_000,
   slimCwd: true,
-  skip: "model perf ceiling on yolo + Edit; bypass proven by LLM pipeline gate",
+  useTempHome: true,
 };
 
 export default async function (session) {
-  try {
-    await session.start();
-    await session.waitForPrompt({ timeout: 15_000 });
-    await session.type(
-      `Use the Edit tool to edit ${targetFile}, replacing "${oldStr}" with "${newStr}"`,
+  const oldStr = `agenc-edit-old-${Date.now()}`;
+  const newStr = `agenc-edit-new-${Date.now()}`;
+  const targetFile = path.join(session.cwd, "edit-target.txt");
+  await writeFile(targetFile, `start ${oldStr} end\n`, "utf8");
+  await session.start();
+  await session.waitForPrompt({ timeout: 15_000 });
+  await session.type(
+    `Use the Read tool to read ${targetFile}, then use the Edit tool to replace "${oldStr}" with "${newStr}".`,
+  );
+  await session.submit();
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 120_000 });
+  await session.assertRolloutToolCompleted({
+    label: "Edit preread completion",
+    toolName: "FileRead",
+  });
+  await session.assertRolloutToolCompleted({
+    label: "Edit completion",
+    toolName: "Edit",
+  });
+  const content = await readFile(targetFile, "utf8");
+  if (content.includes(oldStr) || !content.includes(newStr)) {
+    throw new Error(
+      `Edit did not apply: expected "${newStr}", got: "${content.slice(0, 200)}"`,
     );
-    await session.submit();
-    await session.waitForIdle({ timeout: 200_000 });
-    const content = readFileSync(targetFile, "utf8");
-    if (content.includes(oldStr) || !content.includes(newStr)) {
-      throw new Error(
-        `Edit did not apply: expected "${newStr}", got: "${content.slice(0, 200)}"`,
-      );
-    }
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary
- Enable the yolo Write/Edit TUI E2E scenarios by keeping their fixtures inside the spawned workspace.
- Add a rollout assertion for successful tool completion when the disk side effect is the content proof.
- Require Edit to follow the production Read-before-Edit path and verify the file mutation from disk.

## Test plan
- git diff --check
- npm run build --workspace=@tetsuo-ai/runtime
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --range 34-35
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run check:daemon-errors
- npm --workspace=@tetsuo-ai/runtime run check:llm-pipeline
