### PR TITLE
fix(runtime): LSP bookkeeping correctness (closeFile leak, peek LRU, languageId trim)

### DIFF
--- a/runtime/src/services/lsp/LSPDiagnosticRegistry.ts
+++ b/runtime/src/services/lsp/LSPDiagnosticRegistry.ts
@@ -221,7 +221,11 @@ export function peekLSPDiagnosticsForFile(file: string): DiagnosticEntry[] {
     if (pending.attachmentSent) continue;
     for (const diagnosticFile of pending.files) {
       if (!fileMatches(diagnosticFile.uri, file)) continue;
-      const delivered = deliveredDiagnostics.get(diagnosticFile.uri) ?? new Set();
+      // peek(), not get(): this is a read-only query, so it must not bump the
+      // entry's LRU recency and risk evicting another file's delivered-dedup set
+      // (which would re-deliver already-seen diagnostics as "new").
+      const delivered =
+        deliveredDiagnostics.peek(diagnosticFile.uri) ?? new Set();
       for (const diagnostic of diagnosticFile.diagnostics) {
         const key = diagnosticKey(diagnostic);
         if (seen.has(key) || delivered.has(key)) continue;

--- a/runtime/src/services/lsp/LSPServerManager.ts
+++ b/runtime/src/services/lsp/LSPServerManager.ts
@@ -206,13 +206,17 @@ export function createLSPServerManager(
   }
 
   async function closeFile(filePath: string): Promise<void> {
+    const uri = fileUri(filePath);
+    // Clear the local bookkeeping unconditionally — otherwise closing a file
+    // while the server is crashed/stopped/starting leaks the openedFiles entry,
+    // leaving isFileOpen() true and making a later openFile() skip didOpen for a
+    // document the server never received.
+    openedFiles.delete(uri);
     const server = getServerForFile(filePath);
     if (!server || server.state !== "running") return;
-    const uri = fileUri(filePath);
     await server.sendNotification("textDocument/didClose", {
       textDocument: { uri },
     });
-    openedFiles.delete(uri);
   }
 
   return {

--- a/runtime/src/services/lsp/config.ts
+++ b/runtime/src/services/lsp/config.ts
@@ -81,7 +81,9 @@ function normalizeExtensionMap(
     if (language.trim().length === 0) {
       throw new Error(`extensionToLanguage.${ext} must not be empty`);
     }
-    normalized[key] = language;
+    // Store trimmed (mirroring the key) — this value is sent verbatim as the
+    // LSP textDocument.languageId, which never carries surrounding whitespace.
+    normalized[key] = language.trim();
   }
   return Object.freeze(normalized);
 }

--- a/runtime/tests/services/lsp/LSPServerManager.test.ts
+++ b/runtime/tests/services/lsp/LSPServerManager.test.ts
@@ -109,6 +109,36 @@ describe("createLSPServerManager", () => {
     expect(manager.getAllServers().size).toBe(0);
   });
 
+  test("closeFile clears the openedFiles entry even when the server is not running", async () => {
+    // Regression: closeFile bailed out before deleting the registry entry when
+    // the server wasn't running, leaking the entry (isFileOpen stays true and a
+    // later openFile skips didOpen for a document the server never received).
+    const created: ReturnType<typeof fakeServer>[] = [];
+    const manager = createLSPServerManager({
+      configSource: () => ({
+        ts: normalizeLspServerConfig("ts", {
+          command: "typescript-language-server",
+          extensionToLanguage: { ".ts": "typescript" },
+        }),
+      }),
+      instanceFactory: (name, config) => {
+        const server = fakeServer(name, config);
+        created.push(server);
+        return server;
+      },
+    });
+
+    await manager.initialize();
+    await manager.changeFile("src/a.ts", "let x = 1;");
+    expect(manager.isFileOpen("src/a.ts")).toBe(true);
+
+    // Server crashes/stops before the file is closed.
+    created[0]!.setState("stopped");
+    await manager.closeFile("src/a.ts");
+
+    expect(manager.isFileOpen("src/a.ts")).toBe(false);
+  });
+
   test("does not leave failed servers in extension routing", async () => {
     const validConfig = normalizeLspServerConfig("valid", {
       command: "typescript-language-server",

--- a/runtime/tests/services/lsp/config.test.ts
+++ b/runtime/tests/services/lsp/config.test.ts
@@ -28,6 +28,19 @@ describe("lsp config", () => {
     expect(config.maxRestarts).toBe(2);
   });
 
+  test("trims whitespace from extensionToLanguage language ids", () => {
+    // Regression: the language value was stored untrimmed despite trim-based
+    // validation, so " go" / "typescript " reached the wire as a bad languageId.
+    const config = normalizeLspServerConfig("ts", {
+      command: "typescript-language-server",
+      extensionToLanguage: { ".go": " go ", "ts": "typescript " },
+    });
+    expect(config.extensionToLanguage).toEqual({
+      ".go": "go",
+      ".ts": "typescript",
+    });
+  });
+
   test("rejects invalid server config with an actionable reason", () => {
     const result = parseLspServersConfig({
       broken: { command: "", extensionToLanguage: {} },


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of `src/services/lsp` (audit→adversarial-verify workflow, 10 files). Three adversarially-confirmed bookkeeping bugs fixed:

1. **`closeFile` leaked the `openedFiles` entry when the server wasn't running.** It bailed out before `openedFiles.delete(uri)`, so closing a file during a crash/stop/start left `isFileOpen()` true and made a later `openFile()` skip `didOpen` for a document the server never received. Now clears the local bookkeeping unconditionally, then only sends `didClose` if the server is running.

2. **`peekLSPDiagnosticsForFile` mutated the LRU it only "peeks".** It used `deliveredDiagnostics.get()`, which bumps recency, so a read-only peek of one file could evict another file's delivered-dedup set → already-seen diagnostics re-delivered as "new". Use `.peek()`.

3. **`extensionToLanguage` stored an untrimmed language id.** Validated with `trim()` but stored verbatim, so `" go"`/`"typescript "` reached the wire as the LSP `textDocument.languageId`. Store the trimmed value (mirroring the key).

## Tests
Regression tests added to `tests/services/lsp/config.test.ts` (trim) and `LSPServerManager.test.ts` (close-while-not-running). The LRU peek fix is self-evident (`.get`→`.peek`).

## Deferred (flagged for human PRs — several HIGH, connection/lifecycle state machine)
Transient connection `onError` latches `startFailed` and **bricks a healthy client**; post-spawn child `'error'` latches without cleanup/`onCrash`; client swallows failed notifications; `restart()` lifetime counter never resets; stale `openedFiles` survive a crash; `waitForInitialization` stale-promise race; global diagnostic cap loses novel diagnostics; all-rejected publish clears valid diagnostics. Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10383 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)