### PR TITLE
fix: use hosted backend for managed policy limits

### DIFF
--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -85,7 +85,7 @@ export const BUILT_IN_PROVIDER_BASE_URLS = Object.freeze({
   minimax: "https://api.minimax.io/v1",
   github: "https://api.githubcopilot.com",
   "amazon-bedrock": "https://bedrock-runtime.us-east-1.amazonaws.com",
-  agenc: "https://api.agenc.tech/v1",
+  agenc: "https://id.agenc.ag/v1",
 } as const satisfies Readonly<Record<BuiltInProviderSlug, string>>);
 
 export const BUILT_IN_PROVIDER_SCOPE_OMISSIONS = Object.freeze({} as const);

--- a/runtime/src/services/policyLimits/index.ts
+++ b/runtime/src/services/policyLimits/index.ts
@@ -36,7 +36,7 @@ export type {
 
 const POLICY_LIMITS_CACHE_FILENAME = "policy-limits.json" as const;
 const DEFAULT_POLICY_LIMITS_ENDPOINT =
-  "https://api.agenc.tech/v1/policy-limits" as const;
+  "https://id.agenc.ag/v1/policy-limits" as const;
 const POLICY_LIMITS_ENDPOINT_ENV = "AGENC_POLICY_LIMITS_URL" as const;
 const DEFAULT_POLICY_LIMITS_FETCH_TIMEOUT_MS = 10_000;
 const DEFAULT_POLICY_LIMITS_MAX_RETRIES = 5;
@@ -684,7 +684,10 @@ function isFirstPartyBaseURL(provider: string, value: string): boolean {
 
 function isAgenCHost(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
-  return normalized === "api.agenc.tech" || normalized.endsWith(".agenc.tech");
+  return normalized === "api.agenc.tech" ||
+    normalized.endsWith(".agenc.tech") ||
+    normalized === "agenc.ag" ||
+    normalized.endsWith(".agenc.ag");
 }
 
 function hasOwn(

--- a/runtime/tests/services/policyLimits/policyLimits.test.ts
+++ b/runtime/tests/services/policyLimits/policyLimits.test.ts
@@ -69,7 +69,7 @@ describe("policy limits service", () => {
     const service = createPolicyLimitsService({
       agencHome: home,
       providerName: "anthropic",
-      endpoint: "https://api.agenc.tech/v1/policy-limits",
+      endpoint: "https://id.agenc.ag/v1/policy-limits",
       sleep: async () => {},
       ...options,
     });
@@ -114,7 +114,7 @@ describe("policy limits service", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      "https://api.agenc.tech/v1/policy-limits",
+      "https://id.agenc.ag/v1/policy-limits",
     );
     expect(headersFromCall(fetchMock).get("x-api-key")).toBe(
       "direct-policy-key",
@@ -141,7 +141,7 @@ describe("policy limits service", () => {
     await service.loadPolicyLimits();
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      "https://api.agenc.tech/v1/policy-limits",
+      "https://id.agenc.ag/v1/policy-limits",
     );
   });
 
@@ -278,7 +278,7 @@ describe("policy limits service", () => {
       agencHome: fileHome,
       providerName: "anthropic",
       apiKey: "direct-policy-key",
-      endpoint: "https://api.agenc.tech/v1/policy-limits",
+      endpoint: "https://id.agenc.ag/v1/policy-limits",
       fetchImpl: vi.fn(async () =>
         response(200, {
           restrictions: { allow_remote_sessions: { allowed: false } },


### PR DESCRIPTION
## Summary\n- change the default policy-limits endpoint from the dead api.agenc.tech host to https://id.agenc.ag/v1/policy-limits\n- allow agenc.ag hosts as first-party policy endpoints, while keeping agenc.tech support for compatibility\n- update AgenC provider metadata away from api.agenc.tech\n\n## Verification\n- npm run typecheck\n- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/services/policyLimits/policyLimits.test.ts\n- npm run build