### PR TITLE
fix(agents): apply role config to spawned agents

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -199,7 +199,7 @@
         "reserves and finalizes agent registry entries atomically before a child run can receive messages",
         "allocates path-safe nicknames and rejects path collisions before the live agent handle is exposed",
         "enforces the default child depth cap while preserving configured per-session overrides",
-        "maps role configuration into child model, tools, permission, prompt, and runtime limits",
+        "maps role configuration into child model, tools, permission, prompt, service tier, and runtime limits",
         "normalizes final and nonfinal agent statuses consistently for list and TUI consumers"
       ],
       "edgeCases": [
@@ -207,6 +207,7 @@
         "a child spawn at depth two is rejected when the session cap is one",
         "a role with a configured nickname candidate list uses the first available path-safe candidate",
         "a missing role name resolves to the default role and still applies role-level tool policy",
+        "a role TOML layer with model, reasoning, and service_tier exposes those locked settings in the spawn tool description",
         "an interrupt racing with spawn finalization releases the reserved slot and emits an interrupted status"
       ],
       "tests": [
@@ -345,7 +346,7 @@
         "reports partial progress, final output, and failure state in task-compatible output records",
         "keeps background task lifecycle, agent lifecycle, and TUI task views synchronized from one authoritative state",
         "applies role allowlists and tool policies before child tools execute",
-        "spawn_agent v2 accepts service_tier, validates it against the effective child model, allows explicit service_tier with full-history forks, and forwards the selected tier to child runs",
+        "spawn_agent v2 accepts service_tier, validates it against the effective child model, applies role model/reasoning/service_tier after valid request overrides, allows explicit service_tier with full-history forks, and forwards the selected tier to child runs",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
         "close_agent emits the close-end event with the previous status even when close request delivery fails"
       ],
@@ -354,7 +355,8 @@
         "wait_agent returns timed_out when no parent mailbox update arrives before the timeout",
         "wait_agent rejects timeout_ms below the configured minimum instead of silently clamping",
         "wait_agent rejects removed v1 targets input as an unknown field",
-        "spawn_agent rejects an explicit service_tier unsupported by the selected child model before delegation",
+        "spawn_agent rejects an explicit service_tier unsupported by the role-resolved child model before delegation",
+        "spawn_agent gives role service_tier precedence over a valid requested service_tier when the resolved model supports both",
         "spawn_agent allows an explicit service_tier when fork_turns is all while still rejecting full-history model and effort overrides",
         "a child spawned with service_tier priority forwards priority into the provider request options",
         "closing a running agent interrupts it once and produces an idempotent terminal task status",

--- a/runtime/src/agents/role.ts
+++ b/runtime/src/agents/role.ts
@@ -79,7 +79,11 @@ export interface AgentRoleConfig {
   /** Runtime hint derived from the loaded role layer when possible. */
   readonly timeoutMs?: number;
   /** Runtime hint derived from the loaded role layer when possible. */
+  readonly model?: string;
+  /** Runtime hint derived from the loaded role layer when possible. */
   readonly reasoningEffort?: AgentReasoningEffort;
+  /** Runtime hint derived from the loaded role layer when possible. */
+  readonly serviceTier?: string;
   /** Optional explicit tool allowlist. This is runtime metadata, not a
    *  upstream runtime role-layer config field. */
   readonly allowlist?: ReadonlyArray<string>;
@@ -450,6 +454,7 @@ export interface RoleShapedConfig {
   approval_policy?: string;
   sandbox_mode?: string;
   reasoning_effort?: string;
+  service_tier?: string;
   personality?: string;
   web_search?: unknown;
   tools_config?: Record<string, unknown>;
@@ -587,6 +592,7 @@ function formatRole(role: AgentRole): string {
   const reasoningEffort = asString(
     roleLayerToml?.model_reasoning_effort ?? roleLayerToml?.reasoning_effort,
   );
+  const serviceTier = asString(roleLayerToml?.service_tier);
 
   let lockedSettingsNote = "";
   if (model && reasoningEffort) {
@@ -601,6 +607,11 @@ function formatRole(role: AgentRole): string {
     lockedSettingsNote =
       `\n- This role's reasoning effort is set to ` +
       `\`${reasoningEffort}\` and cannot be changed.`;
+  }
+  if (serviceTier) {
+    lockedSettingsNote +=
+      `\n- This role's service tier is set to \`${serviceTier}\`.` +
+      " If it is supported by the resolved model, it takes precedence over a valid spawn request service tier.";
   }
 
   return `${publicName}: {\n${description}${aliasNote}${lockedSettingsNote}\n}`;
@@ -635,12 +646,26 @@ function deriveRoleRuntimeHints(
     -readonly [K in keyof AgentRoleConfig]?: AgentRoleConfig[K];
   } = {};
 
+  if (config.model === undefined) {
+    const model = asString(normalizedLayer.model);
+    if (model !== undefined) {
+      derived.model = model;
+    }
+  }
+
   if (config.reasoningEffort === undefined) {
     const reasoningEffort = asAgentReasoningEffort(
       normalizedLayer.reasoning_effort,
     );
     if (reasoningEffort) {
       derived.reasoningEffort = reasoningEffort;
+    }
+  }
+
+  if (config.serviceTier === undefined) {
+    const serviceTier = asString(normalizedLayer.service_tier);
+    if (serviceTier !== undefined) {
+      derived.serviceTier = serviceTier;
     }
   }
 

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -1545,17 +1545,22 @@ function buildChildSession(
   provider: LLMProvider,
   startupPrewarm?: StartupPrewarmStore,
 ): ChildSession {
+  const roleConfig = params.live.role.config;
+  const childModel = params.model ?? roleConfig.model;
+  const childReasoningEffort =
+    params.reasoningEffort ?? roleConfig.reasoningEffort;
+  const childServiceTier = params.serviceTier ?? roleConfig.serviceTier;
   const sessionConfiguration = cloneSessionConfiguration(
     params.parent,
     params.live,
     params.worktree,
     {
-      ...(params.model !== undefined ? { model: params.model } : {}),
-      ...(params.reasoningEffort !== undefined
-        ? { reasoningEffort: params.reasoningEffort }
+      ...(childModel !== undefined ? { model: childModel } : {}),
+      ...(childReasoningEffort !== undefined
+        ? { reasoningEffort: childReasoningEffort }
         : {}),
-      ...(params.serviceTier !== undefined
-        ? { serviceTier: params.serviceTier }
+      ...(childServiceTier !== undefined
+        ? { serviceTier: childServiceTier }
         : {}),
     },
   );

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -5,7 +5,12 @@ import { delegate } from "../delegate.js";
 import type { ForkMode } from "../fork-context.js";
 import type { AgentThread } from "../thread.js";
 import { assertValidAgentName, ROOT_AGENT_PATH } from "../registry.js";
-import { formatRoleList, listAgentRoles, requireAgentRole } from "../role.js";
+import {
+  formatRoleList,
+  listAgentRoles,
+  requireAgentRole,
+  type AgentRole,
+} from "../role.js";
 import {
   canonicalAgentRoleName,
   formatAgentRoleLabel,
@@ -199,10 +204,12 @@ async function resolveSpawnServiceTier(opts: {
   readonly session: Session;
   readonly model?: string;
   readonly requestedServiceTier?: string;
+  readonly roleServiceTier?: string;
 }): Promise<{ readonly serviceTier?: string } | ToolResult> {
   const parentServiceTier = opts.session.sessionConfiguration.serviceTier;
   if (
     opts.requestedServiceTier === undefined &&
+    opts.roleServiceTier === undefined &&
     parentServiceTier === undefined
   ) {
     return {};
@@ -235,7 +242,11 @@ async function resolveSpawnServiceTier(opts: {
       true,
     );
   }
-  for (const candidate of [opts.requestedServiceTier, parentServiceTier]) {
+  for (const candidate of [
+    opts.roleServiceTier,
+    opts.requestedServiceTier,
+    parentServiceTier,
+  ]) {
     if (
       candidate !== undefined &&
       modelSupportsServiceTier(modelInfo, candidate)
@@ -244,6 +255,20 @@ async function resolveSpawnServiceTier(opts: {
     }
   }
   return {};
+}
+
+function roleModel(role: AgentRole | undefined): string | undefined {
+  return role?.config.model;
+}
+
+function roleReasoningEffort(
+  role: AgentRole | undefined,
+): ReasoningEffort | undefined {
+  return role?.config.reasoningEffort;
+}
+
+function roleServiceTier(role: AgentRole | undefined): string | undefined {
+  return role?.config.serviceTier;
 }
 
 export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
@@ -404,8 +429,11 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       return failSpawn("Subagents cannot spawn agents. Ask the main session to spawn agents.");
     }
 
+    let resolvedRole: AgentRole | undefined;
     try {
-      if (role !== undefined) requireAgentRole(role);
+      if (role !== undefined) {
+        resolvedRole = requireAgentRole(role);
+      }
     } catch (error) {
       return failSpawn(error instanceof Error ? error.message : String(error));
     }
@@ -433,11 +461,50 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       emitSpawnFailureEnd(overrideReason);
       return overrideError;
     }
+    const roleConfiguredModel = roleModel(resolvedRole);
+    const roleConfiguredReasoningEffort = roleReasoningEffort(resolvedRole);
+    const roleConfiguredServiceTier = roleServiceTier(resolvedRole);
+    const effectiveModel = roleConfiguredModel ?? model;
+    const effectiveReasoningEffort =
+      roleConfiguredReasoningEffort ?? reasoningEffort;
+    const roleOverrideError =
+      roleConfiguredModel !== undefined ||
+      roleConfiguredReasoningEffort !== undefined
+        ? await validateSpawnModelOverrides({
+            session,
+            ...(effectiveModel !== undefined ? { model: effectiveModel } : {}),
+            ...(effectiveReasoningEffort !== undefined
+              ? { reasoningEffort: effectiveReasoningEffort }
+              : {}),
+          })
+        : null;
+    if (roleOverrideError) {
+      const overrideReason =
+        typeof roleOverrideError.content === "string"
+          ? (() => {
+              try {
+                const parsed = JSON.parse(roleOverrideError.content) as {
+                  error?: unknown;
+                };
+                return typeof parsed.error === "string"
+                  ? parsed.error
+                  : roleOverrideError.content;
+              } catch {
+                return roleOverrideError.content;
+              }
+            })()
+          : "spawn_agent role override validation failed";
+      emitSpawnFailureEnd(overrideReason);
+      return roleOverrideError;
+    }
     const serviceTierResult = await resolveSpawnServiceTier({
       session,
-      ...(model !== undefined ? { model } : {}),
+      ...(effectiveModel !== undefined ? { model: effectiveModel } : {}),
       ...(requestedServiceTier !== undefined
         ? { requestedServiceTier }
+        : {}),
+      ...(roleConfiguredServiceTier !== undefined
+        ? { roleServiceTier: roleConfiguredServiceTier }
         : {}),
     });
     if ("content" in serviceTierResult) {
@@ -479,8 +546,10 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         ...(forkMode !== undefined ? { forkMode } : {}),
         runInBackground: true,
         ...(role !== undefined ? { role } : {}),
-        ...(model !== undefined ? { model } : {}),
-        ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+        ...(effectiveModel !== undefined ? { model: effectiveModel } : {}),
+        ...(effectiveReasoningEffort !== undefined
+          ? { reasoningEffort: effectiveReasoningEffort }
+          : {}),
         ...(serviceTierResult.serviceTier !== undefined
           ? { serviceTier: serviceTierResult.serviceTier }
           : {}),

--- a/runtime/tests/agents/role.test.ts
+++ b/runtime/tests/agents/role.test.ts
@@ -110,6 +110,22 @@ describe("role registry", () => {
     expect(getAgentRole("deep-review")?.config.reasoningEffort).toBe("xhigh");
   });
 
+  it("derives model and service tier hints from user role layers", () => {
+    registerAgentRole({
+      name: "priority-review",
+      config: {
+        description: "review",
+        configToml: [
+          'model = "gpt-5.4"',
+          'service_tier = "priority"',
+        ].join("\n"),
+      },
+    });
+
+    expect(getAgentRole("priority-review")?.config.model).toBe("gpt-5.4");
+    expect(getAgentRole("priority-review")?.config.serviceTier).toBe("priority");
+  });
+
   it("registerAgentRole overrides built-ins by name", () => {
     registerAgentRole({
       name: "explorer",
@@ -227,6 +243,7 @@ describe("config-layer stack", () => {
         configToml: [
           'model = "role-model"',
           'model_reasoning_effort = "high"',
+          'service_tier = "priority"',
           'name = "ignored-role-metadata"',
           'developer_instructions = "ignored"',
         ].join("\n"),
@@ -238,8 +255,23 @@ describe("config-layer stack", () => {
     expect(next.cwd).toBe("/tmp/project");
     expect(next.model).toBe("role-model");
     expect(next.reasoning_effort).toBe("high");
+    expect(next.service_tier).toBe("priority");
     expect("name" in next).toBe(false);
     expect("developer_instructions" in next).toBe(false);
+  });
+
+  it("applyRoleToConfig preserves the parent service tier when the role does not override it", () => {
+    registerAgentRole({
+      name: "custom-inline",
+      config: {
+        description: "inline role",
+        configToml: 'model = "role-model"',
+      },
+    });
+
+    const base = { cwd: "/tmp/project", service_tier: "priority" as const };
+    const next = applyRoleToConfig(getAgentRole("custom-inline")!, base);
+    expect(next.service_tier).toBe("priority");
   });
 
   it("buildConfigLayerStack applies base → role → user precedence", () => {
@@ -350,6 +382,7 @@ describe("config-layer stack", () => {
         configToml: [
           'model = "gpt-test"',
           'model_reasoning_effort = "high"',
+          'service_tier = "priority"',
         ].join("\n"),
       },
     });
@@ -365,6 +398,10 @@ describe("config-layer stack", () => {
     expect(text).toContain("model-locked-role:");
     expect(text).toContain("model is set to `gpt-test`");
     expect(text).toContain("reasoning effort is set to `high`");
+    expect(text).toContain("service tier is set to `priority`");
+    expect(text).toContain(
+      "takes precedence over a valid spawn request service tier",
+    );
   });
 
   it("formatRoleList skips duplicate names", () => {

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -29,7 +29,11 @@ import {
   type RunAgentProgressEvent,
   type RunAgentResult,
 } from "./run-agent.js";
-import { _resetNicknamePoolForTesting } from "./role.js";
+import {
+  _resetAgentRolesForTesting,
+  _resetNicknamePoolForTesting,
+  registerAgentRole,
+} from "./role.js";
 import type { InterAgentCommunication } from "./mailbox.js";
 import type {
   LLMChatOptions,
@@ -232,7 +236,7 @@ async function collectRun(
   }
 }
 
-async function spawnLive(session: Session) {
+async function spawnLive(session: Session, roleName?: string) {
   const registry = new AgentRegistry();
   const control = new AgentControl({
     session: session as unknown as ConstructorParameters<
@@ -240,7 +244,10 @@ async function spawnLive(session: Session) {
     >[0]["session"],
     registry,
   });
-  const live = await control.spawn({ parentPath: "/root" });
+  const live = await control.spawn({
+    parentPath: "/root",
+    ...(roleName !== undefined ? { roleName } : {}),
+  });
   return { control, registry, live };
 }
 
@@ -271,10 +278,12 @@ function mkNamedRegistry(names: readonly string[]): ToolRegistry {
 }
 
 beforeEach(() => {
+  _resetAgentRolesForTesting();
   _resetNicknamePoolForTesting();
 });
 
 afterEach(() => {
+  _resetAgentRolesForTesting();
   _resetNicknamePoolForTesting();
   vi.useRealTimers();
 });
@@ -475,6 +484,59 @@ describe("runAgent", () => {
 
     expect(seenOptions[0]?.serviceTier).toBe("priority");
     expect(live.configSnapshot).toMatchObject({ serviceTier: "priority" });
+  });
+
+  it("applies role model, reasoning, and service tier to the child session", async () => {
+    registerAgentRole({
+      name: "priority-reviewer",
+      config: {
+        description: "Review quickly.",
+        configToml: [
+          'model = "gpt-5.4"',
+          'model_reasoning_effort = "high"',
+          'service_tier = "priority"',
+        ].join("\n"),
+      },
+    });
+    const seenOptions: LLMChatOptions[] = [];
+    const provider = {
+      ...makeProvider([]),
+      chatStream: vi.fn(
+        async (
+          _messages: LLMMessage[],
+          _onChunk: StreamProgressCallback,
+          options?: LLMChatOptions,
+        ): Promise<LLMResponse> => {
+          if (options !== undefined) seenOptions.push(options);
+          return {
+            content: "ok",
+            toolCalls: [],
+            usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+            model: "gpt-5.4",
+            finishReason: "stop",
+          };
+        },
+      ),
+    } satisfies LLMProvider;
+    const session = makeStubSession({ services: { provider } });
+    const { live } = await spawnLive(session, "priority-reviewer");
+
+    await collectRun(
+      runAgent({
+        live,
+        parent: session,
+        initialMessages: [{ role: "user", content: "go" }],
+        taskPrompt: "go",
+      }),
+    );
+
+    expect(seenOptions[0]?.reasoningEffort).toBe("high");
+    expect(seenOptions[0]?.serviceTier).toBe("priority");
+    expect(live.configSnapshot).toMatchObject({
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+    });
   });
 
   it("captures AgentSummary cache-safe params from the real child run state", async () => {

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -29,7 +29,7 @@ import {
   clearSessionReadState,
   getSessionReadSnapshot,
 } from "../tools/system/filesystem.js";
-import { _resetAgentRolesForTesting } from "../agents/role.js";
+import { _resetAgentRolesForTesting, registerAgentRole } from "../agents/role.js";
 
 const { delegateMock } = vi.hoisted(() => ({
   delegateMock: vi.fn(),
@@ -2130,6 +2130,160 @@ describe("model-facing tools", () => {
       "Service tier `priority` is not supported for model `gpt-5.3-codex`. Supported service tiers: none", // branding-scan: allow OpenAI model identifier
     );
     expect(delegateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies role model, reasoning, and service tier after valid spawn_agent overrides", async () => {
+    const roleModelInfo = {
+      ...fakeSession().modelInfo,
+      slug: "gpt-5.4",
+      supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
+      serviceTiers: [
+        {
+          id: "priority",
+          name: "Fast",
+          description: "1.5x speed, increased usage",
+        },
+        {
+          id: "standard",
+          name: "Standard",
+          description: "standard queue",
+        },
+      ],
+    };
+    const requestedModelInfo = {
+      ...fakeSession().modelInfo,
+      slug: "gpt-5.3-codex", // branding-scan: allow OpenAI model identifier
+      supportedReasoningLevels: ["low", "medium"],
+      serviceTiers: [
+        {
+          id: "standard",
+          name: "Standard",
+          description: "standard queue",
+        },
+      ],
+    };
+    const session = fakeSession();
+    (session.services as unknown as {
+      modelsManager: {
+        tryListModels: () => readonly unknown[];
+        listModels: () => Promise<readonly unknown[]>;
+        getModelInfo: (model: string) => Promise<unknown>;
+      };
+    }).modelsManager = {
+      tryListModels: () => [roleModelInfo, requestedModelInfo],
+      listModels: async () => [roleModelInfo, requestedModelInfo],
+      getModelInfo: async (model: string) =>
+        model === roleModelInfo.slug ? roleModelInfo : requestedModelInfo,
+    };
+    registerAgentRole({
+      name: "priority-reviewer",
+      config: {
+        description: "Review quickly.",
+        configToml: [
+          'model = "gpt-5.4"',
+          'model_reasoning_effort = "high"',
+          'service_tier = "priority"',
+        ].join("\n"),
+      },
+    });
+    delegateMock.mockResolvedValue({
+      kind: "async_launched",
+      thread: {
+        live: {
+          agentId: "thread-priority",
+          agentPath: "/root/priority_review",
+          nickname: "Priority Review",
+          role: { name: "priority-reviewer" },
+          status: {
+            value: {
+              status: "running",
+              turnId: "turn-priority",
+              startedAtMs: 1,
+            },
+          },
+        },
+        join: vi.fn(async () => ({
+          threadId: "thread-priority",
+          durationMs: 1,
+          outcome: "completed",
+          finalMessage: "done",
+        })),
+      },
+    });
+
+    const result = await createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => session,
+    }).find((tool) => tool.name === "spawn_agent")!.execute({
+      message: "inspect",
+      task_name: "priority_review",
+      agent_type: "priority-reviewer",
+      model: "gpt-5.3-codex", // branding-scan: allow OpenAI model identifier
+      reasoning_effort: "low",
+      service_tier: "standard",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(delegateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "priority-reviewer",
+        model: "gpt-5.4",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+      }),
+    );
+  });
+
+  it("does not let a role service tier hide an invalid spawn_agent service_tier request", async () => {
+    const roleModelInfo = {
+      ...fakeSession().modelInfo,
+      slug: "gpt-5.4",
+      serviceTiers: [
+        {
+          id: "priority",
+          name: "Fast",
+          description: "1.5x speed, increased usage",
+        },
+      ],
+    };
+    const session = fakeSession();
+    (session.services as unknown as {
+      modelsManager: {
+        tryListModels: () => readonly unknown[];
+        listModels: () => Promise<readonly unknown[]>;
+        getModelInfo: (model: string) => Promise<unknown>;
+      };
+    }).modelsManager = {
+      tryListModels: () => [roleModelInfo],
+      listModels: async () => [roleModelInfo],
+      getModelInfo: async () => roleModelInfo,
+    };
+    registerAgentRole({
+      name: "priority-reviewer",
+      config: {
+        description: "Review quickly.",
+        configToml: [
+          'model = "gpt-5.4"',
+          'service_tier = "priority"',
+        ].join("\n"),
+      },
+    });
+
+    const result = await createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => session,
+    }).find((tool) => tool.name === "spawn_agent")!.execute({
+      message: "inspect",
+      task_name: "priority_review",
+      agent_type: "priority-reviewer",
+      service_tier: "turbo",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toBe(
+      "Service tier `turbo` is not supported for model `gpt-5.4`. Supported service tiers: priority",
+    );
+    expect(delegateMock).not.toHaveBeenCalled();
   });
 
   it("allows explicit service_tier on full-history spawn_agent forks", async () => {


### PR DESCRIPTION
## Summary
- derive role model and service-tier hints from role TOML layers
- apply role model, reasoning, and service tier after valid spawn_agent overrides before delegating child runs
- cover role service-tier prompt text, invalid requested tiers, and direct runAgent child-session config

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/agents/role.test.ts tests/bin/model-facing-tools.test.ts tests/agents/run-agent.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm run check:agent-surface-contract -- --command-timeout-ms 600000
- npm --workspace=@tetsuo-ai/runtime run validate:required
- npm --workspace=@tetsuo-ai/runtime run check:unused:report
- git diff --check