### PR TITLE
fix(runtime): close sessionId forgery, trust-gate hooks, bound+order agent events, cap mcp buffers

### DIFF
--- a/runtime/src/agents/_deps/filesystem-args.ts
+++ b/runtime/src/agents/_deps/filesystem-args.ts
@@ -29,6 +29,7 @@
 import { randomBytes, createHmac, timingSafeEqual } from "node:crypto";
 
 export const SESSION_ID_ARG = "__agencSessionId";
+export const SESSION_ID_SIG_ARG = "__agencSessionIdSig";
 export const SESSION_ALLOWED_ROOTS_ARG = "__agencSessionAllowedRoots";
 export const SESSION_ALLOWED_ROOTS_SIG_ARG = "__agencSessionAllowedRootsSig";
 
@@ -108,5 +109,57 @@ export function withSignedAllowedRoots(
     ...args,
     [SESSION_ALLOWED_ROOTS_ARG]: unioned,
     [SESSION_ALLOWED_ROOTS_SIG_ARG]: signAllowedRoots(unioned),
+  };
+}
+
+/**
+ * SECURITY (HMAC-signed session id): the `__agencSessionId` arg names the
+ * active session whose plan-file the filesystem tools may write OUTSIDE
+ * the workspace allowlist (the plan-file carve-out in
+ * `tools/system/coding-common.ts`). A model that could forge this id
+ * would gain a write target outside its confinement, so — exactly like
+ * the trusted-roots channel above — the id is signed with the
+ * per-process secret the model never sees and verified at the SINK
+ * ({@link verifySessionId}, consumed by `planFileContextFromArgs`). An
+ * unsigned/forged id verifies as absent, denying the carve-out.
+ */
+
+/**
+ * Hex HMAC-SHA256 over the session `id`.
+ */
+export function signSessionId(id: string): string {
+  return createHmac("sha256", PROCESS_SECRET).update(id).digest("hex");
+}
+
+/**
+ * Return `id` only when it is a string and `sig` `timingSafeEqual`-matches
+ * {@link signSessionId}`(id)`. Otherwise returns `undefined` — non-string
+ * ids, missing or forged signatures are all treated as absent. The Buffer
+ * compare is length-guarded like {@link verifyAllowedRoots}.
+ */
+export function verifySessionId(id: unknown, sig: unknown): string | undefined {
+  if (typeof id !== "string" || typeof sig !== "string") return undefined;
+  const expected = signSessionId(id);
+  const sigBuf = Buffer.from(sig, "hex");
+  const expectedBuf = Buffer.from(expected, "hex");
+  if (sigBuf.length !== expectedBuf.length) return undefined;
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return undefined;
+  return id;
+}
+
+/**
+ * Writer helper: write the signed session-id channel of `args`, returning
+ * a NEW object (does not mutate input). Both {@link SESSION_ID_ARG} and
+ * {@link SESSION_ID_SIG_ARG} are set so the id verifies at the sink after
+ * the in-process JSON dispatch round-trip.
+ */
+export function withSignedSessionId(
+  args: Record<string, unknown>,
+  id: string,
+): Record<string, unknown> {
+  return {
+    ...args,
+    [SESSION_ID_ARG]: id,
+    [SESSION_ID_SIG_ARG]: signSessionId(id),
   };
 }

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -46,8 +46,8 @@ import {
   type ToolRecoveryCategory,
 } from "./_deps/tools-types.js";
 import {
-  SESSION_ID_ARG,
   withSignedAllowedRoots,
+  withSignedSessionId,
 } from "./_deps/filesystem-args.js";
 import { Session as ChildSession, type Session } from "../session/session.js";
 import { RolloutStore } from "../session/rollout-store.js";
@@ -1362,10 +1362,13 @@ function injectChildToolArgs(
   // worktree-root injection through `withSignedAllowedRoots` so the
   // union (existing signed roots ∪ worktree) is re-signed; any unsigned
   // root that slipped past the strip is dropped rather than laundered.
-  let injectedArgs: Record<string, unknown> = {
-    ...parsedArgs,
-    [SESSION_ID_ARG]: opts.childConversationId,
-  };
+  // Sign the child conversation id so the plan-file carve-out sink
+  // (coding-common.ts `planFileContextFromArgs`) honors it. An unsigned
+  // id verifies as absent there, exactly like an unsigned trusted root.
+  let injectedArgs: Record<string, unknown> = withSignedSessionId(
+    parsedArgs,
+    opts.childConversationId,
+  );
   if (opts.worktree?.path) {
     injectedArgs = withSignedAllowedRoots(injectedArgs, [opts.worktree.path]);
   }

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -331,6 +331,16 @@ interface ActiveBackgroundAgent {
   sessionBinding?: AgenCBackgroundAgentSessionEventBinding;
   bufferedEvents: BackgroundAgentDaemonEvent[];
   activeToolCallIds: Set<string>;
+  /**
+   * Per-agent emission serialization chain. `#emitOrBufferEvent` awaits
+   * an async-locked broadcast, so two fire-and-forget emits from a
+   * single callback (e.g. status + budget-usage) can otherwise complete
+   * out of order. Each emission is chained on this promise so events for
+   * ONE agent are delivered in arrival order; cross-agent concurrency is
+   * preserved because every ActiveBackgroundAgent owns its own chain.
+   * Mirrors AgenCStdioTransport's #dispatchChain (transport/stdio.ts).
+   */
+  dispatchChain: Promise<void>;
 }
 
 interface BackgroundAgentDaemonEvent {
@@ -367,6 +377,34 @@ interface AgentBudgetUsage {
 }
 
 const MAX_AGENT_BUDGET_TIMER_MS = 2_147_483_647;
+
+/**
+ * Upper bound on daemon events buffered for a single agent while no
+ * session binding is attached (and on the per-agent `#pendingEvents`
+ * detach buffer). A detached or pre-attach agent that never gets an
+ * `agent.attach` would otherwise accumulate events on the heap without
+ * limit. When the cap is exceeded the oldest events are dropped (FIFO
+ * eviction) so the newest events — the ones most useful when the TUI
+ * finally attaches — are retained. Mirrors
+ * MAX_RETAINED_NOTIFICATIONS (tasks/lifecycle.ts) and the
+ * per-session caps in agent-cli.ts / client-multiplexer.ts.
+ */
+const MAX_BUFFERED_AGENT_EVENTS = 1_000;
+
+/**
+ * Drops the oldest events in-place until `events` is within
+ * {@link MAX_BUFFERED_AGENT_EVENTS}. Returns the same array so callers
+ * can push then bound, matching `bufferSessionEvent` in
+ * client-multiplexer.ts.
+ */
+function boundBufferedAgentEvents(
+  events: BackgroundAgentDaemonEvent[],
+): BackgroundAgentDaemonEvent[] {
+  if (events.length > MAX_BUFFERED_AGENT_EVENTS) {
+    events.splice(0, events.length - MAX_BUFFERED_AGENT_EVENTS);
+  }
+  return events;
+}
 
 export interface AgenCAgentBudgetTimer {
   readonly unref?: () => void;
@@ -555,10 +593,13 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         status: "running",
         lastActiveAt: startedAt,
         uninstallApprovalBridge,
-        bufferedEvents: this.#pendingEvents.get(managedThread.threadId) ?? [],
+        bufferedEvents: boundBufferedAgentEvents(
+          this.#pendingEvents.get(managedThread.threadId) ?? [],
+        ),
         activeToolCallIds:
           this.#pendingActiveToolCallIds.get(managedThread.threadId) ??
           new Set(),
+        dispatchChain: Promise.resolve(),
       };
       this.#installAgentBudget(active, {
         startedAt,
@@ -783,9 +824,12 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         status: "running",
         lastActiveAt: restoredAt,
         uninstallApprovalBridge,
-        bufferedEvents: this.#pendingEvents.get(params.agentId) ?? [],
+        bufferedEvents: boundBufferedAgentEvents(
+          this.#pendingEvents.get(params.agentId) ?? [],
+        ),
         activeToolCallIds:
           this.#pendingActiveToolCallIds.get(params.agentId) ?? new Set(),
+        dispatchChain: Promise.resolve(),
       };
       this.#installAgentBudget(active, {
         startedAt,
@@ -1390,7 +1434,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         if (bufferedEvents.length > 0) {
           const pending = this.#pendingEvents.get(agentId) ?? [];
           pending.push(...bufferedEvents);
-          this.#pendingEvents.set(agentId, pending);
+          this.#pendingEvents.set(agentId, boundBufferedAgentEvents(pending));
         } else {
           this.#pendingEvents.delete(agentId);
         }
@@ -1414,7 +1458,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       if (event !== null) {
         const pending = this.#pendingEvents.get(agentId) ?? [];
         pending.push(event);
-        this.#pendingEvents.set(agentId, pending);
+        this.#pendingEvents.set(agentId, boundBufferedAgentEvents(pending));
       }
       return;
     }
@@ -1435,7 +1479,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     if (active === undefined) {
       const pending = this.#pendingEvents.get(agentId) ?? [];
       pending.push(event);
-      this.#pendingEvents.set(agentId, pending);
+      this.#pendingEvents.set(agentId, boundBufferedAgentEvents(pending));
       return;
     }
     await this.#emitOrBufferEvent(
@@ -1623,11 +1667,25 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     event: BackgroundAgentDaemonEvent | null,
   ): Promise<void> {
     if (event === null) return;
-    if (active.sessionBinding === undefined) {
-      active.bufferedEvents.push(event);
-      return;
-    }
-    await this.#emitDaemonEvent(active, event);
+    // Serialize emission per agent on the agent's dispatch chain. Several
+    // call sites are fire-and-forget (`void this.#emitOrBufferEvent(...)`)
+    // and `#emitDaemonEvent` awaits an async-locked broadcast, so two
+    // emits from one callback could otherwise complete out of order.
+    // Chaining keeps per-agent delivery in arrival order while preserving
+    // cross-agent concurrency (each agent owns its own chain). A rejection
+    // is isolated to the awaiting caller and never poisons the chain for
+    // later events. Mirrors AgenCStdioTransport.#dispatchChain.
+    let emitError: unknown;
+    let raised = false;
+    const tail = active.dispatchChain.then(() =>
+      this.#emitDaemonEvent(active, event).catch((error: unknown) => {
+        emitError = error;
+        raised = true;
+      }),
+    );
+    active.dispatchChain = tail;
+    await tail;
+    if (raised) throw emitError;
   }
 
   async #emitDaemonEvent(
@@ -1637,6 +1695,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     const binding = active.sessionBinding;
     if (binding === undefined) {
       active.bufferedEvents.push(event);
+      boundBufferedAgentEvents(active.bufferedEvents);
       return;
     }
     await binding.emit(

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2019,7 +2019,10 @@ function createNotebookReadTool(opts: ModelFacingToolOptions): Tool {
         file_path: filePath,
         offset: args.offset,
         limit: args.limit,
+        // Forward BOTH the id and its signature so the plan-file carve-out
+        // sink still verifies (forwarding the bare id would strand the sig).
         __agencSessionId: args.__agencSessionId,
+        __agencSessionIdSig: args.__agencSessionIdSig,
       });
     },
   };

--- a/runtime/src/hooks/configured-hooks.ts
+++ b/runtime/src/hooks/configured-hooks.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import type { HookEventName, HooksMap } from "../config/schema.js";
@@ -19,6 +20,7 @@ import type {
   StopRequest,
 } from "../phases/stop-hooks.js";
 import { hookMatcherInputsForToolName } from "../permissions/hook-event-schedule.js";
+import { isProjectTrustedSync } from "../permissions/trust/project-trust.js";
 import type { UserPromptSubmitHook } from "./user-prompt-submit.js";
 import type {
   HookResult,
@@ -87,12 +89,35 @@ export interface ConfiguredHooksRuntimeOptions {
   readonly env: NodeJS.ProcessEnv;
   readonly agencHome: string;
   readonly shellPath: string;
+  /**
+   * SECURITY: trust gate for config/plugin-sourced command hooks. Returns true
+   * when the current workspace is trusted (persisted in trusted-projects.json).
+   * Defaults to the real project-trust lookup; injectable for tests. Hooks
+   * declared in config.toml or plugins execute arbitrary shell commands, so a
+   * freshly-cloned untrusted repo must NOT be able to run them (RCE).
+   */
+  readonly isWorkspaceTrusted?: () => boolean;
+}
+
+/**
+ * SECURITY opt-in: when set to a truthy value ("1"/"true"), config/plugin
+ * command hooks are allowed to run even in an UNTRUSTED workspace. This exists
+ * for headless/SDK automation that has already vetted the workspace out-of-band.
+ * Default (unset) = untrusted workspaces never run command hooks.
+ */
+const ALLOW_UNTRUSTED_HOOKS_ENV = "AGENC_ALLOW_UNTRUSTED_HOOKS";
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
 export class ConfiguredHooksRuntime {
   private readonly engine: HookEngine;
   private validationIssues: HookValidationIssue[] = [];
   private target: HookInstallTarget | null = null;
+  private readonly isWorkspaceTrusted: () => boolean;
 
   constructor(private readonly opts: ConfiguredHooksRuntimeOptions) {
     this.engine = new HookEngine({
@@ -101,6 +126,14 @@ export class ConfiguredHooksRuntime {
       shellPath: opts.shellPath,
       sourcePath: this.sourcePath(),
     });
+    this.isWorkspaceTrusted =
+      opts.isWorkspaceTrusted ??
+      (() =>
+        isProjectTrustedSync({
+          cwd: opts.cwd,
+          agencHome: opts.agencHome,
+          env: opts.env,
+        }));
   }
 
   attachTarget(target: HookInstallTarget): void {
@@ -653,7 +686,29 @@ export class ConfiguredHooksRuntime {
     input: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<HookCommandRunDiagnostic> {
+    // SECURITY: config/plugin-sourced command hooks run arbitrary shell commands
+    // (engine/command-runner.ts spawn(shell, ["-c", command])). A freshly-cloned
+    // untrusted repo's config.toml must NOT be able to execute host code. Gate
+    // every spawn behind workspace trust; allow untrusted only via explicit
+    // AGENC_ALLOW_UNTRUSTED_HOOKS opt-in (headless/SDK that vetted the workspace).
+    if (!this.shouldRunUntrustedSafe()) {
+      return skippedUntrustedDiagnostic(hook);
+    }
     return this.engine.runCommandHook(hook, input, signal, inputCwd(input));
+  }
+
+  /**
+   * Returns true when configured command hooks are permitted to execute: either
+   * the workspace is trusted, or the AGENC_ALLOW_UNTRUSTED_HOOKS opt-in is set.
+   */
+  private shouldRunUntrustedSafe(): boolean {
+    if (this.isWorkspaceTrusted()) {
+      return true;
+    }
+    if (isTruthyEnvFlag(this.opts.env[ALLOW_UNTRUSTED_HOOKS_ENV])) {
+      return true;
+    }
+    return false;
   }
 
   private recordHookOutputIssue(
@@ -729,6 +784,31 @@ export function hookDisplayText(hook: IndividualHookConfig): string {
 
 function hookCommandLabel(hook: IndividualHookConfig): string {
   return redactSecrets(hook.command.statusMessage ?? hook.command.command);
+}
+
+/**
+ * Synthetic "skipped" diagnostic returned when a config/plugin command hook is
+ * NOT executed because the workspace is untrusted. Mirrors the shape the engine
+ * produces for disabled hooks so downstream parsers treat it as a no-op (the
+ * command is never spawned).
+ */
+function skippedUntrustedDiagnostic(
+  hook: IndividualHookConfig,
+): HookCommandRunDiagnostic {
+  return {
+    id: randomUUID(),
+    event: hook.event,
+    ...(hook.matcher !== undefined ? { matcher: hook.matcher } : {}),
+    command: redactSecrets(hook.command.command),
+    status: "skipped",
+    durationMs: 0,
+    stdout: "",
+    stderr: "",
+    error: "skipped: workspace not trusted (set AGENC_ALLOW_UNTRUSTED_HOOKS=1 to override)",
+    startedAtUnixMs: Date.now(),
+    rawStdout: "",
+    rawStderr: "",
+  };
 }
 
 function matchesToolMatcher(toolName: string, matcher?: string): boolean {

--- a/runtime/src/mcp-client/transports/stdio.ts
+++ b/runtime/src/mcp-client/transports/stdio.ts
@@ -27,6 +27,16 @@ import { configureMcpElicitationClient } from "../../elicitation/mcp.js";
 
 const PROCESS_GROUP_TERM_GRACE_MS = 2_000;
 
+/**
+ * Upper bound on the unflushed stderr buffer. A trusted local child is the
+ * normal case, but a child that emits a very long stderr line with no newline
+ * would otherwise grow `stderrBuffer` without bound. Once the accumulated
+ * newline-less bytes exceed this cap, the oversized prefix is flushed (logged
+ * with a truncation notice) rather than retained, keeping memory bounded while
+ * preserving the existing newline-delimited line-splitting behavior.
+ */
+const STDERR_BUFFER_MAX_BYTES = 1024 * 1024;
+
 export const DEFAULT_STDIO_ENV_VARS: readonly string[] =
   process.platform === "win32"
     ? [
@@ -274,6 +284,18 @@ export class AgenCStdioClientTransport implements Transport {
       const line = this.stderrBuffer.subarray(0, index).toString("utf8").replace(/\r$/, "");
       this.stderrBuffer = this.stderrBuffer.subarray(index + 1);
       this.logger.info(`MCP server stderr (${this.server.command}): ${line}`);
+    }
+    // Defense-in-depth: a child that streams stderr without a newline would
+    // otherwise grow stderrBuffer without bound. Once the unterminated residue
+    // exceeds the cap, flush the oversized prefix with a truncation notice so
+    // memory stays bounded; any trailing bytes keep accumulating toward the
+    // next newline as before.
+    if (this.stderrBuffer.length > STDERR_BUFFER_MAX_BYTES) {
+      const truncated = this.stderrBuffer.subarray(0, STDERR_BUFFER_MAX_BYTES).toString("utf8");
+      this.stderrBuffer = this.stderrBuffer.subarray(STDERR_BUFFER_MAX_BYTES);
+      this.logger.info(
+        `MCP server stderr (${this.server.command}) [truncated ${STDERR_BUFFER_MAX_BYTES} bytes, no newline]: ${truncated}`,
+      );
     }
   };
 

--- a/runtime/src/mcp-server/stdio.ts
+++ b/runtime/src/mcp-server/stdio.ts
@@ -7,6 +7,7 @@
  *     and permission integration are later MS-* items.
  */
 
+import { Buffer } from "node:buffer";
 import { createInterface, type Interface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
 import {
@@ -15,12 +16,24 @@ import {
 } from "./framework.js";
 import type { McpOutgoingMessage } from "./types.js";
 
+/**
+ * Default upper bound on a single unterminated input line, mirroring the
+ * app-server stdio transport's `AGENC_STDIO_DEFAULT_MAX_LINE_BYTES`. Node's
+ * readline imposes no maximum line length, so a peer that streams bytes
+ * without ever emitting a newline would grow the readline internal buffer
+ * (and MCP server memory) unbounded. The transport tracks the bytes seen
+ * since the last newline and tears the connection down once this cap is
+ * exceeded, treating it as a fatal framing violation.
+ */
+export const AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES = 16 * 1024 * 1024;
+
 export interface McpStdioServerTransportOptions {
   readonly input: Readable;
   readonly output: Writable;
   readonly server: McpServerFramework;
   readonly onError?: (error: Error, line?: string) => void;
   readonly onClose?: () => void;
+  readonly maxLineBytes?: number;
 }
 
 export class McpStdioServerTransport {
@@ -52,10 +65,39 @@ export class McpStdioServerTransport {
     });
     this.#reader = reader;
 
+    // Node's readline does not enforce a maximum line length, so a peer that
+    // streams bytes without ever emitting a newline would grow the internal
+    // line buffer (and MCP server memory) unbounded. Track the number of bytes
+    // accumulated since the last newline and tear the connection down once it
+    // exceeds the cap, mirroring the app-server stdio transport.
+    const maxLineBytes =
+      this.#options.maxLineBytes ?? AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES;
+    let unterminatedBytes = 0;
+    const onData = (chunk: Buffer | string): void => {
+      const data =
+        typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+      const lastNewline = data.lastIndexOf(0x0a);
+      if (lastNewline === -1) {
+        unterminatedBytes += data.length;
+      } else {
+        unterminatedBytes = data.length - lastNewline - 1;
+      }
+      if (unterminatedBytes > maxLineBytes) {
+        this.#options.onError?.(
+          new RangeError(
+            `AgenC MCP stdio transport line exceeded ${maxLineBytes} bytes without a newline`,
+          ),
+        );
+        this.#options.input.destroy();
+      }
+    };
+    this.#options.input.on("data", onData);
+
     reader.on("line", (line) => {
       this.#enqueueLine(line);
     });
     reader.once("close", () => {
+      this.#options.input.off("data", onData);
       this.#reader = null;
       this.#closed = true;
       this.#notifyCloseAfterQueue();

--- a/runtime/src/memory/session/sessionMemory.ts
+++ b/runtime/src/memory/session/sessionMemory.ts
@@ -28,12 +28,12 @@ import type { Session } from "../../session/session.js";
 import { FILE_EDIT_TOOL_NAME } from "../../tools/system/file-edit.js";
 import { createFileReadTool } from "../../tools/system/file-read.js";
 import {
-  SESSION_ID_ARG,
   recordSessionRead,
   seedSessionReadState,
   withSignedAllowedRoots,
   type SessionReadSeedEntry,
 } from "../../tools/system/filesystem.js";
+import { withSignedSessionId } from "../../agents/_deps/filesystem-args.js";
 import type { Tool } from "../../tools/types.js";
 import { buildSessionMemoryUpdatePrompt, loadSessionMemoryTemplate } from "./prompts.js";
 import {
@@ -330,10 +330,7 @@ export async function setupSessionMemoryFile(
   });
   const readResult = await readTool.execute(
     withSignedAllowedRoots(
-      {
-        file_path: memoryPath,
-        [SESSION_ID_ARG]: options.sessionId,
-      },
+      withSignedSessionId({ file_path: memoryPath }, options.sessionId),
       [memoryDir],
     ),
   );

--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -79,6 +79,8 @@ import {
 } from "../../tools/orchestrator.js";
 import {
   SESSION_AGENC_HOME_ARG,
+  SESSION_ID_SIG_ARG,
+  signSessionId,
   withSignedAllowedRoots,
 } from "../../tools/system/filesystem.js";
 import {
@@ -972,7 +974,10 @@ export class StreamingToolExecutor {
                   ? { [SESSION_AGENC_HOME_ARG]: this.liveOptions.agencHome }
                   : {}),
                 ...(sessionId !== null
-                  ? { __agencSessionId: sessionId }
+                  ? {
+                      __agencSessionId: sessionId,
+                      [SESSION_ID_SIG_ARG]: signSessionId(sessionId),
+                    }
                   : {}),
               });
             },

--- a/runtime/src/tools/canonicalToolSurface.ts
+++ b/runtime/src/tools/canonicalToolSurface.ts
@@ -9,7 +9,7 @@ import { createFileReadTool } from "./system/file-read.js";
 import { createFileWriteTool } from "./system/file-write.js";
 import { createGlobTool } from "./system/glob.js";
 import { createGrepTool } from "./system/grep.js";
-import { SESSION_ID_ARG } from "./system/filesystem.js";
+import { withSignedSessionId } from "../agents/_deps/filesystem-args.js";
 import { createNotebookEditTool as createSystemNotebookEditTool } from "./system/notebook-edit.js";
 import type { Tool as RuntimeTool, ToolResult as RuntimeToolResult } from "./types.js";
 import { buildTool, type Tool, type ToolCallProgress, type ToolUseContext } from "./Tool.js";
@@ -451,14 +451,17 @@ function mapCanonicalInput(
   root: string,
 ): Record<string, unknown> {
   const mapped = options.mapInput?.(input, root) ?? defaultMapInput(input, root);
-  const suppliedSessionId = input[SESSION_ID_ARG];
-  return {
-    ...mapped,
-    [SESSION_ID_ARG]:
-      typeof suppliedSessionId === "string" && suppliedSessionId.trim().length > 0
-        ? suppliedSessionId
-        : getSessionId(),
-  };
+  // SECURITY: always inject the AUTHORITATIVE session id from the runtime
+  // state (`getSessionId()`), never the model-supplied `input[...]` value.
+  // The model arg could otherwise name an arbitrary session and unlock its
+  // plan-file write carve-out (coding-common.ts `planFileContextFromArgs`).
+  // The id is HMAC-signed so it verifies at that sink; if there is no
+  // authoritative id, we inject nothing (no model-value fallback).
+  const authoritativeSessionId = getSessionId();
+  return typeof authoritativeSessionId === "string" &&
+    authoritativeSessionId.trim().length > 0
+    ? withSignedSessionId(mapped, authoritativeSessionId)
+    : mapped;
 }
 
 const fileReadInputSchema = z.strictObject({

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -80,6 +80,10 @@ import {
 } from "./context.js";
 import type { Tool } from "./types.js";
 import {
+  SESSION_ID_SIG_ARG,
+  signSessionId,
+} from "./system/filesystem.js";
+import {
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
   runPreToolUseHooks,
@@ -1525,6 +1529,15 @@ export async function runToolUse(
     if (typeof sessionId === "string" && sessionId.length > 0) {
       Object.defineProperty(argsForTool, "__agencSessionId", {
         value: sessionId,
+        enumerable: false,
+        writable: false,
+        configurable: true,
+      });
+      // Sign the id (same per-process secret as the trusted-roots channel)
+      // so the plan-file carve-out sinks honor this runtime-injected id; an
+      // unsigned/forged id is rejected at the sink.
+      Object.defineProperty(argsForTool, SESSION_ID_SIG_ARG, {
+        value: signSessionId(sessionId),
         enumerable: false,
         writable: false,
         configurable: true,

--- a/runtime/src/tools/system/coding-common.ts
+++ b/runtime/src/tools/system/coding-common.ts
@@ -6,6 +6,11 @@ import {
 } from "node:path";
 
 import {
+  SESSION_ID_ARG,
+  SESSION_ID_SIG_ARG,
+  verifySessionId,
+} from "../../agents/_deps/filesystem-args.js";
+import {
   isSessionPlanFile,
   type PlanFileContext,
 } from "../../planning/plan-files.js";
@@ -26,15 +31,19 @@ import {
  * allowlist it regardless of the workspace allowlist — mirrors
  * AgenC's `checkEditableInternalPath` carve-out
  * (utils/permissions/filesystem.ts:1488-1506).
+ *
+ * SECURITY: this carve-out grants a WRITE target outside the workspace
+ * allowlist, so the session id must come from a TRUSTED source. We verify
+ * the HMAC signature ({@link verifySessionId}) the runtime attaches via
+ * `withSignedSessionId`; an unsigned/forged `__agencSessionId` (e.g. a
+ * model-supplied value) verifies as absent and yields no carve-out.
  */
 function planFileContextFromArgs(
   args: Record<string, unknown>,
 ): PlanFileContext | null {
+  const verified = verifySessionId(args[SESSION_ID_ARG], args[SESSION_ID_SIG_ARG]);
   const sessionId =
-    typeof args.__agencSessionId === "string" &&
-    args.__agencSessionId.trim().length > 0
-      ? args.__agencSessionId
-      : null;
+    typeof verified === "string" && verified.trim().length > 0 ? verified : null;
   if (sessionId === null) return null;
   const ctx: PlanFileContext = { sessionId };
   if (

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -51,21 +51,30 @@ import {
 import {
   SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ALLOWED_ROOTS_SIG_ARG,
+  SESSION_ID_SIG_ARG,
   signAllowedRoots,
+  signSessionId,
   verifyAllowedRoots,
+  verifySessionId,
   withSignedAllowedRoots,
+  withSignedSessionId,
 } from "../../agents/_deps/filesystem-args.js";
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 
-// Re-export the HMAC-signed trusted-roots channel constants/helpers so
-// existing importers of `filesystem.ts` keep a single source.
+// Re-export the HMAC-signed trusted-roots and session-id channel
+// constants/helpers so existing importers of `filesystem.ts` keep a
+// single source.
 export {
   SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ALLOWED_ROOTS_SIG_ARG,
+  SESSION_ID_SIG_ARG,
   signAllowedRoots,
+  signSessionId,
   verifyAllowedRoots,
+  verifySessionId,
   withSignedAllowedRoots,
+  withSignedSessionId,
 };
 
 const MAX_LIST_ENTRIES = 10_000;
@@ -780,10 +789,18 @@ function planFileContextFromArgs(
   args: Record<string, unknown> | undefined,
 ): PlanFileContext | null {
   if (!args) return null;
+  // SECURITY: honor the session id (which unlocks the plan-file carve-out
+  // OUTSIDE the workspace allowlist) ONLY when it carries a valid
+  // per-process HMAC signature. An unsigned/forged id verifies as absent,
+  // so a model cannot forge a write target. Mirrors the sink in
+  // `coding-common.ts:planFileContextFromArgs`.
+  const verified = verifySessionId(
+    args[SESSION_ID_ARG],
+    args[SESSION_ID_SIG_ARG],
+  );
   const sessionId =
-    typeof args.__agencSessionId === "string" &&
-    args.__agencSessionId.trim().length > 0
-      ? args.__agencSessionId
+    typeof verified === "string" && verified.trim().length > 0
+      ? verified
       : null;
   if (sessionId === null) return null;
   const ctx: PlanFileContext = { sessionId };

--- a/runtime/src/utils/hooks.ts
+++ b/runtime/src/utils/hooks.ts
@@ -38,6 +38,7 @@ import {
   getMainThreadAgentType,
 } from '../bootstrap/state.js'
 import { checkHasTrustDialogAccepted } from './config.js'
+import { checkHasProjectTrustAcceptedSync } from '../permissions/trust/project-trust.js'
 import {
   getHooksConfigFromSnapshot,
   shouldAllowManagedHooksOnly,
@@ -430,19 +431,40 @@ function executeInBackground({
  * Historical vulnerabilities that prompted this check:
  * - SessionEnd hooks executing when user declines trust dialog
  * - SubagentStop hooks executing when subagent completes before trust
+ * - Non-interactive/SDK sessions running hooks from an untrusted, freshly-cloned
+ *   repo's config with no trust gate at all (RCE).
  *
  * @returns true if hook should be skipped, false if it should execute
  */
 export function shouldSkipHookDueToTrust(): boolean {
-  // In non-interactive mode (SDK), trust is implicit - always execute
   const isInteractive = !getIsNonInteractiveSession()
   if (!isInteractive) {
-    return false
+    // SECURITY: non-interactive/SDK mode has no trust dialog. It must NOT
+    // implicitly trust the workspace — a freshly-cloned untrusted repo's config
+    // would otherwise execute host code. Default to running hooks ONLY when the
+    // workspace is persisted as trusted (trusted-projects.json). An UNTRUSTED
+    // workspace runs hooks only via the explicit AGENC_ALLOW_UNTRUSTED_HOOKS
+    // opt-in (headless automation that vetted the workspace out-of-band).
+    if (allowUntrustedHooksOptIn()) {
+      return false
+    }
+    return !checkHasProjectTrustAcceptedSync()
   }
 
   // In interactive mode, ALL hooks require trust
   const hasTrust = checkHasTrustDialogAccepted()
   return !hasTrust
+}
+
+/**
+ * SECURITY opt-in: AGENC_ALLOW_UNTRUSTED_HOOKS="1"|"true"|"yes" permits command
+ * hooks to run even in an untrusted workspace. Intended for headless/SDK
+ * automation that has already vetted the workspace. Unset (default) keeps
+ * untrusted workspaces from running command hooks.
+ */
+function allowUntrustedHooksOptIn(): boolean {
+  const value = process.env.AGENC_ALLOW_UNTRUSTED_HOOKS?.trim().toLowerCase()
+  return value === '1' || value === 'true' || value === 'yes'
 }
 
 /**

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -59,6 +59,7 @@ import {
   verifyAllowedRoots,
   withSignedAllowedRoots,
 } from "../tools/system/filesystem.js";
+import { signSessionId } from "../agents/_deps/filesystem-args.js";
 import { createApplyPatchTool } from "../tools/apply-patch/tool.js";
 import { cloneFileStateCache } from "../utils/fileStateCache.js";
 
@@ -879,7 +880,9 @@ describe("runAgent", () => {
       // Model's "/" stripped; runtime worktree injected and HMAC-signed.
       __agencSessionAllowedRoots: ["/tmp/subagent-wt"],
       __agencSessionAllowedRootsSig: signAllowedRoots(["/tmp/subagent-wt"]),
+      // Session id injected via withSignedSessionId — id + HMAC signature.
       __agencSessionId: "child-123",
+      __agencSessionIdSig: signSessionId("child-123"),
     });
     // The signed channel verifies and the model's "/" never enters it.
     const forwardedArgs = JSON.parse(forwarded.arguments) as Record<
@@ -1104,6 +1107,7 @@ describe("runAgent", () => {
       value: 1,
       __agencSessionAllowedRoots: ["/tmp/memory"],
       __agencSessionId: "child-123",
+      __agencSessionIdSig: signSessionId("child-123"),
     });
   });
 

--- a/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AgenCDelegateBackgroundAgentRunner,
+  type AgenCBootstrapFunction,
+  type AgenCEnsureAgentControlFunction,
+} from "./background-agent-runner.js";
+import type { AgentStatus } from "../agents/status.js";
+import {
+  createEmptyToolPermissionContext,
+  type ToolPermissionContext,
+} from "../permissions/types.js";
+
+// Mirrors the harness in background-agent-runner.contract.test.ts; trimmed to
+// the surface these regression tests exercise (status pushes + attach).
+function makeStubConversationThreadManager(opts: {
+  readonly threadId: string;
+}) {
+  let listeners: ((status: AgentStatus) => void)[] = [];
+  let currentStatus: AgentStatus = {
+    status: "running",
+    turnId: "turn-stub",
+    startedAtMs: 0,
+  } as AgentStatus;
+  const managedThread = {
+    threadId: opts.threadId,
+    agentPath: "/root",
+    kind: "root" as const,
+    status: () => currentStatus,
+    subscribeStatus: (cb: (status: AgentStatus) => void) => {
+      cb(currentStatus);
+      listeners.push(cb);
+      return () => {
+        listeners = listeners.filter((listener) => listener !== cb);
+      };
+    },
+    submit: vi.fn(async () => opts.threadId),
+    appendMessage: vi.fn(async () => opts.threadId),
+    shutdown: vi.fn(async () => {}),
+    totalTokenUsage: () => ({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    }),
+    configSnapshot: () => ({}),
+  };
+  return {
+    hasThread: (id: string) => id === opts.threadId,
+    getThread: (id: string) => {
+      if (id !== opts.threadId) {
+        throw new Error(`stub conversationThreadManager has no thread ${id}`);
+      }
+      return managedThread;
+    },
+    removeThread: vi.fn(() => managedThread),
+    pushStatus(next: AgentStatus) {
+      currentStatus = next;
+      for (const cb of [...listeners]) cb(next);
+    },
+    thread: managedThread,
+  };
+}
+
+function makeTopLevelRunner(opts: { readonly conversationId: string }) {
+  const permissionModeRegistry = {
+    current: () => createEmptyToolPermissionContext(),
+    update: vi.fn(async (_context: ToolPermissionContext) => {}),
+  };
+  const stub = makeStubConversationThreadManager({
+    threadId: opts.conversationId,
+  });
+  const session = {
+    conversationId: opts.conversationId,
+    permissionModeRegistry,
+    subscribeToEvents: () => () => {},
+    emitPhaseEvent: () => {},
+    services: { conversationThreadManager: stub },
+  };
+  const control = {
+    shutdown: vi.fn(async () => {}),
+    sendInput: vi.fn(async () => {}),
+    interrupt: vi.fn(),
+    clearConversationHistory: vi.fn(async () => {}),
+  };
+  const bootstrap = vi.fn(async () => ({
+    session,
+    registry: { tools: [], toLLMTools: () => [], dispatch: vi.fn() },
+    shutdown: vi.fn(async () => {}),
+  })) as unknown as ReturnType<typeof vi.fn> & AgenCBootstrapFunction;
+  const runner = new AgenCDelegateBackgroundAgentRunner({
+    bootstrap,
+    ensureAgentControl: vi.fn(() => ({
+      control,
+      registry: {},
+    })) as unknown as AgenCEnsureAgentControlFunction,
+    now: () => "2026-05-09T00:00:00.000Z",
+  });
+  return { runner, stub, control };
+}
+
+function runningStatus(turnId: string, startedAtMs: number): AgentStatus {
+  return { status: "running", turnId, startedAtMs } as AgentStatus;
+}
+
+describe("AgenC background-agent runner: bounded + ordered events", () => {
+  it("evicts oldest buffered events once the per-agent cap is exceeded (FIFO, newest retained)", async () => {
+    const { runner, stub } = makeTopLevelRunner({
+      conversationId: "session-bounded",
+    });
+    await runner.startAgent({
+      objective: "buffer storm",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    // No session binding is attached yet, so every status event buffers in
+    // the agent's bufferedEvents array. Push far more than the 1000-event
+    // cap with uniquely-identifiable turn ids so we can assert which
+    // survive eviction.
+    const PUSH_COUNT = 2_500;
+    for (let i = 0; i < PUSH_COUNT; i += 1) {
+      stub.pushStatus(runningStatus(`turn-${i}`, i + 1));
+    }
+
+    // Status emits are chained per-agent and resolve on the microtask
+    // queue; let the whole buffering chain settle before attaching so the
+    // events are buffered (and bounded) rather than emitted live.
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    const emitted: Array<{ eventId?: unknown }> = [];
+    await runner.attachAgentSessionEvents("session-bounded", {
+      sessionId: "session_1",
+      emit: (event) => {
+        const params = (event as { params?: { eventId?: unknown } }).params;
+        emitted.push({ eventId: params?.eventId });
+      },
+    });
+
+    // The buffer is bounded: it never grows without limit regardless of how
+    // many events were pushed pre-attach.
+    expect(emitted.length).toBeLessThanOrEqual(1_000);
+    expect(emitted.length).toBeGreaterThan(0);
+
+    // FIFO eviction keeps the NEWEST events. The final push (turn-2499) must
+    // survive; an old event well beyond the cap (turn-0) must have been
+    // dropped.
+    const survivingIds = new Set(emitted.map((event) => event.eventId));
+    expect(survivingIds.has(`turn-${PUSH_COUNT - 1}`)).toBe(true);
+    expect(survivingIds.has("turn-0")).toBe(false);
+
+    // Surviving events remain in arrival order (oldest-kept first).
+    const turnNumbers = emitted
+      .map((event) =>
+        typeof event.eventId === "string" && event.eventId.startsWith("turn-")
+          ? Number.parseInt(event.eventId.slice("turn-".length), 10)
+          : Number.NaN,
+      )
+      .filter((value) => Number.isFinite(value));
+    for (let i = 1; i < turnNumbers.length; i += 1) {
+      expect(turnNumbers[i]!).toBeGreaterThan(turnNumbers[i - 1]!);
+    }
+  });
+
+  it("delivers emissions for one agent in arrival order even when an earlier emit's broadcast is slow", async () => {
+    const { runner, stub } = makeTopLevelRunner({
+      conversationId: "session-ordered",
+    });
+    await runner.startAgent({
+      objective: "ordering",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    // Gate the `turn-first` broadcast on a deferred so it completes AFTER
+    // the `turn-second` broadcast would otherwise resolve. Without per-agent
+    // serialization the two fire-and-forget status emits would race and the
+    // second event could be delivered before the first.
+    const delivered: string[] = [];
+    let releaseFirstEmit: (() => void) | undefined;
+    const firstEmitGate = new Promise<void>((resolve) => {
+      releaseFirstEmit = resolve;
+    });
+    await runner.attachAgentSessionEvents("session-ordered", {
+      sessionId: "session_1",
+      emit: async (event) => {
+        const eventId = String(
+          (event as { params?: { eventId?: unknown } }).params?.eventId,
+        );
+        if (eventId === "turn-first") {
+          // First of the two contended broadcasts is slow.
+          await firstEmitGate;
+        }
+        delivered.push(eventId);
+      },
+    });
+
+    // Two fire-and-forget status emits arrive back to back via the same
+    // status-subscription callback path (#trackAgentStatus).
+    stub.pushStatus(runningStatus("turn-first", 1));
+    stub.pushStatus(runningStatus("turn-second", 2));
+
+    // Let the second emit have every opportunity to overtake the first.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    // turn-second must NOT be delivered while turn-first is still gated.
+    expect(delivered).not.toContain("turn-second");
+
+    releaseFirstEmit?.();
+    // Drain the chain.
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    const contended = delivered.filter(
+      (id) => id === "turn-first" || id === "turn-second",
+    );
+    expect(contended).toEqual(["turn-first", "turn-second"]);
+  });
+});

--- a/runtime/tests/bin/bootstrap-services.test.ts
+++ b/runtime/tests/bin/bootstrap-services.test.ts
@@ -17,6 +17,7 @@ import {
   type HookInstallTarget,
 } from "../hooks/configured-hooks.js";
 import { defaultConfig } from "../config/schema.js";
+import { trustProjectSync } from "../permissions/trust/project-trust.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import type { PostToolUseHook } from "../tools/hooks.js";
@@ -157,6 +158,9 @@ describe("SessionStart bootstrap hooks", () => {
     mockPolicyLimits();
     const home = mkdtempSync(join(tmpdir(), "agenc-sessionstart-home-"));
     const workspace = mkdtempSync(join(tmpdir(), "agenc-sessionstart-ws-"));
+    // SessionStart command hooks now require a trusted workspace (production
+    // establishes trust before bootstrap dispatches them); mark it trusted.
+    trustProjectSync({ cwd: workspace, agencHome: home });
     const config = {
       ...defaultConfig(),
       agentRoles: [],

--- a/runtime/tests/hooks/configured-hooks.test.ts
+++ b/runtime/tests/hooks/configured-hooks.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -24,6 +25,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target = {
@@ -63,6 +68,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     runtime.load({
@@ -82,6 +91,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     runtime.load({
@@ -136,6 +149,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -231,6 +248,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -276,6 +297,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -318,6 +343,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -359,6 +388,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -395,6 +428,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -431,6 +468,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -477,6 +518,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -518,6 +563,10 @@ describe("configured hooks runtime", () => {
       cwd: "/tmp",
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -563,6 +612,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -605,6 +658,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -647,6 +704,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -689,6 +750,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -736,6 +801,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -772,6 +841,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -815,6 +888,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -851,6 +928,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -888,6 +969,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -931,6 +1016,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -966,6 +1055,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1004,6 +1097,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1048,6 +1145,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1092,6 +1193,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1139,6 +1244,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1184,6 +1293,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1239,6 +1352,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1284,6 +1401,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1319,6 +1440,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1368,6 +1493,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1406,6 +1535,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1436,6 +1569,10 @@ describe("configured hooks runtime", () => {
       cwd: "/tmp",
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1488,6 +1625,10 @@ describe("configured hooks runtime", () => {
       cwd: tmpdir(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1531,6 +1672,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1574,6 +1719,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1608,6 +1757,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1643,6 +1796,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1669,6 +1826,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1710,6 +1871,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = makeTarget();
@@ -1752,6 +1917,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target = makeLifecycleTarget();
@@ -1792,6 +1961,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target = makeLifecycleTarget();
@@ -1823,6 +1996,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target = makeLifecycleTarget();
@@ -1870,6 +2047,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     runtime.load({
@@ -1920,6 +2101,10 @@ describe("configured hooks runtime", () => {
       cwd: process.cwd(),
       env: process.env,
       agencHome: "/tmp/agenc-test",
+      // Existing behavioral tests assume a TRUSTED workspace (production
+      // establishes trust through the normal flow before hooks run). The new
+      // trust gate is exercised separately in the "trust gate" describe block.
+      isWorkspaceTrusted: () => true,
       shellPath: process.env.SHELL ?? "/bin/sh",
     });
     const target: HookInstallTarget = {
@@ -1949,6 +2134,128 @@ describe("configured hooks runtime", () => {
     });
 
     expect(signal.listenerCount).toBe(0);
+  });
+});
+
+describe("configured hooks trust gate", () => {
+  async function tempSentinel(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "agenc-trust-gate-"));
+    return join(dir, "ran.txt");
+  }
+
+  function touchCommand(sentinel: string): string {
+    // Side effect that ONLY happens if the shell command actually spawns.
+    return `printf ran > ${JSON.stringify(sentinel)}`;
+  }
+
+  function makeRuntime(opts: {
+    readonly trusted: boolean;
+    readonly env?: NodeJS.ProcessEnv;
+    readonly sentinel: string;
+  }): ConfiguredHooksRuntime {
+    const runtime = new ConfiguredHooksRuntime({
+      cwd: process.cwd(),
+      env: opts.env ?? {},
+      agencHome: "/tmp/agenc-test",
+      shellPath: process.env.SHELL ?? "/bin/sh",
+      isWorkspaceTrusted: () => opts.trusted,
+    });
+    runtime.attachTarget(makeTarget());
+    runtime.load({
+      PreToolUse: [
+        {
+          hooks: [{ type: "command", command: touchCommand(opts.sentinel) }],
+        },
+      ],
+    });
+    return runtime;
+  }
+
+  test("(a) untrusted workspace does NOT spawn a config command hook", async () => {
+    const sentinel = await tempSentinel();
+    const runtime = makeRuntime({ trusted: false, sentinel });
+    const diag = await runtime.testHook(runtime.listHooks()[0]!);
+
+    expect(diag.status).toBe("skipped");
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  test("(b) trusted workspace still runs the config command hook", async () => {
+    const sentinel = await tempSentinel();
+    const runtime = makeRuntime({ trusted: true, sentinel });
+    const diag = await runtime.testHook(runtime.listHooks()[0]!);
+
+    expect(diag.status).toBe("success");
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  test("(c) untrusted + non-interactive is skipped unless AGENC_ALLOW_UNTRUSTED_HOOKS opt-in is set", async () => {
+    const blockedSentinel = await tempSentinel();
+    const blocked = makeRuntime({ trusted: false, sentinel: blockedSentinel });
+    const blockedDiag = await blocked.testHook(blocked.listHooks()[0]!);
+    expect(blockedDiag.status).toBe("skipped");
+    expect(existsSync(blockedSentinel)).toBe(false);
+
+    const allowedSentinel = await tempSentinel();
+    const allowed = makeRuntime({
+      trusted: false,
+      env: { AGENC_ALLOW_UNTRUSTED_HOOKS: "1" },
+      sentinel: allowedSentinel,
+    });
+    const allowedDiag = await allowed.testHook(allowed.listHooks()[0]!);
+    expect(allowedDiag.status).toBe("success");
+    expect(existsSync(allowedSentinel)).toBe(true);
+  });
+
+  test("untrusted gate applies to every hook event type, not just PreToolUse", async () => {
+    const sentinel = await tempSentinel();
+    const runtime = new ConfiguredHooksRuntime({
+      cwd: process.cwd(),
+      env: {},
+      agencHome: "/tmp/agenc-test",
+      shellPath: process.env.SHELL ?? "/bin/sh",
+      isWorkspaceTrusted: () => false,
+    });
+    const target = makeTarget();
+    runtime.attachTarget(target);
+    runtime.load({
+      Stop: [{ hooks: [{ type: "command", command: touchCommand(sentinel) }] }],
+    });
+
+    const outcome = await target.stopHooks[0]!.run({
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      cwd: process.cwd(),
+      model: "test-model",
+      permissionMode: "default",
+      stopHookActive: false,
+      lastAssistantMessage: "",
+    });
+
+    // Skipped hooks are a no-op: the stop is allowed and nothing spawned.
+    expect(outcome.shouldStop).toBe(true);
+    expect(outcome.shouldBlock).toBe(false);
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  test("opt-in flag accepts true/yes and rejects other values", async () => {
+    const yesSentinel = await tempSentinel();
+    const yes = makeRuntime({
+      trusted: false,
+      env: { AGENC_ALLOW_UNTRUSTED_HOOKS: "true" },
+      sentinel: yesSentinel,
+    });
+    expect((await yes.testHook(yes.listHooks()[0]!)).status).toBe("success");
+    expect(existsSync(yesSentinel)).toBe(true);
+
+    const noSentinel = await tempSentinel();
+    const no = makeRuntime({
+      trusted: false,
+      env: { AGENC_ALLOW_UNTRUSTED_HOOKS: "0" },
+      sentinel: noSentinel,
+    });
+    expect((await no.testHook(no.listHooks()[0]!)).status).toBe("skipped");
+    expect(existsSync(noSentinel)).toBe(false);
   });
 });
 

--- a/runtime/tests/mcp-client/transports/stdio.test.ts
+++ b/runtime/tests/mcp-client/transports/stdio.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { Logger } from "../../_deps/logger.js";
 import {
   AgenCStdioClientTransport,
   DEFAULT_STDIO_ENV_VARS,
@@ -63,6 +64,51 @@ describe("AgenCStdioClientTransport", () => {
       method: "server/notice",
       params: { ok: true },
     });
+    await transport.close();
+  });
+
+  it("keeps stderrBuffer bounded under a newline-less flood", async () => {
+    // Defense-in-depth: a child emitting a long stderr run with no newline
+    // must not grow stderrBuffer without bound. The oversized prefix is
+    // flushed with a truncation notice; trailing residue keeps accumulating.
+    const infoMessages: string[] = [];
+    const logger: Logger = {
+      debug() {},
+      info(message: string) {
+        infoMessages.push(message);
+      },
+      warn() {},
+      error() {},
+    };
+    const transport = new AgenCStdioClientTransport(
+      { command: "flooder" },
+      logger,
+    );
+
+    // Reach into the private newline-less stderr handler/buffer. Treated as an
+    // internal here only to assert the cap holds without spawning a real child.
+    const internal = transport as unknown as {
+      onStderrData: (chunk: Buffer) => void;
+      stderrBuffer: Buffer;
+    };
+
+    const oneMiB = 1024 * 1024;
+    // Stream 5 MiB of newline-less bytes across many chunks.
+    for (let i = 0; i < 5; i += 1) {
+      internal.onStderrData(Buffer.alloc(oneMiB, 0x61));
+      // The retained, unflushed residue must never exceed the 1 MiB cap.
+      expect(internal.stderrBuffer.length).toBeLessThanOrEqual(oneMiB);
+    }
+
+    // At least one truncation notice must have been logged for the flood.
+    expect(infoMessages.some((m) => m.includes("truncated"))).toBe(true);
+
+    // A trailing newline-terminated line still splits and logs normally.
+    infoMessages.length = 0;
+    internal.onStderrData(Buffer.from("tail-line\n", "utf8"));
+    expect(internal.stderrBuffer.length).toBe(0);
+    expect(infoMessages.some((m) => m.endsWith("tail-line"))).toBe(true);
+
     await transport.close();
   });
 

--- a/runtime/tests/mcp-server/stdio.test.ts
+++ b/runtime/tests/mcp-server/stdio.test.ts
@@ -4,9 +4,19 @@ import { describe, expect, test } from "vitest";
 
 import { MCP_ERROR_PARSE } from "./types.js";
 import { McpServerFramework } from "./framework.js";
-import { McpStdioServerTransport, encodeMcpJsonLine } from "./stdio.js";
+import {
+  AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES,
+  McpStdioServerTransport,
+  encodeMcpJsonLine,
+} from "./stdio.js";
 import { McpToolRegistry } from "./tools.js";
 import type { McpCallToolResult } from "./types.js";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 function request(id: number, method: string, params?: unknown) {
   return {
@@ -238,6 +248,74 @@ describe("MCP stdio server transport", () => {
 
     await transport.close();
     lines.close();
+  });
+
+  test("tears down the connection when an unterminated line exceeds the cap", async () => {
+    // A peer that streams bytes without a newline must not grow the readline
+    // buffer (and MCP server memory) unbounded; the reader destroys input and
+    // surfaces a RangeError once the cap is tripped.
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const errors: Error[] = [];
+    const destroyed = new Promise<void>((resolve) => {
+      input.once("close", () => resolve());
+    });
+    const transport = new McpStdioServerTransport({
+      input,
+      output,
+      server: new McpServerFramework(),
+      maxLineBytes: 64,
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+    transport.start();
+
+    // 200 bytes with no newline must trip the 64-byte bound.
+    input.write("x".repeat(200));
+
+    await destroyed;
+    expect(input.destroyed).toBe(true);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(RangeError);
+    expect(errors[0]?.message).toMatch(/64 bytes without a newline/);
+
+    await transport.close();
+  });
+
+  test("does not trip the cap when newlines keep lines bounded", async () => {
+    // Prior valid behavior: newline-terminated frames under the cap keep
+    // flowing without tripping the bound.
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const lines = createOutputLines(output);
+    const errors: Error[] = [];
+    const transport = new McpStdioServerTransport({
+      input,
+      output,
+      server: new McpServerFramework({ serverInfo: { version: "1.0.0" } }),
+      maxLineBytes: 256,
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+    transport.start();
+
+    input.write(`${JSON.stringify(request(1, "initialize"))}\n`);
+    await expect(lines.nextLine().then(JSON.parse)).resolves.toEqual(
+      expect.objectContaining({ jsonrpc: "2.0", id: 1 }),
+    );
+
+    await delay(20);
+    expect(errors).toHaveLength(0);
+    expect(input.destroyed).toBe(false);
+
+    await transport.close();
+    lines.close();
+  });
+
+  test("exposes a default max line bound matching the app-server cap", () => {
+    expect(AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES).toBe(16 * 1024 * 1024);
   });
 
   test("notifies close after queued work drains", async () => {

--- a/runtime/tests/phases/stop-hooks.test.ts
+++ b/runtime/tests/phases/stop-hooks.test.ts
@@ -337,6 +337,9 @@ describe("evaluateStopHooks", () => {
       env: process.env,
       agencHome: "/tmp/agenc-test",
       shellPath: process.env.SHELL ?? "/bin/sh",
+      // This test exercises hook dispatch; treat the workspace as trusted
+      // (production establishes trust before command hooks run).
+      isWorkspaceTrusted: () => true,
     });
     const target: HookInstallTarget = {
       preToolUseHooks: [],

--- a/runtime/tests/tools/system/coding-common.test.ts
+++ b/runtime/tests/tools/system/coding-common.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveWorkspacePath } from "src/tools/system/coding-common.js";
+import {
+  SESSION_ID_ARG,
+  SESSION_ID_SIG_ARG,
+  signSessionId,
+  verifySessionId,
+  withSignedSessionId,
+} from "src/agents/_deps/filesystem-args.js";
+import {
+  clearAllPlanSlugs,
+  getPlanFilePath,
+  setPlanSlug,
+} from "src/planning/plan-files.js";
+
+// Simulate the in-process JSON dispatch serialization (router.ts
+// JSON.stringify -> execution.ts JSON.parse, and the child path). The
+// PROCESS_SECRET lives in the same Node runtime, so the signature must
+// survive the round-trip and still verify.
+function roundTrip<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const SESSION_ID = "sess-coding-common-test";
+
+describe("HMAC-signed session id (plan-file carve-out)", () => {
+  describe("verifySessionId", () => {
+    it("returns undefined for non-string ids / non-string sigs", () => {
+      expect(verifySessionId(undefined, undefined)).toBeUndefined();
+      expect(verifySessionId(42, signSessionId("x"))).toBeUndefined();
+      expect(verifySessionId("x", undefined)).toBeUndefined();
+      expect(verifySessionId("x", 42)).toBeUndefined();
+    });
+
+    it("returns undefined for a forged / mismatched signature", () => {
+      expect(verifySessionId(SESSION_ID, "00".repeat(32))).toBeUndefined();
+      // signature for a DIFFERENT id must not validate this id
+      expect(verifySessionId(SESSION_ID, signSessionId("other"))).toBeUndefined();
+      // short/garbage hex (length-guarded buffer compare)
+      expect(verifySessionId(SESSION_ID, "ab")).toBeUndefined();
+    });
+
+    // (b) LEGIT: a signed id verifies and survives JSON round-trip.
+    it("verifies a legitimately signed id through a JSON round-trip", () => {
+      const args = roundTrip(withSignedSessionId({}, SESSION_ID));
+      expect(verifySessionId(args[SESSION_ID_ARG], args[SESSION_ID_SIG_ARG])).toBe(
+        SESSION_ID,
+      );
+    });
+
+    it("withSignedSessionId writes both id and sig on a NEW object", () => {
+      const input: Record<string, unknown> = { file_path: "/x" };
+      const out = withSignedSessionId(input, SESSION_ID);
+      expect(out).not.toBe(input);
+      expect(input[SESSION_ID_SIG_ARG]).toBeUndefined();
+      expect(out[SESSION_ID_ARG]).toBe(SESSION_ID);
+      expect(out[SESSION_ID_SIG_ARG]).toBe(signSessionId(SESSION_ID));
+      expect(out.file_path).toBe("/x");
+    });
+  });
+
+  // The plan-file carve-out in resolveWorkspacePath grants a WRITE target
+  // OUTSIDE the workspace allowlist when the session plan-file is named.
+  // It must fire ONLY for a verifiably signed session id.
+  describe("plan-file carve-out (resolveWorkspacePath SINK)", () => {
+    let agencHome: string;
+    let workspace: string;
+    let planFile: string;
+    let savedAgencHome: string | undefined;
+
+    beforeEach(() => {
+      clearAllPlanSlugs();
+      agencHome = mkdtempSync(join(tmpdir(), "agenc-home-"));
+      workspace = mkdtempSync(join(tmpdir(), "agenc-ws-"));
+      savedAgencHome = process.env.AGENC_HOME;
+      process.env.AGENC_HOME = agencHome;
+      // Pin a deterministic slug so the plan path is stable, then
+      // materialize the plan file on disk (canonicalizePath needs it).
+      setPlanSlug({ agencHome, sessionId: SESSION_ID }, "fixed-slug");
+      planFile = getPlanFilePath({ agencHome, sessionId: SESSION_ID });
+      writeFileSync(planFile, "# plan\n", "utf8");
+    });
+
+    afterEach(() => {
+      if (savedAgencHome === undefined) {
+        delete process.env.AGENC_HOME;
+      } else {
+        process.env.AGENC_HOME = savedAgencHome;
+      }
+      clearAllPlanSlugs();
+    });
+
+    const config = () => ({
+      allowedPaths: [workspace] as const,
+      persistenceRootDir: workspace,
+    });
+
+    // (a) FORGE: an unsigned/forged __agencSessionId must NOT unlock the
+    // plan-file path outside the workspace allowlist.
+    it("DENIES the carve-out for an unsigned session id", async () => {
+      const args = roundTrip({
+        file_path: planFile,
+        [SESSION_ID_ARG]: SESSION_ID, // no signature — pure model forgery
+      });
+      const result = await resolveWorkspacePath({
+        config: config(),
+        args,
+        pathArgKeys: ["file_path"],
+      });
+      expect(typeof result).not.toBe("string");
+    });
+
+    it("DENIES the carve-out for a forged-signature session id", async () => {
+      const args = roundTrip({
+        file_path: planFile,
+        [SESSION_ID_ARG]: SESSION_ID,
+        [SESSION_ID_SIG_ARG]: "ff".repeat(32),
+      });
+      const result = await resolveWorkspacePath({
+        config: config(),
+        args,
+        pathArgKeys: ["file_path"],
+      });
+      expect(typeof result).not.toBe("string");
+    });
+
+    // LEGIT: a signed session id DOES unlock the plan-file write target.
+    it("ALLOWS the carve-out for a legitimately signed session id", async () => {
+      const args = roundTrip(
+        withSignedSessionId({ file_path: planFile }, SESSION_ID),
+      );
+      const result = await resolveWorkspacePath({
+        config: config(),
+        args,
+        pathArgKeys: ["file_path"],
+      });
+      expect(typeof result).toBe("string");
+      expect(result).toBe(resolve(planFile));
+    });
+  });
+});

--- a/runtime/tests/tools/system/file-edit.test.ts
+++ b/runtime/tests/tools/system/file-edit.test.ts
@@ -38,6 +38,8 @@ import {
   recordSessionRead,
   SESSION_AGENC_HOME_ARG,
   SESSION_ID_ARG,
+  SESSION_ID_SIG_ARG,
+  signSessionId,
 } from "./filesystem.js";
 import { notifyLspFileChanged } from "../../services/lsp/fileNotifications.js";
 import {
@@ -175,6 +177,7 @@ describe("Edit tool", () => {
         old_string: "Verify allowlist",
         new_string: "Verify plan edits",
         [SESSION_ID_ARG]: SESSION_ID,
+        [SESSION_ID_SIG_ARG]: signSessionId(SESSION_ID),
         [SESSION_AGENC_HOME_ARG]: agencHome,
       });
 

--- a/runtime/tests/tools/system/file-read.test.ts
+++ b/runtime/tests/tools/system/file-read.test.ts
@@ -14,6 +14,7 @@ import {
   hasSessionRead,
   SESSION_ALLOWED_ROOTS_ARG,
   SESSION_AGENC_HOME_ARG,
+  signSessionId,
 } from "./filesystem.js";
 import {
   clearAllPlanSlugs,
@@ -501,6 +502,7 @@ describe("FileRead tool", () => {
       const result = await tool.execute({
         file_path: planPath,
         __agencSessionId: sessionId,
+        __agencSessionIdSig: signSessionId(sessionId),
         [SESSION_AGENC_HOME_ARG]: agencHome,
       });
 

--- a/runtime/tests/tools/system/file-write.test.ts
+++ b/runtime/tests/tools/system/file-write.test.ts
@@ -22,6 +22,7 @@ import {
   recordSessionRead,
   seedSessionReadState,
   SESSION_AGENC_HOME_ARG,
+  signSessionId,
 } from "./filesystem.js";
 import {
   clearAllPlanSlugs,
@@ -88,6 +89,7 @@ describe("Write tool", () => {
         file_path: planPath,
         content: "# Plan\n\n- [ ] Fix plan file writes\n",
         __agencSessionId: sessionId,
+        __agencSessionIdSig: signSessionId(sessionId),
         [SESSION_AGENC_HOME_ARG]: agencHome,
       });
 
@@ -100,6 +102,7 @@ describe("Write tool", () => {
         file_path: join(agencHome, "plans", "not-active.md"),
         content: "# Not active\n",
         __agencSessionId: sessionId,
+        __agencSessionIdSig: signSessionId(sessionId),
         [SESSION_AGENC_HOME_ARG]: agencHome,
       });
       expect(rejected.isError).toBe(true);

--- a/runtime/tests/tools/system/signed-allowed-roots.test.ts
+++ b/runtime/tests/tools/system/signed-allowed-roots.test.ts
@@ -1,14 +1,34 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { resolve } from "node:path";
 
 import { resolveToolAllowedPaths } from "./filesystem.js";
 import {
   SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ALLOWED_ROOTS_SIG_ARG,
+  SESSION_ID_ARG,
+  SESSION_ID_SIG_ARG,
   signAllowedRoots,
+  signSessionId,
   verifyAllowedRoots,
+  verifySessionId,
   withSignedAllowedRoots,
 } from "src/agents/_deps/filesystem-args.js";
+
+// Capture the args that reach the underlying runtime FileRead tool, so
+// we can observe exactly what the canonical surface injects. Mocked here
+// (not in the per-test body) because vi.mock is hoisted above imports.
+const capturedExecuteArgs = vi.hoisted(() => [] as Record<string, unknown>[]);
+vi.mock("src/tools/system/file-read.js", () => ({
+  createFileReadTool: () => ({
+    name: "FileRead",
+    description: "mock",
+    isReadOnly: true,
+    async execute(args: Record<string, unknown>) {
+      capturedExecuteArgs.push(args);
+      return { content: "ok" };
+    },
+  }),
+}));
 
 // Simulate the in-process JSON dispatch serialization
 // (router.ts JSON.stringify -> execution.ts JSON.parse, and the child
@@ -137,5 +157,62 @@ describe("HMAC-signed trusted filesystem roots", () => {
         again[SESSION_ALLOWED_ROOTS_SIG_ARG],
       )).toEqual(["/root/a"]);
     });
+  });
+});
+
+// (c) The canonical tool surface must ALWAYS inject the AUTHORITATIVE
+// session id (from runtime state) signed with withSignedSessionId, and
+// must NOT adopt a model-supplied __agencSessionId.
+describe("canonicalToolSurface — authoritative signed session id", () => {
+  let switchSession: typeof import("src/bootstrap/state.js").switchSession;
+  let getSessionId: typeof import("src/bootstrap/state.js").getSessionId;
+  let CanonicalFileReadTool: typeof import("src/tools/canonicalToolSurface.js").CanonicalFileReadTool;
+  let restoreSessionId: string;
+
+  beforeEach(async () => {
+    capturedExecuteArgs.length = 0;
+    const state = await import("src/bootstrap/state.js");
+    switchSession = state.switchSession;
+    getSessionId = state.getSessionId;
+    restoreSessionId = getSessionId();
+    ({ CanonicalFileReadTool } = await import("src/tools/canonicalToolSurface.js"));
+  });
+
+  afterEach(() => {
+    switchSession(restoreSessionId as never);
+  });
+
+  function context(): unknown {
+    return {
+      abortController: new AbortController(),
+      readFileState: new Map(),
+      getAppState: () => ({}),
+    };
+  }
+
+  it("injects the authoritative signed id and ignores the model-supplied id", async () => {
+    switchSession("authoritative-session" as never);
+    await CanonicalFileReadTool.call(
+      // The model tries to smuggle its own session id (and even a self-
+      // signed-looking value) — both must be discarded.
+      {
+        file_path: "/tmp/x",
+        [SESSION_ID_ARG]: "model-controlled-session",
+        [SESSION_ID_SIG_ARG]: signSessionId("model-controlled-session"),
+      } as never,
+      context() as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+    );
+    expect(capturedExecuteArgs).toHaveLength(1);
+    const injected = capturedExecuteArgs[0]!;
+    // Authoritative id wins; model value is dropped.
+    expect(injected[SESSION_ID_ARG]).toBe("authoritative-session");
+    expect(injected[SESSION_ID_ARG]).not.toBe("model-controlled-session");
+    // ...and it carries a signature that verifies for the authoritative id.
+    expect(
+      verifySessionId(injected[SESSION_ID_ARG], injected[SESSION_ID_SIG_ARG]),
+    ).toBe("authoritative-session");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the 17-issue audit-fix PR. A grounded needs-assessment found the same **bug classes** the audit fixed still recurring in adjacent subsystems. This closes the two latent security bugs plus the resource/ordering recurrences.

## Security
- **#1 — `__agencSessionId` forgery (closes the gap the prior PR left open).** The id that unlocks the plan-file carve-out *outside* the workspace allowlist is now HMAC-signed (same per-process secret as the trusted-roots channel) and verified at **both** sinks — `coding-common.ts` and `filesystem.ts:safePathAllowingSessionPlanFile`. `canonicalToolSurface` no longer prefers a model-supplied id, and **all** runtime injectors (`execution.ts`, `run-agent`, `sessionMemory`, `phases/tool-runtime`, `model-facing-tools`) sign it so the legit carve-out is preserved (no over-restriction). A forged/unsigned id is denied.
- **#2 — configured-hooks RCE.** Command-hook execution is now gated on workspace trust (`isProjectTrustedSync`). Untrusted + non-interactive no longer runs config/plugin-sourced shell commands unless `AGENC_ALLOW_UNTRUSTED_HOOKS` is set. Closes host RCE on cloning a hostile repo's `config.toml`.

## Resources / ordering
- **#3** background-agent event buffers (`#pendingEvents`/`bufferedEvents`) are FIFO-bounded at `MAX_BUFFERED_AGENT_EVENTS=1000`.
- **#5** per-agent emission is serialized on a dispatch chain (arrival order preserved).
- mcp-server readline 16 MiB line cap; mcp-client stderr 1 MiB cap.

## Verification
`tsc --noEmit` clean; **3,402 tests / 240 files passing**. Includes new forge/sink/trust tests; plan-file tests updated to sign ids and hook tests to establish trust (mirroring the new production requirement).

⚠️ Reviewer note: security-sensitive change to the tool-permission and hook layers — worth a human security pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)