### PR TITLE
fix(tui): preserve agent rail navigation order

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -49,6 +49,10 @@
     {
       "path": "tui/src/multi_agents.rs",
       "sha256": "7de3107ec4c6d0085d34f3149e247be5edb847d40425ca703d9a7e890a4472a6"
+    },
+    {
+      "path": "tui/src/app/agent_navigation.rs",
+      "sha256": "a749009f8792c6a2363c4fa7d8b1ae8fc54cec81ddc0902df0ac655bf9647530"
     }
   ],
   "targetFiles": [
@@ -291,6 +295,7 @@
       "id": "tui-agent-workbench-e2e",
       "source": [
         "tui/src/multi_agents.rs",
+        "tui/src/app/agent_navigation.rs",
         "app-server/src/thread_status.rs",
         "core/src/agent/status.rs"
       ],
@@ -310,7 +315,8 @@
         "maps daemon agent lifecycle events into stable task rows and workbench rail entries",
         "survives late daemon completion messages after the main prompt has returned",
         "renders startup auth notices without throwing when provider credential helpers report no Anthropic or AgenC account key",
-        "keeps PTY startup, prompt visibility, idle detection, and crash detection covered by E2E scenarios"
+        "keeps PTY startup, prompt visibility, idle detection, and crash detection covered by E2E scenarios",
+        "preserves first-seen agent navigation order while keeping completed agents selectable"
       ],
       "edgeCases": [
         "a daemon completion message arriving after the prompt is visible does not crash the TUI",
@@ -319,7 +325,8 @@
         "startup status-notice filtering ignores throwing auth key lookups and keeps other notices renderable",
         "an agent with no transcript renders an empty state instead of throwing during surface selection",
         "a completed agent remains selectable in the rail after active streaming stops",
-        "rapid task-state synchronization batches keep row identity stable across running and completed statuses"
+        "rapid task-state synchronization batches keep row identity stable across running and completed statuses",
+        "agent rail next and previous navigation wraps through completed agents without resorting by status or start time"
       ],
       "tests": [
         "runtime/tests/tui/workbench/agent-surface.test.tsx",

--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -21,12 +21,12 @@ export function AgentsRail({
   const setAppState = useSetAppState();
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
-  const taskList = orderAgentTasks(Object.values(tasks ?? {}).filter((task: any) => task.type !== "local_bash"));
+  const taskList = useStableAgentTasks(Object.values(tasks ?? {}).filter((task: any) => task.type !== "local_bash"));
   const { activeTasks, backgroundTasks } = partitionAgentTasks(taskList);
   const { selectedId, selectedIndex, selectedTask } = resolveAgentSelection(taskList, workbench.selectedAgentTaskId);
   const selectByDelta = (delta: number) => {
     if (taskList.length === 0) return;
-    const next = Math.max(0, Math.min(taskList.length - 1, selectedIndex + delta));
+    const next = wrapIndex(selectedIndex + delta, taskList.length);
     dispatch({ type: "selectAgent", taskId: taskList[next].id });
   };
 
@@ -61,6 +61,19 @@ export function AgentsRail({
   );
 }
 
+function useStableAgentTasks(tasks: readonly any[]): readonly any[] {
+  const orderRef = React.useRef<readonly string[]>([]);
+  const ordered = React.useMemo(() => orderAgentTasks(tasks, orderRef.current), [tasks]);
+
+  React.useEffect(() => {
+    orderRef.current = ordered
+      .map((task: any) => taskIdOf(task))
+      .filter((id: string | null): id is string => id !== null);
+  }, [ordered]);
+
+  return ordered;
+}
+
 export function partitionAgentTasks(tasks: readonly any[]): {
   readonly activeTasks: readonly any[];
   readonly backgroundTasks: readonly any[];
@@ -71,8 +84,37 @@ export function partitionAgentTasks(tasks: readonly any[]): {
   };
 }
 
-export function orderAgentTasks(tasks: readonly any[]): readonly any[] {
-  return [...tasks].sort(compareAgentTasks);
+export function orderAgentTasks(
+  tasks: readonly any[],
+  previousOrder: readonly string[] = [],
+): readonly any[] {
+  const byId = new Map<string, any>();
+  const unkeyed: any[] = [];
+  for (const task of tasks) {
+    const id = taskIdOf(task);
+    if (id === null) {
+      unkeyed.push(task);
+    } else if (!byId.has(id)) {
+      byId.set(id, task);
+    }
+  }
+
+  const ordered: any[] = [];
+  const seen = new Set<string>();
+  for (const id of previousOrder) {
+    const task = byId.get(id);
+    if (!task) continue;
+    ordered.push(task);
+    seen.add(id);
+  }
+  for (const task of tasks) {
+    const id = taskIdOf(task);
+    if (id === null || seen.has(id)) continue;
+    ordered.push(task);
+    seen.add(id);
+  }
+
+  return [...ordered, ...unkeyed];
 }
 
 export function resolveAgentSelection(tasks: readonly any[], selectedId: string | null | undefined): {
@@ -94,11 +136,12 @@ export function resolveAgentSelection(tasks: readonly any[], selectedId: string 
   };
 }
 
-function compareAgentTasks(left: any, right: any): number {
-  const leftActive = isActiveTaskStatus(left?.status);
-  const rightActive = isActiveTaskStatus(right?.status);
-  if (leftActive !== rightActive) return leftActive ? -1 : 1;
-  return (right?.startTime ?? 0) - (left?.startTime ?? 0);
+function wrapIndex(index: number, length: number): number {
+  return ((index % length) + length) % length;
+}
+
+function taskIdOf(task: any): string | null {
+  return typeof task?.id === "string" ? task.id : null;
 }
 
 function isActiveTaskStatus(status: unknown): boolean {

--- a/runtime/tests/tui/workbench/agent-surface.test.tsx
+++ b/runtime/tests/tui/workbench/agent-surface.test.tsx
@@ -75,7 +75,7 @@ describe("AgentSurface", () => {
     keybindingHarness.tails = {};
   });
 
-  it("falls back to the running newest agent when the selected agent id is stale", async () => {
+  it("falls back to the first observed agent when the selected agent id is stale", async () => {
     const oldAgent = {
       id: "agent-old",
       type: "local_agent",
@@ -117,8 +117,8 @@ describe("AgentSurface", () => {
       100,
     );
 
-    expect(output).toContain("AGENT - running - new running agent");
-    expect(output).not.toContain("old completed agent");
+    expect(output).toContain("AGENT - completed - old completed agent");
+    expect(output).not.toContain("new running agent");
   });
 
   it("opens in-process teammate transcripts from the agent surface", async () => {

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -57,10 +57,10 @@ describe("AgentsRail", () => {
     expect(changes.at(-1)?.workbench.focusedPane).toBe("surface");
 
     keybindingHarness.handlers["agents:down"]?.();
-    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-old");
+    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-done");
 
     keybindingHarness.handlers["agents:up"]?.();
-    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-new");
+    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-old");
 
     keybindingHarness.handlers["agents:open"]?.();
     expect(changes.at(-1)?.workbench).toMatchObject({
@@ -73,6 +73,31 @@ describe("AgentsRail", () => {
     expect(changes.at(-1)?.tasks["agent-new"]).toMatchObject({
       status: "killed",
     });
+  });
+
+  it("wraps agent rail navigation across completed agents in first-seen order", async () => {
+    const runningOldest = agentTask("agent-old", "running", {
+      description: "old running agent",
+      startTime: 1_000,
+    });
+    const runningNewest = agentTask("agent-new", "running", {
+      description: "new running agent",
+      startTime: 2_000,
+    });
+    const completed = agentTask("agent-done", "completed", {
+      description: "done agent",
+      startTime: 3_000,
+    });
+    const { changes } = await renderAgentsRail({
+      tasks: [runningOldest, runningNewest, completed],
+      selectedAgentTaskId: "agent-old",
+    });
+
+    keybindingHarness.handlers["agents:up"]?.();
+    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-done");
+
+    keybindingHarness.handlers["agents:down"]?.();
+    expect(changes.at(-1)?.workbench.selectedAgentTaskId).toBe("agent-new");
   });
 
   it("ignores navigation, open, and stop keybindings when there is no selected task", async () => {
@@ -217,7 +242,7 @@ describe("AgentsRail", () => {
     });
   });
 
-  it("opens the running newest agent before older completed agents after stale selection", async () => {
+  it("opens the first observed agent after stale selection", async () => {
     const changes: AppState[] = [];
     const oldAgent = {
       id: "agent-old",
@@ -265,7 +290,7 @@ describe("AgentsRail", () => {
     expect(changes.at(-1)?.workbench).toMatchObject({
       activeSurfaceMode: "agent",
       focusedPane: "surface",
-      selectedAgentTaskId: "agent-new",
+      selectedAgentTaskId: "agent-old",
     });
   });
 });

--- a/runtime/tests/tui/workbench/agents.test.ts
+++ b/runtime/tests/tui/workbench/agents.test.ts
@@ -44,20 +44,20 @@ describe("workbench agents rail model", () => {
     });
   });
 
-  it("resolves stale agent selection to the active newest agent before completed tasks", () => {
+  it("resolves stale agent selection to the first observed agent", () => {
     const tasks = [
       { id: "agent-old", type: "local_agent", status: "completed", startTime: 1_000 },
       { id: "agent-new", type: "local_agent", status: "running", startTime: 2_000 },
     ];
 
     expect(resolveAgentSelection(tasks, "agent-gone")).toMatchObject({
-      selectedId: "agent-new",
+      selectedId: "agent-old",
       selectedIndex: 0,
-      selectedTask: tasks[1],
+      selectedTask: tasks[0],
     });
   });
 
-  it("orders active agents before background agents and sorts equal groups by newest start time", () => {
+  it("preserves first-seen agent order and appends newly observed agents", () => {
     const tasks = [
       { id: "completed-new", type: "local_agent", status: "completed", startTime: 3_000 },
       { id: "running-old", type: "local_agent", status: "running", startTime: 1_000 },
@@ -66,16 +66,28 @@ describe("workbench agents rail model", () => {
     ];
 
     expect(orderAgentTasks(tasks).map((task) => task.id)).toEqual([
+      "completed-new",
+      "running-old",
       "pending-new",
+      "failed-missing-start",
+    ]);
+
+    expect(orderAgentTasks(tasks, ["running-old", "completed-new"]).map((task) => task.id)).toEqual([
       "running-old",
       "completed-new",
+      "pending-new",
       "failed-missing-start",
     ]);
 
     expect(orderAgentTasks([
+      { id: "failed-gone", type: "local_agent", status: "failed" },
       { id: "failed-a", type: "local_agent", status: "failed" },
       { id: "failed-b", type: "local_agent", status: "failed" },
-    ]).map((task) => task.id)).toEqual(["failed-a", "failed-b"]);
+    ], ["failed-a", "failed-gone"]).map((task) => task.id)).toEqual([
+      "failed-a",
+      "failed-gone",
+      "failed-b",
+    ]);
   });
 
   it("formats elapsed runtime and extracts task paths", () => {


### PR DESCRIPTION
## Summary
- Preserve agent rail task order by first observation instead of resorting by active status or newest start time.
- Keep completed agents selectable and make rail up/down navigation wrap through the stable order.
- Add the missing codex agent navigation source to the agent-surface contract and cover the stable-order edge cases in workbench tests.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx tests/tui/workbench/agent-surface.test.tsx --reporter=dot
- npm run check:agent-surface-contract -- --command-timeout-ms 600000
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-agent-surface-deep-pass --full
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 125-at-picker-line-feed-enter
- npm --workspace=@tetsuo-ai/runtime run check:unused:report
- npm --workspace=@tetsuo-ai/runtime run validate:required
- git diff --check