### PR TITLE
fix(runtime): quote MCP shell-prefix argv

### DIFF
--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -70,6 +70,7 @@ import {
   errorMessage,
   TelemetrySafeError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
 } from '../../utils/errors.js'
+import { quote as quoteShellArgs } from '../../utils/bash/shellQuote.js'
 import { getMCPUserAgent } from '../../utils/http.js'
 import { maybeNotifyIDEConnected } from '../../utils/ide.js'
 import { maybeResizeAndDownsampleImageBuffer } from '../../utils/imageResizer.js'
@@ -624,6 +625,13 @@ export function getMcpRootUriForPath(path: string): string {
   return pathToFileURL(path).href
 }
 
+export function formatMcpShellPrefixCommand(
+  command: string,
+  args: readonly string[],
+): string {
+  return quoteShellArgs([command, ...args])
+}
+
 /**
  * Wraps a fetch function to apply a fresh timeout signal to each request.
  * This avoids the bug where a single AbortSignal.timeout() created at connection
@@ -1095,7 +1103,7 @@ export const connectToServer = memoize(
         const finalCommand =
           process.env.AGENC_SHELL_PREFIX || serverRef.command
         const finalArgs = process.env.AGENC_SHELL_PREFIX
-          ? [[serverRef.command, ...serverRef.args].join(' ')]
+          ? [formatMcpShellPrefixCommand(serverRef.command, serverRef.args)]
           : serverRef.args
         transport = new StdioClientTransport({
           command: finalCommand,

--- a/runtime/tests/services/mcp/client-sdk-setup.test.ts
+++ b/runtime/tests/services/mcp/client-sdk-setup.test.ts
@@ -49,6 +49,7 @@ const nativeFetchLog: Array<{
 const tempDirs: string[] = []
 const originalLargeOutputFiles = process.env.ENABLE_MCP_LARGE_OUTPUT_FILES
 const originalMcpTimeout = process.env.MCP_TIMEOUT
+const originalShellPrefix = process.env.AGENC_SHELL_PREFIX
 const mutableGlobal = globalThis as unknown as {
   Bun?: unknown
   WebSocket?: unknown
@@ -282,6 +283,11 @@ afterEach(async () => {
     delete process.env.MCP_TIMEOUT
   } else {
     process.env.MCP_TIMEOUT = originalMcpTimeout
+  }
+  if (originalShellPrefix === undefined) {
+    delete process.env.AGENC_SHELL_PREFIX
+  } else {
+    process.env.AGENC_SHELL_PREFIX = originalShellPrefix
   }
   if (originalBun === undefined) {
     delete mutableGlobal.Bun
@@ -753,6 +759,51 @@ test('connectToServer creates stdio clients with lifecycle handlers and cleanup'
     await reconnected.cleanup()
   }
   assert.equal(fakeClients[1]?.closed, true)
+})
+
+test('connectToServer quotes stdio argv when a shell prefix is configured', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  process.env.AGENC_SHELL_PREFIX = 'bash -lc'
+  const { connectToServer, formatMcpShellPrefixCommand } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: [
+      '--path',
+      'space dir',
+      '$(touch /tmp/agenc-mcp-pwned)',
+      '; echo pwned',
+    ],
+    scope: 'local',
+  } as const
+
+  const result = await connectToServer('stdio-demo', config)
+
+  assert.equal(result.type, 'connected')
+  assert.equal(fakeStdioTransports[0]?.command, 'bash -lc')
+  assert.deepEqual(fakeStdioTransports[0]?.args, [
+    formatMcpShellPrefixCommand(config.command, config.args),
+  ])
+  assert.notEqual(
+    fakeStdioTransports[0]?.args[0],
+    [config.command, ...config.args].join(' '),
+  )
+  const shellCommand = fakeStdioTransports[0]?.args[0] ?? ''
+  assert.equal(shellCommand.includes("'$(touch /tmp/agenc-mcp-pwned)'"), true)
+  assert.equal(shellCommand.includes("'; echo pwned'"), true)
+
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
 })
 
 test('connectToServer logs successful stdio startup stderr before cleanup', async () => {


### PR DESCRIPTION
## Summary
- quote MCP stdio command/args when AGENC_SHELL_PREFIX is enabled
- preserve normal stdio argv behavior when no shell prefix is configured
- add regression coverage for shell metacharacters in configured MCP args

## Verification
- local vLLM candidate review: VERDICT YES
- local vLLM diff review: VERDICT APPROVED
- npm --workspace=@tetsuo-ai/runtime test -- tests/services/mcp/client-sdk-setup.test.ts
- npm --workspace=@tetsuo-ai/runtime test -- tests/services/mcp/client-sdk-setup.test.ts tests/services/mcp/client.test.ts tests/services/mcp/config-toml-namespace.test.ts
- npm run typecheck
- npm test
- npm run test:bun
- npm run validate:runtime
- npm --workspace=@tetsuo-ai/runtime run check:unused
- npm audit --audit-level=high
- AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000
- git diff --check
- pre-commit hook: build + check:tui-runtime-startup