### PR TITLE
chore(runtime): clear broad unused findings

### DIFF
--- a/runtime/knip.config.mjs
+++ b/runtime/knip.config.mjs
@@ -585,11 +585,11 @@ const intentionalRemainingRuntimeIssueIgnores = {
     remainingRuntimeContractTypeFiles.map((file) => [file, ["types"]]),
   ),
 };
+const isProductionScan = process.argv.includes("--production");
 
 export default {
   $schema: "https://unpkg.com/knip@6/schema.json",
   entry: [
-    "src/index.ts!",
     "src/bin/agenc.ts!",
     "src/bin/tui-trust-prompt.tsx!",
     // Type-only shim for build-time `bun:bundle` feature flags.
@@ -600,14 +600,11 @@ export default {
     "scripts/**/*.mjs",
     "tests/**/*.{test,e2e,contract,parity}.ts",
     "tests/**/*.{test,e2e,contract,parity}.tsx",
-    "local-packages/*/src/**/*.{ts,tsx}",
   ],
   project: [
     "src/**/*.{ts,tsx,js,mjs,cjs}!",
     "scripts/**/*.mjs",
     "tests/**/*.{ts,tsx}",
-    "build.config.ts",
-    "local-packages/**/*.{ts,tsx,js,mjs,cjs}!",
   ],
   paths: {
     "bun:bundle": ["./src/build/feature.ts"],
@@ -632,10 +629,14 @@ export default {
     // TUI design smoke tests import these fixtures through the test resolver.
     "src/tui/components/v2/designBrowserMarkerFixture.ts",
     "src/tui/components/v2/designBrowserTextFixture.ts",
-    // Shared TUI test renderer imported from many tests, not production code.
-    "src/utils/staticRender.tsx",
-    "src/test-parity/**",
-    "tests/fixtures/**",
+    ...(isProductionScan
+      ? [
+          // Shared TUI test renderer imported from many tests, not production code.
+          "src/utils/staticRender.tsx",
+        ]
+      : []),
+    // Vitest aliases `bun:test` to this compatibility shim.
+    "tests/helpers/bun-test-shim.ts",
   ],
   ignoreIssues: {
     ...typecheckExcludedIssueIgnores,
@@ -655,24 +656,19 @@ export default {
   },
   ignoreBinaries: [
     "arecord",
-    "findstr",
-    "ip",
+    "cc",
+    "mkfifo",
     "pdftotext",
     "powershell.exe",
-    "ps",
     "rec",
     "rg",
     "secret-tool",
     "security",
-    "tasklist",
     "taskkill",
     "tmux",
     "wslpath",
   ],
   ignoreDependencies: [
-    // Path alias imports such as `src/foo.js` are resolved by esbuild/tsc, but
-    // Knip reports the bare alias root as a package dependency.
-    "src",
     // Optional private integration loaded only when the matching MCP server is
     // configured. It is not available from the public npm registry.
     "@ant/agenc-for-chrome-mcp",

--- a/runtime/src/tools/BashTool/sedValidation.ts
+++ b/runtime/src/tools/BashTool/sedValidation.ts
@@ -39,9 +39,8 @@ function validateFlagsAgainstAllowlist(
  * Allows: sed -n 'N' | sed -n 'N,M' with optional -E, -r, -z flags
  * Allows semicolon-separated print commands like: sed -n '1p;2p;3p'
  * File arguments are ALLOWED for this pattern
- * @internal Exported for testing
  */
-export function isLinePrintingCommand(
+function isLinePrintingCommand(
   command: string,
   expressions: string[],
 ): boolean {
@@ -123,9 +122,8 @@ export function isLinePrintingCommand(
  * - Np (print line N, where N is digits)
  * - N,Mp (print lines N through M)
  * Anything else (including w, W, e, E commands) is rejected.
- * @internal Exported for testing
  */
-export function isPrintCommand(cmd: string): boolean {
+function isPrintCommand(cmd: string): boolean {
   if (!cmd) return false
   // Single strict regex that only matches allowed print commands
   // ^(?:\d+|\d+,\d+)?p$ matches: p, 1p, 123p, 1,5p, 10,200p
@@ -302,9 +300,8 @@ export function sedCommandIsAllowedByAllowlist(
 
 /**
  * Check if a sed command has file arguments (not just stdin)
- * @internal Exported for testing
  */
-export function hasFileArgs(command: string): boolean {
+function hasFileArgs(command: string): boolean {
   const sedMatch = command.match(/^\s*sed\s+/)
   if (!sedMatch) return false
 
@@ -383,9 +380,8 @@ export function hasFileArgs(command: string): boolean {
  * @param command Full sed command
  * @returns Array of sed expressions to check for dangerous operations
  * @throws Error if parsing fails
- * @internal Exported for testing
  */
-export function extractSedExpressions(command: string): string[] {
+function extractSedExpressions(command: string): string[] {
   const expressions: string[] = []
 
   // Calculate withoutSed by trimming off the first N characters (removing 'sed ')

--- a/runtime/tests/fixtures.ts
+++ b/runtime/tests/fixtures.ts
@@ -18,14 +18,14 @@ import type {
 } from "../src/session/turn-context.js";
 import type { ToolRegistry } from "../src/tool-registry.js";
 
-export function mkFeatures(): ManagedFeatures {
+function mkFeatures(): ManagedFeatures {
   return {
     appsEnabledForAuth: () => false,
     useLegacyLandlock: () => false,
   };
 }
 
-export function mkConfig(): Config {
+function mkConfig(): Config {
   return {
     model: "test-model",
     cwd: "/tmp",
@@ -48,7 +48,7 @@ export function mkConfig(): Config {
   };
 }
 
-export function mkModelInfo(overrides?: Partial<ModelInfo>): ModelInfo {
+function mkModelInfo(overrides?: Partial<ModelInfo>): ModelInfo {
   return {
     slug: "test-model",
     effectiveContextWindowPercent: 100,
@@ -97,7 +97,7 @@ export function mkCtx(overrides?: Partial<TurnContext>): TurnContext {
   } as unknown as TurnContext;
 }
 
-export function mkSessionConfiguration(
+function mkSessionConfiguration(
   overrides?: Partial<SessionConfiguration>,
 ): SessionConfiguration {
   const base: SessionConfiguration = {
@@ -167,7 +167,7 @@ export function mkProvider(
   } as LLMProvider;
 }
 
-export function mkRegistry(): ToolRegistry {
+function mkRegistry(): ToolRegistry {
   return {
     tools: [],
     toLLMTools: () => [],

--- a/runtime/tests/helpers/source-path.ts
+++ b/runtime/tests/helpers/source-path.ts
@@ -3,7 +3,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const runtimeRootPath = fileURLToPath(new URL("../../", import.meta.url));
 export const runtimeSourceRootPath = resolve(runtimeRootPath, "src");
-export const runtimeTestsRootPath = resolve(runtimeRootPath, "tests");
 
 export function sourcePath(...parts: readonly string[]): string {
   return resolve(runtimeSourceRootPath, ...parts);
@@ -12,4 +11,3 @@ export function sourcePath(...parts: readonly string[]): string {
 export function sourceUrl(...parts: readonly string[]): URL {
   return pathToFileURL(sourcePath(...parts));
 }
-


### PR DESCRIPTION
## Summary
- tighten the broad Knip scan so stale entries and config hints are gone
- keep the test-only static renderer ignored only for production scans
- make private test and sed-validation helpers non-exported

Closes #972.

## Verification
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/BashTool/sedValidation.test.ts tests/phases/post-sample-recovery.token-budget-cap.test.ts tests/phases/post-sample-recovery.compact-contract.test.ts tests/session/run-turn.compact-contract.test.ts tests/slash-compact.contract.test.ts tests/runtime-session.compact-contract.test.ts tests/run-turn.compact-suspension-guard.ihunt.test.ts --reporter=dot
- npm test
- pre-commit hook: npm run build && npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup