### PR TITLE
feat(runtime): model-facing context-pressure signal

### DIFF
--- a/runtime/src/build/feature.ts
+++ b/runtime/src/build/feature.ts
@@ -20,6 +20,7 @@ const copiedTreeFeatureFlags: Readonly<Record<string, boolean>> = {
   TRANSCRIPT_CLASSIFIER: true,
   ULTRATHINK: true,
   TOKEN_BUDGET: true,
+  COMPACTION_REMINDERS: true,
   HISTORY_PICKER: true,
   QUICK_SEARCH: true,
   EXTRACT_MEMORIES: true,

--- a/runtime/src/prompts/attachments/messages.ts
+++ b/runtime/src/prompts/attachments/messages.ts
@@ -27,6 +27,7 @@ import {
 } from "../../tools/AgentTool/agentListingMetadata.js";
 import { renderFileMentionAttachmentsBlock } from "../file-mentions.js";
 import { renderMcpInstructionsDeltaSection } from "../mcp-instructions-framing.js";
+import { formatContextPressureReminder } from "../../utils/messages.js";
 import { sanitizeSystemReminderContent } from "./system-reminder-sanitizer.js";
 import type { Attachment } from "./types.js";
 
@@ -149,9 +150,12 @@ function renderAttachment(attachment: Attachment): LLMMessage | null {
       );
     }
     case "compaction_reminder": {
+      // Honest, data-bearing context-pressure line (the previous copy
+      // claimed "unlimited context", which prevented the model from
+      // self-pacing before compaction truncated details).
       return userContextMessage(
         wrapSystemReminder(
-          `Auto-compact is enabled. When the context window is nearly full, older messages will be automatically summarized so you can continue working seamlessly. There is no need to stop or rush — you have unlimited context through automatic compaction.`,
+          formatContextPressureReminder(attachment),
         ),
       );
     }

--- a/runtime/src/utils/attachments.ts
+++ b/runtime/src/utils/attachments.ts
@@ -195,6 +195,7 @@ import {
   tokenCountWithEstimation,
 } from './tokens.js'
 import {
+  getAutoCompactThreshold,
   getEffectiveContextWindowSize,
   isAutoCompactEnabled,
 } from '../services/compact/autoCompact.js'
@@ -659,6 +660,10 @@ export type Attachment =
     }
   | {
       type: 'compaction_reminder'
+      used: number
+      threshold: number
+      remaining: number
+      percentUsed: number
     }
   | {
       type: 'context_efficiency'
@@ -3857,30 +3862,40 @@ async function getVerifyPlanReminderAttachment(
   return [{ type: 'verify_plan_reminder' }]
 }
 
+/**
+ * Fraction of the auto-compact threshold at which the model starts
+ * seeing the context-pressure line. Below this the signal is noise;
+ * above it the model can still change course (finish discrete steps,
+ * persist state) before compaction truncates details.
+ */
+const CONTEXT_PRESSURE_SIGNAL_FRACTION = 0.5
+
 export function getCompactionReminderAttachment(
   messages: Message[],
   model: string,
 ): Attachment[] {
-  if (!false) {
-    return []
-  }
-
   if (!isAutoCompactEnabled()) {
     return []
   }
 
-  const contextWindow = getContextWindowForModel(model, getSdkBetas())
-  if (contextWindow < 1_000_000) {
-    return []
-  }
-
-  const effectiveWindow = getEffectiveContextWindowSize(model)
+  const threshold = getAutoCompactThreshold(model)
   const usedTokens = tokenCountWithEstimation(messages)
-  if (usedTokens < effectiveWindow * 0.25) {
+  if (usedTokens < threshold * CONTEXT_PRESSURE_SIGNAL_FRACTION) {
     return []
   }
 
-  return [{ type: 'compaction_reminder' }]
+  return [
+    {
+      type: 'compaction_reminder',
+      used: usedTokens,
+      threshold,
+      remaining: Math.max(0, threshold - usedTokens),
+      percentUsed: Math.min(
+        100,
+        Math.round((usedTokens / threshold) * 100),
+      ),
+    },
+  ]
 }
 
 /**

--- a/runtime/src/utils/messages.ts
+++ b/runtime/src/utils/messages.ts
@@ -4741,11 +4741,52 @@ function normalizeAgentMentionAttachment(
   ])
 }
 
-function normalizeCompactionReminderAttachment(): UserMessage[] {
+/**
+ * Honest context-pressure line. The previous copy told the model it had
+ * "unlimited context" \u2014 the opposite of actionable: the model could not
+ * self-pace (wrap up a discrete step, persist state to files) before
+ * auto-compact summarized details away.
+ */
+export function formatContextPressureReminder(attachment: {
+  used: number
+  threshold: number
+  remaining: number
+  percentUsed: number
+}): string {
+  const roundK = (tokens: number): string =>
+    `${Math.max(1, Math.round(tokens / 1000))}k`
+  const urgency =
+    attachment.percentUsed >= 90
+      ? ' Compaction is imminent: finish the current discrete step and persist anything you must not lose (files, notes, commit) NOW.'
+      : ' Prefer finishing discrete units of work and persisting important state to files before then; details from older messages may be summarized away.'
+  return (
+    `Context status: ~${attachment.percentUsed}% of the auto-compact threshold used ` +
+    `(~${roundK(attachment.used)} of ~${roundK(attachment.threshold)} tokens; ~${roundK(attachment.remaining)} left). ` +
+    `When the threshold is reached, older messages are automatically summarized and work continues.${urgency}`
+  )
+}
+
+function normalizeCompactionReminderAttachment(attachment: {
+  used?: number
+  threshold?: number
+  remaining?: number
+  percentUsed?: number
+}): UserMessage[] {
+  const content =
+    typeof attachment.used === 'number' &&
+    typeof attachment.threshold === 'number' &&
+    typeof attachment.remaining === 'number' &&
+    typeof attachment.percentUsed === 'number'
+      ? formatContextPressureReminder({
+          used: attachment.used,
+          threshold: attachment.threshold,
+          remaining: attachment.remaining,
+          percentUsed: attachment.percentUsed,
+        })
+      : 'Auto-compact is enabled. When the context window is nearly full, older messages will be automatically summarized so you can continue working.'
   return wrapMessagesInSystemReminder([
     createUserMessage({
-      content:
-        'Auto-compact is enabled. When the context window is nearly full, older messages will be automatically summarized so you can continue working seamlessly. There is no need to stop or rush \u2014 you have unlimited context through automatic compaction.',
+      content,
       isMeta: true,
     }),
   ])
@@ -5053,7 +5094,7 @@ export function normalizeAttachmentForAPI(
       return normalizeHookStoppedContinuationAttachment(attachment)
     }
     case 'compaction_reminder': {
-      return normalizeCompactionReminderAttachment()
+      return normalizeCompactionReminderAttachment(attachment)
     }
     case 'context_efficiency': {
       return normalizeContextEfficiencyAttachment()

--- a/runtime/tests/conversation/messages-core.test.ts
+++ b/runtime/tests/conversation/messages-core.test.ts
@@ -1755,9 +1755,21 @@ describe("message utility constructors and predicates", () => {
     expect(hookStoppedText).not.toContain("halted</system-reminder>");
     expect(hookStoppedText.match(/<\/system-reminder>/g)).toHaveLength(1);
 
+    // Fieldless legacy payloads fall back to the generic (still honest)
+    // line; data-bearing payloads render live context-pressure numbers.
     expect(userText(normalizeAttachmentForAPI({
       type: "compaction_reminder",
     } as never)[0])).toContain("Auto-compact is enabled");
+    const pressureText = userText(normalizeAttachmentForAPI({
+      type: "compaction_reminder",
+      used: 80_000,
+      threshold: 100_000,
+      remaining: 20_000,
+      percentUsed: 80,
+    } as never)[0]);
+    expect(pressureText).toContain("~80% of the auto-compact threshold");
+    expect(pressureText).toContain("~80k of ~100k tokens");
+    expect(pressureText).not.toContain("unlimited context");
     expect(normalizeAttachmentForAPI({
       type: "context_efficiency",
     } as never)).toEqual([]);

--- a/runtime/tests/prompts/attachments/messages.test.ts
+++ b/runtime/tests/prompts/attachments/messages.test.ts
@@ -312,8 +312,13 @@ describe("attachmentsToMessages", () => {
     expect(out[2]?.content).toContain(
       "Output tokens — turn: 750 / 4,000 · session: 2,000",
     );
-    expect(out[3]?.content).toContain("Auto-compact is enabled");
-    expect(out[3]?.content).toContain("automatic compaction");
+    expect(out[3]?.content).toContain(
+      "~80% of the auto-compact threshold used",
+    );
+    expect(out[3]?.content).toContain("~80k of ~100k tokens");
+    // The old copy claimed "unlimited context" — the opposite of a
+    // usable pressure signal.
+    expect(out[3]?.content).not.toContain("unlimited context");
     for (const message of out) {
       expect(message.content).toContain("<system-reminder>");
     }

--- a/runtime/tests/utils/attachments-context-pressure.test.ts
+++ b/runtime/tests/utils/attachments-context-pressure.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Task 7: the model-facing context-pressure signal.
+ *
+ * The producer used to be triple-disabled (feature flag absent, a
+ * hard-coded `if (!false) return []`, and a 1M-window gate) and its
+ * copy told the model it had "unlimited context". These tests pin the
+ * live behavior: above half the auto-compact threshold, every turn
+ * carries an honest usage line so the model can self-pace.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getCompactionReminderAttachment } from "./attachments.js";
+import { feature } from "../build/feature.js";
+import { formatContextPressureReminder } from "./messages.js";
+import { getAutoCompactThreshold } from "../services/compact/autoCompact.js";
+import type { Message } from "../types/message.js";
+
+const WINDOW_ENV = "AGENC_AUTO_COMPACT_WINDOW";
+
+function userMessage(chars: number): Message {
+  return {
+    type: "user",
+    uuid: "00000000-0000-0000-0000-000000000001",
+    timestamp: new Date(0).toISOString(),
+    message: { role: "user", content: "x".repeat(chars) },
+  } as unknown as Message;
+}
+
+afterEach(() => {
+  delete process.env[WINDOW_ENV];
+  delete process.env.AGENC_DISABLE_COMPACT;
+});
+
+describe("context-pressure attachment producer", () => {
+  it("is enabled at the feature gate", () => {
+    expect(feature("COMPACTION_REMINDERS")).toBe(true);
+  });
+
+  it("stays silent below half the auto-compact threshold", () => {
+    process.env[WINDOW_ENV] = "100000";
+    const out = getCompactionReminderAttachment(
+      [userMessage(10_000)],
+      "test-model",
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("emits live usage numbers above the signal fraction", () => {
+    process.env[WINDOW_ENV] = "100000";
+    const threshold = getAutoCompactThreshold("test-model");
+    // ~75% of the threshold in estimated tokens (~4 chars/token).
+    const out = getCompactionReminderAttachment(
+      [userMessage(Math.floor(threshold * 0.75) * 4)],
+      "test-model",
+    );
+    expect(out).toHaveLength(1);
+    const attachment = out[0] as {
+      type: string;
+      used: number;
+      threshold: number;
+      remaining: number;
+      percentUsed: number;
+    };
+    expect(attachment.type).toBe("compaction_reminder");
+    expect(attachment.threshold).toBe(threshold);
+    expect(attachment.percentUsed).toBeGreaterThanOrEqual(55);
+    expect(attachment.percentUsed).toBeLessThanOrEqual(100);
+    expect(attachment.remaining).toBe(
+      Math.max(0, threshold - attachment.used),
+    );
+  });
+
+  it("stays silent when auto-compact is disabled", () => {
+    process.env[WINDOW_ENV] = "100000";
+    process.env.AGENC_DISABLE_COMPACT = "1";
+    const out = getCompactionReminderAttachment(
+      [userMessage(999_999)],
+      "test-model",
+    );
+    expect(out).toEqual([]);
+  });
+});
+
+describe("formatContextPressureReminder", () => {
+  it("renders percent, token counts, and pacing guidance", () => {
+    const text = formatContextPressureReminder({
+      used: 60_000,
+      threshold: 100_000,
+      remaining: 40_000,
+      percentUsed: 60,
+    });
+    expect(text).toContain("~60% of the auto-compact threshold used");
+    expect(text).toContain("~60k of ~100k tokens");
+    expect(text).toContain("~40k left");
+    expect(text).toContain("persisting important state");
+    expect(text).not.toContain("unlimited context");
+  });
+
+  it("escalates the guidance when compaction is imminent", () => {
+    const text = formatContextPressureReminder({
+      used: 95_000,
+      threshold: 100_000,
+      remaining: 5_000,
+      percentUsed: 95,
+    });
+    expect(text).toContain("Compaction is imminent");
+  });
+});


### PR DESCRIPTION
## TODO task 7 — the model never sees context pressure

**Verified first (2026-07-07):** all context telemetry was TUI-only; the `compaction_reminder` attachment was triple-disabled (flag absent from the feature table → `feature()` returns false, a literal `if (!false) return []` in the producer, and a 1M-window gate) and its copy claimed "unlimited context".

### What this ships
- `COMPACTION_REMINDERS: true` + a real producer: above 50% of the auto-compact threshold, every turn carries `{used, threshold, remaining, percentUsed}` (live token estimate vs `getAutoCompactThreshold`, all window sizes).
- Honest copy in both renderers: "Context status: ~N% of the auto-compact threshold used (~Xk of ~Yk tokens; ~Zk left)…" with pacing guidance, escalating to "Compaction is imminent… persist NOW" at ≥90%. The misleading "unlimited context" line is corrected everywhere.
- Rides the per-turn attachment channel near the request tail — static prefix caching (task 5) unaffected.

### Tests
6 new producer/formatter tests (silent below the band, live numbers above, silent when compaction disabled, copy assertions, imminent escalation) + the two existing renderer pins updated to the new copy. Revert-sensitive: 4/6 fail with the source stashed.

### Gates
build ✓, tsc 0 ✓; full vitest 68 = pre-existing main set (TODO task 27), zero regressions.