### PR TITLE
chore(runtime): refresh selected runtime dependencies

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -77,7 +77,7 @@
     "ollama": "^0.6.3",
     "openai": "^6.27.0",
     "quickjs-emscripten": "^0.32.0",
-    "sharp": "^0.34.5"
+    "sharp": "^0.35.1"
   },
   "overrides": {
     "rollup": "^4.59.0",
@@ -85,15 +85,15 @@
   },
   "dependencies": {
     "@alcalzone/ansi-tokenize": "0.3.0",
-    "@anthropic-ai/sandbox-runtime": "0.0.46",
-    "@anthropic-ai/sdk": "^0.97.0",
+    "@anthropic-ai/sandbox-runtime": "0.0.54",
+    "@anthropic-ai/sdk": "^0.104.1",
     "@codemirror/state": "^6.6.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@msgpack/msgpack": "^3.1.3",
     "@opentelemetry/api": "1.9.1",
-    "@opentelemetry/api-logs": "0.214.0",
-    "@opentelemetry/sdk-logs": "0.214.0",
-    "@opentelemetry/sdk-metrics": "2.6.1",
+    "@opentelemetry/api-logs": "0.219.0",
+    "@opentelemetry/sdk-logs": "0.219.0",
+    "@opentelemetry/sdk-metrics": "2.8.0",
     "@shikijs/cli": "^4.1.0",
     "ajv": "^8.20.0",
     "auto-bind": "^5.0.1",
@@ -119,7 +119,7 @@
     "js-yaml": "^4.1.0",
     "jsonc-parser": "3.3.1",
     "lodash-es": "^4.17.21",
-    "lru-cache": "11.2.7",
+    "lru-cache": "11.5.1",
     "marked": "^15.0.12",
     "node-pty": "1.1.0",
     "p-map": "7.0.4",

--- a/runtime/src/services/api/anthropic.ts
+++ b/runtime/src/services/api/anthropic.ts
@@ -2718,6 +2718,8 @@ export function updateUsage(
         ? partUsage.cache_read_input_tokens
         : usage.cache_read_input_tokens,
     output_tokens: partUsage.output_tokens ?? usage.output_tokens,
+    output_tokens_details:
+      partUsage.output_tokens_details ?? usage.output_tokens_details,
     server_tool_use: {
       web_search_requests:
         partUsage.server_tool_use?.web_search_requests ??
@@ -2776,6 +2778,11 @@ export function accumulateUsage(
     cache_read_input_tokens:
       totalUsage.cache_read_input_tokens + messageUsage.cache_read_input_tokens,
     output_tokens: totalUsage.output_tokens + messageUsage.output_tokens,
+    output_tokens_details: {
+      thinking_tokens:
+        totalUsage.output_tokens_details.thinking_tokens +
+        messageUsage.output_tokens_details.thinking_tokens,
+    },
     server_tool_use: {
       web_search_requests:
         totalUsage.server_tool_use.web_search_requests +

--- a/runtime/src/services/api/emptyUsage.ts
+++ b/runtime/src/services/api/emptyUsage.ts
@@ -9,6 +9,7 @@ export const EMPTY_USAGE: Readonly<NonNullableUsage> = {
   cache_creation_input_tokens: 0,
   cache_read_input_tokens: 0,
   output_tokens: 0,
+  output_tokens_details: { thinking_tokens: 0 },
   server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
   service_tier: 'standard',
   cache_creation: {

--- a/runtime/src/tools/AgentTool/agentToolUtils.ts
+++ b/runtime/src/tools/AgentTool/agentToolUtils.ts
@@ -236,6 +236,11 @@ export const agentToolResultSchema = lazySchema(() =>
     usage: z.object({
       input_tokens: z.number(),
       output_tokens: z.number(),
+      output_tokens_details: z
+        .object({
+          thinking_tokens: z.number(),
+        })
+        .nullable(),
       cache_creation_input_tokens: z.number().nullable(),
       cache_read_input_tokens: z.number().nullable(),
       server_tool_use: z

--- a/runtime/src/utils/messages.ts
+++ b/runtime/src/utils/messages.ts
@@ -388,6 +388,7 @@ function baseCreateAssistantMessage({
   usage = {
     input_tokens: 0,
     output_tokens: 0,
+    output_tokens_details: null,
     cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
     server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },

--- a/runtime/tests/services/api/anthropic-core.test.ts
+++ b/runtime/tests/services/api/anthropic-core.test.ts
@@ -35,6 +35,9 @@ const harness = vi.hoisted(() => {
     cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
     output_tokens: 0,
+    output_tokens_details: {
+      thinking_tokens: 0,
+    },
     server_tool_use: {
       web_search_requests: 0,
       web_fetch_requests: 0,
@@ -575,6 +578,9 @@ describe('provider API core helpers', () => {
       cache_creation_input_tokens: 13,
       cache_read_input_tokens: 11,
       output_tokens: 2,
+      output_tokens_details: {
+        thinking_tokens: 1,
+      },
       server_tool_use: {
         web_search_requests: 1,
         web_fetch_requests: 4,
@@ -593,6 +599,9 @@ describe('provider API core helpers', () => {
         cache_creation_input_tokens: 0,
         cache_read_input_tokens: null,
         output_tokens: 9,
+        output_tokens_details: {
+          thinking_tokens: 6,
+        },
         server_tool_use: {
           web_search_requests: 3,
         },
@@ -607,6 +616,9 @@ describe('provider API core helpers', () => {
       cache_creation_input_tokens: 13,
       cache_read_input_tokens: 11,
       output_tokens: 9,
+      output_tokens_details: {
+        thinking_tokens: 6,
+      },
       server_tool_use: {
         web_search_requests: 3,
         web_fetch_requests: 4,
@@ -627,6 +639,9 @@ describe('provider API core helpers', () => {
       cache_creation_input_tokens: 2,
       cache_read_input_tokens: 3,
       output_tokens: 4,
+      output_tokens_details: {
+        thinking_tokens: 1,
+      },
       server_tool_use: {
         web_search_requests: 5,
         web_fetch_requests: 6,
@@ -646,6 +661,9 @@ describe('provider API core helpers', () => {
       cache_creation_input_tokens: 20,
       cache_read_input_tokens: 30,
       output_tokens: 40,
+      output_tokens_details: {
+        thinking_tokens: 9,
+      },
       server_tool_use: {
         web_search_requests: 50,
         web_fetch_requests: 60,
@@ -665,6 +683,9 @@ describe('provider API core helpers', () => {
       cache_creation_input_tokens: 22,
       cache_read_input_tokens: 33,
       output_tokens: 44,
+      output_tokens_details: {
+        thinking_tokens: 10,
+      },
       server_tool_use: {
         web_search_requests: 55,
         web_fetch_requests: 66,


### PR DESCRIPTION
## Summary
- refresh selected runtime dependencies with compatible engines and direct local coverage
- adapt Anthropic SDK usage handling for the new `output_tokens_details.thinking_tokens` telemetry field
- add usage merge/accumulation coverage for the new SDK field

Closes #974.

## Notes
The remaining `npm outdated --workspace=@tetsuo-ai/runtime --depth=0` entries are major-version moves (`chokidar`, `env-paths`, `https-proxy-agent`, `marked`, `type-fest`, `typescript`, `undici`, `vscode-jsonrpc`, `wrap-ansi`) and should be handled separately.

## Verification
- npm install
- npm ls @anthropic-ai/sdk @anthropic-ai/sandbox-runtime @opentelemetry/api-logs @opentelemetry/sdk-logs @opentelemetry/sdk-metrics lru-cache sharp --workspaces --all
- npm audit --workspaces
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/services/api/anthropic-core.test.ts tests/services/api/withRetry.test.ts tests/services/api/errors.openaiCompatibility.test.ts tests/test-parity/upstream/security-hardening.test.ts tests/tools/WebFetchTool/readBodyCapped.test.ts tests/tools/WebFetchTool/domainCheck.test.ts tests/tui/components/markdown/markdown-rendering.test.tsx tests/tui/components/markdown/MarkdownTable.wave200-070.coverage.test.tsx --reporter=dot
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- pre-commit hook: npm run build && npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup