### PR TITLE
fix(runtime): resolve 17 audit findings + harden tool-permission boundary

### DIFF
--- a/runtime/src/agents/_deps/filesystem-args.ts
+++ b/runtime/src/agents/_deps/filesystem-args.ts
@@ -12,7 +12,101 @@
  * Carved as a local `_deps/` (mirroring
  * `runtime/src/tools/system/filesystem.ts`) to cut the gut→AgenC
  * crossing without re-importing the full filesystem tool surface.
+ *
+ * SECURITY (HMAC-signed trusted roots): the `__agencSessionAllowedRoots`
+ * arg widens filesystem confinement, so any value the model could forge
+ * would be a sandbox escape. Tool-call args are JSON-serialized on the
+ * dispatch path (router → execution, run-agent → tool-registry), all
+ * within the same Node process, so the trusted channel must itself be
+ * JSON-serializable — a Symbol/WeakMap tag would be lost across the
+ * round-trip. We therefore sign the roots with a per-process secret the
+ * model never sees and verify the signature at the SINK
+ * ({@link resolveToolAllowedPaths}). Unsigned/forged roots are dropped,
+ * so a future ingress that forgets the model-arg boundary strip cannot
+ * reintroduce the escape.
  */
+
+import { randomBytes, createHmac, timingSafeEqual } from "node:crypto";
 
 export const SESSION_ID_ARG = "__agencSessionId";
 export const SESSION_ALLOWED_ROOTS_ARG = "__agencSessionAllowedRoots";
+export const SESSION_ALLOWED_ROOTS_SIG_ARG = "__agencSessionAllowedRootsSig";
+
+/**
+ * Per-process secret keying the trusted-roots HMAC. Generated once at
+ * module load; never serialized, never exposed to the model. Because the
+ * in-process JSON dispatch round-trips (main + child) all run in this
+ * same Node runtime, they share this secret and signatures verify.
+ */
+const PROCESS_SECRET = randomBytes(32);
+
+/**
+ * Deterministic canonical serialization of a roots array: dedupe, sort,
+ * then JSON.stringify, so order/duplication never changes the signature.
+ */
+function canonicalizeRoots(roots: readonly string[]): string {
+  return JSON.stringify([...new Set(roots)].sort());
+}
+
+/**
+ * Hex HMAC-SHA256 over the canonical serialization of `roots`.
+ */
+export function signAllowedRoots(roots: string[]): string {
+  return createHmac("sha256", PROCESS_SECRET)
+    .update(canonicalizeRoots(roots))
+    .digest("hex");
+}
+
+/**
+ * Return the subset of `roots` that is validly signed by `sig`. Returns
+ * the normalized (deduped, sorted) roots when `roots` is a `string[]`,
+ * `sig` is a string, and `sig` `timingSafeEqual`-matches
+ * `signAllowedRoots(roots)`. Otherwise returns `[]` — non-array inputs,
+ * non-string entries, missing or forged signatures are all treated as
+ * absent.
+ */
+export function verifyAllowedRoots(roots: unknown, sig: unknown): string[] {
+  if (!Array.isArray(roots) || typeof sig !== "string") return [];
+  if (!roots.every((entry): entry is string => typeof entry === "string")) {
+    return [];
+  }
+  const normalized = [...new Set(roots as string[])].sort();
+  const expected = signAllowedRoots(normalized);
+  const sigBuf = Buffer.from(sig, "hex");
+  const expectedBuf = Buffer.from(expected, "hex");
+  if (sigBuf.length !== expectedBuf.length) return [];
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return [];
+  return normalized;
+}
+
+/**
+ * Writer helper: union `newRoots` into the signed trusted-roots channel
+ * of `args`, returning a NEW object (does not mutate input).
+ *
+ * Existing roots are read back via {@link verifyAllowedRoots}, so any
+ * unsigned/forged roots already present are DROPPED (they cannot be
+ * laundered into the signed set). The unioned roots are then written
+ * alongside a fresh signature.
+ */
+export function withSignedAllowedRoots(
+  args: Record<string, unknown>,
+  newRoots: string[],
+): Record<string, unknown> {
+  const existing = verifyAllowedRoots(
+    args[SESSION_ALLOWED_ROOTS_ARG],
+    args[SESSION_ALLOWED_ROOTS_SIG_ARG],
+  );
+  const unioned = [
+    ...new Set([
+      ...existing,
+      ...newRoots.filter(
+        (entry): entry is string => typeof entry === "string" && entry.length > 0,
+      ),
+    ]),
+  ];
+  return {
+    ...args,
+    [SESSION_ALLOWED_ROOTS_ARG]: unioned,
+    [SESSION_ALLOWED_ROOTS_SIG_ARG]: signAllowedRoots(unioned),
+  };
+}

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -46,8 +46,8 @@ import {
   type ToolRecoveryCategory,
 } from "./_deps/tools-types.js";
 import {
-  SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ID_ARG,
+  withSignedAllowedRoots,
 } from "./_deps/filesystem-args.js";
 import { Session as ChildSession, type Session } from "../session/session.js";
 import { RolloutStore } from "../session/rollout-store.js";
@@ -1165,7 +1165,9 @@ export function buildFilteredRegistry(
           isError: true,
         };
       }
-      const parsedArgs = parseResult.args;
+      // SECURITY: strip model-supplied `__agenc*` keys at the child
+      // tool-call boundary, before any policy/injection runs.
+      const parsedArgs = stripModelSuppliedChildArgs(parseResult.args);
       const wrappedTool = wrappedByName.get(toolCall.name);
       if (wrappedTool) {
         const result = await wrappedTool.execute(parsedArgs);
@@ -1311,6 +1313,38 @@ function formatToolArgumentsParseError(
   ].join("\n");
 }
 
+/**
+ * Drop every `__agenc*` key from a model-supplied child tool-call args
+ * object.
+ *
+ * SECURITY: `__agenc*` keys (`__agencSessionAllowedRoots`,
+ * `__agencSessionId`, …) are a TRUSTED INTERNAL channel the runtime uses
+ * to scope a child agent's filesystem access. A child model that emits
+ * `__agencSessionAllowedRoots:["/"]` could otherwise widen its own
+ * allowed roots and escape its worktree (audit #1/#2/#4). We strip these
+ * from the raw model args BEFORE the child-tool policy runs, so the only
+ * `__agenc*` values that survive are runtime/policy-injected. Returns the
+ * input untouched when there is nothing to strip.
+ */
+function stripModelSuppliedChildArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  let needsStrip = false;
+  for (const key of Object.keys(args)) {
+    if (key.startsWith("__agenc")) {
+      needsStrip = true;
+      break;
+    }
+  }
+  if (!needsStrip) return args;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (key.startsWith("__agenc")) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 function injectChildToolArgs(
   parsedArgs: Record<string, unknown>,
   toolName: string,
@@ -1319,25 +1353,21 @@ function injectChildToolArgs(
     readonly worktree?: WorktreeHandle;
   },
 ): Record<string, unknown> {
-  const injectedArgs: Record<string, unknown> = {
+  // NOTE: model-supplied `__agenc*` keys are stripped UPSTREAM
+  // (`stripModelSuppliedChildArgs`, applied to the raw model tool-call
+  // args before `applyChildToolPolicy`). By the time we reach here, any
+  // `__agencSessionAllowedRoots` present came from a TRUSTED source — the
+  // child-tool policy's `updatedInput` (e.g. session-memory dir), which
+  // is itself HMAC-signed via `withSignedAllowedRoots`. We route the
+  // worktree-root injection through `withSignedAllowedRoots` so the
+  // union (existing signed roots ∪ worktree) is re-signed; any unsigned
+  // root that slipped past the strip is dropped rather than laundered.
+  let injectedArgs: Record<string, unknown> = {
     ...parsedArgs,
     [SESSION_ID_ARG]: opts.childConversationId,
   };
-  const existingAllowedRoots = Array.isArray(
-    injectedArgs[SESSION_ALLOWED_ROOTS_ARG],
-  )
-    ? (injectedArgs[SESSION_ALLOWED_ROOTS_ARG] as unknown[]).filter(
-        (entry): entry is string =>
-          typeof entry === "string" && entry.length > 0,
-      )
-    : [];
   if (opts.worktree?.path) {
-    existingAllowedRoots.push(opts.worktree.path);
-  }
-  if (existingAllowedRoots.length > 0) {
-    injectedArgs[SESSION_ALLOWED_ROOTS_ARG] = [
-      ...new Set(existingAllowedRoots),
-    ];
+    injectedArgs = withSignedAllowedRoots(injectedArgs, [opts.worktree.path]);
   }
   if (
     opts.worktree?.path &&
@@ -1391,7 +1421,10 @@ function wrapToolForChild(
   return {
     ...tool,
     async execute(args) {
-      const policyResult = await applyChildToolPolicy(tool, args, opts);
+      // SECURITY: strip model-supplied `__agenc*` keys before the child
+      // policy/injection runs (idempotent if the caller already stripped).
+      const sanitizedArgs = stripModelSuppliedChildArgs(args);
+      const policyResult = await applyChildToolPolicy(tool, sanitizedArgs, opts);
       if ("result" in policyResult) {
         return policyResult.result;
       }

--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -140,6 +140,11 @@ const DEFAULT_DAEMON_STREAM_REQUEST_TIMEOUT_MS = 30 * 60_000;
 const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV = "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
 const MAX_BUFFERED_SESSION_EVENT_SESSIONS = 50;
 const MAX_BUFFERED_SESSION_EVENTS_PER_SESSION = 20;
+// Cap the per-connection read buffer so a daemon (or anything impersonating
+// the socket) that streams bytes without ever emitting a newline cannot grow
+// client memory unbounded. Mirrors the daemon transport's max-line / max
+// payload bound (16 MiB).
+const MAX_DAEMON_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024;
 const LONG_RUNNING_DAEMON_METHODS: ReadonlySet<AgenCDaemonMethod> = new Set([
   "message.stream",
 ]);
@@ -963,6 +968,20 @@ function connectPersistentDaemonClient(
     });
     socket.on("data", (chunk) => {
       buffer += chunk.toString("utf8");
+      if (Buffer.byteLength(buffer, "utf8") > MAX_DAEMON_CLIENT_BUFFER_BYTES) {
+        const overflowError = new Error(
+          `Daemon connection exceeded ${MAX_DAEMON_CLIENT_BUFFER_BYTES} bytes without a complete message`,
+        );
+        setConnectionState({
+          status: "disconnected",
+          message: overflowError.message,
+        });
+        failPending(overflowError);
+        closed = true;
+        buffer = "";
+        socket.destroy(overflowError);
+        return;
+      }
       let newlineIndex = buffer.indexOf("\n");
       while (newlineIndex >= 0) {
         const line = buffer.slice(0, newlineIndex).trim();

--- a/runtime/src/app-server/transport/stdio.ts
+++ b/runtime/src/app-server/transport/stdio.ts
@@ -11,9 +11,20 @@
  *     daemon-server concerns owned by later F-03 rows.
  */
 
+import { Buffer } from "node:buffer";
 import { createInterface, type Interface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
 import type { JsonObject, JsonValue } from "../protocol/index.js";
+
+/**
+ * Default upper bound on a single unterminated input line, matching the
+ * websocket transport's default max payload. A peer that streams bytes
+ * without ever emitting a newline would otherwise grow the readline
+ * internal buffer (and daemon memory) unbounded; the transport tracks the
+ * bytes seen since the last newline and tears the connection down once this
+ * cap is exceeded, treating it as a fatal framing violation.
+ */
+export const AGENC_STDIO_DEFAULT_MAX_LINE_BYTES = 16 * 1024 * 1024;
 
 export interface AgenCStdioTransportOptions {
   readonly input: Readable;
@@ -21,11 +32,18 @@ export interface AgenCStdioTransportOptions {
   readonly onMessage: (message: JsonObject) => void | Promise<void>;
   readonly onError?: (error: Error, line: string) => void;
   readonly onClose?: () => void;
+  readonly maxLineBytes?: number;
 }
 
 export class AgenCStdioTransport {
   readonly #options: AgenCStdioTransportOptions;
   readonly #pendingMessages = new Set<Promise<void>>();
+  // Per-connection dispatch is serialized on this chain so that pipelined,
+  // order-dependent requests on a single connection are handed to
+  // onMessage in arrival order (rather than racing as fire-and-forget
+  // promises). Cross-connection concurrency is preserved because each
+  // transport instance owns its own chain.
+  #dispatchChain: Promise<void> = Promise.resolve();
   #reader: Interface | null = null;
 
   constructor(options: AgenCStdioTransportOptions) {
@@ -44,10 +62,39 @@ export class AgenCStdioTransport {
     });
     this.#reader = reader;
 
+    // Node's readline does not enforce a maximum line length, so a peer that
+    // streams bytes without ever emitting a newline would grow the internal
+    // line buffer (and daemon memory) unbounded. Track the number of bytes
+    // accumulated since the last newline and tear the connection down once it
+    // exceeds the cap, mirroring the websocket transport's maxPayload bound.
+    const maxLineBytes =
+      this.#options.maxLineBytes ?? AGENC_STDIO_DEFAULT_MAX_LINE_BYTES;
+    let unterminatedBytes = 0;
+    const onData = (chunk: Buffer | string): void => {
+      const data = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+      const lastNewline = data.lastIndexOf(0x0a);
+      if (lastNewline === -1) {
+        unterminatedBytes += data.length;
+      } else {
+        unterminatedBytes = data.length - lastNewline - 1;
+      }
+      if (unterminatedBytes > maxLineBytes) {
+        this.#options.onError?.(
+          new RangeError(
+            `AgenC stdio transport line exceeded ${maxLineBytes} bytes without a newline`,
+          ),
+          "",
+        );
+        this.#options.input.destroy();
+      }
+    };
+    this.#options.input.on("data", onData);
+
     reader.on("line", (line) => {
       this.#handleLine(line);
     });
     reader.once("close", () => {
+      this.#options.input.off("data", onData);
       this.#reader = null;
       this.#options.onClose?.();
     });
@@ -74,11 +121,15 @@ export class AgenCStdioTransport {
       return;
     }
 
-    const pending = Promise.resolve(this.#options.onMessage(message)).catch(
-      (error) => {
+    // Chain dispatch on a per-connection promise so pipelined,
+    // order-dependent requests are handed to onMessage in arrival order
+    // instead of racing. A handler rejection is caught here so it cannot
+    // break the chain for subsequent messages.
+    const pending = (this.#dispatchChain = this.#dispatchChain.then(() =>
+      Promise.resolve(this.#options.onMessage(message)).catch((error) => {
         this.#options.onError?.(asError(error), line);
-      },
-    );
+      }),
+    ));
     this.#pendingMessages.add(pending);
     pending.finally(() => {
       this.#pendingMessages.delete(pending);

--- a/runtime/src/app-server/transport/websocket.ts
+++ b/runtime/src/app-server/transport/websocket.ts
@@ -71,6 +71,11 @@ export interface AgenCWebSocketServerOptions {
 interface ActiveWebSocketConnection {
   readonly socket: WebSocket;
   readonly pendingMessages: Set<Promise<void>>;
+  // Per-connection dispatch chain. Pipelined, order-dependent requests on a
+  // single connection are handed to onMessage in arrival order rather than
+  // racing as fire-and-forget promises. Each connection owns its own chain so
+  // cross-connection concurrency is preserved.
+  dispatchChain: Promise<void>;
 }
 
 export class AgenCWebSocketServer {
@@ -242,6 +247,7 @@ export class AgenCWebSocketServer {
     const active: ActiveWebSocketConnection = {
       socket,
       pendingMessages: new Set(),
+      dispatchChain: Promise.resolve(),
     };
     this.#connections.set(connectionId, active);
 
@@ -282,11 +288,13 @@ export class AgenCWebSocketServer {
       return;
     }
 
-    const pending = Promise.resolve(
-      this.#options.onMessage(message, context),
-    ).catch((error) => {
-      this.#options.onError?.(asError(error), context.connectionId);
-    });
+    const pending = (active.dispatchChain = active.dispatchChain.then(() =>
+      Promise.resolve(this.#options.onMessage(message, context)).catch(
+        (error) => {
+          this.#options.onError?.(asError(error), context.connectionId);
+        },
+      ),
+    ));
     active.pendingMessages.add(pending);
     pending.finally(() => {
       active.pendingMessages.delete(pending);

--- a/runtime/src/file-watcher/index.ts
+++ b/runtime/src/file-watcher/index.ts
@@ -250,7 +250,8 @@ interface FileWatcherInner {
 
 interface WatchBackend {
   readonly recursiveFallback: boolean;
-  readonly watchers: readonly FSWatcher[];
+  /** Live fs.watch handles keyed by the directory/path each one observes. */
+  readonly watchers: Map<string, FSWatcher>;
 }
 
 const defaultWatchFactory: FileWatcherWatchFactory = (pathToWatch, options, listener) =>
@@ -374,7 +375,7 @@ export class FileWatcher {
 
     if (this.#inner !== null) {
       for (const backend of this.#inner.watchers.values()) {
-        for (const watcher of backend.watchers) {
+        for (const watcher of backend.watchers.values()) {
           watcher.close();
         }
       }
@@ -384,7 +385,7 @@ export class FileWatcher {
   }
 
   liveWatcherCountForTest(pathToWatch: string): number {
-    return this.#inner?.watchers.get(pathToWatch)?.watchers.length ?? 0;
+    return this.#inner?.watchers.get(pathToWatch)?.watchers.size ?? 0;
   }
 
   async sendPathsForTest(paths: readonly string[]): Promise<void> {
@@ -472,27 +473,40 @@ export class FileWatcher {
   private closeBackend(pathToWatch: string): void {
     const backend = this.#inner?.watchers.get(pathToWatch);
     if (backend === undefined) return;
-    for (const watcher of backend.watchers) {
+    for (const watcher of backend.watchers.values()) {
       watcher.close();
     }
     this.#inner?.watchers.delete(pathToWatch);
     this.#inner?.watchedPaths.delete(pathToWatch);
   }
 
-  private replaceBackend(pathToWatch: string, mode: WatchMode, backend: WatchBackend): void {
-    this.closeBackend(pathToWatch);
-    this.#inner?.watchers.set(pathToWatch, backend);
-    this.#inner?.watchedPaths.set(pathToWatch, mode);
-  }
-
-  private refreshRecursiveFallback(pathToWatch: string): void {
+  /**
+   * Incrementally reconcile the recursive-fallback backend with the on-disk
+   * subtree: add a watcher for any newly-created directory and close watchers
+   * for directories that disappeared. This avoids tearing down and re-walking
+   * the whole subtree (an fd/CPU storm) on every filesystem event.
+   */
+  private reconcileRecursiveFallback(pathToWatch: string): void {
     if (this.#inner === null) return;
     const existing = this.#inner.watchers.get(pathToWatch);
     if (existing === undefined || !existing.recursiveFallback) return;
 
-    const refreshed = this.createRecursiveFallbackBackend(pathToWatch);
-    if (refreshed !== null) {
-      this.replaceBackend(pathToWatch, "recursive", refreshed);
+    const desired = new Set(recursiveDirectories(pathToWatch));
+    if (desired.size === 0) return;
+
+    // Drop watchers whose directory no longer exists in the subtree.
+    for (const [dir, watcher] of existing.watchers) {
+      if (!desired.has(dir)) {
+        watcher.close();
+        existing.watchers.delete(dir);
+      }
+    }
+
+    // Add watchers for directories that appeared since the last reconcile.
+    for (const dir of desired) {
+      if (existing.watchers.has(dir)) continue;
+      const watcher = this.createSingleFsWatcher(dir, false, pathToWatch, true);
+      if (watcher !== null) existing.watchers.set(dir, watcher);
     }
   }
 
@@ -503,9 +517,11 @@ export class FileWatcher {
     recursiveFallback: boolean,
   ): FSWatcher | null {
     try {
-      const watcher = this.#watchFactory(pathToWatch, { recursive }, (_eventType, filename) => {
+      const watcher = this.#watchFactory(pathToWatch, { recursive }, (eventType, filename) => {
         const eventPath = filename === null ? pathToWatch : path.join(pathToWatch, filename.toString());
-        if (recursiveFallback) this.refreshRecursiveFallback(eventRoot);
+        // Only directory create/remove (surfaced as "rename") can change the
+        // set of directories we must watch; plain "change" events never do.
+        if (recursiveFallback && eventType === "rename") this.reconcileRecursiveFallback(eventRoot);
         void this.notifySubscribers([eventPath]);
       });
       watcher.on("error", () => {
@@ -523,29 +539,30 @@ export class FileWatcher {
     const directories = recursiveDirectories(pathToWatch);
     if (directories.length === 0) {
       const watcher = this.createSingleFsWatcher(pathToWatch, false, pathToWatch, false);
-      return watcher === null ? null : { recursiveFallback: false, watchers: [watcher] };
+      return watcher === null ? null : { recursiveFallback: false, watchers: singleWatcherMap(pathToWatch, watcher) };
     }
 
-    const watchers: FSWatcher[] = [];
+    const watchers = new Map<string, FSWatcher>();
     for (const dir of directories) {
+      if (watchers.has(dir)) continue;
       const watcher = this.createSingleFsWatcher(dir, false, pathToWatch, true);
-      if (watcher !== null) watchers.push(watcher);
+      if (watcher !== null) watchers.set(dir, watcher);
     }
 
-    return watchers.length === 0 ? null : { recursiveFallback: true, watchers };
+    return watchers.size === 0 ? null : { recursiveFallback: true, watchers };
   }
 
   private createFsWatcher(pathToWatch: string, mode: WatchMode): WatchBackend | null {
     if (mode === "recursive") {
       const nativeRecursive = this.createSingleFsWatcher(pathToWatch, true, pathToWatch, false);
       if (nativeRecursive !== null) {
-        return { recursiveFallback: false, watchers: [nativeRecursive] };
+        return { recursiveFallback: false, watchers: singleWatcherMap(pathToWatch, nativeRecursive) };
       }
       return this.createRecursiveFallbackBackend(pathToWatch);
     }
 
     const watcher = this.createSingleFsWatcher(pathToWatch, false, pathToWatch, false);
-    return watcher === null ? null : { recursiveFallback: false, watchers: [watcher] };
+    return watcher === null ? null : { recursiveFallback: false, watchers: singleWatcherMap(pathToWatch, watcher) };
   }
 
   private decrementPathRef(actual: WatchPath, amount: number): void {
@@ -778,6 +795,10 @@ function recursiveDirectories(root: string): string[] {
     }
   }
   return directories;
+}
+
+function singleWatcherMap(pathToWatch: string, watcher: FSWatcher): Map<string, FSWatcher> {
+  return new Map<string, FSWatcher>([[pathToWatch, watcher]]);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/runtime/src/llm/providers/anthropic/adapter.ts
+++ b/runtime/src/llm/providers/anthropic/adapter.ts
@@ -9,6 +9,7 @@ import type {
   LLMMessage,
   LLMProvider,
   LLMResponse,
+  LLMToolCall,
   StreamProgressCallback,
 } from "../../types.js";
 import {
@@ -345,19 +346,6 @@ export class AnthropicProvider implements LLMProvider {
 
     let consecutiveFallbackFailures = 0;
     streamAttempts: while (true) {
-    try {
-      const response = await session.requestStream({
-        api: "messages",
-        method: "POST",
-        headers: { accept: "text/event-stream" },
-        body: request,
-        timeoutMs,
-        signal: options?.signal,
-        providerFallback: this.providerFallbackForModel(requestModel),
-        // Provider SSE streams are not resumable; preserve single-attempt
-        // stream semantics while using the shared session transport contract.
-        retryBudget: { maxRetries: 0 },
-      });
       let content = "";
       let model = requestModel;
       let finishReason: LLMResponse["finishReason"] = "stop";
@@ -384,6 +372,19 @@ export class AnthropicProvider implements LLMProvider {
         signature?: string;
         redacted: boolean;
       }> = [];
+    try {
+      const response = await session.requestStream({
+        api: "messages",
+        method: "POST",
+        headers: { accept: "text/event-stream" },
+        body: request,
+        timeoutMs,
+        signal: options?.signal,
+        providerFallback: this.providerFallbackForModel(requestModel),
+        // Provider SSE streams are not resumable; preserve single-attempt
+        // stream semantics while using the shared session transport contract.
+        retryBudget: { maxRetries: 0 },
+      });
 
       for await (const event of this.readSseEvents(response)) {
         const eventType = event.event ?? String(event.data.type ?? "");
@@ -736,26 +737,71 @@ export class AnthropicProvider implements LLMProvider {
       if (isFallbackTriggeredError(error)) {
         throw error;
       }
-      const fallbackDecision = this.evaluateConfiguredFallback(
-        error,
-        consecutiveFallbackFailures,
-        requestModel,
-      );
-      if (
-        fallbackDecision?.kind === "wait" &&
-        await this.waitForConfiguredFallbackRetry(
-          fallbackDecision,
-          options?.signal,
-        )
-      ) {
-        consecutiveFallbackFailures = fallbackDecision.consecutiveFailures;
-        continue streamAttempts;
+      // Only retry the stream from scratch when nothing has been emitted to the
+      // consumer yet. Once partial text or tool calls have been forwarded via
+      // onChunk, re-running the attempt would replay (and thus duplicate) the
+      // already-rendered output and inflate mid-stream token estimates, so we
+      // surface a partial response instead (mirrors the in-stream `error`
+      // branch and the grok adapter).
+      const hasEmittedOutput =
+        content.length > 0 ||
+        completedToolCalls.length > 0 ||
+        toolBlocks.size > 0;
+      if (!hasEmittedOutput) {
+        const fallbackDecision = this.evaluateConfiguredFallback(
+          error,
+          consecutiveFallbackFailures,
+          requestModel,
+        );
+        if (
+          fallbackDecision?.kind === "wait" &&
+          await this.waitForConfiguredFallbackRetry(
+            fallbackDecision,
+            options?.signal,
+          )
+        ) {
+          consecutiveFallbackFailures = fallbackDecision.consecutiveFailures;
+          continue streamAttempts;
+        }
       }
       consecutiveFallbackFailures = 0;
       if (error instanceof ProviderHttpError && error.status === 401) {
         throw new LLMAuthenticationError(this.name, error.status);
       }
-      throw mapLLMError(this.name, error, timeoutMs ?? 0);
+      const mappedError = mapLLMError(this.name, error, timeoutMs ?? 0);
+      if (content.length > 0) {
+        const partialToolCalls: LLMToolCall[] = completedToolCalls.flatMap(
+          (toolCall) => {
+            if (!parseToolInputObject(toolCall.arguments)) return [];
+            return [{
+              id: toolCall.id,
+              name: toolCall.name,
+              arguments: toolCall.arguments,
+            }];
+          },
+        );
+        onChunk({
+          content: "",
+          done: true,
+          ...(partialToolCalls.length > 0
+            ? { toolCalls: partialToolCalls }
+            : {}),
+        });
+        return {
+          content,
+          toolCalls: partialToolCalls,
+          usage: {
+            promptTokens: usage.input_tokens,
+            completionTokens: usage.output_tokens,
+            totalTokens: usage.input_tokens + usage.output_tokens,
+          },
+          model,
+          finishReason: "error",
+          error: mappedError,
+          partial: true,
+        };
+      }
+      throw mappedError;
     }
     }
   }

--- a/runtime/src/mcp-client/manager.ts
+++ b/runtime/src/mcp-client/manager.ts
@@ -21,13 +21,14 @@ import type {
 import type { Tool } from "./_deps/tools-types.js";
 import type { Logger } from "./_deps/logger.js";
 import { silentLogger } from "./_deps/logger.js";
-import { isValidPermissionDefaultMode } from "../config/schema.js";
 import { createMCPConnection } from "./connection.js";
 import { createToolBridge } from "./tools.js";
-import { ResilientMCPBridge } from "./resilient-client.js";
+import {
+  ResilientMCPBridge,
+  toToolCatalogPolicyConfig,
+} from "./resilient-client.js";
 import type {
   MCPCallObserver,
-  MCPToolCatalogPolicyConfig,
   MCPToolBridgePermissionOptions,
 } from "./tools.js";
 import {
@@ -69,41 +70,6 @@ interface StartupGate {
 export type MCPConnectionState =
   | { readonly type: "connected" | "pending" | "disabled" | "needs-auth" }
   | { readonly type: "failed"; readonly error?: string };
-
-function toToolCatalogPolicyConfig(
-  config: MCPServerConfig,
-): MCPToolCatalogPolicyConfig | undefined {
-  const typed = config as MCPServerConfig & MCPToolCatalogPolicyConfig;
-  const allowedTools = typed.allowedTools ?? config.enabled_tools;
-  const deniedTools = typed.deniedTools ?? config.disabled_tools;
-  const defaultToolsApprovalMode = isValidPermissionDefaultMode(config.default_tools_approval_mode)
-    ? config.default_tools_approval_mode
-    : undefined;
-  if (
-    !typed.riskControls &&
-    !typed.supplyChain &&
-    !typed.pinnedCatalogSha256 &&
-    allowedTools === undefined &&
-    deniedTools === undefined &&
-    defaultToolsApprovalMode === undefined &&
-    config.tools === undefined
-  ) {
-    return undefined;
-  }
-  return {
-    ...(allowedTools !== undefined ? { allowedTools } : {}),
-    ...(deniedTools !== undefined ? { deniedTools } : {}),
-    ...(typed.pinnedCatalogSha256 !== undefined
-      ? { pinnedCatalogSha256: typed.pinnedCatalogSha256 }
-      : {}),
-    ...(defaultToolsApprovalMode !== undefined
-      ? { defaultToolsApprovalMode }
-      : {}),
-    ...(config.tools !== undefined ? { tools: config.tools } : {}),
-    riskControls: typed.riskControls,
-    supplyChain: typed.supplyChain,
-  };
-}
 
 function toScopedMcpServerConfig(
   config: MCPServerConfig,
@@ -782,6 +748,14 @@ export class MCPManager {
         {
           ...(this.permissionOptions !== undefined
             ? { permissions: this.permissionOptions }
+            : {}),
+          // Telemetry parity: forward the same call observer the initial
+          // `createToolBridge` above received so reconnected bridges keep
+          // emitting `mcp_tool_call_*` events. `serverOrigin` is not derived
+          // here yet; when it is, pass it both here and to `createToolBridge`
+          // so the two connect paths stay in lockstep.
+          ...(this.callObserver !== undefined
+            ? { callObserver: this.callObserver }
             : {}),
         },
       );

--- a/runtime/src/mcp-client/resilient-client.ts
+++ b/runtime/src/mcp-client/resilient-client.ts
@@ -9,9 +9,66 @@
 
 import type { Tool, ToolResult } from "./_deps/tools-types.js";
 import type { MCPServerConfig, MCPToolBridge } from "./types.js";
-import type { MCPToolBridgePermissionOptions } from "./tools.js";
+import type {
+  MCPCallObserver,
+  MCPToolBridgePermissionOptions,
+  MCPToolCatalogPolicyConfig,
+} from "./tools.js";
 import type { Logger } from "./_deps/logger.js";
 import { silentLogger } from "./_deps/logger.js";
+import { isValidPermissionDefaultMode } from "../config/schema.js";
+
+/**
+ * Derive the tool catalog policy (allow/deny filter, I-74 SHA-256 catalog
+ * pin, per-tool + default approval modes) from a server config.
+ *
+ * This is the SINGLE source of truth shared by both connect paths: the
+ * initial connect in `manager.ts` imports this same function (manager already
+ * depends on this module for `ResilientMCPBridge`, so importing it here keeps
+ * the dependency edge one-directional and avoids a cycle), and the reconnect
+ * path below re-applies it so a dropped connection cannot bypass supply-chain
+ * or access controls (#6). Keeping one implementation means a new security
+ * field added to the policy derivation lands on both paths at once.
+ *
+ * The policy fields live alongside `MCPServerConfig` but are not part of its
+ * public surface, so they are read through a widened cast.
+ */
+export function toToolCatalogPolicyConfig(
+  config: MCPServerConfig,
+): MCPToolCatalogPolicyConfig | undefined {
+  const typed = config as MCPServerConfig & MCPToolCatalogPolicyConfig;
+  const allowedTools = typed.allowedTools ?? config.enabled_tools;
+  const deniedTools = typed.deniedTools ?? config.disabled_tools;
+  const defaultToolsApprovalMode = isValidPermissionDefaultMode(
+    config.default_tools_approval_mode,
+  )
+    ? config.default_tools_approval_mode
+    : undefined;
+  if (
+    !typed.riskControls &&
+    !typed.supplyChain &&
+    !typed.pinnedCatalogSha256 &&
+    allowedTools === undefined &&
+    deniedTools === undefined &&
+    defaultToolsApprovalMode === undefined &&
+    config.tools === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    ...(allowedTools !== undefined ? { allowedTools } : {}),
+    ...(deniedTools !== undefined ? { deniedTools } : {}),
+    ...(typed.pinnedCatalogSha256 !== undefined
+      ? { pinnedCatalogSha256: typed.pinnedCatalogSha256 }
+      : {}),
+    ...(defaultToolsApprovalMode !== undefined
+      ? { defaultToolsApprovalMode }
+      : {}),
+    ...(config.tools !== undefined ? { tools: config.tools } : {}),
+    riskControls: typed.riskControls,
+    supplyChain: typed.supplyChain,
+  };
+}
 
 /** Patterns that indicate the underlying MCP connection is dead. */
 const CONNECTION_ERROR_PATTERNS = [
@@ -34,6 +91,15 @@ const BACKOFF_MULTIPLIER = 2;
 
 interface ResilientMCPBridgeOptions {
   readonly permissions?: MCPToolBridgePermissionOptions;
+  /**
+   * Telemetry plumbing forwarded to the inner bridge on reconnect so a
+   * rebuilt bridge keeps emitting the same `mcp_tool_call_*` events and
+   * span origin the initial connect set up. Telemetry-only (not a security
+   * control); kept at parity with the initial-connect `createToolBridge`
+   * call in `manager.ts`.
+   */
+  readonly callObserver?: MCPCallObserver;
+  readonly serverOrigin?: string;
 }
 
 /**
@@ -48,6 +114,12 @@ export class ResilientMCPBridge implements MCPToolBridge {
 
   private inner: MCPToolBridge;
   private readonly config: MCPServerConfig;
+  /**
+   * Catalog policy (allow/deny filter, I-74 SHA-256 pin, approval modes)
+   * derived from `config` at construction and re-applied on every reconnect
+   * so a reconnection cannot bypass supply-chain or access controls (#6).
+   */
+  private readonly catalogPolicy: MCPToolCatalogPolicyConfig | undefined;
   private readonly logger: Logger;
   private readonly options: ResilientMCPBridgeOptions;
 
@@ -63,6 +135,7 @@ export class ResilientMCPBridge implements MCPToolBridge {
     options: ResilientMCPBridgeOptions = {},
   ) {
     this.config = config;
+    this.catalogPolicy = toToolCatalogPolicyConfig(config);
     this.inner = initialBridge;
     this.logger = logger;
     this.options = options;
@@ -157,8 +230,22 @@ export class ResilientMCPBridge implements MCPToolBridge {
         {
           listToolsTimeoutMs: this.config.timeout,
           callToolTimeoutMs: this.config.timeout,
+          // #6: re-apply the allow/deny filter, I-74 catalog pin, and approval
+          // modes on every reconnect — otherwise a dropped connection would
+          // silently bypass supply-chain and access controls.
+          ...(this.catalogPolicy !== undefined
+            ? { serverConfig: this.catalogPolicy }
+            : {}),
           ...(this.options.permissions !== undefined
             ? { permissions: this.options.permissions }
+            : {}),
+          // Telemetry parity with the initial connect (manager.ts): keep the
+          // rebuilt bridge emitting the same call events / span origin.
+          ...(this.options.callObserver !== undefined
+            ? { callObserver: this.options.callObserver }
+            : {}),
+          ...(this.options.serverOrigin !== undefined
+            ? { serverOrigin: this.options.serverOrigin }
             : {}),
         },
       );

--- a/runtime/src/memory/session/sessionMemory.ts
+++ b/runtime/src/memory/session/sessionMemory.ts
@@ -28,10 +28,10 @@ import type { Session } from "../../session/session.js";
 import { FILE_EDIT_TOOL_NAME } from "../../tools/system/file-edit.js";
 import { createFileReadTool } from "../../tools/system/file-read.js";
 import {
-  SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ID_ARG,
   recordSessionRead,
   seedSessionReadState,
+  withSignedAllowedRoots,
   type SessionReadSeedEntry,
 } from "../../tools/system/filesystem.js";
 import type { Tool } from "../../tools/types.js";
@@ -271,16 +271,7 @@ function copyWithAllowedRoot(
   input: Record<string, unknown>,
   memoryDir: string,
 ): Record<string, unknown> {
-  const existing = Array.isArray(input[SESSION_ALLOWED_ROOTS_ARG])
-    ? (input[SESSION_ALLOWED_ROOTS_ARG] as unknown[]).filter(
-        (entry): entry is string =>
-          typeof entry === "string" && entry.length > 0,
-      )
-    : [];
-  return {
-    ...input,
-    [SESSION_ALLOWED_ROOTS_ARG]: [...new Set([...existing, memoryDir])],
-  };
+  return withSignedAllowedRoots(input, [memoryDir]);
 }
 
 export function createSessionMemoryEditPolicy(
@@ -337,11 +328,15 @@ export async function setupSessionMemoryFile(
     maxTokens: 50_000,
     maxTextBytes: ONE_MEBIBYTE,
   });
-  const readResult = await readTool.execute({
-    file_path: memoryPath,
-    [SESSION_ID_ARG]: options.sessionId,
-    [SESSION_ALLOWED_ROOTS_ARG]: [memoryDir],
-  });
+  const readResult = await readTool.execute(
+    withSignedAllowedRoots(
+      {
+        file_path: memoryPath,
+        [SESSION_ID_ARG]: options.sessionId,
+      },
+      [memoryDir],
+    ),
+  );
   if (readResult.isError === true) {
     throw new Error(readResult.content);
   }

--- a/runtime/src/permissions/path-validation.ts
+++ b/runtime/src/permissions/path-validation.ts
@@ -30,6 +30,9 @@ import {
 import {
   getRuleByContentsForTool,
 } from "./rules.js";
+import {
+  withSignedAllowedRoots,
+} from "../agents/_deps/filesystem-args.js";
 import type {
   PermissionDecisionReason,
   PermissionResult,
@@ -43,7 +46,6 @@ const GLOB_PATTERN_REGEX = /[*?[\]{}]/;
 const WINDOWS_DRIVE_ROOT_REGEX = /^[A-Za-z]:\/?$/;
 const WINDOWS_DRIVE_CHILD_REGEX = /^[A-Za-z]:\/[^/]+$/;
 const MAX_PATH_LENGTH = 4096;
-const SESSION_ALLOWED_ROOTS_ARG = "__agencSessionAllowedRoots";
 
 export type FileOperationType = "read" | "write" | "create";
 
@@ -633,36 +635,12 @@ function withTransientAllowedRoot(
   input: Record<string, unknown>,
   resolvedPath: string,
 ): Record<string, unknown> {
-  const existingRoots = Array.isArray(input[SESSION_ALLOWED_ROOTS_ARG])
-    ? input[SESSION_ALLOWED_ROOTS_ARG].filter(
-        (entry): entry is string => typeof entry === "string" && entry.length > 0,
-      )
-    : [];
-  return {
-    ...input,
-    [SESSION_ALLOWED_ROOTS_ARG]: [
-      ...new Set([...existingRoots, dirname(resolvedPath)]),
-    ],
-  };
+  return withSignedAllowedRoots(input, [dirname(resolvedPath)]);
 }
 
 export function checkToolPathPermission(
   opts: ToolPathPermissionOptions,
 ): PermissionResult {
-  // Mirror the bash short-circuit at permissions/bash.ts: in --yolo /
-  // bypassPermissions mode the user has explicitly opted out of approval
-  // gating, so filesystem-touching tools (Read, Glob, FileRead, ...) must
-  // not surface the working-dir prompt. Without this, `agenc --yolo` was
-  // half-bypassing — Bash and Grep auto-approved while Read/Glob still
-  // prompted, breaking GAP-TEST-* scenarios 11/13/35 and the user's
-  // muscle-memory expectation that --yolo means yolo for everything.
-  if (opts.context.mode === "bypassPermissions") {
-    return {
-      behavior: "allow",
-      updatedInput: opts.input,
-      decisionReason: { type: "mode", mode: "bypassPermissions" },
-    };
-  }
   const result = validatePath(
     opts.path,
     opts.cwd,
@@ -688,6 +666,32 @@ export function checkToolPathPermission(
       behavior: "deny",
       message: `Permission to ${verb} ${opts.path} has been denied.`,
       decisionReason,
+    };
+  }
+
+  // Mirror the bash short-circuit at permissions/bash.ts:431 ("hadDeny"
+  // guard): in --yolo / bypassPermissions mode the user has explicitly
+  // opted out of approval gating, so filesystem-touching tools (Read, Glob,
+  // FileRead, ...) must not surface the working-dir prompt. Without this,
+  // `agenc --yolo` was half-bypassing — Bash and Grep auto-approved while
+  // Read/Glob still prompted, breaking GAP-TEST-* scenarios 11/13/35.
+  //
+  // SECURITY: this bypass runs AFTER validatePath, so a path-specific
+  // Deny(...) rule (handled above) and the safety gates surfaced as a
+  // "safetyCheck" decisionReason (the .git/.agenc/.agents protected-path and
+  // dangerous-removal checks in isPathAllowed/checkPathSafetyForAutoEdit) are
+  // still honored. These are exactly the two bypass-immune categories the
+  // evaluator enforces at permissions/evaluator.ts (step 1d deny, step 1g
+  // safetyCheck); everything else (workingDir/ask) is auto-allowed under
+  // bypass.
+  if (
+    opts.context.mode === "bypassPermissions" &&
+    decisionReason?.type !== "safetyCheck"
+  ) {
+    return {
+      behavior: "allow",
+      updatedInput: opts.input,
+      decisionReason: { type: "mode", mode: "bypassPermissions" },
     };
   }
 

--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -79,7 +79,7 @@ import {
 } from "../../tools/orchestrator.js";
 import {
   SESSION_AGENC_HOME_ARG,
-  SESSION_ALLOWED_ROOTS_ARG,
+  withSignedAllowedRoots,
 } from "../../tools/system/filesystem.js";
 import {
   routerFromRegistry as realRouterFromRegistry,
@@ -140,18 +140,7 @@ function withApprovedFilesystemRoot(
     ? filePath
     : resolve(cwd, filePath);
   const approvedRoot = dirname(resolvedPath);
-  const existingRoots = Array.isArray(args[SESSION_ALLOWED_ROOTS_ARG])
-    ? args[SESSION_ALLOWED_ROOTS_ARG].filter(
-        (entry): entry is string =>
-          typeof entry === "string" && entry.length > 0,
-      )
-    : [];
-  if (existingRoots.includes(approvedRoot)) return args;
-
-  return {
-    ...args,
-    [SESSION_ALLOWED_ROOTS_ARG]: [...new Set([...existingRoots, approvedRoot])],
-  };
+  return withSignedAllowedRoots(args, [approvedRoot]);
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/runtime/src/sandbox/linux-launcher/bwrap.ts
+++ b/runtime/src/sandbox/linux-launcher/bwrap.ts
@@ -93,9 +93,9 @@ function createBwrapFlagsFullFilesystem(
     "--bind",
     "/",
     "/",
-    "--unshare-user",
-    "--unshare-pid",
   ];
+  appendProcMask(args, options);
+  args.push("--unshare-user", "--unshare-pid");
   appendNamespaceArgs(args, options);
   args.push("--");
   args.push(...command);
@@ -130,6 +130,17 @@ function createBwrapFlags(
   args.push("--");
   args.push(...command);
   return args;
+}
+
+function appendProcMask(args: string[], options: BwrapOptions): void {
+  // When a private procfs is not mounted, the host /proc bound via the root
+  // bind would otherwise stay visible, leaking other same-UID processes'
+  // environ/cmdline/maps. Mask it with an empty tmpfs so host procfs is never
+  // exposed. When mountProc is true, appendNamespaceArgs mounts a fresh procfs
+  // over this path afterwards.
+  if (!options.mountProc) {
+    args.push("--tmpfs", "/proc");
+  }
 }
 
 function appendNamespaceArgs(args: string[], options: BwrapOptions): void {
@@ -170,6 +181,8 @@ function createFilesystemArgs(
       appendReadOnlyIfExists(args, root);
     }
   }
+
+  appendProcMask(args, options);
 
   args.push("--dev", "/dev");
 

--- a/runtime/src/sandbox/linux-launcher/linux-run-main.ts
+++ b/runtime/src/sandbox/linux-launcher/linux-run-main.ts
@@ -440,8 +440,15 @@ function resolveTrueCommand(): string {
   return "/bin/true";
 }
 
-function isProcMountFailure(stderr: string): boolean {
-  return /proc|permission denied|operation not permitted|not permitted/i.test(stderr);
+export function isProcMountFailure(stderr: string): boolean {
+  // Match only bubblewrap's procfs-mount-specific failure strings. The previous
+  // broad `proc|not permitted` substrings false-positived on unrelated stderr,
+  // which could let the launcher silently fall back to running without a
+  // private procfs while host /proc stayed exposed. Prefer failing closed: only
+  // treat a genuine proc-mount error as a recoverable proc-mount failure.
+  // bubblewrap reports a procfs mount failure as "Can't mount proc on <dest>"
+  // (older builds also emit "Can't mount new procfs").
+  return /can't mount (?:new )?proc(?:fs)?\b/i.test(stderr);
 }
 
 function startProtectedCreateMonitor(

--- a/runtime/src/secrets/sanitizer.ts
+++ b/runtime/src/secrets/sanitizer.ts
@@ -18,6 +18,12 @@ const SECRET_PATTERNS: ReadonlyArray<{
   readonly replacement: string;
 }> = [
   {
+    // xAI — the runtime's OWN classifier key shape; redact first so a bare
+    // `xai-...` never leaks even when no surrounding key/context is present.
+    pattern: /(?<![A-Za-z0-9_-])xai-[A-Za-z0-9_-]{16,}(?=$|[^A-Za-z0-9_-])/g,
+    replacement: REDACTED_SECRET,
+  },
+  {
     pattern: /(?<![A-Za-z0-9_-])sk-(?:proj-)?[A-Za-z0-9_-]{20,}(?=$|[^A-Za-z0-9_-])/g,
     replacement: REDACTED_SECRET,
   },
@@ -40,6 +46,27 @@ const SECRET_PATTERNS: ReadonlyArray<{
   {
     pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
     replacement: REDACTED_SECRET,
+  },
+  {
+    // Slack tokens (bot/app/user/refresh/configuration).
+    pattern: /(?<![A-Za-z0-9_-])xox[baprs]-[A-Za-z0-9-]{10,}(?=$|[^A-Za-z0-9-])/g,
+    replacement: REDACTED_SECRET,
+  },
+  {
+    // Google API keys: fixed `AIza` prefix + 35 chars is specific enough on its own.
+    pattern: /(?<![A-Za-z0-9_-])AIza[0-9A-Za-z_-]{35}(?=$|[^A-Za-z0-9_-])/g,
+    replacement: REDACTED_SECRET,
+  },
+  {
+    // AWS secret access keys are 40-char base64 with no distinctive prefix, so a
+    // bare 40-char token is too noisy to redact. Scope to an explicit
+    // aws/secret/access-key context word immediately preceding the value to keep
+    // false positives off ordinary prose. The separator tolerates a closing
+    // quote before the colon so JSON-quoted keys (`"aws_secret_access_key":`) are
+    // covered, and the value tolerates trailing `=` base64 padding.
+    pattern:
+      /\b(aws[_-]?secret[_-]?access[_-]?key|aws[_-]?secret|secret[_-]?access[_-]?key)\b(["']?\s*[:=]\s*|\s+)(["']?)[A-Za-z0-9/+]{40}={0,2}(?![A-Za-z0-9/+=])/gi,
+    replacement: `$1$2$3${REDACTED_SECRET}`,
   },
   {
     pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}(?=$|[^A-Za-z0-9._~+/=-])/gi,
@@ -143,6 +170,12 @@ function isSensitiveKey(key: string): boolean {
     normalized === "secret" ||
     normalized.endsWith("secret") ||
     normalized.endsWith("secretvalue") ||
+    // AWS access keys normalize to `...accesskey`/`...secretkey`, matching neither
+    // `apikey` nor `secret`; recognize their specific shapes without making every
+    // `...key` sensitive.
+    normalized.endsWith("secretaccesskey") ||
+    normalized.endsWith("secretkey") ||
+    normalized.endsWith("accesskeyid") ||
     normalized === "password" ||
     normalized.endsWith("password") ||
     normalized.endsWith("passwordvalue") ||

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -26,7 +26,7 @@ import type {
 } from "../../agents/run-agent.js";
 import type { delegate as delegateFn } from "../../agents/delegate.js";
 import type { ensureAgentControl as ensureAgentControlFn } from "../../bin/delegate-tool.js";
-import { SESSION_ALLOWED_ROOTS_ARG } from "../../agents/_deps/filesystem-args.js";
+import { withSignedAllowedRoots } from "../../agents/_deps/filesystem-args.js";
 import type { AgentPath } from "../../agents/registry.js";
 import {
   createMemoryExtractionTriggerState,
@@ -190,16 +190,7 @@ function withMemoryAllowedRoot(
   input: Record<string, unknown>,
   memoryDir: string,
 ): Record<string, unknown> {
-  const current = Array.isArray(input[SESSION_ALLOWED_ROOTS_ARG])
-    ? (input[SESSION_ALLOWED_ROOTS_ARG] as unknown[]).filter(
-        (entry): entry is string =>
-          typeof entry === "string" && entry.length > 0,
-      )
-    : [];
-  return {
-    ...input,
-    [SESSION_ALLOWED_ROOTS_ARG]: [...new Set([...current, memoryDir])],
-  };
+  return withSignedAllowedRoots(input, [memoryDir]);
 }
 
 function deny(message: string, reason: string): ReturnType<ChildToolPolicy> {

--- a/runtime/src/session/degraded-store.ts
+++ b/runtime/src/session/degraded-store.ts
@@ -168,23 +168,56 @@ export class DegradedStore<T> {
       return true;
     }
     this.flushing = true;
-    const toFlush = [...this.buffer];
+    // #12: drain by IDENTITY, not by index. We remove the snapshot from
+    // the buffer up front so a concurrent at-capacity append() during
+    // the async `flushFn` gap can only evict from the *newly appended*
+    // tail — never from the slice we are flushing. A post-flush
+    // `splice(0, toFlush.length)` (the old approach) would, after such
+    // an eviction, drop a never-flushed item because the front no longer
+    // points at the flushed prefix.
+    const toFlush = this.buffer;
+    this.buffer = [];
     try {
       const ok = await this.flushFn(toFlush);
       if (ok) {
-        // Only clear the portion we flushed — appends during the
-        // async gap stay in the buffer.
-        this.buffer.splice(0, toFlush.length);
+        // Flushed items already removed. Appends during the async gap
+        // landed in the fresh `this.buffer` and stay there.
         if (this.buffer.length === 0) {
           this.exitDegraded(toFlush.length);
         }
         return true;
       }
+      // Flush failed: re-prepend the drained items ahead of anything
+      // that arrived during the gap so ordering is preserved, then
+      // re-apply capacity/eviction (oldest-first) on the combined buffer.
+      this.requeueFront(toFlush);
       return false;
     } catch {
+      this.requeueFront(toFlush);
       return false;
     } finally {
       this.flushing = false;
+    }
+  }
+
+  /**
+   * Re-insert a previously-drained slice at the FRONT of the buffer
+   * (used when a flush attempt fails). Restores oldest-first ordering
+   * and re-applies capacity eviction on the combined buffer.
+   */
+  private requeueFront(items: T[]): void {
+    if (items.length === 0) return;
+    this.buffer = items.concat(this.buffer);
+    if (this.buffer.length > this.capacity) {
+      const overflow = this.buffer.length - this.capacity;
+      this.buffer.splice(0, overflow);
+      this.totalEvicted += overflow;
+      this.onStatusChange?.({
+        kind: "evicted",
+        evicted: overflow,
+        capacity: this.capacity,
+        at: monotonicMs(),
+      });
     }
   }
 

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -1158,21 +1158,33 @@ export class SessionStore {
     this.pending = [];
     this.batchOpenedAtMs = null;
 
-    const routeToDegraded = (err: unknown) => {
+    // `requeue` distinguishes the two failure shapes (#11):
+    //   - writeSync itself threw (ENOSPC/EROFS/…): the bytes never
+    //     reached the file, so the items must be re-queued into the
+    //     degraded ring buffer for a later re-append (requeue=true).
+    //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
+    //     bytes are ALREADY appended to the rollout on disk. Re-queueing
+    //     them would re-serialize + re-append the same rows on degraded
+    //     flush, bypassing the append()-level seq/UUID dedup and landing
+    //     duplicates in the JSONL (double on resume). So we enter
+    //     degraded mode WITHOUT re-queueing (requeue=false).
+    const routeToDegraded = (err: unknown, requeue: boolean) => {
       if (isDegradedErrno(err)) {
-        // I-12 / I-38 path: route the batch items into the degraded
-        // ring buffer. UUID dedup protects against re-play duplicating
-        // any rows the kernel did eventually persist despite the
-        // fsync failure.
+        // I-12 / I-38 path: enter degraded so subsequent appends buffer
+        // instead of touching the sick disk.
         this.degraded.enterDegraded(
           `${(err as { code?: string }).code} during append`,
         );
-        for (const item of toWrite) this.degraded.append(item);
+        if (requeue) {
+          for (const item of toWrite) this.degraded.append(item);
+        }
         this.emitDiagnostic({
           at: Date.now(),
           level: "error",
           cause: "rollout_degraded",
-          message: `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`,
+          message: requeue
+            ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
+            : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
         });
         return true;
       }
@@ -1182,16 +1194,19 @@ export class SessionStore {
     try {
       if (durable) {
         // I-38: async retry on fsync failure routes to degraded via
-        // the callback, so we don't block the event loop here.
+        // the callback. The bytes were already writeSync'd by this
+        // point, so we MUST NOT re-queue them (#11) — only enter
+        // degraded mode.
         this.writeBytesWithFsync(lines, (err) => {
-          routeToDegraded(err);
+          routeToDegraded(err, /*requeue*/ false);
         });
       } else {
         this.writeBytesAppendOnly(lines);
       }
       this.fileSize += Buffer.byteLength(lines, "utf8");
     } catch (err) {
-      if (!routeToDegraded(err)) {
+      // writeSync threw — bytes never landed; re-queue for re-append.
+      if (!routeToDegraded(err, /*requeue*/ true)) {
         throw err;
       }
     }
@@ -1381,12 +1396,15 @@ export class SessionStore {
       type: "session_meta",
       payload: this.lastSessionMeta,
     };
-    const routeToDegraded = (err: unknown) => {
+    // See #11: writeSync-succeeded-but-fsync-failed leaves the bytes
+    // already on disk, so the fsync-retry path enters degraded without
+    // re-queueing; only a writeSync throw (bytes never landed) re-queues.
+    const routeToDegraded = (err: unknown, requeue: boolean) => {
       if (isDegradedErrno(err)) {
         this.degraded.enterDegraded(
           `${(err as { code?: string }).code} during metadata re-append`,
         );
-        this.degraded.append(item);
+        if (requeue) this.degraded.append(item);
         return true;
       }
       return false;
@@ -1394,11 +1412,11 @@ export class SessionStore {
     try {
       const line = serializeRolloutItem(item);
       this.writeBytesWithFsync(line, (err) => {
-        routeToDegraded(err);
+        routeToDegraded(err, /*requeue*/ false);
       });
       this.fileSize += Buffer.byteLength(line, "utf8");
     } catch (err) {
-      if (!routeToDegraded(err)) throw err;
+      if (!routeToDegraded(err, /*requeue*/ true)) throw err;
     }
   }
 
@@ -1415,18 +1433,25 @@ export class SessionStore {
       this.writeBytesWithFsync(lines, (err) => {
         retryFailure = err;
       });
-      // writeSync succeeded; the bytes are at least in the page cache,
-      // so bump fileSize regardless of fsync retry outcome.
+      // writeSync succeeded → the bytes are now appended to the rollout
+      // file on disk (O_APPEND). Even if the subsequent fsync (+ I-38
+      // retry) fails, these items are physically written. Reporting
+      // drain success (true) removes them from the degraded buffer so a
+      // later retry does NOT re-serialize + re-append the same rows,
+      // which would duplicate them in the JSONL (#11). The fsync failure
+      // still re-trips degraded mode via the retry callback, but without
+      // re-queueing these already-persisted items.
       this.fileSize += Buffer.byteLength(lines, "utf8");
-      // If the sync fsync failed and scheduled an async retry, wait
-      // for it to settle so we accurately report drain success/failure
-      // back to the DegradedStore.
+      // Settle any deferred I-38 fsync retry before returning so the
+      // fsync_failed / fsync_retry_succeeded diagnostics are observable
+      // to callers (and tests) at the point the drain reports success.
       await this.awaitPendingFsyncRetries();
-      if (retryFailure !== undefined) {
-        return !isDegradedErrno(retryFailure);
-      }
+      void retryFailure;
       return true;
     } catch (err) {
+      // writeSync threw — the bytes never reached the file. Keep the
+      // items buffered (return false) so they are retried, unless the
+      // error is non-degraded (then drop, as before).
       return !isDegradedErrno(err);
     }
   }

--- a/runtime/src/state/backfill.ts
+++ b/runtime/src/state/backfill.ts
@@ -1,11 +1,23 @@
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readSync,
+  readdirSync,
+  readFileSync,
+  type Stats,
+  statSync,
+} from "node:fs";
 import { basename, join } from "node:path";
 import {
   parseRolloutLine,
   type RolloutItem,
 } from "../session/rollout-item.js";
-import { StateThreadRepository } from "./threads.js";
+import {
+  StateThreadRepository,
+  type RolloutItemRow,
+} from "./threads.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 
 export interface BackfillProjectRolloutsOptions {
@@ -49,20 +61,63 @@ export function backfillRolloutFile(options: {
   readonly archived?: boolean;
   readonly threads: StateThreadRepository;
 }): { readonly itemsIndexed: number } {
-  const raw = readFileSync(options.rolloutPath, "utf8");
   const stat = statSync(options.rolloutPath);
-  const threadId = threadIdFromRolloutPath(options.rolloutPath);
-  const items: Array<{
-    lineNumber: number;
-    byteOffset: number;
-    itemIndex: number;
-    itemType: string;
-    eventVersion?: number;
-    eventId?: string;
-    eventSeq?: number;
-    payloadJson: string;
-    lineHash: string;
-  }> = [];
+  const existing = options.threads.getBackfillFile(options.rolloutPath);
+
+  // Fast path 1 — file unchanged since last index. The rollout file is an
+  // append-only log; identical size and mtime means nothing was appended, so
+  // there is no work to do. Avoids re-reading and re-hashing the whole file
+  // on every `appendItems` call.
+  if (
+    existing !== undefined &&
+    existing.size === stat.size &&
+    existing.mtimeMs === stat.mtimeMs
+  ) {
+    return { itemsIndexed: 0 };
+  }
+
+  // Fast path 2 — file grew (pure append). Read and parse only the appended
+  // tail and INSERT only the new lines, leaving prior rows untouched. This
+  // keeps each append O(bytes appended) instead of O(file size), avoiding the
+  // O(N^2) re-index that an unconditional DELETE-all + re-INSERT-all causes.
+  if (existing !== undefined && stat.size > existing.size) {
+    const appended = readAppendedTail(options.rolloutPath, existing.size);
+    if (appended !== undefined) {
+      return indexAppendedTail({
+        rolloutPath: options.rolloutPath,
+        archived: options.archived,
+        threads: options.threads,
+        stat,
+        priorSize: existing.size,
+        existing,
+        tail: appended,
+      });
+    }
+    // The tail read was unusable (e.g. a partial line straddling the prior
+    // size boundary); fall through to a full reconcile below.
+  }
+
+  // Full reconcile path — first index, truncation, rewrite, or any case the
+  // incremental fast paths could not safely handle. Preserves crash/resume
+  // correctness by rebuilding the file's rows from scratch.
+  return reindexWholeRolloutFile({
+    rolloutPath: options.rolloutPath,
+    archived: options.archived,
+    threads: options.threads,
+    stat,
+  });
+}
+
+function reindexWholeRolloutFile(args: {
+  readonly rolloutPath: string;
+  readonly archived?: boolean;
+  readonly threads: StateThreadRepository;
+  readonly stat: Stats;
+}): { readonly itemsIndexed: number } {
+  const { rolloutPath, threads, stat } = args;
+  const raw = readFileSync(rolloutPath, "utf8");
+  const threadId = threadIdFromRolloutPath(rolloutPath);
+  const items: RolloutItemRow[] = [];
   let byteOffset = 0;
   let itemIndex = 0;
   let firstMeta: Extract<RolloutItem, { type: "session_meta" }> | undefined;
@@ -81,42 +136,25 @@ export function backfillRolloutFile(options: {
         firstMeta ??= parsed;
         latestMeta = parsed;
       }
-      items.push({
-        lineNumber: i + 1,
-        byteOffset,
-        itemIndex,
-        itemType: parsed.type,
-        eventVersion: parsed.eventVersion,
-        eventId:
-          parsed.type === "event_msg" ? parsed.payload.id : undefined,
-        eventSeq:
-          parsed.type === "event_msg" ? parsed.payload.seq : undefined,
-        payloadJson: JSON.stringify(parsed.payload),
-        lineHash: createHash("sha256").update(line).digest("hex"),
-      });
+      items.push(rolloutItemRow(parsed, i + 1, byteOffset, itemIndex, line));
       itemIndex += 1;
     }
     byteOffset += lineBytes;
   }
   const now = new Date(stat.mtimeMs).toISOString();
-  const archivedAt = options.archived === true ? now : undefined;
-  options.threads.mergeThread({
+  mergeThreadFromMeta({
+    threads,
     threadId,
-    createdAt: firstMeta?.payload.timestamp ?? now,
-    updatedAt: latestMeta?.payload.timestamp ?? now,
-    cwd: latestMeta?.payload.cwd ?? firstMeta?.payload.cwd,
-    source: latestMeta?.payload.source ?? firstMeta?.payload.source,
-    model: latestMeta?.payload.model ?? firstMeta?.payload.model,
-    modelProvider:
-      latestMeta?.payload.modelProvider ?? firstMeta?.payload.modelProvider,
-    memoryMode: normalizeMemoryMode(latestMeta?.payload.memoryMode),
-    ...(archivedAt !== undefined
-      ? { archivedAt, archivedRolloutPath: options.rolloutPath }
-      : { rolloutPath: options.rolloutPath }),
-  }, { replaceArchiveState: true });
-  options.threads.replaceRolloutItems({
+    rolloutPath,
+    archived: args.archived,
+    now,
+    createdAt: firstMeta?.payload.timestamp,
+    metaForUpdate: latestMeta?.payload,
+    metaForCreate: firstMeta?.payload,
+  });
+  threads.replaceRolloutItems({
     threadId,
-    sourcePath: options.rolloutPath,
+    sourcePath: rolloutPath,
     items,
     mtimeMs: stat.mtimeMs,
     size: stat.size,
@@ -124,6 +162,188 @@ export function backfillRolloutFile(options: {
     lineCount: lines.length,
   });
   return { itemsIndexed: items.length };
+}
+
+function indexAppendedTail(args: {
+  readonly rolloutPath: string;
+  readonly archived?: boolean;
+  readonly threads: StateThreadRepository;
+  readonly stat: Stats;
+  readonly priorSize: number;
+  readonly existing: {
+    readonly lineCount: number;
+    readonly itemCount: number;
+    readonly sha256: string;
+  };
+  readonly tail: string;
+}): { readonly itemsIndexed: number } {
+  const { rolloutPath, threads, stat, existing, tail } = args;
+  const threadId = threadIdFromRolloutPath(rolloutPath);
+  const items: RolloutItemRow[] = [];
+  // Prior content occupied line numbers 1..(lineCount-1) plus a trailing empty
+  // split element, so existing.lineCount already counts that empty tail line.
+  // New lines therefore start at line number `existing.lineCount`, and the
+  // first new line's byte offset is the previous file size.
+  let byteOffset = args.priorSize;
+  let lineNumber = existing.lineCount;
+  let itemIndex = existing.itemCount;
+  let firstMeta: Extract<RolloutItem, { type: "session_meta" }> | undefined;
+  let latestMeta: Extract<RolloutItem, { type: "session_meta" }> | undefined;
+  const lines = tail.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    const lineBytes = Buffer.byteLength(line) + 1;
+    if (line.trim().length === 0) {
+      byteOffset += lineBytes;
+      lineNumber += 1;
+      continue;
+    }
+    const parsed = parseRolloutLine(line);
+    if (parsed !== null) {
+      if (parsed.type === "session_meta") {
+        firstMeta ??= parsed;
+        latestMeta = parsed;
+      }
+      items.push(rolloutItemRow(parsed, lineNumber, byteOffset, itemIndex, line));
+      itemIndex += 1;
+    }
+    byteOffset += lineBytes;
+    lineNumber += 1;
+  }
+  const now = new Date(stat.mtimeMs).toISOString();
+  // mergeThread overwrites createdAt/updatedAt unconditionally with whatever we
+  // pass, so carry the already-recorded values forward. The first session_meta
+  // (the source of createdAt) lives in the unchanged prefix we did not re-read,
+  // and the appended tail almost never contains a session_meta to advance
+  // updatedAt — falling back to `now` (file mtime) would make updatedAt jump on
+  // an append and then jump back on the next full reconcile. Carry the prior
+  // updatedAt forward so it only advances when a newer meta timestamp appears,
+  // matching the full-reconcile semantics.
+  const prior = threads.getThread(threadId);
+  mergeThreadFromMeta({
+    threads,
+    threadId,
+    rolloutPath,
+    archived: args.archived,
+    now,
+    createdAt: firstMeta?.payload.timestamp ?? prior?.createdAt,
+    updatedAt: prior?.updatedAt,
+    metaForUpdate: latestMeta?.payload,
+    metaForCreate: firstMeta?.payload,
+  });
+  threads.appendRolloutItems({
+    threadId,
+    sourcePath: rolloutPath,
+    items,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+    // Carry the prior full-file digest forward rather than re-hashing the whole
+    // file on every append (which would reintroduce the O(N^2) behaviour). The
+    // canonical full-file hash is re-established whenever a full reconcile runs.
+    // Change detection here relies on mtime+size, not this digest.
+    sha256: existing.sha256,
+    lineCount: existing.lineCount + (lines.length - 1),
+    totalItemCount: itemIndex,
+  });
+  return { itemsIndexed: items.length };
+}
+
+function rolloutItemRow(
+  parsed: RolloutItem,
+  lineNumber: number,
+  byteOffset: number,
+  itemIndex: number,
+  line: string,
+): RolloutItemRow {
+  return {
+    lineNumber,
+    byteOffset,
+    itemIndex,
+    itemType: parsed.type,
+    eventVersion: parsed.eventVersion,
+    eventId: parsed.type === "event_msg" ? parsed.payload.id : undefined,
+    eventSeq: parsed.type === "event_msg" ? parsed.payload.seq : undefined,
+    payloadJson: JSON.stringify(parsed.payload),
+    lineHash: createHash("sha256").update(line).digest("hex"),
+  };
+}
+
+function mergeThreadFromMeta(args: {
+  readonly threads: StateThreadRepository;
+  readonly threadId: string;
+  readonly rolloutPath: string;
+  readonly archived?: boolean;
+  readonly now: string;
+  readonly createdAt: string | undefined;
+  // Optional override for the stored updatedAt. The incremental-append path
+  // passes the carried-forward value so updatedAt does not regress when the
+  // appended tail has no session_meta; the full-reconcile path omits it and
+  // falls back to the latest meta timestamp (or `now`).
+  readonly updatedAt?: string | undefined;
+  readonly metaForUpdate:
+    | Extract<RolloutItem, { type: "session_meta" }>["payload"]
+    | undefined;
+  readonly metaForCreate:
+    | Extract<RolloutItem, { type: "session_meta" }>["payload"]
+    | undefined;
+}): void {
+  const { metaForUpdate, metaForCreate } = args;
+  const archivedAt = args.archived === true ? args.now : undefined;
+  args.threads.mergeThread(
+    {
+      threadId: args.threadId,
+      createdAt: args.createdAt ?? args.now,
+      updatedAt: metaForUpdate?.timestamp ?? args.updatedAt ?? args.now,
+      cwd: metaForUpdate?.cwd ?? metaForCreate?.cwd,
+      source: metaForUpdate?.source ?? metaForCreate?.source,
+      model: metaForUpdate?.model ?? metaForCreate?.model,
+      modelProvider:
+        metaForUpdate?.modelProvider ?? metaForCreate?.modelProvider,
+      memoryMode: normalizeMemoryMode(metaForUpdate?.memoryMode),
+      ...(archivedAt !== undefined
+        ? { archivedAt, archivedRolloutPath: args.rolloutPath }
+        : { rolloutPath: args.rolloutPath }),
+    },
+    { replaceArchiveState: true },
+  );
+}
+
+/**
+ * Reads only the bytes appended to a rollout file beyond `priorSize`, decoded
+ * as UTF-8. Returns `undefined` when the file is shorter than `priorSize` (a
+ * truncation/rewrite that must go through a full reconcile).
+ */
+function readAppendedTail(
+  rolloutPath: string,
+  priorSize: number,
+): string | undefined {
+  const fd = openSync(rolloutPath, "r");
+  try {
+    const stat = statSync(rolloutPath);
+    if (stat.size < priorSize) return undefined;
+    const length = stat.size - priorSize;
+    if (length === 0) return "";
+    // The incremental append path numbers new lines starting at the prior line
+    // count, which is only valid when the previously indexed content ended on a
+    // line boundary. Verify the byte just before the new region is a newline;
+    // otherwise the tail straddles a prior line and must go through a full
+    // reconcile to renumber correctly.
+    if (priorSize > 0) {
+      const boundary = Buffer.allocUnsafe(1);
+      if (readSync(fd, boundary, 0, 1, priorSize - 1) !== 1) return undefined;
+      if (boundary[0] !== 0x0a) return undefined;
+    }
+    const buffer = Buffer.allocUnsafe(length);
+    let read = 0;
+    while (read < length) {
+      const n = readSync(fd, buffer, read, length - read, priorSize + read);
+      if (n === 0) break;
+      read += n;
+    }
+    return buffer.subarray(0, read).toString("utf8");
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function listRolloutFiles(projectDir: string): RolloutFileEntry[] {

--- a/runtime/src/state/threads.ts
+++ b/runtime/src/state/threads.ts
@@ -158,20 +158,93 @@ export class StateThreadRepository {
       .map((row: ThreadRow) => rowToThread(row));
   }
 
+  /**
+   * Returns the recorded backfill receipt for a rollout source file, or
+   * `undefined` if the file has never been indexed. Used to decide whether a
+   * re-index can be skipped (unchanged file) or reduced to an incremental
+   * append (file grew) instead of a full DELETE-all + re-INSERT-all.
+   */
+  getBackfillFile(sourcePath: string): BackfillFileReceipt | undefined {
+    const row = this.driver
+      .prepareState<[string], BackfillFileRow>(
+        `SELECT mtime_ms, size, sha256, line_count, item_count
+         FROM backfill_files
+         WHERE source_path = ?`,
+      )
+      .get(sourcePath);
+    if (row === undefined) return undefined;
+    return {
+      mtimeMs: row.mtime_ms,
+      size: row.size,
+      sha256: row.sha256,
+      lineCount: row.line_count,
+      itemCount: row.item_count,
+    };
+  }
+
+  /**
+   * Incrementally indexes lines appended to an already-indexed rollout file.
+   * Only the supplied (new) items are INSERTed; prior rows are left intact.
+   * The `backfill_files` / `rollout_receipts` bookkeeping is advanced to the
+   * new file size/line count so the next append can also be incremental.
+   *
+   * Callers must guarantee `items` are strictly new lines (line numbers beyond
+   * the previously recorded `line_count`). Use `replaceRolloutItems` for the
+   * full reconcile path when the prefix may have changed.
+   */
+  appendRolloutItems(params: {
+    readonly threadId: ThreadId;
+    readonly sourcePath: string;
+    readonly items: ReadonlyArray<RolloutItemRow>;
+    readonly mtimeMs: number;
+    readonly size: number;
+    readonly sha256: string;
+    readonly lineCount: number;
+    readonly totalItemCount: number;
+  }): void {
+    this.driver.transaction(() => {
+      const insert = this.driver.prepareState(
+        `INSERT INTO thread_rollout_items (
+          thread_id, source_path, line_number, byte_offset, item_index,
+          item_type, event_version, event_id, event_seq, payload_json, line_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const item of params.items) {
+        insert.run(
+          params.threadId,
+          params.sourcePath,
+          item.lineNumber,
+          item.byteOffset,
+          item.itemIndex,
+          item.itemType,
+          item.eventVersion ?? null,
+          item.eventId ?? null,
+          item.eventSeq ?? null,
+          item.payloadJson,
+          item.lineHash,
+        );
+      }
+      this.writeBackfillReceipts({
+        threadId: params.threadId,
+        sourcePath: params.sourcePath,
+        mtimeMs: params.mtimeMs,
+        size: params.size,
+        // Change-detection digest only. On the append path this is the prior
+        // full-file hash carried forward, so it goes stale vs the on-disk file
+        // until the next full reconcile re-establishes it. Skip decisions rely
+        // on mtime+size (authoritative), not this hash, so it is intentionally
+        // not recomputed per append (doing so would defeat the perf fix).
+        sha256: params.sha256,
+        lineCount: params.lineCount,
+        itemCount: params.totalItemCount,
+      });
+    });
+  }
+
   replaceRolloutItems(params: {
     readonly threadId: ThreadId;
     readonly sourcePath: string;
-    readonly items: ReadonlyArray<{
-      readonly lineNumber: number;
-      readonly byteOffset: number;
-      readonly itemIndex: number;
-      readonly itemType: string;
-      readonly eventVersion?: number;
-      readonly eventId?: string;
-      readonly eventSeq?: number;
-      readonly payloadJson: string;
-      readonly lineHash: string;
-    }>;
+    readonly items: ReadonlyArray<RolloutItemRow>;
     readonly mtimeMs: number;
     readonly size: number;
     readonly sha256: string;
@@ -204,54 +277,104 @@ export class StateThreadRepository {
           item.lineHash,
         );
       }
-      this.driver
-        .prepareState(
-          `INSERT INTO backfill_files (
-            source_path, thread_id, mtime_ms, size, sha256, line_count, item_count
-          ) VALUES (?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(source_path) DO UPDATE SET
-            thread_id = excluded.thread_id,
-            mtime_ms = excluded.mtime_ms,
-            size = excluded.size,
-            sha256 = excluded.sha256,
-            line_count = excluded.line_count,
-            item_count = excluded.item_count,
-            imported_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
-        )
-        .run(
-          params.sourcePath,
-          params.threadId,
-          params.mtimeMs,
-          params.size,
-          params.sha256,
-          params.lineCount,
-          params.items.length,
-        );
-      this.driver
-        .prepareState(
-          `INSERT INTO rollout_receipts (
-            thread_id, source_path, source_mtime_ms, source_size,
-            source_sha256, imported_line_count, imported_item_count
-          ) VALUES (?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(thread_id, source_path) DO UPDATE SET
-            source_mtime_ms = excluded.source_mtime_ms,
-            source_size = excluded.source_size,
-            source_sha256 = excluded.source_sha256,
-            imported_line_count = excluded.imported_line_count,
-            imported_item_count = excluded.imported_item_count,
-            imported_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
-        )
-        .run(
-          params.threadId,
-          params.sourcePath,
-          params.mtimeMs,
-          params.size,
-          params.sha256,
-          params.lineCount,
-          params.items.length,
-        );
+      this.writeBackfillReceipts({
+        threadId: params.threadId,
+        sourcePath: params.sourcePath,
+        mtimeMs: params.mtimeMs,
+        size: params.size,
+        sha256: params.sha256,
+        lineCount: params.lineCount,
+        itemCount: params.items.length,
+      });
     });
   }
+
+  private writeBackfillReceipts(params: {
+    readonly threadId: ThreadId;
+    readonly sourcePath: string;
+    readonly mtimeMs: number;
+    readonly size: number;
+    readonly sha256: string;
+    readonly lineCount: number;
+    readonly itemCount: number;
+  }): void {
+    this.driver
+      .prepareState(
+        `INSERT INTO backfill_files (
+          source_path, thread_id, mtime_ms, size, sha256, line_count, item_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source_path) DO UPDATE SET
+          thread_id = excluded.thread_id,
+          mtime_ms = excluded.mtime_ms,
+          size = excluded.size,
+          sha256 = excluded.sha256,
+          line_count = excluded.line_count,
+          item_count = excluded.item_count,
+          imported_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      )
+      .run(
+        params.sourcePath,
+        params.threadId,
+        params.mtimeMs,
+        params.size,
+        params.sha256,
+        params.lineCount,
+        params.itemCount,
+      );
+    this.driver
+      .prepareState(
+        `INSERT INTO rollout_receipts (
+          thread_id, source_path, source_mtime_ms, source_size,
+          source_sha256, imported_line_count, imported_item_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(thread_id, source_path) DO UPDATE SET
+          source_mtime_ms = excluded.source_mtime_ms,
+          source_size = excluded.source_size,
+          source_sha256 = excluded.source_sha256,
+          imported_line_count = excluded.imported_line_count,
+          imported_item_count = excluded.imported_item_count,
+          imported_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+      )
+      .run(
+        params.threadId,
+        params.sourcePath,
+        params.mtimeMs,
+        params.size,
+        params.sha256,
+        params.lineCount,
+        params.itemCount,
+      );
+  }
+}
+
+/** Receipt of a previously indexed rollout source file. */
+export interface BackfillFileReceipt {
+  readonly mtimeMs: number;
+  readonly size: number;
+  readonly sha256: string;
+  readonly lineCount: number;
+  readonly itemCount: number;
+}
+
+interface BackfillFileRow {
+  readonly mtime_ms: number;
+  readonly size: number;
+  readonly sha256: string;
+  readonly line_count: number;
+  readonly item_count: number;
+}
+
+/** One indexed rollout line, ready to INSERT into `thread_rollout_items`. */
+export interface RolloutItemRow {
+  readonly lineNumber: number;
+  readonly byteOffset: number;
+  readonly itemIndex: number;
+  readonly itemType: string;
+  readonly eventVersion?: number;
+  readonly eventId?: string;
+  readonly eventSeq?: number;
+  readonly payloadJson: string;
+  readonly lineHash: string;
 }
 
 function rowToThread(row: ThreadRow): IndexedThreadRecord {

--- a/runtime/src/tasks/lifecycle.ts
+++ b/runtime/src/tasks/lifecycle.ts
@@ -132,6 +132,7 @@ interface OutputBuffer {
 
 const MAX_OUTPUT_CHARS = 1_000_000;
 const MAX_RETAINED_TERMINAL_TASKS = 100;
+const MAX_RETAINED_NOTIFICATIONS = 1_000;
 
 export class BackgroundTaskError extends Error {
   constructor(
@@ -335,22 +336,32 @@ export class BackgroundTaskLifecycle {
       );
     }
 
+    let stopError: unknown;
     try {
       if (!record.abortController?.signal.aborted) {
         record.abortController?.abort(reason);
       }
       await record.onStop?.(reason);
     } catch (error) {
+      stopError = error;
+    }
+
+    // Always transition the task to a terminal state, even when onStop throws.
+    // Otherwise the task would stay `running` forever and a blocking
+    // TaskOutput would hang (zombie task).
+    const snapshot = this.finish(taskId, "killed", {
+      error: stopError !== undefined ? toErrorMessage(stopError) : reason,
+      summaryStatus: "was stopped",
+    });
+
+    if (stopError !== undefined) {
       throw new BackgroundTaskError(
-        `task ${taskId} stop failed: ${toErrorMessage(error)}`,
+        `task ${taskId} stop failed: ${toErrorMessage(stopError)}`,
         "stop_failed",
       );
     }
 
-    return this.finish(taskId, "killed", {
-      error: reason,
-      summaryStatus: "was stopped",
-    });
+    return snapshot;
   }
 
   bindPromise<T>(
@@ -514,5 +525,9 @@ export class BackgroundTaskLifecycle {
       atMs: Date.now(),
       ...(delta !== undefined ? { delta } : {}),
     });
+    const excess = this.notifications.length - MAX_RETAINED_NOTIFICATIONS;
+    if (excess > 0) {
+      this.notifications.splice(0, excess);
+    }
   }
 }

--- a/runtime/src/tools/apply-patch/tool.ts
+++ b/runtime/src/tools/apply-patch/tool.ts
@@ -19,10 +19,7 @@ import type {
   ToolExecutionInjectedArgs,
   ToolResult,
 } from "../types.js";
-import {
-  SESSION_ID_ARG,
-  resolveToolAllowedPaths,
-} from "../system/filesystem.js";
+import { SESSION_ID_ARG } from "../system/filesystem.js";
 import { parsePatch } from "./parser.js";
 import { applyPatchText } from "./runtime.js";
 import type { ApplyPatchHunk } from "./types.js";
@@ -118,8 +115,24 @@ function permissionForPatch(
   let hunks: readonly ApplyPatchHunk[];
   try {
     hunks = parsePatch(patch).hunks;
-  } catch {
-    return { behavior: "allow", updatedInput: input };
+  } catch (error) {
+    // SECURITY: fail CLOSED on an unparseable patch. The previous
+    // fail-open `behavior: "allow"` let a malformed patch skip the
+    // per-target path-permission check entirely; an attacker could
+    // dodge confinement by sending input that the strict parser
+    // rejects but the apply path still partially honors. Deny instead.
+    const reason = `apply_patch payload could not be parsed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    return {
+      behavior: "deny",
+      message: reason,
+      decisionReason: {
+        type: "safetyCheck",
+        reason,
+        classifierApprovable: false,
+      },
+    };
   }
 
   for (const hunk of hunks) {
@@ -178,11 +191,17 @@ export function createApplyPatchTool(config: ApplyPatchToolConfig): Tool {
         };
       }
       const cwd = asNonEmptyString(args.cwd) ?? config.cwd;
+      // SECURITY: check permissions against the TRUSTED closure roots
+      // only (mirror FileWriteTool/FileEditTool, file-write.ts:231).
+      // Folding `resolveToolAllowedPaths(..., input)` here would honor a
+      // model-supplied `__agencSessionAllowedRoots`, defeating
+      // confinement. Runtime-injected roots are still applied at execute
+      // time via `safePathAllowingSessionPlanFile`.
       return permissionForPatch(
         input as Record<string, unknown>,
         patch,
         cwd,
-        resolveToolAllowedPaths(allowedPaths, input as Record<string, unknown>),
+        allowedPaths,
         context,
       );
     },
@@ -197,7 +216,12 @@ export function createApplyPatchTool(config: ApplyPatchToolConfig): Tool {
       try {
         const result = await applyPatchText(patch, {
           cwd,
-          allowedPaths: resolveToolAllowedPaths(allowedPaths, rawArgs),
+          // Pass the TRUSTED closure roots; `applyPatchText` folds any
+          // runtime-injected `__agencSessionAllowedRoots` from `rawArgs`
+          // through `safePathAllowingSessionPlanFile`. Pre-folding with
+          // `resolveToolAllowedPaths(allowedPaths, rawArgs)` is redundant
+          // and was the same model-controlled widening vector.
+          allowedPaths,
           rawArgs,
           ...(sessionId !== undefined ? { sessionId } : {}),
         });

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -101,7 +101,7 @@ import {
   buildToolRuntimeCallContext,
   type ToolRuntimeAttemptContext,
 } from "./runtimes/context.js";
-import { SESSION_ALLOWED_ROOTS_ARG } from "./system/filesystem.js";
+import { withSignedAllowedRoots } from "./system/filesystem.js";
 
 export interface ToolCall {
   readonly toolName: ToolName;
@@ -491,7 +491,12 @@ export class ToolRouter {
       };
     }
     try {
-      let executionArgs = args;
+      // SECURITY: strip any `__agenc*` keys reaching this dispatch
+      // boundary (e.g. code_mode js_repl helper calls). These are a
+      // TRUSTED INTERNAL channel for runtime-injected filesystem scoping
+      // and must never be supplied by the model; runtime values are
+      // merged in later (execution.ts / withApprovedFilesystemRoot).
+      let executionArgs = stripModelSuppliedAgenCInternalArgs(args);
       let forcedApprovalReason: string | undefined;
       let permissionAlreadyAllowed = false;
       if (opts.canUseTool !== undefined && opts.permissionContext !== undefined) {
@@ -713,7 +718,15 @@ export class ToolRouter {
         isError: true,
       };
     }
-    let executionArgs = parsedArgs;
+    // SECURITY: `__agenc*` keys are a TRUSTED INTERNAL channel
+    // (`__agencSessionAllowedRoots`, `__agencSessionId`, …) the runtime
+    // injects post-approval to scope filesystem confinement. They must
+    // NEVER originate from the model. Strip every model-supplied
+    // `__agenc*` key here, before any runtime-injected value is merged
+    // in, so a crafted `__agencSessionAllowedRoots:["/"]` cannot widen
+    // the allowed roots that reach tool.execute. (The validator-only
+    // strip in execution.ts left the tool body exposed.)
+    let executionArgs = stripModelSuppliedAgenCInternalArgs(parsedArgs);
     let forcedApprovalReason: string | undefined;
     let preHookPermissionDecision: MergedHookPermissionDecision | undefined;
     let hookPermissionResult: HookPermissionResult | undefined;
@@ -1191,6 +1204,38 @@ function stringifyToolArgsWithBigInt(args: Record<string, unknown>): string {
   );
 }
 
+const AGENC_INTERNAL_ARG_PREFIX = "__agenc";
+
+/**
+ * Drop every `__agenc*` key from model-supplied tool-call arguments.
+ *
+ * `__agenc*` keys (e.g. `__agencSessionAllowedRoots`, `__agencSessionId`)
+ * are a TRUSTED INTERNAL channel the runtime injects post-approval to
+ * scope filesystem confinement. A model that emits them directly could
+ * widen its own allowed roots (audit #1/#2/#4). We strip them at the
+ * dispatch boundary so the only `__agenc*` values that ever reach
+ * `tool.execute` are those the runtime itself adds afterwards. Returns
+ * the input untouched when there is nothing to strip.
+ */
+function stripModelSuppliedAgenCInternalArgs(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  let needsStrip = false;
+  for (const key of Object.keys(input)) {
+    if (key.startsWith(AGENC_INTERNAL_ARG_PREFIX)) {
+      needsStrip = true;
+      break;
+    }
+  }
+  if (!needsStrip) return input;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (key.startsWith(AGENC_INTERNAL_ARG_PREFIX)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 const APPROVED_FILE_PATH_TOOLS = new Set([
   "FileRead",
   "Write",
@@ -1225,18 +1270,7 @@ function withApprovedFilesystemRoot(
     ? filePath
     : resolve(cwd, filePath);
   const approvedRoot = dirname(resolvedPath);
-  const existingRoots = Array.isArray(args[SESSION_ALLOWED_ROOTS_ARG])
-    ? args[SESSION_ALLOWED_ROOTS_ARG].filter(
-        (entry): entry is string =>
-          typeof entry === "string" && entry.length > 0,
-      )
-    : [];
-  if (existingRoots.includes(approvedRoot)) return args;
-
-  return {
-    ...args,
-    [SESSION_ALLOWED_ROOTS_ARG]: [...new Set([...existingRoots, approvedRoot])],
-  };
+  return withSignedAllowedRoots(args, [approvedRoot]);
 }
 
 function planFileContextForApproval(

--- a/runtime/src/tools/system/file-read.ts
+++ b/runtime/src/tools/system/file-read.ts
@@ -54,7 +54,7 @@ import {
   recordSessionRead,
   resolveSessionId,
   safePathAllowingSessionPlanFile,
-  SESSION_ALLOWED_ROOTS_ARG,
+  withSignedAllowedRoots,
 } from "./filesystem.js";
 import {
   agentNamespacePathHint,
@@ -1305,20 +1305,12 @@ export function createFileReadTool(config: FileReadToolConfig): Tool {
         !Array.isArray(decision.updatedInput)
           ? (decision.updatedInput as Record<string, unknown>)
           : (input as Record<string, unknown>);
-      const existingRoots = Array.isArray(currentInput[SESSION_ALLOWED_ROOTS_ARG])
-        ? currentInput[SESSION_ALLOWED_ROOTS_ARG].filter(
-            (entry): entry is string => typeof entry === "string",
-          )
-        : [];
       const absolutePath = isAbsolute(filePath) ? filePath : resolve(cwd, filePath);
       return {
         ...decision,
-        updatedInput: {
-          ...currentInput,
-          [SESSION_ALLOWED_ROOTS_ARG]: [
-            ...new Set([...existingRoots, dirname(absolutePath)]),
-          ],
-        },
+        updatedInput: withSignedAllowedRoots(currentInput, [
+          dirname(absolutePath),
+        ]),
       };
     },
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -48,12 +48,28 @@ import {
   isSessionPlanFile,
   type PlanFileContext,
 } from "../../planning/plan-files.js";
+import {
+  SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ALLOWED_ROOTS_SIG_ARG,
+  signAllowedRoots,
+  verifyAllowedRoots,
+  withSignedAllowedRoots,
+} from "../../agents/_deps/filesystem-args.js";
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 
+// Re-export the HMAC-signed trusted-roots channel constants/helpers so
+// existing importers of `filesystem.ts` keep a single source.
+export {
+  SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ALLOWED_ROOTS_SIG_ARG,
+  signAllowedRoots,
+  verifyAllowedRoots,
+  withSignedAllowedRoots,
+};
+
 const MAX_LIST_ENTRIES = 10_000;
 const MAX_PATH_LENGTH = 4096;
-export const SESSION_ALLOWED_ROOTS_ARG = "__agencSessionAllowedRoots";
 export const SESSION_AGENC_HOME_ARG = "__agencHome";
 export type SessionReadViewKind =
   | "full"
@@ -710,15 +726,36 @@ export async function isPathAllowed(
   return (await safePath(targetPath, allowedPaths)).safe;
 }
 
+/**
+ * Fold runtime-injected extra workspace roots into the trusted base
+ * {@link allowedPaths}.
+ *
+ * SECURITY INVARIANT (sink-side HMAC enforcement): widening filesystem
+ * confinement via `args[SESSION_ALLOWED_ROOTS_ARG]` requires a VALID
+ * per-process HMAC signature in `args[SESSION_ALLOWED_ROOTS_SIG_ARG]`.
+ * The sink no longer trusts the bare key: it folds in roots ONLY via
+ * {@link verifyAllowedRoots}, which recomputes the signature with the
+ * module-private process secret the model never sees and drops anything
+ * that doesn't verify. Runtime writers produce the signature through
+ * {@link withSignedAllowedRoots}; the model cannot forge it. The
+ * model-arg boundary strips at the tool-dispatch boundary
+ * (`router.ts` / `run-agent.ts:injectChildToolArgs`) remain as
+ * defense-in-depth, but enforcement now lives HERE — a future ingress
+ * that forgets to strip cannot reintroduce the sandbox escape, because
+ * an unsigned/forged root is ignored at this sink.
+ */
 export function resolveToolAllowedPaths(
   allowedPaths: readonly string[],
   args: Record<string, unknown>,
 ): readonly string[] {
-  const rawExtraRoots = args[SESSION_ALLOWED_ROOTS_ARG];
-  if (!Array.isArray(rawExtraRoots) || rawExtraRoots.length === 0) {
+  const verifiedRoots = verifyAllowedRoots(
+    args[SESSION_ALLOWED_ROOTS_ARG],
+    args[SESSION_ALLOWED_ROOTS_SIG_ARG],
+  );
+  if (verifiedRoots.length === 0) {
     return allowedPaths;
   }
-  const normalizedExtraRoots = rawExtraRoots
+  const normalizedExtraRoots = verifiedRoots
     .filter(
       (entry): entry is string =>
         typeof entry === "string" && entry.trim().length > 0,

--- a/runtime/src/tools/system/glob.ts
+++ b/runtime/src/tools/system/glob.ts
@@ -175,6 +175,14 @@ async function resolveGlobTarget(params: {
   readonly allowedPaths: readonly string[];
   readonly pattern: string;
 }): Promise<ResolvedGlobTarget | { error: string }> {
+  // SECURITY: `params.allowedPaths` is the TRUSTED closure scope. The
+  // only roots `resolveToolAllowedPaths` folds in from `params.args` are
+  // runtime-injected `__agencSessionAllowedRoots` (e.g. the worktree
+  // path) — model-supplied `__agenc*` keys are stripped at the dispatch
+  // boundary (router.ts) before they ever reach here. The requested
+  // search root (`path`/`cwd`, below) is always re-validated against
+  // this set via `safePath`, so a model cannot search outside trusted
+  // roots.
   const effectiveAllowed = resolveToolAllowedPaths(params.allowedPaths, params.args);
   if (effectiveAllowed.length === 0) {
     return { error: "No allowed paths configured for Glob" };

--- a/runtime/src/tools/system/grep.ts
+++ b/runtime/src/tools/system/grep.ts
@@ -291,6 +291,13 @@ async function resolveSearchPath(params: {
   readonly config: GrepToolConfig;
   readonly explicitPath?: string;
 }): Promise<ResolvedTarget | { error: string }> {
+  // SECURITY: `params.config.allowedPaths` is the TRUSTED closure scope.
+  // `resolveToolAllowedPaths` only folds in runtime-injected
+  // `__agencSessionAllowedRoots` (e.g. the worktree path); model-supplied
+  // `__agenc*` keys are stripped at the dispatch boundary (router.ts)
+  // before reaching this tool. The candidate search path is re-validated
+  // against this set via `safePath` below, so a model cannot grep outside
+  // trusted roots.
   const allowedPaths = resolveToolAllowedPaths(
     params.config.allowedPaths,
     params.args,

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -76,11 +76,10 @@ interface SpawnCommand {
   readonly argv0?: string;
 }
 
-class ProcessOutputBuffer {
+export class ProcessOutputBuffer {
   private readonly chunks: OutputChunk[] = [];
   private consumedIndex = 0;
   private totalChars = 0;
-  private droppedChars = 0;
 
   constructor(private readonly maxChars = DEFAULT_OUTPUT_BUFFER_CHARS) {}
 
@@ -94,21 +93,101 @@ class ProcessOutputBuffer {
   drain(): OutputChunk[] {
     const drained = this.chunks.slice(this.consumedIndex);
     this.consumedIndex = this.chunks.length;
-    if (this.droppedChars > 0) {
-      const marker = `[... omitted ${this.droppedChars} chars before collection ...]\n`;
-      this.droppedChars = 0;
-      return [{ stream: "stdout", chunk: marker }, ...drained];
-    }
     return drained;
   }
 
   private enforceCap(): void {
-    while (this.totalChars > this.maxChars && this.chunks.length > 0) {
+    // First, evict already-consumed chunks. These have already been returned to
+    // the caller by a prior drain(), so discarding them costs nothing and never
+    // needs an omitted-count marker.
+    while (
+      this.totalChars > this.maxChars &&
+      this.consumedIndex > 0 &&
+      this.chunks.length > 0
+    ) {
       const removed = this.chunks.shift()!;
       this.totalChars -= removed.chunk.length;
-      this.droppedChars += removed.chunk.length;
-      this.consumedIndex = Math.max(0, this.consumedIndex - 1);
+      this.consumedIndex -= 1;
     }
+
+    if (this.totalChars <= this.maxChars) return;
+
+    // The cap is still exceeded by pending (undrained) output. Rather than
+    // dropping the most-recent unconsumed bytes wholesale (which previously
+    // discarded still-unconsumed HEAD output on a single oversized burst),
+    // collapse the pending region with head/tail truncation so both the head
+    // and the tail/exit-summary survive, and surface the omitted count.
+    const pending = this.chunks.slice(this.consumedIndex);
+    if (pending.length === 0) return;
+
+    // The pending region interleaves stdout AND stderr chunks. Collapsing them
+    // under a single hard-coded "stdout" label would relabel all stderr bytes
+    // as stdout (silently emptying the returned stderr field). Instead, truncate
+    // each stream's pending bytes SEPARATELY so each keeps its own head/tail and
+    // its own stream label.
+    const stdoutText = pending
+      .filter((chunk) => chunk.stream === "stdout")
+      .map((chunk) => chunk.chunk)
+      .join("");
+    const stderrText = pending
+      .filter((chunk) => chunk.stream === "stderr")
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    // Preserve original stream order (stdout before stderr) for deterministic
+    // output; only non-empty streams participate.
+    const segments: OutputChunk[] = [];
+    if (stdoutText.length > 0) {
+      segments.push({ stream: "stdout", chunk: stdoutText });
+    }
+    if (stderrText.length > 0) {
+      segments.push({ stream: "stderr", chunk: stderrText });
+    }
+    if (segments.length === 0) return;
+    const totalLen = stdoutText.length + stderrText.length;
+
+    // Allocate the cap across streams with max-min fairness: smallest stream
+    // first, each taking an equal share of the remaining budget, with any unused
+    // share rolling forward to the larger stream(s). A proportional split would
+    // starve a tiny stderr exit-summary when stdout floods past the cap; this
+    // keeps the small stream intact (its budget == its length) and gives the
+    // overflow budget to whichever stream actually needs truncating.
+    const budgetByStream = new Map<UnifiedExecStream, number>();
+    const ordered = [...segments].sort(
+      (a, b) => a.chunk.length - b.chunk.length,
+    );
+    let remainingCap = this.maxChars;
+    let remaining = ordered.length;
+    for (const segment of ordered) {
+      const share = Math.floor(remainingCap / remaining);
+      const budget = Math.min(segment.chunk.length, share);
+      budgetByStream.set(segment.stream, budget);
+      remainingCap -= budget;
+      remaining -= 1;
+    }
+
+    // truncateHeadTail embeds its own `[... omitted N chars ...]` marker inline
+    // between the preserved head and tail, so we replace the pending chunks with
+    // the per-stream truncated text directly. Clamp each budget to truncateHeadTail's
+    // own 64-char floor: passing a smaller budget would make it report a negative
+    // omitted count for a sub-64 stream (it never truncates below 64 chars anyway).
+    const replacement: OutputChunk[] = [];
+    for (const segment of segments) {
+      const budget = budgetByStream.get(segment.stream) ?? segment.chunk.length;
+      const truncated = truncateHeadTail(
+        segment.chunk,
+        Math.max(64, budget),
+      );
+      replacement.push({ stream: segment.stream, chunk: truncated.text });
+    }
+
+    this.chunks.length = this.consumedIndex;
+    this.chunks.push(...replacement);
+    const replacementChars = replacement.reduce(
+      (sum, chunk) => sum + chunk.chunk.length,
+      0,
+    );
+    this.totalChars = this.totalChars - totalLen + replacementChars;
   }
 }
 

--- a/runtime/src/utils/attachments.ts
+++ b/runtime/src/utils/attachments.ts
@@ -10,7 +10,7 @@ import {
   type ToolPermissionContext,
 } from '../tools/Tool.js'
 import { CanonicalFileReadTool } from '../tools/canonicalToolSurface.js'
-import { SESSION_ALLOWED_ROOTS_ARG } from '../tools/system/filesystem.js'
+import { withSignedAllowedRoots } from '../tools/system/filesystem.js'
 import { FileTooLargeError, readFileInRange } from './readFileInRange.js'
 import { expandPath } from './path.js'
 import { countCharInString } from './stringUtils.js'
@@ -2052,12 +2052,7 @@ async function callCanonicalFileReadTool(
     ? expandPath(input.file_path)
     : undefined
   const callInput = filePath
-    ? {
-        ...input,
-        [SESSION_ALLOWED_ROOTS_ARG]: [
-          dirname(filePath),
-        ],
-      }
+    ? withSignedAllowedRoots(input, [dirname(filePath)])
     : input
   const result = await (CanonicalFileReadTool.call as any)(
     callInput,

--- a/runtime/src/utils/permissions/filesystem.ts
+++ b/runtime/src/utils/permissions/filesystem.ts
@@ -1052,19 +1052,55 @@ export function checkReadPermissionForTool(
       message: `AgenC requested permissions to use ${tool.name}, but you haven't granted it yet.`,
     }
   }
+
+  const path = tool.getPath(input)
+  const decision = computeReadDecision(tool, input, path, toolPermissionContext)
+
   // --yolo / bypassPermissions short-circuit. Same rationale as
-  // checkToolPathPermission and permissions/bash.ts: the user opted out
-  // of all approval gating; filesystem reads must not surface the
-  // working-dir prompt. See GAP-PE-YOLO-LEAK.
+  // checkToolPathPermission and permissions/bash.ts:431 ("hadDeny" guard):
+  // the user opted out of all approval gating, so filesystem reads must not
+  // surface the working-dir prompt. See GAP-PE-YOLO-LEAK.
+  //
+  // SECURITY: this runs AFTER computeReadDecision so the read-specific
+  // Deny(Read(...)) rule loop still wins. Deny and safetyCheck are the two
+  // bypass-immune categories the evaluator enforces at
+  // permissions/evaluator.ts (step 1d deny, step 1g safetyCheck); everything
+  // else (UNC/Windows defense-in-depth asks, ask rules, workingDir) is
+  // auto-allowed under bypass, matching the pre-fix behavior for non-deny
+  // paths. The defect was that the OLD bypass short-circuit fired before this
+  // deny loop, so Deny(Read(...)) was silently skipped.
+  //
+  // NOTE (READ flow): computeReadDecision never returns a 'safetyCheck'
+  // decisionReason — that category is only produced by the write path
+  // (checkWritePermissionForTool step 1.7). For reads, the Deny(Read(...))
+  // rule loop is the only live bypass-immune protection here; the
+  // isSafetyViolation guard below is defensive (kept symmetric with the write
+  // flow and future-proof should a read-specific safetyCheck ever be added).
   if (toolPermissionContext.mode === 'bypassPermissions') {
-    return {
-      behavior: 'allow',
-      updatedInput: input,
-      decisionReason: { type: 'mode', mode: 'bypassPermissions' },
+    const isDenyRule =
+      decision.behavior === 'deny' ||
+      (decision.decisionReason?.type === 'rule' &&
+        decision.decisionReason.rule.ruleBehavior === 'deny')
+    const isSafetyViolation =
+      decision.decisionReason?.type === 'safetyCheck'
+    if (!isDenyRule && !isSafetyViolation) {
+      return {
+        behavior: 'allow',
+        updatedInput: input,
+        decisionReason: { type: 'mode', mode: 'bypassPermissions' },
+      }
     }
   }
-  const path = tool.getPath(input)
 
+  return decision
+}
+
+function computeReadDecision(
+  tool: Tool,
+  input: { [key: string]: unknown },
+  path: string,
+  toolPermissionContext: ToolPermissionContext,
+): PermissionDecision {
   // Get paths to check (includes both original and resolved symlinks).
   // Computed once here and threaded through checkWritePermissionForTool →
   // checkPathSafetyForAutoEdit → pathInAllowedWorkingPath to avoid redundant

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -53,7 +53,11 @@ import type {
 import type { ToolRegistry } from "../tool-registry.js";
 import {
   SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ALLOWED_ROOTS_SIG_ARG,
   SESSION_ID_ARG,
+  signAllowedRoots,
+  verifyAllowedRoots,
+  withSignedAllowedRoots,
 } from "../tools/system/filesystem.js";
 import { createApplyPatchTool } from "../tools/apply-patch/tool.js";
 import { cloneFileStateCache } from "../utils/fileStateCache.js";
@@ -772,6 +776,124 @@ describe("runAgent", () => {
     expect(parsed.value).toBe("hello");
   });
 
+  it("strips model-supplied __agenc* keys before they reach a wrapped child tool", async () => {
+    // SECURITY (audit #1/#2/#4): a child model that emits
+    // `__agencSessionAllowedRoots:["/"]` must NOT have it folded into the
+    // child's allowed roots. The runtime injects only the worktree root.
+    const execute = vi.fn(async () => ({
+      content: JSON.stringify({ ok: true }),
+      isError: false,
+    }));
+    const registry = buildFilteredRegistry(
+      {
+        tools: [
+          {
+            name: "system.echo",
+            description: "echo",
+            inputSchema: { type: "object" },
+            execute,
+          },
+        ],
+        toLLMTools: () => [],
+        dispatch: async () => ({
+          content: JSON.stringify({ ok: true }),
+          isError: false,
+        }),
+      },
+      {
+        childConversationId: "child-123",
+        worktree: {
+          path: "/tmp/subagent-wt",
+          branch: "worktree-child",
+          gitRoot: "/repo",
+          created: false,
+        },
+      },
+    );
+
+    await registry.tools[0]!.execute({
+      value: "hello",
+      // Model-controlled injection attempt:
+      [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
+      [SESSION_ID_ARG]: "attacker-session",
+      __agencHome: "/etc",
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    const parsed = execute.mock.calls[0]![0] as Record<string, unknown>;
+    // The model's "/" root is stripped; only the runtime worktree remains.
+    expect(parsed[SESSION_ALLOWED_ROOTS_ARG]).toEqual(["/tmp/subagent-wt"]);
+    // The runtime's own session id wins, not the model-supplied one.
+    expect(parsed[SESSION_ID_ARG]).toBe("child-123");
+    // Arbitrary model `__agenc*` keys never reach the tool.
+    expect(parsed.__agencHome).toBeUndefined();
+    expect(parsed.value).toBe("hello");
+  });
+
+  it("strips model-supplied __agenc* keys on fallback dispatch before injection", async () => {
+    const dispatch = vi.fn(async () => ({
+      content: JSON.stringify({ ok: true }),
+      isError: false,
+    }));
+    const registry = buildFilteredRegistry(
+      {
+        tools: [],
+        toLLMTools: () => [
+          {
+            type: "function",
+            function: {
+              name: "VirtualTool",
+              description: "virtual",
+              parameters: { type: "object" },
+            },
+          },
+        ],
+        dispatch,
+      },
+      {
+        childConversationId: "child-123",
+        worktree: {
+          path: "/tmp/subagent-wt",
+          branch: "worktree-child",
+          gitRoot: "/repo",
+          created: false,
+        },
+      },
+    );
+
+    await registry.dispatch({
+      id: "call-virtual",
+      name: "VirtualTool",
+      arguments: JSON.stringify({
+        value: 1,
+        [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
+      }),
+    });
+
+    expect(dispatch).toHaveBeenCalledOnce();
+    const forwarded = dispatch.mock.calls[0]![0] as {
+      readonly arguments: string;
+    };
+    expect(JSON.parse(forwarded.arguments)).toEqual({
+      value: 1,
+      // Model's "/" stripped; runtime worktree injected and HMAC-signed.
+      __agencSessionAllowedRoots: ["/tmp/subagent-wt"],
+      __agencSessionAllowedRootsSig: signAllowedRoots(["/tmp/subagent-wt"]),
+      __agencSessionId: "child-123",
+    });
+    // The signed channel verifies and the model's "/" never enters it.
+    const forwardedArgs = JSON.parse(forwarded.arguments) as Record<
+      string,
+      unknown
+    >;
+    expect(
+      verifyAllowedRoots(
+        forwardedArgs[SESSION_ALLOWED_ROOTS_ARG],
+        forwardedArgs[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      ),
+    ).toEqual(["/tmp/subagent-wt"]);
+  });
+
   it("layers child tool policy before wrapped child tool execution", async () => {
     const execute = vi.fn(async () => ({
       content: JSON.stringify({ ok: true }),
@@ -803,11 +925,13 @@ describe("runAgent", () => {
         },
         childToolPolicy: (_tool, input) => ({
           behavior: "allow",
-          updatedInput: {
-            ...input,
-            file_path: "/tmp/memory/feedback.md",
-            [SESSION_ALLOWED_ROOTS_ARG]: ["/tmp/memory"],
-          },
+          // Real policies sign their injected roots via
+          // withSignedAllowedRoots; the run-loop then unions + re-signs
+          // alongside the worktree root.
+          updatedInput: withSignedAllowedRoots(
+            { ...input, file_path: "/tmp/memory/feedback.md" },
+            ["/tmp/memory"],
+          ),
         }),
       },
     );
@@ -817,10 +941,17 @@ describe("runAgent", () => {
     expect(execute).toHaveBeenCalledOnce();
     const parsed = execute.mock.calls[0]![0] as Record<string, unknown>;
     expect(parsed.file_path).toBe("/tmp/memory/feedback.md");
+    // Canonical (sorted) union of the signed policy root and worktree root.
     expect(parsed[SESSION_ALLOWED_ROOTS_ARG]).toEqual([
       "/tmp/memory",
       "/tmp/subagent-wt",
     ]);
+    expect(
+      verifyAllowedRoots(
+        parsed[SESSION_ALLOWED_ROOTS_ARG],
+        parsed[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      ),
+    ).toEqual(["/tmp/memory", "/tmp/subagent-wt"]);
     expect(parsed[SESSION_ID_ARG]).toBe("child-123");
   });
 

--- a/runtime/tests/app-server/stdio-transport.contract.test.ts
+++ b/runtime/tests/app-server/stdio-transport.contract.test.ts
@@ -1,7 +1,9 @@
 import { PassThrough } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import { JSON_RPC_VERSION } from "./protocol/index.js";
 import {
+  AGENC_STDIO_DEFAULT_MAX_LINE_BYTES,
   AgenCStdioTransport,
   encodeJsonLine,
   parseJsonObjectLine,
@@ -109,6 +111,113 @@ describe("AgenC stdio transport", () => {
       method: "auth.whoami",
     });
     expect(errors).toHaveLength(1);
+  });
+
+  it("dispatches two pipelined same-connection requests in arrival order", async () => {
+    // Regression for audit #13: dispatch used to be fire-and-forget
+    // (`Promise.resolve(onMessage(...))` not awaited), so a slow first
+    // handler let the second request's handler complete first, corrupting
+    // order-dependent flows (e.g. session.clear then message.send).
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const completionOrder: number[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const transport = new AgenCStdioTransport({
+      input,
+      output,
+      onMessage: async (message) => {
+        const id = message.id as number;
+        if (id === 1) {
+          // First handler is slow; it must still complete before the
+          // second handler is even invoked, because dispatch is serialized.
+          await new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          });
+        }
+        completionOrder.push(id);
+      },
+    });
+    transport.start();
+
+    input.write('{"jsonrpc":"2.0","id":1,"method":"session.clear"}\n');
+    input.write('{"jsonrpc":"2.0","id":2,"method":"message.send"}\n');
+
+    // Give the event loop time: without serialization the second handler
+    // would have already run and pushed `2` before `1`.
+    await delay(20);
+    expect(completionOrder).toEqual([]);
+
+    resolveFirst?.();
+    await delay(20);
+    expect(completionOrder).toEqual([1, 2]);
+
+    await transport.close();
+  });
+
+  it("tears down the connection when an unterminated line exceeds the cap", async () => {
+    // Regression for audit #14: readline imposes no max line length, so a
+    // peer streaming bytes without a newline grew daemon memory unbounded.
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const errors: Error[] = [];
+    const destroyed = new Promise<void>((resolve) => {
+      input.once("close", () => resolve());
+    });
+    const transport = new AgenCStdioTransport({
+      input,
+      output,
+      maxLineBytes: 64,
+      onMessage: () => {},
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+    transport.start();
+
+    // 200 bytes with no newline must trip the 64-byte bound.
+    input.write("x".repeat(200));
+
+    await destroyed;
+    expect(input.destroyed).toBe(true);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(RangeError);
+    expect(errors[0]?.message).toMatch(/64 bytes without a newline/);
+  });
+
+  it("does not trip the cap when newlines keep lines bounded", async () => {
+    // Prior valid behavior: a long stream of newline-terminated frames whose
+    // individual lines stay under the cap must keep flowing.
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const errors: Error[] = [];
+    const received: number[] = [];
+    const transport = new AgenCStdioTransport({
+      input,
+      output,
+      maxLineBytes: 64,
+      onMessage: (message) => {
+        received.push(message.id as number);
+      },
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+    transport.start();
+
+    for (let id = 1; id <= 10; id += 1) {
+      input.write(`{"jsonrpc":"2.0","id":${id},"method":"ping"}\n`);
+    }
+
+    await delay(20);
+    expect(errors).toHaveLength(0);
+    expect(input.destroyed).toBe(false);
+    expect(received).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    await transport.close();
+  });
+
+  it("exposes a default max line bound matching the websocket payload cap", () => {
+    expect(AGENC_STDIO_DEFAULT_MAX_LINE_BYTES).toBe(16 * 1024 * 1024);
   });
 
   it("can send through the transport instance", async () => {

--- a/runtime/tests/app-server/websocket-transport.contract.test.ts
+++ b/runtime/tests/app-server/websocket-transport.contract.test.ts
@@ -108,6 +108,43 @@ describe("AgenC websocket app-server transport", () => {
     await server.close();
   });
 
+  it("dispatches two pipelined same-connection requests in arrival order", async () => {
+    // Regression for audit #13: websocket dispatch used to be fire-and-forget,
+    // so a slow first handler let a later pipelined request complete first and
+    // corrupt order-dependent flows on the same connection.
+    const completionOrder: number[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const server = new AgenCWebSocketServer({
+      onMessage: async (message, connection) => {
+        const id = message.id as number;
+        if (id === 1) {
+          await new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          });
+        }
+        completionOrder.push(id);
+        await connection.send({ jsonrpc: JSON_RPC_VERSION, id, result: {} });
+      },
+    });
+
+    const address = await server.listen();
+    const client = new WebSocket(address.url);
+    await once(client, "open");
+    client.send('{"jsonrpc":"2.0","id":1,"method":"session.clear"}');
+    client.send('{"jsonrpc":"2.0","id":2,"method":"message.send"}');
+
+    await delay(20);
+    expect(completionOrder).toEqual([]);
+
+    resolveFirst?.();
+    await delay(40);
+    expect(completionOrder).toEqual([1, 2]);
+
+    client.close();
+    await nextClose(client);
+    await server.close();
+  });
+
   it("serves health probes and rejects unsafe HTTP and upgrade requests", async () => {
     const server = new AgenCWebSocketServer({
       ready: () => false,

--- a/runtime/tests/file-watcher/index.test.ts
+++ b/runtime/tests/file-watcher/index.test.ts
@@ -268,6 +268,75 @@ describe("file-watcher subscription bus", () => {
     watcher.close();
   });
 
+  it("does not rebuild the recursive fallback backend on every event", () => {
+    const root = tempDir();
+    const nestedA = path.join(root, "a");
+    const nestedB = path.join(root, "b");
+    mkdirSync(nestedA);
+    mkdirSync(nestedB);
+
+    const factory = makeFallbackFactory();
+    const watcher = FileWatcher.create({ watch: factory.watch });
+    const { subscriber } = watcher.addSubscriber();
+    const registration = subscriber.registerPath(root, true);
+
+    // Fallback walked the subtree once: root + 2 nested dirs = 3 watchers.
+    const initialCreated = factory.created.length;
+    expect(initialCreated).toBe(3);
+    expect(watcher.liveWatcherCountForTest(root)).toBe(3);
+
+    // A burst of "change" events (no directory churn) must not recreate any
+    // watchers. The old code closed and re-walked the whole subtree per event.
+    const rootWatcher = factory.watcherFor(root);
+    expect(rootWatcher).toBeDefined();
+    for (let i = 0; i < 25; i += 1) {
+      rootWatcher?.emitEvent("change", `file-${i}.txt`);
+    }
+
+    expect(factory.created.length).toBe(initialCreated);
+    expect(watcher.liveWatcherCountForTest(root)).toBe(3);
+
+    registration.close();
+    subscriber.close();
+    watcher.close();
+  });
+
+  it("incrementally adds a watcher for a newly-created directory on a rename event", () => {
+    const root = tempDir();
+    const nested = path.join(root, "a");
+    mkdirSync(nested);
+
+    const factory = makeFallbackFactory();
+    const watcher = FileWatcher.create({ watch: factory.watch });
+    const { subscriber } = watcher.addSubscriber();
+    const registration = subscriber.registerPath(root, true);
+
+    // root + a = 2 watchers initially.
+    const initialCreated = factory.created.length;
+    expect(initialCreated).toBe(2);
+    expect(watcher.liveWatcherCountForTest(root)).toBe(2);
+
+    // A new directory appears, then a rename event fires for it.
+    const created = path.join(nested, "child");
+    mkdirSync(created);
+    factory.watcherFor(nested)?.emitEvent("rename", "child");
+
+    // Exactly one new watcher added (incremental), not a full rebuild.
+    expect(factory.created.length).toBe(initialCreated + 1);
+    expect(watcher.liveWatcherCountForTest(root)).toBe(3);
+    expect(factory.watcherFor(created)).toBeDefined();
+
+    // A removed directory drops its watcher on the next rename reconcile.
+    rmSync(created, { recursive: true, force: true });
+    factory.watcherFor(nested)?.emitEvent("rename", "child");
+    expect(watcher.liveWatcherCountForTest(root)).toBe(2);
+    expect(factory.watcherFor(created)).toBeUndefined();
+
+    registration.close();
+    subscriber.close();
+    watcher.close();
+  });
+
   it("contains asynchronous live watcher errors", () => {
     const root = tempDir();
     const createdWatchers: FakeFsWatcher[] = [];
@@ -449,4 +518,54 @@ class FakeFsWatcher extends EventEmitter {
   unref(): this {
     return this;
   }
+}
+
+/** A single controllable non-recursive fs.watch handle for the fallback path. */
+class ControllableFsWatcher extends FakeFsWatcher {
+  closed = false;
+
+  constructor(
+    readonly target: string,
+    private readonly listener: (eventType: string, filename: Buffer | string | null) => void,
+  ) {
+    super();
+  }
+
+  emitEvent(eventType: "rename" | "change", filename: string | null): void {
+    this.listener(eventType, filename);
+  }
+
+  close(): this {
+    this.closed = true;
+    return this;
+  }
+}
+
+/**
+ * Builds an fs.watch factory that forces the recursive fallback (native
+ * recursive watch throws) and records every non-recursive watcher created so a
+ * test can drive events and assert how often watchers are (re)built.
+ */
+function makeFallbackFactory(): {
+  readonly watch: FileWatcherWatchFactory;
+  readonly created: ControllableFsWatcher[];
+  readonly live: () => ControllableFsWatcher[];
+  watcherFor(target: string): ControllableFsWatcher | undefined;
+} {
+  const created: ControllableFsWatcher[] = [];
+  const watch: FileWatcherWatchFactory = (target, options, listener) => {
+    if (options.recursive === true) {
+      throw new Error("recursive watch unsupported");
+    }
+    const watcher = new ControllableFsWatcher(target, listener);
+    created.push(watcher);
+    return watcher as unknown as FSWatcher;
+  };
+  const live = () => created.filter((watcher) => !watcher.closed);
+  return {
+    watch,
+    created,
+    live,
+    watcherFor: (target) => live().find((watcher) => watcher.target === target),
+  };
 }

--- a/runtime/tests/llm/providers/anthropic/adapter.stream-retry-duplication.test.ts
+++ b/runtime/tests/llm/providers/anthropic/adapter.stream-retry-duplication.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test, vi } from "vitest";
+import { AnthropicProvider } from "./adapter.js";
+
+/**
+ * Regression coverage for audit issue #10: the Anthropic adapter's outer catch
+ * used to `continue streamAttempts` on a wait/overload fallback decision even
+ * after partial `onChunk` text had been emitted, with no
+ * `content.length === 0` guard. The consumer would re-append the retried text,
+ * doubling rendered output and mid-stream token estimates.
+ *
+ * The fix guards the outer-catch retry the same way the in-stream `error`
+ * branch does — only retrying when nothing has been emitted yet — and surfaces
+ * a partial response (`finishReason: "error"`, `partial: true`) when content
+ * was already streamed.
+ */
+
+/** An SSE response whose body emits `frames`, then errors the stream. */
+function sseResponseThenError(frames: string[], error: Error): Response {
+  const encoder = new TextEncoder();
+  // Enqueue the frames on the first pull and error only on the next pull, so
+  // the reader actually receives (and the adapter processes) the buffered
+  // frames before the transport error surfaces. Erroring synchronously in the
+  // same tick as the enqueue discards the queued chunk under the WHATWG
+  // ReadableStream semantics, which would defeat the partial-content coverage.
+  let emitted = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!emitted) {
+        for (const frame of frames) {
+          controller.enqueue(encoder.encode(frame));
+        }
+        emitted = true;
+        return;
+      }
+      controller.error(error);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function sseResponse(frames: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const frame of frames) {
+        controller.enqueue(encoder.encode(frame));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+const TEXT_DELTA =
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n';
+
+describe("AnthropicProvider stream retry duplication (audit #10)", () => {
+  test(
+    "does not replay already-emitted chunks when a wait/overload error is " +
+      "thrown mid-stream after partial content",
+    async () => {
+      // The stream emits one text delta and then throws an overloaded_error.
+      // Because content was already forwarded to the consumer, the adapter must
+      // NOT retry (which would re-emit "partial") — it surfaces a partial
+      // response instead.
+      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(() =>
+        Promise.resolve(
+          sseResponseThenError([TEXT_DELTA], new Error("overloaded_error")),
+        )
+      );
+      const provider = new AnthropicProvider({
+        apiKey: "anthropic-test",
+        model: "claude-3-7-sonnet",
+        fetchImpl,
+        providerFallback: {
+          provider: "anthropic",
+          model: "claude-3-7-sonnet",
+          targets: [{ provider: "grok", model: "grok-4-fast" }],
+          maxFailures: 5,
+        },
+      });
+
+      const textChunks: string[] = [];
+      const response = await provider.chatStream(
+        [{ role: "user", content: "hello" }],
+        (chunk) => {
+          if (chunk.content) textChunks.push(chunk.content);
+        },
+      );
+
+      // Exactly one fetch: the stream was NOT retried after partial output.
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      // The already-emitted chunk was not replayed/duplicated.
+      expect(textChunks).toEqual(["partial"]);
+      // A partial error response is surfaced rather than a silent retry.
+      expect(response.content).toBe("partial");
+      expect(response.finishReason).toBe("error");
+      expect(response.partial).toBe(true);
+      expect(response.error).toBeInstanceOf(Error);
+    },
+  );
+
+  test(
+    "still retries when a wait/overload error is thrown before any content",
+    async () => {
+      // First attempt errors immediately (no content emitted) -> retry occurs.
+      // Second attempt succeeds.
+      let attempt = 0;
+      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(() => {
+        attempt += 1;
+        if (attempt === 1) {
+          return Promise.resolve(
+            sseResponseThenError([], new Error("overloaded_error")),
+          );
+        }
+        return Promise.resolve(
+          sseResponse([
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-7-sonnet","content":[],"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"recovered"}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ]),
+        );
+      });
+
+      vi.useFakeTimers();
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+      try {
+        const provider = new AnthropicProvider({
+          apiKey: "anthropic-test",
+          model: "claude-3-7-sonnet",
+          fetchImpl,
+          providerFallback: {
+            provider: "anthropic",
+            model: "claude-3-7-sonnet",
+            targets: [{ provider: "grok", model: "grok-4-fast" }],
+            maxFailures: 5,
+          },
+        });
+
+        const textChunks: string[] = [];
+        const pending = provider.chatStream(
+          [{ role: "user", content: "hello" }],
+          (chunk) => {
+            if (chunk.content) textChunks.push(chunk.content);
+          },
+        );
+
+        // Allow the fallback wait + retry to elapse.
+        await vi.advanceTimersByTimeAsync(2000);
+        const response = await pending;
+
+        // Two fetches: the failed attempt and the successful retry.
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(textChunks).toEqual(["recovered"]);
+        expect(response.content).toBe("recovered");
+        expect(response.finishReason).toBe("stop");
+        expect(response.partial).toBeFalsy();
+      } finally {
+        randomSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    },
+  );
+});

--- a/runtime/tests/mcp-client/resilient-client.test.ts
+++ b/runtime/tests/mcp-client/resilient-client.test.ts
@@ -99,4 +99,86 @@ describe("ResilientMCPBridge", () => {
 
     await bridge.dispose();
   });
+
+  it("re-applies the catalog policy (pin + allow/deny + approval mode) on reconnect (#6)", async () => {
+    vi.useFakeTimers();
+    // Catalog-policy fields live alongside MCPServerConfig but are not part of
+    // its public surface, mirroring how manager.ts forwards them.
+    const config = {
+      name: "srv1",
+      command: "npx",
+      args: ["-y", "@test/srv1"],
+      timeout: 123,
+      enabled_tools: ["safe_tool"],
+      disabled_tools: ["dangerous_tool"],
+      default_tools_approval_mode: "never",
+      pinnedCatalogSha256: "a".repeat(64),
+    } as unknown as MCPServerConfig;
+
+    const initialBridge = makeBridge(
+      "srv1",
+      vi.fn().mockResolvedValue({
+        content: "transport closed",
+        isError: true,
+      }),
+    );
+    const reconnectedBridge = makeBridge("srv1");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    mockCreateMCPConnection.mockResolvedValueOnce("client2");
+    mockCreateToolBridge.mockResolvedValueOnce(reconnectedBridge);
+
+    const bridge = new ResilientMCPBridge(config, initialBridge, logger);
+
+    // Force a connection error -> schedule reconnect.
+    await bridge.tools[0]!.execute({});
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(mockCreateToolBridge).toHaveBeenCalledTimes(1);
+    const options = mockCreateToolBridge.mock.calls[0]![3]!;
+    // The rebuilt bridge MUST receive the catalog policy so the I-74 pin and
+    // the allow/deny filter run on every reconnection.
+    expect(options.serverConfig).toBeDefined();
+    expect(options.serverConfig).toMatchObject({
+      pinnedCatalogSha256: "a".repeat(64),
+      allowedTools: ["safe_tool"],
+      deniedTools: ["dangerous_tool"],
+      defaultToolsApprovalMode: "never",
+    });
+
+    await bridge.dispose();
+  });
+
+  it("omits serverConfig on reconnect when the config carries no catalog policy", async () => {
+    vi.useFakeTimers();
+    const config: MCPServerConfig = {
+      name: "srv1",
+      command: "npx",
+      args: ["-y", "@test/srv1"],
+      timeout: 123,
+    };
+
+    const initialBridge = makeBridge(
+      "srv1",
+      vi.fn().mockResolvedValue({
+        content: "transport closed",
+        isError: true,
+      }),
+    );
+    const reconnectedBridge = makeBridge("srv1");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    mockCreateMCPConnection.mockResolvedValueOnce("client2");
+    mockCreateToolBridge.mockResolvedValueOnce(reconnectedBridge);
+
+    const bridge = new ResilientMCPBridge(config, initialBridge, logger);
+
+    await bridge.tools[0]!.execute({});
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const options = mockCreateToolBridge.mock.calls[0]![3]!;
+    expect(options.serverConfig).toBeUndefined();
+
+    await bridge.dispose();
+  });
 });

--- a/runtime/tests/permissions/checkReadPermissionForTool.bypass.test.ts
+++ b/runtime/tests/permissions/checkReadPermissionForTool.bypass.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { Tool, ToolPermissionContext } from '../tools/Tool.js'
+import { checkReadPermissionForTool } from '../utils/permissions/filesystem.js'
+
+// Minimal Tool stub exposing getPath, matching the shape checkReadPermissionForTool
+// requires. Only the fields the read permission check reads are populated.
+function readTool(): Tool {
+  return {
+    name: 'FileRead',
+    getPath(input: { [key: string]: unknown }): string {
+      return String(input.file_path ?? '')
+    },
+  } as unknown as Tool
+}
+
+function context(
+  overrides: Partial<ToolPermissionContext> = {},
+): ToolPermissionContext {
+  return {
+    mode: 'default',
+    additionalWorkingDirectories: new Map(),
+    alwaysAllowRules: {},
+    alwaysDenyRules: {},
+    alwaysAskRules: {},
+    isBypassPermissionsModeAvailable: false,
+    ...overrides,
+  } as ToolPermissionContext
+}
+
+describe('checkReadPermissionForTool under bypassPermissions', () => {
+  let root = ''
+  // MACRO is an esbuild/tsup build-time define, undefined under vitest. The
+  // auto-allow case reaches getBundledSkillsRoot() which dereferences
+  // MACRO.VERSION, so define a stand-in to keep that path from throwing
+  // `ReferenceError: MACRO is not defined`.
+  const hadMacro = 'MACRO' in globalThis
+  const priorMacro = (globalThis as { MACRO?: unknown }).MACRO
+
+  beforeAll(() => {
+    ;(globalThis as { MACRO?: unknown }).MACRO = { VERSION: 'test' }
+  })
+
+  afterAll(() => {
+    if (hadMacro) {
+      ;(globalThis as { MACRO?: unknown }).MACRO = priorMacro
+    } else {
+      delete (globalThis as { MACRO?: unknown }).MACRO
+    }
+  })
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'agenc-filesystem-read-'))
+  })
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true })
+    root = ''
+  })
+
+  // Regression: audit #3 — bypassPermissions / --yolo must not short-circuit
+  // to allow before the read-specific Deny(Read(...)) rule loop runs.
+  //
+  // A bare-name deny pattern (no leading slash) is matched anywhere via
+  // gitignore semantics, keeping the assertion independent of the settings
+  // root / cwd that an absolute-path pattern would resolve against.
+  test('explicit Deny(Read) rule still denies under bypassPermissions', () => {
+    const tool = readTool()
+
+    const result = checkReadPermissionForTool(
+      tool,
+      { file_path: 'agenc-deny-marker.secret' },
+      context({
+        mode: 'bypassPermissions',
+        alwaysDenyRules: { session: ['FileRead(agenc-deny-marker.secret)'] },
+      }),
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(result.decisionReason?.type).toBe('rule')
+  })
+
+  // Baseline: with no deny rule, bypass still auto-allows a path that would
+  // otherwise prompt (outside the working directory).
+  test('reads with no deny rule are auto-allowed under bypassPermissions', () => {
+    const target = join(root, 'anywhere.txt')
+    const tool = readTool()
+
+    const result = checkReadPermissionForTool(
+      tool,
+      { file_path: target },
+      context({ mode: 'bypassPermissions' }),
+    )
+
+    expect(result.behavior).toBe('allow')
+    expect(result.decisionReason).toEqual({
+      type: 'mode',
+      mode: 'bypassPermissions',
+    })
+  })
+
+  // Prior valid behavior is preserved: a read deny rule still denies in the
+  // default (non-bypass) mode.
+  test('explicit Deny(Read) rule still denies in default mode', () => {
+    const tool = readTool()
+
+    const result = checkReadPermissionForTool(
+      tool,
+      { file_path: 'agenc-deny-marker.secret' },
+      context({
+        mode: 'default',
+        alwaysDenyRules: { session: ['FileRead(agenc-deny-marker.secret)'] },
+      }),
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(result.decisionReason?.type).toBe('rule')
+  })
+})

--- a/runtime/tests/permissions/path-validation.test.ts
+++ b/runtime/tests/permissions/path-validation.test.ts
@@ -250,4 +250,130 @@ describe("path-validation", () => {
       blockedPath: target,
     });
   });
+
+  // Regression: audit #3 — bypassPermissions / --yolo must not short-circuit
+  // to allow before path-specific Deny rules and write-safety gates run.
+  describe("checkToolPathPermission honors deny + safety gates under bypassPermissions", () => {
+    test("explicit Deny(Write) rule still denies under bypassPermissions", () => {
+      const target = join(root, "denied.txt");
+      const permissionContext = applyPermissionUpdate(
+        ctx({ mode: "bypassPermissions" }),
+        {
+          type: "addRules",
+          destination: "session",
+          behavior: "deny",
+          rules: [{ toolName: "Write", ruleContent: target }],
+        },
+      );
+
+      const result = checkToolPathPermission({
+        toolName: "Write",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: permissionContext,
+        operationType: "write",
+      });
+
+      expect(result.behavior).toBe("deny");
+      if (result.behavior === "deny") {
+        expect(result.decisionReason.type).toBe("rule");
+      }
+    });
+
+    test("explicit Deny(Read) rule still denies under bypassPermissions", () => {
+      const target = join(root, "secret.txt");
+      const permissionContext = applyPermissionUpdate(
+        ctx({ mode: "bypassPermissions" }),
+        {
+          type: "addRules",
+          destination: "session",
+          behavior: "deny",
+          rules: [{ toolName: "FileRead", ruleContent: target }],
+        },
+      );
+
+      const result = checkToolPathPermission({
+        toolName: "FileRead",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: permissionContext,
+        operationType: "read",
+      });
+
+      expect(result.behavior).toBe("deny");
+    });
+
+    test(".git protected path is not auto-allowed under bypassPermissions", () => {
+      const target = join(root, ".git", "config");
+
+      const result = checkToolPathPermission({
+        toolName: "Write",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "write",
+      });
+
+      expect(result.behavior).not.toBe("allow");
+      expect(result.decisionReason?.type).toBe("safetyCheck");
+    });
+
+    test(".agenc protected path is not auto-allowed under bypassPermissions", () => {
+      const target = join(root, ".agenc", "settings.json");
+
+      const result = checkToolPathPermission({
+        toolName: "Write",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "write",
+      });
+
+      expect(result.behavior).not.toBe("allow");
+      expect(result.decisionReason?.type).toBe("safetyCheck");
+    });
+
+    test("with no deny rule or safety violation, bypassPermissions auto-allows", () => {
+      // Outside cwd with no rule would normally ask; bypass auto-allows.
+      const target = join(outside, "anywhere.txt");
+
+      const result = checkToolPathPermission({
+        toolName: "Write",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "write",
+      });
+
+      expect(result.behavior).toBe("allow");
+      expect(result.decisionReason).toEqual({
+        type: "mode",
+        mode: "bypassPermissions",
+      });
+    });
+
+    test("reads outside cwd are auto-allowed under bypassPermissions", () => {
+      const target = join(outside, "read-me.txt");
+
+      const result = checkToolPathPermission({
+        toolName: "FileRead",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "read",
+      });
+
+      expect(result.behavior).toBe("allow");
+      expect(result.decisionReason).toEqual({
+        type: "mode",
+        mode: "bypassPermissions",
+      });
+    });
+  });
 });

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -30,6 +30,7 @@ import {
   rewriteProxyEnvValue,
 } from "./proxy-routing.js";
 import {
+  isProcMountFailure,
   runCommandWithSupervision,
   runLinuxSandboxMain,
 } from "./linux-run-main.js";
@@ -717,7 +718,106 @@ describe("Linux sandbox launcher", () => {
       ),
     ).rejects.toThrow(/must stay under socketDir/u);
   });
+
+  it("masks host /proc with a tmpfs when proc is not mounted (full filesystem)", () => {
+    const args = createBwrapCommandArgs(
+      ["/bin/true"],
+      unrestrictedFileSystemPolicy(),
+      "/",
+      "/",
+      {
+        mountProc: false,
+        networkMode: "isolated",
+        seccompFd: SECCOMP_STDIN_FD,
+      },
+    ).args;
+
+    expect(procMaskIndex(args)).toBeGreaterThanOrEqual(0);
+    // No fresh procfs mount and no unmasked host /proc bind survives.
+    expect(args).not.toContain("--proc");
+    expect(boundProcSources(args)).toEqual([]);
+    // The tmpfs mask must land after the host root bind so it overrides it.
+    expect(procMaskIndex(args)).toBeGreaterThan(rootBindIndex(args));
+  });
+
+  it("masks host /proc with a tmpfs when proc is not mounted (restricted policy)", () => {
+    const root = withTempDir("agenc-linux-launcher-proc-mask-");
+    const policy = restrictedFileSystemPolicy([
+      { path: { kind: "path", path: root }, access: "write" },
+    ]);
+
+    const args = createBwrapCommandArgs(["/bin/true"], policy, root, root, {
+      mountProc: false,
+      networkMode: "isolated",
+    }).args;
+
+    expect(procMaskIndex(args)).toBeGreaterThanOrEqual(0);
+    expect(args).not.toContain("--proc");
+    expect(boundProcSources(args)).toEqual([]);
+  });
+
+  it("still mounts a private procfs (and no tmpfs mask) when proc is mounted", () => {
+    const args = createBwrapCommandArgs(
+      ["/bin/true"],
+      unrestrictedFileSystemPolicy(),
+      "/",
+      "/",
+      { mountProc: true, networkMode: "isolated", seccompFd: SECCOMP_STDIN_FD },
+    ).args;
+
+    expect(procMaskIndex(args)).toBe(-1);
+    const procIndex = args.indexOf("--proc");
+    expect(procIndex).toBeGreaterThanOrEqual(0);
+    expect(args[procIndex + 1]).toBe("/proc");
+  });
+
+  it("treats genuine bubblewrap proc-mount errors as recoverable proc-mount failures", () => {
+    expect(isProcMountFailure("bwrap: Can't mount proc on /proc")).toBe(true);
+    expect(isProcMountFailure("bwrap: Can't mount new procfs: Operation not permitted")).toBe(
+      true,
+    );
+  });
+
+  it("does not false-positive on unrelated stderr mentioning proc or permissions", () => {
+    expect(isProcMountFailure("error: permission denied opening /workspace/file")).toBe(false);
+    expect(isProcMountFailure("bwrap: Operation not permitted")).toBe(false);
+    expect(isProcMountFailure("python: process exited reading /proc/self/status")).toBe(false);
+    expect(isProcMountFailure("bwrap: Can't open /proc")).toBe(false);
+    expect(isProcMountFailure("Limit exceeded (ENOSPC). Check /proc/sys/fs/mount-max")).toBe(
+      false,
+    );
+    expect(isProcMountFailure("")).toBe(false);
+  });
 });
+
+function procMaskIndex(args: readonly string[]): number {
+  return args.findIndex(
+    (value, index) => value === "--tmpfs" && args[index + 1] === "/proc",
+  );
+}
+
+function rootBindIndex(args: readonly string[]): number {
+  return args.findIndex(
+    (value, index) =>
+      (value === "--bind" || value === "--ro-bind") &&
+      args[index + 1] === "/" &&
+      args[index + 2] === "/",
+  );
+}
+
+function boundProcSources(args: readonly string[]): string[] {
+  const result: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (flag === "--bind" || flag === "--ro-bind" || flag === "--dev-bind") {
+      const destination = args[index + 2];
+      if (destination === "/proc" || destination === "/proc/") {
+        result.push(args[index + 1] ?? "");
+      }
+    }
+  }
+  return result;
+}
 
 function workspaceWriteProfile(
   workspace: string,

--- a/runtime/tests/secrets/sanitizer.test.ts
+++ b/runtime/tests/secrets/sanitizer.test.ts
@@ -53,6 +53,67 @@ describe("secrets sanitizer", () => {
     expect(redacted).toContain(`Bearer ${REDACTED_SECRET};`);
   });
 
+  it("redacts vendor key shapes lacking a key/context word", () => {
+    // Vendor tokens assembled from fragments so the test fixture is not
+    // flagged as a real secret by push-protection / secret scanning; the
+    // runtime values still match the sanitizer's vendor patterns.
+    const xaiToken = "xai-" + "abcdefghijklmnopqrstuvwxyz0123456789";
+    const slackToken = ["xoxb", "1234567890", "abcdefghijklmnopqrstuvwx"].join("-");
+    const googleToken = "AIza" + "0123456789abcdefghijklmnopqrstuvwxy";
+    const input = [
+      xaiToken,
+      `slack=${slackToken}`,
+      `google=${googleToken}`,
+      "aws_secret_access_key=abcd1234EFGH5678ijkl9012MNOP3456qrst7890",
+      "secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      '{"aws_secret_access_key": "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY"}',
+      "The meeting lasted forty minutes and everyone seemed satisfied",
+      "value=abcd1234EFGH5678ijkl9012MNOP3456qrst7890",
+    ].join("\n");
+
+    const redacted = redactSecrets(input);
+
+    expect(redacted).not.toContain(xaiToken);
+    expect(redacted).not.toContain(slackToken);
+    expect(redacted).not.toContain(googleToken);
+    expect(redacted).toContain(`aws_secret_access_key=${REDACTED_SECRET}`);
+    expect(redacted).toContain(`secret_access_key = ${REDACTED_SECRET}`);
+    // JSON-quoted AWS key:value (closing quote before the colon) is redacted.
+    expect(redacted).not.toContain("je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY");
+    expect(redacted).toContain(`"aws_secret_access_key": "${REDACTED_SECRET}"`);
+    // False-positive guard: a bare 40-char-ish word in prose stays visible.
+    expect(redacted).toContain("forty minutes and everyone seemed satisfied");
+    // A 40-char base64 value with no aws/secret context is NOT AWS-redacted.
+    expect(redacted).toContain("value=abcd1234EFGH5678ijkl9012MNOP3456qrst7890");
+  });
+
+  it("redacts AWS secret/access-key fields on the structured-object path", () => {
+    const artifact = {
+      credentials: {
+        aws_secret_access_key: "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY",
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        secretKey: "opaque-value-12345",
+      },
+      // False-positive guard: non-secret `...key` names stay visible.
+      publicKey: "ssh-rsa AAAAB3NzaC1yc2EexamplePublicKeyMaterial",
+      keyCount: 42,
+    };
+
+    const redacted = redactSecretsInValue(artifact);
+
+    expect(redacted).toEqual({
+      credentials: {
+        aws_secret_access_key: REDACTED_SECRET,
+        secret_access_key: REDACTED_SECRET,
+        aws_access_key_id: REDACTED_SECRET,
+        secretKey: REDACTED_SECRET,
+      },
+      publicKey: "ssh-rsa AAAAB3NzaC1yc2EexamplePublicKeyMaterial",
+      keyCount: 42,
+    });
+  });
+
   it("redacts JWTs and secret-looking assignments", () => {
     const input = [
       "jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signatureValue123-",

--- a/runtime/tests/session/degraded-store.test.ts
+++ b/runtime/tests/session/degraded-store.test.ts
@@ -69,6 +69,95 @@ describe("DegradedStore (I-12, I-38, I-43)", () => {
     expect(store.isDegraded).toBe(true);
   });
 
+  test("#12 concurrent at-capacity append during in-flight flush does not drop a buffered-unflushed event", async () => {
+    let flushed: number[] = [];
+    let startedFlush!: () => void;
+    const flushStarted = new Promise<void>((resolve) => {
+      startedFlush = resolve;
+    });
+    let releaseFlush!: () => void;
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+
+    const store = new DegradedStore<number>({
+      capacity: 3,
+      flushFn: async (evs) => {
+        flushed = [...evs];
+        startedFlush();
+        await flushGate;
+        return true;
+      },
+    });
+    store.enterDegraded("test");
+    // Fill exactly to capacity.
+    store.append(1);
+    store.append(2);
+    store.append(3);
+    expect(store.size).toBe(3);
+
+    // Start the flush but don't await — flushFn parks on flushGate.
+    const flushPromise = store.tryFlush();
+    await flushStarted;
+
+    // Concurrent appends arrive while the flush is in flight. Under the
+    // old index-based splice these would push the at-capacity buffer over
+    // the limit, evict the front, and then the post-flush
+    // `splice(0, toFlush.length)` would remove these never-flushed items
+    // (data loss). Draining by identity keeps them safe.
+    store.append(4);
+    store.append(5);
+
+    releaseFlush();
+    const ok = await flushPromise;
+    expect(ok).toBe(true);
+
+    // The flush only ever saw the original snapshot.
+    expect(flushed).toEqual([1, 2, 3]);
+    // The concurrently-appended, never-flushed items must survive.
+    expect(store.snapshot()).toEqual([4, 5]);
+    // They were not flushed, so we must still be degraded.
+    expect(store.isDegraded).toBe(true);
+  });
+
+  test("#12 flush failure re-prepends drained items ahead of concurrent appends", async () => {
+    let startedFlush!: () => void;
+    const flushStarted = new Promise<void>((resolve) => {
+      startedFlush = resolve;
+    });
+    let releaseFlush!: () => void;
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+
+    const store = new DegradedStore<number>({
+      capacity: 10,
+      flushFn: async () => {
+        startedFlush();
+        await flushGate;
+        return false; // disk still broken — must re-queue drained slice
+      },
+    });
+    store.enterDegraded("test");
+    store.append(1);
+    store.append(2);
+
+    const flushPromise = store.tryFlush();
+    await flushStarted;
+
+    // Arrives during the in-flight (failing) flush.
+    store.append(3);
+
+    releaseFlush();
+    const ok = await flushPromise;
+    expect(ok).toBe(false);
+
+    // Drained items re-prepended ahead of the concurrent append; nothing
+    // lost, order preserved, still degraded.
+    expect(store.snapshot()).toEqual([1, 2, 3]);
+    expect(store.isDegraded).toBe(true);
+  });
+
   test("evictedCount tracks total overflow", () => {
     const store = new DegradedStore<number>({
       capacity: 2,

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -783,6 +783,73 @@ describe("session-store", () => {
     }
   });
 
+  test("#11 durable fsync-failure does not duplicate the row after degraded flush", async () => {
+    const store = new SessionStore({
+      cwd: "/home/test-fsync-dup",
+      sessionId: "sess-fsync-dup",
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId: "sess-fsync-dup",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-fsync-dup",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+
+    try {
+      // Fail every fsync so the durable append's writeSync lands the row
+      // on disk but both the initial fsync and the I-38 retry trip.
+      store.setFsyncImplForTest(() => {
+        const err = new Error("simulated persistent fsync failure") as NodeJS.ErrnoException;
+        err.code = "EIO";
+        throw err;
+      });
+
+      store.append(
+        {
+          id: "durable-once",
+          seq: 1,
+          msg: { type: "turn_complete", payload: { turnId: "t-once" } },
+        },
+        { durable: true },
+      );
+
+      await (store as unknown as {
+        awaitPendingFsyncRetries(): Promise<void>;
+      }).awaitPendingFsyncRetries();
+
+      // writeSync persisted the row even though fsync failed; we entered
+      // degraded mode.
+      expect(store.isDegraded).toBe(true);
+
+      const countOccurrences = () =>
+        readFileSync(store.rolloutPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as { payload?: { id?: string } })
+          .filter((line) => line.payload?.id === "durable-once").length;
+
+      // Already exactly once on disk (the original writeSync).
+      expect(countOccurrences()).toBe(1);
+
+      // Restore fsync and drive the degraded flush. The pre-fix bug
+      // re-queued the already-written row into the degraded buffer, so
+      // this flush re-appended it — producing two copies on disk (and a
+      // double on resume/reduce). With the fix the degraded buffer is
+      // empty, so the flush is a no-op and the row stays exactly once.
+      store.setFsyncImplForTest(fsyncSync);
+      await (store as unknown as {
+        degraded: { tryFlush(): Promise<boolean> };
+      }).degraded.tryFlush();
+
+      expect(countOccurrences()).toBe(1);
+    } finally {
+      store.setFsyncImplForTest(fsyncSync);
+      store.close();
+    }
+  });
+
   test("I-24 truncateCorruptTail removes partial trailing line", () => {
     const dir = mkdtempSync(join(tmpdir(), "agenc-corrupt-"));
     try {

--- a/runtime/tests/state/backfill-incremental.test.ts
+++ b/runtime/tests/state/backfill-incremental.test.ts
@@ -1,0 +1,232 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ROLLOUT_SCHEMA_VERSION } from "../session/event-log.js";
+import { serializeRolloutItem } from "../session/rollout-item.js";
+import { backfillRolloutFile } from "./backfill.js";
+import { StateThreadRepository } from "./threads.js";
+import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
+
+let home = "";
+let cwd = "";
+let originalAgencHome = "";
+let driver: StateSqliteDriver;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-incr-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-incr-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  originalAgencHome = process.env.AGENC_HOME ?? "";
+  process.env.AGENC_HOME = home;
+  driver = openStateDatabases({ cwd });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  driver.close();
+  if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
+  else delete process.env.AGENC_HOME;
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function makeRolloutPath(): string {
+  const sessionDir = join(driver.projectDir, "sessions", "thread-1");
+  mkdirSync(sessionDir, { recursive: true });
+  return join(sessionDir, "rollout-2026-04-29T00-00-00-000Z-thread-1.jsonl");
+}
+
+const META = serializeRolloutItem({
+  type: "session_meta",
+  payload: {
+    sessionId: "thread-1",
+    timestamp: "2026-04-29T00:00:00.000Z",
+    cwd: "/tmp/work",
+    originator: "test",
+    agencVersion: "0.2.0",
+    rolloutSchemaVersion: ROLLOUT_SCHEMA_VERSION,
+    model: "grok-4",
+    modelProvider: "xai",
+  },
+});
+
+function itemLine(n: number): string {
+  return serializeRolloutItem({
+    type: "response_item",
+    payload: { role: "user", content: `msg-${n}` },
+  });
+}
+
+function rowCount(): number {
+  return (
+    driver
+      .prepareState<[], { count: number }>(
+        "SELECT COUNT(*) AS count FROM thread_rollout_items",
+      )
+      .get()?.count ?? -1
+  );
+}
+
+describe("backfillRolloutFile incremental append", () => {
+  it("does not re-INSERT all prior rows on each append", () => {
+    const rolloutPath = makeRolloutPath();
+    const threads = new StateThreadRepository(driver);
+
+    // Spy on the two index code paths so we can prove only the appended tail
+    // is INSERTed after the first full index.
+    const replaceSpy = vi.spyOn(threads, "replaceRolloutItems");
+    const appendSpy = vi.spyOn(threads, "appendRolloutItems");
+
+    // Initial file: session_meta + 1 item => 2 rows, full reconcile.
+    writeFileSync(rolloutPath, META + itemLine(0));
+    expect(backfillRolloutFile({ rolloutPath, threads })).toEqual({
+      itemsIndexed: 2,
+    });
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy).toHaveBeenCalledTimes(0);
+    expect(rowCount()).toBe(2);
+
+    // N sequential appends. Each must take the incremental path and only
+    // index the single new line — never a full reconcile, never re-touching
+    // the prior rows.
+    const N = 8;
+    for (let i = 1; i <= N; i += 1) {
+      appendFileSync(rolloutPath, itemLine(i));
+      const result = backfillRolloutFile({ rolloutPath, threads });
+      // Work is bounded per append: exactly one new item indexed.
+      expect(result).toEqual({ itemsIndexed: 1 });
+    }
+
+    // Full reconcile ran exactly once (the initial index); every append used
+    // the incremental path.
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy).toHaveBeenCalledTimes(N);
+    for (const call of appendSpy.mock.calls) {
+      expect(call[0]?.items.length).toBe(1);
+    }
+
+    // Final indexed state is still complete and correctly ordered.
+    expect(rowCount()).toBe(2 + N);
+    const rows = driver
+      .prepareState<[], { line_number: number; item_index: number }>(
+        "SELECT line_number, item_index FROM thread_rollout_items ORDER BY item_index",
+      )
+      .all();
+    expect(rows.map((r) => r.item_index)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ]);
+    // Line numbers are unique and strictly increasing (no collisions/dupes).
+    const lineNumbers = rows.map((r) => r.line_number);
+    expect(new Set(lineNumbers).size).toBe(lineNumbers.length);
+    expect([...lineNumbers].sort((a, b) => a - b)).toEqual(lineNumbers);
+  });
+
+  it("skips re-indexing entirely when the file is unchanged", () => {
+    const rolloutPath = makeRolloutPath();
+    const threads = new StateThreadRepository(driver);
+    writeFileSync(rolloutPath, META + itemLine(0));
+    backfillRolloutFile({ rolloutPath, threads });
+
+    const replaceSpy = vi.spyOn(threads, "replaceRolloutItems");
+    const appendSpy = vi.spyOn(threads, "appendRolloutItems");
+
+    // Re-indexing an untouched file must be a no-op: neither path runs.
+    expect(backfillRolloutFile({ rolloutPath, threads })).toEqual({
+      itemsIndexed: 0,
+    });
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(appendSpy).not.toHaveBeenCalled();
+    expect(rowCount()).toBe(2);
+  });
+
+  it("produces the same final state as a full re-index", () => {
+    const rolloutPath = makeRolloutPath();
+    const incremental = new StateThreadRepository(driver);
+    writeFileSync(rolloutPath, META + itemLine(0));
+    backfillRolloutFile({ rolloutPath, threads: incremental });
+    for (let i = 1; i <= 5; i += 1) {
+      appendFileSync(rolloutPath, itemLine(i));
+      backfillRolloutFile({ rolloutPath, threads: incremental });
+    }
+
+    const incrementalRows = driver
+      .prepareState<
+        [],
+        { line_number: number; item_index: number; payload_json: string }
+      >(
+        "SELECT line_number, item_index, payload_json FROM thread_rollout_items ORDER BY item_index",
+      )
+      .all();
+
+    // Force a full reconcile by clearing the receipt, then re-index from
+    // scratch; the resulting rows must match the incrementally-built ones.
+    driver
+      .prepareState<[string]>("DELETE FROM backfill_files WHERE source_path = ?")
+      .run(rolloutPath);
+    backfillRolloutFile({ rolloutPath, threads: incremental });
+
+    const fullRows = driver
+      .prepareState<
+        [],
+        { line_number: number; item_index: number; payload_json: string }
+      >(
+        "SELECT line_number, item_index, payload_json FROM thread_rollout_items ORDER BY item_index",
+      )
+      .all();
+
+    expect(incrementalRows).toEqual(fullRows);
+    expect(fullRows.length).toBe(7);
+  });
+
+  it("carries updatedAt forward on appends that contain no session_meta", () => {
+    const rolloutPath = makeRolloutPath();
+    const threads = new StateThreadRepository(driver);
+    writeFileSync(rolloutPath, META + itemLine(0));
+    backfillRolloutFile({ rolloutPath, threads });
+
+    // The full reconcile seeds updatedAt from the session_meta timestamp.
+    const initial = threads.getThread("thread-1");
+    expect(initial?.updatedAt).toBe("2026-04-29T00:00:00.000Z");
+
+    // An appended tail without a session_meta line must not advance updatedAt
+    // to the file mtime; it carries the prior value forward so a later full
+    // reconcile (which also reads it from meta) does not make it jump back.
+    appendFileSync(rolloutPath, itemLine(1));
+    backfillRolloutFile({ rolloutPath, threads });
+    expect(threads.getThread("thread-1")?.updatedAt).toBe(
+      "2026-04-29T00:00:00.000Z",
+    );
+
+    // Forcing a full reconcile produces the same updatedAt: no jump.
+    driver
+      .prepareState<[string]>("DELETE FROM backfill_files WHERE source_path = ?")
+      .run(rolloutPath);
+    backfillRolloutFile({ rolloutPath, threads });
+    expect(threads.getThread("thread-1")?.updatedAt).toBe(
+      "2026-04-29T00:00:00.000Z",
+    );
+  });
+
+  it("falls back to a full reconcile when the file shrinks (rewrite)", () => {
+    const rolloutPath = makeRolloutPath();
+    const threads = new StateThreadRepository(driver);
+    writeFileSync(rolloutPath, META + itemLine(0) + itemLine(1) + itemLine(2));
+    backfillRolloutFile({ rolloutPath, threads });
+    expect(rowCount()).toBe(4);
+
+    const replaceSpy = vi.spyOn(threads, "replaceRolloutItems");
+    // Truncating/rewriting to fewer lines must trigger a full reconcile so the
+    // stale rows are dropped.
+    writeFileSync(rolloutPath, META + itemLine(9));
+    backfillRolloutFile({ rolloutPath, threads });
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(rowCount()).toBe(2);
+  });
+});

--- a/runtime/tests/state/backfill.test.ts
+++ b/runtime/tests/state/backfill.test.ts
@@ -60,8 +60,11 @@ describe("backfillProjectRollouts", () => {
     );
     expect(backfillProjectRollouts({ projectDir: driver.projectDir, driver }))
       .toMatchObject({ filesIndexed: 1, itemsIndexed: 2 });
+    // Re-indexing an unchanged file is now a no-op: it neither re-reads nor
+    // re-INSERTs the prior items (no O(N^2) DELETE-all + re-INSERT-all), so it
+    // reports zero items indexed while leaving the already-indexed rows intact.
     expect(backfillProjectRollouts({ projectDir: driver.projectDir, driver }))
-      .toMatchObject({ filesIndexed: 1, itemsIndexed: 2 });
+      .toMatchObject({ filesIndexed: 1, itemsIndexed: 0 });
     expect(
       driver
         .prepareState<[], { count: number }>(

--- a/runtime/tests/tasks/lifecycle.test.ts
+++ b/runtime/tests/tasks/lifecycle.test.ts
@@ -146,6 +146,58 @@ describe("BackgroundTaskLifecycle", () => {
     } satisfies Partial<BackgroundTaskError>);
   });
 
+  it("reaches a terminal state and surfaces the error when onStop throws", async () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.register({
+      id: "task-zombie",
+      type: "local_bash",
+      description: "stubborn task",
+      onStop: () => {
+        throw new Error("teardown blew up");
+      },
+    });
+
+    await expect(lifecycle.stop("task-zombie", "user stop")).rejects.toMatchObject(
+      {
+        code: "stop_failed",
+      } satisfies Partial<BackgroundTaskError>,
+    );
+
+    // The task must not be left as a zombie stuck in `running`.
+    const snapshot = lifecycle.get("task-zombie");
+    expect(snapshot?.status).toBe("killed");
+    expect(snapshot?.error).toContain("teardown blew up");
+
+    // A second stop should now report the task is no longer running.
+    await expect(lifecycle.stop("task-zombie")).rejects.toMatchObject({
+      code: "not_running",
+    } satisfies Partial<BackgroundTaskError>);
+  });
+
+  it("bounds the notification buffer so it cannot grow unbounded", () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    const id = "noisy";
+    lifecycle.register({
+      id,
+      type: "generic",
+      description: "chatty task",
+    });
+
+    // Far exceed the retention cap (1_000) with progress notifications.
+    for (let index = 0; index < 5_000; index += 1) {
+      lifecycle.appendOutput(id, `chunk-${index}`);
+    }
+
+    const drained = lifecycle.drainNotifications();
+    expect(drained.length).toBeLessThanOrEqual(1_000);
+    // The oldest "started" notification must have been evicted.
+    expect(drained.some((item) => item.kind === "started")).toBe(false);
+    // Most recent notifications are retained.
+    expect(drained.at(-1)?.delta).toBe("chunk-4999");
+    // Draining empties the buffer for the next consumer.
+    expect(lifecycle.drainNotifications()).toHaveLength(0);
+  });
+
   it("does not let late promise completion overwrite a stopped task", async () => {
     const lifecycle = new BackgroundTaskLifecycle();
     const done = deferred<string>();

--- a/runtime/tests/tools/apply-patch/tool.test.ts
+++ b/runtime/tests/tools/apply-patch/tool.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
 
 import { APPLY_PATCH_LARK_GRAMMAR, APPLY_PATCH_TOOL_NAME, createApplyPatchTool } from "./tool.js";
+import { createEmptyToolPermissionContext } from "../../permissions/types.js";
 
 async function tempRoot(): Promise<string> {
   return mkdtemp(join(tmpdir(), "agenc-apply-patch-tool-"));
@@ -36,6 +37,55 @@ describe("apply_patch tool", () => {
     await expect(readFile(join(root, "hello.txt"), "utf8")).resolves.toBe(
       "hello\n",
     );
+  });
+
+  test("denies (fail-closed) on an unparseable patch in checkPermissions", () => {
+    // SECURITY (audit #2): a malformed patch must NOT fail open. The
+    // previous `behavior: "allow"` let unparseable input skip the
+    // per-target path-permission check entirely.
+    const tool = createApplyPatchTool({ cwd: "/tmp", allowedPaths: ["/tmp"] });
+    const context = {
+      getAppState: () => ({
+        toolPermissionContext: createEmptyToolPermissionContext(),
+      }),
+    } as unknown as Parameters<NonNullable<typeof tool.checkPermissions>>[1];
+
+    const decision = tool.checkPermissions!(
+      { input: "this is not a valid apply_patch payload" },
+      context,
+    );
+
+    expect(decision.behavior).toBe("deny");
+    if (decision.behavior === "deny") {
+      expect(decision.message).toContain("could not be parsed");
+    }
+  });
+
+  test("checkPermissions ignores model-supplied __agencSessionAllowedRoots", () => {
+    // SECURITY (audit #1/#4): apply_patch must check writes against the
+    // TRUSTED closure roots only. A model-supplied
+    // `__agencSessionAllowedRoots:["/"]` must not widen the permitted
+    // write target. Writing to /etc must therefore not be auto-allowed.
+    const tool = createApplyPatchTool({ cwd: "/tmp", allowedPaths: ["/tmp"] });
+    const context = {
+      getAppState: () => ({
+        toolPermissionContext: createEmptyToolPermissionContext(),
+      }),
+    } as unknown as Parameters<NonNullable<typeof tool.checkPermissions>>[1];
+
+    const decision = tool.checkPermissions!(
+      {
+        input: `*** Begin Patch
+*** Add File: /etc/agenc-escape.txt
++pwned
+*** End Patch`,
+        __agencSessionAllowedRoots: ["/"],
+      },
+      context,
+    );
+
+    // The model-supplied root must not have made /etc writable.
+    expect(decision.behavior).not.toBe("allow");
   });
 
   test("declares a deferred mutating filesystem surface", () => {

--- a/runtime/tests/tools/router.test.ts
+++ b/runtime/tests/tools/router.test.ts
@@ -105,6 +105,61 @@ describe("ToolRouter", () => {
     );
   });
 
+  test("dispatchModelToolCall strips model-supplied __agenc* keys before tool.execute", async () => {
+    // SECURITY (audit #1/#2/#4): `__agenc*` keys are a TRUSTED INTERNAL
+    // channel. A model that emits `__agencSessionAllowedRoots:["/"]` must
+    // never have it reach tool.execute, where it would widen filesystem
+    // confinement.
+    const execute = vi.fn(async (args: Record<string, unknown>) => ({
+      content: `ok ${String(args.file_path)}`,
+    }));
+    const router = new ToolRouter([
+      {
+        tool: { ...writeTool, execute },
+        supportsParallelToolCalls: true,
+      },
+    ]);
+
+    const result = await router.dispatchModelToolCall(
+      {
+        id: "call-injection",
+        name: "Write",
+        arguments: JSON.stringify({
+          file_path: "main.c",
+          __agencSessionAllowedRoots: ["/"],
+          __agencSessionId: "attacker-session",
+          __agencHome: "/etc",
+        }),
+      },
+      {
+        session: {
+          eventLog: new EventLog(),
+          services: {},
+        } as never,
+        turn: { subId: "turn-injection" } as never,
+        tracker: {
+          appendFileDiff: () => {},
+          snapshot: () => [],
+          clear: () => {},
+        },
+        approvalPolicy: "never",
+        sandboxMode: "workspace_write",
+      },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(execute).toHaveBeenCalledOnce();
+    const received = execute.mock.calls[0]![0] as Record<string, unknown>;
+    // Legitimate model-supplied args survive.
+    expect(received.file_path).toBe("main.c");
+    // Every model-supplied `__agenc*` key is stripped at the boundary.
+    expect(received.__agencSessionAllowedRoots).toBeUndefined();
+    expect(received.__agencHome).toBeUndefined();
+    // The runtime may re-attach its own __agencSessionId (non-enumerable);
+    // it must never be the attacker-controlled value.
+    expect(received.__agencSessionId).not.toBe("attacker-session");
+  });
+
   test("findSpec rejects MCP-serverId entry for plain (no-namespace) lookup (router behavior)", () => {
     // A spec registered with `serverId` (MCP umbrella) must not
     // resolve when the request has no namespace. This prevents a

--- a/runtime/tests/tools/system/signed-allowed-roots.test.ts
+++ b/runtime/tests/tools/system/signed-allowed-roots.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+
+import { resolveToolAllowedPaths } from "./filesystem.js";
+import {
+  SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ALLOWED_ROOTS_SIG_ARG,
+  signAllowedRoots,
+  verifyAllowedRoots,
+  withSignedAllowedRoots,
+} from "src/agents/_deps/filesystem-args.js";
+
+// Simulate the in-process JSON dispatch serialization
+// (router.ts JSON.stringify -> execution.ts JSON.parse, and the child
+// path). The PROCESS_SECRET lives in the same Node runtime, so the
+// signature must survive the round-trip and still verify.
+function roundTrip<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const BASE = [resolve("/srv/trusted")] as const;
+
+describe("HMAC-signed trusted filesystem roots", () => {
+  describe("verifyAllowedRoots", () => {
+    it("rejects non-array roots and non-string signatures", () => {
+      expect(verifyAllowedRoots(undefined, undefined)).toEqual([]);
+      expect(verifyAllowedRoots("/", "deadbeef")).toEqual([]);
+      expect(verifyAllowedRoots(["/tmp"], undefined)).toEqual([]);
+      expect(verifyAllowedRoots(["/tmp"], 42)).toEqual([]);
+      expect(verifyAllowedRoots([1, 2], signAllowedRoots(["/tmp"]))).toEqual([]);
+    });
+
+    it("is order/duplication-insensitive (canonical signature)", () => {
+      const sig = signAllowedRoots(["/b", "/a", "/a"]);
+      expect(verifyAllowedRoots(["/a", "/b"], sig)).toEqual(["/a", "/b"]);
+      expect(verifyAllowedRoots(["/b", "/a"], sig)).toEqual(["/a", "/b"]);
+    });
+  });
+
+  // (a) FORGE: a model-supplied root with NO / a bogus signature must NOT
+  // be folded into the resolved allowed paths.
+  describe("FORGE — sink ignores unsigned/forged model roots", () => {
+    it("ignores __agencSessionAllowedRoots with no signature", () => {
+      const args = roundTrip({ [SESSION_ALLOWED_ROOTS_ARG]: ["/"] });
+      expect(resolveToolAllowedPaths(BASE, args)).toEqual([...BASE]);
+    });
+
+    it("ignores __agencSessionAllowedRoots with a bogus signature", () => {
+      const args = roundTrip({
+        [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
+        [SESSION_ALLOWED_ROOTS_SIG_ARG]: "00".repeat(32),
+      });
+      expect(resolveToolAllowedPaths(BASE, args)).toEqual([...BASE]);
+    });
+
+    it("ignores a signature copied from a DIFFERENT root set", () => {
+      // Model knows a valid signature for ["/srv/trusted"] but swaps the
+      // roots to ["/"] — the recomputed HMAC will not match.
+      const args = roundTrip({
+        [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
+        [SESSION_ALLOWED_ROOTS_SIG_ARG]: signAllowedRoots(["/srv/trusted"]),
+      });
+      expect(resolveToolAllowedPaths(BASE, args)).toEqual([...BASE]);
+    });
+  });
+
+  // (b) LEGIT: roots injected via withSignedAllowedRoots ARE honored,
+  // surviving the JSON dispatch serialization.
+  describe("LEGIT — sink honors signed roots through JSON round-trip", () => {
+    it("folds in a legitimately-signed root", () => {
+      const injected = withSignedAllowedRoots({}, ["/work/tree"]);
+      const args = roundTrip(injected);
+      const resolved = resolveToolAllowedPaths(BASE, args);
+      expect(resolved).toContain(resolve("/work/tree"));
+      expect(resolved).toContain(BASE[0]);
+    });
+  });
+
+  // (c) LAUNDERING: a writer given args that already contain an UNSIGNED
+  // model root drops it and only signs its own legitimately-added root.
+  describe("LAUNDERING — writer drops unsigned existing roots", () => {
+    it("does not carry a forged root into the signed set", () => {
+      const dirty = roundTrip({
+        [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
+        // no valid signature — pure model forgery
+      });
+      const injected = withSignedAllowedRoots(dirty, ["/work/tree"]);
+      const args = roundTrip(injected);
+
+      expect(verifyAllowedRoots(
+        args[SESSION_ALLOWED_ROOTS_ARG],
+        args[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      )).toEqual(["/work/tree"]);
+
+      const resolved = resolveToolAllowedPaths(BASE, args);
+      expect(resolved).toContain(resolve("/work/tree"));
+      expect(resolved).not.toContain(resolve("/"));
+    });
+
+    it("drops a root carrying a bogus signature when laundering", () => {
+      const dirty = roundTrip({
+        [SESSION_ALLOWED_ROOTS_ARG]: ["/etc"],
+        [SESSION_ALLOWED_ROOTS_SIG_ARG]: "ff".repeat(32),
+      });
+      const injected = withSignedAllowedRoots(dirty, ["/work/tree"]);
+      expect(verifyAllowedRoots(
+        injected[SESSION_ALLOWED_ROOTS_ARG],
+        injected[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      )).toEqual(["/work/tree"]);
+    });
+  });
+
+  // (d) UNION: two successive withSignedAllowedRoots passes accumulate
+  // both legitimate roots and the final signature verifies.
+  describe("UNION — successive signed passes accumulate roots", () => {
+    it("preserves the first signed root when adding a second", () => {
+      const first = withSignedAllowedRoots({}, ["/root/a"]);
+      const second = withSignedAllowedRoots(roundTrip(first), ["/root/b"]);
+      const args = roundTrip(second);
+
+      const verified = verifyAllowedRoots(
+        args[SESSION_ALLOWED_ROOTS_ARG],
+        args[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      );
+      expect(verified).toEqual(["/root/a", "/root/b"]);
+
+      const resolved = resolveToolAllowedPaths(BASE, args);
+      expect(resolved).toContain(resolve("/root/a"));
+      expect(resolved).toContain(resolve("/root/b"));
+    });
+
+    it("is idempotent when re-adding an existing signed root", () => {
+      const first = withSignedAllowedRoots({}, ["/root/a"]);
+      const again = withSignedAllowedRoots(roundTrip(first), ["/root/a"]);
+      expect(verifyAllowedRoots(
+        again[SESSION_ALLOWED_ROOTS_ARG],
+        again[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      )).toEqual(["/root/a"]);
+    });
+  });
+});

--- a/runtime/tests/unified-exec/process-output-buffer.test.ts
+++ b/runtime/tests/unified-exec/process-output-buffer.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+
+import { ProcessOutputBuffer } from "./process-manager.js";
+
+const CAP = 4096;
+
+describe("ProcessOutputBuffer cap enforcement (audit #9)", () => {
+  test("preserves unconsumed HEAD and TAIL on a single oversized burst before drain", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    // Emit > cap chars in one window before any drain. Use distinctive
+    // sentinels at the very start and very end so we can prove neither end was
+    // discarded wholesale.
+    const head = "HEAD_SENTINEL_BEGIN";
+    const tail = "TAIL_SENTINEL_END";
+    const filler = "x".repeat(CAP * 4);
+    buffer.append("stdout", `${head}${filler}${tail}`);
+
+    const chunks = buffer.drain();
+    const combined = chunks.map((chunk) => chunk.chunk).join("");
+
+    // The previously-buggy implementation dropped the unconsumed head wholesale,
+    // leaving only a count marker. Both ends must now survive.
+    expect(combined).toContain(head);
+    expect(combined).toContain(tail);
+
+    // The explicit omitted-count marker must be present.
+    expect(combined).toMatch(/\[\.\.\. omitted \d+ chars \.\.\.\]/);
+
+    // The collected output must respect the cap (plus the inline marker text).
+    expect(combined.length).toBeLessThanOrEqual(CAP + 128);
+  });
+
+  test("preserves HEAD/TAIL when the oversized burst is split across many appends", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    const head = "FIRST_BYTES_HEAD";
+    buffer.append("stdout", head);
+    for (let i = 0; i < 200; i += 1) {
+      buffer.append("stdout", "y".repeat(64));
+    }
+    const tail = "LAST_BYTES_TAIL";
+    buffer.append("stdout", tail);
+
+    const combined = buffer
+      .drain()
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    expect(combined).toContain(head);
+    expect(combined).toContain(tail);
+    expect(combined).toMatch(/\[\.\.\. omitted \d+ chars \.\.\.\]/);
+  });
+
+  test("evicts already-consumed chunks silently without an omitted marker", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    // First window: small output that is drained (consumed).
+    buffer.append("stdout", "consumed-output\n");
+    const firstDrain = buffer
+      .drain()
+      .map((chunk) => chunk.chunk)
+      .join("");
+    expect(firstDrain).toBe("consumed-output\n");
+
+    // Second window: enough new output to force eviction of the consumed chunk.
+    buffer.append("stdout", "z".repeat(CAP));
+    const secondDrain = buffer
+      .drain()
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    // Consumed bytes were already delivered, so re-evicting them must NOT emit a
+    // "before collection" marker, and the new pending bytes must survive intact.
+    expect(secondDrain).not.toContain("omitted");
+    expect(secondDrain).toContain("z".repeat(CAP - 100));
+  });
+
+  test("does not truncate output that fits within the cap", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+    const payload = "small payload that fits";
+    buffer.append("stdout", payload);
+
+    const combined = buffer
+      .drain()
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    expect(combined).toBe(payload);
+    expect(combined).not.toContain("omitted");
+  });
+
+  test("keeps the trailing exit-summary visible after a head-heavy burst", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    buffer.append("stdout", "x".repeat(CAP * 3));
+    // An exit summary / final line that arrives last must remain in the tail.
+    const exitSummary = "process exited with code 0";
+    buffer.append("stderr", exitSummary);
+
+    const combined = buffer
+      .drain()
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    expect(combined).toContain(exitSummary);
+  });
+
+  test("preserves stderr stream label on truncation (not relabeled as stdout)", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    // Oversized stdout burst that forces cap enforcement, followed by a stderr
+    // exit-summary. The truncated pending region interleaves both streams; the
+    // buggy implementation collapsed everything under a hard-coded "stdout"
+    // label, silently emptying the returned stderr field.
+    buffer.append("stdout", "x".repeat(CAP * 4));
+    const errSummary = "ERROR_SUMMARY: process failed with code 2";
+    buffer.append("stderr", errSummary);
+
+    const chunks = buffer.drain();
+
+    // The stderr summary must survive in a stderr-labeled chunk, NOT be
+    // relabeled as stdout.
+    const stderrText = chunks
+      .filter((chunk) => chunk.stream === "stderr")
+      .map((chunk) => chunk.chunk)
+      .join("");
+    const stdoutText = chunks
+      .filter((chunk) => chunk.stream === "stdout")
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    expect(stderrText).toContain(errSummary);
+    expect(stderrText).not.toBe("");
+    expect(stdoutText).not.toContain(errSummary);
+  });
+
+  test("does not starve a small stderr summary that arrived BEFORE a stdout flood", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    // A program that warns to stderr first and THEN floods stdout past the cap.
+    // A proportional cap split gives stderr only ~(cap * stderrLen/totalLen)
+    // chars — near zero when stdout dwarfs it — truncating away the summary.
+    // Max-min fair allocation keeps the small stream intact.
+    const errSummary = "WARNING: deprecated flag; process exited with code 0";
+    buffer.append("stderr", errSummary);
+    buffer.append("stdout", "x".repeat(CAP * 100));
+
+    const chunks = buffer.drain();
+    const stderrText = chunks
+      .filter((chunk) => chunk.stream === "stderr")
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    // The full summary must survive verbatim regardless of arrival order.
+    expect(stderrText).toBe(errSummary);
+  });
+
+  test("never emits a negative omitted-count marker", () => {
+    const buffer = new ProcessOutputBuffer(CAP);
+
+    // A moderately sized stderr stream plus a giant stdout flood. Any per-stream
+    // budget passed to truncateHeadTail must be >= its 64-char floor so the
+    // reported omitted count can never go negative (e.g. "[... omitted -23 ...]").
+    buffer.append("stderr", "e".repeat(200));
+    buffer.append("stdout", "x".repeat(CAP * 50));
+
+    const combined = buffer
+      .drain()
+      .map((chunk) => chunk.chunk)
+      .join("");
+
+    expect(combined).not.toMatch(/omitted -\d+/);
+    // Any marker that IS present must report a positive count.
+    for (const match of combined.matchAll(/omitted (-?\d+) chars/g)) {
+      expect(Number(match[1])).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A multi-agent audit of the runtime surfaced **17 confirmed issues** (each adversarially verified). This PR fixes all of them with regression tests, then hardens the tool-permission boundary so the most serious class of bug cannot be reintroduced by a future code change.

**Verification:** `tsc --noEmit` clean; **3,771 tests across 264 files passing**, including dedicated forge/laundering/round-trip tests for the new signed-roots channel.

## Critical / High — security

- **#1 / #2 / #4 — filesystem sandbox escape via model-supplied `__agencSessionAllowedRoots`.** The `__agenc*` keys were stripped only for the schema validator, not from the object passed to `tool.execute`, so a crafted `__agencSessionAllowedRoots:["/"]` widened confinement (Read/Write/Edit/Glob/Grep/`apply_patch`). Fixed by stripping model-supplied `__agenc*` args at the dispatch boundary (`router.ts`, `run-agent.ts`) before any runtime injection; `apply_patch` now uses the trusted `allowedPaths` closure and **fails closed** on unparseable patches.
- **#3 — `--yolo` skipped path-specific Deny rules.** `bypassPermissions` short-circuited to allow before `validatePath`, ignoring `Deny(Write(...))`/`Deny(Read(...))` and the `.git`/`.agenc` write-safety gates. The bypass now runs *after* deny/safety evaluation (mirrors Bash's `hadDeny` guard).
- **#6 — MCP supply-chain pin bypassed on reconnect.** `reconnect()` rebuilt the bridge without `serverConfig`, skipping the SHA-256 catalog pin and allow/deny filter. The policy is now re-applied on every reconnection.

## Medium

| # | Fix |
|---|---|
| #5 | Thread indexing is now incremental (O(N) append) instead of O(N²) full re-index per append |
| #7 | Linux sandbox masks host `/proc` (`--tmpfs /proc`) when proc-mount is skipped; tightened `isProcMountFailure` |
| #8 | Secret sanitizer extended to xAI/Slack/Google/AWS key shapes, including the structured-object path |
| #9 | Exec output buffer preserves per-stream head/tail instead of dropping unconsumed HEAD or relabeling stderr |
| #10 | Anthropic stream adapter no longer replays already-emitted chunks on mid-stream retry |
| #11 / #12 | Durable/degraded session persistence no longer duplicates or drops events |
| #13 / #14 | App-server dispatch is ordered per connection; read buffers are byte-bounded |
| #15 / #16 | Background-task notifications are bounded; `stop()` always reaches a terminal state (no zombie tasks) |
| #17 | Recursive-fallback file watcher reconciles incrementally instead of rebuilding per event |

## Hardening — sink-enforced trusted roots

The runtime JSON-serializes tool args mid-dispatch, so an in-memory tag (Symbol/WeakMap) would be lost and the trusted channel must be JSON-serializable — which by construction a model could forge. So enforcement moved to the **sink**: runtime-injected filesystem roots are now **HMAC-signed with a per-process secret** and verified at `resolveToolAllowedPaths`. Unsigned/forged roots are dropped at the sink, so a future ingress that forgets the boundary strip **cannot reintroduce the escape**. The writer helper drops unsigned existing roots before re-signing (prevents laundering).

Also: MCP policy derivation de-duplicated (single source, cycle-free) with telemetry parity on reconnect; agent-cli read cap is now a true UTF-8 byte bound.

## Verification notes

- Every finding was adversarially verified (independent skeptics) before fixing, and every fix independently reviewed against its spec.
- Two typecheck blockers and one stream-relabeling regression were caught by the central integration gate (`tsc` + full suite), not the individual implementers — they did not run global builds.
- The signed-roots change ships with executable forge / laundering / JSON-round-trip / union tests.

⚠️ **Reviewer note:** This is a large change to the tool-permission and session layers. Despite full green tests, the HMAC signed-roots change in particular warrants a human security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
