### PR TITLE
fix(tui): honor workbench content width

### DIFF
--- a/runtime/scripts/check-tui-command-visual-smoke.mjs
+++ b/runtime/scripts/check-tui-command-visual-smoke.mjs
@@ -154,6 +154,27 @@ function assertNoMalformedHints(text, label) {
   }
 }
 
+function assertFrameWidthContract(rows, dimension, label) {
+  const autoWraps = rows.autoWraps ?? [];
+  if (autoWraps.length > 0) {
+    fail("command surface caused terminal autowrap", {
+      label,
+      wraps: autoWraps.length,
+      first: JSON.stringify(autoWraps[0]),
+    });
+  }
+  for (const [index, row] of rows.entries()) {
+    if (row.length > dimension.cols) {
+      fail("command surface row overflow", {
+        label,
+        row: index + 1,
+        width: row.length,
+        cols: dimension.cols,
+      });
+    }
+  }
+}
+
 function firstMarkerRow(rows, markers) {
   const normalized = markers.map((marker) => marker.toLowerCase());
   return rows.findIndex((row) => {
@@ -168,6 +189,7 @@ function assertSurfaceVisible(session, spec, dimension) {
   const label = `${spec.command} ${dimension.cols}x${dimension.rows}`;
   const lowerFrame = frame.toLowerCase();
   assertNoMalformedHints(frame, label);
+  assertFrameWidthContract(rows, dimension, label);
 
   if (!spec.anchors.some((marker) => lowerFrame.includes(marker.toLowerCase()))) {
     fail("command surface anchor missing from visible frame", {

--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -290,6 +290,7 @@ function printableChar(ch) {
 
 export function renderPtyRows(raw, { cols = 140, rows = 40 } = {}) {
   const grid = emptyGrid(rows, cols);
+  const autoWraps = [];
   let row = 0;
   let col = 0;
   let wrapPending = false;
@@ -331,6 +332,7 @@ export function renderPtyRows(raw, { cols = 140, rows = 40 } = {}) {
 
   const put = (ch) => {
     if (wrapPending) {
+      autoWraps.push({ row: row + 1, col: col + 1 });
       col = 0;
       lineFeed();
       wrapPending = false;
@@ -446,7 +448,12 @@ export function renderPtyRows(raw, { cols = 140, rows = 40 } = {}) {
     }
   }
 
-  return grid.map((line) => line.join("").trimEnd());
+  const renderedRows = grid.map((line) => line.join("").trimEnd());
+  Object.defineProperty(renderedRows, "autoWraps", {
+    value: autoWraps,
+    enumerable: false,
+  });
+  return renderedRows;
 }
 
 export function renderPtyScreen(raw, opts = {}) {

--- a/runtime/scripts/check-tui-workbench-visual-smoke.mjs
+++ b/runtime/scripts/check-tui-workbench-visual-smoke.mjs
@@ -20,11 +20,27 @@ function fail(message, details = {}) {
   throw new Error(suffix ? `${message} (${suffix})` : message);
 }
 
-function assertFrame(session, dimension, label, anchors) {
-  const rows = renderPtyRows(session.raw, dimension);
-  const frame = rows.join("\n");
-  if (rows.every((row) => row.trim().length === 0)) {
-    fail("blank workbench frame", { label });
+function markerColumns(rows, markers) {
+  const matches = [];
+  for (const [rowIndex, row] of rows.entries()) {
+    for (const marker of markers) {
+      const column = row.indexOf(marker);
+      if (column !== -1) {
+        matches.push({ row: rowIndex + 1, column, marker });
+      }
+    }
+  }
+  return matches;
+}
+
+function assertFrameWidthContract(rows, dimension, label) {
+  const autoWraps = rows.autoWraps ?? [];
+  if (autoWraps.length > 0) {
+    fail("workbench frame caused terminal autowrap", {
+      label,
+      wraps: autoWraps.length,
+      first: JSON.stringify(autoWraps[0]),
+    });
   }
   for (const [index, row] of rows.entries()) {
     if (row.length > dimension.cols) {
@@ -36,6 +52,65 @@ function assertFrame(session, dimension, label, anchors) {
       });
     }
   }
+}
+
+function assertPaneLocality(rows, dimension, label) {
+  const explorerMarkers = markerColumns(rows, ["WORKSPACE"]);
+  const surfaceMarkers = markerColumns(rows, ["TRANSCRIPT", "DIFF"]);
+  const agentMarkers = markerColumns(rows, ["Agents"]);
+  const surfaceStart = Math.min(...surfaceMarkers.map((match) => match.column));
+  const agentStart = agentMarkers.length > 0
+    ? Math.min(...agentMarkers.map((match) => match.column))
+    : dimension.cols;
+
+  if (Number.isFinite(surfaceStart)) {
+    for (const match of explorerMarkers) {
+      if (match.column >= surfaceStart) {
+        fail("workbench explorer marker overlapped active surface", {
+          label,
+          marker: match.marker,
+          row: match.row,
+          column: match.column,
+          surfaceStart,
+        });
+      }
+    }
+    for (const match of surfaceMarkers) {
+      if (match.column >= agentStart) {
+        fail("workbench surface marker overlapped agents rail", {
+          label,
+          marker: match.marker,
+          row: match.row,
+          column: match.column,
+          agentStart,
+        });
+      }
+    }
+  }
+
+  if (agentMarkers.length > 0 && Number.isFinite(surfaceStart)) {
+    for (const match of agentMarkers) {
+      if (match.column <= surfaceStart) {
+        fail("workbench agents marker overlapped active surface", {
+          label,
+          marker: match.marker,
+          row: match.row,
+          column: match.column,
+          surfaceStart,
+        });
+      }
+    }
+  }
+}
+
+function assertFrame(session, dimension, label, anchors) {
+  const rows = renderPtyRows(session.raw, dimension);
+  const frame = rows.join("\n");
+  if (rows.every((row) => row.trim().length === 0)) {
+    fail("blank workbench frame", { label });
+  }
+  assertFrameWidthContract(rows, dimension, label);
+  assertPaneLocality(rows, dimension, label);
   const lower = frame.toLowerCase();
   if (!anchors.some((anchor) => lower.includes(anchor.toLowerCase()))) {
     fail("workbench anchor missing", {

--- a/runtime/src/tui/components/FileEditToolUpdatedMessage.tsx
+++ b/runtime/src/tui/components/FileEditToolUpdatedMessage.tsx
@@ -3,6 +3,7 @@
 import { c as _c } from "react-compiler-runtime";
 import type { StructuredPatchHunk } from 'diff';
 import * as React from 'react';
+import { useContentWidth } from '../context/contentWidthContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize';
 import { Box, Text } from '../ink.js';
 import { count } from '../../utils/array.js'; // upstream-import: keep target is owned by another Z-PURGE item
@@ -31,6 +32,8 @@ export function FileEditToolUpdatedMessage(t0) {
   const {
     columns
   } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
+  const diffWidth = Math.max(1, (inheritedContentWidth ?? columns) - 12);
   const numAdditions = structuredPatch.reduce(_temp2, 0);
   const numRemovals = structuredPatch.reduce(_temp4, 0);
   let t1;
@@ -87,7 +90,7 @@ export function FileEditToolUpdatedMessage(t0) {
   } else {
     t5 = $[12];
   }
-  const t6 = columns - 12;
+  const t6 = diffWidth;
   let t7;
   if ($[13] !== fileContent || $[14] !== filePath || $[15] !== firstLine || $[16] !== structuredPatch || $[17] !== t6) {
     t7 = <StructuredDiffList hunks={structuredPatch} dim={false} width={t6} filePath={filePath} firstLine={firstLine} fileContent={fileContent} />;

--- a/runtime/src/tui/components/FileEditToolUseRejectedMessage.tsx
+++ b/runtime/src/tui/components/FileEditToolUseRejectedMessage.tsx
@@ -4,6 +4,7 @@ import { c as _c } from "react-compiler-runtime";
 import type { StructuredPatchHunk } from 'diff';
 import { relative } from 'path';
 import * as React from 'react';
+import { useContentWidth } from '../context/contentWidthContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { getCwd } from '../../utils/cwd.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { Box, Text } from '../ink.js';
@@ -38,6 +39,8 @@ export function FileEditToolUseRejectedMessage(t0) {
   const {
     columns
   } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
+  const previewWidth = Math.max(1, (inheritedContentWidth ?? columns) - 12);
   let t1;
   if ($[0] !== operation) {
     t1 = <Text color="subtle">User rejected {operation} to </Text>;
@@ -102,7 +105,7 @@ export function FileEditToolUseRejectedMessage(t0) {
     }
     const truncatedContent = t5;
     const t6 = truncatedContent || "(No content)";
-    const t7 = columns - 12;
+    const t7 = previewWidth;
     let t8;
     if ($[16] !== file_path || $[17] !== t6 || $[18] !== t7) {
       t8 = <HighlightedCode code={t6} filePath={file_path} width={t7} dim={true} />;
@@ -145,7 +148,7 @@ export function FileEditToolUseRejectedMessage(t0) {
     }
     return t5;
   }
-  const t5 = columns - 12;
+  const t5 = previewWidth;
   let t6;
   if ($[29] !== fileContent || $[30] !== file_path || $[31] !== firstLine || $[32] !== patch || $[33] !== t5) {
     t6 = <StructuredDiffList hunks={patch} dim={true} width={t5} filePath={file_path} firstLine={firstLine} fileContent={fileContent} />;

--- a/runtime/src/tui/components/Message.tsx
+++ b/runtime/src/tui/components/Message.tsx
@@ -2,6 +2,7 @@ import { feature } from 'bun:bundle';
 import * as React from 'react';
 import type { Command } from '../../commands.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
+import { ContentWidthProvider, useContentWidth } from '../context/contentWidthContext.js';
 import { Box } from '../ink.js';
 import type { Tools } from '../../tools/Tool.js';
 import { isConnectorTextBlock } from '../../types/connectorText.js';
@@ -121,51 +122,59 @@ function MessageImpl({
   lastThinkingBlockId,
   latestBashOutputUUID,
 }: Props): React.ReactNode {
+  const inheritedContentWidth = useContentWidth();
+  const messageContentWidth = typeof containerWidth === 'number' ? containerWidth : inheritedContentWidth;
   switch (message.type) {
     case "attachment":
       return (
-        <AttachmentMessage
-          addMargin={addMargin}
-          attachment={message.attachment}
-          verbose={verbose}
-          isTranscriptMode={isTranscriptMode}
-        />
+        <ContentWidthProvider width={messageContentWidth}>
+          <AttachmentMessage
+            addMargin={addMargin}
+            attachment={message.attachment}
+            verbose={verbose}
+            isTranscriptMode={isTranscriptMode}
+          />
+        </ContentWidthProvider>
       );
     case "assistant":
       return (
-        <Box flexDirection="column" width={containerWidth ?? "100%"}>
-          {message.message.content.map((param: AssistantContentBlock, index: number) => (
-            <AssistantMessageBlock
-              key={index}
-              param={param}
-              addMargin={addMargin}
-              tools={tools}
-              commands={commands}
-              verbose={verbose}
-              inProgressToolUseIDs={inProgressToolUseIDs}
-              progressMessagesForMessage={progressMessagesForMessage}
-              shouldAnimate={shouldAnimate}
-              shouldShowDot={shouldShowDot}
-              width={width}
-              inProgressToolCallCount={inProgressToolUseIDs.size}
-              isTranscriptMode={isTranscriptMode}
-              lookups={lookups}
-              onOpenRateLimitOptions={onOpenRateLimitOptions}
-              thinkingBlockId={`${message.uuid}:${index}`}
-              lastThinkingBlockId={lastThinkingBlockId}
-              advisorModel={message.advisorModel}
-            />
-          ))}
-        </Box>
+        <ContentWidthProvider width={messageContentWidth}>
+          <Box flexDirection="column" width={containerWidth ?? "100%"}>
+            {message.message.content.map((param: AssistantContentBlock, index: number) => (
+              <AssistantMessageBlock
+                key={index}
+                param={param}
+                addMargin={addMargin}
+                tools={tools}
+                commands={commands}
+                verbose={verbose}
+                inProgressToolUseIDs={inProgressToolUseIDs}
+                progressMessagesForMessage={progressMessagesForMessage}
+                shouldAnimate={shouldAnimate}
+                shouldShowDot={shouldShowDot}
+                width={width}
+                inProgressToolCallCount={inProgressToolUseIDs.size}
+                isTranscriptMode={isTranscriptMode}
+                lookups={lookups}
+                onOpenRateLimitOptions={onOpenRateLimitOptions}
+                thinkingBlockId={`${message.uuid}:${index}`}
+                lastThinkingBlockId={lastThinkingBlockId}
+                advisorModel={message.advisorModel}
+              />
+            ))}
+          </Box>
+        </ContentWidthProvider>
       );
     case "user":
       {
         if (message.isCompactSummary) {
           return (
-            <CompactSummary
-              message={message}
-              screen={isTranscriptMode ? "transcript" : "prompt"}
-            />
+            <ContentWidthProvider width={messageContentWidth}>
+              <CompactSummary
+                message={message}
+                screen={isTranscriptMode ? "transcript" : "prompt"}
+              />
+            </ContentWidthProvider>
           );
         }
 
@@ -183,24 +192,26 @@ function MessageImpl({
 
         const isLatestBashOutput = latestBashOutputUUID === message.uuid;
         const content = (
-          <Box flexDirection="column" width={containerWidth ?? "100%"}>
-            {message.message.content.map((param: UserContentBlock, index: number) => (
-              <UserMessage
-                key={index}
-                message={message}
-                addMargin={addMargin}
-                tools={tools}
-                progressMessagesForMessage={progressMessagesForMessage}
-                param={param}
-                style={style}
-                verbose={verbose}
-                imageIndex={imageIndices[index]}
-                isUserContinuation={isUserContinuation}
-                lookups={lookups}
-                isTranscriptMode={isTranscriptMode}
-              />
-            ))}
-          </Box>
+          <ContentWidthProvider width={messageContentWidth}>
+            <Box flexDirection="column" width={containerWidth ?? "100%"}>
+              {message.message.content.map((param: UserContentBlock, index: number) => (
+                <UserMessage
+                  key={index}
+                  message={message}
+                  addMargin={addMargin}
+                  tools={tools}
+                  progressMessagesForMessage={progressMessagesForMessage}
+                  param={param}
+                  style={style}
+                  verbose={verbose}
+                  imageIndex={imageIndices[index]}
+                  isUserContinuation={isUserContinuation}
+                  lookups={lookups}
+                  isTranscriptMode={isTranscriptMode}
+                />
+              ))}
+            </Box>
+          </ContentWidthProvider>
         );
 
         return isLatestBashOutput ? (
@@ -230,48 +241,56 @@ function MessageImpl({
         }
         if (message.subtype === "local_command") {
           return (
-            <UserTextMessage
-              addMargin={addMargin}
-              param={{ type: "text", text: message.content }}
-              verbose={verbose}
-              isTranscriptMode={isTranscriptMode}
-            />
+            <ContentWidthProvider width={messageContentWidth}>
+              <UserTextMessage
+                addMargin={addMargin}
+                param={{ type: "text", text: message.content }}
+                verbose={verbose}
+                isTranscriptMode={isTranscriptMode}
+              />
+            </ContentWidthProvider>
           );
         }
         return (
-          <SystemTextMessage
-            message={message}
-            addMargin={addMargin}
-            verbose={verbose}
-            isTranscriptMode={isTranscriptMode}
-          />
+          <ContentWidthProvider width={messageContentWidth}>
+            <SystemTextMessage
+              message={message}
+              addMargin={addMargin}
+              verbose={verbose}
+              isTranscriptMode={isTranscriptMode}
+            />
+          </ContentWidthProvider>
         );
       }
     case "grouped_tool_use":
       return (
-        <GroupedToolUseContent
-          message={message}
-          tools={tools}
-          lookups={lookups}
-          inProgressToolUseIDs={inProgressToolUseIDs}
-          shouldAnimate={shouldAnimate}
-        />
+        <ContentWidthProvider width={messageContentWidth}>
+          <GroupedToolUseContent
+            message={message}
+            tools={tools}
+            lookups={lookups}
+            inProgressToolUseIDs={inProgressToolUseIDs}
+            shouldAnimate={shouldAnimate}
+          />
+        </ContentWidthProvider>
       );
     case "collapsed_read_search":
       {
         const renderVerbose = verbose || isTranscriptMode;
         return (
-          <OffscreenFreeze>
-            <CollapsedReadSearchContent
-              message={message}
-              inProgressToolUseIDs={inProgressToolUseIDs}
-              shouldAnimate={shouldAnimate}
-              verbose={renderVerbose}
-              tools={tools}
-              lookups={lookups}
-              isActiveGroup={isActiveCollapsedGroup}
-            />
-          </OffscreenFreeze>
+          <ContentWidthProvider width={messageContentWidth}>
+            <OffscreenFreeze>
+              <CollapsedReadSearchContent
+                message={message}
+                inProgressToolUseIDs={inProgressToolUseIDs}
+                shouldAnimate={shouldAnimate}
+                verbose={renderVerbose}
+                tools={tools}
+                lookups={lookups}
+                isActiveGroup={isActiveCollapsedGroup}
+              />
+            </OffscreenFreeze>
+          </ContentWidthProvider>
         );
       }
   }
@@ -291,6 +310,8 @@ function UserMessage({
   isTranscriptMode,
 }: UserMessageProps): React.ReactNode {
   const { columns } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
+  const contentColumns = inheritedContentWidth ?? columns;
   switch (param.type) {
     case "text":
       return (
@@ -310,7 +331,7 @@ function UserMessage({
       }
     case "tool_result":
       {
-        const toolResultWidth = getToolResultMessageWidth(columns);
+        const toolResultWidth = getToolResultMessageWidth(contentColumns);
         return (
           <UserToolResultMessage
             param={param}

--- a/runtime/src/tui/components/Messages.tsx
+++ b/runtime/src/tui/components/Messages.tsx
@@ -10,6 +10,7 @@ import { every } from '../../utils/set.js';
 import { getIsRemoteMode } from '../../bootstrap/state.js';
 import type { Command } from '../../commands.js';
 import { BLACK_CIRCLE } from '../../constants/figures.js';
+import { ContentWidthProvider, insetContentWidth, useContentWidth } from '../context/contentWidthContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import type { ScrollBoxHandle } from '../ink/components/ScrollBox.js';
 import { useTerminalNotification } from '../ink/useTerminalNotification.js';
@@ -278,6 +279,9 @@ const MessagesImpl = ({
   const {
     columns
   } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
+  const contentColumns = inheritedContentWidth ?? columns;
+  const streamingContentWidth = insetContentWidth(contentColumns, 2) ?? contentColumns;
   const toggleShowAllShortcut = useShortcutDisplay('transcript:toggleShowAll', 'Transcript', 'Ctrl+E');
   const normalizedMessages = useMemo(() => normalizeMessages(messages).filter(isNotEmptyMessage), [messages]);
   const [streamingThinkingExpiryTick, setStreamingThinkingExpiryTick] = useState(0);
@@ -530,7 +534,7 @@ const MessagesImpl = ({
     // streaming instead of waiting for the block to finalize.
     const hasContentAfter = msg_8.type === 'collapsed_read_search' && (!!streamingText || hasContentAfterIndex(renderableMessages, index, tools, streamingToolUseIDs));
     const k_0 = messageKey(msg_8);
-    const row = <MessageRow key={k_0} message={msg_8} isUserContinuation={isUserContinuation} hasContentAfter={hasContentAfter} tools={tools} commands={commands} verbose={verbose || isItemExpanded(msg_8) || cursor?.expanded === true && index === selectedIdx} inProgressToolUseIDs={inProgressToolUseIDs} streamingToolUseIDs={streamingToolUseIDs} screen={screen} canAnimate={canAnimate} onOpenRateLimitOptions={onOpenRateLimitOptions} lastThinkingBlockId={lastThinkingBlockId} latestBashOutputUUID={latestBashOutputUUID} columns={columns} isLoading={isLoading} lookups={lookups_0} />;
+    const row = <MessageRow key={k_0} message={msg_8} isUserContinuation={isUserContinuation} hasContentAfter={hasContentAfter} tools={tools} commands={commands} verbose={verbose || isItemExpanded(msg_8) || cursor?.expanded === true && index === selectedIdx} inProgressToolUseIDs={inProgressToolUseIDs} streamingToolUseIDs={streamingToolUseIDs} screen={screen} canAnimate={canAnimate} onOpenRateLimitOptions={onOpenRateLimitOptions} lastThinkingBlockId={lastThinkingBlockId} latestBashOutputUUID={latestBashOutputUUID} columns={contentColumns} isLoading={isLoading} lookups={lookups_0} />;
 
     // Per-row Provider — only 2 rows re-render on selection change.
     // Wrapped BEFORE divider branch so both return paths get it.
@@ -539,7 +543,7 @@ const MessagesImpl = ({
       </MessageActionsSelectedContext.Provider>;
     if (unseenDivider && index === dividerBeforeIndex) {
       return [<Box key="unseen-divider" marginTop={1}>
-          <Divider title={`${unseenDivider.count} new ${plural(unseenDivider.count, 'message')}`} width={columns} color="inactive" />
+          <Divider title={`${unseenDivider.count} new ${plural(unseenDivider.count, 'message')}`} width={contentColumns} color="inactive" />
         </Box>, wrapped];
     }
     return wrapped;
@@ -588,14 +592,14 @@ const MessagesImpl = ({
       {!hideLogo && !(renderRange && renderRange[0] > 0) && <LogoHeader agentDefinitions={agentDefinitions} showWelcome={renderableMessages.length === 0 && !streamingText && !isBriefOnly} />}
 
       {/* Truncation indicator */}
-      {hasTruncatedMessages_0 && <Divider title={`${toggleShowAllShortcut} to show ${chalk.bold(hiddenMessageCount_0)} previous messages`} width={columns} />}
+      {hasTruncatedMessages_0 && <Divider title={`${toggleShowAllShortcut} to show ${chalk.bold(hiddenMessageCount_0)} previous messages`} width={contentColumns} />}
 
       {/* Show all indicator */}
       {isTranscriptMode && showAllInTranscript && hiddenMessageCount_0 > 0 &&
     // disableRenderCap (e.g. [ dump-to-scrollback) means we're uncapped
     // as a one-shot escape hatch, not a toggle — ctrl+e is dead and
     // nothing is actually "hidden" to restore.
-    !disableRenderCap && <Divider title={`${toggleShowAllShortcut} to hide ${chalk.bold(hiddenMessageCount_0)} previous messages`} width={columns} />}
+    !disableRenderCap && <Divider title={`${toggleShowAllShortcut} to hide ${chalk.bold(hiddenMessageCount_0)} previous messages`} width={contentColumns} />}
 
       {/* Messages - rendered as memoized MessageRow components.
           flatMap inserts the unseen-divider as a separate keyed sibling so
@@ -606,7 +610,7 @@ const MessagesImpl = ({
           passing the array would accumulate every historical version
           (~1-2MB over a 7-turn session). */}
       {virtualScrollRuntimeGate ? <InVirtualListContext.Provider value={true}>
-          <VirtualMessageList messages={renderableMessages} scrollRef={scrollRef} columns={columns} itemKey={messageKey} renderItem={renderMessageRow} onItemClick={onItemClick} isItemClickable={isItemClickable} isItemExpanded={isItemExpanded} trackStickyPrompt={trackStickyPrompt} selectedIndex={selectedIdx >= 0 ? selectedIdx : undefined} cursorNavRef={cursorNavRef} setCursor={setCursor} jumpRef={jumpRef} onSearchMatchesChange={onSearchMatchesChange} scanElement={scanElement} setPositions={setPositions} extractSearchText={extractSearchText} />
+          <VirtualMessageList messages={renderableMessages} scrollRef={scrollRef} columns={contentColumns} itemKey={messageKey} renderItem={renderMessageRow} onItemClick={onItemClick} isItemClickable={isItemClickable} isItemExpanded={isItemExpanded} trackStickyPrompt={trackStickyPrompt} selectedIndex={selectedIdx >= 0 ? selectedIdx : undefined} cursorNavRef={cursorNavRef} setCursor={setCursor} jumpRef={jumpRef} onSearchMatchesChange={onSearchMatchesChange} scanElement={scanElement} setPositions={setPositions} extractSearchText={extractSearchText} />
         </InVirtualListContext.Provider> : renderableMessages.flatMap(renderMessageRow)}
 
       {streamingText && !isBriefOnly && <Box alignItems="flex-start" flexDirection="row" marginTop={1} width="100%">
@@ -614,8 +618,10 @@ const MessagesImpl = ({
             <Box minWidth={2}>
               <Text color="text">{BLACK_CIRCLE}</Text>
             </Box>
-            <Box flexDirection="column">
-              <StreamingMarkdown>{streamingText}</StreamingMarkdown>
+            <Box flexDirection="column" width={streamingContentWidth}>
+              <ContentWidthProvider width={streamingContentWidth}>
+                <StreamingMarkdown>{streamingText}</StreamingMarkdown>
+              </ContentWidthProvider>
             </Box>
           </Box>
         </Box>}

--- a/runtime/src/tui/message-renderers/SystemTextMessage.tsx
+++ b/runtime/src/tui/message-renderers/SystemTextMessage.tsx
@@ -13,6 +13,7 @@ import { openPath } from '../../utils/browser.js';
 import * as teamMemSavedModule from './teamMemSaved';
 const teamMemSaved = feature('TEAMMEM') ? teamMemSavedModule : null;
 import { TURN_COMPLETION_VERBS } from '../../constants/turnCompletionVerbs.js';
+import { useContentWidth } from '../context/contentWidthContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize';
 import type { SystemMessage, SystemStopHookSummaryMessage, SystemBridgeStatusMessage, SystemTurnDurationMessage, SystemMemorySavedMessage } from '../../types/message';
 import { SystemAPIErrorMessage } from '../components/SystemAPIErrorMessage.js';
@@ -179,6 +180,7 @@ function StopHookSummaryMessage({
   const {
     columns
   } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
   const totalDurationMs = message.totalDurationMs ?? hookInfos.reduce(_temp, 0);
   if (!shouldRenderStopHookSummary(message, totalDurationMs)) {
     return null;
@@ -195,7 +197,7 @@ function StopHookSummaryMessage({
     );
   }
   const marginTop = addMargin ? 1 : 0;
-  const contentWidth = getSystemMessageContentWidth(columns);
+  const contentWidth = getSystemMessageContentWidth(inheritedContentWidth ?? columns);
   const hookLabel = message.hookLabel ?? "stop";
   const hookNoun = hookCount === 1 ? "hook" : "hooks";
   const compactExpandHint = !verbose && hookInfos.length > 0 && <>{" "}<CtrlOToExpand /></>;
@@ -254,9 +256,10 @@ function SystemTextMessageInner({
   const {
     columns
   } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
   const bg = useSelectedMessageBg();
   const marginTop = addMargin ? 1 : 0;
-  const contentWidth = getSystemMessageContentWidth(columns);
+  const contentWidth = getSystemMessageContentWidth(inheritedContentWidth ?? columns);
   const trimmedContent = content.trim();
 
   return (
@@ -319,6 +322,7 @@ function CollabAgentSystemMessage({
 }): React.ReactNode {
   const bg = useSelectedMessageBg();
   const { columns } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
   const marginTop = addMargin ? 1 : 0;
   const state = message.state;
   const color =
@@ -330,7 +334,7 @@ function CollabAgentSystemMessage({
           ? AGENT_MESSAGE_THEME_COLOR
           : undefined;
   const details = Array.isArray(message.details) ? message.details : [];
-  const width = getSystemMessageContentWidth(columns);
+  const width = getSystemMessageContentWidth(inheritedContentWidth ?? columns);
   return (
     <Box flexDirection="row" marginTop={marginTop} backgroundColor={bg} width="100%">
       <Box minWidth={2}>
@@ -462,8 +466,9 @@ function BridgeStatusMessage({
 }) {
   const bg = useSelectedMessageBg();
   const { columns } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
   const marginTop = addMargin ? 1 : 0;
-  const contentWidth = getSystemMessageContentWidth(columns);
+  const contentWidth = getSystemMessageContentWidth(inheritedContentWidth ?? columns);
 
   return (
     <Box flexDirection="row" marginTop={marginTop} backgroundColor={bg} width="100%">

--- a/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolRejectMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserToolResultMessage/UserToolRejectMessage.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
+import { useContentWidth } from '../../context/contentWidthContext.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize';
 import { useTheme } from '../../ink.js';
 import { filterToolProgressMessages, type Tool, type Tools } from '../../../tools/Tool';
@@ -32,6 +33,8 @@ export function UserToolRejectMessage(t0) {
   const {
     columns
   } = useTerminalSize();
+  const inheritedContentWidth = useContentWidth();
+  const effectiveColumns = inheritedContentWidth ?? columns;
   const [theme] = useTheme();
   if (!tool || !tool.renderToolUseRejectedMessage) {
     let t1;
@@ -46,7 +49,7 @@ export function UserToolRejectMessage(t0) {
   const t1 = tool.inputSchema;
   let t2;
   let t3;
-  if ($[1] !== columns || $[2] !== input || $[3] !== isTranscriptMode || $[4] !== progressMessagesForMessage || $[5] !== style || $[6] !== theme || $[7] !== tool || $[8] !== tools || $[9] !== verbose) {
+  if ($[1] !== effectiveColumns || $[2] !== input || $[3] !== isTranscriptMode || $[4] !== progressMessagesForMessage || $[5] !== style || $[6] !== theme || $[7] !== tool || $[8] !== tools || $[9] !== verbose) {
     t3 = Symbol.for("react.early_return_sentinel");
     bb0: {
       const parsedInput = t1.safeParse(input);
@@ -62,7 +65,7 @@ export function UserToolRejectMessage(t0) {
         break bb0;
       }
       t2 = tool.renderToolUseRejectedMessage(parsedInput.data, {
-        columns,
+        columns: effectiveColumns,
         messages: [],
         tools,
         verbose,
@@ -72,7 +75,7 @@ export function UserToolRejectMessage(t0) {
         isTranscriptMode
       }) ?? <FallbackToolUseRejectedMessage />;
     }
-    $[1] = columns;
+    $[1] = effectiveColumns;
     $[2] = input;
     $[3] = isTranscriptMode;
     $[4] = progressMessagesForMessage;

--- a/runtime/tests/tui/components/FileEditToolUpdatedMessage.test.tsx
+++ b/runtime/tests/tui/components/FileEditToolUpdatedMessage.test.tsx
@@ -6,6 +6,7 @@ import stripAnsi from 'strip-ansi'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { renderToString } from '../../utils/staticRender.js'
+import { ContentWidthProvider } from '../context/contentWidthContext.js'
 import { createRoot } from '../ink/root.js'
 import { FileEditToolUpdatedMessage } from './FileEditToolUpdatedMessage.js'
 
@@ -97,6 +98,26 @@ describe('FileEditToolUpdatedMessage', () => {
       firstLine: 'const old = true',
       hunks: [mixedHunk],
       width: 60,
+    })
+  })
+
+  test('sizes structured diffs from inherited content width', async () => {
+    await renderToString(
+      <ContentWidthProvider width={48}>
+        <FileEditToolUpdatedMessage
+          filePath="/repo/src/file.ts"
+          structuredPatch={[mixedHunk]}
+          firstLine="const old = true"
+          fileContent={'const old = true\n'}
+          verbose={false}
+        />
+      </ContentWidthProvider>,
+      120,
+    )
+
+    expect(structuredDiffMock.calls).toHaveLength(1)
+    expect(structuredDiffMock.calls[0]).toMatchObject({
+      width: 36,
     })
   })
 

--- a/runtime/tests/tui/components/FileEditToolUseRejectedMessage.test.tsx
+++ b/runtime/tests/tui/components/FileEditToolUseRejectedMessage.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { renderToString } from '../../utils/staticRender.js'
+import { ContentWidthProvider } from '../context/contentWidthContext.js'
 import { Text } from '../ink.js'
 import { FileEditToolUseRejectedMessage } from './FileEditToolUseRejectedMessage.js'
+
+const renderHarness = vi.hoisted(() => ({
+  highlightedCode: [] as Array<Record<string, unknown>>,
+  structuredDiffs: [] as Array<Record<string, unknown>>,
+}))
 
 vi.mock('../hooks/useTerminalSize.js', () => ({
   useTerminalSize: () => ({ columns: 80, rows: 24 }),
@@ -14,26 +20,33 @@ vi.mock('../../utils/cwd.js', () => ({
 }))
 
 vi.mock('./markdown/HighlightedCode.js', () => ({
-  HighlightedCode: ({
-    code,
-    filePath,
-  }: {
+  HighlightedCode: (props: {
     code: string
     filePath: string
-  }) => <Text>{`${filePath}:${code}`}</Text>,
+    width: number
+  }) => {
+    renderHarness.highlightedCode.push(props)
+    return <Text>{`${props.filePath}:${props.code}:${props.width}`}</Text>
+  },
 }))
 
 vi.mock('./diff/StructuredDiffList.js', () => ({
-  StructuredDiffList: ({
-    filePath,
-    firstLine,
-  }: {
+  StructuredDiffList: (props: {
     filePath: string
     firstLine: string | null
-  }) => <Text>{`diff:${filePath}:${firstLine ?? ''}`}</Text>,
+    width: number
+  }) => {
+    renderHarness.structuredDiffs.push(props)
+    return <Text>{`diff:${props.filePath}:${props.firstLine ?? ''}:${props.width}`}</Text>
+  },
 }))
 
 describe('FileEditToolUseRejectedMessage', () => {
+  beforeEach(() => {
+    renderHarness.highlightedCode = []
+    renderHarness.structuredDiffs = []
+  })
+
   test('renders condensed rejection with a relative path', async () => {
     const output = await renderToString(
       <FileEditToolUseRejectedMessage
@@ -125,5 +138,40 @@ describe('FileEditToolUseRejectedMessage', () => {
         80,
       ),
     ).resolves.toContain('diff:/repo/changed.ts:old')
+  })
+
+  test('sizes rejected write previews from inherited content width', async () => {
+    await renderToString(
+      <ContentWidthProvider width={64}>
+        <FileEditToolUseRejectedMessage
+          content="const value = 1"
+          file_path="/repo/src/new.ts"
+          firstLine={null}
+          operation="write"
+          verbose={false}
+        />
+      </ContentWidthProvider>,
+      120,
+    )
+
+    expect(renderHarness.highlightedCode.at(-1)).toMatchObject({ width: 52 })
+  })
+
+  test('sizes rejected update diffs from inherited content width', async () => {
+    await renderToString(
+      <ContentWidthProvider width={64}>
+        <FileEditToolUseRejectedMessage
+          fileContent="old"
+          file_path="/repo/changed.ts"
+          firstLine="old"
+          operation="update"
+          patch={[{ lines: ['-old', '+new'] }] as never}
+          verbose={false}
+        />
+      </ContentWidthProvider>,
+      120,
+    )
+
+    expect(renderHarness.structuredDiffs.at(-1)).toMatchObject({ width: 52 })
   })
 })

--- a/runtime/tests/tui/components/Message.render.test.tsx
+++ b/runtime/tests/tui/components/Message.render.test.tsx
@@ -88,6 +88,7 @@ vi.mock('./Message.renderers.js', async () => {
 
 import { createRoot } from '../ink/root.js'
 import { Box } from '../ink.js'
+import { ContentWidthProvider } from '../context/contentWidthContext.js'
 import type { Props } from './Message.js'
 import { Message } from './Message.js'
 
@@ -251,6 +252,72 @@ describe('Message render dispatch', () => {
       ).toMatchObject({ width: 7 })
     } finally {
       await rendered.dispose()
+    }
+  })
+
+  test('sizes user tool results from the message content width', async () => {
+    const user = {
+      message: {
+        content: [
+          { content: 'done', tool_use_id: 'tool-1', type: 'tool_result' },
+        ],
+      },
+      type: 'user',
+      uuid: 'user-content-width',
+    } as Props['message']
+
+    const rendered = await renderMessages([user], {
+      containerWidth: 54,
+    })
+
+    try {
+      expect(
+        harness.calls.find(call => call.name === 'UserToolResultMessage')?.props,
+      ).toMatchObject({ width: 49 })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('falls back to inherited content width for user tool results', async () => {
+    const user = {
+      message: {
+        content: [
+          { content: 'done', tool_use_id: 'tool-1', type: 'tool_result' },
+        ],
+      },
+      type: 'user',
+      uuid: 'user-inherited-width',
+    } as Props['message']
+
+    let output = ''
+    const { stdin, stdout } = createStreams()
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <ContentWidthProvider width={63}>
+          <Message {...baseProps(user)} message={user} />
+        </ContentWidthProvider>,
+      )
+      await sleep()
+
+      expect(stripAnsi(output)).toBeDefined()
+      expect(
+        harness.calls.find(call => call.name === 'UserToolResultMessage')?.props,
+      ).toMatchObject({ width: 58 })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
     }
   })
 

--- a/runtime/tests/tui/components/Messages.welcome.test.tsx
+++ b/runtime/tests/tui/components/Messages.welcome.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest'
 import type { Command } from '../../commands.js'
 import type { Tools } from '../../tools/Tool.js'
 import { renderToString } from '../../utils/staticRender.js'
+import { ContentWidthProvider } from '../context/contentWidthContext.js'
+import { stringWidth } from '../ink/stringWidth.js'
 import { Messages } from './Messages.js'
 
 vi.mock('bun:bundle', () => ({
@@ -12,6 +14,12 @@ vi.mock('bun:bundle', () => ({
 
 vi.mock('../startup/StatusNotices.js', () => ({
   StatusNotices: () => null,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
 }))
 
 const baseProps = {
@@ -45,5 +53,28 @@ describe('Messages welcome state', () => {
 
     expect(output).not.toContain('a netrunner with hands on every file')
     expect(output).not.toContain('/claim')
+  })
+
+  it('keeps streaming markdown inside the inherited message content width', async () => {
+    const output = await renderToString(
+      <ContentWidthProvider width={50}>
+        <Messages
+          {...baseProps}
+          hideLogo={true}
+          streamingText={[
+            '| Contract Row | Status | Evidence |',
+            '| --- | --- | --- |',
+            '| Row 1 - provider-boundary | Implemented | types.ts defines full BufferEditorProvider plus seven capability flags and provider selection wiring. |',
+            '| Row 2 - neovim-discovery | Scaffolding present | NeovimDiscovery implements binary detection, version checks, fallback reason codes, and runtime module discovery. |',
+          ].join('\n')}
+        />
+      </ContentWidthProvider>,
+      { columns: 120, rows: 24 },
+    )
+
+    expect(output).toContain('Contract Row:')
+    for (const line of output.split('\n')) {
+      expect(stringWidth(line)).toBeLessThanOrEqual(50)
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Route workbench content width through Messages, MessageRow, Message, tool result, diff/code, and system text render paths.
- Constrain streaming markdown with its live marker gutter before finalization.
- Strengthen TUI visual smoke checks with PTY autowrap diagnostics and workbench pane locality assertions.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/components/Message.render.test.tsx tests/tui/components/Messages.welcome.test.tsx tests/tui/components/FileEditToolUpdatedMessage.test.tsx tests/tui/components/FileEditToolUseRejectedMessage.test.tsx -- --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:tui-command-visual-smoke
- npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-visual-smoke
- npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-transcript-scroll
- npm --workspace=@tetsuo-ai/runtime run check:unused:report
- git diff --check