### PR TITLE
fix(runtime): close SSRF + resource-cap holes in WebFetch native-fetch fallback

### DIFF
--- a/runtime/src/tools/WebFetchTool/utils.ts
+++ b/runtime/src/tools/WebFetchTool/utils.ts
@@ -12,6 +12,8 @@ import {
 } from '../../utils/mcpOutputStorage.js'
 import { getSettings_DEPRECATED } from '../../utils/settings/settings.js'
 import { asSystemPrompt } from '../../utils/systemPromptType.js'
+import type { LookupFunction } from 'node:net'
+import type * as undici from 'undici'
 import { ssrfGuardedLookup } from '../../utils/hooks/ssrfGuard.js'
 import { isPreapprovedHost } from './preapproved.js'
 import { makeSecondaryModelPrompt } from './prompt.js'
@@ -103,6 +105,66 @@ const MAX_URL_LENGTH = 2000
 // memory, and network usage for the Web Fetch tool can prevent a single
 // request or user from overwhelming the system."
 const MAX_HTTP_CONTENT_LENGTH = 10 * 1024 * 1024
+
+// The native-fetch fallback (used when axios+custom-lookup hangs) must keep the
+// same SSRF protection as the axios path. Node's global fetch ignores axios's
+// `lookup`, so we give it an undici dispatcher whose connector resolves through
+// ssrfGuardedLookup — the validated IP is the one pinned to the socket, closing
+// the DNS-rebinding window (a naive pre-resolve-then-fetch would re-resolve and
+// reopen it). Lazy-required + memoized so undici only loads when the fallback
+// actually fires. mTLS/proxy global dispatchers are intentionally not merged
+// here; this edge path already did not honor per-request mTLS.
+let ssrfGuardedFetchDispatcher: undici.Dispatcher | undefined
+function getSsrfGuardedFetchDispatcher(): undici.Dispatcher {
+  if (!ssrfGuardedFetchDispatcher) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const undiciMod = require('undici') as typeof undici
+    ssrfGuardedFetchDispatcher = new undiciMod.Agent({
+      connect: {
+        // ssrfGuardedLookup carries axios's lookup shape, which is call-
+        // compatible with undici's Node-style connect lookup.
+        lookup: ssrfGuardedLookup as unknown as LookupFunction,
+      },
+    })
+  }
+  return ssrfGuardedFetchDispatcher
+}
+
+/**
+ * Read a fetch Response body into a Uint8Array, enforcing a hard byte cap by
+ * streaming (a hostile server can omit/understate Content-Length, so the cap
+ * must be enforced while reading, not from the header). Mirrors the axios
+ * maxContentLength behavior on the fallback path.
+ */
+export async function readBodyCapped(response: Response): Promise<Uint8Array> {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    return new Uint8Array(0)
+  }
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      total += value.byteLength
+      if (total > MAX_HTTP_CONTENT_LENGTH) {
+        await reader.cancel()
+        throw new Error(
+          `maxContentLength size of ${MAX_HTTP_CONTENT_LENGTH} exceeded`,
+        )
+      }
+      chunks.push(value)
+    }
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
+}
 
 // Timeout for the main HTTP fetch request (60 seconds).
 // Prevents hanging indefinitely on slow/unresponsive servers.
@@ -297,7 +359,9 @@ export async function getWithPermittedRedirects(
           signal,
           redirect: 'manual',
           headers: axiosConfig.headers,
-        })
+          // Pin connections to SSRF-validated IPs (see dispatcher comment).
+          dispatcher: getSsrfGuardedFetchDispatcher(),
+        } as RequestInit & { dispatcher: undici.Dispatcher })
         // Handle redirects manually
         if ([301, 302, 307, 308].includes(fetchResponse.status)) {
           const redirectLocation = fetchResponse.headers.get('location')
@@ -321,18 +385,30 @@ export async function getWithPermittedRedirects(
             }
           }
         }
-        const arrayBuffer = await fetchResponse.arrayBuffer()
+        // Enforce the same 10MB cap as the axios path, streaming so a server
+        // that omits/understates Content-Length cannot exhaust memory.
+        const data = await readBodyCapped(fetchResponse)
         // Build an AxiosResponse-like shape so downstream code stays happy
         return {
-          data: new Uint8Array(arrayBuffer),
+          data,
           status: fetchResponse.status,
           statusText: fetchResponse.statusText,
           headers: Object.fromEntries(fetchResponse.headers.entries()),
           config: axiosConfig,
           request: undefined,
         } as unknown as AxiosResponse<ArrayBuffer>
-      } catch {
-        // Fall through to original error handling
+      } catch (fallbackError) {
+        // A user abort during the fallback fetch must propagate as an abort
+        // (so it's classified as an interrupt), not be swallowed and reported
+        // as the original stale axios timeout.
+        if (
+          signal.aborted ||
+          (fallbackError as { name?: string })?.name === 'AbortError' ||
+          (fallbackError as { code?: string })?.code === 'ABORT_ERR'
+        ) {
+          throw fallbackError
+        }
+        // Otherwise fall through to original error handling.
       }
     }
 

--- a/runtime/tests/tools/WebFetchTool/readBodyCapped.test.ts
+++ b/runtime/tests/tools/WebFetchTool/readBodyCapped.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+
+import { readBodyCapped } from '../../../src/tools/WebFetchTool/utils.ts'
+
+function streamResponse(chunks: Uint8Array[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+  return new Response(stream)
+}
+
+describe('readBodyCapped', () => {
+  test('returns the full body when under the cap', async () => {
+    const a = new Uint8Array([1, 2, 3])
+    const b = new Uint8Array([4, 5])
+    const out = await readBodyCapped(streamResponse([a, b]))
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  test('returns empty for a null body', async () => {
+    const out = await readBodyCapped(new Response(null))
+    expect(out.byteLength).toBe(0)
+  })
+
+  test('throws once the streamed total exceeds the 10MB cap', async () => {
+    // Eleven 1MB chunks = 11MB > MAX_HTTP_CONTENT_LENGTH (10MB). A hostile
+    // server could omit Content-Length, so the cap must be enforced while
+    // streaming, not from the header.
+    const oneMB = new Uint8Array(1024 * 1024)
+    const chunks = Array.from({ length: 11 }, () => oneMB)
+    await expect(readBodyCapped(streamResponse(chunks))).rejects.toThrow(
+      /maxContentLength/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Resolves the **security** cluster flagged by the Tick-11 file-tools audit (now fixed, not deferred, per the new directive).

The axios request path is hardened — `lookup: ssrfGuardedLookup` pins the validated IP to the socket, `maxContentLength` caps the body — but the timeout/network-error fallback to Node's global `fetch` bypassed **all** of it. An attacker who can stall the first axios attempt (ECONNABORTED/ETIMEDOUT) or control DNS could drive the request through the unguarded fallback to reach `169.254.169.254` / `10.x` / link-local, and stream an unbounded body to exhaust memory.

### Fixes (`WebFetchTool/utils.ts`)
- **SSRF:** the fallback `fetch` now uses an undici `Agent` dispatcher whose connector resolves through `ssrfGuardedLookup`, so the validated IP is the one actually connected — no DNS-rebinding TOCTOU window (a naive pre-resolve-then-fetch re-resolves and reopens it). Lazy-required + memoized; applies to every redirect hop since the fallback recurses through `getWithPermittedRedirects`.
- **Resource cap:** replaced the unbounded `fetchResponse.arrayBuffer()` with a streaming reader (`readBodyCapped`) that aborts once the 10MB cap is exceeded, enforced **while reading** (not from the spoofable `Content-Length` header).
- **Abort:** the inner `catch` previously swallowed an `AbortError` thrown mid-fallback and rethrew the stale axios timeout, mis-rendering user interrupts. Now rethrows on `signal.aborted` / `AbortError` / `ABORT_ERR` so it's classified as an interrupt.

## Tests
`tests/tools/WebFetchTool/readBodyCapped.test.ts` (under-cap, null body, over-cap streaming rejection).

## Decision notes
mTLS/proxy global dispatchers are intentionally not merged into the guarded dispatcher — this edge path did not honor per-request mTLS before either, and the SSRF closure is the priority.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10387 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)