### PR TITLE
feat(runtime): complete capability gap follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ For the subsystem map and how the pieces fit together, see
   (bubblewrap/Landlock on Linux, Seatbelt on macOS) for shell execution.
 - **In-terminal workbench** — project explorer, code preview, and an editable
   `BUFFER` surface that prefers an embedded `nvim --embed`.
-- **Provider-neutral** — defaults to xAI (`grok-4.3`); also speaks the Anthropic
-  SDK, the OpenAI-compatible HTTP protocol, and local Ollama.
+- **Provider-neutral** — defaults to xAI (`grok-4.3`); also speaks native
+  Gemini, Amazon Bedrock, the Anthropic SDK, OpenAI-compatible HTTP, and local
+  Ollama.
 - **Durable sessions** — append-only rollout logs + SQLite state written
   atomically, with `--continue` / `--resume`.
 
@@ -78,8 +79,10 @@ licensed; see [`LICENSE`](LICENSE).
   pure-JS fallback; `agenc doctor` reports the status with a fix hint.
 - **A provider** before real model calls. The default is **xAI**
   (`XAI_API_KEY`, also accepts `GROK_API_KEY`); the default model is `grok-4.3`
-  (`AGENC_MODEL` overrides). Inspect setup with `agenc providers`,
-  `agenc login`, and `agenc config`.
+  (`AGENC_MODEL` overrides). Gemini accepts `GEMINI_API_KEY`,
+  `GOOGLE_API_KEY`, `GEMINI_ACCESS_TOKEN`, or Google ADC credentials; Vertex
+  Gemini can be selected with project/location settings. Inspect setup with
+  `agenc providers`, `agenc login`, and `agenc config`.
 
 ## Quick start
 
@@ -245,6 +248,9 @@ that home. Key knobs:
 | --- | --- |
 | `AGENC_HOME` | Root for all on-disk state (default `~/.agenc`). |
 | `XAI_API_KEY` / `GROK_API_KEY` | xAI credentials (default provider). |
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Gemini API-key credentials. |
+| `GEMINI_ACCESS_TOKEN` | Gemini bearer token credential; Google ADC is also supported. |
+| `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION` | Optional Vertex Gemini project/location inference. |
 | `AGENC_MODEL` | Override the default model (`grok-4.3`). |
 | `AGENC_LOCAL_VLLM_BASE_URL` | Local vLLM/OpenAI-compatible smoke endpoint (default `http://127.0.0.1:8000/v1`). |
 | `AGENC_LOCAL_VLLM_MODEL` | Optional model override for `npm run check:local-vllm`. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,5 +114,5 @@ and the daemon/persistence/permission cores are mature (WAL SQLite, atomic
 rollout writes, an AST-backed Bash permission layer, transactional file edits).
 The public launcher package is published, the repository has a top-level MIT
 license, and known pre-GA gaps are tracked separately: cross-platform runtime
-artifacts, observability wiring, release hardening, and deciding whether hosted
-CI is worth re-enabling.
+artifacts, release hardening, and deciding whether hosted CI is worth
+re-enabling.

--- a/docs/capability-gap-audit-2026-06-28.md
+++ b/docs/capability-gap-audit-2026-06-28.md
@@ -20,6 +20,17 @@ the advertised event-export surface rather than wiring it. AgenC keeps local
 diagnostics local; trajectory export is explicit opt-in to caller-selected
 JSONL files.
 
+**Follow-up completion note — 2026-06-29:** the current remediation branch also
+closes the verifier follow-ups found after the first merge: native Gemini now
+uses the shared Google credential resolver path (`GEMINI_API_KEY`,
+`GOOGLE_API_KEY`, `GEMINI_ACCESS_TOKEN`, or ADC), can infer Vertex Gemini
+endpoints from project/location settings, and preserves request-scoped
+`cachedContents` hints; MCP host sampling now routes `sampling/createMessage`
+through the session provider when a session owns the connection, with the old
+graceful unavailable response retained only for sessionless compatibility
+paths; daemon overload coverage now includes the token-bucket rate-limit branch.
+The original ranked findings below are retained as audit context.
+
 ---
 
 ## Bottom line
@@ -164,7 +175,7 @@ that returned nothing; this branch resolves that by deleting the advertised expo
 1. **Gemini native provider** (#1) — correctness + cost, real capability hole
 2. **`stream-json` headless I/O** (#2) — cheapest high-leverage; unlocks SDK/CI integration
 3. **Bedrock streaming** (#3) — enterprise UX parity, reuses existing SSE
-4. **OTel: wire it or remove the config** (#4) — stop advertising a dead feature
+4. **Export surface removal** (#4) — stop advertising a dead feature
 5. **Eval harness** (#5) — so quality regressions become detectable
 6. Then the parity/hardening band: MCP sampling (#6), daemon rate-limiting (#7, before relay hardens),
    analyzed `/init` (#8), `/output-style` menu (#9), SBOM/provenance (#10)

--- a/runtime/src/bootstrap/state.ts
+++ b/runtime/src/bootstrap/state.ts
@@ -220,7 +220,7 @@ type State = {
   // benefit to keeping thinking). Once latched, stays on so the newly-warmed
   // thinking-cleared cache isn't busted by flipping back to keep:'all'.
   thinkingClearLatched: boolean | null
-  // Current prompt ID (UUID) correlating a user prompt with subsequent OTel events
+  // Current prompt ID (UUID) correlating a user prompt with subsequent local events.
   promptId: string | null
   // Last API requestId for the main conversation chain (not subagents).
   // Updated after each successful API response for main-session queries.

--- a/runtime/src/llm/provider.ts
+++ b/runtime/src/llm/provider.ts
@@ -46,6 +46,7 @@ import {
   type BuiltInProviderInfo,
   type BuiltInProviderSlug,
 } from "./registry/provider-info.js";
+import { getGeminiProjectIdHint } from "../utils/geminiAuth.js";
 
 export type ProviderName = BuiltInProviderSlug;
 
@@ -683,6 +684,16 @@ function normalizeOllamaHost(baseURL: string | undefined): string | undefined {
   const normalized = normalizeBaseURL(baseURL);
   if (!normalized) return undefined;
   return normalized.replace(/\/v1\/?$/i, "");
+}
+
+function geminiVertexBaseURL(
+  project: string | undefined,
+  location: string | undefined,
+): string | undefined {
+  const normalizedProject = firstNonEmpty(project);
+  const normalizedLocation = firstNonEmpty(location);
+  if (!normalizedProject || !normalizedLocation) return undefined;
+  return `https://${encodeURIComponent(normalizedLocation)}-aiplatform.googleapis.com/v1/projects/${encodeURIComponent(normalizedProject)}/locations/${encodeURIComponent(normalizedLocation)}`;
 }
 
 function cloneExtraValue(value: unknown): unknown {
@@ -1440,7 +1451,10 @@ export function createProvider(
       });
     case "gemini": {
       const apiKeyEnvLabel = apiKeyEnvVarFor("gemini");
-      const apiKey = requireFactoryApiKey("gemini", opts);
+      const apiKey = resolveFactoryApiKey(
+        opts,
+        firstNonEmpty(process.env.GEMINI_API_KEY, process.env.GOOGLE_API_KEY),
+      );
       const model = requireModel(
         "gemini",
         opts.model,
@@ -1448,31 +1462,49 @@ export function createProvider(
         "GEMINI_MODEL",
         defaultModelFor("gemini"),
       );
+      const project = firstNonEmpty(extra.project, getGeminiProjectIdHint());
+      const location = firstNonEmpty(
+        readString(opts.extra, "location"),
+        readString(opts.extra, "geminiLocation"),
+        extra.region,
+        process.env.GEMINI_VERTEX_LOCATION,
+        process.env.GOOGLE_CLOUD_LOCATION,
+        process.env.GOOGLE_CLOUD_REGION,
+        process.env.CLOUD_ML_REGION,
+      );
+      const explicitAccessToken = firstNonEmpty(
+        readString(opts.extra, "accessToken"),
+        readString(readRecord(opts.extra, "oauth"), "accessToken"),
+        process.env.GEMINI_ACCESS_TOKEN,
+      );
+      const configuredBaseURL =
+        normalizeBaseURL(opts.baseURL) ??
+        normalizeBaseURL(process.env.GEMINI_BASE_URL);
+      const inferredVertexBaseURL = apiKey === undefined
+        ? geminiVertexBaseURL(project, location)
+        : undefined;
       const cfg: GeminiProviderConfig = {
         ...buildCommonConfig(extra),
-        apiKey,
+        ...(apiKey !== undefined ? { apiKey } : {}),
         model,
         providerName: "gemini",
         apiKeyEnvLabel,
         tools: opts.tools ? [...opts.tools] : undefined,
-        baseURL:
-          normalizeBaseURL(opts.baseURL) ??
-          normalizeBaseURL(process.env.GEMINI_BASE_URL) ??
-          defaultBaseURLFor("gemini"),
+        baseURL: configuredBaseURL ?? inferredVertexBaseURL ?? defaultBaseURLFor("gemini"),
         useResponsesApi: false,
-        authStrategy: "google_api_key",
         ...(firstNonEmpty(process.env.GEMINI_CACHED_CONTENT)
           ? { cachedContent: firstNonEmpty(process.env.GEMINI_CACHED_CONTENT) }
           : {}),
         ...(extra.defaultHeaders ? { defaultHeaders: extra.defaultHeaders } : {}),
         ...(extra.fetchImpl ? { fetchImpl: extra.fetchImpl } : {}),
-        ...(extra.project ? { project: extra.project } : {}),
+        ...(project ? { project } : {}),
+        ...(explicitAccessToken ? { accessToken: explicitAccessToken } : {}),
         ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
       };
       return markFactoryProvider(new GeminiProvider(cfg), {
         provider: "gemini",
         options: {
-          apiKey,
+          ...(apiKey !== undefined ? { apiKey } : {}),
           baseURL: cfg.baseURL,
           model,
           ...(cfg.timeoutMs !== undefined ? { timeoutMs: cfg.timeoutMs } : {}),

--- a/runtime/src/llm/providers/gemini/index.ts
+++ b/runtime/src/llm/providers/gemini/index.ts
@@ -25,11 +25,18 @@ import type {
 } from "../../types.js";
 import { validateToolCallDetailed } from "../../types.js";
 import { coerceUsage } from "../../wire/shared.js";
-import { OpenAIAuthSession } from "../openai/auth.js";
 import type { OpenAIProviderConfig } from "../openai/types.js";
+import {
+  resolveGeminiCredential,
+  type GeminiResolvedCredential,
+} from "../../../utils/geminiAuth.js";
 
 export interface GeminiProviderConfig extends OpenAIProviderConfig {
   readonly cachedContent?: string;
+  readonly accessToken?: string;
+  readonly resolveCredential?: (
+    env?: NodeJS.ProcessEnv,
+  ) => Promise<GeminiResolvedCredential>;
 }
 
 const DEFAULT_GEMINI_BASE_URL =
@@ -64,14 +71,115 @@ function normalizeGeminiModel(model: string): string {
   return model.trim().replace(/^models\//iu, "");
 }
 
-function modelPath(model: string, operation: "generateContent" | "streamGenerateContent"): string {
-  return `/models/${encodeURIComponent(normalizeGeminiModel(model))}:${operation}`;
-}
-
 function nonEmptyString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isVertexGeminiBaseURL(baseURL: string | undefined): boolean {
+  if (!baseURL) return false;
+  try {
+    return new URL(baseURL).hostname.endsWith("aiplatform.googleapis.com");
+  } catch {
+    return false;
+  }
+}
+
+function hasVertexGooglePublisherBasePath(baseURL: string | undefined): boolean {
+  if (!baseURL) return false;
+  try {
+    return /\/publishers\/google\/?$/iu.test(new URL(baseURL).pathname);
+  } catch {
+    return false;
+  }
+}
+
+function geminiModelName(model: string): string {
+  return normalizeGeminiModel(model).replace(
+    /^publishers\/google\/models\//iu,
+    "",
+  );
+}
+
+function modelPath(
+  baseURL: string | undefined,
+  model: string,
+  operation: "generateContent" | "streamGenerateContent",
+): string {
+  const encodedModel = encodeURIComponent(geminiModelName(model));
+  if (isVertexGeminiBaseURL(baseURL) && !hasVertexGooglePublisherBasePath(baseURL)) {
+    return `/publishers/google/models/${encodedModel}:${operation}`;
+  }
+  return `/models/${encodedModel}:${operation}`;
+}
+
+function modelsListPath(baseURL: string | undefined): string {
+  return isVertexGeminiBaseURL(baseURL) && !hasVertexGooglePublisherBasePath(baseURL)
+    ? "/publishers/google/models"
+    : "/models";
+}
+
+function googleProjectHeaders(project: string | undefined): Record<string, string> {
+  const normalized = nonEmptyString(project);
+  return normalized ? { "x-goog-user-project": normalized } : {};
+}
+
+function authHeadersForCredential(
+  credential: GeminiResolvedCredential,
+  project: string | undefined,
+): Record<string, string> | undefined {
+  switch (credential.kind) {
+    case "api-key":
+      return {
+        "x-goog-api-key": credential.credential,
+        ...googleProjectHeaders(project),
+      };
+    case "access-token":
+    case "adc":
+      return {
+        authorization: `Bearer ${credential.credential}`,
+        ...googleProjectHeaders(project ?? credential.projectId),
+      };
+    case "none":
+      return undefined;
+  }
+}
+
+async function resolveGeminiAuthHeaders(
+  config: GeminiProviderConfig,
+): Promise<Record<string, string>> {
+  const apiKey = nonEmptyString(config.apiKey);
+  if (apiKey) {
+    return {
+      "x-goog-api-key": apiKey,
+      ...googleProjectHeaders(config.project),
+    };
+  }
+
+  const explicitAccessToken =
+    nonEmptyString(config.accessToken) ??
+    (config.authMode === "oauth"
+      ? nonEmptyString(config.oauth?.accessToken)
+      : undefined);
+  if (explicitAccessToken) {
+    return {
+      authorization: `Bearer ${explicitAccessToken}`,
+      ...googleProjectHeaders(config.project),
+    };
+  }
+
+  const resolved = await (config.resolveCredential ?? resolveGeminiCredential)(
+    process.env,
+  );
+  const headers = authHeadersForCredential(resolved, config.project);
+  if (headers) return headers;
+
+  throw new LLMProviderError(
+    "gemini",
+    "Gemini provider requires credentials: set GEMINI_API_KEY, GOOGLE_API_KEY, GEMINI_ACCESS_TOKEN, or Google ADC credentials",
+    401,
+  );
 }
 
 function finiteInteger(value: unknown): number | undefined {
@@ -721,24 +829,21 @@ export class GeminiProvider implements LLMProvider {
 
   private readonly config: GeminiProviderConfig;
   private readonly client: ProviderHttpClient;
-  private readonly auth: OpenAIAuthSession;
 
   constructor(config: GeminiProviderConfig) {
     this.config = {
       ...config,
       providerName: "gemini",
       apiKeyEnvLabel: "GEMINI_API_KEY",
-      authStrategy: config.authStrategy ?? "google_api_key",
       useResponsesApi: false,
       baseURL: normalizeGeminiBaseURL(config.baseURL),
     };
-    this.auth = new OpenAIAuthSession(this.config);
     this.client = new ProviderHttpClient({
       providerName: this.name,
       baseURL: this.config.baseURL ?? DEFAULT_GEMINI_BASE_URL,
       model: this.config.model,
       defaultHeaders: this.config.defaultHeaders,
-      resolveAuthHeaders: (context) => this.auth.resolveHeaders(context),
+      resolveAuthHeaders: () => resolveGeminiAuthHeaders(this.config),
       timeoutMs: this.config.timeoutMs,
       fetchImpl: this.config.fetchImpl,
       providerFallback: this.config.providerFallback,
@@ -764,18 +869,16 @@ export class GeminiProvider implements LLMProvider {
     const metrics = requestMetrics({ messages, tools, body, stream: false });
 
     try {
-      return await this.auth.withAuthorizedOperation(async () => {
-        const session = this.client.createTurnSession({ wireApi: "custom" });
-        const response = await session.requestJson<Record<string, unknown>>({
-          path: modelPath(model, "generateContent"),
-          method: "POST",
-          body,
-          timeoutMs: options?.timeoutMs,
-          signal: options?.signal,
-          providerFallback: this.config.providerFallback,
-        });
-        return withMetrics(parseGeminiResponse(model, response.data), metrics);
+      const session = this.client.createTurnSession({ wireApi: "custom" });
+      const response = await session.requestJson<Record<string, unknown>>({
+        path: modelPath(this.config.baseURL, model, "generateContent"),
+        method: "POST",
+        body,
+        timeoutMs: options?.timeoutMs,
+        signal: options?.signal,
+        providerFallback: this.config.providerFallback,
       });
+      return withMetrics(parseGeminiResponse(model, response.data), metrics);
     } catch (error) {
       mapProviderError(error);
     }
@@ -798,28 +901,26 @@ export class GeminiProvider implements LLMProvider {
     const metrics = requestMetrics({ messages, tools, body, stream: true });
 
     try {
-      return await this.auth.withAuthorizedOperation(async () => {
-        const session = this.client.createTurnSession({ wireApi: "custom" });
-        const response = await session.requestStream({
-          path: modelPath(model, "streamGenerateContent"),
-          method: "POST",
-          headers: { accept: "text/event-stream" },
-          query: { alt: "sse" },
-          body,
-          timeoutMs: options?.timeoutMs,
-          signal: options?.signal,
-          providerFallback: this.config.providerFallback,
-          retryBudget: { maxRetries: 0 },
-        });
-        const state = new GeminiStreamState(model);
-        for await (const event of readGeminiSseEvents(response)) {
-          state.consumeResponse(event.data, onChunk);
-        }
-        return {
-          ...state.finalize(onChunk),
-          requestMetrics: metrics,
-        };
+      const session = this.client.createTurnSession({ wireApi: "custom" });
+      const response = await session.requestStream({
+        path: modelPath(this.config.baseURL, model, "streamGenerateContent"),
+        method: "POST",
+        headers: { accept: "text/event-stream" },
+        query: { alt: "sse" },
+        body,
+        timeoutMs: options?.timeoutMs,
+        signal: options?.signal,
+        providerFallback: this.config.providerFallback,
+        retryBudget: { maxRetries: 0 },
       });
+      const state = new GeminiStreamState(model);
+      for await (const event of readGeminiSseEvents(response)) {
+        state.consumeResponse(event.data, onChunk);
+      }
+      return {
+        ...state.finalize(onChunk),
+        requestMetrics: metrics,
+      };
     } catch (error) {
       mapProviderError(error);
     }
@@ -827,12 +928,10 @@ export class GeminiProvider implements LLMProvider {
 
   async healthCheck(): Promise<boolean> {
     try {
-      await this.auth.withAuthorizedOperation(async () => {
-        const session = this.client.createTurnSession({ wireApi: "custom" });
-        await session.requestJson<Record<string, unknown>>({
-          path: "/models",
-          method: "GET",
-        });
+      const session = this.client.createTurnSession({ wireApi: "custom" });
+      await session.requestJson<Record<string, unknown>>({
+        path: modelsListPath(this.config.baseURL),
+        method: "GET",
       });
       return true;
     } catch {

--- a/runtime/src/mcp-client/README.md
+++ b/runtime/src/mcp-client/README.md
@@ -17,6 +17,9 @@ without knowing the underlying transport.
   per-read byte cap (I-76, see `resources.ts`).
 - Bridge MCP **prompts** (parameterized server-side templates) into
   user/assistant message pairs.
+- Advertise MCP host roots and sampling; session-owned managers route
+  `sampling/createMessage` through the active runtime provider, while
+  sessionless compatibility connections return a graceful unavailable result.
 - Detect dead connections on tool calls and reconnect with exponential
   backoff via `ResilientMCPBridge`.
 

--- a/runtime/src/mcp-client/connection.ts
+++ b/runtime/src/mcp-client/connection.ts
@@ -17,6 +17,7 @@ import { createStdioMCPConnection } from "./transports/stdio.js";
 import { createSseMCPConnection } from "./transports/sse.js";
 import { createHttpMCPConnection } from "./transports/http.js";
 import { createWebSocketMCPConnection } from "./transports/websocket.js";
+import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
 
 /**
  * Create an MCP client connection to an external server.
@@ -30,6 +31,7 @@ export async function createMCPConnection(
   config: MCPServerConfig,
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
+  samplingHandlers?: McpSamplingHandlers,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const transportKind = config.transport ?? "stdio";
@@ -52,6 +54,7 @@ export async function createMCPConnection(
       },
       logger,
       elicitationHandlers,
+      samplingHandlers,
     );
   }
 
@@ -73,15 +76,26 @@ export async function createMCPConnection(
       ...(config.timeout !== undefined ? { timeout: config.timeout } : {}),
     };
     if (transportKind === "sse") {
-      return createSseMCPConnection(remoteConfig, logger, elicitationHandlers);
+      return createSseMCPConnection(
+        remoteConfig,
+        logger,
+        elicitationHandlers,
+        samplingHandlers,
+      );
     }
     if (transportKind === "http") {
-      return createHttpMCPConnection(remoteConfig, logger, elicitationHandlers);
+      return createHttpMCPConnection(
+        remoteConfig,
+        logger,
+        elicitationHandlers,
+        samplingHandlers,
+      );
     }
     return createWebSocketMCPConnection(
       remoteConfig,
       logger,
       elicitationHandlers,
+      samplingHandlers,
     );
   }
 

--- a/runtime/src/mcp-client/manager.ts
+++ b/runtime/src/mcp-client/manager.ts
@@ -43,6 +43,7 @@ import {
   type MCPPromptDescriptor,
   type MCPPromptRendered,
 } from "./prompts.js";
+import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
 
 /** I-50: cancellable MCP startup wait; 30s default. */
 const MCP_STARTUP_TIMEOUT_MS = 30_000;
@@ -198,6 +199,7 @@ export class MCPManager {
   private callObserver: MCPCallObserver | undefined;
   private permissionOptions: MCPToolBridgePermissionOptions | undefined;
   private elicitationHandlers: MCPElicitationHandlers | undefined;
+  private samplingHandlers: McpSamplingHandlers | undefined;
 
   constructor(configs: MCPServerConfig[], logger: Logger = silentLogger) {
     this.configs = configs;
@@ -225,6 +227,10 @@ export class MCPManager {
     handlers: MCPElicitationHandlers | undefined,
   ): void {
     this.elicitationHandlers = handlers;
+  }
+
+  setSamplingHandlers(handlers: McpSamplingHandlers | undefined): void {
+    this.samplingHandlers = handlers;
   }
 
   getConnectionState(name: string): MCPConnectionState | undefined {
@@ -774,6 +780,7 @@ export class MCPManager {
       config,
       this.logger,
       this.elicitationHandlers,
+      this.samplingHandlers,
     );
     try {
       if (startupGate?.isCancelled()) {
@@ -823,11 +830,9 @@ export class MCPManager {
           ...(this.permissionOptions !== undefined
             ? { permissions: this.permissionOptions }
             : {}),
-          // Telemetry parity: forward the same call observer the initial
+          // Reconnect parity: forward the same call observer the initial
           // `createToolBridge` above received so reconnected bridges keep
-          // emitting `mcp_tool_call_*` events. `serverOrigin` is not derived
-          // here yet; when it is, pass it both here and to `createToolBridge`
-          // so the two connect paths stay in lockstep.
+          // emitting local `mcp_tool_call_*` events.
           ...(this.callObserver !== undefined
             ? { callObserver: this.callObserver }
             : {}),
@@ -837,6 +842,9 @@ export class MCPManager {
           // silently after a transient drop.
           ...(this.elicitationHandlers !== undefined
             ? { elicitationHandlers: this.elicitationHandlers }
+            : {}),
+          ...(this.samplingHandlers !== undefined
+            ? { samplingHandlers: this.samplingHandlers }
             : {}),
           // On automatic reconnect the resilient bridge rebuilds only the
           // tool surface and spawns a fresh client. Rebuild the resource +

--- a/runtime/src/mcp-client/resilient-client.ts
+++ b/runtime/src/mcp-client/resilient-client.ts
@@ -13,6 +13,7 @@ import type {
   MCPServerConfig,
   MCPToolBridge,
 } from "./types.js";
+import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
 import type {
   MCPCallObserver,
   MCPToolBridgePermissionOptions,
@@ -96,11 +97,9 @@ const BACKOFF_MULTIPLIER = 2;
 interface ResilientMCPBridgeOptions {
   readonly permissions?: MCPToolBridgePermissionOptions;
   /**
-   * Telemetry plumbing forwarded to the inner bridge on reconnect so a
-   * rebuilt bridge keeps emitting the same `mcp_tool_call_*` events and
-   * span origin the initial connect set up. Telemetry-only (not a security
-   * control); kept at parity with the initial-connect `createToolBridge`
-   * call in `manager.ts`.
+   * Local event observer forwarded to the inner bridge on reconnect so a
+   * rebuilt bridge keeps emitting the same `mcp_tool_call_*` events the
+   * initial connect set up.
    */
   readonly callObserver?: MCPCallObserver;
   readonly serverOrigin?: string;
@@ -128,6 +127,8 @@ interface ResilientMCPBridgeOptions {
    * bridge for this to take effect.
    */
   readonly elicitationHandlers?: MCPElicitationHandlers;
+  /** Session-provided MCP sampling handler, re-registered on reconnect. */
+  readonly samplingHandlers?: McpSamplingHandlers;
 }
 
 /**
@@ -264,6 +265,7 @@ export class ResilientMCPBridge implements MCPToolBridge {
         this.config,
         this.logger,
         this.options.elicitationHandlers,
+        this.options.samplingHandlers,
       );
       // A `dispose()` racing this reconnect already cleared `reconnectTimer`
       // and disposed `this.inner`, but it cannot see the client we just
@@ -291,8 +293,7 @@ export class ResilientMCPBridge implements MCPToolBridge {
           ...(this.options.permissions !== undefined
             ? { permissions: this.options.permissions }
             : {}),
-          // Telemetry parity with the initial connect (manager.ts): keep the
-          // rebuilt bridge emitting the same call events / span origin.
+          // Keep the rebuilt bridge emitting the same local call events.
           ...(this.options.callObserver !== undefined
             ? { callObserver: this.options.callObserver }
             : {}),

--- a/runtime/src/mcp-client/transports/http.ts
+++ b/runtime/src/mcp-client/transports/http.ts
@@ -16,6 +16,7 @@ import { configureMcpElicitationClient } from "../../elicitation/mcp.js";
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
+  type McpSamplingHandlers,
 } from "../../services/mcp/hostCapabilities.js";
 
 export interface MCPServerHttpConfig {
@@ -33,6 +34,7 @@ export async function createHttpMCPConnection(
   config: MCPServerHttpConfig,
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
+  samplingHandlers?: McpSamplingHandlers,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
@@ -61,7 +63,11 @@ export async function createHttpMCPConnection(
       ),
     },
   );
-  configureMcpHostRequestHandlers(client, config.name);
+  configureMcpHostRequestHandlers(
+    client,
+    config.name,
+    samplingHandlers === undefined ? undefined : { samplingHandlers },
+  );
   await configureMcpElicitationClient(
     client,
     config.name,

--- a/runtime/src/mcp-client/transports/sse.ts
+++ b/runtime/src/mcp-client/transports/sse.ts
@@ -24,6 +24,7 @@ import { configureMcpElicitationClient } from "../../elicitation/mcp.js";
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
+  type McpSamplingHandlers,
 } from "../../services/mcp/hostCapabilities.js";
 
 export interface MCPServerSseConfig {
@@ -44,6 +45,7 @@ export async function createSseMCPConnection(
   config: MCPServerSseConfig,
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
+  samplingHandlers?: McpSamplingHandlers,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
@@ -72,7 +74,11 @@ export async function createSseMCPConnection(
       ),
     },
   );
-  configureMcpHostRequestHandlers(client, config.name);
+  configureMcpHostRequestHandlers(
+    client,
+    config.name,
+    samplingHandlers === undefined ? undefined : { samplingHandlers },
+  );
   await configureMcpElicitationClient(
     client,
     config.name,

--- a/runtime/src/mcp-client/transports/stdio.ts
+++ b/runtime/src/mcp-client/transports/stdio.ts
@@ -27,6 +27,7 @@ import { configureMcpElicitationClient } from "../../elicitation/mcp.js";
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
+  type McpSamplingHandlers,
 } from "../../services/mcp/hostCapabilities.js";
 
 const PROCESS_GROUP_TERM_GRACE_MS = 2_000;
@@ -337,6 +338,7 @@ export async function createStdioMCPConnection(
   config: MCPServerStdioConfig,
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
+  samplingHandlers?: McpSamplingHandlers,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
@@ -350,7 +352,11 @@ export async function createStdioMCPConnection(
       ),
     },
   );
-  configureMcpHostRequestHandlers(client, config.name);
+  configureMcpHostRequestHandlers(
+    client,
+    config.name,
+    samplingHandlers === undefined ? undefined : { samplingHandlers },
+  );
   await configureMcpElicitationClient(client, config.name, elicitationHandlers);
 
   logger.info(`Connecting to MCP stdio server "${config.name}"...`, {

--- a/runtime/src/mcp-client/transports/websocket.ts
+++ b/runtime/src/mcp-client/transports/websocket.ts
@@ -26,6 +26,7 @@ import { configureMcpElicitationClient } from "../../elicitation/mcp.js";
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
+  type McpSamplingHandlers,
 } from "../../services/mcp/hostCapabilities.js";
 
 const MCP_WEBSOCKET_SUBPROTOCOL = "mcp";
@@ -174,6 +175,7 @@ export async function createWebSocketMCPConnection(
   config: MCPServerWebSocketConfig,
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
+  samplingHandlers?: McpSamplingHandlers,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
@@ -187,7 +189,11 @@ export async function createWebSocketMCPConnection(
       ),
     },
   );
-  configureMcpHostRequestHandlers(client, config.name);
+  configureMcpHostRequestHandlers(
+    client,
+    config.name,
+    samplingHandlers === undefined ? undefined : { samplingHandlers },
+  );
   await configureMcpElicitationClient(client, config.name, elicitationHandlers);
 
   logger.info(`Connecting to MCP WebSocket server "${config.name}"...`, {

--- a/runtime/src/prompts/attachments/output-style.ts
+++ b/runtime/src/prompts/attachments/output-style.ts
@@ -1,28 +1,13 @@
 /**
  * Output-style attachment producer.
  *
- * Intended hand-port of reference `getOutputStyleAttachment`
- * (`src/utils/attachments.ts:1598-1613`), which emits an
- * `output_style` system-reminder every turn whenever the active style
- * is non-default.
+ * Compatibility producer for the attachment orchestrator.
  *
- * AGENC GAP — Follow-up: AgenC has two separate "output style" surfaces
- * today and neither is threaded through `GetAttachmentsOptions`:
- *
- *   1. `config/schema.ts` `PartialOutputStyleConfig` carries a
- *      cockpit palette `theme` (e.g. "dark"), not the AgenC
- *      style preset shape.
- *   2. `prompts/system-prompt.ts` `OutputStyleInput` (`{ name, prompt }`)
- *      is the actual preset shape but is supplied to the system-prompt
- *      assembler from the per-turn `prepareContext()` result, not via
- *      the orchestrator inputs.
- *
- * Until the runtime exposes the active preset name on
- * `GetAttachmentsOptions` (or the orchestrator gains access to the
- * resolved per-turn context), this producer is a noop. The renderer
- * for `output_style` is already wired in `messages.ts`, so lighting it
- * up later is a one-field change here plus the option-plumbing
- * change at the call site.
+ * Live output-style injection is handled by `prompts/system-prompt.ts`,
+ * where the resolved per-turn `OutputStyleInput` is already available.
+ * The attachment renderer remains available for replay/import paths that
+ * may encounter persisted `output_style` items, but the live producer stays
+ * empty to avoid injecting the same style instructions twice.
  *
  * @module
  */
@@ -33,9 +18,5 @@ export const outputStyleProducer: AttachmentProducer = async (
   _opts,
   _trackingState,
 ) => {
-  // Follow-up(attachments): emit `{ kind: "output_style", style }` once the
-  // active output-style preset name is reachable from
-  // GetAttachmentsOptions. Filter `style === "default"` before emit per
-  // AgenC convention.
   return [];
 };

--- a/runtime/src/sandbox/engine/policies/restricted_read_only_platform_defaults.sbpl
+++ b/runtime/src/sandbox/engine/policies/restricted_read_only_platform_defaults.sbpl
@@ -116,10 +116,8 @@
 ; macOS Standard library queries opendirectoryd at startup
 (allow mach-lookup (global-name "com.apple.system.opendirectoryd.libinfo"))
 
-; Allow IPC to analytics, logging, trust, and other system agents.
+; Allow IPC to logging, trust, and other system agents.
 (allow mach-lookup
-  (global-name "com.apple.analyticsd")
-  (global-name "com.apple.analyticsd.messagetracer")
   (global-name "com.apple.appsleep")
   (global-name "com.apple.bsd.dirhelper")
   (global-name "com.apple.cfprefsd.agent")

--- a/runtime/src/services/autoFix/autoFixHook.ts
+++ b/runtime/src/services/autoFix/autoFixHook.ts
@@ -8,7 +8,7 @@
  *     current turn/conversation key, matching the donor loop guard.
  *
  * Cross-cuts deliberately NOT carried:
- *   - Analytics/logging events; hook failures are contained locally so
+ *   - Donor product events; hook failures are contained locally so
  *     a broken lint command cannot fail the original tool call.
  */
 

--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -125,6 +125,7 @@ import { SdkControlClientTransport } from './SdkControlTransport.js'
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
+  type McpSamplingHandlers,
 } from './hostCapabilities.js'
 import type {
   ConnectedMCPServer,
@@ -755,8 +756,19 @@ function isIncludedMcpTool(tool: Tool): boolean {
 function getServerCacheKey(
   name: string,
   serverRef: ScopedMcpServerConfig,
+  _serverStats?: unknown,
+  options?: ConnectToServerOptions,
 ): string {
-  return `${name}-${jsonStringify(serverRef)}`
+  const baseKey = `${name}-${jsonStringify(serverRef)}`
+  if (options?.samplingHandlers === undefined) {
+    return baseKey
+  }
+  return `${baseKey}-sampling-${options.samplingCacheKey ?? 'anonymous'}`
+}
+
+interface ConnectToServerOptions {
+  readonly samplingHandlers?: McpSamplingHandlers
+  readonly samplingCacheKey?: string
 }
 
 /**
@@ -778,6 +790,7 @@ export const connectToServer = memoize(
       sseIdeCount: number
       wsIdeCount: number
     },
+    options?: ConnectToServerOptions,
   ): Promise<MCPServerConnection> => {
     const connectStartTime = Date.now()
     let inProcessServer: InProcessMcpServer | undefined
@@ -1159,7 +1172,12 @@ export const connectToServer = memoize(
         logMCPDebug(name, `Client created, setting up request handler`)
       }
 
-      configureMcpHostRequestHandlers(client, name, getOriginalCwd())
+      configureMcpHostRequestHandlers(client, name, {
+        rootPath: getOriginalCwd(),
+        ...(options?.samplingHandlers !== undefined
+          ? { samplingHandlers: options.samplingHandlers }
+          : {}),
+      })
 
       // Add a timeout to connection attempts to prevent tests from hanging indefinitely
       logMCPDebug(
@@ -3392,6 +3410,9 @@ export async function setupSdkMcpClients(
     serverName: string,
     message: JSONRPCMessage,
   ) => Promise<JSONRPCMessage>,
+  options: {
+    readonly samplingHandlers?: McpSamplingHandlers
+  } = {},
 ): Promise<{
   clients: MCPServerConnection[]
   tools: Tool[]
@@ -3418,7 +3439,12 @@ export async function setupSdkMcpClients(
           capabilities: buildMcpHostClientCapabilities('none'),
         },
       )
-      configureMcpHostRequestHandlers(client, name, getOriginalCwd())
+      configureMcpHostRequestHandlers(client, name, {
+        rootPath: getOriginalCwd(),
+        ...(options.samplingHandlers !== undefined
+          ? { samplingHandlers: options.samplingHandlers }
+          : {}),
+      })
 
       try {
         // Connect the client

--- a/runtime/src/services/mcp/hostCapabilities.ts
+++ b/runtime/src/services/mcp/hostCapabilities.ts
@@ -2,6 +2,7 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import {
   CreateMessageRequestSchema,
   ListRootsRequestSchema,
+  type CreateMessageRequest,
   type CreateMessageResult,
   type ListRootsResult,
 } from '@modelcontextprotocol/sdk/types.js'
@@ -10,6 +11,27 @@ import { getOriginalCwd } from '../../bootstrap/state.js'
 import { logMCPDebug } from '../../utils/log.js'
 
 export type McpHostElicitationCapabilityMode = 'none' | 'empty' | 'form-url'
+
+export interface McpSamplingHandlers {
+  createMessage(params: {
+    readonly serverName: string
+    readonly requestId: string | number | undefined
+    readonly request: CreateMessageRequest
+    readonly contextMeta?: unknown
+    readonly signal?: AbortSignal
+  }): Promise<CreateMessageResult>
+}
+
+export interface McpHostRequestHandlerOptions {
+  readonly rootPath?: string
+  readonly samplingHandlers?: McpSamplingHandlers
+}
+
+interface McpRequestHandlerExtra {
+  readonly signal?: AbortSignal
+  readonly requestId?: unknown
+  readonly _meta?: unknown
+}
 
 export function getMcpRootUriForPath(path: string): string {
   return pathToFileURL(path).href
@@ -42,11 +64,30 @@ export function createUnavailableSamplingResult(): CreateMessageResult {
   }
 }
 
+function requestIdFromMcpRequest(
+  request: CreateMessageRequest,
+): string | number | undefined {
+  const id = (request as { readonly id?: unknown }).id
+  return typeof id === 'string' || typeof id === 'number' ? id : undefined
+}
+
+function requestIdFromMcpExtra(
+  extra: McpRequestHandlerExtra | undefined,
+): string | number | undefined {
+  const id = extra?.requestId
+  return typeof id === 'string' || typeof id === 'number' ? id : undefined
+}
+
 export function configureMcpHostRequestHandlers(
   client: Client,
   serverName: string,
-  rootPath: string = getOriginalCwd(),
+  rootPathOrOptions: string | McpHostRequestHandlerOptions = getOriginalCwd(),
 ): void {
+  const options =
+    typeof rootPathOrOptions === 'string'
+      ? { rootPath: rootPathOrOptions }
+      : rootPathOrOptions
+  const rootPath = options.rootPath ?? getOriginalCwd()
   client.setRequestHandler(ListRootsRequestSchema, async (): Promise<ListRootsResult> => {
     logMCPDebug(serverName, `Received ListRoots request from server`)
     return {
@@ -60,8 +101,22 @@ export function configureMcpHostRequestHandlers(
 
   client.setRequestHandler(
     CreateMessageRequestSchema,
-    async (): Promise<CreateMessageResult> => {
+    async (
+      request: CreateMessageRequest,
+      extra?: McpRequestHandlerExtra,
+    ): Promise<CreateMessageResult> => {
       logMCPDebug(serverName, `Received sampling/createMessage request from server`)
+      if (options.samplingHandlers !== undefined) {
+        const contextMeta = request.params?._meta ?? extra?._meta
+        return options.samplingHandlers.createMessage({
+          serverName,
+          requestId:
+            requestIdFromMcpExtra(extra) ?? requestIdFromMcpRequest(request),
+          request,
+          ...(contextMeta !== undefined ? { contextMeta } : {}),
+          ...(extra?.signal !== undefined ? { signal: extra.signal } : {}),
+        })
+      }
       return createUnavailableSamplingResult()
     },
   )

--- a/runtime/src/session/mcp-startup.ts
+++ b/runtime/src/session/mcp-startup.ts
@@ -22,13 +22,20 @@
 
 import { readFileSync } from "node:fs";
 import { dirname, join, parse } from "node:path";
+import type {
+  CreateMessageRequest,
+  CreateMessageResult,
+  SamplingMessageContentBlock,
+} from "@modelcontextprotocol/sdk/types.js";
 
 import type { MCPManager, MCPManagerStartOpts } from "../mcp-client/manager.js";
 import { MCPManager as LiveMCPManager } from "../mcp-client/manager.js";
 import type { MCPToolBridgePermissionOptions } from "../mcp-client/tools.js";
 import type { MCPServerConfig } from "../mcp-client/types.js";
+import type { LLMContentPart, LLMMessage } from "../llm/types.js";
 import type { AgenCConfig, McpServerConfig as AgenCMcpServerConfig } from "../config/schema.js";
 import { McpJsonConfigSchema, type McpServerConfig as ServiceMcpServerConfig } from "../services/mcp/types.js";
+import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
 import { freshDenialTracking } from "../permissions/denial-tracking.js";
 import {
   attachContextDefaults,
@@ -153,6 +160,132 @@ export function createSessionMcpManager(
   configs: ReadonlyArray<MCPServerConfig>,
 ): MCPManager {
   return new LiveMCPManager([...configs]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asSamplingContentBlocks(
+  content: unknown,
+): SamplingMessageContentBlock[] {
+  if (Array.isArray(content)) {
+    return content.filter(isRecord) as SamplingMessageContentBlock[];
+  }
+  return isRecord(content) ? [content as SamplingMessageContentBlock] : [];
+}
+
+function textBlockFromUnknown(value: unknown): LLMContentPart | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  return { type: "text", text: value };
+}
+
+function fallbackTextForSamplingBlock(
+  block: Record<string, unknown>,
+): string | undefined {
+  switch (block.type) {
+    case "text":
+      return typeof block.text === "string" ? block.text : undefined;
+    case "tool_use":
+      return JSON.stringify({
+        toolUse: {
+          name: block.name,
+          input: block.input,
+        },
+      });
+    case "tool_result":
+      return JSON.stringify({ toolResult: block });
+    case "audio":
+      return "[MCP sampling audio content omitted]";
+    default:
+      return undefined;
+  }
+}
+
+function samplingContentToLlmContent(
+  content: unknown,
+): string | LLMContentPart[] {
+  const blocks = asSamplingContentBlocks(content);
+  const parts: LLMContentPart[] = [];
+  for (const block of blocks) {
+    if (
+      block.type === "image" &&
+      typeof block.data === "string" &&
+      typeof block.mimeType === "string"
+    ) {
+      parts.push({
+        type: "image_url",
+        image_url: {
+          url: `data:${block.mimeType};base64,${block.data}`,
+        },
+      });
+      continue;
+    }
+    const textPart = textBlockFromUnknown(fallbackTextForSamplingBlock(block));
+    if (textPart !== undefined) {
+      parts.push(textPart);
+    }
+  }
+
+  if (parts.length === 0) return "";
+  if (parts.every((part) => part.type === "text")) {
+    return parts.map((part) => part.text).join("\n");
+  }
+  return parts;
+}
+
+function samplingRequestToLlmMessages(
+  request: CreateMessageRequest,
+): LLMMessage[] {
+  return request.params.messages.map((message) => ({
+    role: message.role === "assistant" ? "assistant" : "user",
+    content: samplingContentToLlmContent(message.content),
+  }));
+}
+
+function mcpSamplingStopReason(
+  finishReason: Awaited<ReturnType<Session["provider"]["chat"]>>["finishReason"],
+): CreateMessageResult["stopReason"] {
+  switch (finishReason) {
+    case "length":
+      return "maxTokens";
+    case "tool_calls":
+      return "toolUse";
+    case "error":
+      return "error";
+    case "stop":
+    case "content_filter":
+    default:
+      return "endTurn";
+  }
+}
+
+export function createSessionMcpSamplingHandlers(
+  session: Session,
+): McpSamplingHandlers {
+  return {
+    async createMessage({ request, signal }) {
+      const response = await session.provider.chat(
+        samplingRequestToLlmMessages(request),
+        {
+          ...(request.params.systemPrompt !== undefined
+            ? { systemPrompt: request.params.systemPrompt }
+            : {}),
+          maxOutputTokens: request.params.maxTokens,
+          ...(signal !== undefined ? { signal } : {}),
+        },
+      );
+      return {
+        role: "assistant",
+        model: response.model,
+        stopReason: mcpSamplingStopReason(response.finishReason),
+        content: {
+          type: "text",
+          text: response.content,
+        },
+      };
+    },
+  };
 }
 
 function cloneRecord<T>(
@@ -503,10 +636,15 @@ export function attachMcpManagerToSession(
         granularElicitationPolicyForSession(session),
       ),
     );
+    const samplingManager = manager as MCPManager & {
+      setSamplingHandlers?: MCPManager["setSamplingHandlers"];
+    };
+    samplingManager.setSamplingHandlers?.(
+      createSessionMcpSamplingHandlers(session),
+    );
   } catch (err) {
-    // Surface the failure through the session's event log so ops
-    // can see that MCP telemetry is missing rather than silently
-    // dropping events.
+    // Surface the failure through the session's event log rather than
+    // silently running MCP with partial session wiring.
     session.emit({
       id: session.nextInternalSubId(),
       msg: {

--- a/runtime/src/tools/AgentTool/runAgent.ts
+++ b/runtime/src/tools/AgentTool/runAgent.ts
@@ -21,6 +21,7 @@ import type { QuerySource } from '../../constants/querySource.js'
 import { getSystemContext, getUserContext } from '../../context.js'
 import type { CanUseToolFn } from '../../tui/hooks/useCanUseTool.js'
 import { requireCurrentRuntimeSession } from '../../session/current-session.js'
+import { createSessionMcpSamplingHandlers } from '../../session/mcp-startup.js'
 import { runTurnCompat } from '../../session/turn-compat.js'
 import { getDumpPromptsPath } from '../../services/api/dumpPrompts.js'
 import { cleanupAgentTracking } from '../../services/api/promptCacheBreakDetection.js'
@@ -33,6 +34,7 @@ import type {
   MCPServerConnection,
   ScopedMcpServerConfig,
 } from '../../services/mcp/types.js'
+import type { McpSamplingHandlers } from '../../services/mcp/hostCapabilities.js'
 import type { Tool, Tools, ToolUseContext } from '../Tool.js'
 import { killShellTasksForAgent } from '../../tasks/LocalShellTask/killShellTasks.js'
 import type { AgentId } from '../../types/ids.js'
@@ -112,6 +114,10 @@ function formatSkillLoadingMetadata(skillName: string): string {
 async function initializeAgentMcpServers(
   agentDefinition: AgentDefinition,
   parentClients: MCPServerConnection[],
+  sampling?: {
+    readonly handlers: McpSamplingHandlers
+    readonly cacheKey: string
+  },
 ): Promise<{
   clients: MCPServerConnection[]
   tools: Tools
@@ -186,8 +192,19 @@ async function initializeAgentMcpServers(
       isNewlyCreated = true
     }
 
-    // Connect to the server
-    const client = await connectToServer(name, config)
+    // Connect to the server. Inline frontmatter MCP servers are owned by this
+    // agent run, so they can safely use the active session sampler.
+    const client = await connectToServer(
+      name,
+      config,
+      undefined,
+      isNewlyCreated && sampling !== undefined
+        ? {
+            samplingHandlers: sampling.handlers,
+            samplingCacheKey: `${sampling.cacheKey}:${name}`,
+          }
+        : undefined,
+    )
     agentClients.push(client)
     if (isNewlyCreated) {
       newlyCreatedClients.push(client)
@@ -703,6 +720,10 @@ export async function* runAgent({
   } = await initializeAgentMcpServers(
     agentDefinition,
     toolUseContext.options.mcpClients,
+    {
+      handlers: createSessionMcpSamplingHandlers(parentSession),
+      cacheKey: `${parentSession.conversationId}:${agentId}`,
+    },
   )
 
   // Merge agent MCP tools with resolved agent tools, deduplicating by name.

--- a/runtime/src/tools/BashTool/bashPermissions.ts
+++ b/runtime/src/tools/BashTool/bashPermissions.ts
@@ -448,7 +448,6 @@ const ANT_ONLY_SAFE_ENV_VARS = new Set([
   'HARNESS_QUIET', // quiet mode flag
   'TEST_CROSSCHECK_LISTS_MATCH_UPDATE', // test update flag
   'DBT_PER_DEVELOPER_ENVIRONMENTS', // DBT config
-  'STATSIG_FORD_DB_CHECKS', // statsig DB check flag
 
   // Build configuration
   'ANT_ENVIRONMENT', // provider environment name

--- a/runtime/src/utils/cliHighlight.ts
+++ b/runtime/src/utils/cliHighlight.ts
@@ -42,9 +42,9 @@ export function getCliHighlightPromise(): Promise<CliHighlight | null> {
 
 /**
  * eg. "foo/bar.ts" → "TypeScript". Awaits the shared cli-highlight load,
- * then reads highlight.js's language registry. All callers are telemetry
- * (OTel counter attributes, permission-dialog unary events) — none block
- * on this, they fire-and-forget or the consumer already handles Promise<string>.
+ * then reads highlight.js's language registry. All callers are non-blocking
+ * local diagnostics or UI adornments — none block on this, they fire-and-forget
+ * or the consumer already handles Promise<string>.
  */
 export async function getLanguageName(file_path: string): Promise<string> {
   await getCliHighlightPromise()

--- a/runtime/src/utils/shell/prefix.ts
+++ b/runtime/src/utils/shell/prefix.ts
@@ -62,7 +62,7 @@ export type PrefixExtractorConfig = {
 
   /** The policy spec containing examples for Haiku */
   policySpec: string
-  /** Analytics event name for logging */
+  /** Local event name for logging */
   eventName: string
 
   /** Query source identifier for the API call */

--- a/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
@@ -218,6 +218,52 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     releaseSearch?.();
   });
 
+  it("rate-limits requests after the burst is exhausted while allowing request.cancel", async () => {
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+    });
+    const connection = dispatcher.createConnection({
+      overloadLimits: {
+        maxInFlightRequests: 10,
+        requestRatePerSecond: 1,
+        requestBurst: 2,
+      },
+    });
+    await initialize(connection);
+
+    await expect(
+      connection.dispatch(request("ping-1", "health.ping")),
+    ).resolves.toMatchObject({
+      result: { ok: true },
+    });
+
+    await expect(
+      connection.dispatch(request("ping-2", "health.ping")),
+    ).resolves.toMatchObject({
+      error: {
+        code: -32000,
+        data: {
+          code: "RATE_LIMITED",
+          requestRatePerSecond: 1,
+          requestBurst: 2,
+        },
+      },
+    });
+
+    await expect(
+      connection.dispatch(
+        request("cancel", "request.cancel", {
+          requestId: "missing",
+          reason: "test cancel",
+        }),
+      ),
+    ).resolves.not.toMatchObject({
+      error: {
+        data: { code: "RATE_LIMITED" },
+      },
+    });
+  });
+
   it("untrackClientId removes one co-located client without dropping the others", () => {
     // A single connection can track MULTIPLE clients (trackedClientIds is a set
     // keyed by the clientId a peer supplies). When one co-located client is

--- a/runtime/tests/gaphunt3/mcp-client-resilient-client.test.ts
+++ b/runtime/tests/gaphunt3/mcp-client-resilient-client.test.ts
@@ -115,6 +115,7 @@ describe("ResilientMCPBridge gaphunt3 fixes", () => {
       config,
       logger,
       elicitationHandlers,
+      undefined,
     );
     expect(registered).toBe(elicitationHandlers);
 
@@ -155,6 +156,7 @@ describe("ResilientMCPBridge gaphunt3 fixes", () => {
     expect(mockCreateMCPConnection).toHaveBeenCalledWith(
       config,
       logger,
+      undefined,
       undefined,
     );
 

--- a/runtime/tests/llm/provider.test.ts
+++ b/runtime/tests/llm/provider.test.ts
@@ -1442,6 +1442,7 @@ describe("createProvider", () => {
       name: "gemini",
       env: {
         GEMINI_API_KEY: undefined,
+        GOOGLE_API_KEY: undefined,
         GEMINI_BASE_URL: undefined,
       },
       apiKey: "gemini-test",
@@ -1457,6 +1458,7 @@ describe("createProvider", () => {
       name: "gemini",
       env: {
         GEMINI_API_KEY: undefined,
+        GOOGLE_API_KEY: undefined,
         GEMINI_BASE_URL:
           "https://generativelanguage.googleapis.com/v1beta/openai",
       },
@@ -1511,6 +1513,52 @@ describe("createProvider", () => {
       }
     },
   );
+
+  test("accepts GOOGLE_API_KEY as a Gemini API key", () => {
+    const provider = withEnv(
+      {
+        GOOGLE_API_KEY: "google-test",
+        GEMINI_API_KEY: undefined,
+        GEMINI_BASE_URL: undefined,
+        GEMINI_MODEL: "gemini-2.5-pro",
+      },
+      () => createProvider("gemini", {}),
+    );
+
+    expect(provider).toBeInstanceOf(GeminiProvider);
+    expect(readProviderFactoryOptions(provider)).toMatchObject({
+      apiKey: "google-test",
+      baseURL: "https://generativelanguage.googleapis.com/v1beta",
+      model: "gemini-2.5-pro",
+    });
+  });
+
+  test("infers a Vertex Gemini base URL from bearer env credentials", () => {
+    const provider = withEnv(
+      {
+        GOOGLE_API_KEY: undefined,
+        GEMINI_API_KEY: undefined,
+        GEMINI_ACCESS_TOKEN: "ya29-env-token",
+        GOOGLE_CLOUD_PROJECT: "project-1",
+        GOOGLE_CLOUD_LOCATION: "us-central1",
+        GOOGLE_CLOUD_REGION: undefined,
+        GEMINI_VERTEX_LOCATION: undefined,
+        GEMINI_BASE_URL: undefined,
+        GEMINI_MODEL: "gemini-2.5-pro",
+      },
+      () => createProvider("gemini", {}),
+    );
+
+    expect(provider).toBeInstanceOf(GeminiProvider);
+    const config = (provider as unknown as {
+      config: { accessToken?: string; baseURL?: string; project?: string };
+    }).config;
+    expect(config.accessToken).toBe("ya29-env-token");
+    expect(config.project).toBe("project-1");
+    expect(config.baseURL).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/project-1/locations/us-central1",
+    );
+  });
 
   test("tracks the canonical provider identity and rebuild options on openai-compatible providers", () => {
     const provider = withEnv(
@@ -1653,15 +1701,6 @@ describe("createProvider", () => {
         DEEPSEEK_MODEL: "deepseek-reasoner",
       },
       expected: /DEEPSEEK_API_KEY|apiKey/i,
-    },
-    {
-      name: "gemini",
-      env: {
-        GOOGLE_API_KEY: "google-test",
-        GEMINI_API_KEY: undefined,
-        GEMINI_MODEL: "gemini-2.5-pro",
-      },
-      expected: /GEMINI_API_KEY|apiKey/i,
     },
     {
       name: "mistral",

--- a/runtime/tests/llm/providers/gemini/provider.test.ts
+++ b/runtime/tests/llm/providers/gemini/provider.test.ts
@@ -89,6 +89,70 @@ describe("GeminiProvider", () => {
     expect("store" in requestBody).toBe(false);
   });
 
+  test("uses Gemini credential resolver bearer auth with user project", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "bearer" }] },
+            finishReason: "STOP",
+          },
+        ],
+      }),
+    );
+
+    const provider = new GeminiProvider({
+      model: "gemini-2.5-pro",
+      fetchImpl,
+      resolveCredential: async () => ({
+        kind: "access-token",
+        credential: "ya29-token",
+        projectId: "project-1",
+      }),
+    });
+
+    const response = await provider.chat([{ role: "user", content: "hello" }]);
+
+    expect(response.content).toBe("bearer");
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const headers = init?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer ya29-token");
+    expect(headers.get("x-goog-api-key")).toBeNull();
+    expect(headers.get("x-goog-user-project")).toBe("project-1");
+  });
+
+  test("uses Vertex Gemini publisher paths with bearer auth", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "vertex" }] },
+            finishReason: "STOP",
+          },
+        ],
+      }),
+    );
+    const provider = new GeminiProvider({
+      model: "gemini-2.5-pro",
+      baseURL:
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/project-1/locations/us-central1",
+      accessToken: "vertex-token",
+      project: "project-1",
+      fetchImpl,
+    });
+
+    const response = await provider.chat([{ role: "user", content: "hello" }]);
+
+    expect(response.content).toBe("vertex");
+    const [requestUrl, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(String(requestUrl)).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/project-1/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent",
+    );
+    const headers = init?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer vertex-token");
+    expect(headers.get("x-goog-user-project")).toBe("project-1");
+  });
+
   test("sends tools as Gemini function declarations and parses function calls", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({
@@ -263,6 +327,33 @@ describe("GeminiProvider", () => {
     const [, init] = fetchImpl.mock.calls[0] ?? [];
     const requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
     expect(requestBody.cachedContent).toBe("cachedContents/project-context");
+  });
+
+  test("uses request prompt-cache hints before configured cachedContents", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "request cache" }] },
+            finishReason: "STOP",
+          },
+        ],
+      }),
+    );
+    const provider = new GeminiProvider({
+      apiKey: "gemini-test",
+      model: "gemini-2.5-pro",
+      cachedContent: "cachedContents/project-context",
+      fetchImpl,
+    });
+
+    await provider.chat([{ role: "user", content: "hello" }], {
+      promptCacheKey: "cachedContents/request-context",
+    });
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(requestBody.cachedContent).toBe("cachedContents/request-context");
   });
 
   test("preserves Gemini thought signatures through history and response thinking", async () => {

--- a/runtime/tests/mcp-client/resilient-client.test.ts
+++ b/runtime/tests/mcp-client/resilient-client.test.ts
@@ -85,7 +85,12 @@ describe("ResilientMCPBridge", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(initialBridge.dispose).toHaveBeenCalledOnce();
-    expect(mockCreateMCPConnection).toHaveBeenCalledWith(config, logger, undefined);
+    expect(mockCreateMCPConnection).toHaveBeenCalledWith(
+      config,
+      logger,
+      undefined,
+      undefined,
+    );
     expect(mockCreateToolBridge).toHaveBeenCalledWith(
       "client2",
       "srv1",
@@ -95,6 +100,50 @@ describe("ResilientMCPBridge", () => {
         listToolsTimeoutMs: 123,
         permissions: permissionOptions,
       }),
+    );
+
+    await bridge.dispose();
+  });
+
+  it("passes sampling handlers to automatically reconnected clients", async () => {
+    vi.useFakeTimers();
+    const config: MCPServerConfig = {
+      name: "srv1",
+      command: "npx",
+      timeout: 123,
+    };
+    const initialBridge = makeBridge(
+      "srv1",
+      vi.fn().mockResolvedValue({
+        content: "transport closed",
+        isError: true,
+      }),
+    );
+    const reconnectedBridge = makeBridge("srv1");
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const samplingHandlers = {
+      createMessage: vi.fn(),
+    };
+
+    mockCreateMCPConnection.mockResolvedValueOnce("client2");
+    mockCreateToolBridge.mockResolvedValueOnce(reconnectedBridge);
+
+    const bridge = new ResilientMCPBridge(config, initialBridge, logger, {
+      samplingHandlers,
+    });
+
+    await bridge.tools[0]!.execute({});
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(mockCreateMCPConnection).toHaveBeenCalledWith(
+      config,
+      logger,
+      undefined,
+      samplingHandlers,
     );
 
     await bridge.dispose();

--- a/runtime/tests/services/mcp/client-sdk-setup.test.ts
+++ b/runtime/tests/services/mcp/client-sdk-setup.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, test, vi } from 'vitest'
+import type { McpSamplingHandlers } from './hostCapabilities.js'
 
 type FakeTransport = {
   serverName: string
@@ -22,7 +23,7 @@ type FakeSdkTransport =
 
 type FakeRequestHandler = {
   schema: unknown
-  handler: (request?: unknown) => unknown
+  handler: (request?: unknown, extra?: unknown) => unknown
 }
 
 const fakeClients: FakeClient[] = []
@@ -148,7 +149,7 @@ class FakeClient {
 
   setRequestHandler(
     schema: unknown,
-    handler: (request?: unknown) => unknown,
+    handler: (request?: unknown, extra?: unknown) => unknown,
   ): void {
     this.handlers.push({ schema, handler })
   }
@@ -380,6 +381,81 @@ test('setupSdkMcpClients connects SDK clients, fetches tools, and reports failed
     await connected.cleanup()
   }
   assert.equal(fakeClients[0]?.closed, true)
+})
+
+test('setupSdkMcpClients routes sampling requests through supplied handlers', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+
+  const { setupSdkMcpClients } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  let captured: unknown
+  const samplingHandlers: McpSamplingHandlers = {
+    async createMessage(params) {
+      captured = params
+      return {
+        role: 'assistant',
+        model: 'sdk-sampler',
+        stopReason: 'endTurn',
+        content: { type: 'text', text: 'sampled via sdk stack' },
+      }
+    },
+  }
+
+  const result = await setupSdkMcpClients(
+    {
+      tooling: { type: 'sdk', name: 'tooling' },
+    },
+    async (_serverName, message) => message,
+    { samplingHandlers },
+  )
+
+  assert.deepEqual(
+    result.clients.map(client => `${client.name}:${client.type}`),
+    ['tooling:connected'],
+  )
+
+  const abort = new AbortController()
+  const request = {
+    method: 'sampling/createMessage',
+    params: {
+      messages: [
+        {
+          role: 'user',
+          content: { type: 'text', text: 'sdk sample' },
+        },
+      ],
+      maxTokens: 8,
+    },
+  }
+  const response = await fakeClients[0]!.handlers[1]!.handler(request, {
+    requestId: 'sdk-sampling-request',
+    signal: abort.signal,
+    _meta: { origin: 'sdk-control' },
+  })
+
+  assert.deepEqual(response, {
+    role: 'assistant',
+    model: 'sdk-sampler',
+    stopReason: 'endTurn',
+    content: { type: 'text', text: 'sampled via sdk stack' },
+  })
+  assert.deepEqual(captured, {
+    serverName: 'tooling',
+    requestId: 'sdk-sampling-request',
+    request,
+    contextMeta: { origin: 'sdk-control' },
+    signal: abort.signal,
+  })
+
+  const connected = result.clients[0]
+  if (connected?.type === 'connected') {
+    await connected.cleanup()
+  }
 })
 
 test('prefetchAllMcpResources includes MCP skill commands when feature enabled', async () => {
@@ -769,6 +845,86 @@ test('connectToServer creates stdio clients with lifecycle handlers and cleanup'
     await reconnected.cleanup()
   }
   assert.equal(fakeClients[1]?.closed, true)
+})
+
+test('connectToServer routes sampling requests through supplied handlers', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  let captured: unknown
+  const samplingHandlers: McpSamplingHandlers = {
+    async createMessage(params) {
+      captured = params
+      return {
+        role: 'assistant',
+        model: 'legacy-sampler',
+        stopReason: 'endTurn',
+        content: { type: 'text', text: 'sampled via legacy stack' },
+      }
+    },
+  }
+  const config = {
+    type: 'stdio',
+    command: 'demo-server',
+    args: ['--flag'],
+    env: { DEMO: '1' },
+    scope: 'local',
+  } as const
+
+  const result = await connectToServer('sampling-stdio', config, undefined, {
+    samplingHandlers,
+    samplingCacheKey: 'test-session',
+  })
+
+  assert.equal(result.type, 'connected')
+  if (result.type !== 'connected') {
+    assert.fail(result.error)
+  }
+  assert.equal(fakeClients[0]?.handlers.length, 3)
+
+  const abort = new AbortController()
+  const request = {
+    method: 'sampling/createMessage',
+    params: {
+      messages: [
+        {
+          role: 'user',
+          content: { type: 'text', text: 'sample this' },
+        },
+      ],
+      maxTokens: 8,
+    },
+  }
+  const response = await fakeClients[0]!.handlers[1]!.handler(request, {
+    requestId: 'sampling-request',
+    signal: abort.signal,
+    _meta: { origin: 'legacy' },
+  })
+
+  assert.deepEqual(response, {
+    role: 'assistant',
+    model: 'legacy-sampler',
+    stopReason: 'endTurn',
+    content: { type: 'text', text: 'sampled via legacy stack' },
+  })
+  assert.deepEqual(captured, {
+    serverName: 'sampling-stdio',
+    requestId: 'sampling-request',
+    request,
+    contextMeta: { origin: 'legacy' },
+    signal: abort.signal,
+  })
+
+  await result.cleanup()
 })
 
 test('connectToServer quotes stdio argv when a shell prefix is configured', async () => {

--- a/runtime/tests/services/mcp/hostCapabilities.test.ts
+++ b/runtime/tests/services/mcp/hostCapabilities.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { configureMcpHostRequestHandlers } from './hostCapabilities.js'
+
+type FakeHandler = (request?: unknown, extra?: unknown) => unknown
+
+class FakeClient {
+  readonly handlers: FakeHandler[] = []
+
+  setRequestHandler(_schema: unknown, handler: FakeHandler): void {
+    this.handlers.push(handler)
+  }
+}
+
+test('configureMcpHostRequestHandlers delegates sampling/createMessage to injected handler', async () => {
+  const client = new FakeClient()
+  let captured: unknown
+
+  configureMcpHostRequestHandlers(client as never, 'srv', {
+    rootPath: process.cwd(),
+    samplingHandlers: {
+      async createMessage(params) {
+        captured = params
+        return {
+          role: 'assistant',
+          model: 'test-model',
+          stopReason: 'endTurn',
+          content: { type: 'text', text: 'sampled' },
+        }
+      },
+    },
+  })
+
+  const abort = new AbortController()
+  const result = await client.handlers[1]?.(
+    {
+      method: 'sampling/createMessage',
+      params: {
+        messages: [
+          {
+            role: 'user',
+            content: { type: 'text', text: 'hello' },
+          },
+        ],
+        maxTokens: 16,
+      },
+    },
+    {
+      requestId: 9,
+      signal: abort.signal,
+      _meta: { trace: 'local' },
+    },
+  )
+
+  assert.deepEqual(result, {
+    role: 'assistant',
+    model: 'test-model',
+    stopReason: 'endTurn',
+    content: { type: 'text', text: 'sampled' },
+  })
+  assert.deepEqual(captured, {
+    serverName: 'srv',
+    requestId: 9,
+    request: {
+      method: 'sampling/createMessage',
+      params: {
+        messages: [
+          {
+            role: 'user',
+            content: { type: 'text', text: 'hello' },
+          },
+        ],
+        maxTokens: 16,
+      },
+    },
+    contextMeta: { trace: 'local' },
+    signal: abort.signal,
+  })
+})

--- a/runtime/tests/session/mcp-startup.test.ts
+++ b/runtime/tests/session/mcp-startup.test.ts
@@ -26,6 +26,7 @@ import {
   createSessionMcpManagerFromConfig,
   createSessionMcpManagerFromEnv,
   createSessionMcpManagerFromSources,
+  createSessionMcpSamplingHandlers,
   createSessionMcpService,
   getMcpConfigFromConfig,
   getMcpConfigFromEnv,
@@ -58,10 +59,16 @@ const mockCreatePromptBridge = vi.mocked(createPromptBridge);
 function stubManager() {
   const setCallObserver = vi.fn();
   const setElicitationHandlers = vi.fn();
+  const setSamplingHandlers = vi.fn();
   return {
-    manager: { setCallObserver, setElicitationHandlers } as unknown as MCPManager,
+    manager: {
+      setCallObserver,
+      setElicitationHandlers,
+      setSamplingHandlers,
+    } as unknown as MCPManager,
     setCallObserver,
     setElicitationHandlers,
+    setSamplingHandlers,
   };
 }
 
@@ -146,16 +153,71 @@ beforeEach(() => {
 
 describe("mcp-startup.attachMcpManagerToSession", () => {
   it("installs a call observer on the manager", () => {
-    const { manager, setCallObserver, setElicitationHandlers } = stubManager();
+    const {
+      manager,
+      setCallObserver,
+      setElicitationHandlers,
+      setSamplingHandlers,
+    } = stubManager();
     const { session } = stubSession();
 
     attachMcpManagerToSession(manager, session);
 
     expect(setCallObserver).toHaveBeenCalledOnce();
     expect(setElicitationHandlers).toHaveBeenCalledOnce();
+    expect(setSamplingHandlers).toHaveBeenCalledOnce();
     const observer = setCallObserver.mock.calls[0]![0]!;
     expect(typeof observer.onBegin).toBe("function");
     expect(typeof observer.onEnd).toBe("function");
+  });
+
+  it("routes MCP sampling requests through the session provider", async () => {
+    const providerChat = vi.fn(async () => ({
+      content: "sampled response",
+      toolCalls: [],
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      model: "grok-4.3",
+      finishReason: "stop" as const,
+    }));
+    const session = {
+      provider: {
+        chat: providerChat,
+      },
+    } as unknown as Session;
+    const handlers = createSessionMcpSamplingHandlers(session);
+
+    const result = await handlers.createMessage({
+      serverName: "srv",
+      requestId: 7,
+      request: {
+        id: 7,
+        method: "sampling/createMessage",
+        params: {
+          messages: [
+            {
+              role: "user",
+              content: { type: "text", text: "Summarize this" },
+            },
+          ],
+          systemPrompt: "Be brief",
+          maxTokens: 32,
+        },
+      } as never,
+    });
+
+    expect(providerChat).toHaveBeenCalledWith(
+      [{ role: "user", content: "Summarize this" }],
+      { systemPrompt: "Be brief", maxOutputTokens: 32 },
+    );
+    expect(result).toEqual({
+      role: "assistant",
+      model: "grok-4.3",
+      stopReason: "endTurn",
+      content: {
+        type: "text",
+        text: "sampled response",
+      },
+    });
   });
 
   it("passes session granular MCP elicitation policy into handlers", async () => {


### PR DESCRIPTION
## Summary
- complete verifier follow-ups for native Gemini auth, Vertex inference, and cached content handling
- wire MCP sampling through session-owned primary and legacy MCP stacks
- remove remaining telemetry/export scaffolding and stale docs/comments
- add daemon overload rate-limit coverage and sync protocol/SDK contract tests

## Test plan
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test -- tests/llm/providers/gemini/provider.test.ts tests/llm/provider.test.ts tests/services/mcp/hostCapabilities.test.ts tests/services/mcp/client-sdk-setup.test.ts tests/mcp-client/connection.test.ts tests/mcp-client/resilient-client.test.ts tests/session/mcp-startup.test.ts tests/gaphunt3/mcp-client-resilient-client.test.ts tests/app-server/protocol.contract.test.ts tests/app-server/sdk-client.contract.test.ts tests/app-server/daemon-dispatcher.contract.test.ts tests/shell-command/bash-ast-security.test.ts
- npm test
- npm run validate:runtime
- npm run sbom -- --output /tmp/agenc-core.spdx.json && npm run check:sbom -- --input /tmp/agenc-core.spdx.json
- strict telemetry/export grep returned no matches for removed vendor/export scaffolding