### PR TITLE
test(runtime): fix the stale addLineNumbers killswitch test + drop dead padded branch

### DIFF
--- a/runtime/src/utils/file.ts
+++ b/runtime/src/utils/file.ts
@@ -265,22 +265,12 @@ export async function suggestPathUnderCwd(
 }
 
 /**
- * Whether to use the compact line-number prefix format (`N→` instead of
- * `     N→`). The padded-arrow format costs 9 bytes/line overhead; at
- * 1.35B Read calls × 132 lines avg this is 2.18% of fleet uncached input
- * (bq-queries/read_line_prefix_overhead_verify.sql).
+ * Adds cat -n style line numbers to the content using the compact `N→` prefix
+ * (a single arrow separator, no left-padding) to keep Read output small.
  *
- * Ant soak validated no Edit error regression (6.29% vs 6.86% baseline).
- * Killswitch pattern: GB can disable if issues surface externally.
- */
-export function isCompactLinePrefixEnabled(): boolean {
-  // 3P default: killswitch off = compact format enabled. Client-side only —
-  // no server support needed, safe for Bedrock/Vertex/Foundry.
-  return !false
-}
-
-/**
- * Adds cat -n style line numbers to the content.
+ * The older padded-arrow format (`     N→`) was gated behind the now-removed
+ * feature-flag system and is no longer emitted, but {@link stripLineNumberPrefix}
+ * still accepts it so line numbers written by earlier versions round-trip.
  */
 export function addLineNumbers({
   content,
@@ -294,22 +284,9 @@ export function addLineNumbers({
     return ''
   }
 
-  const lines = content.split(/\r?\n/)
-
-  if (isCompactLinePrefixEnabled()) {
-    return lines
-      .map((line, index) => `${index + startLine}→${line}`)
-      .join('\n')
-  }
-
-  return lines
-    .map((line, index) => {
-      const numStr = String(index + startLine)
-      if (numStr.length >= 6) {
-        return `${numStr}→${line}`
-      }
-      return `${numStr.padStart(6, ' ')}→${line}`
-    })
+  return content
+    .split(/\r?\n/)
+    .map((line, index) => `${index + startLine}→${line}`)
     .join('\n')
 }
 

--- a/runtime/tests/utils/file.test.ts
+++ b/runtime/tests/utils/file.test.ts
@@ -1,49 +1,31 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 
-async function importFileModuleWithKillswitchEnabled(
-  killswitchEnabled: boolean,
-) {
-  mock.module('../../src/services/analytics/growthbook.js', () => ({
-    getFeatureValue_CACHED_MAY_BE_STALE: () => killswitchEnabled,
-  }))
-
-  return import(`../../src/utils/file.ts?ts=${Date.now()}-${Math.random()}`)
-}
-
-afterEach(() => {
-  mock.restore()
-})
+import { addLineNumbers, stripLineNumberPrefix } from '../../src/utils/file.js'
 
 describe('addLineNumbers', () => {
-  test('uses unambiguous arrow compact prefix and preserves leading tabs', async () => {
-    const { addLineNumbers } = await importFileModuleWithKillswitchEnabled(false)
-
-    const result = addLineNumbers({
-      content: '\tfirst\n\t\tsecond',
-      startLine: 41,
-    })
-
-    expect(result).toBe('41→\tfirst\n42→\t\tsecond')
+  test('uses the unambiguous arrow compact prefix and preserves leading tabs', () => {
+    expect(
+      addLineNumbers({ content: '\tfirst\n\t\tsecond', startLine: 41 }),
+    ).toBe('41→\tfirst\n42→\t\tsecond')
   })
 
-  test('keeps padded arrow format when compact mode is disabled', async () => {
-    const { addLineNumbers } = await importFileModuleWithKillswitchEnabled(true)
+  test('always uses the compact prefix — never left-pads the line number', () => {
+    // The GrowthBook-gated padded-arrow fallback was removed, so even small
+    // line numbers stay compact instead of padding out to six columns.
+    expect(addLineNumbers({ content: 'alpha\nbeta', startLine: 1 })).toBe(
+      '1→alpha\n2→beta',
+    )
+  })
 
-    const result = addLineNumbers({
-      content: 'alpha\nbeta',
-      startLine: 1,
-    })
-
-    expect(result).toBe('     1→alpha\n     2→beta')
+  test('returns an empty string for empty content', () => {
+    expect(addLineNumbers({ content: '', startLine: 1 })).toBe('')
   })
 })
 
 describe('stripLineNumberPrefix', () => {
-  test('strips compact arrow, padded arrow, and legacy tab prefixes', async () => {
-    const { stripLineNumberPrefix } = await importFileModuleWithKillswitchEnabled(
-      false,
-    )
-
+  test('strips compact arrow, legacy padded arrow, and legacy tab prefixes', () => {
+    // The padded + tab prefixes must still round-trip: older sessions/files on
+    // disk were written before the format was unified to the compact arrow.
     expect(stripLineNumberPrefix('41→\tfirst')).toBe('\tfirst')
     expect(stripLineNumberPrefix('     2→beta')).toBe('beta')
     expect(stripLineNumberPrefix('7\t\tlegacy-tab')).toBe('\tlegacy-tab')


### PR DESCRIPTION
## Summary
Fixes the lone red test in the **required Bun gate** (`tests/utils/file.test.ts > "keeps padded arrow format when compact mode is disabled"`). It was a stale test from an incomplete refactor, not a behavior bug.

## Root cause
Commit `6c896c173` ("remove the vestigial GrowthBook feature-flag system") hardcoded `isCompactLinePrefixEnabled()` to always-`true` and deleted `getFeatureValue_CACHED_MAY_BE_STALE`, but left two loose ends:

1. **Stale test** — still mocked the removed analytics module and expected the killswitch to toggle the padded `     N→` format back on. That path no longer exists, so it asserted padding the code can never produce (`expected '     1→alpha'`, got `'1→alpha'`).
2. **Dead code** — `utils/file.ts` still carried the vestigial `isCompactLinePrefixEnabled()` (no callers but its own) and an **unreachable** padded branch in `addLineNumbers`.

The canonical implementation (`tools/system/_deps/line-numbers.ts`, used by file-read) was **already** always-compact and even documents that "the killswitch for the padded form lived in the analytics feature gate that [was removed]". So `utils/file.ts` was just out of sync.

## Fix
- `addLineNumbers` always emits the compact `N→` prefix — **what it already did at runtime** (the branch was dead) and what the canonical helper does.
- Removed the vestigial `isCompactLinePrefixEnabled()`.
- Rewrote the test to assert the real always-compact behavior.
- **`stripLineNumberPrefix` unchanged** — it must still strip the legacy padded + tab prefixes so line numbers written by older versions round-trip (retained test covers this).

## Verification
- **Zero behavior change** (padded branch was unreachable; consumer `file-read` + `FileEditTool` suites **28/28**).
- `typecheck` clean.
- The isolated **Bun gate is now 104/104** (was 103/104).