### PR TITLE
chore(runtime): migrate to TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -155,7 +155,7 @@
     "esbuild": "0.28.1",
     "knip": "^6.14.1",
     "type-fest": "^5.7.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/runtime/tsconfig.json
+++ b/runtime/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "jsx": "react-jsx",
     "lib": ["ES2023"],
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -20,7 +21,6 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "bun:bundle": ["./src/build/feature.ts"],
       "src/*": ["./src/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
+    "types": ["node"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- update root and runtime TypeScript dev dependencies to 6.0.3
- add explicit Node ambient types for TypeScript 6
- remove the deprecated runtime baseUrl setting while preserving paths

Closes #990

## Validation
- npm run typecheck
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --workspaces
- npm outdated --json
- npm run test:bun

## Notes
- Exploratory `check:e2e-all` is not green in this environment: daemon protocol scenarios passed, but the LLM pipeline defaults to the user xAI key unless isolated; with isolated local Ollama `llama4:latest`, 5/7 pipeline scenarios passed and the remaining failures are runner/model-behavior follow-up items.