### PR TITLE
chore(runtime): typecheck foundation — reclaim 13 files from @ts-nocheck

### DIFF
--- a/runtime/src/constants/product.ts
+++ b/runtime/src/constants/product.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 export const PRODUCT_URL = 'https://agenc.tech/agenc-code'
 
 // AgenC Remote session URLs

--- a/runtime/src/constants/system.ts
+++ b/runtime/src/constants/system.ts
@@ -1,11 +1,8 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 // Critical system constants extracted to break circular dependencies
 
 import { feature } from 'bun:bundle'
 import { logForDebugging } from 'src/utils/debug.js'
 import { isEnvDefinedFalsy } from '../utils/envUtils.js'
-import { getAPIProvider } from '../utils/model/providers.js'
 import { getWorkload } from '../utils/workloadContext.js'
 
 const DEFAULT_PREFIX =
@@ -35,11 +32,6 @@ export function getCLISyspromptPrefix(options?: {
   isNonInteractive: boolean
   hasAppendSystemPrompt: boolean
 }): CLISyspromptPrefix {
-  const apiProvider = getAPIProvider()
-  if (apiProvider === 'vertex') {
-    return DEFAULT_PREFIX
-  }
-
   if (options?.isNonInteractive) {
     if (options.hasAppendSystemPrompt) {
       return AGENT_SDK_AGENC_PRESET_PREFIX
@@ -79,7 +71,6 @@ export function getAttributionHeader(fingerprint: string): string {
     return ''
   }
 
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
   const version = `${MACRO.VERSION}.${fingerprint}`
   const entrypoint = process.env.AGENC_ENTRYPOINT ?? 'unknown'
 

--- a/runtime/src/constants/systemPromptSections.ts
+++ b/runtime/src/constants/systemPromptSections.ts
@@ -1,11 +1,8 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import {
   clearBetaHeaderLatches,
   clearSystemPromptSectionState,
   getSystemPromptSectionCache,
   setSystemPromptSectionCacheEntry,
-// @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
 } from '../bootstrap/state.js'
 
 type ComputeFn = () => string | null | Promise<string | null>

--- a/runtime/src/services/api/emptyUsage.ts
+++ b/runtime/src/services/api/emptyUsage.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import type { NonNullableUsage } from '../../entrypoints/sdk/sdkUtilityTypes.js'
 /**
  * Zero-initialized usage object. Extracted from logging.ts so that

--- a/runtime/src/services/api/fetchWithProxyRetry.ts
+++ b/runtime/src/services/api/fetchWithProxyRetry.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import { disableKeepAlive, getProxyFetchOptions } from '../../utils/proxy.js'
 
 const RETRYABLE_FETCH_ERROR_PATTERN =
@@ -28,7 +26,7 @@ export async function fetchWithProxyRetry(
       return await fetch(input, {
         ...init,
         ...getProxyFetchOptions({
-          forproviderAPI: options?.forproviderAPI,
+          forAnthropicAPI: options?.forproviderAPI,
         }),
       })
     } catch (error) {

--- a/runtime/src/tools/EnterPlanModeTool/UI.tsx
+++ b/runtime/src/tools/EnterPlanModeTool/UI.tsx
@@ -1,15 +1,13 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react'; import { BLACK_CIRCLE } from 'src/constants/figures.js';
 import { getModeColor } from 'src/utils/permissions/PermissionMode.js';
 import { Box, Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import type { ThemeName } from '../../utils/theme.js';
 import type { Output } from './EnterPlanModeTool.js';
 export function renderToolUseMessage(): React.ReactNode {
   return null;
 }
-export function renderToolResultMessage(_output: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], _options: {
+export function renderToolResultMessage(_output: Output, _progressMessagesForMessage: ProgressMessage[], _options: {
   theme: ThemeName;
 }): React.ReactNode {
   return <Box flexDirection="column" marginTop={1}>

--- a/runtime/src/tools/EnterWorktreeTool/UI.tsx
+++ b/runtime/src/tools/EnterWorktreeTool/UI.tsx
@@ -1,15 +1,12 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react';
 import { Box, Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import type { ThemeName } from '../../utils/theme.js';
 import type { Output } from './EnterWorktreeTool.js';
 export function renderToolUseMessage(): React.ReactNode {
   return 'Creating worktree…';
 }
-export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], _options: {
+export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage[], _options: {
   theme: ThemeName;
 }): React.ReactNode {
   return <Box flexDirection="column">

--- a/runtime/src/tools/ExitWorktreeTool/UI.tsx
+++ b/runtime/src/tools/ExitWorktreeTool/UI.tsx
@@ -1,15 +1,12 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react';
 import { Box, Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import type { ThemeName } from '../../utils/theme.js';
 import type { Output } from './ExitWorktreeTool.js';
 export function renderToolUseMessage(): React.ReactNode {
   return 'Exiting worktree…';
 }
-export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], _options: {
+export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage[], _options: {
   theme: ThemeName;
 }): React.ReactNode {
   const actionLabel = output.action === 'keep' ? 'Kept worktree' : 'Removed worktree';

--- a/runtime/src/tools/FileReadTool/limits.ts
+++ b/runtime/src/tools/FileReadTool/limits.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 /**
  * Read tool output limits.  Two caps apply to text reads:
  *

--- a/runtime/src/tools/ListMcpResourcesTool/UI.tsx
+++ b/runtime/src/tools/ListMcpResourcesTool/UI.tsx
@@ -1,9 +1,7 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react';
 import { MessageResponse } from '../../tui/components/MessageResponse.js';
 import { OutputLine } from '../../tui/components/shell/OutputLine.js';
 import { Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import { jsonStringify } from '../../utils/slowOperations.js';
 import type { Output } from './ListMcpResourcesTool.js';
@@ -12,7 +10,7 @@ export function renderToolUseMessage(input: Partial<{
 }>): React.ReactNode {
   return input.server ? `List MCP resources from server "${input.server}"` : `List all MCP resources`;
 }
-export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], {
+export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage[], {
   verbose
 }: {
   verbose: boolean;

--- a/runtime/src/tools/ReadMcpResourceTool/UI.tsx
+++ b/runtime/src/tools/ReadMcpResourceTool/UI.tsx
@@ -1,10 +1,8 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react';
 import type { z } from 'zod/v4';
 import { MessageResponse } from '../../tui/components/MessageResponse.js';
 import { OutputLine } from '../../tui/components/shell/OutputLine.js';
 import { Box, Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import { jsonStringify } from '../../utils/slowOperations.js';
 import type { inputSchema, Output } from './ReadMcpResourceTool.js';
@@ -17,7 +15,7 @@ export function renderToolUseMessage(input: Partial<z.infer<ReturnType<typeof in
 export function userFacingName(): string {
   return 'readMcpResource';
 }
-export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], {
+export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage[], {
   verbose
 }: {
   verbose: boolean;

--- a/runtime/src/tools/SendMessageTool/UI.tsx
+++ b/runtime/src/tools/SendMessageTool/UI.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import React from 'react';
 import { MessageResponse } from '../../tui/components/MessageResponse.js';
 import { Text } from '../../tui/ink.js';
@@ -14,9 +12,7 @@ export function renderToolUseMessage(input: Partial<Input>): React.ReactNode {
   }
   return null;
 }
-export function renderToolResultMessage(content: SendMessageToolOutput | string, _progressMessages: unknown, {
-  verbose
-}: {
+export function renderToolResultMessage(content: SendMessageToolOutput | string, _progressMessages: unknown, _options: {
   verbose: boolean;
 }): React.ReactNode {
   const result: SendMessageToolOutput = typeof content === 'string' ? jsonParse(content) : content;

--- a/runtime/src/tools/TaskStopTool/UI.tsx
+++ b/runtime/src/tools/TaskStopTool/UI.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import React from 'react';
 import { MessageResponse } from '../../tui/components/MessageResponse.js';
 import { stringWidth } from '../../tui/ink/stringWidth.js';
@@ -27,9 +25,6 @@ export function renderToolResultMessage(output: Output, _progressMessagesForMess
 }: {
   verbose: boolean;
 }): React.ReactNode {
-  if ("external" === 'ant') {
-    return null;
-  }
   const rawCommand = output.command ?? '';
   const command = verbose ? rawCommand : truncateCommand(rawCommand);
   const suffix = command !== rawCommand ? '… · stopped' : ' · stopped';


### PR DESCRIPTION
First batch of clawing back `tsc` coverage. **191 → 178** `@ts-nocheck` files in `src`. The core (`agents`/`session`/`llm`) was already clean; this starts on `tools`/`services`/`constants`/`tasks`.

Removed the blanket `@ts-nocheck` from 13 small load-bearing files and fixed the real errors it was hiding.

## Free (stale suppression, already clean)
`services/api/emptyUsage.ts`, `constants/product.ts`, `tools/FileReadTool/limits.ts`

## Type-only fixes
- **5 tool `UI.tsx` files** used `ProgressMessage<ToolProgressData>[]`, but `ProgressMessage` is `any` (not generic — `types/message.ts:52`). Dropped the type arg + the orphaned `ToolProgressData` import.
- `SendMessageTool/UI.tsx`: unused `verbose` destructure → `_options`.
- `constants/system.ts` + `systemPromptSections.ts`: removed stale `@ts-expect-error` directives (TS2578).

## Real bugs surfaced + fixed
- **`fetchWithProxyRetry.ts`** passed `forproviderAPI` to `getProxyFetchOptions`, which expects `forAnthropicAPI` — a botched de-brand that **silently dropped the proxy option** (`client.ts:152` passes `forproviderAPI: true`). Now mapped correctly so it actually applies.
- **`constants/system.ts`**: `apiProvider === 'vertex'` was a dead + redundant branch (`'vertex'` isn't in `APIProvider`, and it returned `DEFAULT_PREFIX` like the fallthrough). Removed it + the orphaned `getAPIProvider` import.
- **`TaskStopTool/UI.tsx`**: removed dead `if ("external" === 'ant')` (constant-false) block.

## Verification (local)
- `tsc` — clean
- `tsup` build — passes
- Full `vitest` — **10351 passed / 10 skipped**
- Isolated Bun suite — clean (one pre-existing unrelated failure: `utils/file.test.ts`)

This establishes the per-batch workflow for the typecheck-foundation effort (strip `@ts-nocheck` → fix the real errors → verify). ~178 files remain, concentrated in `tui` (91), `tools`, `services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)