### PR TITLE
fix(tui): show hosted usage diagnostics

### DIFF
--- a/runtime/src/commands/auth.tsx
+++ b/runtime/src/commands/auth.tsx
@@ -129,7 +129,7 @@ async function executeAuthCommand(
       const usage = await resolveLlmUsage(backend);
       return {
         kind: "text",
-        text: formatUsageCommandResult(usage, tier),
+        text: formatUsageCommandResult(usage.usage, tier, usage.error),
       };
     }
 
@@ -172,11 +172,14 @@ async function resolveSubscriptionTier(
 
 async function resolveLlmUsage(
   backend: AuthBackend,
-): Promise<AuthLlmUsage | undefined> {
+): Promise<{
+  readonly error?: string;
+  readonly usage?: AuthLlmUsage;
+}> {
   try {
-    return await backend.getLlmUsage({ sessionId: TUI_AUTH_SESSION_ID });
-  } catch {
-    return undefined;
+    return { usage: await backend.getLlmUsage({ sessionId: TUI_AUTH_SESSION_ID }) };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
   }
 }
 
@@ -308,11 +311,13 @@ export function formatSubscriptionCommandResult(tier: string | undefined): strin
 export function formatUsageCommandResult(
   usage: AuthLlmUsage | undefined,
   fallbackTier: string | undefined,
+  error?: string,
 ): string {
   if (usage === undefined) {
     return [
       `Plan: ${fallbackTier ?? "unknown"}`,
       "Managed model usage is temporarily unavailable.",
+      ...(error !== undefined ? [`Reason: ${error}`] : []),
       `Billing: ${SUBSCRIPTION_URL}`,
     ].join("\n");
   }

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -174,8 +174,8 @@ function isOpenRouterBudgetLimitFailure(args: {
 
 function openRouterBudgetLimitErrorMessage(): string {
   return [
-    "Hosted model usage limit reached for this request.",
-    "Try a shorter prompt/response, choose a smaller hosted model, or run /usage to check your plan.",
+    "This hosted model request is too large for the current allowance.",
+    "You may still have usage left; run /usage, ask for a shorter response, or choose a cheaper hosted model.",
     "[openai_category=rate_limited]",
     "Upstream account details were redacted.",
   ].join(" ");

--- a/runtime/tests/commands/auth.test.ts
+++ b/runtime/tests/commands/auth.test.ts
@@ -208,6 +208,15 @@ describe("auth slash commands", () => {
     );
   });
 
+  it("shows the lookup failure reason when usage cannot be loaded", () => {
+    expect(formatUsageCommandResult(undefined, "pro", "HTTP 500")).toBe(
+      "Plan: pro\n" +
+        "Managed model usage is temporarily unavailable.\n" +
+        "Reason: HTTP 500\n" +
+        "Billing: https://id.agenc.ag/subscription",
+    );
+  });
+
   it("rejects unexpected arguments", async () => {
     const agencHome = await makeHome();
     const ctx = {

--- a/runtime/tests/llm/providers/openai/adapter.test.ts
+++ b/runtime/tests/llm/providers/openai/adapter.test.ts
@@ -579,7 +579,7 @@ describe("OpenAIProvider", () => {
     ).rejects.toMatchObject({
       name: "LLMProviderError",
       message: expect.stringContaining(
-        "Hosted model usage limit reached for this request",
+        "This hosted model request is too large for the current allowance",
       ),
       statusCode: 402,
     });


### PR DESCRIPTION
## Summary\n- show the concrete /usage lookup failure reason instead of a generic unavailable message\n- clarify OpenRouter hosted budget errors as request-size failures, not total subscription exhaustion\n\n## Verification\n- npm test --workspace=@tetsuo-ai/runtime -- tests/commands/auth.test.ts tests/llm/providers/openai/adapter.test.ts --run\n- npm run typecheck --workspace=@tetsuo-ai/runtime\n- npm run build --workspace=@tetsuo-ai/runtime