### PR TITLE
feat(tui): make truncated command output reachable (ctrl+o for full output)

### DIFF
--- a/runtime/src/tui/tool-rendering.tsx
+++ b/runtime/src/tui/tool-rendering.tsx
@@ -7,6 +7,7 @@ import { Ansi } from "./ink/Ansi.js";
 import { stringWidth } from "./ink/stringWidth.js";
 import { stripUnderlineAnsi } from "./components/shell/OutputLine.js";
 import { selectAgenCTuiGlyphs } from "./glyphs.js";
+import { getShortcutDisplay } from "./keybindings/shortcutFormat.js";
 import { AskUserQuestionTool } from "../tools/ask-user-question/tui-tool.js";
 import { formatToolPathForDisplay } from "../tools/system/agent-path-hints.js";
 import { isRecord } from "../utils/record.js";
@@ -396,9 +397,22 @@ interface CappedPreview {
  * Cap a block to the first `maxLines` non-trailing-whitespace lines (each line
  * also width-capped), appending a "… +K lines" continuation when the block is
  * longer. Matches the common CLI-agent `output_lines` convention.
+ *
+ * When `verbose` is set (the transcript is expanded via `app:toggleTranscript`)
+ * the cap is lifted: every line is returned uncapped and un-width-truncated so
+ * the FULL output is reachable — the "view full output" path the `… +K lines`
+ * affordance advertises. `remaining` stays 0 so no elision marker renders.
  */
-function capPreviewLines(value: string, maxLines: number): CappedPreview {
-  const all = value.replace(/\s+$/, "").split("\n").map(truncatePreviewWidth);
+function capPreviewLines(
+  value: string,
+  maxLines: number,
+  verbose = false,
+): CappedPreview {
+  const trimmed = value.replace(/\s+$/, "");
+  if (verbose) {
+    return { lines: trimmed.split("\n"), remaining: 0, tailLines: [] };
+  }
+  const all = trimmed.split("\n").map(truncatePreviewWidth);
   if (all.length <= maxLines)
     return { lines: all, remaining: 0, tailLines: [] };
   return {
@@ -427,8 +441,14 @@ function capPreviewLinesHeadTail(
   value: string,
   maxLines: number,
   headLines: number,
+  verbose = false,
 ): CappedPreview {
-  const all = value.replace(/\s+$/, "").split("\n").map(truncatePreviewWidth);
+  const trimmed = value.replace(/\s+$/, "");
+  // Expanded transcript: lift the cap entirely (full output, un-truncated).
+  if (verbose) {
+    return { lines: trimmed.split("\n"), remaining: 0, tailLines: [] };
+  }
+  const all = trimmed.split("\n").map(truncatePreviewWidth);
   if (all.length <= maxLines)
     return { lines: all, remaining: 0, tailLines: [] };
   // Clamp the head so at least one tail line always survives, then give the
@@ -444,6 +464,28 @@ function capPreviewLinesHeadTail(
 
 /** Head lines reserved for the failure-aware head+tail cap (tail gets the rest). */
 const BASH_PREVIEW_FAILURE_HEAD_LINES = 2;
+
+/**
+ * "view full output" affordance for the `… +K lines` continuation marker.
+ *
+ * The line cap above keeps the inline footprint small, but — unlike the Edit
+ * DIFF card, whose collapsed `… +N more · ctrl+w d for full diff` marker can
+ * reach the full diff — a capped command output was a DEAD END: the hidden
+ * lines were unreachable. This wires the marker to the same transcript-expand
+ * mechanism the rest of the TUI already uses for "show the full thing": the
+ * `app:toggleTranscript` shortcut (default `ctrl+o`, the same one
+ * `CtrlOToExpand`/`AdvisorMessage` surface). When the transcript is expanded the
+ * `verbose` prop (already plumbed into BashOutputView from
+ * `UserToolSuccessMessage`) flips on and the FULL stdout/stderr is rendered
+ * uncapped and scrollable — no bespoke pager/overlay required.
+ *
+ * `getShortcutDisplay` (not a hardcoded literal) so the hint honors a user's
+ * rebind of `app:toggleTranscript`, matching `ctrlOToExpand`'s formatting.
+ */
+function fullOutputAffordance(): string {
+  const shortcut = getShortcutDisplay("app:toggleTranscript", "Global", "ctrl+o");
+  return ` · ${shortcut} for full output`;
+}
 
 /**
  * Live `exec_command` trailer line, e.g.
@@ -514,7 +556,7 @@ function renderBashOutputLine(
 
 export function BashOutputView({
   content,
-  verbose: _verbose,
+  verbose = false,
 }: {
   readonly content: string;
   readonly verbose?: boolean;
@@ -588,14 +630,16 @@ export function BashOutputView({
         stdoutTrimmed,
         BASH_PREVIEW_MAX_LINES,
         BASH_PREVIEW_FAILURE_HEAD_LINES,
+        verbose,
       )
-    : capPreviewLines(stdoutTrimmed, BASH_PREVIEW_MAX_LINES);
+    : capPreviewLines(stdoutTrimmed, BASH_PREVIEW_MAX_LINES, verbose);
   const showStderr = isFailure && stderrTrimmed.length > 0;
   const stderrCap = showStderr
     ? capPreviewLinesHeadTail(
         stderrTrimmed,
         BASH_PREVIEW_MAX_LINES,
         BASH_PREVIEW_FAILURE_HEAD_LINES,
+        verbose,
       )
     : null;
   // Compact non-zero-exit indicator. The plain exec result folds stderr into
@@ -615,7 +659,7 @@ export function BashOutputView({
         {stdoutCap.remaining > 0 ? (
           <Text dimColor>{`… +${stdoutCap.remaining} ${
             stdoutCap.remaining === 1 ? "line" : "lines"
-          }`}</Text>
+          }${fullOutputAffordance()}`}</Text>
         ) : null}
         {/* TAIL block (failure head+tail cap): the trailing verdict/exception
             lines that survive AFTER the `… +K lines` elision. Empty on success. */}
@@ -633,7 +677,7 @@ export function BashOutputView({
         {stderrCap && stderrCap.remaining > 0 ? (
           <Text dimColor>{`… +${stderrCap.remaining} ${
             stderrCap.remaining === 1 ? "line" : "lines"
-          }`}</Text>
+          }${fullOutputAffordance()}`}</Text>
         ) : null}
         {stderrCap
           ? stderrCap.tailLines.map((line, idx) =>

--- a/runtime/tests/tools/tool-rendering-bash.test.tsx
+++ b/runtime/tests/tools/tool-rendering-bash.test.tsx
@@ -415,8 +415,10 @@ describe("BashOutputView — failure cap keeps the trailing verdict/exception (h
     expect(findText(flat, "F....")).toBe(true);
 
     // The elision reports the HIDDEN MIDDLE count: 11 lines, 2 head + 3 tail
-    // visible → 11 - 5 = 6 hidden.
-    expect(findMore(flat)).toBe("… +6 lines");
+    // visible → 11 - 5 = 6 hidden. The marker now also advertises the
+    // "view full output" affordance (the hidden lines are reachable by
+    // expanding the transcript), so it is no longer a dead end.
+    expect(findMore(flat)).toBe("… +6 lines · ctrl+o for full output");
   });
 
   test("STDOUT failure path: the bottom EXCEPTION line survives when it is the last line", () => {
@@ -430,8 +432,9 @@ describe("BashOutputView — failure cap keeps the trailing verdict/exception (h
     expect(findText(flat, "ZeroDivisionError: division by zero")).toBe(true);
     // Head context preserved too.
     expect(findText(flat, "starting computation")).toBe(true);
-    // 8 lines, 2 head + 3 tail → 8 - 5 = 3 hidden.
-    expect(findMore(flat)).toBe("… +3 lines");
+    // 8 lines, 2 head + 3 tail → 8 - 5 = 3 hidden. Marker carries the
+    // "view full output" affordance.
+    expect(findMore(flat)).toBe("… +3 lines · ctrl+o for full output");
   });
 
   test("STDERR envelope path: traceback verdict survives the red cap", () => {
@@ -453,8 +456,9 @@ describe("BashOutputView — failure cap keeps the trailing verdict/exception (h
     expect(verdict).toBeDefined();
     expect(findText(flat, "Ran 5 tests in 0.001s")).toBe(true);
 
-    // The stderr elision count is correct (same 11-line body → 6 hidden).
-    expect(findMore(flat)).toBe("… +6 lines");
+    // The stderr elision count is correct (same 11-line body → 6 hidden), and
+    // the marker advertises the "view full output" affordance.
+    expect(findMore(flat)).toBe("… +6 lines · ctrl+o for full output");
   });
 
   test("SUCCESS path is unchanged: head-only cap, trailing lines truncated away", () => {
@@ -474,7 +478,91 @@ describe("BashOutputView — failure cap keeps the trailing verdict/exception (h
     // ...and the trailing verdict is truncated away (head-only, unchanged).
     expect(findText(flat, "FAILED (failures=1)")).toBe(false);
     expect(findText(flat, "Ran 5 tests in 0.001s")).toBe(false);
-    // Head-only elision: 11 - 5 = 6 remaining.
-    expect(findMore(flat)).toBe("… +6 lines");
+    // Head-only elision: 11 - 5 = 6 remaining, with the "view full output"
+    // affordance on the marker.
+    expect(findMore(flat)).toBe("… +6 lines · ctrl+o for full output");
+  });
+});
+
+/**
+ * "view full output" affordance: a capped command output used to be a DEAD END
+ * — the hidden lines were unreachable, unlike the Edit DIFF card whose collapsed
+ * `… +N more · ctrl+w d for full diff` marker reaches the full diff. The
+ * `… +K lines` marker now advertises the existing transcript-expand mechanism
+ * (`app:toggleTranscript`, default `ctrl+o`), and when the transcript is
+ * expanded the `verbose` prop (already plumbed in from `UserToolSuccessMessage`)
+ * lifts the cap so the FULL output is reachable and scrollable.
+ *
+ * REVERT-SENSITIVITY: against the pre-fix renderer the marker was bare
+ * `… +K lines` (no affordance) and `verbose` was ignored (`_verbose`), so the
+ * "advertises the affordance" and "verbose lifts the cap" assertions go RED. The
+ * "absent when not truncated" assertion holds both before and after (it pins
+ * that the hint is gated on actual truncation, never shown spuriously).
+ */
+describe("BashOutputView — view-full-output affordance", () => {
+  const allTexts = (node: unknown): string[] =>
+    flattenBash(node)
+      .map((child) => child.props?.children)
+      .filter((value): value is string => typeof value === "string");
+
+  const findMoreLine = (node: unknown): string | undefined =>
+    allTexts(node).find((text) => text.startsWith("… +"));
+
+  test("a truncated success output marker advertises the full-output affordance", () => {
+    // 12 lines, exit 0 → head-only cap → 7 hidden. The marker now carries the
+    // affordance hint that points at the transcript-expand shortcut.
+    const body = Array.from({ length: 12 }, (_, i) => `row-${i + 1}`).join("\n");
+    const node = BashOutputView({
+      content: `<bash-stdout>${body}</bash-stdout>[exit_code=0]`,
+    });
+    const more = findMoreLine(node);
+    expect(more).toBe("… +7 lines · ctrl+o for full output");
+    // Honors the configured shortcut for app:toggleTranscript (default ctrl+o).
+    expect(more).toContain("ctrl+o");
+    expect(more).toContain("for full output");
+  });
+
+  test("the affordance is ABSENT when the output is not truncated (K === 0)", () => {
+    // 3 lines, under the 5-line cap → no elision marker, so no affordance.
+    const node = BashOutputView({
+      content: "<bash-stdout>a\nb\nc</bash-stdout>[exit_code=0]",
+    });
+    const texts = allTexts(node);
+    expect(texts.some((text) => text.startsWith("… +"))).toBe(false);
+    expect(texts.some((text) => text.includes("for full output"))).toBe(false);
+  });
+
+  test("verbose (expanded transcript) lifts the cap and shows the FULL output", () => {
+    // Same 12-line body, but verbose → every line is rendered, no elision, no
+    // affordance (nothing left to reach).
+    const body = Array.from({ length: 12 }, (_, i) => `row-${i + 1}`).join("\n");
+    const node = BashOutputView({
+      content: `<bash-stdout>${body}</bash-stdout>[exit_code=0]`,
+      verbose: true,
+    });
+    const texts = allTexts(node);
+    for (let i = 1; i <= 12; i++) {
+      expect(texts).toContain(`row-${i}`);
+    }
+    expect(texts.some((text) => text.startsWith("… +"))).toBe(false);
+    expect(texts.some((text) => text.includes("for full output"))).toBe(false);
+  });
+
+  test("verbose also lifts the cap on a FAILED output (full traceback reachable)", () => {
+    const body = [
+      ...Array.from({ length: 10 }, (_, i) => `step-${i + 1}`),
+      "AssertionError: boom",
+      "FAILED (failures=1)",
+    ].join("\n");
+    const node = BashOutputView({
+      content: `${body}\n\n[exec exit_code=1 wall_time=0.01s tokens=20]`,
+      verbose: true,
+    });
+    const texts = allTexts(node);
+    // The previously-hidden middle line is now reachable.
+    expect(texts).toContain("step-5");
+    expect(texts).toContain("AssertionError: boom");
+    expect(texts).toContain("FAILED (failures=1)");
+    expect(texts.some((text) => text.startsWith("… +"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Clears a deferred improvement — reach the full capped command output

Bash/Run output is capped to ~5 lines with a `… +K lines` marker, but the hidden lines were **unreachable** in the transcript (unlike a diff's `ctrl+w d for full diff`). A long traceback or verbose command was lost.

The diff full-view is approval/task-id-keyed and can't carry arbitrary tool-result text, so instead of a bespoke new surface this reuses the **canonical transcript-expand** mechanism: `app:toggleTranscript` (`ctrl+o`). `verbose` was already plumbed into `BashOutputView` but ignored — now honored, so expanding the transcript lifts the cap and renders the **complete** output, scrollable. Both `… +K lines` markers now show `· ctrl+o for full output` (via `getShortcutDisplay`, honors rebinds), only when truncated. The failure-aware cap is unchanged — this just adds the way to reach the rest.

Revert-sensitive (7 tests red on revert). `npm run build` exit 0 · full `npm run test:unit` **13380 passed, 0 failures**. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG