### PR TITLE
fix(runtime): normalize plugin agent identifiers

### DIFF
--- a/runtime/src/plugins/registration/common.ts
+++ b/runtime/src/plugins/registration/common.ts
@@ -233,6 +233,41 @@ export function descriptionFromMarkdown(raw: string): string | undefined {
   return undefined;
 }
 
+export function normalizePluginIdentifierSegment(
+  value: string,
+  fallback: string,
+): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/gu, "_")
+    .replace(/_+/gu, "_")
+    .replace(/^_+|_+$/gu, "");
+  const segment = normalized.length > 0 ? normalized : fallback;
+  return /^[a-z]/u.test(segment) ? segment : `cmd_${segment}`;
+}
+
+export function normalizePluginIdentifierName(
+  parts: readonly string[],
+  finalFallback: string,
+): string {
+  return parts
+    .map((part, index) =>
+      normalizePluginIdentifierSegment(
+        part,
+        index === parts.length - 1 ? finalFallback : "namespace",
+      )
+    )
+    .join(":");
+}
+
+export function pluginScopedIdentifier(
+  pluginName: string,
+  parts: readonly string[],
+  finalFallback: string,
+): string {
+  return normalizePluginIdentifierName([pluginName, ...parts], finalFallback);
+}
+
 export function pluginSettingValue(
   plugin: LoadedPlugin,
   key: string,

--- a/runtime/src/plugins/registration/load-plugin-agents.ts
+++ b/runtime/src/plugins/registration/load-plugin-agents.ts
@@ -24,6 +24,7 @@ import {
   namespaceFromPath,
   parseBoolean,
   pathIsDirectory,
+  pluginScopedIdentifier,
   readMarkdownFile,
   runtimeIdentityKey,
   splitList,
@@ -133,8 +134,15 @@ function isAutoMemoryEnabled(): boolean {
 function agentName(plugin: LoadedPlugin, file: ParsedMarkdownFile): string {
   const frontmatterName = coerceString(file.frontmatter.name);
   const baseName = frontmatterName ?? markdownStem(file.filePath);
-  return [plugin.name, ...namespaceFromPath(file.filePath, file.baseDir), baseName]
-    .join(":");
+  const baseParts = baseName.split(":").filter((part) => part.length > 0);
+  return pluginScopedIdentifier(
+    plugin.name,
+    [
+      ...namespaceFromPath(file.filePath, file.baseDir),
+      ...(baseParts.length > 0 ? baseParts : ["agent"]),
+    ],
+    "agent",
+  );
 }
 
 function createPluginAgent(

--- a/runtime/src/plugins/registration/load-plugin-commands.ts
+++ b/runtime/src/plugins/registration/load-plugin-commands.ts
@@ -14,8 +14,11 @@ import {
   isPluginRuntimeSimpleMode,
   loadRuntimePlugins,
   markdownStem,
+  normalizePluginIdentifierName,
+  normalizePluginIdentifierSegment,
   parseBoolean,
   pathIsDirectory,
+  pluginScopedIdentifier,
   readMarkdownFile,
   runtimeIdentityKey,
   splitFrontmatter,
@@ -91,32 +94,11 @@ function isSkillFile(filePath: string): boolean {
   return basename(filePath).toLowerCase() === "skill.md";
 }
 
-function normalizeSlashCommandSegment(value: string, fallback: string): string {
-  const normalized = value
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/gu, "_")
-    .replace(/_+/gu, "_")
-    .replace(/^_+|_+$/gu, "");
-  const segment = normalized.length > 0 ? normalized : fallback;
-  return /^[a-z]/u.test(segment) ? segment : `cmd_${segment}`;
-}
-
-function normalizeSlashCommandName(parts: readonly string[]): string {
-  return parts
-    .map((part, index) =>
-      normalizeSlashCommandSegment(
-        part,
-        index === parts.length - 1 ? "command" : "namespace",
-      )
-    )
-    .join(":");
-}
-
 function pluginCommandName(
   pluginName: string,
   parts: readonly string[],
 ): string {
-  return normalizeSlashCommandName([pluginName, ...parts]);
+  return pluginScopedIdentifier(pluginName, parts, "command");
 }
 
 function commandNameFromFile(
@@ -155,8 +137,11 @@ function commandDisplayName(
 ): string {
   const displayName = coerceString(frontmatter.name);
   if (!displayName) return commandName;
-  const normalizedDisplayName = normalizeSlashCommandName(displayName.split(":"));
-  const pluginPrefix = `${normalizeSlashCommandSegment(pluginName, "plugin")}:`;
+  const normalizedDisplayName = normalizePluginIdentifierName(
+    displayName.split(":"),
+    "command",
+  );
+  const pluginPrefix = `${normalizePluginIdentifierSegment(pluginName, "plugin")}:`;
   return normalizedDisplayName.startsWith(pluginPrefix)
     ? normalizedDisplayName
     : commandName;
@@ -218,7 +203,7 @@ function namespacedAliases(
   pluginName: string,
   aliases: readonly string[],
 ): string[] | undefined {
-  const normalizedPluginName = normalizeSlashCommandSegment(
+  const normalizedPluginName = normalizePluginIdentifierSegment(
     pluginName,
     "plugin",
   );
@@ -226,7 +211,7 @@ function namespacedAliases(
   const out = aliases
     .map((alias) =>
       alias.includes(":")
-        ? normalizeSlashCommandName(alias.split(":"))
+        ? normalizePluginIdentifierName(alias.split(":"), "command")
         : pluginCommandName(pluginName, [alias])
     )
     .filter((alias) => alias.startsWith(prefix));

--- a/runtime/tests/plugins/registration.test.ts
+++ b/runtime/tests/plugins/registration.test.ts
@@ -999,6 +999,62 @@ describe("plugin registration", () => {
     });
   });
 
+  test("normalizes plugin agent identifiers before memory paths use them", async () => {
+    await withTempPlugin(async ({ root, pluginRoot, options }) => {
+      await writeJson(join(pluginRoot, ".agenc-plugin", "plugin.json"), {
+        name: "sample",
+      });
+      await rm(join(pluginRoot, "agents", "review.md"), { force: true });
+      await writeFileAt(
+        join(pluginRoot, "agents", "Ops Tools", "123 Review!.md"),
+        [
+          "---",
+          "name: 123/../Escape Agent!",
+          "description: Review risky metadata",
+          "memory: local",
+          "---",
+          "Use memory safely.",
+        ].join("\n"),
+      );
+      await writeFileAt(
+        join(pluginRoot, "agents", "safe.md"),
+        [
+          "---",
+          "name: admin:review",
+          "description: Namespaced reviewer",
+          "---",
+          "Review safely.",
+        ].join("\n"),
+      );
+
+      const result = await loadPlugins(options);
+      const agents = await loadPluginAgents({
+        cwd: root,
+        agencHome: options.agencHome,
+        plugins: result.enabled,
+      });
+      const unsafe = agents.find((agent) =>
+        agent.agentType === "sample:ops_tools:cmd_123_escape_agent"
+      );
+
+      expect(agents.map((agent) => agent.agentType).sort()).toEqual([
+        "sample:admin:review",
+        "sample:ops_tools:cmd_123_escape_agent",
+      ]);
+      expect(agents.every((agent) =>
+        /^[a-z][a-z0-9_:-]*$/u.test(agent.agentType)
+      )).toBe(true);
+      expect(agents.map((agent) => agent.agentType)).not.toContain(
+        "sample:ops tools:123/../Escape Agent!",
+      );
+
+      const memoryPrompt = unsafe?.getSystemPrompt();
+      expect(memoryPrompt).toContain("Memory directory:");
+      expect(memoryPrompt).toContain("sample-ops_tools-cmd_123_escape_agent");
+      expect(memoryPrompt).not.toContain("123/../Escape Agent!");
+    });
+  });
+
   test("plugin agents with memory keep memory access tools when tools are restricted", async () => {
     await withTempPlugin(async ({ root, pluginRoot, options }) => {
       await writeFileAt(


### PR DESCRIPTION
## Summary
- share plugin identifier normalization between command and agent registration
- normalize plugin agent names from frontmatter, paths, and plugin names before exposing agentType
- add regression coverage for agent memory paths derived from unsafe plugin metadata

Fixes #1264

## Validation
- npm test
- npm run test:bun
- npm run typecheck
- npm run validate:runtime
- npm run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --omit=dev
- npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- git diff --cached --check
- touched-file TODO/FIXME/HACK scan
- local vLLM staged diff review: APPROVED