### PR TITLE
fix(runtime): pass ollama image urls through

### DIFF
--- a/runtime/src/llm/providers/ollama/adapter.ts
+++ b/runtime/src/llm/providers/ollama/adapter.ts
@@ -315,7 +315,7 @@ function parseToolCallArguments(argumentsJson: string): Record<string, unknown> 
 
 // Strips the `data:image/...;base64,` prefix from a data-URL, returning the
 // raw base64 payload. Mirrors the data-URL parsing used by the shared wire
-// helpers. Returns null for non-data-URL (e.g. remote `http(s)://`) inputs.
+// helpers. Returns null for non-data-URL inputs.
 function extractImageBase64FromDataUrl(url: string): string | null {
   const match = /^data:image\/[a-z0-9.+-]+;base64,([\s\S]+)$/iu.exec(url.trim());
   if (!match) return null;
@@ -323,11 +323,20 @@ function extractImageBase64FromDataUrl(url: string): string | null {
   return data.length > 0 ? data : null;
 }
 
+function isHttpImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Splits multimodal `LLMContentPart[]` content into the shape Ollama's chat
- * API expects: text parts joined into `content`, and base64 image payloads
- * collected into a separate `images` array (Ollama does NOT accept images
- * inside `content`).
+ * API expects: text parts joined into `content`, and SDK-supported image
+ * strings collected into a separate `images` array (Ollama does NOT accept
+ * images inside `content`).
  */
 function extractOllamaContent(parts: LLMContentPart[]): {
   content: string;
@@ -347,11 +356,12 @@ function extractOllamaContent(parts: LLMContentPart[]): {
         images.push(base64);
         continue;
       }
-      // Remote image URLs cannot be inlined as base64 here. The Ollama SDK
-      // only accepts base64 strings (or raw bytes) in `images`, not URLs.
-      // TODO: fetch remote image URLs and inline their base64 once a shared
-      // image-fetch convention exists; until then, surface a placeholder
-      // rather than silently dropping the reference.
+      if (isHttpImageUrl(url)) {
+        images.push(url.trim());
+        continue;
+      }
+      // The Ollama SDK accepts base64 strings, file paths, and remote URLs.
+      // Unknown schemes are kept as visible text rather than dropped.
       textPieces.push(`[image: ${url}]`);
     }
   }

--- a/runtime/tests/llm/providers/ollama/provider.test.ts
+++ b/runtime/tests/llm/providers/ollama/provider.test.ts
@@ -453,4 +453,84 @@ describe("providers/ollama entrypoint", () => {
     expect((message?.images as string[])[0]).not.toContain("data:image");
     expect(message?.content).not.toContain("base64,");
   });
+
+  test("passes remote HTTP image URLs through Ollama's images[] field", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      model: "llava",
+      message: { role: "assistant", content: "ok" },
+      prompt_eval_count: 4,
+      eval_count: 1,
+    });
+    const provider = new OllamaProvider({
+      model: "llava",
+      host: "http://localhost:11434",
+    });
+    setClient(provider, { chat });
+
+    const imageUrl = " https://example.test/cat.png ";
+
+    await provider.chat([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is in this image?" },
+          {
+            type: "image_url",
+            image_url: { url: imageUrl },
+          },
+        ],
+      },
+    ]);
+
+    const [params] = chat.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      messages: [
+        {
+          role: "user",
+          content: "What is in this image?",
+          images: ["https://example.test/cat.png"],
+        },
+      ],
+    });
+  });
+
+  test("keeps unsupported image URL schemes visible in Ollama text content", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      model: "llava",
+      message: { role: "assistant", content: "ok" },
+      prompt_eval_count: 4,
+      eval_count: 1,
+    });
+    const provider = new OllamaProvider({
+      model: "llava",
+      host: "http://localhost:11434",
+    });
+    setClient(provider, { chat });
+
+    await provider.chat([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is in this image?" },
+          {
+            type: "image_url",
+            image_url: { url: "file:///tmp/cat.png" },
+          },
+        ],
+      },
+    ]);
+
+    const [params] = chat.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      messages: [
+        {
+          role: "user",
+          content: "What is in this image?\n[image: file:///tmp/cat.png]",
+        },
+      ],
+    });
+    const [message] = (params as { messages: Array<Record<string, unknown>> })
+      .messages;
+    expect(message?.images).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- Pass http(s) image URLs through Ollama `images[]` instead of degrading them to text placeholders
- Keep data-URL stripping behavior for raw base64 payloads
- Preserve visible text placeholders for unsupported image URL schemes

## Verification
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/llm/providers/ollama/provider.test.ts --reporter=dot`
- `npm run typecheck`
- `npm test`
- pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke

## Workflow state
- `gh workflow list --repo tetsuo-ai/agenc-core --all`: only Transaction Guard Live is listed, and it is `disabled_manually`