### PR TITLE
tui visual iter 4: slash popup alignment + picker clarity

### DIFF
--- a/runtime/src/commands/agent-management.tsx
+++ b/runtime/src/commands/agent-management.tsx
@@ -17,7 +17,7 @@ import { openAgentsMenu } from "./agents-menu.js";
 
 export const agentsCommand: SlashCommand = {
   name: "agents",
-  description: "Manage agent configurations",
+  description: "Manage agents — opens a picker",
   immediate: true,
   execute: (ctx: SlashCommandContext): Promise<SlashCommandResult> =>
     safeExecute(async () => {

--- a/runtime/src/commands/config.ts
+++ b/runtime/src/commands/config.ts
@@ -390,7 +390,7 @@ export function createConfigCommand(deps: ConfigCommandDeps = {}): SlashCommand 
   return {
     name: "config",
     aliases: ["settings"],
-    description: "Show or manage configuration",
+    description: "Manage configuration — opens a picker",
     immediate: true,
     userInvocable: true,
     execute: (ctx: SlashCommandContext): Promise<SlashCommandResult> =>

--- a/runtime/src/commands/model.ts
+++ b/runtime/src/commands/model.ts
@@ -283,7 +283,7 @@ function updateModelChrome(
 
 export const modelCommand: SlashCommand = {
   name: "model",
-  description: "Switch the model for subsequent turns",
+  description: "Switch the model — opens a picker (or pass a model name)",
   supportedSurfaces: ["runtime", "daemon-tui"],
   userInvocable: true,
   immediate: true,

--- a/runtime/src/tui/components/PromptInput/PromptInputFooterSuggestions.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputFooterSuggestions.tsx
@@ -28,7 +28,13 @@ export type SuggestionType =
 export const OVERLAY_MAX_ITEMS = 5
 
 export function getSuggestionPopupWidth(columns: number, overlay?: boolean): number {
-  return overlay ? Math.max(1, columns - 2) : Math.max(1, columns - 10)
+  // In overlay (fullscreen/workbench) mode the popup floats directly above the
+  // composer box, which spans the full terminal width (width="100%"). The popup
+  // therefore takes the full width too — with no horizontal margin — so its
+  // border corners line up with the composer's border corners below it. Any
+  // inset here makes the popup look misaligned with the composer.
+  // Inline mode floats inside a paddingX={2} wrapper, so it stays narrower.
+  return overlay ? Math.max(1, columns) : Math.max(1, columns - 10)
 }
 
 function padToWidth(text: string, width: number): string {
@@ -302,7 +308,7 @@ export function PromptInputFooterSuggestions({
       flexDirection="column"
       justifyContent={overlay ? undefined : 'flex-end'}
       width={width}
-      marginX={1}
+      marginX={overlay ? 0 : 1}
       borderStyle="single"
       borderColor="agenc"
       paddingX={1}

--- a/runtime/tests/tui/components/PromptInput/PromptInputFooterSuggestions.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputFooterSuggestions.test.tsx
@@ -138,9 +138,59 @@ describe('PromptInputFooterSuggestions', () => {
     expect(output).not.toContain('SLASH COMMANDS')
   })
 
-  it('uses full overlay width so the popup background can cover the overlay row', () => {
-    expect(getSuggestionPopupWidth(80, true)).toBe(78)
-    expect(getSuggestionPopupWidth(12, true)).toBe(10)
+  it('uses the full terminal width in overlay mode so the popup aligns with the composer', () => {
+    // The overlay popup floats directly above the composer box, which is
+    // width="100%". Matching that full width (with no horizontal margin) keeps
+    // the popup border corners flush with the composer border corners below.
+    expect(getSuggestionPopupWidth(80, true)).toBe(80)
+    expect(getSuggestionPopupWidth(12, true)).toBe(12)
+  })
+
+  it('aligns the overlay popup border corners with its content rows', async () => {
+    // Revert-sensitive guard for the inset-border bug: when the overlay popup
+    // used `columns - 2` width plus `marginX={1}`, the box drew at columns 1..N-2
+    // while the composer below spanned 0..N-1, so the popup looked inset and
+    // off-centre. The corners (┌┐└┘) and the content-row bars (│) must share
+    // the same left/right columns AND span the full terminal width.
+    const columns = 80
+    const suggestions: SuggestionItem[] = [
+      {
+        id: 'command-help',
+        displayText: '/help',
+        description: 'Show help and available commands',
+      },
+    ]
+
+    const output = await renderToString(
+      <PromptInputFooterSuggestions
+        suggestions={suggestions}
+        selectedSuggestion={0}
+        overlay={true}
+      />,
+      columns,
+    )
+
+    const lines = output.split('\n').filter(line => /[┌┐└┘│]/.test(line))
+    expect(lines.length).toBeGreaterThanOrEqual(3)
+
+    const leftCols = new Set<number>()
+    const rightCols = new Set<number>()
+    for (const line of lines) {
+      // Box-drawing chars on a row: leftmost border and rightmost border.
+      const left = line.search(/[┌└│]/)
+      const right = line.length - 1 - [...line].reverse().findIndex(c => '┐┘│'.includes(c))
+      leftCols.add(left)
+      rightCols.add(right)
+    }
+
+    // Every bordered row (top corner, content bars, bottom corner) shares the
+    // same left edge and the same right edge — no inset content rows.
+    expect(leftCols.size).toBe(1)
+    expect(rightCols.size).toBe(1)
+    // And the popup spans the full terminal width so it lines up with the
+    // composer box below it (left edge at column 0).
+    expect([...leftCols][0]).toBe(0)
+    expect([...rightCols][0]).toBe(columns - 1)
   })
 
   it('clamps inline popup width to tiny terminals instead of forcing the old minimum', () => {

--- a/runtime/tests/tui/components/PromptInput/slashCommandSuggestions.test.ts
+++ b/runtime/tests/tui/components/PromptInput/slashCommandSuggestions.test.ts
@@ -64,6 +64,35 @@ describe("slash command suggestions", () => {
     ]);
   });
 
+  it("lists every available command when only '/' is typed so they can be browsed", () => {
+    // Discoverability: typing a bare '/' must surface the full, browsable
+    // command list (not a single match), so a user who doesn't know the
+    // prefix can scroll through everything. The typeahead then narrows the
+    // same list as they keep typing.
+    const commands = [
+      localCommand({ name: "help", description: "Show help" }),
+      localCommand({ name: "clear", description: "Clear session history" }),
+      localCommand({ name: "compact", description: "Compact the conversation" }),
+      localCommand({ name: "config", description: "Manage configuration" }),
+      localCommand({ name: "model", description: "Switch the model" }),
+    ];
+
+    const all = generateCommandSuggestions("/", commands);
+    expect(all.length).toBe(commands.length);
+    const names = all.map((s) => s.displayText);
+    for (const cmd of commands) {
+      expect(names).toContain(`/${cmd.name}`);
+    }
+
+    // And the same list narrows as the user types more of a prefix.
+    const narrowed = generateCommandSuggestions("/co", commands);
+    expect(narrowed.length).toBeLessThan(all.length);
+    expect(narrowed.length).toBeGreaterThan(1);
+    expect(narrowed.map((s) => s.displayText)).toEqual(
+      expect.arrayContaining(["/compact", "/config"]),
+    );
+  });
+
   it("marks protocol extension commands with the protocol glyph", () => {
     const suggestions = generateCommandSuggestions("/", getCommandsSync());
     const byName = new Map(


### PR DESCRIPTION
Slash-command suggestion popup now sits flush with the composer (was inset 1 col / 2 narrower). Picker descriptions clarified ('opens a picker'). Confirmed + test-locked that typing '/' lists all commands browsably. Verified live; revert-sensitive tests; full suite 13174.