### PR TITLE
fix(runtime): type shell quote boundary

### DIFF
--- a/runtime/src/types/shell-quote.d.ts
+++ b/runtime/src/types/shell-quote.d.ts
@@ -1,0 +1,56 @@
+declare module 'shell-quote' {
+  export type ControlOperator =
+    | '||'
+    | '&&'
+    | ';;'
+    | '|&'
+    | '<('
+    | '<<<'
+    | '>>'
+    | '>&'
+    | '<&'
+    | '&'
+    | ';'
+    | '('
+    | ')'
+    | '|'
+    | '<'
+    | '>'
+
+  export type OperatorToken = {
+    op: ControlOperator
+  }
+
+  export type GlobToken = {
+    op: 'glob'
+    pattern: string
+  }
+
+  export type CommentToken = {
+    comment: string
+  }
+
+  export type ParseEntry =
+    | string
+    | OperatorToken
+    | GlobToken
+    | CommentToken
+
+  export type Environment =
+    | Record<string, string | ParseEntry | undefined>
+    | ((key: string) => string | ParseEntry | undefined)
+
+  export type ParseOptions = {
+    escape?: string
+  }
+
+  export function parse(
+    cmd: string,
+    env?: Environment,
+    opts?: ParseOptions,
+  ): ParseEntry[]
+
+  export function quote(
+    args: ReadonlyArray<string | OperatorToken | GlobToken | CommentToken>,
+  ): string
+}

--- a/runtime/src/utils/bash/commands.ts
+++ b/runtime/src/utils/bash/commands.ts
@@ -1,5 +1,4 @@
 import { randomBytes } from 'crypto'
-// @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
 import type { ControlOperator, ParseEntry } from 'shell-quote'
 import {
   type CommandPrefixResult,

--- a/runtime/src/utils/bash/shellQuote.ts
+++ b/runtime/src/utils/bash/shellQuote.ts
@@ -7,12 +7,10 @@ import {
   type ParseEntry,
   parse as shellQuoteParse,
   quote as shellQuoteQuote,
-// @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
 } from 'shell-quote'
 import { logError } from '../log.js'
 import { jsonStringify } from '../slowOperations.js'
 
-// @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
 export type { ParseEntry } from 'shell-quote'
 
 export type ShellParseResult =


### PR DESCRIPTION
## Summary
- add a local shell-quote module declaration for parse token shapes
- remove stale moved-source suppressions from Bash command parsing utilities
- preserve existing runtime parser behavior while restoring type coverage

Fixes #1098

## Test plan
- [x] npm run typecheck
- [x] npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/permissions/bash.test.ts tests/tools/BashTool/bashPermissions.test.ts tests/tools/BashTool/modeValidation.test.ts tests/tools/BashTool/sedEditParser.test.ts tests/shell-command/bash-ast-security.test.ts tests/shell-command/bashParser.test.ts --reporter=dot
- [x] git diff --check
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused:all
- [x] npm audit --audit-level=high
- [x] npm outdated --json
- [x] AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- [x] npm run test:bun
- [x] npm test
- [x] pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke