### PR TITLE
auto-fix iter 1: 5 verified fixes (secret scrub, daemon readiness, resume crash, flag parsing)

### DIFF
--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -191,7 +191,17 @@ export async function ensureAgenCDaemonAutostart(
     }
     const startExit = await runAgenCDaemonCli(
       { kind: "command", action: "start" },
-      { host, io },
+      {
+        host,
+        io,
+        // The autostart path owns its own readiness wait below
+        // (`waitForAgenCDaemonReady`, honoring this call's `isReady`/timeout
+        // options), so opt the bare `start` control out of its own duplicate
+        // socket-readiness gate. This keeps autostart's start→ready sequence
+        // byte-for-byte identical to before the bare-control readiness gate
+        // was added.
+        waitForDaemonReady: async () => true,
+      },
     );
     if (startExit !== 0) {
       throw new AgenCDaemonAutostartError("AgenC daemon start failed");

--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -32,6 +32,7 @@ import {
   resolveMcpServeDefaults,
   type ResolvedMcpServeDefaults,
 } from "../mcp/server/start.js";
+import { canConnectToUnixSocket } from "./transport/unix-socket.js";
 
 export type AgenCDaemonAutostartStatus = "already-running" | "started";
 
@@ -249,7 +250,18 @@ async function recoverPidlessAgenCDaemon(params: {
     params.host.env,
     params.host.userHome,
   );
-  if (await isAgenCDaemonSocketPresent(socketPath)) {
+  // Only adopt the orphan when the leftover socket is actually accepting
+  // connections. A stale socket inode (left after a crash without unlink)
+  // passes a bare lstat()/isSocket() check but has no listener, so adopting
+  // it would make autostart wait/connect forever against a dead socket.
+  // `canConnectToUnixSocket` performs a real connect() probe (the same
+  // liveness check `prepareAgenCUnixSocketPath` uses to decide if a socket
+  // is in use). The lstat precondition keeps us from attempting a connect
+  // against a missing or non-socket path.
+  if (
+    (await isAgenCDaemonSocketPresent(socketPath)) &&
+    (await canConnectToUnixSocket(socketPath))
+  ) {
     const recoveredPid = orphanPids[0];
     if (recoveredPid === undefined) return null;
     await writeAgenCDaemonPid(params.pidPath, recoveredPid);

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection, isIP } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -62,7 +62,10 @@ import {
   type SessionStatus,
 } from "./protocol/index.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
-import { AgenCUnixSocketServer } from "./transport/unix-socket.js";
+import {
+  AgenCUnixSocketServer,
+  canConnectToUnixSocket,
+} from "./transport/unix-socket.js";
 import { AgenCWebSocketServer } from "./transport/websocket.js";
 import {
   AgenCDaemonCookieAuthenticator,
@@ -177,6 +180,16 @@ const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV =
   "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
 const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 2_000;
 const DEFAULT_DAEMON_STOP_TIMEOUT_MS = 10_000;
+/**
+ * Bound for how long the bare daemon controls (`start`/`restart`/`reload`)
+ * wait for the detached daemon to bind and accept on its control socket before
+ * giving up. Kept in sync with the agent autostart path
+ * (`AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS` in `daemon-autostart.ts`); imported
+ * as a local constant rather than from that module to avoid an import cycle
+ * (`daemon-autostart` already depends on `daemon-cli`).
+ */
+const DEFAULT_DAEMON_READY_TIMEOUT_MS = 15_000;
+const DEFAULT_DAEMON_READY_POLL_MS = 25;
 
 const DEFAULT_DAEMON_WEBSOCKET_URL = new URL(
   AGENC_PORTAL_DEFAULT_LOCAL_DAEMON_ENDPOINT,
@@ -237,6 +250,21 @@ export interface RunAgenCDaemonCliOptions {
   readonly requestHealthStats?: (
     host: AgenCDaemonCliHost,
   ) => Promise<HealthStatsResult>;
+  /**
+   * Overrides the control-socket readiness probe used by `start`/`restart`,
+   * `status`, and `reload`. Resolves `true` once the detached daemon has bound
+   * and is accepting connections on its Unix socket (pid alive, cookie
+   * written, socket connectable), mirroring the agent autostart readiness
+   * contract. Defaults to a real connectability poll bounded by
+   * {@link DEFAULT_DAEMON_READY_TIMEOUT_MS}. Injectable so unit tests can stub
+   * readiness without spinning up a full server. The boolean argument is the
+   * single-shot mode: when `true`, the probe checks readiness once with no
+   * polling/timeout (used by `status`).
+   */
+  readonly waitForDaemonReady?: (
+    host: AgenCDaemonCliHost,
+    singleShot: boolean,
+  ) => Promise<boolean>;
 }
 
 export interface AgenCDaemonWebSocketListenOptions {
@@ -556,7 +584,7 @@ async function runAgenCDaemonAction(
 ): Promise<number> {
   switch (action) {
     case "start":
-      return startAgenCDaemon(host, io);
+      return startAgenCDaemon(host, io, options);
     case "stop":
       return stopAgenCDaemon(
         host,
@@ -566,7 +594,7 @@ async function runAgenCDaemonAction(
     case "status":
       return statusAgenCDaemon(host, io, options);
     case "reload":
-      return reloadAgenCDaemon(host, io);
+      return reloadAgenCDaemon(host, io, options);
     case "restart": {
       await stopAgenCDaemon(
         host,
@@ -576,7 +604,7 @@ async function runAgenCDaemonAction(
           quietWhenStopped: true,
         },
       );
-      return startAgenCDaemon(host, io);
+      return startAgenCDaemon(host, io, options);
     }
     case "run":
       return runAgenCDaemonForeground(host, io, {
@@ -591,9 +619,64 @@ async function runAgenCDaemonAction(
   }
 }
 
+/**
+ * Single-shot control-socket readiness check, mirroring the agent autostart
+ * contract (`isAgenCDaemonPidAndCookieReady` in `daemon-autostart.ts`): the pid
+ * must be alive, the daemon cookie present and non-empty, and the Unix socket
+ * must exist as a socket AND be connectable. The connectability probe closes
+ * the window where the socket inode exists but `socketServer.listen()` has not
+ * yet started accepting, which is exactly the race the bare controls hit.
+ */
+async function isAgenCDaemonControlSocketReady(
+  host: AgenCDaemonCliHost,
+  pid: number,
+): Promise<boolean> {
+  if (!host.isPidRunning(pid)) return false;
+  const cookiePath = resolveAgenCDaemonCookiePath(host.env, host.userHome);
+  const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
+  try {
+    if ((await readFile(cookiePath, "utf8")).trim().length === 0) {
+      return false;
+    }
+    if (!(await lstat(socketPath)).isSocket()) {
+      return false;
+    }
+  } catch (error) {
+    if (asNodeError(error).code === "ENOENT") return false;
+    throw error;
+  }
+  return canConnectToUnixSocket(socketPath);
+}
+
+/**
+ * Polls {@link isAgenCDaemonControlSocketReady} until it observes readiness or
+ * the bounded timeout elapses. Uses `host.sleep` so tests can drive the clock.
+ * When `singleShot` is true, the readiness is checked exactly once with no
+ * polling (used by `status`, which must not block on a slow/absent socket).
+ */
+async function defaultWaitForAgenCDaemonReady(
+  host: AgenCDaemonCliHost,
+  singleShot: boolean,
+): Promise<boolean> {
+  const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+  const pid = await readAgenCDaemonPid(pidPath);
+  if (pid === null) return false;
+  if (singleShot) {
+    return isAgenCDaemonControlSocketReady(host, pid);
+  }
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < DEFAULT_DAEMON_READY_TIMEOUT_MS) {
+    if (await isAgenCDaemonControlSocketReady(host, pid)) return true;
+    if (!host.isPidRunning(pid)) return false;
+    await host.sleep(DEFAULT_DAEMON_READY_POLL_MS);
+  }
+  return isAgenCDaemonControlSocketReady(host, pid);
+}
+
 async function startAgenCDaemon(
   host: AgenCDaemonCliHost,
   io: AgenCDaemonCliIo,
+  options: RunAgenCDaemonCliOptions = {},
 ): Promise<number> {
   const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
   const existingPid = await readAgenCDaemonPid(pidPath);
@@ -613,6 +696,30 @@ async function startAgenCDaemon(
     AGENC_DAEMON_RUN: "1",
   });
   await writeAgenCDaemonPid(pidPath, childPid);
+
+  // Do not advertise "started" until the detached daemon is actually accepting
+  // connections on its control socket. The foreground daemon binds the socket
+  // only after state hydration, so there is a real window where the pid is
+  // alive but `daemon.sock` is absent/not-yet-listening; printing "started"
+  // before then would lie to callers (and break an immediate reload).
+  const waitForReady =
+    options.waitForDaemonReady ?? defaultWaitForAgenCDaemonReady;
+  const ready = await waitForReady(host, false);
+  if (!ready) {
+    if (host.isPidRunning(childPid)) {
+      io.stderr.write(
+        `agenc: daemon process started (pid ${childPid}) but its control ` +
+          `socket did not become ready before timeout\n`,
+      );
+    } else {
+      await removeAgenCDaemonPid(pidPath, childPid);
+      io.stderr.write(
+        `agenc: daemon process (pid ${childPid}) exited before its control ` +
+          `socket became ready\n`,
+      );
+    }
+    return 1;
+  }
   io.stdout.write(`AgenC daemon started (pid ${childPid})\n`);
   return 0;
 }
@@ -670,7 +777,26 @@ async function statusAgenCDaemon(
   const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
   const pid = await readAgenCDaemonPid(pidPath);
   if (pid !== null && host.isPidRunning(pid)) {
-    io.stdout.write(`AgenC daemon running (pid ${pid})\n`);
+    // Distinguish "pid alive AND control socket accepting" from "pid alive but
+    // socket not yet listening" (the post-spawn / hydrating window). Probe the
+    // socket connectability once (no blocking poll) so `status` stays fast and
+    // never claims definitive readiness while the socket is absent.
+    const waitForReady =
+      options.waitForDaemonReady ?? defaultWaitForAgenCDaemonReady;
+    let socketReady = false;
+    try {
+      socketReady = await waitForReady(host, true);
+    } catch {
+      // Treat a probe error the same as not-ready; the pid is still alive.
+      socketReady = false;
+    }
+    if (socketReady) {
+      io.stdout.write(`AgenC daemon running (pid ${pid})\n`);
+    } else {
+      io.stdout.write(
+        `AgenC daemon running (pid ${pid}, control socket not ready)\n`,
+      );
+    }
     // Best-effort: enrich the running line with live health.stats
     // (uptime/RSS/heap/session+state counts) pulled over the daemon socket.
     // A pid-only fallback is preserved when the daemon is unreachable or the
@@ -833,6 +959,7 @@ function isHealthStateStats(
 async function reloadAgenCDaemon(
   host: AgenCDaemonCliHost,
   io: AgenCDaemonCliIo,
+  options: RunAgenCDaemonCliOptions = {},
 ): Promise<number> {
   const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
   const pid = await readAgenCDaemonPid(pidPath);
@@ -843,6 +970,20 @@ async function reloadAgenCDaemon(
   if (!host.isPidRunning(pid)) {
     await removeAgenCDaemonPid(pidPath);
     io.stdout.write("AgenC daemon stopped\n");
+    return 1;
+  }
+
+  // Wait for the control socket to be connectable before issuing the reload
+  // RPC. Immediately after `start`, the daemon may have a live pid but a socket
+  // that is not yet listening; connecting without this gate races into ENOENT.
+  const waitForReady =
+    options.waitForDaemonReady ?? defaultWaitForAgenCDaemonReady;
+  const ready = await waitForReady(host, false);
+  if (!ready) {
+    io.stderr.write(
+      `agenc: daemon reload failed (pid ${pid}): control socket did not ` +
+        `become ready before timeout\n`,
+    );
     return 1;
   }
 

--- a/runtime/src/app-server/transport/unix-socket.ts
+++ b/runtime/src/app-server/transport/unix-socket.ts
@@ -382,7 +382,9 @@ function getSocketFd(socket: Socket): number | null {
     : null;
 }
 
-async function canConnectToUnixSocket(socketPath: string): Promise<boolean> {
+export async function canConnectToUnixSocket(
+  socketPath: string,
+): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const socket = createConnection(socketPath);
     socket.once("connect", () => {

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -30,6 +30,7 @@ import { applyBestEffortPreMainProcessHardening } from "../sandbox/hardening/ind
 import {
   classifyCLI,
   extractFlagValues,
+  isStartupValueFlagToken,
   routeCLI,
   stripRoutingFlags,
   type BootTUIArgs,
@@ -243,8 +244,44 @@ export {
   sessionConfigurationFromAgenCConfig,
 } from "./bootstrap.js";
 
-function hasArgFlag(argv: readonly string[], flag: string): boolean {
-  return argv.includes(flag);
+/**
+ * Detect whether one of the boolean short-circuit flags (`--help`, `-h`,
+ * `--version`) appears as a REAL leading flag rather than as prompt text.
+ *
+ * A token only counts when it sits in the leading option region: before the
+ * first positional/prompt token and before an end-of-options `--`. We walk
+ * argv left-to-right, skipping the value consumed by a startup value flag
+ * (e.g. the `gpt` in `--model gpt`) so it is not mistaken for a positional.
+ * The first bare token that is neither a flag, a `--flag` option, nor a
+ * value consumed by a preceding value flag ends the option region; anything
+ * at or after it (including `--`) is prompt content and never short-circuits.
+ *
+ * This mirrors the `--image`/value-flag exemption already used elsewhere so
+ * free-form prompts like `agenc what does --version mean` or
+ * `agenc explain the --help flag` run the agent instead of printing help.
+ */
+function leadingFlagBeforePrompt(
+  argv: readonly string[],
+  targets: readonly string[],
+): boolean {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+    // Literal `--` ends the option region: everything after is prompt.
+    if (arg === "--") return false;
+    if (targets.includes(arg)) return true;
+    if (isStartupValueFlagToken(arg)) {
+      // `--flag value` form consumes the next token as its value, so that
+      // value is not a positional that would end the option region.
+      const next = argv[i + 1];
+      if (typeof next === "string" && !next.startsWith("-")) i += 1;
+      continue;
+    }
+    // Any other option-looking token (`-x`, `--foo`, `--foo=bar`) stays in
+    // the option region; the first bare positional ends it.
+    if (arg.startsWith("-")) continue;
+    return false;
+  }
+  return false;
 }
 
 export function formatCliHelpText(): string {
@@ -383,10 +420,10 @@ export function detectStartupShortCircuit(
     }
     return { kind: "help", text };
   }
-  if (hasArgFlag(argv, "--help") || hasArgFlag(argv, "-h")) {
+  if (leadingFlagBeforePrompt(argv, ["--help", "-h"])) {
     return { kind: "help", text: formatCliHelpText() };
   }
-  if (hasArgFlag(argv, "--version")) {
+  if (leadingFlagBeforePrompt(argv, ["--version"])) {
     return { kind: "version", text: `agenc ${VERSION}` };
   }
   return null;

--- a/runtime/src/bin/route.ts
+++ b/runtime/src/bin/route.ts
@@ -107,6 +107,20 @@ function shouldStripValueFlag(arg: string): boolean {
   );
 }
 
+/**
+ * True when `arg` is a startup flag that consumes a following value token
+ * (e.g. `--model gpt`, `-r <id>`). Exported so the short-circuit detector
+ * in `bin/agenc.ts` can walk the leading option region without mistaking a
+ * value (like the `gpt` after `--model`) for a positional prompt token.
+ *
+ * Returns false for the `--flag=value` form, which carries its own value.
+ */
+export function isStartupValueFlagToken(arg: string): boolean {
+  return STARTUP_VALUE_FLAGS.includes(
+    arg as (typeof STARTUP_VALUE_FLAGS)[number],
+  );
+}
+
 function shouldStripBooleanFlag(arg: string): boolean {
   return ROUTING_BOOLEAN_FLAGS.includes(
     arg as (typeof ROUTING_BOOLEAN_FLAGS)[number],

--- a/runtime/src/utils/providerSecrets.ts
+++ b/runtime/src/utils/providerSecrets.ts
@@ -1,4 +1,4 @@
-const SECRET_ENV_KEYS = [
+export const SECRET_ENV_KEYS = [
   'OPENAI_API_KEY',
   'OPENAI_AUTH_HEADER_VALUE',
   'AGENC_API_KEY',

--- a/runtime/src/utils/sessionStorage.ts
+++ b/runtime/src/utils/sessionStorage.ts
@@ -288,12 +288,20 @@ export async function readAgentMetadata(
   agentId: AgentId,
 ): Promise<AgentMetadata | null> {
   const path = getAgentMetadataPath(agentId)
+  let raw: string
   try {
-    const raw = await readFile(path, 'utf-8')
-    return JSON.parse(raw) as AgentMetadata
+    raw = await readFile(path, 'utf-8')
   } catch (e) {
     if (isFsInaccessible(e)) return null
     throw e
+  }
+  try {
+    return JSON.parse(raw) as AgentMetadata
+  } catch (e) {
+    // Skip corrupt files — a partial write from a crashed fire-and-forget
+    // persist shouldn't take down the whole resume.
+    logForDebugging(`readAgentMetadata: skipping ${path}: ${String(e)}`)
+    return null
   }
 }
 
@@ -341,12 +349,20 @@ export async function readRemoteAgentMetadata(
   taskId: string,
 ): Promise<RemoteAgentMetadata | null> {
   const path = getRemoteAgentMetadataPath(taskId)
+  let raw: string
   try {
-    const raw = await readFile(path, 'utf-8')
-    return JSON.parse(raw) as RemoteAgentMetadata
+    raw = await readFile(path, 'utf-8')
   } catch (e) {
     if (isFsInaccessible(e)) return null
     throw e
+  }
+  try {
+    return JSON.parse(raw) as RemoteAgentMetadata
+  } catch (e) {
+    // Skip corrupt files — a partial write from a crashed fire-and-forget
+    // persist shouldn't take down the whole restore.
+    logForDebugging(`readRemoteAgentMetadata: skipping ${path}: ${String(e)}`)
+    return null
   }
 }
 

--- a/runtime/src/utils/subprocessEnv.ts
+++ b/runtime/src/utils/subprocessEnv.ts
@@ -1,39 +1,44 @@
 import { isEnvTruthy } from './envUtils.js'
+import { SECRET_ENV_KEYS } from './providerSecrets.js'
 
-/**
- * Env vars stripped from EVERY subprocess environment by default.
- *
- * Child processes (Bash tool, shell snapshot, MCP stdio servers, LSP servers,
- * shell hooks) are spawned with these removed so that a prompt-injected or
- * model-run command (e.g. `printenv`, or shell expansion like
- * `${ANTHROPIC_API_KEY}`) cannot exfiltrate provider keys or CI credentials.
- *
- * Provider/API calls happen IN-PROCESS — the parent agenc process re-reads
- * these per-request (lazy credential reads), so children never need them.
- *
- * This is the DEFAULT behavior (no flag required). Set
- * AGENC_SUBPROCESS_ENV_NO_SCRUB to a truthy value to opt out (e.g. for a trusted
- * local wrapper script that genuinely needs an inherited token).
- */
-const SUBPROCESS_SECRET_ENV = [
+// Names that subprocessEnv() owns directly (not derived from SECRET_ENV_KEYS).
+// SECRET_ENV_KEYS (the single source of provider-secret env names that the
+// codebase assigns to process.env in providerProfiles.ts) is unioned in below
+// so any newly-added provider key is scrubbed automatically.
+const SUBPROCESS_SECRET_ENV_BASE = [
   // provider auth — agenc re-reads these per-request, subprocesses don't need them
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_FOUNDRY_API_KEY',
   'ANTHROPIC_CUSTOM_HEADERS',
   'OPENAI_API_KEY',
+  'OPENAI_AUTH_HEADER_VALUE',
   'OPENROUTER_API_KEY',
   'GROQ_API_KEY',
   'DEEPSEEK_API_KEY',
   'GEMINI_API_KEY',
+  'GEMINI_ACCESS_TOKEN',
   'GOOGLE_API_KEY',
   'GOOGLE_GENAI_API_KEY',
   'GOOGLE_GENERATIVE_AI_API_KEY',
   'XAI_API_KEY',
   'GROK_API_KEY',
   'AGENC_XAI_API_KEY',
+  'AGENC_API_KEY',
   'AGENC_OAUTH_TOKEN',
   'AGENC_REMOTE_AUTH_TOKEN',
+  'AGENC_SESSION_ACCESS_TOKEN',
+
+  // additional provider keys set live on process.env by provider profiles
+  // (providerProfiles.ts) — these were previously MISSING and leaked to children
+  'MISTRAL_API_KEY',
+  'MINIMAX_API_KEY',
+  'NVIDIA_API_KEY',
+  'BNKR_API_KEY',
+
+  // MCP OAuth client secret — read from process.env by services/mcp/auth.ts;
+  // an MCP stdio child must not inherit the parent's OAuth client secret
+  'MCP_CLIENT_SECRET',
 
   // OTLP exporter headers — documented to carry Authorization=Bearer tokens
   // for monitoring backends; read in-process by OTEL SDK, subprocesses never need them
@@ -72,6 +77,29 @@ const SUBPROCESS_SECRET_ENV = [
   'DEFAULT_WORKFLOW_TOKEN',
   'SSH_SIGNING_KEY',
 ] as const
+
+/**
+ * Env vars stripped from EVERY subprocess environment by default.
+ *
+ * Child processes (Bash tool, shell snapshot, MCP stdio servers, LSP servers,
+ * shell hooks) are spawned with these removed so that a prompt-injected or
+ * model-run command (e.g. `printenv`, or shell expansion like
+ * `${ANTHROPIC_API_KEY}`) cannot exfiltrate provider keys or CI credentials.
+ *
+ * Provider/API calls happen IN-PROCESS — the parent agenc process re-reads
+ * these per-request (lazy credential reads), so children never need them.
+ *
+ * Derived as the union of the curated base list above and SECRET_ENV_KEYS (the
+ * single source of provider-secret env names assigned to process.env by
+ * provider profiles), so a newly-added provider key is scrubbed automatically.
+ *
+ * This is the DEFAULT behavior (no flag required). Set
+ * AGENC_SUBPROCESS_ENV_NO_SCRUB to a truthy value to opt out (e.g. for a trusted
+ * local wrapper script that genuinely needs an inherited token).
+ */
+export const SUBPROCESS_SECRET_ENV: readonly string[] = [
+  ...new Set<string>([...SUBPROCESS_SECRET_ENV_BASE, ...SECRET_ENV_KEYS]),
+]
 
 // Registered by init.ts after the upstreamproxy module is dynamically imported
 // in CCR sessions. Stays undefined in non-CCR startups so we never pull in the

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -1,5 +1,6 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:net";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -64,6 +65,52 @@ async function listenUnixSocket(socketPath: string): Promise<Server> {
     });
   });
   return server;
+}
+
+/**
+ * Leaves a *stale* Unix socket inode on disk: a path that still satisfies
+ * `lstat().isSocket()` but has no listener (connect() yields ECONNREFUSED),
+ * exactly the artifact a daemon crash without unlink leaves behind. A child
+ * process binds the socket and is SIGKILLed so Node never runs its close-time
+ * unlink. Bounded by a short readiness handshake.
+ */
+async function createStaleSocketInode(socketPath: string): Promise<void> {
+  const child = spawn(
+    process.execPath,
+    [
+      "-e",
+      `const { createServer } = require("node:net");` +
+        `const s = createServer(() => {});` +
+        `s.listen(process.argv[1], () => { process.stdout.write("up\\n"); });`,
+      socketPath,
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] },
+  );
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("stale socket listener did not come up")),
+        5_000,
+      );
+      child.stdout.once("data", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      child.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+    });
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  } catch (error) {
+    child.kill("SIGKILL");
+    throw error;
+  }
+  // Confirm the artifact is the stale-inode case we mean to exercise.
+  if (!(await lstat(socketPath)).isSocket()) {
+    throw new Error("expected a leftover socket inode");
+  }
 }
 
 async function closeServer(server: Server | null): Promise<void> {
@@ -218,6 +265,44 @@ port = 0
       expect(host.spawnedPids).toEqual([]);
     } finally {
       await closeServer(socketServer);
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not adopt a pidless daemon whose socket inode is stale (no listener)", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
+    // A leftover socket inode exists (passes lstat().isSocket()) but nothing
+    // is accepting on it, plus a live orphan PID. The recovery path must
+    // probe connectability before adopting and fall through to spawning a
+    // replacement instead of writing the orphan pid.
+    await createStaleSocketInode(socketPath);
+    const terminated: number[] = [];
+    host.runningPids.add(5300);
+
+    try {
+      await expect(
+        ensureAgenCDaemonAutostart({
+          host,
+          findOrphanDaemonPids: () => [5300],
+          terminateOrphanDaemonPid: (pid) => {
+            terminated.push(pid);
+            host.runningPids.delete(pid);
+          },
+          isReady: ({ pid }) => host.runningPids.has(pid),
+          waitTimeoutMs: 1_000,
+        }),
+      ).resolves.toMatchObject({
+        pid: 5201,
+        status: "started",
+      });
+      expect(terminated).toEqual([5300]);
+      expect(host.spawnedPids).toEqual([5201]);
+      // The stale orphan PID must never be written as the live daemon.
+      await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(5201);
+    } finally {
       await rm(agencHome, { recursive: true, force: true });
     }
   });

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -664,20 +664,33 @@ describe("AgenC daemon CLI", () => {
     const host = createHost(agencHome);
     const io = createIo();
     const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    // The fake host never binds a real control socket, so stub the readiness
+    // probe to report the spawned daemon as accepting; this test exercises the
+    // pid/spawn bookkeeping, not the real socket readiness gate.
+    const ready = { waitForDaemonReady: async () => true } as const;
 
     await expect(
-      runAgenCDaemonCli({ kind: "command", action: "start" }, { host, io }),
+      runAgenCDaemonCli(
+        { kind: "command", action: "start" },
+        { host, io, ...ready },
+      ),
     ).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4201);
     expect(io.stdoutText()).toContain("AgenC daemon started (pid 4201)");
 
     await expect(
-      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io }),
+      runAgenCDaemonCli(
+        { kind: "command", action: "status" },
+        { host, io, ...ready },
+      ),
     ).resolves.toBe(0);
     expect(io.stdoutText()).toContain("AgenC daemon running (pid 4201)");
 
     await expect(
-      runAgenCDaemonCli({ kind: "command", action: "start" }, { host, io }),
+      runAgenCDaemonCli(
+        { kind: "command", action: "start" },
+        { host, io, ...ready },
+      ),
     ).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4201);
     expect(host.runningPids).toEqual(new Set([4201]));
@@ -718,7 +731,14 @@ describe("AgenC daemon CLI", () => {
     await expect(
       runAgenCDaemonCli(
         { kind: "command", action: "status" },
-        { host, io, requestHealthStats },
+        {
+          host,
+          io,
+          requestHealthStats,
+          // Socket-ready: the fake host never binds a real socket, so stub the
+          // readiness probe to report the running daemon as accepting.
+          waitForDaemonReady: async () => true,
+        },
       ),
     ).resolves.toBe(0);
 
@@ -757,7 +777,12 @@ describe("AgenC daemon CLI", () => {
 
     expect(requestHealthStats).toHaveBeenCalledTimes(1);
     const out = io.stdoutText();
-    expect(out).toContain("AgenC daemon running (pid 4556)");
+    // The fake host never binds a real socket, so the readiness probe reports
+    // the running pid as not-yet-accepting; status stays exit-0 but no longer
+    // claims definitive readiness, and the health.stats enrichment is absent.
+    expect(out).toContain(
+      "AgenC daemon running (pid 4556, control socket not ready)",
+    );
     expect(out).not.toContain("uptime:");
     expect(out).not.toContain("rss=");
     expect(io.stderrText()).toBe("");
@@ -818,7 +843,10 @@ describe("AgenC daemon CLI", () => {
     );
 
     await expect(
-      runAgenCDaemonCli({ kind: "command", action: "start" }, { host, io }),
+      runAgenCDaemonCli(
+        { kind: "command", action: "start" },
+        { host, io, waitForDaemonReady: async () => true },
+      ),
     ).resolves.toBe(0);
 
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4201);
@@ -979,10 +1007,137 @@ describe("AgenC daemon CLI", () => {
     const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
 
     await expect(
-      runAgenCDaemonCli({ kind: "command", action: "restart" }, { host, io }),
+      runAgenCDaemonCli(
+        { kind: "command", action: "restart" },
+        // The fake host never binds a real control socket; stub readiness so
+        // restart's start phase completes (this test covers restart's
+        // tolerate-stopped + fresh-pid bookkeeping, not the socket gate).
+        { host, io, waitForDaemonReady: async () => true },
+      ),
     ).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4201);
     expect(io.stdoutText()).toContain("AgenC daemon started (pid 4201)");
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("start does not report 'started' until the control socket is ready", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+
+    // Readiness never observed: pid is spawned/alive but the control socket
+    // never becomes connectable. start must surface a non-zero failure rather
+    // than the false "started" line the no-wait code printed unconditionally.
+    const probedPids: number[] = [];
+    await expect(
+      runAgenCDaemonCli(
+        { kind: "command", action: "start" },
+        {
+          host,
+          io,
+          waitForDaemonReady: async (probeHost) => {
+            probedPids.push(
+              (await readAgenCDaemonPid(
+                resolveAgenCDaemonPidPath(probeHost.env, probeHost.userHome),
+              )) ?? -1,
+            );
+            return false;
+          },
+        },
+      ),
+    ).resolves.toBe(1);
+
+    // The readiness probe was actually consulted against the spawned pid.
+    expect(probedPids).toEqual([4201]);
+    expect(io.stdoutText()).not.toContain("AgenC daemon started");
+    expect(io.stderrText()).toContain("control socket did not become ready");
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("start reports 'started' once the control socket becomes ready", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+
+    await expect(
+      runAgenCDaemonCli(
+        { kind: "command", action: "start" },
+        { host, io, waitForDaemonReady: async () => true },
+      ),
+    ).resolves.toBe(0);
+    expect(io.stdoutText()).toContain("AgenC daemon started (pid 4201)");
+    expect(io.stderrText()).toBe("");
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("status flags a live pid whose control socket is not ready", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    host.runningPids.add(4600);
+    await writeAgenCDaemonPid(pidPath, 4600);
+
+    await expect(
+      runAgenCDaemonCli(
+        { kind: "command", action: "status" },
+        {
+          host,
+          io,
+          // pid alive, socket not connectable.
+          waitForDaemonReady: async () => false,
+          // health.stats also unreachable in this window.
+          requestHealthStats: async () => {
+            throw new Error("socket not ready");
+          },
+        },
+      ),
+    ).resolves.toBe(0);
+
+    const out = io.stdoutText();
+    expect(out).toContain(
+      "AgenC daemon running (pid 4600, control socket not ready)",
+    );
+    expect(out).not.toContain("uptime:");
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("reload waits for control-socket connectability before connecting", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    host.runningPids.add(4601);
+    await writeAgenCDaemonPid(pidPath, 4601);
+
+    // Socket never becomes connectable: reload must refuse via the readiness
+    // gate instead of racing into a connect ENOENT, and must not kill the pid.
+    let readinessProbed = false;
+    await expect(
+      runAgenCDaemonCli(
+        { kind: "command", action: "reload" },
+        {
+          host,
+          io,
+          waitForDaemonReady: async () => {
+            readinessProbed = true;
+            return false;
+          },
+        },
+      ),
+    ).resolves.toBe(1);
+
+    expect(readinessProbed).toBe(true);
+    expect(io.stderrText()).toContain(
+      "control socket did not become ready before timeout",
+    );
+    expect(host.terminatedPids).toEqual([]);
+    await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4601);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -1207,7 +1362,7 @@ port = 0
     }
   });
 
-  it("reload fails without a daemon cookie and leaves the daemon running", async () => {
+  it("reload fails when the control socket is not ready and leaves the daemon running", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);
     const io = createIo();
@@ -1216,10 +1371,18 @@ port = 0
     await writeAgenCDaemonPid(pidPath, 4400);
 
     await expect(
-      runAgenCDaemonCli({ kind: "command", action: "reload" }, { host, io }),
+      runAgenCDaemonCli(
+        { kind: "command", action: "reload" },
+        // Pid is alive but the control socket never becomes connectable (no
+        // cookie/socket bound yet). Reload must refuse rather than race into a
+        // connect ENOENT, and must not terminate the running daemon.
+        { host, io, waitForDaemonReady: async () => false },
+      ),
     ).resolves.toBe(1);
 
-    expect(io.stderrText()).toContain("daemon cookie is not available");
+    expect(io.stderrText()).toContain(
+      "control socket did not become ready before timeout",
+    );
     expect(host.terminatedPids).toEqual([]);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4400);
 

--- a/runtime/tests/bin/agenc-help.test.ts
+++ b/runtime/tests/bin/agenc-help.test.ts
@@ -9,6 +9,7 @@ import {
   formatAgenCDaemonCliHelpText,
   parseAgenCDaemonCliArgs,
 } from "../app-server/daemon-cli.js";
+import { VERSION } from "../index.js";
 
 describe("agenc CLI help", () => {
   it("formats top-level CLI help with commands and examples", () => {
@@ -86,6 +87,46 @@ describe("agenc CLI help", () => {
       kind: "error",
       message: "help accepts at most one command topic",
     });
+  });
+
+  it("honors --help/-h/--version only as real leading flags", () => {
+    // Real usages still short-circuit.
+    expect(detectStartupShortCircuit(["--version"])).toEqual({
+      kind: "version",
+      text: `agenc ${VERSION}`,
+    });
+    expect(detectStartupShortCircuit(["--help"])).toEqual({
+      kind: "help",
+      text: formatCliHelpText(),
+    });
+    expect(detectStartupShortCircuit(["-h"])).toEqual({
+      kind: "help",
+      text: formatCliHelpText(),
+    });
+    // A leading flag after other leading options still counts, including a
+    // value flag (`--model gpt`) whose value must not end the option region.
+    expect(detectStartupShortCircuit(["--no-tui", "--help"])).toEqual({
+      kind: "help",
+      text: formatCliHelpText(),
+    });
+    expect(detectStartupShortCircuit(["--model", "gpt", "--version"])).toEqual({
+      kind: "version",
+      text: `agenc ${VERSION}`,
+    });
+
+    // Prompt content that merely CONTAINS these tokens must NOT short-circuit.
+    expect(
+      detectStartupShortCircuit(["what", "does", "--version", "mean"]),
+    ).toBeNull();
+    expect(
+      detectStartupShortCircuit(["explain", "the", "--help", "flag"]),
+    ).toBeNull();
+    expect(
+      detectStartupShortCircuit(["tell", "me", "about", "-h", "usage"]),
+    ).toBeNull();
+    // Anything after an end-of-options `--` is prompt, never a flag.
+    expect(detectStartupShortCircuit(["--", "--help"])).toBeNull();
+    expect(detectStartupShortCircuit(["--", "--version"])).toBeNull();
   });
 
   it("routes nested daemon help without starting the daemon", () => {

--- a/runtime/tests/session/sessionStorage-transcript.test.ts
+++ b/runtime/tests/session/sessionStorage-transcript.test.ts
@@ -338,6 +338,35 @@ test("uses isolated session paths for transcripts and agent metadata", async () 
   );
 });
 
+test("readAgentMetadata returns null for a corrupt sidecar instead of throwing", async () => {
+  await configureIsolatedSession();
+  const agentId = "agent-corrupt" as never;
+
+  // Simulate a partial write from a crashed fire-and-forget persist.
+  const metaPath = getAgentTranscriptPath(agentId).replace(
+    /\.jsonl$/,
+    ".meta.json",
+  );
+  await mkdir(dirname(metaPath), { recursive: true });
+  await writeFile(metaPath, "{");
+
+  await expect(readAgentMetadata(agentId)).resolves.toBeNull();
+});
+
+test("readRemoteAgentMetadata returns null for a corrupt sidecar instead of throwing", async () => {
+  const { projectDir } = await configureIsolatedSession();
+
+  // Simulate a partial write from a crashed fire-and-forget persist.
+  const remoteDir = join(projectDir, sessionId, "remote-agents");
+  await mkdir(remoteDir, { recursive: true });
+  await writeFile(
+    join(remoteDir, "remote-agent-task-corrupt.meta.json"),
+    "{",
+  );
+
+  await expect(readRemoteAgentMetadata("task-corrupt")).resolves.toBeNull();
+});
+
 test("persists, lists, and deletes remote agent metadata", async () => {
   const { projectDir } = await configureIsolatedSession();
   const metadata = {

--- a/runtime/tests/subprocess-env-scrub.test.ts
+++ b/runtime/tests/subprocess-env-scrub.test.ts
@@ -2,7 +2,8 @@ import { execFileSync } from 'node:child_process'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { subprocessEnv } from 'src/utils/subprocessEnv.js'
+import { SUBPROCESS_SECRET_ENV, subprocessEnv } from 'src/utils/subprocessEnv.js'
+import { SECRET_ENV_KEYS } from 'src/utils/providerSecrets.js'
 
 // Security regression: the env handed to every Bash / MCP-stdio / hook /
 // shell-snapshot / LSP child goes through subprocessEnv(). By DEFAULT (with
@@ -101,5 +102,70 @@ describe('subprocessEnv default-scrub (no AGENC_SUBPROCESS_ENV_SCRUB)', () => {
     const childEnv = subprocessEnv()
     // Opt-out restores inheritance for trusted setups that need it.
     expect(childEnv.ANTHROPIC_API_KEY).toBe('sk-ant-secret')
+  })
+
+  // NOT name-enumerated: iterate the ACTUAL denylist so a new entry is
+  // automatically covered and a future omission in the loop is caught.
+  it('scrubs EVERY entry in SUBPROCESS_SECRET_ENV (and its INPUT_ twin)', () => {
+    const savedDenylistVals: Record<string, string | undefined> = {}
+    try {
+      for (const key of SUBPROCESS_SECRET_ENV) {
+        savedDenylistVals[key] = process.env[key]
+        savedDenylistVals[`INPUT_${key}`] = process.env[`INPUT_${key}`]
+        process.env[key] = `secret-value-for-${key}`
+        process.env[`INPUT_${key}`] = `input-secret-for-${key}`
+      }
+
+      const childEnv = subprocessEnv()
+
+      for (const key of SUBPROCESS_SECRET_ENV) {
+        expect(
+          childEnv[key],
+          `${key} (a SUBPROCESS_SECRET_ENV entry) must be scrubbed`,
+        ).toBeUndefined()
+        expect(
+          childEnv[`INPUT_${key}`],
+          `INPUT_${key} must be scrubbed`,
+        ).toBeUndefined()
+      }
+    } finally {
+      for (const [key, value] of Object.entries(savedDenylistVals)) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
+  })
+
+  // STRUCTURAL guard (the one that catches the original gap): every provider
+  // secret env name the codebase assigns to process.env — the single source
+  // SECRET_ENV_KEYS — MUST be in the subprocess denylist. If a new provider key
+  // is added to SECRET_ENV_KEYS but not scrubbed, this fails.
+  it('SUBPROCESS_SECRET_ENV is a superset of providerSecrets.SECRET_ENV_KEYS', () => {
+    const denylist = new Set<string>(SUBPROCESS_SECRET_ENV)
+    const missing = SECRET_ENV_KEYS.filter((key) => !denylist.has(key))
+    expect(
+      missing,
+      `provider secret env names missing from SUBPROCESS_SECRET_ENV: ${missing.join(', ')}`,
+    ).toEqual([])
+  })
+
+  // Explicit lock on the provider/OAuth secrets that previously leaked, so a
+  // regression that drops any one of them goes red even if SECRET_ENV_KEYS
+  // changes shape.
+  it('scrubs the provider/OAuth secrets that previously leaked to children', () => {
+    const previouslyLeaked = [
+      'MISTRAL_API_KEY',
+      'BNKR_API_KEY',
+      'MINIMAX_API_KEY',
+      'NVIDIA_API_KEY',
+      'MCP_CLIENT_SECRET',
+    ]
+    const denylist = new Set<string>(SUBPROCESS_SECRET_ENV)
+    for (const key of previouslyLeaked) {
+      expect(
+        denylist.has(key),
+        `${key} must be in SUBPROCESS_SECRET_ENV`,
+      ).toBe(true)
+    }
   })
 })


### PR DESCRIPTION
Autonomous discover→verify→fix iteration 1. All 5 fixes gated (typecheck + 13054 tests + build), adversarially reviewed, each with a revert-sensitive regression test.

- **HIGH** scrub all provider/OAuth secrets from subprocess env (was leaking MISTRAL/BNKR/MINIMAX/NVIDIA/MCP_CLIENT_SECRET)
- **HIGH** tolerate corrupt agent-metadata sidecars on resume (was crashing resume on partial write)
- **HIGH** gate daemon start/status/reload on real control-socket readiness (was reporting running before socket ready)
- **MED** only short-circuit --version/--help/-h as leading flags (prompts containing them were swallowed)
- **LOW** require socket connectability before adopting an orphan daemon (stale inode adoption)

2 of the HIGHs were promoted from the verifier's rejected pile (strict gate buried real criticals).