### PR TITLE
fix(runtime): guard MCP auth metadata JSON

### DIFF
--- a/runtime/src/services/mcp/auth.ts
+++ b/runtime/src/services/mcp/auth.ts
@@ -353,7 +353,15 @@ async function fetchAuthServerMetadata(
       headers: { Accept: 'application/json' },
     })
     if (response.ok) {
-      return OAuthMetadataSchema.parse(await response.json())
+      let payload: unknown
+      try {
+        payload = await response.json()
+      } catch {
+        throw new Error(
+          `Configured auth server metadata returned invalid JSON from ${configuredMetadataUrl}`,
+        )
+      }
+      return OAuthMetadataSchema.parse(payload)
     }
     throw new Error(
       `HTTP ${response.status} fetching configured auth server metadata from ${configuredMetadataUrl}`,

--- a/runtime/tests/services/mcp/auth.test.ts
+++ b/runtime/tests/services/mcp/auth.test.ts
@@ -1,7 +1,21 @@
 import assert from 'node:assert/strict'
-import { test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 
-import { validateOAuthCallbackParams } from './auth.js'
+const mcpAuthMocks = vi.hoisted(() => ({
+  logMCPDebug: vi.fn(),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logMCPDebug: mcpAuthMocks.logMCPDebug,
+}))
+
+import { AgenCAuthProvider, validateOAuthCallbackParams } from './auth.js'
+import type { McpSSEServerConfig } from './types.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
 
 test('OAuth callback rejects error parameters before state validation can be bypassed', () => {
   const result = validateOAuthCallbackParams(
@@ -57,5 +71,41 @@ test('OAuth callback accepts authorization codes only when state matches', () =>
       'expected-state',
     ),
     { type: 'state_mismatch' },
+  )
+})
+
+test('configured auth metadata invalid JSON is logged as a controlled discovery failure', async () => {
+  const metadataUrl =
+    'https://auth.example.test/.well-known/oauth-authorization-server'
+  const fetchMock = vi.fn(async () =>
+    new Response('<html>login</html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+
+  const serverConfig: McpSSEServerConfig = {
+    type: 'sse',
+    url: 'https://mcp.example.test/sse',
+    oauth: {
+      authServerMetadataUrl: metadataUrl,
+    },
+  }
+  const provider = new AgenCAuthProvider('configured-auth', serverConfig)
+
+  await expect(provider.discoveryState()).resolves.toBeUndefined()
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    metadataUrl,
+    expect.objectContaining({
+      headers: { Accept: 'application/json' },
+    }),
+  )
+  expect(mcpAuthMocks.logMCPDebug).toHaveBeenCalledWith(
+    'configured-auth',
+    expect.stringContaining(
+      `Configured auth server metadata returned invalid JSON from ${metadataUrl}`,
+    ),
   )
 })


### PR DESCRIPTION
## Summary
- catch malformed successful JSON from configured MCP OAuth auth-server metadata URLs
- surface a controlled discovery error through the existing debug path
- add regression coverage through `AgenCAuthProvider.discoveryState()`

Closes #1166

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/services/mcp/auth.test.ts
- npm run typecheck
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook: runtime build, package entrypoints, TUI runtime startup smoke