### PR TITLE
refactor(runtime): unify duplicate permission types + consolidate the CacheSafeParams cast

### DIFF
--- a/runtime/src/permissions/types.ts
+++ b/runtime/src/permissions/types.ts
@@ -19,33 +19,26 @@
 // Modes
 // ─────────────────────────────────────────────────────────────────────
 
+// Single source of truth: the mode + rule-source unions live in the cycle-free
+// foundation module (types/permissions.ts) and are re-exported here so the two
+// copies can't drift again. The runtime constants below stay local.
+import type {
+  InternalPermissionMode,
+  PermissionRuleSource as PermissionRuleSourceType,
+} from "../types/permissions.js";
+
 /**
  * All permission mode variants supported by the runtime.
  *
  * User-addressable modes (settings `defaultMode`, `--permission-mode`):
- *   - "default"
- *   - "acceptEdits"
- *   - "plan"
- *   - "bypassPermissions"
- *   - "dontAsk"
- *   - "auto"
- *
+ *   "default" | "acceptEdits" | "plan" | "bypassPermissions" | "dontAsk" | "auto".
  * Internal-only:
  *   - "unattended" — background-agent mode; unattended policy decides
  *     allow/deny/pause while no client is attached.
- *   - "bubble" — reserved for nested/child permission contexts that
- *     "bubble up" denials to the parent session. Kept here for
- *     completeness; not exposed by CLI or settings today.
+ *   - "bubble" — reserved for nested/child permission contexts that "bubble up"
+ *     denials to the parent session. Kept for completeness; not exposed today.
  */
-export type PermissionMode =
-  | "default"
-  | "acceptEdits"
-  | "plan"
-  | "bypassPermissions"
-  | "dontAsk"
-  | "auto"
-  | "unattended"
-  | "bubble";
+export type PermissionMode = InternalPermissionMode;
 
 /**
  * Modes that can be referenced by CLI flags / settings JSON. Excludes
@@ -112,15 +105,7 @@ export const PERMISSION_BEHAVIORS: readonly PermissionBehavior[] =
  * Ported exactly from AgenC's
  * `src/utils/permissions/permissions.ts :: PERMISSION_RULE_SOURCES`.
  */
-export type PermissionRuleSource =
-  | "userSettings"
-  | "projectSettings"
-  | "localSettings"
-  | "flagSettings"
-  | "policySettings"
-  | "cliArg"
-  | "command"
-  | "session";
+export type PermissionRuleSource = PermissionRuleSourceType;
 
 export const PERMISSION_RULE_SOURCES: readonly PermissionRuleSource[] =
   Object.freeze([

--- a/runtime/src/services/AgentSummary/agentSummary.ts
+++ b/runtime/src/services/AgentSummary/agentSummary.ts
@@ -22,6 +22,7 @@ import type {
   CacheSafeParams,
   ForkedAgentResult,
 } from "../PromptSuggestion/runtime.js";
+import type { CacheSafeParams as ForkedAgentCacheSafeParams } from "../../utils/forkedAgent.js";
 import type { Message } from "../../types/message.js";
 import {
   createUserMessage as defaultCreateUserMessage,
@@ -29,6 +30,24 @@ import {
 } from "../PromptSuggestion/runtime.js";
 
 export const SUMMARY_INTERVAL_MS = 30_000;
+
+/**
+ * Adapter across the deliberate PromptSuggestion decoupling boundary. The fork
+ * machinery hands callers a concrete `CacheSafeParams` (full `ToolUseContext` +
+ * the canonical `SpeculationState`); this service intentionally types its
+ * `cacheSafeParams` against `PromptSuggestion/runtime`, which defines its own
+ * looser `ToolUseContext`/`SpeculationState` so the service never imports
+ * tui/app-state types. The runtime object is the real, richer one and is valid
+ * for the fork — the structural-subset relation just isn't statically provable
+ * (a circular SpeculationState → REPLHookContext → ToolUseContext → AppState
+ * chain). This is the single, documented boundary cast; call sites must not
+ * re-cast inline.
+ */
+export function toSummaryCacheSafeParams(
+  params: ForkedAgentCacheSafeParams,
+): CacheSafeParams {
+  return params as unknown as CacheSafeParams;
+}
 
 export interface AgentTranscript {
   readonly messages: readonly Message[];

--- a/runtime/src/tools/AgentTool/AgentTool.tsx
+++ b/runtime/src/tools/AgentTool/AgentTool.tsx
@@ -6,7 +6,7 @@ import { z } from 'zod/v4';
 import { clearInvokedSkillsForAgent, getSdkAgentProgressSummariesEnabled } from '../../bootstrap/state.js';
 import { enhanceSystemPromptWithEnvDetails, getSystemPrompt } from '../../constants/prompts.js';
 import { isCoordinatorMode } from '../../coordinator/coordinatorMode.js';
-import { startAgentSummarization } from '../../services/AgentSummary/agentSummary.js';
+import { startAgentSummarization, toSummaryCacheSafeParams } from '../../services/AgentSummary/agentSummary.js';
 import { clearDumpState } from '../../services/api/dumpPrompts.js';
 import { completeAgentTask as completeAsyncAgent, createActivityDescriptionResolver, createProgressTracker, enqueueAgentNotification, failAgentTask as failAsyncAgent, getProgressUpdate, getTokenCountFromTracker, isLocalAgentTask, killAsyncAgent, registerAgentForeground, registerAsyncAgent, unregisterAgentForeground, updateAgentProgress as updateAsyncAgentProgress, updateAgentSummary as updateAsyncAgentSummary, updateProgressFromMessage } from '../../tasks/LocalAgentTask/LocalAgentTask.js';
 
@@ -19,11 +19,6 @@ import { logForDebugging } from 'src/utils/debug.js';
 import { isEnvTruthy } from '../../utils/envUtils.js';
 import { AbortError, errorMessage, toError } from '../../utils/errors.js';
 import type { CacheSafeParams } from '../../utils/forkedAgent.js';
-// The summary API types cacheSafeParams via PromptSuggestion/runtime, a
-// structurally-divergent duplicate of CacheSafeParams (its SpeculationState has
-// drifted from the canonical tui one). The runtime value is the real, richer
-// app-state object and is valid for the fork; bridge the stale type boundary.
-import type { CacheSafeParams as SummaryCacheSafeParams } from '../../services/PromptSuggestion/runtime.js';
 import { lazySchema } from '../../utils/lazySchema.js';
 import { createUserMessage, extractTextContent, isSyntheticMessage, normalizeMessages } from '../../utils/messages.js';
 import { getAgentModel } from '../../utils/model/agent.js';
@@ -580,15 +575,7 @@ export const AgentTool = buildTool({
       ...appState.toolPermissionContext,
       mode: selectedAgent.permissionMode ?? 'acceptEdits'
     };
-    // appState.toolPermissionContext and assembleToolPool's ToolPermissionContext
-    // are typed from two divergent permission-type modules (PermissionMode /
-    // WorkingDirectorySource duplicated in types/permissions.ts vs
-    // permissions/types.ts). The runtime object is the real permission context,
-    // valid for the pool; bridge the stale type boundary on the call.
-    const workerTools = assembleToolPool(
-      workerPermissionContext as Parameters<typeof assembleToolPool>[0],
-      appState.mcp.tools,
-    );
+    const workerTools = assembleToolPool(workerPermissionContext, appState.mcp.tools);
 
     // Create a stable agent ID early so it can be used for worktree slug
     const earlyAgentId = createAgentId();
@@ -880,7 +867,7 @@ export const AgentTool = buildTool({
             const { stop } = startAgentSummarization({
               taskId: summaryTaskId,
               agentId: syncAgentId,
-              cacheSafeParams: params as unknown as SummaryCacheSafeParams,
+              cacheSafeParams: toSummaryCacheSafeParams(params),
               getAgentTranscript: async () => ({ messages: agentMessages }),
               updateAgentSummary: (id, summary) =>
                 updateAsyncAgentSummary(id, summary, rootSetAppState),
@@ -967,7 +954,7 @@ export const AgentTool = buildTool({
                         const { stop } = startAgentSummarization({
                           taskId: backgroundedTaskId,
                           agentId: asAgentId(backgroundedTaskId),
-                          cacheSafeParams: params as unknown as SummaryCacheSafeParams,
+                          cacheSafeParams: toSummaryCacheSafeParams(params),
                           getAgentTranscript: async () => ({ messages: agentMessages }),
                           updateAgentSummary: (id, summary) =>
                             updateAsyncAgentSummary(id, summary, rootSetAppState),

--- a/runtime/src/tools/AgentTool/agentToolUtils.ts
+++ b/runtime/src/tools/AgentTool/agentToolUtils.ts
@@ -7,7 +7,7 @@ import {
   CUSTOM_AGENT_DISALLOWED_TOOLS,
   IN_PROCESS_TEAMMATE_ALLOWED_TOOLS,
 } from '../../constants/tools.js'
-import { startAgentSummarization } from '../../services/AgentSummary/agentSummary.js'
+import { startAgentSummarization, toSummaryCacheSafeParams } from '../../services/AgentSummary/agentSummary.js'
 import { clearDumpState } from '../../services/api/dumpPrompts.js'
 import type { AppState } from '../../tui/state/AppState.js'
 import type {
@@ -38,11 +38,6 @@ import { isAgentSwarmsEnabled } from '../../utils/agentSwarmsEnabled.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { AbortError, errorMessage } from '../../utils/errors.js'
 import type { CacheSafeParams } from '../../utils/forkedAgent.js'
-// The summary API types cacheSafeParams via PromptSuggestion/runtime, which
-// carries its own structurally-divergent duplicates of CacheSafeParams +
-// SpeculationState. The runtime value here is the real (richer) app-state
-// object and is valid for the fork; bridge the stale type boundary on the call.
-import type { CacheSafeParams as SummaryCacheSafeParams } from '../../services/PromptSuggestion/runtime.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import {
   extractTextContent,
@@ -495,7 +490,7 @@ export async function runAsyncAgentLifecycle({
           const { stop } = startAgentSummarization({
             taskId,
             agentId: asAgentId(taskId),
-            cacheSafeParams: params as unknown as SummaryCacheSafeParams,
+            cacheSafeParams: toSummaryCacheSafeParams(params),
             getAgentTranscript: async () => ({ messages: agentMessages }),
             updateAgentSummary: (id, summary) =>
               updateAsyncAgentSummary(id, summary, rootSetAppState),

--- a/runtime/src/types/permissions.ts
+++ b/runtime/src/types/permissions.ts
@@ -24,8 +24,16 @@ export const EXTERNAL_PERMISSION_MODES = [
 export type ExternalPermissionMode = (typeof EXTERNAL_PERMISSION_MODES)[number]
 
 // Exhaustive mode union for typechecking. The user-addressable runtime set
-// is INTERNAL_PERMISSION_MODES below.
-export type InternalPermissionMode = ExternalPermissionMode | 'auto' | 'bubble'
+// is INTERNAL_PERMISSION_MODES below. Includes the background-agent-only
+// 'unattended' mode (documented in permissions/types.ts) so this stays the
+// single authoritative mode union — its omission previously forced a cast
+// wherever an agent's 'unattended' permissionMode met a context typed as
+// InternalPermissionMode (e.g. AgentTool → assembleToolPool).
+export type InternalPermissionMode =
+  | ExternalPermissionMode
+  | 'auto'
+  | 'bubble'
+  | 'unattended'
 export type PermissionMode = InternalPermissionMode
 
 // Runtime validation set: modes that are user-addressable (settings.json
@@ -48,8 +56,10 @@ export type PermissionBehavior = 'allow' | 'deny' | 'ask'
 // ============================================================================
 
 /**
- * Where a permission rule originated from.
- * Includes all SettingSource values plus additional rule-specific sources.
+ * Where a permission rule originated from. Includes all SettingSource values
+ * plus rule-specific sources. The single authoritative source union —
+ * permissions/types.ts re-exports it; 'command'/'session' (rule-level and
+ * session-level rules) were previously only in that copy.
  */
 export type PermissionRuleSource =
   | 'userSettings'


### PR DESCRIPTION
## Summary
Resolves the duplicate-type debt that forced the 4 documented `as unknown as` casts left by the `@ts-nocheck` reclamation. The two duplications turned out to need **opposite** treatments.

### Permission types → genuine single source (and a real type fix)
The divergence wasn't cosmetic: `types/permissions.ts`'s `InternalPermissionMode` was **missing the real `'unattended'` mode** (a documented background-agent mode handled throughout `permissions/`), and its `PermissionRuleSource` was missing `'command'`/`'session'`.

- Completed `types/permissions.ts` (the cycle-free foundation) as the authoritative superset — **verified 0 ripple** across its 20 importers.
- `permissions/types.ts` now **re-exports** `PermissionMode`/`PermissionRuleSource` (and `WorkingDirectorySource` via it) instead of keeping divergent local copies — so they can't drift again.
- This **removed the `AgentTool → assembleToolPool` cast outright**: it was a genuine incompleteness (an agent's `'unattended'` permissionMode couldn't satisfy the incomplete `InternalPermissionMode` context), not just a cast to paper over.

### CacheSafeParams → consolidated, *not* merged (by design)
`PromptSuggestion/runtime` **deliberately** defines its own looser `ToolUseContext`/`SpeculationState` subset so the service stays decoupled from `tui`/app-state (they bottom out in a circular `SpeculationState → REPLHookContext → ToolUseContext → AppState` chain). Merging would couple a service to `tui` — architecturally backwards. Instead, the **3 scattered `as unknown as` casts are consolidated into one documented boundary adapter**, `toSummaryCacheSafeParams()`, in `services/AgentSummary/agentSummary.ts`.

## Result
**4 inline casts → 1 documented adapter**, and the permission unions are now single-source. Type-only change (permission constant arrays unchanged, so no runtime behavior change).

## Verification
- `tsc` **0 errors**; **0 `@ts-nocheck`**
- Full `vitest` **12,109 passing / 0 failing**; isolated **Bun gate 104/104**; build green