### PR TITLE
fix(tools): model-aware tool-result cap (context-blowout backstop)

### DIFF
--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -138,6 +138,10 @@ import {
   attachToolRuntimeContext,
   type ToolRuntimeAttemptContext,
 } from "./runtimes/context.js";
+import {
+  DEFAULT_BYTES_PER_TOKEN,
+  detectContentType,
+} from "../llm/token-estimation.js";
 import { enforceRuntimeSandboxAttempt } from "./runtimes/sandboxing.js";
 import {
   createTransactionGuardContextFromEnv,
@@ -158,8 +162,120 @@ export const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
  * I-15: default cap on tool result size in bytes. 400 KB matches
  * donor TS `MAX_TOOL_RESULT_TOKENS=100_000 × BYTES_PER_TOKEN=4`.
  * Per-tool override via `tool.maxResultBytes`.
+ *
+ * This is now used as the absolute *ceiling* for the model-aware cap
+ * (`computeEffectiveMaxResultBytes`): large-window models (≥200K tokens)
+ * meet/exceed this value and so keep the original 400 KB behavior, while
+ * small-window models get a tighter, window-relative cap so one result
+ * can never blow out the context window.
  */
 export const DEFAULT_MAX_TOOL_RESULT_BYTES = 400_000;
+
+/**
+ * Floor for the model-aware per-result cap. Even on a tiny context
+ * window we never starve tools below ~16 KB (~4-8K tokens), so small
+ * configs can still read meaningful output.
+ */
+export const MIN_TOOL_RESULT_BYTES = 16_000;
+
+/**
+ * Fraction of the model's context window a single tool result may
+ * occupy by default. 0.20 keeps one result at ≤ ~20% of the window,
+ * leaving headroom for the system prompt, prior history, and a few more
+ * results before the auto-compact threshold. Tunable via
+ * `AGENC_MAX_TOOL_RESULT_WINDOW_FRACTION`.
+ */
+export const DEFAULT_SINGLE_RESULT_WINDOW_FRACTION = 0.2;
+
+/** JSON-ish content packs ~2 bytes/token; plain text ~4 bytes/token. */
+const JSON_BYTES_PER_TOKEN = 2;
+
+/**
+ * At or above this window the fixed 400 KB ceiling is kept verbatim, so
+ * large-window models (Claude ~200K+) are entirely unaffected by the
+ * model-aware cap — no regression for their existing behavior. (Without
+ * this gate a 200K window would otherwise compute 160 KB for text.)
+ */
+export const LARGE_CONTEXT_WINDOW_TOKENS = 200_000;
+
+/**
+ * Resolve the window-fraction override from the environment, falling
+ * back to the 0.20 default. Out-of-range / unparseable values are
+ * ignored so a bad env var can never disable the guard.
+ */
+function resolveSingleResultWindowFraction(): number {
+  const raw = process.env.AGENC_MAX_TOOL_RESULT_WINDOW_FRACTION;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_SINGLE_RESULT_WINDOW_FRACTION;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    return DEFAULT_SINGLE_RESULT_WINDOW_FRACTION;
+  }
+  return parsed;
+}
+
+/**
+ * Pick a bytes-per-token estimate for the result content. JSON / JSONL /
+ * JSONC content is denser (~2 B/tok) than plain text (~4 B/tok), so the
+ * same token target maps to a *tighter byte cap* for JSON — this is what
+ * fixes the "400 KB of JSON ≈ 200K tokens" worst case.
+ */
+function bytesPerTokenForContent(content: string): number {
+  return detectContentType(content) === "json"
+    ? JSON_BYTES_PER_TOKEN
+    : DEFAULT_BYTES_PER_TOKEN;
+}
+
+/**
+ * Compute the effective per-result byte cap, scaled to the model's
+ * context window so a single tool result can never overflow a
+ * small-window model. Returns the fixed `DEFAULT_MAX_TOOL_RESULT_BYTES`
+ * when no window is known (preserving today's behavior) and lets a
+ * per-tool `tool.maxResultBytes` override win unconditionally.
+ *
+ *   effectiveCapBytes = clamp(
+ *     floor(window * FRACTION * bytesPerToken),
+ *     MIN_TOOL_RESULT_BYTES,            // floor
+ *     DEFAULT_MAX_TOOL_RESULT_BYTES,    // ceiling
+ *   )
+ *
+ * On a 131,072-token window: text → ~104 KB, JSON → ~52 KB.
+ * At or above `LARGE_CONTEXT_WINDOW_TOKENS` (200K) the fixed 400 KB
+ * ceiling is returned verbatim, so Claude-class models are unaffected.
+ */
+export function computeEffectiveMaxResultBytes(args: {
+  readonly content: string;
+  readonly contextWindowTokens?: number | undefined;
+  readonly toolMaxResultBytes?: number | undefined;
+}): number {
+  const { content, contextWindowTokens, toolMaxResultBytes } = args;
+  // Per-tool override always wins (preserves the I-15 branch).
+  if (toolMaxResultBytes !== undefined && toolMaxResultBytes > 0) {
+    return toolMaxResultBytes;
+  }
+  // No usable window → keep the fixed 400 KB cap (nothing breaks).
+  if (
+    contextWindowTokens === undefined ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return DEFAULT_MAX_TOOL_RESULT_BYTES;
+  }
+  // Large-window models keep the fixed 400 KB ceiling — no regression.
+  if (contextWindowTokens >= LARGE_CONTEXT_WINDOW_TOKENS) {
+    return DEFAULT_MAX_TOOL_RESULT_BYTES;
+  }
+  const fraction = resolveSingleResultWindowFraction();
+  const bytesPerToken = bytesPerTokenForContent(content);
+  const windowRelative = Math.floor(
+    contextWindowTokens * fraction * bytesPerToken,
+  );
+  return Math.max(
+    MIN_TOOL_RESULT_BYTES,
+    Math.min(windowRelative, DEFAULT_MAX_TOOL_RESULT_BYTES),
+  );
+}
 const RICH_OUTPUT_CONTENT_ITEMS = new WeakMap<
   ToolOutput,
   readonly FunctionCallOutputContentItem[]
@@ -170,6 +286,36 @@ const PREVENT_CONTINUATION_OUTPUTS = new WeakSet<ToolOutput>();
 /** Appended marker when a result is truncated. */
 const TRUNCATION_MARKER_TEMPLATE =
   "\n\n[truncated: original was {ORIG} bytes, returning first {KEPT}]\n";
+
+/**
+ * Informative truncation marker. Unlike the legacy template it tells the
+ * agent how much was kept (bytes + estimated tokens), that the result was
+ * capped to fit the model's context window, and how to retrieve more —
+ * so the agent can ADAPT (narrow the query, use offset+limit, or a more
+ * specific search) instead of silently losing data.
+ */
+function buildTruncationMarker(args: {
+  readonly originalBytes: number;
+  readonly keptBytes: number;
+  readonly bytesPerToken: number;
+  readonly contextWindowTokens?: number | undefined;
+}): string {
+  const { originalBytes, keptBytes, bytesPerToken, contextWindowTokens } = args;
+  const keptTokens = Math.round(keptBytes / bytesPerToken);
+  const originalTokens = Math.round(originalBytes / bytesPerToken);
+  const windowNote =
+    contextWindowTokens !== undefined &&
+    Number.isFinite(contextWindowTokens) &&
+    contextWindowTokens > 0
+      ? ` to fit the ${contextWindowTokens}-token context window`
+      : "";
+  return (
+    `\n\n[result truncated: kept ${keptBytes} of ${originalBytes} bytes ` +
+    `(~${keptTokens} of ~${originalTokens} tokens)${windowNote}. ` +
+    `To see more, narrow the query, use offset+limit, or run a more ` +
+    `specific search.]\n`
+  );
+}
 
 /**
  * Hard cap on formatted error prose before middle-truncation. Mirrors
@@ -238,15 +384,53 @@ export function parseToolArgsWithBigInt(
 // I-15: result size cap
 // ─────────────────────────────────────────────────────────────────────
 
+export interface CapToolResultMarkerInfo {
+  /** Bytes-per-token estimate used for the ~tokens figures in the marker. */
+  readonly bytesPerToken: number;
+  /** Effective context window the cap was derived from (for the marker). */
+  readonly contextWindowTokens?: number | undefined;
+}
+
 export function capToolResult(
   content: string,
   maxBytes: number,
+  markerInfo?: CapToolResultMarkerInfo,
 ): { readonly capped: string; readonly truncated: boolean; readonly originalBytes: number } {
   const originalBytes = Buffer.byteLength(content, "utf8");
   if (originalBytes <= maxBytes) {
     return { capped: content, truncated: false, originalBytes };
   }
-  const marker = TRUNCATION_MARKER_TEMPLATE
+  // When marker info is supplied (the live cap path), emit the
+  // informative window-aware marker; otherwise keep the legacy marker
+  // so older callers/tests observe unchanged prose. The marker length
+  // is bounded by `maxBytes` either way so the result never grows past
+  // the cap.
+  let marker: string;
+  if (markerInfo !== undefined) {
+    // Provisional marker to measure its own byte cost, then recompute
+    // against the actual kept length.
+    const provisional = buildTruncationMarker({
+      originalBytes,
+      keptBytes: maxBytes,
+      bytesPerToken: markerInfo.bytesPerToken,
+      contextWindowTokens: markerInfo.contextWindowTokens,
+    });
+    const provisionalBytes = Buffer.byteLength(provisional, "utf8");
+    const keptBytes = Math.max(0, maxBytes - provisionalBytes);
+    marker = buildTruncationMarker({
+      originalBytes,
+      keptBytes,
+      bytesPerToken: markerInfo.bytesPerToken,
+      contextWindowTokens: markerInfo.contextWindowTokens,
+    });
+    const markerBytes = Buffer.byteLength(marker, "utf8");
+    const finalKeepBytes = Math.max(0, maxBytes - markerBytes);
+    const kept = Buffer.from(content, "utf8")
+      .subarray(0, finalKeepBytes)
+      .toString("utf8");
+    return { capped: `${kept}${marker}`, truncated: true, originalBytes };
+  }
+  marker = TRUNCATION_MARKER_TEMPLATE
     .replace("{ORIG}", String(originalBytes))
     .replace("{KEPT}", String(maxBytes));
   const markerBytes = Buffer.byteLength(marker, "utf8");
@@ -986,6 +1170,14 @@ export interface RunToolUseOptions {
    * from environment; null means explicitly disabled for this call.
    */
   readonly transactionGuardContext?: TransactionGuardContext | null;
+  /**
+   * Effective context window (in tokens) for the model running this
+   * turn. Threaded from the dispatch layer (`modelContextWindow(turn)`).
+   * When present, the I-15 per-result byte cap is scaled to the window
+   * so a single result can never overflow a small-window model. When
+   * absent the cap falls back to the fixed `DEFAULT_MAX_TOOL_RESULT_BYTES`.
+   */
+  readonly contextWindowTokens?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1876,12 +2068,20 @@ export async function runToolUse(
     );
   }
 
-  // Step 7: I-15 result-size cap.
-  const maxResultBytes =
-    tool.maxResultBytes !== undefined && tool.maxResultBytes > 0
-      ? tool.maxResultBytes
-      : DEFAULT_MAX_TOOL_RESULT_BYTES;
-  const capped = capToolResult(finalDispatch.content, maxResultBytes);
+  // Step 7: I-15 result-size cap — now model-aware. The effective cap
+  // scales to the dispatch layer's context window so a single result
+  // can never overflow a small-window model, while large-window models
+  // keep the fixed 400 KB ceiling. A per-tool `tool.maxResultBytes`
+  // override still wins.
+  const maxResultBytes = computeEffectiveMaxResultBytes({
+    content: finalDispatch.content,
+    contextWindowTokens: opts.contextWindowTokens,
+    toolMaxResultBytes: tool.maxResultBytes,
+  });
+  const capped = capToolResult(finalDispatch.content, maxResultBytes, {
+    bytesPerToken: bytesPerTokenForContent(finalDispatch.content),
+    contextWindowTokens: opts.contextWindowTokens,
+  });
   if (capped.truncated && opts.eventLog) {
     emitWarningEvent(
       opts.eventLog,

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -43,6 +43,7 @@ import type { GuardianApprovalReviewer } from "../permissions/guardian/reviewer.
 import { arbitratePermissionMode } from "../permissions/guardian/arbiter.js";
 import type { Policy } from "../sandbox/execpolicy/policy.js";
 import type { TurnContext } from "../session/turn-context.js";
+import { modelContextWindow } from "../session/turn-context.js";
 import type {
   CanUseToolFn,
   ToolEvaluatorContext,
@@ -636,6 +637,8 @@ export class ToolRouter {
           } else if (opts.signal) {
             opts.signal.addEventListener("abort", forwardAbort, { once: true });
           }
+          const directContextWindowTokens =
+            effectiveContextWindowTokens(invocation.turn);
           try {
             return await executeToolDispatch({
               rawArgs: dispatchRawArgs,
@@ -648,6 +651,9 @@ export class ToolRouter {
               approvalAlreadyResolved: dispatchContext.approvalResolved,
               runtimeAttemptContext,
               abortController: toolAbortController,
+              ...(directContextWindowTokens !== undefined
+                ? { contextWindowTokens: directContextWindowTokens }
+                : {}),
               ...(opts.permissionAuditLogger !== undefined
                 ? { permissionAuditLogger: opts.permissionAuditLogger }
                 : {}),
@@ -1370,6 +1376,29 @@ function withPlanApprovalPreview(
   };
 }
 
+/**
+ * Effective context window (tokens) for the model running this turn,
+ * threaded to `runToolUse` so the I-15 per-result cap can scale to the
+ * window. Returns `undefined` when the window is unknown so the cap
+ * falls back to its fixed 400 KB default.
+ */
+function effectiveContextWindowTokens(
+  turn: TurnContext,
+): number | undefined {
+  // Defensive: minimal turn fixtures (and any turn missing `modelInfo`)
+  // must not throw here — fall back to `undefined` so the I-15 cap uses
+  // its fixed 400 KB default.
+  let window: number | undefined;
+  try {
+    window = modelContextWindow(turn);
+  } catch {
+    return undefined;
+  }
+  return window !== undefined && Number.isFinite(window) && window > 0
+    ? window
+    : undefined;
+}
+
 function rawDispatchOptions(
   rawArgs: string,
   opts: LiveToolDispatchOptions & {
@@ -1383,6 +1412,7 @@ function rawDispatchOptions(
     readonly runtimeAttemptContext?: ToolRuntimeAttemptContext;
   },
 ) {
+  const contextWindowTokens = effectiveContextWindowTokens(opts.turn);
   return {
     rawArgs,
     signal: opts.abortController.signal,
@@ -1391,6 +1421,7 @@ function rawDispatchOptions(
     subId: opts.subId,
     tool: opts.tool,
     invocation: opts.invocation,
+    ...(contextWindowTokens !== undefined ? { contextWindowTokens } : {}),
     ...(opts.preHooks !== undefined ? { preHooks: opts.preHooks } : {}),
     ...(opts.postHooks !== undefined ? { postHooks: opts.postHooks } : {}),
     ...(opts.failureHooks !== undefined ? { failureHooks: opts.failureHooks } : {}),

--- a/runtime/tests/tools/execution.test.ts
+++ b/runtime/tests/tools/execution.test.ts
@@ -665,7 +665,12 @@ describe("runToolUse end-to-end", () => {
       invocation: makeInvocation("c1", "big"),
       eventLog: log,
     });
-    expect(out.content).toContain("[truncated:");
+    // The live cap path emits the informative window-aware marker so the
+    // agent can adapt (narrow query / offset+limit) instead of silently
+    // losing data. The bare `capToolResult(content, bytes)` API still
+    // emits the legacy `[truncated:` marker (covered separately).
+    expect(out.content).toContain("result truncated");
+    expect(out.content).toMatch(/offset\+limit|narrow the query|specific search/);
     expect(warnings).toContain("tool_result_truncated");
   });
 

--- a/runtime/tests/tools/execution.window-cap.test.ts
+++ b/runtime/tests/tools/execution.window-cap.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Model-aware per-tool-result cap (design item (a)).
+ *
+ * The I-15 result-size cap used to be a fixed 400 KB byte limit, never
+ * scaled to the model's context window. On a small-window model (e.g.
+ * the local 131,072-token window) a single 400 KB result is ~100K
+ * tokens of plain text (~76% of the window) or ~200K tokens of JSON
+ * (>100% of the window) — one result could overflow the whole window.
+ *
+ * `computeEffectiveMaxResultBytes` now scales the cap to the live
+ * context window threaded through `RunToolUseOptions.contextWindowTokens`:
+ *   - ≤ ~20% of the window per result (text → ~104 KB @ 131K window)
+ *   - JSON gets a tighter byte cap (~52 KB) for the same token target
+ *   - large-window models (≥200K) keep the fixed 400 KB ceiling
+ *   - no window threaded → fixed 400 KB (unchanged behavior)
+ *
+ * REVERT PROOF: with the `execution.ts` change reverted, the 131K
+ * post-fix assertion reddens (the result is ~100K tokens again).
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  capToolResult,
+  computeEffectiveMaxResultBytes,
+  DEFAULT_MAX_TOOL_RESULT_BYTES,
+  MIN_TOOL_RESULT_BYTES,
+  runToolUse,
+} from "./execution.js";
+import type { Tool } from "./types.js";
+import type { ToolInvocation } from "./context.js";
+
+const LOCAL_WINDOW = 131_072;
+const LARGE_WINDOW = 200_000;
+const TEXT_BYTES_PER_TOKEN = 4;
+const JSON_BYTES_PER_TOKEN = 2;
+
+function estimateTokens(text: string, bytesPerToken: number): number {
+  return Math.round(Buffer.byteLength(text, "utf8") / bytesPerToken);
+}
+
+/** ~420 KB of generic, non-JSON text (a `cat`/MCP/WebFetch-style dump). */
+function makeGenericText(bytes: number): string {
+  // Repeating prose so `detectContentType` classifies it as non-JSON.
+  const unit = "lorem ipsum dolor sit amet consectetur adipiscing elit ";
+  return unit.repeat(Math.ceil(bytes / unit.length)).slice(0, bytes);
+}
+
+/** ~`bytes` of valid JSON (so `detectContentType` returns "json"). */
+function makeJson(bytes: number): string {
+  const items: string[] = [];
+  let size = 2; // for the surrounding []
+  let i = 0;
+  while (size < bytes) {
+    const entry = `{"id":${i},"name":"item-${i}","value":"xxxxxxxxxxxxxxxx"}`;
+    items.push(entry);
+    size += entry.length + 1;
+    i += 1;
+  }
+  return `[${items.join(",")}]`;
+}
+
+function makeInvocation(callId: string, toolName: string): ToolInvocation {
+  return {
+    session: { services: {} } as never,
+    turn: {
+      cwd: "/repo",
+      sandboxPolicy: { value: "workspace_write" },
+      approvalPolicy: { value: "on_request" },
+    } as never,
+    tracker: {
+      appendFileDiff: () => {},
+      snapshot: () => [],
+      clear: () => {},
+    },
+    callId,
+    toolName: { name: toolName },
+    payload: { kind: "function", arguments: "" },
+    source: "direct",
+  };
+}
+
+/** A tool that just echoes back a fixed body so we exercise the cap. */
+function echoTool(name: string, body: string): Tool {
+  return {
+    name,
+    description: "",
+    inputSchema: {},
+    execute: async () => ({ content: body }),
+  };
+}
+
+describe("computeEffectiveMaxResultBytes — model-aware cap", () => {
+  test("131K window scales text cap to ~20% of the window (~104 KB)", () => {
+    const cap = computeEffectiveMaxResultBytes({
+      content: makeGenericText(10_000),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    // 0.20 * 131072 * 4 = 104857
+    expect(cap).toBe(Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN));
+    expect(cap).toBeLessThan(DEFAULT_MAX_TOOL_RESULT_BYTES);
+  });
+
+  test("JSON content gets a tighter byte cap (~half the text cap)", () => {
+    const textCap = computeEffectiveMaxResultBytes({
+      content: makeGenericText(10_000),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    const jsonCap = computeEffectiveMaxResultBytes({
+      content: makeJson(10_000),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    expect(jsonCap).toBe(Math.floor(LOCAL_WINDOW * 0.2 * JSON_BYTES_PER_TOKEN));
+    // JSON byte cap is roughly half the text byte cap for the same token target.
+    expect(jsonCap).toBeCloseTo(textCap / 2, -2);
+    expect(jsonCap).toBeLessThan(textCap);
+  });
+
+  test("large-window models (>=200K) keep the fixed 400 KB ceiling", () => {
+    expect(
+      computeEffectiveMaxResultBytes({
+        content: makeGenericText(10_000),
+        contextWindowTokens: LARGE_WINDOW,
+      }),
+    ).toBe(DEFAULT_MAX_TOOL_RESULT_BYTES);
+    expect(
+      computeEffectiveMaxResultBytes({
+        content: makeGenericText(10_000),
+        contextWindowTokens: 1_000_000,
+      }),
+    ).toBe(DEFAULT_MAX_TOOL_RESULT_BYTES);
+  });
+
+  test("no window threaded → fixed 400 KB (unchanged behavior)", () => {
+    expect(
+      computeEffectiveMaxResultBytes({
+        content: makeGenericText(10_000),
+        contextWindowTokens: undefined,
+      }),
+    ).toBe(DEFAULT_MAX_TOOL_RESULT_BYTES);
+  });
+
+  test("per-tool override wins unconditionally", () => {
+    expect(
+      computeEffectiveMaxResultBytes({
+        content: makeGenericText(10_000),
+        contextWindowTokens: LOCAL_WINDOW,
+        toolMaxResultBytes: 4_096,
+      }),
+    ).toBe(4_096);
+  });
+
+  test("tiny window never starves below the floor", () => {
+    const cap = computeEffectiveMaxResultBytes({
+      content: makeGenericText(10_000),
+      contextWindowTokens: 1_000,
+    });
+    expect(cap).toBe(MIN_TOOL_RESULT_BYTES);
+  });
+});
+
+describe("capToolResult — informative window-aware marker", () => {
+  test("marker reports kept-of-original bytes/tokens + window + how to get more", () => {
+    const body = makeGenericText(420_000);
+    const out = capToolResult(body, 104_857, {
+      bytesPerToken: TEXT_BYTES_PER_TOKEN,
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    expect(out.truncated).toBe(true);
+    expect(Buffer.byteLength(out.capped, "utf8")).toBeLessThanOrEqual(104_857);
+    expect(out.capped).toContain("result truncated");
+    expect(out.capped).toContain("of 420000 bytes");
+    expect(out.capped).toContain(`${LOCAL_WINDOW}-token context window`);
+    expect(out.capped).toMatch(/offset\+limit|narrow the query|specific search/);
+  });
+
+  test("legacy marker preserved when no marker info is supplied", () => {
+    const out = capToolResult(makeGenericText(1_000), 500);
+    expect(out.capped).toContain("[truncated:");
+  });
+});
+
+describe("runToolUse — end-to-end model-aware cap", () => {
+  test("131K window: a 420 KB text result is capped to ~104 KB (≤ 30K tokens)", async () => {
+    const body = makeGenericText(420_000);
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump", body),
+      invocation: makeInvocation("c-text", "dump"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    expect(out.isError).toBe(false);
+    const tokens = estimateTokens(out.content, TEXT_BYTES_PER_TOKEN);
+    // POST-FIX: capped to ~104 KB → ~26K tokens.
+    expect(tokens).toBeLessThanOrEqual(30_000);
+    // Sanity: the full 420 KB body was NOT returned verbatim.
+    expect(Buffer.byteLength(out.content, "utf8")).toBeLessThan(420_000);
+  });
+
+  test("131K window WITHOUT the cap would be ~100K tokens (pre-fix baseline)", async () => {
+    // This is the pre-fix behavior: with the fixed 400 KB cap a 420 KB
+    // text result is capped to 400 KB ≈ ~100K tokens. We reproduce it by
+    // forcing the fixed cap via a per-tool override, demonstrating the
+    // magnitude the model-aware cap removes.
+    const body = makeGenericText(420_000);
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: {
+        ...echoTool("dump-fixed", body),
+        maxResultBytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
+      },
+      invocation: makeInvocation("c-text-fixed", "dump-fixed"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    const tokens = estimateTokens(out.content, TEXT_BYTES_PER_TOKEN);
+    expect(tokens).toBeGreaterThan(90_000);
+  });
+
+  test("131K window: a 420 KB JSON result is capped tighter (~half the text bytes)", async () => {
+    const textBody = makeGenericText(420_000);
+    const jsonBody = makeJson(420_000);
+
+    const textOut = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-text", textBody),
+      invocation: makeInvocation("c-text2", "dump-text"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    const jsonOut = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-json", jsonBody),
+      invocation: makeInvocation("c-json", "dump-json"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+
+    const textBytes = Buffer.byteLength(textOut.content, "utf8");
+    const jsonBytes = Buffer.byteLength(jsonOut.content, "utf8");
+    // JSON byte cap ≈ half the text byte cap (same token target, 2 B/tok).
+    expect(jsonBytes).toBeLessThan(textBytes);
+    expect(jsonBytes).toBeCloseTo(textBytes / 2, -3);
+  });
+
+  test("200K window (or undefined): cap stays 400 KB — Claude untouched", async () => {
+    const body = makeGenericText(420_000);
+
+    const largeOut = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-large", body),
+      invocation: makeInvocation("c-large", "dump-large"),
+      contextWindowTokens: LARGE_WINDOW,
+    });
+    // Truncated to the 400 KB ceiling, not the window-relative value.
+    expect(Buffer.byteLength(largeOut.content, "utf8")).toBeLessThanOrEqual(
+      DEFAULT_MAX_TOOL_RESULT_BYTES,
+    );
+    expect(Buffer.byteLength(largeOut.content, "utf8")).toBeGreaterThan(
+      Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN),
+    );
+
+    const noWindowOut = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-nowin", body),
+      invocation: makeInvocation("c-nowin", "dump-nowin"),
+      // contextWindowTokens omitted → fixed 400 KB cap.
+    });
+    expect(Buffer.byteLength(noWindowOut.content, "utf8")).toBeGreaterThan(
+      Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN),
+    );
+  });
+});


### PR DESCRIPTION
A **real** bug the owner hit: asking agenc to explain a 39 GB repo (`agenc-protocol`) blew out the context window. Root cause: the per-tool-result cap was a **fixed 400 KB**, never scaled to the model window — on a 131 K-token model that's **76% (text) to 153% (JSON)** of the *whole* window in one result, so a single `Bash cat`/MCP/WebFetch result could overflow it.

This is the **backstop** (the hard floor), validated by current-paper research as a *necessary guardrail* — **not the primary fix**. Per the research (`context-management-sota-2026-06.md`), the proper primary fix is to **route comprehension to the Explore subagent (context isolation) + search/map-first + offload-to-disk + ignore generated/build dirs** — staged follow-ups. This PR just guarantees no single result can ever produce `prompt_too_long`.

- `computeEffectiveMaxResultBytes`: `clamp(floor(window × 0.20 × bytesPerToken), 16 KB, 400 KB)`; JSON capped tighter (2 B/tok); per-tool override wins; **≥200 K window (Claude) or unknown → fixed 400 KB** (no regression). Window threaded from the live turn (reusing `modelContextWindow`, the same value autoCompact uses). Informative truncation marker (narrow query / offset+limit) — never silent.

**Gate:** build 0 · tsc 0 · full `test:unit` **13,546 / 0** · tui smoke not worse · revert independently re-verified (fixed cap reddens the 131 K assertions).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG