### PR TITLE
auto-fix iter 2: 5 verified fixes (model strings, permission ask-rule, mcp/config/test hardening)

### DIFF
--- a/runtime/src/bin/mcp-cli.ts
+++ b/runtime/src/bin/mcp-cli.ts
@@ -353,6 +353,9 @@ function parseSimpleOptions(
       const name = normalizeMcpOptionName(rawName);
       const inlineValue = eq === -1 ? undefined : trimmed.slice(eq + 1);
       if (booleanOptions.has(name)) {
+        if (inlineValue !== undefined) {
+          throw new Error(`Option --${name} does not take a value`);
+        }
         flags.add(name);
         continue;
       }

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -699,7 +699,16 @@ export function defaultConfig(): AgenCConfig {
     project_doc_max_bytes: 32_768,
     stream_watchdog_timeout_ms: 30_000,
     max_turns: 50,
-    autoUpdates: false,
+    // NOTE: `autoUpdates` is intentionally NOT defaulted here. The effective
+    // auto-update state is governed solely by the global config
+    // (`GlobalConfig.autoUpdates`, default undefined = enabled-unless-disabled)
+    // and surfaced by `getAutoUpdaterDisabledReason()` / `agenc doctor`. The
+    // TOML `AgenCConfig.autoUpdates` field is not read by the auto-updater, so
+    // injecting a concrete `false` default here only made `config get
+    // autoUpdates` report a hardcoded `false` that contradicted doctor's
+    // "enabled" — see runtime/src/utils/config.ts. Leaving it unset makes
+    // `config get autoUpdates` report "not set: autoUpdates" when the user has
+    // not explicitly configured it, consistent with the effective state.
     editorMode: "default" as EditorMode,
     tuiLayout: Object.freeze({
       mode: "single",

--- a/runtime/src/permissions/bash.ts
+++ b/runtime/src/permissions/bash.ts
@@ -319,6 +319,46 @@ function buildSubcommandReason(
   return { type: "subcommandResults", reasons: map };
 }
 
+/**
+ * True when an aggregated `ask` decision was produced by at least one
+ * explicit permission rule (a rule-based `ask`), as opposed to a non-rule
+ * ask such as an unverifiable shell construct (`bash_parse_unavailable`).
+ *
+ * The aggregate's top-level `decisionReason` is always
+ * `{ type: "subcommandResults", … }`, so the rule provenance lives in the
+ * per-subcommand results. A subcommand's `ask` carries
+ * `decisionReason: { type: "rule", rule: { ruleBehavior: "ask", … } }`
+ * when it matched a content-specific rule (`Bash(cat:*)`) OR a whole-tool
+ * ask rule — both must survive the sandbox auto-allow, mirroring
+ * `checkSandboxAutoAllow`'s rule-based-ask handling.
+ */
+function aggregateAskCameFromRule(
+  aggregate: BashPermissionResult,
+): boolean {
+  // Defensive: top-level reason may itself encode a rule-based ask in
+  // future shapes; honor it directly.
+  const topReason = aggregate.decisionReason;
+  if (
+    topReason !== undefined &&
+    topReason.type === "rule" &&
+    topReason.rule.ruleBehavior === "ask"
+  ) {
+    return true;
+  }
+  const subs = aggregate.subcommandResults;
+  if (subs === undefined) return false;
+  return subs.some((s) => {
+    const r = s.result;
+    if (r.behavior !== "ask") return false;
+    const reason = r.decisionReason;
+    return (
+      reason !== undefined &&
+      reason.type === "rule" &&
+      reason.rule.ruleBehavior === "ask"
+    );
+  });
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Main entry point
 // ─────────────────────────────────────────────────────────────────────
@@ -455,6 +495,20 @@ export async function bashToolHasPermission(
     readonly autoAllowBashIfSandboxed?: boolean;
   };
   if (ctxWithFlag.autoAllowBashIfSandboxed === true && shouldUseSandbox(input)) {
+    // SECURITY: An explicit user ask-rule must survive the sandbox
+    // auto-allow. Mirrors `checkSandboxAutoAllow` in BashTool/bashPermissions.ts:
+    // only `passthrough` (and a non-rule "ask", e.g. an unverifiable shell
+    // construct) may be upgraded to `allow`. An `ask` that originated from a
+    // permission rule (content-specific like `Bash(cat:*)` OR a whole-tool ask)
+    // must be returned as-is, so the user's configured approval prompt fires.
+    // Without this guard the auto-allow short-circuits the evaluator's
+    // "content-specific ask rule survives bypass" protection (evaluator.ts 1f).
+    if (
+      aggregate.behavior === "ask" &&
+      aggregateAskCameFromRule(aggregate)
+    ) {
+      return aggregate;
+    }
     if (aggregate.behavior === "passthrough" || aggregate.behavior === "ask") {
       return {
         behavior: "allow",

--- a/runtime/src/utils/model/modelStrings.ts
+++ b/runtime/src/utils/model/modelStrings.ts
@@ -28,7 +28,15 @@ function getBuiltinModelStrings(provider: string): ModelStrings {
   const providerKey = provider === 'agenc' || provider === 'github' ? 'openai' : provider
   const out = {} as ModelStrings
   for (const key of MODEL_KEYS) {
-    out[key] = (ALL_MODEL_CONFIGS[key] as Record<string, string>)[providerKey]
+    const cfg = ALL_MODEL_CONFIGS[key]
+    // Not every ModelConfig defines every provider key (e.g. only opus46 maps
+    // xai/mistral), so the dynamic provider/openai lookups can be undefined at
+    // runtime. Cast only those dynamic lookups as possibly-undefined and end the
+    // chain on the strongly-typed `firstParty`, which ModelConfig guarantees is
+    // defined, so each ModelKey always resolves to a real, non-undefined model
+    // string regardless of provider.
+    const lookup = cfg as Record<string, string | undefined>
+    out[key] = lookup[providerKey] ?? lookup.openai ?? cfg.firstParty
   }
   return out
 }

--- a/runtime/tests/bin/config-cli.test.ts
+++ b/runtime/tests/bin/config-cli.test.ts
@@ -506,4 +506,37 @@ describe("agenc config CLI", () => {
       stderrSpy.mockRestore();
     }
   });
+
+  it("does not report a contradictory hardcoded autoUpdates default on a fresh home", async () => {
+    // Cross-surface consistency guard. `agenc doctor` derives the effective
+    // auto-update state from getAutoUpdaterDisabledReason() over the GLOBAL
+    // config, which is "enabled" when the user has not explicitly disabled it
+    // (unset => null reason => "enabled"). The TOML `AgenCConfig.autoUpdates`
+    // field is not read by the auto-updater. Previously `defaultConfig()`
+    // injected a concrete `autoUpdates: false`, so on a fresh home with no
+    // config.toml `config get autoUpdates` printed "false" — directly
+    // contradicting doctor's "Auto-updates: enabled". Assert the two surfaces
+    // no longer disagree: with nothing configured, `config get autoUpdates`
+    // must NOT assert a concrete `false`; it reports "not set" instead.
+    //
+    // Revert-sensitive: restore `autoUpdates: false` in schema.ts defaultConfig()
+    // and this expectation flips to `"false\n"`, failing the test.
+    const freshHome = makeHome();
+    expect(existsSync(configPath(freshHome))).toBe(false);
+
+    const get = await run(
+      parseAgenCConfigCliArgs(["config", "get", "autoUpdates"]),
+      freshHome,
+    );
+    expect(get.code).toBe(0);
+    expect(get.io.stdoutText()).not.toBe("false\n");
+    expect(get.io.stdoutText()).toBe("not set: autoUpdates\n");
+
+    // `config show` must likewise not surface a concrete `autoUpdates` value
+    // the auto-updater never honors.
+    const show = await run(parseAgenCConfigCliArgs(["config", "show"]), freshHome);
+    expect(show.code).toBe(0);
+    const snapshot = JSON.parse(show.io.stdoutText()) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(snapshot, "autoUpdates")).toBe(false);
+  });
 });

--- a/runtime/tests/bin/mcp-cli-management.test.ts
+++ b/runtime/tests/bin/mcp-cli-management.test.ts
@@ -401,6 +401,50 @@ describe("AgenC MCP management CLI parsing", () => {
       .toThrow();
   });
 
+  test("mcp add rejects value-form boolean flags instead of silently enabling them", async () => {
+    for (const flagArg of ["--client-secret=false", "--xaa=false", "--client-secret=0"]) {
+      const { io, output } = captureIo();
+
+      await expect(
+        runAgenCMcpCli(
+          {
+            kind: "management",
+            argv: ["add", flagArg, "github", "gh-mcp"],
+          },
+          { io },
+        ),
+      ).resolves.toBe(1);
+
+      const flagName = flagArg.slice(2, flagArg.indexOf("="));
+      expect(output().stderr).toContain(
+        `Option --${flagName} does not take a value`,
+      );
+      // No config should be written when parsing rejects the argument.
+      await expect(readFile(join(agencHome, "config.toml"), "utf8")).rejects
+        .toThrow();
+    }
+  });
+
+  test("mcp add still enables bare boolean flags", async () => {
+    const { io } = captureIo();
+
+    await expect(
+      runAgenCMcpCli(
+        {
+          kind: "management",
+          argv: ["add", "--client-secret", "github", "gh-mcp"],
+        },
+        { io },
+      ),
+    ).resolves.toBe(0);
+
+    const loaded = await loadConfig({ home: agencHome });
+    expect(loaded.config.mcp_servers?.github).toMatchObject({
+      transport: "stdio",
+      command: "gh-mcp",
+    });
+  });
+
   test("mcp xaa setup validates issuer and secret env before writing settings", async () => {
     const { io, output } = captureIo();
 

--- a/runtime/tests/permissions/bash.test.ts
+++ b/runtime/tests/permissions/bash.test.ts
@@ -686,6 +686,39 @@ describe("bashToolHasPermission", () => {
     }
   });
 
+  test("explicit ask-rule survives autoAllowBashIfSandboxed (no sandbox auto-allow upgrade)", async () => {
+    // SECURITY REGRESSION: a user-configured ask rule (Bash(cat:*)) must still
+    // prompt even when the command is sandbox-safe and auto-allow-when-sandboxed
+    // is enabled. Upgrading it to `allow` would silently skip the user's
+    // approval prompt and short-circuit evaluator.ts 1f.
+    const ctx = makeCtx({
+      autoAllowBashIfSandboxed: true,
+      alwaysAskRules: {
+        userSettings: ["Bash(cat:*)"],
+      },
+    });
+    const evalCtx = makeEvaluatorCtx(ctx);
+    const result = await bashToolHasPermission(
+      { command: "cat somefile" },
+      evalCtx,
+    );
+    expect(result.behavior).toBe("ask");
+  });
+
+  test("autoAllowBashIfSandboxed still auto-allows a safe command with no explicit rule", async () => {
+    // Positive case: ensure the ask-rule guard did not disable the feature.
+    const ctx = makeCtx({ autoAllowBashIfSandboxed: true });
+    const evalCtx = makeEvaluatorCtx(ctx);
+    const result = await bashToolHasPermission(
+      { command: "cat somefile" },
+      evalCtx,
+    );
+    expect(result.behavior).toBe("allow");
+    if (result.behavior === "allow") {
+      expect(result.decisionReason?.type).toBe("sandboxOverride");
+    }
+  });
+
   test("plan mode does not hard-block non-read-only commands (upstream parity)", async () => {
     // AgenC's `checkPermissionMode`
     // (BashTool/modeValidation.ts:168-205) has no plan branch; bash

--- a/runtime/tests/prompts/agenc-md.test.ts
+++ b/runtime/tests/prompts/agenc-md.test.ts
@@ -274,6 +274,15 @@ describe("agenc-md (T10-B tiered + @include)", () => {
     });
     const dd = res.dropped.find((d) => d.reason === "max_depth");
     expect(dd).toBeDefined();
+    // Positive: in-bounds files (depth <= maxDepth) ARE inlined. With
+    // maxDepth:2 the guard is `depth+1 > max`, so f0 (->1) and f1 (->2)
+    // inline; f1's ok-marker only appears if f0 was expanded.
+    expect(res.text).toContain("<!-- @include f1.md -->");
+    // Negative: the over-depth file f2 (->3 > 2) is rejected, not inlined,
+    // and the deepest LEAF body (in f4) is never reached/inlined.
+    expect(res.text).toContain("<!-- @include f2.md (rejected: max_depth");
+    expect(res.text).not.toContain("<!-- @include f2.md -->");
+    expect(res.text).not.toContain("LEAF");
   });
 
   test("@include max-bytes exceeded", async () => {

--- a/runtime/tests/utils/model/modelStrings.github.test.ts
+++ b/runtime/tests/utils/model/modelStrings.github.test.ts
@@ -11,6 +11,8 @@ const originalEnv = {
   AGENC_USE_BEDROCK: process.env.AGENC_USE_BEDROCK,
   AGENC_USE_VERTEX: process.env.AGENC_USE_VERTEX,
   AGENC_USE_FOUNDRY: process.env.AGENC_USE_FOUNDRY,
+  AGENC_USE_MISTRAL: process.env.AGENC_USE_MISTRAL,
+  XAI_API_KEY: process.env.XAI_API_KEY,
 }
 
 function clearProviderFlags(): void {
@@ -20,15 +22,18 @@ function clearProviderFlags(): void {
   delete process.env.AGENC_USE_BEDROCK
   delete process.env.AGENC_USE_VERTEX
   delete process.env.AGENC_USE_FOUNDRY
+  delete process.env.AGENC_USE_MISTRAL
+  delete process.env.XAI_API_KEY
 }
 
 afterEach(() => {
-  process.env.AGENC_USE_GITHUB = originalEnv.AGENC_USE_GITHUB
-  process.env.AGENC_USE_OPENAI = originalEnv.AGENC_USE_OPENAI
-  process.env.AGENC_USE_GEMINI = originalEnv.AGENC_USE_GEMINI
-  process.env.AGENC_USE_BEDROCK = originalEnv.AGENC_USE_BEDROCK
-  process.env.AGENC_USE_VERTEX = originalEnv.AGENC_USE_VERTEX
-  process.env.AGENC_USE_FOUNDRY = originalEnv.AGENC_USE_FOUNDRY
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
   resetModelStringsForTestingOnly()
 })
 
@@ -51,4 +56,38 @@ test('GitHub provider model strings are safe to parse', () => {
   const modelStrings = getModelStrings()
 
   expect(() => parseUserSpecifiedModel(modelStrings.sonnet46 as any)).not.toThrow()
+})
+
+// Regression: only AGENC_OPUS_4_6_CONFIG defines `xai`/`mistral` keys, so for
+// every other ModelKey the provider-specific lookup was undefined at runtime
+// (tsc-blind because ModelConfig has an open index signature). Downstream this
+// produced model IDs like 'undefined[1m]' in the /model picker.
+test('xai provider model strings are concrete IDs for every model key', () => {
+  clearProviderFlags()
+  process.env.XAI_API_KEY = 'xai-test-key'
+
+  const modelStrings = getModelStrings()
+
+  const entries = Object.entries(modelStrings)
+  expect(entries.length).toBeGreaterThan(0)
+  for (const [key, value] of entries) {
+    expect(value, `xai model string for key "${key}"`).toBeDefined()
+    expect(typeof value).toBe('string')
+    expect((value as string).trim().length).toBeGreaterThan(0)
+  }
+})
+
+test('mistral provider model strings are concrete IDs for every model key', () => {
+  clearProviderFlags()
+  process.env.AGENC_USE_MISTRAL = '1'
+
+  const modelStrings = getModelStrings()
+
+  const entries = Object.entries(modelStrings)
+  expect(entries.length).toBeGreaterThan(0)
+  for (const [key, value] of entries) {
+    expect(value, `mistral model string for key "${key}"`).toBeDefined()
+    expect(typeof value).toBe('string')
+    expect((value as string).trim().length).toBeGreaterThan(0)
+  }
 })


### PR DESCRIPTION
Autonomous discover→verify→fix iteration 2. All 5 gated (typecheck + 13061 tests + build), adversarially reviewed (the permission fix via a 3-skeptic panel), each with a revert-sensitive test.

- **HIGH** resolve defined model strings for xai/mistral providers (was producing undefined model IDs, tsc-blind)
- **MED** mcp add: reject value-form boolean flags (--client-secret=false was silently enabling)
- **MED** strengthen @include max-depth test to guard actual enforcement
- **LOW** stop reporting a contradictory autoUpdates default (config get vs doctor)
- **LOW** preserve explicit ask-rules under sandbox auto-allow (permission-bypass fix)