### PR TITLE
fix(tui): preserve buffer workspace roots

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -116,6 +116,7 @@ export type WorkbenchBufferStoreOptions = {
 };
 type BufferLoadOptions = {
   readonly preserveCurrentOnError?: boolean;
+  readonly basePath?: string;
 };
 type VimEditSession = {
   readonly context: TransitionContext;
@@ -137,6 +138,7 @@ export class WorkbenchBufferStore {
   #scrollLine = 0;
   #viewportRows = DEFAULT_VIEWPORT_ROWS;
   #openGeneration = 0;
+  #workspaceBasePath: string | null = null;
   #vimCommandLine: string | null = null;
   #vimState: VimState = { mode: "NORMAL", command: { type: "idle" } };
   #visualAnchor: number | null = null;
@@ -193,6 +195,7 @@ export class WorkbenchBufferStore {
     if (closedFile) safeNotifyBufferLsp(() => notifyBufferLspClosed(closedFile.absolutePath));
     this.#file = null;
     this.#document = null;
+    this.#workspaceBasePath = null;
     this.#status = "idle";
     this.#error = null;
     this.#conflictKind = null;
@@ -206,7 +209,9 @@ export class WorkbenchBufferStore {
   async revert(): Promise<void> {
     const file = this.#file;
     if (!file) return;
-    await this.#load(file.absolutePath, this.#position().line, true, file.filePath);
+    await this.#load(file.absolutePath, this.#position().line, true, file.filePath, {
+      basePath: this.#workspaceBasePath ?? getCwd(),
+    });
   }
 
   async save(options: { readonly hasInFlightAgent?: boolean; readonly force?: boolean } = {}): Promise<boolean> {
@@ -272,7 +277,9 @@ export class WorkbenchBufferStore {
       return false;
     }
 
-    return this.#load(file.absolutePath, line, true, file.filePath);
+    return this.#load(file.absolutePath, line, true, file.filePath, {
+      basePath: this.#workspaceBasePath ?? getCwd(),
+    });
   }
 
   insert(text: string): void {
@@ -407,6 +414,7 @@ export class WorkbenchBufferStore {
     });
     if (!target || this.#file !== file || this.#document !== document) return false;
     return this.#load(target.path, target.line, false, displayPathForAbsolute(target.path), {
+      basePath: this.#workspaceBasePath ?? getCwd(),
       preserveCurrentOnError: true,
     });
   }
@@ -423,7 +431,7 @@ export class WorkbenchBufferStore {
       this.#vimCommandLine = null;
       const command = parseVimCommand(rawCommand);
       if (!command) {
-        this.#setProblem("error", `Unsupported Vim command: :${rawCommand.trim()}`, null);
+        this.#setProblem("error", `Unknown Vim command: :${rawCommand.trim()}`, null);
         return true;
       }
       this.#emit();
@@ -782,8 +790,9 @@ export class WorkbenchBufferStore {
     options: BufferLoadOptions = {},
   ): Promise<boolean> {
     let absolutePath: string;
+    const basePath = options.basePath ?? getCwd();
     try {
-      absolutePath = resolveBufferFilePath(filePath);
+      absolutePath = resolveBufferFilePath(filePath, basePath);
     } catch (error) {
       this.#status = "error";
       this.#error = errorMessage(error);
@@ -813,6 +822,7 @@ export class WorkbenchBufferStore {
     const previousPath = this.#file?.absolutePath;
     const previousFile = this.#file;
     const previousDocument = this.#document;
+    const previousWorkspaceBasePath = this.#workspaceBasePath;
     const previousScrollLine = this.#scrollLine;
     const previousVimCommandLine = this.#vimCommandLine;
     const previousVimState = this.#vimState;
@@ -824,12 +834,14 @@ export class WorkbenchBufferStore {
     this.#hoverText = null;
     this.#file = null;
     this.#document = null;
+    this.#workspaceBasePath = null;
     this.#scrollLine = 0;
     this.#resetVimState();
     this.#emit();
 
     try {
       const snapshot = await readBufferFileSnapshot(absolutePath, {
+        basePath,
         displayPath,
       });
       if (generation !== this.#openGeneration) return false;
@@ -838,6 +850,7 @@ export class WorkbenchBufferStore {
       }
       this.#file = snapshot;
       this.#document = createBufferDocument(snapshot.content, line);
+      this.#workspaceBasePath = basePath;
       this.#resetVimState();
       this.#status = "ready";
       this.#error = null;
@@ -852,6 +865,7 @@ export class WorkbenchBufferStore {
       if (options.preserveCurrentOnError && previousFile && previousDocument) {
         this.#file = previousFile;
         this.#document = previousDocument;
+        this.#workspaceBasePath = previousWorkspaceBasePath;
         this.#scrollLine = previousScrollLine;
         this.#vimCommandLine = previousVimCommandLine;
         this.#vimState = previousVimState;

--- a/runtime/src/tui/workbench/buffer/fileSnapshot.ts
+++ b/runtime/src/tui/workbench/buffer/fileSnapshot.ts
@@ -128,9 +128,9 @@ function encodeText(content: string, snapshot: BufferFileSnapshot): string {
 
 export async function readBufferFileSnapshot(
   filePath: string,
-  options: { readonly maxBytes?: number; readonly displayPath?: string } = {},
+  options: { readonly maxBytes?: number; readonly displayPath?: string; readonly basePath?: string } = {},
 ): Promise<BufferFileSnapshot> {
-  const absolutePath = resolveBufferFilePath(filePath);
+  const absolutePath = resolveBufferFilePath(filePath, options.basePath);
   return readAbsoluteBufferFileSnapshot(absolutePath, options.displayPath ?? filePath, options.maxBytes);
 }
 

--- a/runtime/tests/onboarding/useApiKeyVerification.test.ts
+++ b/runtime/tests/onboarding/useApiKeyVerification.test.ts
@@ -83,6 +83,7 @@ describe("verifyApiKey", () => {
         provider: "openai-compatible",
         apiKey: "compatible-test-key",
         config: defaultConfig(),
+        env: { OPENAI_COMPATIBLE_BASE_URL: "http://127.0.0.1:8000/v1" },
         fetchImpl,
       }),
     ).resolves.toEqual({ status: "valid" });

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -122,7 +122,7 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getSnapshot().dirty).toBe(false);
   });
 
-  it("reports non-conflict save errors without clearing the dirty buffer", async () => {
+  it("reports disk save conflicts without clearing the dirty buffer", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\n", "utf8");
     const store = new WorkbenchBufferStore();
@@ -133,10 +133,10 @@ describe("WorkbenchBufferStore", () => {
 
     await expect(store.save()).resolves.toBe(false);
     expect(store.getSnapshot()).toMatchObject({
-      status: "error",
-      conflictKind: null,
+      status: "conflict",
+      conflictKind: "disk",
       dirty: true,
-      error: "target.txt appears to be binary and cannot be edited in BUFFER.",
+      error: "target.txt changed on disk after the buffer was opened. Revert or reopen before saving.",
     });
     expect(store.getText()).toBe("draft alpha\n");
   });
@@ -1202,7 +1202,9 @@ describe("WorkbenchBufferStore", () => {
     await writeFile(large, "too big", "utf8");
     await writeFile(binary, Buffer.from([0x61, 0x00, 0x62]));
 
-    await expect(readBufferFileSnapshot(large, { maxBytes: 3 })).rejects.toBeInstanceOf(BufferFileTooLargeError);
-    await expect(readBufferFileSnapshot(binary)).rejects.toBeInstanceOf(BufferBinaryFileError);
+    await runWithCwdOverride(dir, async () => {
+      await expect(readBufferFileSnapshot(large, { maxBytes: 3 })).rejects.toBeInstanceOf(BufferFileTooLargeError);
+      await expect(readBufferFileSnapshot(binary)).rejects.toBeInstanceOf(BufferBinaryFileError);
+    });
   });
 });

--- a/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
@@ -6,19 +6,27 @@ import {
   resetAllLSPDiagnosticState,
 } from "../../../src/services/lsp/LSPDiagnosticRegistry.js";
 import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import {
+  INLINE_BUFFER_CAPABILITIES,
+  type BufferProviderSnapshot,
+} from "../../../src/tui/workbench/buffer/providers/types.js";
 import { BufferSurface } from "../../../src/tui/workbench/surfaces/BufferSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
-type BufferSnapshot = ReturnType<typeof baseSnapshot>;
+type BufferSnapshot = BufferProviderSnapshot;
 type BufferStoreHarness = ReturnType<typeof createStoreHarness>;
-type CapturedInputHandler = (input: string, key: Record<string, unknown>) => void;
+type CapturedInputHandler = (input: string, key: Record<string, unknown>, event: InputCaptureEvent) => boolean;
+type InputCaptureEvent = {
+  readonly key: Record<string, unknown>;
+  readonly keypress: { readonly isPasted: boolean };
+};
 type VimCommand =
   | { readonly type: "save"; readonly force: boolean }
   | { readonly type: "quit"; readonly discard: boolean; readonly all: boolean }
   | { readonly type: "saveQuit"; readonly force: boolean; readonly all: boolean };
 
 const bufferHarness = vi.hoisted(() => ({
-  handlers: {} as Record<string, () => void>,
+  handlers: {} as Record<string, () => void | false | Promise<void>>,
   highlightBufferVisibleLines: vi.fn(),
   inputCapture: null as CapturedInputHandler | null,
   inputCaptureOptions: null as Record<string, unknown> | null,
@@ -44,7 +52,7 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   },
   useKeybinding: () => {},
   useKeybindings: (
-    handlers: Record<string, () => void>,
+    handlers: Record<string, () => void | false | Promise<void>>,
     options: Record<string, unknown>,
   ) => {
     bufferHarness.handlers = handlers;
@@ -52,8 +60,8 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   },
 }));
 
-vi.mock("../../../src/tui/workbench/buffer/BufferStore.js", () => ({
-  getWorkbenchBufferStore: () => bufferHarness.store,
+vi.mock("../../../src/tui/workbench/buffer/providers/BufferProviderController.js", () => ({
+  getWorkbenchBufferProviderController: () => bufferHarness.store,
 }));
 
 vi.mock("../../../src/tui/workbench/buffer/highlight.js", () => ({
@@ -77,7 +85,7 @@ describe("BufferSurface handlers", () => {
     expect(bufferHarness.keybindingOptions).toEqual({ context: "Buffer", isActive: true });
     expect(bufferHarness.inputCaptureOptions).toEqual({ context: "Buffer", isActive: true });
     expect(bufferHarness.store?.open).toHaveBeenCalledWith("target.ts", 1);
-    expect(bufferHarness.store?.setViewportRows).toHaveBeenCalledWith(3);
+    expect(bufferHarness.store?.resize).toHaveBeenCalledWith({ rows: 3, columns: 40 });
 
     bufferHarness.handlers["buffer:save"]?.();
     expect(bufferHarness.store?.save).toHaveBeenCalledWith({ hasInFlightAgent: true });
@@ -97,15 +105,15 @@ describe("BufferSurface handlers", () => {
     expect(bufferHarness.store?.goToDefinition).toHaveBeenCalledTimes(1);
 
     bufferHarness.store?.close.mockReturnValueOnce(false);
-    bufferHarness.handlers["buffer:close"]?.();
+    await bufferHarness.handlers["buffer:close"]?.();
     expect(changes).toHaveLength(0);
 
     bufferHarness.store?.close.mockReturnValueOnce(true);
-    bufferHarness.handlers["buffer:close"]?.();
+    await bufferHarness.handlers["buffer:close"]?.();
     expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
 
     bufferHarness.store?.close.mockReturnValueOnce(true);
-    bufferHarness.handlers["buffer:closeDiscard"]?.();
+    await bufferHarness.handlers["buffer:closeDiscard"]?.();
     expect(bufferHarness.store?.close).toHaveBeenLastCalledWith({ discard: true });
 
     bufferHarness.handlers["buffer:up"]?.();
@@ -150,12 +158,13 @@ describe("BufferSurface handlers", () => {
 
     await renderBufferSurface({ changes, columns: 24 });
 
-    bufferHarness.inputCapture?.(":", {});
-    expect(bufferHarness.store?.handleVimInput).toHaveBeenCalledWith(
+    bufferHarness.inputCapture?.(":", {}, inputEvent());
+    expect(bufferHarness.store?.handleInput).toHaveBeenCalledWith(
       ":",
       {},
-      20,
+      { columns: 20, rows: 3 },
       expect.any(Function),
+      false,
     );
 
     const execute = bufferHarness.vimCommandExecutor;
@@ -173,6 +182,7 @@ describe("BufferSurface handlers", () => {
 
     bufferHarness.store?.close.mockReturnValueOnce(true);
     execute?.({ type: "quit", discard: true, all: false });
+    await flushPromises();
     expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
     expect(bufferHarness.store?.close).toHaveBeenLastCalledWith({ discard: true });
 
@@ -206,7 +216,7 @@ describe("BufferSurface handlers", () => {
       status: "idle",
     });
 
-    const output = await renderBufferSurface({ activeFilePath: null });
+    const output = await renderBufferSurface({ activeFilePath: null, columns: 100 });
 
     expect(output).toContain("No file selected");
     expect(bufferHarness.store?.open).not.toHaveBeenCalled();
@@ -218,9 +228,9 @@ describe("BufferSurface handlers", () => {
       status: "loading",
     });
 
-    const output = await renderBufferSurface({ activeFilePath: null });
+    const output = await renderBufferSurface({ activeFilePath: null, columns: 100 });
 
-    expect(output).toContain("loading [normal, loading]");
+    expect(output).toContain("loading [basic inline BUFFER fallback, normal, loading]");
     expect(output).toContain("Loading...");
     expect(bufferHarness.store?.open).not.toHaveBeenCalled();
   });
@@ -278,7 +288,7 @@ describe("BufferSurface handlers", () => {
       },
     });
 
-    expect(output).toContain("target.ts [visual, ready, dirty, agent, utf8, LF] 2:4");
+    expect(output).toContain("target.ts [basic inline BUFFER fallback, visual, ready, dirty, agent, utf8, LF] 2:4");
     expect(output).toContain("2 diagnostics - current line");
     expect(output).toContain("agent edit in flight: target.ts");
     expect(output).toContain("hover details");
@@ -291,16 +301,16 @@ describe("BufferSurface handlers", () => {
       vimMode: "NORMAL",
     });
 
-    const commandOutput = await renderBufferSurface();
-    expect(commandOutput).toContain("target.ts [command, ready]");
+    const commandOutput = await renderBufferSurface({ columns: 100 });
+    expect(commandOutput).toContain("target.ts [basic inline BUFFER fallback, command, ready]");
     expect(commandOutput).toContain(":wq");
 
     bufferHarness.snapshot = baseSnapshot({
       vimMode: "INSERT",
     });
 
-    const insertOutput = await renderBufferSurface();
-    expect(insertOutput).toContain("target.ts [insert, ready]");
+    const insertOutput = await renderBufferSurface({ columns: 100 });
+    expect(insertOutput).toContain("target.ts [basic inline BUFFER fallback, insert, ready]");
     expect(insertOutput).toContain("INSERT  esc normal");
   });
 
@@ -388,20 +398,8 @@ function resetHarness(): void {
   bufferHarness.visibleLines = [{ number: 1, text: "const value = 1;", from: 0, to: 16 }];
 }
 
-function baseSnapshot(overrides: Partial<{
-  readonly absolutePath: string | null;
-  readonly dirty: boolean;
-  readonly encoding: "utf8" | "utf16le" | null;
-  readonly error: string | null;
-  readonly filePath: string | null;
-  readonly hoverText: string | null;
-  readonly lineEndings: "LF" | "CRLF" | null;
-  readonly position: { readonly line: number; readonly column: number; readonly offset: number };
-  readonly status: "idle" | "loading" | "ready" | "saving" | "error" | "conflict";
-  readonly viewportRows: number;
-  readonly vimCommandLine: string | null;
-  readonly vimMode: "NORMAL" | "INSERT" | "VISUAL";
-}> = {}) {
+function baseSnapshot(overrides: Partial<BufferProviderSnapshot> = {}): BufferProviderSnapshot {
+  const status = overrides.status ?? "ready";
   return {
     absolutePath: null,
     canRedo: false,
@@ -417,10 +415,19 @@ function baseSnapshot(overrides: Partial<{
     position: { line: 1, column: 0, offset: 0 },
     scrollLine: 0,
     selection: { anchor: 0, head: 0 },
-    status: "ready",
+    status,
     viewportRows: 1,
     vimCommandLine: null,
     vimMode: "NORMAL",
+    provider: {
+      kind: "inline",
+      label: "basic inline BUFFER fallback",
+      fallbackReason: null,
+      capabilities: INLINE_BUFFER_CAPABILITIES,
+    },
+    providerMessage: null,
+    providerStatus: status,
+    terminal: null,
     ...overrides,
   };
 }
@@ -428,15 +435,21 @@ function baseSnapshot(overrides: Partial<{
 function createStoreHarness() {
   return {
     close: vi.fn(() => true),
+    cleanup: vi.fn(async () => {}),
+    click: vi.fn(() => false),
+    focus: vi.fn(),
+    getSnapshot: vi.fn(() => bufferHarness.snapshot),
     getVisibleLines: vi.fn(() => bufferHarness.visibleLines),
     goToDefinition: vi.fn(),
-    handleVimInput: vi.fn((
+    handleInput: vi.fn((
       _input: string,
       _key: Record<string, unknown>,
-      _width: number,
+      _context: Record<string, unknown>,
       execute: (command: VimCommand) => void,
+      _isPasted: boolean,
     ) => {
       bufferHarness.vimCommandExecutor = execute;
+      return true;
     }),
     move: vi.fn(),
     open: vi.fn(async () => {}),
@@ -444,9 +457,16 @@ function createStoreHarness() {
     redo: vi.fn(),
     requestHover: vi.fn(),
     revert: vi.fn(),
+    resize: vi.fn(),
     save: vi.fn(async () => true),
-    setViewportRows: vi.fn(),
     undo: vi.fn(),
+  };
+}
+
+function inputEvent(): InputCaptureEvent {
+  return {
+    key: {},
+    keypress: { isPasted: false },
   };
 }
 


### PR DESCRIPTION
## Summary
- Preserve the validated workspace root for buffer reload, external-editor refresh, and definition navigation operations.
- Refresh buffer surface handler tests around the provider controller boundary.
- Pin the compatible-provider onboarding test to its configured endpoint.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/buffer-store.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/buffer-surface-handlers.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/onboarding/useApiKeyVerification.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface-handlers.test.tsx tests/onboarding/useApiKeyVerification.test.ts tests/bin/mcp-cli.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/buffer-file-safety.contract.test.ts tests/tui/workbench/buffer-provider-boundary.contract.test.ts tests/tui/workbench/buffer-fallback-inline.contract.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-agent-surface-next
- CI=1 npm --workspace=@tetsuo-ai/runtime run check:tui-e2e
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run check:llm-pipeline
- npm --workspace=@tetsuo-ai/runtime run check:daemon-errors