### PR TITLE
fix(agents): reuse completed agents for follow-up turns

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -201,6 +201,7 @@
         "enforces the default child depth cap while preserving configured per-session overrides",
         "maps role configuration into child model, tools, permission, prompt, service tier, and runtime limits",
         "normalizes final and nonfinal agent statuses consistently for list and TUI consumers",
+        "allows completed live agents to transition back to running for later follow-up turns while keeping errored, shutdown, and not_found irreversible",
         "routes child terminal notifications through inter-agent communication for live and root parents, with a no-turn not_found fallback when the child handle is missing"
       ],
       "edgeCases": [
@@ -211,6 +212,7 @@
         "a role TOML layer with model, reasoning, and service_tier exposes those locked settings in the spawn tool description",
         "an interrupt racing with spawn finalization releases the reserved slot and emits an interrupted status",
         "a child completion whose parent is the root thread is delivered to the root session mailbox without triggering a turn",
+        "a child completion watcher emits a distinct parent notification for each completed turn after a follow-up restarts the same live child",
         "a completion watcher for a missing child handle emits a not_found subagent notification to the parent without triggering a turn"
       ],
       "tests": [
@@ -350,6 +352,7 @@
         "keeps background task lifecycle, agent lifecycle, and TUI task views synchronized from one authoritative state",
         "applies role allowlists and tool policies before child tools execute",
         "spawn_agent v2 accepts service_tier, validates it against the effective child model, applies role model/reasoning/service_tier after valid request overrides, allows explicit service_tier with full-history forks, and forwards the selected tier to child runs",
+        "followup_task v2 accepts a completed live agent and sends a trigger-turn inter-agent communication instead of treating completed as a closed terminal state",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
         "close_agent emits the close-end event with the previous status even when close request delivery fails"
       ],
@@ -362,6 +365,7 @@
         "spawn_agent gives role service_tier precedence over a valid requested service_tier when the resolved model supports both",
         "spawn_agent allows an explicit service_tier when fork_turns is all while still rejecting full-history model and effort overrides",
         "a child spawned with service_tier priority forwards priority into the provider request options",
+        "followup_task sends triggerTurn true to a completed live child and still emits begin/end interaction events with the current status",
         "closing a running agent interrupts it once and produces an idempotent terminal task status",
         "a close_agent shutdown failure still emits collab_close_end and returns a structured tool error",
         "a fork containing multiple pending tool calls creates one placeholder result per call before child instructions",

--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -1248,20 +1248,22 @@ export class AgentControl {
     child: LiveAgent,
     parentId: ThreadId,
   ): Promise<void> {
-    await new Promise<void>((resolve) => {
-      if (isFinal(child.status.value)) {
-        resolve();
-        return;
-      }
-      const unsubscribe = child.status.subscribe((status) => {
-        if (isFinal(status)) {
-          unsubscribe();
-          resolve();
-        }
-      });
-    });
+    let lastNotifiedStatusKey: string | undefined;
+    for await (const status of child.status.changes()) {
+      if (!isFinal(status)) continue;
+      const statusKey = completionStatusKey(status);
+      if (statusKey === lastNotifiedStatusKey) continue;
+      lastNotifiedStatusKey = statusKey;
+      await this.sendCompletionNotification(child, parentId, status);
+      if (status.status !== "completed") return;
+    }
+  }
 
-    const final = child.status.value;
+  private async sendCompletionNotification(
+    child: LiveAgent,
+    parentId: ThreadId,
+    final: AgentStatus,
+  ): Promise<void> {
     const message = formatSubagentNotification({
       agentPath: child.agentPath,
       status: final,
@@ -1646,6 +1648,21 @@ function parentAgentPathFor(agentPath: AgentPath): AgentPath | undefined {
   if (index <= 0) return undefined;
   const parentPath = agentPath.slice(0, index);
   return parentPath.length > 0 ? (parentPath as AgentPath) : undefined;
+}
+
+function completionStatusKey(status: AgentStatus): string {
+  switch (status.status) {
+    case "completed":
+    case "errored":
+    case "interrupted":
+    case "running":
+      return `${status.status}:${status.turnId}`;
+    case "shutdown":
+      return `${status.status}:${status.endedAtMs}`;
+    case "pending_init":
+    case "not_found":
+      return status.status;
+  }
 }
 
 /** Port of reference runtime `agent_matches_prefix` (`control.rs:1173`). */

--- a/runtime/src/agents/status.ts
+++ b/runtime/src/agents/status.ts
@@ -5,8 +5,13 @@
  * state transitions of a spawned subagent from creation through
  * terminal states.
  *
- * Final states: `completed`, `errored`, `shutdown`, `not_found`.
+ * Final states for wait/list semantics: `completed`, `errored`, `shutdown`,
+ * `not_found`.
  * Non-final: `pending_init`, `running`, `interrupted`.
+ *
+ * A completed turn is reusable: `followup_task` may move the same live agent
+ * from `completed` back to `running` for its next turn. Shutdown, errored, and
+ * not_found remain irreversible.
  *
  * `interrupted` is intentionally non-final (matches reference runtime
  * `status.rs` — `is_final` returns false for `Running | PendingInit |
@@ -58,6 +63,12 @@ export type AgentStatusJson =
 
 const FINAL_STATES: ReadonlySet<AgentStatus["status"]> = new Set([
   "completed",
+  "errored",
+  "shutdown",
+  "not_found",
+]);
+
+const IRREVERSIBLE_STATES: ReadonlySet<AgentStatus["status"]> = new Set([
   "errored",
   "shutdown",
   "not_found",
@@ -243,16 +254,19 @@ export class AgentStatusTracker {
     return this.subject.subscribe(listener);
   }
 
+  changes(): AsyncIterable<AgentStatus> {
+    return this.subject.changes();
+  }
+
   complete(): void {
     this.subject.complete();
   }
 
   private set(status: AgentStatus): void {
-    // Only genuinely terminal states are sticky (`completed`,
-    // `errored`, `shutdown`). `interrupted` is non-final — the
-    // tracker may transition back to `running` (e.g. resume) or
-    // onward to a truly terminal state.
-    if (isFinal(this.subject.value)) return;
+    // Only irreversible states are sticky. `completed` is final for wait/list
+    // semantics, but a live agent can still accept followup_task and start a
+    // later turn.
+    if (IRREVERSIBLE_STATES.has(this.subject.value.status)) return;
     this.subject.next(status);
   }
 }

--- a/runtime/src/agents/v2/message-tool.ts
+++ b/runtime/src/agents/v2/message-tool.ts
@@ -1,6 +1,5 @@
 import type { ToolResult } from "../../tools/types.js";
 import type { ThreadId } from "../registry.js";
-import { isFinal, toAgentStatusJson } from "../status.js";
 import {
   callIdFromArgs,
   currentAgentContext,
@@ -14,14 +13,6 @@ import {
 } from "./common.js";
 
 export type MessageDeliveryMode = "queue_only" | "trigger_turn";
-
-function terminalStatusLabel(status: Parameters<typeof toAgentStatusJson>[0]): string {
-  const statusJson = toAgentStatusJson(status);
-  if (typeof statusJson === "string") return statusJson;
-  if ("completed" in statusJson) return "completed";
-  if ("errored" in statusJson) return "errored";
-  return "terminal";
-}
 
 export async function handleMessageStringTool(
   args: Record<string, unknown>,
@@ -59,7 +50,6 @@ export async function handleMessageStringTool(
   if (!receiverAgentPath) {
     return json({ error: "target agent is missing an agent_path" }, true);
   }
-  const liveStatus = live?.status?.value;
   emit(sessionOrError, {
     type: "collab_agent_interaction_begin",
     payload: {
@@ -69,25 +59,6 @@ export async function handleMessageStringTool(
       prompt: message,
     },
   });
-  if (liveStatus && isFinal(liveStatus)) {
-    emit(sessionOrError, {
-      type: "collab_agent_interaction_end",
-      payload: {
-        callId,
-        senderThreadId: current.threadId,
-        receiverThreadId: agentId,
-        ...receiverMetadataFor(sessionOrError, agentId, opts),
-        prompt: message,
-        status: liveStatus,
-      },
-    });
-    return json(
-      {
-        error: `target agent ${receiverAgentPath} is ${terminalStatusLabel(liveStatus)} and cannot accept new messages`,
-      },
-      true,
-    );
-  }
   let deliveryError: unknown;
   try {
     await control.sendInterAgentCommunication(agentId, {

--- a/runtime/tests/agents/control.test.ts
+++ b/runtime/tests/agents/control.test.ts
@@ -577,6 +577,39 @@ describe("AgentControl", () => {
     expect(msg.metadata?.kind).toBe("inter_agent_communication");
   });
 
+  it("maybeStartCompletionWatcher() notifies the parent after every completed child turn", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry, maxDepth: 2 });
+    const parent = await control.spawn({ parentPath: "/root" });
+    const child = await control.spawn({ parentPath: parent.agentPath });
+
+    control.maybeStartCompletionWatcher({
+      childThreadId: child.agentId,
+      parentThreadId: parent.agentId,
+    });
+    child.status.markCompleted("turn-1", "first done");
+    await new Promise<void>((r) => setTimeout(r, 10));
+    expect(
+      parent.downInbox.drain().map((msg) =>
+        "content" in msg ? msg.content : "",
+      ),
+    ).toEqual([
+      `<subagent_notification>\n{"agent_path":"${child.agentPath}","status":{"completed":"first done"}}\n</subagent_notification>`,
+    ]);
+
+    child.status.markRunning("turn-2");
+    child.status.markCompleted("turn-2", "second done");
+    await new Promise<void>((r) => setTimeout(r, 10));
+    expect(
+      parent.downInbox.drain().map((msg) =>
+        "content" in msg ? msg.content : "",
+      ),
+    ).toEqual([
+      `<subagent_notification>\n{"agent_path":"${child.agentPath}","status":{"completed":"second done"}}\n</subagent_notification>`,
+    ]);
+  });
+
   it("maybeStartCompletionWatcher() queues root-child completion through the root session mailbox", async () => {
     const session = stubSession({ conversationId: "root-thread" });
     const registry = new AgentRegistry();

--- a/runtime/tests/agents/status.test.ts
+++ b/runtime/tests/agents/status.test.ts
@@ -30,12 +30,17 @@ describe("AgentStatusTracker", () => {
     if (s.status === "interrupted") expect(s.reason).toBe("parent_interrupt");
   });
 
-  it("final→final overrides are ignored (sticky final pair)", () => {
+  it("allows a completed agent to start another turn", () => {
     const t = new AgentStatusTracker();
     t.markCompleted("turn-1");
-    // final→final: ignored.
-    t.markShutdown();
-    expect(t.value.status).toBe("completed");
+    t.markRunning("turn-2");
+    expect(t.value).toMatchObject({ status: "running", turnId: "turn-2" });
+    t.markCompleted("turn-2", "done again");
+    expect(t.value).toMatchObject({
+      status: "completed",
+      turnId: "turn-2",
+      lastMessage: "done again",
+    });
   });
 
   it("isFinal classifies terminal states", () => {
@@ -67,6 +72,17 @@ describe("AgentStatusTracker", () => {
     t.markShutdown();
     t.markRunning("turn-1");
     expect(t.value.status).toBe("shutdown");
+  });
+
+  it("errored stays sticky and rejects further transitions", () => {
+    const t = new AgentStatusTracker();
+    t.markErrored("turn-1", "boom");
+    t.markRunning("turn-2");
+    expect(t.value).toMatchObject({
+      status: "errored",
+      turnId: "turn-1",
+      error: "boom",
+    });
   });
 
   it("subscribe delivers replay of current state", () => {

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -2988,7 +2988,7 @@ describe("model-facing tools", () => {
     expect(waitForMailboxChange).toHaveBeenCalledWith(10_000);
   });
 
-  it("rejects messages to terminal live agents instead of reporting false delivery", async () => {
+  it("followup_task accepts a completed live agent and triggers the next turn", async () => {
     const session = fakeSession();
     const emitted: unknown[] = [];
     (session as unknown as { emit: typeof session.emit }).emit = (event) => {
@@ -3044,11 +3044,14 @@ describe("model-facing tools", () => {
         message: "report now",
       });
 
-      expect(result.isError).toBe(true);
-      expect(JSON.parse(result.content).error).toBe(
-        "target agent /root/task_1 is completed and cannot accept new messages",
-      );
-      expect(sendInterAgentCommunication).not.toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBe("");
+      expect(sendInterAgentCommunication).toHaveBeenCalledWith("agent-1", {
+        author: "/root",
+        recipient: "/root/task_1",
+        content: "report now",
+        triggerTurn: true,
+      });
       expect(
         emitted.map((event) => (event as { msg: { type: string } }).msg.type),
       ).toEqual([

--- a/runtime/tests/tui/components/TaskListV2.render.test.tsx
+++ b/runtime/tests/tui/components/TaskListV2.render.test.tsx
@@ -57,7 +57,7 @@ vi.mock("../../tasks/InProcessTeammateTask/types.js", () => ({
 
 vi.mock("../../utils/collapseReadSearch.js", () => ({
   summarizeRecentActivities: (
-    activities: readonly Array<{ readonly activityDescription?: string }>,
+    activities: ReadonlyArray<{ readonly activityDescription?: string }>,
   ) => activities.map(activity => activity.activityDescription).filter(Boolean).join(" + "),
 }));
 

--- a/runtime/tests/tui/coverage-swarm/swarm-161-components-TaskListV2.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-161-components-TaskListV2.test.tsx
@@ -54,7 +54,7 @@ vi.mock("../../../src/tasks/InProcessTeammateTask/types.js", () => ({
 
 vi.mock("../../../src/utils/collapseReadSearch.js", () => ({
   summarizeRecentActivities: (
-    activities: readonly Array<{ readonly activityDescription?: string }>,
+    activities: ReadonlyArray<{ readonly activityDescription?: string }>,
   ) => activities.map(activity => activity.activityDescription).filter(Boolean).join(" + "),
 }));
 


### PR DESCRIPTION
## Summary
- Allow live agents that completed a turn to accept follow-up work and move back to running.
- Keep parent completion watching active across repeated completed turns so each follow-up completion notifies the parent.
- Let v2 agent message delivery report real delivery errors instead of pre-rejecting completed live agents.
- Fix invalid readonly generic syntax in two TaskListV2 render tests.

## Validation
- npm --workspace=@tetsuo-ai/runtime run validate:required
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 09-ctrl-c-mid-stream
- npm --workspace=@tetsuo-ai/runtime run check:unused:report
- git diff --check