### PR TITLE
fix(runtime): declare AWS auth SDK deps

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -72,6 +72,8 @@
   },
   "optionalDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1049.0",
+    "@aws-sdk/client-sts": "^3.1068.0",
+    "@aws-sdk/credential-providers": "^3.1068.0",
     "@mendable/firecrawl-js": "^4.25.4",
     "cheerio": "^1.2.0",
     "image-processor-napi": "^0.0.1",

--- a/runtime/src/utils/aws.ts
+++ b/runtime/src/utils/aws.ts
@@ -49,7 +49,6 @@ export function isValidAwsStsOutput(obj: unknown): obj is AwsStsOutput {
 /** Throws if STS caller identity cannot be retrieved. */
 export async function checkStsCallerIdentity(): Promise<void> {
   const { STSClient, GetCallerIdentityCommand } = await import(
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     '@aws-sdk/client-sts'
   )
   await new STSClient().send(new GetCallerIdentityCommand({}))
@@ -62,7 +61,6 @@ export async function checkStsCallerIdentity(): Promise<void> {
 export async function clearAwsIniCache(): Promise<void> {
   try {
     logForDebugging('Clearing AWS credential provider cache')
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     const { fromIni } = await import('@aws-sdk/credential-providers')
     const iniProvider = fromIni({ ignoreCache: true })
     await iniProvider() // This updates the global file cache

--- a/runtime/tests/meta/license-and-version.test.ts
+++ b/runtime/tests/meta/license-and-version.test.ts
@@ -33,6 +33,25 @@ describe("repository licensing", () => {
   });
 });
 
+describe("runtime manifest dependencies", () => {
+  test("declares optional AWS auth modules imported by aws.ts", () => {
+    const awsSource = readRepoFile("runtime/src/utils/aws.ts");
+    const runtimePkg = JSON.parse(readRepoFile("runtime/package.json")) as {
+      optionalDependencies?: Record<string, string>;
+    };
+    const optionalDependencies = runtimePkg.optionalDependencies ?? {};
+    const awsAuthModules = [
+      "@aws-sdk/client-sts",
+      "@aws-sdk/credential-providers",
+    ];
+
+    for (const moduleName of awsAuthModules) {
+      expect(awsSource).toContain(`'${moduleName}'`);
+      expect(optionalDependencies[moduleName]).toMatch(/^\^3\.\d+\.\d+$/);
+    }
+  });
+});
+
 describe("build-time MACRO.VERSION wiring", () => {
   // MACRO.VERSION is injected at build time via esbuild `define`.
   // We cannot exercise the bundled define from a unit test, so instead we


### PR DESCRIPTION
## Summary
- declare `@aws-sdk/client-sts` and `@aws-sdk/credential-providers` as runtime optional dependencies
- remove stale suppressions from the AWS auth helper dynamic imports
- add a manifest contract so AWS auth imports stay declared

Fixes #1100

## Test plan
- [x] npm install
- [x] node -e "for (const m of ['@aws-sdk/client-sts','@aws-sdk/credential-providers']) console.log(m, require.resolve(m))"
- [x] npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/meta/license-and-version.test.ts --reporter=verbose
- [x] npm run typecheck
- [x] git diff --check
- [x] npm ls @aws-sdk/client-sts @aws-sdk/credential-providers --workspace=@tetsuo-ai/runtime
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused:all
- [x] npm audit --audit-level=high
- [x] npm outdated --json
- [x] AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- [x] npm run test:bun
- [x] npm test
- [x] pre-commit hook: runtime build + package entrypoints + TUI runtime startup smoke