### PR TITLE
fix(runtime): guard policy limits JSON

### DIFF
--- a/runtime/src/services/policyLimits/index.ts
+++ b/runtime/src/services/policyLimits/index.ts
@@ -365,11 +365,23 @@ export class PolicyLimitsService {
         };
       }
 
-      const parsed = parsePolicyLimitsResponse(await response.json());
+      let payload: unknown;
+      try {
+        payload = await response.json();
+      } catch {
+        return {
+          success: false,
+          error: "Invalid policy limits response format",
+          skipRetry: true,
+        };
+      }
+
+      const parsed = parsePolicyLimitsResponse(payload);
       if (parsed === null) {
         return {
           success: false,
           error: "Invalid policy limits response format",
+          skipRetry: true,
         };
       }
 

--- a/runtime/tests/services/policyLimits/policyLimits.test.ts
+++ b/runtime/tests/services/policyLimits/policyLimits.test.ts
@@ -187,6 +187,50 @@ describe("policy limits service", () => {
     });
   });
 
+  it("does not retry non-JSON successful responses", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response("<html>login</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const sleep = vi.fn(async () => {});
+    const service = makeService({
+      apiKey: "direct-policy-key",
+      fetchImpl: fetchMock,
+      sleep,
+    });
+
+    await service.loadPolicyLimits();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(service.isPolicyAllowed("allow_remote_sessions")).toBe(true);
+    await expect(readFile(service.cachePath(), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not retry invalid successful response shapes", async () => {
+    const fetchMock = vi.fn(async () =>
+      response(200, {
+        restrictions: { allow_remote_sessions: { allowed: "no" } },
+      }),
+    );
+    const sleep = vi.fn(async () => {});
+    const service = makeService({
+      apiKey: "direct-policy-key",
+      fetchImpl: fetchMock,
+      sleep,
+    });
+
+    await service.loadPolicyLimits();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(service.isPolicyAllowed("allow_remote_sessions")).toBe(true);
+  });
+
   it("retries transient failures and reuses stale cache when the API stays down", async () => {
     const retryFetch = vi
       .fn()


### PR DESCRIPTION
## Summary
- handle malformed successful policy-limits JSON as invalid response format
- avoid retrying deterministic invalid 200 responses
- add regressions for non-JSON and invalid-shape successful responses

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/services/policyLimits/policyLimits.test.ts
- npm run typecheck
- git diff --check
- npm run check:unused
- npm run check:unused:all --workspace=@tetsuo-ai/runtime
- npm audit --audit-level=high
- npm outdated --json
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook build + TUI startup smoke

Closes #1170