### PR TITLE
test(runtime): convert openai shim model coverage

### DIFF
--- a/runtime/tests/utils/model/model.openai-shim-providers.test.ts
+++ b/runtime/tests/utils/model/model.openai-shim-providers.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import { saveGlobalConfig } from '../../../src/utils/config.ts'
 
+const providersModulePath = '../../../src/utils/model/providers.js'
+
 async function importFreshModelModule() {
-  mock.restore()
-  mock.module('./providers.js', () => ({
+  vi.resetModules()
+  vi.doMock(providersModulePath, () => ({
     getAPIProvider: () => {
       if (process.env.NVIDIA_NIM) return 'nvidia-nim'
       if (process.env.AGENC_USE_MINIMAX || process.env.MINIMAX_API_KEY) return 'minimax'
@@ -21,8 +23,7 @@ async function importFreshModelModule() {
       return 'firstParty'
     },
   }))
-  const nonce = `${Date.now()}-${Math.random()}`
-  return import(`../../../src/utils/model/model.ts?ts=${nonce}`)
+  return import('../../../src/utils/model/model.ts')
 }
 
 const SAVED_ENV = {
@@ -56,11 +57,9 @@ function restoreEnv(key: keyof typeof SAVED_ENV): void {
 }
 
 beforeEach(() => {
-  // Other test files (notably modelOptions.github.test.ts) install a
-  // persistent mock.module for './providers.js' that overrides getAPIProvider
-  // globally. Without mock.restore() here, those overrides bleed into this
-  // suite and the provider-kind branches we're testing become unreachable.
-  mock.restore()
+  vi.doUnmock(providersModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
   delete process.env.AGENC_USE_OPENAI
   delete process.env.AGENC_USE_GEMINI
   delete process.env.AGENC_USE_GITHUB
@@ -87,7 +86,9 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  mock.restore()
+  vi.doUnmock(providersModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
   for (const key of Object.keys(SAVED_ENV) as Array<keyof typeof SAVED_ENV>) {
     restoreEnv(key)
   }

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -100,6 +100,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/model/model.config-model.test.ts',
   'tests/utils/model/model.github.test.ts',
   'tests/utils/model/modelStrings.github.test.ts',
+  'tests/utils/model/model.openai-shim-providers.test.ts',
   'tests/utils/model/modelOptions.github.test.ts',
   'tests/utils/model/providers.test.ts',
   'tests/utils/monotonic.test.ts',


### PR DESCRIPTION
## Summary
- move OpenAI-shim provider model regression coverage from the Bun-only moved-test quarantine into the normal Vitest suite
- replace Bun provider module mocks with scoped Vitest module mocks
- update the moved-test allowlist so the file runs in the default Vitest gate

Fixes #1068

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/model/model.openai-shim-providers.test.ts --reporter=dot
- moved-test quarantine scan: 70 total, 64 converted, 6 unconverted, 0 compatible unconverted
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke