### PR TITLE
fix(runtime): fail fast for missing local models

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1871,6 +1871,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   async interruptAgentTurn(agentId: string, reason: string): Promise<boolean> {
     const active = this.#active.get(agentId);
     if (active === undefined || !isRunnableActiveAgent(active)) return false;
+    try {
+      await active.bootstrap.session.abortAllTasks("interrupted");
+    } catch {
+      /* interrupt delivery still falls through the managed thread path */
+    }
     void active.thread.submit({ type: "interrupt", reason }).catch(() => {
       /* interrupt delivery surfaces via session events */
     });

--- a/runtime/src/recovery/api-errors.ts
+++ b/runtime/src/recovery/api-errors.ts
@@ -19,6 +19,7 @@ import {
   LLMContextWindowExceededError,
   LLMInvalidResponseError,
   LLMMessageValidationError,
+  LLMProviderError,
 } from "../llm/errors.js";
 
 // ─────────────────────────────────────────────────────────────────────
@@ -224,8 +225,78 @@ export function isStreamingFallbackOccured(state: TurnState): boolean {
     lastAssistant.text !== undefined &&
     lastAssistant.text.length > 0 &&
     lastStreamError !== undefined &&
+    !isNonRecoverableProviderSetupError(lastStreamError) &&
     !isPartialProviderResponseError(lastStreamError) &&
     !isFallbackTriggeredError(lastStreamError)
+  );
+}
+
+const NON_RECOVERABLE_PROVIDER_SETUP_MARKERS = [
+  "openai_category=model_not_found",
+  "openai_category=endpoint_not_found",
+  "openai_category=tool_call_incompatible",
+  "model not found",
+  "model_not_found",
+  "unknown model",
+  "unavailable model",
+  "does not exist",
+] as const;
+
+function isNonRecoverableProviderSetupError(
+  err: unknown,
+  seen: Set<object> = new Set(),
+  depth = 0,
+): boolean {
+  if (depth > 4) return false;
+  if (isExplicitNonTransientProviderError(err)) return true;
+  if (err instanceof LLMProviderError) {
+    if (
+      err.statusCode !== undefined &&
+      err.statusCode >= 400 &&
+      err.statusCode < 500
+    ) {
+      return true;
+    }
+    if (hasNonRecoverableProviderSetupMarker(err.message)) return true;
+  } else if (err instanceof Error) {
+    if (hasNonRecoverableProviderSetupMarker(err.message)) return true;
+  }
+
+  if (!err || typeof err !== "object") return false;
+  if (seen.has(err)) return false;
+  seen.add(err);
+
+  const record = err as {
+    readonly cause?: unknown;
+    readonly errors?: unknown;
+    readonly originalError?: unknown;
+  };
+
+  if (isNonRecoverableProviderSetupError(record.cause, seen, depth + 1)) {
+    return true;
+  }
+  if (
+    isNonRecoverableProviderSetupError(
+      record.originalError,
+      seen,
+      depth + 1,
+    )
+  ) {
+    return true;
+  }
+  if (Array.isArray(record.errors)) {
+    return record.errors.some((nested) =>
+      isNonRecoverableProviderSetupError(nested, seen, depth + 1)
+    );
+  }
+
+  return false;
+}
+
+function hasNonRecoverableProviderSetupMarker(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return NON_RECOVERABLE_PROVIDER_SETUP_MARKERS.some((marker) =>
+    normalized.includes(marker)
   );
 }
 

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -116,6 +116,7 @@ function makeTopLevelRunner(opts: {
   const session = {
     conversationId: opts.conversationId,
     permissionModeRegistry,
+    abortAllTasks: vi.fn(async () => {}),
     eventLog: {
       subscribe: (listener: (event: unknown) => void) => {
         eventLogSubscribers.push(listener);
@@ -1132,8 +1133,8 @@ describe("AgenC delegate background-agent runner", () => {
     ).resolves.toMatchObject({ status: "idle" });
   });
 
-  it("[managed-thread] interruptAgentTurn submits interrupt op on managed thread", async () => {
-    const { runner, stub } = makeTopLevelRunner({
+  it("[managed-thread] interruptAgentTurn aborts the active session and submits interrupt op on managed thread", async () => {
+    const { runner, session, stub } = makeTopLevelRunner({
       conversationId: "session-interrupt",
     });
 
@@ -1151,6 +1152,7 @@ describe("AgenC delegate background-agent runner", () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(interrupted).toBe(true);
+    expect(session.abortAllTasks).toHaveBeenCalledWith("interrupted");
     expect(stub.thread.submit).toHaveBeenCalledWith({
       type: "interrupt",
       reason: "user_cancel",

--- a/runtime/tests/recovery/api-errors.test.ts
+++ b/runtime/tests/recovery/api-errors.test.ts
@@ -6,12 +6,14 @@ import {
   isMediaSizeError,
   isMediaTooLargeMessage,
   isPromptTooLongMessage,
+  isStreamingFallbackOccured,
   isTransientProviderError,
   isWithheld413Message,
   isWithheldMaxOutputTokens,
   parsePromptTooLongTokenCounts,
 } from "./api-errors.js";
-import type { AssistantMessage } from "../session/turn-state.js";
+import { LLMProviderError } from "../llm/errors.js";
+import type { AssistantMessage, TurnState } from "../session/turn-state.js";
 
 function mkMsg(
   text: string,
@@ -109,5 +111,49 @@ describe("isTransientProviderError", () => {
     (err401 as unknown as { status: number }).status = 401;
     expect(isTransientProviderError(err401)).toBe(false);
     expect(isTransientProviderError(new Error("syntax error"))).toBe(false);
+  });
+});
+
+describe("isStreamingFallbackOccured", () => {
+  function stateWithProviderError(error: unknown): TurnState {
+    return {
+      assistantMessages: [
+        mkMsg("provider failed", { apiError: "provider_error" }),
+      ],
+      lastStreamError: error,
+    } as unknown as TurnState & { lastStreamError: unknown };
+  }
+
+  test("generic provider stream errors still enter streaming fallback", () => {
+    expect(
+      isStreamingFallbackOccured(
+        stateWithProviderError(new Error("socket closed mid-stream")),
+      ),
+    ).toBe(true);
+  });
+
+  test("local model-not-found provider errors fail fast instead of fallback looping", () => {
+    const missingModel = new LLMProviderError(
+      "ollama",
+      "Ollama API error: model not found [openai_category=model_not_found]",
+      404,
+    );
+
+    expect(
+      isStreamingFallbackOccured(stateWithProviderError(missingModel)),
+    ).toBe(false);
+  });
+
+  test("nested deterministic provider setup errors are not streaming fallback", () => {
+    const wrapped = new Error("provider wrapper");
+    (wrapped as Error & { cause: Error }).cause = new LLMProviderError(
+      "lmstudio",
+      "OpenAI API error 404: Not Found [openai_category=endpoint_not_found]",
+      404,
+    );
+
+    expect(isStreamingFallbackOccured(stateWithProviderError(wrapped))).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Prevent deterministic local provider setup errors, including missing-model and endpoint-not-found responses, from entering the streaming fallback retry loop.
- Abort daemon-backed active session turns directly before submitting the managed-thread interrupt event so Esc stops loading turns promptly.
- Add regression coverage for missing local model fallback classification and interrupt cancellation routing.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/recovery/api-errors.test.ts tests/app-server/background-agent-runner.contract.test.ts tests/tui/daemon-session.contract.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm test (typecheck passed; vitest currently has unrelated auth/BYOK/bootstrap/onboarding API-key failures in the rebased main tree)