### PR TITLE
fix(runtime): handle control tokens in text highlighting

### DIFF
--- a/runtime/src/utils/textHighlighting.ts
+++ b/runtime/src/utils/textHighlighting.ts
@@ -126,9 +126,11 @@ class HighlightSegmenter {
         this.codes.push(token)
         this.stringPos += token.code.length
         this.tokenIdx++
+      } else if (token.type === 'control') {
+        this.stringPos += token.code.length
+        this.tokenIdx++
       } else {
         const charsNeeded = targetVisiblePos - this.visiblePos
-        // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
         const charsAvailable = token.value.length - this.charIdx
         const charsToTake = Math.min(charsNeeded, charsAvailable)
 
@@ -136,7 +138,6 @@ class HighlightSegmenter {
         this.visiblePos += charsToTake
         this.charIdx += charsToTake
 
-        // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
         if (this.charIdx >= token.value.length) {
           this.tokenIdx++
           this.charIdx = 0

--- a/runtime/tests/utils/textHighlighting.test.ts
+++ b/runtime/tests/utils/textHighlighting.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { segmentTextByHighlights } from "../../src/utils/textHighlighting.js";
+
+describe("segmentTextByHighlights", () => {
+  test("preserves zero-width control tokens inside highlighted text", () => {
+    const controlSequence = "\x1B]0;title\x07";
+    const text = `a${controlSequence}bc`;
+
+    const segments = segmentTextByHighlights(text, [
+      {
+        start: 1,
+        end: 3,
+        color: "success",
+        priority: 1,
+      },
+    ]);
+
+    expect(segments).toEqual([
+      { text: "a", start: 0 },
+      {
+        text: `${controlSequence}bc`,
+        start: 1,
+        highlight: {
+          start: 1,
+          end: 3,
+          color: "success",
+          priority: 1,
+        },
+      },
+    ]);
+  });
+
+  test("does not count leading control tokens toward visible highlight ranges", () => {
+    const controlSequence = "\x1B]2;window-title\x1B\\";
+    const text = `${controlSequence}abc`;
+
+    const segments = segmentTextByHighlights(text, [
+      {
+        start: 0,
+        end: 1,
+        color: "warning",
+        priority: 1,
+      },
+    ]);
+
+    expect(segments).toEqual([
+      {
+        text: `${controlSequence}a`,
+        start: 0,
+        highlight: {
+          start: 0,
+          end: 1,
+          color: "warning",
+          priority: 1,
+        },
+      },
+      { text: "bc", start: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve tokenizer control tokens while segmenting highlighted text without advancing visible highlight positions.
- Remove the stale moved-source `@ts-expect-error` suppressions in `textHighlighting`.
- Add direct utility regression coverage for OSC/control sequences.

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/textHighlighting.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/BaseTextInput.coverage.test.tsx tests/tui/coverage-swarm/swarm-142-components-BaseTextInput.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: `npm run build` and `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`

Fixes #1086