### PR TITLE
test(runtime): convert hook chain core coverage

### DIFF
--- a/runtime/tests/utils/hookChains.test.ts
+++ b/runtime/tests/utils/hookChains.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 type HookChainsModule = typeof import('../../src/utils/hookChains.ts')
 
+const policyLimitsModulePath = '../../src/services/policyLimits/index.js'
 const tempDirs: string[] = []
 const originalHookChainsEnabled = process.env.AGENC_ENABLE_HOOK_CHAINS
 
@@ -19,15 +20,15 @@ async function makeConfigFile(config: unknown): Promise<string> {
 async function importHookChainsModule(options?: {
   allowRemoteSessions?: boolean
 }): Promise<HookChainsModule> {
-  mock.restore()
+  vi.resetModules()
 
   const allowRemoteSessions = options?.allowRemoteSessions ?? true
 
-  mock.module('../../src/services/policyLimits/index.js', () => ({
+  vi.doMock(policyLimitsModulePath, () => ({
     isPolicyAllowed: () => allowRemoteSessions,
   }))
 
-  return import(`../../src/utils/hookChains.ts?test=${Date.now()}-${Math.random()}`)
+  return import('../../src/utils/hookChains.ts')
 }
 
 beforeEach(() => {
@@ -35,7 +36,9 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
-  mock.restore()
+  vi.doUnmock(policyLimitsModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
 
   if (originalHookChainsEnabled === undefined) {
     delete process.env.AGENC_ENABLE_HOOK_CHAINS
@@ -239,7 +242,7 @@ describe('dispatchHookChainsForEvent guard logic', () => {
       ],
     })
 
-    const spawn = mock(async () => ({ launched: true, agentId: 'agent-1' }))
+    const spawn = vi.fn(async () => ({ launched: true, agentId: 'agent-1' }))
 
     const first = await mod.dispatchHookChainsForEvent({
       configPathOverride: configPath,
@@ -287,7 +290,7 @@ describe('dispatchHookChainsForEvent guard logic', () => {
       ],
     })
 
-    const spawn = mock(async () => ({ launched: true, agentId: 'agent-2' }))
+    const spawn = vi.fn(async () => ({ launched: true, agentId: 'agent-2' }))
 
     const first = await mod.dispatchHookChainsForEvent({
       configPathOverride: configPath,
@@ -333,7 +336,7 @@ describe('dispatchHookChainsForEvent guard logic', () => {
       ],
     })
 
-    const spawn = mock(async () => ({ launched: true, agentId: 'agent-3' }))
+    const spawn = vi.fn(async () => ({ launched: true, agentId: 'agent-3' }))
 
     const result = await mod.dispatchHookChainsForEvent({
       configPathOverride: configPath,
@@ -411,7 +414,7 @@ describe('action dispatch skip scenarios', () => {
       ],
     })
 
-    const spawn = mock(async () => ({ launched: true, agentId: 'agent-4' }))
+    const spawn = vi.fn(async () => ({ launched: true, agentId: 'agent-4' }))
 
     const result = await mod.dispatchHookChainsForEvent({
       configPathOverride: configPath,
@@ -446,7 +449,7 @@ describe('action dispatch skip scenarios', () => {
       ],
     })
 
-    const warm = mock(async () => ({
+    const warm = vi.fn(async () => ({
       warmed: true,
       environmentId: 'env-123',
     }))

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -93,6 +93,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/gracefulShutdown.test.ts',
   'tests/utils/handlePromptSubmit.test.ts',
   'tests/utils/handlePromptSubmit.vimMode.test.ts',
+  'tests/utils/hookChains.test.ts',
   'tests/utils/hybridContextStrategy.test.ts',
   'tests/utils/memory/memory-utils.contract.test.ts',
   'tests/utils/messageQueueManager.test.ts',


### PR DESCRIPTION
## Summary\n- Convert core hook-chain regression coverage from Bun's mock API to Vitest.\n- Keep the module mock scoped to the policy-limit boundary.\n- Register the test as converted in the moved donor quarantine list, leaving 4 unconverted moved tests.\n\nFixes #1072\n\n## Test plan\n- `npm --workspace=@tetsuo-ai/runtime run test -- tests/utils/hookChains.test.ts --reporter=dot`\n- `git diff --check`\n- `npm run typecheck`\n- `npm --workspace=@tetsuo-ai/runtime run check:unused`\n- `npm audit --audit-level=high`\n- `npm outdated --json`\n- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`\n- `npm run test:bun`\n- `npm test`\n- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`\n- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke