### PR TITLE
fix(runtime): harden core subsystems — 19 real bugs across agents/session/llm/tasks/memory/tools

### DIFF
--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -852,7 +852,7 @@ export class AgentControl {
 
     // I-1: depth cap. Use metadata.depth as authority, fall back to
     // parent-path-derived depth + 1 if metadata is missing depth.
-    // Matches reference runtime `>=` comparison (`multi_agents_common.rs:283`).
+    // Rejects when depth exceeds the cap (`depth > this.maxDepth`).
     const depth =
       metadata.depth ?? depthOfAgentPath(parentPath) + 1;
     if (depth > this.maxDepth) {

--- a/runtime/src/agents/delegate.ts
+++ b/runtime/src/agents/delegate.ts
@@ -418,6 +418,16 @@ async function runDelegateAgentLoop(opts: {
       if (!restarted) {
         return result;
       }
+      // The restarted agent gets a fresh thread id; carry the failure
+      // count forward so RESUME_MAX_ATTEMPTS still trips on a subagent
+      // that hard-fails repeatedly (otherwise the per-thread counter
+      // resets to 0 on every restart and the loop is unbounded).
+      if (restarted.agentId !== live.agentId) {
+        opts.resumeManager.transferFailureCount(
+          live.agentId,
+          restarted.agentId,
+        );
+      }
       opts.thread.rebindLive(restarted);
       continue;
     }

--- a/runtime/src/agents/fork-context.ts
+++ b/runtime/src/agents/fork-context.ts
@@ -191,7 +191,14 @@ function rolloutItemsToForkMessages(
 }
 
 function rolloutBackedParentMessages(input: ForkContextInput): LLMMessage[] {
-  if (input.useProvidedParentMessages) return [...input.parentMessages];
+  if (input.useProvidedParentMessages) {
+    // Honor the bounded-fork contract on caller-provided messages too:
+    // last_n_turns must truncate the override, not inherit the whole
+    // provided history (the forkSubagent branch trusts this result).
+    return input.mode?.kind === "last_n_turns"
+      ? lastNUserTurns(input.parentMessages, input.mode.n)
+      : [...input.parentMessages];
+  }
   const rolloutStore = input.parent.rolloutStore;
   if (!rolloutStore) return [...input.parentMessages];
   try {

--- a/runtime/src/agents/resume.ts
+++ b/runtime/src/agents/resume.ts
@@ -83,6 +83,19 @@ export class ResumeManager {
     return this.failuresByThread.get(threadId) ?? 0;
   }
 
+  /**
+   * Carry a thread's consecutive-failure count onto a new thread id.
+   * Used when a hard-failing subagent is restarted under a fresh
+   * thread id so the RESUME_MAX_ATTEMPTS cap still trips instead of
+   * resetting to zero on every restart.
+   */
+  transferFailureCount(fromThreadId: string, toThreadId: string): void {
+    const count = this.failuresByThread.get(fromThreadId);
+    if (count === undefined) return;
+    this.failuresByThread.set(toThreadId, count);
+    this.failuresByThread.delete(fromThreadId);
+  }
+
   /** Clear all tracked threads (session reset). */
   clear(): void {
     this.failuresByThread.clear();

--- a/runtime/src/agents/thread-manager.ts
+++ b/runtime/src/agents/thread-manager.ts
@@ -508,18 +508,6 @@ export class ThreadManager implements ThreadOperationManager {
     };
     push(rootThreadId);
 
-    const root = this.state.threads.get(rootThreadId);
-    const rolloutStore = root?.kind === "root"
-      ? undefined
-      : undefined;
-    void rolloutStore;
-
-    const anyThread = this.state.threads.get(rootThreadId);
-    const rootSession = anyThread instanceof AgenCThread
-      ? undefined
-      : undefined;
-    void rootSession;
-
     const session = Array.from(this.state.threads.values())
       .map((thread) =>
         thread instanceof AgenCThread ? thread.sourceSession() : undefined,

--- a/runtime/src/llm/providers/grok/adapter.ts
+++ b/runtime/src/llm/providers/grok/adapter.ts
@@ -1094,20 +1094,6 @@ export class GrokProvider implements LLMProvider {
       stream: true,
     };
     const compactionDiagnostics = plan.compactionDiagnostics;
-    let content = "";
-    let model = this.config.model;
-    let finishReason: LLMResponse["finishReason"] = "stop";
-    let responseError: Error | undefined;
-    let usage: LLMUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
-    let providerEvidence: LLMResponse["providerEvidence"];
-    let encryptedReasoning: LLMResponse["encryptedReasoning"];
-    const toolCallAccum = new Map<string, LLMToolCall>();
-    // Per-summary-index buffers for streamed reasoning summaries. xAI may
-    // emit multiple summary blocks in one turn; each lands at its own index.
-    const reasoningSummaryBuffers = new Map<number, string>();
-    let streamIterator: AsyncIterator<any> | null = null;
-    let responseTracePayload: Record<string, unknown> | undefined;
-    let streamResponseMeta: ProviderResponseTraceMeta | undefined;
     const streamTimeout = resolveRequestTimeoutMs(
       this.configuredTimeoutMs,
       options?.timeoutMs,
@@ -1119,6 +1105,24 @@ export class GrokProvider implements LLMProvider {
 
     let consecutiveFallbackFailures = 0;
     while (true) {
+      // Per-attempt accumulators must be re-initialised on every retry so a
+      // configured-fallback retry (continue below) starts clean. Declaring
+      // these outside the loop would carry attempt-1 state (e.g. streamed
+      // reasoning summaries) into attempt 2 and duplicate it.
+      let content = "";
+      let model = this.config.model;
+      let finishReason: LLMResponse["finishReason"] = "stop";
+      let responseError: Error | undefined;
+      let usage: LLMUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      let providerEvidence: LLMResponse["providerEvidence"];
+      let encryptedReasoning: LLMResponse["encryptedReasoning"];
+      const toolCallAccum = new Map<string, LLMToolCall>();
+      // Per-summary-index buffers for streamed reasoning summaries. xAI may
+      // emit multiple summary blocks in one turn; each lands at its own index.
+      const reasoningSummaryBuffers = new Map<number, string>();
+      let streamIterator: AsyncIterator<any> | null = null;
+      let responseTracePayload: Record<string, unknown> | undefined;
+      let streamResponseMeta: ProviderResponseTraceMeta | undefined;
       try {
       const requestAttemptTimeout =
         Number.isFinite(streamDeadlineAt)

--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -316,7 +316,14 @@ function findLongestPrefix(
 ): RegisteredModelCatalogEntry | undefined {
   const normalized = normalizeId(model);
   return candidates
-    .filter((entry) => normalized.startsWith(normalizeId(entry.model)))
+    .filter((entry) => {
+      const entryId = normalizeId(entry.model);
+      return (
+        normalized === entryId ||
+        (normalized.startsWith(entryId) &&
+          /[-.:/]/.test(normalized.charAt(entryId.length)))
+      );
+    })
     .sort((left, right) => right.model.length - left.model.length)[0];
 }
 

--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -172,16 +172,28 @@ export function buildAnthropicMessagesRequest(
                 }]
                 : []
               : anthropicContent;
-          const toolUseBlocks = message.toolCalls.map((toolCall) => ({
-            type: "tool_use",
-            id: toolCall.id,
-            // The messages API enforces the strict
-            // `^[a-zA-Z0-9_-]{1,64}$` function-name regex; encode the
-            // dotted MCP form before sending. The response parser
-            // decodes back to the internal-registry form.
-            name: encodeMcpToolNameForWire(toolCall.name),
-            input: JSON.parse(toolCall.arguments || "{}"),
-          }));
+          const toolUseBlocks = message.toolCalls.map((toolCall) => {
+            // History tool-call arguments are not re-validated, so a
+            // malformed JSON string must not throw here — that would
+            // also break parseAnthropicMessagesResponse, which rebuilds
+            // this request purely for metrics after a successful call.
+            let parsedInput: unknown = {};
+            try {
+              parsedInput = JSON.parse(toolCall.arguments || "{}");
+            } catch {
+              parsedInput = {};
+            }
+            return {
+              type: "tool_use",
+              id: toolCall.id,
+              // The messages API enforces the strict
+              // `^[a-zA-Z0-9_-]{1,64}$` function-name regex; encode the
+              // dotted MCP form before sending. The response parser
+              // decodes back to the internal-registry form.
+              name: encodeMcpToolNameForWire(toolCall.name),
+              input: parsedInput,
+            };
+          });
           const content =
             hasEphemeralCacheControl(message)
               ? withEphemeralCacheControl([

--- a/runtime/src/llm/wire/shared.ts
+++ b/runtime/src/llm/wire/shared.ts
@@ -43,11 +43,14 @@ function parseAudioDataUrl(
 function parseImageDataUrl(
   url: string,
 ): { readonly data: string; readonly mediaType: string } | null {
-  const match = /^data:(image\/(?:png|jpeg|gif|webp));base64,([\s\S]+)$/iu.exec(
+  const match = /^data:(image\/(?:png|jpe?g|gif|webp));base64,([\s\S]+)$/iu.exec(
     url.trim(),
   );
   if (!match) return null;
-  const mediaType = (match[1] ?? "").trim().toLowerCase();
+  const rawMediaType = (match[1] ?? "").trim().toLowerCase();
+  // The non-standard `image/jpg` form is common; Anthropic expects
+  // `image/jpeg`, so normalize it here.
+  const mediaType = rawMediaType === "image/jpg" ? "image/jpeg" : rawMediaType;
   const data = (match[2] ?? "").replace(/\s+/gu, "");
   if (!mediaType || !data) return null;
   return { data, mediaType };

--- a/runtime/src/memory/find-relevant.ts
+++ b/runtime/src/memory/find-relevant.ts
@@ -118,8 +118,13 @@ async function selectRelevantMemories(
       return []
     }
 
-    const parsed: { selected_memories: string[] } = jsonParse(textBlock.text)
-    return parsed.selected_memories.filter(f => validFilenames.has(f))
+    const parsed: { selected_memories?: unknown } = jsonParse(textBlock.text)
+    const list = Array.isArray(parsed?.selected_memories)
+      ? parsed.selected_memories
+      : []
+    return list.filter(
+      (f): f is string => typeof f === 'string' && validFilenames.has(f),
+    )
   } catch (e) {
     if (signal.aborted) {
       return []

--- a/runtime/src/memory/session/sessionMemory.ts
+++ b/runtime/src/memory/session/sessionMemory.ts
@@ -102,12 +102,15 @@ export interface ManualExtractionResult {
 interface SessionMemoryLane {
   readonly state: SessionMemoryState;
   queue: Promise<void>;
+  lastAccessedAt: number;
+  pending: number;
 }
 
 let agentRunnerForTests: SessionMemoryAgentRunner | null = null;
 let defaultSessionMemoryConfig: Partial<SessionMemoryConfig> = {};
 const defaultExtractionDecisionState = createSessionMemoryState();
 const lanes = new Map<string, SessionMemoryLane>();
+const MAX_SESSION_MEMORY_LANES = 256;
 
 function errnoCode(error: unknown): string | undefined {
   return typeof error === "object" &&
@@ -240,13 +243,30 @@ function laneKeyForContext(context: SessionMemoryPostSamplingContext): string {
 function laneForContext(context: SessionMemoryPostSamplingContext): SessionMemoryLane {
   const key = laneKeyForContext(context);
   const existing = lanes.get(key);
-  if (existing) return existing;
+  if (existing) {
+    existing.lastAccessedAt = Date.now();
+    return existing;
+  }
   const lane: SessionMemoryLane = {
     state: createSessionMemoryState(defaultSessionMemoryConfig),
     queue: Promise.resolve(),
+    lastAccessedAt: Date.now(),
+    pending: 0,
   };
   lanes.set(key, lane);
+  pruneIdleLanes();
   return lane;
+}
+
+function pruneIdleLanes(): void {
+  if (lanes.size <= MAX_SESSION_MEMORY_LANES) return;
+  const idleEntries = [...lanes.entries()]
+    .filter(([, lane]) => lane.pending === 0)
+    .sort(([, left], [, right]) => left.lastAccessedAt - right.lastAccessedAt);
+  for (const [key] of idleEntries) {
+    if (lanes.size <= MAX_SESSION_MEMORY_LANES) return;
+    lanes.delete(key);
+  }
 }
 
 function cwdForSession(session: Session | undefined): string {
@@ -528,12 +548,23 @@ export function runSessionMemoryPostSamplingHook(
   context: SessionMemoryPostSamplingContext,
 ): Promise<void> {
   const lane = laneForContext(context);
+  lane.pending += 1;
   lane.queue = lane.queue.then(
     async () => {
-      await extractSessionMemory(context, lane, false);
+      try {
+        await extractSessionMemory(context, lane, false);
+      } finally {
+        lane.pending -= 1;
+        lane.lastAccessedAt = Date.now();
+      }
     },
     async () => {
-      await extractSessionMemory(context, lane, false);
+      try {
+        await extractSessionMemory(context, lane, false);
+      } finally {
+        lane.pending -= 1;
+        lane.lastAccessedAt = Date.now();
+      }
     },
   );
   return lane.queue;
@@ -560,12 +591,18 @@ export async function manuallyExtractSessionMemory(
     ...(options.signal !== undefined ? { signal: options.signal } : {}),
   };
   const lane = laneForContext(context);
-  return (
-    (await extractSessionMemory(context, lane, true)) ?? {
-      success: false,
-      error: "Session memory extraction skipped",
-    }
-  );
+  lane.pending += 1;
+  try {
+    return (
+      (await extractSessionMemory(context, lane, true)) ?? {
+        success: false,
+        error: "Session memory extraction skipped",
+      }
+    );
+  } finally {
+    lane.pending -= 1;
+    lane.lastAccessedAt = Date.now();
+  }
 }
 
 export function initSessionMemory(

--- a/runtime/src/permissions/risk.ts
+++ b/runtime/src/permissions/risk.ts
@@ -57,7 +57,7 @@ export function typedConfirmationWordForRisk(input: {
   if (/\bsettle\b/u.test(haystack)) return "settle";
   if (/\bstake\b/u.test(haystack)) return "stake";
   if (/\btransfer\b/u.test(haystack)) return "transfer";
-  if (/\bdelete|destroy|wipe\b/u.test(haystack)) return "delete";
+  if (/\b(delete|destroy|wipe)\b/u.test(haystack)) return "delete";
   if (input.command && commandLooksLikeRemoval(input.command)) return "delete";
   return "approve";
 }

--- a/runtime/src/services/api/client.ts
+++ b/runtime/src/services/api/client.ts
@@ -149,7 +149,7 @@ export async function getproviderClient({
     timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
     dangerouslyAllowBrowser: true,
     fetchOptions: getProxyFetchOptions({
-      forproviderAPI: true,
+      forAnthropicAPI: true,
     }) as ClientOptions['fetchOptions'],
     ...(resolvedFetch && {
       fetch: resolvedFetch,

--- a/runtime/src/services/api/withRetry.ts
+++ b/runtime/src/services/api/withRetry.ts
@@ -218,10 +218,7 @@ export async function* withRetry<T>(
       // - Vertex-specific auth errors (credential refresh failures, 401)
       // - ECONNRESET/EPIPE: stale keep-alive socket; disable pooling and reconnect
       const isStaleConnection = isStaleConnectionError(lastError)
-      if (
-        isStaleConnection &&
-        false
-      ) {
+      if (isStaleConnection) {
         logForDebugging(
           'Stale connection (ECONNRESET/EPIPE) — disabling keep-alive for retry',
         )

--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -245,7 +245,8 @@ const MAX_MCP_DESCRIPTION_LENGTH = 2048
 
 /**
  * Gets the timeout for MCP tool calls in milliseconds.
- * Uses MCP_TOOL_TIMEOUT environment variable if set, otherwise defaults to ~27.8 hours.
+ * Uses MCP_TOOL_TIMEOUT environment variable if set, otherwise defaults to
+ * DEFAULT_MCP_TOOL_TIMEOUT_MS (5 minutes).
  */
 function getMcpToolTimeoutMs(): number {
   return (

--- a/runtime/src/services/mcp/envExpansion.ts
+++ b/runtime/src/services/mcp/envExpansion.ts
@@ -14,8 +14,10 @@ export function expandEnvVarsInString(value: string): {
   const missingVars: string[] = []
 
   const expanded = value.replace(/\$\{([^}]+)\}/g, (match, varContent) => {
-    // Split on :- to support default values (limit to 2 parts to preserve :- in defaults)
-    const [varName, defaultValue] = varContent.split(':-', 2)
+    // Split on the first :- to support default values, preserving any :- in the default
+    const sep = varContent.indexOf(':-')
+    const varName = sep === -1 ? varContent : varContent.slice(0, sep)
+    const defaultValue = sep === -1 ? undefined : varContent.slice(sep + 2)
     const envValue = process.env[varName]
 
     if (envValue !== undefined) {

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -1469,16 +1469,33 @@ function mergePendingInputIntoUserContent(
 function mergeSignals(
   a: AbortSignal | undefined,
   b: AbortSignal,
-): AbortSignal {
-  if (!a) return b;
-  if (a.aborted) return a;
-  if (b.aborted) return b;
+): { signal: AbortSignal; dispose: () => void } {
+  if (!a) return { signal: b, dispose: () => {} };
+  if (a.aborted) return { signal: a, dispose: () => {} };
+  if (b.aborted) return { signal: b, dispose: () => {} };
   const merged = new AbortController();
-  const onA = () => merged.abort((a as AbortSignal & { reason?: unknown }).reason);
-  const onB = () => merged.abort((b as AbortSignal & { reason?: unknown }).reason);
-  a.addEventListener("abort", onA, { once: true });
-  b.addEventListener("abort", onB, { once: true });
-  return merged.signal;
+  // Cross-remove both listeners when either fires so the listener left on
+  // a long-lived signal (e.g. the session-level abort, which is a single
+  // readonly AbortController for the whole session) is dropped on abort.
+  const dispose = (): void => {
+    a.removeEventListener("abort", onA);
+    b.removeEventListener("abort", onB);
+  };
+  const onA = (): void => {
+    dispose();
+    merged.abort((a as AbortSignal & { reason?: unknown }).reason);
+  };
+  const onB = (): void => {
+    dispose();
+    merged.abort((b as AbortSignal & { reason?: unknown }).reason);
+  };
+  a.addEventListener("abort", onA);
+  b.addEventListener("abort", onB);
+  // The returned `dispose` is invoked by the turn kernel's finally block so
+  // the happy path (turn completes without abort) also removes the listener
+  // left on the long-lived session signal, preventing an unbounded
+  // per-turn listener/memory leak.
+  return { signal: merged.signal, dispose };
 }
 
 function cumulativeUsage(acc: LLMUsage, next: LLMUsage | undefined): LLMUsage {
@@ -2793,6 +2810,7 @@ export async function* runTurnKernel(
     startedAtMs: turnStartedAt,
   });
   const codeModeTurnWorker = startCodeModeTurnWorker(session);
+  const signalCleanups: Array<() => void> = [];
 
   try {
     return yield* runTurnKernelInner(
@@ -2808,9 +2826,11 @@ export async function* runTurnKernel(
         emitTurnAborted,
         referenceContextItem,
         sessionOwner,
+        signalCleanups,
       },
     );
   } finally {
+    for (const cleanup of signalCleanups) cleanup();
     codeModeTurnWorker.dispose();
     // Upstream agenc runtime emits `on_task_finished` uniformly from the spawn
     // site so every task-kind shares the same lifecycle. In gut the
@@ -2835,6 +2855,10 @@ interface RunTurnKernelCommons {
   readonly sessionOwner: Session & {
     consumePendingProviderSwitch?: () => Promise<void>;
   };
+  // Disposers for the merged abort signals built inside the kernel. The
+  // outer `runTurnKernel` finally invokes these so listeners on long-lived
+  // signals (the session-level abort) are removed on every turn exit.
+  readonly signalCleanups: Array<() => void>;
 }
 
 async function* runTurnKernelInner(
@@ -3043,10 +3067,20 @@ async function* runTurnKernelInner(
   // (see `tasks/mod.rs` line 269) whose cancellation is triggered
   // by `abort_all_tasks`. The merged signal here is the gut
   // equivalent of `task_cancellation_token.child_token()`.
-  const signal = mergeSignals(
-    mergeSignals(opts.signal, session.abortController.signal),
+  const mergedSession = mergeSignals(
+    opts.signal,
+    session.abortController.signal,
+  );
+  const mergedTask = mergeSignals(
+    mergedSession.signal,
     runningTask.abortController.signal,
   );
+  const signal = mergedTask.signal;
+  // Both merges register `abort` listeners on their input signals; the
+  // first merge can leave a listener on the long-lived session signal.
+  // Hand the disposers to the outer kernel's finally so they run on every
+  // exit path (completed, aborted, error, abandoned generator).
+  commons.signalCleanups.push(mergedSession.dispose, mergedTask.dispose);
 
   let usage: LLMUsage = {
     promptTokens: 0,
@@ -3441,18 +3475,33 @@ async function* runTurnKernelInner(
       const completedByCallId = new Map(
         state.completedToolResults.map((record) => [record.callId, record]),
       );
+      // Index user records by their tool-call id rather than by position:
+      // results return in completion order (not toolCalls order), attachment
+      // records (no toolCallId) are appended onto `toolResults` after the tool
+      // results, and synthetic-recovery skips can make `toolResults` shorter
+      // than `toolCalls`. Positional lookup therefore mis-pairs calls and
+      // drops the tail, even though the content lives in `completedByCallId`.
+      const userRecByCallId = new Map(
+        state.toolResults
+          .filter(
+            (record): record is typeof record & { toolCallId: string } =>
+              "toolCallId" in record && typeof record.toolCallId === "string",
+          )
+          .map((record) => [record.toolCallId, record] as const),
+      );
       for (let i = 0; i < lastAssistant.toolCalls.length; i += 1) {
         const call = lastAssistant.toolCalls[i];
-        const userRec = state.toolResults[i];
-        if (!call || !userRec) continue;
+        if (!call) continue;
         const completed = completedByCallId.get(call.id);
+        const userRec = userRecByCallId.get(call.id);
+        if (!completed && !userRec) continue;
         yield {
           type: "tool_result",
           toolCall: call,
           result: {
             content:
               completed?.content ??
-              (typeof userRec.content === "string" ? userRec.content : ""),
+              (typeof userRec?.content === "string" ? userRec.content : ""),
             isError: completed?.isError ?? false,
             ...(completed?.metadata !== undefined
               ? { metadata: completed.metadata }

--- a/runtime/src/tasks/lifecycle.ts
+++ b/runtime/src/tasks/lifecycle.ts
@@ -241,8 +241,9 @@ export class BackgroundTaskLifecycle {
     const output = this.outputs.get(record.id) ?? { content: "", totalBytes: 0 };
     output.content += chunk;
     if (output.content.length > MAX_OUTPUT_CHARS) {
+      const removed = output.content.length - MAX_OUTPUT_CHARS;
       output.content = output.content.slice(-MAX_OUTPUT_CHARS);
-      record.outputOffset = Math.min(record.outputOffset, output.content.length);
+      record.outputOffset = Math.max(0, record.outputOffset - removed);
     }
     output.totalBytes += Buffer.byteLength(chunk, "utf8");
     this.outputs.set(record.id, output);
@@ -369,34 +370,40 @@ export class BackgroundTaskLifecycle {
     promise: Promise<T>,
     options: BindTaskPromiseOptions<T> = {},
   ): void {
-    void promise.then(
-      (value) => {
-        const mapped = options.onFulfilled?.(value);
-        const status = mapped?.status ?? "completed";
-        if (status === "failed") {
+    void promise
+      .then(
+        (value) => {
+          const mapped = options.onFulfilled?.(value);
+          const status = mapped?.status ?? "completed";
+          if (status === "failed") {
+            const snapshot = this.fail(
+              taskId,
+              mapped?.error ?? "task failed",
+              mapped?.output,
+              mapped?.metadata,
+            );
+            options.onSnapshot?.(snapshot);
+            return;
+          }
+          const snapshot = this.complete(taskId, mapped?.output, mapped?.metadata);
+          options.onSnapshot?.(snapshot);
+        },
+        (error) => {
+          const mapped = options.onRejected?.(error);
           const snapshot = this.fail(
             taskId,
-            mapped?.error ?? "task failed",
+            mapped?.error ?? error,
             mapped?.output,
             mapped?.metadata,
           );
           options.onSnapshot?.(snapshot);
-          return;
-        }
-        const snapshot = this.complete(taskId, mapped?.output, mapped?.metadata);
-        options.onSnapshot?.(snapshot);
-      },
-      (error) => {
-        const mapped = options.onRejected?.(error);
-        const snapshot = this.fail(
-          taskId,
-          mapped?.error ?? error,
-          mapped?.output,
-          mapped?.metadata,
-        );
-        options.onSnapshot?.(snapshot);
-      },
-    );
+        },
+      )
+      // A task can be evicted before its join promise settles; in that case the
+      // lifecycle transition throws BackgroundTaskError("not_found"). Swallow it
+      // so a late settle against an evicted task cannot escape as an unhandled
+      // rejection.
+      .catch(() => {});
   }
 
   drainNotifications(): BackgroundTaskNotification[] {

--- a/runtime/src/tools/system/notebook-edit.ts
+++ b/runtime/src/tools/system/notebook-edit.ts
@@ -302,17 +302,21 @@ export function createNotebookEditTool(config: NotebookEditToolConfig): Tool {
       } else {
         const cell = cells[index];
         if (!isRecord(cell)) return json({ error: "Invalid notebook cell." }, true);
-        const wasCode = cell.cell_type === "code";
         cell.source = args.new_source;
-        if (wasCode) {
-          cell.execution_count = null;
-          cell.outputs = [];
-        }
+        const finalCellType =
+          cellType ??
+          (typeof cell.cell_type === "string" ? cell.cell_type : undefined);
         if (cellType !== undefined && cellType !== cell.cell_type) {
           cell.cell_type = cellType;
         }
-        resultCellType =
-          typeof cell.cell_type === "string" ? cell.cell_type : undefined;
+        if (finalCellType === "code") {
+          cell.execution_count = null;
+          cell.outputs = [];
+        } else {
+          delete cell.execution_count;
+          delete cell.outputs;
+        }
+        resultCellType = finalCellType;
       }
 
       const updated = JSON.stringify(parsed, null, 1);

--- a/runtime/src/utils/model/model.ts
+++ b/runtime/src/utils/model/model.ts
@@ -422,6 +422,12 @@ export function getDefaultMainLoopModel(): ModelName {
  */
 export function firstPartyNameToCanonical(name: ModelName): ModelShortName {
   name = name.toLowerCase()
+  // Bedrock inference-profile IDs brand the model segment as
+  // "anthropic.agenc-<model>" (e.g. "us.anthropic.agenc-opus-4-6-v1"). Normalize
+  // that segment back to the canonical "claude-<model>" spelling so the version
+  // branches below match instead of falling through to the generic regex (which
+  // would only capture "agenc-opus").
+  name = name.replaceAll('anthropic.agenc-', 'anthropic.claude-')
   // Special cases for AgenC 4+ models to differentiate versions
   // Order matters: check more specific versions first (4-7 before 4-6 before 4-5 before 4)
   if (name.includes('claude-opus-4-7')) {

--- a/runtime/src/utils/model/modelAllowlist.ts
+++ b/runtime/src/utils/model/modelAllowlist.ts
@@ -46,10 +46,10 @@ function modelMatchesVersionPrefix(model: string, entry: string): boolean {
   if (prefixMatchesModel(resolvedModel, entry)) {
     return true
   }
-  // Try with "agenc-" prefix (e.g. "opus-4-5" → "claude-opus-4-5")
+  // Try with "claude-" prefix (e.g. "opus-4-5" → "claude-opus-4-5")
   if (
-    !entry.startsWith('agenc-') &&
-    prefixMatchesModel(resolvedModel, `agenc-${entry}`)
+    !entry.startsWith('claude-') &&
+    prefixMatchesModel(resolvedModel, `claude-${entry}`)
   ) {
     return true
   }

--- a/runtime/src/utils/model/modelOptions.ts
+++ b/runtime/src/utils/model/modelOptions.ts
@@ -154,7 +154,7 @@ function getCustomOpusOption(): ModelOption | undefined {
 
 function getOpus41Option(): ModelOption {
   return {
-    value: 'opus',
+    value: getModelStrings().opus41,
     label: 'Opus 4.1',
     description: `Opus 4.1 · Legacy`,
     descriptionForModel: 'Opus 4.1 - legacy version',
@@ -602,7 +602,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     payg3pOptions.push(customOpus)
   } else {
     // Add Opus 4.1, Opus 4.7, Opus 4.6 and Opus 4.6 1M
-    payg3pOptions.push(getOpus41Option()) // This is the default opus
+    payg3pOptions.push(getOpus41Option()) // Legacy Opus 4.1
     payg3pOptions.push(getOpus47Option(fastMode))
     payg3pOptions.push(getOpus46Option(fastMode))
     if (checkOpus1mAccess()) {

--- a/runtime/tests/agents/delegate.test.ts
+++ b/runtime/tests/agents/delegate.test.ts
@@ -415,6 +415,7 @@ describe("delegate lifecycle recovery", () => {
         reason: "hard_error",
       })),
       recordSuccess: vi.fn(),
+      transferFailureCount: vi.fn(),
     };
 
     mockRunAgent.mockImplementationOnce(() =>


### PR DESCRIPTION
A per-subsystem audit+fix pass (multi-agent workflow → manual review of every change → full local gate) found and fixed concrete correctness/robustness bugs across the core runtime. Each fix is **minimal and behavior-preserving** except for the bug itself.

## Highlights (real bugs, not style)
**Agents / lifecycle**
- `delegate.ts`+`resume.ts`: restarted subagents reset the per-thread failure counter to 0, so `RESUME_MAX_ATTEMPTS` could never trip → **unbounded restart loop**. Counter now transfers across restart.
- `fork-context.ts`: `last_n_turns` forks silently ignored N when caller-provided messages overrode the rollout store.
- `thread-manager.ts`: removed dead always-undefined refactor scaffolding.

**Session / tasks (correctness + leaks)**
- `run-turn.ts`: `tool_result` events paired **positionally** but results arrive in completion order, attachment records lack `toolCallId`, and synthetic-recovery shortens the array → mis-paired / tail-dropped events. Now keyed by call id. Also fixed a **per-turn abort-listener leak** on the long-lived session signal.
- `tasks/lifecycle.ts`: `outputOffset` not rebased after output-buffer truncation (delta drift); late settle on an evicted task escaped as an **unhandled rejection**.
- `memory/session/sessionMemory.ts`: per-context lane Map grew **unboundedly** (leak) → bounded LRU eviction.

**LLM wire / providers / registry**
- `messages-anthropic.ts`: unguarded `JSON.parse` of historical tool args could **throw after a successful API call**.
- `shared.ts`: `image/jpg` data URLs rejected → `[unsupported image]`; now normalized to `image/jpeg`.
- `model-catalog.ts`: prefix matched across token boundaries (`gpt-5.40` vs `gpt-5.4`).
- `grok/adapter.ts`: stream accumulators declared outside the retry loop → **duplicated reasoning summaries on fallback retry**.

**Services / permissions / model utils (several de-branding-induced)**
- `withRetry.ts`: `if (isStaleConnection && false)` left stale-socket recovery permanently dead.
- `api/client.ts`: `forproviderAPI` (botched de-brand) silently dropped the proxy option → `forAnthropicAPI`.
- `mcp/envExpansion.ts`: `${VAR:-default}` truncated defaults containing `:-`.
- `permissions/risk.ts`: `\bdelete|destroy|wipe\b` alternation bug → `\b(delete|destroy|wipe)\b`.
- `model.ts`/`modelAllowlist.ts`: de-branding left `agenc-` prefixes where model IDs are `claude-*`, so Bedrock canonical-name + version-prefix matching silently failed.
- `modelOptions.ts`: "Opus 4.1" picker entry resolved to default Opus (4.6/4.7); pinned to 4.1.
- `find-relevant.ts`: unvalidated parsed JSON could crash; guarded.
- `notebook-edit.ts`: cell-type conversion produced invalid nbformat.

Plus a one-line depth-cap comment clarification in `control.ts`, and a test-mock update (`delegate.test.ts`) for the new `transferFailureCount`.

## Verification (local)
- `tsc` clean · `tsup` build passes · full `vitest` **10351 passed / 10 skipped** · isolated Bun suite clean (one pre-existing unrelated failure: `utils/file.test.ts`).

## Scope note
This covered the high-value core (agents, session, mcp, api, llm providers/wire/registry, permissions, memory, tasks, system tools, model utils). The giant `tui`/`utils` grab-bags + several flagged **cross-cutting** issues (e.g. live-agent MCP refresh is a no-op; `modelSupports1M()` misses Opus 4.7, dropping 1M context for opus skills — lives in `utils/context.ts`) are deliberately left for follow-up passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)