### PR TITLE
fix(runtime): remove stale Ink reconciler suppressions

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -272,8 +272,6 @@ export default class Ink {
       }
     };
 
-    // @ts-ignore @types/react-reconciler@0.32.3 declares 11 args with transitionCallbacks,
-    // but react-reconciler 0.33.0 source only accepts 10 args (no transitionCallbacks)
     this.container = reconciler.createContainer(
       this.rootNode,
       LegacyRoot,
@@ -860,7 +858,6 @@ export default class Ink {
   }
   pause(): void {
     // Flush pending React updates and render before pausing.
-    // @ts-ignore flushSyncFromReconciler exists in react-reconciler 0.31 but not in @types/react-reconciler
     reconciler.flushSyncFromReconciler();
     this.onRender();
     this.isPaused = true;
@@ -1534,9 +1531,7 @@ export default class Ink {
         </TerminalWriteProvider>
       </App>;
 
-    // @ts-ignore updateContainerSync exists in react-reconciler but not in @types/react-reconciler
     reconciler.updateContainerSync(tree, this.container, null, noop);
-    // @ts-ignore flushSyncWork exists in react-reconciler but not in @types/react-reconciler
     reconciler.flushSyncWork();
     logForDebugging('[Ink:render] updateContainer complete');
   }
@@ -1602,9 +1597,7 @@ export default class Ink {
       this.drainTimer = null;
     }
 
-    // @ts-ignore updateContainerSync exists in react-reconciler but not in @types/react-reconciler
     reconciler.updateContainerSync(null, this.container, null, noop);
-    // @ts-ignore flushSyncWork exists in react-reconciler but not in @types/react-reconciler
     reconciler.flushSyncWork();
     deleteInkInstance(this.options.stdout);
 


### PR DESCRIPTION
## Summary
- remove stale `@ts-ignore` comments around Ink/react-reconciler sync APIs
- leave the reconciler calls and TUI runtime behavior unchanged
- confirm no source-level TypeScript suppressions remain under `runtime/src` or `packages`

Fixes #1124

## Test plan
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/events.runtime-coverage.test.ts --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/ink/render-to-screen.wave200-096.coverage.test.tsx tests/tui/coverage-swarm/swarm-249-ink-render-to-screen.test.ts tests/tui/ink/reconciler.test.ts tests/tui/ink/reconciler-host-config.test.ts tests/tui/ink/reconciler.coverage2.test.ts tests/tui/ink/reconciler.wave200-031.coverage.test.ts --reporter=verbose`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
