### PR TITLE
auto-fix iter 3: 9 verified fixes (headless permissions, validation, corrupt-file tolerance, test hardening)

### DIFF
--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -1728,6 +1728,23 @@ function daemonOneShotPermissionRequestId(event: unknown): string | null {
     : null;
 }
 
+/**
+ * Exit code used when a non-interactive one-shot run auto-denied at least one
+ * permission request and then "completed" (the model gave up after its tool
+ * call was rejected). Distinct from a real success (0) and from a daemon error
+ * (1) so callers/scripts can tell a tool-blocked giveup from a genuine answer.
+ */
+const ONE_SHOT_TOOL_DENIED_EXIT_CODE = 2;
+
+/**
+ * Stderr marker emitted alongside {@link ONE_SHOT_TOOL_DENIED_EXIT_CODE} so a
+ * human reading the run can see why it failed and how to grant the tool.
+ */
+const ONE_SHOT_TOOL_DENIED_MARKER =
+  "agenc: tool denied in non-interactive mode; the run could not complete its " +
+  "tool call and gave up. Re-run with --permission-mode or " +
+  "--dangerously-bypass-approvals-and-sandbox to allow tools.";
+
 function daemonOneShotFinalStatus(
   event: unknown,
 ): DaemonOneShotFinalStatus | null {
@@ -1900,6 +1917,19 @@ async function runDaemonOneShotPrompt(params: {
           ) {
             process.stderr.write(`${finalStatus.message}\n`);
           }
+          // A tool-blocked giveup must NOT masquerade as a successful answer.
+          // When the run auto-denied a permission request (no human to approve;
+          // see daemonOneShotPermissionRequestId) and then "completed", the
+          // model gave up after its tool call was rejected. Override the
+          // otherwise-zero exit so callers/scripts can distinguish a real answer
+          // from a tool-blocked giveup, and surface a clear stderr marker. A run
+          // that denied nothing keeps its normal exit code, so genuine no-tool
+          // answers still exit 0 and genuine daemon errors still exit non-zero.
+          if (finalStatus.code === 0 && deniedPermissionRequestIds.size > 0) {
+            process.stderr.write(`${ONE_SHOT_TOOL_DENIED_MARKER}\n`);
+            settle({ code: ONE_SHOT_TOOL_DENIED_EXIT_CODE });
+            return;
+          }
           settle({ code: finalStatus.code });
         },
       );
@@ -2033,6 +2063,26 @@ export async function oneShotCLI(
       oneShotArgv.includes("--yolo") ||
       oneShotArgv.includes("--dangerously-bypass-approvals-and-sandbox") ||
       oneShotArgv.includes("--allow-dangerously-skip-permissions");
+    // Honor a validated `--permission-mode <value>` in the print path. Without
+    // this, only --yolo/bypass propagated and acceptEdits/plan/default were
+    // silently dropped. readStartupCliFlags already validated the flag (throwing
+    // on a typo so a less-restrictive session can't boot silently). The daemon's
+    // forced --autonomous does NOT override a forwarded acceptEdits/plan:
+    // applyUnattendedPermissionPolicyToContext explicitly preserves the user's
+    // explicit mode (only default → unattended), so forwarding takes effect
+    // without weakening the unattended/security posture. --yolo still wins:
+    // bypassPermissions takes precedence over any other forwarded mode. Narrow
+    // to the daemon-accepted subset (agent.create rejects dontAsk/auto); other
+    // user-addressable modes fall back to the unattended default as before.
+    const startupCliFlags = readStartupCliFlags(process.argv);
+    const oneShotPermissionMode = isYoloOneShot
+      ? ("bypassPermissions" as const)
+      : startupCliFlags.permissionMode === "default" ||
+          startupCliFlags.permissionMode === "plan" ||
+          startupCliFlags.permissionMode === "acceptEdits" ||
+          startupCliFlags.permissionMode === "bypassPermissions"
+        ? startupCliFlags.permissionMode
+        : undefined;
     return await runDaemonOneShotPrompt({
       deps: daemonCliDeps(),
       prompt: daemonPrompt,
@@ -2042,8 +2092,8 @@ export async function oneShotCLI(
       provider: startup.provider,
       ...(startup.profileName !== undefined ? { profile: startup.profileName } : {}),
       ...(initialContent !== undefined ? { initialContent } : {}),
-      ...(isYoloOneShot
-        ? { permissionMode: "bypassPermissions" as const }
+      ...(oneShotPermissionMode !== undefined
+        ? { permissionMode: oneShotPermissionMode }
         : {}),
     });
   } catch (error) {

--- a/runtime/src/bin/startup-selection.ts
+++ b/runtime/src/bin/startup-selection.ts
@@ -3,7 +3,9 @@ import {
   type ProviderName,
 } from "../llm/provider.js";
 import {
+  isPermissionMode,
   isUserAddressablePermissionMode,
+  USER_ADDRESSABLE_PERMISSION_MODES,
   type PermissionMode,
 } from "../permissions/types.js";
 import { AmbiguousModelError, UnknownModelError } from "../config/schema.js";
@@ -48,10 +50,12 @@ export function readStartupCliFlags(
   const profile = extractFlagValue(userArgv, "--profile") ?? undefined;
   const rawPermissionMode =
     extractFlagValue(userArgv, "--permission-mode") ?? undefined;
-  const permissionMode =
-    rawPermissionMode && isUserAddressablePermissionMode(rawPermissionMode)
-      ? rawPermissionMode
-      : undefined;
+  // Distinguish "flag absent" from "flag present but invalid". An invalid
+  // value must not be silently coerced to `undefined` (which would boot in
+  // DEFAULT mode — a silent failure toward a LESS restrictive session). Throw
+  // a helpful error mirroring `resolveProviderNameOrThrow` / `/permissions
+  // mode`, surfacing as a clean error + non-zero exit at the CLI entrypoint.
+  const permissionMode = resolvePermissionModeOrThrow(rawPermissionMode);
   const allowDangerouslySkipPermissions =
     userArgv.includes("--yolo") ||
     userArgv.includes("--dangerously-bypass-approvals-and-sandbox") ||
@@ -68,6 +72,27 @@ export function readStartupCliFlags(
       : {}),
     ...(autonomousMode ? { autonomousMode: true } : {}),
   });
+}
+
+function resolvePermissionModeOrThrow(
+  raw: string | undefined,
+): PermissionMode | undefined {
+  // Flag absent (or explicitly empty) — keep the default-mode behavior.
+  if (!raw) return undefined;
+  // A user-addressable mode — honor it.
+  if (isUserAddressablePermissionMode(raw)) return raw;
+  // A VALID permission mode that simply isn't user-addressable (e.g. the
+  // internal/daemon-only "unattended" or "bubble" modes). The existing
+  // contract is to silently IGNORE these at the startup CLI surface, not
+  // error — they are recognized, just not selectable here.
+  if (isPermissionMode(raw)) return undefined;
+  // Anything else is a genuine typo / garbage value. Throw a helpful error
+  // mirroring `resolveProviderNameOrThrow` / `/permissions mode` so a typo
+  // toward a more restrictive mode can't silently boot a LESS restrictive
+  // session.
+  throw new Error(
+    `unknown permission mode '${raw}'. Expected one of: ${USER_ADDRESSABLE_PERMISSION_MODES.join(", ")}`,
+  );
 }
 
 function resolveProviderNameOrThrow(raw: string): ProviderName {

--- a/runtime/src/utils/TextCursor.ts
+++ b/runtime/src/utils/TextCursor.ts
@@ -471,7 +471,11 @@ export class TextCursor {
     const lineText = this.measuredText.getWrappedText()[line] || ''
 
     const match = lineText.match(/^\s*\S/)
-    const column = match?.index ? match.index + match[0].length - 1 : 0
+    // The regex is anchored (`^`), so `match.index` is always 0 on a match;
+    // the first-non-blank column is the leading-whitespace length, which is
+    // `match[0].length - 1` (the match captures the leading whitespace plus the
+    // first non-blank char). An all-blank/empty line yields no match -> 0.
+    const column = match ? match[0].length - 1 : 0
     const offset = this.getOffset({ line, column })
 
     return new TextCursor(this.measuredText, offset, 0)

--- a/runtime/src/utils/auth.ts
+++ b/runtime/src/utils/auth.ts
@@ -1752,6 +1752,29 @@ let cachedOtelHeaders: Record<string, string> | null = null
 let cachedOtelHeadersTimestamp = 0
 const DEFAULT_OTEL_HEADERS_DEBOUNCE_MS = 29 * 60 * 1000 // 29 minutes
 
+/**
+ * Resolve the otelHeadersHelper debounce interval (ms) from the env override,
+ * falling back to the default when unset or invalid.
+ *
+ * A non-numeric override (e.g. "abc") parses to NaN, and a NaN debounce makes
+ * the `Date.now() - timestamp < debounceMs` comparison always false — silently
+ * disabling the debounce and re-running the helper on every call. Guard with a
+ * finite, non-negative check (matching getMaxMcpOutputTokens in mcpValidation)
+ * so bad input falls back to the intended default instead of propagating NaN.
+ *
+ * Exported for testing.
+ */
+export function resolveOtelHeadersDebounceMs(): number {
+  const envValue = process.env.AGENC_OTEL_HEADERS_HELPER_DEBOUNCE_MS
+  if (envValue) {
+    const parsed = parseInt(envValue, 10)
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed
+    }
+  }
+  return DEFAULT_OTEL_HEADERS_DEBOUNCE_MS
+}
+
 export function getOtelHeadersFromHelper(): Record<string, string> {
   const otelHeadersHelper = getConfiguredOtelHeadersHelper()
 
@@ -1760,10 +1783,7 @@ export function getOtelHeadersFromHelper(): Record<string, string> {
   }
 
   // Return cached headers if still valid (debounce)
-  const debounceMs = parseInt(
-    process.env.AGENC_OTEL_HEADERS_HELPER_DEBOUNCE_MS ||
-      DEFAULT_OTEL_HEADERS_DEBOUNCE_MS.toString(),
-  )
+  const debounceMs = resolveOtelHeadersDebounceMs()
   if (
     cachedOtelHeaders &&
     Date.now() - cachedOtelHeadersTimestamp < debounceMs

--- a/runtime/src/utils/log.ts
+++ b/runtime/src/utils/log.ts
@@ -16,6 +16,7 @@ import {
   sortLogs,
 } from '../types/logs.js'
 import { CACHE_PATHS } from './cachePaths.js'
+import { logForDebugging } from './debug.js'
 import { stripDisplayTags, stripDisplayTagsAllowEmpty } from './displayTags.js'
 import { isEnvTruthy } from './envUtils.js'
 import { toError } from './errors.js'
@@ -240,39 +241,47 @@ async function loadLogList(path: string): Promise<LogOption[]> {
   const logData = await Promise.all(
     files.map(async (file, i) => {
       const fullPath = join(path, file.name)
-      const content = await readFile(fullPath, { encoding: 'utf8' })
-      const messages = jsonParse(content) as SerializedMessage[]
-      const firstMessage = messages[0]
-      const lastMessage = messages[messages.length - 1]
-      const firstPrompt =
-        firstMessage?.type === 'user' &&
-        typeof firstMessage?.message?.content === 'string'
-          ? firstMessage?.message?.content
-          : 'No prompt'
+      try {
+        const content = await readFile(fullPath, { encoding: 'utf8' })
+        const messages = jsonParse(content) as SerializedMessage[]
+        const firstMessage = messages[0]
+        const lastMessage = messages[messages.length - 1]
+        const firstPrompt =
+          firstMessage?.type === 'user' &&
+          typeof firstMessage?.message?.content === 'string'
+            ? firstMessage?.message?.content
+            : 'No prompt'
 
-      // For new random filenames, we'll get stats from the file itself
-      const fileStats = await stat(fullPath)
+        // For new random filenames, we'll get stats from the file itself
+        const fileStats = await stat(fullPath)
 
-      // Check if it's a sidechain by looking at filename
-      const isSidechain = fullPath.includes('sidechain')
+        // Check if it's a sidechain by looking at filename
+        const isSidechain = fullPath.includes('sidechain')
 
-      // For new files, use the file modified time as date
-      const date = dateToFilename(fileStats.mtime)
+        // For new files, use the file modified time as date
+        const date = dateToFilename(fileStats.mtime)
 
-      return {
-        date,
-        fullPath,
-        messages,
-        value: i, // workaround: overwritten after sorting, right below this
-        created: parseISOString(firstMessage?.timestamp || date),
-        modified: lastMessage?.timestamp
-          ? parseISOString(lastMessage.timestamp)
-          : parseISOString(date),
-        firstPrompt:
-          firstPrompt.split('\n')[0]?.slice(0, 50) +
-            (firstPrompt.length > 50 ? '…' : '') || 'No prompt',
-        messageCount: messages.length,
-        isSidechain,
+        return {
+          date,
+          fullPath,
+          messages,
+          value: i, // workaround: overwritten after sorting, right below this
+          created: parseISOString(firstMessage?.timestamp || date),
+          modified: lastMessage?.timestamp
+            ? parseISOString(lastMessage.timestamp)
+            : parseISOString(date),
+          firstPrompt:
+            firstPrompt.split('\n')[0]?.slice(0, 50) +
+              (firstPrompt.length > 50 ? '…' : '') || 'No prompt',
+          messageCount: messages.length,
+          isSidechain,
+        }
+      } catch (e) {
+        // Skip unreadable or corrupt log files — a partial write from a
+        // crashed fire-and-forget persist shouldn't take down the whole
+        // listing; the remaining valid logs still load.
+        logForDebugging(`loadLogList: skipping ${file.name}: ${String(e)}`)
+        return null
       }
     }),
   )
@@ -281,6 +290,14 @@ async function loadLogList(path: string): Promise<LogOption[]> {
     ..._,
     value: i,
   }))
+}
+
+/**
+ * Test-only wrapper exposing the private {@link loadLogList} so tests can
+ * exercise per-file corruption tolerance against a controlled directory.
+ */
+export function _loadLogListForTesting(path: string): Promise<LogOption[]> {
+  return loadLogList(path)
 }
 
 function parseISOString(s: string): Date {

--- a/runtime/tests/agents/status.test.ts
+++ b/runtime/tests/agents/status.test.ts
@@ -27,6 +27,7 @@ describe("AgentStatusTracker", () => {
     const t = new AgentStatusTracker();
     t.markInterrupted("turn-1", "parent_interrupt");
     const s = t.value;
+    expect(s.status).toBe("interrupted");
     if (s.status === "interrupted") expect(s.reason).toBe("parent_interrupt");
   });
 

--- a/runtime/tests/auth/otel-headers-debounce.test.ts
+++ b/runtime/tests/auth/otel-headers-debounce.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { resolveOtelHeadersDebounceMs } from '../../src/utils/auth.js'
+
+const ENV_KEY = 'AGENC_OTEL_HEADERS_HELPER_DEBOUNCE_MS'
+const DEFAULT_OTEL_HEADERS_DEBOUNCE_MS = 29 * 60 * 1000 // 29 minutes
+const ORIGINAL_VALUE = process.env[ENV_KEY]
+
+afterEach(() => {
+  if (ORIGINAL_VALUE === undefined) {
+    delete process.env[ENV_KEY]
+  } else {
+    process.env[ENV_KEY] = ORIGINAL_VALUE
+  }
+})
+
+describe('resolveOtelHeadersDebounceMs', () => {
+  beforeEach(() => {
+    delete process.env[ENV_KEY]
+  })
+
+  it('returns the default debounce when the env override is unset', () => {
+    expect(resolveOtelHeadersDebounceMs()).toBe(DEFAULT_OTEL_HEADERS_DEBOUNCE_MS)
+  })
+
+  it('falls back to the default for a non-numeric override instead of NaN', () => {
+    process.env[ENV_KEY] = 'abc'
+
+    const result = resolveOtelHeadersDebounceMs()
+
+    // Regression: a non-numeric value must not propagate NaN, which would make
+    // the `Date.now() - timestamp < debounceMs` comparison always false and
+    // silently disable the helper debounce.
+    expect(Number.isNaN(result)).toBe(false)
+    expect(result).toBe(DEFAULT_OTEL_HEADERS_DEBOUNCE_MS)
+  })
+
+  it('honors a valid numeric override', () => {
+    process.env[ENV_KEY] = '60000'
+
+    expect(resolveOtelHeadersDebounceMs()).toBe(60000)
+  })
+
+  it('accepts a zero override', () => {
+    process.env[ENV_KEY] = '0'
+
+    expect(resolveOtelHeadersDebounceMs()).toBe(0)
+  })
+
+  it('falls back to the default for a negative override', () => {
+    process.env[ENV_KEY] = '-5'
+
+    expect(resolveOtelHeadersDebounceMs()).toBe(DEFAULT_OTEL_HEADERS_DEBOUNCE_MS)
+  })
+})

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1713,7 +1713,11 @@ describe("main() smoke", () => {
         setTimeout(() => resolve("timeout"), 4000),
       );
       const result = await Promise.race([oneShotCLI("run a command"), timeout]);
-      expect(result).toBe(0);
+      // The run must TERMINATE (not hang as a timeout) — the original fix. With
+      // PART B the deny-then-gave-up run now also surfaces a NON-ZERO exit so a
+      // tool-blocked giveup is distinguishable from a real answer.
+      expect(result).not.toBe("timeout");
+      expect(result).not.toBe(0);
 
       const denyCall = daemon.requests.find((r) => r.method === "tool.deny");
       expect(denyCall).toBeDefined();
@@ -1728,6 +1732,303 @@ describe("main() smoke", () => {
         daemon.requests.some((r) => r.method === "tool.approve"),
       ).toBe(false);
     } finally {
+      stdoutSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("oneShotCLI exits NON-ZERO with a marker after a tool-blocked giveup", async () => {
+    // PART B regression: in headless --print mode a task that needs even a
+    // read-only tool dead-ends — the daemon forces --autonomous, so the model's
+    // tool call resolves to an unanswerable "ask" that the one-shot client must
+    // auto-DENY (so the run terminates instead of hanging). The model then gives
+    // up and the turn "completes". Before the fix the process exited 0 as if it
+    // produced a real answer, so callers could not tell a giveup from a real
+    // answer. A run that auto-denied a permission request and then completed
+    // must exit NON-ZERO and emit a clear stderr marker.
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-giveup-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-giveup-cwd-"));
+    const prevEnv = { ...process.env };
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.AGENC_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+
+    const agentId = "agent_giveup";
+    const sessionId = "session_giveup";
+    const permissionRequestId = "req-giveup-1";
+    installDaemonCliDepsForTest({
+      agentId,
+      sessionId,
+      cwd: tmpCwd,
+      // Deliver a permission request up front; the terminal "completed" status
+      // is withheld until the client answers — modelling the daemon, which keeps
+      // the turn suspended while a decision is pending. The deny resumes the
+      // turn, the model gives up, and the daemon reports completed.
+      oneShotEvents: [
+        {
+          method: "event.permission_request",
+          params: {
+            sessionId,
+            eventId: "perm_evt",
+            agentId,
+            requestId: permissionRequestId,
+            toolName: "FileRead",
+            permissions: ["tool.use"],
+          },
+        },
+      ],
+      onToolDecision: ({ method, requestId, emit }) => {
+        if (method === "tool.deny" && requestId === permissionRequestId) {
+          emit({
+            method: "event.agent_status",
+            params: {
+              sessionId,
+              eventId: "complete_after_deny",
+              agentId,
+              status: "idle",
+              runStatus: "completed",
+              message: "I could not read the file.",
+            },
+          });
+        }
+      },
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      const timeout = new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 4000),
+      );
+      const result = await Promise.race([
+        oneShotCLI("read the file and summarize it"),
+        timeout,
+      ]);
+      // The tool-blocked giveup must surface as a non-zero exit, NOT 0.
+      expect(result).not.toBe(0);
+      expect(result).not.toBe("timeout");
+      // And a clear stderr marker tells the human how to grant tools.
+      const stderrText = stderrSpy.mock.calls
+        .map(([chunk]) => String(chunk))
+        .join("");
+      expect(stderrText).toContain("tool denied in non-interactive mode");
+      expect(stderrText).toContain("--permission-mode");
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("oneShotCLI still exits 0 when no permission request was denied", async () => {
+    // PART B guard: a normal run that never auto-denied a tool must keep its
+    // success exit code. Only a denied-then-gave-up run signals failure.
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-nodeny-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-nodeny-cwd-"));
+    const prevEnv = { ...process.env };
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.AGENC_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+
+    const agentId = "agent_nodeny";
+    const sessionId = "session_nodeny";
+    const daemon = installDaemonCliDepsForTest({
+      agentId,
+      sessionId,
+      cwd: tmpCwd,
+      // No permission request — just an answer + completed status.
+      oneShotEvents: [
+        {
+          method: "event.message_chunk",
+          params: {
+            sessionId,
+            eventId: "delta_ok",
+            agentId,
+            delta: "here is your answer",
+          },
+        },
+        {
+          method: "event.agent_status",
+          params: {
+            sessionId,
+            eventId: "complete_ok",
+            agentId,
+            status: "idle",
+            runStatus: "completed",
+          },
+        },
+      ],
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      const timeout = new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 4000),
+      );
+      const result = await Promise.race([
+        oneShotCLI("just answer this"),
+        timeout,
+      ]);
+      expect(result).toBe(0);
+      // No deny was ever sent.
+      expect(
+        daemon.requests.some((r) => r.method === "tool.deny"),
+      ).toBe(false);
+    } finally {
+      stdoutSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("oneShotCLI forwards --permission-mode acceptEdits to agent.create", async () => {
+    // PART A regression: the print path previously forwarded only --yolo/bypass
+    // and silently dropped --permission-mode acceptEdits/plan/default. The
+    // validated mode must reach agent.create so the daemon honors it (the
+    // unattended policy preserves acceptEdits/plan rather than forcing
+    // unattended — see applyUnattendedPermissionPolicyToContext).
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-permmode-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-permmode-cwd-"));
+    const prevEnv = { ...process.env };
+    const prevArgv = [...process.argv];
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.AGENC_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+    process.argv = [
+      "/usr/bin/node",
+      "/opt/agenc/bin/agenc.js",
+      "--print",
+      "--permission-mode",
+      "acceptEdits",
+      "do a thing",
+    ];
+
+    const agentId = "agent_permmode";
+    const sessionId = "session_permmode";
+    const daemon = installDaemonCliDepsForTest({
+      agentId,
+      sessionId,
+      cwd: tmpCwd,
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      const timeout = new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 4000),
+      );
+      const result = await Promise.race([
+        oneShotCLI("do a thing"),
+        timeout,
+      ]);
+      expect(result).toBe(0);
+      const createCall = daemon.requests.find(
+        (r) => r.method === "agent.create",
+      );
+      expect(createCall).toBeDefined();
+      expect(
+        (createCall?.params as { permissionMode?: string } | undefined)
+          ?.permissionMode,
+      ).toBe("acceptEdits");
+    } finally {
+      process.argv = prevArgv;
+      stdoutSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("oneShotCLI keeps bypassPermissions precedence over --permission-mode", async () => {
+    // --yolo must still win: when both --yolo and --permission-mode acceptEdits
+    // are present, the forwarded mode is bypassPermissions (no posture
+    // weakening of the existing yolo path).
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-yolo-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-yolo-cwd-"));
+    const prevEnv = { ...process.env };
+    const prevArgv = [...process.argv];
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.AGENC_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+    process.argv = [
+      "/usr/bin/node",
+      "/opt/agenc/bin/agenc.js",
+      "--print",
+      "--yolo",
+      "--permission-mode",
+      "acceptEdits",
+      "do a thing",
+    ];
+
+    const agentId = "agent_yolo";
+    const sessionId = "session_yolo";
+    const daemon = installDaemonCliDepsForTest({
+      agentId,
+      sessionId,
+      cwd: tmpCwd,
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      const timeout = new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 4000),
+      );
+      const result = await Promise.race([
+        oneShotCLI("do a thing"),
+        timeout,
+      ]);
+      expect(result).toBe(0);
+      const createCall = daemon.requests.find(
+        (r) => r.method === "agent.create",
+      );
+      expect(
+        (createCall?.params as { permissionMode?: string } | undefined)
+          ?.permissionMode,
+      ).toBe("bypassPermissions");
+    } finally {
+      process.argv = prevArgv;
       stdoutSpy.mockRestore();
       for (const key of Object.keys(process.env)) {
         if (!(key in prevEnv)) delete process.env[key];

--- a/runtime/tests/bin/startup-selection.test.ts
+++ b/runtime/tests/bin/startup-selection.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { defaultConfig } from "../config/schema.js";
-import { resolveStartupSelection } from "./startup-selection.js";
+import {
+  readStartupCliFlags,
+  resolveStartupSelection,
+} from "./startup-selection.js";
 
 describe("resolveStartupSelection", () => {
   it("uses Bedrock model env when selected by provider", () => {
@@ -49,5 +52,49 @@ describe("resolveStartupSelection", () => {
 
     expect(resolved.provider).toBe("grok");
     expect(resolved.model).toBe("grok-4.3");
+  });
+});
+
+describe("readStartupCliFlags --permission-mode validation", () => {
+  it("accepts a valid --permission-mode value", () => {
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "--permission-mode",
+      "plan",
+    ]);
+    expect(flags.permissionMode).toBe("plan");
+  });
+
+  it("defaults (undefined) when --permission-mode is absent", () => {
+    const flags = readStartupCliFlags(["node", "agenc"]);
+    expect(flags.permissionMode).toBeUndefined();
+  });
+
+  it("throws on an invalid --permission-mode typo (no silent drop)", () => {
+    // Regression: a typo toward a MORE restrictive mode must NOT silently
+    // coerce to undefined (which boots in the LESS restrictive DEFAULT mode).
+    expect(() =>
+      readStartupCliFlags(["node", "agenc", "--permission-mode", "plann"]),
+    ).toThrow(/unknown permission mode 'plann'\. Expected one of:/);
+  });
+
+  it("throws on a wrong-case --permission-mode value", () => {
+    expect(() =>
+      readStartupCliFlags(["node", "agenc", "--permission-mode", "Plan"]),
+    ).toThrow(/unknown permission mode 'Plan'\. Expected one of:/);
+  });
+
+  it("ignores a valid-but-internal mode (unattended) without throwing", () => {
+    // `unattended` IS a valid PermissionMode but is not user-addressable at
+    // the startup CLI surface. The existing contract silently ignores it
+    // (returns undefined) rather than erroring like a real typo.
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "--permission-mode",
+      "unattended",
+    ]);
+    expect(flags.permissionMode).toBeUndefined();
   });
 });

--- a/runtime/tests/utils/hybridContextStrategy.test.ts
+++ b/runtime/tests/utils/hybridContextStrategy.test.ts
@@ -14,13 +14,39 @@ function createMessage(role: string, content: string, createdAt: number = Date.n
   }
 }
 
+// Distinct-id message factory: applyHybridStrategy/splitContext dedup by
+// `uuid ?? message.id`, so the shared `id: 'test'` from createMessage collapses
+// otherwise-distinct messages into one. Tests that need budget/weight behavior
+// to actually bite must use distinct ids.
+function createDistinctMessage(
+  id: string,
+  role: string,
+  content: string,
+  createdAt: number,
+): any {
+  return {
+    uuid: id,
+    message: { role, content, id, type: 'message', created_at: createdAt },
+    sender: role,
+  }
+}
+
+// roughTokenCountEstimation = Math.round(content.length / 4); mirror it so tests
+// assert against the same token contract the strategy uses internally.
+function estTokens(content: string): number {
+  return Math.round(content.length / 4)
+}
+
 describe('hybridContextStrategy', () => {
   describe('splitContext', () => {
     it('splits context into cached and fresh', () => {
+      // All three are clearly recent (1h old) so age is well under the 24h
+      // cache-eligibility threshold and they deterministically land in `fresh`.
+      const recent = Date.now() - 60 * 60 * 1000
       const messages = [
-        createMessage('system', 'System prompt', Date.now() - 86400000),
-        createMessage('user', 'Hello'),
-        createMessage('assistant', 'Hi there'),
+        createMessage('system', 'System prompt', recent),
+        createMessage('user', 'Hello', recent),
+        createMessage('assistant', 'Hi there', recent),
       ]
 
       const split = splitContext(messages, {
@@ -29,33 +55,62 @@ describe('hybridContextStrategy', () => {
         maxTotalTokens: 10000,
       })
 
-      expect(split.cachedTokens).toBeGreaterThanOrEqual(0)
-      expect(split.freshTokens).toBeGreaterThanOrEqual(0)
-      expect(split.totalTokens).toBeGreaterThan(0)
+      // Token accounting is exact: 13/4->3, 5/4->1, 8/4->2 = 6 total, all fresh.
+      const expectedFresh =
+        estTokens('System prompt') + estTokens('Hello') + estTokens('Hi there')
+      expect(expectedFresh).toBe(6)
+      expect(split.cachedTokens).toBe(0)
+      expect(split.freshTokens).toBe(expectedFresh)
+      expect(split.totalTokens).toBe(split.cachedTokens + split.freshTokens)
+      expect(split.totalTokens).toBe(expectedFresh)
+      // No message is dropped within budget, and none leaks into both buckets.
+      expect(split.cached).toHaveLength(0)
+      expect(split.fresh).toHaveLength(3)
     })
 
     it('respects weight configuration', () => {
-      const messages = [
-        createMessage('system', 'Old system', Date.now() - 86400000),
-        createMessage('user', 'Recent message', Date.now()),
-      ]
+      // Old (5-day) messages are eligible for the cache bucket, so the weights
+      // genuinely steer how tokens are distributed between cached and fresh.
+      const oldBase = Date.now() - 86400000 * 5
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        createDistinctMessage('o' + i, 'user', 'x'.repeat(400), oldBase - i * 1000),
+      )
 
-      const split = splitContext(messages, {
-        cacheWeight: 0.5,
-        freshWeight: 0.5,
-        maxTotalTokens: 10000,
+      const cacheHeavy = splitContext(messages, {
+        cacheWeight: 0.8,
+        freshWeight: 0.2,
+        maxTotalTokens: 1000,
+      })
+      const freshHeavy = splitContext(messages, {
+        cacheWeight: 0.2,
+        freshWeight: 0.8,
+        maxTotalTokens: 1000,
       })
 
-      expect(split.cached).toBeDefined()
-      expect(split.fresh).toBeDefined()
+      // Each bucket stays within its weight-derived target.
+      expect(cacheHeavy.cachedTokens).toBeLessThanOrEqual(Math.floor(1000 * 0.8))
+      expect(cacheHeavy.freshTokens).toBeLessThanOrEqual(Math.floor(1000 * 0.2))
+      expect(freshHeavy.cachedTokens).toBeLessThanOrEqual(Math.floor(1000 * 0.2))
+      expect(freshHeavy.freshTokens).toBeLessThanOrEqual(Math.floor(1000 * 0.8))
+
+      // Each 400-char message is 100 tokens, so the split lands on exact counts.
+      expect(cacheHeavy.cachedTokens).toBe(800)
+      expect(cacheHeavy.freshTokens).toBe(200)
+      expect(freshHeavy.cachedTokens).toBe(200)
+      expect(freshHeavy.freshTokens).toBe(800)
+
+      // The weights actually move tokens between buckets (not a fixed split).
+      expect(cacheHeavy.cachedTokens).toBeGreaterThan(freshHeavy.cachedTokens)
+      expect(freshHeavy.freshTokens).toBeGreaterThan(cacheHeavy.freshTokens)
     })
   })
 
   describe('applyHybridStrategy', () => {
     it('applies strategy and returns messages', () => {
+      // Distinct ids so both survive dedup; assert exact content and ordering.
       const messages = [
-        createMessage('user', 'Message 1'),
-        createMessage('assistant', 'Response 1'),
+        createDistinctMessage('a', 'user', 'Message 1', 1000),
+        createDistinctMessage('b', 'assistant', 'Response 1', 2000),
       ]
 
       const result = applyHybridStrategy(messages, {
@@ -64,14 +119,19 @@ describe('hybridContextStrategy', () => {
         maxTotalTokens: 10000,
       })
 
-      expect(result.selectedMessages.length).toBeGreaterThan(0)
-      expect(['cache_heavy', 'fresh_heavy', 'balanced']).toContain(result.strategy)
+      // Both messages fit the budget and are returned in chronological order.
+      expect(result.selectedMessages.map(m => m.message.content)).toEqual([
+        'Message 1',
+        'Response 1',
+      ])
+      // Two recent, equal-weight messages produce a balanced strategy label.
+      expect(result.strategy).toBe('balanced')
+      // Total tokens equal the sum of the individual message estimates.
+      expect(result.totalTokens).toBe(estTokens('Message 1') + estTokens('Response 1'))
     })
 
     it('calculates estimated cost', () => {
-      const messages = [
-        createMessage('user', 'Test message'),
-      ]
+      const messages = [createDistinctMessage('c', 'user', 'Test message', 1000)]
 
       const result = applyHybridStrategy(messages, {
         cacheWeight: 0.5,
@@ -79,7 +139,10 @@ describe('hybridContextStrategy', () => {
         maxTotalTokens: 10000,
       })
 
-      expect(result.estimatedCost).toBeGreaterThanOrEqual(0)
+      // Cost is derived deterministically from the counted tokens, not a stub.
+      expect(result.totalTokens).toBe(estTokens('Test message'))
+      expect(result.estimatedCost).toBeCloseTo(result.totalTokens * 0.000001 * 0.5, 12)
+      expect(result.estimatedCost).toBeGreaterThan(0)
     })
 
     it('preserves distinct messages that do not have stable ids', () => {
@@ -117,43 +180,104 @@ describe('hybridContextStrategy', () => {
 
   describe('optimizeForCost', () => {
     it('returns messages within budget', () => {
-      const messages = [
-        createMessage('user', 'Message 1'),
-        createMessage('assistant', 'Response 1'),
-      ]
+      // 12 distinct 100-token messages, all recent (age < 24h) so they are
+      // not cache-eligible and the fresh budget alone governs the core. budget
+      // 0.4 -> maxTotalTokens 400, cacheWeight 0.7 / freshWeight 0.3. The last 5
+      // messages are the always-preserved conversation tail; the remaining 7 are
+      // "core" and must be trimmed to fit the budget-derived fresh target
+      // (floor(400 * 0.3) = 120), which admits exactly one more 100-token message.
+      const base = Date.now() + 50_000
+      const messages = Array.from({ length: 12 }, (_, i) =>
+        createDistinctMessage('c' + i, 'user', 'x'.repeat(400), base + i * 1000),
+      )
 
-      const result = optimizeForCost(messages, 0.001)
+      // optimizeForCost returns the selected Message[] directly.
+      const selected = optimizeForCost(messages, 0.4)
 
-      expect(result.length).toBeGreaterThanOrEqual(0)
+      const tailIds = ['c7', 'c8', 'c9', 'c10', 'c11']
+      const selectedIds = selected.map(m => m.message.id)
+
+      // Over-budget core content is excluded: 12 in, 6 out (not all 12).
+      expect(selected.length).toBe(6)
+      expect(selected.length).toBeLessThan(messages.length)
+
+      // The conversation tail (last 5) is always retained.
+      for (const id of tailIds) {
+        expect(selectedIds).toContain(id)
+      }
+
+      // Only one non-tail message survives the budget; the rest are dropped.
+      const keptCore = selectedIds.filter(id => !tailIds.includes(id))
+      expect(keptCore).toHaveLength(1)
+
+      // The non-tail (budgeted) selection fits the budget-derived fresh target.
+      const coreTokens = selected
+        .filter(m => !tailIds.includes(m.message.id))
+        .reduce((sum, m) => sum + estTokens(m.message.content), 0)
+      expect(coreTokens).toBeLessThanOrEqual(Math.floor(Math.floor(0.4 * 1000) * 0.3))
+
+      // Result is chronologically ordered.
+      const createdAts = selected.map(m => m.message.created_at)
+      expect(createdAts).toEqual([...createdAts].sort((a, b) => a - b))
+    })
+
+    it('preserves all messages when the budget is generous', () => {
+      // Same 12 messages, but a large budget admits the full conversation.
+      const base = Date.now() + 50_000
+      const messages = Array.from({ length: 12 }, (_, i) =>
+        createDistinctMessage('c' + i, 'user', 'x'.repeat(400), base + i * 1000),
+      )
+
+      const selected = optimizeForCost(messages, 100)
+
+      expect(selected).toHaveLength(messages.length)
+      expect(selected.map(m => m.message.id).sort()).toEqual(
+        messages.map(m => m.message.id).sort(),
+      )
     })
   })
 
   describe('optimizeForAccuracy', () => {
     it('optimizes for accuracy with token limit', () => {
       const messages = [
-        createMessage('user', 'Message 1'),
-        createMessage('assistant', 'Response 1'),
+        createDistinctMessage('a', 'user', 'Message 1', 1000),
+        createDistinctMessage('b', 'assistant', 'Response 1', 2000),
       ]
 
       const result = optimizeForAccuracy(messages, 5000)
 
-      expect(result.length).toBeGreaterThan(0)
+      // With ample headroom both messages are kept, in chronological order.
+      expect(result.map(m => m.message.content)).toEqual(['Message 1', 'Response 1'])
     })
   })
 
   describe('getHybridStats', () => {
     it('returns statistics', () => {
+      // Clearly recent (1h old) -> not cache-eligible -> all tokens land in fresh.
+      const recent = Date.now() - 60 * 60 * 1000
       const messages = [
-        createMessage('system', 'System', Date.now() - 86400000),
-        createMessage('user', 'Hello'),
+        createMessage('system', 'System', recent),
+        createMessage('user', 'Hello', recent),
       ]
 
-      const split = splitContext(messages, { cacheWeight: 0.5, freshWeight: 0.5, maxTotalTokens: 10000 })
+      const split = splitContext(messages, {
+        cacheWeight: 0.5,
+        freshWeight: 0.5,
+        maxTotalTokens: 10000,
+      })
       const stats = getHybridStats(split)
 
-      expect(stats.cacheRatio).toBeGreaterThanOrEqual(0)
-      expect(stats.freshRatio).toBeGreaterThanOrEqual(0)
-      expect(stats.totalTokens).toBeGreaterThan(0)
+      const expectedTotal = estTokens('System') + estTokens('Hello')
+      expect(stats.totalTokens).toBe(expectedTotal)
+      expect(stats.totalTokens).toBe(3)
+      // Ratios are percentages of the split and sum to 100 when there are tokens.
+      expect(stats.cacheRatio + stats.freshRatio).toBe(100)
+      // Nothing is cache-eligible here, so the split is entirely fresh.
+      expect(stats.cacheRatio).toBe(0)
+      expect(stats.freshRatio).toBe(100)
+      // messageCount reflects the cached + fresh message counts.
+      expect(stats.messageCount).toBe(split.cached.length + split.fresh.length)
+      expect(stats.messageCount).toBe(2)
     })
   })
 

--- a/runtime/tests/utils/log.test.ts
+++ b/runtime/tests/utils/log.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+
+import { _loadLogListForTesting } from '../../src/utils/log.ts'
+
+const tempDirs: string[] = []
+
+async function makeLogDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'agenc-log-list-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function validLog(prompt: string): string {
+  return JSON.stringify([
+    {
+      type: 'user',
+      timestamp: '2026-04-02T00:00:00.000Z',
+      message: { role: 'user', content: prompt },
+    },
+  ])
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+test('loadLogList skips a corrupt log file and still returns the valid ones', async () => {
+  const dir = await makeLogDir()
+  await writeFile(join(dir, 'good-a.json'), validLog('first valid prompt'))
+  // A partial/corrupt write — e.g. from a crashed fire-and-forget persist.
+  await writeFile(join(dir, 'corrupt.json'), '{ this is not valid json')
+  await writeFile(join(dir, 'good-b.json'), validLog('second valid prompt'))
+
+  const logs = await _loadLogListForTesting(dir)
+
+  // Must not throw, and the two valid logs must still load even though one
+  // file in the same directory is unparseable.
+  expect(logs).toHaveLength(2)
+  const prompts = logs.map(l => l.firstPrompt).sort()
+  expect(prompts).toEqual(['first valid prompt', 'second valid prompt'])
+})
+
+test('loadLogList returns [] for a missing directory without throwing', async () => {
+  const dir = await makeLogDir()
+  const missing = join(dir, 'does-not-exist')
+
+  await expect(_loadLogListForTesting(missing)).resolves.toEqual([])
+})

--- a/runtime/tests/utils/textCursor.firstNonBlank.test.ts
+++ b/runtime/tests/utils/textCursor.firstNonBlank.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+
+import { TextCursor } from "../../src/utils/TextCursor.js";
+
+/**
+ * Regression test for firstNonBlankInLine().
+ *
+ * The regex `/^\s*\S/` is anchored, so `match.index` is always 0 on a match.
+ * The previous implementation derived the column from `match.index` (a falsy 0),
+ * so it always returned column 0 — never the actual first-non-blank column.
+ *
+ * Contract: firstNonBlankInLine() returns the column of the first
+ * non-whitespace character (i.e. the count of leading whitespace), or column 0
+ * for an empty / all-whitespace line (matching firstNonBlankInLogicalLine).
+ */
+describe("TextCursor.firstNonBlankInLine", () => {
+  // Wide width so single-line inputs do not soft-wrap; column == leading ws.
+  const COLUMNS = 200;
+
+  function firstNonBlankColumn(line: string): number {
+    // Start at end of the line so the cursor is on the intended wrapped line.
+    const cursor = TextCursor.fromText(line, COLUMNS, line.length);
+    return cursor.firstNonBlankInLine().getPosition().column;
+  }
+
+  test("returns leading-whitespace length for an indented line", () => {
+    expect(firstNonBlankColumn("    foo")).toBe(4);
+  });
+
+  test("counts tab characters as leading whitespace (display columns)", () => {
+    // MeasuredText expands tabs to TAB_SIZE (8) display columns, so the first
+    // non-blank char after two tabs sits at display column 16, not raw index 2.
+    expect(firstNonBlankColumn("\t\tbar")).toBe(16);
+  });
+
+  test("returns 0 for a line with no indentation", () => {
+    expect(firstNonBlankColumn("noindent")).toBe(0);
+  });
+
+  test("returns 0 for an empty line", () => {
+    expect(firstNonBlankColumn("")).toBe(0);
+  });
+
+  test("returns 0 for an all-whitespace line", () => {
+    expect(firstNonBlankColumn("     ")).toBe(0);
+  });
+});


### PR DESCRIPTION
Autonomous discover→verify→fix iteration 3. All gated (typecheck + 13083 tests + build); each fix independently reviewed (the two permission-sensitive fixes via 3-skeptic panels), each with a revert-sensitive test.

- **HIGH** honor --permission-mode in headless print + signal tool-blocked giveups with non-zero exit (was exit 0, indistinguishable from a real answer)
- **HIGH** validate --permission-mode; reject typos that silently yielded a less-restrictive session
- **HIGH** make 'records interrupted reason' test guard the status (was zero-assertion)
- **MED** loadLogList: skip a corrupt log file instead of failing the whole list
- **MED** strengthen tautological hybridContextStrategy assertions to verify real contracts
- **LOW** firstNonBlankInLine: compute the column instead of always 0
- **LOW** OTEL debounce: fall back to default on non-numeric env override (was NaN)