### PR TITLE
test(runtime): remove stale ts-nocheck suppressions

### DIFF
--- a/runtime/src/types/hooks.ts
+++ b/runtime/src/types/hooks.ts
@@ -192,15 +192,14 @@ export function isAsyncHookJSONOutput(
 
 // NOTE: A compile-time assertion `_assertSDKTypesMatch` previously lived here to
 // verify the local Zod `hookJSONOutputSchema` exactly matched the SDK
-// `HookJSONOutput` type. It was inert while this file carried `// @ts-nocheck`.
-// Once type-checking was re-enabled it failed (TS2344): the generated SDK
-// `PermissionUpdate` union (reached via the `PermissionRequest` hook output's
-// `decision.updatedPermissions`) includes `addDirectories`/`removeDirectories`
-// variants that the runtime `permissionUpdateSchema` does not, so the schema is
-// a strict subset of the SDK type. Fixing that drift requires changing the Zod
-// schema (a different file / runtime-validation change) and is out of scope for
-// this type-only cleanup, so the dead assertion is removed and the drift is
-// recorded for follow-up.
+// `HookJSONOutput` type. Once strict checking reached this file it failed
+// (TS2344): the generated SDK `PermissionUpdate` union (reached via the
+// `PermissionRequest` hook output's `decision.updatedPermissions`) includes
+// `addDirectories`/`removeDirectories` variants that the runtime
+// `permissionUpdateSchema` does not, so the schema is a strict subset of the SDK
+// type. Fixing that drift requires changing the Zod schema (a different file /
+// runtime-validation change) and is out of scope for this type-only cleanup, so
+// the dead assertion is removed and the drift is recorded for follow-up.
 
 /** Context passed to callback hooks for state access */
 export type HookCallbackContext = {

--- a/runtime/src/utils/hooks.ts
+++ b/runtime/src/utils/hooks.ts
@@ -64,11 +64,10 @@ import {
   isSyncHookJSONOutput,
   type PermissionRequestResult,
 } from '../types/hooks.js'
-// The donor `agentSdkTypes.ts` carries `@ts-nocheck` and re-exports overlap
-// with its inline `= any` aliases; TypeScript's export resolver drops the
-// duplicate names from the emitted type table. Resolve type-only imports via
-// the local-aliases helper module which gives us back stable references that
-// hold `any` semantics in the rest of this file.
+// The SDK barrel re-exports generated hook types and also declares inline
+// `= any` aliases for the same names; TypeScript's export resolver drops the
+// duplicates from the emitted type table. Resolve type-only imports via the
+// local-aliases helper module, preserving the current permissive semantics.
 import type {
   HookEvent,
   HookInput,
@@ -5121,4 +5120,3 @@ export async function executeWorktreeRemoveHook(
 
   return true
 }
-

--- a/runtime/src/utils/hooks/AsyncHookRegistry.ts
+++ b/runtime/src/utils/hooks/AsyncHookRegistry.ts
@@ -1,11 +1,8 @@
-// Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import type {
-  // @ts-expect-error -- agentSdkTypes still relies on @ts-nocheck, so this re-export is not visible through the type system.
   AsyncHookJSONOutput,
   HookEvent,
-  // @ts-expect-error -- agentSdkTypes still relies on @ts-nocheck, so this re-export is not visible through the type system.
   SyncHookJSONOutput,
-} from 'src/entrypoints/agentSdkTypes.js'
+} from './agentSdkHookTypes.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import type { ShellCommand } from '../ShellCommand.js'
 import { invalidateSessionEnvCache } from '../sessionEnvironment.js'

--- a/runtime/src/utils/hooks/agentSdkHookTypes.ts
+++ b/runtime/src/utils/hooks/agentSdkHookTypes.ts
@@ -1,11 +1,11 @@
 /**
  * Stable local aliases for hook-related types pulled from the donor SDK.
  *
- * The canonical donor file `src/entrypoints/agentSdkTypes.ts` carries
- * `@ts-nocheck` and overlaps its own `export type * from './sdk/coreTypes.js'`
- * re-exports with inline `export type X = any` declarations. TypeScript's
- * export resolver drops the duplicated names from the emitted type table,
- * which surfaces as `TS2305: has no exported member` at downstream consumers.
+ * The canonical SDK barrel `src/entrypoints/agentSdkTypes.ts` overlaps its
+ * own `export type * from './sdk/coreTypes.js'` re-exports with inline
+ * `export type X = any` declarations. TypeScript's export resolver drops the
+ * duplicated names from the emitted type table, which surfaces as
+ * `TS2305: has no exported member` at downstream consumers.
  *
  * Until the donor surface is absorbed proper, expose `any`-shaped aliases
  * here so live AgenC-owned hook code can type-check without depending on the

--- a/runtime/tests/commands/add-dir/validation.test.ts
+++ b/runtime/tests/commands/add-dir/validation.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — validation.ts is plain TS but transitively imports filesystem.ts which @ts-nocheck'd.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/runtime/tests/commands/terminalSetup/terminalSetup.test.ts
+++ b/runtime/tests/commands/terminalSetup/terminalSetup.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("bun:bundle", () => ({


### PR DESCRIPTION
Fixes #996

## Summary
- remove stale `@ts-nocheck` directives from command tests now covered by `tsc`
- route `AsyncHookRegistry` through the existing hook type alias module instead of barrel imports with `@ts-expect-error`
- refresh stale comments so `@ts-nocheck` scans only hit docs and marker tests

## Verification
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test -- tests/commands/add-dir/validation.test.ts tests/commands/terminalSetup/terminalSetup.test.ts tests/tui/moved-source-markers.test.ts
- npm --workspace=@tetsuo-ai/runtime run test -- tests/hooks/hooks-core.test.ts tests/hooks/configured-hooks.test.ts tests/commands/hooks.test.ts tests/app-server/daemon-dispatcher.hooks.contract.test.ts tests/tools/hooks.test.ts
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm test
- git diff --check
- pre-commit hook: npm run build --workspace=@tetsuo-ai/runtime
- pre-commit hook: npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup

## Note
- `npm run check:agent-surface-contract` still fails on existing agent parity drift and missing `runtime/src/agents/v2/PARITY.md`; this PR does not modify that surface.