### PR TITLE
fix(runtime): require loopback daemon websocket binds

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -8,7 +8,7 @@
 
 import { spawn } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { createConnection } from "node:net";
+import { createConnection, isIP } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -168,6 +168,8 @@ export function buildAgenCDaemonChildNodeArgs(
   ];
 }
 const AGENC_DAEMON_WEBSOCKET_HOST_ENV = "AGENC_DAEMON_WEBSOCKET_HOST";
+const AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK_ENV =
+  "AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK";
 export const AGENC_DAEMON_WEBSOCKET_PORT_ENV = "AGENC_DAEMON_WEBSOCKET_PORT";
 const AGENC_DAEMON_WEBSOCKET_PATH_ENV = "AGENC_DAEMON_WEBSOCKET_PATH";
 const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV =
@@ -262,6 +264,15 @@ export function resolveAgenCDaemonWebSocketListenOptions(
   const host =
     env[AGENC_DAEMON_WEBSOCKET_HOST_ENV]?.trim() ||
     AGENC_DAEMON_WEBSOCKET_DEFAULT_HOST;
+  if (
+    !isLoopbackListenHost(host) &&
+    !allowsNonLoopbackDaemonWebSocketHost(env)
+  ) {
+    throw new Error(
+      `${AGENC_DAEMON_WEBSOCKET_HOST_ENV} must be a loopback host unless ` +
+        `${AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK_ENV}=1 is set`,
+    );
+  }
   const path =
     env[AGENC_DAEMON_WEBSOCKET_PATH_ENV]?.trim() ||
     AGENC_DAEMON_WEBSOCKET_DEFAULT_PATH;
@@ -327,6 +338,22 @@ function isLoopbackHostname(hostname: string): boolean {
     normalized === "127.0.0.1" ||
     normalized === "::1"
   );
+}
+
+function isLoopbackListenHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  const ipFamily = isIP(normalized);
+  if (ipFamily === 4) return normalized.startsWith("127.");
+  return false;
+}
+
+function allowsNonLoopbackDaemonWebSocketHost(
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const value = env[AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK_ENV]?.trim()
+    .toLowerCase();
+  return value === "1" || value === "true";
 }
 
 export function resolveAgenCDaemonPidPath(

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -495,6 +495,32 @@ describe("AgenC daemon CLI", () => {
         [AGENC_DAEMON_WEBSOCKET_PORT_ENV]: "0",
       }).port,
     ).toBe(0);
+    expect(
+      resolveAgenCDaemonWebSocketListenOptions({
+        AGENC_HOME: "/tmp/agenc-isolated-home",
+        AGENC_DAEMON_WEBSOCKET_HOST: "127.0.0.2",
+      }),
+    ).toMatchObject({
+      host: "127.0.0.2",
+      port: 0,
+    });
+    expect(() =>
+      resolveAgenCDaemonWebSocketListenOptions({
+        AGENC_HOME: "/tmp/agenc-isolated-home",
+        AGENC_DAEMON_WEBSOCKET_HOST: "0.0.0.0",
+        AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK: "yes",
+      }),
+    ).toThrow(/must be a loopback host/);
+    expect(
+      resolveAgenCDaemonWebSocketListenOptions({
+        AGENC_HOME: "/tmp/agenc-isolated-home",
+        AGENC_DAEMON_WEBSOCKET_HOST: "0.0.0.0",
+        AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK: "TRUE",
+      }),
+    ).toMatchObject({
+      host: "0.0.0.0",
+      port: 0,
+    });
     expect(validateAgenCDaemonWebSocketOrigin(undefined)).toBe(true);
     expect(validateAgenCDaemonWebSocketOrigin("http://127.0.0.1:4173")).toBe(
       true,


### PR DESCRIPTION
## Summary
- reject daemon WebSocket bind hosts that are not loopback by default
- add explicit AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK opt-in for intentional non-loopback binds
- cover loopback aliases, invalid opt-in values, and explicit opt-in in daemon CLI contract tests

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/app-server/daemon-cli.contract.test.ts --reporter=dot
- npm run typecheck
- npm run test:bun
- npm test
- pre-commit hook: npm run build + check:tui-runtime-startup