### PR TITLE
fix(runtime): guard MCP tool catalog descriptors

### DIFF
--- a/runtime/src/mcp-client/tools.ts
+++ b/runtime/src/mcp-client/tools.ts
@@ -188,11 +188,11 @@ interface ToolBridgeOptions {
 interface MCPToolDescriptor {
   name: string;
   description?: string;
-  inputSchema?: unknown;
+  inputSchema?: JSONSchema;
 }
 
 interface MCPListToolsResponse {
-  tools?: MCPToolDescriptor[];
+  tools?: unknown;
 }
 
 interface MCPCallToolResponse {
@@ -253,6 +253,35 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
     ? value
     : undefined;
+}
+
+function normalizeMCPToolDescriptor(raw: unknown): MCPToolDescriptor | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+
+  const name = stringValue(record.name);
+  if (!name) return null;
+
+  const description = typeof record.description === "string"
+    ? record.description
+    : undefined;
+  const inputSchema = asRecord(record.inputSchema) ?? {
+    type: "object",
+    properties: {},
+  };
+
+  return {
+    name,
+    ...(description !== undefined ? { description } : {}),
+    inputSchema,
+  };
+}
+
+function normalizeMCPToolCatalog(rawTools: unknown): MCPToolDescriptor[] {
+  if (!Array.isArray(rawTools)) return [];
+  return rawTools
+    .map(normalizeMCPToolDescriptor)
+    .filter((tool): tool is MCPToolDescriptor => tool !== null);
 }
 
 function errorResult(content: string): ToolResult {
@@ -652,9 +681,7 @@ export async function createToolBridge(
     listToolsTimeoutMs,
     () => client.listTools(),
   );
-  const rawTools = (Array.isArray(response.tools)
-    ? response.tools
-    : []) as MCPToolDescriptorLike[];
+  const rawTools = normalizeMCPToolCatalog(response.tools);
   const mcpTools: MCPToolDescriptorLike[] = options.serverConfig
     ? (filterMCPToolCatalog(
         options.serverConfig,

--- a/runtime/tests/mcp-client/tools.test.ts
+++ b/runtime/tests/mcp-client/tools.test.ts
@@ -52,6 +52,63 @@ describe("createToolBridge — T6 gap #119 observer wiring", () => {
     );
   });
 
+  test("normalizes malformed MCP tool descriptors before bridge construction", async () => {
+    const bridge = await createToolBridge(
+      {
+        listTools: async () => ({
+          tools: [
+            null,
+            "noise",
+            { name: 42, description: "bad name" },
+            { description: "missing name" },
+            { name: "   ", description: "blank name" },
+            {
+              name: "safe",
+              description: 123,
+              inputSchema: "not-a-schema",
+            },
+            {
+              name: "typed",
+              description: "typed schema",
+              inputSchema: { type: "object", properties: { q: { type: "string" } } },
+            },
+          ],
+        }),
+        callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+        close: async () => {},
+      },
+      "srv",
+    );
+
+    expect(bridge.tools.map((tool) => tool.name)).toEqual([
+      "mcp.srv.safe",
+      "mcp.srv.typed",
+    ]);
+    expect(bridge.tools[0]?.description).toContain("MCP tool: safe");
+    expect(bridge.tools[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(bridge.tools[1]?.description).toContain("typed schema");
+    expect(bridge.tools[1]?.inputSchema).toEqual({
+      type: "object",
+      properties: { q: { type: "string" } },
+    });
+  });
+
+  test("treats non-array MCP tool catalogs as exposing zero tools", async () => {
+    const bridge = await createToolBridge(
+      {
+        listTools: async () => ({ tools: { name: "not-array" } }),
+        callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+        close: async () => {},
+      },
+      "srv",
+    );
+
+    expect(bridge.tools).toEqual([]);
+  });
+
   test("observer.onBegin + onEnd fire around a successful call", async () => {
     const begins: Array<{ server: string; toolName: string; args: string }> = [];
     const ends: Array<{ server: string; toolName: string; isError: boolean }> = [];


### PR DESCRIPTION
## Summary
- normalize MCP `listTools()` catalog entries before filtering, pinning, and bridge construction
- ignore non-object entries and descriptors without non-empty string names
- fallback non-string descriptions and malformed input schemas to safe defaults

## Research context
Current agent-security work treats external tool metadata/tool documents as untrusted inputs that can manipulate agent tool choice. This keeps the MCP tool catalog boundary structural instead of trusting raw server payload shape.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/mcp-client/tools.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI startup smoke

Fixes #1134