### PR TITLE
tui visual iter 8: show the diff inside the approval dialog

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1140,6 +1140,25 @@ export function DiffInline({
   )
 }
 
+/**
+ * A bounded diff/content preview shown INSIDE the approval popup so a Write/Edit
+ * is never approved blind. Shaped like the `buildEditDiffPreview` output (which
+ * the post-approval DIFF card also consumes) so the same `DiffInline` primitive
+ * and diff engine are reused — no new diff logic lives here.
+ */
+export interface ApprovalDiffPreview {
+  readonly file: string
+  readonly stats: string
+  readonly lines: readonly {
+    readonly kind: 'add' | 'rem' | 'ctx' | 'hunk'
+    readonly oldLine?: string
+    readonly newLine?: string
+    readonly code: string
+  }[]
+  /** Rows dropped past the input cap, surfaced as a "… +N more" row. */
+  readonly remaining: number
+}
+
 export function ApprovalCard({
   risk,
   title,
@@ -1147,6 +1166,7 @@ export function ApprovalCard({
   facts,
   note,
   confirmLabel,
+  diffPreview,
   requireTypedConfirmation = false,
   typedConfirmationValue = '',
   typedConfirmationTarget = 'yes',
@@ -1157,6 +1177,7 @@ export function ApprovalCard({
   readonly facts: readonly { readonly label: string; readonly value: string; readonly color?: ThemeColor }[]
   readonly note?: string
   readonly confirmLabel: string
+  readonly diffPreview?: ApprovalDiffPreview
   readonly requireTypedConfirmation?: boolean
   readonly typedConfirmationValue?: string
   readonly typedConfirmationTarget?: string
@@ -1187,6 +1208,41 @@ export function ApprovalCard({
   // When the slot is extremely tight, drop the secondary facts grid so the
   // primary action legend + confirm row are never the ones clipped away.
   const showFacts = popupBodyRows >= 5
+  // The diff/content preview is the LARGEST optional block (a bordered DiffInline
+  // box: 2 chrome rows + one row per changed line). It is the FIRST thing shed
+  // when the slot is tight — never the [1]/[2]/[3] action legend or confirm row.
+  // Gate it behind the most generous budget, then cap the number of diff rows to
+  // the rows actually left after the essential body (summary, command, facts,
+  // note, action legend, confirm). Reserve ~5 essential body rows + 2 for the
+  // preview's own border; everything beyond that is available for diff lines.
+  const previewBudgetRows = popupBodyRows - 7
+  const showPreview =
+    diffPreview !== undefined && diffPreview.lines.length > 0 && previewBudgetRows >= 2
+  // Cap the inline diff to a small, bounded window (6-8 rows of the existing
+  // preview) and never beyond what the slot can hold; the rest stays reachable
+  // via the full diff surface (ctrl+w d), surfaced as a "… +N more" row.
+  const PREVIEW_CAP = 7
+  const previewLineCap = showPreview
+    ? Math.max(1, Math.min(PREVIEW_CAP, previewBudgetRows))
+    : 0
+  let previewLines: ApprovalDiffPreview['lines'] = []
+  if (showPreview && diffPreview !== undefined) {
+    const shown = diffPreview.lines.slice(0, previewLineCap)
+    // Total rows hidden = rows dropped by THIS cap + rows the upstream builder
+    // already collapsed. Keep one continuation row to state the affordance.
+    const droppedHere = diffPreview.lines.length - shown.length
+    const hidden = droppedHere + diffPreview.remaining
+    previewLines =
+      hidden > 0
+        ? [
+            ...shown,
+            {
+              kind: 'ctx' as const,
+              code: `… +${hidden} more ${hidden === 1 ? 'line' : 'lines'} · ctrl+w d for full diff`,
+            },
+          ]
+        : shown
+  }
   return (
     <Popup
       title={title}
@@ -1215,6 +1271,15 @@ export function ApprovalCard({
         <ThemedText color="text2" wrap="truncate-end">
           $ {command}
         </ThemedText>
+        {showPreview && diffPreview !== undefined ? (
+          <Box flexShrink={1} overflow="hidden">
+            <DiffInline
+              file={diffPreview.file.length > 0 ? diffPreview.file : 'file'}
+              stats={diffPreview.stats}
+              lines={previewLines}
+            />
+          </Box>
+        ) : null}
         {showFacts ? (
           <Box flexDirection="row" gap={2} flexWrap="wrap">
             {facts.map(fact => (

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -22,7 +22,8 @@ import { approvalInputText } from "./approval-input-text.js";
 import { Box, useInput } from "./ink.js";
 import { useRegisterKeybindingContext } from "./keybindings/KeybindingContext.js";
 import { useKeybindings } from "./keybindings/useKeybinding.js";
-import { ApprovalCard } from "./components/v2/primitives.js";
+import { ApprovalCard, type ApprovalDiffPreview } from "./components/v2/primitives.js";
+import { buildEditDiffPreview } from "./edit-diff-preview.js";
 import { EXIT_PLAN_MODE_TOOL_NAME } from "../tools/ExitPlanModeTool/constants.js";
 import { PlanApprovalOverlay } from "./components/PlanApprovalOverlay.js";
 import { setPlanApprovalChoice } from "./plan-approval-choice.js";
@@ -388,6 +389,28 @@ function AgenCApprovalOverlay({
   readonly toolUseConfirm: ProjectedToolUseConfirm;
 }) {
   const command = approvalInputText(toolUseConfirm.input, { prettyJson: true });
+  // Build a bounded diff/content preview so a Write/Edit is not approved blind.
+  // Reuses the same diff engine + helper the post-approval DIFF card uses; it
+  // returns null for non-file-write tools (e.g. Bash), so those show no diff.
+  const diffPreview = useMemo<ApprovalDiffPreview | undefined>(() => {
+    try {
+      const built = buildEditDiffPreview(
+        toolUseConfirm.tool.name,
+        toolUseConfirm.input,
+      );
+      if (built === null) return undefined;
+      return {
+        file: built.file,
+        stats: built.stats,
+        lines: built.lines,
+        remaining: built.remaining,
+      };
+    } catch {
+      // A malformed input must never break the approval popup — degrade to the
+      // command-only card rather than throwing inside render.
+      return undefined;
+    }
+  }, [toolUseConfirm.tool.name, toolUseConfirm.input]);
   const risk = classifyApprovalRisk({
     request,
     toolName: toolUseConfirm.tool.name,
@@ -502,6 +525,7 @@ function AgenCApprovalOverlay({
           },
         ]}
         note={toolUseConfirm.description}
+        {...(diffPreview !== undefined ? { diffPreview } : {})}
         confirmLabel={
           destructive
             ? `type '${requiredWord}' to approve`

--- a/runtime/tests/tui/approval-card-diff-preview.test.tsx
+++ b/runtime/tests/tui/approval-card-diff-preview.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { Box } from '../../src/tui/ink.js'
+import {
+  ApprovalCard,
+  type ApprovalDiffPreview,
+} from '../../src/tui/components/v2/primitives.js'
+import { buildEditDiffPreview } from '../../src/tui/edit-diff-preview.js'
+import { renderToString } from '../../src/utils/staticRender.js'
+
+// UX improvement coverage: the tool-approval popup now shows a BOUNDED preview
+// of the change (the diff for an Edit, first lines of content for a new-file
+// Write) INSIDE the dialog, so a Write/Edit is never approved blind.
+//
+// CRITICAL: this must NOT regress the height/overflow discipline that the
+// approval popup was recently repaired for. The preview is part of the existing
+// maxHeight + overflow:'hidden' budget and is the FIRST optional block shed when
+// the slot is tight — never the primary [1]/[2]/[3] action legend.
+
+// A realistic Edit diff: one changed line + one added line.
+function editPreview(): ApprovalDiffPreview {
+  const built = buildEditDiffPreview('Edit', {
+    file_path: 'src/primes.ts',
+    old_string: 'const a = 1\nconst b = 2\n',
+    new_string: 'const a = 10\nconst b = 2\nconst c = 3\n',
+  })
+  if (built === null) throw new Error('expected a diff preview for the Edit')
+  return {
+    file: built.file,
+    stats: built.stats,
+    lines: built.lines,
+    remaining: built.remaining,
+  }
+}
+
+// A long Write diff so the in-dialog cap collapses the tail to "… +N more".
+function longWritePreview(): ApprovalDiffPreview {
+  const lines = Array.from({ length: 40 }, (_v, i) => `line ${i}`).join('\n')
+  const built = buildEditDiffPreview('Write', {
+    file_path: 'src/big.ts',
+    content: `${lines}\n`,
+  })
+  if (built === null) throw new Error('expected a diff preview for the Write')
+  return {
+    file: built.file,
+    stats: built.stats,
+    lines: built.lines,
+    remaining: built.remaining,
+  }
+}
+
+function renderEditApproval(
+  rows: number,
+  opts: { withPreview: boolean } = { withPreview: true },
+  columns = 116,
+): Promise<string> {
+  const preview = opts.withPreview ? editPreview() : undefined
+  return renderToString(
+    <Box flexDirection="column">
+      <ApprovalCard
+        risk="low"
+        title="tool · edit · medium-risk approval"
+        command="src/primes.ts"
+        facts={[
+          { label: 'tool', value: 'edit' },
+          { label: 'scope', value: 'session', color: 'text2' },
+          { label: 'request', value: 'req-77' },
+          { label: 'confirmation', value: 'enter' },
+        ]}
+        note="untrusted policy: approve every call"
+        {...(preview !== undefined ? { diffPreview: preview } : {})}
+        confirmLabel="enter approve · 2 session · 3 deny"
+      />
+    </Box>,
+    { columns, rows },
+  )
+}
+
+function renderBashApproval(rows = 40, columns = 116): Promise<string> {
+  // A Bash approval carries no diffPreview (the wiring builds none for non-file
+  // tools), so it must show the command and never a DIFF box.
+  return renderToString(
+    <Box flexDirection="column">
+      <ApprovalCard
+        risk="low"
+        title="tool · bash · needs approval"
+        command="rm -rf build"
+        facts={[{ label: 'tool', value: 'bash' }]}
+        confirmLabel="enter approve · 2 session · 3 deny"
+      />
+    </Box>,
+    { columns, rows },
+  )
+}
+
+function countLines(out: string, predicate: (line: string) => boolean): number {
+  return out.split('\n').filter(predicate).length
+}
+
+describe('ApprovalCard diff preview (in-dialog change preview)', () => {
+  test('an Edit approval shows a bounded diff with added/removed lines', async () => {
+    const out = await renderEditApproval(40)
+    // The DIFF box header + the changed file is present.
+    expect(out).toContain('DIFF')
+    expect(out).toContain('primes.ts')
+    // Both an added (+) and a removed (-) line are visible in the preview.
+    // The Edit turns `const a = 1` into `const a = 10` (rem+add) and appends
+    // `const c = 3` (add).
+    expect(out).toContain('const a = 1')
+    expect(out).toContain('const a = 10')
+    expect(out).toContain('const c = 3')
+    const sigilRows = out.split('\n').filter((l) => l.includes('const a'))
+    expect(sigilRows.some((l) => l.includes('-'))).toBe(true)
+    expect(sigilRows.some((l) => l.includes('+'))).toBe(true)
+  })
+
+  test('the diff preview does NOT push out the [1]/[2]/[3] action legend', async () => {
+    const out = await renderEditApproval(40)
+    expect(out).toContain('[1] approve once')
+    expect(out).toContain('[2] approve for session')
+    expect(out).toContain('[3] deny')
+  })
+
+  test('REGRESSION: the popup with a diff still fits its border (one top, one bottom)', async () => {
+    const out = await renderEditApproval(40)
+    const lines = out.split('\n').filter((line) => line.trim().length > 0)
+    const firstBorderIndex = lines.findIndex((line) => line.includes('┌'))
+    const lastBorderIndex = lines
+      .map((line) => line.includes('└'))
+      .lastIndexOf(true)
+    expect(firstBorderIndex).toBe(0)
+    expect(lastBorderIndex).toBe(lines.length - 1)
+    // Exactly one OUTER popup top/bottom border. The inner DiffInline box draws
+    // its own '┌'/'└' line corners, so assert the popup border specifically by
+    // checking nothing renders after the last bottom-border line.
+    const renderedRows = out.split('\n').filter((l) => l.length > 0).length
+    expect(lastBorderIndex).toBe(renderedRows - 1)
+  })
+
+  test('REGRESSION: the popup with a diff never exceeds the available rows', async () => {
+    for (const rows of [16, 18, 20, 24, 40]) {
+      const out = await renderEditApproval(rows)
+      const renderedRows = out.split('\n').filter((l) => l.length > 0).length
+      expect(renderedRows).toBeLessThanOrEqual(rows)
+      // Still bounded by a closing bottom border at every height.
+      expect(out).toContain('└')
+    }
+  })
+
+  test('a tight slot DROPS the diff preview BEFORE the action legend', async () => {
+    // At a tight height the diff preview (the largest optional block) is shed,
+    // but the primary [1]/[2]/[3] action legend survives.
+    const tight = await renderEditApproval(16)
+    expect(tight).not.toContain('DIFF')
+    expect(tight).toContain('[1] approve once')
+  })
+
+  test('a long Write diff collapses its tail to a "… +N more" affordance row', async () => {
+    const out = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · write · needs approval"
+          command="src/big.ts"
+          facts={[{ label: 'tool', value: 'write' }]}
+          diffPreview={longWritePreview()}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    expect(out).toContain('DIFF')
+    expect(out).toMatch(/… \+\d+ more lines · ctrl\+w d for full diff/)
+    // The action legend still survives alongside the collapsed preview.
+    expect(out).toContain('[1] approve once')
+  })
+
+  test('a Bash approval shows NO diff preview (command-only card)', async () => {
+    const out = await renderBashApproval()
+    expect(out).not.toContain('DIFF')
+    expect(out).toContain('rm -rf build')
+    expect(out).toContain('[1] approve once')
+  })
+
+  test('REVERT-SENSITIVITY: diff present with the prop, absent without it', async () => {
+    const withPreview = await renderEditApproval(40, { withPreview: true })
+    const withoutPreview = await renderEditApproval(40, { withPreview: false })
+    expect(withPreview).toContain('DIFF')
+    expect(withPreview).toContain('const c = 3')
+    // Same card, no diffPreview prop → no DIFF box, but the card still renders
+    // its command + action legend (the pre-improvement behavior).
+    expect(withoutPreview).not.toContain('DIFF')
+    expect(withoutPreview).not.toContain('const c = 3')
+    expect(withoutPreview).toContain('[1] approve once')
+    // Guard: both still fit one closing bottom border (no overflow regression).
+    expect(countLines(withPreview, (l) => l.includes('└'))).toBeGreaterThanOrEqual(1)
+    expect(countLines(withoutPreview, (l) => l.includes('└'))).toBe(1)
+  })
+})


### PR DESCRIPTION
Write/Edit approvals now render a bounded diff preview inside the dialog (reusing the existing diff engine), so you see what you're approving. Height-gated to shed before the action legend; regression guards that the dialog still fits (no overflow). Verified live; revert-sensitive tests; full suite 13226.