### PR TITLE
fix(runtime): validate native image processor exports

### DIFF
--- a/runtime/src/tools/FileReadTool/imageProcessor.ts
+++ b/runtime/src/tools/FileReadTool/imageProcessor.ts
@@ -56,16 +56,17 @@ export async function getImageProcessor(): Promise<SharpFunction> {
     try {
       // Use the native image processor module.
       // Native optional dep: present at runtime on supported platforms, not installed as a TS dep.
-      // @ts-expect-error -- image-processor-napi is a native optional module loaded at runtime
       const imageProcessor = await import('image-processor-napi')
-      if ((imageProcessor as { __stub?: boolean }).__stub) {
-        throw new ImageProcessorUnavailableError()
+      if (imageProcessor.__stub) {
+        throw new Error('native image processor is a stub')
       }
-      const sharp = imageProcessor.sharp || imageProcessor.default
+      const sharp = imageProcessor.sharp ?? imageProcessor.default
+      if (typeof sharp !== 'function') {
+        throw new Error('native image processor does not export sharp')
+      }
       imageProcessorModule = { default: sharp }
       return sharp
     } catch (e) {
-      if (e instanceof ImageProcessorUnavailableError) throw e
       // Fall back to sharp if native module is not available
       // biome-ignore lint/suspicious/noConsole: intentional warning
       console.warn(

--- a/runtime/src/types/runtime-ambient.d.ts
+++ b/runtime/src/types/runtime-ambient.d.ts
@@ -64,6 +64,56 @@ declare module "audio-capture-napi" {
   ): boolean;
 }
 
+// Optional native image module. The published package used in local installs is
+// a reserved stub, while bundled/native builds may provide these exports.
+declare module "image-processor-napi" {
+  import type { Buffer } from "node:buffer";
+
+  export type NativeImageProcessorInstance = {
+    metadata(): Promise<{ width: number; height: number; format: string }>;
+    resize(
+      width: number,
+      height: number,
+      options?: { fit?: string; withoutEnlargement?: boolean },
+    ): NativeImageProcessorInstance;
+    jpeg(options?: { quality?: number }): NativeImageProcessorInstance;
+    png(options?: {
+      compressionLevel?: number;
+      palette?: boolean;
+      colors?: number;
+    }): NativeImageProcessorInstance;
+    webp(options?: { quality?: number }): NativeImageProcessorInstance;
+    toBuffer(): Promise<Buffer>;
+  };
+
+  export type NativeImageProcessor = (
+    input: Buffer,
+  ) => NativeImageProcessorInstance;
+
+  export type NativeClipboardImage = {
+    png: Buffer;
+    width: number;
+    height: number;
+    originalWidth: number;
+    originalHeight: number;
+  };
+
+  export type NativeClipboardModule = {
+    hasClipboardImage?: () => boolean;
+    readClipboardImage?: (
+      maxWidth: number,
+      maxHeight: number,
+    ) => NativeClipboardImage | null;
+  };
+
+  export const __stub: boolean | undefined;
+  export const sharp: NativeImageProcessor | undefined;
+  export function getNativeModule(): NativeClipboardModule | undefined;
+
+  const defaultProcessor: NativeImageProcessor | undefined;
+  export default defaultProcessor;
+}
+
 declare module "src/entrypoints/agentSdkTypes.js" {
   export type HookEvent = any;
   export type ModelUsage = Record<string, unknown>;

--- a/runtime/src/utils/imagePaste.ts
+++ b/runtime/src/utils/imagePaste.ts
@@ -126,7 +126,6 @@ export async function hasImageInClipboard(): Promise<boolean> {
     // as an unhandled rejection in useClipboardImageHint's setTimeout.
     try {
       // Native optional dep: present at runtime on supported platforms, not installed as a TS dep.
-      // @ts-expect-error -- image-processor-napi is a native optional module loaded at runtime
       const { getNativeModule } = await import('image-processor-napi')
       const hasImage = getNativeModule()?.hasClipboardImage
       if (hasImage) {
@@ -157,7 +156,6 @@ export async function getImageFromClipboard(): Promise<ImageWithDimensions | nul
   ) {
     try {
       // Native optional dep: present at runtime on supported platforms, not installed as a TS dep.
-      // @ts-expect-error -- image-processor-napi is a native optional module loaded at runtime
       const { getNativeModule } = await import('image-processor-napi')
       const readClipboard = getNativeModule()?.readClipboardImage
       if (!readClipboard) {

--- a/runtime/tests/tools/FileReadTool/imageProcessor.test.ts
+++ b/runtime/tests/tools/FileReadTool/imageProcessor.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type GlobalWithBun = typeof globalThis & {
+  Bun?: { embeddedFiles?: readonly unknown[] }
+}
+
+const ORIGINAL_BUN = (globalThis as GlobalWithBun).Bun
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  if (ORIGINAL_BUN === undefined) {
+    delete (globalThis as GlobalWithBun).Bun
+  } else {
+    ;(globalThis as GlobalWithBun).Bun = ORIGINAL_BUN
+  }
+})
+
+describe('getImageProcessor', () => {
+  it('falls back to sharp when the bundled native module is an empty stub', async () => {
+    ;(globalThis as GlobalWithBun).Bun = { embeddedFiles: [{}] }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const [{ getImageProcessor }, sharpModule] = await Promise.all([
+      import('../../../src/tools/FileReadTool/imageProcessor.js'),
+      import('sharp'),
+    ])
+
+    const expectedSharp =
+      typeof sharpModule.default === 'function' ? sharpModule.default : sharpModule
+
+    await expect(getImageProcessor()).resolves.toBe(expectedSharp)
+    expect(warn).toHaveBeenCalledWith(
+      'Native image processor not available, falling back to sharp',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- declare the consumed image-processor-napi native image and clipboard surface
- remove native image import suppressions from image processor and clipboard paths
- reject empty/stubbed native processor exports before falling back to sharp in bundled mode
- add a regression using the real installed empty image-processor-napi stub

Fixes #1120

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tools/FileReadTool/imageProcessor.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
