### PR TITLE
fix(build): copy yolo prompt assets during bundle

### DIFF
--- a/runtime/scripts/check-package-entrypoints.mjs
+++ b/runtime/scripts/check-package-entrypoints.mjs
@@ -14,6 +14,11 @@ const requiredRootExports = [
   "AgenCInProcessDaemonTransport",
   "startAgenCInProcessDaemonTransport",
 ];
+const requiredRuntimeAssetPaths = [
+  "dist/yolo-classifier-prompts/auto_mode_system_prompt.txt",
+  "dist/yolo-classifier-prompts/permissions_anthropic.txt",
+  "dist/yolo-classifier-prompts/permissions_external.txt",
+];
 
 function collectPackageEntryPaths(packageManifest) {
   const paths = new Set();
@@ -78,6 +83,15 @@ async function main() {
       continue;
     }
 
+    const fullPath = path.join(packageDir, relPath);
+    try {
+      await access(fullPath);
+    } catch {
+      missingPaths.push(relPath);
+    }
+  }
+
+  for (const relPath of requiredRuntimeAssetPaths) {
     const fullPath = path.join(packageDir, relPath);
     try {
       await access(fullPath);

--- a/runtime/tsup.config.ts
+++ b/runtime/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsup';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, extname, isAbsolute, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,6 +12,14 @@ const entry = [
 ];
 
 const runtimeRoot = dirname(fileURLToPath(import.meta.url));
+const yoloClassifierPromptSourceDir = resolve(
+  runtimeRoot,
+  'src/utils/permissions/yolo-classifier-prompts',
+);
+const yoloClassifierPromptDistDir = resolve(
+  runtimeRoot,
+  'dist/yolo-classifier-prompts',
+);
 const agencRoot = resolve(runtimeRoot, 'src/agenc');
 const agencUpstreamRoot = resolve(agencRoot, 'upstream');
 const runtimeSourceRoot = resolve(runtimeRoot, 'src');
@@ -76,6 +84,14 @@ const runtimePackage = JSON.parse(
   readFileSync(resolve(runtimeRoot, 'package.json'), 'utf8'),
 ) as { version?: string };
 const displayVersion = runtimePackage.version ?? '0.0.0';
+
+function copyYoloClassifierPrompts(): void {
+  if (!existsSync(yoloClassifierPromptSourceDir)) return;
+  mkdirSync(yoloClassifierPromptDistDir, { recursive: true });
+  cpSync(yoloClassifierPromptSourceDir, yoloClassifierPromptDistDir, {
+    recursive: true,
+  });
+}
 
 function aliasedSourceBases(base: string): string[] {
   const slash = base.lastIndexOf('/');
@@ -236,6 +252,17 @@ const agencFeatureFlagInline = {
       const inlined = inlineCopiedTreeFeatureCalls(source);
       if (inlined === source) return null;
       return { contents: inlined, loader };
+    });
+  },
+};
+
+const agencRuntimeAssets = {
+  name: 'agenc-runtime-assets',
+  setup(build: {
+    onEnd: (callback: () => void) => void;
+  }) {
+    build.onEnd(() => {
+      copyYoloClassifierPrompts();
     });
   },
 };
@@ -458,6 +485,7 @@ export default defineConfig({
     agencBareSrcAlias,
     agencOptionalExternal,
     agencKnownMissingOptionalExternal,
+    agencRuntimeAssets,
   ],
   esbuildOptions(options) {
     options.define = {


### PR DESCRIPTION
## Summary
- Copy yolo classifier prompt assets during the tsup ESM bundle lifecycle instead of waiting for the post-DTS build step.
- Add yolo prompt files to the runtime package build contract so completed builds fail if the assets are missing.

## Test plan
- npm run build
- mid-build: ls -l runtime/dist/yolo-classifier-prompts && node -e \"import('./runtime/dist/tui/main.js').then(()=>console.log('mid-build import ok')).catch(e=>{console.error(e); process.exit(1)})\"
- npm run typecheck
- npm run check:tui-runtime-startup
- git diff --check