### PR TITLE
fix(tui): summarize subscription model access

### DIFF
--- a/runtime/src/commands/auth.tsx
+++ b/runtime/src/commands/auth.tsx
@@ -12,7 +12,10 @@ import {
   type SlashCommandContext,
   type SlashCommandResult,
 } from "./types.js";
-import { formatSubscriptionManagedModels } from "./subscription-managed-models.js";
+import {
+  subscriptionManagedDefaultModel,
+  subscriptionManagedModels,
+} from "./subscription-managed-models.js";
 
 type AuthAction = "login" | "logout" | "whoami" | "subscription";
 
@@ -245,18 +248,39 @@ function formatSubscriptionStatus(tier: string | undefined): string {
   return ` · plan=${tier} · managed keys require Pro (https://id.agenc.ag/pricing)`;
 }
 
-function formatSubscriptionCommandResult(tier: string | undefined): string {
+function managedUsageCapLabel(plan: string): string | undefined {
+  switch (plan) {
+    case "pro":
+      return "$10 model spend / 30d";
+    case "team":
+      return "$200 model spend / 30d";
+    case "enterprise":
+      return "$1000 model spend / 30d";
+    default:
+      return undefined;
+  }
+}
+
+export function formatSubscriptionCommandResult(tier: string | undefined): string {
   const plan = tier ?? "unknown";
   const lines = [
     `Plan: ${plan}`,
     `Billing: ${SUBSCRIPTION_URL}`,
   ];
   if (plan === "pro" || plan === "team" || plan === "enterprise") {
+    const provider = "openrouter";
+    const models = subscriptionManagedModels(provider);
+    const defaultModel = subscriptionManagedDefaultModel(provider);
+    const cap = managedUsageCapLabel(plan);
     lines.push(
-      "Managed model access is enabled for this account.",
-      `Currently live through the subscription: ${formatSubscriptionManagedModels()}.`,
-      "Other providers need BYOK until their managed gateway deployments are enabled.",
-      "Use /provider to inspect whether a provider is using BYOK or subscription-managed keys.",
+      "Managed models: enabled",
+      "Gateway: AgenC -> LiteLLM -> OpenRouter",
+      ...(cap !== undefined ? [`Included usage cap: ${cap}`] : []),
+      `Available models: ${models.length} managed OpenRouter routes`,
+      defaultModel !== undefined
+        ? `Default route: /model ${provider}:${defaultModel}`
+        : "Default route: run /provider",
+      "Choose/switch models with /provider.",
     );
   } else {
     lines.push(

--- a/runtime/tests/commands/auth.test.ts
+++ b/runtime/tests/commands/auth.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LocalAuthBackend } from "../auth/backends/local.js";
 import {
+  formatSubscriptionCommandResult,
   loginCommand,
   logoutCommand,
   subscriptionCommand,
@@ -119,6 +120,23 @@ describe("auth slash commands", () => {
       text:
         "Plan: free\nBilling: https://id.agenc.ag/subscription\nManaged model access requires Pro or higher.\nBYOK still works without a subscription.",
     });
+  });
+
+  it("summarizes paid subscription model access without listing every route", () => {
+    const text = formatSubscriptionCommandResult("pro");
+
+    expect(text).toBe(
+      "Plan: pro\n" +
+        "Billing: https://id.agenc.ag/subscription\n" +
+        "Managed models: enabled\n" +
+        "Gateway: AgenC -> LiteLLM -> OpenRouter\n" +
+        "Included usage cap: $10 model spend / 30d\n" +
+        "Available models: 19 managed OpenRouter routes\n" +
+        "Default route: /model openrouter:x-ai/grok-4.3\n" +
+        "Choose/switch models with /provider.",
+    );
+    expect(text).not.toContain(" or /model ");
+    expect(text).not.toContain("claude-haiku-4.5 or");
   });
 
   it("rejects unexpected arguments", async () => {


### PR DESCRIPTION
## Summary
- replace the long /subscription managed-model command list with a compact account summary
- show plan, billing URL, managed gateway, included usage cap, model count, and default route
- keep model selection details in /provider instead of the subscription transcript

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- tests/commands/auth.test.ts tests/commands/provider.test.ts tests/commands/model.test.ts --run
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime