### PR TITLE
test(runtime): re-enable compatible moved tests

### DIFF
--- a/runtime/tests/utils/dragDropPaths.test.ts
+++ b/runtime/tests/utils/dragDropPaths.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { fileURLToPath } from 'node:url'
 import { extractDraggedFilePaths } from '../../src/utils/dragDropPaths.ts'
 
 function escapeFinderDraggedPath(filePath: string): string {
@@ -10,7 +11,7 @@ function escapeFinderDraggedPath(filePath: string): string {
 
 describe('extractDraggedFilePaths', () => {
   // Paths that exist on any system.
-  const thisFile = import.meta.path
+  const thisFile = fileURLToPath(import.meta.url)
   const packageJson = `${process.cwd()}/package.json`
 
   // Fixtures created synchronously at describe-load time (not in

--- a/runtime/tests/utils/geminiAuth.test.ts
+++ b/runtime/tests/utils/geminiAuth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { fileURLToPath } from 'node:url'
 
 import {
   getGeminiProjectIdHint,
@@ -6,7 +7,7 @@ import {
   resolveGeminiCredential,
 } from '../../src/utils/geminiAuth.ts'
 
-const existingFilePath = import.meta.path
+const existingFilePath = fileURLToPath(import.meta.url)
 
 const originalEnv = {
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,

--- a/runtime/tests/utils/truncate.test.ts
+++ b/runtime/tests/utils/truncate.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest'
 import { truncate, truncateToWidth, truncatePathMiddle } from './truncate.js'
 
 describe('truncate utilities', () => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { dirname, isAbsolute, relative, resolve } from 'path';
+import { createScanner, ScriptTarget, SyntaxKind } from 'typescript';
 
 const agencRoot = resolve(__dirname, 'src/agenc');
 const agencUpstreamRoot = resolve(agencRoot, 'upstream');
@@ -64,18 +65,53 @@ const movedDonorTestFiles = movedDonorTestRoots
   .flatMap(walkTestFiles)
   .map((file) => normalizeConfigPath(relative(__dirname, file)));
 const convertedMovedDonorTestFiles = new Set([
+  'tests/constants/promptIdentity.test.ts',
+  'tests/utils/agencUiSurfaces.test.ts',
+  'tests/utils/api.test.ts',
   'tests/utils/async-lock.test.ts',
   'tests/utils/async-queue.test.ts',
   'tests/utils/async-rwlock.test.ts',
+  'tests/utils/attachments.extractors.test.ts',
   'tests/utils/behavior-subject.test.ts',
+  'tests/utils/buildConfig.test.ts',
+  'tests/utils/config.showCacheStats.test.ts',
+  'tests/utils/context.test.ts',
   'tests/utils/debug.test.ts',
+  'tests/utils/dragDropPaths.test.ts',
+  'tests/utils/file.test.ts',
+  'tests/utils/geminiAuth.test.ts',
+  'tests/utils/githubModelsCredentials.test.ts',
+  'tests/utils/gracefulShutdown.test.ts',
   'tests/utils/handlePromptSubmit.vimMode.test.ts',
+  'tests/utils/hybridContextStrategy.test.ts',
   'tests/utils/memory/memory-utils.contract.test.ts',
   'tests/utils/messageQueueManager.test.ts',
+  'tests/utils/model/agent.test.ts',
+  'tests/utils/model/model.github.test.ts',
+  'tests/utils/model/modelStrings.github.test.ts',
   'tests/utils/monotonic.test.ts',
+  'tests/utils/permissions/yoloClassifier.test.ts',
+  'tests/utils/plugins/pluginLoader.test.ts',
+  'tests/utils/projectInstructions.test.ts',
+  'tests/utils/promptShellExecution.test.ts',
+  'tests/utils/providerModels.test.ts',
   'tests/utils/providerProfile.test.ts',
   'tests/utils/providerRecommendation.test.ts',
+  'tests/utils/providerValidation.test.ts',
+  'tests/utils/requestLogging.test.ts',
+  'tests/utils/ripgrep.test.ts',
+  'tests/utils/schemaSanitizer.test.ts',
+  'tests/utils/serializationStability.test.ts',
+  'tests/utils/sessionStorage.test.ts',
+  'tests/utils/settings/allowBypassPermissionsMode.test.ts',
   'tests/utils/shell-discovery.test.ts',
+  'tests/utils/stableStringify.test.ts',
+  'tests/utils/streamingOptimizer.test.ts',
+  'tests/utils/swarm/spawnUtils.test.ts',
+  'tests/utils/thinkingTokens.test.ts',
+  'tests/utils/toolResultStorage.test.ts',
+  'tests/utils/truncate.test.ts',
+  'tests/utils/worktree.test.ts',
 ]);
 const unconvertedMovedDonorTestFiles = movedDonorTestFiles.filter(
   (file) => !convertedMovedDonorTestFiles.has(file),
@@ -83,14 +119,33 @@ const unconvertedMovedDonorTestFiles = movedDonorTestFiles.filter(
 
 function isVitestCompatibleBunTestFile(file: string): boolean {
   const source = readFileSync(resolve(__dirname, file), 'utf8');
+  const sourceWithoutComments = stripCommentsForCompatibilityScan(source);
   return (
-    !/\bmock\.module\b/.test(source) &&
-    !/\bmock\.restore\b/.test(source) &&
-    !/\bmock\s*\(/.test(source) &&
-    !/\bBun\./.test(source) &&
-    !/import\s*\(\s*`/.test(source) &&
-    !/\bRequestInit\s*&\s*\{\s*proxy\b/.test(source)
+    !/\bmock\.module\b/.test(sourceWithoutComments) &&
+    !/\bmock\.restore\b/.test(sourceWithoutComments) &&
+    !/\bmock\s*\(/.test(sourceWithoutComments) &&
+    !/\bBun\./.test(sourceWithoutComments) &&
+    !/import\s*\(\s*`/.test(sourceWithoutComments) &&
+    !/\bRequestInit\s*&\s*\{\s*proxy\b/.test(sourceWithoutComments)
   );
+}
+
+function stripCommentsForCompatibilityScan(source: string): string {
+  const chars = source.split('');
+  const scanner = createScanner(ScriptTarget.Latest, false, undefined, source);
+  let token = scanner.scan();
+
+  while (token !== SyntaxKind.EndOfFileToken) {
+    if (
+      token === SyntaxKind.SingleLineCommentTrivia ||
+      token === SyntaxKind.MultiLineCommentTrivia
+    ) {
+      chars.fill(' ', scanner.getTokenPos(), scanner.getTextPos());
+    }
+    token = scanner.scan();
+  }
+
+  return chars.join('');
 }
 
 const bunOnlyTestFiles = bunTestFiles.filter(


### PR DESCRIPTION
## Summary
- Re-enable the Vitest-compatible moved utility and prompt identity tests in the normal runtime suite, raising converted moved-test coverage from 12 files to 47 files.
- Make the Bun-only compatibility classifier ignore comments with TypeScript scanner trivia removal while preserving type-only markers such as `RequestInit & { proxy }`.
- Replace Bun-only `import.meta.path` usage in converted tests with `fileURLToPath(import.meta.url)` and add explicit Vitest globals where needed.

## Validation
- `npm --workspace=@tetsuo-ai/runtime run test -- <converted moved test set> --reporter=dot` passed: 47 files, 357 tests.
- Residual quarantine map: 70 moved files total; 47 converted; 23 unconverted; no remaining Vitest-compatible Bun moved tests; `tests/utils/git.test.ts` remains excluded because it targets helper APIs not exported by the current runtime surface.
- `npm run typecheck` passed.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all` passed.
- `git diff --check` passed.
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000` passed.
- `npm test` passed: 1477 files passed, 2 skipped; 12533 tests passed, 10 skipped.
- `npm run test:bun` passed: files=100 failed=0.
- Pre-commit hook passed: runtime build, package entrypoints, TUI runtime startup smoke.
- Remote workflow remains disabled manually.

## SOTA comparison
Recent SWE-agent/OpenHands/SWE-Bench Pro results emphasize repository-scale execution feedback and realistic local validation. This PR moves known-good migrated tests out of quarantine and into the default local loop, improving the same execution-feedback surface without relying on remote CI.

Fixes #1032
