### PR TITLE
feat(runtime): wire the live Cron tools to the real scheduler

### DIFF
--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1520,6 +1520,24 @@ export async function bootstrapLocalRuntimeSession(
         });
         sidecarManager.register(new FileHistorySidecar({ fileHistory }));
         s.attachFileHistory(fileHistory);
+
+        // Re-arm persisted cron jobs across restarts: a durable schedule
+        // written by CronCreate must keep firing after the daemon/session
+        // restarts, not sit inert until the next CronCreate call.
+        void (async () => {
+          try {
+            const { readCronTasks } = await import("../utils/cronTasks.js");
+            const persisted = await readCronTasks(workspaceRoot);
+            if (persisted.length > 0) {
+              const { startCronSchedulerRunner } = await import(
+                "./model-facing-tools.js"
+              );
+              await startCronSchedulerRunner();
+            }
+          } catch {
+            /* cron re-arm is best-effort; tools re-arm on next CronCreate */
+          }
+        })();
         sidecarManager.register(
           new ErrorLogSidecar({
             projectDir,

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -1,15 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import {
-  mkdir,
   readFile,
-  rename,
   stat,
-  writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import {
-  dirname,
   extname,
   isAbsolute,
   join,
@@ -250,13 +246,10 @@ async function readState(opts: ModelFacingToolOptions): Promise<ToolState> {
   }
 }
 
-async function writeState(opts: ModelFacingToolOptions, state: ToolState): Promise<void> {
-  const file = stateFile(opts);
-  await mkdir(dirname(file), { recursive: true });
-  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, "utf8");
-  await rename(tmp, file);
-}
+// NOTE: the legacy runtime-tools/state.json cron store is READ-only now
+// (RemoteTrigger's stub still lists it). Cron definitions live in the
+// scheduler's own store (.agenc/scheduled_tasks.json via utils/cronTasks)
+// so registered jobs actually fire; the old file's entries never did.
 
 function resolveWorkspacePath(opts: ModelFacingToolOptions, input: string): string {
   const resolved = isAbsolute(input) ? resolve(input) : resolve(opts.workspaceRoot, input);
@@ -2649,12 +2642,27 @@ function validateCron(schedule: string): boolean {
   return schedule.trim().split(/\s+/).length === 5;
 }
 
+/**
+ * Enable + start the shared cron runner (idempotent — start() no-ops on
+ * a running scheduler) and re-arm to the new earliest due time. This is
+ * the wiring that makes CronCreate definitions actually FIRE: due jobs
+ * enqueue their prompt onto the session command queue as a new turn.
+ */
+export async function startCronSchedulerRunner(): Promise<void> {
+  const { setScheduledTasksEnabled } = await import("../bootstrap/state.js");
+  const { getCronScheduler } = await import("../utils/cronScheduler.js");
+  setScheduledTasksEnabled(true);
+  const scheduler = getCronScheduler();
+  scheduler.start();
+  await scheduler.reschedule();
+}
+
 function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool[] {
   return [
     {
       name: "CronCreate",
       description:
-        "Register a local scheduled prompt definition. The current runtime records the schedule; an external runner can execute registered jobs.",
+        "Schedule a recurring (or one-shot) prompt on a five-field cron expression. Jobs are executed by the runtime's own scheduler: when a job comes due its prompt is enqueued as a new turn in this session. Durable jobs persist in .agenc/scheduled_tasks.json and re-arm on restart; non-durable jobs die with the session.",
       metadata: toolMetadata("workflow", {
         mutating: true,
         deferred: true,
@@ -2667,7 +2675,11 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
           cron: { type: "string" },
           schedule: { type: "string" },
           prompt: { type: "string" },
-          timezone: { type: "string" },
+          recurring: {
+            type: "boolean",
+            description:
+              "true (default) reschedules after each fire; false fires once and deletes itself.",
+          },
           durable: { type: "boolean" },
         },
         required: ["prompt"],
@@ -2682,24 +2694,25 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
         if (!validateCron(schedule)) {
           return json({ error: "cron expression must have five fields" }, true);
         }
-        const state = await readState(opts);
-        const cron: StoredCron = {
-          id: `cron-${randomUUID()}`,
-          schedule,
-          prompt,
-          ...(stringValue(args.timezone) !== undefined
-            ? { timezone: stringValue(args.timezone) }
-            : {}),
-          durable: boolValue(args.durable) ?? true,
-          createdAt: new Date().toISOString(),
-        };
-        await writeState(opts, { ...state, crons: [...state.crons, cron] });
-        return json({ cron });
+        const { addCronTask, nextCronRunMs } = await import(
+          "../utils/cronTasks.js"
+        );
+        if (nextCronRunMs(schedule, Date.now()) === null) {
+          return json({ error: `invalid cron expression: ${schedule}` }, true);
+        }
+        const recurring = boolValue(args.recurring) ?? true;
+        const durable = boolValue(args.durable) ?? true;
+        const id = await addCronTask(schedule, prompt, recurring, durable);
+        // Arm the real runner: without this the definition is inert.
+        await startCronSchedulerRunner();
+        return json({
+          cron: { id, cron: schedule, prompt, recurring, durable },
+        });
       },
     },
     {
       name: "CronDelete",
-      description: "Delete a local scheduled prompt definition.",
+      description: "Delete a scheduled prompt job by id.",
       metadata: toolMetadata("workflow", {
         mutating: true,
         deferred: true,
@@ -2715,15 +2728,21 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
       execute: async (args) => {
         const id = stringValue(args.id);
         if (!id) return json({ error: "id is required" }, true);
-        const state = await readState(opts);
-        const crons = state.crons.filter((cron) => cron.id !== id);
-        await writeState(opts, { ...state, crons });
-        return json({ deleted: state.crons.length !== crons.length, id });
+        const { listAllCronTasks, removeCronTasks } = await import(
+          "../utils/cronTasks.js"
+        );
+        const before = await listAllCronTasks();
+        const existed = before.some((task) => task.id === id);
+        await removeCronTasks([id]);
+        const { getCronScheduler } = await import("../utils/cronScheduler.js");
+        await getCronScheduler().reschedule();
+        return json({ deleted: existed, id });
       },
     },
     {
       name: "CronList",
-      description: "List local scheduled prompt definitions.",
+      description:
+        "List scheduled prompt jobs (id, cron expression, prompt, recurring).",
       metadata: toolMetadata("workflow", {
         deferred: true,
         keywords: ["cron", "list"],
@@ -2735,7 +2754,22 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
         properties: {},
         additionalProperties: false,
       },
-      execute: async () => json({ crons: (await readState(opts)).crons }),
+      execute: async () => {
+        const { listAllCronTasks } = await import("../utils/cronTasks.js");
+        const tasks = await listAllCronTasks();
+        return json({
+          crons: tasks.map((task) => ({
+            id: task.id,
+            cron: task.cron,
+            prompt: task.prompt,
+            recurring: task.recurring === true,
+            createdAt: new Date(task.createdAt).toISOString(),
+            ...(task.lastFiredAt !== undefined
+              ? { lastFiredAt: new Date(task.lastFiredAt).toISOString() }
+              : {}),
+          })),
+        });
+      },
     },
     {
       name: "WorkflowTool",

--- a/runtime/tests/bin/cron-live-tools.test.ts
+++ b/runtime/tests/bin/cron-live-tools.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Task 6: the live CronCreate/CronDelete/CronList tools drive the REAL
+ * cron scheduler. Before this wiring the live tools only wrote a JSON
+ * definition file whose description admitted "an external runner can
+ * execute registered jobs" — no runner existed, so nothing ever fired.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createModelFacingTools } from "./model-facing-tools.js";
+import type { Tool } from "../tools/types.js";
+import {
+  resetStateForTests,
+  setCwdState,
+  setOriginalCwd,
+  setProjectRoot,
+} from "../bootstrap/state.js";
+import { resetCronSchedulerForTests } from "../utils/cronScheduler.js";
+import { listAllCronTasks } from "../utils/cronTasks.js";
+import {
+  dequeueAll,
+  getCommandQueueSnapshot,
+} from "../utils/messageQueueManager.js";
+
+let tempRoot: string;
+
+/**
+ * The scheduler tick awaits REAL fs I/O (loadTasks / lastFiredAt
+ * persistence) between fake-timer hops, so a plain
+ * advanceTimersByTimeAsync races the dispatch. Advance in minute steps
+ * and yield to the libuv loop between hops so in-flight ticks complete.
+ */
+async function advanceMinutesWithIo(minutes: number): Promise<void> {
+  for (let minute = 0; minute < minutes; minute += 1) {
+    await vi.advanceTimersByTimeAsync(60_000);
+    for (let flush = 0; flush < 20; flush += 1) {
+      await new Promise<void>((resolveFlush) => setImmediate(resolveFlush));
+    }
+  }
+}
+
+function cronTools(): Map<string, Tool> {
+  const tools = createModelFacingTools({
+    workspaceRoot: tempRoot,
+    getSession: () => null,
+  });
+  return new Map(tools.map((tool) => [tool.name, tool]));
+}
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "agenc-cron-live-"));
+  setProjectRoot(tempRoot);
+  setOriginalCwd(tempRoot);
+  setCwdState(tempRoot);
+  dequeueAll();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetCronSchedulerForTests();
+  resetStateForTests();
+  dequeueAll();
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("live Cron tools drive the real scheduler", () => {
+  it("CronCreate persists into the scheduler's store; CronList/CronDelete round-trip", async () => {
+    const tools = cronTools();
+    const created = await tools.get("CronCreate")!.execute({
+      cron: "*/5 * * * *",
+      prompt: "check the deploy",
+      durable: true,
+    });
+    expect(created.isError).toBeUndefined();
+    const createdPayload = JSON.parse(String(created.content)) as {
+      cron: { id: string };
+    };
+    const id = createdPayload.cron.id;
+    expect(id).toMatch(/^[a-f0-9]{8}$/);
+
+    // The definition landed in the store the RUNNER reads — not the
+    // inert legacy runtime-tools/state.json.
+    const stored = await listAllCronTasks(tempRoot);
+    expect(stored.map((task) => task.id)).toContain(id);
+
+    const listed = JSON.parse(
+      String((await tools.get("CronList")!.execute({})).content),
+    ) as { crons: Array<{ id: string; cron: string; prompt: string }> };
+    expect(listed.crons).toEqual([
+      expect.objectContaining({
+        id,
+        cron: "*/5 * * * *",
+        prompt: "check the deploy",
+      }),
+    ]);
+
+    const deleted = JSON.parse(
+      String((await tools.get("CronDelete")!.execute({ id })).content),
+    ) as { deleted: boolean };
+    expect(deleted.deleted).toBe(true);
+    expect(await listAllCronTasks(tempRoot)).toEqual([]);
+  });
+
+  it("rejects unparseable cron expressions", async () => {
+    const tools = cronTools();
+    const result = await tools.get("CronCreate")!.execute({
+      cron: "99 99 99 99 99",
+      prompt: "never",
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it("a due job fires: its prompt is enqueued as a session turn", async () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "Date", "performance"],
+    });
+    vi.setSystemTime(new Date("2026-07-07T12:00:30Z"));
+    // Deterministic jitter.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const tools = cronTools();
+      await tools.get("CronCreate")!.execute({
+        cron: "* * * * *",
+        prompt: "cron fired: run the check",
+        durable: true,
+        recurring: true,
+      });
+      expect(getCommandQueueSnapshot()).toHaveLength(0);
+
+      // Advance past the next whole minute (+ scheduler floors/jitter).
+      await advanceMinutesWithIo(5);
+
+      const queued = getCommandQueueSnapshot();
+      expect(queued.length).toBeGreaterThan(0);
+      expect(
+        queued.some(
+          (command) =>
+            typeof command.value === "string" &&
+            command.value.includes("cron fired: run the check") &&
+            command.mode === "task-notification",
+        ),
+      ).toBe(true);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("re-arms persisted jobs after a scheduler restart (daemon restart path)", async () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "Date", "performance"],
+    });
+    vi.setSystemTime(new Date("2026-07-07T12:00:30Z"));
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const tools = cronTools();
+      await tools.get("CronCreate")!.execute({
+        cron: "* * * * *",
+        prompt: "survives restarts",
+        durable: true,
+        recurring: true,
+      });
+      // Simulate a daemon restart: the in-memory scheduler dies…
+      resetCronSchedulerForTests();
+      resetStateForTests();
+      setProjectRoot(tempRoot);
+      setOriginalCwd(tempRoot);
+      setCwdState(tempRoot);
+      dequeueAll();
+
+      // …and the bootstrap re-arm path starts a fresh runner from the
+      // persisted store.
+      const { startCronSchedulerRunner } = await import(
+        "./model-facing-tools.js"
+      );
+      await startCronSchedulerRunner();
+      await advanceMinutesWithIo(5);
+
+      const queued = getCommandQueueSnapshot();
+      expect(
+        queued.some(
+          (command) =>
+            typeof command.value === "string" &&
+            command.value.includes("survives restarts"),
+        ),
+      ).toBe(true);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## TODO task 6 — cron definitions never fired

**Verified first (2026-07-07):** the live CronCreate wrote `~/.agenc/runtime-tools/state.json` and no runner existed; `getCronScheduler().start()` had exactly one caller — the retired classic `CronCreateTool`. The scheduler itself is complete (sleep-until-due, coalescing, floors, caps, real `enqueuePendingNotification` adapter).

### What this ships
- Live Cron tools rewritten onto the scheduler's own store (`.agenc/scheduled_tasks.json`) with real cron-expression validation and `recurring` support; CronCreate arms the runner, CronDelete re-arms after removal.
- Daemon/session start re-arms persisted durable jobs (best-effort, zero cost when none exist — an empty schedule arms no timer).
- Legacy state file: read-only leftover for the RemoteTrigger stub; documented.

### Tests (4 new, all revert-sensitive — 4/4 fail with the wiring stashed)
Store round-trip; invalid-expression rejection; **a due job actually fires** (fake timers + real-I/O interleave; the prompt lands on the session command queue as a `task-notification`); **restart re-arm** (scheduler singleton killed, `startCronSchedulerRunner()` from the persisted store, job fires again).

Note: the test file needed `git add -f` — the repo-root `bin/` gitignore pattern unintentionally shadows `runtime/tests/bin/`.

### Gates
build ✓, tsc 0 ✓, `check:tui-runtime-startup` ✓ (bootstrap touched); full vitest 68 = pre-existing main set (TODO task 27), zero regressions.