### PR TITLE
fix(runtime): stabilize aggregate TUI e2e

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/126-at-picker-carriage-return-enter.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/126-at-picker-carriage-return-enter.mjs
@@ -35,6 +35,17 @@ export default async function (session) {
     timeout: 15_000,
     label: "files/resources picker",
   });
+  await waitForFrameText(
+    session,
+    /❯ \+ PLAN\.md/u,
+    "filtered PLAN.md picker selection",
+  );
+  await waitForFrameText(
+    session,
+    /❯\s*@PL/u,
+    "composer contains filtered file query",
+  );
+  await sleep(120);
 
   session.send("\r");
   await waitForFrameText(

--- a/runtime/scripts/check-tui-e2e/scenarios/49-paste-multiline.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/49-paste-multiline.mjs
@@ -16,6 +16,8 @@ export const meta = {
   description: "Multi-line bracketed paste is accepted without crash.",
   timeoutMs: 90_000,
   args: ["--yolo"],
+  useTempHome: true,
+  slimCwd: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/55-stdin-not-tty.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/55-stdin-not-tty.mjs
@@ -17,6 +17,11 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  createTempHome,
+  teardownTempHome,
+  trustProjectForHome,
+} from "../harness.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
@@ -27,35 +32,48 @@ const TIMEOUT_MS = 240_000;
 export const meta = {
   description: "Piped stdin (no TTY) routes through one-shot CLI path.",
   timeoutMs: TIMEOUT_MS + 30_000,
+  useTempHome: true,
+  slimCwd: true,
 };
 
-export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC], {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: process.env,
+export default async function (session) {
+  const { home, wsPort } = await createTempHome();
+  await trustProjectForHome(home, session.cwd);
+  try {
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [BIN_AGENC], {
+        cwd: session.cwd,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          HOME: home,
+          AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
+        },
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d.toString()));
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+      child.on("error", reject);
+      child.stdin.write("reply with the single word PIPED");
+      child.stdin.end();
+      setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error("piped stdin exceeded timeout"));
+      }, TIMEOUT_MS).unref();
     });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-    child.stdin.write("reply with the single word PIPED");
-    child.stdin.end();
-    setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("piped stdin exceeded timeout"));
-    }, TIMEOUT_MS).unref();
-  });
-  if (result.code !== 0) {
-    throw new Error(
-      `piped stdin exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
-    );
-  }
-  if (result.stdout.trim().length === 0) {
-    throw new Error(
-      `piped stdin produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
-    );
+    if (result.code !== 0) {
+      throw new Error(
+        `piped stdin exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
+      );
+    }
+    if (result.stdout.trim().length === 0) {
+      throw new Error(
+        `piped stdin produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
+      );
+    }
+  } finally {
+    await teardownTempHome(home);
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/58-cli-no-tui-flag.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/58-cli-no-tui-flag.mjs
@@ -8,6 +8,11 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  createTempHome,
+  teardownTempHome,
+  trustProjectForHome,
+} from "../harness.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
@@ -16,32 +21,50 @@ const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
 export const meta = {
   description: "--no-tui forces daemon one-shot path; produces stdout.",
   timeoutMs: 120_000,
+  useTempHome: true,
+  slimCwd: true,
 };
 
-export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      [BIN_AGENC, "--no-tui", "reply with the single word NOTUI"],
-      { stdio: ["ignore", "pipe", "pipe"], env: process.env },
-    );
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-    setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("--no-tui exceeded timeout"));
-    }, 110_000).unref();
-  });
-  if (result.code !== 0) {
-    throw new Error(
-      `--no-tui exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
-    );
-  }
-  if (result.stdout.trim().length === 0) {
-    throw new Error(`--no-tui produced no stdout; stderr: ${result.stderr.slice(0, 400)}`);
+export default async function (session) {
+  const { home, wsPort } = await createTempHome();
+  await trustProjectForHome(home, session.cwd);
+  try {
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [BIN_AGENC, "--no-tui", "reply with the single word NOTUI"],
+        {
+          cwd: session.cwd,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            HOME: home,
+            AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
+          },
+        },
+      );
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d.toString()));
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+      child.on("error", reject);
+      setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error("--no-tui exceeded timeout"));
+      }, 110_000).unref();
+    });
+    if (result.code !== 0) {
+      throw new Error(
+        `--no-tui exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
+      );
+    }
+    if (result.stdout.trim().length === 0) {
+      throw new Error(
+        `--no-tui produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
+      );
+    }
+  } finally {
+    await teardownTempHome(home);
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/59-daemon-stop-clean.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/59-daemon-stop-clean.mjs
@@ -33,6 +33,21 @@ function spawnSyncAgenc(args, timeoutMs = 15_000) {
   });
 }
 
+async function waitForStoppedStatus(timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = null;
+  while (Date.now() < deadline) {
+    lastStatus = await spawnSyncAgenc(["daemon", "status"]);
+    if (lastStatus.code !== 0 || !/running/.test(lastStatus.stdout)) {
+      return lastStatus;
+    }
+    await sleep(250);
+  }
+  throw new Error(
+    `daemon status still shows running after stop: ${lastStatus?.stdout ?? ""}`,
+  );
+}
+
 export const meta = {
   description: "daemon stop → status reports stopped, then start works.",
   timeoutMs: 30_000,
@@ -40,10 +55,14 @@ export const meta = {
 
 export default async function () {
   // Stop
-  await spawnSyncAgenc(["daemon", "stop"]);
-  await sleep(1_000);
+  const stopResult = await spawnSyncAgenc(["daemon", "stop"], 20_000);
+  if (stopResult.code !== 0) {
+    throw new Error(
+      `daemon stop failed (${stopResult.code}): ${stopResult.stderr}${stopResult.stdout}`,
+    );
+  }
   // Status should report stopped (exit non-zero or message)
-  const stoppedStatus = await spawnSyncAgenc(["daemon", "status"]);
+  const stoppedStatus = await waitForStoppedStatus();
   if (stoppedStatus.code === 0 && /running/.test(stoppedStatus.stdout)) {
     throw new Error(
       `daemon status shows running after stop: ${stoppedStatus.stdout}`,

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -172,6 +172,7 @@ const AGENC_DAEMON_WEBSOCKET_PATH_ENV = "AGENC_DAEMON_WEBSOCKET_PATH";
 const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV =
   "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
 const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 2_000;
+const DEFAULT_DAEMON_STOP_TIMEOUT_MS = 10_000;
 
 const DEFAULT_DAEMON_WEBSOCKET_URL = new URL(
   AGENC_PORTAL_DEFAULT_LOCAL_DAEMON_ENDPOINT,
@@ -528,15 +529,24 @@ async function runAgenCDaemonAction(
     case "start":
       return startAgenCDaemon(host, io);
     case "stop":
-      return stopAgenCDaemon(host, io, options.stopTimeoutMs ?? 2000);
+      return stopAgenCDaemon(
+        host,
+        io,
+        options.stopTimeoutMs ?? DEFAULT_DAEMON_STOP_TIMEOUT_MS,
+      );
     case "status":
       return statusAgenCDaemon(host, io, options);
     case "reload":
       return reloadAgenCDaemon(host, io);
     case "restart": {
-      await stopAgenCDaemon(host, io, options.stopTimeoutMs ?? 2000, {
-        quietWhenStopped: true,
-      });
+      await stopAgenCDaemon(
+        host,
+        io,
+        options.stopTimeoutMs ?? DEFAULT_DAEMON_STOP_TIMEOUT_MS,
+        {
+          quietWhenStopped: true,
+        },
+      );
       return startAgenCDaemon(host, io);
     }
     case "run":

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -816,6 +816,44 @@ describe("AgenC daemon CLI", () => {
     await rm(agencHome, { recursive: true, force: true });
   });
 
+  it("allows a running daemon more than two seconds to stop by default", async () => {
+    const agencHome = await tempAgencHome();
+    const baseHost = createHost(agencHome);
+    const io = createIo();
+    const pidPath = resolveAgenCDaemonPidPath(baseHost.env, baseHost.userHome);
+    const pid = 4301;
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    baseHost.runningPids.add(pid);
+    await writeAgenCDaemonPid(pidPath, pid);
+
+    const host: typeof baseHost = {
+      ...baseHost,
+      terminatePid: (targetPid) => {
+        baseHost.terminatedPids.push(targetPid);
+      },
+      sleep: async (ms) => {
+        now += ms;
+        if (now >= 2_500) {
+          baseHost.runningPids.delete(pid);
+        }
+      },
+    };
+
+    try {
+      await expect(
+        runAgenCDaemonCli({ kind: "command", action: "stop" }, { host, io }),
+      ).resolves.toBe(0);
+      expect(host.terminatedPids).toEqual([pid]);
+      await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+      expect(io.stdoutText()).toContain(`AgenC daemon stopped (pid ${pid})`);
+      expect(io.stderrText()).toBe("");
+    } finally {
+      nowSpy.mockRestore();
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
   it("treats stop with no daemon as already stopped", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);


### PR DESCRIPTION
## Summary
- isolate stateful TUI e2e scenarios with temp HOME/slim cwd so aggregate runs do not inherit shared daemon/session state
- harden at-picker carriage-return selection by waiting for the filtered picker frame before sending CR
- widen daemon stop/restart default wait to 10s and make daemon-stop e2e poll for stopped status

## Verification
- npm run build
- npm --workspace=@tetsuo-ai/runtime run test -- tests/app-server/daemon-cli.contract.test.ts
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 49-paste-multiline
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 126-at-picker-carriage-return-enter
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 59-daemon-stop-clean
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 58-cli-no-tui-flag
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 55-stdin-not-tty
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --range 55-59
- npm --workspace=@tetsuo-ai/runtime run check:e2e-all
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm test
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- npm audit --audit-level=high

Fixes #1000
Fixes #1001
Fixes #1002