### PR TITLE
fix(agents): restore csv worker alias parity

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -79,6 +79,22 @@
       "sha256": "f594446174697678b7235dac245d575f10b68e1b6de65dd944fcd06f8e363e84"
     },
     {
+      "path": "core/src/tools/handlers/agent_jobs.rs",
+      "sha256": "41b4197694a02e37218b9dc45e223aad165b47326efc5e285565927bd8c681ff"
+    },
+    {
+      "path": "core/src/tools/handlers/agent_jobs_spec.rs",
+      "sha256": "94c2f5e30317f092ee61708d725e9bc42fce9d760df67f5ca5543f3b9705c763"
+    },
+    {
+      "path": "core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
+      "sha256": "f615b3f59167ec8fd39d80b93f4ecc4164dbc68e485a08e29bb55d3b6b2aeefa"
+    },
+    {
+      "path": "core/src/tools/handlers/agent_jobs/report_agent_job_result.rs",
+      "sha256": "08da0f44b799aadff183bfc12a224d46c339b664e4af48ee2a13df9936695751"
+    },
+    {
       "path": "protocol/src/agent_path.rs",
       "sha256": "18ddefda817a89b299cfbec14ea8e95ff4248e9fe5aca616656f39f7d5cfb045"
     },
@@ -134,6 +150,11 @@
     "runtime/src/tools/AgentTool/forkSubagent.ts",
     "runtime/src/tools/tasks/background.ts",
     "runtime/src/tools/tasks/task-board.ts",
+    "runtime/src/bin/model-facing-tools.ts",
+    "runtime/src/agents/jobs/job-orchestrator.ts",
+    "runtime/src/agents/jobs/csv-reader.ts",
+    "runtime/src/agents/jobs/instruction-template.ts",
+    "runtime/src/state/csv-agent-jobs.ts",
     "runtime/src/tui/workbench/surfaces/AgentSurface.tsx",
     "runtime/src/tui/workbench/agents/AgentsRail.tsx",
     "runtime/src/tui/hooks/useApiKeyVerification.ts",
@@ -166,6 +187,7 @@
     "runtime/tests/tools/tasks/task-tools.test.ts",
     "runtime/tests/commands/agent-management.test.tsx",
     "runtime/tests/bin/model-facing-tools.test.ts",
+    "runtime/tests/agents/jobs/job-orchestrator.test.ts",
     "runtime/tests/llm/model-registry.test.ts",
     "runtime/tests/llm/models-manager.test.ts",
     "runtime/tests/phases/stream-model.test.ts",
@@ -320,6 +342,11 @@
         "core/src/tools/handlers/multi_agents_v2/send_message.rs",
         "core/src/tools/handlers/multi_agents_v2/spawn.rs",
         "core/src/tools/handlers/multi_agents_v2/wait.rs",
+        "core/src/tools/handlers/agent_jobs.rs",
+        "core/src/tools/handlers/agent_jobs_spec.rs",
+        "core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
+        "core/src/tools/handlers/agent_jobs/report_agent_job_result.rs",
+        "state/src/runtime/agent_jobs.rs",
         "protocol/src/openai_models.rs",
         "protocol/src/config_types.rs",
         "models-manager/models.json"
@@ -340,6 +367,11 @@
         "runtime/src/agents/v2/wait.ts",
         "runtime/src/agents/v2/list-agents.ts",
         "runtime/src/agents/v2/close-agent.ts",
+        "runtime/src/bin/model-facing-tools.ts",
+        "runtime/src/agents/jobs/job-orchestrator.ts",
+        "runtime/src/agents/jobs/csv-reader.ts",
+        "runtime/src/agents/jobs/instruction-template.ts",
+        "runtime/src/state/csv-agent-jobs.ts",
         "runtime/src/session/turn-context.ts",
         "runtime/src/llm/model-registry.ts",
         "runtime/src/llm/types.ts",
@@ -356,7 +388,9 @@
         "followup_task v2 accepts a completed live agent and sends a trigger-turn inter-agent communication instead of treating completed as a closed terminal state",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
         "wait_agent v2 validates, defaults, and describes timeout_ms from configured min, default, and max wait timeout options",
-        "close_agent emits the close-end event with the previous status even when close request delivery fails"
+        "close_agent emits the close-end event with the previous status even when close request delivery fails",
+        "spawn_agents_on_csv exposes the Rust CSV agent job schema including max_workers as a max_concurrency alias and dispatches worker subagents through the same background delegate path",
+        "report_agent_job_result records worker result objects and stop requests into the active CSV agent job state"
       ],
       "edgeCases": [
         "wait_agent returns completed when any parent mailbox update arrives before the timeout",
@@ -377,7 +411,10 @@
         "a close_agent shutdown failure still emits collab_close_end and returns a structured tool error",
         "a fork containing multiple pending tool calls creates one placeholder result per call before child instructions",
         "an agent tool with a disallowed role fails before any child run is started",
-        "task-board output excludes internal mailbox details while preserving user-visible progress and status"
+        "task-board output excludes internal mailbox details while preserving user-visible progress and status",
+        "max_workers set to one runs a two-row CSV agent job sequentially instead of dispatching both workers concurrently",
+        "max_concurrency set to zero normalizes to one CSV worker instead of falling back to the default concurrency",
+        "a worker report with stop true cancels the remaining CSV rows while preserving the completed worker result"
       ],
       "tests": [
         "runtime/tests/session/agent-task-lifecycle.test.ts",
@@ -386,13 +423,14 @@
         "runtime/tests/tools/tasks/task-tools.test.ts",
         "runtime/tests/commands/agent-management.test.tsx",
         "runtime/tests/bin/model-facing-tools.test.ts",
+        "runtime/tests/agents/jobs/job-orchestrator.test.ts",
         "runtime/tests/agents/run-agent.test.ts",
         "runtime/tests/llm/model-registry.test.ts",
         "runtime/tests/llm/models-manager.test.ts",
         "runtime/tests/phases/stream-model.test.ts"
       ],
       "commands": [
-        "npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx tests/bin/model-facing-tools.test.ts tests/agents/run-agent.test.ts tests/llm/model-registry.test.ts tests/llm/models-manager.test.ts tests/phases/stream-model.test.ts --reporter=dot"
+        "npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/agent-task-lifecycle.test.ts tests/tasks/lifecycle.test.ts tests/tools/AgentTool/loadAgentsDir.test.ts tests/tools/tasks/task-tools.test.ts tests/commands/agent-management.test.tsx tests/bin/model-facing-tools.test.ts tests/agents/jobs/job-orchestrator.test.ts tests/agents/run-agent.test.ts tests/llm/model-registry.test.ts tests/llm/models-manager.test.ts tests/phases/stream-model.test.ts --reporter=dot"
       ],
       "status": "required"
     },

--- a/runtime/src/agents/jobs/job-orchestrator.ts
+++ b/runtime/src/agents/jobs/job-orchestrator.ts
@@ -422,11 +422,8 @@ function clampConcurrency(
   requested: number | undefined,
 ): number {
   const raw = requested ?? DEFAULT_MAX_CONCURRENCY;
-  return (
-    !Number.isFinite(raw) || raw <= 0
-      ? DEFAULT_MAX_CONCURRENCY
-      : Math.max(1, Math.min(64, Math.floor(raw)))
-  );
+  if (!Number.isFinite(raw)) return DEFAULT_MAX_CONCURRENCY;
+  return Math.max(1, Math.min(64, Math.floor(raw)));
 }
 
 /**

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -175,6 +175,40 @@ function numberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function optionalUnsignedIntegerArg(
+  args: Record<string, unknown>,
+  name: string,
+): number | ToolResult | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return json({ error: `${name} must be a number` }, true);
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    return json({ error: `${name} must be a non-negative integer` }, true);
+  }
+  return value;
+}
+
+function optionalPositiveIntegerArg(
+  args: Record<string, unknown>,
+  name: string,
+): number | ToolResult | undefined {
+  const value = optionalUnsignedIntegerArg(args, name);
+  if (typeof value === "number" && value < 1) {
+    return json({ error: `${name} must be >= 1` }, true);
+  }
+  return value;
+}
+
+function isToolResult(value: unknown): value is ToolResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as ToolResult).content === "string"
+  );
+}
+
 function stringArray(value: unknown): readonly string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")
@@ -972,6 +1006,7 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
         "id_column",
         "output_csv_path",
         "max_concurrency",
+        "max_workers",
         "max_runtime_seconds",
         "output_schema",
       ]),
@@ -990,8 +1025,16 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
     const csvPath = stringValue(args.csv_path)!;
     const idColumn = stringValue(args.id_column);
     const outputCsvPath = stringValue(args.output_csv_path);
-    const maxConcurrency = numberValue(args.max_concurrency);
-    const maxRuntimeSeconds = numberValue(args.max_runtime_seconds);
+    const maxConcurrencyArg = optionalUnsignedIntegerArg(args, "max_concurrency");
+    if (isToolResult(maxConcurrencyArg)) return maxConcurrencyArg;
+    const maxWorkersArg = optionalUnsignedIntegerArg(args, "max_workers");
+    if (isToolResult(maxWorkersArg)) return maxWorkersArg;
+    const maxRuntimeSeconds = optionalPositiveIntegerArg(
+      args,
+      "max_runtime_seconds",
+    );
+    if (isToolResult(maxRuntimeSeconds)) return maxRuntimeSeconds;
+    const maxConcurrency = maxConcurrencyArg ?? maxWorkersArg;
     const outputSchema =
       typeof args.output_schema === "object" &&
       args.output_schema !== null &&
@@ -1181,7 +1224,12 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
           max_concurrency: {
             type: "number",
             description:
-              "Maximum concurrent workers for this job. Defaults to 16.",
+              "Maximum concurrent workers for this job. Defaults to 16 and is capped by config.",
+          },
+          max_workers: {
+            type: "number",
+            description:
+              "Alias for max_concurrency. Set to 1 to run sequentially.",
           },
           max_runtime_seconds: {
             type: "number",

--- a/runtime/src/tui/hooks/typeaheadKeyHandling.ts
+++ b/runtime/src/tui/hooks/typeaheadKeyHandling.ts
@@ -14,7 +14,9 @@ export function consumeAutocompleteEnterKey(
   if (
     event.key !== 'return' &&
     event.key !== 'enter' &&
-    event.key !== 'Enter'
+    event.key !== 'Enter' &&
+    event.key !== '\r' &&
+    event.key !== '\n'
   ) {
     return false
   }

--- a/runtime/tests/agents/jobs/job-orchestrator.test.ts
+++ b/runtime/tests/agents/jobs/job-orchestrator.test.ts
@@ -131,6 +131,49 @@ describe("runAgentsOnCsv", () => {
     );
   });
 
+  it("normalizes zero maxConcurrency to one worker", async () => {
+    const csvPath = join(workDir, "input.csv");
+    await writeFile(csvPath, "id,value\nrow1,a\nrow2,b\n", "utf8");
+    let activeWorkers = 0;
+    let maxActiveWorkers = 0;
+    const reports: Promise<void>[] = [];
+    const spawn: AgentJobSpawn = {
+      async spawn(ctx) {
+        activeWorkers += 1;
+        maxActiveWorkers = Math.max(maxActiveWorkers, activeWorkers);
+        reports.push(
+          new Promise<void>((resolve) => {
+            setTimeout(() => {
+              recordAgentJobResult({
+                jobId: ctx.jobId,
+                itemId: ctx.itemId,
+                result: { echoed: ctx.row.value ?? "" },
+              });
+              activeWorkers -= 1;
+              resolve();
+            }, 5);
+          }),
+        );
+      },
+      async cancelOutstanding() {},
+    };
+
+    const result = await runAgentsOnCsv({
+      csvPath,
+      instruction: "process {value}",
+      idColumn: "id",
+      maxConcurrency: 0,
+      spawn,
+    });
+
+    await Promise.all(reports);
+    expect(result.items.map((item) => item.status)).toEqual([
+      "completed",
+      "completed",
+    ]);
+    expect(maxActiveWorkers).toBe(1);
+  });
+
   it("rejects when csv contains zero data rows", async () => {
     const csvPath = join(workDir, "empty.csv");
     await writeFile(csvPath, "id\n", "utf8");

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -437,7 +437,7 @@ describe("model-facing tools", () => {
     });
   });
 
-  it("uses max_concurrency as the sole CSV agent worker-count parameter", async () => {
+  it("accepts max_concurrency and the upstream max_workers alias", async () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),
       getSession: () => null,
@@ -448,7 +448,7 @@ describe("model-facing tools", () => {
     ).properties;
 
     expect(properties.max_concurrency).toMatchObject({ type: "number" });
-    expect(properties).not.toHaveProperty("max_workers");
+    expect(properties.max_workers).toMatchObject({ type: "number" });
 
     const accepted = await spawn.execute({
       csv_path: "input.csv",
@@ -459,15 +459,82 @@ describe("model-facing tools", () => {
       "tool invoked before session was initialized",
     );
 
-    const rejected = await spawn.execute({
+    const aliasAccepted = await spawn.execute({
       csv_path: "input.csv",
       instruction: "process {value}",
-      max_workers: "2",
+      max_workers: 2,
     });
-    expect(rejected.isError).toBe(true);
-    expect(JSON.parse(rejected.content).error).toBe(
-      "unknown field `max_workers`",
+    expect(JSON.parse(aliasAccepted.content).error).toBe(
+      "tool invoked before session was initialized",
     );
+  });
+
+  it("uses max_workers as the CSV agent concurrency alias", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agenc-csv-alias-"));
+    try {
+      const csvPath = join(root, "input.csv");
+      await writeFile(csvPath, "id,value\nrow1,a\nrow2,b\n", "utf8");
+      const session = fakeSession();
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      });
+      const byName = new Map(tools.map((tool) => [tool.name, tool]));
+      const report = byName.get("report_agent_job_result")!;
+      let activeWorkers = 0;
+      let maxActiveWorkers = 0;
+      const reports: Promise<void>[] = [];
+      delegateMock.mockImplementation(
+        async (ctx: { taskPrompt: string; agentName: string }) => {
+          activeWorkers += 1;
+          maxActiveWorkers = Math.max(maxActiveWorkers, activeWorkers);
+          const jobId = /Job ID: ([^\n]+)/.exec(ctx.taskPrompt)?.[1];
+          const itemId = /Item ID: ([^\n]+)/.exec(ctx.taskPrompt)?.[1];
+          expect(jobId).toBeDefined();
+          expect(itemId).toBeDefined();
+          reports.push(
+            new Promise<void>((resolve) => {
+              setTimeout(() => {
+                void report
+                  .execute({
+                    job_id: jobId,
+                    item_id: itemId,
+                    result: { worker: ctx.agentName },
+                  })
+                  .finally(() => {
+                    activeWorkers -= 1;
+                    resolve();
+                  });
+              }, 5);
+            }),
+          );
+          return {
+            kind: "async_launched",
+            thread: {
+              threadId: `thread-${ctx.agentName}`,
+              join: vi.fn(() => new Promise<void>(() => {})),
+            },
+          };
+        },
+      );
+
+      const result = await byName.get("spawn_agents_on_csv")!.execute({
+        csv_path: csvPath,
+        instruction: "process {value}",
+        id_column: "id",
+        max_workers: 1,
+      });
+
+      await Promise.all(reports);
+      expect(result.isError).not.toBe(true);
+      expect(JSON.parse(result.content).items).toMatchObject([
+        { item_id: "row1", status: "completed" },
+        { item_id: "row2", status: "completed" },
+      ]);
+      expect(maxActiveWorkers).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("returns LSP diagnostics for one file without draining other pending diagnostics", async () => {

--- a/runtime/tests/tui/hooks/typeaheadKeyHandling.test.ts
+++ b/runtime/tests/tui/hooks/typeaheadKeyHandling.test.ts
@@ -19,9 +19,15 @@ function makeEvent(
 }
 
 describe('consumeAutocompleteEnterKey', () => {
-  it.each(['return', 'enter', 'Enter'])(
+  it.each([
+    ['return', 'return'],
+    ['enter', 'enter'],
+    ['Enter', 'Enter'],
+    ['carriage return', '\r'],
+    ['line feed', '\n'],
+  ])(
     'consumes bare %s while suggestions are visible',
-    keyName => {
+    (_name, keyName) => {
       const event = makeEvent({ key: keyName })
 
       expect(consumeAutocompleteEnterKey(event, 1)).toBe(true)


### PR DESCRIPTION
## Summary
- accept the upstream `max_workers` CSV agent job alias and keep `max_concurrency` precedence
- normalize CSV agent concurrency `0` to one worker for upstream parity
- handle raw carriage-return/newline autocomplete Enter events and cover the `@` picker CR path
- expand the agent-surface parity contract for CSV agent job sources and regression cases

Fixes #895

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/hooks/typeaheadKeyHandling.test.ts tests/tui/keybindings/useKeybinding.wave200-074.coverage.test.ts tests/bin/model-facing-tools.test.ts tests/agents/jobs/job-orchestrator.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime run build`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 126-at-picker-carriage-return-enter`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter at-picker`
- `npm run check:agent-surface-contract -- --command-timeout-ms 300000`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run validate:required`