### PR TITLE
fix(runtime): guard MCP prompt and resource payloads

### DIFF
--- a/runtime/src/mcp-client/prompts.ts
+++ b/runtime/src/mcp-client/prompts.ts
@@ -58,6 +58,8 @@ interface CreatePromptBridgeOpts {
   readonly rpcTimeoutMs?: number;
 }
 
+type PromptRole = MCPPromptRenderedMessage["role"];
+
 export async function createPromptBridge(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   client: any,
@@ -73,40 +75,12 @@ export async function createPromptBridge(
     async listPrompts(): Promise<ReadonlyArray<MCPPromptDescriptor>> {
       if (disposed) return [];
       try {
-        const response = await withDeadline<{
-          prompts?: Array<{
-            name: string;
-            description?: string;
-            arguments?: Array<{
-              name: string;
-              description?: string;
-              required?: boolean;
-            }>;
-          }>;
-        }>(
+        const response = await withDeadline<unknown>(
           `MCP server "${serverName}" listPrompts`,
           rpcTimeoutMs,
           () => client.listPrompts({}),
         );
-        const raw = Array.isArray(response.prompts) ? response.prompts : [];
-        return raw.map((p) => {
-          const args = Array.isArray(p.arguments)
-            ? p.arguments.map((a) => ({
-                name: a.name,
-                ...(a.description !== undefined
-                  ? { description: a.description }
-                  : {}),
-                ...(a.required !== undefined ? { required: a.required } : {}),
-              }))
-            : undefined;
-          return {
-            serverName,
-            name: p.name,
-            namespacedName: `mcp.${serverName}.${p.name}`,
-            ...(p.description !== undefined ? { description: p.description } : {}),
-            ...(args !== undefined ? { arguments: args } : {}),
-          } satisfies MCPPromptDescriptor;
-        });
+        return normalizePromptCatalog(response, serverName);
       } catch (err) {
         logger.warn?.(
           `MCP server "${serverName}" listPrompts failed:`,
@@ -124,13 +98,7 @@ export async function createPromptBridge(
           `MCP prompt bridge for "${serverName}" has been disposed`,
         );
       }
-      const response = await withDeadline<{
-        description?: string;
-        messages?: Array<{
-          role: "user" | "assistant" | "system";
-          content?: unknown;
-        }>;
-      }>(
+      const response = await withDeadline<unknown>(
         `MCP server "${serverName}" getPrompt("${name}")`,
         rpcTimeoutMs,
         () =>
@@ -139,13 +107,14 @@ export async function createPromptBridge(
             ...(args !== undefined ? { arguments: args } : {}),
           }),
       );
-      const messages: MCPPromptRenderedMessage[] = (
-        Array.isArray(response.messages) ? response.messages : []
-      ).map((m) => projectPromptMessage(m.role, m.content));
+      const record = asRecord(response);
+      const messages: MCPPromptRenderedMessage[] = arrayField(record, "messages")
+        .map(projectPromptMessage)
+        .filter((message): message is MCPPromptRenderedMessage => message !== null);
       return {
         promptName: name,
-        ...(response.description !== undefined
-          ? { description: response.description }
+        ...(typeof record?.description === "string"
+          ? { description: record.description }
           : {}),
         messages,
       };
@@ -160,10 +129,92 @@ export async function createPromptBridge(
 // Helpers
 // ─────────────────────────────────────────────────────────────────────
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function arrayField(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): readonly unknown[] {
+  const value = record?.[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizePromptCatalog(
+  response: unknown,
+  serverName: string,
+): MCPPromptDescriptor[] {
+  return arrayField(asRecord(response), "prompts")
+    .map((raw) => normalizePromptDescriptor(raw, serverName))
+    .filter((prompt): prompt is MCPPromptDescriptor => prompt !== null);
+}
+
+function normalizePromptDescriptor(
+  raw: unknown,
+  serverName: string,
+): MCPPromptDescriptor | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+
+  const name = nonEmptyString(record.name);
+  if (!name) return null;
+
+  const args = arrayField(record, "arguments")
+    .map(normalizePromptArgument)
+    .filter((arg): arg is MCPPromptArgumentSpec => arg !== null);
+
+  return {
+    serverName,
+    name,
+    namespacedName: `mcp.${serverName}.${name}`,
+    ...(typeof record.description === "string"
+      ? { description: record.description }
+      : {}),
+    ...(args.length > 0 ? { arguments: args } : {}),
+  };
+}
+
+function normalizePromptArgument(raw: unknown): MCPPromptArgumentSpec | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+
+  const name = nonEmptyString(record.name);
+  if (!name) return null;
+
+  return {
+    name,
+    ...(typeof record.description === "string"
+      ? { description: record.description }
+      : {}),
+    ...(typeof record.required === "boolean" ? { required: record.required } : {}),
+  };
+}
+
+function promptRole(value: unknown): PromptRole | undefined {
+  return value === "user" || value === "assistant" || value === "system"
+    ? value
+    : undefined;
+}
+
 function projectPromptMessage(
-  role: "user" | "assistant" | "system",
-  content: unknown,
-): MCPPromptRenderedMessage {
+  raw: unknown,
+): MCPPromptRenderedMessage | null {
+  const message = asRecord(raw);
+  if (!message) return null;
+
+  const role = promptRole(message.role);
+  if (!role) return null;
+
+  const content = message.content;
   // MCP prompt content can be an object `{type:'text', text:'...'}` or
   // an array of such blocks. Flatten to a single text field when
   // possible; otherwise return rawContent for the caller.

--- a/runtime/src/mcp-client/resources.ts
+++ b/runtime/src/mcp-client/resources.ts
@@ -82,27 +82,12 @@ export async function createResourceBridge(
     async listResources(): Promise<ReadonlyArray<MCPResourceDescriptor>> {
       if (disposed) return [];
       try {
-        const response = await withDeadline<{
-          resources?: Array<{
-            uri: string;
-            name?: string;
-            description?: string;
-            mimeType?: string;
-          }>;
-        }>(
+        const response = await withDeadline<unknown>(
           `MCP server "${serverName}" listResources`,
           rpcTimeoutMs,
           () => client.listResources({}),
         );
-        const raw = Array.isArray(response.resources) ? response.resources : [];
-        return raw.map((r) => ({
-          serverName,
-          uri: r.uri,
-          namespacedName: `mcp.${serverName}.${r.uri}`,
-          ...(r.name !== undefined ? { name: r.name } : {}),
-          ...(r.description !== undefined ? { description: r.description } : {}),
-          ...(r.mimeType !== undefined ? { mimeType: r.mimeType } : {}),
-        }));
+        return normalizeResourceCatalog(response, serverName);
       } catch (err) {
         logger.warn?.(
           `MCP server "${serverName}" listResources failed:`,
@@ -117,21 +102,12 @@ export async function createResourceBridge(
           `MCP resource bridge for "${serverName}" has been disposed`,
         );
       }
-      const response = await withDeadline<{
-        contents?: Array<{
-          uri: string;
-          mimeType?: string;
-          text?: string;
-          blob?: string;
-        }>;
-      }>(
+      const response = await withDeadline<unknown>(
         `MCP server "${serverName}" readResource`,
         rpcTimeoutMs,
         () => client.readResource({ uri }),
       );
-      const first = Array.isArray(response.contents)
-        ? response.contents[0]
-        : undefined;
+      const first = firstResourceContent(response);
       if (!first) {
         return {
           uri,
@@ -140,58 +116,63 @@ export async function createResourceBridge(
         };
       }
 
-      if (typeof first.text === "string") {
-        const bytes = Buffer.byteLength(first.text, "utf8");
+      const contentUri = stringField(first, "uri") ?? uri;
+      const mimeType = stringField(first, "mimeType");
+      const text = stringField(first, "text");
+      const blob = stringField(first, "blob");
+
+      if (text !== undefined) {
+        const bytes = Buffer.byteLength(text, "utf8");
         if (bytes > MAX_RESOURCE_BYTES) {
-          const sliced = truncateUtf8(first.text, MAX_RESOURCE_BYTES);
+          const sliced = truncateUtf8(text, MAX_RESOURCE_BYTES);
           logger.warn?.(
             `MCP resource "${uri}" exceeded I-76 cap (${bytes}B > ${MAX_RESOURCE_BYTES}B); truncated`,
           );
           return {
-            uri: first.uri,
-            ...(first.mimeType !== undefined ? { mimeType: first.mimeType } : {}),
+            uri: contentUri,
+            ...(mimeType !== undefined ? { mimeType } : {}),
             text: sliced,
             truncated: true,
             bytesReturned: Buffer.byteLength(sliced, "utf8"),
           };
         }
         return {
-          uri: first.uri,
-          ...(first.mimeType !== undefined ? { mimeType: first.mimeType } : {}),
-          text: first.text,
+          uri: contentUri,
+          ...(mimeType !== undefined ? { mimeType } : {}),
+          text,
           truncated: false,
           bytesReturned: bytes,
         };
       }
-      if (typeof first.blob === "string") {
+      if (blob !== undefined) {
         // Base64 — decode length approximately via 3/4 ratio.
-        const blobBytes = Math.floor((first.blob.length * 3) / 4);
+        const blobBytes = Math.floor((blob.length * 3) / 4);
         if (blobBytes > MAX_RESOURCE_BYTES) {
           const maxBase64 = Math.floor((MAX_RESOURCE_BYTES * 4) / 3);
-          const sliced = first.blob.slice(0, maxBase64);
+          const sliced = blob.slice(0, maxBase64);
           logger.warn?.(
             `MCP blob resource "${uri}" exceeded I-76 cap (~${blobBytes}B > ${MAX_RESOURCE_BYTES}B); truncated`,
           );
           return {
-            uri: first.uri,
-            ...(first.mimeType !== undefined ? { mimeType: first.mimeType } : {}),
+            uri: contentUri,
+            ...(mimeType !== undefined ? { mimeType } : {}),
             blob: sliced,
             truncated: true,
             bytesReturned: Math.floor((sliced.length * 3) / 4),
           };
         }
         return {
-          uri: first.uri,
-          ...(first.mimeType !== undefined ? { mimeType: first.mimeType } : {}),
-          blob: first.blob,
+          uri: contentUri,
+          ...(mimeType !== undefined ? { mimeType } : {}),
+          blob,
           truncated: false,
           bytesReturned: blobBytes,
         };
       }
 
       return {
-        uri: first.uri,
-        ...(first.mimeType !== undefined ? { mimeType: first.mimeType } : {}),
+        uri: contentUri,
+        ...(mimeType !== undefined ? { mimeType } : {}),
         truncated: false,
         bytesReturned: 0,
       };
@@ -205,6 +186,73 @@ export async function createResourceBridge(
 // ─────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function stringField(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function arrayField(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): readonly unknown[] {
+  const value = record?.[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeResourceCatalog(
+  response: unknown,
+  serverName: string,
+): MCPResourceDescriptor[] {
+  return arrayField(asRecord(response), "resources")
+    .map((raw) => normalizeResourceDescriptor(raw, serverName))
+    .filter((resource): resource is MCPResourceDescriptor => resource !== null);
+}
+
+function normalizeResourceDescriptor(
+  raw: unknown,
+  serverName: string,
+): MCPResourceDescriptor | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+
+  const uri = nonEmptyString(record.uri);
+  if (!uri) return null;
+
+  const name = stringField(record, "name");
+  const description = stringField(record, "description");
+  const mimeType = stringField(record, "mimeType");
+
+  return {
+    serverName,
+    uri,
+    namespacedName: `mcp.${serverName}.${uri}`,
+    ...(name !== undefined ? { name } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(mimeType !== undefined ? { mimeType } : {}),
+  };
+}
+
+function firstResourceContent(response: unknown): Record<string, unknown> | undefined {
+  return arrayField(asRecord(response), "contents")
+    .map(asRecord)
+    .find((record) => record !== undefined);
+}
 
 function withDeadline<T>(
   operation: string,

--- a/runtime/tests/mcp-client/prompts.test.ts
+++ b/runtime/tests/mcp-client/prompts.test.ts
@@ -31,6 +31,57 @@ describe("createPromptBridge", () => {
     expect(items[0].arguments?.[0]).toEqual({ name: "path", required: true });
   });
 
+  it("normalizes malformed prompt catalog entries", async () => {
+    const client = makeClient({
+      listPrompts: vi.fn().mockResolvedValue({
+        prompts: [
+          null,
+          "noise",
+          { name: 42, description: "bad name" },
+          { description: "missing name" },
+          { name: "   ", description: "blank name" },
+          {
+            name: "safe",
+            description: 123,
+            arguments: [
+              null,
+              { name: 42, required: true },
+              { name: "topic", description: 99, required: "yes" },
+              { name: "path", description: "target path", required: true },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const bridge = await createPromptBridge(client, "srv");
+    const items = await bridge.listPrompts();
+
+    expect(items).toEqual([
+      {
+        serverName: "srv",
+        name: "safe",
+        namespacedName: "mcp.srv.safe",
+        arguments: [
+          { name: "topic" },
+          { name: "path", description: "target path", required: true },
+        ],
+      },
+    ]);
+  });
+
+  it("treats non-array prompt catalogs as empty", async () => {
+    const client = makeClient({
+      listPrompts: vi.fn().mockResolvedValue({
+        prompts: { name: "not-array" },
+      }),
+    });
+
+    const bridge = await createPromptBridge(client, "srv");
+
+    await expect(bridge.listPrompts()).resolves.toEqual([]);
+  });
+
   it("returns empty list on upstream error", async () => {
     const client = makeClient({
       listPrompts: vi.fn().mockRejectedValue(new Error("not supported")),
@@ -54,6 +105,49 @@ describe("createPromptBridge", () => {
     expect(rendered.messages).toHaveLength(2);
     expect(rendered.messages[0]).toEqual({ role: "user", text: "hello" });
     expect(rendered.messages[1]).toEqual({ role: "assistant", text: "ok" });
+  });
+
+  it("ignores malformed rendered prompt messages", async () => {
+    const client = makeClient({
+      getPrompt: vi.fn().mockResolvedValue({
+        description: 123,
+        messages: [
+          null,
+          "noise",
+          { role: "bad", content: "skip" },
+          { role: "user", content: { type: "text", text: 42 } },
+          { role: "system", content: "keep" },
+        ],
+      }),
+    });
+
+    const bridge = await createPromptBridge(client, "srv");
+    const rendered = await bridge.renderPrompt("x");
+
+    expect(rendered).toEqual({
+      promptName: "x",
+      messages: [
+        { role: "user", rawContent: { type: "text", text: 42 } },
+        { role: "system", text: "keep" },
+      ],
+    });
+  });
+
+  it("treats non-array rendered prompt messages as empty", async () => {
+    const client = makeClient({
+      getPrompt: vi.fn().mockResolvedValue({
+        description: "desc",
+        messages: { role: "user", content: "not-array" },
+      }),
+    });
+
+    const bridge = await createPromptBridge(client, "srv");
+
+    await expect(bridge.renderPrompt("x")).resolves.toEqual({
+      promptName: "x",
+      description: "desc",
+      messages: [],
+    });
   });
 
   it("flattens arrays of text blocks", async () => {

--- a/runtime/tests/mcp-client/resources.test.ts
+++ b/runtime/tests/mcp-client/resources.test.ts
@@ -31,6 +31,63 @@ describe("createResourceBridge", () => {
     expect(items[0].mimeType).toBe("text/plain");
   });
 
+  it("normalizes malformed listed resource descriptors", async () => {
+    const client = makeClient({
+      listResources: vi.fn().mockResolvedValue({
+        resources: [
+          null,
+          "noise",
+          { uri: 42, name: "bad uri" },
+          { name: "missing uri" },
+          { uri: "   ", name: "blank uri" },
+          {
+            uri: "resource://safe",
+            name: 123,
+            description: false,
+            mimeType: ["text/plain"],
+          },
+          {
+            uri: "file:///typed.txt",
+            name: "typed",
+            description: "typed resource",
+            mimeType: "text/plain",
+          },
+        ],
+      }),
+    });
+
+    const bridge = await createResourceBridge(client, "srv");
+    const items = await bridge.listResources();
+
+    expect(items).toEqual([
+      {
+        serverName: "srv",
+        uri: "resource://safe",
+        namespacedName: "mcp.srv.resource://safe",
+      },
+      {
+        serverName: "srv",
+        uri: "file:///typed.txt",
+        namespacedName: "mcp.srv.file:///typed.txt",
+        name: "typed",
+        description: "typed resource",
+        mimeType: "text/plain",
+      },
+    ]);
+  });
+
+  it("treats non-array resource catalogs as empty", async () => {
+    const client = makeClient({
+      listResources: vi.fn().mockResolvedValue({
+        resources: { uri: "resource://not-array" },
+      }),
+    });
+
+    const bridge = await createResourceBridge(client, "srv");
+
+    await expect(bridge.listResources()).resolves.toEqual([]);
+  });
+
   it("returns empty list when upstream lacks resource support", async () => {
     const client = makeClient({
       listResources: vi.fn().mockRejectedValue(new Error("method not found")),
@@ -50,6 +107,48 @@ describe("createResourceBridge", () => {
     expect(content.text).toBe("hello");
     expect(content.truncated).toBe(false);
     expect(content.bytesReturned).toBe(5);
+  });
+
+  it("skips malformed resource content entries and guards content metadata", async () => {
+    const client = makeClient({
+      readResource: vi.fn().mockResolvedValue({
+        contents: [
+          null,
+          "noise",
+          {
+            uri: 123,
+            mimeType: ["text/plain"],
+            text: "hello",
+          },
+        ],
+      }),
+    });
+
+    const bridge = await createResourceBridge(client, "srv");
+    const content = await bridge.readResource("resource://requested");
+
+    expect(content).toEqual({
+      uri: "resource://requested",
+      text: "hello",
+      truncated: false,
+      bytesReturned: 5,
+    });
+  });
+
+  it("returns empty content for non-array resource read payloads", async () => {
+    const client = makeClient({
+      readResource: vi.fn().mockResolvedValue({
+        contents: { uri: "resource://not-array", text: "ignored" },
+      }),
+    });
+
+    const bridge = await createResourceBridge(client, "srv");
+
+    await expect(bridge.readResource("resource://requested")).resolves.toEqual({
+      uri: "resource://requested",
+      truncated: false,
+      bytesReturned: 0,
+    });
   });
 
   it("I-76: truncates text resource exceeding 5MB cap", async () => {


### PR DESCRIPTION
## Summary
- normalize MCP prompt and resource catalog payloads before exposing runtime descriptors
- ignore malformed prompt/rendered-message entries and invalid roles instead of constructing invalid runtime messages
- guard MCP resource read content metadata and fall back to the requested URI when upstream content URI is malformed

## Research context
Current agent-security and MCP threat-modeling work treats external MCP prompt/resource metadata and content as untrusted data. This extends the structural ingress validation already added for MCP tools to the prompt and resource surfaces.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/mcp-client/prompts.test.ts tests/mcp-client/resources.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI startup smoke

Fixes #1136