### PR TITLE
feat(runtime): add agent eval report checks

### DIFF
--- a/docs/agent-eval-reports.md
+++ b/docs/agent-eval-reports.md
@@ -1,0 +1,86 @@
+# Agent Evaluation Reports
+
+AgenC can record local SWE-style evaluation results in a checked JSON shape and
+summarize them without remote CI, hosted model APIs, or benchmark-specific
+infrastructure.
+
+Schema:
+
+```text
+runtime/src/eval/agent-eval-report.schema.json
+```
+
+Validate and summarize a report:
+
+```bash
+npm --workspace=@tetsuo-ai/runtime run check:agent-eval-report -- path/to/report.json
+```
+
+Print a machine-readable summary:
+
+```bash
+npm --workspace=@tetsuo-ai/runtime run check:agent-eval-report -- path/to/report.json --json
+```
+
+Minimal report:
+
+```json
+{
+  "schemaVersion": 1,
+  "run": {
+    "id": "local-2026-06-14",
+    "benchmark": "swe-style-local-smoke",
+    "startedAt": "2026-06-14T12:00:00Z",
+    "finishedAt": "2026-06-14T12:05:00Z",
+    "agent": {
+      "name": "agenc",
+      "provider": "local",
+      "model": "vllm-compatible"
+    },
+    "environment": {
+      "repo": "tetsuo-ai/agenc-core",
+      "commit": "abc123",
+      "branch": "main",
+      "runner": "local",
+      "sandbox": "workspace",
+      "localOnly": true
+    }
+  },
+  "tasks": [
+    {
+      "id": "task-001",
+      "status": "passed",
+      "durationMs": 120000,
+      "tokens": {
+        "input": 12000,
+        "output": 3000
+      },
+      "commands": [
+        {
+          "command": "npm test",
+          "exitCode": 0,
+          "durationMs": 60000
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "unit-tests",
+          "status": "passed",
+          "command": "npm test"
+        }
+      ],
+      "patch": {
+        "changedFiles": 2,
+        "additions": 40,
+        "deletions": 10
+      }
+    }
+  ]
+}
+```
+
+The script computes attempted-task fix rate from `passed / (passed + failed +
+error)`, excluding skipped tasks. Verifier pass rate uses the same skipped-task
+exclusion. `riskFlags` are free-form strings so local harnesses can record
+benchmark-leakage, verifier-modification, deleted-test, network-use, or other
+shortcut-detection signals as they become relevant.

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -47,6 +47,7 @@
     "check:unused:all": "knip --config knip.config.mjs --no-progress",
     "check:unused:production": "knip --config knip.config.mjs --production --no-progress",
     "check:unused:report": "node scripts/check-unused-report.mjs",
+    "check:agent-eval-report": "node scripts/check-agent-eval-report.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage --maxWorkers=1",
     "test:coverage:tui": "vitest run tests/tui --coverage --coverage.provider=v8 --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.include='src/tui/**/*.{ts,tsx}' --coverage.exclude='src/**/*.d.ts' --coverage.reportsDirectory=coverage/runtime-tui",

--- a/runtime/scripts/check-agent-eval-report.mjs
+++ b/runtime/scripts/check-agent-eval-report.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv";
+
+const runtimeRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const schemaPath = path.join(
+  runtimeRoot,
+  "src",
+  "eval",
+  "agent-eval-report.schema.json",
+);
+
+function usage() {
+  return [
+    "Usage: node scripts/check-agent-eval-report.mjs <report.json> [--json]",
+    "",
+    "Validates an AgenC agent evaluation report and prints a local summary.",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  let json = false;
+  const positional = [];
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      return { help: true, json, reportPath: null };
+    }
+    if (arg?.startsWith("-")) {
+      throw new Error(`unknown option: ${arg}`);
+    }
+    if (arg) {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length !== 1) {
+    throw new Error("expected exactly one report path");
+  }
+
+  return {
+    help: false,
+    json,
+    reportPath: path.resolve(positional[0]),
+  };
+}
+
+async function readJson(filePath, label) {
+  let raw;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `failed to read ${label} at ${filePath}: ${error.message}`,
+    );
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `failed to parse ${label} at ${filePath}: ${error.message}`,
+    );
+  }
+}
+
+function compileValidator(schema) {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+  });
+  return ajv.compile(schema);
+}
+
+function formatAjvErrors(errors) {
+  return (errors ?? [])
+    .map((error) => {
+      const location = error.instancePath || "/";
+      return `- ${location}: ${error.message}`;
+    })
+    .join("\n");
+}
+
+function emptyStatusCounts() {
+  return {
+    passed: 0,
+    failed: 0,
+    error: 0,
+    skipped: 0,
+  };
+}
+
+function percent(numerator, denominator) {
+  if (denominator === 0) {
+    return 0;
+  }
+  return (numerator / denominator) * 100;
+}
+
+function tokenTotal(tokens) {
+  if (!tokens || typeof tokens !== "object") {
+    return 0;
+  }
+  if (Number.isFinite(tokens.total)) {
+    return tokens.total;
+  }
+  return (Number.isFinite(tokens.input) ? tokens.input : 0) +
+    (Number.isFinite(tokens.output) ? tokens.output : 0);
+}
+
+function summarizeReport(report) {
+  const taskCounts = emptyStatusCounts();
+  const verifierCounts = emptyStatusCounts();
+  const riskFlags = new Map();
+  let durationMs = 0;
+  let tokenCount = 0;
+  let commandCount = 0;
+  let failedCommandCount = 0;
+
+  for (const task of report.tasks) {
+    taskCounts[task.status] += 1;
+    durationMs += task.durationMs;
+    tokenCount += tokenTotal(task.tokens);
+
+    for (const command of task.commands ?? []) {
+      commandCount += 1;
+      if (
+        Number.isInteger(command.exitCode) &&
+        command.exitCode !== 0
+      ) {
+        failedCommandCount += 1;
+      }
+    }
+
+    for (const verifier of task.verifiers) {
+      verifierCounts[verifier.status] += 1;
+    }
+
+    for (const flag of task.riskFlags ?? []) {
+      riskFlags.set(flag, (riskFlags.get(flag) ?? 0) + 1);
+    }
+  }
+
+  const attemptedTasks = taskCounts.passed + taskCounts.failed + taskCounts.error;
+  const attemptedVerifiers = verifierCounts.passed +
+    verifierCounts.failed +
+    verifierCounts.error;
+
+  return {
+    schemaVersion: report.schemaVersion,
+    run: report.run,
+    tasks: {
+      total: report.tasks.length,
+      ...taskCounts,
+      attempted: attemptedTasks,
+      fixRate: percent(taskCounts.passed, attemptedTasks),
+    },
+    verifiers: {
+      total: verifierCounts.passed +
+        verifierCounts.failed +
+        verifierCounts.error +
+        verifierCounts.skipped,
+      ...verifierCounts,
+      attempted: attemptedVerifiers,
+      passRate: percent(verifierCounts.passed, attemptedVerifiers),
+    },
+    durationMs,
+    tokens: {
+      total: tokenCount,
+    },
+    commands: {
+      total: commandCount,
+      failed: failedCommandCount,
+    },
+    riskFlags: Object.fromEntries(
+      [...riskFlags.entries()].sort((a, b) => a[0].localeCompare(b[0])),
+    ),
+  };
+}
+
+function formatPercent(value) {
+  return `${value.toFixed(2)}%`;
+}
+
+function formatDuration(ms) {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatMarkdownSummary(summary) {
+  const agent = summary.run.agent;
+  const modelLabel = [agent.provider, agent.model].filter(Boolean).join("/");
+  const agentLabel = modelLabel ? `${agent.name} (${modelLabel})` : agent.name;
+  const riskEntries = Object.entries(summary.riskFlags);
+  const riskLine = riskEntries.length === 0
+    ? "Risk flags: none"
+    : `Risk flags: ${riskEntries.map(([flag, count]) => `${flag}=${count}`).join(", ")}`;
+
+  return [
+    "# Agent Eval Report",
+    "",
+    `Run: ${summary.run.id}`,
+    `Benchmark: ${summary.run.benchmark}`,
+    `Agent: ${agentLabel}`,
+    `Tasks: ${summary.tasks.total} total, ${summary.tasks.passed} passed, ${summary.tasks.failed} failed, ${summary.tasks.error} error, ${summary.tasks.skipped} skipped`,
+    `Fix rate: ${formatPercent(summary.tasks.fixRate)}`,
+    `Verifiers: ${summary.verifiers.total} total, ${summary.verifiers.passed} passed, ${summary.verifiers.failed} failed, ${summary.verifiers.error} error, ${summary.verifiers.skipped} skipped`,
+    `Verifier pass rate: ${formatPercent(summary.verifiers.passRate)}`,
+    `Tokens: ${summary.tokens.total}`,
+    `Duration: ${formatDuration(summary.durationMs)}`,
+    `Commands: ${summary.commands.total} total, ${summary.commands.failed} failed`,
+    riskLine,
+  ].join("\n");
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n\n${usage()}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  const [schema, report] = await Promise.all([
+    readJson(schemaPath, "agent eval report schema"),
+    readJson(args.reportPath, "agent eval report"),
+  ]);
+  const validate = compileValidator(schema);
+
+  if (!validate(report)) {
+    process.stderr.write(
+      `agent eval report validation failed:\n${formatAjvErrors(validate.errors)}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const summary = summarizeReport(report);
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${formatMarkdownSummary(summary)}\n`);
+}
+
+try {
+  await main();
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/runtime/src/eval/agent-eval-report.schema.json
+++ b/runtime/src/eval/agent-eval-report.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "urn:agenc:eval:agent-report",
+  "title": "AgenC Agent Evaluation Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "run", "tasks"],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "benchmark", "startedAt", "finishedAt", "agent"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "benchmark": {
+          "type": "string",
+          "minLength": 1
+        },
+        "startedAt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "finishedAt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "agent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1
+            },
+            "provider": {
+              "type": "string",
+              "minLength": 1
+            },
+            "model": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repo": {
+              "type": "string",
+              "minLength": 1
+            },
+            "commit": {
+              "type": "string",
+              "minLength": 1
+            },
+            "branch": {
+              "type": "string",
+              "minLength": 1
+            },
+            "runner": {
+              "type": "string",
+              "minLength": 1
+            },
+            "sandbox": {
+              "type": "string",
+              "minLength": 1
+            },
+            "localOnly": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/task"
+      }
+    }
+  },
+  "definitions": {
+    "status": {
+      "type": "string",
+      "enum": ["passed", "failed", "error", "skipped"]
+    },
+    "tokenUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "exitCode": {
+          "type": "integer"
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "verifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/definitions/status"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "type": "string"
+        }
+      }
+    },
+    "patchStats": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "changedFiles": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "additions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deletions": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "durationMs", "verifiers"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/definitions/status"
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "tokens": {
+          "$ref": "#/definitions/tokenUsage"
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/command"
+          }
+        },
+        "verifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/verifier"
+          }
+        },
+        "patch": {
+          "$ref": "#/definitions/patchStats"
+        },
+        "riskFlags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/runtime/tests/eval/agent-eval-report.test.ts
+++ b/runtime/tests/eval/agent-eval-report.test.ts
@@ -1,0 +1,200 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import Ajv from "ajv";
+import { describe, expect, test } from "vitest";
+import { runtimeRootPath, sourcePath } from "../helpers/source-path.ts";
+
+const scriptPath = resolve(
+  runtimeRootPath,
+  "scripts",
+  "check-agent-eval-report.mjs",
+);
+const schemaPath = sourcePath("eval", "agent-eval-report.schema.json");
+
+function writeTempReport(report: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenc-eval-report-"));
+  const reportPath = join(dir, "report.json");
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  return reportPath;
+}
+
+function validReport() {
+  return {
+    schemaVersion: 1,
+    run: {
+      id: "local-2026-06-14",
+      benchmark: "swe-style-local-smoke",
+      startedAt: "2026-06-14T12:00:00Z",
+      finishedAt: "2026-06-14T12:05:00Z",
+      agent: {
+        name: "agenc",
+        version: "0.2.0",
+        provider: "local",
+        model: "vllm-compatible",
+      },
+      environment: {
+        repo: "tetsuo-ai/agenc-core",
+        commit: "abc123",
+        branch: "main",
+        runner: "local",
+        sandbox: "workspace",
+        localOnly: true,
+      },
+    },
+    tasks: [
+      {
+        id: "task-pass",
+        source: "local",
+        title: "passing task",
+        status: "passed",
+        durationMs: 1000,
+        tokens: {
+          input: 100,
+          output: 50,
+        },
+        commands: [
+          {
+            command: "npm test",
+            exitCode: 0,
+            durationMs: 500,
+          },
+        ],
+        verifiers: [
+          {
+            name: "unit",
+            status: "passed",
+            command: "npm test",
+          },
+        ],
+        patch: {
+          changedFiles: 1,
+          additions: 10,
+          deletions: 2,
+        },
+      },
+      {
+        id: "task-fail",
+        status: "failed",
+        durationMs: 2000,
+        tokens: {
+          total: 20,
+        },
+        commands: [
+          {
+            command: "npm run typecheck",
+            exitCode: 1,
+          },
+        ],
+        verifiers: [
+          {
+            name: "typecheck",
+            status: "failed",
+            details: "type error remained",
+          },
+          {
+            name: "manual-review",
+            status: "skipped",
+          },
+        ],
+        riskFlags: ["verifier_failed"],
+      },
+      {
+        id: "task-skipped",
+        status: "skipped",
+        durationMs: 0,
+        verifiers: [],
+      },
+    ],
+  };
+}
+
+describe("agent eval report schema", () => {
+  test("validates the documented report shape", () => {
+    const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(schema);
+
+    expect(validate(validReport()), JSON.stringify(validate.errors)).toBe(true);
+  });
+});
+
+describe("check-agent-eval-report script", () => {
+  test("prints a markdown summary for a valid report", () => {
+    const reportPath = writeTempReport(validReport());
+    const result = spawnSync(process.execPath, [scriptPath, reportPath], {
+      cwd: runtimeRootPath,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("# Agent Eval Report");
+    expect(result.stdout).toContain("Run: local-2026-06-14");
+    expect(result.stdout).toContain("Fix rate: 50.00%");
+    expect(result.stdout).toContain("Verifier pass rate: 50.00%");
+    expect(result.stdout).toContain("Tokens: 170");
+    expect(result.stdout).toContain("Commands: 2 total, 1 failed");
+    expect(result.stdout).toContain("Risk flags: verifier_failed=1");
+  });
+
+  test("prints a machine-readable summary with --json", () => {
+    const reportPath = writeTempReport(validReport());
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, reportPath, "--json"],
+      {
+        cwd: runtimeRootPath,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary.tasks).toMatchObject({
+      total: 3,
+      passed: 1,
+      failed: 1,
+      skipped: 1,
+      attempted: 2,
+      fixRate: 50,
+    });
+    expect(summary.verifiers).toMatchObject({
+      total: 3,
+      passed: 1,
+      failed: 1,
+      skipped: 1,
+      attempted: 2,
+      passRate: 50,
+    });
+    expect(summary.tokens.total).toBe(170);
+  });
+
+  test("rejects invalid task status values", () => {
+    const report = validReport();
+    report.tasks[0]!.status = "flaky";
+    const reportPath = writeTempReport(report);
+    const result = spawnSync(process.execPath, [scriptPath, reportPath], {
+      cwd: runtimeRootPath,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("agent eval report validation failed");
+    expect(result.stderr).toContain("/tasks/0/status");
+    expect(result.stderr).toContain("must be equal to one of the allowed values");
+  });
+
+  test("reports usage errors without a report path", () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: runtimeRootPath,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("expected exactly one report path");
+    expect(result.stderr).toContain("Usage:");
+  });
+});


### PR DESCRIPTION
## Summary
- add a checked JSON schema for local agent evaluation reports
- add a local validator/summary script with markdown and JSON output
- document the report shape and cover validation/summary behavior with Vitest

Fixes #966

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/eval/agent-eval-report.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm test
- npm run validate:runtime