### PR TITLE
fix(runtime): guard Ollama chat response payloads

### DIFF
--- a/runtime/src/llm/providers/ollama/adapter.ts
+++ b/runtime/src/llm/providers/ollama/adapter.ts
@@ -185,6 +185,64 @@ function cloneProviderTracePayload(
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function readNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function readNonNegativeNumberOrZero(value: unknown): number {
+  return readNonNegativeNumber(value) ?? 0;
+}
+
+function serializeOllamaToolArguments(value: unknown): string | null {
+  if (value === undefined) return "{}";
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return "{}";
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (isRecord(parsed)) return trimmed;
+    } catch {
+      // Fall through to the validator path below; non-JSON strings should not
+      // become executable tool arguments.
+    }
+  }
+  try {
+    return safeStringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeOllamaToolCall(raw: unknown): LLMToolCall | null {
+  if (!isRecord(raw) || !isRecord(raw.function)) return null;
+  const serializedArguments = serializeOllamaToolArguments(
+    raw.function.arguments,
+  );
+  if (serializedArguments === null) return null;
+  return validateToolCall({
+    id: randomUUID(),
+    name: readString(raw.function.name),
+    arguments: serializedArguments,
+  });
+}
+
+function normalizeOllamaToolCalls(raw: unknown): LLMToolCall[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map(normalizeOllamaToolCall)
+    .filter((toolCall): toolCall is LLMToolCall => toolCall !== null);
+}
+
 function buildProviderTraceErrorPayload(error: unknown): Record<string, unknown> {
   if (error instanceof Error) {
     const payload: Record<string, unknown> = {
@@ -529,32 +587,30 @@ export class OllamaProvider implements LLMProvider {
             abortOllamaStream(stream));
 
           try {
-            for await (const chunk of abortableAsyncIterable(
+            for await (const rawChunk of abortableAsyncIterable(
               stream as AsyncIterable<any>,
               signal,
             )) {
-              if (chunk.message?.content) {
-                content += chunk.message.content;
-                onChunk({ content: chunk.message.content, done: false });
+              const chunk = isRecord(rawChunk) ? rawChunk : {};
+              const message = isRecord(chunk.message) ? chunk.message : {};
+              const chunkContent = readString(message.content);
+
+              if (chunkContent) {
+                content += chunkContent;
+                onChunk({ content: chunkContent, done: false });
               }
 
-              // Accumulate tool calls
-              if (chunk.message?.tool_calls) {
-                for (const tc of chunk.message.tool_calls) {
-                  const validated = validateToolCall({
-                    id: randomUUID(),
-                    name: tc.function?.name ?? "",
-                    arguments: JSON.stringify(tc.function?.arguments ?? {}),
-                  });
-                  if (validated) {
-                    toolCalls.push(validated);
-                  }
-                }
-              }
+              toolCalls = [
+                ...toolCalls,
+                ...normalizeOllamaToolCalls(message.tool_calls),
+              ];
 
-              if (chunk.model) model = chunk.model;
-              if (chunk.prompt_eval_count) promptTokens = chunk.prompt_eval_count;
-              if (chunk.eval_count) completionTokens = chunk.eval_count;
+              const chunkModel = readString(chunk.model);
+              if (chunkModel) model = chunkModel;
+              promptTokens =
+                readNonNegativeNumber(chunk.prompt_eval_count) ?? promptTokens;
+              completionTokens =
+                readNonNegativeNumber(chunk.eval_count) ?? completionTokens;
             }
           } finally {
             cleanupStreamAbort();
@@ -867,35 +923,29 @@ export class OllamaProvider implements LLMProvider {
     };
   }
 
-  private parseResponse(response: any, options?: LLMChatOptions): LLMResponse {
-    const message = response.message ?? {};
-    const content = message.content ?? "";
+  private parseResponse(response: unknown, options?: LLMChatOptions): LLMResponse {
+    const record = isRecord(response) ? response : {};
+    const message = isRecord(record.message) ? record.message : {};
+    const content = readString(message.content);
+    const toolCalls = normalizeOllamaToolCalls(message.tool_calls);
 
-    const toolCalls: LLMToolCall[] = (message.tool_calls ?? [])
-      .map((tc: any) =>
-        validateToolCall({
-          id: randomUUID(),
-          name: tc.function?.name ?? "",
-          arguments: JSON.stringify(tc.function?.arguments ?? {}),
-        }),
-      )
-      .filter(
-        (toolCall: LLMToolCall | null): toolCall is LLMToolCall =>
-          toolCall !== null,
-      );
-
+    const promptTokens = readNonNegativeNumberOrZero(record.prompt_eval_count);
+    const completionTokens = readNonNegativeNumberOrZero(record.eval_count);
     const usage: LLMUsage = {
-      promptTokens: response.prompt_eval_count ?? 0,
-      completionTokens: response.eval_count ?? 0,
-      totalTokens:
-        (response.prompt_eval_count ?? 0) + (response.eval_count ?? 0),
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
     };
 
     return {
       content,
       toolCalls,
       usage,
-      model: response.model ?? options?.model?.trim() ?? this.config.model,
+      model:
+        readString(record.model) ||
+        options?.model?.trim() ||
+        this.config.model ||
+        DEFAULT_MODEL,
       finishReason: toolCalls.length > 0 ? "tool_calls" : "stop",
       ...this.buildUnsupportedDiagnostics(options),
     };

--- a/runtime/tests/llm/providers/ollama/provider.test.ts
+++ b/runtime/tests/llm/providers/ollama/provider.test.ts
@@ -222,6 +222,85 @@ describe("providers/ollama entrypoint", () => {
     ]);
   });
 
+  test("ignores malformed native SDK chat response fields", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      model: 42,
+      message: {
+        role: "assistant",
+        content: 123,
+        tool_calls: { function: { name: "system.echo" } },
+      },
+      prompt_eval_count: "8",
+      eval_count: -1,
+    });
+    const provider = new OllamaProvider({
+      model: "llama3.3",
+    });
+    setClient(provider, { chat });
+
+    const response = await provider.chat(
+      [{ role: "user", content: "echo hi" }],
+      { model: "request-model" },
+    );
+
+    expect(response).toMatchObject({
+      content: "",
+      finishReason: "stop",
+      model: "request-model",
+      toolCalls: [],
+      usage: {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      },
+    });
+  });
+
+  test("ignores malformed native SDK tool-call entries while preserving valid ones", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      model: "llama3.3",
+      message: {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          null,
+          "noise",
+          { function: null },
+          { function: { name: "   ", arguments: { text: "missing name" } } },
+          { function: { name: "system.echo", arguments: { text: "hi" } } },
+          {
+            function: {
+              name: "system.search",
+              arguments: '{"query":"typed string args"}',
+            },
+          },
+        ],
+      },
+      prompt_eval_count: 8,
+      eval_count: 2,
+    });
+    const provider = new OllamaProvider({
+      model: "llama3.3",
+    });
+    setClient(provider, { chat });
+
+    const response = await provider.chat([{ role: "user", content: "echo hi" }]);
+
+    expect(response.finishReason).toBe("tool_calls");
+    expect(response.toolCalls).toEqual([
+      {
+        id: expect.any(String),
+        name: "system.echo",
+        arguments: '{"text":"hi"}',
+      },
+      {
+        id: expect.any(String),
+        name: "system.search",
+        arguments: '{"query":"typed string args"}',
+      },
+    ]);
+  });
+
   test("streams native SDK chat chunks through the provider callback", async () => {
     const chat = vi.fn().mockResolvedValue(
       streamChunks([
@@ -267,6 +346,72 @@ describe("providers/ollama entrypoint", () => {
       messages: [{ role: "user", content: "hello" }],
     });
     expect(chat.mock.calls[0]).toHaveLength(1);
+  });
+
+  test("ignores malformed native SDK stream chunks while preserving valid deltas", async () => {
+    const chat = vi.fn().mockResolvedValue(
+      streamChunks([
+        null,
+        {
+          model: 42,
+          message: {
+            role: "assistant",
+            content: 99,
+            tool_calls: { function: { name: "system.echo" } },
+          },
+          prompt_eval_count: "bad",
+          eval_count: -1,
+        },
+        {
+          model: "llama3.3",
+          message: {
+            role: "assistant",
+            content: "ok",
+            tool_calls: [
+              { function: { name: "system.echo", arguments: { text: "hi" } } },
+              { function: { name: "", arguments: { text: "bad" } } },
+            ],
+          },
+          prompt_eval_count: 4,
+          eval_count: 2,
+        },
+        {
+          message: {
+            role: "assistant",
+            content: "",
+          },
+        },
+      ]),
+    );
+    const provider = new OllamaProvider({
+      model: "llama3.3",
+    });
+    setClient(provider, { chat, list: vi.fn().mockResolvedValue({ models: [] }) });
+    const chunks: Array<{ content: string; done: boolean }> = [];
+
+    const response = await provider.chatStream(
+      [{ role: "user", content: "hello" }],
+      (chunk) => chunks.push({ content: chunk.content, done: chunk.done }),
+    );
+
+    expect(response.content).toBe("ok");
+    expect(response.model).toBe("llama3.3");
+    expect(response.usage).toEqual({
+      promptTokens: 4,
+      completionTokens: 2,
+      totalTokens: 6,
+    });
+    expect(response.toolCalls).toEqual([
+      {
+        id: expect.any(String),
+        name: "system.echo",
+        arguments: '{"text":"hi"}',
+      },
+    ]);
+    expect(chunks).toEqual([
+      { content: "ok", done: false },
+      { content: "", done: true },
+    ]);
   });
 
   test("keeps health monitoring active through slow stream consumption", async () => {


### PR DESCRIPTION
## Summary
- normalize Ollama SDK chat and stream response payloads before reading message, usage, model, and tool-call fields
- ignore malformed response/tool-call entries instead of throwing in local provider paths
- preserve valid native Ollama tool calls, including object arguments and JSON-string object arguments

## Research context
Recent agent-security work frames retrieved records and tool/provider observations as untrusted channels where runtime enforcement matters more than prompt-only boundaries. This hardens a local provider ingress boundary so malformed observations do not crash or become invalid runtime state.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/llm/providers/ollama/provider.test.ts --reporter=verbose
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- pre-commit hook: runtime build, package entrypoints, TUI startup smoke

Fixes #1144