### PR TITLE
fix(tui): approval REQUEST fact label collision; nest empty (No output) under the ⎿ gutter

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1452,14 +1452,27 @@ export function ApprovalCard({
         {showFacts ? (
           <Box flexDirection="row" gap={2} flexWrap="wrap">
             {facts.map(fact => (
+              // Mirror the DiffInline gutter/code-cell split: the LABEL is a
+              // fixed cell (flexShrink={0}) so its text + the inter-cell gap are
+              // never squeezed, and ONLY the VALUE flexes/truncates. Without the
+              // pinned label, a long value (e.g. a `call_…` request id) made Yoga
+              // eat the gap and drop the label's last char to a stray wrap row
+              // (`REQUEScall_…` + a lone `T`). truncate-middle keeps a long call
+              // id's `call_` prefix + trailing chars instead of just the head.
               <Box
                 key={fact.label}
                 flexDirection="row"
                 gap={1}
                 width={fact.label === 'network' || fact.label === 'net' ? 30 : 22}
               >
-                <ThemedText color="muted3">{fact.label.toUpperCase()}</ThemedText>
-                <ThemedText color={fact.color ?? 'text2'} wrap="truncate-end">{fact.value}</ThemedText>
+                <Box flexShrink={0}>
+                  <ThemedText color="muted3">{fact.label.toUpperCase()}</ThemedText>
+                </Box>
+                <Box flexShrink={1} minWidth={0}>
+                  <ThemedText color={fact.color ?? 'text2'} wrap="truncate-middle">
+                    {fact.value}
+                  </ThemedText>
+                </Box>
               </Box>
             ))}
           </Box>

--- a/runtime/src/tui/tool-rendering.tsx
+++ b/runtime/src/tui/tool-rendering.tsx
@@ -497,23 +497,6 @@ export function BashOutputView({
   const stderrTrimmed = stderrRaw.trim();
   // Capped stdout: first N lines + "… +K lines". On a non-zero exit the stderr
   // is appended (also capped) so the failure reason is visible inline.
-  const isSilent = stdoutTrimmed.length === 0 && stderrTrimmed.length === 0;
-  if (isSilent) {
-    return (
-      <Text dimColor>
-        {isFailure ? "(no output, non-zero exit)" : "(No output)"}
-      </Text>
-    );
-  }
-  const stdoutCap = capPreviewLines(stdoutTrimmed, BASH_PREVIEW_MAX_LINES);
-  const showStderr = isFailure && stderrTrimmed.length > 0;
-  const stderrCap = showStderr
-    ? capPreviewLines(stderrTrimmed, BASH_PREVIEW_MAX_LINES)
-    : null;
-  // Compact non-zero-exit indicator. The plain exec result folds stderr into
-  // stdout (no separate stderr stream), so on a failed command with no tagged
-  // stderr we still surface the exit code as a small red note.
-  const showExitNote = isFailure && stderrCap === null;
   // The command output is rendered behind the same `⎿` continuation gutter the
   // file-changed summary, Read/Search results, and the V2Tool `ToolResultLines`
   // use, so the stdout/stderr body visually nests UNDER its `● Run(...)` call
@@ -525,6 +508,33 @@ export function BashOutputView({
   // stays red so a failure is still visually distinct.
   const glyphs = selectAgenCTuiGlyphs();
   const responseGutter = `  ${glyphs.responseGutter}  `;
+  const isSilent = stdoutTrimmed.length === 0 && stderrTrimmed.length === 0;
+  if (isSilent) {
+    // The empty `(No output)` line uses the SAME gutter row layout as the
+    // non-empty branch so it nests under the `● Run(...)` row at the gutter
+    // column too — not flush at the bullet column.
+    return (
+      <Box flexDirection="row">
+        <Box flexShrink={0}>
+          <Text dimColor>{responseGutter}</Text>
+        </Box>
+        <Box flexDirection="column" flexGrow={1}>
+          <Text dimColor>
+            {isFailure ? "(no output, non-zero exit)" : "(No output)"}
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+  const stdoutCap = capPreviewLines(stdoutTrimmed, BASH_PREVIEW_MAX_LINES);
+  const showStderr = isFailure && stderrTrimmed.length > 0;
+  const stderrCap = showStderr
+    ? capPreviewLines(stderrTrimmed, BASH_PREVIEW_MAX_LINES)
+    : null;
+  // Compact non-zero-exit indicator. The plain exec result folds stderr into
+  // stdout (no separate stderr stream), so on a failed command with no tagged
+  // stderr we still surface the exit code as a small red note.
+  const showExitNote = isFailure && stderrCap === null;
   return (
     <Box flexDirection="row">
       <Box flexShrink={0}>

--- a/runtime/tests/tools/tool-rendering-bash.test.tsx
+++ b/runtime/tests/tools/tool-rendering-bash.test.tsx
@@ -134,20 +134,28 @@ function flattenBash(
 describe("BashOutputView — capped preview visual contract", () => {
   test("renders no-output indicator when both stdout and stderr are empty (zero exit)", () => {
     // Capped preview: silent success collapses to a single dim "(No output)".
+    // The line now nests behind the `⎿` continuation gutter (like the non-empty
+    // branch), so the text lives in a child <Text> under the gutter row layout
+    // rather than as the root node's direct child.
     const node = BashOutputView({
       content: "<bash-stdout></bash-stdout><bash-stderr></bash-stderr>[exit_code=0]",
-    }) as { props: { children?: unknown; dimColor?: boolean } };
-    expect(node.props.children).toBe("(No output)");
-    expect(node.props.dimColor).toBe(true);
+    });
+    const flat = flattenBash(node);
+    const noOutput = flat.find((child) => child.props?.children === "(No output)");
+    expect(noOutput).toBeDefined();
+    expect(noOutput!.props.dimColor).toBe(true);
   });
 
   test("silent non-zero exit notes the failed exit instead of a metadata line", () => {
     // The raw [exit_code=...] metadata block is no longer surfaced; a silent
-    // failure is summarized inline instead.
+    // failure is summarized inline instead, nested behind the gutter.
     const node = BashOutputView({
       content: "<bash-stdout></bash-stdout>[exit_code=1]",
-    }) as { props: { children?: unknown } };
-    expect(node.props.children).toBe("(no output, non-zero exit)");
+    });
+    const flat = flattenBash(node);
+    expect(
+      flat.some((child) => child.props?.children === "(no output, non-zero exit)"),
+    ).toBe(true);
   });
 
   test("oversized single stdout line is width-capped with a [N chars truncated] marker", () => {

--- a/runtime/tests/tui/approval-card-layout.test.tsx
+++ b/runtime/tests/tui/approval-card-layout.test.tsx
@@ -135,6 +135,83 @@ describe('ApprovalCard layout (tool-approval popup)', () => {
     expect(out.toUpperCase()).not.toContain('BASH')
   })
 
+  // ---------------------------------------------------------------------------
+  // Meta-fact row: a long fact VALUE must never squeeze its own LABEL.
+  //
+  // The medium-risk popup shows a TOOL · SCOPE · REQUEST · CONFIRMATION fact grid.
+  // Each fact is a fixed `width={22}` row. Before the fix, the label had no
+  // flexShrink protection, so a long REQUEST value (a `call_…` id, ~15 chars)
+  // overflowed the 22-col cell and Yoga squeezed the unprotected LABEL — dropping
+  // its last char to a stray wrap row and eating the label/value gap, producing
+  // `REQUEScall_…` with a lone `T` on the next line. The fix pins the label
+  // (flexShrink={0}) and lets only the value flex/truncate (truncate-middle).
+  // ---------------------------------------------------------------------------
+  function renderLongRequestApproval(rows = 40, columns = 116): Promise<string> {
+    return renderToString(
+      <Box flexDirection="column">
+        <ApprovalCard
+          risk="low"
+          title="tool · write · medium-risk approval"
+          command="primes.ts"
+          facts={[
+            { label: 'tool', value: 'write' },
+            { label: 'scope', value: 'medium', color: 'warning' },
+            // A long opaque call id, like the real `request.id`.
+            { label: 'request', value: 'call_6d2a5e863dabc1234567890' },
+            { label: 'confirmation', value: 'enter' },
+          ]}
+          note="untrusted policy: approve every call"
+          confirmLabel="enter approve · 2 session · 3 deny"
+        />
+      </Box>,
+      { columns, rows },
+    )
+  }
+
+  test('a long REQUEST fact value keeps its label whole and separated by a gap', async () => {
+    const out = await renderLongRequestApproval()
+
+    // The literal label 'REQUEST' is present, intact (its final 'T' not dropped).
+    expect(out).toContain('REQUEST')
+
+    // The row that carries the label is found, and the label is NOT immediately
+    // jammed against the value: against the pre-fix code the label collided as
+    // `REQUEScall_…` (no 'REQUEST', no gap), with a stray lone 'T' wrap row.
+    const lines = out.split('\n')
+    const requestRow = lines.find((line) => line.includes('REQUEST'))
+    expect(requestRow).toBeDefined()
+    // The broken collision `REQUEScall` must never appear (its tell-tale shape).
+    expect(out).not.toContain('REQUEScall')
+    // There is a gap (whitespace) between the whole 'REQUEST' label and the value.
+    expect(/REQUEST\s+\S/u.test(requestRow ?? '')).toBe(true)
+
+    // Revert-sensitivity: the pre-fix bug wrapped the dropped char onto its own
+    // line — a row whose only content is a lone 'T'. That orphan must not exist.
+    const orphanCharRow = lines.find((line) => line.trim() === 'T')
+    expect(orphanCharRow).toBeUndefined()
+  })
+
+  test('the long request value is shown but middle-truncated (keeps the call_ head)', async () => {
+    const out = await renderLongRequestApproval()
+    // The value middle-truncates, so the stable `call_` prefix survives and an
+    // ellipsis marks the elision (rather than dropping the head).
+    expect(out).toContain('call_')
+    expect(out).toContain('…')
+  })
+
+  test('the other short facts (TOOL/SCOPE/CONFIRMATION) still render whole', async () => {
+    const out = await renderLongRequestApproval()
+    const upper = out.toUpperCase()
+    // All sibling labels render intact and uncollided next to their short values.
+    expect(upper).toContain('TOOL')
+    expect(upper).toContain('SCOPE')
+    expect(upper).toContain('CONFIRMATION')
+    // Their short values are present and unbroken.
+    expect(out).toContain('write')
+    expect(out).toContain('medium')
+    expect(out).toContain('enter')
+  })
+
   test('high-risk typed-confirmation variant still bounds its body and keeps the prompt', async () => {
     const out = await renderToString(
       <ApprovalCard

--- a/runtime/tests/tui/bash-output-ansi-consistency.test.tsx
+++ b/runtime/tests/tui/bash-output-ansi-consistency.test.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { describe, expect, test } from 'vitest'
 
 import { BashOutputView } from '../../src/tui/tool-rendering.js'
-import { renderToAnsiString } from '../../src/utils/staticRender.js'
+import { renderToAnsiString, renderToString } from '../../src/utils/staticRender.js'
+import { selectAgenCTuiGlyphs } from '../../src/tui/glyphs.js'
 
 // BUG 2 (MEDIUM): a Run/Bash stdout line that carries the PROGRAM'S OWN SGR
 // colors used to render inconsistently. Iter-26 wrapped every stdout line in
@@ -97,5 +98,74 @@ describe('BashOutputView ANSI consistency (BUG 2: no half-dim/half-raw lines)', 
     // THEME_DIM_FG.
     expect(bodyAfterGutter(coloredRow!)).not.toContain(THEME_DIM_FG)
     expect(plainRow).toContain(THEME_DIM_FG)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// BUG 3: empty command output `(No output)` must nest under the `⎿` gutter.
+//
+// iter-26 nested NON-EMPTY Bash/Run stdout under the `● Run(...)` call row with a
+// `  ⎿  ` gutter, but the silent/empty branch still returned a BARE
+// `<Text dimColor>(No output)</Text>` with no gutter — so `(No output)` rendered
+// flush at the bullet column instead of nested at the gutter column like every
+// other tool-result body. The fix renders the silent line behind the SAME gutter
+// row layout the non-empty branch uses.
+// ---------------------------------------------------------------------------
+
+// A plain-exec trailer with NO stdout/stderr (the silent case).
+const EMPTY_EXEC = '\n\n[exec exit_code=0 wall_time=0.03s tokens=10]'
+const EMPTY_EXEC_FAILURE = '\n\n[exec exit_code=1 wall_time=0.03s tokens=10]'
+
+describe('BashOutputView empty-output gutter (BUG 3: (No output) nests under ⎿)', () => {
+  test('a silent zero-exit command nests `(No output)` under the gutter', async () => {
+    const out = await renderToString(<BashOutputView content={EMPTY_EXEC} />, {
+      columns: 120,
+      rows: 20,
+    })
+    const gutter = selectAgenCTuiGlyphs().responseGutter
+    const row = out.split('\n').find((line) => line.includes('(No output)'))
+    expect(row).toBeDefined()
+    // The line carries the `⎿` continuation gutter (it nests under `● Run(...)`).
+    // Against the pre-fix code the silent branch returned a bare `(No output)`
+    // with NO gutter glyph on its row.
+    expect(row).toContain(gutter)
+    // The gutter precedes the text — i.e. the text is nested at the gutter
+    // column, not flush before it.
+    expect(row!.indexOf(gutter)).toBeLessThan(row!.indexOf('(No output)'))
+  })
+
+  test('a silent non-zero-exit command nests its `(no output, non-zero exit)` under the gutter', async () => {
+    const out = await renderToString(<BashOutputView content={EMPTY_EXEC_FAILURE} />, {
+      columns: 120,
+      rows: 20,
+    })
+    const gutter = selectAgenCTuiGlyphs().responseGutter
+    const row = out
+      .split('\n')
+      .find((line) => line.includes('(no output, non-zero exit)'))
+    expect(row).toBeDefined()
+    expect(row).toContain(gutter)
+    expect(row!.indexOf(gutter)).toBeLessThan(
+      row!.indexOf('(no output, non-zero exit)'),
+    )
+  })
+
+  test('the empty-output gutter aligns with the non-empty-output gutter column', async () => {
+    const gutter = selectAgenCTuiGlyphs().responseGutter
+    const empty = await renderToString(<BashOutputView content={EMPTY_EXEC} />, {
+      columns: 120,
+      rows: 20,
+    })
+    const nonEmpty = await renderToString(
+      <BashOutputView content={`hello world\n\n[exec exit_code=0 wall_time=0.03s tokens=10]`} />,
+      { columns: 120, rows: 20 },
+    )
+    const emptyRow = empty.split('\n').find((l) => l.includes('(No output)'))
+    const nonEmptyRow = nonEmpty.split('\n').find((l) => l.includes('hello world'))
+    expect(emptyRow).toBeDefined()
+    expect(nonEmptyRow).toBeDefined()
+    // The gutter glyph sits at the SAME column in both — the empty line is no
+    // longer flush at the bullet column while the real output sits at the gutter.
+    expect(emptyRow!.indexOf(gutter)).toBe(nonEmptyRow!.indexOf(gutter))
   })
 })

--- a/runtime/tests/tui/tool-rendering.test.tsx
+++ b/runtime/tests/tui/tool-rendering.test.tsx
@@ -45,6 +45,26 @@ function flatten(node: unknown): ChildElement[] {
     );
 }
 
+/** Recursive depth-first find for an element matching `pred` anywhere in the
+ * subtree — used for bodies nested several Box levels deep (e.g. the gutter row
+ * layout that wraps the silent "(No output)" line). */
+function findDeep(
+  node: unknown,
+  pred: (el: ChildElement) => boolean,
+): ChildElement | undefined {
+  if (!node || typeof node !== "object") return undefined;
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const hit = findDeep(item, pred);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+  const el = node as ChildElement;
+  if (el.props && pred(el)) return el;
+  return findDeep(el.props?.children, pred);
+}
+
 describe("TUI tool rendering helpers", () => {
   test("createTuiTools merges canonical tools with nonblank dynamic names, dedupes, and sorts", () => {
     const tools = createTuiTools([
@@ -204,12 +224,19 @@ describe("TUI tool rendering helpers", () => {
   test("BashOutputView marks silent (zero-exit) output as (No output)", () => {
     // Capped preview: silent success collapses to a single dim "(No output)"
     // line; the raw [duration_ms=...] metadata block is no longer surfaced.
+    // The line now nests behind the `⎿` continuation gutter (matching the
+    // non-empty branch), so the dim "(No output)" <Text> lives a couple Box
+    // levels deep rather than as the root node's direct child.
     const node = BashOutputView({
       content: "<bash-stdout></bash-stdout>[duration_ms=42]",
-    }) as { readonly props: ChildProps };
+    });
 
-    expect(node.props.children).toBe("(No output)");
-    expect(node.props.dimColor).toBe(true);
+    const noOutput = findDeep(
+      node,
+      (el) => el.props.children === "(No output)",
+    );
+    expect(noOutput).toBeDefined();
+    expect(noOutput!.props.dimColor).toBe(true);
   });
 
   test("ToolErrorView falls back to raw content when no error envelope exists", () => {


### PR DESCRIPTION
## Iteration 29 — dynamic multifile-refactor round

A units-conversion refactor scenario surfaced 7 bugs → 3 distinct. Two fixed here; the third deferred.

### Fixed
1. **(HIGH) Approval REQUEST fact label collision.** In the meta-fact row (TOOL · SCOPE · REQUEST · CONFIRMATION), the long tool-call id made Yoga squeeze the unprotected `REQUEST` label — its final `T` wrapped to a stray row and the value jammed against the truncation (`REQUEScall_…`). Pinned the label `flexShrink={0}` and put the value in `flexShrink={1} minWidth={0}` with `truncate-middle` (keeps the `call_` head + tail).
2. **(MED) Empty `(No output)` not nested under the `⎿` gutter.** iter-26 nested Bash stdout under the call row but only the non-empty branch; the silent branch still rendered flush at the bullet column. Gave it the same gutter row layout.

Each revert-sensitive. `npm run build` exit 0 · full `npm run test:unit` **13351 passed, 0 failures** · TUI startup smoke clean. No tmux.

### Deferred
A DiffInline body line at exactly the code-cell width spilling one char past the right border was investigated with an exhaustive headless repro (dual-box, exact evidence line, all widths) — **zero spills reproduce**. Like the earlier scroll-clamp variant, it's a Yoga flex-rounding ±1 that only manifests in the live PTY layout, not headless. Both DiffInline width variants share this root and want a deterministic-width refactor validated by a live repro harness — not a blind change to the diff card.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG