### PR TITLE
fix(runtime): remove MCPB package dependency

### DIFF
--- a/runtime/src/utils/dxt/helpers.ts
+++ b/runtime/src/utils/dxt/helpers.ts
@@ -1,21 +1,16 @@
-// @ts-expect-error -- optional peer dependency, may not be installed in all environments
-import type { McpbManifest } from '@anthropic-ai/mcpb'
 import { errorMessage } from '../errors.js'
 import { jsonParse } from '../slowOperations.js'
+import { McpbManifestSchema, type McpbManifest } from './mcpb.js'
 
 /**
  * Parses and validates a DXT manifest from a JSON object.
  *
- * Lazy-imports @anthropic-ai/mcpb: that package uses zod v3 which eagerly
- * creates 24 .bind(this) closures per schema instance (~300 instances between
- * schemas.js and schemas-loose.js). Deferring the import keeps ~700KB of bound
- * closures out of the startup heap for sessions that never touch .dxt/.mcpb.
+ * Uses the local MCPB schema subset instead of the published package's root
+ * export, which includes CLI-only dependencies that the runtime does not need.
  */
 export async function validateManifest(
   manifestJson: unknown,
 ): Promise<McpbManifest> {
-  // @ts-expect-error -- optional peer dependency, may not be installed in all environments
-  const { McpbManifestSchema } = await import('@anthropic-ai/mcpb')
   const parseResult = McpbManifestSchema.safeParse(manifestJson)
 
   if (!parseResult.success) {

--- a/runtime/src/utils/dxt/mcpb.ts
+++ b/runtime/src/utils/dxt/mcpb.ts
@@ -1,0 +1,330 @@
+import { z } from 'zod/v4'
+
+const MANIFEST_VERSIONS = ['0.1', '0.2', '0.3', '0.4'] as const
+const LOCALE_PLACEHOLDER_REGEX = /\$\{locale\}/i
+const BCP47_REGEX = /^[A-Za-z0-9]{2,8}(?:-[A-Za-z0-9]{1,8})*$/
+const ICON_SIZE_REGEX = /^\d+x\d+$/
+
+const McpServerConfigSchema = z.strictObject({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+})
+
+const McpbManifestAuthorSchema = z.strictObject({
+  name: z.string(),
+  email: z.email().optional(),
+  url: z.url().optional(),
+})
+
+const McpbManifestRepositorySchema = z.strictObject({
+  type: z.string(),
+  url: z.url(),
+})
+
+const McpbManifestPlatformOverrideSchema = McpServerConfigSchema.partial()
+
+const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
+  platform_overrides: z
+    .record(z.string(), McpbManifestPlatformOverrideSchema)
+    .optional(),
+})
+
+const McpbManifestCompatibilitySchema = z.strictObject({
+  claude_desktop: z.string().optional(),
+  platforms: z.array(z.enum(['darwin', 'win32', 'linux'])).optional(),
+  runtimes: z
+    .strictObject({
+      python: z.string().optional(),
+      node: z.string().optional(),
+    })
+    .optional(),
+})
+
+const McpbManifestToolSchema = z.strictObject({
+  name: z.string(),
+  description: z.string().optional(),
+})
+
+const McpbManifestPromptSchema = z.strictObject({
+  name: z.string(),
+  description: z.string().optional(),
+  arguments: z.array(z.string()).optional(),
+  text: z.string(),
+})
+
+const McpbUserConfigurationOptionSchema = z.strictObject({
+  type: z.enum(['string', 'number', 'boolean', 'directory', 'file']),
+  title: z.string(),
+  description: z.string(),
+  required: z.boolean().optional(),
+  default: z
+    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+    .optional(),
+  multiple: z.boolean().optional(),
+  sensitive: z.boolean().optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+})
+
+const McpbManifestLocalizationSchema = z.strictObject({
+  resources: z.string().regex(
+    LOCALE_PLACEHOLDER_REGEX,
+    'resources must include a "${locale}" placeholder',
+  ),
+  default_locale: z
+    .string()
+    .regex(BCP47_REGEX, 'default_locale must be a valid BCP 47 locale identifier'),
+})
+
+const McpbManifestIconSchema = z.strictObject({
+  src: z.string(),
+  size: z.string().regex(
+    ICON_SIZE_REGEX,
+    'size must be in the format "WIDTHxHEIGHT" (e.g., "16x16")',
+  ),
+  theme: z.string().min(1, 'theme cannot be empty when provided').optional(),
+})
+
+function mcpbManifestServerSchema(version: (typeof MANIFEST_VERSIONS)[number]) {
+  return z.strictObject({
+    type: z.enum(
+      version === '0.4'
+        ? ['python', 'node', 'binary', 'uv']
+        : ['python', 'node', 'binary'],
+    ),
+    entry_point: z.string(),
+    mcp_config: McpbManifestMcpConfigSchema,
+  })
+}
+
+function mcpbManifestSchema(version: (typeof MANIFEST_VERSIONS)[number]) {
+  const base = {
+    $schema: z.string().optional(),
+    dxt_version: z.literal(version).optional(),
+    manifest_version: z.literal(version).optional(),
+    name: z.string(),
+    display_name: z.string().optional(),
+    version: z.string(),
+    description: z.string(),
+    long_description: z.string().optional(),
+    author: McpbManifestAuthorSchema,
+    repository: McpbManifestRepositorySchema.optional(),
+    homepage: z.url().optional(),
+    documentation: z.url().optional(),
+    support: z.url().optional(),
+    icon: z.string().optional(),
+    screenshots: z.array(z.string()).optional(),
+    server: mcpbManifestServerSchema(version),
+    tools: z.array(McpbManifestToolSchema).optional(),
+    tools_generated: z.boolean().optional(),
+    prompts: z.array(McpbManifestPromptSchema).optional(),
+    prompts_generated: z.boolean().optional(),
+    keywords: z.array(z.string()).optional(),
+    license: z.string().optional(),
+    compatibility: McpbManifestCompatibilitySchema.optional(),
+    user_config: z
+      .record(z.string(), McpbUserConfigurationOptionSchema)
+      .optional(),
+  }
+
+  const versioned =
+    version === '0.1'
+      ? base
+      : {
+          ...base,
+          privacy_policies: z.array(z.url()).optional(),
+          ...(version === '0.2'
+            ? {}
+            : {
+                icons: z.array(McpbManifestIconSchema).optional(),
+                localization: McpbManifestLocalizationSchema.optional(),
+                _meta: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+              }),
+        }
+
+  return z.strictObject(versioned).refine(
+    data => Boolean(data.dxt_version || data.manifest_version),
+    {
+      message:
+        "Either 'dxt_version' (deprecated) or 'manifest_version' must be provided",
+    },
+  )
+}
+
+export const McpbManifestSchema = z.union([
+  mcpbManifestSchema('0.1'),
+  mcpbManifestSchema('0.2'),
+  mcpbManifestSchema('0.3'),
+  mcpbManifestSchema('0.4'),
+])
+
+export type McpbManifest = z.infer<typeof McpbManifestSchema>
+export type McpbUserConfigurationOption = z.infer<
+  typeof McpbUserConfigurationOptionSchema
+>
+export type McpbUserConfigValues = Record<
+  string,
+  string | number | boolean | string[]
+>
+export type McpbMcpConfig = z.infer<typeof McpbManifestMcpConfigSchema>
+
+type Logger = {
+  warn: (...args: unknown[]) => void
+}
+
+type GetMcpConfigForManifestOptions = {
+  manifest: McpbManifest
+  extensionPath: string
+  systemDirs: Record<string, string>
+  userConfig?: McpbUserConfigValues
+  pathSeparator: string
+  logger?: Logger
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function replaceMcpbVariables(
+  value: unknown,
+  variables: Record<string, string | string[]>,
+): unknown {
+  if (typeof value === 'string') {
+    let result = value
+    for (const [key, replacement] of Object.entries(variables)) {
+      const pattern = new RegExp(`\\$\\{${escapeRegExp(key)}\\}`, 'g')
+      if (!pattern.test(result)) {
+        continue
+      }
+      if (!Array.isArray(replacement)) {
+        result = result.replace(pattern, replacement)
+      }
+    }
+    return result
+  }
+
+  if (Array.isArray(value)) {
+    const result: unknown[] = []
+    for (const item of value) {
+      if (typeof item === 'string') {
+        const variableName = item.match(/^\$\{([^}]+)\}$/)?.[1]
+        const replacement = variableName ? variables[variableName] : undefined
+        if (Array.isArray(replacement)) {
+          result.push(...replacement)
+          continue
+        }
+        if (replacement !== undefined) {
+          result.push(replacement)
+          continue
+        }
+      }
+      result.push(replaceMcpbVariables(item, variables))
+    }
+    return result
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        replaceMcpbVariables(nestedValue, variables),
+      ]),
+    )
+  }
+
+  return value
+}
+
+function isInvalidSingleValue(value: unknown): boolean {
+  return value === undefined || value === null || value === ''
+}
+
+function hasRequiredConfigMissing(
+  manifest: McpbManifest,
+  userConfig?: McpbUserConfigValues,
+): boolean {
+  if (!manifest.user_config) {
+    return false
+  }
+
+  const config = userConfig ?? {}
+  for (const [key, configOption] of Object.entries(manifest.user_config)) {
+    if (!configOption.required) {
+      continue
+    }
+    const value = config[key]
+    if (
+      isInvalidSingleValue(value) ||
+      (Array.isArray(value) &&
+        (value.length === 0 || value.some(isInvalidSingleValue)))
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+export async function getMcpConfigForManifest({
+  manifest,
+  extensionPath,
+  systemDirs,
+  userConfig,
+  pathSeparator,
+  logger,
+}: GetMcpConfigForManifestOptions): Promise<McpbMcpConfig | undefined> {
+  const baseConfig = manifest.server?.mcp_config
+  if (!baseConfig) {
+    return undefined
+  }
+
+  let result: McpbMcpConfig = { ...baseConfig }
+  const platformConfig = baseConfig.platform_overrides?.[process.platform]
+  if (platformConfig) {
+    result = {
+      ...result,
+      command: platformConfig.command ?? result.command,
+      args: platformConfig.args ?? result.args,
+      env: platformConfig.env ?? result.env,
+    }
+  }
+
+  if (hasRequiredConfigMissing(manifest, userConfig)) {
+    logger?.warn(
+      `Extension ${manifest.name} has missing required configuration, skipping MCP config`,
+    )
+    return undefined
+  }
+
+  const variables: Record<string, string | string[]> = {
+    __dirname: extensionPath,
+    pathSeparator,
+    '/': pathSeparator,
+    ...systemDirs,
+  }
+
+  const mergedConfig: McpbUserConfigValues = {}
+  if (manifest.user_config) {
+    for (const [key, configOption] of Object.entries(manifest.user_config)) {
+      if (configOption.default !== undefined) {
+        mergedConfig[key] = configOption.default
+      }
+    }
+  }
+  if (userConfig) {
+    Object.assign(mergedConfig, userConfig)
+  }
+
+  for (const [key, value] of Object.entries(mergedConfig)) {
+    const userConfigKey = `user_config.${key}`
+    if (Array.isArray(value)) {
+      variables[userConfigKey] = value.map(String)
+    } else if (typeof value === 'boolean') {
+      variables[userConfigKey] = value ? 'true' : 'false'
+    } else {
+      variables[userConfigKey] = String(value)
+    }
+  }
+
+  return replaceMcpbVariables(result, variables) as McpbMcpConfig
+}

--- a/runtime/src/utils/plugins/mcpbHandler.ts
+++ b/runtime/src/utils/plugins/mcpbHandler.ts
@@ -1,8 +1,3 @@
-import type {
-  McpbManifest,
-  McpbUserConfigurationOption,
-  // @ts-expect-error -- optional peer module not present in this workspace; types are erased at runtime
-} from '@anthropic-ai/mcpb'
 import axios from 'axios'
 import { createHash } from 'crypto'
 import { chmod, writeFile } from 'fs/promises'
@@ -10,6 +5,11 @@ import { dirname, join } from 'path'
 import type { McpServerConfig } from '../../services/mcp/types.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { parseAndValidateManifestFromBytes } from '../dxt/helpers.js'
+import {
+  getMcpConfigForManifest,
+  type McpbManifest,
+  type McpbUserConfigurationOption,
+} from '../dxt/mcpb.js'
 import { parseZipModes, unzipFile } from '../dxt/zip.js'
 import { errorMessage, getErrnoCode, isENOENT, toError } from '../errors.js'
 import { getFsImplementation } from '../fsOperations.js'
@@ -416,10 +416,6 @@ async function generateMcpConfig(
   extractedPath: string,
   userConfig: UserConfigValues = {},
 ): Promise<McpServerConfig> {
-  // Lazy import: @anthropic-ai/mcpb barrel pulls in zod v3 schemas (~700KB of
-  // bound closures). See dxt/helpers.ts for details.
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-  const { getMcpConfigForManifest } = await import('@anthropic-ai/mcpb')
   const mcpConfig = await getMcpConfigForManifest({
     manifest,
     extensionPath: extractedPath,

--- a/runtime/src/utils/plugins/schemas.ts
+++ b/runtime/src/utils/plugins/schemas.ts
@@ -600,12 +600,12 @@ const PluginManifestMcpServerSchema = lazySchema(() =>
 /**
  * Schema for a single user-configurable option in plugin manifest userConfig.
  *
- * Shape intentionally matches `McpbUserConfigurationOption` from
- * `@anthropic-ai/mcpb` so the parsed result is structurally assignable to
- * `UserConfigSchema` in mcpbHandler.ts — this lets us reuse
- * `validateUserConfig` and the config dialog without modification.
- * `title` and `description` are required (not optional) because the upstream
- * type requires them and the config dialog renders them.
+ * Shape intentionally matches `McpbUserConfigurationOption` from the local DXT
+ * MCPB schema helper so the parsed result is structurally assignable to
+ * `UserConfigSchema` in mcpbHandler.ts. This lets us reuse `validateUserConfig`
+ * and the config dialog without modification. `title` and `description` are
+ * required (not optional) because the MCPB schema requires them and the config
+ * dialog renders them.
  *
  * Used by both the top-level manifest.userConfig and the per-channel
  * channels[].userConfig (assistant-mode channels).

--- a/runtime/tests/meta/license-and-version.test.ts
+++ b/runtime/tests/meta/license-and-version.test.ts
@@ -65,6 +65,24 @@ describe("runtime manifest dependencies", () => {
     expect(zipCacheSource).toContain("'fflate'");
     expect(dependencies.fflate).toMatch(/^\^0\.8\.\d+$/);
   });
+
+  test("does not depend on the CLI-heavy MCPB package for runtime validation", () => {
+    const dxtHelperSource = readRepoFile("runtime/src/utils/dxt/helpers.ts");
+    const mcpbHandlerSource = readRepoFile(
+      "runtime/src/utils/plugins/mcpbHandler.ts",
+    );
+    const runtimePkg = JSON.parse(readRepoFile("runtime/package.json")) as {
+      dependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+
+    expect(dxtHelperSource).not.toContain("@anthropic-ai/mcpb");
+    expect(mcpbHandlerSource).not.toContain("@anthropic-ai/mcpb");
+    expect(runtimePkg.dependencies?.["@anthropic-ai/mcpb"]).toBeUndefined();
+    expect(
+      runtimePkg.optionalDependencies?.["@anthropic-ai/mcpb"],
+    ).toBeUndefined();
+  });
 });
 
 describe("build-time MACRO.VERSION wiring", () => {

--- a/runtime/tests/utils/dxt-mcpb.test.ts
+++ b/runtime/tests/utils/dxt-mcpb.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  parseAndValidateManifestFromText,
+  validateManifest,
+} from "../../src/utils/dxt/helpers.js"
+import { getMcpConfigForManifest } from "../../src/utils/dxt/mcpb.js"
+
+const baseManifest = {
+  manifest_version: "0.4",
+  name: "sample-extension",
+  version: "1.0.0",
+  description: "Sample extension",
+  author: {
+    name: "Tetsuo AI",
+  },
+  server: {
+    type: "node",
+    entry_point: "server.js",
+    mcp_config: {
+      command: "node",
+      args: ["${__dirname}/server.js"],
+    },
+  },
+}
+
+describe("MCPB manifest validation", () => {
+  test("accepts current v0.4 manifests including uv servers", async () => {
+    const manifest = await validateManifest({
+      ...baseManifest,
+      server: {
+        type: "uv",
+        entry_point: "main.py",
+        mcp_config: {
+          command: "uv",
+          args: ["run", "${__dirname}/main.py"],
+        },
+      },
+    })
+
+    expect(manifest.server.type).toBe("uv")
+  })
+
+  test("rejects uv servers before manifest v0.4", async () => {
+    await expect(
+      validateManifest({
+        ...baseManifest,
+        manifest_version: "0.3",
+        server: {
+          type: "uv",
+          entry_point: "main.py",
+          mcp_config: {
+            command: "uv",
+          },
+        },
+      }),
+    ).rejects.toThrow(/Invalid manifest/)
+  })
+
+  test("rejects manifests without an MCPB manifest version", async () => {
+    const { manifest_version: _manifestVersion, ...manifestWithoutVersion } =
+      baseManifest
+
+    await expect(validateManifest(manifestWithoutVersion)).rejects.toThrow(
+      /Invalid manifest/,
+    )
+  })
+
+  test("parses valid manifest JSON text", async () => {
+    const manifest = await parseAndValidateManifestFromText(
+      JSON.stringify(baseManifest),
+    )
+
+    expect(manifest.name).toBe("sample-extension")
+  })
+})
+
+describe("getMcpConfigForManifest", () => {
+  test("applies defaults, user config, system dirs, and array expansion", async () => {
+    const manifest = await validateManifest({
+      ...baseManifest,
+      user_config: {
+        paths: {
+          type: "string",
+          title: "Paths",
+          description: "Extra paths",
+          multiple: true,
+          default: ["default-a", "default-b"],
+        },
+        enabled: {
+          type: "boolean",
+          title: "Enabled",
+          description: "Feature switch",
+          default: false,
+        },
+      },
+      server: {
+        type: "node",
+        entry_point: "server.js",
+        mcp_config: {
+          command: "${runtime}",
+          args: [
+            "${__dirname}/server.js",
+            "${user_config.paths}",
+            "--enabled=${user_config.enabled}",
+          ],
+          env: {
+            HOME_DIR: "${HOME}",
+          },
+        },
+      },
+    })
+
+    const config = await getMcpConfigForManifest({
+      manifest,
+      extensionPath: "/tmp/extension",
+      systemDirs: {
+        HOME: "/home/tester",
+        runtime: "node",
+      },
+      userConfig: {
+        enabled: true,
+      },
+      pathSeparator: "/",
+    })
+
+    expect(config).toMatchObject({
+      command: "node",
+      args: [
+        "/tmp/extension/server.js",
+        "default-a",
+        "default-b",
+        "--enabled=true",
+      ],
+      env: {
+        HOME_DIR: "/home/tester",
+      },
+    })
+  })
+
+  test("returns undefined when required user config is missing", async () => {
+    const manifest = await validateManifest({
+      ...baseManifest,
+      user_config: {
+        token: {
+          type: "string",
+          title: "Token",
+          description: "Required token",
+          required: true,
+        },
+      },
+    })
+
+    await expect(
+      getMcpConfigForManifest({
+        manifest,
+        extensionPath: "/tmp/extension",
+        systemDirs: {},
+        pathSeparator: "/",
+      }),
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- replace undeclared `@anthropic-ai/mcpb` imports with a local runtime MCPB schema/config helper
- remove MCPB package suppressions from DXT manifest validation and MCPB config generation
- cover manifest version validation, v0.4 `uv` support, config substitution, required config handling, and a guard against reintroducing the CLI-heavy MCPB package dependency

Fixes #1108

## Notes
Installing `@anthropic-ai/mcpb@2.1.2` directly brought in an audited CLI prompt chain through `@inquirer/prompts -> @inquirer/editor -> external-editor -> tmp@0.0.33`. This PR keeps the runtime behavior local instead of adding that package dependency.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/dxt-mcpb.test.ts tests/meta/license-and-version.test.ts --reporter=verbose`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: runtime build, package entrypoint check, TUI runtime startup smoke
