### PR TITLE
fix(runtime): type AgenC refresh body

### DIFF
--- a/runtime/src/utils/agencCredentials.ts
+++ b/runtime/src/utils/agencCredentials.ts
@@ -287,6 +287,7 @@ export async function refreshAgencAccessTokenIfNeeded(options?: {
   if (!current.refreshToken) {
     return { refreshed: false, credentials: current }
   }
+  const refreshToken = current.refreshToken
 
   if (!options?.force && !shouldRefreshAgencToken(current)) {
     return { refreshed: false, credentials: current }
@@ -304,11 +305,10 @@ export async function refreshAgencAccessTokenIfNeeded(options?: {
     const refreshAttemptedAt = Date.now()
 
     try {
-      // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
       const body = new URLSearchParams({
         client_id: getAgencOAuthClientId(),
         grant_type: 'refresh_token',
-        refresh_token: current.refreshToken,
+        refresh_token: refreshToken,
       })
 
       const response = await fetch(AGENC_REFRESH_URL, {
@@ -336,7 +336,7 @@ export async function refreshAgencAccessTokenIfNeeded(options?: {
       const next: AgencCredentialBlob = {
         accessToken,
         refreshToken:
-          asTrimmedString(payload.refresh_token) ?? current.refreshToken,
+          asTrimmedString(payload.refresh_token) ?? refreshToken,
         idToken: asTrimmedString(payload.id_token) ?? current.idToken,
         accountId:
           parseChatgptAccountId(payload.id_token) ??


### PR DESCRIPTION
## Summary
- capture the validated AgenC refresh token before the async refresh closure
- remove the stale `URLSearchParams` moved-source suppression
- preserve existing refresh request and fallback refresh-token behavior

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/agencCredentials.test.ts --reporter=verbose`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: `npm run build` and `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`

Fixes #1112