### PR TITLE
fix(runtime): unify the config home so AGENC_HOME no longer splits secrets

### DIFF
--- a/runtime/src/utils/env.ts
+++ b/runtime/src/utils/env.ts
@@ -22,20 +22,35 @@ export const getGlobalAgenCFile = memoize((): string => {
   }
 
   const oauthSuffix = fileSuffixForOauthConfig()
-  const configDir = process.env.AGENC_CONFIG_DIR || homedir()
+  const filename = `.agenc${oauthSuffix}.json`
 
-  // Default to .agenc.json. Fall back to .agenc.json only if the new
-  // file doesn't exist yet and the compatibility one does (same migration pattern
-  // as resolveAgenCConfigHomeDir for the config directory).
-  const newFilename = `.agenc${oauthSuffix}.json`
-  const legacyFilename = `.agenc${oauthSuffix}.json`
-  if (
-    !getFsImplementation().existsSync(join(configDir, newFilename)) &&
-    getFsImplementation().existsSync(join(configDir, legacyFilename))
-  ) {
-    return join(configDir, legacyFilename)
+  // Resolve the secrets-bearing global config from the SAME home that
+  // config.toml / auth.json use: AGENC_CONFIG_DIR (explicit per-file override)
+  // > AGENC_HOME > $HOME. Previously AGENC_HOME was ignored here, so a custom
+  // AGENC_HOME relocated config.toml + auth.json but stranded this file at
+  // $HOME/.agenc.json — silently splitting provider keys, MCP servers, and
+  // global settings across two directories.
+  const configDirOverride = process.env.AGENC_CONFIG_DIR
+  const agencHome = process.env.AGENC_HOME
+  const configDir = configDirOverride || agencHome || homedir()
+  const resolvedPath = join(configDir, filename)
+
+  // Backward-compat: an install that set AGENC_HOME before this fix wrote the
+  // file to the legacy $HOME/.agenc.json. If the unified location doesn't exist
+  // yet but that legacy file does, keep reading it so the upgrade doesn't look
+  // like the provider keys were dropped. Scoped to the AGENC_HOME case so the
+  // explicit AGENC_CONFIG_DIR path and the no-env default are unaffected.
+  if (!configDirOverride && agencHome) {
+    const legacyPath = join(homedir(), filename)
+    if (
+      legacyPath !== resolvedPath &&
+      !getFsImplementation().existsSync(resolvedPath) &&
+      getFsImplementation().existsSync(legacyPath)
+    ) {
+      return legacyPath
+    }
   }
-  return join(configDir, newFilename)
+  return resolvedPath
 })
 
 const hasInternetAccess = memoize(async (): Promise<boolean> => {

--- a/runtime/tests/utils/env.test.ts
+++ b/runtime/tests/utils/env.test.ts
@@ -60,3 +60,49 @@ test('getGlobalAgenCFile: migrated user uses .agenc.json when both files exist',
   const { getGlobalAgenCFile } = await importFreshEnvModule()
   expect(getGlobalAgenCFile()).toBe(join(tempDir, '.agenc.json'))
 })
+
+// AGENC_HOME unification: the secrets-bearing global config must resolve from
+// the same home AGENC_HOME selects for config.toml/auth.json, instead of being
+// stranded at $HOME. (os.homedir() ignores $HOME under Bun, so these write the
+// file at the AGENC_HOME location to stay deterministic regardless of the real
+// home — which also exercises the resolved-path-exists branch.)
+test('getGlobalAgenCFile: AGENC_HOME is honored instead of being ignored', async () => {
+  const savedConfigDir = process.env.AGENC_CONFIG_DIR
+  const savedHome = process.env.AGENC_HOME
+  const agencHome = mkdtempSync(join(tmpdir(), 'agenc-home-'))
+  try {
+    delete process.env.AGENC_CONFIG_DIR
+    process.env.AGENC_HOME = agencHome
+    writeFileSync(join(agencHome, '.agenc.json'), '{}')
+    const { getGlobalAgenCFile } = await importFreshEnvModule()
+    // Before the fix this returned $HOME/.agenc.json (AGENC_HOME ignored),
+    // splitting provider keys away from config.toml.
+    expect(getGlobalAgenCFile()).toBe(join(agencHome, '.agenc.json'))
+  } finally {
+    rmSync(agencHome, { recursive: true, force: true })
+    if (savedConfigDir === undefined) delete process.env.AGENC_CONFIG_DIR
+    else process.env.AGENC_CONFIG_DIR = savedConfigDir
+    if (savedHome === undefined) delete process.env.AGENC_HOME
+    else process.env.AGENC_HOME = savedHome
+  }
+})
+
+test('getGlobalAgenCFile: AGENC_CONFIG_DIR takes precedence over AGENC_HOME', async () => {
+  const savedConfigDir = process.env.AGENC_CONFIG_DIR
+  const savedHome = process.env.AGENC_HOME
+  const configDir = mkdtempSync(join(tmpdir(), 'agenc-cfg-'))
+  const agencHome = mkdtempSync(join(tmpdir(), 'agenc-home-'))
+  try {
+    process.env.AGENC_CONFIG_DIR = configDir
+    process.env.AGENC_HOME = agencHome
+    const { getGlobalAgenCFile } = await importFreshEnvModule()
+    expect(getGlobalAgenCFile()).toBe(join(configDir, '.agenc.json'))
+  } finally {
+    rmSync(configDir, { recursive: true, force: true })
+    rmSync(agencHome, { recursive: true, force: true })
+    if (savedConfigDir === undefined) delete process.env.AGENC_CONFIG_DIR
+    else process.env.AGENC_CONFIG_DIR = savedConfigDir
+    if (savedHome === undefined) delete process.env.AGENC_HOME
+    else process.env.AGENC_HOME = savedHome
+  }
+})


### PR DESCRIPTION
## Summary
Audit "fix before GA" item #6 — `AGENC_HOME=/custom` silently splits credentials.

`getGlobalAgenCFile` resolved the secrets-bearing `~/.agenc.json` (provider keys, MCP servers, global settings) from `AGENC_CONFIG_DIR || homedir()`, **ignoring `AGENC_HOME`** — while `config.toml` / `auth.json` honor it. So a custom `AGENC_HOME` relocated most state to `/custom` but stranded the global config at `$HOME/.agenc.json`, splitting credentials across two directories. (The function was already inconsistent with itself: the `.config.json` compat check one line above uses the `AGENC_HOME`-aware `getAgenCConfigHomeDir()`.)

## Fix
Resolve from the same home as everything else: **`AGENC_CONFIG_DIR` (explicit per-file override) > `AGENC_HOME` > `$HOME`**.

- **Backward-compat**, scoped to the `AGENC_HOME` case: if the unified location doesn't exist yet but a legacy `$HOME/.agenc.json` does, keep reading the legacy file so an upgrade doesn't look like provider keys were dropped.
- The explicit-`AGENC_CONFIG_DIR` path and the no-env default are **unchanged**.
- Removes the dead migration branch whose `newFilename` and `legacyFilename` were the **same string** (a no-op).

## Tests (bun — required gate)
- `AGENC_HOME` is honored — **confirmed to fail against the old code** (which returned `$HOME/.agenc.json`).
- `AGENC_CONFIG_DIR` still takes precedence over `AGENC_HOME`.
- Deterministic under Bun (where `os.homedir()` ignores `$HOME`) by writing the file at the `AGENC_HOME` location.

## Verification
- `typecheck` clean; env + credential bun tests green.
- Note: the Bun suite has one **pre-existing, unrelated** failure (`tests/utils/file.test.ts` → `addLineNumbers` formatting) that also fails on `main` with this branch's changes stashed — not introduced here.