### PR TITLE
fix(tui): /cost estimated session total from agents when no sidecar (D7)

### DIFF
--- a/runtime/src/commands/cost.ts
+++ b/runtime/src/commands/cost.ts
@@ -57,6 +57,13 @@ export interface CostAgentRow {
 export interface CostReport {
   /** Real session total cost (USD), when the cost sidecar is available. */
   readonly totalCostUsd?: number;
+  /**
+   * True when {@link totalCostUsd}/{@link totalTokens} are not the sidecar's
+   * real session figures but a fallback aggregated from the per-agent estimates
+   * (e.g. a local/self-hosted model with no cost sidecar). Surfaced as "est."
+   * so we never present an estimate as a measured number.
+   */
+  readonly totalIsEstimated?: boolean;
   readonly inputTokens?: number;
   readonly outputTokens?: number;
   readonly totalTokens?: number;
@@ -190,19 +197,50 @@ export function buildCostReport(ctx: SlashCommandContext): CostReport {
   const getAppState = ctx.appState?.getAppState;
   const agents =
     typeof getAppState === "function" ? readAgentRows(getAppState()) : [];
+
+  // Fallback session total: when the sidecar reports no real session figure
+  // (e.g. a local/self-hosted model with no cost tracking), the bulk of a
+  // fan-out's cost still lives in the per-agent rows we already estimated.
+  // Summing them answers "how much is this costing" with an explicit estimate
+  // rather than a useless "—". The real-sidecar path is left untouched.
+  const agentCostUsd = agents.reduce(
+    (sum, a) => sum + (a.estimatedCostUsd ?? 0),
+    0,
+  );
+  const anyAgentCost = agents.some((a) => a.estimatedCostUsd !== undefined);
+  const agentTokens = agents.reduce((sum, a) => sum + (a.tokenCount ?? 0), 0);
+
+  const realTotalCost = totals.totalCostUsd;
+  const realTotalTokens =
+    totals.inputTokens !== undefined && totals.outputTokens !== undefined
+      ? totals.inputTokens + totals.outputTokens
+      : undefined;
+
+  const totalCostUsd =
+    realTotalCost !== undefined
+      ? realTotalCost
+      : anyAgentCost
+        ? agentCostUsd
+        : undefined;
+  const totalTokens =
+    realTotalTokens !== undefined
+      ? realTotalTokens
+      : agentTokens > 0
+        ? agentTokens
+        : undefined;
+  const totalIsEstimated =
+    realTotalCost === undefined && (anyAgentCost || agentTokens > 0);
+
   return {
-    ...(totals.totalCostUsd !== undefined
-      ? { totalCostUsd: totals.totalCostUsd }
-      : {}),
+    ...(totalCostUsd !== undefined ? { totalCostUsd } : {}),
+    ...(totalIsEstimated ? { totalIsEstimated: true } : {}),
     ...(totals.inputTokens !== undefined
       ? { inputTokens: totals.inputTokens }
       : {}),
     ...(totals.outputTokens !== undefined
       ? { outputTokens: totals.outputTokens }
       : {}),
-    ...(totals.inputTokens !== undefined && totals.outputTokens !== undefined
-      ? { totalTokens: totals.inputTokens + totals.outputTokens }
-      : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
     ...(totals.turns !== undefined ? { turns: totals.turns } : {}),
     hasUnknownCost: totals.hasUnknownCost,
     models: totals.models,
@@ -218,7 +256,10 @@ export function formatCostReport(report: CostReport): string {
   const lines: string[] = [];
   if (report.totalCostUsd !== undefined) {
     const unknown = report.hasUnknownCost ? " (some pricing unknown)" : "";
-    lines.push(`Session cost: ${formatUsdCost(report.totalCostUsd)}${unknown}`);
+    const est = report.totalIsEstimated ? " est. (from agent tokens)" : "";
+    lines.push(
+      `Session cost: ${formatUsdCost(report.totalCostUsd)}${est}${unknown}`,
+    );
   } else {
     lines.push("Session cost: — (cost tracking unavailable)");
   }
@@ -228,6 +269,10 @@ export function formatCostReport(report: CostReport): string {
     lines.push(
       `  • tokens: ${formatTokenCount(input ?? 0)} in / ${formatTokenCount(output ?? 0)} out` +
         (report.turns !== undefined ? ` · turns=${report.turns}` : ""),
+    );
+  } else if (report.totalTokens !== undefined) {
+    lines.push(
+      `  • tokens: ${formatTokenCount(report.totalTokens)} total${report.totalIsEstimated ? " est." : ""}`,
     );
   }
   if (report.models.length > 0) {

--- a/runtime/src/tui/components/v2/CostUsageModal.tsx
+++ b/runtime/src/tui/components/v2/CostUsageModal.tsx
@@ -54,20 +54,22 @@ export function CostUsageModal({
 
   const totalCost =
     report.totalCostUsd !== undefined
-      ? `${formatUsdCost(report.totalCostUsd)}${report.hasUnknownCost ? ' *' : ''}`
+      ? `${formatUsdCost(report.totalCostUsd)}${report.totalIsEstimated ? ' est.' : ''}${report.hasUnknownCost ? ' *' : ''}`
       : '—'
   const tokenDetail =
     report.inputTokens !== undefined || report.outputTokens !== undefined
       ? `${formatTokenCount(report.inputTokens ?? 0)} in · ${formatTokenCount(report.outputTokens ?? 0)} out` +
         (report.turns !== undefined ? ` · ${report.turns} turns` : '')
-      : '—'
+      : report.totalTokens !== undefined
+        ? `${formatTokenCount(report.totalTokens)} total${report.totalIsEstimated ? ' est.' : ''}`
+        : '—'
 
   return (
     <Popup
       title="cost"
       status={
         report.totalCostUsd !== undefined
-          ? `session ${formatUsdCost(report.totalCostUsd)}`
+          ? `session ${formatUsdCost(report.totalCostUsd)}${report.totalIsEstimated ? ' est.' : ''}`
           : 'cost tracking unavailable'
       }
       minHeight={18}

--- a/runtime/tests/commands/cost.test.ts
+++ b/runtime/tests/commands/cost.test.ts
@@ -171,12 +171,32 @@ describe("/cost", () => {
     expect(formatCostReport(report)).toMatch(/warming up · worker: — · —/);
   });
 
-  it("degrades gracefully when no cost sidecar is wired", () => {
+  it("degrades gracefully when no cost sidecar AND no agents", () => {
     const report = buildCostReport(contextWith({}));
     expect(report.totalCostUsd).toBeUndefined();
+    expect(report.totalIsEstimated).toBeUndefined();
     expect(formatCostReport(report)).toContain(
       "Session cost: — (cost tracking unavailable)",
     );
+  });
+
+  it("falls back to an ESTIMATED session total from agents when the sidecar reports none", () => {
+    // The local-model case: no cost sidecar, but spawned agents carry real
+    // token counts. The session line must answer "how much is this costing"
+    // with an explicit estimate, not a useless "—".
+    const report = buildCostReport(contextWith({ appState: AGENT_APP_STATE }));
+    // worker agent has 40K tokens (opus) -> a positive estimate; main-session skipped.
+    expect(report.agents).toHaveLength(1);
+    const agentEstimate = report.agents[0]!.estimatedCostUsd;
+    expect(agentEstimate).toBeGreaterThan(0);
+    expect(report.totalCostUsd).toBeCloseTo(agentEstimate!, 6);
+    expect(report.totalIsEstimated).toBe(true);
+    expect(report.totalTokens).toBe(40_000);
+
+    const out = formatCostReport(report);
+    expect(out).toContain("est. (from agent tokens)");
+    expect(out).not.toContain("cost tracking unavailable");
+    expect(out).toContain("40.0K total est.");
   });
 
   it("opens the cost modal when the interactive TUI surface is available", async () => {


### PR DESCRIPTION
**Multi-agent UX loop — iteration 5 (D7 cost transparency).**

Found by a live 5-agent fan-out drive (S11): the `/cost` panel showed **SESSION `—` + "cost tracking unavailable"** on the local model (no cost sidecar) even though every per-agent row had real token counts + estimated $ (138K/220K/330K/120K tokens). So "how much is this costing" went unanswered exactly when the fan-out cost was largest.

**Fix:** when the sidecar reports no real session total, fall back to an **estimated** session total aggregated from the per-agent estimates (+ total tokens), marked **`est.`** everywhere so an estimate is never shown as measured. Real-sidecar path untouched.

Revert-sensitive test added (fails against pre-fix code). Gate: build + tsc(0) + full test:unit (13,568 passed).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG