### PR TITLE
test(runtime): convert user utility coverage

### DIFF
--- a/runtime/tests/utils/user.test.ts
+++ b/runtime/tests/utils/user.test.ts
@@ -1,9 +1,16 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 const originalEnv = { ...process.env }
+const authModulePath = '../../src/utils/auth.js'
+const configModulePath = '../../src/utils/config.js'
+const cwdModulePath = '../../src/utils/cwd.js'
+const envModulePath = '../../src/utils/env.js'
+const envUtilsModulePath = '../../src/utils/envUtils.js'
+const execaModulePath = 'execa'
 
 async function importFreshUserModule() {
-  return import(`../../src/utils/user.ts?ts=${Date.now()}-${Math.random()}`)
+  vi.resetModules()
+  return import('../../src/utils/user.ts')
 }
 
 function installCommonMocks(options?: {
@@ -11,13 +18,12 @@ function installCommonMocks(options?: {
   gitEmail?: string
 }) {
   // NOTE: Do NOT mock ../bootstrap/state.js here.
-  // mock.module() is process-global in bun:test and mock.restore() does NOT
-  // undo it. Mocking state.js leaks getSessionId = () => 'session-test' into
-  // every other test file that imports state.js (e.g. SDK CON-1 tests).
+  // Mocking state.js leaks getSessionId = () => 'session-test' into
+  // every other test file that imports state.js.
   // The dynamic import (importFreshUserModule) will use the real state.js,
   // which is fine — these tests only assert email, not sessionId.
 
-  mock.module('./auth.js', () => ({
+  vi.doMock(authModulePath, () => ({
     getOauthAccountInfo: () =>
       options?.oauthEmail
         ? {
@@ -30,26 +36,26 @@ function installCommonMocks(options?: {
     getSubscriptionType: () => null,
   }))
 
-  mock.module('./config.js', () => ({
+  vi.doMock(configModulePath, () => ({
     getGlobalConfig: () => ({}),
     getOrCreateUserID: () => 'device-test',
   }))
 
-  mock.module('./cwd.js', () => ({
+  vi.doMock(cwdModulePath, () => ({
     getCwd: () => 'C:\\repo',
   }))
 
-  mock.module('./env.js', () => ({
+  vi.doMock(envModulePath, () => ({
     env: { platform: 'windows' },
     getHostPlatformForAnalytics: () => 'windows',
   }))
 
-  mock.module('./envUtils.js', () => ({
+  vi.doMock(envUtilsModulePath, () => ({
     isEnvTruthy: (value: string | undefined) =>
       !!value && value !== '0' && value.toLowerCase() !== 'false',
   }))
 
-  mock.module('execa', () => ({
+  vi.doMock(execaModulePath, () => ({
     execa: async () => ({
       exitCode: options?.gitEmail ? 0 : 1,
       stdout: options?.gitEmail ?? '',
@@ -62,7 +68,14 @@ function installCommonMocks(options?: {
 }
 
 afterEach(() => {
-  mock.restore()
+  vi.doUnmock(authModulePath)
+  vi.doUnmock(configModulePath)
+  vi.doUnmock(cwdModulePath)
+  vi.doUnmock(envModulePath)
+  vi.doUnmock(envUtilsModulePath)
+  vi.doUnmock(execaModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
   process.env = { ...originalEnv }
   delete (globalThis as Record<string, unknown>).MACRO
 })

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -125,6 +125,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/thinkingTokens.test.ts',
   'tests/utils/toolResultStorage.test.ts',
   'tests/utils/truncate.test.ts',
+  'tests/utils/user.test.ts',
   'tests/utils/worktree.test.ts',
 ]);
 const unconvertedMovedDonorTestFiles = movedDonorTestFiles.filter(


### PR DESCRIPTION
## Summary
- move user utility regression coverage from the Bun-only moved-test quarantine into the normal Vitest suite
- translate auth/config/env/execa mocks to scoped Vitest module mocks while keeping bootstrap state real
- update the moved-test allowlist so the file runs in the default Vitest gate

Fixes #1064

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/user.test.ts --reporter=dot
- moved-test quarantine scan: 70 total, 62 converted, 8 unconverted, 0 compatible unconverted
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke