### PR TITLE
fix(runtime): apply-patch context-anchored pure insertions at the anchor, not EOF

### DIFF
--- a/runtime/src/tools/apply-patch/runtime.ts
+++ b/runtime/src/tools/apply-patch/runtime.ts
@@ -113,6 +113,7 @@ function computeReplacements(
   let lineIndex = 0;
 
   for (const chunk of chunks) {
+    let anchorIndex: number | null = null;
     if (chunk.changeContext !== null) {
       const idx = seekSequence(
         originalLines,
@@ -126,17 +127,26 @@ function computeReplacements(
         );
       }
       lineIndex = idx + 1;
+      anchorIndex = idx + 1; // insert immediately after the matched context line
     }
 
     if (chunk.oldLines.length === 0) {
-      const insertionIdx = originalLines.at(-1) === ""
-        ? originalLines.length - 1
-        : originalLines.length;
+      // A pure insertion (`@@ <context>` with only `+` lines) must land right
+      // after its located anchor, not at EOF. Only fall back to end-of-file
+      // when the chunk had no context anchor at all.
+      const insertionIdx =
+        anchorIndex !== null
+          ? anchorIndex
+          : originalLines.at(-1) === ""
+            ? originalLines.length - 1
+            : originalLines.length;
       replacements.push({
         startIndex: insertionIdx,
         oldLength: 0,
         newLines: chunk.newLines,
       });
+      // Keep subsequent chunks ordered past this insertion point.
+      lineIndex = insertionIdx;
       continue;
     }
 

--- a/runtime/tests/tools/apply-patch/runtime.test.ts
+++ b/runtime/tests/tools/apply-patch/runtime.test.ts
@@ -76,6 +76,25 @@ describe("apply-patch runtime", () => {
     );
   });
 
+  test("inserts a context-anchored pure addition after the anchor, not at EOF", async () => {
+    // Regression: a `@@ <context>` chunk with only `+` lines (oldLines empty)
+    // used to ignore the located context and append at end-of-file.
+    const root = await tempRoot();
+    const path = join(root, "anchored.txt");
+    await writeFile(path, "alpha\nbeta\ngamma\ndelta\n", "utf8");
+
+    await applyPatchText(
+      wrapPatch(`*** Update File: anchored.txt
+@@ beta
++INSERTED`),
+      { cwd: root, allowedPaths: [root] },
+    );
+
+    await expect(readFile(path, "utf8")).resolves.toBe(
+      "alpha\nbeta\nINSERTED\ngamma\ndelta\n",
+    );
+  });
+
   test("moves updated files and creates destination parents", async () => {
     const root = await tempRoot();
     const source = join(root, "source.txt");


### PR DESCRIPTION
## Summary
Resolves the HIGH apply-patch finding from the Tick-11 file-tools audit (fixed, not deferred).

In `computeReplacements`, a chunk with a `@@ <context>` anchor and only `+` lines (`oldLines` empty — the standard "insert after this anchor" hunk) seeks the context and advances `lineIndex`, but the empty-`oldLines` branch then **discarded** `lineIndex` and computed the insertion point purely from `originalLines.length` — i.e. always at end-of-file. So an addition the patch explicitly anchored after a named line was silently written to the bottom of the file. Multiple such chunks also collided on the same `startIndex` and got reordered by the sort/reverse-splice.

### Fix
Thread the matched context position (`anchorIndex = idx + 1`) into the empty-`oldLines` branch: insert immediately after the anchor when one was located, and fall back to EOF only for a context-less chunk (`@@` with no arg — e.g. fixture `016` still appends at EOF). Advance `lineIndex` past the insertion so subsequent chunks stay ordered.

## Tests
Adds a runtime regression test (`@@ beta` / `+INSERTED` → inserted after `beta`, not at EOF). All 47 apply-patch tests pass, including the context-less EOF-append fixtures (confirming `@@`-no-arg behavior is preserved).

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10392 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)