### PR TITLE
chore(runtime): update chokidar dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -101,7 +101,7 @@
     "better-sqlite3": "^12.9.0",
     "bidi-js": "^1.0.3",
     "chalk": "^5.6.2",
-    "chokidar": "^4.0.3",
+    "chokidar": "^5.0.0",
     "cli-boxes": "^4.0.1",
     "cli-highlight": "^2.1.11",
     "diff": "^9.0.0",


### PR DESCRIPTION
## Summary
- update runtime chokidar dependency from v4 to v5
- verify existing default/named import watcher usage remains compatible

Fixes #984

## Test plan
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/keybindings/loadUserBindings.test.ts tests/tui/keybindings/loadUserBindings.wave200-137.coverage.test.ts tests/tui/coverage-swarm/swarm-081-keybindings-loadUserBindings.test.ts --reporter=dot
- node --input-type=module -e "import chokidar, { watch } from 'chokidar'; const watcher = watch([], { ignoreInitial: true }); console.log(typeof chokidar.watch, typeof watch, typeof watcher.on, typeof watcher.close); await watcher.close();"
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- npm audit --workspaces