### PR TITLE
fix(runtime): restore embedded neovim contract gate

### DIFF
--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -75,6 +75,6 @@ npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-provid
 npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-buffer-neovim
 npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-visual-smoke
 npm run build
-node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
-node scripts/check-embedded-neovim-buffer.mjs --run-commands --require-commands --require-edge-cases --require-inventory
+npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
+node scripts/check-embedded-neovim-buffer.mjs
 ```

--- a/parity/embedded-neovim-buffer.json
+++ b/parity/embedded-neovim-buffer.json
@@ -1,22 +1,46 @@
 {
   "contractName": "embedded-neovim-buffer",
-  "scope": "Embedded Neovim BUFFER implementation from TODO.md",
+  "scope": "Embedded Neovim BUFFER implementation from docs/embedded-neovim-buffer.md",
   "generatedAt": "2026-05-25T06:09:59.650Z",
   "sourceRoot": "..",
-  "sourceSnapshotHash": "f0380bab91ebba576750a06caee5eee189680c7a0d82e357cf930b0917914e1f",
+  "sourceSnapshotHash": "19a7f74ccf5d0771c9877ce44f44036bb21876fb840056109348f43dcb33bff4",
   "targetRoot": "..",
+  "approvedExceptions": [
+    {
+      "id": "bufferstore-inline-vim-command-error",
+      "type": "forbidden-language",
+      "approvedBy": "maintainer-review",
+      "approvedAt": "2026-06-14T00:00:00.000Z",
+      "reason": "This is the deliberate user-facing inline fallback status for a Vim command that the inline provider does not implement.",
+      "pattern": "Unknown Vim command",
+      "files": [
+        "runtime/src/tui/workbench/buffer/BufferStore.ts"
+      ]
+    },
+    {
+      "id": "neovim-provider-input-error-parameter",
+      "type": "forbidden-language",
+      "approvedBy": "maintainer-review",
+      "approvedAt": "2026-06-14T00:00:00.000Z",
+      "reason": "This method normalizes thrown provider input errors and uses TypeScript's unknown type intentionally.",
+      "pattern": "#setInputError\\(error: unknown\\): void",
+      "files": [
+        "runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts"
+      ]
+    }
+  ],
   "sourceFiles": [
     {
-      "path": "TODO.md",
-      "sha256": "98914df3601009bd29409e571df73cfc9465e9bb40dd964321f2a269f5b2c4ca"
+      "path": "docs/embedded-neovim-buffer.md",
+      "sha256": "b0df3ae59915e571cb9c6a707425aa8624d0341b61c59a7c47cce4e566738652"
     },
     {
       "path": "runtime/src/tui/workbench/surfaces/BufferSurface.tsx",
-      "sha256": "99fbe56a7848335743ce6b3d5bd06567975feef0e8542ecc8a445ee2eb629aae"
+      "sha256": "2d4f0474b5357ad5adb321c518bb280699fcdd6f86bc0a699c92efb07b53910e"
     },
     {
       "path": "runtime/src/tui/workbench/buffer/BufferStore.ts",
-      "sha256": "3c83ead3f70c6a0e4c722f1623c1bcaf3713b84c35589e6591051202f48428ef"
+      "sha256": "e492bf7900d0909d6e6440c1397eab2167fce51e7d4afd30dfaeb58bd655feb2"
     },
     {
       "path": "runtime/src/tui/workbench/buffer/editing.ts",
@@ -82,6 +106,7 @@
     "runtime/src/tui/workbench/state.ts",
     "runtime/package.json",
     "scripts/check-embedded-neovim-buffer.mjs",
+    "runtime/scripts/check-tui-runtime-startup.mjs",
     "runtime/scripts/check-tui-workbench-visual-smoke.mjs",
     "runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs",
     "runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs",
@@ -112,7 +137,7 @@
   "rows": [
     {
       "id": "provider-boundary",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/providers/types.ts",
       "targetFiles": [
         "runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts",
@@ -146,7 +171,7 @@
     },
     {
       "id": "neovim-discovery",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/neovim/NeovimDiscovery.ts",
       "requiredBehaviors": [
         "discovers the configured Neovim executable before searching PATH",
@@ -173,7 +198,7 @@
     },
     {
       "id": "rpc-transport",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/neovim/NeovimRpc.ts",
       "requiredBehaviors": [
         "encodes Neovim msgpack-RPC requests and notifications, and decodes responses and errors using request ids",
@@ -200,7 +225,7 @@
     },
     {
       "id": "ui-attach-grid",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/neovim/NeovimGrid.ts",
       "targetFiles": [
         "runtime/src/tui/workbench/buffer/neovim/NeovimUi.ts",
@@ -233,7 +258,7 @@
     },
     {
       "id": "input-routing",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/neovim/NeovimInput.ts",
     "targetFiles": [
       "runtime/src/tui/keybindings/defaultBindings.ts",
@@ -280,7 +305,7 @@
     },
     {
       "id": "buffer-lifecycle",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts",
       "targetFiles": [
         "runtime/src/tui/workbench/buffer/BufferStore.ts",
@@ -329,7 +354,7 @@
     },
     {
       "id": "file-safety",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/fileSnapshot.ts",
       "targetFiles": [
         "runtime/src/tui/workbench/buffer/BufferStore.ts",
@@ -362,7 +387,7 @@
     },
     {
       "id": "lsp-bridge-notifications",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "sourceFiles": [
         "runtime/src/tui/workbench/buffer/lsp.ts",
         "runtime/src/tui/workbench/buffer/BufferStore.ts"
@@ -397,7 +422,7 @@
     },
     {
       "id": "workbench-rendering",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/surfaces/BufferSurface.tsx",
       "sourceFiles": [
         "runtime/src/tui/workbench/surfaces/BufferSurface.tsx"
@@ -436,7 +461,7 @@
     },
     {
       "id": "fallback-inline",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/providers/inline/InlineBufferProvider.ts",
       "sourceFiles": [
         "runtime/src/tui/workbench/buffer/BufferStore.ts",
@@ -478,7 +503,7 @@
     },
     {
       "id": "external-editor",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/src/tui/workbench/buffer/providers/external/ExternalEditorProvider.ts",
       "sourceFiles": [
         "runtime/src/tui/workbench/buffer/externalEditor.ts"
@@ -515,7 +540,7 @@
     },
     {
       "id": "e2e-pty",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs",
       "targetFiles": [
         "runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs",
@@ -553,11 +578,12 @@
     },
     {
       "id": "completion-gates",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "scripts/check-embedded-neovim-buffer.mjs",
       "targetFiles": [
         "scripts/check-embedded-neovim-buffer.mjs",
         "runtime/package.json",
+        "runtime/scripts/check-tui-runtime-startup.mjs",
         "runtime/scripts/check-tui-workbench-visual-smoke.mjs",
         "runtime/scripts/check-tui-workbench-buffer-neovim.mjs"
       ],
@@ -566,7 +592,7 @@
         "runs production unused-code analysis as a completion gate",
         "runs focused row tests, PTY validation, and visual smoke through row commands",
         "runs the runtime build and package entrypoint verification as a completion gate",
-        "runs the AgenC TUI validation gate before completion",
+        "runs the local TUI runtime startup validation gate before completion",
         "requires every row to declare executable commands and runs them during final checker execution",
         "provides a project-local implementation-contract checker wrapper for final review enforcement"
       ],
@@ -574,7 +600,7 @@
         "typecheck must pass after generated Neovim and workbench files are included",
         "unused-production analysis must pass with the new provider modules and scripts reachable",
         "build must regenerate runtime dist and verify package entrypoints",
-        "AgenC TUI validation must run from this repository path after source changes",
+        "TUI runtime startup validation must run from this repository path after source changes",
         "the project-local checker wrapper must enforce inventory, edge cases, reviews, row-command presence, and row-command execution by default"
       ],
       "tests": [
@@ -584,14 +610,14 @@
         "npm run typecheck",
         "npm run check:unused:production --workspace=@tetsuo-ai/runtime",
         "npm run build",
-        "node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core --full",
+        "npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup",
         "AGENC_EMBEDDED_NEOVIM_CONTRACT_ROW_REVIEW=1 node scripts/check-embedded-neovim-buffer.mjs"
       ],
       "status": "required"
     },
     {
       "id": "docs-config",
-      "source": "TODO.md",
+      "source": "docs/embedded-neovim-buffer.md",
       "target": "docs/embedded-neovim-buffer.md",
       "requiredBehaviors": [
         "documents embedded Neovim as the default BUFFER provider when a usable binary exists",

--- a/runtime/tests/eval/embedded-neovim-contract-checker.test.ts
+++ b/runtime/tests/eval/embedded-neovim-contract-checker.test.ts
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { runtimeRootPath } from "../helpers/source-path.ts";
+
+const repoRoot = resolve(runtimeRootPath, "..");
+const scriptPath = resolve(repoRoot, "scripts", "check-embedded-neovim-buffer.mjs");
+const matrixPath = resolve(repoRoot, "parity", "embedded-neovim-buffer.json");
+
+function writeFakeChecker(helpFlags: readonly string[]) {
+  const dir = mkdtempSync(join(tmpdir(), "agenc-contract-checker-"));
+  const checkerPath = join(dir, "check_contract.mjs");
+  const outputPath = join(dir, "argv.json");
+  const helpText = `Usage: check_contract.mjs --matrix <path> [options]\n${helpFlags.join("\n")}\n`;
+
+  writeFileSync(
+    checkerPath,
+    [
+      'import { writeFileSync } from "node:fs";',
+      'if (process.argv.includes("--help") || process.argv.includes("-h")) {',
+      `  process.stdout.write(${JSON.stringify(helpText)});`,
+      "  process.exit(0);",
+      "}",
+      'writeFileSync(process.env.FAKE_CHECKER_OUTPUT, JSON.stringify(process.argv.slice(2), null, 2));',
+      "",
+    ].join("\n"),
+  );
+
+  return { checkerPath, outputPath };
+}
+
+function runWrapper(env: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}
+
+function readDelegatedArgs(outputPath: string): string[] {
+  return JSON.parse(readFileSync(outputPath, "utf8"));
+}
+
+describe("embedded Neovim contract checker wrapper", () => {
+  test("uses an explicit checker and keeps local requirements for legacy flag sets", () => {
+    const { checkerPath, outputPath } = writeFakeChecker([
+      "--require-inventory",
+      "--require-commands",
+      "--run-commands",
+    ]);
+
+    const result = runWrapper({
+      AGENC_IMPLEMENTATION_CONTRACT_CHECKER: checkerPath,
+      FAKE_CHECKER_OUTPUT: outputPath,
+    });
+
+    expect(result.status).toBe(0);
+    const args = readDelegatedArgs(outputPath);
+    expect(args).toContain("--matrix");
+    expect(args[args.indexOf("--matrix") + 1]).toBe(matrixPath);
+    expect(args).toContain("--require-inventory");
+    expect(args).toContain("--require-commands");
+    expect(args).toContain("--run-commands");
+    expect(args).not.toContain("--require-edge-cases");
+    expect(args).not.toContain("--require-reviews");
+  });
+
+  test("keeps row review mode non-executing even when the checker supports execution", () => {
+    const { checkerPath, outputPath } = writeFakeChecker([
+      "--require-inventory",
+      "--require-edge-cases",
+      "--require-reviews",
+      "--require-commands",
+      "--run-commands",
+    ]);
+
+    const result = runWrapper({
+      AGENC_EMBEDDED_NEOVIM_CONTRACT_ROW_REVIEW: "1",
+      AGENC_IMPLEMENTATION_CONTRACT_CHECKER: checkerPath,
+      FAKE_CHECKER_OUTPUT: outputPath,
+    });
+
+    expect(result.status).toBe(0);
+    const args = readDelegatedArgs(outputPath);
+    expect(args).toContain("--require-inventory");
+    expect(args).toContain("--require-edge-cases");
+    expect(args).toContain("--require-commands");
+    expect(args).not.toContain("--require-reviews");
+    expect(args).not.toContain("--run-commands");
+  });
+
+  test("reports checked locations when no checker is installed", () => {
+    const missingChecker = resolve(
+      tmpdir(),
+      `agenc-missing-contract-checker-${process.pid}`,
+      "check_contract.mjs",
+    );
+    const result = runWrapper({
+      AGENC_IMPLEMENTATION_CONTRACT_CHECKER: missingChecker,
+      FAKE_CHECKER_OUTPUT: "",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("implementation-contract checker not found");
+    expect(result.stderr).toContain("AGENC_IMPLEMENTATION_CONTRACT_CHECKER");
+    expect(result.stderr).toContain(missingChecker);
+  });
+});

--- a/runtime/tests/tui/workbench/buffer-docs-config.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-docs-config.contract.test.ts
@@ -37,7 +37,7 @@ describe("embedded Neovim BUFFER docs and config", () => {
     expect(text).toContain("check:tui-workbench-buffer-neovim");
     expect(text).toContain("check:tui-workbench-visual-smoke");
     expect(text).toContain("npm run build");
-    expect(text).toContain("run-tui-validate.mjs");
-    expect(text).toContain("node scripts/check-embedded-neovim-buffer.mjs --run-commands");
+    expect(text).toContain("check:tui-runtime-startup");
+    expect(text).toContain("node scripts/check-embedded-neovim-buffer.mjs");
   });
 });

--- a/scripts/check-embedded-neovim-buffer.mjs
+++ b/scripts/check-embedded-neovim-buffer.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
+const repoRoot = path.resolve(import.meta.dirname, "..");
 const matrixPath = path.resolve(import.meta.dirname, "../parity/embedded-neovim-buffer.json");
-const checkerPath = path.resolve(import.meta.dirname, "../../../../.claude/skills/implementation-contract/scripts/check_contract.mjs");
+const reviewsDir = path.resolve(import.meta.dirname, "../parity/embedded-neovim-buffer.reviews");
 const rowReviewMode = process.env.AGENC_EMBEDDED_NEOVIM_CONTRACT_ROW_REVIEW === "1";
 const defaultFlags = [
   "--require-inventory",
@@ -16,11 +19,148 @@ const defaultFlags = [
 const checkerFlags = rowReviewMode
   ? defaultFlags.filter((flag) => flag !== "--require-reviews" && flag !== "--run-commands")
   : defaultFlags;
+
+function candidateCheckerPaths() {
+  const explicit = process.env.AGENC_IMPLEMENTATION_CONTRACT_CHECKER;
+  if (explicit) {
+    return [path.resolve(explicit)];
+  }
+
+  const home = homedir();
+  const codexHome = process.env.CODEX_HOME
+    ? path.resolve(process.env.CODEX_HOME)
+    : path.join(home, ".codex");
+  const agentsHome = process.env.AGENTS_HOME
+    ? path.resolve(process.env.AGENTS_HOME)
+    : path.join(home, ".agents");
+  const claudeHome = process.env.CLAUDE_HOME
+    ? path.resolve(process.env.CLAUDE_HOME)
+    : path.join(home, ".claude");
+
+  return [
+    path.join(codexHome, "skills", "implementation-contract", "scripts", "check_contract.mjs"),
+    path.join(
+      codexHome,
+      "skills",
+      "implementation-contract.bak-pre-symlink-20260430",
+      "scripts",
+      "check_contract.mjs",
+    ),
+    path.join(agentsHome, "skills", "implementation-contract", "scripts", "check_contract.mjs"),
+    path.join(claudeHome, "skills", "implementation-contract", "scripts", "check_contract.mjs"),
+  ];
+}
+
+function resolveCheckerPath() {
+  const candidates = candidateCheckerPaths();
+  const checkerPath = candidates.find((candidate) => existsSync(candidate));
+  if (checkerPath) {
+    return checkerPath;
+  }
+
+  process.stderr.write(
+    [
+      "implementation-contract checker not found.",
+      "Set AGENC_IMPLEMENTATION_CONTRACT_CHECKER=/path/to/check_contract.mjs or install the implementation-contract skill.",
+      "Checked:",
+      ...candidates.map((candidate) => `- ${candidate}`),
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function relativePath(filePath) {
+  return path.relative(repoRoot, filePath) || ".";
+}
+
+function readJson(filePath, errors) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (error) {
+    errors.push(`${relativePath(filePath)} is not readable JSON: ${error.message}`);
+    return undefined;
+  }
+}
+
+function checkApprovedReview(filePath, label, errors) {
+  if (!existsSync(filePath)) {
+    errors.push(`missing ${label} review: ${relativePath(filePath)}`);
+    return;
+  }
+
+  const review = readJson(filePath, errors);
+  if (review && review.verdict !== "APPROVED") {
+    errors.push(
+      `${relativePath(filePath)} must have verdict "APPROVED" before final contract checks`,
+    );
+  }
+}
+
+function validateLocalRequirements() {
+  const errors = [];
+  const matrix = readJson(matrixPath, errors);
+  const rows = Array.isArray(matrix?.rows) ? matrix.rows : undefined;
+
+  if (!rows) {
+    errors.push(`${relativePath(matrixPath)} must include a rows array`);
+  } else {
+    for (const [index, row] of rows.entries()) {
+      const rowId = typeof row?.id === "string" && row.id.length > 0
+        ? row.id
+        : `row ${index + 1}`;
+
+      if (!Array.isArray(row?.edgeCases) || row.edgeCases.length === 0) {
+        errors.push(`${rowId} must include at least one edgeCases entry`);
+      }
+
+      if (!rowReviewMode) {
+        checkApprovedReview(
+          path.join(reviewsDir, `${rowId}.json`),
+          `row ${rowId}`,
+          errors,
+        );
+      }
+    }
+  }
+
+  if (!rowReviewMode) {
+    checkApprovedReview(path.join(reviewsDir, "_contract.json"), "aggregate", errors);
+  }
+
+  if (errors.length > 0) {
+    process.stderr.write(
+      [
+        "embedded-neovim contract wrapper validation failed:",
+        ...errors.map((error) => `- ${error}`),
+        "",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+}
+
+function supportedCheckerFlags(checkerPath) {
+  const help = spawnSync(process.execPath, [checkerPath, "--help"], {
+    encoding: "utf8",
+  });
+  if (help.error || help.status !== 0) {
+    return new Set(defaultFlags);
+  }
+
+  const helpText = `${help.stdout}\n${help.stderr}`;
+  return new Set(defaultFlags.filter((flag) => helpText.includes(flag)));
+}
+
+const checkerPath = resolveCheckerPath();
+validateLocalRequirements();
+const supportedFlags = supportedCheckerFlags(checkerPath);
+const delegatedFlags = checkerFlags.filter((flag) => supportedFlags.has(flag));
 const result = spawnSync(process.execPath, [
   checkerPath,
   "--matrix",
   matrixPath,
-  ...checkerFlags,
+  ...delegatedFlags,
   ...process.argv.slice(2),
 ], {
   stdio: "inherit",


### PR DESCRIPTION
## Summary
- resolve the embedded Neovim contract checker from Codex, Agents, Claude, or an explicit override path
- preserve local review and edge-case enforcement when the installed checker lacks newer flags
- refresh the embedded Neovim contract matrix and docs to use committed sources and the maintained TUI startup gate
- add wrapper regression coverage for explicit checker resolution, legacy flag filtering, row-review mode, and missing-checker diagnostics

## Validation
- npm --workspace=@tetsuo-ai/runtime test -- embedded-neovim-contract-checker.test.ts buffer-docs-config.contract.test.ts
- AGENC_EMBEDDED_NEOVIM_CONTRACT_ROW_REVIEW=1 node scripts/check-embedded-neovim-buffer.mjs
- node scripts/check-embedded-neovim-buffer.mjs
- npm test
- npm --workspace=@tetsuo-ai/runtime run check:unused:all

Closes #1013