### PR TITLE
tui visual iter 14: per-turn files-changed summary

### DIFF
--- a/runtime/src/tui/components/Message.tsx
+++ b/runtime/src/tui/components/Message.tsx
@@ -32,6 +32,8 @@ import {
   UserToolResultMessage,
 } from './Message.renderers.js';
 import { SnipBoundaryMessage } from '../message-renderers/SnipBoundaryMessage.js';
+import { TurnFileChangesSummary } from '../message-renderers/TurnFileChangesSummary.js';
+import { deriveTurnFileChanges } from '../turn-file-changes.js';
 
 export function getToolResultMessageWidth(columns: number): number {
   return Math.max(1, columns - 5);
@@ -137,34 +139,43 @@ function MessageImpl({
         </ContentWidthProvider>
       );
     case "assistant":
-      return (
-        <ContentWidthProvider width={messageContentWidth}>
-          <Box flexDirection="column" width={containerWidth ?? "100%"}>
-            {message.message.content.map((param: AssistantContentBlock, index: number) => (
-              <AssistantMessageBlock
-                key={index}
-                param={param}
-                addMargin={addMargin}
-                tools={tools}
-                commands={commands}
-                verbose={verbose}
-                inProgressToolUseIDs={inProgressToolUseIDs}
-                progressMessagesForMessage={progressMessagesForMessage}
-                shouldAnimate={shouldAnimate}
-                shouldShowDot={shouldShowDot}
-                width={width}
-                inProgressToolCallCount={inProgressToolUseIDs.size}
-                isTranscriptMode={isTranscriptMode}
-                lookups={lookups}
-                onOpenRateLimitOptions={onOpenRateLimitOptions}
-                thinkingBlockId={`${message.uuid}:${index}`}
-                lastThinkingBlockId={lastThinkingBlockId}
-                advisorModel={message.advisorModel}
-              />
-            ))}
-          </Box>
-        </ContentWidthProvider>
-      );
+      {
+        // Per-turn "files changed" rollup: each Write/Edit above renders its own
+        // collapsed diff card, but there is no concise summary of WHAT this turn
+        // touched. Derive it from this message's OWN file-mutating tool uses
+        // (scoped to the turn, no global git scan) and render one compact line
+        // after the tool activity. Empty list → renders nothing.
+        const turnFileChanges = deriveTurnFileChanges(message.message.content);
+        return (
+          <ContentWidthProvider width={messageContentWidth}>
+            <Box flexDirection="column" width={containerWidth ?? "100%"}>
+              {message.message.content.map((param: AssistantContentBlock, index: number) => (
+                <AssistantMessageBlock
+                  key={index}
+                  param={param}
+                  addMargin={addMargin}
+                  tools={tools}
+                  commands={commands}
+                  verbose={verbose}
+                  inProgressToolUseIDs={inProgressToolUseIDs}
+                  progressMessagesForMessage={progressMessagesForMessage}
+                  shouldAnimate={shouldAnimate}
+                  shouldShowDot={shouldShowDot}
+                  width={width}
+                  inProgressToolCallCount={inProgressToolUseIDs.size}
+                  isTranscriptMode={isTranscriptMode}
+                  lookups={lookups}
+                  onOpenRateLimitOptions={onOpenRateLimitOptions}
+                  thinkingBlockId={`${message.uuid}:${index}`}
+                  lastThinkingBlockId={lastThinkingBlockId}
+                  advisorModel={message.advisorModel}
+                />
+              ))}
+              <TurnFileChangesSummary changes={turnFileChanges} />
+            </Box>
+          </ContentWidthProvider>
+        );
+      }
     case "user":
       {
         if (message.isCompactSummary) {

--- a/runtime/src/tui/message-renderers/TurnFileChangesSummary.tsx
+++ b/runtime/src/tui/message-renderers/TurnFileChangesSummary.tsx
@@ -1,0 +1,102 @@
+/**
+ * Compact per-turn "files changed" summary, rendered once after an assistant
+ * turn's tool activity. Each Write/Edit renders its own collapsed diff card; this
+ * adds the missing at-a-glance rollup of WHAT the turn changed:
+ *
+ *   ⎿ files changed · + index.html  ~ styles.css +4 -1  ~ script.js +12 -3
+ *
+ * The data is derived from the turn's OWN tool-use blocks (see
+ * `deriveTurnFileChanges`), so it is scoped to the turn and reuses the same
+ * file path + +N/-M counts and CREATE/EDIT distinction as the diff cards. The
+ * caller renders nothing when the turn changed no files (empty list in →
+ * `null` out).
+ *
+ * On-brand: neutral subtle label + a `+` create marker (success) vs a `~` edit
+ * marker (agenc), additions in success / removals in error — matching the diff
+ * card palette. Long lists wrap to additional rows and collapse past a cap to a
+ * "… +N more" tail, so the block never overflows the content row.
+ *
+ * @module
+ */
+
+import React from "react";
+import Box from "../ink/components/Box.js";
+import ThemedText from "../components/design-system/ThemedText.js";
+import type { TurnFileChange } from "../turn-file-changes.js";
+
+/**
+ * Max files listed inline before collapsing the remainder to "… +N more". Kept
+ * small so a typical multi-file turn shows in full and only a genuinely large
+ * batch collapses (the per-file diff cards above already carry the detail).
+ */
+const MAX_FILES_SHOWN = 8;
+
+/** Render the basename only when a full path would dominate the compact row. */
+function shortenFile(file: string): string {
+  // Keep short/relative paths intact; collapse long absolute-ish paths to a
+  // basename so a single entry can't blow out the row. The diff card above
+  // already shows the full path, so the summary can favor brevity.
+  if (file.length <= 40) return file;
+  const parts = file.split("/");
+  const base = parts[parts.length - 1] ?? file;
+  return base.length > 0 ? base : file;
+}
+
+function FileEntry({ change }: { readonly change: TurnFileChange }): React.ReactNode {
+  const isCreate = change.kind === "create";
+  // '+' = new file (success), '~' = edited file (agenc) — reusing the diff-card
+  // CREATE/EDIT distinction in a single-glyph form.
+  const marker = isCreate ? "+" : "~";
+  const markerColor = isCreate ? "success" : "agenc";
+  const showStats = change.additions > 0 || change.removals > 0;
+  return (
+    <Box flexDirection="row" flexShrink={0} gap={1}>
+      <ThemedText color={markerColor}>{marker}</ThemedText>
+      <ThemedText color="text2" wrap="truncate-middle">
+        {shortenFile(change.file)}
+      </ThemedText>
+      {isCreate ? <ThemedText color="success">(new)</ThemedText> : null}
+      {showStats ? (
+        <Box flexDirection="row" flexShrink={0}>
+          {change.additions > 0 ? (
+            <ThemedText color="success">{`+${change.additions}`}</ThemedText>
+          ) : null}
+          {change.additions > 0 && change.removals > 0 ? (
+            <ThemedText color="muted3"> </ThemedText>
+          ) : null}
+          {change.removals > 0 ? (
+            <ThemedText color="error">{`-${change.removals}`}</ThemedText>
+          ) : null}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+export function TurnFileChangesSummary({
+  changes,
+}: {
+  readonly changes: readonly TurnFileChange[];
+}): React.ReactNode {
+  if (changes.length === 0) return null;
+
+  const shown = changes.slice(0, MAX_FILES_SHOWN);
+  const hidden = changes.length - shown.length;
+
+  return (
+    <Box flexDirection="row" paddingLeft={1} gap={1}>
+      {/* Same `⎿` continuation gutter the diff cards / tool results use, so the
+          summary reads as a child of the turn's tool activity. */}
+      <ThemedText color="muted3">⎿</ThemedText>
+      <Box flexDirection="row" flexWrap="wrap" flexGrow={1} columnGap={2}>
+        <ThemedText color="subtle">files changed</ThemedText>
+        {shown.map(change => (
+          <FileEntry key={change.file} change={change} />
+        ))}
+        {hidden > 0 ? (
+          <ThemedText color="inactive">{`… +${hidden} more`}</ThemedText>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}

--- a/runtime/src/tui/turn-file-changes.ts
+++ b/runtime/src/tui/turn-file-changes.ts
@@ -1,0 +1,119 @@
+/**
+ * Derive a compact per-turn "files changed" summary from a single assistant
+ * message's tool-use blocks.
+ *
+ * Data source rationale: each Write/Edit/MultiEdit renders its own collapsed
+ * diff card, but a build session has no concise "here's what THIS turn changed"
+ * line. The cleanest scoped source for that is the assistant message's OWN
+ * `tool_use` blocks — `Message.tsx` already maps over `message.message.content`,
+ * so the set of file operations for the turn is right there, with no global git
+ * scan and no cross-turn leakage. This reuses the SAME `buildEditDiffPreview`
+ * the diff cards consume (so the file path + +N/-M counts match exactly) and the
+ * SAME Write→CREATE / Edit→EDIT distinction the diff headers use.
+ *
+ * This module is JSX-free so it can be unit-tested without the React renderer.
+ *
+ * @module
+ */
+
+import { buildEditDiffPreview } from "./edit-diff-preview.js";
+import { isRecord } from "../utils/record.js";
+
+/** Tool names that mutate files and contribute to the turn summary. */
+const FILE_EDIT_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+
+/** One file's net change across a turn. */
+export interface TurnFileChange {
+  /** File path exactly as the diff cards show it (may be absolute or relative). */
+  readonly file: string;
+  /**
+   * 'create' when the turn's FIRST op on this file was a Write (new file),
+   * 'edit' otherwise. Matches the CREATE/EDIT verb on the diff cards.
+   */
+  readonly kind: "create" | "edit";
+  /** Total additions across every op on this file this turn. */
+  readonly additions: number;
+  /** Total removals across every op on this file this turn. */
+  readonly removals: number;
+}
+
+/** A minimal tool-use block shape (only the fields this module reads). */
+interface ToolUseLike {
+  readonly type?: unknown;
+  readonly name?: unknown;
+  readonly input?: unknown;
+}
+
+/**
+ * Collapse a turn's file-mutating tool uses into one entry per file, in the
+ * order each file was first touched. A Write followed by an Edit on the same
+ * file still reads as a 'create' (the file was born this turn); +/- counts
+ * accumulate across every op. Tool uses that produce no diffable change (a
+ * no-op Edit, a malformed input) contribute nothing — exactly like the diff
+ * cards, which render nothing for them.
+ *
+ * Returns an empty array when the turn changed no files, so the caller renders
+ * nothing.
+ */
+export function deriveTurnFileChanges(
+  content: readonly unknown[] | undefined,
+): readonly TurnFileChange[] {
+  if (!Array.isArray(content)) return [];
+
+  // Preserve first-touch order while merging repeat ops on the same file.
+  const order: string[] = [];
+  const byFile = new Map<
+    string,
+    { file: string; kind: "create" | "edit"; additions: number; removals: number }
+  >();
+
+  for (const raw of content) {
+    if (!isRecord(raw)) continue;
+    const block = raw as ToolUseLike;
+    if (block.type !== "tool_use") continue;
+    const name = typeof block.name === "string" ? block.name : "";
+    if (!FILE_EDIT_TOOLS.has(name)) continue;
+
+    let preview: ReturnType<typeof buildEditDiffPreview>;
+    try {
+      preview = buildEditDiffPreview(name, block.input);
+    } catch {
+      // A malformed input that throws contributes nothing (the diff card also
+      // renders nothing for it) — never let one bad block sink the summary.
+      continue;
+    }
+    if (preview === null) continue;
+
+    const file = preview.file.length > 0 ? preview.file : "file";
+    // The op's intrinsic kind: a Write births a file, an Edit/MultiEdit changes
+    // one. The MERGED kind keeps 'create' if ANY op this turn created the file.
+    const opKind: "create" | "edit" = name === "Write" ? "create" : "edit";
+
+    const existing = byFile.get(file);
+    if (existing === undefined) {
+      order.push(file);
+      byFile.set(file, {
+        file,
+        kind: opKind,
+        additions: preview.additions,
+        removals: preview.removals,
+      });
+    } else {
+      existing.additions += preview.additions;
+      existing.removals += preview.removals;
+      // Once created this turn, stays created (the file is new regardless of
+      // later edits to it).
+      if (opKind === "create") existing.kind = "create";
+    }
+  }
+
+  return order.map(file => {
+    const entry = byFile.get(file)!;
+    return {
+      file: entry.file,
+      kind: entry.kind,
+      additions: entry.additions,
+      removals: entry.removals,
+    };
+  });
+}

--- a/runtime/tests/tui/turn-file-changes-summary.test.tsx
+++ b/runtime/tests/tui/turn-file-changes-summary.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { Box } from '../../src/tui/ink.js'
+import {
+  deriveTurnFileChanges,
+  type TurnFileChange,
+} from '../../src/tui/turn-file-changes.js'
+import { TurnFileChangesSummary } from '../../src/tui/message-renderers/TurnFileChangesSummary.js'
+import { renderToString } from '../../src/utils/staticRender.js'
+
+// UX improvement coverage: a build session renders a per-file collapsed diff
+// for every Write/Edit, but had no concise "here's what THIS turn changed"
+// rollup. The summary derives that from the assistant message's OWN tool-use
+// blocks (scoped to the turn — no global git scan) and renders one compact
+// line after the turn's tool activity.
+
+// A realistic assistant message content array: one Write (new file) and one
+// Edit (existing file), matching the diff-card inputs in the codebase.
+function writeBlock(file: string, content: string): unknown {
+  return { type: 'tool_use', id: `w-${file}`, name: 'Write', input: { file_path: file, content } }
+}
+function editBlock(file: string, oldStr: string, newStr: string): unknown {
+  return {
+    type: 'tool_use',
+    id: `e-${file}`,
+    name: 'Edit',
+    input: { file_path: file, old_string: oldStr, new_string: newStr },
+  }
+}
+
+function renderSummary(changes: readonly TurnFileChange[], columns = 100): Promise<string> {
+  return renderToString(
+    <Box flexDirection="column" width={columns}>
+      <TurnFileChangesSummary changes={changes} />
+    </Box>,
+    { columns, rows: 40 },
+  )
+}
+
+describe('deriveTurnFileChanges (per-turn changed-file data source)', () => {
+  test('derives a CREATE for a Write and an EDIT for an Edit, in first-touch order', () => {
+    const content = [
+      { type: 'text', text: 'making changes' },
+      writeBlock('index.html', '<html></html>\n'),
+      editBlock('styles.css', 'a{}\n', 'a{color:red}\nb{}\n'),
+    ]
+    const changes = deriveTurnFileChanges(content)
+    expect(changes).toHaveLength(2)
+    expect(changes[0]).toMatchObject({ file: 'index.html', kind: 'create' })
+    expect(changes[1]).toMatchObject({ file: 'styles.css', kind: 'edit' })
+    // The Edit added 2 lines and removed 1.
+    expect(changes[1]?.additions).toBe(2)
+    expect(changes[1]?.removals).toBe(1)
+  })
+
+  test('a turn with no file-mutating tool uses derives an empty list', () => {
+    const content = [
+      { type: 'text', text: 'just thinking out loud' },
+      { type: 'tool_use', id: 'r1', name: 'Read', input: { file_path: 'a.ts' } },
+      { type: 'tool_use', id: 'b1', name: 'Bash', input: { command: 'ls' } },
+    ]
+    expect(deriveTurnFileChanges(content)).toEqual([])
+  })
+
+  test('repeat ops on the same file merge into one entry; a Write then Edit stays CREATE', () => {
+    const content = [
+      writeBlock('app.ts', 'const a = 1\n'),
+      editBlock('app.ts', 'const a = 1\n', 'const a = 1\nconst b = 2\n'),
+    ]
+    const changes = deriveTurnFileChanges(content)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]?.kind).toBe('create')
+    // Additions accumulate across both ops (1 for the write line + 1 for the
+    // appended edit line).
+    expect(changes[0]?.additions).toBe(2)
+  })
+
+  test('a no-op Edit (old === new) and a malformed block contribute nothing', () => {
+    const content = [
+      editBlock('noop.ts', 'same\n', 'same\n'),
+      { type: 'tool_use', id: 'x', name: 'Edit', input: 12345 },
+      { type: 'text', text: 'hi' },
+    ]
+    expect(deriveTurnFileChanges(content)).toEqual([])
+  })
+
+  test('non-array / undefined content is handled defensively', () => {
+    expect(deriveTurnFileChanges(undefined)).toEqual([])
+    expect(deriveTurnFileChanges([])).toEqual([])
+  })
+})
+
+describe('TurnFileChangesSummary (compact per-turn render)', () => {
+  test('a turn with a Write + an Edit renders a summary listing both with create/edit markers', async () => {
+    const changes = deriveTurnFileChanges([
+      writeBlock('index.html', '<html></html>\n'),
+      editBlock('styles.css', 'a{}\n', 'a{color:red}\nb{}\n'),
+    ])
+    const out = await renderSummary(changes)
+    expect(out).toContain('files changed')
+    // Both files appear.
+    expect(out).toContain('index.html')
+    expect(out).toContain('styles.css')
+    // The created file carries the (new) marker + a '+' create marker; the
+    // edited file shows +N -M stats.
+    expect(out).toContain('(new)')
+    expect(out).toContain('+2')
+    expect(out).toContain('-1')
+  })
+
+  test('REVERT-SENSITIVITY: summary present with file ops, absent (null) with none', async () => {
+    const withOps = await renderSummary(
+      deriveTurnFileChanges([writeBlock('index.html', '<html></html>\n')]),
+    )
+    const withoutOps = await renderSummary(deriveTurnFileChanges([{ type: 'text', text: 'hi' }]))
+    expect(withOps).toContain('files changed')
+    expect(withOps).toContain('index.html')
+    // No file ops → the component returns null → nothing rendered.
+    expect(withoutOps.trim()).toBe('')
+    expect(withoutOps).not.toContain('files changed')
+  })
+
+  test('a created file shows a "+" create marker + (new) distinct from the "~" edit marker', async () => {
+    // Render a CREATE-only turn and an EDIT-only turn so each marker is asserted
+    // in isolation (the compact summary may pack several files onto one row).
+    const createOut = await renderSummary(deriveTurnFileChanges([writeBlock('new.ts', 'x\n')]))
+    const editOut = await renderSummary(deriveTurnFileChanges([editBlock('old.ts', 'a\n', 'b\n')]))
+    // Create: '+ new.ts (new)' — the new-file marker and label are present.
+    expect(createOut).toContain('+ new.ts')
+    expect(createOut).toContain('(new)')
+    // Edit: '~ old.ts' — the edit marker, and NO (new) label.
+    expect(editOut).toContain('~ old.ts')
+    expect(editOut).not.toContain('(new)')
+  })
+
+  test('a long list of changed files does NOT overflow the viewport width', async () => {
+    const columns = 80
+    // 20 changed files — more than the inline cap — at a narrow width.
+    const changes = deriveTurnFileChanges(
+      Array.from({ length: 20 }, (_v, i) => writeBlock(`file-${i}.ts`, 'x\n')),
+    )
+    const out = await renderSummary(changes, columns)
+    // Every rendered row stays within the terminal width (no overflow).
+    for (const line of out.split('\n')) {
+      expect(line.length).toBeLessThanOrEqual(columns)
+    }
+    // The remainder past the cap collapses to a "… +N more" tail rather than
+    // listing all 20 files.
+    expect(out).toMatch(/… \+\d+ more/)
+  })
+
+  test('a very long single file path is truncated and never overflows the row', async () => {
+    const columns = 60
+    const longPath = `/very/deeply/nested/${'segment/'.repeat(8)}component.tsx`
+    const out = await renderSummary(
+      deriveTurnFileChanges([editBlock(longPath, 'a\n', 'b\n')]),
+      columns,
+    )
+    for (const line of out.split('\n')) {
+      expect(line.length).toBeLessThanOrEqual(columns)
+    }
+    expect(out).toContain('files changed')
+  })
+
+  test('an empty changes array renders nothing', async () => {
+    const out = await renderSummary([])
+    expect(out.trim()).toBe('')
+  })
+})


### PR DESCRIPTION
Green-lit build-flow improvement: after a turn that writes/edits, a compact '⎿ files changed  + index.html (new)  ~ styles.css +2 -1' summary derived from the turn's own tool-uses (CREATE/EDIT markers + counts, wraps/collapses long lists). Verified live; 11 revert-sensitive tests; full suite 13276.