### PR TITLE
feat(runtime): wire the aggregate tool-result context budget

### DIFF
--- a/runtime/src/phases/post-sample-recovery.ts
+++ b/runtime/src/phases/post-sample-recovery.ts
@@ -30,6 +30,7 @@ import {
   toRuntimeMessageContent,
 } from "../llm/content-conversion.js";
 import { compactConversation } from "../services/compact/compact.js";
+import { shrinkOversizedToolResults } from "../session/_deps/tool-result-storage.js";
 import type { RuntimeMessage } from "../services/compact/types.js";
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
@@ -100,11 +101,23 @@ export async function runContextCollapseOverflowRecovery(params: {
   } as const;
 }
 
+/**
+ * Cap applied to each tool result retained in the recovery tail. The
+ * overflow usually IS one oversized recent result — retaining it
+ * verbatim used to reproduce the very overflow this recovery exists to
+ * fix, looping the 413. Head+tail slicing keeps the pairing valid while
+ * guaranteeing the rebuilt prompt is small.
+ */
+const RECOVERY_TAIL_RESULT_CAP_CHARS = 20_000;
+
 async function recoverFromOverflow(
   messages: RuntimeMessage[],
 ): Promise<{ readonly messages: RuntimeMessage[]; readonly committed: number }> {
   if (messages.length < 4) return { messages, committed: 0 };
-  const retainedTail = selectOverflowRetainedTail(messages);
+  const retainedTail = shrinkOversizedToolResults(
+    selectOverflowRetainedTail(messages) as CollapseRuntimeMessage[],
+    RECOVERY_TAIL_RESULT_CAP_CHARS,
+  ).messages as unknown as readonly RuntimeMessage[];
   const compacted = await compactConversation(
     messages,
     {},

--- a/runtime/src/session/_deps/tool-result-storage.ts
+++ b/runtime/src/session/_deps/tool-result-storage.ts
@@ -122,3 +122,343 @@ export function provisionContentReplacementState(
   }
   return createContentReplacementState();
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Enforcement — the aggregate per-message-group tool-result budget.
+//
+// This is the half the module doc above promises. It operates on the
+// FLAT message shape used on the live turn path (tool results are their
+// own messages carrying `toolCallId`; after runtime conversion the role
+// is "user" with `originalRole: "tool"`), grouping consecutive tool
+// results the way the provider wire folds them into one API message.
+//
+// Prompt-cache contract (identical to the block-shaped implementation
+// in utils/toolResultStorage.ts):
+//   - ids in `state.replacements` re-apply their cached preview string
+//     byte-identically every turn (zero I/O);
+//   - ids in `state.seenIds` but not `replacements` are FROZEN — never
+//     replaced later (the model already saw the full content);
+//   - only FRESH ids (never seen) are eligible, and only when their
+//     group exceeds the budget.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Structural shape the budget needs — satisfied by both LLMMessage and
+ *  the runtime-converted message (which mirrors content into `.message`). */
+export interface ToolResultBudgetMessage {
+  readonly role?: string;
+  readonly originalRole?: string;
+  readonly toolCallId?: string;
+  readonly content?: unknown;
+  readonly message?: { readonly role?: string; readonly content?: unknown };
+}
+
+export interface ToolResultBudgetOptions {
+  /** Per-message-group budget in characters. */
+  readonly limitChars: number;
+  /** Results smaller than this are never persisted (preview overhead
+   *  would not pay for itself). Default 2_000. */
+  readonly minReplaceChars?: number;
+  /**
+   * Persist an oversized result and return the replacement preview
+   * string the model will see instead, or null when persistence failed
+   * (the original content is then kept and frozen).
+   */
+  readonly persist: (
+    content: string,
+    toolUseId: string,
+  ) => Promise<string | null>;
+}
+
+interface FlatCandidate {
+  readonly index: number;
+  readonly toolUseId: string;
+  readonly content: string;
+  readonly size: number;
+}
+
+/**
+ * Extract the replaceable text of a tool-result message. The turn path
+ * carries content in TWO shapes: a plain string (flat LLMMessage) or an
+ * array of `{type:"text", text}` blocks (runtime-converted messages).
+ * Mixed/non-text block arrays (images, documents) return null — those
+ * results must never be persisted or shrunk.
+ */
+function extractToolResultText(
+  message: ToolResultBudgetMessage,
+): string | null {
+  if (message.originalRole !== "tool" && message.role !== "tool") return null;
+  if (typeof message.toolCallId !== "string" || message.toolCallId.length === 0) {
+    return null;
+  }
+  const content = message.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content) && content.length > 0) {
+    const texts: string[] = [];
+    for (const block of content) {
+      if (
+        !block ||
+        typeof block !== "object" ||
+        (block as { type?: unknown }).type !== "text" ||
+        typeof (block as { text?: unknown }).text !== "string"
+      ) {
+        return null;
+      }
+      texts.push((block as { text: string }).text);
+    }
+    return texts.join("\n");
+  }
+  return null;
+}
+
+
+/** Group consecutive tool-result messages (one wire-level API message). */
+function collectFlatCandidateGroups(
+  messages: ReadonlyArray<ToolResultBudgetMessage>,
+): FlatCandidate[][] {
+  const groups: FlatCandidate[][] = [];
+  let current: FlatCandidate[] = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    const text = message !== undefined ? extractToolResultText(message) : null;
+    if (message !== undefined && text !== null) {
+      current.push({
+        index,
+        toolUseId: message.toolCallId as string,
+        content: text,
+        size: text.length,
+      });
+    } else if (current.length > 0) {
+      groups.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
+function selectFreshToReplace(
+  fresh: ReadonlyArray<FlatCandidate>,
+  frozenSize: number,
+  limit: number,
+  minReplaceChars: number,
+): FlatCandidate[] {
+  const sorted = [...fresh].sort((a, b) => b.size - a.size);
+  const selected: FlatCandidate[] = [];
+  let remaining = frozenSize + fresh.reduce((sum, c) => sum + c.size, 0);
+  for (const candidate of sorted) {
+    if (remaining <= limit) break;
+    if (candidate.size < minReplaceChars) break;
+    selected.push(candidate);
+    // Replacement previews are ~2K while anything selected here is much
+    // larger — subtracting the full size is a close approximation.
+    remaining -= candidate.size;
+  }
+  return selected;
+}
+
+function withReplacedContent<M extends ToolResultBudgetMessage>(
+  message: M,
+  replacement: string,
+): M {
+  // Preserve the content SHAPE the message arrived with: block arrays
+  // stay block arrays (the runtime-converted path), strings stay strings.
+  const shaped = Array.isArray(message.content)
+    ? [{ type: "text", text: replacement }]
+    : replacement;
+  return {
+    ...message,
+    content: shaped,
+    ...(message.message !== undefined
+      ? {
+          message: {
+            ...message.message,
+            content: Array.isArray(message.message.content)
+              ? [{ type: "text", text: replacement }]
+              : replacement,
+          },
+        }
+      : {}),
+  };
+}
+
+/**
+ * Enforce the aggregate tool-result budget on a message list. Mutates
+ * `state` in place (seenIds/replacements) — the caller holds the stable
+ * per-thread reference. Returns the input array unchanged when nothing
+ * needed replacing.
+ */
+export async function applyToolResultBudget<
+  M extends ToolResultBudgetMessage,
+>(
+  messages: ReadonlyArray<M>,
+  state: ContentReplacementState | undefined,
+  opts: ToolResultBudgetOptions,
+): Promise<{ messages: M[]; newlyReplaced: ContentReplacementRecord[] }> {
+  if (state === undefined || opts.limitChars <= 0) {
+    return { messages: [...messages], newlyReplaced: [] };
+  }
+  const minReplaceChars = opts.minReplaceChars ?? 2_000;
+  const replacementByIndex = new Map<number, string>();
+  const toPersist: FlatCandidate[] = [];
+
+  for (const group of collectFlatCandidateGroups(messages)) {
+    const mustReapply: FlatCandidate[] = [];
+    const frozen: FlatCandidate[] = [];
+    const fresh: FlatCandidate[] = [];
+    for (const candidate of group) {
+      if (state.replacements.has(candidate.toolUseId)) {
+        mustReapply.push(candidate);
+      } else if (state.seenIds.has(candidate.toolUseId)) {
+        frozen.push(candidate);
+      } else {
+        fresh.push(candidate);
+      }
+    }
+
+    for (const candidate of mustReapply) {
+      const cached = state.replacements.get(candidate.toolUseId);
+      if (cached !== undefined && cached !== candidate.content) {
+        replacementByIndex.set(candidate.index, cached);
+      }
+    }
+
+    if (fresh.length === 0) continue;
+
+    const frozenSize = frozen.reduce((sum, c) => sum + c.size, 0);
+    const freshSize = fresh.reduce((sum, c) => sum + c.size, 0);
+    const selected =
+      frozenSize + freshSize > opts.limitChars
+        ? selectFreshToReplace(
+            fresh,
+            frozenSize,
+            opts.limitChars,
+            minReplaceChars,
+          )
+        : [];
+
+    // Non-selected fresh ids freeze NOW so their fate is stable even if
+    // a later group persists (mirrors the block-shaped implementation's
+    // atomicity note).
+    const selectedIds = new Set(selected.map((c) => c.toolUseId));
+    for (const candidate of fresh) {
+      if (!selectedIds.has(candidate.toolUseId)) {
+        state.seenIds.add(candidate.toolUseId);
+      }
+    }
+    toPersist.push(...selected);
+  }
+
+  const newlyReplaced: ContentReplacementRecord[] = [];
+  for (const candidate of toPersist) {
+    const replacement = await opts.persist(
+      candidate.content,
+      candidate.toolUseId,
+    );
+    // Seen either way: on persist failure the full content was (and
+    // keeps being) sent, so freezing it is the cache-safe outcome.
+    state.seenIds.add(candidate.toolUseId);
+    if (replacement === null) continue;
+    state.replacements.set(candidate.toolUseId, replacement);
+    replacementByIndex.set(candidate.index, replacement);
+    newlyReplaced.push({
+      kind: "tool-result",
+      toolUseId: candidate.toolUseId,
+      replacement,
+    });
+  }
+
+  if (replacementByIndex.size === 0) {
+    return { messages: [...messages], newlyReplaced };
+  }
+  const next = messages.map((message, index) => {
+    const replacement = replacementByIndex.get(index);
+    return replacement === undefined
+      ? message
+      : withReplacedContent(message, replacement);
+  });
+  return { messages: next, newlyReplaced };
+}
+
+const SHRINK_MARKER_TEMPLATE =
+  "\n\n[shrunk to fit the context window: original was {ORIG} chars, keeping the first {HEAD} and last {TAIL}]\n\n";
+
+/**
+ * Head+tail slice of an oversized tool-result string. Keeps the opening
+ * (usually the most information-dense part) AND the closing (errors,
+ * summaries, exit status often live at the end) with an explicit marker
+ * between, so the model knows content was cut and can re-fetch.
+ */
+export function shrinkToolResultContent(
+  content: string,
+  maxChars: number,
+): string {
+  if (content.length <= maxChars) return content;
+  const headChars = Math.floor(maxChars * 0.7);
+  const tailChars = Math.max(0, maxChars - headChars);
+  const marker = SHRINK_MARKER_TEMPLATE.replace(
+    "{ORIG}",
+    String(content.length),
+  )
+    .replace("{HEAD}", String(headChars))
+    .replace("{TAIL}", String(tailChars));
+  return content.slice(0, headChars) + marker + content.slice(
+    content.length - tailChars,
+  );
+}
+
+/**
+ * Emergency truncate-to-fit: shrink every tool-result message whose
+ * string content exceeds `maxCharsPerResult` to a head+tail slice.
+ * Message COUNT and tool_use/tool_result pairing are never touched —
+ * only result contents shrink, so the thread stays valid.
+ *
+ * Returns the same array instance when nothing was over the cap.
+ */
+export function shrinkOversizedToolResults<M extends ToolResultBudgetMessage>(
+  messages: ReadonlyArray<M>,
+  maxCharsPerResult: number,
+): { messages: M[]; shrunkCount: number } {
+  let shrunkCount = 0;
+  const next = messages.map((message) => {
+    const content = extractToolResultText(message);
+    if (content === null || content.length <= maxCharsPerResult) {
+      return message;
+    }
+    shrunkCount += 1;
+    return withReplacedContent(
+      message,
+      shrinkToolResultContent(content, maxCharsPerResult),
+    );
+  });
+  return shrunkCount > 0
+    ? { messages: next, shrunkCount }
+    : { messages: [...messages], shrunkCount: 0 };
+}
+
+/**
+ * Resolve the per-message-group character budget: explicit env override
+ * first (`AGENC_TOOL_RESULT_BUDGET_CHARS`; `0` disables enforcement),
+ * else window-relative — half the context window in characters
+ * (~4 chars/token), clamped to the fixed 200K ceiling shared with the
+ * block-shaped implementation and a 50K floor so tiny windows still
+ * hold a useful result.
+ */
+export function resolveToolResultBudgetChars(
+  contextWindowTokens: number | undefined,
+): number {
+  const override = process.env.AGENC_TOOL_RESULT_BUDGET_CHARS;
+  if (override !== undefined && override !== "") {
+    const parsed = Number(override);
+    if (Number.isFinite(parsed) && parsed >= 0) return Math.floor(parsed);
+  }
+  const ceiling = 200_000;
+  if (
+    contextWindowTokens === undefined ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return ceiling;
+  }
+  const windowRelative = Math.floor(contextWindowTokens * 4 * 0.5);
+  return Math.max(50_000, Math.min(windowRelative, ceiling));
+}

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -67,6 +67,12 @@ import type {
   RuntimeMessage,
 } from "../services/compact/types.js";
 import { getAutoCompactThreshold } from "../services/compact/autoCompact.js";
+import {
+  applyToolResultBudget,
+  resolveToolResultBudgetChars,
+  shrinkOversizedToolResults,
+  type ContentReplacementState,
+} from "./_deps/tool-result-storage.js";
 import { roughTokenCountEstimationForMessages } from "../llm/token-estimation.js";
 import { startCodeModeTurnWorker } from "../tools/code-mode/turn-host.js";
 import { commit } from "../phases/commit.js";
@@ -348,6 +354,7 @@ async function prepareAgenCTurnContext(
       messages,
       toolUseContext,
       querySource,
+      contentReplacementState: state.contentReplacementState,
     });
     state.messagesForQuery = prepared.messages;
     state.snipTokensFreed = prepared.snipTokensFreed;
@@ -499,6 +506,7 @@ async function prepareAgenCQueryMessages(params: {
   readonly messages: readonly LLMMessage[];
   readonly toolUseContext: AgenCToolUseContext;
   readonly querySource: string;
+  readonly contentReplacementState?: ContentReplacementState;
 }): Promise<{
   readonly messages: LLMMessage[];
   readonly snipTokensFreed: number;
@@ -507,7 +515,16 @@ async function prepareAgenCQueryMessages(params: {
   try {
     const result = await withCompactContextGuards(async () => {
       let messages = toAgenCRuntimeMessages(params.messages);
-      const budgeted = await applyToolResultBudget(messages);
+      const budgeted = await applyToolResultBudget(
+        messages,
+        params.contentReplacementState,
+        {
+          limitChars: resolveToolResultBudgetChars(
+            params.toolUseContext.options.contextWindowTokens,
+          ),
+          persist: persistOversizedToolResult,
+        },
+      );
       messages = budgeted.messages as AgenCRuntimeMessage[];
       const { microcompactMessages } =
         await import("../services/compact/microCompact.js");
@@ -519,7 +536,10 @@ async function prepareAgenCQueryMessages(params: {
       messages = microcompactResult.messages as AgenCRuntimeMessage[];
       const committed = false;
       return {
-        messages: fromAgenCRuntimeMessages(messages),
+        messages: truncateToolResultsToFit(
+          fromAgenCRuntimeMessages(messages),
+          params.toolUseContext.options.contextWindowTokens,
+        ),
         snipTokensFreed: 0,
         committed,
       };
@@ -534,11 +554,52 @@ async function prepareAgenCQueryMessages(params: {
   }
 }
 
-async function applyToolResultBudget(messages: RuntimeMessage[]): Promise<{
-  readonly messages: RuntimeMessage[];
-  readonly newlyReplaced: readonly unknown[];
-}> {
-  return { messages, newlyReplaced: [] };
+/**
+ * Pre-send truncate-to-fit backstop. The mid-turn compact gate anchors
+ * on the PREVIOUS sample's `promptTokens`, which cannot see tool
+ * results added since — a burst of large results can push the next
+ * request past the window and waste a full 413 round-trip before the
+ * reactive collapse fires. When the assembled request's rough estimate
+ * exceeds the window minus an output reserve, shrink oversized tool
+ * results (head+tail slices, pairing preserved) at progressively
+ * tighter caps until it fits or nothing shrinkable remains.
+ */
+function truncateToolResultsToFit(
+  messages: LLMMessage[],
+  contextWindowTokens: number | undefined,
+): LLMMessage[] {
+  const window = finitePositive(contextWindowTokens);
+  if (window === undefined) return messages;
+  const fitTokens = Math.max(8_000, window - 16_000);
+  let estimate = roughTokenCountEstimationForMessages(messages);
+  if (estimate <= fitTokens) return messages;
+  let out = messages;
+  for (const cap of [100_000, 50_000, 20_000, 8_000]) {
+    const shrunk = shrinkOversizedToolResults(out, cap);
+    if (shrunk.shrunkCount === 0) continue;
+    out = shrunk.messages;
+    estimate = roughTokenCountEstimationForMessages(out);
+    if (estimate <= fitTokens) break;
+  }
+  return out;
+}
+
+/**
+ * Persist an over-budget tool result via the shared tool-results store
+ * (same disk layout as the single-result offload path in
+ * `tools/execution.ts`, so the model's FileRead pointer works for both)
+ * and return the preview replacement string, or null on failure.
+ */
+async function persistOversizedToolResult(
+  content: string,
+  toolUseId: string,
+): Promise<string | null> {
+  const { persistToolResult, buildLargeToolResultMessage } = await import(
+    "../utils/toolResultStorage.js"
+  );
+  const persisted = await persistToolResult(content, toolUseId);
+  if ("error" in persisted) return null;
+  return buildLargeToolResultMessage(persisted);
 }
 
 async function toAgenCCompactionResult(

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -730,6 +730,87 @@ describe("runTurn — T6 gap #119 lifecycle emits", () => {
     }
   });
 
+  test("a burst of medium tool results is bounded by the aggregate budget (wiring)", async () => {
+    // Each result stays BELOW the single-result execution cap
+    // (MIN_TOOL_RESULT_BYTES = 16K on this 1024-token window), so only
+    // the aggregate per-group budget can bound the sum: 10 × 12K = 120K
+    // chars in one group vs the 50K floor budget.
+    const mediumResult = "M".repeat(12_000);
+    const seenMessages: LLMMessage[][] = [];
+    let calls = 0;
+    const provider: LLMProvider = {
+      name: "budget-provider",
+      chat: async () => ({
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        model: "test-model",
+        finishReason: "stop",
+      }),
+      chatStream: async (messages) => {
+        calls += 1;
+        seenMessages.push(messages.map((message) => ({ ...message })));
+        if (calls === 1) {
+          return {
+            content: "",
+            toolCalls: Array.from({ length: 10 }, (_, i) => ({
+              id: `budget-call-${i}`,
+              name: "budget_tool",
+              arguments: "{}",
+            })),
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "test-model",
+            finishReason: "tool_calls",
+          };
+        }
+        return {
+          content: "final",
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "test-model",
+          finishReason: "stop",
+        };
+      },
+      healthCheck: async () => true,
+    } as unknown as LLMProvider;
+    const registry: ToolRegistry = {
+      tools: [
+        {
+          name: "budget_tool",
+          description: "emits a medium result",
+          inputSchema: { type: "object", additionalProperties: false },
+          requiresApproval: false,
+          execute: async () => ({ content: mediumResult, isError: false }),
+        },
+      ],
+      toLLMTools: () => [],
+      dispatch: async () => ({ content: mediumResult, isError: false }),
+    } as unknown as ToolRegistry;
+    const { session } = mkSession({ provider, registry });
+
+    await drain(session.runTurn("run the big tools", { ctx: mkCtx() }));
+
+    expect(calls).toBe(2);
+    const second = seenMessages[1] ?? [];
+    const verbatimCount = second.filter(
+      (message) =>
+        typeof message.content === "string" &&
+        message.content.includes(mediumResult),
+    ).length;
+    const totalChars = second.reduce(
+      (sum, message) =>
+        sum +
+        (typeof message.content === "string" ? message.content.length : 0),
+      0,
+    );
+    // With the budget wired, most of the 10 results are replaced by
+    // persisted previews (or shrunk); the assembled request is bounded.
+    // Fails when the run-turn wiring is reverted to the no-op stub
+    // (all 10 × 12K flow verbatim → totalChars > 120K).
+    expect(verbatimCount).toBeLessThan(10);
+    expect(totalChars).toBeLessThan(80_000);
+  });
+
   test("stamps the seed user message with the user_message event id (file-history join)", async () => {
     const ctx = mkCtx();
     const { session, events } = mkSession({

--- a/runtime/tests/session/tool-result-budget.test.ts
+++ b/runtime/tests/session/tool-result-budget.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  applyToolResultBudget,
+  provisionContentReplacementState,
+  resolveToolResultBudgetChars,
+  shrinkOversizedToolResults,
+  shrinkToolResultContent,
+  type ContentReplacementState,
+  type ToolResultBudgetMessage,
+} from "./_deps/tool-result-storage.js";
+import { roughTokenCountEstimationForMessages } from "../llm/token-estimation.js";
+import type { LLMMessage } from "../llm/types.js";
+
+function toolMsg(id: string, content: string): ToolResultBudgetMessage {
+  return {
+    role: "user",
+    originalRole: "tool",
+    toolCallId: id,
+    content,
+    message: { role: "user", content },
+  };
+}
+
+function assistantMsg(content = "ok"): ToolResultBudgetMessage {
+  return { role: "assistant", content, message: { role: "assistant", content } };
+}
+
+function freshState(): ContentReplacementState {
+  return provisionContentReplacementState();
+}
+
+const fakePersist = () =>
+  vi.fn(async (_content: string, toolUseId: string) => `<persisted:${toolUseId}>`);
+
+afterEach(() => {
+  delete process.env.AGENC_TOOL_RESULT_BUDGET_CHARS;
+});
+
+describe("applyToolResultBudget (flat shape)", () => {
+  test("replaces the largest fresh results when a group exceeds the budget", async () => {
+    const state = freshState();
+    const persist = fakePersist();
+    const messages = [
+      assistantMsg(),
+      ...Array.from({ length: 50 }, (_, i) =>
+        toolMsg(`id-${i}`, "x".repeat(100_000)),
+      ),
+    ];
+    const result = await applyToolResultBudget(messages, state, {
+      limitChars: 200_000,
+      persist,
+    });
+    // 50 × 100K = 5M chars; each replacement sheds ~100K so 48
+    // replacements bring the group to 200K.
+    expect(result.newlyReplaced).toHaveLength(48);
+    expect(persist).toHaveBeenCalledTimes(48);
+    const totalToolChars = result.messages
+      .filter((m) => m.originalRole === "tool")
+      .reduce((sum, m) => sum + (m.content as string).length, 0);
+    expect(totalToolChars).toBeLessThanOrEqual(220_000);
+    // Replaced messages carry the persisted marker in BOTH content mirrors.
+    const replaced = result.messages.find(
+      (m) => m.toolCallId === result.newlyReplaced[0]?.toolUseId,
+    );
+    expect(replaced?.content).toMatch(/^<persisted:/);
+    expect(replaced?.message?.content).toMatch(/^<persisted:/);
+  });
+
+  test("re-applies cached replacements byte-identically without new persists", async () => {
+    const state = freshState();
+    const persist = fakePersist();
+    const messages = [toolMsg("big", "y".repeat(300_000))];
+    const first = await applyToolResultBudget(messages, state, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(first.newlyReplaced).toHaveLength(1);
+    // Second pass over the ORIGINAL content (as replayed each turn).
+    const second = await applyToolResultBudget(messages, state, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(second.newlyReplaced).toHaveLength(0);
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(second.messages[0]?.content).toBe(first.messages[0]?.content);
+  });
+
+  test("previously-seen unreplaced results are frozen forever", async () => {
+    const state = freshState();
+    const persist = fakePersist();
+    const small = toolMsg("seen-early", "z".repeat(10_000));
+    await applyToolResultBudget([small], state, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(state.seenIds.has("seen-early")).toBe(true);
+    // Later the same result appears in an over-budget group: only the
+    // FRESH sibling may be replaced, never the frozen one.
+    const result = await applyToolResultBudget(
+      [small, toolMsg("fresh-huge", "w".repeat(400_000))],
+      state,
+      { limitChars: 200_000, persist },
+    );
+    expect(result.newlyReplaced.map((r) => r.toolUseId)).toEqual([
+      "fresh-huge",
+    ]);
+    expect(result.messages[0]?.content).toBe(small.content);
+  });
+
+  test("persist failure keeps the original content and freezes the id", async () => {
+    const state = freshState();
+    const persist = vi.fn(async () => null);
+    const messages = [toolMsg("fails", "f".repeat(300_000))];
+    const result = await applyToolResultBudget(messages, state, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(result.newlyReplaced).toHaveLength(0);
+    expect(result.messages[0]?.content).toBe(messages[0]?.content);
+    expect(state.seenIds.has("fails")).toBe(true);
+    // Never retried on the next pass (frozen).
+    await applyToolResultBudget(messages, state, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  test("results under the min-replace floor are never persisted", async () => {
+    const state = freshState();
+    const persist = fakePersist();
+    // 200 × 1K in one group = 200K > 100K limit, but every result is
+    // below the 2K floor.
+    const messages = Array.from({ length: 200 }, (_, i) =>
+      toolMsg(`tiny-${i}`, "t".repeat(1_000)),
+    );
+    const result = await applyToolResultBudget(messages, state, {
+      limitChars: 100_000,
+      persist,
+    });
+    expect(result.newlyReplaced).toHaveLength(0);
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test("groups separated by non-tool messages are budgeted independently", async () => {
+    const state = freshState();
+    const persist = fakePersist();
+    const messages = [
+      toolMsg("a", "a".repeat(150_000)),
+      assistantMsg(),
+      toolMsg("b", "b".repeat(150_000)),
+    ];
+    const result = await applyToolResultBudget(messages, state, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(result.newlyReplaced).toHaveLength(0);
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test("undefined state is a no-op", async () => {
+    const persist = fakePersist();
+    const messages = [toolMsg("x", "x".repeat(500_000))];
+    const result = await applyToolResultBudget(messages, undefined, {
+      limitChars: 200_000,
+      persist,
+    });
+    expect(result.messages[0]?.content).toBe(messages[0]?.content);
+    expect(persist).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveToolResultBudgetChars", () => {
+  test("window-relative with ceiling and floor", () => {
+    expect(resolveToolResultBudgetChars(131_072)).toBe(200_000); // clamped
+    expect(resolveToolResultBudgetChars(32_768)).toBe(65_536); // 0.5× window chars
+    expect(resolveToolResultBudgetChars(4_096)).toBe(50_000); // floor
+    expect(resolveToolResultBudgetChars(undefined)).toBe(200_000);
+  });
+
+  test("env override wins", () => {
+    process.env.AGENC_TOOL_RESULT_BUDGET_CHARS = "123456";
+    expect(resolveToolResultBudgetChars(131_072)).toBe(123_456);
+    process.env.AGENC_TOOL_RESULT_BUDGET_CHARS = "0";
+    expect(resolveToolResultBudgetChars(131_072)).toBe(0);
+  });
+});
+
+describe("shrinkToolResultContent / shrinkOversizedToolResults", () => {
+  test("head+tail slice with marker, no-op under cap", () => {
+    const content = `${"h".repeat(5_000)}${"m".repeat(5_000)}${"t".repeat(5_000)}`;
+    const shrunk = shrinkToolResultContent(content, 4_000);
+    expect(shrunk.length).toBeLessThan(5_000);
+    expect(shrunk.startsWith("hhh")).toBe(true);
+    expect(shrunk.endsWith("ttt")).toBe(true);
+    expect(shrunk).toContain("[shrunk to fit the context window");
+    expect(shrinkToolResultContent("short", 4_000)).toBe("short");
+  });
+
+  test("shrinks only oversized tool results, preserving pairing", () => {
+    const messages = [
+      assistantMsg(),
+      toolMsg("big", "b".repeat(50_000)),
+      toolMsg("small", "s".repeat(100)),
+    ];
+    const result = shrinkOversizedToolResults(messages, 10_000);
+    expect(result.shrunkCount).toBe(1);
+    expect(result.messages).toHaveLength(3);
+    expect((result.messages[1]?.content as string).length).toBeLessThan(11_000);
+    expect(result.messages[2]?.content).toBe("s".repeat(100));
+  });
+});
+
+describe("acceptance: 50 × 100KB results fit a 131K window", () => {
+  test("budget + shrink keep the assembled request under the context budget", async () => {
+    const windowTokens = 131_072;
+    const state = freshState();
+    const persist = fakePersist();
+    const messages = [
+      assistantMsg(),
+      ...Array.from({ length: 50 }, (_, i) =>
+        toolMsg(`acc-${i}`, `result ${i}: ${"data ".repeat(20_000)}`),
+      ),
+    ];
+    const budgeted = await applyToolResultBudget(messages, state, {
+      limitChars: resolveToolResultBudgetChars(windowTokens),
+      persist,
+    });
+    const flat: LLMMessage[] = budgeted.messages.map((m) => ({
+      role: (m.originalRole ?? m.role) as LLMMessage["role"],
+      content: m.content as string,
+      ...(m.toolCallId !== undefined ? { toolCallId: m.toolCallId } : {}),
+    }));
+    const estimate = roughTokenCountEstimationForMessages(flat);
+    expect(estimate).toBeLessThan(windowTokens - 16_000);
+  });
+});


### PR DESCRIPTION
## TODO task 2 — the dead aggregate tool-result budget

**Verified first (2026-07-07):** the main-turn `applyToolResultBudget` was a local no-op stub, and the enforcement half that `session/_deps/tool-result-storage.ts`'s module doc promises was never written — zero callers anywhere. Only microcompact's recent-N clearing bounded live tool output. **Refuted from the audit:** the `FileRead maxResultSizeChars: Infinity` exemption doesn't exist on the live path (legacy catalog only).

### What this ships
- Flat-shape aggregate enforcement in `_deps/tool-result-storage.ts`: consecutive tool results group as one wire message; over-budget groups persist their largest fresh results to the shared tool-results store (FileRead-recoverable) and replace them with previews. Frozen/re-apply semantics keep the prompt-cache prefix stable. Handles both string and text-block content shapes — the runtime conversion wraps strings into block arrays, which is exactly why a naive port silently no-ops (caught by the revert-sensitive integration test).
- Window-relative budget: 0.5× window in chars, 200K ceiling / 50K floor, `AGENC_TOOL_RESULT_BUDGET_CHARS` override.
- run-turn passes the already-provisioned `contentReplacementState` and runs the budget before microcompact on **every** sampling request.
- Pre-send truncate-to-fit backstop: the mid-turn compact gate anchors on the previous sample's `promptTokens` and can't see results added since; oversized results now shrink (head+tail, pairing preserved) instead of wasting a 413 round-trip.
- post-sample-recovery caps retained-tail results at 20K chars — the recovery used to retain the oversized offender verbatim, reproducing the overflow it was fixing.

### Gates
- build ✓, tsc 0 ✓
- Full vitest: 68 failures — identical to the pre-existing main set (TODO task 27); zero regressions, +13 new tests green.
- Bun: 1 failure (`useApiKeyVerification`), proven failing on clean main.
- Revert-sensitivity: with the run-turn wiring stashed back to the stub, the burst-of-medium-results integration test goes red (verified live).