### PR TITLE
feat(portal): in-core `agenc portal serve` bridge (P1–P2b)

### DIFF
--- a/runtime/src/channels/webchat/protocol.ts
+++ b/runtime/src/channels/webchat/protocol.ts
@@ -44,6 +44,10 @@ export const WS_CHAT_SESSION_FORK = "chat.session.fork" as const;
 export const WS_CHAT_CANCELLED = "chat.cancelled" as const;
 export const WS_CHAT_CANCEL = "chat.cancel" as const;
 export const WS_CHAT_USAGE = "chat.usage" as const;
+// Guaranteed, idempotent, turn-id-stamped end-of-turn marker emitted from the turn-wrapper finally
+// (daemon.ts). Unlike agent.status phase:"idle" it carries a turnTraceId and fires exactly once per
+// turn even on crash/abort, giving portal/app clients a reliable per-turn completion contract.
+export const WS_CHAT_TURN_COMPLETE = "turn.complete" as const;
 
 // Session command bus
 export const WS_SESSION_COMMAND_CATALOG_GET =

--- a/runtime/src/cli/route-portal.impl.ts
+++ b/runtime/src/cli/route-portal.impl.ts
@@ -1,6 +1,7 @@
 import type { CliRouteContext, CliRouteModule, RoutedStatus } from "./route-types.js";
 import { startPortalServer } from "../portal/portal-server.js";
 import { startPortalRelayClient } from "../portal/portal-relay-client.js";
+import { signRelayTicket } from "../portal/portal-ticket.js";
 import {
   PORTAL_DEFAULT_DAEMON_URL,
   PORTAL_DEFAULT_HOST,
@@ -10,7 +11,6 @@ import {
 function flagString(value: unknown, fallback: string): string {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }
-
 function flagNumber(value: unknown, fallback: number): number {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
@@ -22,7 +22,9 @@ function flagNumber(value: unknown, fallback: number): number {
 
 const USAGE = [
   "usage: agenc portal serve [--host <h>] [--port <n>] [--daemon-url <ws-url>]",
-  "   or: agenc portal serve --relay --relay-url <wss-url> --ticket <ticket> [--daemon-url <ws-url>]",
+  "   or: agenc portal serve --relay --relay-url <wss-url> --account <id> [--machine <name>] [--ttl-hours <n>]   (signs a host ticket from AGENC_RELAY_TICKET_SECRET)",
+  "   or: agenc portal serve --relay --relay-url <wss-url> --ticket <signed-or-dev-ticket>",
+  "   or: agenc portal pair --account <id> [--ttl-hours <n>]   (mint a client ticket for the app; needs AGENC_RELAY_TICKET_SECRET)",
 ].join("\n");
 
 /** wss:// required; cleartext only to loopback (M6). */
@@ -30,7 +32,6 @@ function isSecureRelayUrl(url: string): boolean {
   return /^wss:\/\//.test(url) || /^ws:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/.test(url);
 }
 
-/** Resolve only on SIGINT/SIGTERM so the long-running server stays up. */
 function waitForShutdown(close: () => void | Promise<void>): Promise<RoutedStatus> {
   return new Promise<RoutedStatus>((resolve) => {
     const shutdown = (): void => {
@@ -41,8 +42,37 @@ function waitForShutdown(close: () => void | Promise<void>): Promise<RoutedStatu
   });
 }
 
+/** `agenc portal pair` — mint a signed CLIENT ticket the user pastes into the app's relay host. */
+function runPair(
+  parsed: CliRouteContext["parsed"],
+  context: CliRouteContext["context"],
+): RoutedStatus {
+  const account = flagString(parsed.flags.account, "");
+  if (!account) {
+    context.output("usage: agenc portal pair --account <id> [--ttl-hours <n>]");
+    return 2;
+  }
+  const secret = process.env.AGENC_RELAY_TICKET_SECRET ?? "";
+  if (!secret) {
+    context.output("agenc portal pair requires AGENC_RELAY_TICKET_SECRET in the environment");
+    return 2;
+  }
+  const ttlHours = flagNumber(parsed.flags["ttl-hours"], 24);
+  const ticket = signRelayTicket({
+    secret,
+    accountId: account,
+    role: "client",
+    ttlMs: ttlHours * 3_600_000,
+  });
+  context.output(ticket);
+  context.output(`# signed client ticket for "${account}", valid ${ttlHours}h — paste as the app's relay host ticket= value`);
+  return 0;
+}
+
 async function run({ parsed, context }: CliRouteContext): Promise<RoutedStatus> {
-  if (parsed.positional[1] !== "serve") {
+  const sub = parsed.positional[1];
+  if (sub === "pair") return runPair(parsed, context);
+  if (sub !== "serve") {
     context.output(USAGE);
     return 2;
   }
@@ -61,16 +91,30 @@ async function run({ parsed, context }: CliRouteContext): Promise<RoutedStatus> 
       context.output(`agenc portal serve --relay requires a wss:// URL (got "${relayUrl}"); ws:// is only allowed to loopback`);
       return 2;
     }
-    // M4: the ticket must be a relay-verified secret token — never auto-derive a bearer from public
-    // identifiers (account id / machine name), which anyone could forge to hijack the host channel.
-    const ticket = flagString(parsed.flags.ticket, "");
-    if (!ticket) {
-      context.output("agenc portal serve --relay requires --ticket <ticket> (a relay-verified secret token; do not derive it from public identifiers)");
-      return 2;
+
+    // Prefer an explicit --ticket; otherwise sign a fresh short-lived host ticket on each (re)connect
+    // from AGENC_RELAY_TICKET_SECRET + --account (never a forgeable public-id ticket).
+    let ticket: string | (() => string);
+    const explicit = flagString(parsed.flags.ticket, "");
+    if (explicit) {
+      if (explicit.startsWith("dev:")) {
+        context.output("WARNING: a 'dev:' ticket is forgeable — local testing only. Production uses a signed ticket (AGENC_RELAY_TICKET_SECRET + --account).");
+      }
+      ticket = explicit;
+    } else {
+      const secret = process.env.AGENC_RELAY_TICKET_SECRET ?? "";
+      const account = flagString(parsed.flags.account, "");
+      if (!secret || !account) {
+        context.output("agenc portal serve --relay needs either --ticket <signed-ticket> or AGENC_RELAY_TICKET_SECRET + --account <id>");
+        return 2;
+      }
+      const hostId = flagString(parsed.flags.machine, "mac");
+      // Short TTL is fine: the host re-signs a fresh ticket on every (re)connect, so 2h only needs
+      // to cover the connect window + clock skew.
+      const ttlMs = flagNumber(parsed.flags["ttl-hours"], 2) * 3_600_000;
+      ticket = () => signRelayTicket({ secret, accountId: account, role: "host", hostId, ttlMs });
     }
-    if (ticket.startsWith("dev:")) {
-      context.output("WARNING: a 'dev:' ticket is a forgeable shared secret — use it only for local testing against a dev-mode relay. Production needs a relay-verified signed ticket (see PORTAL_SERVE_P2A_SECURITY.md M4).");
-    }
+
     const handle = startPortalRelayClient({
       relayUrl,
       ticket,

--- a/runtime/src/cli/route-portal.impl.ts
+++ b/runtime/src/cli/route-portal.impl.ts
@@ -1,5 +1,6 @@
 import type { CliRouteContext, CliRouteModule, RoutedStatus } from "./route-types.js";
 import { startPortalServer } from "../portal/portal-server.js";
+import { startPortalRelayClient } from "../portal/portal-relay-client.js";
 import {
   PORTAL_DEFAULT_DAEMON_URL,
   PORTAL_DEFAULT_HOST,
@@ -19,19 +20,69 @@ function flagNumber(value: unknown, fallback: number): number {
   return fallback;
 }
 
+const USAGE = [
+  "usage: agenc portal serve [--host <h>] [--port <n>] [--daemon-url <ws-url>]",
+  "   or: agenc portal serve --relay --relay-url <wss-url> --ticket <ticket> [--daemon-url <ws-url>]",
+].join("\n");
+
+/** wss:// required; cleartext only to loopback (M6). */
+function isSecureRelayUrl(url: string): boolean {
+  return /^wss:\/\//.test(url) || /^ws:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/.test(url);
+}
+
+/** Resolve only on SIGINT/SIGTERM so the long-running server stays up. */
+function waitForShutdown(close: () => void | Promise<void>): Promise<RoutedStatus> {
+  return new Promise<RoutedStatus>((resolve) => {
+    const shutdown = (): void => {
+      void Promise.resolve(close()).then(() => resolve(0));
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+
 async function run({ parsed, context }: CliRouteContext): Promise<RoutedStatus> {
-  const sub = parsed.positional[1];
-  if (sub !== "serve") {
-    context.output(
-      "usage: agenc portal serve [--host <h>] [--port <n>] [--daemon-url <ws-url>]",
-    );
+  if (parsed.positional[1] !== "serve") {
+    context.output(USAGE);
     return 2;
+  }
+
+  const daemonUrl = flagString(parsed.flags["daemon-url"], PORTAL_DEFAULT_DAEMON_URL);
+  const relayMode =
+    parsed.flags.relay === true || typeof parsed.flags["relay-url"] === "string";
+
+  if (relayMode) {
+    const relayUrl = flagString(parsed.flags["relay-url"], "");
+    if (!relayUrl) {
+      context.output("agenc portal serve --relay requires --relay-url <wss-url>");
+      return 2;
+    }
+    if (!isSecureRelayUrl(relayUrl)) {
+      context.output(`agenc portal serve --relay requires a wss:// URL (got "${relayUrl}"); ws:// is only allowed to loopback`);
+      return 2;
+    }
+    // M4: the ticket must be a relay-verified secret token — never auto-derive a bearer from public
+    // identifiers (account id / machine name), which anyone could forge to hijack the host channel.
+    const ticket = flagString(parsed.flags.ticket, "");
+    if (!ticket) {
+      context.output("agenc portal serve --relay requires --ticket <ticket> (a relay-verified secret token; do not derive it from public identifiers)");
+      return 2;
+    }
+    if (ticket.startsWith("dev:")) {
+      context.output("WARNING: a 'dev:' ticket is a forgeable shared secret — use it only for local testing against a dev-mode relay. Production needs a relay-verified signed ticket (see PORTAL_SERVE_P2A_SECURITY.md M4).");
+    }
+    const handle = startPortalRelayClient({
+      relayUrl,
+      ticket,
+      daemonUrl,
+      logger: (m) => context.output(m),
+    });
+    context.output(`agenc portal serve --relay: dialing ${relayUrl} -> daemon ${daemonUrl}`);
+    return await waitForShutdown(() => handle.close());
   }
 
   const host = flagString(parsed.flags.host, PORTAL_DEFAULT_HOST);
   const port = flagNumber(parsed.flags.port, PORTAL_DEFAULT_PORT);
-  const daemonUrl = flagString(parsed.flags["daemon-url"], PORTAL_DEFAULT_DAEMON_URL);
-
   const handle = await startPortalServer({
     host,
     port,
@@ -41,15 +92,7 @@ async function run({ parsed, context }: CliRouteContext): Promise<RoutedStatus> 
   context.output(
     `agenc portal serve: ready on ws://${handle.host}:${handle.port} -> ${daemonUrl}`,
   );
-
-  // Long-running: resolve only on shutdown signal.
-  return await new Promise<RoutedStatus>((resolve) => {
-    const shutdown = (): void => {
-      void handle.close().then(() => resolve(0));
-    };
-    process.once("SIGINT", shutdown);
-    process.once("SIGTERM", shutdown);
-  });
+  return await waitForShutdown(() => handle.close());
 }
 
 export const routeModule: CliRouteModule = { run };

--- a/runtime/src/cli/route-portal.impl.ts
+++ b/runtime/src/cli/route-portal.impl.ts
@@ -1,0 +1,55 @@
+import type { CliRouteContext, CliRouteModule, RoutedStatus } from "./route-types.js";
+import { startPortalServer } from "../portal/portal-server.js";
+import {
+  PORTAL_DEFAULT_DAEMON_URL,
+  PORTAL_DEFAULT_HOST,
+  PORTAL_DEFAULT_PORT,
+} from "../portal/portal-protocol.js";
+
+function flagString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function flagNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number.parseInt(value, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+async function run({ parsed, context }: CliRouteContext): Promise<RoutedStatus> {
+  const sub = parsed.positional[1];
+  if (sub !== "serve") {
+    context.output(
+      "usage: agenc portal serve [--host <h>] [--port <n>] [--daemon-url <ws-url>]",
+    );
+    return 2;
+  }
+
+  const host = flagString(parsed.flags.host, PORTAL_DEFAULT_HOST);
+  const port = flagNumber(parsed.flags.port, PORTAL_DEFAULT_PORT);
+  const daemonUrl = flagString(parsed.flags["daemon-url"], PORTAL_DEFAULT_DAEMON_URL);
+
+  const handle = await startPortalServer({
+    host,
+    port,
+    daemonUrl,
+    logger: (m) => context.output(m),
+  });
+  context.output(
+    `agenc portal serve: ready on ws://${handle.host}:${handle.port} -> ${daemonUrl}`,
+  );
+
+  // Long-running: resolve only on shutdown signal.
+  return await new Promise<RoutedStatus>((resolve) => {
+    const shutdown = (): void => {
+      void handle.close().then(() => resolve(0));
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+
+export const routeModule: CliRouteModule = { run };

--- a/runtime/src/cli/route-portal.ts
+++ b/runtime/src/cli/route-portal.ts
@@ -1,0 +1,12 @@
+import type { CliRouteDescriptor } from "./route-types.js";
+
+const routePortal: CliRouteDescriptor = {
+  name: "portal",
+  matches(parsed) {
+    return parsed.positional[0] === "portal";
+  },
+  load: () =>
+    import("./route-portal.impl.js").then((module) => module.routeModule),
+};
+
+export default routePortal;

--- a/runtime/src/cli/routes.ts
+++ b/runtime/src/cli/routes.ts
@@ -6,6 +6,7 @@ import routeDaemon from "./route-daemon.js";
 import routeFallback from "./route-fallback.js";
 import routeJobs from "./route-jobs.js";
 import routeMarket from "./route-market.js";
+import routePortal from "./route-portal.js";
 import routeSessions from "./route-sessions.js";
 import routeShell from "./route-shell.js";
 import routeSkill from "./route-skill.js";
@@ -20,6 +21,7 @@ export const CLI_ROUTES = [
   routeJobs,
   routeAgent,
   routeMarket,
+  routePortal,
   routeSkill,
   routeFallback,
 ];

--- a/runtime/src/gateway/approvals-permission-mode.test.ts
+++ b/runtime/src/gateway/approvals-permission-mode.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { ApprovalEngine, type SessionPermissionMode } from "./approvals.js";
+import type { EffectApprovalReasonCode } from "./safety-tiering.js";
+
+// Full universe of effect reason codes — iterate it so any future code forces a test decision.
+const ALL_REASON_CODES: EffectApprovalReasonCode[] = [
+  "read_only_effect",
+  "workspace_scaffold",
+  "workspace_write",
+  "workspace_destructive_mutation",
+  "protected_workspace_mutation",
+  "host_mutation",
+  "shell_read_only",
+  "shell_mutation",
+  "shell_open_world",
+  "desktop_read_only",
+  "desktop_automation",
+  "process_control",
+  "server_control",
+  "credential_secret_access",
+  "irreversible_financial_action",
+  "untrusted_mcp_tool",
+];
+
+// The ONLY effects bypassPermissions may auto-approve (mirrors BYPASS_APPROVABLE_REASONS).
+const BYPASS_APPROVABLE = new Set<string>([
+  "read_only_effect",
+  "shell_read_only",
+  "desktop_read_only",
+  "workspace_scaffold",
+  "workspace_write",
+]);
+
+function engineWith(
+  baseMode: string,
+  status: "allow" | "require_approval" | "deny",
+  reasonCode: string,
+): ApprovalEngine {
+  const effectPolicy = {
+    mode: baseMode,
+    evaluate: () => ({
+      status,
+      source: "effect_policy",
+      reasonCode,
+      riskLevel: "medium",
+      approvalScopeKey: "scope",
+      message: "msg",
+    }),
+  };
+  return new ApprovalEngine({ effectPolicy } as never);
+}
+const decide = (e: ApprovalEngine) => e.simulate("tool", {}, "s");
+
+describe("ApprovalEngine per-session permission mode (P3)", () => {
+  describe("bypassPermissions auto-approves ONLY the benign read/edit allowlist (fail-closed)", () => {
+    for (const rc of ALL_REASON_CODES) {
+      const expectAllow = BYPASS_APPROVABLE.has(rc);
+      it(`${rc} -> ${expectAllow ? "auto-approved" : "still prompts"}`, () => {
+        const e = engineWith("safe_local_dev", "require_approval", rc);
+        e.setSessionPermissionMode("s", "bypassPermissions");
+        const d = decide(e);
+        if (expectAllow) {
+          expect(d.required).not.toBe(true);
+          expect(d.denied).not.toBe(true);
+        } else {
+          expect(d.required).toBe(true);
+        }
+      });
+    }
+  });
+
+  describe("a hard deny is never overridden by any mode", () => {
+    const modes: SessionPermissionMode[] = ["default", "plan", "acceptEdits", "bypassPermissions"];
+    for (const mode of modes) {
+      it(`stays denied under ${mode}`, () => {
+        const e = engineWith("safe_local_dev", "deny", "untrusted_mcp_tool");
+        e.setSessionPermissionMode("s", mode);
+        expect(decide(e).denied).toBe(true);
+      });
+    }
+  });
+
+  describe("bypass never relaxes above the hardened floor", () => {
+    for (const baseMode of ["unattended_background", "benchmark"]) {
+      it(`${baseMode} base: shell_mutation still prompts`, () => {
+        const e = engineWith(baseMode, "require_approval", "shell_mutation");
+        e.setSessionPermissionMode("s", "bypassPermissions");
+        expect(decide(e).required).toBe(true);
+      });
+    }
+  });
+
+  describe("plan mode is read-only", () => {
+    it("read-only effect passes", () => {
+      const e = engineWith("safe_local_dev", "allow", "read_only_effect");
+      e.setSessionPermissionMode("s", "plan");
+      expect(decide(e).denied).not.toBe(true);
+    });
+    it("a mutating effect is blocked even if base-allowed", () => {
+      const e = engineWith("safe_local_dev", "allow", "shell_mutation");
+      e.setSessionPermissionMode("s", "plan");
+      expect(decide(e).denied).toBe(true);
+    });
+  });
+
+  describe("acceptEdits auto-approves only workspace edits", () => {
+    it("workspace_write prompt -> auto-approved", () => {
+      const e = engineWith("safe_local_dev", "require_approval", "workspace_write");
+      e.setSessionPermissionMode("s", "acceptEdits");
+      const d = decide(e);
+      expect(d.required).not.toBe(true);
+      expect(d.denied).not.toBe(true);
+    });
+    it("shell_mutation prompt -> still prompts", () => {
+      const e = engineWith("safe_local_dev", "require_approval", "shell_mutation");
+      e.setSessionPermissionMode("s", "acceptEdits");
+      expect(decide(e).required).toBe(true);
+    });
+  });
+
+  describe("default and reset", () => {
+    it("default leaves the base decision unchanged", () => {
+      const e = engineWith("safe_local_dev", "require_approval", "shell_mutation");
+      expect(decide(e).required).toBe(true);
+    });
+    it("setting then clearing restores prompting", () => {
+      const e = engineWith("safe_local_dev", "require_approval", "shell_mutation");
+      e.setSessionPermissionMode("s", "bypassPermissions");
+      e.setSessionPermissionMode("s", "default");
+      expect(decide(e).required).toBe(true);
+    });
+  });
+});

--- a/runtime/src/gateway/approvals.ts
+++ b/runtime/src/gateway/approvals.ts
@@ -11,7 +11,10 @@
 
 import type { HookHandler, HookContext, HookResult } from "./hooks.js";
 import { createHmac } from "node:crypto";
-import type { EffectApprovalPolicy } from "./effect-approval-policy.js";
+import type {
+  EffectApprovalPolicy,
+  EffectApprovalOutcome,
+} from "./effect-approval-policy.js";
 import type { EffectFilesystemEntryType } from "../workflow/effects.js";
 import type { SessionShellProfile } from "./shell-profile.js";
 
@@ -380,6 +383,48 @@ export type ApprovalEscalationHandler = (
  * Approval engine that evaluates tool invocations against configured rules,
  * manages pending approval requests, and supports per-session elevation.
  */
+/**
+ * Per-session permission MODE (Claude-Code style) overlaid on the startup-baked GatewayApprovalMode.
+ * - default: no change (the base policy + per-session elevations/denials decide).
+ * - plan: read-only — any non-read effect is blocked (the agent plans but never mutates/executes).
+ * - acceptEdits: auto-approve workspace edits that would otherwise prompt; everything else unchanged.
+ * - bypassPermissions: auto-approve prompts — but ONLY within a local base mode, and NEVER for
+ *   financial/credential/protected/untrusted effects, and NEVER overriding a hard deny.
+ */
+export type SessionPermissionMode =
+  | "default"
+  | "acceptEdits"
+  | "plan"
+  | "bypassPermissions";
+
+/** Effect reasonCodes (from the effect policy) classified for the permission-mode overlay. */
+const READ_ONLY_REASONS: ReadonlySet<string> = new Set([
+  "read_only_effect",
+  "shell_read_only",
+  "desktop_read_only",
+]);
+const EDIT_REASONS: ReadonlySet<string> = new Set([
+  "workspace_scaffold",
+  "workspace_write",
+]);
+/** The ONLY effects bypassPermissions may auto-approve — a FAIL-CLOSED allowlist of benign read/edit
+ *  effects. Everything else (shell mutations rm/mv, host/destructive/process/server mutations, open-
+ *  world network, financial, credential, untrusted MCP) still requires explicit human approval even
+ *  under bypass, and any future reasonCode fails closed (keeps prompting) until added here. */
+const BYPASS_APPROVABLE_REASONS: ReadonlySet<string> = new Set([
+  "read_only_effect",
+  "shell_read_only",
+  "desktop_read_only",
+  "workspace_scaffold",
+  "workspace_write",
+]);
+/** bypassPermissions only relaxes within a local base mode — never escalates above the unattended/
+ *  benchmark floor (a hardened deployment's denials must stand). */
+const LOCAL_BASE_MODES: ReadonlySet<string> = new Set([
+  "safe_local_dev",
+  "trusted_operator",
+]);
+
 export class ApprovalEngine {
   private readonly rules: readonly ApprovalRule[];
   private readonly effectPolicy?: EffectApprovalPolicy;
@@ -395,6 +440,7 @@ export class ApprovalEngine {
   private readonly escalationHandlers: ApprovalEscalationHandler[] = [];
   private readonly elevations = new Map<string, Set<string>>();
   private readonly denials = new Map<string, Set<string>>();
+  private readonly sessionModes = new Map<string, SessionPermissionMode>();
   private idCounter = 0;
 
   constructor(config?: ApprovalEngineConfig) {
@@ -656,6 +702,33 @@ export class ApprovalEngine {
         decisionSource: outcome.source,
         approvalScopeKey: outcome.approvalScopeKey,
         denyReason: outcome.message,
+      };
+    }
+
+    // Per-session permission-mode overlay (plan / acceptEdits / bypassPermissions). Runs only after
+    // a per-session denial and a hard policy deny are ruled out above, so it can restrict (plan) or
+    // relax-prompts (acceptEdits/bypass) but never override a deny.
+    const modeDecision = this.applyPermissionMode(sessionId, toolName, outcome);
+    if (modeDecision?.kind === "deny") {
+      return {
+        required: false,
+        denied: true,
+        elevated: false,
+        reasonCode: outcome.reasonCode,
+        decisionSource: outcome.source,
+        approvalScopeKey: outcome.approvalScopeKey,
+        denyReason: modeDecision.reason,
+      };
+    }
+    if (modeDecision?.kind === "allow") {
+      return {
+        required: false,
+        denied: false,
+        elevated: false,
+        reasonCode: outcome.reasonCode,
+        decisionSource: outcome.source,
+        approvalScopeKey: outcome.approvalScopeKey,
+        autoApprovedReasonCode: outcome.reasonCode,
       };
     }
 
@@ -1059,6 +1132,72 @@ export class ApprovalEngine {
     this.clearDeniedPattern(sessionId, pattern);
     this.clearElevatedPattern(sessionId, pattern);
     return this.getSessionPolicyState(sessionId);
+  }
+
+  /** Set the per-session permission mode. "default" (or any unrecognized value) clears the overlay. */
+  setSessionPermissionMode(sessionId: string, mode: SessionPermissionMode): void {
+    const id = sessionId.trim();
+    if (id.length === 0) return;
+    if (mode === "acceptEdits" || mode === "plan" || mode === "bypassPermissions") {
+      this.sessionModes.set(id, mode);
+    } else {
+      this.sessionModes.delete(id);
+    }
+  }
+
+  getSessionPermissionMode(sessionId: string): SessionPermissionMode {
+    return this.sessionModes.get(sessionId.trim()) ?? "default";
+  }
+
+  /** Clear the mode on session teardown (mirrors the elevations/denials lifecycle). */
+  clearSessionPermissionMode(sessionId: string): void {
+    this.sessionModes.delete(sessionId.trim());
+  }
+
+  /**
+   * Per-session permission-mode overlay applied to the base effect outcome. Returns a replacement
+   * decision, or null to keep the base handling. It never overrides a hard deny or a per-session
+   * denial (those are handled before this runs), and bypassPermissions only relaxes within a local
+   * base mode and never for financial/credential/protected/untrusted effects.
+   */
+  private applyPermissionMode(
+    sessionId: string,
+    toolName: string,
+    outcome: EffectApprovalOutcome,
+  ): { kind: "deny" | "allow"; reason: string } | null {
+    const mode = this.getSessionPermissionMode(sessionId);
+    if (mode === "default") return null;
+    const reason = outcome.reasonCode as string;
+
+    if (mode === "plan") {
+      if (!READ_ONLY_REASONS.has(reason)) {
+        return {
+          kind: "deny",
+          reason: `plan mode: "${toolName}" blocked (read-only mode — no mutations or execution)`,
+        };
+      }
+      return null; // read-only effects pass through unchanged
+    }
+
+    // acceptEdits / bypassPermissions only relax things that would otherwise prompt.
+    if (outcome.status !== "require_approval") return null;
+
+    if (mode === "acceptEdits") {
+      return EDIT_REASONS.has(reason)
+        ? { kind: "allow", reason: "acceptEdits: workspace edit auto-approved" }
+        : null;
+    }
+
+    if (mode === "bypassPermissions") {
+      const baseMode = this.effectPolicy?.mode ?? "safe_local_dev";
+      if (!LOCAL_BASE_MODES.has(baseMode)) return null; // never relax above the hardened floor
+      // Fail-closed: only benign read/edit effects auto-approve. Shell mutations, host/destructive/
+      // process/server/open-world, financial, credential, and untrusted MCP still require approval.
+      if (!BYPASS_APPROVABLE_REASONS.has(reason)) return null;
+      return { kind: "allow", reason: "bypassPermissions: auto-approved" };
+    }
+
+    return null;
   }
 
   /**

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -1594,6 +1594,7 @@ export interface CommandRegistryDaemonContext {
     elevatedPatterns: readonly string[];
     deniedPatterns: readonly string[];
   };
+  setSessionPermissionMode(sessionId: string, mode: string): void;
   getSubAgentRuntimeConfig(): ResolvedSubAgentRuntimeConfig | null;
   getActiveDelegationAggressiveness(
     config: ResolvedSubAgentRuntimeConfig,
@@ -4469,9 +4470,23 @@ export function createDaemonCommandRegistry(
         );
         return;
       }
+      if (subcommand === "mode") {
+        const requested = cmdCtx.argv[1]?.trim() ?? "";
+        const valid = ["default", "acceptEdits", "plan", "bypassPermissions"];
+        const mode = valid.find((m) => m.toLowerCase() === requested.toLowerCase());
+        if (!mode) {
+          await cmdCtx.reply(
+            "Usage: /policy mode <default|acceptEdits|plan|bypassPermissions>",
+          );
+          return;
+        }
+        ctx.setSessionPermissionMode(cmdCtx.sessionId, mode);
+        await cmdCtx.reply(`Permission mode set to "${mode}" for this session.`);
+        return;
+      }
       if (subcommand !== "simulate") {
         await cmdCtx.reply(
-          "Usage: /policy [status|simulate <toolName> [jsonArgs]|credentials|revoke-credentials [credentialId]|update <allow|deny|clear|reset> [pattern]]",
+          "Usage: /policy [status|simulate <toolName> [jsonArgs]|credentials|revoke-credentials [credentialId]|update <allow|deny|clear|reset> [pattern]|mode <default|acceptEdits|plan|bypassPermissions>]",
         );
         return;
       }

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -173,7 +173,7 @@ import {
   cleanupDesktopSessionResources as cleanupDesktopSession,
   type DesktopRouterFactory,
 } from "./desktop-routing-config.js";
-import { ApprovalEngine } from "./approvals.js";
+import { ApprovalEngine, type SessionPermissionMode } from "./approvals.js";
 import { resolveGatewayApprovalEngineConfig } from "./approval-runtime.js";
 import { buildToolPolicyAction } from "../policy/tool-governance.js";
 import {
@@ -4232,6 +4232,7 @@ export class DaemonManager {
     sessionMgr.reset(historySessionId);
     this._chatExecutor?.resetSessionTokens(webSessionId);
     this._sessionModelInfo.delete(webSessionId);
+    this._approvalEngine?.clearSessionPermissionMode(webSessionId);
     await progressTracker?.clear(webSessionId);
     await this._sessionCredentialBroker?.revoke({
       sessionId: webSessionId,
@@ -5043,6 +5044,11 @@ export class DaemonManager {
           elevatedPatterns: [],
           deniedPatterns: [],
         },
+      setSessionPermissionMode: (sessionId, mode) =>
+        this._approvalEngine?.setSessionPermissionMode(
+          sessionId,
+          mode as SessionPermissionMode,
+        ),
       getSubAgentRuntimeConfig: () => this._subAgentRuntimeConfig,
       getActiveDelegationAggressiveness: (config) =>
         this.getActiveDelegationAggressiveness(config),

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -7727,6 +7727,18 @@ export class DaemonManager {
         agentDefinitions: this._agentDefinitions,
       });
     } finally {
+      // Guaranteed, idempotent, turn-id-stamped end-of-turn signal for portal/app clients. This
+      // finally runs exactly once per turn (even on throw/abort), so the gaps in agent.status
+      // phase:"idle" (no finally, no turn id, possible double-emit) don't reach the client.
+      // See WS_CHAT_TURN_COMPLETE in channels/webchat/protocol.ts.
+      try {
+        webChat.pushToSession(msg.sessionId, {
+          type: "turn.complete",
+          payload: { sessionId: msg.sessionId, turnTraceId },
+        });
+      } catch {
+        /* never let the completion signal mask the turn outcome */
+      }
       this._foregroundSessionLocks.delete(msg.sessionId);
       if (this._activeSessionTraceIds.get(msg.sessionId) === turnTraceId) {
         this._activeSessionTraceIds.delete(msg.sessionId);

--- a/runtime/src/portal/portal-adapter.ts
+++ b/runtime/src/portal/portal-adapter.ts
@@ -19,7 +19,26 @@ import {
 export interface PortalAdapterOptions {
   sendToApp: (msg: JsonRpcResponse | JsonRpcNotification) => void;
   sendToGateway: (envelope: Record<string, unknown>) => void;
+  /** True for the relay/remote transport. Gates privileged actions the loopback path allows freely
+   *  (the adapter is the SOLE scope-enforcement point for the remote leg — the daemon treats the
+   *  loopback socket as full-privilege operator). */
+  isRemote?: boolean;
   logger?: (msg: string) => void;
+}
+
+/** Fail-closed gate: only obviously read-only actions may be approved by a REMOTE client (P2a). A
+ *  remote relay client must NOT be able to self-approve shell/wallet/destructive/file-mutating tools
+ *  — otherwise a leaked ticket runs privileged ops with no human on the device. */
+function remotelyApprovable(action: string): boolean {
+  const a = action.toLowerCase();
+  if (
+    /bash|shell|exec|command|\brun\b|spawn|write|edit|create|update|delete|remove|\brm\b|destroy|drop|wallet|transfer|\bsend\b|sign|airdrop|swap|\bpay\b|config|sudo|kill|reload|install|chmod|chown|\bmv\b|\bcp\b/.test(
+      a,
+    )
+  ) {
+    return false;
+  }
+  return /read|list|view|search|grep|glob|fetch|\bget\b|\bcat\b|show|inspect|status|browse/.test(a);
 }
 
 type RpcId = string | number | null;
@@ -60,8 +79,13 @@ export class PortalAdapter {
   private streamedThisTurn = false;
   private turnActive = false;
   private readonly turnQueue: string[] = [];
+  /** requestId -> action, captured from approval.request so tool.approve can be scope-checked. */
+  private readonly pendingApprovals = new Map<string, string>();
+  private readonly isRemote: boolean;
 
-  constructor(private readonly opts: PortalAdapterOptions) {}
+  constructor(private readonly opts: PortalAdapterOptions) {
+    this.isRemote = opts.isRemote ?? false;
+  }
 
   // ---- app JSON-RPC -> gateway {type} ----
 
@@ -113,25 +137,46 @@ export class PortalAdapter {
         this.enqueueTurn(content);
         break;
       }
-      case RPC.toolApprove:
+      case RPC.toolApprove: {
+        const requestId = asStr(params.requestId);
+        if (this.isRemote) {
+          const action = this.pendingApprovals.get(requestId) ?? "";
+          if (!remotelyApprovable(action)) {
+            // A remote client must NOT self-approve a privileged tool it just triggered (M1). Reject
+            // the tool on the gateway and tell the client a device-local human confirm is required.
+            this.opts.logger?.(`[portal] denied remote approval of "${action}" (req ${requestId})`);
+            this.replyErr(id, -32001, `remote approval not allowed for "${action || "this action"}"; requires device-local confirmation`);
+            this.sendGateway({ type: GW.approvalRespond, payload: { requestId, approved: false } });
+            this.pendingApprovals.delete(requestId);
+            break;
+          }
+        }
+        this.pendingApprovals.delete(requestId);
         this.reply(id, { ok: true });
-        this.sendGateway({
-          type: GW.approvalRespond,
-          payload: { requestId: asStr(params.requestId), approved: true },
-        });
+        this.sendGateway({ type: GW.approvalRespond, payload: { requestId, approved: true } });
         break;
-      case RPC.toolDeny:
+      }
+      case RPC.toolDeny: {
+        const requestId = asStr(params.requestId);
+        this.pendingApprovals.delete(requestId);
         this.reply(id, { ok: true });
-        this.sendGateway({
-          type: GW.approvalRespond,
-          payload: { requestId: asStr(params.requestId), approved: false },
-        });
+        this.sendGateway({ type: GW.approvalRespond, payload: { requestId, approved: false } });
         break;
-      case RPC.setPermissionMode:
-        // P1: acknowledged but not enforced server-side. P3 wires this to a per-session overlay
+      }
+      case RPC.setPermissionMode: {
+        const mode = asStr(params.permissionMode);
+        // A remote client must never be able to relax the approval mode (M3). This denylist must
+        // remain when P3 actually wires setPermissionMode, so the wiring physically can't expose
+        // yolo/bypass to the relay leg.
+        if (this.isRemote && /yolo|bypass|allow|unsafe|auto/i.test(mode)) {
+          this.replyErr(id, -32001, `permission mode "${mode}" not allowed from a remote client`);
+          break;
+        }
+        // P1/P2a: acknowledged but not enforced server-side. P3 wires this to a per-session overlay
         // on the ApprovalEngine (the elevations/denials precedent) via session.permissionMode.set.
-        this.reply(id, { ok: true, permissionMode: asStr(params.permissionMode) });
+        this.reply(id, { ok: true, permissionMode: mode });
         break;
+      }
       case RPC.agentList:
         this.reply(id, { agents: [] });
         break;
@@ -290,17 +335,21 @@ export class PortalAdapter {
           isError: Boolean(payload.isError),
         });
         break;
-      case GW.approvalRequest:
+      case GW.approvalRequest: {
+        const requestId = asStr(payload.requestId);
+        const action = asStr(payload.action) || "tool";
+        this.pendingApprovals.set(requestId, action); // so tool.approve can be scope-checked (M1)
         this.notify(NOTIFY.permissionRequest, {
           sessionId: sid,
-          requestId: asStr(payload.requestId),
-          toolName: asStr(payload.action) || "tool",
-          title: asStr(payload.action) || "Approve action",
+          requestId,
+          toolName: action,
+          title: action || "Approve action",
           detail: asStr(payload.message) || short(payload.details),
           kind: "tool",
           permissions: [],
         });
         break;
+      }
       case GW.chatMessage: {
         // The final full assistant message. If we already streamed via chat.stream this is a
         // duplicate (suppress); if the gateway one-shot the answer, THIS is the response.

--- a/runtime/src/portal/portal-adapter.ts
+++ b/runtime/src/portal/portal-adapter.ts
@@ -1,0 +1,354 @@
+// Per-connection translator: app JSON-RPC 2.0 <-> daemon gateway `{type,...}`. One adapter instance
+// per app socket, holding per-connection turn + correlation state. P1 ships single-turn-at-a-time
+// per session (the gateway's phase:"idle" is a reliable per-turn signal only when turns don't
+// overlap), so concurrent messages on one session are SERIALIZED here until the turn ends. The
+// daemon's new turn-id-stamped `turn.complete` (when present) is also honored.
+
+import {
+  APP_METHODS,
+  GW,
+  NOTIFY,
+  PORTAL_PROTOCOL_VERSION,
+  RPC,
+  mapGatewayError,
+  type GatewayEnvelope,
+  type JsonRpcNotification,
+  type JsonRpcResponse,
+} from "./portal-protocol.js";
+
+export interface PortalAdapterOptions {
+  sendToApp: (msg: JsonRpcResponse | JsonRpcNotification) => void;
+  sendToGateway: (envelope: Record<string, unknown>) => void;
+  logger?: (msg: string) => void;
+}
+
+type RpcId = string | number | null;
+
+function asObj(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+function asStr(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+function asArr(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+function asNum(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+/** Map a tool name to one of the app's ToolKind raw values (icon/label hints). */
+function toolKind(name = ""): string {
+  const n = name.toLowerCase();
+  if (/edit|write|apply|patch|create|update/.test(n)) return "fileEdit";
+  if (/read|list|cat|view|open/.test(n)) return "fileRead";
+  if (/search|grep|find|glob/.test(n)) return "search";
+  if (/web|fetch|http|url/.test(n)) return "web";
+  if (/bash|shell|exec|command|run/.test(n)) return "bash";
+  return "task";
+}
+
+function short(v: unknown, n = 400): string {
+  const s = typeof v === "string" ? v : JSON.stringify(v ?? "");
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}
+
+export class PortalAdapter {
+  private appSessionId: string | null = null;
+  private gatewaySessionId: string | undefined;
+  private readonly pending = new Map<string, { appId: RpcId; method: string }>();
+  private streamedThisTurn = false;
+  private turnActive = false;
+  private readonly turnQueue: string[] = [];
+
+  constructor(private readonly opts: PortalAdapterOptions) {}
+
+  // ---- app JSON-RPC -> gateway {type} ----
+
+  handleAppMessage(raw: string): void {
+    let msg: { id?: RpcId; method?: string; params?: unknown };
+    try {
+      msg = JSON.parse(raw) as typeof msg;
+    } catch {
+      return;
+    }
+    const id: RpcId = msg.id ?? null;
+    const method = msg.method ?? "";
+    const params = asObj(msg.params);
+
+    switch (method) {
+      case RPC.initialize:
+        this.reply(id, {
+          protocol: { version: PORTAL_PROTOCOL_VERSION },
+          capabilities: { "daemon.methods": APP_METHODS },
+        });
+        break;
+      case RPC.healthPing:
+        this.sendGateway({ type: GW.ping, id: String(id) }, { appId: id, method });
+        break;
+      case RPC.sessionList:
+        this.sendGateway(
+          { type: GW.chatSessionList, id: String(id), payload: {} },
+          { appId: id, method },
+        );
+        break;
+      case RPC.sessionAttach: {
+        this.appSessionId = asStr(params.sessionId) || this.appSessionId;
+        this.reply(id, { sessionId: this.appSessionId });
+        // No scrollback fetch on attach: the app's sessionId is a client-local id the gateway does
+        // not own yet (requesting chat.history for it returns "Not authorized to access this
+        // session"), and the app restores its own persisted transcript. P2/P4 reconcile session ids
+        // with the gateway (chat.session.resume) and add real server-side scrollback replay.
+        break;
+      }
+      case RPC.messageSend:
+      case RPC.messageStream: {
+        this.appSessionId = asStr(params.sessionId) || this.appSessionId;
+        const content = asStr(params.content);
+        this.reply(id, {
+          messageId: `m-${Date.now()}`,
+          streamId: `st-${Date.now()}`,
+          acceptedAt: Date.now(),
+        });
+        this.enqueueTurn(content);
+        break;
+      }
+      case RPC.toolApprove:
+        this.reply(id, { ok: true });
+        this.sendGateway({
+          type: GW.approvalRespond,
+          payload: { requestId: asStr(params.requestId), approved: true },
+        });
+        break;
+      case RPC.toolDeny:
+        this.reply(id, { ok: true });
+        this.sendGateway({
+          type: GW.approvalRespond,
+          payload: { requestId: asStr(params.requestId), approved: false },
+        });
+        break;
+      case RPC.setPermissionMode:
+        // P1: acknowledged but not enforced server-side. P3 wires this to a per-session overlay
+        // on the ApprovalEngine (the elevations/denials precedent) via session.permissionMode.set.
+        this.reply(id, { ok: true, permissionMode: asStr(params.permissionMode) });
+        break;
+      case RPC.agentList:
+        this.reply(id, { agents: [] });
+        break;
+      case RPC.daemonInfo:
+        this.sendGateway({ type: GW.configGet, id: String(id) }, { appId: id, method });
+        break;
+      default:
+        this.reply(id, {});
+    }
+  }
+
+  /** Serialize one turn at a time per session (P1): queue while a turn is in flight. */
+  private enqueueTurn(content: string): void {
+    if (this.turnActive) {
+      this.turnQueue.push(content);
+      return;
+    }
+    this.startTurn(content);
+  }
+
+  private startTurn(content: string): void {
+    this.turnActive = true;
+    this.streamedThisTurn = false;
+    this.sendGateway({ type: GW.chatMessage, payload: { content } });
+  }
+
+  /** Idempotent turn-end: fired by phase:"idle", chat.response, or the turn.complete envelope. */
+  private onTurnEnd(): void {
+    if (!this.turnActive) return;
+    this.turnActive = false;
+    const next = this.turnQueue.shift();
+    if (next !== undefined) this.startTurn(next);
+  }
+
+  // ---- gateway {type} -> app JSON-RPC ----
+
+  handleGatewayMessage(gw: GatewayEnvelope): void {
+    const sid = this.appSessionId ?? "s-1";
+
+    // Correlated responses (ping / config.get / session.list) echo the string id we sent.
+    if (gw.id !== undefined && gw.id !== null && this.pending.has(String(gw.id))) {
+      const entry = this.pending.get(String(gw.id));
+      this.pending.delete(String(gw.id));
+      const appId = entry?.appId ?? null;
+      const method = entry?.method ?? "";
+      if (gw.error !== undefined && gw.error !== null) {
+        const text = asStr(gw.error) || JSON.stringify(gw.error);
+        this.replyErr(appId, mapGatewayError(text), text);
+        return;
+      }
+      if (method === RPC.healthPing) {
+        this.reply(appId, { ok: true });
+        return;
+      }
+      if (method === RPC.daemonInfo) {
+        const llm = asObj(asObj(gw.payload).llm); // only safe fields — never the apiKey
+        this.reply(appId, {
+          model: asStr(llm.model),
+          provider: asStr(llm.provider),
+          baseUrl: asStr(llm.baseUrl),
+        });
+        return;
+      }
+      if (method === RPC.sessionList) {
+        const sessions = asArr(gw.payload).map((r) => {
+          const rec = asObj(r);
+          return {
+            sessionId: asStr(rec.sessionId) || asStr(rec.id),
+            title: asStr(rec.label) || asStr(rec.sessionId) || asStr(rec.id),
+            cwd: asStr(rec.workspaceRoot) || asStr(rec.repoRoot),
+            subtitle: asStr(rec.preview) || asStr(rec.lastAssistantOutputPreview),
+            status: rec.connected ? "working" : "idle",
+            updated: "",
+          };
+        });
+        this.reply(appId, { sessions });
+        return;
+      }
+      this.reply(appId, asObj(gw.payload));
+      return;
+    }
+
+    const payload = asObj(gw.payload);
+    switch (gw.type) {
+      case GW.chatSession:
+        this.gatewaySessionId = asStr(payload.sessionId) || this.gatewaySessionId;
+        break;
+      case GW.chatHistory: {
+        const items = asArr(gw.payload).map((h) => {
+          const hh = asObj(h);
+          const sender = asStr(hh.sender);
+          return {
+            role: sender === "agent" ? "assistant" : sender === "tool" ? "tool" : "user",
+            text: asStr(hh.content),
+          };
+        });
+        if (items.length) this.sessEvent(sid, { type: "session_configured", initialMessages: items });
+        break;
+      }
+      case GW.agentStatus: {
+        const phase = asStr(payload.phase);
+        if (phase === "thinking") {
+          this.sessEvent(sid, { type: "turn_started", turnId: `t-${Date.now()}` });
+        } else if (phase === "idle") {
+          this.sessEvent(sid, { type: "turn_complete", turnId: "t-done" });
+          this.onTurnEnd();
+        }
+        break;
+      }
+      case GW.chatStream: {
+        const c = asStr(payload.content);
+        if (c) {
+          this.streamedThisTurn = true;
+          this.notify(NOTIFY.messageChunk, { sessionId: sid, delta: c });
+        }
+        break;
+      }
+      case GW.chatResponse:
+        this.sessEvent(sid, { type: "turn_complete", turnId: "t-done" });
+        this.onTurnEnd();
+        break;
+      case GW.turnComplete: {
+        // Daemon's guaranteed, turn-id-stamped end signal (the core hardening). Authoritative.
+        const turnId = asStr(payload.turnTraceId) || "t-done";
+        this.sessEvent(sid, { type: "turn_complete", turnId });
+        this.onTurnEnd();
+        break;
+      }
+      case GW.chatUsage: {
+        const econ = asObj(payload.economics);
+        const total = asNum(payload.totalTokens);
+        const prompt = asNum(payload.promptTokens);
+        this.sessEvent(sid, {
+          type: "token_count",
+          input: prompt,
+          output: Math.max(0, total - prompt),
+          // The gateway has no USD price — surface the real abstract spend units (the app labels it).
+          costUSD: asNum(econ.totalSpendUnits),
+        });
+        break;
+      }
+      case GW.toolsExecuting:
+        this.notify(NOTIFY.toolRequest, {
+          sessionId: sid,
+          callId: asStr(payload.toolCallId),
+          toolName: asStr(payload.toolName),
+          title: asStr(payload.toolName) || "tool",
+          kind: toolKind(asStr(payload.toolName)),
+        });
+        break;
+      case GW.toolsResult:
+        this.sessEvent(sid, {
+          type: "tool_call_completed",
+          callId: asStr(payload.toolCallId),
+          result: short(payload.result),
+          isError: Boolean(payload.isError),
+        });
+        break;
+      case GW.approvalRequest:
+        this.notify(NOTIFY.permissionRequest, {
+          sessionId: sid,
+          requestId: asStr(payload.requestId),
+          toolName: asStr(payload.action) || "tool",
+          title: asStr(payload.action) || "Approve action",
+          detail: asStr(payload.message) || short(payload.details),
+          kind: "tool",
+          permissions: [],
+        });
+        break;
+      case GW.chatMessage: {
+        // The final full assistant message. If we already streamed via chat.stream this is a
+        // duplicate (suppress); if the gateway one-shot the answer, THIS is the response.
+        const sender = asStr(payload.sender) || "agent";
+        const content = asStr(payload.content);
+        if (sender === "agent" && !this.streamedThisTurn && content) {
+          this.sessEvent(sid, { type: "agent_message", message: content });
+        }
+        break;
+      }
+      case GW.error:
+        this.opts.logger?.(`[portal] gateway error: ${asStr(gw.error) || JSON.stringify(gw.error)}`);
+        break;
+      default:
+        break; // chat.typing, pong, status, and unknown events are ignored
+    }
+  }
+
+  /** Gateway socket dropped: fail any awaited app calls so the client isn't left hanging. */
+  handleGatewayClose(): void {
+    for (const [, entry] of this.pending) {
+      this.replyErr(entry.appId, -32002, "gateway connection closed");
+    }
+    this.pending.clear();
+  }
+
+  // ---- helpers ----
+
+  private sendGateway(
+    envelope: Record<string, unknown>,
+    pending?: { appId: RpcId; method: string },
+  ): void {
+    if (pending && envelope.id !== undefined && envelope.id !== null) {
+      this.pending.set(String(envelope.id), pending);
+    }
+    this.opts.sendToGateway(envelope);
+  }
+
+  private reply(id: RpcId, result: unknown): void {
+    this.opts.sendToApp({ jsonrpc: "2.0", id, result });
+  }
+  private replyErr(id: RpcId, code: number, message: string): void {
+    this.opts.sendToApp({ jsonrpc: "2.0", id, error: { code, message } });
+  }
+  private notify(method: string, params: Record<string, unknown>): void {
+    this.opts.sendToApp({ jsonrpc: "2.0", method, params });
+  }
+  private sessEvent(sid: string, event: Record<string, unknown>): void {
+    this.notify(NOTIFY.sessionEvent, { sessionId: sid, event });
+  }
+}

--- a/runtime/src/portal/portal-adapter.ts
+++ b/runtime/src/portal/portal-adapter.ts
@@ -165,15 +165,23 @@ export class PortalAdapter {
       }
       case RPC.setPermissionMode: {
         const mode = asStr(params.permissionMode);
-        // A remote client must never be able to relax the approval mode (M3). This denylist must
-        // remain when P3 actually wires setPermissionMode, so the wiring physically can't expose
-        // yolo/bypass to the relay leg.
+        const validModes = ["default", "acceptEdits", "plan", "bypassPermissions"];
+        if (!validModes.includes(mode)) {
+          this.replyErr(id, -32602, `unknown permission mode "${mode}"`);
+          break;
+        }
+        // A remote client must never relax the approval mode (M3). This denylist must remain so the
+        // P3 wiring below physically can't expose yolo/bypass to the relay leg.
         if (this.isRemote && /yolo|bypass|allow|unsafe|auto/i.test(mode)) {
           this.replyErr(id, -32001, `permission mode "${mode}" not allowed from a remote client`);
           break;
         }
-        // P1/P2a: acknowledged but not enforced server-side. P3 wires this to a per-session overlay
-        // on the ApprovalEngine (the elevations/denials precedent) via session.permissionMode.set.
+        // P3: set the daemon's per-session permission mode via the /policy mode command (mode is
+        // validated to one of the four safe values above, so the command string can't be injected).
+        this.sendGateway({
+          type: GW.sessionCommandExecute,
+          payload: { content: `/policy mode ${mode}`, sessionId: this.appSessionId ?? undefined },
+        });
         this.reply(id, { ok: true, permissionMode: mode });
         break;
       }

--- a/runtime/src/portal/portal-connection.ts
+++ b/runtime/src/portal/portal-connection.ts
@@ -1,0 +1,45 @@
+// Shared per-connection wiring used by both transports (the loopback listener and the relay
+// dialer): one PortalAdapter bound to one PortalGatewayClient. Keeps the translation logic in one
+// place so the relay transport is purely about moving frames.
+
+import { PortalAdapter } from "./portal-adapter.js";
+import { PortalGatewayClient } from "./portal-gateway-client.js";
+import type { JsonRpcNotification, JsonRpcResponse } from "./portal-protocol.js";
+
+export interface PortalConnectionOptions {
+  daemonUrl: string;
+  sendToApp: (msg: JsonRpcResponse | JsonRpcNotification) => void;
+  /** Called when the daemon socket drops, so the transport can close its app side. */
+  onGatewayClose: () => void;
+  /** True for the relay/remote transport — enables the adapter's remote scope gate. */
+  isRemote?: boolean;
+  logger?: (msg: string) => void;
+}
+
+export interface PortalConnection {
+  handleAppMessage: (raw: string) => void;
+  close: () => void;
+}
+
+export function createPortalConnection(opts: PortalConnectionOptions): PortalConnection {
+  let adapter: PortalAdapter;
+  const gateway = new PortalGatewayClient({
+    daemonUrl: opts.daemonUrl,
+    onMessage: (m) => adapter.handleGatewayMessage(m),
+    onClose: () => {
+      adapter.handleGatewayClose();
+      opts.onGatewayClose();
+    },
+    onError: (e) => opts.logger?.(`[portal] gateway error: ${e.message}`),
+  });
+  adapter = new PortalAdapter({
+    sendToApp: opts.sendToApp,
+    sendToGateway: (env) => gateway.send(env),
+    isRemote: opts.isRemote,
+    logger: opts.logger,
+  });
+  return {
+    handleAppMessage: (raw) => adapter.handleAppMessage(raw),
+    close: () => gateway.close(),
+  };
+}

--- a/runtime/src/portal/portal-dev-entry.ts
+++ b/runtime/src/portal/portal-dev-entry.ts
@@ -1,0 +1,14 @@
+// Dev smoke entry: run the portal directly (via tsx) against a live daemon, without building the
+// full CLI. The supported entrypoint is `agenc portal serve`; this is only for fast local testing.
+//   PORTAL_PORT=7766 PORTAL_DAEMON_URL=ws://127.0.0.1:9101 tsx portal-dev-entry.ts
+import { startPortalServer } from "./portal-server.js";
+
+const port = Number(process.env.PORTAL_PORT ?? 7766);
+const daemonUrl = process.env.PORTAL_DAEMON_URL ?? "ws://127.0.0.1:9101";
+
+startPortalServer({ port, daemonUrl, logger: (m) => console.log(m) })
+  .then((h) => console.log(`[portal-dev] up on ws://${h.host}:${h.port} -> ${daemonUrl}`))
+  .catch((e) => {
+    console.error("[portal-dev] failed to start:", e);
+    process.exit(1);
+  });

--- a/runtime/src/portal/portal-dev-entry.ts
+++ b/runtime/src/portal/portal-dev-entry.ts
@@ -1,14 +1,23 @@
 // Dev smoke entry: run the portal directly (via tsx) against a live daemon, without building the
 // full CLI. The supported entrypoint is `agenc portal serve`; this is only for fast local testing.
-//   PORTAL_PORT=7766 PORTAL_DAEMON_URL=ws://127.0.0.1:9101 tsx portal-dev-entry.ts
+//   loopback: PORTAL_PORT=7766 PORTAL_DAEMON_URL=ws://127.0.0.1:9101 tsx portal-dev-entry.ts
+//   relay:    RELAY_URL=wss://… ACCT=acct-smoke-1 PORTAL_DAEMON_URL=ws://127.0.0.1:9101 tsx portal-dev-entry.ts
 import { startPortalServer } from "./portal-server.js";
+import { startPortalRelayClient } from "./portal-relay-client.js";
 
-const port = Number(process.env.PORTAL_PORT ?? 7766);
 const daemonUrl = process.env.PORTAL_DAEMON_URL ?? "ws://127.0.0.1:9101";
 
-startPortalServer({ port, daemonUrl, logger: (m) => console.log(m) })
-  .then((h) => console.log(`[portal-dev] up on ws://${h.host}:${h.port} -> ${daemonUrl}`))
-  .catch((e) => {
-    console.error("[portal-dev] failed to start:", e);
-    process.exit(1);
-  });
+if (process.env.RELAY_URL) {
+  const account = process.env.ACCT ?? "acct-smoke-1";
+  const ticket = process.env.TICKET ?? `dev:${account}:host:mac-dev`;
+  startPortalRelayClient({ relayUrl: process.env.RELAY_URL, ticket, daemonUrl, logger: (m) => console.log(m) });
+  console.log(`[portal-dev] relay mode -> ${process.env.RELAY_URL} (ticket ${ticket}) -> ${daemonUrl}`);
+} else {
+  const port = Number(process.env.PORTAL_PORT ?? 7766);
+  startPortalServer({ port, daemonUrl, logger: (m) => console.log(m) })
+    .then((h) => console.log(`[portal-dev] up on ws://${h.host}:${h.port} -> ${daemonUrl}`))
+    .catch((e) => {
+      console.error("[portal-dev] failed to start:", e);
+      process.exit(1);
+    });
+}

--- a/runtime/src/portal/portal-gateway-client.ts
+++ b/runtime/src/portal/portal-gateway-client.ts
@@ -1,0 +1,70 @@
+// One loopback WebSocket client to the daemon gateway per app connection. The gateway routes
+// server-initiated pushes (chat.stream, approval.request, owner pushes) through a connection-bound
+// sink, so the portal must hold a real per-connection socket — it cannot consume the handler
+// in-process. Loopback connections auto-authenticate (gateway.ts), so no auth frame is needed here;
+// the remote/relay leg (P2) presents a token instead.
+
+import WebSocket from "ws";
+import type { GatewayEnvelope } from "./portal-protocol.js";
+
+export interface PortalGatewayClientOptions {
+  daemonUrl: string;
+  onMessage: (msg: GatewayEnvelope) => void;
+  onClose: () => void;
+  onOpen?: () => void;
+  onError?: (err: Error) => void;
+}
+
+export class PortalGatewayClient {
+  private readonly ws: WebSocket;
+  private readonly queue: string[] = [];
+  private open = false;
+  private closed = false;
+
+  constructor(private readonly opts: PortalGatewayClientOptions) {
+    this.ws = new WebSocket(opts.daemonUrl);
+    this.ws.on("open", () => {
+      this.open = true;
+      for (const m of this.queue) this.ws.send(m);
+      this.queue.length = 0;
+      this.opts.onOpen?.();
+    });
+    this.ws.on("message", (data: WebSocket.RawData) => {
+      let parsed: GatewayEnvelope;
+      try {
+        parsed = JSON.parse(data.toString()) as GatewayEnvelope;
+      } catch {
+        return;
+      }
+      this.opts.onMessage(parsed);
+    });
+    this.ws.on("close", () => {
+      this.closed = true;
+      this.open = false;
+      this.opts.onClose();
+    });
+    this.ws.on("error", (err: Error) => {
+      this.opts.onError?.(err);
+    });
+  }
+
+  /** Send a `{type,...}` envelope to the gateway; queues until the socket opens. */
+  send(envelope: Record<string, unknown>): void {
+    if (this.closed) return;
+    const s = JSON.stringify(envelope);
+    if (this.open && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(s);
+    } else {
+      this.queue.push(s);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    try {
+      this.ws.close();
+    } catch {
+      /* already closing */
+    }
+  }
+}

--- a/runtime/src/portal/portal-protocol.ts
+++ b/runtime/src/portal/portal-protocol.ts
@@ -1,0 +1,130 @@
+// Portal protocol: the JSON-RPC 2.0 surface the AgenC iOS app speaks, plus the gateway
+// `{type,...}` message names it is translated to/from. The gateway names mirror
+// `channels/webchat/protocol.ts` (the WebChat catalog) and are validated end-to-end against the
+// running daemon by the existing relay translators. P4: import these directly from the WebChat
+// protocol module / auto-generate, instead of re-declaring, to remove drift.
+
+export const PORTAL_PROTOCOL_VERSION = "1.0.0" as const;
+
+/** Default loopback bind for the portal's inbound JSON-RPC listener (matches the dev translator). */
+export const PORTAL_DEFAULT_HOST = "127.0.0.1" as const;
+export const PORTAL_DEFAULT_PORT = 7766 as const;
+
+/** Default daemon gateway endpoint the portal dials out to as a loopback client. */
+export const PORTAL_DEFAULT_DAEMON_URL = "ws://127.0.0.1:9101" as const;
+
+/** Gateway WebChat `{type}` message names (inbound to / outbound from the daemon gateway). */
+export const GW = {
+  ping: "ping",
+  pong: "pong",
+  configGet: "config.get",
+  chatMessage: "chat.message",
+  chatStream: "chat.stream",
+  chatResponse: "chat.response",
+  chatTyping: "chat.typing",
+  chatHistory: "chat.history",
+  chatSession: "chat.session",
+  chatSessionList: "chat.session.list",
+  chatSessionResume: "chat.session.resume",
+  chatUsage: "chat.usage",
+  agentStatus: "agent.status",
+  toolsExecuting: "tools.executing",
+  toolsResult: "tools.result",
+  approvalRequest: "approval.request",
+  approvalRespond: "approval.respond",
+  sessionCommandExecute: "session.command.execute",
+  turnComplete: "turn.complete", // emitted by the daemon turn-wrapper finally (idempotent, turn-id-stamped)
+  status: "status",
+  error: "error",
+} as const;
+
+/** JSON-RPC methods the app may call. */
+export const RPC = {
+  initialize: "initialize",
+  healthPing: "health.ping",
+  sessionList: "session.list",
+  sessionAttach: "session.attach",
+  messageSend: "message.send",
+  messageStream: "message.stream",
+  toolApprove: "tool.approve",
+  toolDeny: "tool.deny",
+  setPermissionMode: "session.setPermissionMode",
+  agentList: "agent.list",
+  daemonInfo: "daemon.info",
+} as const;
+
+export const APP_METHODS: readonly string[] = [
+  RPC.initialize,
+  RPC.healthPing,
+  RPC.sessionList,
+  RPC.sessionAttach,
+  RPC.messageStream,
+  RPC.toolApprove,
+  RPC.toolDeny,
+  RPC.setPermissionMode,
+  RPC.agentList,
+  RPC.daemonInfo,
+];
+
+/** JSON-RPC notification methods the portal pushes to the app (the app's PortalEventAdapter shape). */
+export const NOTIFY = {
+  messageChunk: "event.message_chunk",
+  sessionEvent: "event.session_event",
+  toolRequest: "event.tool_request",
+  permissionRequest: "event.permission_request",
+} as const;
+
+/** Structured JSON-RPC error codes (G8): a stable map instead of the gateway's free-form strings. */
+export const PORTAL_ERROR = {
+  parse: -32700,
+  invalidRequest: -32600,
+  methodNotFound: -32601,
+  internal: -32603,
+  gateway: -32000,
+  unauthorized: -32001,
+  gatewayClosed: -32002,
+} as const;
+
+/** Map a free-form gateway error string to a structured JSON-RPC error code (G8). */
+export function mapGatewayError(message: string): number {
+  const m = message.toLowerCase();
+  if (m.includes("authentic") || m.includes("expired token") || m.includes("unauthorized")) {
+    return PORTAL_ERROR.unauthorized;
+  }
+  if (m.includes("unknown message type") || m.includes("invalid")) {
+    return PORTAL_ERROR.invalidRequest;
+  }
+  return PORTAL_ERROR.gateway;
+}
+
+// ---- JSON-RPC wire types ----
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** A gateway `{type, payload, id?}` envelope. */
+export interface GatewayEnvelope {
+  type?: string;
+  id?: string | number;
+  payload?: unknown;
+  error?: unknown;
+  sender?: string;
+  content?: string;
+}

--- a/runtime/src/portal/portal-relay-client.ts
+++ b/runtime/src/portal/portal-relay-client.ts
@@ -1,0 +1,186 @@
+// The portal's RELAY transport (P2a). Instead of listening locally, the portal dials OUT to a
+// Cloudflare Durable-Object relay room and serves app connections multiplexed by connection id
+// (cid). Each cid gets its own PortalConnection (adapter + loopback daemon socket). This is the
+// in-core replacement for connector/connector-real.mjs, letting a physical phone reach a local
+// daemon through the relay. Auth to the relay is the host ticket (P2a: a `dev:<account>:host:...`
+// shared-secret ticket; P2b swaps in per-device id.agenc.ag tokens via resolveTicket()).
+
+import WebSocket from "ws";
+import { createPortalConnection, type PortalConnection } from "./portal-connection.js";
+import { PORTAL_DEFAULT_DAEMON_URL } from "./portal-protocol.js";
+
+export interface PortalRelayClientOptions {
+  relayUrl: string; // must be wss:// (ws:// only allowed to loopback)
+  /** Host ticket presented to the relay. P2a: `dev:<account>:host:<machine>`. */
+  ticket: string;
+  daemonUrl?: string;
+  logger?: (msg: string) => void;
+  reconnectDelayMs?: number;
+  keepaliveMs?: number;
+  /** Cap on concurrent remote connections (one daemon socket each) to bound resource use (M5). */
+  maxPeers?: number;
+}
+
+export interface PortalRelayHandle {
+  close: () => void;
+}
+
+interface RelayFrame {
+  t?: string;
+  cid?: string;
+  event?: string;
+  payload?: string;
+}
+
+/** Require TLS to the relay; allow cleartext only to loopback for local dev (M6). */
+function isSecureRelayUrl(url: string): boolean {
+  if (url.startsWith("wss://")) return true;
+  return /^ws:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/.test(url);
+}
+
+export function startPortalRelayClient(
+  options: PortalRelayClientOptions,
+): PortalRelayHandle {
+  if (!isSecureRelayUrl(options.relayUrl)) {
+    throw new Error(
+      `portal relay requires a wss:// URL (got "${options.relayUrl}"); ws:// is only allowed to loopback`,
+    );
+  }
+  const daemonUrl = options.daemonUrl ?? PORTAL_DEFAULT_DAEMON_URL;
+  const log = options.logger ?? ((): void => {});
+  const reconnectDelayMs = options.reconnectDelayMs ?? 2000;
+  const keepaliveMs = options.keepaliveMs ?? 25000;
+  const maxPeers = options.maxPeers ?? 32;
+  const hostUrl = `${options.relayUrl}/v1/host?ticket=${encodeURIComponent(options.ticket)}`;
+
+  const peers = new Map<string, PortalConnection>();
+  let relay: WebSocket | null = null;
+  let keepalive: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+
+  function sendToRelay(cid: string, msg: unknown): void {
+    try {
+      relay?.send(JSON.stringify({ t: "data", cid, payload: JSON.stringify(msg) }));
+    } catch {
+      /* relay closing */
+    }
+  }
+
+  function openPeer(cid: string): PortalConnection {
+    const existing = peers.get(cid);
+    if (existing) return existing;
+    const conn = createPortalConnection({
+      daemonUrl,
+      isRemote: true, // activates the adapter's remote scope gate (M1/M2/M3)
+      logger: log,
+      sendToApp: (msg) => sendToRelay(cid, msg),
+      onGatewayClose: () => {
+        peers.delete(cid);
+        try {
+          relay?.send(JSON.stringify({ t: "peer", cid, event: "close" }));
+        } catch {
+          /* relay closing */
+        }
+      },
+    });
+    peers.set(cid, conn);
+    return conn;
+  }
+
+  function closePeer(cid: string): void {
+    const conn = peers.get(cid);
+    if (conn) {
+      conn.close();
+      peers.delete(cid);
+    }
+  }
+
+  function teardownAllPeers(): void {
+    for (const conn of peers.values()) conn.close();
+    peers.clear();
+  }
+
+  function connect(): void {
+    if (closed) return;
+    relay = new WebSocket(hostUrl);
+
+    relay.on("open", () => {
+      log(`[portal-relay] host channel open -> ${options.relayUrl} -> daemon ${daemonUrl}`);
+      if (keepalive) clearInterval(keepalive);
+      // Keep the host channel warm so the Cloudflare DO doesn't idle-close it.
+      keepalive = setInterval(() => {
+        try {
+          relay?.send(JSON.stringify({ t: "ping" }));
+        } catch {
+          /* a dropped send surfaces via the close handler */
+        }
+      }, keepaliveMs);
+    });
+
+    relay.on("message", (data: WebSocket.RawData) => {
+      let frame: RelayFrame;
+      try {
+        frame = JSON.parse(data.toString()) as RelayFrame;
+      } catch {
+        return;
+      }
+      if (frame.t === "peer" && typeof frame.cid === "string") {
+        if (frame.event === "open") {
+          if (peers.size >= maxPeers) {
+            // Bound resource use: each peer opens a daemon socket (M5). Reject overflow.
+            log(`[portal-relay] peer cap ${maxPeers} reached — rejecting ${frame.cid}`);
+            try {
+              relay?.send(JSON.stringify({ t: "peer", cid: frame.cid, event: "close" }));
+            } catch {
+              /* relay closing */
+            }
+          } else {
+            openPeer(frame.cid);
+            log(`[portal-relay] phone ${frame.cid} connected (${peers.size} active)`);
+          }
+        } else if (frame.event === "close") {
+          closePeer(frame.cid);
+        }
+      } else if (
+        frame.t === "data" &&
+        typeof frame.cid === "string" &&
+        typeof frame.payload === "string"
+      ) {
+        // Only serve cids that completed a peer-open handshake — never lazily spawn a daemon socket
+        // from a data frame for an unknown cid (M5).
+        peers.get(frame.cid)?.handleAppMessage(frame.payload);
+      }
+      // {t:"welcome"}, {t:"pong"}, and anything else are ignored.
+    });
+
+    relay.on("close", () => {
+      if (keepalive) {
+        clearInterval(keepalive);
+        keepalive = null;
+      }
+      // The relay closes all clients when the host drops, so reset every peer and re-dial.
+      teardownAllPeers();
+      if (!closed) {
+        log(`[portal-relay] relay closed — reconnecting in ${reconnectDelayMs}ms`);
+        setTimeout(connect, reconnectDelayMs);
+      }
+    });
+
+    relay.on("error", (err: Error) => log(`[portal-relay] relay error: ${err.message}`));
+  }
+
+  connect();
+
+  return {
+    close: () => {
+      closed = true;
+      if (keepalive) clearInterval(keepalive);
+      teardownAllPeers();
+      try {
+        relay?.close();
+      } catch {
+        /* already closing */
+      }
+    },
+  };
+}

--- a/runtime/src/portal/portal-relay-client.ts
+++ b/runtime/src/portal/portal-relay-client.ts
@@ -11,8 +11,9 @@ import { PORTAL_DEFAULT_DAEMON_URL } from "./portal-protocol.js";
 
 export interface PortalRelayClientOptions {
   relayUrl: string; // must be wss:// (ws:// only allowed to loopback)
-  /** Host ticket presented to the relay. P2a: `dev:<account>:host:<machine>`. */
-  ticket: string;
+  /** Host ticket presented to the relay — a string, or a provider re-invoked on every (re)connect
+   *  so a short-lived signed ticket is freshly minted and never expires mid-session (token refresh). */
+  ticket: string | (() => string | Promise<string>);
   daemonUrl?: string;
   logger?: (msg: string) => void;
   reconnectDelayMs?: number;
@@ -51,7 +52,6 @@ export function startPortalRelayClient(
   const reconnectDelayMs = options.reconnectDelayMs ?? 2000;
   const keepaliveMs = options.keepaliveMs ?? 25000;
   const maxPeers = options.maxPeers ?? 32;
-  const hostUrl = `${options.relayUrl}/v1/host?ticket=${encodeURIComponent(options.ticket)}`;
 
   const peers = new Map<string, PortalConnection>();
   let relay: WebSocket | null = null;
@@ -100,8 +100,17 @@ export function startPortalRelayClient(
     peers.clear();
   }
 
-  function connect(): void {
+  async function connect(): Promise<void> {
     if (closed) return;
+    let ticket: string;
+    try {
+      ticket = typeof options.ticket === "function" ? await options.ticket() : options.ticket;
+    } catch (e) {
+      log(`[portal-relay] could not mint ticket: ${(e as Error).message}; retrying in ${reconnectDelayMs}ms`);
+      if (!closed) setTimeout(() => void connect(), reconnectDelayMs);
+      return;
+    }
+    const hostUrl = `${options.relayUrl}/v1/host?ticket=${encodeURIComponent(ticket)}`;
     relay = new WebSocket(hostUrl);
 
     relay.on("open", () => {
@@ -162,14 +171,14 @@ export function startPortalRelayClient(
       teardownAllPeers();
       if (!closed) {
         log(`[portal-relay] relay closed — reconnecting in ${reconnectDelayMs}ms`);
-        setTimeout(connect, reconnectDelayMs);
+        setTimeout(() => void connect(), reconnectDelayMs);
       }
     });
 
     relay.on("error", (err: Error) => log(`[portal-relay] relay error: ${err.message}`));
   }
 
-  connect();
+  void connect();
 
   return {
     close: () => {

--- a/runtime/src/portal/portal-server.ts
+++ b/runtime/src/portal/portal-server.ts
@@ -1,17 +1,14 @@
-// The portal's inbound transport (P1: loopback). A WebSocket server the AgenC iOS app connects to;
-// each app connection gets its own PortalAdapter + one loopback PortalGatewayClient to the daemon.
-// This is the in-core replacement for connector/local-translator.mjs. The relay/remote transport
-// (P2) reuses the adapter behind an outbound relay-client dialer instead of this listener.
+// The portal's inbound LOOPBACK transport (P1). A WebSocket server the AgenC iOS app connects to
+// directly; each app connection gets its own PortalConnection (adapter + daemon socket). This is
+// the in-core replacement for connector/local-translator.mjs. The relay/remote transport (P2) lives
+// in portal-relay-client.ts and reuses the same PortalConnection.
 
 import WebSocket, { WebSocketServer } from "ws";
-import { PortalAdapter } from "./portal-adapter.js";
-import { PortalGatewayClient } from "./portal-gateway-client.js";
+import { createPortalConnection } from "./portal-connection.js";
 import {
   PORTAL_DEFAULT_DAEMON_URL,
   PORTAL_DEFAULT_HOST,
   PORTAL_DEFAULT_PORT,
-  type JsonRpcNotification,
-  type JsonRpcResponse,
 } from "./portal-protocol.js";
 
 export interface PortalServerOptions {
@@ -59,38 +56,29 @@ export function startPortalServer(
         return;
       }
 
-      const sendToApp = (msg: JsonRpcResponse | JsonRpcNotification): void => {
-        try {
-          if (app.readyState === WebSocket.OPEN) app.send(JSON.stringify(msg));
-        } catch {
-          /* socket closing */
-        }
-      };
-
-      let adapter: PortalAdapter;
-      const gateway = new PortalGatewayClient({
+      const conn = createPortalConnection({
         daemonUrl,
-        onMessage: (m) => adapter.handleGatewayMessage(m),
-        onClose: () => {
-          adapter.handleGatewayClose();
+        logger: log,
+        sendToApp: (msg) => {
+          try {
+            if (app.readyState === WebSocket.OPEN) app.send(JSON.stringify(msg));
+          } catch {
+            /* socket closing */
+          }
+        },
+        onGatewayClose: () => {
           try {
             app.close();
           } catch {
             /* already closed */
           }
         },
-        onError: (e) => log(`[portal] gateway error: ${e.message}`),
-      });
-      adapter = new PortalAdapter({
-        sendToApp,
-        sendToGateway: (env) => gateway.send(env),
-        logger: log,
       });
 
-      app.on("message", (data: WebSocket.RawData) => adapter.handleAppMessage(data.toString()));
-      app.on("close", () => gateway.close());
+      app.on("message", (data: WebSocket.RawData) => conn.handleAppMessage(data.toString()));
+      app.on("close", () => conn.close());
       app.on("error", () => {
-        /* ignore; close handler cleans up */
+        /* close handler cleans up */
       });
       log("[portal] app connected");
     });

--- a/runtime/src/portal/portal-server.ts
+++ b/runtime/src/portal/portal-server.ts
@@ -1,0 +1,98 @@
+// The portal's inbound transport (P1: loopback). A WebSocket server the AgenC iOS app connects to;
+// each app connection gets its own PortalAdapter + one loopback PortalGatewayClient to the daemon.
+// This is the in-core replacement for connector/local-translator.mjs. The relay/remote transport
+// (P2) reuses the adapter behind an outbound relay-client dialer instead of this listener.
+
+import WebSocket, { WebSocketServer } from "ws";
+import { PortalAdapter } from "./portal-adapter.js";
+import { PortalGatewayClient } from "./portal-gateway-client.js";
+import {
+  PORTAL_DEFAULT_DAEMON_URL,
+  PORTAL_DEFAULT_HOST,
+  PORTAL_DEFAULT_PORT,
+  type JsonRpcNotification,
+  type JsonRpcResponse,
+} from "./portal-protocol.js";
+
+export interface PortalServerOptions {
+  host?: string;
+  port?: number;
+  daemonUrl?: string;
+  logger?: (msg: string) => void;
+}
+
+export interface PortalServerHandle {
+  host: string;
+  port: number;
+  close: () => Promise<void>;
+}
+
+export function startPortalServer(
+  options: PortalServerOptions = {},
+): Promise<PortalServerHandle> {
+  const host = options.host ?? PORTAL_DEFAULT_HOST;
+  const port = options.port ?? PORTAL_DEFAULT_PORT;
+  const daemonUrl = options.daemonUrl ?? PORTAL_DEFAULT_DAEMON_URL;
+  const log = options.logger ?? ((): void => {});
+
+  return new Promise((resolve, reject) => {
+    const wss = new WebSocketServer({ host, port });
+
+    wss.on("listening", () => {
+      log(`[portal] listening ws://${host}:${port} -> daemon ${daemonUrl}`);
+      resolve({
+        host,
+        port,
+        close: () => new Promise<void>((res) => wss.close(() => res())),
+      });
+    });
+
+    wss.on("error", (err: Error) => reject(err));
+
+    wss.on("connection", (app: WebSocket, req) => {
+      // Origin allowlist: a native app sends no Origin header; reject any browser Origin so a
+      // malicious page can't reach the loopback bridge.
+      const origin = req.headers.origin;
+      if (typeof origin === "string" && origin.length > 0) {
+        log(`[portal] rejecting connection with Origin: ${origin}`);
+        app.close(1008, "origin not allowed");
+        return;
+      }
+
+      const sendToApp = (msg: JsonRpcResponse | JsonRpcNotification): void => {
+        try {
+          if (app.readyState === WebSocket.OPEN) app.send(JSON.stringify(msg));
+        } catch {
+          /* socket closing */
+        }
+      };
+
+      let adapter: PortalAdapter;
+      const gateway = new PortalGatewayClient({
+        daemonUrl,
+        onMessage: (m) => adapter.handleGatewayMessage(m),
+        onClose: () => {
+          adapter.handleGatewayClose();
+          try {
+            app.close();
+          } catch {
+            /* already closed */
+          }
+        },
+        onError: (e) => log(`[portal] gateway error: ${e.message}`),
+      });
+      adapter = new PortalAdapter({
+        sendToApp,
+        sendToGateway: (env) => gateway.send(env),
+        logger: log,
+      });
+
+      app.on("message", (data: WebSocket.RawData) => adapter.handleAppMessage(data.toString()));
+      app.on("close", () => gateway.close());
+      app.on("error", () => {
+        /* ignore; close handler cleans up */
+      });
+      log("[portal] app connected");
+    });
+  });
+}

--- a/runtime/src/portal/portal-ticket.ts
+++ b/runtime/src/portal/portal-ticket.ts
@@ -1,0 +1,36 @@
+// Signs relay tickets the relay verifies (P2b). HMAC-SHA256 hex over "<accountId>:<role>:<exp>:
+// <hostId>", emitted as s1:<accountId>:<role>:<exp>:<hostId>:<sig>. Node createHmac produces the
+// exact same hex as the relay's WebCrypto hmacHex, so a portal-signed ticket verifies on the relay.
+// The shared secret lives in AGENC_RELAY_TICKET_SECRET (set alongside the relay's wrangler secret);
+// the phone never holds it — it receives a pre-signed client ticket via `agenc portal pair`.
+import { createHmac } from "node:crypto";
+
+export type RelayRole = "host" | "client";
+
+export interface SignRelayTicketOptions {
+  secret: string;
+  accountId: string;
+  role: RelayRole;
+  ttlMs?: number;
+  hostId?: string;
+  now?: number;
+}
+
+/** Fields are colon-delimited in the signed message, so they must be colon-free (and we keep them to
+ *  a safe charset). A ":" in accountId/hostId would shift the signed fields and mis-key the room. */
+const SAFE_FIELD = /^[A-Za-z0-9._-]+$/;
+
+export function signRelayTicket(opts: SignRelayTicketOptions): string {
+  if (!SAFE_FIELD.test(opts.accountId)) {
+    throw new Error(`invalid accountId "${opts.accountId}" — allowed characters: A-Za-z0-9._-`);
+  }
+  if (opts.hostId !== undefined && opts.hostId.length > 0 && !SAFE_FIELD.test(opts.hostId)) {
+    throw new Error(`invalid hostId "${opts.hostId}" — allowed characters: A-Za-z0-9._-`);
+  }
+  const exp = (opts.now ?? Date.now()) + (opts.ttlMs ?? 3_600_000);
+  const hostId = opts.hostId ?? "";
+  const sig = createHmac("sha256", opts.secret)
+    .update(`${opts.accountId}:${opts.role}:${exp}:${hostId}`)
+    .digest("hex");
+  return `s1:${opts.accountId}:${opts.role}:${exp}:${hostId}:${sig}`;
+}


### PR DESCRIPTION
Replaces the two external relay translators (`local-translator.mjs` / `connector-real.mjs`) with a first-class, in-core `agenc portal serve` bridge, so the AgenC iOS app drives the daemon gateway through agenc-core's own code.

## Phases (4 commits)
- **P1** `5f5c9b3d` — `PortalAdapter` (JSON-RPC 2.0 ⇄ WebChat `{type}`) as a loopback gateway client; `agenc portal serve`; a guaranteed, turn-id-stamped `turn.complete` emitted from the turn-wrapper `finally`.
- **P2a** `84a0e596` — relay transport (replaces `connector-real.mjs`) + the **remote scope gate** (a remote client can't self-approve privileged shell/wallet/destructive tools).
- **P3** `79a847a7` — per-session permission mode (plan/acceptEdits/bypassPermissions) as an additive overlay on the approval engine; fail-closed bypass allowlist.
- **P2b** `03a090e2` — HMAC-signed, time-bounded relay tickets (closes the host-forgery/MITM hole); host signs + re-signs on reconnect; `agenc portal pair` mints client tickets.

## Why this PR
The full `npm run build:private-kernel` couldn't run in my local environment (incomplete private-dependency closure — registry 404 on `@tetsuo-ai/protocol@0.2.0`, missing `chromium-bidi`). **This PR exists to run that build in CI, where the private packages resolve** (and as a review surface).

## Validation done locally
- Whole-project `tsc --noEmit` clean (only 2 pre-existing, unrelated marketplace-kit errors).
- Standalone esbuild bundles of the portal subsystem.
- Unit suites: approval-mode gate 7/7, permission-mode matrix 22/22, relay-ticket verify 10/10, portal↔relay HMAC interop 4/4.
- **End-to-end on a physical iPhone** (P1+P2a): a live conversation through the in-core portal, no external translator.

## Adversarial review per security phase (each caught a real hole, fixed before commit)
P2a remote self-approval · P3 incomplete bypass denylist · P2b `RELAY_DEV_MODE` deploy-default bypass. Review docs live in the `agenc-relay` repo.

## Deferred (not in this PR)
- `daemon.test.ts` isn't wired into any CI workflow — the P3 engine + `turn.complete` runtime behavior need a manual `npx vitest run` on a dev machine with the registry.
- Real per-device identity + revocation (id.agenc.ag); the iOS app pairing UI to consume `agenc portal pair`.
- The relay-side signed-ticket verification lives in the separate `agenc-relay` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
