### PR TITLE
test(runtime): convert agenc path coverage

### DIFF
--- a/runtime/tests/utils/agencPaths.test.ts
+++ b/runtime/tests/utils/agencPaths.test.ts
@@ -1,27 +1,33 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import * as fsPromises from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
 
 const originalEnv = { ...process.env }
 const originalArgv = [...process.argv]
+const fsPromisesModulePath = 'fs/promises'
 
 async function importFreshEnvUtils() {
-  return import(`../../src/utils/envUtils.ts?ts=${Date.now()}-${Math.random()}`)
+  vi.resetModules()
+  return import('../../src/utils/envUtils.ts')
 }
 
 async function importFreshSettings() {
-  return import(`../../src/utils/settings/settings.ts?ts=${Date.now()}-${Math.random()}`)
+  vi.resetModules()
+  return import('../../src/utils/settings/settings.ts')
 }
 
 async function importFreshLocalInstaller() {
-  return import(`../../src/utils/localInstaller.ts?ts=${Date.now()}-${Math.random()}`)
+  vi.resetModules()
+  return import('../../src/utils/localInstaller.ts')
 }
 
 afterEach(() => {
   process.env = { ...originalEnv }
   process.argv = [...originalArgv]
-  mock.restore()
+  vi.doUnmock(fsPromisesModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
 })
 
 describe('AgenC paths', () => {
@@ -120,7 +126,7 @@ describe('AgenC paths', () => {
   })
 
   test('legacy local installs are detected when they still expose the agenc binary', async () => {
-    mock.module('fs/promises', () => ({
+    vi.doMock(fsPromisesModulePath, () => ({
       ...fsPromises,
       access: async (path: string) => {
         if (

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -67,6 +67,7 @@ const movedDonorTestFiles = movedDonorTestRoots
 const convertedMovedDonorTestFiles = new Set([
   'tests/constants/promptIdentity.test.ts',
   'tests/utils/agencInstallSurfaces.test.ts',
+  'tests/utils/agencPaths.test.ts',
   'tests/utils/agencUiSurfaces.test.ts',
   'tests/utils/api.test.ts',
   'tests/utils/async-lock.test.ts',


### PR DESCRIPTION
## Summary\n- Convert the moved AgenC path regression test from bun:test to Vitest module isolation.\n- Add the test to the moved-donor converted allowlist, reducing quarantine by one file.\n\nFixes #1062\n\n## Test plan\n- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/agencPaths.test.ts --reporter=dot\n- moved-test quarantine scan: moved=70 converted=61 unconverted=9 compatible_unconverted=0\n- git diff --check\n- npm run typecheck\n- npm --workspace=@tetsuo-ai/runtime run check:unused\n- npm audit --audit-level=high\n- npm outdated --json\n- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000\n- npm run test:bun\n- npm test\n- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke