### PR TITLE
fix(agents): honor configured wait timeouts

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -354,12 +354,16 @@
         "spawn_agent v2 accepts service_tier, validates it against the effective child model, applies role model/reasoning/service_tier after valid request overrides, allows explicit service_tier with full-history forks, and forwards the selected tier to child runs",
         "followup_task v2 accepts a completed live agent and sends a trigger-turn inter-agent communication instead of treating completed as a closed terminal state",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
+        "wait_agent v2 validates, defaults, and describes timeout_ms from configured min, default, and max wait timeout options",
         "close_agent emits the close-end event with the previous status even when close request delivery fails"
       ],
       "edgeCases": [
         "wait_agent returns completed when any parent mailbox update arrives before the timeout",
         "wait_agent returns timed_out when no parent mailbox update arrives before the timeout",
         "wait_agent rejects timeout_ms below the configured minimum instead of silently clamping",
+        "wait_agent uses the configured default timeout when timeout_ms is omitted",
+        "wait_agent rejects timeout_ms above the configured maximum instead of using the global maximum",
+        "wait_agent rejects fractional timeout_ms values instead of passing fractional milliseconds into the mailbox wait",
         "wait_agent rejects removed v1 targets input as an unknown field",
         "spawn_agent rejects an explicit service_tier unsupported by the role-resolved child model before delegation",
         "spawn_agent gives role service_tier precedence over a valid requested service_tier when the resolved model supports both",

--- a/runtime/src/agents/v2/wait.ts
+++ b/runtime/src/agents/v2/wait.ts
@@ -21,22 +21,66 @@ function waitTimeoutMs(
   const sessionOrError = getSessionOrError(opts);
   if (!("conversationId" in sessionOrError)) return sessionOrError;
   const supplied = numberValue(args.timeout_ms);
-  const configuredMin = sessionOrError.config?.multiAgentV2?.minWaitTimeoutMs;
-  const minTimeoutMs = Math.min(
-    MAX_WAIT_TIMEOUT_MS,
-    Math.max(1, configuredMin ?? MIN_WAIT_TIMEOUT_MS),
-  );
-  const maxTimeoutMs = MAX_WAIT_TIMEOUT_MS;
+  const { defaultTimeoutMs, minTimeoutMs, maxTimeoutMs } =
+    effectiveWaitTimeoutOptions(sessionOrError);
   if (supplied !== undefined && supplied < minTimeoutMs) {
     return json({ error: `timeout_ms must be at least ${minTimeoutMs}` }, true);
   }
   if (supplied !== undefined && supplied > maxTimeoutMs) {
     return json({ error: `timeout_ms must be at most ${maxTimeoutMs}` }, true);
   }
-  return supplied ?? DEFAULT_WAIT_TIMEOUT_MS;
+  return supplied ?? defaultTimeoutMs;
+}
+
+function configuredTimeoutOption(value: unknown, fallback: number): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value)
+  ) {
+    return fallback;
+  }
+  return value;
+}
+
+function effectiveWaitTimeoutOptions(session: {
+  readonly config?: {
+    readonly multiAgentV2?: {
+      readonly minWaitTimeoutMs?: number;
+      readonly defaultWaitTimeoutMs?: number;
+      readonly maxWaitTimeoutMs?: number;
+    };
+  };
+}): {
+  readonly defaultTimeoutMs: number;
+  readonly minTimeoutMs: number;
+  readonly maxTimeoutMs: number;
+} {
+  const cfg = session.config?.multiAgentV2;
+  const minTimeoutMs = configuredTimeoutOption(
+    cfg?.minWaitTimeoutMs,
+    MIN_WAIT_TIMEOUT_MS,
+  );
+  const defaultTimeoutMs = configuredTimeoutOption(
+    cfg?.defaultWaitTimeoutMs,
+    DEFAULT_WAIT_TIMEOUT_MS,
+  );
+  const maxTimeoutMs = configuredTimeoutOption(
+    cfg?.maxWaitTimeoutMs,
+    MAX_WAIT_TIMEOUT_MS,
+  );
+  return { defaultTimeoutMs, minTimeoutMs, maxTimeoutMs };
 }
 
 export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
+  const session = opts.getSession();
+  const { defaultTimeoutMs, minTimeoutMs, maxTimeoutMs } = session
+    ? effectiveWaitTimeoutOptions(session)
+    : {
+        defaultTimeoutMs: DEFAULT_WAIT_TIMEOUT_MS,
+        minTimeoutMs: MIN_WAIT_TIMEOUT_MS,
+        maxTimeoutMs: MAX_WAIT_TIMEOUT_MS,
+      };
   const execute = async (
     args: Record<string, unknown>,
   ): Promise<ToolResult> => {
@@ -49,6 +93,12 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
       (typeof args.timeout_ms !== "number" || !Number.isFinite(args.timeout_ms))
     ) {
       return json({ error: "timeout_ms must be a number" }, true);
+    }
+    if (
+      typeof args.timeout_ms === "number" &&
+      !Number.isInteger(args.timeout_ms)
+    ) {
+      return json({ error: "timeout_ms must be an integer" }, true);
     }
     const sessionOrError = getSessionOrError(opts);
     if (!("conversationId" in sessionOrError)) return sessionOrError;
@@ -117,8 +167,8 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
         timeout_ms: {
           type: "number",
           description:
-            `Optional timeout in milliseconds. Defaults to ${DEFAULT_WAIT_TIMEOUT_MS}, ` +
-            `min ${MIN_WAIT_TIMEOUT_MS}, max ${MAX_WAIT_TIMEOUT_MS}.`,
+            `Optional timeout in milliseconds. Defaults to ${defaultTimeoutMs}, ` +
+            `min ${minTimeoutMs}, max ${maxTimeoutMs}.`,
         },
       },
       additionalProperties: false,

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -3614,6 +3614,8 @@ function deriveMinimalSessionConfig(
     features,
     multiAgentV2: {
       minWaitTimeoutMs: 10_000,
+      defaultWaitTimeoutMs: 30_000,
+      maxWaitTimeoutMs: 3_600_000,
       usageHintEnabled: false,
       usageHintText: "",
       hideSpawnAgentMetadata: false,

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -484,6 +484,8 @@ export interface Config {
   readonly multiAgentV2: {
     readonly maxConcurrentThreadsPerSession?: number;
     readonly minWaitTimeoutMs?: number;
+    readonly defaultWaitTimeoutMs?: number;
+    readonly maxWaitTimeoutMs?: number;
     readonly usageHintEnabled: boolean;
     readonly usageHintText: string;
     readonly rootAgentUsageHintText?: string;

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -2988,6 +2988,64 @@ describe("model-facing tools", () => {
     expect(waitForMailboxChange).toHaveBeenCalledWith(10_000);
   });
 
+  it("wait_agent uses configured default and max timeout bounds", async () => {
+    const session = fakeSession();
+    (session as unknown as {
+      config: {
+        multiAgentV2: {
+          minWaitTimeoutMs: number;
+          defaultWaitTimeoutMs: number;
+          maxWaitTimeoutMs: number;
+        };
+      };
+    }).config = {
+      multiAgentV2: {
+        minWaitTimeoutMs: 500,
+        defaultWaitTimeoutMs: 1_250,
+        maxWaitTimeoutMs: 2_000,
+      },
+    };
+    const waitForMailboxChange = vi.fn(async () => true);
+    const sessionWithMailboxWait = session as unknown as {
+      waitForMailboxChange: typeof waitForMailboxChange;
+    };
+    sessionWithMailboxWait.waitForMailboxChange = waitForMailboxChange;
+    const wait = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => session,
+    }).find((tool) => tool.name === "wait_agent")!;
+
+    const defaulted = await wait.execute({});
+    const tooLarge = await wait.execute({ timeout_ms: 2_001 });
+
+    expect(defaulted.isError).toBeUndefined();
+    expect(waitForMailboxChange).toHaveBeenCalledWith(1_250);
+    expect(JSON.parse(tooLarge.content)).toEqual({
+      error: "timeout_ms must be at most 2000",
+    });
+    expect(tooLarge.isError).toBe(true);
+    expect(
+      wait.inputSchema.properties?.timeout_ms &&
+        "description" in wait.inputSchema.properties.timeout_ms
+        ? wait.inputSchema.properties.timeout_ms.description
+        : undefined,
+    ).toBe("Optional timeout in milliseconds. Defaults to 1250, min 500, max 2000.");
+  });
+
+  it("wait_agent rejects fractional timeout_ms values", async () => {
+    const wait = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => fakeSession(),
+    }).find((tool) => tool.name === "wait_agent")!;
+
+    const result = await wait.execute({ timeout_ms: 10_000.5 });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content)).toEqual({
+      error: "timeout_ms must be an integer",
+    });
+  });
+
   it("followup_task accepts a completed live agent and triggers the next turn", async () => {
     const session = fakeSession();
     const emitted: unknown[] = [];


### PR DESCRIPTION
## Summary
- Honor configured min, default, and max wait_agent timeout options in the v2 tool surface.
- Reject fractional timeout_ms values before waiting on the mailbox.
- Update the agent-surface contract and model-facing tool tests for the timeout behavior.

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest -- run tests/bin/model-facing-tools.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest -- run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx tests/bin/model-facing-tools.test.ts tests/agents/run-agent.test.ts tests/llm/model-registry.test.ts tests/llm/models-manager.test.ts tests/phases/stream-model.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm run check:agent-surface-contract -- --command-timeout-ms 600000
- npm --workspace=@tetsuo-ai/runtime run validate:required
- npm --workspace=@tetsuo-ai/runtime run check:unused:report
- git diff --check