### PR TITLE
fix(tui): gate per-turn files-changed rollup on tool resolution; stop leaking internal callId

### DIFF
--- a/runtime/src/tui/components/Message.tsx
+++ b/runtime/src/tui/components/Message.tsx
@@ -144,8 +144,15 @@ function MessageImpl({
         // collapsed diff card, but there is no concise summary of WHAT this turn
         // touched. Derive it from this message's OWN file-mutating tool uses
         // (scoped to the turn, no global git scan) and render one compact line
-        // after the tool activity. Empty list → renders nothing.
-        const turnFileChanges = deriveTurnFileChanges(message.message.content);
+        // after the tool activity. Empty list → renders nothing. Gate it on tool
+        // resolution the SAME way the header glyph and the diff card do
+        // (resolvedToolUseIDs / erroredToolUseIDs) so the rollup never reports a
+        // file as created while its Write is still in-progress (◐) or has FAILED
+        // (✕) — it appears only once the glyph flips to a resolved success (●).
+        const turnFileChanges = deriveTurnFileChanges(message.message.content, {
+          resolvedToolUseIDs: lookups.resolvedToolUseIDs,
+          erroredToolUseIDs: lookups.erroredToolUseIDs,
+        });
         return (
           <ContentWidthProvider width={messageContentWidth}>
             <Box flexDirection="column" width={containerWidth ?? "100%"}>

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -760,19 +760,26 @@ function pushToolResult(
       return;
     }
     if (isStructuredContentBlocks(rawResult)) {
+      // Operator-readable: the raw internal correlation id (call_…) is
+      // meaningless to a user, so it is omitted from the visible prose rather
+      // than surfaced. The recovered result payload below is the meaningful
+      // part; these structured-block branches carry no extra payload here.
       out.push(
         makeSystemMessage(
           isError
-            ? `Tool failed before its start event was received (${callId}).`
-            : `Tool completed before its start event was received (${callId}).`,
+            ? "A tool failed and its result arrived before its start event; recovered."
+            : "A tool result arrived before its start event and was recovered.",
           isError ? "error" : "warning",
         ),
       );
       return;
     }
+    // Keep the recovered RESULT payload visible (that's what the operator needs)
+    // but drop the opaque call_… correlation id and the framework-internal
+    // "without matching start" phrasing from the user-facing lead-in.
     out.push(
       makeSystemMessage(
-        `Recovered tool result without matching start (${callId}): ${stringResult(rawResult)}`,
+        `A tool result arrived out of order and was recovered: ${stringResult(rawResult)}`,
         isError ? "error" : "warning",
       ),
     );

--- a/runtime/src/tui/turn-file-changes.ts
+++ b/runtime/src/tui/turn-file-changes.ts
@@ -42,6 +42,26 @@ interface ToolUseLike {
   readonly type?: unknown;
   readonly name?: unknown;
   readonly input?: unknown;
+  readonly id?: unknown;
+}
+
+/**
+ * Resolution lookups for gating the rollup on tool completion, mirroring how the
+ * tool header glyph and the embedded diff card gate on `resolvedToolUseIDs` /
+ * `erroredToolUseIDs` (see `AssistantToolUseMessage.tsx`).
+ *
+ * The rollup must agree with the header glyph and the diff card: it should
+ * count a file op ONLY once the `◐` has flipped to a resolved success (`●`),
+ * and NEVER for a `✕` failure. Without this, the rollup would assert a file as
+ * created the instant the Write's INPUT parses — while the header still shows
+ * the in-progress glyph and the diff card is still collapsed — and would even
+ * report a FAILED write as a successful create.
+ */
+export interface TurnFileChangeResolution {
+  /** Tool-use ids whose result has arrived (the `◐` flipped to `●` or `✕`). */
+  readonly resolvedToolUseIDs: ReadonlySet<string>;
+  /** Tool-use ids whose result was an ERROR (`✕`). */
+  readonly erroredToolUseIDs: ReadonlySet<string>;
 }
 
 /**
@@ -54,9 +74,18 @@ interface ToolUseLike {
  *
  * Returns an empty array when the turn changed no files, so the caller renders
  * nothing.
+ *
+ * When `resolution` is supplied (the real caller always supplies it), a file op
+ * is accumulated ONLY when its tool-use `id` is in `resolvedToolUseIDs` AND is
+ * NOT in `erroredToolUseIDs` — so the rollup appears only once the header `◐`
+ * has flipped to a resolved success `●`, and NEVER for a `✕` failure, keeping
+ * the header glyph, the embedded diff card, and the rollup in agreement. When
+ * `resolution` is omitted, the function degrades to its prior behavior and
+ * counts every diffable op (used only where no lookups are available).
  */
 export function deriveTurnFileChanges(
   content: readonly unknown[] | undefined,
+  resolution?: TurnFileChangeResolution,
 ): readonly TurnFileChange[] {
   if (!Array.isArray(content)) return [];
 
@@ -73,6 +102,17 @@ export function deriveTurnFileChanges(
     if (block.type !== "tool_use") continue;
     const name = typeof block.name === "string" ? block.name : "";
     if (!FILE_EDIT_TOOLS.has(name)) continue;
+
+    // Gate on tool resolution the SAME way the diff card does: only count an op
+    // once its result has arrived as a success. A still-running op (id absent
+    // from resolvedToolUseIDs) or a FAILED op (id in erroredToolUseIDs) does not
+    // contribute — the header glyph / diff card render the same way for them.
+    if (resolution !== undefined) {
+      const id = typeof block.id === "string" ? block.id : "";
+      if (id.length === 0) continue;
+      if (!resolution.resolvedToolUseIDs.has(id)) continue;
+      if (resolution.erroredToolUseIDs.has(id)) continue;
+    }
 
     let preview: ReturnType<typeof buildEditDiffPreview>;
     try {

--- a/runtime/tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts
@@ -139,11 +139,19 @@ describe("session transcript coverage swarm row 003", () => {
         input: { input: "{bad" },
       }),
     ]);
+    // Recovered out-of-order tool results no longer leak the raw internal
+    // callId (call_…) or the framework-internal "without matching start"
+    // phrasing into the user-facing transcript prose; the recovered RESULT
+    // payload (here empty for the empty array) is still kept visible.
     expect(systemContents(transcript)).toEqual([
-      "Tool completed before its start event was received (orphan-ok).",
-      "Tool failed before its start event was received (orphan-error).",
-      "Recovered tool result without matching start (orphan-empty-array): ",
+      "A tool result arrived before its start event and was recovered.",
+      "A tool failed and its result arrived before its start event; recovered.",
+      "A tool result arrived out of order and was recovered: ",
     ]);
+    // None of these operator-facing lines carry the opaque callId.
+    for (const text of systemContents(transcript)) {
+      expect(text).not.toMatch(/orphan-/);
+    }
   });
 
   test("formats structured tool result edge cases for MCP, Glob, and circular fallback data", () => {

--- a/runtime/tests/tui/parity/session-transcript.streaming-tool-use.parity.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.streaming-tool-use.parity.test.ts
@@ -178,7 +178,7 @@ describe("R5 streamingToolUses accumulator (session-transcript)", () => {
     expect(t.streamingToolUses).toEqual([]);
     expect(t.inProgressToolUseIDs.size).toBe(0);
     expect(allText).toContain("read-ok");
-    expect(allText).not.toContain("Recovered tool result without matching start");
+    expect(allText).not.toContain("arrived out of order and was recovered");
   });
 
   test("E5.7 snapshot identity differs across distinct event sequences (sanity check for accumulator-immutability of element shape)", () => {

--- a/runtime/tests/tui/parity/session-transcript.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.test.ts
@@ -1636,8 +1636,49 @@ describe("AgenC TUI session transcript", () => {
       expect(transcript.messages).toHaveLength(2);
       expect(transcript.messages[0]).toMatchObject({ type: "user" });
       const allText = JSON.stringify(transcript.messages);
-      expect(allText).toContain("Recovered tool result without matching start");
+      // The recovery row no longer leaks the raw internal callId or the
+      // framework-internal "without matching start" phrasing; it uses an
+      // operator-readable lead-in and still surfaces the recovered payload.
+      expect(allText).toContain("A tool result arrived out of order and was recovered");
+      expect(allText).not.toContain("without matching start");
+      expect(allText).not.toContain("phantom-call-1");
       expect(allText).toContain("phantom result");
+    });
+
+    test("BUG 2: recovered-tool-result message does NOT leak the raw call_… id or internal phrasing", () => {
+      // A realistic out-of-order completion carrying an opaque internal
+      // correlation id (call_…) and a meaningful result payload.
+      const transcript = adaptTranscriptEvents([
+        {
+          id: "orphan",
+          msg: {
+            type: "tool_call_completed",
+            payload: {
+              callId: "call_e6820ea7c28742678c811d06",
+              result: "the actual recovered payload",
+              isError: false,
+            },
+          },
+        },
+      ]);
+      const allText = JSON.stringify(transcript.messages);
+      // REVERT-SENSITIVITY: against the pre-fix code the message read
+      // "Recovered tool result without matching start (call_e6820ea7…): …",
+      // so BOTH of these absence checks fail and the test goes red. With the
+      // fix the raw call_ id and the framework-internal phrasing are gone.
+      expect(allText).not.toContain("call_e6820ea7c28742678c811d06");
+      expect(allText).not.toContain("without matching start");
+      // The operator-readable lead-in and the recovered payload remain visible.
+      expect(allText).toContain("A tool result arrived out of order and was recovered");
+      expect(allText).toContain("the actual recovered payload");
+      // The warning glyph/severity is preserved (non-error → warning level).
+      const recovered = transcript.messages.find(
+        (m) =>
+          m.type === "system" &&
+          typeof m.content === "string" &&
+          m.content.includes("arrived out of order and was recovered"),
+      );
+      expect(recovered).toMatchObject({ type: "system", level: "warning" });
     });
 
     test("denied FileRead orphan result renders a user-facing denial", () => {
@@ -1657,7 +1698,7 @@ describe("AgenC TUI session transcript", () => {
 
       const allText = JSON.stringify(transcript.messages);
       expect(allText).toContain("Permission request denied by user.");
-      expect(allText).not.toContain("Recovered tool result without matching start");
+      expect(allText).not.toContain("arrived out of order and was recovered");
       expect(allText).not.toContain("{\\\"error\\\":\\\"rejected by user\\\"}");
     });
 
@@ -1678,7 +1719,7 @@ describe("AgenC TUI session transcript", () => {
 
       const allText = JSON.stringify(transcript.messages);
       expect(allText).toContain("Permission request denied by user.");
-      expect(allText).not.toContain("Recovered tool result without matching start");
+      expect(allText).not.toContain("arrived out of order and was recovered");
       expect(allText).not.toContain("rejected by user");
     });
 
@@ -1699,7 +1740,7 @@ describe("AgenC TUI session transcript", () => {
 
       const allText = JSON.stringify(transcript.messages);
       expect(transcript.messages).toHaveLength(0);
-      expect(allText).not.toContain("Recovered tool result without matching start");
+      expect(allText).not.toContain("arrived out of order and was recovered");
       expect(allText).not.toContain("1→secret");
     });
 
@@ -1730,7 +1771,8 @@ describe("AgenC TUI session transcript", () => {
       ]);
 
       expect(transcript.inProgressToolUseIDs.size).toBe(0);
-      expect(JSON.stringify(transcript.messages)).toContain("Recovered tool result without matching start");
+      expect(JSON.stringify(transcript.messages)).toContain("A tool result arrived out of order and was recovered");
+      expect(JSON.stringify(transcript.messages)).not.toContain("phantom-call-2");
       expect(JSON.stringify(transcript.messages)).not.toContain("echo late");
     });
 

--- a/runtime/tests/tui/turn-file-changes-summary.test.tsx
+++ b/runtime/tests/tui/turn-file-changes-summary.test.tsx
@@ -93,6 +93,83 @@ describe('deriveTurnFileChanges (per-turn changed-file data source)', () => {
   })
 })
 
+// BUG 1 (HIGH): the rollup must agree with the tool header glyph and the
+// embedded diff card, both of which gate on tool RESOLUTION
+// (resolvedToolUseIDs / erroredToolUseIDs). Before this fix the rollup was
+// derived purely from the tool-use INPUT, so it asserted "+ file (new) +N" the
+// instant the Write's input parsed — while the header still showed the
+// in-progress ◐ glyph — and it even reported a FAILED Write (✕) as a successful
+// create. These tests gate the rollup the SAME way the diff card does.
+describe('deriveTurnFileChanges (gated on tool resolution)', () => {
+  const writeId = 'w-docker-compose.yml'
+  const editId = 'e-styles.css'
+  const turn = [
+    writeBlock('docker-compose.yml', 'a\nb\nc\n'),
+    editBlock('styles.css', 'a{}\n', 'a{color:red}\nb{}\n'),
+  ]
+
+  test('an UNRESOLVED Write (id absent from resolvedToolUseIDs) is NOT counted', () => {
+    // The Write input has parsed but the tool result has not arrived (still ◐).
+    // REVERT-SENSITIVITY: against the un-gated code this returned the file as
+    // "+ docker-compose.yml (new) +3"; with the fix it contributes nothing.
+    const changes = deriveTurnFileChanges(turn, {
+      resolvedToolUseIDs: new Set<string>(), // nothing resolved yet
+      erroredToolUseIDs: new Set<string>(),
+    })
+    expect(changes).toEqual([])
+    expect(changes.find(c => c.file === 'docker-compose.yml')).toBeUndefined()
+  })
+
+  test('a RESOLVED success Write IS counted (matches the ● glyph + diff card)', () => {
+    const changes = deriveTurnFileChanges(turn, {
+      resolvedToolUseIDs: new Set<string>([writeId]),
+      erroredToolUseIDs: new Set<string>(),
+    })
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toMatchObject({ file: 'docker-compose.yml', kind: 'create' })
+  })
+
+  test('a RESOLVED ERROR Write (✕) is NOT reported as created', () => {
+    // The Write resolved, but as a FAILURE. The header shows ✕ and the diff
+    // card renders nothing — so the rollup must not claim the file was created.
+    // REVERT-SENSITIVITY: against the un-gated code this still showed
+    // "+ docker-compose.yml (new) +3"; with the fix it is absent.
+    const changes = deriveTurnFileChanges(turn, {
+      resolvedToolUseIDs: new Set<string>([writeId, editId]),
+      erroredToolUseIDs: new Set<string>([writeId]),
+    })
+    expect(changes.find(c => c.file === 'docker-compose.yml')).toBeUndefined()
+    // The sibling resolved-success Edit is still counted.
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toMatchObject({ file: 'styles.css', kind: 'edit' })
+  })
+
+  test('only the resolved-success ops in a mixed turn are counted', () => {
+    // Write resolved-success, Edit still in-flight → only the Write counts.
+    const changes = deriveTurnFileChanges(turn, {
+      resolvedToolUseIDs: new Set<string>([writeId]),
+      erroredToolUseIDs: new Set<string>(),
+    })
+    expect(changes).toHaveLength(1)
+    expect(changes[0]?.file).toBe('docker-compose.yml')
+  })
+
+  test('a tool_use block missing an id is not counted when resolution gating is active', () => {
+    const noIdWrite = { type: 'tool_use', name: 'Write', input: { file_path: 'x.ts', content: 'x\n' } }
+    const changes = deriveTurnFileChanges([noIdWrite], {
+      resolvedToolUseIDs: new Set<string>(),
+      erroredToolUseIDs: new Set<string>(),
+    })
+    expect(changes).toEqual([])
+  })
+
+  test('omitting resolution preserves the prior (un-gated) behavior', () => {
+    // The function degrades sensibly where no lookups are available.
+    const changes = deriveTurnFileChanges(turn)
+    expect(changes).toHaveLength(2)
+  })
+})
+
 describe('TurnFileChangesSummary (compact per-turn render)', () => {
   test('a turn with a Write + an Edit renders a summary listing both with create/edit markers', async () => {
     const changes = deriveTurnFileChanges([


### PR DESCRIPTION
## Iteration 32 — dynamic varied-artifact round

A varied-artifact scenario (Dockerfile/compose-YAML/Makefile diffs) caught a Write mid-flight and exposed a timing-dependent **correctness** bug in the iter-14 files-changed rollup.

### 1. (HIGH) Rollup reported files created before the Write resolved — and failed Writes as succeeded
The per-turn `⎿ files changed  + <file> (new) +N` rollup derived its ops from the tool_use **input** alone, with no resolution info — so it asserted creation the instant the input parsed (while the header still showed the in-progress `◐` and the diff card was still collapsed), and a **failed** Write (`✕`) was still reported as a successful create. Threaded the resolution lookups (`resolvedToolUseIDs` + `erroredToolUseIDs` — the exact signals the header glyph and diff card use) into `deriveTurnFileChanges`; it now counts a file op only once its id is resolved **and** not errored. Header glyph, diff card, and rollup now agree. Backward-compatible.

### 2. (LOW) Orphan-tool-result recovery messages leaked an internal callId
The recovery system messages embedded a raw `call_…` correlation id and framework-internal phrasing ("without matching start") in the user-facing transcript. Dropped the callId (meaningless to users) and reworded the three sibling messages to operator-readable, keeping the recovered payload + warning severity.

### Gate
Each revert-sensitive (reverting the rollup gate reds 5 tests incl. unresolved + errored cases). `npm run build` exit 0 · full `npm run test:unit` **13365 passed, 0 failures** · TUI startup smoke clean. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG