### PR TITLE
fix(runtime): track package binary shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ ter
 *.out
 build/
 bin/
+!runtime/bin/
+!runtime/bin/agenc
+!runtime/bin/agenc-linux-sandbox
 !runtime/src/bin/
 !runtime/src/bin/*.ts
 !packages/agenc/bin/

--- a/runtime/bin/agenc
+++ b/runtime/bin/agenc
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/bin/agenc.js";

--- a/runtime/bin/agenc-linux-sandbox
+++ b/runtime/bin/agenc-linux-sandbox
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/sandbox/linux-launcher/main.js";

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -51,7 +51,7 @@
     "test:coverage:tui": "vitest run tests/tui --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/**/*.{ts,tsx}' --coverage.exclude='src/**/*.d.ts' --coverage.reportsDirectory=coverage/runtime-tui",
     "test:transaction-guard": "vitest run tests/transaction-guard",
     "test:transaction-guard:live": "vitest run tests/transaction-guard/devnet-live.e2e.test.ts",
-    "validate:required": "npm run typecheck && npm run test && npm run check:tui-runtime-startup && npm run check:e2e-all",
+    "validate:required": "npm run typecheck && npm run test && npm run build && npm run check:tui-runtime-startup && npm run check:e2e-all",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- Track the runtime package binary shims so fresh worktrees include the advertised `agenc` and `agenc-linux-sandbox` package bin targets.
- Allow those runtime bin shims through the top-level `bin/` ignore rule.
- Build during `validate:required` before built-artifact startup and E2E gates run.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/sandbox/linux-launcher/linux-launcher.test.ts --reporter=verbose
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/mcp-cli.test.ts tests/sandbox/linux-launcher/linux-launcher.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run validate:required
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run test:tui-openclaude-core-parity
- npm --workspace=@tetsuo-ai/runtime run test:tui-yolo-openclaude-parity
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-agent-surface-scan --full