### PR TITLE
fix(runtime): declare Google auth dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -76,6 +76,7 @@
     "@aws-sdk/credential-providers": "^3.1068.0",
     "@mendable/firecrawl-js": "^4.25.4",
     "cheerio": "^1.2.0",
+    "google-auth-library": "^10.7.0",
     "image-processor-napi": "^0.0.1",
     "ollama": "^0.6.3",
     "openai": "^6.27.0",

--- a/runtime/src/utils/auth.ts
+++ b/runtime/src/utils/auth.ts
@@ -873,7 +873,7 @@ const GCP_CREDENTIALS_CHECK_TIMEOUT_MS = 5_000
 export async function checkGcpCredentialsValid(): Promise<boolean> {
   try {
     // Dynamically import to avoid loading google-auth-library unnecessarily
-    const { GoogleAuth } = (await import('google-auth-library' as string)) as any
+    const { GoogleAuth } = await import('google-auth-library')
     const auth = new GoogleAuth({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     })

--- a/runtime/src/utils/geminiAuth.ts
+++ b/runtime/src/utils/geminiAuth.ts
@@ -109,7 +109,6 @@ function normalizeAccessToken(
 }
 
 async function createDefaultGoogleAuth(): Promise<GoogleAuthLike> {
-  // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
   const { GoogleAuth } = await import('google-auth-library')
   return new GoogleAuth({
     scopes: [GEMINI_ADC_SCOPE],

--- a/runtime/tests/meta/license-and-version.test.ts
+++ b/runtime/tests/meta/license-and-version.test.ts
@@ -51,6 +51,21 @@ describe("runtime manifest dependencies", () => {
     }
   });
 
+  test("declares optional Google auth module imported by GCP auth helpers", () => {
+    const authSource = readRepoFile("runtime/src/utils/auth.ts");
+    const geminiAuthSource = readRepoFile("runtime/src/utils/geminiAuth.ts");
+    const runtimePkg = JSON.parse(readRepoFile("runtime/package.json")) as {
+      optionalDependencies?: Record<string, string>;
+    };
+    const optionalDependencies = runtimePkg.optionalDependencies ?? {};
+
+    expect(authSource).toContain("'google-auth-library'");
+    expect(geminiAuthSource).toContain("'google-auth-library'");
+    expect(optionalDependencies["google-auth-library"]).toMatch(
+      /^\^10\.\d+\.\d+$/,
+    );
+  });
+
   test("declares ZIP archive module imported by plugin zip utilities", () => {
     const zipSource = readRepoFile("runtime/src/utils/dxt/zip.ts");
     const zipCacheSource = readRepoFile(


### PR DESCRIPTION
## Summary
- declare `google-auth-library` as an optional runtime dependency for GCP/Gemini auth paths
- type the lazy Google auth imports directly and remove the Gemini moved-source suppression
- add a manifest contract test covering the auth helpers' dependency declaration

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/meta/license-and-version.test.ts --reporter=verbose`
- `cd runtime && bun test tests/utils/geminiAuth.test.ts`
- `npm run typecheck`
- `node -e "console.log(require.resolve('google-auth-library'))"`
- `npm ls google-auth-library --workspace=@tetsuo-ai/runtime --all`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: `npm run build` and `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`

Fixes #1110