### PR TITLE
fix(runtime): route managed bootstrap through OpenRouter

### DIFF
--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -191,8 +191,10 @@ function isSubscriptionEntitled(tier: AuthSubscriptionTier): boolean {
 }
 
 function providerHasLiveManagedSubscriptionRoute(provider: ProviderName): boolean {
-  return provider === "grok";
+  return provider === "openrouter";
 }
+
+const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
 
 function enforceRemoteSubscriptionGate(params: {
   readonly authBackend: AuthBackend | undefined;
@@ -341,7 +343,7 @@ function requireProviderApiKeyOrUndefined(params: {
   const envHint = providerApiKeyEnvHint(params.provider, params.providerSettings);
   if (envHint === undefined) return undefined;
   const managedKeyHint = !providerHasLiveManagedSubscriptionRoute(params.provider)
-    ? "Subscription-managed access is currently live for Grok only."
+    ? "Subscription-managed access is currently live for OpenRouter only."
     : params.managedKey.disabled
     ? "Managed key vending is disabled by auth.managedKeys.enabled."
     : params.managedKey.attempted
@@ -1078,6 +1080,11 @@ export async function bootstrapLocalRuntimeSession(
         ...(providerSettings?.maxOutputTokens !== undefined
           ? { maxTokens: providerSettings.maxOutputTokens }
           : {}),
+        ...(managedKey.baseURL !== undefined &&
+        resolvedProvider === "openrouter" &&
+        providerSettings?.maxOutputTokens === undefined
+          ? { maxTokens: MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS }
+          : {}),
         ...(providerFallback !== undefined
           ? { providerFallback }
           : {}),
@@ -1132,7 +1139,24 @@ export async function bootstrapLocalRuntimeSession(
   // can propose same-family larger-context-window models without
   // having to await a fresh catalog lookup.
   setContextWindowUpgradeContext({ currentModel: model, modelsManager });
-  const modelInfo = await modelsManager.getModelInfo(model);
+  const rawModelInfo = await modelsManager.getModelInfo(model);
+  const modelInfo =
+    managedKey.baseURL !== undefined &&
+    resolvedProvider === "openrouter" &&
+    providerSettings?.maxOutputTokens === undefined
+      ? {
+          ...rawModelInfo,
+          maxOutputTokens: MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS,
+          maxOutputTokensUpperLimit:
+            rawModelInfo.maxOutputTokensUpperLimit !== undefined
+              ? Math.min(
+                  rawModelInfo.maxOutputTokensUpperLimit,
+                  MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS,
+                )
+              : MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS,
+          maxOutputTokensCappedDefault: true,
+        }
+      : rawModelInfo;
   const baseSessionConfiguration = sessionConfigurationFromAgenCConfig({
     config: startup.config,
     workspaceRoot,

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -867,6 +867,8 @@ const MANAGED_KEY_PROVIDERS = new Set<ProviderName>([
   "openrouter",
 ]);
 
+const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
+
 function isRemoteAuthBackend(authBackend: AuthBackend | undefined): boolean {
   return authBackend?.kind === "remote";
 }
@@ -991,6 +993,13 @@ async function providerFactoryOptionsFromSettings(params: {
           model: params.model,
         })
       : undefined;
+  if (
+    managedCredential !== undefined &&
+    normalizedProvider === "openrouter" &&
+    params.settings?.maxOutputTokens === undefined
+  ) {
+    extra.maxTokens = MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS;
+  }
   const apiKey = params.settings?.apiKey ?? managedCredential?.apiKey;
   const baseURL = params.settings?.baseURL ?? managedCredential?.baseURL;
   return {


### PR DESCRIPTION
## Summary
- switch bootstrap subscription-managed provider guard from Grok to OpenRouter
- cap subscription-managed OpenRouter output tokens to 4096 by default so LiteLLM/OpenRouter budget caps do not reject normal requests
- keep BYOK and explicit max output token config untouched

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime
- npm test --workspace=@tetsuo-ai/runtime -- tests/commands/model.test.ts tests/commands/provider.test.ts tests/llm/provider.test.ts --run
- live smoke: agenc --print --provider openrouter --model x-ai/grok-4.3
- live smoke: agenc --print --provider openrouter --model google/gemini-2.5-flash-lite