### PR TITLE
feat(agents): deterministic multi-agent workflow runner

### DIFF
--- a/runtime/src/agents/workflow-runner.ts
+++ b/runtime/src/agents/workflow-runner.ts
@@ -1,0 +1,278 @@
+/**
+ * Deterministic multi-agent workflow runner.
+ *
+ * Executes a declared step graph over the existing delegation
+ * primitives: control flow (ordering, fan-out, joins, result passing)
+ * lives HERE, deterministically — agents only run inside steps. This
+ * is the orchestration layer the spawn/wait/send primitives were
+ * missing: "spawn these N agents in parallel, gather their outputs,
+ * then run phase 2 with the results".
+ *
+ * Manifest shape (`.agenc/workflows/<name>.json` `steps` array):
+ *
+ *   {
+ *     "description": "review pipeline",
+ *     "steps": [
+ *       { "id": "read_a", "group": "readers", "message": "Summarize src/a" },
+ *       { "id": "read_b", "group": "readers", "message": "Summarize src/b" },
+ *       { "id": "synth", "after": ["readers"],
+ *         "message": "Synthesize:\n{{group.readers}}" }
+ *     ]
+ *   }
+ *
+ * Semantics:
+ *   - `after` entries reference step ids OR group names; a step runs
+ *     once every referenced step/group member is terminal.
+ *   - Steps whose dependencies are satisfied run CONCURRENTLY.
+ *   - `{{steps.<id>}}` in a message is replaced with that step's final
+ *     message; `{{group.<name>}}` with every member's final message
+ *     (labeled, joined). Unknown placeholders are left verbatim.
+ *   - A failed step (outcome !== "completed") marks every transitive
+ *     dependent "skipped"; independent branches keep running.
+ *
+ * @module
+ */
+import { delegate, type IsolationMode } from "./delegate.js";
+import type { AgentControl } from "./control.js";
+import type { AgentRegistry } from "./registry.js";
+import type { AgentThread } from "./thread.js";
+import type { Session } from "../session/session.js";
+import {
+  backgroundTaskLifecycle,
+  registerAgentThreadTask,
+  type BackgroundTaskLifecycle,
+} from "../tasks/index.js";
+
+export interface WorkflowStepSpec {
+  readonly id: string;
+  readonly message: string;
+  readonly task_name?: string;
+  readonly agent_type?: string;
+  readonly model?: string;
+  readonly isolation?: IsolationMode;
+  readonly group?: string;
+  readonly after?: readonly string[];
+}
+
+export type WorkflowStepOutcome =
+  | "completed"
+  | "errored"
+  | "interrupted"
+  | "aborted"
+  | "skipped";
+
+export interface WorkflowStepResult {
+  readonly id: string;
+  readonly outcome: WorkflowStepOutcome;
+  readonly final_message: string;
+  readonly duration_ms?: number;
+  readonly error?: string;
+}
+
+export interface RunAgentWorkflowOptions {
+  readonly session: Session;
+  readonly control: AgentControl;
+  readonly registry: AgentRegistry;
+  readonly steps: readonly WorkflowStepSpec[];
+  readonly parentPath?: string;
+  readonly lifecycle?: BackgroundTaskLifecycle;
+  /** Injectable for tests. Defaults to the real delegate(). */
+  readonly delegateFn?: typeof delegate;
+}
+
+export class WorkflowValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowValidationError";
+  }
+}
+
+/** Validate ids, dependency references, and acyclicity. */
+export function validateWorkflowSteps(
+  steps: readonly WorkflowStepSpec[],
+): void {
+  if (steps.length === 0) {
+    throw new WorkflowValidationError("workflow has no steps");
+  }
+  const ids = new Set<string>();
+  const groups = new Set<string>();
+  for (const step of steps) {
+    if (!step.id || typeof step.id !== "string") {
+      throw new WorkflowValidationError("every step needs a string id");
+    }
+    if (ids.has(step.id)) {
+      throw new WorkflowValidationError(`duplicate step id: ${step.id}`);
+    }
+    if (typeof step.message !== "string" || step.message.length === 0) {
+      throw new WorkflowValidationError(`step ${step.id} needs a message`);
+    }
+    ids.add(step.id);
+    if (step.group) groups.add(step.group);
+  }
+  for (const step of steps) {
+    for (const dep of step.after ?? []) {
+      if (!ids.has(dep) && !groups.has(dep)) {
+        throw new WorkflowValidationError(
+          `step ${step.id} depends on unknown step/group "${dep}"`,
+        );
+      }
+      if (dep === step.id || dep === step.group) {
+        throw new WorkflowValidationError(
+          `step ${step.id} depends on itself (directly or via its group)`,
+        );
+      }
+    }
+  }
+  // Cycle check: repeated ready-set peeling over the dependency graph.
+  const pending = new Set(steps.map((s) => s.id));
+  const byId = new Map(steps.map((s) => [s.id, s]));
+  const groupMembers = new Map<string, string[]>();
+  for (const step of steps) {
+    if (step.group) {
+      groupMembers.set(step.group, [
+        ...(groupMembers.get(step.group) ?? []),
+        step.id,
+      ]);
+    }
+  }
+  const depsOf = (id: string): string[] => {
+    const step = byId.get(id)!;
+    return (step.after ?? []).flatMap((dep) =>
+      groupMembers.get(dep)?.filter((member) => member !== id) ?? [dep],
+    );
+  };
+  while (pending.size > 0) {
+    const ready = [...pending].filter((id) =>
+      depsOf(id).every((dep) => !pending.has(dep)),
+    );
+    if (ready.length === 0) {
+      throw new WorkflowValidationError(
+        `dependency cycle among steps: ${[...pending].join(", ")}`,
+      );
+    }
+    for (const id of ready) pending.delete(id);
+  }
+}
+
+function renderTemplate(
+  message: string,
+  results: ReadonlyMap<string, WorkflowStepResult>,
+  groupMembers: ReadonlyMap<string, readonly string[]>,
+): string {
+  return message
+    .replace(/\{\{\s*steps\.([A-Za-z0-9_-]+)\s*\}\}/g, (match, id: string) => {
+      const result = results.get(id);
+      return result !== undefined ? result.final_message : match;
+    })
+    .replace(/\{\{\s*group\.([A-Za-z0-9_-]+)\s*\}\}/g, (match, name: string) => {
+      const members = groupMembers.get(name);
+      if (members === undefined) return match;
+      return members
+        .map((id) => {
+          const result = results.get(id);
+          return `### ${id}\n${result?.final_message ?? ""}`;
+        })
+        .join("\n\n");
+    });
+}
+
+/**
+ * Run the workflow to completion. Deterministic control flow: waves of
+ * ready steps execute concurrently; each wave joins before dependents
+ * are scheduled.
+ */
+export async function runAgentWorkflow(
+  opts: RunAgentWorkflowOptions,
+): Promise<{ readonly steps: readonly WorkflowStepResult[] }> {
+  validateWorkflowSteps(opts.steps);
+  const delegateFn = opts.delegateFn ?? delegate;
+  const lifecycle = opts.lifecycle ?? backgroundTaskLifecycle;
+  const parentPath = opts.parentPath ?? "/root";
+
+  const groupMembers = new Map<string, string[]>();
+  for (const step of opts.steps) {
+    if (step.group) {
+      groupMembers.set(step.group, [
+        ...(groupMembers.get(step.group) ?? []),
+        step.id,
+      ]);
+    }
+  }
+  const results = new Map<string, WorkflowStepResult>();
+  const pending = new Map(opts.steps.map((s) => [s.id, s]));
+
+  const depIds = (step: WorkflowStepSpec): string[] =>
+    (step.after ?? []).flatMap((dep) =>
+      groupMembers.get(dep)?.filter((member) => member !== step.id) ?? [dep],
+    );
+
+  const runStep = async (step: WorkflowStepSpec): Promise<WorkflowStepResult> => {
+    const deps = depIds(step);
+    if (deps.some((dep) => results.get(dep)?.outcome !== "completed")) {
+      return { id: step.id, outcome: "skipped", final_message: "", error: "upstream step did not complete" };
+    }
+    const message = renderTemplate(step.message, results, groupMembers);
+    const outcome = await delegateFn({
+      parent: opts.session,
+      parentPath,
+      control: opts.control,
+      registry: opts.registry,
+      taskPrompt: message,
+      agentName: step.task_name ?? step.id,
+      runInBackground: true,
+      ...(step.agent_type !== undefined ? { role: step.agent_type } : {}),
+      ...(step.model !== undefined ? { model: step.model } : {}),
+      ...(step.isolation !== undefined && step.isolation !== "none"
+        ? { isolation: step.isolation, worktreeSlug: step.task_name ?? step.id }
+        : {}),
+      forkMode: undefined,
+    });
+    if (outcome.kind === "rejected") {
+      return {
+        id: step.id,
+        outcome: "errored",
+        final_message: "",
+        error: outcome.reason,
+      };
+    }
+    const thread: AgentThread = outcome.thread;
+    try {
+      registerAgentThreadTask(lifecycle, thread as never, {
+        description: `workflow:${step.id}`,
+        prompt: message,
+      });
+    } catch {
+      /* pill registration is best-effort (duplicate ids etc.) */
+    }
+    const result = await thread.join();
+    return {
+      id: step.id,
+      outcome: result.outcome,
+      final_message: result.finalMessage ?? "",
+      duration_ms: result.durationMs,
+      ...(result.outcome !== "completed" && result.error !== undefined
+        ? { error: String(result.error) }
+        : {}),
+    };
+  };
+
+  while (pending.size > 0) {
+    const wave = [...pending.values()].filter((step) =>
+      depIds(step).every((dep) => results.has(dep)),
+    );
+    // validateWorkflowSteps guarantees progress; this guard is a
+    // belt-and-suspenders against future validation drift.
+    if (wave.length === 0) {
+      throw new WorkflowValidationError(
+        `workflow stalled with pending steps: ${[...pending.keys()].join(", ")}`,
+      );
+    }
+    for (const step of wave) pending.delete(step.id);
+    const waveResults = await Promise.all(wave.map((step) => runStep(step)));
+    for (const result of waveResults) results.set(result.id, result);
+  }
+
+  return {
+    steps: opts.steps.map((step) => results.get(step.id)!),
+  };
+}

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2774,11 +2774,11 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
     {
       name: "WorkflowTool",
       description:
-        "Run a named local workflow from .agenc/workflows or AGENC_HOME/workflows.",
+        "Run a named local workflow from .agenc/workflows or AGENC_HOME/workflows. A workflow with a `steps` array is a DETERMINISTIC multi-agent pipeline: each step spawns an agent; steps with satisfied `after` dependencies run in parallel; `{{steps.<id>}}` / `{{group.<name>}}` in a step's message receive earlier results. A workflow with only `command` runs that single shell command (legacy shape).",
       metadata: toolMetadata("workflow", {
         mutating: true,
         deferred: true,
-        keywords: ["workflow", "run"],
+        keywords: ["workflow", "run", "pipeline", "fan-out"],
       }),
       requiresApproval: true,
       recoveryCategory: "side-effecting",
@@ -2805,9 +2805,44 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
         const workflow = JSON.parse(await readFile(workflowPath, "utf8")) as {
           command?: string;
           description?: string;
+          steps?: unknown;
         };
+        if (Array.isArray(workflow.steps) && workflow.steps.length > 0) {
+          const session = opts.getSession();
+          if (!session) {
+            return json(
+              { error: "agent workflows require an active session" },
+              true,
+            );
+          }
+          const { control, registry } = ensureAgentControl(session);
+          const {
+            runAgentWorkflow,
+            WorkflowValidationError,
+          } = await import("../agents/workflow-runner.js");
+          try {
+            const run = await runAgentWorkflow({
+              session,
+              control,
+              registry,
+              steps: workflow.steps as never,
+            });
+            const failed = run.steps.some(
+              (step) => step.outcome !== "completed",
+            );
+            return json(
+              { workflow: name, steps: run.steps },
+              failed ? true : undefined,
+            );
+          } catch (error) {
+            if (error instanceof WorkflowValidationError) {
+              return json({ error: error.message, workflow: name }, true);
+            }
+            throw error;
+          }
+        }
         if (!workflow.command) {
-          return json({ error: `workflow ${name} has no command` }, true);
+          return json({ error: `workflow ${name} has no command or steps` }, true);
         }
         if (!opts.unifiedExecManager) {
           return json({ error: "unified exec manager is not available" }, true);

--- a/runtime/tests/agents/workflow-runner.test.ts
+++ b/runtime/tests/agents/workflow-runner.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Task 11: deterministic multi-agent workflow runner. The Accept
+ * scenario: a 2-phase workflow (3 parallel readers → 1 synthesizer
+ * receiving their outputs) completes with correct data flow and
+ * per-step task pills.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  runAgentWorkflow,
+  validateWorkflowSteps,
+  WorkflowValidationError,
+  type WorkflowStepSpec,
+} from "./workflow-runner.js";
+import { BackgroundTaskLifecycle } from "../tasks/index.js";
+import type { Session } from "../session/session.js";
+
+interface SpawnRecord {
+  readonly agentName: string;
+  readonly taskPrompt: string;
+}
+
+function fakeDelegate(opts: {
+  readonly finalMessages: Record<string, string>;
+  readonly failing?: ReadonlySet<string>;
+  readonly spawns: SpawnRecord[];
+}) {
+  let counter = 0;
+  return vi.fn(async (delegateOpts: { agentName?: string; taskPrompt: string }) => {
+    const agentName = delegateOpts.agentName ?? `agent-${counter}`;
+    counter += 1;
+    opts.spawns.push({ agentName, taskPrompt: delegateOpts.taskPrompt });
+    const threadId = `thread-${agentName}`;
+    const fails = opts.failing?.has(agentName) === true;
+    return {
+      kind: "async_launched" as const,
+      thread: {
+        threadId,
+        taskPrompt: delegateOpts.taskPrompt,
+        live: {
+          agentId: threadId,
+          abortController: new AbortController(),
+          status: { value: "running" },
+        },
+        join: async () =>
+          fails
+            ? {
+                threadId,
+                durationMs: 1,
+                outcome: "errored" as const,
+                error: "boom",
+              }
+            : {
+                threadId,
+                durationMs: 1,
+                outcome: "completed" as const,
+                finalMessage:
+                  opts.finalMessages[agentName] ?? `${agentName} done`,
+              },
+      },
+    };
+  });
+}
+
+const session = { conversationId: "conv-wf" } as unknown as Session;
+const control = {} as never;
+const registry = {} as never;
+
+describe("validateWorkflowSteps", () => {
+  it("rejects duplicates, unknown deps, and cycles", () => {
+    expect(() =>
+      validateWorkflowSteps([
+        { id: "a", message: "x" },
+        { id: "a", message: "y" },
+      ]),
+    ).toThrow(WorkflowValidationError);
+    expect(() =>
+      validateWorkflowSteps([{ id: "a", message: "x", after: ["ghost"] }]),
+    ).toThrow(/unknown step\/group/);
+    expect(() =>
+      validateWorkflowSteps([
+        { id: "a", message: "x", after: ["b"] },
+        { id: "b", message: "y", after: ["a"] },
+      ]),
+    ).toThrow(/cycle/);
+  });
+});
+
+describe("runAgentWorkflow", () => {
+  const readerSteps: WorkflowStepSpec[] = [
+    { id: "read_a", group: "readers", message: "Summarize module A" },
+    { id: "read_b", group: "readers", message: "Summarize module B" },
+    { id: "read_c", group: "readers", message: "Summarize module C" },
+    {
+      id: "synth",
+      after: ["readers"],
+      message: "Synthesize the findings:\n{{group.readers}}",
+    },
+  ];
+
+  it("fans out readers in parallel, then feeds their outputs to the synthesizer", async () => {
+    const spawns: SpawnRecord[] = [];
+    const lifecycle = new BackgroundTaskLifecycle();
+    const delegateFn = fakeDelegate({
+      spawns,
+      finalMessages: {
+        read_a: "A uses pattern X",
+        read_b: "B uses pattern Y",
+        read_c: "C uses pattern Z",
+      },
+    });
+
+    const run = await runAgentWorkflow({
+      session,
+      control,
+      registry,
+      steps: readerSteps,
+      lifecycle,
+      delegateFn: delegateFn as never,
+    });
+
+    // Wave 1: all three readers spawned before the synthesizer.
+    expect(spawns.slice(0, 3).map((s) => s.agentName).sort()).toEqual([
+      "read_a",
+      "read_b",
+      "read_c",
+    ]);
+    expect(spawns[3]?.agentName).toBe("synth");
+
+    // Data flow: the synthesizer's prompt carries every reader output.
+    expect(spawns[3]?.taskPrompt).toContain("A uses pattern X");
+    expect(spawns[3]?.taskPrompt).toContain("B uses pattern Y");
+    expect(spawns[3]?.taskPrompt).toContain("C uses pattern Z");
+    expect(spawns[3]?.taskPrompt).toContain("### read_a");
+
+    // Results in declaration order, all completed.
+    expect(run.steps.map((s) => [s.id, s.outcome])).toEqual([
+      ["read_a", "completed"],
+      ["read_b", "completed"],
+      ["read_c", "completed"],
+      ["synth", "completed"],
+    ]);
+
+    // Per-step task pills registered on the lifecycle.
+    expect(lifecycle.get("thread-read_a")?.description).toBe(
+      "workflow:read_a",
+    );
+    expect(lifecycle.get("thread-synth")?.description).toBe("workflow:synth");
+  });
+
+  it("supports {{steps.<id>}} references and skips dependents of failures", async () => {
+    const spawns: SpawnRecord[] = [];
+    const delegateFn = fakeDelegate({
+      spawns,
+      finalMessages: { first: "FIRST OUTPUT" },
+      failing: new Set(["flaky"]),
+    });
+
+    const run = await runAgentWorkflow({
+      session,
+      control,
+      registry,
+      steps: [
+        { id: "first", message: "do the first thing" },
+        { id: "flaky", message: "explode" },
+        {
+          id: "uses_first",
+          after: ["first"],
+          message: "continue from: {{steps.first}}",
+        },
+        {
+          id: "uses_flaky",
+          after: ["flaky"],
+          message: "never runs: {{steps.flaky}}",
+        },
+      ],
+      lifecycle: new BackgroundTaskLifecycle(),
+      delegateFn: delegateFn as never,
+    });
+
+    const byId = new Map(run.steps.map((s) => [s.id, s]));
+    expect(byId.get("first")?.outcome).toBe("completed");
+    expect(byId.get("flaky")?.outcome).toBe("errored");
+    expect(byId.get("uses_first")?.outcome).toBe("completed");
+    expect(byId.get("uses_flaky")?.outcome).toBe("skipped");
+    expect(
+      spawns.find((s) => s.agentName === "uses_first")?.taskPrompt,
+    ).toContain("FIRST OUTPUT");
+    // The skipped step never spawned an agent.
+    expect(spawns.some((s) => s.agentName === "uses_flaky")).toBe(false);
+  });
+
+  it("reports rejected delegations as errored steps", async () => {
+    const delegateFn = vi.fn(async () => ({
+      kind: "rejected" as const,
+      reason: "no slots",
+    }));
+    const run = await runAgentWorkflow({
+      session,
+      control,
+      registry,
+      steps: [{ id: "only", message: "run" }],
+      lifecycle: new BackgroundTaskLifecycle(),
+      delegateFn: delegateFn as never,
+    });
+    expect(run.steps[0]).toMatchObject({
+      id: "only",
+      outcome: "errored",
+      error: "no slots",
+    });
+  });
+});


### PR DESCRIPTION
## TODO task 11 — deterministic multi-agent workflows

**Verified first (2026-07-07):** WorkflowTool ran only a single `command` string; the live agent primitives (spawn_agent/wait_agent/send_message) offer no deterministic fan-out/join/result-passing — orchestration was entirely model-driven.

### What this ships
- `runtime/src/agents/workflow-runner.ts` — step-graph execution over `delegate()`: concurrent waves of dependency-satisfied steps, `after` referencing step ids or group names, `{{steps.<id>}}`/`{{group.<name>}}` result templating, failure → transitive skip, cycle/dup/unknown-dep validation, per-step task pills.
- WorkflowTool: `steps` manifests run the agent workflow via `ensureAgentControl(session)`; legacy `command` manifests unchanged.

### Accept met
The 3-readers → 1-synthesizer scenario completes with correct data flow (synthesizer prompt carries all three reader outputs) and per-step pills — pinned in `tests/agents/workflow-runner.test.ts` (4 tests; new-module test = red on HEAD by construction).

### Gates
tsc 0 ✓, build ✓, full vitest = 68 known baseline failures, zero new.