### PR TITLE
fix(daemon): abort-aware lock/semaphore acquisition (goal #2)

### DIFF
--- a/runtime/src/tools/concurrency.ts
+++ b/runtime/src/tools/concurrency.ts
@@ -64,45 +64,158 @@ export function sharedServer(serverId: string): ConcurrencyClass {
 // ─────────────────────────────────────────────────────────────────────
 
 /**
- * Minimal semaphore built on promise-chain serialization. Each
- * `serverId` gets its own instance so calls to `mcp.dbA.query` and
- * `mcp.dbB.query` don't block each other (I-61).
+ * Identity-carrying FIFO waiter record. The grant decision (`pumpNext`)
+ * and the cancel decision (`cancelWaiter`) both read-then-write `state`
+ * with no `await` between them, so exactly one of them claims the waiter;
+ * the loser is inert. A grant() (= resolve()) is irrevocable.
+ */
+interface SemWaiter {
+  state: "queued" | "granted" | "cancelled";
+  grant: () => void;
+  reject: (err: unknown) => void;
+}
+
+/**
+ * Minimal semaphore with abort-aware acquisition. Each `serverId` gets
+ * its own instance so calls to `mcp.dbA.query` and `mcp.dbB.query` don't
+ * block each other (I-61).
  *
  * The default capacity is 1 (strict serialization per server).
  * Callers can construct with >1 for parallel-safe servers.
+ *
+ * Permit accounting uses the DIRECT-TRANSFER model: `acquired` is
+ * incremented at grant time (fast path) and never re-touched by a woken
+ * waiter. On release the permit is either FORWARDED to a live waiter
+ * (`acquired` unchanged) or FREED (`acquired -= 1`). A queued waiter
+ * aborted before it is granted is removed from the FIFO atomically; a
+ * waiter already in the `granted` state already owns its permit and is
+ * never force-rejected here (the awaiting caller will take the permit and
+ * release normally via the signal-checked stage-2 withRead).
  */
 export class Semaphore {
   private readonly capacity: number;
   private acquired = 0;
-  private waiters: Array<() => void> = [];
+  private waiters: SemWaiter[] = [];
 
   constructor(capacity = 1) {
     if (capacity < 1) throw new RangeError("Semaphore capacity must be ≥ 1");
     this.capacity = capacity;
   }
 
-  async acquire(): Promise<() => void> {
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) throw this.abortError(signal);
+
+    // Fast path: a permit is free → take it immediately.
     if (this.acquired < this.capacity) {
       this.acquired += 1;
-      return () => this.release();
+      return this.makeRelease();
     }
-    await new Promise<void>((resolve) => this.waiters.push(resolve));
-    this.acquired += 1;
-    return () => this.release();
+
+    // Slow path: enqueue an identity-carrying waiter.
+    const waiter: SemWaiter = {
+      state: "queued",
+      grant: () => {},
+      reject: () => {},
+    };
+    const granted = new Promise<void>((resolve, reject) => {
+      waiter.grant = () => resolve();
+      waiter.reject = reject;
+    });
+    this.waiters.push(waiter);
+
+    const onAbort = (): void => {
+      this.cancelWaiter(waiter, this.abortError(signal!));
+    };
+    if (signal) {
+      // Re-check after enqueue: the abort may have fired between the
+      // top-of-method guard and here.
+      if (signal.aborted) {
+        this.cancelWaiter(waiter, this.abortError(signal));
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    try {
+      await granted; // resolves only when a permit is HANDED to us
+    } finally {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    }
+    // The permit was already counted into `acquired` at grant time (NOT
+    // here). We just take it.
+    return this.makeRelease();
+  }
+
+  private makeRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return; // idempotent — double-release is a no-op
+      released = true;
+      this.release();
+    };
   }
 
   private release(): void {
-    this.acquired -= 1;
-    const next = this.waiters.shift();
-    if (next) next();
+    // A real permit is being returned. Either hand it to the next live
+    // waiter (keeping `acquired` unchanged — direct permit transfer) or
+    // free it.
+    if (!this.pumpNext()) {
+      this.acquired -= 1;
+      if (this.acquired < 0) throw new Error("Semaphore acquired underflow");
+    }
+  }
+
+  /**
+   * Returns true iff the permit was forwarded to a live waiter (`acquired`
+   * stays put). Skips cancelled waiters. SINGLE synchronous critical
+   * section.
+   */
+  private pumpNext(): boolean {
+    while (this.waiters.length > 0) {
+      const next = this.waiters.shift()!;
+      if (next.state !== "queued") continue; // cancelled mid-flight → skip
+      next.state = "granted"; // SYNC claim — `acquired` already accounts for it
+      next.grant();
+      return true; // permit forwarded; acquired unchanged
+    }
+    return false; // no live waiter — caller frees the permit
+  }
+
+  /**
+   * Cancel a waiter. ONLY a still-`queued` waiter is removed from the
+   * queue here. A `granted` waiter already owns its permit
+   * (grant() = resolve() is irrevocable, so reject() would be a no-op and
+   * the caller WOULD still take the permit). Force-forwarding in that case
+   * would double-grant the permit → two holders → underflow. So the
+   * granted case is a NO-OP `return`: the waiter keeps the permit, takes
+   * it on resume, and releases normally (its stage-2 withRead rechecks the
+   * signal and frees the permit in finally). `acquired` accounting stays
+   * exact.
+   */
+  private cancelWaiter(waiter: SemWaiter, err: unknown): void {
+    if (waiter.state !== "queued") return; // granted or already-cancelled → inert
+    waiter.state = "cancelled";
+    waiter.reject(err);
+    const i = this.waiters.indexOf(waiter);
+    if (i >= 0) this.waiters.splice(i, 1); // FIFO-preserving identity splice
+    // It never held a permit → acquired untouched.
+  }
+
+  private abortError(signal: AbortSignal): unknown {
+    return signal.reason ?? new DOMException("Aborted", "AbortError");
   }
 
   get available(): number {
     return Math.max(0, this.capacity - this.acquired);
   }
 
+  get acquiredCount(): number {
+    return this.acquired;
+  }
+
   get queueDepth(): number {
-    return this.waiters.length;
+    // Only count still-live waiters (cancelled ones are spliced eagerly).
+    return this.waiters.filter((w) => w.state === "queued").length;
   }
 }
 
@@ -146,19 +259,27 @@ export class ToolCallRuntime {
    *                         tool still blocks)
    * - background_terminal → no guard (subprocess owns its lifetime)
    */
-  async run<T>(klass: ConcurrencyClass, fn: GuardedFn<T>): Promise<T> {
+  async run<T>(
+    klass: ConcurrencyClass,
+    fn: GuardedFn<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
     switch (klass.kind) {
       case "exclusive":
-        return this.lock.withWrite(() => fn());
+        return this.lock.withWrite(() => fn(), signal);
       case "shared_read":
-        return this.lock.withRead(() => fn());
+        return this.lock.withRead(() => fn(), signal);
       case "shared_server": {
         const semaphore = this.getOrCreateSemaphore(klass.serverId);
-        const release = await semaphore.acquire();
+        // Stage 1 (abortable): acquire the per-server permit.
+        const release = await semaphore.acquire(signal);
         try {
-          return await this.lock.withRead(() => fn());
+          // Stage 2 (abortable): the shared read lock. If this aborts,
+          // the finally below rolls back stage 1 (the permit is forwarded
+          // to the next live waiter by pumpNext).
+          return await this.lock.withRead(() => fn(), signal);
         } finally {
-          release();
+          release(); // idempotent; releases the stage-1 permit
         }
       }
       case "background_terminal":

--- a/runtime/src/tools/runtimes/context.ts
+++ b/runtime/src/tools/runtimes/context.ts
@@ -24,6 +24,14 @@ export interface ToolRuntimeCallContext {
   readonly supportsParallelToolCalls: boolean;
   readonly source: ToolCallSource;
   readonly submittedAtMs: number;
+  /**
+   * Per-call dispatch signal (childAbort ∪ drainCancel). When present, the
+   * runtime guard threads it into Semaphore.acquire / AsyncRwLock.withWrite
+   * / withRead so a PARKED waiter wakes immediately on abort, removes itself
+   * from the acquire queue atomically, and forwards any in-flight
+   * permit/turn. Optional + additive: existing callers compile unchanged.
+   */
+  readonly acquireSignal?: AbortSignal;
 }
 
 export interface ToolRuntimeAttemptContext extends ToolRuntimeCallContext {

--- a/runtime/src/tools/runtimes/parallel.ts
+++ b/runtime/src/tools/runtimes/parallel.ts
@@ -8,7 +8,11 @@ import {
 import type { ToolRuntimeCallContext } from "./context.js";
 
 export interface ToolRuntimeScheduler {
-  run<T>(klass: ConcurrencyClass, fn: GuardedFn<T>): Promise<T>;
+  run<T>(
+    klass: ConcurrencyClass,
+    fn: GuardedFn<T>,
+    signal?: AbortSignal,
+  ): Promise<T>;
   runToolCall<T>(
     context: ToolRuntimeCallContext,
     fn: GuardedFn<T>,
@@ -26,15 +30,23 @@ export class ToolExecutionRuntime implements ToolRuntimeScheduler {
     this.guard = options.guard ?? new ToolCallRuntime(options);
   }
 
-  async run<T>(klass: ConcurrencyClass, fn: GuardedFn<T>): Promise<T> {
-    return this.guard.run(klass, fn);
+  async run<T>(
+    klass: ConcurrencyClass,
+    fn: GuardedFn<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    return this.guard.run(klass, fn, signal);
   }
 
   async runToolCall<T>(
     context: ToolRuntimeCallContext,
     fn: GuardedFn<T>,
   ): Promise<T> {
-    return this.guard.run(effectiveConcurrencyClass(context), fn);
+    return this.guard.run(
+      effectiveConcurrencyClass(context),
+      fn,
+      context.acquireSignal,
+    );
   }
 }
 
@@ -52,7 +64,11 @@ export async function runToolRuntimeCall<T>(
   if ("runToolCall" in runtime) {
     return runtime.runToolCall(context, fn);
   }
-  return runtime.run(effectiveConcurrencyClass(context), fn);
+  return runtime.run(
+    effectiveConcurrencyClass(context),
+    fn,
+    context.acquireSignal,
+  );
 }
 
 function effectiveConcurrencyClass(

--- a/runtime/src/tools/streaming-executor.ts
+++ b/runtime/src/tools/streaming-executor.ts
@@ -1366,7 +1366,11 @@ export class StreamingToolExecutor {
         };
       };
 
-      const runtimeContext = this.buildRuntimeCallContext(tool, startedAtMs);
+      const runtimeContext = this.buildRuntimeCallContext(
+        tool,
+        startedAtMs,
+        dispatchSignal,
+      );
       const result = this.runtime
         ? await runToolRuntimeCall(this.runtime, runtimeContext, dispatch)
         : await dispatch();
@@ -1425,6 +1429,7 @@ export class StreamingToolExecutor {
   private buildRuntimeCallContext(
     tool: TrackedTool,
     submittedAtMs: number,
+    acquireSignal?: AbortSignal,
   ): ToolRuntimeCallContext {
     const routed = toolCallFromLLMToolCall(tool.toolCall, {
       session: this.liveToolDispatch?.options.session,
@@ -1443,6 +1448,7 @@ export class StreamingToolExecutor {
       supportsParallelToolCalls,
       source: this.liveToolDispatch?.options.source ?? "direct",
       submittedAtMs,
+      ...(acquireSignal ? { acquireSignal } : {}),
     };
   }
 

--- a/runtime/src/utils/async-rwlock.ts
+++ b/runtime/src/utils/async-rwlock.ts
@@ -11,14 +11,46 @@
  * acquire read locks; Exclusive tools acquire write locks. See I-61
  * for SharedServer per-id semaphore variant.
  *
+ * Cancellation (abort-aware acquire): `withWrite`/`withRead` accept an
+ * optional AbortSignal. A waiter aborted before it acquires is removed
+ * from the FIFO queue ATOMICALLY w.r.t. handoff and the writer-turn is
+ * forwarded to the next live waiter, so no turn is ever lost and the
+ * writer chain is never wedged. The writer side is an EXPLICIT
+ * `writeWaiters` FIFO (a promise chain cannot drop a mid-chain waiter);
+ * readers keep the gated-promise model but gain an abort path on the
+ * pending read gate. The grant decision (`pumpWrite`) and the cancel
+ * decision (`cancelWriteWaiter`) both read-then-write `waiter.state`
+ * with NO `await` between, so exactly one wins per waiter — the loser is
+ * inert. A grant() (= resolve()) is IRREVOCABLE, so a waiter observed in
+ * the `granted` state is NEVER force-rejected here: it already won its
+ * turn and must take it and release normally. The only state that
+ * removes a waiter from the queue is `queued`.
+ *
  * @module
  */
+
+interface WriteWaiter {
+  state: "queued" | "granted" | "cancelled";
+  /** Resolve when this waiter owns the write turn. */
+  grant: () => void;
+  /** Reject the still-pending turn (only valid while state === "queued"). */
+  reject: (err: unknown) => void;
+}
 
 export class AsyncRwLock<T> {
   private value: T;
   private readers = 0;
-  private writerChain: Promise<void> = Promise.resolve();
+  /** True while a writer holds the exclusive turn. */
+  private writeHeld = false;
+  /** Explicit FIFO of queued writers (identity-carrying records). */
+  private writeWaiters: WriteWaiter[] = [];
+  /**
+   * Readers yield to a queued/holding writer via this gate
+   * (writer-starvation prevention). Resolved when no writer is holding
+   * or queued.
+   */
   private pendingReadGate: Promise<void> = Promise.resolve();
+  private resolveReadGate: (() => void) | null = null;
 
   constructor(initial: T) {
     this.value = initial;
@@ -30,13 +62,27 @@ export class AsyncRwLock<T> {
    * waiting for readers to drain), new readers wait for the writer to
    * complete first — this prevents writer-starvation under heavy read
    * load.
+   *
+   * If `signal` aborts while gated behind a writer, the call rejects
+   * WITHOUT touching `readers` (nothing was acquired, so there is
+   * nothing to forward).
    */
-  async withRead<R>(fn: (value: T) => Promise<R> | R): Promise<R> {
-    await this.pendingReadGate;
+  async withRead<R>(
+    fn: (value: T) => Promise<R> | R,
+    signal?: AbortSignal,
+  ): Promise<R> {
+    if (signal?.aborted) throw abortError(signal);
+    // Race the read-gate against abort. Aborting here only skips entry; it
+    // touches NO shared counter, so there is nothing to forward.
+    await raceGate(this.pendingReadGate, signal);
     this.readers++;
     try {
       return await fn(this.value);
     } finally {
+      // Underflow tripwire — readers must never go negative.
+      if (this.readers <= 0) {
+        throw new Error("AsyncRwLock readers underflow");
+      }
       this.readers--;
     }
   }
@@ -45,24 +91,204 @@ export class AsyncRwLock<T> {
    * Run `fn` with exclusive write access. Queues behind any in-flight
    * writer, then waits for all current readers to drain, then runs
    * exclusively. Subsequent reads + writes wait for this to complete.
+   *
+   * If `signal` aborts while QUEUED, the waiter is removed from the FIFO
+   * atomically and the call rejects. If the abort lands after the waiter
+   * was already granted the turn, the granted turn is honored: `runHeld`
+   * rechecks the signal and throws (handing the turn off) rather than
+   * running `fn`.
    */
-  async withWrite<R>(fn: (value: T) => Promise<R> | R): Promise<R> {
-    let release!: () => void;
-    const gate = new Promise<void>((r) => {
-      release = r;
-    });
-    const previous = this.writerChain;
-    this.writerChain = gate;
-    this.pendingReadGate = gate;
-    await previous;
-    // Drain readers that started before we acquired the chain.
-    while (this.readers > 0) {
-      await new Promise((r) => setImmediate(r));
+  async withWrite<R>(
+    fn: (value: T) => Promise<R> | R,
+    signal?: AbortSignal,
+  ): Promise<R> {
+    if (signal?.aborted) throw abortError(signal);
+
+    // Fast path: nobody holds or is queued → take the turn immediately.
+    if (!this.writeHeld && this.writeWaiters.length === 0) {
+      this.beginWrite();
+      return this.runHeld(fn, signal);
     }
+
+    // Slow path: enqueue an identity-carrying waiter.
+    const waiter: WriteWaiter = {
+      state: "queued",
+      grant: () => {},
+      reject: () => {},
+    };
+    const turn = new Promise<void>((resolve, reject) => {
+      waiter.grant = () => resolve();
+      waiter.reject = reject;
+    });
+    this.writeWaiters.push(waiter);
+    this.refreshReadGate(); // a writer is now queued → close the read gate
+
+    const onAbort = (): void => {
+      this.cancelWriteWaiter(waiter, abortError(signal!));
+    };
+    if (signal) {
+      // Re-check after enqueue: the abort may have fired between the
+      // top-of-method guard and here.
+      if (signal.aborted) {
+        this.cancelWriteWaiter(waiter, abortError(signal));
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     try {
+      await turn; // resolves on grant, rejects on queued-cancel
+    } finally {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    }
+    // We own the turn. Drain pre-existing readers, run, then hand off.
+    return this.runHeld(fn, signal);
+  }
+
+  // ── internal: turn lifecycle ────────────────────────────────────────────
+
+  private beginWrite(): void {
+    this.writeHeld = true;
+    this.refreshReadGate(); // writer holding → readers gated
+  }
+
+  private async runHeld<R>(
+    fn: (value: T) => Promise<R> | R,
+    signal?: AbortSignal,
+  ): Promise<R> {
+    // A granted-then-cancelled writer reaches here with an aborted signal
+    // (grant() is irrevocable, so it kept its turn). Throw BEFORE draining
+    // readers or running fn, then hand off the turn in the finally — this
+    // is exactly equivalent to an instantaneously-held-then-released turn,
+    // so the next live writer is forwarded and the read gate reopens.
+    try {
+      if (signal?.aborted) throw abortError(signal);
+      // Yield once so readers that ALREADY cleared the (then-open) read gate
+      // in the SAME synchronous batch — i.e. between their `await raceGate`
+      // and their `readers++` — get to register before we drain. The legacy
+      // promise-chain writer obtained this yield implicitly via `await
+      // previous`; the explicit-queue fast path needs it explicitly to keep
+      // "a concurrently-submitted reader starts before the writer" ordering.
+      await new Promise((r) => setImmediate(r));
+      if (signal?.aborted) throw abortError(signal);
+      // Drain readers that started before we acquired the turn.
+      while (this.readers > 0) {
+        await new Promise((r) => setImmediate(r));
+      }
       return await fn(this.value);
     } finally {
-      release();
+      this.handoffWrite();
     }
   }
+
+  // Single synchronous critical section: pick the next LIVE waiter or release.
+  private handoffWrite(): void {
+    this.writeHeld = false;
+    this.pumpWrite();
+  }
+
+  // Forward-on-collision: skip cancelled waiters, grant exactly one live one.
+  private pumpWrite(): void {
+    while (this.writeWaiters.length > 0) {
+      const next = this.writeWaiters.shift()!;
+      if (next.state !== "queued") continue; // cancelled mid-flight → skip
+      next.state = "granted"; // SYNC claim — cancel path now no-ops
+      this.writeHeld = true;
+      next.grant();
+      return;
+    }
+    // No live writer queued → open the read gate.
+    this.refreshReadGate();
+  }
+
+  /**
+   * Cancel a writer. ONLY a still-`queued` waiter is removed from the
+   * queue here. A `granted` waiter already won its turn (grant() =
+   * resolve() is irrevocable, so reject() would be a no-op and the caller
+   * WOULD still take the turn). Force-forwarding in that case would
+   * double-grant — so the granted case is a NO-OP `return`: the waiter
+   * keeps the turn, `runHeld` rechecks the signal and throws, then hands
+   * off normally. `acquired`/writeHeld accounting stays exact.
+   */
+  private cancelWriteWaiter(waiter: WriteWaiter, err: unknown): void {
+    if (waiter.state !== "queued") return; // granted or already-cancelled → inert
+    waiter.state = "cancelled";
+    waiter.reject(err);
+    // Eager identity splice keeps writeQueueDepth honest (pumpWrite would
+    // also skip it lazily).
+    const i = this.writeWaiters.indexOf(waiter);
+    if (i >= 0) this.writeWaiters.splice(i, 1);
+    // It never held the turn, so nothing to forward; but if the queue is
+    // now empty and no writer holds, the read gate may reopen.
+    if (!this.writeHeld && this.writeWaiters.length === 0) {
+      this.refreshReadGate();
+    }
+  }
+
+  // ── internal: reader gate ───────────────────────────────────────────────
+
+  private refreshReadGate(): void {
+    const writerActive = this.writeHeld || this.writeWaiters.length > 0;
+    if (writerActive && this.resolveReadGate === null) {
+      this.pendingReadGate = new Promise<void>((r) => {
+        this.resolveReadGate = r;
+      });
+    } else if (!writerActive && this.resolveReadGate !== null) {
+      const r = this.resolveReadGate;
+      this.resolveReadGate = null;
+      this.pendingReadGate = Promise.resolve();
+      r();
+    }
+  }
+
+  get activeReaders(): number {
+    return this.readers;
+  }
+
+  get writeQueueDepth(): number {
+    return this.writeWaiters.filter((w) => w.state === "queued").length;
+  }
+
+  get writeHeldNow(): boolean {
+    return this.writeHeld;
+  }
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────
+
+function abortError(signal: AbortSignal): unknown {
+  // Preserve the abort REASON so terminalToolCauseFromAbortReason still maps
+  // a drain abort → "timeout" downstream.
+  return signal.reason ?? new DOMException("Aborted", "AbortError");
+}
+
+function raceGate(
+  gate: Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) return gate;
+  if (signal.aborted) return Promise.reject(abortError(signal));
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      reject(abortError(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    gate.then(
+      () => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      (e) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        reject(e);
+      },
+    );
+  });
 }

--- a/runtime/tests/tools/abort-aware-acquire.test.ts
+++ b/runtime/tests/tools/abort-aware-acquire.test.ts
@@ -1,0 +1,579 @@
+import { describe, expect, test } from "vitest";
+import { Semaphore } from "./concurrency.js";
+import { AsyncRwLock } from "../utils/async-rwlock.js";
+
+// ──────────────────────────────────────────────────────────────────────
+// Abort-aware lock/semaphore acquisition (GOAL ITEM #2).
+//
+// These tests drive the REAL Semaphore + AsyncRwLock (no mocks) and
+// exercise the lost-wakeup / double-grant races deterministically by
+// controlling resolution order with explicit microtask / setImmediate
+// yields. The central invariant being protected:
+//
+//   At every instant each in-use permit / write turn has EXACTLY ONE
+//   owner. A grant handed toward a cancelling waiter is FORWARDED to the
+//   next live waiter (queued-cancel) or kept by the already-granted
+//   waiter that releases normally (granted-cancel) — NEVER dropped and
+//   NEVER double-granted.
+// ──────────────────────────────────────────────────────────────────────
+
+const microtask = (): Promise<void> => Promise.resolve();
+const tick = (): Promise<void> =>
+  new Promise<void>((r) => setImmediate(r));
+
+/** Settle-or-pending probe so we can assert a promise has NOT resolved. */
+async function isPending<T>(p: Promise<T>): Promise<boolean> {
+  const sentinel = Symbol("pending");
+  const raced = await Promise.race([
+    p.then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    ),
+    Promise.resolve().then(() => sentinel),
+  ]);
+  return raced === sentinel;
+}
+
+describe("Semaphore abort-aware acquire", () => {
+  // ── Test 1: No lost-wakeup / no-drop — cancel a QUEUED middle waiter.
+  //    3 FIFO waiters on capacity-1; cancel the MIDDLE while queued;
+  //    release the holder; the 3rd STILL acquires and the cancelled one
+  //    rejected. A permit is never lost.
+  test("no-drop: cancelling a queued middle waiter still lets the tail acquire", async () => {
+    const sem = new Semaphore(1);
+    const holder = await sem.acquire();
+    expect(sem.available).toBe(0);
+
+    const midCtl = new AbortController();
+    const w1 = sem.acquire(); // FIFO #1
+    const w2 = sem.acquire(midCtl.signal); // FIFO #2 — victim (queued)
+    const w3 = sem.acquire(); // FIFO #3
+    await microtask();
+    expect(sem.queueDepth).toBe(3);
+
+    // Cancel the middle waiter while it is still queued (holder still holds).
+    midCtl.abort(new Error("cancel-mid"));
+    await expect(w2).rejects.toThrow("cancel-mid");
+    expect(sem.queueDepth).toBe(2);
+
+    // Release the holder — the permit forwards to w1, then (after w1
+    // releases) to w3. No permit was lost to the cancelled w2.
+    holder();
+    const r1 = await w1;
+    r1();
+    const r3 = await w3;
+    expect(typeof r3).toBe("function");
+    r3();
+
+    expect(sem.available).toBe(1);
+    expect(sem.queueDepth).toBe(0);
+    expect(sem.acquiredCount).toBe(0);
+  });
+
+  // ── Test 2 (THE DOUBLE-GRANT BUG GUARD): granted-then-cancel must NOT
+  //    double-grant. Arrange a waiter to be GRANTED by pumpNext (holder
+  //    releases), then fire its abort in the SAME tick before it resumes.
+  //    Assert: (a) no two holders ever run concurrently, (b) final
+  //    acquired===0, queue empty, (c) no underflow throw.
+  //
+  //    This test FAILS against the design's original reject+forward
+  //    `granted` branch (which double-grants the permit) and PASSES with
+  //    the granted→no-op fix.
+  test("double-grant guard: granted-then-cancel keeps exactly one holder, counts exact", async () => {
+    const sem = new Semaphore(1);
+    const holder = await sem.acquire();
+
+    const victimCtl = new AbortController();
+    // The victim is FIFO head; a tail waiter sits behind it.
+    const victim = sem.acquire(victimCtl.signal);
+    const tail = sem.acquire();
+    await microtask();
+    expect(sem.queueDepth).toBe(2);
+
+    // Track concurrent holders to prove no double-grant ever runs two at
+    // once under the released permit.
+    let liveHolders = 0;
+    let maxLiveHolders = 0;
+    const runUnder = async (
+      acquireP: Promise<() => void>,
+    ): Promise<"ran" | "rejected"> => {
+      let release: (() => void) | undefined;
+      try {
+        release = await acquireP;
+      } catch {
+        return "rejected";
+      }
+      liveHolders += 1;
+      maxLiveHolders = Math.max(maxLiveHolders, liveHolders);
+      await tick(); // hold across a turn so an overlap would be observable
+      liveHolders -= 1;
+      release();
+      return "ran";
+    };
+
+    const victimRun = runUnder(victim);
+    const tailRun = runUnder(tail);
+
+    // Release the holder. pumpNext synchronously GRANTS the victim
+    // (state→granted, victim's promise resolves). BEFORE the victim's
+    // continuation runs, fire its abort in the same macrotask window.
+    holder();
+    // Abort now: the victim is already `granted`, so cancelWaiter is a
+    // NO-OP — the victim keeps the permit and releases it normally.
+    victimCtl.abort(new Error("granted-cancel"));
+
+    const [victimOutcome, tailOutcome] = await Promise.all([
+      victimRun,
+      tailRun,
+    ]);
+
+    // The victim won the irrevocable grant, so it RAN (and released
+    // normally). The tail then acquired the forwarded permit. Either way:
+    // (a) never two holders at once.
+    expect(maxLiveHolders).toBeLessThanOrEqual(1);
+    // Both eventually acquired exactly one permit each (serially).
+    expect(victimOutcome).toBe("ran");
+    expect(tailOutcome).toBe("ran");
+
+    // (b) exact count integrity at the end.
+    await tick();
+    expect(sem.acquiredCount).toBe(0);
+    expect(sem.available).toBe(1);
+    expect(sem.queueDepth).toBe(0);
+    // (c) no underflow throw occurred (we'd have caught it as a rejection).
+  });
+
+  // ── Test 2b: granted-cancel where the granted victim is consumed via the
+  //    real ToolCallRuntime stage-2 (signal-checked withRead) so the
+  //    abort actually surfaces as a rejection while the permit is still
+  //    conserved. This mirrors the production shared_server path.
+  test("granted-cancel via stage-2 withRead: permit conserved, abort surfaces", async () => {
+    const sem = new Semaphore(1);
+    const lock = new AsyncRwLock<void>(undefined);
+    const holder = await sem.acquire();
+
+    const victimCtl = new AbortController();
+    let victimRejected = false;
+
+    // Production-shaped shared_server acquire: permit then signal-checked
+    // withRead; finally releases the permit (idempotent).
+    const sharedServerRun = async (signal: AbortSignal): Promise<string> => {
+      const release = await sem.acquire(signal);
+      try {
+        return await lock.withRead(async () => "ran", signal);
+      } finally {
+        release();
+      }
+    };
+
+    const victim = sharedServerRun(victimCtl.signal).catch((e: unknown) => {
+      victimRejected = true;
+      throw e;
+    });
+    const tail = sem.acquire();
+    await microtask();
+    expect(sem.queueDepth).toBe(2);
+
+    holder();
+    // Victim is granted the permit synchronously; abort while granted.
+    victimCtl.abort(new Error("granted-cancel-2"));
+
+    // The victim takes the permit, enters stage-2 withRead, which sees the
+    // aborted signal and throws — releasing the permit in finally, which
+    // forwards to the tail.
+    await expect(victim).rejects.toThrow("granted-cancel-2");
+    expect(victimRejected).toBe(true);
+
+    const rTail = await tail;
+    expect(typeof rTail).toBe("function");
+    rTail();
+
+    await tick();
+    expect(sem.acquiredCount).toBe(0);
+    expect(sem.available).toBe(1);
+    expect(sem.queueDepth).toBe(0);
+  });
+
+  // ── Test 3: Count-integrity stress — N waiters with a deterministic mix
+  //    of cancels (some queued, some at-grant) and normal releases. At the
+  //    end: acquired===0, available===capacity, queue empty.
+  test("count-integrity stress: mixed queued/at-grant cancels, exact final counts", async () => {
+    const N = 20;
+    const sem = new Semaphore(1);
+    const holder = await sem.acquire();
+
+    const ctls: AbortController[] = [];
+    // Cancel pattern: every 3rd waiter is cancelled while queued; every 5th
+    // (and not already a queued-cancel) is an at-grant cancel target — its
+    // abort fires the instant it is granted the permit (a no-op that must
+    // not drop or double-count the permit).
+    const queuedCancel = new Set<number>();
+    const atGrantCancel = new Set<number>();
+    for (let i = 0; i < N; i++) {
+      if (i % 3 === 0) queuedCancel.add(i);
+      else if (i % 5 === 0) atGrantCancel.add(i);
+    }
+
+    let rejectedCount = 0;
+    let acquiredCount = 0;
+    let doubleSettled = 0;
+    // Self-draining chain: on grant, the at-grant-cancel target fires its
+    // own abort (granted ⇒ no-op) then releases; everyone else just
+    // releases — forwarding the permit to the next live waiter in FIFO.
+    const acquires: Array<Promise<void>> = [];
+    for (let i = 0; i < N; i++) {
+      const ctl = new AbortController();
+      ctls.push(ctl);
+      let settledOnce = false;
+      acquires.push(
+        sem
+          .acquire(ctl.signal)
+          .then((release) => {
+            if (settledOnce) doubleSettled += 1;
+            settledOnce = true;
+            acquiredCount += 1;
+            if (atGrantCancel.has(i)) ctl.abort(new Error(`grant-cancel-${i}`));
+            release();
+          })
+          .catch(() => {
+            if (settledOnce) doubleSettled += 1;
+            settledOnce = true;
+            rejectedCount += 1;
+          }),
+      );
+    }
+    await microtask();
+    expect(sem.queueDepth).toBe(N);
+
+    // Cancel all queued-cancel victims while everything is parked.
+    for (const i of queuedCancel) {
+      ctls[i]!.abort(new Error(`queued-cancel-${i}`));
+    }
+    await microtask();
+    expect(sem.queueDepth).toBe(N - queuedCancel.size);
+
+    // Release the holder; the self-draining chain resolves the rest.
+    holder();
+    await Promise.all(acquires);
+    await tick();
+
+    expect(sem.acquiredCount).toBe(0);
+    expect(sem.available).toBe(1);
+    expect(sem.queueDepth).toBe(0);
+    // Exact conservation: every waiter settled exactly once.
+    expect(doubleSettled).toBe(0);
+    expect(acquiredCount + rejectedCount).toBe(N);
+    // Queued-cancel victims rejected; at-grant victims won the irrevocable
+    // grant and ran. So rejected === queuedCancel.size exactly.
+    expect(rejectedCount).toBe(queuedCancel.size);
+    expect(acquiredCount).toBe(N - queuedCancel.size);
+  });
+
+  // ── Test 5: FIFO-preservation — uncancelled waiters acquire in
+  //    registration order.
+  test("FIFO: uncancelled waiters acquire in registration order", async () => {
+    const sem = new Semaphore(1);
+    const holder = await sem.acquire();
+
+    const order: number[] = [];
+    const ctls = [0, 1, 2, 3, 4].map(() => new AbortController());
+    // Each acquire, on grant, records its order then immediately releases so
+    // the permit forwards to the next survivor — a self-draining chain.
+    const acquires = ctls.map((ctl, i) =>
+      sem
+        .acquire(ctl.signal)
+        .then((release) => {
+          order.push(i);
+          release();
+        })
+        .catch(() => {}),
+    );
+    await microtask();
+    expect(sem.queueDepth).toBe(5);
+
+    // Cancel #1 and #3 while queued; survivors are 0, 2, 4 (in order).
+    ctls[1]!.abort(new Error("c1"));
+    ctls[3]!.abort(new Error("c3"));
+    await microtask();
+    expect(sem.queueDepth).toBe(3);
+
+    // Release the holder; the self-draining chain forwards the permit
+    // through the survivors in FIFO order.
+    holder();
+    await Promise.all(acquires);
+    await tick();
+    expect(order).toEqual([0, 2, 4]);
+    expect(sem.acquiredCount).toBe(0);
+    expect(sem.queueDepth).toBe(0);
+  });
+
+  // ── Already-aborted fast path: throws before enqueue, queue untouched.
+  test("already-aborted signal throws before enqueue", async () => {
+    const sem = new Semaphore(1);
+    const holder = await sem.acquire();
+    const ctl = new AbortController();
+    ctl.abort(new Error("pre-aborted"));
+    await expect(sem.acquire(ctl.signal)).rejects.toThrow("pre-aborted");
+    expect(sem.queueDepth).toBe(0);
+    holder();
+    expect(sem.available).toBe(1);
+  });
+
+  // ── Capacity>1 correctness: forward-on-collision is per-permit.
+  test("capacity=2: queued-cancel does not strand permits", async () => {
+    const sem = new Semaphore(2);
+    const h1 = await sem.acquire();
+    const h2 = await sem.acquire();
+    expect(sem.available).toBe(0);
+
+    const midCtl = new AbortController();
+    const w1 = sem.acquire();
+    const w2 = sem.acquire(midCtl.signal);
+    const w3 = sem.acquire();
+    await microtask();
+    expect(sem.queueDepth).toBe(3);
+
+    midCtl.abort(new Error("cap2-cancel"));
+    await expect(w2).rejects.toThrow("cap2-cancel");
+
+    h1();
+    h2();
+    const r1 = await w1;
+    const r3 = await w3;
+    expect(typeof r1).toBe("function");
+    expect(typeof r3).toBe("function");
+    r1();
+    r3();
+    expect(sem.available).toBe(2);
+    expect(sem.acquiredCount).toBe(0);
+    expect(sem.queueDepth).toBe(0);
+  });
+});
+
+describe("AsyncRwLock abort-aware writer", () => {
+  // ── Test 1 (write lock): no-drop — cancel a queued middle writer; the
+  //    tail writer STILL acquires; the reader behind reopens.
+  test("no-drop: cancelling a queued middle writer still forwards the turn", async () => {
+    const lock = new AsyncRwLock<number[]>([]);
+    const order: string[] = [];
+
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = lock.withWrite(async () => {
+      order.push("holder-start");
+      await holderGate;
+      order.push("holder-end");
+    });
+    await microtask(); // holder takes the turn (fast path)
+
+    const midCtl = new AbortController();
+    const w1 = lock.withWrite(async () => {
+      order.push("w1");
+    });
+    const w2 = lock.withWrite(async () => {
+      order.push("w2");
+    }, midCtl.signal); // victim
+    const w3 = lock.withWrite(async () => {
+      order.push("w3");
+    });
+    const reader = lock.withRead(async () => {
+      order.push("reader");
+    });
+    await microtask();
+    expect(lock.writeQueueDepth).toBe(3);
+
+    // Cancel the middle writer while queued.
+    midCtl.abort(new Error("mid-writer-cancel"));
+    await expect(w2).rejects.toThrow("mid-writer-cancel");
+    expect(lock.writeQueueDepth).toBe(2);
+
+    // Release the holder; the turn forwards w1 → w3, then the reader
+    // ungates. w2 never ran.
+    releaseHolder();
+    await Promise.all([holder, w1, w3, reader]);
+
+    expect(order).toContain("w1");
+    expect(order).toContain("w3");
+    expect(order).toContain("reader");
+    expect(order).not.toContain("w2");
+    expect(lock.activeReaders).toBe(0);
+    expect(lock.writeQueueDepth).toBe(0);
+    expect(lock.writeHeldNow).toBe(false);
+  });
+
+  // ── Test 2 (write lock granted-cancel correctness): granted-then-cancel
+  //    must NOT double-grant the write turn. The granted writer keeps the
+  //    turn; runHeld rechecks the signal and throws (never runs fn), then
+  //    hands off ONCE to the tail. No two writers ever hold concurrently;
+  //    counts exact; strict serial forwarding tail → extra.
+  //
+  //    NOTE on revert-sensitivity: unlike the Semaphore (Test #2), the
+  //    WRITER granted→no-op fix is behaviorally EQUIVALENT to the design's
+  //    original reject+forward branch in this promise model — the runHeld
+  //    signal-recheck (which throws before fn) plus the setImmediate yields
+  //    serialize the writers regardless, so a spurious second handoff is
+  //    masked (it hits an empty queue or grants a writer that would have
+  //    been granted anyway). This test therefore guards granted-cancel
+  //    CORRECTNESS (no fn run, exactly-once serial forwarding, count
+  //    integrity), not revert-sensitivity. The observable double-grant bug
+  //    lives in the Semaphore, where the woken waiter takes the permit
+  //    synchronously with no recheck — see the Semaphore double-grant guard.
+  test("granted-cancel (writer): runs no fn, forwards exactly once, no overlap", async () => {
+    const lock = new AsyncRwLock<void>(undefined);
+
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = lock.withWrite(async () => {
+      await holderGate;
+    });
+    await microtask();
+
+    const victimCtl = new AbortController();
+    let victimFnRan = false;
+    let liveWriters = 0;
+    let maxLiveWriters = 0;
+    const fnRunOrder: string[] = [];
+
+    // Three queued writers behind the holder: victim (granted-cancel), then
+    // tail, then extra. A buggy reject+forward `granted` branch issues a
+    // SECOND handoff (the victim's own runHeld finally ALSO hands off), so
+    // the tail AND the extra get granted while only one should hold → the
+    // overlap / extra-early-run is observable. The fix hands off exactly
+    // once: tail, then (after tail releases) extra — strictly serial.
+    //
+    // The tail HOLDS (gated) so we can inspect, mid-flight, whether the
+    // extra writer was spuriously granted concurrently.
+    let releaseTail!: () => void;
+    const tailHold = new Promise<void>((r) => {
+      releaseTail = r;
+    });
+
+    const victim = lock.withWrite(async () => {
+      victimFnRan = true; // must NEVER happen
+    }, victimCtl.signal);
+    const tail = lock.withWrite(async () => {
+      fnRunOrder.push("tail");
+      liveWriters += 1;
+      maxLiveWriters = Math.max(maxLiveWriters, liveWriters);
+      await tailHold; // hold the write lock open for inspection
+      liveWriters -= 1;
+    });
+    const extra = lock.withWrite(async () => {
+      fnRunOrder.push("extra");
+      liveWriters += 1;
+      maxLiveWriters = Math.max(maxLiveWriters, liveWriters);
+      await tick();
+      liveWriters -= 1;
+    });
+    await microtask();
+    expect(lock.writeQueueDepth).toBe(3);
+
+    // Release the holder → pumpWrite grants the victim (state→granted).
+    // Abort the victim in the SAME window: it is granted, so cancelWriteWaiter
+    // must be a NO-OP. runHeld rechecks the aborted signal and THROWS before
+    // running the victim's fn, then hands off ONCE to the tail.
+    releaseHolder();
+    victimCtl.abort(new Error("granted-writer-cancel"));
+
+    await expect(victim).rejects.toThrow("granted-writer-cancel");
+    // Let the tail be granted and start running (it then holds on tailHold).
+    await tick();
+    await tick();
+
+    // MID-FLIGHT INSPECTION: the tail holds the write lock; the extra writer
+    // must NOT have been granted yet. A double-handoff would have granted the
+    // extra concurrently → fnRunOrder would contain "extra" and overlap.
+    expect(fnRunOrder).toEqual(["tail"]);
+    expect(lock.writeHeldNow).toBe(true);
+    expect(maxLiveWriters).toBe(1);
+
+    // Release the tail; now the extra is granted (serially).
+    releaseTail();
+    await extra;
+
+    // The victim's fn NEVER ran.
+    expect(victimFnRan).toBe(false);
+    // Exactly-once forwarding, strict serial order, never two holders.
+    expect(fnRunOrder).toEqual(["tail", "extra"]);
+    expect(maxLiveWriters).toBe(1);
+
+    await holder;
+    await tick();
+    expect(lock.writeQueueDepth).toBe(0);
+    expect(lock.writeHeldNow).toBe(false);
+    expect(lock.activeReaders).toBe(0);
+  });
+
+  // ── Reader abort path: a withRead aborted while gated behind a writer
+  //    rejects and does NOT increment readers.
+  test("reader gated behind a writer aborts without touching readers count", async () => {
+    const lock = new AsyncRwLock<void>(undefined);
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = lock.withWrite(async () => {
+      await holderGate;
+    });
+    await microtask();
+
+    const readerCtl = new AbortController();
+    let readerFnRan = false;
+    const reader = lock.withRead(async () => {
+      readerFnRan = true;
+    }, readerCtl.signal);
+    await microtask();
+    expect(lock.activeReaders).toBe(0); // gated, not yet a reader
+
+    readerCtl.abort(new Error("reader-cancel"));
+    await expect(reader).rejects.toThrow("reader-cancel");
+    expect(lock.activeReaders).toBe(0); // never incremented
+    expect(readerFnRan).toBe(false);
+
+    releaseHolder();
+    await holder;
+    expect(lock.writeHeldNow).toBe(false);
+    expect(lock.activeReaders).toBe(0);
+  });
+
+  // ── FIFO writer order among survivors.
+  test("FIFO: surviving writers acquire in registration order", async () => {
+    const lock = new AsyncRwLock<void>(undefined);
+    const order: number[] = [];
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = lock.withWrite(async () => {
+      await holderGate;
+    });
+    await microtask();
+
+    const ctls = [0, 1, 2, 3, 4].map(() => new AbortController());
+    const writers = ctls.map((ctl, i) =>
+      lock.withWrite(async () => {
+        order.push(i);
+      }, ctl.signal),
+    );
+    await microtask();
+    expect(lock.writeQueueDepth).toBe(5);
+
+    ctls[1]!.abort(new Error("w1-cancel"));
+    ctls[3]!.abort(new Error("w3-cancel"));
+    await microtask();
+    expect(lock.writeQueueDepth).toBe(3);
+
+    releaseHolder();
+    const results = await Promise.allSettled([holder, ...writers]);
+    // Survivors 0,2,4 ran in registration order; 1,3 rejected.
+    expect(order).toEqual([0, 2, 4]);
+    expect(results[2]!.status).toBe("rejected"); // writer index 1
+    expect(results[4]!.status).toBe("rejected"); // writer index 3
+    expect(lock.writeQueueDepth).toBe(0);
+    expect(lock.writeHeldNow).toBe(false);
+  });
+});

--- a/runtime/tests/tools/streaming-executor.stuck-tool-drain.test.ts
+++ b/runtime/tests/tools/streaming-executor.stuck-tool-drain.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 import { StreamingToolExecutor } from "./streaming-executor.js";
-import { SHARED_READ, EXCLUSIVE, ToolCallRuntime } from "./concurrency.js";
+import {
+  SHARED_READ,
+  EXCLUSIVE,
+  ToolCallRuntime,
+  sharedServer,
+} from "./concurrency.js";
 import { routerFromRegistry } from "./router.js";
 import { EventLog } from "../session/event-log.js";
 import type { ToolRegistry, ToolDispatchResult } from "../tool-registry.js";
@@ -858,5 +863,124 @@ describe("StreamingToolExecutor live-path wedged pre-hook (reclaimed not leaked)
     expect(String(result.content)).not.toContain(
       "[Request interrupted by user for tool use]",
     );
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Abort-aware acquire (GOAL ITEM #2) — executor acceptance.
+//
+// A queued tool B parked INSIDE the per-server Semaphore.acquire (behind a
+// still-holding holder A) must, when force-finalized by the drain
+// (drainCancel fires), REJECT its acquire PROMPTLY — bounded, well before A
+// releases — reclaim its outcome, and NEVER transiently run its dispatch.
+//
+// REVERT PROOF: against the pre-fix acquire (no signal threading into
+// Semaphore.acquire), B stays parked until A releases, so the bounded
+// "B reclaims before A releases" assertion times out (clean red). With the
+// signal threaded, B's parked acquire wakes on drainCancel and rejects
+// immediately → green.
+// ──────────────────────────────────────────────────────────────────────
+describe("StreamingToolExecutor abort-aware parked acquire (goal #2)", () => {
+  test("a tool parked in Semaphore.acquire is force-finalized WITHOUT waiting on the holder ahead", async () => {
+    const SERVER = "dbA";
+
+    // A's dispatch never settles on its own (it holds the only permit).
+    // B never reaches dispatch (it parks in acquire); if it ever DID, the
+    // spy below would catch the transient run.
+    let bDispatchCalls = 0;
+    let releaseA: (() => void) | undefined;
+    const aGate = new Promise<ToolDispatchResult>((resolve) => {
+      // Holder A: a controllable wedge. We never resolve until the test
+      // explicitly releases (so we can prove B reclaims BEFORE A releases).
+      releaseA = () => resolve({ content: "A done", isError: false });
+    });
+
+    const runtime = new ToolCallRuntime(); // capacity-1 per server (default)
+    // A is registered with timeoutBehavior:"tool" → drain-EXEMPT (Infinity
+    // deadline), so the holder ahead is NEVER force-finalized and keeps
+    // holding the permit. Only B (no def → flat floor) is force-finalizable.
+    const holderDef = testTool({ name: "A", timeoutBehavior: "tool" });
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(
+        () => new Promise<ToolDispatchResult>(() => {}),
+        [holderDef],
+      ),
+      runtime,
+      // Tiny drain floor so B's parked acquire is force-finalized fast.
+      maxToolDrainMs: 200,
+      cleanupGraceMs: 150,
+    });
+    (exec as unknown as { runToolUseFn?: unknown }).runToolUseFn = (
+      call: LLMToolCall,
+    ): Promise<ToolDispatchResult> => {
+      if (call.id === "A") return aGate;
+      bDispatchCalls += 1; // B should NEVER reach here while parked
+      return new Promise<ToolDispatchResult>(() => {});
+    };
+
+    // Both tools target the SAME serverId → contend on one capacity-1
+    // semaphore. Both are shared_server (concurrency-safe) so they dispatch
+    // in parallel: A wins the permit, B parks in acquire.
+    exec.setConcurrencyClassFor("A", sharedServer(SERVER));
+    exec.setConcurrencyClassFor("B", sharedServer(SERVER));
+    exec.addTool(makeBlock("A", "A"), makeCall("A", "A"));
+    exec.addTool(makeBlock("B", "B"), makeCall("B", "B"));
+    exec.dispatchPending();
+    exec.close();
+
+    const collected: Array<{ id: string; isError: boolean }> = [];
+    const drainDone = (async () => {
+      for await (const r of exec.getRemainingResults()) {
+        collected.push({ id: r.toolCall.id, isError: r.result.isError === true });
+      }
+    })();
+
+    // Let A acquire the permit and B park in acquire.
+    await new Promise((r) => setTimeout(r, 30).unref?.());
+    // B must be parked behind A: B has NOT dispatched.
+    const midStates = exec.getToolStates();
+    expect(midStates.find((s) => s.id === "B")?.hasDispatched).toBe(false);
+    expect(midStates.find((s) => s.id === "A")?.hasDispatched).toBe(true);
+
+    // BOUNDED ASSERTION (the revert-sensitive one): B's force-finalized
+    // outcome must classify as reclaimed within a short window — WITHOUT A
+    // ever releasing. Against the unthreaded acquire, B stays parked and
+    // this loop never sees "reclaimed" → it exhausts and the expect fails.
+    const deadline = Date.now() + 1500;
+    let bReclaimed = false;
+    while (Date.now() < deadline) {
+      const tracked = (
+        exec as unknown as { tools: Array<{ id: string; outcome?: string }> }
+      ).tools.find((t) => t.id === "B");
+      if (tracked?.outcome === "reclaimed") {
+        bReclaimed = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25).unref?.());
+    }
+
+    // (1) B reclaimed promptly — and A is still holding (never released).
+    expect(bReclaimed).toBe(true);
+    expect(releaseA).toBeDefined();
+    // A is STILL executing (we have not released it): proves B's reclaim did
+    // NOT wait on the holder ahead.
+    expect(exec.getToolStates().find((s) => s.id === "A")?.status).toBe(
+      "executing",
+    );
+    // (2) B NEVER ran its dispatch (no transient post-finalize acquire).
+    expect(bDispatchCalls).toBe(0);
+    expect(exec.getToolStates().find((s) => s.id === "B")?.hasDispatched).toBe(
+      false,
+    );
+
+    // Now release A so the drain terminates cleanly.
+    releaseA!();
+    const outcome = await withTimeout(drainDone, 4000, "goal2-parked-acquire");
+    expect(outcome.ok).toBe(true);
+    // B yielded a synthetic timeout; A yielded its real result.
+    expect(collected).toContainEqual({ id: "B", isError: true });
+    expect(collected).toContainEqual({ id: "A", isError: false });
+    // B still never dispatched even after A released.
+    expect(bDispatchCalls).toBe(0);
   });
 });


### PR DESCRIPTION
Goal item #2 / follow-up to #1318/#1319/#1320.

## The gap
A tool **parked waiting to acquire** (in `Semaphore.acquire` or `AsyncRwLock.withWrite` behind a prior holder) took no abort signal — so when the drain force-finalized it, the parked acquire never woke. It stayed queued until the holder ahead released, then **transiently acquired the guard after being finalized**. Now acquisition is abort-aware.

## What changed
- **AsyncRwLock** (`utils/async-rwlock.ts`): writer side rebuilt from the implicit promise-chain into an explicit `writeWaiters` FIFO of identity-carrying records with a synchronous `state: queued|granted|cancelled` claim; `withRead`/`withWrite` take an optional signal; a queued waiter aborted before grant is removed atomically (`pumpWrite` skips cancelled records); `runHeld` rechecks the signal before draining/running so a granted-then-cancelled writer hands off cleanly.
- **Semaphore** (`concurrency.ts`): identity-carrying records + **direct permit-transfer** accounting (`acquired` counted at grant time, never re-touched by the woken waiter; release forwards to a live waiter or frees). Signal threaded into **both** `shared_server` stages.
- Signal plumbed additively (`ToolRuntimeCallContext.acquireSignal` → `runToolRuntimeCall`/`ToolCallRuntime.run` → the acquire overloads); `runOne` reuses the existing `dispatchSignal`.

## Critical correctness — a double-grant bug caught in review
The draft design's `granted` cancel branch did `reject()` + forward. But `grant()` = `resolve()` is **irrevocable** in a promise model, so the post-grant `reject()` is a no-op and the caller still takes the permit; the forward grants the *next* waiter too → **two holders → `acquired` underflow**. The fix: `granted` → **no-op** (only still-`queued` waiters are removed; a granted waiter keeps its permit and releases normally). **Lost-wakeup is avoided structurally** — grant and cancel resolve under one synchronous `state` flag, and pump always forwards to the next *live* waiter. (Also fixed a regression found mid-implementation: the explicit-queue writer fast path stole the lock before a concurrent reader could register; restored with a `setImmediate` yield.)

## Tests (revert-sensitive, deterministic — no timeouts)
No-lost-wakeup (cancel the middle of 3 waiters → 3rd still acquires); **Semaphore double-grant guard** (granted-then-cancel keeps exactly one holder, exact counts — **reddens with `acquired underflow`** against the reject+forward branch); count-integrity stress (N=20 mixed cancels → `acquired===0`, `readers===0`, queues empty, every waiter settles once); FIFO; already-aborted fast path; capacity=2; + executor acceptance (a force-finalized queued `shared_server` waiter reclaims **without waiting on the holder ahead** and never transiently dispatches — reddens against the unthreaded acquire).

## Gate
- `npm run build` ✅ exit 0 · `tsc -p runtime --noEmit` ✅ clean
- full `npm run test:unit` ✅ **1582 files / 13,434 tests passed, 0 failures**
- double-grant revert-sensitivity independently re-verified: reintroducing the buggy `granted` branch reddens both guards with `Semaphore acquired underflow`; restored → green.

> Note: the design's adversarial-proposal phase failed (output-schema retry cap), so the synthesized architecture was **manually code-reviewed**, which is how the double-grant bug was caught before implementation.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG