### PR TITLE
chore(runtime): typecheck reclamation batch 3 — 3 more off @ts-nocheck (+ flag a real TaskStopTool bug)

### DIFF
--- a/runtime/src/services/api/cacheStatsTracker.ts
+++ b/runtime/src/services/api/cacheStatsTracker.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 /**
  * Per-query and per-session cache metrics tracker for Phase 1 observability.
  *

--- a/runtime/src/tools/BashTool/shouldUseSandbox.ts
+++ b/runtime/src/tools/BashTool/shouldUseSandbox.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import { splitCommand_DEPRECATED } from '../../utils/bash/commands.js'
 import { SandboxManager } from '../../utils/sandbox/sandbox-runtime.js'
 import { getSettings_DEPRECATED } from '../../utils/settings/settings.js'
@@ -20,7 +19,10 @@ type SandboxInput = {
 // system (which prompts users) is the actual security control.
 function containsExcludedCommand(command: string): boolean {
   // Check dynamic config for disabled commands and substrings
-  const raw = { commands: [], substrings: [] }
+  const raw: { commands: string[]; substrings: string[] } = {
+    commands: [],
+    substrings: [],
+  }
 
   const disabledCommands =
     typeof raw === 'object' && raw !== null

--- a/runtime/src/tools/ScheduleCronTool/prompt.ts
+++ b/runtime/src/tools/ScheduleCronTool/prompt.ts
@@ -1,6 +1,3 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
-import { feature } from 'bun:bundle'
 import { DEFAULT_CRON_JITTER_CONFIG } from '../../utils/cronTasks.js'
 import { isEnvTruthy } from '../../utils/envUtils.js'
 


### PR DESCRIPTION
Autonomous hardening loop (Phase 1). @ts-nocheck 169 → 166: cacheStatsTracker (stale), shouldUseSandbox (never[] → string[]), ScheduleCronTool/prompt (unused import).

**Flagged (not fixed — needs a real fix):** stripping `@ts-nocheck` from TaskStopTool revealed `call()` passes `{getAppState,setAppState}` to `stopTask()`, which needs `{getTask,...}` (StopTaskContext) — wrong shape, `getTask` missing → would throw at runtime. Deferred for a proper fix.

Verified: tsc clean, build, full vitest **10352 passed**, Bun clean (only pre-existing `utils/file.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)