### PR TITLE
fix(runtime): autoFix multibyte decode + isolate auto-dream fire-and-forget rejection

### DIFF
--- a/runtime/src/query/stopHooks.ts
+++ b/runtime/src/query/stopHooks.ts
@@ -127,7 +127,15 @@ export async function* handleStopHooks(
       void executePromptSuggestion(stopHookContext, { cwd: getCwd(), speculationEnabled: getGlobalConfig().speculationEnabled })
     }
     if (!toolUseContext.agentId) {
-      void executeAutoDream(stopHookContext, toolUseContext.appendSystemMessage)
+      // Fire-and-forget: isolate any rejection so an unguarded throw in the
+      // auto-dream runner becomes a logged debug line rather than an
+      // unhandledRejection escaping the turn loop.
+      void executeAutoDream(
+        stopHookContext,
+        toolUseContext.appendSystemMessage,
+      ).catch(err => {
+        logForDebugging(`[auto-dream] execution error: ${errorMessage(err)}`)
+      })
     }
   }
 

--- a/runtime/src/services/autoFix/autoFixRunner.ts
+++ b/runtime/src/services/autoFix/autoFixRunner.ts
@@ -13,6 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 
 export interface AutoFixCheckOptions {
   readonly lint?: string;
@@ -85,6 +86,12 @@ async function runCommand(
     let timedOut = false;
     let stdout = "";
     let stderr = "";
+    // Per-stream decoders buffer partial multibyte UTF-8 sequences across chunk
+    // boundaries — decoding each raw Buffer chunk independently would emit
+    // U+FFFD for a character split across two chunks, garbling lint/test output
+    // that is later shown to the model.
+    const outDecoder = new StringDecoder("utf8");
+    const errDecoder = new StringDecoder("utf8");
     let timer: NodeJS.Timeout | undefined;
     let forceTimer: NodeJS.Timeout | undefined;
     const isWindows = process.platform === "win32";
@@ -163,10 +170,10 @@ async function runCommand(
     signal?.addEventListener("abort", onAbort, { once: true });
 
     proc.stdout?.on("data", (data: Buffer) => {
-      stdout = appendCapped(stdout, data.toString());
+      stdout = appendCapped(stdout, outDecoder.write(data));
     });
     proc.stderr?.on("data", (data: Buffer) => {
-      stderr = appendCapped(stderr, data.toString());
+      stderr = appendCapped(stderr, errDecoder.write(data));
     });
 
     timer = setTimeout(() => {
@@ -183,6 +190,11 @@ async function runCommand(
 
     proc.on("close", (code) => {
       clearForceTimer();
+      // Flush any final complete character buffered in the decoder.
+      const tailOut = outDecoder.end();
+      if (tailOut) stdout = appendCapped(stdout, tailOut);
+      const tailErr = errDecoder.end();
+      if (tailErr) stderr = appendCapped(stderr, tailErr);
       settle({
         stdout,
         stderr,

--- a/runtime/tests/services/autoFix/autoFixRunner.test.ts
+++ b/runtime/tests/services/autoFix/autoFixRunner.test.ts
@@ -136,6 +136,21 @@ describe("runAutoFixCheck", () => {
     ).toBeLessThanOrEqual(10_000);
   });
 
+  test("does not corrupt a multibyte char split across stdout chunks", async () => {
+    // Regression: decoding each Buffer chunk independently emitted U+FFFD when a
+    // multibyte UTF-8 sequence straddled two 'data' events. '✓' is E2 9C 93;
+    // emit [E2 9C] then [93] as separate writes to force the split.
+    const result = await runAutoFixCheck({
+      lint:
+        'node -e "process.stdout.write(Buffer.from([0xe2,0x9c])); setTimeout(() => process.stdout.write(Buffer.from([0x93])), 30)"',
+      timeout: 5_000,
+      cwd: TEST_CWD,
+    });
+    expect(result.hasErrors).toBe(false);
+    expect(result.lintOutput).toContain("✓");
+    expect(result.lintOutput).not.toContain("�");
+  });
+
   test("aborts a running command promptly", async () => {
     const controller = new AbortController();
     setTimeout(() => controller.abort("test"), 50);


### PR DESCRIPTION
## Summary
Phase-2 bug-hardening of the agent-behavior services (autoFix, autoDream, extractMemories, PromptSuggestion — audit→adversarial-verify workflow, 14 files). Two adversarially-confirmed bugs fixed:

1. **`autoFixRunner` corrupted multibyte output split across chunks.** Each stdout/stderr Buffer chunk was decoded independently with `data.toString()`, so a multibyte UTF-8 sequence straddling two `'data'` events (non-ASCII eslint/vitest output) decoded to U+FFFD — and that garbled text is embedded verbatim into the model-facing `auto_fix_feedback`. Now uses a per-stream `StringDecoder` that buffers partial sequences across chunks and flushes on close.

2. **`executeAutoDream` fire-and-forget had no `.catch`.** Invoked as `void executeAutoDream(...)` from `stopHooks` with no rejection handler, so any unguarded throw in the runner became an `unhandledRejection` escaping the turn loop. Added a logging `.catch`.

## Tests
Adds a **deterministic** multibyte-split regression to `tests/services/autoFix/autoFixRunner.test.ts` (emit `E2 9C` then `93` as separate writes → asserts `✓` present, no `�`).

## Deferred (flagged for human PRs — lock/race/path semantics)
`consolidationLock` TOCTOU (two processes both acquire) + ownership-blind rollback; mid-command abort surfaced as fabricated edit errors burning a retry slot; `maxRetries:0` misleading no-op; `completeDreamTask` overwrites a killed task; `extractMemories` cursor lost on partial child write; overlapping `promptSuggestion` orphans an `AbortController`; `copyOverlayToMain` non-atomic partial copy; prompt-suggestion env-disable case-sensitivity; `logEvent` imports a removed analytics module (Phase-3 dead code). Recorded in the hardening ledger.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10384 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)