### PR TITLE
fix(runtime): preserve project MCP config fields

### DIFF
--- a/runtime/src/services/mcp/types.ts
+++ b/runtime/src/services/mcp/types.ts
@@ -25,12 +25,47 @@ export const TransportSchema = lazySchema(() =>
 )
 export type Transport = z.infer<ReturnType<typeof TransportSchema>>
 
-export const McpStdioServerConfigSchema = lazySchema(() =>
+const PermissionDefaultModeSchema = lazySchema(() =>
+  z.enum(['untrusted', 'on-failure', 'on-request', 'never']),
+)
+
+const NonEmptyStringSchema = lazySchema(() => z.string().min(1))
+
+const PerToolConfigSchema = lazySchema(() =>
   z.object({
+    enabled: z.boolean().optional(),
+    default_permission_mode: PermissionDefaultModeSchema().optional(),
+    defaultPermissionMode: PermissionDefaultModeSchema().optional(),
+    approval_mode: z.enum(['auto', 'prompt', 'approve']).optional(),
+  }),
+)
+
+const McpToolCatalogPolicyConfigSchema = lazySchema(() =>
+  z.object({
+    enabled: z.boolean().optional(),
+    required: z.boolean().optional(),
+    timeout: z.number().int().positive().optional(),
+    default_tools_approval_mode: PermissionDefaultModeSchema().optional(),
+    enabled_tools: z.array(NonEmptyStringSchema()).optional(),
+    disabled_tools: z.array(NonEmptyStringSchema()).optional(),
+    tools: z.record(z.string(), PerToolConfigSchema()).optional(),
+    pinnedCatalogSha256: z.string().regex(/^[a-fA-F0-9]{64}$/).optional(),
+    supplyChain: z
+      .object({
+        catalogSha256: z.string().regex(/^[a-fA-F0-9]{64}$/).optional(),
+      })
+      .optional(),
+  }),
+)
+
+export const McpStdioServerConfigSchema = lazySchema(() =>
+  McpToolCatalogPolicyConfigSchema().extend({
     type: z.literal('stdio').optional(), // Optional for backwards compatibility
     command: z.string().min(1, 'Command cannot be empty'),
     args: z.array(z.string()).default([]),
     env: z.record(z.string(), z.string()).optional(),
+    env_vars: z.array(NonEmptyStringSchema()).optional(),
+    cwd: NonEmptyStringSchema().optional(),
   }),
 )
 
@@ -56,7 +91,7 @@ const McpOAuthConfigSchema = lazySchema(() =>
 )
 
 export const McpSSEServerConfigSchema = lazySchema(() =>
-  z.object({
+  McpToolCatalogPolicyConfigSchema().extend({
     type: z.literal('sse'),
     url: z.string(),
     headers: z.record(z.string(), z.string()).optional(),
@@ -87,7 +122,7 @@ export const McpWebSocketIDEServerConfigSchema = lazySchema(() =>
 )
 
 export const McpHTTPServerConfigSchema = lazySchema(() =>
-  z.object({
+  McpToolCatalogPolicyConfigSchema().extend({
     type: z.literal('http'),
     url: z.string(),
     headers: z.record(z.string(), z.string()).optional(),
@@ -97,7 +132,7 @@ export const McpHTTPServerConfigSchema = lazySchema(() =>
 )
 
 export const McpWebSocketServerConfigSchema = lazySchema(() =>
-  z.object({
+  McpToolCatalogPolicyConfigSchema().extend({
     type: z.literal('ws'),
     url: z.string(),
     headers: z.record(z.string(), z.string()).optional(),

--- a/runtime/tests/session/mcp-startup.test.ts
+++ b/runtime/tests/session/mcp-startup.test.ts
@@ -351,6 +351,7 @@ describe("mcp-startup session-owned manager helpers", () => {
 
   it("loads project .mcp.json servers when bypass-mode startup opts in", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-project-mcp-"));
+    const serverCwd = join(cwd, "mcp-server");
     try {
       writeFileSync(
         join(cwd, ".mcp.json"),
@@ -360,6 +361,20 @@ describe("mcp-startup session-owned manager helpers", () => {
               type: "stdio",
               command: "node",
               args: ["server.js"],
+              env: { AUDIT_TOKEN: "test-token" },
+              env_vars: ["PATH", "HOME"],
+              cwd: serverCwd,
+              timeout: 1_234,
+              required: true,
+              enabled: true,
+              default_tools_approval_mode: "on-request",
+              enabled_tools: ["read"],
+              disabled_tools: ["write"],
+              tools: {
+                read: { default_permission_mode: "never" },
+              },
+              pinnedCatalogSha256: "a".repeat(64),
+              supplyChain: { catalogSha256: "b".repeat(64) },
             },
           },
         }),
@@ -381,6 +396,20 @@ describe("mcp-startup session-owned manager helpers", () => {
           transport: "stdio",
           command: "node",
           args: ["server.js"],
+          env: { AUDIT_TOKEN: "test-token" },
+          env_vars: ["PATH", "HOME"],
+          cwd: serverCwd,
+          timeout: 1_234,
+          required: true,
+          enabled: true,
+          default_tools_approval_mode: "on-request",
+          enabled_tools: ["read"],
+          disabled_tools: ["write"],
+          tools: {
+            read: { default_permission_mode: "never" },
+          },
+          pinnedCatalogSha256: "a".repeat(64),
+          supplyChain: { catalogSha256: "b".repeat(64) },
         }),
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- preserve runtime-supported MCP config fields through project .mcp.json validation
- add shared service schemas for MCP process controls, tool policy, and catalog SHA-256 pins
- add regression coverage for project .mcp.json startup parsing

## Validation
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/mcp-startup.test.ts
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/mcp-startup.test.ts tests/services/mcp/config-toml-namespace.test.ts tests/services/mcp/client.test.ts tests/mcp-client/resilient-client.test.ts tests/mcp-client/manager.test.ts
- npm run typecheck
- git diff --check
- npm run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --audit-level=high
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- local vLLM diff review: APPROVED
- npm run test:bun
- npm test
- npm run validate:runtime
- pre-commit hook: build + package entrypoints + TUI runtime startup smoke

Closes #1175