### PR TITLE
tui visual iter 11: transcript scroll-position indicator

### DIFF
--- a/runtime/src/tui/workbench/surfaces/TranscriptSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TranscriptSurface.tsx
@@ -1,7 +1,86 @@
-import React, { type RefObject } from "react";
+import React, { type RefObject, useCallback, useSyncExternalStore } from "react";
 
+import { selectAgenCTuiGlyphs } from "../../glyphs.js";
 import { Box, Text } from "../../ink.js";
 import ScrollBox, { type ScrollBoxHandle } from "../../ink/components/ScrollBox.js";
+
+const NOOP_UNSUB = (): void => {};
+
+/**
+ * Number of content rows below the viewport bottom, or 0 when the viewport
+ * already reaches the bottom. Uses scrollTop + the not-yet-drained
+ * pendingScrollDelta so the count is correct mid-wheel-burst (scrollBy
+ * accumulates into pendingScrollDelta without moving scrollTop until the
+ * renderer drains it). Mirrors FullscreenLayout's pillVisible math.
+ */
+function rowsBelow(handle: ScrollBoxHandle): number {
+  const bottom = handle.getScrollTop() + handle.getPendingDelta() + handle.getViewportHeight();
+  return Math.max(0, handle.getScrollHeight() - bottom);
+}
+
+/**
+ * Compact, on-brand "viewing history" affordance. Renders a single row ONLY
+ * when the transcript is scrolled away from the bottom — nothing when
+ * following (sticky) or when the viewport already reaches the bottom. It
+ * reuses the scroll state the ScrollBox already exposes (isSticky,
+ * scrollTop, pendingScrollDelta, viewportHeight, scrollHeight) — the same
+ * signals FullscreenLayout's NewMessagesPill and the StickyTracker read —
+ * rather than building any new scroll bookkeeping.
+ *
+ * It lives as a fixed 1-row sibling AFTER the ScrollBox (flexShrink={0}) so
+ * it can never overlap the composer/footer: when present it shrinks the
+ * scroll area by exactly one row; when absent the scroll area reclaims it.
+ *
+ * Return-to-bottom is the existing follow key (End / G / ctrl+End, handled
+ * by ScrollKeybindingHandler's modal pager) — this row only labels it.
+ */
+function ScrollPositionIndicator({
+  scrollRef,
+  atWelcome,
+}: {
+  readonly scrollRef: RefObject<ScrollBoxHandle | null>;
+  readonly atWelcome: boolean;
+}): React.ReactElement | null {
+  // Fine-grained subscription to imperative scroll changes — re-renders this
+  // leaf only (the ScrollBox content tree is untouched), exactly like
+  // FullscreenLayout's pillVisible / VirtualMessageList's StickyTracker.
+  const subscribe = useCallback(
+    (listener: () => void) => scrollRef.current?.subscribe(listener) ?? NOOP_UNSUB,
+    [scrollRef],
+  );
+  // Snapshot folds "scrolled up" and the below-count into one number so the
+  // store stays stable when nothing relevant changed: -1 = following (hide),
+  // >= 0 = scrolled up with that many rows below.
+  const snapshot = useSyncExternalStore(subscribe, () => {
+    // On the empty welcome screen stickyScroll is off, so hide the indicator
+    // there — it would otherwise read oddly ("End to follow" with no stream).
+    if (atWelcome) return -1;
+    const handle = scrollRef.current;
+    if (!handle) return -1;
+    // sticky → following the live bottom; never show the indicator. Also hide
+    // when the viewport already reaches the bottom (e.g. content shorter than
+    // the viewport) so we don't flash on a transcript that can't scroll.
+    if (handle.isSticky()) return -1;
+    const below = rowsBelow(handle);
+    return below <= 0 ? -1 : below;
+  });
+
+  if (snapshot < 0) return null;
+
+  const glyphs = selectAgenCTuiGlyphs();
+  const noun = snapshot === 1 ? "line" : "lines";
+  return (
+    <Box height={1} flexShrink={0}>
+      {/* `inactive` tone matches the ProjectExplorer "N above/below" overflow
+          markers — the analogous position affordance — and reads as a
+          position, not a notification. truncate-end degrades cleanly at
+          narrow widths instead of wrapping into a second row. */}
+      <Text color="inactive" wrap="truncate-end">
+        {glyphs.arrowDown} {snapshot} {noun} below {glyphs.separator} End to follow
+      </Text>
+    </Box>
+  );
+}
 
 export function TranscriptSurface({
   children,
@@ -20,9 +99,12 @@ export function TranscriptSurface({
   readonly atWelcome?: boolean;
 }): React.ReactElement {
   const body = scrollRef ? (
-    <ScrollBox ref={scrollRef} flexGrow={1} flexDirection="column" width="100%" stickyScroll={!atWelcome}>
-      {children}
-    </ScrollBox>
+    <>
+      <ScrollBox ref={scrollRef} flexGrow={1} flexDirection="column" width="100%" stickyScroll={!atWelcome}>
+        {children}
+      </ScrollBox>
+      <ScrollPositionIndicator scrollRef={scrollRef} atWelcome={atWelcome} />
+    </>
   ) : (
     <Box flexDirection="column" flexGrow={1} overflow="hidden">
       {children}

--- a/runtime/tests/tui/workbench/TranscriptSurface.scrollIndicator.test.tsx
+++ b/runtime/tests/tui/workbench/TranscriptSurface.scrollIndicator.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Controllable scroll state shared with the ScrollBox mock. Each test sets
+// these before rendering so the indicator reads a deterministic position
+// instead of depending on real Yoga layout (which needs overflowing content
+// to produce a scroll height). The mock wires a ScrollBoxHandle onto the
+// forwarded ref exposing exactly the getters the indicator subscribes to.
+const scrollState = vi.hoisted(() => ({
+  sticky: true,
+  scrollTop: 0,
+  pendingDelta: 0,
+  viewportHeight: 10,
+  scrollHeight: 10,
+}));
+
+vi.mock("../../../src/tui/ink/components/ScrollBox.js", async () => {
+  const ReactModule = await import("react");
+  const ScrollBoxMock = (props: Record<string, unknown>) => {
+    ReactModule.useImperativeHandle(props.ref as React.Ref<unknown>, () => ({
+      scrollTo: () => {},
+      scrollBy: () => {},
+      scrollToElement: () => {},
+      scrollToBottom: () => {},
+      getScrollTop: () => scrollState.scrollTop,
+      getPendingDelta: () => scrollState.pendingDelta,
+      getScrollHeight: () => scrollState.scrollHeight,
+      getFreshScrollHeight: () => scrollState.scrollHeight,
+      getViewportHeight: () => scrollState.viewportHeight,
+      getViewportTop: () => 0,
+      isSticky: () => scrollState.sticky,
+      // The indicator subscribes but the snapshot is read synchronously on
+      // mount; tests assert the committed first frame, so no listener fires.
+      subscribe: () => () => {},
+      setClampBounds: () => {},
+    }));
+    return ReactModule.createElement(ReactModule.Fragment, null, props.children as React.ReactNode);
+  };
+  return { default: ScrollBoxMock };
+});
+
+import { TranscriptSurface } from "../../../src/tui/workbench/surfaces/TranscriptSurface.js";
+import type { ScrollBoxHandle } from "../../../src/tui/ink/components/ScrollBox.js";
+import { Text } from "../../../src/tui/ink.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+function setScrollState(next: Partial<typeof scrollState>): void {
+  Object.assign(scrollState, next);
+}
+
+async function renderSurface(columns = 80, rows = 14): Promise<string> {
+  const scrollRef = React.createRef<ScrollBoxHandle>();
+  return renderToString(
+    <TranscriptSurface scrollRef={scrollRef}>
+      <Text>conversation body</Text>
+    </TranscriptSurface>,
+    { columns, rows },
+  );
+}
+
+function maxRowWidth(rendered: string): number {
+  return rendered
+    .split("\n")
+    .reduce((widest, line) => Math.max(widest, [...line].length), 0);
+}
+
+describe("TranscriptSurface scroll-position indicator", () => {
+  beforeEach(() => {
+    setScrollState({
+      sticky: true,
+      scrollTop: 0,
+      pendingDelta: 0,
+      viewportHeight: 10,
+      scrollHeight: 10,
+    });
+  });
+
+  it("shows a below-count and a return-to-bottom hint when scrolled up", async () => {
+    // 200-row transcript, viewport of 20, scrolled to the top: 180 rows below.
+    setScrollState({ sticky: false, scrollTop: 0, viewportHeight: 20, scrollHeight: 200 });
+    const rendered = await renderSurface();
+
+    expect(rendered).toContain("180 lines below");
+    // The hint must name the live key that returns to the bottom.
+    expect(rendered).toMatch(/End to follow/);
+  });
+
+  it("renders NOTHING when pinned to the bottom (sticky / following)", async () => {
+    setScrollState({ sticky: true, scrollTop: 180, viewportHeight: 20, scrollHeight: 200 });
+    const rendered = await renderSurface();
+
+    expect(rendered).not.toContain("below");
+    expect(rendered).not.toContain("to follow");
+    // The transcript itself still renders — only the indicator is suppressed.
+    expect(rendered).toContain("conversation body");
+  });
+
+  it("renders NOTHING when the viewport already reaches the bottom", async () => {
+    // Not sticky (user nudged) but scrollTop puts the viewport bottom AT the
+    // content bottom: 0 rows below → no indicator.
+    setScrollState({ sticky: false, scrollTop: 180, viewportHeight: 20, scrollHeight: 200 });
+    const rendered = await renderSurface();
+
+    expect(rendered).not.toContain("below");
+    expect(rendered).not.toContain("to follow");
+  });
+
+  it("renders NOTHING when content fits the viewport (no scroll)", async () => {
+    setScrollState({ sticky: false, scrollTop: 0, viewportHeight: 20, scrollHeight: 12 });
+    const rendered = await renderSurface();
+
+    expect(rendered).not.toContain("below");
+  });
+
+  it("counts the not-yet-drained pending wheel delta", async () => {
+    // Mid wheel-burst: scrollTop=0 but pendingDelta=+50 already heads down.
+    // bottom = 0 + 50 + 20 = 70, below = 200 - 70 = 130.
+    setScrollState({ sticky: false, scrollTop: 0, pendingDelta: 50, viewportHeight: 20, scrollHeight: 200 });
+    const rendered = await renderSurface();
+
+    expect(rendered).toContain("130 lines below");
+  });
+
+  it("singularizes the noun when exactly one row is below", async () => {
+    setScrollState({ sticky: false, scrollTop: 0, viewportHeight: 20, scrollHeight: 21 });
+    const rendered = await renderSurface();
+
+    expect(rendered).toContain("1 line below");
+    expect(rendered).not.toContain("1 lines below");
+  });
+
+  it("never overflows the viewport width, even when scrolled up", async () => {
+    setScrollState({ sticky: false, scrollTop: 0, viewportHeight: 20, scrollHeight: 9999 });
+
+    for (const columns of [80, 40, 24, 12]) {
+      const rendered = await renderSurface(columns, 14);
+      expect(maxRowWidth(rendered)).toBeLessThanOrEqual(columns);
+    }
+  });
+
+  it("degrades at narrow widths without dropping into a second row", async () => {
+    setScrollState({ sticky: false, scrollTop: 0, viewportHeight: 20, scrollHeight: 9999 });
+    const rendered = await renderSurface(20, 14);
+
+    // The single 1-row indicator must not wrap — a 20-col render still has the
+    // arrow glyph, and the below text is truncated rather than wrapped.
+    expect(maxRowWidth(rendered)).toBeLessThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
From the multi-turn build session: scrolling up the long transcript gave no cue you'd left the live bottom. Add a '↓ N lines below · End to follow' indicator that shows only when scrolled away (reusing the existing scroll state + follow keys), hidden at bottom and on welcome. Integration-verified via static trace + revert-sensitive unit tests; full suite green.