### PR TITLE
feat(tui): failure-aware Run output cap keeps the trailing verdict/exception

### DIFF
--- a/runtime/src/tui/tool-rendering.tsx
+++ b/runtime/src/tui/tool-rendering.tsx
@@ -380,18 +380,70 @@ function truncatePreviewWidth(line: string): string {
 }
 
 /**
+ * Result of capping a block for the `⎿`-gutter preview. `lines` is the HEAD
+ * block (rendered first), `remaining` is the count of HIDDEN middle lines
+ * surfaced as a `… +K lines` elision, and `tailLines` (when non-empty) is the
+ * TAIL block rendered AFTER the elision. For the head-only success cap
+ * `tailLines` is empty, so the elision lands after `lines` exactly as before.
+ */
+interface CappedPreview {
+  readonly lines: readonly string[];
+  readonly remaining: number;
+  readonly tailLines: readonly string[];
+}
+
+/**
  * Cap a block to the first `maxLines` non-trailing-whitespace lines (each line
  * also width-capped), appending a "… +K lines" continuation when the block is
  * longer. Matches the common CLI-agent `output_lines` convention.
  */
-function capPreviewLines(
+function capPreviewLines(value: string, maxLines: number): CappedPreview {
+  const all = value.replace(/\s+$/, "").split("\n").map(truncatePreviewWidth);
+  if (all.length <= maxLines)
+    return { lines: all, remaining: 0, tailLines: [] };
+  return {
+    lines: all.slice(0, maxLines),
+    remaining: all.length - maxLines,
+    tailLines: [],
+  };
+}
+
+/**
+ * Failure-aware cap. For a FAILED command the diagnostic payload — the
+ * `AssertionError:` / `Traceback` exception line and the
+ * `Ran N tests` / `FAILED (failures=1)` verdict — lives at the END of the
+ * output, so a head-only cap truncates exactly the lines a developer needs in
+ * an error→diagnose→fix loop. This keeps the same ~`maxLines` inline footprint
+ * but splits it into a HEAD block (early context: what ran) and a TAIL block
+ * (the exception + verdict), with the hidden middle surfaced as `… +K lines`.
+ *
+ * Reused for both the stdout failure cap (the live-daemon path folds
+ * stdout+stderr into one stream) and the stderr failure cap (the envelope path
+ * carries the traceback there). When the block already fits within `maxLines`
+ * it returns the full block head-only (no elision), identical to
+ * `capPreviewLines`.
+ */
+function capPreviewLinesHeadTail(
   value: string,
   maxLines: number,
-): { readonly lines: readonly string[]; readonly remaining: number } {
+  headLines: number,
+): CappedPreview {
   const all = value.replace(/\s+$/, "").split("\n").map(truncatePreviewWidth);
-  if (all.length <= maxLines) return { lines: all, remaining: 0 };
-  return { lines: all.slice(0, maxLines), remaining: all.length - maxLines };
+  if (all.length <= maxLines)
+    return { lines: all, remaining: 0, tailLines: [] };
+  // Clamp the head so at least one tail line always survives, then give the
+  // remainder of the budget to the tail (where the verdict/exception live).
+  const head = Math.max(1, Math.min(headLines, maxLines - 1));
+  const tail = maxLines - head;
+  return {
+    lines: all.slice(0, head),
+    remaining: all.length - head - tail,
+    tailLines: all.slice(all.length - tail),
+  };
 }
+
+/** Head lines reserved for the failure-aware head+tail cap (tail gets the rest). */
+const BASH_PREVIEW_FAILURE_HEAD_LINES = 2;
 
 /**
  * Live `exec_command` trailer line, e.g.
@@ -526,10 +578,25 @@ export function BashOutputView({
       </Box>
     );
   }
-  const stdoutCap = capPreviewLines(stdoutTrimmed, BASH_PREVIEW_MAX_LINES);
+  // On a FAILED command the verdict/exception lives at the END of the output,
+  // so cap head+tail (keep early context AND the trailing reason) instead of
+  // head-only. Success stays byte-identical (head-only). This applies to BOTH
+  // the stdout cap — the live-daemon path folds stderr into stdout — and the
+  // stderr cap that carries the traceback in the envelope path.
+  const stdoutCap = isFailure
+    ? capPreviewLinesHeadTail(
+        stdoutTrimmed,
+        BASH_PREVIEW_MAX_LINES,
+        BASH_PREVIEW_FAILURE_HEAD_LINES,
+      )
+    : capPreviewLines(stdoutTrimmed, BASH_PREVIEW_MAX_LINES);
   const showStderr = isFailure && stderrTrimmed.length > 0;
   const stderrCap = showStderr
-    ? capPreviewLines(stderrTrimmed, BASH_PREVIEW_MAX_LINES)
+    ? capPreviewLinesHeadTail(
+        stderrTrimmed,
+        BASH_PREVIEW_MAX_LINES,
+        BASH_PREVIEW_FAILURE_HEAD_LINES,
+      )
     : null;
   // Compact non-zero-exit indicator. The plain exec result folds stderr into
   // stdout (no separate stderr stream), so on a failed command with no tagged
@@ -550,6 +617,11 @@ export function BashOutputView({
             stdoutCap.remaining === 1 ? "line" : "lines"
           }`}</Text>
         ) : null}
+        {/* TAIL block (failure head+tail cap): the trailing verdict/exception
+            lines that survive AFTER the `… +K lines` elision. Empty on success. */}
+        {stdoutCap.tailLines.map((line, idx) =>
+          renderBashOutputLine(line, `ot${idx}`, "dim"),
+        )}
         {stderrCap
           ? stderrCap.lines.map((line, idx) =>
               // stderr: a plain line keeps the red failure tone; a line that
@@ -563,6 +635,11 @@ export function BashOutputView({
             stderrCap.remaining === 1 ? "line" : "lines"
           }`}</Text>
         ) : null}
+        {stderrCap
+          ? stderrCap.tailLines.map((line, idx) =>
+              renderBashOutputLine(line, `et${idx}`, "red" as TextColor),
+            )
+          : null}
         {showExitNote ? (
           <Text color={"red" as TextColor}>{`(exit ${exitCode})`}</Text>
         ) : null}

--- a/runtime/tests/tools/tool-rendering-bash.test.tsx
+++ b/runtime/tests/tools/tool-rendering-bash.test.tsx
@@ -328,3 +328,153 @@ describe("BashOutputView — stdout nests behind the ⎿ gutter in the secondary
     ).toBe(true);
   });
 });
+
+/**
+ * Failure-aware cap: when a command FAILS, the diagnostic payload (the
+ * exception line + the PASS/FAIL verdict) lives at the END of the output. A
+ * head-only cap truncates exactly those lines. The cap is split HEAD+TAIL on
+ * failure so the trailing verdict/exception survives, while SUCCESS stays
+ * head-only and byte-identical.
+ *
+ * REVERT-SENSITIVITY: against the pre-fix head-only renderer the failing-case
+ * assertions below go RED — the `AssertionError:` reason and the
+ * `FAILED (failures=1)` verdict are sliced off (only the first ~5 lines survive,
+ * with `… +K lines` swallowing the tail). The success-case assertion still
+ * passes both before and after (head-only is unchanged) and pins that the
+ * success path was NOT altered.
+ */
+describe("BashOutputView — failure cap keeps the trailing verdict/exception (head+tail)", () => {
+  // A realistic failing `python -m unittest` body: progress dots + the FAIL
+  // header + traceback at the TOP, then the test count + verdict at the BOTTOM.
+  // 11 lines total, far past the 5-line cap. With a 2-head / 3-tail failure
+  // split the bottom 3 lines (the `----` rule, the test count, and the
+  // `FAILED (failures=1)` VERDICT — the most important diagnostic) survive.
+  const FAILING_UNITTEST_BODY = [
+    "F....", // 0 — progress (head)
+    "======================================================================", // 1 — separator (head)
+    "FAIL: test_add_fractions (tests.test_fraction.FractionTest)", // 2
+    "----------------------------------------------------------------------", // 3
+    "Traceback (most recent call last):", // 4
+    '  File "tests/test_fraction.py", line 12, in test_add_fractions', // 5
+    "    self.assertEqual(result, Fraction(3, 4))", // 6
+    "AssertionError: Fraction(1, 2) != Fraction(3, 4)", // 7 (hidden middle)
+    "----------------------------------------------------------------------", // 8 — rule (tail)
+    "Ran 5 tests in 0.001s", // 9 — count (tail)
+    "FAILED (failures=1)", // 10 — verdict (tail, LAST line)
+  ].join("\n");
+
+  // A crashing script whose EXCEPTION line is the LAST line — the canonical
+  // case the head-only cap mangled: the `ZeroDivisionError` (the WHY) lives at
+  // the very bottom, so a head-only 5-line cap drops it entirely.
+  const CRASHING_SCRIPT_BODY = [
+    "starting computation", // 0 (head)
+    "loading inputs", // 1 (head)
+    "Traceback (most recent call last):", // 2
+    '  File "calc.py", line 3, in <module>', // 3
+    "    result = total / count", // 4 (hidden middle)
+    "                ~~~~~~^~~~~~~", // 5 (tail)
+    '  File "calc.py", line 1, in divide', // 6 (tail)
+    "ZeroDivisionError: division by zero", // 7 — verdict/exception (tail, LAST)
+  ].join("\n");
+
+  const findText = (
+    flat: { props: { children?: unknown } }[],
+    text: string,
+  ): boolean =>
+    flat.some(
+      (child) =>
+        typeof child.props?.children === "string" &&
+        child.props.children === text,
+    );
+
+  const findMore = (
+    flat: { props: { children?: unknown } }[],
+  ): string | undefined => {
+    const more = flat.find(
+      (child) =>
+        typeof child.props?.children === "string" &&
+        (child.props.children as string).startsWith("… +"),
+    );
+    return more ? (more.props.children as string) : undefined;
+  };
+
+  test("STDOUT failure path (live-daemon fold): trailing verdict survives the cap", () => {
+    // The live daemon folds stdout+stderr into one plain exec stream; a failing
+    // run surfaces here as a non-zero plain-exec trailer.
+    const node = BashOutputView({
+      content: `${FAILING_UNITTEST_BODY}\n\n[exec exit_code=1 wall_time=0.01s tokens=20]`,
+    });
+    const flat = flattenBash(node);
+
+    // The verdict (LAST line) and the test count must survive — a head-only cap
+    // drops both.
+    expect(findText(flat, "FAILED (failures=1)")).toBe(true);
+    expect(findText(flat, "Ran 5 tests in 0.001s")).toBe(true);
+
+    // Early context (the head) is still shown.
+    expect(findText(flat, "F....")).toBe(true);
+
+    // The elision reports the HIDDEN MIDDLE count: 11 lines, 2 head + 3 tail
+    // visible → 11 - 5 = 6 hidden.
+    expect(findMore(flat)).toBe("… +6 lines");
+  });
+
+  test("STDOUT failure path: the bottom EXCEPTION line survives when it is the last line", () => {
+    // A crash whose `ZeroDivisionError: ...` (the WHY) is the LAST line — the
+    // case a head-only cap mangles most.
+    const node = BashOutputView({
+      content: `${CRASHING_SCRIPT_BODY}\n\n[exec exit_code=1 wall_time=0.01s tokens=20]`,
+    });
+    const flat = flattenBash(node);
+
+    expect(findText(flat, "ZeroDivisionError: division by zero")).toBe(true);
+    // Head context preserved too.
+    expect(findText(flat, "starting computation")).toBe(true);
+    // 8 lines, 2 head + 3 tail → 8 - 5 = 3 hidden.
+    expect(findMore(flat)).toBe("… +3 lines");
+  });
+
+  test("STDERR envelope path: traceback verdict survives the red cap", () => {
+    // unittest writes its report to STDERR; the envelope path carries it in
+    // <bash-stderr>. The failing cap must keep the tail there too, in red.
+    const node = BashOutputView({
+      content:
+        `<bash-stdout></bash-stdout>` +
+        `<bash-stderr>${FAILING_UNITTEST_BODY}</bash-stderr>[exit_code=1]`,
+    });
+    const flat = flattenBash(node);
+
+    // The verdict survives in the red failure tone.
+    const verdict = flat.find(
+      (child) =>
+        child.props?.children === "FAILED (failures=1)" &&
+        (child.props as { color?: string }).color === "red",
+    );
+    expect(verdict).toBeDefined();
+    expect(findText(flat, "Ran 5 tests in 0.001s")).toBe(true);
+
+    // The stderr elision count is correct (same 11-line body → 6 hidden).
+    expect(findMore(flat)).toBe("… +6 lines");
+  });
+
+  test("SUCCESS path is unchanged: head-only cap, trailing lines truncated away", () => {
+    // Same 11-line body but exit 0 → the head-only behavior is preserved. The
+    // verdict-shaped LAST line must NOT survive (it's beyond the 5-line head),
+    // and the elision reports 11 - 5 = 6 remaining.
+    const node = BashOutputView({
+      content: `<bash-stdout>${FAILING_UNITTEST_BODY}</bash-stdout>[exit_code=0]`,
+    });
+    const flat = flattenBash(node);
+
+    // The first 5 lines survive head-only...
+    expect(findText(flat, "F....")).toBe(true);
+    expect(
+      findText(flat, "FAIL: test_add_fractions (tests.test_fraction.FractionTest)"),
+    ).toBe(true);
+    // ...and the trailing verdict is truncated away (head-only, unchanged).
+    expect(findText(flat, "FAILED (failures=1)")).toBe(false);
+    expect(findText(flat, "Ran 5 tests in 0.001s")).toBe(false);
+    // Head-only elision: 11 - 5 = 6 remaining.
+    expect(findMore(flat)).toBe("… +6 lines");
+  });
+});


### PR DESCRIPTION
## Iteration 31 — dynamic run-commands-errors round (0 bugs, 1 high-value improvement)

The error-rendering round found **0 confirmed bugs** (traceback/exit-code/error display all render correctly), but surfaced a high-impact improvement confirmed by 2 agents.

### The problem
`BashOutputView` capped Run/Bash output to the **first 5 lines** (head-only). For a failed command the diagnostic payload is at the **end** — for `python -m unittest`, the dots/`FAIL:` header/traceback frames come first, while the `AssertionError` reason, `Ran N tests`, and `FAILED (failures=1)` verdict land last. So the head-only cap truncated away exactly the lines a developer needs to diagnose the failure. The red `(exit N)` note preserved the failure *signal* but not the *why*.

### The fix
On a non-zero exit, split the same ~5-line footprint into a **head** block (early context) + a **tail** block (exception + verdict), with the hidden middle as `… +K lines` between them. New `capPreviewLinesHeadTail` (head=2, tail=3, head clamped so ≥1 tail line always survives), wired into both failure paths (the stdout-fold path and the stderr envelope). **Success path byte-identical** (head-only).

### Gate
Revert-sensitive (reverting reds the 3 failure-case tests; success-case stays green). `npm run build` exit 0 · full `npm run test:unit` **13358 passed, 0 failures** · TUI startup smoke clean. No tmux.

Still deferred: an interactive `ctrl+o` expand affordance for `… +K lines` (a larger feature) — this change is purely about which lines survive the cap on failure.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG