### PR TITLE
fix(tui): empty-tree label truncation regression + markdown wrap jitter + YOU-highlight ragged edge

### DIFF
--- a/runtime/src/tui/components/markdown/Markdown.tsx
+++ b/runtime/src/tui/components/markdown/Markdown.tsx
@@ -132,6 +132,7 @@ function MarkdownBody(t0: Props & { highlight: CliHighlight | null }): React.Rea
   const AnsiComponent = Ansi as React.ComponentType<{
     children: string;
     dimColor?: boolean;
+    wrap?: string;
   }>;
   configureMarked();
   let elements;
@@ -141,7 +142,13 @@ function MarkdownBody(t0: Props & { highlight: CliHighlight | null }): React.Rea
     let nonTableContent = "";
     const flushNonTableContent = function flushNonTableContent() {
       if (nonTableContent) {
-        elements.push(<AnsiComponent key={elements.length} dimColor={dimColor}>{nonTableContent.trim()}</AnsiComponent>);
+        // wrap="wrap-trim" trims the leftover inter-word space at each soft-wrap
+        // boundary so wrapped continuation rows of a bullet/paragraph share the
+        // same left edge (no one-column jitter between sibling list items). This
+        // is scoped to the markdown body (non-table assistant/user text) — code
+        // blocks render via <HighlightedCode>'s own <Ansi> without this prop, so
+        // their significant leading whitespace is preserved.
+        elements.push(<AnsiComponent key={elements.length} dimColor={dimColor} wrap="wrap-trim">{nonTableContent.trim()}</AnsiComponent>);
         nonTableContent = "";
       }
     };

--- a/runtime/src/tui/ink/Ansi.tsx
+++ b/runtime/src/tui/ink/Ansi.tsx
@@ -10,6 +10,15 @@ type Props = {
   children: string;
   /** When true, force all text to be rendered with dim styling */
   dimColor?: boolean;
+  /**
+   * Text-wrap mode forwarded to the underlying <Text>. Defaults to <Text>'s
+   * own default ("wrap"), which preserves the leftover inter-word space at a
+   * soft-wrap boundary as a leading space on the continuation line. Markdown
+   * body text passes "wrap-trim" so wrapped continuation rows share the same
+   * left edge (no one-column jitter between sibling bullets). Left undefined
+   * for code/ANSI content where a leading space is significant.
+   */
+  wrap?: import('./styles.js').Styles['textWrap'];
 };
 type SpanProps = {
   color?: Color;
@@ -31,83 +40,32 @@ type SpanProps = {
  *
  * Memoized to prevent re-renders when parent changes but children string is the same.
  */
-export const Ansi = React.memo(function Ansi(t0: Props) {
-  const $ = _c(12);
-  const {
-    children,
-    dimColor
-  } = t0;
+export const Ansi = React.memo(function Ansi({ children, dimColor, wrap }: Props) {
   if (typeof children !== "string") {
-    let t1;
-    if ($[0] !== children || $[1] !== dimColor) {
-      t1 = dimColor ? <Text dim={true}>{String(children)}</Text> : <Text>{String(children)}</Text>;
-      $[0] = children;
-      $[1] = dimColor;
-      $[2] = t1;
-    } else {
-      t1 = $[2];
-    }
-    return t1;
+    return dimColor ? <Text dim={true} wrap={wrap}>{String(children)}</Text> : <Text wrap={wrap}>{String(children)}</Text>;
   }
   if (children === "") {
     return null;
   }
-  let t1;
-  let t2;
-  if ($[3] !== children || $[4] !== dimColor) {
-    t2 = Symbol.for("react.early_return_sentinel");
-    bb0: {
-      const spans = parseToSpans(children);
-      if (spans.length === 0) {
-        t2 = null;
-        break bb0;
-      }
-      if (spans.length === 1 && !hasAnyProps(spans[0].props)) {
-        t2 = dimColor ? <Text dim={true}>{spans[0].text}</Text> : <Text>{spans[0].text}</Text>;
-        break bb0;
-      }
-      let t3;
-      if ($[7] !== dimColor) {
-        t3 = (span: Span, i: number) => {
-          const hyperlink = span.props.hyperlink;
-          if (dimColor) {
-            span.props.dim = true;
-          }
-          const hasTextProps = hasAnyTextProps(span.props);
-          if (hyperlink) {
-            return hasTextProps ? <Link key={i} url={hyperlink}><StyledText color={span.props.color} backgroundColor={span.props.backgroundColor} dim={span.props.dim} bold={span.props.bold} italic={span.props.italic} underline={span.props.underline} strikethrough={span.props.strikethrough} inverse={span.props.inverse}>{span.text}</StyledText></Link> : <Link key={i} url={hyperlink}>{span.text}</Link>;
-          }
-          return hasTextProps ? <StyledText key={i} color={span.props.color} backgroundColor={span.props.backgroundColor} dim={span.props.dim} bold={span.props.bold} italic={span.props.italic} underline={span.props.underline} strikethrough={span.props.strikethrough} inverse={span.props.inverse}>{span.text}</StyledText> : span.text;
-        };
-        $[7] = dimColor;
-        $[8] = t3;
-      } else {
-        t3 = $[8];
-      }
-      t1 = spans.map(t3);
+  const spans = parseToSpans(children);
+  if (spans.length === 0) {
+    return null;
+  }
+  if (spans.length === 1 && !hasAnyProps(spans[0].props)) {
+    return dimColor ? <Text dim={true} wrap={wrap}>{spans[0].text}</Text> : <Text wrap={wrap}>{spans[0].text}</Text>;
+  }
+  const content = spans.map((span: Span, i: number) => {
+    const hyperlink = span.props.hyperlink;
+    if (dimColor) {
+      span.props.dim = true;
     }
-    $[3] = children;
-    $[4] = dimColor;
-    $[5] = t1;
-    $[6] = t2;
-  } else {
-    t1 = $[5];
-    t2 = $[6];
-  }
-  if (t2 !== Symbol.for("react.early_return_sentinel")) {
-    return t2;
-  }
-  const content = t1;
-  let t3;
-  if ($[9] !== content || $[10] !== dimColor) {
-    t3 = dimColor ? <Text dim={true}>{content}</Text> : <Text>{content}</Text>;
-    $[9] = content;
-    $[10] = dimColor;
-    $[11] = t3;
-  } else {
-    t3 = $[11];
-  }
-  return t3;
+    const hasTextProps = hasAnyTextProps(span.props);
+    if (hyperlink) {
+      return hasTextProps ? <Link key={i} url={hyperlink}><StyledText color={span.props.color} backgroundColor={span.props.backgroundColor} dim={span.props.dim} bold={span.props.bold} italic={span.props.italic} underline={span.props.underline} strikethrough={span.props.strikethrough} inverse={span.props.inverse}>{span.text}</StyledText></Link> : <Link key={i} url={hyperlink}>{span.text}</Link>;
+    }
+    return hasTextProps ? <StyledText key={i} color={span.props.color} backgroundColor={span.props.backgroundColor} dim={span.props.dim} bold={span.props.bold} italic={span.props.italic} underline={span.props.underline} strikethrough={span.props.strikethrough} inverse={span.props.inverse}>{span.text}</StyledText> : span.text;
+  });
+  return dimColor ? <Text dim={true} wrap={wrap}>{content}</Text> : <Text wrap={wrap}>{content}</Text>;
 });
 type Span = {
   text: string;

--- a/runtime/src/tui/message-renderers/UserPromptMessage.tsx
+++ b/runtime/src/tui/message-renderers/UserPromptMessage.tsx
@@ -99,7 +99,13 @@ export function UserPromptMessage({
     logError(new Error('No content found in user prompt message'));
     return null;
   }
-  return <Box flexDirection="column" marginTop={addMargin ? 1 : 0} backgroundColor={isSelected ? 'messageActionsBackground' : useBriefLayout ? undefined : 'userMessageBackground'} paddingRight={useBriefLayout ? 0 : 1}>
+  // width="100%" mirrors SystemTextMessage/AssistantTextMessage: without it a
+  // full-width word-wrap row renders at the viewport edge with no trailing
+  // background padding while sibling highlighted rows stop one column short, so
+  // the bg reset spills onto the next line's column 0 and the highlight box gets
+  // a ragged right edge. Pinning the width makes every wrapped row pad/clip to
+  // the same right edge and the highlight forms a clean rectangle.
+  return <Box flexDirection="column" width="100%" marginTop={addMargin ? 1 : 0} backgroundColor={isSelected ? 'messageActionsBackground' : useBriefLayout ? undefined : 'userMessageBackground'} paddingRight={useBriefLayout ? 0 : 1}>
       {useBriefLayout ? <HighlightedThinkingText text={displayText} useBriefLayout timestamp={timestamp} /> : <Msg role="user" label="you" time={displayTime}><HighlightedThinkingText text={displayText} showPointer={false} /></Msg>}
     </Box>;
 }

--- a/runtime/src/tui/workbench/project-tree/buildTree.ts
+++ b/runtime/src/tui/workbench/project-tree/buildTree.ts
@@ -187,9 +187,12 @@ function emptyRows(options: BuildProjectTreeOptions): ProjectTreeRow[] {
     // An empty workspace on cold start is a NORMAL state, not a fault: use the
     // neutral "empty" kind so its marker is a space rather than the "!" the tree
     // reserves for genuine errors (which would make a fresh project look broken).
-    // The copy stays inviting to match the welcome-screen tone.
+    // The label is kept short so it fits the narrow tree column (~17-22 cols,
+    // truncate-end) without chopping mid-word — the inviting "describe a task to
+    // get started" guidance already lives on the cold-start welcome card and the
+    // composer placeholder, so nothing is lost by keeping the tree label terse.
     path: "",
-    label: options.gitStatus ? "No files yet — describe a task to get started" : "Loading files",
+    label: options.gitStatus ? "No files yet" : "Loading files",
     kind: options.gitStatus ? "empty" : "loading",
     depth: 1,
     expanded: false,

--- a/runtime/tests/tui/components/markdown/markdown-rendering.test.tsx
+++ b/runtime/tests/tui/components/markdown/markdown-rendering.test.tsx
@@ -229,4 +229,44 @@ describe('markdown rendering components', () => {
     expect(output).toContain('  const value = 1')
     expect(output).not.toContain('\\tconst value = 1')
   })
+
+  test('wraps assistant bullet continuations to a uniform left edge (no stray leading space)', async () => {
+    // BUG B regression: when an assistant markdown bullet soft-wraps at a space
+    // boundary, the leftover inter-word space used to survive as a leading space
+    // on the continuation line — so sibling continuations in the same list
+    // started at different columns (a one-column jitter, e.g. "the page." at
+    // lead 0 vs " fonts." at lead 1). The markdown body now wraps with
+    // "wrap-trim", which strips that boundary whitespace so every continuation
+    // row shares the same left edge.
+    const width = 24
+    const output = await renderToString(
+      <Box width={width}>
+        <Markdown>
+          {[
+            '- Centered heading that is large and clearly centered on the page.',
+            '- Clean layout with plenty of whitespace and system fonts.',
+          ].join('\n')}
+        </Markdown>
+      </Box>,
+      width,
+    )
+
+    const lines = output.split('\n').filter((line) => line.trim().length > 0)
+    // Sanity: the content actually wrapped (more rows than the 2 source bullets).
+    expect(lines.length).toBeGreaterThan(2)
+
+    const leadingSpaces = (line: string): number =>
+      line.length - line.replace(/^ +/u, '').length
+
+    // The two bullet markers ("- ") sit flush-left (lead 0). Every other row is
+    // a soft-wrap continuation and must ALSO start at column 0 — no stray leading
+    // space. Revert-sensitivity: without "wrap-trim" the final continuation
+    // ("system fonts.") keeps the boundary space and renders at lead 1, so the
+    // uniform-edge assertion below fails.
+    const leads = lines.map(leadingSpaces)
+    expect(leads.every((lead) => lead === 0)).toBe(true)
+    // And the specific measured jitter case is gone: no continuation begins with
+    // a space.
+    expect(lines.some((line) => /^ /u.test(line))).toBe(false)
+  })
 })

--- a/runtime/tests/tui/components/visual-contract.test.ts
+++ b/runtime/tests/tui/components/visual-contract.test.ts
@@ -101,6 +101,53 @@ describe("TUI visual contract", () => {
     ).toEqual([]);
   });
 
+  it("pins the highlighted YOU message box to full width like its sibling renderers", () => {
+    // BUG C regression: the YOU prompt highlight Box sets backgroundColor +
+    // paddingRight but, UNLIKE SystemTextMessage/AssistantTextMessage, used to
+    // omit width="100%". When a body/queued line word-wraps at exactly the
+    // content-width boundary, that full-width wrap row rendered one column wider
+    // than its siblings with no trailing bg pad, so the bg reset spilled onto the
+    // next line's column 0 and the purple highlight rectangle got a ragged right
+    // edge. Pinning width="100%" makes every wrapped row pad/clip to the same
+    // right edge. This invariant asserts the user box mirrors its siblings.
+    const messageRenderers = join(tuiRoot, "message-renderers");
+    const userSource = readFileSync(
+      join(messageRenderers, "UserPromptMessage.tsx"),
+      "utf8",
+    );
+
+    // The single Box that paints the user-message highlight (it is the only line
+    // carrying both the userMessageBackground token and paddingRight).
+    const highlightBoxLine = userSource
+      .split("\n")
+      .find(
+        (line) =>
+          line.includes("userMessageBackground") && line.includes("paddingRight"),
+      );
+
+    expect(highlightBoxLine).toBeDefined();
+    // Revert-sensitivity: removing width="100%" from that Box drops this match
+    // and fails the assertion. The sibling renderers below confirm the pattern
+    // this mirrors.
+    expect(highlightBoxLine).toContain('width="100%"');
+
+    // Sibling renderers pair backgroundColor with width="100%" on their text
+    // boxes; assert the pattern the user box is mirroring actually exists so this
+    // invariant cannot silently drift if the siblings change.
+    const assistantSource = readFileSync(
+      join(messageRenderers, "AssistantTextMessage.tsx"),
+      "utf8",
+    );
+    const systemSource = readFileSync(
+      join(messageRenderers, "SystemTextMessage.tsx"),
+      "utf8",
+    );
+    // AssistantTextMessage's default markdown box: backgroundColor + width="100%".
+    expect(assistantSource).toMatch(/width="100%"[^\n]*backgroundColor/u);
+    // SystemTextMessage's text boxes: backgroundColor + width="100%".
+    expect(systemSource).toMatch(/backgroundColor=\{bg\}[^\n]*width="100%"/u);
+  });
+
   it("keeps old message and permissions component trees empty", () => {
     const permissionsRoot = join(componentsRoot, "permissions");
     const messagesRoot = join(componentsRoot, "messages");

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -103,11 +103,40 @@ describe("project tree helpers", () => {
     const emptyRow = rows.find((row) => row.id === "loading-empty");
     expect(emptyRow).toMatchObject({
       kind: "empty",
-      label: "No files yet — describe a task to get started",
+      // Short, column-fitting label. The narrow tree column (truncate-end at
+      // ~17-22 cols, depth:1 4-space indent) would chop the old long copy mid-
+      // word ("No files yet — de…"); the inviting "describe a task" guidance
+      // lives on the welcome card and composer placeholder instead.
+      label: "No files yet",
     });
     // Revert-sensitive: restoring kind:"error" / "No project files" fails these.
     expect(emptyRow?.kind).not.toBe("error");
     expect(rows.some((row) => row.kind === "error")).toBe(false);
+  });
+
+  it("uses a short empty-state label that fits the narrow tree column without truncating", () => {
+    // BUG A regression: the empty-state row sits at depth:1 (4-space indent) in
+    // the narrow workspace column, which truncates to ~13-18 chars. The label
+    // must be short enough to render whole — never chopped to a dangling em-dash
+    // + half-word ("No files yet — de…"). Assert the exact short label.
+    const rows = buildProjectTreeRows({
+      cwd: "/repo",
+      paths: [],
+      expandedPaths: new Set(),
+      cursorPath: null,
+      activePath: null,
+      gitStatus: new Map(),
+    });
+
+    const emptyRow = rows.find((row) => row.id === "loading-empty");
+    expect(emptyRow?.label).toBe("No files yet");
+    // Revert-sensitivity: the long string "No files yet — describe a task to get
+    // started" is 47 cols and fails this exact-match assertion. The new label is
+    // 12 cols, well under the row's render budget (depth:1 indent + truncate at
+    // ~17-22 cols), so it never produces the ellipsis glyph from the long copy.
+    expect(emptyRow?.label.length).toBeLessThanOrEqual(13);
+    expect(emptyRow?.label).not.toContain("…");
+    expect(emptyRow?.label).not.toContain("—");
   });
 
   it("parses git porcelain status", () => {
@@ -318,7 +347,7 @@ describe("project tree helpers", () => {
       expect(snapshot.error).toEqual(expect.stringContaining("ENOTDIR"));
       expect(snapshot.rows.find((row) => row.kind === "error")).toBeUndefined();
       expect(snapshot.rows.find((row) => row.kind === "empty")).toMatchObject({
-        label: "No files yet — describe a task to get started",
+        label: "No files yet",
       });
     } finally {
       store.dispose();

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -175,7 +175,7 @@ describe("workbench render contract", () => {
       <ProjectExplorerRow
         width={48}
         row={{
-          ...row("", "No files yet — describe a task to get started", "file", 1),
+          ...row("", "No files yet", "file", 1),
           id: "loading-empty",
           kind: "empty" as never,
         }}
@@ -186,6 +186,36 @@ describe("workbench render contract", () => {
     expect(output).toContain("No files yet");
     // The label intentionally contains no "!" so any "!" must be the marker.
     expect(output).not.toContain("!");
+  });
+
+  it("renders the empty-workspace label whole in the narrow column (no mid-word truncation)", async () => {
+    // BUG A regression: in production the empty row renders at depth:1 (4-space
+    // indent) in the narrow WORKSPACE column (ProjectExplorer passes width-3,
+    // ~17-22 cols, truncate-end). The old long copy "No files yet — describe a
+    // task to get started" chopped to "No files yet — de…" — a dangling em-dash
+    // + half-word that reads as a glitch. The short label must render whole with
+    // NO trailing ellipsis at a realistic column width.
+    const output = await renderToString(
+      <ProjectExplorerRow
+        width={20}
+        row={{
+          ...row("", "No files yet", "file", 1),
+          id: "loading-empty",
+          kind: "empty" as never,
+        }}
+      />,
+      20,
+    );
+
+    // Full label present, intact.
+    expect(output).toContain("No files yet");
+    // No ellipsis glyph (unicode "…" or ASCII "...") — the label was not chopped.
+    // Revert-sensitivity: the old 47-col label overflows width=20 and trim()
+    // appends the ellipsis, so both assertions fail against the long string.
+    expect(output).not.toContain("…");
+    expect(output).not.toContain("...");
+    // And no severed em-dash tail from the old copy.
+    expect(output).not.toContain("—");
   });
 
   it("renders loading rows, active rows, and one-column label trims", async () => {


### PR DESCRIPTION
## Iteration 22 — TUI visual/UX convergence loop

Disciplined discovery over real captured frames (clean settled turn + queue-under-load), excluding 21 shipped fixes **and** all slow-model artifacts, surfaced 3 distinct real render defects — including a regression from an earlier iteration.

### A) Empty-workspace tree label truncated mid-word — HIGH (regression)
The cold-start empty-state label `No files yet — describe a task to get started` is far wider than the ~17–22 col workspace tree column (truncate-end, depth:1 indent), so it always chopped to a dangling `No files yet — de…` — the invite lost, the fragment reading as a glitch. Shortened the tree label to the column-fitting `No files yet`; the inviting copy already lives on the welcome card + composer placeholder, so nothing is lost.

### B) Markdown bullet soft-wrap continuation jitter — MEDIUM
A stray break-point space survived on some wrapped continuation lines, so sibling bullet continuations jittered by one column. The markdown body is a flat ANSI string wrapped downstream by `<Ansi>` → `<Text>` (default `'wrap'` keeps the space). Added an optional `wrap` prop to `<Ansi>` (defaults `undefined` → **byte-identical for every existing caller**) and pass the existing first-class `wrap-trim` mode (`wrap-text.ts` → `wrapAnsi({ trim:true })`) **only** from the markdown body. Scoped to non-table assistant/user text — code blocks render via `<HighlightedCode>`'s own `<Ansi>` without the prop, preserving significant whitespace. (`Ansi.tsx`'s committed React-compiler `_c()` form was de-compiled to equivalent plain JSX to thread the prop; `React.memo` retained, control flow unchanged, no compiler-form enforcement check exists.)

### C) YOU/queued highlight box ragged right edge — MEDIUM
The user-message purple highlight box set `backgroundColor`+`paddingRight` but, unlike its `SystemTextMessage`/`AssistantTextMessage` siblings, had no explicit width — so a body line wrapping at exactly inner width rendered at the full viewport edge with no trailing bg padding while siblings stopped one column short, spilling the bg reset onto the next line. Added `width="100%"` to mirror the siblings.

### Gate
`npm run build` exit 0 · full `npm run test:unit` **13303 passed, 10 skipped, 0 failures** · TUI runtime startup smoke clean. Each fix revert-sensitive (A: exact-label + narrow-width no-ellipsis render tests; B: space-boundary bullet-wrap uniform-left-edge test; C: source-structure invariant — the pixel symptom only surfaces in the full Yoga layout, not the isolated render harness). No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG