### PR TITLE
fix(tui): keep autocomplete enter handlers current

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/126-at-picker-carriage-return-enter.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/126-at-picker-carriage-return-enter.mjs
@@ -1,0 +1,52 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForFrameText(session, pattern, label, timeout = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    if (pattern.test(session.latestFrame)) return;
+    if (session.exited) {
+      throw new Error(`waitForFrameText(${label}): TUI exited`);
+    }
+    await sleep(100);
+  }
+  throw new Error(
+    `waitForFrameText(${label}): timeout after ${timeout}ms\n\n${session.latestFrame}`,
+  );
+}
+
+export const meta = {
+  description: "@ files/resources picker accepts carriage-return Enter.",
+  slimCwd: true,
+  timeoutMs: 45_000,
+  useTempHome: true,
+};
+
+export default async function (session) {
+  await writeFile(path.join(session.cwd, "PLAN.md"), "test plan\n", "utf8");
+
+  await session.start();
+  await session.waitForPrompt({ timeout: 15_000 });
+
+  await session.type("@PL", { perCharMs: 60 });
+  await session.waitFor(/FILES & RESOURCES/u, {
+    timeout: 15_000,
+    label: "files/resources picker",
+  });
+
+  session.send("\r");
+  await waitForFrameText(
+    session,
+    /@PLAN\.md/u,
+    "selected file mention inserted via carriage return",
+  );
+
+  if (/FILES & RESOURCES/u.test(session.latestFrame)) {
+    throw new Error("files/resources picker remained open after carriage-return Enter");
+  }
+
+  session.send("\x15");
+  await sleep(120);
+}

--- a/runtime/src/tui/keybindings/useKeybinding.ts
+++ b/runtime/src/tui/keybindings/useKeybinding.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import type { InputEvent } from '../ink/events/input-event.js'
 import { type Key, useInput } from '../ink.js'
 import { useOptionalKeybindingContext } from './KeybindingContext.js'
@@ -39,12 +39,23 @@ export function useKeybinding(
 ): void {
   const { context = 'Global', isActive = true } = options
   const keybindingContext = useOptionalKeybindingContext()
+  const handlerRef = useRef(handler)
+
+  useLayoutEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  const invokeLatestHandler = useCallback(() => handlerRef.current(), [])
 
   // Register handler with the context for ChordInterceptor to invoke
   useEffect(() => {
     if (!keybindingContext || !isActive) return
-    return keybindingContext.registerHandler({ action, context, handler })
-  }, [action, context, handler, keybindingContext, isActive])
+    return keybindingContext.registerHandler({
+      action,
+      context,
+      handler: invokeLatestHandler,
+    })
+  }, [action, context, invokeLatestHandler, keybindingContext, isActive])
 
   const handleInput = useCallback(
     (input: string, key: Key, event: InputEvent) => {
@@ -68,7 +79,7 @@ export function useKeybinding(
           // Chord completed (if any) - clear pending state
           keybindingContext.setPendingChord(null)
           if (result.action === action) {
-            if (handler() !== false) {
+            if (invokeLatestHandler() !== false) {
               event.stopImmediatePropagation()
             }
           }
@@ -92,7 +103,7 @@ export function useKeybinding(
           break
       }
     },
-    [action, context, handler, keybindingContext],
+    [action, context, invokeLatestHandler, keybindingContext],
   )
 
   useInput(handleInput, { isActive })
@@ -125,15 +136,26 @@ export function useKeybindings(
 ): void {
   const { context = 'Global', isActive = true } = options
   const keybindingContext = useOptionalKeybindingContext()
+  const handlersRef = useRef(handlers)
+  const actionKey = useMemo(() => Object.keys(handlers).sort().join('\0'), [handlers])
+
+  useLayoutEffect(() => {
+    handlersRef.current = handlers
+  }, [handlers])
 
   // Register all handlers with the context for ChordInterceptor to invoke
   useEffect(() => {
     if (!keybindingContext || !isActive) return
 
     const unregisterFns: Array<() => void> = []
-    for (const [action, handler] of Object.entries(handlers)) {
+    const actionNames = actionKey === '' ? [] : actionKey.split('\0')
+    for (const action of actionNames) {
       unregisterFns.push(
-        keybindingContext.registerHandler({ action, context, handler }),
+        keybindingContext.registerHandler({
+          action,
+          context,
+          handler: () => handlersRef.current[action]?.(),
+        }),
       )
     }
 
@@ -142,7 +164,7 @@ export function useKeybindings(
         unregister()
       }
     }
-  }, [context, handlers, keybindingContext, isActive])
+  }, [actionKey, context, keybindingContext, isActive])
 
   const handleInput = useCallback(
     (input: string, key: Key, event: InputEvent) => {
@@ -165,8 +187,8 @@ export function useKeybindings(
         case 'match':
           // Chord completed (if any) - clear pending state
           keybindingContext.setPendingChord(null)
-          if (result.action in handlers) {
-            const handler = handlers[result.action]
+          if (result.action in handlersRef.current) {
+            const handler = handlersRef.current[result.action]
             if (handler && handler() !== false) {
               event.stopImmediatePropagation()
             }
@@ -191,7 +213,7 @@ export function useKeybindings(
           break
       }
     },
-    [context, handlers, keybindingContext],
+    [context, keybindingContext],
   )
 
   useInput(handleInput, { isActive })

--- a/runtime/tests/tui/keybindings/useKeybinding.wave200-074.coverage.test.ts
+++ b/runtime/tests/tui/keybindings/useKeybinding.wave200-074.coverage.test.ts
@@ -6,6 +6,11 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 const harness = vi.hoisted(() => ({
   context: undefined as undefined | {
     activeContexts: Set<string>
+    registrations: Array<{
+      action: string
+      context: string
+      handler: () => void | false | Promise<void>
+    }>
     registerHandler: ReturnType<typeof vi.fn>
     resolve: ReturnType<typeof vi.fn>
     setPendingChord: ReturnType<typeof vi.fn>
@@ -103,9 +108,16 @@ function sleep(ms = 25): Promise<void> {
 
 function makeContext() {
   harness.unregisters = []
+  const registrations: Array<{
+    action: string
+    context: string
+    handler: () => void | false | Promise<void>
+  }> = []
   const context = {
     activeContexts: new Set(['Autocomplete', 'Chat']),
-    registerHandler: vi.fn(() => {
+    registrations,
+    registerHandler: vi.fn(registration => {
+      registrations.push(registration)
       const unregister = vi.fn()
       harness.unregisters.push(unregister)
       return unregister
@@ -118,6 +130,7 @@ function makeContext() {
 }
 
 async function renderNode(node: React.ReactNode): Promise<{
+  rerender: (nextNode: React.ReactNode) => Promise<void>
   dispose: () => Promise<void>
 }> {
   const { stdin, stdout } = createStreams()
@@ -129,6 +142,10 @@ async function renderNode(node: React.ReactNode): Promise<{
   root.render(node)
   await sleep()
   return {
+    rerender: async (nextNode: React.ReactNode) => {
+      root.render(nextNode)
+      await sleep()
+    },
     dispose: async () => {
       root.unmount()
       stdin.end()
@@ -196,8 +213,26 @@ describe('useKeybinding wave200 coverage', () => {
       expect(singularContext.registerHandler).toHaveBeenCalledWith({
         action: 'chat:submit',
         context: 'Chat',
-        handler: singularHandler,
+        handler: expect.any(Function),
       })
+
+      const registeredSingularHandler = singularContext.registrations[0]?.handler
+      if (!registeredSingularHandler) {
+        throw new Error('singular registry handler was not captured')
+      }
+      registeredSingularHandler()
+      expect(singularHandler).toHaveBeenCalledTimes(1)
+
+      const nextSingularHandler = vi.fn()
+      await singular.rerender(
+        React.createElement(SingularProbe, {
+          handler: nextSingularHandler,
+        }),
+      )
+      expect(singularContext.registerHandler).toHaveBeenCalledTimes(1)
+      registeredSingularHandler()
+      expect(singularHandler).toHaveBeenCalledTimes(1)
+      expect(nextSingularHandler).toHaveBeenCalledTimes(1)
 
       singularContext.resolve.mockReturnValueOnce({
         type: 'match',
@@ -211,17 +246,17 @@ describe('useKeybinding wave200 coverage', () => {
         ['Autocomplete', 'Chat', 'Global'],
       )
       expect(singularContext.setPendingChord).toHaveBeenLastCalledWith(null)
-      expect(singularHandler).toHaveBeenCalledTimes(1)
+      expect(nextSingularHandler).toHaveBeenCalledTimes(2)
       expect(matched.stopImmediatePropagation).toHaveBeenCalledTimes(1)
 
-      singularHandler.mockReturnValueOnce(false)
+      nextSingularHandler.mockReturnValueOnce(false)
       singularContext.resolve.mockReturnValueOnce({
         type: 'match',
         action: 'chat:submit',
       })
       const fallThrough = event()
       singularInput('s', key(), fallThrough)
-      expect(singularHandler).toHaveBeenCalledTimes(2)
+      expect(nextSingularHandler).toHaveBeenCalledTimes(3)
       expect(fallThrough.stopImmediatePropagation).not.toHaveBeenCalled()
 
       singularContext.resolve.mockReturnValueOnce({
@@ -230,7 +265,7 @@ describe('useKeybinding wave200 coverage', () => {
       })
       const otherAction = event()
       singularInput('c', key(), otherAction)
-      expect(singularHandler).toHaveBeenCalledTimes(2)
+      expect(nextSingularHandler).toHaveBeenCalledTimes(3)
       expect(otherAction.stopImmediatePropagation).not.toHaveBeenCalled()
 
       const pendingChord = [{ key: 'x', ctrl: true }]
@@ -287,6 +322,29 @@ describe('useKeybinding wave200 coverage', () => {
 
     try {
       expect(aggregateContext.registerHandler).toHaveBeenCalledTimes(3)
+      const registeredSubmitHandler = aggregateContext.registrations.find(
+        registration => registration.action === 'chat:submit',
+      )?.handler
+      if (!registeredSubmitHandler) {
+        throw new Error('aggregate registry handler was not captured')
+      }
+      registeredSubmitHandler()
+      expect(submitHandler).toHaveBeenCalledTimes(1)
+
+      const nextSubmitHandler = vi.fn()
+      await aggregate.rerender(
+        React.createElement(AggregateProbe, {
+          handlers: {
+            'chat:cancel': cancelHandler,
+            'chat:maybe': undefined,
+            'chat:submit': nextSubmitHandler,
+          },
+        }),
+      )
+      expect(aggregateContext.registerHandler).toHaveBeenCalledTimes(3)
+      registeredSubmitHandler()
+      expect(submitHandler).toHaveBeenCalledTimes(1)
+      expect(nextSubmitHandler).toHaveBeenCalledTimes(1)
 
       aggregateContext.resolve.mockReturnValueOnce({
         type: 'match',
@@ -299,17 +357,17 @@ describe('useKeybinding wave200 coverage', () => {
         key(),
         ['Autocomplete', 'Chat', 'Global'],
       )
-      expect(submitHandler).toHaveBeenCalledTimes(1)
+      expect(nextSubmitHandler).toHaveBeenCalledTimes(2)
       expect(aggregateMatched.stopImmediatePropagation).toHaveBeenCalledTimes(1)
 
-      submitHandler.mockReturnValueOnce(false)
+      nextSubmitHandler.mockReturnValueOnce(false)
       aggregateContext.resolve.mockReturnValueOnce({
         type: 'match',
         action: 'chat:submit',
       })
       const aggregateFallThrough = event()
       aggregateInput('s', key(), aggregateFallThrough)
-      expect(submitHandler).toHaveBeenCalledTimes(2)
+      expect(nextSubmitHandler).toHaveBeenCalledTimes(3)
       expect(aggregateFallThrough.stopImmediatePropagation).not.toHaveBeenCalled()
 
       aggregateContext.resolve.mockReturnValueOnce({


### PR DESCRIPTION
## Summary
- keep keybinding registry entries dispatching through the latest React handler closures
- add E2E coverage for carriage-return Enter selecting @ file/resource suggestions

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/keybindings/useKeybinding.wave200-074.coverage.test.ts tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/hooks/typeaheadKeyHandling.test.ts tests/tui/hooks/useTypeahead.hook.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run build && npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter at-picker
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-at-picker-cr
- npm run check:agent-surface-contract -- --command-timeout-ms 300000
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e