### PR TITLE
test(runtime): convert exec file utility coverage

### DIFF
--- a/runtime/tests/utils/execFileNoThrow.test.ts
+++ b/runtime/tests/utils/execFileNoThrow.test.ts
@@ -2,13 +2,9 @@ import { expect, test } from 'bun:test'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-
-async function importFreshExecFileNoThrowModule() {
-  return import(`../../src/utils/execFileNoThrow.ts?ts=${Date.now()}-${Math.random()}`)
-}
+import { execFileNoThrowWithCwd } from '../../src/utils/execFileNoThrow.ts'
 
 test('execFileNoThrowWithCwd rejects shell-like executable names', async () => {
-  const { execFileNoThrowWithCwd } = await importFreshExecFileNoThrowModule()
   const result = await execFileNoThrowWithCwd('agenc && whoami', [])
 
   expect(result.code).toBe(1)
@@ -16,7 +12,6 @@ test('execFileNoThrowWithCwd rejects shell-like executable names', async () => {
 })
 
 test('execFileNoThrowWithCwd rejects cwd values with control characters', async () => {
-  const { execFileNoThrowWithCwd } = await importFreshExecFileNoThrowModule()
   const result = await execFileNoThrowWithCwd(process.execPath, ['--version'], {
     cwd: 'C:\\repo\nmalicious',
   })
@@ -26,7 +21,6 @@ test('execFileNoThrowWithCwd rejects cwd values with control characters', async 
 })
 
 test('execFileNoThrowWithCwd rejects arguments with control characters', async () => {
-  const { execFileNoThrowWithCwd } = await importFreshExecFileNoThrowModule()
   const result = await execFileNoThrowWithCwd(process.execPath, [
     '--version\nmalicious',
   ])
@@ -36,7 +30,6 @@ test('execFileNoThrowWithCwd rejects arguments with control characters', async (
 })
 
 test('execFileNoThrowWithCwd rejects environment entries with control characters', async () => {
-  const { execFileNoThrowWithCwd } = await importFreshExecFileNoThrowModule()
   const result = await execFileNoThrowWithCwd(process.execPath, ['--version'], {
     env: {
       ...process.env,
@@ -52,7 +45,6 @@ test('execFileNoThrowWithCwd preserves Windows .cmd compatibility', async () => 
   if (process.platform !== 'win32') {
     return
   }
-  const { execFileNoThrowWithCwd } = await importFreshExecFileNoThrowModule()
 
   const dir = mkdtempSync(join(tmpdir(), 'agenc-execfile-'))
   const file = join(dir, 'hello.cmd')

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -79,6 +79,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/debug.test.ts',
   'tests/utils/dragDropPaths.test.ts',
   'tests/utils/env.test.ts',
+  'tests/utils/execFileNoThrow.test.ts',
   'tests/utils/file.test.ts',
   'tests/utils/geminiAuth.test.ts',
   'tests/utils/git.test.ts',


### PR DESCRIPTION
## Summary
- convert the moved execFileNoThrow utility test from a cache-busting dynamic import to a static source import
- re-enable tests/utils/execFileNoThrow.test.ts in the normal Vitest moved-test map

## Validation
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/execFileNoThrow.test.ts --reporter=dot
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm test
- npm run test:bun
- pre-commit hook: runtime build, package entrypoint contract, TUI runtime startup smoke

Fixes #1038
