### PR TITLE
test(runtime): convert provider profile coverage

### DIFF
--- a/runtime/tests/utils/providerProfiles.test.ts
+++ b/runtime/tests/utils/providerProfiles.test.ts
@@ -2,12 +2,15 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import type { ProviderProfile } from '../../src/utils/config.ts'
 
+const configModulePath = '../../src/utils/config.js'
+
 async function importFreshProvidersModule() {
-  return import(`../../src/utils/model/providers.ts?ts=${Date.now()}-${Math.random()}`)
+  vi.resetModules()
+  return import('../../src/utils/model/providers.ts')
 }
 
 const originalEnv = { ...process.env }
@@ -83,14 +86,17 @@ afterEach(() => {
     }
   }
 
-  mock.restore()
+  vi.doUnmock(configModulePath)
+  vi.clearAllMocks()
+  vi.resetModules()
   mockConfigState = createMockConfigState()
   process.chdir(originalCwd)
 })
 
 async function importFreshProviderProfileModules() {
-  mock.restore()
-  mock.module('../../src/utils/config.js', () => ({
+  vi.doUnmock(configModulePath)
+  vi.resetModules()
+  vi.doMock(configModulePath, () => ({
     getGlobalConfig: () => mockConfigState,
     saveGlobalConfig: (
       updater: (current: MockConfigState) => MockConfigState,
@@ -98,9 +104,8 @@ async function importFreshProviderProfileModules() {
       mockConfigState = updater(mockConfigState)
     },
   }))
-  const nonce = `${Date.now()}-${Math.random()}`
-  const providers = await import(`../../src/utils/model/providers.ts?ts=${nonce}`)
-  const providerProfiles = await import(`../../src/utils/providerProfiles.ts?ts=${nonce}`)
+  const providers = await import('../../src/utils/model/providers.ts')
+  const providerProfiles = await import('../../src/utils/providerProfiles.ts')
 
   return {
     ...providers,

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -115,6 +115,7 @@ const convertedMovedDonorTestFiles = new Set([
   'tests/utils/providerDiscovery.test.ts',
   'tests/utils/providerModels.test.ts',
   'tests/utils/providerProfile.test.ts',
+  'tests/utils/providerProfiles.test.ts',
   'tests/utils/providerRecommendation.test.ts',
   'tests/utils/providerValidation.test.ts',
   'tests/utils/requestLogging.test.ts',


### PR DESCRIPTION
## Summary
- convert the final moved donor-origin provider profile test from Bun-only quarantine to Vitest
- register the provider profile suite in the converted moved-test set
- reduce moved-test quarantine from 1 unconverted file to 0

Fixes #1080

## Research context
Current test-evolution work highlights hidden/stale tests as a source of regression risk in agent-maintained codebases. This PR moves the final quarantined provider-profile regression suite into the active local Vitest gate while keeping mocks scoped to the config persistence boundary.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/utils/providerProfiles.test.ts
- moved donor-origin map: 70 total, 70 converted, 0 unconverted
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- pre-commit hook: build, package entrypoints, TUI runtime startup smoke