### PR TITLE
tui visual/ux iter 1: workspace-tree truncation + title-bar debug leak

### DIFF
--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -76,7 +76,7 @@ export function WorkbenchLayout({
 
   return (
     <Box flexDirection="column" width="100%" height={rows} overflow="hidden">
-      {rows >= 8 ? <WorkbenchStatusBar columns={columns} /> : null}
+      {rows >= 8 ? <WorkbenchStatusBar /> : null}
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
         {showExplorer ? (
           <NoSelect flexShrink={0} width={explorerWidth} height="100%">

--- a/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
+++ b/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
@@ -3,18 +3,13 @@ import React from "react";
 import { Box, Text } from "../ink.js";
 import { useWorkbenchState } from "./state.js";
 
-export function WorkbenchStatusBar({
-  columns,
-}: {
-  readonly columns: number;
-}): React.ReactElement {
+export function WorkbenchStatusBar(): React.ReactElement {
   const workbench = useWorkbenchState();
   const active = workbench.activeFilePath ?? workbench.activeSurfaceMode;
   return (
     <Box height={1} width="100%">
       <Text color="text2" wrap="truncate-end">AgenC Workbench</Text>
       <Text dimColor wrap="truncate-end"> | {active}</Text>
-      <Text dimColor wrap="truncate-end"> | {columns} cols</Text>
     </Box>
   );
 }

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -217,7 +217,7 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
             <Text dimColor wrap="truncate-end">{glyphs.arrowUp} {viewport.above} more</Text>
           </Box>
         ) : null}
-        {visibleRows.map((row) => <ProjectExplorerRow key={row.id} row={row} width={Math.max(8, width - 2)} />)}
+        {visibleRows.map((row) => <ProjectExplorerRow key={row.id} row={row} width={Math.max(8, width - 3)} />)}
         {viewport.below > 0 ? (
           <Box height={1} flexShrink={0}>
             <Text dimColor wrap="truncate-end">{glyphs.arrowDown} {viewport.below} more</Text>
@@ -415,7 +415,7 @@ function colorForRow(row: ProjectTreeRow): string | undefined {
 function trim(value: string, width: number): string {
   if (stringWidth(value) <= width) return value;
   if (width <= 1) return value.slice(0, width);
-  const suffix = "...";
+  const suffix = selectAgenCTuiGlyphs().ellipsis;
   const maxWidth = Math.max(0, width - stringWidth(suffix));
   let output = "";
   let used = 0;

--- a/runtime/tests/tui/workbench/project-explorer-row-truncation.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-row-truncation.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Render the WORKSPACE project-tree pane and assert its rows do not pick up a
+// spurious truncation ellipsis. Two regressions are guarded here:
+//   1. Off-by-one row width — the container reserves paddingX(2) + borderRight(1)
+//      = 3 columns of chrome, so a short filename row that obviously fits must
+//      NOT be stamped with a trailing "…" by Ink's wrap="truncate-end".
+//   2. Doubled ellipsis — a too-long filename must end in exactly ONE "…", not
+//      the "..…" produced when a hardcoded "..." suffix collided with the
+//      truncation marker.
+
+const harness = vi.hoisted(() => {
+  const state: { snapshot: Record<string, unknown>; store: Record<string, unknown> } = {
+    snapshot: {},
+    store: {},
+  };
+  state.store = {
+    setActivePath: () => {},
+    setAttachedPaths: () => {},
+    setViewportRows: () => {},
+    setInFlightPaths: () => {},
+    move: () => {},
+    movePage: () => {},
+    moveToStart: () => {},
+    moveToEnd: () => {},
+    expand: () => {},
+    collapse: () => {},
+    reveal: () => {},
+    toggle: () => {},
+    getCursorRow: () => null,
+    createFile: async () => ({ ok: true, path: "" }),
+    renamePath: async () => ({ ok: true, path: "" }),
+    deletePath: async () => ({ ok: true, path: "" }),
+  };
+  return state;
+});
+
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: 120, rows: 24 }),
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: () => {},
+}));
+
+vi.mock("../../../src/tui/components/TextInput.js", async () => {
+  const ReactModule = await import("react");
+  return { default: () => ReactModule.createElement(ReactModule.Fragment) };
+});
+
+vi.mock("../../../src/tui/workbench/project-tree/useProjectTree.js", () => ({
+  useProjectTree: () => harness.snapshot,
+}));
+
+vi.mock("../../../src/tui/workbench/project-tree/ProjectTreeStore.js", () => ({
+  getProjectTreeStore: () => harness.store,
+}));
+
+vi.mock("../../../src/utils/log.js", () => ({ logError: () => {} }));
+
+import { renderToString } from "../../../src/utils/staticRender.js";
+import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { ProjectExplorer } from "../../../src/tui/workbench/project-tree/ProjectExplorer.js";
+
+function fileRow(path: string, label: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: path,
+    path,
+    label,
+    kind: "file",
+    depth: 1,
+    expanded: false,
+    selected: false,
+    focused: false,
+    active: false,
+    attached: false,
+    searchHit: false,
+    inFlight: false,
+    ...overrides,
+  };
+}
+
+async function renderTree(width: number): Promise<string[]> {
+  const output = await renderToString(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        workbench: {
+          ...getDefaultAppState().workbench,
+          focusedPane: "explorer",
+        },
+      }}
+    >
+      <ProjectExplorer focused={false} width={width} />
+    </AppStateProvider>,
+    { columns: 200, rows: 24 },
+  );
+  return output.split("\n");
+}
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+describe("ProjectExplorer row truncation", () => {
+  beforeEach(() => {
+    // Force unicode glyphs so the ellipsis marker is the single-cell "…".
+    delete process.env.AGENC_TUI_GLYPHS;
+  });
+
+  afterEach(() => {
+    if (previousGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = previousGlyphMode;
+    }
+  });
+
+  it("does not stamp a trailing ellipsis on short filename rows that fit", async () => {
+    harness.snapshot = {
+      cwd: "/repo",
+      loading: false,
+      error: null,
+      cursorPath: null,
+      activePath: null,
+      expandedPaths: [],
+      rows: [
+        fileRow("LICENSE", "LICENSE"),
+        fileRow("tsconfig.json", "tsconfig.json"),
+      ],
+    };
+
+    const lines = await renderTree(40);
+    const licenseLine = lines.find((line) => line.includes("LICENSE"));
+    const tsconfigLine = lines.find((line) => line.includes("tsconfig.json"));
+
+    expect(licenseLine).toBeDefined();
+    expect(tsconfigLine).toBeDefined();
+    // A name that clearly fits must render without any truncation marker.
+    expect(licenseLine).not.toContain("…");
+    expect(licenseLine).not.toContain("...");
+    expect(tsconfigLine).not.toContain("…");
+    expect(tsconfigLine).not.toContain("...");
+  });
+
+  it("truncates a long filename with exactly one ellipsis, never a doubled marker", async () => {
+    const longLabel = ".typecheck-baseline-really-long-overflowing-filename.json";
+    harness.snapshot = {
+      cwd: "/repo",
+      loading: false,
+      error: null,
+      cursorPath: null,
+      activePath: null,
+      expandedPaths: [],
+      rows: [fileRow(longLabel, longLabel)],
+    };
+
+    const lines = await renderTree(28);
+    const longLine = lines.find((line) => line.includes(".typecheck"));
+
+    expect(longLine).toBeDefined();
+    const line = longLine ?? "";
+    // The name overflows, so it must be truncated — exactly one ellipsis.
+    expect(line).toContain("…");
+    expect((line.match(/…/gu) ?? []).length).toBe(1);
+    // The doubled-ellipsis regression rendered "..…"; that must never appear.
+    expect(line).not.toContain("..…");
+    expect(line).not.toContain("...");
+  });
+});

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -38,6 +38,7 @@ import { useWorkbenchComposerFocus } from "../../../src/tui/workbench/composerFo
 import { WORKBENCH_SURFACES } from "../../../src/tui/workbench/surfaces/ActiveWorkSurface.js";
 import { TranscriptSurface } from "../../../src/tui/workbench/surfaces/TranscriptSurface.js";
 import { WorkbenchFooter } from "../../../src/tui/workbench/WorkbenchFooter.js";
+import { WorkbenchStatusBar } from "../../../src/tui/workbench/WorkbenchStatusBar.js";
 import { layoutSizeForColumns, WorkbenchLayout } from "../../../src/tui/workbench/WorkbenchLayout.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
@@ -706,6 +707,22 @@ describe("workbench render contract", () => {
     const source = readFileSync("src/tui/components/FullscreenLayout.tsx", "utf8");
 
     expect(source).not.toMatch(/readdirSync|getWorkspaceFileTreeRows|WorkspaceFileTreeGutter/u);
+  });
+
+  it("renders the workbench title bar without leaking the viewport column count", async () => {
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <WorkbenchStatusBar />
+      </AppStateProvider>,
+      120,
+    );
+
+    // Title bar shows the product name and active surface...
+    expect(output).toContain("AgenC Workbench");
+    expect(output).toContain("transcript");
+    // ...but must NOT surface the live terminal width as a debug-style segment.
+    expect(output).not.toMatch(/\d+\s+cols/u);
+    expect(output).not.toContain("cols");
   });
 });
 


### PR DESCRIPTION
First iteration of the TUI visual/UX QA loop (drive the real TUI on an isolated tmux socket, capture frames, fix, verify with before/after frames). Both fixes verified live + full suite (13152) + no new TUI-smoke failures.

- workspace file-tree: every row got a spurious trailing ellipsis (off-by-one width) and long names showed a doubled '..…'. Verified live: spurious trailing ellipses 15 rows -> 0; '..…' -> single '…'.
- workbench title bar: removed the unconditional '| N cols' debug-width leak.

23 visual/UX defects were confirmed this round; the rest (notably a badly broken approval dialog that overlaps the footer) flow into iteration 2.