### PR TITLE
chore(runtime): typecheck reclamation batch 4 — outputStyles + PowerShellTool/UI

### DIFF
--- a/runtime/src/constants/outputStyles.ts
+++ b/runtime/src/constants/outputStyles.ts
@@ -1,8 +1,5 @@
-// @ts-nocheck
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import figures from 'figures'
 import memoize from 'lodash-es/memoize.js'
-// @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
 import { getOutputStyleDirStyles } from '../outputStyles/loadOutputStylesDir.js'
 import type { OutputStyle } from '../utils/config.js'
 import { getCwd } from '../utils/cwd.js'
@@ -149,15 +146,12 @@ export const getAllOutputStyles = memoize(async function getAllOutputStyles(
   }
 
   const managedStyles = customStyles.filter(
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     style => style.source === 'policySettings',
   )
   const userStyles = customStyles.filter(
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     style => style.source === 'userSettings',
   )
   const projectStyles = customStyles.filter(
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     style => style.source === 'projectSettings',
   )
 

--- a/runtime/src/tools/PowerShellTool/UI.tsx
+++ b/runtime/src/tools/PowerShellTool/UI.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs';
 import * as React from 'react';
 import { KeyboardShortcutHint } from '../../tui/components/design-system/KeyboardShortcutHint.js';
@@ -10,7 +9,6 @@ import { ShellTimeDisplay } from '../../tui/components/shell/ShellTimeDisplay.js
 import { Box, Text } from '../../tui/ink.js';
 import type { Tool } from '../Tool.js';
 import type { ProgressMessage } from '../../types/message.js';
-import type { PowerShellProgress } from '../../types/tools.js';
 import type { ThemeName } from '../../utils/theme.js';
 import type { Out, PowerShellToolInput } from './PowerShellTool.js';
 // Constants for command display
@@ -47,7 +45,7 @@ export function renderToolUseMessage(input: Partial<PowerShellToolInput>, {
   }
   return displayCommand;
 }
-export function renderToolUseProgressMessage(progressMessagesForMessage: ProgressMessage<PowerShellProgress>[], {
+export function renderToolUseProgressMessage(progressMessagesForMessage: ProgressMessage[], {
   verbose,
   tools: _tools,
   terminalSize: _terminalSize,
@@ -75,7 +73,7 @@ export function renderToolUseQueuedMessage(): React.ReactNode {
       <Text dimColor>Waiting…</Text>
     </MessageResponse>;
 }
-export function renderToolResultMessage(content: Out, progressMessagesForMessage: ProgressMessage<PowerShellProgress>[], {
+export function renderToolResultMessage(content: Out, progressMessagesForMessage: ProgressMessage[], {
   verbose,
   theme: _theme,
   tools: _tools,
@@ -123,7 +121,7 @@ export function renderToolUseErrorMessage(result: ToolResultBlockParam['content'
   tools: _tools
 }: {
   verbose: boolean;
-  progressMessagesForMessage: ProgressMessage<PowerShellProgress>[];
+  progressMessagesForMessage: ProgressMessage[];
   tools: Tool[];
 }): React.ReactNode {
   return <FallbackToolUseErrorMessage result={result} verbose={verbose} />;


### PR DESCRIPTION
Autonomous hardening loop (Phase 1). @ts-nocheck directives 163 → 161: outputStyles (4 stale @ts-expect-error), PowerShellTool/UI (ProgressMessage generic + non-exported import). Deferred react-compiler-generated + generic-constraint + signature-mismatch files. Note: Phase-1 easy wins nearly exhausted — remaining files are mostly generated (keep @ts-nocheck) or need real type work.

Verified: tsc clean, build, full vitest **10352 passed**, Bun clean (only pre-existing utils/file.test.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)