### PR TITLE
fix(tui): persist onboarding provider selection

### DIFF
--- a/runtime/src/config/edit.ts
+++ b/runtime/src/config/edit.ts
@@ -95,6 +95,34 @@ export class AgenCConfigEditsBuilder {
     return this;
   }
 
+  setModelSelection(provider: string, model: string): this {
+    const normalizedProvider = provider.trim();
+    const normalizedModel = model.trim();
+    this.edits.push((raw) => {
+      if (normalizedProvider.length > 0) {
+        raw.model_provider = normalizedProvider;
+      }
+      if (normalizedModel.length > 0) {
+        raw.model = normalizedModel;
+      }
+      if (
+        normalizedProvider.length > 0 &&
+        normalizedModel.length > 0
+      ) {
+        const providers = isPlainRecord(raw.providers)
+          ? cloneRecord(raw.providers)
+          : {};
+        const existing = isPlainRecord(providers[normalizedProvider])
+          ? cloneRecord(providers[normalizedProvider] as Record<string, unknown>)
+          : {};
+        existing.default_model = normalizedModel;
+        providers[normalizedProvider] = existing;
+        raw.providers = providers;
+      }
+    });
+    return this;
+  }
+
   setPersonality(personality: Personality | null): this {
     this.edits.push((raw) => {
       if (personality === null) {

--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -138,7 +138,7 @@ export interface UseFirstRunOnboardingOptions extends FirstRunOnboardingContext 
   readonly disabled?: boolean;
   readonly hasInitialPrompt?: boolean;
   readonly isInteractive?: boolean;
-  readonly onComplete?: (state: FirstRunOnboardingState) => void;
+  readonly onComplete?: (state: FirstRunOnboardingState) => void | Promise<void>;
 }
 
 export interface UseFirstRunOnboardingResult {
@@ -1092,8 +1092,8 @@ export function useFirstRunOnboardingController(
               completedStepIds: nextState.completedStepIds,
             });
           }
+          await options.onComplete?.(nextState);
           setActive(false);
-          options.onComplete?.(nextState);
         }
         return true;
       } finally {

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1,3 +1,5 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { c as _c } from "react-compiler-runtime";
 import React, { type ReactNode, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { FpsMetricsProvider, useFpsMetrics } from "../context/fpsMetrics.js";
@@ -46,6 +48,7 @@ import type { McpElicitationRequestEvent, McpElicitationResponse, McpPrimitiveSc
 import { createMcpUrlCompletionResponse } from "../../elicitation/url-completion.js";
 import type { ToolPermissionContext } from "../../permissions/types.js";
 import { defaultConfig } from "../../config/schema.js";
+import { configReadsEnabled } from "../../config/init.js";
 import { createTuiTools } from "../tool-rendering.js";
 import { useSessionTranscript } from "../session-transcript.js";
 import { useToolJSX } from "../tool-jsx-state.js";
@@ -73,6 +76,10 @@ import { getTotalCost } from "../../cost/tracker.js";
 import { useNotifications } from "../context/notifications.js";
 import { hasConsoleBillingAccess } from "../../utils/billing.js";
 import { getGlobalConfig, saveGlobalConfig } from "../../utils/config.js";
+import { AgenCConfigEditsBuilder } from "../../config/edit.js";
+import { logError } from "../../utils/log.js";
+import { markInternalWrite } from "../../utils/settings/internalWrites.js";
+import { resetSettingsCache } from "../../utils/settings/settingsCache.js";
 import { createFileStateCacheWithSizeLimit, READ_FILE_STATE_CACHE_SIZE } from "../../utils/fileStateCache.js";
 import { fileHistoryRewind } from "../../utils/fileHistory.js";
 import { getCurrentWorktreeSession } from "../../utils/worktree.js";
@@ -1017,6 +1024,49 @@ function initialPermissionContext(props: AgenCTuiProps): ToolPermissionContext {
 function startupModel(props: AgenCTuiProps): string | null {
   return props.model ?? props.session.sessionConfiguration?.collaborationMode?.model ?? null;
 }
+function hasAcknowledgedCostThreshold(): boolean {
+  return configReadsEnabled() && getGlobalConfig().hasAcknowledgedCostThreshold === true;
+}
+async function persistOnboardingModelSetting(agencHome: string | undefined, model: string): Promise<void> {
+  if (agencHome === undefined || model.length === 0) {
+    return;
+  }
+  const filePath = join(agencHome, "settings.json");
+  let existing: Record<string, unknown> = {};
+  try {
+    const text = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      existing = parsed as Record<string, unknown>;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  await mkdir(dirname(filePath), {
+    recursive: true,
+    mode: 0o700
+  });
+  markInternalWrite(filePath);
+  await writeFile(filePath, `${JSON.stringify({
+    ...existing,
+    model
+  }, null, 2)}\n`, {
+    mode: 0o600
+  });
+  resetSettingsCache();
+}
+async function persistOnboardingSelection(props: AgenCTuiProps, agencHome: string | undefined, next: FirstRunOnboardingState): Promise<void> {
+  const provider = next.selectedProvider.trim();
+  const model = next.selectedModel.trim();
+  await persistOnboardingModelSetting(agencHome, model);
+  if (agencHome !== undefined && provider.length > 0 && model.length > 0) {
+    await new AgenCConfigEditsBuilder(agencHome).setModelSelection(provider, model).apply();
+  }
+  await props.configStore.reload?.();
+  await props.session.services.configStore?.reload?.();
+}
 function initialState(props: AgenCTuiProps): any {
   const agentDefinitions = listAgentRoleDefinitions();
   return {
@@ -1467,7 +1517,7 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
   const [selectorNotice, setSelectorNotice] = useState<string | null>(null);
   const summarizeAbortRef = useRef<AbortController | null>(null);
   const [exitFlow, setExitFlow] = useState<React.ReactNode>(null);
-  const [haveShownCostDialog, setHaveShownCostDialog] = useState(() => getGlobalConfig().hasAcknowledgedCostThreshold === true);
+  const [haveShownCostDialog, setHaveShownCostDialog] = useState(hasAcknowledgedCostThreshold);
   const [showCostDialog, setShowCostDialog] = useState(false);
   const [compactProgress, setCompactProgress] = useState({
     status: "idle",
@@ -1528,13 +1578,16 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
       props.session.setPendingProviderSwitch?.(switchSpec);
     }
   }, [setAppState, props.session]);
-  const applyOnboardingSelection = useCallback((next_0: FirstRunOnboardingState) => {
+  const applyOnboardingSelection = useCallback(async (next_0: FirstRunOnboardingState) => {
+    await persistOnboardingSelection(props, agencHome, next_0).catch(error => {
+      logError(error);
+    });
     setModel(next_0.selectedModel);
     props.session.setPendingProviderSwitch?.({
       provider: next_0.selectedProvider,
       model: next_0.selectedModel
     });
-  }, [props.session, setModel]);
+  }, [agencHome, props, setModel]);
   const onboarding = useFirstRunOnboardingController({
     ...onboardingContext,
     hasInitialPrompt: (props.initialPrompt?.length ?? 0) > 0 || (props.initialUserMessages?.length ?? 0) > 0,

--- a/runtime/src/tui/components/design-system/ThemeProvider.tsx
+++ b/runtime/src/tui/components/design-system/ThemeProvider.tsx
@@ -3,6 +3,7 @@ import { c as _c } from "react-compiler-runtime";
 import { feature } from 'bun:bundle';
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useStdin } from '../../ink/components/StdinContext.js';
+import { configReadsEnabled } from '../../../config/init.js';
 import { getGlobalConfig, saveGlobalConfig } from '../../../utils/config.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { logError } from '../../../utils/log.js';
 import { getSystemThemeName, type SystemTheme } from '../../../utils/systemTheme.js'; // upstream-import: keep target is owned by another Z-PURGE item
@@ -34,9 +35,15 @@ type Props = {
   onThemeSave?: (setting: ThemeSetting) => void;
 };
 function defaultInitialTheme(): ThemeSetting {
+  if (!configReadsEnabled()) {
+    return DEFAULT_THEME;
+  }
   return getGlobalConfig().theme;
 }
 function defaultSaveTheme(setting: ThemeSetting): void {
+  if (!configReadsEnabled()) {
+    return;
+  }
   saveGlobalConfig(current => ({
     ...current,
     theme: setting

--- a/runtime/src/tui/session-types.ts
+++ b/runtime/src/tui/session-types.ts
@@ -240,6 +240,7 @@ export interface ConfigStoreLike {
   readonly agencHome?: string;
   readonly snapshot?: unknown;
   current?(): AgenCConfig;
+  reload?(): Promise<AgenCConfig>;
   subscribe?(listener: (config: unknown) => void): (() => void) | void;
   warnings?(): readonly string[];
 }

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -514,6 +514,62 @@ describe("first-run onboarding wizard", () => {
     }
   });
 
+  test.each([
+    "grok",
+    "openai",
+    "anthropic",
+    "openrouter",
+    "groq",
+    "deepseek",
+    "gemini",
+  ] as const)("verifies and saves approved BYOK keys for %s", async (provider) => {
+    const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-byok-"));
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      const context = {
+        agencHome,
+        config: defaultConfig(),
+        env: {},
+        checkLocalProviders: false,
+        fetchImpl,
+      };
+      let state = createInitialFirstRunOnboardingState(context);
+      state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
+      state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
+      state = (
+        await submitFirstRunOnboardingInput(state, provider, context)
+      ).state;
+
+      expect(state.currentStepId).toBe("api-key");
+      expect(state.selectedProvider).toBe(provider);
+
+      state = (
+        await submitFirstRunOnboardingInput(
+          state,
+          `${provider}-approved-key`,
+          context,
+        )
+      ).state;
+      expect(state.pendingApiKeyApproval).toMatchObject({
+        provider,
+        verificationStatus: "valid",
+      });
+
+      state = (await submitFirstRunOnboardingInput(state, "yes", context)).state;
+      expect(state.currentStepId).toBe("security");
+      await expect(
+        new LocalAuthBackend({ agencHome }).readByokKey(provider),
+      ).resolves.toBe(`${provider}-approved-key`);
+    } finally {
+      rmSync(agencHome, { recursive: true, force: true });
+    }
+  });
+
   test("keeps rejected BYOK API keys out of local auth", async () => {
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-byok-"));
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -1,5 +1,5 @@
 import { PassThrough } from "node:stream";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import React, { type SetStateAction } from "react";
@@ -3305,8 +3305,8 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           await submit("next");
           await submit("1");
           await submit("2");
+          await submit("skip");
           await submit("test");
-          await submit("next");
           await submit("next");
           await submit("done");
 
@@ -3361,7 +3361,6 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           await submit("next");
           await submit("1");
           await submit("1");
-          await submit("test");
           await submit("xai-app-key");
 
           expect(output()).toContain("Approve BYOK API key");
@@ -3376,6 +3375,87 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       );
     } finally {
       fetchSpy.mockRestore();
+      rmSync(agencHome, { recursive: true, force: true });
+    }
+  });
+
+  test("persists first-run BYOK provider selection for restarts", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    const { LocalAuthBackend } = await import("../../auth/backends/local.js");
+    const session = {
+      ...createSession(),
+      setPendingProviderSwitch: vi.fn(),
+    };
+    const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-persist-"));
+    const previousAgencHome = process.env.AGENC_HOME;
+    const previousConfigDir = process.env.AGENC_CONFIG_DIR;
+    process.env.AGENC_HOME = agencHome;
+    delete process.env.AGENC_CONFIG_DIR;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    providerProbe.promptSubmits.length = 0;
+    try {
+      const helpers = {
+        clearBuffer: vi.fn(),
+        resetHistory: vi.fn(),
+        setCursorOffset: vi.fn(),
+      };
+      await withRenderedApp(
+        <AgenCTuiApp
+          session={session}
+          isInteractive={true}
+          configStore={{
+            agencHome,
+            current: () => defaultConfig(),
+            reload: vi.fn(async () => defaultConfig()),
+          }}
+        />,
+        async () => {
+          const submit = async (value: string): Promise<void> => {
+            const onSubmit = providerProbe.promptSubmits.at(-1);
+            expect(onSubmit).toBeDefined();
+            await onSubmit!(value, helpers);
+            await new Promise((resolve) => setTimeout(resolve, 50));
+          };
+
+          await submit("next");
+          await submit("1");
+          await submit("deepseek");
+          await submit("sk-deepseek-onboarding-test");
+          await submit("yes");
+          await submit("next");
+          await submit("done");
+
+          expect(session.setPendingProviderSwitch).toHaveBeenLastCalledWith({
+            provider: "deepseek",
+            model: "deepseek-reasoner",
+          });
+          await expect(
+            new LocalAuthBackend({ agencHome }).readByokKey("deepseek"),
+          ).resolves.toBe("sk-deepseek-onboarding-test");
+          expect(
+            JSON.parse(readFileSync(join(agencHome, "settings.json"), "utf8")),
+          ).toMatchObject({ model: "deepseek-reasoner" });
+          const configToml = readFileSync(join(agencHome, "config.toml"), "utf8");
+          expect(configToml).toContain('"model_provider" = "deepseek"');
+          expect(configToml).toContain('"model" = "deepseek-reasoner"');
+          expect(configToml).toContain('"default_model" = "deepseek-reasoner"');
+        },
+      );
+    } finally {
+      fetchSpy.mockRestore();
+      providerProbe.promptSubmits.length = 0;
+      if (previousAgencHome === undefined) {
+        delete process.env.AGENC_HOME;
+      } else {
+        process.env.AGENC_HOME = previousAgencHome;
+      }
+      if (previousConfigDir === undefined) {
+        delete process.env.AGENC_CONFIG_DIR;
+      } else {
+        process.env.AGENC_CONFIG_DIR = previousConfigDir;
+      }
       rmSync(agencHome, { recursive: true, force: true });
     }
   });

--- a/runtime/tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx
+++ b/runtime/tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "./ThemeProvider.js";
 
 const mocks = vi.hoisted(() => {
+  const configReadsEnabled = vi.fn(() => true);
   const feature = vi.fn(() => false);
   const getGlobalConfig = vi.fn(() => ({ theme: "auto" }));
   const logError = vi.fn();
@@ -24,6 +25,7 @@ const mocks = vi.hoisted(() => {
   const watchSystemTheme = vi.fn(() => () => {});
 
   return {
+    configReadsEnabled,
     feature,
     getGlobalConfig,
     getSystemThemeName,
@@ -33,6 +35,10 @@ const mocks = vi.hoisted(() => {
     watchSystemTheme,
   };
 });
+
+vi.mock("../../../config/init.js", () => ({
+  configReadsEnabled: mocks.configReadsEnabled,
+}));
 
 vi.mock("bun:bundle", () => ({
   feature: mocks.feature,
@@ -113,6 +119,48 @@ async function waitFor(
 }
 
 describe("ThemeProvider", () => {
+  test("uses a dark fallback before config reads are enabled", async () => {
+    mocks.configReadsEnabled.mockReturnValueOnce(false);
+    const snapshots: ThemeSnapshot[] = [];
+    const { stderr, stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+
+    function Probe() {
+      const [theme] = useTheme();
+      const setting = useThemeSetting();
+
+      React.useEffect(() => {
+        snapshots.push({ setting, theme });
+      }, [setting, theme]);
+
+      return <Text>{`${setting}:${theme}`}</Text>;
+    }
+
+    try {
+      root.render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+      );
+
+      await waitFor(
+        () => snapshots.some(snapshot => snapshot.setting === "dark" && snapshot.theme === "dark"),
+        "dark fallback theme was not used",
+      );
+      expect(mocks.getGlobalConfig).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+
   test("resolves cached auto themes, previews changes, and persists default saves", async () => {
     const snapshots: ThemeSnapshot[] = [];
     let controls: ProbeControls | undefined;


### PR DESCRIPTION
## Summary
- persist first-run onboarding provider/model selection into the session AgenC home
- write model_provider/model/default_model so BYOK providers like DeepSeek survive restart
- avoid early TUI config reads before the startup config gate is enabled
- add regression coverage for DeepSeek, BYOK providers, and early ThemeProvider mounting

## Verification
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx tests/tui/components/App.render.test.tsx tests/onboarding/onboarding.test.tsx
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime