### PR TITLE
feat(cli): add 'agenc doctor' + document workbench/Neovim, mcp xaa, doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,18 @@ agenc agent attach <id>
 agenc agent stop <id>
 agenc agent logs <id>
 agenc mcp <serve|add|list|get|remove|add-json|add-from-agenc-desktop|reset-project-choices|doctor|xaa>
+agenc doctor [--json]
 ```
+
+`agenc doctor` diagnoses the installation and environment (version, install
+type, ripgrep status, auto-update permissions, and PATH/glob warnings with
+suggested fixes); `--json` emits the raw diagnostic. For MCP-server-specific
+checks use `agenc mcp doctor`.
+
+The `agenc mcp` subcommands cover MCP server management plus two auth helpers:
+`doctor` (diagnose MCP configuration) and `xaa` (`setup|login|show|clear` for
+Cross-App Access / Enterprise Managed Authorization, SEP-990 — the IdP-brokered
+auth flow used by enterprise-managed MCP servers).
 
 Common flags:
 
@@ -136,6 +147,29 @@ node runtime/bin/agenc agent attach <agent-id>
 node runtime/bin/agenc agent logs <agent-id>
 node runtime/bin/agenc agent stop <agent-id>
 ```
+
+## Workbench & Editing
+
+The interactive TUI includes a **workbench** — a project explorer, a read-only
+code preview surface, and an editable `BUFFER` surface for editing files without
+leaving the terminal. The BUFFER surface supports three editor providers:
+
+- **Embedded Neovim** (preferred): AgenC launches `nvim --embed` and owns its
+  process lifecycle, rendering, and file safety, while Neovim owns Vim
+  semantics. This is the enterprise-grade editing path.
+- **Inline fallback**: a basic built-in editor used only when Neovim is
+  unavailable. It is fallback-only and does not claim exact Vim behavior.
+- **External editor**: explicit handoff to `$VISUAL`/`$EDITOR` (e.g. `nvim`,
+  `vim`, `vi`, `nano`) for users who prefer their own editor.
+
+> Security note: in `auto` mode the embedded-Neovim path loads your full Neovim
+> configuration (`init.lua`) and plugins, which execute as your user. See
+> [`docs/embedded-neovim-buffer.md`](docs/embedded-neovim-buffer.md) for the
+> trust boundary and how to run Neovim isolated under unattended agents.
+
+The embedded-Neovim PTY lifecycle (including the "kill the TUI mid-edit and
+leave no orphaned `nvim` child" guarantee) is exercised by the
+`check:tui-workbench-buffer-neovim` scenario gate, run in CI.
 
 ## Runtime Layout
 

--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -44,6 +44,26 @@ when graceful shutdown does not complete within the configured timeout.
 If the TUI is killed, the PTY gate verifies that descendant Neovim processes are
 gone before the scenario passes.
 
+## Trust boundary
+
+By default (`AGENC_BUFFER_NVIM_USE_INIT=1`, the default), embedded Neovim loads
+your full user configuration — `init.lua`/`init.vim` and any plugins it sources.
+That configuration executes as **your user**, with your privileges, the moment
+BUFFER opens. This is the same trust you already extend to running `nvim`
+yourself, but it is worth calling out explicitly because BUFFER can be opened
+from within an agent session:
+
+- **Interactive use on a workspace you trust:** the default user-init path is
+  expected and convenient.
+- **Unattended / background agents, or untrusted workspaces:** prefer clean
+  embedded mode, which starts `nvim --embed --clean -n` and loads **no** user
+  config or plugins, by setting `AGENC_BUFFER_NVIM_USE_INIT=0`. This removes the
+  arbitrary-code-execution surface of a hostile or unreviewed `init.lua`.
+
+AgenC owns process supervision and lifecycle cleanup (see Cleanup), but it does
+**not** sandbox the Neovim process or vet its configuration — config trust is
+the user's, exactly as with a normal `nvim` invocation.
+
 ## Validation
 
 Use these gates for this surface:

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -134,6 +134,11 @@ import {
   runAgenCMcpCli,
 } from "./mcp-cli.js";
 import {
+  formatAgenCDoctorCliHelpText,
+  parseAgenCDoctorCliArgs,
+  runAgenCDoctorCli,
+} from "./doctor-cli.js";
+import {
   formatAgenCInitCliHelpText,
   parseAgenCInitCliArgs,
   runAgenCInitCli,
@@ -321,6 +326,8 @@ export function formatCliHelpTopicText(topic: string): string | null {
       return formatAgenCDaemonCliHelpText();
     case "mcp":
       return formatAgenCMcpCliHelpText();
+    case "doctor":
+      return formatAgenCDoctorCliHelpText();
     case "permissions":
       return formatAgenCPermissionsCliHelpText();
     case "plugin":
@@ -3276,6 +3283,10 @@ export async function main(): Promise<number> {
   const mcpCommand = parseAgenCMcpCliArgs(argv, mcpConfig);
   if (mcpCommand !== null) {
     return runAgenCMcpCli(mcpCommand);
+  }
+  const doctorCommand = parseAgenCDoctorCliArgs(argv);
+  if (doctorCommand !== null) {
+    return runAgenCDoctorCli(doctorCommand);
   }
   const providersCommand = parseAgenCProvidersCliArgs(argv);
   if (providersCommand !== null) {

--- a/runtime/src/bin/doctor-cli.ts
+++ b/runtime/src/bin/doctor-cli.ts
@@ -1,0 +1,112 @@
+/**
+ * `agenc doctor` — top-level environment/installation diagnostics.
+ *
+ * Surfaces the diagnostic that previously had no top-level entry point
+ * (only `agenc mcp doctor` was wired) by formatting
+ * {@link getDoctorDiagnostic}. For MCP-server-specific diagnostics, see
+ * `agenc mcp doctor`.
+ */
+import { getDoctorDiagnostic } from "../utils/doctorDiagnostic.js";
+
+export interface AgenCDoctorCliCommand {
+  readonly json: boolean;
+}
+
+export function formatAgenCDoctorCliHelpText(): string {
+  return [
+    "agenc doctor — diagnose the AgenC installation and environment",
+    "",
+    "Usage:",
+    "  agenc doctor            Print installation, version, ripgrep, update,",
+    "                          and PATH/glob diagnostics with suggested fixes",
+    "  agenc doctor --json     Emit the raw diagnostic as JSON",
+    "",
+    "See also: agenc mcp doctor (MCP server configuration diagnostics)",
+  ].join("\n");
+}
+
+/**
+ * Parse argv for the top-level `doctor` command. Returns null when argv is
+ * not a `doctor` invocation so the caller can fall through to other CLIs.
+ */
+export function parseAgenCDoctorCliArgs(
+  argv: readonly string[],
+): AgenCDoctorCliCommand | null {
+  if (argv[0] !== "doctor") return null;
+  const rest = argv.slice(1);
+  const json = rest.includes("--json");
+  return { json };
+}
+
+function formatDiagnosticText(
+  info: Awaited<ReturnType<typeof getDoctorDiagnostic>>,
+): string {
+  const lines: string[] = [];
+  lines.push("AgenC Doctor");
+  lines.push("");
+  lines.push(`  Version:            ${info.version}`);
+  lines.push(`  Installation type:  ${info.installationType}`);
+  lines.push(`  Installation path:  ${info.installationPath}`);
+  lines.push(`  Invoked binary:     ${info.invokedBinary}`);
+  if (info.packageManager) {
+    lines.push(`  Package manager:    ${info.packageManager}`);
+  }
+  lines.push(`  Config install:     ${info.configInstallMethod}`);
+  lines.push(`  Auto-updates:       ${info.autoUpdates}`);
+  if (info.hasUpdatePermissions !== null) {
+    lines.push(
+      `  Update permissions: ${info.hasUpdatePermissions ? "yes" : "no"}`,
+    );
+  }
+  lines.push(
+    `  ripgrep:            ${info.ripgrepStatus.working ? "ok" : "NOT WORKING"} ` +
+      `(${info.ripgrepStatus.mode}${
+        info.ripgrepStatus.systemPath
+          ? `: ${info.ripgrepStatus.systemPath}`
+          : ""
+      })`,
+  );
+
+  if (info.multipleInstallations.length > 0) {
+    lines.push("");
+    lines.push("  Multiple installations detected:");
+    for (const install of info.multipleInstallations) {
+      lines.push(`    - ${install.type}: ${install.path}`);
+    }
+  }
+
+  if (info.warnings.length > 0) {
+    lines.push("");
+    lines.push(`  Warnings (${info.warnings.length}):`);
+    for (const warning of info.warnings) {
+      lines.push(`    ⚠ ${warning.issue}`);
+      lines.push(`      fix: ${warning.fix}`);
+    }
+  } else {
+    lines.push("");
+    lines.push("  No warnings.");
+  }
+
+  if (info.recommendation) {
+    lines.push("");
+    lines.push(`  Recommendation: ${info.recommendation}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Run the top-level doctor diagnostic. Returns a process exit code: 1 when
+ * any warning is present (so scripts can gate on a clean environment), else 0.
+ */
+export async function runAgenCDoctorCli(
+  command: AgenCDoctorCliCommand,
+): Promise<number> {
+  const info = await getDoctorDiagnostic();
+  if (command.json) {
+    process.stdout.write(`${JSON.stringify(info, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatDiagnosticText(info)}\n`);
+  }
+  return info.warnings.length > 0 ? 1 : 0;
+}

--- a/runtime/tests/bin/doctor-cli.test.ts
+++ b/runtime/tests/bin/doctor-cli.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  formatAgenCDoctorCliHelpText,
+  parseAgenCDoctorCliArgs,
+  runAgenCDoctorCli,
+} from "./doctor-cli.js";
+
+// MACRO is a build-time esbuild define (tsup) that getDoctorDiagnostic reads
+// (MACRO.VERSION / MACRO.PACKAGE_URL); it is not defined under vitest. Stand it
+// in for the duration of the suite, mirroring the established test pattern.
+let priorMacro: unknown;
+beforeAll(() => {
+  priorMacro = (globalThis as { MACRO?: unknown }).MACRO;
+  (globalThis as { MACRO?: unknown }).MACRO = {
+    VERSION: "test",
+    PACKAGE_URL: "@tetsuo-ai/runtime",
+  };
+});
+afterAll(() => {
+  (globalThis as { MACRO?: unknown }).MACRO = priorMacro;
+});
+
+describe("parseAgenCDoctorCliArgs", () => {
+  it("returns null for non-doctor argv so other CLIs can match", () => {
+    expect(parseAgenCDoctorCliArgs(["mcp", "doctor"])).toBeNull();
+    expect(parseAgenCDoctorCliArgs([])).toBeNull();
+    expect(parseAgenCDoctorCliArgs(["--print", "hi"])).toBeNull();
+  });
+
+  it("parses `doctor` and the --json flag", () => {
+    expect(parseAgenCDoctorCliArgs(["doctor"])).toEqual({ json: false });
+    expect(parseAgenCDoctorCliArgs(["doctor", "--json"])).toEqual({
+      json: true,
+    });
+  });
+});
+
+describe("runAgenCDoctorCli", () => {
+  it("prints a human-readable diagnostic and returns an exit code", async () => {
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    try {
+      const code = await runAgenCDoctorCli({ json: false });
+      const printed = out.mock.calls.map((c) => String(c[0])).join("");
+      expect(printed).toContain("AgenC Doctor");
+      expect(printed).toContain("ripgrep:");
+      // Exit code is 0 (clean) or 1 (warnings present) — always a number.
+      expect([0, 1]).toContain(code);
+    } finally {
+      out.mockRestore();
+    }
+  });
+
+  it("emits valid JSON under --json", async () => {
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    try {
+      await runAgenCDoctorCli({ json: true });
+      const printed = out.mock.calls.map((c) => String(c[0])).join("");
+      const parsed = JSON.parse(printed);
+      expect(parsed).toHaveProperty("ripgrepStatus");
+      expect(parsed).toHaveProperty("installationType");
+    } finally {
+      out.mockRestore();
+    }
+  });
+});
+
+describe("formatAgenCDoctorCliHelpText", () => {
+  it("documents usage and the mcp doctor pointer", () => {
+    const help = formatAgenCDoctorCliHelpText();
+    expect(help).toContain("agenc doctor");
+    expect(help).toContain("--json");
+    expect(help).toContain("agenc mcp doctor");
+  });
+});


### PR DESCRIPTION
## Summary

Product/docs quick wins from the needs assessment.

- **`agenc doctor`** — top-level environment/installation diagnostics (version, install type, ripgrep status, auto-update permissions, multiple-install detection, PATH/glob warnings + fixes; `--json` for raw output). Wires the existing `getDoctorDiagnostic`, which previously had no top-level entry point (only `agenc mcp doctor`). Dispatch mirrors the other subcommand CLIs; exits non-zero when warnings are present. Smoke-tested end-to-end + unit tests.
- **Docs:** README now documents the TUI **workbench + embedded-Neovim BUFFER** editor (previously 0 mentions of a shipped feature), the new `doctor` command, and clarifies the opaque `agenc mcp xaa` as **Cross-App Access / Enterprise Managed Authorization (SEP-990)**. `docs/embedded-neovim-buffer.md` gains a **Trust boundary** section: the default user-init path executes `init.lua`/plugins as the user, and unattended/untrusted use should set `AGENC_BUFFER_NVIM_USE_INIT=0` for clean mode.

## Verification
`agenc doctor` smoke-tested (text + `--json`); new `doctor-cli` unit tests; the `buffer-docs-config` contract test still green; full vitest suite **10,371 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)