### PR TITLE
feat: conservative opt-in rollout/session retention sweep (with safety reworks)

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -102,6 +102,7 @@ import {
 import {
   pruneSessionStateSnapshots,
   pruneTerminalAgentRuns,
+  type RolloutRetentionPolicy,
 } from "../state/pruning.js";
 import { StateSqliteHealthStatsReader } from "../state/health-stats.js";
 import { upsertAgentRun } from "../state/agent-runs.js";
@@ -1653,6 +1654,19 @@ function uniqueStateDatabasePaths(
   );
 }
 
+/**
+ * Project the rollout/session disk-retention window out of the agent retention
+ * config. Returns undefined (sweep stays DISABLED) unless `rollout_days` is set
+ * — the conservative default, since the sweep deletes user data.
+ */
+function rolloutRetentionPolicy(
+  retention: AgentRunRetentionConfig | undefined,
+): RolloutRetentionPolicy | undefined {
+  const days = retention?.rollout_days;
+  if (days === undefined) return undefined;
+  return { retention_days: days };
+}
+
 interface AgenCDaemonSnapshotPolicyRegistryOptions {
   readonly agencHome: string;
   readonly defaultCwd: string;
@@ -1726,8 +1740,10 @@ class AgenCDaemonSnapshotPolicyRegistry {
     snapshotRetention: AgentRunRetentionConfig | undefined,
   ): void {
     this.#snapshotRetention = snapshotRetention;
+    const rolloutRetention = rolloutRetentionPolicy(snapshotRetention);
     for (const entry of this.#policies.values()) {
       entry.policy.updateSnapshotRetention(snapshotRetention);
+      entry.policy.updateRolloutRetention(rolloutRetention);
     }
   }
 
@@ -1912,6 +1928,14 @@ class AgenCDaemonSnapshotPolicyRegistry {
     const policy = new AgenCSessionSnapshotPolicy(driver, {
       agencHome: this.#agencHome,
       snapshotRetention: this.#snapshotRetention,
+      // Rollout/session disk-retention sweep: opt-in via `agent.retention
+      // .rollout_days`. The sessions dir for this project sits next to its
+      // state DB (`<projectDir>/sessions`). No active-session id is threaded
+      // here — the daemon does not own a live foreground session — so the
+      // sweep relies purely on the mtime cutoff (which spares any session
+      // touched within the window, i.e. anything still in use).
+      rolloutRetention: rolloutRetentionPolicy(this.#snapshotRetention),
+      rolloutSessionsDir: join(paths.projectDir, "sessions"),
       onError: this.#onError,
     });
     const entry = { driver, policy };

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -157,6 +157,13 @@ export interface AgentRunRetentionConfig {
   readonly snapshot_days?: number;
   readonly snapshot_max_count?: number;
   readonly snapshot_max_bytes?: number;
+  // Rollout/session disk retention window (days). Lights up the reserved
+  // `cleanupPeriodDays`/`history` retention intent: when set, the daemon's
+  // throttled sweep deletes session dirs + their rollout JSONL + the
+  // thread_rollout_items mirror rows once their newest rollout is older than
+  // this many days. Unset → DISABLED (no pruning; the conservative default,
+  // since this deletes user data).
+  readonly rollout_days?: number;
 }
 
 export interface AgentConfig {
@@ -1372,6 +1379,7 @@ const AGENT_RETENTION_KEYS: ReadonlySet<string> = new Set([
   "snapshot_days",
   "snapshot_max_count",
   "snapshot_max_bytes",
+  "rollout_days",
 ]);
 
 function validateAgentBudget(raw: unknown): AgentBudgetConfig | undefined {
@@ -1429,6 +1437,7 @@ function validateAgentRetention(raw: unknown): AgentRunRetentionConfig | undefin
     "completed_days",
     "failed_days",
     "snapshot_days",
+    "rollout_days",
   ] as const) {
     const value = optionalNonNegativeNumber(
       record[key],

--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -1,11 +1,13 @@
 import {
   existsSync,
+  readFileSync,
   readdirSync,
   renameSync,
   rmSync,
   statSync,
 } from "node:fs";
 import { join } from "node:path";
+import { isProcessRunning } from "../utils/genericProcessUtils.js";
 import { StateThreadRepository } from "./threads.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 
@@ -290,6 +292,13 @@ export function pruneRolloutSessions(
     if (rollout === undefined) continue;
     // Keep anything touched at/after the cutoff.
     if (rollout.newestMtimeMs >= cutoffMs) continue;
+    // Live-writer guard: never prune a session whose rollout lock is held by a
+    // live process. The daemon shares this sessions dir with separate foreground
+    // processes; the mtime cutoff already spares actively-written sessions, and
+    // this additionally protects an idle-but-open session from being removed out
+    // from under a live file descriptor. A stale lock (dead holder) does not
+    // block pruning, so a crashed session is still reclaimable.
+    if (sessionHasLiveRolloutLock(sessionDir)) continue;
 
     // Drop the SQLite mirror rows first: if the FS removal later fails the
     // mirror is already gone (it can't outlive its source), and a re-index
@@ -363,6 +372,55 @@ function describeSessionRollouts(
   return { rolloutPaths, newestMtimeMs };
 }
 
+/**
+ * True when the session directory holds a rollout lock (`rollout-*.jsonl.lock`)
+ * owned by a process that is still alive. The lock file is JSON `{ pid, ... }`
+ * (with a legacy bare-PID fallback) written by SessionLock in session-store.ts.
+ * Mirrors that reader's liveness check: a stale lock (dead holder) is ignored so
+ * a crashed session stays reclaimable; only a live holder spares the session.
+ */
+function sessionHasLiveRolloutLock(sessionDir: string): boolean {
+  let lockFiles: string[];
+  try {
+    lockFiles = readdirSync(sessionDir).filter((f) =>
+      f.endsWith(".jsonl.lock"),
+    );
+  } catch {
+    return false;
+  }
+  for (const lockFile of lockFiles) {
+    let raw: string;
+    try {
+      raw = readFileSync(join(sessionDir, lockFile), "utf8").trim();
+    } catch {
+      continue;
+    }
+    if (raw.length === 0) continue;
+    const pid = parseLockHolderPid(raw);
+    if (pid !== undefined && isProcessRunning(pid)) return true;
+  }
+  return false;
+}
+
+function parseLockHolderPid(raw: string): number | undefined {
+  try {
+    const parsed = JSON.parse(raw) as { pid?: unknown };
+    if (
+      typeof parsed.pid === "number" &&
+      Number.isFinite(parsed.pid) &&
+      parsed.pid > 0
+    ) {
+      return parsed.pid;
+    }
+    return undefined;
+  } catch {
+    // Legacy lockfile format: a bare PID on a single line.
+    const pid = Number.parseInt(raw, 10);
+    if (Number.isFinite(pid) && pid > 0) return pid;
+    return undefined;
+  }
+}
+
 function removeSessionDirAtomically(
   sessionDir: string,
   onError: (error: unknown) => void,
@@ -390,7 +448,13 @@ function rolloutCutoffMs(
   days: number | undefined,
 ): number | undefined {
   if (days === undefined) return undefined;
-  if (!Number.isFinite(days) || days < 0) return undefined;
+  // `days <= 0` means DISABLED, not "delete everything older than now". The
+  // config validator accepts 0 (it shares the non-negative-days rule), and a
+  // user setting 0 means "off", so a zero/negative/non-finite window must never
+  // resolve to cutoff=now (which would make every non-active session eligible
+  // for deletion). This intentionally differs from the sibling cutoffIso(),
+  // whose days===0 semantics are load-bearing for the other pruning paths.
+  if (!Number.isFinite(days) || days <= 0) return undefined;
   const nowMs = Date.parse(now);
   if (!Number.isFinite(nowMs)) return undefined;
   return nowMs - days * MS_PER_DAY;

--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -1,3 +1,12 @@
+import {
+  existsSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { StateThreadRepository } from "./threads.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 
 const COMPLETED_AGENT_RUN_STATUSES = ["completed", "stopped"] as const;
@@ -188,6 +197,223 @@ export function pruneSessionStateSnapshots(
       prunedSessionIds: [...prunedSessionIds].sort(),
     };
   });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Rollout/session retention sweep
+//
+// Rollout JSONL files and their session directories are never rotated, so
+// disk grows unbounded. This sweep deletes whole session directories whose
+// newest rollout file is older than the configured retention window, and
+// (in the same pass) drops the `thread_rollout_items` SQLite mirror rows that
+// point at the removed rollout files so the index can't outlive its source.
+//
+// CONSERVATISM (this deletes user data):
+//   - Disabled by default — `retention_days === undefined` is a no-op.
+//   - Only sessions whose newest rollout mtime is strictly older than the
+//     cutoff are eligible.
+//   - The active session is never pruned.
+//   - Each session dir is removed atomically (rename-aside, then recursive
+//     rm) so a half-deleted directory is never observable.
+//   - Bounded per sweep (`maxDeletions`) so a backlog drains gradually on a
+//     throttled timer rather than stalling the daemon.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Default ceiling on session dirs removed per sweep — drains a backlog over
+ *  successive throttled timer ticks instead of in one blocking pass. */
+export const DEFAULT_ROLLOUT_PRUNE_MAX_DELETIONS = 50;
+
+export interface RolloutRetentionPolicy {
+  /** Retention window in days. Undefined → sweep disabled (default). */
+  readonly retention_days?: number;
+}
+
+export interface RolloutPruningOptions extends RolloutRetentionPolicy {
+  /** Absolute path to `<projectDir>/sessions`. */
+  readonly sessionsDir: string;
+  /** Session id of the live session — never pruned even if past the cutoff. */
+  readonly activeSessionId?: string;
+  /** Upper bound on session dirs deleted in a single sweep. */
+  readonly maxDeletions?: number;
+  readonly now?: () => string;
+  readonly onError?: (error: unknown) => void;
+}
+
+export interface RolloutPruningReport {
+  readonly prunedSessions: number;
+  readonly prunedRolloutFiles: number;
+  readonly prunedMirrorRows: number;
+  readonly prunedSessionIds: readonly string[];
+}
+
+/**
+ * Delete session directories (rollout JSONL + index + sidecars) older than the
+ * retention window, and the `thread_rollout_items` mirror rows that mirror the
+ * removed rollout files. See the section header for the conservatism contract.
+ */
+export function pruneRolloutSessions(
+  driver: StateSqliteDriver,
+  options: RolloutPruningOptions,
+): RolloutPruningReport {
+  const cutoffMs = rolloutCutoffMs(
+    options.now?.() ?? new Date().toISOString(),
+    options.retention_days,
+  );
+  // Disabled by default: no retention window → never delete anything.
+  if (cutoffMs === undefined) return emptyRolloutReport();
+  if (!existsSync(options.sessionsDir)) return emptyRolloutReport();
+
+  const onError = options.onError ?? (() => {});
+  const maxDeletions = boundedDeletions(options.maxDeletions);
+
+  let entries: string[];
+  try {
+    entries = readdirSync(options.sessionsDir);
+  } catch (error) {
+    onError(error);
+    return emptyRolloutReport();
+  }
+
+  const threads = new StateThreadRepository(driver);
+  const prunedSessionIds: string[] = [];
+  let prunedRolloutFiles = 0;
+  let prunedMirrorRows = 0;
+
+  for (const sessionId of entries) {
+    if (prunedSessionIds.length >= maxDeletions) break;
+    // Never prune the live session, regardless of mtime.
+    if (sessionId === options.activeSessionId) continue;
+
+    const sessionDir = join(options.sessionsDir, sessionId);
+    const rollout = describeSessionRollouts(sessionDir);
+    // No rollout files → not a session dir we own; leave it untouched.
+    if (rollout === undefined) continue;
+    // Keep anything touched at/after the cutoff.
+    if (rollout.newestMtimeMs >= cutoffMs) continue;
+
+    // Drop the SQLite mirror rows first: if the FS removal later fails the
+    // mirror is already gone (it can't outlive its source), and a re-index
+    // would only re-add rows for files that still exist.
+    let removedRows = 0;
+    try {
+      for (const sourcePath of rollout.rolloutPaths) {
+        removedRows += threads.deleteRolloutItemsForSource(sourcePath);
+      }
+    } catch (error) {
+      onError(error);
+      continue;
+    }
+
+    // Atomic directory removal: rename aside so a crash mid-rm never leaves a
+    // partially-deleted session dir under its real name, then recursive rm.
+    if (!removeSessionDirAtomically(sessionDir, onError)) continue;
+
+    prunedSessionIds.push(sessionId);
+    prunedRolloutFiles += rollout.rolloutPaths.length;
+    prunedMirrorRows += removedRows;
+  }
+
+  return {
+    prunedSessions: prunedSessionIds.length,
+    prunedRolloutFiles,
+    prunedMirrorRows,
+    prunedSessionIds,
+  };
+}
+
+interface SessionRolloutSummary {
+  readonly rolloutPaths: readonly string[];
+  readonly newestMtimeMs: number;
+}
+
+function describeSessionRollouts(
+  sessionDir: string,
+): SessionRolloutSummary | undefined {
+  let stat;
+  try {
+    stat = statSync(sessionDir);
+  } catch {
+    return undefined;
+  }
+  if (!stat.isDirectory()) return undefined;
+
+  let files: string[];
+  try {
+    files = readdirSync(sessionDir).filter(
+      (f) => f.startsWith("rollout-") && f.endsWith(".jsonl"),
+    );
+  } catch {
+    return undefined;
+  }
+  if (files.length === 0) return undefined;
+
+  const rolloutPaths: string[] = [];
+  let newestMtimeMs = 0;
+  for (const file of files) {
+    const filePath = join(sessionDir, file);
+    try {
+      const fileStat = statSync(filePath);
+      rolloutPaths.push(filePath);
+      if (fileStat.mtimeMs > newestMtimeMs) newestMtimeMs = fileStat.mtimeMs;
+    } catch {
+      // Unreadable rollout — skip it; siblings still gate the decision.
+    }
+  }
+  if (rolloutPaths.length === 0) return undefined;
+  return { rolloutPaths, newestMtimeMs };
+}
+
+function removeSessionDirAtomically(
+  sessionDir: string,
+  onError: (error: unknown) => void,
+): boolean {
+  const aside = `${sessionDir}.pruning-${process.pid}-${Date.now().toString(36)}`;
+  try {
+    renameSync(sessionDir, aside);
+  } catch (error) {
+    // EEXIST/ENOENT/EACCES — leave the dir in place; the next sweep retries.
+    onError(error);
+    return false;
+  }
+  try {
+    rmSync(aside, { recursive: true, force: true });
+  } catch (error) {
+    // The live name is already gone (rename succeeded), so retention held;
+    // only the renamed husk lingers. Report and move on.
+    onError(error);
+  }
+  return true;
+}
+
+function rolloutCutoffMs(
+  now: string,
+  days: number | undefined,
+): number | undefined {
+  if (days === undefined) return undefined;
+  if (!Number.isFinite(days) || days < 0) return undefined;
+  const nowMs = Date.parse(now);
+  if (!Number.isFinite(nowMs)) return undefined;
+  return nowMs - days * MS_PER_DAY;
+}
+
+function boundedDeletions(maxDeletions: number | undefined): number {
+  if (
+    maxDeletions === undefined ||
+    !Number.isFinite(maxDeletions) ||
+    maxDeletions < 1
+  ) {
+    return DEFAULT_ROLLOUT_PRUNE_MAX_DELETIONS;
+  }
+  return Math.floor(maxDeletions);
+}
+
+function emptyRolloutReport(): RolloutPruningReport {
+  return {
+    prunedSessions: 0,
+    prunedRolloutFiles: 0,
+    prunedMirrorRows: 0,
+    prunedSessionIds: [],
+  };
 }
 
 function loadCandidates(

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -3,8 +3,10 @@ import type { ToolRecoveryCategory } from "../tools/types.js";
 import { updateAgentRunStatus } from "./agent-runs.js";
 import { writeSessionSnapshotAtomically } from "./atomic-snapshot-writes.js";
 import {
+  pruneRolloutSessions,
   pruneSessionStateSnapshots,
   type AgentRunRetentionPolicy,
+  type RolloutRetentionPolicy,
 } from "./pruning.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 import {
@@ -47,6 +49,15 @@ export interface SnapshotPolicyOptions {
   readonly clearInterval?: (timer: SnapshotPolicyTimer) => void;
   readonly onError?: (error: unknown) => void;
   readonly snapshotRetention?: AgentRunRetentionPolicy;
+  // Rollout/session disk-retention sweep config. Disabled unless
+  // `rolloutRetention.retention_days` is set AND `rolloutSessionsDir` resolves;
+  // runs on the throttled periodic timer (not a tight loop), bounded per pass.
+  readonly rolloutRetention?: RolloutRetentionPolicy;
+  // Absolute `<projectDir>/sessions` dir the sweep walks. Required for the
+  // sweep to do anything; otherwise it is a no-op (conservative default).
+  readonly rolloutSessionsDir?: string;
+  // Live session id that must never be pruned by the sweep.
+  readonly activeSessionId?: string;
   readonly agencHome?: string;
   readonly outputRotation?: ToolOutputRotationPolicy;
 }
@@ -142,6 +153,9 @@ export class AgenCSessionSnapshotPolicy {
   readonly #clearInterval: (timer: SnapshotPolicyTimer) => void;
   readonly #onError: (error: unknown) => void;
   #snapshotRetention: AgentRunRetentionPolicy | undefined;
+  #rolloutRetention: RolloutRetentionPolicy | undefined;
+  readonly #rolloutSessionsDir: string | undefined;
+  readonly #activeSessionId: string | undefined;
   readonly #agencHome: string | undefined;
   readonly #outputRotation: ToolOutputRotationPolicy | undefined;
   readonly #sessions = new Map<string, SessionSnapshotState>();
@@ -188,6 +202,9 @@ export class AgenCSessionSnapshotPolicy {
       ((timer) => clearInterval(timer as ReturnType<typeof setInterval>));
     this.#onError = options.onError ?? (() => {});
     this.#snapshotRetention = options.snapshotRetention;
+    this.#rolloutRetention = options.rolloutRetention;
+    this.#rolloutSessionsDir = options.rolloutSessionsDir;
+    this.#activeSessionId = options.activeSessionId;
     this.#agencHome = options.agencHome;
     this.#outputRotation = options.outputRotation;
   }
@@ -261,6 +278,38 @@ export class AgenCSessionSnapshotPolicy {
     snapshotRetention: AgentRunRetentionPolicy | undefined,
   ): void {
     this.#snapshotRetention = snapshotRetention;
+  }
+
+  updateRolloutRetention(
+    rolloutRetention: RolloutRetentionPolicy | undefined,
+  ): void {
+    this.#rolloutRetention = rolloutRetention;
+  }
+
+  /**
+   * Run the rollout/session retention sweep once. Driven by the throttled
+   * periodic timer (see {@link flushPeriodic}) so it never spins in a tight
+   * loop. No-op unless a retention window AND a sessions dir are configured —
+   * the conservative default is to delete nothing.
+   */
+  sweepRolloutRetention(): void {
+    const retentionDays = this.#rolloutRetention?.retention_days;
+    if (retentionDays === undefined || this.#rolloutSessionsDir === undefined) {
+      return;
+    }
+    try {
+      pruneRolloutSessions(this.#driver, {
+        sessionsDir: this.#rolloutSessionsDir,
+        retention_days: retentionDays,
+        ...(this.#activeSessionId !== undefined
+          ? { activeSessionId: this.#activeSessionId }
+          : {}),
+        now: this.#now,
+        onError: this.#onError,
+      });
+    } catch (error) {
+      this.#onError(error);
+    }
   }
 
   trackSession(sessionId: string, agentId?: string): void {
@@ -434,9 +483,13 @@ export class AgenCSessionSnapshotPolicy {
   }
 
   flushPeriodic(): readonly SnapshotPolicySnapshotRecord[] {
-    return [...this.#sessions.values()].map((state) =>
+    const records = [...this.#sessions.values()].map((state) =>
       this.#writeSnapshot(state, "periodic"),
     );
+    // Piggy-back the disk-retention sweep on the same throttled tick so
+    // rollout/session pruning runs on a bounded timer, not a tight loop.
+    this.sweepRolloutRetention();
+    return records;
   }
 
   loadLatest(sessionId: string): SnapshotPolicySnapshotRecord | undefined {

--- a/runtime/src/state/threads.ts
+++ b/runtime/src/state/threads.ts
@@ -289,6 +289,34 @@ export class StateThreadRepository {
     });
   }
 
+  /**
+   * Drop every SQLite mirror row that points at `sourcePath` — the indexed
+   * rollout lines plus the backfill/receipt bookkeeping that tracks the file.
+   * Used by the retention sweep so the `thread_rollout_items` mirror cannot
+   * outlive the rollout JSONL it mirrors. Returns the count of indexed lines
+   * removed. Idempotent: deleting an already-gone source is a no-op.
+   */
+  deleteRolloutItemsForSource(sourcePath: string): number {
+    return this.driver.transaction(() => {
+      const removedItems = this.driver
+        .prepareState<[string]>(
+          "DELETE FROM thread_rollout_items WHERE source_path = ?",
+        )
+        .run(sourcePath).changes;
+      this.driver
+        .prepareState<[string]>(
+          "DELETE FROM backfill_files WHERE source_path = ?",
+        )
+        .run(sourcePath);
+      this.driver
+        .prepareState<[string]>(
+          "DELETE FROM rollout_receipts WHERE source_path = ?",
+        )
+        .run(sourcePath);
+      return removedItems;
+    });
+  }
+
   private writeBackfillReceipts(params: {
     readonly threadId: ThreadId;
     readonly sourcePath: string;

--- a/runtime/tests/config/config.test.ts
+++ b/runtime/tests/config/config.test.ts
@@ -992,10 +992,13 @@ describe("schema: closed config block validators (CF-13)", () => {
         snapshot_days: 3,
         snapshot_max_count: 1,
         snapshot_max_bytes: 1_024,
+        rollout_days: 30,
       },
     });
     expect(out?.budget?.dollar_cap).toBe(5.5);
     expect(out?.retention?.completed_days).toBe(0);
+    // rollout_days lights up the reserved rollout/session retention sweep.
+    expect(out?.retention?.rollout_days).toBe(30);
     expect(Object.isFrozen(out?.retention)).toBe(true);
   });
 

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -154,6 +154,55 @@ describe("pruneRolloutSessions", () => {
     expect(existsSync(oldPath)).toBe(true);
     expect(mirrorRowCount()).toBe(2);
   });
+
+  it("treats retention_days: 0 as disabled, not 'delete everything'", () => {
+    // The config validator accepts 0 (shared non-negative-days rule). A user
+    // setting 0 means "off"; it must NOT resolve to cutoff=now and nuke every
+    // non-active session. Guards rolloutCutoffMs's `days <= 0 → disabled`.
+    const oldPath = seedSession("thread-old", 365);
+    const sessionsDir = join(driver.projectDir, "sessions");
+    expect(mirrorRowCount()).toBe(2);
+
+    const report = pruneRolloutSessions(driver, {
+      sessionsDir,
+      retention_days: 0,
+      now: () => NOW,
+    });
+
+    expect(report.prunedSessions).toBe(0);
+    expect(report.prunedSessionIds).toEqual([]);
+    expect(existsSync(oldPath)).toBe(true);
+    expect(mirrorRowCount()).toBe(2);
+  });
+
+  it("never prunes a session whose rollout lock is held by a live process", () => {
+    // Daemon shares the sessions dir with live foreground processes. An old,
+    // non-active session that is still OPEN (lock held by a live pid) must not
+    // be removed out from under the live writer. Guards sessionHasLiveRolloutLock.
+    const lockedPath = seedSession("thread-locked", 90); // old + non-active
+    // Write the rollout lock held by THIS (live) process, matching SessionLock's
+    // `<rolloutPath>.lock` JSON shape.
+    writeFileSync(
+      `${lockedPath}.lock`,
+      JSON.stringify({
+        pid: process.pid,
+        startNs: "0",
+        acquiredAtIso: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    const sessionsDir = join(driver.projectDir, "sessions");
+
+    const report = pruneRolloutSessions(driver, {
+      sessionsDir,
+      retention_days: 30,
+      now: () => NOW,
+    });
+
+    expect(report.prunedSessions).toBe(0);
+    expect(report.prunedSessionIds).toEqual([]);
+    expect(existsSync(lockedPath)).toBe(true);
+    expect(mirrorRowCountForSource(lockedPath)).toBe(2);
+  });
 });
 
 describe("AgenCSessionSnapshotPolicy rollout sweep timer", () => {

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -1,0 +1,217 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ROLLOUT_SCHEMA_VERSION } from "../session/event-log.js";
+import { serializeRolloutItem } from "../session/rollout-item.js";
+import { backfillProjectRollouts } from "./backfill.js";
+import { pruneRolloutSessions } from "./pruning.js";
+import { AgenCSessionSnapshotPolicy } from "./snapshot-policy.js";
+import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
+
+let home = "";
+let cwd = "";
+let originalAgencHome = "";
+let driver: StateSqliteDriver;
+
+const NOW = "2026-06-04T00:00:00.000Z";
+const NOW_MS = Date.parse(NOW);
+const DAY_MS = 86_400_000;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-retention-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-retention-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  originalAgencHome = process.env.AGENC_HOME ?? "";
+  process.env.AGENC_HOME = home;
+  driver = openStateDatabases({ cwd });
+});
+
+afterEach(() => {
+  driver.close();
+  if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
+  else delete process.env.AGENC_HOME;
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+/**
+ * Write a single-message rollout JSONL for `sessionId` into its session dir,
+ * stamp its mtime `ageDays` in the past, and index it into the SQLite mirror.
+ * Returns the rollout file path so callers can assert on it.
+ */
+function seedSession(sessionId: string, ageDays: number): string {
+  const sessionDir = join(driver.projectDir, "sessions", sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  const rolloutPath = join(
+    sessionDir,
+    `rollout-2026-01-01T00-00-00-000Z-${sessionId}.jsonl`,
+  );
+  writeFileSync(
+    rolloutPath,
+    serializeRolloutItem({
+      type: "session_meta",
+      payload: {
+        sessionId,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        cwd,
+        originator: "test",
+        agencVersion: "0.2.0",
+        rolloutSchemaVersion: ROLLOUT_SCHEMA_VERSION,
+        model: "grok-4",
+        modelProvider: "xai",
+      },
+    }) +
+      serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "hello" },
+      }),
+  );
+  // Index the file into thread_rollout_items / backfill_files / rollout_receipts.
+  backfillProjectRollouts({ projectDir: driver.projectDir, driver });
+  // Stamp mtime in the past so the age gate is exercised deterministically.
+  const when = new Date(NOW_MS - ageDays * DAY_MS);
+  utimesSync(rolloutPath, when, when);
+  return rolloutPath;
+}
+
+function mirrorRowCount(): number {
+  return (
+    driver
+      .prepareState<[], { count: number }>(
+        "SELECT COUNT(*) AS count FROM thread_rollout_items",
+      )
+      .get()?.count ?? -1
+  );
+}
+
+function mirrorRowCountForSource(sourcePath: string): number {
+  return (
+    driver
+      .prepareState<[string], { count: number }>(
+        "SELECT COUNT(*) AS count FROM thread_rollout_items WHERE source_path = ?",
+      )
+      .get(sourcePath)?.count ?? -1
+  );
+}
+
+describe("pruneRolloutSessions", () => {
+  it("deletes an old session + its mirror rows, keeps recent and active", () => {
+    const oldPath = seedSession("thread-old", 60); // older than the window
+    const recentPath = seedSession("thread-recent", 5); // inside the window
+    const activePath = seedSession("thread-active", 90); // old but live
+
+    const sessionsDir = join(driver.projectDir, "sessions");
+    // Each seeded rollout indexes 2 items → 6 mirror rows total.
+    expect(mirrorRowCount()).toBe(6);
+
+    const report = pruneRolloutSessions(driver, {
+      sessionsDir,
+      retention_days: 30,
+      activeSessionId: "thread-active",
+      now: () => NOW,
+    });
+
+    // Only the old, non-active session is pruned.
+    expect(report.prunedSessions).toBe(1);
+    expect(report.prunedSessionIds).toEqual(["thread-old"]);
+    expect(report.prunedRolloutFiles).toBe(1);
+    expect(report.prunedMirrorRows).toBe(2);
+
+    // Old session: file gone, dir gone, mirror rows gone.
+    expect(existsSync(oldPath)).toBe(false);
+    expect(existsSync(join(sessionsDir, "thread-old"))).toBe(false);
+    expect(mirrorRowCountForSource(oldPath)).toBe(0);
+
+    // Recent and active sessions: untouched on disk and in the mirror.
+    expect(existsSync(recentPath)).toBe(true);
+    expect(existsSync(activePath)).toBe(true);
+    expect(mirrorRowCountForSource(recentPath)).toBe(2);
+    expect(mirrorRowCountForSource(activePath)).toBe(2);
+    expect(mirrorRowCount()).toBe(4);
+  });
+
+  it("deletes nothing when no retention window is configured", () => {
+    const oldPath = seedSession("thread-old", 365);
+    const sessionsDir = join(driver.projectDir, "sessions");
+    expect(mirrorRowCount()).toBe(2);
+
+    const report = pruneRolloutSessions(driver, {
+      sessionsDir,
+      // retention_days intentionally unset → sweep disabled (conservative).
+      now: () => NOW,
+    });
+
+    expect(report.prunedSessions).toBe(0);
+    expect(report.prunedSessionIds).toEqual([]);
+    expect(existsSync(oldPath)).toBe(true);
+    expect(mirrorRowCount()).toBe(2);
+  });
+});
+
+describe("AgenCSessionSnapshotPolicy rollout sweep timer", () => {
+  it("prunes old sessions on the throttled periodic tick, sparing the active one", () => {
+    const oldPath = seedSession("thread-old", 60);
+    const activePath = seedSession("thread-active", 90);
+    const sessionsDir = join(driver.projectDir, "sessions");
+
+    let tick: (() => void) | undefined;
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => NOW,
+      rolloutRetention: { retention_days: 30 },
+      rolloutSessionsDir: sessionsDir,
+      activeSessionId: "thread-active",
+      setInterval: (callback, intervalMs) => {
+        // Throttled daemon timer, not a tight loop.
+        expect(intervalMs).toBe(30_000);
+        tick = callback;
+        return { unref: vi.fn() };
+      },
+      clearInterval: vi.fn(),
+    });
+
+    policy.startPeriodic();
+    expect(tick).toBeDefined();
+    // No sweep until the timer fires.
+    expect(existsSync(oldPath)).toBe(true);
+
+    tick?.();
+    policy.stopPeriodic();
+
+    expect(existsSync(oldPath)).toBe(false);
+    expect(existsSync(activePath)).toBe(true);
+    expect(mirrorRowCountForSource(oldPath)).toBe(0);
+    expect(mirrorRowCountForSource(activePath)).toBe(2);
+  });
+
+  it("never sweeps when no rollout retention window is configured", () => {
+    const oldPath = seedSession("thread-old", 365);
+    const sessionsDir = join(driver.projectDir, "sessions");
+
+    let tick: (() => void) | undefined;
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => NOW,
+      // rolloutRetention intentionally unset → disabled.
+      rolloutSessionsDir: sessionsDir,
+      setInterval: (callback) => {
+        tick = callback;
+        return { unref: vi.fn() };
+      },
+      clearInterval: vi.fn(),
+    });
+
+    policy.startPeriodic();
+    tick?.();
+    policy.stopPeriodic();
+
+    expect(existsSync(oldPath)).toBe(true);
+    expect(mirrorRowCount()).toBe(2);
+  });
+});


### PR DESCRIPTION
Implements the reserved rollout/session retention keys so the rollout JSONL files, their session dirs, and the `thread_rollout_items` SQLite mirror are finally pruned — closing the unbounded-disk-growth gap. PR B of the verified backlog.

### Behavior
- `pruneRolloutSessions()` deletes whole session dirs whose newest rollout mtime is older than the window, then drops the matching mirror rows so the index can't outlive its source.
- **Conservative by design (it deletes user data):** disabled unless a positive `agent.retention.rollout_days` is set; never prunes the active session; removes each dir atomically (rename-aside → recursive rm); bounded per sweep; runs on the throttled snapshot-policy periodic timer.

### Safety reworks (from adversarial review — `wf_73cac221-d1e`)
The first commit is the generated sweep; the second closes two real data-loss footguns the review caught:
1. **`rollout_days: 0` is now DISABLED, not "delete everything older than now."** The config validator accepts 0 (shared non-negative-days rule), so a user setting 0 (meaning "off") would otherwise resolve to `cutoff=now` and make every non-active session eligible. `rolloutCutoffMs` now returns `undefined` for zero/negative/non-finite — intentionally differing from the sibling `cutoffIso()` whose `days===0` semantics are load-bearing for the other pruning paths.
2. **Live-writer guard.** The daemon shares the sessions dir with separate foreground processes; an idle-but-open session older than the window could be `rm`'d out from under a live fd. The sweep now skips any session whose `rollout-*.jsonl.lock` is held by a **live** process (stale/dead-holder locks don't block pruning, mirroring `SessionLock`'s liveness check).

### Verification
- tsc 0 · 245 state+config tests green · branding clean.
- Both reworks have **revert-sensitive** tests: each goes red ("expected 1 to be 0") when its fix is reverted, green when restored.