### PR TITLE
fix(tui): suppress stale blits over the scrolled viewport (scroll ghost)

### DIFF
--- a/runtime/src/tui/ink/render-node-to-output.ts
+++ b/runtime/src/tui/ink/render-node-to-output.ts
@@ -1170,12 +1170,22 @@ function renderNodeToOutput(
             // bandwidth crosses the chunk boundary and the frame tears.
             const scrolled = contentCached && contentCached.y !== contentY
             if (scrolled && y1 !== undefined && y2 !== undefined) {
-              output.clear({
-                x: Math.floor(x),
-                y: Math.floor(y1),
-                width: Math.floor(width),
-                height: Math.floor(y2 - y1),
-              })
+              // fromAbsolute=true: this scrolled viewport is VACATED — its
+              // prevScreen cells are the pre-scroll content. Mark it like an
+              // absolute clear so a clean-subtree blit from an ancestor/sibling
+              // whose cached rect overlaps these rows can't re-paint that stale
+              // content back (damage-only clear + identical blit = diff sees no
+              // change = ghost glyphs that survive scrolling). The scrollbox's
+              // own children don't blit here (prevScreen is undefined below).
+              output.clear(
+                {
+                  x: Math.floor(x),
+                  y: Math.floor(y1),
+                  width: Math.floor(width),
+                  height: Math.floor(y2 - y1),
+                },
+                true,
+              )
             }
             // positionChanged (ScrollBox height shrunk — pill mount) means a
             // child spanning the old bottom edge would blit its full cached


### PR DESCRIPTION
**Scroll ghost characters.** Root cause (deep render-trace + deterministic unit repro): a `clear` is *damage-only* (marks a vacated region dirty but writes no spaces, trusting `resetScreen` zeroed the buffer); a clean-subtree **blit** then copies that region's prevScreen cells back in, so the blitted cell equals prevScreen and the diff erases nothing → old glyph survives. The `fromAbsolute` guard already suppresses this for absolute clears, but the **full-repaint scroll path's viewport clear** (sub-width workbench transcript, `canShiftFullRows=false`) wasn't marked.

**Fix:** mark that one scroll-viewport clear `fromAbsolute=true` so overlapping stale blits are suppressed. Surgical — only the full-repaint scroll path; not the DECSTBM fast-path / overlay / dialog blits. Reuses the existing (tested) absolute-clear suppression.

**Honesty:** gate green (build + tsc + **full test:unit 13,572 passed**, no regression). But the end-to-end visual ghost is **terminal-specific** — an A/B drive under tmux rendered clean both with and without the fix, so this is mechanism-grounded **pending visual confirmation in a real terminal**. At worst a harmless no-op; trivially revertible.

https://claude.ai/code/session_017SNQuFu6Ca1GHHHiiUXwyG