### PR TITLE
fix(runtime): guard GitHub device flow payloads

### DIFF
--- a/runtime/src/services/github/deviceFlow.ts
+++ b/runtime/src/services/github/deviceFlow.ts
@@ -57,6 +57,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
 export async function requestDeviceCode(options?: {
   clientId?: string
   scope?: string
@@ -100,7 +106,7 @@ export async function requestDeviceCode(options?: {
       throw new GitHubDeviceFlowError(lastError)
     }
 
-    const data = (await res.json()) as Record<string, unknown>
+    const data = asRecord(await res.json()) ?? {}
     const device_code = data.device_code
     const user_code = data.user_code
     const verification_uri = data.verification_uri
@@ -162,7 +168,7 @@ export async function pollAccessToken(
         `Token request failed: ${res.status} ${text}`,
       )
     }
-    const data = (await res.json()) as Record<string, unknown>
+    const data = asRecord(await res.json()) ?? {}
     const err = data.error as string | undefined
     if (err == null) {
       const token = data.access_token
@@ -216,18 +222,16 @@ export async function exchangeForCopilotToken(
       `Copilot token exchange failed: ${res.status} ${text}`,
     )
   }
-  const data = (await res.json()) as Record<string, unknown>
+  const data = asRecord(await res.json()) ?? {}
   const token = data.token
   const expires_at = data.expires_at
   const refresh_in = data.refresh_in
-  const endpoints = data.endpoints
+  const endpoints = asRecord(data.endpoints)
   if (
     typeof token !== 'string' ||
     typeof expires_at !== 'number' ||
     typeof refresh_in !== 'number' ||
-    !endpoints ||
-    typeof endpoints !== 'object' ||
-    typeof (endpoints as Record<string, unknown>).api !== 'string'
+    typeof endpoints?.api !== 'string'
   ) {
     throw new GitHubDeviceFlowError('Malformed Copilot token response')
   }
@@ -235,6 +239,6 @@ export async function exchangeForCopilotToken(
     token,
     expires_at,
     refresh_in,
-    endpoints: endpoints as { api: string },
+    endpoints: { api: endpoints.api },
   }
 }

--- a/runtime/tests/services/github/deviceFlow.test.ts
+++ b/runtime/tests/services/github/deviceFlow.test.ts
@@ -58,6 +58,18 @@ describe('requestDeviceCode', () => {
     ).rejects.toThrow(GitHubDeviceFlowError)
   })
 
+  test('throws controlled error for malformed successful device code payload', async () => {
+    const { requestDeviceCode } = await importFreshModule()
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('null', { status: 200 })),
+    )
+
+    await expect(
+      requestDeviceCode({ clientId: 'test-client', fetchImpl }),
+    ).rejects.toThrow(/Malformed device code response/)
+  })
+
   test('uses OAuth-safe default scope', async () => {
     let capturedScope = ''
     const fetchImpl = mock((_url: RequestInfo | URL, init?: RequestInit) => {
@@ -173,6 +185,21 @@ describe('pollAccessToken', () => {
       }),
     ).rejects.toThrow(/denied/)
   })
+
+  test('throws controlled error for malformed successful access-token payload', async () => {
+    const { pollAccessToken } = await importFreshModule()
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('null', { status: 200 })),
+    )
+
+    await expect(
+      pollAccessToken('dc', {
+        clientId: 'c',
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/No access_token/)
+  })
 })
 
 describe('exchangeForCopilotToken', () => {
@@ -225,5 +252,17 @@ describe('exchangeForCopilotToken', () => {
     await expect(
       exchangeForCopilotToken('oauth-token', fetchImpl),
     ).rejects.toThrow(/Malformed/)
+  })
+
+  test('throws controlled error for malformed successful Copilot token payload', async () => {
+    const { exchangeForCopilotToken } = await importFreshModule()
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('null', { status: 200 })),
+    )
+
+    await expect(
+      exchangeForCopilotToken('oauth-token', fetchImpl),
+    ).rejects.toThrow(/Malformed Copilot token response/)
   })
 })


### PR DESCRIPTION
## Summary
- Normalize GitHub device flow and Copilot token JSON responses before field access
- Keep malformed successful payloads on controlled GitHubDeviceFlowError paths
- Add regressions for JSON null responses across device-code, access-token polling, and Copilot token exchange

Closes #1152

## Verification
- bun test runtime/tests/services/github/deviceFlow.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- npm run validate:runtime