### PR TITLE
test(tui): enable yolo pipeline cwd coverage

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -662,14 +662,10 @@ export class TuiSession {
     return readRolloutItemsForHome(this.tempHome ?? homedir());
   }
 
-  /**
-   * Assert that a completed tool call recorded stdout/result containing a
-   * marker. This proves the tool actually ran without relying on the model
-   * to repeat stdout in the assistant's final message.
-   */
-  async assertRolloutToolOutput(marker, { label = "tool output", toolName } = {}) {
+  async completedRolloutToolCalls({ toolName } = {}) {
     const items = await this.readRolloutItems();
     const startedToolsByCallId = new Map();
+    const completed = [];
     for (const item of items) {
       const msg = item?.payload?.msg;
       if (msg?.type === "tool_call_started") {
@@ -688,6 +684,18 @@ export class TuiSession {
             ? startedToolsByCallId.get(payload.callId)
             : undefined;
       if (toolName !== undefined && completedToolName !== toolName) continue;
+      completed.push({ payload, toolName: completedToolName });
+    }
+    return completed;
+  }
+
+  /**
+   * Assert that a completed tool call recorded stdout/result containing a
+   * marker. This proves the tool actually ran without relying on the model
+   * to repeat stdout in the assistant's final message.
+   */
+  async assertRolloutToolOutput(marker, { label = "tool output", toolName } = {}) {
+    for (const { payload } of await this.completedRolloutToolCalls({ toolName })) {
       const stdout =
         typeof payload.metadata?.stdout === "string" ? payload.metadata.stdout : "";
       const result = typeof payload.result === "string" ? payload.result : "";
@@ -704,30 +712,38 @@ export class TuiSession {
    * success payload does not include the file contents being verified.
    */
   async assertRolloutToolCompleted({ label = "tool completion", toolName } = {}) {
-    const items = await this.readRolloutItems();
-    const startedToolsByCallId = new Map();
-    for (const item of items) {
-      const msg = item?.payload?.msg;
-      if (msg?.type === "tool_call_started") {
-        const payload = msg.payload ?? {};
-        if (typeof payload.callId === "string" && typeof payload.toolName === "string") {
-          startedToolsByCallId.set(payload.callId, payload.toolName);
-        }
-        continue;
-      }
-      if (msg?.type !== "tool_call_completed") continue;
-      const payload = msg.payload ?? {};
-      const completedToolName =
-        typeof payload.toolName === "string"
-          ? payload.toolName
-          : typeof payload.callId === "string"
-            ? startedToolsByCallId.get(payload.callId)
-            : undefined;
-      if (toolName !== undefined && completedToolName !== toolName) continue;
+    for (const { payload } of await this.completedRolloutToolCalls({ toolName })) {
       if (payload.isError === false) return;
     }
     const suffix = toolName === undefined ? "" : ` for ${toolName}`;
     throw new Error(`${label}: no successful rollout tool completion${suffix}`);
+  }
+
+  /**
+   * Assert that distinct completed tool calls produced the given markers in
+   * order. This proves a real multi-call pipeline instead of one combined
+   * command that happened to print multiple expected strings.
+   */
+  async assertRolloutToolOutputSequence(markers, { label = "tool output sequence", toolName } = {}) {
+    if (!Array.isArray(markers) || markers.length === 0) {
+      throw new Error(`${label}: expected at least one marker`);
+    }
+    let nextMarkerIndex = 0;
+    for (const { payload } of await this.completedRolloutToolCalls({ toolName })) {
+      if (payload.isError !== false) continue;
+      const stdout =
+        typeof payload.metadata?.stdout === "string" ? payload.metadata.stdout : "";
+      const result = typeof payload.result === "string" ? payload.result : "";
+      const marker = markers[nextMarkerIndex];
+      if (stdout.includes(marker) || result.includes(marker)) {
+        nextMarkerIndex += 1;
+        if (nextMarkerIndex === markers.length) return;
+      }
+    }
+    const suffix = toolName === undefined ? "" : ` for ${toolName}`;
+    throw new Error(
+      `${label}: matched ${nextMarkerIndex}/${markers.length} completed rollout tool outputs${suffix}`,
+    );
   }
 
   /**

--- a/runtime/scripts/check-tui-e2e/scenarios/42-yolo-multi-tool-pipeline.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/42-yolo-multi-tool-pipeline.mjs
@@ -9,28 +9,22 @@ export const meta = {
   description: "--yolo: model chains two Bash calls in a single turn.",
   args: ["--yolo"],
   timeoutMs: 120_000,
-  // The model (qwen3 via LMStudio) often only runs the first echo and
-  // narrates the second instead of actually invoking Bash for it. The
-  // chain pattern we need is provider/model-dependent and unstable in
-  // CI; either prompt-engineer harder or pin a more obedient model.
-  // Until then, skip.
-  skip: "model-dependent: chain not reliably triggered with current LMStudio config",
+  slimCwd: true,
+  useTempHome: true,
 };
 
 export default async function (session) {
+  const firstMarker = `agenc-pipeline-one-${Date.now()}`;
+  const secondMarker = `agenc-pipeline-two-${Date.now()}`;
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.type(
-    "Use the Bash tool twice: first run 'echo step-one-pipeline', then run 'echo step-two-pipeline'.",
+    `Use the Bash tool exactly twice. First run only: echo ${firstMarker}. Then run only: echo ${secondMarker}. Do not combine the commands.`,
   );
   await session.submit();
-  await session.waitFor(/step-one-pipeline/, {
-    timeout: 90_000,
-    label: "step one output",
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 120_000 });
+  await session.assertRolloutToolOutputSequence([firstMarker, secondMarker], {
+    label: "Bash pipeline outputs",
+    toolName: "exec_command",
   });
-  await session.waitFor(/step-two-pipeline/, {
-    timeout: 60_000,
-    label: "step two output",
-  });
-  await session.waitForIdle({ timeout: 30_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/44-yolo-cwd-context.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/44-yolo-cwd-context.mjs
@@ -17,15 +17,11 @@ const expectedCwd = path.resolve(SCRIPT_DIR, "..", "..", "..");
 export const meta = {
   description: "--yolo: model uses Bash pwd, output matches launch cwd.",
   args: ["--yolo"],
-  timeoutMs: 240_000,
+  timeoutMs: 120_000,
   // Intentionally NOT using slimCwd — this scenario tests cwd
   // propagation to subagent, so it MUST run with the runtime cwd that
   // matches the SCRIPT_DIR-derived expectedCwd assertion below.
-  // The full-cwd context (no slim) plus a 200s wait pushes this past the
-  // model perf ceiling. The cwd propagation path is verified by
-  // check-llm-pipeline scenario 03-yolo-sets-approvalPolicy-never which
-  // inspects the assembled rollout for sessionConfiguration.cwd.
-  skip: "model perf ceiling on yolo + full-cwd Bash; cwd propagation proven via daemon protocol shape",
+  useTempHome: true,
 };
 
 export default async function (session) {
@@ -35,9 +31,9 @@ export default async function (session) {
     "Use the Bash tool to run: pwd",
   );
   await session.submit();
-  await session.waitFor(new RegExp(expectedCwd.replace(/\//g, "\\/")), {
-    timeout: 200_000,
+  await session.waitForIdle({ idleWindow: 4_000, timeout: 120_000 });
+  await session.assertRolloutToolOutput(expectedCwd, {
     label: "pwd output matches launch cwd",
+    toolName: "exec_command",
   });
-  await session.waitForIdle({ timeout: 30_000 });
 }


### PR DESCRIPTION
## Summary
- Enable the remaining yolo multi-tool pipeline and cwd propagation TUI E2E scenarios.
- Replace fragile transcript matching with rollout-backed Bash output assertions.
- Add a sequence assertion that requires expected markers to come from distinct completed tool calls in order.

## Test plan
- git diff --check
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --range 42-44
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e
- npm run build --workspace=@tetsuo-ai/runtime
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run check:daemon-errors
- npm --workspace=@tetsuo-ai/runtime run check:llm-pipeline
