### PR TITLE
fix(agents): honor spawn service tier overrides

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -83,6 +83,18 @@
       "sha256": "18ddefda817a89b299cfbec14ea8e95ff4248e9fe5aca616656f39f7d5cfb045"
     },
     {
+      "path": "protocol/src/openai_models.rs",
+      "sha256": "622e264c2b67b2e37d27c51b5486968a4d5245f6ff3a2893919eb71bb8c060ca"
+    },
+    {
+      "path": "protocol/src/config_types.rs",
+      "sha256": "84491d252377719e67acae0bda0d15f1c27a5aff81f4c4f4d5b58f5975267d3d"
+    },
+    {
+      "path": "models-manager/models.json",
+      "sha256": "b21200fd39c430f750cf10030c13bb19a91fdbc07792abdbda09e0ce6479161a"
+    },
+    {
       "path": "tui/src/multi_agents.rs",
       "sha256": "7de3107ec4c6d0085d34f3149e247be5edb847d40425ca703d9a7e890a4472a6"
     },
@@ -102,6 +114,10 @@
     "runtime/src/agents/mailbox.ts",
     "runtime/src/agents/run-agent.ts",
     "runtime/src/agents/delegate.ts",
+    "runtime/src/session/turn-context.ts",
+    "runtime/src/llm/model-registry.ts",
+    "runtime/src/llm/types.ts",
+    "runtime/src/phases/stream-model.ts",
     "runtime/src/agents/v2/spawn.ts",
     "runtime/src/agents/v2/send-message.ts",
     "runtime/src/agents/v2/wait.ts",
@@ -150,6 +166,9 @@
     "runtime/tests/tools/tasks/task-tools.test.ts",
     "runtime/tests/commands/agent-management.test.tsx",
     "runtime/tests/bin/model-facing-tools.test.ts",
+    "runtime/tests/llm/model-registry.test.ts",
+    "runtime/tests/llm/models-manager.test.ts",
+    "runtime/tests/phases/stream-model.test.ts",
     "runtime/tests/tui/workbench/agent-surface.test.tsx",
     "runtime/tests/tui/workbench/agents-rail.test.tsx",
     "runtime/tests/tui/workbench/agents.test.ts",
@@ -294,9 +313,14 @@
         "core/src/tools/handlers/multi_agents_v2/message_tool.rs",
         "core/src/tools/handlers/multi_agents_v2/send_message.rs",
         "core/src/tools/handlers/multi_agents_v2/spawn.rs",
-        "core/src/tools/handlers/multi_agents_v2/wait.rs"
+        "core/src/tools/handlers/multi_agents_v2/wait.rs",
+        "protocol/src/openai_models.rs",
+        "protocol/src/config_types.rs",
+        "models-manager/models.json"
       ],
       "target": [
+        "runtime/src/agents/delegate.ts",
+        "runtime/src/agents/run-agent.ts",
         "runtime/src/tasks/agent-thread.ts",
         "runtime/src/tasks/LocalAgentTask/LocalAgentTask.tsx",
         "runtime/src/tasks/InProcessTeammateTask/InProcessTeammateTask.tsx",
@@ -309,7 +333,11 @@
         "runtime/src/agents/v2/send-message.ts",
         "runtime/src/agents/v2/wait.ts",
         "runtime/src/agents/v2/list-agents.ts",
-        "runtime/src/agents/v2/close-agent.ts"
+        "runtime/src/agents/v2/close-agent.ts",
+        "runtime/src/session/turn-context.ts",
+        "runtime/src/llm/model-registry.ts",
+        "runtime/src/llm/types.ts",
+        "runtime/src/phases/stream-model.ts"
       ],
       "requiredBehaviors": [
         "exposes agent spawn, send, wait, list, close, and task-board operations through the tool surface without bypassing AgentControl",
@@ -317,6 +345,7 @@
         "reports partial progress, final output, and failure state in task-compatible output records",
         "keeps background task lifecycle, agent lifecycle, and TUI task views synchronized from one authoritative state",
         "applies role allowlists and tool policies before child tools execute",
+        "spawn_agent v2 accepts service_tier, validates it against the effective child model, allows explicit service_tier with full-history forks, and forwards the selected tier to child runs",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
         "close_agent emits the close-end event with the previous status even when close request delivery fails"
       ],
@@ -325,6 +354,9 @@
         "wait_agent returns timed_out when no parent mailbox update arrives before the timeout",
         "wait_agent rejects timeout_ms below the configured minimum instead of silently clamping",
         "wait_agent rejects removed v1 targets input as an unknown field",
+        "spawn_agent rejects an explicit service_tier unsupported by the selected child model before delegation",
+        "spawn_agent allows an explicit service_tier when fork_turns is all while still rejecting full-history model and effort overrides",
+        "a child spawned with service_tier priority forwards priority into the provider request options",
         "closing a running agent interrupts it once and produces an idempotent terminal task status",
         "a close_agent shutdown failure still emits collab_close_end and returns a structured tool error",
         "a fork containing multiple pending tool calls creates one placeholder result per call before child instructions",
@@ -337,10 +369,14 @@
         "runtime/tests/tools/AgentTool/loadAgentsDir.test.ts",
         "runtime/tests/tools/tasks/task-tools.test.ts",
         "runtime/tests/commands/agent-management.test.tsx",
-        "runtime/tests/bin/model-facing-tools.test.ts"
+        "runtime/tests/bin/model-facing-tools.test.ts",
+        "runtime/tests/agents/run-agent.test.ts",
+        "runtime/tests/llm/model-registry.test.ts",
+        "runtime/tests/llm/models-manager.test.ts",
+        "runtime/tests/phases/stream-model.test.ts"
       ],
       "commands": [
-        "npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx tests/bin/model-facing-tools.test.ts --reporter=dot"
+        "npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx tests/bin/model-facing-tools.test.ts tests/agents/run-agent.test.ts tests/llm/model-registry.test.ts tests/llm/models-manager.test.ts tests/phases/stream-model.test.ts --reporter=dot"
       ],
       "status": "required"
     },

--- a/runtime/src/agents/delegate.ts
+++ b/runtime/src/agents/delegate.ts
@@ -60,6 +60,7 @@ export interface DelegateOpts {
   readonly agentName?: string;
   readonly model?: string;
   readonly reasoningEffort?: ReasoningEffort;
+  readonly serviceTier?: string;
   readonly isolation?: IsolationMode;
   readonly worktreeSlug?: string;
   readonly forkMode?: ForkMode;
@@ -223,6 +224,9 @@ export async function delegate(
       ...(opts.reasoningEffort !== undefined
         ? { reasoningEffort: opts.reasoningEffort }
         : {}),
+      ...(opts.serviceTier !== undefined
+        ? { serviceTier: opts.serviceTier }
+        : {}),
       ...(opts.resumeManager !== undefined
         ? { resumeManager: opts.resumeManager }
         : {}),
@@ -336,6 +340,7 @@ async function runDelegateAgentLoop(opts: {
   readonly silent?: boolean;
   readonly model?: string;
   readonly reasoningEffort?: ReasoningEffort;
+  readonly serviceTier?: string;
   readonly resumeManager?: ResumeManager;
   readonly keepAlive?: boolean;
   readonly onProgress?: (
@@ -366,6 +371,9 @@ async function runDelegateAgentLoop(opts: {
         ...(opts.model !== undefined ? { model: opts.model } : {}),
         ...(opts.reasoningEffort !== undefined
           ? { reasoningEffort: opts.reasoningEffort }
+          : {}),
+        ...(opts.serviceTier !== undefined
+          ? { serviceTier: opts.serviceTier }
           : {}),
         ...(opts.keepAlive !== undefined ? { keepAlive: opts.keepAlive } : {}),
         onCacheSafeParams: (params) => {

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -87,6 +87,8 @@ export interface RunAgentParams {
   readonly model?: string;
   /** Optional child reasoning-effort override. */
   readonly reasoningEffort?: ReasoningEffort;
+  /** Optional child service-tier override. */
+  readonly serviceTier?: string;
   /** Optional AbortSignal merged with the live agent's controller. */
   readonly externalSignal?: AbortSignal;
   /** Optional per-call child tool policy layered after allowlist filtering. */
@@ -1410,10 +1412,15 @@ function cloneSessionConfiguration(
   overrides: {
     readonly model?: string;
     readonly reasoningEffort?: ReasoningEffort;
+    readonly serviceTier?: string;
   } = {},
 ): Session["sessionConfiguration"] {
   const base = parent.sessionConfiguration;
   const cwd = worktree?.path ?? base.cwd;
+  const serviceTier =
+    overrides.serviceTier !== undefined
+      ? overrides.serviceTier
+      : base.serviceTier;
   const collaborationMode = {
     ...base.collaborationMode,
     ...(overrides.model !== undefined ? { model: overrides.model } : {}),
@@ -1424,6 +1431,7 @@ function cloneSessionConfiguration(
   return {
     ...base,
     cwd,
+    ...(serviceTier !== undefined ? { serviceTier } : {}),
     collaborationMode,
     sessionSource: {
       kind: "subagent",
@@ -1444,7 +1452,7 @@ function cloneSessionConfiguration(
             model: collaborationMode.model,
             modelReasoningEffort: collaborationMode.reasoningEffort,
             modelReasoningSummary: base.modelReasoningSummary,
-            serviceTier: base.serviceTier,
+            serviceTier,
             personality: base.personality,
             approvalsReviewer: base.approvalsReviewer,
           },
@@ -1545,6 +1553,9 @@ function buildChildSession(
       ...(params.model !== undefined ? { model: params.model } : {}),
       ...(params.reasoningEffort !== undefined
         ? { reasoningEffort: params.reasoningEffort }
+        : {}),
+      ...(params.serviceTier !== undefined
+        ? { serviceTier: params.serviceTier }
         : {}),
     },
   );

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -1,6 +1,6 @@
 import type { Tool, ToolResult } from "../../tools/types.js";
 import type { Session } from "../../session/session.js";
-import type { ReasoningEffort } from "../../session/turn-context.js";
+import type { ModelInfo, ReasoningEffort } from "../../session/turn-context.js";
 import { delegate } from "../delegate.js";
 import type { ForkMode } from "../fork-context.js";
 import type { AgentThread } from "../thread.js";
@@ -134,6 +134,22 @@ function normalizeSpawnTaskName(value: string | undefined): string | undefined {
   return normalized.length > 0 ? normalized : trimmed;
 }
 
+function serviceTierIds(modelInfo: ModelInfo): readonly string[] {
+  return (modelInfo.serviceTiers ?? []).map((tier) => tier.id);
+}
+
+function modelSupportsServiceTier(
+  modelInfo: ModelInfo,
+  serviceTier: string,
+): boolean {
+  return serviceTierIds(modelInfo).includes(serviceTier);
+}
+
+function formatSupportedServiceTiers(modelInfo: ModelInfo): string {
+  const supported = serviceTierIds(modelInfo);
+  return supported.length > 0 ? supported.join(", ") : "none";
+}
+
 async function validateSpawnModelOverrides(opts: {
   readonly session: Session;
   readonly model?: string;
@@ -179,6 +195,57 @@ async function validateSpawnModelOverrides(opts: {
   return null;
 }
 
+async function resolveSpawnServiceTier(opts: {
+  readonly session: Session;
+  readonly model?: string;
+  readonly requestedServiceTier?: string;
+}): Promise<{ readonly serviceTier?: string } | ToolResult> {
+  const parentServiceTier = opts.session.sessionConfiguration.serviceTier;
+  if (
+    opts.requestedServiceTier === undefined &&
+    parentServiceTier === undefined
+  ) {
+    return {};
+  }
+  const model =
+    opts.model ??
+    opts.session.sessionConfiguration.collaborationMode.model ??
+    opts.session.modelInfo.slug;
+  if (!model) {
+    return json(
+      {
+        error:
+          "spawn_agent could not resolve the child model for service tier validation",
+      },
+      true,
+    );
+  }
+  const modelInfo =
+    model === opts.session.modelInfo.slug
+      ? opts.session.modelInfo
+      : await opts.session.services.modelsManager.getModelInfo(model);
+  if (
+    opts.requestedServiceTier !== undefined &&
+    !modelSupportsServiceTier(modelInfo, opts.requestedServiceTier)
+  ) {
+    return json(
+      {
+        error: `Service tier \`${opts.requestedServiceTier}\` is not supported for model \`${model}\`. Supported service tiers: ${formatSupportedServiceTiers(modelInfo)}`,
+      },
+      true,
+    );
+  }
+  for (const candidate of [opts.requestedServiceTier, parentServiceTier]) {
+    if (
+      candidate !== undefined &&
+      modelSupportsServiceTier(modelInfo, candidate)
+    ) {
+      return { serviceTier: candidate };
+    }
+  }
+  return {};
+}
+
 export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
   const roleNames = [...new Set(
     listAgentRoles().flatMap((role) => [
@@ -206,6 +273,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       },
       model: { type: "string" },
       reasoning_effort: { type: "string" },
+      service_tier: { type: "string" },
       fork_turns: { type: "string" },
     },
     required: ["message", "task_name"],
@@ -225,6 +293,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         "agent_type",
         "model",
         "reasoning_effort",
+        "service_tier",
         "fork_turns",
         "fork_context",
       ]),
@@ -237,6 +306,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       "agent_type",
       "model",
       "reasoning_effort",
+      "service_tier",
       "fork_turns",
     ]) {
       if (args[key] !== undefined && typeof args[key] !== "string") {
@@ -286,6 +356,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         true,
       );
     }
+    const requestedServiceTier = stringValue(args.service_tier);
     const callId = callIdFromArgs(args, "agent");
 
     emit(session, {
@@ -362,6 +433,32 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       emitSpawnFailureEnd(overrideReason);
       return overrideError;
     }
+    const serviceTierResult = await resolveSpawnServiceTier({
+      session,
+      ...(model !== undefined ? { model } : {}),
+      ...(requestedServiceTier !== undefined
+        ? { requestedServiceTier }
+        : {}),
+    });
+    if ("content" in serviceTierResult) {
+      const overrideReason =
+        typeof serviceTierResult.content === "string"
+          ? (() => {
+              try {
+                const parsed = JSON.parse(serviceTierResult.content) as {
+                  error?: unknown;
+                };
+                return typeof parsed.error === "string"
+                  ? parsed.error
+                  : serviceTierResult.content;
+              } catch {
+                return serviceTierResult.content;
+              }
+            })()
+          : "spawn_agent service tier validation failed";
+      emitSpawnFailureEnd(overrideReason);
+      return serviceTierResult;
+    }
     if (!taskName) {
       return failSpawn("task_name is required");
     }
@@ -384,6 +481,9 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         ...(role !== undefined ? { role } : {}),
         ...(model !== undefined ? { model } : {}),
         ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+        ...(serviceTierResult.serviceTier !== undefined
+          ? { serviceTier: serviceTierResult.serviceTier }
+          : {}),
       });
       if (outcome.kind === "rejected") {
         throw new Error(outcome.reason);

--- a/runtime/src/llm/model-registry.ts
+++ b/runtime/src/llm/model-registry.ts
@@ -22,7 +22,11 @@ import {
   resolveModelCostEntry,
   type ModelCostEntry,
 } from "../session/cost.js";
-import type { ModelInfo, ReasoningEffort } from "../session/turn-context.js";
+import type {
+  ModelInfo,
+  ModelServiceTier,
+  ReasoningEffort,
+} from "../session/turn-context.js";
 
 const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95;
 
@@ -80,6 +84,38 @@ function inferDefaultReasoningLevel(
   return supportedReasoningLevels.length > 0 ? "medium" : undefined;
 }
 
+function inferServiceTiers(
+  entry: ModelRegistryEntry,
+): readonly ModelServiceTier[] {
+  const catalog = resolveRegisteredModelCatalogEntry({
+    provider: entry.provider,
+    model: entry.model,
+  });
+  const tiers = new Map<string, ModelServiceTier>();
+  for (const tier of catalog?.additionalSpeedTiers ?? []) {
+    if (tier === "fast" || tier === "priority") {
+      tiers.set("priority", {
+        id: "priority",
+        name: "Fast",
+        description: "1.5x speed, increased usage",
+      });
+    } else if (tier === "flex") {
+      tiers.set("flex", {
+        id: "flex",
+        name: "Flex",
+        description: "Lower-priority flexible capacity",
+      });
+    } else {
+      tiers.set(tier, {
+        id: tier,
+        name: tier,
+        description: tier,
+      });
+    }
+  }
+  return [...tiers.values()];
+}
+
 function resolveCostEntry(params: {
   readonly provider: string;
   readonly model: string;
@@ -118,6 +154,7 @@ export function modelRegistryEntryToModelInfo(
     entry,
     supportedReasoningLevels,
   );
+  const serviceTiers = inferServiceTiers(entry);
   const catalog = resolveRegisteredModelCatalogEntry({
     provider: entry.provider,
     model: entry.model,
@@ -149,6 +186,7 @@ export function modelRegistryEntryToModelInfo(
         : DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
     supportedReasoningLevels,
     ...(defaultReasoningLevel !== undefined ? { defaultReasoningLevel } : {}),
+    ...(serviceTiers.length > 0 ? { serviceTiers } : {}),
     defaultReasoningSummary: catalog?.defaultReasoningSummary ?? "auto",
     truncationPolicy: "off",
     supportsToolUse: entry.capabilities.supportsToolUse,

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -335,7 +335,7 @@ interface LLMChatToolRoutingOptions {
 type LLMReasoningEffort = "low" | "medium" | "high" | "xhigh";
 type LLMReasoningSummary = "auto" | "concise" | "detailed" | "none";
 type LLMModelVerbosity = "low" | "medium" | "high";
-type LLMServiceTier = "fast" | "flex";
+type LLMServiceTier = "fast" | "priority" | "flex";
 
 export type LLMProviderNativeServerToolType =
   | "web_search"

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -171,7 +171,9 @@ function buildProviderOptions(
     reasoningSummary: ctx.reasoningSummary,
     modelVerbosity: ctx.modelVerbosity,
     serviceTier:
-      ctx.serviceTier === "fast" || ctx.serviceTier === "flex"
+      ctx.serviceTier === "fast" ||
+      ctx.serviceTier === "priority" ||
+      ctx.serviceTier === "flex"
         ? ctx.serviceTier
         : undefined,
   };

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -62,6 +62,12 @@ export interface AuthManager {
 }
 
 /** agenc runtime `ModelInfo` shape backed by the runtime models manager. */
+export interface ModelServiceTier {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+}
+
 export interface ModelInfo {
   readonly slug: string;
   readonly contextWindow?: number;
@@ -72,6 +78,7 @@ export interface ModelInfo {
   readonly maxOutputTokensCappedDefault?: boolean;
   readonly supportedReasoningLevels: ReadonlyArray<ReasoningEffort>;
   readonly defaultReasoningLevel?: ReasoningEffort;
+  readonly serviceTiers?: ReadonlyArray<ModelServiceTier>;
   readonly defaultReasoningSummary: ReasoningSummary;
   readonly truncationPolicy: TruncationPolicy;
   readonly supportsToolUse?: boolean;

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -439,6 +439,44 @@ describe("runAgent", () => {
     expect(result.toolCallCount).toBe(1);
   });
 
+  it("applies a per-spawn service tier to the child session provider request", async () => {
+    const seenOptions: LLMChatOptions[] = [];
+    const provider = {
+      ...makeProvider([]),
+      chatStream: vi.fn(
+        async (
+          _messages: LLMMessage[],
+          _onChunk: StreamProgressCallback,
+          options?: LLMChatOptions,
+        ): Promise<LLMResponse> => {
+          if (options !== undefined) seenOptions.push(options);
+          return {
+            content: "ok",
+            toolCalls: [],
+            usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+            model: "fake-model",
+            finishReason: "stop",
+          };
+        },
+      ),
+    } satisfies LLMProvider;
+    const session = makeStubSession({ services: { provider } });
+    const { live } = await spawnLive(session);
+
+    await collectRun(
+      runAgent({
+        live,
+        parent: session,
+        initialMessages: [{ role: "user", content: "go" }],
+        taskPrompt: "go",
+        serviceTier: "priority",
+      }),
+    );
+
+    expect(seenOptions[0]?.serviceTier).toBe("priority");
+    expect(live.configSnapshot).toMatchObject({ serviceTier: "priority" });
+  });
+
   it("captures AgentSummary cache-safe params from the real child run state", async () => {
     const provider = makeProvider([{ content: "summary seed" }]);
     const registry = {

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -73,6 +73,13 @@ function fakeSession(): Session {
     effectiveContextWindowPercent: 95,
     supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
     defaultReasoningLevel: "medium",
+    serviceTiers: [
+      {
+        id: "priority",
+        name: "Fast",
+        description: "1.5x speed, increased usage",
+      },
+    ],
     defaultReasoningSummary: "auto",
     truncationPolicy: "off",
     usedFallbackModelMetadata: false,
@@ -369,6 +376,12 @@ describe("model-facing tools", () => {
           ?.inputSchema as { properties?: Record<string, unknown> } | undefined
       )?.properties,
     ).not.toHaveProperty("fork_context");
+    expect(
+      (
+        registry.tools.find((tool) => tool.name === "spawn_agent")
+          ?.inputSchema as { properties?: Record<string, unknown> } | undefined
+      )?.properties,
+    ).toHaveProperty("service_tier");
     expect(
       registry.tools.find((tool) => tool.name === "TaskCreate")?.inputSchema,
     ).toMatchObject({
@@ -2025,6 +2038,142 @@ describe("model-facing tools", () => {
     expect(delegateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         forkMode: { kind: "full_history" },
+      }),
+    );
+  });
+
+  it("accepts explicit service_tier for spawn_agent and validates the effective child model", async () => {
+    const supportedModelInfo = {
+      ...fakeSession().modelInfo,
+      slug: "gpt-5.4",
+      serviceTiers: [
+        {
+          id: "priority",
+          name: "Fast",
+          description: "1.5x speed, increased usage",
+        },
+      ],
+    };
+    const unsupportedModelInfo = {
+      ...fakeSession().modelInfo,
+      slug: "gpt-5.3-codex", // branding-scan: allow OpenAI model identifier
+      serviceTiers: [],
+    };
+    const session = fakeSession();
+    (session.services as unknown as {
+      modelsManager: {
+        tryListModels: () => readonly unknown[];
+        listModels: () => Promise<readonly unknown[]>;
+        getModelInfo: (model: string) => Promise<unknown>;
+      };
+    }).modelsManager = {
+      tryListModels: () => [supportedModelInfo, unsupportedModelInfo],
+      listModels: async () => [supportedModelInfo, unsupportedModelInfo],
+      getModelInfo: async (model: string) =>
+        model === supportedModelInfo.slug
+          ? supportedModelInfo
+          : unsupportedModelInfo,
+    };
+    delegateMock.mockResolvedValue({
+      kind: "async_launched",
+      thread: {
+        live: {
+          agentId: "thread-fast",
+          agentPath: "/root/fast_task",
+          nickname: "Fast Task",
+          role: { name: "default" },
+          status: {
+            value: {
+              status: "running",
+              turnId: "turn-fast",
+              startedAtMs: 1,
+            },
+          },
+        },
+        join: vi.fn(async () => ({
+          threadId: "thread-fast",
+          durationMs: 1,
+          outcome: "completed",
+          finalMessage: "done",
+        })),
+      },
+    });
+    const spawn = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => session,
+    }).find((tool) => tool.name === "spawn_agent")!;
+
+    const accepted = await spawn.execute({
+      message: "inspect",
+      task_name: "fast_task",
+      model: "gpt-5.4",
+      service_tier: "priority",
+    });
+
+    expect(accepted.isError).not.toBe(true);
+    expect(delegateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-5.4",
+        serviceTier: "priority",
+      }),
+    );
+
+    const rejected = await spawn.execute({
+      message: "inspect",
+      task_name: "slow_task",
+      model: "gpt-5.3-codex", // branding-scan: allow OpenAI model identifier
+      service_tier: "priority",
+    });
+
+    expect(rejected.isError).toBe(true);
+    expect(JSON.parse(rejected.content).error).toBe(
+      "Service tier `priority` is not supported for model `gpt-5.3-codex`. Supported service tiers: none", // branding-scan: allow OpenAI model identifier
+    );
+    expect(delegateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows explicit service_tier on full-history spawn_agent forks", async () => {
+    const session = fakeSession();
+    delegateMock.mockResolvedValue({
+      kind: "async_launched",
+      thread: {
+        live: {
+          agentId: "thread-history",
+          agentPath: "/root/history_task",
+          nickname: "History Task",
+          role: { name: "default" },
+          status: {
+            value: {
+              status: "running",
+              turnId: "turn-history",
+              startedAtMs: 1,
+            },
+          },
+        },
+        join: vi.fn(async () => ({
+          threadId: "thread-history",
+          durationMs: 1,
+          outcome: "completed",
+          finalMessage: "done",
+        })),
+      },
+    });
+
+    const result = await createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => session,
+    }).find((tool) => tool.name === "spawn_agent")!.execute({
+      message: "continue context-heavy work",
+      task_name: "history_task",
+      fork_turns: "all",
+      service_tier: "priority",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(delegateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        forkMode: { kind: "full_history" },
+        serviceTier: "priority",
       }),
     );
   });

--- a/runtime/tests/llm/model-registry.test.ts
+++ b/runtime/tests/llm/model-registry.test.ts
@@ -49,6 +49,13 @@ describe("ModelRegistry", () => {
       defaultReasoningLevel: "xhigh",
       defaultReasoningSummary: "none",
       supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
+      serviceTiers: [
+        {
+          id: "priority",
+          name: "Fast",
+          description: "1.5x speed, increased usage",
+        },
+      ],
     });
   });
 

--- a/runtime/tests/llm/models-manager.test.ts
+++ b/runtime/tests/llm/models-manager.test.ts
@@ -49,6 +49,13 @@ describe("StaticModelsManager", () => {
       contextWindow: 272_000,
       defaultReasoningLevel: "xhigh",
       defaultReasoningSummary: "none",
+      serviceTiers: [
+        {
+          id: "priority",
+          name: "Fast",
+          description: "1.5x speed, increased usage",
+        },
+      ],
       usedFallbackModelMetadata: false,
     });
     expect(info.supportedReasoningLevels).toEqual([

--- a/runtime/tests/phases/stream-model.test.ts
+++ b/runtime/tests/phases/stream-model.test.ts
@@ -311,7 +311,8 @@ describe("streamModel — live assistant text sanitization", () => {
     (ctx as TurnContext & { reasoningSummary: "detailed" }).reasoningSummary =
       "detailed";
     (ctx as TurnContext & { modelVerbosity?: "high" }).modelVerbosity = "high";
-    (ctx as TurnContext & { serviceTier?: "flex" }).serviceTier = "flex";
+    (ctx as TurnContext & { serviceTier?: "priority" }).serviceTier =
+      "priority";
 
     const seenOptions: Array<Record<string, unknown> | undefined> = [];
     const provider = mkProvider(async (_messages, _onChunk, options) => {
@@ -338,7 +339,7 @@ describe("streamModel — live assistant text sanitization", () => {
       reasoningEffort: "high",
       reasoningSummary: "detailed",
       modelVerbosity: "high",
-      serviceTier: "flex",
+      serviceTier: "priority",
       parallelToolCalls: false,
     });
   });


### PR DESCRIPTION
## Summary
- Add v2 spawn_agent service_tier schema support and validate explicit tiers against the effective child model.
- Forward the selected service tier through delegate/runAgent into child session provider requests.
- Add model metadata, focused regression tests, and agent-surface contract coverage for service-tier parity.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/model-facing-tools.test.ts tests/agents/run-agent.test.ts tests/llm/model-registry.test.ts tests/llm/models-manager.test.ts tests/phases/stream-model.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm run check:agent-surface-contract -- --command-timeout-ms 600000
- npm --workspace=@tetsuo-ai/runtime run validate:required
- npm --workspace=@tetsuo-ai/runtime run check:unused:report
- git diff --check