### PR TITLE
fix(runtime): type Ink react reconciler declaration

### DIFF
--- a/runtime/src/tui/ink/reconciler.ts
+++ b/runtime/src/tui/ink/reconciler.ts
@@ -262,12 +262,10 @@ export function resetProfileCounters(): void {
 }
 // --- END ---
 
-// `react-reconciler` ships no types in this repo (see
-// src/types/react-reconciler.d.ts, where createReconciler is `any`), so the
-// HostConfig type arguments below would be erased and provide no checking —
-// and passing type arguments to an untyped call is a TS error (TS2347).
-// Each config callback is instead annotated explicitly with the concrete
-// DOMElement/TextNode types it operates on, which is the real type safety.
+// `react-reconciler` ships no types in this repo. The local ambient
+// declaration only models the reconciler instance methods AgenC consumes, so
+// each host-config callback remains annotated explicitly with the concrete
+// DOMElement/TextNode types it operates on.
 const reconciler = createReconciler({
   getRootHostContext: () => ({ isInsideText: false }),
   prepareForCommit: () => {

--- a/runtime/src/tui/ink/render-to-screen.ts
+++ b/runtime/src/tui/ink/render-to-screen.ts
@@ -79,9 +79,13 @@ export function renderToScreen(
       noop,
     )
   }
+  const currentContainer = container
+  if (!currentContainer) {
+    throw new Error('Expected reusable Ink render container to be initialized')
+  }
 
   const t0 = performance.now()
-  reconciler.updateContainerSync(el, container, null, noop)
+  reconciler.updateContainerSync(el, currentContainer, null, noop)
   reconciler.flushSyncWork()
   const t1 = performance.now()
 
@@ -116,7 +120,7 @@ export function renderToScreen(
   const t3 = performance.now()
 
   // Unmount so next call gets a fresh tree. Leaves root/container/pools.
-  reconciler.updateContainerSync(null, container, null, noop)
+  reconciler.updateContainerSync(null, currentContainer, null, noop)
   reconciler.flushSyncWork()
 
   timing.reconcile += t1 - t0

--- a/runtime/src/types/react-reconciler.d.ts
+++ b/runtime/src/types/react-reconciler.d.ts
@@ -1,12 +1,54 @@
 declare module 'react-reconciler' {
-  export type FiberRoot = any;
-  const createReconciler: any;
+  import type { ReactNode } from 'react';
+
+  export interface FiberRoot {
+    readonly current: unknown;
+  }
+
+  export interface DevToolsConfig {
+    readonly bundleType: 0 | 1;
+    readonly version: string;
+    readonly rendererPackageName: string;
+  }
+
+  export interface ReconcilerInstance {
+    createContainer(
+      containerInfo: unknown,
+      tag: number,
+      hydrationCallbacks: null,
+      isStrictMode: boolean,
+      concurrentUpdatesByDefaultOverride: null,
+      identifierPrefix: string,
+      onUncaughtError: (error: unknown) => void,
+      onCaughtError: (error: unknown) => void,
+      onRecoverableError: (error: unknown) => void,
+      onDefaultTransitionIndicator: ((error?: unknown) => void) | null,
+    ): FiberRoot;
+    updateContainerSync(
+      element: ReactNode | null,
+      container: FiberRoot,
+      parentComponent: unknown,
+      callback: (() => void) | null,
+    ): number;
+    flushSyncWork(): boolean;
+    flushSyncFromReconciler<T>(fn?: () => T): T | void;
+    injectIntoDevTools(config: DevToolsConfig): boolean;
+    discreteUpdates<A, B, C, D, R>(
+      fn: (a: A, b: B, c: C, d: D) => R,
+      a: A,
+      b: B,
+      c: C,
+      d: D,
+    ): R;
+  }
+
+  const createReconciler: (hostConfig: unknown) => ReconcilerInstance;
   export default createReconciler;
 }
 
 declare module 'react-reconciler/constants.js' {
-  export const LegacyRoot: any;
-  export const ContinuousEventPriority: number;
-  export const DefaultEventPriority: number;
-  export const DiscreteEventPriority: number;
+  export const LegacyRoot: 0;
+  export const ContinuousEventPriority: 8;
+  export const DefaultEventPriority: 32;
+  export const DiscreteEventPriority: 2;
 }


### PR DESCRIPTION
## Summary
- replace the permissive `any`-based `react-reconciler` ambient declaration with the minimal reconciler API AgenC consumes
- type React 19 sync rendering methods, devtools injection, discrete updates, and event priority constants
- make the reusable `render-to-screen` container invariant explicit after initialization

Fixes #1126

## Test plan
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/ink/ink.render.test.tsx tests/tui/ink/events.runtime-coverage.test.ts tests/tui/ink/render-to-screen.wave200-096.coverage.test.tsx tests/tui/coverage-swarm/swarm-249-ink-render-to-screen.test.ts tests/tui/ink/reconciler.test.ts tests/tui/ink/reconciler-host-config.test.ts tests/tui/ink/reconciler.coverage2.test.ts tests/tui/ink/reconciler.wave200-031.coverage.test.ts --reporter=verbose`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
