### PR TITLE
feat(tui): /cost command + real per-agent spend in the fleet panel (UX loop iter-4, D7)

### DIFF
--- a/runtime/src/commands/cost.ts
+++ b/runtime/src/commands/cost.ts
@@ -1,0 +1,287 @@
+/**
+ * `/cost` — session cost & token transparency (aliases `/usage`, `/stats`).
+ *
+ * Surfaces what the session has actually spent: cumulative USD cost, token
+ * totals (input/output), per-model breakdown, and a per-agent breakdown for
+ * any spawned fan-out agents currently in AppState. This is the discoverable
+ * counterpart to Claude Code's `/usage` — agenc previously had no command that
+ * answered "how much has this session cost?".
+ *
+ * Honesty contract:
+ *   - Session $ and per-model $ are REAL (sourced from the CostSidecar, which
+ *     tallies provider-reported token usage against the cost registry).
+ *   - Per-agent $ is an ESTIMATE derived from the agent's total token count +
+ *     model (the TUI surfaces only a total, not an input/output split). Every
+ *     estimated figure is suffixed "est."; a dash is shown when a real number
+ *     is genuinely unknown. We never fabricate a cost.
+ *
+ * Runs `immediate: true` — no LLM round-trip.
+ *
+ * @module
+ */
+
+import React from "react";
+
+import {
+  estimateAgentCostUsd,
+  formatTokenCount,
+  formatUsdCost,
+} from "../session/cost.js";
+import { asRecord } from "../utils/record.js";
+import { openAsyncLocalJsxCommand } from "./local-jsx-command.js";
+import {
+  safeExecute,
+  type SlashCommand,
+  type SlashCommandContext,
+  type SlashCommandResult,
+} from "./types.js";
+
+/** One per-model row of real, provider-reported usage. */
+export interface CostModelRow {
+  readonly label: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly costUsd: number;
+}
+
+/** One per-agent row. Tokens are real; cost is an estimate (or unknown). */
+export interface CostAgentRow {
+  readonly label: string;
+  readonly status: string;
+  readonly tokenCount?: number;
+  readonly toolUseCount?: number;
+  /** Estimated USD cost; undefined when not derivable (no tokens/model). */
+  readonly estimatedCostUsd?: number;
+}
+
+export interface CostReport {
+  /** Real session total cost (USD), when the cost sidecar is available. */
+  readonly totalCostUsd?: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly turns?: number;
+  /** True when any model in the session has unknown pricing. */
+  readonly hasUnknownCost: boolean;
+  readonly models: readonly CostModelRow[];
+  readonly agents: readonly CostAgentRow[];
+}
+
+interface CostSidecarLike {
+  getTotalCostUsd?: () => number;
+  getTotalInputTokens?: () => number;
+  getTotalOutputTokens?: () => number;
+  getTotalTurns?: () => number;
+  hasUnknownModelCost?: () => boolean;
+  getSessionModelUsage?: () => ReadonlyArray<{
+    readonly model: string;
+    readonly provider?: string;
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+    readonly costUsd: number;
+  }>;
+}
+
+function readCostSidecar(session: unknown): CostSidecarLike | null {
+  const services = asRecord(asRecord(session)?.services);
+  const sidecar = services?.costSidecar;
+  return asRecord(sidecar) as CostSidecarLike | null;
+}
+
+function callNumber(fn: (() => number) | undefined): number | undefined {
+  if (typeof fn !== "function") return undefined;
+  const value = fn();
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readSessionTotals(sidecar: CostSidecarLike | null): {
+  totalCostUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  turns?: number;
+  hasUnknownCost: boolean;
+  models: CostModelRow[];
+} {
+  if (sidecar === null) {
+    return { hasUnknownCost: false, models: [] };
+  }
+  const models: CostModelRow[] = (sidecar.getSessionModelUsage?.() ?? []).map(
+    (usage) => ({
+      label: usage.provider
+        ? `${usage.provider}/${usage.model}`
+        : usage.model,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      costUsd: usage.costUsd,
+    }),
+  );
+  return {
+    ...(callNumber(sidecar.getTotalCostUsd) !== undefined
+      ? { totalCostUsd: callNumber(sidecar.getTotalCostUsd) }
+      : {}),
+    ...(callNumber(sidecar.getTotalInputTokens) !== undefined
+      ? { inputTokens: callNumber(sidecar.getTotalInputTokens) }
+      : {}),
+    ...(callNumber(sidecar.getTotalOutputTokens) !== undefined
+      ? { outputTokens: callNumber(sidecar.getTotalOutputTokens) }
+      : {}),
+    ...(callNumber(sidecar.getTotalTurns) !== undefined
+      ? { turns: callNumber(sidecar.getTotalTurns) }
+      : {}),
+    hasUnknownCost:
+      typeof sidecar.hasUnknownModelCost === "function"
+        ? sidecar.hasUnknownModelCost() === true
+        : false,
+    models,
+  };
+}
+
+function readAgentRows(appState: unknown): CostAgentRow[] {
+  const tasks = asRecord(asRecord(appState)?.tasks);
+  if (tasks === null) return [];
+  const rows: CostAgentRow[] = [];
+  for (const value of Object.values(tasks)) {
+    const task = asRecord(value);
+    if (task === null || task.type !== "local_agent") continue;
+    // Skip the main-session pseudo-task; it is the orchestrator, surfaced
+    // separately as the session totals, not a spawned fan-out agent.
+    if (task.agentType === "main-session") continue;
+    const progress = asRecord(task.progress);
+    const tokenCount =
+      typeof progress?.tokenCount === "number" ? progress.tokenCount : undefined;
+    const toolUseCount =
+      typeof progress?.toolUseCount === "number"
+        ? progress.toolUseCount
+        : undefined;
+    const model = typeof task.model === "string" ? task.model : undefined;
+    const estimate = estimateAgentCostUsd({ totalTokens: tokenCount, model });
+    const name =
+      typeof task.description === "string" && task.description.trim().length > 0
+        ? task.description.trim()
+        : typeof task.agentId === "string"
+          ? task.agentId
+          : "agent";
+    const role = typeof task.agentType === "string" ? task.agentType : "agent";
+    rows.push({
+      label: `${truncate(name, 40)} · ${role}`,
+      status: typeof task.status === "string" ? task.status : "unknown",
+      ...(tokenCount !== undefined ? { tokenCount } : {}),
+      ...(toolUseCount !== undefined ? { toolUseCount } : {}),
+      ...(estimate !== null ? { estimatedCostUsd: estimate.costUsd } : {}),
+    });
+  }
+  return rows;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+/**
+ * Build the cost report from a slash-command context. Pure aside from the two
+ * read-only accessors (`session.services.costSidecar`, `appState.getAppState`)
+ * — exported so tests can feed known usage and assert the rendered numbers.
+ */
+export function buildCostReport(ctx: SlashCommandContext): CostReport {
+  const sidecar = readCostSidecar(ctx.session);
+  const totals = readSessionTotals(sidecar);
+  const getAppState = ctx.appState?.getAppState;
+  const agents =
+    typeof getAppState === "function" ? readAgentRows(getAppState()) : [];
+  return {
+    ...(totals.totalCostUsd !== undefined
+      ? { totalCostUsd: totals.totalCostUsd }
+      : {}),
+    ...(totals.inputTokens !== undefined
+      ? { inputTokens: totals.inputTokens }
+      : {}),
+    ...(totals.outputTokens !== undefined
+      ? { outputTokens: totals.outputTokens }
+      : {}),
+    ...(totals.inputTokens !== undefined && totals.outputTokens !== undefined
+      ? { totalTokens: totals.inputTokens + totals.outputTokens }
+      : {}),
+    ...(totals.turns !== undefined ? { turns: totals.turns } : {}),
+    hasUnknownCost: totals.hasUnknownCost,
+    models: totals.models,
+    agents,
+  };
+}
+
+/**
+ * Render a {@link CostReport} as the plain-text fallback (used when the TUI
+ * JSX surface isn't available, and as the source the modal re-parses).
+ */
+export function formatCostReport(report: CostReport): string {
+  const lines: string[] = [];
+  if (report.totalCostUsd !== undefined) {
+    const unknown = report.hasUnknownCost ? " (some pricing unknown)" : "";
+    lines.push(`Session cost: ${formatUsdCost(report.totalCostUsd)}${unknown}`);
+  } else {
+    lines.push("Session cost: — (cost tracking unavailable)");
+  }
+  const input = report.inputTokens;
+  const output = report.outputTokens;
+  if (input !== undefined || output !== undefined) {
+    lines.push(
+      `  • tokens: ${formatTokenCount(input ?? 0)} in / ${formatTokenCount(output ?? 0)} out` +
+        (report.turns !== undefined ? ` · turns=${report.turns}` : ""),
+    );
+  }
+  if (report.models.length > 0) {
+    lines.push("Models:");
+    for (const m of report.models) {
+      lines.push(
+        `  ${m.label}: ${formatTokenCount(m.inputTokens)} in, ${formatTokenCount(m.outputTokens)} out (${formatUsdCost(m.costUsd)})`,
+      );
+    }
+  }
+  if (report.agents.length > 0) {
+    lines.push("Agents:");
+    for (const a of report.agents) {
+      const tokens =
+        a.tokenCount !== undefined ? `${formatTokenCount(a.tokenCount)} tokens` : "—";
+      const spend =
+        a.estimatedCostUsd !== undefined
+          ? `${formatUsdCost(a.estimatedCostUsd)} est.`
+          : "—";
+      lines.push(`  ${a.status} ${a.label}: ${tokens} · ${spend}`);
+    }
+  } else {
+    lines.push("Agents: none active");
+  }
+  lines.push("  • per-agent $ is estimated from token totals; — = unknown.");
+  return lines.join("\n");
+}
+
+async function openCostModal(
+  ctx: SlashCommandContext,
+  report: CostReport,
+): Promise<boolean> {
+  return openAsyncLocalJsxCommand(ctx, async (close) => {
+    const { CostUsageModal } = await import(
+      "../tui/components/v2/CostUsageModal.js"
+    );
+    return React.createElement(CostUsageModal, { report, onDone: close });
+  });
+}
+
+export const costCommand: SlashCommand = {
+  name: "cost",
+  aliases: ["usage", "stats"],
+  description: "Show session cost, token usage, and per-agent spend",
+  supportedSurfaces: ["runtime", "daemon-tui"],
+  immediate: true,
+  supportsNonInteractive: true,
+  execute: (ctx: SlashCommandContext): Promise<SlashCommandResult> =>
+    safeExecute(async () => {
+      const report = buildCostReport(ctx);
+      const text = formatCostReport(report);
+      if (await openCostModal(ctx, report)) {
+        return { kind: "skip" };
+      }
+      return { kind: "text", text };
+    }),
+};

--- a/runtime/src/commands/registry.ts
+++ b/runtime/src/commands/registry.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types.js";
 import { helpCommand } from "./help.js";
 import { statusCommand } from "./status.js";
+import { costCommand } from "./cost.js";
 import { diffCommand } from "./diff.js";
 import { exitCommand } from "./exit.js";
 import { clearCommand } from "./clear.js";
@@ -127,8 +128,8 @@ function commandSupportsSurface(
  * Build the default user-invocable slash registry.
  *
  * Presentation order matches the runtime stabilization minimal surface:
- * /help, /status, /model, /provider, /permissions, /plan, /agents, /tasks,
- * /config, /hooks, /skills, /mcp, /plugins, /memory, /resume,
+ * /help, /status, /cost, /model, /provider, /permissions, /plan, /agents,
+ * /tasks, /config, /hooks, /skills, /mcp, /plugins, /memory, /resume,
  * /clear, /compact, /context, /diff, protocol commands, /exit.
  */
 export function buildDefaultRegistry(
@@ -137,6 +138,7 @@ export function buildDefaultRegistry(
   return CommandRegistry.fromCommands([
     helpCommand,
     statusCommand,
+    costCommand,
     modelCommand,
     providerCommand,
     permissionsCommand,

--- a/runtime/src/session/cost.ts
+++ b/runtime/src/session/cost.ts
@@ -572,6 +572,70 @@ function costLookupKeys(
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// Per-agent cost estimation (D7 fleet-panel spend column)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Default split assumption used when only a TOTAL token count is known for a
+ * spawned agent. The TUI fan-out rail surfaces `progress.tokenCount`
+ * (= `live.tokenUsage.totalTokens`) but NOT the input/output breakdown, so a
+ * single rate can't be applied directly. A 3:1 input:output ratio is the
+ * conventional shape of a tool-using coding turn (large prompt + context,
+ * smaller completion). The resulting figure is always surfaced as an
+ * ESTIMATE — never presented as a billed amount.
+ */
+const AGENT_COST_ESTIMATE_INPUT_SHARE = 0.75;
+
+export interface AgentCostEstimate {
+  readonly costUsd: number;
+  /** True only when the model resolved to a known registry entry. */
+  readonly known: boolean;
+}
+
+/**
+ * Estimate the USD cost of a spawned agent from its total token count and
+ * model slug, reusing the same {@link computeUsdCostWithResolution} machinery
+ * the live cost sidecar and per-agent dollar caps use. Returns `null` when no
+ * usable token count is available (so the caller renders a dash rather than a
+ * fabricated `$0.00`).
+ *
+ * The split between input/output tokens is unknown on the TUI side, so this
+ * applies {@link AGENT_COST_ESTIMATE_INPUT_SHARE} and flags the result as an
+ * estimate. Honesty contract: callers MUST label the output (e.g. trailing
+ * "est.") and MUST dash when this returns `null`.
+ */
+export function estimateAgentCostUsd(params: {
+  readonly totalTokens: number | undefined;
+  readonly model: string | undefined;
+  readonly provider?: string;
+  readonly registry?: Readonly<Record<string, ModelCostEntry>>;
+}): AgentCostEstimate | null {
+  const total = params.totalTokens;
+  if (total === undefined || !Number.isFinite(total) || total <= 0) return null;
+  const model = params.model?.trim();
+  if (model === undefined || model.length === 0) return null;
+  const inputTokens = Math.round(total * AGENT_COST_ESTIMATE_INPUT_SHARE);
+  const outputTokens = Math.max(0, total - inputTokens);
+  const usage: ModelUsage = {
+    model,
+    ...(params.provider !== undefined ? { provider: params.provider } : {}),
+    inputTokens,
+    outputTokens,
+    cachedInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    reasoningOutputTokens: 0,
+    webSearchRequests: 0,
+    totalTokens: total,
+    turns: 0,
+  };
+  const resolved = computeUsdCostWithResolution(
+    usage,
+    params.registry ?? DEFAULT_MODEL_COSTS,
+  );
+  return { costUsd: resolved.costUsd, known: resolved.known };
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Formatting helpers
 // ─────────────────────────────────────────────────────────────────────
 

--- a/runtime/src/tui/components/CoordinatorAgentStatus.tsx
+++ b/runtime/src/tui/components/CoordinatorAgentStatus.tsx
@@ -11,9 +11,10 @@ import { useTerminalSize } from '../hooks/useTerminalSize';
 import { Box } from '../ink.js';
 import { type AppState, useAppState, useSetAppState } from '../state/AppState.js';
 import { enterTeammateView, exitTeammateView } from '../state/teammateViewHelpers';
-import { isPanelAgentTask, type LocalAgentTaskState } from '../../tasks/LocalAgentTask/LocalAgentTask';
+import { isLocalAgentTask, isPanelAgentTask, type LocalAgentTaskState } from '../../tasks/LocalAgentTask/LocalAgentTask';
 import { agentRolePresentation } from '../../agents/role-presentation.js';
 import { formatDuration, formatNumber } from '../../utils/format';
+import { estimateAgentCostUsd, formatUsdCost } from '../../session/cost.js';
 import { evictTerminalTask } from '../../utils/task/framework';
 import { isTerminalStatus } from './tasks/taskStatusUtils';
 import { AURA_LIFECYCLE_GLYPHS } from '../../utils/theme.js';
@@ -150,7 +151,7 @@ export function CoordinatorTaskPanel(): React.ReactNode {
         <ThemedText color="text2">{visibleTasks.length} active</ThemedText>
       </Box>
       <FleetHeader />
-      <MainLine isSelected={selectedIndex === 0} isViewed={viewingAgentTaskId === undefined} onClick={() => exitTeammateView(setAppState)} />
+      <MainLine isSelected={selectedIndex === 0} isViewed={viewingAgentTaskId === undefined} tokens={orchestratorTokenLabel(tasks)} onClick={() => exitTeammateView(setAppState)} />
       {visibleTasks.map((task, i) => <AgentLine key={task.id} task={task} name={nameByAgentId.get(task.id)} isSelected={selectedIndex === i + 1} isViewed={viewingAgentTaskId === task.id} onClick={() => enterTeammateView(task.id, setAppState)} />)}
       {focusedTask ? <FocusedAgentBlock task={focusedTask} name={nameByAgentId.get(focusedTask.id)} /> : null}
     </ThemedBox>;
@@ -206,6 +207,42 @@ function taskLastAction(task: LocalAgentTaskState): string {
 function taskTokenLabel(task: LocalAgentTaskState): string {
   const tokenCount = task.progress?.tokenCount;
   return tokenCount !== undefined && tokenCount > 0 ? `${formatNumber(tokenCount)} tokens` : '—';
+}
+
+/**
+ * Per-agent spend label for the focused-agent block. The TUI surfaces a per-
+ * agent TOTAL token count (progress.tokenCount) and the agent's model, but no
+ * input/output split — so this is an ESTIMATE (suffixed "est.") derived via
+ * the same cost registry the live sidecar uses. Returns "—" when no real
+ * token count / resolvable model is available; never fabricates "$0.00".
+ */
+export function taskSpendLabel(task: LocalAgentTaskState): string {
+  const estimate = estimateAgentCostUsd({
+    totalTokens: task.progress?.tokenCount,
+    model: task.model,
+  });
+  if (estimate === null) return '—';
+  return `${formatUsdCost(estimate.costUsd)} est.`;
+}
+
+/**
+ * Token label for the orchestrator (main-session) row. Reads the live
+ * main-session task's accumulated token count from AppState so the row shows
+ * real usage instead of a hardcoded dash. "—" only when no main-session task
+ * has reported a token count yet.
+ */
+export function orchestratorTokenLabel(tasks: AppState['tasks']): string {
+  let total = 0;
+  for (const task of Object.values(tasks)) {
+    if (
+      isLocalAgentTask(task) &&
+      task.agentType === 'main-session' &&
+      typeof task.progress?.tokenCount === 'number'
+    ) {
+      total += task.progress.tokenCount;
+    }
+  }
+  return total > 0 ? `${formatNumber(total)} tokens` : '—';
 }
 
 function taskScopeLabel(task: LocalAgentTaskState): string {
@@ -302,7 +339,7 @@ function FocusedAgentBlock({
       </Box>
       <Box flexDirection="row">
         <ThemedText color="muted3">progress </ThemedText><ThemedText color="worker">{progressGlyph} {task.progress?.toolUseCount ?? 0} tools</ThemedText>
-        <ThemedText color="muted3"> · spend —</ThemedText>
+        <ThemedText color="muted3"> · spend </ThemedText><ThemedText color="text2">{taskSpendLabel(task)}</ThemedText>
       </Box>
       {queuedCount > 0 ? (
         <Box flexDirection="row">
@@ -320,13 +357,19 @@ function FocusedAgentBlock({
   );
 }
 
-function MainLine(t0) {
+function MainLine(t0: {
+  isSelected?: boolean;
+  isViewed?: boolean;
+  tokens?: string;
+  onClick: () => void;
+}) {
   const {
     isSelected,
     isViewed,
+    tokens,
     onClick
   } = t0;
-  return <FleetRow nameRole="orchestrator · Orchestrator" status={`${AURA_LIFECYCLE_GLYPHS.done} active`} statusColor="agenc" lastAction="main session" tokens="—" age="now" selected={isSelected || isViewed} onClick={onClick} />;
+  return <FleetRow nameRole="orchestrator · Orchestrator" status={`${AURA_LIFECYCLE_GLYPHS.done} active`} statusColor="agenc" lastAction="main session" tokens={tokens ?? "—"} age="now" selected={isSelected || isViewed} onClick={onClick} />;
 }
 type AgentLineProps = {
   task: LocalAgentTaskState;

--- a/runtime/src/tui/components/v2/CostUsageModal.tsx
+++ b/runtime/src/tui/components/v2/CostUsageModal.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+
+import type { CostReport } from '../../../commands/cost.js'
+import { formatTokenCount, formatUsdCost } from '../../../session/cost.js'
+import { Box, useInput } from '../../ink.js'
+import ThemedText from '../design-system/ThemedText.js'
+import { Popup } from './primitives.js'
+
+function Row({
+  label,
+  value,
+  detail,
+  labelColor = 'subtle',
+}: {
+  readonly label: string
+  readonly value: string
+  readonly detail?: string
+  readonly labelColor?: 'subtle' | 'inactive' | 'agenc'
+}): React.ReactNode {
+  return (
+    <Box flexDirection="row" gap={2}>
+      <Box width={26}>
+        <ThemedText color={labelColor} wrap="truncate-end">
+          {label}
+        </ThemedText>
+      </Box>
+      <Box width={16}>
+        <ThemedText color="text2" wrap="truncate-end">
+          {value}
+        </ThemedText>
+      </Box>
+      <ThemedText color="muted3" wrap="truncate-end">
+        {detail ?? ''}
+      </ThemedText>
+    </Box>
+  )
+}
+
+export function CostUsageModal({
+  report,
+  onDone,
+  active = true,
+}: {
+  readonly report: CostReport
+  readonly onDone: () => void
+  readonly active?: boolean
+}): React.ReactNode {
+  useInput(
+    (input, key) => {
+      if (key.escape || input === 'q') onDone()
+    },
+    { isActive: active },
+  )
+
+  const totalCost =
+    report.totalCostUsd !== undefined
+      ? `${formatUsdCost(report.totalCostUsd)}${report.hasUnknownCost ? ' *' : ''}`
+      : '—'
+  const tokenDetail =
+    report.inputTokens !== undefined || report.outputTokens !== undefined
+      ? `${formatTokenCount(report.inputTokens ?? 0)} in · ${formatTokenCount(report.outputTokens ?? 0)} out` +
+        (report.turns !== undefined ? ` · ${report.turns} turns` : '')
+      : '—'
+
+  return (
+    <Popup
+      title="cost"
+      status={
+        report.totalCostUsd !== undefined
+          ? `session ${formatUsdCost(report.totalCostUsd)}`
+          : 'cost tracking unavailable'
+      }
+      minHeight={18}
+      footer={[{ keyName: 'q', label: 'close' }]}
+    >
+      <Box flexDirection="column" gap={1}>
+        <Box flexDirection="row" gap={2}>
+          <ThemedText color="agenc">SESSION</ThemedText>
+          <ThemedText color="text2">{totalCost}</ThemedText>
+        </Box>
+        <Row label="tokens" value={tokenDetail} labelColor="inactive" />
+        {report.hasUnknownCost ? (
+          <ThemedText color="muted3">* some model pricing unknown — cost approximate</ThemedText>
+        ) : null}
+      </Box>
+
+      {report.models.length > 0 ? (
+        <Box flexDirection="column">
+          <ThemedText color="agenc">BY MODEL</ThemedText>
+          <Box minHeight={1} />
+          {report.models.map((m, i) => (
+            <Row
+              key={`model-${i}`}
+              label={m.label}
+              value={formatUsdCost(m.costUsd)}
+              detail={`${formatTokenCount(m.inputTokens)} in · ${formatTokenCount(m.outputTokens)} out`}
+            />
+          ))}
+        </Box>
+      ) : null}
+
+      <Box flexDirection="column">
+        <ThemedText color="agenc">BY AGENT</ThemedText>
+        <Box minHeight={1} />
+        {report.agents.length === 0 ? (
+          <ThemedText color="muted3">no fan-out agents active</ThemedText>
+        ) : (
+          report.agents.map((a, i) => (
+            <Row
+              key={`agent-${i}`}
+              label={a.label}
+              value={
+                a.estimatedCostUsd !== undefined
+                  ? `${formatUsdCost(a.estimatedCostUsd)} est.`
+                  : '—'
+              }
+              detail={`${a.status} · ${a.tokenCount !== undefined ? `${formatTokenCount(a.tokenCount)} tokens` : '—'}`}
+            />
+          ))
+        )}
+      </Box>
+      <ThemedText color="muted3">
+        per-agent $ estimated from token totals; — = unknown
+      </ThemedText>
+    </Popup>
+  )
+}
+
+export default CostUsageModal

--- a/runtime/tests/commands/command-surface.test.ts
+++ b/runtime/tests/commands/command-surface.test.ts
@@ -28,6 +28,7 @@ import type { SlashCommandContext } from "./types.js";
 const MINIMAL_NAMES = [
   "help",
   "status",
+  "cost",
   "model",
   "provider",
   "permissions",

--- a/runtime/tests/commands/cost.test.ts
+++ b/runtime/tests/commands/cost.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildCostReport,
+  costCommand,
+  formatCostReport,
+} from "../../src/commands/cost.js";
+import { buildDefaultRegistry } from "../../src/commands/registry.js";
+import type {
+  SlashCommandContext,
+  SlashCommandResult,
+} from "../../src/commands/types.js";
+
+vi.mock("bun:bundle", () => ({ feature: () => false }));
+
+/**
+ * A fake CostSidecar exposing only the accessors `/cost` reads. The values
+ * are real, provider-reported-shaped numbers so the assertions exercise the
+ * actual formatting path rather than placeholders.
+ */
+function fakeCostSidecar() {
+  return {
+    getTotalCostUsd: () => 1.2345,
+    getTotalInputTokens: () => 120_000,
+    getTotalOutputTokens: () => 30_000,
+    getTotalTurns: () => 7,
+    hasUnknownModelCost: () => false,
+    getSessionModelUsage: () => [
+      {
+        model: "claude-opus-4-7",
+        provider: "anthropic",
+        inputTokens: 120_000,
+        outputTokens: 30_000,
+        totalTokens: 150_000,
+        costUsd: 1.2345,
+      },
+    ],
+  };
+}
+
+function contextWith(opts: {
+  sidecar?: unknown;
+  appState?: unknown;
+  setToolJSX?: (jsx: unknown) => void;
+}): SlashCommandContext {
+  return {
+    session: {
+      conversationId: "session-1",
+      services: opts.sidecar !== undefined ? { costSidecar: opts.sidecar } : {},
+    } as SlashCommandContext["session"],
+    argsRaw: "",
+    cwd: "/tmp/project",
+    home: "/tmp",
+    ...(opts.appState !== undefined || opts.setToolJSX !== undefined
+      ? {
+          appState: {
+            ...(opts.appState !== undefined
+              ? { getAppState: () => opts.appState }
+              : {}),
+            ...(opts.setToolJSX !== undefined
+              ? { setToolJSX: opts.setToolJSX }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function text(result: SlashCommandResult): string {
+  expect(result.kind).toBe("text");
+  return result.kind === "text" ? result.text : "";
+}
+
+const AGENT_APP_STATE = {
+  tasks: {
+    worker: {
+      id: "agent-1",
+      type: "local_agent",
+      status: "running",
+      agentType: "worker",
+      model: "claude-opus-4-7",
+      description: "build the parser",
+      agentId: "agent-1",
+      progress: { toolUseCount: 4, tokenCount: 40_000 },
+    },
+    mainSession: {
+      id: "main",
+      type: "local_agent",
+      status: "running",
+      agentType: "main-session",
+      description: "orchestrator",
+      agentId: "main",
+      progress: { toolUseCount: 1, tokenCount: 9_000 },
+    },
+  },
+};
+
+describe("/cost", () => {
+  it("is registered with /usage and /stats aliases on the default surface", () => {
+    const registry = buildDefaultRegistry();
+    expect(registry.find("cost")?.name).toBe("cost");
+    expect(registry.find("usage")?.name).toBe("cost");
+    expect(registry.find("stats")?.name).toBe("cost");
+  });
+
+  it("reports real session cost + token totals from the cost sidecar", () => {
+    const report = buildCostReport(
+      contextWith({ sidecar: fakeCostSidecar() }),
+    );
+    expect(report.totalCostUsd).toBeCloseTo(1.2345, 4);
+    expect(report.inputTokens).toBe(120_000);
+    expect(report.outputTokens).toBe(30_000);
+    expect(report.totalTokens).toBe(150_000);
+    expect(report.turns).toBe(7);
+    expect(report.models).toHaveLength(1);
+    expect(report.models[0]).toMatchObject({
+      label: "anthropic/claude-opus-4-7",
+      inputTokens: 120_000,
+      outputTokens: 30_000,
+    });
+    expect(report.models[0]!.costUsd).toBeCloseTo(1.2345, 4);
+
+    const out = formatCostReport(report);
+    expect(out).toContain("Session cost: $1.23");
+    expect(out).toContain("120.0K in / 30.0K out");
+    expect(out).toContain("anthropic/claude-opus-4-7");
+  });
+
+  it("derives a per-agent token + estimated-$ breakdown with real numbers", () => {
+    const report = buildCostReport(
+      contextWith({ sidecar: fakeCostSidecar(), appState: AGENT_APP_STATE }),
+    );
+    // Only the spawned worker agent is listed; main-session is the orchestrator.
+    expect(report.agents).toHaveLength(1);
+    const agent = report.agents[0]!;
+    expect(agent.label).toBe("build the parser · worker");
+    expect(agent.status).toBe("running");
+    expect(agent.tokenCount).toBe(40_000);
+    // Estimated cost is derived from real tokens + model — NOT a fabricated
+    // value, and strictly positive for a known-priced model.
+    expect(agent.estimatedCostUsd).toBeDefined();
+    expect(agent.estimatedCostUsd!).toBeGreaterThan(0);
+
+    const out = formatCostReport(report);
+    expect(out).toContain("running build the parser · worker:");
+    expect(out).toContain("40.0K tokens");
+    expect(out).toContain("est.");
+  });
+
+  it("dashes per-agent spend when the token count is unknown (never $0.00)", () => {
+    const report = buildCostReport(
+      contextWith({
+        sidecar: fakeCostSidecar(),
+        appState: {
+          tasks: {
+            noTokens: {
+              id: "a2",
+              type: "local_agent",
+              status: "running",
+              agentType: "worker",
+              model: "claude-opus-4-7",
+              description: "warming up",
+              agentId: "a2",
+              progress: { toolUseCount: 0 },
+            },
+          },
+        },
+      }),
+    );
+    expect(report.agents[0]!.estimatedCostUsd).toBeUndefined();
+    expect(formatCostReport(report)).toMatch(/warming up · worker: — · —/);
+  });
+
+  it("degrades gracefully when no cost sidecar is wired", () => {
+    const report = buildCostReport(contextWith({}));
+    expect(report.totalCostUsd).toBeUndefined();
+    expect(formatCostReport(report)).toContain(
+      "Session cost: — (cost tracking unavailable)",
+    );
+  });
+
+  it("opens the cost modal when the interactive TUI surface is available", async () => {
+    const setToolJSX = vi.fn();
+    const result = await costCommand.execute(
+      contextWith({ sidecar: fakeCostSidecar(), setToolJSX }),
+    );
+    expect(result).toEqual({ kind: "skip" });
+    expect(setToolJSX).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isLocalJSXCommand: true,
+        jsx: expect.anything(),
+      }),
+    );
+  });
+
+  it("falls back to text output (no TUI surface) with the real numbers", async () => {
+    const result = await costCommand.execute(
+      contextWith({ sidecar: fakeCostSidecar(), appState: AGENT_APP_STATE }),
+    );
+    const out = text(result);
+    expect(out).toContain("Session cost: $1.23");
+    expect(out).toContain("build the parser · worker");
+  });
+});

--- a/runtime/tests/commands/registry.test.ts
+++ b/runtime/tests/commands/registry.test.ts
@@ -10,6 +10,7 @@ import type { SlashCommand, SlashCommandResult } from "./types.js";
 const MINIMAL_REGISTRY_NAMES = [
   "help",
   "status",
+  "cost",
   "model",
   "provider",
   "permissions",
@@ -38,6 +39,7 @@ const MINIMAL_REGISTRY_NAMES = [
 const DAEMON_TUI_REGISTRY_NAMES = [
   "help",
   "status",
+  "cost",
   "model",
   "provider",
   "permissions",
@@ -71,7 +73,6 @@ const REMOVED_TUI_COMMANDS = [
   "color",
   "commit",
   "copy",
-  "cost",
   "doctor",
   "effort",
   "enter-worktree",
@@ -94,10 +95,8 @@ const REMOVED_TUI_COMMANDS = [
   "review",
   "rewind",
   "sandbox",
-  "stats",
   "terminal-setup",
   "theme",
-  "usage",
   "vim",
   "wiki",
 ] as const;

--- a/runtime/tests/commands/tui-command-list.test.ts
+++ b/runtime/tests/commands/tui-command-list.test.ts
@@ -18,6 +18,7 @@ import {
 const MINIMAL_TUI_NAMES = [
   "help",
   "status",
+  "cost",
   "model",
   "provider",
   "permissions",
@@ -46,6 +47,7 @@ const MINIMAL_TUI_NAMES = [
 const DAEMON_TUI_NAMES = [
   "help",
   "status",
+  "cost",
   "model",
   "provider",
   "permissions",
@@ -77,7 +79,6 @@ const REMOVED_TUI_NAMES = [
   "color",
   "commit",
   "copy",
-  "cost",
   "doctor",
   "export",
   "files",
@@ -93,10 +94,8 @@ const REMOVED_TUI_NAMES = [
   "review",
   "rewind",
   "sandbox",
-  "stats",
   "terminal-setup",
   "theme",
-  "usage",
   "wiki",
 ] as const;
 

--- a/runtime/tests/tui/coordinator-fleet-spend.test.ts
+++ b/runtime/tests/tui/coordinator-fleet-spend.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  orchestratorTokenLabel,
+  taskSpendLabel,
+} from "../../src/tui/components/CoordinatorAgentStatus.js";
+import type { LocalAgentTaskState } from "../../src/tasks/LocalAgentTask/LocalAgentTask.js";
+
+/**
+ * Build a minimal LocalAgentTaskState carrying the fields the fleet-panel
+ * spend/token columns read. Only `progress`, `model`, and `agentType` are
+ * load-bearing here.
+ */
+function agentTask(
+  overrides: Partial<LocalAgentTaskState> = {},
+): LocalAgentTaskState {
+  return {
+    id: "agent-1",
+    type: "local_agent",
+    status: "running",
+    description: "build the parser",
+    startTime: 0,
+    outputFile: "urn:agenc:task:agent-1:output",
+    outputOffset: 0,
+    notified: false,
+    agentId: "agent-1",
+    prompt: "build the parser",
+    agentType: "worker",
+    model: "claude-opus-4-7",
+    retrieved: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    isBackgrounded: false,
+    pendingMessages: [],
+    retain: false,
+    diskLoaded: false,
+    progress: { toolUseCount: 4, tokenCount: 40_000 },
+    ...overrides,
+  } as LocalAgentTaskState;
+}
+
+describe("fleet panel spend column (D7)", () => {
+  it("renders a real estimated spend for an agent with real tokens + model", () => {
+    // This is the swap that replaced the hardcoded `· spend —`. With real
+    // tokenCount + a known-priced model, the label is a positive estimate.
+    const label = taskSpendLabel(agentTask());
+    expect(label).not.toBe("—");
+    expect(label).toMatch(/^\$\d/);
+    expect(label).toContain("est.");
+  });
+
+  it("dashes spend only when the data is genuinely unknown (no $0.00)", () => {
+    expect(taskSpendLabel(agentTask({ progress: { toolUseCount: 0 } }))).toBe(
+      "—",
+    );
+    expect(
+      taskSpendLabel(
+        agentTask({ model: undefined, progress: { tokenCount: 40_000 } }),
+      ),
+    ).toBe("—");
+  });
+
+  it("renders the orchestrator row's real session tokens (not a hardcoded dash)", () => {
+    // Replaces the hardcoded `tokens=\"—\"` on the orchestrator MainLine.
+    const tasks = {
+      main: agentTask({
+        id: "main",
+        agentType: "main-session",
+        progress: { tokenCount: 9_000 },
+      }),
+      worker: agentTask(),
+    } as unknown as Record<string, LocalAgentTaskState>;
+    const label = orchestratorTokenLabel(tasks);
+    expect(label).not.toBe("—");
+    expect(label).toContain("tokens");
+  });
+
+  it("dashes the orchestrator tokens when no main-session usage has landed", () => {
+    const tasks = { worker: agentTask() } as unknown as Record<
+      string,
+      LocalAgentTaskState
+    >;
+    // Only a spawned worker is present (no main-session task) → dash.
+    expect(orchestratorTokenLabel(tasks)).toBe("—");
+  });
+});


### PR DESCRIPTION
**agenc multi-agent UX loop — iteration 4** (rubric D7 "cost/token transparency" — agenc's **worst-scoring dimension**). agenc had no `/cost`/`/usage` command, and the AGENT FLEET panel hardcoded `· spend —` + orchestrator `tokens="—"`. Now that per-agent tokens are plumbed (#1329), these become real.

## Cost data (reused, not reinvented)
The `CostSidecar` (`session/cost.ts`) tracks **real** cumulative cost + tokens against a provider-aware pricing registry (`getTotalCostUsd`, per-model usage, turns). Per-agent **tokens** are real; per-agent **$** is *not* tracked on the TUI task (the daemon computes it but it doesn't reach `LocalAgentTaskState`), so per-agent $ is **estimated** from real tokens + model and always labeled `est.`, with `—` only when genuinely unknown — **never a fabricated `$0.00`.**

## What ships
- **`/cost` command** (aliases `/usage`, `/stats`) + `CostUsageModal`: real session cost (USD) + token totals + turns + per-model breakdown + a per-agent breakdown (real tokens, `est.` $). Registered in the registry + `/`-menu (the names were in "removed-commands" test lists — moved into the available set).
- **Fleet panel:** `· spend —` → `taskSpendLabel(task)` (real-token-derived `$… est.`, dash only when unknown); orchestrator `tokens="—"` → real session tokens via `orchestratorTokenLabel(tasks)`.

## Tests (revert-sensitive)
`/cost` shows real session cost/tokens + a per-agent line; the fleet panel renders a real estimated spend / real orchestrator tokens, dashing only when unknown (no `$0.00`). Against the pre-fix panel the swap helpers are absent (`taskSpendLabel is not a function`) and the 4 fleet assertions redden; restored → green.

## Gate
- `npm run build` ✅ exit 0 · `tsc --noEmit` ✅ 0
- full `npm run test:unit` ✅ **13,531 passed, 0 failures**
- `tui-command-visual-smoke` not worse
- revert independently re-verified by hand (stashing the fleet swap reddens 4 fleet tests).

Takes D7 from score 1 (no cost anywhere) toward the bar — real session $/tokens + honest per-agent estimates.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG