### PR TITLE
chore(runtime): remove stale build todo reference

### DIFF
--- a/runtime/scripts/write-build-version.mjs
+++ b/runtime/scripts/write-build-version.mjs
@@ -3,7 +3,7 @@
  * Write `runtime/dist/VERSION` containing { commit, buildTime, runtimeVersion }
  * so the daemon can print a startup banner that proves which build is running.
  *
- * Cut 6.2 of the AgenC runtime refactor (TODO.MD).
+ * This script also copies runtime assets that must sit beside the built chunks.
  */
 
 import { chmodSync, cpSync, existsSync, mkdirSync, writeFileSync } from "node:fs";


### PR DESCRIPTION
## Summary
- replace the stale `TODO.MD` runtime-refactor comment in `write-build-version.mjs`
- describe the script's current asset-copy responsibility instead

## Verification
- `npm --workspace=@tetsuo-ai/runtime run build`
- `rg -n -F "TODO.MD" runtime/src runtime/scripts packages scripts docs README.md --glob '!runtime/dist/**'` returns no matches
- `git diff --check`
- pre-commit hook: `npm run build`, package entrypoint check, TUI runtime startup smoke

Fixes #1011
