### PR TITLE
feat(agents): expose worktree isolation through spawn_agent

### DIFF
--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -357,6 +357,12 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         description:
           "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns.",
       },
+      isolation: {
+        type: "string",
+        enum: ["none", "worktree"],
+        description:
+          "Optional filesystem isolation. `worktree` runs the agent in its own git worktree (branch + directory derived from task_name), so parallel agents that WRITE files never clobber each other or your working tree. Requires the cwd to be inside a git repository. Unchanged worktrees are removed automatically when the agent closes; worktrees with commits or dirty files are kept for review. Default `none` (shared cwd).",
+      },
     },
     required: ["message", "task_name"],
     additionalProperties: false,
@@ -378,6 +384,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         "service_tier",
         "fork_turns",
         "fork_context",
+        "isolation",
       ]),
       required: ["message", "task_name"],
     });
@@ -390,6 +397,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       "reasoning_effort",
       "service_tier",
       "fork_turns",
+      "isolation",
     ]) {
       if (args[key] !== undefined && typeof args[key] !== "string") {
         return json({ error: `${key} must be a string` }, true);
@@ -435,6 +443,21 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
           error:
             "Full-history forked agents inherit the parent agent type, model, and reasoning effort; omit agent_type, model, and reasoning_effort, or spawn without a full-history fork.",
         },
+        true,
+      );
+    }
+    const rawIsolation = stringValue(args.isolation);
+    if (
+      args.isolation !== undefined &&
+      rawIsolation !== "none" &&
+      rawIsolation !== "worktree"
+    ) {
+      return json({ error: "isolation must be `none` or `worktree`" }, true);
+    }
+    const isolation = rawIsolation === "worktree" ? ("worktree" as const) : undefined;
+    if (isolation !== undefined && (!taskName || taskName.length === 0)) {
+      return json(
+        { error: "worktree isolation requires a non-empty task_name (it names the worktree)" },
         true,
       );
     }
@@ -607,6 +630,9 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         ...(serviceTierResult.serviceTier !== undefined
           ? { serviceTier: serviceTierResult.serviceTier }
           : {}),
+        ...(isolation !== undefined
+          ? { isolation, worktreeSlug: taskName }
+          : {}),
       });
       if (outcome.kind === "rejected") {
         throw new Error(outcome.reason);
@@ -724,6 +750,13 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       task_name: live.agentPath,
       ...(!hideSpawnAgentMetadata(session)
         ? { nickname: live.nickname ?? null }
+        : {}),
+      ...(thread.worktree !== undefined
+        ? {
+            isolation: "worktree",
+            worktree_path: thread.worktree.path,
+            worktree_branch: thread.worktree.branch,
+          }
         : {}),
     });
   };

--- a/runtime/src/agents/worktree.ts
+++ b/runtime/src/agents/worktree.ts
@@ -323,7 +323,11 @@ export async function hasWorktreeChanges(opts: {
   readonly hasCommits: boolean;
   readonly isDirty: boolean;
 }> {
-  const status = await runGit(["status", "--porcelain", "-uno"], opts.path);
+  // NOT `-uno`: untracked files count as dirty. A subagent whose whole
+  // work product is NEW files (a fresh test, a generated report) must
+  // not have its worktree judged "unchanged" and deleted on close.
+  // Ignored files are already excluded by `--porcelain`.
+  const status = await runGit(["status", "--porcelain"], opts.path);
   if (status.code !== 0) {
     throw new Error(
       `git status failed for ${opts.path}: ${formatGitFailure(status)}`,

--- a/runtime/tests/agents/delegate-worktree.test.ts
+++ b/runtime/tests/agents/delegate-worktree.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./fork-context.js", () => ({
+  forkSubagent: vi.fn(async () => ({
+    messages: [{ role: "user", content: "seed prompt" }],
+  })),
+}));
+
+vi.mock("./run-agent.js", () => ({
+  runAgent: vi.fn(),
+}));
+
+vi.mock("../session/event-log.js", () => ({
+  emitWarning: vi.fn(),
+}));
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentStatusTracker } from "./status.js";
+import { Mailbox } from "./mailbox.js";
+import { resolveAgentRole } from "./role.js";
+import { delegate } from "./delegate.js";
+import { runAgent } from "./run-agent.js";
+import type { LiveAgent } from "./control.js";
+import type { AgentMetadata } from "./registry.js";
+
+const mockRunAgent = vi.mocked(runAgent);
+
+function makeLive(agentId: string, agentPath: string): LiveAgent {
+  const metadata: AgentMetadata = {
+    agentId,
+    agentPath,
+    agentNickname: "wt",
+    agentRole: "default",
+    depth: 1,
+  };
+  return {
+    agentId,
+    agentPath,
+    role: resolveAgentRole(undefined),
+    depth: 1,
+    nickname: "wt",
+    status: new AgentStatusTracker(),
+    upInbox: new Mailbox({ threadId: agentId }),
+    downInbox: new Mailbox({ threadId: `${agentId}-down` }),
+    abortController: new AbortController(),
+    metadata,
+    messages: [],
+    memoryEntries: [],
+    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+  } as unknown as LiveAgent;
+}
+
+function makeParentSession(cwd: string) {
+  return {
+    conversationId: "parent-session",
+    abortController: new AbortController(),
+    eventLog: {},
+    nextInternalSubId: () => "sub-1",
+    snapshotHistoryMessages: () => [],
+    sessionConfiguration: { cwd },
+    config: { cwd },
+  };
+}
+
+function git(cwd: string, ...argv: string[]): string {
+  return execFileSync("git", argv, { cwd, encoding: "utf8" });
+}
+
+function initRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "agenc-wt-repo-"));
+  git(repo, "init", "-b", "main");
+  git(repo, "config", "user.email", "test@test.invalid");
+  git(repo, "config", "user.name", "test");
+  writeFileSync(join(repo, "README.md"), "hello\n", "utf8");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "init");
+  return repo;
+}
+
+function gatedRun(): {
+  release: () => void;
+  impl: () => AsyncGenerator<never, {
+    threadId: string;
+    durationMs: number;
+    outcome: "completed";
+    finalMessage: string;
+  }>;
+} {
+  let releaseFn: () => void = () => {};
+  const gate = new Promise<void>((resolveGate) => {
+    releaseFn = resolveGate;
+  });
+  return {
+    release: () => releaseFn(),
+    impl: () =>
+      (async function* () {
+        await gate;
+        return {
+          threadId: "t",
+          durationMs: 1,
+          outcome: "completed" as const,
+          finalMessage: "done",
+        };
+      })(),
+  };
+}
+
+describe("delegate worktree isolation (real git)", () => {
+  it("gives two agents distinct worktrees; unchanged ones are removed, dirty ones kept", async () => {
+    const repo = initRepo();
+    try {
+      const gateA = gatedRun();
+      const gateB = gatedRun();
+      mockRunAgent
+        .mockImplementationOnce(gateA.impl)
+        .mockImplementationOnce(gateB.impl);
+      const control = {
+        spawn: vi
+          .fn()
+          .mockResolvedValueOnce(makeLive("thread-a", "/root/agent_a"))
+          .mockResolvedValueOnce(makeLive("thread-b", "/root/agent_b")),
+        shutdown: vi.fn(async () => {}),
+        markThreadSpawnEdgeClosed: vi.fn(async () => {}),
+        resumeAgentFromRollout: vi.fn(),
+      };
+      const parent = makeParentSession(repo) as never;
+
+      const outcomeA = await delegate({
+        parent,
+        parentPath: "/root",
+        control: control as never,
+        registry: {} as never,
+        taskPrompt: "write files",
+        isolation: "worktree",
+        worktreeSlug: "agent_a",
+      });
+      const outcomeB = await delegate({
+        parent,
+        parentPath: "/root",
+        control: control as never,
+        registry: {} as never,
+        taskPrompt: "write files too",
+        isolation: "worktree",
+        worktreeSlug: "agent_b",
+      });
+      if (outcomeA.kind !== "async_launched") {
+        throw new Error(`A: ${JSON.stringify(outcomeA)}`);
+      }
+      if (outcomeB.kind !== "async_launched") {
+        throw new Error(`B: ${JSON.stringify(outcomeB)}`);
+      }
+
+      const pathA = outcomeA.thread.worktree?.path;
+      const pathB = outcomeB.thread.worktree?.path;
+      expect(pathA).toBeDefined();
+      expect(pathB).toBeDefined();
+      expect(pathA).not.toBe(pathB);
+      expect(existsSync(pathA!)).toBe(true);
+      expect(existsSync(pathB!)).toBe(true);
+
+      // Both "agents" write the same relative file — no conflict, they
+      // live in different directories.
+      writeFileSync(join(pathA!, "shared.txt"), "from A", "utf8");
+      // B stays clean (simulates a no-op agent).
+
+      gateA.release();
+      gateB.release();
+      await outcomeA.thread.join();
+      await outcomeB.thread.join();
+
+      // A is dirty → kept for review. B unchanged → removed.
+      expect(existsSync(pathA!)).toBe(true);
+      expect(existsSync(pathB!)).toBe(false);
+      // The parent working tree never saw the write.
+      expect(existsSync(join(repo, "shared.txt"))).toBe(false);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects worktree isolation outside a git repository", async () => {
+    const plainDir = mkdtempSync(join(tmpdir(), "agenc-wt-plain-"));
+    try {
+      const control = {
+        spawn: vi.fn(),
+        shutdown: vi.fn(),
+        resumeAgentFromRollout: vi.fn(),
+      };
+      const outcome = await delegate({
+        parent: makeParentSession(plainDir) as never,
+        parentPath: "/root",
+        control: control as never,
+        registry: {} as never,
+        taskPrompt: "task",
+        isolation: "worktree",
+        worktreeSlug: "agent_x",
+      });
+      expect(outcome.kind).toBe("rejected");
+      if (outcome.kind === "rejected") {
+        expect(outcome.reason).toContain("not inside a git repository");
+      }
+      expect(control.spawn).not.toHaveBeenCalled();
+    } finally {
+      rmSync(plainDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/runtime/tests/agents/v2/spawn-isolation.test.ts
+++ b/runtime/tests/agents/v2/spawn-isolation.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../delegate.js", () => ({
+  delegate: vi.fn(),
+}));
+
+import { createSpawnAgentTool } from "./spawn.js";
+import { delegate } from "../delegate.js";
+import type { MultiAgentV2Options } from "./common.js";
+import type { Session } from "../../session/session.js";
+
+const mockDelegate = vi.mocked(delegate);
+
+interface FakeSchema {
+  readonly properties: Record<string, Record<string, unknown>>;
+}
+
+function fakeThread(withWorktree: boolean): unknown {
+  return {
+    threadId: "thread-x",
+    live: {
+      agentId: "thread-x",
+      agentPath: "/root/writer_a",
+      nickname: "wt",
+      role: { name: "default" },
+      status: { value: "running", watch: () => () => {} },
+    },
+    ...(withWorktree
+      ? {
+          worktree: {
+            path: "/repo/.agenc-worktrees/writer_a",
+            branch: "agent/writer_a",
+            gitRoot: "/repo",
+            created: true,
+          },
+        }
+      : {}),
+    onStatusChange: () => () => {},
+    join: async () => ({
+      threadId: "thread-x",
+      durationMs: 1,
+      outcome: "completed",
+    }),
+  };
+}
+
+function makeSession(): Session {
+  const emitted: unknown[] = [];
+  return {
+    conversationId: "conv-1",
+    emit: (event: unknown) => emitted.push(event),
+    nextInternalSubId: () => `sub-${emitted.length}`,
+    modelInfo: { slug: "test-model" },
+    sessionConfiguration: {
+      collaborationMode: { model: "test-model" },
+    },
+    config: { multiAgentV2: { hideSpawnAgentMetadata: false } },
+    services: {
+      modelsManager: {
+        tryListModels: () => undefined,
+        listModels: async () => [],
+        getModelInfo: async () => ({ slug: "test-model" }),
+      },
+    },
+  } as unknown as Session;
+}
+
+function makeOptions(session: Session): MultiAgentV2Options {
+  return {
+    getSession: () => session,
+    ensureAgentControl: () => ({
+      control: { getLive: () => undefined },
+      registry: {},
+    }),
+  } as unknown as MultiAgentV2Options;
+}
+
+describe("spawn_agent isolation", () => {
+  beforeEach(() => {
+    mockDelegate.mockReset();
+  });
+
+  it("exposes the isolation enum in the input schema", () => {
+    const session = makeSession();
+    const tool = createSpawnAgentTool(makeOptions(session));
+    const schema = tool.inputSchema as unknown as FakeSchema;
+    expect(schema.properties.isolation?.enum).toEqual(["none", "worktree"]);
+    expect(String(schema.properties.isolation?.description)).toContain(
+      "worktree",
+    );
+  });
+
+  it("passes isolation + worktreeSlug (task_name) through to delegate", async () => {
+    const session = makeSession();
+    const tool = createSpawnAgentTool(makeOptions(session));
+    mockDelegate.mockResolvedValueOnce({
+      kind: "async_launched",
+      thread: fakeThread(true) as never,
+    });
+    const result = await tool.execute({
+      message: "write the parser",
+      task_name: "writer_a",
+      fork_turns: "none",
+      isolation: "worktree",
+    });
+    expect(mockDelegate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isolation: "worktree",
+        worktreeSlug: "writer_a",
+      }),
+    );
+    const payload = JSON.parse(String(result.content)) as Record<
+      string,
+      unknown
+    >;
+    expect(payload.isolation).toBe("worktree");
+    expect(payload.worktree_path).toBe("/repo/.agenc-worktrees/writer_a");
+    expect(payload.worktree_branch).toBe("agent/writer_a");
+  });
+
+  it("omits isolation from delegate opts when not requested", async () => {
+    const session = makeSession();
+    const tool = createSpawnAgentTool(makeOptions(session));
+    mockDelegate.mockResolvedValueOnce({
+      kind: "async_launched",
+      thread: fakeThread(false) as never,
+    });
+    const result = await tool.execute({
+      message: "scan the repo",
+      task_name: "scanner_a",
+      fork_turns: "none",
+    });
+    const delegateOpts = mockDelegate.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(delegateOpts.isolation).toBeUndefined();
+    expect(delegateOpts.worktreeSlug).toBeUndefined();
+    const payload = JSON.parse(String(result.content)) as Record<
+      string,
+      unknown
+    >;
+    expect(payload.worktree_path).toBeUndefined();
+  });
+
+  it("rejects invalid isolation values before spawning", async () => {
+    const session = makeSession();
+    const tool = createSpawnAgentTool(makeOptions(session));
+    const result = await tool.execute({
+      message: "do it",
+      task_name: "x",
+      isolation: "chroot",
+    });
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain(
+      "isolation must be `none` or `worktree`",
+    );
+    expect(mockDelegate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## TODO task 3 — spawn_agent worktree isolation

**Verified first (2026-07-07):** `delegate()` fully implements `IsolationMode "worktree"` (creation, dirty-detection, keep-vs-remove teardown) but `spawn_agent`'s schema had no isolation param and passed none — all subagents shared the CWD.

### What this ships
- `isolation: "none" | "worktree"` on `spawn_agent`; worktree mode derives the slug from `task_name`, and the tool result reports `worktree_path` / `worktree_branch` so the model knows where the agent worked.
- **Discovered defect, fixed in-branch:** `hasWorktreeChanges` ran `git status --porcelain -uno` — untracked files invisible — so a subagent whose whole work product was *new files* had its worktree judged unchanged and **deleted on close** (silent data loss). Now untracked non-ignored files count as dirty; the real-git test proves a dirty worktree is kept and a clean one removed.

### Tests
- Real-git delegate test: two agents with worktree isolation get distinct directories, write the same relative path without conflict, parent tree untouched; unchanged worktree auto-removed, dirty one kept.
- Spawn plumbing tests (mocked delegate): schema enum, isolation+slug pass-through, omission by default, invalid-value rejection. Revert-sensitive: 3/4 fail with spawn.ts reverted.

### Gates
build ✓, tsc 0 ✓; full vitest 68 failures = the pre-existing main set (TODO task 27), zero regressions; bun 1 pre-existing (`useApiKeyVerification`).