### PR TITLE
fix(runtime): match nested instruction rules

### DIFF
--- a/runtime/src/prompts/rules/discovery.ts
+++ b/runtime/src/prompts/rules/discovery.ts
@@ -244,13 +244,38 @@ function normalizePathForMatch(path: string): string {
   return path.split(/[\\/]+/).join("/");
 }
 
+function findScopedRulesRoot(rulePath: string): string | null {
+  let current = dirname(rulePath);
+  while (true) {
+    if (
+      basename(current) === RULES_SUBDIR &&
+      basename(dirname(current)) === RULES_DIRNAME
+    ) {
+      return current;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function matchBaseForRule(rulePath: string): string {
+  const rulesRoot = findScopedRulesRoot(rulePath);
+  if (rulesRoot !== null) {
+    return dirname(dirname(rulesRoot));
+  }
+
+  const ruleBase = dirname(dirname(rulePath));
+  return dirname(ruleBase);
+}
+
 export function ruleMatchesTarget(
   rulePath: string,
   frontmatter: InstructionRuleFrontmatter,
   targetPath: string,
 ): boolean {
-  const ruleBase = dirname(dirname(rulePath)); // <dir>/.agenc/rules/file.md -> <dir>/.agenc
-  const projectBase = dirname(ruleBase);
+  const projectBase = matchBaseForRule(rulePath);
   const absTarget = resolve(targetPath);
   const candidates = new Set<string>([
     normalizePathForMatch(absTarget),

--- a/runtime/tests/prompts/rules/discovery.test.ts
+++ b/runtime/tests/prompts/rules/discovery.test.ts
@@ -51,6 +51,19 @@ describe("ruleMatchesTarget", () => {
     expect(ruleMatchesTarget(rulePath, fm, join(dir, "tests", "unit", "x.test.ts"))).toBe(true);
     expect(ruleMatchesTarget(rulePath, fm, join(dir, "docs", "x.md"))).toBe(false);
   });
+
+  test("matches project-relative patterns for nested rule files", () => {
+    const rulePath = join(dir, ".agenc", "rules", "frontend", "typescript.md");
+    const fm = {
+      paths: ["src"],
+      globs: ["tests/**/*.test.ts"],
+      alwaysApply: false,
+      extra: {},
+    };
+    expect(ruleMatchesTarget(rulePath, fm, join(dir, "src", "index.ts"))).toBe(true);
+    expect(ruleMatchesTarget(rulePath, fm, join(dir, "tests", "unit", "x.test.ts"))).toBe(true);
+    expect(ruleMatchesTarget(rulePath, fm, join(dir, "docs", "x.md"))).toBe(false);
+  });
 });
 
 describe("discoverInstructionRules", () => {
@@ -88,5 +101,25 @@ globs: ["src/**/*.ts"]
     expect(rules).toHaveLength(1);
     expect(rules[0]?.content).toBe("# Src");
   });
-});
 
+  test("returns matching conditional rules from nested rule directories", async () => {
+    const rulesDir = projectRulesDir(dir);
+    const nestedRulesDir = join(rulesDir, "frontend");
+    mkdirSync(nestedRulesDir, { recursive: true });
+    writeFileSync(join(nestedRulesDir, "src.md"), `---
+globs: ["src/**/*.ts"]
+---
+# Nested Src
+`);
+    const rules = await discoverInstructionRules({
+      rulesDir,
+      type: "Project",
+      boundaryDir: dir,
+      targetPath: join(dir, "src", "nested", "x.ts"),
+      includeUnconditional: false,
+      includeConditional: true,
+    });
+    expect(rules).toHaveLength(1);
+    expect(rules[0]?.content).toBe("# Nested Src");
+  });
+});


### PR DESCRIPTION
## Summary
- derive rule matching base from the nearest .agenc/rules ancestor
- keep nested conditional rule files matched against project-relative paths and globs
- add regressions for nested rule matching and discovery

Fixes #1096

## Test plan
- [x] npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/prompts/rules/discovery.test.ts --reporter=verbose
- [x] npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/prompts/rules/discovery.test.ts tests/prompts/agenc-md.test.ts --reporter=dot
- [x] npm run typecheck
- [x] git diff --check
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused:all
- [x] npm audit --audit-level=high
- [x] npm outdated --json
- [x] AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- [x] npm run test:bun
- [x] npm test
- [x] pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke