### PR TITLE
feat(runtime): real WebSearch backends + WebFetch prompt extraction

### DIFF
--- a/runtime/src/bin/bootstrap-tool-registry.ts
+++ b/runtime/src/bin/bootstrap-tool-registry.ts
@@ -35,6 +35,9 @@ export function buildBootstrapToolRegistry(
       : {}),
     emitWarning: options.emitWarning,
     env: process.env,
+    ...(options.toolRegistryOptions?.toolsConfig !== undefined
+      ? { toolsConfig: options.toolRegistryOptions.toolsConfig }
+      : {}),
   });
   return buildToolRegistry({
     workspaceRoot: options.workspaceRoot,

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -94,6 +94,12 @@ export interface ModelFacingToolOptions {
   }) => void;
   readonly env?: NodeJS.ProcessEnv;
   readonly providerFactory?: typeof createProvider;
+  /** `[tools]` block from config.toml (env vars win over these). */
+  readonly toolsConfig?: {
+    readonly web_search_endpoint?: string;
+    readonly web_search_endpoint_kind?: string;
+    readonly [k: string]: unknown;
+  };
 }
 
 interface StoredCron {
@@ -322,6 +328,7 @@ async function fetchWithTimeout(
   opts: {
     readonly validateWebFetchUrls?: boolean;
     readonly allowWebFetchRedirect?: (nextUrl: string) => boolean;
+    readonly headers?: Readonly<Record<string, string>>;
   } = {},
 ): Promise<Response> {
   const controller = new AbortController();
@@ -334,6 +341,7 @@ async function fetchWithTimeout(
         headers: {
           "user-agent": "agenc-runtime/0.2",
           accept: "text/html,text/plain,application/json,*/*",
+          ...(opts.headers ?? {}),
         },
       });
     }
@@ -1727,12 +1735,68 @@ function checkWebFetchPermissions(
   };
 }
 
-function createWebFetchTool(toolName: string): Tool {
+/** Content below this size is returned raw — extraction wouldn't pay for itself. */
+const WEB_FETCH_EXTRACTION_MIN_CHARS = 4_000;
+/** Cap on page content handed to the extraction model call. */
+const WEB_FETCH_EXTRACTION_INPUT_CHARS = 60_000;
+/** Raw-content preview retained alongside an extraction. */
+const WEB_FETCH_EXTRACTION_PREVIEW_CHARS = 2_000;
+
+/**
+ * Run the caller's `prompt` against fetched page content through the
+ * session provider and return the extraction, or undefined when no
+ * provider is available or the call fails (callers fall back to raw
+ * content — never worse than the old echo behavior).
+ */
+async function runWebFetchExtraction(
+  opts: ModelFacingToolOptions,
+  input: {
+    readonly url: string;
+    readonly content: string;
+    readonly prompt: string;
+    readonly signal?: AbortSignal;
+  },
+): Promise<string | undefined> {
+  const provider = currentSessionProvider(opts);
+  if (!provider) return undefined;
+  try {
+    const cappedContent =
+      input.content.length > WEB_FETCH_EXTRACTION_INPUT_CHARS
+        ? `${input.content.slice(0, WEB_FETCH_EXTRACTION_INPUT_CHARS)}\n\n[content truncated for extraction]`
+        : input.content;
+    const response = await provider.chat(
+      [
+        {
+          role: "user",
+          content: `<page url="${input.url}">\n${cappedContent}\n</page>\n\nTask: ${input.prompt}`,
+        },
+      ],
+      {
+        systemPrompt:
+          "You are AgenC's web-fetch extraction step. Answer the task using ONLY the page content provided. Be concise and factual; quote exact values, names, and URLs from the page. If the page does not contain the requested information, say so explicitly.",
+        maxOutputTokens: 2_000,
+        tools: [],
+        ...(input.signal !== undefined ? { signal: input.signal } : {}),
+      },
+    );
+    const text = response.content.trim();
+    return text.length > 0 && response.finishReason !== "error"
+      ? text
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function createWebFetchTool(
+  toolName: string,
+  opts: ModelFacingToolOptions,
+): Tool {
   const isLegacy = toolName === LEGACY_WEB_FETCH_TOOL_NAME;
   return {
     name: toolName,
     description:
-      "Fetch an HTTPS URL and return readable text content plus status and final URL.",
+      "Fetch an HTTPS URL and return readable text content plus status and final URL. When `prompt` is provided, large pages are distilled: the prompt runs against the fetched content and the response carries the extraction plus a short raw preview (the full text is saved to disk for follow-up reads).",
     metadata: toolMetadata("web", {
       keywords: ["web", "fetch", "url", "http"],
       deferred: isLegacy,
@@ -1826,6 +1890,58 @@ function createWebFetchTool(toolName: string): Tool {
         } else if (raw.truncated) {
           textBody = `${body}\n\n[truncated response after ${raw.bytesRead} bytes]`;
         }
+        // Prompt-driven extraction: distill large pages instead of
+        // dumping the full markdown into context. Raw content is
+        // persisted to disk so the agent can still read it in full.
+        const prompt = stringValue(args.prompt);
+        if (
+          response.ok &&
+          prompt !== undefined &&
+          prompt.trim().length > 0 &&
+          textBody.length >= WEB_FETCH_EXTRACTION_MIN_CHARS
+        ) {
+          const extracted = await runWebFetchExtraction(opts, {
+            url: finalUrl,
+            content: textBody,
+            prompt,
+          });
+          if (extracted !== undefined) {
+            let fullContentPath: string | undefined;
+            try {
+              const { persistToolResult } = await import(
+                "../utils/toolResultStorage.js"
+              );
+              const persisted = await persistToolResult(
+                textBody,
+                `webfetch-${randomUUID()}`,
+              );
+              if (!("error" in persisted)) {
+                fullContentPath = persisted.filepath;
+              }
+            } catch {
+              /* extraction still useful without the persisted copy */
+            }
+            return json({
+              status: response.status,
+              ok: response.ok,
+              url: normalized,
+              final_url: finalUrl,
+              content_type: contentType,
+              preapproved,
+              rendered_as: renderedAs,
+              truncated: raw.truncated || body.length > maxChars,
+              prompt,
+              extracted,
+              ...(fullContentPath !== undefined
+                ? { full_content_path: fullContentPath }
+                : {}),
+              content_preview: textBody.slice(
+                0,
+                WEB_FETCH_EXTRACTION_PREVIEW_CHARS,
+              ),
+            });
+          }
+        }
         return json({
           status: response.status,
           ok: response.ok,
@@ -1835,7 +1951,7 @@ function createWebFetchTool(toolName: string): Tool {
           preapproved,
           rendered_as: renderedAs,
           truncated: raw.truncated || body.length > maxChars,
-          prompt: stringValue(args.prompt),
+          prompt,
           content: textBody,
         }, response.ok ? undefined : true);
       } catch (error) {
@@ -1845,10 +1961,222 @@ function createWebFetchTool(toolName: string): Tool {
   };
 }
 
+type WebSearchEndpointKind = "duckduckgo" | "searxng" | "brave" | "json";
+
+function webSearchEndpointKind(
+  opts: ModelFacingToolOptions,
+): WebSearchEndpointKind {
+  const raw = (
+    stringValue(opts.env?.AGENC_WEB_SEARCH_KIND) ??
+    stringValue(opts.toolsConfig?.web_search_endpoint_kind)
+  )?.toLowerCase();
+  if (raw === "searxng" || raw === "brave" || raw === "json") return raw;
+  return "duckduckgo";
+}
+
+/**
+ * Query a configured search endpoint and normalize its response.
+ * Kinds:
+ *   - duckduckgo (default): DDG instant-answer-compatible JSON
+ *     (`RelatedTopics`) — preserves the original custom-endpoint contract.
+ *   - searxng: a SearXNG instance (`?q=&format=json`, `results[]` with
+ *     title/url/content).
+ *   - brave: Brave Search API (`?q=`, `X-Subscription-Token` from
+ *     AGENC_WEB_SEARCH_API_KEY, `web.results[]`).
+ *   - json: plain `{results: [{title, url, snippet}]}`.
+ */
+async function runConfiguredEndpointSearch(
+  endpoint: string,
+  kind: WebSearchEndpointKind,
+  env: NodeJS.ProcessEnv | undefined,
+  query: string,
+): Promise<{
+  readonly results: WebSearchResultEntry[];
+  readonly answer?: string;
+  readonly heading?: string;
+}> {
+  const sep = endpoint.includes("?") ? "&" : "?";
+  const searchUrl =
+    kind === "searxng"
+      ? `${endpoint}${sep}q=${encodeURIComponent(query)}&format=json`
+      : `${endpoint}${sep}q=${encodeURIComponent(query)}`;
+  const apiKey = stringValue(env?.AGENC_WEB_SEARCH_API_KEY);
+  const headers: Record<string, string> =
+    kind === "brave" && apiKey !== undefined
+      ? { "X-Subscription-Token": apiKey, Accept: "application/json" }
+      : { Accept: "application/json" };
+  const response = await fetchWithTimeout(searchUrl, DEFAULT_TIMEOUT_MS, {
+    headers,
+  });
+  const raw = recordValue(await response.json().catch(() => undefined)) ?? {};
+  if (kind === "searxng") {
+    const results = arrayValue(raw.results)
+      .flatMap((entry) => {
+        const record = recordValue(entry);
+        return record ? [record] : [];
+      })
+      .map((entry) => ({
+        title: stringValue(entry.title) ?? "",
+        url: stringValue(entry.url) ?? "",
+        snippet: stringValue(entry.content) ?? "",
+      }))
+      .filter((entry) => entry.url.length > 0);
+    return { results };
+  }
+  if (kind === "brave") {
+    const web = recordValue(raw.web) ?? {};
+    const results = arrayValue(web.results)
+      .flatMap((entry) => {
+        const record = recordValue(entry);
+        return record ? [record] : [];
+      })
+      .map((entry) => ({
+        title: stringValue(entry.title) ?? "",
+        url: stringValue(entry.url) ?? "",
+        snippet: stringValue(entry.description) ?? "",
+      }))
+      .filter((entry) => entry.url.length > 0);
+    return { results };
+  }
+  if (kind === "json") {
+    const results = arrayValue(raw.results)
+      .flatMap((entry) => {
+        const record = recordValue(entry);
+        return record ? [record] : [];
+      })
+      .map((entry) => ({
+        title: stringValue(entry.title) ?? "",
+        url: stringValue(entry.url) ?? "",
+        snippet: stringValue(entry.snippet) ?? stringValue(entry.content) ?? "",
+      }))
+      .filter((entry) => entry.url.length > 0);
+    return { results };
+  }
+  return {
+    results: parseDuckDuckGoInstantAnswer(raw),
+    ...(stringValue(raw.AbstractText) !== undefined
+      ? { answer: stringValue(raw.AbstractText) }
+      : {}),
+    ...(stringValue(raw.Heading) !== undefined
+      ? { heading: stringValue(raw.Heading) }
+      : {}),
+  };
+}
+
+function parseDuckDuckGoInstantAnswer(
+  raw: Record<string, unknown>,
+): WebSearchResultEntry[] {
+  const related = arrayValue(raw.RelatedTopics);
+  return related
+    .flatMap((entry): Array<Record<string, unknown>> => {
+      const record = recordValue(entry);
+      if (!record) {
+        return [];
+      }
+      const topics = arrayValue(record.Topics)
+        .flatMap((topic): Array<Record<string, unknown>> => {
+          const topicRecord = recordValue(topic);
+          return topicRecord ? [topicRecord] : [];
+        });
+      if (topics.length > 0) {
+        return topics;
+      }
+      return [record];
+    })
+    .map((entry) => ({
+      title: stringValue(entry.Text)?.split(" - ")[0] ?? stringValue(entry.Result) ?? "",
+      url: stringValue(entry.FirstURL) ?? "",
+      snippet: stringValue(entry.Text) ?? "",
+    }))
+    .filter((entry) => entry.url.length > 0);
+}
+
+const DDG_HTML_SEARCH_URL = "https://html.duckduckgo.com/html/";
+
+function stripHtmlTags(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Resolve DDG's `/l/?uddg=<encoded>` redirect wrapper to the real URL. */
+function resolveDdgResultUrl(href: string): string | null {
+  try {
+    const url = new URL(href, "https://duckduckgo.com");
+    if (url.pathname === "/l/" || url.pathname.startsWith("/l/")) {
+      const target = url.searchParams.get("uddg");
+      return target !== null && target.length > 0 ? target : null;
+    }
+    if (url.protocol === "https:" || url.protocol === "http:") {
+      return url.toString();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Keyless real-SERP fallback: scrape the DuckDuckGo HTML endpoint.
+ * The instant-answer API only returns encyclopedic abstracts and is
+ * near-empty for most real queries; the HTML endpoint returns actual
+ * ranked results. Returns an empty list on any parse/transport failure
+ * so callers can fall through to the instant-answer path.
+ */
+async function runDuckDuckGoHtmlSearch(
+  query: string,
+): Promise<WebSearchResultEntry[]> {
+  try {
+    const response = await fetchWithTimeout(
+      `${DDG_HTML_SEARCH_URL}?q=${encodeURIComponent(query)}`,
+      DEFAULT_TIMEOUT_MS,
+      {
+        headers: {
+          Accept: "text/html",
+          "User-Agent": "Mozilla/5.0 (compatible; agenc-cli)",
+        },
+      },
+    );
+    if (!response.ok) return [];
+    const html = await response.text();
+    const results: WebSearchResultEntry[] = [];
+    const anchorRe =
+      /<a[^>]*class="[^"]*result__a[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g;
+    const snippetRe =
+      /<a[^>]*class="[^"]*result__snippet[^"]*"[^>]*>([\s\S]*?)<\/a>/g;
+    const snippets: string[] = [];
+    for (const match of html.matchAll(snippetRe)) {
+      snippets.push(stripHtmlTags(match[1] ?? ""));
+    }
+    let index = 0;
+    for (const match of html.matchAll(anchorRe)) {
+      const url = resolveDdgResultUrl(match[1] ?? "");
+      const title = stripHtmlTags(match[2] ?? "");
+      if (url !== null && title.length > 0) {
+        results.push({
+          title,
+          url,
+          snippet: snippets[index] ?? "",
+        });
+      }
+      index += 1;
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
 function createWebTools(opts: ModelFacingToolOptions): readonly Tool[] {
   return [
-    createWebFetchTool(WEB_FETCH_TOOL_NAME),
-    createWebFetchTool(LEGACY_WEB_FETCH_TOOL_NAME),
+    createWebFetchTool(WEB_FETCH_TOOL_NAME, opts),
+    createWebFetchTool(LEGACY_WEB_FETCH_TOOL_NAME, opts),
     {
       name: "WebSearch",
       description:
@@ -1874,7 +2202,9 @@ function createWebTools(opts: ModelFacingToolOptions): readonly Tool[] {
         const query = stringValue(args.query);
         if (!query) return json({ error: "query is required" }, true);
         const filters = webSearchFilters(args);
-        const endpoint = stringValue(opts.env?.AGENC_WEB_SEARCH_ENDPOINT);
+        const endpoint =
+          stringValue(opts.env?.AGENC_WEB_SEARCH_ENDPOINT) ??
+          stringValue(opts.toolsConfig?.web_search_endpoint);
         const maxResults = Math.max(
           1,
           Math.min(numberValue(args.max_results) ?? MAX_SEARCH_RESULTS, MAX_SEARCH_RESULTS),
@@ -1889,39 +2219,57 @@ function createWebTools(opts: ModelFacingToolOptions): readonly Tool[] {
         if (nativeResult !== undefined) {
           return nativeResult;
         }
-        const searchUrl =
-          endpoint !== undefined
-            ? `${endpoint}${endpoint.includes("?") ? "&" : "?"}q=${encodeURIComponent(query)}`
-            : `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
-        const response = await fetchWithTimeout(searchUrl);
+        // 1. Explicitly configured endpoint (env or config-bridged).
+        if (endpoint !== undefined) {
+          const kind = webSearchEndpointKind(opts);
+          const configured = await runConfiguredEndpointSearch(
+            endpoint,
+            kind,
+            opts.env,
+            query,
+          );
+          const results = filterWebSearchResults(
+            configured.results,
+            filters,
+          ).slice(0, maxResults);
+          return json({
+            query,
+            source: endpoint,
+            kind,
+            results,
+            ...(configured.answer !== undefined
+              ? { answer: configured.answer }
+              : {}),
+            ...(configured.heading !== undefined
+              ? { heading: configured.heading }
+              : {}),
+          });
+        }
+        // 2. Keyless real-SERP default: DuckDuckGo HTML.
+        const htmlResults = filterWebSearchResults(
+          await runDuckDuckGoHtmlSearch(query),
+          filters,
+        ).slice(0, maxResults);
+        if (htmlResults.length > 0) {
+          return json({
+            query,
+            source: "duckduckgo_html",
+            results: htmlResults,
+          });
+        }
+        // 3. Last resort: the instant-answer API (encyclopedic
+        // abstracts only — near-empty for most real queries).
+        const response = await fetchWithTimeout(
+          `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`,
+        );
         const raw = recordValue(await response.json().catch(() => undefined)) ?? {};
-        const related = arrayValue(raw.RelatedTopics);
-        const results = filterWebSearchResults(related
-          .flatMap((entry): Array<Record<string, unknown>> => {
-            const record = recordValue(entry);
-            if (!record) {
-              return [];
-            }
-            const topics = arrayValue(record.Topics)
-              .flatMap((topic): Array<Record<string, unknown>> => {
-                const topicRecord = recordValue(topic);
-                return topicRecord ? [topicRecord] : [];
-              });
-            if (topics.length > 0) {
-              return topics;
-            }
-            return [record];
-          })
-          .map((entry) => ({
-            title: stringValue(entry.Text)?.split(" - ")[0] ?? stringValue(entry.Result) ?? "",
-            url: stringValue(entry.FirstURL) ?? "",
-            snippet: stringValue(entry.Text) ?? "",
-          }))
-          .filter((entry) => entry.url.length > 0), filters)
-          .slice(0, maxResults);
+        const results = filterWebSearchResults(
+          parseDuckDuckGoInstantAnswer(raw),
+          filters,
+        ).slice(0, maxResults);
         return json({
           query,
-          source: endpoint !== undefined ? endpoint : "duckduckgo_instant_answer",
+          source: "duckduckgo_instant_answer",
           results,
           answer: stringValue(raw.AbstractText),
           heading: stringValue(raw.Heading),

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -105,6 +105,18 @@ export interface ShellEnvironmentPolicy {
 
 export interface ToolsConfig {
   readonly web_search?: boolean | PerToolConfig;
+  /**
+   * Search backend for the WebSearch tool on providers without native
+   * web search. `AGENC_WEB_SEARCH_ENDPOINT` env wins over this value.
+   */
+  readonly web_search_endpoint?: string;
+  /**
+   * Response format of `web_search_endpoint`:
+   * duckduckgo (instant-answer JSON, default) | searxng | brave | json.
+   * `AGENC_WEB_SEARCH_KIND` env wins. Brave API keys come from
+   * `AGENC_WEB_SEARCH_API_KEY` (secrets never live in config.toml).
+   */
+  readonly web_search_endpoint_kind?: "duckduckgo" | "searxng" | "brave" | "json";
   readonly view_image?: boolean | PerToolConfig;
   readonly enabled_tools?: readonly string[];
   readonly disabled_tools?: readonly string[];

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -4208,3 +4208,314 @@ describe("model-facing tools", () => {
     }
   });
 });
+
+describe("WebSearch real backends (task 4)", () => {
+  const withFetchMock = async (
+    fetchMock: ReturnType<typeof vi.fn>,
+    run: () => Promise<void>,
+  ) => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    try {
+      await run();
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  };
+
+  it("keyless default scrapes DuckDuckGo HTML for real SERP results", async () => {
+    const html = [
+      '<div class="result">',
+      '<a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fagenc.tech%2Fdocs&amp;rut=abc">AgenC <b>Docs</b></a>',
+      '<a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fagenc.tech%2Fdocs">The <b>docs</b> for AgenC.</a>',
+      "</div>",
+      '<div class="result">',
+      '<a rel="nofollow" class="result__a" href="https://example.com/page">Example Page</a>',
+      '<a class="result__snippet" href="https://example.com/page">An example snippet.</a>',
+      "</div>",
+    ].join("\n");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "text/html" },
+      text: async () => html,
+      json: async () => ({}),
+    });
+    await withFetchMock(fetchMock, async () => {
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => null,
+      });
+      const result = await tools
+        .find((tool) => tool.name === "WebSearch")!
+        .execute({ query: "agenc docs" });
+      const parsed = JSON.parse(result.content);
+      // Real SERP path, not the instant-answer API.
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+        "html.duckduckgo.com/html/",
+      );
+      expect(parsed.source).toBe("duckduckgo_html");
+      expect(parsed.results).toEqual([
+        {
+          title: "AgenC Docs",
+          url: "https://agenc.tech/docs",
+          snippet: "The docs for AgenC.",
+        },
+        {
+          title: "Example Page",
+          url: "https://example.com/page",
+          snippet: "An example snippet.",
+        },
+      ]);
+    });
+  });
+
+  it("falls back to the instant-answer API when the HTML scrape yields nothing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => "text/html" },
+        text: async () => "<html><body>captcha wall</body></html>",
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: async () => ({
+          Heading: "AgenC",
+          AbstractText: "abstract",
+          RelatedTopics: [
+            { Text: "AgenC - protocol", FirstURL: "https://agenc.tech" },
+          ],
+        }),
+      });
+    await withFetchMock(fetchMock, async () => {
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => null,
+      });
+      const result = await tools
+        .find((tool) => tool.name === "WebSearch")!
+        .execute({ query: "agenc" });
+      const parsed = JSON.parse(result.content);
+      expect(parsed.source).toBe("duckduckgo_instant_answer");
+      expect(parsed.results[0].url).toBe("https://agenc.tech");
+      expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+        "api.duckduckgo.com",
+      );
+    });
+  });
+
+  it("supports SearXNG endpoints via AGENC_WEB_SEARCH_KIND=searxng", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        results: [
+          {
+            title: "Result One",
+            url: "https://one.example",
+            content: "first snippet",
+          },
+        ],
+      }),
+    });
+    await withFetchMock(fetchMock, async () => {
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => null,
+        env: {
+          AGENC_WEB_SEARCH_ENDPOINT: "https://searx.local/search",
+          AGENC_WEB_SEARCH_KIND: "searxng",
+        } as NodeJS.ProcessEnv,
+      });
+      const result = await tools
+        .find((tool) => tool.name === "WebSearch")!
+        .execute({ query: "one" });
+      const parsed = JSON.parse(result.content);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+        "https://searx.local/search?q=one&format=json",
+      );
+      expect(parsed.kind).toBe("searxng");
+      expect(parsed.results).toEqual([
+        {
+          title: "Result One",
+          url: "https://one.example",
+          snippet: "first snippet",
+        },
+      ]);
+    });
+  });
+
+  it("supports Brave endpoints with the subscription token header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        web: {
+          results: [
+            {
+              title: "Brave Result",
+              url: "https://brave.example",
+              description: "brave snippet",
+            },
+          ],
+        },
+      }),
+    });
+    await withFetchMock(fetchMock, async () => {
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => null,
+        env: {
+          AGENC_WEB_SEARCH_ENDPOINT:
+            "https://api.search.brave.com/res/v1/web/search",
+          AGENC_WEB_SEARCH_KIND: "brave",
+          AGENC_WEB_SEARCH_API_KEY: "brave-key",
+        } as NodeJS.ProcessEnv,
+      });
+      const result = await tools
+        .find((tool) => tool.name === "WebSearch")!
+        .execute({ query: "brave" });
+      const parsed = JSON.parse(result.content);
+      const init = fetchMock.mock.calls[0]?.[1] as
+        | { headers?: Record<string, string> }
+        | undefined;
+      expect(init?.headers?.["X-Subscription-Token"]).toBe("brave-key");
+      expect(parsed.results[0].url).toBe("https://brave.example");
+    });
+  });
+
+  it("reads the endpoint from config.toml tools config when env is unset", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        results: [
+          { title: "Cfg", url: "https://cfg.example", snippet: "from config" },
+        ],
+      }),
+    });
+    await withFetchMock(fetchMock, async () => {
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => null,
+        toolsConfig: {
+          web_search_endpoint: "https://cfg.local/search",
+          web_search_endpoint_kind: "json",
+        },
+      });
+      const result = await tools
+        .find((tool) => tool.name === "WebSearch")!
+        .execute({ query: "cfg" });
+      const parsed = JSON.parse(result.content);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+        "https://cfg.local/search?q=cfg",
+      );
+      expect(parsed.results[0].url).toBe("https://cfg.example");
+    });
+  });
+});
+
+describe("WebFetch prompt extraction (task 4)", () => {
+  it("runs the prompt against fetched content instead of echoing it", async () => {
+    const paragraph =
+      "<p>The current release is version 9.9.9 and it shipped today.</p>";
+    const html = `<!doctype html><html><body><h1>Release notes</h1>${paragraph.repeat(400)}</body></html>`;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://agenc.tech/releases",
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "text/html" : null,
+      },
+      text: async () => html,
+    });
+    const chat = vi.fn().mockResolvedValue({
+      content: "The current release is 9.9.9.",
+      toolCalls: [],
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      model: "test-model",
+      finishReason: "stop",
+    });
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    try {
+      const session = withProvider(fakeSession(), fakeProvider({}, chat));
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      });
+      const result = await tools
+        .find((tool) => tool.name === "web_fetch")!
+        .execute({
+          url: "https://agenc.tech/releases",
+          prompt: "What is the current release version?",
+        });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content);
+      // The prompt was EXECUTED, not merely echoed back.
+      expect(parsed.extracted).toBe("The current release is 9.9.9.");
+      expect(parsed.content).toBeUndefined();
+      expect(String(parsed.content_preview).length).toBeLessThanOrEqual(2_000);
+      // Raw content is recoverable from disk.
+      expect(typeof parsed.full_content_path).toBe("string");
+      const { readFileSync } = await import("node:fs");
+      expect(readFileSync(parsed.full_content_path, "utf8")).toContain(
+        "version 9.9.9",
+      );
+      // The extraction model saw the page and the task.
+      const chatMessages = chat.mock.calls[0]?.[0] as Array<{
+        content: string;
+      }>;
+      expect(chatMessages[0]?.content).toContain("version 9.9.9");
+      expect(chatMessages[0]?.content).toContain(
+        "What is the current release version?",
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  it("keeps the raw-content shape when no prompt is given or content is small", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://agenc.tech/small",
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "text/plain" : null,
+      },
+      text: async () => "tiny content",
+    });
+    const chat = vi.fn();
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    try {
+      const session = withProvider(fakeSession(), fakeProvider({}, chat));
+      const tools = createModelFacingTools({
+        workspaceRoot: process.cwd(),
+        getSession: () => session,
+      });
+      const result = await tools
+        .find((tool) => tool.name === "web_fetch")!
+        .execute({
+          url: "https://agenc.tech/small",
+          prompt: "summarize",
+        });
+      const parsed = JSON.parse(result.content);
+      expect(parsed.content).toBe("tiny content");
+      expect(parsed.extracted).toBeUndefined();
+      expect(chat).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+});


### PR DESCRIPTION
## TODO task 4 — WebSearch is a stub off-Grok; WebFetch echoes its prompt

**Verified first (2026-07-07):** default WebSearch backend was `api.duckduckgo.com` instant answers (abstracts, not a SERP); WebFetch's `prompt` was returned verbatim in the result JSON with no extraction.

### What this ships
- **WebSearch chain:** Grok-native (unchanged) → configured endpoint → **keyless DuckDuckGo HTML SERP scrape** → instant-answer last resort. Endpoint kinds: `duckduckgo` (default — preserves the existing custom-endpoint contract; all pre-existing tests pass unmodified), `searxng`, `brave` (subscription-token header), `json`. Config-first-class via `[tools] web_search_endpoint` / `web_search_endpoint_kind` in config.toml (bridged through the existing `toolsConfig` plumbing), env vars win.
- **WebFetch extraction:** with a `prompt` and a large page, the session provider distills the content; the result carries `extracted`, a 2K `content_preview`, and `full_content_path` (persisted via the shared tool-results store, FileRead-recoverable). Graceful fallback to the old raw shape on no-provider/small-page/failure.

### Tests
7 new tests: HTML-scrape parsing (redirect-wrapper URL decoding included), scrape-empty→instant-answer fallback, searxng/brave/json kinds, config.toml-sourced endpoint, extraction executes-not-echoes (provider sees page+task; raw persisted to disk and re-read in the test), small-page passthrough. Revert-sensitive: 6/7 fail with the source stashed.

### Gates
build ✓, tsc 0 ✓; full vitest 68 = the pre-existing main set (TODO task 27), zero regressions.