### PR TITLE
fix(tui): repair agents modal and wait summaries

### DIFF
--- a/runtime/src/agents/v2/wait.ts
+++ b/runtime/src/agents/v2/wait.ts
@@ -72,6 +72,53 @@ function effectiveWaitTimeoutOptions(session: {
   return { defaultTimeoutMs, minTimeoutMs, maxTimeoutMs };
 }
 
+type WaitMailboxUpdate = {
+  readonly role: string;
+  readonly content: string;
+};
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (
+          part !== null &&
+          typeof part === "object" &&
+          "text" in part &&
+          typeof (part as { readonly text?: unknown }).text === "string"
+        ) {
+          return (part as { readonly text: string }).text;
+        }
+        return "";
+      })
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+function drainMailboxUpdates(session: unknown): readonly WaitMailboxUpdate[] {
+  const drain = (session as {
+    readonly drainPendingInputMessages?: () => readonly {
+      readonly role?: unknown;
+      readonly content?: unknown;
+    }[];
+  }).drainPendingInputMessages;
+  if (typeof drain !== "function") return [];
+  return drain.call(session)
+    .map((message): WaitMailboxUpdate | null => {
+      const role = typeof message.role === "string" && message.role.length > 0
+        ? message.role
+        : "user";
+      const content = contentToText(message.content);
+      if (content.length === 0) return null;
+      return { role, content };
+    })
+    .filter((message): message is WaitMailboxUpdate => message !== null);
+}
+
 export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
   const session = opts.getSession();
   const { defaultTimeoutMs, minTimeoutMs, maxTimeoutMs } = session
@@ -134,6 +181,7 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
       );
     }
     const timedOut = !mailboxChanged;
+    const updates = timedOut ? [] : drainMailboxUpdates(sessionOrError);
     emit(sessionOrError, {
       type: "collab_waiting_end",
       payload: {
@@ -142,11 +190,13 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
         statuses: {},
         timedOut,
         agentStatuses: [],
+        ...(updates.length > 0 ? { mailboxUpdates: updates } : {}),
       },
     });
     return json({
       message: timedOut ? "Wait timed out." : "Wait completed.",
       timed_out: timedOut,
+      ...(updates.length > 0 ? { updates } : {}),
     });
   };
 
@@ -154,9 +204,9 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
     name: "wait_agent",
     description:
       "Wait for a mailbox update from any live agent, including queued messages " +
-      "and final-status notifications. Does not return the content; returns either " +
-      "a summary of which agents have updates (if any), " +
-      "or a timeout summary if no mailbox update arrives before the deadline.",
+      "and final-status notifications. When updates arrive, returns the drained " +
+      "mailbox content so you can report completed agent findings immediately. " +
+      "If no mailbox update arrives before the deadline, returns a timeout summary.",
     metadata: toolMetadata("agent", { keywords: ["agent", "wait", "status"] }),
     isReadOnly: true,
     recoveryCategory: "side-effecting",

--- a/runtime/src/commands/agents-menu.tsx
+++ b/runtime/src/commands/agents-menu.tsx
@@ -510,8 +510,8 @@ function AgentsDefinitionsEditor({
 
   return (
     <Popup
-      title="agents · definitions editor"
-      status={`${activeCount} active · ${registeredCount} registered${scrollStatus}`}
+      title="agents"
+      status={`${activeCount} delegate-capable · ${registeredCount} registered${scrollStatus}`}
       footer={[
         { keyName: "up/down", label: "select" },
         { keyName: "enter", label: "detail" },
@@ -523,7 +523,7 @@ function AgentsDefinitionsEditor({
     >
       <Box flexDirection="column">
         <ThemedText color="muted3" wrap="truncate-end">
-          {activeCount} active · {registeredCount} registered
+          {activeCount} delegate-capable · {registeredCount} registered · q/esc close
         </ThemedText>
         <Box flexDirection="row">
           <Box width={2} />
@@ -589,10 +589,11 @@ function AgentDetailModal({
   return (
     <Popup
       title={`agent detail · ${agentIdentityLabel(agent)}`}
-      status="e edit · d delete · esc back"
+      status="e edit · d delete · q close · esc back"
       footer={[
         { keyName: "e", label: "edit" },
         { keyName: "d", label: "delete" },
+        { keyName: "q", label: "close" },
         { keyName: "esc", label: "back" },
       ]}
     >
@@ -619,7 +620,7 @@ function AgentDeleteModal({
       title="delete agent"
       count={agent.agentType}
       summary={editableAgent(agent) ? "confirmation required" : "read-only"}
-      headerRight="y/n · enter"
+      headerRight="y/n · q close · enter"
       columns={[5, 80]}
       headers={["pick", "effect"]}
       items={rows}
@@ -644,6 +645,8 @@ function AgentDeleteModal({
       footer={[
         { keyName: "y", label: "delete" },
         { keyName: "n", label: "cancel" },
+        { keyName: "q", label: "close" },
+        { keyName: "esc", label: "back" },
       ]}
       hint="built-in, plugin, and flag agents are read-only"
     />
@@ -685,7 +688,7 @@ function AgentFormModal({
             ? `${validation.warnings.length} warning(s)`
             : "valid"
       }
-      headerRight="type · ctrl+s save · esc"
+      headerRight="type · ctrl+s save · ctrl+c close · esc"
       columns={[3, 15, 78]}
       headers={["", "field", "value"]}
       items={rows}
@@ -729,6 +732,8 @@ function AgentFormModal({
         { keyName: "up/down", label: "field" },
         { keyName: "type", label: "edit" },
         { keyName: "ctrl+s", label: "save" },
+        { keyName: "ctrl+c", label: "close" },
+        { keyName: "esc", label: "back" },
       ]}
       hint="space cycles source · backspace deletes"
     />
@@ -956,6 +961,11 @@ function AgentsMenuModal({
   }, [modeAgent, setAppState]);
 
   useInput((input, key) => {
+    if (key.ctrl && input === "c") {
+      closeWithMessage();
+      return;
+    }
+
     if (mode.name === "list") {
       if (key.escape || input === "q") {
         closeWithMessage();
@@ -988,7 +998,11 @@ function AgentsMenuModal({
     }
 
     if (mode.name === "detail") {
-      if (key.escape || input === "q") {
+      if (input === "q") {
+        closeWithMessage();
+        return;
+      }
+      if (key.escape) {
         setMode({ name: "list" });
         return;
       }
@@ -1003,7 +1017,11 @@ function AgentsMenuModal({
     }
 
     if (mode.name === "delete") {
-      if (key.escape || input === "n" || input === "q") {
+      if (input === "q") {
+        closeWithMessage();
+        return;
+      }
+      if (key.escape || input === "n") {
         setMode({ name: "detail", agent: mode.agent });
         return;
       }

--- a/runtime/src/tasks/agent-thread.ts
+++ b/runtime/src/tasks/agent-thread.ts
@@ -25,6 +25,15 @@ import {
 } from "../services/AgentSummary/agentSummary.js";
 import { llmMessageToAgentSummaryMessage } from "../services/AgentSummary/transcript.js";
 
+function finalMessageMetadata(
+  finalMessage: string | undefined,
+): Readonly<Record<string, unknown>> | undefined {
+  if (finalMessage === undefined || finalMessage.trim().length === 0) {
+    return undefined;
+  }
+  return { finalMessage };
+}
+
 export interface AgentThreadTaskHandle {
   readonly threadId?: string;
   readonly threadName?: string;
@@ -189,6 +198,7 @@ export function registerAgentThreadTask(
               metadata: {
                 durationMs: result.durationMs,
                 outcome: result.outcome,
+                ...finalMessageMetadata(result.finalMessage),
               },
             };
           case "errored":
@@ -274,7 +284,11 @@ function mapAgentStatus(
       case "interrupted":
         return lifecycle.appendOutput(taskId, `\n[agent interrupted: ${status.reason}]\n`);
       case "completed":
-        return lifecycle.complete(taskId, status.lastMessage);
+        return lifecycle.complete(
+          taskId,
+          status.lastMessage,
+          finalMessageMetadata(status.lastMessage),
+        );
       case "errored":
         return lifecycle.fail(taskId, status.error);
       case "shutdown":

--- a/runtime/src/tasks/app-state-bridge.ts
+++ b/runtime/src/tasks/app-state-bridge.ts
@@ -1,6 +1,8 @@
 import type { BackgroundTaskSnapshot } from "./lifecycle.js";
 import type { LocalAgentTaskState, TaskState } from "./types.js";
 
+const PANEL_GRACE_MS = 30_000;
+
 export interface TaskAppStateBridge {
   setAppState?: (updater: (prev: unknown) => unknown) => void;
 }
@@ -26,15 +28,37 @@ function localAgentTaskFromSnapshot(
   if (snapshot.type !== "local_agent") return null;
   const previousAgent =
     previous?.type === "local_agent" ? (previous as LocalAgentTaskState) : undefined;
-  const progress = snapshot.progress;
   const threadName = stringMetadata(snapshot.metadata, "threadName");
   const agentRole = stringMetadata(snapshot.metadata, "agentRole");
   const model = stringMetadata(snapshot.metadata, "model");
+  const finalMessage = stringMetadata(snapshot.metadata, "finalMessage");
   const cwd = stringMetadata(snapshot.metadata, "cwd") ?? previousAgent?.cwd;
   const worktreePath =
     stringMetadata(snapshot.metadata, "worktreePath") ??
     previousAgent?.worktreePath;
   const path = stringMetadata(snapshot.metadata, "path") ?? previousAgent?.path;
+  const terminal =
+    snapshot.status === "completed" ||
+    snapshot.status === "failed" ||
+    snapshot.status === "killed";
+  const progress = finalMessage !== undefined
+    ? {
+        ...snapshot.progress,
+        toolUseCount:
+          snapshot.progress?.toolUseCount ??
+          previousAgent?.progress?.toolUseCount ??
+          0,
+        tokenCount:
+          snapshot.progress?.tokenCount ??
+          previousAgent?.progress?.tokenCount ??
+          0,
+        summary: finalMessage,
+      }
+    : snapshot.progress;
+  const evictAfter =
+    terminal && previousAgent?.retain !== true
+      ? previousAgent?.evictAfter ?? Date.now() + PANEL_GRACE_MS
+      : previousAgent?.evictAfter;
   return {
     id: snapshot.id,
     type: "local_agent",
@@ -75,9 +99,7 @@ function localAgentTaskFromSnapshot(
       ? { unregisterCleanup: previousAgent.unregisterCleanup }
       : {}),
     ...(previousAgent?.result !== undefined ? { result: previousAgent.result } : {}),
-    ...(previousAgent?.evictAfter !== undefined
-      ? { evictAfter: previousAgent.evictAfter }
-      : {}),
+    ...(evictAfter !== undefined ? { evictAfter } : {}),
   };
 }
 

--- a/runtime/src/tasks/types.ts
+++ b/runtime/src/tasks/types.ts
@@ -71,6 +71,7 @@ export interface AgentProgressActivity {
 export interface AgentProgress {
   readonly toolUseCount?: number;
   readonly tokenCount?: number;
+  readonly summary?: string;
   readonly lastActivity?: AgentProgressActivity;
   readonly recentActivities?: readonly AgentProgressActivity[];
 }

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1144,6 +1144,25 @@ function parseSubagentNotification(message: string): {
   }
 }
 
+function collabMailboxUpdateDetails(updates: unknown): readonly string[] {
+  if (!Array.isArray(updates)) return [];
+  return updates.flatMap((entry): readonly string[] => {
+    if (!entry || typeof entry !== "object") return [];
+    const value = entry as Record<string, unknown>;
+    const content = nonEmptyString(value.content);
+    if (!content) return [];
+    const parsed = parseSubagentNotification(content);
+    if (parsed) {
+      const detail = parsed.details.length > 0
+        ? `: ${parsed.details.join(" · ")}`
+        : "";
+      return [`${parsed.title}${detail}`];
+    }
+    const role = nonEmptyString(value.role) ?? "message";
+    return [`${role}: ${truncatePreview(content, 160)}`];
+  });
+}
+
 function collectSettledCollabSpawnCallIds(
   events: readonly SessionTranscriptEvent[],
 ): ReadonlySet<string> {
@@ -2267,6 +2286,7 @@ export function adaptTranscriptEvents(
             );
           }
         }
+        details.push(...collabMailboxUpdateDetails(payload.mailboxUpdates));
         out.push(
           makeCollabAgentMessage(
             timedOut ? "Wait call timed out" : "Finished waiting",

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -3080,6 +3080,69 @@ describe("model-facing tools", () => {
     }
   });
 
+  it("wait_agent returns drained mailbox updates for the current turn", async () => {
+    const session = fakeSession();
+    const emitted: unknown[] = [];
+    (session as unknown as { emit: typeof session.emit }).emit = (event) => {
+      emitted.push(event);
+    };
+    const waitForMailboxChange = vi.fn(async () => true);
+    const drainPendingInputMessages = vi.fn(() => [
+      {
+        role: "user",
+        content: "Message from reviewer:\nfinished provider-boundary audit",
+      },
+    ]);
+    const sessionWithMailboxWait = session as unknown as {
+      waitForMailboxChange: typeof waitForMailboxChange;
+      drainPendingInputMessages: typeof drainPendingInputMessages;
+    };
+    sessionWithMailboxWait.waitForMailboxChange = waitForMailboxChange;
+    sessionWithMailboxWait.drainPendingInputMessages = drainPendingInputMessages;
+    _setAgentControlForTesting(session, {
+      control: {
+        listAgents: vi.fn(() => []),
+        getLive: vi.fn(() => undefined),
+        resolveAgentReference: vi.fn(() => "agent-1"),
+      } as never,
+      registry: {} as never,
+    });
+    try {
+      const wait = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      }).find((tool) => tool.name === "wait_agent")!;
+
+      const result = await wait.execute({});
+
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content)).toEqual({
+        message: "Wait completed.",
+        timed_out: false,
+        updates: [
+          {
+            role: "user",
+            content: "Message from reviewer:\nfinished provider-boundary audit",
+          },
+        ],
+      });
+      expect(drainPendingInputMessages).toHaveBeenCalledOnce();
+      expect(
+        (
+          emitted[1] as {
+            msg: {
+              payload: {
+                mailboxUpdates: readonly { readonly content: string }[];
+              };
+            };
+          }
+        ).msg.payload.mailboxUpdates[0]?.content,
+      ).toContain("finished provider-boundary audit");
+    } finally {
+      _clearAgentControlCacheForTesting(session);
+    }
+  });
+
   it("wait_agent reports timeout when no parent mailbox update arrives", async () => {
     const session = fakeSession();
     const waitForMailboxChange = vi.fn(async () => false);

--- a/runtime/tests/commands/agent-management.test.tsx
+++ b/runtime/tests/commands/agent-management.test.tsx
@@ -1,7 +1,12 @@
+import { PassThrough } from "node:stream";
+import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { agentsCommand } from "./agent-management.js";
 import type { SlashCommandContext } from "./types.js";
+import { createRoot } from "../tui/ink.js";
+import { AppStateProvider, getDefaultAppState } from "../tui/state/AppState.js";
+import type { AgentDefinition } from "../tools/AgentTool/loadAgentsDir.js";
 
 function makeCtx(
   appState?: SlashCommandContext["appState"],
@@ -13,6 +18,47 @@ function makeCtx(
     home: "/tmp",
     appState,
   };
+}
+
+function testAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+  return {
+    agentType: "reviewer",
+    source: "projectSettings",
+    filename: "reviewer.md",
+    whenToUse: "Review implementation changes and summarize concrete risks.",
+    tools: ["Read", "Grep"],
+    getSystemPrompt: () => "Review the current implementation and report concrete findings.",
+    ...overrides,
+  } as AgentDefinition;
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough;
+  readonly stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY?: boolean;
+    setRawMode?: (enabled: boolean) => void;
+    ref?: () => void;
+    unref?: () => void;
+  };
+  const stdout = new PassThrough() as PassThrough & {
+    columns?: number;
+    rows?: number;
+    isTTY?: boolean;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = vi.fn();
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  stdout.columns = 120;
+  stdout.rows = 30;
+  stdout.isTTY = true;
+  return { stdin, stdout };
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 describe("agentsCommand", () => {
@@ -38,5 +84,53 @@ describe("agentsCommand", () => {
         jsx: expect.anything(),
       }),
     );
+  });
+
+  it("lets q close the agents surface from the detail view", async () => {
+    const setToolJSX = vi.fn();
+    const result = await agentsCommand.execute(makeCtx({ setToolJSX }));
+    const payload = setToolJSX.mock.calls[0]?.[0] as { jsx?: React.ReactNode };
+    const agent = testAgent();
+    const initialState = {
+      ...getDefaultAppState(),
+      agentDefinitions: {
+        activeAgents: [agent],
+        allAgents: [agent],
+      },
+    };
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      expect(result).toEqual({ kind: "skip" });
+      root.render(
+        <AppStateProvider initialState={initialState}>
+          {payload.jsx}
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      stdin.write("\r");
+      await sleep();
+      stdin.write("q");
+      await sleep();
+
+      expect(setToolJSX).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          jsx: null,
+          shouldHidePromptInput: false,
+          clearLocalJSX: true,
+        }),
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
   });
 });

--- a/runtime/tests/tasks/app-state-bridge.test.ts
+++ b/runtime/tests/tasks/app-state-bridge.test.ts
@@ -114,6 +114,42 @@ describe("syncBackgroundTaskSnapshotToAppState", () => {
     });
   });
 
+  it("surfaces final agent messages as completed task summaries", () => {
+    let appState: unknown = { tasks: {} };
+    syncBackgroundTaskSnapshotToAppState(
+      {
+        setAppState(updater) {
+          appState = updater(appState);
+        },
+      },
+      snapshot({
+        status: "completed",
+        endedAtMs: 20,
+        metadata: {
+          threadName: "reviewer",
+          finalMessage: "Found the remaining provider-boundary work.",
+        },
+        progress: {
+          toolUseCount: 4,
+          tokenCount: 500,
+        },
+      }),
+    );
+
+    expect(appState).toMatchObject({
+      tasks: {
+        "agent-1": {
+          status: "completed",
+          progress: {
+            toolUseCount: 4,
+            tokenCount: 500,
+            summary: "Found the remaining provider-boundary work.",
+          },
+        },
+      },
+    });
+  });
+
   it("preserves previous display paths when later lifecycle snapshots omit metadata", () => {
     let appState: unknown = {
       tasks: {

--- a/runtime/tests/tasks/lifecycle.test.ts
+++ b/runtime/tests/tasks/lifecycle.test.ts
@@ -294,6 +294,9 @@ describe("registerAgentThreadTask", () => {
 
     expect(lifecycle.get("agent-2")?.status).toBe("completed");
     expect(lifecycle.readOutput("agent-2")).toBe("summary");
+    expect(lifecycle.get("agent-2")?.metadata).toMatchObject({
+      finalMessage: "summary",
+    });
   });
 
   it("starts AgentSummary for registered threads and writes progress summaries", async () => {

--- a/runtime/tests/tui/parity/session-transcript.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.test.ts
@@ -800,6 +800,48 @@ describe("AgenC TUI session transcript", () => {
     ]);
   });
 
+  test("renders wait_agent mailbox updates with completed subagent findings", async () => {
+    const { formatSubagentNotification } = await import("../../agents/status.js");
+    const transcript = adaptTranscriptEvents([
+      {
+        id: "wait-end",
+        msg: {
+          type: "collab_waiting_end",
+          payload: {
+            callId: "wait-1",
+            timedOut: false,
+            agentStatuses: [],
+            mailboxUpdates: [
+              {
+                role: "user",
+                content: `Message from reviewer:\n${formatSubagentNotification({
+                  agentPath: "019e1e2f-efc6-74c0-86a3-eefa1c5c98c2",
+                  status: {
+                    status: "completed",
+                    turnId: "turn",
+                    endedAtMs: 1,
+                    lastMessage: "finished provider-boundary audit",
+                  },
+                })}`,
+              },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(transcript.messages).toMatchObject([
+      {
+        subtype: "collab_agent",
+        title: "Finished waiting",
+        state: "success",
+      },
+    ]);
+    expect(JSON.stringify(transcript.messages)).toContain(
+      "finished provider-boundary audit",
+    );
+  });
+
   test("tool_progress events are no longer captured into a runningToolProgress map and streamingToolUses is the live-tool contract", () => {
     const transcript = adaptTranscriptEvents([
       {


### PR DESCRIPTION
## Summary
- make /agents close reliably from detail/delete/form subviews and clarify close/back hints
- return drained wait_agent mailbox updates so completed subagent findings surface in the same turn
- carry final agent messages into task summaries and wait transcript rows

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/commands/agent-management.test.tsx tests/tasks/app-state-bridge.test.ts tests/tasks/lifecycle.test.ts tests/tui/parity/session-transcript.test.ts -- --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/model-facing-tools.test.ts -- -t "wait_agent" --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run build
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core-issue-903-agents-modal
- node runtime/scripts/check-tui-command-visual-smoke.mjs
- PTY smoke: /agents -> detail -> q returns to composer

Fixes #903