### PR TITLE
feat(runtime): map MCP sampling preferences

### DIFF
--- a/runtime/src/llm/providers/bedrock/index.ts
+++ b/runtime/src/llm/providers/bedrock/index.ts
@@ -433,9 +433,18 @@ function buildRequest(
   ];
   const maxTokens = positiveInteger(options?.maxOutputTokens) ??
     positiveInteger(config.maxTokens);
-  const temperature = typeof config.temperature === "number" &&
+  const optionTemperature = typeof options?.temperature === "number" &&
+      Number.isFinite(options.temperature)
+    ? options.temperature
+    : undefined;
+  const configTemperature = typeof config.temperature === "number" &&
       Number.isFinite(config.temperature)
     ? config.temperature
+    : undefined;
+  const temperature = optionTemperature ?? configTemperature;
+  const stopSequences = options?.stopSequences !== undefined &&
+      options.stopSequences.length > 0
+    ? [...options.stopSequences]
     : undefined;
   const tools = requestTools(config, options);
   const toolConfig = buildToolConfig(tools, options?.toolChoice);
@@ -443,11 +452,12 @@ function buildRequest(
   return {
     messages: built.messages,
     ...(system.length > 0 ? { system } : {}),
-    ...(maxTokens !== undefined || temperature !== undefined
+    ...(maxTokens !== undefined || temperature !== undefined || stopSequences !== undefined
       ? {
         inferenceConfig: {
           ...(maxTokens !== undefined ? { maxTokens } : {}),
           ...(temperature !== undefined ? { temperature } : {}),
+          ...(stopSequences !== undefined ? { stopSequences } : {}),
         },
       }
       : {}),

--- a/runtime/src/llm/providers/gemini/index.ts
+++ b/runtime/src/llm/providers/gemini/index.ts
@@ -454,6 +454,12 @@ function geminiGenerationConfig(
     finiteInteger(defaultMaxTokens) ??
     DEFAULT_GEMINI_MAX_OUTPUT_TOKENS;
   const config: Record<string, unknown> = { maxOutputTokens };
+  if (typeof options?.temperature === "number" && Number.isFinite(options.temperature)) {
+    config.temperature = options.temperature;
+  }
+  if (options?.stopSequences !== undefined && options.stopSequences.length > 0) {
+    config.stopSequences = [...options.stopSequences];
+  }
   const structuredSchema = options?.structuredOutput?.schema;
   if (options?.structuredOutput?.enabled || structuredSchema) {
     config.responseMimeType = "application/json";

--- a/runtime/src/llm/providers/ollama/adapter.ts
+++ b/runtime/src/llm/providers/ollama/adapter.ts
@@ -749,7 +749,9 @@ export class OllamaProvider implements LLMProvider {
 
     // Build model options
     const modelOptions: Record<string, unknown> = {};
-    if (this.config.temperature !== undefined)
+    if (options?.temperature !== undefined)
+      modelOptions.temperature = options.temperature;
+    else if (this.config.temperature !== undefined)
       modelOptions.temperature = this.config.temperature;
     if (
       typeof (options?.maxOutputTokens ?? this.config.maxTokens) === "number" &&
@@ -761,6 +763,9 @@ export class OllamaProvider implements LLMProvider {
       );
     if (this.config.numCtx !== undefined) modelOptions.num_ctx = this.config.numCtx;
     if (this.config.numGpu !== undefined) modelOptions.num_gpu = this.config.numGpu;
+    if (options?.stopSequences !== undefined && options.stopSequences.length > 0) {
+      modelOptions.stop = [...options.stopSequences];
+    }
     if (Object.keys(modelOptions).length > 0) params.options = modelOptions;
 
     if (this.config.keepAlive !== undefined)

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -561,6 +561,10 @@ export interface LLMChatOptions {
   readonly contextWindowTokens?: number;
   /** Positive output-token budget for this request. */
   readonly maxOutputTokens?: number;
+  /** Request-scoped sampling temperature when the provider exposes it. */
+  readonly temperature?: number;
+  /** Request-scoped stop sequences when the provider exposes them. */
+  readonly stopSequences?: readonly string[];
   /**
    * Optional stable session key passed to providers that expose a
    * prompt-cache routing hint (xAI `prompt_cache_key`, etc.). Pure

--- a/runtime/src/llm/wire/chat-completions.ts
+++ b/runtime/src/llm/wire/chat-completions.ts
@@ -164,6 +164,15 @@ export function buildChatCompletionsRequest(
   if (input.options?.parallelToolCalls !== undefined) {
     body.parallel_tool_calls = input.options.parallelToolCalls;
   }
+  if (input.options?.temperature !== undefined) {
+    body.temperature = input.options.temperature;
+  }
+  if (
+    input.options?.stopSequences !== undefined &&
+    input.options.stopSequences.length > 0
+  ) {
+    body.stop = [...input.options.stopSequences];
+  }
   // Strip fields the destination provider rejects. Hints are
   // adapter-populated; an undefined `acceptsX` flag preserves the
   // pre-hint behavior of "include if caller supplied a value", so

--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -281,6 +281,15 @@ export function buildAnthropicMessagesRequest(
   };
 
   if (system.length > 0) body.system = system;
+  if (input.options?.temperature !== undefined) {
+    body.temperature = input.options.temperature;
+  }
+  if (
+    input.options?.stopSequences !== undefined &&
+    input.options.stopSequences.length > 0
+  ) {
+    body.stop_sequences = [...input.options.stopSequences];
+  }
   const structuredOutputTool = buildAnthropicStructuredOutputTool(input.options);
   const tools = structuredOutputTool
     ? [...input.tools, structuredOutputTool]

--- a/runtime/src/llm/wire/responses-openai.ts
+++ b/runtime/src/llm/wire/responses-openai.ts
@@ -290,6 +290,9 @@ export function buildOpenAIResponsesRequest(
   if (input.options?.serviceTier !== undefined) {
     body.service_tier = input.options.serviceTier;
   }
+  if (input.options?.temperature !== undefined) {
+    body.temperature = input.options.temperature;
+  }
   const maxOutputTokens =
     positiveInteger(input.maxOutputTokens) ??
     positiveInteger(input.options?.maxOutputTokens);

--- a/runtime/src/services/mcp/hostCapabilities.ts
+++ b/runtime/src/services/mcp/hostCapabilities.ts
@@ -4,6 +4,7 @@ import {
   ListRootsRequestSchema,
   type CreateMessageRequest,
   type CreateMessageResult,
+  type CreateMessageResultWithTools,
   type ListRootsResult,
 } from '@modelcontextprotocol/sdk/types.js'
 import { pathToFileURL } from 'node:url'
@@ -19,7 +20,7 @@ export interface McpSamplingHandlers {
     readonly request: CreateMessageRequest
     readonly contextMeta?: unknown
     readonly signal?: AbortSignal
-  }): Promise<CreateMessageResult>
+  }): Promise<CreateMessageResult | CreateMessageResultWithTools>
 }
 
 export interface McpHostRequestHandlerOptions {
@@ -42,7 +43,9 @@ export function buildMcpHostClientCapabilities(
 ): Record<string, unknown> {
   return {
     roots: {},
-    sampling: {},
+    sampling: {
+      tools: {},
+    },
     ...(elicitationMode === 'empty'
       ? { elicitation: {} }
       : elicitationMode === 'form-url'
@@ -104,7 +107,7 @@ export function configureMcpHostRequestHandlers(
     async (
       request: CreateMessageRequest,
       extra?: McpRequestHandlerExtra,
-    ): Promise<CreateMessageResult> => {
+    ): Promise<CreateMessageResult | CreateMessageResultWithTools> => {
       logMCPDebug(serverName, `Received sampling/createMessage request from server`)
       if (options.samplingHandlers !== undefined) {
         const contextMeta = request.params?._meta ?? extra?._meta

--- a/runtime/src/session/mcp-startup.ts
+++ b/runtime/src/session/mcp-startup.ts
@@ -25,6 +25,7 @@ import { dirname, join, parse } from "node:path";
 import type {
   CreateMessageRequest,
   CreateMessageResult,
+  CreateMessageResultWithTools,
   SamplingMessageContentBlock,
 } from "@modelcontextprotocol/sdk/types.js";
 
@@ -32,7 +33,14 @@ import type { MCPManager, MCPManagerStartOpts } from "../mcp-client/manager.js";
 import { MCPManager as LiveMCPManager } from "../mcp-client/manager.js";
 import type { MCPToolBridgePermissionOptions } from "../mcp-client/tools.js";
 import type { MCPServerConfig } from "../mcp-client/types.js";
-import type { LLMContentPart, LLMMessage } from "../llm/types.js";
+import type {
+  LLMChatOptions,
+  LLMContentPart,
+  LLMMessage,
+  LLMResponse,
+  LLMTool,
+  LLMToolChoice,
+} from "../llm/types.js";
 import type { AgenCConfig, McpServerConfig as AgenCMcpServerConfig } from "../config/schema.js";
 import { McpJsonConfigSchema, type McpServerConfig as ServiceMcpServerConfig } from "../services/mcp/types.js";
 import {
@@ -247,6 +255,88 @@ function samplingRequestToLlmMessages(
   }));
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function mcpSamplingModelHint(request: CreateMessageRequest): string | undefined {
+  const hints = request.params.modelPreferences?.hints;
+  if (!Array.isArray(hints)) return undefined;
+  for (const hint of hints) {
+    const name = nonEmptyString(hint.name);
+    if (name !== undefined) return name;
+  }
+  return undefined;
+}
+
+function mcpSamplingStopSequences(
+  request: CreateMessageRequest,
+): readonly string[] | undefined {
+  const sequences = request.params.stopSequences
+    ?.map((sequence) => sequence.trim())
+    .filter((sequence) => sequence.length > 0);
+  return sequences !== undefined && sequences.length > 0 ? sequences : undefined;
+}
+
+function mcpSamplingTools(
+  request: CreateMessageRequest,
+): readonly LLMTool[] | undefined {
+  const tools = request.params.tools;
+  if (tools === undefined || tools.length === 0) return undefined;
+  return tools.map((tool): LLMTool => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description ?? tool.title ?? tool.name,
+      parameters: tool.inputSchema,
+    },
+  }));
+}
+
+function mcpSamplingToolChoice(
+  request: CreateMessageRequest,
+): LLMToolChoice | undefined {
+  const mode = request.params.toolChoice?.mode;
+  if (mode === "auto" || mode === "required" || mode === "none") return mode;
+  return undefined;
+}
+
+function mcpSamplingChatOptions(
+  request: CreateMessageRequest,
+  signal: AbortSignal | undefined,
+): LLMChatOptions {
+  const model = mcpSamplingModelHint(request);
+  const maxOutputTokens = positiveInteger(request.params.maxTokens);
+  const temperature = finiteNumber(request.params.temperature);
+  const stopSequences = mcpSamplingStopSequences(request);
+  const tools = mcpSamplingTools(request);
+  const toolChoice = mcpSamplingToolChoice(request);
+  return {
+    ...(model !== undefined ? { model } : {}),
+    ...(request.params.systemPrompt !== undefined
+      ? { systemPrompt: request.params.systemPrompt }
+      : {}),
+    ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(stopSequences !== undefined ? { stopSequences } : {}),
+    ...(tools !== undefined ? { tools } : {}),
+    ...(toolChoice !== undefined ? { toolChoice } : {}),
+    ...(signal !== undefined ? { signal } : {}),
+  };
+}
+
 function mcpSamplingStopReason(
   finishReason: Awaited<ReturnType<Session["provider"]["chat"]>>["finishReason"],
 ): CreateMessageResult["stopReason"] {
@@ -262,6 +352,45 @@ function mcpSamplingStopReason(
     default:
       return "endTurn";
   }
+}
+
+function parseToolCallInput(argumentsJson: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(argumentsJson || "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function mcpSamplingResultContent(
+  response: LLMResponse,
+): CreateMessageResult["content"] | CreateMessageResultWithTools["content"] {
+  if (response.toolCalls.length === 0) {
+    return {
+      type: "text",
+      text: response.content,
+    };
+  }
+
+  const blocks: SamplingMessageContentBlock[] = [];
+  if (response.content.trim().length > 0) {
+    blocks.push({
+      type: "text",
+      text: response.content,
+    });
+  }
+  for (const toolCall of response.toolCalls) {
+    blocks.push({
+      type: "tool_use",
+      id: toolCall.id,
+      name: toolCall.name,
+      input: parseToolCallInput(toolCall.arguments),
+    });
+  }
+  return blocks;
 }
 
 function mcpSamplingAllowedForSession(session: Session): boolean {
@@ -283,10 +412,37 @@ function mcpSamplingCallId(
 }
 
 function mcpSamplingRequestSummary(request: CreateMessageRequest): string {
+  const modelPreferences = request.params.modelPreferences;
+  const modelHint = mcpSamplingModelHint(request);
+  const prioritySummary = modelPreferences
+    ? {
+      costPriority: finiteNumber(modelPreferences.costPriority),
+      speedPriority: finiteNumber(modelPreferences.speedPriority),
+      intelligencePriority: finiteNumber(modelPreferences.intelligencePriority),
+    }
+    : undefined;
   return JSON.stringify({
     messageCount: request.params.messages.length,
     hasSystemPrompt: request.params.systemPrompt !== undefined,
     maxTokens: request.params.maxTokens,
+    ...(request.params.temperature !== undefined
+      ? { temperature: request.params.temperature }
+      : {}),
+    ...(request.params.stopSequences !== undefined
+      ? { stopSequenceCount: request.params.stopSequences.length }
+      : {}),
+    ...(request.params.includeContext !== undefined
+      ? { includeContext: request.params.includeContext }
+      : {}),
+    ...(modelHint !== undefined ? { modelHint } : {}),
+    ...(prioritySummary !== undefined ? { modelPreferences: prioritySummary } : {}),
+    ...(request.params.tools !== undefined
+      ? { toolCount: request.params.tools.length }
+      : {}),
+    ...(request.params.toolChoice?.mode !== undefined
+      ? { toolChoice: request.params.toolChoice.mode }
+      : {}),
+    ...(request.params.metadata !== undefined ? { hasMetadata: true } : {}),
   });
 }
 
@@ -347,13 +503,7 @@ export function createSessionMcpSamplingHandlers(
       try {
         response = await session.provider.chat(
           samplingRequestToLlmMessages(request),
-          {
-            ...(request.params.systemPrompt !== undefined
-              ? { systemPrompt: request.params.systemPrompt }
-              : {}),
-            maxOutputTokens: request.params.maxTokens,
-            ...(signal !== undefined ? { signal } : {}),
-          },
+          mcpSamplingChatOptions(request, signal),
         );
       } catch (err) {
         emitSessionEvent(session, {
@@ -386,10 +536,7 @@ export function createSessionMcpSamplingHandlers(
         role: "assistant",
         model: response.model,
         stopReason: mcpSamplingStopReason(response.finishReason),
-        content: {
-          type: "text",
-          text: response.content,
-        },
+        content: mcpSamplingResultContent(response),
       };
     },
   };

--- a/runtime/tests/llm/providers/bedrock/provider.test.ts
+++ b/runtime/tests/llm/providers/bedrock/provider.test.ts
@@ -128,6 +128,8 @@ describe("providers/bedrock", () => {
         ],
         toolRouting: { allowedToolNames: ["lookup"] },
         toolChoice: { type: "function", name: "lookup" },
+        temperature: 0.4,
+        stopSequences: ["END"],
       },
     );
 
@@ -191,7 +193,11 @@ describe("providers/bedrock", () => {
           ],
         },
       ],
-      inferenceConfig: { maxTokens: 128, temperature: 0.2 },
+      inferenceConfig: {
+        maxTokens: 128,
+        temperature: 0.4,
+        stopSequences: ["END"],
+      },
       toolConfig: {
         tools: [
           {
@@ -223,7 +229,7 @@ describe("providers/bedrock", () => {
     expect(headers.get("authorization")).toBe(
       "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20240102/us-west-2/bedrock/aws4_request, " +
         "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, " +
-        "Signature=fce0b51b3833e2186a19397da2d5eb962c1dc56afed0a03ca0373fee8efdb852",
+        "Signature=14b03391fc44fbb9113c2e9314b5088756f27cbf2ebb6894bf6ec5aae8bb0713",
     );
   });
 

--- a/runtime/tests/llm/providers/gemini/provider.test.ts
+++ b/runtime/tests/llm/providers/gemini/provider.test.ts
@@ -70,7 +70,10 @@ describe("GeminiProvider", () => {
       fetchImpl,
     });
 
-    const response = await provider.chat([{ role: "user", content: "hello" }]);
+    const response = await provider.chat([{ role: "user", content: "hello" }], {
+      temperature: 0.25,
+      stopSequences: ["END"],
+    });
 
     expect(response.content).toBe("ok");
     const [requestUrl, init] = fetchImpl.mock.calls[0] ?? [];
@@ -83,7 +86,11 @@ describe("GeminiProvider", () => {
     const requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
     expect(requestBody).toMatchObject({
       contents: [{ role: "user", parts: [{ text: "hello" }] }],
-      generationConfig: { maxOutputTokens: 4096 },
+      generationConfig: {
+        maxOutputTokens: 4096,
+        temperature: 0.25,
+        stopSequences: ["END"],
+      },
     });
     expect("model" in requestBody).toBe(false);
     expect("store" in requestBody).toBe(false);

--- a/runtime/tests/llm/providers/ollama/provider.test.ts
+++ b/runtime/tests/llm/providers/ollama/provider.test.ts
@@ -111,6 +111,8 @@ describe("providers/ollama entrypoint", () => {
         model: "qwen2.5-coder:7b",
         maxOutputTokens: 64,
         systemPrompt: "Be terse.",
+        temperature: 0.1,
+        stopSequences: ["END"],
       },
     );
 
@@ -127,8 +129,10 @@ describe("providers/ollama entrypoint", () => {
       model: "qwen2.5-coder:7b",
       keep_alive: "10m",
       options: {
+        temperature: 0.1,
         num_predict: 64,
         num_ctx: 8192,
+        stop: ["END"],
       },
       messages: [
         { role: "system", content: "Be terse." },

--- a/runtime/tests/llm/wire/chat-completions.test.ts
+++ b/runtime/tests/llm/wire/chat-completions.test.ts
@@ -77,6 +77,21 @@ describe("buildChatCompletionsRequest", () => {
     expect(request.max_tokens).toBe(32_000);
   });
 
+  test("serializes request-scoped sampling controls", () => {
+    const request = buildChatCompletionsRequest({
+      model: "qwen-local",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      options: {
+        temperature: 0.2,
+        stopSequences: ["END"],
+      },
+    });
+
+    expect(request.temperature).toBe(0.2);
+    expect(request.stop).toEqual(["END"]);
+  });
+
   test("can target max_completion_tokens for providers that require it", () => {
     const request = buildChatCompletionsRequest({
       model: "gpt-5",

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -53,6 +53,21 @@ describe("buildAnthropicMessagesRequest", () => {
     expect(request.max_tokens).toBe(4096);
   });
 
+  test("serializes request-scoped sampling controls", () => {
+    const request = buildAnthropicMessagesRequest({
+      model: "claude-sonnet-4.5",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      options: {
+        temperature: 0.4,
+        stopSequences: ["END"],
+      },
+    });
+
+    expect(request.temperature).toBe(0.4);
+    expect(request.stop_sequences).toEqual(["END"]);
+  });
+
   test("folds developer messages into system blocks and omits them from turns", () => {
     const request = buildAnthropicMessagesRequest({
       model: "claude-sonnet-4.5",

--- a/runtime/tests/llm/wire/responses-openai.test.ts
+++ b/runtime/tests/llm/wire/responses-openai.test.ts
@@ -41,6 +41,19 @@ describe("buildOpenAIResponsesRequest", () => {
     expect(request.max_output_tokens).toBe(8192);
   });
 
+  test("serializes request-scoped temperature", () => {
+    const request = buildOpenAIResponsesRequest({
+      model: "gpt-5",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      options: {
+        temperature: 0.3,
+      },
+    });
+
+    expect(request.temperature).toBe(0.3);
+  });
+
   test("folds developer messages into instructions before current user input", () => {
     const request = buildOpenAIResponsesRequest({
       model: "gpt-5",

--- a/runtime/tests/services/mcp/hostCapabilities.test.ts
+++ b/runtime/tests/services/mcp/hostCapabilities.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
-import { configureMcpHostRequestHandlers } from './hostCapabilities.js'
+import {
+  buildMcpHostClientCapabilities,
+  configureMcpHostRequestHandlers,
+} from './hostCapabilities.js'
 
 type FakeHandler = (request?: unknown, extra?: unknown) => unknown
 
@@ -12,6 +15,13 @@ class FakeClient {
     this.handlers.push(handler)
   }
 }
+
+test('buildMcpHostClientCapabilities advertises tool-capable sampling', () => {
+  assert.deepEqual(buildMcpHostClientCapabilities(), {
+    roots: {},
+    sampling: { tools: {} },
+  })
+})
 
 test('configureMcpHostRequestHandlers delegates sampling/createMessage to injected handler', async () => {
   const client = new FakeClient()

--- a/runtime/tests/session/mcp-startup.test.ts
+++ b/runtime/tests/session/mcp-startup.test.ts
@@ -206,16 +206,78 @@ describe("mcp-startup.attachMcpManagerToSession", () => {
               content: { type: "text", text: "Summarize this" },
             },
           ],
+          modelPreferences: {
+            hints: [{ name: "grok-4.3-mini" }],
+            costPriority: 0.7,
+            speedPriority: 0.3,
+            intelligencePriority: 0.5,
+          },
           systemPrompt: "Be brief",
+          includeContext: "thisServer",
+          temperature: 0.2,
           maxTokens: 32,
+          stopSequences: ["END"],
+          tools: [
+            {
+              name: "lookup",
+              description: "Look up context.",
+              inputSchema: {
+                type: "object",
+                properties: { query: { type: "string" } },
+                required: ["query"],
+              },
+            },
+          ],
+          toolChoice: { mode: "none" },
+          metadata: { trace: "sampling-test" },
         },
       } as never,
     });
 
     expect(providerChat).toHaveBeenCalledWith(
       [{ role: "user", content: "Summarize this" }],
-      { systemPrompt: "Be brief", maxOutputTokens: 32 },
+      {
+        model: "grok-4.3-mini",
+        systemPrompt: "Be brief",
+        maxOutputTokens: 32,
+        temperature: 0.2,
+        stopSequences: ["END"],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              description: "Look up context.",
+              parameters: {
+                type: "object",
+                properties: { query: { type: "string" } },
+                required: ["query"],
+              },
+            },
+          },
+        ],
+        toolChoice: "none",
+      },
     );
+    const beginEvent = (session.emit as ReturnType<typeof vi.fn>).mock.calls[0]
+      ?.[0].msg;
+    expect(JSON.parse(beginEvent.payload.args)).toMatchObject({
+      messageCount: 1,
+      hasSystemPrompt: true,
+      maxTokens: 32,
+      temperature: 0.2,
+      stopSequenceCount: 1,
+      includeContext: "thisServer",
+      modelHint: "grok-4.3-mini",
+      modelPreferences: {
+        costPriority: 0.7,
+        speedPriority: 0.3,
+        intelligencePriority: 0.5,
+      },
+      toolCount: 1,
+      toolChoice: "none",
+      hasMetadata: true,
+    });
     const emittedTypes = (
       session.emit as ReturnType<typeof vi.fn>
     ).mock.calls.map((call) => call[0].msg.type);
@@ -274,6 +336,73 @@ describe("mcp-startup.attachMcpManagerToSession", () => {
       payload: {
         cause: "mcp_sampling_denied",
       },
+    });
+  });
+
+  it("returns provider tool calls as MCP sampling tool-use blocks", async () => {
+    const providerChat = vi.fn(async () => ({
+      content: "Need a lookup.",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "lookup",
+          arguments: "{\"query\":\"AgenC\"}",
+        },
+      ],
+      usage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 },
+      model: "grok-4.3",
+      finishReason: "tool_calls" as const,
+    }));
+    const session = {
+      provider: {
+        chat: providerChat,
+      },
+      emit: vi.fn(),
+      nextInternalSubId: vi.fn(() => "sub-0"),
+      sessionConfiguration: { approvalPolicy: { value: "never" } },
+    } as unknown as Session;
+    const handlers = createSessionMcpSamplingHandlers(session);
+
+    const result = await handlers.createMessage({
+      serverName: "srv",
+      requestId: 8,
+      request: {
+        id: 8,
+        method: "sampling/createMessage",
+        params: {
+          messages: [
+            {
+              role: "user",
+              content: { type: "text", text: "Use lookup" },
+            },
+          ],
+          maxTokens: 32,
+          tools: [
+            {
+              name: "lookup",
+              inputSchema: {
+                type: "object",
+                properties: { query: { type: "string" } },
+              },
+            },
+          ],
+        },
+      } as never,
+    });
+
+    expect(result).toEqual({
+      role: "assistant",
+      model: "grok-4.3",
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Need a lookup." },
+        {
+          type: "tool_use",
+          id: "call-1",
+          name: "lookup",
+          input: { query: "AgenC" },
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
## Summary
- Map MCP sampling model hints, temperature, stop sequences, tools, tool choice, system prompts, max tokens, and abort signals into runtime provider chat options.
- Serialize request-scoped temperature and stop sequences through supported provider wire adapters.
- Return MCP tool-use content blocks when provider sampling produces tool calls.

## Test plan
- git diff --check
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run test -- tests/services/mcp/hostCapabilities.test.ts tests/session/mcp-startup.test.ts tests/llm/wire/chat-completions.test.ts tests/llm/wire/responses-openai.test.ts tests/llm/wire/messages-anthropic.test.ts tests/llm/providers/gemini/provider.test.ts tests/llm/providers/bedrock/provider.test.ts tests/llm/providers/ollama/provider.test.ts
- commit hook: runtime build + package entrypoints + SDK generated types + TUI runtime startup smoke

## Notes
- Full npm test remains blocked by six auth/onboarding/TUI failures that reproduce on clean origin/main at ea23acb7d.