### PR TITLE
fix(tui): plumb real per-agent tool/token counts to the Agents rail (UX loop iter-3, D2)

### DIFF
--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -639,6 +639,16 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
             reasoningEffort ??
             session.sessionConfiguration.collaborationMode.reasoningEffort,
           status: snapshot.status,
+          // Forward the live per-agent tool-use + token counts so the fan-out
+          // rail / fleet panel show real activity for collab-spawned agents
+          // instead of a frozen `tools 0 tokens 0`. The snapshot's progress is
+          // refreshed from the live handle by registerAgentThreadTask.
+          ...(snapshot.progress?.toolUseCount !== undefined
+            ? { toolUseCount: snapshot.progress.toolUseCount }
+            : {}),
+          ...(snapshot.progress?.tokenCount !== undefined
+            ? { tokenCount: snapshot.progress.tokenCount }
+            : {}),
           ...(snapshot.error !== undefined ? { error: snapshot.error } : {}),
         },
       });

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -489,6 +489,18 @@ export interface CollabAgentStatusEvent {
   readonly model?: string;
   readonly reasoningEffort?: string;
   readonly status: AgentStatus | CollabAgentTaskStatus;
+  /**
+   * Live per-agent tool-use count (cumulative tool calls observed on the
+   * spawned subagent's transcript). Forwarded to the fan-out rail so a
+   * collab-spawned agent shows real activity instead of `tools 0`.
+   */
+  readonly toolUseCount?: number;
+  /**
+   * Live per-agent cumulative token usage for the spawned subagent.
+   * Forwarded to the fan-out rail so a collab-spawned agent shows real
+   * token consumption instead of `tokens 0` — the prerequisite for cost.
+   */
+  readonly tokenCount?: number;
   readonly error?: string;
 }
 

--- a/runtime/src/tasks/agent-thread.ts
+++ b/runtime/src/tasks/agent-thread.ts
@@ -34,6 +34,32 @@ function finalMessageMetadata(
   return { finalMessage };
 }
 
+/**
+ * Derive the live per-agent tool-use + token counts for a spawned
+ * subagent. For DAEMON/collab-spawned agents the runner accumulates token
+ * usage on `live.tokenUsage` and records tool calls in the live transcript;
+ * this reads both so the fan-out rail reflects real activity instead of 0.
+ * Returns `undefined` when neither signal is available (so we don't clobber
+ * a previously-recorded progress with zeros).
+ */
+function liveAgentCounts(
+  thread: AgentThreadTaskHandle,
+): { readonly toolUseCount: number; readonly tokenCount: number } | undefined {
+  const tokenCount = thread.live.tokenUsage?.totalTokens;
+  const messages = thread.live.messages;
+  let toolUseCount = 0;
+  let sawMessages = false;
+  if (messages !== undefined) {
+    sawMessages = true;
+    for (const message of messages) {
+      const calls = message.toolCalls;
+      if (calls !== undefined) toolUseCount += calls.length;
+    }
+  }
+  if (tokenCount === undefined && !sawMessages) return undefined;
+  return { toolUseCount, tokenCount: tokenCount ?? 0 };
+}
+
 export interface AgentThreadTaskHandle {
   readonly threadId?: string;
   readonly threadName?: string;
@@ -56,6 +82,18 @@ export interface AgentThreadTaskHandle {
       readonly value: AgentStatus;
       subscribe?: (listener: (status: AgentStatus) => void) => () => void;
     };
+    /**
+     * Cumulative token usage for this live subagent. Populated by the
+     * runner's per-turn `usage_update` accumulation (run-agent.ts). Read
+     * each time a status snapshot is emitted so the fan-out rail shows
+     * real per-agent token counts for DAEMON/collab-spawned agents, not 0.
+     */
+    readonly tokenUsage?: { readonly totalTokens?: number };
+    /**
+     * Live child transcript. Assistant messages carry `toolCalls`; their
+     * total length is the per-agent tool-use count surfaced on the rail.
+     */
+    readonly messages?: ReadonlyArray<LLMMessage>;
   };
   join(): Promise<RunAgentResult>;
 }
@@ -65,6 +103,12 @@ export interface RegisterAgentThreadTaskOptions {
   readonly description?: string;
   readonly onStop?: (thread: AgentThreadTaskHandle, reason: string) => Promise<void> | void;
   readonly onSnapshot?: (snapshot: BackgroundTaskSnapshot) => void;
+  /**
+   * Cadence (ms) for polling the live subagent's accumulated token/tool
+   * counters and emitting refreshed progress snapshots. Defaults to 1000ms.
+   * Set to `0` to disable the poller (tests that drive snapshots manually).
+   */
+  readonly progressIntervalMs?: number;
   readonly summary?: {
     readonly cacheSafeParams?: CacheSafeParams;
     readonly intervalMs?: number;
@@ -92,6 +136,28 @@ export function registerAgentThreadTask(
     unsubscribeSummaryCacheSafeParams?.();
     unsubscribeSummaryCacheSafeParams = null;
   };
+  // Refresh the lifecycle record's progress from the live subagent's
+  // accumulated counters before a snapshot is emitted. This is the hop that
+  // was missing for DAEMON/collab-spawned agents: their token usage + tool
+  // calls accumulate on the live handle, but nothing copied them into the
+  // task progress the fan-out rail reads — so every row showed `tools 0
+  // tokens 0`. `updateAgentProgress` is a no-op on terminal records, so the
+  // final counts captured on the last running snapshot survive into the
+  // completion snapshot.
+  const refreshLiveProgress = (): BackgroundTaskSnapshot | undefined => {
+    const counts = liveAgentCounts(thread);
+    if (counts === undefined) return undefined;
+    try {
+      return lifecycle.updateAgentProgress(threadId, {
+        toolUseCount: counts.toolUseCount,
+        tokenCount: counts.tokenCount,
+      });
+    } catch {
+      // The record may already be removed/terminal when a late status
+      // transition arrives; dropping the progress update is harmless.
+      return undefined;
+    }
+  };
   const notifySnapshot = (snapshot: BackgroundTaskSnapshot): BackgroundTaskSnapshot => {
     opts.onSnapshot?.(snapshot);
     return snapshot;
@@ -117,6 +183,7 @@ export function registerAgentThreadTask(
         : {}),
     },
     onStop: async (reason) => {
+      stopProgressTimer();
       stopSummary();
       if (opts.onStop) {
         await opts.onStop(thread, reason);
@@ -176,12 +243,53 @@ export function registerAgentThreadTask(
     );
   }
 
+  // Status transitions alone are too coarse to surface live progress: a
+  // collab/daemon subagent stays "running" for its whole turn, so without a
+  // periodic refresh the rail would hold `tools 0 tokens 0` until completion.
+  // Poll the live handle's accumulated counters on a modest cadence and emit
+  // a refreshed snapshot whenever they advance, mirroring how the in-process
+  // AgentTool path emits progress per assistant message.
+  let lastEmittedToolUse = -1;
+  let lastEmittedTokens = -1;
+  const progressTimer: ReturnType<typeof setInterval> | undefined =
+    opts.progressIntervalMs === 0
+      ? undefined
+      : setInterval(() => {
+          if (isTerminalAgentStatus(thread.live.status.value)) return;
+          const counts = liveAgentCounts(thread);
+          if (counts === undefined) return;
+          if (
+            counts.toolUseCount === lastEmittedToolUse &&
+            counts.tokenCount === lastEmittedTokens
+          ) {
+            return;
+          }
+          lastEmittedToolUse = counts.toolUseCount;
+          lastEmittedTokens = counts.tokenCount;
+          const snapshot = refreshLiveProgress();
+          if (snapshot !== undefined) notifySnapshot(snapshot);
+        }, opts.progressIntervalMs ?? 1_000);
+  if (progressTimer !== undefined && typeof progressTimer.unref === "function") {
+    progressTimer.unref();
+  }
+  const stopProgressTimer = (): void => {
+    if (progressTimer !== undefined) clearInterval(progressTimer);
+  };
+
   const unsubscribe =
     typeof thread.live.status.subscribe === "function"
       ? thread.live.status.subscribe((status) => {
+          // Refresh live token/tool counts before mapping the status so the
+          // resulting snapshot (markRunning/complete/fail) carries them. Runs
+          // while the record is still non-terminal so the final counts land
+          // on the record before a terminal transition freezes progress.
+          refreshLiveProgress();
           const snapshot = mapAgentStatus(lifecycle, threadId, status);
           if (snapshot !== undefined) notifySnapshot(snapshot);
-          if (isTerminalAgentStatus(status)) stopSummary();
+          if (isTerminalAgentStatus(status)) {
+            stopProgressTimer();
+            stopSummary();
+          }
         })
       : () => {};
 
@@ -189,6 +297,10 @@ export function registerAgentThreadTask(
   if (joinPromise && typeof joinPromise.then === "function") {
     lifecycle.bindPromise(threadId, joinPromise, {
       onFulfilled: (result) => {
+        // Capture the final live counts while the record is still
+        // non-terminal; the imminent complete/fail transition freezes them.
+        refreshLiveProgress();
+        stopProgressTimer();
         stopSummary();
         unsubscribe();
         switch (result.outcome) {
@@ -236,6 +348,8 @@ export function registerAgentThreadTask(
         }
       },
       onRejected: (error) => {
+        refreshLiveProgress();
+        stopProgressTimer();
         stopSummary();
         unsubscribe();
         return { error: error instanceof Error ? error.message : String(error) };
@@ -244,9 +358,13 @@ export function registerAgentThreadTask(
     });
   }
 
+  refreshLiveProgress();
   const snapshot = mapAgentStatus(lifecycle, threadId, thread.live.status.value);
   if (snapshot !== undefined) notifySnapshot(snapshot);
-  if (isTerminalAgentStatus(thread.live.status.value)) stopSummary();
+  if (isTerminalAgentStatus(thread.live.status.value)) {
+    stopProgressTimer();
+    stopSummary();
+  }
   return task;
 }
 

--- a/runtime/src/tui/state/collabAgentTaskSync.ts
+++ b/runtime/src/tui/state/collabAgentTaskSync.ts
@@ -1,6 +1,7 @@
 import type { LocalAgentTaskState, TaskState, TaskStatus } from "../../tasks/types.js";
 import {
   isTaskRecord,
+  taskNumberField,
   taskStringField,
 } from "../../tasks/record-fields.js";
 
@@ -28,6 +29,8 @@ type CollabAgentTaskPatch = {
   readonly role?: string;
   readonly model?: string;
   readonly error?: string;
+  readonly toolUseCount?: number;
+  readonly tokenCount?: number;
 };
 
 function collabStatusToTaskStatus(status: unknown): TaskStatus {
@@ -134,6 +137,8 @@ function patchFromEvent(event: unknown): CollabAgentTaskPatch | null {
     const id = taskStringField(payload, "threadId");
     if (!id) return null;
     const status = collabStatusToTaskStatus(payload.status);
+    const toolUseCount = taskNumberField(payload, "toolUseCount");
+    const tokenCount = taskNumberField(payload, "tokenCount");
     return {
       id,
       status,
@@ -146,6 +151,11 @@ function patchFromEvent(event: unknown): CollabAgentTaskPatch | null {
         taskStringField(payload, "agentRoleDisplayName") ??
         taskStringField(payload, "agentRole"),
       model: taskStringField(payload, "model"),
+      // Live per-agent activity counts forwarded by the daemon collab event
+      // (spawn.ts emitTaskStatus). These are what make the fan-out rail show
+      // real `tools N tokens N` for a daemon-spawned agent instead of 0.
+      ...(toolUseCount !== undefined ? { toolUseCount } : {}),
+      ...(tokenCount !== undefined ? { tokenCount } : {}),
       error:
         collabStatusError(payload.status) ??
         (status === "failed" ? taskStringField(payload, "error") : undefined),
@@ -231,6 +241,22 @@ function applyPatch(
     patch.status === "completed" ||
     patch.status === "failed" ||
     patch.status === "killed";
+  // Merge live tool-use/token counts (forwarded by the daemon collab status
+  // event) into the task's progress so AgentsRail renders real per-agent
+  // activity. Carry the latest non-undefined count forward; never regress a
+  // known count back to 0 when a later patch omits it.
+  const nextToolUseCount =
+    patch.toolUseCount ?? previousAgent?.progress?.toolUseCount;
+  const nextTokenCount =
+    patch.tokenCount ?? previousAgent?.progress?.tokenCount;
+  const progress =
+    nextToolUseCount !== undefined || nextTokenCount !== undefined
+      ? {
+          ...previousAgent?.progress,
+          toolUseCount: nextToolUseCount ?? 0,
+          tokenCount: nextTokenCount ?? 0,
+        }
+      : previousAgent?.progress;
   const evictAfter =
     ended && previousAgent?.retain !== true
       ? previousAgent?.evictAfter ?? now + PANEL_GRACE_MS
@@ -251,14 +277,16 @@ function applyPatch(
     ...(patch.error !== undefined ? { error: patch.error } : {}),
     retrieved: previousAgent?.retrieved ?? false,
     ...(previousAgent?.messages !== undefined ? { messages: previousAgent.messages } : {}),
-    lastReportedToolCount: previousAgent?.lastReportedToolCount ?? 0,
-    lastReportedTokenCount: previousAgent?.lastReportedTokenCount ?? 0,
+    lastReportedToolCount:
+      progress?.toolUseCount ?? previousAgent?.lastReportedToolCount ?? 0,
+    lastReportedTokenCount:
+      progress?.tokenCount ?? previousAgent?.lastReportedTokenCount ?? 0,
     isBackgrounded: true,
     pendingMessages: previousAgent?.pendingMessages ?? [],
     retain: previousAgent?.retain ?? false,
     diskLoaded: previousAgent?.diskLoaded ?? false,
     selectedAgent: previousAgent?.selectedAgent ?? { name: title },
-    ...(previousAgent?.progress !== undefined ? { progress: previousAgent.progress } : {}),
+    ...(progress !== undefined ? { progress } : {}),
     ...(ended ? { endTime: previousAgent?.endTime ?? now } : {}),
     ...(previousAgent?.abortController !== undefined
       ? { abortController: previousAgent.abortController }

--- a/runtime/tests/tasks/lifecycle.test.ts
+++ b/runtime/tests/tasks/lifecycle.test.ts
@@ -351,6 +351,90 @@ describe("registerAgentThreadTask", () => {
     });
   });
 
+  it("plumbs live tokenUsage and tool-use counts into the emitted snapshot progress", async () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    const status = new FakeStatus();
+    const joined = deferred<RunAgentResult>();
+    // A live handle whose accumulated counters look like a substantial run:
+    // 51000 cumulative tokens and 3 tool calls across the transcript.
+    const live = {
+      agentId: "agent-counts",
+      abortController: new AbortController(),
+      status,
+      tokenUsage: { totalTokens: 51000 },
+      messages: [
+        { role: "user", content: "build it" },
+        {
+          role: "assistant",
+          content: "running tools",
+          toolCalls: [
+            { id: "c1", name: "Bash", arguments: "{}" },
+            { id: "c2", name: "Edit", arguments: "{}" },
+          ],
+        },
+        { role: "tool", toolCallId: "c1", toolName: "Bash", content: "ok" },
+        {
+          role: "assistant",
+          content: "one more",
+          toolCalls: [{ id: "c3", name: "Read", arguments: "{}" }],
+        },
+      ],
+    };
+    const snapshots: Array<{
+      readonly status: string;
+      readonly toolUseCount?: number;
+      readonly tokenCount?: number;
+    }> = [];
+    const thread: AgentThreadTaskHandle = {
+      threadId: "agent-counts",
+      taskPrompt: "build a CLI",
+      live: live as unknown as AgentThreadTaskHandle["live"],
+      join: () => joined.promise,
+    };
+
+    registerAgentThreadTask(lifecycle, thread, {
+      // Disable the poller; drive snapshots through status transitions so the
+      // assertions are deterministic.
+      progressIntervalMs: 0,
+      onSnapshot: (snapshot) => {
+        snapshots.push({
+          status: snapshot.status,
+          toolUseCount: snapshot.progress?.toolUseCount,
+          tokenCount: snapshot.progress?.tokenCount,
+        });
+      },
+    });
+
+    status.set({ status: "running", turnId: "turn-1", startedAtMs: 10 });
+
+    // The running snapshot must carry the REAL live counts, not 0.
+    const running = lifecycle.get("agent-counts");
+    expect(running?.status).toBe("running");
+    expect(running?.progress?.toolUseCount).toBe(3);
+    expect(running?.progress?.tokenCount).toBe(51000);
+
+    // The registration snapshot fires before the first progress refresh, so
+    // assert on the LATEST running snapshot the subscriber observed.
+    const runningSnapshots = snapshots.filter((s) => s.status === "running");
+    const latestRunning = runningSnapshots.at(-1);
+    expect(latestRunning?.toolUseCount).toBe(3);
+    expect(latestRunning?.tokenCount).toBe(51000);
+
+    joined.resolve({
+      threadId: "agent-counts",
+      durationMs: 10,
+      outcome: "completed",
+      finalMessage: "done",
+    });
+    await flush();
+
+    // The terminal snapshot must preserve the final counts, never reset to 0.
+    const completed = lifecycle.get("agent-counts");
+    expect(completed?.status).toBe("completed");
+    expect(completed?.progress?.toolUseCount).toBe(3);
+    expect(completed?.progress?.tokenCount).toBe(51000);
+  });
+
   it("starts AgentSummary for registered threads and writes progress summaries", async () => {
     vi.useFakeTimers();
     try {

--- a/runtime/tests/tui/state/collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.test.ts
@@ -170,6 +170,71 @@ describe("syncCollabAgentEventToAppState", () => {
     });
   });
 
+  it("plumbs live tool-use and token counts from collab status events into task progress", () => {
+    const spawned = applyEvent(baseState(), {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent_1",
+        newAgentNickname: "Builder",
+        newAgentRoleDisplayName: "Default",
+        prompt: "build a CLI",
+        status: { status: "pending_init" },
+      },
+    });
+
+    // First live status update carries real, nonzero per-agent activity —
+    // the exact data the live run showed as `tools 0 tokens 0`.
+    const running = applyEvent(spawned, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        agentNickname: "Builder",
+        status: "running",
+        toolUseCount: 7,
+        tokenCount: 48213,
+      },
+    });
+
+    // The rail reads task.progress.{toolUseCount,tokenCount}; assert the REAL
+    // values landed there (nonzero), not the default 0.
+    expect(running.tasks.agent_1?.progress?.toolUseCount).toBe(7);
+    expect(running.tasks.agent_1?.progress?.tokenCount).toBe(48213);
+    // The "last reported" mirrors used by the rail/notifier must follow too.
+    expect(running.tasks.agent_1?.lastReportedToolCount).toBe(7);
+    expect(running.tasks.agent_1?.lastReportedTokenCount).toBe(48213);
+
+    // A later update advances the counts...
+    const advanced = applyEvent(running, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        status: "running",
+        toolUseCount: 12,
+        tokenCount: 91044,
+      },
+    });
+    expect(advanced.tasks.agent_1?.progress?.toolUseCount).toBe(12);
+    expect(advanced.tasks.agent_1?.progress?.tokenCount).toBe(91044);
+
+    // ...and a terminal update that omits the counts must NOT regress them to 0.
+    const completed = applyEvent(advanced, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        status: "completed",
+      },
+    });
+    expect(completed.tasks.agent_1?.status).toBe("completed");
+    expect(completed.tasks.agent_1?.progress?.toolUseCount).toBe(12);
+    expect(completed.tasks.agent_1?.progress?.tokenCount).toBe(91044);
+  });
+
   it("keeps terminal retained agent tasks visible until the view releases them", () => {
     const spawned = applyEvent(baseState(), {
       type: "collab_agent_spawn_end",

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
 }));
 
 import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { syncCollabAgentEventToAppState } from "../../../src/tui/state/collabAgentTaskSync.js";
 import { AgentsRail } from "../../../src/tui/workbench/agents/AgentsRail.js";
 import { renderToAnsiString, renderToString } from "../../../src/utils/staticRender.js";
 import { ThemeProvider } from "../../../src/tui/components/design-system/ThemeProvider.js";
@@ -189,6 +190,54 @@ describe("AgentsRail", () => {
     expect(output).toContain("ok completed agent");
     expect(output).toContain("x killed agent");
     expect(output).not.toContain("hidden shell");
+  });
+
+  it("renders the real per-agent tool/token counts for a daemon-spawned collab agent", async () => {
+    // Build the task the same way the live daemon path does: a collab_agent_status
+    // event carrying nonzero tool-use + token counts flows through the sync layer.
+    let synced: AppState = { tasks: {} } as AppState;
+    syncCollabAgentEventToAppState(
+      {
+        type: "collab_agent_spawn_end",
+        payload: {
+          newThreadId: "fleet-agent",
+          newAgentNickname: "Compiler",
+          prompt: "compile and run the CLI",
+          status: { status: "running" },
+        },
+      },
+      (updater) => {
+        synced = updater(synced as never) as AppState;
+      },
+    );
+    syncCollabAgentEventToAppState(
+      {
+        type: "collab_agent_status",
+        payload: {
+          callId: "c1",
+          senderThreadId: "root",
+          threadId: "fleet-agent",
+          status: "running",
+          toolUseCount: 9,
+          tokenCount: 73210,
+        },
+      },
+      (updater) => {
+        synced = updater(synced as never) as AppState;
+      },
+    );
+
+    const railTask = (synced.tasks as Record<string, any>)["fleet-agent"];
+    const output = (await renderAgentsRail({
+      tasks: [railTask],
+      selectedAgentTaskId: "fleet-agent",
+      width: 90,
+    })).output;
+
+    // The exact bug was a frozen `tools 0 tokens 0`; the rail must now show the
+    // real values plumbed through the daemon collab status event.
+    expect(output).toContain("tools 9 tokens 73210");
+    expect(output).not.toContain("tools 0 tokens 0");
   });
 
   it("does not advertise stop shortcuts for remote agents that cannot be stopped locally", async () => {


### PR DESCRIPTION
**agenc multi-agent UX loop — iteration 3** (rubric D2 observability / foundation for D7 cost). **Live-evidenced:** driving the real TUI through a 3-agent build of a compiled TS CLI, every daemon-spawned agent row showed a frozen `tools 0 tokens 0` the whole run.

## Root cause (counts accumulated, dropped before the panel)
- `run-agent.ts` accumulates token usage (`LiveAgent.tokenUsage`) + tool calls — but
- `tasks/agent-thread.ts` `mapAgentStatus` (collab/daemon path) **never called `lifecycle.updateAgentProgress`** (the in-process `AgentTool` path did → why that path worked and this one didn't), so `BackgroundTaskSnapshot.progress` stayed 0;
- `agents/v2/spawn.ts` `emitTaskStatus` **omitted** the progress fields from the `collab_agent_status` event;
- `collabAgentTaskSync.ts` never read/merged them into `task.progress` (which `AgentsRail.tsx:205` renders).

## Fix (plumb both counts end-to-end)
`agent-thread.ts`: `liveAgentCounts()` (tokens from `tokenUsage.totalTokens`, tool-uses summed from `messages[].toolCalls`) + `refreshLiveProgress()` before every snapshot + a **1s unref'd poller** (a subagent stays "running" its whole turn, so transition-only refresh would hold 0 until completion; `updateAgentProgress` is a no-op on terminal records so the last running counts survive into completion). `spawn.ts` forwards `progress.{toolUseCount,tokenCount}`; `event-log.ts` types the two new optional fields; `collabAgentTaskSync.ts` reads + merges, carrying the latest known count forward (never regressing to 0). **No faked numbers** — both were genuinely available at the daemon boundary.

## Tests (revert-sensitive)
A collab status event carrying counts lands real values in `task.progress`, and the rail renders them. Against the pre-fix path the rail render **literally reproduces the live bug** (`tools 0 tokens 0` vs `tools 9 tokens 73210`) and progress reads `undefined` → reddens; restored → green.

## Gate
- `npm run build` ✅ exit 0 · `tsc --noEmit` ✅ 0
- full `npm run test:unit` ✅ **13,520 passed, 0 failures**
- `tui-command-visual-smoke` not worse (7 flaky, none on changed files)
- revert independently re-verified by hand (dropping the merge reddens both D2 tests).

Unblocks D7 (`/cost` can now show real per-agent token data).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG