### PR TITLE
fix: hide generic OpenRouter free route from pickers

### DIFF
--- a/runtime/src/commands/auth.tsx
+++ b/runtime/src/commands/auth.tsx
@@ -19,8 +19,7 @@ import {
   hasHostedManagedAccess,
   subscriptionManagedDefaultModel,
   subscriptionManagedDefaultModelForTier,
-  subscriptionManagedModels,
-  subscriptionManagedModelsForTier,
+  visibleSubscriptionManagedModelsForTier,
 } from "./subscription-managed-models.js";
 
 type AuthAction = "login" | "logout" | "whoami" | "subscription" | "usage";
@@ -396,7 +395,7 @@ export function formatSubscriptionCommandResult(tier: string | undefined): strin
   ];
   if (plan === "pro" || plan === "team" || plan === "enterprise") {
     const provider = "openrouter";
-    const models = subscriptionManagedModels(provider);
+    const models = visibleSubscriptionManagedModelsForTier(provider, plan);
     const defaultModel = subscriptionManagedDefaultModel(provider);
     lines.push(
       "Managed models: enabled",
@@ -409,7 +408,7 @@ export function formatSubscriptionCommandResult(tier: string | undefined): strin
     );
   } else if (plan === "free") {
     const provider = "openrouter";
-    const models = subscriptionManagedModelsForTier(provider, "free");
+    const models = visibleSubscriptionManagedModelsForTier(provider, "free");
     const defaultModel = subscriptionManagedDefaultModelForTier(provider, "free");
     lines.push(
       "Free hosted models: enabled",

--- a/runtime/src/commands/model-menu.tsx
+++ b/runtime/src/commands/model-menu.tsx
@@ -23,7 +23,7 @@ import {
   hasHostedManagedAccess,
   hostedManagedSubscriptionTier,
   providerHasLiveSubscriptionRoute,
-  subscriptionManagedModelsForTier,
+  visibleSubscriptionManagedModelsForTier,
 } from "./subscription-managed-models.js";
 import type { SlashCommandContext } from "./types.js";
 
@@ -328,7 +328,7 @@ export function readModelMenuSnapshot(ctx: SlashCommandContext): ModelMenuSnapsh
       providerHasLiveSubscriptionRoute(catalogProvider) &&
       !providerHasByok(catalogProvider)
     ) {
-      return subscriptionManagedModelsForTier(
+      return visibleSubscriptionManagedModelsForTier(
         catalogProvider,
         managedSubscriptionTier,
       );

--- a/runtime/src/commands/model.ts
+++ b/runtime/src/commands/model.ts
@@ -61,7 +61,7 @@ import {
   isSubscriptionManagedModel,
   providerHasLiveSubscriptionRoute,
   subscriptionManagedModels,
-  subscriptionManagedModelsForTier,
+  visibleSubscriptionManagedModelsForTier,
 } from "./subscription-managed-models.js";
 
 export interface HistoryCompatResult {
@@ -342,7 +342,7 @@ function subscriptionManagedModelError(
   if (isSubscriptionManagedModel(provider, targetModel)) return undefined;
   const tier = remoteAuthSessionSubscriptionTierSync(process.env);
   const example =
-    subscriptionManagedModelsForTier(provider, tier)[0] ??
+    visibleSubscriptionManagedModelsForTier(provider, tier)[0] ??
     subscriptionManagedModels(provider)[0];
   const hint =
     example !== undefined

--- a/runtime/src/commands/provider-menu.tsx
+++ b/runtime/src/commands/provider-menu.tsx
@@ -24,7 +24,7 @@ import {
   hostedManagedSubscriptionTier,
   providerHasLiveSubscriptionRoute,
   subscriptionManagedDefaultModelForTier,
-  subscriptionManagedModelsForTier,
+  visibleSubscriptionManagedModelsForTier,
 } from "./subscription-managed-models.js";
 import type { SlashCommandContext } from "./types.js";
 
@@ -463,7 +463,7 @@ export function readProviderMenuSnapshot(ctx: SlashCommandContext): ProviderMenu
     const rawModels = modelCatalog[provider] ?? [];
     const managedModels =
       managedSubscriptionAvailable && providerHasLiveSubscriptionRoute(provider)
-        ? subscriptionManagedModelsForTier(provider, managedSubscriptionTier)
+        ? visibleSubscriptionManagedModelsForTier(provider, managedSubscriptionTier)
         : undefined;
     const models = managedModels !== undefined ? managedModels : rawModels;
     const state = runtimeState({

--- a/runtime/src/commands/provider.ts
+++ b/runtime/src/commands/provider.ts
@@ -45,7 +45,7 @@ import {
   isSubscriptionManagedModel,
   providerHasLiveSubscriptionRoute,
   subscriptionManagedDefaultModelForTier,
-  subscriptionManagedModelsForTier,
+  visibleSubscriptionManagedModelsForTier,
 } from "./subscription-managed-models.js";
 
 /**
@@ -226,7 +226,7 @@ function subscriptionManagedModelError(
   }
   if (!providerHasLiveSubscriptionRoute(normalizedProvider)) return undefined;
   if (isSubscriptionManagedModel(normalizedProvider, targetModel)) return undefined;
-  const liveModels = subscriptionManagedModelsForTier(
+  const liveModels = visibleSubscriptionManagedModelsForTier(
     normalizedProvider,
     remoteAuthSessionSubscriptionTierSync(process.env),
   )

--- a/runtime/src/commands/subscription-managed-models.ts
+++ b/runtime/src/commands/subscription-managed-models.ts
@@ -10,6 +10,9 @@ import type { AuthSubscriptionTier } from "../auth/backend.js";
 import { OPENROUTER_FREE_MODEL_IDS } from "../llm/registry/openrouter-free-models.js";
 
 export const SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER: ProviderSlug = "openrouter";
+const HIDDEN_SUBSCRIPTION_MANAGED_MODEL_IDS = new Set<string>([
+  "openrouter/free",
+]);
 
 const OPENROUTER_PAID_MODELS = [
   "x-ai/grok-4.3",
@@ -74,6 +77,15 @@ export function subscriptionManagedModelsForTier(
   return [];
 }
 
+export function visibleSubscriptionManagedModelsForTier(
+  provider: ProviderSlug | string,
+  tier: AuthSubscriptionTier | undefined,
+): readonly string[] {
+  return subscriptionManagedModelsForTier(provider, tier).filter(
+    (model) => !HIDDEN_SUBSCRIPTION_MANAGED_MODEL_IDS.has(model),
+  );
+}
+
 export function providerHasLiveSubscriptionRoute(
   provider: ProviderSlug | string,
 ): boolean {
@@ -116,7 +128,7 @@ export function subscriptionManagedDefaultModelForTier(
   provider: ProviderSlug | string,
   tier: AuthSubscriptionTier | undefined,
 ): string | undefined {
-  return subscriptionManagedModelsForTier(provider, tier)[0];
+  return visibleSubscriptionManagedModelsForTier(provider, tier)[0];
 }
 
 export function isSubscriptionManagedModel(

--- a/runtime/tests/commands/model.test.ts
+++ b/runtime/tests/commands/model.test.ts
@@ -449,7 +449,7 @@ describe("modelCommand", () => {
       "minimax/minimax-m2.5",
       "z-ai/glm-4.7-flash",
     ]);
-    expect(openrouterModels).toContain("openrouter/free");
+    expect(openrouterModels).not.toContain("openrouter/free");
     expect(openrouterModels).toContain("openai/gpt-oss-20b:free");
     expect(openrouterModels.length).toBeGreaterThan(19);
     expect(snapshot.rows.every(row => row.provider === "openrouter")).toBe(true);

--- a/runtime/tests/commands/provider.test.ts
+++ b/runtime/tests/commands/provider.test.ts
@@ -406,7 +406,7 @@ describe("providerCommand", () => {
         "minimax/minimax-m2.5",
         "z-ai/glm-4.7-flash",
       ]);
-      expect(openrouter?.models).toContain("openrouter/free");
+      expect(openrouter?.models).not.toContain("openrouter/free");
       expect(openrouter?.models).toContain("openai/gpt-oss-20b:free");
       expect(openrouter?.models.length).toBeGreaterThan(19);
       expect(openrouter?.credentialSource).toContain("subscription-managed key");


### PR DESCRIPTION
## Summary
- hide the generic openrouter/free route from /model and /provider picker surfaces
- keep openrouter/free accepted internally/manual so existing configs do not break
- keep concrete free models like openai/gpt-oss-20b:free visible

## Verification
- npm --workspace=@tetsuo-ai/runtime run test -- tests/commands/provider.test.ts tests/commands/model.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck
- npm --workspace=@tetsuo-ai/runtime run build