### PR TITLE
fix(runtime): harden swarm error paths (getLeaderName, spawn cleanup leak)

### DIFF
--- a/runtime/src/utils/swarm/permissionSync.ts
+++ b/runtime/src/utils/swarm/permissionSync.ts
@@ -198,6 +198,19 @@ export async function getLeaderName(teamName?: string): Promise<string | null> {
     return null
   }
 
+  // readTeamFileAsync casts the parsed JSON to TeamFile without validating its
+  // shape, so a present-but-malformed/version-skewed file (e.g. missing
+  // `members`) would make the .find() below throw. Callers `await` this before
+  // their try blocks, so a throw becomes an unhandled rejection and the worker
+  // silently never sends its request. Follow the same graceful return-null
+  // contract as the not-found path above.
+  if (!Array.isArray(teamFile.members)) {
+    logForDebugging(
+      `[PermissionSync] Team file for ${team} is malformed (missing members)`,
+    )
+    return null
+  }
+
   const leadMember = teamFile.members.find(
     m => m.agentId === teamFile.leadAgentId,
   )

--- a/runtime/src/utils/swarm/spawnInProcess.ts
+++ b/runtime/src/utils/swarm/spawnInProcess.ts
@@ -111,6 +111,11 @@ export async function spawnInProcessTeammate(
     `[spawnInProcessTeammate] Spawning ${agentId} (taskId: ${taskId})`,
   )
 
+  // Hoisted so the error path can unregister it. Without this, if registerTask
+  // throws after registerCleanup() has run, the closure leaks in the global
+  // cleanup Set forever (and would abort a never-started teammate on shutdown).
+  let unregisterCleanup: (() => void) | undefined
+
   try {
     // Create independent AbortController for this teammate
     // Teammates should not be aborted when the leader's query is interrupted
@@ -170,7 +175,7 @@ export async function spawnInProcessTeammate(
     }
 
     // Register cleanup handler for graceful shutdown
-    const unregisterCleanup = registerCleanup(async () => {
+    unregisterCleanup = registerCleanup(async () => {
       logForDebugging(`[spawnInProcessTeammate] Cleanup called for ${agentId}`)
       abortController.abort()
       // Task state will be updated by the execution loop when it detects abort
@@ -192,6 +197,11 @@ export async function spawnInProcessTeammate(
       teammateContext,
     }
   } catch (error) {
+    // The task was never inserted into AppState (registerTask failed), so
+    // nothing else will ever call the unregister fn — drop it here so the
+    // closure doesn't leak in the global cleanup Set. Idempotent: a no-op
+    // Set.delete if it was already removed.
+    unregisterCleanup?.()
     const errorMessage =
       error instanceof Error ? error.message : 'Unknown error during spawn'
     logForDebugging(

--- a/runtime/tests/swarm/permissionSync.getLeaderName.test.ts
+++ b/runtime/tests/swarm/permissionSync.getLeaderName.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the team-file reader so we can exercise getLeaderName against
+// well-formed and malformed team files without touching disk.
+const readTeamFileAsync = vi.fn()
+vi.mock('src/utils/swarm/teamHelpers.js', () => ({
+  readTeamFileAsync: (...args: unknown[]) => readTeamFileAsync(...args),
+  // getTeamName is referenced by getLeaderName when no teamName is passed;
+  // our tests always pass an explicit team, but provide a stub anyway.
+  getTeamName: () => undefined,
+}))
+
+import { getLeaderName } from 'src/utils/swarm/permissionSync.js'
+
+afterEach(() => {
+  readTeamFileAsync.mockReset()
+})
+
+describe('getLeaderName', () => {
+  it('returns the lead member name for a well-formed team file', async () => {
+    readTeamFileAsync.mockResolvedValue({
+      leadAgentId: 'a1',
+      members: [
+        { agentId: 'a1', name: 'captain' },
+        { agentId: 'a2', name: 'scout' },
+      ],
+    })
+    await expect(getLeaderName('team-x')).resolves.toBe('captain')
+  })
+
+  it('falls back to "team-lead" when the lead member has no name', async () => {
+    readTeamFileAsync.mockResolvedValue({
+      leadAgentId: 'a1',
+      members: [{ agentId: 'a1' }],
+    })
+    await expect(getLeaderName('team-x')).resolves.toBe('team-lead')
+  })
+
+  it('returns null (no throw) when the team file is missing', async () => {
+    readTeamFileAsync.mockResolvedValue(null)
+    await expect(getLeaderName('team-x')).resolves.toBeNull()
+  })
+
+  it('returns null (no throw) when the team file is malformed (missing members)', async () => {
+    // Regression: readTeamFileAsync casts JSON to TeamFile without validation,
+    // so a present-but-malformed file used to make .find() throw — surfacing as
+    // an unhandled rejection in the fire-and-forget caller. It must instead
+    // follow the graceful return-null contract.
+    readTeamFileAsync.mockResolvedValue({ leadAgentId: 'a1' })
+    await expect(getLeaderName('team-x')).resolves.toBeNull()
+  })
+
+  it('returns null when members is present but not an array', async () => {
+    readTeamFileAsync.mockResolvedValue({ leadAgentId: 'a1', members: {} })
+    await expect(getLeaderName('team-x')).resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/utils/swarm` (audit→adversarial-verify workflow). Two adversarially-confirmed bugs fixed on swarm error paths:

1. **`permissionSync.getLeaderName` threw on a malformed team file.** `readTeamFileAsync` casts parsed JSON to `TeamFile` without validation, so a present-but-malformed/version-skewed file (missing `members`) made `.find()` throw. Both callers `await getLeaderName(...)` *before* their try blocks, so the throw became an unhandled rejection and the worker silently never sent its permission request (polling until abort, no logged reason). Added a members-shape guard following the same graceful `return null` contract as the existing not-found path.

2. **`spawnInProcessTeammate` leaked its cleanup closure on the error path.** `registerCleanup()` adds a closure to the global cleanup Set; if the subsequent `registerTask()` throws, the catch returned failure without unregistering, leaking the closure for the process lifetime (and it would abort a never-started teammate on shutdown). Hoisted `unregisterCleanup` and call it in the catch.

## Tests
Adds `tests/swarm/permissionSync.getLeaderName.test.ts` (well-formed, no-name fallback, missing-file, malformed/missing-members, non-array-members).

## Deferred (flagged for separate human-reviewed PRs)
The audit surfaced 8 more confirmed-but-risky findings (control-flow / permission-wiring / pane-lifecycle / UI-race) left for deliberate PRs rather than this auto-merge batch — recorded in the hardening ledger. Highlights: `inProcessRunner` lifecycle-abort not unblocking a pending permission prompt (teammate zombie on kill); `leaderPermissionBridge` never registered; `teammateModel` mistral/xai default (product decision); `ITermBackend`/`PaneBackendExecutor` pane leaks on spawn failure; `teammateModeSnapshot` never captured + dead CLI override; `It2SetupPrompt` cancel race.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10363 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` `addLineNumbers` failure, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)