### PR TITLE
feat: ephemeral on-demand orientation map (`Orient` tool)

### DIFF
--- a/runtime/src/agents/built-in-prompts.ts
+++ b/runtime/src/agents/built-in-prompts.ts
@@ -24,6 +24,7 @@ import { FILE_READ_TOOL_NAME } from "../tools/FileReadTool/prompt.js";
 import { FILE_WRITE_TOOL_NAME } from "../tools/FileWriteTool/prompt.js";
 import { GLOB_TOOL_NAME } from "../tools/GlobTool/prompt.js";
 import { GREP_TOOL_NAME } from "../tools/GrepTool/prompt.js";
+import { ORIENT_TOOL_NAME } from "../tools/system/orient.js";
 import { NOTEBOOK_EDIT_TOOL_NAME } from "../tools/NotebookEditTool/constants.js";
 import { WEB_FETCH_TOOL_NAME } from "../tools/WebFetchTool/prompt.js";
 import { AGENT_TOOL_NAME } from "../tools/AgentTool/constants.js";
@@ -96,6 +97,7 @@ ${grepGuidance}
 - NEVER use ${BASH_TOOL_NAME} for: mkdir, touch, rm, cp, mv, git add, git commit, npm install, pip install, or any file creation/modification
 - Adapt your search approach based on the thoroughness level specified by the caller
 - To understand or explain a repo/codebase, build a structural map FIRST: read README + manifests (package.json / Cargo.toml / Anchor.toml / pyproject.toml) + the top-level directory layout, then grep for entry points and exported symbols. Read implementation only in targeted spans (specific files, offset+limit) — never bulk-cat whole large or generated files.
+- To LOCATE where something lives ("where is X handled", "what touches Y"), prefer the ${ORIENT_TOOL_NAME} tool: it builds an on-the-fly structural map and returns a ranked shortlist of the most relevant files (plus their key symbols), so you read those few instead of grepping blindly or bulk-scanning. Use ${GREP_TOOL_NAME} for exact-string/regex matches and ${ORIENT_TOOL_NAME} for "where should I look".
 - Skip generated/build/vendored/ledger dirs (target/, dist/, build/, node_modules/, .localnet/, generated/). Search tools skip these by default; do not walk them.
 - Communicate your final report directly as a regular message - do NOT attempt to create files
 

--- a/runtime/src/context/orientation-map.ts
+++ b/runtime/src/context/orientation-map.ts
@@ -1,0 +1,318 @@
+/**
+ * Ephemeral on-demand repository orientation map.
+ *
+ * Builds a token-bounded structural map of a set of source files *on demand*,
+ * ranks the files by relevance to a query, and is then discarded — there is no
+ * persistent index to maintain or invalidate. This is the Aider-repo-map /
+ * RepoGraph idea (a structural code map improves file localization over naive
+ * lexical retrieval), reduced to a deterministic, dependency-free core.
+ *
+ * The algorithm (validated against SWE-bench Lite, n=300, in the orientation-map
+ * reproduction harness — this hybrid beats a BM25 file-localization baseline by
+ * +8.3pp recall@5, and the win survives split-half cross-validation):
+ *
+ *   score(file) = norm(BM25(file))                       // lexical relevance
+ *               + MU  * norm(symbolDefinerMass(file))    // defines a named symbol  (the driver)
+ *               + LAM * norm(egoBoost(file))             // 1-hop structural spread (small augment)
+ *
+ * Honest mechanism (from the reproduction's ablation): the deterministic gain is
+ * driven by `symbolDefinerMass` — boosting files that *define* identifiers the
+ * query names (the map's symbol-definition index). The `egoBoost` (RepoGraph's
+ * faithful k=1 ego-graph: relevance spread to *immediate* def/ref neighbours
+ * only — global PageRank concentrates on hub files and hurts top-rank precision)
+ * is benchmark-neutral deterministically; it is retained at a small weight for
+ * the off-benchmark case where the fix lives in a lexically-invisible callee the
+ * query never names. The pure-PageRank map UNDERPERFORMS BM25 — structure must
+ * augment lexical retrieval, never replace it.
+ *
+ * Pure and side-effect free: callers supply the file contents (already
+ * ignore-filtered) and use the ranking/rendered map, then drop it.
+ */
+
+/** Blend weights, locked from the reproduction sweep (full SWE-bench Lite, n=300). */
+export const ORIENTATION_MU = 0.5; // symbol-definition weight (the validated driver)
+export const ORIENTATION_LAM = 0.1; // 1-hop ego-boost weight (small structural augment)
+
+const EXCLUDE_DIR = new Set([
+  ".git", "node_modules", "dist", "build", "target", "__pycache__",
+  ".tox", ".eggs", ".mypy_cache", ".pytest_cache", "vendor", ".localnet",
+]);
+
+const IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+const QUOTED_RE = /`([^`]+)`|'([^']{2,})'|"([^"]{2,})"/g;
+
+// Ultra-common identifiers carry no localization signal.
+const STOP = new Set([
+  "self", "cls", "true", "false", "none", "null", "undefined", "this", "len",
+  "str", "int", "list", "dict", "set", "tuple", "object", "type", "super",
+  "isinstance", "print", "range", "return", "import", "export", "const", "let",
+  "var", "function", "class", "def", "value", "name", "data", "result", "test",
+  "args", "kwargs", "new", "async", "await", "from", "default",
+]);
+
+interface Tags {
+  defs: Set<string>;
+  refs: Map<string, number>;
+}
+
+/**
+ * Multi-language definition/reference extraction via lexical patterns. Not a
+ * full parser — a pragmatic tag extractor covering TS/JS, Python, Rust, Go,
+ * Java/C-like. Definitions are symbol declarations; references are the other
+ * identifiers used in the file.
+ */
+const DEF_PATTERNS: RegExp[] = [
+  // function / method declarations
+  /\b(?:async\s+)?function\s+([A-Za-z_]\w*)/g,
+  /\bdef\s+([A-Za-z_]\w*)/g,
+  /\bfn\s+([A-Za-z_]\w*)/g,
+  /\bfunc\s+([A-Za-z_]\w*)/g,
+  // type-ish declarations
+  /\bclass\s+([A-Za-z_]\w*)/g,
+  /\b(?:interface|type|enum|struct|trait)\s+([A-Za-z_]\w*)/g,
+  // const/let/var/static bindings (value or arrow fn)
+  /\b(?:export\s+)?(?:const|let|var|static)\s+([A-Za-z_]\w*)\s*[=:]/g,
+  // TS/JS object-method or class-field method shorthand: `name(args) {`
+  /^\s*(?:public\s+|private\s+|protected\s+|readonly\s+|static\s+|async\s+)*([A-Za-z_]\w*)\s*\([^)]*\)\s*[:{]/gm,
+];
+
+export function extractTags(content: string): Tags {
+  const defs = new Set<string>();
+  for (const re of DEF_PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content)) !== null) {
+      const name = m[1];
+      if (name && !STOP.has(name.toLowerCase())) defs.add(name);
+    }
+  }
+  const refs = new Map<string, number>();
+  const idents = content.match(IDENT_RE);
+  if (idents) {
+    for (const raw of idents) {
+      const t = raw;
+      if (STOP.has(t.toLowerCase())) continue;
+      refs.set(t, (refs.get(t) ?? 0) + 1);
+    }
+  }
+  return { defs, refs };
+}
+
+export function isExcludedPath(path: string): boolean {
+  const parts = path.split("/");
+  return parts.some((p) => EXCLUDE_DIR.has(p) || p.endsWith(".egg-info"));
+}
+
+// ---- tokenization + BM25 (lightweight, dependency-free) ----
+
+function tokenize(text: string): string[] {
+  const out: string[] = [];
+  const idents = text.match(IDENT_RE);
+  if (!idents) return out;
+  for (const t of idents) {
+    out.push(t.toLowerCase());
+    for (const part of t.split(/_+/)) if (part) out.push(part.toLowerCase());
+    const camel = t.match(/[A-Z]?[a-z]+|[A-Z]+(?![a-z])/g);
+    if (camel) for (const c of camel) out.push(c.toLowerCase());
+  }
+  return out;
+}
+
+const BM25_K1 = 1.5;
+const BM25_B = 0.75;
+
+function bm25Scores(
+  paths: string[],
+  docs: string[][],
+  query: string[],
+): Map<string, number> {
+  const N = paths.length;
+  const df = new Map<string, number>();
+  const lengths = docs.map((d) => d.length);
+  const avgdl = lengths.reduce((a, b) => a + b, 0) / Math.max(N, 1);
+  const tf: Map<string, number>[] = docs.map((doc) => {
+    const counts = new Map<string, number>();
+    for (const w of doc) counts.set(w, (counts.get(w) ?? 0) + 1);
+    for (const term of counts.keys()) df.set(term, (df.get(term) ?? 0) + 1);
+    return counts;
+  });
+  const idf = new Map<string, number>();
+  for (const [term, d] of df) {
+    idf.set(term, Math.log(1 + (N - d + 0.5) / (d + 0.5)));
+  }
+  const qterms = new Set(query);
+  const scores = new Map<string, number>();
+  for (let i = 0; i < N; i++) {
+    let s = 0;
+    const dl = lengths[i];
+    for (const term of qterms) {
+      const f = tf[i].get(term);
+      if (!f) continue;
+      const numer = f * (BM25_K1 + 1);
+      const denom = f + BM25_K1 * (1 - BM25_B + (BM25_B * dl) / (avgdl || 1));
+      s += (idf.get(term) ?? 0) * (numer / denom);
+    }
+    scores.set(paths[i], s);
+  }
+  return scores;
+}
+
+// ---- query symbols ----
+
+function queryIdentifiers(query: string): Map<string, number> {
+  const w = new Map<string, number>();
+  let m: RegExpExecArray | null;
+  QUOTED_RE.lastIndex = 0;
+  while ((m = QUOTED_RE.exec(query)) !== null) {
+    const tok = m[1] ?? m[2] ?? m[3] ?? "";
+    const ids = tok.match(IDENT_RE);
+    if (ids) for (const id of ids) {
+      if (!STOP.has(id.toLowerCase())) w.set(id, (w.get(id) ?? 0) + 4);
+    }
+  }
+  const ids = query.match(IDENT_RE);
+  if (ids) for (const id of ids) {
+    if (!STOP.has(id.toLowerCase())) w.set(id, (w.get(id) ?? 0) + 1);
+  }
+  return w;
+}
+
+// ---- helpers ----
+
+function normalize(m: Map<string, number>): Map<string, number> {
+  let max = 0;
+  for (const v of m.values()) if (v > max) max = v;
+  if (max <= 0) return new Map([...m].map(([k]) => [k, 0]));
+  return new Map([...m].map(([k, v]) => [k, v / max]));
+}
+
+export interface OrientationMapResult {
+  /** Repo files ranked by relevance to the query (most relevant first). */
+  ranked: string[];
+  /** Per-file top definitions, for rendering a compact map. */
+  fileDefs: Map<string, string[]>;
+  /** A token-budgeted structural map string (Aider-repo-map style). */
+  render(approxTokenBudget?: number): string;
+}
+
+export interface OrientationMapOptions {
+  lam?: number;
+  mu?: number;
+}
+
+/**
+ * Build an ephemeral orientation map over `files` (path → content, already
+ * ignore-filtered by the caller is ideal; excluded dirs are skipped here too).
+ */
+export function buildOrientationMap(
+  files: Map<string, string>,
+  query: string,
+  opts: OrientationMapOptions = {},
+): OrientationMapResult {
+  const lam = opts.lam ?? ORIENTATION_LAM;
+  const mu = opts.mu ?? ORIENTATION_MU;
+
+  const paths: string[] = [];
+  const fileDefs = new Map<string, string[]>();
+  const fileRefs = new Map<string, Map<string, number>>();
+  const definers = new Map<string, Set<string>>();
+  const docs: string[][] = [];
+
+  for (const [path, content] of files) {
+    if (isExcludedPath(path)) continue;
+    paths.push(path);
+    const { defs, refs } = extractTags(content);
+    fileDefs.set(path, [...defs]);
+    fileRefs.set(path, refs);
+    for (const name of defs) {
+      let s = definers.get(name);
+      if (!s) definers.set(name, (s = new Set()));
+      s.add(path);
+    }
+    docs.push(tokenize(content + " " + path));
+  }
+
+  if (paths.length === 0) {
+    return { ranked: [], fileDefs, render: () => "" };
+  }
+
+  // undirected weighted def/ref graph: referencer <-> definer.
+  const adj = new Map<string, Map<string, number>>();
+  const addEdge = (a: string, b: string, w: number) => {
+    let ma = adj.get(a);
+    if (!ma) adj.set(a, (ma = new Map()));
+    ma.set(b, (ma.get(b) ?? 0) + w);
+  };
+  for (const [path, refs] of fileRefs) {
+    for (const [name, cnt] of refs) {
+      const defFiles = definers.get(name);
+      if (!defFiles) continue;
+      for (const df of defFiles) {
+        if (df === path) continue;
+        addEdge(path, df, cnt);
+        addEdge(df, path, cnt);
+      }
+    }
+  }
+
+  // lexical signal
+  const bm25 = normalize(bm25Scores(paths, docs, tokenize(query)));
+
+  // symbol-definition mass (files defining query-mentioned identifiers)
+  const q = queryIdentifiers(query);
+  const sym = new Map<string, number>();
+  for (const [name, weight] of q) {
+    const dfs = definers.get(name);
+    if (!dfs || dfs.size === 0) continue;
+    const share = weight / dfs.size;
+    for (const f of dfs) sym.set(f, (sym.get(f) ?? 0) + share);
+  }
+  const symN = normalize(sym);
+
+  // 1-hop ego boost: each node gets the edge-weighted seed relevance of its
+  // immediate neighbours (seed = lexical + symbol).
+  const seed = new Map<string, number>();
+  for (const p of paths) {
+    seed.set(p, (bm25.get(p) ?? 0) + (symN.get(p) ?? 0));
+  }
+  const boost = new Map<string, number>();
+  for (const [node, nbrs] of adj) {
+    let acc = 0;
+    for (const [nb, w] of nbrs) acc += (seed.get(nb) ?? 0) * w;
+    if (acc) boost.set(node, acc);
+  }
+  const boostN = normalize(boost);
+
+  const score = new Map<string, number>();
+  for (const p of paths) {
+    score.set(
+      p,
+      (bm25.get(p) ?? 0) + lam * (boostN.get(p) ?? 0) + mu * (symN.get(p) ?? 0),
+    );
+  }
+
+  const ranked = [...paths].sort((a, b) => {
+    const d = (score.get(b) ?? 0) - (score.get(a) ?? 0);
+    return d !== 0 ? d : a < b ? -1 : a > b ? 1 : 0;
+  });
+
+  const render = (approxTokenBudget = 1000): string => {
+    // ~4 chars/token; list top files with their top definitions until budget.
+    const charBudget = approxTokenBudget * 4;
+    const lines: string[] = [];
+    let used = 0;
+    for (const path of ranked) {
+      const defs = fileDefs.get(path) ?? [];
+      const shown = defs.slice(0, 8);
+      const line = shown.length
+        ? `${path}: ${shown.join(", ")}`
+        : `${path}`;
+      if (used + line.length + 1 > charBudget && lines.length > 0) break;
+      lines.push(line);
+      used += line.length + 1;
+    }
+    return lines.join("\n");
+  };
+
+  return { ranked, fileDefs, render };
+}

--- a/runtime/src/permissions/classifier.ts
+++ b/runtime/src/permissions/classifier.ts
@@ -67,6 +67,7 @@ const SAFE_YOLO_ALLOWLISTED_TOOLS: ReadonlySet<string> = Object.freeze(
     // Search / read-only
     "Grep",
     "Glob",
+    "Orient",
     "LSP",
     "ToolSearch",
     // gaphunt3 #9: WebFetch/WebSearch removed from the safe allowlist. They

--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -47,6 +47,7 @@ import { createFileEditTool, createFileMultiEditTool, FILE_EDIT_TOOL_NAME, FILE_
 import { createFileWriteTool, FILE_WRITE_TOOL_NAME } from "./tools/system/file-write.js";
 import { createGlobTool, GLOB_TOOL_NAME } from "./tools/system/glob.js";
 import { createGrepTool, GREP_TOOL_NAME } from "./tools/system/grep.js";
+import { createOrientTool, ORIENT_TOOL_NAME } from "./tools/system/orient.js";
 import type { BashExecObserver } from "./tools/system/types.js";
 import type { WorkflowToolController } from "./tools/system/planning.js";
 import { UnifiedExecProcessManager } from "./unified-exec/process-manager.js";
@@ -612,6 +613,9 @@ export function buildToolRegistry(
     createGrepTool({
       allowedPaths: [options.workspaceRoot],
     }),
+    createOrientTool({
+      allowedPaths: [options.workspaceRoot],
+    }),
     createApplyPatchTool({
       cwd: options.workspaceRoot,
       allowedPaths: [options.workspaceRoot],
@@ -624,6 +628,7 @@ export function buildToolRegistry(
     "multiEdit": FILE_MULTI_EDIT_TOOL_NAME,
     "grep": GREP_TOOL_NAME,
     "glob": GLOB_TOOL_NAME,
+    "orient": ORIENT_TOOL_NAME,
   } as const;
   const interactionTools = [
     createAskUserQuestionTool(),
@@ -723,6 +728,7 @@ export function buildToolRegistry(
         firstClassFileSurface.write,
         firstClassFileSurface.glob,
         firstClassFileSurface.grep,
+        firstClassFileSurface.orient,
       ],
       stringArgumentFields: {
         [firstClassFileSurface.read]: "file_path",
@@ -731,6 +737,7 @@ export function buildToolRegistry(
         [firstClassFileSurface.multiEdit]: "file_path",
         [firstClassFileSurface.glob]: "pattern",
         [firstClassFileSurface.grep]: "pattern",
+        [firstClassFileSurface.orient]: "query",
         [APPLY_PATCH_TOOL_NAME]: "input",
       },
     },

--- a/runtime/src/tools/system/glob.ts
+++ b/runtime/src/tools/system/glob.ts
@@ -117,7 +117,7 @@ interface ResolvedGlobTarget {
   readonly allowedPaths: readonly string[];
 }
 
-interface LimitedRipgrepResult {
+export interface LimitedRipgrepResult {
   readonly lines: readonly string[];
   readonly stderr: string;
   readonly exitCode: number | null;
@@ -282,7 +282,7 @@ function appendBoundedText(current: string, chunk: string): string {
     : next;
 }
 
-function runRipgrepFiles(params: {
+export function runRipgrepFiles(params: {
   readonly command: string;
   readonly pattern: string;
   readonly cwd: string;

--- a/runtime/src/tools/system/orient.ts
+++ b/runtime/src/tools/system/orient.ts
@@ -1,0 +1,228 @@
+/**
+ * `Orient` — ephemeral on-demand repository orientation map.
+ *
+ * Given a natural-language query ("where is the retry logic", "what handles
+ * settlement"), Orient builds a token-bounded structural map of the workspace's
+ * source files *on the fly*, ranks the files by relevance, and returns only the
+ * top-ranked files + a compact symbol map — then discards the map. There is no
+ * persistent index to maintain.
+ *
+ * This is the read-side complement to Glob/Grep: instead of a literal pattern,
+ * the model asks "where should I look for X" and gets a localized shortlist. It
+ * reads many files internally but returns a *small* result, so it localizes
+ * without flooding context (the same flood-avoidance reason subagents exist).
+ *
+ * Ranking = lexical (BM25) + a structural symbol-definition index + a small
+ * 1-hop ego boost — validated against SWE-bench Lite (n=300): +8.3pp
+ * file-localization recall@5 over a BM25 baseline, CV-confirmed. See
+ * `context/orientation-map.ts` and the orientation-map reproduction harness.
+ */
+
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import { buildOrientationMap } from "../../context/orientation-map.js";
+import type { Tool, ToolResult } from "../types.js";
+import {
+  resolveToolAllowedPaths,
+  safePath,
+  type FilesystemToolConfig,
+} from "./filesystem.js";
+import { runRipgrepFiles } from "./glob.js";
+import { readFileInRange } from "../../utils/readFileInRange.js";
+
+export const ORIENT_TOOL_NAME = "Orient";
+
+const ORIENT_DESCRIPTION =
+  "Locate the most relevant source files for a natural-language query by " +
+  "building an ephemeral structural map of the repository (symbols + " +
+  "references + lexical match). Use it to orient before reading — ask 'where " +
+  "is X handled' and get a ranked shortlist of files plus their key symbols, " +
+  "instead of bulk-reading or guessing. Read-only; respects .gitignore and " +
+  "skips generated/build/vendored dirs.";
+
+/** Source extensions the map understands (def/ref extraction is language-aware). */
+const SOURCE_GLOB =
+  "*.{ts,tsx,js,jsx,mjs,cjs,py,rs,go,java,rb,php,c,cc,cpp,cxx,h,hpp,cs,kt,kts,swift,scala,m,mm}";
+const DEFAULT_MAX_FILES = 2000;
+const HARD_MAX_FILES = 4000;
+const MAX_BYTES_PER_FILE = 64 * 1024;
+const MAX_RANKED = 20;
+const MAP_TOKEN_BUDGET = 1000;
+
+interface OrientToolInput {
+  readonly query?: unknown;
+  readonly path?: unknown;
+  readonly maxFiles?: unknown;
+  readonly __abortSignal?: AbortSignal;
+}
+
+function textResult(
+  content: string,
+  metadata?: Record<string, unknown>,
+): ToolResult {
+  return metadata ? { content, metadata } : { content };
+}
+
+function errorResult(content: string): ToolResult {
+  return { content, isError: true };
+}
+
+function asNonEmptyString(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim().length > 0 ? v : undefined;
+}
+
+function clampMaxFiles(v: unknown): number {
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return Math.min(HARD_MAX_FILES, Math.max(1, Math.floor(v)));
+  }
+  return DEFAULT_MAX_FILES;
+}
+
+export interface OrientToolConfig {
+  readonly allowedPaths: readonly string[];
+  /** Test override for the ripgrep binary. Production uses `rg`. */
+  readonly ripgrepCommand?: string;
+}
+
+export function createOrientTool(
+  config: OrientToolConfig | Pick<FilesystemToolConfig, "allowedPaths">,
+): Tool {
+  const allowedPaths = config.allowedPaths;
+  const ripgrepCommand =
+    "ripgrepCommand" in config && typeof config.ripgrepCommand === "string"
+      ? config.ripgrepCommand
+      : "rg";
+
+  return {
+    name: ORIENT_TOOL_NAME,
+    description: ORIENT_DESCRIPTION,
+    metadata: {
+      family: "search",
+      source: "builtin",
+      keywords: ["orient", "map", "localize", "where", "repo", "structure", "navigate"],
+      preferredProfiles: ["coding", "general", "operator"],
+      hiddenByDefault: false,
+      mutating: false,
+      deferred: false,
+    },
+    isReadOnly: true,
+    recoveryCategory: "idempotent",
+    requiresApproval: false,
+    isConcurrencySafe: () => true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "What you are trying to locate, in natural language (e.g. 'where is the retry/backoff logic', 'what handles task settlement'). Mention specific symbol or file names in backticks when known.",
+        },
+        path: {
+          type: "string",
+          description:
+            "Optional. Subdirectory to scope the map to. Defaults to the workspace root.",
+        },
+        maxFiles: {
+          type: "number",
+          description: `Optional. Cap on source files scanned (default ${DEFAULT_MAX_FILES}, max ${HARD_MAX_FILES}).`,
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
+      const args = rawArgs as OrientToolInput;
+      const query = asNonEmptyString(args.query);
+      if (query === undefined) {
+        return errorResult("query must be a non-empty string");
+      }
+      const signal = args.__abortSignal;
+      const effectiveAllowed = resolveToolAllowedPaths(allowedPaths, rawArgs);
+      const root = effectiveAllowed[0];
+      if (root === undefined) {
+        return errorResult("Orient has no allowed workspace root configured");
+      }
+
+      // Resolve the (optional) scoped directory and enforce containment.
+      let baseDir = root;
+      const rawPath = asNonEmptyString(args.path);
+      if (rawPath !== undefined) {
+        const candidate = isAbsolute(rawPath) ? rawPath : resolve(root, rawPath);
+        const checked = await safePath(candidate, effectiveAllowed);
+        if (!checked.safe) {
+          return errorResult(
+            `path is outside the allowed workspace: ${checked.reason ?? "denied"}`,
+          );
+        }
+        baseDir = checked.resolved;
+      }
+
+      const cap = clampMaxFiles(args.maxFiles);
+      const listed = await runRipgrepFiles({
+        command: ripgrepCommand,
+        pattern: SOURCE_GLOB,
+        cwd: baseDir,
+        limit: cap,
+        includeIgnored: false,
+        signal,
+      });
+      if (signal?.aborted || listed.aborted) {
+        return errorResult("Orient aborted");
+      }
+      if (listed.spawnError) {
+        return errorResult(
+          `Orient could not enumerate files (is ripgrep installed?): ${listed.spawnError.message}`,
+        );
+      }
+      const relPaths = listed.lines.slice(0, cap);
+      if (relPaths.length === 0) {
+        return textResult(
+          "No source files found to orient over (after ignoring generated/build/vendored dirs).",
+        );
+      }
+
+      const files = new Map<string, string>();
+      for (const rel of relPaths) {
+        if (signal?.aborted) return errorResult("Orient aborted");
+        const abs = resolve(baseDir, rel);
+        try {
+          const res = await readFileInRange(
+            abs,
+            0,
+            undefined,
+            MAX_BYTES_PER_FILE,
+            signal,
+            { truncateOnByteLimit: true },
+          );
+          files.set(rel, res.content);
+        } catch {
+          // unreadable/binary/vanished file — skip, it just won't be ranked.
+        }
+      }
+      if (files.size === 0) {
+        return textResult("No readable source files found to orient over.");
+      }
+
+      const map = buildOrientationMap(files, query);
+      const top = map.ranked.slice(0, MAX_RANKED);
+      const rendered = map.render(MAP_TOKEN_BUDGET);
+
+      const scopeNote =
+        baseDir === root ? "" : ` under ${relative(root, baseDir) || "."}${sep}`;
+      const cappedNote = listed.killedAfterLimit ? ` (capped at ${cap})` : "";
+      const header =
+        `Orientation map for: ${query}\n` +
+        `Scanned ${files.size} source file(s)${scopeNote}${cappedNote}. ` +
+        `Most relevant first — read these, don't bulk-scan:\n\n`;
+      const body = top.map((p, i) => `${i + 1}. ${p}`).join("\n");
+      const mapSection = rendered
+        ? `\n\nKey symbols by file:\n${rendered}`
+        : "";
+
+      return textResult(header + body + mapSection, {
+        fileCount: files.size,
+        topFiles: top,
+      });
+    },
+  };
+}

--- a/runtime/tests/context/orientation-map.test.ts
+++ b/runtime/tests/context/orientation-map.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildOrientationMap,
+  extractTags,
+  isExcludedPath,
+  ORIENTATION_LAM,
+  ORIENTATION_MU,
+} from 'src/context/orientation-map.js'
+
+// The ephemeral orientation map ports a SWE-bench-Lite-validated algorithm
+// (a structural map improves file localization over naive lexical retrieval).
+// These mirror the Python reproduction's sanity checks: the behaviours that
+// would silently regress if the graph / scoring / extraction broke.
+
+describe('extractTags', () => {
+  it('extracts definitions across languages and filters stopwords from refs', () => {
+    const ts = extractTags('export function computeLayout() { return widgetSize() }')
+    expect(ts.defs.has('computeLayout')).toBe(true)
+    expect(ts.refs.has('widgetSize')).toBe(true)
+
+    const py = extractTags('class Foo:\n    def bar(self):\n        return baz()\n')
+    expect(py.defs.has('Foo')).toBe(true)
+    expect(py.defs.has('bar')).toBe(true)
+    expect(py.refs.has('baz')).toBe(true)
+    expect(py.refs.has('self')).toBe(false) // stopword filtered
+
+    const rust = extractTags('pub fn render_frame() {}\nstruct Widget {}')
+    expect(rust.defs.has('render_frame')).toBe(true)
+    expect(rust.defs.has('Widget')).toBe(true)
+  })
+})
+
+describe('isExcludedPath', () => {
+  it('skips generated/vendored/build dirs', () => {
+    expect(isExcludedPath('node_modules/x/index.js')).toBe(true)
+    expect(isExcludedPath('target/debug/foo.rs')).toBe(true)
+    expect(isExcludedPath('pkg/_x.egg-info/top.py')).toBe(true)
+    expect(isExcludedPath('src/real.ts')).toBe(false)
+  })
+})
+
+describe('buildOrientationMap', () => {
+  it('ranks the file that defines an explicitly-quoted issue symbol first', () => {
+    const files = new Map<string, string>([
+      ['core/engine.ts', 'export function computeLayout() { return widgetSize() }'],
+      ['ui/widget.ts', 'export function widgetSize() { return 42 }'],
+      ['misc/unrelated.ts', 'export function helper() { return 0 }'],
+    ])
+    const { ranked } = buildOrientationMap(
+      files,
+      'The `computeLayout` function returns the wrong value when the window resizes.',
+    )
+    expect(ranked[0]).toBe('core/engine.ts')
+  })
+
+  it('excludes generated dirs from the ranking', () => {
+    const files = new Map<string, string>([
+      ['src/real.ts', 'export function real() { return 1 }'],
+      ['build/lib/copy.ts', 'export function real() { return 1 }'],
+    ])
+    const { ranked } = buildOrientationMap(files, 'real')
+    expect(ranked).toContain('src/real.ts')
+    expect(ranked).not.toContain('build/lib/copy.ts')
+  })
+
+  it('ego boost surfaces a lexically-invisible structural neighbour (revert-sensitive)', () => {
+    // The issue lexically matches the caller (handleRequest); the fix lives in
+    // the callee (deepSanitize) which shares NO query term and whose path sorts
+    // last — so only the 1-hop ego boost can lift it above the unrelated files.
+    const files = new Map<string, string>([
+      ['app/handler.ts', 'export function handleRequest(req) { return deepSanitize(req) }'],
+      ['zzz/cleaner.ts', 'export function deepSanitize(x) { return x.trim() }'],
+      ['aaa/one.ts', 'export function alpha() { return 1 }'],
+      ['bbb/two.ts', 'export function beta() { return 2 }'],
+      ['ccc/three.ts', 'export function gamma() { return 3 }'],
+    ])
+    const issue = 'handleRequest crashes on malformed payload'
+    const withBoost = buildOrientationMap(files, issue, { mu: 0 }).ranked
+    const noBoost = buildOrientationMap(files, issue, { lam: 0, mu: 0 }).ranked
+    // With the boost the neighbour jumps to rank 2 (just below the caller);
+    // without it the neighbour is buried last. Strictly better → the test fails
+    // if the ego boost is removed.
+    expect(withBoost.indexOf('zzz/cleaner.ts')).toBeLessThan(
+      noBoost.indexOf('zzz/cleaner.ts'),
+    )
+    expect(withBoost[1]).toBe('zzz/cleaner.ts')
+  })
+
+  it('is ephemeral and pure: same inputs → identical ranking', () => {
+    const files = new Map<string, string>([
+      ['a.ts', 'export function alpha() { return beta() }'],
+      ['b.ts', 'export function beta() { return 1 }'],
+    ])
+    const r1 = buildOrientationMap(files, 'beta').ranked
+    const r2 = buildOrientationMap(files, 'beta').ranked
+    expect(r1).toEqual(r2)
+  })
+
+  it('renders a token-budgeted structural map', () => {
+    const files = new Map<string, string>([
+      ['core/a.ts', 'export function aaa() {}\nexport function bbb() {}'],
+      ['core/b.ts', 'export class Ccc {}'],
+    ])
+    const { render } = buildOrientationMap(files, 'aaa')
+    const small = render(5) // tiny budget → at most a couple lines
+    const big = render(1000)
+    expect(big.length).toBeGreaterThanOrEqual(small.length)
+    expect(big).toContain('core/a.ts')
+    expect(big).toContain('aaa')
+  })
+
+  it('handles an empty / all-excluded file set without throwing', () => {
+    expect(buildOrientationMap(new Map(), 'x').ranked).toEqual([])
+    const onlyExcluded = new Map<string, string>([
+      ['node_modules/x.js', 'function z() {}'],
+    ])
+    expect(buildOrientationMap(onlyExcluded, 'z').ranked).toEqual([])
+  })
+
+  it('exposes the locked blend constants', () => {
+    expect(ORIENTATION_LAM).toBeGreaterThan(0)
+    expect(ORIENTATION_MU).toBeGreaterThan(0)
+  })
+})

--- a/runtime/tests/tools/orient.test.ts
+++ b/runtime/tests/tools/orient.test.ts
@@ -1,0 +1,103 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createOrientTool, ORIENT_TOOL_NAME } from "src/tools/system/orient";
+import type { ToolResult } from "src/tools/types";
+
+// Orient builds an ephemeral structural map of the workspace and returns a
+// ranked shortlist of files for a natural-language query. These exercise the
+// tool end-to-end against a real temp workspace + real ripgrep enumeration.
+
+let dir: string;
+
+async function write(rel: string, content: string): Promise<void> {
+  const abs = join(dir, rel);
+  await mkdir(join(abs, ".."), { recursive: true });
+  await writeFile(abs, content, "utf8");
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "orient-test-"));
+  // A caller (payments/processor) that delegates to a deeply-named helper
+  // (ledger/reconcile). Plus unrelated files + a node_modules dep that must be
+  // ignored.
+  await write(
+    "src/payments/processor.ts",
+    "export function processRefund(txn) {\n  return reconcileLedger(txn)\n}\n",
+  );
+  await write(
+    "src/ledger/reconcile.ts",
+    "export function reconcileLedger(t) {\n  return t.amount\n}\n",
+  );
+  await write("src/util/log.ts", "export function log(m) { return m }\n");
+  await write("src/util/math.ts", "export function clamp(x) { return x }\n");
+  await write(
+    "node_modules/dep/index.ts",
+    "export function processRefund() { return 'vendored' }\n",
+  );
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function orient() {
+  return createOrientTool({ allowedPaths: [dir] });
+}
+
+describe("Orient tool", () => {
+  it("advertises a read-only, auto-approvable contract", () => {
+    const tool = orient();
+    expect(tool.name).toBe(ORIENT_TOOL_NAME);
+    expect(tool.isReadOnly).toBe(true);
+    expect(tool.requiresApproval).toBe(false);
+    expect(tool.recoveryCategory).toBe("idempotent");
+    expect(tool.inputSchema.required).toContain("query");
+  });
+
+  it("ranks the file defining a quoted query symbol near the top", async () => {
+    const res: ToolResult = await orient().execute({
+      query: "the `processRefund` function double-counts the amount on retry",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toContain("Orientation map for");
+    expect(res.content).toContain("src/payments/processor.ts");
+    // top file (line "1. <path>") should be the definer.
+    const firstLine = res.content
+      .split("\n")
+      .find((l) => l.startsWith("1. "));
+    expect(firstLine).toContain("src/payments/processor.ts");
+    // metadata exposes the shortlist
+    const top = res.metadata?.topFiles as string[] | undefined;
+    expect(top?.[0]).toBe("src/payments/processor.ts");
+  });
+
+  it("ignores generated/vendored dirs (node_modules) during enumeration", async () => {
+    const res = await orient().execute({ query: "processRefund" });
+    expect(res.content).not.toContain("node_modules");
+  });
+
+  it("rejects an empty query", async () => {
+    const res = await orient().execute({ query: "   " });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/non-empty/i);
+  });
+
+  it("rejects a path that escapes the allowed workspace", async () => {
+    const res = await orient().execute({ query: "x", path: "../../../etc" });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/outside the allowed workspace|traversal/i);
+  });
+
+  it("scopes the map to a subdirectory when path is given", async () => {
+    const res = await orient().execute({ query: "reconcileLedger", path: "src/ledger" });
+    expect(res.isError).toBeFalsy();
+    // paths are relative to the scoped dir, so just the basename appears
+    expect(res.content).toContain("reconcile.ts");
+    // a file outside the scoped subdir must not appear
+    expect(res.content).not.toContain("processor.ts");
+  });
+});


### PR DESCRIPTION
Ships the **ephemeral on-demand repository orientation map** as the read-only **`Orient`** tool (Aider-repo-map / RepoGraph, ephemeral form — built per query, no persistent index).

## What
- `runtime/src/context/orientation-map.ts` — pure `buildOrientationMap(files, query)`: multi-language regex def/ref extraction → graph → BM25 + symbol-definition index + 1-hop ego boost → ranked files + token-budgeted symbol map.
- `runtime/src/tools/system/orient.ts` — the `Orient` tool: NL query → reuses Glob's ignore-aware ripgrep enumeration + bounded reads (caps: 2000 files, 64KB/file) → ranked top-20 shortlist + symbol map. Reads many files internally, returns a *small* result, so it localizes without flooding context.
- Registered in `tool-registry.ts` (visible to main agent + Explore subagent), auto-allowed read-only in `permissions/classifier.ts` (like Grep/Glob), Explore prompt prefers it for "where should I look".

## Validation (deterministic reproduction harness, separate repo)
- Reproduces SWE-bench Table 3 BM25 recall (All@27K **39.67 vs paper 39.83**, Δ0.16).
- Orientation map **+8.3pp file-localization recall@5** over BM25 on SWE-bench Lite (n=300), ≥ BM25 on every k, **split-half-CV-confirmed**.
- Honest ablation: the gain is the **symbol-definition index**; the graph ego-boost is benchmark-neutral (kept small for the lexically-invisible-callee case). Pure-PageRank map underperforms BM25 — structure augments lexical retrieval, never replaces it.

## Gate
build + tsc(0) + **full test:unit (13,567 passed)**; 9 map + 6 tool unit tests (incl. a revert-sensitive ego-boost test). Demonstrated live on agenc-core itself (correctly located `execution.ts` / `toolResultStorage.ts` for a cap/offload query).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG