### PR TITLE
tui visual iter 17: open the built file from the files-changed summary

### DIFF
--- a/runtime/src/tui/message-renderers/TurnFileChangesSummary.tsx
+++ b/runtime/src/tui/message-renderers/TurnFileChangesSummary.tsx
@@ -16,12 +16,23 @@
  * card palette. Long lists wrap to additional rows and collapse past a cap to a
  * "… +N more" tail, so the block never overflows the content row.
  *
+ * Each entry's file path is wrapped in `FilePathLink`, the SAME OSC 8 hyperlink
+ * the per-file Write/Edit diff cards already render (see `FileWriteTool/UI.tsx`,
+ * `FileEditTool/UI.tsx`). So in a click-to-open terminal (iTerm2, kitty, …) the
+ * just-built file is openable straight from the rollup — the build session is no
+ * longer a dead end. No new keybinding/dispatch wiring into the static
+ * transcript and no external process spawning: it reuses the one open-file
+ * affordance the transcript already exposes. The visible label stays the short
+ * basename (so the compact row never overflows) while the link target is the
+ * full path.
+ *
  * @module
  */
 
 import React from "react";
 import Box from "../ink/components/Box.js";
 import ThemedText from "../components/design-system/ThemedText.js";
+import { FilePathLink } from "../components/FilePathLink.js";
 import type { TurnFileChange } from "../turn-file-changes.js";
 
 /**
@@ -52,9 +63,14 @@ function FileEntry({ change }: { readonly change: TurnFileChange }): React.React
   return (
     <Box flexDirection="row" flexShrink={0} gap={1}>
       <ThemedText color={markerColor}>{marker}</ThemedText>
-      <ThemedText color="text2" wrap="truncate-middle">
-        {shortenFile(change.file)}
-      </ThemedText>
+      {/* OSC 8 hyperlink to the file so it can be opened from the rollup, with
+          the short basename as the visible label and the full path as the link
+          target — same affordance the per-file diff cards already render. */}
+      <FilePathLink filePath={change.file}>
+        <ThemedText color="text2" wrap="truncate-middle">
+          {shortenFile(change.file)}
+        </ThemedText>
+      </FilePathLink>
       {isCreate ? <ThemedText color="success">(new)</ThemedText> : null}
       {showStats ? (
         <Box flexDirection="row" flexShrink={0}>

--- a/runtime/tests/tui/turn-file-changes-summary.test.tsx
+++ b/runtime/tests/tui/turn-file-changes-summary.test.tsx
@@ -1,5 +1,7 @@
+import { pathToFileURL } from 'node:url'
+
 import React from 'react'
-import { describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 
 import { Box } from '../../src/tui/ink.js'
 import {
@@ -7,7 +9,7 @@ import {
   type TurnFileChange,
 } from '../../src/tui/turn-file-changes.js'
 import { TurnFileChangesSummary } from '../../src/tui/message-renderers/TurnFileChangesSummary.js'
-import { renderToString } from '../../src/utils/staticRender.js'
+import { renderToAnsiString, renderToString } from '../../src/utils/staticRender.js'
 
 // UX improvement coverage: a build session renders a per-file collapsed diff
 // for every Write/Edit, but had no concise "here's what THIS turn changed"
@@ -166,5 +168,74 @@ describe('TurnFileChangesSummary (compact per-turn render)', () => {
   test('an empty changes array renders nothing', async () => {
     const out = await renderSummary([])
     expect(out.trim()).toBe('')
+  })
+})
+
+// Open-from-rollup affordance: each changed-file entry is wrapped in the SAME
+// OSC 8 FilePathLink the per-file diff cards render, so in a click-to-open
+// terminal the just-built file opens straight from the summary (no new keybind
+// wiring into the static transcript, no external process). These tests force
+// hyperlink output on and assert the OSC 8 sequence targets the file's URL.
+describe('TurnFileChangesSummary (open-from-rollup OSC 8 affordance)', () => {
+  const previousForceHyperlink = process.env.FORCE_HYPERLINK
+
+  afterEach(() => {
+    if (previousForceHyperlink === undefined) {
+      delete process.env.FORCE_HYPERLINK
+    } else {
+      process.env.FORCE_HYPERLINK = previousForceHyperlink
+    }
+  })
+
+  function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+
+  function renderAnsi(changes: readonly TurnFileChange[], columns = 100): Promise<string> {
+    return renderToAnsiString(
+      <Box flexDirection="column" width={columns}>
+        <TurnFileChangesSummary changes={changes} />
+      </Box>,
+      { columns, rows: 40 },
+    )
+  }
+
+  test('a changed file renders an OSC 8 hyperlink to its file:// URL', async () => {
+    process.env.FORCE_HYPERLINK = '1'
+    const changes = deriveTurnFileChanges([editBlock('styles.css', 'a{}\n', 'a{color:red}\n')])
+    const out = await renderAnsi(changes)
+    // The OSC 8 open sequence targets the file's resolved file:// URL.
+    const url = pathToFileURL('styles.css').href
+    expect(out).toMatch(new RegExp(`\\x1B\\]8;[^;\\x07]*;${escapeRegExp(url)}\\x07`))
+    // It still closes the hyperlink (terminator) so following text is unlinked.
+    expect(out).toContain('\x1B]8;;\x07')
+    // The compact label/stats are still present alongside the link.
+    expect(out).toContain('files changed')
+    expect(out).toContain('styles.css')
+  })
+
+  test('REVERT-SENSITIVITY: without the FilePathLink wrap, no OSC 8 link is emitted', async () => {
+    // This asserts the affordance specifically. If the FilePathLink wrap is
+    // removed from FileEntry (reverting the feature), the file path renders as
+    // plain ThemedText and this OSC 8 open sequence disappears — turning this
+    // test red. With the wrap present, the link target URL is emitted.
+    process.env.FORCE_HYPERLINK = '1'
+    const url = pathToFileURL('index.html').href
+    const withLink = await renderAnsi(
+      deriveTurnFileChanges([writeBlock('index.html', '<html></html>\n')]),
+    )
+    expect(withLink).toContain(`;${url}\x07`)
+
+    // Sanity: with hyperlinks disabled the same render emits no OSC 8 sequence
+    // (graceful degradation in non-supporting terminals), proving the link is
+    // the only source of the sequence.
+    process.env.FORCE_HYPERLINK = '0'
+    const noLink = await renderAnsi(
+      deriveTurnFileChanges([writeBlock('index.html', '<html></html>\n')]),
+    )
+    expect(noLink).not.toContain('\x1B]8;')
+    // The summary content itself is unchanged when hyperlinks are off.
+    expect(noLink).toContain('files changed')
+    expect(noLink).toContain('index.html')
   })
 })


### PR DESCRIPTION
Green-lit build-flow improvement: the per-turn 'files changed' entries are now OSC 8 hyperlinks (the same click-to-open affordance the diff cards use), so you can open the just-built file straight from the rollup in a supporting terminal; degrades to plain text elsewhere. Pure reuse, no new wiring. Revert-sensitive tests; full suite 13282.