### PR TITLE
fix(runtime): apply MCP-server refresh to live subagents (was a silent no-op)

### DIFF
--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -955,6 +955,7 @@ function drainChildMailbox(live: LiveAgent): {
   readonly clearHistory?: boolean;
   readonly interruptReason?: string;
   readonly nextUserMessage?: string | readonly LLMContentPart[];
+  readonly refreshMcpConfig?: unknown;
 } {
   const drained = live.downInbox.drain();
   if (drained.length === 0) {
@@ -964,6 +965,7 @@ function drainChildMailbox(live: LiveAgent): {
   const passthrough: InterAgentCommunication[] = [];
   const nextTurnParts: Array<string | readonly LLMContentPart[]> = [];
   let clearHistory = false;
+  let refreshMcpConfig: unknown;
   let shouldTriggerTurn = false;
 
   for (const item of drained) {
@@ -988,6 +990,12 @@ function drainChildMailbox(live: LiveAgent): {
       shouldTriggerTurn = false;
       continue;
     }
+    if (kind === "mcp_refresh") {
+      // Control message: refresh the live child's MCP servers between turns.
+      // Latest config wins; does not itself trigger a turn.
+      refreshMcpConfig = item.metadata?.mcpConfig;
+      continue;
+    }
     passthrough.push(item);
     shouldTriggerTurn ||= item.triggerTurn;
     const inputContent = item.metadata?.inputContent;
@@ -1010,11 +1018,15 @@ function drainChildMailbox(live: LiveAgent): {
         break;
       }
     }
-    return clearHistory ? { clearHistory } : {};
+    return {
+      ...(clearHistory ? { clearHistory } : {}),
+      ...(refreshMcpConfig !== undefined ? { refreshMcpConfig } : {}),
+    };
   }
 
   return {
     ...(clearHistory ? { clearHistory } : {}),
+    ...(refreshMcpConfig !== undefined ? { refreshMcpConfig } : {}),
     nextUserMessage: mergeChildInputParts(nextTurnParts),
   };
 }
@@ -2075,6 +2087,14 @@ export async function* runAgent(
       if (pendingChildInput.clearHistory) {
         await clearChildConversationHistory(childSession, live, history);
         assistantText = "";
+      }
+      if (pendingChildInput.refreshMcpConfig !== undefined) {
+        // Apply a parent-initiated MCP-config refresh to the live child so a
+        // running subagent picks up added/removed MCP servers between turns
+        // (previously a silent no-op in submitToLiveAgent).
+        await childSession.services.mcpManager?.refreshFromConfig?.(
+          pendingChildInput.refreshMcpConfig,
+        );
       }
       if (pendingChildInput.nextUserMessage !== undefined) {
         nextUserMessage = pendingChildInput.nextUserMessage;

--- a/runtime/src/agents/thread-manager.ts
+++ b/runtime/src/agents/thread-manager.ts
@@ -648,6 +648,18 @@ async function submitToLiveAgent(
       live.status.complete();
       return live.agentId;
     case "refresh_mcp_servers":
+      // Route the refresh to the child's run loop, which applies it to the
+      // child session's MCP manager between turns (drainChildMailbox /
+      // run-agent). Previously this was a silent no-op, leaving live
+      // subagents on stale MCP config.
+      live.downInbox.send({
+        author: live.agentPath,
+        recipient: live.agentPath,
+        content: "",
+        triggerTurn: false,
+        direction: "down",
+        metadata: { kind: "mcp_refresh", mcpConfig: op.config },
+      });
       return live.agentId;
   }
 }

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -22,6 +22,7 @@ import { AgentControl } from "./control.js";
 import { AgentRegistry } from "./registry.js";
 import {
   buildFilteredRegistry,
+  drainChildMailboxForTesting,
   initMcpForAgent,
   MCP_INIT_TIMEOUT_MS,
   mergeRoleDisallowlist,
@@ -736,6 +737,27 @@ describe("runAgent", () => {
     });
     expect(result.outcome).toBe("completed");
     expect(result.finalMessage).toBe("second turn");
+  });
+
+  it("surfaces a refresh_mcp_servers control message from the child downInbox", async () => {
+    const provider = makeProvider([]);
+    const session = makeStubSession({ services: { provider } });
+    const { live } = await spawnLive(session);
+
+    live.downInbox.send({
+      author: live.agentPath,
+      recipient: live.agentPath,
+      content: "",
+      triggerTurn: false,
+      direction: "down",
+      metadata: { kind: "mcp_refresh", mcpConfig: { servers: ["x"] } },
+    });
+
+    const drained = drainChildMailboxForTesting(live);
+    // Routed to the child as a control message (applied between turns); it
+    // surfaces the config and does NOT trigger a follow-up turn.
+    expect(drained.refreshMcpConfig).toEqual({ servers: ["x"] });
+    expect(drained.nextUserMessage).toBeUndefined();
   });
 
   it("injects child session metadata and worktree roots into wrapped child tools", async () => {


### PR DESCRIPTION
When the parent refreshed MCP config (e.g. an MCP server added mid-session), `ThreadManager.refreshMcpServers` fanned a `refresh_mcp_servers` op to every managed thread — but `submitToLiveAgent` just `return live.agentId` and **did nothing**. Running subagents kept stale MCP config and never picked up added/removed servers. (`submitToSession` correctly calls `refreshFromConfig`; only the live-agent path was a no-op.)

## Fix — route through the existing child control-message path
Mirrors how `clear_conversation_history` already works:
- **`thread-manager.ts` `submitToLiveAgent`**: send `{ kind: "mcp_refresh", mcpConfig }` on the child's `downInbox` instead of no-op'ing.
- **`run-agent.ts` `drainChildMailbox`**: drain the control message and surface `refreshMcpConfig` (doesn't trigger a turn; latest config wins).
- **`run-agent.ts` child loop**: between turns, apply via `childSession.services.mcpManager?.refreshFromConfig?.(config)`.

Applied **between turns** (can't safely swap the tool registry mid-turn), at the same point the other control messages are consumed.

## Test
Added a focused unit test (`drainChildMailboxForTesting`) asserting the control message surfaces `refreshMcpConfig` and does not trigger a follow-up turn.

## Verification (local)
- `tsc` clean · `tsup` build passes · full `vitest` **10352 passed / 10 skipped** · isolated Bun clean (one pre-existing unrelated failure: `utils/file.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)