### PR TITLE
feat(tools): tool-result cap offloads + references instead of blind truncation (Technique D)

### DIFF
--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -66,6 +66,11 @@ import {
 } from "../session/event-log.js";
 import type { ToolDispatchResult } from "../tool-registry.js";
 import { isRecord } from "../utils/record.js";
+import {
+  isPersistError,
+  persistToolResult,
+} from "../utils/toolResultStorage.js";
+import { formatFileSize } from "../utils/format.js";
 import type {
   FunctionCallOutputContentItem,
   ToolInvocation,
@@ -438,6 +443,120 @@ export function capToolResult(
   const buf = Buffer.from(content, "utf8");
   const kept = buf.subarray(0, keepBytes).toString("utf8");
   return { capped: `${kept}${marker}`, truncated: true, originalBytes };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Technique D — model-aware OFFLOAD (persist full + reference)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the actionable reference message injected in place of a result
+ * that overflowed the model-aware cap. It carries a HEAD preview of the
+ * output, the on-disk path the FULL output was persisted to, and a
+ * concrete pointer the agent can act on (read the file, a byte/line
+ * range, or narrow the query). This is the cap done as an OFFLOAD
+ * (Technique D / MemGPT memory-pointers) rather than a blind truncation:
+ * no data is lost — the full output is recoverable from `filepath`.
+ *
+ * The whole message is byte-bounded by `maxBytes` so the reference can
+ * never itself overflow the cap.
+ */
+function buildOffloadReferenceMessage(args: {
+  readonly content: string;
+  readonly filepath: string;
+  readonly originalBytes: number;
+  readonly maxBytes: number;
+  readonly bytesPerToken: number;
+}): string {
+  const { content, filepath, originalBytes, maxBytes, bytesPerToken } = args;
+  const originalTokens = Math.round(originalBytes / bytesPerToken);
+  // Header + footer first so the head preview can be sized to the room
+  // that remains under the cap. Keep the pointer phrasing aligned with
+  // the truncation marker ("narrow the query"/"offset+limit"/"search").
+  const header =
+    `[full output (~${formatFileSize(originalBytes)} / ~${originalTokens} tokens) ` +
+    `saved to ${filepath} — read that file (or a byte/line range with ` +
+    `offset+limit) to see more, or narrow your query / run a more specific ` +
+    `search. Head preview follows:]\n`;
+  const footer = `\n[…truncated — full output at ${filepath}]\n`;
+  const headerBytes = Buffer.byteLength(header, "utf8");
+  const footerBytes = Buffer.byteLength(footer, "utf8");
+  const room = Math.max(0, maxBytes - headerBytes - footerBytes);
+  // Trim the head preview to fit, cutting on a UTF-8 boundary.
+  let head = Buffer.from(content, "utf8").subarray(0, room).toString("utf8");
+  // Prefer a clean line boundary for the preview when one is reasonably
+  // close to the end (mirrors generatePreview in toolResultStorage).
+  const lastNewline = head.lastIndexOf("\n");
+  if (lastNewline > room * 0.5) {
+    head = head.slice(0, lastNewline);
+  }
+  return `${header}${head}${footer}`;
+}
+
+/**
+ * Apply the model-aware per-result cap as an OFFLOAD (Technique D), not a
+ * guillotine. When `content` fits within `maxBytes` it is returned
+ * unchanged. When it overflows, the FULL content is persisted to disk
+ * (reusing `persistToolResult` — same session tool-results store the
+ * agent can read back with FileRead) and the model receives a REFERENCE
+ * message: a head preview + the persisted path + an actionable
+ * "read range / narrow query" pointer. If persistence fails for any
+ * reason, we fall back to the legacy blind truncation so the hard cap is
+ * still honored and the wire message can never overflow the window.
+ *
+ * The same `maxBytes` (from `computeEffectiveMaxResultBytes`) is used, so
+ * the per-tool `maxResultBytes` override and the ≥200K-window (Claude)
+ * "fixed 400 KB ceiling" behavior are unchanged — only the over-cap
+ * branch changes from truncate-and-lose to offload-and-reference.
+ */
+async function offloadOrCapToolResult(args: {
+  readonly content: string;
+  readonly toolUseId: string;
+  readonly maxBytes: number;
+  readonly bytesPerToken: number;
+  readonly contextWindowTokens?: number | undefined;
+}): Promise<{
+  readonly content: string;
+  readonly truncated: boolean;
+  readonly originalBytes: number;
+  readonly persistedPath?: string;
+}> {
+  const { content, toolUseId, maxBytes, bytesPerToken, contextWindowTokens } =
+    args;
+  const originalBytes = Buffer.byteLength(content, "utf8");
+  if (originalBytes <= maxBytes) {
+    return { content, truncated: false, originalBytes };
+  }
+
+  // Over the cap: OFFLOAD the full output, then return a reference.
+  const persisted = await persistToolResult(content, toolUseId);
+  if (!isPersistError(persisted)) {
+    const reference = buildOffloadReferenceMessage({
+      content,
+      filepath: persisted.filepath,
+      originalBytes,
+      maxBytes,
+      bytesPerToken,
+    });
+    return {
+      content: reference,
+      truncated: true,
+      originalBytes,
+      persistedPath: persisted.filepath,
+    };
+  }
+
+  // Persist failed → fall back to the legacy blind truncation so the hard
+  // model-aware cap is still enforced (the wire message can never overflow).
+  const capped = capToolResult(content, maxBytes, {
+    bytesPerToken,
+    contextWindowTokens,
+  });
+  return {
+    content: capped.capped,
+    truncated: capped.truncated,
+    originalBytes: capped.originalBytes,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -2068,26 +2187,38 @@ export async function runToolUse(
     );
   }
 
-  // Step 7: I-15 result-size cap — now model-aware. The effective cap
-  // scales to the dispatch layer's context window so a single result
-  // can never overflow a small-window model, while large-window models
-  // keep the fixed 400 KB ceiling. A per-tool `tool.maxResultBytes`
-  // override still wins.
+  // Step 7: I-15 result-size cap — now model-aware AND an OFFLOAD, not a
+  // guillotine (Technique D). The effective cap scales to the dispatch
+  // layer's context window so a single result can never overflow a
+  // small-window model, while large-window models keep the fixed 400 KB
+  // ceiling; a per-tool `tool.maxResultBytes` override still wins. When a
+  // result exceeds the cap we now persist the FULL output to the session
+  // tool-results store and inject a REFERENCE (head preview + path +
+  // "read range to continue") instead of blindly truncating-and-losing —
+  // so the data is recoverable via FileRead. Persist failure falls back
+  // to the legacy truncation so the hard cap is always enforced.
   const maxResultBytes = computeEffectiveMaxResultBytes({
     content: finalDispatch.content,
     contextWindowTokens: opts.contextWindowTokens,
     toolMaxResultBytes: tool.maxResultBytes,
   });
-  const capped = capToolResult(finalDispatch.content, maxResultBytes, {
+  const capped = await offloadOrCapToolResult({
+    content: finalDispatch.content,
+    toolUseId: invocation.callId,
+    maxBytes: maxResultBytes,
     bytesPerToken: bytesPerTokenForContent(finalDispatch.content),
     contextWindowTokens: opts.contextWindowTokens,
   });
   if (capped.truncated && opts.eventLog) {
+    const disposition =
+      capped.persistedPath !== undefined
+        ? `offloaded to ${capped.persistedPath}`
+        : `truncated to ${maxResultBytes}B`;
     emitWarningEvent(
       opts.eventLog,
       subId,
       "tool_result_truncated",
-      `tool ${toolNameDisplay(invocation.toolName)} output ${capped.originalBytes}B truncated to ${maxResultBytes}B (I-15)`,
+      `tool ${toolNameDisplay(invocation.toolName)} output ${capped.originalBytes}B ${disposition} (I-15)`,
     );
   }
 
@@ -2117,7 +2248,7 @@ export async function runToolUse(
     callId: invocation.callId,
     toolName: invocation.toolName,
     payload: invocation.payload,
-    content: capped.capped,
+    content: capped.content,
     isError: finalDispatch.isError === true,
     durationMs: performance.now() - startedAt,
     ...(finalDispatch.metadata !== undefined

--- a/runtime/tests/tools/execution.test.ts
+++ b/runtime/tests/tools/execution.test.ts
@@ -642,7 +642,7 @@ describe("runToolUse end-to-end", () => {
     expect(warnings).toContain("stale_modal_decision");
   });
 
-  test("I-15 oversized result truncated + warning emitted", async () => {
+  test("I-15 oversized result OFFLOADED (full persisted + reference) + warning emitted", async () => {
     const big = "x".repeat(2000);
     const tool: Tool = {
       name: "big",
@@ -665,12 +665,13 @@ describe("runToolUse end-to-end", () => {
       invocation: makeInvocation("c1", "big"),
       eventLog: log,
     });
-    // The live cap path emits the informative window-aware marker so the
-    // agent can adapt (narrow query / offset+limit) instead of silently
-    // losing data. The bare `capToolResult(content, bytes)` API still
-    // emits the legacy `[truncated:` marker (covered separately).
-    expect(out.content).toContain("result truncated");
-    expect(out.content).toMatch(/offset\+limit|narrow the query|specific search/);
+    // The live cap path now OFFLOADS (Technique D): the full output is
+    // persisted to disk and the model gets an actionable REFERENCE (path
+    // + "read that file / narrow query") instead of a blind truncation,
+    // so no data is lost. The warning event still fires.
+    expect(out.content).toContain("saved to");
+    expect(out.content).toMatch(/read that file|read range|to see more/i);
+    expect(out.content).toMatch(/offset\+limit|narrow your query|specific search/);
     expect(warnings).toContain("tool_result_truncated");
   });
 

--- a/runtime/tests/tools/execution.window-cap.test.ts
+++ b/runtime/tests/tools/execution.window-cap.test.ts
@@ -18,6 +18,8 @@
  * post-fix assertion reddens (the result is ~100K tokens again).
  */
 
+import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { describe, expect, test } from "vitest";
 import {
   capToolResult,
@@ -26,6 +28,7 @@ import {
   MIN_TOOL_RESULT_BYTES,
   runToolUse,
 } from "./execution.js";
+import { getToolResultPath } from "../utils/toolResultStorage.js";
 import type { Tool } from "./types.js";
 import type { ToolInvocation } from "./context.js";
 
@@ -265,5 +268,115 @@ describe("runToolUse — end-to-end model-aware cap", () => {
     expect(Buffer.byteLength(noWindowOut.content, "utf8")).toBeGreaterThan(
       Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN),
     );
+  });
+});
+
+/**
+ * Technique D — model-aware OFFLOAD (persist full + reference), not a
+ * blind truncation. When a tool result exceeds the model-aware cap the
+ * FULL output is written to the session tool-results store and the model
+ * receives a REFERENCE (head preview + path + "read range to continue"),
+ * so no data is lost and the full output is recoverable via FileRead.
+ *
+ * REVERT PROOF: stash the `offloadOrCapToolResult` change in
+ * execution.ts so the cap site blind-truncates again → no file is
+ * persisted and the returned message contains no path / no
+ * "read … to see more" pointer → assertions (b)/(a)/(c) redden.
+ */
+describe("runToolUse — model-aware OFFLOAD (Technique D)", () => {
+  test("131K window: a 420 KB result is OFFLOADED (full persisted + reference), not blind-truncated", async () => {
+    const body = makeGenericText(420_000);
+    const callId = `c-offload-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-offload", body),
+      invocation: makeInvocation(callId, "dump-offload"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+
+    // The wire message is bounded by the model-aware cap.
+    expect(out.isError).toBe(false);
+    expect(Buffer.byteLength(out.content, "utf8")).toBeLessThanOrEqual(
+      Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN),
+    );
+
+    // (b) The message returned to the model is a REFERENCE, not a blind
+    // truncation: it names the persisted path and an actionable pointer.
+    const persistedPath = getToolResultPath(callId, false);
+    expect(out.content).toContain(persistedPath);
+    expect(out.content).toContain("saved to");
+    expect(out.content).toMatch(/read that file|read range|to see more/i);
+    // Sanity: it is NOT the legacy blind-truncation marker.
+    expect(out.content).not.toContain("[truncated: original was");
+
+    // (a) A file is PERSISTED holding the FULL original content.
+    const persisted = readFileSync(persistedPath, "utf8");
+    expect(persisted).toBe(body);
+
+    // (c) The full content is recoverable from the path (head preview is
+    // a strict prefix of the persisted full output).
+    const headStart = out.content.indexOf("\n") + 1;
+    const head = out.content.slice(headStart).split("\n[…truncated")[0];
+    expect(head.length).toBeGreaterThan(0);
+    expect(persisted.startsWith(head)).toBe(true);
+  });
+
+  test("(d) tool_use/tool_result pairing stays valid — the result keeps the callId", async () => {
+    const body = makeGenericText(420_000);
+    const callId = `c-pair-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-pair", body),
+      invocation: makeInvocation(callId, "dump-pair"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    // The output is the tool_result for this exact tool_use id — offload
+    // replaces the CONTENT only, never the pairing.
+    expect(out.callId).toBe(callId);
+    expect(out.isError).toBe(false);
+  });
+
+  test("(e) under the cap → returned unchanged, nothing persisted", async () => {
+    const body = makeGenericText(1_000);
+    const callId = `c-small-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-small", body),
+      invocation: makeInvocation(callId, "dump-small"),
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    expect(out.content).toBe(body);
+    // No reference message, no persisted-output pointer.
+    expect(out.content).not.toContain("saved to");
+    expect(() => readFileSync(getToolResultPath(callId, false), "utf8")).toThrow();
+  });
+
+  test("Claude / ≥200K window: a 420 KB result is NOT offloaded (fixed 400 KB ceiling, unaffected)", async () => {
+    const body = makeGenericText(420_000);
+    const callId = `c-claude-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-claude", body),
+      invocation: makeInvocation(callId, "dump-claude"),
+      contextWindowTokens: LARGE_WINDOW,
+    });
+    // 420 KB > 400 KB ceiling, so it still offloads at 400 KB — but the
+    // KEY invariant is that the cap value is the fixed ceiling, NOT the
+    // window-relative value, i.e. Claude's threshold is untouched.
+    expect(Buffer.byteLength(out.content, "utf8")).toBeLessThanOrEqual(
+      DEFAULT_MAX_TOOL_RESULT_BYTES,
+    );
+    // Below the 400 KB ceiling a large-window result is returned verbatim
+    // (no offload, no reference) — proving Claude's behavior is unchanged.
+    const underCeiling = makeGenericText(300_000);
+    const callId2 = `c-claude-under-${randomUUID()}`;
+    const out2 = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-claude-under", underCeiling),
+      invocation: makeInvocation(callId2, "dump-claude-under"),
+      contextWindowTokens: LARGE_WINDOW,
+    });
+    expect(out2.content).toBe(underCeiling);
+    expect(out2.content).not.toContain("saved to");
   });
 });


### PR DESCRIPTION
Research-prescribed **Technique D** (model-aware disk-offload) — the *proper* form of the cap per the current-papers research (§2/§3.2: 'the cap becomes an **offload**, not a guillotine'). Backed by verified papers: MemGPT (arXiv:2310.08560), Anthropic *Managing context on the Claude Developer Platform* (file-based memory), *Solving Context Window Overflow in AI Agents* (arXiv:2511.22729 — raw-data→memory-pointers).

PR #1332 made the cap model-aware but **blind-truncated**. Now, when a result exceeds the model-aware cap, the **full output is persisted to disk** (reusing the existing `persistToolResult` → `<projectDir>/<sessionId>/tool-results/<callId>.txt`, readable via FileRead) and the model gets a **reference** — head preview + `[full output (~N bytes / ~X tokens) saved to <path> — read that file (or a byte/line range with offset+limit) to see more]` — so the agent can **retrieve** the full content on demand (the MemGPT memory-pointer pattern) instead of losing the tail.

- `offloadOrCapToolResult`/`buildOffloadReferenceMessage` at the cap site, reusing the existing persistence (no new store). Persist failure → falls back to the legacy blind cap so the hard model-aware ceiling is **always** enforced.
- tool_use/tool_result pairing preserved (only content replaced, callId kept); per-tool override + ≥200K-window (Claude) carve-out unchanged.
- **Composes with the existing observation-masking** (microcompact / Technique E — already correct per *The Complexity Trap*); **not touched/duplicated** (microcompact 52/52 still pass).

**Scope honesty:** Technique E (masking) was already implemented in agenc, so this PR does **only** the genuinely-missing Technique D. The aggregate per-message budget stub stays a no-op (separate path; the per-result offload fully prevents single-result overflow).

**Gate:** build 0 · tsc 0 · full `test:unit` **13,552 / 0** · tui smoke not worse · revert independently re-verified (disabling the offload reddens the 'OFFLOADED, not blind-truncated' test).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG