### PR TITLE
test(runtime): 100% coverage gate + confidence suite, with LSP/powershell/extractTag fixes

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -48,7 +48,7 @@
     "check:unused:production": "knip --config knip.config.mjs --production --no-progress",
     "check:unused:report": "node scripts/check-unused-report.mjs",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage --maxWorkers=1",
     "test:coverage:tui": "vitest run tests/tui --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/**/*.{ts,tsx}' --coverage.exclude='src/**/*.d.ts' --coverage.reportsDirectory=coverage/runtime-tui",
     "test:transaction-guard": "vitest run tests/transaction-guard",
     "test:transaction-guard:live": "vitest run tests/transaction-guard/devnet-live.e2e.test.ts",

--- a/runtime/src/services/api/sessionIngress.ts
+++ b/runtime/src/services/api/sessionIngress.ts
@@ -1,0 +1,257 @@
+import axios, { type AxiosError } from 'axios'
+import type { UUID } from 'crypto'
+import type { Entry, TranscriptMessage } from '../../types/logs.js'
+import { logForDebugging } from '../../utils/debug.js'
+import { logForDiagnosticsNoPII } from '../../utils/diagLogs.js'
+import { isEnvTruthy } from '../../utils/envUtils.js'
+import { logError } from '../../utils/log.js'
+import { sequential } from '../../utils/sequential.js'
+import { getSessionIngressAuthToken } from '../../utils/sessionIngressAuth.js'
+import { sleep } from '../../utils/sleep.js'
+import { jsonStringify } from '../../utils/slowOperations.js'
+
+interface SessionIngressError {
+  error?: {
+    message?: string
+    type?: string
+  }
+}
+
+const lastUuidMap = new Map<string, UUID>()
+const sequentialAppendBySession = new Map<
+  string,
+  (
+    entry: TranscriptMessage,
+    url: string,
+    headers: Record<string, string>,
+  ) => Promise<boolean>
+>()
+
+const MAX_RETRIES = 10
+const BASE_DELAY_MS = 500
+
+function getOrCreateSequentialAppend(sessionId: string) {
+  let sequentialAppend = sequentialAppendBySession.get(sessionId)
+  if (!sequentialAppend) {
+    sequentialAppend = sequential(
+      async (
+        entry: TranscriptMessage,
+        url: string,
+        headers: Record<string, string>,
+      ) => appendSessionLogImpl(sessionId, entry, url, headers),
+    )
+    sequentialAppendBySession.set(sessionId, sequentialAppend)
+  }
+  return sequentialAppend
+}
+
+async function appendSessionLogImpl(
+  sessionId: string,
+  entry: TranscriptMessage,
+  url: string,
+  headers: Record<string, string>,
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const lastUuid = lastUuidMap.get(sessionId)
+      const requestHeaders = { ...headers }
+      if (lastUuid) {
+        requestHeaders['Last-Uuid'] = lastUuid
+      }
+
+      const response = await axios.put(url, entry, {
+        headers: requestHeaders,
+        validateStatus: status => status < 500,
+      })
+
+      if (response.status === 200 || response.status === 201) {
+        lastUuidMap.set(sessionId, entry.uuid)
+        return true
+      }
+
+      if (response.status === 409) {
+        const serverLastUuid = response.headers['x-last-uuid']
+        if (serverLastUuid === entry.uuid) {
+          lastUuidMap.set(sessionId, entry.uuid)
+          logForDiagnosticsNoPII('info', 'session_persist_recovered_from_409')
+          return true
+        }
+
+        if (serverLastUuid) {
+          lastUuidMap.set(sessionId, serverLastUuid as UUID)
+          logForDiagnosticsNoPII('info', 'session_persist_409_adopt_server_uuid')
+          continue
+        }
+
+        const logs = await fetchSessionLogsFromUrl(url, headers)
+        const adoptedUuid = findLastUuid(logs)
+        if (adoptedUuid) {
+          lastUuidMap.set(sessionId, adoptedUuid)
+          logForDiagnosticsNoPII('info', 'session_persist_409_adopt_server_uuid')
+          continue
+        }
+
+        const errorData = response.data as SessionIngressError
+        const errorMessage =
+          errorData.error?.message || 'Concurrent modification detected'
+        logError(
+          new Error(
+            `Session persistence conflict: UUID mismatch for session ${sessionId}, entry ${entry.uuid}. ${errorMessage}`,
+          ),
+        )
+        logForDiagnosticsNoPII(
+          'error',
+          'session_persist_fail_concurrent_modification',
+        )
+        return false
+      }
+
+      if (response.status === 401) {
+        logForDebugging('Session token expired or invalid')
+        logForDiagnosticsNoPII('error', 'session_persist_fail_bad_token')
+        return false
+      }
+
+      logForDiagnosticsNoPII('error', 'session_persist_fail_status', {
+        status: response.status,
+        attempt,
+      })
+    } catch (error) {
+      const axiosError = error as AxiosError<SessionIngressError>
+      logError(new Error(`Error persisting session log: ${axiosError.message}`))
+      logForDiagnosticsNoPII('error', 'session_persist_fail_status', {
+        status: axiosError.status,
+        attempt,
+      })
+    }
+
+    if (attempt === MAX_RETRIES) {
+      logForDebugging(`Remote persistence failed after ${MAX_RETRIES} attempts`)
+      logForDiagnosticsNoPII(
+        'error',
+        'session_persist_error_retries_exhausted',
+        { attempt },
+      )
+      return false
+    }
+
+    const delayMs = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), 8000)
+    await sleep(delayMs)
+  }
+
+  return false
+}
+
+export async function appendSessionLog(
+  sessionId: string,
+  entry: TranscriptMessage,
+  url: string,
+): Promise<boolean> {
+  const sessionToken = getSessionIngressAuthToken()
+  if (!sessionToken) {
+    logForDebugging('No session token available for session persistence')
+    logForDiagnosticsNoPII('error', 'session_persist_fail_jwt_no_token')
+    return false
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${sessionToken}`,
+    'Content-Type': 'application/json',
+  }
+
+  const sequentialAppend = getOrCreateSequentialAppend(sessionId)
+  return sequentialAppend(entry, url, headers)
+}
+
+export async function getSessionLogs(
+  sessionId: string,
+  url: string,
+): Promise<Entry[] | null> {
+  const sessionToken = getSessionIngressAuthToken()
+  if (!sessionToken) {
+    logForDebugging('No session token available for fetching session logs')
+    logForDiagnosticsNoPII('error', 'session_get_fail_no_token')
+    return null
+  }
+
+  const logs = await fetchSessionLogsFromUrl(url, {
+    Authorization: `Bearer ${sessionToken}`,
+  })
+
+  const lastUuid = findLastUuid(logs)
+  if (lastUuid) {
+    lastUuidMap.set(sessionId, lastUuid)
+  }
+
+  return logs
+}
+
+async function fetchSessionLogsFromUrl(
+  url: string,
+  headers: Record<string, string>,
+): Promise<Entry[] | null> {
+  try {
+    const response = await axios.get(url, {
+      headers,
+      timeout: 20000,
+      validateStatus: status => status < 500,
+      params: isEnvTruthy(process.env.AGENC_AFTER_LAST_COMPACT)
+        ? { after_last_compact: true }
+        : undefined,
+    })
+
+    if (response.status === 200) {
+      const data = response.data
+      if (!data || typeof data !== 'object' || !Array.isArray(data.loglines)) {
+        logError(
+          new Error(
+            `Invalid session logs response format: ${jsonStringify(data)}`,
+          ),
+        )
+        logForDiagnosticsNoPII('error', 'session_get_fail_invalid_response')
+        return null
+      }
+      return data.loglines as Entry[]
+    }
+
+    if (response.status === 404) {
+      return []
+    }
+
+    if (response.status === 401) {
+      logForDebugging('Auth token expired or invalid')
+      logForDiagnosticsNoPII('error', 'session_get_fail_bad_token')
+      throw new Error(
+        'Your session has expired. Please run /login to sign in again.',
+      )
+    }
+
+    logForDiagnosticsNoPII('error', 'session_get_fail_status', {
+      status: response.status,
+    })
+    return null
+  } catch (error) {
+    const axiosError = error as AxiosError<SessionIngressError>
+    logError(new Error(`Error fetching session logs: ${axiosError.message}`))
+    logForDiagnosticsNoPII('error', 'session_get_fail_status', {
+      status: axiosError.status,
+    })
+    return null
+  }
+}
+
+function findLastUuid(logs: Entry[] | null): UUID | undefined {
+  if (!logs) return undefined
+  const entry = logs.findLast(e => 'uuid' in e && e.uuid)
+  return entry && 'uuid' in entry ? (entry.uuid as UUID) : undefined
+}
+
+export function clearSession(sessionId: string): void {
+  lastUuidMap.delete(sessionId)
+  sequentialAppendBySession.delete(sessionId)
+}
+
+export function clearAllSessions(): void {
+  lastUuidMap.clear()
+  sequentialAppendBySession.clear()
+}

--- a/runtime/src/services/lsp/LSPClient.ts
+++ b/runtime/src/services/lsp/LSPClient.ts
@@ -96,6 +96,7 @@ export function createLSPClient(
   let startError: Error | undefined;
   let stopping = false;
   let terminalNotified = false;
+  let connectionClosePending = false;
   const notificationHandlers: Array<{
     readonly method: string;
     readonly handler: (params: unknown) => void;
@@ -126,14 +127,20 @@ export function createLSPClient(
     capabilities = undefined;
   };
 
+  const removeChildListeners = (currentChild: ChildProcess): void => {
+    currentChild.removeAllListeners("error");
+    currentChild.removeAllListeners("exit");
+    currentChild.stdin?.removeAllListeners("error");
+    currentChild.stdout?.removeAllListeners("end");
+    currentChild.stdout?.removeAllListeners("close");
+    currentChild.stderr?.removeAllListeners("data");
+  };
+
   const clearClosedRuntimeState = (opts: { readonly killChild?: boolean } = {}): void => {
     clearConnectionState();
     if (child) {
       const currentChild = child;
-      child.removeAllListeners("error");
-      child.removeAllListeners("exit");
-      child.stdin?.removeAllListeners("error");
-      child.stderr?.removeAllListeners("data");
+      removeChildListeners(currentChild);
       if (opts.killChild === true && !currentChild.killed) {
         currentChild.kill();
       }
@@ -148,6 +155,41 @@ export function createLSPClient(
     startError = undefined;
     options.onCrash?.(error);
     diagnostic(error.message);
+  };
+
+  const scheduleUnexpectedConnectionClose = (): void => {
+    if (stopping || terminalNotified || connectionClosePending) return;
+    connectionClosePending = true;
+    const closedChild = child;
+    clearConnectionState();
+    setTimeout(() => {
+      connectionClosePending = false;
+      if (stopping || terminalNotified) return;
+      if (closedChild && child === closedChild) {
+        removeChildListeners(closedChild);
+        if (!closedChild.killed) closedChild.kill();
+        child = undefined;
+      }
+      if (closedChild?.exitCode !== null && closedChild?.exitCode !== undefined) {
+        notifyUnexpectedTerminal(
+          closedChild.exitCode === 0
+            ? new Error(`LSP server ${serverName} exited unexpectedly with code 0`)
+            : new Error(
+                `LSP server ${serverName} crashed with exit code ${closedChild.exitCode}`,
+              ),
+        );
+        return;
+      }
+      if (closedChild?.signalCode) {
+        notifyUnexpectedTerminal(
+          new Error(`LSP server ${serverName} exited with signal ${closedChild.signalCode}`),
+        );
+        return;
+      }
+      notifyUnexpectedTerminal(
+        new Error(`LSP server ${serverName} connection closed unexpectedly`),
+      );
+    }, CONNECTION_CLOSE_EXIT_GRACE_MS);
   };
 
   const assertStarted = (): void => {
@@ -182,6 +224,7 @@ export function createLSPClient(
       if (connection) return;
       stopping = false;
       terminalNotified = false;
+      connectionClosePending = false;
       startFailed = false;
       startError = undefined;
 
@@ -250,6 +293,8 @@ export function createLSPClient(
         child.stdin.on("error", (error: Error) => {
           if (!stopping) diagnostic(`stdin error: ${error.message}`);
         });
+        child.stdout.once("end", scheduleUnexpectedConnectionClose);
+        child.stdout.once("close", scheduleUnexpectedConnectionClose);
 
         const reader = new StreamMessageReader(child.stdout);
         const writer = new StreamMessageWriter(child.stdin);
@@ -263,43 +308,7 @@ export function createLSPClient(
         });
 
         connection.onClose(() => {
-          if (stopping) return;
-          const closedChild = child;
-          clearConnectionState();
-          setTimeout(() => {
-            if (stopping || terminalNotified) return;
-            if (closedChild && child === closedChild) {
-              child.removeAllListeners("error");
-              child.removeAllListeners("exit");
-              child.stdin?.removeAllListeners("error");
-              child.stderr?.removeAllListeners("data");
-              if (!child.killed) child.kill();
-              child = undefined;
-            }
-            if (closedChild?.exitCode !== null && closedChild?.exitCode !== undefined) {
-              notifyUnexpectedTerminal(
-                closedChild.exitCode === 0
-                  ? new Error(
-                      `LSP server ${serverName} exited unexpectedly with code 0`,
-                    )
-                  : new Error(
-                      `LSP server ${serverName} crashed with exit code ${closedChild.exitCode}`,
-                    ),
-              );
-              return;
-            }
-            if (closedChild?.signalCode) {
-              notifyUnexpectedTerminal(
-                new Error(
-                  `LSP server ${serverName} exited with signal ${closedChild.signalCode}`,
-                ),
-              );
-              return;
-            }
-            notifyUnexpectedTerminal(
-              new Error(`LSP server ${serverName} connection closed unexpectedly`),
-            );
-          }, CONNECTION_CLOSE_EXIT_GRACE_MS);
+          scheduleUnexpectedConnectionClose();
         });
 
         connection.listen();
@@ -397,10 +406,7 @@ export function createLSPClient(
       } finally {
         disposeConnection();
         if (child) {
-          child.removeAllListeners("error");
-          child.removeAllListeners("exit");
-          child.stdin?.removeAllListeners("error");
-          child.stderr?.removeAllListeners("data");
+          removeChildListeners(child);
           if (!child.killed) child.kill();
           child = undefined;
         }

--- a/runtime/src/shell-command/powershell-parser.ts
+++ b/runtime/src/shell-command/powershell-parser.ts
@@ -249,7 +249,10 @@ class PowerShellParserProcess {
     const stdinFd = streamFd(child.stdin);
     const stdoutFd = streamFd(child.stdout);
     if (child.pid === undefined || stdinFd === null || stdoutFd === null) {
-      child.kill();
+      child.stdin.destroy();
+      child.stdout.destroy();
+      child.stderr.destroy();
+      if (child.pid !== undefined) child.kill();
       return {
         ok: false,
         diagnostic: `failed to spawn PowerShell parser process for ${executable}`,
@@ -303,7 +306,7 @@ class PowerShellParserProcess {
     this.child.stdin.destroy();
     this.child.stdout.destroy();
     this.child.stderr.destroy();
-    this.child.kill();
+    if (this.child.pid !== undefined) this.child.kill();
   }
 
   private readLine(timeoutMs: number): string {

--- a/runtime/src/utils/messages.ts
+++ b/runtime/src/utils/messages.ts
@@ -652,51 +652,37 @@ export function extractTag(html: string, tagName: string): string | null {
   }
 
   const escapedTag = escapeRegExp(tagName)
-
-  // Create regex pattern that handles:
-  // 1. Self-closing tags
-  // 2. Tags with attributes
-  // 3. Nested tags of the same type
-  // 4. Multiline content
-  const pattern = new RegExp(
-    `<${escapedTag}(?:\\s+[^>]*)?>` + // Opening tag with optional attributes
-      '([\\s\\S]*?)' + // Content (non-greedy match)
-      `<\\/${escapedTag}>`, // Closing tag
+  const tagPattern = new RegExp(
+    `<${escapedTag}(?:\\s+[^>]*)?\\s*\\/\\s*>|<\\/${escapedTag}\\s*>|<${escapedTag}(?:\\s+[^>]*)?>`,
     'gi',
   )
-
-  let match
   let depth = 0
-  let lastIndex = 0
-  const openingTag = new RegExp(`<${escapedTag}(?:\\s+[^>]*?)?>`, 'gi')
-  const closingTag = new RegExp(`<\\/${escapedTag}>`, 'gi')
+  let contentStart = -1
+  let match: RegExpExecArray | null
 
-  while ((match = pattern.exec(html)) !== null) {
-    // Check for nested tags
-    const content = match[1]
-    const beforeMatch = html.slice(lastIndex, match.index)
-
-    // Reset depth counter
-    depth = 0
-
-    // Count opening tags before this match
-    openingTag.lastIndex = 0
-    while (openingTag.exec(beforeMatch) !== null) {
-      depth++
+  while ((match = tagPattern.exec(html)) !== null) {
+    const token = match[0]
+    const isSelfClosing = /\/\s*>$/.test(token)
+    if (isSelfClosing) {
+      continue
     }
 
-    // Count closing tags before this match
-    closingTag.lastIndex = 0
-    while (closingTag.exec(beforeMatch) !== null) {
+    if (token.startsWith('</')) {
+      if (depth === 0) {
+        continue
+      }
       depth--
+      if (depth === 0 && contentStart >= 0) {
+        const content = html.slice(contentStart, match.index)
+        return content || null
+      }
+      continue
     }
 
-    // Only include content if we're at the correct nesting level
-    if (depth === 0 && content) {
-      return content
+    if (depth === 0) {
+      contentStart = tagPattern.lastIndex
     }
-
-    lastIndex = match.index + match[0].length
+    depth++
   }
 
   return null

--- a/runtime/src/utils/sessionStorage.ts
+++ b/runtime/src/utils/sessionStorage.ts
@@ -29,6 +29,7 @@ import {
 } from '../bootstrap/state.js'
 import { builtInCommandNames } from '../commands.js'
 import { COMMAND_NAME_TAG, TICK_TAG } from '../constants/xml.js'
+import * as sessionIngress from '../services/api/sessionIngress.js'
 import { REPL_TOOL_NAME } from '../tools/REPLTool/constants.js'
 import {
   type AgentId,

--- a/runtime/tests/conversation/messages-core.test.ts
+++ b/runtime/tests/conversation/messages-core.test.ts
@@ -1,0 +1,1985 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createAttachmentMessage } from "../../src/utils/attachments.js";
+import { getImageTooLargeErrorMessage } from "../../src/services/api/errors.js";
+import {
+  AUTO_REJECT_MESSAGE,
+  buildMessageLookups,
+  buildSubagentLookups,
+  buildClassifierUnavailableMessage,
+  buildYoloRejectionMessage,
+  CANCEL_MESSAGE,
+  countToolCalls,
+  createAgentsKilledMessage,
+  createApiMetricsMessage,
+  createAssistantAPIErrorMessage,
+  createAssistantMessage,
+  createAwaySummaryMessage,
+  createBridgeStatusMessage,
+  createCommandInputMessage,
+  createCompactBoundaryMessage,
+  createMemorySavedMessage,
+  createMicrocompactBoundaryMessage,
+  createModelSwitchBreadcrumbs,
+  createPermissionRetryMessage,
+  createProgressMessage,
+  createScheduledTaskFireMessage,
+  createStopHookSummaryMessage,
+  createSyntheticUserCaveatMessage,
+  createSystemAPIErrorMessage,
+  createSystemMessage,
+  createToolResultStopMessage,
+  createToolUseSummaryMessage,
+  createTurnDurationMessage,
+  createUserInterruptionMessage,
+  createUserMessage,
+  deriveShortMessageId,
+  deriveUUID,
+  DONT_ASK_REJECT_MESSAGE,
+  extractTag,
+  extractTextContent,
+  filterUnresolvedToolUses,
+  filterOrphanedThinkingOnlyMessages,
+  filterWhitespaceOnlyAssistantMessages,
+  findLastCompactBoundaryIndex,
+  formatCommandInputTags,
+  getAssistantAPIErrorMessageText,
+  getAssistantMessageText,
+  getContentText,
+  getLastAssistantMessage,
+  getMessagesAfterCompactBoundary,
+  getProgressMessagesFromLookup,
+  getSiblingToolUseIDs,
+  getSiblingToolUseIDsFromLookup,
+  getToolUseID,
+  getToolResultIDs,
+  getToolUseIDs,
+  getUserMessageText,
+  handleMessageFromStream,
+  hasUnresolvedHooks,
+  hasUnresolvedHooksFromLookup,
+  hasSuccessfulToolCall,
+  hasToolCallsInLastAssistantTurn,
+  INTERRUPT_MESSAGE,
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  isAssistantAPIErrorMessage,
+  isClassifierDenial,
+  isCompactBoundaryMessage,
+  isEmptyMessageText,
+  isNotEmptyMessage,
+  isSyntheticMessage,
+  isThinkingMessage,
+  isToolUseRequestMessage,
+  isToolUseResultMessage,
+  NO_RESPONSE_REQUESTED,
+  ensureToolResultPairing,
+  mergeAssistantMessages,
+  mergeUserContentBlocks,
+  mergeUserMessages,
+  mergeUserMessagesAndToolResults,
+  normalizeAttachmentForAPI,
+  normalizeContentFromAPI,
+  normalizeMessagesForAPI,
+  normalizeMessages,
+  prepareUserContent,
+  REJECT_MESSAGE,
+  reorderAttachmentsForAPI,
+  reorderMessagesInUI,
+  shouldShowUserMessage,
+  stripAdvisorBlocks,
+  stripCallerFieldFromAssistantMessage,
+  stripPromptXMLTags,
+  stripSignatureBlocks,
+  stripToolReferenceBlocksFromUserMessage,
+  textForResubmit,
+  wrapCommandText,
+  wrapInSystemReminder,
+  wrapMessagesInSystemReminder,
+} from "../../src/utils/messages.js";
+
+const parentUuid = "00000000-0000-4000-8000-000000000123";
+const originalDisableToolReminders = process.env.AGENC_DISABLE_TOOL_REMINDERS;
+const originalEnableTasks = process.env.AGENC_ENABLE_TASKS;
+const originalEnableToolSearch = process.env.ENABLE_TOOL_SEARCH;
+
+afterEach(() => {
+  if (originalDisableToolReminders === undefined) {
+    delete process.env.AGENC_DISABLE_TOOL_REMINDERS;
+  } else {
+    process.env.AGENC_DISABLE_TOOL_REMINDERS = originalDisableToolReminders;
+  }
+
+  if (originalEnableTasks === undefined) {
+    delete process.env.AGENC_ENABLE_TASKS;
+  } else {
+    process.env.AGENC_ENABLE_TASKS = originalEnableTasks;
+  }
+
+  if (originalEnableToolSearch === undefined) {
+    delete process.env.ENABLE_TOOL_SEARCH;
+  } else {
+    process.env.ENABLE_TOOL_SEARCH = originalEnableToolSearch;
+  }
+});
+
+function textBlock(text: string) {
+  return { type: "text", text } as const;
+}
+
+function toolUseBlock(id: string, name = "Bash") {
+  return {
+    type: "tool_use",
+    id,
+    name,
+    input: { command: "echo ok" },
+  } as const;
+}
+
+function toolResultBlock(id: string, content = "ok", isError = false) {
+  return {
+    type: "tool_result",
+    tool_use_id: id,
+    content,
+    is_error: isError,
+  } as const;
+}
+
+function hookAttachment(hookEvent: "PreToolUse" | "PostToolUse", hookName: string, toolUseID: string) {
+  return createAttachmentMessage({
+    type: "hook_success",
+    hookName,
+    hookEvent,
+    toolUseID,
+    content: "ok",
+  } as never);
+}
+
+function userText(message: unknown): string {
+  return getUserMessageText(message as never) ?? "";
+}
+
+describe("message utility constructors and predicates", () => {
+  test("derives stable compact IDs and UUIDs", () => {
+    expect(
+      deriveShortMessageId("ffffffff-ffff-4000-8000-000000000abc"),
+    ).toHaveLength(6);
+    expect(deriveShortMessageId(parentUuid)).toBe(
+      deriveShortMessageId(parentUuid),
+    );
+    expect(deriveUUID(parentUuid, 42)).toBe(
+      "00000000-0000-4000-8000-00000000002a",
+    );
+  });
+
+  test("builds permission and classifier messages", () => {
+    expect(AUTO_REJECT_MESSAGE("Bash")).toContain("Permission to use Bash");
+    expect(DONT_ASK_REJECT_MESSAGE("FileEdit")).toContain("don't ask mode");
+
+    const denied = buildYoloRejectionMessage("writes outside project");
+    expect(isClassifierDenial(denied)).toBe(true);
+    expect(denied).toContain("writes outside project");
+    expect(denied).toContain("continue working");
+
+    const unavailable = buildClassifierUnavailableMessage("Bash", "safety-model");
+    expect(unavailable).toContain("safety-model is temporarily unavailable");
+    expect(unavailable).toContain("read-only operations");
+  });
+
+  test("creates assistant, API error, and user messages with fallback content", () => {
+    const emptyAssistant = createAssistantMessage({ content: "" });
+    expect(emptyAssistant.message.content[0]).toMatchObject({
+      type: "text",
+      text: "(no content)",
+    });
+    expect(isAssistantAPIErrorMessage(emptyAssistant)).toBe(false);
+
+    const error = createAssistantAPIErrorMessage({
+      content: "",
+      errorDetails: "request failed",
+    });
+    expect(isAssistantAPIErrorMessage(error)).toBe(true);
+    expect(getAssistantAPIErrorMessageText(error)).toBe("(no content)");
+    expect(error.errorDetails).toBe("request failed");
+
+    const user = createUserMessage({
+      content: "",
+      isMeta: true,
+      uuid: parentUuid,
+      timestamp: "2026-04-02T00:00:00.000Z",
+      permissionMode: "default" as never,
+    });
+    expect(user.message.content).toBe("(no content)");
+    expect(user.isMeta).toBe(true);
+    expect(user.uuid).toBe(parentUuid);
+  });
+
+  test("classifies synthetic and non-empty messages", () => {
+    const rejected = createUserMessage({
+      content: [{ type: "text", text: REJECT_MESSAGE }],
+    });
+    const noResponse = createAssistantMessage({ content: NO_RESPONSE_REQUESTED });
+    const interruption = createUserInterruptionMessage({});
+    const toolInterruption = createUserInterruptionMessage({ toolUse: true });
+    const progress = createProgressMessage({
+      toolUseID: "tu_nonempty",
+      parentToolUseID: "tu_nonempty",
+      data: { type: "bash_progress", stdout: "partial" } as never,
+    });
+    const system = createSystemMessage("system", "info");
+    const attachment = hookAttachment("PreToolUse", "pre", "tu_nonempty");
+
+    expect(isSyntheticMessage(rejected)).toBe(true);
+    expect(isSyntheticMessage(noResponse)).toBe(true);
+    expect(interruption.message.content).toEqual([
+      { type: "text", text: INTERRUPT_MESSAGE },
+    ]);
+    expect(toolInterruption.message.content).toEqual([
+      { type: "text", text: INTERRUPT_MESSAGE_FOR_TOOL_USE },
+    ]);
+    expect(isNotEmptyMessage(createUserMessage({ content: "   " }))).toBe(false);
+    expect(
+      isNotEmptyMessage(
+        createUserMessage({
+          content: [{ type: "text", text: INTERRUPT_MESSAGE_FOR_TOOL_USE }],
+        }),
+      ),
+    ).toBe(false);
+    expect(isNotEmptyMessage(createUserMessage({ content: "hello" }))).toBe(true);
+    expect(
+      isNotEmptyMessage(
+        createUserMessage({
+          content: [{ type: "tool_result", tool_use_id: "tu", content: "ok" }],
+        }),
+      ),
+    ).toBe(true);
+    expect(isNotEmptyMessage(progress)).toBe(true);
+    expect(isNotEmptyMessage(system)).toBe(true);
+    expect(isNotEmptyMessage(attachment)).toBe(true);
+    expect(isNotEmptyMessage(createUserMessage({ content: [] as never })))
+      .toBe(false);
+    expect(
+      isNotEmptyMessage(
+        createUserMessage({
+          content: [textBlock(""), textBlock("")] as never,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("extracts tags with attributes and returns the first matching content", () => {
+    expect(extractTag("", "x")).toBeNull();
+    expect(extractTag("<x>value</x>", "")).toBeNull();
+    expect(extractTag("<outer><x>skip</x></outer><x a=\"b\">keep</x>", "x"))
+      .toBe("skip");
+    expect(extractTag("<x a=\"b\">with attributes</x>", "x")).toBe(
+      "with attributes",
+    );
+    expect(extractTag("<x>first</x><x>second</x>", "x")).toBe("first");
+    expect(extractTag("<x><x>inner</x></x><x>outer</x>", "x")).toBe(
+      "<x>inner</x>",
+    );
+  });
+
+  test("builds command breadcrumbs and model switch messages", () => {
+    const tags = formatCommandInputTags("review&fix", "a < b");
+    expect(tags).toContain("<command-name>/review&amp;fix</command-name>");
+    expect(tags).toContain("<command-args>a &lt; b</command-args>");
+
+    const caveat = createSyntheticUserCaveatMessage();
+    expect(caveat.isMeta).toBe(true);
+    expect(String(caveat.message.content)).toContain("local commands");
+
+    const breadcrumbs = createModelSwitchBreadcrumbs("gpt-test", "GPT Test");
+    expect(breadcrumbs).toHaveLength(3);
+    expect(String(breadcrumbs[1]?.message.content)).toContain("gpt-test");
+    expect(String(breadcrumbs[2]?.message.content)).toContain("Set model to GPT Test");
+  });
+
+  test("builds progress and tool-result stop messages", () => {
+    const progress = createProgressMessage({
+      toolUseID: "tu_child",
+      parentToolUseID: "tu_parent",
+      data: { type: "bash_progress", stdout: "chunk" } as never,
+    });
+    expect(progress).toMatchObject({
+      type: "progress",
+      toolUseID: "tu_child",
+      parentToolUseID: "tu_parent",
+      data: { type: "bash_progress", stdout: "chunk" },
+    });
+
+    expect(createToolResultStopMessage("tu_stop")).toEqual({
+      type: "tool_result",
+      content: CANCEL_MESSAGE,
+      is_error: true,
+      tool_use_id: "tu_stop",
+    });
+  });
+
+  test("prepares content and inspects assistant tool calls", () => {
+    expect(
+      prepareUserContent({ inputString: "hello", precedingInputBlocks: [] }),
+    ).toBe("hello");
+    expect(
+      prepareUserContent({
+        inputString: "tail",
+        precedingInputBlocks: [{ type: "text", text: "head" }],
+      }),
+    ).toEqual([
+      { type: "text", text: "head" },
+      { type: "text", text: "tail" },
+    ]);
+
+    const assistantWithoutTool = createAssistantMessage({ content: "plain" });
+    const assistantWithTool = createAssistantMessage({
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "Bash",
+          input: { command: "echo ok" },
+        } as never,
+      ],
+    });
+    expect(getLastAssistantMessage([assistantWithoutTool, assistantWithTool]))
+      .toBe(assistantWithTool);
+    expect(hasToolCallsInLastAssistantTurn([assistantWithoutTool])).toBe(false);
+    expect(
+      hasToolCallsInLastAssistantTurn([assistantWithoutTool, assistantWithTool]),
+    ).toBe(true);
+  });
+
+  test("normalizes multi-block assistant and user messages", () => {
+    const assistant = createAssistantMessage({
+      content: [textBlock("first"), toolUseBlock("tu_norm")] as never,
+    });
+    const user = createUserMessage({
+      uuid: parentUuid,
+      content: [
+        textBlock("second"),
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "abc",
+          },
+        },
+      ] as never,
+      imagePasteIds: [77],
+    });
+
+    const normalized = normalizeMessages([assistant, user] as never);
+    expect(normalized).toHaveLength(4);
+    expect(normalized.map(message => message.message.content[0]?.type))
+      .toEqual(["text", "tool_use", "text", "image"]);
+    expect(normalized[0]?.uuid).toBe(deriveUUID(assistant.uuid, 0));
+    expect(normalized[1]?.uuid).toBe(deriveUUID(assistant.uuid, 1));
+    expect(normalized[2]?.uuid).toBe(deriveUUID(parentUuid, 0));
+    expect(normalized[3]?.uuid).toBe(deriveUUID(parentUuid, 1));
+    expect(normalized[3]).toMatchObject({ imagePasteIds: [77] });
+
+    const progress = createProgressMessage({
+      toolUseID: "tu_passthrough",
+      parentToolUseID: "tu_passthrough",
+      data: { type: "bash_progress", stdout: "partial" } as never,
+    });
+    const system = createSystemMessage("system", "info");
+    const attachment = hookAttachment("PreToolUse", "pre", "tu_passthrough");
+    expect(normalizeMessages([attachment, progress, system] as never))
+      .toEqual([attachment, progress, system]);
+  });
+
+  test("identifies tool-use request and result messages", () => {
+    const assistant = createAssistantMessage({
+      content: [textBlock("run"), toolUseBlock("tu_request")] as never,
+    });
+    const result = createUserMessage({
+      content: [toolResultBlock("tu_request")] as never,
+    });
+    const normalizedAssistant = normalizeMessages([assistant] as never)[1]!;
+    const normalizedResult = normalizeMessages([result] as never)[0]!;
+    const progress = createProgressMessage({
+      toolUseID: "tu_request",
+      data: { type: "bash_progress", stdout: "partial" } as never,
+    });
+    const system = createSystemMessage("checking", "info", "tu_request");
+
+    expect(isToolUseRequestMessage(assistant)).toBe(true);
+    expect(isToolUseRequestMessage(createAssistantMessage({ content: "text" })))
+      .toBe(false);
+    expect(isToolUseResultMessage(result)).toBe(true);
+    expect(isToolUseResultMessage(createUserMessage({ content: "text" }))).toBe(
+      false,
+    );
+    expect(getToolUseID(normalizedAssistant as never)).toBe("tu_request");
+    expect(getToolUseID(normalizedResult as never)).toBe("tu_request");
+    expect(getToolUseID(progress as never)).toBe("tu_request");
+    expect(getToolUseID(system as never)).toBe("tu_request");
+    expect(getToolUseID(createAssistantMessage({ content: "text" }) as never))
+      .toBeNull();
+  });
+
+  test("builds lookup indexes and reorders UI tool-use groups", () => {
+    const assistant = createAssistantMessage({
+      content: [
+        toolUseBlock("tu_lookup_a"),
+        toolUseBlock("tu_lookup_b"),
+      ] as never,
+    });
+    const result = createUserMessage({
+      content: [
+        toolResultBlock("tu_lookup_a"),
+        toolResultBlock("tu_lookup_err", "bad", true),
+      ] as never,
+    });
+    const normalizedAssistant = normalizeMessages([assistant] as never);
+    const normalizedResult = normalizeMessages([result] as never);
+    const hookProgress = createProgressMessage({
+      toolUseID: "hook-progress",
+      parentToolUseID: "tu_lookup_a",
+      data: {
+        type: "hook_progress",
+        hookEvent: "PreToolUse",
+        hookName: "pre-hook",
+      } as never,
+    });
+    const bashProgress = createProgressMessage({
+      toolUseID: "bash-progress",
+      parentToolUseID: "tu_lookup_a",
+      data: { type: "bash_progress", stdout: "partial" } as never,
+    });
+    const hookSuccess = hookAttachment("PreToolUse", "pre-hook", "tu_lookup_a");
+    const allNormalized = [
+      ...normalizedAssistant,
+      bashProgress,
+      hookProgress,
+      hookSuccess,
+      ...normalizedResult,
+    ] as never;
+
+    const lookups = buildMessageLookups(allNormalized, [assistant, result] as never);
+    expect([...getSiblingToolUseIDs(normalizedAssistant[0]!, [assistant] as never)])
+      .toEqual(["tu_lookup_a", "tu_lookup_b"]);
+    expect([...getSiblingToolUseIDsFromLookup(normalizedAssistant[0]!, lookups)])
+      .toEqual(["tu_lookup_a", "tu_lookup_b"]);
+    expect(getProgressMessagesFromLookup(normalizedAssistant[0]!, lookups))
+      .toEqual([bashProgress, hookProgress]);
+    expect(hasUnresolvedHooks(allNormalized, "tu_lookup_a", "PreToolUse"))
+      .toBe(false);
+    expect(
+      hasUnresolvedHooks(
+        [...normalizedAssistant, hookProgress] as never,
+        "tu_lookup_a",
+        "PreToolUse",
+      ),
+    ).toBe(true);
+    expect(hasUnresolvedHooksFromLookup("tu_lookup_a", "PreToolUse", lookups))
+      .toBe(false);
+    expect(getToolResultIDs(normalizedResult as never)).toEqual({
+      tu_lookup_a: false,
+      tu_lookup_err: true,
+    });
+    expect([...getToolUseIDs(normalizedAssistant as never)]).toEqual([
+      "tu_lookup_a",
+      "tu_lookup_b",
+    ]);
+    const noToolMessage = normalizeMessages([
+      createUserMessage({ content: "no tool id" }),
+    ] as never)[0]!;
+    expect(getSiblingToolUseIDsFromLookup(noToolMessage, lookups).size).toBe(0);
+    expect(getProgressMessagesFromLookup(noToolMessage, lookups)).toEqual([]);
+
+    const serverToolAssistant = createAssistantMessage({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srv_orphan_lookup",
+          name: "web_search",
+          input: {},
+        },
+      ] as never,
+    });
+    const serverToolLookups = buildMessageLookups(
+      [serverToolAssistant] as never,
+      [serverToolAssistant, createUserMessage({ content: "after" })] as never,
+    );
+    expect(serverToolLookups.resolvedToolUseIDs.has("srv_orphan_lookup"))
+      .toBe(true);
+    expect(serverToolLookups.erroredToolUseIDs.has("srv_orphan_lookup"))
+      .toBe(true);
+
+    const advisorResultAssistant = createAssistantMessage({
+      content: [
+        {
+          type: "advisor_tool_result",
+          tool_use_id: "advisor_lookup",
+          content: { type: "advisor_tool_result_error" },
+        },
+      ] as never,
+    });
+    const advisorLookups = buildMessageLookups(
+      [advisorResultAssistant] as never,
+      [advisorResultAssistant] as never,
+    );
+    expect(advisorLookups.resolvedToolUseIDs.has("advisor_lookup")).toBe(true);
+    expect(advisorLookups.erroredToolUseIDs.has("advisor_lookup")).toBe(true);
+
+    const childAssistant = createAssistantMessage({
+      content: [
+        toolUseBlock("tu_child_done"),
+        toolUseBlock("tu_child_open"),
+      ] as never,
+    });
+    const childResult = normalizeMessages([
+      createUserMessage({ content: [toolResultBlock("tu_child_done")] as never }),
+    ] as never)[0]!;
+    const subagent = buildSubagentLookups([
+      { message: childAssistant },
+      { message: childResult as never },
+    ]);
+    expect(subagent.lookups.resolvedToolUseIDs.has("tu_child_done")).toBe(true);
+    expect(subagent.inProgressToolUseIDs.has("tu_child_open")).toBe(true);
+
+    const uiAssistant = normalizeMessages([
+      createAssistantMessage({ content: [toolUseBlock("tu_ui")] as never }),
+    ] as never)[0]!;
+    const uiResult = normalizeMessages([
+      createUserMessage({ content: [toolResultBlock("tu_ui")] as never }),
+    ] as never)[0]!;
+    const preHook = hookAttachment("PreToolUse", "pre", "tu_ui");
+    const postHook = hookAttachment("PostToolUse", "post", "tu_ui");
+    expect(
+      reorderMessagesInUI([uiResult, postHook, preHook, uiAssistant] as never, []),
+    ).toEqual([uiAssistant, preHook, uiResult, postHook]);
+    const standaloneToolUse = normalizeMessages([
+      createAssistantMessage({ content: [toolUseBlock("tu_standalone")] as never }),
+    ] as never)[0]!;
+    expect(reorderMessagesInUI([standaloneToolUse] as never, []))
+      .toEqual([standaloneToolUse]);
+    const orphanPreHook = hookAttachment("PreToolUse", "orphan-pre", "tu_orphan");
+    const orphanPostHook = hookAttachment("PostToolUse", "orphan-post", "tu_orphan");
+    expect(reorderMessagesInUI([orphanPreHook, orphanPostHook] as never, []))
+      .toEqual([]);
+    const syntheticStreamingToolUse = normalizeMessages([
+      createAssistantMessage({ content: [toolUseBlock("tu_synthetic")] as never }),
+    ] as never)[0]!;
+    expect(reorderMessagesInUI([], [syntheticStreamingToolUse]))
+      .toEqual([syntheticStreamingToolUse]);
+
+    const firstError = createSystemAPIErrorMessage(new Error("first"), 1, 1, 2);
+    const secondError = createSystemAPIErrorMessage(new Error("second"), 2, 2, 2);
+    expect(reorderMessagesInUI([firstError, secondError] as never, []))
+      .toEqual([secondError]);
+  });
+
+  test("reorders API attachments and strips unsupported tool-search fields", () => {
+    const assistant = createAssistantMessage({ content: "assistant" });
+    const floating = hookAttachment("PreToolUse", "floating", "tu_api");
+    expect(reorderAttachmentsForAPI([createUserMessage({ content: "before" }), floating] as never))
+      .toEqual([floating, expect.objectContaining({ type: "user" })]);
+
+    const stopped = hookAttachment("PostToolUse", "after", "tu_api");
+    expect(reorderAttachmentsForAPI([assistant, stopped] as never))
+      .toEqual([assistant, stopped]);
+
+    const toolReference = {
+      type: "tool_reference",
+      tool_name: "MissingTool",
+      tool_id: "tool-1",
+    };
+    const mixedReferenceResult = createUserMessage({
+      content: [
+        {
+          ...toolResultBlock("tu_ref"),
+          content: [{ type: "text", text: "keep" }, toolReference],
+        },
+      ] as never,
+    });
+    const strippedMixed = stripToolReferenceBlocksFromUserMessage(
+      mixedReferenceResult,
+    );
+    expect(
+      JSON.stringify((strippedMixed.message.content as never[])[0]),
+    ).not.toContain("tool_reference");
+    expect(JSON.stringify(strippedMixed.message.content)).toContain("keep");
+
+    const referenceOnlyResult = createUserMessage({
+      content: [
+        {
+          ...toolResultBlock("tu_ref_only"),
+          content: [toolReference],
+        },
+      ] as never,
+    });
+    expect(
+      JSON.stringify(
+        stripToolReferenceBlocksFromUserMessage(referenceOnlyResult).message.content,
+      ),
+    ).toContain("tool search not enabled");
+
+    const stringToolReferenceInput = createUserMessage({ content: "plain" });
+    expect(stripToolReferenceBlocksFromUserMessage(stringToolReferenceInput))
+      .toBe(stringToolReferenceInput);
+    const noReferenceResult = createUserMessage({
+      content: [toolResultBlock("tu_no_ref")] as never,
+    });
+    expect(stripToolReferenceBlocksFromUserMessage(noReferenceResult))
+      .toBe(noReferenceResult);
+
+    process.env.ENABLE_TOOL_SEARCH = "true";
+    const unavailableReferenceResult = createUserMessage({
+      content: [
+        {
+          ...toolResultBlock("tu_unavailable_ref"),
+          content: [
+            {
+              type: "tool_reference",
+              tool_name: "MissingTool",
+              tool_id: "tool-missing",
+            },
+          ],
+        },
+      ] as never,
+    });
+    expect(
+      JSON.stringify(
+        normalizeMessagesForAPI(
+          [unavailableReferenceResult],
+          [{ name: "AvailableTool" }] as never,
+        ),
+      ),
+    ).toContain("tools no longer available");
+
+    const callerMessage = createAssistantMessage({
+      content: [
+        { ...toolUseBlock("tu_caller"), caller: { tool_use_id: "parent" } },
+        textBlock("keep"),
+      ] as never,
+    });
+    const strippedCaller = stripCallerFieldFromAssistantMessage(callerMessage);
+    expect("caller" in (strippedCaller.message.content[0] as object)).toBe(false);
+    expect(strippedCaller.message.content[1]).toEqual(textBlock("keep"));
+    const noCallerMessage = createAssistantMessage({
+      content: [toolUseBlock("tu_no_caller")] as never,
+    });
+    expect(stripCallerFieldFromAssistantMessage(noCallerMessage))
+      .toBe(noCallerMessage);
+  });
+
+  test("merges and sanitizes API-bound message content", () => {
+    const assistantA = createAssistantMessage({ content: [textBlock("a")] });
+    const assistantB = createAssistantMessage({ content: [toolUseBlock("tu_merge")] as never });
+    expect(mergeAssistantMessages(assistantA, assistantB).message.content)
+      .toEqual([textBlock("a"), toolUseBlock("tu_merge")]);
+
+    const userA = createUserMessage({ content: "alpha" });
+    const userB = createUserMessage({ content: "beta" });
+    const mergedUser = mergeUserMessages(userA, userB);
+    expect(JSON.stringify(mergedUser.message.content)).toContain("alpha\\n");
+    expect(JSON.stringify(mergedUser.message.content)).toContain("beta");
+
+    const mergedToolResult = mergeUserMessagesAndToolResults(
+      createUserMessage({ content: "tail" }),
+      createUserMessage({
+        content: [toolResultBlock("tu_merged"), textBlock("after")] as never,
+      }),
+    );
+    expect((mergedToolResult.message.content as never[])[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tu_merged",
+    });
+
+    const smooshedBlocks = mergeUserContentBlocks(
+      [{ ...toolResultBlock("tu_smoosh"), content: "base" }] as never,
+      [textBlock("extra")] as never,
+    );
+    expect((smooshedBlocks[0] as { content?: string }).content).toBe(
+      "base\n\nextra",
+    );
+    expect(mergeUserContentBlocks([textBlock("first")] as never, [textBlock("second")] as never))
+      .toEqual([textBlock("first"), textBlock("second")]);
+
+    expect(normalizeContentFromAPI(undefined as never, [] as never)).toEqual([]);
+    const normalizedApiContent = normalizeContentFromAPI(
+      [
+        {
+          type: "tool_use",
+          id: "tu_api",
+          name: "Bash",
+          input: "{\"command\":\"pwd\"}",
+        },
+        {
+          type: "server_tool_use",
+          id: "srv_1",
+          name: "web_search",
+          input: "{\"query\":\"docs\"}",
+        },
+        textBlock("keep"),
+      ] as never,
+      [] as never,
+    );
+    expect(normalizedApiContent[0]).toMatchObject({
+      type: "tool_use",
+      input: { command: "pwd" },
+    });
+    expect(normalizedApiContent[1]).toMatchObject({
+      type: "server_tool_use",
+      input: { query: "docs" },
+    });
+    expect(() =>
+      normalizeContentFromAPI(
+        [{ type: "tool_use", id: "bad", name: "Bash", input: 3 }] as never,
+        [] as never,
+      ),
+    ).toThrow("Tool use input must be a string or object");
+
+    const whitespace = createAssistantMessage({ content: [textBlock("  \n")] });
+    const filteredWhitespace = filterWhitespaceOnlyAssistantMessages([
+      createUserMessage({ content: "first" }),
+      whitespace,
+      createUserMessage({ content: "second" }),
+    ] as never);
+    expect(filteredWhitespace).toHaveLength(1);
+    expect(JSON.stringify(filteredWhitespace[0])).toContain("second");
+
+    const sharedIdThinking = createAssistantMessage({
+      content: [{ type: "thinking", thinking: "work", signature: "sig" }] as never,
+    });
+    const sharedIdText = createAssistantMessage({ content: [textBlock("answer")] });
+    sharedIdText.message.id = sharedIdThinking.message.id;
+    const orphanThinking = createAssistantMessage({
+      content: [{ type: "redacted_thinking", data: "secret" }] as never,
+    });
+    expect(
+      filterOrphanedThinkingOnlyMessages([
+        sharedIdThinking,
+        sharedIdText,
+        orphanThinking,
+      ] as never),
+    ).toEqual([sharedIdThinking, sharedIdText]);
+    expect(stripSignatureBlocks([sharedIdThinking] as never)[0]).toMatchObject({
+      message: { content: [] },
+    });
+
+    const repaired = ensureToolResultPairing([
+      createAssistantMessage({ content: [toolUseBlock("tu_missing")] as never }),
+    ]);
+    expect(repaired).toHaveLength(2);
+    expect(JSON.stringify(repaired[1])).toContain("Tool result missing");
+
+    expect(
+      stripAdvisorBlocks([
+        createAssistantMessage({
+          content: [
+            {
+              type: "server_tool_use",
+              id: "advisor_1",
+              name: "advisor",
+              input: {},
+            },
+          ] as never,
+        }),
+      ] as never)[0],
+    ).toMatchObject({
+      message: { content: [{ type: "text", text: "[Advisor response]" }] },
+    });
+
+    const summary = createToolUseSummaryMessage("ran tools", ["tu_merge"]);
+    expect(summary).toMatchObject({
+      type: "tool_use_summary",
+      summary: "ran tools",
+      precedingToolUseIds: ["tu_merge"],
+    });
+    expect(wrapCommandText("done", { kind: "task-notification" } as never))
+      .toContain("background agent completed");
+    expect(wrapCommandText("sync", { kind: "coordinator" } as never))
+      .toContain("coordinator sent a message");
+    expect(wrapCommandText("ping", { kind: "channel", server: "slack" } as never))
+      .toContain("slack");
+    expect(wrapCommandText("hello", undefined)).toContain("MUST address");
+    expect(wrapInSystemReminder("remember")).toBe(
+      "<system-reminder>\nremember\n</system-reminder>",
+    );
+  });
+
+  test("wraps string and array user messages in system reminders", () => {
+    const imageBlock = {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: "abc",
+      },
+    } as const;
+
+    const [stringWrapped, arrayWrapped] = wrapMessagesInSystemReminder([
+      createUserMessage({ content: "remember", isMeta: true }),
+      createUserMessage({
+        content: [textBlock("look"), imageBlock] as never,
+        isMeta: true,
+      }),
+    ]);
+
+    expect(getUserMessageText(stringWrapped!)).toBe(
+      "<system-reminder>\nremember\n</system-reminder>",
+    );
+    expect(arrayWrapped!.message.content).toEqual([
+      {
+        type: "text",
+        text: "<system-reminder>\nlook\n</system-reminder>",
+      },
+      imageBlock,
+    ]);
+  });
+
+  test("normalizes plan and auto mode reminder attachments", () => {
+    const fullPlan = normalizeAttachmentForAPI({
+      type: "plan_mode",
+      reminderType: "full",
+      isSubAgent: false,
+      planFilePath: "/tmp/plan.md",
+      planExists: false,
+    } as never);
+    expect(getUserMessageText(fullPlan[0]!)).toContain("Plan mode is active");
+    expect(getUserMessageText(fullPlan[0]!)).toContain("/tmp/plan.md");
+    expect(getUserMessageText(fullPlan[0]!)).toContain("only file you are allowed to edit");
+
+    const sparsePlan = normalizeAttachmentForAPI({
+      type: "plan_mode",
+      reminderType: "sparse",
+      isSubAgent: false,
+      planFilePath: "/tmp/plan.md",
+      planExists: true,
+    } as never);
+    expect(getUserMessageText(sparsePlan[0]!)).toContain("Plan mode still active");
+
+    const subagentPlan = normalizeAttachmentForAPI({
+      type: "plan_mode",
+      reminderType: "full",
+      isSubAgent: true,
+      planFilePath: "/tmp/subagent-plan.md",
+      planExists: true,
+    } as never);
+    expect(getUserMessageText(subagentPlan[0]!)).toContain("MUST NOT make any edits");
+    expect(getUserMessageText(subagentPlan[0]!)).toContain("A plan file already exists");
+
+    const fullAuto = normalizeAttachmentForAPI({
+      type: "auto_mode",
+      reminderType: "full",
+    } as never);
+    expect(getUserMessageText(fullAuto[0]!)).toContain("Auto mode is active");
+
+    const sparseAuto = normalizeAttachmentForAPI({
+      type: "auto_mode",
+      reminderType: "sparse",
+    } as never);
+    expect(getUserMessageText(sparseAuto[0]!)).toContain("Auto mode still active");
+  });
+
+  test("normalizes tool-backed and informational attachments", () => {
+    const directory = normalizeAttachmentForAPI({
+      type: "directory",
+      path: "/tmp/work",
+      content: "one\ntwo",
+    } as never);
+    expect(directory).toHaveLength(2);
+    expect(getUserMessageText(directory[0]!)).toContain(
+      "Called the system.bash tool",
+    );
+    expect(getUserMessageText(directory[1]!)).toContain(
+      "Result of calling the system.bash tool",
+    );
+    expect(getUserMessageText(directory[1]!)).toContain("one\ntwo");
+
+    const edited = normalizeAttachmentForAPI({
+      type: "edited_text_file",
+      filename: "src/app.ts",
+      snippet: "1:+const ok = true;",
+    } as never);
+    expect(getUserMessageText(edited[0]!)).toContain("src/app.ts was modified");
+
+    const selected = normalizeAttachmentForAPI({
+      type: "selected_lines_in_ide",
+      filename: "src/app.ts",
+      lineStart: 2,
+      lineEnd: 4,
+      content: "x".repeat(2100),
+    } as never);
+    expect(getUserMessageText(selected[0]!)).toContain("lines 2 to 4");
+    expect(getUserMessageText(selected[0]!)).toContain("... (truncated)");
+
+    const listedSkill = normalizeAttachmentForAPI({
+      type: "skill_listing",
+      content: "- test-skill: useful",
+    } as never);
+    expect(getUserMessageText(listedSkill[0]!)).toContain("test-skill");
+    expect(normalizeAttachmentForAPI({ type: "skill_listing", content: "" } as never))
+      .toEqual([]);
+    expect(normalizeAttachmentForAPI({ type: "dynamic_skill" } as never))
+      .toEqual([]);
+  });
+
+  test("normalizes todo and task reminders with suppression", () => {
+    delete process.env.AGENC_DISABLE_TOOL_REMINDERS;
+    process.env.AGENC_ENABLE_TASKS = "1";
+
+    const todoAttachment = {
+      type: "todo_reminder",
+      content: [{ status: "pending", content: "write coverage tests" }],
+    } as never;
+    const taskAttachment = {
+      type: "task_reminder",
+      content: [{ id: 7, status: "in_progress", subject: "cover messages" }],
+    } as never;
+
+    const todo = normalizeAttachmentForAPI(todoAttachment);
+    expect(getUserMessageText(todo[0]!)).toContain(
+      "1. [pending] write coverage tests",
+    );
+
+    const task = normalizeAttachmentForAPI(taskAttachment);
+    expect(getUserMessageText(task[0]!)).toContain(
+      "#7. [in_progress] cover messages",
+    );
+
+    process.env.AGENC_DISABLE_TOOL_REMINDERS = "1";
+    expect(normalizeAttachmentForAPI(todoAttachment)).toEqual([]);
+    expect(normalizeAttachmentForAPI(taskAttachment)).toEqual([]);
+  });
+
+  test("normalizes file references, memories, queued commands, and diagnostics", () => {
+    const file = normalizeAttachmentForAPI({
+      type: "file",
+      filename: "/tmp/file.txt",
+      content: "file contents",
+      truncated: true,
+    } as never);
+    expect(file).toHaveLength(3);
+    expect(userText(file[0])).toContain("Called the FileRead tool");
+    expect(userText(file[1])).toContain("file contents");
+    expect(userText(file[2])).toContain("has been truncated");
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "compact_file_reference",
+      filename: "/tmp/huge.txt",
+    } as never)[0])).toContain("too large to include");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "pdf_reference",
+      filename: "book.pdf",
+      pageCount: 12,
+      fileSize: 2048,
+    } as never)[0])).toContain("book.pdf (12 pages");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "opened_file_in_ide",
+      filename: "src/open.ts",
+    } as never)[0])).toContain("opened the file src/open.ts");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "plan_file_reference",
+      planFilePath: "/tmp/plan.md",
+      planContent: "ship it",
+    } as never)[0])).toContain("Plan contents");
+
+    expect(normalizeAttachmentForAPI({
+      type: "invoked_skills",
+      skills: [],
+    } as never)).toEqual([]);
+    expect(userText(normalizeAttachmentForAPI({
+      type: "invoked_skills",
+      skills: [{ name: "test-skill", path: "/skills/test", content: "Use it." }],
+    } as never)[0])).toContain("### Skill: test-skill");
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "nested_memory",
+      content: { path: "AGENTS.md", content: "remember this" },
+    } as never)[0])).toContain("Contents of AGENTS.md");
+    const relevant = normalizeAttachmentForAPI({
+      type: "relevant_memories",
+      memories: [
+        {
+          path: "A.md",
+          mtimeMs: 1,
+          content: "alpha memory",
+          header: "Memory header",
+        },
+      ],
+    } as never);
+    expect(userText(relevant[0])).toContain("Memory header");
+
+    const queuedString = normalizeAttachmentForAPI({
+      type: "queued_command",
+      prompt: "queued text",
+      source_uuid: "00000000-0000-4000-8000-000000000777",
+    } as never);
+    expect(queuedString[0]?.isMeta).toBeUndefined();
+    expect(queuedString[0]?.uuid).toBe("00000000-0000-4000-8000-000000000777");
+    expect(userText(queuedString[0])).toContain("queued text");
+
+    const imageBlock = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "abc" },
+    } as const;
+    const queuedBlocks = normalizeAttachmentForAPI({
+      type: "queued_command",
+      commandMode: "task-notification",
+      prompt: [textBlock("done"), imageBlock],
+      source_uuid: "00000000-0000-4000-8000-000000000778",
+    } as never);
+    expect(queuedBlocks[0]).toMatchObject({
+      isMeta: true,
+      origin: { kind: "task-notification" },
+    });
+    expect(userText(queuedBlocks[0])).toContain("background agent completed");
+    expect(queuedBlocks[0]?.message.content).toContainEqual(imageBlock);
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "output_style",
+      style: "Explanatory",
+    } as never)[0])).toContain("Explanatory output style is active");
+    expect(normalizeAttachmentForAPI({
+      type: "output_style",
+      style: "MissingStyle",
+    } as never)).toEqual([]);
+    expect(normalizeAttachmentForAPI({
+      type: "diagnostics",
+      files: [],
+    } as never)).toEqual([]);
+    expect(userText(normalizeAttachmentForAPI({
+      type: "diagnostics",
+      files: [
+        {
+          uri: "/tmp/problem.ts",
+          diagnostics: [
+            {
+              severity: "Error",
+              message: "bad type",
+              range: {
+                start: { line: 2, character: 4 },
+                end: { line: 2, character: 8 },
+              },
+              code: "TS1",
+              source: "ts",
+            },
+          ],
+        },
+      ],
+    } as never)[0])).toContain("bad type [TS1] (ts)");
+  });
+
+  test("normalizes mode transitions, MCP resources, agent mentions, and task status", () => {
+    expect(userText(normalizeAttachmentForAPI({
+      type: "plan_mode_reentry",
+      planFilePath: "/tmp/plan.md",
+    } as never)[0])).toContain("Re-entering Plan Mode");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "plan_mode_exit",
+      planExists: true,
+      planFilePath: "/tmp/plan.md",
+    } as never)[0])).toContain("You have exited plan mode");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "auto_mode_exit",
+    } as never)[0])).toContain("You have exited auto mode");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "critical_system_reminder",
+      content: "critical reminder",
+    } as never)[0])).toContain("critical reminder");
+
+    const emptyResource = normalizeAttachmentForAPI({
+      type: "mcp_resource",
+      server: "srv",
+      uri: "res://empty",
+      content: { contents: [] },
+    } as never);
+    expect(userText(emptyResource[0])).toContain("(No content)");
+
+    const textResource = normalizeAttachmentForAPI({
+      type: "mcp_resource",
+      server: "srv",
+      uri: "res://text",
+      content: { contents: [{ text: "resource text" }] },
+    } as never);
+    expect(userText(textResource[0])).toContain("Full contents of resource");
+    expect(userText(textResource[0])).toContain("resource text");
+
+    const binaryResource = normalizeAttachmentForAPI({
+      type: "mcp_resource",
+      server: "srv",
+      uri: "res://binary",
+      content: { contents: [{ blob: "AA==", mimeType: "application/pdf" }] },
+    } as never);
+    expect(userText(binaryResource[0])).toContain(
+      "[Binary content: application/pdf]",
+    );
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "agent_mention",
+      agentType: "scanner",
+    } as never)[0])).toContain("agent \"scanner\"");
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "task_status",
+      status: "killed",
+      description: "old task",
+      taskId: "task-1",
+      taskType: "scanner",
+    } as never)[0])).toContain("was stopped by the user");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "task_status",
+      status: "running",
+      description: "live task",
+      taskId: "task-2",
+      taskType: "scanner",
+      deltaSummary: "half done",
+      outputFilePath: "/tmp/out.txt",
+    } as never)[0])).toContain("Do NOT spawn a duplicate");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "task_status",
+      status: "completed",
+      description: "done task",
+      taskId: "task-3",
+      taskType: "scanner",
+      deltaSummary: "finished",
+    } as never)[0])).toContain("You can check its output");
+  });
+
+  test("normalizes hook, budget, usage, and delta attachments", () => {
+    const asyncHook = normalizeAttachmentForAPI({
+      type: "async_hook_response",
+      response: {
+        systemMessage: "system hook note",
+        hookSpecificOutput: { additionalContext: "extra hook context" },
+      },
+    } as never);
+    expect(asyncHook).toHaveLength(2);
+    expect(userText(asyncHook[0])).toContain("system hook note");
+    expect(userText(asyncHook[1])).toContain("extra hook context");
+    expect(normalizeAttachmentForAPI({
+      type: "async_hook_response",
+      response: {},
+    } as never)).toEqual([]);
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "token_usage",
+      used: 3,
+      total: 10,
+      remaining: 7,
+    } as never)[0])).toContain("Token usage: 3/10; 7 remaining");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "budget_usd",
+      used: "1.25",
+      total: "4.00",
+      remaining: "2.75",
+    } as never)[0])).toContain("USD budget: $1.25/$4.00; $2.75 remaining");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "output_token_usage",
+      turn: 1234,
+      budget: 2000,
+      session: 987654,
+    } as never)[0])).toContain("turn: 1.2k / 2.0k");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "output_token_usage",
+      turn: 1234,
+      budget: null,
+      session: 987654,
+    } as never)[0])).toContain("turn: 1.2k");
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "hook_blocking_error",
+      hookName: "PreToolUse",
+      blockingError: {
+        command: "node hook.js",
+        blockingError: "denied",
+      },
+    } as never)[0])).toContain("node hook.js");
+    expect(normalizeAttachmentForAPI({
+      type: "hook_success",
+      hookEvent: "PreToolUse",
+      hookName: "pre",
+      content: "ignored",
+    } as never)).toEqual([]);
+    expect(normalizeAttachmentForAPI({
+      type: "hook_success",
+      hookEvent: "SessionStart",
+      hookName: "start",
+      content: "",
+    } as never)).toEqual([]);
+    expect(userText(normalizeAttachmentForAPI({
+      type: "hook_success",
+      hookEvent: "SessionStart",
+      hookName: "start",
+      content: "ready",
+    } as never)[0])).toContain("start hook success: ready");
+    expect(normalizeAttachmentForAPI({
+      type: "hook_additional_context",
+      hookName: "ctx",
+      content: [],
+    } as never)).toEqual([]);
+    expect(userText(normalizeAttachmentForAPI({
+      type: "hook_additional_context",
+      hookName: "ctx",
+      content: ["one", "two"],
+    } as never)[0])).toContain("one\ntwo");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "hook_stopped_continuation",
+      hookName: "stop",
+      message: "halted",
+    } as never)[0])).toContain("halted");
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "compaction_reminder",
+    } as never)[0])).toContain("Auto-compact is enabled");
+    expect(normalizeAttachmentForAPI({
+      type: "context_efficiency",
+    } as never)).toEqual([]);
+    expect(userText(normalizeAttachmentForAPI({
+      type: "date_change",
+      newDate: "2026-06-03",
+    } as never)[0])).toContain("2026-06-03");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "ultrathink_effort",
+      level: "high",
+    } as never)[0])).toContain("high");
+
+    expect(userText(normalizeAttachmentForAPI({
+      type: "deferred_tools_delta",
+      addedLines: ["- ToolA: does work"],
+      removedNames: ["ToolB"],
+    } as never)[0])).toContain("ToolA");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "agent_listing_delta",
+      isInitial: true,
+      showConcurrencyNote: true,
+      addedLines: ["- scanner: scans"],
+      removedTypes: ["old-agent"],
+    } as never)[0])).toContain("Available agent types");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "agent_listing_delta",
+      isInitial: false,
+      showConcurrencyNote: false,
+      addedLines: ["- planner: plans"],
+      removedTypes: [],
+    } as never)[0])).toContain("New agent types");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "mcp_instructions_delta",
+      addedBlocks: ["srv: use carefully"],
+      removedNames: ["old-srv"],
+    } as never)[0])).toContain("MCP Server Instructions");
+    expect(userText(normalizeAttachmentForAPI({
+      type: "verify_plan_reminder",
+    } as never)[0])).toContain("verify directly");
+
+    for (const type of [
+      "already_read_file",
+      "command_permissions",
+      "edited_image_file",
+      "hook_cancelled",
+      "hook_error_during_execution",
+      "hook_non_blocking_error",
+      "hook_system_message",
+      "structured_output",
+      "hook_permission_decision",
+      "autocheckpointing",
+      "background_task_status",
+      "todo",
+      "task_progress",
+      "ultramemory",
+    ]) {
+      expect(normalizeAttachmentForAPI({ type } as never)).toEqual([]);
+    }
+  });
+
+  test("handles stream events and non-stream message callbacks", () => {
+    const received: unknown[] = [];
+    const tombstones: unknown[] = [];
+    const modes: string[] = [];
+    const lengthUpdates: string[] = [];
+    const metrics: unknown[] = [];
+    let streamingToolUses: Array<{
+      index: number;
+      contentBlock: unknown;
+      unparsedToolInput: string;
+    }> = [];
+    let streamingThinking: { thinking: string; isStreaming: boolean } | null = null;
+    let streamingText: string | null = "stale";
+
+    const callbacks = [
+      (message: unknown) => received.push(message),
+      (content: string) => lengthUpdates.push(content),
+      (mode: string) => modes.push(mode),
+      (update: typeof streamingToolUses | ((current: typeof streamingToolUses) => typeof streamingToolUses)) => {
+        streamingToolUses = typeof update === "function" ? update(streamingToolUses) : update;
+      },
+      (message: unknown) => tombstones.push(message),
+      (update: (current: typeof streamingThinking) => typeof streamingThinking) => {
+        streamingThinking = update(streamingThinking);
+      },
+      (metric: unknown) => metrics.push(metric),
+      (update: (current: string | null) => string | null) => {
+        streamingText = update(streamingText);
+      },
+    ] as const;
+
+    const assistantThinking = createAssistantMessage({
+      content: [{ type: "thinking", thinking: "final thought", signature: "sig" }] as never,
+    });
+    handleMessageFromStream(assistantThinking as never, ...callbacks);
+    expect(received).toEqual([assistantThinking]);
+    expect(streamingThinking).toMatchObject({ thinking: "final thought", isStreaming: false });
+    expect(streamingText).toBeNull();
+
+    const tombstoneTarget = createUserMessage({ content: "remove me" });
+    handleMessageFromStream(
+      { type: "tombstone", message: tombstoneTarget } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(createToolUseSummaryMessage("ignored", []) as never, ...callbacks);
+    expect(tombstones).toEqual([tombstoneTarget]);
+
+    handleMessageFromStream({ type: "stream_request_start" } as never, ...callbacks);
+    handleMessageFromStream(
+      { type: "stream_event", ttftMs: 42, event: { type: "message_start" } } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "thinking", thinking: "", signature: "" },
+        },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          index: 2,
+          content_block: toolUseBlock("tu_stream"),
+        },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "hi" } },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 2,
+          delta: { type: "input_json_delta", partial_json: "{\"command\":" },
+        },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 99,
+          delta: { type: "input_json_delta", partial_json: "ignored" },
+        },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "thinking_delta", thinking: "think" } },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      {
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "signature_delta", signature: "sig" } },
+      } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      { type: "stream_event", event: { type: "content_block_stop" } } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      { type: "stream_event", event: { type: "message_delta" } } as never,
+      ...callbacks,
+    );
+    handleMessageFromStream(
+      { type: "stream_event", event: { type: "message_stop" } } as never,
+      ...callbacks,
+    );
+
+    expect(metrics).toEqual([{ ttftMs: 42 }]);
+    expect(modes).toEqual([
+      "requesting",
+      "responding",
+      "responding",
+      "thinking",
+      "tool-input",
+      "responding",
+      "tool-use",
+    ]);
+    expect(lengthUpdates).toEqual(["hi", "{\"command\":", "ignored", "think"]);
+    expect(streamingToolUses).toEqual([]);
+  });
+
+  test("normalizes API-bound message arrays with local commands and assistant merging", () => {
+    const localCommand = createCommandInputMessage("local output");
+    const firstUser = createUserMessage({ content: "first" });
+    const secondUser = createUserMessage({ content: "second" });
+    const virtualUser = createUserMessage({ content: "virtual", isVirtual: true });
+    const assistantText = createAssistantMessage({ content: [textBlock("part one")] });
+    const assistantTool = createAssistantMessage({
+      content: [toolUseBlock("tu_api_missing")] as never,
+    });
+    assistantTool.message.id = assistantText.message.id;
+
+    const normalized = normalizeMessagesForAPI([
+      virtualUser,
+      localCommand,
+      firstUser,
+      secondUser,
+      assistantText,
+      assistantTool,
+    ] as never);
+
+    expect(JSON.stringify(normalized)).not.toContain("virtual");
+    expect(normalized[0]).toMatchObject({ type: "user" });
+    expect(JSON.stringify(normalized[0])).toContain("local output");
+    expect(JSON.stringify(normalized[0])).toContain("first");
+    expect(JSON.stringify(normalized[0])).toContain("second");
+
+    const assistant = normalized.find((message) => message.type === "assistant");
+    expect(assistant?.message.content).toEqual([
+      textBlock("part one"),
+      toolUseBlock("tu_api_missing"),
+    ]);
+    expect(normalized).toHaveLength(2);
+  });
+
+  test("normalizes API-bound messages after synthetic content-size errors", () => {
+    const imageBlock = {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: "abc",
+      },
+    } as const;
+    const metaWithImage = createUserMessage({
+      content: [textBlock("keep this context"), imageBlock] as never,
+      isMeta: true,
+    });
+    const imageOnly = createUserMessage({
+      content: [imageBlock] as never,
+      isMeta: true,
+    });
+    const imageTooLarge = createAssistantAPIErrorMessage({
+      content: getImageTooLargeErrorMessage(),
+    });
+
+    const preservedText = normalizeMessagesForAPI([
+      metaWithImage,
+      imageTooLarge,
+    ] as never);
+    expect(preservedText).toHaveLength(1);
+    expect(preservedText[0]?.message.content).toEqual([
+      textBlock("keep this context"),
+    ]);
+
+    const strippedCompletely = normalizeMessagesForAPI([
+      imageOnly,
+      imageTooLarge,
+    ] as never);
+    expect(strippedCompletely).toEqual([]);
+  });
+
+  test("sanitizes non-text blocks from errored tool results before API calls", () => {
+    const erroredResult = createUserMessage({
+      content: [
+        {
+          ...toolResultBlock("tu_error", undefined as never, true),
+          content: [
+            textBlock("error text"),
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "abc",
+              },
+            },
+          ],
+        },
+      ] as never,
+    });
+
+    const normalized = normalizeMessagesForAPI([erroredResult] as never);
+    expect(normalized[0]?.message.content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tu_error",
+        content: [{ type: "text", text: "error text" }],
+        is_error: true,
+      },
+    ]);
+  });
+
+  test("normalizes trailing thinking and non-final empty assistant content for API calls", () => {
+    const assistantWithTrailingThinking = createAssistantMessage({
+      content: [
+        textBlock("visible answer"),
+        { type: "thinking", thinking: "hidden", signature: "sig" },
+      ] as never,
+    });
+    expect(normalizeMessagesForAPI([assistantWithTrailingThinking] as never))
+      .toEqual([
+        expect.objectContaining({
+          message: expect.objectContaining({
+            content: [textBlock("visible answer")],
+          }),
+        }),
+      ]);
+
+    const emptyAssistant = createAssistantMessage({ content: [] as never });
+    const followingUser = createUserMessage({ content: "after empty assistant" });
+    const normalized = normalizeMessagesForAPI([
+      emptyAssistant,
+      followingUser,
+    ] as never);
+    expect(normalized[0]).toMatchObject({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "(no content)" }] },
+    });
+    expect(userText(normalized[1])).toBe("after empty assistant");
+  });
+
+  test("repairs duplicate and orphaned tool-use pairings defensively", () => {
+    const duplicateAssistant = createAssistantMessage({
+      content: [
+        toolUseBlock("tu_dupe"),
+        toolUseBlock("tu_dupe"),
+      ] as never,
+    });
+    const duplicateResult = createUserMessage({
+      content: [
+        toolResultBlock("tu_dupe", "first"),
+        toolResultBlock("tu_dupe", "duplicate"),
+      ] as never,
+    });
+
+    const repairedDuplicates = ensureToolResultPairing([
+      duplicateAssistant,
+      duplicateResult,
+    ]);
+    expect(repairedDuplicates[0]).toMatchObject({
+      type: "assistant",
+      message: { content: [toolUseBlock("tu_dupe")] },
+    });
+    expect(repairedDuplicates[1]?.message.content).toEqual([
+      toolResultBlock("tu_dupe", "first"),
+    ]);
+
+    const orphanAtStart = createUserMessage({
+      content: [toolResultBlock("tu_orphan")] as never,
+    });
+    const strippedOrphan = ensureToolResultPairing([orphanAtStart]);
+    expect(strippedOrphan[0]).toMatchObject({
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "text",
+            text: "[Orphaned tool result removed due to conversation resume]",
+          },
+        ],
+      },
+    });
+
+    const assistantWithServerTool = createAssistantMessage({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srv_missing",
+          name: "web_search",
+          input: {},
+        },
+      ] as never,
+    });
+    expect(ensureToolResultPairing([assistantWithServerTool])[0]).toMatchObject({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "[Tool use interrupted]" }] },
+    });
+
+    const userBeforeOrphan = createUserMessage({ content: "before" });
+    const orphanWithText = createUserMessage({
+      content: [
+        toolResultBlock("tu_orphan_with_text"),
+        textBlock("survives"),
+      ] as never,
+    });
+    expect(
+      ensureToolResultPairing([userBeforeOrphan, orphanWithText])[1],
+    ).toMatchObject({
+      type: "user",
+      message: { content: [textBlock("survives")] },
+    });
+
+    const textAssistant = createAssistantMessage({ content: "plain" });
+    const orphanAfterAssistant = createUserMessage({
+      content: [toolResultBlock("tu_orphan_after_assistant")] as never,
+    });
+    expect(
+      ensureToolResultPairing([textAssistant, orphanAfterAssistant])[1],
+    ).toMatchObject({
+      type: "user",
+      isMeta: true,
+      message: { content: "(no content)" },
+    });
+
+    const serverToolWithResult = createAssistantMessage({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srv_ok",
+          name: "web_search",
+          input: {},
+        },
+        {
+          type: "mcp_tool_result",
+          tool_use_id: "srv_ok",
+          content: [],
+        },
+      ] as never,
+    });
+    expect(ensureToolResultPairing([serverToolWithResult]))
+      .toEqual([serverToolWithResult]);
+  });
+
+  test("filters assistant turns whose tool calls never resolved", () => {
+    const unresolved = createAssistantMessage({
+      content: [toolUseBlock("tu_drop")] as never,
+    });
+    const resolved = createAssistantMessage({
+      content: [toolUseBlock("tu_keep")] as never,
+    });
+    const mixed = createAssistantMessage({
+      content: [
+        toolUseBlock("tu_drop_2"),
+        toolUseBlock("tu_keep_2"),
+      ] as never,
+    });
+    const result = createUserMessage({
+      content: [
+        toolResultBlock("tu_keep"),
+        toolResultBlock("tu_keep_2"),
+      ] as never,
+    });
+
+    expect(filterUnresolvedToolUses([unresolved, resolved, mixed, result]))
+      .toEqual([resolved, mixed, result]);
+    expect(filterUnresolvedToolUses([resolved, result])).toEqual([
+      resolved,
+      result,
+    ]);
+  });
+
+  test("extracts readable text for resubmission and display", () => {
+    const assistant = createAssistantMessage({
+      content: [
+        textBlock("alpha"),
+        toolUseBlock("tu_text"),
+        textBlock("omega"),
+      ] as never,
+    });
+    const user = createUserMessage({
+      content: [textBlock("one"), textBlock("two")] as never,
+    });
+    const bash = createUserMessage({
+      content: "<bash-input>echo &amp; ok</bash-input>",
+    });
+    const command = createUserMessage({
+      content: formatCommandInputTags("review", "file & notes"),
+    });
+
+    expect(getAssistantMessageText(assistant)).toBe("alpha\nomega");
+    expect(getAssistantMessageText(user)).toBeNull();
+    expect(getUserMessageText(user)).toBe("one\ntwo");
+    expect(getUserMessageText(assistant)).toBeNull();
+    expect(textForResubmit(bash)).toEqual({ text: "echo & ok", mode: "bash" });
+    expect(textForResubmit(command)).toEqual({
+      text: "/review file & notes",
+      mode: "prompt",
+    });
+    expect(
+      textForResubmit(
+        createUserMessage({
+          content: "<ide_opened_file>hide</ide_opened_file>ask",
+        }),
+      ),
+    ).toEqual({ text: "ask", mode: "prompt" });
+    expect(extractTextContent([textBlock("a"), toolUseBlock("tu_skip")], "|"))
+      .toBe("a");
+    expect(getContentText("plain")).toBe("plain");
+    expect(getContentText([textBlock(" a "), textBlock(" b ")] as never)).toBe(
+      "a \n b",
+    );
+    expect(isEmptyMessageText("<context>hidden</context>")).toBe(true);
+    expect(stripPromptXMLTags("<pr_analysis>x</pr_analysis>\nkeep")).toBe(
+      "keep",
+    );
+  });
+
+  test("creates system messages and locates compact boundaries", () => {
+    const informational = createSystemMessage("hello", "warning", "tu_sys", true);
+    const permission = createPermissionRetryMessage(["Bash", "Edit"]);
+    const bridge = createBridgeStatusMessage("http://127.0.0.1:1234", "upgrade");
+    const scheduled = createScheduledTaskFireMessage("wake up");
+    const stopSummary = createStopHookSummaryMessage(
+      2,
+      [{ name: "Stop", status: "success", durationMs: 5 }] as never,
+      ["warn"],
+      true,
+      "max_turns",
+      true,
+      "warning",
+      "tu_stop",
+      "Stop hooks",
+      15,
+    );
+    const turnDuration = createTurnDurationMessage(
+      123,
+      { tokens: 10, limit: 20, nudges: 1 },
+      4,
+    );
+    const away = createAwaySummaryMessage("summary");
+    const memory = createMemorySavedMessage(["AGENTS.md"]);
+    const killed = createAgentsKilledMessage();
+    const metrics = createApiMetricsMessage({
+      ttftMs: 1,
+      otps: 2,
+      isP50: true,
+      toolCount: 3,
+    });
+    const command = createCommandInputMessage("local");
+    const compact = createCompactBoundaryMessage(
+      "manual",
+      100,
+      parentUuid,
+      "keep this",
+      9,
+    );
+    const microcompact = createMicrocompactBoundaryMessage(
+      "auto",
+      200,
+      50,
+      ["tu"],
+      ["att"],
+    );
+    const cause = new Error("root cause");
+    const apiError = createSystemAPIErrorMessage(
+      Object.assign(new Error("rate limited"), { cause }) as never,
+      250,
+      1,
+      3,
+    );
+
+    expect(informational).toMatchObject({
+      subtype: "informational",
+      level: "warning",
+      toolUseID: "tu_sys",
+      preventContinuation: true,
+    });
+    expect(permission).toMatchObject({
+      subtype: "permission_retry",
+      content: "Allowed Bash, Edit",
+      commands: ["Bash", "Edit"],
+    });
+    expect(bridge).toMatchObject({
+      subtype: "bridge_status",
+      url: "http://127.0.0.1:1234",
+      upgradeNudge: "upgrade",
+    });
+    expect(scheduled).toMatchObject({ subtype: "scheduled_task_fire" });
+    expect(stopSummary).toMatchObject({
+      subtype: "stop_hook_summary",
+      hookCount: 2,
+      preventedContinuation: true,
+      toolUseID: "tu_stop",
+      totalDurationMs: 15,
+    });
+    expect(turnDuration).toMatchObject({
+      subtype: "turn_duration",
+      durationMs: 123,
+      budgetTokens: 10,
+      budgetLimit: 20,
+      budgetNudges: 1,
+      messageCount: 4,
+    });
+    expect(away).toMatchObject({ subtype: "away_summary", content: "summary" });
+    expect(memory).toMatchObject({
+      subtype: "memory_saved",
+      writtenPaths: ["AGENTS.md"],
+    });
+    expect(killed).toMatchObject({ subtype: "agents_killed" });
+    expect(metrics).toMatchObject({
+      subtype: "api_metrics",
+      ttftMs: 1,
+      otps: 2,
+      isP50: true,
+      toolCount: 3,
+    });
+    expect(command).toMatchObject({ subtype: "local_command", content: "local" });
+    expect(compact).toMatchObject({
+      subtype: "compact_boundary",
+      logicalParentUuid: parentUuid,
+      compactMetadata: {
+        trigger: "manual",
+        preTokens: 100,
+        userContext: "keep this",
+        messagesSummarized: 9,
+      },
+    });
+    expect(microcompact).toMatchObject({
+      subtype: "microcompact_boundary",
+      microcompactMetadata: {
+        trigger: "auto",
+        preTokens: 200,
+        tokensSaved: 50,
+        compactedToolIds: ["tu"],
+        clearedAttachmentUUIDs: ["att"],
+      },
+    });
+    expect(apiError).toMatchObject({
+      subtype: "api_error",
+      cause,
+      retryInMs: 250,
+      retryAttempt: 1,
+      maxRetries: 3,
+    });
+
+    const before = createUserMessage({ content: "before" });
+    const after = createUserMessage({ content: "after" });
+    expect(isCompactBoundaryMessage(compact)).toBe(true);
+    expect(isCompactBoundaryMessage(before)).toBe(false);
+    expect(findLastCompactBoundaryIndex([before, compact, after])).toBe(1);
+    expect(getMessagesAfterCompactBoundary([before, compact, after])).toEqual([
+      compact,
+      after,
+    ]);
+    expect(findLastCompactBoundaryIndex([before, after])).toBe(-1);
+    expect(getMessagesAfterCompactBoundary([before, after])).toEqual([
+      before,
+      after,
+    ]);
+  });
+
+  test("applies display predicates and tool-call counters", () => {
+    const hiddenMeta = normalizeMessages([
+      createUserMessage({ content: "meta", isMeta: true }),
+    ] as never)[0]!;
+    const transcriptOnly = normalizeMessages([
+      createUserMessage({
+        content: "transcript",
+        isVisibleInTranscriptOnly: true,
+      }),
+    ] as never)[0]!;
+    const visible = normalizeMessages([
+      createUserMessage({ content: "visible" }),
+    ] as never)[0]!;
+    const thinking = createAssistantMessage({
+      content: [
+        { type: "thinking", thinking: "working", signature: "sig" },
+        { type: "redacted_thinking", data: "hidden" },
+      ] as never,
+    });
+    const toolOne = createAssistantMessage({
+      content: [toolUseBlock("tu_success", "Bash")] as never,
+    });
+    const toolTwo = createAssistantMessage({
+      content: [toolUseBlock("tu_failed", "Bash")] as never,
+    });
+    const successResult = createUserMessage({
+      content: [toolResultBlock("tu_success")] as never,
+    });
+    const failedResult = createUserMessage({
+      content: [toolResultBlock("tu_failed", "no", true)] as never,
+    });
+    const emptyAssistant = createAssistantMessage({ content: [] as never });
+    const assistantWithToolBlock = createAssistantMessage({
+      content: [toolUseBlock("tu_filter_keep")] as never,
+    });
+    const plainAssistant = createAssistantMessage({ content: "plain" });
+
+    expect(shouldShowUserMessage(createSystemMessage("system", "info") as never, false))
+      .toBe(true);
+    expect(shouldShowUserMessage(hiddenMeta as never, false)).toBe(false);
+    expect(shouldShowUserMessage(transcriptOnly as never, false)).toBe(false);
+    expect(shouldShowUserMessage(transcriptOnly as never, true)).toBe(true);
+    expect(shouldShowUserMessage(visible as never, false)).toBe(true);
+    expect(isThinkingMessage(createUserMessage({ content: "not assistant" })))
+      .toBe(false);
+    expect(isThinkingMessage(thinking)).toBe(true);
+    expect(isThinkingMessage(createAssistantMessage({ content: "plain" })))
+      .toBe(false);
+    expect(countToolCalls([undefined as never, toolOne, toolTwo], "Bash"))
+      .toBe(2);
+    expect(countToolCalls([toolOne, toolTwo], "Bash", 1)).toBe(1);
+    expect(hasSuccessfulToolCall([toolOne, successResult], "Bash")).toBe(true);
+    expect(
+      hasSuccessfulToolCall(
+        [toolOne, successResult, toolTwo, failedResult],
+        "Bash",
+      ),
+    ).toBe(false);
+    expect(hasSuccessfulToolCall([toolOne], "Bash")).toBe(false);
+    expect(hasSuccessfulToolCall([undefined as never, toolOne], "Other"))
+      .toBe(false);
+    expect(filterWhitespaceOnlyAssistantMessages([emptyAssistant] as never))
+      .toEqual([emptyAssistant]);
+    const noWhitespaceFilterInput = [assistantWithToolBlock];
+    expect(filterWhitespaceOnlyAssistantMessages(noWhitespaceFilterInput as never))
+      .toBe(noWhitespaceFilterInput);
+    expect(filterOrphanedThinkingOnlyMessages([emptyAssistant] as never))
+      .toEqual([emptyAssistant]);
+    const noSignatureInput = [plainAssistant];
+    expect(stripSignatureBlocks(noSignatureInput as never)).toBe(noSignatureInput);
+    const advisorUserMessage = createUserMessage({ content: "user" });
+    expect(stripAdvisorBlocks([advisorUserMessage] as never))
+      .toEqual([advisorUserMessage]);
+    const advisorWithText = createAssistantMessage({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "advisor_keep_text",
+          name: "advisor",
+          input: {},
+        },
+        textBlock("kept advisor text"),
+      ] as never,
+    });
+    expect(stripAdvisorBlocks([advisorWithText] as never)[0]).toMatchObject({
+      message: { content: [textBlock("kept advisor text")] },
+    });
+  });
+});

--- a/runtime/tests/helpers/bun-test-shim.ts
+++ b/runtime/tests/helpers/bun-test-shim.ts
@@ -1,0 +1,20 @@
+import { vi } from 'vitest';
+
+export {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  test,
+} from 'vitest';
+
+export const mock = Object.assign(vi.fn, {
+  restore() {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  },
+});
+

--- a/runtime/tests/hooks/hooks-core.test.ts
+++ b/runtime/tests/hooks/hooks-core.test.ts
@@ -1,0 +1,1268 @@
+import { afterEach, expect, test } from "vitest";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  resetStateForTests,
+  registerHookCallbacks,
+  setCwdState,
+  setMainThreadAgentType,
+  setOriginalCwd,
+  setSessionTrustAccepted,
+  switchSession,
+} from "../../src/bootstrap/state.js";
+import {
+  createBaseHookInput,
+  executeConfigChangeHooks,
+  executeCwdChangedHooks,
+  executeElicitationHooks,
+  executeElicitationResultHooks,
+  executeFileChangedHooks,
+  executeFileSuggestionCommand,
+  executeInstructionsLoadedHooks,
+  executePermissionDeniedHooks,
+  executePermissionRequestHooks,
+  executeNotificationHooks,
+  executePostCompactHooks,
+  executePostToolHooks,
+  executePostToolUseFailureHooks,
+  executePreCompactHooks,
+  executePreToolHooks,
+  executeSessionEndHooks,
+  executeSessionStartHooks,
+  executeSetupHooks,
+  executeStatusLineCommand,
+  executeStopHooks,
+  executeSubagentStartHooks,
+  executeTaskCompletedHooks,
+  executeTaskCreatedHooks,
+  executeTeammateIdleHooks,
+  executeUserPromptSubmitHooks,
+  executeWorktreeCreateHook,
+  executeWorktreeRemoveHook,
+  getPreToolHookBlockingMessage,
+  getSessionEndHookTimeoutMs,
+  getStopHookMessage,
+  getTaskCompletedHookMessage,
+  getTaskCreatedHookMessage,
+  getTeammateIdleHookMessage,
+  getUserPromptSubmitHookBlockingMessage,
+  getMatchingHooks,
+  hasBlockingResult,
+  hasInstructionsLoadedHook,
+  hasWorktreeCreateHook,
+  matchesPattern,
+} from "../../src/utils/hooks.js";
+import type { Message } from "../../src/types/message.js";
+
+const tempDirs: string[] = [];
+const sessionId = "00000000-0000-4000-8000-000000000901";
+const originalConfigDir = process.env.AGENC_CONFIG_DIR;
+const originalAgenCHome = process.env.AGENC_HOME;
+const originalSessionEndTimeout = process.env.AGENC_SESSIONEND_HOOKS_TIMEOUT_MS;
+const originalAllowUntrustedHooks = process.env.AGENC_ALLOW_UNTRUSTED_HOOKS;
+const hookCommandTimeoutMs = 5_000;
+
+function restoreOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function configureHookSession(): Promise<{ configDir: string; cwd: string }> {
+  const configDir = await mkdtemp(join(tmpdir(), "agenc-hooks-core-"));
+  tempDirs.push(configDir);
+  process.env.AGENC_CONFIG_DIR = configDir;
+  delete process.env.AGENC_HOME;
+  resetStateForTests();
+
+  const cwd = join(configDir, "workspace");
+  await mkdir(cwd, { recursive: true });
+  setOriginalCwd(cwd);
+  setCwdState(cwd);
+  switchSession(sessionId as never, null);
+  return { configDir, cwd };
+}
+
+async function collectAsyncGenerator<T>(generator: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const result of generator) {
+    results.push(result);
+  }
+  return results;
+}
+
+function toolUseContext(appState: { sessionHooks: Map<string, unknown> }) {
+  return {
+    getAppState: () => appState,
+    abortController: new AbortController(),
+    updateAttributionState: () => undefined,
+  } as never;
+}
+
+function nodeCommand(script: string): string {
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+function stdoutCommand(output: string): string {
+  return nodeCommand(`process.stdout.write(${JSON.stringify(output)})`);
+}
+
+afterEach(async () => {
+  resetStateForTests();
+  restoreOptionalEnv("AGENC_CONFIG_DIR", originalConfigDir);
+  restoreOptionalEnv("AGENC_HOME", originalAgenCHome);
+  restoreOptionalEnv("AGENC_SESSIONEND_HOOKS_TIMEOUT_MS", originalSessionEndTimeout);
+  restoreOptionalEnv("AGENC_ALLOW_UNTRUSTED_HOOKS", originalAllowUntrustedHooks);
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("parses session end hook timeout from the environment", () => {
+  delete process.env.AGENC_SESSIONEND_HOOKS_TIMEOUT_MS;
+  expect(getSessionEndHookTimeoutMs()).toBe(1500);
+
+  process.env.AGENC_SESSIONEND_HOOKS_TIMEOUT_MS = "2500";
+  expect(getSessionEndHookTimeoutMs()).toBe(2500);
+
+  for (const value of ["0", "-1", "not-a-number"]) {
+    process.env.AGENC_SESSIONEND_HOOKS_TIMEOUT_MS = value;
+    expect(getSessionEndHookTimeoutMs()).toBe(1500);
+  }
+});
+
+test("creates base hook input from session, cwd, permission, and agent state", async () => {
+  const { configDir, cwd } = await configureHookSession();
+  setMainThreadAgentType("planner");
+
+  const base = createBaseHookInput("acceptEdits");
+  expect(base).toMatchObject({
+    session_id: sessionId,
+    cwd,
+    permission_mode: "acceptEdits",
+    agent_type: "planner",
+  });
+  expect(base.transcript_path).toContain(configDir);
+  expect(base.transcript_path.endsWith(`${sessionId}.jsonl`)).toBe(true);
+
+  const other = createBaseHookInput(undefined, "00000000-0000-4000-8000-000000000902", {
+    agentId: "agent-1",
+    agentType: "worker",
+  });
+  expect(other).toMatchObject({
+    session_id: "00000000-0000-4000-8000-000000000902",
+    agent_id: "agent-1",
+    agent_type: "worker",
+  });
+});
+
+test("matches hook patterns for wildcards, exact names, lists, regex, and rejected regex", () => {
+  expect(matchesPattern("Write", "")).toBe(true);
+  expect(matchesPattern("Write", "*")).toBe(true);
+  expect(matchesPattern("Write", "Write")).toBe(true);
+  expect(matchesPattern("Edit", "Write|Edit")).toBe(true);
+  expect(matchesPattern("Bash", "^Ba.*$")).toBe(true);
+  expect(matchesPattern("Read", "^Ba.*$")).toBe(false);
+  expect(matchesPattern("Read", "[")).toBe(false);
+  expect(matchesPattern("aaaaaaaaaaaaaaaaaaaa", "^(a+)+$")).toBe(false);
+  expect(matchesPattern("Read", "x".repeat(513))).toBe(false);
+});
+
+test("formats blocking hook messages and detects blocked outside-repl results", () => {
+  const blockingError = { blockingError: "revise the output", command: "hook.sh" };
+  expect(getPreToolHookBlockingMessage("PreToolUse", blockingError)).toBe(
+    "PreToolUse hook error: revise the output",
+  );
+  expect(getStopHookMessage(blockingError)).toBe("Stop hook feedback:\nrevise the output");
+  expect(getTeammateIdleHookMessage(blockingError)).toBe(
+    "TeammateIdle hook feedback:\nrevise the output",
+  );
+  expect(getTaskCreatedHookMessage(blockingError)).toBe(
+    "TaskCreated hook feedback:\nrevise the output",
+  );
+  expect(getTaskCompletedHookMessage(blockingError)).toBe(
+    "TaskCompleted hook feedback:\nrevise the output",
+  );
+  expect(getUserPromptSubmitHookBlockingMessage(blockingError)).toBe(
+    "UserPromptSubmit operation blocked by hook:\nrevise the output",
+  );
+
+  expect(
+    hasBlockingResult([
+      { command: "a", succeeded: true, output: "", blocked: false },
+      { command: "b", succeeded: false, output: "blocked", blocked: true },
+    ]),
+  ).toBe(true);
+  expect(hasBlockingResult([{ command: "a", succeeded: true, output: "", blocked: false }])).toBe(false);
+});
+
+test("matches registered hooks with filtering, deduplication, and plugin source context", async () => {
+  await configureHookSession();
+  registerHookCallbacks({
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          { type: "command", command: "echo one" },
+          { type: "command", command: "echo one" },
+          { type: "command", command: "echo one", shell: "powershell" },
+          { type: "prompt", prompt: "review the command" },
+          { type: "agent", prompt: "inspect the command" },
+          { type: "http", url: "https://example.test/hook" },
+          { type: "callback", callback: async () => ({}) },
+        ],
+      },
+      {
+        matcher: "Read",
+        hooks: [{ type: "command", command: "echo ignored" }],
+      },
+      {
+        matcher: "Bash",
+        pluginRoot: "/plugins/a",
+        pluginId: "plugin-a",
+        pluginName: "Plugin A",
+        hooks: [{ type: "command", command: "echo one" }],
+      },
+    ],
+  } as never);
+
+  const matched = await getMatchingHooks(
+    undefined,
+    sessionId,
+    "PreToolUse",
+    {
+      ...createBaseHookInput(),
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+      tool_id: "tool-1",
+    } as never,
+  );
+
+  expect(matched).toHaveLength(7);
+  expect(matched.map((match) => match.hook.type).sort()).toEqual([
+    "agent",
+    "callback",
+    "command",
+    "command",
+    "command",
+    "http",
+    "prompt",
+  ]);
+  expect(matched.some((match) => match.hookSource === "plugin:Plugin A")).toBe(true);
+  expect(matched.some((match) => match.pluginId === "plugin-a")).toBe(true);
+  expect(
+    matched.filter(
+      (match) => match.hook.type === "command" && match.hook.command === "echo one",
+    ),
+  ).toHaveLength(3);
+  expect(
+    matched
+      .filter((match) => match.hook.type === "command")
+      .map((match) => ({
+        command: match.hook.command,
+        shell: match.hook.shell,
+        pluginRoot: match.pluginRoot,
+      })),
+  ).toEqual([
+    { command: "echo one", shell: undefined, pluginRoot: undefined },
+    { command: "echo one", shell: "powershell", pluginRoot: undefined },
+    { command: "echo one", shell: undefined, pluginRoot: "/plugins/a" },
+  ]);
+});
+
+test("filters HTTP hooks from startup events during matching", async () => {
+  await configureHookSession();
+  registerHookCallbacks({
+    SessionStart: [
+      {
+        matcher: "startup",
+        hooks: [
+          { type: "command", command: "echo startup" },
+          { type: "http", url: "https://example.test/startup" },
+        ],
+      },
+    ],
+  } as never);
+
+  const matched = await getMatchingHooks(
+    undefined,
+    sessionId,
+    "SessionStart",
+    {
+      ...createBaseHookInput(),
+      hook_event_name: "SessionStart",
+      source: "startup",
+    } as never,
+  );
+  expect(matched).toEqual([
+    expect.objectContaining({
+      hook: { type: "command", command: "echo startup" },
+      hookSource: "settings",
+    }),
+  ]);
+});
+
+test("executes registered callback hooks through the pre-tool generator", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  const appState = { sessionHooks: new Map<string, unknown>() };
+  registerHookCallbacks({
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              decision: "block",
+              reason: "callback blocked command",
+            }),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  const results = await collectAsyncGenerator(
+    executePreToolHooks(
+      "Bash",
+      "tool-1",
+      { command: "rm -rf /tmp/nope" },
+      toolUseContext(appState),
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+
+  expect(results.some((result) => result.message?.type === "progress")).toBe(true);
+  expect(
+    results.some(
+      (result) =>
+        result.blockingError?.blockingError === "callback blocked command" &&
+        result.blockingError.command === "callback",
+    ),
+  ).toBe(true);
+  expect(
+    results.some(
+      (result) =>
+        result.permissionBehavior === "deny" &&
+        result.hookPermissionDecisionReason === "callback blocked command",
+    ),
+  ).toBe(true);
+});
+
+test("executes command hooks through the pre-tool generator", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  const appState = { sessionHooks: new Map<string, unknown>() };
+  registerHookCallbacks({
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          { type: "command", command: stdoutCommand("plain hook ok\n") },
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({
+                decision: "approve",
+                reason: "approved by command",
+                systemMessage: "command system message",
+                hookSpecificOutput: {
+                  hookEventName: "PreToolUse",
+                  permissionDecision: "ask",
+                  permissionDecisionReason: "ask after command",
+                  updatedInput: { command: "pwd" },
+                  additionalContext: "command context",
+                },
+              }),
+            ),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  const results = await collectAsyncGenerator(
+    executePreToolHooks(
+      "Bash",
+      "tool-command",
+      { command: "ls" },
+      toolUseContext(appState),
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+
+  expect(
+    results.some((result) => JSON.stringify(result.message).includes("plain hook ok")),
+  ).toBe(true);
+  expect(
+    results.some((result) => JSON.stringify(result.message).includes("command system message")),
+  ).toBe(true);
+  expect(
+    results.some((result) => result.additionalContexts?.includes("command context")),
+  ).toBe(true);
+  expect(
+    results.some(
+      (result) =>
+        result.permissionBehavior === "ask" &&
+        result.hookPermissionDecisionReason === "ask after command" &&
+      result.updatedInput?.command === "pwd",
+    ),
+  ).toBe(true);
+});
+
+test("executes blocking command hook output through the pre-tool generator", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  const appState = { sessionHooks: new Map<string, unknown>() };
+  registerHookCallbacks({
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({
+                decision: "block",
+                reason: "blocked by command",
+              }),
+            ),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  const results = await collectAsyncGenerator(
+    executePreToolHooks(
+      "Bash",
+      "tool-command-block",
+      { command: "ls" },
+      toolUseContext(appState),
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+
+  expect(
+    results.some(
+      (result) => result.blockingError?.blockingError === "blocked by command",
+    ),
+  ).toBe(true);
+});
+
+test("executes outside-REPL wrapper hooks with structured outputs", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  let notificationCalls = 0;
+  let instructionsCalls = 0;
+  let sessionEndCleared = false;
+  registerHookCallbacks({
+    ConfigChange: [
+      {
+        matcher: "user_settings|policy_settings",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({ decision: "block", reason: "config blocked" }),
+            ),
+          },
+        ],
+      },
+    ],
+    CwdChanged: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({
+                systemMessage: "cwd system message",
+                hookSpecificOutput: {
+                  hookEventName: "CwdChanged",
+                  watchPaths: ["/tmp/agenc-cwd-watch"],
+                },
+              }),
+            ),
+          },
+        ],
+      },
+    ],
+    FileChanged: [
+      {
+        matcher: "file.txt",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({
+                systemMessage: "file system message",
+                hookSpecificOutput: {
+                  hookEventName: "FileChanged",
+                  watchPaths: ["/tmp/agenc-file-watch"],
+                },
+              }),
+            ),
+          },
+        ],
+      },
+    ],
+    InstructionsLoaded: [
+      {
+        matcher: "session_start",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => {
+              instructionsCalls += 1;
+              return {};
+            },
+          },
+        ],
+      },
+    ],
+    Notification: [
+      {
+        matcher: "info",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => {
+              notificationCalls += 1;
+              return {};
+            },
+          },
+        ],
+      },
+    ],
+    PreCompact: [
+      {
+        matcher: "manual",
+        hooks: [{ type: "command", command: stdoutCommand("new instructions") }],
+      },
+    ],
+    PostCompact: [
+      {
+        matcher: "manual",
+        hooks: [{ type: "command", command: stdoutCommand("compact noted") }],
+      },
+    ],
+    SessionEnd: [
+      {
+        matcher: "quit",
+        hooks: [{ type: "callback", callback: async () => ({}) }],
+      },
+    ],
+    WorktreeRemove: [
+      {
+        matcher: "*",
+        hooks: [{ type: "callback", callback: async () => ({}) }],
+      },
+    ],
+    Elicitation: [
+      {
+        matcher: "mcp-server",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({
+                hookSpecificOutput: {
+                  hookEventName: "Elicitation",
+                  action: "accept",
+                  content: { accepted: true },
+                },
+              }),
+            ),
+          },
+          {
+            type: "command",
+            command: nodeCommand(
+              "process.stderr.write('elicitation blocked'); process.exit(2)",
+            ),
+          },
+        ],
+      },
+    ],
+    ElicitationResult: [
+      {
+        matcher: "mcp-server",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand(
+              JSON.stringify({
+                reason: "result declined",
+                hookSpecificOutput: {
+                  hookEventName: "ElicitationResult",
+                  action: "decline",
+                  content: { declined: true },
+                },
+              }),
+            ),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  const userConfig = await executeConfigChangeHooks("user_settings", "/tmp/user.json", hookCommandTimeoutMs);
+  expect(hasBlockingResult(userConfig)).toBe(true);
+  const policyConfig = await executeConfigChangeHooks("policy_settings", "/tmp/policy.json", hookCommandTimeoutMs);
+  expect(hasBlockingResult(policyConfig)).toBe(false);
+
+  await expect(executeCwdChangedHooks("/old", "/new", hookCommandTimeoutMs)).resolves.toMatchObject({
+    watchPaths: ["/tmp/agenc-cwd-watch"],
+    systemMessages: ["cwd system message"],
+  });
+  await expect(executeFileChangedHooks("/tmp/file.txt", "change", hookCommandTimeoutMs)).resolves.toMatchObject({
+    watchPaths: ["/tmp/agenc-file-watch"],
+    systemMessages: ["file system message"],
+  });
+
+  await executeInstructionsLoadedHooks("/tmp/AGENC.md", "Project", "session_start", {
+    timeoutMs: hookCommandTimeoutMs,
+  });
+  await executeNotificationHooks(
+    { message: "hello", notificationType: "info", title: "Info" },
+    hookCommandTimeoutMs,
+  );
+  expect(instructionsCalls).toBe(1);
+  expect(notificationCalls).toBe(1);
+
+  await expect(
+    executePreCompactHooks(
+      { trigger: "manual", customInstructions: "old" },
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  ).resolves.toMatchObject({
+    newCustomInstructions: "new instructions",
+  });
+  await expect(
+    executePostCompactHooks(
+      { trigger: "manual", compactSummary: "summary" },
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  ).resolves.toMatchObject({
+    userDisplayMessage: expect.stringContaining("compact noted"),
+  });
+
+  await executeSessionEndHooks("quit" as never, {
+    timeoutMs: hookCommandTimeoutMs,
+    setAppState: (updater) => {
+      sessionEndCleared = true;
+      updater({ sessionHooks: new Map<string, unknown>() } as never);
+    },
+  });
+  expect(sessionEndCleared).toBe(true);
+  await expect(executeWorktreeRemoveHook("/tmp/worktree")).resolves.toBe(true);
+
+  await expect(
+    executeElicitationHooks({
+      serverName: "mcp-server",
+      message: "Need a value",
+      timeoutMs: hookCommandTimeoutMs,
+    }),
+  ).resolves.toMatchObject({
+    elicitationResponse: { action: "accept", content: { accepted: true } },
+    blockingError: { blockingError: "elicitation blocked" },
+  });
+  await expect(
+    executeElicitationResultHooks({
+      serverName: "mcp-server",
+      action: "accept",
+      content: { value: true },
+      timeoutMs: hookCommandTimeoutMs,
+    }),
+  ).resolves.toMatchObject({
+    elicitationResultResponse: { action: "decline", content: { declined: true } },
+    blockingError: { blockingError: "result declined" },
+  });
+});
+
+test("executes session-scoped function hooks through stop hooks", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  const appState = {
+    sessionHooks: new Map<string, unknown>([
+      [
+        sessionId,
+        {
+          hooks: {
+            Stop: [
+              {
+                matcher: "*",
+                hooks: [
+                  {
+                    hook: {
+                      type: "function",
+                      id: "fn-stop",
+                      callback: () => false,
+                      errorMessage: "function blocked stop",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]),
+  };
+  const messages = [
+    {
+      type: "assistant",
+      uuid: "00000000-0000-4000-8000-000000000903",
+      message: {
+        id: "msg-1",
+        role: "assistant",
+        content: [{ type: "text", text: "last response" }],
+      },
+    },
+  ] as Message[];
+
+  const results = await collectAsyncGenerator(
+    executeStopHooks(
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+      false,
+      undefined,
+      toolUseContext(appState),
+      messages,
+    ),
+  );
+
+  expect(results.some((result) => result.message?.type === "progress")).toBe(true);
+  expect(
+    results.some(
+      (result) =>
+        result.blockingError?.blockingError === "function blocked stop" &&
+        result.blockingError.command === "function",
+    ),
+  ).toBe(true);
+});
+
+test("executes callback hooks across public generator event wrappers", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  const appState = { sessionHooks: new Map<string, unknown>() };
+  const ctx = toolUseContext(appState);
+  registerHookCallbacks({
+    PostToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "PostToolUse",
+                additionalContext: "post context",
+                updatedMCPToolOutput: { patched: true },
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    PostToolUseFailure: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              continue: false,
+              stopReason: "stop after failure",
+              hookSpecificOutput: {
+                hookEventName: "PostToolUseFailure",
+                additionalContext: "failure context",
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    PermissionDenied: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "PermissionDenied",
+                retry: true,
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    PermissionRequest: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "PermissionRequest",
+                decision: {
+                  behavior: "allow",
+                  updatedInput: { command: "pwd" },
+                  updatedPermissions: [],
+                },
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    UserPromptSubmit: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "UserPromptSubmit",
+                additionalContext: "prompt context",
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    SessionStart: [
+      {
+        matcher: "resume",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "SessionStart",
+                additionalContext: "session context",
+                initialUserMessage: "start here",
+                watchPaths: ["/tmp/watch-session"],
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    Setup: [
+      {
+        matcher: "init",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "Setup",
+                additionalContext: "setup context",
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    SubagentStart: [
+      {
+        matcher: "worker",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "SubagentStart",
+                additionalContext: "subagent context",
+              },
+            }),
+          },
+        ],
+      },
+    ],
+    TeammateIdle: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              decision: "block",
+              reason: "teammate should continue",
+            }),
+          },
+        ],
+      },
+    ],
+    TaskCreated: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              decision: "block",
+              reason: "task creation blocked",
+            }),
+          },
+        ],
+      },
+    ],
+    TaskCompleted: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "callback",
+            callback: async () => ({
+              continue: false,
+              stopReason: "task needs follow-up",
+            }),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  const post = await collectAsyncGenerator(
+    executePostToolHooks(
+      "Bash",
+      "tool-post",
+      { command: "pwd" },
+      { stdout: "/tmp" },
+      ctx,
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+  expect(
+    post.some((result) => result.additionalContexts?.includes("post context")),
+  ).toBe(true);
+  expect(
+    post.some(
+      (result) => JSON.stringify(result.updatedMCPToolOutput) === JSON.stringify({ patched: true }),
+    ),
+  ).toBe(true);
+
+  const failure = await collectAsyncGenerator(
+    executePostToolUseFailureHooks(
+      "Bash",
+      "tool-failure",
+      { command: "false" },
+      "failed",
+      ctx,
+      false,
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+  expect(
+    failure.some(
+      (result) =>
+        result.preventContinuation === true &&
+        result.stopReason === "stop after failure",
+    ),
+  ).toBe(true);
+  expect(
+    failure.some((result) => result.additionalContexts?.includes("failure context")),
+  ).toBe(true);
+
+  const denied = await collectAsyncGenerator(
+    executePermissionDeniedHooks(
+      "Bash",
+      "tool-denied",
+      { command: "false" },
+      "denied",
+      ctx,
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+  expect(denied.some((result) => result.retry === true)).toBe(true);
+
+  const permission = await collectAsyncGenerator(
+    executePermissionRequestHooks(
+      "Bash",
+      "tool-permission",
+      { command: "ls" },
+      ctx,
+      "default",
+      [],
+      undefined,
+      hookCommandTimeoutMs,
+    ),
+  );
+  expect(
+    permission.some(
+      (result) =>
+        result.permissionBehavior === "allow" &&
+        result.updatedInput?.command === "pwd",
+    ),
+  ).toBe(true);
+  expect(
+    permission.some(
+      (result) => result.permissionRequestResult?.behavior === "allow",
+    ),
+  ).toBe(true);
+
+  const prompt = await collectAsyncGenerator(
+    executeUserPromptSubmitHooks("hello", "default", ctx),
+  );
+  expect(prompt.some((result) => result.additionalContexts?.includes("prompt context"))).toBe(true);
+
+  const sessionStart = await collectAsyncGenerator(
+    executeSessionStartHooks("resume", sessionId, "planner", "test-model", undefined, hookCommandTimeoutMs),
+  );
+  expect(
+    sessionStart.some(
+      (result) => result.additionalContexts?.includes("session context"),
+    ),
+  ).toBe(true);
+  expect(
+    sessionStart.some((result) => result.initialUserMessage === "start here"),
+  ).toBe(true);
+  expect(
+    sessionStart.some((result) => result.watchPaths?.includes("/tmp/watch-session")),
+  ).toBe(true);
+
+  const setup = await collectAsyncGenerator(
+    executeSetupHooks("init", undefined, hookCommandTimeoutMs),
+  );
+  expect(setup.some((result) => result.additionalContexts?.includes("setup context"))).toBe(true);
+
+  const subagent = await collectAsyncGenerator(
+    executeSubagentStartHooks("agent-1", "worker", undefined, hookCommandTimeoutMs),
+  );
+  expect(subagent.some((result) => result.additionalContexts?.includes("subagent context"))).toBe(true);
+
+  const idle = await collectAsyncGenerator(
+    executeTeammateIdleHooks("Alice", "team", "default", undefined, hookCommandTimeoutMs),
+  );
+  expect(
+    idle.some(
+      (result) => result.blockingError?.blockingError === "teammate should continue",
+    ),
+  ).toBe(true);
+  expect(idle.some((result) => result.permissionBehavior === "deny")).toBe(true);
+
+  const created = await collectAsyncGenerator(
+    executeTaskCreatedHooks(
+      "task-1",
+      "Write tests",
+      "Add coverage",
+      "Alice",
+      "team",
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+      ctx,
+    ),
+  );
+  expect(
+    created.some(
+      (result) => result.blockingError?.blockingError === "task creation blocked",
+    ),
+  ).toBe(true);
+  expect(created.some((result) => result.permissionBehavior === "deny")).toBe(true);
+
+  const completed = await collectAsyncGenerator(
+    executeTaskCompletedHooks(
+      "task-1",
+      "Write tests",
+      "Add coverage",
+      "Alice",
+      "team",
+      "default",
+      undefined,
+      hookCommandTimeoutMs,
+      ctx,
+    ),
+  );
+  expect(
+    completed.some(
+      (result) =>
+        result.preventContinuation === true &&
+        result.stopReason === "task needs follow-up",
+    ),
+  ).toBe(true);
+});
+
+test("executes outside-REPL WorktreeCreate hook variants", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  registerHookCallbacks({
+    WorktreeCreate: [
+      {
+        matcher: "*",
+        hooks: [
+          { type: "prompt", prompt: "prepare worktree" },
+          { type: "agent", prompt: "prepare worktree with agent" },
+          {
+            type: "function",
+            id: "unexpected-outside-repl",
+            callback: () => true,
+          },
+          {
+            type: "callback",
+            callback: async () => ({
+              hookSpecificOutput: {
+                hookEventName: "WorktreeCreate",
+                worktreePath: "/tmp/agenc-worktree-callback",
+              },
+            }),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  expect(hasWorktreeCreateHook()).toBe(true);
+  await expect(executeWorktreeCreateHook("feature")).resolves.toEqual({
+    worktreePath: "/tmp/agenc-worktree-callback",
+  });
+});
+
+test("executes HTTP WorktreeCreate hook JSON output", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+
+  const server = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    if (request.url === "/empty") {
+      response.end("");
+    } else if (request.url === "/text") {
+      response.end("not json");
+    } else if (request.url === "/broken") {
+      response.end("{");
+    } else {
+      response.end(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "WorktreeCreate",
+            worktreePath: "/tmp/agenc-worktree-http",
+          },
+        }),
+      );
+    }
+  });
+
+  try {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP server address");
+    }
+
+    registerHookCallbacks({
+      WorktreeCreate: [
+        {
+          matcher: "*",
+          hooks: [
+            { type: "http", url: `http://127.0.0.1:${address.port}/empty` },
+            { type: "http", url: `http://127.0.0.1:${address.port}/text` },
+            { type: "http", url: `http://127.0.0.1:${address.port}/broken` },
+            { type: "http", url: `http://127.0.0.1:${address.port}/hook` },
+          ],
+        },
+      ],
+    } as never);
+
+    await expect(executeWorktreeCreateHook("feature")).resolves.toEqual({
+      worktreePath: "/tmp/agenc-worktree-http",
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("reports malformed command hook JSON outside the REPL", async () => {
+  await configureHookSession();
+  setSessionTrustAccepted(true);
+  registerHookCallbacks({
+    WorktreeCreate: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "command",
+            command: stdoutCommand("{\"continue\":\"nope\"}"),
+          },
+        ],
+      },
+    ],
+  } as never);
+
+  await expect(executeWorktreeCreateHook("feature")).rejects.toThrow(
+    "Hook JSON output validation failed",
+  );
+});
+
+test("returns empty results for public no-hook execution paths", async () => {
+  await configureHookSession();
+
+  await expect(executeConfigChangeHooks("user_settings", "/tmp/settings.json", 1)).resolves.toEqual([]);
+  await expect(executeConfigChangeHooks("policy_settings", "/tmp/policy.json", 1)).resolves.toEqual([]);
+  await expect(executeCwdChangedHooks("/old", "/new", 1)).resolves.toEqual({
+    results: [],
+    watchPaths: [],
+    systemMessages: [],
+  });
+  await expect(executeFileChangedHooks("/tmp/file.txt", "change", 1)).resolves.toEqual({
+    results: [],
+    watchPaths: [],
+    systemMessages: [],
+  });
+  expect(hasInstructionsLoadedHook()).toBe(false);
+  await expect(
+    executeInstructionsLoadedHooks("/tmp/AGENC.md", "Project", "session_start", {
+      timeoutMs: 1,
+    }),
+  ).resolves.toBeUndefined();
+  await expect(
+    executeElicitationHooks({
+      serverName: "mcp-server",
+      message: "Need a value",
+      timeoutMs: 1,
+    }),
+  ).resolves.toEqual({});
+  await expect(
+    executeElicitationResultHooks({
+      serverName: "mcp-server",
+      action: "accept",
+      content: { value: true },
+      timeoutMs: 1,
+    }),
+  ).resolves.toEqual({});
+  await expect(executeStatusLineCommand({} as never, undefined, 1)).resolves.toBeUndefined();
+  await expect(executeFileSuggestionCommand({} as never, undefined, 1)).resolves.toEqual([]);
+  expect(hasWorktreeCreateHook()).toBe(false);
+  await expect(executeWorktreeRemoveHook("/tmp/worktree")).resolves.toBe(false);
+  await expect(executeWorktreeCreateHook("feature")).rejects.toThrow(
+    "WorktreeCreate hook failed: no successful output",
+  );
+});

--- a/runtime/tests/memory/memdir.test.ts
+++ b/runtime/tests/memory/memdir.test.ts
@@ -46,7 +46,7 @@ let oldDisableAutoMemory: string | undefined;
 beforeAll(async () => {
   memory = await import("./memdir.js");
   agencmd = await import("./agencmd.js");
-});
+}, 30_000);
 
 beforeEach(() => {
   tempRoot = mkdtempSync(join(tmpdir(), "agenc-memory-prompt-"));

--- a/runtime/tests/plugins/pluginLoader-core.test.ts
+++ b/runtime/tests/plugins/pluginLoader-core.test.ts
@@ -1,0 +1,1771 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { chmod, mkdtemp, mkdir, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { LoadedPlugin } from "../../src/types/plugin.js";
+import type { PluginSource } from "../../src/utils/plugins/schemas.js";
+import { setInlinePlugins } from "../../src/bootstrap/state.js";
+import { clearInstalledPluginsCache } from "../../src/utils/plugins/installedPluginsManager.js";
+import {
+  cachePluginSettings,
+  clearPluginCache,
+  copyDir,
+  copyPluginToVersionedCache,
+  createPluginFromPath,
+  generateTemporaryCacheNameForPlugin,
+  getLegacyCachePath,
+  getPluginCachePath,
+  getVersionedCachePath,
+  getVersionedCachePathIn,
+  getVersionedZipCachePath,
+  cachePlugin,
+  installFromGitSubdir,
+  loadAllPlugins,
+  loadAllPluginsCacheOnly,
+  loadPluginManifest,
+  probeSeedCacheAnyVersion,
+  resolvePluginPath,
+} from "../../src/utils/plugins/pluginLoader.js";
+import {
+  getPluginSettingsBase,
+  resetSettingsCache,
+  setPluginSettingsBase,
+} from "../../src/utils/settings/settingsCache.js";
+
+const originalConfigDir = process.env.AGENC_CONFIG_DIR;
+const originalPluginCacheDir = process.env.AGENC_PLUGIN_CACHE_DIR;
+const originalPluginSeedDir = process.env.AGENC_PLUGIN_SEED_DIR;
+const originalSyncPluginInstall = process.env.AGENC_SYNC_PLUGIN_INSTALL;
+const originalPath = process.env.PATH;
+const tempDirs: string[] = [];
+const execFile = promisify(execFileCallback);
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function withPluginCacheDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await tempDir("agenc-plugin-loader-");
+  process.env.AGENC_PLUGIN_CACHE_DIR = dir;
+  return await run(dir);
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFile("git", args, { cwd });
+  return stdout.trim();
+}
+
+afterEach(async () => {
+  if (originalConfigDir === undefined) {
+    delete process.env.AGENC_CONFIG_DIR;
+  } else {
+    process.env.AGENC_CONFIG_DIR = originalConfigDir;
+  }
+  if (originalPluginCacheDir === undefined) {
+    delete process.env.AGENC_PLUGIN_CACHE_DIR;
+  } else {
+    process.env.AGENC_PLUGIN_CACHE_DIR = originalPluginCacheDir;
+  }
+  if (originalPluginSeedDir === undefined) {
+    delete process.env.AGENC_PLUGIN_SEED_DIR;
+  } else {
+    process.env.AGENC_PLUGIN_SEED_DIR = originalPluginSeedDir;
+  }
+  if (originalSyncPluginInstall === undefined) {
+    delete process.env.AGENC_SYNC_PLUGIN_INSTALL;
+  } else {
+    process.env.AGENC_SYNC_PLUGIN_INSTALL = originalSyncPluginInstall;
+  }
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = originalPath;
+  }
+  vi.restoreAllMocks();
+  setInlinePlugins([]);
+  setPluginSettingsBase(undefined);
+  resetSettingsCache();
+  clearInstalledPluginsCache();
+  clearPluginCache("test cleanup");
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+describe("plugin loader path helpers", () => {
+  test("builds sanitized plugin cache paths", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      expect(getPluginCachePath()).toBe(join(cacheRoot, "cache"));
+      expect(getVersionedCachePathIn("/seed", "bad/name@market.place", "v1/../../x")).toBe(
+        join("/seed", "cache", "market-place", "bad-name", "v1-..-..-x"),
+      );
+      expect(getVersionedCachePath("bad/name@market.place", "1.2.3")).toBe(
+        join(cacheRoot, "cache", "market-place", "bad-name", "1.2.3"),
+      );
+      expect(getVersionedZipCachePath("bad/name@market.place", "1.2.3")).toBe(
+        join(cacheRoot, "cache", "market-place", "bad-name", "1.2.3.zip"),
+      );
+      expect(getLegacyCachePath("bad/name")).toBe(join(cacheRoot, "cache", "bad-name"));
+    });
+  });
+
+  test("resolves versioned cache first, legacy cache second, then new target", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const versioned = getVersionedCachePath("demo@market", "1.0.0");
+      await mkdir(versioned, { recursive: true });
+      expect(await resolvePluginPath("demo@market", "1.0.0")).toBe(versioned);
+
+      await rm(versioned, { recursive: true, force: true });
+      const legacy = getLegacyCachePath("demo");
+      await mkdir(legacy, { recursive: true });
+      expect(await resolvePluginPath("demo@market", "1.0.0")).toBe(legacy);
+
+      await rm(legacy, { recursive: true, force: true });
+      expect(await resolvePluginPath("demo@market", "1.0.0")).toBe(
+        join(cacheRoot, "cache", "market", "demo", "1.0.0"),
+      );
+      expect(await resolvePluginPath("demo@market")).toBe(legacy);
+    });
+  });
+
+  test("probes seed caches only when a single populated version exists", async () => {
+    expect(await probeSeedCacheAnyVersion("demo@market")).toBeNull();
+
+    const root = await tempDir("agenc-plugin-seed-");
+    const ambiguousSeed = join(root, "ambiguous");
+    const emptySeed = join(root, "empty");
+    const populatedSeed = join(root, "populated");
+    await mkdir(getVersionedCachePathIn(ambiguousSeed, "demo@market", "1.0.0"), {
+      recursive: true,
+    });
+    await mkdir(getVersionedCachePathIn(ambiguousSeed, "demo@market", "2.0.0"), {
+      recursive: true,
+    });
+    const emptyVersion = getVersionedCachePathIn(emptySeed, "demo@market", "3.0.0");
+    await mkdir(emptyVersion, { recursive: true });
+    const populatedVersion = getVersionedCachePathIn(populatedSeed, "demo@market", "4.0.0");
+    await mkdir(populatedVersion, { recursive: true });
+    await writeFile(join(populatedVersion, "plugin.json"), "{}", "utf8");
+
+    process.env.AGENC_PLUGIN_SEED_DIR = [
+      join(root, "missing"),
+      ambiguousSeed,
+      emptySeed,
+      populatedSeed,
+    ].join(delimiter);
+
+    expect(await probeSeedCacheAnyVersion("demo@market")).toBe(populatedVersion);
+  });
+
+  test("generates temporary cache names with source-specific prefixes", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const cases: Array<[PluginSource, string]> = [
+      ["./local-plugin", "local"],
+      [{ source: "npm", package: "demo" }, "npm"],
+      [{ source: "pip", package: "demo" }, "pip"],
+      [{ source: "github", repo: "owner/repo" }, "github"],
+      [{ source: "url", url: "https://example.com/repo.git" }, "git"],
+      [{ source: "git-subdir", url: "owner/repo", path: "plugins/demo" }, "subdir"],
+    ];
+
+    for (const [source, prefix] of cases) {
+      expect(generateTemporaryCacheNameForPlugin(source)).toBe(
+        `temp_${prefix}_1700000000000_i`,
+      );
+    }
+    expect(
+      generateTemporaryCacheNameForPlugin({ source: "future-source" } as never),
+    ).toBe("temp_unknown_1700000000000_i");
+  });
+});
+
+describe("plugin loader file copying", () => {
+  test("copyDir recursively copies files and preserves symlink intent", async () => {
+    const root = await tempDir("agenc-plugin-copy-");
+    const src = join(root, "src");
+    const dest = join(root, "dest");
+    const external = join(root, "external.txt");
+    await mkdir(join(src, "nested"), { recursive: true });
+    await writeFile(join(src, "nested", "file.txt"), "nested content", "utf8");
+    await writeFile(external, "external content", "utf8");
+    await symlink(join(src, "nested", "file.txt"), join(src, "inside-link"));
+    await symlink(external, join(src, "outside-link"));
+    await symlink("missing-target", join(src, "broken-link"));
+
+    await copyDir(src, dest);
+
+    expect(await readFile(join(dest, "nested", "file.txt"), "utf8")).toBe("nested content");
+    expect(await readFile(join(dest, "inside-link"), "utf8")).toBe("nested content");
+    expect(await readFile(join(dest, "outside-link"), "utf8")).toBe("external content");
+    await expect(readFile(join(dest, "broken-link"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("copyPluginToVersionedCache copies source, removes git metadata, and rejects empty copies", async () => {
+    await withPluginCacheDir(async () => {
+      const root = await tempDir("agenc-plugin-cache-copy-");
+      const source = join(root, "source");
+      await mkdir(join(source, ".git"), { recursive: true });
+      await writeFile(join(source, ".git", "config"), "private", "utf8");
+      await writeFile(join(source, "plugin.json"), JSON.stringify({ name: "cached" }), "utf8");
+
+      const cachedPath = await copyPluginToVersionedCache(
+        source,
+        "cached@market",
+        "1.0.0",
+      );
+
+      expect(cachedPath).toBe(getVersionedCachePath("cached@market", "1.0.0"));
+      expect(await readFile(join(cachedPath, "plugin.json"), "utf8")).toContain("cached");
+      await expect(readFile(join(cachedPath, ".git", "config"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+
+      const emptySource = join(root, "empty");
+      await mkdir(emptySource, { recursive: true });
+      await expect(
+        copyPluginToVersionedCache(emptySource, "empty@market", "1.0.0"),
+      ).rejects.toThrow("destination is empty after copy");
+    });
+  });
+
+  test("copyPluginToVersionedCache reuses populated caches and replaces empty cache dirs", async () => {
+    await withPluginCacheDir(async () => {
+      const root = await tempDir("agenc-plugin-existing-cache-");
+      const source = join(root, "source");
+      await mkdir(source, { recursive: true });
+      await writeFile(join(source, "plugin.json"), JSON.stringify({ name: "fresh" }), "utf8");
+
+      const populatedCache = getVersionedCachePath("existing@market", "1.0.0");
+      await mkdir(populatedCache, { recursive: true });
+      await writeFile(join(populatedCache, "plugin.json"), "stale", "utf8");
+
+      await expect(
+        copyPluginToVersionedCache(source, "existing@market", "1.0.0"),
+      ).resolves.toBe(populatedCache);
+      expect(await readFile(join(populatedCache, "plugin.json"), "utf8")).toBe("stale");
+
+      const emptyCache = getVersionedCachePath("empty@market", "1.0.0");
+      await mkdir(emptyCache, { recursive: true });
+
+      await expect(
+        copyPluginToVersionedCache(source, "empty@market", "1.0.0"),
+      ).resolves.toBe(emptyCache);
+      expect(await readFile(join(emptyCache, "plugin.json"), "utf8")).toContain("fresh");
+    });
+  });
+
+  test("copyPluginToVersionedCache returns an exact seed-cache hit without copying source", async () => {
+    await withPluginCacheDir(async () => {
+      const seedRoot = await tempDir("agenc-plugin-exact-seed-");
+      const seedPath = getVersionedCachePathIn(seedRoot, "seeded@market", "9.0.0");
+      await mkdir(seedPath, { recursive: true });
+      await writeFile(join(seedPath, "plugin.json"), JSON.stringify({ name: "seeded" }), "utf8");
+      process.env.AGENC_PLUGIN_SEED_DIR = seedRoot;
+
+      await expect(
+        copyPluginToVersionedCache("/missing/source", "seeded@market", "9.0.0"),
+      ).resolves.toBe(seedPath);
+    });
+  });
+
+  test("copyPluginToVersionedCache uses marketplace entry source relative to marketplace dir", async () => {
+    await withPluginCacheDir(async () => {
+      const root = await tempDir("agenc-plugin-market-source-");
+      const marketplaceDir = join(root, "marketplace");
+      const pluginSource = join(marketplaceDir, "plugins", "demo");
+      await mkdir(pluginSource, { recursive: true });
+      await writeFile(join(pluginSource, "plugin.json"), JSON.stringify({ name: "demo" }), "utf8");
+
+      const cachedPath = await copyPluginToVersionedCache(
+        join(root, "unused-fallback"),
+        "demo@market",
+        "2.0.0",
+        { name: "demo", version: "2.0.0", source: "./plugins/demo" } as never,
+        marketplaceDir,
+      );
+
+      expect(await readFile(join(cachedPath, "plugin.json"), "utf8")).toContain("demo");
+
+      await expect(
+        copyPluginToVersionedCache(
+          join(root, "unused-fallback"),
+          "missing@market",
+          "2.0.0",
+          { name: "missing", version: "2.0.0", source: "./plugins/missing" } as never,
+          marketplaceDir,
+        ),
+      ).rejects.toThrow(`Plugin source directory not found: ${join(marketplaceDir, "plugins", "missing")}`);
+    });
+  });
+});
+
+describe("plugin loader cache and git-subdir installs", () => {
+  test("cachePlugin caches a local plugin, replaces stale cache, and removes git metadata", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const root = await tempDir("agenc-plugin-cache-local-");
+      const source = join(root, "source");
+      await mkdir(join(source, ".agenc-plugin"), { recursive: true });
+      await mkdir(join(source, ".git"), { recursive: true });
+      await writeFile(join(source, ".git", "config"), "private", "utf8");
+      await writeFile(join(source, "README.md"), "# cached\n", "utf8");
+      await writeFile(
+        join(source, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "cached-local", description: "cached desc" }),
+        "utf8",
+      );
+
+      const staleFinalPath = join(cacheRoot, "cache", "cached-local");
+      await mkdir(staleFinalPath, { recursive: true });
+      await writeFile(join(staleFinalPath, "stale.txt"), "old", "utf8");
+
+      const result = await cachePlugin(source);
+
+      expect(result).toMatchObject({
+        path: staleFinalPath,
+        manifest: { name: "cached-local", description: "cached desc" },
+      });
+      expect(await readFile(join(result.path, "README.md"), "utf8")).toBe("# cached\n");
+      await expect(readFile(join(result.path, ".git", "config"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(readFile(join(result.path, "stale.txt"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  test("cachePlugin uses the provided manifest when cached content has no manifest", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const source = await tempDir("agenc-plugin-cache-manifest-option-");
+      await writeFile(join(source, "command.md"), "# command\n", "utf8");
+
+      const result = await cachePlugin(source, {
+        manifest: { name: "provided-manifest", description: "provided desc" },
+      });
+
+      expect(result).toEqual({
+        path: join(cacheRoot, "cache", "provided-manifest"),
+        manifest: { name: "provided-manifest", description: "provided desc" },
+      });
+      expect(await readFile(join(result.path, "command.md"), "utf8")).toBe("# command\n");
+    });
+  });
+
+  test("cachePlugin loads legacy root manifests and rejects corrupt manifests", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const source = await tempDir("agenc-plugin-cache-legacy-manifest-");
+      await writeFile(
+        join(source, "plugin.json"),
+        JSON.stringify({ name: "legacy-manifest", description: "legacy desc" }),
+        "utf8",
+      );
+
+      await expect(cachePlugin(source)).resolves.toEqual({
+        path: join(cacheRoot, "cache", "legacy-manifest"),
+        manifest: { name: "legacy-manifest", description: "legacy desc" },
+      });
+
+      const corruptSource = await tempDir("agenc-plugin-cache-corrupt-manifest-");
+      await mkdir(join(corruptSource, ".agenc-plugin"), { recursive: true });
+      await writeFile(join(corruptSource, ".agenc-plugin", "plugin.json"), "{", "utf8");
+
+      await expect(cachePlugin(corruptSource)).rejects.toThrow(
+        "Plugin has a corrupt manifest file",
+      );
+    });
+  });
+
+  test("cachePlugin rejects unsupported Python package sources without leaving temp cache entries", async () => {
+    await withPluginCacheDir(async () => {
+      await expect(
+        cachePlugin({ source: "pip", package: "demo-package" }),
+      ).rejects.toThrow("Python package plugins are not yet supported");
+
+      expect(await readdir(getPluginCachePath())).toEqual([]);
+    });
+  });
+
+  test("installFromGitSubdir sparsely extracts a local git subdirectory and returns HEAD sha", async () => {
+    const root = await tempDir("agenc-plugin-git-subdir-");
+    const repo = join(root, "repo");
+    const target = join(root, "target");
+    await mkdir(join(repo, "plugins", "demo", ".agenc-plugin"), { recursive: true });
+    await mkdir(join(repo, "unrelated"), { recursive: true });
+    await writeFile(join(repo, "plugins", "demo", "command.md"), "# demo\n", "utf8");
+    await writeFile(
+      join(repo, "plugins", "demo", ".agenc-plugin", "plugin.json"),
+      JSON.stringify({ name: "subdir-demo" }),
+      "utf8",
+    );
+    await writeFile(join(repo, "unrelated", "ignored.txt"), "ignored", "utf8");
+    await git(["init"], repo);
+    await git(["add", "."], repo);
+    await git(
+      ["-c", "user.name=AgenC Test", "-c", "user.email=test@example.com", "commit", "-m", "init"],
+      repo,
+    );
+    const sha = await git(["rev-parse", "HEAD"], repo);
+
+    const resolvedSha = await installFromGitSubdir(
+      pathToFileURL(repo).href,
+      target,
+      "plugins/demo",
+    );
+
+    expect(resolvedSha).toBe(sha);
+    expect(await readFile(join(target, "command.md"), "utf8")).toBe("# demo\n");
+    expect(await readFile(join(target, ".agenc-plugin", "plugin.json"), "utf8")).toContain(
+      "subdir-demo",
+    );
+    await expect(readFile(join(target, "..", "unrelated", "ignored.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readdir(`${target}.clone`)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const pinnedTarget = join(root, "target-pinned");
+    await expect(
+      installFromGitSubdir(pathToFileURL(repo).href, pinnedTarget, "plugins/demo", undefined, sha),
+    ).resolves.toBe(sha);
+    expect(await readFile(join(pinnedTarget, "command.md"), "utf8")).toBe("# demo\n");
+
+    const missingTarget = join(root, "target-missing");
+    await expect(
+      installFromGitSubdir(pathToFileURL(repo).href, missingTarget, "plugins/missing"),
+    ).rejects.toThrow("Subdirectory 'plugins/missing' not found");
+    await expect(readdir(`${missingTarget}.clone`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("installFromGitSubdir rejects invalid repository URLs", async () => {
+    const root = await tempDir("agenc-plugin-git-subdir-invalid-");
+
+    await expect(
+      installFromGitSubdir("not a url", join(root, "target"), "plugins/demo"),
+    ).rejects.toThrow("Invalid git URL: not a url");
+  });
+
+  test("cachePlugin installs npm sources through the global npm cache", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const root = await tempDir("agenc-plugin-fake-npm-");
+      const binDir = join(root, "bin");
+      await mkdir(binDir, { recursive: true });
+      await writeFile(
+        join(binDir, "npm"),
+        [
+          "#!/bin/sh",
+          "pkg=\"\"",
+          "prefix=\"\"",
+          "while [ \"$#\" -gt 0 ]; do",
+          "  case \"$1\" in",
+          "    install) shift; pkg=\"$1\" ;;",
+          "    --prefix) shift; prefix=\"$1\" ;;",
+          "  esac",
+          "  shift || true",
+          "done",
+          "name=\"${pkg%@*}\"",
+          "mkdir -p \"$prefix/node_modules/$name/.agenc-plugin\"",
+          "printf '%s' '{\"name\":\"npm-cached\",\"description\":\"from npm\"}' > \"$prefix/node_modules/$name/.agenc-plugin/plugin.json\"",
+          "printf '%s\\n' '# npm command' > \"$prefix/node_modules/$name/command.md\"",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(join(binDir, "npm"), 0o755);
+      process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`;
+
+      const result = await cachePlugin({
+        source: "npm",
+        package: "demo-package",
+        version: "1.2.3",
+        registry: "https://registry.test",
+      });
+
+      expect(result).toEqual({
+        path: join(cacheRoot, "cache", "npm-cached"),
+        manifest: { name: "npm-cached", description: "from npm" },
+      });
+      expect(await readFile(join(result.path, "command.md"), "utf8")).toBe("# npm command\n");
+
+      await writeFile(
+        join(binDir, "npm"),
+        [
+          "#!/bin/sh",
+          "prefix=\"\"",
+          "while [ \"$#\" -gt 0 ]; do",
+          "  if [ \"$1\" = \"--prefix\" ]; then shift; prefix=\"$1\"; fi",
+          "  shift || true",
+          "done",
+          "mkdir -p \"$prefix/node_modules/demo-fail\"",
+          "printf '%s' 'simulated npm failure' >&2",
+          "exit 42",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(join(binDir, "npm"), 0o755);
+
+      await expect(
+        cachePlugin({ source: "npm", package: "demo-fail" }),
+      ).rejects.toThrow("Failed to install npm package: simulated npm failure");
+    });
+  });
+
+  test("cachePlugin caches local file-url git and git-subdir sources", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const root = await tempDir("agenc-plugin-cache-git-");
+      const repo = join(root, "repo");
+      await mkdir(join(repo, ".agenc-plugin"), { recursive: true });
+      await mkdir(join(repo, "plugins", "nested", ".agenc-plugin"), { recursive: true });
+      await writeFile(join(repo, "command.md"), "# git command\n", "utf8");
+      await writeFile(
+        join(repo, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "git-cached" }),
+        "utf8",
+      );
+      await writeFile(join(repo, "plugins", "nested", "command.md"), "# nested command\n", "utf8");
+      await writeFile(
+        join(repo, "plugins", "nested", ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "subdir-cached" }),
+        "utf8",
+      );
+      await git(["init"], repo);
+      await git(["add", "."], repo);
+      await git(
+        ["-c", "user.name=AgenC Test", "-c", "user.email=test@example.com", "commit", "-m", "init"],
+        repo,
+      );
+      const sha = await git(["rev-parse", "HEAD"], repo);
+      const defaultBranch = await git(["branch", "--show-current"], repo);
+      await git(["checkout", "-b", "feature"], repo);
+      await writeFile(join(repo, "command.md"), "# feature command\n", "utf8");
+      await writeFile(
+        join(repo, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "git-ref-cached" }),
+        "utf8",
+      );
+      await git(["add", "."], repo);
+      await git(
+        ["-c", "user.name=AgenC Test", "-c", "user.email=test@example.com", "commit", "-m", "feature"],
+        repo,
+      );
+      await git(["checkout", defaultBranch], repo);
+
+      await expect(
+        cachePlugin({ source: "url", url: pathToFileURL(repo).href }),
+      ).resolves.toEqual({
+        path: join(cacheRoot, "cache", "git-cached"),
+        manifest: { name: "git-cached" },
+      });
+      expect(await readFile(join(cacheRoot, "cache", "git-cached", "command.md"), "utf8")).toBe(
+        "# git command\n",
+      );
+
+      await expect(
+        cachePlugin({ source: "url", url: pathToFileURL(repo).href, ref: "feature" }),
+      ).resolves.toEqual({
+        path: join(cacheRoot, "cache", "git-ref-cached"),
+        manifest: { name: "git-ref-cached" },
+      });
+      expect(await readFile(join(cacheRoot, "cache", "git-ref-cached", "command.md"), "utf8")).toBe(
+        "# feature command\n",
+      );
+
+      await expect(
+        cachePlugin({ source: "url", url: pathToFileURL(repo).href, sha }),
+      ).resolves.toEqual({
+        path: join(cacheRoot, "cache", "git-cached"),
+        manifest: { name: "git-cached" },
+      });
+
+      await expect(
+        cachePlugin({
+          source: "git-subdir",
+          url: pathToFileURL(repo).href,
+          path: "plugins/nested",
+        }),
+      ).resolves.toEqual({
+        path: join(cacheRoot, "cache", "subdir-cached"),
+        manifest: { name: "subdir-cached" },
+        gitCommitSha: sha,
+      });
+      expect(await readFile(join(cacheRoot, "cache", "subdir-cached", "command.md"), "utf8")).toBe(
+        "# nested command\n",
+      );
+
+      await expect(cachePlugin(join(root, "missing-local"))).rejects.toThrow(
+        "Source path does not exist",
+      );
+    });
+  });
+
+  test("cachePlugin rejects invalid remote sources and manifest schemas", async () => {
+    await withPluginCacheDir(async () => {
+      await expect(
+        cachePlugin({ source: "github", repo: "bad repo" }),
+      ).rejects.toThrow("Invalid GitHub repository format");
+      await expect(
+        cachePlugin({ source: "future-source" } as never),
+      ).rejects.toThrow("Unsupported plugin source type");
+
+      const invalidManifestSource = await tempDir("agenc-plugin-invalid-manifest-");
+      await mkdir(join(invalidManifestSource, ".agenc-plugin"), { recursive: true });
+      await writeFile(
+        join(invalidManifestSource, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: 42 }),
+        "utf8",
+      );
+      await expect(cachePlugin(invalidManifestSource)).rejects.toThrow(
+        "invalid manifest file",
+      );
+
+      const invalidLegacyManifestSource = await tempDir("agenc-plugin-invalid-legacy-manifest-");
+      await writeFile(
+        join(invalidLegacyManifestSource, "plugin.json"),
+        JSON.stringify({ name: 42 }),
+        "utf8",
+      );
+      await expect(cachePlugin(invalidLegacyManifestSource)).rejects.toThrow(
+        "invalid manifest file",
+      );
+    });
+  });
+});
+
+describe("plugin loader manifest and settings helpers", () => {
+  test("loadPluginManifest returns defaults, strips unknown keys, and reports invalid files", async () => {
+    const root = await tempDir("agenc-plugin-manifest-");
+    const missingManifest = join(root, "missing", "plugin.json");
+
+    await expect(loadPluginManifest(missingManifest, "missing", "local")).resolves.toEqual({
+      name: "missing",
+      description: "Plugin from local",
+    });
+
+    const validManifest = join(root, "plugin.json");
+    await writeFile(
+      validManifest,
+      JSON.stringify({ name: "demo", description: "desc", extra: "stripped" }),
+      "utf8",
+    );
+    await expect(loadPluginManifest(validManifest, "fallback", "local")).resolves.toEqual({
+      name: "demo",
+      description: "desc",
+    });
+
+    const corruptManifest = join(root, "corrupt.json");
+    await writeFile(corruptManifest, "{", "utf8");
+    await expect(loadPluginManifest(corruptManifest, "bad", "local")).rejects.toThrow(
+      "corrupt manifest file",
+    );
+
+    const invalidManifest = join(root, "invalid.json");
+    await writeFile(invalidManifest, JSON.stringify({ name: 42 }), "utf8");
+    await expect(loadPluginManifest(invalidManifest, "bad", "local")).rejects.toThrow(
+      "invalid manifest file",
+    );
+  });
+
+  test("createPluginFromPath detects default component directories without a manifest", async () => {
+    const pluginRoot = await tempDir("agenc-plugin-default-components-");
+    await mkdir(join(pluginRoot, "commands"), { recursive: true });
+    await mkdir(join(pluginRoot, "agents"), { recursive: true });
+    await mkdir(join(pluginRoot, "skills"), { recursive: true });
+    await mkdir(join(pluginRoot, "output-styles"), { recursive: true });
+
+    const { plugin, errors } = await createPluginFromPath(
+      pluginRoot,
+      "session:/plugin-root",
+      false,
+      "fallback-plugin",
+    );
+
+    expect(errors).toEqual([]);
+    expect(plugin).toMatchObject({
+      name: "fallback-plugin",
+      source: "session:/plugin-root",
+      repository: "session:/plugin-root",
+      enabled: false,
+      commandsPath: join(pluginRoot, "commands"),
+      agentsPath: join(pluginRoot, "agents"),
+      skillsPath: join(pluginRoot, "skills"),
+      outputStylesPath: join(pluginRoot, "output-styles"),
+    });
+  });
+
+  test("createPluginFromPath loads manifest components, hooks, settings, and non-fatal path errors", async () => {
+    const pluginRoot = await tempDir("agenc-plugin-manifest-components-");
+    await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+    await mkdir(join(pluginRoot, "extra"), { recursive: true });
+    await mkdir(join(pluginRoot, "extra", "skill"), { recursive: true });
+    await mkdir(join(pluginRoot, "hooks"), { recursive: true });
+    await writeFile(join(pluginRoot, "extra", "command.md"), "# command\n", "utf8");
+    await writeFile(join(pluginRoot, "extra", "agent.md"), "# agent\n", "utf8");
+    await writeFile(join(pluginRoot, "extra", "skill", "SKILL.md"), "# skill\n", "utf8");
+    await writeFile(join(pluginRoot, "extra", "style.md"), "# style\n", "utf8");
+    await writeFile(
+      join(pluginRoot, "hooks", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: "command", command: "echo stop" }] }],
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(pluginRoot, "extra-hooks.json"),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [{ hooks: [{ type: "command", command: "echo start" }] }],
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(pluginRoot, "settings.json"),
+      JSON.stringify({ agent: "file-agent", model: "ignored" }),
+      "utf8",
+    );
+    await writeFile(
+      join(pluginRoot, ".agenc-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "manifest-plugin",
+        commands: {
+          file: { source: "./extra/command.md", description: "File command" },
+          inline: { content: "# inline" },
+          missing: { source: "./extra/missing.md" },
+        },
+        agents: ["./extra/agent.md", "./extra/missing-agent.md"],
+        skills: ["./extra/skill", "./extra/missing-skill"],
+        outputStyles: ["./extra/style.md", "./extra/missing-style.md"],
+        hooks: [
+          "./extra-hooks.json",
+          { Stop: [{ hooks: [{ type: "command", command: "echo inline" }] }] },
+        ],
+        settings: { agent: "manifest-agent" },
+      }),
+      "utf8",
+    );
+
+    const { plugin, errors } = await createPluginFromPath(
+      pluginRoot,
+      "marketplace:manifest-plugin",
+      true,
+      "fallback",
+    );
+
+    expect(plugin.name).toBe("manifest-plugin");
+    expect(plugin.enabled).toBe(true);
+    expect(plugin.commandsPaths).toEqual([join(pluginRoot, "extra", "command.md")]);
+    expect(plugin.commandsMetadata).toMatchObject({
+      file: { source: "./extra/command.md", description: "File command" },
+      inline: { content: "# inline" },
+    });
+    expect(plugin.agentsPaths).toEqual([join(pluginRoot, "extra", "agent.md")]);
+    expect(plugin.skillsPaths).toEqual([join(pluginRoot, "extra", "skill")]);
+    expect(plugin.outputStylesPaths).toEqual([join(pluginRoot, "extra", "style.md")]);
+    expect(plugin.hooksConfig?.Stop).toHaveLength(2);
+    expect(plugin.hooksConfig?.SessionStart).toHaveLength(1);
+    expect(plugin.settings).toEqual({ agent: "file-agent" });
+    expect(errors).toEqual([
+      {
+        type: "path-not-found",
+        source: "marketplace:manifest-plugin",
+        plugin: "manifest-plugin",
+        path: join(pluginRoot, "extra", "missing.md"),
+        component: "commands",
+      },
+      {
+        type: "path-not-found",
+        source: "marketplace:manifest-plugin",
+        plugin: "manifest-plugin",
+        path: join(pluginRoot, "extra", "missing-agent.md"),
+        component: "agents",
+      },
+      {
+        type: "path-not-found",
+        source: "marketplace:manifest-plugin",
+        plugin: "manifest-plugin",
+        path: join(pluginRoot, "extra", "missing-skill"),
+        component: "skills",
+      },
+      {
+        type: "path-not-found",
+        source: "marketplace:manifest-plugin",
+        plugin: "manifest-plugin",
+        path: join(pluginRoot, "extra", "missing-style.md"),
+        component: "output-styles",
+      },
+    ]);
+  });
+
+  test("createPluginFromPath falls back to manifest settings and reports duplicate hooks in strict mode", async () => {
+    const pluginRoot = await tempDir("agenc-plugin-duplicate-hooks-");
+    await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+    await mkdir(join(pluginRoot, "hooks"), { recursive: true });
+    await writeFile(join(pluginRoot, "settings.json"), "{", "utf8");
+    await writeFile(
+      join(pluginRoot, "hooks", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: "command", command: "echo stop" }] }],
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(pluginRoot, ".agenc-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "duplicate-hooks",
+        hooks: "./hooks/hooks.json",
+        settings: { agent: "manifest-agent", model: "ignored" },
+      }),
+      "utf8",
+    );
+
+    const strict = await createPluginFromPath(
+      pluginRoot,
+      "marketplace:duplicate-hooks",
+      true,
+      "fallback",
+    );
+    expect(strict.plugin.settings).toEqual({ agent: "manifest-agent" });
+    expect(strict.plugin.hooksConfig?.Stop).toHaveLength(1);
+    expect(strict.errors).toHaveLength(1);
+    expect(strict.errors[0]).toMatchObject({
+      type: "hook-load-failed",
+      source: "marketplace:duplicate-hooks",
+      plugin: "duplicate-hooks",
+      hookPath: join(pluginRoot, "hooks", "hooks.json"),
+    });
+    expect(strict.errors[0]?.reason).toContain("Duplicate hooks file detected");
+
+    const loose = await createPluginFromPath(
+      pluginRoot,
+      "marketplace:duplicate-hooks",
+      true,
+      "fallback",
+      false,
+    );
+    expect(loose.plugin.settings).toEqual({ agent: "manifest-agent" });
+    expect(loose.errors).toEqual([]);
+  });
+
+  test("createPluginFromPath reports path-array command and hook loading errors", async () => {
+    const pluginRoot = await tempDir("agenc-plugin-hook-errors-");
+    await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+    await mkdir(join(pluginRoot, "hooks"), { recursive: true });
+    await writeFile(join(pluginRoot, "command.md"), "# command\n", "utf8");
+    await writeFile(join(pluginRoot, "hooks", "hooks.json"), "{", "utf8");
+    await writeFile(join(pluginRoot, "bad-hooks.json"), "{", "utf8");
+    await writeFile(
+      join(pluginRoot, ".agenc-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "hook-errors",
+        commands: ["./command.md", "./missing-command.md"],
+        hooks: [
+          "./missing-hooks.json",
+          "./bad-hooks.json",
+          { Stop: [{ hooks: [{ type: "command", command: "echo inline" }] }] },
+        ],
+        settings: { agent: 42, model: "ignored" },
+      }),
+      "utf8",
+    );
+
+    const { plugin, errors } = await createPluginFromPath(
+      pluginRoot,
+      "marketplace:hook-errors",
+      true,
+      "fallback",
+    );
+
+    expect(plugin).toMatchObject({
+      name: "hook-errors",
+      commandsPaths: [join(pluginRoot, "command.md")],
+      hooksConfig: {
+        Stop: [{ hooks: [{ type: "command", command: "echo inline" }] }],
+      },
+    });
+    expect(plugin.settings).toBeUndefined();
+    expect(errors).toHaveLength(4);
+    expect(errors).toEqual([
+      {
+        type: "path-not-found",
+        source: "marketplace:hook-errors",
+        plugin: "hook-errors",
+        path: join(pluginRoot, "missing-command.md"),
+        component: "commands",
+      },
+      {
+        type: "hook-load-failed",
+        source: "marketplace:hook-errors",
+        plugin: "hook-errors",
+        hookPath: join(pluginRoot, "hooks", "hooks.json"),
+        reason: expect.any(String),
+      },
+      {
+        type: "path-not-found",
+        source: "marketplace:hook-errors",
+        plugin: "hook-errors",
+        path: join(pluginRoot, "missing-hooks.json"),
+        component: "hooks",
+      },
+      {
+        type: "hook-load-failed",
+        source: "marketplace:hook-errors",
+        plugin: "hook-errors",
+        hookPath: join(pluginRoot, "bad-hooks.json"),
+        reason: expect.any(String),
+      },
+    ]);
+  });
+
+  test("cachePluginSettings merges enabled plugin settings and clearPluginCache drops them", () => {
+    const first = {
+      name: "first",
+      manifest: { name: "first" },
+      path: "/tmp/first",
+      source: "first",
+      enabled: true,
+      settings: { model: "one", theme: "dark" },
+    } as LoadedPlugin;
+    const second = {
+      name: "second",
+      manifest: { name: "second" },
+      path: "/tmp/second",
+      source: "second",
+      enabled: true,
+      settings: { model: "two", statusLine: { type: "command", command: "echo ok" } },
+    } as LoadedPlugin;
+
+    cachePluginSettings([first, second]);
+    expect(getPluginSettingsBase()).toEqual({
+      model: "two",
+      theme: "dark",
+      statusLine: { type: "command", command: "echo ok" },
+    });
+
+    clearPluginCache("settings test");
+    expect(getPluginSettingsBase()).toBeUndefined();
+  });
+
+  test("cachePluginSettings ignores plugins without settings", () => {
+    cachePluginSettings([
+      {
+        name: "plain",
+        manifest: { name: "plain" },
+        path: "/tmp/plain",
+        source: "plain",
+        enabled: true,
+      } as LoadedPlugin,
+    ]);
+
+    expect(getPluginSettingsBase()).toBeUndefined();
+  });
+});
+
+describe("plugin loader orchestration", () => {
+  test("loadAllPlugins loads session-only plugins, records missing inline paths, and caches settings", async () => {
+    const configRoot = await tempDir("agenc-plugin-load-config-");
+    const pluginRoot = await tempDir("agenc-plugin-inline-load-");
+    const missingPluginRoot = join(pluginRoot, "..", "missing-inline");
+    process.env.AGENC_CONFIG_DIR = configRoot;
+    resetSettingsCache();
+
+    await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+    await mkdir(join(pluginRoot, "commands"), { recursive: true });
+    await writeFile(join(pluginRoot, "commands", "hello.md"), "# hello\n", "utf8");
+    await writeFile(
+      join(pluginRoot, ".agenc-plugin", "plugin.json"),
+      JSON.stringify({ name: "inline-loaded", description: "inline desc" }),
+      "utf8",
+    );
+    await writeFile(join(pluginRoot, "settings.json"), JSON.stringify({ agent: "inline-agent" }), "utf8");
+
+    setInlinePlugins([missingPluginRoot, pluginRoot]);
+
+    const result = await loadAllPlugins();
+
+    expect(result.enabled.map(plugin => plugin.name)).toEqual(["inline-loaded"]);
+    expect(result.enabled[0]).toMatchObject({
+      name: "inline-loaded",
+      source: "inline-loaded@inline",
+      repository: "inline-loaded@inline",
+      enabled: true,
+      commandsPath: join(pluginRoot, "commands"),
+      settings: { agent: "inline-agent" },
+    });
+    expect(result.disabled).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        type: "path-not-found",
+        source: "inline[0]",
+        path: missingPluginRoot,
+        component: "commands",
+      },
+    ]);
+    expect(getPluginSettingsBase()).toEqual({ agent: "inline-agent" });
+
+    await expect(loadAllPluginsCacheOnly()).resolves.toEqual(result);
+  });
+
+  test("loadAllPluginsCacheOnly honors synchronous plugin install mode", async () => {
+    const configRoot = await tempDir("agenc-plugin-load-sync-config-");
+    const pluginRoot = await tempDir("agenc-plugin-inline-sync-");
+    process.env.AGENC_CONFIG_DIR = configRoot;
+    process.env.AGENC_SYNC_PLUGIN_INSTALL = "1";
+    resetSettingsCache();
+
+    await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+    await writeFile(
+      join(pluginRoot, ".agenc-plugin", "plugin.json"),
+      JSON.stringify({ name: "sync-inline" }),
+      "utf8",
+    );
+    setInlinePlugins([pluginRoot]);
+
+    const result = await loadAllPluginsCacheOnly();
+
+    expect(result.enabled.map(plugin => plugin.name)).toEqual(["sync-inline"]);
+  });
+
+  test("loadAllPluginsCacheOnly loads cached local marketplace plugins and reports missing marketplace components", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-market-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-marketplace-");
+      const pluginRoot = join(marketplaceRoot, "plugins", "market-plugin");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({ enabledPlugins: { "market-plugin@test-market": true } }),
+        "utf8",
+      );
+
+      await mkdir(join(cacheRoot), { recursive: true });
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await mkdir(pluginRoot, { recursive: true });
+      await writeFile(join(pluginRoot, "command.md"), "# command\n", "utf8");
+      await writeFile(join(pluginRoot, "agent.md"), "# agent\n", "utf8");
+      await mkdir(join(pluginRoot, "skill"), { recursive: true });
+      await writeFile(join(pluginRoot, "skill", "SKILL.md"), "# skill\n", "utf8");
+      await writeFile(join(pluginRoot, "style.md"), "# style\n", "utf8");
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "market-plugin",
+              source: "./plugins/market-plugin",
+              commands: {
+                file: { source: "./command.md", description: "File command" },
+                inline: { content: "# inline" },
+                missing: { source: "./missing-command.md" },
+              },
+              agents: ["./agent.md", "./missing-agent.md"],
+              skills: ["./skill", "./missing-skill"],
+              outputStyles: ["./style.md", "./missing-style.md"],
+              hooks: {
+                Stop: [{ hooks: [{ type: "command", command: "echo stop" }] }],
+              },
+              strict: true,
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPluginsCacheOnly();
+
+      expect(result.enabled).toHaveLength(1);
+      expect(result.enabled[0]).toMatchObject({
+        name: "market-plugin",
+        source: "market-plugin@test-market",
+        enabled: true,
+        commandsPaths: [join(pluginRoot, "command.md")],
+        commandsMetadata: {
+          file: { source: "./command.md", description: "File command" },
+        },
+        agentsPaths: [join(pluginRoot, "agent.md")],
+        skillsPaths: [join(pluginRoot, "skill")],
+        outputStylesPaths: [join(pluginRoot, "style.md")],
+        hooksConfig: {
+          Stop: [{ hooks: [{ type: "command", command: "echo stop" }] }],
+        },
+      });
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([
+        {
+          type: "path-not-found",
+          source: "market-plugin@test-market",
+          plugin: "market-plugin",
+          path: join(pluginRoot, "missing-command.md"),
+          component: "commands",
+        },
+        {
+          type: "path-not-found",
+          source: "market-plugin@test-market",
+          plugin: "market-plugin",
+          path: join(pluginRoot, "missing-agent.md"),
+          component: "agents",
+        },
+        {
+          type: "path-not-found",
+          source: "market-plugin@test-market",
+          plugin: "market-plugin",
+          path: join(pluginRoot, "missing-skill"),
+          component: "skills",
+        },
+        {
+          type: "path-not-found",
+          source: "market-plugin@test-market",
+          plugin: "market-plugin",
+          path: join(pluginRoot, "missing-style.md"),
+          component: "output-styles",
+        },
+      ]);
+    });
+  });
+
+  test("loadAllPluginsCacheOnly reports external marketplace plugins with no recorded install path", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-external-cache-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-external-marketplace-");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({ enabledPlugins: { "remote-plugin@test-market": true } }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "remote-plugin",
+              source: { source: "github", repo: "owner/repo" },
+              version: "1.0.0",
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPluginsCacheOnly();
+
+      expect(result.enabled).toEqual([]);
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([
+        {
+          type: "plugin-cache-miss",
+          source: "remote-plugin@test-market",
+          plugin: "remote-plugin",
+          installPath: "(not recorded)",
+        },
+      ]);
+    });
+  });
+
+  test("loadAllPluginsCacheOnly reports external marketplace plugins with missing install paths", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-missing-install-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-missing-install-marketplace-");
+      const missingInstallPath = join(cacheRoot, "cache", "test-market", "remote-plugin", "missing");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+      clearInstalledPluginsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({ enabledPlugins: { "remote-plugin@test-market": true } }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "installed_plugins.json"),
+        JSON.stringify({
+          version: 2,
+          plugins: {
+            "remote-plugin@test-market": [
+              {
+                scope: "user",
+                installPath: missingInstallPath,
+                version: "1.0.0",
+                installedAt: "2026-06-03T00:00:00.000Z",
+              },
+            ],
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "remote-plugin",
+              source: { source: "github", repo: "owner/repo" },
+              version: "1.0.0",
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPluginsCacheOnly();
+
+      expect(result.enabled).toEqual([]);
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([
+        {
+          type: "plugin-cache-miss",
+          source: "remote-plugin@test-market",
+          plugin: "remote-plugin",
+          installPath: missingInstallPath,
+        },
+      ]);
+    });
+  });
+
+  test("loadAllPlugins loads local marketplace plugins through versioned cache and supplements manifest components", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-full-market-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-full-marketplace-");
+      const pluginRoot = join(marketplaceRoot, "plugins", "manifest-market");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({ enabledPlugins: { "manifest-market@test-market": true } }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+      await mkdir(join(pluginRoot, "manifest-skill"), { recursive: true });
+      await mkdir(join(pluginRoot, "entry-skill"), { recursive: true });
+      await writeFile(join(pluginRoot, "manifest-command.md"), "# manifest\n", "utf8");
+      await writeFile(join(pluginRoot, "entry-command.md"), "# entry\n", "utf8");
+      await writeFile(join(pluginRoot, "manifest-agent.md"), "# manifest agent\n", "utf8");
+      await writeFile(join(pluginRoot, "entry-agent.md"), "# entry agent\n", "utf8");
+      await writeFile(join(pluginRoot, "manifest-skill", "SKILL.md"), "# manifest skill\n", "utf8");
+      await writeFile(join(pluginRoot, "entry-skill", "SKILL.md"), "# entry skill\n", "utf8");
+      await writeFile(join(pluginRoot, "manifest-style.md"), "# manifest style\n", "utf8");
+      await writeFile(join(pluginRoot, "entry-style.md"), "# entry style\n", "utf8");
+      await writeFile(
+        join(pluginRoot, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({
+          name: "manifest-market",
+          version: "1.0.0",
+          commands: {
+            manifest: { source: "./manifest-command.md", description: "Manifest command" },
+          },
+          agents: "./manifest-agent.md",
+          skills: "./manifest-skill",
+          outputStyles: "./manifest-style.md",
+          hooks: {
+            Stop: [{ hooks: [{ type: "command", command: "echo manifest" }] }],
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "manifest-market",
+              source: "./plugins/manifest-market",
+              commands: {
+                entry: { source: "./entry-command.md", description: "Entry command" },
+              },
+              agents: "./entry-agent.md",
+              skills: "./entry-skill",
+              outputStyles: "./entry-style.md",
+              hooks: {
+                SessionStart: [{ hooks: [{ type: "command", command: "echo entry" }] }],
+              },
+              strict: true,
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPlugins();
+      const cachedPluginPath = getVersionedCachePath("manifest-market@test-market", "1.0.0");
+
+      expect(result.enabled).toHaveLength(1);
+      expect(result.enabled[0]).toMatchObject({
+        name: "manifest-market",
+        source: "manifest-market@test-market",
+        path: cachedPluginPath,
+        enabled: true,
+        commandsPaths: [
+          join(cachedPluginPath, "manifest-command.md"),
+          join(cachedPluginPath, "entry-command.md"),
+        ],
+        commandsMetadata: {
+          manifest: { source: "./manifest-command.md", description: "Manifest command" },
+          entry: { source: "./entry-command.md", description: "Entry command" },
+        },
+        agentsPaths: [
+          join(cachedPluginPath, "manifest-agent.md"),
+          join(cachedPluginPath, "entry-agent.md"),
+        ],
+        skillsPaths: [
+          join(cachedPluginPath, "manifest-skill"),
+          join(cachedPluginPath, "entry-skill"),
+        ],
+        outputStylesPaths: [
+          join(cachedPluginPath, "manifest-style.md"),
+          join(cachedPluginPath, "entry-style.md"),
+        ],
+        hooksConfig: {
+          Stop: [{ hooks: [{ type: "command", command: "echo manifest" }] }],
+          SessionStart: [{ hooks: [{ type: "command", command: "echo entry" }] }],
+        },
+      });
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(await readFile(join(cachedPluginPath, "entry-command.md"), "utf8")).toBe("# entry\n");
+    });
+  });
+
+  test("loadAllPluginsCacheOnly rejects non-strict marketplace component conflicts with plugin manifests", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-conflict-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-conflict-marketplace-");
+      const pluginRoot = join(marketplaceRoot, "plugins", "conflict-plugin");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({ enabledPlugins: { "conflict-plugin@test-market": true } }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+      await writeFile(join(pluginRoot, "entry-command.md"), "# entry\n", "utf8");
+      await writeFile(
+        join(pluginRoot, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "conflict-plugin" }),
+        "utf8",
+      );
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "conflict-plugin",
+              source: "./plugins/conflict-plugin",
+              commands: "./entry-command.md",
+              strict: false,
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPluginsCacheOnly();
+
+      expect(result.enabled).toEqual([]);
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([
+        {
+          type: "generic-error",
+          source: "conflict-plugin@test-market",
+          error:
+            "Plugin conflict-plugin has conflicting manifests: both plugin.json and marketplace entry specify components. Set strict: true in marketplace entry or remove component specs from one location.",
+        },
+      ]);
+    });
+  });
+
+  test("loadAllPlugins loads external marketplace plugins from existing versioned cache", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-external-full-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-external-full-marketplace-");
+      const sha = "1234567890abcdef1234567890abcdef12345678";
+      const cachedPluginPath = getVersionedCachePath("external-cached@test-market", "1.2.3");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({ enabledPlugins: { "external-cached@test-market": true } }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "external-cached",
+              source: { source: "github", repo: "owner/repo", sha },
+              version: "1.2.3",
+            },
+          ],
+        }),
+        "utf8",
+      );
+      await mkdir(join(cachedPluginPath, ".agenc-plugin"), { recursive: true });
+      await writeFile(
+        join(cachedPluginPath, ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "external-cached", version: "1.2.3" }),
+        "utf8",
+      );
+
+      const result = await loadAllPlugins();
+
+      expect(result.enabled).toHaveLength(1);
+      expect(result.enabled[0]).toMatchObject({
+        name: "external-cached",
+        source: "external-cached@test-market",
+        path: cachedPluginPath,
+        sha,
+        enabled: true,
+      });
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  test("loadAllPlugins handles missing and uncached local marketplace sources", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-local-edge-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-local-edge-marketplace-");
+      const emptyPluginRoot = join(marketplaceRoot, "plugins", "empty-local");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({
+          enabledPlugins: {
+            "missing-local@test-market": true,
+            "empty-local@test-market": true,
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await mkdir(emptyPluginRoot, { recursive: true });
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "missing-local",
+              source: "./plugins/missing-local",
+              version: "1.0.0",
+            },
+            {
+              name: "empty-local",
+              source: "./plugins/empty-local",
+              version: "1.0.0",
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPlugins();
+
+      expect(result.enabled).toHaveLength(1);
+      expect(result.enabled[0]).toMatchObject({
+        name: "empty-local",
+        source: "empty-local@test-market",
+        path: emptyPluginRoot,
+        enabled: true,
+      });
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toEqual([
+        {
+          type: "generic-error",
+          source: "missing-local@test-market",
+          error: `Plugin directory not found at path: ${join(marketplaceRoot, "plugins", "missing-local")}. Check that the marketplace entry has the correct path.`,
+        },
+      ]);
+    });
+  });
+
+  test("loadAllPlugins downloads uncached git-subdir marketplace plugins and reports external cache failures", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-external-download-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-external-download-marketplace-");
+      const repoRoot = await tempDir("agenc-plugin-external-download-repo-");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(join(repoRoot, "plugins", "demo", ".agenc-plugin"), { recursive: true });
+      await writeFile(join(repoRoot, "plugins", "demo", "command.md"), "# downloaded\n", "utf8");
+      await writeFile(
+        join(repoRoot, "plugins", "demo", ".agenc-plugin", "plugin.json"),
+        JSON.stringify({ name: "git-subdir-market" }),
+        "utf8",
+      );
+      await git(["init"], repoRoot);
+      await git(["add", "."], repoRoot);
+      await git(
+        ["-c", "user.name=AgenC Test", "-c", "user.email=test@example.com", "commit", "-m", "init"],
+        repoRoot,
+      );
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({
+          enabledPlugins: {
+            "git-subdir-market@test-market": true,
+            "broken-remote@test-market": true,
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "git-subdir-market",
+              source: {
+                source: "git-subdir",
+                url: pathToFileURL(repoRoot).href,
+                path: "plugins/demo",
+              },
+            },
+            {
+              name: "broken-remote",
+              source: { source: "url", url: "file:///definitely/missing/repo" },
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPlugins();
+
+      expect(result.enabled).toHaveLength(1);
+      expect(result.enabled[0]).toMatchObject({
+        name: "git-subdir-market",
+        source: "git-subdir-market@test-market",
+        enabled: true,
+      });
+      expect(result.enabled[0]?.path).toContain(join(cacheRoot, "cache", "test-market", "git-subdir-market"));
+      expect(await readFile(join(result.enabled[0]!.path, "command.md"), "utf8")).toBe("# downloaded\n");
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        type: "generic-error",
+        source: "broken-remote@test-market",
+      });
+      expect(result.errors[0]?.error).toContain("Failed to download/cache plugin broken-remote");
+    });
+  });
+
+  test("loadAllPluginsCacheOnly supports no-manifest path commands and reports missing catalogs", async () => {
+    await withPluginCacheDir(async cacheRoot => {
+      const configRoot = await tempDir("agenc-plugin-path-command-config-");
+      const marketplaceRoot = await tempDir("agenc-plugin-path-command-marketplace-");
+      const pluginRoot = join(marketplaceRoot, "plugins", "path-command");
+      process.env.AGENC_CONFIG_DIR = configRoot;
+      resetSettingsCache();
+
+      await mkdir(configRoot, { recursive: true });
+      await writeFile(
+        join(configRoot, "settings.json"),
+        JSON.stringify({
+          enabledPlugins: {
+            "path-command@test-market": true,
+            "missing-catalog@missing-market": true,
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(cacheRoot, "known_marketplaces.json"),
+        JSON.stringify({
+          "test-market": {
+            source: { source: "directory", path: marketplaceRoot },
+            installLocation: marketplaceRoot,
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+          "missing-market": {
+            source: { source: "directory", path: join(marketplaceRoot, "missing-market") },
+            installLocation: join(marketplaceRoot, "missing-market"),
+            lastUpdated: "2026-06-03T00:00:00.000Z",
+          },
+        }),
+        "utf8",
+      );
+      await mkdir(join(marketplaceRoot, ".agenc-plugin"), { recursive: true });
+      await mkdir(pluginRoot, { recursive: true });
+      await writeFile(join(pluginRoot, "command.md"), "# path command\n", "utf8");
+      await writeFile(
+        join(marketplaceRoot, ".agenc-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "test-market",
+          owner: { name: "Tests" },
+          plugins: [
+            {
+              name: "path-command",
+              source: "./plugins/path-command",
+              commands: ["./command.md", "./missing-command.md"],
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const result = await loadAllPluginsCacheOnly();
+
+      expect(result.enabled).toHaveLength(1);
+      expect(result.enabled[0]).toMatchObject({
+        name: "path-command",
+        commandsPaths: [join(pluginRoot, "command.md")],
+      });
+      expect(result.disabled).toEqual([]);
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors).toContainEqual({
+        type: "plugin-not-found",
+        source: "missing-catalog@missing-market",
+        pluginId: "missing-catalog",
+        marketplace: "missing-market",
+      });
+      expect(result.errors).toContainEqual({
+        type: "path-not-found",
+        source: "path-command@test-market",
+        plugin: "path-command",
+        path: join(pluginRoot, "missing-command.md"),
+        component: "commands",
+      });
+    });
+  });
+});

--- a/runtime/tests/plugins/pluginLoader-merge-sources.test.ts
+++ b/runtime/tests/plugins/pluginLoader-merge-sources.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+
+import type { LoadedPlugin } from "../../src/types/plugin.js";
+import { mergePluginSources } from "../../src/utils/plugins/pluginLoader.js";
+
+function loadedPlugin(name: string, source: string, enabled = true): LoadedPlugin {
+  return {
+    name,
+    manifest: { name } as LoadedPlugin["manifest"],
+    path: `/tmp/${source}`,
+    source,
+    repository: source,
+    enabled,
+  };
+}
+
+function marketplacePlugin(
+  name: string,
+  marketplace: string,
+  enabled: boolean,
+): LoadedPlugin {
+  const pluginId = `${name}@${marketplace}`;
+  return loadedPlugin(name, pluginId, enabled);
+}
+
+describe("mergePluginSources", () => {
+  test("keeps the enabled copy when duplicate marketplace plugins disagree on enabled state", () => {
+    const enabledOfficial = marketplacePlugin(
+      "frontend-design",
+      "agenc-plugins-official",
+      true,
+    );
+    const disabledLegacy = marketplacePlugin(
+      "frontend-design",
+      "agenc-code-plugins",
+      false,
+    );
+
+    const result = mergePluginSources({
+      session: [],
+      marketplace: [disabledLegacy, enabledOfficial],
+      builtin: [],
+    });
+
+    expect(result.plugins).toEqual([enabledOfficial]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("keeps the existing enabled copy when a later duplicate marketplace plugin is disabled", () => {
+    const enabledOfficial = marketplacePlugin(
+      "frontend-design",
+      "agenc-plugins-official",
+      true,
+    );
+    const disabledLegacy = marketplacePlugin(
+      "frontend-design",
+      "agenc-code-plugins",
+      false,
+    );
+
+    const result = mergePluginSources({
+      session: [],
+      marketplace: [enabledOfficial, disabledLegacy],
+      builtin: [],
+    });
+
+    expect(result.plugins).toEqual([enabledOfficial]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("keeps the later copy when duplicate marketplace plugins are both disabled", () => {
+    const legacy = marketplacePlugin(
+      "frontend-design",
+      "agenc-code-plugins",
+      false,
+    );
+    const official = marketplacePlugin(
+      "frontend-design",
+      "agenc-plugins-official",
+      false,
+    );
+
+    const result = mergePluginSources({
+      session: [],
+      marketplace: [legacy, official],
+      builtin: [],
+    });
+
+    expect(result.plugins).toEqual([official]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("keeps the later copy when duplicate marketplace plugins are both enabled", () => {
+    const legacy = marketplacePlugin(
+      "frontend-design",
+      "agenc-code-plugins",
+      true,
+    );
+    const official = marketplacePlugin(
+      "frontend-design",
+      "agenc-plugins-official",
+      true,
+    );
+
+    const result = mergePluginSources({
+      session: [],
+      marketplace: [legacy, official],
+      builtin: [],
+    });
+
+    expect(result.plugins).toEqual([official]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      type: "generic-error",
+      source: legacy.source,
+      plugin: legacy.name,
+    });
+  });
+
+  test("lets session plugins override marketplace copies and keeps builtin plugins last", () => {
+    const sessionCopy = loadedPlugin("dev-plugin", "session:/plugins/dev");
+    const installedCopy = marketplacePlugin("dev-plugin", "agenc-code-plugins", true);
+    const unrelatedMarketplace = marketplacePlugin("theme", "agenc-code-plugins", true);
+    const builtin = loadedPlugin("builtin-tool", "builtin");
+
+    const result = mergePluginSources({
+      session: [sessionCopy],
+      marketplace: [installedCopy, unrelatedMarketplace],
+      builtin: [builtin],
+    });
+
+    expect(result.plugins).toEqual([sessionCopy, unrelatedMarketplace, builtin]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("drops session plugins locked by managed settings and reports the override denial", () => {
+    const sessionCopy = loadedPlugin("locked-plugin", "session:/plugins/locked");
+    const installedCopy = marketplacePlugin("locked-plugin", "agenc-code-plugins", true);
+
+    const result = mergePluginSources({
+      session: [sessionCopy],
+      marketplace: [installedCopy],
+      builtin: [],
+      managedNames: new Set(["locked-plugin"]),
+    });
+
+    expect(result.plugins).toEqual([installedCopy]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      type: "generic-error",
+      source: sessionCopy.source,
+      plugin: sessionCopy.name,
+    });
+  });
+});

--- a/runtime/tests/prompts/attachments/extractors.test.ts
+++ b/runtime/tests/prompts/attachments/extractors.test.ts
@@ -1,0 +1,1186 @@
+import { mkdir, mkdtemp, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createUserMessage, createAssistantMessage } from "../../../src/utils/messages.js";
+import type { ToolUseContext } from "../../../src/tools/Tool.js";
+import { createTask, getTaskListId } from "../../../src/utils/tasks.js";
+import { CanonicalFileReadTool } from "../../../src/tools/canonicalToolSurface.js";
+import { applyPermissionRulesToPermissionContext } from "../../../src/permissions/rules.js";
+import {
+  createEmptyToolPermissionContext,
+  type PermissionRule,
+  type ToolPermissionContext,
+} from "../../../src/permissions/types.js";
+import {
+  setLastEmittedDate,
+  setHasExitedPlanMode,
+  setNeedsAutoModeExitAttachment,
+  setNeedsPlanModeExitAttachment,
+} from "../../../src/bootstrap/state.js";
+import {
+  collectRecentSuccessfulTools,
+  collectSurfacedMemories,
+  createAttachmentMessage,
+  extractAgentMentions,
+  extractAtMentionedFiles,
+  extractMcpResourceMentions,
+  filterDuplicateMemoryAttachments,
+  filterToBundledAndMcp,
+  generateFileAttachment,
+  getAttachments,
+  getAttachmentMessages,
+  getChangedFiles,
+  getDateChangeAttachments,
+  getDirectoriesToProcess,
+  getQueuedCommandAttachments,
+  getVerifyPlanReminderTurnCount,
+  memoryFilesToAttachments,
+  memoryHeader,
+  parseAtMentionedFileLines,
+  tryGetPDFReference,
+} from "../../../src/utils/attachments.js";
+
+const originalDisableAttachments = process.env.AGENC_DISABLE_ATTACHMENTS;
+const originalSimpleMode = process.env.AGENC_SIMPLE;
+const originalEnableTasks = process.env.AGENC_ENABLE_TASKS;
+const originalTaskListId = process.env.AGENC_TASK_LIST_ID;
+const originalConfigDir = process.env.AGENC_CONFIG_DIR;
+const originalUserType = process.env.USER_TYPE;
+
+function toolUse(id: string, name = "Bash") {
+  return {
+    type: "tool_use",
+    id,
+    name,
+    input: { command: "echo ok" },
+  } as const;
+}
+
+function toolResult(id: string, isError = false) {
+  return {
+    type: "tool_result",
+    tool_use_id: id,
+    content: isError ? "failed" : "ok",
+    is_error: isError,
+  } as const;
+}
+
+function attachmentContext(
+  readFileState = new Map<string, unknown>(),
+  toolPermissionContext: ToolPermissionContext = createEmptyToolPermissionContext(),
+  optionOverrides: Partial<ToolUseContext["options"]> = {},
+  appStateOverrides: Record<string, unknown> = {},
+): ToolUseContext {
+  return {
+    abortController: new AbortController(),
+    readFileState,
+    nestedMemoryAttachmentTriggers: new Set(),
+    options: {
+      commands: [],
+      debug: false,
+      tools: [],
+      verbose: false,
+      mainLoopModel: "gpt-test",
+      mcpClients: [],
+      mcpResources: {},
+      agentDefinitions: { activeAgents: [], allowedAgentTypes: undefined },
+      ...optionOverrides,
+    },
+    getAppState: () => ({
+      toolPermissionContext,
+      todos: {},
+      ...appStateOverrides,
+    }),
+  } as unknown as ToolUseContext;
+}
+
+async function collectAsyncGenerator<T>(generator: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const result of generator) {
+    results.push(result);
+  }
+  return results;
+}
+
+function restoreOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restoreOptionalEnv("AGENC_DISABLE_ATTACHMENTS", originalDisableAttachments);
+  restoreOptionalEnv("AGENC_SIMPLE", originalSimpleMode);
+  restoreOptionalEnv("AGENC_ENABLE_TASKS", originalEnableTasks);
+  restoreOptionalEnv("AGENC_TASK_LIST_ID", originalTaskListId);
+  restoreOptionalEnv("AGENC_CONFIG_DIR", originalConfigDir);
+  restoreOptionalEnv("USER_TYPE", originalUserType);
+  setLastEmittedDate(null);
+  setHasExitedPlanMode(false);
+  setNeedsPlanModeExitAttachment(false);
+  setNeedsAutoModeExitAttachment(false);
+});
+
+async function withMockedCanonicalFileRead<T>(
+  call: typeof CanonicalFileReadTool.call,
+  run: () => Promise<T>,
+): Promise<T> {
+  const original = CanonicalFileReadTool.call;
+  CanonicalFileReadTool.call = call;
+  try {
+    return await run();
+  } finally {
+    CanonicalFileReadTool.call = original;
+  }
+}
+
+async function withTempWorkspace<T>(
+  prefix: string,
+  run: (workspace: string) => Promise<T>,
+): Promise<T> {
+  const workspace = await mkdtemp(join(process.cwd(), prefix));
+  try {
+    return await run(workspace);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+describe("attachment mention extractors", () => {
+  describe("getAttachments aggregation", () => {
+    test("returns queued commands when attachments are disabled", async () => {
+      process.env.AGENC_DISABLE_ATTACHMENTS = "1";
+
+      const attachments = await getAttachments(
+        "ignored while disabled",
+        attachmentContext(),
+        null,
+        [
+          {
+            mode: "prompt",
+            value: "queued prompt",
+            uuid: "cmd-disabled-1",
+            origin: { kind: "human" },
+          },
+          {
+            mode: "bash",
+            value: "echo skipped",
+            uuid: "cmd-disabled-2",
+          },
+        ] as never,
+      );
+
+      expect(attachments).toEqual([
+        expect.objectContaining({
+          type: "queued_command",
+          prompt: "queued prompt",
+          source_uuid: "cmd-disabled-1",
+        }),
+      ]);
+    });
+
+    test("wraps generated attachments as attachment messages", async () => {
+      process.env.AGENC_DISABLE_ATTACHMENTS = "1";
+
+      const messages = await collectAsyncGenerator(
+        getAttachmentMessages(
+          "ignored while disabled",
+          attachmentContext(),
+          null,
+          [
+            {
+              mode: "prompt",
+              value: "queued prompt",
+              uuid: "cmd-generator-1",
+              origin: { kind: "human" },
+            },
+          ] as never,
+        ),
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        type: "attachment",
+        attachment: {
+          type: "queued_command",
+          prompt: "queued prompt",
+          source_uuid: "cmd-generator-1",
+        },
+      });
+
+      await expect(
+        collectAsyncGenerator(
+          getAttachmentMessages(null, attachmentContext(), null, []),
+        ),
+      ).resolves.toEqual([]);
+    });
+
+    test("adds plan-mode reminders on first plan turn and throttles recent reminders", async () => {
+      const planContext = attachmentContext(
+        new Map(),
+        createEmptyToolPermissionContext({ mode: "plan" }),
+      );
+
+      const firstTurn = await getAttachments(null, planContext, null, [], []);
+      expect(firstTurn).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "plan_mode",
+            reminderType: "full",
+            isSubAgent: false,
+            planExists: false,
+          }),
+        ]),
+      );
+
+      const throttled = await getAttachments(
+        null,
+        planContext,
+        null,
+        [],
+        [
+          createAttachmentMessage({
+            type: "plan_mode",
+            reminderType: "full",
+            isSubAgent: false,
+            planFilePath: "/tmp/plan.md",
+            planExists: false,
+          } as never),
+          createUserMessage({ content: "one" }),
+        ],
+      );
+
+      expect(throttled.some(attachment => attachment.type === "plan_mode")).toBe(false);
+    });
+
+    test("emits a one-shot plan-mode exit attachment outside plan mode", async () => {
+      setNeedsPlanModeExitAttachment(true);
+
+      const first = await getAttachments(null, attachmentContext(), null, [], []);
+      expect(first).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "plan_mode_exit",
+            planExists: false,
+          }),
+        ]),
+      );
+
+      const second = await getAttachments(null, attachmentContext(), null, [], []);
+      expect(second.some(attachment => attachment.type === "plan_mode_exit")).toBe(false);
+    });
+
+    test("includes critical system reminders from the tool-use context", async () => {
+      const context = {
+        ...attachmentContext(),
+        criticalSystemReminder_EXPERIMENTAL: "Keep the safety invariant.",
+      } as ToolUseContext;
+
+      const attachments = await getAttachments(null, context, null, [], []);
+
+      expect(attachments).toEqual(
+        expect.arrayContaining([
+          {
+            type: "critical_system_reminder",
+            content: "Keep the safety invariant.",
+          },
+        ]),
+      );
+    });
+
+    test("adds TodoWrite reminders after enough assistant turns and respects recent reminders", async () => {
+      const agentId = "agent-todo-reminder";
+      const context = {
+        ...attachmentContext(
+          new Map(),
+          createEmptyToolPermissionContext(),
+          {
+            tools: [{ name: "TodoWrite" }] as never,
+          },
+          {
+            todos: {
+              [agentId]: [
+                {
+                  content: "Ship the test tranche",
+                  status: "pending",
+                  activeForm: "Shipping the test tranche",
+                },
+              ],
+            },
+          },
+        ),
+        agentId,
+      } as ToolUseContext;
+      const oldAssistantTurns = Array.from({ length: 10 }, (_value, index) =>
+        createAssistantMessage({ content: `assistant turn ${index}` }),
+      );
+
+      const reminder = await getAttachments(null, context, null, [], oldAssistantTurns);
+      expect(reminder).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "todo_reminder",
+            itemCount: 1,
+            content: [
+              expect.objectContaining({
+                content: "Ship the test tranche",
+              }),
+            ],
+          }),
+        ]),
+      );
+
+      const recentlyReminded = await getAttachments(
+        null,
+        context,
+        null,
+        [],
+        [
+          createAttachmentMessage({
+            type: "todo_reminder",
+            content: [],
+            itemCount: 0,
+          } as never),
+          createAssistantMessage({ content: "assistant turn after reminder" }),
+        ],
+      );
+
+      expect(recentlyReminded.some(attachment => attachment.type === "todo_reminder")).toBe(false);
+    });
+
+    test("emits dynamic skill attachments from triggered directories once", async () => {
+      await withTempWorkspace(".tmp-attachment-dynamic-skills-", async (workspace) => {
+        const skillDir = join(workspace, "skills");
+        await mkdir(join(skillDir, "alpha"), { recursive: true });
+        await mkdir(join(skillDir, "not-a-skill"), { recursive: true });
+        await writeFile(join(skillDir, "alpha", "SKILL.md"), "# Alpha\n", "utf8");
+        await writeFile(join(skillDir, "not-a-skill", "README.md"), "# nope\n", "utf8");
+        const context = {
+          ...attachmentContext(),
+          dynamicSkillDirTriggers: new Set([skillDir, join(workspace, "missing")]),
+        } as ToolUseContext;
+
+        const first = await getAttachments(null, context, null, [], []);
+        expect(first).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "dynamic_skill",
+              skillDir,
+              skillNames: ["alpha"],
+            }),
+          ]),
+        );
+
+        const second = await getAttachments(null, context, null, [], []);
+        expect(second.some(attachment => attachment.type === "dynamic_skill")).toBe(false);
+      });
+    });
+
+    test("adds task reminders for task-enabled sessions and throttles recent reminders", async () => {
+      await withTempWorkspace(".tmp-attachment-task-reminders-", async (workspace) => {
+        process.env.AGENC_ENABLE_TASKS = "1";
+        process.env.AGENC_TASK_LIST_ID = "attachment-task-reminder";
+        process.env.AGENC_CONFIG_DIR = join(workspace, "home");
+        delete process.env.USER_TYPE;
+
+        await createTask(getTaskListId(), {
+          subject: "Review task reminder",
+          description: "Make sure task reminders surface.",
+          activeForm: "Reviewing task reminder",
+          status: "pending",
+          blocks: [],
+          blockedBy: [],
+        });
+        const context = attachmentContext(new Map(), createEmptyToolPermissionContext(), {
+          tools: [{ name: "TaskUpdate" }] as never,
+        });
+        const messages = [
+          createAssistantMessage({
+            content: [
+              {
+                type: "tool_use",
+                id: "task-update",
+                name: "TaskUpdate",
+                input: {},
+              },
+            ] as never,
+          }),
+          ...Array.from({ length: 10 }, (_value, index) =>
+            createAssistantMessage({ content: `assistant task turn ${index}` }),
+          ),
+        ];
+
+        const reminder = await getAttachments(null, context, null, [], messages);
+        expect(reminder).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "task_reminder",
+              itemCount: 1,
+              content: [
+                expect.objectContaining({
+                  subject: "Review task reminder",
+                }),
+              ],
+            }),
+          ]),
+        );
+
+        const recentlyReminded = await getAttachments(
+          null,
+          context,
+          null,
+          [],
+          [
+            createAttachmentMessage({
+              type: "task_reminder",
+              content: [],
+              itemCount: 0,
+            } as never),
+            createAssistantMessage({ content: "assistant turn after task reminder" }),
+          ],
+        );
+
+        expect(recentlyReminded.some(attachment => attachment.type === "task_reminder")).toBe(false);
+      });
+    });
+
+    test("processes agent and MCP resource mentions from user input", async () => {
+      const context = attachmentContext(new Map(), createEmptyToolPermissionContext(), {
+        agentDefinitions: {
+          activeAgents: [
+            { agentType: "reviewer" },
+          ] as never,
+          allowedAgentTypes: undefined,
+        },
+        mcpClients: [
+          {
+            name: "docs",
+            type: "connected",
+            client: {
+              readResource: async ({ uri }: { uri: string }) => ({
+                contents: [{ uri, text: "resource text" }],
+              }),
+            },
+          },
+        ] as never,
+        mcpResources: {
+          docs: [
+            {
+              uri: "guide",
+              name: "Project guide",
+              description: "Useful docs",
+            },
+          ],
+        } as never,
+      });
+
+      const attachments = await getAttachments(
+        "ask @agent-reviewer and @agent-ghost about @docs:guide",
+        context,
+        null,
+        [],
+        [],
+      );
+
+      expect(attachments).toEqual(
+        expect.arrayContaining([
+          { type: "agent_mention", agentType: "reviewer" },
+          expect.objectContaining({
+            type: "mcp_resource",
+            server: "docs",
+            uri: "guide",
+            name: "Project guide",
+            description: "Useful docs",
+          }),
+        ]),
+      );
+      expect(
+        attachments.some(
+          attachment =>
+            attachment.type === "agent_mention" &&
+            attachment.agentType === "ghost",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("extractMcpResourceMentions ignores file mentions", () => {
+    const cases: Array<[string, string]> = [
+      ["a quoted Windows drive-letter path", '@"C:\\Users\\me\\file.txt"'],
+      ["an unquoted Windows drive-letter path", "@C:\\Users\\me\\file.txt"],
+      ["a quoted POSIX path with a space", '@"/Users/foo/my file.ts"'],
+      ["an unquoted POSIX path", "@/Users/foo/bar.ts"],
+      ["a quoted POSIX path with a colon in the name", '@"/tmp/weird:name.txt"'],
+    ];
+
+    test.each(cases)("%s", (_label, input) => {
+      expect(extractMcpResourceMentions(input)).toEqual([]);
+    });
+  });
+
+  describe("extractMcpResourceMentions matches legitimate MCP mentions", () => {
+    const cases: Array<[string, string, string[]]> = [
+      [
+        "a simple server:resource token",
+        "@server:resource/path",
+        ["server:resource/path"],
+      ],
+      [
+        "a plugin-scoped server name with a dash",
+        "@asana-plugin:project-status/123",
+        ["asana-plugin:project-status/123"],
+      ],
+      ["an MCP mention inline in prose", "please check @server:res here", ["server:res"]],
+    ];
+
+    test.each(cases)("%s", (_label, input, expected) => {
+      expect(extractMcpResourceMentions(input)).toEqual(expected);
+    });
+  });
+
+  describe("extractAtMentionedFiles extracts file paths", () => {
+    const cases: Array<[string, string, string[]]> = [
+      [
+        "a quoted Windows drive-letter path",
+        '@"C:\\Users\\me\\file.txt"',
+        ["C:\\Users\\me\\file.txt"],
+      ],
+      [
+        "a quoted POSIX path with a space",
+        '@"/Users/foo/my file.ts"',
+        ["/Users/foo/my file.ts"],
+      ],
+      ["an unquoted POSIX path", "@/Users/foo/bar.ts", ["/Users/foo/bar.ts"]],
+    ];
+
+    test.each(cases)("%s", (_label, input, expected) => {
+      expect(extractAtMentionedFiles(input)).toEqual(expected);
+    });
+  });
+
+  test("extracts agent mentions and file line ranges", () => {
+    expect(
+      extractAgentMentions(
+        'ask @agent-code-review and @"asana:project.status (agent)" plus @agent-plugin@scope.worker',
+      ),
+    ).toEqual([
+      "asana:project.status",
+      "agent-code-review",
+      "agent-plugin@scope.worker",
+    ]);
+
+    expect(parseAtMentionedFileLines("src/app.ts#L10-20")).toEqual({
+      filename: "src/app.ts",
+      lineStart: 10,
+      lineEnd: 20,
+    });
+    expect(parseAtMentionedFileLines("src/app.ts#L7")).toEqual({
+      filename: "src/app.ts",
+      lineStart: 7,
+      lineEnd: 7,
+    });
+    expect(parseAtMentionedFileLines("src/app.ts#heading")).toEqual({
+      filename: "src/app.ts",
+      lineStart: undefined,
+      lineEnd: undefined,
+    });
+  });
+
+  test("builds queued command attachments for inline notification modes", async () => {
+    await expect(
+      getQueuedCommandAttachments([
+        {
+          mode: "prompt",
+          value: "run prompt",
+          uuid: "cmd-1",
+          isMeta: true,
+          origin: { kind: "human" },
+        },
+        {
+          mode: "task-notification",
+          value: [{ type: "text", text: "task done" }],
+          uuid: "cmd-2",
+          origin: { kind: "task-notification" },
+        },
+        {
+          mode: "bash",
+          value: "echo skipped",
+          uuid: "cmd-3",
+        },
+      ] as never),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        type: "queued_command",
+        prompt: "run prompt",
+        source_uuid: "cmd-1",
+        commandMode: "prompt",
+        isMeta: true,
+      }),
+      expect.objectContaining({
+        type: "queued_command",
+        prompt: [{ type: "text", text: "task done" }],
+        source_uuid: "cmd-2",
+        commandMode: "task-notification",
+      }),
+    ]);
+  });
+
+  test("collects and deduplicates surfaced memory attachments", () => {
+    const previous = createAttachmentMessage({
+      type: "relevant_memories",
+      memories: [
+        {
+          path: "/tmp/a.md",
+          content: "alpha",
+          mtimeMs: 1,
+          header: "A",
+        },
+        {
+          path: "/tmp/b.md",
+          content: "beta",
+          mtimeMs: 2,
+          header: "B",
+        },
+      ],
+    } as never);
+
+    const surfaced = collectSurfacedMemories([previous]);
+    expect([...surfaced.paths]).toEqual(["/tmp/a.md", "/tmp/b.md"]);
+    expect(surfaced.totalBytes).toBe("alphabeta".length);
+    expect(memoryHeader("/tmp/a.md", 1)).toContain("/tmp/a.md");
+
+    const cache = new Map<string, unknown>([
+      ["/tmp/a.md", { content: "existing" }],
+    ]);
+    const filtered = filterDuplicateMemoryAttachments(
+      [
+        previous.attachment,
+        { type: "text", content: "keep" },
+      ] as never,
+      cache as never,
+    );
+    expect(filtered).toEqual([
+      expect.objectContaining({
+        type: "relevant_memories",
+        memories: [expect.objectContaining({ path: "/tmp/b.md" })],
+      }),
+      { type: "text", content: "keep" },
+    ]);
+    expect(cache.has("/tmp/b.md")).toBe(true);
+  });
+
+  test("collects recent successful tools before the last real turn boundary", () => {
+    const olderUser = createUserMessage({ content: "older" });
+    const lastUser = createUserMessage({ content: "current" });
+    const assistant = createAssistantMessage({
+      content: [
+        toolUse("ok", "Bash"),
+        toolUse("bad", "Edit"),
+        toolUse("pending", "Read"),
+      ] as never,
+    });
+    const results = createUserMessage({
+      content: [toolResult("ok"), toolResult("bad", true)] as never,
+      toolUseResult: {},
+    });
+
+    expect(
+      collectRecentSuccessfulTools(
+        [olderUser, lastUser, assistant, results],
+        lastUser,
+      ),
+    ).toEqual(["Bash"]);
+  });
+
+  test("filters skill listings and counts verify-plan reminder turns", () => {
+    expect(
+      filterToBundledAndMcp([
+        { name: "bundled", loadedFrom: "bundled" },
+        { name: "mcp", loadedFrom: "mcp" },
+        { name: "user", loadedFrom: "user" },
+      ] as never),
+    ).toEqual([
+      { name: "bundled", loadedFrom: "bundled" },
+      { name: "mcp", loadedFrom: "mcp" },
+    ]);
+
+    const many = Array.from({ length: 31 }, (_value, index) => ({
+      name: `skill-${index}`,
+      loadedFrom: index === 0 ? "bundled" : "mcp",
+    }));
+    expect(filterToBundledAndMcp(many as never)).toEqual([
+      { name: "skill-0", loadedFrom: "bundled" },
+    ]);
+
+    expect(
+      getVerifyPlanReminderTurnCount([
+        createAttachmentMessage({ type: "plan_mode_exit" } as never),
+        createUserMessage({ content: "one" }),
+        createUserMessage({
+          content: [toolResult("tool")] as never,
+          toolUseResult: {},
+        }),
+        createUserMessage({ content: "two" }),
+      ]),
+    ).toBe(2);
+  });
+
+  describe("file attachment generation", () => {
+    test("reads a text file through the canonical file-read tool", async () => {
+      await withTempWorkspace(".tmp-attachment-read-", async (workspace) => {
+        const filePath = join(workspace, "note.txt");
+        await writeFile(filePath, "alpha\nbeta\n", "utf8");
+
+        const attachment = await generateFileAttachment(
+          filePath,
+          attachmentContext(),
+          "attachment_success",
+          "attachment_error",
+          "at-mention",
+        );
+
+        expect(attachment).toMatchObject({
+          type: "file",
+          filename: filePath,
+        });
+        expect(JSON.stringify((attachment as { content?: unknown }).content)).toContain("alpha");
+      });
+    });
+
+    test("returns already-read metadata when the cached timestamp still matches", async () => {
+      await withTempWorkspace(".tmp-attachment-already-read-", async (workspace) => {
+        const filePath = join(workspace, "cached.txt");
+        const content = "cached\ncontent\n";
+        await writeFile(filePath, content, "utf8");
+        const fileStat = await stat(filePath);
+        const readFileState = new Map<string, unknown>([
+          [
+            filePath,
+            {
+              content,
+              timestamp: Math.floor(fileStat.mtimeMs),
+              offset: undefined,
+              limit: undefined,
+            },
+          ],
+        ]);
+
+        const attachment = await generateFileAttachment(
+          filePath,
+          attachmentContext(readFileState),
+          "attachment_success",
+          "attachment_error",
+          "at-mention",
+        );
+
+        expect(attachment).toMatchObject({
+          type: "already_read_file",
+          filename: filePath,
+          content: {
+            type: "text",
+            file: {
+              filePath,
+              content,
+              numLines: 3,
+              startLine: 1,
+              totalLines: 3,
+            },
+          },
+        });
+      });
+    });
+
+    test("short-circuits when a read deny rule matches the file path", async () => {
+      await withTempWorkspace(".tmp-attachment-deny-", async (workspace) => {
+        const filePath = join(workspace, "secret.txt");
+        await writeFile(filePath, "secret\n", "utf8");
+        const relativePath = relative(process.cwd(), filePath);
+        const denyRule: PermissionRule = {
+          source: "session",
+          ruleBehavior: "deny",
+          ruleValue: { toolName: "FileRead", ruleContent: relativePath },
+        };
+        const permissionContext = applyPermissionRulesToPermissionContext(
+          createEmptyToolPermissionContext(),
+          [denyRule],
+        );
+
+        const result = await withMockedCanonicalFileRead(
+          (async () => {
+            throw new Error("canonical reader should not be called");
+          }) as typeof CanonicalFileReadTool.call,
+          () =>
+            generateFileAttachment(
+              filePath,
+              attachmentContext(new Map(), permissionContext),
+              "attachment_success",
+              "attachment_error",
+              "at-mention",
+            ),
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    test("uses a compact reference when compact-mode canonical read is too large", async () => {
+      await withTempWorkspace(".tmp-attachment-compact-", async (workspace) => {
+        const filePath = join(workspace, "large.txt");
+        await writeFile(filePath, "content\n", "utf8");
+
+        const result = await withMockedCanonicalFileRead(
+          (async () => ({
+            data: {
+              content:
+                "File content (100000 tokens) exceeds maximum allowed tokens (25000).",
+              isError: true,
+            },
+          })) as typeof CanonicalFileReadTool.call,
+          () =>
+            generateFileAttachment(
+              filePath,
+              attachmentContext(),
+              "attachment_success",
+              "attachment_error",
+              "compact",
+            ),
+        );
+
+        expect(result).toMatchObject({
+          type: "compact_file_reference",
+          filename: filePath,
+        });
+      });
+    });
+
+    test("drops oversized non-PDF at-mentions before canonical reading", async () => {
+      await withTempWorkspace(".tmp-attachment-too-large-", async (workspace) => {
+        const filePath = join(workspace, "too-large.txt");
+        await writeFile(filePath, "x".repeat(300 * 1024), "utf8");
+
+        const result = await withMockedCanonicalFileRead(
+          (async () => {
+            throw new Error("canonical reader should not be called");
+          }) as typeof CanonicalFileReadTool.call,
+          () =>
+            generateFileAttachment(
+              filePath,
+              attachmentContext(),
+              "attachment_success",
+              "attachment_error",
+              "at-mention",
+            ),
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    test("returns null PDF references for non-PDFs and inaccessible PDFs", async () => {
+      await withTempWorkspace(".tmp-attachment-pdf-reference-", async (workspace) => {
+        const textPath = join(workspace, "note.txt");
+        const missingPdfPath = join(workspace, "missing.pdf");
+        await writeFile(textPath, "plain\n", "utf8");
+
+        await expect(tryGetPDFReference(textPath)).resolves.toBeNull();
+        await expect(tryGetPDFReference(missingPdfPath)).resolves.toBeNull();
+      });
+    });
+  });
+
+  describe("changed-file attachments", () => {
+    test("emits a text diff for a cached file that changed on disk", async () => {
+      await withTempWorkspace(".tmp-attachment-changed-text-", async (workspace) => {
+        const filePath = join(workspace, "changed.txt");
+        await writeFile(filePath, "old line\nshared\n", "utf8");
+        const readFileState = new Map<string, unknown>([
+          [
+            filePath,
+            {
+              content: "old line\nshared\n",
+              timestamp: 0,
+              offset: undefined,
+              limit: undefined,
+            },
+          ],
+        ]);
+        await writeFile(filePath, "new line\nshared\n", "utf8");
+
+        const attachments = await getChangedFiles(attachmentContext(readFileState));
+
+        expect(attachments).toEqual([
+          expect.objectContaining({
+            type: "edited_text_file",
+            filename: filePath,
+            snippet: expect.stringContaining("new line"),
+          }),
+        ]);
+      });
+    });
+
+    test("skips range reads and unchanged cached files", async () => {
+      await withTempWorkspace(".tmp-attachment-unchanged-", async (workspace) => {
+        const rangedPath = join(workspace, "ranged.txt");
+        const unchangedPath = join(workspace, "unchanged.txt");
+        await writeFile(rangedPath, "ranged\n", "utf8");
+        await writeFile(unchangedPath, "same\n", "utf8");
+        const unchangedStat = await stat(unchangedPath);
+        const readFileState = new Map<string, unknown>([
+          [
+            rangedPath,
+            {
+              content: "ranged\n",
+              timestamp: 0,
+              offset: 1,
+              limit: 1,
+            },
+          ],
+          [
+            unchangedPath,
+            {
+              content: "same\n",
+              timestamp: Math.floor(unchangedStat.mtimeMs),
+              offset: undefined,
+              limit: undefined,
+            },
+          ],
+        ]);
+
+        await expect(getChangedFiles(attachmentContext(readFileState))).resolves.toEqual([]);
+      });
+    });
+
+    test("evicts missing files from the read-state cache", async () => {
+      await withTempWorkspace(".tmp-attachment-deleted-", async (workspace) => {
+        const filePath = join(workspace, "deleted.txt");
+        await writeFile(filePath, "removed\n", "utf8");
+        const readFileState = new Map<string, unknown>([
+          [
+            filePath,
+            {
+              content: "removed\n",
+              timestamp: 0,
+              offset: undefined,
+              limit: undefined,
+            },
+          ],
+        ]);
+        await unlink(filePath);
+
+        await expect(getChangedFiles(attachmentContext(readFileState))).resolves.toEqual([]);
+        expect(readFileState.has(filePath)).toBe(false);
+      });
+    });
+
+    test("preserves standalone canonical image media as edited-image attachments", async () => {
+      await withTempWorkspace(".tmp-attachment-changed-image-", async (workspace) => {
+        const filePath = join(workspace, "image.png");
+        await writeFile(filePath, "new image bytes", "utf8");
+        const imageData = {
+          content: "Read image",
+          contentItems: [
+            { type: "input_text", text: "Read image" },
+            { type: "input_image", image_url: "data:image/png;base64,YWJj" },
+          ],
+          metadata: { mediaType: "image/png" },
+        };
+        const readFileState = new Map<string, unknown>([
+          [
+            filePath,
+            {
+              content: "old image bytes",
+              timestamp: 0,
+              offset: undefined,
+              limit: undefined,
+            },
+          ],
+        ]);
+
+        const result = await withMockedCanonicalFileRead(
+          (async () => ({ data: imageData })) as typeof CanonicalFileReadTool.call,
+          () => getChangedFiles(attachmentContext(readFileState)),
+        );
+
+        expect(result).toEqual([
+          {
+            type: "edited_image_file",
+            filename: filePath,
+            content: imageData,
+          },
+        ]);
+      });
+    });
+
+    test("drops non-text canonical media from changed-file attachments", async () => {
+      await withTempWorkspace(".tmp-attachment-changed-media-", async (workspace) => {
+        const filePath = join(workspace, "doc.pdf");
+        await writeFile(filePath, "new pdf bytes", "utf8");
+        const readFileState = new Map<string, unknown>([
+          [
+            filePath,
+            {
+              content: "old pdf bytes",
+              timestamp: 0,
+              offset: undefined,
+              limit: undefined,
+            },
+          ],
+        ]);
+
+        const result = await withMockedCanonicalFileRead(
+          (async () => ({
+            data: {
+              content: "pdf text",
+              metadata: { mediaType: "application/pdf" },
+            },
+          })) as typeof CanonicalFileReadTool.call,
+          () => getChangedFiles(attachmentContext(readFileState)),
+        );
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe("nested memory helper attachments", () => {
+    test("computes nested directories from the workspace root to the target file", () => {
+      const originalCwd = join(process.cwd(), "project");
+      const targetPath = join(originalCwd, "src", "feature", "file.ts");
+
+      const directories = getDirectoriesToProcess(targetPath, originalCwd);
+
+      expect(directories.nestedDirs).toEqual([
+        join(originalCwd, "src"),
+        join(originalCwd, "src", "feature"),
+      ]);
+      expect(directories.cwdLevelDirs.at(-1)).toBe(originalCwd);
+    });
+
+    test("creates nested memory attachments once and records loaded paths", () => {
+      const memoryPath = join(process.cwd(), "AGENC.memory.md");
+      const readFileState = new Map<string, unknown>();
+      const loadedNestedMemoryPaths = new Set<string>();
+      const context = {
+        ...attachmentContext(readFileState),
+        loadedNestedMemoryPaths,
+      } as unknown as ToolUseContext;
+
+      const first = memoryFilesToAttachments(
+        [
+          {
+            path: memoryPath,
+            type: "AutoMem",
+            content: "remember this",
+          },
+        ],
+        context,
+      );
+      const second = memoryFilesToAttachments(
+        [
+          {
+            path: memoryPath,
+            type: "AutoMem",
+            content: "remember this",
+          },
+        ],
+        context,
+      );
+
+      expect(first).toEqual([
+        expect.objectContaining({
+          type: "nested_memory",
+          path: memoryPath,
+          content: expect.objectContaining({ content: "remember this" }),
+        }),
+      ]);
+      expect(second).toEqual([]);
+      expect(loadedNestedMemoryPaths.has(memoryPath)).toBe(true);
+      expect(readFileState.get(memoryPath)).toMatchObject({
+        content: "remember this",
+        offset: undefined,
+        limit: undefined,
+      });
+    });
+
+    test("marks transformed memory content as a partial raw-content cache entry", () => {
+      const memoryPath = join(process.cwd(), "AGENC.partial.md");
+      const readFileState = new Map<string, unknown>();
+      const context = attachmentContext(readFileState);
+
+      const attachments = memoryFilesToAttachments(
+        [
+          {
+            path: memoryPath,
+            type: "AutoMem",
+            content: "processed content",
+            contentDiffersFromDisk: true,
+            rawContent: "raw disk content",
+          },
+        ],
+        context,
+      );
+
+      expect(attachments).toHaveLength(1);
+      expect(readFileState.get(memoryPath)).toMatchObject({
+        content: "raw disk content",
+        isPartialView: true,
+      });
+    });
+
+    test("skips memory files already present in read state", () => {
+      const memoryPath = join(process.cwd(), "AGENC.cached.md");
+      const readFileState = new Map<string, unknown>([
+        [
+          memoryPath,
+          {
+            content: "existing",
+            timestamp: Date.now(),
+            offset: undefined,
+            limit: undefined,
+          },
+        ],
+      ]);
+
+      expect(
+        memoryFilesToAttachments(
+          [
+            {
+              path: memoryPath,
+              type: "AutoMem",
+              content: "new content",
+            },
+          ],
+          attachmentContext(readFileState),
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("date-change attachments", () => {
+    test("records the first date and emits once when the local date advances", () => {
+      const originalOverride = process.env.AGENC_OVERRIDE_DATE;
+      try {
+        setLastEmittedDate(null);
+        process.env.AGENC_OVERRIDE_DATE = "2030-01-01";
+        expect(getDateChangeAttachments(undefined)).toEqual([]);
+
+        process.env.AGENC_OVERRIDE_DATE = "2030-01-02";
+        expect(
+          getDateChangeAttachments([createUserMessage({ content: "overnight" })]),
+        ).toEqual([{ type: "date_change", newDate: "2030-01-02" }]);
+        expect(getDateChangeAttachments(undefined)).toEqual([]);
+      } finally {
+        if (originalOverride === undefined) {
+          delete process.env.AGENC_OVERRIDE_DATE;
+        } else {
+          process.env.AGENC_OVERRIDE_DATE = originalOverride;
+        }
+        setLastEmittedDate(null);
+      }
+    });
+  });
+});

--- a/runtime/tests/services/api/anthropic-core.test.ts
+++ b/runtime/tests/services/api/anthropic-core.test.ts
@@ -1,0 +1,915 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { resetStateForTests, setPromptCache1hAllowlist, setPromptCache1hEligible } from '../../../src/bootstrap/state.ts'
+import {
+  accumulateUsage,
+  cleanupStream,
+  getAPIMetadata,
+  getCacheControl,
+  getMaxOutputTokensForModel,
+  queryHaiku,
+  queryModelWithStreaming,
+  queryWithModel,
+  updateUsage,
+  verifyApiKey,
+} from '../../../src/services/api/anthropic.ts'
+import { asSystemPrompt } from '../../../src/utils/systemPromptType.ts'
+
+type AnyRecord = Record<string, any>
+
+const harness = vi.hoisted(() => {
+  class MockCannotRetryError extends Error {
+    constructor(
+      public readonly originalError: unknown,
+      public readonly retryContext: AnyRecord,
+    ) {
+      super(
+        originalError instanceof Error ? originalError.message : String(originalError),
+      )
+    }
+  }
+
+  class MockFallbackTriggeredError extends Error {}
+
+  const usage = () => ({
+    input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    output_tokens: 0,
+    server_tool_use: {
+      web_search_requests: 0,
+      web_fetch_requests: 0,
+    },
+    service_tier: null,
+    cache_creation: {
+      ephemeral_1h_input_tokens: 0,
+      ephemeral_5m_input_tokens: 0,
+    },
+    inference_geo: null,
+    iterations: 0,
+    speed: null,
+  })
+
+  const state: AnyRecord = {
+    createCalls: [],
+    getClientCalls: [],
+    streamEvents: [],
+    responseHeaders: {},
+    requestId: 'req_stream_1',
+    createError: undefined,
+    nonStreamingResponse: undefined,
+    logAPIError: vi.fn(),
+    logAPISuccessAndDuration: vi.fn(),
+    logAPIQuery: vi.fn(),
+    logForDebugging: vi.fn(),
+    captureAPIRequest: vi.fn(),
+    recordUsageCacheStats: vi.fn(),
+    addToTotalSessionCost: vi.fn(() => 0),
+    calculateUSDCost: vi.fn(() => 0),
+  }
+
+  const makeStream = (events: AnyRecord[]) => ({
+    controller: new AbortController(),
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) {
+        yield event
+      }
+    },
+  })
+
+  state.client = {
+    beta: {
+      messages: {
+        create: vi.fn((params: AnyRecord, options?: AnyRecord) => {
+          state.createCalls.push({ params, options })
+          if (state.createError) {
+            throw state.createError
+          }
+          if (params.stream) {
+            return {
+              withResponse: async () => ({
+                data: makeStream(state.streamEvents),
+                request_id: state.requestId,
+                response: new Response('', {
+                  headers: state.responseHeaders,
+                }),
+              }),
+            }
+          }
+          return Promise.resolve(
+            state.nonStreamingResponse ?? {
+              id: 'msg_nonstream',
+              type: 'message',
+              role: 'assistant',
+              model: params.model,
+              content: [{ type: 'text', text: 'nonstream ok' }],
+              stop_reason: 'end_turn',
+              stop_sequence: null,
+              usage: usage(),
+            },
+          )
+        }),
+      },
+    },
+  }
+
+  state.getproviderClient = vi.fn(async (options: AnyRecord) => {
+    state.getClientCalls.push(options)
+    return state.client
+  })
+
+  state.withRetry = async function* (
+    getClient: () => Promise<unknown>,
+    operation: (
+      client: unknown,
+      attempt: number,
+      context: AnyRecord,
+    ) => Promise<unknown>,
+    options: AnyRecord,
+  ) {
+    const client = await getClient()
+    return await operation(client, 1, {
+      model: options.model,
+      thinkingConfig: options.thinkingConfig,
+      fastMode: options.fastMode,
+    })
+  }
+
+  state.CannotRetryError = MockCannotRetryError
+  state.FallbackTriggeredError = MockFallbackTriggeredError
+  state.usage = usage
+  return state
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/constants/system.js', () => ({
+  getAttributionHeader: (fingerprint: string) => `attr:${fingerprint}`,
+  getCLISyspromptPrefix: () => 'system-prefix',
+}))
+
+vi.mock('../../../src/services/api/client.js', () => ({
+  CLIENT_REQUEST_ID_HEADER: 'x-client-request-id',
+  getproviderClient: harness.getproviderClient,
+}))
+
+vi.mock('../../../src/services/api/withRetry.js', () => ({
+  CannotRetryError: harness.CannotRetryError,
+  FallbackTriggeredError: harness.FallbackTriggeredError,
+  getDefaultMaxRetries: () => 10,
+  is529Error: (error: AnyRecord) => error?.status === 529,
+  withRetry: harness.withRetry,
+}))
+
+vi.mock('../../../src/services/vcr.js', () => ({
+  withStreamingVCR: async function* (
+    _messages: unknown[],
+    run: () => AsyncGenerator<unknown, void>,
+  ) {
+    yield* run()
+  },
+  withVCR: async (_messages: unknown[], run: () => Promise<unknown[]>) => run(),
+}))
+
+vi.mock('../../../src/utils/model/providers.js', () => ({
+  getAPIProvider: () => 'firstParty',
+  isFirstPartyproviderBaseUrl: () => true,
+  isGithubNativeproviderMode: () => false,
+}))
+
+vi.mock('../../../src/utils/auth.js', () => ({
+  getOauthAccountInfo: () => null,
+  isAgenCAISubscriber: () => false,
+}))
+
+vi.mock('../../../src/utils/config.js', () => ({
+  getOrCreateUserID: () => 'user-test-id',
+}))
+
+vi.mock('../../../src/utils/context.js', () => ({
+  CAPPED_DEFAULT_MAX_TOKENS: 8192,
+  getMaxThinkingTokensForModel: () => 2048,
+  getModelMaxOutputTokens: () => ({
+    default: 4096,
+    upperLimit: 128000,
+  }),
+  getSonnet1mExpTreatmentEnabled: () => false,
+}))
+
+vi.mock('../../../src/utils/model/model.js', () => ({
+  getDefaultOpusModel: () => 'opus-default',
+  getDefaultSonnetModel: () => 'sonnet-default',
+  getSmallFastModel: () => 'small-fast-model',
+  isNonCustomOpusModel: () => false,
+  normalizeModelStringForAPI: (model: string) => `normalized-${model}`,
+  parseUserSpecifiedModel: (model: string) => model,
+}))
+
+vi.mock('../../../src/utils/betas.js', () => ({
+  getMergedBetas: () => ['base-beta'],
+  getModelBetas: () => ['model-beta'],
+  getToolSearchBetaHeader: () => 'tool-search-beta',
+  modelSupportsStructuredOutputs: () => true,
+  shouldIncludeFirstPartyOnlyBetas: () => true,
+  shouldUseGlobalCacheScope: () => false,
+}))
+
+vi.mock('../../../src/utils/effort.js', () => ({
+  modelSupportsEffort: () => true,
+  resolveAppliedEffort: (_model: string, effort: unknown) => effort,
+}))
+
+vi.mock('../../../src/utils/fastMode.js', () => ({
+  isFastModeAvailable: () => false,
+  isFastModeCooldown: () => false,
+  isFastModeEnabled: () => false,
+  isFastModeSupportedByModel: () => true,
+}))
+
+vi.mock('../../../src/utils/advisor.js', () => ({
+  ADVISOR_TOOL_INSTRUCTIONS: 'advisor instructions',
+  getExperimentAdvisorModels: () => undefined,
+  isAdvisorEnabled: () => false,
+  isValidAdvisorModel: () => true,
+  modelSupportsAdvisor: () => true,
+}))
+
+vi.mock('../../../src/utils/toolSearch.js', () => ({
+  extractDiscoveredToolNames: () => new Set<string>(),
+  isDeferredToolsDeltaEnabled: () => false,
+  isToolSearchEnabled: async () => false,
+}))
+
+vi.mock('../../../src/tools/ToolSearchTool/prompt.js', () => ({
+  TOOL_SEARCH_TOOL_NAME: 'ToolSearch',
+  formatDeferredToolLine: (tool: AnyRecord) => tool.name,
+  isDeferredTool: (tool: AnyRecord) => tool.defer_loading === true,
+}))
+
+vi.mock('../../../src/utils/api.js', () => ({
+  logAPIPrefix: vi.fn(),
+  splitSysPromptPrefix: (systemPrompt: readonly string[]) =>
+    systemPrompt.map(text => ({ text, cacheScope: null })),
+  toolToAPISchema: async (tool: AnyRecord) => ({
+    name: tool.name,
+    description: 'tool',
+    input_schema: { type: 'object' },
+  }),
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  createAssistantAPIErrorMessage: ({ content, apiError, error }: AnyRecord) => ({
+    type: 'assistant',
+    isApiErrorMessage: true,
+    apiError,
+    error,
+    message: {
+      role: 'assistant',
+      model: 'error-model',
+      content: [{ type: 'text', text: content }],
+      stop_reason: null,
+      usage: harness.usage(),
+    },
+  }),
+  createUserMessage: ({ content, isMeta }: AnyRecord) => ({
+    type: 'user',
+    isMeta,
+    message: { role: 'user', content },
+  }),
+  ensureToolResultPairing: (messages: unknown[]) => messages,
+  normalizeContentFromAPI: (content: unknown[]) => content,
+  normalizeMessagesForAPI: (messages: unknown[]) => messages,
+  stripAdvisorBlocks: (messages: unknown[]) => messages,
+  stripCallerFieldFromAssistantMessage: (message: unknown) => message,
+  stripToolReferenceBlocksFromUserMessage: (message: unknown) => message,
+}))
+
+vi.mock('../../../src/services/api/errors.js', () => ({
+  API_ERROR_MESSAGE_PREFIX: 'API Error',
+  CUSTOM_OFF_SWITCH_MESSAGE: 'off switch',
+  getAssistantMessageFromError: (error: unknown, model: string) => ({
+    type: 'assistant',
+    isApiErrorMessage: true,
+    message: {
+      role: 'assistant',
+      model,
+      content: [
+        {
+          type: 'text',
+          text: error instanceof Error ? error.message : String(error),
+        },
+      ],
+      stop_reason: null,
+      usage: harness.usage(),
+    },
+  }),
+  getErrorMessageIfRefusal: () => null,
+}))
+
+vi.mock('../../../src/utils/fingerprint.js', () => ({
+  computeFingerprintFromMessages: () => 'fingerprint',
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: harness.logForDebugging,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  captureAPIRequest: harness.captureAPIRequest,
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../src/services/api/logging.js', () => ({
+  EMPTY_USAGE: harness.usage(),
+  logAPIError: harness.logAPIError,
+  logAPIQuery: harness.logAPIQuery,
+  logAPISuccessAndDuration: harness.logAPISuccessAndDuration,
+}))
+
+vi.mock('../../../src/services/agencAiLimits.js', () => ({
+  currentLimits: { isUsingOverage: false },
+  extractQuotaStatusFromError: vi.fn(),
+  extractQuotaStatusFromHeaders: vi.fn(),
+}))
+
+vi.mock('../../../src/services/compact/apiMicrocompact.js', () => ({
+  getAPIContextManagement: () => null,
+}))
+
+vi.mock('../../../src/services/compact/microCompact.js', () => ({
+  consumePendingCacheEdits: () => null,
+  getPinnedCacheEdits: () => [],
+  markToolsSentToAPIState: vi.fn(),
+  pinCacheEdits: vi.fn(),
+}))
+
+vi.mock('../../../src/services/lsp/manager.js', () => ({
+  getInitializationStatus: () => ({ status: 'initialized' }),
+}))
+
+vi.mock('../../../src/services/mcp/utils.js', () => ({
+  isToolFromMcpServer: () => false,
+}))
+
+vi.mock('../../../src/utils/agentContext.js', () => ({
+  getAgentContext: () => null,
+}))
+
+vi.mock('../../../src/utils/headlessProfiler.js', () => ({
+  headlessProfilerCheckpoint: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/queryProfiler.js', () => ({
+  endQueryProfile: vi.fn(),
+  queryCheckpoint: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/sessionActivity.js', () => ({
+  startSessionActivity: vi.fn(),
+  stopSessionActivity: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/diagLogs.js', () => ({
+  logForDiagnosticsNoPII: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/mcpInstructionsDelta.js', () => ({
+  isMcpInstructionsDeltaEnabled: () => false,
+}))
+
+vi.mock('../../../src/utils/modelCost.js', () => ({
+  calculateUSDCost: harness.calculateUSDCost,
+}))
+
+vi.mock('../../../src/cost/tracker.js', () => ({
+  addToTotalSessionCost: harness.addToTotalSessionCost,
+}))
+
+vi.mock('../../../src/services/api/cacheStatsTracker.js', () => ({
+  recordUsageCacheStats: harness.recordUsageCacheStats,
+}))
+
+vi.mock('../../../src/utils/tokens.js', () => ({
+  tokenCountFromLastAPIResponse: () => 123,
+}))
+
+function resetHarness(): void {
+  harness.createCalls.length = 0
+  harness.getClientCalls.length = 0
+  harness.streamEvents = []
+  harness.responseHeaders = {}
+  harness.requestId = 'req_stream_1'
+  harness.createError = undefined
+  harness.nonStreamingResponse = undefined
+  harness.getproviderClient.mockClear()
+  harness.client.beta.messages.create.mockClear()
+  harness.logAPIError.mockClear()
+  harness.logAPISuccessAndDuration.mockClear()
+  harness.logAPIQuery.mockClear()
+  harness.logForDebugging.mockClear()
+  harness.captureAPIRequest.mockClear()
+  harness.recordUsageCacheStats.mockClear()
+  harness.addToTotalSessionCost.mockClear()
+  harness.calculateUSDCost.mockClear()
+}
+
+function baseOptions(overrides: AnyRecord = {}): AnyRecord {
+  return {
+    getToolPermissionContext: async () => ({
+      mode: 'default',
+      additionalWorkingDirectories: new Map(),
+      alwaysAllowRules: {},
+      alwaysDenyRules: {},
+      alwaysAskRules: {},
+      isBypassPermissionsModeAvailable: false,
+    }),
+    model: 'test-model',
+    isNonInteractiveSession: false,
+    querySource: 'sdk',
+    agents: [],
+    hasAppendSystemPrompt: false,
+    mcpTools: [],
+    ...overrides,
+  }
+}
+
+function userMessage(content = 'hello'): AnyRecord {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content,
+    },
+  }
+}
+
+function textStreamEvents(text = 'stream ok'): AnyRecord[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_stream',
+        type: 'message',
+        role: 'assistant',
+        model: 'test-model',
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          ...harness.usage(),
+          input_tokens: 7,
+          cache_read_input_tokens: 3,
+        },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'text',
+        text: 'ignored-prefix',
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: {
+        type: 'text_delta',
+        text,
+      },
+    },
+    {
+      type: 'content_block_stop',
+      index: 0,
+    },
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'end_turn',
+      },
+      usage: {
+        output_tokens: 5,
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        server_tool_use: {
+          web_search_requests: 2,
+        },
+        cache_creation: {
+          ephemeral_1h_input_tokens: 11,
+        },
+        iterations: 2,
+        speed: 'standard',
+      },
+    },
+    {
+      type: 'message_stop',
+    },
+  ]
+}
+
+beforeEach(() => {
+  resetHarness()
+  resetStateForTests()
+  ;(globalThis as AnyRecord).MACRO = { VERSION: 'test-version' }
+  delete process.env.AGENC_MAX_OUTPUT_TOKENS
+  delete process.env.AGENC_EXTRA_METADATA
+  delete process.env.AGENC_EXTRA_BODY
+  delete process.env.AGENC_DISABLE_THINKING
+  delete process.env.AGENC_DISABLE_PROMPT_CACHING
+  delete process.env.AGENC_DISABLE_NONSTREAMING_FALLBACK
+  delete process.env.API_TIMEOUT_MS
+  delete process.env.USER_TYPE
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete process.env.AGENC_MAX_OUTPUT_TOKENS
+  delete process.env.AGENC_EXTRA_METADATA
+  delete process.env.AGENC_EXTRA_BODY
+  delete process.env.AGENC_DISABLE_THINKING
+  delete process.env.AGENC_DISABLE_PROMPT_CACHING
+  delete process.env.AGENC_DISABLE_NONSTREAMING_FALLBACK
+  delete process.env.API_TIMEOUT_MS
+  delete process.env.USER_TYPE
+})
+
+describe('provider API core helpers', () => {
+  test('getCacheControl adds one-hour TTL and global scope when the latched allowlist matches', () => {
+    setPromptCache1hEligible(true)
+    setPromptCache1hAllowlist(['sdk', 'agent:*'])
+
+    expect(getCacheControl({ scope: 'global', querySource: 'agent:default' })).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+      scope: 'global',
+    })
+
+    setPromptCache1hEligible(false)
+    expect(getCacheControl({ querySource: 'sdk' })).toEqual({
+      type: 'ephemeral',
+    })
+  })
+
+  test('getAPIMetadata merges metadata with stable user, account, and session fields', () => {
+    process.env.AGENC_EXTRA_METADATA = '{"workspace":"runtime","count":2}'
+
+    const metadata = getAPIMetadata()
+    const userId = JSON.parse(metadata.user_id)
+
+    expect(userId).toMatchObject({
+      workspace: 'runtime',
+      count: 2,
+      device_id: 'user-test-id',
+      account_uuid: '',
+    })
+    expect(typeof userId.session_id).toBe('string')
+    expect(userId.session_id.length).toBeGreaterThan(0)
+  })
+
+  test('updateUsage preserves nonzero input counters while applying output and server-tool deltas', () => {
+    const current = {
+      ...harness.usage(),
+      input_tokens: 17,
+      cache_creation_input_tokens: 13,
+      cache_read_input_tokens: 11,
+      output_tokens: 2,
+      server_tool_use: {
+        web_search_requests: 1,
+        web_fetch_requests: 4,
+      },
+      cache_creation: {
+        ephemeral_1h_input_tokens: 5,
+        ephemeral_5m_input_tokens: 7,
+      },
+      iterations: 1,
+      speed: 'standard',
+    }
+
+    expect(
+      updateUsage(current, {
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: null,
+        output_tokens: 9,
+        server_tool_use: {
+          web_search_requests: 3,
+        },
+        cache_creation: {
+          ephemeral_1h_input_tokens: 19,
+        },
+        iterations: 4,
+        speed: 'fast',
+      } as AnyRecord),
+    ).toMatchObject({
+      input_tokens: 17,
+      cache_creation_input_tokens: 13,
+      cache_read_input_tokens: 11,
+      output_tokens: 9,
+      server_tool_use: {
+        web_search_requests: 3,
+        web_fetch_requests: 4,
+      },
+      cache_creation: {
+        ephemeral_1h_input_tokens: 19,
+        ephemeral_5m_input_tokens: 7,
+      },
+      iterations: 4,
+      speed: 'fast',
+    })
+  })
+
+  test('accumulateUsage sums token totals and carries most-recent scalar fields', () => {
+    const total = {
+      ...harness.usage(),
+      input_tokens: 1,
+      cache_creation_input_tokens: 2,
+      cache_read_input_tokens: 3,
+      output_tokens: 4,
+      server_tool_use: {
+        web_search_requests: 5,
+        web_fetch_requests: 6,
+      },
+      cache_creation: {
+        ephemeral_1h_input_tokens: 7,
+        ephemeral_5m_input_tokens: 8,
+      },
+      service_tier: 'standard',
+      inference_geo: 'us',
+      iterations: 1,
+      speed: 'standard',
+    }
+    const next = {
+      ...harness.usage(),
+      input_tokens: 10,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 30,
+      output_tokens: 40,
+      server_tool_use: {
+        web_search_requests: 50,
+        web_fetch_requests: 60,
+      },
+      cache_creation: {
+        ephemeral_1h_input_tokens: 70,
+        ephemeral_5m_input_tokens: 80,
+      },
+      service_tier: 'priority',
+      inference_geo: 'eu',
+      iterations: 3,
+      speed: 'fast',
+    }
+
+    expect(accumulateUsage(total, next)).toMatchObject({
+      input_tokens: 11,
+      cache_creation_input_tokens: 22,
+      cache_read_input_tokens: 33,
+      output_tokens: 44,
+      server_tool_use: {
+        web_search_requests: 55,
+        web_fetch_requests: 66,
+      },
+      cache_creation: {
+        ephemeral_1h_input_tokens: 77,
+        ephemeral_5m_input_tokens: 88,
+      },
+      service_tier: 'priority',
+      inference_geo: 'eu',
+      iterations: 3,
+      speed: 'fast',
+    })
+  })
+
+  test('cleanupStream aborts live streams and ignores undefined or already-broken streams', () => {
+    const controller = new AbortController()
+    cleanupStream({ controller } as AnyRecord)
+    expect(controller.signal.aborted).toBe(true)
+
+    expect(() => cleanupStream(undefined)).not.toThrow()
+    expect(() =>
+      cleanupStream({
+        controller: {
+          signal: { aborted: false },
+          abort: () => {
+            throw new Error('already closed')
+          },
+        },
+      } as AnyRecord),
+    ).not.toThrow()
+  })
+
+  test('getMaxOutputTokensForModel respects bounded environment overrides', () => {
+    expect(getMaxOutputTokensForModel('test-model')).toBe(4096)
+
+    process.env.AGENC_MAX_OUTPUT_TOKENS = '8192'
+    expect(getMaxOutputTokensForModel('test-model')).toBe(8192)
+
+    process.env.AGENC_MAX_OUTPUT_TOKENS = '999999'
+    expect(getMaxOutputTokensForModel('test-model')).toBe(128000)
+  })
+})
+
+describe('provider API requests', () => {
+  test('verifyApiKey skips network verification for non-interactive sessions', async () => {
+    await expect(verifyApiKey('test-key', true)).resolves.toBe(true)
+    expect(harness.getproviderClient).not.toHaveBeenCalled()
+  })
+
+  test('verifyApiKey sends a minimal test message and returns false for invalid credentials', async () => {
+    await expect(verifyApiKey('test-key', false)).resolves.toBe(true)
+
+    expect(harness.getClientCalls[0]).toMatchObject({
+      apiKey: 'test-key',
+      maxRetries: 3,
+      model: 'small-fast-model',
+      source: 'verify_api_key',
+    })
+    expect(harness.createCalls[0].params).toMatchObject({
+      model: 'small-fast-model',
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'test' }],
+      temperature: 1,
+      betas: ['model-beta'],
+    })
+
+    resetHarness()
+    harness.createError = new Error(
+      '{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+    )
+
+    await expect(verifyApiKey('bad-key', false)).resolves.toBe(false)
+  })
+
+  test('queryModelWithStreaming assembles request params, yields stream events, and mutates final usage onto the assistant message', async () => {
+    harness.streamEvents = textStreamEvents('hello from stream')
+    harness.responseHeaders = { 'x-litellm-model-id': 'gateway-model' }
+
+    const seen: AnyRecord[] = []
+    for await (const event of queryModelWithStreaming({
+      messages: [userMessage()],
+      systemPrompt: asSystemPrompt(['system one']),
+      thinkingConfig: { type: 'disabled' },
+      tools: [],
+      signal: new AbortController().signal,
+      options: baseOptions({
+        maxOutputTokensOverride: 1200,
+        outputFormat: { type: 'json_schema', schema: { type: 'object' } },
+        taskBudget: { total: 100, remaining: 42 },
+      }),
+    })) {
+      seen.push(event as AnyRecord)
+    }
+
+    const assistant = seen.find(event => event.type === 'assistant')
+    expect(assistant).toMatchObject({
+      requestId: 'req_stream_1',
+      message: {
+        role: 'assistant',
+        model: 'test-model',
+        content: [{ type: 'text', text: 'hello from stream' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 7,
+          cache_read_input_tokens: 3,
+          output_tokens: 5,
+          server_tool_use: {
+            web_search_requests: 2,
+          },
+        },
+      },
+    })
+    expect(seen.filter(event => event.type === 'stream_event')).toHaveLength(
+      textStreamEvents().length,
+    )
+
+    const streamingCall = harness.createCalls.find(
+      ({ params }: AnyRecord) => params.stream === true,
+    )
+    expect(streamingCall.params).toMatchObject({
+      model: 'normalized-test-model',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'hello',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ],
+      max_tokens: 1200,
+      stream: true,
+      output_config: {
+        format: { type: 'json_schema', schema: { type: 'object' } },
+        task_budget: { type: 'tokens', total: 100, remaining: 42 },
+      },
+    })
+    expect(streamingCall.params.system.map((block: AnyRecord) => block.text)).toEqual([
+      'attr:fingerprint',
+      'system-prefix',
+      'system one',
+    ])
+    expect(streamingCall.params.betas).toContain('structured-outputs-2025-12-15')
+    expect(streamingCall.options).toMatchObject({
+      signal: expect.any(AbortSignal),
+      headers: {
+        'x-client-request-id': expect.any(String),
+      },
+    })
+    expect(harness.logAPISuccessAndDuration).toHaveBeenCalled()
+  })
+
+  test('queryModelWithStreaming falls back to nonstreaming when a stream ends before message_start', async () => {
+    const onStreamingFallback = vi.fn()
+    harness.streamEvents = []
+    harness.nonStreamingResponse = {
+      id: 'msg_fallback',
+      type: 'message',
+      role: 'assistant',
+      model: 'test-model',
+      content: [{ type: 'text', text: 'fallback ok' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        ...harness.usage(),
+        input_tokens: 3,
+        output_tokens: 2,
+      },
+    }
+
+    const seen: AnyRecord[] = []
+    for await (const event of queryModelWithStreaming({
+      messages: [userMessage()],
+      systemPrompt: asSystemPrompt(['fallback system']),
+      thinkingConfig: { type: 'disabled' },
+      tools: [],
+      signal: new AbortController().signal,
+      options: baseOptions({ onStreamingFallback }),
+    })) {
+      seen.push(event as AnyRecord)
+    }
+
+    expect(onStreamingFallback).toHaveBeenCalledOnce()
+    expect(seen).toContainEqual(
+      expect.objectContaining({
+        type: 'assistant',
+        message: expect.objectContaining({
+          content: [{ type: 'text', text: 'fallback ok' }],
+        }),
+      }),
+    )
+    expect(harness.createCalls.map((call: AnyRecord) => call.params.stream)).toEqual([
+      true,
+      undefined,
+    ])
+  })
+
+  test('queryHaiku and queryWithModel delegate through the nonstreaming query pipeline', async () => {
+    harness.streamEvents = textStreamEvents('haiku path')
+    const haiku = await queryHaiku({
+      systemPrompt: asSystemPrompt(['haiku system']),
+      userPrompt: 'haiku prompt',
+      outputFormat: { type: 'json_schema', schema: { type: 'object' } },
+      signal: new AbortController().signal,
+      options: {
+        isNonInteractiveSession: true,
+        querySource: 'sdk',
+        agents: [],
+        hasAppendSystemPrompt: false,
+        mcpTools: [],
+      },
+    })
+
+    expect(haiku.message.content).toEqual([
+      { type: 'text', text: 'haiku path' },
+    ])
+    expect(
+      harness.createCalls.some(
+        ({ params }: AnyRecord) => params.model === 'normalized-small-fast-model',
+      ),
+    ).toBe(true)
+
+    resetHarness()
+    harness.streamEvents = textStreamEvents('specific model path')
+    const specific = await queryWithModel({
+      systemPrompt: asSystemPrompt(['model system']),
+      userPrompt: 'model prompt',
+      signal: new AbortController().signal,
+      options: {
+        ...baseOptions(),
+        model: 'custom-model',
+      },
+    })
+
+    expect(specific.message.content).toEqual([
+      { type: 'text', text: 'specific model path' },
+    ])
+    expect(
+      harness.createCalls.some(
+        ({ params }: AnyRecord) => params.model === 'normalized-custom-model',
+      ),
+    ).toBe(true)
+  })
+})

--- a/runtime/tests/services/api/sessionIngress.test.ts
+++ b/runtime/tests/services/api/sessionIngress.test.ts
@@ -1,0 +1,476 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UUID } from "node:crypto";
+import axios from "axios";
+
+import { resetStateForTests } from "../../../src/bootstrap/state.js";
+import {
+  appendSessionLog,
+  clearAllSessions,
+  clearSession,
+  getSessionLogs,
+} from "../../../src/services/api/sessionIngress.js";
+import type { TranscriptMessage } from "../../../src/types/logs.js";
+
+vi.mock("../../../src/utils/sleep.js", () => ({
+  sleep: async () => undefined,
+}));
+
+const tempDirs: string[] = [];
+const sessionId = "00000000-0000-4000-8000-000000000777";
+const originalSessionAccessToken = process.env.AGENC_SESSION_ACCESS_TOKEN;
+const originalAfterLastCompact = process.env.AGENC_AFTER_LAST_COMPACT;
+const originalTokenFile = process.env.AGENC_SESSION_INGRESS_TOKEN_FILE;
+const originalTokenFd = process.env.AGENC_WEBSOCKET_AUTH_FILE_DESCRIPTOR;
+
+function id(n: number): UUID {
+  return `00000000-0000-4000-8000-${String(n).padStart(12, "0")}` as UUID;
+}
+
+function transcriptEntry(
+  uuid: UUID,
+  parentUuid: UUID | null = null,
+): TranscriptMessage {
+  return {
+    type: "user",
+    uuid,
+    parentUuid,
+    timestamp: "2026-04-02T00:00:00.000Z",
+    cwd: "/tmp",
+    userType: "external",
+    sessionId,
+    version: "test",
+    isSidechain: false,
+    isMeta: false,
+    message: {
+      role: "user",
+      content: `message ${uuid}`,
+    },
+  } as TranscriptMessage;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startIngressServer(
+  handler: (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ) => void | Promise<void>,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((request, response) => {
+    void Promise.resolve(handler(request, response)).catch((error) => {
+      response.statusCode = 500;
+      response.end(String(error));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/session`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function restoreOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function forceNoSessionToken(): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "agenc-session-ingress-token-"));
+  tempDirs.push(dir);
+  delete process.env.AGENC_SESSION_ACCESS_TOKEN;
+  delete process.env.AGENC_WEBSOCKET_AUTH_FILE_DESCRIPTOR;
+  process.env.AGENC_SESSION_INGRESS_TOKEN_FILE = join(dir, "missing-token");
+  resetStateForTests();
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  clearAllSessions();
+  resetStateForTests();
+  restoreOptionalEnv("AGENC_SESSION_ACCESS_TOKEN", originalSessionAccessToken);
+  restoreOptionalEnv("AGENC_AFTER_LAST_COMPACT", originalAfterLastCompact);
+  restoreOptionalEnv("AGENC_SESSION_INGRESS_TOKEN_FILE", originalTokenFile);
+  restoreOptionalEnv("AGENC_WEBSOCKET_AUTH_FILE_DESCRIPTOR", originalTokenFd);
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("does not call remote ingress without an auth token", async () => {
+  await forceNoSessionToken();
+  let requestCount = 0;
+  const server = await startIngressServer((_request, response) => {
+    requestCount += 1;
+    response.statusCode = 500;
+    response.end();
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(1)), server.url)).resolves.toBe(false);
+    await expect(getSessionLogs(sessionId, server.url)).resolves.toBeNull();
+    expect(requestCount).toBe(0);
+  } finally {
+    await server.close();
+  }
+});
+
+test("fetches session logs with bearer auth and adopts the remote last uuid", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  process.env.AGENC_AFTER_LAST_COMPACT = "1";
+  resetStateForTests();
+  const remoteEntries = [transcriptEntry(id(10)), transcriptEntry(id(11), id(10))];
+  const requests: Array<{
+    method: string | undefined;
+    url: string | undefined;
+    authorization: string | undefined;
+    lastUuid: string | undefined;
+    bodyUuid?: unknown;
+  }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    requests.push({
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    if (request.method === "GET") {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ loglines: remoteEntries }));
+      return;
+    }
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    requests.at(-1)!.bodyUuid = body.uuid;
+    response.statusCode = 201;
+    response.end("{}");
+  });
+
+  try {
+    await expect(getSessionLogs(sessionId, server.url)).resolves.toEqual(remoteEntries);
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(12), id(11)), server.url)).resolves.toBe(true);
+    expect(requests).toEqual([
+      {
+        method: "GET",
+        url: "/session?after_last_compact=true",
+        authorization: "Bearer session-token",
+        lastUuid: undefined,
+      },
+      {
+        method: "PUT",
+        url: "/session",
+        authorization: "Bearer session-token",
+        lastUuid: id(11),
+        bodyUuid: id(12),
+      },
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("serializes appends and advances Last-Uuid headers", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const putRequests: Array<{ uuid: unknown; lastUuid: string | undefined }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    putRequests.push({
+      uuid: body.uuid,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    inFlight -= 1;
+    response.statusCode = 201;
+    response.end("{}");
+  });
+
+  try {
+    await expect(
+      Promise.all([
+        appendSessionLog(sessionId, transcriptEntry(id(20)), server.url),
+        appendSessionLog(sessionId, transcriptEntry(id(21), id(20)), server.url),
+      ]),
+    ).resolves.toEqual([true, true]);
+    expect(maxInFlight).toBe(1);
+    expect(putRequests).toEqual([
+      { uuid: id(20), lastUuid: undefined },
+      { uuid: id(21), lastUuid: id(20) },
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("recovers from a 409 conflict by adopting the server last uuid header", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const putRequests: Array<{ uuid: unknown; lastUuid: string | undefined }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    putRequests.push({
+      uuid: body.uuid,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    if (putRequests.length === 1) {
+      response.statusCode = 409;
+      response.setHeader("x-last-uuid", id(30));
+      response.end("{}");
+      return;
+    }
+    response.statusCode = 201;
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(31), id(30)), server.url)).resolves.toBe(true);
+    expect(putRequests).toEqual([
+      { uuid: id(31), lastUuid: undefined },
+      { uuid: id(31), lastUuid: id(30) },
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("recovers from a 409 conflict by refetching the remote session head", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const requests: Array<{
+    method: string | undefined;
+    uuid?: unknown;
+    lastUuid: string | undefined;
+  }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    if (request.method === "GET") {
+      requests.push({
+        method: request.method,
+        lastUuid: request.headers["last-uuid"] as string | undefined,
+      });
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ loglines: [transcriptEntry(id(40))] }));
+      return;
+    }
+
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    requests.push({
+      method: request.method,
+      uuid: body.uuid,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    if (requests.length === 1) {
+      response.statusCode = 409;
+      response.end("{}");
+      return;
+    }
+    response.statusCode = 201;
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(41), id(40)), server.url)).resolves.toBe(true);
+    expect(requests).toEqual([
+      { method: "PUT", uuid: id(41), lastUuid: undefined },
+      { method: "GET", lastUuid: undefined },
+      { method: "PUT", uuid: id(41), lastUuid: id(40) },
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("treats a duplicate 409 entry as already persisted", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const putRequests: Array<{ uuid: unknown; lastUuid: string | undefined }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    putRequests.push({
+      uuid: body.uuid,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    response.statusCode = 409;
+    response.setHeader("x-last-uuid", id(50));
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(50)), server.url)).resolves.toBe(true);
+    expect(putRequests).toEqual([{ uuid: id(50), lastUuid: undefined }]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("returns false for unauthorized appends", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const server = await startIngressServer((_request, response) => {
+    response.statusCode = 401;
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(60)), server.url)).resolves.toBe(false);
+  } finally {
+    await server.close();
+  }
+});
+
+test("returns false when a 409 conflict cannot discover a server head", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const requests: Array<{ method: string | undefined; lastUuid: string | undefined }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    requests.push({
+      method: request.method,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    if (request.method === "GET") {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ loglines: [] }));
+      return;
+    }
+
+    await readRequestBody(request);
+    response.statusCode = 409;
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({ error: { message: "chain mismatch" } }));
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(70)), server.url)).resolves.toBe(false);
+    expect(requests).toEqual([
+      { method: "PUT", lastUuid: undefined },
+      { method: "GET", lastUuid: undefined },
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("uses the default message when an unrecoverable 409 has no error payload", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  let requestCount = 0;
+  const server = await startIngressServer(async (request, response) => {
+    requestCount += 1;
+    if (request.method === "GET") {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ loglines: [] }));
+      return;
+    }
+
+    await readRequestBody(request);
+    response.statusCode = 409;
+    response.setHeader("Content-Type", "application/json");
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(75)), server.url)).resolves.toBe(false);
+    expect(requestCount).toBe(2);
+  } finally {
+    await server.close();
+  }
+});
+
+test("handles missing, invalid, unauthorized, and rejected log fetches", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const statuses = [200, 404, 401, 403];
+  const server = await startIngressServer((_request, response) => {
+    const status = statuses.shift() ?? 500;
+    response.statusCode = status;
+    response.setHeader("Content-Type", "application/json");
+    if (status === 200) {
+      response.end(JSON.stringify({ invalid: true }));
+      return;
+    }
+    response.end("{}");
+  });
+
+  try {
+    await expect(getSessionLogs(sessionId, server.url)).resolves.toBeNull();
+    await expect(getSessionLogs(sessionId, server.url)).resolves.toEqual([]);
+    await expect(getSessionLogs(sessionId, server.url)).resolves.toBeNull();
+    await expect(getSessionLogs(sessionId, server.url)).resolves.toBeNull();
+  } finally {
+    await server.close();
+  }
+});
+
+test("retries retryable append responses until the limit is exhausted", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  let requestCount = 0;
+  const server = await startIngressServer(async (request, response) => {
+    requestCount += 1;
+    await readRequestBody(request);
+    response.statusCode = 429;
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(80)), server.url)).resolves.toBe(false);
+    expect(requestCount).toBe(10);
+  } finally {
+    await server.close();
+  }
+});
+
+test("retries network append errors until the limit is exhausted", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const putSpy = vi.spyOn(axios, "put").mockRejectedValue(new Error("socket closed"));
+
+  await expect(
+    appendSessionLog(sessionId, transcriptEntry(id(85)), "http://127.0.0.1/session"),
+  ).resolves.toBe(false);
+  expect(putSpy).toHaveBeenCalledTimes(10);
+});
+
+test("clears cached append state for a single session", async () => {
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  resetStateForTests();
+  const putRequests: Array<{ uuid: unknown; lastUuid: string | undefined }> = [];
+  const server = await startIngressServer(async (request, response) => {
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    putRequests.push({
+      uuid: body.uuid,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    response.statusCode = 200;
+    response.end("{}");
+  });
+
+  try {
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(90)), server.url)).resolves.toBe(true);
+    clearSession(sessionId);
+    await expect(appendSessionLog(sessionId, transcriptEntry(id(91)), server.url)).resolves.toBe(true);
+    expect(putRequests).toEqual([
+      { uuid: id(90), lastUuid: undefined },
+      { uuid: id(91), lastUuid: undefined },
+    ]);
+  } finally {
+    await server.close();
+  }
+});

--- a/runtime/tests/services/lsp/LSPClient.test.ts
+++ b/runtime/tests/services/lsp/LSPClient.test.ts
@@ -52,6 +52,14 @@ process.stdin.on("data", chunk => {
 });
 `;
 
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 describe("createLSPClient", () => {
   test("clears closed process state so a crashed server can be started again", async () => {
     let crashCount = 0;
@@ -62,11 +70,11 @@ describe("createLSPClient", () => {
     });
 
     await client.start(process.execPath, ["-e", EXITING_SERVER]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => crashCount === 1);
     expect(crashCount).toBe(1);
 
     await client.start(process.execPath, ["-e", EXITING_SERVER]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => crashCount === 2);
     expect(crashCount).toBe(2);
   });
 
@@ -79,13 +87,13 @@ describe("createLSPClient", () => {
     });
 
     await client.start(process.execPath, ["-e", CLEAN_EXIT_SERVER]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => terminalEvents.length === 1);
     expect(terminalEvents).toEqual([
       "LSP server clean-exit exited unexpectedly with code 0",
     ]);
 
     await client.start(process.execPath, ["-e", CLEAN_EXIT_SERVER]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => terminalEvents.length === 2);
     expect(terminalEvents).toHaveLength(2);
   });
 
@@ -98,7 +106,7 @@ describe("createLSPClient", () => {
     });
 
     await client.start(process.execPath, ["-e", CLOSE_CONNECTION_SERVER]);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => terminalEvents.length === 1);
 
     expect(terminalEvents).toEqual([
       "LSP server close connection closed unexpectedly",

--- a/runtime/tests/services/mcp/client-sdk-setup.test.ts
+++ b/runtime/tests/services/mcp/client-sdk-setup.test.ts
@@ -1,0 +1,2729 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { afterEach, test, vi } from 'vitest'
+
+type FakeTransport = {
+  serverName: string
+  closed?: boolean
+  close?: () => Promise<void>
+}
+
+type FakeSdkTransport =
+  | FakeTransport
+  | FakeStdioTransport
+  | FakeSseTransport
+  | FakeHttpTransport
+  | FakeWebSocketTransport
+
+type FakeRequestHandler = {
+  schema: unknown
+  handler: (request?: unknown) => unknown
+}
+
+const fakeClients: FakeClient[] = []
+const fakeStdioTransports: FakeStdioTransport[] = []
+const fakeSseTransports: FakeSseTransport[] = []
+const fakeHttpTransports: FakeHttpTransport[] = []
+const fakeWebSocketClients: FakeWebSocketClient[] = []
+const fakeWebSocketTransports: FakeWebSocketTransport[] = []
+const fakeChromeMcpServers: Array<{
+  context: unknown
+  connectedTransport?: unknown
+  closed: boolean
+}> = []
+let nextClientOnerror: ((error: Error) => void) | undefined
+let nextClientOnclose: (() => void) | undefined
+const requestLog: Array<{ serverName: string; method: string }> = []
+const fetchLog: Array<{ url: string; method: string; accept?: string | null }> =
+  []
+const nativeFetchLog: Array<{
+  url: string
+  headers: Record<string, string>
+  dispatcher?: unknown
+}> = []
+const tempDirs: string[] = []
+const originalLargeOutputFiles = process.env.ENABLE_MCP_LARGE_OUTPUT_FILES
+const originalMcpTimeout = process.env.MCP_TIMEOUT
+const mutableGlobal = globalThis as unknown as {
+  Bun?: unknown
+  WebSocket?: unknown
+  fetch?: typeof fetch
+}
+const originalBun = mutableGlobal.Bun
+const originalWebSocket = mutableGlobal.WebSocket
+const originalFetch = mutableGlobal.fetch
+
+function installNativeFetchRecorder(responseText = 'ok'): void {
+  mutableGlobal.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit,
+  ) => {
+    const headers = new Headers(init?.headers)
+    nativeFetchLog.push({
+      url:
+        typeof input === 'string' || input instanceof URL
+          ? String(input)
+          : input.url,
+      headers: Object.fromEntries(headers.entries()),
+      dispatcher: (init as RequestInit & { dispatcher?: unknown })?.dispatcher,
+    })
+    return new Response(responseText)
+  }) as typeof fetch
+}
+
+class FakeClient {
+  readonly clientInfo: unknown
+  private serverName = ''
+  closed = false
+  onerror?: (error: Error) => void
+  onclose?: () => void
+  readonly handlers: FakeRequestHandler[] = []
+
+  constructor(clientInfo: unknown) {
+    this.clientInfo = clientInfo
+    this.onerror = nextClientOnerror
+    this.onclose = nextClientOnclose
+    nextClientOnerror = undefined
+    nextClientOnclose = undefined
+    fakeClients.push(this)
+  }
+
+  async connect(transport: FakeSdkTransport): Promise<void> {
+    this.serverName =
+      'serverName' in transport
+        ? transport.serverName
+        : 'kind' in transport
+          ? `${transport.kind}-demo`
+          : transport.command === 'broken-server'
+            ? 'broken'
+            : transport.command === 'hanging-server'
+              ? 'hanging'
+              : transport.command === 'stderr-server'
+                ? 'stderr'
+                : transport.command === 'long-instructions-server'
+                  ? 'long-instructions'
+                  : 'stdio-demo'
+    if (this.serverName === 'broken') {
+      if ('stderr' in transport) {
+        transport.stderr.emit('data', Buffer.from('boot failed'))
+      }
+      throw new Error('connect failed')
+    }
+    if (this.serverName === 'hanging') {
+      return new Promise(() => {})
+    }
+    if (this.serverName === 'stderr' && 'stderr' in transport) {
+      transport.stderr.emit('data', Buffer.from('startup warning'))
+    }
+    if ('kind' in transport && String(transport.url).includes('connect-401')) {
+      throw Object.assign(new Error('proxy unauthorized'), { code: 401 })
+    }
+    if ('kind' in transport && String(transport.url).includes('auth')) {
+      throw new UnauthorizedError('needs auth')
+    }
+  }
+
+  getServerCapabilities(): Record<string, unknown> {
+    return this.serverName === 'tooling' || this.serverName === 'stdio-demo'
+      ? { tools: {}, resources: { subscribe: true } }
+      : {}
+  }
+
+  getServerVersion(): Record<string, string> {
+    return { name: this.serverName, version: '1.0.0' }
+  }
+
+  getInstructions(): string {
+    if (this.serverName === 'long-instructions') {
+      return 'x'.repeat(2100)
+    }
+    return `instructions for ${this.serverName}`
+  }
+
+  setRequestHandler(
+    schema: unknown,
+    handler: (request?: unknown) => unknown,
+  ): void {
+    this.handlers.push({ schema, handler })
+  }
+
+  async request(request: { method: string }): Promise<unknown> {
+    requestLog.push({ serverName: this.serverName, method: request.method })
+    if (request.method === 'tools/list') {
+      return {
+        tools: [{ name: 'inspect', inputSchema: { type: 'object' } }],
+      }
+    }
+    throw new Error(`unexpected request ${request.method}`)
+  }
+
+  async notification(): Promise<void> {}
+
+  async close(): Promise<void> {
+    this.closed = true
+    this.onclose?.()
+  }
+}
+
+class FakeStdioTransport {
+  readonly stderr = new EventEmitter()
+  readonly command: string
+  readonly args: string[]
+  closed = false
+  pid?: number
+
+  constructor(options: { command: string; args?: string[] }) {
+	    this.command = options.command
+	    this.args = options.args ?? []
+	    if (options.command === 'pid-server') {
+	      this.pid = 4242
+	    }
+	    if (options.command === 'throw-pid-server') {
+	      Object.defineProperty(this, 'pid', {
+	        get: () => {
+	          throw new Error('pid unavailable')
+	        },
+	      })
+	    }
+	    fakeStdioTransports.push(this)
+	  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+}
+
+class FakeSseTransport {
+  readonly kind = 'sse'
+  readonly url: URL
+  readonly options: unknown
+  closed = false
+
+  constructor(url: URL, options?: unknown) {
+    this.url = url
+    this.options = options
+    fakeSseTransports.push(this)
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+}
+
+class FakeHttpTransport {
+  readonly kind = 'http'
+  readonly url: URL
+  readonly options: unknown
+  closed = false
+
+  constructor(url: URL, options?: unknown) {
+    this.url = url
+    this.options = options
+    fakeHttpTransports.push(this)
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+}
+
+class FakeWebSocketClient {
+  readonly url: string
+  readonly options: unknown
+  readonly protocols: unknown
+
+  constructor(url: string, protocolsOrOptions?: unknown, options?: unknown) {
+    this.url = url
+    this.protocols = options === undefined ? undefined : protocolsOrOptions
+    this.options = options ?? protocolsOrOptions
+    fakeWebSocketClients.push(this)
+  }
+}
+
+class FakeWebSocketTransport {
+  readonly kind = 'ws'
+  readonly client: FakeWebSocketClient
+  closed = false
+
+  constructor(client: FakeWebSocketClient) {
+    this.client = client
+    fakeWebSocketTransports.push(this)
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+}
+
+afterEach(async () => {
+  fakeClients.length = 0
+  fakeStdioTransports.length = 0
+  fakeSseTransports.length = 0
+  fakeHttpTransports.length = 0
+  fakeWebSocketClients.length = 0
+  fakeWebSocketTransports.length = 0
+  fakeChromeMcpServers.length = 0
+  nextClientOnerror = undefined
+  nextClientOnclose = undefined
+  requestLog.length = 0
+  fetchLog.length = 0
+  nativeFetchLog.length = 0
+  if (originalLargeOutputFiles === undefined) {
+    delete process.env.ENABLE_MCP_LARGE_OUTPUT_FILES
+  } else {
+    process.env.ENABLE_MCP_LARGE_OUTPUT_FILES = originalLargeOutputFiles
+  }
+  if (originalMcpTimeout === undefined) {
+    delete process.env.MCP_TIMEOUT
+  } else {
+    process.env.MCP_TIMEOUT = originalMcpTimeout
+  }
+  if (originalBun === undefined) {
+    delete mutableGlobal.Bun
+  } else {
+    mutableGlobal.Bun = originalBun
+  }
+  if (originalWebSocket === undefined) {
+    delete mutableGlobal.WebSocket
+  } else {
+    mutableGlobal.WebSocket = originalWebSocket
+  }
+  if (originalFetch === undefined) {
+    delete mutableGlobal.fetch
+  } else {
+    mutableGlobal.fetch = originalFetch
+  }
+  vi.doUnmock('@modelcontextprotocol/sdk/client/index.js')
+  vi.doUnmock('@modelcontextprotocol/sdk/client/sse.js')
+  vi.doUnmock('@modelcontextprotocol/sdk/client/stdio.js')
+  vi.doUnmock('@modelcontextprotocol/sdk/client/streamableHttp.js')
+  vi.doUnmock('@modelcontextprotocol/sdk/shared/transport.js')
+  vi.doUnmock('ws')
+  vi.doUnmock('bun:bundle')
+  vi.doUnmock('@ant/agenc-for-chrome-mcp')
+  vi.doUnmock('../../../src/bootstrap/state.js')
+  vi.doUnmock('../../../src/constants/oauth.js')
+  vi.doUnmock('../../../src/services/mcp/config.js')
+  vi.doUnmock('../../../src/services/mcp/elicitationHandler.js')
+  vi.doUnmock('../../../src/services/mcp/InProcessTransport.js')
+  vi.doUnmock('../../../src/services/mcp/agencai.js')
+  vi.doUnmock('../../../src/skills/mcpSkills.js')
+  vi.doUnmock('../../../src/utils/agencInChrome/common.js')
+  vi.doUnmock('../../../src/utils/agencInChrome/mcpServer.js')
+  vi.doUnmock('../../../src/utils/agencInChrome/toolRendering.js')
+  vi.doUnmock('../../../src/utils/agencInChrome/toolRendering.tsx')
+  vi.doUnmock('../../../src/utils/auth.js')
+  vi.doUnmock('../../../src/utils/proxy.js')
+  vi.doUnmock('../../../src/utils/envUtils.js')
+  vi.doUnmock('../../../src/utils/ide.js')
+	  vi.doUnmock('../../../src/utils/mcpNodeWsClient.js')
+	  vi.doUnmock('../../../src/utils/mcpWebSocketTransport.js')
+	  vi.doUnmock('../../../src/utils/mcpValidation.js')
+	  vi.doUnmock('../../../src/utils/secureStorage/macOsKeychainHelpers.js')
+	  vi.doUnmock('../../../src/utils/sleep.js')
+	  vi.doUnmock('../../../src/utils/toolResultStorage.js')
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  vi.resetModules()
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map(dir => rm(dir, { recursive: true, force: true }).catch(() => {})),
+  )
+})
+
+test('setupSdkMcpClients connects SDK clients, fetches tools, and reports failed servers', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+
+  const { setupSdkMcpClients } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await setupSdkMcpClients(
+    {
+      tooling: { type: 'sdk', name: 'tooling' },
+      passive: { type: 'sdk', name: 'passive' },
+      broken: { type: 'sdk', name: 'broken' },
+    },
+    async (_serverName, message) => message,
+  )
+
+  assert.deepEqual(
+    result.clients.map(client => `${client.name}:${client.type}`),
+    ['tooling:connected', 'passive:connected', 'broken:failed'],
+  )
+  assert.deepEqual(
+    result.tools.map(tool => tool.name),
+    ['mcp__tooling__inspect'],
+  )
+  assert.deepEqual(requestLog, [
+    { serverName: 'tooling', method: 'tools/list' },
+  ])
+
+  const connected = result.clients.find(client => client.name === 'tooling')
+  assert.equal(connected?.type, 'connected')
+  if (connected?.type === 'connected') {
+    await connected.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('prefetchAllMcpResources includes MCP skill commands when feature enabled', async () => {
+  vi.resetModules()
+  const skillCalls: string[] = []
+  const deletedSkillCacheKeys: string[] = []
+  const fetchMcpSkillsForClient = Object.assign(
+    async (client: { name: string }) => {
+      skillCalls.push(client.name)
+      return [
+        {
+          type: 'prompt',
+          name: `mcp__${client.name}__skill`,
+          description: 'Skill command',
+          hasUserSpecifiedDescription: false,
+          contentLength: 0,
+          isEnabled: () => true,
+          isHidden: false,
+          isMcp: true,
+          progressMessage: 'running',
+          userFacingName: () => `${client.name}:skill (MCP)`,
+          argNames: [],
+          source: 'mcp',
+          getPromptForCommand: async () => [],
+        },
+      ]
+    },
+    {
+      cache: {
+        delete: (name: string) => {
+          deletedSkillCacheKeys.push(name)
+        },
+      },
+    },
+  )
+  vi.doMock('bun:bundle', () => ({
+    feature: (name: string) => name === 'MCP_SKILLS',
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+  vi.doMock('../../../src/skills/mcpSkills.js', () => ({
+    fetchMcpSkillsForClient,
+  }))
+
+  const { prefetchAllMcpResources } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: [],
+    scope: 'local',
+  } as const
+
+  const first = await prefetchAllMcpResources({ 'stdio-demo': config })
+  const second = await prefetchAllMcpResources({ 'stdio-demo': config })
+
+  assert.deepEqual(
+    first.commands.map(command => command.name),
+    ['mcp__stdio-demo__skill'],
+  )
+  assert.deepEqual(
+    second.commands.map(command => command.name),
+    ['mcp__stdio-demo__skill'],
+  )
+  assert.deepEqual(skillCalls, ['stdio-demo', 'stdio-demo'])
+  const connected = second.clients[0]
+  assert.equal(connected?.type, 'connected')
+  if (connected?.type === 'connected') {
+    await connected.cleanup()
+  }
+  assert.deepEqual(deletedSkillCacheKeys, ['stdio-demo'])
+})
+
+test('prefetchAllMcpResources reports disabled servers before connecting', async () => {
+  vi.resetModules()
+  const disabledChecks = new Map<string, number>()
+  vi.doMock('../../../src/services/mcp/config.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/services/mcp/config.js')>()),
+    isMcpServerDisabled: (name: string) => {
+      const count = disabledChecks.get(name) ?? 0
+      disabledChecks.set(name, count + 1)
+      return name === 'early-disabled' || (name === 'late-disabled' && count > 0)
+    },
+  }))
+
+  const { prefetchAllMcpResources } = await import('./client.js')
+
+  const result = await prefetchAllMcpResources({
+    'early-disabled': {
+      type: 'http',
+      url: 'https://example.test/early',
+      scope: 'local',
+    },
+    'late-disabled': {
+      type: 'stdio',
+      command: 'should-not-spawn',
+      args: [],
+      scope: 'local',
+    },
+  })
+
+  assert.deepEqual(
+    result.clients.map(client => `${client.name}:${client.type}`),
+    ['early-disabled:disabled', 'late-disabled:disabled'],
+  )
+  assert.deepEqual(result.tools, [])
+  assert.deepEqual(result.commands, [])
+  assert.deepEqual(Object.fromEntries(disabledChecks), {
+    'early-disabled': 1,
+    'late-disabled': 2,
+  })
+  assert.equal(fakeClients.length, 0)
+  assert.equal(fakeStdioTransports.length, 0)
+})
+
+test('prefetchAllMcpResources reports a failed client when a server disable check throws during processing', async () => {
+  vi.resetModules()
+  const disabledChecks = new Map<string, number>()
+  vi.doMock('../../../src/services/mcp/config.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/services/mcp/config.js')>()),
+    isMcpServerDisabled: (name: string) => {
+      const count = disabledChecks.get(name) ?? 0
+      disabledChecks.set(name, count + 1)
+      if (name === 'throw-late' && count > 0) {
+        throw new Error('disabled check failed')
+      }
+      return false
+    },
+  }))
+
+  const { prefetchAllMcpResources } = await import('./client.js')
+  const result = await prefetchAllMcpResources({
+    'throw-late': {
+      type: 'stdio',
+      command: 'demo-server',
+      args: [],
+      scope: 'local',
+    },
+  })
+
+  assert.deepEqual(
+    result.clients.map(client => `${client.name}:${client.type}`),
+    ['throw-late:failed'],
+  )
+  assert.deepEqual(result.tools, [])
+  assert.deepEqual(result.commands, [])
+  assert.deepEqual(Object.fromEntries(disabledChecks), { 'throw-late': 2 })
+})
+
+test('prefetchAllMcpResources resolves empty results when batch setup throws', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/services/mcp/config.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/services/mcp/config.js')>()),
+    isMcpServerDisabled: () => {
+      throw new Error('partition failed')
+    },
+  }))
+
+  const { prefetchAllMcpResources } = await import('./client.js')
+  const result = await prefetchAllMcpResources({
+    'throw-early': {
+      type: 'stdio',
+      command: 'demo-server',
+      args: [],
+      scope: 'local',
+    },
+  })
+
+  assert.deepEqual(result, {
+    clients: [],
+    tools: [],
+    commands: [],
+  })
+})
+
+test('reconnectMcpServerImpl handles MCP skills being disabled during lazy lookup', async () => {
+  vi.resetModules()
+  let mcpSkillFeatureCalls = 0
+  vi.doMock('bun:bundle', () => ({
+    feature: (name: string) => {
+      if (name !== 'MCP_SKILLS') return false
+      mcpSkillFeatureCalls += 1
+      return mcpSkillFeatureCalls === 3
+    },
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { clearServerCache, reconnectMcpServerImpl } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: [],
+    scope: 'local',
+  } as const
+
+  await clearServerCache('stdio-demo', config)
+  const result = await reconnectMcpServerImpl('stdio-demo', config)
+
+  assert.equal(result.client.type, 'connected')
+  assert.deepEqual(result.commands, [])
+  assert.equal(mcpSkillFeatureCalls >= 4, true)
+  if (result.client.type === 'connected') {
+    await result.client.cleanup()
+  }
+})
+
+test('prefetchAllMcpResources skips lazy MCP skills when feature disables before import', async () => {
+  vi.resetModules()
+  let mcpSkillFeatureCalls = 0
+  vi.doMock('bun:bundle', () => ({
+    feature: (name: string) => {
+      if (name !== 'MCP_SKILLS') return false
+      mcpSkillFeatureCalls += 1
+      return mcpSkillFeatureCalls === 1
+    },
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { prefetchAllMcpResources } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const result = await prefetchAllMcpResources({
+    'stdio-demo': {
+      type: 'stdio',
+      command: 'demo-server',
+      args: [],
+      scope: 'local',
+    },
+  })
+
+  assert.equal(result.clients[0]?.type, 'connected')
+  assert.deepEqual(result.commands, [])
+  assert.equal(mcpSkillFeatureCalls >= 2, true)
+  const connected = result.clients[0]
+  if (connected?.type === 'connected') {
+    await connected.cleanup()
+  }
+})
+
+test('clearServerCache clears pending lazy MCP skills cache after import resolves', async () => {
+  vi.resetModules()
+  let resolveSkillsModule:
+    | ((module: { fetchMcpSkillsForClient: unknown }) => void)
+    | undefined
+  const deletedSkillCacheKeys: string[] = []
+  const fetchMcpSkillsForClient = Object.assign(
+    async () => [],
+    {
+      cache: {
+        delete: (name: string) => {
+          deletedSkillCacheKeys.push(name)
+        },
+      },
+    },
+  )
+  vi.doMock('bun:bundle', () => ({
+    feature: (name: string) => name === 'MCP_SKILLS',
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+  vi.doMock('../../../src/skills/mcpSkills.js', async () => {
+    return await new Promise(resolve => {
+      resolveSkillsModule = resolve
+    })
+  })
+
+  const { clearServerCache, prefetchAllMcpResources } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: [],
+    scope: 'local',
+  } as const
+
+  const prefetchPromise = prefetchAllMcpResources({ 'stdio-demo': config })
+  for (let attempt = 0; attempt < 50 && !resolveSkillsModule; attempt++) {
+    await Promise.resolve()
+  }
+  assert.ok(resolveSkillsModule)
+  await clearServerCache('stdio-demo', config)
+  resolveSkillsModule({ fetchMcpSkillsForClient })
+  const result = await prefetchPromise
+
+  assert.equal(result.clients[0]?.type, 'connected')
+  assert.equal(deletedSkillCacheKeys.length >= 1, true)
+  assert.equal(deletedSkillCacheKeys.every(name => name === 'stdio-demo'), true)
+})
+
+test('connectToServer creates stdio clients with lifecycle handlers and cleanup', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: ['--flag'],
+    env: { DEMO: '1' },
+    scope: 'local',
+  } as const
+
+  const result = await connectToServer('stdio-demo', config)
+
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  assert.equal(fakeStdioTransports[0]?.command, 'demo-server')
+  assert.deepEqual(fakeStdioTransports[0]?.args, ['--flag'])
+  assert.deepEqual(result.capabilities, {
+    tools: {},
+    resources: { subscribe: true },
+  })
+  assert.deepEqual(result.serverInfo, {
+    name: 'stdio-demo',
+    version: '1.0.0',
+  })
+  assert.equal(result.instructions, 'instructions for stdio-demo')
+  assert.equal(fakeClients[0]?.handlers.length, 2)
+  assert.deepEqual(await fakeClients[0]!.handlers[0]!.handler(), {
+    roots: [{ uri: `file://${process.cwd()}` }],
+  })
+  assert.deepEqual(await fakeClients[0]!.handlers[1]!.handler({}), {
+    action: 'cancel',
+  })
+  for (const message of [
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ECONNREFUSED',
+    'EPIPE',
+    'EHOSTUNREACH',
+    'ESRCH',
+    'spawn missing',
+    'other failure',
+  ]) {
+    fakeClients[0]?.onerror?.(new Error(message))
+  }
+
+  await result.cleanup()
+
+  assert.equal(fakeClients[0]?.closed, true)
+
+  const reconnected = await connectToServer('stdio-demo', config)
+  assert.equal(reconnected.type, 'connected')
+  assert.equal(fakeClients.length, 2)
+  if (reconnected.type === 'connected') {
+    await reconnected.cleanup()
+  }
+  assert.equal(fakeClients[1]?.closed, true)
+})
+
+test('connectToServer logs successful stdio startup stderr before cleanup', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('stderr-stdio', {
+    type: 'stdio',
+    command: 'stderr-server',
+    args: [],
+    scope: 'local',
+  })
+
+  assert.equal(result.type, 'connected')
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup escalates stdio child process termination signals', async () => {
+  vi.resetModules()
+  vi.useFakeTimers()
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('pid-stdio', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  const cleanupPromise = result.cleanup()
+  await vi.advanceTimersByTimeAsync(700)
+  await cleanupPromise
+
+  assert.equal(fakeClients[0]?.closed, true)
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGINT'),
+    true,
+  )
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGTERM'),
+    true,
+  )
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGKILL'),
+    true,
+  )
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 0),
+    true,
+  )
+})
+
+test('connectToServer cleanup handles stdio signal and client close failures', async () => {
+  vi.resetModules()
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      if (signal === 'SIGINT') {
+        throw new Error('sigint denied')
+      }
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('pid-stdio-sigint-fail', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  fakeClients[0]!.close = async () => {
+    throw new Error('client close denied')
+  }
+
+  await result.cleanup()
+
+  assert.deepEqual(killCalls, [{ pid: 4242, signal: 'SIGINT' }])
+})
+
+test('connectToServer cleanup logs stdio client close failures without a child process', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('stdio-close-fail', {
+    type: 'stdio',
+    command: 'demo-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  fakeClients[0]!.close = async () => {
+    throw new Error('stdio client close denied')
+  }
+
+  await result.cleanup()
+})
+
+test('connectToServer cleanup resolves when stdio process exits during monitoring', async () => {
+  vi.resetModules()
+  vi.useFakeTimers()
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      if (signal === 0) {
+        throw new Error('process exited')
+      }
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('pid-stdio-exits', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  const cleanupPromise = result.cleanup()
+  await vi.advanceTimersByTimeAsync(100)
+  await cleanupPromise
+
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 0),
+    true,
+  )
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup resolves when stdio SIGTERM fails', async () => {
+  vi.resetModules()
+  vi.useFakeTimers()
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      if (signal === 'SIGTERM') {
+        throw new Error('sigterm denied')
+      }
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('pid-stdio-sigterm-fail', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  const cleanupPromise = result.cleanup()
+  await vi.advanceTimersByTimeAsync(150)
+  await cleanupPromise
+
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGTERM'),
+    true,
+  )
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup logs stdio SIGKILL failures without rejecting', async () => {
+  vi.resetModules()
+  vi.useFakeTimers()
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      if (signal === 'SIGKILL') {
+        throw new Error('sigkill denied')
+      }
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('pid-stdio-sigkill-fail', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  const cleanupPromise = result.cleanup()
+  await vi.advanceTimersByTimeAsync(700)
+  await cleanupPromise
+
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGKILL'),
+    true,
+  )
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup resolves when stdio process exits after SIGINT grace period', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/utils/sleep.js', () => ({
+    sleep: async () => {},
+  }))
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      if (signal === 0) {
+        throw new Error('process exited after sigint')
+      }
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const result = await connectToServer('pid-stdio-exits-after-sigint', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  await result.cleanup()
+
+  assert.deepEqual(killCalls, [
+    { pid: 4242, signal: 'SIGINT' },
+    { pid: 4242, signal: 0 },
+  ])
+})
+
+test('connectToServer cleanup resolves when stdio process exits before SIGKILL', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/utils/sleep.js', () => ({
+    sleep: async () => {},
+  }))
+  let zeroChecks = 0
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = []
+  vi.spyOn(process, 'kill').mockImplementation(
+    ((pid: number, signal?: NodeJS.Signals | 0) => {
+      killCalls.push({ pid, signal })
+      if (signal === 0) {
+        zeroChecks += 1
+        if (zeroChecks >= 2) {
+          throw new Error('process exited before sigkill')
+        }
+      }
+      return true
+    }) as typeof process.kill,
+  )
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const result = await connectToServer('pid-stdio-exits-before-sigkill', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  await result.cleanup()
+
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGTERM'),
+    true,
+  )
+  assert.equal(
+    killCalls.some(call => call.pid === 4242 && call.signal === 'SIGKILL'),
+    false,
+  )
+})
+
+test('connectToServer cleanup resolves when stdio escalation sleep throws', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/utils/sleep.js', () => ({
+    sleep: async () => {
+      throw new Error('sleep failed')
+    },
+  }))
+  vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill)
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const result = await connectToServer('pid-stdio-sleep-fail', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  await result.cleanup()
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup uses failsafe when stdio escalation never settles', async () => {
+  vi.resetModules()
+  vi.useFakeTimers()
+  vi.doMock('../../../src/utils/sleep.js', () => ({
+    sleep: async () => await new Promise(() => {}),
+  }))
+  vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill)
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const result = await connectToServer('pid-stdio-failsafe', {
+    type: 'stdio',
+    command: 'pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  const cleanupPromise = result.cleanup()
+  await vi.advanceTimersByTimeAsync(650)
+  await cleanupPromise
+
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup logs stdio pid access failures without rejecting', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const result = await connectToServer('pid-stdio-throws-pid', {
+    type: 'stdio',
+    command: 'throw-pid-server',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  await result.cleanup()
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer preserves original lifecycle handlers during remote close retries', async () => {
+  vi.resetModules()
+  const originalErrors: string[] = []
+  let originalCloseCount = 0
+  nextClientOnerror = error => originalErrors.push(error.message)
+  nextClientOnclose = () => {
+    originalCloseCount += 1
+  }
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+    SSEClientTransport: FakeSseTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('sse-lifecycle', {
+    type: 'sse',
+    url: 'https://example.test/lifecycle',
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+	  const client = fakeClients[0]!
+	  client.close = async () => {
+	    client.closed = true
+	    client.onclose?.()
+	    throw new Error('close failed')
+	  }
+
+	  client.onerror?.(new Error('temporary blip'))
+	  client.onerror?.(new Error('Maximum reconnection attempts reached'))
+	  client.onerror?.(new Error('Maximum reconnection attempts reached'))
+	  await Promise.resolve()
+  await Promise.resolve()
+
+	  assert.equal(client.closed, true)
+	  assert.deepEqual(originalErrors, [
+	    'temporary blip',
+	    'Maximum reconnection attempts reached',
+	    'Maximum reconnection attempts reached',
+	  ])
+  assert.equal(originalCloseCount, 1)
+})
+
+test('connectToServer forwards HTTP session expiry to the original error handler', async () => {
+  vi.resetModules()
+  const originalErrors: string[] = []
+  nextClientOnerror = error => originalErrors.push(error.message)
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+    StreamableHTTPClientTransport: FakeHttpTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('http-session-expired', {
+    type: 'http',
+    url: 'https://example.test/session-expired',
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+
+  fakeClients[0]?.onerror?.(
+    Object.assign(
+      new Error('{"error":{"code":-32001,"message":"Session not found"}}'),
+      { code: 404 },
+    ),
+  )
+  await Promise.resolve()
+
+  assert.deepEqual(originalErrors, [
+    '{"error":{"code":-32001,"message":"Session not found"}}',
+  ])
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('callMCPToolWithUrlElicitationRetry returns hook-declined URL elicitations', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/services/mcp/elicitationHandler.js', () => ({
+    runElicitationHooks: async () => ({ action: 'decline' }),
+    runElicitationResultHooks: async (
+      _serverName: string,
+      result: { action: string },
+    ) => result,
+  }))
+
+  const { callMCPToolWithUrlElicitationRetry } = await import('./client.js')
+  const result = await callMCPToolWithUrlElicitationRetry({
+    client: {
+      name: 'browser',
+      type: 'connected',
+      capabilities: {},
+      config: { type: 'stdio', command: 'browser', scope: 'local' },
+      cleanup: async () => {},
+      client: {},
+    } as never,
+    clientConnection: {
+      name: 'browser',
+      type: 'connected',
+      capabilities: {},
+      config: { type: 'stdio', command: 'browser', scope: 'local' },
+      cleanup: async () => {},
+      client: {},
+    } as never,
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: () => {
+      throw new Error('hook-declined URL elicitation should not queue')
+    },
+    callToolFn: async () => {
+      throw new McpError(ErrorCode.UrlElicitationRequired, 'needs url', {
+        elicitations: [
+          {
+            mode: 'url',
+            url: 'https://example.test/hook-decline',
+            elicitationId: 'hook-decline',
+            message: 'Open hook decline URL',
+          },
+        ],
+      })
+    },
+  })
+
+  assert.equal(
+    result.content,
+    'URL elicitation was declined by a hook. The tool "open-url" could not complete because it requires the user to open a URL.',
+  )
+})
+
+test('callMCPToolWithUrlElicitationRetry retries hook-accepted URL elicitations without queueing', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/services/mcp/elicitationHandler.js', () => ({
+    runElicitationHooks: async () => ({ action: 'accept' }),
+    runElicitationResultHooks: async (
+      _serverName: string,
+      result: { action: string },
+    ) => result,
+  }))
+
+  const { callMCPToolWithUrlElicitationRetry } = await import('./client.js')
+  let calls = 0
+  const result = await callMCPToolWithUrlElicitationRetry({
+    client: {
+      name: 'browser',
+      type: 'connected',
+      capabilities: {},
+      config: { type: 'stdio', command: 'browser', scope: 'local' },
+      cleanup: async () => {},
+      client: {},
+    } as never,
+    clientConnection: {
+      name: 'browser',
+      type: 'connected',
+      capabilities: {},
+      config: { type: 'stdio', command: 'browser', scope: 'local' },
+      cleanup: async () => {},
+      client: {},
+    } as never,
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: () => {
+      throw new Error('hook-accepted URL elicitation should not queue')
+    },
+    callToolFn: async () => {
+      calls += 1
+      if (calls === 1) {
+        throw new McpError(ErrorCode.UrlElicitationRequired, 'needs url', {
+          elicitations: [
+            {
+              mode: 'url',
+              url: 'https://example.test/hook-accept',
+              elicitationId: 'hook-accept',
+              message: 'Open hook accept URL',
+            },
+          ],
+        })
+      }
+      return { content: 'opened by hook' }
+    },
+  })
+
+  assert.deepEqual(result, { content: 'opened by hook' })
+  assert.equal(calls, 2)
+})
+
+test('reconnectMcpServerImpl rebuilds connected clients with tools and resource tools', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { reconnectMcpServerImpl } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: [],
+    scope: 'local',
+  } as const
+
+  const result = await reconnectMcpServerImpl('stdio-demo', config)
+
+  assert.equal(result.client.type, 'connected')
+  assert.deepEqual(
+    result.tools.map(tool => tool.name),
+    ['mcp__stdio-demo__inspect', 'ListMcpResourcesTool', 'ReadMcpResourceTool'],
+  )
+  assert.deepEqual(result.commands, [])
+  assert.equal(fakeClients.length, 2)
+  assert.equal(fakeClients[0]?.closed, true)
+  if (result.client.type === 'connected') {
+    await result.client.cleanup()
+  }
+  assert.equal(fakeClients[1]?.closed, true)
+})
+
+test('connectToServer creates in-process Chrome MCP clients without spawning stdio', async () => {
+  vi.resetModules()
+  const linkedClientTransport: FakeTransport = {
+    serverName: 'chrome-in-process',
+    closed: false,
+    close: async () => {
+      linkedClientTransport.closed = true
+    },
+  }
+  const linkedServerTransport: FakeTransport = {
+    serverName: 'chrome-server',
+    closed: false,
+    close: async () => {
+      linkedServerTransport.closed = true
+    },
+  }
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+  vi.doMock('../../../src/utils/agencInChrome/common.js', () => ({
+    isAgenCInChromeMCPServer: (name: string) => name === 'chrome-in-process',
+  }))
+  const chromeToolRenderingMock = {
+    getAgenCInChromeMCPToolOverrides: (toolName: string) => ({
+      userFacingName: () => `chrome override ${toolName}`,
+      renderToolUseMessage: () => 'rendered chrome tool',
+    }),
+  }
+  vi.doMock(
+    '../../../src/utils/agencInChrome/toolRendering.js',
+    () => chromeToolRenderingMock,
+  )
+  vi.doMock(
+    '../../../src/utils/agencInChrome/toolRendering.tsx',
+    () => chromeToolRenderingMock,
+  )
+  vi.doMock('../../../src/utils/agencInChrome/mcpServer.js', () => ({
+    createChromeContext: (env?: Record<string, string>) => ({ env }),
+  }))
+  vi.doMock('@ant/agenc-for-chrome-mcp', () => ({
+    createAgenCForChromeMcpServer: (context: unknown) => {
+      const server = {
+        context,
+        connectedTransport: undefined as unknown,
+        closed: false,
+      }
+      fakeChromeMcpServers.push(server)
+      return {
+        connect: async (transport: unknown) => {
+          server.connectedTransport = transport
+        },
+        close: async () => {
+          server.closed = true
+        },
+      }
+    },
+  }))
+  vi.doMock('../../../src/services/mcp/InProcessTransport.js', () => ({
+    createLinkedTransportPair: () => [
+      linkedClientTransport,
+      linkedServerTransport,
+    ],
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('chrome-in-process', {
+    type: 'stdio',
+    command: 'should-not-spawn',
+    args: ['--unused'],
+    env: { PROFILE: 'default' },
+    scope: 'local',
+  })
+
+  assert.equal(result.type, 'connected')
+  assert.equal(fakeStdioTransports.length, 0)
+  assert.deepEqual(fakeChromeMcpServers[0]?.context, {
+    env: { PROFILE: 'default' },
+  })
+  assert.equal(fakeChromeMcpServers[0]?.connectedTransport, linkedServerTransport)
+  assert.equal(fakeClients[0]?.handlers.length, 2)
+
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
+  assert.equal(fakeChromeMcpServers[0]?.closed, true)
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer cleanup logs in-process server and client close failures', async () => {
+  vi.resetModules()
+  const linkedClientTransport: FakeTransport = {
+    serverName: 'chrome-in-process',
+    close: async () => {},
+  }
+  const linkedServerTransport: FakeTransport = {
+    serverName: 'chrome-server',
+    close: async () => {},
+  }
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+  vi.doMock('../../../src/utils/agencInChrome/common.js', () => ({
+    isAgenCInChromeMCPServer: (name: string) => name === 'chrome-in-process',
+  }))
+  vi.doMock('../../../src/utils/agencInChrome/mcpServer.js', () => ({
+    createChromeContext: () => ({}),
+  }))
+  vi.doMock('@ant/agenc-for-chrome-mcp', () => ({
+    createAgenCForChromeMcpServer: () => ({
+      connect: async () => {},
+      close: async () => {
+        throw new Error('in-process close denied')
+      },
+    }),
+  }))
+  vi.doMock('../../../src/services/mcp/InProcessTransport.js', () => ({
+    createLinkedTransportPair: () => [
+      linkedClientTransport,
+      linkedServerTransport,
+    ],
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('chrome-in-process', {
+    type: 'stdio',
+    command: 'should-not-spawn',
+    args: [],
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  fakeClients[0]!.close = async () => {
+    throw new Error('in-process client close denied')
+  }
+
+  await result.cleanup()
+})
+
+test('connectToServer times out hanging in-process Chrome connections and cleans up', async () => {
+  vi.resetModules()
+  process.env.MCP_TIMEOUT = '5'
+  vi.useFakeTimers()
+  const linkedClientTransport: FakeTransport = {
+    serverName: 'hanging',
+    close: async () => {
+      throw new Error('client transport close denied')
+    },
+  }
+  const linkedServerTransport: FakeTransport = {
+    serverName: 'chrome-server',
+    close: async () => {},
+  }
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+  vi.doMock('../../../src/utils/agencInChrome/common.js', () => ({
+    isAgenCInChromeMCPServer: (name: string) => name === 'chrome-in-process',
+  }))
+  vi.doMock('../../../src/utils/agencInChrome/mcpServer.js', () => ({
+    createChromeContext: () => ({}),
+  }))
+  vi.doMock('@ant/agenc-for-chrome-mcp', () => ({
+    createAgenCForChromeMcpServer: () => ({
+      connect: async () => {},
+      close: async () => {
+        throw new Error('in-process timeout close denied')
+      },
+    }),
+  }))
+  vi.doMock('../../../src/services/mcp/InProcessTransport.js', () => ({
+    createLinkedTransportPair: () => [
+      linkedClientTransport,
+      linkedServerTransport,
+    ],
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  try {
+    const resultPromise = connectToServer('chrome-in-process', {
+      type: 'stdio',
+      command: 'should-not-spawn',
+      args: [],
+      scope: 'local',
+    })
+    await vi.advanceTimersByTimeAsync(5)
+    const result = await resultPromise
+    assert.equal(result.type, 'failed')
+    if (result.type === 'failed') {
+      assert.match(result.error, /connection timed out after 5ms/)
+    }
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('connectToServer returns failed stdio clients after connect errors and closes transport', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('broken-stdio', {
+    type: 'stdio',
+    command: 'broken-server',
+    args: [],
+    scope: 'local',
+  })
+
+  assert.deepEqual(result, {
+    name: 'broken-stdio',
+    type: 'failed',
+    config: {
+      type: 'stdio',
+      command: 'broken-server',
+      args: [],
+      scope: 'local',
+    },
+    error: 'connect failed',
+  })
+  assert.equal(fakeStdioTransports[0]?.closed, true)
+})
+
+test('connectToServer returns failed stdio clients after connection timeout', async () => {
+  vi.resetModules()
+  vi.useFakeTimers()
+  process.env.MCP_TIMEOUT = '5'
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const resultPromise = connectToServer('hanging-stdio', {
+    type: 'stdio',
+    command: 'hanging-server',
+    args: [],
+    scope: 'local',
+  })
+  await vi.advanceTimersByTimeAsync(5)
+  const result = await resultPromise
+
+  assert.equal(result.type, 'failed')
+  if (result.type === 'failed') {
+    assert.equal(
+      result.error,
+      'MCP server "hanging-stdio" connection timed out after 5ms',
+    )
+  }
+  assert.equal(fakeStdioTransports[0]?.closed, true)
+})
+
+test('connectToServer creates remote SSE, SSE-IDE, and HTTP transports without real network IO', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+    SSEClientTransport: FakeSseTransport,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+    StreamableHTTPClientTransport: FakeHttpTransport,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/shared/transport.js', async importOriginal => ({
+    ...(await importOriginal<
+      typeof import('@modelcontextprotocol/sdk/shared/transport.js')
+    >()),
+    createFetchWithInit: () =>
+      async (url: string | URL, init?: RequestInit): Promise<Response> => {
+        const headers = new Headers(init?.headers)
+        fetchLog.push({
+          url: String(url),
+          method: init?.method ?? 'GET',
+          accept: headers.get('accept'),
+        })
+        if (String(url).includes('parent-abort')) {
+          return await new Promise<Response>(resolve => {
+            init?.signal?.addEventListener(
+              'abort',
+              () => resolve(new Response(String(init.signal?.reason))),
+              { once: true },
+            )
+          })
+        }
+        if (String(url).includes('fail')) {
+          throw new Error('fetch failed')
+        }
+        return new Response('ok')
+      },
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const sse = await connectToServer('sse-demo', {
+    type: 'sse',
+    url: 'https://example.test/sse',
+    headers: { 'X-Test': 'yes' },
+    scope: 'local',
+  })
+  assert.equal(sse.type, 'connected')
+  assert.equal(fakeSseTransports[0]?.url.href, 'https://example.test/sse')
+  assert.equal(
+    (
+      fakeSseTransports[0]?.options as {
+        requestInit?: { headers?: Record<string, string> }
+      }
+    )?.requestInit?.headers?.['X-Test'],
+    'yes',
+  )
+  const sseOptions = fakeSseTransports[0]?.options as {
+    authProvider?: { tokens: () => Promise<{ access_token: string } | undefined> }
+    eventSourceInit?: { fetch?: typeof fetch }
+  }
+  assert.equal(typeof sseOptions.eventSourceInit?.fetch, 'function')
+  sseOptions.authProvider!.tokens = async () => ({
+    access_token: 'sse-token',
+  })
+  installNativeFetchRecorder()
+  const eventStreamResponse = await sseOptions.eventSourceInit!.fetch!(
+    'https://example.test/events',
+    { headers: { 'X-Event': 'yes' } },
+  )
+  assert.equal(await eventStreamResponse.text(), 'ok')
+  assert.equal(nativeFetchLog[0]?.url, 'https://example.test/events')
+  assert.equal(nativeFetchLog[0]?.headers.authorization, 'Bearer sse-token')
+  assert.equal(nativeFetchLog[0]?.headers['x-event'], 'yes')
+  assert.equal(nativeFetchLog[0]?.headers['x-test'], 'yes')
+  assert.equal(nativeFetchLog[0]?.headers.accept, 'text/event-stream')
+  if (sse.type === 'connected') {
+    await sse.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+
+  const sseIde = await connectToServer('ide', {
+    type: 'sse-ide',
+    url: 'https://example.test/ide-sse',
+    ideName: 'Test IDE',
+    scope: 'local',
+  })
+  assert.equal(sseIde.type, 'connected')
+  assert.equal(fakeSseTransports[1]?.url.href, 'https://example.test/ide-sse')
+  if (sseIde.type === 'connected') {
+    await sseIde.cleanup()
+  }
+  assert.equal(fakeClients[1]?.closed, true)
+
+  const http = await connectToServer('http-demo', {
+    type: 'http',
+    url: 'https://example.test/mcp',
+    headers: { 'X-Http': 'yes' },
+    scope: 'local',
+  })
+  assert.equal(http.type, 'connected')
+  assert.equal(fakeHttpTransports[0]?.url.href, 'https://example.test/mcp')
+  assert.equal(
+    (
+      fakeHttpTransports[0]?.options as {
+        requestInit?: { headers?: Record<string, string> }
+      }
+    )?.requestInit?.headers?.['X-Http'],
+    'yes',
+  )
+  if (http.type === 'connected') {
+    const httpFetch = (
+      fakeHttpTransports[0]?.options as {
+        fetch?: (url: string, init?: RequestInit) => Promise<Response>
+      }
+    )?.fetch
+    assert.ok(httpFetch)
+    await httpFetch('https://example.test/stream', { method: 'GET' })
+    await httpFetch('https://example.test/post', { method: 'POST' })
+    const abortController = new AbortController()
+    abortController.abort('already stopped')
+    await httpFetch('https://example.test/aborted', {
+      method: 'POST',
+      signal: abortController.signal,
+    })
+    const laterAbortController = new AbortController()
+    const laterAbortResponse = httpFetch('https://example.test/parent-abort', {
+      method: 'POST',
+      signal: laterAbortController.signal,
+    })
+    laterAbortController.abort('stopped later')
+    assert.equal(await (await laterAbortResponse).text(), 'stopped later')
+    await assert.rejects(
+      httpFetch('https://example.test/fail', { method: 'POST' }),
+      /fetch failed/,
+    )
+    assert.deepEqual(fetchLog, [
+      { url: 'https://example.test/stream', method: 'GET', accept: null },
+      {
+        url: 'https://example.test/post',
+        method: 'POST',
+        accept: 'application/json, text/event-stream',
+      },
+      {
+        url: 'https://example.test/aborted',
+        method: 'POST',
+        accept: 'application/json, text/event-stream',
+      },
+      {
+        url: 'https://example.test/parent-abort',
+        method: 'POST',
+        accept: 'application/json, text/event-stream',
+      },
+      {
+        url: 'https://example.test/fail',
+        method: 'POST',
+        accept: 'application/json, text/event-stream',
+      },
+    ])
+    fakeClients[2]?.onerror?.(new Error('temporary blip'))
+    fakeClients[2]?.onerror?.(
+      Object.assign(
+        new Error('{"error":{"code":-32001,"message":"Session not found"}}'),
+        { code: 404 },
+      ),
+    )
+    await Promise.resolve()
+    assert.equal(fakeClients[2]?.closed, true)
+    await http.cleanup()
+  }
+  assert.equal(fakeClients[2]?.closed, true)
+
+  const reconnectingSse = await connectToServer('sse-reconnect', {
+    type: 'sse',
+    url: 'https://example.test/reconnect',
+    scope: 'local',
+  })
+  assert.equal(reconnectingSse.type, 'connected')
+  const reconnectingClient = fakeClients[3]!
+  reconnectingClient.onerror?.(new Error('ECONNRESET'))
+  reconnectingClient.onerror?.(new Error('ECONNRESET'))
+  reconnectingClient.onerror?.(new Error('ECONNRESET'))
+  await Promise.resolve()
+  assert.equal(reconnectingClient.closed, true)
+
+  const exhaustedSse = await connectToServer('sse-exhausted', {
+    type: 'sse',
+    url: 'https://example.test/exhausted',
+    scope: 'local',
+  })
+  assert.equal(exhaustedSse.type, 'connected')
+  const exhaustedClient = fakeClients[4]!
+  exhaustedClient.onerror?.(new Error('Maximum reconnection attempts reached'))
+  await Promise.resolve()
+  assert.equal(exhaustedClient.closed, true)
+
+  const loopbackHttp = await connectToServer('http-loopback', {
+    type: 'http',
+    url: 'http://localhost:3333/mcp',
+    scope: 'local',
+  })
+  assert.equal(loopbackHttp.type, 'connected')
+  if (loopbackHttp.type === 'connected') {
+    await loopbackHttp.cleanup()
+  }
+  assert.equal(fakeClients[5]?.closed, true)
+})
+
+test('connectToServer HTTP fetch wrapper aborts long POST requests on timeout', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+    StreamableHTTPClientTransport: FakeHttpTransport,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/shared/transport.js', async importOriginal => ({
+    ...(await importOriginal<
+      typeof import('@modelcontextprotocol/sdk/shared/transport.js')
+    >()),
+    createFetchWithInit: () =>
+      async (_url: string | URL, init?: RequestInit): Promise<Response> => {
+        return await new Promise<Response>(resolve => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => resolve(new Response((init.signal?.reason as Error).name)),
+            { once: true },
+          )
+        })
+      },
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('http-timeout', {
+    type: 'http',
+    url: 'https://example.test/timeout',
+    scope: 'local',
+  })
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  const httpFetch = (
+    fakeHttpTransports[0]?.options as {
+      fetch?: (url: string, init?: RequestInit) => Promise<Response>
+    }
+  )?.fetch
+  assert.ok(httpFetch)
+
+  vi.useFakeTimers()
+  try {
+    const responsePromise = httpFetch('https://example.test/slow-post', {
+      method: 'POST',
+    })
+    await vi.advanceTimersByTimeAsync(60_000)
+    assert.equal(await (await responsePromise).text(), 'TimeoutError')
+  } finally {
+    vi.useRealTimers()
+  }
+  await result.cleanup()
+})
+
+test('connectToServer wires proxy fetch options into SSE IDE event streams', async () => {
+  vi.resetModules()
+  const fakeDispatcher = { name: 'proxy-dispatcher' }
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+    SSEClientTransport: FakeSseTransport,
+  }))
+  vi.doMock('../../../src/utils/proxy.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/utils/proxy.js')>()),
+    getProxyFetchOptions: () => ({ dispatcher: fakeDispatcher }),
+  }))
+  installNativeFetchRecorder('proxied')
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('ide', {
+    type: 'sse-ide',
+    url: 'https://example.test/ide-sse-proxy',
+    ideName: 'Proxy IDE',
+    scope: 'local',
+  })
+
+  assert.equal(result.type, 'connected')
+  const options = fakeSseTransports[0]?.options as {
+    eventSourceInit?: { fetch?: typeof fetch }
+  }
+  assert.equal(typeof options.eventSourceInit?.fetch, 'function')
+  const response = await options.eventSourceInit!.fetch!(
+    'https://example.test/proxy-events',
+    { headers: { 'X-Init': '1' } },
+  )
+  assert.equal(await response.text(), 'proxied')
+  assert.equal(nativeFetchLog[0]?.dispatcher, fakeDispatcher)
+  assert.equal(nativeFetchLog[0]?.headers['x-init'], '1')
+  assert.ok(nativeFetchLog[0]?.headers['user-agent'])
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer tolerates IDE connected notification failures', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+    SSEClientTransport: FakeSseTransport,
+  }))
+  vi.doMock('../../../src/utils/ide.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/utils/ide.js')>()),
+    maybeNotifyIDEConnected: () => {
+      throw new Error('notify failed')
+    },
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('ide', {
+    type: 'sse-ide',
+    url: 'https://example.test/notify-failure',
+    ideName: 'Failing IDE',
+    scope: 'local',
+  })
+
+  assert.equal(result.type, 'connected')
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('connectToServer returns failed connections for unsupported direct paths', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const sdk = await connectToServer('sdk-wrong-path', {
+    type: 'sdk',
+    name: 'sdk-wrong-path',
+    scope: 'local',
+  })
+  assert.equal(sdk.type, 'failed')
+  if (sdk.type === 'failed') {
+    assert.equal(sdk.error, 'SDK servers should be handled in print.ts')
+  }
+
+  const proxy = await connectToServer('proxy-no-token', {
+    type: 'agencai-proxy',
+    url: 'https://example.test/proxy',
+    id: 'server-1',
+    scope: 'agencai',
+  } as never)
+  assert.equal(proxy.type, 'failed')
+  if (proxy.type === 'failed') {
+    assert.equal(proxy.error, 'No agenc.tech OAuth token found')
+  }
+
+  const unsupported = await connectToServer('unsupported', {
+    type: 'unsupported',
+    scope: 'local',
+  } as never)
+  assert.equal(unsupported.type, 'failed')
+  if (unsupported.type === 'failed') {
+    assert.equal(unsupported.error, 'Unsupported server type: unsupported')
+  }
+})
+
+test('connectToServer returns needs-auth for unauthorized SSE and HTTP connections', async () => {
+  vi.resetModules()
+  const configDir = await mkdtemp(join(tmpdir(), 'agenc-mcp-auth-cache-'))
+  tempDirs.push(configDir)
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+    SSEClientTransport: FakeSseTransport,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+    StreamableHTTPClientTransport: FakeHttpTransport,
+  }))
+  vi.doMock('../../../src/utils/envUtils.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/utils/envUtils.js')>()),
+    getAgenCConfigHomeDir: () => configDir,
+  }))
+
+  const { clearMcpAuthCache, connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const sse = await connectToServer('sse-auth', {
+    type: 'sse',
+    url: 'https://example.test/auth-sse',
+    scope: 'local',
+  })
+  assert.equal(sse.type, 'needs-auth')
+
+  const http = await connectToServer('http-auth', {
+    type: 'http',
+    url: 'https://example.test/auth-http',
+    scope: 'local',
+  })
+  assert.equal(http.type, 'needs-auth')
+
+  await new Promise(resolve => setTimeout(resolve, 0))
+  clearMcpAuthCache()
+})
+
+test('connectToServer creates WebSocket and WebSocket IDE transports without real sockets', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('../../../src/utils/mcpWebSocketTransport.js', () => ({
+    WebSocketTransport: FakeWebSocketTransport,
+  }))
+  mutableGlobal.Bun = {}
+  mutableGlobal.WebSocket = FakeWebSocketClient
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const ws = await connectToServer('ws-demo', {
+    type: 'ws',
+    url: 'wss://example.test/socket',
+    headers: { 'X-Ws': 'yes' },
+    scope: 'local',
+  })
+  assert.equal(ws.type, 'connected')
+  assert.equal(fakeWebSocketClients[0]?.url, 'wss://example.test/socket')
+  assert.equal(
+    (
+      fakeWebSocketClients[0]?.options as {
+        headers?: Record<string, string>
+      }
+    )?.headers?.['X-Ws'],
+    'yes',
+  )
+  assert.equal(fakeWebSocketTransports[0]?.client, fakeWebSocketClients[0])
+  if (ws.type === 'connected') {
+    await ws.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+
+  const wsIde = await connectToServer('ide', {
+    type: 'ws-ide',
+    url: 'ws://127.0.0.1:1234/mcp',
+    ideName: 'Test IDE',
+    authToken: 'secret-token',
+    scope: 'local',
+  })
+  assert.equal(wsIde.type, 'connected')
+  assert.equal(fakeWebSocketClients[1]?.url, 'ws://127.0.0.1:1234/mcp')
+  assert.equal(
+    (
+      fakeWebSocketClients[1]?.options as {
+        headers?: Record<string, string>
+      }
+    )?.headers?.['X-AgenC-Code-Ide-Authorization'],
+    'secret-token',
+  )
+  if (wsIde.type === 'connected') {
+    await wsIde.cleanup()
+  }
+  assert.equal(fakeClients[1]?.closed, true)
+})
+
+test('connectToServer creates Node WebSocket transports without real sockets', async () => {
+  vi.resetModules()
+  delete mutableGlobal.Bun
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('../../../src/utils/mcpWebSocketTransport.js', () => ({
+    WebSocketTransport: FakeWebSocketTransport,
+  }))
+  vi.doMock('ws', () => ({
+    default: FakeWebSocketClient,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const wsIde = await connectToServer('ide', {
+    type: 'ws-ide',
+    url: 'ws://127.0.0.1:4321/mcp',
+    ideName: 'Node IDE',
+    authToken: 'node-secret',
+    scope: 'local',
+  })
+  assert.equal(wsIde.type, 'connected')
+  assert.equal(fakeWebSocketClients[0]?.url, 'ws://127.0.0.1:4321/mcp')
+  assert.deepEqual(fakeWebSocketClients[0]?.protocols, ['mcp'])
+  assert.equal(
+    (
+      fakeWebSocketClients[0]?.options as {
+        headers?: Record<string, string>
+      }
+    )?.headers?.['X-AgenC-Code-Ide-Authorization'],
+    'node-secret',
+  )
+  if (wsIde.type === 'connected') {
+    await wsIde.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+
+  const ws = await connectToServer('node-ws-demo', {
+    type: 'ws',
+    url: 'wss://example.test/node-socket',
+    headers: { 'X-Node-Ws': 'yes' },
+    scope: 'local',
+  })
+  assert.equal(ws.type, 'connected')
+  assert.equal(fakeWebSocketClients[1]?.url, 'wss://example.test/node-socket')
+  assert.deepEqual(fakeWebSocketClients[1]?.protocols, ['mcp'])
+  assert.equal(
+    (
+      fakeWebSocketClients[1]?.options as {
+        headers?: Record<string, string>
+      }
+    )?.headers?.['X-Node-Ws'],
+    'yes',
+  )
+  if (ws.type === 'connected') {
+    await ws.cleanup()
+  }
+  assert.equal(fakeClients[1]?.closed, true)
+})
+
+test('connectToServer creates agenc.tech proxy transports and retries bearer fetch 401s', async () => {
+  vi.resetModules()
+  const configDir = await mkdtemp(join(tmpdir(), 'agenc-mcp-proxy-auth-cache-'))
+  tempDirs.push(configDir)
+  let oauthTokens: { accessToken: string } | null = {
+    accessToken: 'first-token',
+  }
+  let refreshCalls = 0
+  const handledTokens: string[] = []
+  let handleMode:
+    | 'refresh'
+    | 'unchanged'
+    | 'changed-without-signal'
+    | 'throw' = 'refresh'
+  const statuses: number[] = [200, 401, 200]
+  const fetchFailures: boolean[] = []
+  const markedProxyConnections: string[] = []
+  mutableGlobal.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit,
+  ) => {
+    const headers = new Headers(init?.headers)
+    nativeFetchLog.push({
+      url:
+        typeof input === 'string' || input instanceof URL
+          ? String(input)
+          : input.url,
+      headers: Object.fromEntries(headers.entries()),
+      dispatcher: (init as RequestInit & { dispatcher?: unknown })?.dispatcher,
+    })
+    if (fetchFailures.shift()) {
+      throw new Error('retry network down')
+    }
+    const status = statuses.shift() ?? 200
+    return new Response(`status-${status}`, { status })
+  }) as typeof fetch
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+    StreamableHTTPClientTransport: FakeHttpTransport,
+  }))
+  vi.doMock('../../../src/utils/auth.js', () => ({
+    checkAndRefreshOAuthTokenIfNeeded: async () => {
+      refreshCalls += 1
+    },
+    getAgenCAIOAuthTokens: () => oauthTokens,
+    handleOAuth401Error: async (sentToken: string) => {
+      handledTokens.push(sentToken)
+      if (handleMode === 'throw') {
+        throw new Error('refresh failed')
+      }
+      if (handleMode === 'refresh') {
+        oauthTokens = { accessToken: 'second-token' }
+        return true
+      }
+      if (handleMode === 'changed-without-signal') {
+        oauthTokens = { accessToken: 'background-token' }
+      }
+      return false
+    },
+  }))
+  vi.doMock('../../../src/constants/oauth.js', () => ({
+    getOauthConfig: () => ({
+      MCP_PROXY_URL: 'https://proxy.example.test',
+      MCP_PROXY_PATH: '/mcp/{server_id}',
+    }),
+  }))
+  vi.doMock('../../../src/bootstrap/state.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/bootstrap/state.js')>()),
+    getSessionId: () => 'session-123',
+  }))
+  vi.doMock('../../../src/services/mcp/agencai.js', () => ({
+    markAgenCAiMcpConnected: (name: string) => {
+      markedProxyConnections.push(name)
+    },
+  }))
+  vi.doMock('../../../src/utils/envUtils.js', async importOriginal => ({
+    ...(await importOriginal<typeof import('../../../src/utils/envUtils.js')>()),
+    getAgenCConfigHomeDir: () => configDir,
+  }))
+
+  const { connectToServer, prefetchAllMcpResources, reconnectMcpServerImpl } =
+    await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('proxy-demo', {
+    type: 'agencai-proxy',
+    id: 'server-42',
+    url: 'https://unused.example.test',
+    scope: 'agencai',
+  } as never)
+
+  assert.equal(result.type, 'connected')
+  assert.equal(
+    fakeHttpTransports[0]?.url.href,
+    'https://proxy.example.test/mcp/server-42',
+  )
+  assert.equal(
+    (
+      fakeHttpTransports[0]?.options as {
+        requestInit?: { headers?: Record<string, string> }
+      }
+    )?.requestInit?.headers?.['X-Mcp-Client-Session-Id'],
+    'session-123',
+  )
+  const proxyFetch = (
+    fakeHttpTransports[0]?.options as {
+      fetch?: (url: string, init?: RequestInit) => Promise<Response>
+    }
+  )?.fetch
+  assert.equal(typeof proxyFetch, 'function')
+
+  const firstResponse = await proxyFetch!('https://proxy.example.test/rpc', {
+    method: 'POST',
+  })
+  assert.equal(firstResponse.status, 200)
+  assert.equal(nativeFetchLog[0]?.headers.authorization, 'Bearer first-token')
+
+  const retryResponse = await proxyFetch!('https://proxy.example.test/rpc', {
+    method: 'POST',
+  })
+  assert.equal(await retryResponse.text(), 'status-200')
+  assert.deepEqual(handledTokens, ['first-token'])
+  assert.equal(nativeFetchLog[1]?.headers.authorization, 'Bearer first-token')
+  assert.equal(nativeFetchLog[2]?.headers.authorization, 'Bearer second-token')
+  assert.equal(refreshCalls, 3)
+
+  oauthTokens = null
+  await assert.rejects(
+    proxyFetch!('https://proxy.example.test/rpc', { method: 'POST' }),
+    /No agenc\.tech OAuth token available/,
+  )
+
+  oauthTokens = { accessToken: 'same-token' }
+  handleMode = 'unchanged'
+  statuses.push(401)
+  const unchangedResponse = await proxyFetch!('https://proxy.example.test/rpc', {
+    method: 'POST',
+  })
+  assert.equal(unchangedResponse.status, 401)
+
+  oauthTokens = { accessToken: 'throw-token' }
+  handleMode = 'throw'
+  statuses.push(401)
+  const thrownHandlerResponse = await proxyFetch!(
+    'https://proxy.example.test/rpc',
+    { method: 'POST' },
+  )
+  assert.equal(thrownHandlerResponse.status, 401)
+
+  oauthTokens = { accessToken: 'stale-token' }
+  handleMode = 'changed-without-signal'
+  statuses.push(401)
+  fetchFailures.push(false, true)
+  const failedRetryResponse = await proxyFetch!(
+    'https://proxy.example.test/rpc',
+    { method: 'POST' },
+  )
+  assert.equal(failedRetryResponse.status, 401)
+  assert.deepEqual(handledTokens, [
+    'first-token',
+    'same-token',
+    'throw-token',
+    'stale-token',
+  ])
+
+  oauthTokens = { accessToken: 'connect-token' }
+  const needsAuth = await connectToServer('proxy-connect-401', {
+    type: 'agencai-proxy',
+    id: 'connect-401',
+    url: 'https://unused.example.test',
+    scope: 'agencai',
+  } as never)
+  assert.equal(needsAuth.type, 'needs-auth')
+
+  oauthTokens = { accessToken: 'reconnect-token' }
+  const reconnectResult = await reconnectMcpServerImpl('proxy-reconnect', {
+    type: 'agencai-proxy',
+    id: 'reconnect-42',
+    url: 'https://unused.example.test',
+    scope: 'agencai',
+  } as never)
+  assert.equal(reconnectResult.client.type, 'connected')
+  if (reconnectResult.client.type === 'connected') {
+    await reconnectResult.client.cleanup()
+  }
+
+  oauthTokens = { accessToken: 'prefetch-token' }
+  const prefetchResult = await prefetchAllMcpResources({
+    'proxy-prefetch': {
+      type: 'agencai-proxy',
+      id: 'prefetch-42',
+      url: 'https://unused.example.test',
+      scope: 'agencai',
+    } as never,
+  })
+  assert.equal(prefetchResult.clients[0]?.type, 'connected')
+  const prefetchClient = prefetchResult.clients[0]
+  if (prefetchClient?.type === 'connected') {
+    await prefetchClient.cleanup()
+  }
+  assert.deepEqual(markedProxyConnections, [
+    'proxy-reconnect',
+    'proxy-prefetch',
+  ])
+
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
+  assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('reconnectMcpServerImpl returns a failed client when cache invalidation throws', async () => {
+  vi.resetModules()
+  vi.doMock('../../../src/utils/secureStorage/macOsKeychainHelpers.js', () => ({
+    clearKeychainCache: () => {
+      throw new Error('keychain unavailable')
+    },
+  }))
+
+  const { reconnectMcpServerImpl } = await import('./client.js')
+  const result = await reconnectMcpServerImpl('keychain-fail', {
+    type: 'stdio',
+    command: 'unused',
+    args: [],
+    scope: 'local',
+  })
+
+  assert.equal(result.client.type, 'failed')
+  assert.deepEqual(result.tools, [])
+  assert.deepEqual(result.commands, [])
+})
+
+test('connectToServer truncates oversized server instructions', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer('long-instructions', {
+    type: 'stdio',
+    command: 'long-instructions-server',
+    args: [],
+    scope: 'local',
+  })
+
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  assert.equal(result.instructions?.length, 2061)
+  assert.equal(result.instructions?.endsWith('… [truncated]'), true)
+
+  await result.cleanup()
+})
+
+test('MCP tool calls persist large non-image output and fall back when disabled', async () => {
+  vi.resetModules()
+  delete process.env.ENABLE_MCP_LARGE_OUTPUT_FILES
+  const persisted: Array<{ content: unknown; id: string }> = []
+  const pngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+  vi.doMock('../../../src/utils/mcpValidation.js', () => ({
+    mcpContentNeedsTruncation: async () => true,
+    truncateMcpContentIfNeeded: async () => 'truncated fallback',
+  }))
+  vi.doMock('../../../src/utils/toolResultStorage.js', () => ({
+    isPersistError: (value: unknown) =>
+      !!value && typeof value === 'object' && 'error' in value,
+    persistToolResult: async (content: unknown, id: string) => {
+      persisted.push({ content, id })
+      if (id.includes('fail-persist')) {
+        return { error: 'disk full' }
+      }
+      return {
+        filepath: '/tmp/agenc-large-output.json',
+        originalSize: String(content).length,
+        isJson: true,
+        preview: '',
+        hasMore: false,
+      }
+    },
+  }))
+
+  const { fetchToolsForClient } = await import('./client.js')
+  const client = {
+    name: 'large-output',
+    type: 'connected',
+    capabilities: { tools: {} },
+    config: { type: 'sdk', name: 'large-output', scope: 'local' },
+    cleanup: async () => {},
+    client: {
+      request: async () => ({
+	        tools: [
+	          { name: 'dump', inputSchema: { type: 'object' } },
+	          { name: 'plain', inputSchema: { type: 'object' } },
+	          { name: 'empty', inputSchema: { type: 'object' } },
+	          { name: 'image', inputSchema: { type: 'object' } },
+	          { name: 'fail-persist', inputSchema: { type: 'object' } },
+	        ],
+	      }),
+	      callTool: async (request: { name: string }) => {
+	        if (request.name === 'plain') {
+	          return { toolResult: 'huge result' }
+	        }
+	        if (request.name === 'empty') {
+	          return { toolResult: '' }
+	        }
+	        if (request.name === 'image') {
+	          return {
+	            content: [
+              {
+                type: 'image',
+                data: pngBase64,
+                mimeType: 'image/png',
+              },
+            ],
+          }
+        }
+        return {
+          content: [{ type: 'text', text: 'huge result' }],
+        }
+      },
+    },
+  } as never
+
+  const tools = await fetchToolsForClient(client)
+  const toolByName = new Map(tools.map(tool => [tool.mcpInfo?.toolName, tool]))
+  const persistedResult = await toolByName.get('dump')!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+
+  assert.equal(persisted.length, 1)
+  assert.equal(persisted[0]?.id.startsWith('mcp-large-output-dump-'), true)
+  assert.equal(
+    (persistedResult.data as string).includes(
+      'Output has been saved to /tmp/agenc-large-output.json',
+    ),
+    true,
+  )
+  assert.equal((persistedResult.data as string).includes('Format: JSON array'), true)
+
+  const plainResult = await toolByName.get('plain')!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+  assert.equal(persisted[1]?.id.startsWith('mcp-large-output-plain-'), true)
+  assert.equal((plainResult.data as string).includes('Format: Plain text'), true)
+
+  const emptyResult = await toolByName.get('empty')!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+  assert.deepEqual(emptyResult, { data: '' })
+
+  const imageResult = await toolByName.get('image')!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+  assert.deepEqual(imageResult, { data: 'truncated fallback' })
+
+  const persistErrorResult = await toolByName.get('fail-persist')!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+  assert.match(
+    persistErrorResult.data as string,
+    /^Error: result \(\d+ characters\) exceeds maximum allowed tokens\. Failed to save output to file: disk full\./,
+  )
+
+  process.env.ENABLE_MCP_LARGE_OUTPUT_FILES = '0'
+  fetchToolsForClient.cache.clear()
+  const fallbackTools = await fetchToolsForClient(client)
+  const fallbackTool = fallbackTools.find(tool => tool.mcpInfo?.toolName === 'dump')
+  const fallbackResult = await fallbackTool!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+
+  assert.deepEqual(fallbackResult, { data: 'truncated fallback' })
+})

--- a/runtime/tests/services/mcp/client.test.ts
+++ b/runtime/tests/services/mcp/client.test.ts
@@ -1,7 +1,129 @@
 import assert from 'node:assert/strict'
-import { test } from 'vitest'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { afterEach, test, vi } from 'vitest'
 
-import { cleanupFailedConnection } from './client.js'
+import {
+  resetStateForTests,
+  setOriginalCwd,
+  switchSession,
+} from '../../../src/bootstrap/state.js'
+import { resetProjectForTesting } from '../../../src/utils/sessionStorage.js'
+import { getToolResultsDir } from '../../../src/utils/toolResultStorage.js'
+import {
+  McpAuthError,
+  McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+  callMCPToolWithUrlElicitationRetry,
+  callIdeRpc,
+  clearServerCache,
+  cleanupFailedConnection,
+  connectToServer,
+  ensureConnectedClient,
+  fetchResourcesForClient,
+  fetchToolsForClient,
+  getMcpServerConnectionBatchSize,
+  prefetchAllMcpResources,
+  reconnectMcpServerImpl,
+} from './client.js'
+import type { ConnectedMCPServer, MCPServerConnection } from './types.js'
+
+const originalBatchSize = process.env.MCP_SERVER_CONNECTION_BATCH_SIZE
+const originalNoPrefix = process.env.AGENC_AGENT_SDK_MCP_NO_PREFIX
+const originalToolTimeout = process.env.MCP_TOOL_TIMEOUT
+const originalConfigDir = process.env.AGENC_CONFIG_DIR
+const originalAgenCHome = process.env.AGENC_HOME
+const tempDirs: string[] = []
+const isolatedSessionId = '00000000-0000-4000-8000-000000000321'
+
+type QueuedUrlElicitation = {
+  params: { elicitationId: string; url: string }
+  waitingState: { actionLabel: string; showCancel: boolean }
+  respond: (result: { action: string }) => void
+  onWaitingDismiss: (action: string) => void
+}
+
+function restoreOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
+afterEach(async () => {
+  restoreOptionalEnv('MCP_SERVER_CONNECTION_BATCH_SIZE', originalBatchSize)
+  restoreOptionalEnv('AGENC_AGENT_SDK_MCP_NO_PREFIX', originalNoPrefix)
+  restoreOptionalEnv('MCP_TOOL_TIMEOUT', originalToolTimeout)
+  restoreOptionalEnv('AGENC_CONFIG_DIR', originalConfigDir)
+  restoreOptionalEnv('AGENC_HOME', originalAgenCHome)
+  resetProjectForTesting()
+  resetStateForTests()
+  connectToServer.cache.clear?.()
+  fetchToolsForClient.cache.clear()
+  fetchResourcesForClient.cache.clear()
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+function connectedClient(
+  overrides: Partial<ConnectedMCPServer> & {
+    request?: (input: unknown) => Promise<unknown>
+  } = {},
+): ConnectedMCPServer {
+  return {
+    name: overrides.name ?? 'demo',
+    type: 'connected',
+    capabilities: overrides.capabilities ?? {},
+    config: overrides.config ?? { type: 'stdio', command: 'demo', scope: 'local' },
+    cleanup: overrides.cleanup ?? (async () => {}),
+    client: overrides.client ?? ({
+      request: overrides.request ?? (async () => ({})),
+      callTool: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    } as never),
+  } as ConnectedMCPServer
+}
+
+function seedConnectionCache(
+  name: string,
+  config: MCPServerConnection['config'],
+  connection: MCPServerConnection,
+): void {
+  const key = `${name}-${JSON.stringify(config)}`
+  ;(
+    connectToServer.cache as {
+      set: (key: string, value: Promise<MCPServerConnection>) => unknown
+    }
+  ).set(key, Promise.resolve(connection))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+  assert.fail(message)
+}
+
+async function configureIsolatedSession(): Promise<{ toolResultsDir: string }> {
+  const configDir = await mkdtemp(join(tmpdir(), 'agenc-mcp-client-'))
+  tempDirs.push(configDir)
+  process.env.AGENC_CONFIG_DIR = configDir
+  delete process.env.AGENC_HOME
+  resetProjectForTesting()
+  resetStateForTests()
+
+  const cwd = join(configDir, 'workspace', 'mcp project')
+  setOriginalCwd(cwd)
+  switchSession(isolatedSessionId as never, null)
+
+  return { toolResultsDir: getToolResultsDir() }
+}
 
 test('cleanupFailedConnection awaits transport close before resolving', async () => {
   let closed = false
@@ -45,4 +167,1496 @@ test('cleanupFailedConnection closes in-process server and transport', async () 
 
   assert.equal(inProcessClosed, true)
   assert.equal(transportClosed, true)
+})
+
+test('MCP exported error classes preserve server and metadata details', () => {
+  const authError = new McpAuthError('calendar', 'login expired')
+  assert.equal(authError.name, 'McpAuthError')
+  assert.equal(authError.serverName, 'calendar')
+  assert.equal(authError.message, 'login expired')
+
+  const toolError = new McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS(
+    'tool failed',
+    'safe telemetry',
+    { _meta: { requestId: 'req-1' } },
+  )
+  assert.equal(toolError.name, 'McpToolCallError')
+  assert.deepEqual(toolError.mcpMeta, { _meta: { requestId: 'req-1' } })
+})
+
+test('MCP server connection batch size reads valid env overrides and falls back', () => {
+  delete process.env.MCP_SERVER_CONNECTION_BATCH_SIZE
+  assert.equal(getMcpServerConnectionBatchSize(), 3)
+
+  process.env.MCP_SERVER_CONNECTION_BATCH_SIZE = '7'
+  assert.equal(getMcpServerConnectionBatchSize(), 7)
+
+  process.env.MCP_SERVER_CONNECTION_BATCH_SIZE = 'invalid'
+  assert.equal(getMcpServerConnectionBatchSize(), 3)
+})
+
+test('fetchToolsForClient returns no tools for disconnected clients or missing capabilities', async () => {
+  assert.deepEqual(
+    await fetchToolsForClient({
+      name: 'failed',
+      type: 'failed',
+      config: { type: 'stdio', command: 'demo', scope: 'local' },
+      error: 'nope',
+    } as MCPServerConnection),
+    [],
+  )
+
+  assert.deepEqual(await fetchToolsForClient(connectedClient({ name: 'no-tools' })), [])
+})
+
+test('fetchToolsForClient maps MCP tool metadata onto runtime tools', async () => {
+  const client = connectedClient({
+    name: 'jira',
+    capabilities: { tools: {} },
+    request: async () => ({
+      tools: [
+        {
+          name: 'search',
+          description: 'x'.repeat(2100),
+          inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: true,
+            title: 'Issue search',
+          },
+          _meta: {
+            'anthropic/searchHint': '  find\nissues\tquickly  ',
+            'anthropic/alwaysLoad': true,
+          },
+        },
+      ],
+    }),
+  })
+
+  const tools = await fetchToolsForClient(client)
+  assert.equal(tools.length, 1)
+  const tool = tools[0]!
+
+  assert.equal(tool.name, 'mcp__jira__search')
+  assert.deepEqual(tool.mcpInfo, { serverName: 'jira', toolName: 'search' })
+  assert.equal(tool.isMcp, true)
+  assert.equal(tool.searchHint, 'find issues quickly')
+  assert.equal(tool.alwaysLoad, true)
+  assert.equal(await tool.description(), 'x'.repeat(2100))
+  assert.equal((await tool.prompt()).endsWith('… [truncated]'), true)
+  assert.equal(tool.isConcurrencySafe?.(), true)
+  assert.equal(tool.isReadOnly?.(), true)
+  assert.equal(tool.isDestructive?.(), false)
+  assert.equal(tool.isOpenWorld?.(), true)
+  assert.notEqual(tool.isSearchOrReadCommand?.(), undefined)
+  assert.equal(tool.userFacingName?.(), 'jira - Issue search (MCP)')
+  assert.equal(tool.toAutoClassifierInput?.({ q: 'bugs', limit: 5 }), 'q=bugs limit=5')
+  assert.equal(tool.toAutoClassifierInput?.({}), 'search')
+  assert.deepEqual(await tool.checkPermissions?.({} as never, {} as never), {
+    behavior: 'passthrough',
+    message: 'MCPTool requires permission.',
+    suggestions: [
+      {
+        type: 'addRules',
+        rules: [{ toolName: 'mcp__jira__search', ruleContent: undefined }],
+        behavior: 'allow',
+        destination: 'localSettings',
+      },
+    ],
+  })
+})
+
+test('fetchToolsForClient supports SDK no-prefix mode and filters IDE tools', async () => {
+  process.env.AGENC_AGENT_SDK_MCP_NO_PREFIX = '1'
+  const sdkTools = await fetchToolsForClient(
+    connectedClient({
+      name: 'sdk-server',
+      capabilities: { tools: {} },
+      config: { type: 'sdk', name: 'sdk-server', scope: 'local' },
+      request: async () => ({
+        tools: [{ name: 'override', inputSchema: { type: 'object' } }],
+      }),
+    }),
+  )
+  assert.equal(sdkTools[0]?.name, 'override')
+  assert.deepEqual(sdkTools[0]?.mcpInfo, {
+    serverName: 'sdk-server',
+    toolName: 'override',
+  })
+
+  const ideTools = await fetchToolsForClient(
+    connectedClient({
+      name: 'ide',
+      capabilities: { tools: {} },
+      request: async () => ({
+        tools: [
+          { name: 'executeCode', inputSchema: { type: 'object' } },
+          { name: 'getDiagnostics', inputSchema: { type: 'object' } },
+          { name: 'openFile', inputSchema: { type: 'object' } },
+        ],
+      }),
+    }),
+  )
+  assert.deepEqual(
+    ideTools.map(tool => tool.name),
+    ['mcp__ide__executeCode', 'mcp__ide__getDiagnostics'],
+  )
+})
+
+test('fetchToolsForClient returns an empty list on request failure', async () => {
+  const tools = await fetchToolsForClient(
+    connectedClient({
+      name: 'broken-tools',
+      capabilities: { tools: {} },
+      request: async () => {
+        throw new Error('tools unavailable')
+      },
+    }),
+  )
+
+  assert.deepEqual(tools, [])
+})
+
+test('fetchResourcesForClient maps server names and handles unavailable resources', async () => {
+  assert.deepEqual(await fetchResourcesForClient({ name: 'pending', type: 'pending' } as never), [])
+  assert.deepEqual(await fetchResourcesForClient(connectedClient({ name: 'no-resources' })), [])
+
+  const resources = await fetchResourcesForClient(
+    connectedClient({
+      name: 'docs',
+      capabilities: { resources: {} },
+      request: async () => ({
+        resources: [{ uri: 'file://readme', name: 'README' }],
+      }),
+    }),
+  )
+  assert.deepEqual(resources, [
+    { uri: 'file://readme', name: 'README', server: 'docs' },
+  ])
+
+  fetchResourcesForClient.cache.clear()
+  assert.deepEqual(
+    await fetchResourcesForClient(
+      connectedClient({
+        name: 'broken-resources',
+        capabilities: { resources: {} },
+        request: async () => {
+          throw new Error('resources unavailable')
+        },
+      }),
+    ),
+    [],
+  )
+})
+
+test('fetchResourcesForClient returns an empty list when resources/list omits resources', async () => {
+  const resources = await fetchResourcesForClient(
+    connectedClient({
+      name: 'empty-resources',
+      capabilities: { resources: {} },
+      request: async () => ({}),
+    }),
+  )
+
+  assert.deepEqual(resources, [])
+})
+
+test('clearServerCache cleans up a cached connected server and invalidates its cache entry', async () => {
+  let cleanupCalled = false
+  const config = { type: 'stdio', command: 'demo', args: [], scope: 'local' } as const
+  seedConnectionCache(
+    'cached',
+    config,
+    connectedClient({
+      name: 'cached',
+      config,
+      cleanup: async () => {
+        cleanupCalled = true
+      },
+    }),
+  )
+
+  await clearServerCache('cached', config)
+
+  assert.equal(cleanupCalled, true)
+  assert.equal(connectToServer.cache.has(`${'cached'}-${JSON.stringify(config)}`), false)
+})
+
+test('ensureConnectedClient throws when cached reconnect result is not connected', async () => {
+  const config = { type: 'stdio', command: 'missing', args: [], scope: 'local' } as const
+  const client = connectedClient({
+    name: 'missing',
+    config,
+  })
+  seedConnectionCache('missing', config, {
+    name: 'missing',
+    type: 'failed',
+    config,
+    error: 'not found',
+  })
+
+  await assert.rejects(
+    ensureConnectedClient(client),
+    /MCP server "missing" is not connected/,
+  )
+})
+
+test('prefetchAllMcpResources collects cached tools, commands, clients, and resource tools', async () => {
+  const config = { type: 'stdio', command: 'prefetch', args: [], scope: 'local' } as const
+  let promptRequest: unknown
+  const client = connectedClient({
+    name: 'prefetch',
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+    config,
+    client: {
+      request: async (request: { method: string }) => {
+        if (request.method === 'tools/list') {
+          return {
+            tools: [{ name: 'search', inputSchema: { type: 'object' } }],
+          }
+        }
+        if (request.method === 'resources/list') {
+          return {
+            resources: [{ uri: 'file://guide', name: 'Guide' }],
+          }
+        }
+        if (request.method === 'prompts/list') {
+          return {
+            prompts: [
+              {
+                name: 'ask',
+                description: 'Ask the server',
+                arguments: [{ name: 'topic' }],
+              },
+            ],
+          }
+        }
+        throw new Error(`unexpected request ${request.method}`)
+      },
+      getPrompt: async (request: unknown) => {
+        promptRequest = request
+        return {
+          messages: [{ content: { type: 'text', text: 'Prompt answer' } }],
+        }
+      },
+      callTool: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    } as never,
+  })
+  seedConnectionCache('prefetch', config, client)
+
+  const result = await prefetchAllMcpResources({ prefetch: config })
+
+  assert.deepEqual(
+    result.clients.map(server => `${server.name}:${server.type}`),
+    ['prefetch:connected'],
+  )
+  assert.deepEqual(
+    result.tools.map(tool => tool.name),
+    ['mcp__prefetch__search', 'ListMcpResourcesTool', 'ReadMcpResourceTool'],
+  )
+  assert.deepEqual(
+    result.commands.map(command => command.name),
+    ['mcp__prefetch__ask'],
+  )
+  assert.equal(result.commands[0]!.isEnabled(), true)
+  assert.equal(result.commands[0]!.userFacingName(), 'prefetch:ask (MCP)')
+  assert.deepEqual(await result.commands[0]!.getPromptForCommand('weather'), [
+    { type: 'text', text: 'Prompt answer' },
+  ])
+  assert.deepEqual(promptRequest, {
+    name: 'ask',
+    arguments: { topic: 'weather' },
+  })
+})
+
+test('MCP prompt commands rethrow getPrompt failures', async () => {
+  const config = { type: 'stdio', command: 'prompt-fail', args: [], scope: 'local' } as const
+  const client = connectedClient({
+    name: 'prompt-fail',
+    capabilities: { prompts: {} },
+    config,
+    client: {
+      request: async (request: { method: string }) => {
+        if (request.method === 'prompts/list') {
+          return {
+            prompts: [{ name: 'ask', arguments: [{ name: 'topic' }] }],
+          }
+        }
+        throw new Error(`unexpected request ${request.method}`)
+      },
+      getPrompt: async () => {
+        throw new Error('prompt unavailable')
+      },
+    } as never,
+  })
+  seedConnectionCache('prompt-fail', config, client)
+
+  const result = await prefetchAllMcpResources({ 'prompt-fail': config })
+
+  assert.deepEqual(
+    result.commands.map(command => command.name),
+    ['mcp__prompt-fail__ask'],
+  )
+  await assert.rejects(
+    result.commands[0]!.getPromptForCommand('weather'),
+    /prompt unavailable/,
+  )
+})
+
+test('prefetchAllMcpResources handles missing and failed prompt lists', async () => {
+  const missingConfig = {
+    type: 'stdio',
+    command: 'prompt-missing',
+    args: [],
+    scope: 'local',
+  } as const
+  const failedConfig = {
+    type: 'stdio',
+    command: 'prompt-failed',
+    args: [],
+    scope: 'local',
+  } as const
+  seedConnectionCache(
+    'prompt-missing',
+    missingConfig,
+    connectedClient({
+      name: 'prompt-missing',
+      capabilities: { prompts: {} },
+      config: missingConfig,
+      request: async () => ({}),
+    }),
+  )
+  seedConnectionCache(
+    'prompt-failed',
+    failedConfig,
+    connectedClient({
+      name: 'prompt-failed',
+      capabilities: { prompts: {} },
+      config: failedConfig,
+      request: async () => {
+        throw new Error('prompts unavailable')
+      },
+    }),
+  )
+
+  const result = await prefetchAllMcpResources({
+    'prompt-missing': missingConfig,
+    'prompt-failed': failedConfig,
+  })
+
+  assert.deepEqual(
+    result.clients.map(client => `${client.name}:${client.type}`),
+    ['prompt-missing:connected', 'prompt-failed:connected'],
+  )
+  assert.deepEqual(result.commands, [])
+})
+
+test('reconnectMcpServerImpl returns failed non-connected reconnects without tools', async () => {
+  const config = { type: 'sdk', name: 'direct-sdk', scope: 'local' } as const
+
+  const result = await reconnectMcpServerImpl('direct-sdk', config)
+
+  assert.deepEqual(result, {
+    client: {
+      name: 'direct-sdk',
+      type: 'failed',
+      config,
+      error: 'SDK servers should be handled in print.ts',
+    },
+    tools: [],
+    commands: [],
+  })
+})
+
+test('MCP tool call passes metadata, progress, structured content, and result metadata', async () => {
+  let toolRequest: unknown
+  let toolOptions: unknown
+  const progress: unknown[] = []
+  const client = connectedClient({
+    name: 'sdk-tools',
+    capabilities: { tools: {} },
+    config: { type: 'sdk', name: 'sdk-tools', scope: 'local' },
+    client: {
+      request: async () => ({
+        tools: [{ name: 'summarize', inputSchema: { type: 'object' } }],
+      }),
+      callTool: async (request: unknown, _schema: unknown, options: unknown) => {
+        toolRequest = request
+        toolOptions = options
+        ;(options as { onprogress?: (event: unknown) => void }).onprogress?.({
+          progress: 2,
+          total: 5,
+          message: 'working',
+        })
+        return {
+          content: [{ type: 'text', text: 'ignored when structuredContent exists' }],
+          structuredContent: { answer: 42, source: 'mcp' },
+          _meta: { requestId: 'req-1' },
+        }
+      },
+    } as never,
+  })
+
+  const [tool] = await fetchToolsForClient(client)
+  assert.ok(tool)
+
+  const abortController = new AbortController()
+  const result = await tool.call(
+    { topic: 'coverage' },
+    {
+      abortController,
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    {
+      message: {
+        content: [{ type: 'tool_use', id: 'toolu_1' }],
+      },
+    } as never,
+    event => {
+      progress.push(event)
+    },
+  )
+
+  assert.deepEqual(toolRequest, {
+    name: 'summarize',
+    arguments: { topic: 'coverage' },
+    _meta: { 'agenccode/toolUseId': 'toolu_1' },
+  })
+  assert.equal((toolOptions as { signal?: AbortSignal }).signal, abortController.signal)
+  assert.deepEqual(result, {
+    data: '{"answer":42,"source":"mcp"}',
+    mcpMeta: {
+      _meta: { requestId: 'req-1' },
+      structuredContent: { answer: 42, source: 'mcp' },
+    },
+  })
+  assert.deepEqual(
+    progress.map(event => (event as { data: { status: string } }).data.status),
+    ['started', 'progress', 'completed'],
+  )
+  assert.deepEqual(progress[1], {
+    toolUseID: 'toolu_1',
+    data: {
+      type: 'mcp_progress',
+      status: 'progress',
+      serverName: 'sdk-tools',
+      toolName: 'summarize',
+      progress: 2,
+      total: 5,
+      progressMessage: 'working',
+    },
+  })
+})
+
+test('MCP tool call wraps generic and protocol errors with telemetry-safe errors', async () => {
+  const genericProgress: unknown[] = []
+  const genericClient = connectedClient({
+    name: 'sdk-errors',
+    capabilities: { tools: {} },
+    config: { type: 'sdk', name: 'sdk-errors', scope: 'local' },
+    client: {
+      request: async () => ({
+        tools: [{ name: 'explode', inputSchema: { type: 'object' } }],
+      }),
+      callTool: async () => {
+        throw new Error('plain failure')
+      },
+    } as never,
+  })
+
+  const [genericTool] = await fetchToolsForClient(genericClient)
+  await assert.rejects(
+    genericTool!.call(
+      {},
+      {
+        abortController: new AbortController(),
+        setAppState: value => value({ elicitation: { queue: [] } } as never),
+      } as never,
+      undefined as never,
+      { message: { content: [{ type: 'tool_use', id: 'toolu_fail' }] } } as never,
+      event => {
+        genericProgress.push(event)
+      },
+    ),
+    (error: unknown) => {
+      assert.equal((error as Error).message, 'plain failure')
+      assert.notEqual((error as Error).constructor.name, 'Error')
+      return true
+    },
+  )
+  assert.deepEqual(
+    genericProgress.map(event => (event as { data: { status: string } }).data.status),
+    ['started', 'failed'],
+  )
+  const failedProgress = genericProgress[1] as {
+    toolUseID?: string
+    data: Record<string, unknown>
+  }
+  const { elapsedTimeMs, ...failedProgressData } = failedProgress.data
+  assert.equal(failedProgress.toolUseID, 'toolu_fail')
+  assert.deepEqual(failedProgressData, {
+    type: 'mcp_progress',
+    status: 'failed',
+    serverName: 'sdk-errors',
+    toolName: 'explode',
+  })
+  assert.equal(typeof elapsedTimeMs, 'number')
+
+  fetchToolsForClient.cache.clear()
+  const mcpClient = connectedClient({
+    name: 'sdk-mcp-errors',
+    capabilities: { tools: {} },
+    config: { type: 'sdk', name: 'sdk-mcp-errors', scope: 'local' },
+    client: {
+      request: async () => ({
+        tools: [{ name: 'protocol', inputSchema: { type: 'object' } }],
+      }),
+      callTool: async () => {
+        throw new McpError(ErrorCode.InternalError, 'protocol failure')
+      },
+    } as never,
+  })
+
+  const [mcpTool] = await fetchToolsForClient(mcpClient)
+  await assert.rejects(
+    mcpTool!.call(
+      {},
+      {
+        abortController: new AbortController(),
+        setAppState: value => value({ elicitation: { queue: [] } } as never),
+      } as never,
+      undefined as never,
+      { message: { content: [] } } as never,
+    ),
+    (error: unknown) => {
+      assert.equal((error as Error).message, 'MCP error -32603: protocol failure')
+      assert.notEqual((error as Error).constructor.name, 'McpError')
+      return true
+    },
+  )
+})
+
+test('MCP tool call retries once after HTTP session expiry clears the connection cache', async () => {
+  let calls = 0
+  const config = { type: 'sdk', name: 'sdk-session', scope: 'local' } as const
+  const client = connectedClient({
+    name: 'sdk-session',
+    capabilities: { tools: {} },
+    config,
+    client: {
+      request: async () => ({
+        tools: [{ name: 'recover', inputSchema: { type: 'object' } }],
+      }),
+      callTool: async () => {
+        calls += 1
+        if (calls === 1) {
+          const expired = new Error('{"error":{"code":-32001,"message":"Session not found"}}') as Error & {
+            code: number
+          }
+          expired.code = 404
+          throw expired
+        }
+        return { content: [{ type: 'text', text: 'recovered' }] }
+      },
+    } as never,
+  })
+
+  const [tool] = await fetchToolsForClient(client)
+  const result = await tool!.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
+
+  assert.deepEqual(result, { data: [{ type: 'text', text: 'recovered' }] })
+  assert.equal(calls, 2)
+})
+
+test('MCP tool call timeout uses MCP_TOOL_TIMEOUT and reports a telemetry-safe timeout', async () => {
+  process.env.MCP_TOOL_TIMEOUT = '1'
+  const client = connectedClient({
+    name: 'slow-sdk',
+    capabilities: { tools: {} },
+    config: { type: 'sdk', name: 'slow-sdk', scope: 'local' },
+    client: {
+      request: async () => ({
+        tools: [{ name: 'slow', inputSchema: { type: 'object' } }],
+      }),
+      callTool: async () => await new Promise(() => {}),
+    } as never,
+  })
+
+  const [tool] = await fetchToolsForClient(client)
+  await assert.rejects(
+    tool!.call(
+      {},
+      {
+        abortController: new AbortController(),
+        setAppState: value => value({ elicitation: { queue: [] } } as never),
+      } as never,
+      undefined as never,
+      { message: { content: [] } } as never,
+    ),
+    /MCP server "slow-sdk" tool "slow" timed out after 0s/,
+  )
+})
+
+test('MCP tool calls log progress while waiting before timing out', async () => {
+  process.env.MCP_TOOL_TIMEOUT = '31000'
+  vi.useFakeTimers()
+  try {
+    const client = connectedClient({
+      name: 'slow-progress-sdk',
+      capabilities: { tools: {} },
+      config: { type: 'sdk', name: 'slow-progress-sdk', scope: 'local' },
+      client: {
+        request: async () => ({
+          tools: [{ name: 'slow-progress', inputSchema: { type: 'object' } }],
+        }),
+        callTool: async () => await new Promise(() => {}),
+      } as never,
+    })
+
+    const [tool] = await fetchToolsForClient(client)
+    const rejection = assert.rejects(
+      tool!.call(
+        {},
+        {
+          abortController: new AbortController(),
+          setAppState: value => value({ elicitation: { queue: [] } } as never),
+        } as never,
+        undefined as never,
+        { message: { content: [] } } as never,
+      ),
+      /MCP server "slow-progress-sdk" tool "slow-progress" timed out after 31s/,
+    )
+
+    await vi.advanceTimersByTimeAsync(31_000)
+    await rejection
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('callMCPToolWithUrlElicitationRetry aborts before attempting calls', async () => {
+  const controller = new AbortController()
+  controller.abort()
+
+  await assert.rejects(
+    callMCPToolWithUrlElicitationRetry({
+      client: connectedClient(),
+      clientConnection: connectedClient(),
+      tool: 'open-url',
+      args: {},
+      signal: controller.signal,
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+      callToolFn: async () => {
+        throw new Error('should not call tool')
+      },
+    }),
+    /Tool call aborted during URL elicitation/,
+  )
+})
+
+test('callMCPToolWithUrlElicitationRetry rejects malformed URL elicitation errors', async () => {
+  const error = new McpError(ErrorCode.UrlElicitationRequired, 'needs url', {
+    elicitations: [{ mode: 'url', url: 123 }],
+  })
+
+  await assert.rejects(
+    callMCPToolWithUrlElicitationRetry({
+      client: connectedClient(),
+      clientConnection: connectedClient({ name: 'browser' }),
+      tool: 'open-url',
+      args: {},
+      signal: new AbortController().signal,
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+      callToolFn: async () => {
+        throw error
+      },
+    }),
+    error,
+  )
+})
+
+test('callMCPToolWithUrlElicitationRetry retries after accepted URL elicitation', async () => {
+  let calls = 0
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        {
+          mode: 'url',
+          url: 'https://example.test/login',
+          elicitationId: 'elicit-1',
+          message: 'Open login',
+        },
+      ],
+    },
+  )
+
+  const result = await callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: value => value({ elicitation: { queue: [] } } as never),
+    handleElicitation: async (_serverName, params) => {
+      assert.equal(params.elicitationId, 'elicit-1')
+      return { action: 'accept' }
+    },
+    callToolFn: async () => {
+      calls += 1
+      if (calls === 1) throw elicitationError
+      return { content: 'opened' }
+    },
+  })
+
+  assert.deepEqual(result, { content: 'opened' })
+  assert.equal(calls, 2)
+})
+
+test('callMCPToolWithUrlElicitationRetry ignores invalid URL elicitation entries before retrying', async () => {
+  let calls = 0
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        null,
+        {
+          mode: 'url',
+          url: 'https://example.test/valid',
+          elicitationId: 'valid-1',
+          message: 'Open valid URL',
+        },
+      ],
+    },
+  )
+
+  const result = await callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: value => value({ elicitation: { queue: [] } } as never),
+    handleElicitation: async (_serverName, params) => {
+      assert.equal(params.elicitationId, 'valid-1')
+      return { action: 'accept' }
+    },
+    callToolFn: async () => {
+      calls += 1
+      if (calls === 1) throw elicitationError
+      return { content: 'opened after invalid entries' }
+    },
+  })
+
+  assert.deepEqual(result, { content: 'opened after invalid entries' })
+  assert.equal(calls, 2)
+})
+
+test('callMCPToolWithUrlElicitationRetry queues REPL elicitation and retries after waiting dismissal', async () => {
+  let calls = 0
+  let queued: QueuedUrlElicitation | undefined
+  let appState = { elicitation: { queue: [] as unknown[] } }
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        {
+          mode: 'url',
+          url: 'https://example.test/consent',
+          elicitationId: 'queue-1',
+          message: 'Open consent',
+        },
+      ],
+    },
+  )
+
+  const resultPromise = callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: update => {
+      appState = update(appState as never) as never
+      queued = appState.elicitation.queue.at(-1) as typeof queued
+    },
+    callToolFn: async () => {
+      calls += 1
+      if (calls === 1) throw elicitationError
+      return { content: 'opened after queue' }
+    },
+  })
+
+  await waitFor(() => queued !== undefined, 'expected URL elicitation to be queued')
+  assert.ok(queued)
+  assert.equal(queued.params.elicitationId, 'queue-1')
+  assert.equal(queued.params.url, 'https://example.test/consent')
+  assert.deepEqual(queued.waitingState, {
+    actionLabel: 'Retry now',
+    showCancel: true,
+  })
+
+  queued.respond({ action: 'accept' })
+  queued.onWaitingDismiss('retry')
+
+  assert.deepEqual(await resultPromise, { content: 'opened after queue' })
+  assert.equal(calls, 2)
+})
+
+test('callMCPToolWithUrlElicitationRetry returns queued decline without retrying', async () => {
+  let calls = 0
+  let queued: QueuedUrlElicitation | undefined
+  let appState = { elicitation: { queue: [] as unknown[] } }
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        {
+          mode: 'url',
+          url: 'https://example.test/decline',
+          elicitationId: 'queue-decline',
+          message: 'Open decline URL',
+        },
+      ],
+    },
+  )
+
+  const resultPromise = callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: update => {
+      appState = update(appState as never) as never
+      queued = appState.elicitation.queue.at(-1) as typeof queued
+    },
+    callToolFn: async () => {
+      calls += 1
+      throw elicitationError
+    },
+  })
+
+  await waitFor(() => queued !== undefined, 'expected URL elicitation to be queued')
+  assert.ok(queued)
+  queued.respond({ action: 'decline' })
+
+  assert.equal(
+    (await resultPromise).content,
+    'URL elicitation was declined by the user. The tool "open-url" could not complete because it requires the user to open a URL.',
+  )
+  assert.equal(calls, 1)
+})
+
+test('callMCPToolWithUrlElicitationRetry cancels queued elicitation from waiting dismissal', async () => {
+  let queued: QueuedUrlElicitation | undefined
+  let appState = { elicitation: { queue: [] as unknown[] } }
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        {
+          mode: 'url',
+          url: 'https://example.test/cancel',
+          elicitationId: 'queue-cancel',
+          message: 'Open cancel URL',
+        },
+      ],
+    },
+  )
+
+  const resultPromise = callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: update => {
+      appState = update(appState as never) as never
+      queued = appState.elicitation.queue.at(-1) as typeof queued
+    },
+    callToolFn: async () => {
+      throw elicitationError
+    },
+  })
+
+  await waitFor(() => queued !== undefined, 'expected URL elicitation to be queued')
+  assert.ok(queued)
+  queued.onWaitingDismiss('cancel')
+
+  assert.equal(
+    (await resultPromise).content,
+    'URL elicitation was canceled by the user. The tool "open-url" could not complete because it requires the user to open a URL.',
+  )
+})
+
+test('callMCPToolWithUrlElicitationRetry cancels before queuing when the signal aborts during the tool call', async () => {
+  let calls = 0
+  const controller = new AbortController()
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        {
+          mode: 'url',
+          url: 'https://example.test/abort',
+          elicitationId: 'queue-abort',
+          message: 'Open abort URL',
+        },
+      ],
+    },
+  )
+
+  const result = await callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: controller.signal,
+    setAppState: () => {
+      throw new Error('should not queue after abort')
+    },
+    callToolFn: async () => {
+      calls += 1
+      controller.abort()
+      throw elicitationError
+    },
+  })
+
+  assert.equal(
+    result.content,
+    'URL elicitation was canceled by the user. The tool "open-url" could not complete because it requires the user to open a URL.',
+  )
+  assert.equal(calls, 1)
+})
+
+test('callMCPToolWithUrlElicitationRetry stops after the URL elicitation retry limit', async () => {
+  let calls = 0
+  let elicitations = 0
+  const elicitationError = new McpError(
+    ErrorCode.UrlElicitationRequired,
+    'needs url',
+    {
+      elicitations: [
+        {
+          mode: 'url',
+          url: 'https://example.test/retry',
+          elicitationId: 'retry-1',
+          message: 'Open retry',
+        },
+      ],
+    },
+  )
+
+  await assert.rejects(
+    callMCPToolWithUrlElicitationRetry({
+      client: connectedClient(),
+      clientConnection: connectedClient({ name: 'browser' }),
+      tool: 'open-url',
+      args: {},
+      signal: new AbortController().signal,
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+      handleElicitation: async () => {
+        elicitations += 1
+        return { action: 'accept' }
+      },
+      callToolFn: async () => {
+        calls += 1
+        throw elicitationError
+      },
+    }),
+    elicitationError,
+  )
+  assert.equal(calls, 4)
+  assert.equal(elicitations, 3)
+})
+
+test('callMCPToolWithUrlElicitationRetry returns a user-facing decline message', async () => {
+  const result = await callMCPToolWithUrlElicitationRetry({
+    client: connectedClient(),
+    clientConnection: connectedClient({ name: 'browser' }),
+    tool: 'open-url',
+    args: {},
+    signal: new AbortController().signal,
+    setAppState: value => value({ elicitation: { queue: [] } } as never),
+    handleElicitation: async () => ({ action: 'decline' }),
+    callToolFn: async () => {
+      throw new McpError(ErrorCode.UrlElicitationRequired, 'needs url', {
+        elicitations: [
+          {
+            mode: 'url',
+            url: 'https://example.test/login',
+            elicitationId: 'elicit-1',
+            message: 'Open login',
+          },
+        ],
+      })
+    },
+  })
+
+  assert.equal(
+    result.content,
+    'URL elicitation was declined by the user. The tool "open-url" could not complete because it requires the user to open a URL.',
+  )
+})
+
+test('ensureConnectedClient returns SDK clients without reconnecting', async () => {
+  const sdkClient = connectedClient({
+    name: 'sdk-direct',
+    config: { type: 'sdk', name: 'sdk-direct', scope: 'local' },
+  })
+
+  assert.equal(await ensureConnectedClient(sdkClient), sdkClient)
+})
+
+test('prefetchAllMcpResources resolves empty config without connecting', async () => {
+  assert.deepEqual(await prefetchAllMcpResources({}), {
+    clients: [],
+    tools: [],
+    commands: [],
+  })
+})
+
+test('prefetchAllMcpResources emits auth tools for cached remote auth failures', async () => {
+  const configDir = await mkdtemp(join(tmpdir(), 'agenc-mcp-auth-prefetch-'))
+  tempDirs.push(configDir)
+  process.env.AGENC_CONFIG_DIR = configDir
+  delete process.env.AGENC_HOME
+  await writeFile(
+    join(configDir, 'mcp-needs-auth-cache.json'),
+    JSON.stringify({
+      cached: { timestamp: Date.now() },
+    }),
+  )
+
+  const result = await prefetchAllMcpResources({
+    cached: {
+      type: 'http',
+      url: 'https://example.test/cached-mcp',
+      scope: 'local',
+    },
+  })
+
+  assert.deepEqual(
+    result.clients.map(client => `${client.name}:${client.type}`),
+    ['cached:needs-auth'],
+  )
+  assert.deepEqual(
+    result.tools.map(tool => tool.name),
+    ['mcp__cached__authenticate'],
+  )
+  assert.deepEqual(result.commands, [])
+})
+
+test('prefetchAllMcpResources reports failed remote clients after auth cache misses', async () => {
+  const configDir = await mkdtemp(join(tmpdir(), 'agenc-mcp-auth-miss-'))
+  tempDirs.push(configDir)
+  process.env.AGENC_CONFIG_DIR = configDir
+  delete process.env.AGENC_HOME
+  const config = {
+    type: 'http',
+    url: 'https://example.test/uncached-mcp',
+    scope: 'local',
+  } as const
+  seedConnectionCache('uncached', config, {
+    name: 'uncached',
+    type: 'failed',
+    config,
+    error: 'connection refused',
+  })
+
+  const result = await prefetchAllMcpResources({ uncached: config })
+
+  assert.deepEqual(result.clients, [
+    {
+      name: 'uncached',
+      type: 'failed',
+      config,
+      error: 'connection refused',
+    },
+  ])
+  assert.deepEqual(result.tools, [])
+  assert.deepEqual(result.commands, [])
+})
+
+test('callIdeRpc returns transformed MCP text content', async () => {
+  const calls: unknown[] = []
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async (...args: unknown[]) => {
+        calls.push(args)
+        return {
+          content: [
+            { type: 'text', text: 'hello' },
+            {
+              type: 'resource_link',
+              name: 'Readme',
+              uri: 'file://readme',
+              description: 'docs',
+            },
+          ],
+          _meta: { requestId: 'req-1' },
+        }
+      },
+    } as never,
+  })
+
+  const content = await callIdeRpc('inspect', { path: 'README.md' }, client)
+
+  assert.deepEqual(content, [
+    { type: 'text', text: 'hello' },
+    { type: 'text', text: '[Resource link: Readme] file://readme (docs)' },
+  ])
+  assert.equal(calls.length, 1)
+  assert.equal((calls[0] as Array<{ name: string; arguments: unknown }>)[0].name, 'inspect')
+  assert.deepEqual((calls[0] as Array<{ name: string; arguments: unknown }>)[0].arguments, {
+    path: 'README.md',
+  })
+})
+
+test('callIdeRpc returns legacy toolResult content as text', async () => {
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        toolResult: 123,
+      }),
+    } as never,
+  })
+
+  assert.equal(await callIdeRpc('legacy', {}, client), '123')
+})
+
+test('callIdeRpc returns structured content as JSON while inferring nested schemas', async () => {
+  const structuredContent = {
+    nullable: null,
+    empty: [],
+    list: [{ deep: true }],
+  }
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({ structuredContent }),
+    } as never,
+  })
+
+  const content = await callIdeRpc('structured', {}, client)
+
+  assert.equal(typeof content, 'string')
+  assert.deepEqual(JSON.parse(content), structuredContent)
+})
+
+test('callIdeRpc transforms resource text and resource links without descriptions', async () => {
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              uri: 'file://notes',
+              text: 'hello',
+            },
+          },
+          {
+            type: 'resource',
+            resource: {
+              uri: 'file://empty',
+            },
+          },
+          {
+            type: 'resource_link',
+            name: 'Notes',
+            uri: 'file://notes',
+          },
+          {
+            type: 'unknown',
+          },
+        ],
+      }),
+    } as never,
+  })
+
+  assert.deepEqual(await callIdeRpc('read', {}, client), [
+    {
+      type: 'text',
+      text: '[Resource from ide at file://notes] hello',
+    },
+    {
+      type: 'text',
+      text: '[Resource link: Notes] file://notes',
+    },
+  ])
+})
+
+test('callIdeRpc persists audio and binary resource content as file references', async () => {
+  const { toolResultsDir } = await configureIsolatedSession()
+  const audioBytes = Buffer.from('sound')
+  const resourceBytes = Buffer.from('%PDF-1.7')
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        content: [
+          {
+            type: 'audio',
+            data: audioBytes.toString('base64'),
+            mimeType: 'audio/wav',
+          },
+          {
+            type: 'resource',
+            resource: {
+              uri: 'file://manual.pdf',
+              blob: resourceBytes.toString('base64'),
+              mimeType: 'application/pdf',
+            },
+          },
+        ],
+      }),
+    } as never,
+  })
+
+  const content = await callIdeRpc('binary-content', {}, client)
+
+  assert.ok(Array.isArray(content))
+  const texts = content.map(block => {
+    if (block.type !== 'text') {
+      assert.fail(`Expected text block, received ${block.type}`)
+    }
+    return block.text
+  })
+  assert.match(
+    texts[0] ?? '',
+    /^\[Audio from ide\] Binary content \(audio\/wav, 5 bytes\) saved to .+\.wav$/,
+  )
+  assert.match(
+    texts[1] ?? '',
+    /^\[Resource from ide at file:\/\/manual\.pdf\] Binary content \(application\/pdf, 8 bytes\) saved to .+\.pdf$/,
+  )
+
+  const persistedFiles = await readdir(toolResultsDir)
+  const audioFile = persistedFiles.find(file => file.endsWith('.wav'))
+  const resourceFile = persistedFiles.find(file => file.endsWith('.pdf'))
+  assert.ok(audioFile)
+  assert.ok(resourceFile)
+  assert.deepEqual(await readFile(join(toolResultsDir, audioFile)), audioBytes)
+  assert.deepEqual(
+    await readFile(join(toolResultsDir, resourceFile)),
+    resourceBytes,
+  )
+})
+
+test('callIdeRpc reports binary persistence failures without exposing raw base64', async () => {
+  const { toolResultsDir } = await configureIsolatedSession()
+  await mkdir(dirname(toolResultsDir), { recursive: true })
+  await writeFile(toolResultsDir, 'not a directory')
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        content: [
+          {
+            type: 'audio',
+            data: Buffer.from('sound').toString('base64'),
+            mimeType: 'audio/wav',
+          },
+        ],
+      }),
+    } as never,
+  })
+
+  const content = await callIdeRpc('binary-write-failure', {}, client)
+
+  assert.ok(Array.isArray(content))
+  assert.equal(content.length, 1)
+  const [block] = content
+  assert.equal(block?.type, 'text')
+  if (block?.type === 'text') {
+    assert.match(
+      block.text,
+      /^\[Audio from ide\] Binary content \(audio\/wav, 5 bytes\) could not be saved to disk: ENOTDIR: not a directory, open '.+\.wav'$/,
+    )
+    assert.doesNotMatch(block.text, /c291bmQ=/)
+  }
+})
+
+test('callIdeRpc transforms image and resource image content into image blocks', async () => {
+  const pngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        content: [
+          {
+            type: 'image',
+            data: pngBase64,
+            mimeType: 'image/png',
+          },
+          {
+            type: 'resource',
+            resource: {
+              uri: 'file://chart.png',
+              blob: pngBase64,
+              mimeType: 'image/png',
+            },
+          },
+        ],
+      }),
+    } as never,
+  })
+
+  const content = await callIdeRpc('image-content', {}, client)
+
+  assert.ok(Array.isArray(content))
+  assert.equal(content.length, 3)
+  assert.equal(content[0]?.type, 'image')
+  assert.equal(content[1]?.type, 'text')
+  if (content[1]?.type === 'text') {
+    assert.equal(content[1].text, '[Resource from ide at file://chart.png] ')
+  }
+  assert.equal(content[2]?.type, 'image')
+  for (const block of [content[0], content[2]]) {
+    if (block?.type !== 'image') {
+      assert.fail(`Expected image block, received ${block?.type}`)
+    }
+    assert.equal(block.source.type, 'base64')
+    assert.equal(block.source.media_type, 'image/png')
+    assert.ok(block.source.data.length > 0)
+  }
+})
+
+test('callIdeRpc throws MCP tool call errors with metadata', async () => {
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        isError: true,
+        content: [{ type: 'text', text: 'tool exploded' }],
+        _meta: { trace: 'trace-1' },
+      }),
+    } as never,
+  })
+
+  await assert.rejects(
+    callIdeRpc('explode', {}, client),
+    (error: unknown) => {
+      assert.equal(
+        error instanceof McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        true,
+      )
+      assert.equal((error as Error).message, 'tool exploded')
+      assert.deepEqual(
+        (error as McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS)
+          .mcpMeta,
+        { _meta: { trace: 'trace-1' } },
+      )
+      return true
+    },
+  )
+})
+
+test('callIdeRpc uses legacy error fields when an MCP error result has no content', async () => {
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({
+        isError: true,
+        error: 'legacy exploded',
+      }),
+    } as never,
+  })
+
+  await assert.rejects(
+    callIdeRpc('legacy-error', {}, client),
+    (error: unknown) => {
+      assert.equal(
+        error instanceof McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        true,
+      )
+      assert.equal((error as Error).message, 'legacy exploded')
+      assert.equal(
+        (error as McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS)
+          .mcpMeta,
+        undefined,
+      )
+      return true
+    },
+  )
+})
+
+test('callIdeRpc rejects unexpected MCP response formats', async () => {
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => ({ ok: true }),
+    } as never,
+  })
+
+  await assert.rejects(
+    callIdeRpc('bad-format', {}, client),
+    /MCP server "ide" tool "bad-format": unexpected response format/,
+  )
+})
+
+test('callIdeRpc converts abort-shaped errors to the runtime AbortError', async () => {
+  const client = connectedClient({
+    name: 'ide',
+    client: {
+      callTool: async () => {
+        const abort = new Error('user stopped')
+        abort.name = 'AbortError'
+        throw abort
+      },
+    } as never,
+  })
+
+  await assert.rejects(
+    callIdeRpc('abort', {}, client),
+    (error: unknown) => {
+      assert.equal((error as Error).name, 'AbortError')
+      assert.equal((error as Error).message, 'user stopped')
+      return true
+    },
+  )
+})
+
+test('callIdeRpc converts unauthorized tool errors into McpAuthError', async () => {
+  const unauthorized = new Error('unauthorized') as Error & { code: number }
+  unauthorized.code = 401
+  const client = connectedClient({
+    name: 'private',
+    client: {
+      callTool: async () => {
+        throw unauthorized
+      },
+    } as never,
+  })
+
+  await assert.rejects(
+    callIdeRpc('secret', {}, client),
+    (error: unknown) => {
+      assert.equal(error instanceof McpAuthError, true)
+      assert.equal((error as McpAuthError).serverName, 'private')
+      return true
+    },
+  )
 })

--- a/runtime/tests/session/sessionStorage-read-helpers.test.ts
+++ b/runtime/tests/session/sessionStorage-read-helpers.test.ts
@@ -1,0 +1,717 @@
+import { afterEach, expect, test } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { UUID } from "node:crypto";
+
+import {
+  resetStateForTests,
+  setOriginalCwd,
+  switchSession,
+} from "../../src/bootstrap/state.js";
+import type { Message } from "../../src/types/message.js";
+import {
+  cleanMessagesForLogging,
+  clearSessionMessagesCache,
+  createProjectForTesting,
+  adoptResumedSessionFile,
+  cacheSessionTitle,
+  buildConversationChain,
+  checkResumeConsistency,
+  doesMessageExistInSession,
+  enrichLogs,
+  extractAgentIdsFromMessages,
+  extractTeammateTranscriptsFromTasks,
+  findUnresolvedToolUse,
+  getAgentTranscript,
+  getAgentTranscriptPath,
+  getLogByIndex,
+  getLastSessionLog,
+  getProjectDir,
+  getProjectsDir,
+  getSessionFilesLite,
+  getSessionFilesWithMtime,
+  getTranscriptPath,
+  getTranscriptPathForSession,
+  hydrateFromCCRv2InternalEvents,
+  loadAllLogsFromSessionFile,
+  loadAllProjectsMessageLogs,
+  loadAllProjectsMessageLogsProgressive,
+  loadAllSubagentTranscriptsFromDisk,
+  loadMessageLogs,
+  loadSameRepoMessageLogs,
+  loadSameRepoMessageLogsProgressive,
+  loadSubagentTranscripts,
+  loadTranscriptFile,
+  resetProjectForTesting,
+  resetProjectFlushStateForTesting,
+  resetSessionFilePointer,
+  searchSessionsByCustomTitle,
+  setInternalEventReader,
+} from "../../src/utils/sessionStorage.js";
+
+const tempDirs: string[] = [];
+const sessionId = "00000000-0000-4000-8000-000000000888";
+const originalConfigDir = process.env.AGENC_CONFIG_DIR;
+const originalAgenCHome = process.env.AGENC_HOME;
+const originalUserType = process.env.USER_TYPE;
+const originalSaveHookContext = process.env.AGENC_SAVE_HOOK_ADDITIONAL_CONTEXT;
+
+function id(n: number): UUID {
+  return `00000000-0000-4000-8000-${String(n).padStart(12, "0")}` as UUID;
+}
+
+function base(uuid: UUID, parentUuid: UUID | null, sid: string = sessionId) {
+  return {
+    uuid,
+    parentUuid,
+    timestamp: `2026-04-02T00:00:${String(Number(uuid.slice(-2)) % 60).padStart(2, "0")}.000Z`,
+    cwd: "/tmp/project",
+    userType: "external",
+    sessionId: sid,
+    version: "test",
+    isSidechain: false,
+  };
+}
+
+function user(
+  uuid: UUID,
+  parentUuid: UUID | null,
+  content: unknown,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    ...base(uuid, parentUuid),
+    type: "user",
+    isMeta: false,
+    message: {
+      role: "user",
+      content,
+    },
+    ...extra,
+  };
+}
+
+function assistant(
+  uuid: UUID,
+  parentUuid: UUID | null,
+  content: unknown,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    ...base(uuid, parentUuid),
+    type: "assistant",
+    message: {
+      id: uuid,
+      type: "message",
+      role: "assistant",
+      content,
+      model: "test-model",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+    ...extra,
+  };
+}
+
+function assistantWithMessageId(
+  uuid: UUID,
+  parentUuid: UUID | null,
+  content: unknown,
+  messageId: string,
+) {
+  const entry = assistant(uuid, parentUuid, content);
+  return {
+    ...entry,
+    message: {
+      ...entry.message,
+      id: messageId,
+    },
+  };
+}
+
+async function writeJsonl(filePath: string, entries: unknown[]): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(
+    filePath,
+    `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+  );
+}
+
+function restoreOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function configureIsolatedSession(cwdName = "project-one"): Promise<{
+  configDir: string;
+  cwd: string;
+  projectDir: string;
+}> {
+  const configDir = await mkdtemp(join(tmpdir(), "agenc-session-read-"));
+  tempDirs.push(configDir);
+  process.env.AGENC_CONFIG_DIR = configDir;
+  delete process.env.AGENC_HOME;
+  resetStateForTests();
+  resetProjectForTesting();
+  clearSessionMessagesCache();
+
+  const cwd = join(configDir, "workspace", cwdName);
+  setOriginalCwd(cwd);
+  switchSession(sessionId as never, null);
+  const projectDir = getProjectDir(cwd);
+  await mkdir(projectDir, { recursive: true });
+  return { configDir, cwd, projectDir };
+}
+
+afterEach(async () => {
+  clearSessionMessagesCache();
+  resetProjectForTesting();
+  resetStateForTests();
+  restoreOptionalEnv("AGENC_CONFIG_DIR", originalConfigDir);
+  restoreOptionalEnv("AGENC_HOME", originalAgenCHome);
+  restoreOptionalEnv("USER_TYPE", originalUserType);
+  restoreOptionalEnv("AGENC_SAVE_HOOK_ADDITIONAL_CONTEXT", originalSaveHookContext);
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("loads lite session files, enriches resume metadata, and resolves log indexes", async () => {
+  const { cwd, projectDir } = await configureIsolatedSession();
+  const visibleSession = sessionId;
+  const sidechainSession = "00000000-0000-4000-8000-000000000889";
+  const teammateSession = "00000000-0000-4000-8000-000000000890";
+
+  await writeJsonl(join(projectDir, `${visibleSession}.jsonl`), [
+    user(id(1), null, "Visible prompt", { gitBranch: "main", cwd }),
+    assistant(id(2), id(1), [{ type: "text", text: "response" }], { gitBranch: "feature/read" }),
+    { type: "last-prompt", sessionId: visibleSession, lastPrompt: "Tail prompt wins" },
+    { type: "custom-title", sessionId: visibleSession, customTitle: "Readable Session" },
+    { type: "summary", leafUuid: id(2), summary: "short summary" },
+    { type: "tag", sessionId: visibleSession, tag: "important" },
+    { type: "agent-setting", sessionId: visibleSession, agentSetting: "planner" },
+    {
+      type: "pr-link",
+      sessionId: visibleSession,
+      prNumber: 42,
+      prUrl: "https://example.test/pr/42",
+      prRepository: "owner/repo",
+      timestamp: "2026-04-02T00:00:10.000Z",
+    },
+  ]);
+  await writeJsonl(join(projectDir, `${sidechainSession}.jsonl`), [
+    user(id(3), null, "hidden sidechain", { sessionId: sidechainSession, isSidechain: true, cwd }),
+  ]);
+  await writeJsonl(join(projectDir, `${teammateSession}.jsonl`), [
+    user(id(4), null, "hidden teammate", { sessionId: teammateSession, teamName: "alpha", cwd }),
+  ]);
+  await writeJsonl(join(projectDir, "not-a-session.jsonl"), [
+    user(id(5), null, "invalid name", { cwd }),
+  ]);
+
+  const files = await getSessionFilesWithMtime(projectDir);
+  expect([...files.keys()].sort()).toEqual([sidechainSession, teammateSession, visibleSession].sort());
+
+  const liteLogs = await getSessionFilesLite(projectDir, undefined, cwd);
+  expect(liteLogs).toHaveLength(3);
+  expect(liteLogs.every((log) => log.isLite)).toBe(true);
+
+  const enriched = await enrichLogs(liteLogs, 0, 3);
+  expect(enriched.nextIndex).toBe(3);
+  expect(enriched.logs).toHaveLength(1);
+  expect(enriched.logs[0]).toMatchObject({
+    firstPrompt: "Tail prompt wins",
+    customTitle: "Readable Session",
+    summary: "short summary",
+    tag: "important",
+    agentSetting: "planner",
+    prNumber: 42,
+    prUrl: "https://example.test/pr/42",
+    prRepository: "owner/repo",
+    gitBranch: "feature/read",
+    projectPath: cwd,
+  });
+
+  const messageLogs = await loadMessageLogs();
+  expect(messageLogs).toHaveLength(1);
+  expect(messageLogs[0]!.value).toBe(0);
+  await expect(getLogByIndex(0)).resolves.toMatchObject({
+    customTitle: "Readable Session",
+    firstPrompt: "Tail prompt wins",
+  });
+  await expect(getLogByIndex(9)).resolves.toBeNull();
+  await expect(searchSessionsByCustomTitle("readable")).resolves.toHaveLength(1);
+  await expect(
+    searchSessionsByCustomTitle("Readable Session", { exact: true, limit: 1 }),
+  ).resolves.toMatchObject([{ customTitle: "Readable Session" }]);
+  await expect(searchSessionsByCustomTitle("missing")).resolves.toEqual([]);
+});
+
+test("loads all project logs through progressive and full scan paths", async () => {
+  const { configDir, cwd, projectDir } = await configureIsolatedSession("project-a");
+  const otherCwd = join(configDir, "workspace", "project-b");
+  const otherProjectDir = getProjectDir(otherCwd);
+  await mkdir(otherProjectDir, { recursive: true });
+  const otherSession = "00000000-0000-4000-8000-000000000891";
+
+  await writeJsonl(join(projectDir, `${sessionId}.jsonl`), [
+    user(id(10), null, "Prompt from A", { cwd }),
+    assistant(id(11), id(10), [{ type: "text", text: "A" }], { cwd }),
+  ]);
+  await writeJsonl(join(otherProjectDir, `${otherSession}.jsonl`), [
+    user(id(12), null, "Prompt from B", { sessionId: otherSession, cwd: otherCwd }),
+    assistant(id(13), id(12), [{ type: "text", text: "B" }], {
+      sessionId: otherSession,
+      cwd: otherCwd,
+    }),
+  ]);
+
+  const progressive = await loadAllProjectsMessageLogsProgressive(undefined, 1);
+  expect(progressive.allStatLogs).toHaveLength(2);
+  expect(progressive.logs).toHaveLength(1);
+  expect(progressive.nextIndex).toBe(1);
+
+  const defaultAllProjects = await loadAllProjectsMessageLogs(undefined, {
+    initialEnrichCount: 2,
+  });
+  expect(defaultAllProjects.map((log) => log.firstPrompt).sort()).toEqual([
+    "Prompt from A",
+    "Prompt from B",
+  ]);
+
+  const fullScan = await loadAllProjectsMessageLogs(undefined, { skipIndex: true });
+  expect(fullScan.map((log) => log.firstPrompt).sort()).toEqual([
+    "Prompt from A",
+    "Prompt from B",
+  ]);
+});
+
+test("loads same-repo worktree logs from matching project directories", async () => {
+  const { configDir, cwd, projectDir } = await configureIsolatedSession("repo");
+  const worktreeCwd = join(configDir, "workspace", "repo-feature");
+  const worktreeProjectDir = getProjectDir(worktreeCwd);
+  await mkdir(worktreeProjectDir, { recursive: true });
+  const worktreeSession = "00000000-0000-4000-8000-000000000892";
+
+  await writeJsonl(join(projectDir, `${sessionId}.jsonl`), [
+    user(id(20), null, "Main worktree prompt", { cwd }),
+  ]);
+  await writeJsonl(join(worktreeProjectDir, `${worktreeSession}.jsonl`), [
+    user(id(21), null, "Feature worktree prompt", {
+      sessionId: worktreeSession,
+      cwd: worktreeCwd,
+    }),
+  ]);
+
+  const currentOnly = await loadSameRepoMessageLogsProgressive([cwd], undefined, 5);
+  expect(currentOnly.logs.map((log) => log.firstPrompt)).toEqual(["Main worktree prompt"]);
+
+  const both = await loadSameRepoMessageLogsProgressive([cwd, worktreeCwd], undefined, 5);
+  expect(both.logs.map((log) => log.firstPrompt).sort()).toEqual([
+    "Feature worktree prompt",
+    "Main worktree prompt",
+  ]);
+  expect(both.allStatLogs).toHaveLength(2);
+
+  const wrapper = await loadSameRepoMessageLogs([cwd, worktreeCwd], undefined, 5);
+  expect(wrapper.map((log) => log.firstPrompt).sort()).toEqual([
+    "Feature worktree prompt",
+    "Main worktree prompt",
+  ]);
+});
+
+test("loads full logs from a session file with leaf metadata and trailing children", async () => {
+  const { cwd, projectDir } = await configureIsolatedSession();
+  const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+  await writeJsonl(sessionFile, [
+    user(id(30), null, "Root prompt", { cwd }),
+    assistant(id(31), id(30), [{ type: "text", text: "Leaf response" }], { cwd }),
+    user(id(32), id(31), "Trailing child", { cwd }),
+    { type: "custom-title", sessionId, customTitle: "Full log title" },
+    { type: "tag", sessionId, tag: "full" },
+    { type: "agent-name", sessionId, agentName: "Agent Smith" },
+    { type: "agent-color", sessionId, agentColor: "blue" },
+    { type: "agent-setting", sessionId, agentSetting: "reviewer" },
+    { type: "mode", sessionId, mode: "coordinator" },
+  ]);
+
+  const logs = await loadAllLogsFromSessionFile(sessionFile, "/override/project");
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toMatchObject({
+    firstPrompt: "Root prompt",
+    customTitle: "Full log title",
+    tag: "full",
+    agentName: "Agent Smith",
+    agentColor: "blue",
+    agentSetting: "reviewer",
+    mode: "coordinator",
+    projectPath: "/override/project",
+  });
+  expect(logs[0]!.messages.map((message) => message.uuid)).toEqual([id(30), id(31), id(32)]);
+  await expect(doesMessageExistInSession(sessionId as UUID, id(31))).resolves.toBe(true);
+  await expect(doesMessageExistInSession(sessionId as UUID, id(99))).resolves.toBe(false);
+  await expect(getLastSessionLog(sessionId as UUID)).resolves.toMatchObject({
+    firstPrompt: "Root prompt",
+    customTitle: "Full log title",
+  });
+});
+
+test("hydrates CCR v2 internal events into foreground and subagent transcripts", async () => {
+  await configureIsolatedSession();
+  const agentId = "worker-two";
+
+  await expect(hydrateFromCCRv2InternalEvents(sessionId)).resolves.toBe(false);
+
+  setInternalEventReader(
+    async () => null,
+    async () => [],
+  );
+  await expect(hydrateFromCCRv2InternalEvents(sessionId)).resolves.toBe(false);
+
+  setInternalEventReader(
+    async () => [{ payload: user(id(70), null, "foreground event") }],
+    async () => [
+      {
+        agent_id: agentId,
+        payload: user(id(71), null, "subagent event", {
+          isSidechain: true,
+          agentId,
+        }),
+      },
+      {
+        agent_id: "",
+        payload: user(id(72), null, "ignored missing agent", {
+          isSidechain: true,
+        }),
+      },
+    ],
+  );
+
+  await expect(hydrateFromCCRv2InternalEvents(sessionId)).resolves.toBe(true);
+  const foreground = (await readFile(getTranscriptPathForSession(sessionId), "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  expect(foreground).toEqual([expect.objectContaining({ uuid: id(70) })]);
+  await expect(getAgentTranscript(agentId as never)).resolves.toMatchObject({
+    messages: [expect.objectContaining({ uuid: id(71) })],
+  });
+
+  setInternalEventReader(
+    async () => {
+      throw new Error("CCRClient: Epoch mismatch (409)");
+    },
+    async () => [],
+  );
+  await expect(hydrateFromCCRv2InternalEvents(sessionId)).rejects.toThrow(
+    "CCRClient: Epoch mismatch (409)",
+  );
+
+  setInternalEventReader(
+    async () => {
+      throw new Error("reader failed");
+    },
+    async () => [],
+  );
+  await expect(hydrateFromCCRv2InternalEvents(sessionId)).resolves.toBe(false);
+});
+
+test("adopts a resumed session file and re-appends cached metadata", async () => {
+  await configureIsolatedSession();
+  await writeJsonl(getTranscriptPath(), [user(id(80), null, "resumed prompt")]);
+
+  cacheSessionTitle("Adopted title");
+  resetSessionFilePointer();
+  adoptResumedSessionFile();
+
+  const lines = (await readFile(getTranscriptPath(), "utf8")).trim().split("\n");
+  expect(lines.map((line) => JSON.parse(line) as Record<string, unknown>)).toEqual([
+    expect.objectContaining({ uuid: id(80) }),
+    expect.objectContaining({
+      type: "custom-title",
+      customTitle: "Adopted title",
+      sessionId,
+    }),
+  ]);
+});
+
+test("exposes a project write handle for drain and append failure tests", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "agenc-project-handle-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, "queued.jsonl");
+  const projectHandle = createProjectForTesting();
+  const writes: string[] = [];
+
+  expect(projectHandle.flushIntervalMs).toBeGreaterThan(0);
+  projectHandle.setAppendOverride(async (_filePath, data) => {
+    writes.push(data);
+  });
+  await projectHandle.enqueueWrite(filePath, {
+    type: "tag",
+    sessionId: sessionId as UUID,
+    tag: "queued",
+  });
+  await projectHandle.flush();
+  expect(writes).toEqual([
+    `${JSON.stringify({ type: "tag", sessionId, tag: "queued" })}\n`,
+  ]);
+
+  projectHandle.setAppendOverride(async () => {
+    throw new Error("disk full");
+  });
+  await expect(
+    projectHandle.enqueueWrite(filePath, {
+      type: "custom-title",
+      sessionId: sessionId as UUID,
+      customTitle: "still resolves",
+    }),
+  ).resolves.toBeUndefined();
+  await expect(projectHandle.flush()).resolves.toBeUndefined();
+  resetProjectFlushStateForTesting();
+});
+
+test("finds unresolved tool uses and ignores resolved ones", async () => {
+  await configureIsolatedSession();
+  await writeJsonl(getTranscriptPath(), [
+    user(id(40), null, "Run a tool"),
+    assistant(id(41), id(40), [
+      { type: "text", text: "checking" },
+      { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "pwd" } },
+    ]),
+  ]);
+
+  await expect(findUnresolvedToolUse("tool-1")).resolves.toMatchObject({
+    uuid: id(41),
+    type: "assistant",
+  });
+
+  await writeJsonl(getTranscriptPath(), [
+    user(id(40), null, "Run a tool"),
+    assistant(id(41), id(40), [
+      { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "pwd" } },
+    ]),
+    user(id(42), id(41), [{ type: "tool_result", tool_use_id: "tool-1", content: "done" }]),
+  ]);
+  await expect(findUnresolvedToolUse("tool-1")).resolves.toBeNull();
+});
+
+test("bridges legacy progress entries and applies snip removals on transcript load", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  const filePath = join(projectDir, `${sessionId}.jsonl`);
+  const progressUuid = id(101);
+  const removedUuid = id(103);
+  await writeJsonl(filePath, [
+    user(id(100), null, "root"),
+    {
+      type: "progress",
+      uuid: progressUuid,
+      parentUuid: id(100),
+      timestamp: "2026-04-02T00:01:41.000Z",
+    },
+    assistant(id(102), progressUuid, [{ type: "text", text: "after progress" }]),
+    user(removedUuid, id(102), "removed by snip"),
+    assistant(id(104), removedUuid, [{ type: "text", text: "survives snip" }]),
+    {
+      ...base(id(105), id(104)),
+      type: "system",
+      subtype: "compact_boundary",
+      level: "info",
+      content: "snipped",
+      snipMetadata: { removedUuids: [removedUuid] },
+    },
+  ]);
+
+  const loaded = await loadTranscriptFile(filePath);
+  expect(loaded.messages.get(id(102))!.parentUuid).toBe(id(100));
+  expect(loaded.messages.has(removedUuid)).toBe(false);
+  expect(loaded.messages.get(id(104))!.parentUuid).toBe(id(102));
+  checkResumeConsistency([...loaded.messages.values()] as never);
+});
+
+test("recovers orphaned parallel tool results when rebuilding a chain", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  const filePath = join(projectDir, `${sessionId}.jsonl`);
+  await writeJsonl(filePath, [
+    user(id(110), null, "parallel tools"),
+    assistantWithMessageId(id(111), id(110), [
+      { type: "tool_use", id: "tool-a", name: "Read", input: { file_path: "a" } },
+    ], "assistant-message-1"),
+    assistantWithMessageId(id(112), id(111), [
+      { type: "tool_use", id: "tool-b", name: "Read", input: { file_path: "b" } },
+    ], "assistant-message-1"),
+    user(id(113), id(111), [{ type: "tool_result", tool_use_id: "tool-a", content: "a" }]),
+    user(id(114), id(112), [{ type: "tool_result", tool_use_id: "tool-b", content: "b" }]),
+    assistant(id(115), id(113), [{ type: "text", text: "done" }]),
+  ]);
+
+  const { messages } = await loadTranscriptFile(filePath);
+  const chain = buildConversationChain(messages, messages.get(id(115))!);
+  expect(chain.map((message) => message.uuid)).toEqual([
+    id(110),
+    id(111),
+    id(112),
+    id(114),
+    id(113),
+    id(115),
+  ]);
+});
+
+test("enriches lite logs from a truncated prompt prefix", async () => {
+  const { cwd, projectDir } = await configureIsolatedSession();
+  const truncatedSession = "00000000-0000-4000-8000-000000000893";
+  await writeFile(
+    join(projectDir, `${truncatedSession}.jsonl`),
+    '{"type":"user","message":{"content":"Prompt recovered from prefix only',
+  );
+
+  const liteLogs = await getSessionFilesLite(projectDir, undefined, cwd);
+  const { logs } = await enrichLogs(liteLogs, 0, liteLogs.length);
+  expect(logs).toEqual([
+    expect.objectContaining({
+      sessionId: truncatedSession,
+      firstPrompt: "Prompt recovered from prefix only",
+    }),
+  ]);
+});
+
+test("loads subagent transcripts from agent files and task state", async () => {
+  await configureIsolatedSession();
+  const agentId = "worker-one";
+  const agentFile = getAgentTranscriptPath(agentId as never);
+  await writeJsonl(agentFile, [
+    user(id(50), null, "agent prompt", {
+      isSidechain: true,
+      agentId,
+    }),
+    assistant(id(51), id(50), [{ type: "text", text: "agent reply" }], {
+      isSidechain: true,
+      agentId,
+    }),
+    {
+      type: "content-replacement",
+      sessionId,
+      agentId,
+      replacements: [
+        {
+          kind: "tool-result",
+          toolUseId: "tool-1",
+          replacement: "[stored elsewhere]",
+        },
+      ],
+    },
+  ]);
+  await writeJsonl(join(dirname(agentFile), "agent-ignored.txt"), []);
+
+  await expect(getAgentTranscript(agentId as never)).resolves.toMatchObject({
+    messages: [{ uuid: id(50) }, { uuid: id(51) }],
+    contentReplacements: [{ toolUseId: "tool-1" }],
+  });
+  await expect(loadSubagentTranscripts([agentId, "missing-agent"])).resolves.toEqual({
+    [agentId]: expect.arrayContaining([expect.objectContaining({ uuid: id(50) })]),
+  });
+  await expect(loadAllSubagentTranscriptsFromDisk()).resolves.toEqual({
+    [agentId]: expect.arrayContaining([expect.objectContaining({ uuid: id(51) })]),
+  });
+
+  const progressMessages = [
+    { type: "progress", data: { type: "agent_progress", agentId } },
+    { type: "progress", data: { type: "skill_progress", agentId: "skill-one" } },
+    { type: "progress", data: { type: "other", agentId: "ignored" } },
+  ] as Message[];
+  expect(extractAgentIdsFromMessages(progressMessages)).toEqual([agentId, "skill-one"]);
+
+  const taskMessages = [{ type: "user", uuid: id(55), message: { role: "user", content: "task" } }] as Message[];
+  expect(
+    extractTeammateTranscriptsFromTasks({
+      one: {
+        type: "in_process_teammate",
+        identity: { agentId: "teammate-one" },
+        messages: taskMessages,
+      },
+      two: { type: "other", identity: { agentId: "ignored" }, messages: taskMessages },
+    }),
+  ).toEqual({ "teammate-one": taskMessages });
+});
+
+test("cleans transcript messages for external logging while preserving ant transcripts", () => {
+  restoreOptionalEnv("USER_TYPE", undefined);
+  process.env.AGENC_SAVE_HOOK_ADDITIONAL_CONTEXT = "1";
+  const replAssistant = assistant(id(60), null, [
+    { type: "tool_use", id: "repl-1", name: "REPL", input: {} },
+    { type: "tool_use", id: "bash-1", name: "Bash", input: { command: "ls" } },
+  ]) as Message;
+  const replResult = {
+    ...user(id(61), id(60), [
+      { type: "tool_result", tool_use_id: "repl-1", content: "hidden" },
+      { type: "text", text: "visible" },
+    ]),
+    isVirtual: true,
+  } as Message;
+  const plainVirtual = { ...user(id(62), id(61), "plain virtual"), isVirtual: true } as Message;
+  const normalAttachment = {
+    type: "attachment",
+    uuid: id(63),
+    attachment: { type: "file", filePath: "/tmp/a.txt" },
+  } as unknown as Message;
+  const hookAttachment = {
+    type: "attachment",
+    uuid: id(64),
+    attachment: { type: "hook_additional_context", content: "hook" },
+  } as unknown as Message;
+  const progress = { type: "progress", uuid: id(65), data: { type: "status" } } as unknown as Message;
+
+  const cleaned = cleanMessagesForLogging(
+    [replAssistant, replResult, plainVirtual, normalAttachment, hookAttachment, progress],
+    [replAssistant],
+  ) as Array<Record<string, unknown>>;
+
+  expect(cleaned.map((message) => message.type)).toEqual([
+    "assistant",
+    "user",
+    "user",
+    "attachment",
+  ]);
+  expect((cleaned[0]!.message as { content: Array<{ id?: string }> }).content).toEqual([
+    { type: "tool_use", id: "bash-1", name: "Bash", input: { command: "ls" } },
+  ]);
+  expect(cleaned[1]).not.toHaveProperty("isVirtual");
+  expect((cleaned[1]!.message as { content: Array<{ type: string }> }).content).toEqual([
+    { type: "text", text: "visible" },
+  ]);
+  expect(cleaned[2]).not.toHaveProperty("isVirtual");
+
+  process.env.USER_TYPE = "ant";
+  const antCleaned = cleanMessagesForLogging([replAssistant, normalAttachment], [replAssistant]);
+  expect(antCleaned).toHaveLength(2);
+  expect((antCleaned[0]!.message.content as Array<{ id?: string }>).map((block) => block.id)).toEqual([
+    "repl-1",
+    "bash-1",
+  ]);
+});
+
+test("returns empty read results for missing project and transcript files", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  await rm(projectDir, { recursive: true, force: true });
+
+  await expect(getSessionFilesWithMtime(projectDir)).resolves.toEqual(new Map());
+  await expect(loadMessageLogs()).resolves.toEqual([]);
+  await expect(loadAllProjectsMessageLogs()).resolves.toEqual([]);
+  await expect(loadAllProjectsMessageLogsProgressive()).resolves.toEqual({
+    logs: [],
+    allStatLogs: [],
+    nextIndex: 0,
+  });
+  await rm(getProjectsDir(), { recursive: true, force: true });
+  await expect(loadSameRepoMessageLogsProgressive(["/missing-a", "/missing-b"])).resolves.toEqual({
+    logs: [],
+    allStatLogs: [],
+    nextIndex: 0,
+  });
+});

--- a/runtime/tests/session/sessionStorage-transcript.test.ts
+++ b/runtime/tests/session/sessionStorage-transcript.test.ts
@@ -1,0 +1,1118 @@
+import { afterEach, expect, test } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { clearAllSessions as clearSessionIngressState } from "../../src/services/api/sessionIngress.js";
+import {
+  resetStateForTests,
+  setOriginalCwd,
+  switchSession,
+} from "../../src/bootstrap/state.js";
+import {
+  buildConversationChain,
+  clearAgentTranscriptSubdir,
+  deleteRemoteAgentMetadata,
+  cacheSessionTitle,
+  clearSessionMetadata,
+  getAgentTranscriptPath,
+  getCurrentSessionAgentColor,
+  getCurrentSessionTag,
+  getCurrentSessionTitle,
+  getFirstMeaningfulUserMessageTextContent,
+  getProjectDir,
+  getSessionIdFromLog,
+  getTranscriptPath,
+  getTranscriptPathForSession,
+  flushSessionStorage,
+  hydrateRemoteSession,
+  isChainParticipant,
+  isCustomTitleEnabled,
+  isEphemeralToolProgress,
+  isLiteLog,
+  isTranscriptMessage,
+  linkSessionToPR,
+  listRemoteAgentMetadata,
+  loadFullLog,
+  loadTranscriptFromFile,
+  loadTranscriptFile,
+  readAgentMetadata,
+  readRemoteAgentMetadata,
+  reAppendSessionMetadata,
+  recordAttributionSnapshot,
+  recordContentReplacement,
+  recordContextCollapseCommit,
+  recordContextCollapseSnapshot,
+  recordFileHistorySnapshot,
+  recordQueueOperation,
+  recordSidechainTranscript,
+  recordTranscript,
+  removeTranscriptMessage,
+  removeExtraFields,
+  resetProjectForTesting,
+  restoreSessionMetadata,
+  saveAgentColor,
+  saveAgentName,
+  saveAgentSetting,
+  saveAiGeneratedTitle,
+  saveCustomTitle,
+  saveMode,
+  saveTag,
+  saveTaskSummary,
+  saveWorktreeState,
+  sessionIdExists,
+  setAgentTranscriptSubdir,
+  setInternalEventWriter,
+  setRemoteIngressUrlForTesting,
+  setSessionFileForTesting,
+  stripPersistedToolUseResultsFromJSONLBuffer,
+  writeAgentMetadata,
+  writeRemoteAgentMetadata,
+} from "../../src/utils/sessionStorage.js";
+
+const tempDirs: string[] = [];
+const sessionId = "00000000-0000-4000-8000-000000000999";
+const ts = "2026-04-02T00:00:00.000Z";
+const originalConfigDir = process.env.AGENC_CONFIG_DIR;
+const originalAgenCHome = process.env.AGENC_HOME;
+const originalTestPersistence = process.env.TEST_ENABLE_SESSION_PERSISTENCE;
+const originalEnablePersistence = process.env.ENABLE_SESSION_PERSISTENCE;
+const originalSessionAccessToken = process.env.AGENC_SESSION_ACCESS_TOKEN;
+const originalAfterLastCompact = process.env.AGENC_AFTER_LAST_COMPACT;
+
+function id(n: number): string {
+  return `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+}
+
+function base(uuid: string, parentUuid: string | null) {
+  return {
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    cwd: "/tmp",
+    userType: "external",
+    sessionId,
+    version: "test",
+    isSidechain: false,
+  };
+}
+
+function user(uuid: string, parentUuid: string | null, content: string) {
+  return {
+    ...base(uuid, parentUuid),
+    type: "user",
+    isMeta: false,
+    message: {
+      role: "user",
+      content,
+    },
+  };
+}
+
+function assistant(uuid: string, parentUuid: string | null, text: string) {
+  return {
+    ...base(uuid, parentUuid),
+    type: "assistant",
+    message: {
+      id: uuid,
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text }],
+      model: "test-model",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  };
+}
+
+function runtimeMessage<T extends Record<string, unknown>>(entry: T): T {
+  const {
+    parentUuid: _parentUuid,
+    cwd: _cwd,
+    userType: _userType,
+    sessionId: _sessionId,
+    version: _version,
+    isSidechain: _isSidechain,
+    ...message
+  } = entry;
+  return message as T;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startSessionIngressServer(
+  handler: (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ) => void | Promise<void>,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((request, response) => {
+    void Promise.resolve(handler(request, response)).catch((error) => {
+      response.statusCode = 500;
+      response.end(String(error));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/session`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function compactBoundary(
+  uuid: string,
+  parentUuid: string | null,
+  preservedSegment: {
+    headUuid: string;
+    anchorUuid: string;
+    tailUuid: string;
+  },
+) {
+  return {
+    ...base(uuid, parentUuid),
+    type: "system",
+    subtype: "compact_boundary",
+    level: "info",
+    isMeta: false,
+    content: "Conversation compacted",
+    compactMetadata: {
+      trigger: "manual",
+      preTokens: 123,
+      preservedSegment,
+    },
+  };
+}
+
+async function writeJsonl(entries: unknown[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "agenc-session-storage-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, "session.jsonl");
+  await writeFile(filePath, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+  return filePath;
+}
+
+async function writeTempFile(fileName: string, content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "agenc-session-storage-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, fileName);
+  await writeFile(filePath, content);
+  return filePath;
+}
+
+async function readJsonlEntries(filePath: string): Promise<Record<string, unknown>[]> {
+  return (await readFile(filePath, "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function restoreOptionalEnv(
+  name:
+    | "AGENC_CONFIG_DIR"
+    | "AGENC_HOME"
+    | "TEST_ENABLE_SESSION_PERSISTENCE"
+    | "ENABLE_SESSION_PERSISTENCE"
+    | "AGENC_SESSION_ACCESS_TOKEN"
+    | "AGENC_AFTER_LAST_COMPACT",
+  value: string | undefined,
+) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function configureIsolatedSession(): Promise<{
+  configDir: string;
+  cwd: string;
+  projectDir: string;
+}> {
+  const configDir = await mkdtemp(join(tmpdir(), "agenc-session-config-"));
+  tempDirs.push(configDir);
+  process.env.AGENC_CONFIG_DIR = configDir;
+  delete process.env.AGENC_HOME;
+  resetStateForTests();
+  resetProjectForTesting();
+
+  const cwd = join(configDir, "workspace", "project one");
+  setOriginalCwd(cwd);
+  switchSession(sessionId as never, null);
+
+  return {
+    configDir,
+    cwd,
+    projectDir: getProjectDir(cwd),
+  };
+}
+
+afterEach(async () => {
+  resetProjectForTesting();
+  resetStateForTests();
+  restoreOptionalEnv("AGENC_CONFIG_DIR", originalConfigDir);
+  restoreOptionalEnv("AGENC_HOME", originalAgenCHome);
+  restoreOptionalEnv("TEST_ENABLE_SESSION_PERSISTENCE", originalTestPersistence);
+  restoreOptionalEnv("ENABLE_SESSION_PERSISTENCE", originalEnablePersistence);
+  restoreOptionalEnv("AGENC_SESSION_ACCESS_TOKEN", originalSessionAccessToken);
+  restoreOptionalEnv("AGENC_AFTER_LAST_COMPACT", originalAfterLastCompact);
+  clearSessionIngressState();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+test("classifies transcript, chain, and ephemeral progress entries", () => {
+  expect(isTranscriptMessage({ type: "user" } as never)).toBe(true);
+  expect(isTranscriptMessage({ type: "assistant" } as never)).toBe(true);
+  expect(isTranscriptMessage({ type: "attachment" } as never)).toBe(true);
+  expect(isTranscriptMessage({ type: "system" } as never)).toBe(true);
+  expect(isTranscriptMessage({ type: "progress" } as never)).toBe(false);
+
+  expect(isChainParticipant({ type: "user" })).toBe(true);
+  expect(isChainParticipant({ type: "progress" })).toBe(false);
+
+  expect(isEphemeralToolProgress("bash_progress")).toBe(true);
+  expect(isEphemeralToolProgress("powershell_progress")).toBe(true);
+  expect(isEphemeralToolProgress("mcp_progress")).toBe(true);
+  expect(isEphemeralToolProgress("other_progress")).toBe(false);
+  expect(isEphemeralToolProgress(undefined)).toBe(false);
+});
+
+test("uses isolated session paths for transcripts and agent metadata", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  const agentId = "agent-meta" as never;
+
+  expect(getTranscriptPath()).toBe(join(projectDir, `${sessionId}.jsonl`));
+  expect(getTranscriptPathForSession(sessionId)).toBe(
+    join(projectDir, `${sessionId}.jsonl`),
+  );
+  expect(getTranscriptPathForSession("00000000-0000-4000-8000-000000000111"))
+    .toBe(join(projectDir, "00000000-0000-4000-8000-000000000111.jsonl"));
+  expect(isCustomTitleEnabled()).toBe(true);
+  expect(await readAgentMetadata(agentId)).toBeNull();
+
+  setAgentTranscriptSubdir("agent-meta", "workflow/run-1");
+  const nestedPath = getAgentTranscriptPath(agentId);
+  expect(nestedPath).toBe(
+    join(
+      projectDir,
+      sessionId,
+      "subagents",
+      "workflow/run-1",
+      "agent-agent-meta.jsonl",
+    ),
+  );
+
+  await writeAgentMetadata(agentId, {
+    agentType: "review",
+    worktreePath: "/tmp/worktree",
+    description: "inspect changes",
+  });
+  expect(await readAgentMetadata(agentId)).toEqual({
+    agentType: "review",
+    worktreePath: "/tmp/worktree",
+    description: "inspect changes",
+  });
+
+  clearAgentTranscriptSubdir("agent-meta");
+  expect(getAgentTranscriptPath(agentId)).toBe(
+    join(projectDir, sessionId, "subagents", "agent-agent-meta.jsonl"),
+  );
+});
+
+test("persists, lists, and deletes remote agent metadata", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  const metadata = {
+    taskId: "task-1",
+    remoteTaskType: "review",
+    sessionId: "ccr-session",
+    title: "Review task",
+    command: "review",
+    spawnedAt: 123,
+    toolUseId: "tu_remote",
+    isLongRunning: true,
+    isRemoteReview: true,
+    remoteTaskMetadata: { priority: "high" },
+  };
+
+  expect(await readRemoteAgentMetadata("task-1")).toBeNull();
+  expect(await listRemoteAgentMetadata()).toEqual([]);
+
+  await writeRemoteAgentMetadata("task-1", metadata);
+  const remoteDir = join(projectDir, sessionId, "remote-agents");
+  await writeFile(join(remoteDir, "remote-agent-corrupt.meta.json"), "{");
+  await writeFile(join(remoteDir, "ignore.txt"), "{}");
+
+  expect(await readRemoteAgentMetadata("task-1")).toEqual(metadata);
+  expect(await listRemoteAgentMetadata()).toEqual([metadata]);
+
+  await deleteRemoteAgentMetadata("task-1");
+  await deleteRemoteAgentMetadata("task-1");
+  expect(await readRemoteAgentMetadata("task-1")).toBeNull();
+});
+
+test("checks session file existence in the current project directory", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  const transcriptPath = join(projectDir, `${sessionId}.jsonl`);
+
+  expect(sessionIdExists(sessionId)).toBe(false);
+  await mkdir(dirname(transcriptPath), { recursive: true });
+  await writeFile(transcriptPath, "");
+  expect(sessionIdExists(sessionId)).toBe(true);
+  expect(sessionIdExists("00000000-0000-4000-8000-000000000404")).toBe(false);
+});
+
+test("persists and re-appends session metadata entries", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  const transcriptPath = join(projectDir, `${sessionId}.jsonl`);
+  setSessionFileForTesting(transcriptPath);
+
+  await saveCustomTitle(sessionId as never, "Custom title", transcriptPath);
+  saveAiGeneratedTitle(sessionId as never, "AI title");
+  saveTaskSummary(sessionId as never, "Working on tests");
+  await saveTag(sessionId as never, "coverage", transcriptPath);
+  await saveAgentName(sessionId as never, "Runtime Agent", transcriptPath);
+  await saveAgentColor(sessionId as never, "blue", transcriptPath);
+  saveAgentSetting("staff-engineer");
+  cacheSessionTitle("Startup title");
+  saveMode("coordinator");
+  saveWorktreeState({
+    originalCwd: "/repo",
+    worktreePath: "/repo/.agenc-worktrees/feat",
+    worktreeName: "feat",
+    worktreeBranch: "worktree-feat",
+    originalBranch: "main",
+    originalHeadCommit: "abc123",
+    sessionId,
+    tmuxSessionName: "agenc-feat",
+    hookBased: true,
+    creationDurationMs: 999,
+    usedSparsePaths: true,
+  } as never);
+  await linkSessionToPR(
+    sessionId as never,
+    42,
+    "https://github.example/pull/42",
+    "owner/repo",
+    transcriptPath,
+  );
+
+  expect(getCurrentSessionTitle(sessionId as never)).toBe("Startup title");
+  expect(getCurrentSessionTag(sessionId as never)).toBe("coverage");
+  expect(getCurrentSessionAgentColor()).toBe("blue");
+
+  reAppendSessionMetadata();
+
+  const entries = await readJsonlEntries(transcriptPath);
+  expect(entries.map((entry) => entry.type)).toEqual(
+    expect.arrayContaining([
+      "custom-title",
+      "ai-title",
+      "task-summary",
+      "tag",
+      "agent-name",
+      "agent-color",
+      "agent-setting",
+      "mode",
+      "worktree-state",
+      "pr-link",
+    ]),
+  );
+  expect(entries.filter((entry) => entry.type === "custom-title").at(-1))
+    .toMatchObject({ customTitle: "Custom title", sessionId });
+  expect(entries.filter((entry) => entry.type === "tag").at(-1))
+    .toMatchObject({ tag: "coverage", sessionId });
+  expect(entries.filter((entry) => entry.type === "worktree-state").at(-1))
+    .toMatchObject({
+      worktreeSession: {
+        originalCwd: "/repo",
+        worktreePath: "/repo/.agenc-worktrees/feat",
+        worktreeName: "feat",
+        worktreeBranch: "worktree-feat",
+        originalBranch: "main",
+        originalHeadCommit: "abc123",
+        sessionId,
+        tmuxSessionName: "agenc-feat",
+        hookBased: true,
+      },
+    });
+  expect(
+    entries
+      .filter((entry) => entry.type === "worktree-state")
+      .at(-1)?.worktreeSession,
+  ).not.toMatchObject({
+    creationDurationMs: 999,
+    usedSparsePaths: true,
+  });
+});
+
+test("restores and clears in-memory session metadata", async () => {
+  await configureIsolatedSession();
+
+  restoreSessionMetadata({
+    customTitle: "Restored title",
+    tag: "restored",
+    agentName: "Restored Agent",
+    agentColor: "green",
+    agentSetting: "reviewer",
+    mode: "normal",
+    worktreeSession: null,
+    prNumber: 7,
+    prUrl: "https://github.example/pull/7",
+    prRepository: "owner/repo",
+  });
+
+  expect(getCurrentSessionTitle(sessionId as never)).toBe("Restored title");
+  expect(getCurrentSessionTag(sessionId as never)).toBe("restored");
+  expect(getCurrentSessionAgentColor()).toBe("green");
+
+  clearSessionMetadata();
+  expect(getCurrentSessionTitle(sessionId as never)).toBeUndefined();
+  expect(getCurrentSessionTag(sessionId as never)).toBeUndefined();
+  expect(getCurrentSessionAgentColor()).toBeUndefined();
+});
+
+test("hydrates lite logs with transcript messages and metadata", async () => {
+  const worktreeSession = {
+    originalCwd: "/repo",
+    worktreePath: "/repo/.agenc-worktrees/feat",
+    worktreeName: "feat",
+    worktreeBranch: "worktree-feat",
+    sessionId,
+  };
+  const replacement = {
+    toolUseId: "tu_replace",
+    blockIndex: 0,
+    storageKey: "tool-results/tu_replace.json",
+  };
+  const fileSnapshot = {
+    messageId: id(302),
+    files: { "src/file.ts": { content: "before" } },
+  };
+  const attributionSnapshot = {
+    type: "attribution-snapshot",
+    messageId: id(302),
+    surface: "cli",
+    fileStates: {
+      "src/file.ts": {
+        contentHash: "hash",
+        agentContribution: 10,
+        mtime: 123,
+      },
+    },
+  };
+  const prompt = user(id(301), null, "hydrate this log");
+  const response = assistant(id(302), id(301), "hydrated");
+  const filePath = await writeJsonl([
+    { type: "custom-title", sessionId, customTitle: "Hydrated title" },
+    { type: "tag", sessionId, tag: "hydrated" },
+    { type: "agent-name", sessionId, agentName: "Hydrator" },
+    { type: "agent-color", sessionId, agentColor: "purple" },
+    { type: "agent-setting", sessionId, agentSetting: "debugger" },
+    { type: "mode", sessionId, mode: "coordinator" },
+    { type: "worktree-state", sessionId, worktreeSession },
+    {
+      type: "pr-link",
+      sessionId,
+      prNumber: 88,
+      prUrl: "https://github.example/pull/88",
+      prRepository: "owner/repo",
+      timestamp: ts,
+    },
+    { type: "summary", leafUuid: id(302), summary: "Hydrated summary" },
+    {
+      type: "file-history-snapshot",
+      messageId: id(302),
+      snapshot: fileSnapshot,
+      isSnapshotUpdate: false,
+    },
+    attributionSnapshot,
+    {
+      type: "content-replacement",
+      sessionId,
+      replacements: [replacement],
+    },
+    prompt,
+    response,
+  ]);
+  const liteLog = {
+    date: ts,
+    messages: [],
+    fullPath: filePath,
+    value: 7,
+    created: new Date(ts),
+    modified: new Date(ts),
+    firstPrompt: "",
+    messageCount: 0,
+    isSidechain: false,
+    isLite: true,
+    sessionId,
+  };
+
+  expect(isLiteLog(liteLog as never)).toBe(true);
+  expect(getSessionIdFromLog(liteLog as never)).toBe(sessionId);
+
+  const hydrated = await loadFullLog(liteLog as never);
+  expect(hydrated).toMatchObject({
+    firstPrompt: "hydrate this log",
+    messageCount: 2,
+    summary: "Hydrated summary",
+    customTitle: "Hydrated title",
+    tag: "hydrated",
+    agentName: "Hydrator",
+    agentColor: "purple",
+    agentSetting: "debugger",
+    mode: "coordinator",
+    worktreeSession,
+    prNumber: 88,
+    prUrl: "https://github.example/pull/88",
+    prRepository: "owner/repo",
+    leafUuid: id(302),
+    contentReplacements: [replacement],
+  });
+  expect(hydrated.messages.map((message) => message.uuid)).toEqual([
+    id(301),
+    id(302),
+  ]);
+  expect(hydrated.fileHistorySnapshots).toEqual([fileSnapshot]);
+  expect(hydrated.attributionSnapshots).toEqual([
+    expect.objectContaining(attributionSnapshot),
+  ]);
+  expect(isLiteLog(hydrated)).toBe(false);
+  expect(getSessionIdFromLog(hydrated)).toBe(sessionId);
+});
+
+test("loadFullLog returns the original lite log when hydration is impossible", async () => {
+  const missing = {
+    date: ts,
+    messages: [],
+    value: 0,
+    created: new Date(ts),
+    modified: new Date(ts),
+    firstPrompt: "fallback",
+    messageCount: 0,
+    isSidechain: false,
+    isLite: true,
+    sessionId,
+  };
+  expect(await loadFullLog(missing as never)).toBe(missing);
+
+  const corrupt = {
+    ...missing,
+    fullPath: await writeJsonl([{ type: "summary", summary: "no messages" }]),
+  };
+  expect(await loadFullLog(corrupt as never)).toBe(corrupt);
+});
+
+test("loads JSON and JSONL transcripts through loadTranscriptFromFile", async () => {
+  const prompt = user(id(321), null, "jsonl prompt");
+  const response = assistant(id(322), id(321), "jsonl response");
+  const jsonlPath = await writeJsonl([
+    { type: "custom-title", sessionId, customTitle: "JSONL title" },
+    { type: "tag", sessionId, tag: "jsonl" },
+    prompt,
+    response,
+  ]);
+
+  const jsonlLog = await loadTranscriptFromFile(jsonlPath);
+  expect(jsonlLog).toMatchObject({
+    firstPrompt: "jsonl prompt",
+    customTitle: "JSONL title",
+    tag: "jsonl",
+    leafUuid: id(322),
+    messageCount: 2,
+  });
+
+  const jsonArrayPath = await writeTempFile(
+    "session.json",
+    JSON.stringify([prompt, response]),
+  );
+  const jsonArrayLog = await loadTranscriptFromFile(jsonArrayPath);
+  expect(jsonArrayLog.messages.map((message) => message.uuid)).toEqual([
+    id(321),
+    id(322),
+  ]);
+
+  const jsonObjectPath = await writeTempFile(
+    "session.json",
+    JSON.stringify({ messages: [prompt] }),
+  );
+  expect((await loadTranscriptFromFile(jsonObjectPath)).messages).toHaveLength(1);
+
+  const invalidPath = await writeTempFile("session.json", "{");
+  await expect(loadTranscriptFromFile(invalidPath)).rejects.toThrow(
+    /Invalid JSON/,
+  );
+
+  const emptyJsonlPath = await writeJsonl([]);
+  await expect(loadTranscriptFromFile(emptyJsonlPath)).rejects.toThrow(
+    /No messages found/,
+  );
+});
+
+test("records transcript chains and queued session artifacts", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  process.env.TEST_ENABLE_SESSION_PERSISTENCE = "1";
+  const transcriptPath = join(projectDir, `${sessionId}.jsonl`);
+  const internalEvents: Array<{
+    eventType: string;
+    payload: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
+  setInternalEventWriter(async (eventType, payload, options) => {
+    internalEvents.push({ eventType, payload, options });
+  });
+
+  const prompt = runtimeMessage(user(id(401), null, "record this prompt"));
+  const response = runtimeMessage(assistant(id(402), null, "recorded response"));
+  await expect(
+    recordTranscript([prompt, response] as never, {
+      teamName: "Runtime Team",
+      agentName: "Recorder",
+    }),
+  ).resolves.toBe(id(402));
+  await flushSessionStorage();
+
+  let entries = await readJsonlEntries(transcriptPath);
+  expect(entries.filter((entry) => entry.type === "user")).toHaveLength(1);
+  expect(entries.filter((entry) => entry.type === "assistant")).toHaveLength(1);
+  expect(entries.find((entry) => entry.uuid === id(401))).toMatchObject({
+    parentUuid: null,
+    teamName: "Runtime Team",
+    agentName: "Recorder",
+    sessionId,
+  });
+  expect(entries.find((entry) => entry.uuid === id(402))).toMatchObject({
+    parentUuid: id(401),
+    sessionId,
+  });
+  expect(internalEvents.map((event) => event.payload.uuid)).toEqual([
+    id(401),
+    id(402),
+  ]);
+
+  await expect(recordTranscript([prompt, response] as never)).resolves.toBe(
+    id(402),
+  );
+  await flushSessionStorage();
+  entries = await readJsonlEntries(transcriptPath);
+  expect(entries.filter((entry) => entry.type === "assistant")).toHaveLength(1);
+
+  await recordQueueOperation({
+    type: "queue-operation",
+    operation: "enqueue",
+    timestamp: ts,
+    sessionId: sessionId as never,
+    content: "queued",
+  });
+  await recordFileHistorySnapshot(
+    id(402) as never,
+    {
+      messageId: id(402),
+      files: { "src/file.ts": { content: "after" } },
+    } as never,
+    false,
+  );
+  await recordAttributionSnapshot({
+    type: "attribution-snapshot",
+    messageId: id(402),
+    surface: "cli",
+    fileStates: {},
+  } as never);
+  await recordContentReplacement([
+    {
+      toolUseId: "tu_main",
+      blockIndex: 0,
+      storageKey: "tool-results/tu_main.json",
+    } as never,
+  ]);
+  await recordContextCollapseCommit({
+    collapseId: "collapse-1",
+    summaryUuid: id(410),
+    summaryContent: "summary content",
+    summary: "summary",
+    firstArchivedUuid: id(401),
+    lastArchivedUuid: id(402),
+  });
+  await recordContextCollapseSnapshot({
+    staged: [
+      {
+        startUuid: id(401),
+        endUuid: id(402),
+        summary: "staged summary",
+        risk: 1,
+        stagedAt: 123,
+      },
+    ],
+    armed: true,
+    lastSpawnTokens: 55,
+  });
+  await flushSessionStorage();
+
+  entries = await readJsonlEntries(transcriptPath);
+  expect(entries.map((entry) => entry.type)).toEqual(
+    expect.arrayContaining([
+      "queue-operation",
+      "file-history-snapshot",
+      "attribution-snapshot",
+      "content-replacement",
+      "marble-origami-commit",
+      "marble-origami-snapshot",
+    ]),
+  );
+
+  const sidechainMessage = runtimeMessage(
+    assistant(id(403), null, "sidechain response"),
+  );
+  await recordSidechainTranscript([sidechainMessage] as never, "agent-side", id(402) as never);
+  await recordContentReplacement(
+    [
+      {
+        toolUseId: "tu_side",
+        blockIndex: 1,
+        storageKey: "tool-results/tu_side.json",
+      } as never,
+    ],
+    "agent-side" as never,
+  );
+  await flushSessionStorage();
+
+  const sidechainPath = getAgentTranscriptPath("agent-side" as never);
+  const sidechainEntries = await readJsonlEntries(sidechainPath);
+  expect(sidechainEntries.find((entry) => entry.uuid === id(403))).toMatchObject({
+    isSidechain: true,
+    agentId: "agent-side",
+    parentUuid: id(402),
+  });
+  expect(sidechainEntries.find((entry) => entry.type === "content-replacement"))
+    .toMatchObject({ agentId: "agent-side" });
+
+  await removeTranscriptMessage(id(402) as never);
+  await removeTranscriptMessage(id(499) as never);
+  entries = await readJsonlEntries(transcriptPath);
+  expect(entries.some((entry) => entry.uuid === id(402))).toBe(false);
+});
+
+test("hydrates a remote session through session ingress", async () => {
+  const { projectDir } = await configureIsolatedSession();
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  process.env.AGENC_AFTER_LAST_COMPACT = "1";
+  const remoteEntries = [
+    user(id(501), null, "remote prompt"),
+    assistant(id(502), id(501), "remote response"),
+  ];
+  const requests: Array<{
+    method: string | undefined;
+    url: string | undefined;
+    authorization: string | undefined;
+  }> = [];
+  const server = await startSessionIngressServer((request, response) => {
+    requests.push({
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+    });
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({ loglines: remoteEntries }));
+  });
+
+  try {
+    await expect(hydrateRemoteSession(sessionId, server.url)).resolves.toBe(true);
+    expect(requests).toEqual([
+      {
+        method: "GET",
+        url: "/session?after_last_compact=true",
+        authorization: "Bearer session-token",
+      },
+    ]);
+    expect(
+      await readJsonlEntries(join(projectDir, `${sessionId}.jsonl`)),
+    ).toEqual(remoteEntries);
+  } finally {
+    await server.close();
+  }
+});
+
+test("appends transcript messages to remote session ingress", async () => {
+  await configureIsolatedSession();
+  process.env.TEST_ENABLE_SESSION_PERSISTENCE = "1";
+  process.env.ENABLE_SESSION_PERSISTENCE = "1";
+  process.env.AGENC_SESSION_ACCESS_TOKEN = "session-token";
+  const putRequests: Array<{
+    uuid: unknown;
+    authorization: string | undefined;
+    lastUuid: string | undefined;
+  }> = [];
+  const server = await startSessionIngressServer(async (request, response) => {
+    if (request.method !== "PUT") {
+      response.statusCode = 405;
+      response.end();
+      return;
+    }
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    putRequests.push({
+      uuid: body.uuid,
+      authorization: request.headers.authorization,
+      lastUuid: request.headers["last-uuid"] as string | undefined,
+    });
+    response.statusCode = 201;
+    response.end("{}");
+  });
+
+  try {
+    setRemoteIngressUrlForTesting(server.url);
+    const prompt = runtimeMessage(user(id(511), null, "remote append prompt"));
+    const response = runtimeMessage(assistant(id(512), null, "remote append response"));
+    await recordTranscript([prompt, response] as never);
+    await flushSessionStorage();
+
+    expect(putRequests).toEqual([
+      {
+        uuid: id(511),
+        authorization: "Bearer session-token",
+        lastUuid: undefined,
+      },
+      {
+        uuid: id(512),
+        authorization: "Bearer session-token",
+        lastUuid: id(511),
+      },
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("extracts the first meaningful user text while skipping metadata", () => {
+  const transcript = [
+    {
+      type: "user",
+      isMeta: false,
+      message: { role: "user", content: "<ide_context>noise</ide_context>" },
+    },
+    {
+      type: "user",
+      isMeta: true,
+      message: { role: "user", content: "meta prompt" },
+    },
+    {
+      type: "user",
+      isMeta: false,
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "<hook-output>skip</hook-output>" },
+          { type: "text", text: "<bash-input>ls -la</bash-input>" },
+        ],
+      },
+    },
+  ];
+
+  expect(getFirstMeaningfulUserMessageTextContent(transcript as never)).toBe(
+    "! ls -la",
+  );
+});
+
+test("removeExtraFields strips persistence-only chain fields", () => {
+  const transcript = [
+    {
+      ...user(id(90), null, "hello"),
+      extra: "kept",
+    },
+  ];
+
+  expect(removeExtraFields(transcript as never)).toEqual([
+    {
+      uuid: id(90),
+      timestamp: ts,
+      cwd: "/tmp",
+      userType: "external",
+      sessionId,
+      version: "test",
+      type: "user",
+      isMeta: false,
+      message: {
+        role: "user",
+        content: "hello",
+      },
+      extra: "kept",
+    },
+  ]);
+});
+
+test("loadTranscriptFile fails closed when preserved-segment tail is missing", async () => {
+  const oldUser = user(id(1), null, "old user");
+  const oldAssistant = assistant(id(2), id(1), "old assistant");
+  const preservedHead = assistant(id(3), id(2), "preserved head");
+  const boundary = compactBoundary(id(4), id(2), {
+    headUuid: id(3),
+    anchorUuid: id(5),
+    tailUuid: id(30),
+  });
+  const summary = user(id(5), id(4), "summary");
+
+  const filePath = await writeJsonl([
+    oldUser,
+    oldAssistant,
+    preservedHead,
+    boundary,
+    summary,
+  ]);
+
+  const { messages } = await loadTranscriptFile(filePath);
+  expect(messages.has(id(1))).toBe(false);
+  expect(messages.has(id(2))).toBe(false);
+  expect(messages.has(id(3))).toBe(false);
+  expect(messages.has(id(4))).toBe(true);
+  expect(messages.has(id(5))).toBe(true);
+
+  const chain = buildConversationChain(messages, messages.get(id(5))!);
+  expect(chain.map((message) => message.uuid)).toEqual([id(4), id(5)]);
+});
+
+test("loadTranscriptFile preserves and relinks a valid preserved segment", async () => {
+  const oldUser = user(id(11), null, "old user");
+  const oldAssistant = assistant(id(12), id(11), "old assistant");
+  const preservedHead = assistant(id(13), id(12), "preserved head");
+  const preservedTail = assistant(id(14), id(13), "preserved tail");
+  const boundary = compactBoundary(id(15), id(12), {
+    headUuid: id(13),
+    anchorUuid: id(16),
+    tailUuid: id(14),
+  });
+  const summary = user(id(16), id(15), "summary");
+
+  const filePath = await writeJsonl([
+    oldUser,
+    oldAssistant,
+    preservedHead,
+    preservedTail,
+    boundary,
+    summary,
+  ]);
+
+  const { messages } = await loadTranscriptFile(filePath);
+  expect(messages.has(id(11))).toBe(false);
+  expect(messages.has(id(12))).toBe(false);
+  expect(messages.has(id(13))).toBe(true);
+  expect(messages.has(id(14))).toBe(true);
+  expect(messages.get(id(13))?.parentUuid).toBe(id(16));
+  expect(messages.get(id(14))?.parentUuid).toBe(id(13));
+
+  const chain = buildConversationChain(messages, messages.get(id(14))!);
+  expect(chain.map((message) => message.uuid)).toEqual([
+    id(15),
+    id(16),
+    id(13),
+    id(14),
+  ]);
+});
+
+test("loadTranscriptFile fails closed when preserved-segment anchor is missing", async () => {
+  const oldUser = user(id(21), null, "old user");
+  const oldAssistant = assistant(id(22), id(21), "old assistant");
+  const preservedHead = assistant(id(23), id(22), "preserved head");
+  const preservedTail = assistant(id(24), id(23), "preserved tail");
+  const boundary = compactBoundary(id(25), id(22), {
+    headUuid: id(23),
+    anchorUuid: id(26),
+    tailUuid: id(24),
+  });
+
+  const filePath = await writeJsonl([
+    oldUser,
+    oldAssistant,
+    preservedHead,
+    preservedTail,
+    boundary,
+  ]);
+
+  const { messages } = await loadTranscriptFile(filePath);
+  expect(messages.has(id(21))).toBe(false);
+  expect(messages.has(id(22))).toBe(false);
+  expect(messages.has(id(23))).toBe(false);
+  expect(messages.has(id(24))).toBe(false);
+  expect(messages.has(id(25))).toBe(true);
+
+  const chain = buildConversationChain(messages, messages.get(id(25))!);
+  expect(chain.map((message) => message.uuid)).toEqual([id(25)]);
+});
+
+test("stripPersistedToolUseResultsFromJSONLBuffer drops raw toolUseResult while preserving preview content", () => {
+  const persisted = user(id(31), null, "placeholder");
+  persisted.message = {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-31",
+        is_error: false,
+        content: "<persisted-output>\nPreview text\n</persisted-output>",
+      },
+    ],
+  };
+  (persisted as typeof persisted & { toolUseResult?: unknown }).toolUseResult = {
+    stdout: "x".repeat(200_000),
+    stderr: "",
+  };
+
+  const raw = Buffer.from(`${JSON.stringify(persisted)}\n`);
+  const sanitized = stripPersistedToolUseResultsFromJSONLBuffer(raw);
+  const [parsed] = JSON.parse(`[${sanitized.toString("utf8").trim()}]`) as Array<
+    typeof persisted & { toolUseResult?: unknown }
+  >;
+
+  expect(parsed?.toolUseResult).toBeUndefined();
+  expect(
+    (parsed?.message.content as Array<{ content: string }>)[0]?.content,
+  ).toContain("Preview text");
+});
+
+test("loadTranscriptFile omits raw toolUseResult for persisted-output transcript entries", async () => {
+  const persisted = user(id(41), null, "placeholder");
+  persisted.message = {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-41",
+        is_error: false,
+        content: "<persisted-output>\nPreview text\n</persisted-output>",
+      },
+    ],
+  };
+  (persisted as typeof persisted & { toolUseResult?: unknown }).toolUseResult = {
+    stdout: "y".repeat(200_000),
+    stderr: "",
+  };
+
+  const filePath = await writeJsonl([persisted]);
+  const { messages } = await loadTranscriptFile(filePath);
+  const loaded = messages.get(id(41)) as
+    | (typeof persisted & { toolUseResult?: unknown })
+    | undefined;
+
+  expect(loaded).toBeDefined();
+  expect(loaded?.toolUseResult).toBeUndefined();
+  expect(
+    (loaded?.message.content as Array<{ content: string }>)[0]?.content,
+  ).toContain("Preview text");
+});

--- a/runtime/tests/shell-command/bash-ast-security.test.ts
+++ b/runtime/tests/shell-command/bash-ast-security.test.ts
@@ -1,0 +1,457 @@
+import { beforeAll, describe, expect, test } from "vitest";
+
+import {
+  checkSemantics,
+  nodeTypeId,
+  parseForSecurity,
+  parseForSecurityFromAst,
+  type ParseForSecurityResult,
+  type SimpleCommand,
+} from "../../src/utils/bash/ast.js";
+import { PARSE_ABORTED } from "../../src/utils/bash/parser.js";
+import {
+  ensureParserInitialized,
+  getParserModule,
+  type TsNode,
+} from "../../src/utils/bash/bashParser.js";
+
+beforeAll(async () => {
+  await ensureParserInitialized();
+});
+
+function rootFor(source: string): TsNode {
+  const root = getParserModule()?.parse(source, Infinity);
+  if (!root) throw new Error(`expected parser root for ${JSON.stringify(source)}`);
+  return root;
+}
+
+function parseAst(source: string): ParseForSecurityResult {
+  return parseForSecurityFromAst(source, rootFor(source));
+}
+
+function simple(source: string): SimpleCommand[] {
+  const result = parseAst(source);
+  expect(result).toMatchObject({ kind: "simple" });
+  return result.kind === "simple" ? result.commands : [];
+}
+
+function command(argv: string[], extra: Partial<SimpleCommand> = {}): SimpleCommand {
+  return {
+    argv,
+    envVars: [],
+    redirects: [],
+    text: argv.join(" "),
+    ...extra,
+  };
+}
+
+describe("bash AST security parser", () => {
+  test("maps dangerous node types to stable telemetry ids", () => {
+    expect(nodeTypeId(undefined)).toBe(-2);
+    expect(nodeTypeId("ERROR")).toBe(-1);
+    expect(nodeTypeId("command_substitution")).toBeGreaterThan(0);
+    expect(nodeTypeId("not-a-known-danger")).toBe(0);
+  });
+
+  test("handles empty and unavailable parse paths", async () => {
+    await expect(parseForSecurity("")).resolves.toEqual({
+      kind: "simple",
+      commands: [],
+    });
+
+    await expect(parseForSecurity("echo hi")).resolves.toEqual({
+      kind: "parse-unavailable",
+    });
+
+    expect(parseForSecurityFromAst("echo hi", PARSE_ABORTED)).toEqual({
+      kind: "too-complex",
+      reason:
+        "Parser aborted (timeout or resource limit) \u2014 possible adversarial input",
+      nodeType: "PARSE_ABORT",
+    });
+  });
+
+  test.each([
+    [`printf '${String.fromCharCode(1)}'`, "Contains control characters"],
+    ["echo hello\u00a0world", "Contains Unicode whitespace"],
+    ["cat foo\\ bar", "Contains backslash-escaped whitespace"],
+    ["echo ~[name]", "Contains zsh ~[ dynamic directory syntax"],
+    ["=curl example.test", "Contains zsh =cmd equals expansion"],
+    ["echo {a'}',b}", "Contains brace with quote character"],
+  ])("rejects pre-parse differential: %s", (source, reason) => {
+    expect(parseAst(source)).toMatchObject({
+      kind: "too-complex",
+      reason: expect.stringContaining(reason),
+    });
+  });
+
+  test("extracts command lists, env prefixes, redirects, and static variables", () => {
+    expect(
+      simple("ROOT=/tmp && FOO=bar printf '%s' \"$ROOT\" >out 2>&1"),
+    ).toEqual([
+      {
+        argv: ["printf", "%s", "/tmp"],
+        envVars: [{ name: "FOO", value: "bar" }],
+        redirects: [
+          { op: ">", target: "out" },
+          { op: ">&", target: "1", fd: 2 },
+        ],
+        text: "printf %s /tmp",
+      },
+    ]);
+  });
+
+  test("keeps scope conservative across pipelines, background, and conditionals", () => {
+    expect(parseAst("VAR=/tmp | cat $VAR")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "simple_expansion",
+    });
+
+    expect(parseAst("true || FLAG=--force && rm $FLAG")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "simple_expansion",
+    });
+
+    expect(parseAst("if false; then TARGET=/etc; fi && cat $TARGET")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "simple_expansion",
+    });
+  });
+
+  test("extracts negated commands", () => {
+    expect(simple("! grep needle file").map((cmd) => cmd.argv)).toEqual([
+      ["grep", "needle", "file"],
+    ]);
+  });
+
+  test("fails closed on unsupported bare subshell parser shapes", () => {
+    expect(parseAst("(cd src; pwd)")).toMatchObject({
+      kind: "too-complex",
+    });
+  });
+
+  test("extracts if condition and branch commands", () => {
+    expect(
+      simple("if test -f lock; then echo yes; else echo no; fi").map(
+        (cmd) => cmd.argv,
+      ),
+    ).toEqual([
+      ["test", "-f", "lock"],
+      ["echo", "yes"],
+      ["echo", "no"],
+    ]);
+  });
+
+  test("extracts test command expression trees", () => {
+    expect(
+      simple('VALUE=foo && [[ -n "$VALUE" && ( "$VALUE" == foo || "$VALUE" =~ ^fo+ ) ]]').map(
+        (cmd) => cmd.argv,
+      ),
+    ).toEqual([
+      [
+        "[[",
+        "-n",
+        "foo",
+        "&&",
+        "(",
+        "foo",
+        "==",
+        "foo",
+        "||",
+        "foo",
+        "=~",
+        "^fo+ )",
+        "",
+      ],
+    ]);
+  });
+
+  test("extracts unset commands", () => {
+    expect(simple("unset line").map((cmd) => cmd.argv)).toEqual([
+      ["unset", "line"],
+    ]);
+  });
+
+  test("extracts while read bodies with tracked string-only variables", () => {
+    expect(simple('while read line; do echo "line:$line"; done').map((cmd) => cmd.argv)).toEqual([
+      ["read", "line"],
+      ["echo", "line:__TRACKED_VAR__"],
+    ]);
+  });
+
+  test("handles declaration commands while rejecting semantic-changing forms", () => {
+    expect(
+      simple("export FOO=bar NAME; declare -r readonly_name=value; typeset plain").map(
+        (cmd) => cmd.argv,
+      ),
+    ).toEqual([
+      ["export", "FOO=bar", "NAME"],
+      ["declare", "-r", "readonly_name=value"],
+      ["typeset", "plain"],
+    ]);
+
+    expect(parseAst("declare -n ref=target")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "declaration_command",
+    });
+    expect(parseAst("local 'arr[$(id)]=value'")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "declaration_command",
+    });
+  });
+
+  test("handles for loops and rejects unsafe loop-variable usage", () => {
+    expect(simple("for item in one two; do echo \"item:$item\"; done").map((cmd) => cmd.argv)).toEqual([
+      ["echo", "item:__TRACKED_VAR__"],
+    ]);
+
+    expect(parseAst("for item in one two; do rm $item; done")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "simple_expansion",
+    });
+    expect(parseAst("for PS4 in prompt; do echo ok; done")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "for_statement",
+    });
+  });
+
+  test("validates redirects, quoted heredocs, and here-strings", () => {
+    expect(simple("> out")).toEqual([
+      {
+        argv: [],
+        envVars: [],
+        redirects: [{ op: ">", target: "out" }],
+        text: "> out",
+      },
+    ]);
+
+    expect(simple("cat <<'EOF'\nplain text\nEOF\n").map((cmd) => cmd.argv)).toEqual([
+      ["cat"],
+    ]);
+
+    expect(parseAst("cat <<EOF\n$(id)\nEOF\n")).toMatchObject({
+      kind: "too-complex",
+      reason: "Heredoc with unquoted delimiter undergoes shell expansion",
+    });
+
+    expect(simple("cat <<< 'literal input'").map((cmd) => cmd.argv)).toEqual([
+      ["cat"],
+    ]);
+    expect(parseAst('cat <<< "ok\n# hidden"')).toMatchObject({
+      kind: "too-complex",
+    });
+  });
+
+  test("extracts redirect target variants and rejects ambiguous redirect syntax", () => {
+    expect(simple("echo hi > 'out file'").at(0)?.redirects).toEqual([
+      { op: ">", target: "out file" },
+    ]);
+    expect(simple('echo hi > "out"file').at(0)?.redirects).toEqual([
+      { op: ">", target: "outfile" },
+    ]);
+    expect(parseAst("echo hi > {a,b}")).toMatchObject({
+      kind: "too-complex",
+    });
+    expect(parseAst("cat <<'EOF' | rm x\nbody\nEOF\n")).toMatchObject({
+      kind: "too-complex",
+    });
+  });
+
+  test("handles strings, command substitutions, safe heredoc substitutions, and arithmetic", () => {
+    expect(simple('echo "commit: $(git rev-parse HEAD)"').map((cmd) => cmd.argv)).toEqual([
+      ["git", "rev-parse", "HEAD"],
+      ["echo", "commit: __CMDSUB_OUTPUT__"],
+    ]);
+
+    expect(
+      simple("printf '%s' \"$(cat <<'EOF'\nbody\nEOF\n)\"").map((cmd) => cmd.argv),
+    ).toEqual([["printf", "%s", "body"]]);
+
+    expect(simple("echo $((1 + 2 * 3))").map((cmd) => cmd.argv)).toEqual([
+      ["echo", "$((1 + 2 * 3))"],
+    ]);
+
+    expect(parseAst("echo $((value + 1))")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "arithmetic_expansion",
+    });
+    expect(parseAst('cd "$(pwd)"')).toMatchObject({
+      kind: "too-complex",
+      nodeType: "string",
+    });
+    expect(parseAst('echo " "')).toMatchObject({
+      kind: "too-complex",
+      nodeType: "string",
+    });
+  });
+
+  test("handles literal dollar signs, safe env interpolation, and unsafe bare env interpolation", () => {
+    expect(simple('echo "$" "home:$HOME"').map((cmd) => cmd.argv)).toEqual([
+      ["echo", "$", "home:__TRACKED_VAR__"],
+    ]);
+    expect(parseAst("cat $HOME")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "simple_expansion",
+    });
+  });
+
+  test("rejects assignments that change later expansion semantics", () => {
+    expect(simple("A=foo && A+=bar && B=$A && echo $B").map((cmd) => cmd.argv)).toEqual([
+      ["echo", "foobar"],
+    ]);
+    expect(simple('A=$(date) && echo "time:$A"').map((cmd) => cmd.argv)).toEqual([
+      ["date"],
+      ["echo", "time:__TRACKED_VAR__"],
+    ]);
+    expect(simple("PS4='+${BASH_SOURCE}:${LINENO}: ' && echo ok").map((cmd) => cmd.argv)).toEqual([
+      ["echo", "ok"],
+    ]);
+
+    expect(parseAst("IFS=: && echo ok")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "variable_assignment",
+    });
+    expect(parseAst("PS4+='$(id)' && echo ok")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "variable_assignment",
+    });
+    expect(parseAst("PS4='$(id)' && echo ok")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "variable_assignment",
+    });
+    expect(parseAst("TARGET=~/secret && cat $TARGET")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "variable_assignment",
+    });
+    expect(parseAst("EMPTY= && $EMPTY eval x")).toMatchObject({
+      kind: "too-complex",
+      nodeType: "simple_expansion",
+    });
+  });
+});
+
+describe("bash AST semantic checks", () => {
+  test("unwraps safe command wrappers before checking dangerous commands", () => {
+    expect(checkSemantics([command(["time", "nohup", "eval", "id"])])).toEqual({
+      ok: false,
+      reason: "'eval' evaluates arguments as shell code",
+    });
+    expect(
+      checkSemantics([command(["timeout", "--foreground", "-k", "5", "10s", "eval", "id"])]),
+    ).toEqual({
+      ok: false,
+      reason: "'eval' evaluates arguments as shell code",
+    });
+    expect(checkSemantics([command(["nice", "-10", "eval", "id"])])).toEqual({
+      ok: false,
+      reason: "'eval' evaluates arguments as shell code",
+    });
+    expect(checkSemantics([command(["env", "A=1", "-u", "B", "eval", "id"])])).toEqual({
+      ok: false,
+      reason: "'eval' evaluates arguments as shell code",
+    });
+    expect(checkSemantics([command(["stdbuf", "-o0", "-eL", "eval", "id"])])).toEqual({
+      ok: false,
+      reason: "'eval' evaluates arguments as shell code",
+    });
+  });
+
+  test.each([
+    [["timeout", "--mystery", "10", "echo"], "timeout with --mystery flag cannot be statically analyzed"],
+    [["timeout", ".5", "echo"], "timeout duration '.5' cannot be statically analyzed"],
+    [["nice", "$((0-5))", "echo"], "nice argument '$((0-5))' contains expansion"],
+    [["env", "-S", "echo hi"], "env with -S flag cannot be statically analyzed"],
+    [["stdbuf", "--output", "0", "echo"], "stdbuf with --output flag cannot be statically analyzed"],
+  ])("rejects wrapper shape %j", (argv, reason) => {
+    expect(checkSemantics([command(argv)])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining(reason),
+    });
+  });
+
+  test("allows inert wrapper commands and supported timeout flag forms", () => {
+    expect(
+      checkSemantics([
+        command(["timeout"]),
+        command(["env", "A=1"]),
+        command(["stdbuf"]),
+        command(["timeout", "--signal", "TERM", "-k5", "1m", "echo", "ok"]),
+      ]),
+    ).toEqual({ ok: true });
+  });
+
+  test.each([
+    [command([""]), "Empty command name"],
+    [command(["__TRACKED_VAR__"]) , "Command name is runtime-determined"],
+    [command(["-fragment"]) , "Command appears to be an incomplete fragment"],
+    [command(["for"]) , "Shell keyword 'for' as command name"],
+    [command(["zmodload"]) , "Zsh builtin 'zmodload'"],
+    [command(["eval", "id"]) , "'eval' evaluates arguments as shell code"],
+    [command(["trap", "id", "EXIT"]) , "'trap' evaluates arguments as shell code"],
+  ])("rejects dangerous command shape %#", (cmd, reason) => {
+    expect(checkSemantics([cmd])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining(reason),
+    });
+  });
+
+  test("allows narrow safe forms of eval-like builtins", () => {
+    expect(
+      checkSemantics([
+        command(["command", "-v", "node"]),
+        command(["fc", "-ln"]),
+        command(["compgen", "-c"]),
+      ]),
+    ).toEqual({ ok: true });
+  });
+
+  test("rejects subscript-evaluating builtin operands", () => {
+    expect(checkSemantics([command(["printf", "-v", "arr[$(id)]", "x"])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("'printf -v' operand contains array subscript"),
+    });
+    expect(checkSemantics([command(["printf", "-vx[$(id)]", "x"])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("'printf -v' (fused) operand contains array subscript"),
+    });
+    expect(checkSemantics([command(["read", "-rp", "[prompt]", "arr[$(id)]"])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("'read' positional NAME"),
+    });
+    expect(checkSemantics([command(["[[", "arr[$(id)]", "-eq", "0"])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("[[ ... -eq ... ]]"),
+    });
+  });
+
+  test("rejects newline-comment hiding, jq execution, and proc environ reads", () => {
+    expect(checkSemantics([command(["cat", "ok\n# hidden"])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("Newline followed by # inside a quoted argument"),
+    });
+    expect(
+      checkSemantics([
+        command(["echo"], { envVars: [{ name: "A", value: "ok\n# hidden" }] }),
+      ]),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("inside an env var value"),
+    });
+    expect(
+      checkSemantics([
+        command(["cat"], { redirects: [{ op: "<", target: "/proc/self/environ" }] }),
+      ]),
+    ).toMatchObject({
+      ok: false,
+      reason: "Accesses /proc/*/environ which may expose secrets",
+    });
+    expect(checkSemantics([command(["jq", "system(\"id\")"])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("system() function"),
+    });
+    expect(checkSemantics([command(["jq", "--rawfile=secret", "x", "."])])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("dangerous flags"),
+    });
+  });
+});

--- a/runtime/tests/shell-command/bashParser.test.ts
+++ b/runtime/tests/shell-command/bashParser.test.ts
@@ -1,0 +1,1090 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  ensureParserInitialized,
+  getParserModule,
+  type TsNode,
+} from "../../src/utils/bash/bashParser.js";
+
+function parse(source: string): TsNode {
+  const root = getParserModule()?.parse(source, Infinity);
+  if (root === null || root === undefined) {
+    throw new Error(`expected bash parser to parse ${JSON.stringify(source)}`);
+  }
+  return root;
+}
+
+function collectTypes(node: TsNode, out: string[] = []): string[] {
+  out.push(node.type);
+  for (const child of node.children) collectTypes(child, out);
+  return out;
+}
+
+function findNode(
+  node: TsNode,
+  predicate: (candidate: TsNode) => boolean,
+): TsNode | undefined {
+  if (predicate(node)) return node;
+  for (const child of node.children) {
+    const found = findNode(child, predicate);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+describe("pure TypeScript bash parser", () => {
+  test("keeps the compatibility initialization API ready", async () => {
+    await expect(ensureParserInitialized()).resolves.toBeUndefined();
+    expect(getParserModule()).not.toBeNull();
+  });
+
+  test.each([
+    {
+      name: "lists, pipelines, redirects, and assignments",
+      source: 'FOO=bar echo "$FOO" && printf %s done | cat -n >out 2>&1',
+      types: [
+        "list",
+        "pipeline",
+        "redirected_statement",
+        "variable_assignment",
+        "string",
+        "simple_expansion",
+        "file_redirect",
+        "file_descriptor",
+      ],
+    },
+    {
+      name: "negation, subshells, background separators, and brace groups",
+      source: "! grep -q needle file || (cd src; pwd) & { echo one; echo two; } >>log",
+      types: [
+        "negated_command",
+        "list",
+        "subshell",
+        "&",
+        "compound_statement",
+        "file_redirect",
+      ],
+    },
+    {
+      name: "herestrings and process substitutions",
+      source: 'read value <<<"inline $USER"; diff <(printf a) >(printf b)',
+      types: [
+        "herestring_redirect",
+        "string_content",
+        "simple_expansion",
+        "process_substitution",
+        "<(",
+        ">(",
+      ],
+    },
+    {
+      name: "loops and c-style arithmetic",
+      source:
+        "while read line; do echo $line; done < input; for ((i=0; i<3; i++)); do echo $i; done",
+      types: [
+        "while_statement",
+        "do_group",
+        "file_redirect",
+        "c_style_for_statement",
+        "binary_expression",
+        "postfix_expression",
+      ],
+    },
+    {
+      name: "select loops and case items",
+      source:
+        "select item in a b; do echo $item; done; case $item in a|b) echo ab ;; *) echo other ;; esac",
+      types: [
+        "for_statement",
+        "select",
+        "case_statement",
+        "case_item",
+        "extglob_pattern",
+        ";;",
+      ],
+    },
+    {
+      name: "function definitions, declarations, arrays, and unset",
+      source: "name() { local x=${1:-default}; echo $(date); }; export A=1 B+=two C=(x y); unset -v name array[0]",
+      types: [
+        "function_definition",
+        "declaration_command",
+        "expansion",
+        "command_substitution",
+        "array",
+        "unset_command",
+        "concatenation",
+      ],
+    },
+    {
+      name: "test commands and regex operators",
+      source: "[[ -n $x && ( $x == foo || $x =~ ^bar ) ]]; [ ! cmd -v go &>/dev/null ]",
+      types: [
+        "test_command",
+        "unary_expression",
+        "parenthesized_expression",
+        "regex",
+        "redirected_statement",
+        "&>",
+      ],
+    },
+    {
+      name: "parameter, arithmetic, command, and ansi-c expansions",
+      source:
+        "echo ${name:-fallback} ${arr[2]//foo/bar} ${#name} $(( a ? b + 1 : c[2] )) `printf hi` $'line\\n'",
+      types: [
+        "expansion",
+        "subscript",
+        "regex",
+        "arithmetic_expansion",
+        "ternary_expression",
+        "command_substitution",
+        "ansi_c_string",
+      ],
+    },
+  ])("parses $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.text).toBe(source);
+    expect(root.startIndex).toBe(0);
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test.each([
+    {
+      name: "explicit if, elif, and else clauses",
+      source: "if true; then echo yes; elif false; then echo maybe; else echo no; fi",
+      types: ["if_statement", "if", "then", "elif_clause", "else_clause", "fi"],
+    },
+    {
+      name: "function keyword definitions with optional parens and redirects",
+      source: "function f() { echo hi; } >out; function g { echo hi; }",
+      types: [
+        "function_definition",
+        "function",
+        "compound_statement",
+        "file_redirect",
+      ],
+    },
+    {
+      name: "assignment subscripts with normal and special expansions",
+      source: "arr[$i]=value arr[$?]=status echo done",
+      types: [
+        "variable_assignment",
+        "subscript",
+        "simple_expansion",
+        "special_variable_name",
+      ],
+    },
+    {
+      name: "brace ranges and brace-like concatenations",
+      source: "echo {1..3} {a..c} {foo,bar} {o[k]}",
+      types: ["brace_expression", "..", "concatenation", "number"],
+    },
+    {
+      name: "segmented case patterns with quoted fragments",
+      source: 'case $x in plain|*"foo"*|\'bar\') echo hit ;; esac',
+      types: [
+        "case_statement",
+        "case_item",
+        "string",
+        "raw_string",
+        "word",
+      ],
+    },
+    {
+      name: "segmented parameter expansion patterns",
+      source:
+        'echo ${file%".txt"} ${file%%\'tmp\'*} ${path#${HOME}/} ${path%$(basename "$path")}',
+      types: [
+        "expansion",
+        "%",
+        "%%",
+        "#",
+        "string",
+        "raw_string",
+        "regex",
+      ],
+    },
+    {
+      name: "base-prefixed arithmetic numbers",
+      source: "echo $((0xff + 16#ff + 2#1010 + 8#77))",
+      types: ["arithmetic_expansion", "binary_expression", "number"],
+    },
+  ])("parses additional branch target: $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.text).toBe(source);
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test.each([
+    {
+      name: "comments, CRLF whitespace, and line continuations",
+      source: "# leading\r\nprintf foo\\\r\nbar # trailing\n# done",
+      types: ["comment", "command", "command_name", "word"],
+    },
+    {
+      name: "standalone assignments and bare redirects",
+      source: "A=1 B+=two; >out; 2>&- 3<&- cat",
+      types: [
+        "variable_assignments",
+        "redirected_statement",
+        "file_redirect",
+        "file_descriptor",
+        ">&-",
+        "<&-",
+      ],
+    },
+    {
+      name: "redirect operator variants and greedy redirect destinations",
+      source: "cmd >|out &>>append >&2 <&0 >file arg tail",
+      types: [">|", "&>>", ">&", "<&", "file_redirect", "word"],
+    },
+    {
+      name: "heredoc trailing redirects, pipelines, and tab-stripped quoted bodies",
+      source: "cat <<-\\EOF >out | grep x\n\t$HOME literal\n\tEOF\n",
+      types: [
+        "heredoc_redirect",
+        "heredoc_start",
+        "file_redirect",
+        "pipeline",
+        "heredoc_body",
+        "heredoc_end",
+      ],
+    },
+    {
+      name: "unquoted heredoc body expansion content",
+      source: "cat <<EOF\nbefore $USER after $(date) tail\nEOF\n",
+      types: [
+        "heredoc_body",
+        "simple_expansion",
+        "command_substitution",
+        "heredoc_content",
+      ],
+    },
+    {
+      name: "command substitution shorthand and bracket arithmetic",
+      source: "echo $(< input) $[a+=1, b<<=2]",
+      types: [
+        "command_substitution",
+        "file_redirect",
+        "arithmetic_expansion",
+        "binary_expression",
+        "+=",
+        "<<=",
+      ],
+    },
+    {
+      name: "parameter expansion prefixes, transforms, substrings, arrays, and replacements",
+      source:
+        'echo $1 $_ $! $(cmd) ${!prefix*} ${var@Q} ${name: -2:1} ${var:} ${var:-("x" y)} ${v//"${old}"\\/$(cmd)tail}',
+      types: [
+        "simple_expansion",
+        "special_variable_name",
+        "expansion",
+        "@",
+        "number",
+        "array",
+        "string",
+        "regex",
+        "command_substitution",
+      ],
+    },
+    {
+      name: "bizarre and zsh-style parameter expansion forms",
+      source: "echo ${#!} ${!#} ${!## } ${=name} ${~name} ${#name} ${2+ ${2}}",
+      types: ["expansion", "#", "variable_name", "word"],
+    },
+    {
+      name: "arithmetic unary, assignment, bitwise, logical, exponent, and subscript operators",
+      source:
+        "echo $(( ++i, --j, ~mask, !ok, a**b, x<<=1, y>>=2, z&=3, q^=4, r|=5, a&&b||c, arr[++i] ))",
+      types: [
+        "arithmetic_expansion",
+        "unary_expression",
+        "binary_expression",
+        "**",
+        "<<=",
+        ">>=",
+        "&=",
+        "^=",
+        "|=",
+        "subscript",
+      ],
+    },
+    {
+      name: "c-style for with brace body",
+      source: "for ((i=0; i<3; i++)) { echo $i; }",
+      types: [
+        "c_style_for_statement",
+        "compound_statement",
+        "variable_assignment",
+        "postfix_expression",
+      ],
+    },
+    {
+      name: "regular for without explicit in list",
+      source: "for item\ndo echo $item\ndone",
+      types: ["for_statement", "variable_name", "do_group", "done"],
+    },
+    {
+      name: "case leading parens and fall-through terminators",
+      source: "case $x in (-g) ;; foo) echo foo ;& bar|baz) echo bar ;;& esac",
+      types: ["case_statement", "case_item", "(", ";&", ";;&", "word"],
+    },
+    {
+      name: "case alternatives with line continuations and quoted segments",
+      source: "case $x in foo|\\\n@(bar|baz)|*\"bar\"*) echo hit ;; esac",
+      types: [
+        "case_statement",
+        "case_item",
+        "concatenation",
+        "string",
+        "extglob_pattern",
+      ],
+    },
+    {
+      name: "test pattern operators with quoted regex and extglob RHS",
+      source:
+        '[[ "$x" = foo && "$x" != @(bar|baz) || "$x" =~ "quoted" ]]; [[ ! "x" =~ \' boop \'(.*)$ ]]',
+      types: [
+        "test_command",
+        "binary_expression",
+        "=",
+        "!=",
+        "=~",
+        "extglob_pattern",
+        "string",
+        "regex",
+        "unary_expression",
+      ],
+    },
+    {
+      name: "declaration command flags, quoted args, arrays, and bare names",
+      source: 'readonly -a arr=(one two); declare "FOO=bar" \'$WEIRD\' plain',
+      types: [
+        "declaration_command",
+        "word",
+        "variable_assignment",
+        "array",
+        "string",
+        "raw_string",
+        "variable_name",
+      ],
+    },
+    {
+      name: "unset command preserves quoted arguments for security walkers",
+      source: 'unset -v name \'array[$(id)]\' "$quoted"',
+      types: ["unset_command", "variable_name", "raw_string", "string"],
+    },
+    {
+      name: "translated strings, bare dollars, and empty backticks",
+      source: 'echo $"hello $USER" "cost $ and $x" foo`\n`bar',
+      types: ["$", "string", "simple_expansion", "concatenation"],
+    },
+  ])("parses targeted uncovered branch: $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.text).toBe(source);
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test.each([
+    {
+      name: "surrogate-pair word byte accounting",
+      source: "echo 😀",
+      types: ["command", "word"],
+    },
+    {
+      name: "unterminated heredoc still exposes body and synthetic end",
+      source: "cat <<EOF\nbody without delimiter",
+      types: ["heredoc_redirect", "heredoc_body", "heredoc_end"],
+    },
+    {
+      name: "unterminated double quote preserves parsed expansion",
+      source: 'echo "unterminated $USER',
+      types: ["string", "simple_expansion"],
+    },
+    {
+      name: "subscript and parameter operator boundary forms",
+      source:
+        "echo ${arr[((n+1))]} ${arr[@]} ${arr[*]} ${v:?missing} ${v:=default} ${v:+alt} ${v^x} ${v,,X}",
+      types: [
+        "subscript",
+        "compound_statement",
+        "word",
+        ":?",
+        ":=",
+        ":+",
+        "^",
+        ",,",
+      ],
+    },
+    {
+      name: "base-prefixed numbers with expansion children",
+      source: "echo 10#${base} 16#$(digits)",
+      types: ["number", "expansion", "command_substitution"],
+    },
+    {
+      name: "test expressions with missing unary and binary RHS",
+      source: "[[ -f ]] || [[ x == ]] || [[ x =~ ]]",
+      types: ["test_command", "test_operator", "list"],
+    },
+    {
+      name: "function keyword without a body",
+      source: "function f",
+      types: ["function_definition", "function", "word"],
+    },
+    {
+      name: "c-style for without body",
+      source: "for ((i=0; i<3; i++))",
+      types: ["c_style_for_statement", "variable_assignment"],
+    },
+    {
+      name: "empty case body",
+      source: "case $x in esac",
+      types: ["case_statement", "esac"],
+    },
+    {
+      name: "replacement expansion treats opening parens as replacement words",
+      source: "echo ${v/(/(Gentoo ${x}, }",
+      types: ["expansion", "regex", "concatenation"],
+    },
+  ])("recovers targeted parser boundary: $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.text).toBe(source);
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test.each([
+    {
+      name: "leading newlines before comments",
+      source: "\n\n# top\n\n",
+      types: ["comment"],
+    },
+    {
+      name: "trailing bare escape recovers as sibling error",
+      source: "echo word\\",
+      types: ["command", "word", "ERROR"],
+    },
+    {
+      name: "trailing and-or operator",
+      source: "echo ok &&",
+      types: ["list", "&&"],
+    },
+    {
+      name: "trailing pipeline operator",
+      source: "printf ok |",
+      types: ["pipeline", "|"],
+    },
+    {
+      name: "lone negation remains visible as a command word",
+      source: "!",
+      types: ["command", "command_name", "word"],
+    },
+    {
+      name: "synthetic subshell closer at EOF",
+      source: "(echo hi",
+      types: ["subshell", ")", "command"],
+    },
+    {
+      name: "synthetic brace group closer at EOF",
+      source: "{ echo hi",
+      types: ["compound_statement", "}", "command"],
+    },
+    {
+      name: "synthetic test closer at EOF",
+      source: "[[ x",
+      types: ["test_command", "]]", "word"],
+    },
+    {
+      name: "synthetic arithmetic command closer at EOF",
+      source: "(( 1 +",
+      types: ["compound_statement", "((", "))", "number"],
+    },
+    {
+      name: "assignment plus redirect without command name",
+      source: "A=1 >out",
+      types: ["command", "variable_assignment", "file_redirect"],
+    },
+    {
+      name: "function definition hoists redirected compound body",
+      source: "f() { echo hi; } >out",
+      types: ["function_definition", "compound_statement", "file_redirect"],
+    },
+    {
+      name: "single bracket command fallback stops at closing bracket",
+      source: "[ foo bar ]",
+      types: ["test_command", "word"],
+    },
+    {
+      name: "word immediately followed by paren becomes recoverable error",
+      source: "echo foo(bar)",
+      types: ["command", "ERROR", "subshell"],
+    },
+    {
+      name: "heredoc and-or child command before body",
+      source: "cat <<EOF && die\nbody\nEOF\n",
+      types: ["heredoc_redirect", "command", "heredoc_body", "heredoc_end"],
+    },
+    {
+      name: "heredoc terminator artifact becomes error child",
+      source: "cat <<EOF ; rm -rf x\nbody\nEOF\n",
+      types: ["heredoc_redirect", "ERROR", "heredoc_body", "heredoc_end"],
+    },
+    {
+      name: "heredoc trailing words remain visible to walkers",
+      source: "cat <<EOF extra words\nbody\nEOF\n",
+      types: ["heredoc_redirect", "word", "heredoc_body", "heredoc_end"],
+    },
+    {
+      name: "redirect close-fd destination and process substitution target",
+      source: "exec >&-target > >(cat)",
+      types: [">&-", "file_redirect", "process_substitution", ">("],
+    },
+    {
+      name: "unterminated process substitution",
+      source: "echo >(cmd",
+      types: ["process_substitution", ")", "command"],
+    },
+    {
+      name: "escaped heredoc body suppresses expansions",
+      source: "cat <<EOF\n\\$HOME \\`date\\` \\\\ $USER\nEOF\n",
+      types: [
+        "heredoc_body",
+        "simple_expansion",
+        "heredoc_content",
+        "heredoc_end",
+      ],
+    },
+    {
+      name: "dollar before backtick elides to command substitution",
+      source: "echo $`date`",
+      types: ["command_substitution", "`", "command"],
+    },
+    {
+      name: "brace terminator and standalone bracket fragments",
+      source: "echo {; echo } [ :lower: ]",
+      types: ["word", ";", "command"],
+    },
+    {
+      name: "rejected brace ranges fall back to word fragments",
+      source: "echo {1..a} {ab..cd} {foo",
+      types: ["command", "word", "concatenation"],
+    },
+    {
+      name: "double quotes split escaped newline and backtick substitutions",
+      source: 'echo "a\\$b\n`date` $ end"',
+      types: ["string", "string_content", "command_substitution", "$"],
+    },
+    {
+      name: "bare dollar and special brace variables",
+      source: "echo $ ${!} ${9}",
+      types: ["$", "expansion", "special_variable_name", "variable_name"],
+    },
+    {
+      name: "empty and negative substring expansion forms",
+      source: "echo ${var:\n} ${var:1:-2}",
+      types: ["expansion", "variable_name", "number"],
+    },
+    {
+      name: "replacement with command substitution emits split siblings",
+      source: "echo ${v/foo/$(cmd)tail}",
+      types: ["expansion", "regex", "command_substitution", "word"],
+    },
+    {
+      name: "regex replacements scan nested substitutions opaquely",
+      source: 'echo ${v/${outer:-x}/"quoted"/tail}',
+      types: ["expansion", "regex", "string"],
+    },
+    {
+      name: "segmented pattern removal skips nested command and brace forms",
+      source: "echo ${file%${prefix:-x}$(suffix)'tail'*}",
+      types: ["expansion", "regex", "raw_string"],
+    },
+    {
+      name: "regex test rhs tracks parens and brackets",
+      source: "[[ $x =~ ^(foo|bar)[0-9]+\\ space$ ]]",
+      types: ["test_command", "binary_expression", "regex"],
+    },
+    {
+      name: "extglob test rhs includes substitutions and quotes",
+      source: '[[ $x == pre${name}$(cmd)"mid"\'tail\'@(a|b) ]]',
+      types: [
+        "test_command",
+        "binary_expression",
+        "expansion",
+        "command_substitution",
+        "string",
+        "raw_string",
+      ],
+    },
+  ])("recovers additional parser edge: $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test.each([
+    {
+      name: "escaped blanks and CRLF continuations in separator whitespace",
+      source: "echo \\ foo \\\r\nbar",
+      types: ["command", "word"],
+    },
+    {
+      name: "pipe stderr operator",
+      source: "echo a |& cat",
+      types: ["pipeline", "|&"],
+    },
+    {
+      name: "stray arithmetic closer recovers as top-level error",
+      source: "))",
+      types: ["ERROR"],
+    },
+    {
+      name: "single assignment without command name",
+      source: "A=1",
+      types: ["variable_assignment"],
+    },
+    {
+      name: "array assignment with synthetic close",
+      source: "A=(",
+      types: ["variable_assignment", "array", ")"],
+    },
+    {
+      name: "assignment subscripts preserve numeric and word indexes",
+      source: "arr[42]=x arr[name]=y",
+      types: ["variable_assignment", "subscript", "number", "word"],
+    },
+    {
+      name: "compound herestring remains outside disallowed redirect",
+      source: "{ echo hi; } <<<inline",
+      types: ["compound_statement", "herestring_redirect"],
+    },
+    {
+      name: "redirect without a destination remains a file redirect",
+      source: "cmd >",
+      types: ["redirected_statement", "file_redirect", ">"],
+    },
+    {
+      name: "pre-command redirect takes only one literal destination",
+      source: ">out extra",
+      types: ["command", "file_redirect", "command_name"],
+    },
+    {
+      name: "redirect target stops before brace closer",
+      source: "{ cmd >}",
+      types: ["compound_statement", "file_redirect", "}"],
+    },
+    {
+      name: "quoted punctuation heredoc delimiter",
+      source: "cat <<'!EOF!'\nbody\n!EOF!\n",
+      types: ["heredoc_redirect", "heredoc_start", "heredoc_body"],
+    },
+    {
+      name: "heredoc trailer restores non-redirect digit words",
+      source: "cat <<EOF 2abc\nbody\nEOF\n",
+      types: ["heredoc_redirect", "word", "heredoc_body"],
+    },
+    {
+      name: "heredoc trailer keeps multi-stage pipeline child",
+      source: "cat <<EOF | grep x | wc\nbody\nEOF\n",
+      types: ["heredoc_redirect", "pipeline", "|", "heredoc_body"],
+    },
+    {
+      name: "word-mode expansion rest segments every literal form",
+      source: "echo ${v:-$'ansi'$USER\"q\"'r'<(cmd)>($(cmd))`date`{a}}",
+      types: [
+        "expansion",
+        "ansi_c_string",
+        "simple_expansion",
+        "string",
+        "raw_string",
+        "process_substitution",
+        "command_substitution",
+        "concatenation",
+      ],
+    },
+    {
+      name: "slash regex replacement scans nested forms opaquely",
+      source: "echo ${v//foo\\/${bar:-x}$(cmd){a}/tail}",
+      types: ["expansion", "regex", "/", "word"],
+    },
+    {
+      name: "pattern removal segmentation handles quotes and escapes",
+      source: "echo ${file%\"quoted\"\\x${prefix}$(cmd)'raw'*}",
+      types: ["expansion", "string", "raw_string", "regex"],
+    },
+    {
+      name: "unterminated backtick command substitution",
+      source: "echo `date",
+      types: ["command_substitution", "`", "command"],
+    },
+    {
+      name: "backtick body keeps command separators",
+      source: "echo `a; b& c`",
+      types: ["command_substitution", ";", "&"],
+    },
+    {
+      name: "c-style for brace body with synthetic close",
+      source: "for ((i=0;i<1;i++)) { echo $i",
+      types: ["c_style_for_statement", "compound_statement", "}"],
+    },
+    {
+      name: "regular for restores do keyword when separator is absent",
+      source: "for item do echo $item; done",
+      types: ["for_statement", "do_group", "done"],
+    },
+    {
+      name: "case statement reaches EOF without esac",
+      source: "case $x in foo) echo hit",
+      types: ["case_statement", "case_item", "command"],
+    },
+    {
+      name: "test command empty primaries",
+      source: "[ ] || [[ ]]",
+      types: ["test_command", "list"],
+    },
+    {
+      name: "test and-or operators without right-hand sides",
+      source: "[[ x || ]] && [[ y && ]]",
+      types: ["test_command", "list", "&&"],
+    },
+    {
+      name: "test parenthesized expression and bare negation",
+      source: "[[ ( x ) && ! ]]",
+      types: ["parenthesized_expression", "!"],
+    },
+    {
+      name: "test less-than and greater-than comparisons",
+      source: "[[ a < b && c > d ]]",
+      types: ["binary_expression", "<", ">"],
+    },
+    {
+      name: "test equality operators without right-hand sides",
+      source: "[[ x = ]] || [[ y == ]]",
+      types: ["test_command", "list"],
+    },
+    {
+      name: "regex test rhs stops at newline",
+      source: "[[ $x =~ foo\n]]",
+      types: ["test_command", "regex"],
+    },
+    {
+      name: "extglob rhs keeps escapes and interior spaces",
+      source: "[[ $x == foo\\ bar baz ]]",
+      types: ["test_command", "binary_expression", "extglob_pattern"],
+    },
+    {
+      name: "arithmetic operators and incomplete unary operands",
+      source:
+        "echo $(( a-=1, b*=2, c/=3, d%=4, e==f, g!=h, i<=j, k>=l, m<<n, o>>p, q&r, s|t, u=v, !, ~ ))",
+      types: [
+        "arithmetic_expansion",
+        "binary_expression",
+        "-=",
+        "*=",
+        "/=",
+        "%=",
+        "==",
+        "!=",
+        "<=",
+        ">=",
+        "<<",
+        ">>",
+        "&",
+        "|",
+        "=",
+        "!",
+        "~",
+      ],
+    },
+    {
+      name: "arithmetic parenthesis, string, and dollar primaries",
+      source: 'echo $(( (1 + $x) * "${y}" ))',
+      types: [
+        "arithmetic_expansion",
+        "parenthesized_expression",
+        "simple_expansion",
+        "string",
+      ],
+    },
+    {
+      name: "arithmetic synthetic parenthesis and subscript closers",
+      source: "echo $(( (1 + arr[2 ))",
+      types: ["parenthesized_expression", "subscript", "]", ")"],
+    },
+    {
+      name: "c-style for chained assignments and negative head literal",
+      source: "for ((a = b = c = -1; a<=c; a++)); do :; done",
+      types: [
+        "c_style_for_statement",
+        "variable_assignment",
+        "number",
+        "<=",
+        "postfix_expression",
+      ],
+    },
+  ])("covers expression parser edge: $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test.each([
+    {
+      name: "empty source returns an empty program",
+      source: "",
+      types: [],
+    },
+    {
+      name: "stray separator and doubled separator recovery",
+      source: "; echo ok ;;",
+      types: ["command"],
+    },
+    {
+      name: "plain LF continuation in command lookahead word",
+      source: "foo\\\nbar",
+      types: ["command", "command_name"],
+    },
+    {
+      name: "assignment subscript with nested brackets",
+      source: "arr[a[b]]=x",
+      types: ["variable_assignment", "subscript", "word"],
+    },
+    {
+      name: "expansion subscript with synthetic arithmetic close",
+      source: "echo ${arr[((n+1]}",
+      types: ["expansion", "subscript", "compound_statement", "))"],
+    },
+    {
+      name: "heredoc pipeline with no command after pipe",
+      source: "cat <<EOF |\nbody\nEOF\n",
+      types: ["heredoc_redirect", "heredoc_body"],
+    },
+    {
+      name: "heredoc body keeps non-expansion escapes as content",
+      source: "cat <<EOF\n\\q $USER\nEOF\n",
+      types: ["heredoc_body", "simple_expansion", "heredoc_content"],
+    },
+    {
+      name: "word stops before inline redirect operator",
+      source: "echo a>b",
+      types: ["redirected_statement", "file_redirect", "word"],
+    },
+    {
+      name: "invalid brace expression stays concatenated",
+      source: "echo {1..}",
+      types: ["command", "concatenation", "word"],
+    },
+    {
+      name: "bracket-only brace-like word fragments",
+      source: "echo {[]",
+      types: ["command", "concatenation", "word"],
+    },
+    {
+      name: "bracket arithmetic expansion with synthetic close",
+      source: "echo $[1+2",
+      types: ["arithmetic_expansion", "$[", "]", "binary_expression"],
+    },
+    {
+      name: "command substitution with synthetic close",
+      source: "echo $(date",
+      types: ["command_substitution", "$(", ")", "command"],
+    },
+    {
+      name: "brace expansion with synthetic close",
+      source: "echo ${var",
+      types: ["expansion", "${", "}", "variable_name"],
+    },
+    {
+      name: "anchored slash replacements",
+      source: "echo ${v//#foo/bar} ${v//%foo/bar}",
+      types: ["expansion", "#", "%", "regex", "word"],
+    },
+    {
+      name: "array default consumes trailing newline before close",
+      source: "echo ${v:-(x\n)}",
+      types: ["expansion", "array", "word"],
+    },
+    {
+      name: "regex replacement handles quoted middle segments",
+      source: "echo ${v//a\"b\"${nested:-x}$(cmd){a}/tail}",
+      types: ["expansion", "regex", "word"],
+    },
+    {
+      name: "word replacement stops at slash before replacement",
+      source: "echo ${v/foo/bar/baz}",
+      types: ["expansion", "regex", "/", "word"],
+    },
+    {
+      name: "empty default expansion has no replacement word",
+      source: "echo ${v:-}",
+      types: ["expansion", ":-", "variable_name"],
+    },
+    {
+      name: "segmented pattern removal scans nested structures",
+      source: "echo ${file%${outer${inner}}$(cmd $(nested))\n}",
+      types: ["expansion", "regex"],
+    },
+    {
+      name: "backtick with only a separator elides empty body",
+      source: "echo `;`",
+      types: ["command"],
+    },
+    {
+      name: "for in-list stops on non-word opener",
+      source: "for x in (; do echo $x; done",
+      types: ["for_statement", "in"],
+    },
+    {
+      name: "case item empty pattern breaks item parsing",
+      source: "case $x in ) echo hit ;; esac",
+      types: ["case_statement", "case_item"],
+    },
+    {
+      name: "case line continuation before alternative separator",
+      source: "case $x in foo\\\n|bar) echo hit ;; esac",
+      types: ["case_statement", "case_item", "|"],
+    },
+    {
+      name: "case pattern with dollar and bracket fragments",
+      source: "case $x in ${PN}.pot|*.[1357]) echo hit ;; esac",
+      types: ["case_statement", "concatenation", "expansion"],
+    },
+    {
+      name: "case pattern escaped and quoted segments",
+      source: "case $x in foo\\ bar|*\"q\\\"\"*) echo hit ;; esac",
+      types: ["case_statement", "case_item", "string"],
+    },
+    {
+      name: "case extglob pattern stops at newline inside parens",
+      source: "case $x in @(foo\n) echo hit ;; esac",
+      types: ["case_statement", "extglob_pattern"],
+    },
+    {
+      name: "declaration treats numeric token as word",
+      source: "declare 123",
+      types: ["declaration_command", "word"],
+    },
+    {
+      name: "unset without parseable argument stops cleanly",
+      source: "unset (",
+      types: ["unset_command"],
+    },
+    {
+      name: "if statement without then restores missing keyword",
+      source: "if true; echo no",
+      types: ["if_statement", "command"],
+    },
+    {
+      name: "arithmetic empty and partial ternary forms",
+      source: "echo $(( )), $(( a ? b ))",
+      types: ["arithmetic_expansion", "ternary_expression", ":"],
+    },
+    {
+      name: "arithmetic remaining binary operators",
+      source: "echo $(( a-b, c/d, e%f, g>h, i^j ))",
+      types: ["binary_expression", "-", "/", "%", ">", "^"],
+    },
+    {
+      name: "arithmetic prefix increment without operand",
+      source: "echo $(( ++ ))",
+      types: ["arithmetic_expansion", "++"],
+    },
+    {
+      name: "arithmetic parenthesis with synthetic close at EOF",
+      source: "echo $(( (1 + 2",
+      types: ["arithmetic_expansion", "parenthesized_expression", ")"],
+    },
+  ])("covers residual parser edge: $name", ({ source, types }) => {
+    const root = parse(source);
+    const seen = new Set(collectTypes(root));
+
+    expect(root.type).toBe("program");
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    for (const type of types) {
+      expect(seen, `missing node type ${type}`).toContain(type);
+    }
+  });
+
+  test("tracks UTF-8 byte spans while preserving node text", () => {
+    const source = 'echo cafe\u0301 "雪"';
+    const root = parse(source);
+    const decomposedCafe = findNode(root, (node) => node.text === "cafe\u0301");
+    const snowString = findNode(root, (node) => node.text === '"雪"');
+
+    expect(root.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+    expect(decomposedCafe?.startIndex).toBe(Buffer.byteLength("echo ", "utf8"));
+    expect(decomposedCafe?.endIndex).toBe(
+      Buffer.byteLength("echo cafe\u0301", "utf8"),
+    );
+    expect(snowString?.startIndex).toBe(
+      Buffer.byteLength("echo cafe\u0301 ", "utf8"),
+    );
+    expect(snowString?.endIndex).toBe(Buffer.byteLength(source, "utf8"));
+  });
+
+  test("distinguishes quoted and unquoted heredoc bodies", () => {
+    const unquoted = parse("cat <<EOF\n$HOME literal\nEOF");
+    const quoted = parse('cat <<"EOF"\n$HOME literal\nEOF');
+    const unquotedBody = findNode(
+      unquoted,
+      (node) => node.type === "heredoc_body",
+    );
+    const quotedBody = findNode(quoted, (node) => node.type === "heredoc_body");
+
+    expect(unquotedBody?.children.map((node) => node.type)).toContain(
+      "simple_expansion",
+    );
+    expect(quotedBody?.children).toEqual([]);
+  });
+
+  test("recovers zsh-style parse errors without losing following structure", () => {
+    const root = parse("echo =(cmd)");
+    const seen = new Set(collectTypes(root));
+
+    expect(seen).toContain("ERROR");
+    expect(seen).toContain("subshell");
+  });
+
+  test("returns null when the deadline is already exhausted", () => {
+    const source = Array.from({ length: 500 }, (_, index) => `echo ${index}`).join(
+      "; ",
+    );
+
+    expect(getParserModule()?.parse(source, -1)).toBeNull();
+  });
+});

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -57,12 +57,28 @@ function walkTestFiles(dir: string): string[] {
   });
 }
 
-const movedDonorTestFiles = movedDonorTestRoots
-  .flatMap(walkTestFiles)
-  .map((file) => normalizeConfigPath(relative(__dirname, file)));
 const bunTestFiles = walkTestFiles(runtimeTestRoot)
   .filter((file) => readFileSync(file, 'utf8').includes('bun:test'))
   .map((file) => normalizeConfigPath(relative(__dirname, file)));
+const movedDonorTestFiles = movedDonorTestRoots
+  .flatMap(walkTestFiles)
+  .map((file) => normalizeConfigPath(relative(__dirname, file)));
+
+function isVitestCompatibleBunTestFile(file: string): boolean {
+  const source = readFileSync(resolve(__dirname, file), 'utf8');
+  return (
+    !/\bmock\.module\b/.test(source) &&
+    !/\bmock\.restore\b/.test(source) &&
+    !/\bmock\s*\(/.test(source) &&
+    !/\bBun\./.test(source) &&
+    !/import\s*\(\s*`/.test(source) &&
+    !/\bRequestInit\s*&\s*\{\s*proxy\b/.test(source)
+  );
+}
+
+const bunOnlyTestFiles = bunTestFiles.filter(
+  (file) => !isVitestCompatibleBunTestFile(file),
+);
 
 function splitModuleId(id: string): { readonly path: string; readonly suffix: string } {
   const index = id.search(/[?#]/);
@@ -345,6 +361,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: [
+      { find: 'bun:test', replacement: resolve(__dirname, 'tests/helpers/bun-test-shim.ts') },
       { find: 'bun:bundle', replacement: resolve(__dirname, 'src/build/feature.ts') },
       { find: /^src\/(.*)$/, replacement: resolve(__dirname, 'src/$1') },
     ],
@@ -362,7 +379,7 @@ export default defineConfig({
       'dist',
       'tests/agenc/**/*.test.ts',
       'tests/agenc/**/*.test.tsx',
-      ...bunTestFiles,
+      ...bunOnlyTestFiles,
       // Moved donor-origin tests were previously hidden under src/agenc.
       // Keep them out of Vitest until their owning items convert them.
       ...movedDonorTestFiles,
@@ -372,6 +389,19 @@ export default defineConfig({
     testTimeout: 30000,
     deps: {
       interopDefault: true,
+    },
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx,mts,cts}'],
+      exclude: ['src/**/*.d.ts'],
+      reporter: ['text-summary', 'json-summary', 'json'],
+      reportsDirectory: 'coverage/runtime',
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
Test-confidence / 100%-coverage push for the runtime, plus source fixes uncovered along the way. Branch is 3 clean commits; all green locally (\`tsc\` exit 0, 15 test files / 469 tests passing).

### Source fixes
- **LSPClient**: consolidate child-listener teardown (\`removeChildListeners\`) and factor connection-close into \`scheduleUnexpectedConnectionClose\` with a \`connectionClosePending\` guard so \`stdout\` end/close and \`onClose\` can't double-fire.
- **powershell-parser**: destroy stdio streams and guard \`kill()\` on \`pid !== undefined\` on spawn failure / shutdown.
- **messages.extractTag**: replace multi-regex backtracking with a single tokenizing depth-counter (self-closing, nested, multiline tags).

### Refactor
- Extract session-ingress append/fetch logic into \`src/services/api/sessionIngress.ts\`; wire into \`sessionStorage\`.

### Test infra
- \`vitest.config\`: alias \`bun:test\` → \`tests/helpers/bun-test-shim\`, run vitest-compatible bun tests under vitest, add **100% coverage thresholds**.
- \`package.json\`: \`test:coverage\` runs \`--maxWorkers=1\`.
- ~13.5k lines of new tests across 13 new files plus expanded mcp/client, LSPClient, memdir.

## Test plan
- \`npx tsc --noEmit\` → exit 0
- \`npx vitest run\` on all new/modified files → 15 files, 469 tests passing