### PR TITLE
fix(tui): constrain markdown tables to content width

### DIFF
--- a/runtime/src/tui/components/markdown/MarkdownTable.tsx
+++ b/runtime/src/tui/components/markdown/MarkdownTable.tsx
@@ -1,10 +1,12 @@
 import type { Token, Tokens } from 'marked';
 import React from 'react';
 import stripAnsi from 'strip-ansi';
+import { useContentWidth } from '../../context/contentWidthContext.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';
+import { RawAnsi } from '../../ink/components/RawAnsi.js';
 import { stringWidth } from '../../ink/stringWidth.js';
 import { wrapAnsi } from '../../ink/wrapAnsi.js';
-import { Ansi, useTheme } from '../../ink.js';
+import { useTheme } from '../../ink.js';
 import { resolveAgenCTuiGlyphMode } from '../../glyphs.js';
 import { color } from '../design-system/color.js';
 import type { CliHighlight } from '../../../utils/cliHighlight.js';
@@ -108,7 +110,8 @@ export function MarkdownTable({
   const {
     columns: actualTerminalWidth
   } = useTerminalSize();
-  const terminalWidth = forceWidth ?? actualTerminalWidth;
+  const inheritedContentWidth = useContentWidth();
+  const terminalWidth = Math.max(1, Math.floor(forceWidth ?? inheritedContentWidth ?? actualTerminalWidth));
   const tableGlyphs = getMarkdownTableGlyphs();
 
   // Format cell content to ANSI string
@@ -269,7 +272,7 @@ export function MarkdownTable({
   function renderVerticalFormat(): string {
     const lines_2: string[] = [];
     const headers = token.header.map(h => getPlainText(h.tokens));
-    const separatorWidth = Math.min(terminalWidth - 1, 40);
+    const separatorWidth = Math.max(1, Math.min(terminalWidth - 1, 40));
     const separator = tableGlyphs.horizontal.repeat(separatorWidth);
     // Small indent for wrapped lines (just 2 spaces)
     const wrapIndent = '  ';
@@ -315,9 +318,14 @@ export function MarkdownTable({
     return lines_2.join('\n');
   }
 
+  function renderPreformattedLines(lines: string[]): React.ReactNode {
+    const width = Math.max(1, ...lines.map(line_2 => stringWidth(stripAnsi(line_2))));
+    return <RawAnsi lines={lines} width={Math.min(terminalWidth, width)} />;
+  }
+
   // Choose format based on available width
   if (useVerticalFormat) {
-    return <Ansi>{renderVerticalFormat()}</Ansi>;
+    return renderPreformattedLines(renderVerticalFormat().split('\n'));
   }
 
   // Build the complete horizontal table as an array of strings
@@ -341,9 +349,9 @@ export function MarkdownTable({
   // If we're within SAFETY_MARGIN characters of the edge, use vertical format
   // to account for terminal resize race conditions.
   if (maxLineWidth > terminalWidth - SAFETY_MARGIN) {
-    return <Ansi>{renderVerticalFormat()}</Ansi>;
+    return renderPreformattedLines(renderVerticalFormat().split('\n'));
   }
 
-  // Render as a single Ansi block to prevent Ink from wrapping mid-row
-  return <Ansi>{tableLines.join('\n')}</Ansi>;
+  // Render as one pre-wrapped leaf so Ink cannot wrap mid-row and corrupt borders.
+  return renderPreformattedLines(tableLines);
 }

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { PermissionMode } from '../../../permissions/types.js'
 import { AURA_LIFECYCLE_GLYPHS, AURA_PLAN_GLYPHS, type Theme } from '../../../utils/theme.js'
 import { useModalOrTerminalSize } from '../../context/modalContext.js'
+import { ContentWidthProvider, insetContentWidth, useContentWidth } from '../../context/contentWidthContext.js'
 import { useTerminalSize } from '../../hooks/useTerminalSize.js'
 import Box from '../../ink/components/Box.js'
 import ThemedBox from '../design-system/ThemedBox.js'
@@ -831,6 +832,8 @@ export function Msg({
     worker: 'briefLabelWorker',
     system: 'subtle',
   }
+  const inheritedWidth = useContentWidth()
+  const contentWidth = insetContentWidth(inheritedWidth, 3)
   return (
     <Box flexDirection="row" gap={2}>
       <ThemedText color={colors[role]}>{role === 'system' ? '∙' : '▮'}</ThemedText>
@@ -841,7 +844,9 @@ export function Msg({
           </ThemedText>
           {time ? <ThemedText color="inactive">{time}</ThemedText> : null}
         </Box>
-        <Content color="text2">{children}</Content>
+        <ContentWidthProvider width={contentWidth}>
+          <Content color="text2">{children}</Content>
+        </ContentWidthProvider>
       </Box>
     </Box>
   )

--- a/runtime/src/tui/context/contentWidthContext.tsx
+++ b/runtime/src/tui/context/contentWidthContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext } from 'react'
+
+const ContentWidthContext = createContext<number | null>(null)
+
+function normalizeWidth(width: number | null | undefined): number | null {
+  if (typeof width !== 'number' || !Number.isFinite(width)) {
+    return null
+  }
+  return Math.max(1, Math.floor(width))
+}
+
+export function useContentWidth(): number | null {
+  return useContext(ContentWidthContext)
+}
+
+export function ContentWidthProvider({
+  children,
+  width,
+}: {
+  readonly children: React.ReactNode
+  readonly width: number | null | undefined
+}): React.ReactNode {
+  return (
+    <ContentWidthContext.Provider value={normalizeWidth(width)}>
+      {children}
+    </ContentWidthContext.Provider>
+  )
+}
+
+export function insetContentWidth(
+  width: number | null | undefined,
+  inset: number,
+): number | null {
+  const normalized = normalizeWidth(width)
+  if (normalized === null) {
+    return null
+  }
+  return Math.max(1, normalized - Math.max(0, Math.floor(inset)))
+}

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, type RefObject } from "react";
 
 import { Box, Text } from "../ink.js";
 import { ModalContext } from "../context/modalContext.js";
+import { ContentWidthProvider } from "../context/contentWidthContext.js";
 import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
 import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { useKeybindings } from "../keybindings/useKeybinding.js";
@@ -44,8 +45,15 @@ export function WorkbenchLayout({
   const layoutSize = layoutSizeForColumns(columns);
   const focusedPane = visibleWorkbenchPane(workbench);
   const editorOwnsKeys = focusedPane === "surface" && workbench.activeSurfaceMode === "buffer";
+  const explorerWidth = layoutSize === "wide" ? 30 : 26;
+  const agentsWidth = 30;
   const showExplorer = workbench.explorerVisible && layoutSize !== "narrow";
   const showAgents = workbench.agentsVisible && layoutSize === "wide";
+  const surfaceWidth = Math.max(
+    1,
+    columns - (showExplorer ? explorerWidth : 0) - (showAgents ? agentsWidth : 0),
+  );
+  const surfaceContentWidth = Math.max(1, surfaceWidth - 2);
   const visiblePanes = useMemo(
     () => visiblePaneList(showExplorer, showAgents),
     [showExplorer, showAgents],
@@ -67,15 +75,14 @@ export function WorkbenchLayout({
     { context: "Workbench", isActive: !editorOwnsKeys },
   );
 
-  const explorerWidth = layoutSize === "wide" ? 30 : 26;
-  const agentsWidth = 30;
-
   return (
     <Box flexDirection="column" width="100%" height={rows} overflow="hidden">
       {rows >= 8 ? <WorkbenchStatusBar columns={columns} /> : null}
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
         {showExplorer ? <ProjectExplorer focused={focusedPane === "explorer"} width={explorerWidth} /> : null}
-        <ActiveWorkSurface focused={focusedPane === "surface"} transcript={transcript} pendingApproval={pendingApproval} scrollRef={scrollRef} />
+        <ContentWidthProvider width={surfaceContentWidth}>
+          <ActiveWorkSurface focused={focusedPane === "surface"} transcript={transcript} pendingApproval={pendingApproval} scrollRef={scrollRef} />
+        </ContentWidthProvider>
         {showAgents ? <AgentsRail focused={focusedPane === "agents"} width={agentsWidth} /> : null}
       </Box>
       {overlay ? (

--- a/runtime/tests/tui/components/markdown/markdown-rendering.test.tsx
+++ b/runtime/tests/tui/components/markdown/markdown-rendering.test.tsx
@@ -3,6 +3,9 @@ import { marked, type Tokens } from 'marked'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { renderToString } from '../../../utils/staticRender.js'
+import { ContentWidthProvider } from '../../context/contentWidthContext.js'
+import { Box } from '../../ink.js'
+import { stringWidth } from '../../ink/stringWidth.js'
 import { HighlightedCode } from './HighlightedCode.js'
 import { HighlightedCodeFallback } from './HighlightedCodeFallback.js'
 import { Markdown } from './Markdown.js'
@@ -108,6 +111,31 @@ describe('markdown rendering components', () => {
     expect(output).toContain('42')
     expect(output).toContain('┌')
     expect(output).toContain('┘')
+  })
+
+  test('uses inherited content width for long markdown tables in constrained panes', async () => {
+    const output = await renderToString(
+      <ContentWidthProvider width={72}>
+        <Box width={72}>
+          <Markdown>
+            {[
+              '| Contract Row | Status | Evidence |',
+              '| --- | --- | --- |',
+              '| Row 1 - provider-boundary | Implemented | types.ts defines full BufferEditorProvider plus seven capability flags; InlineBufferProvider, ExternalEditorProvider, NeovimBufferProvider, selectBufferEditorProvider, and BufferProviderController all exist and are wired. |',
+              '| Row 2 - neovim-discovery | Scaffolding present | NeovimDiscovery.ts implements binary detection, version check, embed mode, clean fallback, explicit usable false reason codes, and all runtime modules exist. |',
+            ].join('\n')}
+          </Markdown>
+        </Box>
+      </ContentWidthProvider>,
+      160,
+    )
+
+    expect(output).toContain('Contract Row:')
+    expect(output).toContain('BufferEditorProvider')
+    expect(output).not.toContain('┌')
+    for (const line of output.split('\n')) {
+      expect(stringWidth(line)).toBeLessThanOrEqual(72)
+    }
   })
 
   test('renders MarkdownTable with wrapping and right-aligned numeric column', async () => {


### PR DESCRIPTION
## Summary
- Size markdown tables against the active content pane instead of raw terminal columns.
- Render pre-wrapped table output with RawAnsi so Ink cannot rewrap table borders mid-row.
- Add a constrained-pane regression test for long markdown tables.

## Test plan
- npm test -- tests/tui/components/markdown/markdown-rendering.test.tsx --reporter=dot
- npm test -- tests/tui/components/markdown/MarkdownTable.wave200-070.coverage.test.tsx tests/tui/coverage-swarm/swarm-122-components-markdown-MarkdownTable.test.tsx --reporter=dot
- npm run typecheck
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused:report