### PR TITLE
test(runtime): convert github models hydrate coverage

### DIFF
--- a/runtime/tests/utils/githubModelsCredentials.hydrate.test.ts
+++ b/runtime/tests/utils/githubModelsCredentials.hydrate.test.ts
@@ -1,9 +1,20 @@
-/**
- * Hydrate tests live in a separate file with no static import of
- * githubModelsCredentials so Bun's mock.module can replace secureStorage
- * before that module is first loaded.
- */
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const secureStorageModulePath = '../../src/utils/secureStorage/index.js'
+
+async function importCredentialsModule() {
+  return import('../../src/utils/githubModelsCredentials.ts')
+}
+
+function mockSecureStorageToken(accessToken: string): void {
+  vi.doMock(secureStorageModulePath, () => ({
+    getSecureStorage: () => ({
+      read: () => ({
+        githubModels: { accessToken },
+      }),
+    }),
+  }))
+}
 
 describe('hydrateGithubModelsTokenFromSecureStorage', () => {
   const orig = {
@@ -16,7 +27,8 @@ describe('hydrateGithubModelsTokenFromSecureStorage', () => {
   }
 
   afterEach(() => {
-    mock.restore()
+    vi.doUnmock(secureStorageModulePath)
+    vi.resetModules()
     for (const [k, v] of Object.entries(orig)) {
       if (v === undefined) {
         delete process.env[k as keyof typeof orig]
@@ -32,17 +44,10 @@ describe('hydrateGithubModelsTokenFromSecureStorage', () => {
     delete process.env.GH_TOKEN
     delete process.env.AGENC_SIMPLE
 
-    mock.module('../../src/utils/secureStorage/index.js', () => ({
-      getSecureStorage: () => ({
-        read: () => ({
-          githubModels: { accessToken: 'stored-secret' },
-        }),
-      }),
-    }))
+    mockSecureStorageToken('stored-secret')
 
-    const { hydrateGithubModelsTokenFromSecureStorage } = await import(
-      '../../src/utils/githubModelsCredentials.ts?hydrate=sets-token'
-    )
+    const { hydrateGithubModelsTokenFromSecureStorage } =
+      await importCredentialsModule()
     hydrateGithubModelsTokenFromSecureStorage()
     expect(process.env.GITHUB_TOKEN).toBe('stored-secret')
     expect(process.env.AGENC_GITHUB_TOKEN_HYDRATED).toBe('1')
@@ -53,17 +58,10 @@ describe('hydrateGithubModelsTokenFromSecureStorage', () => {
     process.env.GITHUB_TOKEN = 'already'
     delete process.env.AGENC_GITHUB_TOKEN_HYDRATED
 
-    mock.module('../../src/utils/secureStorage/index.js', () => ({
-      getSecureStorage: () => ({
-        read: () => ({
-          githubModels: { accessToken: 'stored-secret' },
-        }),
-      }),
-    }))
+    mockSecureStorageToken('stored-secret')
 
-    const { hydrateGithubModelsTokenFromSecureStorage } = await import(
-      '../../src/utils/githubModelsCredentials.ts?hydrate=preserve-existing'
-    )
+    const { hydrateGithubModelsTokenFromSecureStorage } =
+      await importCredentialsModule()
     hydrateGithubModelsTokenFromSecureStorage()
     expect(process.env.GITHUB_TOKEN).toBe('already')
     expect(process.env.AGENC_GITHUB_TOKEN_HYDRATED).toBeUndefined()

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -84,6 +84,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/geminiAuth.test.ts',
   'tests/utils/git.test.ts',
   'tests/utils/githubModelsCredentials.test.ts',
+  'tests/utils/githubModelsCredentials.hydrate.test.ts',
   'tests/utils/gracefulShutdown.test.ts',
   'tests/utils/handlePromptSubmit.test.ts',
   'tests/utils/handlePromptSubmit.vimMode.test.ts',


### PR DESCRIPTION
## Summary
- Convert the GitHub Models token hydration regression from Bun-only syntax to Vitest.
- Replace Bun secure-storage module mocks with Vitest module isolation.
- Add the test to the converted moved-donor coverage list.

Fixes #1048

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/githubModelsCredentials.hydrate.test.ts --reporter=dot
- moved donor-test scanner: 70 total, 55 converted, 15 unconverted, 0 compatible
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoint contract, TUI runtime startup smoke
