### PR TITLE
tui visual iter 6: persistent context strip (model · mode · cwd)

### DIFF
--- a/runtime/src/tui/workbench/WorkbenchContextStrip.tsx
+++ b/runtime/src/tui/workbench/WorkbenchContextStrip.tsx
@@ -1,0 +1,237 @@
+import { homedir } from "node:os";
+import { sep as pathSep } from "node:path";
+
+import React from "react";
+
+import { Box, Text } from "../ink.js";
+import { useAppStateMaybeOutsideOfProvider } from "../state/AppState.js";
+import type { AppState } from "../state/AppStateStore.js";
+import {
+  getDefaultMainLoopModelSetting,
+  parseUserSpecifiedModel,
+  renderModelName,
+} from "../../utils/model/model.js";
+import { getCwdState, getOriginalCwd } from "../../bootstrap/state.js";
+import { permissionModeShortTitle } from "../../permissions/mode-display.js";
+import type { PermissionMode } from "../../permissions/types.js";
+
+/**
+ * Compact, always-visible session-context strip for the workbench status bar.
+ *
+ * Once a user leaves the welcome screen the summary box (model + workspace)
+ * disappears, leaving no persistent indicator of which MODEL is active, the
+ * current PERMISSION MODE, or the working directory. This strip restores that
+ * always-on context: `model · permission-mode · cwd`.
+ *
+ * Safety: an elevated/dangerous permission mode (bypassPermissions / unattended
+ * / dontAsk / auto) is rendered in the warning color so it stands out — being
+ * able to always see when you are in a bypass mode is safety-relevant.
+ *
+ * Width discipline: the strip never overflows the status-bar row. The caller
+ * passes the columns available after the left-hand label so we can budget the
+ * remaining space and degrade gracefully — drop cwd first, then the permission
+ * detail, always keeping the model. If nothing fits, render nothing.
+ *
+ * State sources:
+ *  - model: app-state main-loop model setting (selectModelSetting), resolved
+ *    via parseUserSpecifiedModel + renderModelName. Read directly rather than
+ *    via useMainLoopModel, whose extra refresh-signal re-render placeholder is
+ *    unnecessary here.
+ *  - permission mode: app-state toolPermissionContext.mode.
+ *  - cwd: the stable session working directory (getCwdState), NOT getCwd().
+ *    getCwd() consults a per-async-context AsyncLocalStorage override used by
+ *    concurrent agents; the session status strip must show the session's own
+ *    directory, and reading the stable global avoids width-reflow churn when an
+ *    override scope enters/exits between renders.
+ */
+
+/** Permission modes that grant elevated/auto authority — shown in warning style. */
+const DANGEROUS_PERMISSION_MODES: ReadonlySet<PermissionMode> = new Set<PermissionMode>([
+  "bypassPermissions",
+  "unattended",
+  "dontAsk",
+  "auto",
+]);
+
+export function isDangerousPermissionMode(mode: PermissionMode): boolean {
+  return DANGEROUS_PERMISSION_MODES.has(mode);
+}
+
+/** Join with the same middle-dot separator the rest of the chrome uses. */
+const SEP = " · ";
+
+/**
+ * Resolve a compact, display-friendly working directory: home-relativized to
+ * `~` and, when still long, reduced to its basename. Never the full long path.
+ */
+export function compactCwd(cwd: string, home: string = homedir()): string {
+  const normalizedHome = home.replace(/[/\\]+$/u, "");
+  let display = cwd;
+  if (
+    normalizedHome.length > 0 &&
+    (cwd === normalizedHome || cwd.startsWith(normalizedHome + pathSep))
+  ) {
+    display = "~" + cwd.slice(normalizedHome.length);
+  }
+  // Normalize a trailing slash for display.
+  display = display.replace(/[/\\]+$/u, "");
+  if (display === "") return "/";
+  return display;
+}
+
+/** Basename of a (possibly already home-relativized) path, for tight widths. */
+export function basenameOf(displayPath: string): string {
+  const parts = displayPath.split(/[/\\]+/u).filter((part) => part.length > 0);
+  const last = parts.at(-1);
+  return last ?? displayPath;
+}
+
+/** Stable session working directory, ignoring per-async-context overrides. */
+function sessionCwd(): string {
+  try {
+    return getCwdState();
+  } catch {
+    return getOriginalCwd();
+  }
+}
+
+type StripParts = {
+  readonly model: string;
+  readonly modeLabel: string;
+  readonly cwd: string;
+  readonly cwdBasename: string;
+};
+
+/**
+ * Compute which parts of the strip fit within `available` columns, degrading
+ * in priority order: full → cwd-to-basename → drop cwd → drop mode → model only
+ * → hard-truncated model. Returns the chosen segments so the renderer and tests
+ * share one source of truth.
+ */
+export function selectStripSegments(
+  parts: StripParts,
+  available: number,
+): {
+  readonly model: string;
+  readonly modeLabel: string | null;
+  readonly cwd: string | null;
+} | null {
+  if (available <= 0) return null;
+
+  const width = (
+    model: string,
+    modeLabel: string | null,
+    cwd: string | null,
+  ): number => {
+    let w = model.length;
+    if (modeLabel !== null) w += SEP.length + modeLabel.length;
+    if (cwd !== null) w += SEP.length + cwd.length;
+    return w;
+  };
+
+  // Candidates in descending richness; first that fits wins.
+  const candidates: ReadonlyArray<{
+    readonly model: string;
+    readonly modeLabel: string | null;
+    readonly cwd: string | null;
+  }> = [
+    { model: parts.model, modeLabel: parts.modeLabel, cwd: parts.cwd },
+    { model: parts.model, modeLabel: parts.modeLabel, cwd: parts.cwdBasename },
+    { model: parts.model, modeLabel: parts.modeLabel, cwd: null },
+    { model: parts.model, modeLabel: parts.modeLabel.length > 0 ? parts.modeLabel : null, cwd: null },
+    { model: parts.model, modeLabel: null, cwd: null },
+  ];
+
+  for (const candidate of candidates) {
+    if (width(candidate.model, candidate.modeLabel, candidate.cwd) <= available) {
+      return candidate;
+    }
+  }
+
+  // Even the model alone does not fit: hard-truncate the model so we still show
+  // *something* (the most important value) rather than overflowing the row.
+  if (parts.model.length > 0) {
+    const truncated =
+      available <= 1
+        ? parts.model.slice(0, available)
+        : parts.model.slice(0, Math.max(1, available - 1)) + "…";
+    return { model: truncated, modeLabel: null, cwd: null };
+  }
+  return null;
+}
+
+function selectMode(state: AppState): PermissionMode {
+  return (state.toolPermissionContext?.mode ?? "default") as PermissionMode;
+}
+
+/**
+ * The active main-loop model setting, mirroring useMainLoopModel's source
+ * (mainLoopModelForSession ?? mainLoopModel ?? default), selected directly so
+ * this strip subscribes to a plain string without useMainLoopModel's extra
+ * refresh-signal re-render placeholder.
+ */
+function selectModelSetting(state: AppState): string {
+  return (
+    state.mainLoopModelForSession ??
+    state.mainLoopModel ??
+    getDefaultMainLoopModelSetting()
+  );
+}
+
+export function WorkbenchContextStrip({
+  /**
+   * Columns available for this strip on the status-bar row (the row width minus
+   * whatever the left-hand label + activity indicator already consumed). Drives
+   * graceful degradation so the strip never overflows the row.
+   */
+  available,
+}: {
+  readonly available: number;
+}): React.ReactElement | null {
+  const modelSetting =
+    useAppStateMaybeOutsideOfProvider(selectModelSetting) ??
+    getDefaultMainLoopModelSetting();
+  const mode = useAppStateMaybeOutsideOfProvider(selectMode) ?? "default";
+
+  const modelLabel = renderModelName(parseUserSpecifiedModel(modelSetting));
+  const modeLabel = permissionModeShortTitle(mode).toLowerCase();
+  const dangerous = isDangerousPermissionMode(mode);
+  const cwdDisplay = compactCwd(sessionCwd());
+
+  const segments = selectStripSegments(
+    {
+      model: modelLabel,
+      modeLabel,
+      cwd: cwdDisplay,
+      cwdBasename: basenameOf(cwdDisplay),
+    },
+    available,
+  );
+
+  if (segments === null) return null;
+
+  // Normal modes render dim; dangerous/elevated modes render in the warning
+  // color (and bold) so the safety-relevant state is always visible at a glance.
+  const modeColor = dangerous ? "warning" : undefined;
+
+  return (
+    <Box flexShrink={0} flexDirection="row">
+      <Text dimColor wrap="truncate-end">{SEP}</Text>
+      <Text color="text2" wrap="truncate-end">{segments.model}</Text>
+      {segments.modeLabel !== null ? (
+        <>
+          <Text dimColor wrap="truncate-end">{SEP}</Text>
+          <Text color={modeColor} dimColor={!dangerous} bold={dangerous} wrap="truncate-end">
+            {segments.modeLabel}
+          </Text>
+        </>
+      ) : null}
+      {segments.cwd !== null ? (
+        <>
+          <Text dimColor wrap="truncate-end">{SEP}</Text>
+          <Text dimColor wrap="truncate-end">{segments.cwd}</Text>
+        </>
+      ) : null}
+    </Box>
+  );
+}

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -90,7 +90,7 @@ export function WorkbenchLayout({
 
   return (
     <Box flexDirection="column" width="100%" height={rows} overflow="hidden">
-      {rows >= 8 ? <WorkbenchStatusBar activityMode={activityMode} /> : null}
+      {rows >= 8 ? <WorkbenchStatusBar activityMode={activityMode} columns={columns} /> : null}
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
         {showExplorer ? (
           <NoSelect flexShrink={0} width={explorerWidth} height="100%">

--- a/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
+++ b/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
@@ -3,13 +3,22 @@ import React from "react";
 import { Box, Text } from "../ink.js";
 import type { SpinnerMode } from "../components/spinner/types.js";
 import { WorkbenchActivityIndicator } from "./WorkbenchActivityIndicator.js";
+import { WorkbenchContextStrip } from "./WorkbenchContextStrip.js";
 import { useWorkbenchState } from "./state.js";
 
 export function WorkbenchStatusBar({
   activityMode = null,
+  columns,
 }: {
   /** Current streaming phase, or null when idle. Drives the working indicator. */
   readonly activityMode?: SpinnerMode | null;
+  /**
+   * Full status-bar row width (terminal columns). Lets the right-hand context
+   * strip budget its remaining space so it degrades gracefully instead of
+   * overflowing the row. Omitted in tiny/unknown-width contexts, where the
+   * strip is hidden.
+   */
+  readonly columns?: number;
 } = {}): React.ReactElement {
   const workbench = useWorkbenchState();
   // Show the active file path when one is open (preview/buffer); otherwise show
@@ -18,11 +27,19 @@ export function WorkbenchStatusBar({
   // the descriptors in ActiveWorkSurface render the same uppercase titles. The
   // file-path branch is left untouched so file labels keep their real casing.
   const active = workbench.activeFilePath ?? workbench.activeSurfaceMode.toUpperCase();
+  // Reserve the columns the fixed left label consumes ("AgenC Workbench | <x>")
+  // plus a small gutter, so the context strip only claims what is actually left
+  // over and never collides with the title or overflows the row.
+  const leftLabelWidth = "AgenC Workbench | ".length + active.length;
+  const stripAvailable =
+    typeof columns === "number" ? columns - leftLabelWidth - 1 : 0;
   return (
     <Box height={1} width="100%" flexDirection="row">
       <Text color="text2" wrap="truncate-end">AgenC Workbench</Text>
       <Text dimColor wrap="truncate-end"> | {active}</Text>
       <WorkbenchActivityIndicator mode={activityMode} />
+      <Box flexGrow={1} />
+      {stripAvailable > 0 ? <WorkbenchContextStrip available={stripAvailable} /> : null}
     </Box>
   );
 }

--- a/runtime/tests/tui/workbench-context-strip.test.tsx
+++ b/runtime/tests/tui/workbench-context-strip.test.tsx
@@ -1,0 +1,283 @@
+import { homedir } from "node:os";
+
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { Box, Text } from "../../src/tui/ink.js";
+import {
+  AppStateProvider,
+  getDefaultAppState,
+  type AppState,
+} from "../../src/tui/state/AppState.js";
+import { WorkbenchStatusBar } from "../../src/tui/workbench/WorkbenchStatusBar.js";
+import {
+  basenameOf,
+  compactCwd,
+  isDangerousPermissionMode,
+  selectStripSegments,
+  WorkbenchContextStrip,
+} from "../../src/tui/workbench/WorkbenchContextStrip.js";
+import type { PermissionMode } from "../../src/permissions/types.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+// The context strip restores the always-on session context (model · permission
+// mode · cwd) to the workbench status bar after the welcome summary box scrolls
+// away. These tests assert:
+//   - it shows the real model, permission mode, and a compact cwd
+//   - a dangerous/elevated mode renders in the warning style (distinct from dim)
+//   - it degrades (drops cwd, then mode) and never overflows the row at narrow
+//     widths
+//   - revert sensitivity: present-vs-absent + dangerous-vs-normal styling
+
+const TEST_MODEL = "test-model-xyz";
+
+function stateWith(
+  overrides: {
+    readonly model?: string;
+    readonly mode?: PermissionMode;
+  } = {},
+): AppState {
+  const base = getDefaultAppState();
+  return {
+    ...base,
+    mainLoopModelForSession: overrides.model ?? TEST_MODEL,
+    toolPermissionContext: {
+      ...base.toolPermissionContext,
+      mode: overrides.mode ?? "default",
+    },
+  };
+}
+
+function renderStatusBar(
+  columns: number,
+  overrides: Parameters<typeof stateWith>[0] = {},
+): Promise<string> {
+  return renderToString(
+    <AppStateProvider initialState={stateWith(overrides)}>
+      <WorkbenchStatusBar columns={columns} />
+    </AppStateProvider>,
+    { columns, rows: 3 },
+  );
+}
+
+/** The single rendered row, trimmed of right padding. */
+function statusRow(out: string): string {
+  return (out.split("\n")[0] ?? "").replace(/\s+$/u, "");
+}
+
+describe("compactCwd / basenameOf helpers", () => {
+  test("home-relativizes the cwd to ~", () => {
+    const home = homedir();
+    expect(compactCwd(`${home}/git/AgenC/agenc-core`, home)).toBe(
+      "~/git/AgenC/agenc-core",
+    );
+  });
+
+  test("leaves non-home paths absolute", () => {
+    expect(compactCwd("/var/tmp/work", "/home/someone")).toBe("/var/tmp/work");
+  });
+
+  test("does not treat a sibling prefix as the home dir", () => {
+    // "/home/me-other" must NOT be relativized against home "/home/me".
+    expect(compactCwd("/home/me-other/x", "/home/me")).toBe("/home/me-other/x");
+  });
+
+  test("basename of a relativized path is the trailing segment", () => {
+    expect(basenameOf("~/git/AgenC/agenc-core")).toBe("agenc-core");
+    expect(basenameOf("/var/tmp/work")).toBe("work");
+  });
+});
+
+describe("isDangerousPermissionMode", () => {
+  test("flags elevated/auto modes", () => {
+    expect(isDangerousPermissionMode("bypassPermissions")).toBe(true);
+    expect(isDangerousPermissionMode("unattended")).toBe(true);
+    expect(isDangerousPermissionMode("dontAsk")).toBe(true);
+    expect(isDangerousPermissionMode("auto")).toBe(true);
+  });
+
+  test("does not flag normal modes", () => {
+    expect(isDangerousPermissionMode("default")).toBe(false);
+    expect(isDangerousPermissionMode("acceptEdits")).toBe(false);
+    expect(isDangerousPermissionMode("plan")).toBe(false);
+  });
+});
+
+describe("selectStripSegments degradation", () => {
+  const parts = {
+    model: "test-model-xyz",
+    mode: "default" as PermissionMode,
+    modeLabel: "default",
+    cwd: "~/git/AgenC/agenc-core",
+    cwdBasename: "agenc-core",
+    dangerous: false,
+  };
+
+  test("shows everything when there is room", () => {
+    const seg = selectStripSegments(parts, 80);
+    expect(seg).not.toBeNull();
+    expect(seg?.model).toBe("test-model-xyz");
+    expect(seg?.modeLabel).toBe("default");
+    expect(seg?.cwd).toBe("~/git/AgenC/agenc-core");
+  });
+
+  test("drops full cwd to basename first under pressure", () => {
+    // Wide enough for model + mode + basename, not the full path.
+    const full = "test-model-xyz".length + 3 + "default".length + 3 + "agenc-core".length;
+    const seg = selectStripSegments(parts, full);
+    expect(seg?.cwd).toBe("agenc-core");
+    expect(seg?.modeLabel).toBe("default");
+  });
+
+  test("drops cwd entirely, then the mode, keeping the model", () => {
+    const modelOnly = selectStripSegments(parts, "test-model-xyz".length + 1);
+    expect(modelOnly?.model).toBe("test-model-xyz");
+    expect(modelOnly?.modeLabel).toBeNull();
+    expect(modelOnly?.cwd).toBeNull();
+
+    const modelPlusMode = selectStripSegments(
+      parts,
+      "test-model-xyz".length + 3 + "default".length,
+    );
+    expect(modelPlusMode?.modeLabel).toBe("default");
+    expect(modelPlusMode?.cwd).toBeNull();
+  });
+
+  test("never returns a combination wider than the budget", () => {
+    for (let available = 0; available <= 60; available += 1) {
+      const seg = selectStripSegments(parts, available);
+      if (seg === null) continue;
+      let width = seg.model.length;
+      if (seg.modeLabel !== null) width += 3 + seg.modeLabel.length;
+      if (seg.cwd !== null) width += 3 + seg.cwd.length;
+      expect(width).toBeLessThanOrEqual(available);
+    }
+  });
+
+  test("returns null when nothing fits", () => {
+    expect(selectStripSegments(parts, 0)).toBeNull();
+  });
+});
+
+describe("WorkbenchStatusBar context strip rendering", () => {
+  test("shows model, permission mode, and a compact cwd at a wide width", async () => {
+    const { getCwdState } = await import("../../src/bootstrap/state.js");
+    const out = await renderStatusBar(120, { mode: "default" });
+    expect(out).toContain(TEST_MODEL);
+    expect(out).toContain("default");
+    // Compact cwd: the basename of the session cwd (the same stable source the
+    // strip reads) is present; the strip never shows the full long path raw.
+    const expectedCwd = compactCwd(getCwdState());
+    const tail = basenameOf(expectedCwd);
+    expect(out).toContain(tail);
+  });
+
+  test("shows the dangerous mode label (bypass) when elevated", async () => {
+    const out = await renderStatusBar(120, { mode: "bypassPermissions" });
+    expect(out).toContain(TEST_MODEL);
+    // permissionModeShortTitle("bypassPermissions") === "Bypass" -> lowercased.
+    expect(out).toContain("bypass");
+  });
+
+  test("the title label is always present alongside the strip", async () => {
+    const out = await renderStatusBar(120);
+    expect(out).toContain("AgenC Workbench");
+  });
+});
+
+describe("WorkbenchContextStrip dangerous-mode styling (ANSI)", () => {
+  async function renderStripAnsi(
+    mode: PermissionMode,
+    available = 80,
+  ): Promise<string> {
+    const { renderToAnsiString } = await import("../../src/utils/staticRender.js");
+    return renderToAnsiString(
+      <AppStateProvider initialState={stateWith({ mode })}>
+        <Box width={available + 4}>
+          <WorkbenchContextStrip available={available} />
+        </Box>
+      </AppStateProvider>,
+      // color: true forces chalk into truecolor mode so theme colors emit SGR
+      // codes we can assert on (otherwise the PassThrough render is colorless).
+      { columns: available + 4, rows: 3, color: true },
+    );
+  }
+
+  // Count SGR escape sequences so we can prove the dangerous render carries
+  // strictly more styling than the all-dim normal render.
+  function sgrCount(out: string): number {
+    return (out.match(/\u001b\[[0-9;]*m/gu) ?? []).length;
+  }
+
+  test("dangerous mode uses the warning color; normal mode does not", async () => {
+    // Dark theme 'warning' resolves to truecolor amber (rgb(255,151,72)).
+    const WARNING_SGR = "\u001b[38;2;255;151;72m";
+    const dangerous = await renderStripAnsi("bypassPermissions");
+    const normal = await renderStripAnsi("default");
+
+    // Both render the model + mode label; only the dangerous one styles the
+    // mode segment in the warning color.
+    expect(dangerous).toContain("bypass");
+    expect(normal).toContain("default");
+    expect(dangerous).toContain(WARNING_SGR);
+    expect(normal).not.toContain(WARNING_SGR);
+    // The warning styling is *extra*, so the dangerous render has more SGR codes.
+    expect(sgrCount(dangerous)).toBeGreaterThan(sgrCount(normal));
+  });
+});
+
+describe("WorkbenchContextStrip never overflows the row", () => {
+  // Render the full status bar (left label + strip) at a sweep of widths and
+  // assert no rendered line exceeds the viewport width. This is the bug class
+  // we keep fixing: chrome that bleeds past the column budget.
+  for (const columns of [20, 28, 36, 48, 64, 80, 100, 120, 160]) {
+    test(`fits within ${columns} columns (default mode)`, async () => {
+      const out = await renderStatusBar(columns, { mode: "default" });
+      for (const line of out.split("\n")) {
+        expect([...line.replace(/\s+$/u, "")].length).toBeLessThanOrEqual(columns);
+      }
+    });
+
+    test(`fits within ${columns} columns (dangerous mode + long cwd)`, async () => {
+      const out = await renderStatusBar(columns, { mode: "unattended" });
+      for (const line of out.split("\n")) {
+        expect([...line.replace(/\s+$/u, "")].length).toBeLessThanOrEqual(columns);
+      }
+    });
+  }
+});
+
+describe("WorkbenchContextStrip revert sensitivity (present vs absent)", () => {
+  // When no column budget reaches the strip (status bar omits it), the strip's
+  // values must be absent — proving the strip is what surfaces them.
+  test("strip absent when no columns are available to it", async () => {
+    const tiny = await renderToString(
+      <AppStateProvider initialState={stateWith({ model: TEST_MODEL, mode: "default" })}>
+        {/* columns omitted -> stripAvailable = 0 -> strip not rendered */}
+        <WorkbenchStatusBar />
+      </AppStateProvider>,
+      { columns: 120, rows: 3 },
+    );
+    const wide = await renderStatusBar(120, { model: TEST_MODEL, mode: "default" });
+
+    // The same app state, but the model only appears once the strip has room.
+    expect(statusRow(tiny)).not.toContain(TEST_MODEL);
+    expect(statusRow(wide)).toContain(TEST_MODEL);
+    // The title label is present in both (it is not part of the strip).
+    expect(tiny).toContain("AgenC Workbench");
+  });
+
+  test("a bare strip with zero budget renders nothing", async () => {
+    const out = await renderToString(
+      <AppStateProvider initialState={stateWith({ mode: "default" })}>
+        <Box>
+          <Text>EDGE</Text>
+          <WorkbenchContextStrip available={0} />
+        </Box>
+      </AppStateProvider>,
+      { columns: 40, rows: 3 },
+    );
+    expect(out).toContain("EDGE");
+    expect(out).not.toContain(TEST_MODEL);
+  });
+});


### PR DESCRIPTION
Adds an always-visible session context strip to the workbench status bar: active model, permission mode (warning-styled when dangerous), and compact cwd, wired to real state with graceful narrow-width degradation. Verified live; 35 revert-sensitive tests; full suite 13215.