### PR TITLE
feat(agent-jobs): resume CSV fan-out across daemon restart + real cancel

### DIFF
--- a/runtime/src/agents/jobs/job-orchestrator.ts
+++ b/runtime/src/agents/jobs/job-orchestrator.ts
@@ -558,6 +558,11 @@ async function processItems(
       const item = state.items.get(itemId)!;
       item.status = "cancelled";
       item.completedAt = new Date();
+      state.repository?.markItemCancelled(
+        state.config.jobId,
+        itemId,
+        "job cancelled before dispatch",
+      );
       return {};
     }
     const item = state.items.get(itemId)!;
@@ -608,16 +613,31 @@ async function processItems(
       // (or after the wait resolved without `recordAgentJobResult`),
       // mark failed with the reference message.
       if (item.status === "pending") {
-        const message =
-          "worker finished without calling report_agent_job_result";
-        item.status = "failed";
-        item.error = message;
-        item.completedAt = new Date();
-        state.repository?.markItemFailed(
-          state.config.jobId,
-          itemId,
-          message,
-        );
+        if (state.stopRequested) {
+          // The job was cancelled while this item was in flight and its
+          // worker was terminated by cancelOutstanding — that's a
+          // cancellation, not a worker failure.
+          const message = "job cancelled while item was in flight";
+          item.status = "cancelled";
+          item.error = message;
+          item.completedAt = new Date();
+          state.repository?.markItemCancelled(
+            state.config.jobId,
+            itemId,
+            message,
+          );
+        } else {
+          const message =
+            "worker finished without calling report_agent_job_result";
+          item.status = "failed";
+          item.error = message;
+          item.completedAt = new Date();
+          state.repository?.markItemFailed(
+            state.config.jobId,
+            itemId,
+            message,
+          );
+        }
       }
       return {};
     } catch (err) {
@@ -635,6 +655,7 @@ async function processItems(
     }
   };
 
+  let cancelIssued = false;
   while (queue.length > 0 || inflight.size > 0) {
     // reference `run_agent_job_loop` polls `is_agent_job_cancelled` at the
     // top of each loop iteration (agent_jobs.rs:611) so external
@@ -644,6 +665,22 @@ async function processItems(
       const dbJob = state.repository.getJob(state.config.jobId);
       if (dbJob?.status === "cancelled") {
         state.stopRequested = true;
+      }
+    }
+    // Cancel must fire while items are still in flight — waiting for the
+    // in-flight set to drain first (the old tail-call placement) blocks
+    // on the very work cancellation is supposed to stop. Terminate the
+    // worker threads, then release the report waiters so the finalize
+    // guard can mark still-pending items cancelled.
+    if (state.stopRequested && !cancelIssued) {
+      cancelIssued = true;
+      try {
+        await spawn.cancelOutstanding(state.config.jobId);
+      } catch {
+        /* cancellation is best-effort; the runtime timeout still bounds workers */
+      }
+      for (const waiter of state.pending.values()) {
+        waiter.resolve();
       }
     }
     while (!state.stopRequested && inflight.size < max && queue.length > 0) {
@@ -668,7 +705,27 @@ async function processItems(
   }
 
   if (state.stopRequested) {
-    await spawn.cancelOutstanding(state.config.jobId);
+    if (!cancelIssued) {
+      try {
+        await spawn.cancelOutstanding(state.config.jobId);
+      } catch {
+        /* best-effort */
+      }
+    }
+    // Rows that were still queued when the job was cancelled were never
+    // dispatched (the dispatch loop skips on stopRequested) — mark them
+    // cancelled instead of leaving them pending forever.
+    for (const [itemId, item] of state.items) {
+      if (item.status === "pending" && !state.pending.has(itemId)) {
+        item.status = "cancelled";
+        item.completedAt = new Date();
+        state.repository?.markItemCancelled(
+          state.config.jobId,
+          itemId,
+          "job cancelled before dispatch",
+        );
+      }
+    }
   }
 }
 
@@ -752,6 +809,143 @@ async function writeOutputCsv(
       return row;
     });
   await writeFile(path, writeCsv({ headers, rows }), "utf8");
+}
+
+export interface ResumeAgentJobsOpts {
+  readonly repository: CsvAgentJobsRepository;
+  readonly spawn: AgentJobSpawn;
+  readonly threadOps?: AgentJobThreadOps;
+  readonly progressEmitter?: AgentJobProgressEmitter;
+  readonly maxConcurrency?: number;
+}
+
+/**
+ * Resume jobs left `running` in the DB by a daemon that died mid-flight.
+ *
+ * The in-process resolvers are gone after a restart, so every orphaned
+ * `running` item is reset to `pending` (unless it already carries a
+ * reported result, in which case it is finalized as completed) and
+ * re-dispatched through the normal loop respecting `maxConcurrency`.
+ * Row execution is idempotent by construction: the output CSV is
+ * rendered from the full item map at completion, so a re-run row
+ * overwrites its output instead of appending a duplicate.
+ */
+export async function resumeAgentJobsFromRepository(
+  opts: ResumeAgentJobsOpts,
+): Promise<RunAgentsOnCsvResult[]> {
+  const results: RunAgentsOnCsvResult[] = [];
+  for (const job of opts.repository.listJobs({ status: "running" })) {
+    if (jobs.has(job.id)) continue; // already live in this process
+    results.push(await resumeSingleJob(job.id, opts));
+  }
+  return results;
+}
+
+async function resumeSingleJob(
+  jobId: JobId,
+  opts: ResumeAgentJobsOpts,
+): Promise<RunAgentsOnCsvResult> {
+  const repository = opts.repository;
+  const job = repository.getJob(jobId);
+  if (job === null) {
+    throw new Error(`cannot resume unknown agent job ${jobId}`);
+  }
+  const config: JobConfig = {
+    jobId,
+    instruction: job.instruction,
+    ...(job.outputSchema !== undefined ? { outputSchema: job.outputSchema } : {}),
+    maxConcurrency: clampConcurrency(opts.maxConcurrency),
+    maxRuntimeSeconds: job.maxRuntimeSeconds ?? DEFAULT_MAX_RUNTIME_SECONDS,
+  };
+  const items = new Map<ItemId, JobItemRecord>();
+  for (const dbItem of repository.listItems({ jobId })) {
+    const mutableRow: { [column: string]: string } = {};
+    for (const [key, value] of Object.entries(dbItem.row)) {
+      mutableRow[key] = typeof value === "string" ? value : String(value ?? "");
+    }
+    const row: CsvRow = mutableRow;
+    let status: JobItemStatus;
+    switch (dbItem.status) {
+      case "completed":
+        status = "completed";
+        break;
+      case "failed":
+        status = "failed";
+        break;
+      case "cancelled":
+        status = "cancelled";
+        break;
+      case "running":
+        // Orphaned by the dead daemon: its resolver no longer exists.
+        // A result on the row means the worker reported before the
+        // crash — finalize; otherwise the row goes back to pending
+        // for re-dispatch.
+        if (dbItem.result !== undefined) {
+          repository.markItemCompleted(jobId, dbItem.itemId, dbItem.result);
+          status = "completed";
+        } else {
+          repository.markItemPending(jobId, dbItem.itemId);
+          status = "pending";
+        }
+        break;
+      default:
+        status = "pending";
+    }
+    items.set(dbItem.itemId, {
+      jobId,
+      itemId: dbItem.itemId,
+      rowIndex: dbItem.rowIndex,
+      ...(dbItem.sourceId !== undefined ? { sourceId: dbItem.sourceId } : {}),
+      row,
+      instruction: renderInstructionTemplate(job.instruction, row),
+      status,
+      attemptCount: dbItem.attemptCount,
+      ...(dbItem.result !== undefined ? { result: dbItem.result } : {}),
+      ...(dbItem.lastError !== undefined ? { error: dbItem.lastError } : {}),
+    });
+  }
+  const state: JobRuntimeState = {
+    config,
+    items,
+    pending: new Map(),
+    repository,
+    ...(opts.threadOps !== undefined ? { threadOps: opts.threadOps } : {}),
+    progress: new JobProgressEmitterImpl(opts.progressEmitter),
+    stopRequested: false,
+  };
+  jobs.set(jobId, state);
+  try {
+    state.progress.maybeEmit(jobId, computeProgressSnapshot(state), true);
+    await processItems(state, opts.spawn);
+    if (job.autoExport && job.outputCsvPath.length > 0) {
+      await writeOutputCsv(job.outputCsvPath, job.inputHeaders, items);
+    }
+    if (state.stopRequested) {
+      const current = repository.getJob(jobId);
+      if (current?.status !== "cancelled") {
+        repository.markJobCancelled(jobId, "cancelled by worker request");
+      }
+    } else {
+      repository.markJobCompleted(jobId);
+    }
+    state.progress.maybeEmit(jobId, computeProgressSnapshot(state), true);
+    return {
+      jobId,
+      items: Array.from(items.values()),
+      stoppedEarly: state.stopRequested,
+      ...(job.autoExport && job.outputCsvPath.length > 0
+        ? { outputCsvPath: job.outputCsvPath }
+        : {}),
+    };
+  } catch (err) {
+    repository.markJobFailed(
+      jobId,
+      err instanceof Error ? err.message : String(err),
+    );
+    throw err;
+  } finally {
+    jobs.delete(jobId);
+  }
 }
 
 export interface RecordAgentJobResultArgs {

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1560,6 +1560,23 @@ export async function bootstrapLocalRuntimeSession(
             /* cron re-arm is best-effort; tools re-arm on next CronCreate */
           }
         })();
+
+        // Resume CSV agent jobs orphaned by a daemon restart: rows left
+        // `running` in the DB are re-dispatched once a session exists to
+        // spawn workers from.
+        void (async () => {
+          try {
+            const { resumeInterruptedAgentJobs } = await import(
+              "./model-facing-tools.js"
+            );
+            await resumeInterruptedAgentJobs({
+              session: s,
+              workspaceRoot,
+            });
+          } catch {
+            /* resume is best-effort; jobs stay visible in the DB */
+          }
+        })();
         sidecarManager.register(
           new ErrorLogSidecar({
             projectDir,

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -51,6 +51,7 @@ import { delegate } from "../agents/delegate.js";
 import {
   runAgentsOnCsv,
   recordAgentJobResult,
+  resumeAgentJobsFromRepository,
   type AgentJobProgressEmitter,
   type AgentJobSpawn,
   type AgentJobSpawnContext,
@@ -1043,6 +1044,7 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
         ? (args.output_schema as Record<string, unknown>)
         : undefined;
 
+    const outstandingThreadIds = new Set<string>();
     const spawn: AgentJobSpawn = {
       async spawn(ctx: AgentJobSpawnContext) {
         const outcome = await delegate({
@@ -1060,6 +1062,7 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
           );
         }
         const thread = outcome.thread;
+        outstandingThreadIds.add(thread.threadId);
         // AgenC `agent_jobs.rs:704` subscribes to thread status to detect
         // a worker that terminates without calling `report_agent_job_result`
         // (handled by `finalize_finished_item`). AgenC mirrors this by
@@ -1069,15 +1072,21 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
         const threadFinished = thread
           .join()
           .then(() => undefined)
-          .catch(() => undefined);
+          .catch(() => undefined)
+          .finally(() => outstandingThreadIds.delete(thread.threadId));
         return { threadId: thread.threadId, threadFinished };
       },
       async cancelOutstanding() {
-        // In-memory orchestrator: workers self-terminate when they
-        // observe a stop=true report. Outstanding agents will be
-        // bounded by `max_runtime_seconds`. Hard-cancel via the
-        // control plane is deferred (agenc SQLite-backed lifecycle
-        // not ported).
+        // Hard-cancel: shut down every worker thread this job still has
+        // in flight. The orchestrator then finalizes their items as
+        // cancelled via the stopRequested finalize guard.
+        const ids = [...outstandingThreadIds];
+        outstandingThreadIds.clear();
+        await Promise.all(
+          ids.map((id) =>
+            control.shutdown(id, "agent_job_cancelled").catch(() => {}),
+          ),
+        );
       },
     };
 
@@ -2648,6 +2657,74 @@ function validateCron(schedule: string): boolean {
  * the wiring that makes CronCreate definitions actually FIRE: due jobs
  * enqueue their prompt onto the session command queue as a new turn.
  */
+/**
+ * Resume CSV agent jobs orphaned by a daemon restart. In-flight jobs
+ * survive in the DB with `running` items whose Promise resolvers died
+ * with the old process; this reconstructs each job from the repository
+ * and re-dispatches the unfinished rows through the normal loop.
+ * Resumed worker threads register task pills like any other background
+ * agent work.
+ */
+export async function resumeInterruptedAgentJobs(opts: {
+  readonly session: Session;
+  readonly workspaceRoot: string;
+}): Promise<number> {
+  const repository = getCsvAgentJobsRepository(opts.workspaceRoot);
+  if (repository.listJobs({ status: "running" }).length === 0) {
+    return 0;
+  }
+  const { control, registry } = ensureAgentControl(opts.session);
+  const { backgroundTaskLifecycle, registerAgentThreadTask } = await import(
+    "../tasks/index.js"
+  );
+  const outstandingThreadIds = new Set<string>();
+  const spawn: AgentJobSpawn = {
+    async spawn(ctx: AgentJobSpawnContext) {
+      const outcome = await delegate({
+        parent: opts.session,
+        parentPath: ROOT_AGENT_PATH,
+        control,
+        registry,
+        taskPrompt: ctx.workerPrompt,
+        agentName: ctx.itemId,
+        runInBackground: true,
+      });
+      if (outcome.kind === "rejected") {
+        throw new Error(
+          `agent-jobs resume spawn rejected for item ${ctx.itemId}: ${outcome.reason}`,
+        );
+      }
+      const thread = outcome.thread;
+      outstandingThreadIds.add(thread.threadId);
+      try {
+        registerAgentThreadTask(backgroundTaskLifecycle, thread as never, {
+          description: `csv-job:${ctx.itemId}`,
+          prompt: ctx.workerPrompt,
+        });
+      } catch {
+        /* pill registration is best-effort */
+      }
+      const threadFinished = thread
+        .join()
+        .then(() => undefined)
+        .catch(() => undefined)
+        .finally(() => outstandingThreadIds.delete(thread.threadId));
+      return { threadId: thread.threadId, threadFinished };
+    },
+    async cancelOutstanding() {
+      const ids = [...outstandingThreadIds];
+      outstandingThreadIds.clear();
+      await Promise.all(
+        ids.map((id) =>
+          control.shutdown(id, "agent_job_cancelled").catch(() => {}),
+        ),
+      );
+    },
+  };
+  const resumed = await resumeAgentJobsFromRepository({ repository, spawn });
+  return resumed.length;
+}
+
 export async function startCronSchedulerRunner(): Promise<void> {
   const { setScheduledTasksEnabled } = await import("../bootstrap/state.js");
   const { getCronScheduler } = await import("../utils/cronScheduler.js");

--- a/runtime/src/state/csv-agent-jobs.ts
+++ b/runtime/src/state/csv-agent-jobs.ts
@@ -28,7 +28,8 @@ export type CsvAgentJobItemStatus =
   | "pending"
   | "running"
   | "completed"
-  | "failed";
+  | "failed"
+  | "cancelled";
 
 const JOB_STATUSES: ReadonlySet<CsvAgentJobStatus> = new Set([
   "pending",
@@ -43,6 +44,7 @@ const ITEM_STATUSES: ReadonlySet<CsvAgentJobItemStatus> = new Set([
   "running",
   "completed",
   "failed",
+  "cancelled",
 ]);
 
 function parseJobStatus(raw: string): CsvAgentJobStatus {
@@ -488,6 +490,20 @@ export class CsvAgentJobsRepository {
          WHERE job_id = ? AND item_id = ?`,
       )
       .run(error, now, now, now, jobId, itemId);
+  }
+
+  markItemCancelled(jobId: string, itemId: string, reason: string): void {
+    const now = nowSeconds();
+    this.driver
+      .prepareState(
+        `UPDATE csv_agent_job_items
+         SET status = 'cancelled',
+             last_error = ?,
+             completed_at = ?,
+             updated_at = ?
+         WHERE job_id = ? AND item_id = ?`,
+      )
+      .run(reason, now, now, jobId, itemId);
   }
 
   getJobProgress(jobId: string): CsvAgentJobProgress {

--- a/runtime/tests/agents/jobs/job-orchestrator.test.ts
+++ b/runtime/tests/agents/jobs/job-orchestrator.test.ts
@@ -122,11 +122,11 @@ describe("runAgentsOnCsv", () => {
     });
     expect(result.stoppedEarly).toBe(true);
     expect(result.items[0]!.status).toBe("completed");
-    // The reference run loop stops dispatching new workers when
-    // cancellation is requested but does not auto-cancel pending items;
-    // they remain in `pending` status. AgenC matches that behavior:
-    // row2 and row3 never dispatch and stay pending.
-    expect(result.items.slice(1).every((it) => it.status === "pending")).toBe(
+    // Deliberate divergence from the reference loop (which left
+    // never-dispatched items in `pending` forever): a cancelled job
+    // marks its outstanding rows `cancelled` so the job's terminal
+    // state is unambiguous. row2 and row3 never dispatch.
+    expect(result.items.slice(1).every((it) => it.status === "cancelled")).toBe(
       true,
     );
   });

--- a/runtime/tests/agents/jobs/resume-cancel.test.ts
+++ b/runtime/tests/agents/jobs/resume-cancel.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Task 14: CSV fan-out survives a daemon restart and supports real
+ * cancellation.
+ *
+ * Restart test: a 10-row job is killed mid-flight (4 completed, 2
+ * orphaned `running`, 4 never dispatched — exactly the DB state a dead
+ * daemon leaves behind), then resumed: all 10 rows complete with
+ * exactly 10 output rows. Cancel test: a stop=true report terminates
+ * outstanding workers and marks their rows cancelled — including rows
+ * still queued, which previously stayed `pending` forever.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CsvAgentJobsRepository } from "../../state/csv-agent-jobs.js";
+import { openStateDatabases } from "../../state/sqlite-driver.js";
+import {
+  recordAgentJobResult,
+  resumeAgentJobsFromRepository,
+  runAgentsOnCsv,
+  type AgentJobSpawn,
+} from "./job-orchestrator.js";
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "agenc-job-resume-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+function openRepository(): CsvAgentJobsRepository {
+  return new CsvAgentJobsRepository(openStateDatabases({ cwd: workDir }));
+}
+
+function reportingSpawn(): AgentJobSpawn & { spawned: string[] } {
+  const spawned: string[] = [];
+  return {
+    spawned,
+    async spawn(ctx) {
+      spawned.push(ctx.itemId);
+      queueMicrotask(() => {
+        recordAgentJobResult({
+          jobId: ctx.jobId,
+          itemId: ctx.itemId,
+          result: { echoed: ctx.row.value ?? "" },
+        });
+      });
+    },
+    async cancelOutstanding() {},
+  };
+}
+
+describe("resume across daemon restart", () => {
+  it("re-dispatches orphaned rows and completes all 10 with exactly 10 output rows", async () => {
+    const repository = openRepository();
+    const outputCsvPath = join(workDir, "out.csv");
+    const jobId = "job_killed_mid_flight";
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      itemId: `item_${i}`,
+      rowIndex: i,
+      row: { id: `row${i}`, value: `v${i}` },
+    }));
+    repository.createJob(
+      {
+        id: jobId,
+        name: "restart test",
+        instruction: "process {value}",
+        autoExport: true,
+        inputHeaders: ["id", "value"],
+        inputCsvPath: join(workDir, "input.csv"),
+        outputCsvPath,
+      },
+      rows,
+    );
+    repository.markJobRunning(jobId);
+    // The dead daemon's footprint: 4 rows finished, 2 were in flight
+    // when the process died (their resolvers are gone), 4 untouched.
+    for (let i = 0; i < 4; i++) {
+      repository.markItemRunningWithThread(jobId, `item_${i}`, `thread_${i}`);
+      repository.markItemCompleted(jobId, `item_${i}`, { echoed: `v${i}` });
+    }
+    repository.markItemRunningWithThread(jobId, "item_4", "thread_4");
+    repository.markItemRunningWithThread(jobId, "item_5", "thread_5");
+
+    const spawn = reportingSpawn();
+    const results = await resumeAgentJobsFromRepository({ repository, spawn });
+
+    expect(results).toHaveLength(1);
+    const items = results[0]!.items;
+    expect(items).toHaveLength(10);
+    expect(items.every((item) => item.status === "completed")).toBe(true);
+    // Only the 6 unfinished rows were re-dispatched.
+    expect(spawn.spawned.sort()).toEqual(
+      ["item_4", "item_5", "item_6", "item_7", "item_8", "item_9"].sort(),
+    );
+    // Completed rows kept their original results.
+    expect(items.find((i) => i.itemId === "item_0")?.result).toEqual({
+      echoed: "v0",
+    });
+    // Exactly 10 output rows — idempotent, no duplicates.
+    const csv = await readFile(outputCsvPath, "utf8");
+    const lines = csv.trim().split("\n");
+    expect(lines).toHaveLength(11); // header + 10 rows
+    expect(repository.getJob(jobId)?.status).toBe("completed");
+    expect(
+      repository
+        .listItems({ jobId })
+        .every((item) => item.status === "completed"),
+    ).toBe(true);
+  });
+
+  it("is a no-op when no jobs are running", async () => {
+    const repository = openRepository();
+    const spawn = reportingSpawn();
+    const results = await resumeAgentJobsFromRepository({ repository, spawn });
+    expect(results).toEqual([]);
+    expect(spawn.spawned).toEqual([]);
+  });
+});
+
+describe("real cancellation", () => {
+  it("stops outstanding rows and marks them cancelled", async () => {
+    const csvPath = join(workDir, "input.csv");
+    await writeFile(
+      csvPath,
+      ["id,value", ...Array.from({ length: 6 }, (_, i) => `row${i},v${i}`)].join(
+        "\n",
+      ) + "\n",
+      "utf8",
+    );
+    const repository = openRepository();
+    let cancelCalls = 0;
+    const spawn: AgentJobSpawn = {
+      async spawn(ctx) {
+        if (ctx.itemId === "row0") {
+          queueMicrotask(() => {
+            recordAgentJobResult({
+              jobId: ctx.jobId,
+              itemId: ctx.itemId,
+              result: { done: "yes" },
+              stop: true,
+            });
+          });
+        }
+        // Every other worker hangs until cancelled.
+      },
+      async cancelOutstanding() {
+        cancelCalls += 1;
+      },
+    };
+
+    const result = await runAgentsOnCsv({
+      csvPath,
+      instruction: "do {value}",
+      idColumn: "id",
+      maxConcurrency: 2,
+      spawn,
+      repository,
+    });
+
+    expect(result.stoppedEarly).toBe(true);
+    expect(cancelCalls).toBe(1);
+    const byId = new Map(result.items.map((item) => [item.itemId, item]));
+    expect(byId.get("row0")?.status).toBe("completed");
+    // The in-flight worker (row1) and every queued row are cancelled.
+    for (const id of ["row1", "row2", "row3", "row4", "row5"]) {
+      expect(byId.get(id)?.status).toBe("cancelled");
+    }
+    // DB agrees — including the item-level cancelled status round-trip.
+    const dbItems = repository.listItems({ jobId: result.jobId });
+    expect(
+      dbItems.filter((item) => item.status === "cancelled"),
+    ).toHaveLength(5);
+    expect(repository.getJob(result.jobId)?.status).toBe("cancelled");
+  }, 15_000);
+});


### PR DESCRIPTION
## TODO task 14 — restart-resume + real cancel

**Verified first (2026-07-07):** the self-documented gap is still open (`job-orchestrator.ts:11-16`); `recoverRunningItems` reconciles but never re-dispatches; `cancelOutstanding` was a no-op. Verification also found two additional defects fixed here: cancel fired only **after** the in-flight set drained (deadlock-shaped), and item-status `cancelled` existed in the orchestrator type but `parseItemStatus` would **throw** reading it back from the DB.

### What this ships
- `resumeAgentJobsFromRepository()` — DB-running jobs rebuilt (config + rows from the repository), orphaned `running` rows finalized-if-reported else reset to `pending`, re-dispatched respecting `maxConcurrency`; output CSV rendered from the full item map = idempotent (exactly one output row per input row).
- Cancel restructured: fires while work is in flight, tool adapter hard-cancels worker threads via `control.shutdown`, in-flight rows finalize `cancelled`, queued rows marked `cancelled` (previously stuck `pending` forever — the pinned test documenting that behavior is updated as a deliberate divergence from the reference loop).
- Repository `markItemCancelled` + `cancelled` in the item-status union.
- Bootstrap resume wiring (best-effort, next to cron re-arm); resumed workers register `csv-job:<item>` task pills.

### Accept met
`tests/agents/jobs/resume-cancel.test.ts`: 10-row job killed mid-flight (4 done / 2 orphaned running / 4 queued) → resume completes all 10 with exactly 10 output rows, originals' results preserved, only the 6 unfinished re-dispatched; cancel test → 1 completed, 5 cancelled (in-flight + queued), `cancelOutstanding` invoked once, DB round-trips the cancelled status. Red on HEAD (imports the new export).

### Gates
tsc 0 ✓, build ✓, `check:tui-runtime-startup` ✓ (bootstrap touched), full vitest = exactly the 68-failure baseline.