### PR TITLE
fix(runtime): stabilize aggregate daemon e2e

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -39,6 +39,36 @@ const require = createRequire(path.join(RUNTIME_DIR, "package.json"));
 const pty = require("node-pty");
 
 const TRUST_FILE = path.join(homedir(), ".agenc", "trusted-projects.json");
+const TEMP_HOME_DAEMON_START_ATTEMPTS = 3;
+const TEMP_HOME_DAEMON_READY_TIMEOUT_MS = 20_000;
+
+function randomTempDaemonWebSocketPort() {
+  return 17_766 + Math.floor(Math.random() * 10_000);
+}
+
+function tempDaemonEnv(home, wsPort) {
+  return {
+    ...process.env,
+    HOME: home,
+    AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
+  };
+}
+
+async function waitForTempDaemonReady(env, timeoutMs = TEMP_HOME_DAEMON_READY_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = spawnSync(
+      process.execPath,
+      [BIN_AGENC, "daemon", "status"],
+      { encoding: "utf8", env, timeout: 5_000 },
+    );
+    if (status.status === 0 && /\brunning\b/.test(status.stdout)) {
+      return true;
+    }
+    await sleep(200);
+  }
+  return false;
+}
 
 /**
  * Ensure the given absolute path is in `~/.agenc/trusted-projects.json`. The
@@ -125,33 +155,43 @@ export async function createTempHome() {
       await copyFile(source, path.join(agencDir, name));
     }
   }
-  // Pre-start the daemon and wait for the Unix socket to bind. Without
-  // this, the spawned agenc CLI tries to connect before the daemon has
-  // finished binding (~5s in a fresh HOME) and dies with ENOENT.
+  // Pre-start the daemon and wait for status to report running. Without
+  // this, the spawned agenc CLI can connect before the daemon has finished
+  // writing its cookie/socket readiness markers and fail autostart.
   //
   // The daemon also binds a WebSocket on AGENC_DAEMON_WEBSOCKET_PORT
   // (default 7766) for portal/IDE clients. The user's main daemon is
   // already on 7766, so each temp HOME daemon must use a different
   // port. Random in 17766–27765 to avoid collisions with each other
   // and with anything else on the dev box.
-  const wsPort = 17_766 + Math.floor(Math.random() * 10_000);
-  const daemonEnv = {
-    ...process.env,
-    HOME: home,
-    AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
-  };
-  spawnSync(
-    process.execPath,
-    [BIN_AGENC, "daemon", "start"],
-    { encoding: "utf8", env: daemonEnv, timeout: 30_000 },
-  );
-  const socketPath = path.join(agencDir, "daemon.sock");
-  const deadline = Date.now() + 20_000;
-  while (Date.now() < deadline) {
-    if (existsSync(socketPath)) break;
-    await new Promise((r) => setTimeout(r, 200));
+  let lastStart = null;
+  for (let attempt = 1; attempt <= TEMP_HOME_DAEMON_START_ATTEMPTS; attempt += 1) {
+    const wsPort = randomTempDaemonWebSocketPort();
+    const daemonEnv = tempDaemonEnv(home, wsPort);
+    lastStart = spawnSync(
+      process.execPath,
+      [BIN_AGENC, "daemon", "start"],
+      { encoding: "utf8", env: daemonEnv, timeout: 30_000 },
+    );
+    if (await waitForTempDaemonReady(daemonEnv)) {
+      return { home, wsPort };
+    }
+    spawnSync(
+      process.execPath,
+      [BIN_AGENC, "daemon", "stop"],
+      { encoding: "utf8", env: daemonEnv, timeout: 10_000 },
+    );
+    await rm(path.join(agencDir, "daemon.pid"), { force: true });
+    await rm(path.join(agencDir, "daemon.sock"), { force: true });
   }
-  return { home, wsPort };
+  throw new Error(
+    [
+      "temp HOME daemon did not become ready",
+      `start status: ${lastStart?.status ?? "unknown"}`,
+      `stdout: ${lastStart?.stdout ?? ""}`,
+      `stderr: ${lastStart?.stderr ?? ""}`,
+    ].join("\n"),
+  );
 }
 
 /**

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -129,6 +129,7 @@ const AGENC_DAEMON_SOCKET_FILENAME = "daemon.sock";
 const AGENC_DAEMON_COOKIE_FILENAME = "daemon.cookie";
 const AGENC_DAEMON_SNAPSHOT_FILENAME = "daemon-snapshot.json";
 const AGENC_DAEMON_LOG_FILENAME = "daemon.log";
+const AGENC_DAEMON_FORCE_STOP_GRACE_MS = 2_000;
 
 /**
  * Env override (megabytes) for the detached daemon's V8 old-space cap, and the
@@ -211,7 +212,7 @@ export interface AgenCDaemonCliHost {
   readonly pid: number;
   spawnDetachedDaemon(env: NodeJS.ProcessEnv): number;
   isPidRunning(pid: number): boolean;
-  terminatePid(pid: number): void;
+  terminatePid(pid: number, signal?: NodeJS.Signals): void;
   sleep(ms: number): Promise<void>;
 }
 
@@ -610,14 +611,25 @@ async function stopAgenCDaemon(
     return 0;
   }
 
-  host.terminatePid(pid);
+  host.terminatePid(pid, "SIGTERM");
   const stopped = await waitForPidExit(host, pid, timeoutMs);
   if (!stopped) {
-    io.stderr.write(`agenc: daemon did not stop before timeout (pid ${pid})\n`);
-    return 1;
+    io.stderr.write(
+      `agenc: daemon did not stop gracefully before timeout (pid ${pid}); forcing stop\n`,
+    );
+    host.terminatePid(pid, "SIGKILL");
+    const forceStopped = await waitForPidExit(
+      host,
+      pid,
+      AGENC_DAEMON_FORCE_STOP_GRACE_MS,
+    );
+    if (!forceStopped) {
+      io.stderr.write(`agenc: daemon did not stop before timeout (pid ${pid})\n`);
+      return 1;
+    }
   }
 
-  await removeAgenCDaemonPid(pidPath);
+  await removeAgenCDaemonPid(pidPath, pid);
   io.stdout.write(`AgenC daemon stopped (pid ${pid})\n`);
   return 0;
 }
@@ -2713,8 +2725,8 @@ export function createNodeDaemonCliHost(): AgenCDaemonCliHost {
         return false;
       }
     },
-    terminatePid: (pid) => {
-      process.kill(pid, "SIGTERM");
+    terminatePid: (pid, signal = "SIGTERM") => {
+      process.kill(pid, signal);
     },
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   };

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -141,10 +141,18 @@ function createIo(): AgenCDaemonCliIo & {
 function createHost(agencHome: string): AgenCDaemonCliHost & {
   readonly runningPids: Set<number>;
   readonly terminatedPids: number[];
+  readonly terminatedSignals: Array<{
+    readonly pid: number;
+    readonly signal: NodeJS.Signals;
+  }>;
 } {
   let nextPid = 4200;
   const runningPids = new Set<number>();
   const terminatedPids: number[] = [];
+  const terminatedSignals: Array<{
+    readonly pid: number;
+    readonly signal: NodeJS.Signals;
+  }> = [];
   return {
     env: {
       AGENC_HOME: agencHome,
@@ -156,14 +164,16 @@ function createHost(agencHome: string): AgenCDaemonCliHost & {
     pid: 4100,
     runningPids,
     terminatedPids,
+    terminatedSignals,
     spawnDetachedDaemon: () => {
       nextPid += 1;
       runningPids.add(nextPid);
       return nextPid;
     },
     isPidRunning: (pid) => runningPids.has(pid),
-    terminatePid: (pid) => {
+    terminatePid: (pid, signal = "SIGTERM") => {
       terminatedPids.push(pid);
+      terminatedSignals.push({ pid, signal });
       runningPids.delete(pid);
     },
     sleep: async () => {},
@@ -848,6 +858,51 @@ describe("AgenC daemon CLI", () => {
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
       expect(io.stdoutText()).toContain(`AgenC daemon stopped (pid ${pid})`);
       expect(io.stderrText()).toBe("");
+    } finally {
+      nowSpy.mockRestore();
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
+  it("force-stops a daemon that ignores graceful termination", async () => {
+    const agencHome = await tempAgencHome();
+    const baseHost = createHost(agencHome);
+    const io = createIo();
+    const pidPath = resolveAgenCDaemonPidPath(baseHost.env, baseHost.userHome);
+    const pid = 4302;
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    baseHost.runningPids.add(pid);
+    await writeAgenCDaemonPid(pidPath, pid);
+
+    const host: typeof baseHost = {
+      ...baseHost,
+      terminatePid: (targetPid, signal = "SIGTERM") => {
+        baseHost.terminatedPids.push(targetPid);
+        baseHost.terminatedSignals.push({ pid: targetPid, signal });
+        if (signal === "SIGKILL") {
+          baseHost.runningPids.delete(targetPid);
+        }
+      },
+      sleep: async (ms) => {
+        now += ms;
+      },
+    };
+
+    try {
+      await expect(
+        runAgenCDaemonCli(
+          { kind: "command", action: "stop" },
+          { host, io, stopTimeoutMs: 75 },
+        ),
+      ).resolves.toBe(0);
+      expect(host.terminatedSignals).toEqual([
+        { pid, signal: "SIGTERM" },
+        { pid, signal: "SIGKILL" },
+      ]);
+      await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+      expect(io.stdoutText()).toContain(`AgenC daemon stopped (pid ${pid})`);
+      expect(io.stderrText()).toContain("forcing stop");
     } finally {
       nowSpy.mockRestore();
       await rm(agencHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- force-stop daemons that ignore graceful `daemon stop` termination before reporting failure
- make TUI e2e temp HOME daemon startup wait for `daemon status` readiness instead of socket existence
- add a daemon CLI contract regression test for SIGTERM-to-SIGKILL fallback

Closes #1015

## Verification
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/app-server/daemon-cli.contract.test.ts --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run build`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 59-daemon-stop-clean`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 35-yolo-tool-edit`
- `npm --workspace=@tetsuo-ai/runtime run check:e2e-all`
- `npm test`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `git diff --check`
- pre-commit hook: build + package entrypoints + TUI runtime startup smoke