### PR TITLE
auto-fix iter 5: 2 verified fixes (unbounded client delivery queue, swallowed value flags)

### DIFF
--- a/runtime/src/app-server/client-multiplexer.ts
+++ b/runtime/src/app-server/client-multiplexer.ts
@@ -49,6 +49,34 @@ export interface AgenCClientMultiplexerOptions {
   readonly createClientId?: () => string;
   readonly maxBufferedEventsPerSession?: number;
   readonly maxBufferedBytesPerSession?: number;
+  /**
+   * Live-broadcast per-client pending-backlog caps. These gate the slow-consumer
+   * eviction on the ONGOING broadcast path (an already-attached client falling
+   * behind); they do NOT apply to the one-shot replay hand-off, which never
+   * evicts. When omitted they default to the detached-session buffer caps
+   * ({@link maxBufferedBytesPerSession} / {@link maxBufferedEventsPerSession}),
+   * which is the production wiring — the daemon never overrides them, so default
+   * behavior is unchanged. They exist as an independent seam because the live
+   * pending cap and the detached-buffer cap are conceptually distinct bounds:
+   * the detached buffer trims itself to within its cap before any replay, so a
+   * cap-on-replay regression is only observable when the live pending cap is set
+   * STRICTLY SMALLER than the detached-buffer cap (a legitimately-buffered
+   * multi-event replay then exceeds the live pending cap). Tests use that to
+   * exercise the replay-vs-live boundary; production leaves them coupled.
+   */
+  readonly maxPendingDeliveryBytesPerClient?: number;
+  readonly maxPendingDeliveryCountPerClient?: number;
+  /**
+   * Optional hook fired when an attached client is evicted because its pending
+   * (queued-but-undelivered) delivery backlog exceeded the per-client cap — see
+   * {@link AgenCClientMultiplexerOptions.maxBufferedBytesPerSession}. The
+   * multiplexer holds only a `send` closure, not the underlying socket, so it
+   * cannot tear down the transport itself; the daemon supplies this callback to
+   * `socket.destroy()` the slow consumer. The client has already been removed
+   * from the multiplexer and detached from its sessions by the time this fires.
+   * It can reconnect later through the normal detached-buffer/replay path.
+   */
+  readonly onClientEvicted?: (clientId: string) => void;
 }
 
 /**
@@ -85,6 +113,23 @@ interface MutableClient {
   send: AgenCClientSend;
   sessionIds: Set<string>;
   deliveryQueue: Promise<void>;
+  /**
+   * Approximate bytes of events enqueued for delivery to this attached client
+   * but not yet flushed (the per-delivery promise has not settled). `send` is
+   * ultimately a socket write that resolves only when the OS write callback
+   * fires, so a backpressured/stuck client leaves these promises pending and
+   * pins their payloads in daemon heap. A healthy, fast client drains its queue
+   * promptly, so this stays near zero. When it crosses the cap the client is
+   * evicted as a slow consumer. Pairs with {@link pendingDeliveryCount}.
+   */
+  pendingDeliveryBytes: number;
+  /** Count analog of {@link pendingDeliveryBytes}. */
+  pendingDeliveryCount: number;
+  /**
+   * Set once the client trips the pending-backlog cap. No further events are
+   * enqueued for it and it is removed/detached as a slow consumer.
+   */
+  evicted: boolean;
 }
 
 interface MutableSessionRoute {
@@ -108,6 +153,9 @@ export class AgenCDaemonClientMultiplexer {
   readonly #createClientId: () => string;
   readonly #maxBufferedEventsPerSession: number;
   readonly #maxBufferedBytesPerSession: number;
+  readonly #maxPendingDeliveryBytesPerClient: number;
+  readonly #maxPendingDeliveryCountPerClient: number;
+  readonly #onClientEvicted?: (clientId: string) => void;
   readonly #state = new AsyncLock<MultiplexerState>({
     clients: new Map(),
     sessions: new Map(),
@@ -122,6 +170,15 @@ export class AgenCDaemonClientMultiplexer {
     this.#maxBufferedBytesPerSession =
       options.maxBufferedBytesPerSession ??
       DEFAULT_MAX_BUFFERED_BYTES_PER_SESSION;
+    // Default the live pending caps to the detached-buffer caps so production
+    // (which never overrides them) keeps the exact prior behavior.
+    this.#maxPendingDeliveryBytesPerClient =
+      options.maxPendingDeliveryBytesPerClient ??
+      this.#maxBufferedBytesPerSession;
+    this.#maxPendingDeliveryCountPerClient =
+      options.maxPendingDeliveryCountPerClient ??
+      this.#maxBufferedEventsPerSession;
+    this.#onClientEvicted = options.onClientEvicted;
   }
 
   async registerClient(
@@ -141,6 +198,9 @@ export class AgenCDaemonClientMultiplexer {
         send: options.send,
         sessionIds: new Set(),
         deliveryQueue: Promise.resolve(),
+        pendingDeliveryBytes: 0,
+        pendingDeliveryCount: 0,
+        evicted: false,
       });
       return { clientId };
     });
@@ -150,6 +210,9 @@ export class AgenCDaemonClientMultiplexer {
     sessionId: string,
     clientId: string,
   ): Promise<SessionAttachResult> {
+    // Replay never evicts (allowEvict=false below), so nothing is ever pushed
+    // here; the array only satisfies the shared enqueueDelivery signature.
+    const replayEvictedClientIds: string[] = [];
     const { attachment, replayedEventCount, replay } = await this.#state.with(
       async (state) => {
         const client = requireClient(state, clientId);
@@ -163,7 +226,17 @@ export class AgenCDaemonClientMultiplexer {
         route.clientAttachmentIds.set(clientId, attachment.attachmentId);
         const replayedEventCount = route.bufferedEvents.length;
         const replay = route.bufferedEvents
-          .map((event) => enqueueDelivery(client, event))
+          .map((event) =>
+            enqueueDelivery(
+              client,
+              event,
+              this.#maxBufferedBytesPerSession,
+              this.#maxBufferedEventsPerSession,
+              replayEvictedClientIds,
+              // REPLAY is a bounded one-shot hand-off: never evict, never drop.
+              false,
+            ),
+          )
           .filter((delivery): delivery is EnqueuedDelivery => delivery !== null);
 
         return { attachment, replayedEventCount, replay };
@@ -265,6 +338,26 @@ export class AgenCDaemonClientMultiplexer {
     });
   }
 
+  /**
+   * Tear down clients flagged by {@link enqueueDelivery} as slow consumers whose
+   * pending delivery backlog exceeded the per-client cap. Each is removed from
+   * the multiplexer and detached from its sessions (same internal cleanup as
+   * {@link disconnectClient}), then surfaced via the `onClientEvicted` callback
+   * so the transport can `socket.destroy()` the stuck connection. The client can
+   * reconnect later through the normal detached-buffer/replay path.
+   */
+  async #evictSlowClients(clientIds: readonly string[]): Promise<void> {
+    if (clientIds.length === 0) return;
+    for (const clientId of clientIds) {
+      try {
+        await this.disconnectClient(clientId);
+      } catch {
+        // Client may already be gone (concurrent disconnect); ignore.
+      }
+      this.#onClientEvicted?.(clientId);
+    }
+  }
+
   async attachedClientIds(sessionId: string): Promise<readonly string[]> {
     return this.#state.with((state) => {
       const route = state.sessions.get(sessionId);
@@ -276,6 +369,7 @@ export class AgenCDaemonClientMultiplexer {
     sessionId: string,
     event: JsonObject,
   ): Promise<AgenCSessionBroadcastResult> {
+    const evictedClientIds: string[] = [];
     const deliveries = await this.#state.with(async (state) => {
       const existingRoute = state.sessions.get(sessionId);
 
@@ -308,9 +402,21 @@ export class AgenCDaemonClientMultiplexer {
       }
 
       return activeClientIds
-        .map((clientId) => enqueueDelivery(state.clients.get(clientId), event))
+        .map((clientId) =>
+          enqueueDelivery(
+            state.clients.get(clientId),
+            event,
+            this.#maxPendingDeliveryBytesPerClient,
+            this.#maxPendingDeliveryCountPerClient,
+            evictedClientIds,
+            // Live broadcast: enforce the per-client backlog cap.
+            true,
+          ),
+        )
         .filter((delivery): delivery is EnqueuedDelivery => delivery !== null);
     });
+
+    await this.#evictSlowClients(evictedClientIds);
 
     return {
       sessionId,
@@ -391,15 +497,91 @@ function routeClientIdForDetach(
   return undefined;
 }
 
+/**
+ * Bound on a single attached client's pending (queued-but-undelivered) delivery
+ * backlog for the ONGOING broadcast path. Mirrors the detached-session
+ * buffering caps: a client whose pending backlog exceeds {@link maxPendingBytes}
+ * bytes OR {@link maxPendingCount} events is a stuck/backpressured slow consumer
+ * and is evicted rather than allowed to pin daemon heap without limit.
+ *
+ * `allowEvict` gates the cap. It is TRUE only for the live broadcast path
+ * (an already-attached client falling behind). It is FALSE for the one-shot
+ * REPLAY path in {@link AgenCDaemonClientMultiplexer.attachClientToSession},
+ * which maps this function SYNCHRONOUSLY over the detached buffer inside the
+ * state lock: the per-delivery decrement microtasks cannot run during that
+ * synchronous map, so the pending counters would only ever accumulate across
+ * the batch and a perfectly healthy client replaying a buffer near the 8 MB
+ * detached cap would be falsely evicted mid-replay (and its un-delivered
+ * boundary event then spliced away and lost). The replay batch is already
+ * bounded by the detached-buffer cap and is a controlled hand-off to a freshly
+ * attaching client, so it must never trip eviction or drop an event — when
+ * `allowEvict` is false this function performs the original unbounded enqueue
+ * (no cap, no counter bookkeeping).
+ *
+ * When the broadcast path trips the cap, the client's id is pushed onto
+ * `evictedClientIds`; the caller (outside the lock-managed section) tears it
+ * down via {@link AgenCDaemonClientMultiplexer.evictSlowClients}. Once flagged
+ * `evicted` the client accepts no further events. Healthy fast clients drain
+ * their queue promptly, so their counters stay near zero and never trip the cap.
+ */
 function enqueueDelivery(
   client: MutableClient | undefined,
   event: JsonObject,
+  maxPendingBytes: number,
+  maxPendingCount: number,
+  evictedClientIds: string[],
+  allowEvict: boolean,
 ): EnqueuedDelivery | null {
-  if (client === undefined) return null;
+  if (client === undefined || client.evicted) return null;
+
+  if (!allowEvict) {
+    // REPLAY path: original unbounded enqueue. No cap and no pending-counter
+    // bookkeeping (those counters track the live broadcast backlog only), so a
+    // healthy client's bounded one-shot replay is never evicted and no buffered
+    // event is ever dropped.
+    const delivered = client.deliveryQueue.then(() =>
+      Promise.resolve(client.send(event)),
+    );
+    client.deliveryQueue = delivered.then(
+      () => undefined,
+      () => undefined,
+    );
+    return {
+      clientId: client.clientId,
+      delivered,
+    };
+  }
+
+  const eventBytes = bufferedEventByteSize(event);
+  // Trip the cap when this event WOULD push the pending backlog over either
+  // budget. Always allow the very first pending event through (count 0) so a
+  // single oversized payload is still delivered to an otherwise-idle client
+  // rather than evicting it for one event, mirroring the byte-budget path's
+  // "retain at least the most recent event" rule.
+  if (
+    client.pendingDeliveryCount > 0 &&
+    (client.pendingDeliveryBytes + eventBytes > maxPendingBytes ||
+      client.pendingDeliveryCount + 1 > maxPendingCount)
+  ) {
+    client.evicted = true;
+    evictedClientIds.push(client.clientId);
+    return null;
+  }
+
+  client.pendingDeliveryBytes += eventBytes;
+  client.pendingDeliveryCount += 1;
 
   const delivered = client.deliveryQueue.then(() =>
     Promise.resolve(client.send(event)),
   );
+  // Decrement the pending counters once THIS delivery settles (success or
+  // failure) so a healthy client's backlog drains back toward zero. Bound to a
+  // local `client` reference so it is unaffected by later re-registration.
+  const settleAccounting = (): void => {
+    client.pendingDeliveryBytes -= eventBytes;
+    client.pendingDeliveryCount -= 1;
+  };
+  delivered.then(settleAccounting, settleAccounting);
   client.deliveryQueue = delivered.then(
     () => undefined,
     () => undefined,

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -1250,8 +1250,15 @@ async function runAgenCDaemonForeground(
     agencHome: authStartup.daemonHome,
   });
   const sessionManager = new AgenCDaemonSessionManager({ threadStore });
+  // Forward declaration: set once the connection registry below exists. Lets
+  // the multiplexer ask the transport to tear down a slow consumer's socket
+  // when that client's pending delivery backlog trips the per-client cap.
+  let destroyEvictedClientConnection: ((clientId: string) => void) | undefined;
   const clientMultiplexer = new AgenCDaemonClientMultiplexer({
     sessionManager,
+    onClientEvicted: (clientId) => {
+      destroyEvictedClientConnection?.(clientId);
+    },
   });
   const commandExec = new AgenCCommandExecService();
   const cleanup = new AgenCCleanupRegistry();
@@ -1530,6 +1537,28 @@ async function runAgenCDaemonForeground(
     void connection?.close().catch(() => {});
     for (const clientId of connection?.trackedClientIds ?? []) {
       void clientMultiplexer.removeClient(clientId).catch(() => {});
+    }
+  };
+  // Tear down the transport for a slow consumer the multiplexer evicted for an
+  // unbounded pending delivery backlog. The multiplexer already removed the
+  // client from its routing state. A single transport connection can carry
+  // MULTIPLE tracked clients (trackedClientIds is a set keyed by the clientId a
+  // peer supplies in attach calls), so only destroy the whole connection when
+  // the evicted client is its SOLE tracked client — otherwise just stop
+  // tracking that client and leave the connection (and its other healthy
+  // co-located clients) untouched. Destroying the socket ends the backpressured
+  // peer so it stops pinning daemon heap; it can reconnect and replay through
+  // the normal detached-buffer path.
+  destroyEvictedClientConnection = (clientId: string): void => {
+    for (const [connectionKey, connection] of connections) {
+      if (!connection.trackedClientIds.includes(clientId)) {
+        continue;
+      }
+      const wasSoleClient = connection.untrackClientId(clientId);
+      if (wasSoleClient) {
+        closeConnection(connectionKey);
+      }
+      return;
     }
   };
   const socketServer = new AgenCUnixSocketServer({

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -1147,6 +1147,17 @@ export class AgenCDaemonJsonRpcConnection {
     this.#clientIds.add(clientId);
   }
 
+  /**
+   * Stop tracking a single client on this connection without tearing the
+   * connection down. Used when one co-located client is evicted (e.g. as a slow
+   * consumer) but other healthy clients still share the connection. Returns
+   * whether the connection no longer tracks any client.
+   */
+  untrackClientId(clientId: string): boolean {
+    this.#clientIds.delete(clientId);
+    return this.#clientIds.size === 0;
+  }
+
   get trackedClientIds(): readonly string[] {
     return [...this.#clientIds];
   }

--- a/runtime/src/bin/route.ts
+++ b/runtime/src/bin/route.ts
@@ -136,6 +136,64 @@ export function isStartupValueFlagToken(arg: string): boolean {
   );
 }
 
+/**
+ * Startup value-flags that select the boot configuration (provider, model,
+ * profile, attached image). Unlike `--resume` (which has its own guard above)
+ * and `--permission-mode` (guarded in startup-selection's
+ * `resolvePermissionModeOrThrow`), these are silently swallowed when their
+ * value is missing or dash-prefixed: `extractFlagValue` / `extractFlagValues`
+ * return null/empty (correct, tested dash-guard) and `stripRoutingFlags`
+ * removes the bare flag token, so the user's explicit selection vanishes and
+ * the session boots on defaults with zero feedback. Each is guarded below.
+ */
+const STARTUP_SELECTION_VALUE_FLAGS = Object.freeze([
+  "--provider",
+  "--model",
+  "--profile",
+  "--image",
+] as const);
+
+type StartupSelectionValueFlag =
+  (typeof STARTUP_SELECTION_VALUE_FLAGS)[number];
+
+const STARTUP_SELECTION_FLAG_USAGE: Readonly<
+  Record<StartupSelectionValueFlag, string>
+> = Object.freeze({
+  "--provider": "agenc --provider requires a value (usage: agenc --provider <name>)",
+  "--model": "agenc --model requires a value (usage: agenc --model <id|provider:id>)",
+  "--profile": "agenc --profile requires a value (usage: agenc --profile <name>)",
+  "--image": "agenc --image requires a value (usage: agenc --image <path|url>)",
+});
+
+/**
+ * Detect a selection value-flag (`--provider`/`--model`/`--profile`/`--image`)
+ * that was supplied as a real leading flag token but with no usable value —
+ * either a bare flag whose next token is absent or dash-prefixed, or the empty
+ * `--flag=` form. Returns the first such flag in argv order (so the error names
+ * the flag the user actually mistyped), or null when every selection flag that
+ * appears carries a value (or none appears at all). A `--flag=value` token and
+ * a positional prompt that merely contains the word "model" never match.
+ */
+function findMissingValueSelectionFlag(
+  userArgv: readonly string[],
+): StartupSelectionValueFlag | null {
+  for (let i = 0; i < userArgv.length; i += 1) {
+    const arg = userArgv[i]!;
+    for (const flag of STARTUP_SELECTION_VALUE_FLAGS) {
+      // Empty equals form (`--model=`) is unambiguously a missing value.
+      if (arg === `${flag}=`) return flag;
+      // Bare flag token (`--model`): missing when the next token is absent
+      // or a dash-prefixed flag (the same condition that makes
+      // extractFlagValue/extractFlagValues yield null/empty).
+      if (arg === flag) {
+        const next = userArgv[i + 1];
+        if (typeof next !== "string" || next.startsWith("-")) return flag;
+      }
+    }
+  }
+  return null;
+}
+
 function shouldStripBooleanFlag(arg: string): boolean {
   return ROUTING_BOOLEAN_FLAGS.includes(
     arg as (typeof ROUTING_BOOLEAN_FLAGS)[number],
@@ -248,6 +306,26 @@ export function classifyCLI(opts: ClassifyCLIOptions): RouteCLIPlan {
     return {
       kind: "errorAndExit",
       message: `agenc --resume requires a session id (usage: agenc --resume <session-id>)`,
+      exitCode: 2,
+    };
+  }
+
+  // 0b. A selection value-flag (`--provider`/`--model`/`--profile`/`--image`)
+  //     was supplied as a real leading flag token but with no value — its next
+  //     token is absent or dash-prefixed, or it is the empty `--flag=` form.
+  //     `extractFlagValue`/`extractFlagValues` correctly yield null/empty here
+  //     (the tested dash-guard), but readStartupCliFlags/startup-selection then
+  //     drop the override AND stripRoutingFlags removes the bare flag token, so
+  //     the user's explicit selection vanishes and the session silently boots
+  //     on defaults. Error instead, mirroring the --resume guard exactly (same
+  //     errorAndExit shape, exitCode 2, both TTY and non-TTY). Only a real
+  //     leading flag token matches — a `--model=gpt` value form or a prompt
+  //     that merely contains the word "model" is unaffected.
+  const missingSelectionFlag = findMissingValueSelectionFlag(userArgv);
+  if (missingSelectionFlag !== null) {
+    return {
+      kind: "errorAndExit",
+      message: STARTUP_SELECTION_FLAG_USAGE[missingSelectionFlag],
       exitCode: 2,
     };
   }

--- a/runtime/tests/app-server/client-multiplexer.slow-consumer-eviction.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.slow-consumer-eviction.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
+import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
+import type { JsonObject } from "./protocol/index.js";
+
+// Harness with default (auto-generated) session/attachment ids and a real clock
+// so tests that attach/detach/re-attach many times do not exhaust fixed
+// sequences. Only the byte budget is pinned, which is all these tests assert on.
+function createUnsequencedHarness(
+  maxBufferedBytesPerSession: number,
+  options: {
+    readonly maxPendingDeliveryBytesPerClient?: number;
+    readonly maxPendingDeliveryCountPerClient?: number;
+    readonly maxBufferedEventsPerSession?: number;
+  } = {},
+): {
+  readonly sessionManager: AgenCDaemonSessionManager;
+  readonly multiplexer: AgenCDaemonClientMultiplexer;
+  readonly evicted: string[];
+} {
+  const sessionManager = new AgenCDaemonSessionManager({
+    createSessionId: () => "session_1",
+  });
+  const evicted: string[] = [];
+  const multiplexer = new AgenCDaemonClientMultiplexer({
+    sessionManager,
+    maxBufferedEventsPerSession: options.maxBufferedEventsPerSession ?? 100_000,
+    maxBufferedBytesPerSession,
+    ...(options.maxPendingDeliveryBytesPerClient !== undefined
+      ? {
+          maxPendingDeliveryBytesPerClient:
+            options.maxPendingDeliveryBytesPerClient,
+        }
+      : {}),
+    ...(options.maxPendingDeliveryCountPerClient !== undefined
+      ? {
+          maxPendingDeliveryCountPerClient:
+            options.maxPendingDeliveryCountPerClient,
+        }
+      : {}),
+    onClientEvicted: (clientId) => {
+      evicted.push(clientId);
+    },
+  });
+  return { sessionManager, multiplexer, evicted };
+}
+
+function bigEvent(sequenceNumber: number, payloadBytes: number): JsonObject {
+  return {
+    type: "session.delta",
+    sessionId: "session_1",
+    sequence: sequenceNumber,
+    text: "x".repeat(payloadBytes),
+  };
+}
+
+describe("client multiplexer slow-consumer eviction", () => {
+  it("bounds a stuck attached client's pending backlog and evicts it, while a healthy client still receives everything", async () => {
+    // Budget fits roughly ~8 of the ~1KB payloads below.
+    const { sessionManager, multiplexer, evicted } =
+      createUnsequencedHarness(8 * 1100);
+    await sessionManager.createSession({ agentId: "agent_1" });
+
+    // SLOW client: every send returns a promise that never settles, modelling a
+    // backpressured / stuck socket whose OS write callback never fires. Count
+    // how many events were actually handed to it before eviction.
+    let slowSendCount = 0;
+    await multiplexer.registerClient({
+      clientId: "slow_client",
+      send: () => {
+        slowSendCount += 1;
+        return new Promise<void>(() => {
+          /* never resolves */
+        });
+      },
+    });
+    await multiplexer.attachClientToSession("session_1", "slow_client");
+
+    // HEALTHY client: send resolves immediately, so its queue drains and its
+    // pending counters return to ~zero between events.
+    const healthyReceived: JsonObject[] = [];
+    await multiplexer.registerClient({
+      clientId: "healthy_client",
+      send: (message) => {
+        healthyReceived.push(message);
+        return Promise.resolve();
+      },
+    });
+    await multiplexer.attachClientToSession("session_1", "healthy_client");
+
+    // Drive many large events. Do NOT await each broadcast: the slow client's
+    // first delivery never settles, so a broadcast that targets it never
+    // resolves. A real producer emits faster than the stuck consumer drains but
+    // yields the event loop between emits (its own delivery to the HEALTHY
+    // client resolves), so we yield between broadcasts. That lets the healthy
+    // client's queue drain (its pending counters return to ~zero) while the
+    // slow client's keep climbing toward the cap.
+    const totalEvents = 200;
+    const broadcasts: Promise<unknown>[] = [];
+    for (let i = 1; i <= totalEvents; i += 1) {
+      broadcasts.push(
+        multiplexer.broadcastSessionEvent("session_1", bigEvent(i, 1000)),
+      );
+      // Yield so the healthy client's just-enqueued delivery settles and
+      // decrements before the next event is enqueued.
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    // Let any trailing eviction/teardown microtasks settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // (b) The slow client was EVICTED as a slow consumer and REMOVED from the
+    // session route. Both are revert-sensitive: the old unbounded code has no
+    // eviction path, so it never reports an eviction and never drops the client
+    // from the route.
+    expect(evicted).toContain("slow_client");
+    expect(evicted).not.toContain("healthy_client");
+    const stillAttached = await multiplexer.attachedClientIds("session_1");
+    expect(stillAttached).not.toContain("slow_client");
+    expect(stillAttached).toContain("healthy_client");
+
+    // (a) The slow client's pending backlog is BOUNDED — it does NOT grow with
+    // the event count. Capture how many events had reached the slow client at
+    // eviction, then drive MANY more broadcasts: a bounded backlog means the
+    // slow client receives ZERO further events (it is gone from the route), so
+    // its send count stays flat. Against the old unbounded code the slow client
+    // is never evicted, so every additional broadcast still enqueues to it and
+    // the count keeps climbing with the event count.
+    const slowSendCountAtEviction = slowSendCount;
+    for (let i = totalEvents + 1; i <= totalEvents * 3; i += 1) {
+      void multiplexer.broadcastSessionEvent("session_1", bigEvent(i, 1000));
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+    // Flat: no growth after eviction (bounded). Old code: would keep growing.
+    expect(slowSendCount).toBe(slowSendCountAtEviction);
+    // And the backlog that ever reached the slow client was a small bound near
+    // budget/event-size, not proportional to the ~600 broadcasts driven total.
+    expect(slowSendCount).toBeGreaterThan(0);
+    expect(slowSendCount).toBeLessThan(20);
+
+    // The healthy client, attached at the same time, still received EVERY one
+    // of the first `totalEvents` events in order — its fast queue never tripped
+    // the cap. (It keeps receiving the post-eviction events too, but we only
+    // assert the controlled window.)
+    expect(healthyReceived.length).toBeGreaterThanOrEqual(totalEvents);
+    expect((healthyReceived[0] as { sequence: number }).sequence).toBe(1);
+    for (let i = 0; i < totalEvents; i += 1) {
+      expect((healthyReceived[i] as { sequence: number }).sequence).toBe(i + 1);
+    }
+
+    // Avoid unhandled-rejection noise from the broadcasts that target the
+    // never-settling slow client: they stay pending, which is expected.
+    void broadcasts;
+  });
+
+  it("never evicts or drops events for a HEALTHY client replaying a buffer larger than the LIVE pending cap", async () => {
+    // Correctness guard for the replay path: a freshly-attaching client replays
+    // the WHOLE detached buffer in one synchronous batch inside the state lock,
+    // and the per-delivery decrement microtasks cannot run during that
+    // synchronous map. The fix makes replay BYPASS the live-broadcast eviction
+    // cap (allowEvict=false) precisely so that synchronous accumulation can
+    // never falsely evict a healthy client mid-replay or let the post-replay
+    // splice drop an un-delivered boundary event.
+    //
+    // REVERT-SENSITIVITY: this only catches the cap-on-replay bug when the LIVE
+    // pending cap is STRICTLY SMALLER than the detached-buffer cap. The detached
+    // buffer trims itself to within its own cap before any replay, so when both
+    // caps share one value the replay's running partial sums can never cross it
+    // (the whole buffer already fits) — that coupling is exactly why the old
+    // version of this test was a false guard. Here the detached buffer keeps a
+    // multi-event run (~12 KB) that is far larger than the small live pending
+    // cap (2 KB / 3 events). If replay enqueued with allowEvict=true (the v1
+    // bug) the running pending backlog crosses the small live cap mid-replay and
+    // the healthy client is wrongly evicted and its boundary events dropped.
+    // With the shipped fix (allowEvict=false) the live cap is bypassed on replay
+    // and every buffered event is delivered.
+    const detachedBufferCap = 1024 * 1024; // generous: keep the whole run
+    const { sessionManager, multiplexer, evicted } = createUnsequencedHarness(
+      detachedBufferCap,
+      {
+        // Live pending caps STRICTLY SMALLER than the buffered run below.
+        maxPendingDeliveryBytesPerClient: 2 * 1024,
+        maxPendingDeliveryCountPerClient: 3,
+      },
+    );
+    await sessionManager.createSession({ agentId: "agent_1" });
+
+    // Buffer a contiguous multi-event run whose TOTAL bytes (~12 KB over 12
+    // events) far exceed the 2 KB / 3-event live pending cap, while staying well
+    // under the 1 MB detached-buffer cap so the detached eviction retains ALL of
+    // them (no buffer trimming — every event is a replay survivor). ~1 KB each,
+    // no single oversized payload.
+    const newestSequence = 12;
+    for (let i = 1; i <= newestSequence; i += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", bigEvent(i, 1000));
+    }
+
+    // A perfectly HEALTHY client (send resolves immediately) attaches and the
+    // bounded buffer is replayed to it.
+    const replayed: JsonObject[] = [];
+    await multiplexer.registerClient({
+      clientId: "healthy_replay_client",
+      send: (message) => {
+        replayed.push(message);
+        return Promise.resolve();
+      },
+    });
+    await multiplexer.attachClientToSession(
+      "session_1",
+      "healthy_replay_client",
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // The healthy client was NOT evicted — even though the replayed run is far
+    // larger than the live pending cap. Under the v1 cap-on-replay bug it WOULD
+    // be evicted here (synchronous replay accumulation crosses the 2 KB cap).
+    expect(evicted).not.toContain("healthy_replay_client");
+    const stillAttached = await multiplexer.attachedClientIds("session_1");
+    expect(stillAttached).toContain("healthy_replay_client");
+
+    // ...and received EVERY buffered event, in order, with NO data loss. All
+    // `newestSequence` events were retained by the detached buffer (it never
+    // trimmed), so the replay must deliver the FULL contiguous run 1..N with the
+    // newest (boundary) event present — the bug drops the boundary event and any
+    // events past the point the running cap trips.
+    expect(replayed.length).toBe(newestSequence);
+    const replayedSequences = replayed.map(
+      (event) => (event as { sequence: number }).sequence,
+    );
+    expect(replayedSequences[0]).toBe(1);
+    expect(replayedSequences[replayedSequences.length - 1]).toBe(newestSequence);
+    for (let i = 1; i < replayedSequences.length; i += 1) {
+      const prev = replayedSequences[i - 1] as number;
+      const cur = replayedSequences[i] as number;
+      expect(cur).toBe(prev + 1);
+    }
+
+    // The buffer was fully drained on a clean replay (every retained event was
+    // delivered and the buffer spliced empty), proving no event was lost AND the
+    // splice did not discard an undelivered boundary event.
+    await multiplexer.detachClientFromSession(
+      "session_1",
+      "healthy_replay_client",
+    );
+    // Re-attach and confirm nothing is re-replayed (buffer was fully consumed).
+    const secondReplay: JsonObject[] = [];
+    await multiplexer.registerClient({
+      clientId: "second_client",
+      send: (message) => {
+        secondReplay.push(message);
+        return Promise.resolve();
+      },
+    });
+    await multiplexer.attachClientToSession("session_1", "second_client");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(secondReplay).toHaveLength(0);
+  });
+});

--- a/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
@@ -137,6 +137,191 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     });
   });
 
+  it("untrackClientId removes one co-located client without dropping the others", () => {
+    // A single connection can track MULTIPLE clients (trackedClientIds is a set
+    // keyed by the clientId a peer supplies). When one co-located client is
+    // evicted as a slow consumer, the daemon must scope teardown to JUST that
+    // client and only destroy the whole connection when the evicted client is
+    // its SOLE tracked client. This is the per-connection seam that makes that
+    // scoping correct: untrackClientId removes one client and reports whether
+    // the connection still tracks any. Revert-sensitive — without it (or if the
+    // daemon tore down the whole connection) the healthy co-located client would
+    // be collaterally disconnected.
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+    });
+    const connection = dispatcher.createConnection();
+
+    connection.trackClientId("client_a");
+    connection.trackClientId("client_b");
+    expect([...connection.trackedClientIds].sort()).toEqual([
+      "client_a",
+      "client_b",
+    ]);
+
+    // Untrack one of two co-located clients: NOT the sole client, the other
+    // healthy client remains tracked (connection must be kept alive).
+    expect(connection.untrackClientId("client_a")).toBe(false);
+    expect([...connection.trackedClientIds]).toEqual(["client_b"]);
+
+    // Untrack the last client: now sole — connection may be torn down.
+    expect(connection.untrackClientId("client_b")).toBe(true);
+    expect([...connection.trackedClientIds]).toEqual([]);
+
+    // Untracking an unknown client is a no-op and reports the empty state.
+    expect(connection.untrackClientId("client_x")).toBe(true);
+  });
+
+  it("scopes slow-consumer teardown to the evicted client and keeps the connection + co-located client alive", async () => {
+    // Integration coverage for the EXACT regression site in daemon-cli's
+    // destroyEvictedClientConnection wiring: when the multiplexer evicts ONE
+    // slow consumer that shares a transport connection with a healthy co-located
+    // client, only the evicted client must be torn down — the connection and the
+    // healthy client must survive. This reconstructs that wiring faithfully:
+    //   * a REAL multiplexer whose onClientEvicted drives a copy of daemon-cli's
+    //     destroyEvictedClientConnection,
+    //   * a REAL dispatcher connection that tracks BOTH clientIds via the genuine
+    //     trackClientId/untrackClientId/trackedClientIds API,
+    //   * eviction triggered by a REAL broadcastSessionEvent against a stuck slow
+    //     consumer (its send never settles), with an independent healthy client.
+    // The scoping decision flows multiplexer eviction -> onClientEvicted ->
+    // destroyEvictedClientConnection -> connection.untrackClientId. It is
+    // revert-sensitive to untrackClientId's `size === 0` return: if that returns
+    // true unconditionally (v1's whole-connection teardown) the connection is
+    // closed and the healthy co-located client is collaterally removed.
+    const sessionManager = new AgenCDaemonSessionManager({
+      createSessionId: () => "session_1",
+    });
+
+    // Reconstruct daemon-cli's connection registry + teardown seam.
+    const connections = new Map<string, AgenCDaemonJsonRpcConnection>();
+    const closedConnectionKeys: string[] = [];
+    let destroyEvictedClientConnection:
+      | ((clientId: string) => void)
+      | undefined;
+
+    const multiplexer = new AgenCDaemonClientMultiplexer({
+      sessionManager,
+      // Small live pending caps so a couple of ~1KB events trip the slow
+      // consumer; the detached-buffer cap stays generous and irrelevant here.
+      maxBufferedBytesPerSession: 8 * 1024 * 1024,
+      maxPendingDeliveryBytesPerClient: 2 * 1024,
+      maxPendingDeliveryCountPerClient: 1000,
+      onClientEvicted: (clientId) => {
+        destroyEvictedClientConnection?.(clientId);
+      },
+    });
+
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+      clientMultiplexer: multiplexer,
+      sessionManager,
+    });
+
+    const closeConnection = (connectionKey: string): void => {
+      const connection = connections.get(connectionKey);
+      connections.delete(connectionKey);
+      closedConnectionKeys.push(connectionKey);
+      for (const clientId of connection?.trackedClientIds ?? []) {
+        void multiplexer.removeClient(clientId).catch(() => {});
+      }
+    };
+    // Byte-for-byte the daemon-cli scoping decision under test.
+    destroyEvictedClientConnection = (clientId: string): void => {
+      for (const [connectionKey, connection] of connections) {
+        if (!connection.trackedClientIds.includes(clientId)) {
+          continue;
+        }
+        const wasSoleClient = connection.untrackClientId(clientId);
+        if (wasSoleClient) {
+          closeConnection(connectionKey);
+        }
+        return;
+      }
+    };
+
+    // ONE transport connection carrying TWO co-located tracked clients. Each
+    // clientId is a distinct multiplexer client with its OWN send closure, so
+    // their pending-backlog accounting is independent (the slow one stalls, the
+    // healthy one drains).
+    const connection = dispatcher.createConnection({ sendNotification: () => {} });
+    connections.set("conn_1", connection);
+    await sessionManager.createSession({ agentId: "agent_1" });
+
+    let slowSendCount = 0;
+    await multiplexer.registerClient({
+      clientId: "slow_client",
+      send: () => {
+        slowSendCount += 1;
+        return new Promise<void>(() => {
+          /* never resolves: backpressured/stuck socket */
+        });
+      },
+    });
+    await multiplexer.attachClientToSession("session_1", "slow_client");
+    connection.trackClientId("slow_client");
+
+    const healthyReceived: JsonObject[] = [];
+    await multiplexer.registerClient({
+      clientId: "healthy_client",
+      send: (message) => {
+        healthyReceived.push(message);
+        return Promise.resolve();
+      },
+    });
+    await multiplexer.attachClientToSession("session_1", "healthy_client");
+    connection.trackClientId("healthy_client");
+
+    expect([...connection.trackedClientIds].sort()).toEqual([
+      "healthy_client",
+      "slow_client",
+    ]);
+
+    // Drive large events: the slow client's first delivery never settles so its
+    // pending backlog climbs past the 2KB cap and the multiplexer evicts it,
+    // firing onClientEvicted -> destroyEvictedClientConnection. Yield between
+    // broadcasts so the healthy client's deliveries drain.
+    for (let i = 1; i <= 50; i += 1) {
+      void multiplexer.broadcastSessionEvent("session_1", {
+        type: "session.delta",
+        sessionId: "session_1",
+        sequence: i,
+        text: "x".repeat(1000),
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // The slow client was evicted from the multiplexer route AND untracked from
+    // the connection — but the connection itself was NOT closed.
+    expect(slowSendCount).toBeGreaterThan(0);
+    expect(closedConnectionKeys).toEqual([]);
+    expect(connections.has("conn_1")).toBe(true);
+    expect([...connection.trackedClientIds]).toEqual(["healthy_client"]);
+
+    const attached = await multiplexer.attachedClientIds("session_1");
+    expect(attached).toEqual(["healthy_client"]);
+
+    // The healthy co-located client SURVIVED: still registered, still attached,
+    // and still receiving broadcasts after the slow client was torn down.
+    healthyReceived.length = 0;
+    await multiplexer.broadcastSessionEvent("session_1", {
+      type: "session.delta",
+      sessionId: "session_1",
+      sequence: 1000,
+      text: "post-eviction",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(healthyReceived).toEqual([
+      {
+        type: "session.delta",
+        sessionId: "session_1",
+        sequence: 1000,
+        text: "post-eviction",
+      },
+    ]);
+  });
+
   it("requires initialization before daemon.reload", async () => {
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: new AgenCDaemonAgentManager(),

--- a/runtime/tests/bin/agenc.cli-branch.test.ts
+++ b/runtime/tests/bin/agenc.cli-branch.test.ts
@@ -430,6 +430,165 @@ describe("classifyCLI", () => {
   });
 });
 
+describe("classifyCLI startup selection value-flag missing-value guard", () => {
+  // Regression: `--model`/`--provider`/`--profile`/`--image` were SILENTLY
+  // swallowed when their value was missing or dash-prefixed. extractFlagValue
+  // returned null (correct dash-guard), readStartupCliFlags dropped the
+  // override, and stripRoutingFlags removed the bare flag token — so the
+  // user's explicit selection vanished and the session booted on defaults
+  // with zero feedback. Each flag must now error explicitly (exit 2), mirroring
+  // the --resume guard. These tests fail against the pre-fix silent-swallow
+  // code (which routes to bootTUI/oneShotCLI on defaults) and pass with the fix.
+  const SELECTION_FLAG_CASES = [
+    [
+      "--provider",
+      "agenc --provider requires a value (usage: agenc --provider <name>)",
+    ],
+    [
+      "--model",
+      "agenc --model requires a value (usage: agenc --model <id|provider:id>)",
+    ],
+    [
+      "--profile",
+      "agenc --profile requires a value (usage: agenc --profile <name>)",
+    ],
+    ["--image", "agenc --image requires a value (usage: agenc --image <path|url>)"],
+  ] as const;
+
+  describe.each(SELECTION_FLAG_CASES)(
+    "%s with no value",
+    (flag, message) => {
+      it("errors (exit 2) when the flag is the trailing token (value absent), TTY", () => {
+        expect(
+          classifyCLI({
+            argv: [NODE, SCRIPT, flag],
+            isTTY: true,
+            isStdoutTTY: true,
+          }),
+        ).toEqual({ kind: "errorAndExit", message, exitCode: 2 });
+      });
+
+      it("errors (exit 2) when the flag is the trailing token (value absent), non-TTY", () => {
+        expect(
+          classifyCLI({
+            argv: [NODE, SCRIPT, flag],
+            isTTY: false,
+            isStdoutTTY: false,
+          }),
+        ).toEqual({ kind: "errorAndExit", message, exitCode: 2 });
+      });
+
+      it("errors (exit 2) when the next token is dash-prefixed (no value), TTY", () => {
+        // e.g. `agenc --model -p prompt` — the traced failure: print-mode
+        // booted on the DEFAULT model, silently ignoring --model.
+        expect(
+          classifyCLI({
+            argv: [NODE, SCRIPT, flag, "-p", "prompt"],
+            isTTY: true,
+            isStdoutTTY: true,
+          }),
+        ).toEqual({ kind: "errorAndExit", message, exitCode: 2 });
+      });
+
+      it("errors (exit 2) when the next token is dash-prefixed (no value), non-TTY", () => {
+        expect(
+          classifyCLI({
+            argv: [NODE, SCRIPT, flag, "-p", "prompt"],
+            isTTY: false,
+            isStdoutTTY: false,
+          }),
+        ).toEqual({ kind: "errorAndExit", message, exitCode: 2 });
+      });
+
+      it("errors (exit 2) for the empty equals form (--flag=)", () => {
+        expect(
+          classifyCLI({
+            argv: [NODE, SCRIPT, `${flag}=`],
+            isTTY: true,
+            isStdoutTTY: true,
+          }),
+        ).toEqual({ kind: "errorAndExit", message, exitCode: 2 });
+      });
+    },
+  );
+
+  it("happy path: --model <id> still selects the model and boots the TUI", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--model", "gpt-x", "build", "a", "game"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({ kind: "bootTUI", args: { initialPrompt: "build a game" } });
+  });
+
+  it("happy path: --model=gpt-x (equals form) is unaffected", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--model=gpt-x", "hello"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({ kind: "bootTUI", args: { initialPrompt: "hello" } });
+  });
+
+  it("happy path: --provider openai and --profile fast carry values fine", () => {
+    expect(
+      classifyCLI({
+        argv: [
+          NODE,
+          SCRIPT,
+          "--provider",
+          "openai",
+          "--profile",
+          "fast",
+          "hi",
+        ],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({ kind: "bootTUI", args: { initialPrompt: "hi" } });
+  });
+
+  it("happy path: --image with a normal path is a value, not a missing-value error", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--image", "/tmp/cat.png", "describe"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "bootTUI",
+      args: { initialPrompt: "describe", startupImages: ["/tmp/cat.png"] },
+    });
+  });
+
+  it("absent flags: a plain prompt is unaffected (no selection flag present)", () => {
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "build", "a", "game"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({ kind: "bootTUI", args: { initialPrompt: "build a game" } });
+  });
+
+  it("prompt text: a positional word like 'model' is not a flag token", () => {
+    // Only a real leading `--model` flag token triggers the guard — a prompt
+    // that merely contains the word must boot the TUI with that text intact.
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "pick", "a", "model", "for", "me"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "bootTUI",
+      args: { initialPrompt: "pick a model for me" },
+    });
+  });
+});
+
 describe("signal handler integration with activeInkUnmount", () => {
   afterEach(() => {
     __resetActiveInkUnmountForTest();


### PR DESCRIPTION
Autonomous discover→verify→fix iteration 5. Both gated (typecheck + 13149 tests + build), independently reviewed (the delivery-queue fix via a 3-skeptic panel that caught and forced correction of a data-loss regression in the first attempt), each with revert-sensitive tests.

- **MED** bound the attached-client event delivery queue + evict slow consumers — a stalled client previously pinned daemon heap without limit. Replay path bypasses the cap (no false eviction / no data loss); teardown scoped so healthy co-located clients survive.
- **MED** error when --model/--provider/--profile/--image are given without a value (were silently swallowed, booting on defaults)

Counts trended [5,3,5,9,4,2] across iterations 0-5.