### PR TITLE
test(runtime): convert prompt submit queue coverage

### DIFF
--- a/runtime/tests/utils/handlePromptSubmit.test.ts
+++ b/runtime/tests/utils/handlePromptSubmit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { getCommandQueue, resetCommandQueue } from '../../src/utils/messageQueueManager.ts'
 
 describe('handlePromptSubmit', () => {
@@ -8,7 +8,6 @@ describe('handlePromptSubmit', () => {
 
   afterEach(() => {
     resetCommandQueue()
-    mock.restore()
   })
 
   it('queues prompt submissions during generation without interrupting the current turn', async () => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -85,6 +85,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/git.test.ts',
   'tests/utils/githubModelsCredentials.test.ts',
   'tests/utils/gracefulShutdown.test.ts',
+  'tests/utils/handlePromptSubmit.test.ts',
   'tests/utils/handlePromptSubmit.vimMode.test.ts',
   'tests/utils/hybridContextStrategy.test.ts',
   'tests/utils/memory/memory-utils.contract.test.ts',


### PR DESCRIPTION
## Summary
- remove unused Bun mock cleanup from `tests/utils/handlePromptSubmit.test.ts`
- re-enable the prompt submit queue regression test in the normal Vitest suite

## Validation
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/handlePromptSubmit.test.ts --reporter=dot`
- moved donor-origin test map: 70 total, 53 converted, 17 unconverted, 0 compatible
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm test`
- `npm run test:bun`
- pre-commit hook: runtime build, package entrypoint contract, TUI runtime startup smoke

Fixes #1044
