### PR TITLE
fix(runtime): unblock a killed teammate's pending permission prompt (no more zombie)

### DIFF
--- a/runtime/src/utils/swarm/inProcessRunner.ts
+++ b/runtime/src/utils/swarm/inProcessRunner.ts
@@ -61,7 +61,7 @@ import {
 import { evictTaskOutput } from '../task/diskOutput.js'
 import { evictTerminalTask } from '../task/framework.js'
 import { tokenCountWithEstimation } from '../tokens.js'
-import { createAbortController } from '../abortController.js'
+import { createChildAbortController } from '../abortController.js'
 import { type AgentContext, runWithAgentContext } from '../agentContext.js'
 import { count } from '../array.js'
 import { logForDebugging } from 'src/utils/debug.js'
@@ -1029,10 +1029,15 @@ export async function runInProcessTeammate(
         `[inProcessRunner] ${identity.agentId} processing prompt: ${currentPrompt.substring(0, 50)}...`,
       )
 
-      // Create a per-turn abort controller for this iteration.
-      // This allows Escape to stop current work without killing the whole teammate.
-      // The lifecycle abortController still kills the whole teammate if needed.
-      const currentWorkAbortController = createAbortController()
+      // Create a per-turn abort controller for this iteration, linked to the
+      // lifecycle abortController. Escape aborts only this child (stops current
+      // work, teammate survives); a lifecycle/kill abort of the parent cascades
+      // to the child, which unblocks any pending permission-prompt Promise so
+      // runAgent/query yields and the loop can break. Previously this was an
+      // unlinked controller, so killing a teammate that was blocked awaiting a
+      // leader permission decision left it hung forever as a zombie.
+      const currentWorkAbortController =
+        createChildAbortController(abortController)
 
       // Store the work controller in task state so UI can abort it
       updateTaskState(

--- a/runtime/src/utils/swarm/spawnInProcess.ts
+++ b/runtime/src/utils/swarm/spawnInProcess.ts
@@ -252,8 +252,12 @@ export function killInProcessTeammate(
     toolUseId = teammateTask.toolUseId
     description = teammateTask.description
 
-    // Abort the controller to stop execution
+    // Abort the controller to stop execution. The per-turn work controller is
+    // now a child of this lifecycle controller so it already cascades, but abort
+    // it explicitly too (belt-and-suspenders) so a pending permission prompt is
+    // unblocked even if the child link is ever removed.
     teammateTask.abortController?.abort()
+    teammateTask.currentWorkAbortController?.abort()
 
     // Call cleanup handler
     teammateTask.unregisterCleanup?.()

--- a/runtime/tests/abortController.childLink.test.ts
+++ b/runtime/tests/abortController.childLink.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createAbortController,
+  createChildAbortController,
+} from 'src/utils/abortController.js'
+
+describe('createChildAbortController', () => {
+  it('cascades a parent abort to the child (the swarm kill→unblock invariant)', () => {
+    const parent = createAbortController()
+    const child = createChildAbortController(parent)
+    expect(child.signal.aborted).toBe(false)
+
+    parent.abort('killed')
+    expect(child.signal.aborted).toBe(true)
+  })
+
+  it('does not abort the parent when only the child is aborted (Escape stops the turn, teammate survives)', () => {
+    const parent = createAbortController()
+    const child = createChildAbortController(parent)
+
+    child.abort('escape')
+    expect(child.signal.aborted).toBe(true)
+    expect(parent.signal.aborted).toBe(false)
+  })
+
+  it('fast-paths an already-aborted parent', () => {
+    const parent = createAbortController()
+    parent.abort('already')
+    const child = createChildAbortController(parent)
+    expect(child.signal.aborted).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Resolves the HIGH swarm finding from the Tick-6 audit (fixed, not deferred).

`runInProcessTeammate` created the per-turn `currentWorkAbortController` as a plain, **unlinked** `createAbortController()`. `runAgent` and the permission-wait Promises were driven solely by that work controller, while `killInProcessTeammate` aborts the **lifecycle** `abortController`. So if a teammate was killed while blocked awaiting a leader permission decision, the work controller never aborted → the permission Promise never settled → `runAgent` never yielded → the `for-await` loop never re-checked the lifecycle abort → the teammate **hung forever**, leaking the pending request, its listeners, and (fallback path) a 500ms poller. The code comment already claimed the lifecycle controller "still kills the whole teammate" — but the link making that true was missing.

### Fix
`currentWorkAbortController = createChildAbortController(abortController)`. A lifecycle/kill abort of the parent now cascades to the child (unblocking the permission Promise so the loop breaks), while Escape aborting the child still does **not** abort the parent (teammate survives). The helper fast-paths an already-aborted parent and uses WeakRefs (no leak). Defense-in-depth: `killInProcessTeammate` also aborts `currentWorkAbortController` explicitly before clearing it.

## Tests
`tests/abortController.childLink.test.ts` locks the cascade invariant the fix relies on (parent→child aborts; child↛parent; already-aborted-parent fast path).

## Gate
`tsc --noEmit` clean · `npm run build` clean · full `npx vitest run` 10395 passed / 10 skipped · bun isolated green (only the pre-existing `tests/utils/file.test.ts` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)