### PR TITLE
fix(agents): align wait agent with mailbox updates

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -27,6 +27,18 @@
       "sha256": "5b8a9a570cafea31d6ab8e3a802b9cb38736122c90310dc1654aea9761cf30b7"
     },
     {
+      "path": "core/src/tools/handlers/multi_agents_common.rs",
+      "sha256": "13ce14269e9c2570b89533e824960b0863b02b7a49576a8b4fd7f3a6267e23e0"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_spec.rs",
+      "sha256": "dcd6a7abd9f6cec6821f9c03b3c7936cbc2845324196b3a368cc15fc08a1f5fd"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_v2/wait.rs",
+      "sha256": "4ddd23c93ccae17d9a3b0006d4b2675acc450196ca207bbc1db4c5c841707a46"
+    },
+    {
       "path": "core/src/codex_thread.rs",
       "sha256": "de69256771379d633216a30de68303c21c3fa307608b6aefb40802fc4c6dc81e"
     },
@@ -113,6 +125,7 @@
     "runtime/tests/tools/AgentTool/loadAgentsDir.test.ts",
     "runtime/tests/tools/tasks/task-tools.test.ts",
     "runtime/tests/commands/agent-management.test.tsx",
+    "runtime/tests/bin/model-facing-tools.test.ts",
     "runtime/tests/tui/workbench/agent-surface.test.tsx",
     "runtime/tests/tui/workbench/agents-rail.test.tsx",
     "runtime/tests/tui/workbench/agents.test.ts",
@@ -248,7 +261,10 @@
       "source": [
         "core/src/agent/control.rs",
         "core/src/agent/role.rs",
-        "core/src/thread_manager.rs"
+        "core/src/thread_manager.rs",
+        "core/src/tools/handlers/multi_agents_common.rs",
+        "core/src/tools/handlers/multi_agents_spec.rs",
+        "core/src/tools/handlers/multi_agents_v2/wait.rs"
       ],
       "target": [
         "runtime/src/tasks/agent-thread.ts",
@@ -270,10 +286,14 @@
         "forks parent context into child prompts with preserved tool-use placeholders and per-child instructions",
         "reports partial progress, final output, and failure state in task-compatible output records",
         "keeps background task lifecycle, agent lifecycle, and TUI task views synchronized from one authoritative state",
-        "applies role allowlists and tool policies before child tools execute"
+        "applies role allowlists and tool policies before child tools execute",
+        "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out"
       ],
       "edgeCases": [
-        "waiting for multiple agents returns completed agents and leaves active agents observable",
+        "wait_agent returns completed when any parent mailbox update arrives before the timeout",
+        "wait_agent returns timed_out when no parent mailbox update arrives before the timeout",
+        "wait_agent rejects timeout_ms below the configured minimum instead of silently clamping",
+        "wait_agent rejects removed v1 targets input as an unknown field",
         "closing a running agent interrupts it once and produces an idempotent terminal task status",
         "a fork containing multiple pending tool calls creates one placeholder result per call before child instructions",
         "an agent tool with a disallowed role fails before any child run is started",
@@ -284,10 +304,11 @@
         "runtime/tests/tasks/lifecycle.test.ts",
         "runtime/tests/tools/AgentTool/loadAgentsDir.test.ts",
         "runtime/tests/tools/tasks/task-tools.test.ts",
-        "runtime/tests/commands/agent-management.test.tsx"
+        "runtime/tests/commands/agent-management.test.tsx",
+        "runtime/tests/bin/model-facing-tools.test.ts"
       ],
       "commands": [
-        "npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx --reporter=dot"
+        "npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx tests/bin/model-facing-tools.test.ts --reporter=dot"
       ],
       "status": "required"
     },

--- a/runtime/src/agents/v2/wait.ts
+++ b/runtime/src/agents/v2/wait.ts
@@ -1,7 +1,4 @@
 import type { Tool, ToolResult } from "../../tools/types.js";
-import type { AgentStatus } from "../status.js";
-import { isFinal, toAgentStatusJson } from "../status.js";
-import type { AgentPath, ThreadId } from "../registry.js";
 import {
   callIdFromArgs,
   currentAgentContext,
@@ -12,9 +9,7 @@ import {
   MAX_WAIT_TIMEOUT_MS,
   MIN_WAIT_TIMEOUT_MS,
   numberValue,
-  resolveAgentId,
   strictArgs,
-  stringValue,
   toolMetadata,
   type MultiAgentV2Options,
 } from "./common.js";
@@ -26,134 +21,19 @@ function waitTimeoutMs(
   const sessionOrError = getSessionOrError(opts);
   if (!("conversationId" in sessionOrError)) return sessionOrError;
   const supplied = numberValue(args.timeout_ms);
-  if (supplied !== undefined && supplied <= 0) {
-    return json({ error: "timeout_ms must be greater than zero" }, true);
-  }
   const configuredMin = sessionOrError.config?.multiAgentV2?.minWaitTimeoutMs;
   const minTimeoutMs = Math.min(
     MAX_WAIT_TIMEOUT_MS,
     Math.max(1, configuredMin ?? MIN_WAIT_TIMEOUT_MS),
   );
-  return Math.min(
-    MAX_WAIT_TIMEOUT_MS,
-    Math.max(minTimeoutMs, supplied ?? DEFAULT_WAIT_TIMEOUT_MS),
-  );
-}
-
-interface WaitTarget {
-  readonly threadId: ThreadId;
-  readonly label: string;
-}
-
-interface StatusSubscription {
-  readonly value: AgentStatus;
-  readonly unsubscribe: () => void;
-}
-
-function parseTargets(args: Record<string, unknown>): ToolResult | string[] | undefined {
-  const raw = args.targets;
-  if (raw === undefined) return undefined;
-  if (!Array.isArray(raw)) {
-    return json({ error: "targets must be an array of strings" }, true);
+  const maxTimeoutMs = MAX_WAIT_TIMEOUT_MS;
+  if (supplied !== undefined && supplied < minTimeoutMs) {
+    return json({ error: `timeout_ms must be at least ${minTimeoutMs}` }, true);
   }
-  const targets = raw.map((target) => stringValue(target));
-  if (targets.some((target) => target === undefined)) {
-    return json({ error: "targets must be an array of non-empty strings" }, true);
+  if (supplied !== undefined && supplied > maxTimeoutMs) {
+    return json({ error: `timeout_ms must be at most ${maxTimeoutMs}` }, true);
   }
-  if (targets.length === 0) {
-    return json({ error: "targets must contain at least one agent" }, true);
-  }
-  return targets as string[];
-}
-
-function uniqueTargets(targets: readonly WaitTarget[]): WaitTarget[] {
-  const seen = new Set<string>();
-  const result: WaitTarget[] = [];
-  for (const target of targets) {
-    if (seen.has(target.threadId)) continue;
-    seen.add(target.threadId);
-    result.push(target);
-  }
-  return result;
-}
-
-async function waitForTargets(
-  control: {
-    subscribeStatus?: (threadId: ThreadId) => Promise<StatusSubscription>;
-    getStatus?: (threadId: ThreadId) => Promise<AgentStatus>;
-  },
-  targets: readonly WaitTarget[],
-  timeoutMs: number,
-): Promise<{
-  readonly timedOut: boolean;
-  readonly rawStatuses: Readonly<Record<string, AgentStatus>>;
-  readonly statuses: Readonly<Record<string, ReturnType<typeof toAgentStatusJson>>>;
-}> {
-  const subscriptions: Array<WaitTarget & { readonly subscription: StatusSubscription }> = [];
-  try {
-    for (const target of targets) {
-      const subscription =
-        typeof control.subscribeStatus === "function"
-          ? await control.subscribeStatus(target.threadId)
-          : {
-              value:
-                typeof control.getStatus === "function"
-                  ? await control.getStatus(target.threadId)
-                  : ({ status: "not_found" } as const),
-              unsubscribe: () => {},
-            };
-      subscriptions.push({ ...target, subscription });
-    }
-
-    const snapshot = (): Record<string, ReturnType<typeof toAgentStatusJson>> =>
-      Object.fromEntries(
-        subscriptions.map(({ label, subscription }) => [
-          label,
-          toAgentStatusJson(subscription.value),
-        ]),
-      );
-    const rawSnapshot = (): Record<string, AgentStatus> =>
-      Object.fromEntries(
-        subscriptions.map(({ label, subscription }) => [
-          label,
-          subscription.value,
-        ]),
-      );
-
-    const allFinal = (): boolean =>
-      subscriptions.every(({ subscription }) => isFinal(subscription.value));
-
-    if (allFinal()) {
-      return {
-        timedOut: false,
-        rawStatuses: rawSnapshot(),
-        statuses: snapshot(),
-      };
-    }
-
-    const timedOut = await new Promise<boolean>((resolve) => {
-      let timeout: ReturnType<typeof setTimeout>;
-      const interval = setInterval(() => {
-        if (allFinal()) {
-          clearInterval(interval);
-          clearTimeout(timeout);
-          resolve(false);
-        }
-      }, 100);
-      timeout = setTimeout(() => {
-        clearInterval(interval);
-        resolve(true);
-      }, timeoutMs);
-      interval.unref?.();
-      timeout.unref?.();
-    });
-
-    return { timedOut, rawStatuses: rawSnapshot(), statuses: snapshot() };
-  } finally {
-    for (const { subscription } of subscriptions) {
-      subscription.unsubscribe();
-    }
-  }
+  return supplied ?? DEFAULT_WAIT_TIMEOUT_MS;
 }
 
 export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
@@ -161,7 +41,7 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
     args: Record<string, unknown>,
   ): Promise<ToolResult> => {
     const strict = strictArgs(args, {
-      allowed: new Set(["timeout_ms", "targets"]),
+      allowed: new Set(["timeout_ms"]),
     });
     if (strict) return strict;
     if (
@@ -170,77 +50,24 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
     ) {
       return json({ error: "timeout_ms must be a number" }, true);
     }
-    const parsedTargets = parseTargets(args);
-    if (parsedTargets !== undefined && !Array.isArray(parsedTargets)) {
-      return parsedTargets;
-    }
     const sessionOrError = getSessionOrError(opts);
     if (!("conversationId" in sessionOrError)) return sessionOrError;
     const timeoutMs = waitTimeoutMs(args, opts);
     if (typeof timeoutMs !== "number") return timeoutMs;
     const current = currentAgentContext(sessionOrError, args, opts);
-    const { control } = opts.ensureAgentControl(sessionOrError);
-    let targets: WaitTarget[];
-    if (parsedTargets !== undefined) {
-      try {
-        targets = uniqueTargets(
-          parsedTargets.map((target) => ({
-            threadId: resolveAgentId(
-              sessionOrError,
-              target,
-              current.agentPath,
-              opts,
-            ),
-            label: target,
-          })),
-        );
-      } catch (error) {
-        return json(
-          { error: error instanceof Error ? error.message : String(error) },
-          true,
-        );
-      }
-    } else {
-      const listed = control.listAgents({
-        pathPrefix: current.agentPath as AgentPath,
-      }).filter((agent) => agent.agentName !== current.agentPath);
-      const active = listed.filter((agent) => !isFinal(agent.agentStatus));
-      const selected = active.length > 0 ? active : listed;
-      try {
-        targets = uniqueTargets(
-          selected.map((agent) => ({
-            threadId: resolveAgentId(
-              sessionOrError,
-              agent.agentName,
-              current.agentPath,
-              opts,
-            ),
-            label: agent.agentName,
-          })),
-        );
-      } catch (error) {
-        return json(
-          { error: error instanceof Error ? error.message : String(error) },
-          true,
-        );
-      }
-    }
     const waitCallId = callIdFromArgs(args, "wait");
     emit(sessionOrError, {
       type: "collab_waiting_begin",
       payload: {
         senderThreadId: current.threadId,
-        receiverThreadIds: targets.map((target) => target.threadId),
-        receiverAgents: targets.map((target) => ({ threadId: target.threadId })),
+        receiverThreadIds: [],
+        receiverAgents: [],
         callId: waitCallId,
       },
     });
-    let waitResult: Awaited<ReturnType<typeof waitForTargets>>;
+    let mailboxChanged = false;
     try {
-      waitResult =
-        targets.length > 0
-          ? await waitForTargets(control, targets, timeoutMs)
-          : { timedOut: false, rawStatuses: {}, statuses: {} };
+      mailboxChanged = await sessionOrError.waitForMailboxChange(timeoutMs);
     } catch (error) {
       emit(sessionOrError, {
         type: "collab_waiting_end",
@@ -256,37 +83,30 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
         true,
       );
     }
+    const timedOut = !mailboxChanged;
     emit(sessionOrError, {
       type: "collab_waiting_end",
       payload: {
         senderThreadId: current.threadId,
         callId: waitCallId,
-        statuses: waitResult.rawStatuses,
-        timedOut: waitResult.timedOut,
-        agentStatuses: targets.map((target) => ({
-          threadId: target.threadId,
-          status:
-            waitResult.rawStatuses[target.label] ??
-            ({ status: "not_found" } as const),
-        })),
+        statuses: {},
+        timedOut,
+        agentStatuses: [],
       },
     });
     return json({
-      message:
-        targets.length === 0
-          ? "No agents to wait for."
-          : waitResult.timedOut
-            ? "Wait call timed out; agents may still be running."
-            : "Wait completed.",
-      timed_out: waitResult.timedOut,
-      statuses: waitResult.statuses,
+      message: timedOut ? "Wait timed out." : "Wait completed.",
+      timed_out: timedOut,
     });
   };
 
   return {
     name: "wait_agent",
     description:
-      "Wait for spawned agents to reach a terminal status. When targets is omitted, waits for all currently active descendants of the current agent.",
+      "Wait for a mailbox update from any live agent, including queued messages " +
+      "and final-status notifications. Does not return the content; returns either " +
+      "a summary of which agents have updates (if any), " +
+      "or a timeout summary if no mailbox update arrives before the deadline.",
     metadata: toolMetadata("agent", { keywords: ["agent", "wait", "status"] }),
     isReadOnly: true,
     recoveryCategory: "side-effecting",
@@ -294,15 +114,11 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
     inputSchema: {
       type: "object",
       properties: {
-        targets: {
-          type: "array",
-          items: { type: "string" },
-          description:
-            "Optional list of agent names or paths to wait for. Defaults to active descendants of the current agent.",
-        },
         timeout_ms: {
           type: "number",
-          description: `Optional timeout in milliseconds. Defaults to ${DEFAULT_WAIT_TIMEOUT_MS}, min ${MIN_WAIT_TIMEOUT_MS}, max ${MAX_WAIT_TIMEOUT_MS}.`,
+          description:
+            `Optional timeout in milliseconds. Defaults to ${DEFAULT_WAIT_TIMEOUT_MS}, ` +
+            `min ${MIN_WAIT_TIMEOUT_MS}, max ${MAX_WAIT_TIMEOUT_MS}.`,
         },
       },
       additionalProperties: false,

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -1825,7 +1825,12 @@ describe("model-facing tools", () => {
     const zeroTimeout = await wait.execute({ timeout_ms: 0 });
     expect(zeroTimeout.isError).toBe(true);
     expect(JSON.parse(zeroTimeout.content).error).toBe(
-      "timeout_ms must be greater than zero",
+      "timeout_ms must be at least 10000",
+    );
+    const tooLargeTimeout = await wait.execute({ timeout_ms: 3_600_001 });
+    expect(tooLargeTimeout.isError).toBe(true);
+    expect(JSON.parse(tooLargeTimeout.content).error).toBe(
+      "timeout_ms must be at most 3600000",
     );
     for (const timeout_ms of ["1000", {}, []]) {
       const invalidTimeout = await wait.execute({ timeout_ms });
@@ -1834,11 +1839,9 @@ describe("model-facing tools", () => {
         "timeout_ms must be a number",
       );
     }
-    for (const targets of ["task_1", {}, []]) {
-      const invalidTargets = await wait.execute({ targets });
-      expect(invalidTargets.isError).toBe(true);
-      expect(JSON.parse(invalidTargets.content).error).toMatch(/targets must/);
-    }
+    const targets = await wait.execute({ targets: ["/root/worker"] });
+    expect(targets.isError).toBe(true);
+    expect(JSON.parse(targets.content).error).toBe("unknown field `targets`");
 
     const invalidRole = await spawnAgent.execute({
       message: "inspect",
@@ -2592,37 +2595,22 @@ describe("model-facing tools", () => {
     }
   });
 
-  it("wait_agent waits against actual descendant agent statuses", async () => {
+  it("wait_agent waits for parent mailbox updates without enumerating agent statuses", async () => {
     const session = fakeSession();
     const emitted: unknown[] = [];
     (session as unknown as { emit: typeof session.emit }).emit = (event) => {
       emitted.push(event);
     };
-    const completedStatus = {
-      status: "completed" as const,
-      turnId: "turn-1",
-      endedAtMs: 1,
-      lastMessage: "done",
+    const waitForMailboxChange = vi.fn(async () => true);
+    const sessionWithMailboxWait = session as unknown as {
+      waitForMailboxChange: typeof waitForMailboxChange;
     };
+    sessionWithMailboxWait.waitForMailboxChange = waitForMailboxChange;
     const control = {
-      listAgents: vi.fn(() => [
-        {
-          agentName: "/root",
-          agentStatus: { status: "pending_init" as const },
-          lastTaskMessage: "Main thread",
-        },
-        {
-          agentName: "/root/worker",
-          agentStatus: completedStatus,
-          lastTaskMessage: "inspect",
-        },
-      ]),
+      listAgents: vi.fn(() => []),
       getLive: vi.fn(() => undefined),
       resolveAgentReference: vi.fn(() => "agent-1"),
-      subscribeStatus: vi.fn(async () => ({
-        value: completedStatus,
-        unsubscribe: vi.fn(),
-      })),
+      subscribeStatus: vi.fn(),
     };
     _setAgentControlForTesting(session, {
       control: control as never,
@@ -2640,21 +2628,61 @@ describe("model-facing tools", () => {
       expect(JSON.parse(result.content)).toEqual({
         message: "Wait completed.",
         timed_out: false,
-        statuses: {
-          "/root/worker": { completed: "done" },
-        },
       });
-      expect(control.listAgents).toHaveBeenCalledWith({ pathPrefix: "/root" });
-      expect(control.subscribeStatus).toHaveBeenCalledWith("agent-1");
+      expect(waitForMailboxChange).toHaveBeenCalledWith(30_000);
+      expect(control.listAgents).not.toHaveBeenCalled();
+      expect(control.subscribeStatus).not.toHaveBeenCalled();
       expect(
         emitted.map((event) => (event as { msg: { type: string } }).msg.type),
       ).toEqual(["collab_waiting_begin", "collab_waiting_end"]);
       expect(
-        (emitted[1] as { msg: { payload: { statuses: unknown } } }).msg.payload.statuses,
-      ).toEqual({ "/root/worker": completedStatus });
+        (
+          emitted[0] as {
+            msg: { payload: { receiverThreadIds: unknown[] } };
+          }
+        ).msg.payload.receiverThreadIds,
+      ).toEqual([]);
+      expect(
+        (
+          emitted[1] as {
+            msg: {
+              payload: { statuses: unknown; agentStatuses: unknown[] };
+            };
+          }
+        ).msg.payload.statuses,
+      ).toEqual({});
+      expect(
+        (
+          emitted[1] as {
+            msg: { payload: { agentStatuses: unknown[] } };
+          }
+        ).msg.payload.agentStatuses,
+      ).toEqual([]);
     } finally {
       _clearAgentControlCacheForTesting(session);
     }
+  });
+
+  it("wait_agent reports timeout when no parent mailbox update arrives", async () => {
+    const session = fakeSession();
+    const waitForMailboxChange = vi.fn(async () => false);
+    const sessionWithMailboxWait = session as unknown as {
+      waitForMailboxChange: typeof waitForMailboxChange;
+    };
+    sessionWithMailboxWait.waitForMailboxChange = waitForMailboxChange;
+    const wait = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => session,
+    }).find((tool) => tool.name === "wait_agent")!;
+
+    const result = await wait.execute({ timeout_ms: 10_000 });
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content)).toEqual({
+      message: "Wait timed out.",
+      timed_out: true,
+    });
+    expect(waitForMailboxChange).toHaveBeenCalledWith(10_000);
   });
 
   it("rejects messages to terminal live agents instead of reporting false delivery", async () => {


### PR DESCRIPTION
## Summary
- align v2 `wait_agent` with mailbox-update semantics instead of descendant status polling
- remove the old v1-style `targets` input from the v2 wait tool surface
- extend the agent-surface contract and model-facing tests to cover the Codex wait-agent parity source

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/bin/model-facing-tools.test.ts --testNamePattern "wait_agent|invalid strict spawn_agent" --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run validate:required`
- `npm run check:agent-surface-contract -- --command-timeout-ms 600000`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:report`
- `git diff --check`
