### PR TITLE
fix(runtime): make OpenRouter managed routes provider-safe

### DIFF
--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -196,7 +196,7 @@ function providerHasLiveManagedSubscriptionRoute(provider: ProviderName): boolea
   return provider === "openrouter";
 }
 
-const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
+const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 2_048;
 
 async function buildBaseInstructionsForModel(params: {
   readonly registry: ToolRegistry;

--- a/runtime/src/llm/wire/mcp-tool-naming.ts
+++ b/runtime/src/llm/wire/mcp-tool-naming.ts
@@ -25,6 +25,7 @@ import { TextDecoder, TextEncoder } from "node:util";
 const INTERNAL_PREFIX = "mcp.";
 const WIRE_PREFIX = "mcp__";
 const ESCAPED_WIRE_PREFIX = "mcp2__";
+const GENERIC_ESCAPED_WIRE_PREFIX = "tool2__";
 const SEP = "__";
 const PROVIDER_FUNCTION_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 const WIRE_SAFE_SEGMENT_BYTE_PATTERN = /^[a-zA-Z0-9-]$/;
@@ -109,7 +110,12 @@ function decodeMcpNameSegment(segment: string): string | null {
  */
 export function encodeMcpToolNameForWire(name: string): string {
   const parts = splitInternalMcpToolName(name);
-  if (!parts) return name;
+  if (!parts) {
+    if (name.length === 0 || name.startsWith(INTERNAL_PREFIX)) return name;
+    if (isProviderToolNameSafe(name)) return name;
+    const escaped = `${GENERIC_ESCAPED_WIRE_PREFIX}${encodeMcpNameSegment(name)}`;
+    return isProviderToolNameSafe(escaped) ? escaped : name;
+  }
 
   if (!parts.server.includes(SEP)) {
     const legacyWireName = `${WIRE_PREFIX}${parts.server}${SEP}${parts.tool}`;
@@ -125,6 +131,13 @@ export function encodeMcpToolNameForWire(name: string): string {
  * tool name (e.g. `FileEdit`) round-trips unchanged.
  */
 export function decodeMcpToolNameFromWire(name: string): string {
+  if (name.startsWith(GENERIC_ESCAPED_WIRE_PREFIX)) {
+    const decoded = decodeMcpNameSegment(
+      name.slice(GENERIC_ESCAPED_WIRE_PREFIX.length),
+    );
+    return decoded ?? name;
+  }
+
   if (name.startsWith(ESCAPED_WIRE_PREFIX)) {
     const afterPrefix = name.slice(ESCAPED_WIRE_PREFIX.length);
     const sepIndex = afterPrefix.indexOf(SEP);

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -869,7 +869,7 @@ const MANAGED_KEY_PROVIDERS = new Set<ProviderName>([
   "openrouter",
 ]);
 
-const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
+const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 2_048;
 
 async function buildBaseInstructionsForModel(params: {
   readonly registry: ToolRegistry;

--- a/runtime/tests/llm/wire/mcp-tool-naming.test.ts
+++ b/runtime/tests/llm/wire/mcp-tool-naming.test.ts
@@ -61,6 +61,20 @@ describe("MCP tool-name wire encoding", () => {
     );
   });
 
+  test("escapes non-MCP internal tool names rejected by strict providers", () => {
+    const systemSearchWire = encodeMcpToolNameForWire("system.searchTools");
+    expect(systemSearchWire).toBe("tool2__system_x2esearchTools");
+    expect(isProviderToolNameSafe(systemSearchWire)).toBe(true);
+    expect(decodeMcpToolNameFromWire(systemSearchWire)).toBe(
+      "system.searchTools",
+    );
+
+    const dottedWire = encodeMcpToolNameForWire("foo.bar-baz");
+    expect(dottedWire).toBe("tool2__foo_x2ebar-baz");
+    expect(isProviderToolNameSafe(dottedWire)).toBe(true);
+    expect(decodeMcpToolNameFromWire(dottedWire)).toBe("foo.bar-baz");
+  });
+
   test("decodes mcp__<server>__<tool> back to the dotted form", () => {
     expect(decodeMcpToolNameFromWire("mcp__memory__search_nodes")).toBe(
       "mcp.memory.search_nodes",
@@ -105,6 +119,8 @@ describe("MCP tool-name wire encoding", () => {
       "mcp.server.do__stuff", // tool name with __
       "mcp.serv__er.foo",
       "mcp.plugin:sample:local.ping",
+      "system.searchTools",
+      "foo.bar-baz",
       "FileEdit",
       "exec_command",
       "TodoWrite",
@@ -127,6 +143,8 @@ describe("MCP tool-name wire encoding", () => {
       "mcp.design_tooling.get_design_context",
       "mcp.plugin:sample:local.ping",
       "mcp.serv__er.foo",
+      "system.searchTools",
+      "foo.bar-baz",
     ];
     for (const internal of cases) {
       const wire = encodeMcpToolNameForWire(internal);


### PR DESCRIPTION
## Summary
- encode non-MCP internal tool names like system.searchTools for strict OpenAI/OpenRouter tool-name validation
- decode those wire names back before dispatch, preserving existing MCP behavior
- lower subscription-managed OpenRouter default output cap from 4096 to 2048 to reduce per-request budget failures

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- tests/llm/wire/mcp-tool-naming.test.ts tests/commands/model.test.ts tests/commands/provider.test.ts tests/llm/provider.test.ts --run
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime
- route sweep before provider-credit exhaustion: 19/19 direct gateway routes returned the requested responseModel with sufficient max_tokens
- CLI route sweep after tool-name fix is now blocked by OpenRouter account credit: 402 Insufficient credits, no longer tool-name validation