### PR TITLE
chore(runtime): update undici dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -81,7 +81,7 @@
   },
   "overrides": {
     "rollup": "^4.59.0",
-    "undici": "^7.22.0"
+    "undici": "^8.4.1"
   },
   "dependencies": {
     "@alcalzone/ansi-tokenize": "0.3.0",
@@ -134,7 +134,7 @@
     "strip-ansi": "^7.2.0",
     "tree-kill": "^1.2.2",
     "turndown": "^7.2.4",
-    "undici": "^7.22.0",
+    "undici": "^8.4.1",
     "usehooks-ts": "^3.1.1",
     "vscode-jsonrpc": "9.0.0",
     "vscode-languageserver-types": "^3.17.5",


### PR DESCRIPTION
## Summary
- update runtime undici dependency and override from v7 to v8
- verify existing Agent, EnvHttpProxyAgent, dispatcher, proxy, and mTLS option surfaces remain compatible

Fixes #988

## Test plan
- npm run typecheck
- node --input-type=module import/construction check for Agent and EnvHttpProxyAgent
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tools/WebFetchTool/readBodyCapped.test.ts tests/tools/WebFetchTool/domainCheck.test.ts tests/tools/WebFetchTool/applyPromptFallback.test.ts tests/services/mcp/client-sdk-setup.test.ts --reporter=dot
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- npm audit --workspaces
- npm outdated --workspace=@tetsuo-ai/runtime --json
