### PR TITLE
fix(runtime): guard web search payloads

### DIFF
--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -1894,16 +1894,23 @@ function createWebTools(opts: ModelFacingToolOptions): readonly Tool[] {
             ? `${endpoint}${endpoint.includes("?") ? "&" : "?"}q=${encodeURIComponent(query)}`
             : `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
         const response = await fetchWithTimeout(searchUrl);
-        const raw = (await response.json()) as Record<string, unknown>;
-        const related = Array.isArray(raw.RelatedTopics) ? raw.RelatedTopics : [];
+        const raw = recordValue(await response.json().catch(() => undefined)) ?? {};
+        const related = arrayValue(raw.RelatedTopics);
         const results = filterWebSearchResults(related
           .flatMap((entry): Array<Record<string, unknown>> => {
-            if (entry && typeof entry === "object" && Array.isArray((entry as Record<string, unknown>).Topics)) {
-              return (entry as { Topics: Array<Record<string, unknown>> }).Topics;
+            const record = recordValue(entry);
+            if (!record) {
+              return [];
             }
-            return entry && typeof entry === "object"
-              ? [entry as Record<string, unknown>]
-              : [];
+            const topics = arrayValue(record.Topics)
+              .flatMap((topic): Array<Record<string, unknown>> => {
+                const topicRecord = recordValue(topic);
+                return topicRecord ? [topicRecord] : [];
+              });
+            if (topics.length > 0) {
+              return topics;
+            }
+            return [record];
           })
           .map((entry) => ({
             title: stringValue(entry.Text)?.split(" - ")[0] ?? stringValue(entry.Result) ?? "",

--- a/runtime/tests/tool-registry.test.ts
+++ b/runtime/tests/tool-registry.test.ts
@@ -358,6 +358,102 @@ describe("tool-registry dynamic and deferred catalog", () => {
     }
   });
 
+  test("model-facing WebSearch handles malformed successful response payloads", async () => {
+    const previousFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue(new Response("null", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      const registry = buildToolRegistry({
+        workspaceRoot: "/tmp",
+        modelFacingTools: createModelFacingTools({
+          workspaceRoot: "/tmp",
+          getSession: () => null,
+          env: {
+            AGENC_WEB_SEARCH_ENDPOINT: "https://search.example/api",
+          } as NodeJS.ProcessEnv,
+        }),
+      });
+
+      const result = await registry.dispatch({
+        id: "web-search-null",
+        name: "WebSearch",
+        arguments: JSON.stringify({ query: "agenc" }),
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toMatchObject({
+        query: "agenc",
+        source: "https://search.example/api",
+        results: [],
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("model-facing WebSearch skips malformed grouped RelatedTopics entries", async () => {
+    const previousFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          Heading: "Search heading",
+          AbstractText: "Search abstract",
+          RelatedTopics: [
+            {
+              Topics: [
+                null,
+                {
+                  Text: "Example title - Example snippet",
+                  FirstURL: "https://example.com/result",
+                },
+              ],
+            },
+            null,
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      const registry = buildToolRegistry({
+        workspaceRoot: "/tmp",
+        modelFacingTools: createModelFacingTools({
+          workspaceRoot: "/tmp",
+          getSession: () => null,
+          env: {
+            AGENC_WEB_SEARCH_ENDPOINT: "https://search.example/api",
+          } as NodeJS.ProcessEnv,
+        }),
+      });
+
+      const result = await registry.dispatch({
+        id: "web-search-grouped",
+        name: "WebSearch",
+        arguments: JSON.stringify({ query: "agenc" }),
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toMatchObject({
+        answer: "Search abstract",
+        heading: "Search heading",
+        results: [
+          {
+            title: "Example title",
+            url: "https://example.com/result",
+            snippet: "Example title - Example snippet",
+          },
+        ],
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test("apply_patch is deferred but dispatch accepts raw patch strings", async () => {
     const root = await mkdtemp(join(tmpdir(), "agenc-registry-apply-patch-"));
     const registry = buildToolRegistry({ workspaceRoot: root });


### PR DESCRIPTION
## Summary
- Normalize model-facing WebSearch fallback JSON before field access
- Skip malformed grouped RelatedTopics entries instead of throwing
- Add registry dispatch regressions for JSON null and malformed grouped search results

Closes #1154

## Verification
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tool-registry.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- npm run validate:runtime