### PR TITLE
fix(runtime): preserve $-sequences in compact summary formatting

### DIFF
--- a/runtime/src/services/compact/prompt.ts
+++ b/runtime/src/services/compact/prompt.ts
@@ -284,9 +284,14 @@ export function formatCompactSummary(summary: string): string {
 
   if (summaryMatch) {
     const content = summaryMatch[1] ?? "";
+    // Use a function replacer: a string replacement would treat $-sequences in
+    // the model-authored summary ($&, $1, $$, shell snippets like $@) as
+    // special substitutions and silently corrupt the output. Function return
+    // values are inserted literally.
+    const replacement = `Summary:\n${content.trim()}`;
     formattedSummary = formattedSummary.replace(
       SUMMARY_BLOCK_PATTERN,
-      `Summary:\n${content.trim()}`,
+      () => replacement,
     );
   }
 

--- a/runtime/tests/services/compact/compact-surfaces.test.ts
+++ b/runtime/tests/services/compact/compact-surfaces.test.ts
@@ -99,6 +99,17 @@ describe("compact supporting surfaces", () => {
     ].join("\n"))).toBe("Summary:\nuse this\n\nnext");
   });
 
+  test("preserves $-sequences in the summary body verbatim", () => {
+    // Regression: the summary was injected into String.replace's replacement
+    // string, so $&, $1, $$ and shell snippets were reinterpreted as
+    // substitution patterns and corrupted the output.
+    expect(
+      formatCompactSummary(
+        "<summary>cost was $5 and $$ and $& and $1 and $`echo`</summary>",
+      ),
+    ).toBe("Summary:\ncost was $5 and $$ and $& and $1 and $`echo`");
+  });
+
   test("builds compact prompts with no-tool framing and custom instructions", () => {
     const prompt = getCompactPrompt("Focus on runtime files.");
 


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/services/compact` (audit→adversarial-verify workflow, 15 files).

`formatCompactSummary` injected the model-authored `<summary>` content into the **replacement-string** argument of `String.prototype.replace`, so `$`-sequences in the summary (`$&`, `$1`, `$$`, `` $` ``, shell snippets like `$@`) were reinterpreted as substitution patterns and silently corrupted the persisted summary. The compact prompt explicitly asks for verbatim code snippets, so this is reachable. Fixed with a function replacer (its return value is inserted literally).

## Tests
Adds a `$`-sequence regression test to `tests/services/compact/compact-surfaces.test.ts`.

## Deferred (flagged for human PRs — several HIGH)
- `autoCompact` counts a **user-aborted** compaction as a failure → trips the circuit breaker (abort-detection has two surfaces: `AbortError` and a generic `"Partial compaction aborted"`).
- `microCompact` path-2 clears **non-compactable** tool results (e.g. Task/sub-agent output) because the compactability scope is only applied on the block path.
- time-window protection not applied to block-structured `tool_result` compaction.
- `getAPIContextManagement` contract incompatible with its `anthropic.ts` caller (API-side CM is a silent no-op).
- `preserveToolPairsFromIndex` can orphan a `tool_result` at the kept-window head (API 400) — pairing invariant.
- `snipCompact` missing exports referenced behind a feature flag (feature-surface/product decision).
- per-family context-window shortcut shadows the openai-compat table for github-copilot Claude models.

Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10381 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)