### PR TITLE
fix(runtime): make e2e gates deterministic locally

### DIFF
--- a/runtime/build.config.ts
+++ b/runtime/build.config.ts
@@ -12,6 +12,7 @@ const entry = [
   'src/bin/tui-trust-prompt.tsx',
   'src/sandbox/linux-launcher/main.ts',
   'src/tui/main.tsx',
+  'src/tui/pending-resume.ts',
 ];
 
 const runtimeRoot =
@@ -472,6 +473,14 @@ const external = [
   'sharp',
   'yaml',
   '@mendable/firecrawl-js',
+  // Keep the TUI renderer stack on one runtime React singleton. The moved-source
+  // resolver externalizes some TUI React imports; bundling the reconciler or
+  // hook helpers alongside them creates split dispatchers and invalid hook calls.
+  'react',
+  'react-compiler-runtime',
+  'react-reconciler',
+  'scheduler',
+  'usehooks-ts',
 ];
 
 export default defineConfig({
@@ -523,5 +532,6 @@ export default defineConfig({
       '.md': 'text',
       '.txt': 'text',
     };
+    options.jsx = 'automatic';
   },
 });

--- a/runtime/scripts/check-daemon-errors/runner.mjs
+++ b/runtime/scripts/check-daemon-errors/runner.mjs
@@ -21,12 +21,17 @@
  * means a daemon protocol regression doesn't get blamed on a TUI flake.
  */
 import { connect } from "node:net";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SOCKET_PATH = path.join(homedir(), ".agenc", "daemon.sock");
 const COOKIE_PATH = path.join(homedir(), ".agenc", "daemon.cookie");
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..");
+const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
 const PROTOCOL_VERSION = "1.0.0";
 
 const COLORS = {
@@ -41,6 +46,29 @@ const color = (c, s) => (process.stdout.isTTY ? `${COLORS[c]}${s}${COLORS.reset}
 
 function readCookie() {
   return readFileSync(COOKIE_PATH, "utf8").trim();
+}
+
+function daemonStatusOk() {
+  const result = spawnSync(
+    process.execPath,
+    [BIN_AGENC, "daemon", "status"],
+    { encoding: "utf8", timeout: 5_000 },
+  );
+  return result.status === 0 && existsSync(SOCKET_PATH);
+}
+
+function ensureDaemonReady() {
+  if (daemonStatusOk()) return true;
+  spawnSync(
+    process.execPath,
+    [BIN_AGENC, "daemon", "start"],
+    { encoding: "utf8", timeout: 20_000 },
+  );
+  for (let i = 0; i < 60; i += 1) {
+    if (daemonStatusOk()) return true;
+    spawnSync("sleep", ["0.25"]);
+  }
+  return false;
 }
 
 /**
@@ -433,6 +461,13 @@ scenarios.push({
 
 async function main() {
   console.log(color("bold", `agenc daemon protocol-error gate (${scenarios.length} scenarios)`));
+  process.stdout.write(color("dim", "  ensuring daemon is ready ... "));
+  const daemonReady = ensureDaemonReady();
+  console.log(color("dim", daemonReady ? "ok" : "failed"));
+  if (!daemonReady) {
+    console.error(color("red", "fatal: default daemon is not reachable"));
+    process.exit(1);
+  }
   console.log("");
 
   const failed = [];

--- a/runtime/scripts/check-llm-pipeline/runner.mjs
+++ b/runtime/scripts/check-llm-pipeline/runner.mjs
@@ -8,31 +8,35 @@
  * delivered first, tool-call payloads have the expected structure,
  * token tracking fires, and compaction is wired correctly.
  *
- * Architecture: spawn a fresh `agenc -p '<prompt>'` (one-shot daemon
- * agent), wait for completion, then parse the rollout file the daemon
- * wrote to `~/.agenc/projects/<project>/sessions/<sid>/rollout-*.jsonl`.
+ * Architecture: start a local OpenAI-compatible mock model server,
+ * spawn a fresh `agenc -p '<prompt>'` (one-shot daemon agent) against
+ * an isolated HOME/AGENC_HOME, wait for completion, then parse the
+ * rollout file the daemon wrote to
+ * `~/.agenc/projects/<project>/sessions/<sid>/rollout-*.jsonl`.
  * The rollout is the daemon's authoritative record of every event in
  * the conversation, including tool calls with their full id/name/
- * arguments shape and the assembled message order. Pure offline
- * inspection — no PTY required.
- *
- * Why not vllm logs? VLLM's stdout only logs HTTP status (it
- * intentionally doesn't capture request bodies for privacy). The
- * daemon-side rollout has the same data the daemon sent to vllm,
- * just one layer up.
+ * arguments shape and the assembled message order.
  */
 import { mkdir, mkdtemp, readFile, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  MOCK_MODEL,
+  buildMockProviderEnv,
+  startMockModelServer,
+} from "../local-openai-compatible-mock.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..");
 const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-const PROJECTS_DIR = path.join(homedir(), ".agenc", "projects");
-const TRUST_FILE = path.join(homedir(), ".agenc", "trusted-projects.json");
+let pipelineHome = homedir();
+let agencHome = path.join(pipelineHome, ".agenc");
+let projectsDir = path.join(agencHome, "projects");
+let trustFile = path.join(agencHome, "trusted-projects.json");
 let pipelineCwd = process.cwd();
+let runnerEnv = process.env;
 
 const COLORS = {
   reset: "\x1b[0m",
@@ -46,11 +50,26 @@ const color = (c, s) => (process.stdout.isTTY ? `${COLORS[c]}${s}${COLORS.reset}
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+function configurePipelineHome(home) {
+  pipelineHome = home;
+  agencHome = path.join(home, ".agenc");
+  projectsDir = path.join(agencHome, "projects");
+  trustFile = path.join(agencHome, "trusted-projects.json");
+}
+
+function buildRunnerEnv(baseUrl) {
+  return buildMockProviderEnv(baseUrl, {
+    ...process.env,
+    HOME: pipelineHome,
+    AGENC_HOME: agencHome,
+  });
+}
+
 async function ensureProjectTrusted(projectPath) {
-  await mkdir(path.dirname(TRUST_FILE), { recursive: true });
+  await mkdir(path.dirname(trustFile), { recursive: true });
   let trust = { version: 1, trustedProjects: [] };
   try {
-    const raw = await readFile(TRUST_FILE, "utf8");
+    const raw = await readFile(trustFile, "utf8");
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object" && Array.isArray(parsed.trustedProjects)) {
       trust = parsed;
@@ -79,7 +98,7 @@ async function ensureProjectTrusted(projectPath) {
     }
   }
   if (mutated) {
-    await writeFile(TRUST_FILE, JSON.stringify(trust, null, 2), "utf8");
+    await writeFile(trustFile, JSON.stringify(trust, null, 2), "utf8");
   }
 }
 
@@ -100,7 +119,7 @@ async function runOneShot(prompt, { yolo = false, timeoutMs = 120_000 } = {}) {
     args.push("-p", prompt);
     const child = spawn(process.execPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
+      env: runnerEnv,
       cwd: pipelineCwd,
     });
     let stdout = "";
@@ -125,9 +144,9 @@ async function readMostRecentRollout({ sinceMs = 30_000 } = {}) {
   let newest = null;
   let newestMtime = 0;
   // Walk projects → sessions → rollout-*.jsonl.
-  const projects = await readdir(PROJECTS_DIR);
+  const projects = await readdir(projectsDir);
   for (const proj of projects) {
-    const sessionsDir = path.join(PROJECTS_DIR, proj, "sessions");
+    const sessionsDir = path.join(projectsDir, proj, "sessions");
     let sessions;
     try {
       sessions = await readdir(sessionsDir);
@@ -163,6 +182,26 @@ async function readMostRecentRollout({ sinceMs = 30_000 } = {}) {
   const raw = await readFile(newest, "utf8");
   const lines = raw.split("\n").filter((l) => l.trim().length > 0);
   return { path: newest, items: lines.map((l) => JSON.parse(l)) };
+}
+
+async function stopPipelineDaemon() {
+  await new Promise((resolve) => {
+    const child = spawn(process.execPath, [BIN_AGENC, "daemon", "stop"], {
+      stdio: "ignore",
+      env: runnerEnv,
+      cwd: pipelineCwd,
+    });
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve();
+    }, 10_000);
+    const done = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    child.on("close", done);
+    child.on("error", done);
+  });
 }
 
 /* -------------------------------------------------------------------- */
@@ -212,11 +251,7 @@ scenarios.push({
     const { items } = await readMostRecentRollout();
     const turnIdx = items.findIndex((i) => i.type === "turn_context");
     const userIdx = items.findIndex(
-      (i) =>
-        (i.type === "event_msg" &&
-          i.payload?.msg?.type === "user_message") ||
-        (i.type === "response_item" &&
-          i.payload?.role === "user"),
+      (i) => i.type === "response_item" && i.payload?.role === "user",
     );
     if (turnIdx === -1) {
       throw new Error("rollout has no turn_context entry");
@@ -399,26 +434,36 @@ scenarios.push({
 /* -------------------------------------------------------------------- */
 
 async function main() {
+  const mockServer = await startMockModelServer();
+  const isolatedHome = await mkdtemp(path.join(tmpdir(), "agenc-llm-pipeline-home-"));
+  configurePipelineHome(isolatedHome);
+  runnerEnv = buildRunnerEnv(mockServer.baseUrl);
   pipelineCwd = await preparePipelineWorkspace();
   console.log(color("bold", `agenc LLM pipeline gate (${scenarios.length} scenarios)`));
   console.log(color("dim", `  cwd: ${pipelineCwd}`));
+  console.log(color("dim", `  model: openai-compatible:${MOCK_MODEL} (${mockServer.baseUrl})`));
   console.log("");
   let passed = 0;
   const failed = [];
-  for (const sc of scenarios) {
-    process.stdout.write(`  ${color("dim", "→")} ${sc.name} … `);
-    const startedAt = Date.now();
-    try {
-      await sc.run();
-      const dur = Date.now() - startedAt;
-      passed += 1;
-      console.log(`${color("green", "PASS")} ${color("dim", `(${dur}ms)`)}`);
-    } catch (error) {
-      const dur = Date.now() - startedAt;
-      console.log(`${color("red", "FAIL")} ${color("dim", `(${dur}ms)`)}`);
-      console.log(`      ${color("red", "✗")} ${error.message}`);
-      failed.push({ name: sc.name, error });
+  try {
+    for (const sc of scenarios) {
+      process.stdout.write(`  ${color("dim", "→")} ${sc.name} … `);
+      const startedAt = Date.now();
+      try {
+        await sc.run();
+        const dur = Date.now() - startedAt;
+        passed += 1;
+        console.log(`${color("green", "PASS")} ${color("dim", `(${dur}ms)`)}`);
+      } catch (error) {
+        const dur = Date.now() - startedAt;
+        console.log(`${color("red", "FAIL")} ${color("dim", `(${dur}ms)`)}`);
+        console.log(`      ${color("red", "✗")} ${error.message}`);
+        failed.push({ name: sc.name, error });
+      }
     }
+  } finally {
+    await stopPipelineDaemon();
+    await mockServer.close();
   }
   console.log("");
   if (failed.length === 0) {

--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -107,7 +107,7 @@ async function ensureProjectTrusted(projectPath) {
  * fresh), permission policy, session state. Anything else should be
  * stateless across daemon spawns.
  */
-async function createTempHome() {
+export async function createTempHome() {
   const home = await mkdtemp(path.join(tmpdir(), "agenc-tui-e2e-home-"));
   const agencDir = path.join(home, ".agenc");
   await mkdir(agencDir, { recursive: true });
@@ -159,7 +159,7 @@ async function createTempHome() {
  * directory tree. Best-effort; failures are logged but don't block the
  * scenario teardown.
  */
-async function teardownTempHome(home) {
+export async function teardownTempHome(home) {
   if (!home) return;
   try {
     spawnSync(
@@ -175,6 +175,18 @@ async function teardownTempHome(home) {
   } catch {
     // best-effort
   }
+}
+
+export async function trustProjectForHome(home, projectPath) {
+  const tempTrust = path.join(home, ".agenc", "trusted-projects.json");
+  await writeFile(
+    tempTrust,
+    JSON.stringify({
+      version: 1,
+      trustedProjects: [{ path: projectPath, trustedAt: new Date().toISOString() }],
+    }, null, 2),
+    "utf8",
+  );
 }
 
 async function walkFiles(dir) {
@@ -228,6 +240,8 @@ async function readRolloutItemsForHome(home) {
 // not reply, the renderer hangs waiting on those.
 const XTVERSION_REPLY = "\x1bP>|xterm 370\x1b\\";
 const DA1_REPLY = "\x1b[?65;6;9;15;18;21;22;28c";
+const XTVERSION_QUERY = "\x1b[>0q";
+const DA1_QUERY = "\x1b[c";
 
 // Crash patterns that make a scenario fail regardless of explicit assertions.
 // Anything that looks like a Node.js uncaught exception or unresolved
@@ -545,14 +559,18 @@ export class TuiSession {
     });
     this.term.onData((data) => {
       this.buffer += data;
+      if (data.includes(XTVERSION_QUERY)) {
+        this.term.write(XTVERSION_REPLY);
+      }
+      if (data.includes(DA1_QUERY)) {
+        this.term.write(DA1_REPLY);
+      }
     });
     this.term.onExit(({ exitCode, signal }) => {
       this.exited = true;
       this.exitInfo = { exitCode, signal };
     });
     await sleep(firstPaintMs);
-    this.term.write(XTVERSION_REPLY);
-    this.term.write(DA1_REPLY);
     await sleep(postReplyMs);
   }
 

--- a/runtime/scripts/check-tui-e2e/runner.mjs
+++ b/runtime/scripts/check-tui-e2e/runner.mjs
@@ -10,16 +10,59 @@
  * temp-HOME isolation and enable parallel execution.
  */
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { readdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { TuiSession } from "./harness.mjs";
+import {
+  MOCK_MODEL,
+  buildMockProviderEnv,
+  startMockModelServer,
+} from "../local-openai-compatible-mock.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCENARIOS_DIR = path.join(SCRIPT_DIR, "scenarios");
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..");
 const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
+const DEFAULT_DAEMON_SOCKET = path.join(
+  process.env.AGENC_HOME ?? path.join(homedir(), ".agenc"),
+  "daemon.sock",
+);
 const DEFAULT_TIMEOUT_MS = 60_000;
+const PROVIDER_ENV_KEYS = [
+  "XAI_API_KEY",
+  "GROK_API_KEY",
+  "AGENC_XAI_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_MODEL",
+  "AGENC_PROVIDER",
+  "AGENC_MODEL",
+  "OPENAI_COMPATIBLE_MODEL",
+  "OPENAI_COMPATIBLE_BASE_URL",
+  "OPENAI_COMPATIBLE_API_KEY",
+  "API_TIMEOUT_MS",
+  "AGENC_AUTH_MANAGED_KEYS_ENABLED",
+];
+
+function applyProcessEnv(nextEnv) {
+  for (const key of PROVIDER_ENV_KEYS) {
+    if (!(key in nextEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, nextEnv);
+}
+
+function restoreProcessEnv(originalEnv) {
+  for (const key of PROVIDER_ENV_KEYS) {
+    if (key in originalEnv) {
+      process.env[key] = originalEnv[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+}
 
 /**
  * Restart the user's daemon so each gate run starts from a clean session
@@ -29,12 +72,31 @@ const DEFAULT_TIMEOUT_MS = 60_000;
  * the daemon's session/permission state has drifted.
  */
 function restartDaemon() {
+  spawnSync(
+    process.execPath,
+    [BIN_AGENC, "daemon", "stop"],
+    { encoding: "utf8", timeout: 15_000 },
+  );
+  let stopped = false;
+  for (let i = 0; i < 60; i += 1) {
+    if (!isDefaultDaemonAlive()) {
+      stopped = true;
+      break;
+    }
+    spawnSync("sleep", ["0.25"]);
+  }
+  if (!stopped) return false;
   const result = spawnSync(
     process.execPath,
-    [BIN_AGENC, "daemon", "restart"],
+    [BIN_AGENC, "daemon", "start"],
     { encoding: "utf8", timeout: 30_000 },
   );
-  return result.status === 0;
+  if (result.status !== 0 && !isDefaultDaemonAlive()) return false;
+  for (let i = 0; i < 60; i += 1) {
+    if (isDefaultDaemonAlive()) return true;
+    spawnSync("sleep", ["0.25"]);
+  }
+  return false;
 }
 
 /**
@@ -51,7 +113,7 @@ function isDefaultDaemonAlive() {
     [BIN_AGENC, "daemon", "status"],
     { encoding: "utf8", timeout: 5_000 },
   );
-  return result.status === 0;
+  return result.status === 0 && existsSync(DEFAULT_DAEMON_SOCKET);
 }
 
 function ensureDefaultDaemon() {
@@ -201,6 +263,9 @@ async function dumpFailureLog(scenario, result) {
 }
 
 async function main() {
+  const originalEnv = { ...process.env };
+  const mockServer = await startMockModelServer();
+  applyProcessEnv(buildMockProviderEnv(mockServer.baseUrl, process.env));
   let names = await discoverScenarios();
   // Optional filter: --filter <substr>  or  --range <lo>-<hi>
   const argv = process.argv.slice(2);
@@ -221,10 +286,15 @@ async function main() {
   }
   if (names.length === 0) {
     console.log(color("yellow", "no scenarios found under scenarios/"));
+    restoreProcessEnv(originalEnv);
+    await mockServer.close();
     return 0;
   }
   console.log(
     color("bold", `agenc TUI e2e gate (${names.length} scenarios)`),
+  );
+  console.log(
+    color("dim", `  model: openai-compatible:${MOCK_MODEL} (${mockServer.baseUrl})`),
   );
   process.stdout.write(color("dim", "  restarting daemon for clean baseline ... "));
   const restarted = restartDaemon();
@@ -234,54 +304,71 @@ async function main() {
   const failed = [];
   const skipped = [];
   let passed = 0;
-  for (const name of names) {
-    const scenario = await loadScenario(name);
-    process.stdout.write(`  ${color("dim", "→")} ${name} … `);
-    if (scenario.meta.skip) {
-      console.log(
-        `${color("yellow", "SKIP")} ${color("dim", `(${scenario.meta.skip})`)}`,
-      );
-      skipped.push({ name, reason: scenario.meta.skip });
-      continue;
-    }
-    // Scenarios that don't isolate via temp HOME share the user's default
-    // daemon. If a prior scenario killed it (autostart hiccup, lock
-    // contention, or a temp-HOME teardown that mis-targeted the default
-    // socket), respawn before continuing. useTempHome scenarios spawn
-    // their own daemon and must not be touched here.
-    if (scenario.meta.useTempHome !== true && !ensureDefaultDaemon()) {
-      console.log(
-        `${color("red", "FAIL")} ${color("dim", "(default daemon not reachable; could not respawn)")}`,
-      );
-      failed.push({
-        name,
-        error: new Error("default daemon not reachable; respawn failed"),
-        logPath: null,
-      });
-      continue;
-    }
-    const result = await runScenario(scenario);
-    if (result.ok) {
-      passed += 1;
-      console.log(
-        `${color("green", "PASS")} ${color("dim", `(${result.durationMs}ms)`)}`,
-      );
-      if (process.env.TUI_E2E_DEBUG === "1" && result.capturedOutput) {
-        const logPath = `/tmp/tui-e2e-pass-${name.replace(/\.mjs$/, "")}.log`;
-        await writeFile(logPath, result.capturedOutput, "utf8");
-        console.log(`      ${color("dim", `debug log: ${logPath}`)}`);
+  try {
+    for (const name of names) {
+      const scenario = await loadScenario(name);
+      process.stdout.write(`  ${color("dim", "→")} ${name} … `);
+      if (scenario.meta.skip) {
+        console.log(
+          `${color("yellow", "SKIP")} ${color("dim", `(${scenario.meta.skip})`)}`,
+        );
+        skipped.push({ name, reason: scenario.meta.skip });
+        continue;
       }
-    } else {
-      const logPath = await dumpFailureLog(scenario, result);
-      console.log(
-        `${color("red", "FAIL")} ${color("dim", `(${result.durationMs}ms)`)}`,
-      );
-      console.log(
-        `      ${color("red", "✗")} ${result.error?.message ?? String(result.error)}`,
-      );
-      console.log(`      ${color("dim", `log: ${logPath}`)}`);
-      failed.push({ name, error: result.error, logPath });
+      // Scenarios that don't isolate via temp HOME share the user's default
+      // daemon. If a prior scenario killed it (autostart hiccup, lock
+      // contention, or a temp-HOME teardown that mis-targeted the default
+      // socket), respawn before continuing. useTempHome scenarios spawn
+      // their own daemon and must not be touched here.
+      if (scenario.meta.restartDaemonBefore === true && !restartDaemon()) {
+        console.log(
+          `${color("red", "FAIL")} ${color("dim", "(default daemon not reachable after restart)")}`,
+        );
+        failed.push({
+          name,
+          error: new Error("default daemon not reachable after restart"),
+          logPath: null,
+        });
+        continue;
+      }
+      if (scenario.meta.useTempHome !== true && !ensureDefaultDaemon()) {
+        console.log(
+          `${color("red", "FAIL")} ${color("dim", "(default daemon not reachable; could not respawn)")}`,
+        );
+        failed.push({
+          name,
+          error: new Error("default daemon not reachable; respawn failed"),
+          logPath: null,
+        });
+        continue;
+      }
+      const result = await runScenario(scenario);
+      if (result.ok) {
+        passed += 1;
+        console.log(
+          `${color("green", "PASS")} ${color("dim", `(${result.durationMs}ms)`)}`,
+        );
+        if (process.env.TUI_E2E_DEBUG === "1" && result.capturedOutput) {
+          const logPath = `/tmp/tui-e2e-pass-${name.replace(/\.mjs$/, "")}.log`;
+          await writeFile(logPath, result.capturedOutput, "utf8");
+          console.log(`      ${color("dim", `debug log: ${logPath}`)}`);
+        }
+      } else {
+        const logPath = await dumpFailureLog(scenario, result);
+        console.log(
+          `${color("red", "FAIL")} ${color("dim", `(${result.durationMs}ms)`)}`,
+        );
+        console.log(
+          `      ${color("red", "✗")} ${result.error?.message ?? String(result.error)}`,
+        );
+        console.log(`      ${color("dim", `log: ${logPath}`)}`);
+        failed.push({ name, error: result.error, logPath });
+      }
     }
+  } finally {
+    restoreProcessEnv(originalEnv);
+    restartDaemon();
+    await mockServer.close();
   }
 
   console.log("");

--- a/runtime/scripts/check-tui-e2e/scenarios/05-ctrl-d-exit.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/05-ctrl-d-exit.mjs
@@ -1,7 +1,7 @@
 /**
  * Ctrl+D shutdown scenario.
  *
- * Sends Ctrl+D (EOF) on an empty input and expects the TUI to shut down
+ * Sends Ctrl+D on an empty input and expects the TUI to shut down
  * cleanly within a short grace window. Catches: shutdown handlers that
  * throw, daemon-detach paths that hang, transcript-flush logic that loops.
  *
@@ -13,6 +13,9 @@
  * machinery entirely.
  */
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// Send the CSI-u Ctrl+D encoding so node-pty delivers a key event instead of
+// letting the pseudo-terminal line discipline treat raw \x04 as EOF.
+const CTRL_D = "\x1b[100;5u";
 
 export const meta = {
   description: "Ctrl+D twice triggers clean shutdown of the TUI.",
@@ -21,14 +24,18 @@ export const meta = {
 
 export default async function (session) {
   await session.start();
-  await session.waitForPrompt({ timeout: 15_000 });
+  await session.waitForPrompt({ idleWindow: 2500, timeout: 15_000 });
   // First Ctrl+D arms the exit confirmation ("Press Ctrl-D again to exit").
   // The second Ctrl+D actually shuts down. The two-press requirement is a
   // safety guard: a single accidental Ctrl+D mid-conversation should not
   // throw away the session.
-  session.send("\x04");
-  await sleep(400);
-  session.send("\x04");
+  session.send(CTRL_D);
+  await session.waitFor(/same key again to exit/i, {
+    timeout: 4_000,
+    label: "Ctrl+D exit confirmation",
+  });
+  await sleep(100);
+  session.send(CTRL_D);
   const start = Date.now();
   while (Date.now() - start < 8_000) {
     if (session.exited) return;

--- a/runtime/scripts/check-tui-e2e/scenarios/36-print-mode-basic.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/36-print-mode-basic.mjs
@@ -8,6 +8,11 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  createTempHome,
+  teardownTempHome,
+  trustProjectForHome,
+} from "../harness.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
@@ -19,30 +24,40 @@ export const meta = {
 };
 
 export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, "-p", "say only the word HELLO and nothing else"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
+  const { home, wsPort } = await createTempHome();
+  await trustProjectForHome(home, process.cwd());
+  try {
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [BIN_AGENC, "-p", "say only the word HELLO and nothing else"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          HOME: home,
+          AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
+        },
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d.toString()));
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+      child.on("error", reject);
+      setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error("print mode exceeded timeout"));
+      }, 80_000).unref();
     });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-    setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("print mode exceeded timeout"));
-    }, 80_000).unref();
-  });
-  if (result.code !== 0) {
-    throw new Error(
-      `print mode exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
-    );
-  }
-  if (result.stdout.trim().length === 0) {
-    throw new Error(
-      `print mode produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
-    );
+    if (result.code !== 0) {
+      throw new Error(
+        `print mode exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
+      );
+    }
+    if (result.stdout.trim().length === 0) {
+      throw new Error(
+        `print mode produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
+      );
+    }
+  } finally {
+    await teardownTempHome(home);
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/37-print-mode-yolo.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/37-print-mode-yolo.mjs
@@ -7,6 +7,11 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  createTempHome,
+  teardownTempHome,
+  trustProjectForHome,
+} from "../harness.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
@@ -18,37 +23,50 @@ export const meta = {
 };
 
 export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      [BIN_AGENC, "--yolo", "-p", "say only the word HELLO and nothing else"],
-      { stdio: ["ignore", "pipe", "pipe"], env: process.env },
-    );
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-    setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("yolo print mode exceeded timeout"));
-    }, 80_000).unref();
-  });
-  // Strip the noisy config-migration banner so the assertion error
-  // surfaces the actual cause.
-  const cleanStderr = result.stderr
-    .split("\n")
-    .filter((line) => !line.includes("[agenc:config-migration]"))
-    .join("\n");
-  if (result.code !== 0) {
-    throw new Error(
-      `yolo print mode exited code=${result.code}; stderr: ${cleanStderr.slice(0, 600)}`,
-    );
-  }
-  if (result.stdout.trim().length === 0) {
-    throw new Error(
-      `yolo print mode produced no stdout; stderr: ${cleanStderr.slice(0, 600)}`,
-    );
+  const { home, wsPort } = await createTempHome();
+  await trustProjectForHome(home, process.cwd());
+  try {
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [BIN_AGENC, "--yolo", "-p", "say only the word HELLO and nothing else"],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            HOME: home,
+            AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
+          },
+        },
+      );
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d.toString()));
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+      child.on("error", reject);
+      setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error("yolo print mode exceeded timeout"));
+      }, 80_000).unref();
+    });
+    // Strip the noisy config-migration banner so the assertion error
+    // surfaces the actual cause.
+    const cleanStderr = result.stderr
+      .split("\n")
+      .filter((line) => !line.includes("[agenc:config-migration]"))
+      .join("\n");
+    if (result.code !== 0) {
+      throw new Error(
+        `yolo print mode exited code=${result.code}; stderr: ${cleanStderr.slice(0, 600)}`,
+      );
+    }
+    if (result.stdout.trim().length === 0) {
+      throw new Error(
+        `yolo print mode produced no stdout; stderr: ${cleanStderr.slice(0, 600)}`,
+      );
+    }
+  } finally {
+    await teardownTempHome(home);
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/75-slash-skills.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/75-slash-skills.mjs
@@ -7,6 +7,8 @@
 export const meta = {
   description: "/skills renders skill list, returns to idle without crash.",
   timeoutMs: 30_000,
+  slimCwd: true,
+  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/local-openai-compatible-mock.mjs
+++ b/runtime/scripts/local-openai-compatible-mock.mjs
@@ -1,0 +1,367 @@
+import { createServer } from "node:http";
+
+export const MOCK_MODEL = "local-pipeline-model";
+
+export function buildMockProviderEnv(baseUrl, baseEnv = process.env) {
+  const env = {
+    ...baseEnv,
+    AGENC_PROVIDER: "openai-compatible",
+    AGENC_MODEL: MOCK_MODEL,
+    OPENAI_COMPATIBLE_MODEL: MOCK_MODEL,
+    OPENAI_COMPATIBLE_BASE_URL: `${baseUrl}/v1`,
+    OPENAI_COMPATIBLE_API_KEY: "local-pipeline-key",
+    API_TIMEOUT_MS: "600000",
+    AGENC_AUTH_MANAGED_KEYS_ENABLED: "0",
+  };
+  for (const key of [
+    "XAI_API_KEY",
+    "GROK_API_KEY",
+    "AGENC_XAI_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL",
+  ]) {
+    delete env[key];
+  }
+  return env;
+}
+
+async function readRequestBody(request) {
+  let raw = "";
+  for await (const chunk of request) {
+    raw += chunk.toString();
+  }
+  return raw.length > 0 ? JSON.parse(raw) : {};
+}
+
+function userPromptFromMessages(messages) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") continue;
+    const content = message.content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => typeof part?.text === "string" ? part.text : "")
+        .join(" ");
+    }
+  }
+  return "";
+}
+
+function toolResultCount(messages) {
+  return messages.filter((message) => message?.role === "tool").length;
+}
+
+function completionForPrompt(prompt) {
+  const singleWord =
+    /\b(?:reply with|say only)\s+(?:the\s+)?(?:single\s+)?word\s+([A-Za-z0-9_-]+)/i
+      .exec(prompt)?.[1];
+  if (singleWord) return singleWord;
+  const literalText =
+    /\breply with the literal text\s+([A-Za-z0-9_-]+)/i.exec(prompt)?.[1];
+  if (literalText) return literalText;
+  if (/RECORDED/i.test(prompt)) return "RECORDED";
+  if (/\bDONE\b/i.test(prompt)) return "DONE";
+  if (/\bYES\b/i.test(prompt)) return "YES";
+  return "OK";
+}
+
+function toolName(tool) {
+  return tool?.function?.name ?? tool?.name ?? "";
+}
+
+function selectTool(tools, preferred, fallbackPattern) {
+  const candidates = Array.isArray(tools) ? tools : [];
+  for (const name of preferred) {
+    const found = candidates.find((tool) => toolName(tool) === name);
+    if (found) return found;
+  }
+  if (fallbackPattern) {
+    const found = candidates.find((tool) => fallbackPattern.test(toolName(tool)));
+    if (found) return found;
+  }
+  return candidates[0];
+}
+
+function toolArgumentsFor(tool, args) {
+  const name = toolName(tool);
+  if (name === "exec_command") {
+    return {
+      cmd: args.command,
+      yield_time_ms: 1000,
+      max_output_tokens: 2000,
+    };
+  }
+  if (name === "system.bash") return { command: args.command };
+  return args;
+}
+
+function shellCommandFromPrompt(prompt) {
+  return /Use the Bash tool(?: exactly twice)?\.\s*First run/i.test(prompt)
+    ? null
+    : /Use the Bash tool to run(?: exactly)?:\s*([\s\S]+)/i.exec(prompt)?.[1]
+      ?.trim() ?? null;
+}
+
+function pipelineCommandsFromPrompt(prompt) {
+  const match =
+    /First run only:\s*(echo\s+\S+)\.\s*Then run only:\s*(echo\s+\S+)\./i.exec(prompt);
+  return match ? [match[1], match[2]] : null;
+}
+
+function fileReadArgsFromPrompt(prompt) {
+  const path =
+    /Use the Read tool to read\s+(.+?)(?:,?\s+then\b|\s+and\s+report\b|$)/i.exec(prompt)?.[1]
+      ?.trim()
+      .replace(/\s*\.$/, "");
+  return path ? { file_path: path } : null;
+}
+
+function grepArgsFromPrompt(prompt) {
+  const match =
+    /Use the Grep tool[\s\S]*?search\s+(.+?)\s+for the pattern\s+'([^']+)'/i.exec(prompt);
+  return match
+    ? { path: match[1].trim(), pattern: match[2], output_mode: "content" }
+    : null;
+}
+
+function globArgsFromPrompt(prompt) {
+  const match =
+    /Use the Glob tool[\s\S]*?in\s+(.+?)\s+matching the pattern\s+'([^']+)'/i.exec(prompt);
+  return match ? { path: match[1].trim(), pattern: match[2] } : null;
+}
+
+function writeArgsFromPrompt(prompt) {
+  const match =
+    /Use the Write tool to write the exact text\s+"([^"]+)"\s+to the file\s+(.+)/i.exec(prompt);
+  return match ? { content: match[1], file_path: match[2].trim() } : null;
+}
+
+function editArgsFromPrompt(prompt) {
+  const path =
+    /Use the Read tool to read\s+(.+?),\s+then use the Edit tool/i.exec(prompt)?.[1]
+      ?.trim();
+  const replacement =
+    /replace\s+"([^"]+)"\s+with\s+"([^"]+)"/i.exec(prompt);
+  return path && replacement
+    ? {
+      file_path: path,
+      old_string: replacement[1],
+      new_string: replacement[2],
+    }
+    : null;
+}
+
+function nextToolCall(body, prompt, completedTools) {
+  const tools = body.tools;
+  const pipelineCommands = pipelineCommandsFromPrompt(prompt);
+  if (pipelineCommands && completedTools < pipelineCommands.length) {
+    return {
+      tool: selectTool(tools, ["exec_command", "system.bash", "Bash"], /bash|shell|command/i),
+      args: { command: pipelineCommands[completedTools] },
+    };
+  }
+
+  if (!completedTools && /PIPELINE-TOOL-CHECK/i.test(prompt)) {
+    return {
+      tool: selectTool(tools, ["exec_command", "system.bash", "Bash"], /bash|shell|command/i),
+      args: { command: "echo PIPELINE-TOOL-CHECK" },
+    };
+  }
+  if (!completedTools && /TOKEN-CHECK/i.test(prompt)) {
+    return {
+      tool: selectTool(tools, ["exec_command", "system.bash", "Bash"], /bash|shell|command/i),
+      args: { command: "echo TOKEN-CHECK" },
+    };
+  }
+
+  const editArgs = editArgsFromPrompt(prompt);
+  if (editArgs && completedTools === 0) {
+    return { tool: selectTool(tools, ["FileRead", "Read"], /read/i), args: fileReadArgsFromPrompt(prompt) };
+  }
+  if (editArgs && completedTools === 1) {
+    return { tool: selectTool(tools, ["Edit", "FileEdit"], /edit/i), args: editArgs };
+  }
+
+  const command = shellCommandFromPrompt(prompt);
+  if (command && !completedTools) {
+    return {
+      tool: selectTool(tools, ["exec_command", "system.bash", "Bash"], /bash|shell|command/i),
+      args: { command },
+    };
+  }
+
+  const readArgs = fileReadArgsFromPrompt(prompt);
+  if (readArgs && !completedTools) {
+    return { tool: selectTool(tools, ["FileRead", "Read"], /read/i), args: readArgs };
+  }
+
+  const grepArgs = grepArgsFromPrompt(prompt);
+  if (grepArgs && !completedTools) {
+    return { tool: selectTool(tools, ["Grep"], /grep|search/i), args: grepArgs };
+  }
+
+  const globArgs = globArgsFromPrompt(prompt);
+  if (globArgs && !completedTools) {
+    return { tool: selectTool(tools, ["Glob"], /glob/i), args: globArgs };
+  }
+
+  const writeArgs = writeArgsFromPrompt(prompt);
+  if (writeArgs && !completedTools) {
+    return { tool: selectTool(tools, ["Write", "FileWrite"], /write/i), args: writeArgs };
+  }
+
+  return null;
+}
+
+function writeSse(response, chunks) {
+  response.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  for (const chunk of chunks) {
+    response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  }
+  response.end("data: [DONE]\n\n");
+}
+
+function makeChunk(body, choice) {
+  return {
+    id: `chatcmpl-${Date.now()}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: body.model ?? MOCK_MODEL,
+    choices: [choice],
+  };
+}
+
+function usage(promptTokens, completionTokens) {
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+  };
+}
+
+function respondWithText(response, body, text) {
+  const tokenCount = Math.max(1, text.split(/\s+/).length);
+  writeSse(response, [
+    makeChunk(body, {
+      index: 0,
+      delta: { role: "assistant" },
+      finish_reason: null,
+    }),
+    makeChunk(body, {
+      index: 0,
+      delta: { content: text },
+      finish_reason: null,
+    }),
+    {
+      ...makeChunk(body, {
+        index: 0,
+        delta: {},
+        finish_reason: "stop",
+      }),
+      usage: usage(64, tokenCount),
+    },
+  ]);
+}
+
+function respondWithToolCall(response, body, call) {
+  const selected = call.tool;
+  const name = toolName(selected) || "exec_command";
+  const args = JSON.stringify(toolArgumentsFor(selected, call.args));
+  writeSse(response, [
+    makeChunk(body, {
+      index: 0,
+      delta: { role: "assistant" },
+      finish_reason: null,
+    }),
+    makeChunk(body, {
+      index: 0,
+      delta: {
+        tool_calls: [
+          {
+            index: 0,
+            id: `call_${Date.now()}`,
+            type: "function",
+            function: { name, arguments: args },
+          },
+        ],
+      },
+      finish_reason: null,
+    }),
+    {
+      ...makeChunk(body, {
+        index: 0,
+        delta: {},
+        finish_reason: "tool_calls",
+      }),
+      usage: usage(96, 12),
+    },
+  ]);
+}
+
+async function handleChatCompletions(request, response) {
+  const body = await readRequestBody(request);
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const prompt = userPromptFromMessages(messages);
+  const completedTools = toolResultCount(messages);
+  const call = nextToolCall(body, prompt, completedTools);
+  if (call) {
+    respondWithToolCall(response, body, call);
+    return;
+  }
+  respondWithText(
+    response,
+    body,
+    completedTools > 0 ? "tool complete" : completionForPrompt(prompt),
+  );
+}
+
+export async function startMockModelServer() {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/v1/models") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({
+        object: "list",
+        data: [{ id: MOCK_MODEL, object: "model", owned_by: "local" }],
+      }));
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
+      handleChatCompletions(request, response).catch((error) => {
+        response.writeHead(500, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({
+          error: { message: String(error?.message ?? error) },
+        }));
+      });
+      return;
+    }
+    response.writeHead(404, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({
+      error: { message: `not found: ${url.pathname}` },
+    }));
+  });
+  await new Promise((resolve, reject) => {
+    const onError = (error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock model server did not bind to a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    }),
+  };
+}


### PR DESCRIPTION
Closes #992

## Summary
- add a shared local OpenAI-compatible mock server for daemon-backed e2e gates
- isolate LLM pipeline and TUI e2e scenarios from user provider credentials and daemon state
- harden daemon readiness, print-mode, slash-skills, and Ctrl-D TUI scenarios for deterministic local runs
- keep React renderer modules externalized in the runtime build so built TUI smoke checks run consistently

## Verification
- npm --workspace=@tetsuo-ai/runtime run check:e2e-all
- npm run typecheck
- npm test
- npm run build
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --workspaces
- git diff --cached --check