### PR TITLE
fix(daemon): signal-aware tool hooks — a wedged hook releases the lock (goal #1)

### DIFF
--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -753,6 +753,13 @@ export class StreamingToolExecutor {
             args,
           },
           onHookError ? (err, idx) => onHookError("pre", err, idx) : undefined,
+          undefined,
+          // Bound a wedged pre-hook by the executor abort signal. NOTE:
+          // this lean-rebuild StreamingToolExecutor does NOT wrap dispatch
+          // in a ToolCallRuntime lock guard (its run() just calls fn()), so
+          // this is a hang-bound, not a lock-release leg. The lock-release
+          // guarantee lives on the real router/concurrency path.
+          this.abortSignal,
         );
         if (preResult.kind === "deny") {
           denyFromPre = preResult.reason ?? "denied by pre-tool-use hook";

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -1127,6 +1127,27 @@ export async function runToolUse(
         );
       },
       opts.onHookTiming,
+      // Direct/test (non-router) pre-hook seam. Dead on the live router
+      // hot path (router passes preHooks:[] into runToolUse), but
+      // reachable by direct callers and tests — thread for coherence so
+      // a wedged pre-hook here is also bounded by the abort signal.
+      effectiveSignal,
+      (idx) => {
+        emitHookAttachment(
+          opts.eventLog,
+          subId,
+          "hook_cancelled",
+          `PreToolUse:${tool.name}#${idx} cancelled (drain/timeout); fail-closed deny synthesized`,
+        );
+      },
+      (idx) => {
+        emitHookAttachment(
+          opts.eventLog,
+          subId,
+          "hook_orphaned",
+          `PreToolUse:${tool.name}#${idx} ignored its cancel signal; lock reclaimed, hook task orphaned`,
+        );
+      },
     );
     args = preDecision.args ?? args;
     if (preDecision.hookPermissionResult) {
@@ -1709,6 +1730,7 @@ export async function runToolUse(
           args: inputForTool,
           error: err,
           isInterrupt: cls === "aborted" || cls === "shell_interrupted",
+          ...(effectiveSignal !== undefined ? { signal: effectiveSignal } : {}),
         },
         (hookErr, idx) => {
           opts.onHookError?.("failure", hookErr, idx);
@@ -1720,6 +1742,26 @@ export async function runToolUse(
           );
         },
         opts.onHookTiming,
+        // Race the drain/timeout signal: a wedged failure hook is dropped
+        // (records-so-far returned) so the lock-wrapped fn() settles; the
+        // original tool error still bubbles below (unchanged).
+        effectiveSignal,
+        (idx) => {
+          emitHookAttachment(
+            opts.eventLog,
+            subId,
+            "hook_cancelled",
+            `PostToolUseFailure:${tool.name}#${idx} cancelled (drain/timeout); remaining failure hooks dropped`,
+          );
+        },
+        (idx) => {
+          emitHookAttachment(
+            opts.eventLog,
+            subId,
+            "hook_orphaned",
+            `PostToolUseFailure:${tool.name}#${idx} ignored its cancel signal; lock reclaimed, hook task orphaned`,
+          );
+        },
       );
     }
     cleanupModeSub();
@@ -1763,6 +1805,25 @@ export async function runToolUse(
         );
       },
       opts.onHookTiming,
+      // The signal in `base` is now RACED by the loop (not just plumbed):
+      // a wedged post-hook resolves fail-safe `continue` (the tool already
+      // ran) so this lock-wrapped fn() settles and releases the guard.
+      (idx) => {
+        emitHookAttachment(
+          opts.eventLog,
+          subId,
+          "hook_cancelled",
+          `PostToolUse:${tool.name}#${idx} cancelled (drain/timeout); rewritten result preserved (continue)`,
+        );
+      },
+      (idx) => {
+        emitHookAttachment(
+          opts.eventLog,
+          subId,
+          "hook_orphaned",
+          `PostToolUse:${tool.name}#${idx} ignored its cancel signal; lock reclaimed, hook task orphaned`,
+        );
+      },
     );
     finalDispatch = postDecision.result;
     for (const c of postDecision.additionalContexts) {

--- a/runtime/src/tools/hooks.ts
+++ b/runtime/src/tools/hooks.ts
@@ -46,6 +46,150 @@ export interface HookTimingRecord {
   readonly hookIndex: number;
   readonly durationMs: number;
   readonly overThreshold: boolean;
+  /**
+   * Set when the hook's per-call `await` was cut short by an aborting
+   * signal (drain/timeout) rather than the hook producing a verdict.
+   * Distinct from a thrown hook (which is fail-open and never sets
+   * this). See `raceHookWithSignal`.
+   */
+  readonly cancelled?: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Signal-aware single-hook race (mirrors execution.ts withTimeoutAndAbort
+// minus the timeout leg). On abort, resolves `cancelled` WITHOUT awaiting
+// the (possibly wedged) hook — this is what lets the surrounding loop
+// return so the lock-wrapped fn() can settle and release its guard.
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Typed three-variant terminal of a single hook race. Keeping
+ * throw-vs-cancel in the type (never a cast) is load-bearing: a thrown
+ * hook had its say and is treated fail-OPEN (swallow + continue) by every
+ * runner, while a cancelled hook never produced its verdict and the
+ * security-relevant runners treat it fail-CLOSED.
+ */
+export type HookRace<T> =
+  | { readonly settled: "value"; readonly value: T }
+  | { readonly settled: "cancelled"; readonly reason: unknown }
+  | { readonly settled: "threw"; readonly error: unknown };
+
+/**
+ * Grace (ms) after a cancel before a still-pending hook is labelled an
+ * orphan. A cooperative hook that resolves in response to the abort settles
+ * within this window and is NOT counted; only a signal-blind hook is. Small
+ * enough to be observable promptly, large enough to absorb the
+ * resolve-on-abort microtask hop. The `cancelled` resolution does NOT wait
+ * for this; only the `hook_orphaned` label does.
+ */
+const ORPHAN_GRACE_MS = 10;
+
+/**
+ * Run a single hook, racing it against `signal`.
+ *
+ * - No signal → just await the hook (value/threw).
+ * - Already aborted → resolve `cancelled` immediately WITHOUT calling the
+ *   hook (the already-aborted fast path).
+ * - Otherwise → race the hook against the signal's `abort`. If the signal
+ *   fires first, resolve `cancelled` immediately, WITHOUT awaiting the
+ *   (possibly wedged) hook. The orphaned hook promise is detached and
+ *   `.catch(()=>{})`'d so a wedged hook never becomes an unhandledRejection,
+ *   and a first-settle `done` latch guarantees a late settle cannot mutate
+ *   caller state (same first-settle-wins discipline as
+ *   `finalizeOnce`/`startReclaimAccounting`).
+ *
+ * `onOrphaned` (optional) fires AT MOST ONCE if, after the race resolved
+ * `cancelled`, the hook task is STILL pending past a short cooperative
+ * grace — i.e. an uncooperative hook that ignored its signal and keeps
+ * running detached. A cooperative hook that resolves *in response to* the
+ * abort (a very common pattern: the hook itself listens on the same signal)
+ * settles within the grace and is NOT counted as an orphan, even though it
+ * is momentarily pending at the exact synchronous abort instant. This is
+ * the same reclaimed-vs-leaked grace-race discipline as
+ * `startReclaimAccounting`. `onOrphaned` is NEVER fired for the
+ * already-aborted fast path (the hook never ran). The orphan accounting is
+ * decoupled from — and never delays — the `cancelled` resolution, which
+ * still happens immediately so the lock-wrapped fn() settles at once.
+ */
+export async function raceHookWithSignal<T>(
+  call: () => Promise<T> | T,
+  signal: AbortSignal | undefined,
+  onOrphaned?: () => void,
+): Promise<HookRace<T>> {
+  if (!signal) {
+    try {
+      return { settled: "value", value: await call() };
+    } catch (error) {
+      return { settled: "threw", error };
+    }
+  }
+  if (signal.aborted) {
+    return { settled: "cancelled", reason: signal.reason };
+  }
+
+  let done = false;
+  let hookSettled = false;
+  let onAbort: (() => void) | null = null;
+  const cleanup = (): void => {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+      onAbort = null;
+    }
+  };
+  try {
+    return await new Promise<HookRace<T>>((resolve) => {
+      onAbort = (): void => {
+        if (done) return;
+        done = true;
+        cleanup();
+        // Resolve `cancelled` IMMEDIATELY — lock release must not wait for
+        // the orphan determination.
+        resolve({ settled: "cancelled", reason: signal.reason });
+        // Orphan accounting is deferred and decoupled: a cooperative hook
+        // that resolves in response to THIS abort settles within a short
+        // grace and is NOT an orphan; only a hook still pending past the
+        // grace is the uncooperative residue. Fire onOrphaned at most once.
+        if (onOrphaned) {
+          let orphanFired = false;
+          const maybeOrphan = (): void => {
+            if (orphanFired || hookSettled) return;
+            orphanFired = true;
+            try {
+              onOrphaned();
+            } catch {
+              // observability must never throw into the hook loop
+            }
+          };
+          const t = setTimeout(maybeOrphan, ORPHAN_GRACE_MS);
+          (t as { unref?: () => void }).unref?.();
+        }
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      Promise.resolve()
+        .then(call)
+        .then(
+          (value) => {
+            hookSettled = true;
+            if (done) return;
+            done = true;
+            cleanup();
+            resolve({ settled: "value", value });
+          },
+          (error) => {
+            hookSettled = true;
+            if (done) return;
+            done = true;
+            cleanup();
+            resolve({ settled: "threw", error });
+          },
+        )
+        // Detached orphan: a wedged/late hook must never surface as an
+        // unhandledRejection once the race has already settled.
+        .catch(() => {});
+    });
+  } finally {
+    cleanup(); // belt-and-suspenders listener removal on every path
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -110,6 +254,12 @@ export type PreToolUseHook = (input: {
   readonly invocation: ToolInvocation;
   readonly tool: Tool;
   readonly args: Record<string, unknown>;
+  /**
+   * Drain/timeout-aware abort signal. Cooperative hooks may observe it
+   * to bail early; the lock-release guarantee comes from the runner
+   * racing the signal (see `raceHookWithSignal`), not from this field.
+   */
+  readonly signal?: AbortSignal;
 }) => Promise<PreToolUseDecision> | PreToolUseDecision;
 
 export interface PreHooksResult {
@@ -145,6 +295,9 @@ export async function runPreToolUseHooks(
   },
   onError?: (err: unknown, idx: number) => void,
   onTiming?: (record: HookTimingRecord) => void,
+  signal?: AbortSignal,
+  onCancelled?: (idx: number) => void,
+  onOrphaned?: (idx: number) => void,
 ): Promise<PreHooksResult> {
   let args = base.args;
   let hookPermissionResult: HookPermissionResult | undefined;
@@ -156,10 +309,47 @@ export async function runPreToolUseHooks(
     if (!hook) continue;
     let decision: PreToolUseDecision;
     const started = Date.now();
-    try {
-      decision = await hook({ invocation: base.invocation, tool: base.tool, args });
-    } catch (err) {
-      onError?.(err, i);
+    const race = await raceHookWithSignal(
+      () =>
+        hook({
+          invocation: base.invocation,
+          tool: base.tool,
+          args,
+          ...(signal !== undefined ? { signal } : {}),
+        }),
+      signal,
+      () => onOrphaned?.(i),
+    );
+    if (race.settled === "cancelled") {
+      // FAIL-CLOSED: synthesize a deny terminal carrying everything
+      // accumulated by hooks that fully completed BEFORE this point.
+      // This makes the surrounding loop RETURN so the lock-wrapped
+      // dispatch fn() settles and its finally releases the guard. The
+      // cancelled hook produced no decision ⇒ none of its
+      // args/permission/context are applied (atomic break).
+      const durationMs = Date.now() - started;
+      onTiming?.({
+        phase: "pre",
+        toolName: base.tool.name,
+        hookIndex: i,
+        durationMs,
+        overThreshold: durationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS,
+        cancelled: true,
+      });
+      onCancelled?.(i);
+      return {
+        kind: "deny",
+        reason: `pre-hook cancelled (drain/timeout) before producing a verdict: ${base.tool.name}#${i}`,
+        args,
+        additionalContexts,
+        ...(hookPermissionResult !== undefined ? { hookPermissionResult } : {}),
+        ...(preventContinuation !== undefined ? { preventContinuation } : {}),
+      };
+    }
+    if (race.settled === "threw") {
+      // UNCHANGED existing fail-open behavior: a thrown hook is swallowed
+      // and the loop proceeds (the hook had its say; throw != cancel).
+      onError?.(race.error, i);
       const durationMs = Date.now() - started;
       onTiming?.({
         phase: "pre",
@@ -170,6 +360,7 @@ export async function runPreToolUseHooks(
       });
       continue;
     }
+    decision = race.value;
     const durationMs = Date.now() - started;
     onTiming?.({
       phase: "pre",
@@ -293,6 +484,16 @@ export type PostToolUseHook = (input: {
 /** Kinds of live-path attachments every hook pipeline can emit. */
 export type HookAttachmentKind =
   | "hook_cancelled"
+  /**
+   * Distinct from `hook_cancelled` (which fires on every drain/timeout
+   * cancellation) and from the execute-phase `leaked` count: a
+   * `hook_orphaned` event fires only when a cancelled hook's underlying
+   * task was STILL PENDING at cancel time — i.e. an uncooperative hook
+   * that ignored its signal and keeps running detached. The LOCK is
+   * already reclaimed; this honestly accounts the residual orphan task
+   * (never claimed killed).
+   */
+  | "hook_orphaned"
   | "hook_blocking_error"
   | "hook_additional_context"
   | "hook_stopped_continuation"
@@ -332,6 +533,8 @@ export async function runPostToolUseHooks(
   },
   onError?: (err: unknown, idx: number) => void,
   onTiming?: (record: HookTimingRecord) => void,
+  onCancelled?: (idx: number) => void,
+  onOrphaned?: (idx: number) => void,
 ): Promise<PostHooksResult> {
   let result = base.result;
   const additionalContexts: string[] = [];
@@ -344,15 +547,37 @@ export async function runPostToolUseHooks(
     if (!hook) continue;
     let decision: PostToolUseDecision;
     const started = Date.now();
-    try {
-      decision = await hook({
-        invocation: base.invocation,
-        tool: base.tool,
-        args: base.args,
-        result,
-        ...(base.signal !== undefined ? { signal: base.signal } : {}),
+    const race = await raceHookWithSignal(
+      () =>
+        hook({
+          invocation: base.invocation,
+          tool: base.tool,
+          args: base.args,
+          result,
+          ...(base.signal !== undefined ? { signal: base.signal } : {}),
+        }),
+      base.signal,
+      () => onOrphaned?.(i),
+    );
+    if (race.settled === "cancelled") {
+      // FAIL-SAFE-AS-CONTINUE: the tool already ran. Keep the
+      // already-rewritten result + everything accumulated and let the
+      // loop return so the lock-wrapped fn() settles. NEVER coerce to
+      // stop/preventContinuation on a cancel.
+      const durationMs = Date.now() - started;
+      onTiming?.({
+        phase: "post",
+        toolName: base.tool.name,
+        hookIndex: i,
+        durationMs,
+        overThreshold: durationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS,
+        cancelled: true,
       });
-    } catch (err) {
+      onCancelled?.(i);
+      return { kind: "continue", result, additionalContexts, blockingErrors };
+    }
+    if (race.settled === "threw") {
+      const err = race.error;
       onError?.(err, i);
       const durationMs = Date.now() - started;
       onTiming?.({
@@ -365,6 +590,7 @@ export async function runPostToolUseHooks(
       blockingErrors.push(err instanceof Error ? err.message : String(err));
       continue;
     }
+    decision = race.value;
     const durationMs = Date.now() - started;
     onTiming?.({
       phase: "post",
@@ -432,6 +658,8 @@ export interface PostToolUseFailureHookInput {
   readonly args: Record<string, unknown>;
   readonly error: unknown;
   readonly isInterrupt?: boolean;
+  /** Drain/timeout-aware abort signal (cooperative hooks may observe it). */
+  readonly signal?: AbortSignal;
 }
 
 export type PostToolUseFailureHook = (
@@ -450,16 +678,40 @@ export async function runPostToolUseFailureHooks(
   base: PostToolUseFailureHookInput,
   onError?: (err: unknown, idx: number) => void,
   onTiming?: (record: HookTimingRecord) => void,
+  signal?: AbortSignal,
+  onCancelled?: (idx: number) => void,
+  onOrphaned?: (idx: number) => void,
 ): Promise<ReadonlyArray<HookTimingRecord>> {
   const records: HookTimingRecord[] = [];
   for (let i = 0; i < hooks.length; i += 1) {
     const hook = hooks[i];
     if (!hook) continue;
     const started = Date.now();
-    try {
-      await hook(base);
-    } catch (err) {
-      onError?.(err, i);
+    const race = await raceHookWithSignal(
+      () => hook(base),
+      signal,
+      () => onOrphaned?.(i),
+    );
+    if (race.settled === "cancelled") {
+      // Drop the remaining (purely observational) failure hooks and
+      // return the records gathered so far plus a cancelled marker. The
+      // original tool error still bubbles from the caller (unchanged).
+      onCancelled?.(i);
+      const durationMs = Date.now() - started;
+      const record: HookTimingRecord = {
+        phase: "failure",
+        toolName: base.tool.name,
+        hookIndex: i,
+        durationMs,
+        overThreshold: durationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS,
+        cancelled: true,
+      };
+      records.push(record);
+      onTiming?.(record);
+      return records;
+    }
+    if (race.settled === "threw") {
+      onError?.(race.error, i);
     }
     const durationMs = Date.now() - started;
     const record: HookTimingRecord = {
@@ -594,17 +846,42 @@ export async function resolveHookPermissionDecision(
   onError?: (err: unknown, idx: number) => void,
   onTiming?: (record: HookTimingRecord) => void,
   context: Omit<PermissionDecisionHookInput, "toolName" | "args"> = {},
+  onCancelled?: (idx: number) => void,
+  onOrphaned?: (idx: number) => void,
 ): Promise<PermissionDecisionResult> {
   for (let i = 0; i < hooks.length; i += 1) {
     const hook = hooks[i];
     if (!hook) continue;
     const started = Date.now();
     let decision: PermissionDecisionResult | undefined;
-    try {
-      decision = await hook({ toolName, args, ...context });
-    } catch (err) {
-      onError?.(err, i);
+    const race = await raceHookWithSignal(
+      () => hook({ toolName, args, ...context }),
+      context.signal,
+      () => onOrphaned?.(i),
+    );
+    if (race.settled === "cancelled") {
+      // PRESERVE the documented fail-open-on-broken-hook contract: a
+      // cancelled permission hook resolves to `pass` (falls through to
+      // the next hook / the final {kind:"pass"}). The real fail-closed
+      // gate is the pre-hook deny terminal + the already-shipped
+      // execute-phase abort — NOT this runner. Do NOT flip to deny.
+      onCancelled?.(i);
+      const durationMs = Date.now() - started;
+      onTiming?.({
+        phase: "permission",
+        toolName,
+        hookIndex: i,
+        durationMs,
+        overThreshold: durationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS,
+        cancelled: true,
+      });
+      continue;
+    }
+    if (race.settled === "threw") {
+      onError?.(race.error, i);
       decision = undefined;
+    } else {
+      decision = race.value;
     }
     const durationMs = Date.now() - started;
     onTiming?.({

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -772,6 +772,27 @@ export class ToolRouter {
             `PreToolUse:${spec.tool.name} threw: ${err instanceof Error ? err.message : String(err)}`,
           );
         },
+        undefined,
+        // Drain/timeout-aware signal: lets a wedged pre-hook be cancelled
+        // in place so this lock-wrapped dispatch settles and releases the
+        // ToolCallRuntime guard (turning `leaked` → `reclaimed`).
+        opts.signal,
+        (idx) => {
+          emitWarningEvent(
+            opts.session.eventLog,
+            toolCall.id,
+            "hook_cancelled",
+            `PreToolUse:${spec.tool.name}#${idx} cancelled (drain/timeout); fail-closed deny synthesized`,
+          );
+        },
+        (idx) => {
+          emitWarningEvent(
+            opts.session.eventLog,
+            toolCall.id,
+            "hook_orphaned",
+            `PreToolUse:${spec.tool.name}#${idx} ignored its cancel signal; lock reclaimed, hook task orphaned`,
+          );
+        },
       );
       executionArgs = preDecision.args ?? executionArgs;
       if (preDecision.hookPermissionResult) {

--- a/runtime/tests/tools/hooks-lock-release.test.ts
+++ b/runtime/tests/tools/hooks-lock-release.test.ts
@@ -1,0 +1,161 @@
+/**
+ * PRIMARY acceptance test for GOAL ITEM #1 (signal-aware, cooperatively-
+ * cancellable tool hooks).
+ *
+ * The load-bearing proof: a real `ToolCallRuntime` lock held by tool A
+ * while A runs a WEDGED, UNCOOPERATIVE pre-hook (`() => new Promise(()=>{})`
+ * that ignores its abort signal). A sibling B is queued on the SAME runtime
+ * guard. Before abort, B has NOT acquired. After `ac.abort(...)`:
+ *
+ *   - A's `runPreToolUseHooks` resolves to a fail-closed `"deny"` (the
+ *     signal-race cut the wedged hook short WITHOUT awaiting it), so the
+ *     lock-wrapped fn() settles and the existing `finally` releases the
+ *     guard, AND
+ *   - B ACQUIRES the guard within a bounded timeout. ← THE PROOF.
+ *
+ * The acceptance criterion is the SIBLING acquiring the released guard,
+ * not "the call returned". Three guard variants prove all three release
+ * legs: exclusive (write gate), shared_read (readers--), shared_server
+ * (Semaphore permit freed).
+ *
+ * REVERT-SENSITIVITY: against the pre-fix `hooks.ts` (no signal param, no
+ * `raceHookWithSignal`), the wedged `await hook(...)` hangs forever, A's
+ * fn() never settles, B never acquires, and the bounded await REJECTS
+ * (clean red). The stash/restore run is reported in the agent summary.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  EXCLUSIVE,
+  SHARED_READ,
+  sharedServer,
+  ToolCallRuntime,
+  type ConcurrencyClass,
+} from "./concurrency.js";
+import { runPreToolUseHooks, type PreToolUseHook } from "./hooks.js";
+import type { Tool } from "./types.js";
+import type { ToolInvocation } from "./context.js";
+
+const stubTool: Tool = {
+  name: "stub",
+  description: "",
+  inputSchema: {},
+  execute: async () => ({ content: "ok" }),
+};
+const stubInvocation: ToolInvocation = {
+  session: {} as never,
+  turn: {} as never,
+  tracker: {
+    appendFileDiff: () => {},
+    snapshot: () => [],
+    clear: () => {},
+  },
+  callId: "c1",
+  toolName: { name: "stub" },
+  payload: { kind: "function", arguments: "" },
+  source: "direct",
+};
+
+/** Bound an await so a regression is a CLEAN reject, not an ambient hang. */
+function withTestTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_resolve, reject) => {
+      const t = setTimeout(
+        () => reject(new Error(`withTestTimeout(${ms}ms) exceeded`)),
+        ms,
+      );
+      (t as { unref?: () => void }).unref?.();
+    }),
+  ]);
+}
+
+describe("wedged pre-hook releases the ToolCallRuntime guard on abort", () => {
+  for (const variant of [
+    // A holds the guard; the SIBLING is the contention primitive that
+    // proves that exact guard was released:
+    //   exclusive    → sibling EXCLUSIVE drains the write gate
+    //   shared_read  → sibling EXCLUSIVE waits for readers-- to reach 0
+    //   shared_server→ sibling on the SAME serverId waits for the freed
+    //                  Semaphore permit (capacity 1)
+    {
+      name: "exclusive",
+      klass: EXCLUSIVE as ConcurrencyClass,
+      sibling: EXCLUSIVE as ConcurrencyClass,
+    },
+    {
+      name: "shared_read",
+      klass: SHARED_READ as ConcurrencyClass,
+      sibling: EXCLUSIVE as ConcurrencyClass,
+    },
+    {
+      name: "shared_server",
+      klass: sharedServer("srvA"),
+      sibling: sharedServer("srvA"),
+    },
+  ] as const) {
+    test(`${variant.name}: sibling acquires after a wedged uncooperative pre-hook is force-cancelled`, async () => {
+      const runtime = new ToolCallRuntime();
+      const ac = new AbortController();
+      let entered = false;
+      // UNCOOPERATIVE: ignores its signal entirely (the hard case).
+      const wedged: PreToolUseHook = () =>
+        new Promise<never>(() => {
+          entered = true;
+        });
+
+      // Tool A holds the guard while running the wedged pre-hook.
+      const aDone = runtime.run(variant.klass, async () => {
+        const res = await runPreToolUseHooks(
+          [wedged],
+          { invocation: stubInvocation, tool: stubTool, args: {} },
+          undefined,
+          undefined,
+          ac.signal, // NEW signal param
+        );
+        return res.kind; // expect "deny" (fail-closed)
+      });
+
+      // Sibling B must wait for A to release the SAME guard.
+      let bAcquired = false;
+      const bDone = runtime.run(variant.sibling, async () => {
+        bAcquired = true;
+        return "B";
+      });
+
+      // Let A enter the wedged hook; B must still be blocked.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(entered).toBe(true);
+      expect(bAcquired).toBe(false);
+
+      ac.abort("tool timeout: drain exceeded");
+
+      // cancelled ⇒ fail-closed deny.
+      await expect(withTestTimeout(aDone, 2000)).resolves.toBe("deny");
+      // ← THE PROOF: the sibling acquired the released guard.
+      await expect(withTestTimeout(bDone, 2000)).resolves.toBe("B");
+      expect(bAcquired).toBe(true);
+    });
+  }
+
+  test("already-aborted signal: pre-hook denies immediately without awaiting the hook", async () => {
+    const ac = new AbortController();
+    ac.abort("pre-aborted");
+    let hookCalled = false;
+    const neverResolves: PreToolUseHook = () => {
+      hookCalled = true;
+      return new Promise<never>(() => {});
+    };
+    const res = await withTestTimeout(
+      runPreToolUseHooks(
+        [neverResolves],
+        { invocation: stubInvocation, tool: stubTool, args: {} },
+        undefined,
+        undefined,
+        ac.signal,
+      ),
+      1000,
+    );
+    expect(res.kind).toBe("deny");
+    expect(hookCalled).toBe(false); // never invoked on the already-aborted fast path
+  });
+});

--- a/runtime/tests/tools/hooks.test.ts
+++ b/runtime/tests/tools/hooks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   HOOK_TIMING_DISPLAY_THRESHOLD_MS,
   mergeHookPermissionDecision,
+  raceHookWithSignal,
   resolveHookPermissionDecision,
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
@@ -12,6 +13,7 @@ import {
   type PermissionDecisionHook,
   type PostToolUseFailureHook,
   type PostToolUseHook,
+  type PreToolUseHook,
 } from "./hooks.js";
 import type { Tool } from "./types.js";
 import type { ToolInvocation } from "./context.js";
@@ -558,5 +560,310 @@ describe("HOOK_TIMING_DISPLAY_THRESHOLD_MS", () => {
     );
     expect(timings).toHaveLength(1);
     expect(timings[0]?.overThreshold).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// §4.3 — Signal-aware hook cancellation: invariant preservation.
+//
+// Each test BOUNDS its awaits so a regression (the loop never racing the
+// signal) reddens as a clean per-test timeout rather than an ambient hang.
+// A wedged uncooperative hook is `() => new Promise(()=>{})` — it ignores
+// its signal entirely; only the runner racing the signal makes the loop
+// return.
+// ──────────────────────────────────────────────────────────────────────
+describe("signal-aware hook cancellation (invariants)", () => {
+  const wedged: PreToolUseHook = () => new Promise<never>(() => {});
+  /** Reject if the promise does not settle within `ms`. */
+  function bound<T>(p: Promise<T>, ms = 1500): Promise<T> {
+    return Promise.race([
+      p,
+      new Promise<T>((_r, reject) => {
+        const t = setTimeout(
+          () => reject(new Error(`bound(${ms}ms) exceeded`)),
+          ms,
+        );
+        (t as { unref?: () => void }).unref?.();
+      }),
+    ]);
+  }
+  function abortedSignal(reason = "drain"): AbortSignal {
+    const ac = new AbortController();
+    ac.abort(reason);
+    return ac.signal;
+  }
+
+  // 1 — Ordering + atomic break: [completesA, wedged, neverReached]. Abort
+  //     mid-#2 ⇒ #3 never ran, #1's accumulated state survives in the deny
+  //     terminal, result is kind:"deny".
+  test("pre: ordering + atomic break on cancel preserves earlier accumulation", async () => {
+    const ac = new AbortController();
+    let thirdRan = false;
+    const completesA: PreToolUseHook = () => ({
+      kind: "continue",
+      args: { a: 1 },
+      hookPermissionResult: { behavior: "allow", hookName: "A" },
+      additionalContext: ["ctxA"],
+    });
+    const neverReached: PreToolUseHook = () => {
+      thirdRan = true;
+      return { kind: "continue" };
+    };
+    const run = runPreToolUseHooks(
+      [completesA, wedged, neverReached],
+      { invocation: stubInvocation, tool: stubTool, args: {} },
+      undefined,
+      undefined,
+      ac.signal,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const decision = await bound(run);
+    expect(decision.kind).toBe("deny");
+    expect(thirdRan).toBe(false); // hook #3 never started (atomic break)
+    // #1's accumulation survives in the deny terminal.
+    expect(decision.args).toEqual({ a: 1 });
+    expect(decision.hookPermissionResult?.hookName).toBe("A");
+    expect(decision.additionalContexts).toEqual(["ctxA"]);
+  });
+
+  // 2 — First-wins preserved: #1 sets hookPermissionResult, #2 cancelled ⇒
+  //     deny carries #1's permission result (never overwritten).
+  test("pre: first-wins permission preserved through a cancel", async () => {
+    const ac = new AbortController();
+    const first: PreToolUseHook = () => ({
+      kind: "continue",
+      hookPermissionResult: { behavior: "deny", hookName: "first" },
+    });
+    const run = runPreToolUseHooks(
+      [first, wedged],
+      { invocation: stubInvocation, tool: stubTool, args: {} },
+      undefined,
+      undefined,
+      ac.signal,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const decision = await bound(run);
+    expect(decision.kind).toBe("deny");
+    expect(decision.hookPermissionResult?.hookName).toBe("first");
+    expect(decision.hookPermissionResult?.behavior).toBe("deny");
+  });
+
+  // 3 — Arg-mutation gating: #1 rewrites args, #2 cancelled ⇒ deny carries
+  //     #1's rewritten args (and a deny never reaches execute).
+  test("pre: arg-mutation from completed hook survives the cancel deny", async () => {
+    const ac = new AbortController();
+    const rewrite: PreToolUseHook = ({ args }) => ({
+      kind: "continue",
+      args: { ...args, rewritten: true },
+    });
+    const run = runPreToolUseHooks(
+      [rewrite, wedged],
+      { invocation: stubInvocation, tool: stubTool, args: { orig: 1 } },
+      undefined,
+      undefined,
+      ac.signal,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const decision = await bound(run);
+    expect(decision.kind).toBe("deny");
+    expect(decision.args).toEqual({ orig: 1, rewritten: true });
+  });
+
+  // 4 — additionalContext fidelity + hook_cancelled emitted: #1 adds context,
+  //     #2 cancelled ⇒ context present exactly once; onCancelled fired for #2.
+  test("pre: additionalContext fidelity + onCancelled fires on cancel", async () => {
+    const ac = new AbortController();
+    const cancelledIdx: number[] = [];
+    const ctxHook: PreToolUseHook = () => ({
+      kind: "continue",
+      additionalContext: ["once"],
+    });
+    const run = runPreToolUseHooks(
+      [ctxHook, wedged],
+      { invocation: stubInvocation, tool: stubTool, args: {} },
+      undefined,
+      undefined,
+      ac.signal,
+      (i) => cancelledIdx.push(i),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const decision = await bound(run);
+    expect(decision.kind).toBe("deny");
+    expect(decision.additionalContexts).toEqual(["once"]); // exactly once
+    expect(cancelledIdx).toEqual([1]); // hook #1 (index 1) was cancelled
+  });
+
+  // 5 — Throw ≠ cancel: a pre-hook that THROWS takes the existing
+  //     swallow-and-continue path, NOT the deny terminal.
+  test("pre: a thrown hook is swallowed (continue), distinct from cancel (deny)", async () => {
+    const ac = new AbortController(); // never aborted
+    const errors: unknown[] = [];
+    const throwing: PreToolUseHook = () => {
+      throw new Error("boom");
+    };
+    const after: PreToolUseHook = () => ({ kind: "continue", args: { ok: 1 } });
+    const decision = await bound(
+      runPreToolUseHooks(
+        [throwing, after],
+        { invocation: stubInvocation, tool: stubTool, args: {} },
+        (err) => errors.push(err),
+        undefined,
+        ac.signal,
+      ),
+    );
+    expect(decision.kind).toBe("continue"); // NOT deny
+    expect(decision.args).toEqual({ ok: 1 });
+    expect(errors).toHaveLength(1);
+  });
+
+  // 6 — Post-hook cancel → continue: [rewriteHook, wedgedPost], abort ⇒
+  //     kind:"continue" with the rewritten result, never stop/preventContinuation.
+  test("post: cancel returns continue preserving the rewritten result", async () => {
+    const ac = new AbortController();
+    const rewriteHook: PostToolUseHook = () => ({
+      kind: "rewrite",
+      result: { content: "rewritten" },
+    });
+    const wedgedPost: PostToolUseHook = () => new Promise<never>(() => {});
+    const run = runPostToolUseHooks(
+      [rewriteHook, wedgedPost],
+      {
+        invocation: stubInvocation,
+        tool: stubTool,
+        args: {},
+        result: { content: "original" },
+        signal: ac.signal,
+      },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const decision = await bound(run);
+    expect(decision.kind).toBe("continue"); // never stop/preventContinuation
+    expect(decision.result.content).toBe("rewritten");
+  });
+
+  // 7 — Failure-hook cancel: [obsA, wedgedFailure, obsC], abort ⇒ partial
+  //     records (A + cancelled marker), C dropped.
+  test("failure: cancel drops remaining hooks + returns partial records", async () => {
+    const ac = new AbortController();
+    let cRan = false;
+    const obsA: PostToolUseFailureHook = () => {};
+    const wedgedFailure: PostToolUseFailureHook = () =>
+      new Promise<void>(() => {});
+    const obsC: PostToolUseFailureHook = () => {
+      cRan = true;
+    };
+    const cancelledIdx: number[] = [];
+    const run = runPostToolUseFailureHooks(
+      [obsA, wedgedFailure, obsC],
+      {
+        invocation: stubInvocation,
+        tool: stubTool,
+        args: {},
+        error: new Error("tool failed"),
+      },
+      undefined,
+      undefined,
+      ac.signal,
+      (i) => cancelledIdx.push(i),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const records = await bound(run);
+    expect(cRan).toBe(false); // hook C dropped
+    expect(records).toHaveLength(2); // A + cancelled marker for the wedged hook
+    expect(records[0]?.cancelled).toBeUndefined();
+    expect(records[1]?.cancelled).toBe(true);
+    expect(cancelledIdx).toEqual([1]);
+  });
+
+  // 8 — Permission-hook cancel → pass (bounded): a wedged permission hook
+  //     with an aborting signal resolves {kind:"pass"} without hanging.
+  test("permission: cancel falls through to pass (fail-open contract)", async () => {
+    const ac = new AbortController();
+    const wedgedPerm: PermissionDecisionHook = () =>
+      new Promise<never>(() => {});
+    const run = resolveHookPermissionDecision(
+      "stub",
+      {},
+      [wedgedPerm],
+      undefined,
+      undefined,
+      { signal: ac.signal },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort("drain");
+    const decision = await bound(run);
+    expect(decision.kind).toBe("pass"); // NOT deny — preserves fail-open
+  });
+
+  // 9 — Already-aborted fast path: runPreToolUseHooks([wedged], …,
+  //     alreadyAbortedSignal) returns kind:"deny" immediately, never awaits.
+  test("pre: already-aborted signal denies immediately without awaiting", async () => {
+    let hookCalled = false;
+    const neverResolves: PreToolUseHook = () => {
+      hookCalled = true;
+      return new Promise<never>(() => {});
+    };
+    const decision = await bound(
+      runPreToolUseHooks(
+        [neverResolves],
+        { invocation: stubInvocation, tool: stubTool, args: {} },
+        undefined,
+        undefined,
+        abortedSignal(),
+      ),
+      1000,
+    );
+    expect(decision.kind).toBe("deny");
+    expect(hookCalled).toBe(false);
+  });
+
+  // raceHookWithSignal direct: no-signal value/throw passthrough + listener
+  // hygiene (no abort-listener accumulation across a multi-hook loop).
+  test("raceHookWithSignal: no-signal passthrough (value + throw)", async () => {
+    const ok = await raceHookWithSignal(async () => 42, undefined);
+    expect(ok).toEqual({ settled: "value", value: 42 });
+    const err = await raceHookWithSignal(async () => {
+      throw new Error("x");
+    }, undefined);
+    expect(err.settled).toBe("threw");
+  });
+
+  test("listener hygiene: no abort-listener accumulation across a multi-hook loop", async () => {
+    const ac = new AbortController();
+    let added = 0;
+    let removed = 0;
+    const realAdd = ac.signal.addEventListener.bind(ac.signal);
+    const realRemove = ac.signal.removeEventListener.bind(ac.signal);
+    ac.signal.addEventListener = ((type: string, ...rest: unknown[]) => {
+      if (type === "abort") added += 1;
+      return (realAdd as never)(type, ...(rest as never[]));
+    }) as never;
+    ac.signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+      if (type === "abort") removed += 1;
+      return (realRemove as never)(type, ...(rest as never[]));
+    }) as never;
+
+    // Three fast hooks that all settle normally; the signal never aborts.
+    const fast: PreToolUseHook = () => ({ kind: "continue" });
+    const decision = await bound(
+      runPreToolUseHooks(
+        [fast, fast, fast],
+        { invocation: stubInvocation, tool: stubTool, args: {} },
+        undefined,
+        undefined,
+        ac.signal,
+      ),
+    );
+    expect(decision.kind).toBe("continue");
+    // Every added abort listener was removed (no accumulation on a long-
+    // lived signal).
+    expect(removed).toBeGreaterThanOrEqual(added);
+    expect(added).toBe(3); // one per hook
   });
 });

--- a/runtime/tests/tools/streaming-executor.stuck-tool-drain.test.ts
+++ b/runtime/tests/tools/streaming-executor.stuck-tool-drain.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "vitest";
 import { StreamingToolExecutor } from "./streaming-executor.js";
 import { SHARED_READ, EXCLUSIVE, ToolCallRuntime } from "./concurrency.js";
+import { routerFromRegistry } from "./router.js";
+import { EventLog } from "../session/event-log.js";
 import type { ToolRegistry, ToolDispatchResult } from "../tool-registry.js";
 import type { LLMTool, LLMToolCall } from "../llm/types.js";
 import type { Tool } from "./types.js";
+import type { PreToolUseHook } from "./hooks.js";
 import type { ToolUseBlock } from "../session/turn-state.js";
 
 function makeBlock(id: string, name: string): ToolUseBlock {
@@ -644,5 +647,216 @@ describe("StreamingToolExecutor cooperative cancel of wedged tools", () => {
     // buildTerminalToolResult({ cause: "timeout" }) -> "tool execution timed out".
     expect(decoded.content).toContain("tool execution timed out");
     expect(decoded.content).not.toContain("aborted before completion");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// §4.2 — Live-path integration: a wedged PRE-HOOK (router.ts:763 seam,
+// run INSIDE the ToolCallRuntime lock by router.dispatchModelToolCall)
+// flips `leaked` → `reclaimed`.
+//
+// The earlier suites drive the `runToolUseFn` shortcut, which BYPASSES the
+// router pre-hook block. To exercise the real live seam we wire a genuine
+// `liveToolDispatch` (routerFromRegistry + preHooks). A small maxToolDrainMs
+// makes drainCancel fire quickly; the drain signal flows
+// opts.signal → router.ts:763 runPreToolUseHooks → raceHookWithSignal,
+// which cancels the wedged hook in place ⇒ synthetic fail-closed deny ⇒
+// the lock-wrapped dispatch settles ⇒ the ToolCallRuntime write-lock frees
+// ⇒ a sibling EXCLUSIVE acquire resolves.
+// ──────────────────────────────────────────────────────────────────────
+describe("StreamingToolExecutor live-path wedged pre-hook (reclaimed not leaked)", () => {
+  function liveTool(name: string): Tool {
+    return testTool({
+      name,
+      concurrencyClass: EXCLUSIVE,
+      // The TOOL itself completes instantly — the wedge is the PRE-HOOK,
+      // which never reaches execute (deny short-circuits).
+      execute: async () => ({ content: "tool ran" }),
+    });
+  }
+
+  // A cooperative wedged pre-hook: resolves a deny when its signal aborts
+  // (proves the threaded signal REACHES the hook). Uncooperative variant:
+  // ignores the signal entirely (proves the RACE releases the lock anyway).
+  const cooperativePreHook: PreToolUseHook = ({ signal }) =>
+    new Promise((resolve) => {
+      if (signal?.aborted) {
+        resolve({ kind: "deny", reason: "cancelled" });
+        return;
+      }
+      signal?.addEventListener(
+        "abort",
+        () => resolve({ kind: "deny", reason: "cancelled" }),
+        { once: true },
+      );
+    });
+  const uncooperativePreHook: PreToolUseHook = () =>
+    new Promise<never>(() => {});
+
+  for (const variant of [
+    { name: "cooperative", hook: cooperativePreHook, expectOrphan: false },
+    { name: "uncooperative", hook: uncooperativePreHook, expectOrphan: true },
+  ] as const) {
+    test(`${variant.name} wedged pre-hook: turn finalizes reclaimed, no leak, sibling EXCLUSIVE acquires`, async () => {
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown): void => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+
+      const eventLog = new EventLog();
+      const orphanedEvents: string[] = [];
+      const cancelledEvents: string[] = [];
+      const unsub = eventLog.subscribe((ev) => {
+        const msg = ev.msg as { type?: string; payload?: { cause?: string } };
+        if (msg.type === "warning" && msg.payload?.cause === "hook_orphaned") {
+          orphanedEvents.push(ev.id);
+        }
+        if (msg.type === "warning" && msg.payload?.cause === "hook_cancelled") {
+          cancelledEvents.push(ev.id);
+        }
+      });
+
+      // The ROUTER registry carries the tool so dispatchModelToolCall's
+      // findSpec resolves and the live preHooks block at router.ts:763
+      // actually runs. The EXECUTOR registry is intentionally EMPTY so the
+      // drain deadline falls back to the flat `maxToolDrainMs` floor
+      // (toolDrainDeadlineMs's def===undefined branch) rather than
+      // own-timeout + 60s grace — this is what makes the per-tool drainCancel
+      // / reclaim-accounting path fire in-test. A pre-hook wedge never reaches
+      // tool.execute, so the tool's own execute timeout is irrelevant here.
+      const routerRegistry = registryFor(
+        async () => ({ content: "registry dispatch should not run", isError: true }),
+        [liveTool("wedgehook")],
+      );
+      const executorRegistry = registryFor(
+        async () => ({ content: "registry dispatch should not run", isError: true }),
+        [],
+      );
+      const runtime = new ToolCallRuntime();
+      const exec = new StreamingToolExecutor({
+        registry: executorRegistry,
+        runtime,
+        maxToolDrainMs: 200,
+        cleanupGraceMs: 150,
+        liveToolDispatch: {
+          router: routerFromRegistry(routerRegistry),
+          options: {
+            session: { eventLog, services: {} } as never,
+            turn: { subId: "turn-wedge" } as never,
+            tracker: {
+              appendFileDiff: () => {},
+              snapshot: () => [],
+              clear: () => {},
+            },
+            approvalPolicy: "never",
+            sandboxMode: "workspace_write",
+            preHooks: [variant.hook],
+          },
+        },
+      });
+
+      exec.setConcurrencyClassFor("wedgehook", EXCLUSIVE);
+      exec.addTool(makeBlock("w1", "wedgehook"), makeCall("w1", "wedgehook"));
+      exec.dispatchPending();
+      exec.close();
+
+      const collected: Array<{ id: string; isError: boolean }> = [];
+      const outcome = await withTimeout(
+        (async () => {
+          for await (const r of exec.getRemainingResults()) {
+            collected.push({
+              id: r.toolCall.id,
+              isError: r.result.isError === true,
+            });
+          }
+        })(),
+        4000,
+        `live-wedge-${variant.name}`,
+      );
+
+      // (a) the turn finalizes with exactly one isError result (the
+      //     fail-closed deny renders a paired <tool_use_error>).
+      expect(outcome.ok).toBe(true);
+      expect(collected).toEqual([{ id: "w1", isError: true }]);
+
+      // Allow the reclaim grace race to classify.
+      await new Promise((r) => setTimeout(r, 250).unref?.());
+
+      const tracked = (
+        exec as unknown as { tools: Array<{ id: string; outcome?: string }> }
+      ).tools.find((t) => t.id === "w1");
+      // (b) outcome reclaimed and leakedToolCount did NOT increment.
+      expect(tracked?.outcome).toBe("reclaimed");
+      expect(exec.leakedTools).toBe(0);
+
+      // a hook_cancelled attachment fired on every cancellation.
+      expect(cancelledEvents.length).toBeGreaterThanOrEqual(1);
+
+      // (d) uncooperative variant: a hook_orphaned event fired exactly once.
+      if (variant.expectOrphan) {
+        expect(orphanedEvents).toHaveLength(1);
+      } else {
+        expect(orphanedEvents).toHaveLength(0);
+      }
+
+      // (c) a follow-up EXCLUSIVE acquire on the SAME runtime resolves
+      //     (the wedged-pre-hook holder released the write-lock).
+      const acquire = await withTimeout(
+        runtime.run(EXCLUSIVE, async () => "ok"),
+        1000,
+        "live-sibling-exclusive-acquire",
+      );
+      expect(acquire.ok).toBe(true);
+      if (acquire.ok) expect(acquire.value).toBe("ok");
+
+      // no unhandledRejection from the orphaned/detached hook promise.
+      await new Promise((r) => setTimeout(r, 50).unref?.());
+      unsub();
+      process.off("unhandledRejection", onUnhandled);
+      expect(unhandled).toEqual([]);
+    });
+  }
+
+  // §4.4 non-regression: the synthetic pre-hook cancel-deny renders a
+  // <tool_use_error> tool_result and is NOT misclassified as an interrupt
+  // (the router deny path returns <tool_use_error> directly, never
+  // INTERRUPT_MESSAGE_FOR_TOOL_USE). Exercised on the DIRECT router path
+  // with an already-aborted signal so the deny actually renders (the drain
+  // backstop does not race/override it here).
+  test("synthetic pre-hook cancel-deny renders <tool_use_error>, not an interrupt", async () => {
+    const eventLog = new EventLog();
+    const registry = registryFor(
+      async () => ({ content: "registry dispatch should not run", isError: true }),
+      [liveTool("wedgehook")],
+    );
+    const router = routerFromRegistry(registry);
+    const ac = new AbortController();
+    ac.abort("tool timeout: drain exceeded");
+
+    const result = await (
+      router as unknown as {
+        dispatchModelToolCall(
+          call: LLMToolCall,
+          opts: Record<string, unknown>,
+        ): Promise<ToolDispatchResult>;
+      }
+    ).dispatchModelToolCall(makeCall("w1", "wedgehook"), {
+      session: { eventLog, services: {} },
+      turn: { subId: "turn-deny" },
+      tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} },
+      approvalPolicy: "never",
+      sandboxMode: "workspace_write",
+      preHooks: [uncooperativePreHook],
+      signal: ac.signal,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("<tool_use_error>");
+    expect(String(result.content)).toContain("pre-hook cancelled");
+    // NOT misclassified as a user interrupt.
+    expect(String(result.content)).not.toContain(
+      "[Request interrupted by user for tool use]",
+    );
   });
 });


### PR DESCRIPTION
Goal item #1 / follow-up to #1318 + #1319. Closes the **highest-severity remaining leak**.

## The gap
#1319's cooperative cancel releases `tool.execute()`-phase wedges. But a wedged/slow **pre-tool-use hook** (and post/failure/permission hooks) runs **inside the `ToolCallRuntime` lock** and takes **no abort signal** — so `drainCancel` can't reach it, the `AsyncRwLock`/`Semaphore` stays pinned, and the tool is marked `leaked`.

## The fix — race the signal in place (no critical-section refactor)
- New `raceHookWithSignal` helper (modeled on `withTimeoutAndAbort`): on abort it **resolves `cancelled` without awaiting the hook**, so the loop returns → the lock-wrapped `fn()` settles → the runtime's own `finally` releases the lock/permit.
- **Pre-hook cancelled → `deny` (FAIL-CLOSED):** a cancelled security gate must never fall through to allow (distinct from the existing fail-open throw-swallow for *completed-but-broken* hooks). Post → `continue` (fail-safe, tool already ran); failure → drop + bubble; permission → `pass` (preserves the documented fail-open-on-broken-hook contract; the pre-hook deny + execute-phase abort are the real gates).
- **Honest accounting:** a wedged *uncooperative* hook is reclaimed at the **lock** level (its orphan holds only its own heap); surfaced via a distinct `hook_orphaned` label, separate from the execute-phase `leaked` count. Never claimed killed.

Threaded the signal at the **live** pre-hook seam (`router.ts:763` — the router runs pre-hooks itself and passes `preHooks:[]` downstream), the direct/test seam, and the post/failure seams. `phases/_deps/tool-runtime.ts` is an **unlocked** lean-rebuild stub → signal threaded for hang-bounding only.

**SOTA-grounded:** a signal passed *into* work is cooperative-only, so the **caller must race it** (the post-hook signal was already plumbed but never raced — a half-measure with zero lock-release guarantee); the losing branch is neutralized; security gates fail closed.

## Scope
Hooks deliberately stay **in** the lock. Moving post/failure hooks *outside* it (critical-section minimization) is a **separate follow-up** — bundling that refactor here risked dropping a post-execute emit (judges flagged it).

## Tests (revert-sensitive)
Acceptance: a sibling **EXCLUSIVE / shared_read / shared_server** holder **acquires the guard after a wedged uncooperative pre-hook is force-cancelled** (not "the turn finalized"). Plus live-path `leaked→reclaimed`, and 9 invariant tests (ordering/atomic-break, first-wins permission, arg-mutation gating, additionalContext fidelity, throw≠cancel, post-cancel→continue, failure partial-records, permission-cancel→pass, already-aborted).

## Gate
- `npm run build` ✅ exit 0 · `tsc -p runtime --noEmit` ✅ clean
- full `npm run test:unit` ✅ **1581 files / 13,422 tests passed, 0 failures**
- revert-sensitivity re-verified independently: disabling the signal-race reddens all 4 lock-release tests (`aDone` times out, sibling never acquires); restored → green.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG