### PR TITLE
fix(runtime): plugin loader robustness (memo poisoning, per-file isolation, case-insensitive .md, manifest layout)

### DIFF
--- a/runtime/src/utils/plugins/installedPluginsManager.ts
+++ b/runtime/src/utils/plugins/installedPluginsManager.ts
@@ -1013,16 +1013,25 @@ function getPluginVersionFromManifest(
   pluginId: string,
 ): string {
   const fs = getFsImplementation()
-  const manifestPath = join(pluginCachePath, '.agenc-plugin', 'plugin.json')
-
-  try {
-    const manifestContent = fs.readFileSync(manifestPath, { encoding: 'utf-8' })
-    const manifest = jsonParse(manifestContent)
-    return manifest.version || 'unknown'
-  } catch {
-    logForDebugging(`Could not read version from manifest for ${pluginId}`)
-    return 'unknown'
+  // Mirror the loader's dual-layout support (pluginLoader.ts): the new layout
+  // is .agenc-plugin/plugin.json, but legacy plugins keep a root plugin.json.
+  // Checking only the new layout returned 'unknown' for legacy plugins even
+  // when a valid version existed, recording a degraded version + cache path.
+  for (const relParts of [['.agenc-plugin', 'plugin.json'], ['plugin.json']]) {
+    try {
+      const manifestContent = fs.readFileSync(join(pluginCachePath, ...relParts), {
+        encoding: 'utf-8',
+      })
+      const version = jsonParse(manifestContent).version
+      if (version) {
+        return version
+      }
+    } catch {
+      // Try the next layout.
+    }
   }
+  logForDebugging(`Could not read version from manifest for ${pluginId}`)
+  return 'unknown'
 }
 
 /**

--- a/runtime/src/utils/plugins/loadPluginAgents.ts
+++ b/runtime/src/utils/plugins/loadPluginAgents.ts
@@ -83,7 +83,10 @@ async function loadAgentFromFile(
     )
 
     const baseAgentName =
-      (frontmatter.name as string) || basename(filePath).replace(/\.md$/, '')
+      (frontmatter.name as string) ||
+      // Case-insensitive to match walkPluginMarkdown's case-insensitive .md
+      // discovery — otherwise a Foo.MD file loads but keeps ".MD" in its name.
+      basename(filePath).replace(/\.md$/i, '')
 
     // Apply namespace prefixing like we do for commands
     const nameParts = [pluginName, ...namespace, baseAgentName]
@@ -300,7 +303,10 @@ export const loadPluginAgents = memoize(
                       )
                     }
                     return agents
-                  } else if (stats.isFile() && agentPath.endsWith('.md')) {
+                  } else if (
+                    stats.isFile() &&
+                    agentPath.toLowerCase().endsWith('.md')
+                  ) {
                     // Load single agent file
                     const agent = await loadAgentFromFile(
                       agentPath,

--- a/runtime/src/utils/plugins/loadPluginCommands.ts
+++ b/runtime/src/utils/plugins/loadPluginCommands.ts
@@ -82,7 +82,8 @@ function getCommandNameFromFile(
   } else {
     // For regular files, use filename without .md
     const fileDirectory = dirname(filePath)
-    const commandBaseName = basename(filePath).replace(/\.md$/, '')
+    // Case-insensitive to match the case-insensitive .md discovery walk.
+    const commandBaseName = basename(filePath).replace(/\.md$/i, '')
 
     // Build namespace from file directory
     const relativePath = fileDirectory.startsWith(baseDir)
@@ -539,7 +540,7 @@ export const getPluginCommands = memoize(async (): Promise<Command[]> => {
 
                 // Fall back to filename-based naming if no metadata
                 if (!commandName) {
-                  commandName = `${plugin.name}:${basename(commandPath).replace(/\.md$/, '')}`
+                  commandName = `${plugin.name}:${basename(commandPath).replace(/\.md$/i, '')}`
                 }
 
                 // Apply metadata overrides to frontmatter

--- a/runtime/src/utils/plugins/marketplaceManager.ts
+++ b/runtime/src/utils/plugins/marketplaceManager.ts
@@ -2126,61 +2126,77 @@ export async function getMarketplaceCacheOnly(
  */
 export const getMarketplace = memoize(
   async (name: string): Promise<PluginMarketplace> => {
-    const config = await loadKnownMarketplacesConfig()
-    const entry = config[name]
-
-    if (!entry) {
-      throw new Error(
-        `Marketplace '${name}' not found in configuration. Available marketplaces: ${Object.keys(config).join(', ')}`,
-      )
-    }
-
-    // Compatibility entries (pre-#19708) may have relative paths in global config.
-    // These are meaningless outside the project that wrote them — resolving
-    // against process.cwd() produces the wrong path. Give actionable guidance
-    // instead of a misleading ENOENT.
-    if (
-      isLocalMarketplaceSource(entry.source) &&
-      !isAbsolute(entry.source.path)
-    ) {
-      throw new Error(
-        `Marketplace "${name}" has a relative source path (${entry.source.path}) ` +
-          `in known_marketplaces.json — this is stale state from an older ` +
-          `AgenC version. Run 'agenc marketplace remove ${name}' and ` +
-          `re-add it from the original project directory.`,
-      )
-    }
-
-    // Try to read from disk cache
     try {
-      return await readCachedMarketplace(entry.installLocation)
+      return await getMarketplaceUncached(name)
     } catch (error) {
-      // Log cache corruption before re-fetching
-      logForDebugging(
-        `Cache corrupted or missing for marketplace ${name}, re-fetching from source: ${errorMessage(error)}`,
-        {
-          level: 'warn',
-        },
-      )
+      // memoize() stores the (rejected) promise synchronously, so without this
+      // a single transient failure (network blip, git timeout, corrupt cache +
+      // failed re-fetch) would poison the in-memory cache for the whole session,
+      // making the marketplace permanently unloadable. Evict the key so the next
+      // call retries once the underlying condition clears.
+      getMarketplace.cache?.delete?.(name)
+      throw error
     }
-
-    // Cache doesn't exist or is invalid, fetch from source
-    let marketplace: PluginMarketplace
-    try {
-      ;({ marketplace } = await loadAndCacheMarketplace(entry.source))
-    } catch (error) {
-      throw new Error(
-        `Failed to load marketplace "${name}" from source (${entry.source.source}): ${errorMessage(error)}`,
-      )
-    }
-
-    // Update lastUpdated only when we actually fetch
-    config[name]!.lastUpdated = new Date().toISOString()
-    await saveKnownMarketplacesConfig(config)
-
-    return marketplace
   },
 )
+
+async function getMarketplaceUncached(
+  name: string,
+): Promise<PluginMarketplace> {
+  const config = await loadKnownMarketplacesConfig()
+  const entry = config[name]
+
+  if (!entry) {
+    throw new Error(
+      `Marketplace '${name}' not found in configuration. Available marketplaces: ${Object.keys(config).join(', ')}`,
+    )
+  }
+
+  // Compatibility entries (pre-#19708) may have relative paths in global config.
+  // These are meaningless outside the project that wrote them — resolving
+  // against process.cwd() produces the wrong path. Give actionable guidance
+  // instead of a misleading ENOENT.
+  if (
+    isLocalMarketplaceSource(entry.source) &&
+    !isAbsolute(entry.source.path)
+  ) {
+    throw new Error(
+      `Marketplace "${name}" has a relative source path (${entry.source.path}) ` +
+        `in known_marketplaces.json — this is stale state from an older ` +
+        `AgenC version. Run 'agenc marketplace remove ${name}' and ` +
+        `re-add it from the original project directory.`,
+    )
+  }
+
+  // Try to read from disk cache
+  try {
+    return await readCachedMarketplace(entry.installLocation)
+  } catch (error) {
+    // Log cache corruption before re-fetching
+    logForDebugging(
+      `Cache corrupted or missing for marketplace ${name}, re-fetching from source: ${errorMessage(error)}`,
+      {
+        level: 'warn',
+      },
+    )
+  }
+
+  // Cache doesn't exist or is invalid, fetch from source
+  let marketplace: PluginMarketplace
+  try {
+    ;({ marketplace } = await loadAndCacheMarketplace(entry.source))
+  } catch (error) {
+    throw new Error(
+      `Failed to load marketplace "${name}" from source (${entry.source.source}): ${errorMessage(error)}`,
+    )
+  }
+
+  // Update lastUpdated only when we actually fetch
+  config[name]!.lastUpdated = new Date().toISOString()
+  await saveKnownMarketplacesConfig(config)
+
+  return marketplace
+}
 
 /**
  * Get plugin by ID from cache only (no network calls).
@@ -2348,6 +2364,11 @@ export async function refreshAllMarketplaces(): Promise<void> {
   }
 
   await saveKnownMarketplacesConfig(config)
+
+  // Bulk refresh updated the on-disk caches; invalidate the in-process memo so
+  // already-loaded marketplaces don't keep returning pre-refresh contents for
+  // the rest of the session (refreshMarketplace() does the per-name equivalent).
+  clearMarketplacesCache()
 }
 
 /**

--- a/runtime/src/utils/plugins/walkPluginMarkdown.ts
+++ b/runtime/src/utils/plugins/walkPluginMarkdown.ts
@@ -16,7 +16,9 @@ const SKILL_MD_RE = /^skill\.md$/i
  * scanned — skill directories are leaf containers.
  *
  * Readdir errors are swallowed with a debug log so one bad directory doesn't
- * abort a plugin load.
+ * abort a plugin load. A failing onFile is likewise isolated per-file (logged
+ * with the offending file path) so one unreadable/invalid file doesn't abort
+ * the rest of its directory or get mislogged as a directory-scan failure.
  */
 export async function walkPluginMarkdown(
   rootDir: string,
@@ -25,6 +27,16 @@ export async function walkPluginMarkdown(
 ): Promise<void> {
   const fs = getFsImplementation()
   const label = opts.logLabel ?? 'plugin'
+
+  // Isolate a single file's onFile rejection so it doesn't reject the whole
+  // directory's Promise.all (dropping sibling files) and surface via the
+  // directory catch as a misleading "Failed to scan directory" error.
+  const safeOnFile = (p: string, ns: string[]): Promise<void> =>
+    onFile(p, ns).catch(err =>
+      logForDebugging(`Failed to process ${label} file ${p}: ${err}`, {
+        level: 'error',
+      }),
+    )
 
   async function scan(dirPath: string, namespace: string[]): Promise<void> {
     try {
@@ -38,7 +50,7 @@ export async function walkPluginMarkdown(
         await Promise.all(
           entries.map(entry =>
             entry.isFile() && entry.name.toLowerCase().endsWith('.md')
-              ? onFile(join(dirPath, entry.name), namespace)
+              ? safeOnFile(join(dirPath, entry.name), namespace)
               : undefined,
           ),
         )
@@ -52,7 +64,7 @@ export async function walkPluginMarkdown(
             return scan(fullPath, [...namespace, entry.name])
           }
           if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
-            return onFile(fullPath, namespace)
+            return safeOnFile(fullPath, namespace)
           }
           return undefined
         }),

--- a/runtime/tests/plugins/walkPluginMarkdown.test.ts
+++ b/runtime/tests/plugins/walkPluginMarkdown.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getFsImplementation,
+  setFsImplementation,
+} from 'src/utils/fsOperations.js'
+import { walkPluginMarkdown } from 'src/utils/plugins/walkPluginMarkdown.js'
+
+function dirent(name: string, kind: 'file' | 'dir') {
+  return {
+    name,
+    isFile: () => kind === 'file',
+    isDirectory: () => kind === 'dir',
+  }
+}
+
+describe('walkPluginMarkdown per-file isolation', () => {
+  let original: ReturnType<typeof getFsImplementation>
+
+  beforeEach(() => {
+    original = getFsImplementation()
+  })
+  afterEach(() => {
+    setFsImplementation(original)
+  })
+
+  it('continues processing sibling files when one onFile rejects', async () => {
+    setFsImplementation({
+      readdir: async () => [
+        dirent('good1.md', 'file'),
+        dirent('bad.md', 'file'),
+        dirent('good2.md', 'file'),
+        dirent('ignore.txt', 'file'),
+      ],
+    } as unknown as ReturnType<typeof getFsImplementation>)
+
+    const processed: string[] = []
+    await expect(
+      walkPluginMarkdown('/root', async fullPath => {
+        if (fullPath.endsWith('bad.md')) {
+          throw new Error('boom')
+        }
+        processed.push(fullPath)
+      }),
+    ).resolves.toBeUndefined()
+
+    // Both good files ran even though bad.md rejected; the .txt was skipped.
+    expect(processed.some(p => p.endsWith('good1.md'))).toBe(true)
+    expect(processed.some(p => p.endsWith('good2.md'))).toBe(true)
+    expect(processed.some(p => p.endsWith('ignore.txt'))).toBe(false)
+    expect(processed).toHaveLength(2)
+  })
+
+  it('discovers .md files case-insensitively', async () => {
+    setFsImplementation({
+      readdir: async () => [
+        dirent('Upper.MD', 'file'),
+        dirent('mixed.Md', 'file'),
+      ],
+    } as unknown as ReturnType<typeof getFsImplementation>)
+
+    const processed: string[] = []
+    await walkPluginMarkdown('/root', async fullPath => {
+      processed.push(fullPath)
+    })
+
+    expect(processed).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/utils/plugins` (audit→adversarial-verify workflow, 28 files). Five adversarially-confirmed robustness bugs fixed:

1. **[HIGH] `getMarketplace` cached rejected promises (memo poisoning).** lodash `memoize` stores the promise synchronously, so a single transient failure (network blip, git timeout, corrupt cache + failed re-fetch) permanently poisoned the in-memory cache for the whole session — the marketplace stayed unloadable until `clearMarketplacesCache()` (test-only). Extracted the body to `getMarketplaceUncached` and evict the memo key on rejection so the next call retries.

2. **[MEDIUM] `refreshAllMarketplaces` never invalidated the memo.** It refreshed the on-disk caches but already-loaded marketplaces kept returning pre-refresh contents. Now calls `clearMarketplacesCache()` after the save (`refreshMarketplace` already does the per-name equivalent).

3. **[MEDIUM] `walkPluginMarkdown` aborted a whole directory on one file error.** `onFile` ran inside a per-directory `Promise.all`, so one failing file (e.g. readFile error) dropped its siblings and was mislogged as a directory-scan failure. Now each `onFile` is isolated with a `.catch` logging the real file path.

4. **[LOW] Case-insensitive `.md` discovery + case-sensitive stripping.** A `Foo.MD` file loaded but kept `.MD` in its derived agent/command name. Use `/\.md$/i` (`loadPluginAgents`, `loadPluginCommands`) and align the single-file agent branch's `endsWith`.

5. **[LOW] `getPluginVersionFromManifest` missed legacy root `plugin.json`.** Returned `'unknown'` for legacy-layout plugins even with a valid version (the loader already supports both layouts). Now checks both.

## Tests
Adds `tests/plugins/walkPluginMarkdown.test.ts` (per-file isolation + case-insensitive discovery). The other fixes are fs/network-coupled and gate-verified.

## Deferred (flagged for human PRs)
zip-cache `installPath` mismatch in migrate paths; corrupt `installed_plugins.json` silent reset/overwrite (data loss); MCPB stale extraction dir; npm package cache ignoring version; GCS empty-zip clobbering a working marketplace; **git-URL official-source substring impersonation (security)**; non-ENOENT `SKILL.md` read aborting the skill scan. Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10369 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` `addLineNumbers` failure, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)