### PR TITLE
tui visual iter 10: humanize transcript timestamps

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
@@ -109,8 +109,17 @@ function PromptInputQueuedCommandsImpl(): React.ReactNode {
       }
       // [Image #N] placeholders are inline in the text value (inserted at
       // paste time), so the queue preview shows them without stub blocks.
+      //
+      // Pass an explicit empty timestamp so createUserMessage does NOT default
+      // to new Date().toISOString(): the queue is a "what's next" preview, not
+      // the live turn, and the per-item enqueue time isn't tracked. Defaulting
+      // here mints the SAME render-time clock for every queued item (the
+      // useMemo re-mints the whole list whenever one is added), so all previews
+      // would show one identical machine timestamp. A quiet "queued" marker is
+      // rendered in the header instead (see Msg / HighlightedThinkingText).
       return createUserMessage({
-        content
+        content,
+        timestamp: '',
       });
     }));
   }, [queuedCommands]);

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { PermissionMode } from '../../../permissions/types.js'
 import { AURA_LIFECYCLE_GLYPHS, AURA_PLAN_GLYPHS, type Theme } from '../../../utils/theme.js'
 import { useModalOrTerminalSize } from '../../context/modalContext.js'
+import { useQueuedMessage } from '../../context/QueuedMessageContext.js'
 import { ContentWidthProvider, insetContentWidth, useContentWidth } from '../../context/contentWidthContext.js'
 import { useTerminalSize } from '../../hooks/useTerminalSize.js'
 import Box from '../../ink/components/Box.js'
@@ -885,6 +886,10 @@ export function Msg({
   }
   const inheritedWidth = useContentWidth()
   const contentWidth = insetContentWidth(inheritedWidth, 3)
+  // Queued previews carry no real per-item enqueue time, so they pass no
+  // `time` (see PromptInputQueuedCommands). Show a quiet neutral "queued"
+  // marker in the header slot instead of a misleading render-time clock.
+  const isQueued = useQueuedMessage()?.isQueued ?? false
   return (
     <Box flexDirection="row" gap={2}>
       <ThemedText color={colors[role]}>{role === 'system' ? '∙' : '▮'}</ThemedText>
@@ -893,7 +898,11 @@ export function Msg({
           <ThemedText color={colors[role]} bold>
             {label.toUpperCase()}
           </ThemedText>
-          {time ? <ThemedText color="inactive">{time}</ThemedText> : null}
+          {time ? (
+            <ThemedText color="inactive">{time}</ThemedText>
+          ) : isQueued ? (
+            <ThemedText color="inactive">queued</ThemedText>
+          ) : null}
         </Box>
         <ContentWidthProvider width={contentWidth}>
           <Content color="text2">{children}</Content>

--- a/runtime/src/tui/context/QueuedMessageContext.tsx
+++ b/runtime/src/tui/context/QueuedMessageContext.tsx
@@ -18,7 +18,7 @@ type Props = {
   useBriefLayout?: boolean;
   children: React.ReactNode;
 };
-export function QueuedMessageProvider(t0) {
+export function QueuedMessageProvider(t0: Props) {
   const $ = _c(9);
   const {
     isFirst,

--- a/runtime/src/tui/message-renderers/UserPromptMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserPromptMessage.tsx
@@ -5,6 +5,7 @@ import type { AgenCTextBlockParam } from '../../types/message.js';
 import { Box } from '../ink.js';
 import { useAppState } from '../state/AppState.js';
 import { isEnvTruthy } from '../../utils/envUtils';
+import { formatBriefTimestamp } from '../../utils/formatBriefTimestamp.js';
 import { logError } from '../../utils/log.js';
 import { countCharInString } from '../../utils/stringUtils.js';
 import { selectAgenCTuiGlyphs } from '../glyphs.js';
@@ -85,12 +86,20 @@ export function UserPromptMessage({
   const displayText = useMemo(() => {
     return truncateUserPromptDisplayText(text);
   }, [text]);
+  // The transcript label line is a chat header, not a log line: render a short
+  // local time ("1:37 AM" / "Sunday, 4:15 PM") via the shared messaging-app
+  // formatter instead of leaking the raw ISO-8601 machine timestamp. The brief
+  // path already does this inside HighlightedThinkingText.
+  const displayTime = useMemo(
+    () => (timestamp ? formatBriefTimestamp(timestamp) : undefined),
+    [timestamp],
+  );
   const isSelected = useContext(MessageActionsSelectedContext);
   if (!text) {
     logError(new Error('No content found in user prompt message'));
     return null;
   }
   return <Box flexDirection="column" marginTop={addMargin ? 1 : 0} backgroundColor={isSelected ? 'messageActionsBackground' : useBriefLayout ? undefined : 'userMessageBackground'} paddingRight={useBriefLayout ? 0 : 1}>
-      {useBriefLayout ? <HighlightedThinkingText text={displayText} useBriefLayout timestamp={timestamp} /> : <Msg role="user" label="you" time={timestamp}><HighlightedThinkingText text={displayText} showPointer={false} /></Msg>}
+      {useBriefLayout ? <HighlightedThinkingText text={displayText} useBriefLayout timestamp={timestamp} /> : <Msg role="user" label="you" time={displayTime}><HighlightedThinkingText text={displayText} showPointer={false} /></Msg>}
     </Box>;
 }

--- a/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
@@ -14,6 +14,11 @@ const queueFixture = vi.hoisted(() => ({
   commands: [] as QueuedCommandFixture[],
 }))
 
+// Capture the exact args the queue passes to createUserMessage so we can
+// assert it supplies an explicit empty timestamp (never letting it default
+// to a render-time ISO clock).
+const createUserMessageSpy = vi.hoisted(() => vi.fn())
+
 vi.mock('bun:bundle', () => ({
   feature: () => false,
 }))
@@ -40,10 +45,14 @@ vi.mock('../Message.js', () => ({
 
 vi.mock('../../../utils/messages.js', () => ({
   EMPTY_LOOKUPS: {},
-  createUserMessage: ({ content }: { content: unknown }) => ({
-    type: 'user',
-    message: { content },
-  }),
+  createUserMessage: (args: { content: unknown; timestamp?: string }) => {
+    createUserMessageSpy(args)
+    return {
+      type: 'user',
+      message: { content: args.content },
+      timestamp: args.timestamp,
+    }
+  },
   normalizeMessages: (messages: unknown[]) => messages,
 }))
 
@@ -55,12 +64,32 @@ vi.mock('../../../utils/messageQueueManager.js', () => ({
 
 describe('PromptInputQueuedCommands', () => {
   beforeEach(() => {
+    createUserMessageSpy.mockClear()
     queueFixture.commands = [
       {
         value: 'Use another library',
         mode: 'prompt',
       },
     ]
+  })
+
+  it('passes an explicit empty timestamp so queued previews never default to a render-time ISO clock', async () => {
+    queueFixture.commands = [
+      { value: 'first prompt', mode: 'prompt' },
+      { value: 'second prompt', mode: 'prompt' },
+    ]
+    const { PromptInputQueuedCommands } = await import('./PromptInputQueuedCommands.js')
+
+    await renderToString(<PromptInputQueuedCommands />, 100)
+
+    expect(createUserMessageSpy).toHaveBeenCalled()
+    // Every queued preview must receive an explicit empty timestamp; a bare
+    // call (no timestamp) lets createUserMessage default to
+    // new Date().toISOString(), collapsing all previews to one identical
+    // render-time machine clock.
+    for (const call of createUserMessageSpy.mock.calls) {
+      expect(call[0]).toHaveProperty('timestamp', '')
+    }
   })
 
   it('shows a next-turn guidance banner for queued prompt messages', async () => {

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest'
 
 import { renderToString } from '../../../utils/staticRender.js'
 import { Text } from '../../ink.js'
+import { QueuedMessageProvider } from '../../context/QueuedMessageContext.js'
 import {
   MenuModal,
   ModeSwitcher,
+  Msg,
   PlanList,
   SlashPalette,
   StatusSegment,
@@ -181,5 +183,40 @@ describe('v2 primitives', () => {
     expect(output).toContain('scroll 16-22/30')
     expect(output).not.toContain('item-00')
     expect(output).not.toContain('item-29')
+  })
+})
+
+describe('Msg queued header marker', () => {
+  it('shows a quiet "queued" marker (not a clock) for a queued message without a time', async () => {
+    const output = await renderToString(
+      <QueuedMessageProvider isFirst>
+        <Msg role="user" label="you">
+          <Text>pending prompt body</Text>
+        </Msg>
+      </QueuedMessageProvider>,
+      { columns: 100, rows: 12 },
+    )
+
+    expect(output).toContain('YOU')
+    expect(output).toContain('pending prompt body')
+    // The neutral marker stands in for the missing per-item enqueue time.
+    // (Body text deliberately avoids the word "queued" so this assertion is
+    // revert-sensitive to the marker rendering.)
+    expect(output).toContain('queued')
+    // It must not invent a clock or leak an ISO machine timestamp.
+    expect(output).not.toMatch(/\d{1,2}:\d{2}/)
+    expect(output).not.toMatch(/\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('shows the provided time (not the queued marker) when a non-queued message has a time', async () => {
+    const output = await renderToString(
+      <Msg role="user" label="you" time="1:37 AM">
+        <Text>live prompt body</Text>
+      </Msg>,
+      { columns: 100, rows: 12 },
+    )
+
+    expect(output).toContain('1:37 AM')
+    expect(output).not.toContain('queued')
   })
 })

--- a/runtime/tests/tui/coverage-swarm/swarm-114-message-renderers-UserPromptMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-114-message-renderers-UserPromptMessage.test.tsx
@@ -88,11 +88,18 @@ vi.mock('../../../src/tui/components/v2/primitives.js', async () => {
 
 import { renderToString } from '../../../src/utils/staticRender.js'
 import { MessageActionsSelectedContext } from '../../../src/tui/components/messageActions.js'
+import { formatBriefTimestamp } from '../../../src/utils/formatBriefTimestamp.js'
 import {
   getUserPromptTruncationNotice,
   truncateUserPromptDisplayText,
   UserPromptMessage,
 } from '../../../src/tui/message-renderers/UserPromptMessage.js'
+
+// A real ISO timestamp the standard transcript path must format to a short
+// local time before handing it to <Msg>. Use the shared formatter for the
+// expected value so the assertion stays locale-robust.
+const ISO_TS = '2026-06-24T11:45:00.000Z'
+const FORMATTED_TS = formatBriefTimestamp(ISO_TS)
 
 const originalBriefEnv = process.env.AGENC_BRIEF
 
@@ -178,11 +185,16 @@ describe('UserPromptMessage swarm 114 coverage', () => {
       addMargin: true,
       isSelected: true,
       text: 'normal selected prompt',
-      timestamp: '11:45',
+      timestamp: ISO_TS,
     })
 
-    expect(output).toContain('msg role:user label:you time:11:45')
-    expect(output).toContain(
+    // The raw ISO is formatted to a short local time before reaching <Msg>.
+    // Collapse whitespace: the formatted timestamp is longer than a raw ISO and
+    // can push later content onto a wrapped terminal line.
+    const flat = output.replace(/\s+/g, ' ')
+    expect(flat).toContain(`msg role:user label:you time:${FORMATTED_TS}`)
+    expect(output).not.toContain(ISO_TS)
+    expect(flat).toContain(
       'highlight brief:undefined pointer:false time:none text:normal',
     )
     expect(output).toContain('selected prompt')
@@ -197,25 +209,34 @@ describe('UserPromptMessage swarm 114 coverage', () => {
     process.env.AGENC_BRIEF = '1'
     state.isBriefOnly = true
 
-    await expect(
-      renderPrompt({ text: 'brief prompt', timestamp: '12:00' }),
-    ).resolves.toContain(
-      'highlight brief:true pointer:undefined time:12:00 text:brief prompt',
+    const flatten = (s: string) => s.replace(/\s+/g, ' ')
+
+    // Brief path passes the raw timestamp straight to HighlightedThinkingText
+    // (which formats internally); the stub here echoes whatever it receives.
+    expect(
+      flatten(await renderPrompt({ text: 'brief prompt', timestamp: ISO_TS })),
+    ).toContain(
+      `highlight brief:true pointer:undefined time:${ISO_TS} text:brief prompt`,
     )
 
-    await expect(
-      renderPrompt({
-        isTranscriptMode: true,
-        text: 'transcript prompt',
-        timestamp: '12:01',
-      }),
-    ).resolves.toContain('msg role:user label:you time:12:01')
+    // Standard transcript path formats before <Msg>.
+    expect(
+      flatten(
+        await renderPrompt({
+          isTranscriptMode: true,
+          text: 'transcript prompt',
+          timestamp: ISO_TS,
+        }),
+      ),
+    ).toContain(`msg role:user label:you time:${FORMATTED_TS}`)
 
     state.viewingAgentTaskId = 'task-114'
 
-    await expect(
-      renderPrompt({ text: 'viewing task prompt', timestamp: '12:02' }),
-    ).resolves.toContain('msg role:user label:you time:12:02')
+    expect(
+      flatten(
+        await renderPrompt({ text: 'viewing task prompt', timestamp: ISO_TS }),
+      ),
+    ).toContain(`msg role:user label:you time:${FORMATTED_TS}`)
   })
 
   test('allows active Kairos with env opt-in to drive brief layout', async () => {

--- a/runtime/tests/tui/message-renderers/UserPromptMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserPromptMessage.coverage.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, expect, test } from 'vitest'
 
 import { renderToString } from '../../utils/staticRender.js'
+import { QueuedMessageProvider } from '../context/QueuedMessageContext.js'
 import { UserPromptMessage } from './UserPromptMessage.js'
 
 describe('UserPromptMessage coverage', () => {
@@ -17,16 +18,77 @@ describe('UserPromptMessage coverage', () => {
       <UserPromptMessage
         addMargin={false}
         param={{ type: 'text', text: `${head}\n${hidden}\n${tail}` }}
-        timestamp="12:34"
+        timestamp="2026-06-24T12:34:00.000Z"
       />,
       { columns: 6_000, rows: 24 },
     )
 
     expect(output).toContain('YOU')
-    expect(output).toContain('12:34')
+    // Header shows a short local time, never the raw ISO machine timestamp.
+    expect(output).toMatch(/\d{1,2}:\d{2}/)
+    expect(output).not.toContain('2026-06-24T12:34:00.000Z')
     expect(output).toContain('HEAD_START')
     expect(output).toContain('TAIL_END')
     expect(output).toMatch(/… \+\d+ lines …/)
     expect(output).not.toContain('MIDDLE_SENTINEL')
+  })
+
+  // Regression: the standard transcript YOU header used to leak the raw
+  // ISO-8601 machine timestamp (e.g. "2026-06-24T01:37:00.437Z"). It must
+  // now render a short local time via formatBriefTimestamp.
+  test('renders a short local time in the YOU header, never a raw ISO timestamp', async () => {
+    const output = await renderToString(
+      <UserPromptMessage
+        addMargin={false}
+        param={{ type: 'text', text: 'hello there' }}
+        timestamp="2026-06-24T01:37:00.437Z"
+      />,
+      { columns: 100, rows: 12 },
+    )
+
+    expect(output).toContain('YOU')
+    expect(output).toContain('hello there')
+    // No raw ISO machine timestamp in the header.
+    expect(output).not.toContain('2026-06-24T01:37:00.437Z')
+    expect(output).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)
+    expect(output).not.toContain('Z')
+    // A short clock time is present (e.g. "1:37 AM" or "01:37").
+    expect(output).toMatch(/\d{1,2}:\d{2}/)
+  })
+
+  // Regression for the queued-input preview bug: queued previews used to all
+  // share one identical render-time ISO timestamp. The queue now hands
+  // createUserMessage an explicit empty timestamp (no render-time default), so
+  // the preview shows a neutral "queued" marker instead of a machine clock.
+  // This renders the same UserPromptMessage the queue renders, with the empty
+  // timestamp the queue supplies, inside the queued context.
+  test('queued preview shows a quiet "queued" marker, never a render-time ISO clock', async () => {
+    const renderQueued = (text: string) =>
+      renderToString(
+        <QueuedMessageProvider isFirst>
+          <UserPromptMessage
+            addMargin={false}
+            param={{ type: 'text', text }}
+            isTranscriptMode={false}
+            timestamp=""
+          />
+        </QueuedMessageProvider>,
+        { columns: 100, rows: 12 },
+      )
+
+    // Body text deliberately avoids the word "queued" so the marker assertion
+    // below is revert-sensitive to the header rendering.
+    const first = await renderQueued('first pending prompt')
+    const second = await renderQueued('second pending prompt')
+
+    for (const output of [first, second]) {
+      expect(output).toContain('YOU')
+      expect(output).toContain('queued')
+      // No machine timestamp of any kind.
+      expect(output).not.toMatch(/\d{4}-\d{2}-\d{2}T/)
+      expect(output).not.toMatch(/\d{1,2}:\d{2}/)
+    }
+    expect(first).toContain('first pending prompt')
+    expect(second).toContain('second pending prompt')
   })
 })


### PR DESCRIPTION
From the real multi-turn build session: YOU turn headers showed raw ISO-8601 ('2026-06-24T01:37:00.437Z') -> now formatBriefTimestamp ('1:37 AM'); queued-input previews showed five identical render-time ISO clocks -> now a neutral 'queued' marker. Verified live; revert-sensitive tests; full suite 13242.