### PR TITLE
test(runtime): re-enable async utility vitest tests

### DIFF
--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -64,6 +64,10 @@ const movedDonorTestFiles = movedDonorTestRoots
   .flatMap(walkTestFiles)
   .map((file) => normalizeConfigPath(relative(__dirname, file)));
 const convertedMovedDonorTestFiles = new Set([
+  'tests/utils/async-lock.test.ts',
+  'tests/utils/async-queue.test.ts',
+  'tests/utils/async-rwlock.test.ts',
+  'tests/utils/monotonic.test.ts',
   'tests/utils/providerProfile.test.ts',
 ]);
 const unconvertedMovedDonorTestFiles = movedDonorTestFiles.filter(


### PR DESCRIPTION
## Summary
- Move four converted async utility tests out of the moved donor-origin Vitest quarantine.
- Re-enable coverage for AsyncLock, AsyncQueue, AsyncRwLock, and monotonic timer helpers in the normal runtime Vitest suite.

Fixes #1028

## SOTA comparison
- Current software-engineering-agent work emphasizes reliable local execution and benchmark coverage for repository-scale changes.
- This PR increases always-on local test coverage for core async primitives, matching that verification-first direction without relying on remote CI.

## Test plan
- [x] npx vitest run tests/utils/async-lock.test.ts tests/utils/async-queue.test.ts tests/utils/async-rwlock.test.ts tests/utils/monotonic.test.ts with temporary quarantine override
- [x] npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/async-lock.test.ts tests/utils/async-queue.test.ts tests/utils/async-rwlock.test.ts tests/utils/monotonic.test.ts --reporter=dot
- [x] npm run typecheck
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused:all
- [x] git diff --check
- [x] AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- [x] npm test
- [x] npm run test:bun

## Remote CI
Remote workflow remains disabled manually; validation was local-only.