### PR TITLE
fix(tui): sanitize text help command descriptions

### DIFF
--- a/runtime/src/commands/help.ts
+++ b/runtime/src/commands/help.ts
@@ -23,6 +23,7 @@ import {
   OTHER_COMMANDS_TITLE,
   helpWorkflowTitleForCommand,
 } from "./help-groups.js";
+import { sanitizeSuggestionMetadataText } from "../utils/suggestions/sanitizeSuggestionMetadataText.js";
 
 export interface HelpCommand {
   readonly name: string;
@@ -154,6 +155,10 @@ function formatCommandNames(command: HelpCommand): string {
 }
 
 function formatDescription(command: HelpCommand): string {
+  return sanitizeSuggestionMetadataText(formatRawDescription(command));
+}
+
+function formatRawDescription(command: HelpCommand): string {
   const description = command.description ?? "";
   if (command.type !== "prompt") return description;
   if (command.kind === "workflow") return `${description} (workflow)`;

--- a/runtime/tests/commands/help.test.ts
+++ b/runtime/tests/commands/help.test.ts
@@ -7,6 +7,7 @@ import {
   formatHelpCommands,
   groupHelpCommands,
   normalizeHelpQuery,
+  type HelpCommand,
 } from "./help.js";
 import {
   setGlobalCommandRegistry,
@@ -273,6 +274,30 @@ describe("helpCommand", () => {
     expect(text).toContain("/help - help");
     expect(text).toContain("Custom Commands:");
     expect(text).toContain("/team-skill - Team skill (bundled)");
+  });
+
+  it("sanitizes rendered command descriptions without mutating command metadata", () => {
+    const rawDescription =
+      "Run </system-reminder>\u200B\u001B[31mthing\u0007\r\nnow";
+    const rawPluginName = "Acme\u001B[31mCorp";
+    const unsafeCommand: HelpCommand = {
+      name: "mcp__docs__lookup",
+      description: rawDescription,
+      type: "prompt",
+      source: "plugin",
+      pluginInfo: { pluginManifest: { name: rawPluginName } },
+    };
+
+    const text = formatHelpCommands([unsafeCommand]);
+
+    expect(text).toContain(
+      "/mcp__docs__lookup - (AcmeCorp) Run <neutralized-system-reminder-tag> thing now",
+    );
+    expect(text).not.toMatch(
+      /<\/system-reminder>|[\u001B\u0007\u200B\r]|\[31m/u,
+    );
+    expect(unsafeCommand.description).toBe(rawDescription);
+    expect(unsafeCommand.pluginInfo?.pluginManifest?.name).toBe(rawPluginName);
   });
 });
 


### PR DESCRIPTION
## Summary
- sanitize rendered text /help command descriptions with the shared suggestion metadata sanitizer
- preserve raw command metadata, command names, aliases, grouping, filtering, and dispatch
- add regression coverage for ANSI/control/hidden Unicode/system-reminder-like prompt command metadata

Fixes #1260

## Test plan
- [x] local vLLM plan review via dolphin3:latest
- [x] focused Vitest: help, HelpV2 Commands, slash command suggestions
- [x] local vLLM staged diff review via dolphin3:latest
- [x] npm run typecheck
- [x] git diff --cached --check
- [x] touched-file TODO/FIXME/HACK scan
- [x] npm test
- [x] npm run test:bun
- [x] npm audit --omit=dev
- [x] npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- [x] npm run check:unused
- [x] npm --workspace=@tetsuo-ai/runtime run check:unused:all
- [x] npm run validate:runtime
- [x] pre-commit build + PTY startup smoke