### PR TITLE
fix(tui): approval-diff budget + $-prefix; colored command output; TodoWrite header/result

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1251,10 +1251,71 @@ export interface ApprovalDiffPreview {
   readonly op?: string
 }
 
+/**
+ * Fixed (line-independent) rows the embedded `DiffInline` box ALWAYS draws,
+ * regardless of how many diff lines it shows:
+ *   - top border + bottom border (2)
+ *   - the `CREATE/EDIT path +N -M` header (1)
+ *   - the header's bottom separator border row (1)
+ *   - the `… +N more · ctrl+w d` continuation row that a capped (always-capped
+ *     for a real Write/Edit) diff appends (1)
+ * The box can never render in fewer than these 5 rows PLUS at least one diff
+ * body line.
+ */
+const DIFF_INLINE_FIXED_CHROME_ROWS = 5
+/** Hard cap on inline diff lines so even a huge diff stays a compact preview. */
+const APPROVAL_PREVIEW_LINE_CAP = 7
+/**
+ * Essential popup body rows that must ALWAYS survive at the bottom of the body:
+ * the summary line, the optional facts grid, the optional note, the
+ * `[1]/[2]/[3]` action legend, and the confirm row. The popup clips its body
+ * from the BOTTOM and the diff box renders ABOVE these rows, so the diff must be
+ * shed BEFORE it can push the legend/confirm off the bottom edge — reserve all
+ * of them up front.
+ */
+const APPROVAL_ESSENTIAL_BODY_ROWS = 5
+
+/**
+ * Decide whether the approval popup can show its embedded `DiffInline` preview
+ * at a given body height, and if so how many diff lines fit.
+ *
+ * Two bugs this guards (BUG 1):
+ *   1. Gating the preview on too small a budget let the popup body's
+ *      `overflow:'hidden'` clip the box right after its header, leaving an
+ *      UNTERMINATED box (top border + header, no body, no closing border).
+ *   2. Even when the box closed, an under-reserved budget let the box push the
+ *      `[1]/[2]/[3]` action legend + confirm row off the BOTTOM of the clipped
+ *      body — shedding the PRIMARY action instead of the optional diff.
+ * So the box's FULL fixed chrome (5 rows) + at least one diff line must fit
+ * AFTER the essential body is reserved, or the preview is omitted entirely — the
+ * `$ command`/path summary, `+N -M` stats, and `ctrl+w d for full diff`
+ * affordance already cover the constrained case.
+ *
+ * Pure (no React) so the height/overflow decision is unit-testable in isolation.
+ */
+export function approvalDiffPreviewBudget(
+  popupBodyRows: number,
+  availableDiffLines: number,
+): { readonly showPreview: boolean; readonly previewLineCap: number } {
+  // Rows left for actual diff LINES after reserving the essential body and the
+  // box's fixed chrome (borders + header + header separator + continuation row).
+  const lineBudget =
+    popupBodyRows - APPROVAL_ESSENTIAL_BODY_ROWS - DIFF_INLINE_FIXED_CHROME_ROWS
+  if (availableDiffLines <= 0 || lineBudget < 1) {
+    return { showPreview: false, previewLineCap: 0 }
+  }
+  const previewLineCap = Math.max(
+    1,
+    Math.min(APPROVAL_PREVIEW_LINE_CAP, lineBudget),
+  )
+  return { showPreview: true, previewLineCap }
+}
+
 export function ApprovalCard({
   risk,
   title,
   command,
+  commandIsShell = true,
   facts,
   note,
   confirmLabel,
@@ -1266,6 +1327,16 @@ export function ApprovalCard({
   readonly risk: 'low' | 'high'
   readonly title: string
   readonly command: string
+  /**
+   * Whether `command` is an actual SHELL command (Run/Bash) that should carry
+   * the `$ ` shell-prompt glyph, or a non-shell input — e.g. a Write/Edit
+   * `file_path` — where a `$ ` would misread as a runnable command AND duplicate
+   * the path already shown in the CREATE/EDIT diff header below. File tools pass
+   * `false` to drop the prompt glyph (and the redundant path line entirely when a
+   * diff header already names the file). Defaults to `true` so existing
+   * command-card callers are unchanged.
+   */
+  readonly commandIsShell?: boolean
   readonly facts: readonly { readonly label: string; readonly value: string; readonly color?: ThemeColor }[]
   readonly note?: string
   readonly confirmLabel: string
@@ -1301,22 +1372,15 @@ export function ApprovalCard({
   // primary action legend + confirm row are never the ones clipped away.
   const showFacts = popupBodyRows >= 5
   // The diff/content preview is the LARGEST optional block (a bordered DiffInline
-  // box: 2 chrome rows + one row per changed line). It is the FIRST thing shed
-  // when the slot is tight — never the [1]/[2]/[3] action legend or confirm row.
-  // Gate it behind the most generous budget, then cap the number of diff rows to
-  // the rows actually left after the essential body (summary, command, facts,
-  // note, action legend, confirm). Reserve ~5 essential body rows + 2 for the
-  // preview's own border; everything beyond that is available for diff lines.
-  const previewBudgetRows = popupBodyRows - 7
-  const showPreview =
-    diffPreview !== undefined && diffPreview.lines.length > 0 && previewBudgetRows >= 2
-  // Cap the inline diff to a small, bounded window (6-8 rows of the existing
-  // preview) and never beyond what the slot can hold; the rest stays reachable
-  // via the full diff surface (ctrl+w d), surfaced as a "… +N more" row.
-  const PREVIEW_CAP = 7
-  const previewLineCap = showPreview
-    ? Math.max(1, Math.min(PREVIEW_CAP, previewBudgetRows))
-    : 0
+  // box). The pure budget helper decides whether it fits (and how many diff
+  // lines it may show) so the same decision is unit-testable without the
+  // renderer; see `approvalDiffPreviewBudget`.
+  const budget = approvalDiffPreviewBudget(
+    popupBodyRows,
+    diffPreview?.lines.length ?? 0,
+  )
+  const showPreview = diffPreview !== undefined && budget.showPreview
+  const previewLineCap = showPreview ? budget.previewLineCap : 0
   let previewLines: ApprovalDiffPreview['lines'] = []
   if (showPreview && diffPreview !== undefined) {
     const shown = diffPreview.lines.slice(0, previewLineCap)
@@ -1360,9 +1424,21 @@ export function ApprovalCard({
         <ThemedText color="text2" wrap="truncate-end">
           {approvalSummary}
         </ThemedText>
-        <ThemedText color="text2" wrap="truncate-end">
-          $ {command}
-        </ThemedText>
+        {commandIsShell ? (
+          // A real shell command (Run/Bash): show it behind the `$ ` prompt glyph.
+          <ThemedText color="text2" wrap="truncate-end">
+            $ {command}
+          </ThemedText>
+        ) : showPreview ? null : (
+          // A non-shell input (a Write/Edit file_path). Never prefix it with the
+          // `$ ` shell-prompt marker — it would misread as a runnable command.
+          // When the embedded diff is shown its CREATE/EDIT header already names
+          // the file, so this line is redundant and omitted (the `showPreview`
+          // branch above); only surface the bare path when no diff is rendered.
+          <ThemedText color="text2" wrap="truncate-end">
+            {command}
+          </ThemedText>
+        )}
         {showPreview && diffPreview !== undefined ? (
           <Box flexShrink={1} overflow="hidden">
             <DiffInline

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -381,6 +381,35 @@ function toolLabel(toolUseConfirm: ProjectedToolUseConfirm): string {
   return toolUseConfirm.tool.name;
 }
 
+/** Live shell/command tool names whose approval input IS a runnable command. */
+const SHELL_COMMAND_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "Bash",
+  "exec_command",
+  "Run",
+]);
+
+/**
+ * Whether the approval `command` string is a real SHELL command (so it earns the
+ * `$ ` prompt glyph), vs a non-shell input such as a Write/Edit `file_path` where
+ * a `$ ` would misread as runnable and duplicate the diff header's path. Decided
+ * from the tool name (the known shell tools) OR — for any other tool — from the
+ * input actually carrying a `command`/`cmd` key (the same signal
+ * `approvalInputText` uses to render a command rather than a bare path/field).
+ */
+function approvalCommandIsShell(
+  toolUseConfirm: ProjectedToolUseConfirm,
+): boolean {
+  if (SHELL_COMMAND_TOOL_NAMES.has(toolUseConfirm.tool.name)) return true;
+  const input = toolUseConfirm.input;
+  if (input !== null && typeof input === "object" && !Array.isArray(input)) {
+    const record = input as Record<string, unknown>;
+    if (typeof record.command === "string" || typeof record.cmd === "string") {
+      return true;
+    }
+  }
+  return false;
+}
+
 function AgenCApprovalOverlay({
   request,
   toolUseConfirm,
@@ -513,6 +542,7 @@ function AgenCApprovalOverlay({
         risk={destructive ? "high" : "low"}
         title={`tool · ${name} · ${title}`}
         command={command.length > 0 ? command : toolUseConfirm.description}
+        commandIsShell={approvalCommandIsShell(toolUseConfirm)}
         facts={[
           { label: "tool", value: name },
           {

--- a/runtime/src/tui/tool-rendering.tsx
+++ b/runtime/src/tui/tool-rendering.tsx
@@ -1,7 +1,11 @@
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import React from "react";
+import stripAnsi from "strip-ansi";
 
 import { Box, Text } from "./ink.js";
+import { Ansi } from "./ink/Ansi.js";
+import { stringWidth } from "./ink/stringWidth.js";
+import { stripUnderlineAnsi } from "./components/shell/OutputLine.js";
 import { selectAgenCTuiGlyphs } from "./glyphs.js";
 import { AskUserQuestionTool } from "../tools/ask-user-question/tui-tool.js";
 import { formatToolPathForDisplay } from "../tools/system/agent-path-hints.js";
@@ -350,10 +354,28 @@ const BASH_PREVIEW_MAX_LINES = 5;
 /** Width cap for an individual previewed line (keeps the gutter tidy). */
 const MAX_PREVIEW_LINE_WIDTH = 200;
 
+/**
+ * Whether a line carries its OWN ANSI SGR (program color/style). Such a line is
+ * rendered through `<Ansi>` so its program color is preserved intact (matching
+ * the live-shell `OutputLine` precedent) instead of having a `dimColor` wrapper
+ * applied OVER it — which the program's own `ESC[39m`/`ESC[0m` resets terminate
+ * mid-line, leaving the row half-dim / half-raw.
+ */
+function lineHasOwnAnsi(line: string): boolean {
+  return stripAnsi(line) !== line;
+}
+
 function truncatePreviewWidth(line: string): string {
-  if (line.length <= MAX_PREVIEW_LINE_WIDTH) return line;
-  return `${line.slice(0, MAX_PREVIEW_LINE_WIDTH - 1)}… [${
-    line.length - (MAX_PREVIEW_LINE_WIDTH - 1)
+  // Measure VISIBLE width (ANSI escapes are zero-width). Counting escape BYTES
+  // as visible characters truncated colored lines early and miscapped the
+  // gutter; `stringWidth` strips ANSI before measuring. A line that is within
+  // the visible cap is returned unchanged (escapes intact). When it overflows,
+  // strip the ANSI before slicing so the truncation marker math stays on a
+  // clean string and we never cut through the middle of an escape sequence.
+  if (stringWidth(line) <= MAX_PREVIEW_LINE_WIDTH) return line;
+  const plain = stripAnsi(line);
+  return `${plain.slice(0, MAX_PREVIEW_LINE_WIDTH - 1)}… [${
+    plain.length - (MAX_PREVIEW_LINE_WIDTH - 1)
   } chars truncated]`;
 }
 
@@ -403,6 +425,39 @@ function parsePlainExecResult(content: string): {
     }
   }
   return { stdout: lines.slice(0, end).join("\n"), exitCode };
+}
+
+/**
+ * Render one capped Run/Bash output line. Lines are nested detail under the call
+ * row, so a PLAIN line renders in the dim/secondary tone its sibling report
+ * bodies use. A line that carries its OWN program SGR (e.g. a tool that prints
+ * `ESC[31m…ESC[39m`) must NOT have a `dimColor` wrapper applied over it: the
+ * program's own resets terminate the dim mid-line, leaving the row half-dim /
+ * half-raw — visually inconsistent with its uniformly-dim siblings. For those
+ * lines, follow the live-shell `OutputLine` precedent: render through `<Ansi>` so
+ * the program color is preserved intact (intentional), stripping only leaking
+ * underline codes — never double-applying dim over program color.
+ *
+ * Inlined as a helper (not a component) so a plain line stays a direct
+ * `<Text dimColor>` element — the existing flatten-based tests walk for it.
+ */
+function renderBashOutputLine(
+  line: string,
+  key: string,
+  plainColor: "dim" | TextColor,
+): React.ReactElement {
+  if (lineHasOwnAnsi(line)) {
+    return <Ansi key={key}>{stripUnderlineAnsi(line)}</Ansi>;
+  }
+  return plainColor === "dim" ? (
+    <Text key={key} dimColor>
+      {line}
+    </Text>
+  ) : (
+    <Text key={key} color={plainColor}>
+      {line}
+    </Text>
+  );
 }
 
 export function BashOutputView({
@@ -476,22 +531,22 @@ export function BashOutputView({
         <Text dimColor>{responseGutter}</Text>
       </Box>
       <Box flexDirection="column" flexGrow={1}>
-        {stdoutCap.lines.map((line, idx) => (
-          <Text key={`o${idx}`} dimColor>
-            {line}
-          </Text>
-        ))}
+        {stdoutCap.lines.map((line, idx) =>
+          // stdout: plain lines dim; lines with their own SGR keep program color.
+          renderBashOutputLine(line, `o${idx}`, "dim"),
+        )}
         {stdoutCap.remaining > 0 ? (
           <Text dimColor>{`… +${stdoutCap.remaining} ${
             stdoutCap.remaining === 1 ? "line" : "lines"
           }`}</Text>
         ) : null}
         {stderrCap
-          ? stderrCap.lines.map((line, idx) => (
-              <Text key={`e${idx}`} color={"red" as TextColor}>
-                {line}
-              </Text>
-            ))
+          ? stderrCap.lines.map((line, idx) =>
+              // stderr: a plain line keeps the red failure tone; a line that
+              // carries its OWN program SGR is rendered via <Ansi> so its colors
+              // stay intact (and don't emit raw escape bytes inside a <Text>).
+              renderBashOutputLine(line, `e${idx}`, "red" as TextColor),
+            )
           : null}
         {stderrCap && stderrCap.remaining > 0 ? (
           <Text dimColor>{`… +${stderrCap.remaining} ${
@@ -669,6 +724,39 @@ function skillInputParts(record: Record<string, unknown>): {
   };
 }
 
+/**
+ * Readable TodoWrite/TodoRead summary from the `{ todos: [...] }` input. The
+ * generic branch would JSON-stringify the whole array and `shortJson`-truncate
+ * it to a garbled `{"todos":[{"activeForm":"…__.py","status":"completed"},{…).`
+ * header. Instead surface a `<count> todos · <active item>` line: the total
+ * count plus the name of the in-progress item (or the first todo when none is
+ * in progress). Returns null when there is no usable todos array so the caller
+ * falls through to its other branches.
+ */
+function todoSummaryForInput(record: Record<string, unknown>): string | null {
+  const todos = record.todos;
+  if (!Array.isArray(todos)) return null;
+  const total = todos.length;
+  const todoLabel = (todo: unknown): string | null => {
+    if (!isRecord(todo)) return null;
+    const content =
+      typeof todo.content === "string" && todo.content.trim().length > 0
+        ? todo.content
+        : typeof todo.activeForm === "string" && todo.activeForm.trim().length > 0
+          ? todo.activeForm
+          : null;
+    return content === null ? null : truncateInline(content, 72);
+  };
+  const inProgress = todos.find(
+    (todo) => isRecord(todo) && todo.status === "in_progress",
+  );
+  const highlightLabel =
+    (inProgress !== undefined ? todoLabel(inProgress) : null) ??
+    (total > 0 ? todoLabel(todos[0]) : null);
+  const countText = `${total} ${total === 1 ? "todo" : "todos"}`;
+  return highlightLabel !== null ? `${countText} · ${highlightLabel}` : countText;
+}
+
 function isMcpToolName(name: string): boolean {
   return name.startsWith("mcp.");
 }
@@ -714,6 +802,10 @@ function toolUseSummaryForInput(name: string, input: unknown): string {
   }
   if (name === "Bash" && typeof record.command === "string") {
     return truncateInline(record.command);
+  }
+  if (name === "TodoWrite" || name === "TodoRead") {
+    const todos = todoSummaryForInput(record);
+    if (todos !== null) return todos;
   }
   const sanitized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {

--- a/runtime/src/tui/tool-result-routing.ts
+++ b/runtime/src/tui/tool-result-routing.ts
@@ -106,6 +106,18 @@ const WRITE_SUCCESS_RE =
   /\bhas been (created|written) successfully\.|\bFile created successfully at:/;
 
 /**
+ * The live daemon's TodoWrite SUCCESS result is a boilerplate sentence —
+ * "Todos have been modified successfully. Ensure that you continue to use the
+ * todo list…" — that carries no information the user needs (the todo state is
+ * shown from the tool-use INPUT on the call row, the same way Edit/Write diffs
+ * are). Suppress it so the verbose boilerplate never renders, mirroring the
+ * Edit/Write success suppression. Anchored on the specific success wording so a
+ * FAILED TodoWrite (different wording, routed through the error/generic path)
+ * never matches.
+ */
+const TODO_WRITE_SUCCESS_RE = /\bTodos have been modified successfully\./;
+
+/**
  * Heuristic for a bare Grep match list with no `Found ...` summary line — every
  * non-empty line looks like `path:line:content` or `path:count` (the
  * files-with-counts and matches shapes the daemon emits). Used so a raw match
@@ -223,6 +235,15 @@ export function pickToolResultDispatch(
   ) {
     const trimmed = joinedContent.trim();
     if (EDIT_SUCCESS_RE.test(trimmed) || WRITE_SUCCESS_RE.test(trimmed)) {
+      return "suppress";
+    }
+  }
+  // TodoWrite success: the boilerplate "Todos have been modified successfully…"
+  // body is noise — the todo state is shown from the tool-use INPUT on the call
+  // row. Suppress it the same way Edit/Write success bodies are. A failed
+  // TodoWrite uses different wording and still renders through generic/error.
+  if (toolName === "TodoWrite") {
+    if (TODO_WRITE_SUCCESS_RE.test(joinedContent.trim())) {
       return "suppress";
     }
   }

--- a/runtime/tests/tui/approval-card-command-prefix.test.tsx
+++ b/runtime/tests/tui/approval-card-command-prefix.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { Box } from '../../src/tui/ink.js'
+import {
+  ApprovalCard,
+  type ApprovalDiffPreview,
+} from '../../src/tui/components/v2/primitives.js'
+import { buildEditDiffPreview } from '../../src/tui/edit-diff-preview.js'
+import { renderToString } from '../../src/utils/staticRender.js'
+
+// BUG 4 (MEDIUM): the approval dialog rendered the tool input unconditionally as
+// `$ {command}`. The `$ ` is a shell-prompt marker — correct for Run/Bash, but
+// for a Write/Edit tool the input is a bare file path, so the card showed
+// `$ config_validator/validator.py`, which reads as a runnable command (it isn't)
+// AND duplicates the `CREATE path` diff header. The fix makes the `$ ` prefix
+// conditional on `commandIsShell`, and omits the redundant path line entirely
+// when a diff header already names the file.
+
+function writePreview(): ApprovalDiffPreview {
+  const built = buildEditDiffPreview('Write', {
+    file_path: 'config_validator/validator.py',
+    content: 'a = 1\nb = 2\n',
+  })
+  if (built === null) throw new Error('expected a Write diff preview')
+  return {
+    file: built.file,
+    stats: built.stats,
+    lines: built.lines,
+    remaining: built.remaining,
+    op: 'CREATE',
+  }
+}
+
+describe('ApprovalCard command prefix (BUG 4: no `$ ` shell glyph on file paths)', () => {
+  test('a Run/Bash command keeps the `$ ` shell-prompt prefix', async () => {
+    const out = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · run · needs approval"
+          command="rm -rf build"
+          commandIsShell={true}
+          facts={[{ label: 'tool', value: 'run' }]}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    expect(out).toMatch(/\$ rm -rf build/)
+  })
+
+  test('a Write file path is shown WITHOUT a `$ ` shell-prompt prefix', async () => {
+    // No diff preview here, so the bare path IS shown — but never behind `$ `.
+    const out = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · write · needs approval"
+          command="config_validator/validator.py"
+          commandIsShell={false}
+          facts={[{ label: 'tool', value: 'write' }]}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    expect(out).toContain('config_validator/validator.py')
+    // The path line is present but NOT prefixed with the shell-prompt glyph.
+    expect(out).not.toMatch(/\$ config_validator\/validator\.py/)
+  })
+
+  test('a Write WITH a diff header omits the redundant bare path line', async () => {
+    const out = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · write · needs approval"
+          command="config_validator/validator.py"
+          commandIsShell={false}
+          facts={[{ label: 'tool', value: 'write' }]}
+          diffPreview={writePreview()}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    // The CREATE diff header still names the file …
+    expect(out).toContain('CREATE')
+    // … and there is NO standalone command/path line for the file (the bare
+    // `config_validator/validator.py` line that used to render between the
+    // summary and the diff). The path still appears in the approval SUMMARY line
+    // (which lists the primary fact) and in the CREATE diff header — but never as
+    // its own `$ path` / bare-path line. So a row that is JUST the path (only
+    // popup chrome + whitespace + the path, no other words) must not exist.
+    const standalonePathRow = out.split('\n').find((l) => {
+      const stripped = l.replace(/[│┌┐└┘─\s]/g, '')
+      return stripped === 'config_validator/validator.py'
+    })
+    expect(standalonePathRow).toBeUndefined()
+    // Never behind a `$ ` prompt glyph.
+    expect(out).not.toMatch(/\$ config_validator\/validator\.py/)
+  })
+
+  test('REVERT-SENSITIVITY: shell vs file path differ ONLY by the `$ ` glyph', async () => {
+    const shell = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="t"
+          command="some/path/here.py"
+          commandIsShell={true}
+          facts={[{ label: 'tool', value: 'run' }]}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    const file = await renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="t"
+          command="some/path/here.py"
+          commandIsShell={false}
+          facts={[{ label: 'tool', value: 'run' }]}
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns: 116, rows: 40 },
+    )
+    // The shell card prefixes the value with `$ `; the file card does not.
+    expect(shell).toMatch(/\$ some\/path\/here\.py/)
+    expect(file).not.toMatch(/\$ some\/path\/here\.py/)
+    expect(file).toContain('some/path/here.py')
+  })
+})

--- a/runtime/tests/tui/approval-card-diff-budget.test.tsx
+++ b/runtime/tests/tui/approval-card-diff-budget.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { Box } from '../../src/tui/ink.js'
+import {
+  ApprovalCard,
+  approvalDiffPreviewBudget,
+  type ApprovalDiffPreview,
+} from '../../src/tui/components/v2/primitives.js'
+import { buildEditDiffPreview } from '../../src/tui/edit-diff-preview.js'
+import { renderToString } from '../../src/utils/staticRender.js'
+
+// BUG 1 (HIGH): in a height-constrained approval popup for a large file Write,
+// the embedded DiffInline preview used to clip right after its header row,
+// leaving an UNTERMINATED box (top border + `CREATE path +153 -0` header, then
+// no diff body and no closing border) — and the user was asked to approve a
+// 153-line write seeing ZERO content. ROOT CAUSE: `showPreview` was gated on a
+// budget (`>= 2`) that did NOT reserve the box's full minimum chrome (2 border
+// + 1 header + >=1 diff line = 4 rows). The fix reserves that full chrome up
+// front (`approvalDiffPreviewBudget`) and OMITS the embedded diff entirely when
+// it cannot fit at least the closing border + one diff line.
+
+// A realistic large Write diff (153 added lines).
+function bigWritePreview(): ApprovalDiffPreview {
+  const lines = Array.from({ length: 153 }, (_v, i) => `line ${i} content`).join(
+    '\n',
+  )
+  const built = buildEditDiffPreview('Write', {
+    file_path: 'config_validator/validator.py',
+    content: `${lines}\n`,
+  })
+  if (built === null) throw new Error('expected a Write diff preview')
+  return {
+    file: built.file,
+    stats: built.stats,
+    lines: built.lines,
+    remaining: built.remaining,
+    op: 'CREATE',
+  }
+}
+
+describe('approvalDiffPreviewBudget (BUG 1: never a header-only unterminated box)', () => {
+  test('omits the preview when the slot cannot fit the box chrome + one diff line', () => {
+    // The DiffInline box's fixed chrome is 5 rows (2 borders + header + header
+    // separator + continuation row); with 5 essential body rows reserved it
+    // needs popupBodyRows >= 11 to fit even one diff line. Below that it must be
+    // omitted, NOT rendered header-only and NOT at the cost of the action legend.
+    for (let popupBodyRows = 0; popupBodyRows <= 10; popupBodyRows++) {
+      const budget = approvalDiffPreviewBudget(popupBodyRows, 153)
+      expect(budget.showPreview).toBe(false)
+      expect(budget.previewLineCap).toBe(0)
+    }
+  })
+
+  test('shows the preview with >=1 diff line once the full chrome fits', () => {
+    // The threshold: popupBodyRows = 11 leaves exactly room for the essential
+    // body + box chrome + one diff line. Whenever the preview is shown, at least
+    // one line is shown (never a header-only box).
+    for (let popupBodyRows = 11; popupBodyRows <= 40; popupBodyRows++) {
+      const budget = approvalDiffPreviewBudget(popupBodyRows, 153)
+      expect(budget.showPreview).toBe(true)
+      expect(budget.previewLineCap).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  test('REVERT-SENSITIVITY: the budget reserves the box header + continuation, not just borders', () => {
+    // The bug was gating on a budget (`>= 2` after reserving only 5 essential +
+    // 2 border = 7) that did NOT reserve the box header, its separator, or the
+    // continuation row — so at marginal heights the box either clipped after its
+    // header (unterminated) or pushed the [1]/[2]/[3] legend off the bottom. The
+    // corrected helper reserves all of it, so the preview is OMITTED below
+    // popupBodyRows = 11. Against the broken gate, popupBodyRows = 10 SHOWED the
+    // diff (and clipped the legend); now it is omitted.
+    expect(approvalDiffPreviewBudget(10, 153).showPreview).toBe(false)
+    // And at the first height where the full chrome fits, exactly one line.
+    expect(approvalDiffPreviewBudget(11, 153)).toEqual({
+      showPreview: true,
+      previewLineCap: 1,
+    })
+  })
+
+  test('no diff lines available → no preview regardless of height', () => {
+    expect(approvalDiffPreviewBudget(40, 0).showPreview).toBe(false)
+  })
+
+  test('a generous slot caps the inline diff to the compact window', () => {
+    expect(approvalDiffPreviewBudget(100, 153).previewLineCap).toBe(7)
+  })
+})
+
+describe('ApprovalCard (BUG 1: embedded diff is complete or absent, never half-drawn)', () => {
+  // Invariant on the rendered card across every constrained height: if the
+  // inner DiffInline box draws a CREATE header, it ALSO draws its closing border
+  // (a complete box), and the count of inner `┌` and `└` corners is balanced.
+  // AND the [1]/[2]/[3] legend + confirm row ALWAYS survive — the diff is shed
+  // before either of those, never the other way round.
+  for (const rows of [16, 18, 20, 21, 22, 23, 24, 28, 40]) {
+    test(`rows=${rows}: the embedded diff is a complete box or omitted, legend always survives`, async () => {
+      const out = await renderToString(
+        <Box flexDirection="column">
+          <ApprovalCard
+            risk="low"
+            title="tool · write · needs approval"
+            command="config_validator/validator.py"
+            commandIsShell={false}
+            facts={[
+              { label: 'tool', value: 'write' },
+              { label: 'scope', value: 'session' },
+              { label: 'request', value: 'req-1' },
+              { label: 'confirmation', value: 'enter' },
+            ]}
+            note="untrusted policy: approve every call"
+            diffPreview={bigWritePreview()}
+            confirmLabel="enter approve · 2 session · 3 deny"
+          />
+        </Box>,
+        { columns: 116, rows },
+      )
+      const lines = out.split('\n')
+      const topCorners = lines.filter((l) => l.includes('┌')).length
+      const bottomCorners = lines.filter((l) => l.includes('└')).length
+      // Outer popup always draws one top + one bottom; the inner diff box, when
+      // present, adds exactly one more of each. Either way they are balanced —
+      // never a header-only box that adds a top with no matching bottom.
+      expect(topCorners).toBe(bottomCorners)
+      if (out.includes('CREATE')) {
+        // When the CREATE header shows, the inner box must be complete (2 of
+        // each corner) and show at least one diff line.
+        expect(topCorners).toBe(2)
+        expect(out).toMatch(/\+ line \d+ content/)
+      }
+      // The primary action legend + confirm row are NEVER the thing clipped —
+      // at every height, whether or not the diff is shown.
+      expect(out).toContain('[1] approve once')
+      expect(out).toContain('▸ enter approve')
+    })
+  }
+})

--- a/runtime/tests/tui/bash-output-ansi-consistency.test.tsx
+++ b/runtime/tests/tui/bash-output-ansi-consistency.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { BashOutputView } from '../../src/tui/tool-rendering.js'
+import { renderToAnsiString } from '../../src/utils/staticRender.js'
+
+// BUG 2 (MEDIUM): a Run/Bash stdout line that carries the PROGRAM'S OWN SGR
+// colors used to render inconsistently. Iter-26 wrapped every stdout line in
+// `<Text dimColor>`, but the program's own `ESC[39m`/`ESC[0m` resets terminate
+// the dim tone mid-line, so part of the line was raw program-color and the rest
+// fell back to the dim theme color — a half-dim / half-raw line, visually
+// inconsistent with its uniformly-dim plain siblings.
+//
+// FIX (option b — matches the live-shell `OutputLine` precedent, which never
+// applies dimColor OVER colored program output): a line that carries its OWN SGR
+// renders through `<Ansi>` so the program color is preserved intact; only PLAIN
+// lines (no SGR of their own) are dimmed. So a single report is never
+// half-dim / half-raw.
+
+// The true-color theme tone that `dimColor`/muted text resolves to in the
+// rendered output (the tone the plain sibling lines + the gutter carry). Used to
+// detect whether a dim color was injected INTO a program-colored line.
+const THEME_DIM_FG = '\x1b[38;2;'
+
+function plainExec(...stdoutLines: string[]): string {
+  return `${stdoutLines.join('\n')}\n\n[exec exit_code=0 wall_time=0.03s tokens=10]`
+}
+
+// The dim `  ⎿  ` continuation gutter prefixes the FIRST content row and is
+// ALWAYS dim (correctly). Strip it so the body-color assertions look only at the
+// stdout line content, not the intentionally-dim gutter. Rows without the gutter
+// glyph are returned unchanged.
+function bodyAfterGutter(row: string): string {
+  const idx = row.indexOf('⎿')
+  return idx === -1 ? row : row.slice(idx + 1)
+}
+
+describe('BashOutputView ANSI consistency (BUG 2: no half-dim/half-raw lines)', () => {
+  test('a program-colored stdout line keeps its OWN color and is NOT half-dimmed', async () => {
+    // The colored line carries its own ESC[31m…ESC[39m. The plain line carries
+    // no SGR of its own.
+    const content = plainExec(
+      '\x1b[31m[1] version\x1b[39m Expected type str',
+      'plain sibling line',
+    )
+    const ansi = await renderToAnsiString(<BashOutputView content={content} />, {
+      columns: 120,
+      rows: 20,
+      color: true,
+    })
+    // The program's red is preserved.
+    expect(ansi).toContain('\x1b[31m[1] version')
+    // Split the rendered output into rows and isolate the colored row.
+    const coloredRow = ansi
+      .split('\n')
+      .find((row) => row.includes('[1] version'))
+    expect(coloredRow).toBeDefined()
+    // The colored line BODY (after the always-dim gutter) must NOT have the dim
+    // theme foreground injected into it — that injection (after the program's
+    // `[1] version`) is exactly the half-dim break the old `<Text dimColor>`
+    // wrapper produced over the program text. With the fix the whole body
+    // renders in the program's own color, so no theme-dim fg appears in it.
+    expect(bodyAfterGutter(coloredRow!)).not.toContain(THEME_DIM_FG)
+  })
+
+  test('a PLAIN stdout line (no own SGR) is still dimmed', async () => {
+    const content = plainExec('plain line one', 'plain line two')
+    const ansi = await renderToAnsiString(<BashOutputView content={content} />, {
+      columns: 120,
+      rows: 20,
+      color: true,
+    })
+    // Plain lines carry the dim theme tone (they have no program color of their
+    // own to preserve).
+    const plainRow = ansi.split('\n').find((row) => row.includes('plain line one'))
+    expect(plainRow).toBeDefined()
+    expect(plainRow).toContain(THEME_DIM_FG)
+  })
+
+  test('REVERT-SENSITIVITY: colored line is uniform program color, plain line is uniform dim', async () => {
+    const content = plainExec(
+      '\x1b[31mERR\x1b[39m the rest of the colored line',
+      'a totally plain line',
+    )
+    const ansi = await renderToAnsiString(<BashOutputView content={content} />, {
+      columns: 120,
+      rows: 20,
+      color: true,
+    })
+    const coloredRow = ansi.split('\n').find((row) => row.includes('ERR'))
+    const plainRow = ansi.split('\n').find((row) => row.includes('totally plain'))
+    expect(coloredRow).toBeDefined()
+    expect(plainRow).toBeDefined()
+    // The colored line BODY is NOT broken into program-color + dim-theme halves
+    // (the old behavior injected `THEME_DIM_FG` right after `ERR`). The plain row
+    // IS dim. Against the reverted code the colored BODY would contain
+    // THEME_DIM_FG.
+    expect(bodyAfterGutter(coloredRow!)).not.toContain(THEME_DIM_FG)
+    expect(plainRow).toContain(THEME_DIM_FG)
+  })
+})

--- a/runtime/tests/tui/tool-rendering.test.tsx
+++ b/runtime/tests/tui/tool-rendering.test.tsx
@@ -140,6 +140,47 @@ describe("TUI tool rendering helpers", () => {
     expect(tool.renderToolUseMessage("raw")).toBe('{"value":"raw"}');
   });
 
+  test("BUG 3: TodoWrite header is a readable count + active item, NOT raw {\"todos\"} JSON", () => {
+    const tool = createTuiTool("TodoWrite");
+    const summary = tool.renderToolUseMessage({
+      todos: [
+        { content: "Creating package __init__.py", activeForm: "Creating package __init__.py", status: "completed" },
+        { content: "Wire the config validator", activeForm: "Wiring the config validator", status: "in_progress" },
+        { content: "Add tests", activeForm: "Adding tests", status: "pending" },
+      ],
+    });
+
+    // Human-readable: the total count + the in-progress item's name.
+    expect(summary).toContain("3 todos");
+    expect(summary).toContain("Wire the config validator");
+    // None of the garbled raw-JSON / truncation artifacts from the old generic
+    // branch (`{"todos":[{"activeForm":…__.py","status":"completed"},{…).`).
+    expect(summary).not.toContain('{"todos"');
+    expect(summary).not.toContain('"activeForm"');
+    expect(summary).not.toContain('"status"');
+    expect(summary).not.toMatch(/\.\)\.$/);
+    expect(summary).not.toContain("...");
+  });
+
+  test("BUG 3: TodoWrite header falls back to the first item when none is in progress, and pluralizes", () => {
+    const tool = createTuiTool("TodoWrite");
+    // Singular.
+    expect(
+      tool.renderToolUseMessage({ todos: [{ content: "Lone task", status: "pending" }] }),
+    ).toBe("1 todo · Lone task");
+    // No in-progress item → highlight the first todo.
+    expect(
+      tool.renderToolUseMessage({
+        todos: [
+          { content: "First", status: "pending" },
+          { content: "Second", status: "completed" },
+        ],
+      }),
+    ).toBe("2 todos · First");
+    // Empty list → just the count, no trailing separator.
+    expect(tool.renderToolUseMessage({ todos: [] })).toBe("0 todos");
+  });
+
   test("EditDiffView renders a capped (+a -r) stat line plus green/red changes", () => {
     const children = flatten(
       EditDiffView({

--- a/runtime/tests/tui/tool-result-routing.editSuccessSuppress.test.ts
+++ b/runtime/tests/tui/tool-result-routing.editSuccessSuppress.test.ts
@@ -87,3 +87,32 @@ describe("pickToolResultDispatch — edit/write success suppression (GAP #3)", (
     ).toBe("generic");
   });
 });
+
+// BUG 3: TodoWrite has no structured renderer; its boilerplate success body
+// ("Todos have been modified successfully. Ensure that you continue…") used to
+// render verbatim. Mirror the Edit/Write success suppression so it does not.
+// The live result string is copied from
+//   runtime/src/tools/TodoWriteTool/TodoWriteTool.ts (mapToolResultToToolResultBlockParam)
+describe("pickToolResultDispatch — TodoWrite success suppression (BUG 3)", () => {
+  const TODO_SUCCESS =
+    "Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable";
+
+  test("TodoWrite success boilerplate suppresses (no verbatim render alongside the call row)", () => {
+    expect(pickToolResultDispatch("TodoWrite", TODO_SUCCESS)).toBe("suppress");
+  });
+
+  test("TodoWrite success with the trailing verification nudge still suppresses", () => {
+    const withNudge = `${TODO_SUCCESS}\n\nNOTE: You just closed out 3+ tasks and none of them was a verification step.`;
+    expect(pickToolResultDispatch("TodoWrite", withNudge)).toBe("suppress");
+  });
+
+  test("a FAILED TodoWrite (different wording) does NOT suppress — renders through generic", () => {
+    expect(
+      pickToolResultDispatch("TodoWrite", "Error: invalid todo status 'foo'"),
+    ).toBe("generic");
+  });
+
+  test("suppression is tool-name scoped — a Bash result echoing the todo phrase is not suppressed", () => {
+    expect(pickToolResultDispatch("Bash", TODO_SUCCESS)).toBe("generic");
+  });
+});


### PR DESCRIPTION
## Iteration 28 — dynamic search-navigate round (4 bugs from a multi-file package scenario)

A config-validator package scenario (multi-file, large-file approval, program-colored output, TodoWrite) exposed 4 distinct bugs across the approval dialog, command output, and TodoWrite.

1. **(HIGH) Unterminated approval-diff box / blind approval.** The embedded `DiffInline` preview could clip after its header — open `┌`, `CREATE path +N -0`, then no body and no closing `└` — and at marginal heights clipped the `[1]/[2]/[3]` legend + confirm off the bottom, so the user approved a large write seeing zero content. `showPreview` was gated on `previewBudgetRows >= 2`, under-reserving the diff box's chrome. Extracted a pure `approvalDiffPreviewBudget` reserving full chrome (5 rows) + essential body, omitting the diff unless ≥1 line fits (threshold `>= 11`), and **always shedding the diff before the legend/confirm**.
2. **(MED) `$ ` shell-prompt prefix on file paths.** The approval card showed `$ path/to/file` for Write/Edit — reads as a command, duplicates the diff header. Added a `commandIsShell` signal; file tools drop the `$ ` and the redundant path line.
3. **(MED) Program-colored command output half-dim/half-raw.** After iter-26 dimmed stdout, a line with its own SGR had the dim terminated mid-line by the program's resets. Following the `OutputLine` precedent, lines with their own SGR render via `<Ansi>` (color preserved, leaking underline stripped); plain lines stay dim. Also fixed the preview width cap to measure **visible** width (`stringWidth`) instead of escape bytes.
4. **(MED) TodoWrite raw-JSON header.** TodoWrite had no TUI handling → header dumped `{"todos":[…]}` ending in a garbled `.).`, with boilerplate result shown verbatim. Added a `todoSummaryForInput` (`<count> todos · <in-progress/first>`) + result suppression mirroring Write/Edit (failed TodoWrite still renders).

The "duplicated legend" item was investigated and intentionally **not** changed (two distinct intentional rows, each test-pinned).

### Gate
Each revert-sensitive (reverting reds 7/3/2/4 tests). `npm run build` exit 0 · full `npm run test:unit` **13345 passed, 0 failures** · TUI startup smoke clean. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG