### PR TITLE
fix(runtime): declare ZIP archive dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -112,6 +112,7 @@
     "emoji-regex": "^10.6.0",
     "env-paths": "^4.0.0",
     "execa": "9.6.1",
+    "fflate": "^0.8.3",
     "figures": "6.1.0",
     "fuse.js": "^7.1.0",
     "get-east-asian-width": "^1.5.0",

--- a/runtime/src/utils/dxt/zip.ts
+++ b/runtime/src/utils/dxt/zip.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, normalize } from 'path'
 import { logForDebugging } from 'src/utils/debug.js'
+import type { UnzipFileInfo } from 'fflate'
 import { isENOENT } from '../errors.js'
 import { getFsImplementation } from '../fsOperations.js'
 import { containsPathTraversal } from '../path.js'
@@ -25,10 +26,7 @@ type ZipValidationState = {
 /**
  * File metadata from fflate filter
  */
-type ZipFileMetadata = {
-  name: string
-  originalSize?: number
-}
+type ZipFileMetadata = Pick<UnzipFileInfo, 'name' | 'originalSize'>
 
 /**
  * Result of validating a single file in a zip archive
@@ -113,7 +111,6 @@ export function validateZipFile(
 export async function unzipFile(
   zipData: Buffer,
 ): Promise<Record<string, Uint8Array>> {
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
   const { unzipSync } = await import('fflate')
   const compressedSize = zipData.length
 
@@ -125,7 +122,6 @@ export async function unzipFile(
   }
 
   const result = unzipSync(new Uint8Array(zipData), {
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
     filter: file => {
       const validationResult = validateZipFile(file, state)
       if (!validationResult.isValid) {

--- a/runtime/src/utils/plugins/zipCache.ts
+++ b/runtime/src/utils/plugins/zipCache.ts
@@ -30,6 +30,7 @@
  */
 
 import { randomBytes } from 'crypto'
+import type { ZippableFile } from 'fflate'
 import {
   chmod,
   lstat,
@@ -202,7 +203,7 @@ export async function atomicWriteToZipCache(
 
 // fflate's ZippableFile tuple form: [data, opts]. Using the tuple lets us
 // store {os, attrs} so parseZipModes can recover exec bits on extraction.
-type ZipEntry = [Uint8Array, { os: number; attrs: number }]
+type ZipEntry = ZippableFile
 
 /**
  * Create a ZIP archive from a directory.
@@ -220,7 +221,6 @@ export async function createZipFromDirectory(
   const visited = new Set<string>()
   await collectFilesForZip(sourceDir, '', files, visited)
 
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
   const { zipSync } = await import('fflate')
   const zipData = zipSync(files, { level: 6 })
   logForDebugging(

--- a/runtime/tests/meta/license-and-version.test.ts
+++ b/runtime/tests/meta/license-and-version.test.ts
@@ -50,6 +50,21 @@ describe("runtime manifest dependencies", () => {
       expect(optionalDependencies[moduleName]).toMatch(/^\^3\.\d+\.\d+$/);
     }
   });
+
+  test("declares ZIP archive module imported by plugin zip utilities", () => {
+    const zipSource = readRepoFile("runtime/src/utils/dxt/zip.ts");
+    const zipCacheSource = readRepoFile(
+      "runtime/src/utils/plugins/zipCache.ts",
+    );
+    const runtimePkg = JSON.parse(readRepoFile("runtime/package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    const dependencies = runtimePkg.dependencies ?? {};
+
+    expect(zipSource).toContain("'fflate'");
+    expect(zipCacheSource).toContain("'fflate'");
+    expect(dependencies.fflate).toMatch(/^\^0\.8\.\d+$/);
+  });
 });
 
 describe("build-time MACRO.VERSION wiring", () => {

--- a/runtime/tests/utils/dxt-zip.test.ts
+++ b/runtime/tests/utils/dxt-zip.test.ts
@@ -1,0 +1,50 @@
+import { Buffer } from "node:buffer"
+import { describe, expect, test } from "vitest"
+import { strToU8, zipSync } from "fflate"
+
+import { isPathSafe, unzipFile } from "../../src/utils/dxt/zip.js"
+
+const textDecoder = new TextDecoder()
+
+describe("isPathSafe", () => {
+  test("accepts relative archive paths and rejects traversal or absolute paths", () => {
+    expect(isPathSafe("plugin.json")).toBe(true)
+    expect(isPathSafe("commands/hello.md")).toBe(true)
+    expect(isPathSafe("./commands/hello.md")).toBe(true)
+
+    expect(isPathSafe("../escape.txt")).toBe(false)
+    expect(isPathSafe("commands/../../escape.txt")).toBe(false)
+    expect(isPathSafe("/tmp/escape.txt")).toBe(false)
+  })
+})
+
+describe("unzipFile", () => {
+  test("extracts safe zip entries", async () => {
+    const zipData = Buffer.from(
+      zipSync({
+        "plugin.json": strToU8("{}"),
+        "commands/hello.md": strToU8("hello"),
+      }),
+    )
+
+    const files = await unzipFile(zipData)
+
+    expect(Object.keys(files).sort()).toEqual([
+      "commands/hello.md",
+      "plugin.json",
+    ])
+    expect(textDecoder.decode(files["commands/hello.md"])).toBe("hello")
+  })
+
+  test("rejects traversal entries before returning data", async () => {
+    const zipData = Buffer.from(
+      zipSync({
+        "../escape.txt": strToU8("bad"),
+      }),
+    )
+
+    await expect(unzipFile(zipData)).rejects.toThrow(
+      /Unsafe file path detected/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- declare the `fflate` runtime dependency used by ZIP archive extraction and plugin zip creation
- replace moved-source suppressions with `fflate`'s exported TypeScript types
- add regression coverage for safe ZIP extraction, traversal rejection, and manifest dependency wiring

Fixes #1106

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/dxt-zip.test.ts tests/meta/license-and-version.test.ts --reporter=verbose`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: runtime build, package entrypoint check, TUI runtime startup smoke
