### PR TITLE
fix(runtime): parse host for official-marketplace git-URL check (anti-impersonation)

### DIFF
--- a/runtime/src/utils/plugins/schemas.ts
+++ b/runtime/src/utils/plugins/schemas.ts
@@ -137,13 +137,41 @@ export function validateOfficialNameSource(
 
   // Check for git URL source type
   if (source.source === 'git' && source.url) {
-    const url = source.url.toLowerCase()
-    // Check for HTTPS URL format: https://github.com/tetsuo-ai/...
-    // or SSH format: git@github.com:tetsuo-ai/...
-    const isHttpsOfficial = url.includes(`github.com/${OFFICIAL_GITHUB_ORG}/`)
-    const isSshOfficial = url.includes(`git@github.com:${OFFICIAL_GITHUB_ORG}/`)
+    // Decide officialness by parsing the host + org path — NOT by substring
+    // matching the raw URL. A substring check (url.includes('github.com/org/'))
+    // is trivially bypassed by embedding the magic string in the query/fragment/
+    // path of an attacker host, e.g. https://evil.com/?u=github.com/tetsuo-ai/x,
+    // letting a third-party repo claim a reserved official name.
+    const raw = source.url.trim()
+    const orgPrefix = `${OFFICIAL_GITHUB_ORG.toLowerCase()}/`
+    let isOfficial = false
 
-    if (isHttpsOfficial || isSshOfficial) {
+    if (raw.includes('://')) {
+      // URL form (https://, ssh://, git://, …): require host === github.com.
+      // Parsed (not substring) so the org path can't be faked in the
+      // query/fragment of an attacker host. Handled before the scp branch so a
+      // "git@host:path" sequence buried in a URL fragment can't be mistaken for
+      // an scp-like address.
+      try {
+        const u = new URL(raw)
+        const host = u.hostname.toLowerCase()
+        const path = u.pathname.toLowerCase().replace(/^\/+/, '')
+        isOfficial = host === 'github.com' && path.startsWith(orgPrefix)
+      } catch {
+        isOfficial = false
+      }
+    } else {
+      // SSH scp-like form: git@github.com:tetsuo-ai/repo(.git). Anchored so the
+      // host segment must be exactly github.com.
+      const sshMatch = raw.match(/^[^@\s]+@([^:\s]+):(.+)$/)
+      if (sshMatch) {
+        const host = sshMatch[1]!.toLowerCase()
+        const path = sshMatch[2]!.toLowerCase().replace(/^\/+/, '')
+        isOfficial = host === 'github.com' && path.startsWith(orgPrefix)
+      }
+    }
+
+    if (isOfficial) {
       return null // Valid: reserved name from official git URL
     }
 

--- a/runtime/tests/plugins/validateOfficialNameSource.test.ts
+++ b/runtime/tests/plugins/validateOfficialNameSource.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateOfficialNameSource } from 'src/utils/plugins/schemas.js'
+
+const RESERVED = 'agenc-code-plugins'
+
+describe('validateOfficialNameSource — git URL official-source check', () => {
+  it('rejects attacker hosts that embed the magic substring in query/fragment/path', () => {
+    // Regression: a substring check on the raw URL accepted these.
+    const attacks = [
+      'https://evil.com/?u=github.com/tetsuo-ai/x',
+      'https://evil.com/path#git@github.com:tetsuo-ai/x',
+      'https://evil.com/github.com/tetsuo-ai/repo.git',
+      'https://github.com.evil.com/tetsuo-ai/repo.git',
+    ]
+    for (const url of attacks) {
+      expect(
+        validateOfficialNameSource(RESERVED, { source: 'git', url }),
+        url,
+      ).toMatch(/reserved for official provider marketplaces/)
+    }
+  })
+
+  it('accepts legitimate github.com/tetsuo-ai URLs (https, scp-ssh, ssh://)', () => {
+    const legit = [
+      'https://github.com/tetsuo-ai/agenc-code-plugins.git',
+      'git@github.com:tetsuo-ai/agenc-code-plugins.git',
+      'ssh://git@github.com/tetsuo-ai/repo.git',
+      'https://GitHub.com/Tetsuo-AI/Repo', // case-insensitive
+    ]
+    for (const url of legit) {
+      expect(
+        validateOfficialNameSource(RESERVED, { source: 'git', url }),
+        url,
+      ).toBeNull()
+    }
+  })
+
+  it('still validates the github source arm by org prefix', () => {
+    expect(
+      validateOfficialNameSource(RESERVED, {
+        source: 'github',
+        repo: 'tetsuo-ai/x',
+      }),
+    ).toBeNull()
+    expect(
+      validateOfficialNameSource(RESERVED, {
+        source: 'github',
+        repo: 'evil/x',
+      }),
+    ).toMatch(/reserved/)
+  })
+
+  it('does not gate non-reserved names', () => {
+    expect(
+      validateOfficialNameSource('some-random-marketplace', {
+        source: 'git',
+        url: 'https://evil.com/whatever',
+      }),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Resolves the **security** finding from the Tick-9 plugins audit (fixed, not deferred).

`validateOfficialNameSource` gates reserved/official marketplace names so only `github.com/tetsuo-ai/` repos may claim them. The `'git'` URL arm decided officialness with `url.includes('github.com/tetsuo-ai/')` / `url.includes('git@github.com:tetsuo-ai/')` on the raw lowercased URL — **no host parsing**. The magic substring could live in the query, fragment, or path of *any* host, so an attacker-controlled repo could register under a reserved name. Confirmed PoCs (all previously accepted):
- `https://evil.com/?u=github.com/tetsuo-ai/x`
- `https://evil.com/path#git@github.com:tetsuo-ai/x`
- `https://evil.com/github.com/tetsuo-ai/repo.git`

### Fix
Parse the URL and require `host === github.com` with the org as the leading path segment:
- URL forms (`https://`, `ssh://`, `git://`) are checked first via `new URL()`, so a `git@host:path` sequence buried in a fragment can't be mistaken for an scp-like address.
- scp-like (`git@github.com:org/repo`) is matched only when there is no scheme.
- leading slashes stripped before the org-prefix check; host **equality** (not `includes`) rejects look-alikes like `github.com.evil.com`.

## Tests
`tests/plugins/validateOfficialNameSource.test.ts`: PoC attacks (rejected), legitimate https/scp/ssh + mixed-case (accepted), the github-source arm, and non-reserved names. The test caught an over-greedy scp regex in my first attempt — which is exactly why the scheme check now runs first.

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10391 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)