### PR TITLE
chore(runtime): update marked dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -120,7 +120,7 @@
     "jsonc-parser": "3.3.1",
     "lodash-es": "^4.17.21",
     "lru-cache": "11.5.1",
-    "marked": "^15.0.12",
+    "marked": "^18.0.5",
     "node-pty": "1.1.0",
     "p-map": "7.0.4",
     "performant-array-to-tree": "^1.11.0",


### PR DESCRIPTION
## Summary
- Update `marked` to v18
- Validate TUI markdown rendering and AGENTS.md memory parsing against the new lexer/types

Closes #982

## Validation
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/markdown/markdown-rendering.test.tsx tests/tui/components/markdown/MarkdownTable.wave200-070.coverage.test.tsx tests/tui/coverage-swarm/swarm-122-components-markdown-MarkdownTable.test.tsx tests/tui/coverage-swarm/swarm-045-components-markdown-Markdown.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/memory/index.test.ts tests/memory/memdir.test.ts tests/memory/project-memory.test.ts tests/memory/scan.test.ts tests/memdir/memory.contract.test.ts --reporter=dot`
- `npm test`
- `npm run build`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- `npm audit --workspaces`