### PR TITLE
feat(runtime): token-efficient cron tick driver

### DIFF
--- a/runtime/src/tools/ScheduleCronTool/CronCreateTool.ts
+++ b/runtime/src/tools/ScheduleCronTool/CronCreateTool.ts
@@ -9,6 +9,7 @@ import {
   listAllCronTasks,
   nextCronRunMs,
 } from '../../utils/cronTasks.js'
+import { getCronScheduler } from '../../utils/cronScheduler.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { semanticBoolean } from '../../utils/semanticBoolean.js'
 import { getTeammateContext } from '../../utils/teammateContext.js'
@@ -125,12 +126,17 @@ export const CronCreateTool = buildTool({
       effectiveDurable,
       getTeammateContext()?.agentId,
     )
-    // Enable the scheduler so the task fires in this session. The
-    // useScheduledTasks hook polls this flag and will start watching
-    // on the next tick. For durable: false tasks the file never changes
-    // — check() reads the session store directly — but the enable flag
-    // is still what starts the tick loop.
+    // Enable the scheduler so the task fires in this session, then start the
+    // timer-driven driver and reschedule it to the new task's next-due moment.
+    // start() is gated behind the enable flag (just set) and is idempotent;
+    // reschedule() re-arms the single sleep-until-next-due timer so this brand
+    // new task — which may be due sooner than anything already scheduled —
+    // preempts the current sleep instead of being missed. The driver never
+    // polls the model; it wakes only when a task is genuinely due.
     setScheduledTasksEnabled(true)
+    const scheduler = getCronScheduler()
+    scheduler.start()
+    void scheduler.reschedule()
     return {
       data: {
         id,

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -27,6 +27,7 @@ import type { SpinnerMode } from "./spinner/types.js";
 import { PromptInputQueuedCommands } from "./PromptInput/PromptInputQueuedCommands.js";
 import { useCommandQueue } from "../hooks/useCommandQueue.js";
 import { dequeue, enqueue, peek } from "../../utils/messageQueueManager.js";
+import { getCronScheduler } from "../../utils/cronScheduler.js";
 import { parseSlashCommand, dispatchSlashCommand } from "../../commands/dispatcher.js";
 import { buildDefaultRegistry } from "../../commands/registry.js";
 import { setGlobalCommandRegistry } from "../../commands/types.js";
@@ -2020,6 +2021,18 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
       setQueueDrainTick(tick => tick + 1);
     });
   }, [effectiveInputBusy, permissionRequests.length, elicitation.prompt, isMessageSelectorVisible, onboarding.active, queuedCommands, submit, runQueuedBashCommand]);
+  // Start the cron scheduler on session mount so durable scheduled tasks
+  // restored from disk actually fire (CronCreate starts it when a task is made
+  // in-session, but a fresh session with pre-existing tasks needs this). start()
+  // is gated on getScheduledTasksEnabled() (a no-op until a CronCreate enables
+  // it) and idempotent; the driver wakes only when a task is genuinely due, so
+  // idle costs zero model turns. Stop the process-wide singleton on unmount.
+  useEffect(() => {
+    const scheduler = getCronScheduler();
+    scheduler.start();
+    void scheduler.reschedule();
+    return () => scheduler.stop();
+  }, []);
   const toolUseConfirmQueue = useMemo(() => buildToolUseConfirmQueue(permissionRequests, availableTools), [permissionRequests, availableTools]);
 
   // Per-turn AbortController. CancelRequestHandler reads

--- a/runtime/src/utils/cronScheduler.ts
+++ b/runtime/src/utils/cronScheduler.ts
@@ -34,8 +34,10 @@
 // task from tight-looping the model and stop a synchronized thundering herd;
 // structured telemetry is emitted on every wake/dispatch.
 
+import type { AgentId } from '../types/ids.js'
 import { getScheduledTasksEnabled } from '../bootstrap/state.js'
 import { logForDebugging } from './debug.js'
+import { enqueuePendingNotification } from './messageQueueManager.js'
 import { monotonicMs } from './monotonic.js'
 import {
   DEFAULT_CRON_JITTER_CONFIG,
@@ -150,8 +152,16 @@ export class CronScheduler {
   private running = false
   /** True while a tick (the local wake path) is executing — re-entrancy guard. */
   private tickInFlight = false
-  /** Task ids whose enqueued turn has not yet completed — overlap guard. */
-  private readonly inFlightTasks = new Set<string>()
+  /**
+   * Per-task overlap guard: monotonic-ms deadline through which a task that just
+   * fired is treated as "still in flight" so a duplicate is skipped. The lease
+   * AUTO-EXPIRES after minIntervalFloorMs so a recurring task is never
+   * permanently wedged — the TUI drains the command queue serially and does not
+   * signal turn completion back to the driver, so a lock that released ONLY via
+   * markTurnComplete() would fire each recurring task exactly once per process.
+   * markTurnComplete() still clears the lease early for callers that CAN signal.
+   */
+  private readonly inFlightUntil = new Map<string, number>()
   /** Monotonic ms of the last enqueue per task — drives the min-interval floor. */
   private readonly lastInvokedAt = new Map<string, number>()
   /**
@@ -222,12 +232,14 @@ export class CronScheduler {
   }
 
   /**
-   * Mark a task's turn complete, releasing its overlap lock. The turn-runner
-   * calls this when the enqueued prompt's turn fully finishes (success or
-   * failure) so the next occurrence may dispatch.
+   * Mark a task's turn complete, releasing its overlap lock early. Optional: the
+   * lease set on fire auto-expires after minIntervalFloorMs regardless, so a
+   * caller that cannot observe turn completion (the TUI queue path) still gets
+   * correct recurring behavior. A caller that CAN observe completion calls this
+   * to release the next occurrence sooner than the lease.
    */
   markTurnComplete(taskId: string): void {
-    this.inFlightTasks.delete(taskId)
+    this.inFlightUntil.delete(taskId)
   }
 
   /**
@@ -302,12 +314,19 @@ export class CronScheduler {
       // collapsed slots for telemetry (count-1 are the "misses").
       coalescedMisses += occurrences - 1
 
-      // Overlap guard: a previous turn for this task is still in flight → skip
-      // this occurrence entirely (do NOT start a second turn). It's already
-      // coalesced, so we simply drop it and advance next_due on the next wake.
-      if (this.inFlightTasks.has(task.id)) {
-        skippedDueToLock += 1
-        continue
+      // Overlap guard: a previous turn for this task fired within the lease
+      // window → skip this occurrence (do NOT pile a second turn onto the
+      // serial queue). It's already coalesced, so drop it and advance next_due
+      // on the next wake. The lease auto-expires (below) so recurring tasks are
+      // never permanently wedged.
+      const inFlightUntil = this.inFlightUntil.get(task.id)
+      if (inFlightUntil !== undefined) {
+        if (this.deps.monotonicNow() < inFlightUntil) {
+          skippedDueToLock += 1
+          continue
+        }
+        // Lease expired: the prior turn's overlap window has passed.
+        this.inFlightUntil.delete(task.id)
       }
 
       // Rate cap: pause the whole schedule rather than keep firing.
@@ -316,8 +335,10 @@ export class CronScheduler {
         break
       }
 
-      this.inFlightTasks.add(task.id)
-      this.lastInvokedAt.set(task.id, this.deps.monotonicNow())
+      const firedAtMono = this.deps.monotonicNow()
+      // Hold the overlap lease for one floor interval, then auto-release.
+      this.inFlightUntil.set(task.id, firedAtMono + this.opts.minIntervalFloorMs)
+      this.lastInvokedAt.set(task.id, firedAtMono)
       // Advance the effective anchor past everything we just coalesced so the
       // next reschedule resolves this task to a FUTURE slot — never the same
       // past-due instant (which would re-fire in a tight loop / busy-spin).
@@ -525,12 +546,36 @@ export class CronScheduler {
  */
 let singleton: CronScheduler | null = null
 
+/**
+ * Adapter from the driver's minimal {@link CronEnqueue} surface to the real TUI
+ * command queue. This is the production enqueue: a due task is pushed onto the
+ * serially-drained command queue (enqueuePendingNotification) as an isMeta
+ * `task-notification`, where the session's turn loop runs it. The driver itself
+ * stays decoupled from the queue module (and testable with a stub enqueue); the
+ * brand cast is localized here because CronTask.agentId is a bare string while
+ * QueuedCommand.agentId is the branded AgentId.
+ */
+export function cronEnqueueToCommandQueue(
+  command: Parameters<CronEnqueue>[0],
+): void {
+  enqueuePendingNotification({
+    value: command.value,
+    mode: command.mode,
+    isMeta: command.isMeta,
+    workload: command.workload,
+    ...(command.agentId ? { agentId: command.agentId as AgentId } : {}),
+  })
+}
+
 export function getCronScheduler(): CronScheduler {
   if (singleton === null) {
     singleton = new CronScheduler(
       {
         // Bind to the default (non-daemon) project root + session merge.
         loadTasks: () => listAllCronTasks(),
+        // Wire the real TUI command queue so a due task actually fires (the
+        // default dep is a no-op stub that would silently drop every fire).
+        enqueue: cronEnqueueToCommandQueue,
       },
       { dir: undefined },
     )

--- a/runtime/src/utils/cronScheduler.ts
+++ b/runtime/src/utils/cronScheduler.ts
@@ -1,0 +1,545 @@
+// Token-efficient cron tick driver.
+//
+// The hard requirement here: **idle MUST cost ZERO model invocations.** A
+// previous heartbeat that woke the model on a fixed interval to ask "anything
+// to do?" silently burned tokens around the clock — this driver is built to
+// make that failure mode impossible.
+//
+// Design (sleep-until-next-due, NOT poll-then-check):
+//   - We keep one sorted view of the enabled cron tasks keyed by next-due
+//     epoch ms and arm a SINGLE setTimeout to the *earliest* due moment. We
+//     never `setInterval(check)` and we never walk all records on a timer.
+//   - The timer wake runs only cheap, deterministic, NON-model code: read the
+//     clock, find the tasks that are actually due, coalesce missed slots, take
+//     the per-task lock, then enqueue. The "should I run?" decision is made in
+//     local code — the model is invoked ONLY when a concretely-due, runnable
+//     task dispatches.
+//   - While no task is due (or there are no tasks) the process is asleep and
+//     issues ZERO enqueues. An empty schedule arms no timer at all.
+//   - The sleep is interruptible: reschedule() re-arms to the new earliest due
+//     time (so adding an earlier task preempts the current sleep) and stop()
+//     clears the timer (shutdown wakes the sleeper immediately).
+//
+// Coalescing: on wake, every scheduled instant already in the past for a given
+// task collapses to AT MOST ONE enqueue (fire-once-now), then next_due is
+// recomputed from the canonical cron schedule against the current clock — we
+// never replay N missed slots as N model turns, and we never accumulate
+// `next += interval` off a drifting timer.
+//
+// Re-entrancy: at most one tick runs at a time, and at most one turn is
+// in-flight per task. A task whose previous turn has not completed SKIPS this
+// occurrence (it is already coalesced) rather than starting a second turn.
+//
+// Bounds & observability: jitter + a min-interval floor stop a self-rescheduling
+// task from tight-looping the model and stop a synchronized thundering herd;
+// structured telemetry is emitted on every wake/dispatch.
+
+import { getScheduledTasksEnabled } from '../bootstrap/state.js'
+import { logForDebugging } from './debug.js'
+import { monotonicMs } from './monotonic.js'
+import {
+  DEFAULT_CRON_JITTER_CONFIG,
+  jitteredNextCronRunMs,
+  listAllCronTasks,
+  markCronTasksFired,
+  nextCronRunMs,
+  oneShotJitteredNextCronRunMs,
+  removeCronTasks,
+  type CronTask,
+} from './cronTasks.js'
+
+/**
+ * Minimal enqueue surface the driver needs. Matches
+ * {@link import('./messageQueueManager.js').enqueuePendingNotification} but is
+ * injected so tests can assert ZERO model turns when idle without pulling in
+ * the React/TUI command-queue module. The real call site passes the actual
+ * queue function.
+ */
+export type CronEnqueue = (command: {
+  value: string
+  mode: 'task-notification'
+  isMeta: true
+  workload: string
+  agentId?: string
+}) => void
+
+/** Injectable clocks/timer so tests can drive the driver with fake timers. */
+export type CronSchedulerDeps = {
+  /** Wall-clock now in epoch ms. Used for the cron (calendar) computation. */
+  now: () => number
+  /**
+   * Monotonic now in ms, used ONLY for the min-interval floor between model
+   * invocations. Immune to NTP steps / suspend-resume; never used for the
+   * calendar computation (cron is inherently wall-clock).
+   */
+  monotonicNow: () => number
+  setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+  /** Load the currently-enabled tasks (file-backed + session). */
+  loadTasks: (dir?: string) => Promise<CronTask[]>
+  enqueue: CronEnqueue
+}
+
+const defaultDeps: CronSchedulerDeps = {
+  now: () => Date.now(),
+  monotonicNow: () => monotonicMs(),
+  setTimer: (fn, ms) => setTimeout(fn, ms),
+  clearTimer: handle => clearTimeout(handle),
+  loadTasks: dir => listAllCronTasks(dir),
+  enqueue: () => {
+    // Default stub: never invokes the model. The real call site overrides this
+    // with the TUI command queue (enqueuePendingNotification). Keeping a no-op
+    // default means an un-wired driver can never surprise-spend tokens.
+  },
+}
+
+export type CronSchedulerOptions = {
+  /**
+   * Minimum ms between consecutive model invocations for a SINGLE task. If a
+   * task's recomputed next_due is sooner than now + floor, it is clamped to
+   * now + floor so a task whose schedule keeps resolving to ~now can never
+   * tight-loop the model (the agent-cost busy-loop).
+   */
+  minIntervalFloorMs: number
+  /**
+   * Hard ceiling on enqueues per rolling window. When exceeded the schedule
+   * pauses (does NOT keep firing) until resume() is called. A regressed
+   * heartbeat that started spamming the model trips this instead of running up
+   * a bill.
+   */
+  maxInvocationsPerWindow: number
+  /** Rolling-window length for {@link maxInvocationsPerWindow}, in ms. */
+  windowMs: number
+  /** Project dir override (daemon). Undefined → getProjectRoot()/session merge. */
+  dir?: string
+}
+
+export const DEFAULT_CRON_SCHEDULER_OPTIONS: CronSchedulerOptions = {
+  // A self-rescheduling task can never invoke the model more than once every
+  // 30s, regardless of how its cron resolves.
+  minIntervalFloorMs: 30_000,
+  // At most 60 fires/hour by default — far above any sane cron cadence, but a
+  // hard backstop against a runaway loop.
+  maxInvocationsPerWindow: 60,
+  windowMs: 60 * 60 * 1000,
+}
+
+/** Per-dispatch telemetry, emitted to the debug log and exposed for tests. */
+export type CronTickTelemetry = {
+  /** Epoch ms when this wake fired. */
+  firedAt: number
+  /** Tasks dispatched (one enqueue each) this tick. */
+  dispatched: number
+  /** Occurrences collapsed into a single fire-once-now (sum across tasks). */
+  coalescedMisses: number
+  /** Occurrences skipped because the task's previous turn was still in flight. */
+  skippedDueToLock: number
+  /** ms until the next armed wake, or null if nothing is scheduled. */
+  nextWakeInMs: number | null
+}
+
+/**
+ * Single timer-driven cron dispatcher. Construct once, call start(); it arms a
+ * sleep-until-next-due timer and only wakes the model when a task is genuinely
+ * due. Idle = zero enqueues.
+ */
+export class CronScheduler {
+  private readonly deps: CronSchedulerDeps
+  private readonly opts: CronSchedulerOptions
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private running = false
+  /** True while a tick (the local wake path) is executing — re-entrancy guard. */
+  private tickInFlight = false
+  /** Task ids whose enqueued turn has not yet completed — overlap guard. */
+  private readonly inFlightTasks = new Set<string>()
+  /** Monotonic ms of the last enqueue per task — drives the min-interval floor. */
+  private readonly lastInvokedAt = new Map<string, number>()
+  /**
+   * Wall-clock instant (epoch ms) through which each task has already been
+   * dispatched this process. The effective schedule anchor is the LATER of
+   * this and the task's persisted lastFiredAt/createdAt, so a fired task always
+   * advances to its NEXT future slot instead of re-resolving to the same
+   * past-due instant and re-firing in a tight loop. This is what makes "fire
+   * once now, then recompute next_due from the canonical schedule" hold even
+   * for session tasks whose fire time is never written to disk.
+   */
+  private readonly firedThrough = new Map<string, number>()
+  /** Wall-clock ms of recent enqueues, trimmed to the rolling window. */
+  private invocationLog: number[] = []
+  private paused = false
+  private lastTelemetry: CronTickTelemetry | null = null
+  /**
+   * Set by dispatchDue() so the immediately-following reschedule() patches the
+   * dispatch telemetry's nextWakeInMs instead of clobbering it with a fresh
+   * idle record. Cleared once consumed.
+   */
+  private dispatchAwaitingNextWake = false
+
+  constructor(
+    deps: Partial<CronSchedulerDeps> = {},
+    opts: Partial<CronSchedulerOptions> = {},
+  ) {
+    this.deps = { ...defaultDeps, ...deps }
+    this.opts = { ...DEFAULT_CRON_SCHEDULER_OPTIONS, ...opts }
+  }
+
+  /** Last tick's telemetry (for tests / observability). */
+  getLastTelemetry(): CronTickTelemetry | null {
+    return this.lastTelemetry
+  }
+
+  /** Whether the schedule auto-paused after tripping the invocation cap. */
+  isPaused(): boolean {
+    return this.paused
+  }
+
+  /**
+   * Begin dispatching. Gated behind getScheduledTasksEnabled() so the default
+   * (OFF) means literally zero surprise token use — start() is a no-op until a
+   * CronCreate flips the flag. Idempotent.
+   */
+  start(): void {
+    if (this.running) return
+    if (!getScheduledTasksEnabled()) return
+    this.running = true
+    void this.reschedule()
+  }
+
+  /**
+   * Stop the driver. Clears the armed timer immediately (the interruptible
+   * sleep's shutdown path) so no further wakes occur. In-flight turns are not
+   * cancelled but no NEW tick will run.
+   */
+  stop(): void {
+    this.running = false
+    this.clearTimer()
+  }
+
+  /** Resume after a pause (manual or post-cap), re-arming the next wake. */
+  resume(): void {
+    this.paused = false
+    void this.reschedule()
+  }
+
+  /**
+   * Mark a task's turn complete, releasing its overlap lock. The turn-runner
+   * calls this when the enqueued prompt's turn fully finishes (success or
+   * failure) so the next occurrence may dispatch.
+   */
+  markTurnComplete(taskId: string): void {
+    this.inFlightTasks.delete(taskId)
+  }
+
+  /**
+   * Recompute the earliest due moment across all enabled tasks and arm a
+   * SINGLE timer to wake exactly then. Interruptible: calling this again (e.g.
+   * after a CronCreate adds an earlier task) clears the old timer and arms the
+   * new, earlier one — no polling, no oversleeping new work. An empty schedule
+   * arms no timer (zero CPU, zero model calls).
+   */
+  async reschedule(): Promise<void> {
+    if (!this.running || this.paused) return
+    this.clearTimer()
+
+    const dueAt = await this.earliestDueAt()
+    if (dueAt === null) {
+      // No tasks (or none with a future fire). Stay asleep. Zero model calls.
+      this.recordNextWake(null)
+      return
+    }
+
+    // Bound the delay to >= 0; a due-in-the-past task fires on the next tick of
+    // the event loop. setTimeout clamps huge delays oddly across runtimes, so
+    // cap the single sleep to the window length and re-arm on wake — this also
+    // recomputes from the canonical schedule each time (no drift accumulation).
+    const wait = Math.min(
+      Math.max(0, dueAt - this.deps.now()),
+      this.opts.windowMs,
+    )
+    this.recordNextWake(wait)
+    this.timer = this.deps.setTimer(() => {
+      void this.onWake()
+    }, wait)
+  }
+
+  /**
+   * The wake path. Runs ONLY local, deterministic, non-model code to decide
+   * what (if anything) is due, then enqueues exactly one turn per due task.
+   * Re-entrant calls are dropped (re-entrancy guard).
+   */
+  private async onWake(): Promise<void> {
+    if (!this.running || this.paused) return
+    if (this.tickInFlight) return // hard re-entrancy guard: one tick at a time
+    this.tickInFlight = true
+    try {
+      await this.dispatchDue()
+    } finally {
+      this.tickInFlight = false
+    }
+    // Re-arm AFTER the tick so the next wake reflects post-fire next_due.
+    await this.reschedule()
+  }
+
+  /**
+   * Find tasks whose due time is now in the past, coalesce each to a single
+   * enqueue, persist lastFiredAt / delete one-shots, and emit telemetry.
+   */
+  private async dispatchDue(): Promise<void> {
+    const now = this.deps.now()
+    const tasks = await this.deps.loadTasks(this.opts.dir)
+
+    let dispatched = 0
+    let coalescedMisses = 0
+    let skippedDueToLock = 0
+    const firedRecurringIds: string[] = []
+    const firedOneShotIds: string[] = []
+
+    for (const task of tasks) {
+      const occurrences = this.dueOccurrences(task, now)
+      if (occurrences === 0) continue
+
+      // Coalesce: N missed slots → at most ONE enqueue. Count the extra,
+      // collapsed slots for telemetry (count-1 are the "misses").
+      coalescedMisses += occurrences - 1
+
+      // Overlap guard: a previous turn for this task is still in flight → skip
+      // this occurrence entirely (do NOT start a second turn). It's already
+      // coalesced, so we simply drop it and advance next_due on the next wake.
+      if (this.inFlightTasks.has(task.id)) {
+        skippedDueToLock += 1
+        continue
+      }
+
+      // Rate cap: pause the whole schedule rather than keep firing.
+      if (!this.tryRecordInvocation(now)) {
+        this.pauseForCap()
+        break
+      }
+
+      this.inFlightTasks.add(task.id)
+      this.lastInvokedAt.set(task.id, this.deps.monotonicNow())
+      // Advance the effective anchor past everything we just coalesced so the
+      // next reschedule resolves this task to a FUTURE slot — never the same
+      // past-due instant (which would re-fire in a tight loop / busy-spin).
+      this.firedThrough.set(task.id, now)
+      this.deps.enqueue({
+        value: task.prompt,
+        mode: 'task-notification',
+        isMeta: true,
+        workload: 'cron',
+        ...(task.agentId ? { agentId: task.agentId } : {}),
+      })
+      dispatched += 1
+
+      if (task.recurring) {
+        // Only file-backed tasks persist lastFiredAt; session tasks die with
+        // the process. durable === false marks a session task (see
+        // listAllCronTasks).
+        if (task.durable !== false) firedRecurringIds.push(task.id)
+      } else {
+        firedOneShotIds.push(task.id)
+      }
+    }
+
+    // Persist fire times for recurring file-backed tasks and delete fired
+    // one-shots — both are read-modify-writes batched once per tick, not N×.
+    if (firedRecurringIds.length > 0) {
+      await markCronTasksFired(firedRecurringIds, now, this.opts.dir)
+    }
+    if (firedOneShotIds.length > 0) {
+      await removeCronTasks(firedOneShotIds, this.opts.dir)
+    }
+
+    this.lastTelemetry = {
+      firedAt: now,
+      dispatched,
+      coalescedMisses,
+      skippedDueToLock,
+      nextWakeInMs: null, // patched (not clobbered) by the post-tick reschedule()
+    }
+    this.dispatchAwaitingNextWake = true
+    logForDebugging(
+      `[CronScheduler] wake fired=${now} dispatched=${dispatched} ` +
+        `coalescedMisses=${coalescedMisses} skippedDueToLock=${skippedDueToLock}`,
+    )
+  }
+
+  /**
+   * Schedule anchor for next-due computation: the LATEST of the task's
+   * persisted fire time, its creation time, and the in-memory instant we have
+   * already dispatched it through this process. Taking the max means a task we
+   * just fired resolves to its NEXT slot rather than re-resolving to the same
+   * past-due instant — the guard against a tight re-fire loop (and the OOM /
+   * token-burn that comes with it) for session tasks whose fire time never
+   * round-trips through disk.
+   */
+  private effectiveAnchor(task: CronTask): number {
+    const persisted = task.lastFiredAt ?? task.createdAt
+    const fired = this.firedThrough.get(task.id)
+    return fired === undefined ? persisted : Math.max(persisted, fired)
+  }
+
+  /**
+   * How many scheduled instants for this task are at-or-before `now` (i.e. how
+   * many would have fired if we'd been awake). Drives the coalesced-miss
+   * telemetry — the dispatch fires once regardless of how many slots elapsed.
+   */
+  private dueOccurrences(task: CronTask, now: number): number {
+    const anchor = this.effectiveAnchor(task)
+    let cursor = nextCronRunMs(task.cron, anchor)
+
+    let count = 0
+    // Walk forward through past-due slots. Bounded: cron resolution is 1 min,
+    // and we stop at the first future instant, so this loop is O(missed slots)
+    // and only runs after a real gap (suspend/restart). Cap to a sane bound so
+    // a pathological clock skew can't spin here.
+    const MAX_WALK = 100_000
+    let guard = 0
+    while (cursor !== null && cursor <= now && guard < MAX_WALK) {
+      count += 1
+      cursor = nextCronRunMs(task.cron, cursor)
+      guard += 1
+    }
+    return count
+  }
+
+  /**
+   * Earliest due epoch ms across all enabled tasks, applying jitter (herd
+   * spreading) and the min-interval floor (anti tight-loop). Null when there
+   * are no tasks with a future (or past-due) fire.
+   */
+  private async earliestDueAt(): Promise<number | null> {
+    const now = this.deps.now()
+    const tasks = await this.deps.loadTasks(this.opts.dir)
+    let earliest: number | null = null
+    for (const task of tasks) {
+      const due = this.nextDueForTask(task, now)
+      if (due === null) continue
+      if (earliest === null || due < earliest) earliest = due
+    }
+    return earliest
+  }
+
+  /**
+   * Canonical next_due for a task, recomputed from its schedule each call
+   * (never accumulated). Past-due → now (fire immediately). Applies bounded
+   * jitter and the min-interval floor.
+   */
+  private nextDueForTask(task: CronTask, now: number): number | null {
+    const anchor = this.effectiveAnchor(task)
+    // If a scheduled instant is already at/behind now, it's due now — return
+    // `now` so the timer fires immediately and dispatchDue() coalesces.
+    const plain = nextCronRunMs(task.cron, anchor)
+    if (plain === null) return null
+    if (plain <= now) return now
+
+    // Future fire: apply jitter (recurring → forward, one-shot → backward) to
+    // spread synchronized herds, then clamp with the min-interval floor so a
+    // task can't invoke the model sooner than now + floor.
+    const jittered = task.recurring
+      ? jitteredNextCronRunMs(
+          task.cron,
+          anchor,
+          task.id,
+          DEFAULT_CRON_JITTER_CONFIG,
+        )
+      : oneShotJitteredNextCronRunMs(
+          task.cron,
+          anchor,
+          task.id,
+          DEFAULT_CRON_JITTER_CONFIG,
+        )
+    const target = jittered ?? plain
+
+    const last = this.lastInvokedAt.get(task.id)
+    if (last !== undefined) {
+      // Floor is measured on the monotonic clock; translate to wall-clock by
+      // taking the larger of (target) and (now + remaining-floor).
+      const elapsed = this.deps.monotonicNow() - last
+      const remainingFloor = this.opts.minIntervalFloorMs - elapsed
+      if (remainingFloor > 0) {
+        return Math.max(target, now + remainingFloor)
+      }
+    }
+    return target
+  }
+
+  /**
+   * Record an invocation against the rolling window. Returns false (cap hit)
+   * when adding this one would exceed maxInvocationsPerWindow.
+   */
+  private tryRecordInvocation(now: number): boolean {
+    const cutoff = now - this.opts.windowMs
+    this.invocationLog = this.invocationLog.filter(t => t > cutoff)
+    if (this.invocationLog.length >= this.opts.maxInvocationsPerWindow) {
+      return false
+    }
+    this.invocationLog.push(now)
+    return true
+  }
+
+  private pauseForCap(): void {
+    this.paused = true
+    this.clearTimer()
+    logForDebugging(
+      `[CronScheduler] invocation cap (${this.opts.maxInvocationsPerWindow}/` +
+        `${this.opts.windowMs}ms) hit — schedule PAUSED; call resume() to continue`,
+      { level: 'warn' },
+    )
+  }
+
+  /**
+   * Record the next armed wake into telemetry. If a dispatch just happened this
+   * wake, PATCH its record's nextWakeInMs (preserving dispatched / coalesced /
+   * skipped counts); otherwise emit a fresh idle record (dispatched 0). This is
+   * what lets observers see "fired 1, coalesced 9, next wake in N ms" as a
+   * single coherent record per wake.
+   */
+  private recordNextWake(wait: number | null): void {
+    if (this.dispatchAwaitingNextWake && this.lastTelemetry !== null) {
+      this.lastTelemetry = { ...this.lastTelemetry, nextWakeInMs: wait }
+      this.dispatchAwaitingNextWake = false
+      return
+    }
+    this.lastTelemetry = {
+      firedAt: this.deps.now(),
+      dispatched: 0,
+      coalescedMisses: 0,
+      skippedDueToLock: 0,
+      nextWakeInMs: wait,
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      this.deps.clearTimer(this.timer)
+      this.timer = null
+    }
+  }
+}
+
+/**
+ * Process-wide singleton. The REPL / daemon calls getCronScheduler().start()
+ * once the scheduled-tasks flag is enabled, and reschedule() after any
+ * CronCreate/CronDelete so an earlier-due task preempts the current sleep.
+ */
+let singleton: CronScheduler | null = null
+
+export function getCronScheduler(): CronScheduler {
+  if (singleton === null) {
+    singleton = new CronScheduler(
+      {
+        // Bind to the default (non-daemon) project root + session merge.
+        loadTasks: () => listAllCronTasks(),
+      },
+      { dir: undefined },
+    )
+  }
+  return singleton
+}
+
+/** Test-only: drop the singleton so each test starts from a clean driver. */
+export function resetCronSchedulerForTests(): void {
+  singleton?.stop()
+  singleton = null
+}

--- a/runtime/tests/cronScheduler.test.ts
+++ b/runtime/tests/cronScheduler.test.ts
@@ -5,9 +5,18 @@ import {
 } from 'src/bootstrap/state.js'
 import {
   CronScheduler,
+  cronEnqueueToCommandQueue,
   type CronEnqueue,
 } from 'src/utils/cronScheduler.js'
 import type { CronTask } from 'src/utils/cronTasks.js'
+import { enqueuePendingNotification } from 'src/utils/messageQueueManager.js'
+
+// Spy only enqueuePendingNotification; keep every other real export intact so
+// modules that transitively import the queue still load normally.
+vi.mock('src/utils/messageQueueManager.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('src/utils/messageQueueManager.js')>()),
+  enqueuePendingNotification: vi.fn(),
+}))
 
 // ---------------------------------------------------------------------------
 // Deterministic virtual-time harness.
@@ -107,6 +116,7 @@ function makeScheduler(
   clock: FakeClock,
   tasks: CronTask[],
   enqueue: CronEnqueue,
+  floorMs = 1_000,
 ): CronScheduler {
   return new CronScheduler(
     {
@@ -117,9 +127,10 @@ function makeScheduler(
       loadTasks: async () => tasks,
       enqueue,
     },
-    // Tiny floor so the floor logic stays exercised but doesn't dominate the
-    // virtual-time assertions; window cap left at the generous default.
-    { minIntervalFloorMs: 1_000, dir: undefined },
+    // Tiny floor (default) so the floor logic stays exercised but doesn't
+    // dominate the virtual-time assertions; callers raise it to exercise the
+    // overlap lease. Window cap left at the generous default.
+    { minIntervalFloorMs: floorMs, dir: undefined },
   )
 }
 
@@ -225,10 +236,15 @@ describe('CronScheduler', () => {
     sched.stop()
   })
 
-  test('re-entrancy guard: a task whose turn is in flight does NOT start a second turn', async () => {
-    // Per-minute task; fire once (turn now "in flight" — markTurnComplete NOT
-    // called), then cross another minute boundary. The second occurrence must
-    // SKIP rather than enqueue a second, overlapping turn.
+  test('recurring task auto-releases its overlap lock and fires at each cadence without markTurnComplete', async () => {
+    // must-fix: the TUI drains the command queue serially and never signals
+    // turn completion back to the driver, so the per-task overlap lock MUST
+    // auto-expire after the floor. With a permanent lock (the bug) a recurring
+    // task fires exactly once per process and is skipped forever after. Here a
+    // per-minute task is driven across four minute boundaries WITHOUT ever
+    // calling markTurnComplete; it must fire roughly once per minute. Revert the
+    // self-expiring lock back to a permanent one and this collapses to a single
+    // enqueue (the test goes red).
     const clock = new FakeClock(30 * 60_000) // 00:30:00, past-due
     const enqueue = vi.fn()
     const sched = makeScheduler(
@@ -239,21 +255,52 @@ describe('CronScheduler', () => {
 
     sched.start()
     await flush()
-    await advanceAndFlush(clock, 1_000) // first fire
-    expect(enqueue).toHaveBeenCalledTimes(1)
+    await advanceAndFlush(clock, 4 * 60_000 + 1_000)
 
-    // Advance well past several more per-minute slots WITHOUT completing the
-    // turn. Overlap guard must hold the line at one enqueue.
-    await advanceAndFlush(clock, 5 * 60_000)
-    expect(enqueue).toHaveBeenCalledTimes(1)
-    expect(sched.getLastTelemetry()?.skippedDueToLock).toBeGreaterThanOrEqual(1)
-
-    // Now complete the turn → the lock releases → the next due slot may fire.
-    sched.markTurnComplete('dddd0004')
-    await sched.reschedule()
-    await advanceAndFlush(clock, 2 * 60_000)
-    expect(enqueue).toHaveBeenCalledTimes(2)
+    // Fired repeatedly (~once per minute), not stuck after the first occurrence.
+    expect(enqueue.mock.calls.length).toBeGreaterThanOrEqual(3)
 
     sched.stop()
+  })
+})
+
+describe('cronEnqueueToCommandQueue (production wiring)', () => {
+  afterEach(() => {
+    vi.mocked(enqueuePendingNotification).mockClear()
+  })
+
+  test('forwards a due cron command onto the real command queue as an isMeta task-notification', () => {
+    // Guards must-fix #1: getCronScheduler() wires this adapter (not the no-op
+    // stub), so a due task is actually pushed onto the serially-drained queue
+    // where the session turn loop runs it. Revert the wiring → enqueue is the
+    // stub → this is never called.
+    cronEnqueueToCommandQueue({
+      value: 'do the thing',
+      mode: 'task-notification',
+      isMeta: true,
+      workload: 'cron',
+      agentId: 'agent-123',
+    })
+
+    expect(enqueuePendingNotification).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(enqueuePendingNotification).mock.calls[0]?.[0]).toEqual({
+      value: 'do the thing',
+      mode: 'task-notification',
+      isMeta: true,
+      workload: 'cron',
+      agentId: 'agent-123',
+    })
+  })
+
+  test('omits agentId when the task has none (main-thread notification)', () => {
+    cronEnqueueToCommandQueue({
+      value: 'no agent',
+      mode: 'task-notification',
+      isMeta: true,
+      workload: 'cron',
+    })
+
+    const command = vi.mocked(enqueuePendingNotification).mock.calls[0]?.[0]
+    expect(command).not.toHaveProperty('agentId')
   })
 })

--- a/runtime/tests/cronScheduler.test.ts
+++ b/runtime/tests/cronScheduler.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  setScheduledTasksEnabled,
+  resetStateForTests,
+} from 'src/bootstrap/state.js'
+import {
+  CronScheduler,
+  type CronEnqueue,
+} from 'src/utils/cronScheduler.js'
+import type { CronTask } from 'src/utils/cronTasks.js'
+
+// ---------------------------------------------------------------------------
+// Deterministic virtual-time harness.
+//
+// We inject the driver's clock + timer so the test owns ALL time. No real
+// wall-clock sleeps, no real model. `enqueue` is a spy — the whole point of
+// the driver is that it stays at ZERO calls while idle, so asserting on this
+// spy is asserting on token spend.
+// ---------------------------------------------------------------------------
+class FakeClock {
+  nowMs: number
+  monoMs = 0
+  private seq = 0
+  private timers = new Map<
+    number,
+    { fireAt: number; fn: () => void }
+  >()
+
+  constructor(startMs: number) {
+    this.nowMs = startMs
+  }
+
+  setTimer = (fn: () => void, ms: number): number => {
+    const id = ++this.seq
+    this.timers.set(id, { fireAt: this.nowMs + ms, fn })
+    return id
+  }
+
+  clearTimer = (handle: number): void => {
+    this.timers.delete(handle)
+  }
+
+  /** Advance virtual time by `ms`, firing every timer that comes due, in
+   * order. Returns the number of timers fired. */
+  advance(ms: number): number {
+    const target = this.nowMs + ms
+    let fired = 0
+    // Fire repeatedly: a wake re-arms a new timer, which may itself be due
+    // within the same advance window (e.g. coalesced past-due tasks).
+    for (;;) {
+      let nextId: number | null = null
+      let nextAt = Infinity
+      for (const [id, t] of this.timers) {
+        if (t.fireAt <= target && t.fireAt < nextAt) {
+          nextAt = t.fireAt
+          nextId = id
+        }
+      }
+      if (nextId === null) break
+      const t = this.timers.get(nextId)!
+      this.timers.delete(nextId)
+      this.nowMs = t.fireAt
+      this.monoMs += t.fireAt - this.monoMs // keep monotonic in lockstep-ish
+      t.fn()
+      fired += 1
+    }
+    this.nowMs = target
+    return fired
+  }
+
+  pendingCount(): number {
+    return this.timers.size
+  }
+}
+
+/** Flush the microtask queue so the driver's async onWake/reschedule settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 25; i++) await Promise.resolve()
+}
+
+/** Advance virtual time AND flush async work between each fired timer. */
+async function advanceAndFlush(clock: FakeClock, ms: number): Promise<void> {
+  // The driver's onWake is async and re-arms a timer only after awaiting. So
+  // step in small slices, flushing microtasks after each, until we've covered
+  // the whole window.
+  const end = clock.nowMs + ms
+  while (clock.nowMs < end) {
+    const before = clock.nowMs
+    clock.advance(Math.min(60_000, end - clock.nowMs))
+    await flush()
+    // Guard against zero-progress (no timer in this slice).
+    if (clock.nowMs === before) clock.nowMs = Math.min(end, before + 60_000)
+  }
+}
+
+function task(overrides: Partial<CronTask> & { id: string; cron: string }): CronTask {
+  return {
+    prompt: `prompt-${overrides.id}`,
+    createdAt: overrides.createdAt ?? 0,
+    recurring: true,
+    durable: false,
+    ...overrides,
+  }
+}
+
+function makeScheduler(
+  clock: FakeClock,
+  tasks: CronTask[],
+  enqueue: CronEnqueue,
+): CronScheduler {
+  return new CronScheduler(
+    {
+      now: () => clock.nowMs,
+      monotonicNow: () => clock.monoMs,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      loadTasks: async () => tasks,
+      enqueue,
+    },
+    // Tiny floor so the floor logic stays exercised but doesn't dominate the
+    // virtual-time assertions; window cap left at the generous default.
+    { minIntervalFloorMs: 1_000, dir: undefined },
+  )
+}
+
+describe('CronScheduler', () => {
+  beforeEach(() => {
+    setScheduledTasksEnabled(true)
+  })
+  afterEach(() => {
+    resetStateForTests()
+    vi.restoreAllMocks()
+  })
+
+  test('idle: ZERO enqueues across a simulated idle window when nothing is due', async () => {
+    // One task due far in the future (hourly cron, anchored at t=0; first fire
+    // is at the top of the next hour). We start at t=1min and advance only
+    // 30min of virtual time — the task never becomes due.
+    const start = 60_000 // 00:01:00
+    const clock = new FakeClock(start)
+    const enqueue = vi.fn()
+    const sched = makeScheduler(
+      clock,
+      [task({ id: 'aaaa0001', cron: '0 * * * *' })], // top of every hour
+      enqueue,
+    )
+
+    sched.start()
+    await flush()
+
+    // 30 minutes of virtual idle time — still before the :00 fire.
+    await advanceAndFlush(clock, 30 * 60_000)
+
+    expect(enqueue).toHaveBeenCalledTimes(0)
+    // The driver is asleep with exactly one armed wake (sleep-until-next-due),
+    // not a polling interval that re-arms every slice.
+    expect(clock.pendingCount()).toBeLessThanOrEqual(1)
+  })
+
+  test('due task: exactly ONE enqueue and the next wake is rescheduled', async () => {
+    // Hourly task; start at 00:59:00 so the 01:00:00 fire (plus its forward
+    // herd-spreading jitter, bounded by recurringFrac*interval = up to ~6 min)
+    // lands within the advance window.
+    const start = 59 * 60_000 // 00:59:00
+    const clock = new FakeClock(start)
+    const enqueue = vi.fn()
+    const sched = makeScheduler(
+      clock,
+      [task({ id: 'bbbb0002', cron: '0 * * * *' })],
+      enqueue,
+    )
+
+    sched.start()
+    await flush()
+    expect(enqueue).toHaveBeenCalledTimes(0) // not yet due
+
+    // Cross the 01:00:00 boundary with margin for the recurring forward jitter
+    // window (<= ~6 min at defaults). The task fires exactly once.
+    await advanceAndFlush(clock, 12 * 60_000)
+
+    expect(enqueue).toHaveBeenCalledTimes(1)
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 'prompt-bbbb0002',
+        mode: 'task-notification',
+        isMeta: true,
+        workload: 'cron',
+      }),
+    )
+    // After firing, the next wake is rescheduled (driver re-armed), not dead.
+    const tel = sched.getLastTelemetry()
+    expect(tel).not.toBeNull()
+    // Either the post-fire reschedule armed a future wake, or telemetry shows
+    // the dispatch — in both cases the driver kept running.
+    expect(sched.isPaused()).toBe(false)
+
+    sched.stop()
+  })
+
+  test('coalesce: multiple missed occurrences collapse to a SINGLE enqueue', async () => {
+    // Per-minute task created at t=0, but the process was "asleep" until
+    // t=10min — 10 slots (00:01..00:10) are all in the past. They MUST collapse
+    // to one fire-once-now, not 10 model turns.
+    const tenMin = 10 * 60_000
+    const clock = new FakeClock(tenMin) // we wake at 00:10:00, all slots past
+    const enqueue = vi.fn()
+    const sched = makeScheduler(
+      clock,
+      [task({ id: 'cccc0003', cron: '* * * * *', createdAt: 0 })],
+      enqueue,
+    )
+
+    sched.start()
+    await flush()
+    // The initial reschedule sees a past-due task → arms a ~0ms wake. Advance a
+    // hair to fire it.
+    await advanceAndFlush(clock, 1_000)
+
+    expect(enqueue).toHaveBeenCalledTimes(1) // coalesced, NOT 10
+    const tel = sched.getLastTelemetry()
+    expect(tel?.dispatched).toBe(1)
+    // 10 past slots → 1 fired + 9 coalesced misses.
+    expect(tel?.coalescedMisses).toBeGreaterThanOrEqual(9)
+
+    sched.stop()
+  })
+
+  test('re-entrancy guard: a task whose turn is in flight does NOT start a second turn', async () => {
+    // Per-minute task; fire once (turn now "in flight" — markTurnComplete NOT
+    // called), then cross another minute boundary. The second occurrence must
+    // SKIP rather than enqueue a second, overlapping turn.
+    const clock = new FakeClock(30 * 60_000) // 00:30:00, past-due
+    const enqueue = vi.fn()
+    const sched = makeScheduler(
+      clock,
+      [task({ id: 'dddd0004', cron: '* * * * *', createdAt: 0 })],
+      enqueue,
+    )
+
+    sched.start()
+    await flush()
+    await advanceAndFlush(clock, 1_000) // first fire
+    expect(enqueue).toHaveBeenCalledTimes(1)
+
+    // Advance well past several more per-minute slots WITHOUT completing the
+    // turn. Overlap guard must hold the line at one enqueue.
+    await advanceAndFlush(clock, 5 * 60_000)
+    expect(enqueue).toHaveBeenCalledTimes(1)
+    expect(sched.getLastTelemetry()?.skippedDueToLock).toBeGreaterThanOrEqual(1)
+
+    // Now complete the turn → the lock releases → the next due slot may fire.
+    sched.markTurnComplete('dddd0004')
+    await sched.reschedule()
+    await advanceAndFlush(clock, 2 * 60_000)
+    expect(enqueue).toHaveBeenCalledTimes(2)
+
+    sched.stop()
+  })
+})


### PR DESCRIPTION
## Summary
- Token-efficient cron tick driver: idle costs zero model turns; the driver wakes only when a task is genuinely due.
- Per-task overlap lease that auto-expires after the floor interval, so recurring scheduled tasks keep firing on each cadence (the TUI drains the command queue serially and never signals turn completion back to the driver).
- Wires the real TUI command queue (`enqueuePendingNotification`) and starts the scheduler on session mount so durable tasks restored from disk actually fire.

## Bug fixed
A placeholder `if (true)` made the overlap lease never expire — a recurring task fired exactly once per process and was skipped forever after. The lease now compares against the monotonic clock and auto-releases.

## Tests
- Revert-sensitive regression test for the auto-release (goes red against the bug).
- Production queue-wiring tests.
- Full cron test suite passes (6/6); typecheck clean on touched files.