### PR TITLE
fix(tui): hide internal subscription budget

### DIFF
--- a/runtime/src/commands/auth.tsx
+++ b/runtime/src/commands/auth.tsx
@@ -248,19 +248,6 @@ function formatSubscriptionStatus(tier: string | undefined): string {
   return ` · plan=${tier} · managed keys require Pro (https://id.agenc.ag/pricing)`;
 }
 
-function managedUsageCapLabel(plan: string): string | undefined {
-  switch (plan) {
-    case "pro":
-      return "$10 model spend / 30d";
-    case "team":
-      return "$200 model spend / 30d";
-    case "enterprise":
-      return "$1000 model spend / 30d";
-    default:
-      return undefined;
-  }
-}
-
 export function formatSubscriptionCommandResult(tier: string | undefined): string {
   const plan = tier ?? "unknown";
   const lines = [
@@ -271,11 +258,9 @@ export function formatSubscriptionCommandResult(tier: string | undefined): strin
     const provider = "openrouter";
     const models = subscriptionManagedModels(provider);
     const defaultModel = subscriptionManagedDefaultModel(provider);
-    const cap = managedUsageCapLabel(plan);
     lines.push(
       "Managed models: enabled",
-      "Gateway: AgenC -> LiteLLM -> OpenRouter",
-      ...(cap !== undefined ? [`Included usage cap: ${cap}`] : []),
+      "Model access: hosted by AgenC",
       `Available models: ${models.length} managed OpenRouter routes`,
       defaultModel !== undefined
         ? `Default route: /model ${provider}:${defaultModel}`

--- a/runtime/tests/commands/auth.test.ts
+++ b/runtime/tests/commands/auth.test.ts
@@ -129,14 +129,15 @@ describe("auth slash commands", () => {
       "Plan: pro\n" +
         "Billing: https://id.agenc.ag/subscription\n" +
         "Managed models: enabled\n" +
-        "Gateway: AgenC -> LiteLLM -> OpenRouter\n" +
-        "Included usage cap: $10 model spend / 30d\n" +
+        "Model access: hosted by AgenC\n" +
         "Available models: 19 managed OpenRouter routes\n" +
         "Default route: /model openrouter:x-ai/grok-4.3\n" +
         "Choose/switch models with /provider.",
     );
     expect(text).not.toContain(" or /model ");
     expect(text).not.toContain("claude-haiku-4.5 or");
+    expect(text).not.toContain("$10");
+    expect(text).not.toContain("LiteLLM");
   });
 
   it("rejects unexpected arguments", async () => {


### PR DESCRIPTION
## Summary
- remove internal model-spend caps from /subscription output
- replace gateway internals with public user-facing copy: hosted by AgenC
- add regression assertions that /subscription does not expose internal cap or LiteLLM details

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- tests/commands/auth.test.ts tests/commands/provider.test.ts tests/commands/model.test.ts --run
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime