### PR TITLE
feat(mcp-server): expose prompts (skills) and resources (memory) to MCP clients

### DIFF
--- a/runtime/src/mcp-server/framework.ts
+++ b/runtime/src/mcp-server/framework.ts
@@ -27,6 +27,10 @@ import {
   type McpOutgoingMessage,
   type McpRequestId,
   type McpResponseMessage,
+  type McpListPromptsResult,
+  type McpListResourcesResult,
+  type McpPromptProvider,
+  type McpResourceProvider,
   type McpServerCapabilities,
   type McpServerInfo,
   type McpToolCallParams,
@@ -40,6 +44,8 @@ export interface McpServerFrameworkOptions {
   readonly instructions?: string | null;
   readonly defaultProtocolVersion?: string;
   readonly toolProvider?: McpToolProvider;
+  readonly promptProvider?: McpPromptProvider;
+  readonly resourceProvider?: McpResourceProvider;
 }
 
 export interface McpServerFrameworkSnapshot {
@@ -232,6 +238,8 @@ export class McpServerFramework {
   private readonly instructions: string | null;
   private readonly defaultProtocolVersion: string;
   private readonly toolProvider: McpToolProvider | null;
+  private readonly promptProvider: McpPromptProvider | null;
+  private readonly resourceProvider: McpResourceProvider | null;
   private initialized = false;
   private initializedNotificationReceived = false;
   private clientInfo: McpInitializeParams["clientInfo"] | null = null;
@@ -245,8 +253,16 @@ export class McpServerFramework {
       title: options.serverInfo?.title ?? "AgenC",
       version: options.serverInfo?.version ?? "0.0.0",
     };
+    this.promptProvider = options.promptProvider ?? null;
+    this.resourceProvider = options.resourceProvider ?? null;
     this.capabilities = options.capabilities ?? {
       tools: { listChanged: true },
+      ...(this.promptProvider !== null
+        ? { prompts: { listChanged: false } }
+        : {}),
+      ...(this.resourceProvider !== null
+        ? { resources: { listChanged: false, subscribe: false } }
+        : {}),
     };
     this.instructions = options.instructions ?? null;
     this.defaultProtocolVersion =
@@ -342,7 +358,14 @@ export class McpServerFramework {
   private async handleRequestAsync(
     request: McpJsonRpcRequest,
   ): Promise<McpOutgoingMessage> {
-    if (request.method !== "tools/call") {
+    const asyncMethods = [
+      "tools/call",
+      "prompts/list",
+      "prompts/get",
+      "resources/list",
+      "resources/read",
+    ];
+    if (!asyncMethods.includes(request.method)) {
       return this.handleRequest(request);
     }
     if (!this.initialized) {
@@ -354,6 +377,16 @@ export class McpServerFramework {
           { method: request.method },
         ),
       );
+    }
+    switch (request.method) {
+      case "prompts/list":
+        return await this.handleListPrompts(request);
+      case "prompts/get":
+        return await this.handleGetPrompt(request);
+      case "resources/list":
+        return await this.handleListResources(request);
+      case "resources/read":
+        return await this.handleReadResource(request);
     }
     const parsedParams = parseToolCallParams(request.params);
     if (!parsedParams.ok) {
@@ -442,12 +475,33 @@ export class McpServerFramework {
       case "tools/list":
         return response(request.id, this.handleListTools());
       case "resources/list":
-      case "resources/templates/list":
       case "resources/read":
-      case "resources/subscribe":
-      case "resources/unsubscribe":
       case "prompts/list":
       case "prompts/get":
+        // Served by the async dispatcher when a provider is configured.
+        if (
+          (request.method.startsWith("prompts/") &&
+            this.promptProvider !== null) ||
+          (request.method.startsWith("resources/") &&
+            this.resourceProvider !== null)
+        ) {
+          return errorResponse(
+            request.id,
+            errorObject(
+              MCP_ERROR_INVALID_REQUEST,
+              `${request.method} requires the async MCP dispatcher`,
+            ),
+          );
+        }
+        return errorResponse(
+          request.id,
+          errorObject(MCP_ERROR_METHOD_NOT_FOUND, `method not found: ${request.method}`, {
+            method: request.method,
+          }),
+        );
+      case "resources/templates/list":
+      case "resources/subscribe":
+      case "resources/unsubscribe":
       case "logging/setLevel":
       case "completion/complete":
         return errorResponse(
@@ -509,6 +563,96 @@ export class McpServerFramework {
 
   private handleListTools(): McpListToolsResult {
     return { tools: this.toolProvider?.listTools() ?? [], nextCursor: null };
+  }
+
+  private methodNotFound(request: McpJsonRpcRequest): McpOutgoingMessage {
+    return errorResponse(
+      request.id,
+      errorObject(
+        MCP_ERROR_METHOD_NOT_FOUND,
+        `method not found: ${request.method}`,
+        { method: request.method },
+      ),
+    );
+  }
+
+  private async handleListPrompts(
+    request: McpJsonRpcRequest,
+  ): Promise<McpOutgoingMessage> {
+    if (this.promptProvider === null) {
+      return this.methodNotFound(request);
+    }
+    const result: McpListPromptsResult = {
+      prompts: await this.promptProvider.listPrompts(),
+      nextCursor: null,
+    };
+    return response(request.id, result);
+  }
+
+  private async handleGetPrompt(
+    request: McpJsonRpcRequest,
+  ): Promise<McpOutgoingMessage> {
+    if (this.promptProvider === null) {
+      return this.methodNotFound(request);
+    }
+    const params = asRecord(request.params);
+    const name = params?.name;
+    if (typeof name !== "string" || name.length === 0) {
+      return errorResponse(
+        request.id,
+        errorObject(MCP_ERROR_INVALID_PARAMS, "prompts/get name must be a non-empty string"),
+      );
+    }
+    const rawArgs = asRecord(params?.arguments);
+    const args: Record<string, string> = {};
+    for (const [key, value] of Object.entries(rawArgs ?? {})) {
+      if (typeof value === "string") args[key] = value;
+    }
+    const prompt = await this.promptProvider.getPrompt(name, args);
+    if (prompt === null) {
+      return errorResponse(
+        request.id,
+        errorObject(MCP_ERROR_INVALID_PARAMS, `unknown prompt: ${name}`),
+      );
+    }
+    return response(request.id, prompt);
+  }
+
+  private async handleListResources(
+    request: McpJsonRpcRequest,
+  ): Promise<McpOutgoingMessage> {
+    if (this.resourceProvider === null) {
+      return this.methodNotFound(request);
+    }
+    const result: McpListResourcesResult = {
+      resources: await this.resourceProvider.listResources(),
+      nextCursor: null,
+    };
+    return response(request.id, result);
+  }
+
+  private async handleReadResource(
+    request: McpJsonRpcRequest,
+  ): Promise<McpOutgoingMessage> {
+    if (this.resourceProvider === null) {
+      return this.methodNotFound(request);
+    }
+    const params = asRecord(request.params);
+    const uri = params?.uri;
+    if (typeof uri !== "string" || uri.length === 0) {
+      return errorResponse(
+        request.id,
+        errorObject(MCP_ERROR_INVALID_PARAMS, "resources/read uri must be a non-empty string"),
+      );
+    }
+    const contents = await this.resourceProvider.readResource(uri);
+    if (contents === null) {
+      return errorResponse(
+        request.id,
+        errorObject(MCP_ERROR_INVALID_PARAMS, `unknown resource: ${uri}`),
+      );
+    }
+    return response(request.id, contents);
   }
 
   private handleNotification(notification: McpJsonRpcNotification): void {

--- a/runtime/src/mcp-server/types.ts
+++ b/runtime/src/mcp-server/types.ts
@@ -61,8 +61,19 @@ export interface McpToolsCapability {
   readonly listChanged?: boolean;
 }
 
+export interface McpPromptsCapability {
+  readonly listChanged?: boolean;
+}
+
+export interface McpResourcesCapability {
+  readonly listChanged?: boolean;
+  readonly subscribe?: boolean;
+}
+
 export interface McpServerCapabilities {
   readonly tools?: McpToolsCapability;
+  readonly prompts?: McpPromptsCapability;
+  readonly resources?: McpResourcesCapability;
 }
 
 export interface McpInitializeParams {
@@ -117,6 +128,76 @@ export interface McpToolProvider {
     params: McpToolCallParams,
     context: McpToolCallContext,
   ): Promise<McpCallToolResult>;
+}
+
+// --- Prompts (MCP `prompts/*`) ---
+
+export interface McpPromptArgumentDefinition {
+  readonly name: string;
+  readonly description?: string;
+  readonly required?: boolean;
+}
+
+export interface McpPromptDefinition {
+  readonly name: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly arguments?: readonly McpPromptArgumentDefinition[];
+}
+
+export interface McpListPromptsResult {
+  readonly prompts: readonly McpPromptDefinition[];
+  readonly nextCursor?: string | null;
+}
+
+export interface McpPromptMessage {
+  readonly role: "user" | "assistant";
+  readonly content: McpToolTextContent;
+}
+
+export interface McpGetPromptResult {
+  readonly description?: string;
+  readonly messages: readonly McpPromptMessage[];
+}
+
+export interface McpPromptProvider {
+  listPrompts(): Promise<readonly McpPromptDefinition[]>;
+  /** Returns null when no prompt with that name exists. */
+  getPrompt(
+    name: string,
+    args?: Readonly<Record<string, string>>,
+  ): Promise<McpGetPromptResult | null>;
+}
+
+// --- Resources (MCP `resources/*`) ---
+
+export interface McpResourceDefinition {
+  readonly uri: string;
+  readonly name: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly mimeType?: string;
+}
+
+export interface McpListResourcesResult {
+  readonly resources: readonly McpResourceDefinition[];
+  readonly nextCursor?: string | null;
+}
+
+export interface McpResourceContents {
+  readonly uri: string;
+  readonly mimeType?: string;
+  readonly text: string;
+}
+
+export interface McpReadResourceResult {
+  readonly contents: readonly McpResourceContents[];
+}
+
+export interface McpResourceProvider {
+  listResources(): Promise<readonly McpResourceDefinition[]>;
+  /** Returns null when the uri is unknown (never reads arbitrary paths). */
+  readResource(uri: string): Promise<McpReadResourceResult | null>;
 }
 
 export const MCP_JSON_RPC_VERSION = "2.0" as const;

--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -1,0 +1,260 @@
+/**
+ * MCP prompt + resource providers for `agenc mcp serve`.
+ *
+ * The runtime already loads skills (natural MCP prompts) and memory /
+ * instruction files (natural MCP resources), but the MCP server exposed
+ * only tools — other MCP hosts saw none of it. These providers surface
+ * that content read-only:
+ *
+ *   - Prompts: skills discovered from the standard skill roots
+ *     (`<root>/<name>/SKILL.md` and legacy `<root>/<name>.md`). Skills
+ *     marked `disable-model-invocation: true` are NOT exposed — an MCP
+ *     client's model can trigger prompts/get, so the flag is honored
+ *     the same way it gates in-process model invocation.
+ *   - Resources: memory files (via the same scanner the runtime uses)
+ *     plus explicitly-passed instruction files (AGENC.md tiers).
+ *     Path-bounded by construction: `readResource` only serves URIs
+ *     minted by its own listing — it never resolves client-supplied
+ *     paths. Contents pass through the memory secret redactor.
+ *
+ * @module
+ */
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import {
+  detectSessionFileType,
+  redactSecrets,
+  scanMemoryFiles,
+} from "../../memory/index.js";
+import {
+  parseBooleanFrontmatter,
+  parseFrontmatter,
+} from "../../utils/frontmatterParser.js";
+import type {
+  McpGetPromptResult,
+  McpPromptDefinition,
+  McpPromptProvider,
+  McpReadResourceResult,
+  McpResourceDefinition,
+  McpResourceProvider,
+} from "../../mcp-server/types.js";
+
+export interface SkillPromptProviderOptions {
+  /** Directories whose children are skills (`<dir>/<name>/SKILL.md` or `<dir>/<name>.md`). */
+  readonly skillRoots: readonly string[];
+}
+
+interface DiscoveredSkill {
+  readonly name: string;
+  readonly filePath: string;
+  readonly description: string;
+  readonly argumentHint: string | undefined;
+}
+
+async function discoverSkills(
+  roots: readonly string[],
+): Promise<Map<string, DiscoveredSkill>> {
+  const skills = new Map<string, DiscoveredSkill>();
+  for (const root of roots) {
+    let entries;
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const candidate = entry.isDirectory()
+        ? { name: entry.name, filePath: join(root, entry.name, "SKILL.md") }
+        : entry.name.endsWith(".md")
+          ? {
+              name: entry.name.slice(0, -".md".length),
+              filePath: join(root, entry.name),
+            }
+          : null;
+      if (candidate === null || skills.has(candidate.name)) continue;
+      let raw: string;
+      try {
+        raw = await readFile(candidate.filePath, "utf8");
+      } catch {
+        continue;
+      }
+      const { frontmatter } = parseFrontmatter(raw, candidate.filePath);
+      if (parseBooleanFrontmatter(frontmatter["disable-model-invocation"])) {
+        continue;
+      }
+      skills.set(candidate.name, {
+        name: candidate.name,
+        filePath: candidate.filePath,
+        description:
+          typeof frontmatter.description === "string"
+            ? frontmatter.description
+            : `Skill: ${candidate.name}`,
+        argumentHint:
+          frontmatter["argument-hint"] != null
+            ? String(frontmatter["argument-hint"])
+            : undefined,
+      });
+    }
+  }
+  return skills;
+}
+
+export function createSkillPromptProvider(
+  options: SkillPromptProviderOptions,
+): McpPromptProvider {
+  return {
+    async listPrompts(): Promise<readonly McpPromptDefinition[]> {
+      const skills = await discoverSkills(options.skillRoots);
+      return [...skills.values()].map((skill) => ({
+        name: skill.name,
+        description: skill.description,
+        arguments: [
+          {
+            name: "arguments",
+            description:
+              skill.argumentHint ?? "Optional arguments for the skill",
+            required: false,
+          },
+        ],
+      }));
+    },
+    async getPrompt(
+      name: string,
+      args?: Readonly<Record<string, string>>,
+    ): Promise<McpGetPromptResult | null> {
+      const skills = await discoverSkills(options.skillRoots);
+      const skill = skills.get(name);
+      if (skill === undefined) return null;
+      let raw: string;
+      try {
+        raw = await readFile(skill.filePath, "utf8");
+      } catch {
+        return null;
+      }
+      const { content } = parseFrontmatter(raw, skill.filePath);
+      const argumentText = args?.arguments ?? "";
+      const text = content.includes("$ARGUMENTS")
+        ? content.replaceAll("$ARGUMENTS", argumentText)
+        : argumentText.length > 0
+          ? `${content}\n\nARGUMENTS: ${argumentText}`
+          : content;
+      return {
+        description: skill.description,
+        messages: [{ role: "user", content: { type: "text", text } }],
+      };
+    },
+  };
+}
+
+export interface MemoryResourceProviderOptions {
+  /** Memory directories scanned with the runtime's memory scanner. */
+  readonly memoryDirs: readonly string[];
+  /** Explicit instruction files (AGENC.md tiers). Listed only if they exist. */
+  readonly instructionFiles?: readonly string[];
+}
+
+const MEMORY_URI_SCHEME = "agenc-memory://";
+const INSTRUCTIONS_URI_SCHEME = "agenc-instructions://";
+
+interface ListedResource {
+  readonly definition: McpResourceDefinition;
+  readonly filePath: string;
+}
+
+async function listMemoryResources(
+  options: MemoryResourceProviderOptions,
+): Promise<Map<string, ListedResource>> {
+  const resources = new Map<string, ListedResource>();
+  for (const [dirIndex, dir] of options.memoryDirs.entries()) {
+    const headers = await scanMemoryFiles(dir);
+    for (const header of headers) {
+      // Session memory/transcripts are excluded outright — same boundary
+      // the permission layer enforces for in-process reads.
+      if (detectSessionFileType(header.filePath) !== null) continue;
+      const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${header.filename}`;
+      resources.set(uri, {
+        definition: {
+          uri,
+          name: header.filename,
+          ...(header.description !== null
+            ? { description: header.description }
+            : {}),
+          mimeType: "text/markdown",
+        },
+        filePath: header.filePath,
+      });
+    }
+    const entrypoint = join(dir, "MEMORY.md");
+    try {
+      if ((await stat(entrypoint)).isFile()) {
+        const uri = `${MEMORY_URI_SCHEME}${dirIndex}/MEMORY.md`;
+        resources.set(uri, {
+          definition: {
+            uri,
+            name: "MEMORY.md",
+            description: "Memory index",
+            mimeType: "text/markdown",
+          },
+          filePath: entrypoint,
+        });
+      }
+    } catch {
+      /* no entrypoint */
+    }
+  }
+  for (const [fileIndex, filePath] of (
+    options.instructionFiles ?? []
+  ).entries()) {
+    try {
+      if (!(await stat(filePath)).isFile()) continue;
+    } catch {
+      continue;
+    }
+    if (detectSessionFileType(filePath) !== null) continue;
+    const uri = `${INSTRUCTIONS_URI_SCHEME}${fileIndex}/${basename(filePath)}`;
+    resources.set(uri, {
+      definition: {
+        uri,
+        name: basename(filePath),
+        description: `Project instructions (${filePath})`,
+        mimeType: "text/markdown",
+      },
+      filePath,
+    });
+  }
+  return resources;
+}
+
+export function createMemoryResourceProvider(
+  options: MemoryResourceProviderOptions,
+): McpResourceProvider {
+  return {
+    async listResources(): Promise<readonly McpResourceDefinition[]> {
+      const resources = await listMemoryResources(options);
+      return [...resources.values()].map((resource) => resource.definition);
+    },
+    async readResource(uri: string): Promise<McpReadResourceResult | null> {
+      // Path bounding: only URIs from a fresh listing are readable. The
+      // client-supplied uri is a map key, never a filesystem path.
+      const resources = await listMemoryResources(options);
+      const resource = resources.get(uri);
+      if (resource === undefined) return null;
+      let raw: string;
+      try {
+        raw = await readFile(resource.filePath, "utf8");
+      } catch {
+        return null;
+      }
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "text/markdown",
+            text: redactSecrets(raw),
+          },
+        ],
+      };
+    },
+  };
+}

--- a/runtime/src/mcp/server/start.ts
+++ b/runtime/src/mcp/server/start.ts
@@ -7,8 +7,20 @@
  */
 
 import type { Server } from "node:http";
+import { join } from "node:path";
 import { cwd as processCwd } from "node:process";
 import type { Readable, Writable } from "node:stream";
+import {
+  getMemoryBaseDir,
+  MEMORY_DIRNAME,
+  PROJECT_INSTRUCTION_FILE,
+  PROJECT_MEMORY_DIR,
+} from "../../memory/index.js";
+import { getAgenCConfigHomeDir } from "../../utils/envUtils.js";
+import {
+  createMemoryResourceProvider,
+  createSkillPromptProvider,
+} from "./content-providers.js";
 import type { AgenCConfig, McpServerModeConfig } from "../../config/schema.js";
 import { VERSION } from "../../index.js";
 import { McpServerFramework } from "../../mcp-server/framework.js";
@@ -110,7 +122,7 @@ export async function runMcpStdioServe(
   io: McpServerStartIo,
   options: McpServerStartOptions = {},
 ): Promise<void> {
-  const server = createMcpFramework(createLazyMcpToolProvider(options));
+  const server = createMcpFramework(createLazyMcpToolProvider(options), options.cwd);
   await new Promise<void>((resolve, reject) => {
     const transport = new McpStdioServerTransport({
       input: io.stdin,
@@ -131,7 +143,7 @@ export async function startMcpSseServe(
   const host = normalizeMcpSseLoopbackHost(command.host);
   const transport = new McpHttpSseServerTransport({
     serverFactory: () =>
-      createMcpFramework(mcpToolRegistryFromAgenCTools(registry)),
+      createMcpFramework(mcpToolRegistryFromAgenCTools(registry), options.cwd),
   });
   const server = transport.createNodeServer();
   await new Promise<void>((resolve, reject) => {
@@ -222,9 +234,32 @@ function createLazyMcpToolProvider(
   };
 }
 
-function createMcpFramework(toolProvider: McpToolProvider): McpServerFramework {
+function createMcpFramework(
+  toolProvider: McpToolProvider,
+  cwd?: string,
+): McpServerFramework {
+  const workspaceRoot = cwd ?? processCwd();
+  const configHome = getAgenCConfigHomeDir();
   return new McpServerFramework({
     serverInfo: { version: VERSION },
     toolProvider,
+    promptProvider: createSkillPromptProvider({
+      skillRoots: [
+        join(configHome, "skills"),
+        join(configHome, "commands"),
+        join(workspaceRoot, PROJECT_MEMORY_DIR, "skills"),
+        join(workspaceRoot, PROJECT_MEMORY_DIR, "commands"),
+      ],
+    }),
+    resourceProvider: createMemoryResourceProvider({
+      memoryDirs: [
+        join(getMemoryBaseDir(), MEMORY_DIRNAME),
+        join(workspaceRoot, PROJECT_MEMORY_DIR, MEMORY_DIRNAME),
+      ],
+      instructionFiles: [
+        join(configHome, PROJECT_INSTRUCTION_FILE),
+        join(workspaceRoot, PROJECT_INSTRUCTION_FILE),
+      ],
+    }),
   });
 }

--- a/runtime/tests/mcp-server/prompts-resources.test.ts
+++ b/runtime/tests/mcp-server/prompts-resources.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Task 13: the MCP server exposes prompts (skills) and resources
+ * (memory files + instruction files), not just tools. Protocol-level:
+ * a client initializes, sees the capabilities, lists/gets a skill as a
+ * prompt, and reads a memory file as a resource; excluded/secret
+ * content stays out.
+ */
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { McpServerFramework } from "../../src/mcp-server/framework.js";
+import {
+  createMemoryResourceProvider,
+  createSkillPromptProvider,
+} from "../../src/mcp/server/content-providers.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "agenc-mcp-content-"));
+  vi.stubEnv("AGENC_CONFIG_DIR", root);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await rm(root, { recursive: true, force: true });
+});
+
+async function request(
+  server: McpServerFramework,
+  method: string,
+  params?: unknown,
+  id = 1,
+): Promise<any> {
+  const [out] = await server.handleMessageAsync({
+    jsonrpc: "2.0",
+    id,
+    method,
+    ...(params !== undefined ? { params } : {}),
+  });
+  return out;
+}
+
+async function initialized(server: McpServerFramework): Promise<any> {
+  return await request(server, "initialize", {
+    protocolVersion: "2025-06-18",
+    clientInfo: { name: "test-client", version: "1.0" },
+  }, 0);
+}
+
+describe("MCP prompts backed by skills", () => {
+  async function makeSkillServer(): Promise<McpServerFramework> {
+    const skillsDir = join(root, "skills");
+    await mkdir(join(skillsDir, "review-pr"), { recursive: true });
+    await writeFile(
+      join(skillsDir, "review-pr", "SKILL.md"),
+      [
+        "---",
+        "description: Review a pull request",
+        "argument-hint: <pr-number>",
+        "---",
+        "Review PR $ARGUMENTS carefully.",
+      ].join("\n"),
+    );
+    await mkdir(join(skillsDir, "internal-only"), { recursive: true });
+    await writeFile(
+      join(skillsDir, "internal-only", "SKILL.md"),
+      [
+        "---",
+        "description: Not for model invocation",
+        "disable-model-invocation: true",
+        "---",
+        "secret workflow",
+      ].join("\n"),
+    );
+    return new McpServerFramework({
+      promptProvider: createSkillPromptProvider({ skillRoots: [skillsDir] }),
+    });
+  }
+
+  it("advertises the prompts capability in the initialize handshake", async () => {
+    const server = await makeSkillServer();
+    const init = await initialized(server);
+    expect(init.result.capabilities.prompts).toEqual({ listChanged: false });
+  });
+
+  it("lists skills as prompts, excluding disable-model-invocation skills", async () => {
+    const server = await makeSkillServer();
+    await initialized(server);
+    const out = await request(server, "prompts/list");
+    const names = out.result.prompts.map((p: any) => p.name);
+    expect(names).toContain("review-pr");
+    expect(names).not.toContain("internal-only");
+    const prompt = out.result.prompts.find((p: any) => p.name === "review-pr");
+    expect(prompt.description).toBe("Review a pull request");
+  });
+
+  it("gets a skill as a prompt with argument substitution", async () => {
+    const server = await makeSkillServer();
+    await initialized(server);
+    const out = await request(server, "prompts/get", {
+      name: "review-pr",
+      arguments: { arguments: "#42" },
+    });
+    expect(out.result.messages).toEqual([
+      {
+        role: "user",
+        content: { type: "text", text: "Review PR #42 carefully." },
+      },
+    ]);
+  });
+
+  it("refuses prompts/get for excluded and unknown prompts", async () => {
+    const server = await makeSkillServer();
+    await initialized(server);
+    const excluded = await request(server, "prompts/get", {
+      name: "internal-only",
+    });
+    expect(excluded.error.message).toContain("unknown prompt");
+    const missing = await request(server, "prompts/get", { name: "nope" });
+    expect(missing.error).toBeDefined();
+  });
+
+  it("still METHOD_NOT_FOUNDs when no provider is configured", async () => {
+    const server = new McpServerFramework({});
+    await initialized(server);
+    const out = await request(server, "prompts/list");
+    expect(out.error.code).toBe(-32601);
+  });
+});
+
+describe("MCP resources backed by memory + instruction files", () => {
+  async function makeResourceServer(): Promise<{
+    server: McpServerFramework;
+    memoryDir: string;
+  }> {
+    const memoryDir = join(root, "memory");
+    await mkdir(memoryDir, { recursive: true });
+    await writeFile(
+      join(memoryDir, "MEMORY.md"),
+      "- [Deploy notes](deploy-notes.md)",
+    );
+    await writeFile(
+      join(memoryDir, "deploy-notes.md"),
+      [
+        "---",
+        "name: deploy-notes",
+        "description: How deploys work",
+        "---",
+        "Use the staging pipeline. Token: ghp_0123456789abcdefABCDEF0123456789abcdef",
+      ].join("\n"),
+    );
+    // Session memory lives under the config home's session-memory dir; it
+    // must never be listed even if a memory dir points at it.
+    const sessionDir = join(root, "session-memory");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, "leak.md"), "session transcript notes");
+    await writeFile(join(root, "AGENC.md"), "# Project instructions\nhello");
+    const server = new McpServerFramework({
+      resourceProvider: createMemoryResourceProvider({
+        memoryDirs: [memoryDir, sessionDir],
+        instructionFiles: [join(root, "AGENC.md")],
+      }),
+    });
+    return { server, memoryDir };
+  }
+
+  it("advertises the resources capability in the initialize handshake", async () => {
+    const { server } = await makeResourceServer();
+    const init = await initialized(server);
+    expect(init.result.capabilities.resources).toEqual({
+      listChanged: false,
+      subscribe: false,
+    });
+  });
+
+  it("lists memory files + instruction files but never session files", async () => {
+    const { server } = await makeResourceServer();
+    await initialized(server);
+    const out = await request(server, "resources/list");
+    const names = out.result.resources.map((r: any) => r.name);
+    expect(names).toContain("deploy-notes.md");
+    expect(names).toContain("MEMORY.md");
+    expect(names).toContain("AGENC.md");
+    expect(names).not.toContain("leak.md");
+  });
+
+  it("reads a memory file with secrets redacted", async () => {
+    const { server } = await makeResourceServer();
+    await initialized(server);
+    const list = await request(server, "resources/list");
+    const note = list.result.resources.find(
+      (r: any) => r.name === "deploy-notes.md",
+    );
+    const out = await request(server, "resources/read", { uri: note.uri });
+    const text = out.result.contents[0].text;
+    expect(text).toContain("staging pipeline");
+    expect(text).not.toContain("ghp_0123456789abcdef");
+  });
+
+  it("rejects URIs it did not mint (path bounding)", async () => {
+    const { server } = await makeResourceServer();
+    await initialized(server);
+    for (const uri of [
+      "file:///etc/passwd",
+      "agenc-memory://0/../../etc/passwd",
+      "agenc-memory://99/nope.md",
+    ]) {
+      const out = await request(server, "resources/read", { uri });
+      expect(out.error.message).toContain("unknown resource");
+    }
+  });
+});


### PR DESCRIPTION
## TODO task 13 — MCP server was tools-only

**Verified first (2026-07-07):** `framework.ts` returned METHOD_NOT_FOUND for all `prompts/*` and `resources/*`; capabilities advertised tools only.

### What this ships
- Provider interfaces + async-dispatcher routing for `prompts/list|get`, `resources/list|read`; initialize handshake advertises `prompts`/`resources` capabilities only when providers are configured.
- **Prompts = skills**: discovered from standard skill roots, frontmatter-parsed with the shared parser, `disable-model-invocation: true` honored (not exposed), `$ARGUMENTS` substitution on get.
- **Resources = memory + instructions**: runtime memory scanner + MEMORY.md + AGENC.md tiers; session memory/transcripts excluded; **path-bounded by construction** — `readResource` resolves the client URI against its own fresh listing, never the filesystem; contents redacted via the memory secret redactor.
- Wired into `agenc mcp serve` (stdio + SSE).

### Accept met
Protocol tests (9): client initializes → sees capabilities → lists/gets a skill as a prompt (with args), excluded skill absent and un-gettable → lists memory + AGENC.md but never session files → reads a memory file with a token redacted → `file:///etc/passwd` and traversal URIs rejected.

### Gates
tsc 0 ✓, build ✓; full vitest = 68 baseline + one memory-wiring contract failure (imports must go through `memory/index` — fixed, 14/14 green on re-run); existing MCP suites 182/182.