### PR TITLE
tui visual iter 5: workbench layout polish

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -684,6 +684,34 @@ function defaultWorkspaceLabel(): string {
   return home && cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd
 }
 
+// Welcome summary/recent cards used to be fixed shrink-to-content boxes, so the
+// two cards rendered at mismatched widths and left a jarring empty band on the
+// right of a wide transcript pane. They now share one width that grows with the
+// available pane up to a tasteful cap. MIN keeps the widest default recent row
+// (`[1] swap-program · 12m ago · main · clean`, plus border + padding) from
+// truncating; MAX stops them from stretching absurdly wide on a 200-col
+// terminal.
+const WELCOME_CARD_MIN_WIDTH = 46
+const WELCOME_CARD_MAX_WIDTH = 64
+// The transcript surface (ActiveWorkSurface) adds paddingX={1} around the
+// welcome panel, so reserve 2 columns from the reported content width to avoid
+// overflowing the pane.
+const WELCOME_CARD_INSET = 2
+
+function useWelcomeCardWidth(): number {
+  const contentWidth = useContentWidth()
+  const frameColumns = React.useContext(TerminalFrameColumnsContext)
+  const available = contentWidth ?? frameColumns
+  const usable = Math.max(1, available - WELCOME_CARD_INSET)
+  const capped = Math.min(
+    WELCOME_CARD_MAX_WIDTH,
+    Math.max(WELCOME_CARD_MIN_WIDTH, usable),
+  )
+  // Never exceed the usable width — on a very narrow pane the cap floor would
+  // otherwise overflow.
+  return Math.min(capped, usable)
+}
+
 function WelcomeMetaRow({
   label,
   value,
@@ -713,6 +741,7 @@ export function WelcomeColdPanel({
   readonly recentSessions?: readonly WelcomeRecentSession[]
 }): React.ReactNode {
   const visibleSessions = recentSessions.slice(0, 3)
+  const cardWidth = useWelcomeCardWidth()
   return (
     <Box flexDirection="column" gap={1}>
       <Box flexDirection="column">
@@ -726,6 +755,7 @@ export function WelcomeColdPanel({
 
       <ThemedBox
         flexDirection="column"
+        width={cardWidth}
         borderStyle="single"
         borderColor="lineSoft"
         paddingX={1}
@@ -751,6 +781,7 @@ export function WelcomeColdPanel({
         </Box>
         <ThemedBox
           flexDirection="column"
+          width={cardWidth}
           borderStyle="single"
           borderColor="lineSoft"
           paddingX={1}

--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -10,7 +10,11 @@ export function WorkbenchFooter(): React.ReactElement {
   const hints = hintsForPane(visibleWorkbenchPane(workbench), workbench.activeSurfaceMode);
   const composerAttachments = composerAttachmentsForState(workbench);
   return (
-    <Box height={1} width="100%">
+    // paddingX={2} matches the composer's own footer hint inset
+    // (PromptInputFooter), so the stacked "? for shortcuts" line and this
+    // surface-hint line share a consistent left margin instead of one being
+    // indented two columns and the other flush at column 0.
+    <Box height={1} width="100%" paddingX={2}>
       <Text dimColor wrap="truncate-end">{hints}</Text>
       {composerAttachments.length > 0 ? (
         <Text color="suggestion" wrap="truncate-end"> | context {composerAttachments.map((item) => item.label).join(", ")}</Text>

--- a/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
+++ b/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
@@ -12,7 +12,12 @@ export function WorkbenchStatusBar({
   readonly activityMode?: SpinnerMode | null;
 } = {}): React.ReactElement {
   const workbench = useWorkbenchState();
-  const active = workbench.activeFilePath ?? workbench.activeSurfaceMode;
+  // Show the active file path when one is open (preview/buffer); otherwise show
+  // the surface name. Uppercase the surface name so the title-bar label matches
+  // the pane-header casing (e.g. "TRANSCRIPT", not lowercase "transcript") —
+  // the descriptors in ActiveWorkSurface render the same uppercase titles. The
+  // file-path branch is left untouched so file labels keep their real casing.
+  const active = workbench.activeFilePath ?? workbench.activeSurfaceMode.toUpperCase();
   return (
     <Box height={1} width="100%" flexDirection="row">
       <Text color="text2" wrap="truncate-end">AgenC Workbench</Text>

--- a/runtime/tests/tui/components/v2/welcomeColdPanel.cards.test.tsx
+++ b/runtime/tests/tui/components/v2/welcomeColdPanel.cards.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { ContentWidthProvider } from '../../../../src/tui/context/contentWidthContext.js'
+import { renderToString } from '../../../utils/staticRender.js'
+import { WelcomeColdPanel } from '../../../../src/tui/components/v2/primitives.js'
+
+// Regression for the cold-start workbench welcome layout: the "workspace"
+// summary card and the "recent" card used to be fixed shrink-to-content boxes,
+// so (a) they rendered at MISMATCHED widths (~40 vs ~45 cols) and (b) neither
+// grew with a wide transcript pane, leaving a jarring empty band on the right.
+// They now share one width that grows with the available pane up to a tasteful
+// cap. These tests are revert-sensitive against re-introducing the tiny fixed
+// width: reverting the `width={cardWidth}` props (so the boxes shrink to their
+// own content again) makes the equal-width and grow-to-cap assertions fail.
+
+const CARD_BORDER = /^[┌└][─]+[┐┘]$/u
+
+function cardWidths(output: string): readonly number[] {
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter((line) => CARD_BORDER.test(line))
+    .map((line) => [...line].length)
+}
+
+describe('WelcomeColdPanel summary/recent cards', () => {
+  it('renders both cards at the SAME width', async () => {
+    const output = await renderToString(
+      <ContentWidthProvider width={92}>
+        <WelcomeColdPanel />
+      </ContentWidthProvider>,
+      { columns: 120, rows: 40 },
+    )
+
+    const widths = cardWidths(output)
+    // Two cards, each contributing a top + bottom border line.
+    expect(widths.length).toBe(4)
+    expect(new Set(widths).size).toBe(1)
+  })
+
+  it('grows the cards with the pane up to the tasteful cap on a wide pane', async () => {
+    const output = await renderToString(
+      <ContentWidthProvider width={92}>
+        <WelcomeColdPanel />
+      </ContentWidthProvider>,
+      { columns: 120, rows: 40 },
+    )
+
+    const widths = cardWidths(output)
+    const width = widths[0]!
+    // Caps at 64 instead of stretching to fill the ~92-col pane, but is far
+    // wider than the old ~40/45 fixed boxes — the regression we are guarding.
+    expect(width).toBe(64)
+    expect(widths.every((value) => value === width)).toBe(true)
+  })
+
+  it('uses the available pane width when it is below the cap', async () => {
+    const output = await renderToString(
+      <ContentWidthProvider width={50}>
+        <WelcomeColdPanel />
+      </ContentWidthProvider>,
+      { columns: 80, rows: 40 },
+    )
+
+    const widths = cardWidths(output)
+    expect(widths.length).toBe(4)
+    expect(new Set(widths).size).toBe(1)
+    // Tracks the pane (50 - 2 inset) rather than a fixed tiny value, and stays
+    // below the cap.
+    expect(widths[0]).toBe(48)
+  })
+
+  it('never overflows a very narrow pane', async () => {
+    const paneWidth = 40
+    const output = await renderToString(
+      <ContentWidthProvider width={paneWidth}>
+        <WelcomeColdPanel />
+      </ContentWidthProvider>,
+      { columns: 80, rows: 40 },
+    )
+
+    const widths = cardWidths(output)
+    expect(new Set(widths).size).toBe(1)
+    // Clamped to the usable pane width (paneWidth - 2 inset) so the border never
+    // spills past the transcript surface padding.
+    expect(widths[0]).toBeLessThanOrEqual(paneWidth - 2)
+  })
+
+  it('falls back to a capped width when no content-width provider is present', async () => {
+    const output = await renderToString(<WelcomeColdPanel />, {
+      columns: 120,
+      rows: 40,
+    })
+
+    const widths = cardWidths(output)
+    expect(widths.length).toBe(4)
+    expect(new Set(widths).size).toBe(1)
+    expect(widths[0]).toBe(64)
+  })
+})

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -476,6 +476,29 @@ describe("workbench render contract", () => {
     expect(output).not.toContain("src/stale.ts");
   });
 
+  it("indents the surface-hint footer line to match the composer footer", async () => {
+    // The composer's own "? for shortcuts" hint is rendered inside a
+    // paddingX={2} box (PromptInputFooter). The workbench surface-hint line
+    // used to render flush at column 0, so the two stacked footer lines had
+    // mismatched left margins. WorkbenchFooter now shares the same 2-column
+    // inset. Revert-sensitive: dropping paddingX={2} from WorkbenchFooter makes
+    // the leading-space assertion fail.
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <WorkbenchFooter />
+      </AppStateProvider>,
+      120,
+    );
+
+    const hintLine = output
+      .split(/\r?\n/u)
+      .find((line) => line.includes("Composer: write prompt"));
+
+    expect(hintLine).toBeDefined();
+    expect(hintLine).toMatch(/^ {2}\S/u);
+    expect(hintLine?.startsWith("Composer:")).toBe(false);
+  });
+
   it.each([
     [148, "wide"],
     [120, "medium"],
@@ -738,9 +761,12 @@ describe("workbench render contract", () => {
       120,
     );
 
-    // Title bar shows the product name and active surface...
+    // Title bar shows the product name and active surface. The surface label
+    // uses the same uppercase casing as the pane header ("TRANSCRIPT"), not the
+    // lowercase surface-mode id, so the two render sites stay consistent.
     expect(output).toContain("AgenC Workbench");
-    expect(output).toContain("transcript");
+    expect(output).toContain("TRANSCRIPT");
+    expect(output).not.toContain("| transcript");
     // ...but must NOT surface the live terminal width as a debug-style segment.
     expect(output).not.toMatch(/\d+\s+cols/u);
     expect(output).not.toContain("cols");


### PR DESCRIPTION
Equal-width welcome cards that grow to a 64-col cap (was mismatched ~40/45 with a big gutter), aligned the two-line footer indent, and made the title-bar casing match the pane header (TRANSCRIPT). Verified live; revert-sensitive tests; full suite 13180.