### PR TITLE
test(runtime): convert gemini credential coverage

### DIFF
--- a/runtime/tests/utils/geminiCredentials.test.ts
+++ b/runtime/tests/utils/geminiCredentials.test.ts
@@ -1,13 +1,15 @@
-import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 type MockStorageData = Record<string, unknown>
 
+const secureStorageModulePath = '../../src/utils/secureStorage/index.js'
 const originalEnv = { ...process.env }
 const originalArgv = [...process.argv]
 let storageState: MockStorageData = {}
 
 async function importFreshModule() {
-  mock.module('./secureStorage/index.js', () => ({
+  vi.resetModules()
+  vi.doMock(secureStorageModulePath, () => ({
     getSecureStorage: () => ({
       name: 'mock-secure-storage',
       read: () => storageState,
@@ -23,7 +25,7 @@ async function importFreshModule() {
     }),
   }))
 
-  return import(`../../src/utils/geminiCredentials.ts?ts=${Date.now()}-${Math.random()}`)
+  return import('../../src/utils/geminiCredentials.ts')
 }
 
 beforeEach(() => {
@@ -37,7 +39,9 @@ afterEach(() => {
   process.env = { ...originalEnv }
   process.argv = [...originalArgv]
   storageState = {}
-  mock.restore()
+  vi.doUnmock(secureStorageModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
 })
 
 test('saveGeminiAccessToken stores and reads back the token', async () => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -83,6 +83,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/execFileNoThrow.test.ts',
   'tests/utils/file.test.ts',
   'tests/utils/geminiAuth.test.ts',
+  'tests/utils/geminiCredentials.test.ts',
   'tests/utils/git.test.ts',
   'tests/utils/githubModelsCredentials.test.ts',
   'tests/utils/githubModelsCredentials.hydrate.test.ts',


### PR DESCRIPTION
## Summary
- convert Gemini credential secure-storage coverage from Bun-only mocks to Vitest module isolation
- keep save/read/clear token coverage against a focused secure-storage test double
- move the file into the converted moved-donor allowlist, reducing the Bun-only quarantine

Fixes #1056

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/geminiCredentials.test.ts --reporter=dot
- node --input-type=module quarantine accounting check: moved=70 converted=58 unconverted=12 compatible_unconverted=0
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --audit-level=high
- npm outdated --json
- git diff --check
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke