### PR TITLE
chore(runtime): typecheck reclamation batch 2 — 9 more files off @ts-nocheck

### DIFF
--- a/runtime/src/constants/tools.ts
+++ b/runtime/src/constants/tools.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Moved-source note: this moved utility still imports not-yet-absorbed upstream subsystems.
 // biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle'
 import { TASK_OUTPUT_TOOL_NAME } from '../tools/TaskOutputTool/constants.js'

--- a/runtime/src/tools/ExitPlanModeTool/UI.tsx
+++ b/runtime/src/tools/ExitPlanModeTool/UI.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react';
 import { Markdown } from '../../tui/components/markdown/Markdown.js';
 import { MessageResponse } from 'src/tui/components/MessageResponse.js';
@@ -6,7 +5,6 @@ import { RejectedPlanMessage } from 'src/tui/components/v2/messagePrimitives.js'
 import { BLACK_CIRCLE } from 'src/constants/figures.js';
 import { getModeColor } from 'src/utils/permissions/PermissionMode.js';
 import { Box, Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import { getDisplayPath } from '../../utils/file.js';
 import { getPlan } from '../../utils/plans.js';
@@ -15,7 +13,7 @@ import type { Output } from './ExitPlanModeV2Tool.js';
 export function renderToolUseMessage(): React.ReactNode {
   return null;
 }
-export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], {
+export function renderToolResultMessage(output: Output, _progressMessagesForMessage: ProgressMessage[], {
   theme: _theme
 }: {
   theme: ThemeName;

--- a/runtime/src/tools/ToolSearchTool/prompt.ts
+++ b/runtime/src/tools/ToolSearchTool/prompt.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import { feature } from 'bun:bundle'
 import { isReplBridgeActive } from '../../bootstrap/state.js'
 import type { Tool } from '../Tool.js'

--- a/runtime/src/tools/WebFetchTool/UI.tsx
+++ b/runtime/src/tools/WebFetchTool/UI.tsx
@@ -1,10 +1,7 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import React from 'react';
 import { MessageResponse } from '../../tui/components/MessageResponse.js';
 import { TOOL_SUMMARY_MAX_LENGTH } from '../../constants/toolLimits.js';
 import { Box, Text } from '../../tui/ink.js';
-import type { ToolProgressData } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
 import { formatFileSize, truncate } from '../../utils/format.js';
 import type { Output } from './WebFetchTool.js';
@@ -38,7 +35,7 @@ export function renderToolResultMessage({
   code,
   codeText,
   result
-}: Output, _progressMessagesForMessage: ProgressMessage<ToolProgressData>[], {
+}: Output, _progressMessagesForMessage: ProgressMessage[], {
   verbose
 }: {
   verbose: boolean;

--- a/runtime/src/tools/WebSearchTool/UI.tsx
+++ b/runtime/src/tools/WebSearchTool/UI.tsx
@@ -1,12 +1,10 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import React from 'react';
 import { MessageResponse } from '../../tui/components/MessageResponse.js';
 import { TOOL_SUMMARY_MAX_LENGTH } from '../../constants/toolLimits.js';
 import { Box, Text } from '../../tui/ink.js';
 import type { ProgressMessage } from '../../types/message.js';
 import { truncate } from '../../utils/format.js';
-import type { Output, SearchResult, WebSearchProgress } from './WebSearchTool.js';
+import type { Output, SearchResult } from './WebSearchTool.js';
 function getSearchSummary(results: (SearchResult | string | null | undefined)[]): {
   searchCount: number;
   totalResultCount: number;
@@ -54,7 +52,7 @@ export function renderToolUseMessage({
   }
   return message;
 }
-export function renderToolUseProgressMessage(progressMessages: ProgressMessage<WebSearchProgress>[]): React.ReactNode {
+export function renderToolUseProgressMessage(progressMessages: ProgressMessage[]): React.ReactNode {
   if (progressMessages.length === 0) {
     return null;
   }

--- a/runtime/src/tools/WebSearchTool/providers/duckduckgo.ts
+++ b/runtime/src/tools/WebSearchTool/providers/duckduckgo.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import type { SearchInput, SearchProvider } from './types.js'
 import { applyDomainFilters, type ProviderOutput } from './types.js'
 // DuckDuckGo's HTML scraper aggressively blocks datacenter / repeat IPs with

--- a/runtime/src/tools/WebSearchTool/providers/exa.ts
+++ b/runtime/src/tools/WebSearchTool/providers/exa.ts
@@ -1,11 +1,10 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 /**
  * Exa Search API adapter.
  * POST https://api.exa.ai/search
  * Auth: x-api-key: <key>
  */
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, safeHostname, type ProviderOutput } from './types.js'
+import { safeHostname, type ProviderOutput } from './types.js'
 
 export const exaProvider: SearchProvider = {
   name: 'exa',

--- a/runtime/src/tools/WebSearchTool/providers/firecrawl.ts
+++ b/runtime/src/tools/WebSearchTool/providers/firecrawl.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import type { SearchInput, SearchProvider } from './types.js'
 import { applyDomainFilters, type ProviderOutput } from './types.js'
 export const firecrawlProvider: SearchProvider = {
@@ -22,8 +21,16 @@ export const firecrawlProvider: SearchProvider = {
     }
 
     const data = await app.search(query, { limit: 15 })
+    // The SDK over-types `.web` as `(SearchResultWeb | Document)[]`; firecrawl's
+    // web search returns web results carrying url/title/description, so narrow
+    // to the shape we read.
+    const webResults = (data.web ?? []) as ReadonlyArray<{
+      url: string
+      title?: string
+      description?: string
+    }>
     const hits = applyDomainFilters(
-      (data.web ?? []).map((r: { url: string; title?: string; description?: string }) => ({
+      webResults.map((r) => ({
         title: r.title ?? r.url,
         url: r.url,
         description: r.description,

--- a/runtime/src/tools/testing/TestingPermissionTool.tsx
+++ b/runtime/src/tools/testing/TestingPermissionTool.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 /**
  * This testing-only tool will always pop up a permission dialog when called by
  * the model.
@@ -26,7 +25,10 @@ export const TestingPermissionTool: Tool<InputSchema, string> = buildTool({
     return 'TestingPermission';
   },
   isEnabled() {
-    return "production" === 'test';
+    // Always disabled (the prior `"production" === 'test'` literal was a
+    // constant-false no-op). If this testing-only tool should be gated on an
+    // env, wire a real check — left behavior-identical here.
+    return false;
   },
   isConcurrencySafe() {
     return true;


### PR DESCRIPTION
Autonomous hardening loop (Phase 1). @ts-nocheck 178 → 169. Mechanical ProgressMessage fixes (3 tool UIs), a dropped unused import (exa), an SDK union narrow (firecrawl), a constant-false comparison → explicit `return false` (TestingPermissionTool), and 3 stale-suppression removals. Deferred 4 involved/justified files (generic constraint, native-module types, react-compiler-generated) for later ticks.

Verified: tsc clean, build passes, full vitest **10352 passed**, Bun clean (only pre-existing `utils/file.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)