### PR TITLE
fix(tools,prompts): navigate-first repo exploration (context-blowout proper fix)

### DIFF
--- a/runtime/src/agents/built-in-prompts.ts
+++ b/runtime/src/agents/built-in-prompts.ts
@@ -95,6 +95,8 @@ ${grepGuidance}
 - Use ${BASH_TOOL_NAME} ONLY for read-only operations (ls, git status, git log, git diff, find${embedded ? ", grep" : ""}, cat, head, tail)
 - NEVER use ${BASH_TOOL_NAME} for: mkdir, touch, rm, cp, mv, git add, git commit, npm install, pip install, or any file creation/modification
 - Adapt your search approach based on the thoroughness level specified by the caller
+- To understand or explain a repo/codebase, build a structural map FIRST: read README + manifests (package.json / Cargo.toml / Anchor.toml / pyproject.toml) + the top-level directory layout, then grep for entry points and exported symbols. Read implementation only in targeted spans (specific files, offset+limit) — never bulk-cat whole large or generated files.
+- Skip generated/build/vendored/ledger dirs (target/, dist/, build/, node_modules/, .localnet/, generated/). Search tools skip these by default; do not walk them.
 - Communicate your final report directly as a regular message - do NOT attempt to create files
 
 NOTE: You are meant to be a fast agent that returns output as quickly as possible. In order to achieve this you must:

--- a/runtime/src/prompts/system-prompt.ts
+++ b/runtime/src/prompts/system-prompt.ts
@@ -355,9 +355,17 @@ function getSessionGuidanceSection(
     );
   }
 
+  const hasSearch = enabledTools.has("Grep") || enabledTools.has("Glob");
+  if (hasSearch) {
+    items.push(
+      `To understand or explain a repo or large codebase, NAVIGATE — do not ingest it. Build a structural map first: read README + manifest files (package.json / Cargo.toml / Anchor.toml / pyproject.toml) + the top-level directory layout, then grep for entry points and exported symbols. Read implementation only in targeted spans (specific files, offset+limit); never bulk-read whole large or generated files. Skip generated/build/vendored/ledger dirs (target/, dist/, build/, node_modules/, .localnet/, generated/) — search tools skip these by default.`,
+    );
+  }
+
   if (agentsEnabled) {
     items.push(
       `Use subagents (via the agent/task tool) when a task matches a specialized agent's description, or to protect your main context from large exploration output.`,
+      `Delegate heavy or broad codebase exploration (e.g. "what does this repo do") to the Explore subagent so its large reads happen in an isolated context and only a compact summary returns to you — instead of flooding your own context with file contents you won't reference again.`,
     );
   }
 

--- a/runtime/src/tools/system/glob.ts
+++ b/runtime/src/tools/system/glob.ts
@@ -44,6 +44,30 @@ const TRUNCATION_NOTE =
   "(Results are truncated. Consider using a more specific path or pattern.)";
 
 /**
+ * Generated/build/vendored/ledger directories that are excluded from a Glob
+ * walk BY DEFAULT. A repo's real source surface is tiny next to these; walking
+ * them surfaces nothing useful for "what does this repo do" and can be
+ * pathological (e.g. a 26 GB `.localnet/` validator log under agenc-protocol).
+ *
+ * This explicit exclude set is the load-bearing protection: ripgrep's
+ * `--glob <pattern>` whitelist (the user's search pattern) OVERRIDES
+ * `.gitignore`, so dropping `--no-ignore` alone would not reliably skip
+ * gitignored artifacts. The negative `!<glob>` excludes below DO win over the
+ * positive pattern, so they deterministically skip these dirs. Set
+ * `includeIgnored: true` to opt back into the legacy `--no-ignore` walk that
+ * surfaces build output, `.git`, and gitignored files.
+ */
+export const DEFAULT_GLOB_EXCLUDE_GLOBS: ReadonlyArray<string> = Object.freeze([
+  "**/node_modules/**",
+  "**/target/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.localnet/**",
+  "**/.git/**",
+  "**/*.lock",
+]);
+
+/**
  * Platform-specific hint telling the user how to install ripgrep. No binary is
  * bundled, so when `rg` is missing from PATH the only fix is a system install;
  * surface the exact command instead of a bare "requires ripgrep" message.
@@ -63,12 +87,18 @@ const GLOB_DESCRIPTION = `- Fast file pattern matching tool that works with any 
 - Supports glob patterns like "**/*.js" or "src/**/*.ts"
 - Returns matching file paths sorted by modification time
 - Use this tool when you need to find files by name patterns
+- By default skips generated/build/vendored dirs (node_modules, target, dist, build, .localnet, .git, lockfiles); pass includeIgnored: true to search those too
 - When you are doing an open ended search that may require multiple rounds of globbing and grepping, use the spawn_agent tool instead`;
 
 interface GlobToolInput extends ToolExecutionInjectedArgs {
   readonly pattern?: unknown;
   readonly path?: unknown;
   readonly cwd?: unknown;
+  readonly includeIgnored?: unknown;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
 }
 
 export interface GlobToolConfig {
@@ -257,6 +287,7 @@ function runRipgrepFiles(params: {
   readonly pattern: string;
   readonly cwd: string;
   readonly limit: number;
+  readonly includeIgnored: boolean;
   readonly signal?: AbortSignal;
 }): Promise<LimitedRipgrepResult> {
   const args = [
@@ -265,9 +296,27 @@ function runRipgrepFiles(params: {
     params.pattern,
     "--sortr",
     "modified",
-    "--no-ignore",
+    // `--hidden` keeps dotfile parity (e.g. `.gitignore`, `.github/`) which is
+    // routinely useful to find; the gating of build/vendored output is done by
+    // RESPECTING `.gitignore` (ripgrep default) plus the explicit default
+    // excludes below — NOT by hiding dotfiles.
     "--hidden",
   ];
+  if (params.includeIgnored) {
+    // Opt-in legacy walk: surface gitignored + build output (e.g. searching
+    // inside `target/`/`dist/` deliberately). `--no-ignore` restores the prior
+    // default and the default excludes are skipped.
+    args.push("--no-ignore");
+  } else {
+    // Default walk: layer the built-in generated/build/vendored/ledger excludes
+    // on top of ripgrep's ignore handling. These negative globs win over the
+    // user's positive search pattern, so the dirs are skipped deterministically
+    // even when un-gitignored or when the pattern would otherwise whitelist
+    // them.
+    for (const exclude of DEFAULT_GLOB_EXCLUDE_GLOBS) {
+      args.push("--glob", `!${exclude}`);
+    }
+  }
   return new Promise((resolveResult) => {
     const lines: string[] = [];
     let pending = "";
@@ -411,6 +460,11 @@ export function createGlobTool(
           description:
             "Optional. Directory to search in. Defaults to the workspace root.",
         },
+        includeIgnored: {
+          type: "boolean",
+          description:
+            "Optional. When true, search gitignored and build/vendored output too (node_modules, target, dist, build, .localnet, lockfiles). Defaults to false: the walk respects .gitignore and skips generated/build dirs so it never enumerates large artifacts.",
+        },
       },
       required: ["pattern"],
       additionalProperties: false,
@@ -434,6 +488,7 @@ export function createGlobTool(
       const startedAt = Date.now();
       const effectiveLimit = limit + 1;
       const signal = args.__abortSignal;
+      const includeIgnored = asBoolean(args.includeIgnored) ?? false;
       let rawMatches: readonly string[];
       let truncated = false;
       const rg = await runRipgrepFiles({
@@ -441,6 +496,7 @@ export function createGlobTool(
         pattern: target.pattern,
         cwd: target.searchRoot,
         limit: effectiveLimit,
+        includeIgnored,
         signal,
       });
       if (signal?.aborted || rg.aborted) {
@@ -495,4 +551,5 @@ export const __INTERNAL = {
   extractGlobBaseDirectory,
   toRelativeIfInside,
   ripgrepInstallHint,
+  DEFAULT_GLOB_EXCLUDE_GLOBS,
 };

--- a/runtime/src/tools/system/grep.ts
+++ b/runtime/src/tools/system/grep.ts
@@ -42,6 +42,21 @@ const VCS_DIRECTORIES_TO_EXCLUDE = [
   ".sl",
 ] as const;
 
+/**
+ * Generated/build/vendored/ledger directories excluded from a Grep walk BY
+ * DEFAULT, on top of `.gitignore` (which ripgrep already honors). Searching
+ * these surfaces noise and can be pathological on a large repo (e.g. a multi-GB
+ * `.localnet/` validator log). `includeIgnored: true` restores `--no-ignore`
+ * and drops these excludes for a power-user search of build output.
+ */
+const DEFAULT_GENERATED_DIRECTORIES_TO_EXCLUDE = [
+  "node_modules",
+  "target",
+  "dist",
+  "build",
+  ".localnet",
+] as const;
+
 const DEFAULT_HEAD_LIMIT = 250;
 const MAX_RIPGREP_STDERR_CHARS = 128 * 1024;
 const MAX_FALLBACK_FILES = 5_000;
@@ -92,6 +107,7 @@ interface GrepInput extends ToolExecutionInjectedArgs {
   readonly head_limit?: unknown;
   readonly offset?: unknown;
   readonly multiline?: unknown;
+  readonly includeIgnored?: unknown;
 }
 
 export interface GrepToolConfig {
@@ -383,6 +399,7 @@ interface RipgrepOptions {
   readonly caseInsensitive: boolean;
   readonly showLineNumbers: boolean;
   readonly multiline: boolean;
+  readonly includeIgnored: boolean;
   readonly contextBefore?: number;
   readonly contextAfter?: number;
   readonly contextBoth?: number;
@@ -394,6 +411,18 @@ function buildRipgrepArgs(opts: RipgrepOptions): string[] {
   const args: string[] = ["--hidden"];
   for (const dir of VCS_DIRECTORIES_TO_EXCLUDE) {
     args.push("--glob", `!${dir}`);
+  }
+  if (opts.includeIgnored) {
+    // Opt-in power-user walk: surface gitignored + build output (e.g. grepping
+    // inside `target/`/`dist/`). `--no-ignore` plus dropping the generated-dir
+    // excludes restores the unfiltered search.
+    args.push("--no-ignore");
+  } else {
+    // Default walk: layer generated/build/vendored/ledger excludes on top of
+    // ripgrep's `.gitignore` handling so even un-gitignored copies are skipped.
+    for (const dir of DEFAULT_GENERATED_DIRECTORIES_TO_EXCLUDE) {
+      args.push("--glob", `!${dir}`);
+    }
   }
   args.push("--max-columns", "500", "--max-columns-preview");
 
@@ -944,6 +973,7 @@ function formatFallbackContentLine(params: {
 
 async function* walkFiles(
   root: string,
+  includeIgnored: boolean,
   abortSignal?: AbortSignal,
 ): AsyncGenerator<string> {
   const stack: string[] = [root];
@@ -962,6 +992,17 @@ async function* walkFiles(
       if ((VCS_DIRECTORIES_TO_EXCLUDE as readonly string[]).includes(name)) {
         continue;
       }
+      // Parity with the ripgrep path: skip generated/build/vendored/ledger
+      // dirs by default; `includeIgnored` opts back into walking them. (The
+      // `.gitignore` matcher in runFallbackGrep additionally filters files.)
+      if (
+        !includeIgnored &&
+        (DEFAULT_GENERATED_DIRECTORIES_TO_EXCLUDE as readonly string[]).includes(
+          name,
+        )
+      ) {
+        continue;
+      }
       const full = join(current, name);
       if (entry.isDirectory()) {
         stack.push(full);
@@ -974,10 +1015,11 @@ async function* walkFiles(
 
 async function* iterTargetFiles(
   target: ResolvedTarget,
+  includeIgnored: boolean,
   abortSignal?: AbortSignal,
 ): AsyncGenerator<string> {
   if (target.isDirectory) {
-    yield* walkFiles(target.absolute, abortSignal);
+    yield* walkFiles(target.absolute, includeIgnored, abortSignal);
     return;
   }
   if (!abortSignal?.aborted) {
@@ -994,6 +1036,7 @@ async function runFallbackGrep(params: {
   readonly globs: readonly string[];
   readonly headLimit: number;
   readonly offset: number;
+  readonly includeIgnored: boolean;
   readonly signal?: AbortSignal;
 }): Promise<ToolResult> {
   const {
@@ -1005,6 +1048,7 @@ async function runFallbackGrep(params: {
     globs,
     headLimit,
     offset,
+    includeIgnored,
     signal,
   } = params;
   if (outputMode === "count") {
@@ -1027,7 +1071,12 @@ async function runFallbackGrep(params: {
   let fallbackSafetyCapped = false;
   let visitedFiles = 0;
   const displayRoot = displayRootForTarget(target);
-  const isIgnored = await compileFallbackIgnoreMatcher(displayRoot);
+  // `includeIgnored` restores the unfiltered fallback walk: skip the
+  // `.gitignore` matcher (the generated-dir skip is also bypassed in
+  // `iterTargetFiles`).
+  const isIgnored = includeIgnored
+    ? async (): Promise<boolean> => false
+    : await compileFallbackIgnoreMatcher(displayRoot);
   const fallbackCollectionLimit =
     headLimit === 0 ? 0 : collectionLineLimit(headLimit, offset);
   // gaphunt3 #26/#30: wall-clock deadline so an expensive scan (clamping
@@ -1036,7 +1085,7 @@ async function runFallbackGrep(params: {
   const scanDeadline = Date.now() + FALLBACK_SCAN_BUDGET_MS;
   let fallbackScanAborted = false;
 
-  for await (const filePath of iterTargetFiles(target, signal)) {
+  for await (const filePath of iterTargetFiles(target, includeIgnored, signal)) {
     if (signal?.aborted) {
       return errorResult("Search aborted");
     }
@@ -1301,6 +1350,11 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
           description:
             "Enable multiline mode where . matches newlines and patterns can span lines (rg -U --multiline-dotall). Default: false.",
         },
+        includeIgnored: {
+          type: "boolean",
+          description:
+            "Search gitignored and build/vendored output too (node_modules, target, dist, build, .localnet). Defaults to false: the search respects .gitignore and skips generated/build dirs.",
+        },
       },
       required: ["pattern"],
       additionalProperties: false,
@@ -1329,6 +1383,7 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
       const caseInsensitive = asBoolean(args["-i"]) ?? false;
       const showLineNumbers = asBoolean(args["-n"]) ?? true;
       const multiline = asBoolean(args.multiline) ?? false;
+      const includeIgnored = asBoolean(args.includeIgnored) ?? false;
       const contextBefore = asNonNegativeInteger(args["-B"]);
       const contextAfter = asNonNegativeInteger(args["-A"]);
       const contextBoth =
@@ -1367,6 +1422,7 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
           globs,
           headLimit,
           offset,
+          includeIgnored,
           signal,
         });
       }
@@ -1379,6 +1435,7 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
           caseInsensitive,
           showLineNumbers,
           multiline,
+          includeIgnored,
           contextBefore,
           contextAfter,
           contextBoth,

--- a/runtime/tests/agents/role.test.ts
+++ b/runtime/tests/agents/role.test.ts
@@ -80,6 +80,11 @@ describe("role registry", () => {
     expect(explorer.config.disallowlist).toContain("spawn_agent");
     expect(explorer.config.disallowlist).toContain("Edit");
     expect(explorer.config.disallowlist).toContain("Write");
+    // Navigate-first guidance (revert-sensitive): structural-map-first, read
+    // spans not whole files, and skip generated/build dirs.
+    expect(explorer.config.systemPrompt).toContain("structural map FIRST");
+    expect(explorer.config.systemPrompt).toContain("targeted spans");
+    expect(explorer.config.systemPrompt).toMatch(/Skip generated\/build\/vendored/);
 
     const plan = requireAgentRole("Plan");
     expect(plan.config.systemPrompt).toContain("software architect");

--- a/runtime/tests/prompts/system-prompt.test.ts
+++ b/runtime/tests/prompts/system-prompt.test.ts
@@ -661,6 +661,17 @@ describe("assembleSystemPrompt", () => {
     expect(text).not.toContain("# Subagents");
     expect(text).toContain(SYSTEM_PROMPT_DYNAMIC_BOUNDARY);
     expect(sections.length).toBeGreaterThan(8);
+
+    // Navigate-first exploration guidance (revert-sensitive): with search tools
+    // enabled the prompt tells the model to map a repo first and skip generated
+    // dirs, and with agents enabled to delegate heavy exploration to a subagent
+    // for context isolation.
+    expect(text).toContain("structural map first");
+    expect(text).toMatch(/Skip generated\/build\/vendored\/ledger dirs/);
+    expect(text).toContain(
+      "Delegate heavy or broad codebase exploration",
+    );
+    expect(text).toContain("isolated context");
   });
 
   test("permissions section is injected when a permissionContext is supplied", async () => {

--- a/runtime/tests/tools/system/glob.test.ts
+++ b/runtime/tests/tools/system/glob.test.ts
@@ -286,28 +286,87 @@ describe("Glob tool", () => {
     expect(result.content).toBe("a.txt");
   });
 
-  test("primary search includes hidden and ignored files", async () => {
+  test("default search still includes ordinary hidden (dotfile) content", async () => {
+    // Dotfiles are still surfaced by default (`.gitignore`/`.github` are
+    // routinely useful to find) — the fix gates build/vendored/ledger dirs via
+    // an explicit exclude set, NOT by hiding dotfiles.
     await mkdir(join(root, ".hidden-dir"), { recursive: true });
-    await writeFile(join(root, ".gitignore"), "ignored.txt\n", "utf8");
-    await writeFile(join(root, "ignored.txt"), "ignored\n", "utf8");
     await writeFile(join(root, ".hidden.txt"), "hidden\n", "utf8");
     await writeFile(join(root, ".hidden-dir", "nested.txt"), "nested\n", "utf8");
 
     const tool = createGlobTool({ allowedPaths: [root] });
-    const result = await tool.execute({
-      pattern: "*.txt",
-      path: root,
-    });
+    const result = await tool.execute({ pattern: "*.txt", path: root });
 
     expect(result.isError).toBeUndefined();
     const lines = result.content.split("\n").filter(Boolean);
     expect(lines).toEqual(
-      expect.arrayContaining([
-        "ignored.txt",
-        ".hidden.txt",
-        ".hidden-dir/nested.txt",
-      ]),
+      expect.arrayContaining([".hidden.txt", ".hidden-dir/nested.txt"]),
     );
+  });
+
+  test("default walk skips generated/build/ledger dirs and .git", async () => {
+    // The built-in default-exclude set must skip these dirs regardless of
+    // .gitignore. This is the agenc-protocol 26 GB `.localnet/` ledger /
+    // `target/` blowout the navigate-first fix prevents. NOTE: ripgrep's
+    // `--glob <pattern>` whitelist overrides `.gitignore`, so the EXPLICIT
+    // exclude set (not gitignore) is the load-bearing protection here.
+    await mkdir(join(root, "target"), { recursive: true });
+    await mkdir(join(root, ".localnet"), { recursive: true });
+    await mkdir(join(root, "node_modules", "pkg"), { recursive: true });
+    await mkdir(join(root, "dist"), { recursive: true });
+    await mkdir(join(root, "build"), { recursive: true });
+    await mkdir(join(root, ".git"), { recursive: true });
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "target", "huge.bin"), "x".repeat(4096), "utf8");
+    await writeFile(join(root, ".localnet", "validator.log"), "y".repeat(4096), "utf8");
+    await writeFile(join(root, "node_modules", "pkg", "dep.js"), "z\n", "utf8");
+    await writeFile(join(root, "dist", "bundle.js"), "z\n", "utf8");
+    await writeFile(join(root, "build", "artifact.o"), "z\n", "utf8");
+    await writeFile(join(root, ".git", "HEAD"), "ref\n", "utf8");
+    // `**/*.lock` covers Cargo.lock / yarn.lock (the .lock-suffixed lockfiles).
+    await writeFile(join(root, "Cargo.lock"), "lock\n", "utf8");
+    await writeFile(join(root, "src", "main.ts"), "ok\n", "utf8");
+
+    const tool = createGlobTool({ allowedPaths: [root] });
+    const result = await tool.execute({ pattern: "**/*", path: root });
+
+    expect(result.isError).toBeUndefined();
+    const lines = result.content.split("\n").filter(Boolean);
+    // The real source surface is found...
+    expect(lines).toContain("src/main.ts");
+    // ...and the generated/build/ledger/VCS dirs + lockfiles are NOT walked.
+    expect(lines).not.toContain("target/huge.bin");
+    expect(lines).not.toContain(".localnet/validator.log");
+    expect(lines).not.toContain("node_modules/pkg/dep.js");
+    expect(lines).not.toContain("dist/bundle.js");
+    expect(lines).not.toContain("build/artifact.o");
+    expect(lines).not.toContain(".git/HEAD");
+    expect(lines).not.toContain("Cargo.lock");
+  });
+
+  test("includeIgnored restores walking generated/build dirs and ignored files", async () => {
+    await mkdir(join(root, "target"), { recursive: true });
+    await mkdir(join(root, ".git"), { recursive: true });
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "target", "out.bin"), "x\n", "utf8");
+    await writeFile(join(root, ".git", "HEAD"), "ref\n", "utf8");
+    await writeFile(join(root, "src", "main.ts"), "ok\n", "utf8");
+
+    const tool = createGlobTool({ allowedPaths: [root] });
+    const result = await tool.execute({
+      pattern: "**/*",
+      path: root,
+      includeIgnored: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const lines = result.content.split("\n").filter(Boolean);
+    // Revert-sensitive: with the opt-in, build output + .git ARE reachable
+    // again. The post-fix default (above) excludes them; this restores the
+    // legacy `--no-ignore` walk.
+    expect(lines).toContain("target/out.bin");
+    expect(lines).toContain(".git/HEAD");
+    expect(lines).toContain("src/main.ts");
   });
 
   test("returns relative paths under allowed root", async () => {


### PR DESCRIPTION
Research-backed **proper fix** for the context-blowout bug (current-papers research), atop the model-aware byte-cap backstop (#1332). The proper move is to **not ingest** a large repo — long context degrades quality even when it fits (*Lost-in-the-Middle*, *Context Rot*, *Context-Length-Alone-Hurts*).

**(F) ignore-first** (additive: default-safe + `includeIgnored` opt-in): Glob now applies `DEFAULT_GLOB_EXCLUDE_GLOBS` (node_modules/target/dist/build/.localnet/.git/lockfiles) as negative excludes + dropped unconditional `--no-ignore` (empirical: a positive `--glob` whitelist overrides .gitignore, so the negative excludes are the deterministic guard); Grep gets the same generated-dir excludes (+ JS fallback). FileRead untouched.

**(C) map-first + delegate** (prompt-only): Explore subagent + main agent prompts → build a structural map first (README+manifests+grep entry points), read targeted spans not whole/generated files, skip generated/build dirs, and **delegate heavy exploration to the Explore subagent** (context isolation → only a compact summary returns).

So 'what does agenc-protocol do' navigates + delegates, and the default walks never enumerate the 26 GB `.localnet/` ledger.

**Gate:** build 0 · tsc 0 · full `test:unit` 13,548 / 0 · tui smoke not worse · revert independently re-verified (dropping the Glob excludes → the walk returns `target/huge.bin`+`.localnet/validator.log`).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG