### PR TITLE
fix(runtime): byte-bound sessionReadState to close the second --yolo OOM leak

### DIFF
--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -206,6 +206,67 @@ const workspaceReadState = new Map<string, Map<string, SessionReadSnapshot>>();
 
 const LOCAL_FILE_HISTORY_MAX_ENTRIES = 8;
 
+// OOM fix: `sessionReadState` / `workspaceReadState` retain the full file
+// `content` + `rawContent` (KB–MB each) for every unique path read in a
+// session. In a long-lived `agenc --yolo` run touching thousands of files this
+// grew without bound. The read-before-write GATE only needs the tiny presence +
+// view-kind metadata, and the per-turn changed-files producer only needs
+// `rawContent` for recently-read files — so cap the retained large-field bytes
+// and strip `content`/`rawContent` from the OLDEST entries (keeping their gate
+// metadata in memory) once the budget is exceeded. The full content remains
+// reloadable from the persisted per-file local history or a fresh disk read.
+const DEFAULT_MAX_SESSION_READ_CONTENT_BYTES = 25 * 1024 * 1024;
+
+function sessionReadContentBudget(): number {
+  const raw = Number(process.env.AGENC_MAX_SESSION_READ_CONTENT_BYTES);
+  return Number.isFinite(raw) && raw > 0
+    ? raw
+    : DEFAULT_MAX_SESSION_READ_CONTENT_BYTES;
+}
+
+function sessionReadContentBytes(snapshot: SessionReadSnapshot): number {
+  return (
+    (typeof snapshot.content === "string" ? snapshot.content.length : 0) +
+    (typeof snapshot.rawContent === "string" ? snapshot.rawContent.length : 0)
+  );
+}
+
+function stripSessionReadLargeFields(
+  snapshot: SessionReadSnapshot,
+): SessionReadSnapshot {
+  if (snapshot.content === undefined && snapshot.rawContent === undefined) {
+    return snapshot;
+  }
+  const { content: _content, rawContent: _rawContent, ...metadata } = snapshot;
+  return metadata;
+}
+
+/**
+ * Bound the retained large-field bytes of an in-memory read map by stripping
+ * `content`/`rawContent` from the oldest entries (Map iteration is insertion
+ * order, so the front is oldest) while preserving each entry's gate metadata.
+ * Stripping is non-destructive to the read-before-write gate (which only reads
+ * presence + `isPartialView`) and only degrades the optional changed-files diff
+ * / range-dedup for the evicted (older) paths.
+ */
+function boundSessionReadContent(
+  fileMap: Map<string, SessionReadSnapshot>,
+): void {
+  const budget = sessionReadContentBudget();
+  let total = 0;
+  for (const snapshot of fileMap.values()) {
+    total += sessionReadContentBytes(snapshot);
+  }
+  if (total <= budget) return;
+  for (const [path, snapshot] of fileMap) {
+    if (total <= budget) break;
+    const bytes = sessionReadContentBytes(snapshot);
+    if (bytes === 0) continue;
+    fileMap.set(path, stripSessionReadLargeFields(snapshot));
+    total -= bytes;
+  }
+}
+
 /**
  * Resolve the workspace root used to key {@link workspaceReadState}. This
  * is the process-global session workspace root (env `AGENC_WORKSPACE`,
@@ -243,6 +304,7 @@ function mirrorWorkspaceRead(
     workspaceReadState.set(workspaceRoot, fileMap);
   }
   fileMap.set(canonicalPath, snapshot);
+  boundSessionReadContent(fileMap);
 }
 
 /**
@@ -431,6 +493,7 @@ function rehydrateSessionReadSnapshot(
     sessionReadState.set(sessionId, fileMap);
   }
   fileMap.set(canonicalPath, persistedSnapshot);
+  boundSessionReadContent(fileMap);
   return persistedSnapshot;
 }
 
@@ -458,6 +521,7 @@ export function recordSessionRead(
       snapshot?.viewKind ?? "full";
   }
   fileMap.set(canonicalPath, nextSnapshot);
+  boundSessionReadContent(fileMap);
   mirrorWorkspaceRead(canonicalPath, nextSnapshot);
   persistLocalFileHistorySnapshot(sessionId, canonicalPath, nextSnapshot);
 }

--- a/runtime/tests/tools/system/filesystem-session-read-bound.test.ts
+++ b/runtime/tests/tools/system/filesystem-session-read-bound.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSessionReadState,
+  forEachSessionRead,
+  hasSessionRead,
+  recordSessionRead,
+  type SessionReadSnapshot,
+} from "src/tools/system/filesystem.js";
+
+// OOM-fix regression: the per-session read map (which backs the read-before-write
+// gate) retained the full file content + rawContent for every unique path read.
+// A long-lived `agenc --yolo` session touching thousands of files pinned all of
+// it until the V8 heap was exhausted. The retained large-field bytes must now be
+// bounded — by STRIPPING content/rawContent from the oldest entries — WITHOUT
+// breaking the gate (presence + view-kind metadata must survive the eviction).
+describe("sessionReadState content is byte-bounded (OOM fix)", () => {
+  const sessionId = "oom-fs-regression";
+  let historyRoot = "";
+  let prevBudget: string | undefined;
+  let prevHistory: string | undefined;
+
+  beforeEach(() => {
+    historyRoot = mkdtempSync(join(tmpdir(), "agenc-fs-bound-"));
+    prevBudget = process.env.AGENC_MAX_SESSION_READ_CONTENT_BYTES;
+    prevHistory = process.env.AGENC_FILESYSTEM_HISTORY_ROOT;
+    process.env.AGENC_MAX_SESSION_READ_CONTENT_BYTES = String(64 * 1024);
+    process.env.AGENC_FILESYSTEM_HISTORY_ROOT = historyRoot;
+  });
+
+  afterEach(() => {
+    clearSessionReadState(sessionId);
+    if (prevBudget === undefined) {
+      delete process.env.AGENC_MAX_SESSION_READ_CONTENT_BYTES;
+    } else {
+      process.env.AGENC_MAX_SESSION_READ_CONTENT_BYTES = prevBudget;
+    }
+    if (prevHistory === undefined) {
+      delete process.env.AGENC_FILESYSTEM_HISTORY_ROOT;
+    } else {
+      process.env.AGENC_FILESYSTEM_HISTORY_ROOT = prevHistory;
+    }
+    rmSync(historyRoot, { recursive: true, force: true });
+  });
+
+  it("caps retained content bytes and strips old entries while preserving the read-before-write gate", () => {
+    const perField = 8 * 1024; // 8 KB content + 8 KB rawContent = 16 KB / file
+    const fileCount = 200; // 200 * 16 KB = 3.2 MB, far above the 64 KB budget
+    for (let i = 0; i < fileCount; i++) {
+      recordSessionRead(sessionId, `/proj/file-${i}.ts`, {
+        content: "c".repeat(perField),
+        rawContent: "r".repeat(perField),
+        viewKind: "full",
+        timestamp: i,
+      } as SessionReadSnapshot);
+    }
+
+    let retainedBytes = 0;
+    let entryCount = 0;
+    forEachSessionRead(sessionId, (_path, snapshot) => {
+      entryCount += 1;
+      retainedBytes +=
+        (snapshot.content?.length ?? 0) + (snapshot.rawContent?.length ?? 0);
+    });
+
+    // Before the fix this was ~3.2 MB. Allow a little slack for the most-recent
+    // not-yet-evicted entry above the 64 KB budget.
+    expect(retainedBytes).toBeLessThanOrEqual(64 * 1024 + 2 * perField);
+    // The tiny metadata entry is kept for every path (only the bytes are
+    // bounded, not the entry count) so the gate never loses a read.
+    expect(entryCount).toBe(fileCount);
+
+    // Read-before-write gate still authorizes BOTH an old (content-stripped) and
+    // a recent path: presence + view-kind metadata survived the eviction.
+    expect(hasSessionRead(sessionId, "/proj/file-0.ts")).toBe(true);
+    expect(hasSessionRead(sessionId, "/proj/file-199.ts")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Close the second `--yolo` OOM leak: byte-bound `sessionReadState`

Companion to #946. `tools/system/filesystem.ts`'s per-session / per-workspace read maps retained the **full file `content` + `rawContent`** (KB–MB each) for every unique path read in a session, with no eviction in a single long-lived run — the sibling `fileStateCache` already has an LRU + 25 MB cap; this one had none. A FileRead-heavy `agenc --yolo` session touching thousands of files accumulated all of it until the heap was exhausted.

This map backs the **read-before-write safety gate**, so a naive count cap / LRU delete would cause spurious `READ_BEFORE_WRITE` errors. Instead this bounds **only the large fields**: it strips `content`/`rawContent` from the *oldest* entries (keeping each entry's tiny presence + view-kind gate metadata) once retained bytes exceed `AGENC_MAX_SESSION_READ_CONTENT_BYTES` (default 25 MB). The gate is untouched; only the optional changed-files diff / range-dedup degrades for evicted older paths, and the full content stays reloadable from the persisted per-file local history.

**Validation:** tsc clean · full suite **11,115 passed / 0 failed** (incl. the read-before-write gate, cross-agent, and changed-files tests) · build green. Revert-sensitive test drives 200 large reads through a 64 KB budget and asserts bounded bytes while the gate still authorizes both oldest and newest paths.

Together with #946 this removes both dominant unbounded in-memory accumulators behind the OOM.
