### PR TITLE
fix(runtime): guard web search provider JSON

### DIFF
--- a/runtime/src/tools/WebSearchTool/providers/bing.ts
+++ b/runtime/src/tools/WebSearchTool/providers/bing.ts
@@ -10,6 +10,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   recordField,
   type ProviderOutput,
 } from './types.js'
@@ -37,7 +38,7 @@ export const bingProvider: SearchProvider = {
       throw new Error(`Bing search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'Bing search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const hits = normalizeHits(arrayField(recordField(record, 'webPages'), 'value'))
 

--- a/runtime/src/tools/WebSearchTool/providers/custom.ts
+++ b/runtime/src/tools/WebSearchTool/providers/custom.ts
@@ -32,8 +32,10 @@ import {
   applyDomainFilters,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   recordField,
   safeHostname,
+  SearchProviderMalformedJsonError,
   type ProviderOutput,
   type SearchHit,
 } from './types.js'
@@ -551,12 +553,13 @@ async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSign
         lastStatus = res.status
         throw new Error(`Custom search API returned ${res.status}: ${res.statusText}`)
       }
-      return await res.json()
+      return await readSearchProviderJson(res, 'Custom search API')
     } catch (err) {
       lastErr = err instanceof Error ? err : new Error(String(err))
 
       // Caller-initiated abort wins — propagate without retry or rewrite.
       if (signal?.aborted) throw lastErr
+      if (lastErr instanceof SearchProviderMalformedJsonError) throw lastErr
 
       // Timeout (TimeoutError on Bun/Node, or AbortError with timeoutSignal aborted).
       if (timeoutSignal.aborted) {

--- a/runtime/src/tools/WebSearchTool/providers/exa.ts
+++ b/runtime/src/tools/WebSearchTool/providers/exa.ts
@@ -8,6 +8,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   type ProviderOutput,
 } from './types.js'
 
@@ -43,7 +44,7 @@ export const exaProvider: SearchProvider = {
     if (!res.ok) {
       throw new Error(`Exa search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'Exa search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const hits = normalizeHits(arrayField(record, 'results'), {
       inferSourceFromUrl: true,

--- a/runtime/src/tools/WebSearchTool/providers/jina.ts
+++ b/runtime/src/tools/WebSearchTool/providers/jina.ts
@@ -10,6 +10,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   type ProviderOutput,
 } from './types.js'
 
@@ -39,7 +40,7 @@ export const jinaProvider: SearchProvider = {
       throw new Error(`Jina search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'Jina search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const rawHits =
       record && 'data' in record

--- a/runtime/src/tools/WebSearchTool/providers/linkup.ts
+++ b/runtime/src/tools/WebSearchTool/providers/linkup.ts
@@ -10,6 +10,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   type ProviderOutput,
 } from './types.js'
 
@@ -41,7 +42,7 @@ export const linkupProvider: SearchProvider = {
       throw new Error(`Linkup search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'Linkup search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const hits = normalizeHits(arrayField(record, 'results'), {
       inferSourceFromUrl: true,

--- a/runtime/src/tools/WebSearchTool/providers/mojeek.ts
+++ b/runtime/src/tools/WebSearchTool/providers/mojeek.ts
@@ -10,6 +10,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   recordField,
   type ProviderOutput,
 } from './types.js'
@@ -42,7 +43,7 @@ export const mojeekProvider: SearchProvider = {
       throw new Error(`Mojeek search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'Mojeek search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const rawResults =
       record && 'response' in record

--- a/runtime/src/tools/WebSearchTool/providers/tavily.ts
+++ b/runtime/src/tools/WebSearchTool/providers/tavily.ts
@@ -10,6 +10,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   type ProviderOutput,
 } from './types.js'
 
@@ -41,7 +42,7 @@ export const tavilyProvider: SearchProvider = {
       throw new Error(`Tavily search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'Tavily search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const hits = normalizeHits(arrayField(record, 'results'), {
       inferSourceFromUrl: true,

--- a/runtime/src/tools/WebSearchTool/providers/types.ts
+++ b/runtime/src/tools/WebSearchTool/providers/types.ts
@@ -40,6 +40,24 @@ export interface SearchProvider {
   search(input: SearchInput, signal?: AbortSignal): Promise<ProviderOutput>
 }
 
+export class SearchProviderMalformedJsonError extends Error {
+  constructor(source: string) {
+    super(`${source} returned malformed JSON response`)
+    this.name = 'SearchProviderMalformedJsonError'
+  }
+}
+
+export async function readSearchProviderJson(
+  response: Response,
+  source: string,
+): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    throw new SearchProviderMalformedJsonError(source)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Flexible response parsing helpers
 // ---------------------------------------------------------------------------

--- a/runtime/src/tools/WebSearchTool/providers/you.ts
+++ b/runtime/src/tools/WebSearchTool/providers/you.ts
@@ -10,6 +10,7 @@ import {
   arrayField,
   isSearchProviderJsonRecord,
   normalizeHits,
+  readSearchProviderJson,
   type ProviderOutput,
 } from './types.js'
 
@@ -36,7 +37,7 @@ export const youProvider: SearchProvider = {
       throw new Error(`You.com search error ${res.status}: ${await res.text().catch(() => '')}`)
     }
 
-    const data: unknown = await res.json()
+    const data = await readSearchProviderJson(res, 'You.com search API')
     const record = isSearchProviderJsonRecord(data) ? data : undefined
     const results = record?.['results']
     const webResults = isSearchProviderJsonRecord(results)

--- a/runtime/tests/tools/WebSearchTool/providers/custom.test.ts
+++ b/runtime/tests/tools/WebSearchTool/providers/custom.test.ts
@@ -205,6 +205,52 @@ describe('buildAuthHeadersForPreset direct assertions', () => {
 })
 
 // ---------------------------------------------------------------------------
+// customProvider.search — successful malformed JSON boundary
+// ---------------------------------------------------------------------------
+
+describe('customProvider search response parsing', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+  const originalFetch = globalThis.fetch
+  const originalWarn = console.warn
+
+  beforeEach(() => {
+    for (const k of ['WEB_SEARCH_API', 'WEB_PROVIDER', 'WEB_URL_TEMPLATE']) {
+      savedEnv[k] = process.env[k]
+    }
+    console.warn = () => {}
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+    globalThis.fetch = originalFetch
+    console.warn = originalWarn
+  })
+
+  test('throws controlled error for malformed successful JSON responses without retrying', async () => {
+    process.env.WEB_SEARCH_API = 'https://search.example/api'
+    delete process.env.WEB_PROVIDER
+    delete process.env.WEB_URL_TEMPLATE
+
+    let calls = 0
+    globalThis.fetch = (async () => {
+      calls += 1
+      return new Response('<html>not json</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    }) as typeof fetch
+
+    await expect(customProvider.search({ query: 'agent security' })).rejects.toThrow(
+      'Custom search API returned malformed JSON response',
+    )
+    expect(calls).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // isPrivateHostname — SSRF guard
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add a shared web-search provider JSON parser that reports malformed successful responses deterministically
- route fetch-backed search adapters through the shared parser
- prevent the custom provider from retrying malformed 200 responses as transient failures

Closes #1158

## Verification
- bun test runtime/tests/tools/WebSearchTool/providers/custom.test.ts
- bun test runtime/tests/tools/WebSearchTool/providers/index.test.ts runtime/tests/tools/WebSearchTool/providers/types.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook: runtime build + PTY startup smoke