### PR TITLE
fix(agents): preserve close events on shutdown failure

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -35,6 +35,30 @@
       "sha256": "dcd6a7abd9f6cec6821f9c03b3c7936cbc2845324196b3a368cc15fc08a1f5fd"
     },
     {
+      "path": "core/src/tools/handlers/multi_agents_v2/close_agent.rs",
+      "sha256": "105a877567d3d609b8ffc14f409402d8071fc7ad9442214c55104018246764f4"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_v2/followup_task.rs",
+      "sha256": "56e5d3cedb93a77b38cb0d64a0579a323af45b99b1e239018ac4ce4d2fade576"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_v2/list_agents.rs",
+      "sha256": "e13e2b0426ed3e53f9cb024e292a5cef9e228ce9234faaadb39e8722f222cc2f"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_v2/message_tool.rs",
+      "sha256": "eb9f3c30243ae6e83d5a69a66f805f0ba64abd5e0b2298a18bfe3886aa835151"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_v2/send_message.rs",
+      "sha256": "5ecb5d1fd7bf576b9520e966d852e9b133fb8459d478e7e6c9fdb107b60f7829"
+    },
+    {
+      "path": "core/src/tools/handlers/multi_agents_v2/spawn.rs",
+      "sha256": "9df1654c431c76f5adecb4ef07c1328993a84039f22ed59a373c203f1fbc2481"
+    },
+    {
       "path": "core/src/tools/handlers/multi_agents_v2/wait.rs",
       "sha256": "4ddd23c93ccae17d9a3b0006d4b2675acc450196ca207bbc1db4c5c841707a46"
     },
@@ -264,6 +288,12 @@
         "core/src/thread_manager.rs",
         "core/src/tools/handlers/multi_agents_common.rs",
         "core/src/tools/handlers/multi_agents_spec.rs",
+        "core/src/tools/handlers/multi_agents_v2/close_agent.rs",
+        "core/src/tools/handlers/multi_agents_v2/followup_task.rs",
+        "core/src/tools/handlers/multi_agents_v2/list_agents.rs",
+        "core/src/tools/handlers/multi_agents_v2/message_tool.rs",
+        "core/src/tools/handlers/multi_agents_v2/send_message.rs",
+        "core/src/tools/handlers/multi_agents_v2/spawn.rs",
         "core/src/tools/handlers/multi_agents_v2/wait.rs"
       ],
       "target": [
@@ -287,7 +317,8 @@
         "reports partial progress, final output, and failure state in task-compatible output records",
         "keeps background task lifecycle, agent lifecycle, and TUI task views synchronized from one authoritative state",
         "applies role allowlists and tool policies before child tools execute",
-        "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out"
+        "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
+        "close_agent emits the close-end event with the previous status even when close request delivery fails"
       ],
       "edgeCases": [
         "wait_agent returns completed when any parent mailbox update arrives before the timeout",
@@ -295,6 +326,7 @@
         "wait_agent rejects timeout_ms below the configured minimum instead of silently clamping",
         "wait_agent rejects removed v1 targets input as an unknown field",
         "closing a running agent interrupts it once and produces an idempotent terminal task status",
+        "a close_agent shutdown failure still emits collab_close_end and returns a structured tool error",
         "a fork containing multiple pending tool calls creates one placeholder result per call before child instructions",
         "an agent tool with a disallowed role fails before any child run is started",
         "task-board output excludes internal mailbox details while preserving user-visible progress and status"

--- a/runtime/src/agents/v2/close-agent.ts
+++ b/runtime/src/agents/v2/close-agent.ts
@@ -65,7 +65,12 @@ export function createCloseAgentTool(opts: MultiAgentV2Options): Tool {
           ? await control.getStatus(agentId)
           : { status: "not_found" });
     }
-    await control.shutdown(agentId, "closed_by_tool");
+    let closeError: unknown;
+    try {
+      await control.shutdown(agentId, "closed_by_tool");
+    } catch (error) {
+      closeError = error;
+    }
     emit(sessionOrError, {
       type: "collab_close_end",
       payload: {
@@ -76,6 +81,15 @@ export function createCloseAgentTool(opts: MultiAgentV2Options): Tool {
         status: previous,
       },
     });
+    if (closeError !== undefined) {
+      return json(
+        {
+          error:
+            closeError instanceof Error ? closeError.message : String(closeError),
+        },
+        true,
+      );
+    }
     return json({ previous_status: toAgentStatusJson(previous) });
   };
 

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -2899,6 +2899,77 @@ describe("model-facing tools", () => {
     }
   });
 
+  it("close_agent emits the close end event after shutdown failure", async () => {
+    const session = fakeSession();
+    const emit = vi.fn();
+    (session as unknown as { emit: typeof emit }).emit = emit;
+    const status = {
+      status: "running" as const,
+      turnId: "turn-1",
+      startedAtMs: 1,
+    };
+    const unsubscribe = vi.fn();
+    const control = {
+      resolveAgentReference: vi.fn(() => "550e8400-e29b-41d4-a716-446655440004"),
+      getLive: vi.fn((threadId: string) =>
+        threadId === "550e8400-e29b-41d4-a716-446655440004"
+          ? {
+              agentId: "550e8400-e29b-41d4-a716-446655440004",
+              agentPath: "/root/failing_close",
+              nickname: "ShutdownProbe",
+              role: { name: "worker" },
+              status: { value: status },
+            }
+          : undefined,
+      ),
+      getAgentMetadata: vi.fn((threadId: string) =>
+        threadId === "550e8400-e29b-41d4-a716-446655440004"
+          ? {
+              agentId: "550e8400-e29b-41d4-a716-446655440004",
+              agentPath: "/root/failing_close",
+              agentNickname: "ShutdownProbe",
+              agentRole: "worker",
+              depth: 1,
+            }
+          : undefined,
+      ),
+      subscribeStatus: vi.fn(async () => ({ value: status, unsubscribe })),
+      shutdown: vi.fn(async () => {
+        throw new Error("close failed");
+      }),
+    };
+    _setAgentControlForTesting(session, {
+      control: control as never,
+      registry: {} as never,
+    });
+    try {
+      const close = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      }).find((tool) => tool.name === "close_agent")!;
+
+      const result = await close.execute({ target: "/root/failing_close" });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content).error).toBe("close failed");
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(emit.mock.calls.map((call) => call[0].msg.type)).toEqual([
+        "collab_close_begin",
+        "collab_close_end",
+      ]);
+      expect(emit.mock.calls[1]?.[0].msg.payload).toEqual(
+        expect.objectContaining({
+          receiverThreadId: "550e8400-e29b-41d4-a716-446655440004",
+          receiverAgentNickname: "ShutdownProbe",
+          receiverAgentRole: "worker",
+          status,
+        }),
+      );
+    } finally {
+      _clearAgentControlCacheForTesting(session);
+    }
+  });
+
   function notebookSource(cells: readonly Record<string, unknown>[]): string {
     return JSON.stringify({
       cells,


### PR DESCRIPTION
## Summary
- preserve `collab_close_end` emission when v2 `close_agent` shutdown fails
- return a structured model-facing tool error instead of letting the tool promise reject
- extend the agent-surface contract with the Codex v2 handler sources and the shutdown-failure edge case

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/bin/model-facing-tools.test.ts --testNamePattern "close_agent" --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `npm run check:agent-surface-contract -- --command-timeout-ms 600000`
- `npm --workspace=@tetsuo-ai/runtime run validate:required`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:report`
- `git diff --check`
