### PR TITLE
fix(runtime): normalize Ollama model picker discovery

### DIFF
--- a/runtime/src/utils/model/ollamaModels.ts
+++ b/runtime/src/utils/model/ollamaModels.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ModelOption } from './modelOptions.js'
-import { getOllamaApiBaseUrl } from '../providerDiscovery.js'
+import { listOllamaModels } from '../providerDiscovery.js'
 
 let cachedOllamaOptions: ModelOption[] | null = null
 let fetchPromise: Promise<ModelOption[]> | null = null
@@ -33,49 +33,18 @@ export function isOllamaProvider(): boolean {
  * Fetch models from the Ollama /api/tags endpoint.
  */
 export async function fetchOllamaModels(): Promise<ModelOption[]> {
-  const apiUrl = getOllamaApiBaseUrl()
-  if (!apiUrl) return []
-
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 5000)
-
-  try {
-    const response = await fetch(`${apiUrl}/api/tags`, {
-      method: 'GET',
-      signal: controller.signal,
-    })
-    if (!response.ok) return []
-
-    const data = (await response.json()) as {
-      models?: Array<{
-        name?: string
-        size?: number
-        details?: {
-          parameter_size?: string
-          quantization_level?: string
-          family?: string
-        }
-      }>
+  const models = await listOllamaModels()
+  return models.map(model => {
+    const paramSize = model.parameterSize ?? ''
+    const quant = model.quantizationLevel ?? ''
+    const sizeGB = model.sizeBytes ? `${(model.sizeBytes / 1e9).toFixed(1)}GB` : ''
+    const parts = [paramSize, quant, sizeGB].filter(Boolean).join(' · ')
+    return {
+      value: model.name,
+      label: model.name,
+      description: parts ? `Ollama · ${parts}` : 'Ollama model',
     }
-
-    return (data.models ?? [])
-      .filter(m => Boolean(m.name))
-      .map(m => {
-        const paramSize = m.details?.parameter_size ?? ''
-        const quant = m.details?.quantization_level ?? ''
-        const sizeGB = m.size ? `${(m.size / 1e9).toFixed(1)}GB` : ''
-        const parts = [paramSize, quant, sizeGB].filter(Boolean).join(' · ')
-        return {
-          value: m.name!,
-          label: m.name!,
-          description: parts ? `Ollama · ${parts}` : 'Ollama model',
-        }
-      })
-  } catch {
-    return []
-  } finally {
-    clearTimeout(timeout)
-  }
+  })
 }
 
 /**

--- a/runtime/tests/utils/model/ollamaModels.test.ts
+++ b/runtime/tests/utils/model/ollamaModels.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+async function loadOllamaModelsModule() {
+  vi.resetModules()
+  return import('../../../src/utils/model/ollamaModels.ts')
+}
+
+const originalFetch = globalThis.fetch
+const originalEnv = {
+  OLLAMA_BASE_URL: process.env.OLLAMA_BASE_URL,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.clearAllMocks()
+  vi.resetModules()
+  for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = originalEnv[key]
+    }
+  }
+})
+
+test('fetchOllamaModels maps normalized Ollama tags into model picker options', async () => {
+  const { fetchOllamaModels } = await loadOllamaModelsModule()
+  const requestedUrls: string[] = []
+
+  globalThis.fetch = vi.fn(input => {
+    const url = typeof input === 'string' ? input : input.url
+    requestedUrls.push(url)
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          models: [
+            {
+              name: 'qwen2.5-coder:7b',
+              size: 4_200_000_000,
+              details: {
+                parameter_size: '7B',
+                quantization_level: 'Q4_K_M',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+  }) as typeof globalThis.fetch
+
+  await expect(fetchOllamaModels()).resolves.toEqual([
+    {
+      value: 'qwen2.5-coder:7b',
+      label: 'qwen2.5-coder:7b',
+      description: 'Ollama · 7B · Q4_K_M · 4.2GB',
+    },
+  ])
+  expect(requestedUrls).toEqual(['http://localhost:11434/api/tags'])
+})
+
+test('fetchOllamaModels ignores malformed Ollama tag entries', async () => {
+  const { fetchOllamaModels } = await loadOllamaModelsModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          models: [
+            null,
+            'noise',
+            { name: 42, size: 100 },
+            { name: '   ' },
+            {
+              name: 'llama3.3:latest',
+              size: 0,
+              details: {
+                parameter_size: 70,
+                quantization_level: null,
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(fetchOllamaModels()).resolves.toEqual([
+    {
+      value: 'llama3.3:latest',
+      label: 'llama3.3:latest',
+      description: 'Ollama model',
+    },
+  ])
+})
+
+test('fetchOllamaModels treats malformed Ollama tag payloads as empty', async () => {
+  const { fetchOllamaModels } = await loadOllamaModelsModule()
+
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ models: { name: 'not-array' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(fetchOllamaModels()).resolves.toEqual([])
+})


### PR DESCRIPTION
## Summary
- route `/model` picker Ollama discovery through the normalized provider discovery path
- remove the duplicate direct `/api/tags` JSON cast in the model picker helper
- add malformed Ollama tag regressions for the model picker path while preserving valid option labels/descriptions

## Research context
Current agent-security work treats external tool/provider outputs and shared context as untrusted ingress. This keeps the local Ollama model picker aligned with the normalized local provider discovery path used by vLLM/OpenAI-compatible setup.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/utils/model/ollamaModels.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI startup smoke

Fixes #1142