### PR TITLE
auto-fix iter 4: 6 verified fixes (resume validation, daemon cold-start, render hang, classifier coverage)

### DIFF
--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -13,6 +13,7 @@ import {
   removeAgenCDaemonPid,
   resolveAgenCDaemonCookiePath,
   resolveAgenCDaemonPidPath,
+  resolveAgenCDaemonReadyTimeoutMs,
   resolveAgenCDaemonSocketPath,
   runAgenCDaemonCli,
   resolveAgenCDaemonHome,
@@ -36,7 +37,17 @@ import { canConnectToUnixSocket } from "./transport/unix-socket.js";
 
 export type AgenCDaemonAutostartStatus = "already-running" | "started";
 
-export const AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS = 15_000;
+/**
+ * Default cold-start readiness budget for the agent autostart path. Derived
+ * from the shared {@link resolveAgenCDaemonReadyTimeoutMs} default (45s, raised
+ * from 15s — see that helper for the cold-hydration rationale) so the autostart
+ * and bare-control (`start`/`restart`/`reload`) budgets stay in sync from one
+ * source. The actual wait honors the `AGENC_DAEMON_READY_TIMEOUT_MS` env
+ * override via {@link resolveAgenCDaemonReadyTimeoutMs}; this constant is the
+ * resolved fallback used when no per-call override is supplied.
+ */
+export const AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS =
+  resolveAgenCDaemonReadyTimeoutMs({});
 
 export interface AgenCDaemonConnectionTarget {
   readonly pid: number;
@@ -393,7 +404,8 @@ async function waitForAgenCDaemonReady(
   host: AgenCDaemonCliHost,
   options: AgenCDaemonAutostartOptions,
 ): Promise<boolean> {
-  const timeoutMs = options.waitTimeoutMs ?? AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS;
+  const timeoutMs =
+    options.waitTimeoutMs ?? resolveAgenCDaemonReadyTimeoutMs(host.env);
   const pollMs = options.pollMs ?? 25;
   const startedAt = Date.now();
   const isReady =

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -181,15 +181,49 @@ const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV =
 const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 2_000;
 const DEFAULT_DAEMON_STOP_TIMEOUT_MS = 10_000;
 /**
- * Bound for how long the bare daemon controls (`start`/`restart`/`reload`)
- * wait for the detached daemon to bind and accept on its control socket before
- * giving up. Kept in sync with the agent autostart path
- * (`AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS` in `daemon-autostart.ts`); imported
- * as a local constant rather than from that module to avoid an import cycle
- * (`daemon-autostart` already depends on `daemon-cli`).
+ * Env override (ms) for how long the daemon readiness waits block, plus the
+ * default applied when unset/invalid. This single name covers BOTH the bare
+ * daemon controls (`start`/`restart`/`reload`, here) and the agent autostart
+ * path (`waitForAgenCDaemonReady` in `daemon-autostart.ts`), which imports
+ * {@link resolveAgenCDaemonReadyTimeoutMs} so both budgets stay in sync from
+ * one resolved value.
  */
-const DEFAULT_DAEMON_READY_TIMEOUT_MS = 15_000;
+export const AGENC_DAEMON_READY_TIMEOUT_MS_ENV = "AGENC_DAEMON_READY_TIMEOUT_MS";
+/**
+ * Bound for how long the daemon readiness waits block for the detached daemon
+ * to bind and accept on its control socket before giving up.
+ *
+ * Raised from 15s to 45s: a cold start has to pay the full hydration cost
+ * (state recovery + MCP server start + `socketServer.listen()`) before it can
+ * accept, which empirically lands at ~15-16.5s — leaving the old 15s budget with
+ * near-zero margin and producing false "did not become ready before timeout"
+ * failures on healthy daemons. 45s gives ~3x headroom; CI can tune it back down
+ * via {@link AGENC_DAEMON_READY_TIMEOUT_MS_ENV}. A longer budget only makes a
+ * genuinely-broken daemon take longer to surface, which is the safer tradeoff
+ * against false negatives on cold start.
+ */
+export const DEFAULT_DAEMON_READY_TIMEOUT_MS = 45_000;
 const DEFAULT_DAEMON_READY_POLL_MS = 25;
+
+/**
+ * Resolve the daemon readiness timeout (ms) from the env override, falling back
+ * to {@link DEFAULT_DAEMON_READY_TIMEOUT_MS} when unset or invalid. Matches the
+ * codebase env-int convention (e.g. `getMaxMcpOutputTokens`): only a finite,
+ * strictly-positive parse wins; everything else (non-numeric, NaN, <= 0) falls
+ * back to the default. Exported so the autostart path resolves the same value.
+ */
+export function resolveAgenCDaemonReadyTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const envValue = env[AGENC_DAEMON_READY_TIMEOUT_MS_ENV];
+  if (envValue !== undefined && envValue.trim().length > 0) {
+    const parsed = Number(envValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_DAEMON_READY_TIMEOUT_MS;
+}
 
 const DEFAULT_DAEMON_WEBSOCKET_URL = new URL(
   AGENC_PORTAL_DEFAULT_LOCAL_DAEMON_ENDPOINT,
@@ -665,7 +699,8 @@ async function defaultWaitForAgenCDaemonReady(
     return isAgenCDaemonControlSocketReady(host, pid);
   }
   const startedAt = Date.now();
-  while (Date.now() - startedAt < DEFAULT_DAEMON_READY_TIMEOUT_MS) {
+  const timeoutMs = resolveAgenCDaemonReadyTimeoutMs(host.env);
+  while (Date.now() - startedAt < timeoutMs) {
     if (await isAgenCDaemonControlSocketReady(host, pid)) return true;
     if (!host.isPidRunning(pid)) return false;
     await host.sleep(DEFAULT_DAEMON_READY_POLL_MS);

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -240,7 +240,7 @@ export function __setDaemonCliDepsForTest(
 
 export {
   PROVIDER_MODEL_CATALOG,
-  resolveModelOrExit,
+  resolveModelOrThrow,
   sessionConfigurationFromAgenCConfig,
 } from "./bootstrap.js";
 

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -98,7 +98,7 @@ import {
 import { resolveProjectTrustStateSync } from "../permissions/trust/project-trust.js";
 export {
   PROVIDER_MODEL_CATALOG,
-  resolveModelOrExit,
+  resolveModelOrThrow,
 } from "./startup-selection.js";
 export type {
   StartupCliFlags,

--- a/runtime/src/bin/route.ts
+++ b/runtime/src/bin/route.ts
@@ -107,6 +107,21 @@ function shouldStripValueFlag(arg: string): boolean {
   );
 }
 
+const RESUME_FLAGS = Object.freeze(["--resume", "-r"] as const);
+
+/**
+ * True when `arg` is an explicit resume-flag TOKEN: a bare `--resume`/`-r`,
+ * or the `--resume=`/`-r=` equals form (regardless of whether a value
+ * follows it). Used to distinguish "user asked to resume but omitted the id"
+ * from a plain prompt that merely contains the word "resume" — only a real
+ * leading flag token matches, never positional prompt text.
+ */
+function isResumeFlagToken(arg: string): boolean {
+  return RESUME_FLAGS.some(
+    (flag) => arg === flag || arg.startsWith(`${flag}=`),
+  );
+}
+
 /**
  * True when `arg` is a startup flag that consumes a following value token
  * (e.g. `--model gpt`, `-r <id>`). Exported so the short-circuit detector
@@ -218,8 +233,24 @@ export function classifyCLI(opts: ClassifyCLIOptions): RouteCLIPlan {
     userArgv.includes("--continue") || userArgv.includes("-c");
   const resumeId =
     extractFlagValue(userArgv, "--resume") ?? extractFlagValue(userArgv, "-r");
+  const hasResumeFlag = userArgv.some(isResumeFlagToken);
   const prompt = stripRoutingFlags(userArgv).join(" ").trim();
   const startupImages = extractFlagValues(userArgv, "--image");
+
+  // 0. A resume flag token was supplied but with no session id (bare
+  //    `--resume`/`-r`, or the empty `--resume=`/`-r=` form). Resuming
+  //    requires an id, so error instead of silently stripping the flag and
+  //    booting a fresh TUI (which gives the user zero feedback). This must
+  //    fire for BOTH TTY and non-TTY paths, before any boot/one-shot
+  //    fall-through. Note: this only matches a real leading flag token —
+  //    a plain prompt that merely contains the word "resume" is unaffected.
+  if (hasResumeFlag && (resumeId === null || resumeId.length === 0)) {
+    return {
+      kind: "errorAndExit",
+      message: `agenc --resume requires a session id (usage: agenc --resume <session-id>)`,
+      exitCode: 2,
+    };
+  }
 
   // 1. `--resume <id>` / `-r <id>` boots through the TUI resume path. Errors
   //    inside `resumeTUI` (missing session, corrupt rollout, etc.) are

--- a/runtime/src/bin/startup-selection.ts
+++ b/runtime/src/bin/startup-selection.ts
@@ -8,7 +8,6 @@ import {
   USER_ADDRESSABLE_PERMISSION_MODES,
   type PermissionMode,
 } from "../permissions/types.js";
-import { AmbiguousModelError, UnknownModelError } from "../config/schema.js";
 import { BUILT_IN_PROVIDER_DEFAULT_MODELS, BUILT_IN_PROVIDER_MODEL_CATALOG, buildProviderModelCatalog, resolveProviderSelection, resolveProviderSettings } from "../config/resolve-provider.js";
 import { configuredModelForProvider, defaultModelForProvider, resolveDisambiguatedModelSelection } from "../config/resolve-model.js";
 import { resolveProfile } from "../config/profiles.js";
@@ -158,34 +157,31 @@ function startupModelForProvider(params: {
   );
 }
 
-export function resolveModelOrExit(
+/**
+ * Resolve a model slug to a {provider, model} pair, THROWING on an ambiguous
+ * or unknown model.
+ *
+ * This is shared selection code: `resolveStartupSelection` is reached not only
+ * from the `bin/agenc.ts` CLI entrypoints but also from the daemon/TUI context
+ * (`app-server-client` `createAgenCDaemonOnlyTuiContext`). An earlier version
+ * called `process.exit(1)` here, which hard-killed the process for any caller —
+ * even ones (daemon/TUI) that want to intercept the failure for cleanup or
+ * remapping. Mirroring `resolvePermissionModeOrThrow`, this now throws a
+ * catchable error and lets each caller's existing `try/catch` decide. The CLI
+ * entrypoints already funnel thrown errors through `main()`'s top-level catch,
+ * which emits a clean `agenc: <message>` and exits 1 — so the user-visible CLI
+ * behavior for an ambiguous/unknown `--model` is unchanged (clean message, no
+ * stack trace), while non-CLI callers regain control.
+ *
+ * The original `AmbiguousModelError` / `UnknownModelError` are re-thrown
+ * unchanged so callers can `instanceof`-discriminate and their messages stay
+ * stable.
+ */
+export function resolveModelOrThrow(
   slug: string,
   catalog: Readonly<Record<string, readonly string[]>> = PROVIDER_MODEL_CATALOG,
-  exit: (code: number) => never = ((code: number) => {
-    process.exit(code);
-  }) as (code: number) => never,
-  errSink: (line: string) => void = (line) => process.stderr.write(line),
 ): { provider: string; model: string } {
-  try {
-    return resolveDisambiguatedModelSelection({ slug, catalog });
-  } catch (err) {
-    if (err instanceof AmbiguousModelError) {
-      const candidates = err.candidates
-        .map((c) => `${c.provider}:${c.model}`)
-        .join(", ");
-      errSink(
-        `agenc: ambiguous model '${slug}' — matches ${err.candidates.length} providers. ` +
-          `Use 'provider:model' form. Candidates: ${candidates}\n`,
-      );
-      exit(1);
-    }
-    if (err instanceof UnknownModelError) {
-      errSink(`agenc: ${err.message}\n`);
-      exit(1);
-    }
-    throw err;
-  }
-  throw new Error("resolveModelOrExit: unreachable");
+  return resolveDisambiguatedModelSelection({ slug, catalog });
 }
 
 export function resolveStartupSelection(params: {
@@ -209,7 +205,7 @@ export function resolveStartupSelection(params: {
   const providerCatalog = buildProviderModelCatalog(configWithProfile);
 
   if (typeof modelOverride === "string" && modelOverride.includes(":")) {
-    const resolved = resolveModelOrExit(modelOverride, providerCatalog);
+    const resolved = resolveModelOrThrow(modelOverride, providerCatalog);
     const providerSettings = resolveProviderSettings(
       resolved.provider,
       configWithProfile,
@@ -276,7 +272,7 @@ export function resolveStartupSelection(params: {
   }
 
   if (modelOverride ?? configWithProfile.model) {
-    const resolved = resolveModelOrExit(
+    const resolved = resolveModelOrThrow(
       modelOverride ?? configWithProfile.model ?? DEFAULT_MODEL,
       providerCatalog,
     );

--- a/runtime/src/utils/staticRender.tsx
+++ b/runtime/src/utils/staticRender.tsx
@@ -97,56 +97,59 @@ function normalizeViewport(
   return viewport ?? {};
 }
 
-export function renderToAnsiString(node: React.ReactNode, viewport?: StaticRenderViewport): Promise<string> {
-  return new Promise(async resolve => {
-    let output = '';
-    const previousChalkLevel = chalk.level;
+export async function renderToAnsiString(node: React.ReactNode, viewport?: StaticRenderViewport): Promise<string> {
+  let output = '';
+  const previousChalkLevel = chalk.level;
 
-    try {
-      // Capture all writes. Set .columns so Ink (ink.tsx:~165) picks up a
-      // chosen width instead of PassThrough's undefined → 80 fallback —
-      // useful for rendering at terminal width for file dumps that should
-      // match what the user sees on screen.
-      const stream = new PassThrough();
-      const { columns, rows, color } = normalizeViewport(viewport);
-      if (color === true && chalk.level < 3) {
-        chalk.level = 3;
-      }
-      if (columns !== undefined) {
-        (stream as unknown as {
-          columns: number;
-        }).columns = columns;
-      }
-      if (rows !== undefined) {
-        (stream as unknown as {
-          rows: number;
-        }).rows = rows;
-      }
-      stream.on('data', chunk => {
-        output += chunk.toString();
-      });
-
-      // Render the component wrapped in RenderOnceAndExit
-      // Non-TTY stdout (PassThrough) gives full-frame output instead of diffs
-      const instance = await render(<RenderOnceAndExit>{node}</RenderOnceAndExit>, {
-        stdout: stream as unknown as NodeJS.WriteStream,
-        patchConsole: false
-      });
-
-      // Wait for the component to exit naturally, with a timeout guard so
-      // tests never hang indefinitely if a render error prevents exit().
-      await Promise.race([
-        instance.waitUntilExit(),
-        new Promise<void>(resolve => setTimeout(resolve, 3000)),
-      ]);
-
-      // Extract only the first frame's content to avoid duplication
-      // (Ink outputs multiple frames in non-TTY mode)
-      await resolve(extractFirstFrame(output));
-    } finally {
-      chalk.level = previousChalkLevel;
+  try {
+    // Capture all writes. Set .columns so Ink (ink.tsx:~165) picks up a
+    // chosen width instead of PassThrough's undefined → 80 fallback —
+    // useful for rendering at terminal width for file dumps that should
+    // match what the user sees on screen.
+    const stream = new PassThrough();
+    const { columns, rows, color } = normalizeViewport(viewport);
+    if (color === true && chalk.level < 3) {
+      chalk.level = 3;
     }
-  });
+    if (columns !== undefined) {
+      (stream as unknown as {
+        columns: number;
+      }).columns = columns;
+    }
+    if (rows !== undefined) {
+      (stream as unknown as {
+        rows: number;
+      }).rows = rows;
+    }
+    stream.on('data', chunk => {
+      output += chunk.toString();
+    });
+
+    // Render the component wrapped in RenderOnceAndExit
+    // Non-TTY stdout (PassThrough) gives full-frame output instead of diffs
+    const instance = await render(<RenderOnceAndExit>{node}</RenderOnceAndExit>, {
+      stdout: stream as unknown as NodeJS.WriteStream,
+      patchConsole: false
+    });
+
+    // Wait for the component to exit naturally, with a timeout guard so
+    // tests never hang indefinitely if a render error prevents exit().
+    await Promise.race([
+      instance.waitUntilExit(),
+      new Promise<void>(resolve => setTimeout(resolve, 3000)),
+    ]);
+
+    // Extract only the first frame's content to avoid duplication
+    // (Ink outputs multiple frames in non-TTY mode)
+    return extractFirstFrame(output);
+  } finally {
+    // Always restore chalk's level — even when render()/waitUntilExit()
+    // reject. The rejection propagates to the caller (whose await throws);
+    // it must never leave the returned promise unsettled (see the prior
+    // `new Promise(async resolve => …)` executor, which had no catch and so
+    // hung forever on an infrastructure-level render rejection).
+    chalk.level = previousChalkLevel;
+  }
 }
 
 /**

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -12,6 +12,7 @@ import {
   shouldAutostartAgenCDaemon,
 } from "./daemon-autostart.js";
 import {
+  DEFAULT_DAEMON_READY_TIMEOUT_MS,
   readAgenCDaemonPid,
   resolveAgenCDaemonCookiePath,
   resolveAgenCDaemonPidPath,
@@ -125,8 +126,13 @@ async function closeServer(server: Server | null): Promise<void> {
 
 describe("AgenC daemon autostart", () => {
   it("keeps the default readiness window long enough for cold starts", () => {
+    // Raised from 15s to give cold hydration comfortable margin, and kept in
+    // sync with the shared bare-control default so both paths move together.
     expect(AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(
-      10_000,
+      30_000,
+    );
+    expect(AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS).toBe(
+      DEFAULT_DAEMON_READY_TIMEOUT_MS,
     );
   });
 

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -17,11 +17,14 @@ import type { AgenCShutdownSignal } from "../lifecycle/signal-handlers.js";
 import { openStateDatabases } from "../state/sqlite-driver.js";
 import { createAgenCJsonLineDaemonRequestClient } from "./agent-cli.js";
 import {
+  AGENC_DAEMON_READY_TIMEOUT_MS_ENV,
   AGENC_DAEMON_WEBSOCKET_DEFAULT_HOST,
   AGENC_DAEMON_WEBSOCKET_DEFAULT_PATH,
   AGENC_DAEMON_WEBSOCKET_DEFAULT_PORT,
   AGENC_DAEMON_WEBSOCKET_PORT_ENV,
+  DEFAULT_DAEMON_READY_TIMEOUT_MS,
   defaultAgenCDaemonPidPath,
+  resolveAgenCDaemonReadyTimeoutMs,
   ensureAgenCDaemonCookie,
   formatAgenCDaemonCliHelpText,
   createAgenCDaemonRealtimeHeaderResolver,
@@ -390,6 +393,43 @@ async function resolveRealtimeHeadersForTest(
 ): Promise<Readonly<Record<string, string>>> {
   return typeof provider === "function" ? provider(sessionConfig) : provider;
 }
+
+describe("AgenC daemon readiness timeout resolution", () => {
+  it("raises the default cold-start budget to at least 30s", () => {
+    // Regression guard: the old 15s default left near-zero margin for cold
+    // hydration (state recovery + MCP start + socketServer.listen), which
+    // produced false "did not become ready before timeout" failures on healthy
+    // daemons. The default must keep comfortable headroom.
+    expect(DEFAULT_DAEMON_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+  });
+
+  it("honors AGENC_DAEMON_READY_TIMEOUT_MS when set to a valid number", () => {
+    // Revert-sensitive: the pre-fix code hardcoded 15s with no env override, so
+    // the resolver would have ignored this env var entirely.
+    expect(
+      resolveAgenCDaemonReadyTimeoutMs({
+        [AGENC_DAEMON_READY_TIMEOUT_MS_ENV]: "60000",
+      }),
+    ).toBe(60_000);
+  });
+
+  it("falls back to the default when the env override is unset", () => {
+    expect(resolveAgenCDaemonReadyTimeoutMs({})).toBe(
+      DEFAULT_DAEMON_READY_TIMEOUT_MS,
+    );
+  });
+
+  it.each(["", "   ", "abc", "0", "-5", "NaN", "1e", "Infinity"])(
+    "falls back to the default for invalid env override %j",
+    (raw) => {
+      expect(
+        resolveAgenCDaemonReadyTimeoutMs({
+          [AGENC_DAEMON_READY_TIMEOUT_MS_ENV]: raw,
+        }),
+      ).toBe(DEFAULT_DAEMON_READY_TIMEOUT_MS);
+    },
+  );
+});
 
 describe("AgenC daemon CLI", () => {
   it("resolves the required pid file path", () => {

--- a/runtime/tests/bin/agenc.cli-branch.test.ts
+++ b/runtime/tests/bin/agenc.cli-branch.test.ts
@@ -300,6 +300,113 @@ describe("classifyCLI", () => {
     ).toEqual({ kind: "continueTUI", args: {} });
   });
 
+  it("errors (exit 2) when --resume is given with no session id in a TTY", () => {
+    // Regression: a bare `--resume` flag used to fall through the resume
+    // branch (resumeId === null) and silently boot a brand-new TUI with no
+    // initialPrompt — the user asked to resume and got a fresh session with
+    // zero feedback. It must error explicitly instead.
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--resume"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "errorAndExit",
+      message:
+        "agenc --resume requires a session id (usage: agenc --resume <session-id>)",
+      exitCode: 2,
+    });
+  });
+
+  it("errors (exit 2) when -r is given with no session id in a TTY", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "-r"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "errorAndExit",
+      message:
+        "agenc --resume requires a session id (usage: agenc --resume <session-id>)",
+      exitCode: 2,
+    });
+  });
+
+  it("errors (exit 2) for the empty --resume= form in a TTY", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--resume="],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "errorAndExit",
+      message:
+        "agenc --resume requires a session id (usage: agenc --resume <session-id>)",
+      exitCode: 2,
+    });
+  });
+
+  it("errors (exit 2) when --resume has no id in a non-TTY context too", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--resume"],
+        isTTY: false,
+        isStdoutTTY: false,
+      }),
+    ).toEqual({
+      kind: "errorAndExit",
+      message:
+        "agenc --resume requires a session id (usage: agenc --resume <session-id>)",
+      exitCode: 2,
+    });
+  });
+
+  it("errors when --resume is followed only by another flag (no value)", () => {
+    // `--resume` consumes nothing because the next token is a flag, so the
+    // id is missing — still an error, not a silent fresh boot.
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--resume", "--no-tui"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "errorAndExit",
+      message:
+        "agenc --resume requires a session id (usage: agenc --resume <session-id>)",
+      exitCode: 2,
+    });
+  });
+
+  it("still resumes normally when --resume carries a session id", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--resume", "sess-9"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({ kind: "resumeTUI", args: { resumeId: "sess-9" } });
+  });
+
+  it("treats a plain prompt containing the word 'resume' as prompt text", () => {
+    // Only a real leading `--resume`/`-r` flag token triggers the missing-id
+    // error — a positional prompt that merely mentions resume must boot the
+    // TUI with that text intact.
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "please", "resume", "my", "work"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "bootTUI",
+      args: { initialPrompt: "please resume my work" },
+    });
+  });
+
   it("keeps non-interactive routes out of the TUI preflight path", () => {
     expect(
       classifyCLI({

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -4,7 +4,7 @@
  *   - `system.agent.delegate` built-in tool
  *
  * T10 Group I integration seams:
- *   - I-60 ambiguous-model hard-fail (`resolveModelOrExit`)
+ *   - I-60 ambiguous-model hard-fail (`resolveModelOrThrow`)
  *   - I-47 between-turn config reload (`maybeReloadConfigBetweenTurns`)
  *   - AgenCConfig → SessionConfiguration bridge
  *   - Memory auto-save sidecar + per-turn attachments
@@ -38,7 +38,7 @@ import {
   oneShotCLI,
   prepareTurnRuntimeInputs,
   resolveCliCwdForStartup,
-  resolveModelOrExit,
+  resolveModelOrThrow,
   resumeTUIEntry,
   runSingleTurn,
   sessionConfigurationFromAgenCConfig,
@@ -47,7 +47,11 @@ import {
   type ConfigReloadLatch,
 } from "./agenc.js";
 import { ConfigStore } from "../config/store.js";
-import { defaultConfig } from "../config/schema.js";
+import {
+  AmbiguousModelError,
+  defaultConfig,
+  UnknownModelError,
+} from "../config/schema.js";
 import * as configUtils from "../config/init.js";
 import {
   assembleSystemPrompt,
@@ -551,15 +555,15 @@ describe("PROVIDER_MODEL_CATALOG", () => {
   });
 });
 
-describe("I-60: resolveModelOrExit hard-fail", () => {
+describe("I-60: resolveModelOrThrow hard-fail", () => {
   it("returns {provider, model} for an unambiguous bare slug", () => {
-    const result = resolveModelOrExit("grok-4.3", PROVIDER_MODEL_CATALOG);
+    const result = resolveModelOrThrow("grok-4.3", PROVIDER_MODEL_CATALOG);
     expect(result.provider).toBe("grok");
     expect(result.model).toBe("grok-4.3");
   });
 
   it("accepts explicit provider:model form", () => {
-    const result = resolveModelOrExit(
+    const result = resolveModelOrThrow(
       "grok:grok-4.20-0309-reasoning",
       PROVIDER_MODEL_CATALOG,
     );
@@ -567,43 +571,52 @@ describe("I-60: resolveModelOrExit hard-fail", () => {
     expect(result.model).toBe("grok-4.20-0309-reasoning");
   });
 
-  it("hard-fails with exit(1) + clear message on ambiguous bare slug", () => {
-    const exit = vi.fn() as unknown as (code: number) => never;
-    const err: string[] = [];
-    const errSink = (line: string) => {
-      err.push(line);
-    };
+  it("THROWS a catchable AmbiguousModelError on an ambiguous bare slug (no process.exit)", () => {
     const catalog = {
       grok: ["shared-model", "grok-4"] as readonly string[],
       openai: ["shared-model", "gpt-4"] as readonly string[],
     };
-    // `resolveModelOrExit` calls exit(1) on ambiguity; the mock doesn't
-    // throw, so control falls through — guard with a try/catch.
+    // Spy on process.exit so a regression to the old exit-based code is caught:
+    // shared selection code must never hard-kill the process — it must throw so
+    // daemon/TUI and CLI callers can intercept via their own try/catch.
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
     try {
-      resolveModelOrExit("shared-model", catalog, exit, errSink);
-    } catch {
-      /* reachable after the unreachable-guard throw */
+      let captured: unknown;
+      try {
+        resolveModelOrThrow("shared-model", catalog);
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeInstanceOf(AmbiguousModelError);
+      const message = (captured as Error).message;
+      expect(message).toMatch(/ambiguous/i);
+      expect(message).toMatch(/grok:shared-model/);
+      expect(message).toMatch(/openai:shared-model/);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
     }
-    expect(exit).toHaveBeenCalledWith(1);
-    const joined = err.join("");
-    expect(joined).toMatch(/ambiguous model/);
-    expect(joined).toMatch(/grok:shared-model/);
-    expect(joined).toMatch(/openai:shared-model/);
   });
 
-  it("hard-fails with exit(1) on unknown model slug", () => {
-    const exit = vi.fn() as unknown as (code: number) => never;
-    const err: string[] = [];
-    const errSink = (line: string) => {
-      err.push(line);
-    };
+  it("THROWS a catchable UnknownModelError on an unknown model slug (no process.exit)", () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
     try {
-      resolveModelOrExit("nope-unknown", PROVIDER_MODEL_CATALOG, exit, errSink);
-    } catch {
-      /* expected unreachable guard */
+      let captured: unknown;
+      try {
+        resolveModelOrThrow("nope-unknown", PROVIDER_MODEL_CATALOG);
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeInstanceOf(UnknownModelError);
+      expect((captured as Error).message).toMatch(/unknown model/i);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
     }
-    expect(exit).toHaveBeenCalledWith(1);
-    expect(err.join("")).toMatch(/unknown model/);
   });
 });
 

--- a/runtime/tests/bin/bootstrap.test.ts
+++ b/runtime/tests/bin/bootstrap.test.ts
@@ -14,7 +14,12 @@ import {
   readStartupCliFlags,
   resolveStartupSelection,
 } from "../bin/startup-selection.js";
-import { defaultConfig, mergeConfigs } from "../config/schema.js";
+import {
+  AmbiguousModelError,
+  defaultConfig,
+  mergeConfigs,
+  UnknownModelError,
+} from "../config/schema.js";
 import { parseToml } from "../config/loader.js";
 import { trustProjectSync } from "../permissions/trust/project-trust.js";
 import type { AuthBackend } from "../auth/backend.js";
@@ -148,6 +153,71 @@ function rolloutEvent(
 }
 
 describe("resolveStartupSelection", () => {
+  // Regression for the shared-selection hard-exit bug. `resolveStartupSelection`
+  // is reached from the daemon/TUI context (app-server-client), not just the
+  // CLI, so an ambiguous/unknown CONFIGURED model must surface as a CATCHABLE
+  // thrown error — it must NOT call process.exit(1) from inside shared code,
+  // which would bypass every caller's try/catch. We spy on process.exit so a
+  // revert to the old exit-based behavior is caught even if it somehow also
+  // "threw".
+  it("THROWS (catchable) on an ambiguous bare CONFIGURED model — never process.exit", () => {
+    const config = mergeConfigs(defaultConfig(), {
+      // model_provider intentionally unset → falls through to the bare-model
+      // disambiguation path (the buggy branch).
+      model_provider: "",
+      model: "shared-cfg-model",
+      providers: {
+        grok: { default_model: "shared-cfg-model" },
+        openai: { default_model: "shared-cfg-model" },
+      },
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    try {
+      let captured: unknown;
+      try {
+        resolveStartupSelection({
+          config,
+          env: {},
+          argv: ["node", "agenc"],
+        });
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeInstanceOf(AmbiguousModelError);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("THROWS (catchable) on an unknown bare CONFIGURED model — never process.exit", () => {
+    const config = mergeConfigs(defaultConfig(), {
+      model_provider: "",
+      model: "definitely-not-a-real-model-xyz",
+    });
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    try {
+      let captured: unknown;
+      try {
+        resolveStartupSelection({
+          config,
+          env: {},
+          argv: ["node", "agenc"],
+        });
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeInstanceOf(UnknownModelError);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
   it("applies CLI provider/model/profile ahead of env and config", () => {
     const config = mergeConfigs(defaultConfig(), {
       model: "grok-3",

--- a/runtime/tests/transaction-guard/transaction-guard.test.ts
+++ b/runtime/tests/transaction-guard/transaction-guard.test.ts
@@ -581,6 +581,140 @@ describe("transaction guard tool intent detection", () => {
     expect(input).toBeNull();
   });
 
+  // Gap A: lock the AND-gate at tool-intent.ts:92
+  // (SOLANA_SIGNAL_RE.test(text) && SOLANA_WRITE_SIGNAL_RE.test(text)).
+  // SOLANA_WRITE_SIGNAL_RE matches generic shell verbs (transfer/deploy/
+  // upgrade/approve/...), so every command below DELIBERATELY contains a
+  // write-signal word but NO Solana token. Detection must stay null because
+  // the write half alone is not sufficient. Loosening the AND to an OR (or
+  // broadening SOLANA_WRITE_SIGNAL_RE) would start blocking these benign
+  // commands — and reddens this table.
+  test.each([
+    { name: "kubectl apply with deploy manifest", cmd: "kubectl apply -f deploy.yaml" },
+    { name: "terraform apply auto-approve", cmd: "terraform apply -auto-approve" },
+    { name: "make deploy target", cmd: "make deploy" },
+    { name: "helm upgrade release", cmd: "helm upgrade myrelease ./chart" },
+    { name: "ansible deploy playbook", cmd: "ansible-playbook deploy.yml" },
+    { name: "move report into transfer dir", cmd: "mv report.pdf /tmp/transfer/" },
+    {
+      name: "stress string of write verbs",
+      cmd: "echo transfer deploy submit execute sign swap approve",
+    },
+  ])(
+    "does not guard benign non-Solana command with write word: $name",
+    ({ cmd }) => {
+      const input = buildToolTransactionGuardInput(
+        makeTool("exec_command", () => {}),
+        makeInvocation("benign-write", "exec_command"),
+        { cmd },
+      );
+      expect(input).toBeNull();
+    },
+  );
+
+  // Gap B: lock the metadata branch at tool-intent.ts:95
+  // (metadataSolanaHint(tool) && tool.metadata?.mutating === true).
+  // metadataSolanaHint() returns true when tool.metadata.family — or any
+  // tool.metadata.keywords entry — contains the word "solana". To isolate
+  // this branch from the text-based AND-gate above, the metadata carries a
+  // Solana hint but NO write-signal word (e.g. family "solana" / keyword
+  // "cluster"), and the args carry no command text. So detection here is
+  // decided solely by line 95.
+  test("guards a mutating Solana-hinted metadata tool (family hint)", () => {
+    const tool: Tool = {
+      name: "mcp.solana.settle",
+      description: "test tool",
+      inputSchema: { type: "object", additionalProperties: true },
+      metadata: { family: "solana", source: "mcp", mutating: true },
+      async execute() {
+        return { content: "executed" };
+      },
+    };
+    const input = buildToolTransactionGuardInput(
+      tool,
+      makeInvocation("meta-family-mutating", "mcp.solana.settle"),
+      {},
+    );
+    expect(input).not.toBeNull();
+    expect(input?.kind).toBe("solana_tool_invocation");
+  });
+
+  test("guards a mutating Solana-hinted metadata tool (keyword hint)", () => {
+    const tool: Tool = {
+      name: "mcp.defi.settle",
+      description: "test tool",
+      inputSchema: { type: "object", additionalProperties: true },
+      metadata: {
+        family: "defi",
+        keywords: ["solana", "cluster"],
+        source: "mcp",
+        mutating: true,
+      },
+      async execute() {
+        return { content: "executed" };
+      },
+    };
+    const input = buildToolTransactionGuardInput(
+      tool,
+      makeInvocation("meta-keyword-mutating", "mcp.defi.settle"),
+      {},
+    );
+    expect(input).not.toBeNull();
+    expect(input?.kind).toBe("solana_tool_invocation");
+  });
+
+  // Negatives that lock the AND in line 95. A Solana hint without
+  // mutating=true must NOT be guarded — reddening if the
+  // `&& tool.metadata?.mutating === true` conjunct is dropped.
+  test.each([
+    { name: "mutating false", mutating: false },
+    { name: "mutating undefined", mutating: undefined },
+  ])(
+    "does not guard a Solana-hinted metadata tool when not mutating: $name",
+    ({ mutating }) => {
+      const tool: Tool = {
+        name: "mcp.solana.lookup",
+        description: "test tool",
+        inputSchema: { type: "object", additionalProperties: true },
+        metadata: {
+          family: "solana",
+          source: "mcp",
+          ...(mutating === undefined ? {} : { mutating }),
+        },
+        async execute() {
+          return { content: "executed" };
+        },
+      };
+      const input = buildToolTransactionGuardInput(
+        tool,
+        makeInvocation("meta-not-mutating", "mcp.solana.lookup"),
+        {},
+      );
+      expect(input).toBeNull();
+    },
+  );
+
+  // Negative that locks the metadataSolanaHint() conjunct in line 95.
+  // A mutating tool WITHOUT a Solana hint and with no transaction text
+  // must NOT be guarded.
+  test("does not guard a mutating tool with no Solana metadata hint", () => {
+    const tool: Tool = {
+      name: "exec_command",
+      description: "test tool",
+      inputSchema: { type: "object", additionalProperties: true },
+      metadata: { family: "terminal", source: "mcp", mutating: true },
+      async execute() {
+        return { content: "executed" };
+      },
+    };
+    const input = buildToolTransactionGuardInput(
+      tool,
+      makeInvocation("meta-no-hint", "exec_command"),
+      { cmd: "ls -la" },
+    );
+    expect(input).toBeNull();
+  });
+
   test("guards write_stdin content that would submit a transaction", () => {
     const input = buildToolTransactionGuardInput(
       makeTool("write_stdin", () => {}),

--- a/runtime/tests/utils/staticRender.test.tsx
+++ b/runtime/tests/utils/staticRender.test.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// Absolute path to the module staticRender.tsx imports as `../tui/ink.js`,
+// plus the render mock — both computed inside vi.hoisted so they exist when
+// the hoisted vi.mock factory runs. Mocking by absolute path sidesteps the
+// repo's custom vitest source-resolver aliasing so the mock reliably replaces
+// the same module instance that staticRender resolves.
+const { INK_MODULE_PATH, renderMock } = vi.hoisted(() => {
+  const { resolve } = require("node:path") as typeof import("node:path");
+  const { fileURLToPath } = require("node:url") as typeof import("node:url");
+  const here = fileURLToPath(import.meta.url);
+  const inkPath = resolve(here, "../../../src/tui/ink.ts");
+  return { INK_MODULE_PATH: inkPath, renderMock: vi.fn() };
+});
+
+vi.mock(INK_MODULE_PATH, () => ({
+  // `useApp` is referenced by RenderOnceAndExit; provide a no-op so the
+  // component module loads even though the mocked render never mounts it.
+  useApp: () => ({ exit: () => {} }),
+  render: renderMock,
+}));
+
+import { renderToAnsiString, renderToString } from "../../src/utils/staticRender.js";
+
+afterEach(() => {
+  renderMock.mockReset();
+});
+
+describe("staticRender infrastructure-rejection handling", () => {
+  // Regression guard for the latent hang: the previous implementation used a
+  // `new Promise(async resolve => …)` executor with no `catch`, so an
+  // infrastructure-level render() rejection escaped to the global
+  // unhandledRejection handler and left the returned promise UNSETTLED — the
+  // caller's await hung forever. The bounded vitest timeout below turns any
+  // regression (a hang) into a clear, deterministic failure instead.
+
+  test(
+    "renderToAnsiString settles (rejects) when ink render() rejects",
+    async () => {
+      const renderError = new Error("ink render() failed");
+      renderMock.mockRejectedValue(renderError);
+
+      await expect(
+        renderToAnsiString(<React.Fragment>hi</React.Fragment>),
+      ).rejects.toThrow("ink render() failed");
+    },
+    1000,
+  );
+
+  test(
+    "renderToString settles (rejects) when ink render() rejects",
+    async () => {
+      const renderError = new Error("ink render() failed for renderToString");
+      renderMock.mockRejectedValue(renderError);
+
+      await expect(
+        renderToString(<React.Fragment>hi</React.Fragment>),
+      ).rejects.toThrow("ink render() failed for renderToString");
+    },
+    1000,
+  );
+
+  test(
+    "renderToAnsiString settles (rejects) when waitUntilExit() rejects",
+    async () => {
+      const waitError = new Error("waitUntilExit() failed");
+      renderMock.mockResolvedValue({
+        waitUntilExit: () => Promise.reject(waitError),
+      });
+
+      await expect(
+        renderToAnsiString(<React.Fragment>hi</React.Fragment>),
+      ).rejects.toThrow("waitUntilExit() failed");
+    },
+    1000,
+  );
+
+  test(
+    "renderToAnsiString resolves the captured frame on the happy path",
+    async () => {
+      renderMock.mockImplementation(
+        (
+          _node: React.ReactNode,
+          options: { stdout: NodeJS.WriteStream },
+        ) => {
+          const stream = options.stdout as unknown as {
+            write(chunk: string): void;
+          };
+          // Emit a single DEC-synchronized frame the way Ink does in non-TTY
+          // mode, then resolve an instance that exits immediately.
+          stream.write("\x1B[?2026hHELLO-FRAME\x1B[?2026l");
+          return Promise.resolve({
+            waitUntilExit: () => Promise.resolve(),
+          });
+        },
+      );
+
+      await expect(
+        renderToAnsiString(<React.Fragment>hi</React.Fragment>),
+      ).resolves.toContain("HELLO-FRAME");
+    },
+    2000,
+  );
+});


### PR DESCRIPTION
Autonomous discover→verify→fix iteration 4. All gated (typecheck + 13119 tests + build); each fix independently reviewed (the daemon-timeout fix also live-verified), each with a revert-sensitive test.

- **HIGH** error when --resume/-r given without a session id (was silently booting a fresh TUI)
- **HIGH** raise daemon cold-start readiness timeout 15s->45s + AGENC_DAEMON_READY_TIMEOUT_MS override (cold --print/start/restart falsely failed at ~15.5s; live-verified now succeeds ~16s)
- **HIGH** renderToAnsiString always settles on render failure (async-executor anti-pattern hung forever)
- **MED** resolveModelOrExit throws instead of process.exit (an ambiguous configured model hard-killed the whole daemon)
- **MED** lock the transaction-guard AND-gate + metadata detection branch with revert-sensitive coverage

Two of the HIGHs were promoted from the verifier's rejected pile.