### PR TITLE
fix(tui): label spawned agents by task_name, not their full prompt (D1b/D10)

### DIFF
--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -142,6 +142,26 @@ function normalizeSpawnTaskName(value: string | undefined): string | undefined {
   return normalized.length > 0 ? normalized : trimmed;
 }
 
+/**
+ * The short, human-readable title shown for a spawned agent on the rail /
+ * transcript / `/cost` (the task's `description`). Derived from the validated
+ * `task_name` (separators humanized) — NEVER the full prompt, which floods the
+ * rail with the agent's entire instruction block. Falls back to the first line
+ * of the prompt only when no task name is available, always length-bounded.
+ */
+export function shortAgentTaskTitle(
+  taskName: string | undefined,
+  prompt: string,
+): string {
+  const fromName = taskName?.trim().replace(/[_-]+/gu, " ").trim();
+  const base =
+    fromName && fromName.length > 0
+      ? fromName
+      : (prompt.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ??
+        prompt.trim());
+  return base.length > 60 ? `${base.slice(0, 59).trimEnd()}…` : base;
+}
+
 function serviceTierIds(modelInfo: ModelInfo): readonly string[] {
   return (modelInfo.serviceTiers ?? []).map((tier) => tier.id);
 }
@@ -656,7 +676,11 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
     try {
       registerAgentThreadTask(backgroundTaskLifecycle, thread, {
         toolUseId: callId,
-        description: prompt,
+        // Short title (from task_name), not the full prompt — the rail /
+        // transcript / `/cost` show this as the agent's label. The full prompt
+        // is preserved separately on the task's `prompt` field.
+        description: shortAgentTaskTitle(taskName, prompt),
+        prompt,
         onSnapshot: (snapshot) => {
           syncBackgroundTaskSnapshotToAppState(
             (

--- a/runtime/src/tasks/agent-thread.ts
+++ b/runtime/src/tasks/agent-thread.ts
@@ -100,7 +100,13 @@ export interface AgentThreadTaskHandle {
 
 export interface RegisterAgentThreadTaskOptions {
   readonly toolUseId?: string;
+  /** Short display label (rail/transcript/cost). Defaults to the task prompt. */
   readonly description?: string;
+  /**
+   * The agent's full task prompt, preserved on the mirrored task's `prompt`
+   * field independently of {@link description}. Defaults to `thread.taskPrompt`.
+   */
+  readonly prompt?: string;
   readonly onStop?: (thread: AgentThreadTaskHandle, reason: string) => Promise<void> | void;
   readonly onSnapshot?: (snapshot: BackgroundTaskSnapshot) => void;
   /**
@@ -127,6 +133,10 @@ export function registerAgentThreadTask(
 ): BackgroundTaskSnapshot {
   const threadId = thread.threadId ?? thread.live.agentId;
   const description = opts.description ?? thread.taskPrompt;
+  // The full task prompt, carried separately from `description` so a short
+  // display label (e.g. the humanized task_name) never erases the agent's
+  // actual instruction in the mirrored AppState task's `prompt` field.
+  const taskPromptFull = opts.prompt ?? thread.taskPrompt;
   const agentPath = thread.agentPath ?? thread.live.agentPath;
   let summaryHandle: AgentSummaryHandle | null = null;
   let unsubscribeSummaryCacheSafeParams: (() => void) | null = null;
@@ -174,6 +184,7 @@ export function registerAgentThreadTask(
       : {}),
     metadata: {
       threadName: thread.threadName ?? thread.nickname ?? thread.threadId,
+      ...(taskPromptFull !== undefined ? { taskPrompt: taskPromptFull } : {}),
       ...(agentPath !== undefined ? { agentPath } : {}),
       ...(thread.worktreePath !== undefined
         ? { worktreePath: thread.worktreePath }

--- a/runtime/src/tasks/app-state-bridge.ts
+++ b/runtime/src/tasks/app-state-bridge.ts
@@ -74,7 +74,7 @@ function localAgentTaskFromSnapshot(
     outputOffset: snapshot.outputOffset,
     notified: snapshot.notified,
     agentId: snapshot.id,
-    prompt: snapshot.description,
+    prompt: stringMetadata(snapshot.metadata, "taskPrompt") ?? snapshot.description,
     agentType: agentRole ?? previousAgent?.agentType ?? "agent",
     ...(cwd !== undefined ? { cwd } : {}),
     ...(worktreePath !== undefined ? { worktreePath } : {}),

--- a/runtime/tests/agents/v2/spawn-task-title.test.ts
+++ b/runtime/tests/agents/v2/spawn-task-title.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { shortAgentTaskTitle } from "../../../src/agents/v2/spawn.js";
+
+// Multi-agent UX loop iter 6 (D1b/D10 legibility). A live 5-agent fan-out drive
+// showed each rail/transcript row labelled with the agent's ENTIRE prompt block
+// ("You are responsible for generating a microservice stub for the 'billing'
+// service under the src/ directory. Your task: 1. ..."). The spawned task's
+// `description` must be a short title derived from task_name, not the prompt.
+
+const PROMPT =
+  "You are responsible for generating a microservice stub for the " +
+  "\"billing\" service under the src/ directory. Your task: 1. Create the " +
+  "folder src/billing/. 2. Write index.ts, README.md, and a smoke test.";
+
+describe("shortAgentTaskTitle", () => {
+  it("uses the task_name (humanized), never the full prompt", () => {
+    const title = shortAgentTaskTitle("billing_microservice", PROMPT);
+    expect(title).toBe("billing microservice");
+    // the regression we are fixing: the title must NOT be the prompt block.
+    expect(title).not.toBe(PROMPT);
+    expect(title.length).toBeLessThan(PROMPT.length);
+  });
+
+  it("humanizes underscores and dashes from the task name", () => {
+    expect(shortAgentTaskTitle("auth-gateway_v2", PROMPT)).toBe("auth gateway v2");
+  });
+
+  it("falls back to the first non-empty prompt line when no task name", () => {
+    expect(shortAgentTaskTitle(undefined, "\n  Build the parser.\nmore detail")).toBe(
+      "Build the parser.",
+    );
+    expect(shortAgentTaskTitle("   ", "Fix the off-by-one bug")).toBe(
+      "Fix the off-by-one bug",
+    );
+  });
+
+  it("bounds the length (rail rows must not overflow)", () => {
+    const long = "a".repeat(200);
+    const title = shortAgentTaskTitle(long, PROMPT);
+    expect(title.length).toBeLessThanOrEqual(60);
+    expect(title.endsWith("…")).toBe(true);
+  });
+});

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -2719,7 +2719,9 @@ describe("model-facing tools", () => {
       id: "thread-visible-1",
       type: "local_agent",
       status: "running",
-      description: "inspect visible task",
+      // description is the short humanized task_name (rail/transcript label),
+      // not the full prompt; the prompt is preserved separately.
+      description: "visible task",
       agentId: "thread-visible-1",
       prompt: "inspect visible task",
       isBackgrounded: true,
@@ -2875,7 +2877,7 @@ describe("model-facing tools", () => {
     });
     expect(stopped.isError).toBeUndefined();
     expect(stopped.content).toBe(
-      "Successfully stopped task: thread-handle-1 (inspect handle)",
+      "Successfully stopped task: thread-handle-1 (task handle)",
     );
     expect(abortController.signal.aborted).toBe(true);
   });


### PR DESCRIPTION
**Multi-agent UX loop — iteration 6 (D1b/D10 legibility).**

A live 5-agent fan-out drive showed every rail/transcript/`/cost` row labelled with the agent's **entire prompt block** ("You are responsible for generating a microservice stub for the 'billing'…") instead of a title — `spawn.ts` registered the task with `description = prompt`.

**Fix:** register a short humanized title from `task_name` (`shortAgentTaskTitle` → `billing microservice`). This surfaced a latent conflation — the task's `prompt` field derived from the same `description`, so shortening it erased the agent's instruction. The full prompt is now carried separately (`registerAgentThreadTask` `prompt` opt → snapshot `metadata.taskPrompt` → mirror `task.prompt`), so **description = short label, prompt = full**.

Helper unit-tested; the AppState-mirror integration tests updated to assert the split (now revert-sensitive to the spawn change). Gate: build + tsc(0) + full test:unit (13,572 passed).

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG