### PR TITLE
fix(tui): prefer hosted OpenRouter for paid users

### DIFF
--- a/docs/managed-openrouter.md
+++ b/docs/managed-openrouter.md
@@ -9,17 +9,36 @@ the AgenC LiteLLM/OpenRouter gateway.
 
 1. `agenc login` stores the remote auth token in `AGENC_HOME/auth.json`.
 2. The TUI or CLI reads the subscription tier from the auth backend.
-3. With `AGENC_AUTH_MANAGED_KEYS_ENABLED=true`, paid users can select managed
-   OpenRouter models from `/provider` or `/model`.
-4. `/usage` asks the auth backend for the user's hosted model allowance,
+3. With `AGENC_AUTH_MANAGED_KEYS_ENABLED=true`, paid users get the hosted
+   OpenRouter route selected automatically when the active provider is the old
+   default `grok` route.
+4. `/provider` opens with OpenRouter first and marked as subscription-managed.
+   `/model` opens on the hosted OpenRouter model list first, even if the
+   previous session provider was `grok`.
+5. `/usage` asks the auth backend for the user's hosted model allowance,
    current spend, remaining included usage, and reset timestamp.
-5. The backend vends a LiteLLM key for the session. The local CLI keeps it in
+6. The backend vends a LiteLLM key for the session. The local CLI keeps it in
    provider memory only; it is not written as a provider API key.
-6. The provider sends requests to the managed gateway with the model normalized
+7. The provider sends requests to the managed gateway with the model normalized
    as `openrouter/<provider>/<model>`.
 
 BYOK still wins. If a user has `OPENROUTER_API_KEY` or provider config API keys,
 those credentials are used instead of the subscription-managed route.
+
+## TUI Behavior
+
+After a successful paid `/login`, the TUI should feel ready without extra
+provider setup:
+
+- If the session was still on the default `grok` provider, login switches it to
+  `openrouter / x-ai/grok-4.3` and tells the user to run `/model` for other
+  hosted models.
+- If the user intentionally configured another provider, login keeps that
+  provider and tells the user that `/provider openrouter` is available.
+- `/provider` prioritizes the hosted OpenRouter route for paid accounts, then
+  shows BYOK and local routes.
+- `/model` prioritizes hosted OpenRouter models for paid accounts, while still
+  leaving BYOK/local provider rows visible when they are configured.
 
 ## Output Cap
 

--- a/runtime/src/commands/auth.tsx
+++ b/runtime/src/commands/auth.tsx
@@ -3,9 +3,11 @@ import { spawn } from "node:child_process";
 import type { AuthBackend, AuthIdentity, AuthLlmUsage } from "../auth/backend.js";
 import { createAuthBackend } from "../auth/selection.js";
 import { resolveAgencHome } from "../config/env.js";
+import { normalizeProviderSlug } from "../config/resolve-provider.js";
 import { defaultConfig } from "../config/schema.js";
 import { Box, Text } from "../tui/ink.js";
 import { openLocalJsxCommand } from "./local-jsx-command.js";
+import { applyProviderSwitch } from "./provider.js";
 import {
   safeExecute,
   type SlashCommand,
@@ -13,6 +15,8 @@ import {
   type SlashCommandResult,
 } from "./types.js";
 import {
+  SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+  hasHostedSubscriptionAccess,
   subscriptionManagedDefaultModel,
   subscriptionManagedModels,
 } from "./subscription-managed-models.js";
@@ -94,11 +98,13 @@ async function executeAuthCommand(
         clearLocalAuthNotice(ctx);
       }
       const tier = await resolveSubscriptionTier(backend);
+      const routeMessage = await maybeSelectHostedSubscriptionRoute(ctx, tier);
       return {
         kind: "text",
         text:
           `Logged in as ${formatAgenCAuthIdentity(result.identity)}` +
-          formatSubscriptionStatus(tier),
+          formatSubscriptionStatus(tier) +
+          (routeMessage !== undefined ? `\n${routeMessage}` : ""),
       };
     }
 
@@ -138,6 +144,103 @@ async function executeAuthCommand(
       text: `${formatAgenCAuthIdentity(result.identity)}${formatSubscriptionStatus(tier)}`,
     };
   });
+}
+
+function paidSubscriptionTier(tier: string | undefined): boolean {
+  return tier === "pro" || tier === "team" || tier === "enterprise";
+}
+
+function readSessionProvider(ctx: SlashCommandContext): string | undefined {
+  const peekState = (ctx.session as unknown as {
+    state?: { unsafePeek?: () => unknown };
+  }).state?.unsafePeek;
+  const rawState =
+    typeof peekState === "function"
+      ? (peekState.call((ctx.session as unknown as { state?: unknown }).state) as {
+          sessionConfiguration?: {
+            provider?: { slug?: string };
+          };
+        })
+      : null;
+  const directConfig = (ctx.session as unknown as {
+    sessionConfiguration?: {
+      provider?: { slug?: string };
+    };
+  }).sessionConfiguration;
+  return rawState?.sessionConfiguration?.provider?.slug ??
+    directConfig?.provider?.slug;
+}
+
+async function maybeSelectHostedSubscriptionRoute(
+  ctx: SlashCommandContext,
+  tier: string | undefined,
+): Promise<string | undefined> {
+  if (!paidSubscriptionTier(tier)) return undefined;
+  const config = ctx.configStore?.current() ?? defaultConfig();
+  if (!hasHostedSubscriptionAccess(config, process.env)) return undefined;
+
+  const currentProvider =
+    normalizeProviderSlug(readSessionProvider(ctx)) ??
+    normalizeProviderSlug(config.model_provider) ??
+    "grok";
+  if (currentProvider === SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER) {
+    return undefined;
+  }
+
+  const configuredProvider = normalizeProviderSlug(config.model_provider);
+  if (
+    configuredProvider !== undefined &&
+    configuredProvider !== "grok" &&
+    configuredProvider !== SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER
+  ) {
+    return (
+      "Hosted models ready through OpenRouter. Your configured provider was kept; " +
+      "run /provider openrouter to switch."
+    );
+  }
+
+  if (currentProvider !== "grok") {
+    return (
+      "Hosted models ready through OpenRouter. Your current provider was kept; " +
+      "run /provider openrouter to switch."
+    );
+  }
+
+  const defaultModel = subscriptionManagedDefaultModel(
+    SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+  );
+  if (defaultModel === undefined) return undefined;
+  const summary = await applyProviderSwitch(
+    ctx.session,
+    SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+    defaultModel,
+  );
+  if (!summary.startsWith("Provider switched ") && !summary.startsWith("Provider switch staged:")) {
+    return `Hosted models ready, but the automatic OpenRouter switch was blocked: ${summary}`;
+  }
+  updateHostedRouteChrome(ctx, defaultModel);
+  return (
+    `Hosted route selected: ${SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER} / ` +
+    `${defaultModel}. Run /model to choose another hosted model.`
+  );
+}
+
+function updateHostedRouteChrome(
+  ctx: SlashCommandContext,
+  model: string,
+): void {
+  if (typeof ctx.appState?.setAppState === "function") {
+    ctx.appState.setAppState((prev: unknown): unknown => {
+      if (typeof prev !== "object" || prev === null) return prev;
+      return {
+        ...prev,
+        mainLoopModel: model,
+        mainLoopModelForSession: model,
+      };
+    });
+    return;
+  }
+  ctx.appState?.setModel?.(model);
 }
 
 function createSlashAuthBackend(ctx: SlashCommandContext): AuthBackend {

--- a/runtime/src/commands/model-menu.tsx
+++ b/runtime/src/commands/model-menu.tsx
@@ -6,7 +6,6 @@ import {
   resolveProviderSettings,
   type ProviderSlug,
 } from "../config/resolve-provider.js";
-import { hasEntitledRemoteAuthSessionSync } from "../auth/session-state.js";
 import {
   configuredModelForProvider,
   defaultModelForProvider,
@@ -20,6 +19,8 @@ import { readCommandConfig } from "./config-context.js";
 import { openLocalJsxCommand } from "./local-jsx-command.js";
 import { nextMenuIndex, previousMenuIndex } from "./menu-navigation.js";
 import {
+  SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+  hasHostedSubscriptionAccess,
   providerHasLiveSubscriptionRoute,
   subscriptionManagedModels,
 } from "./subscription-managed-models.js";
@@ -193,12 +194,17 @@ function statusGlyph(status: ModelRowStatus): string {
 function providerOrder(
   catalog: Readonly<Record<string, readonly string[]>>,
   currentProvider: ProviderSlug,
+  preferredProvider?: ProviderSlug,
 ): readonly ProviderSlug[] {
   const ids = Object.keys(catalog)
     .map(provider => normalizeProviderSlug(provider))
     .filter((provider): provider is ProviderSlug => provider !== undefined);
   const unique = [...new Set(ids)];
   return unique.sort((left, right) => {
+    if (preferredProvider !== undefined) {
+      if (left === preferredProvider) return -1;
+      if (right === preferredProvider) return 1;
+    }
     if (left === currentProvider) return -1;
     if (right === currentProvider) return 1;
     return left.localeCompare(right);
@@ -296,8 +302,10 @@ export function readModelMenuSnapshot(ctx: SlashCommandContext): ModelMenuSnapsh
     config !== undefined ? configuredModelForProvider(config, provider) : undefined;
   const catalog = buildProviderModelCatalog(config);
   const managedKeysEnabled = config?.auth?.managedKeys?.enabled === true;
-  const managedSubscriptionAvailable =
-    managedKeysEnabled && hasEntitledRemoteAuthSessionSync(process.env);
+  const managedSubscriptionAvailable = hasHostedSubscriptionAccess(
+    config,
+    process.env,
+  );
   const providerApiKey = (catalogProvider: ProviderSlug): string | undefined =>
     config !== undefined
       ? resolveProviderSettings(catalogProvider, config, process.env)?.apiKey
@@ -325,7 +333,10 @@ export function readModelMenuSnapshot(ctx: SlashCommandContext): ModelMenuSnapsh
     }
     return catalog[catalogProvider] ?? [];
   };
-  const rows = providerOrder(catalog, provider)
+  const preferredProvider = managedSubscriptionAvailable
+    ? SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER
+    : undefined;
+  const rows = providerOrder(catalog, provider, preferredProvider)
     .filter(shouldShowProvider)
     .flatMap(catalogProvider => {
       const managedRoute =
@@ -341,7 +352,19 @@ export function readModelMenuSnapshot(ctx: SlashCommandContext): ModelMenuSnapsh
         managedRoute,
       });
     });
-  const activeIndex = Math.max(0, rows.findIndex(row => row.status === "current"));
+  const preferredActiveIndex =
+    managedSubscriptionAvailable
+      ? rows.findIndex(
+          row =>
+            row.provider === SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER &&
+            row.selectable,
+        )
+      : -1;
+  const currentActiveIndex = rows.findIndex(row => row.status === "current");
+  const activeIndex = Math.max(
+    0,
+    preferredActiveIndex >= 0 ? preferredActiveIndex : currentActiveIndex,
+  );
   // Count the rows actually offered per provider (hidden models are filtered
   // out in providerRows) so the displayed count matches the selectable list.
   const providerCounts = Object.freeze(

--- a/runtime/src/commands/provider-menu.tsx
+++ b/runtime/src/commands/provider-menu.tsx
@@ -6,7 +6,6 @@ import {
   readProviderConfig,
   type ProviderSlug,
 } from "../config/resolve-provider.js";
-import { hasEntitledRemoteAuthSessionSync } from "../auth/session-state.js";
 import {
   configuredModelForProvider,
   defaultModelForProvider,
@@ -20,6 +19,8 @@ import { readCommandConfig } from "./config-context.js";
 import { openLocalJsxCommand } from "./local-jsx-command.js";
 import { nextMenuIndex, previousMenuIndex } from "./menu-navigation.js";
 import {
+  SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+  hasHostedSubscriptionAccess,
   providerHasLiveSubscriptionRoute,
   subscriptionManagedDefaultModel,
   subscriptionManagedModels,
@@ -373,6 +374,43 @@ function authColor(state: ProviderAuthState): ProviderColor {
   }
 }
 
+function providerRuntimeRank(state: ProviderRuntimeState): number {
+  switch (state) {
+    case "active":
+      return 0;
+    case "available":
+      return 1;
+    case "local":
+      return 2;
+    case "unauthenticated":
+      return 3;
+    case "unavailable":
+      return 4;
+    case "error":
+      return 5;
+  }
+}
+
+function sortProviderRows(
+  rows: readonly ProviderMenuRow[],
+  currentProvider: ProviderSlug,
+  hostedSubscriptionReady: boolean,
+): readonly ProviderMenuRow[] {
+  return [...rows].sort((left, right) => {
+    if (hostedSubscriptionReady) {
+      if (left.provider === SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER) return -1;
+      if (right.provider === SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER) return 1;
+    }
+    if (left.provider === currentProvider) return -1;
+    if (right.provider === currentProvider) return 1;
+    const rankDelta =
+      providerRuntimeRank(left.runtimeState) -
+      providerRuntimeRank(right.runtimeState);
+    if (rankDelta !== 0) return rankDelta;
+    return left.provider.localeCompare(right.provider);
+  });
+}
+
 export function readProviderMenuSnapshot(ctx: SlashCommandContext): ProviderMenuSnapshot {
   const config = readCommandConfig(ctx);
   const sessionSelection = readSessionSelection(ctx);
@@ -394,10 +432,12 @@ export function readProviderMenuSnapshot(ctx: SlashCommandContext): ProviderMenu
     defaultModelForProvider(currentProvider);
   const modelCatalog = buildProviderModelCatalog(config);
   const managedKeysEnabled = config?.auth?.managedKeys?.enabled === true;
-  const managedSubscriptionAvailable =
-    managedKeysEnabled && hasEntitledRemoteAuthSessionSync(process.env);
+  const managedSubscriptionAvailable = hasHostedSubscriptionAccess(
+    config,
+    process.env,
+  );
 
-  const rows = listBuiltInProviderInfo().map((info): ProviderMenuRow => {
+  const unsortedRows = listBuiltInProviderInfo().map((info): ProviderMenuRow => {
     const provider = info.id;
     const providerConfig = config ? readProviderConfig(config, provider) : undefined;
     const status = rowStatus({ config, provider, currentProvider });
@@ -456,9 +496,21 @@ export function readProviderMenuSnapshot(ctx: SlashCommandContext): ProviderMenu
     };
   });
 
+  const rows = sortProviderRows(
+    unsortedRows,
+    currentProvider,
+    managedSubscriptionAvailable,
+  );
+  const preferredActiveIndex =
+    managedSubscriptionAvailable
+      ? rows.findIndex(
+          row => row.provider === SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+        )
+      : -1;
+  const currentActiveIndex = rows.findIndex(row => row.provider === currentProvider);
   const activeIndex = Math.max(
     0,
-    rows.findIndex(row => row.provider === currentProvider),
+    preferredActiveIndex >= 0 ? preferredActiveIndex : currentActiveIndex,
   );
   return {
     currentProvider,

--- a/runtime/src/commands/subscription-managed-models.ts
+++ b/runtime/src/commands/subscription-managed-models.ts
@@ -1,4 +1,9 @@
+import type { EnvSnapshot } from "../config/env.js";
 import { normalizeProviderSlug, type ProviderSlug } from "../config/resolve-provider.js";
+import type { AgenCConfig } from "../config/schema.js";
+import { hasEntitledRemoteAuthSessionSync } from "../auth/session-state.js";
+
+export const SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER: ProviderSlug = "openrouter";
 
 const LIVE_SUBSCRIPTION_MODELS: Readonly<Record<string, readonly string[]>> = {
   openrouter: [
@@ -46,6 +51,16 @@ export function providerHasLiveSubscriptionRoute(
   provider: ProviderSlug | string,
 ): boolean {
   return subscriptionManagedModels(provider).length > 0;
+}
+
+export function hasHostedSubscriptionAccess(
+  config: AgenCConfig | undefined,
+  env: EnvSnapshot = process.env,
+): boolean {
+  return (
+    config?.auth?.managedKeys?.enabled === true &&
+    hasEntitledRemoteAuthSessionSync(env)
+  );
 }
 
 export function subscriptionManagedDefaultModel(

--- a/runtime/tests/commands/model.test.ts
+++ b/runtime/tests/commands/model.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 import {
   modelCommand,
@@ -69,6 +73,54 @@ function mkctx(
     home: "/home/test",
     ...(appState ? { appState } : {}),
   };
+}
+
+function withProAuthSession<T>(fn: () => T): T {
+  const agencHome = mkdtempSync(join(tmpdir(), "agenc-model-pro-"));
+  writeFileSync(
+    join(agencHome, "auth.json"),
+    JSON.stringify({
+      provider: "remote",
+      token: "test-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      subscriptionTier: "pro",
+    }),
+  );
+  const previousHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = agencHome;
+  try {
+    return fn();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.AGENC_HOME;
+    } else {
+      process.env.AGENC_HOME = previousHome;
+    }
+  }
+}
+
+async function withProAuthSessionAsync<T>(fn: () => Promise<T>): Promise<T> {
+  const agencHome = mkdtempSync(join(tmpdir(), "agenc-model-pro-"));
+  writeFileSync(
+    join(agencHome, "auth.json"),
+    JSON.stringify({
+      provider: "remote",
+      token: "test-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      subscriptionTier: "pro",
+    }),
+  );
+  const previousHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = agencHome;
+  try {
+    return await fn();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.AGENC_HOME;
+    } else {
+      process.env.AGENC_HOME = previousHome;
+    }
+  }
 }
 
 describe("checkModelHistoryCompat", () => {
@@ -363,6 +415,7 @@ describe("modelCommand", () => {
   });
 
   it("model menu limits subscription-managed OpenRouter to live models", () => {
+    withProAuthSession(() => {
     const snapshot = readModelMenuSnapshot({
       ...mkctx(stubSession({ provider: "openrouter", model: "x-ai/grok-4.3" }), ""),
       configStore: {
@@ -417,9 +470,45 @@ describe("modelCommand", () => {
       "openrouter",
       "openrouter",
     ]);
+    });
+  });
+
+  it("opens paid managed sessions on hosted OpenRouter models first", () => {
+    withProAuthSession(() => {
+      const previous = process.env.OPENROUTER_API_KEY;
+      delete process.env.OPENROUTER_API_KEY;
+      try {
+        const snapshot = readModelMenuSnapshot({
+          ...mkctx(stubSession({ provider: "grok", model: "grok-4.3" }), ""),
+          configStore: {
+            current: () => ({
+              auth: { managedKeys: { enabled: true } },
+            }),
+          } as SlashCommandContext["configStore"],
+        });
+
+        expect(snapshot.rows[0]).toMatchObject({
+          provider: "openrouter",
+          model: "x-ai/grok-4.3",
+          detail: "default hosted subscription model",
+        });
+        expect(snapshot.rows[snapshot.activeIndex]).toMatchObject({
+          provider: "openrouter",
+          model: "x-ai/grok-4.3",
+        });
+        expect(snapshot.rows.some(row => row.provider === "grok")).toBe(true);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.OPENROUTER_API_KEY;
+        } else {
+          process.env.OPENROUTER_API_KEY = previous;
+        }
+      }
+    });
   });
 
   it("blocks direct model switches to unavailable subscription-managed OpenRouter models", async () => {
+    await withProAuthSessionAsync(async () => {
     const previous = process.env.OPENROUTER_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
     try {
@@ -451,9 +540,11 @@ describe("modelCommand", () => {
         process.env.OPENROUTER_API_KEY = previous;
       }
     }
+    });
   });
 
   it("allows direct switches to subscription-managed OpenRouter models outside the base catalog", async () => {
+    await withProAuthSessionAsync(async () => {
     const previous = process.env.OPENROUTER_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
     try {
@@ -486,6 +577,7 @@ describe("modelCommand", () => {
         process.env.OPENROUTER_API_KEY = previous;
       }
     }
+    });
   });
 
   it("blocks direct model switches to unavailable managed routes without BYOK", async () => {

--- a/runtime/tests/commands/provider.test.ts
+++ b/runtime/tests/commands/provider.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 import {
   providerCommand,
@@ -76,6 +80,30 @@ function mkctx(
     home: "/home/test",
     ...(appState ? { appState } : {}),
   };
+}
+
+function withProAuthSession<T>(fn: () => T): T {
+  const agencHome = mkdtempSync(join(tmpdir(), "agenc-provider-pro-"));
+  writeFileSync(
+    join(agencHome, "auth.json"),
+    JSON.stringify({
+      provider: "remote",
+      token: "test-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      subscriptionTier: "pro",
+    }),
+  );
+  const previousHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = agencHome;
+  try {
+    return fn();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.AGENC_HOME;
+    } else {
+      process.env.AGENC_HOME = previousHome;
+    }
+  }
 }
 
 describe("providerCommand", () => {
@@ -339,6 +367,7 @@ describe("providerCommand", () => {
   });
 
   it("shows subscription-managed auth when managed keys are enabled and BYOK is absent", () => {
+    withProAuthSession(() => {
     const previous = process.env.OPENROUTER_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
     try {
@@ -385,6 +414,39 @@ describe("providerCommand", () => {
         process.env.OPENROUTER_API_KEY = previous;
       }
     }
+    });
+  });
+
+  it("prioritizes hosted OpenRouter for paid managed sessions", () => {
+    withProAuthSession(() => {
+      const previous = process.env.OPENROUTER_API_KEY;
+      delete process.env.OPENROUTER_API_KEY;
+      try {
+        const snapshot = readProviderMenuSnapshot({
+          ...mkctx(stubSession({ provider: "grok", model: "grok-4.3" }), ""),
+          configStore: {
+            current: () => ({
+              auth: { managedKeys: { enabled: true } },
+            }),
+          } as SlashCommandContext["configStore"],
+        });
+
+        expect(snapshot.rows[0]).toMatchObject({
+          provider: "openrouter",
+          authState: "managed",
+          auth: "subscription",
+          model: "x-ai/grok-4.3",
+        });
+        expect(snapshot.rows[snapshot.activeIndex]?.provider).toBe("openrouter");
+        expect(snapshot.currentProvider).toBe("grok");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.OPENROUTER_API_KEY;
+        } else {
+          process.env.OPENROUTER_API_KEY = previous;
+        }
+      }
+    });
   });
 
   it("does not mark providers without live managed routes as subscription-managed", () => {


### PR DESCRIPTION
## Summary
- Auto-select the hosted OpenRouter route after paid /login when the session is still on the legacy default Grok provider
- Prioritize subscription-managed OpenRouter in /provider and /model for paid accounts
- Document paid hosted OpenRouter TUI behavior and add regression tests

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime
- npm --workspace=@tetsuo-ai/runtime run test -- tests/commands/provider.test.ts tests/commands/model.test.ts tests/commands/auth.test.ts
- Manual TUI smoke confirmed by Pavel after /login, /provider, /model

## Note
- npm run validate:runtime reached check:tui-runtime-startup, but local node-pty fails before the app starts with posix_spawnp failed even for a minimal node-pty spawn. The built TUI artifact imports cleanly and the real TUI session was manually verified.