### PR TITLE
fix(runtime): bound in-memory snapshot tool-state to stop the --yolo OOM

### DIFF
--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -26,6 +26,14 @@ export interface SnapshotPolicyOptions {
   readonly periodicIntervalMs?: number;
   readonly maxConversationEvents?: number;
   readonly maxTrackedSessions?: number;
+  // OOM fix: bound the in-memory per-session tool state so a single long-lived
+  // session (e.g. `agenc --yolo`) cannot grow `completed` / `statusTransitions`
+  // without limit. The authoritative, full tool result is already persisted and
+  // size-rotated to SQLite (recordInFlightToolCallCompletion); the in-memory
+  // copy only needs a bounded preview for snapshotting.
+  readonly maxCompletedToolCalls?: number;
+  readonly maxStatusTransitions?: number;
+  readonly maxInMemoryToolResultBytes?: number;
   readonly now?: () => string;
   readonly setInterval?: (
     callback: () => void,
@@ -107,12 +115,18 @@ interface SnapshotRow {
 const DEFAULT_PERIODIC_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_CONVERSATION_EVENTS = 200;
 const DEFAULT_MAX_TRACKED_SESSIONS = 1_024;
+const DEFAULT_MAX_COMPLETED_TOOL_CALLS = 200;
+const DEFAULT_MAX_STATUS_TRANSITIONS = 500;
+const DEFAULT_MAX_IN_MEMORY_TOOL_RESULT_BYTES = 4_096;
 
 export class AgenCSessionSnapshotPolicy {
   readonly #driver: StateSqliteDriver;
   readonly #periodicIntervalMs: number;
   readonly #maxConversationEvents: number;
   readonly #maxTrackedSessions: number;
+  readonly #maxCompletedToolCalls: number;
+  readonly #maxStatusTransitions: number;
+  readonly #maxInMemoryToolResultBytes: number;
   readonly #now: () => string;
   readonly #setInterval: (
     callback: () => void,
@@ -141,6 +155,19 @@ export class AgenCSessionSnapshotPolicy {
       1,
       options.maxTrackedSessions ?? DEFAULT_MAX_TRACKED_SESSIONS,
     );
+    this.#maxCompletedToolCalls = Math.max(
+      1,
+      options.maxCompletedToolCalls ?? DEFAULT_MAX_COMPLETED_TOOL_CALLS,
+    );
+    this.#maxStatusTransitions = Math.max(
+      1,
+      options.maxStatusTransitions ?? DEFAULT_MAX_STATUS_TRANSITIONS,
+    );
+    this.#maxInMemoryToolResultBytes = Math.max(
+      0,
+      options.maxInMemoryToolResultBytes ??
+        DEFAULT_MAX_IN_MEMORY_TOOL_RESULT_BYTES,
+    );
     this.#now = options.now ?? (() => new Date().toISOString());
     this.#setInterval =
       options.setInterval ??
@@ -152,6 +179,35 @@ export class AgenCSessionSnapshotPolicy {
     this.#snapshotRetention = options.snapshotRetention;
     this.#agencHome = options.agencHome;
     this.#outputRotation = options.outputRotation;
+  }
+
+  // OOM fix: evict the oldest completed tool calls (FIFO by insertion order)
+  // once the in-memory map exceeds its cap. The full result lives in the
+  // rotated-output SQLite store, so the in-memory `completed` map is a snapshot
+  // convenience — dropping the oldest entries is safe and stops a tool-heavy
+  // long-lived session from accumulating one entry per tool call forever.
+  #boundCompletedToolCalls(state: SessionSnapshotState): void {
+    const completed = state.toolState.completed;
+    const keys = Object.keys(completed);
+    const overflow = keys.length - this.#maxCompletedToolCalls;
+    for (let i = 0; i < overflow; i++) {
+      delete completed[keys[i] as string];
+    }
+  }
+
+  // OOM fix: replace a large tool result with a bounded preview before it is
+  // pinned in the in-memory `completed` map. The untruncated result is already
+  // persisted (and size-rotated) to SQLite, so the in-memory copy only needs a
+  // preview for snapshotting. This is the change that stops a FileRead/Bash-heavy
+  // `--yolo` session from pinning MBs per completed call until the heap is gone.
+  #boundInMemoryResult(result: JsonValue | null): JsonValue | null {
+    const cap = this.#maxInMemoryToolResultBytes;
+    if (cap === 0 || typeof result !== "string" || result.length <= cap) {
+      return result;
+    }
+    return `${result.slice(0, cap)}\n…[${
+      result.length - cap
+    } more chars elided in memory; full result persisted to the snapshot store]`;
   }
 
   startPeriodic(): void {
@@ -256,6 +312,12 @@ export class AgenCSessionSnapshotPolicy {
         ? { metadataPatch: transition.metadataPatch }
         : {}),
     });
+    // OOM fix: cap the status-transition log so a long-lived session can't grow
+    // it without bound.
+    const transitions = state.toolState.statusTransitions;
+    if (transitions.length > this.#maxStatusTransitions) {
+      transitions.splice(0, transitions.length - this.#maxStatusTransitions);
+    }
     return this.#writeSnapshot(state, "agent_status");
   }
 
@@ -423,8 +485,11 @@ export class AgenCSessionSnapshotPolicy {
               }
             : {}),
           status: booleanField(payload, "isError") ? "failed" : "completed",
-          result: (payload.result as JsonValue | undefined) ?? null,
+          result: this.#boundInMemoryResult(
+            (payload.result as JsonValue | undefined) ?? null,
+          ),
         };
+        this.#boundCompletedToolCalls(state);
       }
       return this.#writeSnapshot(state, "tool_call");
     }
@@ -466,8 +531,11 @@ export class AgenCSessionSnapshotPolicy {
           ...(recoveryCategory !== undefined ? { recoveryCategory } : {}),
           recoveryAction: "poison",
           status: "poisoned",
-          result: (payload.result as JsonValue | undefined) ?? null,
+          result: this.#boundInMemoryResult(
+            (payload.result as JsonValue | undefined) ?? null,
+          ),
         };
+        this.#boundCompletedToolCalls(state);
       }
       return this.#writeSnapshot(state, "tool_call");
     }

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -115,6 +115,78 @@ describe("AgenCSessionSnapshotPolicy", () => {
     expect(runLastSnapshotAt("run-1")).toBe("2026-05-01T00:00:05.000Z");
   });
 
+  // OOM fix: a long-lived (e.g. `agenc --yolo`) session fires many tool calls;
+  // the in-memory `completed` map previously pinned the RAW result of every one
+  // forever (unbounded large-payload growth → ~4GB heap → crash). Assert it is
+  // now FIFO-capped and each retained result is truncated to a bounded preview.
+  it("bounds the in-memory completed tool-call map and truncates large results (OOM fix)", () => {
+    seedRun("run-oom", "session-oom");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+      maxCompletedToolCalls: 50,
+      maxInMemoryToolResultBytes: 1024,
+    });
+
+    const big = "x".repeat(64 * 1024); // 64 KB per result — the leak's payload shape
+    const total = 300;
+    for (let i = 0; i < total; i++) {
+      policy.recordSessionEvent("session-oom", {
+        method: "event.tool_request",
+        params: {
+          eventId: `evt-req-${i}`,
+          requestId: `tool-${i}`,
+          toolName: "FileRead",
+        },
+      });
+      policy.recordSessionEvent("session-oom", {
+        method: "event.session_event",
+        params: {
+          event: {
+            type: "tool_call_completed",
+            payload: { callId: `tool-${i}`, result: `${big}-${i}`, isError: false },
+          },
+        },
+      });
+    }
+
+    const completed = latestSnapshot("session-oom").toolState.completed as Record<
+      string,
+      { result?: string }
+    >;
+    const keys = Object.keys(completed);
+    // Before the fix this held all 300 entries (each pinning 64 KB).
+    expect(keys.length).toBeLessThanOrEqual(50);
+    // Oldest entries are evicted (FIFO); the newest survive.
+    expect(completed["tool-0"]).toBeUndefined();
+    expect(completed["tool-299"]).toBeDefined();
+    // Each retained result is a bounded preview, not the full 64 KB payload
+    // (the untruncated result lives in the rotated-output snapshot store).
+    for (const key of keys) {
+      expect((completed[key]?.result ?? "").length).toBeLessThan(2048);
+    }
+  });
+
+  // OOM fix: the per-session status-transition log was an unbounded push target.
+  it("bounds the status-transition log (OOM fix)", () => {
+    seedRun("run-oom-st", "session-oom-st");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      maxStatusTransitions: 25,
+    });
+    for (let i = 0; i < 300; i++) {
+      policy.recordAgentStatusTransition({
+        sessionId: "session-oom-st",
+        agentId: "run-oom-st",
+        status: `status-${i}`, // distinct status forces a push (no dedup)
+        transitionAt: "2026-05-01T00:00:00.000Z",
+      });
+    }
+    const transitions = latestSnapshot("session-oom-st").toolState
+      .statusTransitions as unknown[];
+    expect(transitions.length).toBeLessThanOrEqual(25);
+  });
+
   it("updates agent_runs from runner-emitted terminal run statuses", () => {
     seedRun("run-complete", "session-complete");
     seedRun("run-error", "session-error");


### PR DESCRIPTION
## Fix the `agenc --yolo` out-of-memory crash

A long-lived autonomous session climbed to the ~4 GB V8 heap ceiling and died (`Ineffective mark-compacts near heap limit`) after ~57 min.

**Root cause:** `AgenCSessionSnapshotPolicy` pinned the **raw result of every completed tool call** in the in-memory `toolState.completed` map for the whole daemon lifetime, with no eviction within a single session (`conversation`/`inFlight` were bounded; `completed`/`statusTransitions` were not; `forgetSession` has no callers; the session-LRU only fires above 1024 sessions — `--yolo` has one). Reached on every session event, so a FileRead/Bash/Grep-heavy run accumulated MBs per tool call until OOM.

**Fix** (`src/state/snapshot-policy.ts`):
- FIFO-cap `completed` (`maxCompletedToolCalls`, default 200)
- Truncate the in-memory `result` to a preview (`maxInMemoryToolResultBytes`, default 4 KB) — the untruncated result is already persisted + size-rotated to SQLite
- Cap `statusTransitions` (`maxStatusTransitions`, default 500)

**Validation:** tsc clean · full suite **11,114 passed / 0 failed** · build green. Revert-sensitive regression tests drive 300 large tool results / status transitions and assert the persisted snapshot stays bounded + truncated.

**On the terminal mouse-event flood after the crash:** an OOM is an uncatchable V8 abort (SIGABRT), so no JS cleanup runs post-abort — fixing the leak (no abort) is the fix; catchable-exit paths already restore the terminal.

**Follow-up (separate change):** `tools/system/filesystem.ts` `sessionReadState` also grows unbounded (full file content per path) but backs the read-before-write safety gate, so it needs a careful bound (keep the was-read flag, evict only the large content).
