### PR TITLE
test(runtime): re-enable utility vitest tests

### DIFF
--- a/runtime/tests/utils/messageQueueManager.test.ts
+++ b/runtime/tests/utils/messageQueueManager.test.ts
@@ -5,6 +5,7 @@ vi.mock("bun:bundle", () => ({
 }));
 
 vi.mock("../bootstrap/state.js", () => ({
+  getActiveTimeCounter: () => null,
   getSessionId: () => "queue-test-session",
 }));
 

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -67,8 +67,15 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/async-lock.test.ts',
   'tests/utils/async-queue.test.ts',
   'tests/utils/async-rwlock.test.ts',
+  'tests/utils/behavior-subject.test.ts',
+  'tests/utils/debug.test.ts',
+  'tests/utils/handlePromptSubmit.vimMode.test.ts',
+  'tests/utils/memory/memory-utils.contract.test.ts',
+  'tests/utils/messageQueueManager.test.ts',
   'tests/utils/monotonic.test.ts',
   'tests/utils/providerProfile.test.ts',
+  'tests/utils/providerRecommendation.test.ts',
+  'tests/utils/shell-discovery.test.ts',
 ]);
 const unconvertedMovedDonorTestFiles = movedDonorTestFiles.filter(
   (file) => !convertedMovedDonorTestFiles.has(file),


### PR DESCRIPTION
## Summary
- Re-enable the next batch of moved donor-origin utility Vitest tests in the normal runtime test suite.
- Update the `messageQueueManager` bootstrap-state mock to provide `getActiveTimeCounter`, matching the runtime state module contract.
- Keep `runtime/tests/constants/promptIdentity.test.ts` out of this batch because it remains in the Bun-only lane.

## Validation
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/behavior-subject.test.ts tests/utils/debug.test.ts tests/utils/handlePromptSubmit.vimMode.test.ts tests/utils/memory/memory-utils.contract.test.ts tests/utils/messageQueueManager.test.ts tests/utils/providerRecommendation.test.ts tests/utils/shell-discovery.test.ts --reporter=dot` passed: 7 files, 34 tests.
- `npm run typecheck` passed.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all` passed.
- `git diff --check` passed.
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000` passed.
- `npm test` passed: 1442 files passed, 2 skipped; 12281 tests passed, 10 skipped.
- `npm run test:bun` passed: files=100 failed=0.
- Pre-commit hook passed: runtime build, package entrypoints, TUI runtime startup smoke.

## Notes
This continues the repo-scale local validation work aligned with current software-agent evaluation practice: broad local execution checks, isolated sandboxes, and regression-sensitive test recovery before merge.

Fixes #1030
