### PR TITLE
fix(runtime): guard OAuth token payloads

### DIFF
--- a/runtime/src/services/api/openAiCodeOAuthShared.ts
+++ b/runtime/src/services/api/openAiCodeOAuthShared.ts
@@ -17,6 +17,31 @@ export function asTrimmedString(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined
 }
 
+export type OAuthTokenPayload = {
+  accessToken?: string
+  refreshToken?: string
+  idToken?: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+export function normalizeOAuthTokenPayload(value: unknown): OAuthTokenPayload {
+  const record = asRecord(value)
+  if (!record) return {}
+  const accessToken = asTrimmedString(record.access_token)
+  const refreshToken = asTrimmedString(record.refresh_token)
+  const idToken = asTrimmedString(record.id_token)
+  return {
+    ...(accessToken !== undefined ? { accessToken } : {}),
+    ...(refreshToken !== undefined ? { refreshToken } : {}),
+    ...(idToken !== undefined ? { idToken } : {}),
+  }
+}
+
 export function getOpenAiCodeOAuthClientId(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -127,8 +152,8 @@ export async function exchangeProviderCodeIdTokenForApiKey(
     )
   }
 
-  const payload = (await response.json()) as { access_token?: string }
-  const apiKey = asTrimmedString(payload.access_token)
+  const payload = normalizeOAuthTokenPayload(await response.json())
+  const apiKey = payload.accessToken
   if (!apiKey) {
     throw new Error(
       'ProviderCode API key exchange completed, but no API key token was returned.',

--- a/runtime/src/utils/agencCredentials.ts
+++ b/runtime/src/utils/agencCredentials.ts
@@ -5,6 +5,7 @@ import {
   PROVIDER_CODE_REFRESH_URL as AGENC_REFRESH_URL,
   exchangeProviderCodeIdTokenForApiKey as exchangeAgencIdTokenForApiKey,
   getOpenAiCodeOAuthClientId as getAgencOAuthClientId,
+  normalizeOAuthTokenPayload,
   parseChatgptAccountId,
   decodeJwtPayload,
 } from '../services/api/openAiCodeOAuthShared.js'
@@ -22,12 +23,6 @@ export type AgencCredentialBlob = {
   profileId?: string
   lastRefreshAt?: number
   lastRefreshFailureAt?: number
-}
-
-type AgencTokenRefreshResponse = {
-  access_token?: string
-  refresh_token?: string
-  id_token?: string
 }
 
 let inFlightAgencRefresh:
@@ -325,8 +320,8 @@ export async function refreshAgencAccessTokenIfNeeded(options?: {
         throw new Error(getRefreshErrorMessage(response.status, bodyText))
       }
 
-      const payload = (await response.json()) as AgencTokenRefreshResponse
-      const accessToken = asTrimmedString(payload.access_token)
+      const payload = normalizeOAuthTokenPayload(await response.json())
+      const accessToken = payload.accessToken
       if (!accessToken) {
         throw new Error(
           'Agenc token refresh succeeded without a new access token.',
@@ -336,11 +331,11 @@ export async function refreshAgencAccessTokenIfNeeded(options?: {
       const next: AgencCredentialBlob = {
         accessToken,
         refreshToken:
-          asTrimmedString(payload.refresh_token) ?? refreshToken,
-        idToken: asTrimmedString(payload.id_token) ?? current.idToken,
+          payload.refreshToken ?? refreshToken,
+        idToken: payload.idToken ?? current.idToken,
         accountId:
-          parseChatgptAccountId(payload.id_token) ??
-          parseChatgptAccountId(payload.access_token) ??
+          parseChatgptAccountId(payload.idToken) ??
+          parseChatgptAccountId(payload.accessToken) ??
           current.accountId,
         lastRefreshAt: Date.now(),
       }

--- a/runtime/tests/services/api/openAiCodeOAuthShared.test.ts
+++ b/runtime/tests/services/api/openAiCodeOAuthShared.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  exchangeProviderCodeIdTokenForApiKey,
+} from '../../../src/services/api/openAiCodeOAuthShared.ts'
+
+describe('openAiCodeOAuthShared', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.clearAllMocks()
+  })
+
+  test('exchangeProviderCodeIdTokenForApiKey rejects malformed token payloads predictably', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('null', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    ) as unknown as typeof fetch
+
+    await expect(
+      exchangeProviderCodeIdTokenForApiKey('id-token'),
+    ).rejects.toThrow(
+      'ProviderCode API key exchange completed, but no API key token was returned.',
+    )
+  })
+})

--- a/runtime/tests/utils/agencCredentials.test.ts
+++ b/runtime/tests/utils/agencCredentials.test.ts
@@ -238,6 +238,51 @@ describe('agencCredentials', () => {
     expect(refreshAttempts).toBe(1)
   })
 
+  test('refreshAgencAccessTokenIfNeeded rejects malformed success payloads predictably', async () => {
+    delete process.env.AGENC_SIMPLE
+    delete process.env.AGENC_API_KEY
+
+    const expiredToken = makeJwt({
+      exp: Math.floor((Date.now() - 60_000) / 1000),
+      chatgpt_account_id: 'acct_old',
+    })
+
+    let storageState: Record<string, unknown> = {
+      agenc: {
+        accessToken: expiredToken,
+        refreshToken: 'refresh-old',
+        accountId: 'acct_old',
+      },
+    }
+
+    vi.doMock(secureStorageModulePath, () => ({
+      getSecureStorage: () => ({
+        read: () => storageState,
+        readAsync: async () => storageState,
+        update: (next: Record<string, unknown>) => {
+          storageState = next
+          return { success: true }
+        },
+      }),
+    }))
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response('null', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    ) as unknown as typeof fetch
+
+    const { refreshAgencAccessTokenIfNeeded } =
+      await importFreshAgencCredentialsModule()
+
+    await expect(refreshAgencAccessTokenIfNeeded()).rejects.toThrow(
+      'Agenc token refresh succeeded without a new access token.',
+    )
+  })
+
   test('refreshAgencAccessTokenIfNeeded drops a stale api key when id-token exchange fails', async () => {
     delete process.env.AGENC_SIMPLE
     delete process.env.AGENC_API_KEY


### PR DESCRIPTION
## Summary

- normalize OAuth token JSON payloads through an object guard before reading token fields
- reuse the guard for ProviderCode API-key exchange and AgenC credential refresh
- add regressions for successful JSON `null` token responses so malformed payloads fail with controlled missing-token errors

## Validation

- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/services/api/openAiCodeOAuthShared.test.ts tests/utils/agencCredentials.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `npm outdated --json`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- `npm run validate:runtime`

Closes #1148