### PR TITLE
fix(runtime): avoid AppStateProvider noise in welcome rendering

### DIFF
--- a/runtime/src/tui/hooks/useMainLoopModel.ts
+++ b/runtime/src/tui/hooks/useMainLoopModel.ts
@@ -1,6 +1,6 @@
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import { useEffect, useReducer } from 'react'
-import { type AppState, useAppState } from '../state/AppState.js'
+import { type AppState, useAppStateMaybeOutsideOfProvider } from '../state/AppState.js'
 import {
   getDefaultMainLoopModelSetting,
   type ModelName,
@@ -11,8 +11,10 @@ import {
 // API calls. Use this over getMainLoopModel() when the component needs to
 // update upon a model config change.
 export function useMainLoopModel(): ModelName {
-  const mainLoopModel = useAppState((s: AppState) => s.mainLoopModel)
-  const mainLoopModelForSession = useAppState(
+  const mainLoopModel = useAppStateMaybeOutsideOfProvider(
+    (s: AppState) => s.mainLoopModel,
+  )
+  const mainLoopModelForSession = useAppStateMaybeOutsideOfProvider(
     (s: AppState) => s.mainLoopModelForSession,
   )
 

--- a/runtime/tests/tui/components/Messages.welcome.test.tsx
+++ b/runtime/tests/tui/components/Messages.welcome.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from 'vitest'
 import type { Command } from '../../commands.js'
 import type { Tools } from '../../tools/Tool.js'
 import { renderToString } from '../../utils/staticRender.js'
+import {
+  getDefaultMainLoopModelSetting,
+  parseUserSpecifiedModel,
+} from '../../utils/model/model.js'
 import { ContentWidthProvider } from '../context/contentWidthContext.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { Messages } from './Messages.js'
@@ -42,6 +46,10 @@ describe('Messages welcome state', () => {
 
     expect(output).toContain('agenc.')
     expect(output).toContain('a netrunner with hands on every file')
+    expect(output).toContain(
+      parseUserSpecifiedModel(getDefaultMainLoopModelSetting()),
+    )
+    expect(output).not.toContain('default model')
     expect(output).toContain('workspace')
     expect(output).toContain('recent')
     expect(output).not.toContain('18.40')

--- a/runtime/tests/tui/hooks/useMainLoopModel.test.tsx
+++ b/runtime/tests/tui/hooks/useMainLoopModel.test.tsx
@@ -16,7 +16,7 @@ const model = vi.hoisted(() => ({
 }))
 
 vi.mock('../state/AppState.js', () => ({
-  useAppState: (
+  useAppStateMaybeOutsideOfProvider: (
     selector: (state: {
       mainLoopModel?: string
       mainLoopModelForSession?: string


### PR DESCRIPTION
## Summary
- Use the provider-tolerant AppState selector in `useMainLoopModel` so static welcome renders resolve the default model without throwing through the error-boundary fallback.
- Strengthen welcome rendering coverage to assert the resolved default model is shown instead of the fallback `default model` label.
- Update the hook test mock to match the provider-tolerant selector API.

Fixes #1088

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/Messages.welcome.test.tsx --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/components/Messages.welcomeModel.test.tsx --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/hooks/useMainLoopModel.test.tsx tests/tui/components/Messages.welcome.test.tsx tests/tui/components/Messages.welcomeModel.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- Pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke