### PR TITLE
fix(runtime): preserve anonymous hybrid context messages

### DIFF
--- a/runtime/src/utils/hybridContextStrategy.ts
+++ b/runtime/src/utils/hybridContextStrategy.ts
@@ -222,8 +222,7 @@ export function applyHybridStrategy(
   const cfg = { ...DEFAULT_CONFIG, ...config }
   
   // Preserve message chains (tool_use/tool_result pairs)
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-  const { chains, orphans } = getMessageChain(messages)
+  const { chains } = getMessageChain(messages)
   
   // Always preserve the conversation tail (last N messages)
   const tailMessages = messages.slice(-MIN_TAILMessages)
@@ -246,11 +245,21 @@ export function applyHybridStrategy(
   ]
 
   const seenUuids = new Set<string>()
+  const seenAnonymousMessages = new WeakSet<Message>()
   const selectedMessages: Message[] = []
   for (const msg of allSelected) {
-    const uuid = msg.uuid ?? msg.message?.id ?? ''
-    if (!seenUuids.has(uuid)) {
+    const uuid = msg.uuid ?? msg.message?.id
+    if (uuid && uuid.length > 0) {
+      if (seenUuids.has(uuid)) {
+        continue
+      }
       seenUuids.add(uuid)
+      selectedMessages.push(msg)
+      continue
+    }
+
+    if (!seenAnonymousMessages.has(msg)) {
+      seenAnonymousMessages.add(msg)
       selectedMessages.push(msg)
     }
   }

--- a/runtime/tests/utils/hybridContextStrategy.test.ts
+++ b/runtime/tests/utils/hybridContextStrategy.test.ts
@@ -81,6 +81,38 @@ describe('hybridContextStrategy', () => {
 
       expect(result.estimatedCost).toBeGreaterThanOrEqual(0)
     })
+
+    it('preserves distinct messages that do not have stable ids', () => {
+      const messages = [
+        {
+          message: {
+            role: 'user',
+            content: 'Anonymous user message',
+            created_at: 1000,
+          },
+          sender: 'user',
+        },
+        {
+          message: {
+            role: 'assistant',
+            content: 'Anonymous assistant response',
+            created_at: 2000,
+          },
+          sender: 'assistant',
+        },
+      ] as any[]
+
+      const result = applyHybridStrategy(messages, {
+        cacheWeight: 0.5,
+        freshWeight: 0.5,
+        maxTotalTokens: 10000,
+      })
+
+      expect(result.selectedMessages.map(m => m.message.content)).toEqual([
+        'Anonymous user message',
+        'Anonymous assistant response',
+      ])
+    })
   })
 
   describe('optimizeForCost', () => {


### PR DESCRIPTION
## Summary
- Preserve distinct hybrid-context messages that lack both `uuid` and `message.id` by deduping anonymous messages by object identity instead of the empty string.
- Remove the stale moved-source suppression in `hybridContextStrategy.ts`.
- Add a regression test that fails on the previous implementation.

Fixes #1094

## Research/quality note
Recent test-evolution work such as TEBench and mutation-guided regression-suite diagnosis highlights stale tests that pass while no longer checking meaningful behavioral invariants. This patch tightens the hybrid strategy test from "returns something" to "preserves every distinct anonymous message" so the suite catches the actual regression.

## Test plan
- Failing before fix: `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/hybridContextStrategy.test.ts --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/hybridContextStrategy.test.ts --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/hybridContextStrategy.test.ts tests/services/api/anthropic-core.test.ts --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- Pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke

Remote workflow remains disabled: `Transaction Guard Live disabled_manually 274957897`.
