### PR TITLE
fix(runtime): remove worktree attribution hook import

### DIFF
--- a/runtime/src/utils/worktree.ts
+++ b/runtime/src/utils/worktree.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import chalk from 'chalk'
 import { spawnSync } from 'child_process'
 import {
@@ -629,42 +628,6 @@ async function performPostCreationSetup(
   // Copy gitignored files specified in .worktreeinclude (best-effort)
   await copyWorktreeIncludeFiles(repoRoot, worktreePath)
 
-  // The core.hooksPath config-set above is fragile: husky's prepare script
-  // (`git config core.hooksPath .husky`) runs on every `bun install` and
-  // resets the SHARED .git/config value back to relative, causing each
-  // worktree to resolve to its OWN .husky/ again. The attribution hook
-  // file isn't tracked (it's in .git/info/exclude), so fresh worktrees
-  // don't have it. Install it directly into the worktree's .husky/ —
-  // husky won't delete it (husky install is additive-only), and for
-  // non-husky repos this resolves to the shared .git/hooks/ (idempotent).
-  //
-  // Pass the worktree-local .husky explicitly: getHooksDir would return
-  // the absolute core.hooksPath we just set above (main repo's .husky),
-  // not the worktree's — `git rev-parse --git-path hooks` echoes the config
-  // value verbatim when it's absolute.
-  if (feature('COMMIT_ATTRIBUTION')) {
-    const worktreeHooksDir =
-      hooksPath === huskyPath ? join(worktreePath, '.husky') : undefined
-    // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-    void import('./postCommitAttribution.js')
-      .then(m =>
-        m
-          .installPrepareCommitMsgHook(worktreePath, worktreeHooksDir)
-          // @ts-expect-error -- moved-source note: moved utility depends on not-yet-absorbed subsystem types.
-          .catch(error => {
-            logForDebugging(
-              `Failed to install attribution hook in worktree: ${error}`,
-            )
-          }),
-      )
-      .catch(error => {
-        // Dynamic import() itself rejected (module load failure). The inner
-        // .catch above only handles installPrepareCommitMsgHook rejection —
-        // without this outer handler an import failure would surface as an
-        // unhandled promise rejection.
-        logForDebugging(`Failed to load postCommitAttribution module: ${error}`)
-      })
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove the unreachable `COMMIT_ATTRIBUTION` worktree hook-install block
- drop the missing `./postCommitAttribution.js` dynamic import and its stale moved-source suppressions
- preserve normal worktree setup, hooks path configuration, symlink handling, and `.worktreeinclude` copy behavior

## Validation
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tools/system/worktree.test.ts tests/gaphunt3/tools-system-worktree.test.ts tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx --reporter=verbose`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: `npm run build` and `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`

Fixes #1116