### PR TITLE
fix(runtime): bound local compatible output budget

### DIFF
--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -118,6 +118,18 @@ export class ModelMetadataResolver {
 
   async resolve(params: LookupParams): Promise<ResolvedModelMetadata> {
     const explicit = readExplicitConfigMetadata(params);
+    if (shouldPreferLiveEndpointOverExplicit(params, this.env)) {
+      const live = await this.resolveLiveEndpointMetadata(params);
+      if (hasAnyMetadata(live)) {
+        return this.finalize(
+          params,
+          mergeLiveEndpointMetadata(live, explicit),
+          "live_endpoint",
+          false,
+        );
+      }
+    }
+
     if (hasAnyMetadata(explicit)) {
       return this.finalize(params, explicit, "explicit_config", false);
     }
@@ -307,6 +319,53 @@ function shouldQueryLiveEndpoint(
     Boolean(providerConfig?.base_url?.trim()) ||
     Boolean(envBaseUrl(provider, env))
   );
+}
+
+function shouldPreferLiveEndpointOverExplicit(
+  params: LookupParams,
+  env: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return (
+    normalizeProvider(params.provider) === "openai-compatible" &&
+    shouldQueryLiveEndpoint(params, env)
+  );
+}
+
+function mergeLiveEndpointMetadata(
+  live: ModelMetadataValues,
+  explicit: ModelMetadataValues | undefined,
+): ModelMetadataValues {
+  return {
+    ...(live.contextWindow !== undefined
+      ? { contextWindow: live.contextWindow }
+      : explicit?.contextWindow !== undefined
+        ? { contextWindow: explicit.contextWindow }
+        : {}),
+    ...(live.maxContextWindow !== undefined
+      ? { maxContextWindow: live.maxContextWindow }
+      : explicit?.maxContextWindow !== undefined
+        ? { maxContextWindow: explicit.maxContextWindow }
+        : {}),
+    ...(explicit?.maxOutputTokens !== undefined
+      ? {
+        maxOutputTokens: explicit.maxOutputTokens,
+        maxOutputTokensUpperLimit:
+          explicit.maxOutputTokensUpperLimit ?? explicit.maxOutputTokens,
+        ...(explicit.maxOutputTokensExplicit !== undefined
+          ? { maxOutputTokensExplicit: explicit.maxOutputTokensExplicit }
+          : {}),
+      }
+      : live.maxOutputTokens !== undefined
+        ? {
+          maxOutputTokens: live.maxOutputTokens,
+          maxOutputTokensUpperLimit:
+            live.maxOutputTokensUpperLimit ?? live.maxOutputTokens,
+          ...(live.maxOutputTokensExplicit !== undefined
+            ? { maxOutputTokensExplicit: live.maxOutputTokensExplicit }
+            : {}),
+        }
+        : {}),
+  };
 }
 
 function readExplicitConfigMetadata(

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -70,6 +70,8 @@ const OPENAI_RESPONSES_INVALID_FUNCTION_CALL_MESSAGE =
 const OPENAI_STREAM_FAILED_MESSAGE = "OpenAI stream failed"; // branding-scan: allow real OpenAI provider identifier
 const OPENAI_CHAT_COMPLETIONS_INVALID_TOOL_CALL_MESSAGE =
   "OpenAI chat-completions stream emitted invalid tool_call"; // branding-scan: allow real OpenAI provider identifier
+const CHAT_COMPLETIONS_CONTEXT_SAFETY_BUFFER_TOKENS = 1024;
+const CHAT_COMPLETIONS_MIN_OUTPUT_TOKENS = 256;
 
 interface OpenAISseEvent {
   readonly event?: string;
@@ -742,18 +744,30 @@ export class OpenAIProvider implements LLMProvider {
     });
   }
 
-  private assertWithinContextWindow(
+  private fitRequestWithinContextWindow(
+    request: Record<string, unknown>,
     metadata: ChatCompletionsRequestMetadata,
     contextWindowTokens: number | undefined,
-  ): void {
+  ): ChatCompletionsRequestMetadata {
     if (contextWindowTokens === undefined || metadata.maxTokens === undefined) {
-      return;
+      return metadata;
+    }
+    const maxTokenField = metadata.maxTokenField;
+    if (maxTokenField === undefined) return metadata;
+    const availableOutputTokens = Math.floor(
+      contextWindowTokens -
+        metadata.estimatedPromptTokens -
+        CHAT_COMPLETIONS_CONTEXT_SAFETY_BUFFER_TOKENS,
+    );
+    if (metadata.maxTokens <= availableOutputTokens) return metadata;
+    if (availableOutputTokens >= CHAT_COMPLETIONS_MIN_OUTPUT_TOKENS) {
+      request[maxTokenField] = availableOutputTokens;
+      return collectChatCompletionsRequestMetadata(request);
     }
     const requestedTokens = metadata.estimatedPromptTokens + metadata.maxTokens;
-    if (requestedTokens <= contextWindowTokens) return;
     throw new LLMContextWindowExceededError(
       this.name,
-      `estimated prompt (${metadata.estimatedPromptTokens}) plus reserved output (${metadata.maxTokens}) exceeds context window (${contextWindowTokens})`,
+      `estimated prompt (${metadata.estimatedPromptTokens}) plus reserved output (${metadata.maxTokens}) exceeds context window (${contextWindowTokens}) after ${CHAT_COMPLETIONS_CONTEXT_SAFETY_BUFFER_TOKENS} token safety buffer`,
       {
         effectiveTokens: requestedTokens,
         maxTokens: contextWindowTokens,
@@ -786,12 +800,13 @@ export class OpenAIProvider implements LLMProvider {
       maxTokenField: this.resolveChatCompletionsMaxTokenField(),
       providerCapabilityHints,
     });
-    const metadata = collectChatCompletionsRequestMetadata(request);
-    this.emitRequestMetadata("chat_completions", metadata);
-    this.assertWithinContextWindow(
+    let metadata = collectChatCompletionsRequestMetadata(request);
+    metadata = this.fitRequestWithinContextWindow(
+      request,
       metadata,
       this.resolveContextWindowTokens(args.options),
     );
+    this.emitRequestMetadata("chat_completions", metadata);
     return request;
   }
 

--- a/runtime/tests/llm/models-manager.test.ts
+++ b/runtime/tests/llm/models-manager.test.ts
@@ -302,6 +302,51 @@ describe("StaticModelsManager", () => {
     expect(info.usedFallbackModelMetadata).toBe(false);
   });
 
+  it("prefers live openai-compatible context over stale configured context", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe("http://127.0.0.1:8001/v1/models");
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer local-token",
+      );
+      return jsonResponse({
+        data: [
+          {
+            id: "qwen3-coder-next-fp8",
+            max_model_len: 65_536,
+          },
+        ],
+      });
+    });
+    const manager = new StaticModelsManager({
+      config: mergeConfigs(defaultConfig(), {
+        model_provider: "openai-compatible",
+        model: "qwen3-coder-next-fp8",
+        providers: {
+          "openai-compatible": {
+            api_key_env: "OPENAI_COMPATIBLE_API_KEY",
+            base_url: "http://127.0.0.1:8001/v1",
+            default_model: "qwen3-coder-next-fp8",
+            context_window_tokens: 131_072,
+            max_output_tokens: 32_768,
+          },
+        },
+      }),
+      fallbackProvider: "openai-compatible",
+      metadata: {
+        fetchImpl,
+        env: {
+          OPENAI_COMPATIBLE_API_KEY: "local-token",
+        },
+      },
+    });
+
+    const info = await manager.getModelInfo("qwen3-coder-next-fp8");
+    expect(info.contextWindow).toBe(65_536);
+    expect(info.maxOutputTokens).toBe(32_768);
+    expect(info.usedFallbackModelMetadata).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("reads default generic openai-compatible endpoint metadata without requiring auth", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       expect(String(input)).toBe("http://localhost:8000/v1/models");

--- a/runtime/tests/llm/providers/openai/adapter.test.ts
+++ b/runtime/tests/llm/providers/openai/adapter.test.ts
@@ -587,7 +587,46 @@ describe("OpenAIProvider", () => {
     expectNoRequestMetadataWarning(emitWarning);
   });
 
-  test("fails before chat-completions network calls when the request exceeds the context window", async () => {
+  test("clamps chat-completions max_tokens to the remaining context window", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl_clamped",
+          model: "qwen3.6-35b-a3b-fp8",
+          choices: [
+            {
+              message: { role: "assistant", content: "ok" },
+              finish_reason: "stop",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const provider = new OpenAIProvider({
+      apiKey: "local-token",
+      model: "qwen3.6-35b-a3b-fp8",
+      baseURL: "http://127.0.0.1:8000/v1",
+      useResponsesApi: false,
+      contextWindowTokens: 2048,
+      maxTokens: 4096,
+      fetchImpl,
+    });
+
+    await provider.chat([{ role: "user", content: "hello" }]);
+
+    const request = JSON.parse(
+      String(fetchImpl.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>;
+    expect(typeof request.max_tokens).toBe("number");
+    expect(request.max_tokens as number).toBeLessThan(4096);
+    expect(request.max_tokens as number).toBeGreaterThanOrEqual(256);
+  });
+
+  test("fails before chat-completions network calls when no safe output room remains", async () => {
     const fetchImpl = vi.fn<typeof fetch>();
     const provider = new OpenAIProvider({
       apiKey: "local-token",


### PR DESCRIPTION
## Summary
- prefer live /models context metadata for configured openai-compatible endpoints
- clamp Chat Completions max_tokens to the remaining context window with a safety buffer
- keep a hard preflight failure when there is no safe output room left

## Verification
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/llm/providers/openai/adapter.test.ts tests/llm/models-manager.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm run build
- pre-commit build + check:tui-runtime-startup
- default agenc local smoke returned AGENC_CONTEXT_FIX_OK