### PR TITLE
chore(runtime): update lsp jsonrpc dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -136,7 +136,7 @@
     "turndown": "^7.2.4",
     "undici": "^7.22.0",
     "usehooks-ts": "^3.1.1",
-    "vscode-jsonrpc": "8.2.0",
+    "vscode-jsonrpc": "9.0.0",
     "vscode-languageserver-types": "^3.17.5",
     "wrap-ansi": "^9.0.2",
     "ws": "^8.18.0",

--- a/runtime/src/services/lsp/LSPClient.ts
+++ b/runtime/src/services/lsp/LSPClient.ts
@@ -12,11 +12,12 @@ import { spawn, type ChildProcess } from "node:child_process";
 
 import {
   createMessageConnection,
+  type HandlerResult,
   type MessageConnection,
   StreamMessageReader,
   StreamMessageWriter,
   Trace,
-} from "vscode-jsonrpc/node.js";
+} from "vscode-jsonrpc/node";
 
 import type {
   InitializeParams,
@@ -103,7 +104,7 @@ export function createLSPClient(
   }> = [];
   const requestHandlers: Array<{
     readonly method: string;
-    readonly handler: (params: unknown) => unknown | Promise<unknown>;
+    readonly handler: (params: unknown) => HandlerResult<unknown, unknown>;
   }> = [];
 
   const diagnostic = (message: string): void => {
@@ -207,9 +208,16 @@ export function createLSPClient(
       connection.onNotification(method, handler);
     }
     for (const { method, handler } of requestHandlers) {
-      connection.onRequest(method, handler);
+      connection.onRequest<unknown, unknown>(method, handler);
     }
   };
+
+  function requestHandler<TParams, TResult>(
+    handler: (params: TParams) => TResult | Promise<TResult>,
+  ): (params: unknown) => HandlerResult<TResult, unknown> {
+    return (params: unknown) =>
+      handler(params as TParams) as HandlerResult<TResult, unknown>;
+  }
 
   return {
     get capabilities(): ServerCapabilities | undefined {
@@ -378,15 +386,16 @@ export function createLSPClient(
       method: string,
       handler: (params: TParams) => TResult | Promise<TResult>,
     ): void {
+      const wrapped = requestHandler(handler);
       requestHandlers.push({
         method,
-        handler: handler as (params: unknown) => unknown | Promise<unknown>,
+        handler: wrapped as (params: unknown) => HandlerResult<unknown, unknown>,
       });
       if (!connection) {
         return;
       }
       assertStarted();
-      connection.onRequest(method, handler);
+      connection.onRequest<TResult, unknown>(method, wrapped);
     },
 
     async stop(): Promise<void> {


### PR DESCRIPTION
## Summary
- update `vscode-jsonrpc` to 9.0.0
- switch the LSP client to the v9 `vscode-jsonrpc/node` export
- adapt request handler registration to v9’s tightened `HandlerResult` generic contract

Closes #976.

## Verification
- npm install
- npm ls vscode-jsonrpc --workspaces --all
- npm audit --workspaces
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/services/lsp/LSPClient.test.ts tests/services/lsp/LSPServerInstance.test.ts tests/services/lsp/LSPDiagnosticRegistry.test.ts tests/services/lsp/manager.test.ts tests/services/lsp/LSPServerManager.test.ts tests/services/lsp/config.test.ts tests/services/lsp/passiveFeedback.test.ts tests/services/diagnosticTracking.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-lsp-bridge.contract.test.ts --reporter=dot
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- pre-commit hook: npm run build && npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup

Note: one initial startup-smoke run failed while `npm run build` was running in parallel and replacing `dist` chunks; rerunning after build completed passed.