### PR TITLE
test(runtime): cover output scanner recursion

### DIFF
--- a/runtime/src/utils/filePersistence/outputsScanner.ts
+++ b/runtime/src/utils/filePersistence/outputsScanner.ts
@@ -8,6 +8,7 @@
  */
 
 import * as fs from 'fs/promises'
+import type { Dirent } from 'node:fs'
 import * as path from 'path'
 import { logForDebugging } from 'src/utils/debug.js'
 // Donor teleport environments module was removed in the upstream-backend
@@ -15,6 +16,11 @@ import { logForDebugging } from 'src/utils/debug.js'
 // independent of any future remote-environment module.
 type EnvironmentKind = 'byoc' | 'agenc_cloud'
 import type { TurnStartTime } from './types.js'
+
+type RecursiveDirent = Omit<Dirent<string>, 'parentPath'> & {
+  readonly parentPath?: string
+  readonly path?: string
+}
 
 /** Shared debug logger for file persistence modules */
 export function logDebug(message: string): void {
@@ -33,17 +39,19 @@ export function getEnvironmentKind(): EnvironmentKind | null {
   return null
 }
 
-function hasParentPath(
-  entry: object,
-): entry is { parentPath: string; name: string } {
+function hasParentPath(entry: RecursiveDirent): entry is RecursiveDirent & {
+  readonly parentPath: string
+} {
   return 'parentPath' in entry && typeof entry.parentPath === 'string'
 }
 
-function hasPath(entry: object): entry is { path: string; name: string } {
+function hasPath(entry: RecursiveDirent): entry is RecursiveDirent & {
+  readonly path: string
+} {
   return 'path' in entry && typeof entry.path === 'string'
 }
 
-function getEntryParentPath(entry: object, fallback: string): string {
+function getEntryParentPath(entry: RecursiveDirent, fallback: string): string {
   if (hasParentPath(entry)) {
     return entry.parentPath
   }
@@ -67,13 +75,12 @@ export async function findModifiedFiles(
   outputsDir: string,
 ): Promise<string[]> {
   // Use recursive flag to get all entries in one call
-  let entries: Awaited<ReturnType<typeof fs.readdir>>
+  let entries: RecursiveDirent[]
   try {
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-    entries = await fs.readdir(outputsDir, {
+    entries = (await fs.readdir(outputsDir, {
       withFileTypes: true,
       recursive: true,
-    })
+    })) as RecursiveDirent[]
   } catch {
     // Directory doesn't exist or is not accessible
     return []
@@ -88,7 +95,6 @@ export async function findModifiedFiles(
     if (entry.isFile()) {
       // entry.parentPath is available in Node 20+, fallback to entry.path for older versions
       const parentPath = getEntryParentPath(entry, outputsDir)
-      // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
       filePaths.push(path.join(parentPath, entry.name))
     }
   }

--- a/runtime/tests/utils/filePersistence.outputsScanner.test.ts
+++ b/runtime/tests/utils/filePersistence.outputsScanner.test.ts
@@ -1,0 +1,84 @@
+import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, relative } from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+
+import {
+  findModifiedFiles,
+  getEnvironmentKind,
+} from "../../src/utils/filePersistence/outputsScanner.js"
+
+const tempDirs: string[] = []
+const originalEnvironmentKind = process.env.AGENC_ENVIRONMENT_KIND
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "agenc-outputs-scanner-"))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  if (originalEnvironmentKind === undefined) {
+    delete process.env.AGENC_ENVIRONMENT_KIND
+  } else {
+    process.env.AGENC_ENVIRONMENT_KIND = originalEnvironmentKind
+  }
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+describe("getEnvironmentKind", () => {
+  test("accepts only recognized environment kinds", () => {
+    process.env.AGENC_ENVIRONMENT_KIND = "byoc"
+    expect(getEnvironmentKind()).toBe("byoc")
+
+    process.env.AGENC_ENVIRONMENT_KIND = "agenc_cloud"
+    expect(getEnvironmentKind()).toBe("agenc_cloud")
+
+    process.env.AGENC_ENVIRONMENT_KIND = "local"
+    expect(getEnvironmentKind()).toBeNull()
+  })
+})
+
+describe("findModifiedFiles", () => {
+  test("returns nested regular files modified since the turn started", async () => {
+    const root = await makeTempDir()
+    const nestedDir = join(root, "nested", "deeper")
+    const staleFile = join(root, "stale.txt")
+    const rootFreshFile = join(root, "fresh.txt")
+    const nestedFreshFile = join(nestedDir, "fresh-nested.txt")
+
+    await mkdir(nestedDir, { recursive: true })
+    await writeFile(staleFile, "old")
+    await writeFile(rootFreshFile, "new")
+    await writeFile(nestedFreshFile, "nested")
+
+    const turnStartTime = Date.now() - 5_000
+    const staleDate = new Date(turnStartTime - 10_000)
+    await utimes(staleFile, staleDate, staleDate)
+
+    const modified = await findModifiedFiles(turnStartTime, root)
+
+    expect(modified.map((file) => relative(root, file)).sort()).toEqual([
+      "fresh.txt",
+      join("nested", "deeper", "fresh-nested.txt"),
+    ])
+  })
+
+  test("skips symlinks and tolerates missing output directories", async () => {
+    const root = await makeTempDir()
+    const target = join(root, "target.txt")
+    const link = join(root, "link.txt")
+
+    await writeFile(target, "target")
+    await symlink(target, link)
+
+    const modified = await findModifiedFiles(Date.now() - 5_000, root)
+
+    expect(modified.map((file) => relative(root, file))).toEqual(["target.txt"])
+    await expect(
+      findModifiedFiles(Date.now(), join(root, "missing")),
+    ).resolves.toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Type the recursive output scanner Dirent handling without moved-source suppressions.
- Add focused coverage for recognized environment kinds, nested modified files, stale files, symlink skipping, and missing output directories.

Fixes #1102

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/filePersistence.outputsScanner.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke