### PR TITLE
fix(onboarding): collect API key before connection check

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ Start the interactive TUI:
 npm run start
 ```
 
+### First-run onboarding
+
+On a clean `AGENC_HOME`, the TUI walks new users through:
+
+```text
+Preflight -> Theme -> Provider -> API key -> Connection check -> Security -> Terminal setup
+```
+
+The API key step verifies and saves a BYOK provider key before the connection
+check runs. If the user skips the key, the connection check still runs next and
+reports whether the selected provider is ready, local-only, managed by the
+AgenC account, or missing credentials.
+
 Run a one-shot prompt without the TUI:
 
 ```bash

--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -152,8 +152,8 @@ const FIRST_RUN_STEP_ORDER: readonly FirstRunOnboardingStepId[] = Object.freeze(
   "preflight",
   "theme",
   "provider",
-  "connection-test",
   "api-key",
+  "connection-test",
   "security",
   "terminal-setup",
 ]);
@@ -283,6 +283,21 @@ function withCompletedStep(
   };
 }
 
+function withCompletedSteps(
+  state: FirstRunOnboardingState,
+  ids: readonly FirstRunOnboardingStepId[],
+  next: FirstRunOnboardingStepId | null,
+): FirstRunOnboardingState {
+  const completed = new Set(state.completedStepIds);
+  for (const id of ids) completed.add(id);
+  return {
+    ...state,
+    completedStepIds: [...completed],
+    ...(next !== null ? { currentStepId: next } : {}),
+    error: null,
+  };
+}
+
 function parseTheme(raw: string, current: string): string | null {
   const input = raw.trim().toLowerCase();
   if (input === "" || input === "next") return current;
@@ -382,6 +397,20 @@ function onboardingSlashCommandError(raw: string): string | null {
 function apiKeyVerificationErrorMessage(error: string | undefined): string {
   const base = error?.trim() || "API key verification failed.";
   return `${base} Type next or skip to continue without saving, or paste a replacement key.`;
+}
+
+function verifiedApiKeyConnection(
+  provider: BuiltInProviderSlug,
+  model: string,
+): ProviderConnectionCheck {
+  return {
+    provider,
+    model,
+    status: "ready",
+    ok: true,
+    detail: "Provider API key verified.",
+    keyEnvVar: BUILT_IN_PROVIDER_API_KEY_ENVS[provider],
+  };
 }
 
 function captureApiKeyPaste(
@@ -752,7 +781,7 @@ export async function submitFirstRunOnboardingInput(
             pendingApiKeyApproval: null,
           },
           "provider",
-          "connection-test",
+          "api-key",
         ),
         completed: false,
       };
@@ -774,7 +803,7 @@ export async function submitFirstRunOnboardingInput(
         state: withCompletedStep(
           { ...state, connection },
           "connection-test",
-          "api-key",
+          "security",
         ),
         completed: false,
       };
@@ -796,7 +825,7 @@ export async function submitFirstRunOnboardingInput(
             state: withCompletedStep(
               { ...state, pendingApiKeyApproval: null },
               "api-key",
-              "security",
+              "connection-test",
             ),
             completed: false,
           };
@@ -835,9 +864,16 @@ export async function submitFirstRunOnboardingInput(
           };
         }
         return {
-          state: withCompletedStep(
-            { ...state, pendingApiKeyApproval: null },
-            "api-key",
+          state: withCompletedSteps(
+            {
+              ...state,
+              pendingApiKeyApproval: null,
+              connection: verifiedApiKeyConnection(
+                state.selectedProvider,
+                state.selectedModel,
+              ),
+            },
+            ["api-key", "connection-test"],
             "security",
           ),
           completed: false,
@@ -854,7 +890,7 @@ export async function submitFirstRunOnboardingInput(
             };
           }
           return {
-            state: withCompletedStep(state, "api-key", "security"),
+            state: withCompletedStep(state, "api-key", "connection-test"),
             completed: false,
           };
         }
@@ -1067,6 +1103,17 @@ function apiKeyInstructionForConnection(
   return `Paste ${connection.keyEnvVar} to verify it, or type next or skip to add it later.`;
 }
 
+function apiKeyInstructionForProvider(provider: BuiltInProviderSlug): string {
+  const keyEnvVar = BUILT_IN_PROVIDER_API_KEY_ENVS[provider];
+  if (!KEY_REQUIRED_PROVIDERS.has(provider)) {
+    return "This provider can continue without a BYOK API key. Type next to continue.";
+  }
+  if (keyEnvVar === undefined) {
+    return "Paste an API key to verify it, or type next or skip to add it later.";
+  }
+  return `Paste ${keyEnvVar} to verify it, or type next or skip to add it later.`;
+}
+
 function securityLinesForContext(
   context: FirstRunOnboardingContext,
 ): readonly string[] {
@@ -1128,8 +1175,8 @@ export function detailLinesForStep(
       const connection = state.connection;
       if (connection === null) {
         return [
-          "Connection check has not run yet.",
-          "Paste an API key to verify it, or type next to continue without saving.",
+          `Provider: ${state.selectedProvider}`,
+          apiKeyInstructionForProvider(state.selectedProvider),
         ];
       }
       return [

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -130,11 +130,10 @@ describe("first-run onboarding wizard", () => {
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
-    state = (await submitFirstRunOnboardingInput(state, "test", context)).state;
     return state;
   }
 
-  test("advances through provider selection, connection check, and completion", async () => {
+  test("advances through provider selection, API key, connection check, and completion", async () => {
     const config = defaultConfig();
     const context = { config, env: {}, checkLocalProviders: false };
     let state = createInitialFirstRunOnboardingState(context);
@@ -151,15 +150,16 @@ describe("first-run onboarding wizard", () => {
 
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
     expect(state.selectedProvider).toBe("grok");
+    expect(state.currentStepId).toBe("api-key");
+
+    state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     expect(state.currentStepId).toBe("connection-test");
 
     state = (await submitFirstRunOnboardingInput(state, "test", context)).state;
-    expect(state.currentStepId).toBe("api-key");
+    expect(state.currentStepId).toBe("security");
     expect(state.connection?.status).toBe("needs-key");
     expect(state.connection?.keyEnvVar).toBe("XAI_API_KEY");
 
-    state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
-    expect(state.currentStepId).toBe("security");
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     expect(state.currentStepId).toBe("terminal-setup");
     const result = await submitFirstRunOnboardingInput(state, "done", context);
@@ -403,7 +403,7 @@ describe("first-run onboarding wizard", () => {
     );
   });
 
-  test("rejects invalid theme, provider, and connection-test input", async () => {
+  test("rejects invalid theme, provider, API-key, and connection-test input", async () => {
     const config = defaultConfig();
     const context = { config, env: {}, checkLocalProviders: false };
     let state = createInitialFirstRunOnboardingState(context);
@@ -419,6 +419,11 @@ describe("first-run onboarding wizard", () => {
     expect(result.state.error).toContain("provider");
 
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
+    result = await submitFirstRunOnboardingInput(state, "later", context);
+    expect(result.state.currentStepId).toBe("api-key");
+    expect(result.state.error).toContain("next or skip");
+
+    state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     result = await submitFirstRunOnboardingInput(state, "later", context);
     expect(result.state.currentStepId).toBe("connection-test");
     expect(result.state.error).toContain("connection check");
@@ -521,13 +526,8 @@ describe("first-run onboarding wizard", () => {
     };
     let state = await advanceToApiKey(context);
 
-    expect(state.connection).toMatchObject({
-      ok: false,
-      status: "provider-unreachable",
-      keyEnvVar: "XAI_API_KEY",
-    });
     expect(detailLinesForStep(state, context).join("\n")).toContain(
-      "Type next or skip",
+      "Paste XAI_API_KEY",
     );
 
     let result = await submitFirstRunOnboardingInput(
@@ -543,7 +543,19 @@ describe("first-run onboarding wizard", () => {
       "/skip",
       context,
     );
+    expect(result.state.currentStepId).toBe("connection-test");
+
+    result = await submitFirstRunOnboardingInput(
+      result.state,
+      "test",
+      context,
+    );
     expect(result.state.currentStepId).toBe("security");
+    expect(result.state.connection).toMatchObject({
+      ok: false,
+      status: "provider-unreachable",
+      keyEnvVar: "XAI_API_KEY",
+    });
   });
 
   test("accepts slash aliases for onboarding navigation", async () => {
@@ -558,9 +570,12 @@ describe("first-run onboarding wizard", () => {
 
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
-    state = (await submitFirstRunOnboardingInput(state, "test", context)).state;
     state = (
       await submitFirstRunOnboardingInput(state, "/skip", context)
+    ).state;
+    expect(state.currentStepId).toBe("connection-test");
+    state = (
+      await submitFirstRunOnboardingInput(state, "/test", context)
     ).state;
     expect(state.currentStepId).toBe("security");
   });
@@ -594,7 +609,7 @@ describe("first-run onboarding wizard", () => {
       });
 
       state = (await submitFirstRunOnboardingInput(state, "no", context)).state;
-      expect(state.currentStepId).toBe("security");
+      expect(state.currentStepId).toBe("connection-test");
       await expect(
         new LocalAuthBackend({ agencHome }).readByokKey("grok"),
       ).resolves.toBeUndefined();
@@ -679,7 +694,7 @@ describe("first-run onboarding wizard", () => {
         "no",
         validContext,
       );
-      expect(declined.state.currentStepId).toBe("security");
+      expect(declined.state.currentStepId).toBe("connection-test");
       await expect(
         retrievePastedText({ agencHome, hash: omittedHash }),
       ).resolves.toBeNull();
@@ -765,7 +780,6 @@ describe("first-run onboarding wizard", () => {
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
-    state = (await submitFirstRunOnboardingInput(state, "test", context)).state;
     expect(state.currentStepId).toBe("api-key");
 
     result = await submitFirstRunOnboardingInput(
@@ -782,9 +796,11 @@ describe("first-run onboarding wizard", () => {
       "disable sandbox",
       context,
     );
-    expect(result.state.currentStepId).toBe("security");
-    expect(result.state.error).toContain("Type next");
+    expect(result.state.currentStepId).toBe("connection-test");
+    expect(result.state.error).toContain("connection check");
 
+    state = (await submitFirstRunOnboardingInput(state, "test", context)).state;
+    expect(state.currentStepId).toBe("security");
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     result = await submitFirstRunOnboardingInput(
       state,


### PR DESCRIPTION
## Summary
- Reorder first-run onboarding so API key collection happens before provider connection check.
- Treat a verified BYOK key as satisfying the connection check and move straight to security.
- Document the first-run onboarding order in the README.

## Verification
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test -- tests/onboarding/onboarding.test.tsx tests/onboarding/useApiKeyVerification.test.ts --reporter=dot
- npm run build