### PR TITLE
fix(runtime): wire the global error net + self-heal the TUI render loop

### DIFF
--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -192,6 +192,7 @@ import {
 } from "../permissions/trust/trust-sources.js";
 import { runStartupConfigMigrations } from "../state/migrations/config-migrations.js";
 import { setSessionTrustAccepted } from "../bootstrap/state.js";
+import { installGlobalErrorNet } from "../utils/gracefulShutdown.js";
 
 type AgenCDaemonCliDeps = {
   readonly startPromptAgent: typeof startAgenCDaemonPromptAgent;
@@ -3671,6 +3672,12 @@ function isDirectInvocation(): boolean {
 
 if (isDirectInvocation()) {
   void (async () => {
+    // Install the process-global error net before anything runs so a stray
+    // uncaught exception / unhandled rejection on the daemon or TUI main path
+    // is logged instead of vanishing silently or crashing with a raw stack.
+    // Only on direct invocation — tests import main() and must keep vitest's
+    // own rejection detection intact.
+    installGlobalErrorNet();
     try {
       const code = await main();
       process.exit(code);

--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -100,6 +100,8 @@ export default class Ink {
   private backFrame: Frame;
   private lastPoolResetTime = performance.now();
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  // Throttle for the self-healing render error boundary (see onRenderError).
+  private lastRenderErrorLoggedAt = 0;
   private lastYogaCounters: {
     ms: number;
     visited: number;
@@ -459,6 +461,35 @@ export default class Ink {
     if (this.isUnmounted || this.isPaused) {
       return;
     }
+    // Self-healing render boundary: a single throwing frame must not crash the
+    // process (now that the global error net keeps it alive) or leave the
+    // double buffer / terminal desynced. Contain the throw, force a full
+    // repaint next frame, and keep rendering.
+    try {
+      this.renderFrame();
+    } catch (error) {
+      this.onRenderError(error);
+    }
+  }
+  onRenderError(error: unknown) {
+    // Drop this frame and force the NEXT one to do a full-damage repaint so a
+    // partially-written diff self-heals. Throttle logging so a deterministic
+    // per-frame failure can't spam the diagnostics log.
+    this.prevFrameContaminated = true;
+    const now = Date.now();
+    if (now - (this.lastRenderErrorLoggedAt ?? 0) > 1000) {
+      this.lastRenderErrorLoggedAt = now;
+      try {
+        logForDebugging(
+          `[Ink] render frame threw and was contained: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+          { level: 'error' }
+        );
+      } catch {
+        // Logging must never re-throw out of the render error handler.
+      }
+    }
+  }
+  renderFrame() {
     // Entering a render cancels any pending drain tick — this render will
     // handle the drain (and re-schedule below if needed). Prevents a
     // wheel-event-triggered render AND a drain-timer render both firing.

--- a/runtime/src/utils/gracefulShutdown.ts
+++ b/runtime/src/utils/gracefulShutdown.ts
@@ -229,6 +229,47 @@ function forceExit(exitCode: number): never {
 }
 
 /**
+ * Install the process-global error net: log uncaught exceptions and unhandled
+ * promise rejections through the no-PII diagnostics channel instead of letting
+ * an unhandled rejection vanish silently or an uncaught exception crash the
+ * process with a raw stack. Idempotent (memoized) — safe to call from multiple
+ * entrypoints; handlers register once per process.
+ *
+ * Intentionally NON-exiting: a long-lived daemon / TUI should survive a stray
+ * async error. The TUI render loop self-heals per frame (see ink.tsx onRender),
+ * and orderly signal shutdown is owned separately (installSignalHandlers /
+ * setupGracefulShutdown).
+ *
+ * `proc` is injectable for tests so they can assert registration + handler
+ * behavior against a fake emitter without touching the real process (which
+ * would swallow vitest's own rejection detection).
+ */
+export const installGlobalErrorNet = memoize(
+  (proc: Pick<NodeJS.Process, 'on'> = process): void => {
+    // Log uncaught exceptions for container observability and analytics.
+    // Error names (e.g., "TypeError") are not sensitive - safe to log.
+    proc.on('uncaughtException', error => {
+      logForDiagnosticsNoPII('error', 'uncaught_exception', {
+        error_name: error?.name ?? 'Error',
+        error_message: String(error?.message ?? error).slice(0, 2000),
+      })
+    })
+    // Log unhandled promise rejections for container observability and analytics.
+    proc.on('unhandledRejection', reason => {
+      const errorInfo =
+        reason instanceof Error
+          ? {
+              error_name: reason.name,
+              error_message: reason.message.slice(0, 2000),
+              error_stack: reason.stack?.slice(0, 4000),
+            }
+          : { error_message: String(reason).slice(0, 2000) }
+      logForDiagnosticsNoPII('error', 'unhandled_rejection', errorInfo)
+    })
+  },
+)
+
+/**
  * Set up global signal handlers for graceful shutdown
  */
 export const setupGracefulShutdown = memoize(() => {
@@ -293,27 +334,10 @@ export const setupGracefulShutdown = memoize(() => {
     }
   }
 
-  // Log uncaught exceptions for container observability and analytics
-  // Error names (e.g., "TypeError") are not sensitive - safe to log
-  process.on('uncaughtException', error => {
-    logForDiagnosticsNoPII('error', 'uncaught_exception', {
-      error_name: error.name,
-      error_message: error.message.slice(0, 2000),
-    })
-  })
-
-  // Log unhandled promise rejections for container observability and analytics
-  process.on('unhandledRejection', reason => {
-    const errorInfo =
-      reason instanceof Error
-        ? {
-            error_name: reason.name,
-            error_message: reason.message.slice(0, 2000),
-            error_stack: reason.stack?.slice(0, 4000),
-          }
-        : { error_message: String(reason).slice(0, 2000) }
-    logForDiagnosticsNoPII('error', 'unhandled_rejection', errorInfo)
-  })
+  // Uncaught-exception + unhandled-rejection logging lives in the shared,
+  // memoized installGlobalErrorNet so the standalone entrypoint wiring and this
+  // bundled setup register the same handlers exactly once.
+  installGlobalErrorNet()
 })
 
 export function gracefulShutdownSync(

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -247,6 +247,39 @@ describe('Ink instance rendering paths', () => {
     }
   })
 
+  test('contains a throwing render frame instead of crashing, and self-heals next frame', async () => {
+    const harness = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      harness.root.render(textNode('ready'))
+      await sleep(10)
+
+      const instance = harness.instance as InkInternals & {
+        onRender: () => void
+        renderer: unknown
+      }
+      // Force the next frame's renderer to throw mid-render.
+      const originalRenderer = instance.renderer
+      instance.renderer = () => {
+        throw new Error('render boom')
+      }
+      instance.prevFrameContaminated = false
+
+      // Without the self-healing boundary this propagates as an uncaught throw,
+      // which (with the global error net keeping the process alive) would leave
+      // the double buffer / terminal desynced.
+      expect(() => instance.onRender()).not.toThrow()
+      // The bad frame is dropped and the next frame is forced to full-repaint.
+      expect(instance.prevFrameContaminated).toBe(true)
+
+      // Restoring a working renderer lets rendering resume cleanly.
+      instance.renderer = originalRenderer
+      expect(() => instance.onRender()).not.toThrow()
+    } finally {
+      await harness.dispose()
+    }
+  })
+
   test('does not reassert terminal modes after unmounting', async () => {
     const harness = await createHarness({ columns: 20, rows: 5 })
 

--- a/runtime/tests/utils/gracefulShutdown.test.ts
+++ b/runtime/tests/utils/gracefulShutdown.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+
+import { installGlobalErrorNet } from '../../src/utils/gracefulShutdown.js'
+
+type Handler = (...args: unknown[]) => void
+
+// A throwaway stand-in for `process` so we never register swallowing handlers
+// on the real process (which would mask the test runner's own rejection
+// detection). A fresh object per call keeps the memoize on installGlobalErrorNet
+// keyed per-process, so tests don't bleed registrations into one another.
+function fakeProc(): { on: Handler; handlers: Map<string, Handler[]> } {
+  const handlers = new Map<string, Handler[]>()
+  const proc = {
+    on(event: string, handler: Handler) {
+      const list = handlers.get(event) ?? []
+      list.push(handler)
+      handlers.set(event, list)
+      return proc
+    },
+    handlers,
+  }
+  return proc
+}
+
+describe('installGlobalErrorNet', () => {
+  test('registers uncaughtException + unhandledRejection handlers', () => {
+    const proc = fakeProc()
+    installGlobalErrorNet(proc as never)
+    expect(proc.handlers.get('uncaughtException')).toHaveLength(1)
+    expect(proc.handlers.get('unhandledRejection')).toHaveLength(1)
+  })
+
+  test('is non-exiting: handlers only log and never re-throw', () => {
+    const proc = fakeProc()
+    installGlobalErrorNet(proc as never)
+    const uncaught = proc.handlers.get('uncaughtException')![0]!
+    const rejection = proc.handlers.get('unhandledRejection')![0]!
+    // A real process.exit would throw here (it is not stubbed); the handlers
+    // must only log. Cover an Error and a non-Error rejection reason.
+    expect(() => uncaught(new TypeError('boom'))).not.toThrow()
+    expect(() => rejection(new Error('y'))).not.toThrow()
+    expect(() => rejection('plain string reason')).not.toThrow()
+  })
+
+  test('is idempotent per process (memoized) — a second call does not re-register', () => {
+    const proc = fakeProc()
+    installGlobalErrorNet(proc as never)
+    installGlobalErrorNet(proc as never)
+    expect(proc.handlers.get('uncaughtException')).toHaveLength(1)
+    expect(proc.handlers.get('unhandledRejection')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
Audit "fix before GA" item #5 — two operability gaps:

### 1. No global error net
`setupGracefulShutdown`'s `uncaughtException` / `unhandledRejection` handlers — **the only ones in the entire tree** — had **zero callers**, so a daemon-backed or TUI session that threw off the main path crashed with a raw stack (or, for a rejection, vanished silently). Operators had no signal.

- Extracted the handlers into a shared, memoized, idempotent **`installGlobalErrorNet()`** (`proc` injectable for tests).
- Wired it at the **direct-invocation entry** in `bin/agenc.ts` — the single process entry for the TUI, one-shot CLI, and the foreground/background daemon. Installed **only** on direct invocation so tests that `import { main }` keep the runner's own rejection detection intact.
- `setupGracefulShutdown` now delegates to the same function (single source of truth).
- Intentionally **non-exiting**: a long-lived agent should survive a stray async error rather than hard-crash and reset the terminal.

### 2. TUI render loop had no try/catch
With the error net keeping the process alive, a single throwing frame would leave the double buffer / terminal desynced. Wrapped `onRender`'s body (extracted to `renderFrame()`) so a throwing frame is **contained**: drop the frame, force a full-damage repaint next frame (`prevFrameContaminated`), and **throttle** the diagnostic log so a deterministic per-frame failure can't spam.

## Tests
- **`tests/utils/gracefulShutdown.test.ts`** (bun) — registers both handlers, non-exiting, idempotent. Lands in the **required Bun gate** alongside `env.test.ts`.
- **`ink.render.test.tsx`** — a throwing renderer is contained (`onRender` doesn't throw; self-heals via `prevFrameContaminated`). Confirmed to **fail without the wrap** (temporarily bypassed the try/catch → red → restored).

## Verification
- `typecheck` clean (0 errors)
- ink suites **29/29**, `tests/bin` **375/375**, bun gracefulShutdown **3/3**