### PR TITLE
fix(runtime): guard Ollama courtguard payloads

### DIFF
--- a/runtime/src/transaction-guard/ollama-courtguard.ts
+++ b/runtime/src/transaction-guard/ollama-courtguard.ts
@@ -21,6 +21,28 @@ interface OllamaGenerateResponse {
   };
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function normalizeOllamaGenerateResponse(
+  value: unknown,
+): OllamaGenerateResponse {
+  const record = asRecord(value);
+  if (record === null) return {};
+  const messageRecord = asRecord(record.message);
+  return {
+    ...(typeof record.response === "string"
+      ? { response: record.response }
+      : {}),
+    ...(typeof messageRecord?.content === "string"
+      ? { message: { content: messageRecord.content } }
+      : {}),
+  };
+}
+
 // gaphunt3 #23: Untrusted, attacker-influenced content (the docket and the
 // intermediate defense/prosecution/judge model outputs) is interpolated into
 // triple-backtick-fenced prompt regions. JSON.stringify does not escape the
@@ -149,7 +171,7 @@ export class OllamaCourtGuard implements TransactionGuard {
       if (!response.ok) {
         throw new Error(`Ollama guard request failed with HTTP ${response.status}`);
       }
-      const payload = (await response.json()) as OllamaGenerateResponse;
+      const payload = normalizeOllamaGenerateResponse(await response.json());
       const text =
         typeof payload.message?.content === "string"
           ? payload.message.content

--- a/runtime/tests/transaction-guard/transaction-guard.test.ts
+++ b/runtime/tests/transaction-guard/transaction-guard.test.ts
@@ -57,6 +57,8 @@ const policy: TransactionGuardPolicy = {
   maxDocketBytes: 48 * 1024,
 };
 
+const originalFetch = globalThis.fetch;
+
 function decision(verdict: TransactionGuardDecision["verdict"]): TransactionGuardDecision {
   return {
     allowed: verdict === "benign",
@@ -522,6 +524,38 @@ describe("transaction guard config and docket", () => {
     expect(docket).toContain('"lamports": "10"');
     expect(docket).toContain("[truncated]");
     expect(Buffer.byteLength(docket, "utf8")).toBeLessThanOrEqual(32 * 1024 + 20);
+  });
+});
+
+describe("OllamaCourtGuard", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("fails closed predictably for malformed Ollama response payloads", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("null", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    ) as unknown as typeof fetch;
+
+    const guard = new OllamaCourtGuard(policy);
+    const result = await guard.evaluate({
+      source: "tool-dispatch",
+      kind: "solana_tool_invocation",
+      toolName: "exec_command",
+      command: DEVNET_TRANSFER,
+    });
+
+    expect(result).toMatchObject({
+      allowed: false,
+      verdict: "unavailable",
+      code: TRANSACTION_GUARD_UNAVAILABLE,
+      reason: "Ollama guard returned an empty response",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Normalize Ollama CourtGuard generate responses before reading fields
- Fail closed with the existing empty-response verdict for malformed payloads
- Add a regression test for a JSON null response

Closes #1150

## Verification
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/transaction-guard/transaction-guard.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- npm run validate:runtime