### PR TITLE
feat(tools): background-shell trio — run, poll by id, kill by id

### DIFF
--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -37,6 +37,7 @@ import { createCodingTools, SESSION_ADVERTISED_TOOL_NAMES_ARG } from "./tools/sy
 import { createBashTool } from "./tools/system/bash.js";
 import { createExecCommandTool } from "./tools/system/exec-command.js";
 import { createWriteStdinTool } from "./tools/system/write-stdin.js";
+import { createKillProcessTool } from "./tools/system/kill-process.js";
 import { createPlanningTools } from "./tools/system/planning.js";
 import { createAskUserQuestionTool } from "./tools/ask-user-question/tool.js";
 import { createSleepTool } from "./tools/system/sleep.js";
@@ -581,6 +582,10 @@ export function buildToolRegistry(
       allowedPaths: [options.workspaceRoot],
       unifiedExecManager,
     }),
+    createKillProcessTool({
+      cwd: options.workspaceRoot,
+      unifiedExecManager,
+    }),
     createBashTool({
       cwd: options.workspaceRoot,
       ...(options.bashExecObserver !== undefined
@@ -712,6 +717,7 @@ export function buildToolRegistry(
       visibleByDefault: [
         shellToolSurface.execCommand,
         shellToolSurface.writeStdin,
+        "kill_process",
       ],
       stringArgumentFields: {
         [shellToolSurface.execCommand]: "cmd",

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -239,7 +239,7 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
   return {
     name: "exec_command",
     description:
-      "Run a shell command in the current AgenC workspace and return captured stdout/stderr. Use this for inspection, tests, builds, and other terminal work. Use Edit or Write for source-file edits. Never use this to print commentary, placeholders, or reminders to yourself; call the relevant tool directly instead.",
+      "Run a shell command in the current AgenC workspace and return captured stdout/stderr. Use this for inspection, tests, builds, and other terminal work. Use Edit or Write for source-file edits. Never use this to print commentary, placeholders, or reminders to yourself; call the relevant tool directly instead.\n\nLong-running commands: set a short yield_time_ms to run in the BACKGROUND — when the command outlives the yield window the result carries a session_id and the process keeps running. Poll for more output with write_stdin(session_id, chars='') and stop it with kill_process(session_id). Prefer this over trailing '&' (a shell-backgrounded child has no session_id, so its output is unrecoverable).",
     metadata: {
       family: "terminal",
       source: "builtin",

--- a/runtime/src/tools/system/kill-process.ts
+++ b/runtime/src/tools/system/kill-process.ts
@@ -1,0 +1,100 @@
+/**
+ * kill_process — the kill half of the background-shell trio
+ * (exec_command run-in-background via yield_time_ms → write_stdin
+ * chars:'' output polling → kill_process termination). Before this
+ * tool existed a yielded background process could only be abandoned:
+ * the model had no handle to stop a runaway command short of waiting
+ * for the manager's hard timeout.
+ */
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
+import type { UnifiedExecProcessManagerLike } from "../../unified-exec/types.js";
+
+export interface KillProcessToolConfig {
+  readonly cwd?: string;
+  readonly env?: Record<string, string>;
+  readonly maxTimeoutMs?: number;
+  readonly unifiedExecManager?: UnifiedExecProcessManagerLike;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export function createKillProcessTool(config?: KillProcessToolConfig): Tool {
+  const manager =
+    config?.unifiedExecManager ??
+    new UnifiedExecProcessManager({
+      cwd: config?.cwd,
+      env: config?.env,
+      maxTimeoutMs: config?.maxTimeoutMs,
+    });
+
+  return {
+    name: "kill_process",
+    description:
+      "Terminate a background process started by exec_command, by its session_id. Reports terminated=false when the process already exited (killing a finished process is a benign race, not an error).",
+    metadata: {
+      family: "terminal",
+      source: "builtin",
+      keywords: ["kill", "terminate", "process", "background", "session"],
+      preferredProfiles: ["coding", "validation", "operator"],
+      hiddenByDefault: false,
+      mutating: true,
+      deferred: false,
+    },
+    requiresApproval: false,
+    concurrencyClass: { kind: "background_terminal" },
+    isReadOnly: false,
+    recoveryCategory: "idempotent",
+    supportsParallelToolCalls: false,
+    isConcurrencySafe: () => false,
+    interruptBehavior: () => "cancel",
+    inputSchema: {
+      type: "object",
+      properties: {
+        session_id: {
+          type: "number",
+          description:
+            "The session_id returned by exec_command for the process to terminate.",
+        },
+        process_id: {
+          type: "number",
+          description: "Compatibility alias for session_id.",
+        },
+      },
+      anyOf: [{ required: ["session_id"] }, { required: ["process_id"] }],
+      additionalProperties: false,
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const sessionId = asNumber(args.session_id) ?? asNumber(args.process_id);
+      if (sessionId === undefined) {
+        return {
+          content: safeStringify({ error: "session_id must be a number" }),
+          isError: true,
+        };
+      }
+      if (manager.terminateProcess === undefined) {
+        return {
+          content: safeStringify({
+            error: "process termination is not supported by this runtime",
+          }),
+          isError: true,
+        };
+      }
+      const outcome = manager.terminateProcess(sessionId);
+      return {
+        content: safeStringify({
+          session_id: sessionId,
+          terminated: outcome.terminated,
+          ...(outcome.terminated
+            ? {}
+            : { note: "no live process with this id (already exited or unknown)" }),
+        }),
+      };
+    },
+  };
+}

--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -51,7 +51,7 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
   return {
     name: "write_stdin",
     description:
-      "Send input to a live AgenC PTY session created by exec_command with tty=true. Use session_id from the exec_command result. Pass chars='' to poll for more output.",
+      "Interact with a live exec_command session by session_id. Pass chars='' to poll for more output from ANY still-running session (background commands included — tty not required). Sending non-empty input requires the session to have been started with tty=true.",
     metadata: {
       family: "terminal",
       source: "builtin",

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -540,6 +540,21 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
     };
   }
 
+  /**
+   * Terminate one live background process by id (the model-facing
+   * kill half of the run-in-background / poll / kill trio). Unknown or
+   * already-exited ids report `terminated: false` rather than throwing —
+   * killing a finished process is a benign race, not an error.
+   */
+  terminateProcess(processId: number): { terminated: boolean } {
+    const entry = this.processes.get(processId);
+    if (!entry || entry.exitState !== null) {
+      return { terminated: false };
+    }
+    this.forceTerminate(entry);
+    return { terminated: true };
+  }
+
   async closeAll(_reason = "session_shutdown"): Promise<void> {
     const entries = [...this.processes.values()];
     for (const entry of entries) {

--- a/runtime/src/unified-exec/types.ts
+++ b/runtime/src/unified-exec/types.ts
@@ -110,6 +110,8 @@ export interface UnifiedExecProcessManagerLike {
   readonly maxTimeoutMs: number;
   execCommand(request: ExecCommandRequest): Promise<ExecCommandToolOutput>;
   writeStdin(request: WriteStdinRequest): Promise<ExecCommandToolOutput>;
+  /** Terminate one live background process by its session/process id. */
+  terminateProcess?(processId: number): { terminated: boolean };
   closeAll(reason?: string): Promise<void>;
 }
 

--- a/runtime/tests/bin/cron-live-tools.test.ts
+++ b/runtime/tests/bin/cron-live-tools.test.ts
@@ -41,6 +41,19 @@ async function advanceMinutesWithIo(minutes: number): Promise<void> {
   }
 }
 
+/**
+ * Advance fake minutes until the command queue is non-empty (or the
+ * minute budget runs out). Under full-suite load the tick's real fs
+ * hops can take more wall time per fake minute, so a fixed advance
+ * count is flaky — poll instead.
+ */
+async function advanceUntilQueued(maxMinutes: number): Promise<void> {
+  for (let minute = 0; minute < maxMinutes; minute += 1) {
+    await advanceMinutesWithIo(1);
+    if (getCommandQueueSnapshot().length > 0) return;
+  }
+}
+
 function cronTools(): Map<string, Tool> {
   const tools = createModelFacingTools({
     workspaceRoot: tempRoot,
@@ -130,7 +143,7 @@ describe("live Cron tools drive the real scheduler", () => {
       expect(getCommandQueueSnapshot()).toHaveLength(0);
 
       // Advance past the next whole minute (+ scheduler floors/jitter).
-      await advanceMinutesWithIo(5);
+      await advanceUntilQueued(20);
 
       const queued = getCommandQueueSnapshot();
       expect(queued.length).toBeGreaterThan(0);
@@ -175,7 +188,7 @@ describe("live Cron tools drive the real scheduler", () => {
         "./model-facing-tools.js"
       );
       await startCronSchedulerRunner();
-      await advanceMinutesWithIo(5);
+      await advanceUntilQueued(20);
 
       const queued = getCommandQueueSnapshot();
       expect(

--- a/runtime/tests/tools/kill-process.test.ts
+++ b/runtime/tests/tools/kill-process.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { createKillProcessTool } from "./system/kill-process.js";
+import type { UnifiedExecProcessManagerLike } from "../unified-exec/types.js";
+
+function fakeManager(
+  terminated: boolean,
+): UnifiedExecProcessManagerLike & { terminateProcess: ReturnType<typeof vi.fn> } {
+  return {
+    maxTimeoutMs: 1_000,
+    execCommand: vi.fn(),
+    writeStdin: vi.fn(),
+    terminateProcess: vi.fn(() => ({ terminated })),
+    closeAll: vi.fn(),
+  } as never;
+}
+
+describe("kill_process tool", () => {
+  it("terminates a live session by session_id", async () => {
+    const manager = fakeManager(true);
+    const tool = createKillProcessTool({ unifiedExecManager: manager });
+    const result = await tool.execute({ session_id: 7 });
+    expect(manager.terminateProcess).toHaveBeenCalledWith(7);
+    expect(JSON.parse(String(result.content))).toEqual({
+      session_id: 7,
+      terminated: true,
+    });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("accepts the process_id alias and reports benign no-ops", async () => {
+    const manager = fakeManager(false);
+    const tool = createKillProcessTool({ unifiedExecManager: manager });
+    const result = await tool.execute({ process_id: 9 });
+    const payload = JSON.parse(String(result.content)) as {
+      terminated: boolean;
+      note?: string;
+    };
+    expect(payload.terminated).toBe(false);
+    expect(payload.note).toContain("already exited or unknown");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("rejects calls without an id", async () => {
+    const tool = createKillProcessTool({
+      unifiedExecManager: fakeManager(true),
+    });
+    const result = await tool.execute({});
+    expect(result.isError).toBe(true);
+  });
+});

--- a/runtime/tests/unified-exec/process-manager.test.ts
+++ b/runtime/tests/unified-exec/process-manager.test.ts
@@ -708,3 +708,55 @@ describe("UnifiedExecProcessManager", () => {
     } satisfies Partial<UnifiedExecError>);
   }, 10_000);
 });
+
+describe("background-shell trio (task 8)", () => {
+  test("yield → poll (non-tty) → completion output → kill", async () => {
+    const manager = new UnifiedExecProcessManager({ cwd: process.cwd() });
+
+    // 1) Run in background: the command outlives the yield window and
+    //    returns a live session id.
+    const started = await manager.execCommand({
+      cmd: "sleep 8 && echo done-marker",
+      yield_time_ms: 150,
+    });
+    expect(started.process_id).toEqual(expect.any(Number));
+    const sessionId = started.process_id!;
+    expect(started.stdout).not.toContain("done-marker");
+
+    // 2) Early poll via write_stdin with EMPTY input — allowed for
+    //    non-tty sessions (only WRITING requires tty).
+    const early = await manager.writeStdin({
+      session_id: sessionId,
+      chars: "",
+      yield_time_ms: 100, // floored to the 5s empty-poll minimum
+    });
+    expect(early.stdout).not.toContain("done-marker");
+    expect(early.process_id).toBe(sessionId);
+
+    // 3) Later poll sees the completed output and the exit.
+    const later = await manager.writeStdin({
+      session_id: sessionId,
+      chars: "",
+      yield_time_ms: 6_000,
+    });
+    expect(later.stdout).toContain("done-marker");
+    expect(later.process_id).toBeUndefined();
+
+    // 4) Kill a long-runner by id.
+    const longRunner = await manager.execCommand({
+      cmd: "sleep 300",
+      yield_time_ms: 100,
+    });
+    const killId = longRunner.process_id!;
+    expect(manager.terminateProcess(killId)).toEqual({ terminated: true });
+    // Wait for the SIGTERM to land (exit is asynchronous), then a
+    // second kill (or an unknown id) is a benign no-op.
+    await manager
+      .writeStdin({ session_id: killId, chars: "", yield_time_ms: 100 })
+      .catch(() => undefined);
+    expect(manager.terminateProcess(killId)).toEqual({ terminated: false });
+    expect(manager.terminateProcess(999_999)).toEqual({ terminated: false });
+
+    await manager.closeAll();
+  }, 40_000);
+});


### PR DESCRIPTION
## TODO task 8 — background bash is fire-and-forget

**Verified first (2026-07-07):** partially REFUTED, which shrank the task: the manager already permits empty-input polling on non-tty sessions (the tty gate only applies to writes) — only the write_stdin description claimed otherwise. What was genuinely missing: any kill-by-id, and model-facing documentation of the run-in-background pattern.

### What this ships
- `kill_process` (visible by default, shared manager): `terminateProcess(sessionId)` on the unified-exec manager; benign no-op semantics for exited/unknown ids.
- Corrected `write_stdin` description (poll works for ANY live session) and `exec_command` background-pattern docs (prefer `yield_time_ms` over trailing `&`, whose output is unrecoverable).
- Completion visibility: a finished background command's output + exit arrive on the next poll (the empty-poll floor returns early on exit).

### Tests
Manager-level acceptance (the TODO's literal flow): background launch returns id → early poll misses → later poll returns `done-marker` + exit → long-runner killed by id → double-kill/unknown-id no-ops. 3 tool-level tests. Revert-sensitivity proven via a HEAD worktree (2 test files red). Also hardens the task-6 cron test against a full-suite-load flake (poll-until-queued).

### Gates
build ✓, tsc 0 ✓; full vitest: 68 known pre-existing (TODO task 27) + 1 occurrence of the now-hardened cron flake (3× green after hardening), zero regressions.