### PR TITLE
fix(runtime): reclaim the last 2 @ts-nocheck files + fix the agent-summarization bug

### DIFF
--- a/runtime/src/tasks/LocalAgentTask/LocalAgentTask.tsx
+++ b/runtime/src/tasks/LocalAgentTask/LocalAgentTask.tsx
@@ -343,6 +343,25 @@ export function updateAgentProgress(taskId: string, progress: AgentProgress, set
 }
 
 /**
+ * Update only the background-summarization summary for an agent task,
+ * preserving the rest of the progress. Counterpart to updateAgentProgress
+ * (which preserves the summary): the two write disjoint parts of `progress`
+ * so live progress updates and async summary updates don't clobber each other.
+ */
+export function updateAgentSummary(taskId: string, summary: string, setAppState: SetAppState): void {
+  updateTaskState<LocalAgentTaskState>(taskId, setAppState, task => {
+    if (task.status !== 'running') {
+      return task;
+    }
+    const base: AgentProgress = task.progress ?? { toolUseCount: 0, tokenCount: 0 };
+    return {
+      ...task,
+      progress: { ...base, summary }
+    };
+  });
+}
+
+/**
  * Complete an agent task with result.
  */
 export function completeAgentTask(result: AgentToolResult, setAppState: SetAppState): void {

--- a/runtime/src/tools/AgentTool/AgentTool.tsx
+++ b/runtime/src/tools/AgentTool/AgentTool.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import { feature } from 'bun:bundle';
-import * as React from 'react';
 import { buildTool, type ToolDef, toolMatchesName } from 'src/tools/Tool.js';
 import type { Message as MessageType, NormalizedUserMessage } from 'src/types/message.js';
 import { getQuerySourceForAgent } from 'src/utils/promptCategory.js';
@@ -10,7 +8,7 @@ import { enhanceSystemPromptWithEnvDetails, getSystemPrompt } from '../../consta
 import { isCoordinatorMode } from '../../coordinator/coordinatorMode.js';
 import { startAgentSummarization } from '../../services/AgentSummary/agentSummary.js';
 import { clearDumpState } from '../../services/api/dumpPrompts.js';
-import { completeAgentTask as completeAsyncAgent, createActivityDescriptionResolver, createProgressTracker, enqueueAgentNotification, failAgentTask as failAsyncAgent, getProgressUpdate, getTokenCountFromTracker, isLocalAgentTask, killAsyncAgent, registerAgentForeground, registerAsyncAgent, unregisterAgentForeground, updateAgentProgress as updateAsyncAgentProgress, updateProgressFromMessage } from '../../tasks/LocalAgentTask/LocalAgentTask.js';
+import { completeAgentTask as completeAsyncAgent, createActivityDescriptionResolver, createProgressTracker, enqueueAgentNotification, failAgentTask as failAsyncAgent, getProgressUpdate, getTokenCountFromTracker, isLocalAgentTask, killAsyncAgent, registerAgentForeground, registerAsyncAgent, unregisterAgentForeground, updateAgentProgress as updateAsyncAgentProgress, updateAgentSummary as updateAsyncAgentSummary, updateProgressFromMessage } from '../../tasks/LocalAgentTask/LocalAgentTask.js';
 
 import { assembleToolPool } from '../../tools.js';
 import { asAgentId } from '../../types/ids.js';
@@ -21,6 +19,11 @@ import { logForDebugging } from 'src/utils/debug.js';
 import { isEnvTruthy } from '../../utils/envUtils.js';
 import { AbortError, errorMessage, toError } from '../../utils/errors.js';
 import type { CacheSafeParams } from '../../utils/forkedAgent.js';
+// The summary API types cacheSafeParams via PromptSuggestion/runtime, a
+// structurally-divergent duplicate of CacheSafeParams (its SpeculationState has
+// drifted from the canonical tui one). The runtime value is the real, richer
+// app-state object and is valid for the fork; bridge the stale type boundary.
+import type { CacheSafeParams as SummaryCacheSafeParams } from '../../services/PromptSuggestion/runtime.js';
 import { lazySchema } from '../../utils/lazySchema.js';
 import { createUserMessage, extractTextContent, isSyntheticMessage, normalizeMessages } from '../../utils/messages.js';
 import { getAgentModel } from '../../utils/model/agent.js';
@@ -61,13 +64,19 @@ import { renderGroupedAgentToolUse, renderToolResultMessage, renderToolUseErrorM
 // purge. They are stubbed here as no-ops so the surrounding moved-source
 // code paths degrade silently. Real implementations land when AgenC ships
 // the equivalent backend.
-const checkRemoteAgentEligibility = async (..._args: unknown[]): Promise<{ eligible: false }> => ({ eligible: false });
+// Stub signatures match the real internal CCR API shapes the (dead, external-
+// build-eliminated) remote block below consumes, so the block still type-checks.
+const checkRemoteAgentEligibility = async (..._args: unknown[]): Promise<{ eligible: false; errors: readonly string[] }> => ({ eligible: false, errors: [] });
 const formatPreconditionError = (..._args: unknown[]): string => 'Remote agents are not available in this build.';
-const getRemoteTaskSessionUrl = (..._args: unknown[]): null => null;
-const registerRemoteAgentTask = (..._args: unknown[]): { agentTaskId: string; sessionUrl: null } => ({ agentTaskId: '', sessionUrl: null });
-const teleportToRemote = async (..._args: unknown[]): Promise<null> => null;
+const getRemoteTaskSessionUrl = (..._args: unknown[]): string => '';
+const registerRemoteAgentTask = (..._args: unknown[]): { taskId: string; sessionId: string } => ({ taskId: '', sessionId: '' });
+const teleportToRemote = async (..._args: unknown[]): Promise<{ id: string; title: string } | null> => null;
 // ---- end donor-purge stubs ----
-const proactiveModule = null;
+// Stub for the internal-only proactive module (always absent in this build).
+// Typed via an IIFE so the value isn't control-flow-narrowed to the `null`
+// literal, which would make the `?.isProactiveActive()` access below resolve
+// against `never`.
+const proactiveModule = ((): { isProactiveActive(): boolean } | null => null)();
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 // Progress display constants (for showing background hint)
@@ -107,6 +116,7 @@ const fullInputSchema = lazySchema(() => {
     mode: permissionModeSchema().optional().describe('Permission mode for spawned teammate (e.g., "plan" to require plan approval).')
   });
   return baseInputSchema().merge(multiAgentInputSchema).extend({
+    // @ts-expect-error TS2367 — "external" === 'ant' is a constant build guard kept verbatim for esbuild DCE of the internal-only remote isolation.
     isolation: ("external" === 'ant' ? z.enum(['worktree', 'remote']) : z.enum(['worktree'])).optional().describe("external" === 'ant' ? 'Isolation mode. "worktree" creates a temporary git worktree so the agent works on an isolated copy of the repo. "remote" launches the agent in a remote CCR environment (always runs in background).' : 'Isolation mode. "worktree" creates a temporary git worktree so the agent works on an isolated copy of the repo.'),
     cwd: z.string().optional().describe('Absolute path to run the agent in. Overrides the working directory for all filesystem and shell operations within this agent. Mutually exclusive with isolation: "worktree".')
   });
@@ -441,6 +451,7 @@ export const AgentTool = buildTool({
 
     // Remote isolation: delegate to CCR. Gated internal-only — the guard enables
     // dead code elimination of the entire block for external builds.
+    // @ts-expect-error TS2367 — "external" === 'ant' is a constant build guard kept verbatim for esbuild DCE of the internal-only remote block.
     if ("external" === 'ant' && effectiveIsolation === 'remote') {
       const eligibility = await checkRemoteAgentEligibility();
       if (!eligibility.eligible) {
@@ -452,7 +463,7 @@ export const AgentTool = buildTool({
         initialMessage: prompt,
         description,
         signal: toolUseContext.abortController.signal,
-        onBundleFail: msg => {
+        onBundleFail: (msg: string) => {
           bundleFailHint = msg;
         }
       });
@@ -569,7 +580,15 @@ export const AgentTool = buildTool({
       ...appState.toolPermissionContext,
       mode: selectedAgent.permissionMode ?? 'acceptEdits'
     };
-    const workerTools = assembleToolPool(workerPermissionContext, appState.mcp.tools);
+    // appState.toolPermissionContext and assembleToolPool's ToolPermissionContext
+    // are typed from two divergent permission-type modules (PermissionMode /
+    // WorkingDirectorySource duplicated in types/permissions.ts vs
+    // permissions/types.ts). The runtime object is the real permission context,
+    // valid for the pool; bridge the stale type boundary on the call.
+    const workerTools = assembleToolPool(
+      workerPermissionContext as Parameters<typeof assembleToolPool>[0],
+      appState.mcp.tools,
+    );
 
     // Create a stable agent ID early so it can be used for worktree slug
     const earlyAgentId = createAgentId();
@@ -858,9 +877,14 @@ export const AgentTool = buildTool({
             agentId: syncAgentId
           },
           onCacheSafeParams: summaryTaskId && getSdkAgentProgressSummariesEnabled() ? (params: CacheSafeParams) => {
-            const {
-              stop
-            } = startAgentSummarization(summaryTaskId, syncAgentId, params, rootSetAppState);
+            const { stop } = startAgentSummarization({
+              taskId: summaryTaskId,
+              agentId: syncAgentId,
+              cacheSafeParams: params as unknown as SummaryCacheSafeParams,
+              getAgentTranscript: async () => ({ messages: agentMessages }),
+              updateAgentSummary: (id, summary) =>
+                updateAsyncAgentSummary(id, summary, rootSetAppState),
+            });
             stopForegroundSummarization = stop;
           } : undefined
         })[Symbol.asyncIterator]();
@@ -940,9 +964,14 @@ export const AgentTool = buildTool({
                         abortController: task.abortController
                       },
                       onCacheSafeParams: getSdkAgentProgressSummariesEnabled() ? (params: CacheSafeParams) => {
-                        const {
-                          stop
-                        } = startAgentSummarization(backgroundedTaskId, asAgentId(backgroundedTaskId), params, rootSetAppState);
+                        const { stop } = startAgentSummarization({
+                          taskId: backgroundedTaskId,
+                          agentId: asAgentId(backgroundedTaskId),
+                          cacheSafeParams: params as unknown as SummaryCacheSafeParams,
+                          getAgentTranscript: async () => ({ messages: agentMessages }),
+                          updateAgentSummary: (id, summary) =>
+                            updateAsyncAgentSummary(id, summary, rootSetAppState),
+                        });
                         stopBackgroundedSummarization = stop;
                       } : undefined
                     })) {
@@ -1268,6 +1297,7 @@ export const AgentTool = buildTool({
     // Only route through auto mode classifier when in auto mode
     // In all other modes, auto-approve sub-agent generation
     // Note: "external" === 'ant' guard enables dead code elimination for external builds
+    // @ts-expect-error TS2367 — constant build guard kept verbatim for DCE (see note above).
     if ("external" === 'ant' && appState.toolPermissionContext.mode === 'auto') {
       return {
         behavior: 'passthrough',

--- a/runtime/src/tools/AgentTool/agentToolUtils.ts
+++ b/runtime/src/tools/AgentTool/agentToolUtils.ts
@@ -29,6 +29,7 @@ import {
   killAsyncAgent,
   type ProgressTracker,
   updateAgentProgress as updateAsyncAgentProgress,
+  updateAgentSummary as updateAsyncAgentSummary,
   updateProgressFromMessage,
 } from '../../tasks/LocalAgentTask/LocalAgentTask.js'
 import { asAgentId } from '../../types/ids.js'
@@ -37,6 +38,11 @@ import { isAgentSwarmsEnabled } from '../../utils/agentSwarmsEnabled.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { AbortError, errorMessage } from '../../utils/errors.js'
 import type { CacheSafeParams } from '../../utils/forkedAgent.js'
+// The summary API types cacheSafeParams via PromptSuggestion/runtime, which
+// carries its own structurally-divergent duplicates of CacheSafeParams +
+// SpeculationState. The runtime value here is the real (richer) app-state
+// object and is valid for the fork; bridge the stale type boundary on the call.
+import type { CacheSafeParams as SummaryCacheSafeParams } from '../../services/PromptSuggestion/runtime.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import {
   extractTextContent,
@@ -483,21 +489,17 @@ export async function runAsyncAgentLifecycle({
     )
     const onCacheSafeParams = enableSummarization
       ? (params: CacheSafeParams) => {
-          // LATENT BUG: startAgentSummarization was migrated to a single
-          // options-object API (StartAgentSummarizationOptions), but this call
-          // site (and AgentTool.tsx:866/948) still pass the old 4 positional
-          // args. At runtime the string taskId is received as `options`, so
-          // options.cacheSafeParams is undefined and summarization throws when
-          // enableSummarization is true. Left as-is per behavior-preservation:
-          // the correct fix needs getAgentTranscript/updateAgentSummary
-          // callbacks not in scope here and must be done across all 3 sites.
-          const { stop } = startAgentSummarization(
+          // Live transcript is the locally-accumulated agentMessages array
+          // (captured by reference, so the summarizer sees new messages as they
+          // stream); the summary is written back into the task's progress.
+          const { stop } = startAgentSummarization({
             taskId,
-            // @ts-expect-error -- incomplete API migration, see note above
-            asAgentId(taskId),
-            params,
-            rootSetAppState,
-          )
+            agentId: asAgentId(taskId),
+            cacheSafeParams: params as unknown as SummaryCacheSafeParams,
+            getAgentTranscript: async () => ({ messages: agentMessages }),
+            updateAgentSummary: (id, summary) =>
+              updateAsyncAgentSummary(id, summary, rootSetAppState),
+          })
           stopSummarization = stop
         }
       : undefined

--- a/runtime/src/tools/TaskStopTool/TaskStopTool.ts
+++ b/runtime/src/tools/TaskStopTool/TaskStopTool.ts
@@ -1,8 +1,8 @@
-// @ts-nocheck -- moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import { z } from 'zod/v4'
 import type { TaskStateBase } from '../../tasks/Task.js'
+import type { TaskState } from '../../tasks/types.js'
 import { buildTool, type ToolDef } from '../Tool.js'
-import { stopTask } from '../../tasks/stopTask.js'
+import { stopTuiTask } from '../../tui/task-stop-actions.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { jsonStringify } from '../../utils/slowOperations.js'
 import { DESCRIPTION, TASK_STOP_TOOL_NAME } from './prompt.js'
@@ -104,25 +104,39 @@ export const TaskStopTool = buildTool({
   },
   renderToolUseMessage,
   renderToolResultMessage,
-  async call(
-    { task_id, shell_id },
-    { getAppState, setAppState, abortController },
-  ) {
+  async call({ task_id, shell_id }, { getAppState, setAppState }) {
     // Support both task_id and shell_id (deprecated KillShell compat)
     const id = task_id ?? shell_id
     if (!id) {
       throw new Error('Missing required parameter: task_id')
     }
-    const result = await stopTask(id, {
-      getAppState,
-      setAppState,
-    })
+    const task = getAppState().tasks?.[id] as TaskState | undefined
+    if (!task) {
+      throw new Error(`No task found with ID: ${id}`)
+    }
+    // Cancel through the same app-state stop dispatch the TUI uses
+    // (killTask / killAsyncAgent / requestTeammateShutdown by type). This is
+    // the correct path for tool-context tasks; the lifecycle-backed stopTask()
+    // helper is for the daemon coordinator, which owns a BackgroundTaskLifecycle.
+    const action = stopTuiTask(task, setAppState)
+    if (action === null) {
+      throw new Error(`Task ${id} is not running (status: ${task.status})`)
+    }
+    if (action === 'remote-unavailable') {
+      throw new Error(
+        `Task ${id} is a remote agent and cannot be stopped from this session`,
+      )
+    }
+    const command =
+      'command' in task && typeof task.command === 'string'
+        ? task.command
+        : task.description
     return {
       data: {
-        message: `Successfully stopped task: ${result.taskId} (${result.command})`,
-        task_id: result.taskId,
-        task_type: result.taskType,
-        command: result.command,
+        message: `Successfully stopped task: ${id} (${command})`,
+        task_id: id,
+        task_type: task.type,
+        command,
       },
     }
   },

--- a/runtime/src/types/utils.ts
+++ b/runtime/src/types/utils.ts
@@ -4,11 +4,21 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export type DeepImmutable<T> = T extends any[]
-  ? readonly DeepImmutable<T[number]>[]
-  : T extends object
-    ? { readonly [K in keyof T]: DeepImmutable<T[K]> }
-    : T
+// Deep readonly. Functions, Maps and Sets must be special-cased BEFORE the
+// generic object branch: mapping over a function's or a Map's own keys
+// (`{ readonly [K in keyof T]: … }`) collapses callables to a non-callable
+// `{}`, which is what broke `ReadonlyMap.keys()`/`.get()` on app state (#473).
+export type DeepImmutable<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends ReadonlyMap<infer K, infer V>
+    ? ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>>
+    : T extends ReadonlySet<infer U>
+      ? ReadonlySet<DeepImmutable<U>>
+      : T extends readonly (infer E)[]
+        ? readonly DeepImmutable<E>[]
+        : T extends object
+          ? { readonly [K in keyof T]: DeepImmutable<T[K]> }
+          : T
 
 export type Permutations<T extends string, U extends string = T> = T extends T
   ? T | `${T}${Permutations<Exclude<U, T>>}`

--- a/runtime/tests/tools/TaskStopTool/TaskStopTool.test.ts
+++ b/runtime/tests/tools/TaskStopTool/TaskStopTool.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+
+import { TaskStopTool } from '../../../src/tools/TaskStopTool/TaskStopTool.js'
+
+type MutableState = { tasks: Record<string, unknown> }
+
+// Minimal getAppState/setAppState backing store — TaskStopTool.call only reads
+// `.tasks` and applies setAppState updaters, so a partial AppState suffices.
+function makeContext(tasks: Record<string, unknown>) {
+  let state: MutableState = { tasks }
+  return {
+    getAppState: () => state,
+    setAppState: (updater: (prev: MutableState) => MutableState) => {
+      state = updater(state)
+    },
+    current: () => state,
+  }
+}
+
+const NOOP_CAN_USE_TOOL = (async () => undefined) as never
+
+describe('TaskStopTool', () => {
+  test('stops a running local_agent task and cancels its work (regression: the old call passed {getAppState,setAppState} to stopTask and threw "context.getTask is not a function")', async () => {
+    const abort = new AbortController()
+    let aborted = false
+    abort.signal.addEventListener('abort', () => {
+      aborted = true
+    })
+    const ctx = makeContext({
+      'agent-1': {
+        id: 'agent-1',
+        type: 'local_agent',
+        status: 'running',
+        description: 'do the thing',
+        abortController: abort,
+      },
+    })
+
+    const result = await TaskStopTool.call(
+      { task_id: 'agent-1' },
+      ctx as never,
+      NOOP_CAN_USE_TOOL,
+      {} as never,
+    )
+
+    expect(result.data.task_id).toBe('agent-1')
+    expect(result.data.task_type).toBe('local_agent')
+    expect(result.data.command).toBe('do the thing')
+    // The fix actually cancels the work (aborts) and marks the task killed.
+    expect(aborted).toBe(true)
+    expect((ctx.current().tasks['agent-1'] as { status: string }).status).toBe(
+      'killed',
+    )
+  })
+
+  test('throws a clear error when the task does not exist', async () => {
+    const ctx = makeContext({})
+    await expect(
+      TaskStopTool.call(
+        { task_id: 'missing' },
+        ctx as never,
+        NOOP_CAN_USE_TOOL,
+        {} as never,
+      ),
+    ).rejects.toThrow('No task found with ID: missing')
+  })
+})


### PR DESCRIPTION
## Summary
Completes the `@ts-nocheck` reclamation — **the runtime now has ZERO directives** (155 → 0). The 2 files deferred in #954 are reclaimed, and the **latent bug** the re-enabled type-checking surfaced is fixed. All three are *behavioral* fixes, not annotations.

### 🐛 1. Agent-summarization bug (was throwing in production)
`startAgentSummarization` was migrated to an options-object API, but 3 call sites still passed the old 4 positional args → `options.cacheSafeParams` was `undefined` → summarization **threw whenever `enableSummarization` was true**. Migrated `AgentTool.tsx` (×2) + `agentToolUtils.ts` to the options object:
- `getAgentTranscript` returns the live `agentMessages`
- `updateAgentSummary` writes the task summary via a **new `updateAgentSummary()` helper** in `LocalAgentTask.tsx` (counterpart to `updateAgentProgress`, preserving the disjoint-write contract)
- `cacheSafeParams` bridged across the duplicate `forkedAgent`/`PromptSuggestion` `CacheSafeParams` type

### 🐛 2. TaskStopTool crash (a *live shipped* tool)
Its `call` passed `{getAppState, setAppState}` to the lifecycle-oriented `stopTask()`, which calls `context.getTask()` first → **"getTask is not a function" on every invocation**. Rewired to `stopTuiTask()` — the app-state stop dispatch the TUI already uses (`killTask`/`killAsyncAgent`/`requestTeammateShutdown` by type). Added a **revert-sensitive regression test** (confirmed to fail against the old crash).

### 3. AgentTool.tsx reclaimed — root-caused the `DeepImmutable` stub (#473)
The stub recursed into `ReadonlyMap`/function keys, collapsing `.keys()`/`.get()` to a non-callable `{}`. Fixed it in `types/utils.ts` to special-case functions/Map/Set — **clean, zero ripple** across its 9 consumers. Plus: completed the internal-only CCR stub signatures (dead block, DCE'd in external builds), `@ts-expect-error` on the constant `"external"==='ant'` build guards, and a documented cast across the duplicate `PermissionMode`/`WorkingDirectorySource` permission-type modules.

## Verification
- `tsc` **0 errors**; **0 `@ts-nocheck`** in the whole runtime
- Full `vitest` **12,107 passing / 0 failing**; isolated **Bun gate 104/104**; build green
- The new TaskStopTool test fails against the old crash (revert-proven)

## Follow-up tech debt (not bugs)
Duplicate type definitions this exposed: `CacheSafeParams`+`SpeculationState` and `PermissionMode`+`WorkingDirectorySource` each defined in two modules — unifying them would remove the 3 `as unknown as` casts. Tracked in memory.