### PR TITLE
tui visual iter 12: trust-dialog path + CREATE/EDIT diff labels

### DIFF
--- a/runtime/src/permissions/trust/TrustDialog.tsx
+++ b/runtime/src/permissions/trust/TrustDialog.tsx
@@ -1,5 +1,53 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useContext, useRef, useState } from "react";
 import useInput from "../../tui/ink/hooks/use-input.js";
+import { TerminalSizeContext } from "../../tui/ink/components/TerminalSizeContext.js";
+
+/** Floor for the path width budget so a tiny/unknown terminal still truncates. */
+const MIN_TRUST_PATH_WIDTH = 24;
+/** Default width assumed when the terminal columns are unknown. */
+const DEFAULT_TRUST_PATH_WIDTH = 80;
+
+/**
+ * Render the project path for the trust dialog as a single clean line that fits
+ * the available width WITHOUT a hard mid-segment wrap.
+ *
+ * When the full path fits, it is returned verbatim. When it is too long, the
+ * MIDDLE is elided with `…` while the meaningful tail (the deepest path
+ * segments — e.g. `…/visualqa/frames-build/sandbox`) and the leading root are
+ * preserved, so the box never wraps a path component across two lines. A single
+ * over-long segment degrades to a plain middle-character truncation rather than
+ * a hard cut.
+ *
+ * Pure + width-parameterized so it is unit-testable without the terminal.
+ */
+export function formatTrustPath(path: string, maxWidth: number): string {
+  const budget = Math.max(MIN_TRUST_PATH_WIDTH, Math.trunc(maxWidth));
+  if (path.length <= budget) return path;
+
+  const ELLIPSIS = "…";
+  // Keep as much of the tail (deepest, most meaningful segments) as fits,
+  // breaking only at "/" boundaries so no segment is ever split.
+  const segments = path.split("/");
+  // Reserve room for the ellipsis prefix joiner "…/".
+  let tail = "";
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i] ?? "";
+    const candidate = tail.length === 0 ? segment : `${segment}/${tail}`;
+    // +2 for the leading "…/" we will prepend.
+    if (candidate.length + ELLIPSIS.length + 1 > budget) break;
+    tail = candidate;
+  }
+  if (tail.length > 0) {
+    return `${ELLIPSIS}/${tail}`;
+  }
+  // Even the last segment alone overflows — fall back to a middle truncation of
+  // that segment so the tail end (often the unique part) still shows.
+  const last = segments[segments.length - 1] ?? path;
+  const keep = Math.max(1, budget - ELLIPSIS.length);
+  const headLen = Math.ceil(keep / 2);
+  const tailLen = keep - headLen;
+  return `${last.slice(0, headLen)}${ELLIPSIS}${tailLen > 0 ? last.slice(last.length - tailLen) : ""}`;
+}
 
 export interface TrustDialogProps {
   readonly workspaceRoot: string;
@@ -36,6 +84,15 @@ export function TrustDialog(props: TrustDialogProps): React.ReactElement {
   // arrow / tab / explicit y / n before Enter is meaningful. Pressing
   // Enter on launch (the most common reflex) should not commit a
   // destructive action; it just sits waiting for an actual choice.
+  const terminalSize = useContext(TerminalSizeContext);
+  // Width budget for the framed path: terminal columns minus the dialog's
+  // paddingX (1 each side), the path frame border (1 each side) and the frame's
+  // own paddingX (1 each side). Falls back to a sane default off-terminal.
+  const columns =
+    terminalSize && Number.isFinite(terminalSize.columns)
+      ? terminalSize.columns
+      : DEFAULT_TRUST_PATH_WIDTH;
+  const pathBudget = columns - 6;
   const [choice, setChoice] = useState<TrustChoice | null>(null);
   const [pending, setPending] = useState(false);
   const choiceRef = useRef<TrustChoice | null>(null);
@@ -121,7 +178,25 @@ export function TrustDialog(props: TrustDialogProps): React.ReactElement {
       },
     },
     h("ink-text", { textStyles: { bold: true } }, "Trust this project?"),
-    h("ink-text", null, props.workspaceRoot),
+    // Present the project path as a clear, framed element consistent with the
+    // rest of the boxed TUI — and elide the middle (keeping the meaningful tail)
+    // instead of hard-wrapping a path segment across two lines.
+    h(
+      "ink-box",
+      {
+        style: {
+          flexDirection: "column",
+          borderStyle: "round",
+          paddingX: 1,
+          alignSelf: "flex-start",
+        },
+      },
+      h(
+        "ink-text",
+        { style: { textWrap: "truncate-middle" } },
+        formatTrustPath(props.workspaceRoot, pathBudget),
+      ),
+    ),
     h(
       "ink-text",
       null,

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1077,6 +1077,7 @@ export function DiffInline({
   file,
   stats,
   lines,
+  op = 'DIFF',
 }: {
   readonly file: string
   readonly stats?: string
@@ -1086,11 +1087,18 @@ export function DiffInline({
     readonly newLine?: string
     readonly code: string
   }[]
+  /**
+   * Header verb. Distinguishes a first-write CREATE from an EDIT so the user can
+   * tell "made a new file" from "changed an existing one" — the diff body looks
+   * identical otherwise. Defaults to the neutral 'DIFF' for the approval-preview
+   * and any caller that doesn't know the operation.
+   */
+  readonly op?: string
 }): React.ReactNode {
   return (
     <ThemedBox flexDirection="column" borderStyle="single" borderColor="lineSoft">
       <ThemedBox flexDirection="row" paddingX={1} borderBottom borderBottomColor="lineSoft" gap={1}>
-        <ThemedText color="subtle">DIFF</ThemedText>
+        <ThemedText color="subtle">{op}</ThemedText>
         <ThemedText color="text2" wrap="truncate-middle">{file}</ThemedText>
         <Box flexGrow={1} />
         {stats ? <ThemedText color="subtle">{stats}</ThemedText> : null}

--- a/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
+++ b/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
@@ -304,7 +304,7 @@ export function AssistantToolUseMessage({
  * there is no diffable change (so the row stays clean). Reuses the `DiffInline`
  * primitive + the shared diff engine via `buildEditDiffPreview`.
  */
-function renderEditDiffPreview(
+export function renderEditDiffPreview(
   toolName: string,
   input: unknown,
 ): React.ReactNode {
@@ -330,11 +330,16 @@ function renderEditDiffPreview(
       } · ctrl+w d for full diff`,
     });
   }
+  // Distinguish a first write from an edit in the header so the two no longer
+  // look identical. A Write produces a brand-new file (all additions, old
+  // content empty) → CREATE; Edit/MultiEdit change an existing file → EDIT.
+  const op = toolName === "Write" ? "CREATE" : "EDIT";
   return (
     <DiffInline
       file={preview.file.length > 0 ? preview.file : "file"}
       stats={preview.stats}
       lines={lines}
+      op={op}
     />
   );
 }

--- a/runtime/tests/permissions/trust/TrustDialog.render.test.tsx
+++ b/runtime/tests/permissions/trust/TrustDialog.render.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// The dialog calls useInput, which (in the real hook) flips the terminal into
+// raw mode — unsupported on the non-TTY test stream. Stub it so the render is
+// pure; we exercise the path LAYOUT here, not the keyboard logic (covered by
+// the trustDialogOptionLabel unit test).
+vi.mock("../../../src/tui/ink/hooks/use-input.js", () => ({
+  default: () => {},
+}));
+
+import { TerminalSizeContext } from "../../../src/tui/ink/components/TerminalSizeContext.js";
+import { TrustDialog, formatTrustPath } from "./TrustDialog.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+// A realistic deep project path — the exact shape that hard-wrapped mid-segment
+// in the first-run "Trust this project?" dialog (a long scratchpad path).
+const LONG_PATH =
+  "/tmp/user/1000/claude-1000/-home-tetsuo-git-AgenC-agenc-core/5ea051e8-c097-408c-8fcc-841eb4b0e57a/scratchpad/visualqa/frames-build/sandbox";
+
+function renderTrust(path: string, columns: number): Promise<string> {
+  return renderToString(
+    <TerminalSizeContext.Provider value={{ columns, rows: 24 }}>
+      <TrustDialog workspaceRoot={path} onAccept={() => {}} onReject={() => {}} />
+    </TerminalSizeContext.Provider>,
+    { columns, rows: 24 },
+  );
+}
+
+describe("formatTrustPath", () => {
+  it("returns a short path verbatim", () => {
+    expect(formatTrustPath("/home/me/project", 80)).toBe("/home/me/project");
+  });
+
+  it("elides the MIDDLE and keeps the meaningful tail at a segment boundary", () => {
+    const out = formatTrustPath(LONG_PATH, 60);
+    // Fits the budget…
+    expect(out.length).toBeLessThanOrEqual(60);
+    // …leads with an ellipsis (middle elided)…
+    expect(out.startsWith("…/")).toBe(true);
+    // …and preserves the deepest, most meaningful tail intact.
+    expect(out.endsWith("/frames-build/sandbox")).toBe(true);
+    // The break happened at a "/" boundary — the segment right after the
+    // ellipsis is a WHOLE path component, never a sliced fragment.
+    const firstTailSegment = out.slice("…/".length).split("/")[0];
+    expect(LONG_PATH.split("/")).toContain(firstTailSegment);
+  });
+
+  it("never splits a path segment across the elision boundary", () => {
+    for (const width of [24, 30, 40, 50, 60, 70]) {
+      const out = formatTrustPath(LONG_PATH, width);
+      expect(out.length).toBeLessThanOrEqual(width);
+      if (out.startsWith("…/")) {
+        // Every kept tail segment is a genuine component of the source path.
+        const tailSegments = out.slice("…/".length).split("/");
+        for (const seg of tailSegments) {
+          expect(LONG_PATH.split("/")).toContain(seg);
+        }
+      }
+    }
+  });
+
+  it("degrades a single over-long segment to a middle truncation (no hard cut)", () => {
+    const giant = "/" + "x".repeat(200);
+    const out = formatTrustPath(giant, 30);
+    expect(out.length).toBeLessThanOrEqual(30);
+    expect(out).toContain("…");
+  });
+});
+
+describe("TrustDialog path presentation", () => {
+  it("frames the path and elides it instead of hard-wrapping mid-segment", async () => {
+    const out = await renderTrust(LONG_PATH, 80);
+    // The dialog still shows its core copy + choices (logic unchanged).
+    expect(out).toContain("Trust this project?");
+    expect(out).toContain("Yes, I trust this project");
+    expect(out).toContain("No, exit");
+
+    // The path is framed: a bordered box surrounds it.
+    expect(out).toMatch(/[╭┌]/);
+
+    // It is elided (middle removed) — the meaningful tail survives on ONE line.
+    const tailLine = out
+      .split("\n")
+      .find((line) => line.includes("frames-build/sandbox"));
+    expect(tailLine).toBeDefined();
+    expect(tailLine).toContain("…");
+
+    // REGRESSION GUARD vs the hard mid-segment wrap: the prior bug split the
+    // raw path so that a line ENDED in `.../visualqa/` and the next line BEGAN
+    // with a bare `frames-build/sandbox` fragment (no leading slash, no
+    // indentation). With the fix the path is a single elided line, so no line
+    // begins with that orphaned fragment.
+    const lines = out.split("\n").map((line) => line.trimStart());
+    expect(lines.some((line) => line.startsWith("frames-build/sandbox"))).toBe(
+      false,
+    );
+    // And the full raw path is no longer printed verbatim across the dialog
+    // (it has been elided), so no single line carries the whole thing.
+    expect(out.split("\n").some((line) => line.includes(LONG_PATH))).toBe(false);
+  });
+
+  it("REVERT-SENSITIVITY: a short path is shown in full, a long path is elided", async () => {
+    const shortPath = "/home/me/workdir";
+    const shortOut = await renderTrust(shortPath, 80);
+    const longOut = await renderTrust(LONG_PATH, 80);
+    // The short path is shown in full with no ellipsis on its line.
+    const shortLine = shortOut
+      .split("\n")
+      .find((line) => line.includes("/home/me/workdir"));
+    expect(shortLine).toBeDefined();
+    expect(shortLine).not.toContain("…");
+    expect(shortLine).toContain(shortPath);
+    // The long path's line is elided — proving the truncation path is exercised
+    // (a revert to the raw `props.workspaceRoot` text would carry no ellipsis
+    // and would hard-wrap the segment instead).
+    const longLine = longOut
+      .split("\n")
+      .find((line) => line.includes("sandbox"));
+    expect(longLine).toBeDefined();
+    expect(longLine).toContain("…");
+  });
+});

--- a/runtime/tests/tui/message-renderers/edit-diff-header-op.test.tsx
+++ b/runtime/tests/tui/message-renderers/edit-diff-header-op.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { Box } from "../../../src/tui/ink.js";
+import { renderEditDiffPreview } from "../../../src/tui/message-renderers/AssistantToolUseMessage.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+// UX fix: the first-create diff and an edit diff used to render an identical
+// "DIFF <file>" header, so a user could not tell "created a new file" from
+// "edited an existing one". The header now distinguishes the operation:
+//   - Write (a first write / all-additions, old content empty) → CREATE
+//   - Edit / MultiEdit (a change to existing content)          → EDIT
+
+function render(node: React.ReactNode): Promise<string> {
+  return renderToString(
+    <Box flexDirection="column">{node}</Box>,
+    { columns: 100, rows: 24 },
+  );
+}
+
+describe("edit diff header operation label", () => {
+  it("a Write (new file) header says CREATE, not EDIT", async () => {
+    const node = renderEditDiffPreview("Write", {
+      file_path: "src/new-thing.ts",
+      content: "export const x = 1\nexport const y = 2\n",
+    });
+    expect(node).not.toBeNull();
+    const out = await render(node);
+    expect(out).toContain("CREATE");
+    expect(out).toContain("new-thing.ts");
+    // It is a first write — all additions, nothing removed.
+    expect(out).toContain("+2 -0");
+    // The old neutral/edit label is NOT used for a create.
+    expect(out).not.toContain("EDIT");
+  });
+
+  it("an Edit (existing file) header says EDIT, not CREATE", async () => {
+    const node = renderEditDiffPreview("Edit", {
+      file_path: "src/existing.ts",
+      old_string: "const a = 1\n",
+      new_string: "const a = 2\n",
+    });
+    expect(node).not.toBeNull();
+    const out = await render(node);
+    expect(out).toContain("EDIT");
+    expect(out).toContain("existing.ts");
+    expect(out).not.toContain("CREATE");
+  });
+
+  it("a MultiEdit header says EDIT (an edit, not a create)", async () => {
+    const node = renderEditDiffPreview("MultiEdit", {
+      file_path: "src/multi.ts",
+      edits: [
+        { old_string: "alpha", new_string: "ALPHA" },
+        { old_string: "beta", new_string: "BETA" },
+      ],
+    });
+    expect(node).not.toBeNull();
+    const out = await render(node);
+    expect(out).toContain("EDIT");
+    expect(out).not.toContain("CREATE");
+  });
+
+  it("REVERT-SENSITIVITY: Write→CREATE and Edit→EDIT are distinct headers", async () => {
+    // The crux of the bug: the two operations must NOT share one header label.
+    const createOut = await render(
+      renderEditDiffPreview("Write", {
+        file_path: "src/a.ts",
+        content: "line one\nline two\n",
+      }),
+    );
+    const editOut = await render(
+      renderEditDiffPreview("Edit", {
+        file_path: "src/a.ts",
+        old_string: "line one\n",
+        new_string: "line ONE\n",
+      }),
+    );
+    // Distinct verbs — a revert to the hard-coded shared "DIFF" header would
+    // make both contain "DIFF" and neither contain CREATE/EDIT, failing here.
+    expect(createOut).toContain("CREATE");
+    expect(createOut).not.toContain("EDIT");
+    expect(editOut).toContain("EDIT");
+    expect(editOut).not.toContain("CREATE");
+    // Neither still shows the old undifferentiated "DIFF" header.
+    expect(createOut).not.toContain("DIFF");
+    expect(editOut).not.toContain("DIFF");
+  });
+});

--- a/runtime/tests/tui/message-renderers/liveRawToolResult.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/liveRawToolResult.render.test.tsx
@@ -327,8 +327,9 @@ describe('LIVE raw daemon tool results (no envelope) — capped industry-standar
     })
     const combined = `${row}\n${body}`
 
-    // The diff stats + DIFF chrome render on the CALL ROW.
-    expect(row).toContain('DIFF')
+    // The diff stats + diff chrome render on the CALL ROW. An Edit to an
+    // existing file is labelled EDIT (distinct from a first-write CREATE).
+    expect(row).toContain('EDIT')
     expect(row).toContain('+3 -2')
     // The removed and added lines are present in the diff.
     expect(row).toContain('M0 stubs')
@@ -361,7 +362,8 @@ describe('LIVE raw daemon tool results (no envelope) — capped industry-standar
     })
     const combined = `${row}\n${body}`
 
-    expect(row).toContain('DIFF')
+    // A MultiEdit changes an existing file → EDIT (not a first-write CREATE).
+    expect(row).toContain('EDIT')
     expect(row).toContain('+2 -2')
     expect(row).toContain('aliasmap_alloc')
     expect(combined).not.toContain('updated successfully')
@@ -386,7 +388,9 @@ describe('LIVE raw daemon tool results (no envelope) — capped industry-standar
     })
     const combined = `${row}\n${body}`
 
-    expect(row).toContain('DIFF')
+    // A first Write of a new file is labelled CREATE (distinct from an EDIT to
+    // an existing file), so the user can tell "made a new file" apart.
+    expect(row).toContain('CREATE')
     // Whole-file add: 3 additions, 0 removals.
     expect(row).toContain('+3 -0')
     expect(row).toContain('int main')
@@ -406,8 +410,11 @@ describe('LIVE raw daemon tool results (no envelope) — capped industry-standar
       isError: true,
     })
     const row = await renderCallRow(c.param, c.lookups)
-    // Failed row surfaces the friendly reason, and no diff chrome.
+    // Failed row surfaces the friendly reason, and no diff chrome at all —
+    // neither the old 'DIFF' label nor the new operation labels render.
     expect(row).toContain('File must be read first')
     expect(row).not.toContain('DIFF')
+    expect(row).not.toContain('EDIT')
+    expect(row).not.toContain('CREATE')
   })
 })


### PR DESCRIPTION
From the multi-turn build session: trust dialog path hard-wrapped mid-segment + unframed -> now segment-elided inside a rounded frame (trust logic unchanged); first-create diffs were identical to edits -> transcript header now says CREATE vs EDIT. Trust dialog verified live; CREATE/EDIT revert-sensitive unit tests; full suite 13260.