### PR TITLE
fix(runtime): send base instructions for managed model turns

### DIFF
--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -68,6 +68,8 @@ import {
   type BuildToolRegistryOptions,
   type ToolRegistry,
 } from "../tool-registry.js";
+import { getSystemPrompt } from "../constants/prompts.js";
+import type { Tools as PromptTools } from "../tools/Tool.js";
 import { buildBootstrapToolRegistry } from "./bootstrap-tool-registry.js";
 import { UnifiedExecProcessManager } from "../unified-exec/process-manager.js";
 import { createCodeModeService } from "../tools/code-mode/service.js";
@@ -195,6 +197,17 @@ function providerHasLiveManagedSubscriptionRoute(provider: ProviderName): boolea
 }
 
 const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
+
+async function buildBaseInstructionsForModel(params: {
+  readonly registry: ToolRegistry;
+  readonly model: string;
+}): Promise<string> {
+  const sections = await getSystemPrompt(
+    params.registry.tools as unknown as PromptTools,
+    params.model,
+  );
+  return sections.join("\n\n");
+}
 
 function enforceRemoteSubscriptionGate(params: {
   readonly authBackend: AuthBackend | undefined;
@@ -1157,13 +1170,20 @@ export async function bootstrapLocalRuntimeSession(
           maxOutputTokensCappedDefault: true,
         }
       : rawModelInfo;
-  const baseSessionConfiguration = sessionConfigurationFromAgenCConfig({
-    config: startup.config,
-    workspaceRoot,
-    model,
-    provider: resolvedProvider,
-    projectTrust,
+  const baseInstructions = await buildBaseInstructionsForModel({
+    registry,
+    model: selectedProviderModel,
   });
+  const baseSessionConfiguration = {
+    ...sessionConfigurationFromAgenCConfig({
+      config: startup.config,
+      workspaceRoot,
+      model,
+      provider: resolvedProvider,
+      projectTrust,
+    }),
+    baseInstructions,
+  };
   const sessionConfiguration = cli.allowDangerouslySkipPermissions
     ? ({
         ...baseSessionConfiguration,

--- a/runtime/src/constants/prompts.ts
+++ b/runtime/src/constants/prompts.ts
@@ -622,8 +622,8 @@ export async function computeEnvInfo(
   } else {
     const marketingName = getMarketingNameForModel(modelId)
     modelDescription = marketingName
-      ? `You are powered by the model named ${marketingName}. The exact model ID is ${modelId}.`
-      : `You are powered by the model ${modelId}.`
+      ? `You are powered by the model named ${marketingName}. The exact model ID is ${modelId}. If asked what model you are, answer from this exact ID/name; do not claim to be ChatGPT, Claude, GPT-4, or another model family unless this ID/name says so.`
+      : `You are powered by the model ${modelId}. If asked what model you are, answer from this exact ID; do not claim to be ChatGPT, Claude, GPT-4, or another model family unless this ID says so.`
   }
 
   const additionalDirsInfo =
@@ -661,8 +661,8 @@ export async function computeSimpleEnvInfo(
   } else {
     const marketingName = getMarketingNameForModel(modelId)
     modelDescription = marketingName
-      ? `You are powered by the model named ${marketingName}. The exact model ID is ${modelId}.`
-      : `You are powered by the model ${modelId}.`
+      ? `You are powered by the model named ${marketingName}. The exact model ID is ${modelId}. If asked what model you are, answer from this exact ID/name; do not claim to be ChatGPT, Claude, GPT-4, or another model family unless this ID/name says so.`
+      : `You are powered by the model ${modelId}. If asked what model you are, answer from this exact ID; do not claim to be ChatGPT, Claude, GPT-4, or another model family unless this ID says so.`
   }
 
   const cutoff = getKnowledgeCutoff(modelId)

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -92,6 +92,8 @@ import {
   type DenialTrackingState,
 } from "../permissions/denial-tracking.js";
 import type { ConfigStore } from "../config/store.js";
+import { getSystemPrompt } from "../constants/prompts.js";
+import type { Tools as PromptTools } from "../tools/Tool.js";
 import {
   resolveProviderSettings,
   type ResolvedProviderSettings,
@@ -868,6 +870,17 @@ const MANAGED_KEY_PROVIDERS = new Set<ProviderName>([
 ]);
 
 const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
+
+async function buildBaseInstructionsForModel(params: {
+  readonly registry: ToolRegistry;
+  readonly model: string;
+}): Promise<string> {
+  const sections = await getSystemPrompt(
+    params.registry.tools as unknown as PromptTools,
+    params.model,
+  );
+  return sections.join("\n\n");
+}
 
 function isRemoteAuthBackend(authBackend: AuthBackend | undefined): boolean {
   return authBackend?.kind === "remote";
@@ -2109,6 +2122,10 @@ export class Session {
       this.services.modelsManager,
       preparedSwitch.model,
     );
+    const nextBaseInstructions = await buildBaseInstructionsForModel({
+      registry: this.services.registry,
+      model: preparedSwitch.model,
+    });
     const previousClient = readProviderHttpClient(liveProvider);
     const nextClient = readProviderHttpClient(preparedSwitch.instance);
 
@@ -2118,6 +2135,7 @@ export class Session {
           sessionConfiguration?: {
             provider?: unknown;
             collaborationMode?: { model?: string };
+            baseInstructions?: string;
           };
         }
       ).sessionConfiguration;
@@ -2127,6 +2145,7 @@ export class Session {
         ...(cfg.collaborationMode ?? {}),
         model: preparedSwitch.model,
       };
+      cfg.baseInstructions = nextBaseInstructions;
     });
 
     (this as { modelInfo: ModelInfo }).modelInfo = nextModelInfo;

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -620,6 +620,9 @@ export interface TurnContext {
   /** App-server client identifier. */
   readonly appServerClientName?: string;
 
+  /** Baseline system prompt for the active model/session. */
+  readonly baseInstructions?: string;
+
   /** Developer instructions (separate from user instructions). */
   readonly developerInstructions?: string;
 
@@ -1269,6 +1272,7 @@ export function buildTurnContext(opts: BuildTurnContextOptions): TurnContext {
     currentDate,
     timezone,
     appServerClientName: sc.appServerClientName,
+    baseInstructions: sc.baseInstructions,
     developerInstructions: sc.developerInstructions,
     compactPrompt: sc.compactPrompt,
     userInstructions: sc.userInstructions,


### PR DESCRIPTION
## Summary
- wire the generated AgenC system prompt into local runtime bootstrap as baseInstructions
- carry baseInstructions into TurnContext so provider calls receive the active model identity/instructions
- regenerate baseInstructions after /model provider switches
- strengthen model identity guidance so non-OpenAI models do not claim ChatGPT/Claude/GPT-4 unless the selected model ID says so

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime
- npm test --workspace=@tetsuo-ai/runtime -- tests/commands/model.test.ts tests/commands/provider.test.ts tests/llm/provider.test.ts --run
- live smoke: agenc --print --provider openrouter --model deepseek/deepseek-v4-flash "are you deepseek?" -> DeepSeek/OpenRouter answer
- raw LiteLLM smoke: responseModel=openrouter/deepseek/deepseek-v4-flash