### PR TITLE
fix(runtime): handle control tokens in ANSI slicing

### DIFF
--- a/runtime/src/utils/sliceAnsi.ts
+++ b/runtime/src/utils/sliceAnsi.ts
@@ -43,25 +43,40 @@ export default function sliceAnsi(
     // pass start/end in display cells (via stringWidth), so position must
     // track the same units.
     const width =
-      // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-      token.type === 'ansi' ? 0 : token.fullWidth ? 2 : stringWidth(token.value)
+      token.type === 'char'
+        ? token.fullWidth
+          ? 2
+          : stringWidth(token.value)
+        : 0
 
     // Break AFTER trailing zero-width marks — a combining mark attaches to
     // the preceding base char, so "भा" (भ + ा, 1 display cell) sliced at
     // end=1 must include the ा. Breaking on position >= end BEFORE the
     // zero-width check would drop it and render भ bare. ANSI codes are
     // width 0 but must NOT be included past end (they open new style runs
-    // that leak into the undo sequence), so gate on char type too. The
-    // !include guard ensures empty slices (start===end) stay empty even
-    // when the string starts with a zero-width char (BOM, ZWJ).
+    // that leak into the undo sequence). Control tokens are also zero-width
+    // raw bytes, but they belong to the following visible range rather than
+    // the preceding slice. The !include guard ensures empty slices
+    // (start===end) stay empty even when the string starts with a zero-width
+    // char (BOM, ZWJ).
     if (end !== undefined && position >= end) {
-      if (token.type === 'ansi' || width > 0 || !include) break
+      if (token.type !== 'char' || width > 0 || !include) break
     }
 
     if (token.type === 'ansi') {
       activeCodes.push(token)
       if (include) {
         // Emit all ANSI codes during the slice
+        result += token.code
+      }
+    } else if (token.type === 'control') {
+      if (!include && position >= start) {
+        include = true
+        activeCodes = filterStartCodes(reduceAnsiCodes(activeCodes))
+        result = ansiCodesToString(activeCodes)
+      }
+
+      if (include) {
         result += token.code
       }
     } else {
@@ -78,7 +93,6 @@ export default function sliceAnsi(
       }
 
       if (include) {
-        // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
         result += token.value
       }
 

--- a/runtime/tests/utils/sliceAnsi.test.ts
+++ b/runtime/tests/utils/sliceAnsi.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import sliceAnsi from "../../src/utils/sliceAnsi.js";
+
+describe("sliceAnsi", () => {
+  test("preserves zero-width control tokens without advancing visible slices", () => {
+    const controlSequence = "\x1B]0;window-title\x07";
+    const text = `a${controlSequence}bc`;
+
+    expect(sliceAnsi(text, 0, 1)).toBe("a");
+    expect(sliceAnsi(text, 0, 2)).toBe(`a${controlSequence}b`);
+    expect(sliceAnsi(text, 1, 3)).toBe(`${controlSequence}bc`);
+    expect(sliceAnsi(text, 0, 1) + sliceAnsi(text, 1, 3)).toBe(text);
+  });
+});


### PR DESCRIPTION
## Summary
- Handle `@alcalzone/ansi-tokenize` `control` tokens explicitly in `sliceAnsi` as zero-width raw codes.
- Preserve OSC control sequences in visible slices without emitting `undefined` or duplicating boundary controls.
- Remove two stale moved-source `@ts-expect-error` suppressions and add focused regression coverage.

Fixes #1090

## Research context
- Current test-evolution work such as TEBench highlights stale and missing tests as project-level maintenance risks.
- Recent TypeScript ecosystem bug research points to build/tooling-boundary fragility; this fix removes a suppression that masked an unhandled tokenizer union member.

## Validation
- Before fix: `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/sliceAnsi.test.ts --reporter=verbose` failed with `expected 'aundefinedb'`.
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/sliceAnsi.test.ts --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/sliceAnsi.test.ts tests/tui/ink/wrap-text.test.ts tests/tui/ink/output.coverage.test.ts tests/tui/ink/output.wave200-033.coverage.test.ts --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- Pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke