### PR TITLE
fix(runtime): guard startup internal events

### DIFF
--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -108,19 +108,7 @@ import {
   buildBootstrapSessionServices,
   type BootstrapSessionServicesHandle,
 } from "./bootstrap-services.js";
-
-type StartupInternalEvent = {
-  readonly payload: Record<string, unknown>;
-  readonly agent_id?: string;
-};
-
-type StartupInternalEventPage = {
-  readonly data?: ReadonlyArray<{
-    readonly payload?: Record<string, unknown> | null;
-    readonly agent_id?: string;
-  }>;
-  readonly next_cursor?: string;
-};
+import { fetchStartupInternalEvents } from "./startup-internal-events.js";
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
@@ -382,49 +370,6 @@ function parseWorkerEpoch(env: NodeJS.ProcessEnv): number | null {
     return null;
   }
   return parsed;
-}
-
-async function fetchStartupInternalEvents(params: {
-  readonly sessionBaseUrl: string;
-  readonly headers: Record<string, string>;
-  readonly subagents?: boolean;
-}): Promise<StartupInternalEvent[] | null> {
-  const allEvents: StartupInternalEvent[] = [];
-  let cursor: string | undefined;
-
-  while (true) {
-    const url = new URL(
-      `${params.sessionBaseUrl}/worker/internal-events`,
-    );
-    if (params.subagents) {
-      url.searchParams.set("subagents", "true");
-    }
-    if (cursor) {
-      url.searchParams.set("cursor", cursor);
-    }
-
-    const response = await fetch(url, {
-      headers: params.headers,
-    });
-    if (!response.ok) {
-      return null;
-    }
-
-    const page = (await response.json()) as StartupInternalEventPage;
-    for (const event of page.data ?? []) {
-      if (event.payload) {
-        allEvents.push({
-          payload: event.payload,
-          ...(event.agent_id ? { agent_id: event.agent_id } : {}),
-        });
-      }
-    }
-
-    if (!page.next_cursor) {
-      return allEvents;
-    }
-    cursor = page.next_cursor;
-  }
 }
 
 async function writeStartupInternalEvent(params: {

--- a/runtime/src/bin/startup-internal-events.ts
+++ b/runtime/src/bin/startup-internal-events.ts
@@ -1,0 +1,96 @@
+type StartupInternalEvent = {
+  readonly payload: Record<string, unknown>;
+  readonly agent_id?: string;
+};
+
+const MAX_STARTUP_INTERNAL_EVENT_PAGES = 1000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeStartupInternalEventPage(
+  value: unknown,
+):
+  | { readonly events: StartupInternalEvent[]; readonly nextCursor?: string }
+  | null {
+  if (!isRecord(value)) return null;
+
+  const rawData = value.data;
+  const events: StartupInternalEvent[] = [];
+  if (rawData !== undefined) {
+    if (!Array.isArray(rawData)) return null;
+    for (const rawEvent of rawData) {
+      if (!isRecord(rawEvent) || !isRecord(rawEvent.payload)) continue;
+      events.push({
+        payload: rawEvent.payload,
+        ...(typeof rawEvent.agent_id === "string"
+          ? { agent_id: rawEvent.agent_id }
+          : {}),
+      });
+    }
+  }
+
+  const rawCursor = value.next_cursor;
+  if (rawCursor === undefined || rawCursor === null || rawCursor === "") {
+    return { events };
+  }
+  if (typeof rawCursor !== "string") return null;
+  return { events, nextCursor: rawCursor };
+}
+
+export async function fetchStartupInternalEvents(params: {
+  readonly sessionBaseUrl: string;
+  readonly headers: Record<string, string>;
+  readonly subagents?: boolean;
+}): Promise<StartupInternalEvent[] | null> {
+  const allEvents: StartupInternalEvent[] = [];
+  let cursor: string | undefined;
+  const seenCursors = new Set<string>();
+
+  for (
+    let pageCount = 0;
+    pageCount < MAX_STARTUP_INTERNAL_EVENT_PAGES;
+    pageCount++
+  ) {
+    const url = new URL(`${params.sessionBaseUrl}/worker/internal-events`);
+    if (params.subagents) {
+      url.searchParams.set("subagents", "true");
+    }
+    if (cursor) {
+      url.searchParams.set("cursor", cursor);
+    }
+
+    const response = await fetch(url, {
+      headers: params.headers,
+    });
+    if (!response.ok) {
+      return null;
+    }
+
+    let rawPage: unknown;
+    try {
+      rawPage = await response.json();
+    } catch {
+      return null;
+    }
+
+    const page = normalizeStartupInternalEventPage(rawPage);
+    if (page === null) {
+      return null;
+    }
+
+    allEvents.push(...page.events);
+
+    if (!page.nextCursor) {
+      return allEvents;
+    }
+    if (seenCursors.has(page.nextCursor)) {
+      return null;
+    }
+    seenCursors.add(page.nextCursor);
+    cursor = page.nextCursor;
+  }
+
+  return null;
+}

--- a/runtime/tests/bin/bootstrap.session-ingress.test.ts
+++ b/runtime/tests/bin/bootstrap.session-ingress.test.ts
@@ -29,6 +29,7 @@ vi.mock("./_deps/session-ingress-auth.js", () => ({
 }));
 
 import { bootstrapLocalRuntimeSession } from "./bootstrap.js";
+import { fetchStartupInternalEvents } from "./startup-internal-events.js";
 import { Session } from "../session/session.js";
 
 type InternalEventReader = () => Promise<
@@ -302,6 +303,65 @@ describe("bootstrapLocalRuntimeSession session-ingress startup wiring", () => {
         /* best effort */
       });
     }
+  });
+
+  it("returns null instead of throwing for malformed successful internal-event JSON", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+    });
+
+    await expect(
+      fetchStartupInternalEvents({
+        sessionBaseUrl: "https://api.example.test/v1/code/sessions/cse_session_123",
+        headers: { Authorization: "Bearer worker-jwt" },
+      }),
+    ).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null for malformed internal-event page envelopes", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { payload: { uuid: "not-an-array" } },
+      }),
+    });
+
+    await expect(
+      fetchStartupInternalEvents({
+        sessionBaseUrl: "https://api.example.test/v1/code/sessions/cse_session_123",
+        headers: { Authorization: "Bearer worker-jwt" },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when internal-event pagination repeats a cursor", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ payload: { uuid: "first", type: "assistant" } }],
+          next_cursor: "cursor-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ payload: { uuid: "second", type: "assistant" } }],
+          next_cursor: "cursor-1",
+        }),
+      });
+
+    await expect(
+      fetchStartupInternalEvents({
+        sessionBaseUrl: "https://api.example.test/v1/code/sessions/cse_session_123",
+        headers: { Authorization: "Bearer worker-jwt" },
+      }),
+    ).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not install a fake CCR v2 writer when the worker epoch is missing", async () => {


### PR DESCRIPTION
## Summary
- move startup internal-event reads into a focused helper
- fail closed on malformed successful JSON or malformed page envelopes
- stop repeated-cursor pagination loops during startup transcript reads
- add session-ingress regressions for malformed JSON, malformed envelopes, and repeated cursors

Closes #1164

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/bootstrap.session-ingress.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke