### PR TITLE
test(runtime): remove stale todo render fixtures

### DIFF
--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -1307,7 +1307,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
             toolName: { name: "FileRead" },
             payload: {
               kind: "function",
-              arguments: "{\"file_path\":\"TODO.MD\"}",
+              arguments: "{\"file_path\":\"README.md\"}",
             },
             source: "direct",
           },
@@ -1728,7 +1728,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           type: "tool_input_delta",
           payload: {
             index: 0,
-            partialJson: "{\"file_path\":\"TODO.MD\"",
+            partialJson: "{\"file_path\":\"README.md\"",
           },
         },
       ],


### PR DESCRIPTION
## Summary
- replace stale `TODO.MD` fixture paths in TUI render tests with `README.md`
- keep the same FileRead/tool-input JSON shapes while removing deleted-path marker noise

Closes #1017

## Verification
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/components/App.render.test.tsx --reporter=dot`
- `git diff --check`
- `rg -n -F "TODO.MD" runtime/tests/tui/components/App.render.test.tsx runtime/src runtime/scripts scripts docs README.md parity --glob "!runtime/dist/**" --glob "!node_modules/**"`
- pre-commit hook: build + package entrypoints + TUI runtime startup smoke