### PR TITLE
chore(runtime): update env-paths dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -107,7 +107,7 @@
     "diff": "^9.0.0",
     "duck-duck-scrape": "^2.2.7",
     "emoji-regex": "^10.6.0",
-    "env-paths": "3.0.0",
+    "env-paths": "^4.0.0",
     "execa": "9.6.1",
     "figures": "6.1.0",
     "fuse.js": "^7.1.0",


### PR DESCRIPTION
## Summary
- Update `env-paths` to v4
- Verify the default `agenc-cli` cache path shape remains unchanged from v3

Closes #980

## Validation
- `npm run typecheck`
- Direct runtime import check for `env-paths("agenc-cli")`
- v3/v4 path comparison for `env-paths("agenc-cli")`
- `npm test`
- `npm run build`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- `npm audit --workspaces`