### PR TITLE
fix(runtime): encode MCP root file URIs

### DIFF
--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -38,6 +38,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import mapValues from 'lodash-es/mapValues.js'
 import memoize from 'lodash-es/memoize.js'
+import { pathToFileURL } from 'node:url'
 import zipObject from 'lodash-es/zipObject.js'
 import pMap from 'p-map'
 import { getOriginalCwd, getSessionId } from '../../bootstrap/state.js'
@@ -619,6 +620,10 @@ const MCP_REQUEST_TIMEOUT_MS = 60000
  */
 const MCP_STREAMABLE_HTTP_ACCEPT = 'application/json, text/event-stream'
 
+export function getMcpRootUriForPath(path: string): string {
+  return pathToFileURL(path).href
+}
+
 /**
  * Wraps a fetch function to apply a fresh timeout signal to each request.
  * This avoids the bug where a single AbortSignal.timeout() created at connection
@@ -1158,7 +1163,7 @@ export const connectToServer = memoize(
         return {
           roots: [
             {
-              uri: `file://${getOriginalCwd()}`,
+              uri: getMcpRootUriForPath(getOriginalCwd()),
             },
           ],
         }

--- a/runtime/tests/services/mcp/client.test.ts
+++ b/runtime/tests/services/mcp/client.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, test, vi } from 'vitest'
 
@@ -23,6 +24,7 @@ import {
   ensureConnectedClient,
   fetchResourcesForClient,
   fetchToolsForClient,
+  getMcpRootUriForPath,
   getMcpServerConnectionBatchSize,
   prefetchAllMcpResources,
   reconnectMcpServerImpl,
@@ -87,6 +89,17 @@ function connectedClient(
     } as never),
   } as ConnectedMCPServer
 }
+
+test('getMcpRootUriForPath encodes roots as unambiguous file URIs', () => {
+  const rootPath = '/tmp/agenc roots/#repo?query%done'
+  const uri = getMcpRootUriForPath(rootPath)
+  const parsed = new URL(uri)
+
+  assert.equal(parsed.protocol, 'file:')
+  assert.equal(parsed.hash, '')
+  assert.equal(parsed.search, '')
+  assert.equal(fileURLToPath(uri), rootPath)
+})
 
 function seedConnectionCache(
   name: string,


### PR DESCRIPTION
## Summary
- encode MCP roots with pathToFileURL instead of string interpolation
- add a round-trip test for ambiguous path characters in root paths

## Verification
- npm --workspace=@tetsuo-ai/runtime test -- tests/services/mcp/client.test.ts tests/services/mcp/client-sdk-setup.test.ts
- npm run typecheck
- npm test
- npm run test:bun
- npm run validate:runtime
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --audit-level=high
- git diff --check
- pre-commit hook: build + check:tui-runtime-startup