### PR TITLE
fix: resolve root targets before agent messaging

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -11,6 +11,10 @@
       "sha256": "53828c3def4a8e356789e0b59bd101ae843b9bab45c73af6e48cd6ab12394c83"
     },
     {
+      "path": "core/src/agent/agent_resolver.rs",
+      "sha256": "339d52319dfef0bd946fe721c3178e13f8fd39dd05aa8972623f539135985616"
+    },
+    {
       "path": "core/src/agent/registry.rs",
       "sha256": "2caa3524fe451546c516d28d3f7085dad6e731f8c2d7b2c4e54897c11c556843"
     },
@@ -135,6 +139,7 @@
     "runtime/src/llm/types.ts",
     "runtime/src/phases/stream-model.ts",
     "runtime/src/agents/v2/PARITY.md",
+    "runtime/src/agents/v2/common.ts",
     "runtime/src/agents/v2/spawn.ts",
     "runtime/src/agents/v2/send-message.ts",
     "runtime/src/agents/v2/wait.ts",
@@ -332,6 +337,7 @@
       "id": "task-tool-bridge",
       "source": [
         "core/src/agent/control.rs",
+        "core/src/agent/agent_resolver.rs",
         "core/src/agent/role.rs",
         "core/src/thread_manager.rs",
         "core/src/tools/handlers/multi_agents_common.rs",
@@ -364,6 +370,7 @@
         "runtime/src/tools/tasks/background.ts",
         "runtime/src/tools/tasks/task-board.ts",
         "runtime/src/agents/v2/PARITY.md",
+        "runtime/src/agents/v2/common.ts",
         "runtime/src/agents/v2/spawn.ts",
         "runtime/src/agents/v2/send-message.ts",
         "runtime/src/agents/v2/wait.ts",
@@ -389,6 +396,7 @@
         "spawn_agent v2 defaults omitted fork_turns to the Rust default of all, documents that schema default, and requires fork_turns none for clean-fork role/model/reasoning overrides",
         "spawn_agent v2 permits a child agent to spawn descendants under its current agent path and applies a per-call child depth allowance instead of rejecting on the session max-depth cap",
         "followup_task v2 accepts a completed live agent and sends a trigger-turn inter-agent communication instead of treating completed as a closed terminal state",
+        "send_message, followup_task, and close_agent v2 register the current root thread before resolving id or path targets so canonical /root maps to the active root session",
         "list_agents v2 registers the current root thread before listing so the root entry is present even before any child spawn has registered it",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
         "wait_agent v2 validates, defaults, and describes timeout_ms from configured min, default, and max wait timeout options",
@@ -412,6 +420,9 @@
         "spawn_agent allows an explicit service_tier when fork_turns is all while still rejecting full-history model and effort overrides",
         "spawn_agent called from a depth-one child with agent_max_depth set to one spawns a grandchild under the child path and emits begin/end lifecycle events",
         "list_agents called before any child spawn on an unregistered AgentControl returns the registered /root entry instead of an empty agent list",
+        "send_message called from a child to /root on an unregistered AgentControl queues an upward non-triggering inter-agent communication to the root session",
+        "followup_task called from a child to /root on an unregistered AgentControl returns the root-task rejection without enqueuing root mail",
+        "close_agent called with /root on an unregistered AgentControl returns the root-not-spawned rejection instead of an unresolved path error",
         "a child spawned with service_tier priority forwards priority into the provider request options",
         "child session tool filtering keeps v2 agent tools visible at the configured depth cap while still blocking main-thread coordination tools",
         "followup_task sends triggerTurn true to a completed live child and still emits begin/end interaction events with the current status",

--- a/runtime/src/agents/v2/common.ts
+++ b/runtime/src/agents/v2/common.ts
@@ -158,6 +158,7 @@ export function resolveAgentId(
   opts: MultiAgentV2Options,
 ): ThreadId {
   const { control } = opts.ensureAgentControl(session);
+  control.registerSessionRoot(session.conversationId);
   if (target === session.conversationId) return target;
   if (control.getLive(target)) return target;
   return control.resolveAgentReference({

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -30,6 +30,7 @@ import type { LSPServerInstance } from "../services/lsp/LSPServerInstance.js";
 import {
   clearSessionReadState,
   getSessionReadSnapshot,
+  SESSION_ID_ARG,
 } from "../tools/system/filesystem.js";
 import { _resetAgentRolesForTesting, registerAgentRole } from "../agents/role.js";
 
@@ -2950,6 +2951,7 @@ describe("model-facing tools", () => {
       emitted.push(event);
     };
     const control = {
+      registerSessionRoot: vi.fn(),
       getLive: vi.fn((threadId: string) =>
         threadId === "agent-1"
           ? {
@@ -3172,6 +3174,7 @@ describe("model-facing tools", () => {
     };
     const sendInterAgentCommunication = vi.fn();
     const control = {
+      registerSessionRoot: vi.fn(),
       getLive: vi.fn((threadId: string) =>
         threadId === "agent-1"
           ? {
@@ -3336,6 +3339,114 @@ describe("model-facing tools", () => {
     }
   });
 
+  it("send_message resolves the current root target from child context", async () => {
+    const session = fakeSession();
+    const mailboxSend = vi.fn(() => 1);
+    (session as unknown as { mailbox: { hasPending: () => boolean; send: typeof mailboxSend } }).mailbox = {
+      hasPending: () => false,
+      send: mailboxSend,
+    };
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    const child = await control.spawn({
+      parentPath: "/root",
+      threadId: "agent-worker",
+      agentName: "worker",
+    });
+    expect(control.listAgents().some((agent) => agent.agentName === "/root")).toBe(
+      false,
+    );
+    _setAgentControlForTesting(session, { control, registry });
+    try {
+      const sendMessage = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      }).find((tool) => tool.name === "send_message")!;
+
+      const result = await sendMessage.execute({
+        [SESSION_ID_ARG]: child.agentId,
+        target: "/root",
+        message: "done",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBe("");
+      expect(mailboxSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          author: "/root/worker",
+          recipient: "/root",
+          content: "done",
+          triggerTurn: false,
+          direction: "up",
+        }),
+      );
+      expect(control.listAgents().some((agent) => agent.agentName === "/root")).toBe(
+        true,
+      );
+    } finally {
+      _clearAgentControlCacheForTesting(session);
+    }
+  });
+
+  it("followup_task rejects the current root target from child context", async () => {
+    const session = fakeSession();
+    const mailboxSend = vi.fn(() => 1);
+    (session as unknown as { mailbox: { hasPending: () => boolean; send: typeof mailboxSend } }).mailbox = {
+      hasPending: () => false,
+      send: mailboxSend,
+    };
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    const child = await control.spawn({
+      parentPath: "/root",
+      threadId: "agent-worker",
+      agentName: "worker",
+    });
+    _setAgentControlForTesting(session, { control, registry });
+    try {
+      const followup = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      }).find((tool) => tool.name === "followup_task")!;
+
+      const result = await followup.execute({
+        [SESSION_ID_ARG]: child.agentId,
+        target: "/root",
+        message: "run this",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content).error).toBe(
+        "Tasks can't be assigned to the root agent",
+      );
+      expect(mailboxSend).not.toHaveBeenCalled();
+    } finally {
+      _clearAgentControlCacheForTesting(session);
+    }
+  });
+
+  it("close_agent rejects the current root target after resolving it", async () => {
+    const session = fakeSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    _setAgentControlForTesting(session, { control, registry });
+    try {
+      const close = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      }).find((tool) => tool.name === "close_agent")!;
+
+      const result = await close.execute({ target: "/root" });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content).error).toBe(
+        "root is not a spawned agent",
+      );
+    } finally {
+      _clearAgentControlCacheForTesting(session);
+    }
+  });
+
   it("rejects closing the root agent", async () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),
@@ -3359,6 +3470,7 @@ describe("model-facing tools", () => {
       startedAtMs: 1,
     };
     const control = {
+      registerSessionRoot: vi.fn(),
       resolveAgentReference: vi.fn(() => "550e8400-e29b-41d4-a716-446655440003"),
       getLive: vi.fn(() => ({
         agentId: "550e8400-e29b-41d4-a716-446655440003",
@@ -3417,6 +3529,7 @@ describe("model-facing tools", () => {
     };
     const unsubscribe = vi.fn();
     const control = {
+      registerSessionRoot: vi.fn(),
       resolveAgentReference: vi.fn(() => "550e8400-e29b-41d4-a716-446655440004"),
       getLive: vi.fn((threadId: string) =>
         threadId === "550e8400-e29b-41d4-a716-446655440004"

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -35,6 +35,17 @@ describe("session-store", () => {
   let home = "";
   let origHome = "";
 
+  function findDeadPid(): number {
+    for (const pid of [2_147_483_647, 99_999_999, 4_194_303]) {
+      try {
+        process.kill(pid, 0);
+      } catch (err) {
+        if ((err as { code?: string }).code === "ESRCH") return pid;
+      }
+    }
+    throw new Error("unable to find a dead pid for stale-lock test");
+  }
+
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "agenc-session-store-"));
     origHome = process.env.AGENC_HOME ?? "";
@@ -276,11 +287,7 @@ describe("session-store", () => {
     const dir = mkdtempSync(join(tmpdir(), "agenc-lock-stale-"));
     try {
       const lockPath = join(dir, "rollout.jsonl.lock");
-      // Find a PID that is guaranteed dead. `1` is init and is always
-      // alive on POSIX, so we can't use it. Use a very-high PID that
-      // is exceedingly unlikely to be live; kill(pid, 0) should
-      // return ESRCH.
-      const deadPid = 4_194_303; // above most Linux pid_max defaults
+      const deadPid = findDeadPid();
       const stamp = JSON.stringify({
         pid: deadPid,
         startNs: "stale",


### PR DESCRIPTION
## Summary
- register the current root session before v2 agent target resolution in send_message, followup_task, and close_agent paths
- add regression coverage for child-to-/root send_message plus root rejection behavior for followup_task and close_agent
- stabilize the SessionLock stale-holder validation test by selecting a PID confirmed dead at runtime

Fixes #901

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/model-facing-tools.test.ts -- -t "current root target" --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/model-facing-tools.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/session-store.test.ts -- -t "stale-holder reclaim" --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/session-store.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm run check:agent-surface-contract -- --command-timeout-ms 300000
- npm --workspace=@tetsuo-ai/runtime run validate:required