### PR TITLE
fix(runtime): type embedded ripgrep bun spawn

### DIFF
--- a/runtime/src/types/runtime-ambient.d.ts
+++ b/runtime/src/types/runtime-ambient.d.ts
@@ -133,9 +133,27 @@ interface ObjectConstructor {
 
 type StructuredSerializeOptions = import("node:worker_threads").StructuredSerializeOptions;
 
+type BunSpawnStdio = "pipe" | "ignore" | "inherit";
+type BunSpawnOptions = {
+  argv0?: string;
+  stdout?: BunSpawnStdio;
+  stderr?: BunSpawnStdio;
+};
+type BunSpawnPipeOptions = BunSpawnOptions & { stdout: "pipe" };
+type BunSpawnPipeResult = {
+  stdout: { text(): Promise<string> };
+  exited: Promise<number>;
+};
+type BunSpawnResult = {
+  stdout: unknown;
+  exited: Promise<number>;
+};
+
 declare const Bun: {
   embeddedFiles?: readonly unknown[];
   file(path: string): unknown;
+  spawn(command: readonly string[], options: BunSpawnPipeOptions): BunSpawnPipeResult;
+  spawn(command: readonly string[], options?: BunSpawnOptions): BunSpawnResult;
   which(command: string): string | null;
   hash(input: string | ArrayBufferView | ArrayBuffer, seed?: number | bigint): bigint;
   gc(synchronous?: boolean): number;

--- a/runtime/src/utils/ripgrep.ts
+++ b/runtime/src/utils/ripgrep.ts
@@ -680,16 +680,14 @@ const testRipgrepOnFirstUse = memoize(async (): Promise<void> => {
     if (config.argv0) {
       // Only Bun embeds ripgrep.
       // eslint-disable-next-line custom-rules/require-bun-typeof-guard
-      // @ts-expect-error -- Bun.spawn typing is not declared in the narrow Bun ambient (runtime-only).
       const proc = Bun.spawn([config.command, '--version'], {
         argv0: config.argv0,
         stderr: 'ignore',
         stdout: 'pipe',
       })
 
-      // Bun's ReadableStream has .text() at runtime, but TS types don't reflect it
       const [stdout, code] = await Promise.all([
-        (proc.stdout as unknown as Blob).text(),
+        proc.stdout.text(),
         proc.exited,
       ])
       test = {


### PR DESCRIPTION
## Summary
- add a narrow Bun.spawn pipe overload to the runtime ambient types
- remove the embedded ripgrep first-use probe suppression and typed stdout cast

Fixes #1118

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/ripgrep.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
