### PR TITLE
fix(runtime): redact provider trace secrets

### DIFF
--- a/runtime/src/llm/providers/grok/adapter-utils.ts
+++ b/runtime/src/llm/providers/grok/adapter-utils.ts
@@ -61,6 +61,22 @@ const PRIORITY_TOOL_NAMES = new Set([
   "desktop.mouse_move",
   "desktop.scroll",
 ]);
+const TRACE_REDACTED_VALUE = "[REDACTED]";
+const TRACE_SENSITIVE_KEY_PARTS = [
+  "authorization",
+  "apikey",
+  "bearer",
+  "cookie",
+  "idtoken",
+  "mnemonic",
+  "password",
+  "privatekey",
+  "refreshtoken",
+  "secret",
+  "seedphrase",
+  "signingkey",
+  "token",
+];
 
 export type ToolResolutionStrategy =
   | "all_tools_no_filter"
@@ -169,6 +185,32 @@ export function buildToolSelectionTraceContext(
   };
 }
 
+function isSensitiveTraceKey(key: string | undefined): boolean {
+  if (!key) return false;
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return TRACE_SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
+}
+
+function redactProviderTraceValue(
+  value: unknown,
+  key?: string,
+  seen: WeakSet<object> = new WeakSet(),
+): unknown {
+  if (isSensitiveTraceKey(key)) return TRACE_REDACTED_VALUE;
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => redactProviderTraceValue(item, undefined, seen));
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([entryKey, entry]) => [
+      entryKey,
+      redactProviderTraceValue(entry, entryKey, seen),
+    ]),
+  );
+}
+
 export function cloneProviderTracePayload(
   value: unknown,
 ): Record<string, unknown> | undefined {
@@ -176,7 +218,9 @@ export function cloneProviderTracePayload(
     return undefined;
   }
   try {
-    return JSON.parse(safeStringify(value)) as Record<string, unknown>;
+    return JSON.parse(
+      safeStringify(redactProviderTraceValue(value)),
+    ) as Record<string, unknown>;
   } catch {
     return undefined;
   }
@@ -229,8 +273,10 @@ export function buildProviderTraceErrorPayload(
           typeof (headers as { [Symbol.iterator]?: unknown })[Symbol.iterator] ===
             "function"
         ) {
-          payload.headers = Object.fromEntries(
-            Array.from(headers as Iterable<readonly [string, string]>),
+          payload.headers = cloneProviderTracePayload(
+            Object.fromEntries(
+              Array.from(headers as Iterable<readonly [string, string]>),
+            ),
           );
         } else if (!Array.isArray(headers)) {
           payload.headers = cloneProviderTracePayload(headers);

--- a/runtime/tests/llm/providers/grok/adapter-utils.test.ts
+++ b/runtime/tests/llm/providers/grok/adapter-utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { LLMMessage, LLMTool } from "../../types.js";
 import {
+  buildProviderTraceErrorPayload,
+  cloneProviderTracePayload,
   computeReconciliationChain,
   extractTraceToolNames,
   slimTools,
@@ -8,6 +10,75 @@ import {
 } from "./adapter-utils.js";
 
 describe("grok adapter utils", () => {
+  it("redacts provider trace secrets recursively without changing public fields", () => {
+    const payload = cloneProviderTracePayload({
+      model: "grok-4-fast",
+      tools: [
+        {
+          type: "mcp",
+          server_url: "https://mcp.example.test/sse",
+          server_label: "docs",
+          authorization: "Bearer remote-mcp-token",
+          headers: {
+            "x-api-key": "remote-header-key",
+            "x-public-trace-id": "trace-123",
+            nested: {
+              refresh_token: "refresh-secret",
+            },
+          },
+        },
+      ],
+      metadata: {
+        cookie: "session=secret",
+        safe: "visible",
+      },
+    });
+
+    expect(payload).toEqual({
+      model: "grok-4-fast",
+      tools: [
+        {
+          type: "mcp",
+          server_url: "https://mcp.example.test/sse",
+          server_label: "docs",
+          authorization: "[REDACTED]",
+          headers: {
+            "x-api-key": "[REDACTED]",
+            "x-public-trace-id": "trace-123",
+            nested: {
+              refresh_token: "[REDACTED]",
+            },
+          },
+        },
+      ],
+      metadata: {
+        cookie: "[REDACTED]",
+        safe: "visible",
+      },
+    });
+  });
+
+  it("redacts provider error headers from iterable header collections", () => {
+    const error = new Error("upstream failed") as Error & {
+      headers: Headers;
+    };
+    error.headers = new Headers({
+      authorization: "Bearer provider-token",
+      "set-cookie": "sid=secret",
+      "x-request-id": "req-1",
+    });
+
+    expect(buildProviderTraceErrorPayload(error)).toMatchObject({
+      name: "Error",
+      message: "upstream failed",
+      headers: {
+        authorization: "[REDACTED]",
+        "set-cookie": "[REDACTED]",
+        "x-request-id": "req-1",
+      },
+    });
+  });
+
   it("extracts trace tool names from mixed provider tool shapes", () => {
     expect(
       extractTraceToolNames([


### PR DESCRIPTION
## Summary
- redact sensitive keys recursively when cloning Grok provider trace payloads
- route iterable provider error headers through the same trace redactor
- add regressions for remote MCP auth/header redaction in traces

## Verification
- local vLLM finding review: YES
- local vLLM diff review: VERDICT: APPROVED
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/llm/providers/grok/adapter-utils.test.ts
- npm run typecheck
- npm test
- npm run test:bun
- pre-commit hook: npm --workspace=@tetsuo-ai/runtime run build + check:tui-runtime-startup

Remote workflow state checked: Transaction Guard Live disabled_manually.