### PR TITLE
chore(runtime): update sandbox runtime

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "@alcalzone/ansi-tokenize": "0.3.0",
-    "@anthropic-ai/sandbox-runtime": "0.0.54",
+    "@anthropic-ai/sandbox-runtime": "0.0.55",
     "@anthropic-ai/sdk": "^0.104.1",
     "@codemirror/state": "^6.6.0",
     "@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
## Summary\n- update @anthropic-ai/sandbox-runtime from 0.0.54 to 0.0.55\n- keep the dependency as an exact runtime manifest pin\n- pull in upstream sandbox hardening for proxy auth, strict allowlists, deniedDomains deny-all handling, and Linux denyRead/denyWrite mount ordering\n\nFixes #1183\n\n## Validation\n- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/sandbox/engine/linux-engine.test.ts tests/sandbox/engine/seatbelt.test.ts tests/sandbox/hardening/hardening.test.ts tests/sandbox/network-policy.test.ts tests/permissions/sandbox.test.ts tests/tools/BashTool/shouldUseSandbox.test.ts tests/tools/BashTool/bashPermissions.test.ts tests/app-server/command-exec.contract.test.ts tests/unified-exec/process-manager.test.ts tests/plugins/sandbox.test.ts\n- npm outdated --json\n- npm audit --audit-level=high\n- git diff --check\n- npm run typecheck\n- npm run check:unused\n- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000\n- local vLLM diff review: VERDICT: APPROVED\n- npm run test:bun\n- npm test\n- npm run validate:runtime\n- pre-commit hook build + TUI startup smoke\n\n## Remote workflow\n- Transaction Guard Live remains disabled_manually