### PR TITLE
fix(runtime): guard remote auth JSON responses

### DIFF
--- a/runtime/src/auth/backends/remote.ts
+++ b/runtime/src/auth/backends/remote.ts
@@ -357,7 +357,10 @@ function createHttpRemoteAuthKeyVendor(
         `RemoteAuthBackend key vending failed with HTTP ${response.status}`,
       );
     }
-    return parseRemoteAuthVendKeyResponse(await response.json(), request);
+    return parseRemoteAuthVendKeyResponse(
+      await readRemoteAuthJsonResponse(response, "key vending"),
+      request,
+    );
   };
 }
 
@@ -390,7 +393,7 @@ function createHttpRemoteAuthLoginFlow(
       );
     }
     const started = parseRemoteAuthLoginStartResponse(
-      await startResponse.json(),
+      await readRemoteAuthJsonResponse(startResponse, "login start"),
     );
     if ("token" in started) return started;
     await notifyRemoteAuthDeviceCode(options.onDeviceCode, started);
@@ -488,7 +491,9 @@ function createHttpRemoteAuthModelInferer(
         `RemoteAuthBackend hosted model routing failed with HTTP ${response.status}`,
       );
     }
-    return parseRemoteAuthModelInferenceResponse(await response.json());
+    return parseRemoteAuthModelInferenceResponse(
+      await readRemoteAuthJsonResponse(response, "hosted model routing"),
+    );
   };
 }
 
@@ -517,7 +522,9 @@ function createHttpRemoteAuthSubscriptionTierResolver(
         `RemoteAuthBackend subscription tier lookup failed with HTTP ${response.status}`,
       );
     }
-    return parseRemoteAuthSubscriptionTierResponse(await response.json());
+    return parseRemoteAuthSubscriptionTierResponse(
+      await readRemoteAuthJsonResponse(response, "subscription tier lookup"),
+    );
   };
 }
 
@@ -658,7 +665,21 @@ async function readRemoteAuthPollResponse(response: Response): Promise<unknown> 
   try {
     return await response.json();
   } catch {
+    if (response.ok) {
+      throw new Error("RemoteAuthBackend login poll returned invalid JSON");
+    }
     return undefined;
+  }
+}
+
+async function readRemoteAuthJsonResponse(
+  response: Response,
+  operation: string,
+): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`RemoteAuthBackend ${operation} returned invalid JSON`);
   }
 }
 

--- a/runtime/tests/auth/backends/remote.contract.test.ts
+++ b/runtime/tests/auth/backends/remote.contract.test.ts
@@ -12,6 +12,10 @@ const REMOTE_AUTH_TIER_URL_ENV = "AGENC_REMOTE_AUTH_TIER_URL";
 const REMOTE_AUTH_TOKEN_ENV = "AGENC_REMOTE_AUTH_TOKEN";
 const REMOTE_AUTH_URL_ENV = "AGENC_REMOTE_AUTH_URL";
 
+function invalidJsonResponse(): Response {
+  return new Response("not-json", { status: 200 });
+}
+
 describe("RemoteAuthBackend", () => {
   it("persists a long-lived token returned by the configured login flow", async () => {
     const agencHome = await mkdtemp(join(tmpdir(), "agenc-remote-auth-"));
@@ -579,6 +583,71 @@ describe("RemoteAuthBackend", () => {
     await expect(sessionMismatch.vendKey("grok", "session-1")).rejects.toThrow(
       /session mismatch/,
     );
+  });
+
+  it("rejects malformed successful HTTP JSON with remote auth errors", async () => {
+    const agencHome = await mkdtemp(join(tmpdir(), "agenc-remote-auth-"));
+
+    try {
+      const keyBackend = new RemoteAuthBackend({
+        agencHome,
+        managedKeysEnabled: true,
+        env: { [REMOTE_AUTH_TOKEN_ENV]: "remote-token" },
+        fetchImpl: vi.fn(async () => invalidJsonResponse()),
+      });
+      await expect(keyBackend.vendKey("grok", "session-1")).rejects.toThrow(
+        "RemoteAuthBackend key vending returned invalid JSON",
+      );
+
+      const loginStartBackend = new RemoteAuthBackend({
+        agencHome,
+        fetchImpl: vi.fn(async () => invalidJsonResponse()),
+      });
+      await expect(loginStartBackend.login({ sessionId: "cli" })).rejects.toThrow(
+        "RemoteAuthBackend login start returned invalid JSON",
+      );
+
+      const loginPollBackend = new RemoteAuthBackend({
+        agencHome,
+        fetchImpl: vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ deviceCode: "device-1" }), {
+              status: 200,
+            }),
+          )
+          .mockResolvedValueOnce(invalidJsonResponse()),
+      });
+      await expect(loginPollBackend.login({ sessionId: "cli" })).rejects.toThrow(
+        "RemoteAuthBackend login poll returned invalid JSON",
+      );
+
+      const modelBackend = new RemoteAuthBackend({
+        agencHome,
+        env: { [REMOTE_AUTH_TOKEN_ENV]: "remote-token" },
+        fetchImpl: vi.fn(async () => invalidJsonResponse()),
+      });
+      await expect(
+        modelBackend.inferAgencModel({
+          provider: "agenc",
+          requestedModel: "agenc",
+          sessionId: "session-1",
+        }),
+      ).rejects.toThrow(
+        "RemoteAuthBackend hosted model routing returned invalid JSON",
+      );
+
+      const tierBackend = new RemoteAuthBackend({
+        agencHome,
+        env: { [REMOTE_AUTH_TOKEN_ENV]: "remote-token" },
+        fetchImpl: vi.fn(async () => invalidJsonResponse()),
+      });
+      await expect(tierBackend.getSubscriptionTier()).rejects.toThrow(
+        "RemoteAuthBackend subscription tier lookup returned invalid JSON",
+      );
+    } finally {
+      await rm(agencHome, { recursive: true, force: true });
+    }
   });
 
   it("infers hosted AgenC model aliases through the configured model inferer", async () => {


### PR DESCRIPTION
## Summary
- add explicit invalid-JSON handling for successful remote auth HTTP responses
- preserve non-OK login poll fallback behavior while surfacing malformed successful poll responses
- add contract coverage for key vending, login start, login poll, hosted model routing, and subscription tier lookup

Closes #1162

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/auth/backends/remote.contract.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm run test:bun
- npm test
- npm run validate:runtime
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000