### PR TITLE
fix(runtime): correct settings validation diagnostics (too_small, malformed-JSON tip, error message)

### DIFF
--- a/runtime/src/utils/settings/settings.ts
+++ b/runtime/src/utils/settings/settings.ts
@@ -521,9 +521,11 @@ export function updateSettingsForSource(
       )
     }
   } catch (e) {
-    const error = new Error(
-      `Failed to read raw settings from ${filePath}: ${e}`,
-    )
+    // This try wraps mkdir + read + merge + write, so a failure can originate
+    // from any of them. Use a neutral message rather than the read-specific
+    // one, which misdirected debugging of write/flush failures (ENOSPC, EACCES,
+    // read-only fs) by reporting them as "read" errors.
+    const error = new Error(`Failed to update settings at ${filePath}: ${e}`)
     logError(error)
     return { error }
   }

--- a/runtime/src/utils/settings/validation.ts
+++ b/runtime/src/utils/settings/validation.ts
@@ -156,7 +156,14 @@ export function formatZodError(
       const keys = issue.keys.join(', ')
       message = `Unrecognized ${plural(issue.keys.length, 'field')}: ${keys}`
     } else if (isTooSmallIssue(issue)) {
-      message = `Number must be greater than or equal to ${issue.minimum}`
+      // Only numeric origins should use the "Number must be ..." phrasing.
+      // For array/string/set/date origins, preserve issue.message — which is
+      // either the schema author's custom message (e.g. "Server command must
+      // have at least one element") or Zod's accurate default — instead of
+      // mislabelling them as "Number".
+      if (issue.origin === 'number' || issue.origin === 'bigint') {
+        message = `Number must be greater than or equal to ${issue.minimum}`
+      }
       expected = String(issue.minimum)
     }
 

--- a/runtime/src/utils/settings/validationTips.ts
+++ b/runtime/src/utils/settings/validationTips.ts
@@ -107,7 +107,11 @@ const TIP_MATCHERS: TipMatcher[] = [
     matches: (ctx): boolean =>
       ctx.code === 'invalid_type' &&
       ctx.expected === 'object' &&
-      ctx.received === null &&
+      // formatZodError passes `received` as the type-name STRING (e.g. 'null'),
+      // never the JS null literal — so the old `=== null` never matched and
+      // this malformed-JSON suggestion was dead code. Compare the string form
+      // (mirrors the sibling check in validation.ts that rewrites the message).
+      ctx.received === 'null' &&
       ctx.path === '',
     tip: {
       suggestion:

--- a/runtime/tests/settings/validation.formatZodError.test.ts
+++ b/runtime/tests/settings/validation.formatZodError.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+
+import { formatZodError } from 'src/utils/settings/validation.js'
+import { getValidationTip } from 'src/utils/settings/validationTips.js'
+
+describe('formatZodError too_small handling', () => {
+  it('keeps the "Number must be ..." phrasing for numeric origins', () => {
+    const schema = z.number().min(5)
+    const result = schema.safeParse(3)
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const [err] = formatZodError(result.error, 'settings')
+    expect(err!.message).toBe('Number must be greater than or equal to 5')
+  })
+
+  it('preserves a schema author\'s custom message for array (non-number) origins', () => {
+    // Regression: too_small was unconditionally rewritten to "Number must be
+    // greater than or equal to N", discarding custom array messages and
+    // mislabelling array origins as "Number".
+    const schema = z.object({
+      serverCommand: z
+        .array(z.string())
+        .min(1, 'Server command must have at least one element (the command)'),
+    })
+    const result = schema.safeParse({ serverCommand: [] })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const [err] = formatZodError(result.error, 'settings')
+    expect(err!.message).toBe(
+      'Server command must have at least one element (the command)',
+    )
+    expect(err!.message).not.toContain('Number')
+  })
+})
+
+describe('getValidationTip malformed-JSON matcher', () => {
+  it('attaches the syntax-error suggestion for a null root (received as the string "null")', () => {
+    // Regression: the matcher compared `received === null` (JS literal) but
+    // formatZodError supplies the type-name string 'null', so the suggestion
+    // was dead code.
+    const tip = getValidationTip({
+      path: '',
+      code: 'invalid_type',
+      expected: 'object',
+      received: 'null',
+    })
+    expect(tip?.suggestion).toContain('missing commas')
+  })
+
+  it('does not attach the suggestion for a non-root path', () => {
+    const tip = getValidationTip({
+      path: 'permissions',
+      code: 'invalid_type',
+      expected: 'object',
+      received: 'null',
+    })
+    expect(tip?.suggestion).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/utils/settings` (audit→adversarial-verify workflow). Three adversarially-confirmed diagnostic-correctness bugs fixed:

1. **`formatZodError` discarded custom `too_small` messages and mislabelled non-number origins as "Number".** It unconditionally rewrote every `too_small` issue to `Number must be greater than or equal to N`, so an empty `serverCommand` array showed a bogus "Number" error instead of the schema's accurate `Server command must have at least one element`. Now only `number`/`bigint` origins use the numeric phrasing; other origins preserve `issue.message`.

2. **The malformed-JSON validation tip was dead code.** The matcher compared `ctx.received === null` (JS literal), but `formatZodError` supplies the type-name **string** `'null'`, so the "check for missing commas / unmatched brackets" suggestion never attached to a malformed settings root. Now compares the string form (mirrors the sibling check in `validation.ts`).

3. **`updateSettingsForSource` reported write failures as read failures.** A single catch wrapped mkdir+read+merge+write and labelled everything `Failed to read raw settings`, misdirecting debugging of write/flush failures (ENOSPC, EACCES, read-only fs). Now a neutral `Failed to update settings` message.

## Tests
Adds `tests/settings/validation.formatZodError.test.ts`: numeric vs array `too_small` messages, and the malformed-JSON tip matcher (root vs non-root path).

## Deferred (flagged for human PRs)
Valid-`null` settings file misreported as syntax error (needs parse-failure detection independent of `safeParseJSON`); enterprise/managed MCP config errors omitted from `getSettingsWithAllErrors`; schema-invalid MDM/HKLM policy silently dropping validation errors (admin-feedback/policy semantics). Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10367 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` `addLineNumbers` failure, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)