### PR TITLE
test(runtime): convert install surface cleanup coverage

### DIFF
--- a/runtime/tests/utils/agencInstallSurfaces.test.ts
+++ b/runtime/tests/utils/agencInstallSurfaces.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, expect, mock, test } from 'bun:test'
+import { afterEach, expect, test, vi } from 'vitest'
 import * as fsPromises from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
-import { sourceUrl } from '../helpers/source-path.ts'
+
+const execModulePath = '../../src/utils/execFileNoThrow.js'
 
 const originalEnv = { ...process.env }
 const originalMacro = (globalThis as Record<string, unknown>).MACRO
@@ -10,13 +11,15 @@ const originalMacro = (globalThis as Record<string, unknown>).MACRO
 afterEach(() => {
   process.env = { ...originalEnv }
   ;(globalThis as Record<string, unknown>).MACRO = originalMacro
-  mock.restore()
+  vi.doUnmock('fs/promises')
+  vi.doUnmock(execModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
 })
 
 async function importFreshInstaller() {
-  const url = sourceUrl('utils/nativeInstaller/installer.ts')
-  url.search = `ts=${Date.now()}-${Math.random()}`
-  return import(url.href)
+  vi.resetModules()
+  return import('../../src/utils/nativeInstaller/installer.ts')
 }
 
 test('cleanupNpmInstallations removes both agenc and legacy agenc local install dirs', async () => {
@@ -25,14 +28,14 @@ test('cleanupNpmInstallations removes both agenc and legacy agenc local install 
     PACKAGE_URL: '@gitlawb/agenc',
   }
 
-  mock.module('fs/promises', () => ({
+  vi.doMock('fs/promises', () => ({
     ...fsPromises,
     rm: async (path: string) => {
       removedPaths.push(path)
     },
   }))
 
-  mock.module(sourceUrl('utils/execFileNoThrow.js').href, () => ({
+  vi.doMock(execModulePath, () => ({
     execSyncWithDefaults_DEPRECATED: () => '',
     execFileNoThrow: async () => ({
       code: 1,
@@ -47,6 +50,5 @@ test('cleanupNpmInstallations removes both agenc and legacy agenc local install 
   const { cleanupNpmInstallations } = await importFreshInstaller()
   await cleanupNpmInstallations()
 
-  expect(removedPaths).toContain(join(homedir(), '.agenc', 'local'))
-  expect(removedPaths).toContain(join(homedir(), '.agenc', 'local'))
+  expect(removedPaths).toEqual([join(homedir(), '.agenc', 'local')])
 })

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -66,6 +66,7 @@ const movedDonorTestFiles = movedDonorTestRoots
   .map((file) => normalizeConfigPath(relative(__dirname, file)));
 const convertedMovedDonorTestFiles = new Set([
   'tests/constants/promptIdentity.test.ts',
+  'tests/utils/agencInstallSurfaces.test.ts',
   'tests/utils/agencUiSurfaces.test.ts',
   'tests/utils/api.test.ts',
   'tests/utils/async-lock.test.ts',


### PR DESCRIPTION
## Summary
- convert the install surface cleanup coverage from Bun-only module mocks to Vitest module isolation
- keep the npm uninstall fallback mocked while asserting the de-duplicated legacy local install cleanup path
- move the test into the converted moved-donor allowlist, reducing the Bun-only quarantine

Fixes #1052

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/agencInstallSurfaces.test.ts --reporter=dot
- node --input-type=module quarantine accounting check: moved=70 converted=57 unconverted=13 compatible_unconverted=0
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- git diff --check
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke