### PR TITLE
fix(runtime): guard tool result storage parsing

### DIFF
--- a/runtime/src/utils/toolResultStorage.ts
+++ b/runtime/src/utils/toolResultStorage.ts
@@ -460,6 +460,84 @@ type CandidatePartition = {
   fresh: ToolResultCandidate[]
 }
 
+type UnknownRecord = Record<string, unknown>
+
+type ToolResultBlockRecord = UnknownRecord & {
+  type: 'tool_result'
+  tool_use_id: string
+  content: NonNullable<ToolResultBlockParam['content']>
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null
+}
+
+function userContentBlocks(message: Message): readonly unknown[] | undefined {
+  if (!isRecord(message) || message.type !== 'user') return undefined
+  const envelope = message.message
+  if (!isRecord(envelope) || !Array.isArray(envelope.content)) {
+    return undefined
+  }
+  return envelope.content
+}
+
+function assistantContentBlocks(message: Message): readonly unknown[] | undefined {
+  if (!isRecord(message) || message.type !== 'assistant') return undefined
+  const envelope = message.message
+  if (!isRecord(envelope) || !Array.isArray(envelope.content)) {
+    return undefined
+  }
+  return envelope.content
+}
+
+function assistantMessageId(message: Message): string | undefined {
+  if (!isRecord(message) || message.type !== 'assistant') return undefined
+  const envelope = message.message
+  if (!isRecord(envelope) || typeof envelope.id !== 'string') return undefined
+  return envelope.id
+}
+
+function isToolResultContentBlock(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.type !== 'string') return false
+  return value.type !== 'text' || typeof value.text === 'string'
+}
+
+function isToolResultContent(
+  value: unknown,
+): value is NonNullable<ToolResultBlockParam['content']> {
+  if (typeof value === 'string') return true
+  return Array.isArray(value) && value.every(isToolResultContentBlock)
+}
+
+function asToolResultBlock(block: unknown): ToolResultBlockRecord | undefined {
+  if (
+    !isRecord(block) ||
+    block.type !== 'tool_result' ||
+    typeof block.tool_use_id !== 'string' ||
+    block.content === undefined ||
+    block.content === null ||
+    block.content === '' ||
+    !isToolResultContent(block.content)
+  ) {
+    return undefined
+  }
+  return block as ToolResultBlockRecord
+}
+
+function asToolUseBlock(
+  block: unknown,
+): { readonly id: string; readonly name: string } | undefined {
+  if (
+    !isRecord(block) ||
+    block.type !== 'tool_use' ||
+    typeof block.id !== 'string' ||
+    typeof block.name !== 'string'
+  ) {
+    return undefined
+  }
+  return { id: block.id, name: block.name }
+}
+
 function isContentAlreadyCompacted(
   content: ToolResultBlockParam['content'],
 ): boolean {
@@ -501,12 +579,12 @@ function contentSize(
 function buildToolNameMap(messages: Message[]): Map<string, string> {
   const map = new Map<string, string>()
   for (const message of messages) {
-    if (message.type !== 'assistant') continue
-    const content = message.message.content
-    if (!Array.isArray(content)) continue
+    const content = assistantContentBlocks(message)
+    if (!content) continue
     for (const block of content) {
-      if (block.type === 'tool_use') {
-        map.set(block.id, block.name)
+      const toolUse = asToolUseBlock(block)
+      if (toolUse) {
+        map.set(toolUse.id, toolUse.name)
       }
     }
   }
@@ -520,18 +598,18 @@ function buildToolNameMap(messages: Message[]): Map<string, string> {
  * Returns [] for messages with no eligible blocks.
  */
 function collectCandidatesFromMessage(message: Message): ToolResultCandidate[] {
-  if (message.type !== 'user' || !Array.isArray(message.message.content)) {
-    return []
-  }
-  return message.message.content.flatMap((block: any) => {
-    if (block.type !== 'tool_result' || !block.content) return []
-    if (isContentAlreadyCompacted(block.content)) return []
-    if (hasImageBlock(block.content)) return []
+  const content = userContentBlocks(message)
+  if (!content) return []
+  return content.flatMap(block => {
+    const toolResult = asToolResultBlock(block)
+    if (!toolResult) return []
+    if (isContentAlreadyCompacted(toolResult.content)) return []
+    if (hasImageBlock(toolResult.content)) return []
     return [
       {
-        toolUseId: block.tool_use_id,
-        content: block.content,
-        size: contentSize(block.content),
+        toolUseId: toolResult.tool_use_id,
+        content: toolResult.content,
+        size: contentSize(toolResult.content),
       },
     ]
   })
@@ -587,12 +665,13 @@ function collectCandidatesByMessage(
   // message — so the budget must see them as one group too.
   const seenAsstIds = new Set<string>()
   for (const message of messages) {
-    if (message.type === 'user') {
+    if (isRecord(message) && message.type === 'user') {
       current.push(...collectCandidatesFromMessage(message))
-    } else if (message.type === 'assistant') {
-      if (!seenAsstIds.has(message.message.id)) {
+    } else if (isRecord(message) && message.type === 'assistant') {
+      const id = assistantMessageId(message)
+      if (id !== undefined && !seenAsstIds.has(id)) {
         flush()
-        seenAsstIds.add(message.message.id)
+        seenAsstIds.add(id)
       }
     }
     // progress / attachment / system are filtered or merged by
@@ -667,28 +746,29 @@ function replaceToolResultContents(
 ): Message[] {
   let changed = false
   const nextMessages = messages.map(message => {
-    if (message.type !== 'user' || !Array.isArray(message.message.content)) {
-      return message
-    }
-    const content = message.message.content
-    const needsReplace = content.some(
-      (b: any) =>
-        b.type === 'tool_result' &&
-        replacementMap.has(b.tool_use_id) &&
-        b.content !== replacementMap.get(b.tool_use_id),
-    )
+    const content = userContentBlocks(message)
+    if (!content) return message
+    const needsReplace = content.some(block => {
+      const toolResult = asToolResultBlock(block)
+      return (
+        toolResult !== undefined &&
+        replacementMap.has(toolResult.tool_use_id) &&
+        toolResult.content !== replacementMap.get(toolResult.tool_use_id)
+      )
+    })
     if (!needsReplace) return message
     changed = true
     return {
       ...message,
       message: {
         ...message.message,
-        content: content.map((block: any) => {
-          if (block.type !== 'tool_result') return block
-          const replacement = replacementMap.get(block.tool_use_id)
-          return replacement === undefined || block.content === replacement
+        content: content.map(block => {
+          const toolResult = asToolResultBlock(block)
+          if (!toolResult) return block
+          const replacement = replacementMap.get(toolResult.tool_use_id)
+          return replacement === undefined || toolResult.content === replacement
             ? block
-            : { ...block, content: replacement }
+            : { ...toolResult, content: replacement }
         }),
       },
       // Drop the original tool payload once the model-facing content has been

--- a/runtime/tests/utils/toolResultStorage.test.ts
+++ b/runtime/tests/utils/toolResultStorage.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from 'bun:test'
 
 import { createUserMessage } from '../../src/utils/messages.ts'
-import { applyToolResultReplacementsToMessages } from '../../src/utils/toolResultStorage.ts'
+import {
+  applyToolResultReplacementsToMessages,
+  reconstructContentReplacementState,
+} from '../../src/utils/toolResultStorage.ts'
 
 test('applyToolResultReplacementsToMessages replaces matching tool results and preserves unrelated messages', () => {
   const unrelated = createUserMessage({ content: 'keep me' })
@@ -56,4 +59,80 @@ test('applyToolResultReplacementsToMessages is idempotent when messages are alre
   )
 
   expect(next).toBe(messages)
+})
+
+test('applyToolResultReplacementsToMessages ignores malformed transcript blocks', () => {
+  const validToolResult = {
+    type: 'tool_result',
+    tool_use_id: 'tool-1',
+    content: 'very large tool output',
+    is_error: false,
+  }
+  const message = createUserMessage({
+    content: 'placeholder',
+  })
+  ;(message.message as { content: unknown }).content = [
+    null,
+    'loose text block',
+    { type: 'tool_result', tool_use_id: 123, content: 'bad id' },
+    { type: 'tool_result', tool_use_id: 'bad-content', content: { raw: true } },
+    { type: 'tool_result', tool_use_id: 'bad-text', content: [{ type: 'text' }] },
+    validToolResult,
+  ]
+  const replacement =
+    '<persisted-output>\nOutput too large. Preview\n</persisted-output>'
+
+  const next = applyToolResultReplacementsToMessages(
+    [message],
+    new Map([
+      ['tool-1', replacement],
+      ['bad-content', 'must not be read'],
+      ['bad-text', 'must not be read'],
+    ]),
+  )
+
+  const blocks = next[0]!.message.content as unknown[]
+  expect(next[0]).not.toBe(message)
+  expect(blocks.slice(0, 5)).toEqual([
+    null,
+    'loose text block',
+    { type: 'tool_result', tool_use_id: 123, content: 'bad id' },
+    { type: 'tool_result', tool_use_id: 'bad-content', content: { raw: true } },
+    { type: 'tool_result', tool_use_id: 'bad-text', content: [{ type: 'text' }] },
+  ])
+  expect((blocks[5] as { content: unknown }).content).toBe(replacement)
+  expect(next[0]!.toolUseResult).toBeUndefined()
+})
+
+test('reconstructContentReplacementState ignores malformed tool result candidates', () => {
+  const message = createUserMessage({
+    content: 'placeholder',
+  })
+  ;(message.message as { content: unknown }).content = [
+    { type: 'tool_result', tool_use_id: 'bad-content', content: 42 },
+    { type: 'tool_result', tool_use_id: 'bad-text', content: [{ type: 'text' }] },
+    { type: 'tool_result', tool_use_id: 'tool-1', content: 'large output' },
+  ]
+
+  const state = reconstructContentReplacementState(
+    [message],
+    [
+      {
+        kind: 'tool-result',
+        toolUseId: 'tool-1',
+        replacement: '<persisted-output>\nPreview\n</persisted-output>',
+      },
+      {
+        kind: 'tool-result',
+        toolUseId: 'bad-content',
+        replacement: 'must not be restored',
+      },
+    ],
+  )
+
+  expect(state.seenIds.has('tool-1')).toBe(true)
+  expect(state.seenIds.has('bad-content')).toBe(false)
+  expect(state.seenIds.has('bad-text')).toBe(false)
+  expect(state.replacements.get('tool-1')).toContain('Preview')
+  expect(state.replacements.has('bad-content')).toBe(false)
 })


### PR DESCRIPTION
## Summary
- parse transcript tool-result storage blocks through local `unknown` structural guards instead of explicit `any` block reads
- ignore malformed user/assistant content blocks during candidate collection, replacement, and resume reconstruction
- add malformed transcript block regressions for replacement and reconstruction paths

Fixes #1130

## Test plan
- `bun test runtime/tests/utils/toolResultStorage.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/sessionStorage.test.ts tests/session/sessionStorage-transcript.test.ts --reporter=verbose`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/session/rollout-reconstruction.test.ts --reporter=verbose`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke
