### PR TITLE
fix(runtime): isolate hook leaks/rejections (session-hook cleanup, progress-interval catch)

### DIFF
--- a/runtime/src/utils/hooks/execAgentHook.ts
+++ b/runtime/src/utils/hooks/execAgentHook.ts
@@ -82,6 +82,11 @@ export async function execAgentHook(
     // Combined signal is just our controller's signal now
     const combinedSignal = hookAbortController.signal
 
+    // Set once the per-agent Stop hook is registered, so the finally below can
+    // always remove it — the success path alone used to clear it, leaking the
+    // hook-agent-<uuid> entry on every throw/abort.
+    let hookAgentIdForCleanup: ReturnType<typeof asAgentId> | undefined
+
     try {
       // Create StructuredOutput tool with our schema
       const structuredOutputTool = createStructuredOutputTool()
@@ -156,6 +161,7 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
         toolUseContext.setAppState,
         hookAgentId,
       )
+      hookAgentIdForCleanup = hookAgentId
 
       let structuredOutputResult: { ok: boolean; reason?: string } | null = null
       let turnCount = 0
@@ -227,9 +233,6 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
       parentTimeoutSignal.removeEventListener('abort', onParentTimeout)
       cleanupCombinedSignal()
 
-      // Clean up the session hook we registered for this agent
-      clearSessionHooks(toolUseContext.setAppState, hookAgentId)
-
       // Check if we got a result
       if (!structuredOutputResult) {
         // If we hit max turns, just log and return cancelled (no UI message)
@@ -291,6 +294,13 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
         }
       }
       throw error
+    } finally {
+      // Always remove the per-agent Stop hook, regardless of
+      // success/abort/throw. Idempotent Map.delete, and only runs once the
+      // hook was actually registered.
+      if (hookAgentIdForCleanup) {
+        clearSessionHooks(toolUseContext.setAppState, hookAgentIdForCleanup)
+      }
     }
   } catch (error) {
     const errorMsg = errorMessage(error)

--- a/runtime/src/utils/hooks/hookEvents.ts
+++ b/runtime/src/utils/hooks/hookEvents.ts
@@ -133,18 +133,27 @@ export function startHookProgressInterval(params: {
 
   let lastEmittedOutput = ''
   const interval = setInterval(() => {
-    void params.getOutput().then(({ stdout, stderr, output }) => {
-      if (output === lastEmittedOutput) return
-      lastEmittedOutput = output
-      emitHookProgress({
-        hookId: params.hookId,
-        hookName: params.hookName,
-        hookEvent: params.hookEvent,
-        stdout,
-        stderr,
-        output,
+    void params
+      .getOutput()
+      .then(({ stdout, stderr, output }) => {
+        if (output === lastEmittedOutput) return
+        lastEmittedOutput = output
+        emitHookProgress({
+          hookId: params.hookId,
+          hookName: params.hookName,
+          hookEvent: params.hookEvent,
+          stdout,
+          stderr,
+          output,
+        })
       })
-    })
+      .catch(err => {
+        // getOutput is caller-supplied; isolate a rejection so it doesn't
+        // surface as a per-tick unhandledRejection on this repeating interval.
+        logForDebugging(
+          `Hook progress getOutput failed for ${params.hookName}: ${err}`,
+        )
+      })
   }, params.intervalMs ?? 1000)
   interval.unref()
 


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/utils/hooks` (audit→adversarial-verify workflow). Two adversarially-confirmed isolation bugs fixed:

1. **`execAgentHook` leaked its per-agent Stop hook on error/abort paths.** The session-scoped hook registered under a fresh `hook-agent-<uuid>` key was cleared only on normal completion; if `query()` threw mid-stream or the parent signal aborted, the entry was orphaned in the long-lived `sessionHooks` Map for the session's lifetime — an unbounded leak under repeatedly-failing stop/verification hook agents. Moved cleanup into a `finally`, tracked via a hoisted id set only after registration (runs on every exit path, never touches `hookAgentId` before assignment). `clearSessionHooks` is an idempotent `Map.delete`.

2. **`startHookProgressInterval` could emit a per-tick `unhandledRejection`.** The repeating `getOutput().then()` had no `.catch`, so a rejecting caller-supplied `getOutput` surfaced as an unhandled rejection every ~1000ms until the interval cleared. Added a logging `.catch` matching the emit subsystem's best-effort logging.

Both are error-path/leak isolation with no happy-path behavior change, verified via the full gate (nothing observable to assert in a focused test without heavy `query()`/timer/AppState mocking).

## Deferred (flagged for human / Phase-3)
`fileChangedWatcher` is dead (`initializeFileChangedWatcher` never called, so `initialized` stays false) and its mid-session start via `onCwdChangedForHooks` leaks because cleanup is only registered when `hasEnvHooks` was true at init. Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10367 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` `addLineNumbers` failure, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)