### PR TITLE
feat(tui): retain the multi-agent result board (UX loop iter-1, D8)

### DIFF
--- a/runtime/src/tasks/app-state-bridge.ts
+++ b/runtime/src/tasks/app-state-bridge.ts
@@ -1,7 +1,10 @@
 import type { BackgroundTaskSnapshot } from "./lifecycle.js";
 import type { LocalAgentTaskState, TaskState } from "./types.js";
 
-const PANEL_GRACE_MS = 30_000;
+// Result-board retention for terminal local_agent rows — keep in sync with
+// PANEL_GRACE_MS in utils/task/framework.ts. A long window so a finished
+// fan-out agent's row + result survives review instead of self-erasing.
+const PANEL_GRACE_MS = 1_800_000;
 
 export interface TaskAppStateBridge {
   setAppState?: (updater: (prev: unknown) => unknown) => void;

--- a/runtime/src/tui/state/collabAgentTaskSync.ts
+++ b/runtime/src/tui/state/collabAgentTaskSync.ts
@@ -5,7 +5,10 @@ import {
 } from "../../tasks/record-fields.js";
 
 // Inlined from framework.ts; importing it creates a cycle through task UI.
-const PANEL_GRACE_MS = 30_000;
+// Result-board retention for terminal local_agent rows — keep in sync with
+// PANEL_GRACE_MS in utils/task/framework.ts. A long window so a finished
+// fan-out agent's row + result survives review instead of self-erasing.
+const PANEL_GRACE_MS = 1_800_000;
 
 export type SetAppStateWithTasks = (
   updater: (prev: { readonly tasks?: Record<string, TaskState> }) => unknown,

--- a/runtime/src/tui/state/teammateViewHelpers.ts
+++ b/runtime/src/tui/state/teammateViewHelpers.ts
@@ -3,8 +3,10 @@ import type { LocalAgentTaskState } from '../../tasks/LocalAgentTask/LocalAgentT
 
 // Inlined from framework.ts — importing creates a cycle through
 // BackgroundTasksPanel. Keep in sync with PANEL_GRACE_MS there.
+// Result-board retention for terminal local_agent rows: a long window so a
+// finished agent's row + result survives review instead of self-erasing.
 
-const PANEL_GRACE_MS = 30_000
+const PANEL_GRACE_MS = 1_800_000
 
 import type { AppState } from './AppState.js'
 

--- a/runtime/src/utils/task/framework.ts
+++ b/runtime/src/utils/task/framework.ts
@@ -16,8 +16,16 @@ export const POLL_INTERVAL_MS = 1000
 // Duration to display killed tasks before eviction
 export const STOPPED_DISPLAY_MS = 3_000
 
-// Grace period for terminal local_agent tasks in the coordinator panel
-export const PANEL_GRACE_MS = 30_000
+// Result-board retention for terminal (completed/failed/killed) local_agent
+// tasks in the coordinator/fleet panel. A finished agent's row + result stays
+// visible this long so the user can review the fan-out "result board" instead
+// of having it self-erase mid-review. It is intentionally long (not a few
+// seconds): a fan-out's outcomes should survive until the user has had a chance
+// to act on them. `retain` still exempts a held/viewed agent entirely, and the
+// `x` dismiss (evictAfter:0) still clears a row immediately. NOTE: this governs
+// AGENT rows only — killed shell/in-process background tasks use the much
+// shorter STOPPED_DISPLAY_MS above and are deliberately untouched.
+export const PANEL_GRACE_MS = 1_800_000
 
 // Attachment type for task status updates
 export type TaskAttachment = {

--- a/runtime/tests/tui/coverage-swarm/swarm-057-state-teammateViewHelpers.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-057-state-teammateViewHelpers.test.ts
@@ -126,7 +126,8 @@ describe("teammateViewHelpers coverage edges", () => {
       retain: false,
       diskLoaded: false,
       messages: undefined,
-      evictAfter: 31_000,
+      // Date.now()(1_000) + PANEL_GRACE_MS(1_800_000) — result-board retention
+      evictAfter: 1_801_000,
     });
     expect(next.tasks.agent_new).toMatchObject({
       retain: true,

--- a/runtime/tests/tui/coverage-swarm/swarm-140-state-collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-140-state-collabAgentTaskSync.test.ts
@@ -129,7 +129,8 @@ describe("collabAgentTaskSync coverage swarm row 140", () => {
       error: "missing worker",
       notified: true,
       endTime: 10_000,
-      evictAfter: 40_000,
+      // now(10_000) + PANEL_GRACE_MS(1_800_000) — terminal result-board retention
+      evictAfter: 1_810_000,
     });
   });
 

--- a/runtime/tests/tui/state/agentResultBoardRetention.test.ts
+++ b/runtime/tests/tui/state/agentResultBoardRetention.test.ts
@@ -1,0 +1,182 @@
+// D8 (error recovery & resumability) + D2 (observability): the AGENT FLEET
+// "result board" must NOT self-erase a completed/failed agent's row + result
+// at the old 30s grace — a fan-out's outcomes have to survive review.
+//
+// This is a revert-sensitive guard. The pre-fix code set the terminal grace to
+// PANEL_GRACE_MS = 30_000, so a completed/failed agent's row was evicted from
+// getVisibleAgentTasks() once the panel's 1s tick ran evictTerminalTask() at
+// the 30s mark. With the result-board retention (PANEL_GRACE_MS = 1_800_000),
+// the row is still visible at +30s. Stash the source change to framework.ts /
+// collabAgentTaskSync.ts and "the result board survives 30s" goes RED.
+
+import { describe, expect, it } from "vitest";
+
+import { syncCollabAgentEventToAppState } from "./collabAgentTaskSync.js";
+import type { AppState } from "./AppStateStore.js";
+import {
+  getVisibleAgentTasks,
+} from "src/tui/components/CoordinatorAgentStatus.js";
+import { evictTerminalTask } from "src/utils/task/framework.js";
+
+const SPAWN_NOW = 1_000;
+const OLD_GRACE_MS = 30_000;
+
+function baseState(): AppState {
+  return { tasks: {} } as AppState;
+}
+
+function applyEvent(state: AppState, event: unknown, now: number): AppState {
+  let next = state;
+  syncCollabAgentEventToAppState(
+    event,
+    (updater) => {
+      next = updater(next as never) as AppState;
+    },
+    now,
+  );
+  return next;
+}
+
+/** Drives the panel's 1s-tick eviction (CoordinatorTaskPanel) at a given clock. */
+function tickPanelEvictionAt(state: AppState, now: number): AppState {
+  const realNow = Date.now;
+  // evictTerminalTask compares evictAfter against Date.now(); pin the clock so
+  // the test is deterministic across the +30s and +grace boundaries.
+  (Date as { now: () => number }).now = () => now;
+  try {
+    let next = state;
+    for (const task of Object.values(state.tasks ?? {})) {
+      evictTerminalTask(task.id, (updater) => {
+        next = updater(next as never) as AppState;
+      });
+    }
+    return next;
+  } finally {
+    (Date as { now: () => number }).now = realNow;
+  }
+}
+
+function spawnRunningAgent(state: AppState, id: string, now: number): AppState {
+  return applyEvent(
+    state,
+    {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: id,
+        newAgentNickname: id,
+        status: { status: "running" },
+      },
+    },
+    now,
+  );
+}
+
+function markTerminal(
+  state: AppState,
+  id: string,
+  status: "completed" | "errored",
+  now: number,
+): AppState {
+  return applyEvent(
+    state,
+    {
+      type: "collab_agent_status",
+      payload: {
+        threadId: id,
+        status:
+          status === "errored"
+            ? { status: "errored", error: "boom" }
+            : { status: "completed" },
+      },
+    },
+    now,
+  );
+}
+
+describe("agent fleet result-board retention (D8 / D2)", () => {
+  it("keeps a COMPLETED and a FAILED agent row visible past the old 30s grace", () => {
+    let state = baseState();
+    state = spawnRunningAgent(state, "done_agent", SPAWN_NOW);
+    state = spawnRunningAgent(state, "boom_agent", SPAWN_NOW);
+    state = markTerminal(state, "done_agent", "completed", SPAWN_NOW);
+    state = markTerminal(state, "boom_agent", "errored", SPAWN_NOW);
+
+    // Both terminal rows start visible with a retention deadline far beyond 30s.
+    const visibleNow = getVisibleAgentTasks(state.tasks);
+    expect(visibleNow.map((t) => t.id).sort()).toEqual([
+      "boom_agent",
+      "done_agent",
+    ]);
+    for (const t of visibleNow) {
+      expect(t.evictAfter).toBeDefined();
+      // The deadline must be well past the old 30s grace — this is what makes
+      // the row survive the +30s tick below.
+      expect(t.evictAfter! - SPAWN_NOW).toBeGreaterThan(OLD_GRACE_MS);
+    }
+
+    // Run the panel's eviction tick at exactly the OLD 30s boundary. Pre-fix
+    // (PANEL_GRACE_MS = 30_000) this is where the result board self-erased.
+    const afterOldGrace = tickPanelEvictionAt(state, SPAWN_NOW + OLD_GRACE_MS);
+
+    // REVERT-SENSITIVE ASSERTION: both rows are STILL on the board after 30s.
+    const visibleAfter = getVisibleAgentTasks(afterOldGrace.tasks);
+    expect(visibleAfter.map((t) => t.id).sort()).toEqual([
+      "boom_agent",
+      "done_agent",
+    ]);
+    // And their result-bearing fields survive (status + error are the board).
+    const failed = visibleAfter.find((t) => t.id === "boom_agent");
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toBe("boom");
+    expect(
+      visibleAfter.find((t) => t.id === "done_agent")?.status,
+    ).toBe("completed");
+  });
+
+  it("still evicts terminal rows once the retention window elapses (cleanup not regressed)", () => {
+    let state = baseState();
+    state = spawnRunningAgent(state, "done_agent", SPAWN_NOW);
+    state = markTerminal(state, "done_agent", "completed", SPAWN_NOW);
+
+    const deadline = getVisibleAgentTasks(state.tasks)[0]!.evictAfter!;
+
+    // Just before the deadline: still visible.
+    const before = tickPanelEvictionAt(state, deadline - 1);
+    expect(getVisibleAgentTasks(before.tasks).map((t) => t.id)).toEqual([
+      "done_agent",
+    ]);
+
+    // At/after the deadline: the row is finally GC'd from the board.
+    const after = tickPanelEvictionAt(state, deadline);
+    expect(getVisibleAgentTasks(after.tasks)).toEqual([]);
+  });
+
+  it("does not retain ACTIVE agents and still honors immediate x-dismiss", () => {
+    let state = baseState();
+    state = spawnRunningAgent(state, "live_agent", SPAWN_NOW);
+
+    // A running agent has no eviction deadline and is unaffected by the tick.
+    const live = getVisibleAgentTasks(state.tasks)[0]!;
+    expect(live.status).toBe("running");
+    expect(live.evictAfter).toBeUndefined();
+    const afterTick = tickPanelEvictionAt(state, SPAWN_NOW + 10_000_000);
+    expect(getVisibleAgentTasks(afterTick.tasks).map((t) => t.id)).toEqual([
+      "live_agent",
+    ]);
+
+    // x-dismiss (evictAfter:0) still hides a row immediately, independent of
+    // the retention window.
+    const dismissed = {
+      tasks: {
+        gone: {
+          ...getVisibleAgentTasks(
+            markTerminal(state, "live_agent", "completed", SPAWN_NOW).tasks,
+          )[0]!,
+          id: "gone",
+          evictAfter: 0,
+        },
+      },
+    } as unknown as AppState;
+    expect(getVisibleAgentTasks(dismissed.tasks)).toEqual([]);
+  });
+});

--- a/runtime/tests/tui/state/collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.test.ts
@@ -164,7 +164,8 @@ describe("syncCollabAgentEventToAppState", () => {
       status: "completed",
       description: "Librarian",
       endTime: 1234,
-      evictAfter: 31234,
+      // now(1234) + PANEL_GRACE_MS(1_800_000) — terminal result-board retention
+      evictAfter: 1_801_234,
       notified: true,
     });
   });
@@ -300,7 +301,8 @@ describe("syncCollabAgentEventToAppState", () => {
       status: "completed",
       description: "ChromeRider",
       endTime: 1234,
-      evictAfter: 31234,
+      // now(1234) + PANEL_GRACE_MS(1_800_000) — terminal result-board retention
+      evictAfter: 1_801_234,
       notified: true,
     });
     expect(completed.tasks.agent_2).toMatchObject({
@@ -308,7 +310,8 @@ describe("syncCollabAgentEventToAppState", () => {
       description: "Quickhack",
       error: "review failed",
       endTime: 1234,
-      evictAfter: 31234,
+      // now(1234) + PANEL_GRACE_MS(1_800_000) — terminal result-board retention
+      evictAfter: 1_801_234,
       notified: true,
     });
     expect(completed.tasks.missing).toBeUndefined();

--- a/runtime/tests/tui/state/collabAgentTaskSync.wave200-116.coverage.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.wave200-116.coverage.test.ts
@@ -51,7 +51,8 @@ describe("syncCollabAgentEventToAppState coverage edges", () => {
       description: "agent/canceled 1",
       outputFile: "urn:agenc:task:agent%2Fcanceled%201:output",
       endTime: 5000,
-      evictAfter: 35000,
+      // now(5000) + PANEL_GRACE_MS(1_800_000) — terminal result-board retention
+      evictAfter: 1_805_000,
       notified: true,
       selectedAgent: { name: "agent/canceled 1" },
     });


### PR DESCRIPTION
**agenc multi-agent UX loop — iteration 1** (rubric D8 error-recovery / D2 observability).

## The gap (vs Claude Code agent-view)
When a fan-out of subagents finishes, each terminal agent row (+ its status/error/result) was **deleted from the AGENT FLEET panel 30s** after reaching a terminal state (`evictTerminalTask` at `evictAfter = now + PANEL_GRACE_MS`). So you spawn 3–5 agents, they complete, and **the result board self-erases while you're reading it.** Best-in-class keeps a completed/failed agent visible with its result long enough to act on.

## Fix
Raise the **terminal-agent** panel grace 30s → 30min (`PANEL_GRACE_MS 30_000 → 1_800_000`) at all 4 const sites. Scoped to terminal `local_agent` rows only:
- `retain` exemption, `x`-dismiss (`evictAfter:0` immediate hide), and active/running-row churn (no `evictAfter`) — **unchanged**;
- shell/background tasks are a **separate** concern (`STOPPED_DISPLAY_MS = 3s`) — **untouched**;
- the panel still cleans up terminal rows after the longer bounded window (no stale accumulation).

## Test (revert-sensitive)
A COMPLETED and a FAILED agent spawned via the real `syncCollabAgentEventToAppState` path are still in `getVisibleAgentTasks()` after a +30s eviction tick. Against the old 30s grace the row is evicted (`→ []`) and the assertion reddens (`expected 30000 to be greater than 30000`); control tests confirm terminal rows still evict after the new window and active rows are never retained.

## Gate
- `npm run build` ✅ exit 0
- full `npm run test:unit` ✅ **13,514 passed, 0 failures**
- `tui-command-visual-smoke` not worse (same flaky labels on clean HEAD)
- revert independently re-verified: reverting the const reddens the retention test.

First iteration of the autonomous loop grading agenc's multi-agent UX against a Claude-Code-docs rubric.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG