### PR TITLE
fix(runtime): validate MCP headers

### DIFF
--- a/runtime/src/services/mcp/headerValidation.ts
+++ b/runtime/src/services/mcp/headerValidation.ts
@@ -1,0 +1,72 @@
+const MCP_MAX_HEADERS = 64
+const MCP_MAX_HEADER_NAME_LENGTH = 128
+const MCP_MAX_HEADER_VALUE_BYTES = 8192
+
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+// HTTP header values must not contain request-splitting control bytes.
+// Reject HTAB too; MCP auth/header values should not need embedded controls.
+const CONTROL_BYTE_PATTERN = /[\x00-\x1f\x7f]/
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function validateMcpHeaderName(name: string, source: string): void {
+  if (name.length === 0) {
+    throw new Error(`${source}: header name cannot be empty`)
+  }
+  if (name.length > MCP_MAX_HEADER_NAME_LENGTH) {
+    throw new Error(
+      `${source}: header name "${name}" exceeds ${MCP_MAX_HEADER_NAME_LENGTH} characters`,
+    )
+  }
+  if (!HTTP_HEADER_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `${source}: invalid header name "${name}"; header names must be RFC token characters`,
+    )
+  }
+}
+
+function validateMcpHeaderValue(
+  name: string,
+  value: string,
+  source: string,
+): void {
+  if (CONTROL_BYTE_PATTERN.test(value)) {
+    throw new Error(
+      `${source}: header "${name}" contains control characters`,
+    )
+  }
+  const valueBytes = byteLength(value)
+  if (valueBytes > MCP_MAX_HEADER_VALUE_BYTES) {
+    throw new Error(
+      `${source}: header "${name}" exceeds ${MCP_MAX_HEADER_VALUE_BYTES} bytes`,
+    )
+  }
+}
+
+export function validateMcpHeaders(
+  headers: Record<string, string>,
+  source: string,
+): Record<string, string> {
+  const entries = Object.entries(headers)
+  if (entries.length > MCP_MAX_HEADERS) {
+    throw new Error(
+      `${source}: too many headers (${entries.length}; max ${MCP_MAX_HEADERS})`,
+    )
+  }
+
+  const validated: Record<string, string> = {}
+  const seenNames = new Set<string>()
+  for (const [name, value] of entries) {
+    validateMcpHeaderName(name, source)
+    const normalizedName = name.toLowerCase()
+    if (seenNames.has(normalizedName)) {
+      throw new Error(`${source}: duplicate header name "${name}"`)
+    }
+    seenNames.add(normalizedName)
+    validateMcpHeaderValue(name, value, source)
+    validated[name] = value
+  }
+  return validated
+}

--- a/runtime/src/services/mcp/headersHelper.ts
+++ b/runtime/src/services/mcp/headersHelper.ts
@@ -11,6 +11,7 @@ import type {
   McpWebSocketServerConfig,
   ScopedMcpServerConfig,
 } from './types.js'
+import { validateMcpHeaders } from './headerValidation.js'
 /**
  * Check if the MCP server config comes from project settings (projectSettings or localSettings)
  * This is important for security checks
@@ -98,11 +99,16 @@ async function getMcpHeadersFromHelper(
       }
     }
 
+    const validatedHeaders = validateMcpHeaders(
+      headers as Record<string, string>,
+      `headersHelper for MCP server '${serverName}'`,
+    )
+
     logMCPDebug(
       serverName,
-      `Successfully retrieved ${Object.keys(headers).length} headers from headersHelper`,
+      `Successfully retrieved ${Object.keys(validatedHeaders).length} headers from headersHelper`,
     )
-    return headers as Record<string, string>
+    return validatedHeaders
   } catch (error) {
     logMCPError(
       serverName,
@@ -127,12 +133,18 @@ export async function getMcpServerHeaders(
   serverName: string,
   config: McpSSEServerConfig | McpHTTPServerConfig | McpWebSocketServerConfig,
 ): Promise<Record<string, string>> {
-  const staticHeaders = config.headers || {}
+  const staticHeaders = validateMcpHeaders(
+    config.headers || {},
+    `static headers for MCP server '${serverName}'`,
+  )
   const dynamicHeaders =
     (await getMcpHeadersFromHelper(serverName, config)) || {}
   // Dynamic headers override static headers if both are present
-  return {
-    ...staticHeaders,
-    ...dynamicHeaders,
-  }
+  return validateMcpHeaders(
+    {
+      ...staticHeaders,
+      ...dynamicHeaders,
+    },
+    `combined headers for MCP server '${serverName}'`,
+  )
 }

--- a/runtime/src/services/mcp/utils.ts
+++ b/runtime/src/services/mcp/utils.ts
@@ -9,6 +9,7 @@ import {
   hasSkipDangerousModePermissionPrompt,
 } from '../../utils/settings/settings.js'
 import { getEnterpriseMcpFilePath } from './config.js'
+import { validateMcpHeaders } from './headerValidation.js'
 import { mcpInfoFromString } from './mcpStringUtils.js'
 import { normalizeNameForMCP } from './normalization.js'
 import {
@@ -120,7 +121,7 @@ export function parseHeaders(headerArray: string[]): Record<string, string> {
     headers[key] = value
   }
 
-  return headers
+  return validateMcpHeaders(headers, 'MCP CLI headers')
 }
 
 export function getProjectMcpServerStatus(
@@ -179,4 +180,3 @@ export function getProjectMcpServerStatus(
 
   return 'pending'
 }
-

--- a/runtime/tests/services/mcp/headersHelper.test.ts
+++ b/runtime/tests/services/mcp/headersHelper.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import { afterEach, test, vi } from 'vitest'
+
+const headerHelperMocks = vi.hoisted(() => ({
+  execFileNoThrowWithCwd: vi.fn(),
+}))
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrowWithCwd: headerHelperMocks.execFileNoThrowWithCwd,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: vi.fn(),
+  logMCPDebug: vi.fn(),
+  logMCPError: vi.fn(),
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logAntError: vi.fn(),
+}))
+
+import { getMcpServerHeaders } from './headersHelper.js'
+import { parseHeaders } from './utils.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function httpConfig(
+  overrides: Partial<Parameters<typeof getMcpServerHeaders>[1]> = {},
+): Parameters<typeof getMcpServerHeaders>[1] {
+  return {
+    type: 'http',
+    url: 'https://example.test/mcp',
+    ...overrides,
+  }
+}
+
+test('getMcpServerHeaders merges validated static and helper headers', async () => {
+  headerHelperMocks.execFileNoThrowWithCwd.mockResolvedValue({
+    code: 0,
+    stdout: JSON.stringify({
+      Authorization: 'Bearer dynamic',
+      'X-Helper': 'yes',
+    }),
+    stderr: '',
+  })
+
+  const headers = await getMcpServerHeaders(
+    'docs',
+    httpConfig({
+      headers: {
+        Authorization: 'Bearer static',
+        'X-Static': 'yes',
+      },
+      headersHelper: 'helper',
+    }),
+  )
+
+  assert.deepEqual(headers, {
+    Authorization: 'Bearer dynamic',
+    'X-Static': 'yes',
+    'X-Helper': 'yes',
+  })
+})
+
+test('getMcpServerHeaders ignores helper headers with invalid names', async () => {
+  headerHelperMocks.execFileNoThrowWithCwd.mockResolvedValue({
+    code: 0,
+    stdout: JSON.stringify({ 'Bad Header': 'value' }),
+    stderr: '',
+  })
+
+  const headers = await getMcpServerHeaders(
+    'docs',
+    httpConfig({ headersHelper: 'helper' }),
+  )
+
+  assert.deepEqual(headers, {})
+})
+
+test('getMcpServerHeaders ignores helper headers with control characters', async () => {
+  headerHelperMocks.execFileNoThrowWithCwd.mockResolvedValue({
+    code: 0,
+    stdout: JSON.stringify({
+      Authorization: 'Bearer token\r\nX-Evil: 1',
+    }),
+    stderr: '',
+  })
+
+  const headers = await getMcpServerHeaders(
+    'docs',
+    httpConfig({
+      headers: { 'X-Static': 'yes' },
+      headersHelper: 'helper',
+    }),
+  )
+
+  assert.deepEqual(headers, { 'X-Static': 'yes' })
+})
+
+test('getMcpServerHeaders ignores helper headers that exceed the count cap', async () => {
+  const manyHeaders = Object.fromEntries(
+    Array.from({ length: 65 }, (_, index) => [`X-Test-${index}`, 'value']),
+  )
+  headerHelperMocks.execFileNoThrowWithCwd.mockResolvedValue({
+    code: 0,
+    stdout: JSON.stringify(manyHeaders),
+    stderr: '',
+  })
+
+  const headers = await getMcpServerHeaders(
+    'docs',
+    httpConfig({ headersHelper: 'helper' }),
+  )
+
+  assert.deepEqual(headers, {})
+})
+
+test('getMcpServerHeaders rejects invalid static headers', async () => {
+  await assert.rejects(
+    () =>
+      getMcpServerHeaders(
+        'docs',
+        httpConfig({ headers: { 'Bad Header': 'value' } }),
+      ),
+    /invalid header name/,
+  )
+})
+
+test('parseHeaders rejects invalid names and control characters', () => {
+  assert.throws(() => parseHeaders(['Bad Header: value']), /invalid header name/)
+  assert.throws(
+    () => parseHeaders(['Authorization: Bearer token\r\nX-Evil: 1']),
+    /control characters/,
+  )
+})
+
+test('parseHeaders rejects duplicate header names by case-insensitive match', () => {
+  assert.throws(
+    () => parseHeaders(['Authorization: Bearer one', 'authorization: Bearer two']),
+    /duplicate header name/,
+  )
+})
+
+test('parseHeaders rejects header count and size caps', () => {
+  assert.throws(
+    () =>
+      parseHeaders(
+        Array.from({ length: 65 }, (_, index) => [`X-Test-${index}: value`]).flat(),
+      ),
+    /too many headers/,
+  )
+  assert.throws(() => parseHeaders([`${'X'.repeat(129)}: value`]), /exceeds 128/)
+  assert.throws(
+    () => parseHeaders([`Authorization: ${'x'.repeat(8193)}`]),
+    /exceeds 8192/,
+  )
+})


### PR DESCRIPTION
## Summary
- add shared validation for MCP static, helper, and merged transport headers
- reject invalid header names, control-byte values, excessive header count/value/name size, and case-insensitive duplicates
- keep invalid dynamic helper output non-fatal while rejecting invalid static/CLI header config early

## Verification
- local vLLM candidate review: yes, header validation gap was actionable
- local vLLM diff review: requested cap/duplicate coverage; addressed with tests and duplicate detection
- `npm --workspace=@tetsuo-ai/runtime test -- tests/services/mcp/headersHelper.test.ts tests/bin/mcp-cli-management.test.ts`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run check:unused`
- `git diff --cached --check`
- `npm test`
- `npm run test:bun`
- `npm audit --audit-level=high`
- `AGENC_LOCAL_VLLM_BASE_URL=http://127.0.0.1:11434/v1 AGENC_LOCAL_VLLM_MODEL=dolphin3:latest npm run check:local-vllm -- --timeout-ms 120000`
- `npm run validate:runtime`
- pre-commit hook: build + package entrypoints + TUI runtime startup smoke
