### PR TITLE
fix(tui): de-duplicate esc-to-interrupt + unify running-indicator purple

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx
@@ -133,12 +133,17 @@ function PromptInputQueuedCommandsImpl(): React.ReactNode {
       {queuedInputCount > 0 && <Box marginLeft={2} marginBottom={1}>
           <Text dimColor>
             {queuedInputCount === 1 ? '1 input queued for next turn' : `${queuedInputCount} inputs queued for next turn`}
-            {' · esc to interrupt'}
+            {/* The "esc to interrupt" affordance is NOT repeated here: a queue
+                can only exist while a turn is loading (inputs are enqueued only
+                when isLoading — see applyBusyInputSubmissionPolicy), and the
+                footer spinner hint always renders the canonical
+                "esc → interrupt" while loading (getSpinnerHintParts). Painting
+                it again on this banner doubled the same hint on screen. */}
             {/* Lowercase the rendered keycap so this inline hint reads in the
-                same lowercase style as the adjacent "esc to interrupt" (and the
-                footer's chat:cancel hint, which .toLowerCase()s its shortcut
-                too). getShortcutDisplay capitalizes named keys ("Backspace"),
-                which would otherwise mix casing within this one line. */}
+                same lowercase style as the footer's chat:cancel hint (which
+                .toLowerCase()s its shortcut too). getShortcutDisplay
+                capitalizes named keys ("Backspace"), which would otherwise mix
+                casing within this one line. */}
             {` · ${getShortcutDisplay('chat:dropQueuedInput', 'Chat', 'ctrl+x backspace').toLowerCase()} to drop last`}
           </Text>
         </Box>}

--- a/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
+++ b/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
@@ -55,7 +55,16 @@ export function WorkbenchActivityIndicator({
   return (
     <Box flexShrink={0} flexDirection="row">
       <Text dimColor wrap="truncate-end">{separator}</Text>
-      <Text color="agenc">{glyph}</Text>
+      {/*
+        Use the SAME color token as the composer body spinner's status glyph
+        (SpinnerAnimationRow renders its glyph in `messageColor`, which defaults
+        to "suggestion"). Both indicators describe the same in-flight turn, so a
+        clashing second purple here read as two unrelated activity signals. This
+        only unifies the COLOR — the title bar keeps its animated brand glyph
+        family while the body keeps its own glyph, so the comment no longer
+        claims a glyph match that isn't made.
+      */}
+      <Text color="suggestion">{glyph}</Text>
       {/*
         Title-case the verb so the status bar reads "✻ Working…" — matching the
         composer body spinner (which uses titleVerbForMode) for the same turn,

--- a/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputQueuedCommands.test.tsx
@@ -101,17 +101,22 @@ describe('PromptInputQueuedCommands', () => {
     expect(output).toContain('Use another library')
   })
 
-  it('describes the Esc action with the same wording as the footer hint', async () => {
+  it('does NOT repeat the "esc to interrupt" hint on the queued banner', async () => {
     const { PromptInputQueuedCommands } = await import('./PromptInputQueuedCommands.js')
 
     const output = await renderToString(<PromptInputQueuedCommands />, 100)
 
-    // The queued-commands banner and the footer/spinner Esc hint must use ONE
-    // consistent phrasing so the same Esc action is not described two different
-    // ways on screen at once. Canonical wording is the footer's "esc to
-    // interrupt" (KeyboardShortcutHint shortcut="esc" action="interrupt").
-    expect(output).toContain('esc to interrupt')
-    expect(output).not.toContain('esc interrupts the current turn')
+    // A queue can only exist while a turn is loading (inputs are enqueued only
+    // when isLoading — applyBusyInputSubmissionPolicy returns false otherwise),
+    // and the footer spinner hint ALWAYS renders the canonical "esc → interrupt"
+    // while loading (getSpinnerHintParts). Painting it again on this banner
+    // doubled the same affordance on screen. The banner must NOT carry its own
+    // interrupt hint; the count and the "drop last" control stay.
+    // Revert-sensitive: the old banner appended " · esc to interrupt", so this
+    // assertion fails if that segment is restored.
+    expect(output).not.toContain('esc to interrupt')
+    expect(output).not.toContain('interrupt')
+    expect(output).toContain('1 input queued for next turn')
   })
 
   it('shows a discoverable per-item drop hint alongside the queued-input banner', async () => {

--- a/runtime/tests/tui/workbench/activity-and-diff.test.tsx
+++ b/runtime/tests/tui/workbench/activity-and-diff.test.tsx
@@ -7,7 +7,11 @@ import { WorkbenchActivityIndicator } from "../../../src/tui/workbench/Workbench
 import { WorkbenchStatusBar } from "../../../src/tui/workbench/WorkbenchStatusBar.js";
 import { DiffInline } from "../../../src/tui/components/v2/primitives.js";
 import { buildEditDiffPreview } from "../../../src/tui/edit-diff-preview.js";
-import { renderToString } from "../../../src/utils/staticRender.js";
+import { renderToAnsiString, renderToString } from "../../../src/utils/staticRender.js";
+import {
+  SpinnerAnimationRow,
+  type SpinnerAnimationRowProps,
+} from "../../../src/tui/components/spinner/SpinnerAnimationRow.js";
 import {
   getReducedMotionDot,
   titleVerbForMode,
@@ -129,6 +133,91 @@ describe("title bar / status line phase agreement", () => {
       // casing for the same turn.
       expect(out).toContain(titleVerbForMode(mode));
     }
+  });
+});
+
+// The title-bar activity indicator and the composer body status glyph both
+// describe the SAME in-flight turn. They must not animate in two different
+// purples at once, which read as two unrelated activity signals. The title bar
+// renders its glyph in the same color token the body spinner uses for its
+// status glyph (SpinnerAnimationRow's `messageColor`, whose production default
+// is "suggestion"). This test pins the on-screen colors so they can't silently
+// diverge again.
+describe("title bar / body spinner glyph color agreement", () => {
+  // Pull the SGR color escape that immediately precedes `glyph` in the rendered
+  // ANSI string. Returns the raw escape (e.g. "[38;2;178;95;255m").
+  function colorBefore(ansi: string, glyph: string): string | null {
+    const idx = ansi.indexOf(glyph);
+    if (idx < 0) return null;
+    const before = ansi.slice(0, idx);
+    const matches = before.match(/\[[0-9;]*m/g);
+    return matches && matches.length > 0 ? matches[matches.length - 1] : null;
+  }
+
+  function bodyProps(
+    overrides: Partial<SpinnerAnimationRowProps> = {},
+  ): SpinnerAnimationRowProps {
+    const now = Date.now();
+    return {
+      columns: 100,
+      effortSuffix: "",
+      foregroundedTeammate: undefined,
+      // hasActiveTools forces the static "◐" status glyph (statusGlyph()).
+      hasActiveTools: true,
+      hasRunningTeammates: false,
+      leaderIsIdle: false,
+      loadingStartTimeRef: { current: now - 1000 },
+      message: "Working",
+      // Production default messageColor (see Spinner.tsx: messageColor =
+      // overrideColor ?? "suggestion"). The body glyph is painted in this token.
+      messageColor: "suggestion",
+      mode: "tool-use",
+      overrideColor: null,
+      pauseStartTimeRef: { current: null },
+      reducedMotion: false,
+      responseLengthRef: { current: 0 },
+      shimmerColor: "agencShimmer",
+      spinnerSuffix: null,
+      teammateTokens: 0,
+      thinkingStatus: null,
+      totalPausedMsRef: { current: 0 },
+      verbose: false,
+      ...overrides,
+    };
+  }
+
+  it("paints the title-bar glyph in the SAME color as the body status glyph", async () => {
+    // Reduced motion pins the title-bar glyph to a single deterministic frame so
+    // the color (not the glyph) is what's asserted.
+    const state = getDefaultAppState();
+    const reduced = {
+      ...state,
+      settings: { ...state.settings, prefersReducedMotion: true },
+    };
+    const titleAnsi = await renderToAnsiString(
+      <AppStateProvider initialState={reduced as never}>
+        <WorkbenchActivityIndicator mode="requesting" />
+      </AppStateProvider>,
+      { columns: 80, color: true },
+    );
+    const bodyAnsi = await renderToAnsiString(
+      withState(<SpinnerAnimationRow {...bodyProps()} />),
+      { columns: 100, color: true },
+    );
+
+    const titleColor = colorBefore(titleAnsi, getReducedMotionDot());
+    const bodyColor = colorBefore(bodyAnsi, "◐");
+
+    expect(titleColor).not.toBeNull();
+    expect(bodyColor).not.toBeNull();
+    // Both glyphs must use the identical SGR color escape. Revert-sensitive:
+    // before unification the title bar used color="agenc" (a different purple
+    // than the body's "suggestion"), so this equality fails on the old code.
+    expect(titleColor).toBe(bodyColor);
+    // Belt-and-suspenders: in the default theme "suggestion" is rgb(178,95,255).
+    // Reverting the title bar to "agenc" (rgb(206,92,255)) changes this escape.
+    expect(titleColor).toContain("178;95;255");
+    expect(titleColor).not.toContain("206;92;255");
   });
 });
 


### PR DESCRIPTION
## Iteration 23 — TUI visual/UX convergence loop (first clean-capture round)

The fast-model swap finally produced a fully-clean multi-turn capture; discovery over it found 3 real bugs. This PR ships 2; the 3rd was correctly **not** shipped (see below).

### Bug 2 (MEDIUM) — `esc to interrupt` painted twice when the queue is non-empty
The queued-input banner appended `· esc to interrupt` unconditionally, while the footer spinner hint already renders the canonical `esc → interrupt` whenever a turn is loading. A queue can only exist while loading (`applyBusyInputSubmissionPolicy` enqueues only when `isLoading`), so the two always co-occurred. Removed the banner copy only — count + `· ctrl+x backspace to drop last` stay — leaving exactly one interrupt hint, never zero.

### Bug 3 (LOW) — clashing purples on the running indicator
Title-bar activity glyph rendered in `agenc` (rgb 206,92,255); composer body status glyph `◐` uses `suggestion` (rgb 178,95,255) — two purples for the same in-flight turn. Unified the title glyph to `suggestion` (the body color it already claimed to match). Color only; glyphs intentionally stay distinct; misleading comment corrected.

Both revert-sensitive. Build exit 0 · full `npm run test:unit` **13304 passed, 0 failures** · TUI startup smoke clean.

### Bug 1 (HIGH) — deferred, not speculatively patched
A diff body line ellipsized when it fits *exactly*, but only in certain scroll states (`A1` elides `…1.0` ; `A6` scrollback shows it flush `…1.0">`). Investigation found the hypothesized `>`/`>=` off-by-one **does not exist** — the `truncate()` boundary is already strict-correct. The real cause is a scroll-dependent width-clamp interaction under `ScrollBox` (`render-node-to-output.ts` `Math.min(getMaxWidth, output.width - x)` landing 1 short when the card's top border is scrolled off). Deferred to a focused follow-up with a proper scroll repro harness rather than shipping a guess.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG