### PR TITLE
test(runtime): convert github models refresh coverage

### DIFF
--- a/runtime/tests/utils/githubModelsCredentials.refresh.test.ts
+++ b/runtime/tests/utils/githubModelsCredentials.refresh.test.ts
@@ -1,8 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 async function importFreshModule() {
-  return import(`../../src/utils/githubModelsCredentials.ts?ts=${Date.now()}-${Math.random()}`)
+  vi.resetModules()
+  return import('../../src/utils/githubModelsCredentials.ts')
 }
+
+const secureStorageModulePath = '../../src/utils/secureStorage/index.js'
+const deviceFlowModulePath = '../../src/services/github/deviceFlow.js'
 
 describe('refreshGithubModelsTokenIfNeeded', () => {
   const orig = {
@@ -13,10 +17,16 @@ describe('refreshGithubModelsTokenIfNeeded', () => {
   }
 
   beforeEach(() => {
-    mock.restore()
+    vi.doUnmock(secureStorageModulePath)
+    vi.doUnmock(deviceFlowModulePath)
+    vi.clearAllMocks()
+    vi.resetModules()
   })
 
   afterEach(() => {
+    vi.doUnmock(secureStorageModulePath)
+    vi.doUnmock(deviceFlowModulePath)
+    vi.resetModules()
     for (const [k, v] of Object.entries(orig)) {
       if (v === undefined) {
         delete process.env[k as keyof typeof orig]
@@ -40,7 +50,7 @@ describe('refreshGithubModelsTokenIfNeeded', () => {
       },
     }
 
-    mock.module('../../src/utils/secureStorage/index.js', () => ({
+    vi.doMock(secureStorageModulePath, () => ({
       getSecureStorage: () => ({
         read: () => store,
         update: (next: Record<string, unknown>) => {
@@ -50,7 +60,7 @@ describe('refreshGithubModelsTokenIfNeeded', () => {
       }),
     }))
 
-    mock.module('../../src/services/github/deviceFlow.js', () => ({
+    vi.doMock(deviceFlowModulePath, () => ({
       DEFAULT_GITHUB_DEVICE_SCOPE: 'read:user',
       exchangeForCopilotToken: async () => ({
         token: `tid=fresh;exp=${futureExp};sku=free`,
@@ -81,14 +91,14 @@ describe('refreshGithubModelsTokenIfNeeded', () => {
     delete process.env.GH_TOKEN
 
     const futureExp = Math.floor(Date.now() / 1000) + 3600
-    const exchangeSpy = mock(async () => ({
+    const exchangeSpy = vi.fn(async () => ({
       token: `tid=unexpected;exp=${futureExp};sku=free`,
       expires_at: futureExp,
       refresh_in: 1500,
       endpoints: { api: 'https://api.githubcopilot.com' },
     }))
 
-    mock.module('../../src/utils/secureStorage/index.js', () => ({
+    vi.doMock(secureStorageModulePath, () => ({
       getSecureStorage: () => ({
         read: () => ({
           githubModels: {
@@ -100,7 +110,7 @@ describe('refreshGithubModelsTokenIfNeeded', () => {
       }),
     }))
 
-    mock.module('../../src/services/github/deviceFlow.js', () => ({
+    vi.doMock(deviceFlowModulePath, () => ({
       DEFAULT_GITHUB_DEVICE_SCOPE: 'read:user',
       exchangeForCopilotToken: exchangeSpy,
     }))

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -85,6 +85,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/git.test.ts',
   'tests/utils/githubModelsCredentials.test.ts',
   'tests/utils/githubModelsCredentials.hydrate.test.ts',
+  'tests/utils/githubModelsCredentials.refresh.test.ts',
   'tests/utils/gracefulShutdown.test.ts',
   'tests/utils/handlePromptSubmit.test.ts',
   'tests/utils/handlePromptSubmit.vimMode.test.ts',


### PR DESCRIPTION
## Summary
- Convert the GitHub Models token refresh regression from Bun-only syntax to Vitest.
- Replace secure-storage and device-flow Bun module mocks with Vitest module isolation.
- Add the test to the converted moved-donor coverage list.

Fixes #1050

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/githubModelsCredentials.refresh.test.ts --reporter=dot
- moved donor-test scanner: 70 total, 56 converted, 14 unconverted, 0 compatible
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoint contract, TUI runtime startup smoke
