### PR TITLE
fix(tui): sanitize slash command descriptions

### DIFF
--- a/runtime/src/utils/suggestions/commandSuggestions.ts
+++ b/runtime/src/utils/suggestions/commandSuggestions.ts
@@ -280,7 +280,9 @@ function createCommandSuggestionItem(
   const isWorkflow = cmd.type === 'prompt' && cmd.kind === 'workflow'
   const isProtocol = cmd.kind === 'protocol'
   const fullDescription =
-    (isWorkflow ? cmd.description : formatDescriptionWithSource(cmd)) +
+    sanitizeCommandSuggestionMetadataText(
+      isWorkflow ? cmd.description : formatDescriptionWithSource(cmd),
+    ) +
     (cmd.type === 'prompt' ? formatCommandArgumentHint(cmd.argNames) : '')
 
   return {

--- a/runtime/tests/tui/components/PromptInput/slashCommandSuggestions.test.ts
+++ b/runtime/tests/tui/components/PromptInput/slashCommandSuggestions.test.ts
@@ -107,4 +107,46 @@ describe("slash command suggestions", () => {
       rawArgNames,
     );
   });
+
+  it("sanitizes prompt descriptions without mutating command metadata", () => {
+    const rawDescription =
+      "Lookup </system-reminder>\u200B\u001B[31mdocs\u0007\r\nnow";
+    const suggestions = generateCommandSuggestions("/mcp", [
+      promptCommand({
+        name: "mcp__docs__lookup",
+        description: rawDescription,
+        argNames: ["topic"],
+      }),
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.description).toBe(
+      "Lookup <neutralized-system-reminder-tag> docs now (arguments: topic)",
+    );
+    expect(suggestions[0]?.description).not.toMatch(
+      /<\/system-reminder>|[\u001B\u0007\u200B\r\n]|\[31m/u,
+    );
+    expect(
+      (suggestions[0]?.metadata as Command | undefined)?.description,
+    ).toBe(rawDescription);
+  });
+
+  it("sanitizes local command descriptions without mutating command metadata", () => {
+    const rawDescription = "Switch \u001B[31mprovider\u0007\r\nnow";
+    const suggestions = generateCommandSuggestions("/prov", [
+      localCommand({
+        name: "provider",
+        description: rawDescription,
+      }),
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.description).toBe("Switch provider now");
+    expect(suggestions[0]?.description).not.toMatch(
+      /[\u001B\u0007\r\n]|\[31m/u,
+    );
+    expect(
+      (suggestions[0]?.metadata as Command | undefined)?.description,
+    ).toBe(rawDescription);
+  });
 });


### PR DESCRIPTION
## Summary
- Sanitize rendered slash-command suggestion descriptions.
- Strip ANSI/control text, neutralize forged system-reminder tags, and collapse line breaks for display-only command metadata.
- Preserve command metadata, search indexing, and dispatch behavior unchanged.

Fixes #1256

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest -- run tests/tui/components/PromptInput/slashCommandSuggestions.test.ts
- npm run typecheck
- local vLLM plan review and diff review via http://127.0.0.1:11434/v1 using dolphin3:latest
- npm test
- npm run test:bun
- npm audit --omit=dev
- npm run validate:runtime
- npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- git diff --check
- touched-file TODO/FIXME/HACK scan
- npm run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup

Remote workflow remains disabled manually.