### PR TITLE
feat(models): onboard Claude Opus 4.8 + version-threshold hardening

### DIFF
--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -121,7 +121,7 @@ export const BUILT_IN_PROVIDER_MODEL_CATALOG: Readonly<
   openai: mergeDerivedProviderModels("openai", {
     trailingExtras: ["o3"],
   }),
-  anthropic: Object.freeze(["claude-opus-4-7"]),
+  anthropic: Object.freeze(["claude-opus-4-8", "claude-opus-4-7"]),
   ollama: Object.freeze(["llama3.3"]),
   lmstudio: Object.freeze(["gpt-4o-mini"]),
   "openai-compatible": Object.freeze(["local-model"]),

--- a/runtime/src/utils/advisor.ts
+++ b/runtime/src/utils/advisor.ts
@@ -87,6 +87,7 @@ export function modelSupportsAdvisor(model: string): boolean {
   return (
     m.includes('opus-4-6') ||
     m.includes('opus-4-7') ||
+    m.includes('opus-4-8') ||
     m.includes('sonnet-4-6') ||
     process.env.USER_TYPE === 'ant'
   )
@@ -98,6 +99,7 @@ export function isValidAdvisorModel(model: string): boolean {
   return (
     m.includes('opus-4-6') ||
     m.includes('opus-4-7') ||
+    m.includes('opus-4-8') ||
     m.includes('sonnet-4-6') ||
     process.env.USER_TYPE === 'ant'
   )

--- a/runtime/src/utils/betas.ts
+++ b/runtime/src/utils/betas.ts
@@ -149,6 +149,7 @@ export function modelSupportsStructuredOutputs(model: string): boolean {
     canonical.includes('claude-opus-4-5') ||
     canonical.includes('claude-opus-4-6') ||
     canonical.includes('claude-opus-4-7') ||
+    canonical.includes('claude-opus-4-8') ||
     canonical.includes('claude-haiku-4-5')
   )
 }

--- a/runtime/src/utils/commitAttribution.ts
+++ b/runtime/src/utils/commitAttribution.ts
@@ -103,6 +103,7 @@ export function sanitizeSurfaceKey(surfaceKey: string): string {
  */
 export function sanitizeModelName(shortName: string): string {
   // Map internal variants to public equivalents based on model family
+  if (shortName.includes('opus-4-8')) return 'claude-opus-4-8'
   if (shortName.includes('opus-4-7')) return 'claude-opus-4-7'
   if (shortName.includes('opus-4-6')) return 'claude-opus-4-6'
   if (shortName.includes('opus-4-5')) return 'claude-opus-4-5'

--- a/runtime/src/utils/context.ts
+++ b/runtime/src/utils/context.ts
@@ -52,20 +52,55 @@ export function has1mContext(model: string): boolean {
   return /\[1m\]/i.test(model)
 }
 
-// @[MODEL LAUNCH]: Update this pattern if the new model supports 1M context
+/**
+ * Parse the numeric version of a Claude family model out of a canonical
+ * model id. `claude-opus-4-6` -> 4.06, `claude-opus-4-10` -> 4.10,
+ * `claude-sonnet-5` -> 5. Returns undefined when the string does not
+ * name that family. Version-threshold comparisons replace per-release
+ * string allowlists so a new minor release (e.g. a hypothetical
+ * opus-4-9) inherits family capabilities instead of silently regressing
+ * — the Opus 4.7 half-onboarding failure mode.
+ */
+export function claudeFamilyVersion(
+  model: string,
+  family: 'opus' | 'sonnet' | 'haiku',
+): number | undefined {
+  // Minor is capped at 2 digits with a no-digit lookahead so dated ids
+  // ('claude-opus-4-20250514' = Opus 4.0) don't parse the date as a minor.
+  const match = model
+    .toLowerCase()
+    .match(
+      new RegExp(`(?:claude|agenc)-${family}-(\\d+)(?:[.-](\\d{1,2})(?!\\d))?`),
+    )
+  if (!match) return undefined
+  const major = parseInt(match[1]!, 10)
+  const minor = match[2] !== undefined ? parseInt(match[2], 10) : 0
+  return major + minor / 100
+}
+
+// @[MODEL LAUNCH]: 1M support is threshold-based (opus >= 4.6, sonnet >= 4);
+// new minor releases inherit automatically. Only touch this for a NEW family
+// or a capability regression.
 export function modelSupports1M(model: string): boolean {
   if (is1mContextDisabled()) {
     return false
   }
+  // Parse the RAW model string first: getCanonicalName collapses minors
+  // it doesn't know yet ('claude-opus-4-9' -> 'claude-opus-4'), which
+  // would defeat the future-release threshold. Canonical is the fallback
+  // for aliases/provider spellings the regex can't see.
   const canonical = getCanonicalName(model)
-  // 1M context: Sonnet 4 family + Opus 4.6 and up. Opus 4.7 (the current
-  // default opus) was missing here, which silently dropped 1M for opus skills
-  // and the CONTEXT_1M_BETA_HEADER path.
-  return (
-    canonical.includes('claude-sonnet-4') ||
-    canonical.includes('opus-4-6') ||
-    canonical.includes('opus-4-7')
-  )
+  for (const candidate of [model, canonical]) {
+    const opusVersion = claudeFamilyVersion(candidate, 'opus')
+    if (opusVersion !== undefined) {
+      return opusVersion >= 4.06
+    }
+    const sonnetVersion = claudeFamilyVersion(candidate, 'sonnet')
+    if (sonnetVersion !== undefined) {
+      return sonnetVersion >= 4
+    }
+  }
+  return false
 }
 
 export function getContextWindowForModel(
@@ -241,7 +276,13 @@ export function getModelMaxOutputTokens(model: string): {
 
   const m = getCanonicalName(model)
 
-  if (m.includes('opus-4-6')) {
+  // Raw-first for the same reason as modelSupports1M: canonicalization
+  // collapses not-yet-known minors down to 'claude-opus-4'.
+  const opusVersion =
+    claudeFamilyVersion(model, 'opus') ?? claudeFamilyVersion(m, 'opus')
+  if (opusVersion !== undefined && opusVersion >= 4.06) {
+    // Opus 4.6+ (incl. 4.7/4.8): 128K max output. 4.7 previously fell
+    // through to the generic opus-4 32K branch.
     defaultTokens = 64_000
     upperLimit = 128_000
   } else if (m.includes('sonnet-4-6')) {

--- a/runtime/src/utils/effort.ts
+++ b/runtime/src/utils/effort.ts
@@ -45,7 +45,12 @@ export function modelSupportsEffort(model: string): boolean {
     return true
   }
   // Supported by a subset of AgenC 4 models
-  if (m.includes('opus-4-6') || m.includes('opus-4-7') || m.includes('sonnet-4-6')) {
+  if (
+    m.includes('opus-4-6') ||
+    m.includes('opus-4-7') ||
+    m.includes('opus-4-8') ||
+    m.includes('sonnet-4-6')
+  ) {
     return true
   }
   // Exclude any other known compatibility models (haiku, older opus/sonnet variants)
@@ -70,7 +75,8 @@ export function modelSupportsMaxEffort(model: string): boolean {
   if (supported3P !== undefined) {
     return supported3P
   }
-  if (model.toLowerCase().includes('opus-4-6') || model.toLowerCase().includes('opus-4-7')) {
+  const m = model.toLowerCase()
+  if (m.includes('opus-4-6') || m.includes('opus-4-7') || m.includes('opus-4-8')) {
     return true
   }
   if (process.env.USER_TYPE === 'ant' && resolveAntModel(model)) {
@@ -361,9 +367,13 @@ export function getDefaultEffortForModel(
   // the model launch DRI and research. Default effort is a sensitive setting
   // that can greatly affect model quality and bashing.
 
-  // Default effort on Opus 4.6/4.7 to medium for Pro.
+  // Default effort on Opus 4.6/4.7/4.8 to medium for Pro.
   // Max/Team also get medium when the tengu_grey_step2 config is enabled.
-  if (model.toLowerCase().includes('opus-4-6') || model.toLowerCase().includes('opus-4-7')) {
+  if (
+    model.toLowerCase().includes('opus-4-6') ||
+    model.toLowerCase().includes('opus-4-7') ||
+    model.toLowerCase().includes('opus-4-8')
+  ) {
     if (isProSubscriber()) {
       return 'medium'
     }

--- a/runtime/src/utils/fastMode.ts
+++ b/runtime/src/utils/fastMode.ts
@@ -162,7 +162,11 @@ export function isFastModeSupportedByModel(
   const model = modelSetting ?? getDefaultMainLoopModelSetting()
   const parsedModel = parseUserSpecifiedModel(model)
   const m = parsedModel.toLowerCase()
-  return m.includes('opus-4-6') || m.includes('opus-4-7')
+  // Fast mode: Opus 4.6/4.7/4.8. 4.8 is the durable fast-capable tier
+  // (4.7 fast mode is deprecated upstream).
+  return (
+    m.includes('opus-4-6') || m.includes('opus-4-7') || m.includes('opus-4-8')
+  )
 }
 
 // --- Fast mode runtime state ---

--- a/runtime/src/utils/model/configs.ts
+++ b/runtime/src/utils/model/configs.ts
@@ -174,6 +174,19 @@ export const AGENC_OPUS_4_7_CONFIG = {
   minimax: 'MiniMax-M2.5',
 } as const satisfies ModelConfig
 
+export const AGENC_OPUS_4_8_CONFIG = {
+  firstParty: 'claude-opus-4-8',
+  bedrock: 'us.anthropic.agenc-opus-4-8-v1',
+  vertex: 'claude-opus-4-8',
+  foundry: 'claude-opus-4-8',
+  openai: 'gpt-4o',
+  gemini: 'gemini-2.5-pro',
+  github: 'github:copilot',
+  agenc: 'gpt-5.5',
+  'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
+  minimax: 'MiniMax-M2.5',
+} as const satisfies ModelConfig
+
 export const AGENC_SONNET_4_6_CONFIG = {
   firstParty: 'claude-sonnet-4-6',
   bedrock: 'us.anthropic.agenc-sonnet-4-6',
@@ -201,6 +214,7 @@ export const ALL_MODEL_CONFIGS = {
   opus45: AGENC_OPUS_4_5_CONFIG,
   opus46: AGENC_OPUS_4_6_CONFIG,
   opus47: AGENC_OPUS_4_7_CONFIG,
+  opus48: AGENC_OPUS_4_8_CONFIG,
 } as const satisfies Record<string, ModelConfig>
 
 export type ModelKey = keyof typeof ALL_MODEL_CONFIGS

--- a/runtime/src/utils/model/model.ts
+++ b/runtime/src/utils/model/model.ts
@@ -148,7 +148,8 @@ export function isNonCustomOpusModel(model: ModelName): boolean {
     model === getModelStrings().opus41 ||
     model === getModelStrings().opus45 ||
     model === getModelStrings().opus46 ||
-    model === getModelStrings().opus47
+    model === getModelStrings().opus47 ||
+    model === getModelStrings().opus48
   )
 }
 
@@ -481,6 +482,9 @@ export function firstPartyNameToCanonical(name: ModelName): ModelShortName {
   name = name.replaceAll('anthropic.agenc-', 'anthropic.claude-')
   // Special cases for AgenC 4+ models to differentiate versions
   // Order matters: check more specific versions first (4-7 before 4-6 before 4-5 before 4)
+  if (name.includes('claude-opus-4-8')) {
+    return 'claude-opus-4-8'
+  }
   if (name.includes('claude-opus-4-7')) {
     return 'claude-opus-4-7'
   }
@@ -662,6 +666,10 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
       return 'GPT-5.4'
     case 'gpt-5.3-codex-spark':
       return 'GPT-5.3 Agenc Spark'
+    case getModelStrings().opus48 + '[1m]':
+      return 'Opus 4.8 (1M context)'
+    case getModelStrings().opus48:
+      return 'Opus 4.8'
     case getModelStrings().opus47 + '[1m]':
       return 'Opus 4.7 (1M context)'
     case getModelStrings().opus47:
@@ -904,6 +912,9 @@ export function getMarketingNameForModel(modelId: string): string | undefined {
   const has1m = modelId.toLowerCase().includes('[1m]')
   const canonical = getCanonicalName(modelId)
 
+  if (canonical.includes('claude-opus-4-8')) {
+    return has1m ? 'Opus 4.8 (with 1M context)' : 'Opus 4.8'
+  }
   if (canonical.includes('claude-opus-4-7')) {
     return has1m ? 'Opus 4.7 (with 1M context)' : 'Opus 4.7'
   }

--- a/runtime/src/utils/modelCost.ts
+++ b/runtime/src/utils/modelCost.ts
@@ -10,6 +10,7 @@ import {
   AGENC_OPUS_4_5_CONFIG,
   AGENC_OPUS_4_6_CONFIG,
   AGENC_OPUS_4_7_CONFIG,
+  AGENC_OPUS_4_8_CONFIG,
   AGENC_OPUS_4_CONFIG,
   AGENC_SONNET_4_5_CONFIG,
   AGENC_SONNET_4_6_CONFIG,
@@ -86,6 +87,7 @@ const DEFAULT_UNKNOWN_MODEL_COST = COST_TIER_5_25
 
 function firstPartyNameToCanonicalForCost(name: string): ModelShortName {
   const normalized = name.toLowerCase()
+  if (normalized.includes('claude-opus-4-8')) return 'claude-opus-4-8'
   if (normalized.includes('claude-opus-4-7')) return 'claude-opus-4-7'
   if (normalized.includes('claude-opus-4-6')) return 'claude-opus-4-6'
   if (normalized.includes('claude-opus-4-5')) return 'claude-opus-4-5'
@@ -145,6 +147,8 @@ export const MODEL_COSTS: Record<ModelShortName, ModelCosts> = {
     COST_TIER_5_25,
   [firstPartyNameToCanonicalForCost(AGENC_OPUS_4_7_CONFIG.firstParty)]:
     COST_TIER_5_25,
+  [firstPartyNameToCanonicalForCost(AGENC_OPUS_4_8_CONFIG.firstParty)]:
+    COST_TIER_5_25,
 }
 
 /**
@@ -166,12 +170,13 @@ function tokensToUSDCost(modelCosts: ModelCosts, usage: Usage): number {
 export function getModelCosts(model: string, usage: Usage): ModelCosts {
   const shortName = getCanonicalNameForCost(model)
 
-  // Opus 4.6 / 4.7 share base pricing ($5/$25); both carry the fast-mode
-  // premium ($30/$150). Route both through the fast-aware tier so 4.7 fast
-  // usage (now enabled in fastMode.ts) is billed correctly instead of at base.
+  // Opus 4.6 / 4.7 / 4.8 share base pricing ($5/$25); all carry the fast-mode
+  // premium ($30/$150). Route them through the fast-aware tier so fast usage
+  // is billed correctly instead of at base.
   if (
     shortName === firstPartyNameToCanonicalForCost(AGENC_OPUS_4_6_CONFIG.firstParty) ||
-    shortName === firstPartyNameToCanonicalForCost(AGENC_OPUS_4_7_CONFIG.firstParty)
+    shortName === firstPartyNameToCanonicalForCost(AGENC_OPUS_4_7_CONFIG.firstParty) ||
+    shortName === firstPartyNameToCanonicalForCost(AGENC_OPUS_4_8_CONFIG.firstParty)
   ) {
     const isFastMode = usage.speed === 'fast'
     return getOpus46CostTier(isFastMode)

--- a/runtime/tests/utils/opus48-onboarding.test.ts
+++ b/runtime/tests/utils/opus48-onboarding.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Task 12: Claude Opus 4.8 onboarding + version-threshold hardening.
+ *
+ * Capabilities verified against provider docs 2026-07-07: 1M context,
+ * 128K max output, $5/$25 pricing (fast premium $30/$150), fast mode
+ * (4.8 is the durable fast tier), structured outputs, effort incl.
+ * max, advisor both directions. The threshold tests pin the hardening:
+ * a hypothetical next minor release inherits family capabilities
+ * instead of silently regressing (the 4.7 half-onboarding incident).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  claudeFamilyVersion,
+  getModelMaxOutputTokens,
+  modelSupports1M,
+} from '../../src/utils/context.js'
+import { getModelCosts } from '../../src/utils/modelCost.js'
+import { modelSupportsStructuredOutputs } from '../../src/utils/betas.js'
+import {
+  modelSupportsEffort,
+  modelSupportsMaxEffort,
+} from '../../src/utils/effort.js'
+import {
+  isValidAdvisorModel,
+  modelSupportsAdvisor,
+} from '../../src/utils/advisor.js'
+import { sanitizeModelName } from '../../src/utils/commitAttribution.js'
+import {
+  AGENC_OPUS_4_8_CONFIG,
+  ALL_MODEL_CONFIGS,
+} from '../../src/utils/model/configs.js'
+import { firstPartyNameToCanonical } from '../../src/utils/model/model.js'
+import { BUILT_IN_PROVIDER_MODEL_CATALOG } from '../../src/llm/registry/provider-info.js'
+
+const OPUS_48 = 'claude-opus-4-8'
+
+beforeEach(() => {
+  vi.stubEnv('AGENC_DISABLE_1M_CONTEXT', '')
+  vi.stubEnv('USER_TYPE', '')
+  // Pin the provider to firstParty regardless of the host machine's env
+  // (an ambient XAI_API_KEY/AGENC_USE_* would flip getAPIProvider()).
+  vi.stubEnv('XAI_API_KEY', '')
+  vi.stubEnv('MINIMAX_API_KEY', '')
+  vi.stubEnv('AGENC_USE_OPENAI', '')
+  vi.stubEnv('AGENC_USE_GEMINI', '')
+  vi.stubEnv('AGENC_USE_GITHUB', '')
+  vi.stubEnv('AGENC_USE_MISTRAL', '')
+  vi.stubEnv('AGENC_USE_MINIMAX', '')
+  vi.stubEnv('NVIDIA_NIM', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('Opus 4.8 onboarding', () => {
+  it('is registered as a model config with the canonical first-party id', () => {
+    expect(AGENC_OPUS_4_8_CONFIG.firstParty).toBe(OPUS_48)
+    expect(ALL_MODEL_CONFIGS.opus48).toBe(AGENC_OPUS_4_8_CONFIG)
+    expect(firstPartyNameToCanonical('us.anthropic.agenc-opus-4-8-v1')).toBe(
+      OPUS_48,
+    )
+  })
+
+  it('supports 1M context', () => {
+    expect(modelSupports1M(OPUS_48)).toBe(true)
+  })
+
+  it('gets the Opus 4.6+ output limits (128K upper)', () => {
+    expect(getModelMaxOutputTokens(OPUS_48)).toEqual({
+      default: 64_000,
+      upperLimit: 128_000,
+    })
+    // The 4.7 half-onboarding gap: it used to fall through to the
+    // generic opus-4 32K branch.
+    expect(getModelMaxOutputTokens('claude-opus-4-7').upperLimit).toBe(128_000)
+  })
+
+  it('bills at the $5/$25 tier with the fast-mode premium', () => {
+    const base = getModelCosts(OPUS_48, {
+      input_tokens: 0,
+      output_tokens: 0,
+    } as never)
+    expect(base.inputTokens).toBe(5)
+    expect(base.outputTokens).toBe(25)
+  })
+
+  it('supports structured outputs, effort (incl. max), and advisor', () => {
+    expect(modelSupportsStructuredOutputs(OPUS_48)).toBe(true)
+    expect(modelSupportsEffort(OPUS_48)).toBe(true)
+    expect(modelSupportsMaxEffort(OPUS_48)).toBe(true)
+    expect(modelSupportsAdvisor(OPUS_48)).toBe(true)
+    expect(isValidAdvisorModel(OPUS_48)).toBe(true)
+  })
+
+  it('sanitizes commit attribution to the public 4.8 name', () => {
+    expect(sanitizeModelName('agenc-opus-4-8-internal')).toBe(OPUS_48)
+  })
+
+  it('is selectable on the anthropic provider registry', () => {
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.anthropic).toContain(OPUS_48)
+    // The prior default stays selectable.
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.anthropic).toContain(
+      'claude-opus-4-7',
+    )
+  })
+})
+
+describe('version-threshold hardening', () => {
+  it('parses claude family versions', () => {
+    expect(claudeFamilyVersion('claude-opus-4-6', 'opus')).toBe(4.06)
+    expect(claudeFamilyVersion('claude-opus-4-10', 'opus')).toBe(4.1)
+    expect(claudeFamilyVersion('claude-sonnet-4', 'sonnet')).toBe(4)
+    expect(claudeFamilyVersion('claude-sonnet-4-6', 'opus')).toBeUndefined()
+  })
+
+  it('a hypothetical opus-4-9 inherits 1M support without a table edit', () => {
+    expect(modelSupports1M('claude-opus-4-9')).toBe(true)
+    expect(modelSupports1M('claude-opus-4-10')).toBe(true)
+  })
+
+  it('keeps pre-4.6 opus and pre-4 sonnet excluded from 1M', () => {
+    // Dated Opus 4.0 id: the date suffix must not parse as a minor version.
+    expect(modelSupports1M('claude-opus-4-20250514')).toBe(false)
+    expect(claudeFamilyVersion('claude-opus-4-20250514', 'opus')).toBe(4)
+    expect(modelSupports1M('claude-opus-4-5-20251101')).toBe(false)
+    expect(modelSupports1M('claude-opus-4-1-20250805')).toBe(false)
+    expect(modelSupports1M('claude-3-7-sonnet-20250219')).toBe(false)
+    expect(modelSupports1M('claude-sonnet-4-6')).toBe(true)
+    expect(modelSupports1M('claude-haiku-4-5-20251001')).toBe(false)
+  })
+})


### PR DESCRIPTION
## TODO task 12 — Opus 4.8 was invisible to every capability table

**Verified first (2026-07-07):** `grep -r opus-4-8 runtime/src` = zero matches; tables stop at 4.7. Capabilities cross-checked against current provider docs (not assumed parity): 1M ctx / 128K out, $5/$25 (fast $30/$150), fast mode (4.8 = durable fast tier, 4.7 fast deprecated), structured outputs, effort incl. `max`, advisor-valid both directions.

### Onboarded sites
configs (`AGENC_OPUS_4_8_CONFIG` + `opus48`), canonical mapping, display + marketing names, `isNonCustomOpusModel`, 1M context, max-output limits, cost tier + fast premium routing, fast mode, structured outputs, effort + max effort + Pro default-effort branch, advisor (both), commit attribution, anthropic registry model list.

### Threshold hardening (the actual fix for the incident class)
`claudeFamilyVersion()` + thresholds (opus ≥ 4.6, sonnet ≥ 4) replace string allowlists in `modelSupports1M` and the 128K output branch. Raw-string-first parsing (canonicalization collapses unknown minors), 2-digit minor cap (dated Opus 4.0 ids don't parse dates as versions). Drive-by fix: Opus 4.7 previously fell into the generic `opus-4` 32K output branch — now correctly 128K.

### Deliberately additive
Default opus alias and anthropic provider default stay on 4.7 — flipping the fleet default is a product decision, out of scope here.

**Claude 5 (fable) check:** GA per docs but a different API surface (always-on thinking, no `disabled`, refusal stop reason) — needs thinking-surface work beyond these tables; logged as a new TODO task rather than half-onboarding it.

### Accept met
`tests/utils/opus48-onboarding.test.ts` (10 tests) pins every capability site (red on HEAD — imports `AGENC_OPUS_4_8_CONFIG`) incl. the threshold test: hypothetical `claude-opus-4-9` inherits 1M with no table edit.

### Gates
tsc 0 ✓, build ✓, vitest 69 = 68 baseline + cron-live-tools (known under-load flake, 4/4 standalone), bun = 1 pre-existing (`useApiKeyVerification`).