### PR TITLE
tui visual iter 9: honest 'working' feedback on slow turns (no fake 'Booting' hang)

### DIFF
--- a/runtime/src/constants/spinnerVerbs.ts
+++ b/runtime/src/constants/spinnerVerbs.ts
@@ -16,22 +16,24 @@ export function getSpinnerVerbs(): string[] {
 // Cyberpunk-flavored: technical action verbs from compilers, networks,
 // crypto, runtime systems, and reverse engineering. No clichés.
 // Disjoint from the previous default list (no carryover).
+//
+// IMPORTANT: do NOT add words that NAME a real system/daemon/transport state
+// (e.g. "Booting", "Daemonizing", "Mounting", "Buffering", "Reconnecting",
+// "Connecting"). A frozen flavor verb that happens to spell a genuine state
+// reads as a fault — a 12-minute slow turn once showed "Booting…" and looked
+// like the daemon was hung. Keep these to harmless action flavor only.
 export const SPINNER_VERBS = [
   'Backporting',
-  'Booting',
   'Branching',
   'Bridging',
-  'Buffering',
   'Caching',
   'Chaining',
   'Checksumming',
   'Clocking',
-  'Compiling',
   'Compressing',
   'Concatenating',
   'Cracking',
   'Cross-compiling',
-  'Daemonizing',
   'Debouncing',
   'Debugging',
   'Decoding',
@@ -72,7 +74,6 @@ export const SPINNER_VERBS = [
   'Iterating',
   'Jamming',
   'Latching',
-  'Linking',
   'Lowering',
   'Mapping',
   'Marshalling',
@@ -80,7 +81,6 @@ export const SPINNER_VERBS = [
   'Memoizing',
   'Merging',
   'Mirroring',
-  'Mounting',
   'Multiplexing',
   'Negotiating',
   'Normalizing',

--- a/runtime/src/tui/components/spinner/Spinner.tsx
+++ b/runtime/src/tui/components/spinner/Spinner.tsx
@@ -21,7 +21,7 @@ import { useAppState } from '../../state/AppState.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { stringWidth } from '../../ink/stringWidth.js';
 import type { SpinnerMode } from './types.js';
-import { computeBriefRightStatusLayout, getSpinnerEllipsis } from './utils.js';
+import { computeBriefRightStatusLayout, getSpinnerEllipsis, titleVerbForMode } from './utils.js';
 import { SpinnerAnimationRow } from './SpinnerAnimationRow.js';
 import { useSettings } from '../../hooks/useSettings.js';
 import { isInProcessTeammateTask } from '../../../tasks/InProcessTeammateTask/types.js';
@@ -158,11 +158,21 @@ function SpinnerWithVerbInner({
   const currentTask = tasksV2?.find(task => task.status !== 'pending' && task.status !== 'completed');
   const nextTask = findNextPendingTask(tasksV2);
 
-  // Use useState with initializer to pick a random verb once on mount
+  // Use useState with initializer to pick a random verb once on mount.
+  // Only used as a teammate-verb fallback now — the leader's own fallback is an
+  // HONEST phase label (see phaseVerb below), never a random flavor word, so a
+  // slow turn can't read as a system fault like a frozen "Booting…".
   const [randomVerb] = useState(() => sample(getSpinnerVerbs()));
 
-  // Leader's own verb (always the leader's, regardless of who is foregrounded)
-  const leaderVerb = overrideMessage ?? currentTask?.activeForm ?? currentTask?.subject ?? randomVerb;
+  // Honest phase label derived from the real streaming mode. Agrees with the
+  // workbench title-bar indicator (both call verbForMode), so the title bar and
+  // the status line never disagree about what the model is doing.
+  const phaseVerb = titleVerbForMode(mode);
+
+  // Leader's own verb (always the leader's, regardless of who is foregrounded).
+  // Prefer a real task subject/activeForm when present; otherwise show the
+  // honest phase label rather than a random flavor verb.
+  const leaderVerb = overrideMessage ?? currentTask?.activeForm ?? currentTask?.subject ?? phaseVerb;
   const effectiveVerb = foregroundedTeammate && !foregroundedTeammate.isIdle ? foregroundedTeammate.spinnerVerb ?? randomVerb : leaderVerb;
   const message = effectiveVerb + getSpinnerEllipsis();
 

--- a/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
+++ b/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
@@ -15,6 +15,72 @@ import { computeSpinnerMessageMaxWidth, truncateSpinnerText } from './utils.js';
 const SEP_WIDTH = stringWidth(' · ');
 const THINKING_BARE_WIDTH = stringWidth('thinking');
 const SHOW_TOKENS_AFTER_MS = 30_000;
+// After this long with no new token, surface a heartbeat note so a slow model
+// reads as "alive but slow" instead of "hung". A healthy model streams tokens
+// every fraction of a second, so this only fires on genuinely slow turns.
+const STALL_NOTE_AFTER_MS = 8_000;
+// Only compute a tokens/sec rate once the turn has run long enough and produced
+// enough tokens that the figure is meaningful (mirrors the budget-path gate).
+const RATE_MIN_ELAPSED_MS = 5_000;
+const RATE_MIN_TOKENS = 20;
+
+/**
+ * Tracks token liveness across renders so the row can tell "alive but slow"
+ * from "hung". Returns ms since the token counter last moved and a tokens/sec
+ * rate once tokens are flowing. Refs (not state) — the row re-renders from its
+ * parent's wall-clock tick, so reading on render is enough and avoids extra
+ * re-renders. `firstSeenAt` lets us measure rate from when tokens started, not
+ * from a pre-stream zero.
+ *
+ * `turnStartedAt` seeds the no-token clock so a turn that has already been
+ * silent for minutes reports its real silence on the very first render (e.g.
+ * after a remount), rather than resetting to zero each mount.
+ */
+function useTokenLiveness(
+  totalTokens: number,
+  now: number,
+  turnStartedAt: number,
+): {
+  msSinceLastToken: number;
+  ratePerSec: number;
+} {
+  const state = React.useRef<{
+    firstSeenAt: number | null;
+    lastChangeAt: number;
+    lastTokens: number;
+  } | null>(null);
+  if (state.current === null) {
+    // First render of this turn. If no token has streamed yet, anchor the
+    // no-token clock at the turn start so a long pre-token silence reads as
+    // honest immediately (e.g. a remount mid-stall). If tokens are already
+    // present we don't know when the last one arrived, so treat "now" as fresh
+    // and never falsely flag a clearly-alive stream as stalled.
+    state.current = {
+      firstSeenAt: totalTokens > 0 ? now : null,
+      lastChangeAt: totalTokens > 0 ? now : Math.min(turnStartedAt, now),
+      lastTokens: totalTokens,
+    };
+  }
+  const s = state.current;
+  if (totalTokens !== s.lastTokens) {
+    if (s.firstSeenAt === null && totalTokens > 0) s.firstSeenAt = now;
+    s.lastTokens = totalTokens;
+    s.lastChangeAt = now;
+  }
+  const msSinceLastToken = Math.max(0, now - s.lastChangeAt);
+  const sinceFirst = s.firstSeenAt !== null ? now - s.firstSeenAt : 0;
+  const ratePerSec =
+    totalTokens >= RATE_MIN_TOKENS && sinceFirst >= RATE_MIN_ELAPSED_MS
+      ? (totalTokens / sinceFirst) * 1000
+      : 0;
+  return { msSinceLastToken, ratePerSec };
+}
+
+function formatRate(ratePerSec: number): string {
+  return ratePerSec >= 10
+    ? `${Math.round(ratePerSec)} tok/s`
+    : `${ratePerSec.toFixed(1)} tok/s`;
+}
 
 export type SpinnerAnimationRowProps = {
   // Kept in the public prop shape while the surrounding spinner code is
@@ -77,12 +143,39 @@ export function SpinnerAnimationRow({
       ? foregroundedTeammate.progress?.tokenCount ?? 0
       : leaderTokens + teammateTokens;
   const tokenCount = formatNumber(totalTokens);
+  // Singular when exactly one token so the counter never reads "1 tokens".
+  const tokenNoun = totalTokens === 1 ? 'token' : 'tokens';
+  const tokensLabel = `${tokenCount} ${tokenNoun}`;
   const tokensText = hasRunningTeammates
-    ? `${tokenCount} tokens`
-    : `${figures.arrowDown} ${tokenCount} tokens`;
+    ? tokensLabel
+    : `${figures.arrowDown} ${tokensLabel}`;
   const tokensWidth = stringWidth(tokensText);
   const timerText = formatDuration(elapsedTimeMs);
   const timerWidth = stringWidth(timerText);
+
+  // Liveness: distinguishes "alive but slow" from "hung". Only meaningful for
+  // the leader's own stream (a foregrounded teammate reports its own progress).
+  const trackLiveness = !(foregroundedTeammate && !foregroundedTeammate.isIdle);
+  const { msSinceLastToken, ratePerSec } = useTokenLiveness(
+    trackLiveness ? totalTokens : 0,
+    now,
+    loadingStartTimeRef.current,
+  );
+  // Show the heartbeat once the turn has been waiting on a token long enough to
+  // look stuck — but not while "thinking" is already explaining the silence.
+  const showStallNote =
+    trackLiveness &&
+    !hasRunningTeammates &&
+    thinkingStatus !== 'thinking' &&
+    elapsedTimeMs > STALL_NOTE_AFTER_MS &&
+    msSinceLastToken > STALL_NOTE_AFTER_MS;
+  const stallNoteText = showStallNote
+    ? totalTokens > 0
+      ? `slow model · last token ${formatDuration(msSinceLastToken)} ago`
+      : 'slow model · still generating'
+    : null;
+  const stallNoteWidth = stallNoteText ? stringWidth(stallNoteText) : 0;
+  const rateText = ratePerSec > 0 ? formatRate(ratePerSec) : null;
 
   let thinkingText =
     thinkingStatus === 'thinking'
@@ -94,7 +187,10 @@ export function SpinnerAnimationRow({
 
   const messageWidth = stringWidth(visibleMessage) + 2;
   const wantsThinking = thinkingStatus !== null;
-  const wantsTimerAndTokens = verbose || hasRunningTeammates || elapsedTimeMs > SHOW_TOKENS_AFTER_MS;
+  // The stall note is itself a liveness signal, so surface the timer/tokens
+  // alongside it even before the usual 30s threshold.
+  const wantsTimerAndTokens =
+    verbose || hasRunningTeammates || elapsedTimeMs > SHOW_TOKENS_AFTER_MS || showStallNote;
   const availableSpace = columns - messageWidth - 5;
   let showThinking = wantsThinking && availableSpace > thinkingWidthValue;
   if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
@@ -109,6 +205,14 @@ export function SpinnerAnimationRow({
   const showTimer = wantsTimerAndTokens && availableSpace > usedAfterThinking + timerWidth;
   const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + SEP_WIDTH : 0);
   const showTokens = wantsTimerAndTokens && totalTokens > 0 && availableSpace > usedAfterTimer + tokensWidth;
+  // Only append the rate when it actually fits next to the token count.
+  const usedAfterTokens = usedAfterTimer + (showTokens ? tokensWidth + SEP_WIDTH : 0);
+  const rateSuffix = showTokens && rateText ? ` · ${rateText}` : '';
+  const showRate =
+    rateSuffix !== '' && availableSpace > usedAfterTokens + stringWidth(rateSuffix);
+  const usedAfterRate = usedAfterTokens + (showRate ? stringWidth(rateSuffix) : 0);
+  const fitStallNote =
+    stallNoteText !== null && availableSpace > usedAfterRate + stallNoteWidth + SEP_WIDTH;
   const thinkingOnly = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
 
   const parts = [
@@ -117,8 +221,11 @@ export function SpinnerAnimationRow({
     ...(showTokens ? [
       <Box flexDirection="row" key="tokens">
         {!hasRunningTeammates && <SpinnerModeGlyph mode={mode} />}
-        <Text dimColor>{tokenCount} tokens</Text>
+        <Text dimColor>{tokensLabel}{showRate ? rateSuffix : ''}</Text>
       </Box>,
+    ] : []),
+    ...(fitStallNote && stallNoteText ? [
+      <Text color="warning" key="stall">{stallNoteText}</Text>,
     ] : []),
     ...(showThinking && thinkingText ? [
       <Text dimColor key="thinking">{thinkingOnly ? `(${thinkingText})` : thinkingText}</Text>,

--- a/runtime/src/tui/components/spinner/utils.ts
+++ b/runtime/src/tui/components/spinner/utils.ts
@@ -5,7 +5,42 @@ import {
 import { stringWidth } from '../../ink/stringWidth.js'
 import { getGraphemeSegmenter } from '../../../utils/intl.js'
 import type { RGBColor as RGBColorString } from '../../ink/styles.js'
-import type { RGBColor as RGBColorType } from './types.js'
+import type { RGBColor as RGBColorType, SpinnerMode } from './types.js'
+
+/**
+ * Single source of truth for the plain-language phase label of a streaming
+ * turn. Both the workbench title-bar indicator and the composer status line
+ * read this so they always agree (e.g. the title bar showing "responding…"
+ * while the status line shows a different word is a known confusion bug).
+ *
+ * This is an HONEST description of what the model is actually doing right now,
+ * derived from the real SpinnerMode — never a random flavor word that could be
+ * misread as a system fault (e.g. "Booting…" stuck for minutes).
+ */
+export function verbForMode(mode: SpinnerMode): string {
+  switch (mode) {
+    case 'tool-use':
+      return 'running tools'
+    case 'tool-input':
+      return 'preparing tools'
+    case 'thinking':
+      return 'thinking'
+    case 'responding':
+      return 'responding'
+    case 'requesting':
+      return 'working'
+    // Any unexpected/legacy mode value degrades to the neutral honest label
+    // rather than blank or a crash.
+    default:
+      return 'working'
+  }
+}
+
+/** Title-case variant for the composer status line ("Responding…"). */
+export function titleVerbForMode(mode: SpinnerMode): string {
+  const verb = verbForMode(mode)
+  return verb.charAt(0).toUpperCase() + verb.slice(1)
+}
 
 type SpinnerGlyphEnv = {
   readonly AGENC_TUI_GLYPHS?: string

--- a/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
+++ b/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
@@ -5,6 +5,7 @@ import type { SpinnerMode } from "../components/spinner/types.js";
 import {
   getDefaultCharacters,
   getReducedMotionDot,
+  verbForMode,
 } from "../components/spinner/utils.js";
 import { useSettings } from "../hooks/useSettings.js";
 
@@ -19,23 +20,6 @@ import { useSettings } from "../hooks/useSettings.js";
  */
 
 const FRAME_INTERVAL_MS = 120;
-
-/** Plain-language verb for each streaming phase, kept short for the status bar. */
-function verbForMode(mode: SpinnerMode): string {
-  switch (mode) {
-    case "tool-use":
-      return "running tools";
-    case "tool-input":
-      return "preparing tools";
-    case "thinking":
-      return "thinking";
-    case "responding":
-      return "responding";
-    case "requesting":
-    default:
-      return "working";
-  }
-}
 
 export function WorkbenchActivityIndicator({
   mode,
@@ -63,9 +47,14 @@ export function WorkbenchActivityIndicator({
     ? getReducedMotionDot()
     : (frames[frameIndex % frames.length] ?? frames[0] ?? "·");
 
+  // When the animated glyph lands on its dot frame ("·"), it sits right next to
+  // the leading "·" separator and reads as a doubled "· ·". Drop the separator
+  // for that frame so it renders a single dot instead.
+  const separator = glyph === "·" ? " " : " · ";
+
   return (
     <Box flexShrink={0} flexDirection="row">
-      <Text dimColor wrap="truncate-end"> · </Text>
+      <Text dimColor wrap="truncate-end">{separator}</Text>
       <Text color="agenc">{glyph}</Text>
       <Text color="text2" wrap="truncate-end"> {verbForMode(mode)}…</Text>
     </Box>

--- a/runtime/tests/constants/spinnerVerbs.test.ts
+++ b/runtime/tests/constants/spinnerVerbs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import { SPINNER_VERBS } from "../../src/constants/spinnerVerbs.js";
+
+// #1: a frozen flavor verb that spells a genuine system/daemon/transport state
+// reads as a fault — a slow turn once showed "Booting…" for 12 minutes and
+// looked like the daemon was hung. The flavor list must never name such a
+// state. This guard is revert-sensitive: re-adding any of these goes red.
+const SYSTEM_STATE_COLLISIONS = [
+  "Booting",
+  "Daemonizing",
+  "Mounting",
+  "Buffering",
+  "Compiling",
+  "Linking",
+  "Reconnecting",
+  "Connecting",
+  "Disconnected",
+];
+
+describe("SPINNER_VERBS flavor list", () => {
+  test("contains no word that names a real system/daemon/transport state", () => {
+    for (const collision of SYSTEM_STATE_COLLISIONS) {
+      expect(SPINNER_VERBS).not.toContain(collision);
+    }
+  });
+
+  test("is still a non-empty list of capitalized flavor verbs", () => {
+    expect(SPINNER_VERBS.length).toBeGreaterThan(0);
+    for (const verb of SPINNER_VERBS) {
+      expect(verb).toMatch(/^[A-Z]/);
+    }
+  });
+});

--- a/runtime/tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx
+++ b/runtime/tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  SpinnerAnimationRow,
+  type SpinnerAnimationRowProps,
+} from "../../../../src/tui/components/spinner/SpinnerAnimationRow.js";
+import { renderToString } from "../../../../src/utils/staticRender.js";
+
+const NOW = new Date("2026-06-23T12:00:00.000Z").getTime();
+
+function makeRef<T>(current: T): React.RefObject<T> {
+  return { current };
+}
+
+function props(
+  overrides: Partial<SpinnerAnimationRowProps> = {},
+): SpinnerAnimationRowProps {
+  return {
+    columns: 120,
+    effortSuffix: "",
+    foregroundedTeammate: undefined,
+    hasActiveTools: false,
+    hasRunningTeammates: false,
+    leaderIsIdle: false,
+    loadingStartTimeRef: makeRef(NOW - 31_000),
+    message: "Responding",
+    messageColor: "text",
+    mode: "responding",
+    overrideColor: null,
+    pauseStartTimeRef: makeRef(null),
+    reducedMotion: false,
+    responseLengthRef: makeRef(800),
+    shimmerColor: "agencShimmer",
+    spinnerSuffix: null,
+    teammateTokens: 0,
+    thinkingStatus: null,
+    totalPausedMsRef: makeRef(0),
+    verbose: false,
+    ...overrides,
+  };
+}
+
+async function renderRow(
+  overrides: Partial<SpinnerAnimationRowProps> = {},
+): Promise<string> {
+  const rowProps = props(overrides);
+  return renderToString(<SpinnerAnimationRow {...rowProps} />, rowProps.columns);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SpinnerAnimationRow liveness + token grammar", () => {
+  // #3a: the counter must read "1 token", never "1 tokens".
+  test("uses the singular noun for exactly one token", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      // round(4 / 4) === 1 token
+      responseLengthRef: makeRef(4),
+      verbose: true,
+    });
+
+    expect(output).toContain("1 token");
+    expect(output).not.toContain("1 tokens");
+  });
+
+  test("keeps the plural noun for token counts other than one", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      responseLengthRef: makeRef(800), // 200 tokens
+      verbose: true,
+    });
+
+    expect(output).toContain("200 tokens");
+  });
+
+  // #2: a slow turn that has produced no new token for a while must surface a
+  // moving liveness note so it reads as "alive but slow", not "hung". This
+  // reproduces the frozen "↓ 1 token (12m …)" build session.
+  test("shows a slow-model heartbeat after a long no-token gap", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      // Turn started ~13 minutes ago and nothing has streamed yet.
+      loadingStartTimeRef: makeRef(NOW - 13 * 60_000),
+      responseLengthRef: makeRef(0),
+      mode: "responding",
+    });
+
+    expect(output).toContain("slow model");
+    expect(output).toContain("still generating");
+  });
+
+  test("reports time since the last token once some output has streamed", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      // Tokens already present at mount, so the note reports the silence gap.
+      loadingStartTimeRef: makeRef(NOW - 5 * 60_000),
+      responseLengthRef: makeRef(40), // 10 tokens
+      mode: "responding",
+    });
+
+    // Tokens are present, so on the first render the stream is treated as
+    // fresh — no false stall. (The "last token Ns ago" branch only appears
+    // after a real observed gap across renders in the live UI.)
+    expect(output).not.toContain("slow model");
+    expect(output).toContain("10 tokens");
+  });
+
+  // The heartbeat must NOT appear while "thinking" is already explaining the
+  // silence (thinking has its own visible status).
+  test("suppresses the heartbeat while thinking is shown", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      loadingStartTimeRef: makeRef(NOW - 13 * 60_000),
+      responseLengthRef: makeRef(0),
+      thinkingStatus: "thinking",
+    });
+
+    expect(output).not.toContain("slow model");
+    expect(output).toContain("thinking");
+  });
+
+  // The heartbeat must NOT appear for a fresh, fast turn (no false alarm).
+  test("does not flag a fresh turn as slow", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      loadingStartTimeRef: makeRef(NOW - 1_000),
+      responseLengthRef: makeRef(0),
+      verbose: true,
+    });
+
+    expect(output).not.toContain("slow model");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-076-components-spinner-Spinner.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-076-components-spinner-Spinner.test.tsx
@@ -341,7 +341,9 @@ describe("Spinner coverage swarm row 076", () => {
       />,
     );
 
-    expect(output).toContain("ROW|responding|Working");
+    // With no real task, the leader's fallback is the honest phase label
+    // ("Responding") rather than a random flavor verb.
+    expect(output).toContain("ROW|responding|Responding");
     expect(output).toContain("Indexing, Testing");
     expect(output).not.toContain("Tip: Use /clear");
   });

--- a/runtime/tests/tui/workbench/activity-and-diff.test.tsx
+++ b/runtime/tests/tui/workbench/activity-and-diff.test.tsx
@@ -8,7 +8,12 @@ import { WorkbenchStatusBar } from "../../../src/tui/workbench/WorkbenchStatusBa
 import { DiffInline } from "../../../src/tui/components/v2/primitives.js";
 import { buildEditDiffPreview } from "../../../src/tui/edit-diff-preview.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
-import { getReducedMotionDot } from "../../../src/tui/components/spinner/utils.js";
+import {
+  getReducedMotionDot,
+  titleVerbForMode,
+  verbForMode,
+} from "../../../src/tui/components/spinner/utils.js";
+import type { SpinnerMode } from "../../../src/tui/components/spinner/types.js";
 
 function withState(node: React.ReactNode): React.ReactElement {
   return <AppStateProvider initialState={getDefaultAppState()}>{node}</AppStateProvider>;
@@ -65,6 +70,57 @@ describe("WorkbenchActivityIndicator (working / waiting-on-model signal)", () =>
     );
     expect(out).toContain(getReducedMotionDot());
     expect(out).toContain("working");
+  });
+
+  // #16: when the animated glyph lands on its dot frame ("·") it sits next to
+  // the leading "·" separator and reads as a doubled "· ·". The separator must
+  // collapse for that frame. reduced-motion forces a deterministic, stable
+  // glyph so the assertion is frame-independent.
+  it("never renders a doubled '· ·' next to the verb", async () => {
+    for (const mode of [
+      "requesting",
+      "responding",
+      "thinking",
+      "tool-use",
+      "tool-input",
+    ] as const) {
+      const out = await renderToString(
+        withState(<WorkbenchActivityIndicator mode={mode} />),
+        80,
+      );
+      expect(out).not.toContain("· ·");
+    }
+  });
+});
+
+// #1 / #11: the workbench title bar and the composer status line must describe
+// the SAME phase. Both derive their honest label from verbForMode, so the
+// title-bar phrasing and the status-line phrasing can never silently diverge.
+describe("title bar / status line phase agreement", () => {
+  const MODES: readonly SpinnerMode[] = [
+    "requesting",
+    "responding",
+    "thinking",
+    "tool-use",
+    "tool-input",
+  ];
+
+  it("derives the status-line title verb from the same phase as the title bar", () => {
+    for (const mode of MODES) {
+      // titleVerbForMode (status line) is just the title-cased verbForMode
+      // (title bar) — same word, never a random system-colliding flavor verb.
+      expect(titleVerbForMode(mode).toLowerCase()).toBe(verbForMode(mode));
+    }
+  });
+
+  it("renders the honest phase word in the workbench title bar for each mode", async () => {
+    for (const mode of MODES) {
+      const out = await renderToString(
+        withState(<WorkbenchActivityIndicator mode={mode} />),
+        80,
+      );
+      expect(out).toContain(verbForMode(mode));
+    }
   });
 });
 


### PR DESCRIPTION
Found by a real multi-turn build on a slow local model that looked hung for 12 min. Replace the random frozen verb (which showed 'Booting…') with an honest phase label shared by the status line and title bar; scrub system-state words from the flavor list; add a liveness heartbeat (still generating / last token Ns ago / tok/s) so a slow turn reads as alive. Verified live; revert-sensitive tests; full suite 13237.