### PR TITLE
test(runtime): convert config model coverage

### DIFF
--- a/runtime/tests/utils/model/model.config-model.test.ts
+++ b/runtime/tests/utils/model/model.config-model.test.ts
@@ -1,19 +1,14 @@
-import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, expect, test } from 'bun:test'
 
 import { saveGlobalConfig } from '../../../src/utils/config.ts'
 import {
   setActiveConfigModel,
   getActiveConfigModel,
 } from '../../../src/bootstrap/state.ts'
-
-// model.ts is env-driven: getAPIProvider() reads env. The real providers.js
-// returns 'xai' when XAI_API_KEY is set, 'openai'/'agenc' when AGENC_USE_OPENAI
-// is set. We exercise those branches directly so getDefaultMainLoopModel()
-// reflects the AgenC config.model published via setActiveConfigModel().
-async function importFreshModelModule() {
-  const nonce = `${Date.now()}-${Math.random()}`
-  return import(`../../../src/utils/model/model.ts?cfg=${nonce}`)
-}
+import {
+  getDefaultMainLoopModel,
+  getDefaultMainLoopModelSetting,
+} from '../../../src/utils/model/model.ts'
 
 const SAVED_ENV = {
   XAI_API_KEY: process.env.XAI_API_KEY,
@@ -30,14 +25,12 @@ function clearEnv(): void {
 }
 
 beforeEach(() => {
-  mock.restore()
   clearEnv()
   setActiveConfigModel(undefined)
   saveGlobalConfig(current => ({ ...current, model: undefined }))
 })
 
 afterEach(() => {
-  mock.restore()
   setActiveConfigModel(undefined)
   for (const key of Object.keys(SAVED_ENV) as Array<keyof typeof SAVED_ENV>) {
     if (SAVED_ENV[key] === undefined) delete process.env[key]
@@ -46,7 +39,7 @@ afterEach(() => {
   saveGlobalConfig(current => ({ ...current, model: undefined }))
 })
 
-test('getDefaultMainLoopModel reflects config.model for the active xai provider', async () => {
+test('getDefaultMainLoopModel reflects config.model for the active xai provider', () => {
   // Regression: `agenc config set model grok-build-0.1` (no OPENAI_MODEL env).
   // The xai branch hardcoded grok-4.3; it must now read the published config
   // model instead.
@@ -57,42 +50,36 @@ test('getDefaultMainLoopModel reflects config.model for the active xai provider'
     model: 'grok-build-0.1',
   })
 
-  const { getDefaultMainLoopModel, getDefaultMainLoopModelSetting } =
-    await importFreshModelModule()
   expect(getDefaultMainLoopModelSetting()).toBe('grok-build-0.1')
   expect(getDefaultMainLoopModel()).toBe('grok-build-0.1')
 })
 
-test('getDefaultMainLoopModel still defaults to grok-4.3 when config.model is unset', async () => {
+test('getDefaultMainLoopModel still defaults to grok-4.3 when config.model is unset', () => {
   process.env.XAI_API_KEY = 'xai-test'
   setActiveConfigModel(undefined)
 
-  const { getDefaultMainLoopModel } = await importFreshModelModule()
   expect(getDefaultMainLoopModel()).toBe('grok-4.3')
 })
 
-test('grok-4.3 keeps working when it is the configured model', async () => {
+test('grok-4.3 keeps working when it is the configured model', () => {
   process.env.XAI_API_KEY = 'xai-test'
   setActiveConfigModel({ provider: 'grok', model: 'grok-4.3' })
 
-  const { getDefaultMainLoopModel } = await importFreshModelModule()
   expect(getDefaultMainLoopModel()).toBe('grok-4.3')
 })
 
-test('OPENAI_MODEL env wins over the published config model (provider profile precedence)', async () => {
+test('OPENAI_MODEL env wins over the published config model (provider profile precedence)', () => {
   process.env.XAI_API_KEY = 'xai-test'
   process.env.OPENAI_MODEL = 'grok-from-env'
   setActiveConfigModel({ provider: 'grok', model: 'grok-build-0.1' })
 
-  const { getDefaultMainLoopModel } = await importFreshModelModule()
   expect(getDefaultMainLoopModel()).toBe('grok-from-env')
 })
 
-test('config model for a different provider does not leak into xai default', async () => {
+test('config model for a different provider does not leak into xai default', () => {
   process.env.XAI_API_KEY = 'xai-test'
   // Published selection is for openai, but the active provider is xai.
   setActiveConfigModel({ provider: 'openai', model: 'gpt-5' })
 
-  const { getDefaultMainLoopModel } = await importFreshModelModule()
   expect(getDefaultMainLoopModel()).toBe('grok-4.3')
 })

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -90,6 +90,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/memory/memory-utils.contract.test.ts',
   'tests/utils/messageQueueManager.test.ts',
   'tests/utils/model/agent.test.ts',
+  'tests/utils/model/model.config-model.test.ts',
   'tests/utils/model/model.github.test.ts',
   'tests/utils/model/modelStrings.github.test.ts',
   'tests/utils/model/providers.test.ts',


### PR DESCRIPTION
## Summary
- convert `tests/utils/model/model.config-model.test.ts` from cache-busting dynamic imports to static model helper imports
- remove unused `mock.restore()` calls from the test setup
- re-enable the config model moved test in the normal Vitest suite

## Validation
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/model/model.config-model.test.ts --reporter=dot`
- moved donor-origin test map: 70 total, 52 converted, 18 unconverted, 0 compatible
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm test`
- `npm run test:bun`
- pre-commit hook: runtime build, package entrypoint contract, TUI runtime startup smoke

Fixes #1042
