### PR TITLE
fix(remote): require login for device pairing

### DIFF
--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -12,14 +12,22 @@ Drive AgenC coding sessions running on your computer from the [AgenC iOS app](ht
 
 ## Device pairing
 
-Production account identity is a shared mock, so routing by account would put every phone in the same room. Instead we pair by *device*:
+Remote pairing requires a signed-in AgenC account. If the TUI/CLI does not have
+a valid remote login session, `/remote on` and `agenc remote on` stop before
+creating a code, calling the backend, or opening the relay.
 
-1. On the computer: `agenc remote on` prints an 8-char code and a QR encoding `agenc://pair?c=<code>`.
-2. The connector registers the pairing with the backend (a random 128-bit `pairingId` + a hashed host secret) and starts bridging on the room `pairingId`.
-3. In the app: scan the QR or type the code → the app calls `/v1/pair/claim` (bearer-gated) → the backend marks the pairing active and issues the app a signed *client ticket* for the same room.
-4. Both sides now share one isolated relay room. The QR surface auto-closes the moment the phone connects.
+Production routing still pairs by *device*, not by account room:
 
-**Security:** the backend mints every ticket; the host is gated by its secret, the claim by the app's bearer; the code is single-use; rooms are 128-bit and isolated; there is no server-side pairing list to enumerate.
+1. On the computer: sign in with `/login` or `AGENC_AUTH_BACKEND=remote agenc login`.
+2. Run `agenc remote on`; it sends the remote auth bearer to the backend, prints an 8-char code, and shows a QR encoding `agenc://pair?c=<code>`.
+3. The connector registers the pairing with the backend (a random 128-bit `pairingId` + a hashed host secret) and starts bridging on the room `pairingId`.
+4. In the app: scan the QR or type the code → the app calls `/v1/pair/claim` (bearer-gated) → the backend marks the pairing active and issues the app a signed *client ticket* for the same room.
+5. Both sides now share one isolated relay room. The QR surface auto-closes the moment the phone connects.
+
+**Security:** the backend mints every ticket; pair creation requires the
+computer's remote auth bearer, the host is gated by its secret, the claim by the
+app's bearer; the code is single-use; rooms are 128-bit and isolated; there is
+no server-side pairing list to enumerate.
 
 ## The `/remote` command
 

--- a/runtime/src/auth/session-state.ts
+++ b/runtime/src/auth/session-state.ts
@@ -57,6 +57,12 @@ export function hasRemoteAuthSessionSync(
   return readRemoteAuthSessionSync(env) !== null;
 }
 
+export function remoteAuthSessionTokenSync(
+  env: EnvSnapshot = process.env,
+): string | undefined {
+  return readRemoteAuthSessionSync(env)?.token as string | undefined;
+}
+
 export function remoteAuthSessionSubscriptionTierSync(
   env: EnvSnapshot = process.env,
 ): AuthSubscriptionTier | undefined {

--- a/runtime/src/bin/remote-cli.ts
+++ b/runtime/src/bin/remote-cli.ts
@@ -20,7 +20,11 @@ import { join } from "node:path";
 import QRCode from "qrcode";
 import WebSocket from "ws";
 
+import { remoteAuthSessionTokenSync } from "../auth/session-state.js";
+
 const DEFAULT_BACKEND = "https://id.agenc.ag";
+const REMOTE_LOGIN_REQUIRED_MESSAGE =
+  "Not logged in. Run `/login` in the TUI or `AGENC_AUTH_BACKEND=remote agenc login` before using remote pairing.";
 
 export interface RemoteCliCommand {
   readonly kind: "on" | "off" | "status" | "help";
@@ -112,10 +116,14 @@ interface PostResult {
 async function postJson(
   url: string,
   body: Record<string, unknown>,
+  authToken?: string,
 ): Promise<PostResult> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(authToken !== undefined ? { authorization: `Bearer ${authToken}` } : {}),
+    },
     body: JSON.stringify(body),
   });
   let json: Record<string, unknown> = {};
@@ -218,6 +226,12 @@ export async function runAgenCRemoteCli(command: RemoteCliCommand): Promise<numb
   }
 
   // command.kind === "on"
+  const authToken = remoteAuthSessionTokenSync();
+  if (authToken === undefined) {
+    process.stderr.write(`${REMOTE_LOGIN_REQUIRED_MESSAGE}\n`);
+    return 1;
+  }
+
   let pair = readPairFile();
   let pairingId: string;
   let hostSecret: string;
@@ -230,7 +244,7 @@ export async function runAgenCRemoteCli(command: RemoteCliCommand): Promise<numb
     const { status, json } = await postJson(`${backend}/v1/pair/host-poll`, {
       pairingId: pair.pairingId,
       hostSecret: pair.hostSecret,
-    });
+    }, authToken);
     if (status === 410) {
       rmSync(pairPath(), { force: true });
       process.stdout.write("This Mac was unlinked from the phone — re-pairing.\n");
@@ -250,7 +264,7 @@ export async function runAgenCRemoteCli(command: RemoteCliCommand): Promise<numb
 
   if (!pair) {
     const name = hostname() || "A Mac";
-    const { status, json } = await postJson(`${backend}/v1/pair/start`, { machineName: name });
+    const { status, json } = await postJson(`${backend}/v1/pair/start`, { machineName: name }, authToken);
     if (status !== 200 || typeof json.pairingId !== "string") {
       process.stderr.write(`Could not start pairing (${status}).\n`);
       return 1;
@@ -274,7 +288,7 @@ export async function runAgenCRemoteCli(command: RemoteCliCommand): Promise<numb
     // Wait for the phone to redeem the code.
     for (;;) {
       await sleep(2000);
-      const poll = await postJson(`${backend}/v1/pair/host-poll`, { pairingId, hostSecret });
+      const poll = await postJson(`${backend}/v1/pair/host-poll`, { pairingId, hostSecret }, authToken);
       if (poll.status === 410) {
         process.stderr.write("Pairing was revoked. Run `agenc remote on` to try again.\n");
         return 1;
@@ -293,7 +307,15 @@ export async function runAgenCRemoteCli(command: RemoteCliCommand): Promise<numb
     }
   }
 
-  return runConnector({ relayUrl: relayUrl!, pairingId: pairingId!, hostSecret: hostSecret!, backend, initialHostTicket: hostTicket!, machineName: machineName! });
+  return runConnector({
+    relayUrl: relayUrl!,
+    pairingId: pairingId!,
+    hostSecret: hostSecret!,
+    backend,
+    initialHostTicket: hostTicket!,
+    machineName: machineName!,
+    authToken,
+  });
 }
 
 interface ConnectorArgs {
@@ -303,6 +325,7 @@ interface ConnectorArgs {
   backend: string;
   initialHostTicket: string;
   machineName: string;
+  authToken: string;
   /** True when run inside the agent TUI (the /remote surface): suppress all stdout/stderr (raw
    *  writes corrupt the Ink render) and never process.exit (it would kill the session). */
   quiet?: boolean;
@@ -313,7 +336,7 @@ interface ConnectorArgs {
  *  hostSecret) on every reconnect, so it stays short-lived and this Mac never signs its own.
  *  Fire-and-forget: starts the relay connection + reconnect loop and returns immediately. */
 function startBridge(args: ConnectorArgs): void {
-  const { relayUrl, pairingId, hostSecret, backend, machineName } = args;
+  const { relayUrl, pairingId, hostSecret, backend, machineName, authToken } = args;
   const DAEMON = daemonUrl();
   const out = (msg: string) => { if (!args.quiet) process.stdout.write(msg); };
   const dbg = (msg: string) => { if (!args.quiet && process.env.AGENC_REMOTE_DEBUG) process.stderr.write(msg); };
@@ -387,7 +410,7 @@ function startBridge(args: ConnectorArgs): void {
       const { status, json } = await postJson(`${backend}/v1/pair/host-poll`, {
         pairingId,
         hostSecret,
-      });
+      }, authToken);
       if (status === 410) return null; // unlinked
       if (status === 200 && typeof json.hostTicket === "string") return json.hostTicket;
     } catch {
@@ -512,13 +535,17 @@ export interface RemoteOnStarted {
  */
 export async function startRemoteOn(): Promise<RemoteOnStarted | { message: string }> {
   const backend = backendUrl();
+  const authToken = remoteAuthSessionTokenSync();
+  if (authToken === undefined) {
+    return { message: REMOTE_LOGIN_REQUIRED_MESSAGE };
+  }
 
   const existing = readPairFile();
   if (existing) {
     const { status, json } = await postJson(`${backend}/v1/pair/host-poll`, {
       pairingId: existing.pairingId,
       hostSecret: existing.hostSecret,
-    });
+    }, authToken);
     if (status === 200 && typeof json.hostTicket === "string") {
       startBridge({
         relayUrl: (json.relayUrl as string) ?? existing.relayUrl,
@@ -527,6 +554,7 @@ export async function startRemoteOn(): Promise<RemoteOnStarted | { message: stri
         backend,
         initialHostTicket: json.hostTicket,
         machineName: existing.machineName,
+        authToken,
         quiet: true,
       });
       return { message: `● Remote access ON — already linked to “${existing.machineName}”. Drive this Mac from your phone.` };
@@ -535,7 +563,7 @@ export async function startRemoteOn(): Promise<RemoteOnStarted | { message: stri
   }
 
   const name = hostname() || "A Mac";
-  const { status, json } = await postJson(`${backend}/v1/pair/start`, { machineName: name });
+  const { status, json } = await postJson(`${backend}/v1/pair/start`, { machineName: name }, authToken);
   if (status !== 200 || typeof json.pairingId !== "string") {
     return { message: `Could not start pairing (${status}). Check your connection.` };
   }
@@ -551,7 +579,7 @@ export async function startRemoteOn(): Promise<RemoteOnStarted | { message: stri
     backendUrl: backend,
     createdAt: new Date().toISOString(),
   });
-  startBridge({ relayUrl, pairingId, hostSecret, backend, initialHostTicket: hostTicket, machineName: name, quiet: true });
+  startBridge({ relayUrl, pairingId, hostSecret, backend, initialHostTicket: hostTicket, machineName: name, authToken, quiet: true });
 
   const code = String(json.code ?? "");
   const box = await renderCodeBox(code, pairingDeepLink(code), json.expiresAt as string | undefined, {
@@ -564,7 +592,7 @@ export async function startRemoteOn(): Promise<RemoteOnStarted | { message: stri
     for (let i = 0; i < 90; i += 1) {
       await sleep(2000);
       try {
-        const poll = await postJson(`${backend}/v1/pair/host-poll`, { pairingId, hostSecret });
+        const poll = await postJson(`${backend}/v1/pair/host-poll`, { pairingId, hostSecret }, authToken);
         if (poll.status === 200 && poll.json.status === "active") {
           return (poll.json.appLabel as string) || "your phone";
         }

--- a/runtime/tests/commands/remote.test.ts
+++ b/runtime/tests/commands/remote.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { remoteCommand } from 'src/commands/remote.js'
-import { runRemoteSlash } from 'src/bin/remote-cli.js'
+import { runRemoteSlash, startRemoteOn } from 'src/bin/remote-cli.js'
+
+const ORIGINAL_AGENC_HOME = process.env.AGENC_HOME
+
+afterEach(() => {
+  if (ORIGINAL_AGENC_HOME === undefined) delete process.env.AGENC_HOME
+  else process.env.AGENC_HOME = ORIGINAL_AGENC_HOME
+  vi.restoreAllMocks()
+})
 
 describe('/remote slash command', () => {
   it('is an immediate command named remote', () => {
@@ -21,5 +33,24 @@ describe('/remote slash command', () => {
       argsRaw: 'status',
     } as unknown as Parameters<typeof remoteCommand.execute>[0])
     expect(result.kind).toBe('text')
+  })
+
+  it('does not start pairing without a remote login session', async () => {
+    const agencHome = mkdtempSync(join(tmpdir(), 'agenc-remote-no-login-'))
+    process.env.AGENC_HOME = agencHome
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('network should not be touched'))
+    try {
+      const result = await startRemoteOn()
+
+      expect(result).toEqual({
+        message:
+          'Not logged in. Run `/login` in the TUI or `AGENC_AUTH_BACKEND=remote agenc login` before using remote pairing.',
+      })
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      rmSync(agencHome, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Require a valid remote login session before `/remote on` or `agenc remote on` can create/reuse a pairing.
- Send the remote auth bearer to pairing endpoints when creating or polling host tickets.
- Document the no-login/no-pairing rule in the remote-control guide.

## Verification
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test -- tests/commands/remote.test.ts tests/auth/remote-token-path.test.ts tests/auth/backends/remote.contract.test.ts --reporter=dot
- npm run build