### PR TITLE
test(runtime): convert secure storage platform coverage

### DIFF
--- a/runtime/tests/utils/secureStorage/platformStorage.test.ts
+++ b/runtime/tests/utils/secureStorage/platformStorage.test.ts
@@ -1,22 +1,63 @@
-
-import { expect, test, mock, describe, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { linuxSecretStorage } from "../../../src/utils/secureStorage/linuxSecretStorage.ts";
 import { windowsCredentialStorage } from "../../../src/utils/secureStorage/windowsCredentialStorage.ts";
 import { getSecureStorageServiceName, CREDENTIALS_SERVICE_SUFFIX } from "../../../src/utils/secureStorage/macOsKeychainHelpers.ts";
 
-// Mock execaSync
-const mockExecaSync = mock(() => ({ exitCode: 0, stdout: "" }));
-mock.module("execa", () => ({
+type ExecaSyncOptions = {
+  input?: string;
+  reject?: boolean;
+};
+
+type ExecaSyncResult = {
+  exitCode: number;
+  stdout: string;
+};
+
+type ExecaSyncMock = (
+  command: string,
+  args: string[],
+  options?: ExecaSyncOptions,
+) => ExecaSyncResult;
+
+const { mockExecaSync } = vi.hoisted(() => ({
+  mockExecaSync: vi.fn<ExecaSyncMock>(() => ({ exitCode: 0, stdout: "" })),
+}));
+
+vi.mock("execa", () => ({
   execaSync: mockExecaSync,
 }));
+
+function getExecaCall(index: number): Parameters<ExecaSyncMock> {
+  const call = mockExecaSync.mock.calls[index];
+  if (!call) {
+    throw new Error(`Expected execaSync call ${index}`);
+  }
+  return call;
+}
+
+function getPowerShellScript(index: number): string {
+  const [, args] = getExecaCall(index);
+  const script = args[1];
+  if (script === undefined) {
+    throw new Error(`Expected PowerShell script for execaSync call ${index}`);
+  }
+  return script;
+}
+
+function getExecaOptions(index: number): ExecaSyncOptions {
+  const [, , options] = getExecaCall(index);
+  if (!options) {
+    throw new Error(`Expected execaSync options for call ${index}`);
+  }
+  return options;
+}
 
 describe("Secure Storage Platform Implementations", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
-    mockExecaSync.mockClear();
-    // Default mock behavior
+    mockExecaSync.mockReset();
     mockExecaSync.mockImplementation(() => ({ exitCode: 0, stdout: "" }));
   });
 
@@ -53,8 +94,8 @@ describe("Secure Storage Platform Implementations", () => {
 
       linuxSecretStorage.update(testData);
 
-      const args = mockExecaSync.mock.calls[0];
-      expect(args[1]).toContain(expectedName);
+      const [, args] = getExecaCall(0);
+      expect(args).toContain(expectedName);
     });
 
     test("Windows storage uses scoped resource name", () => {
@@ -63,8 +104,8 @@ describe("Secure Storage Platform Implementations", () => {
 
       windowsCredentialStorage.update(testData);
 
-      const script = mockExecaSync.mock.calls[0][1][1];
-      const options = mockExecaSync.mock.calls[0][2];
+      const script = getPowerShellScript(0);
+      const options = getExecaOptions(0);
       expect(script).toContain(expectedName);
       expect(script).toContain("ProtectedData");
       expect(options.input).toContain("secret-token");
@@ -86,28 +127,28 @@ describe("Secure Storage Platform Implementations", () => {
 
       windowsCredentialStorage.update(dataWithDollar);
 
-      const script = mockExecaSync.mock.calls[0][1][1];
-      const options = mockExecaSync.mock.calls[0][2];
+      const script = getPowerShellScript(0);
+      const options = getExecaOptions(0);
       expect(script).toContain("[Console]::In.ReadToEnd()");
       expect(options.input).toContain("token-with-$env:USERNAME");
 
       const dataWithQuote = { mcpOAuth: { "s": { accessToken: "token'quote", expiresAt: 1, serverName: "s", serverUrl: "u" } } };
       windowsCredentialStorage.update(dataWithQuote);
-      const options2 = mockExecaSync.mock.calls[1][2];
+      const options2 = getExecaOptions(1);
       expect(options2.input).toContain("token'quote");
     });
 
     test("delete() skips legacy PasswordVault by default", () => {
       windowsCredentialStorage.delete();
       expect(mockExecaSync).toHaveBeenCalledTimes(1);
-      const script = mockExecaSync.mock.calls[0][1][1];
+      const script = getPowerShellScript(0);
       expect(script).not.toContain("System.Runtime.WindowsRuntime");
     });
 
     test("delete() includes legacy assembly load when explicitly enabled", () => {
       process.env.AGENC_ENABLE_LEGACY_WINDOWS_PASSWORDVAULT = "1";
       windowsCredentialStorage.delete();
-      const script = mockExecaSync.mock.calls[1][1][1];
+      const script = getPowerShellScript(1);
       expect(script).toContain("Add-Type -AssemblyName System.Runtime.WindowsRuntime");
     });
 
@@ -115,7 +156,7 @@ describe("Secure Storage Platform Implementations", () => {
       process.env.AGENC_ENABLE_LEGACY_WINDOWS_PASSWORDVAULT = "1";
       process.env.USER = 'user"name';
       windowsCredentialStorage.read();
-      const script = mockExecaSync.mock.calls[1][1][1];
+      const script = getPowerShellScript(1);
       // gaphunt3 #29: untrusted values are emitted as single-quoted PowerShell
       // literals, so the double quote is passed through verbatim (no expansion,
       // no backtick escaping) inside Retrieve('...').
@@ -166,7 +207,7 @@ describe("Secure Storage Platform Implementations", () => {
     test("update passes payload via stdin", () => {
       linuxSecretStorage.update(testData);
 
-      const options = mockExecaSync.mock.calls[0][2];
+      const options = getExecaOptions(0);
       expect(options.input).toContain("secret-token");
     });
 
@@ -182,7 +223,8 @@ describe("Secure Storage Platform Implementations", () => {
     const originalPlatform = process.platform;
 
     async function importFreshSecureStorage() {
-      return import(`../../../src/utils/secureStorage/index.ts?ts=${Date.now()}-${Math.random()}`);
+      vi.resetModules();
+      return import("../../../src/utils/secureStorage/index.ts");
     }
 
     afterEach(() => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -119,6 +119,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/serializationStability.test.ts',
   'tests/utils/sessionStorage.test.ts',
   'tests/utils/settings/allowBypassPermissionsMode.test.ts',
+  'tests/utils/secureStorage/platformStorage.test.ts',
   'tests/utils/shell-discovery.test.ts',
   'tests/utils/stableStringify.test.ts',
   'tests/utils/streamingOptimizer.test.ts',


### PR DESCRIPTION
## Summary\n- Convert secure storage platform regressions from Bun's module mock API to Vitest.\n- Keep mocking scoped to the external `execa` process boundary.\n- Register the test as converted in the moved donor quarantine list, leaving 5 unconverted moved tests.\n\nFixes #1070\n\n## Test plan\n- `npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/secureStorage/platformStorage.test.ts --reporter=dot`\n- `git diff --check`\n- `npm run typecheck`\n- `npm --workspace=@tetsuo-ai/runtime run check:unused`\n- `npm audit --audit-level=high`\n- `npm outdated --json`\n- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`\n- `npm run test:bun`\n- `npm test`\n- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`\n- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke