### PR TITLE
test(runtime): type YAML Bun boundary

### DIFF
--- a/runtime/src/types/runtime-ambient.d.ts
+++ b/runtime/src/types/runtime-ambient.d.ts
@@ -139,6 +139,9 @@ declare const Bun: {
   which(command: string): string | null;
   hash(input: string | ArrayBufferView | ArrayBuffer, seed?: number | bigint): bigint;
   gc(synchronous?: boolean): number;
+  YAML: {
+    parse(input: string): unknown;
+  };
   semver: {
     order(a: string, b: string): -1 | 0 | 1;
     satisfies(version: string, range: string): boolean;

--- a/runtime/src/utils/yaml.ts
+++ b/runtime/src/utils/yaml.ts
@@ -13,7 +13,6 @@ const require = createRequire(import.meta.url)
 
 export function parseYaml(input: string): unknown {
   if (typeof Bun !== 'undefined') {
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     return Bun.YAML.parse(input)
   }
   return (require('js-yaml') as { load: typeof loadYaml }).load(input)

--- a/runtime/tests/utils/yaml.bun.test.ts
+++ b/runtime/tests/utils/yaml.bun.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+
+import { parseYaml } from "../../src/utils/yaml.ts"
+
+test("parseYaml uses Bun.YAML in Bun", () => {
+  expect(typeof Bun.YAML.parse).toBe("function")
+  expect(parseYaml("name: AgenC\npaths:\n  - runtime/src/**/*.ts\n")).toEqual({
+    name: "AgenC",
+    paths: ["runtime/src/**/*.ts"],
+  })
+})

--- a/runtime/tests/utils/yaml.test.ts
+++ b/runtime/tests/utils/yaml.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest"
+
+import { parseYaml } from "../../src/utils/yaml.js"
+
+describe("parseYaml", () => {
+  test("uses the Node js-yaml fallback outside Bun", () => {
+    expect(parseYaml("name: AgenC\npaths:\n  - src/**/*.ts\n")).toEqual({
+      name: "AgenC",
+      paths: ["src/**/*.ts"],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Declare the `Bun.YAML.parse` surface consumed by the YAML wrapper.
- Remove the stale moved-source suppression from `parseYaml`.
- Cover both Node `js-yaml` fallback and native Bun YAML parsing.

Fixes #1104

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/yaml.test.ts --reporter=verbose
- cd runtime && bun test tests/utils/yaml.bun.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke