### PR TITLE
fix(runtime): stabilize diff and mcp stdio surfaces

### DIFF
--- a/runtime/src/mcp/server/start.ts
+++ b/runtime/src/mcp/server/start.ts
@@ -15,6 +15,13 @@ import { McpServerFramework } from "../../mcp-server/framework.js";
 import { McpHttpSseServerTransport } from "../../mcp-server/http-sse.js";
 import { McpStdioServerTransport } from "../../mcp-server/stdio.js";
 import { mcpToolRegistryFromAgenCTools } from "../../mcp-server/tools.js";
+import type {
+  McpCallToolResult,
+  McpToolCallContext,
+  McpToolCallParams,
+  McpToolDefinition,
+  McpToolProvider,
+} from "../../mcp-server/types.js";
 import {
   buildToolRegistry,
   type ToolRegistry,
@@ -103,7 +110,7 @@ export async function runMcpStdioServe(
   io: McpServerStartIo,
   options: McpServerStartOptions = {},
 ): Promise<void> {
-  const server = createMcpFramework(resolveToolRegistry(options));
+  const server = createMcpFramework(createLazyMcpToolProvider(options));
   await new Promise<void>((resolve, reject) => {
     const transport = new McpStdioServerTransport({
       input: io.stdin,
@@ -123,7 +130,8 @@ export async function startMcpSseServe(
   const registry = resolveToolRegistry(options);
   const host = normalizeMcpSseLoopbackHost(command.host);
   const transport = new McpHttpSseServerTransport({
-    serverFactory: () => createMcpFramework(registry),
+    serverFactory: () =>
+      createMcpFramework(mcpToolRegistryFromAgenCTools(registry)),
   });
   const server = transport.createNodeServer();
   await new Promise<void>((resolve, reject) => {
@@ -193,9 +201,30 @@ function resolveToolRegistry(options: McpServerStartOptions): ToolRegistry {
   });
 }
 
-function createMcpFramework(registry: ToolRegistry): McpServerFramework {
+function createLazyMcpToolProvider(
+  options: McpServerStartOptions,
+): McpToolProvider {
+  let provider: McpToolProvider | null = null;
+  const getProvider = (): McpToolProvider => {
+    provider ??= mcpToolRegistryFromAgenCTools(resolveToolRegistry(options));
+    return provider;
+  };
+  return {
+    listTools(): readonly McpToolDefinition[] {
+      return getProvider().listTools();
+    },
+    callTool(
+      params: McpToolCallParams,
+      context: McpToolCallContext,
+    ): Promise<McpCallToolResult> {
+      return getProvider().callTool(params, context);
+    },
+  };
+}
+
+function createMcpFramework(toolProvider: McpToolProvider): McpServerFramework {
   return new McpServerFramework({
     serverInfo: { version: VERSION },
-    toolProvider: mcpToolRegistryFromAgenCTools(registry),
+    toolProvider,
   });
 }

--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -91,10 +91,18 @@ export function DiffSurface({
     { context: "Surface", isActive: focused },
   );
 
-  if (loadError !== null) return <EmptySurface title="DIFF" message={`Unable to load diff: ${loadError}`} />;
-  if (snapshot === null) return <EmptySurface title="DIFF" message="Loading diff" />;
-  if (snapshot.state === "not-repo") return <EmptySurface title="DIFF" message="Not a git repository" />;
-  if (snapshot.state === "clean") return <EmptySurface title="DIFF" message="No working tree changes" />;
+  if (loadError !== null) {
+    return <EmptySurface title="DIFF" detail="git diff HEAD" message={`Unable to load diff: ${loadError}`} />;
+  }
+  if (snapshot === null) {
+    return <EmptySurface title="DIFF" detail="git diff HEAD" message="Loading diff" />;
+  }
+  if (snapshot.state === "not-repo") {
+    return <EmptySurface title="DIFF" detail="git diff HEAD" message="Not a git repository" />;
+  }
+  if (snapshot.state === "clean") {
+    return <EmptySurface title="DIFF" detail="git diff HEAD" message="No uncommitted changes" />;
+  }
 
   return (
     <DiffSurfaceView

--- a/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
@@ -190,13 +190,15 @@ export function SurfaceHeader({
 export function EmptySurface({
   title,
   message,
+  detail,
 }: {
   readonly title: string;
   readonly message: string;
+  readonly detail?: string;
 }): React.ReactElement {
   return (
     <Box flexDirection="column" width="100%" height="100%">
-      <SurfaceHeader title={title} />
+      <SurfaceHeader title={title} detail={detail} />
       <Text dimColor>{message}</Text>
     </Box>
   );

--- a/runtime/tests/bin/mcp-cli.test.ts
+++ b/runtime/tests/bin/mcp-cli.test.ts
@@ -370,6 +370,39 @@ describe("AgenC MCP CLI", () => {
     });
   });
 
+  test("exits stdio serve without materializing tools when stdin closes", async () => {
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+    const registry: ToolRegistry = {
+      get tools(): readonly Tool[] {
+        throw new Error("tool registry should not be materialized before MCP requests");
+      },
+      toLLMTools(): LLMTool[] {
+        throw new Error("tool registry should not be materialized before MCP requests");
+      },
+      async dispatch(): Promise<ToolDispatchResult> {
+        throw new Error("tool registry should not be materialized before MCP requests");
+      },
+    };
+
+    await expect(
+      runAgenCMcpCli(
+        {
+          kind: "serve",
+          transport: "stdio",
+          host: "127.0.0.1",
+          port: 3334,
+        },
+        {
+          io: createIo(Readable.from([]), stdout, stderr),
+          toolRegistry: registry,
+        },
+      ),
+    ).resolves.toBe(0);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toBe("");
+  });
+
   test("serves MCP over stdio", async () => {
     const input = new PassThrough();
     const output = new PassThrough();

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -328,7 +328,7 @@ describe("DiffSurface", () => {
 
   it.each([
     ["not-repo", createDiffMenuSnapshot({ rawDiff: "", nameStatus: "", numstat: "", untrackedFiles: [], notRepo: true }), "repository"],
-    ["clean", createDiffMenuSnapshot({ rawDiff: "", nameStatus: "", numstat: "", untrackedFiles: [] }), "treechanges"],
+    ["clean", createDiffMenuSnapshot({ rawDiff: "", nameStatus: "", numstat: "", untrackedFiles: [] }), "uncomm"],
   ])("renders %s diff snapshot states", async (_name, snapshot, expectedText) => {
     diffHarness.snapshot = snapshot;
     const { root, stdin, stdout, output } = await mountDiffSurface();
@@ -337,6 +337,7 @@ describe("DiffSurface", () => {
       await sleep();
 
       expect(compact(output())).toContain(expectedText);
+      expect(compact(output())).toContain("gitdiffHEAD");
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Keep `/diff` empty states visibly tied to `git diff HEAD` and use clearer clean-state text.
- Lazily materialize MCP stdio tools so closed/no-request stdio sessions exit without loading the full tool registry.
- Add regression coverage for diff empty-state markers and MCP stdio closed-input behavior.

## Verification
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/mcp-cli.test.ts tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-v2-design-audit`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-visual-smoke`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-agent-surface-diff --full`
- `npm --workspace=@tetsuo-ai/runtime run validate:required`
- `npm run check:agent-surface-contract`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:report`