### PR TITLE
fix(runtime): sync daemon permission mode changes

### DIFF
--- a/runtime/src/app-server/protocol/schema.json
+++ b/runtime/src/app-server/protocol/schema.json
@@ -22,6 +22,7 @@
     "session.terminate",
     "session.clear",
     "session.snapshot",
+    "session.transcript",
     "session.cancelTurn",
     "session.mcp.addServer",
     "message.send",
@@ -393,6 +394,17 @@
       "required": ["sessionId"]
     },
     "SessionSnapshotParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["sessionId"]
+    },
+    "SessionTranscriptParams": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -1621,6 +1633,9 @@
           "$ref": "#/definitions/SessionSnapshotRequest"
         },
         {
+          "$ref": "#/definitions/SessionTranscriptRequest"
+        },
+        {
           "$ref": "#/definitions/SessionCancelTurnRequest"
         },
         {
@@ -2270,6 +2285,25 @@
         },
         "params": {
           "$ref": "#/definitions/SessionSnapshotParams"
+        }
+      },
+      "required": ["jsonrpc", "id", "method", "params"]
+    },
+    "SessionTranscriptRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0"
+        },
+        "id": {
+          "$ref": "#/definitions/RequestId"
+        },
+        "method": {
+          "const": "session.transcript"
+        },
+        "params": {
+          "$ref": "#/definitions/SessionTranscriptParams"
         }
       },
       "required": ["jsonrpc", "id", "method", "params"]

--- a/runtime/src/commands/plan.ts
+++ b/runtime/src/commands/plan.ts
@@ -206,15 +206,17 @@ export const planCommand: SlashCommand = {
         };
         // Daemon-backed TUI: the local `registry` is a client-side shim the
         // daemon's tool evaluator never reads. Route the plan-mode switch to
-        // the daemon's REAL registry via session.setPermissionMode so the
-        // mode actually gates tool use. Best-effort: a failure leaves the
-        // local registry updated so the chrome still reflects plan mode.
+        // the daemon's REAL registry via session.setPermissionMode first; if
+        // the RPC fails, do not let the local chrome claim plan mode.
         const daemonSetMode = daemonPermissionModeFn(ctx);
         if (daemonSetMode !== null) {
           try {
             await daemonSetMode("plan");
-          } catch {
-            // best-effort; fall through to local update + warning.
+          } catch (err) {
+            return {
+              kind: "error",
+              message: err instanceof Error ? err.message : String(err),
+            };
           }
         }
         await registry.update(nextCtx);

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1029,61 +1029,77 @@ function initialState(props: AgenCTuiProps): any {
     }
   };
 }
-function useSyncedPermissionContext(session) {
-  const $ = _c(12);
-  const toolPermissionContext = useAppState(_temp2);
+
+type SetToolPermissionContext = (next: ToolPermissionContext) => void;
+
+function daemonPermissionModeFn(
+  session: AgenCTuiProps["session"],
+): ((mode: ToolPermissionContext["mode"]) => Promise<unknown>) | null {
+  const fn = session.setDaemonPermissionMode;
+  return typeof fn === "function" ? fn.bind(session) : null;
+}
+
+function emitPermissionModeSyncWarning(
+  session: AgenCTuiProps["session"],
+  mode: ToolPermissionContext["mode"],
+  err: unknown,
+): void {
+  if (typeof session.emit !== "function" || typeof session.nextInternalSubId !== "function") {
+    return;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  session.emit({
+    id: session.nextInternalSubId(),
+    msg: {
+      type: "warning",
+      payload: {
+        cause: "permission_mode_sync_failed",
+        message: `Failed to change daemon permission mode to ${mode}: ${message}`,
+      },
+    },
+  });
+}
+
+function useSyncedPermissionContext(
+  session: AgenCTuiProps["session"],
+): readonly [ToolPermissionContext, SetToolPermissionContext] {
+  const toolPermissionContext = useAppState(_temp2) as ToolPermissionContext;
   const setAppState = useSetAppState();
-  let t0;
-  if ($[0] !== session.services.permissionModeRegistry || $[1] !== setAppState) {
-    t0 = () => session.services.permissionModeRegistry.subscribeToModeChange?.(() => {
+  useEffect(() => {
+    return session.services.permissionModeRegistry.subscribeToModeChange?.(() => {
       const next = session.services.permissionModeRegistry.current();
       setAppState(prev => ({
         ...prev,
         toolPermissionContext: next
       }));
     });
-    $[0] = session.services.permissionModeRegistry;
-    $[1] = setAppState;
-    $[2] = t0;
-  } else {
-    t0 = $[2];
-  }
-  let t1;
-  if ($[3] !== session || $[4] !== setAppState) {
-    t1 = [session, setAppState];
-    $[3] = session;
-    $[4] = setAppState;
-    $[5] = t1;
-  } else {
-    t1 = $[5];
-  }
-  useEffect(t0, t1);
-  let t2;
-  if ($[6] !== session.services.permissionModeRegistry || $[7] !== setAppState) {
-    t2 = next_0 => {
-      setAppState(prev_0 => ({
-        ...prev_0,
-        toolPermissionContext: next_0
+  }, [session, setAppState]);
+  const setToolPermissionContext = useCallback((next: ToolPermissionContext) => {
+    const registry = session.services.permissionModeRegistry;
+    const daemonSetMode = daemonPermissionModeFn(session);
+    const applyLocal = async (): Promise<void> => {
+      setAppState(prev => ({
+        ...prev,
+        toolPermissionContext: next
       }));
-      Promise.resolve(session.services.permissionModeRegistry.update?.(next_0)).catch(_temp3);
+      await registry.update?.(next);
     };
-    $[6] = session.services.permissionModeRegistry;
-    $[7] = setAppState;
-    $[8] = t2;
-  } else {
-    t2 = $[8];
-  }
-  const setToolPermissionContext = t2;
-  let t3;
-  if ($[9] !== setToolPermissionContext || $[10] !== toolPermissionContext) {
-    t3 = [toolPermissionContext, setToolPermissionContext];
-    $[9] = setToolPermissionContext;
-    $[10] = toolPermissionContext;
-    $[11] = t3;
-  } else {
-    t3 = $[11];
-  }
-  return t3 as const;
+    if (daemonSetMode === null || next.mode === registry.current().mode) {
+      void applyLocal().catch(_temp3);
+      return;
+    }
+    const previous = registry.current();
+    void daemonSetMode(next.mode)
+      .then(() => applyLocal())
+      .catch(err => {
+        setAppState(prev => ({
+          ...prev,
+          toolPermissionContext: previous
+        }));
+        emitPermissionModeSyncWarning(session, next.mode, err);
+      });
+  }, [session, setAppState]);
+  return [toolPermissionContext, setToolPermissionContext] as const;
 }
 function _temp3() {}
 function _temp2(s) {

--- a/runtime/src/tui/session-types.ts
+++ b/runtime/src/tui/session-types.ts
@@ -154,6 +154,7 @@ export interface AgenCBridgeSession extends AgenCCompactProgressControls {
     event: Event | { readonly kind: string; readonly [key: string]: unknown },
   ): void;
   nextInternalSubId?(): string;
+  setDaemonPermissionMode?(mode: ToolPermissionContext["mode"]): Promise<unknown>;
   readonly sessionConfiguration?: {
     readonly cwd?: string;
     readonly collaborationMode?: { readonly model?: string };

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -73,6 +73,7 @@ const expectedMethods = [
   "session.terminate",
   "session.clear",
   "session.snapshot",
+  "session.transcript",
   "session.cancelTurn",
   "session.mcp.addServer",
   "message.send",

--- a/runtime/tests/commands/plan.test.ts
+++ b/runtime/tests/commands/plan.test.ts
@@ -38,6 +38,7 @@ function mkHarness(opts: {
   readonly argsRaw?: string;
   readonly withoutRegistry?: boolean;
   readonly appState?: SlashCommandContext["appState"];
+  readonly setDaemonPermissionMode?: (mode: string) => Promise<unknown>;
 } = {}): Harness {
   const cwd = opts.cwd ?? mkdtempSync(join(tmpdir(), "agenc-plan-cwd-"));
   const agencHome = mkdtempSync(join(tmpdir(), "agenc-plan-home-"));
@@ -60,6 +61,9 @@ function mkHarness(opts: {
     emit: (event: Event) => {
       events.push(event);
     },
+    ...(opts.setDaemonPermissionMode !== undefined
+      ? { setDaemonPermissionMode: opts.setDaemonPermissionMode }
+      : {}),
   } as unknown as Session;
 
   const ctx: SlashCommandContext = {
@@ -199,6 +203,32 @@ describe("planCommand.execute", () => {
     if (warn && warn.msg.type === "warning") {
       expect(warn.msg.payload.cause).toBe("mode_changed_to_plan");
     }
+  });
+
+  it("does not update the local shim when daemon plan-mode transition fails", async () => {
+    const setDaemonPermissionMode = vi.fn(async () => {
+      throw new Error("daemon refused plan");
+    });
+    const h = mkHarness({
+      initialMode: "default",
+      setDaemonPermissionMode,
+    });
+
+    const res = await planCommand.execute(h.ctx);
+
+    expect(setDaemonPermissionMode).toHaveBeenCalledWith("plan");
+    expect(res.kind).toBe("error");
+    if (res.kind !== "error") throw new Error("expected error");
+    expect(res.message).toContain("daemon refused plan");
+    expect(h.registry.current().mode).toBe("default");
+    expect(h.events).not.toContainEqual(
+      expect.objectContaining({
+        msg: expect.objectContaining({
+          type: "warning",
+          payload: expect.objectContaining({ cause: "mode_changed_to_plan" }),
+        }),
+      }),
+    );
   });
 
   it("transitions default -> plan and opens v2 dashboard when TUI app state is wired", async () => {

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -543,6 +543,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       setPastedContents,
       mode,
       onModeChange,
+      setToolPermissionContext,
     }: {
       input: string;
       onSubmit: (input: string, helpers: {
@@ -566,6 +567,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       setPastedContents?: unknown;
       mode?: unknown;
       onModeChange?: unknown;
+      setToolPermissionContext?: unknown;
     }) => {
       providerProbe.promptSubmits.push(onSubmit);
       providerProbe.promptProps.push({
@@ -587,6 +589,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
         setPastedContents,
         mode,
         onModeChange,
+        setToolPermissionContext,
       });
       return React.createElement("ink-text", null, `prompt:${input}`);
     },
@@ -748,13 +751,23 @@ async function withRenderedApp(
   }
 }
 
-function createSession(): AgenCBridgeSession {
+function createSession(opts: {
+  readonly permissionContext?: ToolPermissionContext;
+  readonly updatePermissionContext?: (next: ToolPermissionContext) => Promise<void> | void;
+  readonly setDaemonPermissionMode?: (mode: ToolPermissionContext["mode"]) => Promise<unknown>;
+  readonly emit?: AgenCBridgeSession["emit"];
+  readonly nextInternalSubId?: AgenCBridgeSession["nextInternalSubId"];
+} = {}): AgenCBridgeSession {
   const modeSubscribers: Array<() => void> = [];
+  const permissionContext = opts.permissionContext ?? PERMISSION_CONTEXT;
   return {
     conversationId: "conversation-app-smoke",
     services: {
       permissionModeRegistry: {
-        current: () => PERMISSION_CONTEXT,
+        current: () => permissionContext,
+        ...(opts.updatePermissionContext !== undefined
+          ? { update: opts.updatePermissionContext }
+          : {}),
         subscribeToModeChange: (cb) => {
           modeSubscribers.push(cb);
           return () => {
@@ -764,6 +777,13 @@ function createSession(): AgenCBridgeSession {
         },
       },
     },
+    ...(opts.setDaemonPermissionMode !== undefined
+      ? { setDaemonPermissionMode: opts.setDaemonPermissionMode }
+      : {}),
+    ...(opts.emit !== undefined ? { emit: opts.emit } : {}),
+    ...(opts.nextInternalSubId !== undefined
+      ? { nextInternalSubId: opts.nextInternalSubId }
+      : {}),
     eventLog: {
       subscribe: () => () => {},
     },
@@ -1176,6 +1196,92 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         input: "draft",
         vimMode: "INSERT",
         setVimMode: expect.any(Function),
+      }),
+    );
+  });
+
+  test("syncs PromptInput permission mode changes through the daemon before the local shim", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    const calls: string[] = [];
+    const modeContext = {
+      ...PERMISSION_CONTEXT,
+      mode: "plan" as const,
+    };
+    const setDaemonPermissionMode = vi.fn(async (mode: ToolPermissionContext["mode"]) => {
+      calls.push(`daemon:${mode}`);
+      return { applied: true, previousMode: "default", mode };
+    });
+    const updatePermissionContext = vi.fn(async (next: ToolPermissionContext) => {
+      calls.push(`local:${next.mode}`);
+    });
+    providerProbe.promptProps.length = 0;
+
+    await withRenderedApp(
+      <AgenCTuiApp
+        session={createSession({
+          updatePermissionContext,
+          setDaemonPermissionMode,
+        })}
+        configStore={{}}
+        isInteractive={false}
+      />,
+      async () => {
+        const promptProps = providerProbe.promptProps.at(-1)!;
+        (promptProps.setToolPermissionContext as (next: ToolPermissionContext) => void)(
+          modeContext,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      },
+    );
+
+    expect(setDaemonPermissionMode).toHaveBeenCalledWith("plan");
+    expect(updatePermissionContext).toHaveBeenCalledWith(modeContext);
+    expect(calls).toEqual(["daemon:plan", "local:plan"]);
+  });
+
+  test("rolls PromptInput permission mode changes back when daemon sync fails", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    const warningEvents: unknown[] = [];
+    const setDaemonPermissionMode = vi.fn(async () => {
+      throw new Error("daemon refused mode");
+    });
+    const updatePermissionContext = vi.fn();
+    providerProbe.promptProps.length = 0;
+
+    await withRenderedApp(
+      <AgenCTuiApp
+        session={createSession({
+          updatePermissionContext,
+          setDaemonPermissionMode,
+          emit: (event) => {
+            warningEvents.push(event);
+          },
+          nextInternalSubId: () => "permission-sync-warning",
+        })}
+        configStore={{}}
+        isInteractive={false}
+      />,
+      async () => {
+        const promptProps = providerProbe.promptProps.at(-1)!;
+        (promptProps.setToolPermissionContext as (next: ToolPermissionContext) => void)({
+          ...PERMISSION_CONTEXT,
+          mode: "plan",
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      },
+    );
+
+    expect(setDaemonPermissionMode).toHaveBeenCalledWith("plan");
+    expect(updatePermissionContext).not.toHaveBeenCalled();
+    expect(warningEvents).toContainEqual(
+      expect.objectContaining({
+        id: "permission-sync-warning",
+        msg: expect.objectContaining({
+          type: "warning",
+          payload: expect.objectContaining({
+            cause: "permission_mode_sync_failed",
+          }),
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Summary
- Route daemon-backed TUI permission mode changes through the daemon before mirroring to the local permission registry.
- Make /plan fail closed when daemon mode switching rejects, so the UI does not claim plan mode while daemon enforcement stays unchanged.
- Align the in-repo daemon protocol schema and contract list with the existing session.transcript method.

## Test plan
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/commands/plan.test.ts tests/commands/permissions.test.ts tests/tui/components/App.render.test.tsx tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/daemon-session.contract.test.ts --reporter=dot
- npm run test:bun
- npm run validate:runtime
- git diff --check

## Known remaining blockers
- npm test still fails on sibling checkout drift: agenc-protocol generated daemon schema and agenc-sdk daemon wrapper are missing session.transcript.
- npm run check:unused still fails with the same 13 unused exports observed before this change.