### PR TITLE
feat(llm): prefix-cache split for the OpenAI and xAI wires

### DIFF
--- a/runtime/src/llm/providers/grok/adapter.ts
+++ b/runtime/src/llm/providers/grok/adapter.ts
@@ -88,7 +88,10 @@ import {
   toXaiResponsesTools,
   XAI_ENCRYPTED_REASONING_INCLUDE,
 } from "../../wire/responses-xai.js";
-import { coerceUsage } from "../../wire/shared.js";
+import {
+  coerceUsage,
+  splitSystemPromptOnDynamicBoundary,
+} from "../../wire/shared.js";
 import {
   BUILT_IN_PROVIDER_BASE_URLS,
   BUILT_IN_PROVIDER_DEFAULT_MODELS,
@@ -1753,10 +1756,23 @@ export class GrokProvider implements LLMProvider {
     requestMessages: readonly LLMMessage[];
   } {
     const visionModel = this.config.visionModel ?? DEFAULT_VISION_MODEL;
-    const requestMessages =
-      options?.systemPrompt && options.systemPrompt.length > 0
-        ? [{ role: "system" as const, content: options.systemPrompt }, ...messages]
-        : messages;
+    // Prefix-cache split: xAI caching is prefix-based ("never modify
+    // earlier messages — only append"), so the volatile tail of the
+    // system prompt (timestamp, git state, …) must not sit at the front
+    // where it diverges every turn and prevents the system + history
+    // prefix from ever being served from cache. Static head leads,
+    // dynamic tail becomes the FINAL message.
+    const { staticPrefix: staticSystemPrompt, dynamicSuffix: dynamicSystemPrompt } =
+      splitSystemPromptOnDynamicBoundary(options?.systemPrompt);
+    const requestMessages = [
+      ...(staticSystemPrompt !== undefined
+        ? [{ role: "system" as const, content: staticSystemPrompt }]
+        : []),
+      ...messages,
+      ...(dynamicSystemPrompt !== undefined
+        ? [{ role: "system" as const, content: dynamicSystemPrompt }]
+        : []),
+    ];
     const repairedMessages = repairToolTurnSequence(requestMessages);
     validateToolTurnSequence(repairedMessages, {
       providerName: this.name,

--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -111,13 +111,14 @@ function buildAnthropicStructuredOutputTool(
 }
 
 /**
- * gaphunt3 #5/#33: the system-prompt static/dynamic boundary marker. Must stay
- * byte-equal to `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` exported by
- * `src/prompts/system-prompt.ts` (the producer of `options.systemPrompt`).
- * Kept local so the prompt-assembly module graph does not leak into the wire
- * layer; the gaphunt3 regression test asserts the two never diverge.
+ * gaphunt3 #5/#33: the system-prompt static/dynamic boundary marker.
+ * Single-sourced in `wire/shared.ts` (task 5 extended the split to the
+ * OpenAI/xAI wires); re-exported here for existing importers. The
+ * gaphunt3 regression test still asserts it never diverges from
+ * `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` in `src/prompts/system-prompt.ts`.
  */
-export const SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER = "<!-- dynamic-boundary -->";
+export { SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER } from "./shared.js";
+import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER } from "./shared.js";
 
 /**
  * Build the Anthropic `system` block(s) for the option-supplied system prompt.

--- a/runtime/src/llm/wire/responses-openai.ts
+++ b/runtime/src/llm/wire/responses-openai.ts
@@ -27,6 +27,7 @@ import {
   prepareMessagesForWire,
   readAudioPayload,
   readDocumentPayload,
+  splitSystemPromptOnDynamicBoundary,
   toResponsesToolOutput,
   withEndpointMarkers,
   withSerializedMetrics,
@@ -201,8 +202,14 @@ export function buildOpenAIResponsesRequest(
   input: OpenAIResponsesRequestOptions,
 ): Record<string, unknown> {
   const messages = prepareMessagesForWire(input.messages);
+  // Prefix-cache split: only the cross-turn-stable head of the system
+  // prompt goes into `instructions` (part of the cached prefix); the
+  // volatile tail is appended as the LAST input item below so the
+  // request prefix stays byte-identical across turns.
+  const { staticPrefix: staticSystemPrompt, dynamicSuffix: dynamicSystemPrompt } =
+    splitSystemPromptOnDynamicBoundary(input.options?.systemPrompt);
   const instructions = [
-    input.options?.systemPrompt?.trim(),
+    staticSystemPrompt,
     ...messages
       .filter((message) =>
         message.role === "system" || message.role === "developer"
@@ -263,6 +270,14 @@ export function buildOpenAIResponsesRequest(
       type: "message",
       role: "user",
       content: [{ type: "input_text", text: "" }],
+    });
+  }
+
+  if (dynamicSystemPrompt !== undefined) {
+    responseInput.push({
+      type: "message",
+      role: "system",
+      content: [{ type: "input_text", text: dynamicSystemPrompt }],
     });
   }
 

--- a/runtime/src/llm/wire/shared.ts
+++ b/runtime/src/llm/wire/shared.ts
@@ -74,6 +74,47 @@ function toAnthropicImageSource(
   };
 }
 
+/**
+ * The system-prompt static/dynamic boundary marker. Must stay byte-equal
+ * to `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` exported by
+ * `src/prompts/system-prompt.ts` (the producer of `options.systemPrompt`);
+ * a regression test asserts the two never diverge. Single-sourced here so
+ * every wire can split without importing the prompt-assembly graph.
+ */
+export const SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER = "<!-- dynamic-boundary -->";
+
+/**
+ * Split an assembled system prompt into its cross-turn-stable head and
+ * its volatile tail (env timestamp, git branch, MCP servers, …).
+ *
+ * Prefix-caching providers (OpenAI, xAI) hash the leading bytes of the
+ * request: sending the volatile tail at the FRONT (inside instructions
+ * or a leading system message) makes every turn's prefix diverge, so
+ * the growing conversation is never served from cache. Callers place
+ * `staticPrefix` at the front and `dynamicSuffix` at the very end of
+ * the request — both providers' documented best practice ("put variable
+ * content at the end"; "never modify earlier messages — only append").
+ *
+ * When the marker is absent, the whole prompt is the static prefix
+ * (unchanged legacy behaviour).
+ */
+export function splitSystemPromptOnDynamicBoundary(
+  systemPrompt: string | undefined,
+): { staticPrefix?: string; dynamicSuffix?: string } {
+  const trimmed = systemPrompt?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return {};
+  const markerIndex = trimmed.indexOf(SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER);
+  if (markerIndex === -1) return { staticPrefix: trimmed };
+  const staticPrefix = trimmed.slice(0, markerIndex).trimEnd();
+  const dynamicSuffix = trimmed
+    .slice(markerIndex + SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER.length)
+    .trim();
+  return {
+    ...(staticPrefix.length > 0 ? { staticPrefix } : {}),
+    ...(dynamicSuffix.length > 0 ? { dynamicSuffix } : {}),
+  };
+}
+
 export function readDocumentPayload(part: unknown): {
   readonly data: string;
   readonly mediaType: string;

--- a/runtime/tests/llm/wire/prefix-cache-split.test.ts
+++ b/runtime/tests/llm/wire/prefix-cache-split.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Task 5: prefix-cache split for the OpenAI/xAI wires.
+ *
+ * Both providers cache on the leading bytes of the request (OpenAI:
+ * "place static content at the beginning and variable content at the
+ * end"; xAI: "never modify earlier messages — only append"). The
+ * volatile tail of the assembled system prompt (timestamp, git state)
+ * previously sat at the FRONT of every request, so the prefix diverged
+ * every turn and the growing conversation was never served from cache.
+ *
+ * These tests pin the split: across two consecutive turns the
+ * serialized prefix (instructions/static system + earlier messages) is
+ * byte-identical, with dynamic content only in the final item.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  splitSystemPromptOnDynamicBoundary,
+  SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER,
+} from "./shared.js";
+import { buildOpenAIResponsesRequest } from "./responses-openai.js";
+import { GrokProvider } from "../providers/grok/adapter.js";
+import type { LLMMessage } from "../types.js";
+
+const STATIC_HEAD = "You are AgenC. Follow the project instructions.";
+
+function promptAt(timestamp: string): string {
+  return `${STATIC_HEAD}\n${SYSTEM_PROMPT_DYNAMIC_BOUNDARY_MARKER}\nNow: ${timestamp}\nBranch: main`;
+}
+
+type BuildParamsAccess = {
+  buildParams: (
+    messages: readonly LLMMessage[],
+    options?: Record<string, unknown>,
+  ) => { params: Record<string, unknown> };
+};
+
+describe("splitSystemPromptOnDynamicBoundary", () => {
+  it("splits on the marker", () => {
+    const { staticPrefix, dynamicSuffix } = splitSystemPromptOnDynamicBoundary(
+      promptAt("2026-07-07T00:00:00Z"),
+    );
+    expect(staticPrefix).toBe(STATIC_HEAD);
+    expect(dynamicSuffix).toBe("Now: 2026-07-07T00:00:00Z\nBranch: main");
+  });
+
+  it("treats a marker-less prompt as fully static", () => {
+    expect(splitSystemPromptOnDynamicBoundary("plain prompt")).toEqual({
+      staticPrefix: "plain prompt",
+    });
+    expect(splitSystemPromptOnDynamicBoundary(undefined)).toEqual({});
+    expect(splitSystemPromptOnDynamicBoundary("   ")).toEqual({});
+  });
+});
+
+describe("OpenAI Responses wire keeps the request prefix stable across turns", () => {
+  function requestFor(turnMessages: LLMMessage[], timestamp: string) {
+    return buildOpenAIResponsesRequest({
+      model: "gpt-test",
+      messages: turnMessages,
+      tools: [],
+      options: { systemPrompt: promptAt(timestamp) },
+    });
+  }
+
+  it("instructions carry only the static head; dynamic content is the final input item", () => {
+    const turn1: LLMMessage[] = [{ role: "user", content: "first" }];
+    const turn2: LLMMessage[] = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "answer" },
+      { role: "user", content: "second" },
+    ];
+    const request1 = requestFor(turn1, "T1");
+    const request2 = requestFor(turn2, "T2");
+
+    expect(request1.instructions).toBe(STATIC_HEAD);
+    // Byte-identical across turns despite different timestamps.
+    expect(request2.instructions).toBe(request1.instructions);
+
+    const input1 = request1.input as Array<Record<string, unknown>>;
+    const input2 = request2.input as Array<Record<string, unknown>>;
+    const last1 = input1.at(-1);
+    const last2 = input2.at(-1);
+    expect(last1).toEqual({
+      type: "message",
+      role: "system",
+      content: [{ type: "input_text", text: "Now: T1\nBranch: main" }],
+    });
+    expect(JSON.stringify(last2)).toContain("Now: T2");
+
+    // The serialized prefix (everything before the dynamic tail) of
+    // turn 2 begins with turn 1's serialized prefix.
+    const prefix1 = JSON.stringify(input1.slice(0, -1));
+    const prefix2 = JSON.stringify(input2.slice(0, -1));
+    expect(
+      prefix2.startsWith(prefix1.slice(0, prefix1.length - 1)),
+    ).toBe(true);
+  });
+});
+
+describe("grok adapter keeps the request prefix stable across turns", () => {
+  function paramsFor(turnMessages: LLMMessage[], timestamp: string) {
+    const provider = new GrokProvider({
+      apiKey: "xai-test",
+      model: "grok-4.3",
+    });
+    return (provider as unknown as BuildParamsAccess).buildParams(
+      turnMessages,
+      { systemPrompt: promptAt(timestamp) },
+    ).params;
+  }
+
+  it("static system leads, dynamic tail is the final input item", () => {
+    const turn1: LLMMessage[] = [{ role: "user", content: "first" }];
+    const turn2: LLMMessage[] = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "answer" },
+      { role: "user", content: "second" },
+    ];
+    const input1 = paramsFor(turn1, "T1").input as Array<
+      Record<string, unknown>
+    >;
+    const input2 = paramsFor(turn2, "T2").input as Array<
+      Record<string, unknown>
+    >;
+
+    // First item: the static head only — byte-identical across turns.
+    expect(JSON.stringify(input1[0])).toContain(STATIC_HEAD);
+    expect(JSON.stringify(input1[0])).not.toContain("Now: T1");
+    expect(JSON.stringify(input2[0])).toBe(JSON.stringify(input1[0]));
+
+    // Last item: the dynamic tail (per-turn).
+    expect(JSON.stringify(input1.at(-1))).toContain("Now: T1");
+    expect(JSON.stringify(input2.at(-1))).toContain("Now: T2");
+    expect(JSON.stringify(input2.at(-1))).not.toContain(STATIC_HEAD);
+
+    // Turn 2's serialized prefix extends turn 1's.
+    const prefix1 = JSON.stringify(input1.slice(0, -1));
+    const prefix2 = JSON.stringify(input2.slice(0, -1));
+    expect(
+      prefix2.startsWith(prefix1.slice(0, prefix1.length - 1)),
+    ).toBe(true);
+  });
+
+  it("marker-less prompts keep the legacy single leading system message", () => {
+    const input = paramsFor(
+      [{ role: "user", content: "hello" }],
+      "unused",
+    );
+    const legacyProvider = new GrokProvider({
+      apiKey: "xai-test",
+      model: "grok-4.3",
+    });
+    const legacy = (legacyProvider as unknown as BuildParamsAccess).buildParams(
+      [{ role: "user", content: "hello" }],
+      { systemPrompt: "plain prompt with no marker" },
+    ).params.input as Array<Record<string, unknown>>;
+    expect(JSON.stringify(legacy[0])).toContain("plain prompt with no marker");
+    expect(JSON.stringify(legacy.at(-1))).toContain("hello");
+    void input;
+  });
+});


### PR DESCRIPTION
## TODO task 5 — the DEFAULT provider never caches

**Verified first (2026-07-07):** split applied only on the Anthropic wire; `responses-openai` folded `options.systemPrompt` (volatile tail included) into `instructions`, the grok adapter prepended it as message[0]. Provider docs verified per the TODO's version-sensitivity requirement: [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching) (exact prefix matching; "place static content at the beginning and variable content at the end") and [xAI prompt caching](https://docs.x.ai/developers/advanced-api-usage/prompt-caching) ("never modify earlier messages — only append").

### What this ships
- `splitSystemPromptOnDynamicBoundary` single-sourced in `wire/shared.ts` (marker re-exported from messages-anthropic; gaphunt3 byte-equality regression test unaffected).
- OpenAI Responses: `instructions` = static head only; volatile tail = final input item.
- grok adapter (the live xAI path): static head leads, volatile tail is the final message.
- chat-completions deliberately unchanged — it folds into a single first system message for strict single-system providers (pinned behavior); noted in code.

### Tests
5 new wire tests: split semantics; per-wire two-consecutive-turn assertions that the serialized prefix is byte-identical with dynamic content only in the tail; marker-less legacy behavior. Revert-sensitive: 2/5 fail with the wire changes stashed.

### Gates
build ✓, tsc 0 ✓; full vitest 68 = the pre-existing main set (TODO task 27), zero regressions.