### PR TITLE
refactor(runtime): remove donor branding from provider profiles

### DIFF
--- a/runtime/src/utils/providerProfile.ts
+++ b/runtime/src/utils/providerProfile.ts
@@ -375,7 +375,7 @@ export function buildOpenAIProfileEnv(options: {
   }
 }
 
-export function buildCodexProfileEnv(options: {
+export function buildProviderCodeProfileEnv(options: {
   model?: string | null
   baseUrl?: string | null
   apiKey?: string | null
@@ -486,7 +486,7 @@ export function buildBankrProfileEnv(options: {
   return env
 }
 
-export function buildCodexOAuthProfileEnv(
+export function buildProviderCodeOAuthProfileEnv(
   tokens: {
     accessToken: string
     idToken?: string
@@ -521,7 +521,7 @@ export function createProfileFile(
   }
 }
 
-export function isPersistedCodexOAuthProfile(
+export function isPersistedAgencOAuthProfile(
   persisted: ProfileFile | null,
 ): boolean {
   return (
@@ -530,11 +530,11 @@ export function isPersistedCodexOAuthProfile(
   )
 }
 
-export function clearPersistedCodexOAuthProfile(
+export function clearPersistedAgencOAuthProfile(
   options?: ProfileFileLocation,
 ): string | null {
   const persisted = loadProfileFile(options)
-  if (!isPersistedCodexOAuthProfile(persisted)) {
+  if (!isPersistedAgencOAuthProfile(persisted)) {
     return null
   }
 
@@ -906,11 +906,11 @@ export async function buildLaunchEnv(options: {
     const agencKey =
       sanitizeApiKey(processEnv.AGENC_API_KEY) ||
       sanitizeApiKey(persistedEnv.AGENC_API_KEY)
-    const liveCodexCredentials = resolveProviderCodeApiCredentials(processEnv)
+    const liveProviderCodeCredentials = resolveProviderCodeApiCredentials(processEnv)
     const agencAccountId =
       processEnv.CHATGPT_ACCOUNT_ID ||
       processEnv.AGENC_ACCOUNT_ID ||
-      liveCodexCredentials.accountId ||
+      liveProviderCodeCredentials.accountId ||
       persistedEnv.CHATGPT_ACCOUNT_ID ||
       persistedEnv.AGENC_ACCOUNT_ID
     if (agencKey) {
@@ -1067,13 +1067,13 @@ export async function applySavedProfileToCurrentSession(options: {
 }): Promise<string | null> {
   const processEnv = options.processEnv ?? process.env
   const baseEnv = { ...processEnv }
-  const isCodexOAuthProfile =
+  const isAgencOAuthProfile =
     options.profileFile.profile === 'agenc' &&
     options.profileFile.env.AGENC_CREDENTIAL_SOURCE === 'oauth'
 
   delete baseEnv.AGENC_PROVIDER_PROFILE_ENV_APPLIED
   delete baseEnv.AGENC_PROVIDER_PROFILE_ENV_APPLIED_ID
-  if (isCodexOAuthProfile) {
+  if (isAgencOAuthProfile) {
     delete baseEnv.AGENC_API_KEY
     delete baseEnv.AGENC_ACCOUNT_ID
     delete baseEnv.CHATGPT_ACCOUNT_ID

--- a/runtime/tests/utils/providerProfile.test.ts
+++ b/runtime/tests/utils/providerProfile.test.ts
@@ -9,14 +9,14 @@ import {
   applySavedProfileToCurrentSession,
   buildStartupEnvFromProfile,
   buildAtomicChatProfileEnv,
-  buildCodexProfileEnv,
+  buildProviderCodeProfileEnv,
   buildGeminiProfileEnv,
   buildLaunchEnv,
   buildOllamaProfileEnv,
   buildOpenAIProfileEnv,
-  clearPersistedCodexOAuthProfile,
+  clearPersistedAgencOAuthProfile,
   createProfileFile,
-  isPersistedCodexOAuthProfile,
+  isPersistedAgencOAuthProfile,
   maskSecretForDisplay,
   loadProfileFile,
   PROFILE_FILE_NAME,
@@ -47,7 +47,7 @@ async function importFreshProviderProfileModule() {
   return import(`./providerProfile.ts?ts=${nonce}`)
 }
 
-const missingCodexAuthPath = join(tmpdir(), 'agenc-missing-agenc-auth.json')
+const missingAgencAuthPath = join(tmpdir(), 'agenc-missing-agenc-auth.json')
 
 test('matching persisted ollama env is reused for ollama launch', async () => {
   const env = await buildLaunchEnv({
@@ -269,7 +269,7 @@ test('matching persisted agenc env is reused for agenc launch', async () => {
     }),
     goal: 'balanced',
     processEnv: {
-      AGENC_AUTH_JSON_PATH: missingCodexAuthPath,
+      AGENC_AUTH_JSON_PATH: missingAgencAuthPath,
     },
   })
 
@@ -289,7 +289,7 @@ test('agenc launch normalizes poisoned persisted base urls', async () => {
     }),
     goal: 'balanced',
     processEnv: {
-      AGENC_AUTH_JSON_PATH: missingCodexAuthPath,
+      AGENC_AUTH_JSON_PATH: missingAgencAuthPath,
     },
   })
 
@@ -334,7 +334,7 @@ test('agenc launch ignores placeholder agenc env keys', async () => {
     goal: 'balanced',
     processEnv: {
       AGENC_API_KEY: 'SUA_CHAVE',
-      AGENC_AUTH_JSON_PATH: missingCodexAuthPath,
+      AGENC_AUTH_JSON_PATH: missingAgencAuthPath,
     },
   })
 
@@ -386,7 +386,7 @@ test('ollama profiles never persist openai api keys', () => {
 })
 
 test('agenc profiles accept explicit agenc credentials', () => {
-  const env = buildCodexProfileEnv({
+  const env = buildProviderCodeProfileEnv({
     model: 'agencspark',
     apiKey: 'agenc-live',
     processEnv: {
@@ -404,11 +404,11 @@ test('agenc profiles accept explicit agenc credentials', () => {
 })
 
 test('agenc profiles require a chatgpt account id', () => {
-  const env = buildCodexProfileEnv({
+  const env = buildProviderCodeProfileEnv({
     model: 'agencspark',
     apiKey: 'agenc-live',
     processEnv: {
-      AGENC_AUTH_JSON_PATH: missingCodexAuthPath,
+      AGENC_AUTH_JSON_PATH: missingAgencAuthPath,
     },
   })
 
@@ -526,8 +526,8 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
   }
 })
 
-test('buildCodexProfileEnv tags OAuth-saved profiles so logout can remove them safely', () => {
-  const env = buildCodexProfileEnv({
+test('buildProviderCodeProfileEnv tags OAuth-saved profiles so logout can remove them safely', () => {
+  const env = buildProviderCodeProfileEnv({
     model: 'agencplan',
     apiKey: makeJwt({
       'https://api.openai.com/auth': {
@@ -551,7 +551,7 @@ test('buildCodexProfileEnv tags OAuth-saved profiles so logout can remove them s
   })
 })
 
-test('clearPersistedCodexOAuthProfile removes only persisted Agenc OAuth profiles', async () => {
+test('clearPersistedAgencOAuthProfile removes only persisted Agenc OAuth profiles', async () => {
   const cwd = mkdtempSync(join(tmpdir(), 'agenc-agenc-oauth-profile-'))
 
   try {
@@ -560,9 +560,9 @@ test('clearPersistedCodexOAuthProfile removes only persisted Agenc OAuth profile
     )
     const {
       PROFILE_FILE_NAME,
-      clearPersistedCodexOAuthProfile,
+      clearPersistedAgencOAuthProfile,
       createProfileFile,
-      isPersistedCodexOAuthProfile,
+      isPersistedAgencOAuthProfile,
       loadProfileFile,
       saveProfileFile,
     } = providerProfileModule
@@ -574,9 +574,9 @@ test('clearPersistedCodexOAuthProfile removes only persisted Agenc OAuth profile
     })
     saveProfileFile(oauthProfile, { cwd })
 
-    assert.equal(isPersistedCodexOAuthProfile(loadProfileFile({ cwd })), true)
+    assert.equal(isPersistedAgencOAuthProfile(loadProfileFile({ cwd })), true)
     assert.equal(
-      clearPersistedCodexOAuthProfile({ cwd }),
+      clearPersistedAgencOAuthProfile({ cwd }),
       join(cwd, PROFILE_FILE_NAME),
     )
     assert.equal(loadProfileFile({ cwd }), null)
@@ -589,8 +589,8 @@ test('clearPersistedCodexOAuthProfile removes only persisted Agenc OAuth profile
     })
     saveProfileFile(existingCredentialProfile, { cwd })
 
-    assert.equal(isPersistedCodexOAuthProfile(loadProfileFile({ cwd })), false)
-    assert.equal(clearPersistedCodexOAuthProfile({ cwd }), null)
+    assert.equal(isPersistedAgencOAuthProfile(loadProfileFile({ cwd })), false)
+    assert.equal(clearPersistedAgencOAuthProfile({ cwd }), null)
     assert.deepEqual(loadProfileFile({ cwd }), existingCredentialProfile)
   } finally {
     rmSync(cwd, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- rename internal provider-code profile helpers away from donor-era identifiers
- update the matching provider-profile tests and local variables
- keep Agenc/provider-code profile behavior unchanged

Fixes #1024

## Test plan
- npm run typecheck
- rg -n "CodexProfile|CodexOAuth|CodexCredentials|isCodex|buildCodex|clearPersistedCodex|isPersistedCodex|liveCodex|missingCodex" runtime/src runtime/tests --glob '!runtime/dist/**'
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- git diff --check
- npm test
- commit hook: build + package entrypoints + check:tui-runtime-startup

## Notes
The moved donor-origin provider-profile test file is excluded by the default Vitest config. A forced one-off run exposes pre-existing stale expectations and dynamic-import issues, so this PR relies on typecheck, targeted search, unused-code scan, and the normal included suite.