### PR TITLE
tui visual iter 7: polish sweep (hints, contrast, scroll labels)

### DIFF
--- a/runtime/src/tui/components/PromptInput/usePromptInputPlaceholder.ts
+++ b/runtime/src/tui/components/PromptInput/usePromptInputPlaceholder.ts
@@ -68,7 +68,7 @@ export function usePromptInputPlaceholder({
     // knows what to type. It disappears as soon as input is non-empty (guarded
     // above) and renders dim like every other placeholder.
     if (submitCount < 1 && !proactiveActive) {
-      return 'Describe a task, or / for commands'
+      return 'Describe a task · / for commands · @ to attach a file'
     }
   }, [
     input,

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -721,7 +721,12 @@ function WelcomeMetaRow({
 }): React.ReactNode {
   return (
     <Box flexDirection="row" flexWrap="wrap">
-      <ThemedText color="muted3">{label.padEnd(13)}</ThemedText>
+      {/* Labels use `inactive` (a readable secondary tone), not `muted3`. In the
+          dark themes muted3 (rgb(64,64,70)) sits almost on top of the card's
+          lineSoft border (rgb(34,35,39)), so the labels read as chrome rather
+          than text. `inactive` is clearly brighter than the border while still
+          ranking below the `text2` values. */}
+      <ThemedText color="inactive">{label.padEnd(13)}</ThemedText>
       <ThemedText color="text2" wrap="truncate-middle">
         {value}
       </ThemedText>

--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -26,6 +26,6 @@ export function WorkbenchFooter(): React.ReactElement {
 function hintsForPane(pane: string, surface: string): string {
   if (pane === "explorer") return "Explorer: j/k move  h/l fold  enter/o edit  a add  r rename  d delete  @ attach";
   if (pane === "agents") return "Agents: enter detail  ctrl+w w next";
-  if (pane === "composer") return "Composer: write prompt  ctrl+w k surface";
+  if (pane === "composer") return "Composer: write prompt  / commands  @ attach file  ctrl+w k focus transcript";
   return footerHintsForSurface(surface as never);
 }

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -214,13 +214,17 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {viewport.above > 0 ? (
           <Box height={1} flexShrink={0}>
-            <Text dimColor wrap="truncate-end">{glyphs.arrowUp} {viewport.above} more</Text>
+            {/* "N above" / "N below" reads as a position (how far the window
+                sits from each end) instead of an ambiguous "N more". The
+                `inactive` tone is brighter than the prior dimColor so the
+                indicator is legible against the rows. */}
+            <Text color="inactive" wrap="truncate-end">{glyphs.arrowUp} {viewport.above} above</Text>
           </Box>
         ) : null}
         {visibleRows.map((row) => <ProjectExplorerRow key={row.id} row={row} width={Math.max(8, width - 3)} />)}
         {viewport.below > 0 ? (
           <Box height={1} flexShrink={0}>
-            <Text dimColor wrap="truncate-end">{glyphs.arrowDown} {viewport.below} more</Text>
+            <Text color="inactive" wrap="truncate-end">{glyphs.arrowDown} {viewport.below} below</Text>
           </Box>
         ) : null}
       </Box>

--- a/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.test.tsx
@@ -115,7 +115,7 @@ describe("usePromptInputPlaceholder", () => {
     // No queue/example hint applies, so the composer shows the stable
     // cold-start guidance rather than sitting blank at rest.
     await expect(renderPlaceholder()).resolves.toContain(
-      "Describe a task, or / for commands",
+      "Describe a task",
     );
   });
 
@@ -137,15 +137,20 @@ describe("usePromptInputPlaceholder", () => {
     // still surfaces the stable cold-start hint instead of a blank line.
     mocks.promptSuggestionEnabled = false;
     await expect(renderPlaceholder()).resolves.toContain(
-      "Describe a task, or / for commands",
+      "Describe a task",
     );
   });
 
   test("shows the cold-start hint when no other hint applies, and only before the first submit", async () => {
     // Default cold start: suggestions disabled, no queue, no teammate.
-    await expect(renderPlaceholder()).resolves.toContain(
-      "Describe a task, or / for commands",
-    );
+    const coldStart = await renderPlaceholder();
+    expect(coldStart).toContain("Describe a task");
+    // The cold-start hint advertises BOTH discoverability affordances right
+    // where the user types: `/` opens commands and `@` attaches a file. The
+    // `@` advert is the item-2 addition; assert it explicitly so a revert of
+    // the placeholder string (dropping `@ to attach`) fails this test.
+    expect(coldStart).toContain("/ for commands");
+    expect(coldStart).toContain("@ to attach a file");
 
     // The hint is a cold-start affordance only — it disappears once the user
     // has started the conversation.

--- a/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.wave200-148.coverage.test.ts
+++ b/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.wave200-148.coverage.test.ts
@@ -201,8 +201,9 @@ describe('usePromptInputPlaceholder coverage', () => {
         fixture.state.appState.promptSuggestionEnabled = false
       },
       // Cold start with suggestions disabled: instead of a blank composer, the
-      // hook now surfaces the stable on-brand guidance hint.
-      'Describe a task, or / for commands',
+      // hook now surfaces the stable on-brand guidance hint, advertising both
+      // the `/` command and `@` attach affordances.
+      'Describe a task · / for commands · @ to attach a file',
     )
 
     await expectPlaceholder(() => {}, undefined, { submitCount: 1 })

--- a/runtime/tests/tui/components/v2/welcomeColdPanel.cards.test.tsx
+++ b/runtime/tests/tui/components/v2/welcomeColdPanel.cards.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { ContentWidthProvider } from '../../../../src/tui/context/contentWidthContext.js'
-import { renderToString } from '../../../utils/staticRender.js'
+import { renderToAnsiString, renderToString } from '../../../utils/staticRender.js'
 import { WelcomeColdPanel } from '../../../../src/tui/components/v2/primitives.js'
 
 // Regression for the cold-start workbench welcome layout: the "workspace"
@@ -97,5 +97,42 @@ describe('WelcomeColdPanel summary/recent cards', () => {
     expect(widths.length).toBe(4)
     expect(new Set(widths).size).toBe(1)
     expect(widths[0]).toBe(64)
+  })
+
+  // Dark-theme SGR truecolor sequences for the colors that meet on the summary
+  // card. The labels ("workspace"/"model"/"last session") used to render in
+  // `muted3` (rgb(64,64,70)), nearly identical to the card's `lineSoft` border
+  // (rgb(34,35,39)) — so they read as chrome. They now render in the brighter,
+  // clearly-readable `inactive` tone (rgb(139,120,157)).
+  const INACTIVE_SGR = '[38;2;139;120;157m'
+  const MUTED3_SGR = '[38;2;64;64;70m'
+  const LINESOFT_SGR = '[38;2;34;35;39m'
+
+  // The SGR escape that immediately precedes a label's text on its row.
+  function sgrBefore(out: string, label: string): string | undefined {
+    const match = out.match(new RegExp(`(\\u001b\\[[0-9;]*m)${label}`, 'u'))
+    return match?.[1]
+  }
+
+  it('styles the summary-card labels in the readable label tone, not the dim border tone', async () => {
+    const out = await renderToAnsiString(
+      <WelcomeColdPanel model="qwen3.6-27b-fp8" />,
+      { columns: 80, rows: 40, color: true },
+    )
+
+    // The box border still draws in the dim `lineSoft` tone.
+    expect(out).toContain(LINESOFT_SGR)
+
+    // Each summary-card label is now colored with the brighter, readable
+    // `inactive` tone — NOT the near-border `muted3` tone it used to use.
+    // Scoped per-label (the unrelated "recent" card legitimately still uses
+    // muted3, so a global not.toContain would over-assert). Revert-sensitive:
+    // switching the label color back to "muted3" flips each preceding SGR to
+    // MUTED3_SGR and fails these checks.
+    for (const label of ['workspace', 'model', 'last session']) {
+      const sgr = sgrBefore(out, label)
+      expect(sgr).toBe(INACTIVE_SGR)
+      expect(sgr).not.toBe(MUTED3_SGR)
+    }
   })
 })

--- a/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
@@ -429,7 +429,10 @@ describe("ProjectExplorer interactions", () => {
       expect(renderedText).toContain("1 changed");
       expect(renderedText).toContain("sync");
       expect(renderedText).toContain("tree unavailable");
-      expect(renderedText).toContain("more");
+      // Scroll-overflow indicators read as a position relative to each end
+      // ("N above" / "N below") rather than an ambiguous "N more".
+      expect(renderedText).toMatch(/\d+ above/u);
+      expect(renderedText).toMatch(/\d+ below/u);
     } finally {
       cleanupExplorer(root, stdin, stdout);
     }

--- a/runtime/tests/tui/workbench/project-explorer-row-truncation.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-row-truncation.test.tsx
@@ -167,4 +167,32 @@ describe("ProjectExplorer row truncation", () => {
     expect(line).not.toContain("..…");
     expect(line).not.toContain("...");
   });
+
+  it("labels the scroll overflow indicators with a position sense (N above / N below)", async () => {
+    // useTerminalSize is mocked to 24 rows, so maxTreeRows = 24 - 8 = 16. A
+    // longer list with a selection mid-window forces both an above- and a
+    // below-overflow indicator. They now read "N above" / "N below" — a
+    // position relative to each end — instead of the prior ambiguous "N more".
+    // Revert-sensitive: restoring the "N more" wording fails the assertions.
+    const rows: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < 40; i++) {
+      rows.push(fileRow(`file-${i}.ts`, `file-${i}.ts`, { selected: i === 20 }));
+    }
+    harness.snapshot = {
+      cwd: "/repo",
+      loading: false,
+      error: null,
+      cursorPath: null,
+      activePath: "file-20.ts",
+      expandedPaths: [],
+      rows,
+    };
+
+    const output = (await renderTree(40)).join("\n");
+
+    expect(output).toMatch(/\d+ above/u);
+    expect(output).toMatch(/\d+ below/u);
+    // The old ambiguous "N more" wording must be gone.
+    expect(output).not.toContain("more");
+  });
 });

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -476,6 +476,41 @@ describe("workbench render contract", () => {
     expect(output).not.toContain("src/stale.ts");
   });
 
+  it("gives the composer footer a readable hint that advertises / and @ and explains the surface chord", async () => {
+    // The composer-pane footer used to read "Composer: write prompt  ctrl+w k
+    // surface" — the trailing "ctrl+w k surface" was opaque (what is a
+    // surface?) and the line advertised neither the `/` command nor the `@`
+    // attach affordance. It now glosses the chord ("focus transcript") and
+    // surfaces both discoverability hints. Revert-sensitive: restoring the old
+    // string (no "/ commands", no "@ attach file", bare "ctrl+w k surface")
+    // fails the assertions below.
+    const state = {
+      ...getDefaultAppState(),
+      workbench: {
+        ...getDefaultAppState().workbench,
+        focusedPane: "composer" as const,
+      },
+    };
+    const output = await renderToString(
+      <AppStateProvider initialState={state}>
+        <WorkbenchFooter />
+      </AppStateProvider>,
+      120,
+    );
+
+    const hintLine = output
+      .split(/\r?\n/u)
+      .find((line) => line.includes("Composer: write prompt"));
+    expect(hintLine).toBeDefined();
+    // Discoverability: `/` opens commands and `@` attaches a file, advertised
+    // where the user types.
+    expect(hintLine).toContain("/ commands");
+    expect(hintLine).toContain("@ attach file");
+    // The surface chord is glossed instead of left as a bare token.
+    expect(hintLine).toContain("ctrl+w k focus transcript");
+    expect(hintLine).not.toContain("ctrl+w k surface");
+  });
+
   it("indents the surface-hint footer line to match the composer footer", async () => {
     // The composer's own "? for shortcuts" hint is rendered inside a
     // paddingX={2} box (PromptInputFooter). The workbench surface-hint line


### PR DESCRIPTION
Clearer composer footer + placeholder (advertise / commands and @ attach; reword cryptic 'ctrl+w k surface' to 'focus transcript'), higher welcome info-card label contrast, and 'N above'/'N below' file-tree scroll indicators. Verified live; revert-sensitive tests; full suite 13218.