### PR TITLE
feat(app-server): session.transcript — read a session's conversation history (history-on-join)

### DIFF
--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -45,6 +45,8 @@ import type {
   SessionMcpServerMutationResult,
   SessionSnapshotParams,
   SessionSnapshotResult,
+  SessionTranscriptParams,
+  SessionTranscriptResult,
   SessionPartialCompactFromMessageParams,
   SessionPartialCompactFromMessageResult,
   SessionRewindConversationToMessageParams,
@@ -1466,6 +1468,30 @@ export class AgenCDaemonAgentManager {
       { allowSnapshot: true },
     );
     return this.#runner.snapshotAgentSession(agentId, {
+      sessionId: params.sessionId,
+    });
+  }
+
+  async getSessionTranscript(
+    params: SessionTranscriptParams,
+  ): Promise<SessionTranscriptResult> {
+    if (this.#sessionManager === undefined) {
+      throw new AgenCDaemonAgentLifecycleError(
+        "INVALID_ARGUMENT",
+        "session.transcript requires a daemon session manager",
+      );
+    }
+    if (this.#runner?.getAgentSessionTranscript === undefined) {
+      throw new AgenCDaemonAgentLifecycleError(
+        "BACKGROUND_RUNNER_UNAVAILABLE",
+        "session.transcript requires a background runner",
+      );
+    }
+    const agentId = await this.#resolveActiveAgentIdForSession(
+      params.sessionId,
+      { allowSnapshot: true },
+    );
+    return this.#runner.getAgentSessionTranscript(agentId, {
       sessionId: params.sessionId,
     });
   }

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -99,6 +99,7 @@ import type {
   SessionPartialCompactFromMessageResult,
   SessionRewindConversationToMessageResult,
   SessionSnapshotResult,
+  SessionTranscriptResult,
   SessionHookConfigShape,
   SessionHookValidationIssueShape,
   SessionHookRunDiagnosticShape,
@@ -325,6 +326,10 @@ export interface AgenCBackgroundAgentRunner {
     agentId: string,
     params: AgenCBackgroundAgentSnapshotSessionParams,
   ): Promise<SessionSnapshotResult>;
+  getAgentSessionTranscript?(
+    agentId: string,
+    params: { readonly sessionId: string },
+  ): Promise<SessionTranscriptResult>;
   addMcpServer?(
     agentId: string,
     params: AgenCBackgroundAgentMcpAddServerParams,
@@ -1267,6 +1272,46 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       },
       cacheStats: cache,
     };
+  }
+
+  async getAgentSessionTranscript(
+    agentId: string,
+    params: { readonly sessionId: string },
+  ): Promise<SessionTranscriptResult> {
+    const active = this.#active.get(agentId);
+    if (active === undefined || !isRunnableActiveAgent(active)) {
+      throw new Error(`AgenC daemon agent not running: ${agentId}`);
+    }
+    // The session's conversation history (ResponseItem[]: { role, content }). content is a string or
+    // an array of blocks; we surface user/assistant text so a joining client can render the transcript.
+    const state = active.bootstrap.session.state?.unsafePeek?.();
+    const history = Array.isArray(
+      (state as { history?: unknown[] } | undefined)?.history,
+    )
+      ? ((state as { history: unknown[] }).history as unknown[])
+      : [];
+    const messages: { role: string; text: string }[] = [];
+    for (const raw of history) {
+      const item = raw as { role?: string; content?: unknown };
+      if (item.role !== "user" && item.role !== "assistant") continue;
+      let text = "";
+      if (typeof item.content === "string") {
+        text = item.content;
+      } else if (Array.isArray(item.content)) {
+        text = item.content
+          .map((b) =>
+            b &&
+            typeof b === "object" &&
+            typeof (b as { text?: unknown }).text === "string"
+              ? (b as { text: string }).text
+              : "",
+          )
+          .filter((s) => s.length > 0)
+          .join("");
+      }
+      if (text.length > 0) messages.push({ role: item.role, text });
+    }
+    return { sessionId: params.sessionId, messages };
   }
 
   // Read the global session-level cache stats tracker (lives in the

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -78,6 +78,7 @@ import {
   type SessionMcpAddServerParams,
   type SessionMcpServerByNameParams,
   type SessionSnapshotParams,
+  type SessionTranscriptParams,
   type SessionCreateParams,
   type SessionDetachParams,
   type SessionListParams,
@@ -168,6 +169,7 @@ function buildServerCapabilities(
     "session.terminate": hasMethod(sessionManager, "terminateSession"),
     "session.clear": hasMethod(agentManager, "clearSessionHistory"),
     "session.snapshot": hasMethod(agentManager, "snapshotSession"),
+    "session.transcript": hasMethod(agentManager, "getSessionTranscript"),
     "session.cancelTurn": hasMethod(agentManager, "cancelSessionTurn"),
     "session.mcp.addServer": hasMethod(agentManager, "addMcpServerToSession"),
     "message.send": hasMethod(agentManager, "streamAgentMessage"),
@@ -264,6 +266,7 @@ export interface AgenCDaemonDispatcherOptions {
     | "denyTool"
     | "clearSessionHistory"
     | "snapshotSession"
+    | "getSessionTranscript"
     | "addMcpServerToSession"
     | "reconnectMcpServerOnSession"
     | "enableMcpServerOnSession"
@@ -335,6 +338,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     | "denyTool"
     | "clearSessionHistory"
     | "snapshotSession"
+    | "getSessionTranscript"
     | "addMcpServerToSession"
     | "reconnectMcpServerOnSession"
     | "enableMcpServerOnSession"
@@ -621,6 +625,13 @@ export class AgenCDaemonJsonRpcDispatcher {
           id,
           await this.#agentManager.snapshotSession(
             validateSessionSnapshotParams(params),
+          ),
+        );
+      case "session.transcript":
+        return successResponse(
+          id,
+          await this.#agentManager.getSessionTranscript(
+            validateSessionTranscriptParams(params),
           ),
         );
       case "session.cancelTurn":
@@ -1571,6 +1582,17 @@ function validateSessionSnapshotParams(
   });
   validateRequiredString(validated, "session.snapshot", "sessionId");
   return validated as SessionSnapshotParams;
+}
+
+function validateSessionTranscriptParams(
+  params: JsonObject,
+): SessionTranscriptParams {
+  const validated = validateObjectShape(params, {
+    methodName: "session.transcript",
+    stringFields: ["sessionId"],
+  });
+  validateRequiredString(validated, "session.transcript", "sessionId");
+  return validated as SessionTranscriptParams;
 }
 
 function validateSessionCancelTurnParams(

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -51,6 +51,7 @@ export const AGENC_DAEMON_METHODS = [
   "session.terminate",
   "session.clear",
   "session.snapshot",
+  "session.transcript",
   "session.cancelTurn",
   "session.mcp.addServer",
   "message.send",
@@ -283,6 +284,14 @@ export const AGENC_DAEMON_METHOD_SPECS = defineMethodSpecs({
     result: "object",
     description:
       "Read live counters (turn count, token usage, cache stats) for a daemon-owned session so the TUI's /status, /usage, /cache-stats can surface real numbers.",
+  },
+  "session.transcript": {
+    method: "session.transcript",
+    direction: "client-to-server",
+    params: "required",
+    result: "object",
+    description:
+      "Read a daemon-owned session's conversation history (user/assistant messages) so a client joining an existing session (e.g. one started in another client) can render the prior transcript.",
   },
   "session.cancelTurn": {
     method: "session.cancelTurn",
@@ -1360,6 +1369,7 @@ export type AgenCDaemonRequest =
   | AgenCDaemonRequestWithParams<"session.terminate", SessionTerminateParams>
   | AgenCDaemonRequestWithParams<"session.clear", SessionClearParams>
   | AgenCDaemonRequestWithParams<"session.snapshot", SessionSnapshotParams>
+  | AgenCDaemonRequestWithParams<"session.transcript", SessionTranscriptParams>
   | AgenCDaemonRequestWithParams<"session.cancelTurn", SessionCancelTurnParams>
   | AgenCDaemonRequestWithParams<"session.mcp.addServer", SessionMcpAddServerParams>
   | AgenCDaemonRequestWithParams<"message.send", MessageSendParams>
@@ -1570,6 +1580,20 @@ export interface SessionSnapshotResult extends JsonObject {
     readonly cacheTotalInputTokens: number;
     readonly hitRate: number | null;
   };
+}
+
+export interface SessionTranscriptParams extends JsonObject {
+  readonly sessionId: string;
+}
+
+export interface SessionTranscriptMessage extends JsonObject {
+  readonly role: string; // "user" | "assistant"
+  readonly text: string;
+}
+
+export interface SessionTranscriptResult extends JsonObject {
+  readonly sessionId: string;
+  readonly messages: readonly SessionTranscriptMessage[];
 }
 
 export interface SessionCancelTurnResult extends JsonObject {
@@ -1808,6 +1832,7 @@ export interface AgenCDaemonResultByMethod {
   readonly "session.terminate": SessionTerminateResult;
   readonly "session.clear": SessionClearResult;
   readonly "session.snapshot": SessionSnapshotResult;
+  readonly "session.transcript": SessionTranscriptResult;
   readonly "session.cancelTurn": SessionCancelTurnResult;
   readonly "session.mcp.addServer": SessionMcpAddServerResult;
   readonly "message.send": MessageSendResult;


### PR DESCRIPTION
## Summary

Adds a daemon method `session.transcript { sessionId } -> { messages: [{role, text}] }` so a client that **joins an existing session** can render its prior conversation.

Today a *second* client attaching to a live session gets nothing: the client-multiplexer's replay buffer is a one-shot hand-off drained by the first attacher, and `session.snapshot` returns only metrics (turn count / tokens / cache). So e.g. the iOS app joining a session started by `agenc` in a terminal shows an empty chat.

## Implementation (mirrors `session.snapshot`)

- **`background-agent-runner.ts`** — `getAgentSessionTranscript(agentId, {sessionId})` reads the live session's `state.history` (`ResponseItem[]`: `{role, content}`, where content is a string or text blocks) and surfaces user/assistant text as `{role, text}`.
- **`agent-lifecycle.ts`** — `agentManager.getSessionTranscript` resolves the agentId via `#resolveActiveAgentIdForSession` and delegates to the runner.
- **`daemon-dispatcher.ts`** — capability flag (`hasMethod(agentManager, "getSessionTranscript")`), the dispatch case, and `validateSessionTranscriptParams`.
- **`protocol/index.ts`** — `SessionTranscriptParams` / `SessionTranscriptResult` + method-name list, descriptor, request union, and result-by-method entries.

## Verification

Built clean (`npm run build`). Live, on a completed turn:
```
session.transcript -> 2 messages
  [user] List exactly 3 common git commands, one per line, nothing else.
  [assistant] git status / git commit / git push
```
And the iOS app (tetsuo-ai/agenc-ios) now renders a joined terminal session's full history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
