### PR TITLE
chore(runtime): update axios dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -97,7 +97,7 @@
     "@shikijs/cli": "^4.1.0",
     "ajv": "^8.20.0",
     "auto-bind": "^5.0.1",
-    "axios": "^1.17.0",
+    "axios": "^1.18.0",
     "better-sqlite3": "^12.9.0",
     "bidi-js": "^1.0.3",
     "chalk": "^5.6.2",


### PR DESCRIPTION
## Summary
- update the runtime direct axios dependency from 1.17.0 to 1.18.0
- leave transitive package copies unchanged

## Verification
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tools/WebFetchTool/domainCheck.test.ts tests/services/api/sessionIngress.test.ts tests/services/api/fetchWithProxyRetry.test.ts tests/test-parity/upstream/security-hardening.test.ts tests/errors/runtime.test.ts tests/errors/api.test.ts
- npm run test:bun -- tests/utils/fastMode.test.ts
- npm test
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --audit-level=high
- npm outdated --json
- pre-commit hook: build + package entrypoints + TUI runtime startup smoke