### PR TITLE
fix(runtime): harden TaskOutput pipe-mode progress + poller monotonicity

### DIFF
--- a/runtime/src/utils/task/TaskOutput.ts
+++ b/runtime/src/utils/task/TaskOutput.ts
@@ -137,17 +137,21 @@ export class TaskOutput {
             if (lineCount === 100) n100 = pos <= 0 ? 0 : pos + 1
           }
           // lineCount is exact when the whole file fits in PROGRESS_TAIL_BYTES.
-          // Otherwise extrapolate from the tail sample; monotone max keeps the
-          // counter from going backwards when the tail has longer lines on one tick.
+          // Otherwise extrapolate from the tail sample. Monotone max keeps the
+          // counter from going backwards — both when the tail has longer lines
+          // on one tick, and when ticks (which run without awaiting the prior
+          // read's I/O) resolve out of order. The output file is append-only, so
+          // size and line counts only ever grow; clamping both branches and the
+          // byte total preserves that invariant against stale late-resolving reads.
           const totalLines =
             bytesRead >= bytesTotal
-              ? lineCount
+              ? Math.max(entry.#totalLines, lineCount)
               : Math.max(
                   entry.#totalLines,
                   Math.round((bytesTotal / bytesRead) * lineCount),
                 )
           entry.#totalLines = totalLines
-          entry.#totalBytes = bytesTotal
+          entry.#totalBytes = Math.max(entry.#totalBytes, bytesTotal)
           entry.#onProgress(
             content.slice(n5),
             content.slice(n100),
@@ -233,6 +237,24 @@ export class TaskOutput {
         }
       }
       pos = prev
+    }
+
+    // The loop above only extracts segments *between* newlines, so the text
+    // before the first newline of the chunk is never captured by it. After the
+    // loop `pos` holds the index of the first newline (or the whole chunk length
+    // when there is no newline at all), so data.slice(0, pos) is that leading
+    // segment. Without this, a chunk that is exactly one line (the common
+    // pipe-mode/hooks case, e.g. "done\n") yields zero extracted lines and the
+    // onProgress callback below never fires. Mirror the in-loop guards exactly.
+    if (lines.length < MAX_PROGRESS_LINES && extractedBytes < MAX_PROGRESS_BYTES) {
+      const lineLen = pos
+      if (lineLen > 0 && lineLen <= MAX_PROGRESS_BYTES - extractedBytes) {
+        const line = data.slice(0, pos)
+        if (line.trim()) {
+          lines.push(Buffer.from(line).toString())
+          extractedBytes += lineLen
+        }
+      }
     }
 
     this.#totalLines += lineCount

--- a/runtime/tests/tasks/TaskOutput.test.ts
+++ b/runtime/tests/tasks/TaskOutput.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { TaskOutput } from 'src/utils/task/TaskOutput.js'
+
+type ProgressCall = {
+  lastLines: string
+  allLines: string
+  totalLines: number
+  totalBytes: number
+  isIncomplete: boolean
+}
+
+function makePipeOutput() {
+  const calls: ProgressCall[] = []
+  const out = new TaskOutput(
+    `test-${calls.length}-${calls.push.length}`,
+    (lastLines, allLines, totalLines, totalBytes, isIncomplete) => {
+      calls.push({ lastLines, allLines, totalLines, totalBytes, isIncomplete })
+    },
+    // pipe mode (hooks): data flows through writeStdout()
+    false,
+  )
+  return { out, calls }
+}
+
+describe('TaskOutput pipe-mode progress (#updateProgress)', () => {
+  it('extracts a chunk that is exactly one complete line', () => {
+    // Regression: the backward scan only sliced text *between* newlines, so the
+    // segment before the first newline (here the entire line) was dropped and
+    // onProgress never fired for single-line writes — the common hooks case.
+    const { out, calls } = makePipeOutput()
+    out.writeStdout('done\n')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.lastLines).toBe('done')
+  })
+
+  it('extracts both lines of a two-line chunk in document order', () => {
+    const { out, calls } = makePipeOutput()
+    out.writeStdout('line1\nline2\n')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.lastLines).toBe('line1\nline2')
+  })
+
+  it('extracts a leading complete line plus an unterminated trailing line', () => {
+    const { out, calls } = makePipeOutput()
+    out.writeStdout('line1\nline2')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.lastLines).toBe('line1\nline2')
+  })
+
+  it('extracts a chunk that has no newline at all', () => {
+    const { out, calls } = makePipeOutput()
+    out.writeStdout('no newline here')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.lastLines).toBe('no newline here')
+  })
+
+  it('skips empty and whitespace-only writes (no progress callback)', () => {
+    const { out, calls } = makePipeOutput()
+    out.writeStdout('\n')
+    out.writeStdout('   \n')
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('accumulates totalBytes across writes', () => {
+    const { out, calls } = makePipeOutput()
+    out.writeStdout('abc\n')
+    out.writeStdout('de\n')
+
+    expect(out.totalBytes).toBe(7)
+    expect(calls.at(-1)!.totalBytes).toBe(7)
+  })
+})


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/utils/task` (audit→adversarial-verify workflow). Two real, adversarially-confirmed bugs fixed in `TaskOutput.ts`:

1. **`#updateProgress` dropped the leading line of every chunk.** The backward scan only sliced text *between* newlines, so the segment before the first newline was never captured. A chunk that is exactly one line (`"done\n"` — the common pipe-mode/hooks case) yielded zero extracted lines, so `onProgress` never fired and recent-lines stayed empty. Now captures the leading segment after the loop, mirroring the in-loop guards.

2. **Poller (`#tick`) counters could move backward.** Ticks run without awaiting the prior read's I/O, so out-of-order resolution could regress `#totalLines`/`#totalBytes`. The exact-`lineCount` branch and the byte assignment had no monotone guard (only the extrapolation branch did — against the documented intent in the comment). Both are now clamped with `Math.max`; the output file is append-only so counts only ever grow.

## Tests
Adds `tests/tasks/TaskOutput.test.ts` locking pipe-mode progress extraction: single-line, multi-line, unterminated trailing line, no-newline, and empty/whitespace inputs.

## Deferred (flagged for a separate human-reviewed PR)
The same audit surfaced `readFileRange`/`tailFile` UTF-8-boundary + char-vs-byte-unit issues. Those modify a shared fs primitive with wider blast radius and are low-severity, so they're left for a deliberate PR rather than this auto-merge batch.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10358 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` `addLineNumbers` failure, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)