### PR TITLE
tui visual iter 16: consistent assistant marker + Esc wording

### DIFF
--- a/runtime/src/tui/components/Messages.tsx
+++ b/runtime/src/tui/components/Messages.tsx
@@ -9,8 +9,7 @@ import type { StreamingToolUse } from '../../llm/types.js';
 import { every } from '../../utils/set.js';
 import { getIsRemoteMode } from '../../bootstrap/state.js';
 import type { Command } from '../../commands.js';
-import { BLACK_CIRCLE } from '../../constants/figures.js';
-import { ContentWidthProvider, insetContentWidth, useContentWidth } from '../context/contentWidthContext.js';
+import { useContentWidth } from '../context/contentWidthContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import type { ScrollBoxHandle } from '../ink/components/ScrollBox.js';
 import { useTerminalNotification } from '../ink/useTerminalNotification.js';
@@ -40,7 +39,7 @@ import { StreamingMarkdown } from './markdown/Markdown.js';
 import { hasContentAfterIndex, MessageRow } from './MessageRow.js';
 import { InVirtualListContext, type MessageActionsNav, MessageActionsSelectedContext, type MessageActionsState } from './messageActions.js';
 import { ThinkingMessage as AssistantThinkingMessage } from './v2/messagePrimitives.js';
-import { WelcomeColdPanel } from './v2/primitives.js';
+import { Msg, WelcomeColdPanel } from './v2/primitives.js';
 import { isNullRenderingAttachment } from '../message-visibility.js';
 import { OffscreenFreeze } from './OffscreenFreeze.js';
 import type { ToolUseConfirm } from '../permission-types.js';
@@ -308,7 +307,6 @@ const MessagesImpl = ({
   } = useTerminalSize();
   const inheritedContentWidth = useContentWidth();
   const contentColumns = inheritedContentWidth ?? columns;
-  const streamingContentWidth = insetContentWidth(contentColumns, 2) ?? contentColumns;
   const toggleShowAllShortcut = useShortcutDisplay('transcript:toggleShowAll', 'Transcript', 'Ctrl+E');
   const normalizedMessages = useMemo(() => normalizeMessages(messages).filter(isNotEmptyMessage), [messages]);
   const [streamingThinkingExpiryTick, setStreamingThinkingExpiryTick] = useState(0);
@@ -640,17 +638,17 @@ const MessagesImpl = ({
           <VirtualMessageList messages={renderableMessages} scrollRef={scrollRef} columns={contentColumns} itemKey={messageKey} renderItem={renderMessageRow} onItemClick={onItemClick} isItemClickable={isItemClickable} isItemExpanded={isItemExpanded} trackStickyPrompt={trackStickyPrompt} selectedIndex={selectedIdx >= 0 ? selectedIdx : undefined} cursorNavRef={cursorNavRef} setCursor={setCursor} jumpRef={jumpRef} onSearchMatchesChange={onSearchMatchesChange} scanElement={scanElement} setPositions={setPositions} extractSearchText={extractSearchText} />
         </InVirtualListContext.Provider> : renderableMessages.flatMap(renderMessageRow)}
 
-      {streamingText && !isBriefOnly && <Box alignItems="flex-start" flexDirection="row" marginTop={1} width="100%">
-          <Box flexDirection="row">
-            <Box minWidth={2}>
-              <Text color="text">{BLACK_CIRCLE}</Text>
-            </Box>
-            <Box flexDirection="column" width={streamingContentWidth}>
-              <ContentWidthProvider width={streamingContentWidth}>
-                <StreamingMarkdown>{streamingText}</StreamingMarkdown>
-              </ContentWidthProvider>
-            </Box>
-          </Box>
+      {streamingText && !isBriefOnly && <Box flexDirection="column" marginTop={1} width="100%">
+          {/* The live (most-recent, still-streaming) assistant turn carries the
+              same `▮ AGENC` identity as historical/settled turns. Wrapping in
+              `Msg role="agenc"` (instead of a bare `●` marker) keeps the
+              marker consistent across the streaming→settled transition, so the
+              same assistant message never flips between two identity markers.
+              `Msg` derives its own content-width inset from context, matching
+              the settled AssistantTextMessage render. */}
+          <Msg role="agenc" label="agenc">
+            <StreamingMarkdown>{streamingText}</StreamingMarkdown>
+          </Msg>
         </Box>}
 
       {shouldRenderStreamingThinking(streamingThinking, screen, verbose) && streamingThinking && !isBriefOnly && <Box marginTop={1}>

--- a/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
@@ -132,7 +132,7 @@ function PromptInputQueuedCommandsImpl(): React.ReactNode {
       {queuedInputCount > 0 && <Box marginLeft={2} marginBottom={1}>
           <Text dimColor>
             {queuedInputCount === 1 ? '1 input queued for next turn' : `${queuedInputCount} inputs queued for next turn`}
-            {' · esc interrupts the current turn'}
+            {' · esc to interrupt'}
           </Text>
         </Box>}
       {messages.map((message, i) => <QueuedMessageProvider key={i} isFirst={i === 0} useBriefLayout={useBriefLayout}>

--- a/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
@@ -101,6 +101,19 @@ describe('PromptInputQueuedCommands', () => {
     expect(output).toContain('Use another library')
   })
 
+  it('describes the Esc action with the same wording as the footer hint', async () => {
+    const { PromptInputQueuedCommands } = await import('./PromptInputQueuedCommands.js')
+
+    const output = await renderToString(<PromptInputQueuedCommands />, 100)
+
+    // The queued-commands banner and the footer/spinner Esc hint must use ONE
+    // consistent phrasing so the same Esc action is not described two different
+    // ways on screen at once. Canonical wording is the footer's "esc to
+    // interrupt" (KeyboardShortcutHint shortcut="esc" action="interrupt").
+    expect(output).toContain('esc to interrupt')
+    expect(output).not.toContain('esc interrupts the current turn')
+  })
+
   it('shows queued bash commands as next-turn input', async () => {
     queueFixture.commands = [
       {

--- a/runtime/tests/tui/coverage-swarm/swarm-005-components-Messages.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-005-components-Messages.test.tsx
@@ -17,6 +17,7 @@ const harness = vi.hoisted(() => ({
   dividers: [] as string[],
   features: new Set<string>(),
   hasContentAfterIndexResult: false,
+  msgMarkers: [] as Array<{ label: string; role: string }>,
   progress: vi.fn(),
   streamingMarkdown: [] as string[],
   thinkingMessages: [] as string[],
@@ -33,6 +34,7 @@ const harness = vi.hoisted(() => ({
     harness.dividers = []
     harness.features = new Set()
     harness.hasContentAfterIndexResult = false
+    harness.msgMarkers = []
     harness.progress.mockClear()
     harness.streamingMarkdown = []
     harness.thinkingMessages = []
@@ -96,6 +98,23 @@ vi.mock('../../../src/tui/components/v2/primitives.js', async () => {
   const { Text } = await import('../../../src/tui/ink.js')
   return {
     WelcomeColdPanel: () => React.createElement(Text, null, 'welcome'),
+    Msg: ({
+      role,
+      label,
+      children,
+    }: {
+      readonly role: string
+      readonly label: string
+      readonly children?: ReactNode
+    }) => {
+      harness.msgMarkers.push({ label, role })
+      return React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(Text, null, `▮ ${label.toUpperCase()}`),
+        children,
+      )
+    },
   }
 })
 
@@ -351,6 +370,12 @@ describe('Messages coverage swarm row 005', () => {
       expect(latestVirtualCall().selectedIndex).toBe(1)
       expect(harness.dividers).toContain('1 new message')
       expect(harness.streamingMarkdown).toContain('streaming answer')
+      // The live (most-recent, still-streaming) assistant turn must carry the
+      // same `▮ AGENC` identity marker as historical/settled turns, so the same
+      // assistant message never flips between two identity markers across the
+      // streaming→settled transition. Revert-sensitive: if the streaming render
+      // falls back to a bare `●` marker (no Msg wrapper), this is empty.
+      expect(harness.msgMarkers).toContainEqual({ label: 'agenc', role: 'agenc' })
       expect(harness.thinkingMessages).toContain('still thinking')
       expect(harness.progress).toHaveBeenCalledWith('completed')
     } finally {


### PR DESCRIPTION
From the build re-run: the most-recent assistant turn showed a bare '●' vs '▮ AGENC' on historical turns (marker flipped on settle) -> render the streaming turn through the same Msg wrapper for a seamless, consistent identity; and unify two Esc phrasings to 'esc to interrupt'. Write-vs-CREATE intentionally left distinct. Revert-sensitive tests; full suite 13280.