### PR TITLE
fix(runtime): type WebSearch provider JSON parsing

### DIFF
--- a/runtime/src/tools/WebSearchTool/WebSearchTool.ts
+++ b/runtime/src/tools/WebSearchTool/WebSearchTool.ts
@@ -212,12 +212,7 @@ function addProviderCodeSource(
   sourceMap: Map<string, { title: string; url: string }>,
   source: unknown,
 ): void {
-  // Provider JSON is dynamic; narrow to an indexable record so the existing
-  // `typeof`/optional-chaining guards can read `url`/`title` without TS2339.
-  const src = source as
-    | { url?: unknown; title?: unknown }
-    | null
-    | undefined
+  const src = asProviderCodeRecord(source)
   if (typeof src?.url !== 'string' || !src.url) return
   sourceMap.set(src.url, {
     title:
@@ -226,31 +221,62 @@ function addProviderCodeSource(
   })
 }
 
-function getProviderCodeSources(item: Record<string, any>): unknown[] {
-  if (Array.isArray(item.action?.sources)) {
-    return item.action.sources
+function asProviderCodeRecord(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function providerCodeArrayField(
+  item: Record<string, unknown> | undefined,
+  field: string,
+): unknown[] {
+  const value = item?.[field]
+  return Array.isArray(value) ? value : []
+}
+
+function providerCodeMessage(value: unknown): string | undefined {
+  const record = asProviderCodeRecord(value)
+  const message = record?.message
+  return typeof message === 'string' && message ? message : undefined
+}
+
+function getProviderCodeSources(item: Record<string, unknown>): unknown[] {
+  const action = asProviderCodeRecord(item.action)
+  const actionSources = providerCodeArrayField(action, 'sources')
+  if (actionSources.length > 0) {
+    return actionSources
   }
-  if (Array.isArray(item.sources)) {
-    return item.sources
+  const sources = providerCodeArrayField(item, 'sources')
+  if (sources.length > 0) {
+    return sources
   }
-  if (Array.isArray(item.result?.sources)) {
-    return item.result.sources
+  const resultSources = providerCodeArrayField(
+    asProviderCodeRecord(item.result),
+    'sources',
+  )
+  if (resultSources.length > 0) {
+    return resultSources
   }
   return []
 }
 
-function extractProviderCodeWebSearchFailure(item: Record<string, any>): string | undefined {
+function extractProviderCodeWebSearchFailure(
+  item: Record<string, unknown>,
+): string | undefined {
   // ProviderCode web_search_call items can carry a status field. When the tool
   // call fails (rate limit, upstream error, model-side guardrail), the
   // parser should surface a meaningful error rather than the generic
   // "No results found." fallback. Shape observed across recent payloads:
   //   { type: 'web_search_call', status: 'failed', error: { message?: string } }
   //   { type: 'web_search_call', status: 'failed', action: { error?: { message?: string } } }
-  if (item?.status !== 'failed') return undefined
+  if (item.status !== 'failed') return undefined
+  const action = asProviderCodeRecord(item.action)
   const reason =
-    (typeof item.error?.message === 'string' && item.error.message) ||
-    (typeof item.action?.error?.message === 'string' &&
-      item.action.error.message) ||
+    providerCodeMessage(item.error) ||
+    providerCodeMessage(action?.error) ||
     (typeof item.error === 'string' && item.error) ||
     undefined
   return reason ? `Web search failed: ${reason}` : 'Web search failed.'
@@ -265,7 +291,9 @@ function makeOutputFromProviderCodeWebSearchResponse(
   const sourceMap = new Map<string, { title: string; url: string }>()
   const output = Array.isArray(response.output) ? response.output : []
 
-  for (const item of output) {
+  for (const rawItem of output) {
+    const item = asProviderCodeRecord(rawItem)
+    if (!item) continue
     if (item?.type === 'web_search_call') {
       const failure = extractProviderCodeWebSearchFailure(item)
       if (failure) {
@@ -277,11 +305,14 @@ function makeOutputFromProviderCodeWebSearchResponse(
       continue
     }
 
-    if (item?.type !== 'message' || !Array.isArray(item.content)) {
+    const content = providerCodeArrayField(item, 'content')
+    if (item.type !== 'message' || content.length === 0) {
       continue
     }
 
-    for (const part of item.content) {
+    for (const rawPart of content) {
+      const part = asProviderCodeRecord(rawPart)
+      if (!part) continue
       if (part?.type === 'output_text' || part?.type === 'text') {
         pushProviderCodeTextResult(results, part.text)
       }
@@ -290,10 +321,8 @@ function makeOutputFromProviderCodeWebSearchResponse(
         addProviderCodeSource(sourceMap, source)
       }
 
-      const annotations = Array.isArray(part?.annotations)
-        ? part.annotations
-        : []
-      for (const annotation of annotations) {
+      for (const rawAnnotation of providerCodeArrayField(part, 'annotations')) {
+        const annotation = asProviderCodeRecord(rawAnnotation)
         if (annotation?.type !== 'url_citation') continue
         addProviderCodeSource(sourceMap, annotation)
       }

--- a/runtime/src/tools/WebSearchTool/providers/bing.ts
+++ b/runtime/src/tools/WebSearchTool/providers/bing.ts
@@ -5,7 +5,14 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, type ProviderOutput } from './types.js'
+import {
+  applyDomainFilters,
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  recordField,
+  type ProviderOutput,
+} from './types.js'
 
 export const bingProvider: SearchProvider = {
   name: 'bing',
@@ -30,13 +37,9 @@ export const bingProvider: SearchProvider = {
       throw new Error(`Bing search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data = await res.json()
-    const hits = (data.webPages?.value ?? []).map((r: any) => ({
-      title: r.name ?? '',
-      url: r.url ?? '',
-      description: r.snippet,
-      source: r.displayUrl,
-    }))
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const hits = normalizeHits(arrayField(recordField(record, 'webPages'), 'value'))
 
     return {
       hits: applyDomainFilters(hits, input),

--- a/runtime/src/tools/WebSearchTool/providers/custom.ts
+++ b/runtime/src/tools/WebSearchTool/providers/custom.ts
@@ -28,8 +28,11 @@
 
 import type { SearchInput, SearchProvider } from './types.js'
 import {
+  arrayField,
   applyDomainFilters,
-  normalizeHit,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  recordField,
   safeHostname,
   type ProviderOutput,
   type SearchHit,
@@ -46,7 +49,7 @@ interface ProviderPreset {
   authHeader?: string
   authScheme?: string
   jsonPath?: string
-  responseAdapter?: (data: any) => SearchHit[]
+  responseAdapter?: (data: unknown) => SearchHit[]
 }
 
 const BUILT_IN_PROVIDERS: Record<string, ProviderPreset> = {
@@ -57,13 +60,10 @@ const BUILT_IN_PROVIDERS: Record<string, ProviderPreset> = {
     urlTemplate: 'https://localhost:8080/search',
     queryParam: 'q',
     jsonPath: 'results',
-    responseAdapter(data: any) {
-      return (data.results ?? []).map((r: any) => ({
-        title: r.title ?? r.url,
-        url: r.url,
-        description: r.content,
-        source: r.engine ?? r.source,
-      }))
+    responseAdapter(data: unknown) {
+      return normalizeHits(
+        arrayField(isSearchProviderJsonRecord(data) ? data : undefined, 'results'),
+      )
     },
   },
   google: {
@@ -71,26 +71,21 @@ const BUILT_IN_PROVIDERS: Record<string, ProviderPreset> = {
     queryParam: 'q',
     authHeader: 'Authorization',
     authScheme: 'Bearer',
-    responseAdapter(data: any) {
-      return (data.items ?? []).map((r: any) => ({
-        title: r.title ?? '',
-        url: r.link ?? '',
-        description: r.snippet,
-        source: r.displayLink,
-      }))
+    responseAdapter(data: unknown) {
+      return normalizeHits(
+        arrayField(isSearchProviderJsonRecord(data) ? data : undefined, 'items'),
+      )
     },
   },
   brave: {
     urlTemplate: 'https://api.search.brave.com/res/v1/web/search',
     queryParam: 'q',
     authHeader: 'X-Subscription-Token',
-    responseAdapter(data: any) {
-      return (data.web?.results ?? []).map((r: any) => ({
-        title: r.title ?? '',
-        url: r.url ?? '',
-        description: r.description,
-        source: safeHostname(r.url),
-      }))
+    responseAdapter(data: unknown) {
+      const record = isSearchProviderJsonRecord(data) ? data : undefined
+      return normalizeHits(arrayField(recordField(record, 'web'), 'results'), {
+        inferSourceFromUrl: true,
+      })
     },
   },
   serpapi: {
@@ -98,13 +93,13 @@ const BUILT_IN_PROVIDERS: Record<string, ProviderPreset> = {
     queryParam: 'q',
     authHeader: 'Authorization',
     authScheme: 'Bearer',
-    responseAdapter(data: any) {
-      return (data.organic_results ?? []).map((r: any) => ({
-        title: r.title ?? '',
-        url: r.link ?? '',
-        description: r.snippet,
-        source: r.displayed_link,
-      }))
+    responseAdapter(data: unknown) {
+      return normalizeHits(
+        arrayField(
+          isSearchProviderJsonRecord(data) ? data : undefined,
+          'organic_results',
+        ),
+      )
     },
   },
 }
@@ -366,7 +361,7 @@ function resolveConfig(): {
   queryParam: string
   method: string
   jsonPath?: string
-  responseAdapter?: (data: any) => SearchHit[]
+  responseAdapter?: (data: unknown) => SearchHit[]
   preset?: ProviderPreset
 } {
   const providerName = process.env.WEB_PROVIDER
@@ -390,7 +385,19 @@ function parseExtraParams(): Record<string, string> {
   if (!raw) return {}
   try {
     const obj = JSON.parse(raw)
-    if (obj && typeof obj === 'object' && !Array.isArray(obj)) return obj
+    if (isSearchProviderJsonRecord(obj)) {
+      const params: Record<string, string> = {}
+      for (const [key, value] of Object.entries(obj)) {
+        if (
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean'
+        ) {
+          params[key] = String(value)
+        }
+      }
+      return params
+    }
   } catch { /* ignore */ }
   return {}
 }
@@ -474,19 +481,19 @@ function buildRequest(query: string) {
 // Response parsing — flexible, handles many shapes
 // ---------------------------------------------------------------------------
 
-function walkJsonPath(obj: any, path: string): any {
+function walkJsonPath(obj: unknown, path: string): unknown {
   let current = obj
   for (const seg of path.split('.')) {
-    if (current == null || typeof current !== 'object') return undefined
+    if (!isSearchProviderJsonRecord(current)) return undefined
     current = current[seg]
   }
   return current
 }
 
-function extractFromNode(node: any): SearchHit[] {
+function extractFromNode(node: unknown): SearchHit[] {
   if (!node) return []
-  if (Array.isArray(node)) return node.map(normalizeHit).filter(Boolean) as SearchHit[]
-  if (typeof node === 'object') {
+  if (Array.isArray(node)) return normalizeHits(node)
+  if (isSearchProviderJsonRecord(node)) {
     const all: SearchHit[] = []
     for (const sub of Object.values(node)) all.push(...extractFromNode(sub))
     return all
@@ -495,19 +502,19 @@ function extractFromNode(node: any): SearchHit[] {
   return []
 }
 
-export function extractHits(raw: any, jsonPath?: string): SearchHit[] {
+export function extractHits(raw: unknown, jsonPath?: string): SearchHit[] {
   if (jsonPath) return extractFromNode(walkJsonPath(raw, jsonPath))
-  if (Array.isArray(raw)) return raw.map(normalizeHit).filter(Boolean) as SearchHit[]
-  if (!raw || typeof raw !== 'object') return []
+  if (Array.isArray(raw)) return normalizeHits(raw)
+  if (!isSearchProviderJsonRecord(raw)) return []
 
   const arrayKeys = ['results', 'items', 'data', 'web', 'organic_results', 'hits', 'entries']
   for (const key of arrayKeys) {
     const val = raw[key]
-    if (Array.isArray(val)) return val.map(normalizeHit).filter(Boolean) as SearchHit[]
-    if (val && typeof val === 'object' && !Array.isArray(val)) {
+    if (Array.isArray(val)) return normalizeHits(val)
+    if (isSearchProviderJsonRecord(val)) {
       const all: SearchHit[] = []
       for (const sub of Object.values(val)) {
-        if (Array.isArray(sub)) all.push(...(sub.map(normalizeHit).filter(Boolean) as SearchHit[]))
+        if (Array.isArray(sub)) all.push(...normalizeHits(sub))
       }
       if (all.length > 0) return all
     }
@@ -520,7 +527,7 @@ export function extractHits(raw: any, jsonPath?: string): SearchHit[] {
 // Fetch with one retry + timeout
 // ---------------------------------------------------------------------------
 
-async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSignal): Promise<any> {
+async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSignal): Promise<unknown> {
   const timeoutSec = Number(process.env.WEB_CUSTOM_TIMEOUT_SEC) || DEFAULT_TIMEOUT_SECONDS
   const timeoutMs = timeoutSec * 1000
   let lastErr: Error | undefined

--- a/runtime/src/tools/WebSearchTool/providers/exa.ts
+++ b/runtime/src/tools/WebSearchTool/providers/exa.ts
@@ -4,7 +4,12 @@
  * Auth: x-api-key: <key>
  */
 import type { SearchInput, SearchProvider } from './types.js'
-import { safeHostname, type ProviderOutput } from './types.js'
+import {
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  type ProviderOutput,
+} from './types.js'
 
 export const exaProvider: SearchProvider = {
   name: 'exa',
@@ -16,7 +21,7 @@ export const exaProvider: SearchProvider = {
   async search(input: SearchInput, signal?: AbortSignal): Promise<ProviderOutput> {
     const start = performance.now()
 
-    const body: Record<string, any> = {
+    const body: Record<string, unknown> = {
       query: input.query,
       numResults: 15,
       type: 'auto',
@@ -38,13 +43,11 @@ export const exaProvider: SearchProvider = {
     if (!res.ok) {
       throw new Error(`Exa search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
-    const data = await res.json()
-    const hits = (data.results ?? []).map((r: any) => ({
-      title: r.title ?? '',
-      url: r.url ?? '',
-      description: r.snippet ?? r.text,
-      source: r.url ? safeHostname(r.url) : undefined,
-    }))
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const hits = normalizeHits(arrayField(record, 'results'), {
+      inferSourceFromUrl: true,
+    })
     return {
       // Exa handles domain filtering server-side via includeDomains/excludeDomains
       hits,

--- a/runtime/src/tools/WebSearchTool/providers/jina.ts
+++ b/runtime/src/tools/WebSearchTool/providers/jina.ts
@@ -5,7 +5,13 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, safeHostname, type ProviderOutput } from './types.js'
+import {
+  applyDomainFilters,
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  type ProviderOutput,
+} from './types.js'
 
 export const jinaProvider: SearchProvider = {
   name: 'jina',
@@ -33,13 +39,13 @@ export const jinaProvider: SearchProvider = {
       throw new Error(`Jina search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data = await res.json()
-    const hits = (data.data ?? data.results ?? []).map((r: any) => ({
-      title: r.title ?? '',
-      url: r.url ?? '',
-      description: r.description ?? r.snippet ?? r.content,
-      source: r.url ? safeHostname(r.url) : undefined,
-    }))
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const rawHits =
+      record && 'data' in record
+        ? arrayField(record, 'data')
+        : arrayField(record, 'results')
+    const hits = normalizeHits(rawHits, { inferSourceFromUrl: true })
 
     return {
       hits: applyDomainFilters(hits, input),

--- a/runtime/src/tools/WebSearchTool/providers/linkup.ts
+++ b/runtime/src/tools/WebSearchTool/providers/linkup.ts
@@ -5,7 +5,13 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, safeHostname, type ProviderOutput } from './types.js'
+import {
+  applyDomainFilters,
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  type ProviderOutput,
+} from './types.js'
 
 export const linkupProvider: SearchProvider = {
   name: 'linkup',
@@ -35,13 +41,11 @@ export const linkupProvider: SearchProvider = {
       throw new Error(`Linkup search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data = await res.json()
-    const hits = (data.results ?? []).map((r: any) => ({
-      title: r.name ?? r.title ?? '',
-      url: r.url ?? '',
-      description: r.snippet ?? r.description ?? r.content,
-      source: r.url ? safeHostname(r.url) : undefined,
-    }))
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const hits = normalizeHits(arrayField(record, 'results'), {
+      inferSourceFromUrl: true,
+    })
 
     return {
       hits: applyDomainFilters(hits, input),

--- a/runtime/src/tools/WebSearchTool/providers/mojeek.ts
+++ b/runtime/src/tools/WebSearchTool/providers/mojeek.ts
@@ -5,7 +5,14 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, safeHostname, type ProviderOutput } from './types.js'
+import {
+  applyDomainFilters,
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  recordField,
+  type ProviderOutput,
+} from './types.js'
 
 export const mojeekProvider: SearchProvider = {
   name: 'mojeek',
@@ -35,15 +42,13 @@ export const mojeekProvider: SearchProvider = {
       throw new Error(`Mojeek search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data = await res.json()
-    const rawResults = data?.response?.results ?? data?.results ?? []
-
-    const hits = rawResults.map((r: any) => ({
-      title: r.title ?? '',
-      url: r.url ?? '',
-      description: r.snippet ?? r.desc,
-      source: r.url ? safeHostname(r.url) : undefined,
-    }))
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const rawResults =
+      record && 'response' in record
+        ? arrayField(recordField(record, 'response'), 'results')
+        : arrayField(record, 'results')
+    const hits = normalizeHits(rawResults, { inferSourceFromUrl: true })
 
     return {
       hits: applyDomainFilters(hits, input),

--- a/runtime/src/tools/WebSearchTool/providers/tavily.ts
+++ b/runtime/src/tools/WebSearchTool/providers/tavily.ts
@@ -5,7 +5,13 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, safeHostname, type ProviderOutput } from './types.js'
+import {
+  applyDomainFilters,
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  type ProviderOutput,
+} from './types.js'
 
 export const tavilyProvider: SearchProvider = {
   name: 'tavily',
@@ -35,14 +41,11 @@ export const tavilyProvider: SearchProvider = {
       throw new Error(`Tavily search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data = await res.json()
-
-    const hits = (data.results ?? []).map((r: any) => ({
-      title: r.title ?? '',
-      url: r.url ?? '',
-      description: r.content ?? r.snippet,
-      source: r.url ? safeHostname(r.url) : undefined,
-    }))
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const hits = normalizeHits(arrayField(record, 'results'), {
+      inferSourceFromUrl: true,
+    })
 
     return {
       hits: applyDomainFilters(hits, input),

--- a/runtime/src/tools/WebSearchTool/providers/types.ts
+++ b/runtime/src/tools/WebSearchTool/providers/types.ts
@@ -48,30 +48,85 @@ const TITLE_KEYS = ['title', 'headline', 'name', 'heading'] as const
 const URL_KEYS = ['url', 'link', 'href', 'uri', 'permalink'] as const
 const DESC_KEYS = [
   'description', 'snippet', 'content', 'preview', 'summary', 'text', 'body',
+  'desc',
 ] as const
 const SOURCE_KEYS = [
-  'source', 'domain', 'displayLink', 'displayed_link', 'engine',
+  'source', 'domain', 'displayLink', 'displayUrl', 'displayed_link', 'engine',
 ] as const
 
-function firstMatch(obj: any, keys: readonly string[]): string | undefined {
+export type SearchProviderJsonRecord = Record<string, unknown>
+
+export function isSearchProviderJsonRecord(
+  value: unknown,
+): value is SearchProviderJsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function recordField(
+  obj: SearchProviderJsonRecord | null | undefined,
+  key: string,
+): SearchProviderJsonRecord | undefined {
+  const value = obj?.[key]
+  return isSearchProviderJsonRecord(value) ? value : undefined
+}
+
+export function arrayField(
+  obj: SearchProviderJsonRecord | null | undefined,
+  key: string,
+): readonly unknown[] {
+  const value = obj?.[key]
+  return Array.isArray(value) ? value : []
+}
+
+function firstMatch(
+  obj: SearchProviderJsonRecord,
+  keys: readonly string[],
+): string | undefined {
   for (const k of keys) {
-    if (typeof obj?.[k] === 'string' && obj[k]) return obj[k]
+    const value = obj[k]
+    if (typeof value === 'string' && value) return value
   }
   return undefined
 }
 
 /** Extract a SearchHit from any object shape using well-known field aliases. */
-export function normalizeHit(raw: any): SearchHit | null {
-  if (!raw || typeof raw !== 'object') return null
+export function normalizeHit(raw: unknown): SearchHit | null {
+  if (!isSearchProviderJsonRecord(raw)) return null
   const title = firstMatch(raw, TITLE_KEYS)
   const url = firstMatch(raw, URL_KEYS)
   if (!title && !url) return null
   const hit: SearchHit = { title: title ?? url!, url: url ?? title! }
-  const desc = firstMatch(raw, DESC_KEYS)
+  const desc =
+    firstMatch(raw, DESC_KEYS) ??
+    (
+      Array.isArray(raw['snippets']) &&
+      typeof raw['snippets'][0] === 'string' &&
+      raw['snippets'][0]
+        ? raw['snippets'][0]
+        : undefined
+    )
   const source = firstMatch(raw, SOURCE_KEYS)
   if (desc) hit.description = desc
   if (source) hit.source = source
   return hit
+}
+
+export function normalizeHits(
+  raw: unknown,
+  options: { readonly inferSourceFromUrl?: boolean } = {},
+): SearchHit[] {
+  if (!Array.isArray(raw)) return []
+  const hits: SearchHit[] = []
+  for (const item of raw) {
+    const hit = normalizeHit(item)
+    if (!hit) continue
+    if (options.inferSourceFromUrl && !hit.source) {
+      const host = safeHostname(hit.url)
+      if (host) hit.source = host
+    }
+    hits.push(hit)
+  }
+  return hits
 }
 
 // ---------------------------------------------------------------------------
@@ -116,4 +171,3 @@ export function applyDomainFilters(
   }
   return out
 }
-

--- a/runtime/src/tools/WebSearchTool/providers/you.ts
+++ b/runtime/src/tools/WebSearchTool/providers/you.ts
@@ -5,7 +5,13 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
-import { applyDomainFilters, safeHostname, type ProviderOutput } from './types.js'
+import {
+  applyDomainFilters,
+  arrayField,
+  isSearchProviderJsonRecord,
+  normalizeHits,
+  type ProviderOutput,
+} from './types.js'
 
 export const youProvider: SearchProvider = {
   name: 'you',
@@ -30,18 +36,15 @@ export const youProvider: SearchProvider = {
       throw new Error(`You.com search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data = await res.json()
-    const webResults = data?.results?.web ?? data?.results ?? []
-
-    const hits = webResults.map((r: any) => {
-      const snippet = Array.isArray(r.snippets) ? r.snippets[0] : r.snippet
-      return {
-        title: r.title ?? '',
-        url: r.url ?? '',
-        description: snippet ?? r.description,
-        source: r.url ? safeHostname(r.url) : undefined,
-      }
-    })
+    const data: unknown = await res.json()
+    const record = isSearchProviderJsonRecord(data) ? data : undefined
+    const results = record?.['results']
+    const webResults = isSearchProviderJsonRecord(results)
+      ? arrayField(results, 'web')
+      : Array.isArray(results)
+        ? results
+        : []
+    const hits = normalizeHits(webResults, { inferSourceFromUrl: true })
 
     return {
       hits: applyDomainFilters(hits, input),

--- a/runtime/tests/services/api/openAiCodeTransform.test.ts
+++ b/runtime/tests/services/api/openAiCodeTransform.test.ts
@@ -768,6 +768,44 @@ describe('ProviderCode request translation', () => {
     ])
   })
 
+  test('ignores malformed ProviderCode web search response entries', () => {
+    const output = webSearchToolTest.makeOutputFromProviderCodeWebSearchResponse(
+      {
+        output: [
+          null,
+          'noise',
+          {
+            type: 'message',
+            content: [
+              null,
+              { type: 'text', text: 'Usable result.' },
+              {
+                type: 'text',
+                annotations: [
+                  null,
+                  { type: 'url_citation', title: 'Docs', url: 'https://docs.example.com' },
+                  { type: 'url_citation', title: 'Missing URL' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      'AgenC GitHub 2026',
+      0.07,
+    )
+
+    expect(output.results).toEqual([
+      'Usable result.',
+      {
+        tool_use_id: 'providerCode-web-search',
+        content: [
+          { title: 'Docs', url: 'https://docs.example.com' },
+        ],
+      },
+    ])
+  })
+
   test('translates ProviderCode SSE text stream into provider events', async () => {
     const responseText = [
       'event: response.output_item.added',

--- a/runtime/tests/tools/WebSearchTool/providers/custom.test.ts
+++ b/runtime/tests/tools/WebSearchTool/providers/custom.test.ts
@@ -80,12 +80,40 @@ describe('extractHits', () => {
     expect(hits).toHaveLength(1)
   })
 
+  test('ignores malformed values inside provider result arrays', () => {
+    const data = {
+      results: [
+        null,
+        'plain text',
+        42,
+        { title: 'Valid', url: 'https://ex.com' },
+        { title: '', url: '' },
+      ],
+    }
+    expect(extractHits(data)).toEqual([
+      { title: 'Valid', url: 'https://ex.com' },
+    ])
+  })
+
   test('extracts from organic_results (SerpAPI-style)', () => {
     const data = {
       organic_results: [{ title: 'T', link: 'https://ex.com' }],
     }
     const hits = extractHits(data)
     expect(hits).toHaveLength(1)
+  })
+
+  test('does not recursively parse primitive nested map values', () => {
+    const data = {
+      web: {
+        count: 3,
+        metadata: { status: 'ok' },
+        results: [{ title: 'T', url: 'https://ex.com' }],
+      },
+    }
+    expect(extractHits(data)).toEqual([
+      { title: 'T', url: 'https://ex.com' },
+    ])
   })
 })
 

--- a/runtime/tests/tools/WebSearchTool/providers/types.test.ts
+++ b/runtime/tests/tools/WebSearchTool/providers/types.test.ts
@@ -89,6 +89,30 @@ describe('normalizeHit', () => {
     expect(hit?.source).toBe('example.com')
   })
 
+  test('extracts provider-specific source and description aliases', () => {
+    const hit = normalizeHit({
+      name: 'Bing result',
+      url: 'https://example.com',
+      displayUrl: 'example.com/page',
+      desc: 'Mojeek-style description',
+    })
+    expect(hit).toEqual({
+      title: 'Bing result',
+      url: 'https://example.com',
+      description: 'Mojeek-style description',
+      source: 'example.com/page',
+    })
+  })
+
+  test('uses first snippets entry for You.com-style descriptions', () => {
+    const hit = normalizeHit({
+      title: 'Result',
+      url: 'https://example.com',
+      snippets: ['first snippet', 'second snippet'],
+    })
+    expect(hit?.description).toBe('first snippet')
+  })
+
   test('returns null for empty object', () => {
     expect(normalizeHit({})).toBeNull()
   })


### PR DESCRIPTION
## Summary
- parse WebSearch provider and ProviderCode search JSON through structural `unknown` guards instead of raw `any`
- share guarded hit normalization across first-party and custom providers, including provider-specific aliases like `displayUrl`, `desc`, and `snippets`
- add malformed-payload regression coverage for provider arrays and ProviderCode web-search responses

Fixes #1128

## Test plan
- `bun test tests/tools/WebSearchTool/providers/*.test.ts tests/services/api/openAiCodeTransform.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
