### PR TITLE
feat(tui): color-code agent lifecycle states + role label in the Agents rail (UX loop iter-2, D1b)

### DIFF
--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -185,13 +185,21 @@ function AgentRailRow({
     nonBlankString(progress.lastActivity?.toolName) ??
     nonBlankString(task.status) ??
     "unknown";
-  const description = nonBlankString(task.description) ?? nonBlankString(task.id) ?? "agent";
+  const label = agentRowLabel(task);
   const stopAction = workbenchStopActionForTask(task);
   const diffCount = progress.diffCount ?? task.diffCount;
   const approvalPending = task.approvalPending === true || task.pendingApproval === true;
+  // Semantic state color (working/done/failed/stopped/idle) on the marker so a
+  // fan-out reads at a glance instead of as a wall of identical rows. When the
+  // agent is waiting on a human decision, the marker shifts to the warning
+  // accent regardless of run state so "needs you" stands out.
+  const markerColor = approvalPending ? "warning" : statusColor(task.status);
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <Text color={selected ? "suggestion" : undefined} wrap="truncate-end">{statusMarker(task.status)} {description}</Text>
+      <Text wrap="truncate-end">
+        <Text color={markerColor}>{statusMarker(task.status)}</Text>
+        <Text color={selected ? "suggestion" : undefined}> {label}</Text>
+      </Text>
       <Text dimColor wrap="truncate-end">{activity}</Text>
       <Text dimColor wrap="truncate-end">
         {formatTaskElapsed(task)} · tools {progress.toolUseCount ?? 0} tokens {progress.tokenCount ?? 0}
@@ -203,6 +211,27 @@ function AgentRailRow({
   );
 }
 
+/**
+ * Friendly short label for a rail row. Prefers the friendly task title the
+ * sync layer already stores on `description` (the agent nickname / path, e.g.
+ * "Nova"), appending the role when one is known so a fan-out of same-named
+ * lifecycles is still distinguishable (e.g. "Nova · Scanner"). Falls back to
+ * the id, never the raw spawn prompt, which is noisy and truncates badly.
+ */
+function agentRowLabel(task: any): string {
+  const title = nonBlankString(task.description) ?? nonBlankString(task.id) ?? "agent";
+  const role = nonBlankString(task.agentType);
+  return role && role !== "agent" && role !== title ? `${title} · ${role}` : title;
+}
+
+/**
+ * Lifecycle glyph for the rail row. Kept ASCII (not the AURA glyph set used by
+ * the wider fleet panel in CoordinatorAgentStatus) because the rail is a
+ * narrow, dense column where a single-cell ASCII marker stays legible across
+ * all terminals; the *semantic state* is now carried by color (statusColor),
+ * matching the AURA panel's color intent without a risky cross-surface glyph
+ * refactor.
+ */
 function statusMarker(status: string): string {
   switch (status) {
     case "running":
@@ -215,5 +244,27 @@ function statusMarker(status: string): string {
       return "x";
     default:
       return "-";
+  }
+}
+
+/**
+ * Theme color token for an agent lifecycle state. Mirrors the fleet panel's
+ * intent: working=accent, completed=green, failed=red, stopped=grey,
+ * pending/idle=dim. Returns a theme key (resolved by ThemedText), never a raw
+ * ANSI value.
+ */
+function statusColor(status: string): "worker" | "success" | "error" | "muted3" | "inactive" {
+  switch (status) {
+    case "running":
+      return "worker";
+    case "completed":
+      return "success";
+    case "failed":
+      return "error";
+    case "killed":
+      return "muted3";
+    default:
+      // pending / unknown / idle — dim, awaiting work.
+      return "inactive";
   }
 }

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -14,7 +14,9 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
 
 import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
 import { AgentsRail } from "../../../src/tui/workbench/agents/AgentsRail.js";
-import { renderToString } from "../../../src/utils/staticRender.js";
+import { renderToAnsiString, renderToString } from "../../../src/utils/staticRender.js";
+import { ThemeProvider } from "../../../src/tui/components/design-system/ThemeProvider.js";
+import { getTheme } from "../../../src/utils/theme.js";
 
 describe("AgentsRail", () => {
   beforeEach(() => {
@@ -292,6 +294,111 @@ describe("AgentsRail", () => {
       focusedPane: "surface",
       selectedAgentTaskId: "agent-old",
     });
+  });
+});
+
+describe("AgentsRail lifecycle legibility (color + friendly label)", () => {
+  // Dark is the default render theme (ThemeProvider DEFAULT_THEME); pin it
+  // explicitly so the asserted SGR codes never drift with user settings.
+  const theme = getTheme("dark");
+
+  // Truecolor foreground SGR for a theme rgb() token, matching what chalk emits
+  // at level 3 (renderToAnsiString({ color: true })).
+  function fgSgr(rgb: string): string {
+    const m = /^rgb\((\d+),(\d+),(\d+)\)$/.exec(rgb.replaceAll(" ", ""));
+    if (m === null) throw new Error(`not an rgb token: ${rgb}`);
+    return `[38;2;${m[1]};${m[2]};${m[3]}m`;
+  }
+
+  const RUNNING_SGR = fgSgr(theme.worker);
+  const COMPLETED_SGR = fgSgr(theme.success);
+  const FAILED_SGR = fgSgr(theme.error);
+  const KILLED_SGR = fgSgr(theme.muted3);
+  const APPROVAL_SGR = fgSgr(theme.warning);
+
+  async function renderRailAnsi(tasks: readonly any[]): Promise<string> {
+    return renderToAnsiString(
+      <ThemeProvider initialState="dark">
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: Object.fromEntries(tasks.map((t) => [t.id, t])),
+            remoteBackgroundTaskCount: 0,
+            workbench: {
+              ...getDefaultAppState().workbench,
+              selectedAgentTaskId: null,
+            },
+          }}
+        >
+          <AgentsRail focused={true} width={48} />
+        </AppStateProvider>
+      </ThemeProvider>,
+      { columns: 60, rows: 24, color: true },
+    );
+  }
+
+  it("color-codes completed vs failed vs running markers distinctly", async () => {
+    const out = await renderRailAnsi([
+      agentTask("agent-run", "running", { description: "scanning", startTime: 3_000 }),
+      agentTask("agent-ok", "completed", { description: "wrote tests", startTime: 2_000 }),
+      agentTask("agent-bad", "failed", { description: "crashed", startTime: 1_000 }),
+    ]);
+
+    // Each lifecycle state surfaces its own semantic color on the marker.
+    expect(out).toContain(RUNNING_SGR);
+    expect(out).toContain(COMPLETED_SGR);
+    expect(out).toContain(FAILED_SGR);
+    // The three colors are genuinely different (legibility at a glance).
+    expect(new Set([RUNNING_SGR, COMPLETED_SGR, FAILED_SGR]).size).toBe(3);
+  });
+
+  it("colors a stopped agent in the muted/grey state and a needs-approval agent in the warning accent", async () => {
+    const killed = await renderRailAnsi([
+      agentTask("agent-killed", "killed", { description: "stopped", startTime: 1_000 }),
+    ]);
+    expect(killed).toContain(KILLED_SGR);
+
+    const approval = await renderRailAnsi([
+      agentTask("agent-wait", "running", {
+        description: "awaiting decision",
+        pendingApproval: true,
+        startTime: 1_000,
+      }),
+    ]);
+    // Needs-input/approval overrides the run color with the warning accent so
+    // "needs you" stands out from a plain working agent.
+    expect(approval).toContain(APPROVAL_SGR);
+    expect(approval).not.toContain(RUNNING_SGR);
+  });
+
+  it("labels rows with the friendly title (+ role), never the raw prompt", async () => {
+    const out = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            nova: agentTask("nova", "running", {
+              description: "Nova",
+              agentType: "Scanner",
+              prompt:
+                "You are a research agent. Investigate the entire authentication subsystem and report every call site in exhaustive detail.",
+              startTime: 1_000,
+            }),
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            selectedAgentTaskId: null,
+          },
+        }}
+      >
+        <AgentsRail focused={true} width={60} />
+      </AppStateProvider>,
+      { columns: 72, rows: 24 },
+    );
+
+    // Friendly nickname + role, not the raw multi-sentence spawn prompt.
+    expect(out).toContain("Nova · Scanner");
+    expect(out).not.toContain("You are a research agent");
   });
 });
 


### PR DESCRIPTION
**agenc multi-agent UX loop — iteration 2** (rubric D1b "agent legibility at a glance").

## The gap
The Agents rail rendered every agent in one flat color with a colorless ASCII marker, so a 3–5 agent fan-out was a wall of identical-looking rows — you couldn't tell **working / done / failed** apart at a glance. *(The rubric's "raw prompt dumped" claim turned out inaccurate for the live path — the rail already shows the friendly nickname; the real gap was color + role context. Verified.)*

## Fix (scoped to the rail)
- **`statusColor(status)`** → theme tokens: running=`worker` (accent), completed=`success` (green), failed=`error` (red), killed=`muted3` (grey), pending/idle=`inactive` (dim). Marker split into its own `<Text>` so semantic state rides on color. No raw ANSI.
- **`agentRowLabel(task)`** — friendly nickname/title + role when known/distinct (e.g. `Nova · Scanner`); never the raw prompt.
- **`approvalPending` → `warning`** marker accent, so a "needs you" agent stands out (achievable subset of needs-input).

**Deferred honestly (need runtime/state plumbing, next iterations):** a true distinct "blocked on a question" needs-input state (`TaskStatus` has no such member — only approval-pending, shipped) and a done/total subwork counter (no count plumbed).

## Test (revert-sensitive)
Completed vs failed vs running markers render in distinct semantic colors, and a needs-approval agent in the warning accent. Against the pre-fix code the marker is one flat color → assertions redden; restored → green.

## Gate
- `npm run build` ✅ exit 0
- full `npm run test:unit` ✅ **13,517 passed, 0 failures**
- `tui-command-visual-smoke` not worse (8 vs 8 flaky, none on the rail)
- revert independently re-verified: neutralizing the marker color reddens both color tests.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG