### PR TITLE
fix(runtime): repair agent surface contract gate

### DIFF
--- a/parity/agent-surface-contract.json
+++ b/parity/agent-surface-contract.json
@@ -1,14 +1,14 @@
 {
   "contractName": "agent-surface-contract",
   "scope": "AgenC agent runtime, daemon lifecycle, task bridge, and TUI workbench parity against the Rust agent surface in codex-rs",
-  "generatedAt": "2026-05-28T01:39:00.000Z",
+  "generatedAt": "2026-06-14T17:35:39.962Z",
   "sourceRoot": "../../../codex/codex-rs",
-  "sourceCommit": "4d0c4cd058d9bc488ee2c331f085e25b7af3268d",
+  "sourceCommit": "966932124c243aab71719c269d79305844f35814",
   "targetRoot": "..",
   "sourceFiles": [
     {
       "path": "core/src/agent/control.rs",
-      "sha256": "53828c3def4a8e356789e0b59bd101ae843b9bab45c73af6e48cd6ab12394c83"
+      "sha256": "ae7ff254ba6b5192c6b897bc0c36ab50c1ba513ad3255a62170f229f39e1e387"
     },
     {
       "path": "core/src/agent/agent_resolver.rs",
@@ -28,7 +28,7 @@
     },
     {
       "path": "core/src/thread_manager.rs",
-      "sha256": "5b8a9a570cafea31d6ab8e3a802b9cb38736122c90310dc1654aea9761cf30b7"
+      "sha256": "fd59c62f870b92cdd01b6813e3535194521774aa8571bd89a515f6bc3196a399"
     },
     {
       "path": "core/src/tools/handlers/multi_agents_common.rs",
@@ -36,15 +36,15 @@
     },
     {
       "path": "core/src/tools/handlers/multi_agents_spec.rs",
-      "sha256": "dcd6a7abd9f6cec6821f9c03b3c7936cbc2845324196b3a368cc15fc08a1f5fd"
+      "sha256": "15eab88fa19d88e6892f16fa2008b028c3528370e9bcab3a362cedb1a7b7eba5"
     },
     {
       "path": "core/src/tools/handlers/multi_agents_v2/close_agent.rs",
-      "sha256": "105a877567d3d609b8ffc14f409402d8071fc7ad9442214c55104018246764f4"
+      "sha256": "d5c200224663e4bde5af59b62544be658472e27df75b658001c8f5617428a981"
     },
     {
-      "path": "core/src/tools/handlers/multi_agents_v2/followup_task.rs",
-      "sha256": "56e5d3cedb93a77b38cb0d64a0579a323af45b99b1e239018ac4ce4d2fade576"
+      "path": "core/src/tools/handlers/multi_agents_v2/assign_task.rs",
+      "sha256": "5a86135e3d196a79f07112ed15fa03b80b70cf18398daa2afe2e586553277d4d"
     },
     {
       "path": "core/src/tools/handlers/multi_agents_v2/list_agents.rs",
@@ -52,7 +52,7 @@
     },
     {
       "path": "core/src/tools/handlers/multi_agents_v2/message_tool.rs",
-      "sha256": "eb9f3c30243ae6e83d5a69a66f805f0ba64abd5e0b2298a18bfe3886aa835151"
+      "sha256": "985a6e8eb0a781385d974aad18aa03d85cc80ab70e6280a10141752fec34cdad"
     },
     {
       "path": "core/src/tools/handlers/multi_agents_v2/send_message.rs",
@@ -68,11 +68,11 @@
     },
     {
       "path": "core/src/codex_thread.rs",
-      "sha256": "de69256771379d633216a30de68303c21c3fa307608b6aefb40802fc4c6dc81e"
+      "sha256": "48b718935d3d2a3403b9ff388bce60c81c8bef28540f7cc3c1720ceb3bebf3a9"
     },
     {
       "path": "app-server/src/thread_state.rs",
-      "sha256": "5a41b07777520dcb8c7adaf48f0ee34ba8b4ea3dede417b4b4d37007f4ffef64"
+      "sha256": "7bb6dd0fb4bd7877ee6058f33553a60219ffedced780651ca69dc67a70202091"
     },
     {
       "path": "app-server/src/thread_status.rs",
@@ -88,7 +88,7 @@
     },
     {
       "path": "core/src/tools/handlers/agent_jobs_spec.rs",
-      "sha256": "94c2f5e30317f092ee61708d725e9bc42fce9d760df67f5ca5543f3b9705c763"
+      "sha256": "7a4f99c3e99ea259c9bfa6061b3719ccfa802da6f32dc7d979373397b80b33c5"
     },
     {
       "path": "core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs",
@@ -104,7 +104,7 @@
     },
     {
       "path": "protocol/src/openai_models.rs",
-      "sha256": "622e264c2b67b2e37d27c51b5486968a4d5245f6ff3a2893919eb71bb8c060ca"
+      "sha256": "582dfda3a8235545fbf5d48ad3f8a69c7cde0027f2369ae5203a8c7a00ee71de"
     },
     {
       "path": "protocol/src/config_types.rs",
@@ -139,9 +139,13 @@
     "runtime/src/llm/types.ts",
     "runtime/src/phases/stream-model.ts",
     "runtime/src/agents/v2/PARITY.md",
+    "runtime/src/agents/v2/index.ts",
+    "runtime/src/agents/v2/assign-task.ts",
     "runtime/src/agents/v2/common.ts",
     "runtime/src/agents/v2/spawn.ts",
     "runtime/src/agents/v2/send-message.ts",
+    "runtime/src/agents/v2/followup-task.ts",
+    "runtime/src/agents/v2/message-tool.ts",
     "runtime/src/agents/v2/wait.ts",
     "runtime/src/agents/v2/list-agents.ts",
     "runtime/src/agents/v2/close-agent.ts",
@@ -343,7 +347,7 @@
         "core/src/tools/handlers/multi_agents_common.rs",
         "core/src/tools/handlers/multi_agents_spec.rs",
         "core/src/tools/handlers/multi_agents_v2/close_agent.rs",
-        "core/src/tools/handlers/multi_agents_v2/followup_task.rs",
+        "core/src/tools/handlers/multi_agents_v2/assign_task.rs",
         "core/src/tools/handlers/multi_agents_v2/list_agents.rs",
         "core/src/tools/handlers/multi_agents_v2/message_tool.rs",
         "core/src/tools/handlers/multi_agents_v2/send_message.rs",
@@ -370,9 +374,13 @@
         "runtime/src/tools/tasks/background.ts",
         "runtime/src/tools/tasks/task-board.ts",
         "runtime/src/agents/v2/PARITY.md",
+        "runtime/src/agents/v2/index.ts",
+        "runtime/src/agents/v2/assign-task.ts",
         "runtime/src/agents/v2/common.ts",
         "runtime/src/agents/v2/spawn.ts",
         "runtime/src/agents/v2/send-message.ts",
+        "runtime/src/agents/v2/followup-task.ts",
+        "runtime/src/agents/v2/message-tool.ts",
         "runtime/src/agents/v2/wait.ts",
         "runtime/src/agents/v2/list-agents.ts",
         "runtime/src/agents/v2/close-agent.ts",
@@ -395,8 +403,8 @@
         "spawn_agent v2 accepts service_tier, validates it against the effective child model, applies role model/reasoning/service_tier after valid request overrides, allows explicit service_tier with full-history forks, and forwards the selected tier to child runs",
         "spawn_agent v2 defaults omitted fork_turns to the Rust default of all, documents that schema default, and requires fork_turns none for clean-fork role/model/reasoning overrides",
         "spawn_agent v2 permits a child agent to spawn descendants under its current agent path and applies a per-call child depth allowance instead of rejecting on the session max-depth cap",
-        "followup_task v2 accepts a completed live agent and sends a trigger-turn inter-agent communication instead of treating completed as a closed terminal state",
-        "send_message, followup_task, and close_agent v2 register the current root thread before resolving id or path targets so canonical /root maps to the active root session",
+        "assign_task v2 accepts a completed live agent and sends a trigger-turn inter-agent communication instead of treating completed as a closed terminal state; followup_task remains a deferred compatibility alias",
+        "send_message, assign_task, followup_task, and close_agent v2 register the current root thread before resolving id or path targets so canonical /root maps to the active root session",
         "list_agents v2 registers the current root thread before listing so the root entry is present even before any child spawn has registered it",
         "wait_agent v2 waits for parent mailbox updates and returns only message plus timed_out",
         "wait_agent v2 validates, defaults, and describes timeout_ms from configured min, default, and max wait timeout options",
@@ -421,11 +429,11 @@
         "spawn_agent called from a depth-one child with agent_max_depth set to one spawns a grandchild under the child path and emits begin/end lifecycle events",
         "list_agents called before any child spawn on an unregistered AgentControl returns the registered /root entry instead of an empty agent list",
         "send_message called from a child to /root on an unregistered AgentControl queues an upward non-triggering inter-agent communication to the root session",
-        "followup_task called from a child to /root on an unregistered AgentControl returns the root-task rejection without enqueuing root mail",
+        "assign_task called from a child to /root on an unregistered AgentControl returns the root-task rejection without enqueuing root mail",
         "close_agent called with /root on an unregistered AgentControl returns the root-not-spawned rejection instead of an unresolved path error",
         "a child spawned with service_tier priority forwards priority into the provider request options",
         "child session tool filtering keeps v2 agent tools visible at the configured depth cap while still blocking main-thread coordination tools",
-        "followup_task sends triggerTurn true to a completed live child and still emits begin/end interaction events with the current status",
+        "assign_task sends triggerTurn true to a completed live child and still emits begin/end interaction events with the current status",
         "closing a running agent interrupts it once and produces an idempotent terminal task status",
         "a close_agent shutdown failure still emits collab_close_end and returns a structured tool error",
         "a fork containing multiple pending tool calls creates one placeholder result per call before child instructions",

--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -3,7 +3,7 @@
  *
  * Port of reference runtime `core/src/agent/control.rs` (1,214 LOC). Covers: full
  * lifecycle (spawn/interrupt/shutdown/resume), parent→child message
- * routing (followup_task / send_message / inter-agent communication),
+ * routing (assign_task / send_message / inter-agent communication),
  * metadata + subtree queries (list_agents / subtree descendants /
  * token totals / environment context), completion watcher, fork-mode
  * spawn helpers, and subtree genealogy bookkeeping.
@@ -19,7 +19,7 @@
  * Invariants wired:
  *   I-1  (MAX_AGENT_DEPTH=1) — spawn rejects `childDepth > cap`.
  *        Matches reference runtime's `DEFAULT_AGENT_MAX_DEPTH=1`.
- *   I-5  (bidirectional mailbox) — routing methods (followup_task /
+ *   I-5  (bidirectional mailbox) — routing methods (assign_task /
  *        append_message / IAC / interrupt) go through the child's
  *        `downInbox` with `direction: 'down'`.
  *   I-32 (parent-interrupt race) — cancellation token from the

--- a/runtime/src/agents/status.ts
+++ b/runtime/src/agents/status.ts
@@ -9,7 +9,7 @@
  * `not_found`.
  * Non-final: `pending_init`, `running`, `interrupted`.
  *
- * A completed turn is reusable: `followup_task` may move the same live agent
+ * A completed turn is reusable: `assign_task` may move the same live agent
  * from `completed` back to `running` for its next turn. Shutdown, errored, and
  * not_found remain irreversible.
  *
@@ -264,7 +264,7 @@ export class AgentStatusTracker {
 
   private set(status: AgentStatus): void {
     // Only irreversible states are sticky. `completed` is final for wait/list
-    // semantics, but a live agent can still accept followup_task and start a
+    // semantics, but a live agent can still accept assign_task and start a
     // later turn.
     if (IRREVERSIBLE_STATES.has(this.subject.value.status)) return;
     this.subject.next(status);

--- a/runtime/src/agents/v2/PARITY.md
+++ b/runtime/src/agents/v2/PARITY.md
@@ -1,0 +1,32 @@
+# Multi-Agent v2 Parity
+
+This directory owns the model-facing v2 agent tools tracked by the
+`task-tool-bridge` row in `parity/agent-surface-contract.json`.
+
+## Tool Map
+
+| Reference source | Local target | Model-facing tool |
+| --- | --- | --- |
+| `core/src/tools/handlers/multi_agents_v2/spawn.rs` | `spawn.ts` | `spawn_agent` |
+| `core/src/tools/handlers/multi_agents_v2/wait.rs` | `wait.ts` | `wait_agent` |
+| `core/src/tools/handlers/multi_agents_v2/close_agent.rs` | `close-agent.ts` | `close_agent` |
+| `core/src/tools/handlers/multi_agents_v2/assign_task.rs` | `assign-task.ts` | `assign_task` |
+| `core/src/tools/handlers/multi_agents_v2/send_message.rs` | `send-message.ts` | `send_message` |
+| `core/src/tools/handlers/multi_agents_v2/list_agents.rs` | `list-agents.ts` | `list_agents` |
+| `core/src/tools/handlers/multi_agents_v2/message_tool.rs` | `message-tool.ts` | shared message dispatch |
+
+`followup-task.ts` remains as a deferred compatibility alias for the previous
+`followup_task` spelling. New model-visible tool lists should prefer
+`assign_task`.
+
+## Guarded Behavior
+
+- `assign_task` and `send_message` share strict `target` plus `message`
+  validation and the same event envelope.
+- `assign_task` sets `triggerTurn: true`; `send_message` sets
+  `triggerTurn: false`.
+- `assign_task` rejects assigning work to the root agent and does not enqueue
+  root mail on that failure.
+- Completed live agents remain reusable for later trigger-turn work.
+- All v2 path resolution registers the current root thread before resolving
+  relative or canonical targets.

--- a/runtime/src/agents/v2/assign-task.ts
+++ b/runtime/src/agents/v2/assign-task.ts
@@ -1,0 +1,56 @@
+import type { Tool } from "../../tools/types.js";
+import {
+  strictArgs,
+  toolMetadata,
+  type MultiAgentV2Options,
+} from "./common.js";
+import { handleMessageStringTool } from "./message-tool.js";
+
+const TRIGGER_TURN_TASK_DESCRIPTION =
+  "Send a message to an existing non-root target agent and trigger a turn in that target. If the target is currently mid-turn, the message is queued and will be used to start the target's next turn, after the current turn completes.";
+
+export function createTriggerTurnTaskTool(
+  opts: MultiAgentV2Options,
+  config: {
+    readonly name: "assign_task" | "followup_task";
+    readonly keywords: readonly string[];
+    readonly deferred?: boolean;
+  },
+): Tool {
+  return {
+    name: config.name,
+    description: TRIGGER_TURN_TASK_DESCRIPTION,
+    metadata: toolMetadata("agent", {
+      mutating: true,
+      ...(config.deferred !== undefined
+        ? { deferred: config.deferred, hiddenByDefault: config.deferred }
+        : {}),
+      keywords: config.keywords,
+    }),
+    recoveryCategory: "side-effecting",
+    inputSchema: {
+      type: "object",
+      properties: {
+        target: { type: "string" },
+        message: { type: "string" },
+      },
+      required: ["target", "message"],
+      additionalProperties: false,
+    },
+    execute: (args) => {
+      const strict = strictArgs(args, {
+        allowed: new Set(["target", "message"]),
+        required: ["target", "message"],
+      });
+      if (strict) return Promise.resolve(strict);
+      return handleMessageStringTool(args, opts, "trigger_turn");
+    },
+  };
+}
+
+export function createAssignTaskTool(opts: MultiAgentV2Options): Tool {
+  return createTriggerTurnTaskTool(opts, {
+    name: "assign_task",
+    keywords: ["agent", "assign", "task"],
+  });
+}

--- a/runtime/src/agents/v2/followup-task.ts
+++ b/runtime/src/agents/v2/followup-task.ts
@@ -1,33 +1,11 @@
 import type { Tool } from "../../tools/types.js";
-import { strictArgs, toolMetadata, type MultiAgentV2Options } from "./common.js";
-import { handleMessageStringTool } from "./message-tool.js";
+import type { MultiAgentV2Options } from "./common.js";
+import { createTriggerTurnTaskTool } from "./assign-task.js";
 
 export function createFollowupTaskTool(opts: MultiAgentV2Options): Tool {
-  return {
+  return createTriggerTurnTaskTool(opts, {
     name: "followup_task",
-    description:
-      "Send a message to an existing non-root target agent and trigger a turn in that target. If the target is currently mid-turn, the message is queued and will be used to start the target's next turn, after the current turn completes.",
-    metadata: toolMetadata("agent", {
-      mutating: true,
-      keywords: ["agent", "followup", "task"],
-    }),
-    recoveryCategory: "side-effecting",
-    inputSchema: {
-      type: "object",
-      properties: {
-        target: { type: "string" },
-        message: { type: "string" },
-      },
-      required: ["target", "message"],
-      additionalProperties: false,
-    },
-    execute: (args) => {
-      const strict = strictArgs(args, {
-        allowed: new Set(["target", "message"]),
-        required: ["target", "message"],
-      });
-      if (strict) return Promise.resolve(strict);
-      return handleMessageStringTool(args, opts, "trigger_turn");
-    },
-  };
+    keywords: ["agent", "followup", "task"],
+    deferred: true,
+  });
 }

--- a/runtime/src/agents/v2/index.ts
+++ b/runtime/src/agents/v2/index.ts
@@ -1,5 +1,6 @@
 import type { Tool } from "../../tools/types.js";
 import type { MultiAgentV2Options } from "./common.js";
+import { createAssignTaskTool } from "./assign-task.js";
 import { createCloseAgentTool } from "./close-agent.js";
 import { createFollowupTaskTool } from "./followup-task.js";
 import { createListAgentsTool } from "./list-agents.js";
@@ -14,6 +15,7 @@ export function createMultiAgentV2Tools(
     createSpawnAgentTool(opts),
     createWaitAgentTool(opts),
     createCloseAgentTool(opts),
+    createAssignTaskTool(opts),
     createFollowupTaskTool(opts),
     createSendMessageTool(opts),
     createListAgentsTool(opts),

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -296,6 +296,7 @@ const COLLAB_V2_TOOL_NAMES: ReadonlySet<string> = new Set([
   "spawn_agent",
   "wait_agent",
   "close_agent",
+  "assign_task",
   "send_message",
   "followup_task",
 ]);

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -298,6 +298,7 @@ describe("model-facing tools", () => {
         "spawn_agent",
         "wait_agent",
         "close_agent",
+        "assign_task",
         "followup_task",
         "send_message",
         "list_agents",
@@ -340,7 +341,7 @@ describe("model-facing tools", () => {
         "WebSearch",
         "Skill",
         "spawn_agent",
-        "followup_task",
+        "assign_task",
         "send_message",
         "wait_agent",
         "close_agent",
@@ -349,6 +350,7 @@ describe("model-facing tools", () => {
       ]),
     );
     expect(visibleNames).not.toContain("WebFetch");
+    expect(visibleNames).not.toContain("followup_task");
     expect(allNames).not.toContain("system.agent.delegate");
     expect(visibleNames).not.toContain("system.agent.delegate");
     expect(visibleNames).not.toContain("NotebookEdit");
@@ -1882,13 +1884,23 @@ describe("model-facing tools", () => {
     expect(send.isError).toBe(true);
     expect(JSON.parse(send.content).error).toContain("unknown field `interrupt`");
 
-    const followup = await byName.get("followup_task")!.execute({
+    const assign = await byName.get("assign_task")!.execute({
       target: "/root/task_1",
       message: "hello",
       items: [],
     });
-    expect(followup.isError).toBe(true);
-    expect(JSON.parse(followup.content).error).toContain("unknown field `items`");
+    expect(assign.isError).toBe(true);
+    expect(JSON.parse(assign.content).error).toContain("unknown field `items`");
+
+    const followupLegacy = await byName.get("followup_task")!.execute({
+      target: "/root/task_1",
+      message: "hello",
+      items: [],
+    });
+    expect(followupLegacy.isError).toBe(true);
+    expect(JSON.parse(followupLegacy.content).error).toContain(
+      "unknown field `items`",
+    );
   });
 
   it("rejects invalid strict spawn_agent arguments before delegation", async () => {
@@ -3223,7 +3235,7 @@ describe("model-facing tools", () => {
     });
   });
 
-  it("followup_task accepts a completed live agent and triggers the next turn", async () => {
+  it("assign_task accepts a completed live agent and triggers the next turn", async () => {
     const session = fakeSession();
     const emitted: unknown[] = [];
     (session as unknown as { emit: typeof session.emit }).emit = (event) => {
@@ -3270,12 +3282,12 @@ describe("model-facing tools", () => {
       registry: {} as never,
     });
     try {
-      const followup = createModelFacingTools({
+      const assign = createModelFacingTools({
         workspaceRoot: process.cwd(),
         getSession: () => session,
-      }).find((tool) => tool.name === "followup_task")!;
+      }).find((tool) => tool.name === "assign_task")!;
 
-      const result = await followup.execute({
+      const result = await assign.execute({
         target: "/root/task_1",
         message: "report now",
       });
@@ -3451,7 +3463,7 @@ describe("model-facing tools", () => {
     }
   });
 
-  it("followup_task rejects the current root target from child context", async () => {
+  it("assign_task rejects the current root target from child context", async () => {
     const session = fakeSession();
     const mailboxSend = vi.fn(() => 1);
     (session as unknown as { mailbox: { hasPending: () => boolean; send: typeof mailboxSend } }).mailbox = {
@@ -3467,12 +3479,12 @@ describe("model-facing tools", () => {
     });
     _setAgentControlForTesting(session, { control, registry });
     try {
-      const followup = createModelFacingTools({
+      const assign = createModelFacingTools({
         workspaceRoot: process.cwd(),
         getSession: () => session,
-      }).find((tool) => tool.name === "followup_task")!;
+      }).find((tool) => tool.name === "assign_task")!;
 
-      const result = await followup.execute({
+      const result = await assign.execute({
         [SESSION_ID_ARG]: child.agentId,
         target: "/root",
         message: "run this",


### PR DESCRIPTION
## Summary
- refresh `parity/agent-surface-contract.json` to the current Rust reference checkout and renamed `assign_task` source
- expose `assign_task` as the canonical v2 trigger-turn agent tool while keeping `followup_task` as a deferred compatibility alias
- add a v2 parity map and update catalog/transcript tests for the canonical surface

Fixes #998

## Test plan
- [x] `npm run check:agent-surface-contract`
- [x] `npm run typecheck`
- [x] `npm --workspace=@tetsuo-ai/runtime run test -- tests/bin/model-facing-tools.test.ts tests/tool-registry.test.ts tests/tui/parity/session-transcript.test.ts tests/tui/parity/session-transcript.contract.test.ts`
- [x] `npm --workspace=@tetsuo-ai/runtime run check:unused`
- [x] `npm test`
- [x] `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- [x] `npm audit --audit-level=high`