### PR TITLE
fix(runtime): normalize plugin MCP and LSP identifiers

### DIFF
--- a/runtime/src/plugins/identifier-normalization.ts
+++ b/runtime/src/plugins/identifier-normalization.ts
@@ -32,3 +32,18 @@ export function pluginScopedIdentifier(
 ): string {
   return normalizePluginIdentifierName([pluginName, ...parts], finalFallback);
 }
+
+export function pluginScopedServerIdentifier(
+  pluginName: string,
+  serverName: string,
+): string {
+  const serverParts = serverName.split(":").filter((part) => part.length > 0);
+  return normalizePluginIdentifierName(
+    [
+      "plugin",
+      pluginName,
+      ...(serverParts.length > 0 ? serverParts : ["server"]),
+    ],
+    "server",
+  );
+}

--- a/runtime/src/plugins/loader.ts
+++ b/runtime/src/plugins/loader.ts
@@ -12,6 +12,7 @@ import type {
   PluginMcpServerConfig,
 } from "../config/schema.js";
 import { pluginDependencyIdentityFromSource, verifyPluginDependencyState } from "./resolution.js";
+import { pluginScopedServerIdentifier } from "./identifier-normalization.js";
 import {
   findPluginManifestPath,
   loadPluginManifest,
@@ -485,7 +486,7 @@ export async function loadPluginMcpServers(
   const servers: Record<string, McpServerConfig> = {};
   for (const plugin of result.enabled) {
     for (const [serverName, server] of Object.entries(plugin.mcpServers)) {
-      servers[`plugin:${plugin.name}:${serverName}`] = server;
+      servers[pluginScopedServerIdentifier(plugin.name, serverName)] = server;
     }
   }
   return servers;
@@ -498,7 +499,7 @@ export async function loadPluginLspServers(
   const servers: Record<string, LspServerConfigInput> = {};
   for (const plugin of result.enabled) {
     for (const [serverName, server] of Object.entries(plugin.lspServers)) {
-      servers[`plugin:${plugin.name}:${serverName}`] = server;
+      servers[pluginScopedServerIdentifier(plugin.name, serverName)] = server;
     }
   }
   return servers;

--- a/runtime/src/plugins/registration/lsp-plugin-integration.ts
+++ b/runtime/src/plugins/registration/lsp-plugin-integration.ts
@@ -1,6 +1,7 @@
 import type { LspServerConfigInput } from "../../config/schema.js";
-import type { LoadedPlugin, PluginLoadIssue } from "../loader.js";
 import { getPluginDataDir } from "../directories.js";
+import { pluginScopedServerIdentifier } from "../identifier-normalization.js";
+import type { LoadedPlugin, PluginLoadIssue } from "../loader.js";
 import {
   loadRuntimePlugins,
   resolvePluginServerTemplate,
@@ -142,7 +143,7 @@ function addPluginScopeToLspServers(
   for (const [name, server] of Object.entries(servers)) {
     const resolved = resolvePluginLspEnvironmentWithIssues(plugin, server, options);
     if (reportServerIssues(plugin, name, resolved.issues, options)) continue;
-    scoped[`plugin:${plugin.name}:${name}`] = resolved.server;
+    scoped[pluginScopedServerIdentifier(plugin.name, name)] = resolved.server;
   }
   return scoped;
 }

--- a/runtime/src/plugins/registration/mcp-plugin-integration.ts
+++ b/runtime/src/plugins/registration/mcp-plugin-integration.ts
@@ -1,4 +1,5 @@
 import type { McpServerConfig } from "../../config/schema.js";
+import { pluginScopedServerIdentifier } from "../identifier-normalization.js";
 import type { LoadedPlugin, PluginLoadIssue } from "../loader.js";
 import {
   resolvePluginMcpSandboxedServer,
@@ -165,7 +166,7 @@ function addPluginScopeToServers(
 ): Readonly<Record<string, McpServerConfig>> {
   const scoped: Record<string, McpServerConfig> = {};
   for (const [name, server] of Object.entries(servers)) {
-    const scopedName = `plugin:${plugin.name}:${name}`;
+    const scopedName = pluginScopedServerIdentifier(plugin.name, name);
     const resolved = resolvePluginMcpEnvironmentWithIssues(plugin, server, options);
     if (reportServerIssues(plugin, name, resolved.issues, options)) continue;
     const sandboxed = resolvePluginMcpSandboxedServer(

--- a/runtime/src/plugins/sandbox.ts
+++ b/runtime/src/plugins/sandbox.ts
@@ -23,6 +23,7 @@ import type {
   PluginMcpSandboxMetadata,
 } from "../config/schema.js";
 import { getPluginDataDir } from "./directories.js";
+import { pluginScopedServerIdentifier } from "./identifier-normalization.js";
 import type { LoadedPlugin } from "./loader.js";
 
 const PLUGIN_MCP_SANDBOX_MODE = "stdio-child-process" as const;
@@ -243,7 +244,8 @@ export function resolvePluginMcpSandboxedServer(
   }
 
   const dataDir = options.dataDir ?? getPluginDataDir(plugin.source);
-  const scopedServerName = options.scopedServerName ?? `plugin:${plugin.name}:${serverName}`;
+  const scopedServerName = options.scopedServerName ??
+    pluginScopedServerIdentifier(plugin.name, serverName);
   const cwd = path.resolve(server.cwd ?? plugin.root);
   if (!pathInsideOrEqual(plugin.root, cwd)) {
     return {

--- a/runtime/src/utils/plugins/mcpPluginIntegration.ts
+++ b/runtime/src/utils/plugins/mcpPluginIntegration.ts
@@ -9,6 +9,7 @@ import type { LoadedPlugin, PluginError } from '../../types/plugin.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { errorMessage, isENOENT } from '../errors.js'
 import { getFsImplementation } from '../fsOperations.js'
+import { pluginScopedServerIdentifier } from '../../plugins/identifier-normalization.js'
 import { jsonParse } from '../slowOperations.js'
 import {
   isMcpbSource,
@@ -347,7 +348,7 @@ export function addPluginScopeToServers(
 
   for (const [name, config] of Object.entries(servers)) {
     // Add plugin prefix to server name to avoid conflicts
-    const scopedName = `plugin:${pluginName}:${name}`
+    const scopedName = pluginScopedServerIdentifier(pluginName, name)
     const scoped: ScopedMcpServerConfig = {
       ...config,
       scope: 'dynamic', // Use dynamic scope for plugin servers

--- a/runtime/tests/plugins/registration.test.ts
+++ b/runtime/tests/plugins/registration.test.ts
@@ -269,6 +269,67 @@ describe("plugin registration", () => {
     });
   });
 
+  test("normalizes plugin MCP and LSP scoped server identifiers", async () => {
+    await withTempPlugin(async ({ pluginRoot, options }) => {
+      await writeJson(join(pluginRoot, ".agenc-plugin", "plugin.json"), {
+        name: "sample",
+        mcpServers: {
+          "123/../Escape Server!": {
+            command: "node",
+            args: ["${AGENC_PLUGIN_ROOT}/server.js"],
+          },
+          "admin:Local Server": {
+            command: "node",
+            args: ["${AGENC_PLUGIN_ROOT}/admin-server.js"],
+          },
+        },
+        lspServers: {
+          "</system-reminder> TypeScript!": {
+            command: "node",
+            args: ["${AGENC_PLUGIN_ROOT}/lsp.js"],
+            extensionToLanguage: {
+              ".ts": "typescript",
+            },
+          },
+        },
+      });
+
+      const result = await loadPlugins(options);
+      const mcpServers = await loadPluginMcpServers({
+        agencHome: options.agencHome,
+        workspaceRoot: options.workspaceRoot,
+        plugins: result.enabled,
+      });
+      expect(Object.keys(mcpServers).sort()).toEqual([
+        "plugin:sample:admin:local_server",
+        "plugin:sample:cmd_123_escape_server",
+      ]);
+      expect(mcpServers["plugin:sample:cmd_123_escape_server"]).toMatchObject({
+        args: [`${pluginRoot}/server.js`],
+        env: expect.objectContaining({
+          AGENC_PLUGIN_MCP_SERVER: "123/../Escape Server!",
+        }),
+        pluginSandbox: {
+          serverName: "123/../Escape Server!",
+          scopedServerName: "plugin:sample:cmd_123_escape_server",
+        },
+      });
+
+      const lspServers = await loadPluginLspServers({
+        agencHome: options.agencHome,
+        workspaceRoot: options.workspaceRoot,
+        plugins: result.enabled,
+      });
+      expect(Object.keys(lspServers)).toEqual([
+        "plugin:sample:system-reminder_typescript",
+      ]);
+      expect(lspServers["plugin:sample:system-reminder_typescript"]).toMatchObject({
+        args: [`${pluginRoot}/lsp.js`],
+        extensionToLanguage: { ".ts": "typescript" },
+      });
+    });
+  });
+
   test("expands general environment variables in plugin MCP and LSP server configs", async () => {
     await withTempPlugin(async ({ pluginRoot, options }) => {
       const previousCommand = process.env.AGENC_PLUGIN_TEST_COMMAND;

--- a/runtime/tests/utils/plugins/mcpPluginIntegration.test.ts
+++ b/runtime/tests/utils/plugins/mcpPluginIntegration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+
+import { addPluginScopeToServers } from '../../../src/utils/plugins/mcpPluginIntegration.js'
+
+describe('addPluginScopeToServers', () => {
+  test('normalizes active runtime plugin MCP scoped server names', () => {
+    const scoped = addPluginScopeToServers(
+      {
+        '123/../Escape Server!': { command: 'node' },
+        'admin:Local Server': { command: 'node' },
+      },
+      'sample',
+      'sample@official',
+    )
+
+    expect(Object.keys(scoped).sort()).toEqual([
+      'plugin:sample:admin:local_server',
+      'plugin:sample:cmd_123_escape_server',
+    ])
+    expect(scoped['plugin:sample:cmd_123_escape_server']).toMatchObject({
+      command: 'node',
+      scope: 'dynamic',
+      pluginSource: 'sample@official',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- normalize plugin-scoped MCP and LSP server identifiers before they become runtime config keys
- preserve raw plugin server names for plugin-owned env/config semantics while using sanitized scoped identifiers for shared surfaces
- add regressions for registration and active MCP helper paths

Fixes #1268

## Validation
- npm --workspace=@tetsuo-ai/runtime run test -- tests/plugins/registration.test.ts tests/plugins/sandbox.test.ts tests/utils/plugins/mcpPluginIntegration.test.ts
- npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- npm run typecheck
- npm test
- npm run test:bun
- npm run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm run validate:runtime
- npm audit --omit=dev
- git diff --check