### PR TITLE
chore(runtime): update https proxy agent

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -113,7 +113,7 @@
     "fuse.js": "^7.1.0",
     "get-east-asian-width": "^1.5.0",
     "globby": "^16.2.0",
-    "https-proxy-agent": "7.0.6",
+    "https-proxy-agent": "^9.1.0",
     "ignore": "7.0.5",
     "indent-string": "^5.0.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary
- update runtime https-proxy-agent dependency from v7 to v9
- verify the existing proxy helper construction and option pattern remain compatible

Fixes #986

## Test plan
- npm run typecheck
- node --input-type=module -e "import { HttpsProxyAgent } from 'https-proxy-agent'; const agent = new HttpsProxyAgent('http://127.0.0.1:3128', { rejectUnauthorized: false, lookup: (hostname, options, callback) => callback(null, hostname, 4) }); console.log(typeof HttpsProxyAgent, typeof agent.addRequest, agent.proxy.protocol); agent.destroy();"
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/services/api/fetchWithProxyRetry.test.ts tests/services/mcp/client-sdk-setup.test.ts --reporter=dot
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- npm audit --workspaces