### PR TITLE
feat(tui): accurate WORKSPACE file count + auto-reveal agent-created directories

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -185,7 +185,11 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
   const viewport = projectTreeViewport(snapshot.rows, maxTreeRows);
   const visibleRows = viewport.rows
     .map((row) => row.selected ? { ...row, focused } : row);
-  const itemCount = snapshot.rows.filter((row) => row.kind === "file" || row.kind === "directory").length;
+  // Drive the WORKSPACE count from the project's real file total (carried on the
+  // snapshot, collapse-independent) rather than the currently-visible rows — a
+  // collapsed directory hides its children from the rows, which would undercount
+  // a multi-file project (e.g. an agent-created subpackage showing "WORKSPACE 1").
+  const itemCount = snapshot.fileCount;
   const dirtyCount = snapshot.rows.filter((row) => row.gitState && row.gitState !== "clean").length;
   const glyphs = selectAgenCTuiGlyphs();
 

--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -20,6 +20,7 @@ const EMPTY_SNAPSHOT: ProjectTreeSnapshot = Object.freeze({
   cursorPath: null,
   activePath: null,
   expandedPaths: [],
+  fileCount: 0,
 });
 const DEFAULT_VIEWPORT_ROWS = 20;
 const WORKSPACE_TREE_IGNORE = [
@@ -63,6 +64,11 @@ export class ProjectTreeStore {
   #refreshVersion = 0;
   #refreshTimer: ReturnType<typeof setInterval> | null = null;
   #started = false;
+  // Directory paths known at the last successful scan, used to detect directories
+  // that newly appeared mid-session (an agent-created subpackage) so they can be
+  // auto-revealed. Stays null until the first scan establishes the baseline — the
+  // initial repo tree must NOT auto-expand (that would explode a large repo).
+  #knownDirectories: ReadonlySet<string> | null = null;
 
   constructor(cwd = process.cwd(), refreshIntervalMs = 5_000) {
     this.#cwd = cwd;
@@ -108,6 +114,7 @@ export class ProjectTreeStore {
         collectGitStatus(this.#cwd),
       ]);
       if (version !== this.#refreshVersion) return;
+      this.#autoExpandNewDirectories(paths);
       this.#paths = paths;
       this.#gitStatus = gitStatus;
       this.#cursorPath = this.#cursorPath ?? firstFilePath(paths) ?? paths[0] ?? null;
@@ -304,6 +311,32 @@ export class ProjectTreeStore {
     }
   }
 
+  /**
+   * Auto-reveal directories that appeared since the last scan. When AgenC writes
+   * files into a NEW subdirectory mid-session (e.g. a `converters/` subpackage),
+   * that directory would otherwise render collapsed and the freshly-written files
+   * would stay hidden in the tree. Expanding only the directories that newly
+   * appeared keeps this scoped to agent-created/just-modified dirs — the initial
+   * repo tree is never force-expanded (the first scan only records the baseline),
+   * so large repos do not blow up. It is a one-time reveal on appearance, not a
+   * persistent override: if the user later collapses the directory, the next scan
+   * no longer sees it as "new", so the collapse sticks.
+   */
+  #autoExpandNewDirectories(nextPaths: readonly string[]): void {
+    const nextDirectories = collectDirectoryPaths(nextPaths);
+    // First successful scan only establishes the baseline; do not auto-expand the
+    // existing repo tree.
+    if (this.#knownDirectories === null) {
+      this.#knownDirectories = nextDirectories;
+      return;
+    }
+    const known = this.#knownDirectories;
+    for (const directory of nextDirectories) {
+      if (!known.has(directory)) this.#expandedPaths.add(directory);
+    }
+    this.#knownDirectories = nextDirectories;
+  }
+
   #rowForPath(pathValue: string): ProjectTreeRow | null {
     return this.#snapshot.rows.find((row) => row.path === pathValue) ?? null;
   }
@@ -367,6 +400,10 @@ export class ProjectTreeStore {
       cursorPath: this.#cursorPath,
       activePath: this.#activePath,
       expandedPaths: [...this.#expandedPaths],
+      // Count the real project files (collapse-independent) rather than the
+      // currently-visible rows, so the WORKSPACE header never undercounts a
+      // project whose files sit inside a collapsed directory.
+      fileCount: countFilePaths(this.#paths),
     };
     for (const listener of this.#listeners) listener();
   }
@@ -416,6 +453,46 @@ function normalizedPathSet(paths: Iterable<string>): Set<string> {
 
 function firstFilePath(paths: readonly string[]): string | null {
   return paths.find((item) => item.length > 0 && !item.endsWith("/")) ?? null;
+}
+
+/**
+ * Count the file entries in a workspace path list. Directory entries carry a
+ * trailing slash (see `normalizeScannedPath`); git-tracked paths are always
+ * files. Counting files (not directories) keeps the WORKSPACE header reading as
+ * "how many files exist", which is what the at-a-glance anchor is meant to show.
+ */
+function countFilePaths(paths: readonly string[]): number {
+  let count = 0;
+  for (const item of paths) {
+    if (item.length > 0 && !item.endsWith("/")) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Derive every directory path implied by a workspace path list. Git-tracked
+ * paths are files, so a directory appears only as an ANCESTOR of a file; the
+ * recursive scanner may also list a directory explicitly with a trailing slash.
+ * Both forms collapse to the same slash-free relative directory path here, so a
+ * directory's "is it new this scan" status is stable across the git and scanner
+ * fallbacks (matching how `addPathItems` materializes directory rows).
+ */
+function collectDirectoryPaths(paths: readonly string[]): ReadonlySet<string> {
+  const directories = new Set<string>();
+  for (const rawPath of paths) {
+    if (rawPath.length === 0 || rawPath.startsWith("../")) continue;
+    const isDirectoryEntry = rawPath.endsWith("/");
+    const trimmed = rawPath.replace(/\/+$/u, "");
+    if (trimmed.length === 0) continue;
+    const segments = trimmed.split("/").filter(Boolean);
+    // For a file, every parent segment is a directory; for an explicit directory
+    // entry, the entry itself is also a directory.
+    const lastDirectoryIndex = isDirectoryEntry ? segments.length : segments.length - 1;
+    for (let index = 1; index <= lastDirectoryIndex; index += 1) {
+      directories.add(segments.slice(0, index).join("/"));
+    }
+  }
+  return directories;
 }
 
 function parentPath(value: string): string | null {

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -125,6 +125,14 @@ export type ProjectTreeSnapshot = {
   readonly cursorPath: string | null;
   readonly activePath: string | null;
   readonly expandedPaths: readonly string[];
+  /**
+   * Total number of FILES the project tree knows about, independent of which
+   * directories are currently expanded. The WORKSPACE header count is driven by
+   * this — counting only the currently-visible rows undercounts a project whose
+   * files live inside a collapsed directory (e.g. an agent-created subpackage),
+   * which is the "what exists" anchor the header is meant to convey.
+   */
+  readonly fileCount: number;
 };
 
 export type SearchMatch = {

--- a/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
@@ -72,6 +72,7 @@ const explorerHarness = vi.hoisted(() => {
       cursorPath: "src",
       activePath: "src/nested/app.ts",
       expandedPaths: ["src"],
+      fileCount: 1,
       rows: [
         {
           id: "src",
@@ -361,6 +362,7 @@ describe("ProjectExplorer interactions", () => {
       cursorPath: "src",
       activePath: "src/nested/app.ts",
       expandedPaths: ["src"],
+      fileCount: 1,
       rows: [
         directoryRow("src"),
         fileRow("src/nested/app.ts", "app.ts", 3, { active: true }),
@@ -416,6 +418,7 @@ describe("ProjectExplorer interactions", () => {
       cursorPath: "src/file-20.ts",
       activePath: null,
       expandedPaths: ["src"],
+      fileCount: rows.length,
       rows,
     };
     const { output, root, stdin, stdout } = await renderExplorer({ width: 48 });

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -472,6 +472,124 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("counts every project file in the WORKSPACE total even when a directory is collapsed", async () => {
+    // BUG (undercount): the WORKSPACE header used to count only the currently-
+    // VISIBLE tree rows. A collapsed directory hides its children from the rows,
+    // so a multi-file subpackage (e.g. an agent-created `converters/`) would read
+    // "WORKSPACE 1" while several files actually exist. The snapshot now carries a
+    // collapse-independent `fileCount` driven from the real path set.
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-file-count-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "converters"), { recursive: true });
+      await writeFile(join(repo, "README.md"), "readme\n", "utf8");
+      await writeFile(join(repo, "converters", "json.ts"), "json\n", "utf8");
+      await writeFile(join(repo, "converters", "yaml.ts"), "yaml\n", "utf8");
+      await writeFile(join(repo, "converters", "toml.ts"), "toml\n", "utf8");
+
+      await store.refresh();
+      // Leave `converters` collapsed: it is NOT in expandedPaths, so its three
+      // files are absent from the visible rows.
+      const snapshot = store.getSnapshot();
+      expect(snapshot.expandedPaths).not.toContain("converters");
+
+      const visibleFileRows = snapshot.rows.filter((row) => row.kind === "file").length;
+      // Only README.md is a visible file row while converters/ stays collapsed.
+      expect(visibleFileRows).toBe(1);
+
+      // The header count must reflect the 4 real files (README.md + 3 converters),
+      // not the single visible file row. Revert-sensitivity: the old behavior
+      // (counting visible file+directory rows) reported 2 here (README.md +
+      // converters/), undercounting the four-file project — this assertion fails
+      // against that code.
+      expect(snapshot.fileCount).toBe(4);
+      expect(snapshot.fileCount).toBeGreaterThan(visibleFileRows);
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("auto-expands a directory the agent creates mid-session without disturbing pre-existing collapsed dirs", async () => {
+    // UX: when AgenC writes files into a NEW subdirectory during the session, the
+    // directory must reveal so the just-written files are visible in the tree —
+    // the user should SEE what the agent built without manually expanding. Scope:
+    // only directories that newly APPEARED since the baseline scan are revealed,
+    // so a pre-existing collapsed directory stays collapsed (no large-repo blowup).
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-auto-expand-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      // Baseline: an existing collapsed directory and a root file. The first scan
+      // only records the baseline — it must NOT auto-expand the existing tree.
+      await mkdir(join(repo, "existing"), { recursive: true });
+      await writeFile(join(repo, "existing", "old.ts"), "old\n", "utf8");
+      await writeFile(join(repo, "README.md"), "readme\n", "utf8");
+
+      await store.refresh();
+      expect(store.getSnapshot().expandedPaths).not.toContain("existing");
+
+      // The agent creates a brand-new subpackage with files mid-session.
+      await mkdir(join(repo, "converters"), { recursive: true });
+      await writeFile(join(repo, "converters", "json.ts"), "json\n", "utf8");
+      await writeFile(join(repo, "converters", "yaml.ts"), "yaml\n", "utf8");
+
+      await store.refresh();
+      const snapshot = store.getSnapshot();
+      const rowPaths = snapshot.rows.map((row) => row.path);
+
+      // The newly-created directory is auto-expanded and its new files are visible.
+      // Revert-sensitivity: without the auto-expand, `converters` defaults to
+      // collapsed, so it is absent from expandedPaths and its two files never
+      // appear as rows — these three assertions fail against that code.
+      expect(snapshot.expandedPaths).toContain("converters");
+      expect(rowPaths).toContain("converters/json.ts");
+      expect(rowPaths).toContain("converters/yaml.ts");
+
+      // User-control / scope guard: the pre-existing directory is NOT force-
+      // expanded, and its child stays hidden.
+      expect(snapshot.expandedPaths).not.toContain("existing");
+      expect(rowPaths).not.toContain("existing/old.ts");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("does not re-expand a directory the user collapsed after it was auto-revealed", async () => {
+    // Preserve user control: auto-expand is a one-time reveal on a directory's
+    // first appearance, not a persistent override. Once the user collapses an
+    // agent-created directory, a later refresh must not fight them by re-expanding.
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-auto-expand-respect-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await writeFile(join(repo, "README.md"), "readme\n", "utf8");
+      await store.refresh();
+
+      // Agent creates a new directory → auto-revealed.
+      await mkdir(join(repo, "pkg"), { recursive: true });
+      await writeFile(join(repo, "pkg", "a.ts"), "a\n", "utf8");
+      await store.refresh();
+      expect(store.getSnapshot().expandedPaths).toContain("pkg");
+
+      // User collapses it.
+      store.collapse("pkg");
+      expect(store.getSnapshot().expandedPaths).not.toContain("pkg");
+
+      // A later refresh (the directory still exists, just not "new") must respect
+      // the collapse. Revert-sensitivity: a force-expand-on-every-refresh design
+      // would re-add `pkg` here and fail this assertion.
+      await writeFile(join(repo, "pkg", "b.ts"), "b\n", "utf8");
+      await store.refresh();
+      expect(store.getSnapshot().expandedPaths).not.toContain("pkg");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("navigates, expands, collapses, and reveals project tree rows", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-navigation-"));
     const store = new ProjectTreeStore(repo, 0);


### PR DESCRIPTION
## Iteration 30 — workspace-tree UX improvements (surfaced twice in multi-file rounds)

Two gaps that recurred across the search-navigate and multifile-refactor dynamic rounds, where AgenC builds a package in a subdirectory.

### 1. Accurate `WORKSPACE N` count
The header undercounted (`WORKSPACE 1` for a multi-file project) because it filtered the **visible** rows, and a collapsed directory's children aren't in those rows. Added a collapse-independent `fileCount` to the tree snapshot (counts all scanned file paths); the header reads that now.

### 2. Auto-reveal agent-created directories
Files the agent wrote into a new subdirectory stayed hidden (the dir rendered collapsed), so a refactor's fresh package only showed in the transcript. Added `#autoExpandNewDirectories`: each scan diffs the directory set vs the prior baseline and expands only directories that **newly appeared**.

**Scoped for safety:** `#knownDirectories` starts `null`, so the *first* scan only records the baseline — the initial repo tree is never force-expanded (no large-repo blowup). Only a subpackage appearing **mid-session** (agent-created) is revealed, as a **one-time reveal** — once known, later scans don't touch its expand state, so a user's manual collapse sticks.

### Gate
Both revert-sensitive (reverting the count reds the collapsed-count test; disabling auto-expand reds the reveal test, which also asserts pre-existing collapsed dirs stay collapsed and user re-collapse sticks). `npm run build` exit 0 · full `npm run test:unit` **13354 passed, 0 failures** · TUI startup smoke clean. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG