### PR TITLE
fix(runtime): guard OpenAI shim response payloads

### DIFF
--- a/runtime/src/services/api/openaiShim.ts
+++ b/runtime/src/services/api/openaiShim.ts
@@ -138,6 +138,29 @@ const SENSITIVE_URL_QUERY_PARAM_NAMES = [
   'authorization',
 ]
 
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+async function readJsonObjectResponse(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    return recordValue(await response.json())
+  } catch {
+    return null
+  }
+}
+
+function malformedJsonResponseError(response: Response): APIError {
+  return APIError.generate(
+    response.status,
+    undefined,
+    `OpenAi API error ${response.status}: malformed JSON response payload`,
+    response.headers as unknown as Headers,
+  )
+}
+
 function isGithubModelsMode(): boolean {
   return isEnvTruthy(process.env.AGENC_USE_GITHUB)
 }
@@ -1571,10 +1594,11 @@ class OpenAiShimMessages {
       ) {
         const contentType = response.headers.get('content-type') ?? ''
         if (contentType.includes('application/json')) {
-          const parsed = await response.json() as Record<string, unknown>
+          const parsed = await readJsonObjectResponse(response)
+          if (parsed === null) {
+            throw malformedJsonResponseError(response)
+          }
           if (
-            parsed &&
-            typeof parsed === 'object' &&
             ('output' in parsed || 'incomplete_details' in parsed)
           ) {
             return convertProviderCodeResponseToproviderMessage(
@@ -1588,7 +1612,10 @@ class OpenAiShimMessages {
 
       const contentType = response.headers.get('content-type') ?? ''
       if (contentType.includes('application/json')) {
-        const data = await response.json()
+        const data = await readJsonObjectResponse(response)
+        if (data === null) {
+          throw malformedJsonResponseError(response)
+        }
         return self._convertNonStreamingResponse(data, request.resolvedModel)
       }
 

--- a/runtime/tests/services/api/openaiShim.test.ts
+++ b/runtime/tests/services/api/openaiShim.test.ts
@@ -242,6 +242,51 @@ test('uses provider-compatible responses endpoint when OPENAI_API_FORMAT=respons
   ])
 })
 
+test('throws controlled error for malformed successful chat-completions JSON payload', async () => {
+  globalThis.fetch = (async () =>
+    new Response('null', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })) as FetchType
+
+  const client = createOpenAiShimClient({ defaultHeaders: {} }) as OpenAiShimClient
+
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-4o',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    }),
+  ).rejects.toThrow('malformed JSON response payload')
+})
+
+test('throws controlled error for malformed successful responses JSON payload', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  globalThis.fetch = (async () =>
+    new Response('null', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })) as FetchType
+
+  const client = createOpenAiShimClient({ defaultHeaders: {} }) as OpenAiShimClient
+
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-5.4',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    }),
+  ).rejects.toThrow('malformed JSON response payload')
+})
+
 test('strips store from strict provider-compatible responses providers', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
   process.env.OPENAI_API_FORMAT = 'responses'


### PR DESCRIPTION
## Summary
- guard successful non-streaming OpenAI shim JSON responses so only top-level objects reach converters
- return a controlled API error for malformed JSON payloads from chat-completions and responses-format endpoints
- add regression coverage for null JSON payloads on both non-streaming paths

Closes #1156

## Verification
- bun test runtime/tests/services/api/openaiShim.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook: runtime build + PTY startup smoke