### PR TITLE
fix(runtime): guard OAuth token JSON

### DIFF
--- a/runtime/src/services/api/openAiCodeOAuthShared.ts
+++ b/runtime/src/services/api/openAiCodeOAuthShared.ts
@@ -42,6 +42,17 @@ export function normalizeOAuthTokenPayload(value: unknown): OAuthTokenPayload {
   }
 }
 
+export async function readOAuthTokenJsonResponse(
+  response: Response,
+  operation: string,
+): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    throw new Error(`${operation} returned invalid JSON.`)
+  }
+}
+
 export function getOpenAiCodeOAuthClientId(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -152,7 +163,12 @@ export async function exchangeProviderCodeIdTokenForApiKey(
     )
   }
 
-  const payload = normalizeOAuthTokenPayload(await response.json())
+  const payload = normalizeOAuthTokenPayload(
+    await readOAuthTokenJsonResponse(
+      response,
+      'ProviderCode API key exchange',
+    ),
+  )
   const apiKey = payload.accessToken
   if (!apiKey) {
     throw new Error(

--- a/runtime/src/utils/agencCredentials.ts
+++ b/runtime/src/utils/agencCredentials.ts
@@ -8,6 +8,7 @@ import {
   normalizeOAuthTokenPayload,
   parseChatgptAccountId,
   decodeJwtPayload,
+  readOAuthTokenJsonResponse,
 } from '../services/api/openAiCodeOAuthShared.js'
 
 export const AGENC_STORAGE_KEY = 'agenc' as const
@@ -320,7 +321,9 @@ export async function refreshAgencAccessTokenIfNeeded(options?: {
         throw new Error(getRefreshErrorMessage(response.status, bodyText))
       }
 
-      const payload = normalizeOAuthTokenPayload(await response.json())
+      const payload = normalizeOAuthTokenPayload(
+        await readOAuthTokenJsonResponse(response, 'Agenc token refresh'),
+      )
       const accessToken = payload.accessToken
       if (!accessToken) {
         throw new Error(

--- a/runtime/tests/services/api/openAiCodeOAuthShared.test.ts
+++ b/runtime/tests/services/api/openAiCodeOAuthShared.test.ts
@@ -28,4 +28,19 @@ describe('openAiCodeOAuthShared', () => {
       'ProviderCode API key exchange completed, but no API key token was returned.',
     )
   })
+
+  test('exchangeProviderCodeIdTokenForApiKey rejects non-JSON successful responses predictably', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('<html>login</html>', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html',
+        },
+      }),
+    ) as unknown as typeof fetch
+
+    await expect(
+      exchangeProviderCodeIdTokenForApiKey('id-token'),
+    ).rejects.toThrow('ProviderCode API key exchange returned invalid JSON.')
+  })
 })

--- a/runtime/tests/utils/agencCredentials.test.ts
+++ b/runtime/tests/utils/agencCredentials.test.ts
@@ -283,6 +283,51 @@ describe('agencCredentials', () => {
     )
   })
 
+  test('refreshAgencAccessTokenIfNeeded rejects non-JSON success payloads predictably', async () => {
+    delete process.env.AGENC_SIMPLE
+    delete process.env.AGENC_API_KEY
+
+    const expiredToken = makeJwt({
+      exp: Math.floor((Date.now() - 60_000) / 1000),
+      chatgpt_account_id: 'acct_old',
+    })
+
+    let storageState: Record<string, unknown> = {
+      agenc: {
+        accessToken: expiredToken,
+        refreshToken: 'refresh-old',
+        accountId: 'acct_old',
+      },
+    }
+
+    vi.doMock(secureStorageModulePath, () => ({
+      getSecureStorage: () => ({
+        read: () => storageState,
+        readAsync: async () => storageState,
+        update: (next: Record<string, unknown>) => {
+          storageState = next
+          return { success: true }
+        },
+      }),
+    }))
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response('<html>login</html>', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html',
+        },
+      }),
+    ) as unknown as typeof fetch
+
+    const { refreshAgencAccessTokenIfNeeded } =
+      await importFreshAgencCredentialsModule()
+
+    await expect(refreshAgencAccessTokenIfNeeded()).rejects.toThrow(
+      'Agenc token refresh returned invalid JSON.',
+    )
+  })
+
   test('refreshAgencAccessTokenIfNeeded drops a stale api key when id-token exchange fails', async () => {
     delete process.env.AGENC_SIMPLE
     delete process.env.AGENC_API_KEY


### PR DESCRIPTION
## Summary
- add a shared OAuth token JSON reader with operation-scoped invalid-JSON errors
- use it for ProviderCode API-key exchange and AgenC token refresh success paths
- add regressions for successful non-JSON token responses

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/services/api/openAiCodeOAuthShared.test.ts tests/utils/agencCredentials.test.ts
- npm run typecheck
- git diff --check
- npm run check:unused
- npm run check:unused:all --workspace=@tetsuo-ai/runtime
- npm audit --audit-level=high
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook build + TUI startup smoke

## Follow-up
- npm outdated --json currently reports better-sqlite3 12.10.1 -> 12.11.1; this is unrelated to the OAuth fix and will be handled separately.

Closes #1172