### PR TITLE
fix(cli): make mcp stdio route deterministic

### DIFF
--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -3178,6 +3178,34 @@ async function loadMcpCliConfig(): Promise<AgenCConfig | undefined> {
   }
 }
 
+export function shouldLoadMcpCliConfig(argv: readonly string[]): boolean {
+  if (argv[0] !== "mcp" || argv[1] !== "serve") return false;
+  const rest = argv.slice(2);
+  if (rest.length === 0) return true;
+
+  let explicitTransport: "stdio" | "sse" | null = null;
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i]!;
+    if (arg === "--help" || arg === "-h") return false;
+    if (arg === "--transport") {
+      const value = rest[i + 1];
+      if (value !== "stdio" && value !== "sse") return false;
+      explicitTransport = value;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--transport=")) {
+      const value = arg.slice("--transport=".length);
+      if (value !== "stdio" && value !== "sse") return false;
+      explicitTransport = value;
+      continue;
+    }
+    return false;
+  }
+
+  return explicitTransport === "sse";
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // main — Wave 5-B routing entrypoint
 // ─────────────────────────────────────────────────────────────────────
@@ -3242,7 +3270,9 @@ export async function main(): Promise<number> {
   if (authCommand !== null) {
     return runAgenCAuthCli(authCommand);
   }
-  const mcpConfig = argv[0] === "mcp" ? await loadMcpCliConfig() : undefined;
+  const mcpConfig = shouldLoadMcpCliConfig(argv)
+    ? await loadMcpCliConfig()
+    : undefined;
   const mcpCommand = parseAgenCMcpCliArgs(argv, mcpConfig);
   if (mcpCommand !== null) {
     return runAgenCMcpCli(mcpCommand);

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -42,6 +42,7 @@ import {
   resumeTUIEntry,
   runSingleTurn,
   sessionConfigurationFromAgenCConfig,
+  shouldLoadMcpCliConfig,
   validateAgencHome,
   type ConfigReloadLatch,
 } from "./agenc.js";
@@ -1426,6 +1427,45 @@ describe("runSingleTurn seam (R1 multi-turn future-proofing)", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("main() smoke", () => {
+  it("loads mcp serve config only when the route needs configured defaults", () => {
+    expect(shouldLoadMcpCliConfig(["mcp"])).toBe(false);
+    expect(shouldLoadMcpCliConfig(["mcp", "list"])).toBe(false);
+    expect(shouldLoadMcpCliConfig(["mcp", "serve", "--help"])).toBe(false);
+    expect(shouldLoadMcpCliConfig(["mcp", "serve"])).toBe(true);
+    expect(shouldLoadMcpCliConfig(["mcp", "serve", "--transport", "sse"])).toBe(
+      true,
+    );
+    expect(shouldLoadMcpCliConfig(["mcp", "serve", "--transport=sse"])).toBe(
+      true,
+    );
+    expect(
+      shouldLoadMcpCliConfig(["mcp", "serve", "--transport", "stdio"]),
+    ).toBe(false);
+    expect(shouldLoadMcpCliConfig(["mcp", "serve", "--transport=stdio"])).toBe(
+      false,
+    );
+    expect(
+      shouldLoadMcpCliConfig([
+        "mcp",
+        "serve",
+        "--transport",
+        "sse",
+        "--transport",
+        "stdio",
+      ]),
+    ).toBe(false);
+    expect(
+      shouldLoadMcpCliConfig([
+        "mcp",
+        "serve",
+        "--transport",
+        "sse",
+        "--bad-arg",
+      ]),
+    ).toBe(false);
+    expect(shouldLoadMcpCliConfig(["mcp", "serve", "--bad-arg"])).toBe(false);
+  });
+
   it("main() short-circuits --help before TUI/CLI routing", async () => {
     const prevArgv = [...process.argv];
     const stdoutSpy = vi

--- a/runtime/tests/bin/mcp-cli.test.ts
+++ b/runtime/tests/bin/mcp-cli.test.ts
@@ -34,6 +34,7 @@ const SAMPLE_TOOL: Tool = {
 };
 
 const RUNTIME_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const AGENC_MCP_STDIO_ROUTE_TIMEOUT_MS = 15_000;
 
 function request(id: number, method: string, params?: unknown) {
   return {
@@ -213,8 +214,16 @@ function runAgencMainForMcpServe(): Promise<{
     const timeout = setTimeout(() => {
       child.kill("SIGKILL");
       rmSync(loaderDir, { recursive: true, force: true });
-      reject(new Error("agenc mcp stdio route timed out"));
-    }, 5_000);
+      reject(
+        new Error(
+          [
+            `agenc mcp stdio route timed out after ${AGENC_MCP_STDIO_ROUTE_TIMEOUT_MS}ms`,
+            stdout.trim().length > 0 ? `stdout:\n${stdout}` : "stdout: <empty>",
+            stderr.trim().length > 0 ? `stderr:\n${stderr}` : "stderr: <empty>",
+          ].join("\n"),
+        ),
+      );
+    }, AGENC_MCP_STDIO_ROUTE_TIMEOUT_MS);
     child.once("error", (error) => {
       clearTimeout(timeout);
       rmSync(loaderDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Skip MCP config loading for explicit stdio serve routes and other MCP routes that do not need configured serve defaults.
- Preserve configured defaults for bare `agenc mcp serve` and explicit SSE serve routes.
- Add regression coverage and a more diagnostic stdio route timeout for full-suite contention.

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/agenc.test.ts tests/bin/mcp-cli.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime run validate:required`
- `npm run check:agent-surface-contract -- --command-timeout-ms 600000`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:report`
- `git diff --check`
