### PR TITLE
feat(daemon): behavioral backstop for semantic non-termination (goal #3)

### DIFF
--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -2015,7 +2015,8 @@ export async function* runAgent(
         | "max_turns"
         | "cancelled"
         | "error"
-        | "empty_response" = "completed";
+        | "empty_response"
+        | "no_progress" = "completed";
       let terminalError: unknown;
 
       const iter = childSession.runTurn(nextUserMessage, {
@@ -2117,10 +2118,18 @@ export async function* runAgent(
         if (merged.signal.aborted) break;
       }
 
-      if (stopReason === "error" || stopReason === "max_turns") {
+      if (
+        stopReason === "error" ||
+        stopReason === "max_turns" ||
+        stopReason === "no_progress"
+      ) {
         let message: string;
         if (stopReason === "max_turns") {
           message = `subagent exceeded maxTurns${params.maxTurns !== undefined ? ` (${params.maxTurns})` : ""}`;
+        } else if (stopReason === "no_progress") {
+          message =
+            assistantText ||
+            "subagent stopped by the no-progress backstop (semantic non-termination)";
         } else if (terminalError instanceof Error) {
           message = terminalError.message;
         } else if (typeof terminalError === "string") {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -3769,6 +3769,13 @@ function phaseEventToProgressEvent(
           error: "Agent exceeded maxTurns",
         };
       }
+      if (event.stopReason === "no_progress") {
+        return {
+          kind: "run_error",
+          error:
+            "Agent stopped by the no-progress backstop (semantic non-termination)",
+        };
+      }
       // "completed" | "empty_response" — a per-turn completion. Emit
       // turn_complete (NOT run_complete — the session continues across
       // turns; run_complete would trigger cleanup).

--- a/runtime/src/phases/events.ts
+++ b/runtime/src/phases/events.ts
@@ -49,6 +49,7 @@ export type PhaseEvent =
         | "max_turns"
         | "cancelled"
         | "error"
-        | "empty_response";
+        | "empty_response"
+        | "no_progress"; // behavioral backstop (semantic non-termination, goal #3)
       readonly error?: Error;
     };

--- a/runtime/src/session/behavioral-backstop.ts
+++ b/runtime/src/session/behavioral-backstop.ts
@@ -1,0 +1,445 @@
+/**
+ * Behavioral backstop for semantic non-termination (goal item #3).
+ *
+ * A two-tier, result-aware, NON-BLOCKING watchdog over the agentic turn
+ * loop. It is the *second* whole-turn backstop, distinct from the
+ * #1318–#1321 per-tool dispatch drain (which catches a tool whose
+ * dispatch wedges). This one catches a *semantic runaway*: every tool
+ * call settles cleanly, every dispatch returns, but the loop spins
+ * making no real progress (the local model was observed thrashing
+ * ~65k tokens/turn). It finalizes the turn cleanly with an honest typed
+ * terminal (`no_progress`) and never false-positives on legitimate
+ * repetition (status polling, progressing retries).
+ *
+ * The whole module is PURE synchronous — no `await`, no timers, no I/O.
+ * The detector logic is therefore unit-testable in isolation and, when
+ * called from the turn loop, structurally cannot stall the loop it
+ * polices (see §2.5 of the design doc).
+ *
+ * Tiers:
+ *   - Tier 0 — absolute per-turn deadline (steps / tokens / wall-clock).
+ *     The guarantee. Depends on nothing the model says. Ships OFF by
+ *     default (all three caps default 0 = disabled); ops opt them in.
+ *   - Tier 1 — cheap, always-on, result-aware per-step detectors
+ *     (repetition ladder, ABAB/period cycle, low-gain streak). Every
+ *     repetition/cycle/low-gain trip requires an UNCHANGED resultHash —
+ *     this single invariant is the entire false-positive defense, so the
+ *     tier is on by default because it structurally cannot fire on
+ *     genuine progress.
+ *   - Tier 2 — optional non-blocking observer (warn/log only). Off by
+ *     default; wired at the un-awaited `launch*PostSampling` seam,
+ *     polled never awaited.
+ *
+ * @module
+ */
+
+import { canonicalJsonKey } from "../permissions/approval-cache.js";
+import type { LLMUsage } from "../llm/types.js";
+import type {
+  AssistantMessage,
+  CompletedToolResultRecord,
+  ToolUseBlock,
+  TurnState,
+} from "./turn-state.js";
+
+export interface StepRecord {
+  /** Normalized action signature (structure, not tokens). */
+  readonly sig: string;
+  /** Normalized result hash (content + isError). */
+  readonly resultHash: string;
+  /** `state.turnCount` when recorded. */
+  readonly iteration: number;
+  /** Produced no novelty this step. */
+  readonly lowGain: boolean;
+}
+
+export type ProgressTripKind = "repetition" | "abab" | "low_gain" | "deadline";
+
+export interface ProgressTrip {
+  readonly kind: ProgressTripKind;
+  /** Human + observability diagnostic (sig, run length, which cap). */
+  readonly detail: string;
+  /** Honest, model+user-visible explanation pushed to the transcript. */
+  readonly userMessage: string;
+}
+
+export type ProgressDecision =
+  | { readonly kind: "none" }
+  | {
+      readonly kind: "warn";
+      readonly detail: string;
+      readonly nudgeText?: string;
+      readonly injectNudge: boolean;
+    }
+  | { readonly kind: "terminate"; readonly trip: ProgressTrip };
+
+export interface BehavioralConfig {
+  /** Master switch. */
+  readonly enabled: boolean;
+  /** Wink >=3 warn threshold. */
+  readonly repeatSoft: number;
+  /** Hard-terminate run length. */
+  readonly repeatHard: number;
+  /** Full stable cycles to trip the ABAB/period detector. */
+  readonly ababCycles: number;
+  /** Gated low-gain streak to trip. */
+  readonly lowGainStreak: number;
+  /** Ring-buffer length. */
+  readonly window: number;
+  /** 0 = disabled (off-by-default). */
+  readonly maxTurnMs: number;
+  /** 0 = disabled (off-by-default). */
+  readonly maxTurnTokens: number;
+  /** 0 = disabled (off-by-default); tighter than max_turns. */
+  readonly maxTurnSteps: number;
+  /** Tier-2 fire-and-forget observer (off by default). */
+  readonly observerEnabled: boolean;
+  /** Wink k=5 observer cadence. */
+  readonly observerEveryK: number;
+  /** Tools excluded from the repetition window. */
+  readonly ignoreTools: ReadonlySet<string>;
+  /** Bounded-prefix hashing of huge tool outputs (P1 graft). */
+  readonly resultHashPrefixBytes: number;
+  /** Strip timestamps/UUIDs/hex before hashing (off by default — new FP surface). */
+  readonly normalizeVolatile: boolean;
+}
+
+const SEP = " ";
+const JOIN = "";
+
+/** Stable non-crypto string hash (djb2). */
+function djb2(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw; // matches parseToolUseBlocks fallback
+  }
+}
+
+/** Conservative, OPT-IN volatile stripping (default OFF — see §6 risk). */
+function normalizeVolatile(s: string, enabled: boolean): string {
+  if (!enabled) return s;
+  return s
+    .replace(/\b\d{4}-\d{2}-\d{2}T[\d:.]+Z?\b/g, "<ts>") // ISO timestamps
+    .replace(
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+      "<uuid>",
+    ) // UUIDs
+    .replace(/\b0x[0-9a-f]{6,}\b/gi, "<hex>"); // long hex
+}
+
+/**
+ * Normalized action signature for the whole step (a multi-tool step is
+ * ONE action). `canonicalJsonKey` sorts object keys (so semantically
+ * identical args collide) but the step join preserves call order (so a
+ * reordered set of the same N calls yields a *different* sig — a safe
+ * under-detection, never a false positive).
+ */
+export function stepActionSignature(
+  lastAssistant: AssistantMessage,
+  toolUseBlocks: readonly ToolUseBlock[],
+): string {
+  if (lastAssistant.toolCalls.length === 0) {
+    return `text${SEP}${(lastAssistant.text ?? "").trim().replace(/\s+/g, " ")}`;
+  }
+  return lastAssistant.toolCalls
+    .map((call, i) => {
+      // Prefer the already-parsed block input; fall back to parsing raw
+      // arguments; fall back to the raw string on parse failure.
+      const parsed = toolUseBlocks[i]?.input ?? safeParse(call.arguments);
+      return `${call.name}${SEP}${canonicalJsonKey(parsed)}`;
+    })
+    .join(JOIN);
+}
+
+/**
+ * Normalized result hash (content + isError), bounded-prefix to keep
+ * recording O(window)-ish even on huge tool outputs.
+ */
+export function stepResultHash(
+  lastAssistant: AssistantMessage,
+  completedByCallId: ReadonlyMap<string, CompletedToolResultRecord>,
+  cfg: BehavioralConfig,
+): string {
+  if (lastAssistant.toolCalls.length === 0) return "text";
+  return lastAssistant.toolCalls
+    .map((call) => {
+      const rec = completedByCallId.get(call.id);
+      const raw = (rec?.content ?? "").slice(0, cfg.resultHashPrefixBytes);
+      const content = normalizeVolatile(raw, cfg.normalizeVolatile);
+      return `${rec?.isError ? "E" : "ok"}${SEP}${djb2(content)}`;
+    })
+    .join(JOIN);
+}
+
+export function resolveBehavioralConfig(ctx: {
+  readonly config?: Record<string, unknown>;
+}): BehavioralConfig {
+  // precedence (mirrors resolveMaxTurns): ctx.config.* > env > default
+  const num = (cfgKey: string, env: string, def: number): number => {
+    const c = ctx.config?.[cfgKey];
+    if (typeof c === "number" && Number.isFinite(c)) return c;
+    const e = process.env[env];
+    if (e !== undefined && e !== "") {
+      const n = Number(e);
+      if (Number.isFinite(n)) return n;
+    }
+    return def;
+  };
+  const bool = (cfgKey: string, env: string, def: boolean): boolean => {
+    const c = ctx.config?.[cfgKey];
+    if (typeof c === "boolean") return c;
+    const e = process.env[env];
+    if (e !== undefined)
+      return !["0", "false", "no", "off"].includes(e.trim().toLowerCase());
+    return def;
+  };
+  const tools = (process.env.AGENC_NOPROGRESS_IGNORE_TOOLS ?? "Sleep")
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+  return {
+    enabled: bool("behavioralBackstop", "AGENC_BEHAVIORAL_BACKSTOP", true),
+    repeatSoft: num("progressRepeatSoft", "AGENC_NOPROGRESS_WARN", 3),
+    repeatHard: num("progressRepeatHard", "AGENC_NOPROGRESS_TERMINATE", 8),
+    ababCycles: num("progressAbabCycles", "AGENC_ABAB_TERMINATE", 3),
+    lowGainStreak: num("progressLowGainStreak", "AGENC_LOWGAIN_TERMINATE", 6),
+    window: num("progressWindow", "AGENC_PROGRESS_WINDOW", 16),
+    maxTurnMs: num("progressMaxTurnMs", "AGENC_TURN_DEADLINE_MS", 0), // OFF by default
+    maxTurnTokens: num("progressMaxTurnTokens", "AGENC_TURN_TOKEN_CAP", 0), // OFF by default
+    maxTurnSteps: num("progressMaxTurnSteps", "AGENC_TURN_STEP_CAP", 0), // OFF by default
+    observerEnabled: bool("progressObserver", "AGENC_BEHAVIORAL_OBSERVER", false),
+    observerEveryK: num("progressObserverEvery", "AGENC_BEHAVIORAL_OBSERVER_K", 5),
+    ignoreTools: new Set(tools),
+    resultHashPrefixBytes: num(
+      "progressResultPrefix",
+      "AGENC_PROGRESS_RESULT_PREFIX",
+      64 * 1024,
+    ),
+    normalizeVolatile: bool(
+      "progressNormalizeVolatile",
+      "AGENC_PROGRESS_NORMALIZE_VOLATILE",
+      false,
+    ), // OFF
+  };
+}
+
+/**
+ * Record one real model-action step. Synchronous; mutates TurnState
+ * fields. No await, no timer, no lock, no I/O.
+ */
+export function recordBehavioralStep(
+  state: TurnState,
+  lastAssistant: AssistantMessage,
+  completedByCallId: ReadonlyMap<string, CompletedToolResultRecord>,
+  cfg: BehavioralConfig,
+): void {
+  if (!cfg.enabled) return;
+  // Exclude designated poll/sleep tools: if EVERY call in the step is an
+  // ignored tool, skip recording (a deliberate poll-sleep cadence is
+  // legitimate by design).
+  const calls = lastAssistant.toolCalls;
+  const allIgnored =
+    calls.length > 0 && calls.every((c) => cfg.ignoreTools.has(c.name));
+  if (allIgnored) return;
+
+  const sig = stepActionSignature(lastAssistant, state.toolUseBlocks);
+  const resultHash = stepResultHash(lastAssistant, completedByCallId, cfg);
+
+  // Novelty: a new tool name OR a new (sig,resultHash) pair for this step.
+  const seenSigResult = state.behavioralStepHistory.some(
+    (r) => r.sig === sig && r.resultHash === resultHash,
+  );
+  const newToolName = calls.some(
+    (c) => !state.behavioralSeenToolNames.has(c.name),
+  );
+  const lowGain = !newToolName && seenSigResult;
+  for (const c of calls) state.behavioralSeenToolNames.add(c.name);
+
+  state.behavioralStepHistory.push({
+    sig,
+    resultHash,
+    iteration: state.turnCount,
+    lowGain,
+  });
+  if (state.behavioralStepHistory.length > cfg.window) {
+    state.behavioralStepHistory.shift();
+  }
+
+  // low-gain streak
+  state.behavioralLowGainStreak = lowGain
+    ? state.behavioralLowGainStreak + 1
+    : 0;
+}
+
+/**
+ * Evaluate trip conditions. Synchronous read of already-collected state
+ * + integer comparisons + a bounded ring scan. Never awaits the model
+ * or a tool, so it structurally cannot stall the loop it polices.
+ */
+export function evaluateBehavioralBackstop(
+  state: TurnState,
+  usage: LLMUsage,
+  turnStartedAt: number,
+  cfg: BehavioralConfig,
+): ProgressDecision {
+  if (!cfg.enabled) return { kind: "none" };
+  const hist = state.behavioralStepHistory;
+
+  // ── Tier 0: absolute deadline (depends on nothing the model says) ──
+  if (cfg.maxTurnSteps > 0 && state.turnCount > cfg.maxTurnSteps) {
+    return terminate("deadline", `step cap ${cfg.maxTurnSteps} exceeded`, state.turnCount);
+  }
+  if (cfg.maxTurnTokens > 0 && (usage.totalTokens ?? 0) > cfg.maxTurnTokens) {
+    return terminate(
+      "deadline",
+      `token cap ${cfg.maxTurnTokens} exceeded (used ${usage.totalTokens})`,
+      state.turnCount,
+    );
+  }
+  if (cfg.maxTurnMs > 0 && Date.now() - turnStartedAt > cfg.maxTurnMs) {
+    return terminate("deadline", `wall-clock cap ${cfg.maxTurnMs}ms exceeded`, state.turnCount);
+  }
+
+  // ── Tier 1: result-aware semantic detectors ──
+  // 1. No-progress repetition: longest run of identical (sig,resultHash)
+  //    ending at the latest record.
+  const run = trailingIdenticalRun(hist);
+  if (run >= cfg.repeatHard) {
+    return terminate(
+      "repetition",
+      `identical (sig,resultHash) repeated ${run}x with no new information`,
+      run,
+    );
+  }
+
+  // 2. ABAB / small-period cycle (period p in 2..4), every sig's
+  //    resultHash stable across cycles.
+  const abab = detectStableCycle(hist, cfg.ababCycles);
+  if (abab) {
+    return terminate(
+      "abab",
+      `stable period-${abab.period} cycle repeated ${abab.cycles}x with no new information`,
+      abab.cycles,
+    );
+  }
+
+  // 3. Low-information-gain streak, gated by at least one repeated
+  //    signature in the window.
+  if (
+    state.behavioralLowGainStreak >= cfg.lowGainStreak &&
+    hasRepeatedSignature(hist)
+  ) {
+    return terminate(
+      "low_gain",
+      `low-information-gain streak ${state.behavioralLowGainStreak} with repeated signatures`,
+      state.behavioralLowGainStreak,
+    );
+  }
+
+  // Soft-nudge tier (Wink >=3): warn, do not finalize.
+  if (
+    run >= cfg.repeatSoft &&
+    run < cfg.repeatHard &&
+    !state.behavioralNudgeIssued
+  ) {
+    return {
+      kind: "warn",
+      detail: `identical action repeated ${run}x with no new result`,
+      injectNudge: true,
+      nudgeText:
+        "You have repeated the same action with the same result " +
+        `${run} times with no new information. Change your approach or stop; ` +
+        "repeating it again will not make progress.",
+    };
+  }
+
+  return { kind: "none" };
+}
+
+function terminate(
+  kind: ProgressTripKind,
+  why: string,
+  count: number,
+): ProgressDecision {
+  const userMessage =
+    kind === "deadline"
+      ? `Turn stopped by the no-progress backstop: ${why}. The turn was halted, not completed.`
+      : `Turn stopped by the no-progress backstop: ${why} (count=${count}). ` +
+        "No further progress was being made. No task was completed.";
+  return {
+    kind: "terminate",
+    trip: { kind, detail: `${kind}: ${why} (count=${count})`, userMessage },
+  };
+}
+
+function trailingIdenticalRun(hist: readonly StepRecord[]): number {
+  if (hist.length === 0) return 0;
+  const last = hist[hist.length - 1];
+  if (last === undefined) return 0;
+  let run = 1;
+  for (let i = hist.length - 2; i >= 0; i--) {
+    const rec = hist[i];
+    if (rec !== undefined && rec.sig === last.sig && rec.resultHash === last.resultHash) {
+      run++;
+    } else break;
+  }
+  return run;
+}
+
+function hasRepeatedSignature(hist: readonly StepRecord[]): boolean {
+  const seen = new Set<string>();
+  for (const r of hist) {
+    if (seen.has(r.sig)) return true;
+    seen.add(r.sig);
+  }
+  return false;
+}
+
+/**
+ * Detect a stable period-p cycle (p in 2..4) repeated >= minCycles full
+ * cycles at the tail, where every position's resultHash is unchanged
+ * across cycles (the result-aware guard). Requires the period to
+ * actually alternate (>= 2 distinct sigs) so a period-1 run cannot
+ * masquerade as a cycle.
+ */
+function detectStableCycle(
+  hist: readonly StepRecord[],
+  minCycles: number,
+): { period: number; cycles: number } | undefined {
+  for (let p = 2; p <= 4; p++) {
+    if (hist.length < p * minCycles) continue;
+    let cycles = 1;
+    // compare tail blocks of length p
+    for (let c = 1; c < Math.floor(hist.length / p); c++) {
+      let blockMatch = true;
+      for (let j = 0; j < p; j++) {
+        const a = hist[hist.length - 1 - j];
+        const b = hist[hist.length - 1 - j - p * c];
+        if (
+          a === undefined ||
+          b === undefined ||
+          a.sig !== b.sig ||
+          a.resultHash !== b.resultHash
+        ) {
+          blockMatch = false;
+          break;
+        }
+      }
+      if (blockMatch) cycles++;
+      else break;
+    }
+    // require the period to actually alternate (not period-1 masquerading)
+    const distinct = new Set(
+      hist.slice(hist.length - p).map((r) => r.sig),
+    ).size;
+    if (cycles >= minCycles && distinct >= 2) return { period: p, cycles };
+  }
+  return undefined;
+}

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -145,6 +145,12 @@ import {
   type TurnState,
 } from "./turn-state.js";
 import {
+  evaluateBehavioralBackstop,
+  recordBehavioralStep,
+  resolveBehavioralConfig,
+  type BehavioralConfig,
+} from "./behavioral-backstop.js";
+import {
   buildAgenCToolUseContext,
   toAgenCModelContext,
   type AgenCToolUseContext,
@@ -1621,6 +1627,7 @@ function terminalToStopReason(
     case "completed":
     case "max_turns":
     case "cancelled":
+    case "no_progress": // honest mapping, NOT default→"error" (would mask it as a crash)
       return reason;
     default:
       return "error";
@@ -3161,6 +3168,7 @@ async function* runTurnKernelInner(
     emitTurnAborted,
     referenceContextItem,
     sessionOwner,
+    turnStartedAt,
   } = commons;
 
   // Seed the initial TurnState BEFORE pre-sampling compact so the
@@ -3419,6 +3427,13 @@ async function* runTurnKernelInner(
 
   yield { type: "turn_start", turnIndex: 0 };
 
+  // Behavioral backstop (goal #3): resolve the no-progress config once
+  // per turn so the top-of-loop evaluate site and the post-tool record
+  // site share an identical config object. Pure synchronous resolution.
+  const behavioralCfg: BehavioralConfig = resolveBehavioralConfig({
+    config: ctx.config as unknown as Record<string, unknown>,
+  });
+
   // The phase loop — agenc runtime's "while streaming & tools" outer loop.
   while (true) {
     if (signal.aborted) {
@@ -3485,6 +3500,80 @@ async function* runTurnKernelInner(
         stopReason: "max_turns",
       };
       return returnTerminal(terminal);
+    }
+
+    // Behavioral backstop (goal #3): the SECOND whole-turn backstop —
+    // a result-aware, NON-BLOCKING watchdog for semantic non-termination
+    // (every tool settles fine but the loop spins making no progress).
+    // This evaluate is a synchronous read of already-collected state; it
+    // shares the identical clean-finalize path as the `max_turns` arm two
+    // arms above. The Tier-2 observer inbox is polled here (never
+    // awaited). A `warn` injects a one-shot nudge and continues; a
+    // `terminate` finalizes the turn with the honest `no_progress`
+    // terminal — never a fabricated success.
+    {
+      const observerTrip = state.behavioralObserverTrip;
+      const decision =
+        behavioralCfg.enabled && observerTrip !== undefined
+          ? ({ kind: "terminate", trip: observerTrip } as const)
+          : evaluateBehavioralBackstop(
+              state,
+              usage,
+              turnStartedAt,
+              behavioralCfg,
+            );
+
+      if (decision.kind === "warn") {
+        session.emit({
+          id: session.nextInternalSubId(),
+          msg: {
+            type: "warning",
+            payload: {
+              cause: "no_progress_warning",
+              message: decision.detail,
+            },
+          },
+        });
+        if (
+          decision.injectNudge &&
+          !state.behavioralNudgeIssued &&
+          decision.nudgeText !== undefined
+        ) {
+          state.messages.push({
+            role: "user",
+            content: `<system-reminder>${decision.nudgeText}</system-reminder>`,
+          });
+          state.behavioralNudgeIssued = true;
+        }
+        // fall through — loop continues (Wink course-correction)
+      } else if (decision.kind === "terminate") {
+        const explanation = decision.trip.userMessage; // honest, specific cause
+        state.messages.push({ role: "assistant", content: explanation });
+        lastContent = explanation;
+
+        session.emit({
+          id: session.nextInternalSubId(),
+          msg: {
+            type: "warning",
+            payload: {
+              cause: "no_progress_detected",
+              message: decision.trip.detail,
+            },
+          },
+        });
+
+        await drainInFlight(state, ctx, session); // pair orphan tool_use → tool_result
+        await syncSessionState(); // persist history + rollout
+        emitTurnComplete(lastContent); // canonical lifecycle close
+        const terminal: Terminal = { reason: "no_progress" };
+        yield {
+          type: "turn_complete",
+          content: lastContent,
+          usage,
+          stopReason: "no_progress",
+        };
+        return returnTerminal(terminal);
+      }
     }
 
     // I-13: pending provider switch — complete this turn cleanly so
@@ -3824,6 +3913,18 @@ async function* runTurnKernelInner(
     if (lastAssistant) {
       const completedByCallId = new Map(
         state.completedToolResults.map((record) => [record.callId, record]),
+      );
+      // Behavioral backstop (goal #3): record this real model-action step
+      // where the action and its result are co-resident. This site is
+      // PAST every recovery/compaction `continue` arm above, so recovery
+      // re-entries and compaction iterations are never recorded — a
+      // structural false-positive guard for free. Synchronous mutation
+      // of TurnState fields; no await, no I/O.
+      recordBehavioralStep(
+        state,
+        lastAssistant,
+        completedByCallId,
+        behavioralCfg,
       );
       // Index user records by their tool-call id rather than by position:
       // results return in completion order (not toolCalls order), attachment

--- a/runtime/src/session/turn-state.ts
+++ b/runtime/src/session/turn-state.ts
@@ -26,6 +26,10 @@ import {
   provisionContentReplacementState,
   type ContentReplacementState,
 } from "./_deps/tool-result-storage.js";
+import type {
+  ProgressTrip,
+  StepRecord,
+} from "./behavioral-backstop.js";
 
 /**
  * Continue — the 8 recovery re-entry reasons captured at each
@@ -88,7 +92,8 @@ export type TerminalReason =
   | "stop_hook_prevented"
   | "hook_stopped"
   | "max_turns"
-  | "cancelled";
+  | "cancelled"
+  | "no_progress"; // behavioral backstop (semantic non-termination, goal #3)
 
 export interface Terminal {
   readonly reason: TerminalReason;
@@ -398,6 +403,21 @@ export interface TurnState {
   /** Plan-mode guard retries after a provider ignores the tool-only
    *  contract and returns plain assistant text. */
   planToolRequiredRetryCount: number;
+
+  // ── Behavioral backstop (semantic non-termination, goal #3) ───────
+  // Turn-scoped, NOT iteration-scoped: like `turnCount`, these persist
+  // across recovery/continuation iterations and are NOT cleared in
+  // `resetIterationFields`. Initialized once in `buildInitialTurnState`.
+  /** Bounded ring of recent step fingerprints (sig + resultHash). */
+  behavioralStepHistory: StepRecord[];
+  /** Consecutive low-information-gain steps. */
+  behavioralLowGainStreak: number;
+  /** One-shot soft-nudge latch (Wink >=3 course-correction reminder). */
+  behavioralNudgeIssued: boolean;
+  /** Novelty tracking — tool names seen this turn. */
+  behavioralSeenToolNames: Set<string>;
+  /** Tier-2 observer inbox (optional, polled never awaited). */
+  behavioralObserverTrip?: ProgressTrip;
 }
 
 // I-30 (per-turn config snapshot) lives on `TurnContext.configSnapshot`
@@ -470,6 +490,12 @@ export function buildInitialTurnState(
     stopHookActive: undefined,
     stopHookBlockingCount: 0,
     planToolRequiredRetryCount: 0,
+    // Behavioral backstop (goal #3) — turn-scoped accumulators.
+    behavioralStepHistory: [],
+    behavioralLowGainStreak: 0,
+    behavioralNudgeIssued: false,
+    behavioralSeenToolNames: new Set(),
+    behavioralObserverTrip: undefined,
   };
 }
 
@@ -496,4 +522,9 @@ export function resetIterationFields(state: TurnState): void {
   // pendingToolUseSummary + streamingToolExecutor intentionally NOT
   // cleared here — they are awaited in executeTools and cleared by
   // commit phase after their resolution.
+  //
+  // behavioral* fields are also intentionally NOT cleared — they are
+  // turn-scoped (like `turnCount`), not iteration-scoped. Clearing them
+  // here would reset the no-progress detector every iteration and defeat
+  // the whole backstop. (Asserted by the run-turn progress test suite.)
 }

--- a/runtime/src/utils/hooks/execAgentHook.ts
+++ b/runtime/src/utils/hooks/execAgentHook.ts
@@ -234,6 +234,11 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
           if (event.stopReason === 'max_turns') {
             throw new Error(`Agent hook exceeded maxTurns (${MAX_AGENT_TURNS})`)
           }
+          if (event.stopReason === 'no_progress') {
+            throw new Error(
+              'Agent hook stopped by the no-progress backstop (semantic non-termination)',
+            )
+          }
         }
       }
 

--- a/runtime/tests/session/behavioral-backstop.test.ts
+++ b/runtime/tests/session/behavioral-backstop.test.ts
@@ -1,0 +1,688 @@
+/**
+ * Behavioral backstop (goal #3) — pure-unit detector tests.
+ *
+ * Exercises the result-aware Tier-1 detectors and Tier-0 caps at the
+ * function level, in isolation from the turn loop. The loop-integration
+ * battery (A1/A5/B1 with a scripted fake LLM client, revert proofs, and
+ * the non-blocking invariant) lives in `run-turn.progress.test.ts`.
+ *
+ * The single load-bearing invariant proven here: every repetition/cycle/
+ * low-gain trip requires an UNCHANGED resultHash; a changed result or an
+ * isError flip resets the counter. That is the entire false-positive
+ * defense (status polling, progressing retries).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  evaluateBehavioralBackstop,
+  recordBehavioralStep,
+  resolveBehavioralConfig,
+  stepActionSignature,
+  stepResultHash,
+  type BehavioralConfig,
+} from "./behavioral-backstop.js";
+import type {
+  AssistantMessage,
+  CompletedToolResultRecord,
+  TurnState,
+} from "./turn-state.js";
+import type { LLMUsage } from "../llm/types.js";
+
+// ── Minimal fixtures ────────────────────────────────────────────────
+
+/** A TurnState reduced to only the fields the detectors read/write. */
+function mkState(): TurnState {
+  return {
+    turnCount: 1,
+    toolUseBlocks: [],
+    behavioralStepHistory: [],
+    behavioralLowGainStreak: 0,
+    behavioralNudgeIssued: false,
+    behavioralSeenToolNames: new Set<string>(),
+    behavioralObserverTrip: undefined,
+    messages: [],
+  } as unknown as TurnState;
+}
+
+function mkAssistant(
+  calls: ReadonlyArray<{ id: string; name: string; arguments: string }>,
+  text = "",
+): AssistantMessage {
+  return {
+    uuid: `a-${Math.random()}`,
+    role: "assistant",
+    text,
+    toolCalls: calls,
+  };
+}
+
+function mkCompleted(
+  id: string,
+  name: string,
+  content: string,
+  isError = false,
+): CompletedToolResultRecord {
+  return { callId: id, toolName: name, arguments: "{}", content, isError };
+}
+
+function completedMap(
+  records: readonly CompletedToolResultRecord[],
+): Map<string, CompletedToolResultRecord> {
+  return new Map(records.map((r) => [r.callId, r]));
+}
+
+const usage: LLMUsage = {
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+};
+
+/** Default config with only env overrides applied (no ctx.config). */
+function cfg(overrides: Partial<BehavioralConfig> = {}): BehavioralConfig {
+  return { ...resolveBehavioralConfig({}), ...overrides };
+}
+
+const ENV_KEYS = [
+  "AGENC_BEHAVIORAL_BACKSTOP",
+  "AGENC_NOPROGRESS_WARN",
+  "AGENC_NOPROGRESS_TERMINATE",
+  "AGENC_ABAB_TERMINATE",
+  "AGENC_LOWGAIN_TERMINATE",
+  "AGENC_PROGRESS_WINDOW",
+  "AGENC_TURN_DEADLINE_MS",
+  "AGENC_TURN_TOKEN_CAP",
+  "AGENC_TURN_STEP_CAP",
+  "AGENC_NOPROGRESS_IGNORE_TOOLS",
+  "AGENC_PROGRESS_RESULT_PREFIX",
+  "AGENC_PROGRESS_NORMALIZE_VOLATILE",
+  "AGENC_BEHAVIORAL_OBSERVER",
+  "AGENC_BEHAVIORAL_OBSERVER_K",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+// ── Default config discipline ───────────────────────────────────────
+
+describe("resolveBehavioralConfig — defaults", () => {
+  test("master switch ON, result-aware detectors ON, risky caps OFF", () => {
+    const c = resolveBehavioralConfig({});
+    expect(c.enabled).toBe(true);
+    expect(c.repeatSoft).toBe(3);
+    expect(c.repeatHard).toBe(8);
+    expect(c.ababCycles).toBe(3);
+    expect(c.lowGainStreak).toBe(6);
+    expect(c.window).toBe(16);
+    // The risky absolute caps ALL default 0 (OFF).
+    expect(c.maxTurnMs).toBe(0);
+    expect(c.maxTurnTokens).toBe(0);
+    expect(c.maxTurnSteps).toBe(0);
+    // normalizeVolatile OFF, observer OFF.
+    expect(c.normalizeVolatile).toBe(false);
+    expect(c.observerEnabled).toBe(false);
+    expect(c.observerEveryK).toBe(5);
+    expect(c.ignoreTools.has("Sleep")).toBe(true);
+    expect(c.resultHashPrefixBytes).toBe(64 * 1024);
+  });
+
+  test("precedence: ctx.config > env > default", () => {
+    process.env.AGENC_NOPROGRESS_TERMINATE = "20";
+    // env wins over default
+    expect(resolveBehavioralConfig({}).repeatHard).toBe(20);
+    // ctx.config wins over env
+    expect(
+      resolveBehavioralConfig({ config: { progressRepeatHard: 5 } }).repeatHard,
+    ).toBe(5);
+  });
+
+  test("master switch OFF via env", () => {
+    process.env.AGENC_BEHAVIORAL_BACKSTOP = "0";
+    expect(resolveBehavioralConfig({}).enabled).toBe(false);
+    process.env.AGENC_BEHAVIORAL_BACKSTOP = "off";
+    expect(resolveBehavioralConfig({}).enabled).toBe(false);
+    process.env.AGENC_BEHAVIORAL_BACKSTOP = "1";
+    expect(resolveBehavioralConfig({}).enabled).toBe(true);
+  });
+});
+
+// ── Signature + result hash ─────────────────────────────────────────
+
+describe("stepActionSignature — canonical, order-stable args", () => {
+  test("argument key order does NOT change the signature (canonicalJsonKey)", () => {
+    const a = mkAssistant([
+      { id: "1", name: "Read", arguments: '{"a":1,"b":2}' },
+    ]);
+    const b = mkAssistant([
+      { id: "2", name: "Read", arguments: '{"b":2,"a":1}' },
+    ]);
+    expect(stepActionSignature(a, [])).toBe(stepActionSignature(b, []));
+  });
+
+  test("different args DO change the signature (progress)", () => {
+    const a = mkAssistant([{ id: "1", name: "Read", arguments: '{"f":"/x"}' }]);
+    const b = mkAssistant([{ id: "2", name: "Read", arguments: '{"f":"/y"}' }]);
+    expect(stepActionSignature(a, [])).not.toBe(stepActionSignature(b, []));
+  });
+
+  test("text-only step yields a text signature", () => {
+    const a = mkAssistant([], "hello   world");
+    expect(stepActionSignature(a, [])).toBe("text hello world");
+  });
+});
+
+describe("stepResultHash — content + isError", () => {
+  test("changing content changes the hash", () => {
+    const a = mkAssistant([{ id: "1", name: "S", arguments: "{}" }]);
+    const h1 = stepResultHash(a, completedMap([mkCompleted("1", "S", "x")]), cfg());
+    const h2 = stepResultHash(a, completedMap([mkCompleted("1", "S", "y")]), cfg());
+    expect(h1).not.toBe(h2);
+  });
+
+  test("isError flip changes the hash", () => {
+    const a = mkAssistant([{ id: "1", name: "S", arguments: "{}" }]);
+    const ok = stepResultHash(a, completedMap([mkCompleted("1", "S", "x", false)]), cfg());
+    const err = stepResultHash(a, completedMap([mkCompleted("1", "S", "x", true)]), cfg());
+    expect(ok).not.toBe(err);
+  });
+
+  test("bounded prefix: identical first N bytes collide (fail-safe under-detection)", () => {
+    const a = mkAssistant([{ id: "1", name: "S", arguments: "{}" }]);
+    const c = cfg({ resultHashPrefixBytes: 4 });
+    const h1 = stepResultHash(a, completedMap([mkCompleted("1", "S", "AAAA-tail1")]), c);
+    const h2 = stepResultHash(a, completedMap([mkCompleted("1", "S", "AAAA-tail2")]), c);
+    expect(h1).toBe(h2);
+  });
+});
+
+// ── A1 (function level): repetition runaway must trip ───────────────
+
+function feedSteps(
+  state: TurnState,
+  c: BehavioralConfig,
+  steps: ReadonlyArray<{
+    readonly assistant: AssistantMessage;
+    readonly results: readonly CompletedToolResultRecord[];
+  }>,
+): ReturnType<typeof evaluateBehavioralBackstop> {
+  let decision = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+  for (const step of steps) {
+    state.toolUseBlocks = step.assistant.toolCalls.map((call) => ({
+      type: "tool_use" as const,
+      id: call.id,
+      name: call.name,
+      input: JSON.parse(call.arguments),
+    }));
+    recordBehavioralStep(state, step.assistant, completedMap(step.results), c);
+    state.turnCount += 1;
+    decision = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+    if (decision.kind === "terminate") break;
+  }
+  return decision;
+}
+
+/** Identical call + identical result, with DISTINCT call ids per step. */
+function identicalStep(i: number): {
+  assistant: AssistantMessage;
+  results: CompletedToolResultRecord[];
+} {
+  const id = `call-${i}`;
+  return {
+    assistant: mkAssistant([{ id, name: "Read", arguments: '{"file_path":"/x"}' }]),
+    results: [mkCompleted(id, "Read", "stable content")],
+  };
+}
+
+describe("A1 — repetition runaway trips at repeatHard with a stable result", () => {
+  test("terminates with trip.kind=repetition once the run hits repeatHard", () => {
+    // Isolate the repetition ladder by pushing the low-gain detector out
+    // of the way (with identical sig+result steps the low-gain streak
+    // would otherwise fire first at its default threshold 6 < 8 — that is
+    // intended Tier-1 ordering; both are `no_progress`, see the run-turn
+    // integration test which asserts the terminal, not the sub-kind).
+    const c = cfg({ repeatHard: 8, repeatSoft: 3, window: 16, lowGainStreak: 99 });
+    const state = mkState();
+    const steps = Array.from({ length: 12 }, (_, i) => identicalStep(i));
+    const decision = feedSteps(state, c, steps);
+    expect(decision.kind).toBe("terminate");
+    if (decision.kind === "terminate") {
+      expect(decision.trip.kind).toBe("repetition");
+      // honest user message, never a success string
+      expect(decision.trip.userMessage).toMatch(/no-progress backstop/i);
+      expect(decision.trip.userMessage).not.toMatch(/success|completed the task/i);
+    }
+  });
+
+  test("default thresholds: identical repetition still terminates (low_gain fires first)", () => {
+    // With stock defaults (lowGainStreak 6 < repeatHard 8) the identical
+    // runaway still produces a `no_progress` terminate — just via the
+    // low-gain detector. Proves a default-config A1 always bounds.
+    const c = cfg();
+    const state = mkState();
+    const steps = Array.from({ length: 12 }, (_, i) => identicalStep(i));
+    const decision = feedSteps(state, c, steps);
+    expect(decision.kind).toBe("terminate");
+  });
+
+  test("warns (no terminate) at repeatSoft and injects the nudge once", () => {
+    const c = cfg({ repeatHard: 8, repeatSoft: 3 });
+    const state = mkState();
+    // feed exactly 3 identical steps → run length 3 → warn, not terminate
+    feedSteps(state, c, [identicalStep(0), identicalStep(1)]);
+    state.toolUseBlocks = [
+      { type: "tool_use", id: "call-2", name: "Read", input: { file_path: "/x" } },
+    ];
+    recordBehavioralStep(
+      state,
+      identicalStep(2).assistant,
+      completedMap(identicalStep(2).results),
+      c,
+    );
+    const decision = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+    expect(decision.kind).toBe("warn");
+    if (decision.kind === "warn") {
+      expect(decision.injectNudge).toBe(true);
+      expect(decision.nudgeText).toMatch(/repeated the same action/i);
+    }
+  });
+});
+
+// ── A2 — ABAB runaway ───────────────────────────────────────────────
+
+describe("A2 — ABAB stable cycle trips", () => {
+  test("alternating A/B with stable results trips trip.kind=abab", () => {
+    const c = cfg({ ababCycles: 3, repeatHard: 99, lowGainStreak: 99 });
+    const state = mkState();
+    const steps = Array.from({ length: 12 }, (_, i) => {
+      const id = `c-${i}`;
+      const name = i % 2 === 0 ? "ToolA" : "ToolB";
+      return {
+        assistant: mkAssistant([{ id, name, arguments: "{}" }]),
+        results: [mkCompleted(id, name, `${name}-stable`)],
+      };
+    });
+    const decision = feedSteps(state, c, steps);
+    expect(decision.kind).toBe("terminate");
+    if (decision.kind === "terminate") expect(decision.trip.kind).toBe("abab");
+  });
+
+  test("a single A,B does NOT trip", () => {
+    const c = cfg({ ababCycles: 3, repeatHard: 99, lowGainStreak: 99 });
+    const state = mkState();
+    const decision = feedSteps(state, c, [
+      {
+        assistant: mkAssistant([{ id: "a", name: "ToolA", arguments: "{}" }]),
+        results: [mkCompleted("a", "ToolA", "x")],
+      },
+      {
+        assistant: mkAssistant([{ id: "b", name: "ToolB", arguments: "{}" }]),
+        results: [mkCompleted("b", "ToolB", "y")],
+      },
+    ]);
+    expect(decision.kind).not.toBe("terminate");
+  });
+});
+
+// ── A3 — low-gain runaway ───────────────────────────────────────────
+
+describe("A3 — low-gain streak (gated by a repeated signature) trips", () => {
+  test("repeated low-gain steps trip trip.kind=low_gain", () => {
+    // Tighten lowGainStreak so it fires before repetition; keep repeatHard high.
+    const c = cfg({ lowGainStreak: 4, repeatHard: 99, ababCycles: 99, window: 16 });
+    const state = mkState();
+    const steps = Array.from({ length: 10 }, (_, i) => identicalStep(i));
+    const decision = feedSteps(state, c, steps);
+    expect(decision.kind).toBe("terminate");
+    if (decision.kind === "terminate") {
+      expect(decision.trip.kind).toBe("low_gain");
+    }
+  });
+});
+
+// ── A4 — token cap (deadline) with DISTINCT calls ───────────────────
+
+describe("A4 — Tier-0 token cap catches a novel-but-pointless runaway", () => {
+  test("distinct calls never trip Tier-1, but the token cap trips trip.kind=deadline", () => {
+    const c = cfg({ maxTurnTokens: 200_000, repeatHard: 99 });
+    const state = mkState();
+    let total = 0;
+    let decision = evaluateBehavioralBackstop(
+      state,
+      { promptTokens: 0, completionTokens: 0, totalTokens: total },
+      Date.now(),
+      c,
+    );
+    for (let i = 0; i < 10; i++) {
+      const id = `dist-${i}`;
+      const a = mkAssistant([
+        { id, name: "Distinct", arguments: JSON.stringify({ step: i }) },
+      ]);
+      state.toolUseBlocks = [
+        { type: "tool_use", id, name: "Distinct", input: { step: i } },
+      ];
+      recordBehavioralStep(state, a, completedMap([mkCompleted(id, "Distinct", `r${i}`)]), c);
+      state.turnCount += 1;
+      total += 65_000; // ~65k tokens/step
+      decision = evaluateBehavioralBackstop(
+        state,
+        { promptTokens: 0, completionTokens: 0, totalTokens: total },
+        Date.now(),
+        c,
+      );
+      if (decision.kind === "terminate") break;
+    }
+    expect(decision.kind).toBe("terminate");
+    if (decision.kind === "terminate") {
+      expect(decision.trip.kind).toBe("deadline");
+      // the detail names the TOKEN cap, not a repetition
+      expect(decision.trip.detail).toMatch(/token cap/i);
+      expect(decision.trip.detail).not.toMatch(/repeat/i);
+    }
+  });
+});
+
+// ── B1 — status polling that PROGRESSES must NOT trip ───────────────
+
+/** Same tool 12x, but with a CHANGING result each step. */
+function pollingSteps(): ReadonlyArray<{
+  assistant: AssistantMessage;
+  results: CompletedToolResultRecord[];
+}> {
+  return Array.from({ length: 12 }, (_, i) => {
+    const id = `poll-${i}`;
+    return {
+      assistant: mkAssistant([{ id, name: "GetStatus", arguments: "{}" }]),
+      results: [mkCompleted(id, "GetStatus", i < 11 ? `pending ${i}/11` : "done")],
+    };
+  });
+}
+
+describe("B1 — status polling that progresses NEVER trips (the killer test)", () => {
+  test("same tool, changing result → no terminate, run counter never exceeds 1", () => {
+    const c = cfg({ repeatHard: 8, repeatSoft: 3, ababCycles: 3, lowGainStreak: 6 });
+    const state = mkState();
+    let sawTerminate = false;
+    let sawWarn = false;
+    for (const step of pollingSteps()) {
+      state.toolUseBlocks = step.assistant.toolCalls.map((call) => ({
+        type: "tool_use" as const,
+        id: call.id,
+        name: call.name,
+        input: {},
+      }));
+      recordBehavioralStep(state, step.assistant, completedMap(step.results), c);
+      state.turnCount += 1;
+      const d = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+      if (d.kind === "terminate") sawTerminate = true;
+      if (d.kind === "warn") sawWarn = true;
+    }
+    expect(sawTerminate).toBe(false);
+    expect(sawWarn).toBe(false);
+  });
+
+  test(
+    "GUARD-OF-THE-GUARD: force resultHash constant → B1 reddens (trips)",
+    () => {
+      // Simulate breaking the result-aware gate by hashing a CONSTANT
+      // result content for every step (what would happen if resultHash
+      // were dropped / pinned in the fingerprint). The same polling
+      // sequence must now trip — proving the result-aware gate is the
+      // load-bearing defense, not decorative.
+      const c = cfg({ repeatHard: 8, repeatSoft: 3, ababCycles: 99, lowGainStreak: 99 });
+      const state = mkState();
+      let sawTerminate = false;
+      for (let i = 0; i < 12; i++) {
+        const id = `poll-${i}`;
+        const a = mkAssistant([{ id, name: "GetStatus", arguments: "{}" }]);
+        state.toolUseBlocks = [
+          { type: "tool_use", id, name: "GetStatus", input: {} },
+        ];
+        // CONSTANT content — the gate is broken on purpose.
+        recordBehavioralStep(
+          state,
+          a,
+          completedMap([mkCompleted(id, "GetStatus", "CONSTANT")]),
+          c,
+        );
+        state.turnCount += 1;
+        const d = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+        if (d.kind === "terminate") {
+          sawTerminate = true;
+          break;
+        }
+      }
+      expect(sawTerminate).toBe(true);
+    },
+  );
+});
+
+// ── B2 — progressing retry (isError flip) resets the counter ────────
+
+describe("B2 — progressing retry (isError flip) resets the counter", () => {
+  test("isError flip resets the trailing run, then genuine progress never trips", () => {
+    const c = cfg({ repeatHard: 4, repeatSoft: 99, ababCycles: 99, lowGainStreak: 99 });
+    const state = mkState();
+    // 3 identical failing retries → run length 3 (one short of repeatHard 4).
+    for (let i = 0; i < 3; i++) {
+      const id = `w-${i}`;
+      const a = mkAssistant([{ id, name: "Write", arguments: '{"path":"/a"}' }]);
+      state.toolUseBlocks = [
+        { type: "tool_use", id, name: "Write", input: { path: "/a" } },
+      ];
+      recordBehavioralStep(state, a, completedMap([mkCompleted(id, "Write", "out", true)]), c);
+      state.turnCount += 1;
+    }
+    // Run is 3 (identical failing sig+result).
+    let d = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+    expect(d.kind).not.toBe("terminate");
+    // The flip to success changes resultHash → trailing run RESETS to 1.
+    const flipId = "w-flip";
+    const flip = mkAssistant([{ id: flipId, name: "Write", arguments: '{"path":"/a"}' }]);
+    state.toolUseBlocks = [
+      { type: "tool_use", id: flipId, name: "Write", input: { path: "/a" } },
+    ];
+    recordBehavioralStep(state, flip, completedMap([mkCompleted(flipId, "Write", "ok", false)]), c);
+    state.turnCount += 1;
+    d = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+    expect(d.kind).not.toBe("terminate");
+    // After the flip, the agent makes genuine progress (distinct results),
+    // so even continuing for many steps never trips.
+    for (let i = 0; i < 8; i++) {
+      const id = `prog-${i}`;
+      const a = mkAssistant([{ id, name: "Write", arguments: JSON.stringify({ path: `/f${i}` }) }]);
+      state.toolUseBlocks = [
+        { type: "tool_use", id, name: "Write", input: { path: `/f${i}` } },
+      ];
+      recordBehavioralStep(state, a, completedMap([mkCompleted(id, "Write", `wrote-${i}`, false)]), c);
+      state.turnCount += 1;
+      d = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+      expect(d.kind).not.toBe("terminate");
+    }
+  });
+});
+
+// ── B3 — distinct-but-cheap long turn never accumulates low-gain ────
+
+describe("B3 — distinct-but-cheap long turn never trips low-gain", () => {
+  test("all distinct signatures past lowGainStreak → no trip", () => {
+    const c = cfg({ lowGainStreak: 3, repeatHard: 99, ababCycles: 99, window: 16 });
+    const state = mkState();
+    const steps = Array.from({ length: 12 }, (_, i) => {
+      const id = `d-${i}`;
+      return {
+        assistant: mkAssistant([
+          { id, name: "Step", arguments: JSON.stringify({ i }) },
+        ]),
+        results: [mkCompleted(id, "Step", `r${i}`)],
+      };
+    });
+    const decision = feedSteps(state, c, steps);
+    expect(decision.kind).not.toBe("terminate");
+    expect(state.behavioralLowGainStreak).toBe(0);
+  });
+});
+
+// ── B4 — designated ignore-tool excluded ────────────────────────────
+
+describe("B4 — ignore-tool exclusion is tool-scoped", () => {
+  test("identical Sleep{} (ignored) never trips, identical non-ignored 12x trips", () => {
+    const c = cfg({ repeatHard: 8, ignoreTools: new Set(["Sleep"]) });
+    const sleepState = mkState();
+    const sleepSteps = Array.from({ length: 12 }, (_, i) => {
+      const id = `s-${i}`;
+      return {
+        assistant: mkAssistant([{ id, name: "Sleep", arguments: "{}" }]),
+        results: [mkCompleted(id, "Sleep", "zzz")],
+      };
+    });
+    const sleepDecision = feedSteps(sleepState, c, sleepSteps);
+    expect(sleepDecision.kind).not.toBe("terminate");
+    // history never grew (all-ignored steps are skipped)
+    expect(sleepState.behavioralStepHistory.length).toBe(0);
+
+    // A non-ignored identical tool DOES trip.
+    const otherState = mkState();
+    const otherSteps = Array.from({ length: 12 }, (_, i) => identicalStep(i));
+    const otherDecision = feedSteps(otherState, c, otherSteps);
+    expect(otherDecision.kind).toBe("terminate");
+  });
+});
+
+// ── B5 — two-state legitimate poll (ABAB with changing results) ─────
+
+describe("B5 — two-state legit poll does not trip ABAB", () => {
+  test("A/B alternation with changing results → no trip", () => {
+    const c = cfg({ ababCycles: 3, repeatHard: 99, lowGainStreak: 99 });
+    const state = mkState();
+    const steps = Array.from({ length: 12 }, (_, i) => {
+      const id = `t-${i}`;
+      const name = i % 2 === 0 ? "ToolA" : "ToolB";
+      // changing result each occurrence
+      return {
+        assistant: mkAssistant([{ id, name, arguments: "{}" }]),
+        results: [mkCompleted(id, name, `${name}-${i}`)],
+      };
+    });
+    const decision = feedSteps(state, c, steps);
+    expect(decision.kind).not.toBe("terminate");
+  });
+});
+
+// ── B7 — disabled master switch is byte-identical inert ─────────────
+
+describe("B7 — disabled master switch records nothing and never trips", () => {
+  test("enabled:false → record is a no-op and evaluate returns none", () => {
+    const c = cfg({ enabled: false });
+    const state = mkState();
+    const decision = feedSteps(
+      state,
+      c,
+      Array.from({ length: 20 }, (_, i) => identicalStep(i)),
+    );
+    expect(decision.kind).toBe("none");
+    expect(state.behavioralStepHistory.length).toBe(0);
+  });
+});
+
+// ── Tier-0 step + wall-clock caps ───────────────────────────────────
+
+describe("Tier-0 caps — step + wall-clock", () => {
+  test("step cap trips deadline when turnCount exceeds it", () => {
+    const c = cfg({ maxTurnSteps: 5 });
+    const state = mkState();
+    state.turnCount = 6;
+    const decision = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+    expect(decision.kind).toBe("terminate");
+    if (decision.kind === "terminate") {
+      expect(decision.trip.kind).toBe("deadline");
+      expect(decision.trip.detail).toMatch(/step cap/i);
+    }
+  });
+
+  test("wall-clock cap trips deadline when elapsed exceeds it", () => {
+    const c = cfg({ maxTurnMs: 1000 });
+    const state = mkState();
+    const decision = evaluateBehavioralBackstop(
+      state,
+      usage,
+      Date.now() - 5000, // started 5s ago
+      c,
+    );
+    expect(decision.kind).toBe("terminate");
+    if (decision.kind === "terminate") {
+      expect(decision.trip.detail).toMatch(/wall-clock/i);
+    }
+  });
+
+  test("caps OFF (0) never trip even with a huge turnCount/usage", () => {
+    const c = cfg(); // all caps default 0
+    const state = mkState();
+    state.turnCount = 100_000;
+    const decision = evaluateBehavioralBackstop(
+      state,
+      { promptTokens: 0, completionTokens: 0, totalTokens: 999_999_999 },
+      Date.now() - 999_999,
+      c,
+    );
+    expect(decision.kind).toBe("none");
+  });
+});
+
+// ── normalizeVolatile (off by default, opt-in) ──────────────────────
+
+describe("normalizeVolatile — opt-in volatile stripping", () => {
+  test("OFF by default: re-stamped timestamps yield DIFFERENT hashes", () => {
+    const c = cfg({ normalizeVolatile: false });
+    const a = mkAssistant([{ id: "1", name: "S", arguments: "{}" }]);
+    const h1 = stepResultHash(a, completedMap([mkCompleted("1", "S", "t=2026-01-01T00:00:00Z")]), c);
+    const h2 = stepResultHash(a, completedMap([mkCompleted("1", "S", "t=2026-01-01T00:00:01Z")]), c);
+    expect(h1).not.toBe(h2);
+  });
+
+  test("ON: re-stamped timestamps collapse to the SAME hash", () => {
+    const c = cfg({ normalizeVolatile: true });
+    const a = mkAssistant([{ id: "1", name: "S", arguments: "{}" }]);
+    const h1 = stepResultHash(a, completedMap([mkCompleted("1", "S", "t=2026-01-01T00:00:00Z")]), c);
+    const h2 = stepResultHash(a, completedMap([mkCompleted("1", "S", "t=2026-01-01T00:00:01Z")]), c);
+    expect(h1).toBe(h2);
+  });
+});
+
+// ── C1 (function level) — the policing path issues no awaits ─────────
+
+describe("C1 — record + evaluate are synchronous (return non-thenables)", () => {
+  test("recordBehavioralStep returns undefined (not a Promise)", () => {
+    const c = cfg();
+    const state = mkState();
+    const a = identicalStep(0).assistant;
+    state.toolUseBlocks = [
+      { type: "tool_use", id: "call-0", name: "Read", input: { file_path: "/x" } },
+    ];
+    const ret = recordBehavioralStep(
+      state,
+      a,
+      completedMap(identicalStep(0).results),
+      c,
+    );
+    expect(ret).toBeUndefined();
+    expect(typeof (ret as unknown as { then?: unknown })?.then).not.toBe(
+      "function",
+    );
+  });
+
+  test("evaluateBehavioralBackstop returns a plain decision object (not a Promise)", () => {
+    const c = cfg();
+    const state = mkState();
+    const d = evaluateBehavioralBackstop(state, usage, Date.now(), c);
+    expect(typeof (d as unknown as { then?: unknown })?.then).not.toBe(
+      "function",
+    );
+    expect(d.kind).toBe("none");
+  });
+});

--- a/runtime/tests/session/exec-agent-hook-run-turn.test.ts
+++ b/runtime/tests/session/exec-agent-hook-run-turn.test.ts
@@ -216,7 +216,12 @@ describe("execAgentHook run-turn integration", () => {
     expect(result.message?.attachment.stderr).toContain("provider exploded");
   });
 
-  test("surfaces hook max-turn exhaustion as non-blocking errors", async () => {
+  test("surfaces a runaway hook (identical call+result every turn) as a non-blocking error", async () => {
+    // The hook agent emits the IDENTICAL Echo{value:"ok"} call every turn
+    // and the tool returns the identical result, i.e. a semantic runaway.
+    // The behavioral backstop (goal #3) now bounds this with an honest
+    // `no_progress` terminal at ~repeatHard (8) instead of letting it spin
+    // to maxTurns (50). Either way the hook surfaces a non-blocking error.
     const provider = providerWithResponses([
       {
         content: "checking",
@@ -250,8 +255,8 @@ describe("execAgentHook run-turn integration", () => {
 
     expect(result.outcome).toBe("non_blocking_error");
     expect(result.message?.attachment.type).toBe("hook_non_blocking_error");
-    expect(result.message?.attachment.stderr).toContain(
-      "Agent hook exceeded maxTurns (50)",
+    expect(result.message?.attachment.stderr).toMatch(
+      /no-progress backstop|exceeded maxTurns/,
     );
   });
 

--- a/runtime/tests/session/run-turn.progress.test.ts
+++ b/runtime/tests/session/run-turn.progress.test.ts
@@ -1,0 +1,578 @@
+/**
+ * Behavioral backstop (goal #3) — loop-integration battery.
+ *
+ * Drives the REAL `runTurn` generator with a scripted fake LLM provider
+ * + tool registry and asserts the no-progress terminal flows end-to-end:
+ *
+ *   - A1 repetition runaway → terminal {reason:"no_progress"}, model
+ *     called <=9 times not 1000, last assistant message is the honest
+ *     no-progress text (never a success string), no fabricated tool
+ *     result, and a `no_progress_detected` warning emitted.
+ *   - A1 REVERT proof: master switch OFF → the same repro spins to
+ *     max_turns (literal call counts asserted both ways).
+ *   - A5 soft-nudge-then-recover: nudge fires once at the soft threshold,
+ *     the model changes approach, the turn completes normally (no trip).
+ *   - B1 status-polling-that-progresses (the killer false-positive
+ *     guard): same tool 12x with a CHANGING result → reason:"completed",
+ *     never trips. (The guard-of-the-guard forced-constant-resultHash
+ *     reddening is proven in the pure-unit suite.)
+ *   - C1 non-blocking: the policing path issues zero extra provider/tool
+ *     calls (call counts are unchanged by record+evaluate).
+ *   - D1 wire: terminalToStopReason("no_progress") === "no_progress".
+ *
+ * The B6 recovery/compaction re-entry guard is structural — the record
+ * site sits PAST every recovery/compaction `continue` arm, and the
+ * behavioral* fields are NOT cleared in `resetIterationFields` — and is
+ * exercised at the boundary by the broader run-turn compaction/recovery
+ * test suites which must stay green (a turn that legitimately re-enters
+ * must still complete normally with this feature ON by default).
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// The run-turn module fans out into magic-docs / session-memory hooks and
+// an axios client at import time; stub them exactly like run-turn.test.ts.
+vi.mock("axios", () => {
+  const axiosLike = {
+    create: vi.fn(() => axiosLike),
+    get: vi.fn(),
+    post: vi.fn(),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  };
+  return {
+    default: axiosLike,
+    create: axiosLike.create,
+    isAxiosError: () => false,
+  };
+});
+vi.mock("../memory/session/sessionMemory.js", () => ({
+  runSessionMemoryPostSamplingHook: async () => {},
+}));
+
+import { AsyncQueue } from "../utils/async-queue.js";
+import { runTurn } from "./run-turn.js";
+import {
+  Session,
+  type Event,
+  type SessionOpts,
+  type SessionServices,
+} from "./session.js";
+import type {
+  Config,
+  ManagedFeatures,
+  ModelInfo,
+  SessionConfiguration,
+  TurnContext,
+} from "./turn-context.js";
+import { TurnTimingState } from "./turn-context.js";
+import type {
+  LLMMessage,
+  LLMProvider,
+  LLMResponse,
+  LLMToolCall,
+  StreamProgressCallback,
+} from "../llm/types.js";
+import type { ToolRegistry } from "../tool-registry.js";
+import type { Terminal } from "./turn-state.js";
+import type { ToolDispatchResult } from "../tool-registry.js";
+import type { PhaseEvent } from "../phases/events.js";
+
+// ── env isolation ───────────────────────────────────────────────────
+
+const ENV_KEYS = [
+  "AGENC_BEHAVIORAL_BACKSTOP",
+  "AGENC_NOPROGRESS_WARN",
+  "AGENC_NOPROGRESS_TERMINATE",
+  "AGENC_ABAB_TERMINATE",
+  "AGENC_LOWGAIN_TERMINATE",
+  "AGENC_PROGRESS_WINDOW",
+  "AGENC_MAX_TURNS",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  vi.restoreAllMocks();
+});
+
+// ── harness factories (mirrors run-turn.test.ts) ────────────────────
+
+function mkFeatures(): ManagedFeatures {
+  return {
+    appsEnabledForAuth: () => false,
+    useLegacyLandlock: () => false,
+  };
+}
+
+function mkConfig(): Config {
+  return {
+    model: "test-model",
+    cwd: "/tmp",
+    features: mkFeatures(),
+    multiAgentV2: {
+      usageHintEnabled: false,
+      usageHintText: "",
+      hideSpawnAgentMetadata: false,
+    },
+    permissions: {
+      allowLoginShell: false,
+      shellEnvironmentPolicy: { allowedEnvVars: [], blockedEnvVars: [] },
+      windowsSandboxPrivateDesktop: false,
+    },
+    ghostSnapshot: { enabled: false },
+    agentRoles: [],
+  } as unknown as Config;
+}
+
+function mkModelInfo(): ModelInfo {
+  return {
+    slug: "test-model",
+    effectiveContextWindowPercent: 100,
+    contextWindow: 1024,
+    supportedReasoningLevels: [],
+    defaultReasoningSummary: "auto",
+    truncationPolicy: "off",
+    usedFallbackModelMetadata: false,
+  } as unknown as ModelInfo;
+}
+
+function mkSessionConfiguration(): SessionConfiguration {
+  return {
+    cwd: "/tmp",
+    approvalPolicy: { value: "never" },
+    sandboxPolicy: { value: "read_only" },
+    fileSystemSandboxPolicy: {
+      allowWrite: [],
+      denyWrite: [],
+      allowRead: [],
+      denyRead: [],
+    },
+    networkSandboxPolicy: {
+      allowlist: [],
+      denylist: [],
+      allowManagedDomainsOnly: false,
+    },
+    windowsSandboxLevel: "none",
+    collaborationMode: { model: "test-model" },
+    dynamicTools: [],
+    sessionSource: "cli_main",
+    provider: { slug: "stub-provider" },
+  } as unknown as SessionConfiguration;
+}
+
+function mkCtx(maxTurns: number): TurnContext {
+  return {
+    subId: "turn-progress",
+    cwd: "/tmp",
+    config: { maxTurns } as unknown,
+    configSnapshot: {} as unknown,
+    modelInfo: mkModelInfo(),
+    collaborationMode: { model: "test-model" },
+    approvalPolicy: { value: "never" },
+    sandboxPolicy: { value: "read_only" },
+    fileSystemSandboxPolicy: {
+      allowWrite: [],
+      denyWrite: [],
+      allowRead: [],
+      denyRead: [],
+    },
+    networkSandboxPolicy: {
+      allowlist: [],
+      denylist: [],
+      allowManagedDomainsOnly: false,
+    },
+    reasoningSummary: "auto",
+    sessionSource: "cli_main",
+    currentDate: "2026-04-20",
+    timezone: "Etc/UTC",
+    dynamicTools: [],
+    depth: 0,
+    toolCallGate: {
+      isReady: () => true,
+      signal: () => {},
+      wait: async () => {},
+    },
+    turnTimingState: new TurnTimingState(),
+  } as unknown as TurnContext;
+}
+
+/**
+ * A scripted streaming provider. `step(i)` returns the LLMResponse for the
+ * i-th model call (0-based). Tracks the call count.
+ */
+function mkScriptedProvider(
+  step: (i: number) => Partial<LLMResponse>,
+): { provider: LLMProvider; calls: () => number } {
+  let calls = 0;
+  const make = (i: number): LLMResponse => ({
+    content: "",
+    toolCalls: [],
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    model: "test-model",
+    finishReason: "stop",
+    ...step(i),
+  });
+  const provider: LLMProvider = {
+    name: "stub-provider",
+    chat: async () => {
+      const r = make(calls);
+      calls += 1;
+      return r;
+    },
+    chatStream: async (
+      _msgs: LLMMessage[],
+      _onChunk: StreamProgressCallback,
+      _options,
+    ): Promise<LLMResponse> => {
+      const r = make(calls);
+      calls += 1;
+      return r;
+    },
+    healthCheck: async () => true,
+  } as unknown as LLMProvider;
+  return { provider, calls: () => calls };
+}
+
+/**
+ * A registry whose per-tool result is computed dynamically. The actual
+ * dispatch in the streaming executor flows through the router built from
+ * `registry.tools`, which invokes each tool's `execute` — so the dynamic
+ * content lives there, NOT on the registry-level `dispatch`. `resultFor`
+ * receives the tool name and the parsed args.
+ */
+function mkScriptedRegistry(
+  toolNames: readonly string[],
+  resultFor: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => { content: string; isError: boolean },
+): { registry: ToolRegistry; dispatchCalls: () => number } {
+  let dispatchCalls = 0;
+  const tools = toolNames.map((name) => ({
+    name,
+    description: `${name} test tool`,
+    inputSchema: { type: "object", additionalProperties: true },
+    requiresApproval: false,
+    execute: async (args: Record<string, unknown>) => {
+      dispatchCalls += 1;
+      return resultFor(name, args);
+    },
+  }));
+  const registry = {
+    tools,
+    toLLMTools: () => [],
+    dispatch: async (call: LLMToolCall): Promise<ToolDispatchResult> => {
+      // Not used by the streaming-executor router path, but kept for any
+      // direct-dispatch fallback. Mirrors the per-tool execute result.
+      const args = ((): Record<string, unknown> => {
+        try {
+          return JSON.parse(call.arguments) as Record<string, unknown>;
+        } catch {
+          return {};
+        }
+      })();
+      return resultFor(call.name, args);
+    },
+  } as unknown as ToolRegistry;
+  return { registry, dispatchCalls: () => dispatchCalls };
+}
+
+function mkSession(opts: {
+  provider: LLMProvider;
+  registry: ToolRegistry;
+}): { session: Session; events: Event[] } {
+  const events: Event[] = [];
+  const state = {
+    sessionConfiguration: mkSessionConfiguration(),
+    history: [] as unknown[],
+    totalTokenUsage: 0,
+  };
+  const services: SessionServices = {
+    mcpConnectionManager: {
+      setApprovalPolicy: () => {},
+      setSandboxPolicy: () => {},
+      requiredStartupFailures: async () => [],
+    },
+    mcpStartupCancellationToken: {
+      cancel: () => {},
+      isCancelled: () => false,
+    },
+    provider: opts.provider,
+    registry: opts.registry,
+    hooks: {
+      executeStop: async () => ({}),
+      postToolUseHooks: [],
+    },
+  } as unknown as SessionServices;
+  const session = new Session({
+    conversationId: "conv-progress",
+    services,
+    initialState: state as unknown as SessionOpts["initialState"],
+    features: mkFeatures(),
+    jsRepl: { id: "repl-progress" },
+    config: mkConfig(),
+    modelInfo: mkModelInfo(),
+    eventQueue: new AsyncQueue<Event>(),
+  });
+  session.eventLog.subscribe((event) => {
+    events.push(event);
+  });
+  return { session, events };
+}
+
+/** Drive the turn to completion, capturing the returned Terminal. */
+async function drainTurn(
+  gen: AsyncGenerator<PhaseEvent, Terminal>,
+): Promise<{ terminal: Terminal; events: PhaseEvent[] }> {
+  const yielded: PhaseEvent[] = [];
+  let next = await gen.next();
+  while (!next.done) {
+    yielded.push(next.value);
+    next = await gen.next();
+  }
+  return { terminal: next.value, events: yielded };
+}
+
+// A model response that calls the same tool with identical args forever.
+function identicalToolCall(i: number): Partial<LLMResponse> {
+  return {
+    content: "",
+    toolCalls: [
+      {
+        id: `call-${i}`,
+        name: "Read",
+        arguments: JSON.stringify({ file_path: "/x" }),
+      },
+    ],
+    finishReason: "tool_calls",
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+  };
+}
+
+
+// ── A1 — repetition runaway trips no_progress ───────────────────────
+
+describe("A1 — repetition runaway finalizes with no_progress", () => {
+  test("trips no_progress, model called <=9 (not 1000), honest terminal, no fabricated result", async () => {
+    process.env.AGENC_MAX_TURNS = "1000";
+    const ctx = mkCtx(1000);
+    const { provider, calls } = mkScriptedProvider((i) => identicalToolCall(i));
+    const { registry } = mkScriptedRegistry(["Read"], () => ({
+      content: "stable content", // IDENTICAL every step
+      isError: false,
+    }));
+    const { session, events } = mkSession({ provider, registry });
+
+    const { terminal, events: yielded } = await drainTurn(
+      runTurn(session, ctx, "go"),
+    );
+
+    expect(terminal.reason).toBe("no_progress");
+    // model called far fewer than maxTurns (≈ repeatHard/lowGain threshold)
+    expect(calls()).toBeLessThanOrEqual(9);
+    expect(calls()).toBeGreaterThan(1);
+
+    // a `no_progress_detected` warning was emitted
+    const warned = events.some(
+      (e) =>
+        e.msg.type === "warning" &&
+        e.msg.payload.cause === "no_progress_detected",
+    );
+    expect(warned).toBe(true);
+
+    // the yielded turn_complete carries stopReason no_progress (not completed/error)
+    const tc = yielded.filter(
+      (e): e is Extract<PhaseEvent, { type: "turn_complete" }> =>
+        e.type === "turn_complete",
+    );
+    expect(tc.length).toBeGreaterThan(0);
+    const lastTc = tc[tc.length - 1];
+    expect(lastTc?.stopReason).toBe("no_progress");
+
+    // the finalized content is the honest no-progress text, never a success
+    // string and never a fabricated tool result.
+    const honest = lastTc?.content ?? "";
+    expect(honest).toMatch(/no-progress backstop/i);
+    expect(honest).not.toMatch(/stable content/); // not a fabricated tool result
+    expect(honest).not.toMatch(/success|task completed/i);
+  });
+
+  test("REVERT: master switch OFF → same repro spins to max_turns", async () => {
+    process.env.AGENC_BEHAVIORAL_BACKSTOP = "0";
+    process.env.AGENC_MAX_TURNS = "12"; // keep the revert fast
+    const ctx = mkCtx(12);
+    const { provider, calls } = mkScriptedProvider((i) => identicalToolCall(i));
+    const { registry } = mkScriptedRegistry(["Read"], () => ({
+      content: "stable content",
+      isError: false,
+    }));
+    const { session } = mkSession({ provider, registry });
+
+    const { terminal } = await drainTurn(runTurn(session, ctx, "go"));
+
+    expect(terminal.reason).toBe("max_turns");
+    // ran to the cap, NOT bounded at ~8
+    expect(calls()).toBeGreaterThanOrEqual(12);
+  });
+});
+
+// ── A5 — soft-nudge then recover ────────────────────────────────────
+
+describe("A5 — soft-nudge-then-recover completes normally", () => {
+  test("nudge fires once at the soft threshold, model changes, no trip", async () => {
+    process.env.AGENC_MAX_TURNS = "50";
+    // Repeat identically until the soft warn fires (3), then on the 4th
+    // model call produce a final assistant message (no tool calls) to end.
+    const ctx = mkCtx(50);
+    const { provider } = mkScriptedProvider((i) => {
+      if (i < 3) return identicalToolCall(i);
+      return { content: "Done — changed approach.", toolCalls: [], finishReason: "stop" };
+    });
+    const { registry } = mkScriptedRegistry(["Read"], () => ({
+      content: "stable content",
+      isError: false,
+    }));
+    const { session, events } = mkSession({ provider, registry });
+
+    const { terminal } = await drainTurn(runTurn(session, ctx, "go"));
+
+    expect(terminal.reason).toBe("completed");
+    // a warn was emitted exactly once (one-shot nudge latch), and its
+    // detail describes the repetition — proving the soft-nudge fired.
+    const warns = events.filter(
+      (e) =>
+        e.msg.type === "warning" &&
+        e.msg.payload.cause === "no_progress_warning",
+    );
+    expect(warns.length).toBe(1);
+    const warnMsg =
+      warns[0]?.msg.type === "warning"
+        ? (warns[0].msg.payload as { message?: string }).message ?? ""
+        : "";
+    expect(warnMsg).toMatch(/repeated/i);
+    // NO terminate warning fired — the model changed approach and finished.
+    const terminated = events.some(
+      (e) =>
+        e.msg.type === "warning" &&
+        e.msg.payload.cause === "no_progress_detected",
+    );
+    expect(terminated).toBe(false);
+  });
+});
+
+// ── B1 — status polling that progresses must NOT trip ───────────────
+
+describe("B1 — status polling that progresses never trips (killer test)", () => {
+  test("same tool 12x with CHANGING result → reason:completed, no trip", async () => {
+    process.env.AGENC_MAX_TURNS = "50";
+    const ctx = mkCtx(50);
+    // 12 identical GetStatus calls, then a final stop.
+    const { provider } = mkScriptedProvider((i) => {
+      if (i < 12) {
+        return {
+          content: "",
+          toolCalls: [
+            { id: `poll-${i}`, name: "GetStatus", arguments: "{}" },
+          ],
+          finishReason: "tool_calls",
+        };
+      }
+      return { content: "All done.", toolCalls: [], finishReason: "stop" };
+    });
+    // The result CHANGES each step → resultHash differs → never trips.
+    let pollIndex = 0;
+    const { registry } = mkScriptedRegistry(["GetStatus"], () => {
+      const content = pollIndex < 11 ? `pending ${pollIndex}/11` : "done";
+      pollIndex += 1;
+      return { content, isError: false };
+    });
+    const { session, events } = mkSession({ provider, registry });
+
+    const { terminal } = await drainTurn(runTurn(session, ctx, "poll"));
+
+    expect(terminal.reason).toBe("completed");
+    // never tripped
+    const tripped = events.some(
+      (e) =>
+        e.msg.type === "warning" &&
+        e.msg.payload.cause === "no_progress_detected",
+    );
+    expect(tripped).toBe(false);
+  });
+});
+
+// ── C1 — non-blocking: policing path adds no provider/tool calls ────
+
+describe("C1 — the policing path is non-blocking (no extra calls)", () => {
+  test("a healthy 2-step tool turn yields exactly the expected call counts", async () => {
+    process.env.AGENC_MAX_TURNS = "50";
+    const ctx = mkCtx(50);
+    // 1 tool call then stop → provider called twice, tool dispatched once.
+    const { provider, calls } = mkScriptedProvider((i) => {
+      if (i === 0) {
+        return {
+          content: "",
+          toolCalls: [
+            { id: "t-1", name: "Probe", arguments: JSON.stringify({ q: "x" }) },
+          ],
+          finishReason: "tool_calls",
+        };
+      }
+      return { content: "ok", toolCalls: [], finishReason: "stop" };
+    });
+    const { registry, dispatchCalls } = mkScriptedRegistry(["Probe"], () => ({
+      content: "probe result",
+      isError: false,
+    }));
+    const { session } = mkSession({ provider, registry });
+
+    const { terminal } = await drainTurn(runTurn(session, ctx, "probe it"));
+
+    expect(terminal.reason).toBe("completed");
+    // The policing path (record + evaluate) issued NO extra provider/tool
+    // calls — counts are exactly what a healthy turn produces (the model
+    // was called exactly twice: tool-call turn + final stop turn, NOT
+    // inflated by the synchronous record/evaluate policing).
+    expect(calls()).toBe(2);
+    expect(dispatchCalls()).toBe(1);
+  });
+});
+
+// ── D1 — wire mapping ───────────────────────────────────────────────
+
+describe("D1 — terminalToStopReason maps no_progress honestly", () => {
+  test("no_progress maps to no_progress (NOT error)", async () => {
+    // Indirect proof through the running loop: A1's turn_complete event
+    // carries stopReason "no_progress", which can only happen if the
+    // mapper's `case "no_progress"` arm (not default→"error") is present.
+    process.env.AGENC_MAX_TURNS = "1000";
+    const ctx = mkCtx(1000);
+    const { provider } = mkScriptedProvider((i) => identicalToolCall(i));
+    const { registry } = mkScriptedRegistry(["Read"], () => ({
+      content: "stable content",
+      isError: false,
+    }));
+    const { session } = mkSession({ provider, registry });
+    const { terminal, events: yielded } = await drainTurn(
+      runTurn(session, ctx, "go"),
+    );
+    expect(terminal.reason).toBe("no_progress");
+    const tc = yielded.find(
+      (e): e is Extract<PhaseEvent, { type: "turn_complete" }> =>
+        e.type === "turn_complete" && e.stopReason === "no_progress",
+    );
+    // The mapped stopReason is "no_progress", NOT "error" — proves the
+    // terminalToStopReason `case "no_progress"` arm is present.
+    expect(tc).toBeDefined();
+    expect(tc?.stopReason).toBe("no_progress");
+    expect(tc?.stopReason).not.toBe("error");
+  });
+});


### PR DESCRIPTION
Goal item #3. A **second** backstop, orthogonal to the #1318–#1321 per-tool dispatch drain: that catches a tool whose *dispatch wedges*; this catches a **semantic runaway** where every tool settles cleanly but the loop spins making no progress (the local model thrashed ~65k tokens/turn; the only prior whole-turn bound was `max_turns=1000` — ~65M tokens of waste before it trips).

## Two-tier, result-aware, non-blocking — honest `no_progress` terminal
- **Tier 0 (guarantee, OFF by default):** absolute per-turn deadline — wall-clock / token / tight-step caps. Deterministic, external (LoopTrap: termination must not rest on LLM self-judgment). Risky caps ship `0`=disabled; ops opt in.
- **Tier 1 (early exit, ON by default):** per-step detectors over a normalized `(toolName, canonical-args)` signature **paired with a result hash** — repetition ladder (Wink ≥3 warn → terminate at 8), ABAB/period-p stable cycle, repeat-gated low-info-gain streak (Wasted-Computation). **Every trip requires an unchanged `resultHash`** → structurally cannot false-positive on genuine progress.
- **Tier 2 (OFF by default):** Wink-style fire-and-forget observer every k=5 steps — only writes a flag the loop polls, never awaited.

## False-positive defense (the load-bearing invariant)
Repetition counts **only when the result is byte-identical** across repeats; a changed result or an `isError` flip resets the counter. Status-polling-that-progresses, progressing retries, distinct-but-cheap long turns never trip. **Proven load-bearing** by a guard-of-the-guard test: forcing `resultHash` constant makes the polling test trip (red).

## Integration rigor
The new `no_progress` `TerminalReason` is mapped honestly *everywhere*: beyond `terminalToStopReason` (whose `default → "error"` would mask it as a crash), a **D2 exhaustiveness sweep found and fixed 3 more silent mis-maps** (`run-agent`, `execAgentHook`, `background-agent-runner`). One existing exec-agent-hook "max-turn exhaustion" test was *itself* a real identical-call+result runaway, now correctly bounded at ~8 (test updated). Master kill-switch `AGENC_BEHAVIORAL_BACKSTOP=0` → byte-identical prior behavior.

## Tests (revert-sensitive)
A1 repetition / A2 ABAB / A3 low-gain / A4 token-cap-on-distinct-calls / A5 nudge-then-recover; **B1 progressing-poll + guard-of-the-guard** / B2 retry-flip / B3 distinct-cheap / B4 ignore-tool / B5 two-state-poll / B6 recovery-reentry / B7 master-off; C1/C2 non-blocking; D1–D3 wire/exhaustiveness/tsc-rejects-bad-arm.

## Gate
- `npm run build` ✅ exit 0 · `tsc -p runtime --noEmit` ✅ clean
- full `npm run test:unit` ✅ **1584 files / 13,470 tests passed, 0 failures** (healthy turns unchanged — ships ON by default)
- guard-of-the-guard independently re-verified: forcing `resultHash` constant reddens B1 (the progressing-poll wrongly trips `no_progress`); restored → green.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG