### PR TITLE
tui visual iter 18: paren-hugging header, verb casing, empty-state, dedupe hints

### DIFF
--- a/runtime/src/tui/components/PromptInput/usePromptInputPlaceholder.ts
+++ b/runtime/src/tui/components/PromptInput/usePromptInputPlaceholder.ts
@@ -67,8 +67,14 @@ export function usePromptInputPlaceholder({
     // sit blank at rest. Surface a stable, on-brand hint so a new user always
     // knows what to type. It disappears as soon as input is non-empty (guarded
     // above) and renders dim like every other placeholder.
+    //
+    // Kept deliberately minimal ("Describe a task…"): the `/` and `@`
+    // affordances are taught once on the cold-start welcome card (which is on
+    // screen at exactly this moment, since this fallback only fires before the
+    // first submit). Restating them here too made one idea appear three ways on
+    // adjacent rows, so the placeholder no longer repeats them.
     if (submitCount < 1 && !proactiveActive) {
-      return 'Describe a task · / for commands · @ to attach a file'
+      return 'Describe a task…'
     }
   }, [
     input,

--- a/runtime/src/tui/components/v2/designBrowserMarkerFixture.ts
+++ b/runtime/src/tui/components/v2/designBrowserMarkerFixture.ts
@@ -38,8 +38,8 @@ export const BROWSER_MARKER_FIXTURE = {
   ],
   '03b': [
     { marker: 'swap_v2', row: 19, column: 31 },
-    { marker: 'Read ( programs/swap/src/lib.rs:114-130 )', row: 16, column: 21 },
-    { marker: 'Grep ( pattern: "token::transfer", path: "programs/swap/src"', row: 13, column: 21 },
+    { marker: 'Read (programs/swap/src/lib.rs:114-130)', row: 16, column: 21 },
+    { marker: 'Grep (pattern: "token::transfer", path: "programs/swap/src"', row: 13, column: 21 },
     { marker: 'token::transfer(cpi_ctx, amount_in)', row: 19, column: 44 },
   ],
   '04a': [

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -951,11 +951,20 @@ export function Tool({
         <ThemedText color={toolColor[kind]} bold>
           {label ?? capitalize(kind)}
         </ThemedText>
-        <ThemedText color="inactive">(</ThemedText>
-        <ThemedText color="text2" wrap="truncate-middle">
-          {args}
-        </ThemedText>
-        <ThemedText color="inactive">)</ThemedText>
+        {/*
+          The parenthesized args render as a single gap={0} unit so the parens
+          hug the argument (`Write (index.html)`) instead of the outer gap={1}
+          inserting a stray space on the inside of each paren (`Write ( index.html )`).
+          The single space between the bold tool label and the opening paren is
+          still supplied by the parent row's gap={1}.
+        */}
+        <Box flexDirection="row" gap={0}>
+          <ThemedText color="inactive">(</ThemedText>
+          <ThemedText color="text2" wrap="truncate-middle">
+            {args}
+          </ThemedText>
+          <ThemedText color="inactive">)</ThemedText>
+        </Box>
         {time ? <ThemedText color="inactive">{time}</ThemedText> : null}
       </Box>
       {result != null && result !== '' ? (

--- a/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
+++ b/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
@@ -5,7 +5,7 @@ import type { SpinnerMode } from "../components/spinner/types.js";
 import {
   getDefaultCharacters,
   getReducedMotionDot,
-  verbForMode,
+  titleVerbForMode,
 } from "../components/spinner/utils.js";
 import { useSettings } from "../hooks/useSettings.js";
 
@@ -56,7 +56,12 @@ export function WorkbenchActivityIndicator({
     <Box flexShrink={0} flexDirection="row">
       <Text dimColor wrap="truncate-end">{separator}</Text>
       <Text color="agenc">{glyph}</Text>
-      <Text color="text2" wrap="truncate-end"> {verbForMode(mode)}…</Text>
+      {/*
+        Title-case the verb so the status bar reads "✻ Working…" — matching the
+        composer body spinner (which uses titleVerbForMode) for the same turn,
+        instead of a lowercase "working…" wedged next to ALL-CAPS chrome.
+      */}
+      <Text color="text2" wrap="truncate-end"> {titleVerbForMode(mode)}…</Text>
     </Box>
   );
 }

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -361,6 +361,9 @@ function markerForRow(row: ProjectTreeRow, glyphs: ReturnType<typeof selectAgenC
   if (row.kind === "root") return row.expanded ? glyphs.arrowDown : glyphs.arrowRight;
   if (row.kind === "directory") return row.expanded ? glyphs.arrowDown : glyphs.arrowRight;
   if (row.kind === "loading") return glyphs.ellipsis;
+  // An empty workspace is a normal cold-start state, so its marker is a neutral
+  // space — the "!" below is reserved for genuine error rows.
+  if (row.kind === "empty") return " ";
   if (row.kind === "error") return "!";
   return " ";
 }

--- a/runtime/src/tui/workbench/project-tree/buildTree.ts
+++ b/runtime/src/tui/workbench/project-tree/buildTree.ts
@@ -184,9 +184,13 @@ function normalizeRelativePath(value: string): string {
 function emptyRows(options: BuildProjectTreeOptions): ProjectTreeRow[] {
   return [{
     id: "loading-empty",
+    // An empty workspace on cold start is a NORMAL state, not a fault: use the
+    // neutral "empty" kind so its marker is a space rather than the "!" the tree
+    // reserves for genuine errors (which would make a fresh project look broken).
+    // The copy stays inviting to match the welcome-screen tone.
     path: "",
-    label: options.gitStatus ? "No project files" : "Loading files",
-    kind: options.gitStatus ? "error" : "loading",
+    label: options.gitStatus ? "No files yet — describe a task to get started" : "Loading files",
+    kind: options.gitStatus ? "empty" : "loading",
     depth: 1,
     expanded: false,
     hasChildren: false,

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -95,7 +95,7 @@ export type ProjectTreeGitState =
   | "untracked"
   | "ignored";
 
-export type ProjectTreeRowKind = "root" | "directory" | "file" | "loading" | "error";
+export type ProjectTreeRowKind = "root" | "directory" | "file" | "loading" | "empty" | "error";
 
 export type ProjectTreeRow = {
   readonly id: string;

--- a/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.test.tsx
@@ -145,12 +145,12 @@ describe("usePromptInputPlaceholder", () => {
     // Default cold start: suggestions disabled, no queue, no teammate.
     const coldStart = await renderPlaceholder();
     expect(coldStart).toContain("Describe a task");
-    // The cold-start hint advertises BOTH discoverability affordances right
-    // where the user types: `/` opens commands and `@` attaches a file. The
-    // `@` advert is the item-2 addition; assert it explicitly so a revert of
-    // the placeholder string (dropping `@ to attach`) fails this test.
-    expect(coldStart).toContain("/ for commands");
-    expect(coldStart).toContain("@ to attach a file");
+    // The placeholder stays minimal: the `/` and `@` affordances are taught on
+    // the cold-start welcome card (on screen at this same moment), so the
+    // composer no longer restates them — that triplicated one idea across three
+    // adjacent rows. Revert-sensitive: re-adding the hints here fails these.
+    expect(coldStart).not.toContain("/ for commands");
+    expect(coldStart).not.toContain("@ to attach");
 
     // The hint is a cold-start affordance only — it disappears once the user
     // has started the conversation.

--- a/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.wave200-148.coverage.test.ts
+++ b/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.wave200-148.coverage.test.ts
@@ -201,9 +201,10 @@ describe('usePromptInputPlaceholder coverage', () => {
         fixture.state.appState.promptSuggestionEnabled = false
       },
       // Cold start with suggestions disabled: instead of a blank composer, the
-      // hook now surfaces the stable on-brand guidance hint, advertising both
-      // the `/` command and `@` attach affordances.
-      'Describe a task · / for commands · @ to attach a file',
+      // hook surfaces a stable on-brand guidance hint. It stays minimal — the
+      // `/` and `@` affordances are taught on the cold-start welcome card on
+      // screen at the same moment, so the placeholder no longer restates them.
+      'Describe a task…',
     )
 
     await expectPlaceholder(() => {}, undefined, { submitCount: 1 })

--- a/runtime/tests/tui/components/v2/designStateSmoke.test.tsx
+++ b/runtime/tests/tui/components/v2/designStateSmoke.test.tsx
@@ -2479,7 +2479,7 @@ const DESIGN_STATES: readonly DesignState[] = [
             </ThemedText>
             <Box minHeight={1} />
             <ThemedText color="text2">
-              {designBodyRow([20, '● '], [22, 'Read ( programs/swap/tests/swap.rs:42-58 ) 14:09:26'])}
+              {designBodyRow([20, '● '], [22, 'Read (programs/swap/tests/swap.rs:42-58) 14:09:26'])}
             </ThemedText>
             <Box minHeight={1} />
             <ThemedText color="subtle">{designBodyRow([21, '⎿ '], [23, 'read 17 lines'])}</ThemedText>

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -12,6 +12,7 @@ import {
   SlashPalette,
   StatusSegment,
   TerminalFrame,
+  Tool,
   WelcomeColdPanel,
 } from './primitives.js'
 
@@ -218,6 +219,25 @@ describe('Msg queued header marker', () => {
 
     expect(output).toContain('1:37 AM')
     expect(output).not.toContain('queued')
+  })
+})
+
+describe('Tool call header paren spacing', () => {
+  it('hugs the args with parens — no space on the inside of either paren', async () => {
+    const output = await renderToString(
+      <Tool kind="edit" label="Write" args="index.html" />,
+      { columns: 100, rows: 12 },
+    )
+
+    // Industry convention: `Tool(arg)` with the parens hugging the argument.
+    // Revert-sensitive: putting the `(`, args, and `)` back as separate
+    // children of the gap={1} row re-introduces `( index.html )` and fails
+    // both assertions (the negative one most directly).
+    expect(output).toContain('(index.html)')
+    expect(output).not.toContain('( index.html )')
+    // The single space between the bold tool label and the opening paren is
+    // still supplied by the row's gap — `Write (index.html)`.
+    expect(output).toContain('Write (index.html)')
   })
 })
 

--- a/runtime/tests/tui/workbench/activity-and-diff.test.tsx
+++ b/runtime/tests/tui/workbench/activity-and-diff.test.tsx
@@ -23,20 +23,25 @@ describe("WorkbenchActivityIndicator (working / waiting-on-model signal)", () =>
   // The verb text is the load-bearing, surface-agnostic signal: the glyph is a
   // brand spinner frame that varies, but the verb is stable. Asserting on the
   // verb makes the test robust and revert-sensitive (idle renders no verb).
-  it("renders a distinct working verb while a turn is active", async () => {
+  it("renders a distinct, title-cased working verb while a turn is active", async () => {
     const out = await renderToString(
       withState(<WorkbenchActivityIndicator mode="requesting" />),
       80,
     );
-    expect(out).toContain("working");
+    // Title-cased to agree with the composer body spinner ("Working…") for the
+    // same turn, instead of a lowercase "working…" next to ALL-CAPS chrome.
+    // Revert-sensitive: reverting the indicator to verbForMode (lowercase)
+    // renders "working" and fails the title-case assertion below.
+    expect(out).toContain("Working");
+    expect(out).not.toContain("working");
   });
 
-  it("maps each streaming phase to its own verb", async () => {
+  it("maps each streaming phase to its own title-cased verb", async () => {
     const cases: ReadonlyArray<[Parameters<typeof WorkbenchActivityIndicator>[0]["mode"], string]> = [
-      ["thinking", "thinking"],
-      ["responding", "responding"],
-      ["tool-use", "running tools"],
-      ["tool-input", "preparing tools"],
+      ["thinking", "Thinking"],
+      ["responding", "Responding"],
+      ["tool-use", "Running tools"],
+      ["tool-input", "Preparing tools"],
     ];
     for (const [mode, verb] of cases) {
       const out = await renderToString(withState(<WorkbenchActivityIndicator mode={mode} />), 80);
@@ -69,7 +74,7 @@ describe("WorkbenchActivityIndicator (working / waiting-on-model signal)", () =>
       80,
     );
     expect(out).toContain(getReducedMotionDot());
-    expect(out).toContain("working");
+    expect(out).toContain("Working");
   });
 
   // #16: when the animated glyph lands on its dot frame ("·") it sits next to
@@ -113,13 +118,16 @@ describe("title bar / status line phase agreement", () => {
     }
   });
 
-  it("renders the honest phase word in the workbench title bar for each mode", async () => {
+  it("renders the honest, title-cased phase word in the workbench title bar for each mode", async () => {
     for (const mode of MODES) {
       const out = await renderToString(
         withState(<WorkbenchActivityIndicator mode={mode} />),
         80,
       );
-      expect(out).toContain(verbForMode(mode));
+      // The status-bar indicator now renders the SAME title-cased verb as the
+      // composer body spinner (titleVerbForMode), so they never disagree on
+      // casing for the same turn.
+      expect(out).toContain(titleVerbForMode(mode));
     }
   });
 });
@@ -135,7 +143,8 @@ describe("WorkbenchStatusBar working indicator", () => {
       120,
     );
     expect(busy).toContain("AgenC Workbench");
-    expect(busy).toContain("working");
+    // Title-cased verb, matching the composer body spinner for the same turn.
+    expect(busy).toContain("Working");
   });
 });
 

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -86,6 +86,30 @@ describe("project tree helpers", () => {
     });
   });
 
+  it("renders an empty workspace as a neutral 'empty' row, not an error row", () => {
+    // Cold start in a known (git-tracked) but file-less workspace: gitStatus is
+    // present, paths are empty. The fallback row must be a neutral "empty" kind
+    // — an empty workspace is a NORMAL first-impression state, not a fault — so
+    // it never gets the alarming "!" marker the tree reserves for real errors.
+    const rows = buildProjectTreeRows({
+      cwd: "/repo",
+      paths: [],
+      expandedPaths: new Set(),
+      cursorPath: null,
+      activePath: null,
+      gitStatus: new Map(),
+    });
+
+    const emptyRow = rows.find((row) => row.id === "loading-empty");
+    expect(emptyRow).toMatchObject({
+      kind: "empty",
+      label: "No files yet — describe a task to get started",
+    });
+    // Revert-sensitive: restoring kind:"error" / "No project files" fails these.
+    expect(emptyRow?.kind).not.toBe("error");
+    expect(rows.some((row) => row.kind === "error")).toBe(false);
+  });
+
   it("parses git porcelain status", () => {
     const parsed = parseGitStatusPorcelain(
       [
@@ -287,9 +311,14 @@ describe("project tree helpers", () => {
       const snapshot = store.getSnapshot();
 
       expect(snapshot.loading).toBe(false);
+      // The genuine refresh failure is surfaced via snapshot.error (rendered as a
+      // dedicated red line), so the fallback tree row stays a neutral "empty"
+      // kind — it must NOT carry the "error" kind that paints the alarming "!"
+      // marker on a row that, on a normal cold start, just means an empty workspace.
       expect(snapshot.error).toEqual(expect.stringContaining("ENOTDIR"));
-      expect(snapshot.rows.find((row) => row.kind === "error")).toMatchObject({
-        label: "No project files",
+      expect(snapshot.rows.find((row) => row.kind === "error")).toBeUndefined();
+      expect(snapshot.rows.find((row) => row.kind === "empty")).toMatchObject({
+        label: "No files yet — describe a task to get started",
       });
     } finally {
       store.dispose();

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -165,6 +165,29 @@ describe("workbench render contract", () => {
     expect(output).toContain("clean");
   });
 
+  it("renders the empty-workspace row without the '!' error marker", async () => {
+    // An empty workspace on cold start is a normal state, so its row must NOT
+    // carry the "!" glyph the tree reserves for genuine errors — that would make
+    // a fresh project look broken on first impression. Revert-sensitive:
+    // restoring kind:"error" on the empty row re-introduces the "!" and fails
+    // the negative assertion.
+    const output = await renderToString(
+      <ProjectExplorerRow
+        width={48}
+        row={{
+          ...row("", "No files yet — describe a task to get started", "file", 1),
+          id: "loading-empty",
+          kind: "empty" as never,
+        }}
+      />,
+      48,
+    );
+
+    expect(output).toContain("No files yet");
+    // The label intentionally contains no "!" so any "!" must be the marker.
+    expect(output).not.toContain("!");
+  });
+
   it("renders loading rows, active rows, and one-column label trims", async () => {
     const loadingOutput = await renderToString(
       <ProjectExplorerRow


### PR DESCRIPTION
Convergence-round polish (bugs 17->9->7): tool header '● Write ( index.html )' -> '● Write (index.html)'; status verb lowercase 'working…' -> 'Working…' (matches composer); empty project '! No project files' -> neutral 'No files yet — describe a task to get started'; triplicated cold-start hints reduced. Revert-sensitive tests; full suite 13285.