### PR TITLE
fix(tui): nest Bash/Run command stdout under its call row (⎿ gutter + secondary tone)

### DIFF
--- a/runtime/src/tui/tool-rendering.tsx
+++ b/runtime/src/tui/tool-rendering.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 
 import { Box, Text } from "./ink.js";
+import { selectAgenCTuiGlyphs } from "./glyphs.js";
 import { AskUserQuestionTool } from "../tools/ask-user-question/tui-tool.js";
 import { formatToolPathForDisplay } from "../tools/system/agent-path-hints.js";
 import { isRecord } from "../utils/record.js";
@@ -458,31 +459,49 @@ export function BashOutputView({
   // stdout (no separate stderr stream), so on a failed command with no tagged
   // stderr we still surface the exit code as a small red note.
   const showExitNote = isFailure && stderrCap === null;
+  // The command output is rendered behind the same `⎿` continuation gutter the
+  // file-changed summary, Read/Search results, and the V2Tool `ToolResultLines`
+  // use, so the stdout/stderr body visually nests UNDER its `● Run(...)` call
+  // row instead of breaking out flush at the bullet column. The gutter glyph
+  // sits on the first line; the content column aligns the rest under it.
+  // Mirrors the row layout in CollapsedReadSearchContent: a fixed-width gutter
+  // column + a flex content column. stdout uses the dim/secondary tone the
+  // sibling result bodies use (it's nested detail, not headline text); stderr
+  // stays red so a failure is still visually distinct.
+  const glyphs = selectAgenCTuiGlyphs();
+  const responseGutter = `  ${glyphs.responseGutter}  `;
   return (
-    <Box flexDirection="column">
-      {stdoutCap.lines.map((line, idx) => (
-        <Text key={`o${idx}`}>{line}</Text>
-      ))}
-      {stdoutCap.remaining > 0 ? (
-        <Text dimColor>{`… +${stdoutCap.remaining} ${
-          stdoutCap.remaining === 1 ? "line" : "lines"
-        }`}</Text>
-      ) : null}
-      {stderrCap
-        ? stderrCap.lines.map((line, idx) => (
-            <Text key={`e${idx}`} color={"red" as TextColor}>
-              {line}
-            </Text>
-          ))
-        : null}
-      {stderrCap && stderrCap.remaining > 0 ? (
-        <Text dimColor>{`… +${stderrCap.remaining} ${
-          stderrCap.remaining === 1 ? "line" : "lines"
-        }`}</Text>
-      ) : null}
-      {showExitNote ? (
-        <Text color={"red" as TextColor}>{`(exit ${exitCode})`}</Text>
-      ) : null}
+    <Box flexDirection="row">
+      <Box flexShrink={0}>
+        <Text dimColor>{responseGutter}</Text>
+      </Box>
+      <Box flexDirection="column" flexGrow={1}>
+        {stdoutCap.lines.map((line, idx) => (
+          <Text key={`o${idx}`} dimColor>
+            {line}
+          </Text>
+        ))}
+        {stdoutCap.remaining > 0 ? (
+          <Text dimColor>{`… +${stdoutCap.remaining} ${
+            stdoutCap.remaining === 1 ? "line" : "lines"
+          }`}</Text>
+        ) : null}
+        {stderrCap
+          ? stderrCap.lines.map((line, idx) => (
+              <Text key={`e${idx}`} color={"red" as TextColor}>
+                {line}
+              </Text>
+            ))
+          : null}
+        {stderrCap && stderrCap.remaining > 0 ? (
+          <Text dimColor>{`… +${stderrCap.remaining} ${
+            stderrCap.remaining === 1 ? "line" : "lines"
+          }`}</Text>
+        ) : null}
+        {showExitNote ? (
+          <Text color={"red" as TextColor}>{`(exit ${exitCode})`}</Text>
+        ) : null}
+      </Box>
     </Box>
   );
 }

--- a/runtime/tests/tools/tool-rendering-bash.test.tsx
+++ b/runtime/tests/tools/tool-rendering-bash.test.tsx
@@ -18,6 +18,7 @@ vi.mock("../tui/ink.js", () => {
 });
 
 import { createTuiTool, BashOutputView } from "../tui/tool-rendering.js";
+import { selectAgenCTuiGlyphs } from "../tui/glyphs.js";
 
 describe("createTuiTool('Bash').renderToolResultMessage — end-to-end dispatch", () => {
   test("Bash content with <bash-stdout> envelope produces a React element whose type is BashOutputView", () => {
@@ -98,27 +99,36 @@ describe("createTuiTool('Bash').renderToolResultMessage — end-to-end dispatch"
 });
 
 /**
- * Flatten the children of a BashOutputView node into an array of child
- * elements. When the view returns a bare <Text> (the silent / no-output case)
- * the node itself is the only "child".
+ * Recursively collect every descendant element of a BashOutputView node into a
+ * flat array. The capped stdout/stderr lines now sit one level deeper inside the
+ * `⎿`-gutter content column (a row layout: gutter column + content column), so
+ * this walks the element tree rather than only the immediate children. When the
+ * view returns a bare <Text> (the silent / no-output case) the node itself is
+ * the only element.
  */
-function flattenBash(node: unknown): { props: { children?: unknown; color?: string } }[] {
-  const children = (node as { props?: { children?: unknown } }).props?.children;
-  const isElementWithChildrenArray =
-    children !== undefined &&
-    (Array.isArray(children) ||
-      (typeof children === "object" && children !== null));
-  const arr = isElementWithChildrenArray
-    ? Array.isArray(children)
-      ? children
-      : [children]
-    : [node];
-  return arr
-    .flat(Infinity)
-    .filter(
-      (child): child is { props: { children?: unknown; color?: string } } =>
-        typeof child === "object" && child !== null,
+function flattenBash(
+  node: unknown,
+): { props: { children?: unknown; color?: string; dimColor?: boolean } }[] {
+  const out: { props: { children?: unknown; color?: string; dimColor?: boolean } }[] =
+    [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (typeof value !== "object" || value === null) return;
+    const element = value as {
+      props?: { children?: unknown; color?: string; dimColor?: boolean };
+    };
+    out.push(
+      element as { props: { children?: unknown; color?: string; dimColor?: boolean } },
     );
+    if (element.props && "children" in element.props) {
+      visit(element.props.children);
+    }
+  };
+  visit(node);
+  return out;
 }
 
 describe("BashOutputView — capped preview visual contract", () => {
@@ -213,20 +223,100 @@ describe("formatStructuredToolResult ⇄ BashOutputView wire-shape lock", () => 
 
     const node = BashOutputView({ content: joined });
     expect(node).toBeDefined();
-    const children = (node as { props: { children: unknown[] } }).props.children;
-    const flat = (Array.isArray(children) ? children : [children])
-      .flat(Infinity)
-      .filter((child) => child !== null);
-    const renderedTexts = flat
+    const renderedTexts = flattenBash(node)
       .filter(
         (child): child is { props: { children: string } } =>
-          typeof child === "object" &&
-          child !== null &&
-          typeof (child as { props?: { children?: unknown } }).props
-            ?.children === "string",
+          typeof child.props.children === "string",
       )
       .map((child) => child.props.children);
     expect(renderedTexts.some((t) => t === "out")).toBe(true);
     expect(renderedTexts.some((t) => t === "err")).toBe(true);
+  });
+});
+
+/**
+ * The command stdout must nest UNDER its `● Run(...)` call row behind the same
+ * `⎿` continuation gutter the file-changed summary and the Read/Search collapsed
+ * body use — instead of breaking out flush at the bullet column — and render in
+ * the dim/secondary tone the other tool-result bodies use (so the raw output is
+ * not the loudest, full-brightness block in the transcript).
+ *
+ * REVERT-SENSITIVITY: against the pre-fix renderer the multi-line stdout was a
+ * flat list of bare `<Text>{line}</Text>` children — no gutter Text existed
+ * anywhere and the stdout lines carried no `dimColor`. Both assertions below go
+ * red if the gutter/indent + secondary-tone change is reverted.
+ */
+describe("BashOutputView — stdout nests behind the ⎿ gutter in the secondary tone", () => {
+  const gutter = selectAgenCTuiGlyphs().responseGutter;
+
+  test("multi-line stdout renders behind a single ⎿ continuation gutter, indented into a content column (not flush at the glyph column)", () => {
+    const node = BashOutputView({
+      content:
+        "<bash-stdout>INFO: 3\nWARN: 2\nERROR: 2</bash-stdout>[exit_code=0]",
+    });
+    const flat = flattenBash(node);
+
+    // A gutter Text containing the responseGutter glyph must exist. The old
+    // renderer had no gutter at all, so this find() returns undefined on revert.
+    const gutterLine = flat.find(
+      (child) =>
+        typeof child.props?.children === "string" &&
+        (child.props.children as string).includes(gutter),
+    );
+    expect(gutterLine).toBeDefined();
+    // The gutter sits in its own dimmed column.
+    expect(gutterLine!.props.dimColor).toBe(true);
+
+    // The top-level node is a ROW (gutter column + content column), so the
+    // stdout lines are NOT direct children of the returned node — they live one
+    // level deeper in the content column. The pre-fix node rendered them as
+    // immediate column children with no gutter, so this structural nesting is
+    // itself the fix.
+    const topChildren = (node as { props: { children: unknown } }).props
+      .children;
+    const topArray = Array.isArray(topChildren) ? topChildren : [topChildren];
+    const stdoutAtTopLevel = topArray
+      .flat(Infinity)
+      .some(
+        (child) =>
+          typeof child === "object" &&
+          child !== null &&
+          (child as { props?: { children?: unknown } }).props?.children ===
+            "INFO: 3",
+      );
+    expect(stdoutAtTopLevel).toBe(false);
+
+    // Each stdout line is reachable (nested) and rendered in the dim/secondary
+    // tone — never full brightness.
+    for (const expected of ["INFO: 3", "WARN: 2", "ERROR: 2"]) {
+      const line = flat.find((child) => child.props?.children === expected);
+      expect(line).toBeDefined();
+      expect(line!.props.dimColor).toBe(true);
+    }
+  });
+
+  test("the `… +N lines` truncation summary inherits the gutter/indent and stays dim", () => {
+    // 7 lines with a 5-line cap → 2 remaining, surfaced as "… +2 lines" under
+    // the same gutter. (No new interactivity is added for the truncation.)
+    const body = Array.from({ length: 7 }, (_, i) => `row ${i}`).join("\n");
+    const node = BashOutputView({
+      content: `<bash-stdout>${body}</bash-stdout>[exit_code=0]`,
+    });
+    const flat = flattenBash(node);
+    const more = flat.find(
+      (child) =>
+        typeof child.props?.children === "string" &&
+        (child.props.children as string).startsWith("… +2"),
+    );
+    expect(more).toBeDefined();
+    expect(more!.props.dimColor).toBe(true);
+    // Still behind the gutter.
+    expect(
+      flat.some(
+        (child) =>
+          typeof child.props?.children === "string" &&
+          (child.props.children as string).includes(gutter),
+      ),
+    ).toBe(true);
   });
 });

--- a/runtime/tests/tui/coverage-swarm/swarm-017-tool-rendering.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-017-tool-rendering.test.tsx
@@ -32,15 +32,24 @@ interface ChildElement {
 }
 
 function flatten(node: unknown): ChildElement[] {
-  if (!node || typeof node !== "object") return [];
-  const children = (node as { props?: { children?: unknown } }).props?.children;
-  const arr = Array.isArray(children) ? children : [children];
-  return arr
-    .flat(Infinity)
-    .filter(
-      (child): child is ChildElement =>
-        typeof child === "object" && child !== null,
-    );
+  // Recurse through the element tree. BashOutputView now nests its stdout/stderr
+  // lines one level deeper inside the `⎿`-gutter content column, so a shallow
+  // (immediate-children only) walk would miss them.
+  const out: ChildElement[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    out.push(value as ChildElement);
+    const children = (value as { props?: { children?: unknown } }).props
+      ?.children;
+    if (children !== undefined) visit(children);
+  };
+  const top = (node as { props?: { children?: unknown } })?.props?.children;
+  visit(top);
+  return out;
 }
 
 function textOf(child: ChildElement): string {

--- a/runtime/tests/tui/tool-rendering.ihunt-bash-escaping.test.tsx
+++ b/runtime/tests/tui/tool-rendering.ihunt-bash-escaping.test.tsx
@@ -32,15 +32,22 @@ interface ChildElement {
 }
 
 function flatten(node: unknown): ChildElement[] {
-  if (!node || typeof node !== "object") return [];
-  const children = (node as { props?: { children?: unknown } }).props?.children;
-  const arr = Array.isArray(children) ? children : [children];
-  return arr
-    .flat(Infinity)
-    .filter(
-      (child): child is ChildElement =>
-        typeof child === "object" && child !== null,
-    );
+  // Recurse through the element tree: BashOutputView nests its stdout/stderr
+  // lines inside the `⎿`-gutter content column, so a shallow walk misses them.
+  const out: ChildElement[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    out.push(value as ChildElement);
+    const children = (value as { props?: { children?: unknown } }).props
+      ?.children;
+    if (children !== undefined) visit(children);
+  };
+  visit((node as { props?: { children?: unknown } })?.props?.children);
+  return out;
 }
 
 /**


### PR DESCRIPTION
## Iteration 26 — first DYNAMIC-scenario round (run-commands focus)

The QA loop now runs a **different planner-generated scenario each round** to exercise varied surfaces. The first dynamic scenario — a `logscan` CLI that actually **runs commands** — immediately exposed a HIGH-value bug (confirmed by 4 independent discovery agents) on a surface the old fixed webpage/game scenario never touched.

### The bug
Bash/Run command **stdout rendered flush at the `●` tool-glyph column with no `⎿` gutter and no indent** — so output (`INFO: 3`, `WARN: 2`…) floated as orphaned top-level text instead of belonging to its `● Run(...)` call row. It was the *only* tool result that broke out of the nesting every other body uses (`⎿ files changed`, diff cards, Read/Search collapsed bodies, prose). It was also the only **full-brightness** text in the transcript (inverted hierarchy — the loudest thing on screen despite being secondary detail).

### The fix
The live exec-result path is `BashOutputView` (`UserToolSuccessMessage` → `renderToolResultMessage` `"bash-output-view"`), which returned a bare column of full-brightness `<Text>` lines (the upstream `OutputLine`→`MessageResponse` gutter path isn't used for live exec results). Rewrote it as the same row layout `CollapsedReadSearchContent` uses — a fixed-width `⎿` gutter column + a flex content column — so stdout nests under the call row, with `dimColor` for the secondary tone. stderr stays red; the `… +N lines` summary and exit note inherit the gutter + tone.

### Gate
Revert-sensitive test added (gutter `⎿` and dim stdout absent against pre-fix code); 14 existing bash-render tests stay green (3 test helpers updated to recurse the now-deeper tree, assertions preserved). `npm run build` exit 0 · full `npm run test:unit` **13312 passed, 0 failures** · TUI startup smoke clean. No tmux.

Deferred (noted): an expand affordance for `… +N lines` truncation (diffs have `· ctrl+w d`; command output doesn't yet).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG