### PR TITLE
fix(runtime): guard GitHub device flow JSON

### DIFF
--- a/runtime/src/services/github/deviceFlow.ts
+++ b/runtime/src/services/github/deviceFlow.ts
@@ -63,6 +63,19 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
+async function readGitHubDeviceFlowJson(
+  response: Response,
+  operation: string,
+): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    throw new GitHubDeviceFlowError(
+      `${operation} returned invalid JSON from GitHub`,
+    )
+  }
+}
+
 export async function requestDeviceCode(options?: {
   clientId?: string
   scope?: string
@@ -106,7 +119,9 @@ export async function requestDeviceCode(options?: {
       throw new GitHubDeviceFlowError(lastError)
     }
 
-    const data = asRecord(await res.json()) ?? {}
+    const data = asRecord(
+      await readGitHubDeviceFlowJson(res, 'Device code request'),
+    ) ?? {}
     const device_code = data.device_code
     const user_code = data.user_code
     const verification_uri = data.verification_uri
@@ -168,7 +183,9 @@ export async function pollAccessToken(
         `Token request failed: ${res.status} ${text}`,
       )
     }
-    const data = asRecord(await res.json()) ?? {}
+    const data = asRecord(
+      await readGitHubDeviceFlowJson(res, 'Token request'),
+    ) ?? {}
     const err = data.error as string | undefined
     if (err == null) {
       const token = data.access_token
@@ -222,7 +239,9 @@ export async function exchangeForCopilotToken(
       `Copilot token exchange failed: ${res.status} ${text}`,
     )
   }
-  const data = asRecord(await res.json()) ?? {}
+  const data = asRecord(
+    await readGitHubDeviceFlowJson(res, 'Copilot token exchange'),
+  ) ?? {}
   const token = data.token
   const expires_at = data.expires_at
   const refresh_in = data.refresh_in

--- a/runtime/tests/services/github/deviceFlow.test.ts
+++ b/runtime/tests/services/github/deviceFlow.test.ts
@@ -70,6 +70,18 @@ describe('requestDeviceCode', () => {
     ).rejects.toThrow(/Malformed device code response/)
   })
 
+  test('throws controlled error for non-JSON successful device code response', async () => {
+    const { requestDeviceCode } = await importFreshModule()
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('<html>login</html>', { status: 200 })),
+    )
+
+    await expect(
+      requestDeviceCode({ clientId: 'test-client', fetchImpl }),
+    ).rejects.toThrow(/Device code request returned invalid JSON from GitHub/)
+  })
+
   test('uses OAuth-safe default scope', async () => {
     let capturedScope = ''
     const fetchImpl = mock((_url: RequestInfo | URL, init?: RequestInit) => {
@@ -200,6 +212,21 @@ describe('pollAccessToken', () => {
       }),
     ).rejects.toThrow(/No access_token/)
   })
+
+  test('throws controlled error for non-JSON successful access-token response', async () => {
+    const { pollAccessToken } = await importFreshModule()
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('<html>login</html>', { status: 200 })),
+    )
+
+    await expect(
+      pollAccessToken('dc', {
+        clientId: 'c',
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/Token request returned invalid JSON from GitHub/)
+  })
 })
 
 describe('exchangeForCopilotToken', () => {
@@ -264,5 +291,17 @@ describe('exchangeForCopilotToken', () => {
     await expect(
       exchangeForCopilotToken('oauth-token', fetchImpl),
     ).rejects.toThrow(/Malformed Copilot token response/)
+  })
+
+  test('throws controlled error for non-JSON successful Copilot token response', async () => {
+    const { exchangeForCopilotToken } = await importFreshModule()
+
+    const fetchImpl = mock(() =>
+      Promise.resolve(new Response('<html>login</html>', { status: 200 })),
+    )
+
+    await expect(
+      exchangeForCopilotToken('oauth-token', fetchImpl),
+    ).rejects.toThrow(/Copilot token exchange returned invalid JSON from GitHub/)
   })
 })


### PR DESCRIPTION
## Summary
- convert successful GitHub device-flow JSON parse failures into controlled GitHubDeviceFlowError messages
- cover device-code, access-token polling, and Copilot-token exchange success-path malformed bodies

## Validation
- bun test runtime/tests/services/github/deviceFlow.test.ts
- npm run typecheck
- git diff --check
- npm run check:unused
- npm run check:unused:all --workspace=@tetsuo-ai/runtime
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook build + TUI startup smoke

Closes #1168