### PR TITLE
fix(runtime): apply-patch EOF seek fallback + edit/code-mode diagnostics

### DIFF
--- a/runtime/src/tools/FileEditTool/utils.ts
+++ b/runtime/src/tools/FileEditTool/utils.ts
@@ -409,7 +409,13 @@ export function getSnippetForTwoFileDiff(
   const cutoff = full.lastIndexOf('\n', DIFF_SNIPPET_MAX_BYTES)
   const kept =
     cutoff > 0 ? full.slice(0, cutoff) : full.slice(0, DIFF_SNIPPET_MAX_BYTES)
-  const remaining = countCharInString(full, '\n', kept.length) + 1
+  // When we cut on a line boundary, kept.length points AT the boundary '\n', so
+  // counting newlines from there already equals the number of dropped lines.
+  // Only the mid-line fallback (cutoff <= 0) needs +1 for the partial line.
+  const remaining =
+    cutoff > 0
+      ? countCharInString(full, '\n', kept.length)
+      : countCharInString(full, '\n', kept.length) + 1
   return `${kept}\n\n... [${remaining} lines truncated] ...`
 }
 

--- a/runtime/src/tools/apply-patch/seek-sequence.ts
+++ b/runtime/src/tools/apply-patch/seek-sequence.ts
@@ -54,30 +54,39 @@ export function seekSequence(
   if (pattern.length === 0) return start;
   if (pattern.length > lines.length) return null;
 
-  const searchStart = eof && lines.length >= pattern.length
-    ? lines.length - pattern.length
-    : start;
-
-  return (
-    findWithComparator(lines, pattern, searchStart, (line, pat) => line === pat) ??
+  const runChain = (from: number): number | null =>
+    findWithComparator(lines, pattern, from, (line, pat) => line === pat) ??
     findWithComparator(
       lines,
       pattern,
-      searchStart,
+      from,
       (line, pat) => line.trimEnd() === pat.trimEnd(),
     ) ??
     findWithComparator(
       lines,
       pattern,
-      searchStart,
+      from,
       (line, pat) => line.trim() === pat.trim(),
     ) ??
     findWithComparator(
       lines,
       pattern,
-      searchStart,
+      from,
       (line, pat) =>
         normalizeCommonPunctuation(line) === normalizeCommonPunctuation(pat),
-    )
-  );
+    );
+
+  // For an end-of-file-anchored hunk, try the flush-against-EOF position first
+  // (matching the donor), then fall back to a normal scan from `start`. The
+  // previous port pinned the search to the EOF position only, so any EOF hunk
+  // whose context/removed lines were not literally the final lines of the file
+  // failed to apply — a silent loss of patch-application capability. The
+  // fallback is strictly additive: a flush match still wins first.
+  if (eof && lines.length >= pattern.length) {
+    const anchored = runChain(lines.length - pattern.length);
+    if (anchored !== null) return anchored;
+    return runChain(start);
+  }
+
+  return runChain(start);
 }

--- a/runtime/src/tools/code-mode/tools.ts
+++ b/runtime/src/tools/code-mode/tools.ts
@@ -117,7 +117,10 @@ export function codeModeRuntimeResponseToToolResult(
 
   return {
     content,
-    isError: response.type === "result" && response.errorText !== undefined,
+    // Key on truthiness to match status (line 72) and the "Script error"
+    // section gating — an empty errorText ("" from `throw new Error('')`) must
+    // not report status=completed yet isError=true.
+    isError: response.type === "result" && Boolean(response.errorText),
     contentItems: richItems,
     metadata: {
       codeMode: true,

--- a/runtime/tests/tools/apply-patch/seek-sequence.test.ts
+++ b/runtime/tests/tools/apply-patch/seek-sequence.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+
+import { seekSequence } from "./seek-sequence.js";
+
+describe("seekSequence", () => {
+  test("returns the matching index for a normal (non-EOF) scan", () => {
+    expect(seekSequence(["a", "b", "c", "d"], ["b", "c"], 0, false)).toBe(1);
+  });
+
+  test("returns null when the pattern is absent", () => {
+    expect(seekSequence(["a", "b", "c"], ["x", "y"], 0, false)).toBeNull();
+  });
+
+  test("EOF: matches when the pattern is flush against the end of file", () => {
+    expect(seekSequence(["x", "y", "z"], ["y", "z"], 0, true)).toBe(1);
+  });
+
+  test("EOF: falls back to a scan from start for a non-flush pattern", () => {
+    // Regression: the EOF path used to pin the search to the flush position
+    // only, so a non-flush EOF hunk failed to apply. It must fall back to a
+    // normal scan (matching the donor's two-phase behavior).
+    expect(seekSequence(["x", "y", "z"], ["x", "y"], 0, true)).toBe(0);
+  });
+
+  test("EOF: prefers the flush position over an earlier match", () => {
+    // "a" appears at index 0 and 2; flush-against-EOF (index 2) must win.
+    expect(seekSequence(["a", "b", "a"], ["a"], 0, true)).toBe(2);
+  });
+
+  test("empty pattern returns the start index", () => {
+    expect(seekSequence(["a", "b"], [], 1, false)).toBe(1);
+  });
+
+  test("pattern longer than the file returns null", () => {
+    expect(seekSequence(["a"], ["a", "b"], 0, true)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of the file-manipulation tools (apply-patch, FileEditTool, code-mode, WebFetchTool — audit→adversarial-verify workflow). Three adversarially-confirmed bugs fixed:

1. **apply-patch `seekSequence` EOF anchor had no fallback.** EOF-anchored searches were pinned to the flush-against-end position only, so any `*** End of File` hunk whose context/removed lines were not literally the final lines of the file failed to apply (`Failed to find expected lines`) — a silent loss of patch-application capability vs the donor algorithm. Restored the donor's two-phase behavior: try the EOF anchor first, then fall back to a scan from `start`. **Strictly additive** — a flush match still wins first, so no currently-succeeding patch changes behavior (verified by execution against the donor in the audit).

2. **code-mode `isError` inconsistency.** `tools.ts` computed `isError` with `errorText !== undefined` while `status` and the "Script error" section key on truthiness, so a script doing `throw new Error('')` reported `status=completed` yet `isError=true`. Use `Boolean(errorText)`.

3. **FileEditTool truncated-line over-count.** `getSnippetForTwoFileDiff` over-counted dropped lines by one when the cut landed on a line boundary (the boundary newline was double-counted). The `+1` is now conditional on the mid-line fallback branch only.

## Tests
Adds `tests/tools/apply-patch/seek-sequence.test.ts` (flush, non-flush fallback, flush-precedence, normal scan, edge cases). The other two are gate-verified.

## Deferred (flagged for human PRs — several HIGH/security)
- apply-patch context-anchored insertion (empty `oldLines`) always inserts at **EOF** instead of at the located context (`runtime.ts`) — HIGH, but changes insertion placement w/ sort/reverse-splice interactions.
- **WebFetch native-fetch fallback bypasses the SSRF guard + content-length cap** — HIGH security.
- code-mode worker leak on no-waiter completion; re-entrant continue-yield skip; `maxOutputTokens` cap bypass on the multimodal `contentItems` path; WebFetch fallback swallowing `AbortError`.

Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10380 passed / 10 skipped (a one-off `mcp-cli` flake that spawns the real entrypoint cleared on re-run) · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)