### PR TITLE
fix(runtime): type plugin metadata cleanup paths

### DIFF
--- a/runtime/src/utils/plugins/installedPluginsManager.ts
+++ b/runtime/src/utils/plugins/installedPluginsManager.ts
@@ -387,8 +387,6 @@ function saveInstalledPluginsV2(data: InstalledPluginsFileV2): void {
       `Saved ${Object.keys(data.plugins).length} installed plugins to ${filePath}`,
     )
   } catch (error) {
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-    const _errorMsg = errorMessage(error)
     logError(toError(error))
     throw error
   }

--- a/runtime/src/utils/plugins/marketplaceManager.ts
+++ b/runtime/src/utils/plugins/marketplaceManager.ts
@@ -2003,19 +2003,21 @@ export async function removeMarketplaceSource(name: string): Promise<void> {
     // Remove related plugins from enabledPlugins (format: "plugin@marketplace")
     if (settings.enabledPlugins) {
       const marketplaceSuffix = `@${name}`
-      const updatedPlugins = { ...settings.enabledPlugins }
+      const updatedPlugins: Partial<
+        NonNullable<SettingsJson['enabledPlugins']>
+      > = { ...settings.enabledPlugins }
       let removedPlugins = false
 
       for (const pluginId in updatedPlugins) {
         if (pluginId.endsWith(marketplaceSuffix)) {
-          // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
           updatedPlugins[pluginId] = undefined
           removedPlugins = true
         }
       }
 
       if (removedPlugins) {
-        updates.enabledPlugins = updatedPlugins
+        updates.enabledPlugins =
+          updatedPlugins as SettingsJson['enabledPlugins']
         needsUpdate = true
       }
     }


### PR DESCRIPTION
## Summary
- remove a stale installed-plugins save-error suppression and unused error-message artifact
- type marketplace enabled-plugin delete sentinels with the existing internal `Partial<T> -> T` settings deletion pattern
- preserve `updateSettingsForSource` mergeWith deletion behavior

## Validation
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/plugins/pluginLoader-core.test.ts tests/plugins/marketplace/marketplace.test.ts tests/test-parity/upstream/security-hardening.test.ts --reporter=verbose`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: `npm run build` and `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`

Fixes #1114