### PR TITLE
feat(tui): link a fixed re-run to the failure it resolves (now passing · was ✕ above)

### DIFF
--- a/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
+++ b/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
@@ -21,6 +21,8 @@ import { summarizeFileEditError } from '../../tools/FileEditTool/UI.js';
 import { firstLineOf } from '../../utils/stringUtils.js';
 import { summarizeToolInput } from './toolRowPreview.js';
 import { buildEditDiffPreview } from '../edit-diff-preview.js';
+import { isFixedRerunSuccess } from './fixedRerunLink.js';
+import { AURA_LIFECYCLE_GLYPHS } from '../../utils/theme.js';
 type Props = {
   param: AgenCToolUseBlockParam;
   addMargin: boolean;
@@ -241,6 +243,16 @@ export function AssistantToolUseMessage({
           : `×${retriedFailureCount} attempts failed`
         : `succeeded after ${retriedFailureCount} attempts`
       : baseReason;
+  // Cross-turn "fixed re-run" linkage: when THIS command row passes (`●`) and
+  // the identical command most-recently FAILED (`✕`) earlier in the session,
+  // annotate the passing row so the user sees the fix worked without manually
+  // scroll-matching two identical command strings across user-turn boundaries.
+  // Distinct from retriedFailureCount, which only folds AUTOMATIC same-turn
+  // retries. Mirrors the dim, inline, non-headline tone of failedReason.
+  const fixedRerunNote =
+    !verbose && toolState === "done" && isFixedRerunSuccess(param, lookups)
+      ? `now passing · was ${AURA_LIFECYCLE_GLYPHS.failed} above`
+      : undefined;
   const toolArgs =
     typeof renderedToolUseMessage === "string" &&
     renderedToolUseMessage.length > 0
@@ -253,7 +265,10 @@ export function AssistantToolUseMessage({
   // success path here, so there is no double-render and no vanish. A FAILED row
   // still surfaces its one-line reason inline (P0); the retry rollup is folded
   // into that same annotation (P1).
-  const rowResult: string | React.ReactNode | undefined = failedReason;
+  const rowResult: string | React.ReactNode | undefined =
+    failedReason && fixedRerunNote
+      ? `${failedReason} · ${fixedRerunNote}`
+      : failedReason ?? fixedRerunNote;
   const extraDetail = typeof renderedToolUseMessage === "string" ? null : renderedToolUseMessage;
   // Compact green/red diff for Edit/MultiEdit/Write, rendered HERE on the call
   // row from the tool-use INPUT (old_string/new_string for Edit/MultiEdit,

--- a/runtime/src/tui/message-renderers/fixedRerunLink.ts
+++ b/runtime/src/tui/message-renderers/fixedRerunLink.ts
@@ -1,0 +1,122 @@
+import type { MessageLookups } from '../../utils/messages.js'
+
+/**
+ * "Fixed re-run" linkage detection for command-bearing tool rows (Run/Bash).
+ *
+ * In an error → fix → re-run loop the user runs a command, it FAILS (`✕`), they
+ * fix the code, then run the SAME command again in a LATER user turn and it now
+ * PASSES (`●`). Those are two separate transcript rows with identical args,
+ * distinguished only by the leading glyph + exit note. There is no explicit
+ * "this passing re-run is the same command that failed above, now fixed" signal,
+ * so confirming the fix worked means manually scroll-matching two identical
+ * command strings.
+ *
+ * This detector links a PASSING command row back to an EARLIER FAILED row with
+ * the identical command in the same session/transcript, so the renderer can
+ * surface a dim inline note ("now passing · was ✕ above"). It complements — and
+ * is distinct from — the `retriedFailureCount` affordance, which only folds
+ * AUTOMATIC same-tool retries WITHIN one turn into "×N attempts failed"; it does
+ * NOT link a passing run across USER-TURN boundaries to an earlier failed run.
+ *
+ * History source: the `lookups` object the renderer already receives.
+ *   - `lookups.toolUseByToolUseID` is a Map of every tool_use in the session,
+ *     keyed by id, in chronological insertion order (built by iterating the
+ *     original `messages` array in `buildMessageLookups`). Iterating it yields
+ *     the prior tool-use sequence.
+ *   - `lookups.resolvedToolUseIDs` / `lookups.erroredToolUseIDs` give each
+ *     prior tool-use's resolution/error state.
+ *
+ * Matching rules (kept minimal + robust):
+ *   - Only command-bearing tool-uses participate: the input must carry a string
+ *     `command` field. Write/Edit (file_path/content) never match, so there are
+ *     no false positives from non-command tools.
+ *   - Identity is `(tool name, trimmed command string)`. Two runs link only when
+ *     both the tool name and the normalized command are identical.
+ *   - "First success after a failure" scoping: we inspect the MOST RECENT prior
+ *     RESOLVED occurrence of the same command. If that most recent resolved
+ *     occurrence ERRORED, this passing row is the fix → annotate. If it
+ *     SUCCEEDED (an intervening pass with no failure since), do NOT annotate, so
+ *     only the first pass after a failure is linked, not every later pass.
+ */
+
+type CommandToolUse = {
+  readonly id: string
+  readonly name: string
+  readonly command: string
+}
+
+/** Normalize a command string for cross-run identity (trim only — preserve
+ * internal whitespace so genuinely different commands stay distinct). */
+function normalizeCommand(command: string): string {
+  return command.trim()
+}
+
+/** Extract the command-bearing identity of a tool-use, or null if it carries no
+ * string `command` (e.g. Write/Edit/Read), so non-command tools never match. */
+function asCommandToolUse(
+  param: { id?: unknown; name?: unknown; input?: unknown } | undefined | null,
+): CommandToolUse | null {
+  if (!param || typeof param !== 'object') return null
+  const id = (param as { id?: unknown }).id
+  const name = (param as { name?: unknown }).name
+  const input = (param as { input?: unknown }).input
+  if (typeof id !== 'string' || typeof name !== 'string') return null
+  if (!input || typeof input !== 'object') return null
+  const command = (input as { command?: unknown }).command
+  if (typeof command !== 'string') return null
+  const normalized = normalizeCommand(command)
+  if (normalized.length === 0) return null
+  return { id, name, command: normalized }
+}
+
+/**
+ * Returns true when `param` is a PASSING command row whose identical command
+ * most-recently FAILED earlier in this session — i.e. the first passing re-run
+ * after a failure of the same command. Returns false for the failing row
+ * itself, when there is no earlier failure, when the most recent prior run of
+ * the same command already passed, when commands differ, and for non-command
+ * tools (Write/Edit).
+ *
+ * Caller must have already established that THIS row resolved successfully
+ * (resolved && not errored); we still re-check the success precondition here so
+ * the helper is safe to call standalone and never annotates a failing row.
+ */
+export function isFixedRerunSuccess(
+  param: { id?: unknown; name?: unknown; input?: unknown },
+  lookups: Pick<
+    MessageLookups,
+    'toolUseByToolUseID' | 'resolvedToolUseIDs' | 'erroredToolUseIDs'
+  >,
+): boolean {
+  const current = asCommandToolUse(param)
+  if (current === null) return false
+
+  // The current row must itself be a SUCCESS (resolved + not errored). A failing
+  // row is never annotated.
+  if (!lookups.resolvedToolUseIDs.has(current.id)) return false
+  if (lookups.erroredToolUseIDs.has(current.id)) return false
+
+  const sequence = lookups.toolUseByToolUseID
+  if (!sequence) return false
+
+  // Walk the chronological tool-use sequence up to (but excluding) the current
+  // row, tracking the resolution state of the MOST RECENT prior occurrence of
+  // the same (name, command). Map iteration order is chronological insertion
+  // order from buildMessageLookups.
+  let mostRecentPriorErrored: boolean | undefined
+  for (const prior of sequence.values()) {
+    if (prior.id === current.id) break // reached current row; stop scanning forward
+    const priorCmd = asCommandToolUse(prior)
+    if (priorCmd === null) continue
+    if (priorCmd.name !== current.name) continue
+    if (priorCmd.command !== current.command) continue
+    // Only RESOLVED prior runs count toward "most recent prior state"; an
+    // unresolved (still-running/queued) prior run is ignored.
+    if (!lookups.resolvedToolUseIDs.has(priorCmd.id)) continue
+    mostRecentPriorErrored = lookups.erroredToolUseIDs.has(priorCmd.id)
+  }
+
+  // Annotate only when the most recent prior RESOLVED run of this exact command
+  // ERRORED — i.e. this is the first success after a failure.
+  return mostRecentPriorErrored === true
+}

--- a/runtime/tests/tui/message-renderers/fixedRerunLink.test.tsx
+++ b/runtime/tests/tui/message-renderers/fixedRerunLink.test.tsx
@@ -1,0 +1,475 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Tool } from '../../tools/Tool.js'
+import type { AgenCToolUseBlockParam } from '../../types/message.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { isFixedRerunSuccess } from './fixedRerunLink.js'
+import { AssistantToolUseMessage } from './AssistantToolUseMessage.js'
+
+const classifierMock = vi.hoisted(() => ({ checking: false }))
+
+const appStateMock = vi.hoisted(() => ({
+  pendingWorkerRequest: undefined as undefined | { toolUseId: string },
+  toolPermissionContext: {
+    mode: 'default',
+    strippedDangerousRules: undefined as undefined | Record<string, unknown>,
+  },
+}))
+
+vi.mock('../../utils/classifierApprovalsHook.js', () => ({
+  useIsClassifierChecking: () => classifierMock.checking,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateMaybeOutsideOfProvider: (
+    selector: (state: typeof appStateMock) => unknown,
+  ) => selector(appStateMock),
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>('../ink.js')
+  return { ...actual, useTheme: () => ['dark'] }
+})
+
+// The on-brand failure glyph the annotation references (= AURA_LIFECYCLE_GLYPHS.failed).
+const FAIL_GLYPH = '✕'
+const NOW_PASSING = 'now passing'
+
+const tool = {
+  name: 'Bash',
+  inputSchema: {
+    safeParse: (input: unknown) => ({ success: true, data: input }),
+  },
+  userFacingName: () => 'Bash',
+  renderToolUseMessage: (input: { command: string }) => input.command,
+  renderToolUseProgressMessage: () => null,
+} as unknown as Tool
+
+type ToolUseBlock = {
+  id: string
+  name: string
+  input: unknown
+}
+
+/**
+ * Build the `lookups` object the renderer receives. `runs` is the chronological
+ * tool-use sequence; each carries its resolution state so we can reproduce a
+ * fail-then-pass transcript.
+ */
+function buildLookups(
+  runs: readonly {
+    id: string
+    name: string
+    input: unknown
+    resolved: boolean
+    errored?: boolean
+  }[],
+) {
+  const toolUseByToolUseID = new Map<string, ToolUseBlock>()
+  const resolvedToolUseIDs = new Set<string>()
+  const erroredToolUseIDs = new Set<string>()
+  for (const run of runs) {
+    toolUseByToolUseID.set(run.id, {
+      id: run.id,
+      name: run.name,
+      input: run.input,
+    })
+    if (run.resolved) resolvedToolUseIDs.add(run.id)
+    if (run.errored) erroredToolUseIDs.add(run.id)
+  }
+  return { toolUseByToolUseID, resolvedToolUseIDs, erroredToolUseIDs }
+}
+
+async function renderRow(
+  param: AgenCToolUseBlockParam,
+  lookups: ReturnType<typeof buildLookups>,
+): Promise<string> {
+  return renderToString(
+    <AssistantToolUseMessage
+      param={param}
+      addMargin={false}
+      tools={[tool]}
+      commands={[]}
+      verbose={false}
+      // Resolved rows are NOT in-progress; pass an empty in-progress set so the
+      // row renders in its resolved (done/failed) state.
+      inProgressToolUseIDs={new Set<string>()}
+      progressMessagesForMessage={[]}
+      shouldAnimate={false}
+      shouldShowDot={false}
+      lookups={lookups as never}
+    />,
+    80,
+  )
+}
+
+beforeEach(() => {
+  classifierMock.checking = false
+  appStateMock.pendingWorkerRequest = undefined
+  appStateMock.toolPermissionContext.mode = 'default'
+  appStateMock.toolPermissionContext.strippedDangerousRules = undefined
+})
+
+describe('isFixedRerunSuccess (unit)', () => {
+  const failThenPass = buildLookups([
+    {
+      id: 'fail1',
+      name: 'Bash',
+      input: { command: 'npm run build' },
+      resolved: true,
+      errored: true,
+    },
+    {
+      id: 'pass1',
+      name: 'Bash',
+      input: { command: 'npm run build' },
+      resolved: true,
+    },
+  ])
+
+  it('links a passing row to an earlier failed run of the identical command', () => {
+    expect(
+      isFixedRerunSuccess(
+        { id: 'pass1', name: 'Bash', input: { command: 'npm run build' } },
+        failThenPass,
+      ),
+    ).toBe(true)
+  })
+
+  it('ignores leading/trailing whitespace when matching the command', () => {
+    const lookups = buildLookups([
+      {
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: '  npm run build  ' },
+        resolved: true,
+      },
+    ])
+    expect(
+      isFixedRerunSuccess(
+        { id: 'pass1', name: 'Bash', input: { command: '  npm run build  ' } },
+        lookups,
+      ),
+    ).toBe(true)
+  })
+
+  it('does NOT link when the earlier run of the same command also passed', () => {
+    const lookups = buildLookups([
+      {
+        id: 'pass0',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+    ])
+    expect(
+      isFixedRerunSuccess(
+        { id: 'pass1', name: 'Bash', input: { command: 'npm run build' } },
+        lookups,
+      ),
+    ).toBe(false)
+  })
+
+  it('only links the FIRST pass after a failure, not a later pass with no intervening failure', () => {
+    const lookups = buildLookups([
+      {
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm test' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm test' },
+        resolved: true,
+      },
+      {
+        id: 'pass2',
+        name: 'Bash',
+        input: { command: 'npm test' },
+        resolved: true,
+      },
+    ])
+    // First pass after the failure → linked.
+    expect(
+      isFixedRerunSuccess(
+        { id: 'pass1', name: 'Bash', input: { command: 'npm test' } },
+        lookups,
+      ),
+    ).toBe(true)
+    // Second pass, whose most recent prior run (pass1) already passed → NOT linked.
+    expect(
+      isFixedRerunSuccess(
+        { id: 'pass2', name: 'Bash', input: { command: 'npm test' } },
+        lookups,
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT link when the earlier failure was a DIFFERENT command', () => {
+    const lookups = buildLookups([
+      {
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm run lint' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+    ])
+    expect(
+      isFixedRerunSuccess(
+        { id: 'pass1', name: 'Bash', input: { command: 'npm run build' } },
+        lookups,
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT link the failing row itself', () => {
+    expect(
+      isFixedRerunSuccess(
+        { id: 'fail1', name: 'Bash', input: { command: 'npm run build' } },
+        failThenPass,
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT link Write/Edit rows (no command field)', () => {
+    const lookups = buildLookups([
+      {
+        id: 'edit_fail',
+        name: 'Edit',
+        input: { file_path: '/a.ts', old_string: 'x', new_string: 'y' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'edit_pass',
+        name: 'Edit',
+        input: { file_path: '/a.ts', old_string: 'y', new_string: 'z' },
+        resolved: true,
+      },
+    ])
+    expect(
+      isFixedRerunSuccess(
+        {
+          id: 'edit_pass',
+          name: 'Edit',
+          input: { file_path: '/a.ts', old_string: 'y', new_string: 'z' },
+        },
+        lookups,
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT cross-link different tool names sharing a command string', () => {
+    const lookups = buildLookups([
+      {
+        id: 'ps_fail',
+        name: 'PowerShell',
+        input: { command: 'build' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'bash_pass',
+        name: 'Bash',
+        input: { command: 'build' },
+        resolved: true,
+      },
+    ])
+    expect(
+      isFixedRerunSuccess(
+        { id: 'bash_pass', name: 'Bash', input: { command: 'build' } },
+        lookups,
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('AssistantToolUseMessage fixed re-run annotation (render)', () => {
+  it('annotates a passing row that re-runs an earlier failed command', async () => {
+    const lookups = buildLookups([
+      {
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+    ])
+    const output = await renderRow(
+      {
+        type: 'tool_use',
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+      },
+      lookups,
+    )
+    expect(output).toContain(NOW_PASSING)
+    expect(output).toContain(`was ${FAIL_GLYPH} above`)
+  })
+
+  it('does NOT annotate when the earlier run of the same command succeeded', async () => {
+    const lookups = buildLookups([
+      {
+        id: 'pass0',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+    ])
+    const output = await renderRow(
+      {
+        type: 'tool_use',
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+      },
+      lookups,
+    )
+    expect(output).not.toContain(NOW_PASSING)
+  })
+
+  it('does NOT annotate when the earlier failure was a different command', async () => {
+    const lookups = buildLookups([
+      {
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm run lint' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+    ])
+    const output = await renderRow(
+      {
+        type: 'tool_use',
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+      },
+      lookups,
+    )
+    expect(output).not.toContain(NOW_PASSING)
+  })
+
+  it('does NOT annotate the failing row itself', async () => {
+    const lookups = buildLookups([
+      {
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'pass1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+        resolved: true,
+      },
+    ])
+    const output = await renderRow(
+      {
+        type: 'tool_use',
+        id: 'fail1',
+        name: 'Bash',
+        input: { command: 'npm run build' },
+      },
+      lookups,
+    )
+    expect(output).not.toContain(NOW_PASSING)
+  })
+
+  it('does NOT annotate a Write/Edit re-run', async () => {
+    const editTool = {
+      name: 'Edit',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      userFacingName: () => 'Edit',
+      renderToolUseMessage: () => '/a.ts',
+      renderToolUseProgressMessage: () => null,
+    } as unknown as Tool
+    const lookups = buildLookups([
+      {
+        id: 'edit_fail',
+        name: 'Edit',
+        input: { file_path: '/a.ts', old_string: 'x', new_string: 'y' },
+        resolved: true,
+        errored: true,
+      },
+      {
+        id: 'edit_pass',
+        name: 'Edit',
+        input: { file_path: '/a.ts', old_string: 'y', new_string: 'z' },
+        resolved: true,
+      },
+    ])
+    const output = await renderToString(
+      <AssistantToolUseMessage
+        param={{
+          type: 'tool_use',
+          id: 'edit_pass',
+          name: 'Edit',
+          input: { file_path: '/a.ts', old_string: 'y', new_string: 'z' },
+        }}
+        addMargin={false}
+        tools={[editTool]}
+        commands={[]}
+        verbose={false}
+        inProgressToolUseIDs={new Set<string>()}
+        progressMessagesForMessage={[]}
+        shouldAnimate={false}
+        shouldShowDot={false}
+        lookups={lookups as never}
+      />,
+      80,
+    )
+    expect(output).not.toContain(NOW_PASSING)
+  })
+})


### PR DESCRIPTION
## Clears the last deferred improvement — fixed-rerun linkage

In an error→fix→re-run loop, a command fails (`✕`), gets fixed, then passes (`●`) in a later turn — two separate rows with identical args, so confirming the fix meant scroll-matching command strings. (`retriedFailureCount` only handles automatic retries within one turn.)

No new data flow needed: `lookups` already carries `toolUseByToolUseID` (chronological) + `resolvedToolUseIDs`/`erroredToolUseIDs`. New `isFixedRerunSuccess` matches on `(tool name, trimmed command)` (so Write/Edit never match), requires the current row be a success, and uses first-success-after-failure scoping (annotates only when the most-recent prior run of that exact command errored). The note `now passing · was ✕ above` (canonical failed glyph) folds into the passing row's result line in the same dim tone as the existing reason/retry notes.

Revert-sensitive (reverting reds the render assertion). 13 tests covering whitespace-tolerant match, no-link cases (prior passed / different command / failing row / Write-Edit / cross-tool-name), and first-pass-only scoping. `npm run build` exit 0 · full `npm run test:unit` **13393 passed, 0 failures**. No tmux.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG