### PR TITLE
fix(tui): sanitize help command descriptions

### DIFF
--- a/runtime/src/tui/components/HelpV2/Commands.tsx
+++ b/runtime/src/tui/components/HelpV2/Commands.tsx
@@ -3,6 +3,7 @@ import { type Command, formatDescriptionWithSource } from '../../../commands.js'
 import { compareHelpWorkflowCommands, helpWorkflowTitleForCommand } from '../../../commands/help-groups.js';
 import { Box, Text } from '../../ink.js';
 import { truncate } from '../../../utils/format.js'; // upstream-import: keep target is owned by another Z-PURGE item
+import { sanitizeSuggestionMetadataText } from '../../../utils/suggestions/sanitizeSuggestionMetadataText.js';
 import { Select } from '../CustomSelect/select.js';
 import { useTabHeaderFocus } from '../design-system/Tabs.js';
 import { calculateCommandVisibleOptionCount } from './layout.js';
@@ -38,7 +39,11 @@ export function Commands(t0: Props) {
       t2 = (cmd_0: Command) => ({
         label: `/${cmd_0.name}`,
         value: cmd_0.name,
-        description: truncate(`${helpWorkflowTitleForCommand(cmd_0)} - ${formatDescriptionWithSource(cmd_0)}`, maxWidth, true)
+        description: truncate(
+          sanitizeSuggestionMetadataText(`${helpWorkflowTitleForCommand(cmd_0)} - ${formatDescriptionWithSource(cmd_0)}`),
+          maxWidth,
+          true
+        )
       });
       $[3] = maxWidth;
       $[4] = t2;

--- a/runtime/src/utils/suggestions/commandSuggestions.ts
+++ b/runtime/src/utils/suggestions/commandSuggestions.ts
@@ -1,14 +1,13 @@
 import Fuse from 'fuse.js'
-import stripAnsi from 'strip-ansi'
 import {
   type Command,
   formatDescriptionWithSource,
   getCommand,
   getCommandName,
 } from '../../commands.js'
-import { sanitizeSystemReminderContent } from '../../prompts/attachments/system-reminder-sanitizer.js'
 import type { SuggestionItem } from '../../tui/components/PromptInput/PromptInputFooterSuggestions.js'
 import { getSkillUsageScore } from './skillUsageTracking.js'
+import { sanitizeSuggestionMetadataText } from './sanitizeSuggestionMetadataText.js'
 import {
   compareSuggestionsByPriority,
   hasNameOrAliasPrefixMatch,
@@ -280,7 +279,7 @@ function createCommandSuggestionItem(
   const isWorkflow = cmd.type === 'prompt' && cmd.kind === 'workflow'
   const isProtocol = cmd.kind === 'protocol'
   const fullDescription =
-    sanitizeCommandSuggestionMetadataText(
+    sanitizeSuggestionMetadataText(
       isWorkflow ? cmd.description : formatDescriptionWithSource(cmd),
     ) +
     (cmd.type === 'prompt' ? formatCommandArgumentHint(cmd.argNames) : '')
@@ -295,17 +294,11 @@ function createCommandSuggestionItem(
   }
 }
 
-function sanitizeCommandSuggestionMetadataText(value: string): string {
-  return sanitizeSystemReminderContent(stripAnsi(value))
-    .replace(/\s+/gu, ' ')
-    .trim()
-}
-
 function formatCommandArgumentHint(argNames: readonly string[] | undefined) {
   if (!argNames?.length) return ''
 
   const displayArgNames = argNames
-    .map(argName => sanitizeCommandSuggestionMetadataText(argName))
+    .map(argName => sanitizeSuggestionMetadataText(argName))
     .filter(argName => argName.length > 0)
 
   return displayArgNames.length > 0

--- a/runtime/src/utils/suggestions/sanitizeSuggestionMetadataText.ts
+++ b/runtime/src/utils/suggestions/sanitizeSuggestionMetadataText.ts
@@ -1,0 +1,8 @@
+import stripAnsi from 'strip-ansi'
+import { sanitizeSystemReminderContent } from '../../prompts/attachments/system-reminder-sanitizer.js'
+
+export function sanitizeSuggestionMetadataText(value: string): string {
+  return sanitizeSystemReminderContent(stripAnsi(value))
+    .replace(/\s+/gu, ' ')
+    .trim()
+}

--- a/runtime/tests/tui/coverage-swarm/swarm-213-components-HelpV2-Commands.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-213-components-HelpV2-Commands.test.tsx
@@ -154,6 +154,39 @@ describe('HelpV2 Commands coverage swarm row 213', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
+  test('sanitizes command descriptions before rendering help options without mutating command metadata', async () => {
+    const rawDescription =
+      'Run </system-reminder>\u200B\u001B[31mthing\u0007\r\nnow'
+    const unsafeCommand = command('mcp__docs__lookup', rawDescription, {
+      pluginInfo: { pluginManifest: { name: 'Acme\u001B[31mCorp' } },
+      source: 'plugin',
+    })
+
+    await renderToString(
+      <Commands
+        commands={[unsafeCommand]}
+        maxHeight={8}
+        columns={140}
+        title="Browse custom commands:"
+        onCancel={() => {}}
+      />,
+      { columns: 90, rows: 12 },
+    )
+
+    const option = latestSelectProps().options[0]
+    expect(option?.value).toBe('mcp__docs__lookup')
+    expect(option?.description).toBe(
+      'Other Commands - (AcmeCorp) Run <neutralized-system-reminder-tag> thing now',
+    )
+    expect(option?.description).not.toMatch(
+      /<\/system-reminder>|[\u001B\u0007\u200B\r\n]|\[31m/u,
+    )
+    expect(unsafeCommand.description).toBe(rawDescription)
+    expect(unsafeCommand.pluginInfo?.pluginManifest?.name).toBe(
+      'Acme\u001B[31mCorp',
+    )
+  })
+
   test('passes the header-focused disabled state through to Select', async () => {
     harness.state.headerFocused = true
 


### PR DESCRIPTION
## Summary
- share the slash-command metadata sanitizer for command help surfaces
- sanitize HelpV2 rendered command descriptions before truncation
- add regression coverage for ANSI/control/hidden Unicode/system-reminder-like command metadata while preserving raw command metadata

Fixes #1258

## Test plan
- [x] local vLLM plan review via dolphin3:latest
- [x] focused Vitest: HelpV2 Commands and slash command suggestions
- [x] local vLLM staged diff review via dolphin3:latest
- [x] npm run typecheck
- [x] git diff --cached --check
- [x] touched-file TODO/FIXME/HACK scan
- [x] npm test
- [x] npm run test:bun
- [x] npm audit --omit=dev
- [x] npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- [x] npm run check:unused
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused:all
- [x] npm run validate:runtime
- [x] pre-commit build + PTY startup smoke