### PR TITLE
fix(runtime): normalize nested tool input JSON

### DIFF
--- a/runtime/src/utils/messages.ts
+++ b/runtime/src/utils/messages.ts
@@ -5,6 +5,7 @@
 // for this 5486-line file is deferred to a dedicated typecheck-foundation
 // item.
 import { feature } from 'bun:bundle'
+import { Ajv } from 'ajv'
 import { getAPIProvider } from './model/providers.js'
 import type { BetaUsage as Usage } from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
 import type { StreamingToolUse } from '../llm/types.js'
@@ -2684,6 +2685,135 @@ export function mergeUserContentBlocks(
   return [...a.slice(0, -1), smooshed, ...toolResults]
 }
 
+let nestedToolInputAjv: Ajv | null = null
+const nestedToolInputValidators = new WeakMap<object, (value: unknown) => boolean>()
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isJsonSchemaObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null
+}
+
+function getNestedToolInputValidator(
+  schema: object,
+): ((value: unknown) => boolean) | null {
+  const cached = nestedToolInputValidators.get(schema)
+  if (cached) {
+    return cached
+  }
+
+  try {
+    const ajv = (nestedToolInputAjv ??= new Ajv({ strict: false }))
+    const validator = ajv.compile(schema)
+    const validate = (value: unknown): boolean => validator(value) === true
+    nestedToolInputValidators.set(schema, validate)
+    return validate
+  } catch {
+    return null
+  }
+}
+
+function toolInputMatchesSchema(tool: Tool, input: unknown): boolean {
+  if (isJsonSchemaObject(tool.inputJSONSchema)) {
+    const validate = getNestedToolInputValidator(tool.inputJSONSchema)
+    if (validate) {
+      return validate(input)
+    }
+  }
+
+  const schema = tool.inputSchema as {
+    safeParse?: (value: unknown) => { success: boolean }
+    parse?: (value: unknown) => unknown
+  }
+
+  if (typeof schema.safeParse === 'function') {
+    try {
+      return schema.safeParse(input).success === true
+    } catch {
+      return false
+    }
+  }
+
+  if (typeof schema.parse === 'function') {
+    try {
+      schema.parse(input)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  return false
+}
+
+function parseJsonStructuredString(value: string): unknown {
+  let current: unknown = value
+
+  for (let depth = 0; depth < 8; depth++) {
+    if (typeof current !== 'string') {
+      break
+    }
+
+    const trimmed = current.trim()
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+      break
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (
+        typeof parsed === 'string' ||
+        Array.isArray(parsed) ||
+        isRecordValue(parsed)
+      ) {
+        current = parsed
+        continue
+      }
+      break
+    } catch {
+      break
+    }
+  }
+
+  return current
+}
+
+function decodeNestedJsonStrings(value: unknown, depth = 0): unknown {
+  if (depth > 32) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = parseJsonStructuredString(value)
+    return parsed === value ? value : decodeNestedJsonStrings(parsed, depth + 1)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => decodeNestedJsonStrings(item, depth + 1))
+  }
+
+  if (isRecordValue(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        decodeNestedJsonStrings(entry, depth + 1),
+      ]),
+    )
+  }
+
+  return value
+}
+
+function normalizeNestedToolInput(tool: Tool, input: unknown): unknown {
+  const decoded = decodeNestedJsonStrings(input)
+  if (decoded === input || toolInputMatchesSchema(tool, input)) {
+    return input
+  }
+  return toolInputMatchesSchema(tool, decoded) ? decoded : input
+}
+
 // Sometimes the API returns empty messages (eg. "\n\n"). We need to filter these out,
 // otherwise they will give an API error when we send them to the API next time we call query().
 export function normalizeContentFromAPI(
@@ -2705,11 +2835,12 @@ export function normalizeContentFromAPI(
           throw new Error('Tool use input must be a string or object')
         }
 
-        // With fine-grained streaming on, we are getting a stringied JSON back from the API.
+        // With fine-grained streaming on, we are getting stringified JSON back from the API.
         // The API has strange behaviour, where it returns nested stringified JSONs, and so
         // we need to recursively parse these. If the top-level value returned from the API is
         // an empty string, this should become an empty object (nested values should be empty string).
-        // Follow-up: This needs patching as recursive fields can still be stringified
+        // Nested object/array fields are decoded after tool lookup so the tool schema can
+        // prove that the decoded shape is preferable to the original string shape.
         let normalizedInput: unknown
         if (typeof contentBlock.input === 'string') {
           const parsed = safeParseJSON(contentBlock.input)
@@ -2730,9 +2861,13 @@ export function normalizeContentFromAPI(
           normalizedInput = contentBlock.input
         }
 
+        const tool = findToolByName(tools, contentBlock.name)
+        if (tool) {
+          normalizedInput = normalizeNestedToolInput(tool, normalizedInput)
+        }
+
         // Then apply tool-specific corrections
         if (typeof normalizedInput === 'object' && normalizedInput !== null) {
-          const tool = findToolByName(tools, contentBlock.name)
           if (tool) {
             try {
               normalizedInput = normalizeToolInput(

--- a/runtime/tests/conversation/messages-core.test.ts
+++ b/runtime/tests/conversation/messages-core.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, test } from "vitest";
 
 import { createAttachmentMessage } from "../../src/utils/attachments.js";
 import { getImageTooLargeErrorMessage } from "../../src/services/api/errors.js";
+import { CanonicalFileWriteTool } from "../../src/tools/canonicalToolSurface.js";
+import { MCPTool } from "../../src/tools/MCPTool/MCPTool.js";
+import { TodoWriteTool } from "../../src/tools/TodoWriteTool/TodoWriteTool.js";
 import {
   AUTO_REJECT_MESSAGE,
   buildMessageLookups,
@@ -727,6 +730,88 @@ describe("message utility constructors and predicates", () => {
       type: "server_tool_use",
       input: { query: "docs" },
     });
+
+    const normalizedNestedApiContent = normalizeContentFromAPI(
+      [
+        {
+          type: "tool_use",
+          id: "tu_todo",
+          name: "TodoWrite",
+          input: JSON.stringify({
+            todos: JSON.stringify([
+              {
+                content: "Guard nested JSON normalization",
+                status: "pending",
+                activeForm: "Guarding nested JSON normalization",
+              },
+            ]),
+          }),
+        },
+      ] as never,
+      [TodoWriteTool] as never,
+    );
+    expect(normalizedNestedApiContent[0]).toMatchObject({
+      type: "tool_use",
+      input: {
+        todos: [
+          {
+            content: "Guard nested JSON normalization",
+            status: "pending",
+            activeForm: "Guarding nested JSON normalization",
+          },
+        ],
+      },
+    });
+
+    const normalizedWriteContent = normalizeContentFromAPI(
+      [
+        {
+          type: "tool_use",
+          id: "tu_write",
+          name: "Write",
+          input: JSON.stringify({
+            file_path: "/tmp/data.json",
+            content: JSON.stringify({ keep: true }),
+          }),
+        },
+      ] as never,
+      [CanonicalFileWriteTool] as never,
+    );
+    expect(normalizedWriteContent[0]).toMatchObject({
+      type: "tool_use",
+      input: {
+        file_path: "/tmp/data.json",
+        content: "{\"keep\":true}",
+      },
+    });
+
+    const mcpArrayTool = Object.assign(Object.create(MCPTool), {
+      name: "mcp__demo__list",
+      inputJSONSchema: {
+        type: "object",
+        properties: {
+          items: { type: "array", items: { type: "string" } },
+        },
+        required: ["items"],
+        additionalProperties: false,
+      },
+    });
+    const normalizedSchemaOnlyContent = normalizeContentFromAPI(
+      [
+        {
+          type: "tool_use",
+          id: "tu_mcp",
+          name: "mcp__demo__list",
+          input: JSON.stringify({ items: JSON.stringify(["alpha", "beta"]) }),
+        },
+      ] as never,
+      [mcpArrayTool] as never,
+    );
+    expect(normalizedSchemaOnlyContent[0]).toMatchObject({
+      type: "tool_use",
+      input: { items: ["alpha", "beta"] },
+    });
+
     expect(() =>
       normalizeContentFromAPI(
         [{ type: "tool_use", id: "bad", name: "Bash", input: 3 }] as never,


### PR DESCRIPTION
## Summary
- Decode nested JSON string fields in model-returned tool inputs only when the tool schema rejects the original shape and accepts the decoded shape.
- Validate both Zod-backed tools and JSON Schema-backed MCP-style tools before adopting decoded input.
- Add regressions for TodoWrite nested arrays, MCP JSON Schema input, and preserving legitimate JSON-looking Write content strings.

## Verification
- bun test runtime/tests/conversation/messages-core.test.ts
- bun test runtime/tests/conversation/messages-core.test.ts runtime/tests/tools/MCPTool/MCPTool.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime

Closes #1160