### PR TITLE
fix(tui): make DiffInline code-cell width deterministic (clears the deferred ±1 spill/ellipsize)

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -7,12 +7,72 @@ import { useQueuedMessage } from '../../context/QueuedMessageContext.js'
 import { ContentWidthProvider, insetContentWidth, useContentWidth } from '../../context/contentWidthContext.js'
 import { useTerminalSize } from '../../hooks/useTerminalSize.js'
 import Box from '../../ink/components/Box.js'
+import wrapText from '../../ink/wrap-text.js'
 import ThemedBox from '../design-system/ThemedBox.js'
 import ThemedText from '../design-system/ThemedText.js'
 
 type ThemeColor = keyof Theme
 
 const TerminalFrameColumnsContext = React.createContext(120)
+
+/**
+ * Fixed horizontal chrome of the `DiffInline` box, measured against the rendered
+ * output (see `diffInlineCodeCellWidth` for the exact decomposition). These are
+ * the columns that are NEVER available to the flexing code text:
+ *
+ *   - the box's `borderStyle="single"` border: 1 col on each side          → 2
+ *   - each diff row's `paddingX={1}`: 1 col on each side                    → 2
+ *   - the fixed line-number gutter on every row:
+ *       old line, `padStart(4, ' ')`                                        → 4
+ *       new line, `padStart(4, ' ')`                                        → 4
+ *       the ` {sigil} ` marker cell (space + 1-col sigil + space)           → 3
+ *
+ * Border (2) + paddingX (2) + gutter (4 + 4 + 3 = 11) = 15. The gutter is
+ * content-independent — the line numbers are always padded to 4 and the sigil
+ * cell is always 3 wide — so the chrome is a constant, which is what lets the
+ * code-cell width be deterministic.
+ */
+const DIFF_INLINE_BORDER_COLS = 2
+const DIFF_INLINE_ROW_PADDING_COLS = 2
+const DIFF_INLINE_GUTTER_COLS = 4 + 4 + 3
+const DIFF_INLINE_CHROME_COLS =
+  DIFF_INLINE_BORDER_COLS + DIFF_INLINE_ROW_PADDING_COLS + DIFF_INLINE_GUTTER_COLS
+
+/**
+ * The EXACT visible width available to a `DiffInline` code cell, given the box's
+ * total outer width. Pure + exported so the width contract is unit-testable in
+ * isolation, independent of Yoga: `codeCellWidth = boxOuterWidth − 15`.
+ *
+ * When the box is so narrow there is no room for code (≤ chrome), this clamps to
+ * a minimum of 1 so the truncate helper still emits a single-column marker
+ * rather than producing a negative/zero width.
+ */
+export function diffInlineCodeCellWidth(boxOuterWidth: number): number {
+  return Math.max(1, Math.floor(boxOuterWidth) - DIFF_INLINE_CHROME_COLS)
+}
+
+/**
+ * Carries the EXACT outer width the embedded `DiffInline` box should occupy, set
+ * ONLY by render contexts that fill a known content width (the post-approval
+ * transcript DIFF card under a tool-use row). When present, `DiffInline` sizes
+ * its code cell deterministically (`diffInlineCodeCellWidth`) and pre-truncates
+ * each line, so Yoga flex rounding can never shift the truncation point by ±1
+ * (which produced both the early-ellipsis and the spill-past-border symptoms).
+ *
+ * Deliberately separate from the general `ContentWidthContext`: a surface-wide
+ * content width (e.g. an auto-sized approval popup that does NOT fill the whole
+ * surface) is NOT the DiffInline box width, so reading the general context could
+ * feed a too-wide value and overflow. `null` → the legacy flex layout is kept.
+ */
+const DiffInlineWidthContext = React.createContext<number | null>(null)
+
+/**
+ * Horizontal chrome the `Tool` detail box adds around its content before an
+ * embedded `DiffInline`: `marginLeft={2}` + the `borderLeft` rule (1) +
+ * `paddingLeft={1}` = 4 columns. The diff's outer width is therefore the
+ * inherited content width minus this inset.
+ */
+const DIFF_INLINE_DETAIL_INSET_COLS = 2 + 1 + 1
 
 export type BadgeVariant =
   | 'neutral'
@@ -975,6 +1035,13 @@ export function Tool({
   readonly time?: string
 }): React.ReactNode {
   const color = state === 'failed' ? 'error' : state === 'queued' ? 'inactive' : toolColor[kind]
+  // The detail box below indents its content by `marginLeft={2}` + the
+  // `borderLeft` rule (1) + `paddingLeft={1}` = 4 columns. An embedded
+  // `DiffInline` therefore has exactly `inheritedContentWidth − 4` columns to
+  // fill; surface that exact width so the diff sizes its code cell
+  // deterministically instead of relying on Yoga flex rounding.
+  const inheritedWidth = useContentWidth()
+  const detailContentWidth = insetContentWidth(inheritedWidth, DIFF_INLINE_DETAIL_INSET_COLS)
   return (
     <Box flexDirection="column">
       <Box flexDirection="row" gap={1}>
@@ -1033,7 +1100,9 @@ export function Tool({
           borderLeft
           borderLeftColor="lineSoft"
         >
-          {detail}
+          <DiffInlineWidthContext.Provider value={detailContentWidth}>
+            {detail}
+          </DiffInlineWidthContext.Provider>
         </ThemedBox>
       ) : null}
     </Box>
@@ -1164,8 +1233,23 @@ export function DiffInline({
    */
   readonly op?: string
 }): React.ReactNode {
+  // When a render context supplies the box's exact outer width (the transcript
+  // DIFF card), size the code cell deterministically instead of leaving it to
+  // Yoga flex. Yoga's flex rounding occasionally lands ±1 col off, which made an
+  // at-width code line either ellipsize one char too early OR spill its last
+  // char past the right border (two identically-sized boxes rendering the same
+  // line differently). Pinning `width={codeCellWidth}` on the code cell and
+  // pre-truncating the text to that same width removes the rounding entirely.
+  const explicitBoxWidth = React.useContext(DiffInlineWidthContext)
+  const codeCellWidth =
+    explicitBoxWidth !== null ? diffInlineCodeCellWidth(explicitBoxWidth) : null
   return (
-    <ThemedBox flexDirection="column" borderStyle="single" borderColor="lineSoft">
+    <ThemedBox
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="lineSoft"
+      {...(explicitBoxWidth !== null ? { width: explicitBoxWidth } : {})}
+    >
       <ThemedBox flexDirection="row" paddingX={1} borderBottom borderBottomColor="lineSoft" gap={1}>
         <ThemedText color="subtle">{op}</ThemedText>
         <ThemedText color="text2" wrap="truncate-middle">{file}</ThemedText>
@@ -1215,9 +1299,23 @@ export function DiffInline({
               <Box flexShrink={0}>
                 <ThemedText color={sigilColor}> {sigil} </ThemedText>
               </Box>
-              <Box flexGrow={1} flexShrink={1} minWidth={0}>
-                <ThemedText color={codeColor} wrap="truncate-end">{line.code}</ThemedText>
-              </Box>
+              {codeCellWidth !== null ? (
+                // Deterministic path: the cell is a fixed `codeCellWidth` wide and
+                // never flexes, and the code is PRE-TRUNCATED to that exact width
+                // with the same `truncate-end` helper the text node would use — so
+                // the visible result cannot depend on Yoga rounding. A line at or
+                // under the width passes through unchanged (truncate is a no-op),
+                // so short lines still render in full.
+                <Box flexShrink={0} width={codeCellWidth}>
+                  <ThemedText color={codeColor} wrap="truncate-end">
+                    {wrapText(line.code, codeCellWidth, 'truncate-end')}
+                  </ThemedText>
+                </Box>
+              ) : (
+                <Box flexGrow={1} flexShrink={1} minWidth={0}>
+                  <ThemedText color={codeColor} wrap="truncate-end">{line.code}</ThemedText>
+                </Box>
+              )}
             </ThemedBox>
           )
         })}

--- a/runtime/tests/tui/components/v2/diffInlineWidth.test.tsx
+++ b/runtime/tests/tui/components/v2/diffInlineWidth.test.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, it } from "vitest";
+
+import { Box } from "../../../../src/tui/ink.js";
+import { stringWidth } from "../../../../src/tui/ink/stringWidth.js";
+import { ContentWidthProvider } from "../../../../src/tui/context/contentWidthContext.js";
+import {
+  DiffInline,
+  Tool,
+  diffInlineCodeCellWidth,
+} from "../../../../src/tui/components/v2/primitives.js";
+import { renderToString } from "../../../../src/utils/staticRender.js";
+
+/**
+ * Render a `DiffInline` through the SAME tree the live transcript uses: a
+ * message-level `ContentWidthProvider` (carrying `messageContentWidth`) wrapping
+ * a `Tool` whose `detail` is the diff and which is `expanded`. The Tool detail
+ * box indents the diff by 4 columns and re-provides that exact width to
+ * `DiffInline`, which is what enables the deterministic code-cell sizing under
+ * test. Returns the plain (ANSI-stripped) frame.
+ */
+function renderTranscriptDiff(
+  messageContentWidth: number,
+  lines: React.ComponentProps<typeof DiffInline>["lines"],
+): Promise<string> {
+  return renderToString(
+    <ContentWidthProvider width={messageContentWidth}>
+      <Box flexDirection="column" width={messageContentWidth}>
+        <Tool
+          kind="write"
+          label="Write"
+          state="done"
+          args="x.ts"
+          expanded
+          detail={<DiffInline file="x.ts" stats="+1 -0" lines={lines} />}
+        />
+      </Box>
+    </ContentWidthProvider>,
+    messageContentWidth,
+  );
+}
+
+describe("diffInlineCodeCellWidth (pure width contract)", () => {
+  // The cell width is the box outer width minus a CONSTANT chrome of 15 columns:
+  // border (2) + row paddingX (2) + the fixed line-number gutter (4 + 4 + 3).
+  // This is the single source of truth the deterministic render relies on, so it
+  // is asserted directly, independent of Yoga.
+  it("is exactly boxOuterWidth − 15 across a range of widths", () => {
+    for (const boxOuterWidth of [20, 30, 40, 56, 60, 76, 80, 96, 120, 200]) {
+      expect(diffInlineCodeCellWidth(boxOuterWidth)).toBe(boxOuterWidth - 15);
+    }
+  });
+
+  it("clamps to a minimum of 1 when the box is narrower than its chrome", () => {
+    expect(diffInlineCodeCellWidth(15)).toBe(1);
+    expect(diffInlineCodeCellWidth(10)).toBe(1);
+    expect(diffInlineCodeCellWidth(0)).toBe(1);
+  });
+
+  it("floors fractional widths before subtracting chrome", () => {
+    expect(diffInlineCodeCellWidth(60.9)).toBe(45);
+  });
+});
+
+describe("DiffInline deterministic code-cell width (revert-sensitive)", () => {
+  // messageContentWidth 80 → DiffInline box 76 → codeCellWidth 76 − 15 = 61.
+  const MCW = 80;
+  const BOX_WIDTH = MCW - 4; // Tool detail box inset (marginLeft 2 + border 1 + paddingLeft 1)
+  const CODE_CELL_WIDTH = diffInlineCodeCellWidth(BOX_WIDTH); // 61
+
+  /**
+   * Pull the visible code text out of a rendered diff body row, given the
+   * one-char marker the row carries (+ / - / space). The gutter (line numbers +
+   * ` {sigil} `) precedes the code; everything after the ` {sigil} ` marker and
+   * before the trailing padding + right border is the code cell content.
+   */
+  function extractCode(frame: string, sigil: "+" | "-" | " ", needle: string): string {
+    const bodyRow = frame
+      .split("\n")
+      .find((l) => l.includes(` ${sigil} `) && l.includes(needle));
+    expect(bodyRow, `expected a body row containing ${JSON.stringify(needle)}`).toBeDefined();
+    // After the marker ` {sigil} `, before the trailing ` │` (paddingX + border).
+    const afterMarker = bodyRow!.slice(bodyRow!.indexOf(` ${sigil} `) + 3);
+    return afterMarker.replace(/\s*│\s*$/, "");
+  }
+
+  // THE crux assertion. A code line whose visible width EXCEEDS the code-cell
+  // width must reach the render PRE-TRUNCATED to EXACTLY codeCellWidth visible
+  // columns, with the ellipsis INSIDE that width.
+  //
+  // Revert-sensitivity: against the pre-fix code the cell flexed and the FULL,
+  // un-pre-truncated `line.code` was handed to the text node, leaving Yoga +
+  // the text node to truncate to whatever the flex-rounded cell happened to be
+  // (±1). With the fix, the string is truncated deterministically to exactly
+  // codeCellWidth. Reverting either the `width={codeCellWidth}` pin or the
+  // `wrapText(..., codeCellWidth, ...)` pre-truncation makes the visible width
+  // drift off `CODE_CELL_WIDTH`, failing this exact-equality assertion.
+  it("pre-truncates an over-width line to EXACTLY codeCellWidth visible columns", async () => {
+    const over = "g".repeat(MCW + 40); // far wider than the cell
+    const frame = await renderTranscriptDiff(MCW, [
+      { kind: "add", newLine: "2", code: over },
+    ]);
+    const code = extractCode(frame, "+", "g");
+    expect(stringWidth(code)).toBe(CODE_CELL_WIDTH);
+    expect(code.endsWith("…")).toBe(true);
+    // The ellipsis is the LAST column — the content before it is codeCellWidth-1.
+    expect(stringWidth(code.replace(/…$/, ""))).toBe(CODE_CELL_WIDTH - 1);
+  });
+
+  // A line EXACTLY at the code-cell width must render in FULL — no early
+  // ellipsis (Symptom A) — and must not spill past the border (Symptom B).
+  it("renders an at-width line in full with no ellipsis", async () => {
+    const exact = "f".repeat(CODE_CELL_WIDTH);
+    const frame = await renderTranscriptDiff(MCW, [
+      { kind: "add", newLine: "2", code: exact },
+    ]);
+    const code = extractCode(frame, "+", "f");
+    expect(code).toBe(exact); // unchanged, all CODE_CELL_WIDTH chars
+    expect(code).not.toContain("…");
+    expect(stringWidth(code)).toBe(CODE_CELL_WIDTH);
+  });
+
+  // A SHORT line (≤ codeCellWidth) must pass through UNCHANGED (no
+  // over-truncation regression).
+  it("passes a short line through unchanged", async () => {
+    const short = "const x = 1;";
+    const frame = await renderTranscriptDiff(MCW, [
+      { kind: "add", newLine: "2", code: short },
+    ]);
+    const code = extractCode(frame, "+", "const x");
+    expect(code).toBe(short);
+    expect(code).not.toContain("…");
+  });
+
+  // REVERT-SENSITIVE in the headless harness. A single-line diff in a tightly
+  // fitted parent lets Yoga's flex round to exactly codeCellWidth, so a render
+  // assertion alone cannot tell the two layouts apart there. We force a
+  // divergence by rendering at a PHYSICAL viewport much wider than the content
+  // width the context reports: the deterministic box is PINNED to its inset
+  // content width (and the cell to codeCellWidth) regardless of the viewport,
+  // while the reverted flex box would grow to fill the wider viewport and
+  // truncate the over-width line to a much larger column count.
+  it("pins the box + cell width even when the physical viewport is far wider (revert proof)", async () => {
+    const PHYSICAL = 130; // much wider than MCW (80)
+    const over = "g".repeat(220);
+    const frame = await renderToString(
+      <ContentWidthProvider width={MCW}>
+        <Box flexDirection="column">
+          <Tool
+            kind="write"
+            label="Write"
+            state="done"
+            args="x.ts"
+            expanded
+            detail={
+              <DiffInline
+                file="x.ts"
+                stats="+1 -0"
+                lines={[{ kind: "add", newLine: "2", code: over }]}
+              />
+            }
+          />
+        </Box>
+      </ContentWidthProvider>,
+      PHYSICAL,
+    );
+    // Deterministic: the over-width code is truncated to EXACTLY codeCellWidth
+    // (61), NOT to the ~111 cols the flex box would allow at a 130-col viewport.
+    const code = extractCode(frame, "+", "g");
+    expect(stringWidth(code)).toBe(CODE_CELL_WIDTH);
+    // The diff card rows stay at the inset box width (BOX_WIDTH=76) + the 4-col
+    // Tool detail indent = 80, never widening toward the 130-col viewport.
+    const cardRows = stripAnsi(frame)
+      .split("\n")
+      .filter((l) => l.includes("│"));
+    expect(cardRows.length).toBeGreaterThan(0);
+    for (const row of cardRows) {
+      expect(stringWidth(row)).toBe(BOX_WIDTH + 4);
+    }
+  });
+
+  // Belt-and-suspenders: no rendered diff row exceeds the diff box width at a
+  // range of widths (the last code char can never sit past the right border).
+  it("never renders a diff row wider than the box across several widths", async () => {
+    for (const mcw of [40, 60, 80, 120]) {
+      const boxWidth = mcw - 4;
+      const cellWidth = diffInlineCodeCellWidth(boxWidth);
+      const frame = await renderTranscriptDiff(mcw, [
+        { kind: "ctx", oldLine: "1", newLine: "1", code: "ok();" },
+        { kind: "add", newLine: "2", code: "x".repeat(cellWidth) }, // exactly at width
+        { kind: "add", newLine: "3", code: "y".repeat(mcw + 50) }, // far over
+      ]);
+      const diffRows = stripAnsi(frame)
+        .split("\n")
+        .filter((l) => l.includes("│"));
+      for (const row of diffRows) {
+        // Every diff card row is the box width plus the 4-col Tool detail inset.
+        expect(stringWidth(row)).toBeLessThanOrEqual(boxWidth + 4);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Clears the longest-standing deferral — DiffInline code-cell width

Two diff-rendering symptoms (deferred twice for lack of a headless repro) share one root: the code cell sized itself by Yoga flex, and the ±1 rounding made an at-width line either ellipsize one char early (card top scrolled off) or spill its last char past the `│` border (border on-screen).

**Fix — deterministic by construction:** `codeCellWidth = boxOuterWidth − 15` (border 2 + paddingX 2 + the constant 11-col gutter), via a pure exported `diffInlineCodeCellWidth`. A dedicated `DiffInlineWidthContext` carries the box's exact outer width only where it's known (the transcript DIFF card under a Tool detail box). When present, the box + code cell widths are pinned and the code is **pre-truncated** with the same `truncate-end` helper — so Yoga rounding can't shift the truncation point. Short lines pass through unchanged. The auto-sized approval popup (width unknowable at that layer) keeps the legacy flex path → untouched.

Resolves **both** symptoms in one change.

**Revert-sensitive test** (sidesteps the no-headless-repro problem): forces a layout divergence — narrow content-width context (cell 61) at a wide viewport (130). Deterministic path truncates to 61; reverted flex path grows to 130 and truncates to 111 (`expected 111 to be 61`).

`npm run build` exit 0 · full `npm run test:unit` **13376 passed, 0 failures** · gutter/borders/coloring/collapse unchanged. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG