### PR TITLE
fix(tui): queued-preview wrap width + Linux spinner star flicker + welcome-card path wrap

### DIFF
--- a/runtime/src/tui/components/spinner/utils.ts
+++ b/runtime/src/tui/components/spinner/utils.ts
@@ -59,7 +59,12 @@ export function getDefaultCharacters(
   }
   return process.platform === 'darwin'
     ? [...glyphs.spinnerFrames]
-    : ['·', '✢', '*', '✶', '✻', '✽']
+    : // Mirror the macOS flower-star frame family (glyphs.spinnerFrames). The
+      // index-2 frame is `✳`, NOT a bare ASCII `*`: the asterisk renders as a
+      // thin glyph between the fat unicode stars and visibly flickers each
+      // animation cycle. (The Ghostty branch above keeps a `*` deliberately,
+      // with a documented offset-rendering rationale.)
+      ['·', '✢', '✳', '✶', '✻', '✽']
 }
 
 export function getReducedMotionDot(

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -721,16 +721,26 @@ function WelcomeMetaRow({
   readonly value: string
 }): React.ReactNode {
   return (
-    <Box flexDirection="row" flexWrap="wrap">
+    // No `flexWrap="wrap"`: the value is `truncate-middle`, so it must shrink
+    // and truncate IN PLACE on the label's row rather than wrap onto a fresh
+    // flex line under the label (which breaks the 2-column label/value grid for
+    // any long absolute path — the common workspace case). `flexShrink`/
+    // `minWidth={0}` on the value cell lets Yoga squeeze it to the truncation
+    // width while the fixed 13-col label holds its column.
+    <Box flexDirection="row">
       {/* Labels use `inactive` (a readable secondary tone), not `muted3`. In the
           dark themes muted3 (rgb(64,64,70)) sits almost on top of the card's
           lineSoft border (rgb(34,35,39)), so the labels read as chrome rather
           than text. `inactive` is clearly brighter than the border while still
           ranking below the `text2` values. */}
-      <ThemedText color="inactive">{label.padEnd(13)}</ThemedText>
-      <ThemedText color="text2" wrap="truncate-middle">
-        {value}
-      </ThemedText>
+      <Box flexShrink={0}>
+        <ThemedText color="inactive">{label.padEnd(13)}</ThemedText>
+      </Box>
+      <Box flexShrink={1} minWidth={0}>
+        <ThemedText color="text2" wrap="truncate-middle">
+          {value}
+        </ThemedText>
+      </Box>
     </Box>
   )
 }
@@ -794,12 +804,24 @@ export function WelcomeColdPanel({
           paddingY={1}
         >
           {visibleSessions.length > 0 ? visibleSessions.map(session => (
-            <Box key={session.keyName} flexDirection="row" flexWrap="wrap">
-              <ThemedText color="muted3">[</ThemedText>
-              <ThemedText color="agenc">{session.keyName}</ThemedText>
-              <ThemedText color="muted3">] </ThemedText>
-              <ThemedText color="text2">{session.title}</ThemedText>
-              <ThemedText color="muted3"> · {session.detail}</ThemedText>
+            // No `flexWrap="wrap"`: a long title/detail must truncate in place
+            // rather than wrap the `· detail` segment onto its own flex line
+            // under the `[n]` key (the same grid-breaking pattern as
+            // WelcomeMetaRow). The flexing cell holds title + detail and
+            // truncate-ends them together; the `[n] ` key prefix stays fixed.
+            <Box key={session.keyName} flexDirection="row">
+              {/* The `[n] ` key prefix is fixed and must not be squeezed when the
+                  flexing title/detail cell shrinks (without flexShrink={0} Yoga
+                  eats the `[` bracket under pressure). */}
+              <Box flexShrink={0} flexDirection="row">
+                <ThemedText color="muted3">[</ThemedText>
+                <ThemedText color="agenc">{session.keyName}</ThemedText>
+                <ThemedText color="muted3">] </ThemedText>
+              </Box>
+              <Box flexShrink={1} minWidth={0} flexDirection="row">
+                <ThemedText color="text2" wrap="truncate-end">{session.title}</ThemedText>
+                <ThemedText color="muted3" wrap="truncate-end"> · {session.detail}</ThemedText>
+              </Box>
             </Box>
           )) : (
             <ThemedText color="muted3">no resumable sessions</ThemedText>
@@ -885,14 +907,23 @@ export function Msg({
     system: 'subtle',
   }
   const inheritedWidth = useContentWidth()
-  // The marker glyph (1 cell) + the single-space row gap below = a 2-cell inset
-  // for the content column; keep the inset in sync with the gap so wrapped body
-  // text measures against the right width.
-  const contentWidth = insetContentWidth(inheritedWidth, 2)
   // Queued previews carry no real per-item enqueue time, so they pass no
   // `time` (see PromptInputQueuedCommands). Show a quiet neutral "queued"
   // marker in the header slot instead of a misleading render-time clock.
-  const isQueued = useQueuedMessage()?.isQueued ?? false
+  const queued = useQueuedMessage()
+  const isQueued = queued?.isQueued ?? false
+  // QUEUED items are additionally wrapped by QueuedMessageProvider in a
+  // `<Box paddingX={2}>` (4 cols of horizontal padding) that the inherited
+  // ContentWidth does NOT account for. Subtract that padding (the context's
+  // already-computed `paddingWidth`, 0 for the brief layout) so the wrapped
+  // body measures against the real available width and its first wrapped line
+  // can't overshoot the highlight box by a column. Non-queued messages are
+  // unaffected: `paddingWidth` defaults to 0.
+  const queuedPaddingWidth = isQueued ? queued?.paddingWidth ?? 0 : 0
+  // The marker glyph (1 cell) + the single-space row gap below = a 2-cell inset
+  // for the content column; keep the inset in sync with the gap so wrapped body
+  // text measures against the right width.
+  const contentWidth = insetContentWidth(inheritedWidth, 2 + queuedPaddingWidth)
   return (
     // A single space after the marker glyph (gap={1}); a double gap read as a
     // layout seam between the marker and the role label.

--- a/runtime/tests/tui/components/spinner/spinner-primitives.test.tsx
+++ b/runtime/tests/tui/components/spinner/spinner-primitives.test.tsx
@@ -50,6 +50,23 @@ describe('spinner primitives', () => {
     expect(getDefaultCharacters()).toEqual(['·', '✢', '✳', '✶', '✻', '*'])
   })
 
+  test('Linux/default spinner frames contain no bare ASCII "*" glyph', () => {
+    // Non-darwin, non-ghostty, unicode glyphs => the default Linux fallback.
+    // Force a generic unicode TERM so neither the ASCII nor the ghostty branch
+    // is taken; this test process is on Linux, so process.platform !== 'darwin'.
+    const env = { TERM: 'xterm-256color' }
+    const frames = getDefaultCharacters(env)
+
+    // The index-2 frame must be the flower-star `✳` (matching the macOS frame
+    // family glyphs.spinnerFrames), NOT a bare ASCII `*`. The asterisk renders
+    // as a thin glyph between the fat unicode stars and visibly flickers on
+    // every animation cycle.
+    expect(frames[2]).toBe('✳')
+    expect(frames).toEqual(['·', '✢', '✳', '✶', '✻', '✽'])
+    // No bare ASCII asterisk anywhere in the default unicode path.
+    expect(frames).not.toContain('*')
+  })
+
   test('uses ASCII spinner glyph primitives when ASCII glyphs are requested', () => {
     const env = { AGENC_TUI_GLYPHS: 'ascii' }
 

--- a/runtime/tests/tui/components/spinner/utils.wave200-128.coverage.test.ts
+++ b/runtime/tests/tui/components/spinner/utils.wave200-128.coverage.test.ts
@@ -31,10 +31,13 @@ function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
 
 describe('spinner utility coverage edges', () => {
   test('handles narrow layouts, unicode frame fallbacks, hue sectors, and cached RGB parsing', () => {
+    // The Linux/default unicode fallback now mirrors the macOS flower-star
+    // frame family: index 2 is `✳`, not a bare ASCII `*` (the `*` rendered as a
+    // thin glyph that flickered between the fat unicode stars each cycle).
     expect(withPlatform('linux', () => getDefaultCharacters({ TERM: 'xterm-256color' }))).toEqual([
       '·',
       '✢',
-      '*',
+      '✳',
       '✶',
       '✻',
       '✽',

--- a/runtime/tests/tui/v2-primitives-render.test.tsx
+++ b/runtime/tests/tui/v2-primitives-render.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { Msg, WelcomeColdPanel } from '../../src/tui/components/v2/primitives.js'
+import { Box, Text } from '../../src/tui/ink.js'
+import {
+  ContentWidthProvider,
+  useContentWidth,
+} from '../../src/tui/context/contentWidthContext.js'
+import { QueuedMessageProvider } from '../../src/tui/context/QueuedMessageContext.js'
+import { renderToString } from '../../src/utils/staticRender.js'
+
+// ---------------------------------------------------------------------------
+// BUG 1 — queued-message preview body wrap width.
+//
+// Queued previews render inside QueuedMessageProvider's `<Box paddingX={2}>`
+// (4 cols of horizontal padding). `Msg` propagates a ContentWidth to its body
+// for downstream consumers (markdown/system messages size an explicit-width
+// box from useContentWidth(), e.g. SystemTextMessage). Before the fix that
+// propagated width subtracted only the 2-col marker inset and ignored the
+// queued container padding, so the first wrapped body line could overshoot the
+// queued highlight box's interior by up to the padding width.
+//
+// `WidthProbe` mirrors a real downstream consumer: it reads useContentWidth()
+// and paints a solid block exactly that wide, so the propagated value is
+// directly observable as a row width.
+// ---------------------------------------------------------------------------
+
+function WidthProbe(): React.ReactNode {
+  const w = useContentWidth() ?? 0
+  return (
+    <Box width={w}>
+      <Text>{'#'.repeat(Math.max(0, w))}</Text>
+    </Box>
+  )
+}
+
+const PARENT_CONTENT_WIDTH = 116
+// Msg insets the marker glyph + row gap (2 cols) from the inherited width.
+const MARKER_INSET = 2
+// QueuedMessageProvider (non-brief) padding = paddingX={2} => 4 cols.
+const QUEUED_PADDING = 4
+
+async function probeBodyWidth(node: React.ReactNode): Promise<number> {
+  const out = await renderToString(
+    <ContentWidthProvider width={PARENT_CONTENT_WIDTH}>{node}</ContentWidthProvider>,
+    { columns: 130, rows: 10 },
+  )
+  const row = out.split('\n').find(line => line.includes('#')) ?? ''
+  return (row.match(/#/g) ?? []).length
+}
+
+describe('Msg queued body wrap width (BUG 1)', () => {
+  test('non-queued message body width is unchanged (marker inset only)', async () => {
+    const width = await probeBodyWidth(
+      <Msg role="user" label="you">
+        <WidthProbe />
+      </Msg>,
+    )
+    // Only the 2-col marker inset is subtracted — no queued padding double-count.
+    expect(width).toBe(PARENT_CONTENT_WIDTH - MARKER_INSET)
+  })
+
+  test('queued message body width subtracts the queued container padding', async () => {
+    const width = await probeBodyWidth(
+      <QueuedMessageProvider isFirst>
+        <Msg role="user" label="you">
+          <WidthProbe />
+        </Msg>
+      </QueuedMessageProvider>,
+    )
+    // Marker inset (2) + queued padding (4). Against the pre-fix code this would
+    // be PARENT_CONTENT_WIDTH - 2 (4 cols too wide), overshooting the queued
+    // highlight box's padded interior — the ragged right edge from the bug.
+    expect(width).toBe(PARENT_CONTENT_WIDTH - MARKER_INSET - QUEUED_PADDING)
+  })
+
+  test('the queued body never exceeds the queued box interior width', async () => {
+    // The queued highlight box reserves paddingX={2} on each side, so the body
+    // column (marker + content) must fit within PARENT_CONTENT_WIDTH - padding.
+    const width = await probeBodyWidth(
+      <QueuedMessageProvider isFirst>
+        <Msg role="user" label="you">
+          <WidthProbe />
+        </Msg>
+      </QueuedMessageProvider>,
+    )
+    const interior = PARENT_CONTENT_WIDTH - QUEUED_PADDING
+    expect(width + MARKER_INSET).toBeLessThanOrEqual(interior)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// BUG 3 — welcome card meta row / recent session row grid alignment.
+//
+// A long workspace path (or recent-session title) must truncate IN PLACE on the
+// same line as its label, keeping the 2-column label/value grid aligned —
+// rather than wrapping the value onto a fresh flex line under the label.
+// ---------------------------------------------------------------------------
+
+const LONG_WORKSPACE = '/tmp/some/very/long/absolute/path/to/a/workspace/sandbox/dir'
+
+function renderWelcome(extra?: {
+  readonly recentSessions?: React.ComponentProps<typeof WelcomeColdPanel>['recentSessions']
+}): Promise<string> {
+  return renderToString(
+    <ContentWidthProvider width={64}>
+      <WelcomeColdPanel
+        workspace={LONG_WORKSPACE}
+        model="default model"
+        lastSession="12m ago · clean"
+        recentSessions={extra?.recentSessions}
+      />
+    </ContentWidthProvider>,
+    { columns: 80, rows: 30 },
+  )
+}
+
+/** Card body rows (inside the border), trimmed of trailing padding. */
+function cardLines(out: string): string[] {
+  return out
+    .split('\n')
+    .map(line => line.replace(/^│/u, '').replace(/│\s*$/u, '').trimEnd())
+}
+
+describe('WelcomeMetaRow long-path grid alignment (BUG 3)', () => {
+  test('the workspace value stays on the same line as its label', async () => {
+    const out = await renderWelcome()
+    const lines = cardLines(out)
+
+    // The label and (truncated) value share one row. truncate-middle inserts an
+    // ellipsis, so match on the stable path head + tail around the label.
+    const labelRow = lines.find(line => /\bworkspace\b/u.test(line))
+    expect(labelRow).toBeDefined()
+    // The value must be present on the SAME row as the label.
+    expect(labelRow).toContain('/tmp/some/very/long')
+    expect(labelRow).toContain('sandbox/dir')
+
+    // Revert-sensitivity guard: there must be NO standalone value row (a row
+    // that carries the path WITHOUT the label) — that is the wrapped/broken
+    // layout the fix removes.
+    const orphanValueRow = lines.find(
+      line => line.includes('sandbox/dir') && !/\bworkspace\b/u.test(line),
+    )
+    expect(orphanValueRow).toBeUndefined()
+  })
+
+  test('a long recent-session title truncates in place and keeps the [n] key prefix', async () => {
+    const out = await renderWelcome({
+      recentSessions: [
+        {
+          keyName: '1',
+          title: 'a-session-with-a-really-long-title-here',
+          detail: 'yesterday · main · clean · plus more detail text',
+        },
+      ],
+    })
+    const lines = cardLines(out)
+    const row = lines.find(line => line.includes('a-session-with-a-really'))
+    expect(row).toBeDefined()
+    // The fixed `[1] ` key prefix survives (not squeezed to `1]`), and the row
+    // truncates rather than wrapping the detail to its own line.
+    expect(row).toContain('[1]')
+    // The detail keeps reading on the SAME row as the title/key.
+    expect(row).toContain('yesterday')
+    // Revert-sensitivity: the pre-fix `flexWrap="wrap"` row pushed the `· detail`
+    // segment onto its own flex line under the `[1]` key. There must be no such
+    // orphan detail row (a `yesterday …` line with no title/key on it).
+    const orphanDetailRow = lines.find(
+      line => line.includes('yesterday') && !line.includes('a-session-with-a-really'),
+    )
+    expect(orphanDetailRow).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Iteration 25 — TUI visual/UX convergence loop (clean-capture round)

Discovery over a clean fast-model multi-turn capture (`build9`) found 3 new medium defects, all model-independent.

### 1) Queued-message preview body wrap overshoots the highlight box by 1 column
`Msg` derived the body wrap width as `insetContentWidth(width, 2)`, but queued items are additionally wrapped by `QueuedMessageProvider` in a `<Box paddingX={2}>` (4 cols) the inherited `ContentWidth` never accounted for — so the first wrapped line ran to the viewport edge past the box's right edge. The context already exposed a `paddingWidth` (4/0) for exactly this but it was **dead**. Now consumed for queued messages only; non-queued unchanged, no double-count. (Distinct from iter-22's active-message `width="100%"` fix.)

### 2) Linux spinner flickers a bare ASCII `*` one frame in six
The Linux/default spinner family was `· ✢ * ✶ ✻ ✽` — a thin ASCII asterisk wedged between unicode flower-stars, flickering every animation cycle. Replaced index-2 with `✳` to match the macOS family `· ✢ ✳ ✶ ✻ ✽`. (Glyph follow-up to iter-23, which unified the indicator *color*.) Ghostty's deliberate documented `*` untouched.

### 3) Welcome-card `workspace` path wraps to its own line, breaking the label/value grid
`WelcomeMetaRow` (and recent-session rows) used `flexWrap="wrap"`, so a long absolute path pushed the already-`truncate-middle` value onto a fresh line under the label. Dropped `flexWrap`; value goes in a `flexShrink/minWidth:0` cell so it truncates on the label's row, with the fixed 13-col label / `[n] ` key prefixes protected by `flexShrink={0}` (Yoga was otherwise clipping the `[` bracket).

### Gate
Each revert-sensitive. `npm run build` exit 0 · full `npm run test:unit` **13310 passed, 0 failures** · TUI startup smoke clean. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG