### PR TITLE
fix(runtime): guard project root permission subpaths

### DIFF
--- a/runtime/src/permissions/rpc/request-permissions.ts
+++ b/runtime/src/permissions/rpc/request-permissions.ts
@@ -118,6 +118,19 @@ function optionalString(value: unknown, field: string): string | undefined {
   return stringField(value, field);
 }
 
+function projectRootSubpath(value: unknown, field: string): string | null {
+  if (value === null) return null;
+  const raw = stringField(value, field);
+  if (path.isAbsolute(raw)) {
+    throw new Error(`${field} must be relative`);
+  }
+  const normalized = path.normalize(raw);
+  if (normalized === ".." || normalized.startsWith(`..${path.sep}`)) {
+    throw new Error(`${field} must stay within the project root`);
+  }
+  return raw;
+}
+
 function normalizeAbsolutePath(
   value: unknown,
   field: string,
@@ -170,7 +183,12 @@ function normalizeSpecialPath(value: unknown): FileSystemSpecialPath {
       return {
         kind: "project_roots",
         ...(record.subpath !== undefined
-          ? { subpath: optionalString(record.subpath, "fileSystem entry special subpath") ?? null }
+          ? {
+              subpath: projectRootSubpath(
+                record.subpath,
+                "fileSystem entry special subpath",
+              ),
+            }
           : {}),
       };
     case "tmpdir":

--- a/runtime/src/sandbox/engine/index.ts
+++ b/runtime/src/sandbox/engine/index.ts
@@ -243,6 +243,13 @@ export function resolvePathAgainstBase(value: string, base: string): string {
     : normalizePathForPolicy(path.resolve(base, value));
 }
 
+function resolveProjectRootSubpath(subpath: string, cwd: string): string | null {
+  if (path.isAbsolute(subpath)) return null;
+  const normalizedCwd = normalizePathForPolicy(cwd);
+  const resolved = normalizePathForPolicy(path.resolve(normalizedCwd, subpath));
+  return pathStartsWith(resolved, normalizedCwd) ? resolved : null;
+}
+
 export function pathOverlaps(left: string, right: string): boolean {
   const a = normalizePathForPolicy(left);
   const b = normalizePathForPolicy(right);
@@ -280,7 +287,7 @@ export function resolveSpecialPath(
       return path.parse(normalizePathForPolicy(cwd)).root;
     case "project_roots":
       return target.subpath
-        ? resolvePathAgainstBase(target.subpath, cwd)
+        ? resolveProjectRootSubpath(target.subpath, cwd)
         : normalizePathForPolicy(cwd);
     case "tmpdir": {
       const tmpdir = process.env["TMPDIR"];

--- a/runtime/src/sandbox/linux-launcher/cli.ts
+++ b/runtime/src/sandbox/linux-launcher/cli.ts
@@ -248,6 +248,23 @@ function assertSpecialPath(value: unknown): void {
   if (special.subpath !== undefined && typeof special.subpath !== "string") {
     throw new LinuxSandboxCliError("permission profile special path subpath must be a string");
   }
+  if (special.kind === "project_roots" && typeof special.subpath === "string") {
+    assertProjectRootSubpath(special.subpath);
+  }
+}
+
+function assertProjectRootSubpath(value: string): void {
+  if (path.isAbsolute(value)) {
+    throw new LinuxSandboxCliError(
+      "permission profile project root subpath must be relative",
+    );
+  }
+  const normalized = path.normalize(value);
+  if (normalized === ".." || normalized.startsWith(`..${path.sep}`)) {
+    throw new LinuxSandboxCliError(
+      "permission profile project root subpath must stay within the project root",
+    );
+  }
 }
 
 function normalizeCwd(value: string): string {

--- a/runtime/tests/permissions/rpc/request-permissions.test.ts
+++ b/runtime/tests/permissions/rpc/request-permissions.test.ts
@@ -213,6 +213,31 @@ describe("request-permissions RPC profiles", () => {
     });
   });
 
+  it("rejects project-root subpaths that escape the cwd", () => {
+    for (const subpath of ["/etc", "../outside", "safe/../../outside"]) {
+      expect(() =>
+        normalizeRequestPermissionsArgs(
+          {
+            permissions: {
+              fileSystem: {
+                entries: [
+                  {
+                    path: {
+                      type: "special",
+                      value: { kind: "project_roots", subpath },
+                    },
+                    access: "read",
+                  },
+                ],
+              },
+            },
+          },
+          { cwd },
+        ),
+      ).toThrow(/project root|relative/);
+    }
+  });
+
   it("preserves exact unresolved special-path grants", () => {
     expect(
       intersectRequestPermissionProfiles(

--- a/runtime/tests/sandbox/engine/policy-transforms.test.ts
+++ b/runtime/tests/sandbox/engine/policy-transforms.test.ts
@@ -279,6 +279,27 @@ describe("sandbox permission profile transforms", () => {
     }
   });
 
+  it("keeps project-root special subpaths inside the cwd", () => {
+    expect(
+      resolveSpecialPath({ kind: "project_roots", subpath: "src" }, "/repo"),
+    ).toBe("/repo/src");
+    expect(
+      resolveSpecialPath({ kind: "project_roots", subpath: "/etc" }, "/repo"),
+    ).toBeNull();
+    expect(
+      resolveSpecialPath(
+        { kind: "project_roots", subpath: "../outside" },
+        "/repo",
+      ),
+    ).toBeNull();
+    expect(
+      resolveSpecialPath(
+        { kind: "project_roots", subpath: "safe/../../outside" },
+        "/repo",
+      ),
+    ).toBeNull();
+  });
+
   it("applies specific carveouts and protected metadata over broader writes", () => {
     const workspaceWrite = restrictedFileSystemPolicy([
       { path: { kind: "path", path: "/repo" }, access: "write" },

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -91,6 +91,25 @@ describe("Linux sandbox launcher", () => {
         "/bin/true",
       ]),
     ).toThrow(/network must be enabled, disabled, or restricted/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs([
+        "--permission-profile",
+        JSON.stringify({
+          fileSystem: restrictedFileSystemPolicy([
+            {
+              path: {
+                kind: "special",
+                value: { kind: "project_roots", subpath: "../outside" },
+              },
+              access: "read",
+            },
+          ]),
+          network: "disabled",
+        }),
+        "--",
+        "/bin/true",
+      ]),
+    ).toThrow(/project root subpath must stay within the project root/u);
   });
 
   it("builds full-filesystem bubblewrap flags for network-isolated full-write policies", () => {


### PR DESCRIPTION
## Summary

- reject `project_roots.subpath` values that are absolute or resolve outside the cwd in request-permissions RPC normalization
- fail closed for escaped project-root subpaths in sandbox policy resolution
- add Linux launcher parser validation and regression coverage for escaped subpaths

## Validation

- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/permissions/rpc/request-permissions.test.ts tests/sandbox/engine/policy-transforms.test.ts tests/sandbox/linux-launcher/linux-launcher.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- `npm run validate:runtime`

Closes #1146