### PR TITLE
fix(tui): keep tool-call header intact when args overflow (glyph/label/parens never shrink)

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -978,23 +978,47 @@ export function Tool({
   return (
     <Box flexDirection="column">
       <Box flexDirection="row" gap={1}>
-        <ThemedText color={color}>{toolGlyph[state]}</ThemedText>
-        <ThemedText color={toolColor[kind]} bold>
-          {label ?? capitalize(kind)}
-        </ThemedText>
+        {/*
+          The leading glyph and bold tool label must NEVER shrink: every
+          ink-text node defaults to flexShrink:1, so under arg overflow Yoga
+          would otherwise squeeze the glyph + label down too, collapsing the
+          `gap={1}` space (the glyph touches the label — `●Run`) and doubling
+          the trailing space. Pinning each in a flexShrink={0} Box keeps
+          `● Run` intact and forces all shrinkage onto the args text below.
+        */}
+        <Box flexShrink={0}>
+          <ThemedText color={color}>{toolGlyph[state]}</ThemedText>
+        </Box>
+        <Box flexShrink={0}>
+          <ThemedText color={toolColor[kind]} bold>
+            {label ?? capitalize(kind)}
+          </ThemedText>
+        </Box>
         {/*
           The parenthesized args render as a single gap={0} unit so the parens
           hug the argument (`Write (index.html)`) instead of the outer gap={1}
           inserting a stray space on the inside of each paren (`Write ( index.html )`).
           The single space between the bold tool label and the opening paren is
           still supplied by the parent row's gap={1}.
+
+          The whole group shrinks (flexShrink={1} minWidth={0}), but only the
+          inner args text gives way: both parens are pinned flexShrink={0} so
+          the opening `(` is never dropped and the closing `)` always survives,
+          while the args text truncates in the middle. Without this, Yoga shrank
+          the parens too and dropped the opening `(` while keeping the close `)`.
         */}
-        <Box flexDirection="row" gap={0}>
-          <ThemedText color="inactive">(</ThemedText>
-          <ThemedText color="text2" wrap="truncate-middle">
-            {args}
-          </ThemedText>
-          <ThemedText color="inactive">)</ThemedText>
+        <Box flexDirection="row" gap={0} flexShrink={1} minWidth={0}>
+          <Box flexShrink={0}>
+            <ThemedText color="inactive">(</ThemedText>
+          </Box>
+          <Box flexShrink={1} minWidth={0}>
+            <ThemedText color="text2" wrap="truncate-middle">
+              {args}
+            </ThemedText>
+          </Box>
+          <Box flexShrink={0}>
+            <ThemedText color="inactive">)</ThemedText>
+          </Box>
         </Box>
         {time ? <ThemedText color="inactive">{time}</ThemedText> : null}
       </Box>

--- a/runtime/tests/tui/v2-primitives-render.test.tsx
+++ b/runtime/tests/tui/v2-primitives-render.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { describe, expect, test } from 'vitest'
 
-import { Msg, WelcomeColdPanel } from '../../src/tui/components/v2/primitives.js'
+import { Msg, Tool, WelcomeColdPanel } from '../../src/tui/components/v2/primitives.js'
 import { Box, Text } from '../../src/tui/ink.js'
 import {
   ContentWidthProvider,
@@ -170,5 +170,81 @@ describe('WelcomeMetaRow long-path grid alignment (BUG 3)', () => {
       line => line.includes('yesterday') && !line.includes('a-session-with-a-really'),
     )
     expect(orphanDetailRow).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// BUG A — Tool call header collapses when the args overflow the content width.
+//
+// `● Run (cmd)` renders correctly only when the args FIT. When the args overflow
+// (the common case for any real bash/Read/Edit/Grep command) Yoga shrank the
+// leading glyph, the bold label, AND the parens along with the args, so the row
+// degraded to `●Run  cmd…)` — the glyph/label gap collapsed (`●Run`), a doubled
+// space appeared after the label, the opening `(` was DROPPED, and the closing
+// `)` survived (unbalanced parens).
+//
+// The fix pins the glyph, the label, and both parens flexShrink={0} and lets ONLY
+// the inner args text (flexShrink={1} minWidth={0}, truncate-middle) give way.
+// The asserted shape `● Run (…)` is the same hug as the short-fitting case.
+// ---------------------------------------------------------------------------
+
+const LONG_TOOL_ARGS =
+  'python3 /some/very/long/path/to/a/script/that/overflows/the/content/width.py --flag value --another-flag'
+
+/** First (call) row of a rendered Tool, with trailing pad trimmed. */
+async function firstToolRow(node: React.ReactNode, contentWidth: number): Promise<string> {
+  const out = await renderToString(
+    <ContentWidthProvider width={contentWidth}>{node}</ContentWidthProvider>,
+    { columns: contentWidth + 10, rows: 10 },
+  )
+  return (out.split('\n')[0] ?? '').trimEnd()
+}
+
+describe('Tool call header under arg overflow (BUG A)', () => {
+  test('a fitting arg keeps the canonical `● Run (cmd)` shape', async () => {
+    const row = await firstToolRow(<Tool kind="bash" label="Run" args="short cmd" />, 90)
+    expect(row).toBe('● Run (short cmd)')
+  })
+
+  test('an overflowing bash arg keeps glyph/space/label/space/open-paren and the closing paren', async () => {
+    const row = await firstToolRow(<Tool kind="bash" label="Run" args={LONG_TOOL_ARGS} />, 90)
+
+    // Glyph, single space, bold label, single space, opening paren — all intact.
+    // Against the pre-fix code the row started `●Run  ` (glyph touching label, no
+    // space; doubled space after label) and the `(` was missing entirely, so this
+    // exact prefix is the revert-sensitive guard.
+    expect(row.startsWith('● Run (')).toBe(true)
+    // The opening paren is present and the args text was truncated in the middle
+    // (the ellipsis appears between the open paren and the close paren).
+    expect(row).toContain('…')
+    // The closing paren survives — and balances the opening one.
+    expect(row.endsWith(')')).toBe(true)
+    expect((row.match(/\(/g) ?? []).length).toBe(1)
+    expect((row.match(/\)/g) ?? []).length).toBe(1)
+    // Revert-sensitivity, negative form: the collapsed defects must be gone.
+    expect(row.startsWith('●Run')).toBe(false)
+    expect(row).not.toContain('Run  ')
+  })
+
+  test.each(['edit', 'read', 'grep'] as const)(
+    'kind=%s collapses the same way and is fixed by the same pinning',
+    async kind => {
+      const expectedLabel = kind.charAt(0).toUpperCase() + kind.slice(1)
+      const row = await firstToolRow(<Tool kind={kind} args={LONG_TOOL_ARGS} />, 90)
+      expect(row.startsWith(`● ${expectedLabel} (`)).toBe(true)
+      expect(row.endsWith(')')).toBe(true)
+      expect((row.match(/\(/g) ?? []).length).toBe(1)
+      expect((row.match(/\)/g) ?? []).length).toBe(1)
+      // The collapsed `●Edit`/`●Read`/`●Grep` (no glyph space) must not reappear.
+      expect(row.startsWith(`●${expectedLabel}`)).toBe(false)
+    },
+  )
+
+  test('the defect reproduces across narrow widths and the fix holds at each', async () => {
+    for (const width of [70, 60, 50]) {
+      const row = await firstToolRow(<Tool kind="bash" label="Run" args={LONG_TOOL_ARGS} />, width)
+      expect(row.startsWith('● Run (')).toBe(true)
+      expect(row.endsWith(')')).toBe(true)
+    }
   })
 })


### PR DESCRIPTION
## Iteration 27 — dynamic read-explain round (high-frequency tool-header fix)

A dynamic read-explain scenario (roman.py — show/explain code) generated long commands that overflowed the tool-call header, exposing a **high-frequency** bug.

### Fixed: `● Run (args)` collapses on arg overflow
The header rendered correctly only when args fit. On overflow (almost every real command) Yoga shrank the glyph + bold label + parens along with the args → `●Run  python3 …--flag)`: glyph touching label (lost `gap={1}` space), doubled space after label, and the **opening `(` dropped** while `)` survived (unbalanced). Since nearly every command line truncates, almost every tool header rendered broken. (Distinct from iter-18's fit-case paren-hug fix.)

Every ink-text/Box defaults to `flexShrink:1`, so the fix pins what must never collapse: glyph + label each `flexShrink={0}`; inside the iter-18 `gap={0}` paren group (now `flexShrink={1} minWidth={0}`) both parens `flexShrink={0}` with only the args text `flexShrink={1} minWidth={0}` (truncate-middle). Result: `● Run (python3 /…middle-truncated…/--flag)` — structure intact, args truncate, balanced parens. Verified for Run/Edit/Read/Grep; short fitting case unchanged.

Revert-sensitive (5/6 new cases red against pre-fix code). `npm run build` exit 0 · full `npm run test:unit` **13318 passed, 0 failures** · TUI startup smoke clean. No tmux.

### Deferred (investigated, not shipped)
A scroll-position indicator fusing with a content row in one mid-stream scrollback capture was investigated across **616 streaming frames** — the row budget is derived consistently and no fusion reproduces in the render model. Almost certainly a transient alt-screen DECSTBM hardware-scroll / tmux-capture-replay artifact, not a persistent layout bug. Deferred pending an alt-screen TTY repro harness rather than shipping a blind change to the streaming/scroll path.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG