### PR TITLE
fix(runtime): type constant build guards

### DIFF
--- a/runtime/src/tools/AgentTool/AgentTool.tsx
+++ b/runtime/src/tools/AgentTool/AgentTool.tsx
@@ -111,8 +111,7 @@ const fullInputSchema = lazySchema(() => {
     mode: permissionModeSchema().optional().describe('Permission mode for spawned teammate (e.g., "plan" to require plan approval).')
   });
   return baseInputSchema().merge(multiAgentInputSchema).extend({
-    // @ts-expect-error TS2367 — "external" === 'ant' is a constant build guard kept verbatim for esbuild DCE of the internal-only remote isolation.
-    isolation: ("external" === 'ant' ? z.enum(['worktree', 'remote']) : z.enum(['worktree'])).optional().describe("external" === 'ant' ? 'Isolation mode. "worktree" creates a temporary git worktree so the agent works on an isolated copy of the repo. "remote" launches the agent in a remote CCR environment (always runs in background).' : 'Isolation mode. "worktree" creates a temporary git worktree so the agent works on an isolated copy of the repo.'),
+    isolation: (("external" as string) === 'ant' ? z.enum(['worktree', 'remote']) : z.enum(['worktree'])).optional().describe(("external" as string) === 'ant' ? 'Isolation mode. "worktree" creates a temporary git worktree so the agent works on an isolated copy of the repo. "remote" launches the agent in a remote CCR environment (always runs in background).' : 'Isolation mode. "worktree" creates a temporary git worktree so the agent works on an isolated copy of the repo.'),
     cwd: z.string().optional().describe('Absolute path to run the agent in. Overrides the working directory for all filesystem and shell operations within this agent. Mutually exclusive with isolation: "worktree".')
   });
 });
@@ -446,8 +445,7 @@ export const AgentTool = buildTool({
 
     // Remote isolation: delegate to CCR. Gated internal-only — the guard enables
     // dead code elimination of the entire block for external builds.
-    // @ts-expect-error TS2367 — "external" === 'ant' is a constant build guard kept verbatim for esbuild DCE of the internal-only remote block.
-    if ("external" === 'ant' && effectiveIsolation === 'remote') {
+    if (("external" as string) === 'ant' && effectiveIsolation === 'remote') {
       const eligibility = await checkRemoteAgentEligibility();
       if (!eligibility.eligible) {
         const reasons = eligibility.errors.map(formatPreconditionError).join('\n');
@@ -1284,8 +1282,7 @@ export const AgentTool = buildTool({
     // Only route through auto mode classifier when in auto mode
     // In all other modes, auto-approve sub-agent generation
     // Note: "external" === 'ant' guard enables dead code elimination for external builds
-    // @ts-expect-error TS2367 — constant build guard kept verbatim for DCE (see note above).
-    if ("external" === 'ant' && appState.toolPermissionContext.mode === 'auto') {
+    if (("external" as string) === 'ant' && appState.toolPermissionContext.mode === 'auto') {
       return {
         behavior: 'passthrough',
         message: 'Agent tool requires permission to spawn sub-agents.'

--- a/runtime/src/tui/cost/MemoryUsageIndicator.tsx
+++ b/runtime/src/tui/cost/MemoryUsageIndicator.tsx
@@ -9,9 +9,8 @@ export function MemoryUsageIndicator(): React.ReactNode {
   // USER_TYPE is a build-time constant, so the hook call below is either always
   // reached or dead-code-eliminated — never conditional at runtime.
   // The swarm-128 test rewrites this exact `if (...)` line at the source level
-  // to flip the build path, so the literal comparison must stay verbatim.
-  // @ts-expect-error TS2367 — "external" !== 'ant' is a constant build-time guard.
-  if ("external" !== 'ant') {
+  // to flip the build path, so the literal comparison must stay build-constant.
+  if (("external" as string) !== 'ant') {
     return null;
   }
 

--- a/runtime/tests/tui/coverage-swarm/swarm-128-cost-MemoryUsageIndicator.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-128-cost-MemoryUsageIndicator.test.tsx
@@ -48,8 +48,8 @@ function loadInternalBuildComponent({
 }): MemoryUsageComponent {
   const externalSource = readFileSync(sourcePath, 'utf8')
   const internalSource = externalSource.replace(
-    `if ("external" !== 'ant') {`,
-    `if ("ant" !== 'ant') {`,
+    `if (("external" as string) !== 'ant') {`,
+    `if (("ant" as string) !== 'ant') {`,
   )
 
   if (internalSource === externalSource) {


### PR DESCRIPTION
## Summary
- replace TS2367 suppressions on deterministic external-build guards with the existing typed literal comparison pattern
- keep AgentTool remote/internal paths and MemoryUsageIndicator guard build-constant for DCE
- update the MemoryUsageIndicator source-rewrite coverage test to match the typed guard line

Fixes #1122

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/coverage-swarm/swarm-128-cost-MemoryUsageIndicator.test.tsx tests/tui/cost/MemoryUsageIndicator.coverage.test.tsx tests/tools/AgentTool/loadAgentsDir.test.ts tests/utils/hookChains.integration.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
