### PR TITLE
fix(runtime): cap per-session indices + snapshot inFlight to finish the --yolo OOM fix

### DIFF
--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -85,6 +85,17 @@ import { DegradedStore } from "./degraded-store.js";
 export const I4_FSYNC_RETRY_MS = 100;
 const I83_SUSPEND_DETECTION_MS = 10_000;
 
+// OOM: bound the per-session monotonic indices (`toolResultBytesByTurn`,
+// `tokenEstimateByTurn`, `toolCallTurnIds`, `offsetsBySeq`). These are advisory
+// accumulators — the rollout JSONL is the source of truth (I-25), the live
+// compaction window is far smaller than the cap, and the only production readers
+// tolerate a missing entry — so evicting the oldest tail (FIFO by Map insertion
+// order) once a map exceeds MAX bounds both heap and the index.json snapshot
+// without affecting correctness. Siblings of the already-capped `seenEventIds`
+// dedup set; closes the same unbounded-per-session growth class as #946/#947.
+export const MAX_SESSION_INDEX_ENTRIES = 50_000;
+export const SESSION_INDEX_EVICT_BATCH = 5_000;
+
 /**
  * index.json snapshot schema. Written atomically via tmp+rename
  * (I-24) on close and on explicit `writeIndexSnapshot()` calls.
@@ -1064,10 +1075,12 @@ export class SessionStore {
     if (turnId && toolResultBytes > 0) {
       const prev = this.toolResultBytesByTurn.get(turnId) ?? 0;
       this.toolResultBytesByTurn.set(turnId, prev + toolResultBytes);
+      this.boundIndexMap(this.toolResultBytesByTurn);
     }
     if (turnId && tokenEstimate > 0) {
       const prev = this.tokenEstimateByTurn.get(turnId) ?? 0;
       this.tokenEstimateByTurn.set(turnId, prev + tokenEstimate);
+      this.boundIndexMap(this.tokenEstimateByTurn);
     }
     if (
       turnId &&
@@ -1076,6 +1089,7 @@ export class SessionStore {
       toolCompletion.callId.length > 0
     ) {
       this.toolCallTurnIds.set(toolCompletion.callId, turnId);
+      this.boundIndexMap(this.toolCallTurnIds);
     }
 
     const item: RolloutItem = { type: "event_msg", payload: event };
@@ -1189,6 +1203,7 @@ export class SessionStore {
       }
       offsetAccumulator += Buffer.byteLength(serializeRolloutItem(item), "utf8");
     }
+    this.boundIndexMap(this.offsetsBySeq);
 
     const lines = this.pending.map(serializeRolloutItem).join("");
     const toWrite = this.pending;
@@ -1582,6 +1597,29 @@ export class SessionStore {
     // as a reconstruction speedup.
     this.writeIndexSnapshot();
     this.lock.release();
+  }
+
+  /**
+   * OOM: FIFO-evict the oldest entries of a monotonic per-session index Map
+   * once it grows past {@link MAX_SESSION_INDEX_ENTRIES}. Map iteration is
+   * insertion-ordered, so `keys()` yields oldest-first; deleting a batch keeps
+   * the recent tail (the entries a `/resume` fast-seek or compaction decision
+   * actually needs) and drops cold history. See the constant for why this is
+   * safe (advisory index; rollout JSONL is authoritative).
+   */
+  private boundIndexMap<K, V>(map: Map<K, V>): void {
+    if (map.size <= MAX_SESSION_INDEX_ENTRIES) return;
+    // Evict down to a low-water mark (not just one fixed batch) so a single
+    // bulk flush — `offsetsBySeq` sets one entry per pending event — cannot
+    // leave the map above the cap, and so we don't re-trigger on the very next
+    // insert. `keys()` is insertion-ordered, so this drops the coldest history.
+    const target = MAX_SESSION_INDEX_ENTRIES - SESSION_INDEX_EVICT_BATCH;
+    let toRemove = map.size - target;
+    for (const key of map.keys()) {
+      if (toRemove <= 0) break;
+      map.delete(key);
+      toRemove -= 1;
+    }
   }
 
   /**

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -27,11 +27,16 @@ export interface SnapshotPolicyOptions {
   readonly maxConversationEvents?: number;
   readonly maxTrackedSessions?: number;
   // OOM fix: bound the in-memory per-session tool state so a single long-lived
-  // session (e.g. `agenc --yolo`) cannot grow `completed` / `statusTransitions`
-  // without limit. The authoritative, full tool result is already persisted and
-  // size-rotated to SQLite (recordInFlightToolCallCompletion); the in-memory
-  // copy only needs a bounded preview for snapshotting.
+  // session (e.g. `agenc --yolo`) cannot grow `completed` / `inFlight` /
+  // `statusTransitions` without limit. The authoritative, full tool result is
+  // already persisted and size-rotated to SQLite (recordInFlightToolCallStart /
+  // recordInFlightToolCallCompletion); the in-memory copy only needs a bounded
+  // preview for snapshotting.
   readonly maxCompletedToolCalls?: number;
+  // OOM fix: `inFlight` normally drains on tool_call_completed/poisoned, but an
+  // orphaned call (cancel / crash / lost completion event) would otherwise pin
+  // an entry forever — the sibling leak to `completed`. Cap it the same way.
+  readonly maxInFlightToolCalls?: number;
   readonly maxStatusTransitions?: number;
   readonly maxInMemoryToolResultBytes?: number;
   readonly now?: () => string;
@@ -116,6 +121,7 @@ const DEFAULT_PERIODIC_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_CONVERSATION_EVENTS = 200;
 const DEFAULT_MAX_TRACKED_SESSIONS = 1_024;
 const DEFAULT_MAX_COMPLETED_TOOL_CALLS = 200;
+const DEFAULT_MAX_IN_FLIGHT_TOOL_CALLS = 256;
 const DEFAULT_MAX_STATUS_TRANSITIONS = 500;
 const DEFAULT_MAX_IN_MEMORY_TOOL_RESULT_BYTES = 4_096;
 
@@ -125,6 +131,7 @@ export class AgenCSessionSnapshotPolicy {
   readonly #maxConversationEvents: number;
   readonly #maxTrackedSessions: number;
   readonly #maxCompletedToolCalls: number;
+  readonly #maxInFlightToolCalls: number;
   readonly #maxStatusTransitions: number;
   readonly #maxInMemoryToolResultBytes: number;
   readonly #now: () => string;
@@ -159,6 +166,10 @@ export class AgenCSessionSnapshotPolicy {
       1,
       options.maxCompletedToolCalls ?? DEFAULT_MAX_COMPLETED_TOOL_CALLS,
     );
+    this.#maxInFlightToolCalls = Math.max(
+      1,
+      options.maxInFlightToolCalls ?? DEFAULT_MAX_IN_FLIGHT_TOOL_CALLS,
+    );
     this.#maxStatusTransitions = Math.max(
       1,
       options.maxStatusTransitions ?? DEFAULT_MAX_STATUS_TRANSITIONS,
@@ -192,6 +203,24 @@ export class AgenCSessionSnapshotPolicy {
     const overflow = keys.length - this.#maxCompletedToolCalls;
     for (let i = 0; i < overflow; i++) {
       delete completed[keys[i] as string];
+    }
+  }
+
+  // OOM fix: evict the oldest still-tracked in-flight tool calls (FIFO by
+  // insertion order) once the in-memory map exceeds its cap. `inFlight` normally
+  // drains on tool_call_completed/poisoned, but an orphaned call (cancellation,
+  // crash, or a lost completion event) would otherwise pin one entry forever in
+  // a long-lived `--yolo` session — the sibling leak to `completed`, which
+  // #boundCompletedToolCalls already caps. The full in-flight record is persisted
+  // via recordInFlightToolCallStart, so dropping the oldest in-memory entry is
+  // safe; a late completion still resolves via its own payload metadata
+  // (`previous ?? {}` at every consumer).
+  #boundInFlightToolCalls(state: SessionSnapshotState): void {
+    const inFlight = state.toolState.inFlight;
+    const keys = Object.keys(inFlight);
+    const overflow = keys.length - this.#maxInFlightToolCalls;
+    for (let i = 0; i < overflow; i++) {
+      delete inFlight[keys[i] as string];
     }
   }
 
@@ -366,6 +395,7 @@ export class AgenCSessionSnapshotPolicy {
           recoveryCategory: toolRecoveryCategoryField(params, "recoveryCategory"),
           status: "running",
         };
+        this.#boundInFlightToolCalls(state);
         recordInFlightToolCallStart(this.#driver, {
           sessionId,
           agentId,
@@ -584,6 +614,7 @@ export class AgenCSessionSnapshotPolicy {
           status: "running",
           lastProgressAt: stringField(event, "acceptedAt") ?? observedAt,
         };
+        this.#boundInFlightToolCalls(state);
       }
       return this.#writeSnapshot(state, "tool_call");
     }

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -19,9 +19,11 @@ import {
   findProjectRootSync,
   getProjectDir,
   I4_FSYNC_RETRY_MS,
+  MAX_SESSION_INDEX_ENTRIES,
   readIndexSnapshot,
   rewriteAtomically,
   SchemaMismatchError,
+  SESSION_INDEX_EVICT_BATCH,
   SessionLock,
   SessionLockedError,
   SessionStore,
@@ -382,6 +384,83 @@ describe("session-store", () => {
     expect(store.getToolResultBytes("turn-1")).toBe(12000);
     expect(store.getTokenEstimate("turn-1")).toBe(3000);
     store.close();
+  });
+
+  // OOM regression: the four per-session monotonic indices (offsetsBySeq,
+  // toolCallTurnIds, toolResultBytesByTurn, tokenEstimateByTurn) previously grew
+  // one entry per event/tool-call for the whole session — the same unbounded
+  // growth class as the #946/#947 leaks — bloating both heap and index.json.
+  // Drive a 50k+ tool-call soak and assert every index stays capped, both
+  // in-memory and in the serialized snapshot.
+  test("bounds the per-session monotonic indices under a 50k+ tool-call soak (OOM regression)", () => {
+    const store = new SessionStore({
+      cwd: "/home/test-index-soak",
+      sessionId: "sess-soak",
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId: "sess-soak",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-index-soak",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+
+    // Enough unique completions to cross the cap and force ≥1 eviction cycle.
+    // Unique seq + callId + turnId per event so all four indices grow 1/event.
+    const total = MAX_SESSION_INDEX_ENTRIES + SESSION_INDEX_EVICT_BATCH + 100;
+    for (let i = 0; i < total; i++) {
+      store.append(
+        {
+          id: `evt-${i}`,
+          seq: i + 1,
+          msg: {
+            type: "tool_call_completed",
+            payload: { callId: `call-${i}`, result: "ok", isError: false },
+          },
+        },
+        { turnId: `turn-${i}`, toolResultBytes: 1, tokenEstimate: 1 },
+      );
+    }
+
+    // In-memory (heap) bound: the append-path indices stay capped, the oldest
+    // entries are evicted (FIFO), and the newest survive. Before the fix each
+    // held all `total` entries.
+    const live = store.getCompactionIndexSnapshot();
+    expect(live.toolResultBytesByTurn.size).toBeLessThanOrEqual(
+      MAX_SESSION_INDEX_ENTRIES,
+    );
+    expect(live.toolResultBytesByTurn.size).toBeLessThan(total);
+    expect(live.tokenEstimateByTurn?.size ?? 0).toBeLessThanOrEqual(
+      MAX_SESSION_INDEX_ENTRIES,
+    );
+    expect(live.toolCallTurnIds.size).toBeLessThanOrEqual(
+      MAX_SESSION_INDEX_ENTRIES,
+    );
+    expect(live.toolCallTurnIds.get("call-0")).toBeUndefined();
+    expect(live.toolCallTurnIds.get(`call-${total - 1}`)).toBe(
+      `turn-${total - 1}`,
+    );
+
+    store.close();
+
+    // Serialized (index.json) bound: the snapshot the audit flagged as bloated
+    // by unbounded indices stays capped for all four records, including
+    // offsetsBySeq (bounded on the flush path).
+    const snapshot = readIndexSnapshot(store.indexPath);
+    expect(snapshot).not.toBeNull();
+    expect(Object.keys(snapshot!.offsetsBySeq).length).toBeLessThanOrEqual(
+      MAX_SESSION_INDEX_ENTRIES,
+    );
+    expect(
+      Object.keys(snapshot!.toolCallTurnIds ?? {}).length,
+    ).toBeLessThanOrEqual(MAX_SESSION_INDEX_ENTRIES);
+    expect(
+      Object.keys(snapshot!.toolResultBytesByTurn ?? {}).length,
+    ).toBeLessThanOrEqual(MAX_SESSION_INDEX_ENTRIES);
+    expect(
+      Object.keys(snapshot!.tokenEstimateByTurn ?? {}).length,
+    ).toBeLessThanOrEqual(MAX_SESSION_INDEX_ENTRIES);
   });
 
   test("Session.emit forwards real tool completion bytes into the rollout index", () => {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -167,6 +167,77 @@ describe("AgenCSessionSnapshotPolicy", () => {
     }
   });
 
+  // OOM fix: `inFlight` normally drains on tool_call_completed/poisoned, but an
+  // orphaned tool call (cancellation, crash, or a lost completion event)
+  // previously pinned an entry forever — the sibling leak to `completed`, the
+  // same unbounded-per-session class as #946/#947. Assert it is now FIFO-capped.
+  it("bounds the in-memory in-flight tool-call map for orphaned calls (OOM fix)", () => {
+    seedRun("run-oom-inflight", "session-oom-inflight");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+      maxInFlightToolCalls: 50,
+    });
+
+    // 300 tool requests, NONE completed → all remain "in flight" (orphaned).
+    const total = 300;
+    for (let i = 0; i < total; i++) {
+      policy.recordSessionEvent("session-oom-inflight", {
+        method: "event.tool_request",
+        params: {
+          eventId: `evt-req-${i}`,
+          requestId: `tool-${i}`,
+          toolName: "FileRead",
+        },
+      });
+    }
+
+    const inFlight = latestSnapshot("session-oom-inflight").toolState
+      .inFlight as Record<string, unknown>;
+    const keys = Object.keys(inFlight);
+    // Before the fix this held all 300 orphaned entries.
+    expect(keys.length).toBeLessThanOrEqual(50);
+    // Oldest are evicted (FIFO by insertion order); the newest survive.
+    expect(inFlight["tool-0"]).toBeUndefined();
+    expect(inFlight["tool-299"]).toBeDefined();
+  });
+
+  // The cap must not interfere with the happy-path lifecycle: a completed tool
+  // call still drains its in-flight entry, so a well-behaved session keeps
+  // `inFlight` near-empty regardless of the cap.
+  it("drains in-flight entries on completion (cap leaves the happy path intact)", () => {
+    seedRun("run-inflight-drain", "session-inflight-drain");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+      maxInFlightToolCalls: 50,
+    });
+
+    for (let i = 0; i < 120; i++) {
+      policy.recordSessionEvent("session-inflight-drain", {
+        method: "event.tool_request",
+        params: {
+          eventId: `evt-${i}`,
+          requestId: `tool-${i}`,
+          toolName: "FileRead",
+        },
+      });
+      policy.recordSessionEvent("session-inflight-drain", {
+        method: "event.session_event",
+        params: {
+          event: {
+            type: "tool_call_completed",
+            payload: { callId: `tool-${i}`, result: "ok", isError: false },
+          },
+        },
+      });
+    }
+
+    const inFlight = latestSnapshot("session-inflight-drain").toolState
+      .inFlight as Record<string, unknown>;
+    expect(Object.keys(inFlight).length).toBe(0);
+  });
+
   // OOM fix: the per-session status-transition log was an unbounded push target.
   it("bounds the status-transition log (OOM fix)", () => {
     seedRun("run-oom-st", "session-oom-st");


### PR DESCRIPTION
## Summary
Closes the unbounded-per-session memory-growth class that the last two `--yolo` OOM fixes (#946, #947) left half-done. Those bounded `seenEventIds` and the `completed` tool-call map but missed their siblings.

### `session-store.ts` — 4 monotonic indices
`offsetsBySeq`, `toolCallTurnIds`, `toolResultBytesByTurn`, `tokenEstimateByTurn` grew **one entry per event / tool-call for the whole session**, bloating both heap and the `index.json` snapshot. Added a FIFO `boundIndexMap()` (cap **50k**, evict down to a **45k** low-water mark) at every write site.

Why the low-water mark: `offsetsBySeq` is written in a **bulk** flush loop (one entry per pending event), so a single fixed-size evict batch could leave it over cap. Evicting to a target handles bulk- and single-insert callers uniformly.

Why eviction is safe: the rollout JSONL is the source of truth (I-25), and the only production readers (`getByteOffsetForSeq` + the snapshot getters) have **zero** non-test callers and already tolerate a missing entry.

### `snapshot-policy.ts` — `inFlight` map
`inFlight` normally drains on `tool_call_completed`/`poisoned`, but an **orphaned** call (cancel / crash / lost completion event) pinned an entry forever — the sibling leak to `completed`. Added `#boundInFlightToolCalls()` mirroring `#boundCompletedToolCalls`, plus a `maxInFlightToolCalls` option (default **256**). Safe because the full record is persisted via `recordInFlightToolCallStart` and late completions resolve via their own payload metadata (`previous ?? {}`).

## Tests (revert-sensitive)
- **session-store**: a **55,100-event soak** asserting all 4 indices stay capped in-memory *and* in the serialized `index.json`, oldest evicted / newest retained.
- **snapshot-policy**: a 300-orphaned-request soak (`inFlight` ≤ cap) + a happy-path drain test proving the cap doesn't break normal completion.
- Both soaks were confirmed to **fail without the fix** (temporarily neutered the caps → `55100 > 50000`, `300 > 50` → restored).

## Verification
- `typecheck` clean (0 errors)
- `state` + `session` suites: **800/800 pass**

Found via a production-readiness audit; this is item #2 of the "fix before GA" list (the OOM-leak hot zone).