### PR TITLE
test(runtime): convert thinking support coverage

### DIFF
--- a/runtime/tests/utils/thinking.test.ts
+++ b/runtime/tests/utils/thinking.test.ts
@@ -1,17 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { modelSupportsThinking } from '../../src/utils/thinking.ts'
 import { resetSettingsCache } from '../../src/utils/settings/settingsCache.ts'
-
-mock.module('./model/providers.js', () => ({
-  getAPIProvider: () =>
-    process.env.AGENC_USE_OPENAI === '1' ? 'openai' : 'firstParty',
-}))
-
-const { modelSupportsThinking } = await import('../../src/utils/thinking.ts')
 
 const ENV_KEYS = [
   'AGENC_USE_OPENAI',
   'AGENC_USE_GEMINI',
   'AGENC_USE_GITHUB',
+  'AGENC_USE_MINIMAX',
   'AGENC_USE_MISTRAL',
   'AGENC_USE_BEDROCK',
   'AGENC_USE_VERTEX',

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -114,6 +114,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/stableStringify.test.ts',
   'tests/utils/streamingOptimizer.test.ts',
   'tests/utils/swarm/spawnUtils.test.ts',
+  'tests/utils/thinking.test.ts',
   'tests/utils/thinkingTokens.test.ts',
   'tests/utils/toolResultStorage.test.ts',
   'tests/utils/truncate.test.ts',


### PR DESCRIPTION
## Summary
- Convert the Z.AI GLM thinking-support regression from Bun-only syntax to Vitest.
- Remove the provider module mock and exercise the real OpenAI-compatible provider detection path under controlled env setup.
- Add the test to the converted moved-donor coverage list.

Fixes #1046

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/thinking.test.ts --reporter=dot
- moved donor-test scanner: 70 total, 54 converted, 16 unconverted
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoint contract, TUI runtime startup smoke
