### PR TITLE
tui visual iter 13: approval CREATE/EDIT, role-marker spacing, queue hint

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
@@ -132,6 +132,7 @@ function PromptInputQueuedCommandsImpl(): React.ReactNode {
       {queuedInputCount > 0 && <Box marginLeft={2} marginBottom={1}>
           <Text dimColor>
             {queuedInputCount === 1 ? '1 input queued for next turn' : `${queuedInputCount} inputs queued for next turn`}
+            {' · esc interrupts the current turn'}
           </Text>
         </Box>}
       {messages.map((message, i) => <QueuedMessageProvider key={i} isFirst={i === 0} useBriefLayout={useBriefLayout}>

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -885,13 +885,18 @@ export function Msg({
     system: 'subtle',
   }
   const inheritedWidth = useContentWidth()
-  const contentWidth = insetContentWidth(inheritedWidth, 3)
+  // The marker glyph (1 cell) + the single-space row gap below = a 2-cell inset
+  // for the content column; keep the inset in sync with the gap so wrapped body
+  // text measures against the right width.
+  const contentWidth = insetContentWidth(inheritedWidth, 2)
   // Queued previews carry no real per-item enqueue time, so they pass no
   // `time` (see PromptInputQueuedCommands). Show a quiet neutral "queued"
   // marker in the header slot instead of a misleading render-time clock.
   const isQueued = useQueuedMessage()?.isQueued ?? false
   return (
-    <Box flexDirection="row" gap={2}>
+    // A single space after the marker glyph (gap={1}); a double gap read as a
+    // layout seam between the marker and the role label.
+    <Box flexDirection="row" gap={1}>
       <ThemedText color={colors[role]}>{role === 'system' ? '∙' : '▮'}</ThemedText>
       <Box flexDirection="column" flexGrow={1}>
         <Box flexDirection="row" gap={1}>
@@ -1174,6 +1179,12 @@ export interface ApprovalDiffPreview {
   }[]
   /** Rows dropped past the input cap, surfaced as a "… +N more" row. */
   readonly remaining: number
+  /**
+   * Header verb for the inline diff, matching the post-approval TRANSCRIPT card:
+   * a first-write Write → 'CREATE', an Edit/MultiEdit → 'EDIT'. Optional so any
+   * caller that doesn't know the operation falls back to the neutral 'DIFF'.
+   */
+  readonly op?: string
 }
 
 export function ApprovalCard({
@@ -1294,6 +1305,7 @@ export function ApprovalCard({
               file={diffPreview.file.length > 0 ? diffPreview.file : 'file'}
               stats={diffPreview.stats}
               lines={previewLines}
+              {...(diffPreview.op !== undefined ? { op: diffPreview.op } : {})}
             />
           </Box>
         ) : null}

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -399,11 +399,17 @@ function AgenCApprovalOverlay({
         toolUseConfirm.input,
       );
       if (built === null) return undefined;
+      // Label the inline diff the same way the post-approval TRANSCRIPT card
+      // does: a Write produces a brand-new file → CREATE; Edit/MultiEdit change
+      // an existing one → EDIT. Keeps the approval preview and the transcript in
+      // sync instead of showing a neutral DIFF here.
+      const op = toolUseConfirm.tool.name === "Write" ? "CREATE" : "EDIT";
       return {
         file: built.file,
         stats: built.stats,
         lines: built.lines,
         remaining: built.remaining,
+        op,
       };
     } catch {
       // A malformed input must never break the approval popup — degrade to the

--- a/runtime/tests/tui/approval-card-diff-preview.test.tsx
+++ b/runtime/tests/tui/approval-card-diff-preview.test.tsx
@@ -183,6 +183,78 @@ describe('ApprovalCard diff preview (in-dialog change preview)', () => {
     expect(out).toContain('[1] approve once')
   })
 
+  test('an Edit approval labels the inline diff EDIT (matching the transcript card)', async () => {
+    // The approval path passes op = (tool === 'Write' ? 'CREATE' : 'EDIT'),
+    // the SAME label the post-approval TRANSCRIPT diff card uses.
+    const preview = { ...editPreview(), op: 'EDIT' as const }
+    const out = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · edit · medium-risk approval"
+          command="src/primes.ts"
+          facts={[{ label: 'tool', value: 'edit' }]}
+          diffPreview={preview}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    expect(out).toContain('EDIT')
+    // The neutral DIFF verb must NOT leak when the op is known.
+    expect(out).not.toContain('DIFF')
+    expect(out).toContain('primes.ts')
+  })
+
+  test('a Write approval labels the inline diff CREATE (new-file write)', async () => {
+    const preview = { ...longWritePreview(), op: 'CREATE' as const }
+    const out = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · write · needs approval"
+          command="src/big.ts"
+          facts={[{ label: 'tool', value: 'write' }]}
+          diffPreview={preview}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    expect(out).toContain('CREATE')
+    expect(out).not.toContain('DIFF')
+    expect(out).toContain('big.ts')
+  })
+
+  test('REVERT-SENSITIVITY: the diff-box header verb falls back to DIFF only when op is absent', async () => {
+    // With op set, the inline diff header reads EDIT; without it (the old
+    // behavior), it falls back to the neutral DIFF. The card TITLE independently
+    // contains "EDIT", so assert against the diff-box header ROW specifically:
+    // the row that carries the file name + stats.
+    const diffHeaderRow = (out: string): string =>
+      out
+        .split('\n')
+        .find((line) => line.includes('primes.ts') && line.includes('+2 -1')) ?? ''
+    const withOp = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · edit · medium-risk approval"
+          command="src/primes.ts"
+          facts={[{ label: 'tool', value: 'edit' }]}
+          diffPreview={{ ...editPreview(), op: 'EDIT' }}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    const withoutOp = await renderEditApproval(40)
+    expect(diffHeaderRow(withOp)).toContain('EDIT')
+    expect(diffHeaderRow(withOp)).not.toContain('DIFF')
+    expect(diffHeaderRow(withoutOp)).toContain('DIFF')
+    expect(diffHeaderRow(withoutOp)).not.toContain('EDIT')
+  })
+
   test('REVERT-SENSITIVITY: diff present with the prop, absent without it', async () => {
     const withPreview = await renderEditApproval(40, { withPreview: true })
     const withoutPreview = await renderEditApproval(40, { withPreview: false })

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -220,3 +220,32 @@ describe('Msg queued header marker', () => {
     expect(output).not.toContain('queued')
   })
 })
+
+describe('Msg role-marker glyph spacing', () => {
+  it('renders a SINGLE space between the marker glyph and the role label (no layout seam)', async () => {
+    const output = await renderToString(
+      <Msg role="agenc" label="agenc">
+        <Text>body</Text>
+      </Msg>,
+      { columns: 100, rows: 12 },
+    )
+
+    // The marker glyph is followed by exactly one space, then the label —
+    // a double space read as an empty layout gap (#16). Revert-sensitive:
+    // restoring gap={2} re-introduces the '▮  AGENC' double space.
+    expect(output).toContain('▮ AGENC')
+    expect(output).not.toContain('▮  AGENC')
+  })
+
+  it('keeps the single-space marker for the system role (∙)', async () => {
+    const output = await renderToString(
+      <Msg role="system" label="system">
+        <Text>body</Text>
+      </Msg>,
+      { columns: 100, rows: 12 },
+    )
+
+    expect(output).toContain('∙ SYSTEM')
+    expect(output).not.toContain('∙  SYSTEM')
+  })
+})


### PR DESCRIPTION
Consistency/polish from the multi-turn build session: approval-dialog diff preview now labels CREATE/EDIT (matching the transcript); role marker tightened from double to single space; queued-input hint clarifies esc interrupts the current turn. Revert-sensitive tests; full suite 13265.