### PR TITLE
fix(runtime): cap managed OpenRouter budget errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ vending locally:
 AGENC_AUTH_BACKEND=remote AGENC_AUTH_MANAGED_KEYS_ENABLED=true agenc login
 ```
 
+Paid hosted model access currently routes through the AgenC OpenRouter gateway.
+See [`docs/managed-openrouter.md`](docs/managed-openrouter.md) for the model
+surface, output-token caps, and budget-limit behavior.
+
 Common flags:
 
 ```text

--- a/docs/managed-openrouter.md
+++ b/docs/managed-openrouter.md
@@ -1,0 +1,45 @@
+# Managed OpenRouter Models
+
+Paid AgenC accounts can use hosted model access without setting provider API
+keys locally. The CLI signs in through the remote auth backend, asks
+`id.agenc.ag` for a short-lived managed credential, and sends model traffic to
+the AgenC LiteLLM/OpenRouter gateway.
+
+## Runtime Flow
+
+1. `agenc login` stores the remote auth token in `AGENC_HOME/auth.json`.
+2. The TUI or CLI reads the subscription tier from the auth backend.
+3. With `AGENC_AUTH_MANAGED_KEYS_ENABLED=true`, paid users can select managed
+   OpenRouter models from `/provider` or `/model`.
+4. The backend vends a LiteLLM key for the session. The local CLI keeps it in
+   provider memory only; it is not written as a provider API key.
+5. The provider sends requests to the managed gateway with the model normalized
+   as `openrouter/<provider>/<model>`.
+
+BYOK still wins. If a user has `OPENROUTER_API_KEY` or provider config API keys,
+those credentials are used instead of the subscription-managed route.
+
+## Output Cap
+
+Managed OpenRouter routes default to `2048` output tokens unless the user's
+provider config explicitly sets `max_output_tokens`. This cap is applied both at
+startup and after `/model` or `/provider` switches so catalog metadata such as
+`128000` does not become the reserved `max_tokens` value on the provider call.
+
+## Budget Errors
+
+OpenRouter can reject managed requests when the workspace/key is out of credits,
+the monthly key budget is too low, or the request reserves too many output
+tokens for the remaining allowance. The CLI must not show raw upstream JSON,
+OpenRouter key URLs, or provider account identifiers. Users should see a short
+message telling them to use a smaller response/model or that the hosted
+OpenRouter allowance needs to be topped up.
+
+When debugging production, check these layers in order:
+
+1. User subscription is active on the backend.
+2. `/v1/auth/llm-credential` returns a managed OpenRouter credential.
+3. LiteLLM key allowlist includes the selected `openrouter/...` model.
+4. OpenRouter workspace has credits and the key monthly limit is high enough.
+5. The CLI request uses the managed `2048` default unless the user configured a
+   smaller or larger explicit cap.

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -127,6 +127,61 @@ function providerHttpBodyToString(body: unknown): string {
   }
 }
 
+function readNestedProviderMessage(value: unknown, depth = 0): string | undefined {
+  if (depth > 5 || value === null || value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.message === "string") return record.message;
+  if (typeof record.error === "string") return record.error;
+  const nestedError = readNestedProviderMessage(record.error, depth + 1);
+  if (nestedError !== undefined) return nestedError;
+  if (Array.isArray(record.previous_errors)) {
+    for (const item of record.previous_errors) {
+      const itemMessage = readNestedProviderMessage(item, depth + 1);
+      if (itemMessage !== undefined) return itemMessage;
+    }
+  }
+  if (Array.isArray(record.previousErrors)) {
+    for (const item of record.previousErrors) {
+      const itemMessage = readNestedProviderMessage(item, depth + 1);
+      if (itemMessage !== undefined) return itemMessage;
+    }
+  }
+  return undefined;
+}
+
+function isOpenRouterBudgetLimitFailure(args: {
+  readonly providerName: string;
+  readonly status: number;
+  readonly body: unknown;
+  readonly message: string;
+}): boolean {
+  if (args.providerName !== "openrouter") return false;
+  if (args.status !== 402 && args.status !== 403 && args.status !== 429) {
+    return false;
+  }
+  const nested = readNestedProviderMessage(args.body);
+  const text = `${args.message}\n${nested ?? ""}\n${providerHttpBodyToString(args.body)}`;
+  const lower = text.toLowerCase();
+  return (
+    lower.includes("requires more credits") ||
+    lower.includes("insufficient credits") ||
+    lower.includes("monthly limit") ||
+    (lower.includes("can only afford") && lower.includes("max_tokens"))
+  );
+}
+
+function openRouterBudgetLimitErrorMessage(): string {
+  return [
+    "managed OpenRouter budget limit reached.",
+    "Try a shorter request/response or choose a smaller model.",
+    "If this is a paid AgenC subscription, the hosted OpenRouter key needs more credits or a higher monthly allowance.",
+    "[openai_category=rate_limited]",
+    "Hint: upstream account and key details were redacted.",
+  ].join(" ");
+}
+
 function errorCode(error: unknown): string | undefined {
   let current: unknown = error;
   for (let depth = 0; depth < 5; depth += 1) {
@@ -275,6 +330,13 @@ function mapOpenAIHttpFailureToError(args: {
   readonly body: unknown;
   readonly retryAfterMs?: number;
 }): Error {
+  if (isOpenRouterBudgetLimitFailure(args)) {
+    return new LLMProviderError(
+      args.providerName,
+      openRouterBudgetLimitErrorMessage(),
+      args.status,
+    );
+  }
   const bodyText = providerHttpBodyToString(args.body);
   const failure = classifyOpenAIHttpFailure({
     status: args.status,

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -871,6 +871,27 @@ const MANAGED_KEY_PROVIDERS = new Set<ProviderName>([
 
 const MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS = 2_048;
 
+function isManagedGatewayProviderOptions(
+  options: ProviderFactoryOptions | undefined,
+): boolean {
+  return options?.extra?.managedGateway === true;
+}
+
+function capManagedOpenRouterModelInfo(modelInfo: ModelInfo): ModelInfo {
+  return {
+    ...modelInfo,
+    maxOutputTokens: MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS,
+    maxOutputTokensUpperLimit:
+      modelInfo.maxOutputTokensUpperLimit !== undefined
+        ? Math.min(
+            modelInfo.maxOutputTokensUpperLimit,
+            MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS,
+          )
+        : MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS,
+    maxOutputTokensCappedDefault: true,
+  };
+}
+
 async function buildBaseInstructionsForModel(params: {
   readonly registry: ToolRegistry;
   readonly model: string;
@@ -2054,6 +2075,7 @@ export class Session {
     }
 
     let preparedSwitch: PreparedProviderSwitch;
+    let targetProviderSettings: ResolvedProviderSettings | undefined;
     try {
       const targetNormalizedProvider = normalizeProviderName(resolvedProvider);
       const liveProviderIdentity = readProviderIdentity(
@@ -2068,7 +2090,7 @@ export class Session {
           : undefined;
       const configStore = (this.services as Partial<SessionServices>)
         .configStore;
-      const targetProviderSettings =
+      targetProviderSettings =
         targetNormalizedProvider !== null && configStore?.current
           ? resolveProviderSettings(
               targetNormalizedProvider,
@@ -2118,10 +2140,19 @@ export class Session {
       return { applied: false, reason };
     }
 
-    const nextModelInfo = await deriveNextModelInfo(
+    const rawNextModelInfo = await deriveNextModelInfo(
       this.services.modelsManager,
       preparedSwitch.model,
     );
+    const preparedSwitchOptions = readProviderFactoryOptions(
+      preparedSwitch.instance,
+    );
+    const nextModelInfo =
+      normalizeProviderName(preparedSwitch.provider) === "openrouter" &&
+      isManagedGatewayProviderOptions(preparedSwitchOptions) &&
+      targetProviderSettings?.maxOutputTokens === undefined
+        ? capManagedOpenRouterModelInfo(rawNextModelInfo)
+        : rawNextModelInfo;
     const nextBaseInstructions = await buildBaseInstructionsForModel({
       registry: this.services.registry,
       model: preparedSwitch.model,

--- a/runtime/tests/llm/providers/openai/adapter.test.ts
+++ b/runtime/tests/llm/providers/openai/adapter.test.ts
@@ -538,6 +538,58 @@ describe("OpenAIProvider", () => {
     expectNoRequestMetadataWarning(emitWarning);
   });
 
+  test("redacts OpenRouter managed budget errors", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            message:
+              "This request requires more credits, or fewer max_tokens. You requested up to 128000 tokens, but can only afford 48795. To increase, visit https://openrouter.ai/workspaces/default/keys/d1c7a95e8d4f8808ad9cdbf6c4a257650cc07e7e2be6afaba263ac58a32af514 and adjust the key's monthly limit",
+            code: 402,
+            metadata: {
+              previous_errors: [
+                {
+                  code: 402,
+                  message:
+                    "This request requires more credits, or fewer max_tokens. user_id=user_3FtLIoOmuZCXYUQSkEKiiHSWvIo",
+                },
+              ],
+            },
+          },
+        }),
+        {
+          status: 402,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const provider = new OpenAIProvider({
+      apiKey: "managed-key",
+      providerName: "openrouter",
+      model: "openrouter/openai/gpt-5-nano",
+      baseURL: "https://llm.agenc.tech/v1",
+      useResponsesApi: false,
+      fetchImpl,
+    });
+
+    await expect(
+      provider.chat([{ role: "user", content: "hello" }], {
+        maxOutputTokens: 128_000,
+      }),
+    ).rejects.toMatchObject({
+      name: "LLMProviderError",
+      message: expect.stringContaining(
+        "managed OpenRouter budget limit reached",
+      ),
+      statusCode: 402,
+    });
+    await expect(
+      provider.chat([{ role: "user", content: "hello" }], {
+        maxOutputTokens: 128_000,
+      }),
+    ).rejects.not.toThrow(/d1c7a95e8d4f|user_3FtLIoOmu|openrouter\.ai\/workspaces|128000/);
+  });
+
   test("rejects chat-completions non-stream tool calls with invalid JSON", async () => {
     const emitWarning = vi.fn();
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(

--- a/runtime/tests/session/session.test.ts
+++ b/runtime/tests/session/session.test.ts
@@ -65,6 +65,16 @@ import {
 import type { AuthBackend } from "../auth/backend.js";
 import { clearSession } from "../commands/clear.js";
 
+;(globalThis as Record<string, unknown>).MACRO ??= {
+  VERSION: "test-version",
+  DISPLAY_VERSION: "test-version",
+  BUILD_TIME: "test-build-time",
+  ISSUES_EXPLAINER: "open an issue",
+  PACKAGE_URL: "@tetsuo-ai/agenc",
+  NATIVE_PACKAGE_URL: undefined,
+  FEEDBACK_CHANNEL: "support",
+};
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers
 // ─────────────────────────────────────────────────────────────────────
@@ -816,12 +826,10 @@ describe("Session.consumePendingProviderSwitch", () => {
     );
   });
 
-  it("uses AuthBackend-managed keys for live managed routes without BYOK", async () => {
+  it("caps managed OpenRouter switches to the hosted output-token default", async () => {
     await withEnv(
       {
-        XAI_API_KEY: undefined,
-        GROK_API_KEY: undefined,
-        AGENC_XAI_API_KEY: undefined,
+        OPENROUTER_API_KEY: undefined,
       },
       async () => {
         const calls: string[] = [];
@@ -835,13 +843,13 @@ describe("Session.consumePendingProviderSwitch", () => {
             return {
               provider,
               sessionId,
-              apiKey: "managed-grok-key",
+              apiKey: "managed-openrouter-key",
               baseUrl: "https://llm.agenc.tech",
             };
           },
           inferAgencModel: () => ({
-            provider: "grok",
-            model: "grok-4.3",
+            provider: "openrouter",
+            model: "openai/gpt-5-nano",
           }),
           getSubscriptionTier: () => "team",
         };
@@ -858,26 +866,42 @@ describe("Session.consumePendingProviderSwitch", () => {
                 auth: { managedKeys: { enabled: true } },
               }),
             },
+            modelsManager: {
+              getModelInfo: async (model: string) => ({
+                ...mkModelInfo(),
+                slug: model,
+                contextWindow: 128_000,
+                maxOutputTokens: 128_000,
+                maxOutputTokensUpperLimit: 128_000,
+              }),
+            },
           },
         });
         session.setPendingProviderSwitch({
-          provider: "grok",
-          model: "grok-4.3",
+          provider: "openrouter",
+          model: "openai/gpt-5-nano",
         });
 
         const applied = await session.consumePendingProviderSwitch();
 
         expect(applied).toEqual({
           applied: true,
-          provider: "grok",
-          model: "grok-4.3",
+          provider: "openrouter",
+          model: "openrouter/openai/gpt-5-nano",
         });
-        expect(calls).toEqual(["vendKey:grok:conv-test"]);
+        expect(calls).toEqual(["vendKey:openrouter:conv-test"]);
         expect(readProviderFactoryOptions(session.services.provider)).toMatchObject({
-          apiKey: "managed-grok-key",
+          apiKey: "managed-openrouter-key",
           baseURL: "https://llm.agenc.tech",
-          model: "grok-4.3",
+          model: "openrouter/openai/gpt-5-nano",
+          extra: {
+            managedGateway: true,
+            maxTokens: 2048,
+          },
         });
+        expect(session.modelInfo.maxOutputTokens).toBe(2048);
+        expect(session.modelInfo.maxOutputTokensUpperLimit).toBe(2048);
+        expect(session.modelInfo.maxOutputTokensCappedDefault).toBe(true);
       },
     );
   });
@@ -944,15 +968,13 @@ describe("Session.consumePendingProviderSwitch", () => {
   it("rejects free remote managed-key switches before vending", async () => {
     await withEnv(
       {
-        XAI_API_KEY: undefined,
-        GROK_API_KEY: undefined,
-        AGENC_XAI_API_KEY: undefined,
+        OPENROUTER_API_KEY: undefined,
       },
       async () => {
         const vendKey = vi.fn(() => ({
-          provider: "grok",
+          provider: "openrouter",
           sessionId: "conv-test",
-          apiKey: "managed-grok-key",
+          apiKey: "managed-openrouter-key",
         }));
         const authBackend: AuthBackend = {
           kind: "remote",
@@ -961,8 +983,8 @@ describe("Session.consumePendingProviderSwitch", () => {
           whoami: () => ({ authenticated: true, provider: "remote" }),
           vendKey,
           inferAgencModel: () => ({
-            provider: "grok",
-            model: "grok-4.3",
+            provider: "openrouter",
+            model: "openai/gpt-5-nano",
           }),
           getSubscriptionTier: () => "free",
         };
@@ -983,8 +1005,8 @@ describe("Session.consumePendingProviderSwitch", () => {
           },
         });
         session.setPendingProviderSwitch({
-          provider: "grok",
-          model: "grok-4.3",
+          provider: "openrouter",
+          model: "openai/gpt-5-nano",
         });
 
         const applied = await session.consumePendingProviderSwitch();


### PR DESCRIPTION
## Summary
- cap managed OpenRouter model metadata after /model and /provider switches so catalog output windows like 128000 do not become request max_tokens
- sanitize OpenRouter budget/credit errors before they reach CLI/TUI users
- document managed OpenRouter runtime behavior and budget limits

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- tests/session/session.test.ts tests/llm/providers/openai/adapter.test.ts tests/commands/model.test.ts tests/commands/provider.test.ts tests/llm/provider.test.ts --run
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime
- live smoke: managed OpenRouter now returns a redacted budget-limit message when the hosted key is out of allowance