### PR TITLE
fix(runtime): resolve teammate fallback models for xai and mistral

### DIFF
--- a/runtime/src/utils/model/configs.ts
+++ b/runtime/src/utils/model/configs.ts
@@ -157,6 +157,8 @@ export const AGENC_OPUS_4_6_CONFIG = {
   agenc: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
+  mistral: 'devstral-latest',
+  xai: 'grok-4.3',
 } as const satisfies ModelConfig
 
 export const AGENC_OPUS_4_7_CONFIG = {

--- a/runtime/src/utils/swarm/teammateModel.ts
+++ b/runtime/src/utils/swarm/teammateModel.ts
@@ -6,6 +6,5 @@ import { getAPIProvider } from '../model/providers.js'
 // use Opus 4.6. Must be provider-aware so Bedrock/Vertex/Foundry customers get
 // the correct model ID.
 export function getHardcodedTeammateModelFallback(): string {
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
   return AGENC_OPUS_4_6_CONFIG[getAPIProvider()]
 }

--- a/runtime/tests/utils/swarm/teammateModel.test.ts
+++ b/runtime/tests/utils/swarm/teammateModel.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { getHardcodedTeammateModelFallback } from "../../../src/utils/swarm/teammateModel.js";
+
+const providerEnvKeys = [
+  "AGENC_USE_GEMINI",
+  "AGENC_USE_GITHUB",
+  "AGENC_USE_MINIMAX",
+  "AGENC_USE_MISTRAL",
+  "AGENC_USE_OPENAI",
+  "MINIMAX_API_KEY",
+  "MISTRAL_MODEL",
+  "NVIDIA_MODEL",
+  "NVIDIA_NIM",
+  "OPENAI_MODEL",
+  "XAI_API_KEY",
+] as const;
+
+const originalProviderEnv = Object.fromEntries(
+  providerEnvKeys.map(key => [key, process.env[key]]),
+) as Record<(typeof providerEnvKeys)[number], string | undefined>;
+
+function clearProviderEnv(): void {
+  for (const key of providerEnvKeys) {
+    delete process.env[key];
+  }
+}
+
+function restoreProviderEnv(): void {
+  clearProviderEnv();
+  for (const [key, value] of Object.entries(originalProviderEnv)) {
+    if (value !== undefined) {
+      process.env[key as (typeof providerEnvKeys)[number]] = value;
+    }
+  }
+}
+
+describe("getHardcodedTeammateModelFallback", () => {
+  beforeEach(() => {
+    clearProviderEnv();
+  });
+
+  afterEach(() => {
+    restoreProviderEnv();
+  });
+
+  test("resolves a concrete xAI fallback when xAI is the active provider", () => {
+    process.env.XAI_API_KEY = "xai-test-key";
+
+    expect(getHardcodedTeammateModelFallback()).toBe("grok-4.3");
+  });
+
+  test("resolves a concrete Mistral fallback when Mistral is the active provider", () => {
+    process.env.AGENC_USE_MISTRAL = "1";
+
+    expect(getHardcodedTeammateModelFallback()).toBe("devstral-latest");
+  });
+});


### PR DESCRIPTION
## Summary
- Add xAI and Mistral entries to the Opus 4.6 teammate fallback provider map.
- Remove the stale moved-source `@ts-expect-error` from `getHardcodedTeammateModelFallback`.
- Add regression coverage proving xAI and Mistral teammate fallbacks return concrete model strings.

Fixes #1092

## Research context
- Recent TypeScript ecosystem bug research highlights fragility around build and tooling boundaries; this fix removes a suppression that hid a real undefined-return path.
- Current test-evolution work such as TEBench emphasizes missing/stale regression coverage for behavior introduced as projects evolve.

## Validation
- Before fix: `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/swarm/teammateModel.test.ts --reporter=verbose` failed with `expected undefined` for xAI and Mistral.
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/swarm/teammateModel.test.ts --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/swarm/teammateModel.test.ts tests/utils/model/model.config-model.test.ts tests/utils/model/model.openai-shim-providers.test.ts tests/utils/model/providers.test.ts --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- Pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke