### PR TITLE
fix(runtime): correct internal model error guidance

### DIFF
--- a/runtime/src/services/api/errors.ts
+++ b/runtime/src/services/api/errors.ts
@@ -48,6 +48,14 @@ import {
   type OpenAiCompatibilityFailureCategory,
 } from './openaiErrorClassification.js'
 export const API_ERROR_MESSAGE_PREFIX = 'API Error'
+const DEFAULT_FEEDBACK_CHANNEL =
+  'https://github.com/tetsuo-ai/agenc-core/issues'
+
+function getFeedbackChannel(): string {
+  return typeof MACRO === 'undefined'
+    ? DEFAULT_FEEDBACK_CHANNEL
+    : MACRO.FEEDBACK_CHANNEL
+}
 
 function stripOpenAiCompatibilityMetadata(message: string): string {
   return message
@@ -574,7 +582,7 @@ export function getAssistantMessageFromError(
     )
   ) {
     if (process.env.USER_TYPE === 'ant') {
-      const baseMessage = `API Error: 400 ${error.message}\n\nRun /share and post the JSON file to ${MACRO.FEEDBACK_CHANNEL}.`
+      const baseMessage = `API Error: 400 ${error.message}\n\nRun /share and post the JSON file to ${getFeedbackChannel()}.`
       const rewindInstruction = getIsNonInteractiveSession()
         ? ''
         : ' Then, use /rewind to recover the conversation.'
@@ -638,10 +646,10 @@ export function getAssistantMessageFromError(
   ) {
     // Get organization ID from config - only use OAuth account data when actively using OAuth
     const orgId = getOauthAccountInfo()?.organizationUuid
-    const baseMsg = `[internal] Your org isn't gated into the \`${model}\` model. Either run \`claude\` with \`ANTHROPIC_MODEL=${getDefaultMainLoopModelSetting()}\``
+    const baseMsg = `[internal] Your org isn't gated into the \`${model}\` model. Either run \`agenc\` with \`ANTHROPIC_MODEL=${getDefaultMainLoopModelSetting()}\``
     const msg = orgId
-      ? `${baseMsg} or share your orgId (${orgId}) in ${MACRO.FEEDBACK_CHANNEL} for help getting access.`
-      : `${baseMsg} or reach out in ${MACRO.FEEDBACK_CHANNEL} for help getting access.`
+      ? `${baseMsg} or share your orgId (${orgId}) in ${getFeedbackChannel()} for help getting access.`
+      : `${baseMsg} or reach out in ${getFeedbackChannel()} for help getting access.`
 
     return createAssistantAPIErrorMessage({
       content: msg,

--- a/runtime/tests/services/api/errors.openaiCompatibility.test.ts
+++ b/runtime/tests/services/api/errors.openaiCompatibility.test.ts
@@ -42,3 +42,33 @@ test('maps tool_call_incompatible category markers to model/tool guidance', () =
   expect(text).toContain('rejected tool-calling payloads')
   expect(text).toContain('/model')
 })
+
+test('internal invalid-model guidance uses the AgenC CLI name', () => {
+  const previousUserType = process.env.USER_TYPE
+  const previousAnthropicModel = process.env.ANTHROPIC_MODEL
+
+  try {
+    process.env.USER_TYPE = 'ant'
+    delete process.env.ANTHROPIC_MODEL
+
+    const message = getAssistantMessageFromError(
+      new Error('invalid model name'),
+      'internal-opus',
+    )
+    const text = getFirstText(message)
+
+    expect(text).toContain('Either run `agenc` with `ANTHROPIC_MODEL=')
+    expect(text).not.toContain('Either run `claude`')
+  } finally {
+    if (previousUserType === undefined) {
+      delete process.env.USER_TYPE
+    } else {
+      process.env.USER_TYPE = previousUserType
+    }
+    if (previousAnthropicModel === undefined) {
+      delete process.env.ANTHROPIC_MODEL
+    } else {
+      process.env.ANTHROPIC_MODEL = previousAnthropicModel
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- replace the legacy CLI name in the internal invalid-model guidance with `agenc`
- add a safe fallback for feedback-channel text when `errors.ts` is imported unbundled by tests/tooling
- add a focused Bun regression for the internal invalid-model branch

## Verification
- `npm run test:bun -- tests/services/api/errors.openaiCompatibility.test.ts`
- `npm run typecheck`
- `npm test`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm audit --audit-level=high`
- pre-commit hook: `npm run build`, package entrypoint check, TUI runtime startup smoke
- `git diff --check`

Fixes #1007
