### PR TITLE
fix(runtime): config migration version-skew guard + profile web_search composition

### DIFF
--- a/runtime/src/config/migrate.ts
+++ b/runtime/src/config/migrate.ts
@@ -435,6 +435,18 @@ async function migrateJsonConfig(params: {
     return;
   }
 
+  // Mirror the TOML path's version-skew guard: a config.json written by a newer
+  // runtime must NOT be migrated by an older one, because prepareRawConfigForDisk
+  // unconditionally stamps CURRENT_CONFIG_FILE_VERSION — silently downgrading the
+  // version and rewriting under an old schema/migration regime.
+  if (shouldSkipFutureVersion(parsed)) {
+    params.onWarn(
+      `[agenc:config-migration] skipped config.json migration: ${CONFIG_FILE_VERSION_KEY} is newer than this runtime`,
+    );
+    params.result.skipped.push("json:future-version");
+    return;
+  }
+
   let migrated: JsonRecord;
   let serialized: string;
   try {

--- a/runtime/src/config/profiles.ts
+++ b/runtime/src/config/profiles.ts
@@ -113,8 +113,12 @@ export function resolveProfile(
     override.tools_config = tools;
   }
   if (hasProfileOverride(profile, "tools")) {
+    // Compose on top of any tools_config already built above (e.g. from a
+    // web_search override) rather than re-reading the base config — otherwise a
+    // profile that sets both web_search and tools silently drops web_search.
+    // An explicit profile.tools.web_search still wins (spread last).
     override.tools_config = {
-      ...(config.tools_config ?? {}),
+      ...(override.tools_config ?? config.tools_config ?? {}),
       ...profile.tools,
     };
   }

--- a/runtime/tests/config/migrate.test.ts
+++ b/runtime/tests/config/migrate.test.ts
@@ -252,6 +252,32 @@ provider = "xai"
     expect(warnings.join("\n")).toContain("cannot be represented in TOML");
   });
 
+  test("future configVersion in config.json skips migration (no downgrade)", async () => {
+    const home = makeTempDir("agenc-config-migrate");
+    writeFileSync(
+      join(home, "config.json"),
+      JSON.stringify({
+        [CONFIG_FILE_VERSION_KEY]: CURRENT_CONFIG_FILE_VERSION + 1,
+        provider: "xai",
+      }),
+      "utf8",
+    );
+    const warnings: string[] = [];
+
+    const result = await runConfigFileMigrations({
+      home,
+      parseToml,
+      onWarn: (message) => warnings.push(message),
+    });
+
+    // Must NOT rewrite a newer-than-this-runtime config.json into a v1
+    // config.toml — that would silently downgrade the version stamp.
+    expect(result.wrote).toBe(false);
+    expect(result.skipped).toContain("json:future-version");
+    expect(existsSync(join(home, "config.toml"))).toBe(false);
+    expect(warnings.join("\n")).toContain("newer than this runtime");
+  });
+
   test("serializer round-trips quoted keys, arrays, and nested records", () => {
     const raw = {
       "dotted.key": {

--- a/runtime/tests/config/profiles.webSearch.test.ts
+++ b/runtime/tests/config/profiles.webSearch.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { defaultConfig } from "src/config/schema.js";
+import { resolveProfile } from "src/config/profiles.js";
+
+function configWithProfile(profile: Record<string, unknown>) {
+  return {
+    ...defaultConfig(),
+    profiles: { dev: profile },
+  } as unknown as Parameters<typeof resolveProfile>[0];
+}
+
+describe("resolveProfile web_search + tools composition", () => {
+  test("preserves web_search when the profile also sets tools", () => {
+    // Regression: the `tools` block re-read the base config and clobbered the
+    // tools_config built by the `web_search` block, silently dropping it.
+    const config = configWithProfile({ web_search: true, tools: {} });
+    const resolved = resolveProfile(config, "dev");
+    expect(resolved.tools_config?.web_search).toBe(true);
+  });
+
+  test("an explicit profile.tools.web_search still wins over the web_search field", () => {
+    const config = configWithProfile({
+      web_search: true,
+      tools: { web_search: false },
+    });
+    const resolved = resolveProfile(config, "dev");
+    expect(resolved.tools_config?.web_search).toBe(false);
+  });
+
+  test("web_search alone still applies", () => {
+    const config = configWithProfile({ web_search: true });
+    const resolved = resolveProfile(config, "dev");
+    expect(resolved.tools_config?.web_search).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/config` + `src/bootstrap` (audit→adversarial-verify workflow). Two adversarially-confirmed HIGH bugs fixed:

1. **`migrateJsonConfig` had no future-version guard → silent config downgrade.** `migrateTomlConfig` refuses to migrate a config whose `configVersion` is newer than this runtime (`shouldSkipFutureVersion`), but the JSON path unconditionally ran `prepareRawConfigForDisk`, which hard-stamps `CURRENT_CONFIG_FILE_VERSION`. So a `config.json` written by a **newer** runtime was rewritten as a v1 `config.toml` — silently downgrading the version stamp and re-migrating under an old schema regime on every subsequent run. Added the same guard the TOML path already has.

2. **`resolveProfile` dropped a profile's `web_search` when the profile also set `tools`.** The `tools` block rebuilt `tools_config` from the **base** config, clobbering the `tools_config` the preceding `web_search` block had populated. Now composes on the in-progress override (an explicit `profile.tools.web_search` still wins via last-spread).

## Tests
Adds a JSON future-version test to `tests/config/migrate.test.ts` and a new `tests/config/profiles.webSearch.test.ts` (compose / precedence / web_search-alone).

## Deferred (flagged for human PRs)
`setMcpServer`/`removeMcpServer` silent clobber of a non-record `mcp_servers`; `AGENC_SIMPLE`/`AGENC_AUTONOMOUS` untrimmed coercion clobbering config; Grok default-model hardcoded literal ×3; custom `api_key_env` raw/empty (credential handling); profile `reasoning_summary` no-op. Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10373 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` `addLineNumbers` failure, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)