### PR TITLE
fix(runtime): guard MCP tool result payloads

### DIFF
--- a/runtime/src/mcp-client/tools.ts
+++ b/runtime/src/mcp-client/tools.ts
@@ -195,12 +195,6 @@ interface MCPListToolsResponse {
   tools?: unknown;
 }
 
-interface MCPCallToolResponse {
-  content?: unknown;
-  isError?: boolean;
-  _meta?: unknown;
-}
-
 type PermissionResolution =
   | { readonly ok: true; readonly args: Record<string, unknown> }
   | { readonly ok: false; readonly result: ToolResult };
@@ -243,6 +237,17 @@ function safeStringifyArgs(args: Record<string, unknown>): string {
   }
 }
 
+function safeStringifyMCPPayload(value: unknown, fallback = ""): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return fallback;
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? fallback : serialized;
+  } catch {
+    return String(value);
+  }
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -282,6 +287,39 @@ function normalizeMCPToolCatalog(rawTools: unknown): MCPToolDescriptor[] {
   return rawTools
     .map(normalizeMCPToolDescriptor)
     .filter((tool): tool is MCPToolDescriptor => tool !== null);
+}
+
+function renderMCPCallContentItem(raw: unknown): string {
+  const record = asRecord(raw);
+  if (record?.type === "text") {
+    return safeStringifyMCPPayload(record.text);
+  }
+  return safeStringifyMCPPayload(raw);
+}
+
+function renderMCPCallContent(rawContent: unknown): string {
+  if (Array.isArray(rawContent)) {
+    return rawContent.map(renderMCPCallContentItem).join("\n");
+  }
+  return safeStringifyMCPPayload(rawContent);
+}
+
+function normalizeMCPCallToolResponse(raw: unknown): {
+  readonly content: string;
+  readonly isError: boolean;
+} {
+  const record = asRecord(raw);
+  if (!record) {
+    return {
+      content: renderMCPCallContent(raw),
+      isError: false,
+    };
+  }
+
+  return {
+    content: renderMCPCallContent(record.content),
+    isError: record.isError === true,
+  };
 }
 
 function errorResult(content: string): ToolResult {
@@ -769,26 +807,19 @@ export async function createToolBridge(
             toolName: mcpTool.name,
             args: callArgs,
           });
-          const result = await withRPCDeadline<MCPCallToolResponse>(
-            `MCP tool "${mcpTool.name}" callTool`,
-            callToolTimeoutMs,
-            () =>
-              client.callTool({
-                name: mcpTool.name,
-                arguments: executionArgs,
-              }),
+          const result = normalizeMCPCallToolResponse(
+            await withRPCDeadline<unknown>(
+              `MCP tool "${mcpTool.name}" callTool`,
+              callToolTimeoutMs,
+              () =>
+                client.callTool({
+                  name: mcpTool.name,
+                  arguments: executionArgs,
+                }),
+            ),
           );
 
-          // MCP tool results contain a content array
-          const rawContent = Array.isArray(result.content)
-            ? result.content
-                .map((c: { type: string; text?: string }) =>
-                  c.type === "text" ? c.text ?? "" : JSON.stringify(c),
-                )
-                .join("\n")
-            : typeof result.content === "string"
-              ? result.content
-              : JSON.stringify(result.content);
+          const rawContent = result.content;
 
           // I-76: cap result payload at 5MB.
           const bytes = Buffer.byteLength(rawContent, "utf8");
@@ -800,7 +831,7 @@ export async function createToolBridge(
             );
           }
 
-          const isError = result.isError === true;
+          const isError = result.isError;
           const durationMs = Date.now() - startedAtMs;
           observer?.onEnd?.({
             callId,

--- a/runtime/tests/mcp-client/tools.test.ts
+++ b/runtime/tests/mcp-client/tools.test.ts
@@ -156,6 +156,73 @@ describe("createToolBridge — T6 gap #119 observer wiring", () => {
     expect(ends[0]!.isError).toBe(false);
   });
 
+  test("normalizes malformed MCP tool call result content", async () => {
+    const observedResults: string[] = [];
+    const bridge = await createToolBridge(
+      {
+        listTools: async () => ({
+          tools: [{ name: "mixed", description: "returns mixed content" }],
+        }),
+        callTool: async () => ({
+          content: [
+            null,
+            7,
+            "loose string",
+            { type: "text", text: 42 },
+            { type: "text", text: { nested: true } },
+            { type: "image", data: "abc", mimeType: "image/png" },
+            { type: "text" },
+          ],
+          isError: "true",
+        }),
+        close: async () => {},
+      },
+      "srv",
+      undefined,
+      {
+        callObserver: {
+          onEnd: (end) => {
+            observedResults.push(end.result);
+          },
+        },
+      },
+    );
+
+    const result = await bridge.tools[0]!.execute({});
+
+    expect(result).toEqual({
+      content: [
+        "null",
+        "7",
+        "loose string",
+        "42",
+        "{\"nested\":true}",
+        "{\"type\":\"image\",\"data\":\"abc\",\"mimeType\":\"image/png\"}",
+        "",
+      ].join("\n"),
+      isError: false,
+    });
+    expect(observedResults).toEqual([result.content]);
+  });
+
+  test("normalizes primitive MCP tool call responses", async () => {
+    const bridge = await createToolBridge(
+      {
+        listTools: async () => ({
+          tools: [{ name: "primitive", description: "returns primitive" }],
+        }),
+        callTool: async () => "raw response",
+        close: async () => {},
+      },
+      "srv",
+    );
+
+    await expect(bridge.tools[0]!.execute({})).resolves.toEqual({
+      content: "raw response",
+      isError: false,
+    });
+  });
+
   test("applies server tool filters and approval defaults", async () => {
     const fakeClient = {
       listTools: async () => ({


### PR DESCRIPTION
## Summary
- treat MCP `callTool()` responses as untrusted payloads before rendering tool output text
- normalize primitive, missing, and malformed content entries without throwing inside the bridge
- preserve existing observer, truncation, and `isError === true` behavior for valid responses

## Research context
Recent MCP and agent-security work treats tool outputs and shared context as untrusted attack surfaces, in the same family as tool metadata poisoning. This keeps the MCP tool-result ingress boundary aligned with the prompt/resource/catalog guards already merged.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/mcp-client/tools.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI startup smoke

Fixes #1138