### PR TITLE
chore(runtime): add local vllm smoke gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ that home. Key knobs:
 | `AGENC_HOME` | Root for all on-disk state (default `~/.agenc`). |
 | `XAI_API_KEY` / `GROK_API_KEY` | xAI credentials (default provider). |
 | `AGENC_MODEL` | Override the default model (`grok-4.3`). |
+| `AGENC_LOCAL_VLLM_BASE_URL` | Local vLLM/OpenAI-compatible smoke endpoint (default `http://127.0.0.1:8000/v1`). |
+| `AGENC_LOCAL_VLLM_MODEL` | Optional model override for `npm run check:local-vllm`. |
 | `AGENC_DAEMON_AUTOSTART=0` | Disable launcher daemon autostart. |
 | `AGENC_DAEMON_READY_TIMEOUT_MS` | Launcher daemon-ready timeout. |
 | `config.toml` (via `agenc config`) | Persisted config: providers, MCP servers, permissions, profiles. |
@@ -264,6 +266,7 @@ npm run build            # esbuild bundle → runtime/dist + VERSION
 npm run test             # typecheck + full vitest suite
 npm run test:bun         # isolated Bun suite (one file per process)
 npm run validate:runtime # typecheck + build + PTY startup smoke
+npm run check:local-vllm # local vLLM/OpenAI-compatible /models + chat smoke
 ```
 
 Runtime-scoped gates (`npm --workspace=@tetsuo-ai/runtime run <name>`):
@@ -273,9 +276,14 @@ check:tui-runtime-startup   # launch agenc / agenc --yolo in real PTYs
 check:tui-e2e               # TUI scenario suite (-- --filter <name>)
 check:daemon-errors
 check:llm-pipeline
+check:local-vllm           # local-only OpenAI-compatible endpoint smoke
 check:e2e-all               # daemon-errors + llm-pipeline + tui-e2e
 check:unused                # knip (unused exports/files/deps)
 ```
+
+`check:local-vllm` refuses non-loopback endpoints unless `--allow-nonlocal` is
+passed explicitly. For Ollama's OpenAI-compatible local endpoint, use
+`AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1`.
 
 `check:tui-runtime-startup` imports the built TUI bundle and launches `agenc`
 and `agenc --yolo` in real pseudo-terminals at several viewport sizes — keep it

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "validate:tui-core-parity": "npm --workspace=@tetsuo-ai/runtime run validate:tui-core-parity",
     "check:agent-surface-contract": "node scripts/check-agent-surface-contract.mjs",
     "check:agent-surface-contract:reviewed": "node scripts/check-agent-surface-contract.mjs --require-reviews",
+    "check:local-vllm": "npm --workspace=@tetsuo-ai/runtime run check:local-vllm --",
     "check:tui-v2-design-audit": "npm run check:tui-v2-design-audit --workspace=@tetsuo-ai/runtime",
     "test": "npm run typecheck --workspace=@tetsuo-ai/runtime && npm run test --workspace=@tetsuo-ai/runtime",
     "test:unit": "npm run test --workspace=@tetsuo-ai/runtime",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -41,6 +41,7 @@
     "check:tui-workbench-transcript-scroll": "node scripts/check-tui-workbench-transcript-scroll.mjs",
     "check:tui-v2-design-audit": "npm run build && vitest run tests/tui/components/v2/designStateSmoke.test.tsx && node scripts/check-tui-command-visual-smoke.mjs",
     "check:llm-pipeline": "node scripts/check-llm-pipeline/runner.mjs",
+    "check:local-vllm": "node scripts/check-local-vllm-smoke.mjs",
     "check:daemon-errors": "node scripts/check-daemon-errors/runner.mjs",
     "check:e2e-all": "npm run check:daemon-errors && npm run check:llm-pipeline && npm run check:tui-e2e",
     "check:unused": "knip --config knip.config.mjs --production --no-progress",

--- a/runtime/scripts/check-local-vllm-smoke.mjs
+++ b/runtime/scripts/check-local-vllm-smoke.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+import { isIP } from "node:net";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export const DEFAULT_LOCAL_VLLM_BASE_URL = "http://127.0.0.1:8000/v1";
+export const DEFAULT_LOCAL_VLLM_API_KEY = "local-vllm-smoke-key";
+export const DEFAULT_LOCAL_VLLM_TIMEOUT_MS = 30_000;
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseBoolean(value) {
+  if (value === undefined) return false;
+  return /^(1|true|yes|on)$/i.test(value);
+}
+
+function parsePositiveInteger(value, fallback, label) {
+  if (value === undefined || value === "") return fallback;
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function takeOptionValue(args, option) {
+  const value = args.shift();
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/check-local-vllm-smoke.mjs [options]",
+    "",
+    "Checks a local vLLM/OpenAI-compatible endpoint without using remote APIs.",
+    "",
+    "Options:",
+    "  --base-url <url>      Endpoint base URL (default: AGENC_LOCAL_VLLM_BASE_URL or http://127.0.0.1:8000/v1)",
+    "  --model <id>          Model ID (default: first /models result)",
+    "  --api-key <key>       Bearer token (default: local placeholder)",
+    "  --timeout-ms <ms>     Request timeout (default: 30000)",
+    "  --models-only         Check /models without sending a chat completion",
+    "  --allow-nonlocal      Allow non-loopback base URLs",
+    "  --json                Print machine-readable result",
+    "  -h, --help            Show this help",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    baseUrl: undefined,
+    model: undefined,
+    apiKey: undefined,
+    timeoutMs: undefined,
+    modelsOnly: false,
+    allowNonLocal: false,
+    json: false,
+    help: false,
+  };
+
+  const args = [...argv];
+  while (args.length > 0) {
+    const arg = args.shift();
+    switch (arg) {
+      case "--base-url":
+        parsed.baseUrl = takeOptionValue(args, arg);
+        break;
+      case "--model":
+        parsed.model = takeOptionValue(args, arg);
+        break;
+      case "--api-key":
+        parsed.apiKey = takeOptionValue(args, arg);
+        break;
+      case "--timeout-ms":
+        parsed.timeoutMs = takeOptionValue(args, arg);
+        break;
+      case "--models-only":
+        parsed.modelsOnly = true;
+        break;
+      case "--allow-nonlocal":
+        parsed.allowNonLocal = true;
+        break;
+      case "--json":
+        parsed.json = true;
+        break;
+      case "-h":
+      case "--help":
+        parsed.help = true;
+        break;
+      default:
+        if (arg?.startsWith("--base-url=")) {
+          parsed.baseUrl = arg.slice("--base-url=".length);
+        } else if (arg?.startsWith("--model=")) {
+          parsed.model = arg.slice("--model=".length);
+        } else if (arg?.startsWith("--api-key=")) {
+          parsed.apiKey = arg.slice("--api-key=".length);
+        } else if (arg?.startsWith("--timeout-ms=")) {
+          parsed.timeoutMs = arg.slice("--timeout-ms=".length);
+        } else {
+          throw new Error(`unknown option: ${arg}`);
+        }
+    }
+  }
+
+  return parsed;
+}
+
+export function normalizeBaseUrl(rawBaseUrl) {
+  const trimmed = rawBaseUrl.trim().replace(/\/+$/, "");
+  const url = new URL(trimmed);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("base URL must use http or https");
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+export function isLoopbackUrl(baseUrl) {
+  const url = new URL(baseUrl);
+  if (LOCAL_HOSTNAMES.has(url.hostname)) return true;
+  const ipKind = isIP(url.hostname);
+  return ipKind === 4 && url.hostname.startsWith("127.");
+}
+
+export function assertLocalBaseUrl(baseUrl, allowNonLocal = false) {
+  if (allowNonLocal || isLoopbackUrl(baseUrl)) return;
+  throw new Error(
+    [
+      `refusing non-local OpenAI-compatible endpoint: ${baseUrl}`,
+      "Use --allow-nonlocal only for an explicitly approved private endpoint.",
+    ].join("\n"),
+  );
+}
+
+export function selectModel(modelsResponse, requestedModel) {
+  if (requestedModel && requestedModel.trim().length > 0) {
+    return requestedModel.trim();
+  }
+  const models = Array.isArray(modelsResponse?.data) ? modelsResponse.data : [];
+  const firstModel = models
+    .map((model) => model?.id)
+    .find((id) => typeof id === "string" && id.trim().length > 0);
+  if (!firstModel) {
+    throw new Error("local endpoint returned no models; pass --model explicitly");
+  }
+  return firstModel;
+}
+
+export function buildChatRequest(model) {
+  return {
+    model,
+    messages: [
+      {
+        role: "user",
+        content: "Reply with exactly LOCAL_VLLM_SMOKE_OK.",
+      },
+    ],
+    temperature: 0,
+    max_tokens: 16,
+    stream: false,
+  };
+}
+
+export function resolveSmokeConfig({
+  argv = process.argv.slice(2),
+  env = process.env,
+} = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { help: true };
+  }
+
+  const baseUrl = normalizeBaseUrl(
+    firstNonEmpty(
+      args.baseUrl,
+      env.AGENC_LOCAL_VLLM_BASE_URL,
+      env.AGENC_LOCAL_OPENAI_BASE_URL,
+      env.OPENAI_BASE_URL,
+      DEFAULT_LOCAL_VLLM_BASE_URL,
+    ),
+  );
+  const allowNonLocal =
+    args.allowNonLocal ||
+    parseBoolean(env.AGENC_LOCAL_VLLM_ALLOW_NONLOCAL) ||
+    parseBoolean(env.AGENC_LOCAL_OPENAI_ALLOW_NONLOCAL);
+  assertLocalBaseUrl(baseUrl, allowNonLocal);
+
+  return {
+    help: false,
+    baseUrl,
+    requestedModel: firstNonEmpty(
+      args.model,
+      env.AGENC_LOCAL_VLLM_MODEL,
+      env.AGENC_LOCAL_OPENAI_MODEL,
+      env.AGENC_MODEL,
+    ),
+    apiKey: firstNonEmpty(
+      args.apiKey,
+      env.AGENC_LOCAL_VLLM_API_KEY,
+      env.AGENC_LOCAL_OPENAI_API_KEY,
+      env.OPENAI_COMPATIBLE_API_KEY,
+      DEFAULT_LOCAL_VLLM_API_KEY,
+    ),
+    timeoutMs: parsePositiveInteger(
+      args.timeoutMs ?? env.AGENC_LOCAL_VLLM_TIMEOUT_MS,
+      DEFAULT_LOCAL_VLLM_TIMEOUT_MS,
+      "timeout",
+    ),
+    modelsOnly: args.modelsOnly || parseBoolean(env.AGENC_LOCAL_VLLM_MODELS_ONLY),
+    json: args.json,
+    allowNonLocal,
+  };
+}
+
+function endpointUrl(baseUrl, suffix) {
+  return `${baseUrl}${suffix.startsWith("/") ? suffix : `/${suffix}`}`;
+}
+
+async function fetchJson(url, {
+  apiKey,
+  timeoutMs,
+  method = "GET",
+  body,
+} = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method,
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+        ...(body ? { "Content-Type": "application/json" } : {}),
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    const text = await response.text();
+    let parsed = null;
+    if (text.trim().length > 0) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        throw new Error(`${url} returned non-JSON response: ${text.slice(0, 200)}`);
+      }
+    }
+    if (!response.ok) {
+      throw new Error(`${url} returned HTTP ${response.status}: ${text.slice(0, 300)}`);
+    }
+    return parsed;
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error(`${url} timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function assertChatCompletion(response) {
+  const choice = Array.isArray(response?.choices) ? response.choices[0] : undefined;
+  const content = choice?.message?.content;
+  if (typeof content === "string" && content.length > 0) {
+    return content;
+  }
+  throw new Error("chat completion response did not include choices[0].message.content");
+}
+
+export async function runSmoke(config) {
+  const models = await fetchJson(endpointUrl(config.baseUrl, "/models"), {
+    apiKey: config.apiKey,
+    timeoutMs: config.timeoutMs,
+  });
+  const model = selectModel(models, config.requestedModel);
+  const result = {
+    baseUrl: config.baseUrl,
+    model,
+    models: Array.isArray(models?.data) ? models.data.length : 0,
+    chat: config.modelsOnly ? "skipped" : "passed",
+  };
+
+  if (!config.modelsOnly) {
+    const chat = await fetchJson(endpointUrl(config.baseUrl, "/chat/completions"), {
+      apiKey: config.apiKey,
+      timeoutMs: config.timeoutMs,
+      method: "POST",
+      body: buildChatRequest(model),
+    });
+    result.sample = assertChatCompletion(chat).slice(0, 120);
+  }
+
+  return result;
+}
+
+async function main() {
+  const config = resolveSmokeConfig();
+  if (config.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+
+  const result = await runSmoke(config);
+  if (config.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return 0;
+  }
+
+  process.stdout.write(
+    [
+      "Local vLLM/OpenAI-compatible smoke passed",
+      `- baseUrl: ${result.baseUrl}`,
+      `- model: ${result.model}`,
+      `- models: ${result.models}`,
+      `- chat: ${result.chat}`,
+      ...(result.sample ? [`- sample: ${result.sample}`] : []),
+      "",
+    ].join("\n"),
+  );
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      process.stderr.write(`local vLLM smoke failed: ${error?.message ?? error}\n`);
+      process.exit(1);
+    });
+}

--- a/runtime/src/utils/profilerBase.ts
+++ b/runtime/src/utils/profilerBase.ts
@@ -4,7 +4,8 @@
  * line format for detailed reports.
  */
 
-import type { performance as PerformanceType } from 'perf_hooks'
+import { performance as nodePerformance } from 'node:perf_hooks'
+import type { performance as PerformanceType } from 'node:perf_hooks'
 import { formatFileSize } from './format.js'
 
 // Lazy-load performance API only when profiling is enabled.
@@ -13,8 +14,7 @@ let performance: typeof PerformanceType | null = null
 
 export function getPerformance(): typeof PerformanceType {
   if (!performance) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    performance = require('perf_hooks').performance
+    performance = nodePerformance
   }
   return performance!
 }

--- a/runtime/tests/scripts/check-local-vllm-smoke.test.ts
+++ b/runtime/tests/scripts/check-local-vllm-smoke.test.ts
@@ -1,0 +1,244 @@
+import { createServer, type IncomingMessage } from "node:http";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import { runtimeRootPath } from "../helpers/source-path.ts";
+
+const scriptPath = resolve(runtimeRootPath, "scripts", "check-local-vllm-smoke.mjs");
+
+type SmokeModule = {
+  assertLocalBaseUrl(baseUrl: string, allowNonLocal?: boolean): void;
+  buildChatRequest(model: string): unknown;
+  isLoopbackUrl(baseUrl: string): boolean;
+  resolveSmokeConfig(options: { argv?: string[]; env?: NodeJS.ProcessEnv }): {
+    readonly baseUrl: string;
+    readonly requestedModel?: string;
+    readonly modelsOnly: boolean;
+    readonly timeoutMs: number;
+  };
+  selectModel(modelsResponse: unknown, requestedModel?: string): string;
+};
+
+async function loadSmokeModule(): Promise<SmokeModule> {
+  return await import(pathToFileURL(scriptPath).href) as SmokeModule;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolveBody) => {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    request.on("end", () => resolveBody(body));
+  });
+}
+
+function runScript(args: string[], env: NodeJS.ProcessEnv): Promise<{
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}> {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: runtimeRootPath,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      resolveRun({ status, stdout, stderr });
+    });
+  });
+}
+
+const servers: Array<{ close: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  const closing = servers.splice(0);
+  await Promise.all(closing.map((server) => server.close()));
+});
+
+async function startFakeOpenAiCompatibleServer() {
+  const requests: Array<{
+    readonly method: string | undefined;
+    readonly url: string | undefined;
+    readonly body: unknown;
+    readonly authorization: string | undefined;
+  }> = [];
+  const server = createServer(async (request, response) => {
+    const rawBody = await readBody(request);
+    const body = rawBody.length > 0 ? JSON.parse(rawBody) : null;
+    requests.push({
+      method: request.method,
+      url: request.url,
+      body,
+      authorization: request.headers.authorization,
+    });
+
+    if (request.method === "GET" && request.url === "/v1/models") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({
+        object: "list",
+        data: [{ id: "fake-local-model", object: "model" }],
+      }));
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/v1/chat/completions") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({
+        id: "chatcmpl-local",
+        object: "chat.completion",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "LOCAL_VLLM_SMOKE_OK",
+            },
+            finish_reason: "stop",
+          },
+        ],
+      }));
+      return;
+    }
+
+    response.writeHead(404, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fake server did not bind to a TCP port");
+  }
+  servers.push({
+    close: () => new Promise((resolveClose, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolveClose();
+      });
+    }),
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+  };
+}
+
+describe("check-local-vllm-smoke helpers", () => {
+  test("accepts loopback URLs and rejects nonlocal URLs by default", async () => {
+    const smoke = await loadSmokeModule();
+
+    expect(smoke.isLoopbackUrl("http://127.0.0.1:8000/v1")).toBe(true);
+    expect(smoke.isLoopbackUrl("http://localhost:8000/v1")).toBe(true);
+    expect(smoke.isLoopbackUrl("https://api.openai.com/v1")).toBe(false);
+    expect(() => smoke.assertLocalBaseUrl("https://api.openai.com/v1")).toThrow(
+      /refusing non-local/i,
+    );
+    expect(() => smoke.assertLocalBaseUrl(
+      "https://api.openai.com/v1",
+      true,
+    )).not.toThrow();
+  });
+
+  test("prefers an explicit model and otherwise uses the first discovered model", async () => {
+    const smoke = await loadSmokeModule();
+    const response = { data: [{ id: "first-local" }, { id: "second-local" }] };
+
+    expect(smoke.selectModel(response)).toBe("first-local");
+    expect(smoke.selectModel(response, " explicit-local ")).toBe("explicit-local");
+    expect(() => smoke.selectModel({ data: [] })).toThrow(/no models/i);
+  });
+
+  test("resolves safe defaults without carrying remote provider settings", async () => {
+    const smoke = await loadSmokeModule();
+
+    const config = smoke.resolveSmokeConfig({
+      argv: ["--models-only"],
+      env: {
+        OPENAI_BASE_URL: "http://127.0.0.1:11434/v1",
+        AGENC_MODEL: "local-model",
+      },
+    });
+
+    expect(config.baseUrl).toBe("http://127.0.0.1:11434/v1");
+    expect(config.requestedModel).toBe("local-model");
+    expect(config.modelsOnly).toBe(true);
+    expect(config.timeoutMs).toBe(30_000);
+  });
+
+  test("rejects malformed CLI values before network access", async () => {
+    const smoke = await loadSmokeModule();
+
+    expect(() => smoke.resolveSmokeConfig({
+      argv: ["--base-url"],
+      env: {},
+    })).toThrow(/requires a value/i);
+    expect(() => smoke.resolveSmokeConfig({
+      argv: ["--timeout-ms", "10seconds"],
+      env: {},
+    })).toThrow(/positive integer/i);
+  });
+
+  test("builds a minimal non-streaming chat-completions request", async () => {
+    const smoke = await loadSmokeModule();
+
+    expect(smoke.buildChatRequest("fake-local-model")).toMatchObject({
+      model: "fake-local-model",
+      max_tokens: 16,
+      stream: false,
+      messages: [
+        {
+          role: "user",
+        },
+      ],
+    });
+  });
+});
+
+describe("check-local-vllm-smoke script", () => {
+  test("checks /models and /chat/completions on a local endpoint", async () => {
+    const server = await startFakeOpenAiCompatibleServer();
+    const result = await runScript(
+      [
+        scriptPath,
+        "--base-url",
+        server.baseUrl,
+        "--api-key",
+        "test-local-key",
+      ],
+      {
+        ...process.env,
+        OPENAI_BASE_URL: "https://api.openai.com/v1",
+        AGENC_MODEL: "",
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Local vLLM/OpenAI-compatible smoke passed");
+    expect(result.stdout).toContain("fake-local-model");
+    expect(server.requests.map((request) => request.url)).toEqual([
+      "/v1/models",
+      "/v1/chat/completions",
+    ]);
+    expect(server.requests[1]?.authorization).toBe("Bearer test-local-key");
+    expect(server.requests[1]?.body).toMatchObject({
+      model: "fake-local-model",
+      stream: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a loopback-only local vLLM/OpenAI-compatible smoke gate for /models and chat completions
- document the local smoke command and environment knobs
- fix Node 25 native-ESM profiler loading exposed by the full MCP entrypoint test

Fixes #1021
Fixes #1022

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/scripts/check-local-vllm-smoke.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run test -- tests/bin/mcp-cli.test.ts --reporter=dot
- npm run typecheck
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm test
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm run test:bun
- npm --workspace=@tetsuo-ai/runtime run check:e2e-all