### PR TITLE
fix(runtime): preserve plugin MCP duplicate identity

### DIFF
--- a/runtime/src/services/mcp/config.ts
+++ b/runtime/src/services/mcp/config.ts
@@ -213,7 +213,7 @@ export function getMcpServerSignature(config: McpServerConfig): string | null {
  * manually-configured server or an earlier-loaded plugin server.
  * Manual wins over plugin; between plugins, first-loaded wins.
  *
- * Plugin servers are namespaced `plugin:name:server` so they never key-collide
+ * Plugin servers use normalized scoped identifiers so they never key-collide
  * with manual servers in the merge — this content-based check catches the case
  * where both actually launch the same underlying process/connection.
  */
@@ -222,7 +222,11 @@ export function dedupPluginMcpServers(
   manualServers: Record<string, ScopedMcpServerConfig>,
 ): {
   servers: Record<string, ScopedMcpServerConfig>
-  suppressed: Array<{ name: string; duplicateOf: string }>
+  suppressed: Array<{
+    name: string
+    duplicateOf: string
+    config: ScopedMcpServerConfig
+  }>
 } {
   // Map signature -> server name so we can report which server a dup matches
   const manualSigs = new Map<string, string>()
@@ -232,7 +236,11 @@ export function dedupPluginMcpServers(
   }
 
   const servers: Record<string, ScopedMcpServerConfig> = {}
-  const suppressed: Array<{ name: string; duplicateOf: string }> = []
+  const suppressed: Array<{
+    name: string
+    duplicateOf: string
+    config: ScopedMcpServerConfig
+  }> = []
   const seenPluginSigs = new Map<string, string>()
   for (const [name, config] of Object.entries(pluginServers)) {
     const sig = getMcpServerSignature(config)
@@ -245,7 +253,7 @@ export function dedupPluginMcpServers(
       logForDebugging(
         `Suppressing plugin MCP server "${name}": duplicates manually-configured "${manualDup}"`,
       )
-      suppressed.push({ name, duplicateOf: manualDup })
+      suppressed.push({ name, duplicateOf: manualDup, config })
       continue
     }
     const pluginDup = seenPluginSigs.get(sig)
@@ -253,13 +261,60 @@ export function dedupPluginMcpServers(
       logForDebugging(
         `Suppressing plugin MCP server "${name}": duplicates earlier plugin server "${pluginDup}"`,
       )
-      suppressed.push({ name, duplicateOf: pluginDup })
+      suppressed.push({ name, duplicateOf: pluginDup, config })
       continue
     }
     seenPluginSigs.set(sig, name)
     servers[name] = config
   }
   return { servers, suppressed }
+}
+
+export function pluginMcpDuplicateSuppressionError(
+  suppression: {
+    readonly name: string
+    readonly duplicateOf: string
+    readonly config: ScopedMcpServerConfig
+  },
+): PluginError | null {
+  const pluginServer = suppression.config.pluginServer
+  if (pluginServer !== undefined) {
+    return {
+      type: 'mcp-server-suppressed-duplicate',
+      source: suppression.name,
+      plugin: pluginServer.pluginName,
+      serverName: pluginServer.serverName,
+      duplicateOf: suppression.duplicateOf,
+    }
+  }
+
+  const sandbox = (
+    suppression.config as {
+      readonly pluginSandbox?: {
+        readonly pluginName: string
+        readonly serverName: string
+      }
+    }
+  ).pluginSandbox
+  if (sandbox !== undefined) {
+    return {
+      type: 'mcp-server-suppressed-duplicate',
+      source: suppression.name,
+      plugin: sandbox.pluginName,
+      serverName: sandbox.serverName,
+      duplicateOf: suppression.duplicateOf,
+    }
+  }
+
+  const parts = suppression.name.split(':')
+  if (parts[0] !== 'plugin' || parts.length < 3) return null
+  return {
+    type: 'mcp-server-suppressed-duplicate',
+    source: suppression.name,
+    plugin: parts[1]!,
+    serverName: parts.slice(2).join(':'),
+    duplicateOf: suppression.duplicateOf,
+  }
 }
 
 /**
@@ -1109,9 +1164,9 @@ export async function getAgenCCodeMcpConfigs(
   }
 
   // Dedup plugin servers against manually-configured ones (and each other).
-  // Plugin server keys are namespaced `plugin:x:y` so they never collide with
-  // manual keys in the merge below — this content-based filter catches the case
-  // where both would launch the same underlying process/connection.
+  // Plugin server keys use normalized plugin-scoped identifiers so they never
+  // collide with manual keys in the merge below — this content-based filter
+  // catches the case where both would launch the same underlying connection.
   // Only servers that will actually connect are valid dedup targets — a
   // disabled manual server mustn't suppress a plugin server, or neither runs
   // (manual is skipped by name at connection time; plugin was removed here).
@@ -1154,17 +1209,9 @@ export async function getAgenCCodeMcpConfigs(
   Object.assign(dedupedPluginServers, disabledPluginServers)
   // Surface suppressions in /plugin UI. Pushed AFTER the logError loop above
   // so these don't go to the error log — they're informational, not errors.
-  for (const { name, duplicateOf } of suppressed) {
-    // name is "plugin:${pluginName}:${serverName}" from addPluginScopeToServers
-    const parts = name.split(':')
-    if (parts[0] !== 'plugin' || parts.length < 3) continue
-    mcpErrors.push({
-      type: 'mcp-server-suppressed-duplicate',
-      source: name,
-      plugin: parts[1]!,
-      serverName: parts.slice(2).join(':'),
-      duplicateOf,
-    })
+  for (const suppression of suppressed) {
+    const error = pluginMcpDuplicateSuppressionError(suppression)
+    if (error !== null) mcpErrors.push(error)
   }
 
   // Merge in order of precedence: plugin < user < project < local

--- a/runtime/src/services/mcp/types.ts
+++ b/runtime/src/services/mcp/types.ts
@@ -195,12 +195,20 @@ export type McpAgenCAIProxyServerConfig = z.infer<
 >
 export type McpServerConfig = z.infer<ReturnType<typeof McpServerConfigSchema>>
 
+export type PluginMcpServerIdentity = {
+  pluginName: string
+  serverName: string
+}
+
 export type ScopedMcpServerConfig = McpServerConfig & {
   scope: ConfigScope
   // For plugin-provided servers: the providing plugin's LoadedPlugin.source
   // (e.g. 'slack@anthropic'). Stashed at config-build time so the channel
   // gate doesn't have to race AppState.plugins.enabled hydration.
   pluginSource?: string
+  // Raw plugin/server identity for diagnostics. Scoped map keys are normalized
+  // and may differ from manifest server names.
+  pluginServer?: PluginMcpServerIdentity
 }
 
 export const McpJsonConfigSchema = lazySchema(() =>

--- a/runtime/src/utils/plugins/mcpPluginIntegration.ts
+++ b/runtime/src/utils/plugins/mcpPluginIntegration.ts
@@ -353,6 +353,10 @@ export function addPluginScopeToServers(
       ...config,
       scope: 'dynamic', // Use dynamic scope for plugin servers
       pluginSource,
+      pluginServer: {
+        pluginName,
+        serverName: name,
+      },
     }
     scopedServers[scopedName] = scoped
   }

--- a/runtime/tests/services/mcp/config.test.ts
+++ b/runtime/tests/services/mcp/config.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  dedupPluginMcpServers,
+  pluginMcpDuplicateSuppressionError,
+} from "../../../src/services/mcp/config.js";
+import type { ScopedMcpServerConfig } from "../../../src/services/mcp/types.js";
+
+describe("MCP config plugin duplicate suppression", () => {
+  test("reports raw plugin server identity for normalized scoped keys", () => {
+    const pluginServer: ScopedMcpServerConfig = {
+      scope: "dynamic",
+      command: "node",
+      args: ["server.js"],
+      pluginSource: "sample@official",
+      pluginServer: {
+        pluginName: "sample",
+        serverName: "123/../Escape Server!",
+      },
+    };
+
+    const result = dedupPluginMcpServers(
+      {
+        "plugin:sample:cmd_123_escape_server": pluginServer,
+      },
+      {
+        local: {
+          scope: "user",
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+    );
+
+    expect(result.servers).toEqual({});
+    expect(result.suppressed).toHaveLength(1);
+    expect(pluginMcpDuplicateSuppressionError(result.suppressed[0]!))
+      .toMatchObject({
+        type: "mcp-server-suppressed-duplicate",
+        source: "plugin:sample:cmd_123_escape_server",
+        plugin: "sample",
+        serverName: "123/../Escape Server!",
+        duplicateOf: "local",
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- carry raw plugin/server identity on active plugin MCP server configs for diagnostics
- make duplicate-suppression reporting prefer carried plugin metadata instead of parsing normalized scoped keys
- add a regression for unsafe plugin server names suppressed as duplicates

Fixes #1270

## Validation
- npm --workspace=@tetsuo-ai/runtime run test -- tests/services/mcp/config.test.ts tests/utils/plugins/mcpPluginIntegration.test.ts
- npm run check:local-vllm -- --base-url http://127.0.0.1:11434/v1 --model dolphin3:latest
- local vLLM staged diff review: APPROVED
- git diff --check
- npm run typecheck
- npm test
- npm run test:bun
- npm run check:unused
- npm --workspace=@tetsuo-ai/runtime run check:unused:all
- npm audit --omit=dev
- npm run validate:runtime