### PR TITLE
test(runtime): convert effort coverage

### DIFF
--- a/runtime/tests/utils/effort.agenc.test.ts
+++ b/runtime/tests/utils/effort.agenc.test.ts
@@ -1,13 +1,21 @@
-import { afterEach, expect, mock, test } from 'bun:test'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const providersModulePath = '../../src/utils/model/providers.js'
+const modelSupportOverridesModulePath =
+  '../../src/utils/model/modelSupportOverrides.js'
 
 afterEach(() => {
-  mock.restore()
+  vi.doUnmock(providersModulePath)
+  vi.doUnmock(modelSupportOverridesModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
 })
 
 async function importFreshEffortModule(options: {
   provider: 'agenc' | 'openai'
 }) {
-  mock.module('../../src/utils/model/providers.js', () => ({
+  vi.resetModules()
+  vi.doMock(providersModulePath, () => ({
     getAPIProvider: () => options.provider,
     getAPIProviderForStatsig: () => options.provider,
     isFirstPartyAnthropicBaseUrl: () => options.provider === 'agenc',
@@ -16,11 +24,11 @@ async function importFreshEffortModule(options: {
     isGithubNativeproviderMode: () => false,
     usesAnthropicAccountFlow: () => false,
   }))
-  mock.module('../../src/utils/model/modelSupportOverrides.js', () => ({
+  vi.doMock(modelSupportOverridesModulePath, () => ({
     get3PModelCapabilityOverride: () => undefined,
   }))
 
-  return import(`../../src/utils/effort.ts?ts=${Date.now()}-${Math.random()}`)
+  return import('../../src/utils/effort.ts')
 }
 
 test('gpt-5.4 on the ChatGPT Agenc backend supports effort selection', async () => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -81,6 +81,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/dragDropPaths.test.ts',
   'tests/utils/env.test.ts',
   'tests/utils/execFileNoThrow.test.ts',
+  'tests/utils/effort.agenc.test.ts',
   'tests/utils/file.test.ts',
   'tests/utils/geminiAuth.test.ts',
   'tests/utils/geminiCredentials.test.ts',


### PR DESCRIPTION
## Summary\n- Convert the moved effort selection regression test from bun:test to Vitest module isolation.\n- Add the test to the moved-donor converted allowlist, reducing quarantine by one file.\n\nFixes #1058\n\n## Test plan\n- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/effort.agenc.test.ts --reporter=dot\n- moved-test quarantine scan: moved=70 converted=59 unconverted=11 compatible_unconverted=0\n- git diff --check\n- npm run typecheck\n- npm --workspace=@tetsuo-ai/runtime run check:unused\n- npm audit --audit-level=high\n- npm outdated --json\n- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000\n- npm run test:bun\n- npm test\n- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke