### PR TITLE
fix(tui): normalize enter for resource picker

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/125-at-picker-line-feed-enter.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/125-at-picker-line-feed-enter.mjs
@@ -1,0 +1,38 @@
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForFrameText(session, pattern, label, timeout = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    if (pattern.test(session.latestFrame)) return;
+    await sleep(100);
+  }
+  throw new Error(`waitForFrameText(${label}): timeout after ${timeout}ms`);
+}
+
+export const meta = {
+  description: "@ files/resources picker accepts line-feed Enter.",
+  slimCwd: true,
+  timeoutMs: 45_000,
+  useTempHome: true,
+};
+
+export default async function (session) {
+  await session.start();
+  await session.waitForPrompt({ timeout: 15_000 });
+
+  await session.type("@", { perCharMs: 60 });
+  await session.waitFor(/FILES & RESOURCES/u, {
+    timeout: 15_000,
+    label: "files/resources picker",
+  });
+
+  session.send("\n");
+  await waitForFrameText(
+    session,
+    /❯\s*@README\.md/u,
+    "selected file mention inserted",
+  );
+
+  session.send("\x15");
+  await sleep(120);
+}

--- a/runtime/src/tui/hooks/typeaheadKeyHandling.ts
+++ b/runtime/src/tui/hooks/typeaheadKeyHandling.ts
@@ -11,7 +11,13 @@ export function consumeAutocompleteEnterKey(
   suggestionCount: number,
 ): boolean {
   if (suggestionCount === 0) return false
-  if (event.key !== 'return') return false
+  if (
+    event.key !== 'return' &&
+    event.key !== 'enter' &&
+    event.key !== 'Enter'
+  ) {
+    return false
+  }
   if (event.shift || event.meta) return false
 
   event.preventDefault()

--- a/runtime/src/tui/ink/events/input-event.ts
+++ b/runtime/src/tui/ink/events/input-event.ts
@@ -25,6 +25,7 @@ export type Key = {
 }
 
 function parseKey(keypress: ParsedKey): [Key, string] {
+  const isEnterKey = keypress.name === 'return' || keypress.name === 'enter'
   const key: Key = {
     upArrow: keypress.name === 'up',
     downArrow: keypress.name === 'down',
@@ -36,7 +37,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
     wheelDown: keypress.name === 'wheeldown',
     home: keypress.name === 'home',
     end: keypress.name === 'end',
-    return: keypress.name === 'return',
+    return: isEnterKey,
     escape: keypress.name === 'escape',
     fn: keypress.fn,
     ctrl: keypress.ctrl,

--- a/runtime/src/tui/ink/parse-keypress.ts
+++ b/runtime/src/tui/ink/parse-keypress.ts
@@ -448,6 +448,7 @@ export const nonAlphanumericKeys = [
   // via Kitty/modifyOtherKeys leaks the literal word "escape" as input text
   // (input-event.ts:58 assigns keypress.name when ctrl is set).
   'escape',
+  'enter',
   'backspace',
   'wheelup',
   'wheeldown',

--- a/runtime/tests/tui/hooks/typeaheadKeyHandling.test.ts
+++ b/runtime/tests/tui/hooks/typeaheadKeyHandling.test.ts
@@ -19,13 +19,16 @@ function makeEvent(
 }
 
 describe('consumeAutocompleteEnterKey', () => {
-  it('consumes bare Enter while suggestions are visible', () => {
-    const event = makeEvent()
+  it.each(['return', 'enter', 'Enter'])(
+    'consumes bare %s while suggestions are visible',
+    keyName => {
+      const event = makeEvent({ key: keyName })
 
-    expect(consumeAutocompleteEnterKey(event, 1)).toBe(true)
-    expect(event.preventDefault).toHaveBeenCalledOnce()
-    expect(event.stopImmediatePropagation).toHaveBeenCalledOnce()
-  })
+      expect(consumeAutocompleteEnterKey(event, 1)).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalledOnce()
+      expect(event.stopImmediatePropagation).toHaveBeenCalledOnce()
+    },
+  )
 
   it('leaves Enter alone when there is no active suggestion list', () => {
     const event = makeEvent()

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -1919,6 +1919,36 @@ describe('useTypeahead hook paths', () => {
     }
   })
 
+  test('line-feed enter applies file suggestions from an @ token', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'src/app.ts', displayText: 'src/app.ts', description: 'file' },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@sr',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestion',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('enter'))
+      expect(onInputChange).toHaveBeenCalledWith('@src/app.ts ')
+      expect(setCursorOffset).toHaveBeenCalledWith('@src/app.ts '.length)
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'cleared file suggestion',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('enter applies general path directory suggestions outside slash commands', async () => {
     harness.directorySuggestions = [
       {

--- a/runtime/tests/tui/ink/parse-keypress.test.ts
+++ b/runtime/tests/tui/ink/parse-keypress.test.ts
@@ -252,6 +252,9 @@ test('parses control, meta, printable, and navigation key variants', () => {
     expect.objectContaining({ name: 'return', raw: undefined }),
   )
   expect(parseKey('\n').name).toBe('enter')
+  const lineFeedEnter = parseInputEvent('\n')
+  expect(lineFeedEnter.input).toBe('')
+  expect(lineFeedEnter.key.return).toBe(true)
   expect(parseKey('\t').name).toBe('tab')
   expect(parseKey('\b').name).toBe('backspace')
   const [escapedBackspace] = parseMultipleKeypresses(INITIAL_STATE, '\x1b\b')


### PR DESCRIPTION
Summary
- Normalize CR and LF Enter into the same logical TUI Enter key.
- Consume LF-style Enter in autocomplete confirmation so @ file/resource picker selections insert correctly.
- Add unit, hook, and PTY E2E coverage for the @ picker line-feed Enter path.

Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/hooks/typeaheadKeyHandling.test.ts tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/ink/parse-keypress.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/ink/parse-keypress.test.ts tests/tui/ink/events.test.ts tests/tui/ink/events.runtime-coverage.test.ts tests/tui/hooks/typeaheadKeyHandling.test.ts tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/components/PromptInput/PromptInput.render.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- node runtime/scripts/check-tui-e2e/runner.mjs --filter 125-at-picker-line-feed-enter
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-at-picker-enter --full
- npm --workspace=@tetsuo-ai/runtime run check:unused:report