### PR TITLE
feat(tui): per-item queue control — drop the last queued input

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -9,7 +9,7 @@ import { type IDEAtMentioned, useIdeAtMentioned } from '../../hooks/useIdeAtMent
 import { type AppState, useAppState, useAppStateStore, useSetAppState } from '../../state/AppState.js';
 import type { FooterItem } from '../../state/AppStateStore.js';
 import { getCwd } from '../../../utils/cwd.js';
-import { enqueue, isQueuedCommandEditable, popAllEditable } from '../../../utils/messageQueueManager.js';
+import { enqueue, isQueuedCommandEditable, popAllEditable, removeLastQueuedInput } from '../../../utils/messageQueueManager.js';
 import stripAnsi from 'strip-ansi';
 import { type Command, hasCommand } from '../../../commands.js';
 import { useIsModalOverlayActive, useRegisterOverlay } from '../../context/overlayContext.js';
@@ -1913,6 +1913,22 @@ function PromptInput({
     }
   }, [stashedPrompt, trackAndSetInput, setStashedPrompt, setPastedContentsAndRef, setCurrentCursorOffset]);
 
+  // Handler for chat:dropQueuedInput - remove the most recently queued input
+  // before it dispatches. Per-item queue control: deletes exactly one specific
+  // queued item (the last one added) through the same store the dispatcher
+  // drains, so a dropped item truly never sends. No-op (and no notification)
+  // when nothing is queued.
+  const handleDropQueuedInput = useCallback(() => {
+    const removed = removeLastQueuedInput();
+    if (removed === undefined) return;
+    addNotification({
+      key: 'queued-input-dropped',
+      text: 'Removed last queued input',
+      priority: 'immediate',
+      timeoutMs: 3000
+    });
+  }, [addNotification]);
+
   // Handler for chat:modelPicker - toggle model picker
   const handleModelPicker = useCallback(() => {
     setShowModelPicker(prev => !prev);
@@ -2205,10 +2221,11 @@ function PromptInput({
     'chat:newline': handleNewline,
     'chat:externalEditor': handleExternalEditor,
     'chat:stash': handleStash,
+    'chat:dropQueuedInput': handleDropQueuedInput,
     'chat:modelPicker': handleModelPicker,
     'chat:thinkingToggle': handleThinkingToggle,
     'chat:imagePaste': handleImagePaste
-  }), [handleUndo, handleNewline, handleExternalEditor, handleStash, handleModelPicker, handleThinkingToggle, handleImagePaste]);
+  }), [handleUndo, handleNewline, handleExternalEditor, handleStash, handleDropQueuedInput, handleModelPicker, handleThinkingToggle, handleImagePaste]);
   useKeybindings(chatHandlers, {
     context: 'Chat',
     isActive: promptKeyboardActive

--- a/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
@@ -9,6 +9,7 @@ import { QueuedMessageProvider } from '../../context/QueuedMessageContext.js';
 import { useCommandQueue } from '../../hooks/useCommandQueue.js';
 import type { QueuedCommand } from '../../../types/textInputTypes.js';
 import { isQueuedCommandEditable, isQueuedCommandVisible } from '../../../utils/messageQueueManager.js';
+import { getShortcutDisplay } from '../../keybindings/shortcutFormat.js';
 import { createUserMessage, EMPTY_LOOKUPS, normalizeMessages } from '../../../utils/messages.js';
 import { jsonParse } from '../../../utils/slowOperations.js';
 import { escapeXml } from '../../../utils/xml.js';
@@ -133,6 +134,7 @@ function PromptInputQueuedCommandsImpl(): React.ReactNode {
           <Text dimColor>
             {queuedInputCount === 1 ? '1 input queued for next turn' : `${queuedInputCount} inputs queued for next turn`}
             {' · esc to interrupt'}
+            {` · ${getShortcutDisplay('chat:dropQueuedInput', 'Chat', 'ctrl+x backspace')} to drop last`}
           </Text>
         </Box>}
       {messages.map((message, i) => <QueuedMessageProvider key={i} isFirst={i === 0} useBriefLayout={useBriefLayout}>

--- a/runtime/src/tui/keybindings/defaultBindings.ts
+++ b/runtime/src/tui/keybindings/defaultBindings.ts
@@ -69,6 +69,10 @@ export const DEFAULT_BINDINGS: KeybindingBlock[] = [
       escape: 'chat:cancel',
       // ctrl+x chord prefix avoids shadowing readline editing keys (ctrl+a/b/e/f/...).
       'ctrl+x ctrl+k': 'chat:killAgents',
+      // Per-item queue control: drop the most recently queued input before it
+      // dispatches. ctrl+x prefix keeps it off the readline backspace inside
+      // the composer (bare backspace still deletes a char as usual).
+      'ctrl+x backspace': 'chat:dropQueuedInput',
       [MODE_CYCLE_KEY]: 'chat:cycleMode',
       'meta+p': 'chat:modelPicker',
       'meta+o': 'chat:fastMode',

--- a/runtime/src/tui/keybindings/types.ts
+++ b/runtime/src/tui/keybindings/types.ts
@@ -56,6 +56,7 @@ export const KEYBINDING_ACTION_NAMES = [
   'chat:stash',
   'chat:imagePaste',
   'chat:messageActions',
+  'chat:dropQueuedInput',
   'autocomplete:accept',
   'autocomplete:confirm',
   'autocomplete:dismiss',

--- a/runtime/src/utils/messageQueueManager.ts
+++ b/runtime/src/utils/messageQueueManager.ts
@@ -291,6 +291,68 @@ export function remove(commandsToRemove: QueuedCommand[]): void {
 }
 
 /**
+ * Whether this queued command is a user-typed input awaiting dispatch
+ * (a prompt or bash command), as opposed to a system notification or a
+ * raw-XML meta command. Matches the same set the prompt's "N inputs
+ * queued for next turn" banner counts — so per-item removal only ever
+ * targets the items the user actually sees as their own queued input.
+ */
+function isQueuedUserInput(cmd: QueuedCommand): boolean {
+  return (
+    isQueuedCommandEditable(cmd) &&
+    (cmd.mode === 'prompt' || cmd.mode === 'bash')
+  )
+}
+
+/**
+ * Number of user-typed inputs currently queued for dispatch.
+ * Mirrors the prompt banner's count so a UI affordance can decide
+ * whether to show/enable a per-item removal hint without re-deriving
+ * the filter.
+ */
+export function getQueuedUserInputCount(): number {
+  let count = 0
+  for (const cmd of commandQueue) {
+    if (isQueuedUserInput(cmd)) count++
+  }
+  return count
+}
+
+/**
+ * Remove the most-recently-queued user input (prompt/bash) from the queue,
+ * returning the removed command or undefined when there is none.
+ *
+ * This is the per-item queue-control primitive: it deletes exactly one
+ * specific queued item — the last one the user added, the most common
+ * "oops, drop that" target — through the SAME module-level queue the
+ * dispatcher drains. System notifications and raw-XML meta commands are
+ * never touched.
+ *
+ * Dispatch-boundary safety: the drain in App.tsx synchronously `dequeue`s
+ * (splices) a command out of `commandQueue` before it starts running it.
+ * Because this removal also operates synchronously on that same array, the
+ * command being dispatched is, at the instant of removal, EITHER still in
+ * the queue (we remove it; the drain's later peek never finds it) OR already
+ * spliced out by the drain (we no-op — `splice` finds nothing). There is no
+ * interleaving in single-threaded JS, so a queued item can never be both
+ * removed here and dispatched, nor double-sent.
+ */
+export function removeLastQueuedInput(): QueuedCommand | undefined {
+  for (let i = commandQueue.length - 1; i >= 0; i--) {
+    if (isQueuedUserInput(commandQueue[i]!)) {
+      const [removed] = commandQueue.splice(i, 1)
+      notifySubscribers()
+      logOperation(
+        'remove',
+        typeof removed?.value === 'string' ? removed.value : undefined,
+      )
+      return removed
+    }
+  }
+  return undefined
+}
+
+/**
  * Remove commands matching a predicate.
  * Returns the removed commands.
  */

--- a/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
@@ -114,6 +114,33 @@ describe('PromptInputQueuedCommands', () => {
     expect(output).not.toContain('esc interrupts the current turn')
   })
 
+  it('shows a discoverable per-item drop hint alongside the queued-input banner', async () => {
+    queueFixture.commands = [
+      { value: 'first prompt', mode: 'prompt' },
+      { value: 'second prompt', mode: 'prompt' },
+    ]
+    const { PromptInputQueuedCommands } = await import('./PromptInputQueuedCommands.js')
+
+    const output = await renderToString(<PromptInputQueuedCommands />, 100)
+
+    // The banner advertises the per-item queue control next to the interrupt
+    // hint, so the user can discover that a queued item can be dropped.
+    expect(output).toContain('2 inputs queued for next turn')
+    expect(output).toContain('to drop last')
+  })
+
+  it('omits the drop hint entirely when nothing is queued', async () => {
+    queueFixture.commands = []
+    const { PromptInputQueuedCommands } = await import('./PromptInputQueuedCommands.js')
+
+    const output = await renderToString(<PromptInputQueuedCommands />, 100)
+
+    // No queue → no affordance at all (and no empty banner).
+    expect(output).not.toContain('to drop last')
+    expect(output).not.toContain('queued for next turn')
+    expect(output.trim()).toBe('')
+  })
+
   it('shows queued bash commands as next-turn input', async () => {
     queueFixture.commands = [
       {

--- a/runtime/tests/utils/messageQueueManager.test.ts
+++ b/runtime/tests/utils/messageQueueManager.test.ts
@@ -14,11 +14,17 @@ vi.mock("./sessionStorage.js", () => ({
 }));
 
 import {
+  dequeue,
   enqueue,
+  enqueuePendingNotification,
   getCommandQueue,
+  getQueuedUserInputCount,
+  peek,
   popAllEditable,
+  removeLastQueuedInput,
   resetCommandQueue,
 } from "./messageQueueManager.js";
+import type { QueuedCommand } from "../types/textInputTypes.js";
 
 describe("messageQueueManager editable restore", () => {
   afterEach(() => {
@@ -66,6 +72,128 @@ describe("messageQueueManager editable restore", () => {
       cursorOffset: 0,
       images: [image],
     });
+    expect(getCommandQueue()).toEqual([]);
+  });
+});
+
+describe("messageQueueManager per-item removal (removeLastQueuedInput)", () => {
+  afterEach(() => {
+    resetCommandQueue();
+  });
+
+  // Mirror of App.tsx's drain primitive: peek the next main-thread runnable
+  // command (prompt/bash, no agentId), then dequeue it by reference identity.
+  function isMainThreadRunnableCommand(command: QueuedCommand): boolean {
+    return (
+      command.agentId === undefined &&
+      (command.mode === "prompt" || command.mode === "bash")
+    );
+  }
+  function dispatchNext(): QueuedCommand | undefined {
+    const next = peek(isMainThreadRunnableCommand);
+    if (next === undefined) return undefined;
+    return dequeue((command) => command === next);
+  }
+
+  test("counts only user inputs (prompt/bash), not notifications", () => {
+    enqueue({ value: "first", mode: "prompt" });
+    enqueue({ value: "echo hi", mode: "bash" });
+    enqueuePendingNotification({
+      value: "<task-notification/>",
+      mode: "task-notification",
+    });
+    expect(getQueuedUserInputCount()).toBe(2);
+  });
+
+  test("removes only the most recently queued input and leaves the rest intact", () => {
+    enqueue({ value: "first", mode: "prompt" });
+    enqueue({ value: "second", mode: "prompt" });
+    enqueue({ value: "third", mode: "prompt" });
+
+    const removed = removeLastQueuedInput();
+
+    expect(removed?.value).toBe("third");
+    expect(getCommandQueue().map((c) => c.value)).toEqual(["first", "second"]);
+  });
+
+  test("queue 3 → remove the middle item is reachable by removing twice then re-checking dispatch order", () => {
+    // The slice ships "drop last", so to drop the middle of [a,b,c] the user
+    // drops c (last) then b (now last). Prove b never dispatches afterward.
+    enqueue({ value: "a", mode: "prompt" });
+    enqueue({ value: "b", mode: "prompt" });
+    enqueue({ value: "c", mode: "prompt" });
+
+    expect(removeLastQueuedInput()?.value).toBe("c");
+    expect(removeLastQueuedInput()?.value).toBe("b");
+
+    // Only "a" remains and only "a" can ever dispatch.
+    expect(getCommandQueue().map((c) => c.value)).toEqual(["a"]);
+    expect(dispatchNext()?.value).toBe("a");
+    expect(dispatchNext()).toBeUndefined();
+  });
+
+  test("a removed item is never dispatched", () => {
+    enqueue({ value: "keep", mode: "prompt" });
+    enqueue({ value: "drop-me", mode: "prompt" });
+
+    removeLastQueuedInput();
+
+    const dispatched: (string | unknown)[] = [];
+    let cmd = dispatchNext();
+    while (cmd !== undefined) {
+      dispatched.push(cmd.value);
+      cmd = dispatchNext();
+    }
+    expect(dispatched).toEqual(["keep"]);
+    expect(dispatched).not.toContain("drop-me");
+  });
+
+  test("dispatch-boundary race: removing an item that was JUST dispatched is a safe no-op (no double-send)", () => {
+    enqueue({ value: "racing", mode: "prompt" });
+
+    // The drain dispatches the item first (synchronous splice out of the queue).
+    const dispatched = dispatchNext();
+    expect(dispatched?.value).toBe("racing");
+    expect(getCommandQueue()).toEqual([]);
+
+    // The user's drop key lands a tick later — the item is already gone, so the
+    // removal finds nothing and returns undefined. It does NOT remove some other
+    // item, and the item is not sent a second time.
+    expect(removeLastQueuedInput()).toBeUndefined();
+    expect(getCommandQueue()).toEqual([]);
+  });
+
+  test("dispatch-boundary race: dropping the item BEFORE the drain runs means it is never dispatched", () => {
+    enqueue({ value: "will-dispatch", mode: "prompt" });
+    enqueue({ value: "will-drop", mode: "prompt" });
+
+    // The user drops the last item before the turn settles; the drain then runs.
+    expect(removeLastQueuedInput()?.value).toBe("will-drop");
+
+    const dispatched: unknown[] = [];
+    let cmd = dispatchNext();
+    while (cmd !== undefined) {
+      dispatched.push(cmd.value);
+      cmd = dispatchNext();
+    }
+    expect(dispatched).toEqual(["will-dispatch"]);
+    expect(dispatched).not.toContain("will-drop");
+  });
+
+  test("ignores task notifications and meta commands — only user input is dropped", () => {
+    enqueuePendingNotification({
+      value: "<task-notification/>",
+      mode: "task-notification",
+    });
+    enqueue({ value: "system-meta", mode: "prompt", isMeta: true });
+
+    // No droppable user input → no-op, queue untouched.
+    expect(removeLastQueuedInput()).toBeUndefined();
+    expect(getCommandQueue()).toHaveLength(2);
+  });
+
+  test("returns undefined and mutates nothing when the queue is empty", () => {
+    expect(removeLastQueuedInput()).toBeUndefined();
     expect(getCommandQueue()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Iteration 20 — TUI visual/UX convergence loop

The last green-lit UX improvement in this loop: **per-item queue control.** Messages submitted during a running turn are queued and dispatched when the turn settles. They were *visible* (the "N inputs queued for next turn" banner) but the user couldn't remove a specific one — a mis-queued message had to run or required interrupting the whole turn.

**Implemented — "drop last queued input":**
- `ctrl+x backspace` removes the most recently queued user input (prompt/bash) before it dispatches, through the **same** module-level `commandQueue` the `App.tsx` drain reads — so a dropped item truly never sends.
- The `ctrl+x` chord prefix matches the existing `ctrl+x ctrl+k` (killAgents) convention and leaves bare backspace as the composer's readline delete (avoids the `ctrl+k` kill-to-EOL collision).
- The queued-commands banner gains a discoverable hint (`· <key> to drop last`, via `getShortcutDisplay` so it honors rebinds, matching the existing `dimColor` style).
- Targets only the user inputs the banner counts — never system notifications or raw-XML meta commands. Silent no-op when nothing is queued (with a "Removed last queued input" notification on success).

**Dispatch-boundary race:** the drain synchronously dequeues (splices) a command out of `commandQueue` before running it; `removeLastQueuedInput` splices the same array synchronously. In single-threaded JS the dispatching command is, at the instant of removal, either still queued (removed → the drain's later peek never finds it) or already spliced out (our splice no-ops) — never both, never double-sent. Both orderings are tested.

**Deferred (documented in code):** arbitrary item-N removal via a numbered focus mode (a large, race-prone modal competing with composer/scroll focus) and per-item edit (the all-items `popAllEditable` via ESC/UP already covers editing). Drop-last is the highest-value, lowest-risk single-item control.

**Tests:** 8 store tests (remove last; count; drop-twice reaches the middle; removed item never dispatches; both dispatch-boundary orderings; ignores notifications/meta; empty no-op) + 2 render tests (hint shows with a queue, absent without). Revert-sensitivity proven — reverting the store mutation + banner hint turns **5 tests red**.

**Gate:** `npm run build` exit 0 · full `npm run test:unit` **13297 passed, 10 skipped, 0 failures** · TUI runtime startup smoke clean (`agenc` + `agenc --yolo` at 148×40 / 120×30 / 80×24). No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG