### PR TITLE
docs(runtime): update SDK prompt example model

### DIFF
--- a/runtime/src/entrypoints/agentSdkTypes.ts
+++ b/runtime/src/entrypoints/agentSdkTypes.ts
@@ -116,7 +116,6 @@ export function unstable_v2_resumeSession(
   throw new Error('unstable_v2_resumeSession is not implemented in the SDK')
 }
 
-// @[MODEL LAUNCH]: Update the example model ID in this docstring.
 /**
  * V2 API - UNSTABLE
  * One-shot convenience function for single prompts.
@@ -125,7 +124,7 @@ export function unstable_v2_resumeSession(
  * @example
  * ```typescript
  * const result = await unstable_v2_prompt("What files are here?", {
- *   model: 'claude-sonnet-4-6'
+ *   model: 'grok-4.3'
  * })
  * ```
  */


### PR DESCRIPTION
## Summary
- remove the stale model-launch reminder from the SDK prompt docstring
- update the example model from `claude-sonnet-4-6` to the AgenC default `grok-4.3`

Closes #1019

## Verification
- `npm run typecheck`
- `git diff --check`
- `rg -n "MODEL LAUNCH|claude-sonnet-4-6" runtime/src/entrypoints/agentSdkTypes.ts`
- pre-commit hook: build + package entrypoints + TUI runtime startup smoke