### PR TITLE
fix(runtime): guard MCP provider tool names

### DIFF
--- a/runtime/src/llm/wire/mcp-tool-naming.ts
+++ b/runtime/src/llm/wire/mcp-tool-naming.ts
@@ -13,24 +13,90 @@
  * providers because of the dots.
  *
  * This module performs a bijective encoding so the runtime keeps the
- * dotted form everywhere internally, but the wire layer ships the
- * encoded form to the provider and decodes the model's tool-call
- * responses back to the dotted form before dispatch. The encoded form
- * is `mcp__<server>__<tool>` — `__` is a sentinel separator that MCP
- * server-name conventions (lowercase, single underscores, hyphens) do
- * not produce.
- *
- * Decoding uses `indexOf("__")` rather than `split("__")` so a tool
- * name that itself contains `__` survives the round trip intact:
- * `mcp.memory.do__stuff` → `mcp__memory__do__stuff` →
- * `mcp.memory.do__stuff`. Server names containing `__` are not
- * supported (none observed in practice; an MCP server choosing such a
- * name would have its tools mis-routed).
+ * dotted form everywhere internally, but the wire layer ships an encoded
+ * form to the provider and decodes the model's tool-call responses back
+ * to the dotted form before dispatch. The common short encoded form is
+ * `mcp__<server>__<tool>`; for server IDs such as plugin IDs that need
+ * escaping, the module falls back to `mcp2__<escaped-server>__<escaped-tool>`.
  */
+
+import { TextDecoder, TextEncoder } from "node:util";
 
 const INTERNAL_PREFIX = "mcp.";
 const WIRE_PREFIX = "mcp__";
+const ESCAPED_WIRE_PREFIX = "mcp2__";
 const SEP = "__";
+const PROVIDER_FUNCTION_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+const WIRE_SAFE_SEGMENT_BYTE_PATTERN = /^[a-zA-Z0-9-]$/;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+export function isProviderToolNameSafe(name: string): boolean {
+  return PROVIDER_FUNCTION_NAME_PATTERN.test(name);
+}
+
+function splitInternalMcpToolName(
+  name: string,
+): { readonly server: string; readonly tool: string } | null {
+  if (!name.startsWith(INTERNAL_PREFIX)) return null;
+  const afterPrefix = name.slice(INTERNAL_PREFIX.length);
+  const dotIndex = afterPrefix.indexOf(".");
+  if (dotIndex === -1) return null;
+  return {
+    server: afterPrefix.slice(0, dotIndex),
+    tool: afterPrefix.slice(dotIndex + 1),
+  };
+}
+
+function encodeMcpNameSegment(segment: string): string {
+  let encoded = "";
+  for (const byte of textEncoder.encode(segment)) {
+    const char = String.fromCharCode(byte);
+    if (WIRE_SAFE_SEGMENT_BYTE_PATTERN.test(char)) {
+      encoded += char;
+    } else if (char === "_") {
+      encoded += "_u";
+    } else {
+      encoded += `_x${byte.toString(16).padStart(2, "0")}`;
+    }
+  }
+  return encoded;
+}
+
+function decodeMcpNameSegment(segment: string): string | null {
+  const bytes: number[] = [];
+  for (let index = 0; index < segment.length;) {
+    const char = segment[index]!;
+    if (char !== "_") {
+      bytes.push(char.charCodeAt(0));
+      index += 1;
+      continue;
+    }
+
+    const escapeKind = segment[index + 1];
+    if (escapeKind === "u") {
+      bytes.push("_".charCodeAt(0));
+      index += 2;
+      continue;
+    }
+    if (escapeKind === "x") {
+      const hex = segment.slice(index + 2, index + 4);
+      if (!/^[0-9a-f]{2}$/i.test(hex)) return null;
+      bytes.push(Number.parseInt(hex, 16));
+      index += 4;
+      continue;
+    }
+
+    return null;
+  }
+
+  try {
+    return textDecoder.decode(new Uint8Array(bytes));
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Convert an internal tool name to the strict-regex wire form.
@@ -42,17 +108,15 @@ const SEP = "__";
  *   this would be malformed and provider-side validation will surface it)
  */
 export function encodeMcpToolNameForWire(name: string): string {
-  if (!name.startsWith(INTERNAL_PREFIX)) return name;
-  const afterPrefix = name.slice(INTERNAL_PREFIX.length);
-  const dotIndex = afterPrefix.indexOf(".");
-  if (dotIndex === -1) return name;
-  const server = afterPrefix.slice(0, dotIndex);
-  const tool = afterPrefix.slice(dotIndex + 1);
-  // Server names containing `__` would create a decode ambiguity.
-  // Pass through unchanged in that case so the malformed name reaches
-  // provider-side validation rather than corrupting silently.
-  if (server.includes(SEP)) return name;
-  return `${WIRE_PREFIX}${server}${SEP}${tool}`;
+  const parts = splitInternalMcpToolName(name);
+  if (!parts) return name;
+
+  if (!parts.server.includes(SEP)) {
+    const legacyWireName = `${WIRE_PREFIX}${parts.server}${SEP}${parts.tool}`;
+    if (isProviderToolNameSafe(legacyWireName)) return legacyWireName;
+  }
+
+  return `${ESCAPED_WIRE_PREFIX}${encodeMcpNameSegment(parts.server)}${SEP}${encodeMcpNameSegment(parts.tool)}`;
 }
 
 /**
@@ -61,6 +125,18 @@ export function encodeMcpToolNameForWire(name: string): string {
  * tool name (e.g. `FileEdit`) round-trips unchanged.
  */
 export function decodeMcpToolNameFromWire(name: string): string {
+  if (name.startsWith(ESCAPED_WIRE_PREFIX)) {
+    const afterPrefix = name.slice(ESCAPED_WIRE_PREFIX.length);
+    const sepIndex = afterPrefix.indexOf(SEP);
+    if (sepIndex === -1) return name;
+    const server = decodeMcpNameSegment(afterPrefix.slice(0, sepIndex));
+    const tool = decodeMcpNameSegment(
+      afterPrefix.slice(sepIndex + SEP.length),
+    );
+    if (server === null || tool === null) return name;
+    return `${INTERNAL_PREFIX}${server}.${tool}`;
+  }
+
   if (!name.startsWith(WIRE_PREFIX)) return name;
   const afterPrefix = name.slice(WIRE_PREFIX.length);
   const sepIndex = afterPrefix.indexOf(SEP);

--- a/runtime/src/mcp-client/tools.ts
+++ b/runtime/src/mcp-client/tools.ts
@@ -49,7 +49,10 @@ import {
   catalogDigestMatches,
   type MCPToolDescriptorLike,
 } from "./supply-chain.js";
-import { encodeMcpToolNameForWire } from "../llm/wire/mcp-tool-naming.js";
+import {
+  encodeMcpToolNameForWire,
+  isProviderToolNameSafe,
+} from "../llm/wire/mcp-tool-naming.js";
 
 /**
  * Policy knobs forwarded from server config to the bridge. `allowedTools`
@@ -130,9 +133,38 @@ function modelFacingMcpToolDescription(
 const DEFAULT_MCP_LIST_TOOLS_TIMEOUT_MS = 30_000;
 const DEFAULT_MCP_CALL_TIMEOUT_MS = 45_000;
 const MCP_REQUEST_PERMISSIONS_TOOL_NAME = "request_permissions";
+const MCP_RAW_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 
 /** I-76: upper bound on a single MCP tool-call result, 5MB. */
 const MAX_MCP_CALL_RESULT_BYTES = 5 * 1024 * 1024;
+
+function filterProviderSafeMcpToolCatalog(
+  serverName: string,
+  tools: readonly MCPToolDescriptorLike[],
+  logger: Logger,
+): readonly MCPToolDescriptorLike[] {
+  return tools.filter((mcpTool) => {
+    if (!MCP_RAW_TOOL_NAME_PATTERN.test(mcpTool.name)) {
+      logger.warn?.(
+        `MCP server ${JSON.stringify(serverName)} skipped provider-unsafe tool ` +
+          `${JSON.stringify(mcpTool.name)}: raw tool name must match ` +
+          `/${MCP_RAW_TOOL_NAME_PATTERN.source}/`,
+      );
+      return false;
+    }
+
+    const namespacedName = `mcp.${serverName}.${mcpTool.name}`;
+    const wireName = encodeMcpToolNameForWire(namespacedName);
+    if (isProviderToolNameSafe(wireName)) return true;
+
+    logger.warn?.(
+      `MCP server ${JSON.stringify(serverName)} skipped provider-unsafe tool ` +
+        `${JSON.stringify(mcpTool.name)}: encoded function name ` +
+        `${JSON.stringify(wireName)} violates provider function-name constraints`,
+    );
+    return false;
+  });
+}
 
 /**
  * T6 gap #119: optional observer hooks for `mcp_tool_call_begin` /
@@ -740,12 +772,20 @@ export async function createToolBridge(
     }
   }
 
-  logger.info(`MCP server "${serverName}" exposes ${mcpTools.length} tools`);
+  const providerSafeMcpTools = filterProviderSafeMcpToolCatalog(
+    serverName,
+    mcpTools,
+    logger,
+  );
+
+  logger.info(
+    `MCP server "${serverName}" exposes ${providerSafeMcpTools.length} tools`,
+  );
 
   // Track disposal to prevent use-after-close
   let disposed = false;
 
-  const tools: Tool[] = mcpTools.map((mcpTool) => {
+  const tools: Tool[] = providerSafeMcpTools.map((mcpTool) => {
     const namespacedName = `mcp.${serverName}.${mcpTool.name}`;
     const defaultPermissionMode = perMcpToolApprovalMode(
       options.serverConfig,

--- a/runtime/tests/llm/wire/mcp-tool-naming.test.ts
+++ b/runtime/tests/llm/wire/mcp-tool-naming.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   decodeMcpToolNameFromWire,
   encodeMcpToolNameForWire,
+  isProviderToolNameSafe,
 } from "./mcp-tool-naming.js";
 
 describe("MCP tool-name wire encoding", () => {
@@ -42,13 +43,21 @@ describe("MCP tool-name wire encoding", () => {
     expect(encodeMcpToolNameForWire("mcp.server")).toBe("mcp.server");
   });
 
-  test("passes through when server name contains __ (decode would be ambiguous)", () => {
-    // Defensive pass-through: encoding `mcp.serv__er.foo` to
-    // `mcp__serv____er__foo` would decode as server=`serv`, tool=`__er__foo`,
-    // which is wrong. MCP server-name conventions don't produce `__`,
-    // so this branch is mostly a safety net.
+  test("escapes server names that would be ambiguous in the legacy form", () => {
     expect(encodeMcpToolNameForWire("mcp.serv__er.foo")).toBe(
+      "mcp2__serv_u_uer__foo",
+    );
+    expect(decodeMcpToolNameFromWire("mcp2__serv_u_uer__foo")).toBe(
       "mcp.serv__er.foo",
+    );
+  });
+
+  test("escapes plugin-style server names while preserving canonical decode", () => {
+    const wire = encodeMcpToolNameForWire("mcp.plugin:sample:local.ping");
+    expect(wire).toBe("mcp2__plugin_x3asample_x3alocal__ping");
+    expect(isProviderToolNameSafe(wire)).toBe(true);
+    expect(decodeMcpToolNameFromWire(wire)).toBe(
+      "mcp.plugin:sample:local.ping",
     );
   });
 
@@ -94,6 +103,8 @@ describe("MCP tool-name wire encoding", () => {
       "mcp.context7.resolve-library-id",
       "mcp.design_tooling.get_design_context",
       "mcp.server.do__stuff", // tool name with __
+      "mcp.serv__er.foo",
+      "mcp.plugin:sample:local.ping",
       "FileEdit",
       "exec_command",
       "TodoWrite",
@@ -114,11 +125,14 @@ describe("MCP tool-name wire encoding", () => {
       "mcp.github.create_issue",
       "mcp.context7.resolve-library-id",
       "mcp.design_tooling.get_design_context",
+      "mcp.plugin:sample:local.ping",
+      "mcp.serv__er.foo",
     ];
     for (const internal of cases) {
       const wire = encodeMcpToolNameForWire(internal);
       expect(wire).toMatch(strictRegex);
       expect(wire.length).toBeLessThanOrEqual(64);
+      expect(isProviderToolNameSafe(wire)).toBe(true);
     }
   });
 });

--- a/runtime/tests/mcp-client/tools.test.ts
+++ b/runtime/tests/mcp-client/tools.test.ts
@@ -9,6 +9,8 @@
 
 import { describe, expect, test, vi } from "vitest";
 import type { ToolEvaluatorContext } from "../permissions/evaluator.js";
+import type { LLMTool } from "../llm/types.js";
+import { toChatCompletionsTools } from "../llm/wire/tools.js";
 import { freshDenialTracking } from "../permissions/denial-tracking.js";
 import { RequestPermissionsRpc } from "../permissions/rpc/request-permissions.js";
 import { buildGuardianApprovalRequest } from "../permissions/guardian/approval-request.js";
@@ -16,6 +18,7 @@ import type { GuardianApprovalReviewOptions } from "../permissions/guardian/revi
 import { APPROVED, DENIED } from "../permissions/review-decision.js";
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import { createToolBridge, type MCPCallObserver } from "./tools.js";
+import { computeMCPToolCatalogSha256 } from "./supply-chain.js";
 
 function permissionContext(): ToolEvaluatorContext {
   const toolPermissionContext = createEmptyToolPermissionContext();
@@ -94,6 +97,122 @@ describe("createToolBridge — T6 gap #119 observer wiring", () => {
       type: "object",
       properties: { q: { type: "string" } },
     });
+  });
+
+  test("skips MCP tools whose model-facing names violate provider constraints", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const bridge = await createToolBridge(
+      {
+        listTools: async () => ({
+          tools: [
+            { name: "safe_tool", description: "safe" },
+            { name: "bad tool", description: "contains a space" },
+            { name: "bad.dot", description: "contains a dot" },
+            { name: "line\nbreak", description: "contains a newline" },
+            { name: "x".repeat(60), description: "too long after namespacing" },
+          ],
+        }),
+        callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+        close: async () => {},
+      },
+      "srv",
+      logger,
+    );
+
+    expect(bridge.tools.map((tool) => tool.name)).toEqual([
+      "mcp.srv.safe_tool",
+    ]);
+    expect(logger.warn).toHaveBeenCalledTimes(4);
+    const warnings = logger.warn.mock.calls.map(([message]) => String(message));
+    expect(warnings.every((message) => message.includes("provider-unsafe")))
+      .toBe(true);
+    expect(warnings.some((message) => message.includes("\\n"))).toBe(true);
+    expect(warnings.some((message) => message.includes("line\nbreak")))
+      .toBe(false);
+
+    const llmTools = bridge.tools.map((tool): LLMTool => ({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputSchema as Record<string, unknown>,
+      },
+    }));
+    const wireNames = toChatCompletionsTools(llmTools).map(
+      (tool) => tool.function.name,
+    );
+    expect(wireNames).toEqual(["mcp__srv__safe_tool"]);
+    expect(wireNames.every((name) => /^[a-zA-Z0-9_-]{1,64}$/.test(name)))
+      .toBe(true);
+  });
+
+  test("escapes plugin-style server names before provider exposure", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const bridge = await createToolBridge(
+      {
+        listTools: async () => ({
+          tools: [{ name: "safe_tool", description: "safe" }],
+        }),
+        callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+        close: async () => {},
+      },
+      "plugin:sample:local",
+      logger,
+    );
+
+    expect(bridge.tools.map((tool) => tool.name)).toEqual([
+      "mcp.plugin:sample:local.safe_tool",
+    ]);
+    const llmTools = bridge.tools.map((tool): LLMTool => ({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputSchema as Record<string, unknown>,
+      },
+    }));
+    expect(
+      toChatCompletionsTools(llmTools).map((tool) => tool.function.name),
+    ).toEqual(["mcp2__plugin_x3asample_x3alocal__safe_utool"]);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("checks catalog pins before dropping provider-unsafe tool names", async () => {
+    const safeOnlyPin = computeMCPToolCatalogSha256([
+      {
+        name: "safe_tool",
+        description: "safe",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]).sha256;
+
+    await expect(
+      createToolBridge(
+        {
+          listTools: async () => ({
+            tools: [
+              { name: "safe_tool", description: "safe" },
+              { name: "bad tool", description: "poisoned" },
+            ],
+          }),
+          callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          close: async () => {},
+        },
+        "srv",
+        undefined,
+        { serverConfig: { pinnedCatalogSha256: safeOnlyPin } },
+      ),
+    ).rejects.toThrow(/tool catalog digest mismatch/);
   });
 
   test("treats non-array MCP tool catalogs as exposing zero tools", async () => {


### PR DESCRIPTION
## Summary
- Preserve provider-safe MCP wire names while adding a reversible escaped form for plugin-style server IDs such as `plugin:sample:local`.
- Filter unsafe raw MCP tool names and overlong encoded provider names after catalog pin verification.
- Add regressions for unsafe tool names, provider wire conversion, escaped server-name round trips, plugin-style server IDs, and catalog-pin ordering.

Fixes #1178.

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/llm/wire/mcp-tool-naming.test.ts tests/mcp-client/tools.test.ts tests/mcp-client/manager.test.ts tests/plugins/registration.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/mcp-startup.test.ts tests/services/mcp/config-toml-namespace.test.ts tests/services/mcp/client.test.ts tests/mcp-client/resilient-client.test.ts tests/mcp-client/manager.test.ts tests/mcp-client/tools.test.ts tests/llm/wire/mcp-tool-naming.test.ts tests/plugins/registration.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run check:unused`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:all`
- `npm audit --audit-level=high`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run test:bun`
- `npm test`
- `npm run validate:runtime`