### PR TITLE
feat(daemon): adaptive per-tool drain timeouts (goal #4a)

### DIFF
--- a/runtime/src/bin/bootstrap-services.ts
+++ b/runtime/src/bin/bootstrap-services.ts
@@ -43,6 +43,10 @@ import {
   createCodeModeService,
 } from "../tools/code-mode/service.js";
 import type { CodeModeService } from "../tools/code-mode/types.js";
+import {
+  ToolLatencyStore,
+  type ToolLatencyConfig,
+} from "../tools/tool-latency-store.js";
 import { initMagicDocs } from "../services/MagicDocs/magicDocs.js";
 import { configurePolicyLimitsService } from "../services/policyLimits/index.js";
 import type { RolloutItem } from "../session/rollout-item.js";
@@ -593,6 +597,47 @@ function createSessionTelemetry(opts: {
   } as SessionTelemetry;
 }
 
+/**
+ * Resolve the adaptive per-tool drain-timeout latency-store config (Goal #4a)
+ * from env. Each knob follows the `AGENC_MAX_TOOL_DRAIN_MS` precedent:
+ * a parseable, in-range positive value overrides the default; anything
+ * invalid (NaN, non-positive, out-of-range probability) falls back to the
+ * `ToolLatencyStore` default. Only knobs that are explicitly set are returned,
+ * so unset env leaves the store on `DEFAULT_TOOL_LATENCY_CONFIG`.
+ */
+function resolveToolLatencyConfig(
+  env: NodeJS.ProcessEnv,
+): Partial<ToolLatencyConfig> {
+  const cfg: { -readonly [K in keyof ToolLatencyConfig]?: number } = {};
+  const intKnob = (raw: string | undefined): number | undefined => {
+    if (raw === undefined) return undefined;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n <= 0) return undefined;
+    return n;
+  };
+  const probKnob = (raw: string | undefined): number | undefined => {
+    if (raw === undefined) return undefined;
+    const n = Number.parseFloat(raw);
+    if (!Number.isFinite(n) || n <= 0 || n >= 1) return undefined;
+    return n;
+  };
+  const floatKnob = (raw: string | undefined): number | undefined => {
+    if (raw === undefined) return undefined;
+    const n = Number.parseFloat(raw);
+    if (!Number.isFinite(n) || n <= 0) return undefined;
+    return n;
+  };
+  const minSamples = intKnob(env.AGENC_DRAIN_MIN_SAMPLES);
+  if (minSamples !== undefined) cfg.minSamples = minSamples;
+  const ringCap = intKnob(env.AGENC_DRAIN_RING_CAP);
+  if (ringCap !== undefined) cfg.ringCap = ringCap;
+  const percentile = probKnob(env.AGENC_DRAIN_PERCENTILE);
+  if (percentile !== undefined) cfg.percentile = percentile;
+  const kSigma = floatKnob(env.AGENC_DRAIN_K_SIGMA);
+  if (kSigma !== undefined) cfg.kSigma = kSigma;
+  return cfg;
+}
+
 export function buildBootstrapSessionServices(
   opts: BootstrapSessionServicesOptions,
 ): BootstrapSessionServicesHandle {
@@ -717,6 +762,7 @@ export function buildBootstrapSessionServices(
       providerName: opts.providerName,
       conversationId: opts.conversationId,
     }),
+    toolLatencyStore: new ToolLatencyStore(resolveToolLatencyConfig(opts.env)),
     modelsManager: opts.modelsManager,
     toolApprovals: {
       hasApproval: (key: string) => opts.toolApprovals.get(key) !== undefined,

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -153,6 +153,7 @@ import type { RunTurnOptions, Terminal } from "./run-turn.js";
 import { runWithCurrentRuntimeSession } from "./current-session.js";
 import type { UnifiedExecProcessManagerLike } from "../unified-exec/types.js";
 import type { CodeModeService } from "../tools/code-mode/types.js";
+import type { ToolLatencyStore } from "../tools/tool-latency-store.js";
 import type { PolicyLimitsService } from "../services/policyLimits/index.js";
 import type { AgentStatus as RuntimeAgentStatus } from "../agents/status.js";
 import type {
@@ -821,6 +822,13 @@ export interface SessionServices {
   readonly costSidecar?: CostSidecar;
   readonly hooksRuntime?: ConfiguredHooksRuntime;
   readonly policyLimits?: PolicyLimitsService;
+  /**
+   * Adaptive per-tool drain-timeout latency store (Goal #4a). In-memory,
+   * session-scoped. Optional so minimal/test SessionServices literals need not
+   * supply one; the streaming executor falls through to the flat drain
+   * deadline (and the recording site is a no-op) when this is absent.
+   */
+  readonly toolLatencyStore?: ToolLatencyStore;
 }
 
 /**

--- a/runtime/src/tools/streaming-executor.ts
+++ b/runtime/src/tools/streaming-executor.ts
@@ -237,6 +237,52 @@ function normalizeMaxToolDrainMs(value: number | undefined): number {
   return DEFAULT_MAX_TOOL_DRAIN_MS;
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Adaptive drain-deadline knobs (Goal #4a). All follow the
+// `normalizeMaxToolDrainMs` precedent: explicit constructor option →
+// `AGENC_*` env override → default; invalid input falls back to the default.
+// Off-by-default for the first ship (`AGENC_ADAPTIVE_DRAIN` unset == OFF), so
+// the deadline is byte-identical to today while the store warms up silently.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Master enable; OFF unless explicitly opted in. Default false. */
+const DEFAULT_ADAPTIVE_DRAIN_ENABLED = false;
+/** `candidate = estimate * margin + grace`. Default 1.5. */
+const DEFAULT_ADAPTIVE_DRAIN_MARGIN_MULT = 1.5;
+/** Absolute hard floor; `lo = max(own + grace, this)`. Default 30s. */
+const DEFAULT_ADAPTIVE_DRAIN_SAFE_MIN_MS = 30_000;
+/** Runaway-raise ceiling; `hi = max(maxDrain, own + grace) * this`. Default 4. */
+const DEFAULT_ADAPTIVE_DRAIN_RAISE_CAP = 4;
+
+function normalizeAdaptiveDrainEnabled(value: boolean | undefined): boolean {
+  if (value !== undefined) return value;
+  const raw = process.env.AGENC_ADAPTIVE_DRAIN;
+  if (raw === undefined) return DEFAULT_ADAPTIVE_DRAIN_ENABLED;
+  const t = raw.trim().toLowerCase();
+  if (t === "1" || t === "true" || t === "yes" || t === "on") return true;
+  if (t === "0" || t === "false" || t === "no" || t === "off" || t === "") {
+    return false;
+  }
+  return DEFAULT_ADAPTIVE_DRAIN_ENABLED;
+}
+
+function normalizePositiveNumber(
+  value: number | undefined,
+  envRaw: string | undefined,
+  fallback: number,
+): number {
+  if (value !== undefined) {
+    if (!Number.isFinite(value) || value <= 0) return fallback;
+    return value;
+  }
+  if (envRaw !== undefined) {
+    const n = Number.parseFloat(envRaw);
+    if (!Number.isFinite(n) || n <= 0) return fallback;
+    return n;
+  }
+  return fallback;
+}
+
 /**
  * Reason string fired on a wedged tool's per-tool `drainCancel` when the drain
  * backstop force-finalizes it. Chosen so the EXISTING mapper resolves it to the
@@ -284,6 +330,21 @@ export interface StreamingToolExecutorOptions {
    * never affected; only a genuinely stuck tool trips it.
    */
   readonly maxToolDrainMs?: number;
+  /**
+   * Adaptive per-tool drain deadline (Goal #4a). When enabled, the drain
+   * deadline for a finite-own, locally-defined tool is derived from the
+   * session's `ToolLatencyStore` tail estimate (clamped to never drop below
+   * `own + DRAIN_GRACE_MS` / `adaptiveDrainSafeMinMs`). Default OFF: the
+   * deadline is byte-identical to today's flat formula. Mirrors env
+   * `AGENC_ADAPTIVE_DRAIN`.
+   */
+  readonly adaptiveDrainEnabled?: boolean;
+  /** `candidate = estimate * this + grace`. Default 1.5 / `AGENC_DRAIN_MARGIN_MULT`. */
+  readonly adaptiveDrainMarginMult?: number;
+  /** Absolute hard floor; `lo = max(own + grace, this)`. Default 30000 / `AGENC_DRAIN_SAFE_MIN_MS`. */
+  readonly adaptiveDrainSafeMinMs?: number;
+  /** Runaway-raise ceiling multiplier. Default 4 / `AGENC_DRAIN_RAISE_CAP`. */
+  readonly adaptiveDrainRaiseCap?: number;
   /** Session-scoped AbortSignal (user Ctrl+C, provider switch). */
   readonly abortSignal?: AbortSignal;
   /**
@@ -347,6 +408,11 @@ export class StreamingToolExecutor {
   private readonly onProgress?: (event: ProgressEvent) => void;
   private readonly maxConcurrency: number;
   private readonly maxToolDrainMs: number;
+  /** Goal #4a adaptive drain knobs (resolved once at construction). */
+  private readonly adaptiveDrainEnabled: boolean;
+  private readonly adaptiveDrainMarginMult: number;
+  private readonly adaptiveDrainSafeMinMs: number;
+  private readonly adaptiveDrainRaiseCap: number;
   private readonly siblingAbortController: AbortController;
   private readonly bashToolName: string;
   private readonly runtime?: ToolCallRuntime | ToolRuntimeScheduler;
@@ -396,6 +462,24 @@ export class StreamingToolExecutor {
     this.onProgress = opts.onProgress;
     this.maxConcurrency = normalizeMaxConcurrency(opts.maxConcurrency);
     this.maxToolDrainMs = normalizeMaxToolDrainMs(opts.maxToolDrainMs);
+    this.adaptiveDrainEnabled = normalizeAdaptiveDrainEnabled(
+      opts.adaptiveDrainEnabled,
+    );
+    this.adaptiveDrainMarginMult = normalizePositiveNumber(
+      opts.adaptiveDrainMarginMult,
+      process.env.AGENC_DRAIN_MARGIN_MULT,
+      DEFAULT_ADAPTIVE_DRAIN_MARGIN_MULT,
+    );
+    this.adaptiveDrainSafeMinMs = normalizePositiveNumber(
+      opts.adaptiveDrainSafeMinMs,
+      process.env.AGENC_DRAIN_SAFE_MIN_MS,
+      DEFAULT_ADAPTIVE_DRAIN_SAFE_MIN_MS,
+    );
+    this.adaptiveDrainRaiseCap = normalizePositiveNumber(
+      opts.adaptiveDrainRaiseCap,
+      process.env.AGENC_DRAIN_RAISE_CAP,
+      DEFAULT_ADAPTIVE_DRAIN_RAISE_CAP,
+    );
     this.bashToolName = opts.bashToolName ?? "system.bash";
     this.runtime = opts.runtime;
     this.onLeakedTool = opts.onLeakedTool;
@@ -930,7 +1014,26 @@ export class StreamingToolExecutor {
       // timeoutBehavior:"tool" — intentionally unbounded; exempt entirely.
       return Number.POSITIVE_INFINITY;
     }
-    return Math.max(this.maxToolDrainMs, own + DRAIN_GRACE_MS);
+
+    // ── adaptive refinement (Goal #4a) — reachable ONLY for a finite-own,
+    //    locally-defined, non-exempt tool. Everything above is untouched. ──
+    const flat = Math.max(this.maxToolDrainMs, own + DRAIN_GRACE_MS);
+    if (!this.adaptiveDrainEnabled) return flat; // OFF → byte-identical to today
+    const store =
+      this.liveToolDispatch?.options.session?.services.toolLatencyStore;
+    if (store === undefined) return flat; // crash-safe (minimal/test executor)
+
+    const estimate = store.estimateLatencyMs(resolvedName);
+    if (estimate === null) return flat; // cold start (per-tool < K AND global < K)
+
+    // estimate -> candidate deadline: multiplicative + additive margin.
+    const candidate = estimate * this.adaptiveDrainMarginMult + DRAIN_GRACE_MS;
+
+    // CLAMP — the SAFE-MINIMUM floor is the non-negotiable never-kill guard.
+    const ownFloor = own + DRAIN_GRACE_MS; // contractual timeout + pipeline grace
+    const lo = Math.max(ownFloor, this.adaptiveDrainSafeMinMs); // never below this
+    const hi = Math.max(this.maxToolDrainMs, ownFloor) * this.adaptiveDrainRaiseCap;
+    return Math.min(hi, Math.max(lo, candidate));
   }
 
   /**
@@ -1418,8 +1521,31 @@ export class StreamingToolExecutor {
       tool.detachAbortListeners?.();
     }
 
-    const durationMs = performance.now() - startedAtMs;
-    void durationMs;
+    // Adaptive drain latency sample (Goal #4a). Recompute against
+    // `executingSinceMs` for clock-consistency with the watchdog (which
+    // measures `now - executingSinceMs`); fall back to `startedAtMs` only if
+    // the tool was never stamped executing.
+    const since = tool.executingSinceMs ?? startedAtMs;
+    const durationMs = performance.now() - since;
+    // Record ONLY a clean completion. The two gates are the LOAD-BEARING
+    // anti-ratchet guard:
+    //   - tool.error === undefined   → no thrown / synthetic-timeout error
+    //     (finalizeOnce sets it).
+    //   - tool.outcome === undefined → not on the drain/reclaim path
+    //     (startReclaimAccounting sets it).
+    // A force-finalized late-settle has BOTH set, so it is excluded — feeding a
+    // ~deadline-ms killed run back in would ratchet the deadline up on every
+    // wedge.
+    if (
+      tool.error === undefined &&
+      tool.outcome === undefined &&
+      Number.isFinite(durationMs) &&
+      durationMs >= 0
+    ) {
+      const store =
+        this.liveToolDispatch?.options.session?.services.toolLatencyStore;
+      store?.record(this.resolveModelToolName(tool.toolCall.name), durationMs);
+    }
   }
 
   private isSiblingAbortShellTool(toolName: string): boolean {

--- a/runtime/src/tools/tool-latency-store.ts
+++ b/runtime/src/tools/tool-latency-store.ts
@@ -1,0 +1,152 @@
+/**
+ * Adaptive per-tool drain-timeout latency store (Goal #4a).
+ *
+ * Learns each tool's empirical latency distribution ONLINE and exposes a tail
+ * estimate used to derive an adaptive drain deadline. Faithful to Continuum
+ * (arXiv 2511.02230): per-key empirical CDF, K=100 sample-count ladder,
+ * global-pool fallback, fixed cold-start default (handled by the CALLER, which
+ * uses today's flat formula when this returns null).
+ *
+ * The statistic is `max(percentile(ring, P), ewmaMean + KSigma * ewmaStd)`:
+ *   - the percentile is P^-1(P) of the per-tool empirical CDF (Continuum);
+ *   - the EWMA term is TCP RTO's tail-safe estimator (RFC 6298, k=4);
+ *   - the `max` biases toward RAISING (a tool is "fast" only when BOTH small).
+ *
+ * IN-MEMORY, SESSION-SCOPED. Cold start on a fresh session is acceptable and
+ * intended (matches Continuum's online model). No durable persistence here.
+ *
+ * INVARIANTS (load-bearing — do not weaken):
+ *   - `record()` must be called ONLY for clean completions, NEVER for
+ *     force-finalized / leaked / errored runs. Recording a killed run would
+ *     teach the store "this tool takes ~deadline ms" and RATCHET the deadline
+ *     upward on every wedge. The caller enforces the gate; this class assumes
+ *     every recorded sample is a real, clean latency.
+ *   - This class never produces a deadline; it produces a raw latency estimate.
+ *     The SAFE-MINIMUM floor that guarantees a legit run is never killed lives
+ *     in the caller (`toolDrainDeadlineMs`).
+ *
+ * @module
+ */
+
+export interface ToolLatencyConfig {
+  /** Continuum K — min samples before a per-tool / global stat is trusted. */
+  readonly minSamples: number; // default 100
+  /** Per-tool ring-buffer capacity (recent-sample window + memory bound). */
+  readonly ringCap: number; // default 512
+  /** Empirical-CDF quantile, P^-1(percentile). */
+  readonly percentile: number; // default 0.99
+  /** EWMA mean smoothing (RFC 6298 SRTT, 1/8). */
+  readonly ewmaAlpha: number; // default 0.125
+  /** EWMA deviation smoothing (RFC 6298 RTTVAR, 1/4). */
+  readonly ewmaBeta: number; // default 0.25
+  /** Deviation multiplier (RFC 6298 SRTT + 4*RTTVAR). */
+  readonly kSigma: number; // default 4
+}
+
+export const DEFAULT_TOOL_LATENCY_CONFIG: ToolLatencyConfig = {
+  minSamples: 100,
+  ringCap: 512,
+  percentile: 0.99,
+  ewmaAlpha: 0.125,
+  ewmaBeta: 0.25,
+  kSigma: 4,
+};
+
+interface ToolLatencyStat {
+  ring: Float64Array; // recent clean durations (ms), capacity = ringCap
+  head: number; // next write index
+  count: number; // valid entries in ring (<= ringCap)
+  total: number; // lifetime clean samples (saturates; for the >= K gate)
+  ewmaMean: number; // EWMA mean (ms)
+  ewmaDev: number; // EWMA mean-absolute-deviation (ms)
+  seeded: boolean; // first-sample seeding flag
+}
+
+export class ToolLatencyStore {
+  private readonly perTool = new Map<string, ToolLatencyStat>();
+  private readonly global: ToolLatencyStat;
+  private readonly cfg: ToolLatencyConfig;
+
+  constructor(config: Partial<ToolLatencyConfig> = {}) {
+    this.cfg = { ...DEFAULT_TOOL_LATENCY_CONFIG, ...config };
+    this.global = this.newStat();
+  }
+
+  private newStat(): ToolLatencyStat {
+    return {
+      ring: new Float64Array(this.cfg.ringCap),
+      head: 0,
+      count: 0,
+      total: 0,
+      ewmaMean: 0,
+      ewmaDev: 0,
+      seeded: false,
+    };
+  }
+
+  /** Record one CLEAN-completion latency (ms). Never call for killed/leaked runs. */
+  record(resolvedToolName: string, durationMs: number): void {
+    if (!Number.isFinite(durationMs) || durationMs < 0) return;
+    let stat = this.perTool.get(resolvedToolName);
+    if (stat === undefined) {
+      stat = this.newStat();
+      this.perTool.set(resolvedToolName, stat);
+    }
+    this.ingest(stat, durationMs);
+    this.ingest(this.global, durationMs); // pooled global distribution (fallback tier)
+  }
+
+  private ingest(stat: ToolLatencyStat, r: number): void {
+    // ring (for the empirical percentile)
+    stat.ring[stat.head] = r;
+    stat.head = (stat.head + 1) % stat.ring.length;
+    if (stat.count < stat.ring.length) stat.count += 1;
+    if (stat.total < Number.MAX_SAFE_INTEGER) stat.total += 1;
+    // EWMA (RFC 6298 order: deviation against the PRE-update mean)
+    if (!stat.seeded) {
+      stat.ewmaMean = r;
+      stat.ewmaDev = r / 2;
+      stat.seeded = true;
+      return;
+    }
+    const { ewmaAlpha: a, ewmaBeta: b } = this.cfg;
+    stat.ewmaDev = (1 - b) * stat.ewmaDev + b * Math.abs(r - stat.ewmaMean);
+    stat.ewmaMean = (1 - a) * stat.ewmaMean + a * r;
+  }
+
+  /**
+   * Raw adaptive latency estimate (ms) for a tool, or null when there is not
+   * yet enough data and the CALLER must fall back to its fixed default.
+   *
+   * Ladder (Continuum K=100):
+   *   total[name] >= K           -> per-tool max(percentile, ewma+k*dev)
+   *   else global.total >= K     -> global  max(percentile, ewma+k*dev)
+   *   else                        -> null (cold start)
+   */
+  estimateLatencyMs(resolvedToolName: string): number | null {
+    const stat = this.perTool.get(resolvedToolName);
+    if (stat !== undefined && stat.total >= this.cfg.minSamples) {
+      return this.estimate(stat);
+    }
+    if (this.global.total >= this.cfg.minSamples) {
+      return this.estimate(this.global);
+    }
+    return null; // cold start
+  }
+
+  private estimate(stat: ToolLatencyStat): number {
+    const pct = this.percentileOf(stat, this.cfg.percentile);
+    const ewma = stat.ewmaMean + this.cfg.kSigma * stat.ewmaDev;
+    return Math.max(pct, ewma);
+  }
+
+  /** Nearest-rank percentile over the live ring window. */
+  private percentileOf(stat: ToolLatencyStat, p: number): number {
+    const n = stat.count;
+    if (n === 0) return 0;
+    const scratch = stat.ring.slice(0, n); // copy only the valid window
+    scratch.sort();
+    const idx = Math.min(n - 1, Math.max(0, Math.ceil(p * n) - 1));
+    return scratch[idx]!;
+  }
+}

--- a/runtime/tests/tools/streaming-executor.adaptive-drain.test.ts
+++ b/runtime/tests/tools/streaming-executor.adaptive-drain.test.ts
@@ -1,0 +1,567 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { StreamingToolExecutor } from "./streaming-executor.js";
+import { SHARED_READ } from "./concurrency.js";
+import { ToolLatencyStore } from "./tool-latency-store.js";
+import type { ToolRegistry, ToolDispatchResult } from "../tool-registry.js";
+import type { LLMTool, LLMToolCall } from "../llm/types.js";
+import type { Tool } from "./types.js";
+import type { ToolUseBlock } from "../session/turn-state.js";
+
+const GRACE_MS = 60_000;
+const FLAT_FLOOR_MS = 180_000;
+
+// ── shared helpers (mirrors streaming-executor.stuck-tool-drain.test.ts) ──
+function makeBlock(id: string, name: string): ToolUseBlock {
+  return { type: "tool_use", id, name, input: {} };
+}
+function makeCall(id: string, name: string, args = "{}"): LLMToolCall {
+  return { id, name, arguments: args };
+}
+function registryFor(
+  dispatch: (call: LLMToolCall) => Promise<ToolDispatchResult>,
+  tools: Tool[] = [],
+): ToolRegistry {
+  return {
+    tools,
+    toLLMTools(): LLMTool[] {
+      return [];
+    },
+    dispatch,
+  };
+}
+function testTool(overrides: Partial<Tool> & { name: string }): Tool {
+  return {
+    description: "test",
+    inputSchema: { type: "object" },
+    execute: async () => ({ content: "" }),
+    ...overrides,
+  };
+}
+function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<{ ok: true; value: T } | { ok: false; reason: string }> {
+  return Promise.race([
+    p.then((value) => ({ ok: true as const, value })),
+    new Promise<{ ok: false; reason: string }>((resolve) =>
+      setTimeout(
+        () => resolve({ ok: false, reason: `TIMEOUT(${label})` }),
+        ms,
+      ).unref?.(),
+    ),
+  ]);
+}
+
+// A minimal `liveToolDispatch` whose ONLY load-bearing reach for these tests is
+// `options.session.services.toolLatencyStore`. The deadline path never consults
+// the router for a tool that lives in the executor registry (resolveModelToolName
+// returns the name unchanged), so a no-op router suffices.
+function liveDispatchWithStore(store: ToolLatencyStore | undefined): {
+  router: never;
+  options: never;
+} {
+  return {
+    router: {
+      findSpec: () => undefined,
+      dispatchModelToolCall: async () => ({ content: "", isError: false }),
+      toolSupportsParallel: () => true,
+    } as unknown as never,
+    options: {
+      session: { services: { toolLatencyStore: store } },
+      turn: { subId: "adaptive-test" },
+      tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} },
+      approvalPolicy: "never",
+      sandboxMode: "workspace_write",
+    } as unknown as never,
+  };
+}
+
+// White-box deadline accessor.
+interface InternalExec {
+  tools: Array<{ toolCall: LLMToolCall; executingSinceMs?: number }>;
+  toolDrainDeadlineMs(tool: {
+    toolCall: LLMToolCall;
+    executingSinceMs?: number;
+  }): number;
+}
+function internal(exec: StreamingToolExecutor): InternalExec {
+  return exec as unknown as InternalExec;
+}
+
+// Build an executor wired with an (optionally seeded) latency store, a single
+// finite-own tool in the executor registry, and the adaptive flag toggled.
+// Returns the executor plus the tracked tool for white-box deadline queries.
+function buildDeadlineExec(opts: {
+  store: ToolLatencyStore | undefined;
+  enabled: boolean;
+  toolName?: string;
+  ownTimeoutMs?: number;
+  maxToolDrainMs?: number;
+  safeMinMs?: number;
+  marginMult?: number;
+  raiseCap?: number;
+  args?: string;
+}): { exec: StreamingToolExecutor; tool: InternalExec["tools"][number] } {
+  const name = opts.toolName ?? "Read";
+  const tool = testTool({
+    name,
+    ...(opts.ownTimeoutMs !== undefined
+      ? { timeoutMs: opts.ownTimeoutMs }
+      : {}),
+  });
+  const exec = new StreamingToolExecutor({
+    registry: registryFor(
+      () => new Promise<ToolDispatchResult>(() => {}),
+      [tool],
+    ),
+    maxToolDrainMs: opts.maxToolDrainMs ?? FLAT_FLOOR_MS,
+    adaptiveDrainEnabled: opts.enabled,
+    ...(opts.safeMinMs !== undefined
+      ? { adaptiveDrainSafeMinMs: opts.safeMinMs }
+      : {}),
+    ...(opts.marginMult !== undefined
+      ? { adaptiveDrainMarginMult: opts.marginMult }
+      : {}),
+    ...(opts.raiseCap !== undefined
+      ? { adaptiveDrainRaiseCap: opts.raiseCap }
+      : {}),
+    liveToolDispatch: liveDispatchWithStore(opts.store),
+  });
+  exec.setConcurrencyClassFor(name, SHARED_READ);
+  exec.addTool(makeBlock("t1", name), makeCall("t1", name, opts.args ?? "{}"));
+  exec.dispatchPending();
+  const tracked = internal(exec).tools.find((t) => t.toolCall.id === "t1")!;
+  return { exec, tool: tracked };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("StreamingToolExecutor adaptive drain (Goal #4a) — deadline math", () => {
+  // (#8) FAST tool → TIGHTER deadline. 200 fast (~50ms) samples, own=30s, flat
+  // = max(180s, 90s) = 180s. Adaptive: candidate = 1.5*50ms + 60s ≈ 60s, clamp
+  // lo = max(own+grace=90s, safeMin=30s) = 90s → deadline 90s, strictly <180s.
+  // REVERT: with toolDrainDeadlineMs's final return reverted to the flat
+  // formula, the deadline is 180s and `< 180_000` reddens.
+  test("#8 fast tool gets a TIGHTER deadline (90s < flat 180s)", () => {
+    const store = new ToolLatencyStore();
+    for (let i = 0; i < 200; i += 1) store.record("Read", 50);
+    const { exec, tool } = buildDeadlineExec({
+      store,
+      enabled: true,
+      toolName: "Read",
+      ownTimeoutMs: 30_000,
+    });
+    const deadline = internal(exec).toolDrainDeadlineMs(tool);
+    expect(deadline).toBe(90_000); // own(30s) + grace(60s) floor
+    expect(deadline).toBeLessThan(FLAT_FLOOR_MS);
+    exec.discard("teardown");
+  });
+
+  // (#9 white-box) SLOW-but-legit → deadline RAISED above 180s. p99 ≈ 150s,
+  // own=30s → candidate = 1.5*150s + 60s = 285s > 180s. A 200s legit run that
+  // flat-180s would FALSE-KILL now survives (deadline 285s).
+  // REVERT: flat formula → deadline 180s, `> 180_000` reddens.
+  test("#9 slow-but-legit tool RAISES the deadline above flat (≈285s > 180s)", () => {
+    const store = new ToolLatencyStore();
+    // 200 samples whose p99 ≈ 150s (mostly fast, tail at 150s so p99 lands there).
+    for (let i = 0; i < 198; i += 1) store.record("slow", 10_000);
+    for (let i = 0; i < 2; i += 1) store.record("slow", 150_000);
+    const { exec, tool } = buildDeadlineExec({
+      store,
+      enabled: true,
+      toolName: "slow",
+      ownTimeoutMs: 30_000,
+    });
+    const deadline = internal(exec).toolDrainDeadlineMs(tool);
+    expect(deadline).toBeGreaterThan(FLAT_FLOOR_MS); // RAISED, not killed at 180s
+    // ≈ 1.5*150s + 60s = 285s (allow margin since p99 of the ring picks 150s).
+    expect(deadline).toBeGreaterThanOrEqual(285_000 - 1);
+    expect(deadline).toBeLessThan(285_000 * 2);
+    // And a 200s legit run sits comfortably under the deadline.
+    expect(200_000).toBeLessThan(deadline);
+    exec.discard("teardown");
+  });
+
+  // (#10) COLD-START == DISABLED differential. enabled-but-empty store must be
+  // byte-identical to AGENC_ADAPTIVE_DRAIN=0 for fast/slow/default tools.
+  test("#10 cold-start (enabled, empty store) == disabled, byte-identical", () => {
+    for (const own of [undefined, 30_000, 600_000]) {
+      const emptyStore = new ToolLatencyStore();
+      const enabled = buildDeadlineExec({
+        store: emptyStore,
+        enabled: true,
+        toolName: "X",
+        ...(own !== undefined ? { ownTimeoutMs: own } : {}),
+      });
+      const disabled = buildDeadlineExec({
+        store: new ToolLatencyStore(),
+        enabled: false,
+        toolName: "X",
+        ...(own !== undefined ? { ownTimeoutMs: own } : {}),
+      });
+      const dEnabled = internal(enabled.exec).toolDrainDeadlineMs(enabled.tool);
+      const dDisabled = internal(disabled.exec).toolDrainDeadlineMs(
+        disabled.tool,
+      );
+      expect(dEnabled).toBe(dDisabled);
+      enabled.exec.discard("teardown");
+      disabled.exec.discard("teardown");
+    }
+  });
+
+  // (#13) timeoutBehavior:"tool" stays Infinity — the store is NEVER consulted,
+  // even fully populated under that resolved name. Guards against moving the
+  // store call above the `own === null` exemption branch.
+  test("#13 timeoutBehavior:'tool' stays Infinity (store never consulted)", () => {
+    const store = new ToolLatencyStore();
+    for (let i = 0; i < 300; i += 1) store.record("request-user-input", 50);
+    const exemptTool = testTool({
+      name: "request-user-input",
+      timeoutBehavior: "tool",
+    });
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(
+        () => new Promise<ToolDispatchResult>(() => {}),
+        [exemptTool],
+      ),
+      maxToolDrainMs: FLAT_FLOOR_MS,
+      adaptiveDrainEnabled: true,
+      liveToolDispatch: liveDispatchWithStore(store),
+    });
+    exec.setConcurrencyClassFor("request-user-input", SHARED_READ);
+    exec.addTool(
+      makeBlock("e1", "request-user-input"),
+      makeCall("e1", "request-user-input"),
+    );
+    exec.dispatchPending();
+    const tool = internal(exec).tools.find((t) => t.toolCall.id === "e1")!;
+    expect(internal(exec).toolDrainDeadlineMs(tool)).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+    exec.discard("teardown");
+  });
+
+  // (#15) Crash-safe reach: enabled but NO liveToolDispatch ⇒ the deadline is
+  // the flat formula and the construction does not throw.
+  // REVERT (against a non-optional `this.liveToolDispatch.options...`): throws.
+  test("#15 crash-safe: enabled + no liveToolDispatch → flat formula, no throw", () => {
+    const tool = testTool({ name: "Read", timeoutMs: 30_000 });
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(
+        () => new Promise<ToolDispatchResult>(() => {}),
+        [tool],
+      ),
+      maxToolDrainMs: FLAT_FLOOR_MS,
+      adaptiveDrainEnabled: true,
+      // NO liveToolDispatch — minimal/test executor shape.
+    });
+    exec.setConcurrencyClassFor("Read", SHARED_READ);
+    exec.addTool(makeBlock("r1", "Read"), makeCall("r1", "Read"));
+    exec.dispatchPending();
+    const tracked = internal(exec).tools.find((t) => t.toolCall.id === "r1")!;
+    let deadline = 0;
+    expect(() => {
+      deadline = internal(exec).toolDrainDeadlineMs(tracked);
+    }).not.toThrow();
+    expect(deadline).toBe(Math.max(FLAT_FLOOR_MS, 30_000 + GRACE_MS)); // flat
+    exec.discard("teardown");
+  });
+
+  // (#16) SAFE-MIN floor property: for randomized sample sets and random own,
+  // deadline ≥ max(own + grace, safeMin) ALWAYS. This is the false-kill guard.
+  // REVERT: removing the `lo` clamp lets a tiny estimate drop below the floor.
+  test("#16 floor property: deadline ≥ max(own+grace, safeMin) for random inputs", () => {
+    const safeMin = 45_000;
+    for (let trial = 0; trial < 60; trial += 1) {
+      const own = 1_000 + Math.floor(Math.random() * 600_000);
+      const store = new ToolLatencyStore({ minSamples: 50 });
+      // Random sample distribution (any latencies, incl. tiny → would tighten).
+      const n = 50 + Math.floor(Math.random() * 100);
+      for (let i = 0; i < n; i += 1) {
+        store.record("Rnd", Math.random() * 500); // sub-second fast samples
+      }
+      const { exec, tool } = buildDeadlineExec({
+        store,
+        enabled: true,
+        toolName: "Rnd",
+        ownTimeoutMs: own,
+        safeMinMs: safeMin,
+      });
+      const deadline = internal(exec).toolDrainDeadlineMs(tool);
+      const floor = Math.max(own + GRACE_MS, safeMin);
+      expect(deadline).toBeGreaterThanOrEqual(floor);
+      exec.discard("teardown");
+    }
+  });
+
+  // (#17) Raise-cap clamps a garbage outlier. One 1e9 ms sample → the candidate
+  // explodes, but `hi = max(maxDrain, own+grace)*raiseCap` clamps it.
+  test("#17 raise-cap clamps a garbage 1e9ms outlier to hi", () => {
+    const store = new ToolLatencyStore({ minSamples: 1 });
+    store.record("Garbage", 1_000_000_000); // 1e9 ms
+    const { exec, tool } = buildDeadlineExec({
+      store,
+      enabled: true,
+      toolName: "Garbage",
+      ownTimeoutMs: 30_000,
+      maxToolDrainMs: FLAT_FLOOR_MS,
+      raiseCap: 4,
+    });
+    const deadline = internal(exec).toolDrainDeadlineMs(tool);
+    const ownFloor = 30_000 + GRACE_MS;
+    const hi = Math.max(FLAT_FLOOR_MS, ownFloor) * 4;
+    expect(deadline).toBe(hi); // clamped to the runaway ceiling, NOT unbounded
+    expect(Number.isFinite(deadline)).toBe(true);
+    exec.discard("teardown");
+  });
+});
+
+// ── runtime-behavior tests ──
+//
+// `DRAIN_GRACE_MS` (60s) floors EVERY adaptive def-path deadline at ≥60s, so a
+// real-timer wedge cannot be force-finalized inside a 30s test budget on the
+// adaptive path. We instead drive the watchdog white-box: back-date
+// `executingSinceMs` so `now - since` straddles the flat vs adaptive deadline,
+// then invoke `forceTimeoutOverdueExecutingTools()` directly. This proves the
+// force fires (or does NOT) as a function of the deadline NUMBER — exactly what
+// the adaptive change controls — and is revert-sensitive at sub-second speed.
+interface ForceInternal extends InternalExec {
+  forceTimeoutOverdueExecutingTools(): boolean;
+  resolveModelToolName(name: string): string;
+}
+function forceInternal(exec: StreamingToolExecutor): ForceInternal {
+  return exec as unknown as ForceInternal;
+}
+
+// Back-date a tool's `executingSinceMs` so the watchdog sees `elapsedMs`
+// elapsed; leave it `executing` so the force path considers it.
+function backdateExecuting(
+  exec: StreamingToolExecutor,
+  id: string,
+  elapsedMs: number,
+): void {
+  const t = (
+    exec as unknown as {
+      tools: Array<{
+        toolCall: LLMToolCall;
+        status: string;
+        executingSinceMs?: number;
+      }>;
+    }
+  ).tools.find((x) => x.toolCall.id === id)!;
+  t.status = "executing";
+  t.executingSinceMs = performance.now() - elapsedMs;
+}
+
+describe("StreamingToolExecutor adaptive drain (Goal #4a) — runtime behavior", () => {
+  function drainCollect(exec: StreamingToolExecutor): {
+    done: Promise<void>;
+    collected: Array<{ id: string; isError: boolean }>;
+  } {
+    const collected: Array<{ id: string; isError: boolean }> = [];
+    const done = (async () => {
+      for await (const r of exec.getRemainingResults()) {
+        collected.push({
+          id: r.toolCall.id,
+          isError: r.result.isError === true,
+        });
+      }
+    })();
+    return { done, collected };
+  }
+
+  // (#9 runtime) A LEGIT slow run, having executed PAST the flat 180s deadline
+  // but UNDER the raised adaptive deadline (≈285s), is NOT force-finalized.
+  // We back-date executingSinceMs to 200s (200_000ms) — strictly above the flat
+  // 180s, where the flat rule WOULD force-kill it — and assert the watchdog
+  // does NOT force it (adaptive deadline 285s not yet crossed). Then a clean
+  // settle records the real 200s sample.
+  // REVERT (flat formula → deadline 180s): at 200s elapsed the watchdog DOES
+  // force-finalize → `forced === false` reddens (the run is killed). Reported.
+  test("#9 slow-but-legit run past the flat floor is NOT force-killed (adaptive raised)", async () => {
+    const store = new ToolLatencyStore();
+    // p99 ≈ 150s → adaptive deadline ≈ 1.5*150s + 60s = 285s (> flat 180s).
+    for (let i = 0; i < 198; i += 1) store.record("legit", 10_000);
+    for (let i = 0; i < 2; i += 1) store.record("legit", 150_000);
+
+    let releaseDispatch!: (r: ToolDispatchResult) => void;
+    const gate = new Promise<ToolDispatchResult>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const legitTool = testTool({ name: "legit", timeoutMs: 30_000 }); // own=30s
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(() => gate, [legitTool]),
+      maxToolDrainMs: FLAT_FLOOR_MS, // flat = max(180s, 30s+60s) = 180s
+      adaptiveDrainEnabled: true,
+      liveToolDispatch: liveDispatchWithStore(store),
+    });
+    (exec as unknown as { runToolUseFn?: unknown }).runToolUseFn = (
+      call: LLMToolCall,
+    ) => (exec as { registry: ToolRegistry }).registry.dispatch(call);
+    exec.setConcurrencyClassFor("legit", SHARED_READ);
+    exec.addTool(makeBlock("L1", "legit"), makeCall("L1", "legit"));
+    exec.dispatchPending();
+    exec.close();
+
+    const tracked = internal(exec).tools.find((t) => t.toolCall.id === "L1")!;
+    const deadline = internal(exec).toolDrainDeadlineMs(tracked);
+    expect(deadline).toBeGreaterThan(FLAT_FLOOR_MS); // RAISED above 180s
+
+    const { done, collected } = drainCollect(exec);
+
+    // Simulate 200s of execution — PAST the flat 180s, UNDER the adaptive 285s.
+    backdateExecuting(exec, "L1", 200_000);
+    const forced = forceInternal(exec).forceTimeoutOverdueExecutingTools();
+    // THE CRITICAL GUARD: the legit run is NOT force-finalized. (Flat formula:
+    // 200s > 180s → forced true → revert reddens.)
+    expect(forced).toBe(false);
+
+    // Now the dispatch settles cleanly → real result, clean sample recorded.
+    releaseDispatch({ content: "legit done", isError: false });
+    const final = await withTimeout(done, 4000, "legit-settles");
+    expect(final.ok).toBe(true);
+    expect(collected).toEqual([{ id: "L1", isError: false }]); // REAL, not synthetic
+    expect(exec.leakedTools).toBe(0);
+    const stat = (
+      store as unknown as { perTool: Map<string, { total: number }> }
+    ).perTool.get("legit");
+    expect(stat!.total).toBe(201); // 200 seeded + 1 clean settle recorded
+  });
+
+  // (#9 differential) Under the FLAT rule (adaptive disabled), the SAME 200s
+  // elapsed DOES force-finalize — proving the adaptive raise is what saved the
+  // run above. (This is the in-suite analog of the manual revert.)
+  test("#9 differential: with adaptive OFF the same 200s run IS force-killed at 180s", async () => {
+    const legitTool = testTool({ name: "legit", timeoutMs: 30_000 });
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(
+        () => new Promise<ToolDispatchResult>(() => {}),
+        [legitTool],
+      ),
+      maxToolDrainMs: FLAT_FLOOR_MS,
+      adaptiveDrainEnabled: false, // FLAT
+      liveToolDispatch: liveDispatchWithStore(new ToolLatencyStore()),
+    });
+    (exec as unknown as { runToolUseFn?: unknown }).runToolUseFn = () =>
+      new Promise<ToolDispatchResult>(() => {});
+    exec.setConcurrencyClassFor("legit", SHARED_READ);
+    exec.addTool(makeBlock("L1", "legit"), makeCall("L1", "legit"));
+    exec.dispatchPending();
+    exec.close();
+
+    const tracked = internal(exec).tools.find((t) => t.toolCall.id === "L1")!;
+    expect(internal(exec).toolDrainDeadlineMs(tracked)).toBe(FLAT_FLOOR_MS);
+
+    backdateExecuting(exec, "L1", 200_000);
+    const forced = forceInternal(exec).forceTimeoutOverdueExecutingTools();
+    expect(forced).toBe(true); // 200s > flat 180s → KILLED
+
+    exec.discard("teardown");
+  });
+
+  // (#11) Anti-ratchet: a FORCE-FINALIZED tool is NOT recorded. Spy on the
+  // store's `record`. We force-finalize a wedged tool white-box, then resolve
+  // its dispatch so the runOne tail runs; the error/outcome gate must exclude
+  // it. A killed-duration sample feeding back would ratchet the deadline up.
+  // REVERT (remove the error/outcome gate): the runOne tail records the
+  // force-finalized run → record() called for the wedged tool → spy reddens.
+  test("#11 anti-ratchet: a force-finalized tool is NOT recorded", async () => {
+    const store = new ToolLatencyStore({ minSamples: 5 });
+    const recordSpy = vi.spyOn(store, "record");
+
+    const wedgeTool = testTool({ name: "wedge", timeoutMs: 30_000 });
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(
+        () => new Promise<ToolDispatchResult>(() => {}),
+        [wedgeTool],
+      ),
+      maxToolDrainMs: FLAT_FLOOR_MS,
+      cleanupGraceMs: 100,
+      adaptiveDrainEnabled: true,
+      liveToolDispatch: liveDispatchWithStore(store),
+    });
+    // Cooperative wedge: rejects when its drainCancel signal aborts so its
+    // runOne `catch` runs (error set) and the tail record gate excludes it.
+    let releaseReject!: () => void;
+    (exec as unknown as { runToolUseFn?: unknown }).runToolUseFn = (
+      _call: LLMToolCall,
+      signal: AbortSignal,
+    ) =>
+      new Promise<ToolDispatchResult>((_resolve, reject) => {
+        releaseReject = () => reject(new Error("aborted"));
+        if (signal.aborted) {
+          releaseReject();
+          return;
+        }
+        signal.addEventListener("abort", () => reject(new Error("aborted")), {
+          once: true,
+        });
+      });
+    exec.setConcurrencyClassFor("wedge", SHARED_READ);
+    exec.addTool(makeBlock("W1", "wedge"), makeCall("W1", "wedge"));
+    exec.dispatchPending();
+    exec.close();
+
+    const { done, collected } = drainCollect(exec);
+
+    // Simulate the deadline being crossed and force-finalize white-box.
+    backdateExecuting(exec, "W1", FLAT_FLOOR_MS + 1_000);
+    const forced = forceInternal(exec).forceTimeoutOverdueExecutingTools();
+    expect(forced).toBe(true); // wedge IS force-finalized
+
+    const outcome = await withTimeout(done, 4000, "wedge-forced");
+    expect(outcome.ok).toBe(true);
+    expect(collected).toEqual([{ id: "W1", isError: true }]); // synthetic timeout
+
+    // Flush the runOne tail / reclaim race (drainCancel already fired).
+    await new Promise((r) => setTimeout(r, 250).unref?.());
+
+    // THE LOAD-BEARING ASSERTION: record() was NEVER called for the wedged run.
+    expect(recordSpy).not.toHaveBeenCalled();
+    const stat = (
+      store as unknown as { perTool: Map<string, { total: number }> }
+    ).perTool.get("wedge");
+    expect(stat).toBeUndefined(); // no killed-duration sample leaked in
+
+    recordSpy.mockRestore();
+  });
+
+  // (#11 cont.) A subsequent CLEAN run on a fresh tool name DOES record — so the
+  // recording path is alive; only KILLED runs are excluded (not all runs).
+  test("#11 anti-ratchet: a clean run IS recorded (the gate excludes only kills)", async () => {
+    const store = new ToolLatencyStore({ minSamples: 1 });
+    let release!: (r: ToolDispatchResult) => void;
+    const gate = new Promise<ToolDispatchResult>((resolve) => {
+      release = resolve;
+    });
+    const cleanTool = testTool({ name: "clean", timeoutMs: 30_000 });
+    const exec = new StreamingToolExecutor({
+      registry: registryFor(() => gate, [cleanTool]),
+      maxToolDrainMs: FLAT_FLOOR_MS, // big floor so the clean run is never forced
+      adaptiveDrainEnabled: true,
+      liveToolDispatch: liveDispatchWithStore(store),
+    });
+    (exec as unknown as { runToolUseFn?: unknown }).runToolUseFn = (
+      call: LLMToolCall,
+    ) => (exec as { registry: ToolRegistry }).registry.dispatch(call);
+    exec.setConcurrencyClassFor("clean", SHARED_READ);
+    exec.addTool(makeBlock("C1", "clean"), makeCall("C1", "clean"));
+    exec.dispatchPending();
+    exec.close();
+
+    const { done, collected } = drainCollect(exec);
+    release({ content: "clean ok", isError: false }); // settle cleanly at once
+    const outcome = await withTimeout(done, 4000, "clean-settles");
+    expect(outcome.ok).toBe(true);
+    expect(collected).toEqual([{ id: "C1", isError: false }]);
+
+    const stat = (
+      store as unknown as { perTool: Map<string, { total: number }> }
+    ).perTool.get("clean");
+    expect(stat).toBeDefined();
+    expect(stat!.total).toBe(1); // the clean run WAS recorded
+  });
+});

--- a/runtime/tests/tools/tool-latency-store.test.ts
+++ b/runtime/tests/tools/tool-latency-store.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "vitest";
+import {
+  ToolLatencyStore,
+  DEFAULT_TOOL_LATENCY_CONFIG,
+  type ToolLatencyConfig,
+} from "./tool-latency-store.js";
+
+// Reach the private per-tool stat for the ring/EWMA white-box assertions.
+interface StatLike {
+  count: number;
+  total: number;
+  ewmaMean: number;
+  ewmaDev: number;
+  seeded: boolean;
+}
+function perToolStat(
+  store: ToolLatencyStore,
+  name: string,
+): StatLike | undefined {
+  return (
+    store as unknown as { perTool: Map<string, StatLike> }
+  ).perTool.get(name);
+}
+function globalStat(store: ToolLatencyStore): StatLike {
+  return (store as unknown as { global: StatLike }).global;
+}
+
+function seed(store: ToolLatencyStore, name: string, ms: number, n: number) {
+  for (let i = 0; i < n; i += 1) store.record(name, ms);
+}
+
+describe("ToolLatencyStore (Goal #4a)", () => {
+  // (1) Cold start → null. < K per-tool AND < K global → null.
+  // REVERT: removing the `total >= minSamples` gate (return estimate
+  // unconditionally) would return a non-null value here → red.
+  test("cold start: < K samples per-tool and global → estimateLatencyMs is null", () => {
+    const store = new ToolLatencyStore();
+    seed(store, "Read", 50, 99); // 99 per-tool, 99 global — both < 100
+    expect(store.estimateLatencyMs("Read")).toBeNull();
+    expect(store.estimateLatencyMs("Unseen")).toBeNull();
+  });
+
+  // (2) K boundary — exact `>= K`. 99 → null, the 100th → non-null.
+  // REVERT: `>` instead of `>=` would keep null at 100 → red.
+  test("K boundary: 99 → null, 100 → non-null (>= not >)", () => {
+    const store = new ToolLatencyStore();
+    seed(store, "Read", 50, 99);
+    expect(store.estimateLatencyMs("Read")).toBeNull();
+    store.record("Read", 50); // 100th
+    expect(store.estimateLatencyMs("Read")).not.toBeNull();
+  });
+
+  // (3) Per-tool p99 picks the tail, not the mean.
+  test("per-tool >= K: estimate ≈ p99 picks the slow tail, not the mean", () => {
+    const store = new ToolLatencyStore();
+    seed(store, "T", 100, 990); // 990 fast
+    seed(store, "T", 5000, 10); // 10 slow → top 1%
+    const est = store.estimateLatencyMs("T");
+    expect(est).not.toBeNull();
+    // p99 over a 512-ring window dominated by recent slow samples sits near the
+    // tail, far above the 100ms body and well above the arithmetic mean.
+    expect(est!).toBeGreaterThan(1000);
+  });
+
+  // (4) Global fallback: a thin tool (< K) uses the pooled global estimate.
+  // REVERT: dropping the global tier (return null when per-tool < K) → red.
+  test("global fallback: thin per-tool tool uses the pooled global estimate", () => {
+    const store = new ToolLatencyStore();
+    // 100 pooled samples across OTHER tools → global >= K.
+    seed(store, "other", 200, 100);
+    // Tool A has only 10 samples (< K), so its own per-tool tier is not eligible.
+    seed(store, "A", 250, 10);
+    const est = store.estimateLatencyMs("A");
+    expect(est).not.toBeNull();
+    // The thin tool resolves to the GLOBAL pooled estimate — IDENTICAL to what
+    // an entirely unseen name (which can only use the global tier) resolves to.
+    const globalEst = store.estimateLatencyMs("definitely-unseen-name");
+    expect(globalEst).not.toBeNull();
+    expect(est).toBe(globalEst);
+  });
+
+  // (5) Ring eviction / memory bound: count never exceeds ringCap; p99 reflects
+  // only the recent window after the old huge samples age out.
+  test("ring eviction: count bounded by ringCap; p99 tracks the recent window", () => {
+    const cfg: Partial<ToolLatencyConfig> = { ringCap: 64, minSamples: 10 };
+    const store = new ToolLatencyStore(cfg);
+    seed(store, "T", 100_000, 64); // fill the ring with huge old samples
+    seed(store, "T", 50, 64 + 200); // overwrite entirely with tiny recent ones
+    const stat = perToolStat(store, "T")!;
+    expect(stat.count).toBe(64); // never exceeds ringCap
+    expect(stat.total).toBeGreaterThan(64); // lifetime total keeps climbing
+    const est = store.estimateLatencyMs("T");
+    expect(est).not.toBeNull();
+    // The old 100_000ms samples have all been evicted; p99 reflects the tiny
+    // recent window (EWMA may add headroom but the percentile is small).
+    const pctOnly = (
+      store as unknown as {
+        percentileOf: (s: StatLike, p: number) => number;
+      }
+    ).percentileOf(stat, 0.99);
+    expect(pctOnly).toBeLessThan(1000);
+  });
+
+  // (6) EWMA tail dominance via `max`: a variance burst pushes ewma+kσ above
+  // p99, so the EWMA term is the chosen estimate.
+  // REVERT: replacing `max(pct, ewma)` with percentile-only → red.
+  test("EWMA tail dominance: max() selects ewma+kσ over p99 on a variance burst", () => {
+    const store = new ToolLatencyStore({ minSamples: 10, ringCap: 512 });
+    // Steady body, then ONE recent giant spike. The ring p99 (1/512 ≈ 0.2%
+    // of the window) does NOT capture a single outlier at the 99th pct, but
+    // the EWMA deviation absorbs the spike and ewma+4σ jumps.
+    seed(store, "T", 100, 500);
+    store.record("T", 100_000); // single recent spike
+    const stat = perToolStat(store, "T")!;
+    const pct = (
+      store as unknown as {
+        percentileOf: (s: StatLike, p: number) => number;
+      }
+    ).percentileOf(stat, 0.99);
+    const ewma = stat.ewmaMean + DEFAULT_TOOL_LATENCY_CONFIG.kSigma * stat.ewmaDev;
+    expect(ewma).toBeGreaterThan(pct); // EWMA term wins
+    expect(store.estimateLatencyMs("T")).toBe(Math.max(pct, ewma));
+  });
+
+  // (7) RFC 6298 EWMA order: deviation measured against the PRE-update mean.
+  // REVERT: swapping the two update lines (mean before dev) → red.
+  test("RFC 6298 order: ewmaDev uses the pre-update mean", () => {
+    const a = DEFAULT_TOOL_LATENCY_CONFIG.ewmaAlpha; // 0.125
+    const b = DEFAULT_TOOL_LATENCY_CONFIG.ewmaBeta; // 0.25
+    const store = new ToolLatencyStore();
+    // First sample seeds: mean = r0, dev = r0/2.
+    const r0 = 100;
+    const r1 = 300;
+    store.record("T", r0);
+    store.record("T", r1);
+    const stat = perToolStat(store, "T")!;
+    // After r0 seed: mean0 = 100, dev0 = 50.
+    // r1 update (RFC 6298 ORDER — dev against PRE-update mean):
+    //   dev1  = (1-b)*dev0 + b*|r1 - mean0|
+    //   mean1 = (1-a)*mean0 + a*r1
+    const expectedDev = (1 - b) * (r0 / 2) + b * Math.abs(r1 - r0);
+    const expectedMean = (1 - a) * r0 + a * r1;
+    expect(stat.ewmaDev).toBeCloseTo(expectedDev, 6);
+    expect(stat.ewmaMean).toBeCloseTo(expectedMean, 6);
+    // Sanity: if the order were swapped, dev would be computed against mean1,
+    // i.e. (1-b)*dev0 + b*|r1-mean1| = 0.75*50 + 0.25*|300-125| = 81.25,
+    // distinct from the correct 0.75*50 + 0.25*200 = 87.5.
+    const swappedDev = (1 - b) * (r0 / 2) + b * Math.abs(r1 - expectedMean);
+    expect(swappedDev).not.toBeCloseTo(expectedDev, 6);
+  });
+
+  // Hardening: negative / non-finite samples are ignored (never poison the ring).
+  test("invalid samples (NaN / negative / Infinity) are dropped", () => {
+    const store = new ToolLatencyStore({ minSamples: 5 });
+    store.record("T", Number.NaN);
+    store.record("T", -1);
+    store.record("T", Number.POSITIVE_INFINITY);
+    expect(perToolStat(store, "T")).toBeUndefined(); // never created a stat
+    expect(globalStat(store).total).toBe(0);
+  });
+});


### PR DESCRIPTION
Goal item #4a. The per-tool drain deadline was a flat `max(180s, own+60s grace)`. Now it can **adapt** — learn each tool's empirical latency distribution online and derive the deadline from the tail: a reliably-fast tool gets a **tighter** deadline (wedge caught sooner), a long-tail / queue-bound tool gets its deadline **raised** so a legitimately slow run isn't force-killed.

## What changed
- New `ToolLatencyStore`: per-tool + global ring (empirical p99) + RFC 6298 EWMA(mean)+4·dev; statistic = `max(p99, ewma+4dev)` (biased toward raising). Continuum K=100 ladder (per-tool ≥100 → per-tool; else global ≥100 → global; else cold-start `null`). Pure, in-memory, session-scoped.
- `toolDrainDeadlineMs` adaptive branch (the 3 exemption early-returns untouched): `candidate = estimate*1.5 + grace`; `deadline = clamp(candidate, lo, hi)` with `lo = max(own+grace, SAFE_MIN 30s)`, `hi = max(maxToolDrainMs, own+grace)*4`.
- Sample recording replaces the discarded `durationMs`, measured against `executingSinceMs`.

## Two load-bearing invariants (everything else is a tunable)
1. **`deadline ≥ own + DRAIN_GRACE_MS` always** (the `lo` clamp) → killing a legit run is **structurally impossible**, not merely unlikely.
2. **Never record a killed/leaked/errored run** (the `tool.error===undefined && tool.outcome===undefined` gate) → a wedge can't ratchet the deadline up.

## Ship-dark-record-live
`AGENC_ADAPTIVE_DRAIN` defaults **OFF** — the first ship is byte-identical to today except harmless silent recording, so distributions warm up before enforcement is ever flipped on (no production cold-start enforcement window). Cooperative-cancel/reclaim release path (#1319/#1320/#1321) untouched; `timeoutBehavior:"tool"` stays `Infinity`.

Faithful to Continuum (arXiv 2511.02230), RFC 6298, and Dean & Barroso "The Tail at Scale" (deadline above the legit tail; breach action recoverable — our synthetic timeout + cooperative cancel, never a hard kill).

## Tests (revert-sensitive)
#8 fast-tighter (90s<180s); **#9 slow-but-legit 200s run survives** (reverts to force-kill at 180s); #10 cold-start==disabled differential; **#11 anti-ratchet** (reverts to recording the killed run); **#16 floor property** `deadline ≥ max(own+grace, safeMin)` for random inputs (reverts when the `lo` clamp drops); #13 exemption; #15 crash-safe; #17 raise-cap; + store unit tests.

## Gate
- `npm run build` ✅ exit 0 · `tsc -p runtime --noEmit` ✅ clean
- full `npm run test:unit` ✅ **1586 files / 13,489 tests passed, 0 failures** (default-off ship is a behavioral no-op — drain suite green both ways)
- floor-invariant revert independently re-verified: removing the `lo` clamp reddens #16 + #8; restored → green.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG