### PR TITLE
fix(runtime): normalize plugin command identifiers

### DIFF
--- a/runtime/src/plugins/registration/load-plugin-commands.ts
+++ b/runtime/src/plugins/registration/load-plugin-commands.ts
@@ -91,13 +91,41 @@ function isSkillFile(filePath: string): boolean {
   return basename(filePath).toLowerCase() === "skill.md";
 }
 
+function normalizeSlashCommandSegment(value: string, fallback: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/gu, "_")
+    .replace(/_+/gu, "_")
+    .replace(/^_+|_+$/gu, "");
+  const segment = normalized.length > 0 ? normalized : fallback;
+  return /^[a-z]/u.test(segment) ? segment : `cmd_${segment}`;
+}
+
+function normalizeSlashCommandName(parts: readonly string[]): string {
+  return parts
+    .map((part, index) =>
+      normalizeSlashCommandSegment(
+        part,
+        index === parts.length - 1 ? "command" : "namespace",
+      )
+    )
+    .join(":");
+}
+
+function pluginCommandName(
+  pluginName: string,
+  parts: readonly string[],
+): string {
+  return normalizeSlashCommandName([pluginName, ...parts]);
+}
+
 function commandNameFromFile(
   file: ParsedMarkdownFile,
   pluginName: string,
 ): string {
   const namespace = namespaceFromCommandPath(file.filePath, file.baseDir);
   const name = markdownStem(file.filePath);
-  return [pluginName, ...namespace, name].join(":");
+  return pluginCommandName(pluginName, [...namespace, name]);
 }
 
 function skillNameFromFile(
@@ -111,7 +139,7 @@ function skillNameFromFile(
     !rel || rel === "." || rel.startsWith("..")
       ? []
       : rel.split(sep).filter((part) => part.length > 0);
-  return [pluginName, ...namespace, basename(skillDir)].join(":");
+  return pluginCommandName(pluginName, [...namespace, basename(skillDir)]);
 }
 
 function namespaceFromCommandPath(filePath: string, baseDir: string): readonly string[] {
@@ -126,7 +154,12 @@ function commandDisplayName(
   frontmatter: Record<string, unknown>,
 ): string {
   const displayName = coerceString(frontmatter.name);
-  return displayName?.startsWith(`${pluginName}:`) ? displayName : commandName;
+  if (!displayName) return commandName;
+  const normalizedDisplayName = normalizeSlashCommandName(displayName.split(":"));
+  const pluginPrefix = `${normalizeSlashCommandSegment(pluginName, "plugin")}:`;
+  return normalizedDisplayName.startsWith(pluginPrefix)
+    ? normalizedDisplayName
+    : commandName;
 }
 
 function metadataFrontmatter(
@@ -185,9 +218,17 @@ function namespacedAliases(
   pluginName: string,
   aliases: readonly string[],
 ): string[] | undefined {
-  const prefix = `${pluginName}:`;
+  const normalizedPluginName = normalizeSlashCommandSegment(
+    pluginName,
+    "plugin",
+  );
+  const prefix = `${normalizedPluginName}:`;
   const out = aliases
-    .map((alias) => alias.includes(":") ? alias : `${prefix}${alias}`)
+    .map((alias) =>
+      alias.includes(":")
+        ? normalizeSlashCommandName(alias.split(":"))
+        : pluginCommandName(pluginName, [alias])
+    )
     .filter((alias) => alias.startsWith(prefix));
   return out.length > 0 ? [...new Set(out)] : undefined;
 }
@@ -280,7 +321,7 @@ async function readCommandPath(
         markdown: parsed.markdown,
       },
       metadata: command.metadata,
-      declaredName: `${plugin.name}:${command.name}`,
+      declaredName: pluginCommandName(plugin.name, [command.name]),
       isSkillMode: false,
     }];
   }
@@ -298,10 +339,10 @@ async function readCommandPath(
     ? plugin.commandsPath
     : dirname(command.path);
   const declaredName = command.manifestName !== undefined
-    ? `${plugin.name}:${command.manifestName}`
+    ? pluginCommandName(plugin.name, [command.manifestName])
     : command.name === markdownStem(command.path)
     ? undefined
-    : `${plugin.name}:${command.name}`;
+    : pluginCommandName(plugin.name, [command.name]);
   return [
     await readFileAsCommand(
       plugin,

--- a/runtime/tests/plugins/registration.test.ts
+++ b/runtime/tests/plugins/registration.test.ts
@@ -781,6 +781,100 @@ describe("plugin registration", () => {
     });
   });
 
+  test("normalizes manifest command keys and aliases into dispatchable identifiers", async () => {
+    await withTempPlugin(async ({ pluginRoot, options }) => {
+      await writeJson(join(pluginRoot, ".agenc-plugin", "plugin.json"), {
+        name: "sample",
+        commands: {
+          "Deploy Now!": {
+            source: "./commands/Admin Tools/Review Now.md",
+          },
+          "123 Inline!": {
+            content: [
+              "---",
+              "aliases: Safe+Alias!, sample:Already+Safe!, other:unsafe",
+              "---",
+              "Inline command.",
+            ].join("\n"),
+          },
+        },
+      });
+      await writeFileAt(
+        join(pluginRoot, "commands", "Admin Tools", "Review Now.md"),
+        "Review now.",
+      );
+
+      const result = await loadPlugins(options);
+      const commands = await loadPluginCommands({ plugins: result.enabled });
+      const inline = commands.find((command) =>
+        command.name === "sample:cmd_123_inline"
+      );
+
+      expect(commands.map((command) => command.name).sort()).toEqual([
+        "sample:cmd_123_inline",
+        "sample:deploy_now",
+      ]);
+      expect(commands.every((command) =>
+        /^[a-z][a-z0-9_:-]*$/u.test(command.name)
+      )).toBe(true);
+      expect(inline?.aliases).toEqual([
+        "sample:safe_alias",
+        "sample:already_safe",
+      ]);
+      expect(findCommand("sample:safe_alias", commands)).toBe(inline);
+      expect(findCommand("other:unsafe", commands)).toBeUndefined();
+    });
+  });
+
+  test("normalizes discovered command paths and skill directories into dispatchable identifiers", async () => {
+    await withTempPlugin(async ({ pluginRoot, options }) => {
+      await writeJson(join(pluginRoot, ".agenc-plugin", "plugin.json"), {
+        name: "sample",
+      });
+      await rm(join(pluginRoot, "commands", "deploy.md"), { force: true });
+      await rm(join(pluginRoot, "skills", "inspector"), {
+        recursive: true,
+        force: true,
+      });
+      await writeFileAt(
+        join(pluginRoot, "commands", "Admin Tools", "Review Now!.md"),
+        [
+          "---",
+          "name: sample:Pretty Name!",
+          "aliases: Run+Review!, sample:Review+Alias!, foreign:Review+Alias!",
+          "---",
+          "Review now.",
+        ].join("\n"),
+      );
+      await writeFileAt(
+        join(pluginRoot, "skills", "Ops Tools", "TriAge Now!", "SKILL.md"),
+        "Triage skill.",
+      );
+
+      const result = await loadPlugins(options);
+      const commands = await loadPluginCommands({ plugins: result.enabled });
+      const skills = await loadPluginSkills({ plugins: result.enabled });
+      const review = commands.find((command) =>
+        command.name === "sample:admin_tools:review_now"
+      );
+
+      expect(commands.map((command) => command.name)).toEqual([
+        "sample:admin_tools:review_now",
+      ]);
+      expect(review?.userFacingName?.()).toBe("sample:pretty_name");
+      expect(review?.aliases).toEqual([
+        "sample:run_review",
+        "sample:review_alias",
+      ]);
+      expect(skills.map((skill) => skill.name)).toEqual([
+        "sample:ops_tools:triage_now",
+      ]);
+      expect([...commands, ...skills].every((command) =>
+        /^[a-z][a-z0-9_:-]*$/u.test(command.name)
+      )).toBe(true);
+    });
+  });
+
   test("plugin frontmatter names and aliases cannot create unscoped command identifiers", async () => {
     await withTempPlugin(async ({ pluginRoot, options }) => {
       await writeJson(join(pluginRoot, ".agenc-plugin", "plugin.json"), {


### PR DESCRIPTION
## Summary
- Normalize plugin command names, aliases, and frontmatter display names to the slash-command grammar before registration.
- Preserve plugin namespace boundaries while making manifest keys, discovered file paths, inline command keys, and skill directories dispatchable.
- Add regression coverage for unsafe manifest keys, aliases, nested command paths, and skill directory names.

Fixes #1262

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest -- run tests/plugins/registration.test.ts
- npm --workspace=@tetsuo-ai/runtime exec vitest -- run tests/plugins/registration.test.ts tests/commands/dispatcher.test.ts tests/tui/components/PromptInput/slashCommandSuggestions.test.ts
- local vLLM diff review via http://127.0.0.1:11434/v1 model dolphin3:latest
- npm run typecheck
- git diff --check
- rg -n "TODO|FIXME|HACK" runtime/src/plugins/registration/load-plugin-commands.ts runtime/tests/plugins/registration.test.ts
- npm test
- npm run test:bun
- npm audit --omit=dev
- npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- npm run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm run validate:runtime
- pre-commit hook build + PTY startup smoke