### PR TITLE
chore(runtime): bump vitest patch release

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -152,12 +152,12 @@
     "@types/react": "^19.0.0",
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.5.14",
-    "@vitest/coverage-v8": "^4.1.6",
+    "@vitest/coverage-v8": "^4.1.9",
     "esbuild": "0.28.1",
     "knip": "^6.14.1",
     "type-fest": "^5.7.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   },
   "engines": {
     "node": ">=25.0.0"


### PR DESCRIPTION
## Summary
- bump runtime devDependency ranges for vitest and @vitest/coverage-v8 to 4.1.9
- confirm npm outdated is empty after the update
- keep remote Actions disabled; all verification was local

Fixes #1054

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/agencInstallSurfaces.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --audit-level=high
- npm outdated --json
- git diff --check
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke