### PR TITLE
fix(runtime): normalize provider discovery payloads

### DIFF
--- a/runtime/src/utils/providerDiscovery.ts
+++ b/runtime/src/utils/providerDiscovery.ts
@@ -41,32 +41,66 @@ function compactDetail(value: string, maxLength = 180): string {
   return `${compact.slice(0, maxLength)}...`
 }
 
-type OllamaTagsPayload = {
-  models?: Array<{
-    name?: string
-    size?: number
-    details?: {
-      family?: string
-      families?: string[]
-      parameter_size?: string
-      quantization_level?: string
-    }
-  }>
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function arrayField(record: Record<string, unknown>, key: string): readonly unknown[] {
+  const value = record[key]
+  return Array.isArray(value) ? value : []
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value
+    : undefined
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
+}
+
+function normalizeOpenAICompatibleModelIds(payload: unknown): string[] {
+  const record = asRecord(payload)
+  if (!record) return []
+  return Array.from(
+    new Set(
+      arrayField(record, 'data')
+        .map(model => nonEmptyString(asRecord(model)?.id))
+        .filter((id): id is string => id !== undefined),
+    ),
+  )
 }
 
 function normalizeOllamaModels(
-  payload: OllamaTagsPayload,
+  payload: unknown,
 ): OllamaModelDescriptor[] {
-  return (payload.models ?? [])
-    .filter(model => Boolean(model.name))
-    .map(model => ({
-      name: model.name!,
-      sizeBytes: typeof model.size === 'number' ? model.size : null,
-      family: model.details?.family ?? null,
-      families: model.details?.families ?? [],
-      parameterSize: model.details?.parameter_size ?? null,
-      quantizationLevel: model.details?.quantization_level ?? null,
-    }))
+  const record = asRecord(payload)
+  if (!record) return []
+  return arrayField(record, 'models')
+    .map((model): OllamaModelDescriptor | null => {
+      const modelRecord = asRecord(model)
+      const name = nonEmptyString(modelRecord?.name)
+      if (!modelRecord || name === undefined) return null
+      const details = asRecord(modelRecord.details)
+      return {
+        name,
+        sizeBytes: typeof modelRecord.size === 'number' ? modelRecord.size : null,
+        family: typeof details?.family === 'string' ? details.family : null,
+        families: stringArray(details?.families),
+        parameterSize: typeof details?.parameter_size === 'string'
+          ? details.parameter_size
+          : null,
+        quantizationLevel: typeof details?.quantization_level === 'string'
+          ? details.quantization_level
+          : null,
+      }
+    })
+    .filter((model): model is OllamaModelDescriptor => model !== null)
 }
 
 async function fetchOllamaModelsProbe(
@@ -90,7 +124,7 @@ async function fetchOllamaModelsProbe(
       }
     }
 
-    const payload = (await response.json().catch(() => ({}))) as OllamaTagsPayload
+    const payload: unknown = await response.json().catch(() => ({}))
     return {
       reachable: true,
       models: normalizeOllamaModels(payload),
@@ -265,17 +299,7 @@ export async function listOpenAICompatibleModels(options?: {
       return null
     }
 
-    const data = (await response.json()) as {
-      data?: Array<{ id?: string }>
-    }
-
-    return Array.from(
-      new Set(
-        (data.data ?? [])
-          .filter(model => Boolean(model.id))
-          .map(model => model.id!),
-      ),
-    )
+    return normalizeOpenAICompatibleModelIds(await response.json())
   } catch {
     return null
   } finally {
@@ -311,13 +335,7 @@ export async function listAtomicChatModels(
       return []
     }
 
-    const data = (await response.json()) as {
-      data?: Array<{ id?: string }>
-    }
-
-    return (data.data ?? [])
-      .filter(model => Boolean(model.id))
-      .map(model => model.id!)
+    return normalizeOpenAICompatibleModelIds(await response.json())
   } catch {
     return []
   } finally {

--- a/runtime/tests/utils/providerDiscovery.test.ts
+++ b/runtime/tests/utils/providerDiscovery.test.ts
@@ -48,6 +48,49 @@ test('lists models from a local openai-compatible /models endpoint', async () =>
   ])
 })
 
+test('ignores malformed local openai-compatible model entries', async () => {
+  const { listOpenAICompatibleModels } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            null,
+            'noise',
+            { id: 42 },
+            { id: '   ' },
+            { id: 'qwen3-coder' },
+            { id: 'qwen3-coder' },
+            { id: 'llama-3.3' },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    listOpenAICompatibleModels({ baseUrl: 'http://localhost:1234/v1' }),
+  ).resolves.toEqual(['qwen3-coder', 'llama-3.3'])
+})
+
+test('returns an empty local openai-compatible model list for malformed payloads', async () => {
+  const { listOpenAICompatibleModels } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ data: { id: 'not-an-array' } }), {
+        status: 200,
+      }),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    listOpenAICompatibleModels({ baseUrl: 'http://localhost:1234/v1' }),
+  ).resolves.toEqual([])
+})
+
 test('returns null when a local openai-compatible /models request fails', async () => {
   const { listOpenAICompatibleModels } = await loadProviderDiscoveryModule()
 
@@ -139,6 +182,69 @@ test('ollama generation readiness reports unreachable when tags endpoint is down
   expect(calledUrls).toEqual([
     'http://localhost:11434/api/tags',
   ])
+})
+
+test('ollama model discovery ignores malformed tag entries', async () => {
+  const { listOllamaModels } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          models: [
+            null,
+            'noise',
+            { name: 42, size: 100 },
+            { name: '   ' },
+            {
+              name: 'qwen2.5-coder:7b',
+              size: 123,
+              details: {
+                family: 'qwen',
+                families: ['qwen', 7],
+                parameter_size: '7B',
+                quantization_level: 'Q4_K_M',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    listOllamaModels('http://localhost:11434'),
+  ).resolves.toEqual([
+    {
+      name: 'qwen2.5-coder:7b',
+      sizeBytes: 123,
+      family: 'qwen',
+      families: ['qwen'],
+      parameterSize: '7B',
+      quantizationLevel: 'Q4_K_M',
+    },
+  ])
+})
+
+test('ollama model discovery treats malformed tag payloads as empty', async () => {
+  const { listOllamaModels } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ models: { name: 'not-array' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    listOllamaModels('http://localhost:11434'),
+  ).resolves.toEqual([])
 })
 
 test('ollama generation readiness reports no models when server is reachable', async () => {
@@ -350,6 +456,36 @@ test('atomic chat readiness reports no_models when server is reachable but empty
   await expect(
     probeAtomicChatReadiness({ baseUrl: 'http://127.0.0.1:1337' }),
   ).resolves.toEqual({ state: 'no_models' })
+})
+
+test('atomic chat readiness ignores malformed model entries', async () => {
+  const { probeAtomicChatReadiness } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            null,
+            { id: 99 },
+            { id: '   ' },
+            { id: 'Qwen3_5-4B_Q4_K_M' },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    probeAtomicChatReadiness({ baseUrl: 'http://127.0.0.1:1337' }),
+  ).resolves.toEqual({
+    state: 'ready',
+    models: ['Qwen3_5-4B_Q4_K_M'],
+  })
 })
 
 test('atomic chat readiness returns loaded model ids when ready', async () => {


### PR DESCRIPTION
## Summary
- parse local provider discovery responses as `unknown` before consuming model lists
- normalize OpenAI-compatible, Atomic Chat, and Ollama model-list payloads with local record/array/string guards
- add malformed-payload regressions while preserving existing null/empty behavior for failed discovery

## Research context
Current agent-security work treats external tool/provider outputs and shared context as untrusted. Local model discovery responses influence provider selection and startup UX, so this applies the same structural ingress validation discipline to the local vLLM/OpenAI-compatible discovery path.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/providerDiscovery.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI startup smoke

Fixes #1140