### PR TITLE
fix(tests): make main's full vitest + bun suites green (68 baseline failures)

### DIFF
--- a/runtime/src/utils/cronScheduler.ts
+++ b/runtime/src/utils/cronScheduler.ts
@@ -153,6 +153,16 @@ export class CronScheduler {
   /** True while a tick (the local wake path) is executing — re-entrancy guard. */
   private tickInFlight = false
   /**
+   * The most recent timer-initiated tick, kept so stop paths can await
+   * quiescence: stop() only clears the NEXT wake — a tick already executing
+   * keeps running and persists fire state to disk. Without draining it,
+   * shutdown (and test teardown that deletes the state dir) races the
+   * in-flight write. Rejections are caught where this is assigned, so an
+   * exploding tick logs instead of dying as an unhandled rejection from
+   * the bare timer callback.
+   */
+  private lastTick: Promise<void> = Promise.resolve()
+  /**
    * Per-task overlap guard: monotonic-ms deadline through which a task that just
    * fired is treated as "still in flight" so a duplicate is skipped. The lease
    * AUTO-EXPIRES after minIntervalFloorMs so a recurring task is never
@@ -225,6 +235,16 @@ export class CronScheduler {
     this.clearTimer()
   }
 
+  /**
+   * Await the most recent timer-initiated tick. stop() prevents NEW wakes but
+   * a tick already executing keeps going (it persists lastFiredAt / removes
+   * fired one-shots on disk); callers that are about to tear down the state
+   * directory must stop() then drain() before deleting files.
+   */
+  async drain(): Promise<void> {
+    await this.lastTick
+  }
+
   /** Resume after a pause (manual or post-cap), re-arming the next wake. */
   resume(): void {
     this.paused = false
@@ -270,7 +290,9 @@ export class CronScheduler {
     )
     this.recordNextWake(wait)
     this.timer = this.deps.setTimer(() => {
-      void this.onWake()
+      this.lastTick = this.onWake().catch((error: unknown) => {
+        logForDebugging(`[CronScheduler] tick failed: ${String(error)}`)
+      })
     }, wait)
   }
 
@@ -583,8 +605,14 @@ export function getCronScheduler(): CronScheduler {
   return singleton
 }
 
-/** Test-only: drop the singleton so each test starts from a clean driver. */
-export function resetCronSchedulerForTests(): void {
+/**
+ * Test-only: drop the singleton so each test starts from a clean driver.
+ * Async because stop() alone leaves an in-flight tick running — a caller that
+ * deletes the temp state dir right after reset would race the tick's
+ * scheduled_tasks.json write (observed as an unhandled ENOENT rejection).
+ */
+export async function resetCronSchedulerForTests(): Promise<void> {
   singleton?.stop()
+  await singleton?.drain()
   singleton = null
 }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -1318,9 +1318,16 @@ token_cap = 123
     const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
     const cookiePath = resolveAgenCDaemonCookiePath(host.env, host.userHome);
     host.runningPids.add(host.pid);
+    // Pin the local auth backend explicitly: since 97f1baf8 ("add Google
+    // login flow") the default backend is "remote", which would make the
+    // active-vs-reloaded auth state indistinguishable below (and route
+    // auth requests at the hosted identity service).
     await writeFile(
       join(agencHome, "config.toml"),
       `
+[auth]
+backend = "local"
+
 [mcp.server]
 enabled = true
 transport = "sse"
@@ -1464,6 +1471,17 @@ port = 0
     const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
     const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
     const cookiePath = resolveAgenCDaemonCookiePath(host.env, host.userHome);
+    // Pin the local auth backend: since 97f1baf8 ("add Google login flow")
+    // the default is "remote", whose auth.login performs a real device-code
+    // flow against the hosted identity service — a live network dependency
+    // this offline contract test must not have.
+    await writeFile(
+      join(agencHome, "config.toml"),
+      `
+[auth]
+backend = "local"
+      `,
+    );
 
     const running = runAgenCDaemonCli(
       { kind: "command", action: "run" },

--- a/runtime/tests/auth/byok-fallback.contract.test.ts
+++ b/runtime/tests/auth/byok-fallback.contract.test.ts
@@ -108,9 +108,41 @@ describe("BYOK fallback", () => {
           },
         }),
       ).rejects.toThrow(
-        /grok provider requires an API key.*auth\.managedKeys\.enabled.*XAI_API_KEY.*providers\.grok\.api_key_env/,
+        // Since e4a54ec1 ("route managed bootstrap through OpenRouter") grok
+        // has no live managed route, so the actionable error explains the
+        // OpenRouter-only managed surface plus both BYOK escape hatches.
+        /grok provider requires an API key.*Subscription-managed access is currently live for OpenRouter only.*XAI_API_KEY.*providers\.grok\.api_key_env/,
       );
       expect(calls).toEqual(["getSubscriptionTier:conv-no-key"]);
+    } finally {
+      await rm(agencHome, { recursive: true, force: true });
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("points at auth.managedKeys.enabled when managed vending is disabled for the live OpenRouter route", async () => {
+    const agencHome = await mkdtemp(join(tmpdir(), "agenc-byok-fallback-home-"));
+    const workspace = await mkdtemp(join(tmpdir(), "agenc-byok-fallback-ws-"));
+    const calls: string[] = [];
+
+    try {
+      await expect(
+        bootstrapLocalRuntimeSession({
+          authBackend: localBackendThatCannotVend(calls),
+          conversationId: "conv-no-key-openrouter",
+          env: {
+            AGENC_HOME: agencHome,
+            AGENC_AUTH_MANAGED_KEYS_ENABLED: "false",
+            AGENC_PROVIDER: "openrouter",
+            AGENC_WORKSPACE: workspace,
+            HOME: agencHome,
+            OPENROUTER_API_KEY: "",
+          },
+        }),
+      ).rejects.toThrow(
+        /openrouter provider requires an API key.*auth\.managedKeys\.enabled.*OPENROUTER_API_KEY.*providers\.openrouter\.api_key_env/,
+      );
+      expect(calls).toEqual(["getSubscriptionTier:conv-no-key-openrouter"]);
     } finally {
       await rm(agencHome, { recursive: true, force: true });
       await rm(workspace, { recursive: true, force: true });

--- a/runtime/tests/auth/remote-bootstrap.contract.test.ts
+++ b/runtime/tests/auth/remote-bootstrap.contract.test.ts
@@ -14,10 +14,13 @@ describe("remote AuthBackend bootstrap key vending", () => {
   it("vends a remote managed key through createAuthBackend during provider startup", async () => {
     const agencHome = await mkdtemp(join(tmpdir(), "agenc-remote-auth-home-"));
     const workspace = await mkdtemp(join(tmpdir(), "agenc-remote-auth-ws-"));
+    // Managed subscription vending is OpenRouter-only (e4a54ec1 "route
+    // managed bootstrap through OpenRouter"), so the remote key is vended
+    // for the openrouter provider.
     const fetchImpl = vi.fn(async () =>
       new Response(
         JSON.stringify({
-          provider: "grok",
+          provider: "openrouter",
           sessionId: "conv-remote-key",
           apiKey: " remote-managed-key ",
         }),
@@ -71,20 +74,23 @@ describe("remote AuthBackend bootstrap key vending", () => {
         env: {
           AGENC_HOME: agencHome,
           AGENC_AUTH_MANAGED_KEYS_ENABLED: "true",
+          AGENC_MODEL: "x-ai/grok-4.3",
+          AGENC_PROVIDER: "openrouter",
           AGENC_WORKSPACE: workspace,
           AGENC_XAI_API_KEY: "",
           GROK_API_KEY: "",
           HOME: agencHome,
+          OPENROUTER_API_KEY: "",
           XAI_API_KEY: "",
         },
       });
       shutdown = boot.shutdown;
 
       expect(createProviderSpy).toHaveBeenCalledWith(
-        "grok",
+        "openrouter",
         expect.objectContaining({
           apiKey: "remote-managed-key",
-          model: "grok-4.3",
+          model: "x-ai/grok-4.3",
         }),
       );
       expect(fetchImpl).toHaveBeenCalledWith(
@@ -92,7 +98,7 @@ describe("remote AuthBackend bootstrap key vending", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
-            provider: "grok",
+            provider: "openrouter",
             sessionId: "conv-remote-key",
           }),
         }),

--- a/runtime/tests/bin/bootstrap.test.ts
+++ b/runtime/tests/bin/bootstrap.test.ts
@@ -1273,8 +1273,14 @@ describe("bootstrapLocalRuntimeSession", () => {
         true,
       );
       const state = boot.session.state.unsafePeek();
+      // User history entries carry the file-history join key since 07ae54e6
+      // ("make conversation rewind restore files on disk").
       expect(state.history).toEqual([
-        { role: "user", content: "driver prompt" },
+        {
+          role: "user",
+          content: "driver prompt",
+          runtimeOnly: { userMessageId: expect.stringMatching(/^user-msg-/) },
+        },
         { role: "assistant", content: "driver reply" },
       ]);
       expect(manager!.snapshot(conversationId).historyLength).toBe(2);
@@ -1966,10 +1972,15 @@ describe("bootstrapLocalRuntimeSession", () => {
           ...process.env,
           AGENC_HOME: home,
           AGENC_AUTH_MANAGED_KEYS_ENABLED: "true",
+          // Managed subscription vending is live for OpenRouter only
+          // (e4a54ec1 "route managed bootstrap through OpenRouter").
+          AGENC_MODEL: "x-ai/grok-4.3",
+          AGENC_PROVIDER: "openrouter",
           AGENC_WORKSPACE: workspace,
           AGENC_XAI_API_KEY: "",
           HOME: home,
           GROK_API_KEY: "",
+          OPENROUTER_API_KEY: "",
           XAI_API_KEY: "",
         },
       });
@@ -1977,16 +1988,16 @@ describe("bootstrapLocalRuntimeSession", () => {
 
       expect(boot.authSubscriptionTier).toBe("pro");
       expect(createProviderSpy).toHaveBeenCalledWith(
-        "grok",
+        "openrouter",
         expect.objectContaining({
           apiKey: "managed-key",
           baseURL: "https://llm.agenc.tech",
-          model: "xai/grok-4.3",
+          model: "openrouter/x-ai/grok-4.3",
         }),
       );
       expect(calls).toEqual([
         "getSubscriptionTier:conv-auth",
-        "vendKey:grok:conv-auth",
+        "vendKey:openrouter:conv-auth",
       ]);
     } finally {
       await shutdown?.().catch(() => {
@@ -2032,8 +2043,13 @@ describe("bootstrapLocalRuntimeSession", () => {
             AGENC_WORKSPACE: workspace,
             AGENC_XAI_API_KEY: "",
             AGENC_AUTH_MANAGED_KEYS_ENABLED: "false",
+            // OpenRouter is the only provider with a live managed route, so
+            // it is the only one that can surface the managed-keys-disabled
+            // hint (other providers report "OpenRouter only" instead).
+            AGENC_PROVIDER: "openrouter",
             HOME: home,
             GROK_API_KEY: "",
+            OPENROUTER_API_KEY: "",
             XAI_API_KEY: "",
           },
         }),
@@ -2265,9 +2281,11 @@ describe("bootstrapLocalRuntimeSession", () => {
         calls.push(
           `inferAgencModel:${provider ?? ""}:${requestedModel ?? ""}:${subscriptionTier ?? ""}`,
         );
+        // Managed subscription vending is OpenRouter-only (e4a54ec1), so the
+        // hosted alias resolves to the OpenRouter route.
         return {
-          provider: "agenc",
-          model: "grok-4.3",
+          provider: "openrouter",
+          model: "x-ai/grok-4.3",
           subscriptionTier,
         };
       },
@@ -2311,25 +2329,26 @@ describe("bootstrapLocalRuntimeSession", () => {
           AGENC_XAI_API_KEY: "",
           HOME: home,
           GROK_API_KEY: "",
+          OPENROUTER_API_KEY: "",
           XAI_API_KEY: "",
         },
       });
       shutdown = boot.shutdown;
 
       expect(boot.authSubscriptionTier).toBe("team");
-      expect(boot.resolvedProvider).toBe("grok");
-      expect(boot.model).toBe("grok-4.3");
+      expect(boot.resolvedProvider).toBe("openrouter");
+      expect(boot.model).toBe("x-ai/grok-4.3");
       expect(createProviderSpy).toHaveBeenCalledWith(
-        "grok",
+        "openrouter",
         expect.objectContaining({
           apiKey: "managed-key",
-          model: "grok-4.3",
+          model: "x-ai/grok-4.3",
         }),
       );
       expect(calls).toEqual([
         "getSubscriptionTier:conv-hosted",
         "inferAgencModel:grok:agenc:team",
-        "vendKey:grok:conv-hosted",
+        "vendKey:openrouter:conv-hosted",
       ]);
     } finally {
       await shutdown?.().catch(() => {

--- a/runtime/tests/bin/cron-live-tools.test.ts
+++ b/runtime/tests/bin/cron-live-tools.test.ts
@@ -70,9 +70,11 @@ beforeEach(() => {
   dequeueAll();
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.useRealTimers();
-  resetCronSchedulerForTests();
+  // Await quiescence: an in-flight tick would otherwise race the rmSync
+  // below and die with an unhandled ENOENT writing scheduled_tasks.json.
+  await resetCronSchedulerForTests();
   resetStateForTests();
   dequeueAll();
   rmSync(tempRoot, { recursive: true, force: true });
@@ -175,7 +177,7 @@ describe("live Cron tools drive the real scheduler", () => {
         recurring: true,
       });
       // Simulate a daemon restart: the in-memory scheduler dies…
-      resetCronSchedulerForTests();
+      await resetCronSchedulerForTests();
       resetStateForTests();
       setProjectRoot(tempRoot);
       setOriginalCwd(tempRoot);

--- a/runtime/tests/bin/providers-cli.test.ts
+++ b/runtime/tests/bin/providers-cli.test.ts
@@ -222,9 +222,17 @@ describe("providers CLI", () => {
     });
     const entries = byProvider(report.entries);
 
-    expect(entries.get("grok")).toMatchObject({
+    // Managed key vending is restricted to OpenRouter (b461d139 "use
+    // OpenRouter for managed Pro models"); grok/openai rows are no longer
+    // vended and fall back to BYOK-missing.
+    expect(entries.get("openrouter")).toMatchObject({
       usable: true,
       keyStatus: "managed",
+      subscriptionTier: "pro",
+    });
+    expect(entries.get("grok")).toMatchObject({
+      usable: false,
+      keyStatus: "missing",
       subscriptionTier: "pro",
     });
     expect(entries.get("agenc")).toMatchObject({
@@ -232,15 +240,20 @@ describe("providers CLI", () => {
       keyStatus: "not-required",
       subscriptionTier: "pro",
     });
-    expect(calls).toContain("vendKey:grok:cli");
-    expect(calls).toContain("vendKey:openai:cli");
+    // Exactly two vends happen: the managed OpenRouter provider row, and the
+    // hosted agenc route verifying its inferred grok delegate. No other
+    // provider row (openai, anthropic, ...) is vended anymore.
+    expect([...calls].sort()).toEqual([
+      "vendKey:grok:cli",
+      "vendKey:openrouter:cli",
+    ]);
   });
 
   it("marks managed-key provider rows unusable when vending fails", async () => {
     const report = await collectProviderAvailability({
       authBackend: authBackend("remote", "pro", {
         vendKey: (provider, sessionId) => {
-          if (provider === "grok") throw new Error("grok denied");
+          if (provider === "openrouter") throw new Error("openrouter denied");
           return { provider, sessionId, apiKey: "managed-key" };
         },
       }),
@@ -250,42 +263,53 @@ describe("providers CLI", () => {
     });
     const entries = byProvider(report.entries);
 
-    expect(entries.get("grok")).toMatchObject({
+    expect(entries.get("openrouter")).toMatchObject({
       usable: false,
       keyStatus: "unavailable",
     });
-    expect(entries.get("grok")?.detail).toContain("grok denied");
+    expect(entries.get("openrouter")?.detail).toContain("openrouter denied");
   });
 
   it("rejects managed-key vending with an empty or mismatched key response", async () => {
-    const report = await collectProviderAvailability({
+    // OpenRouter is the only provider with a live managed vending route, so
+    // the mismatch and empty-key rejections are exercised in two passes.
+    const mismatchReport = await collectProviderAvailability({
       authBackend: authBackend("remote", "team", {
-        vendKey: (provider, sessionId) => {
-          if (provider === "openai") {
-            return { provider: "grok", sessionId, apiKey: "managed-key" };
-          }
-          if (provider === "anthropic") {
-            return { provider, sessionId, apiKey: " " };
-          }
-          return { provider, sessionId, apiKey: "managed-key" };
-        },
+        vendKey: (_provider, sessionId) => ({
+          provider: "grok",
+          sessionId,
+          apiKey: "managed-key",
+        }),
       }),
       checkLocal: false,
       config: defaultConfig(),
       env: {},
     });
-    const entries = byProvider(report.entries);
+    const mismatchEntries = byProvider(mismatchReport.entries);
 
-    expect(entries.get("openai")).toMatchObject({
+    expect(mismatchEntries.get("openrouter")).toMatchObject({
       usable: false,
       keyStatus: "unavailable",
     });
-    expect(entries.get("openai")?.detail).toContain("provider mismatch");
-    expect(entries.get("anthropic")).toMatchObject({
+    expect(mismatchEntries.get("openrouter")?.detail).toContain(
+      "provider mismatch",
+    );
+
+    const emptyKeyReport = await collectProviderAvailability({
+      authBackend: authBackend("remote", "team", {
+        vendKey: (provider, sessionId) => ({ provider, sessionId, apiKey: " " }),
+      }),
+      checkLocal: false,
+      config: defaultConfig(),
+      env: {},
+    });
+    const emptyKeyEntries = byProvider(emptyKeyReport.entries);
+
+    expect(emptyKeyEntries.get("openrouter")).toMatchObject({
       usable: false,
       keyStatus: "unavailable",
     });
-    expect(entries.get("anthropic")?.detail).toContain("empty key");
+    expect(emptyKeyEntries.get("openrouter")?.detail).toContain("empty key");
   });
 
   it("marks hosted AgenC routing unusable when inference fails", async () => {

--- a/runtime/tests/commands/model.test.ts
+++ b/runtime/tests/commands/model.test.ts
@@ -75,6 +75,26 @@ function mkctx(
   };
 }
 
+// Ambient BYOK credentials (e.g. a developer's real XAI_API_KEY) would add
+// legitimate BYOK provider rows to the managed model menu and break the
+// hermetic managed-only expectations, so they are stripped for the duration
+// of each pro-session test.
+const PROVIDER_KEY_ENV_VARS = [
+  "XAI_API_KEY",
+  "GROK_API_KEY",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "LMSTUDIO_API_KEY",
+  "OPENAI_COMPATIBLE_API_KEY",
+  "OPENROUTER_API_KEY",
+  "GROQ_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GEMINI_API_KEY",
+  "MISTRAL_API_KEY",
+  "NVIDIA_API_KEY",
+  "MINIMAX_API_KEY",
+] as const;
+
 function withProAuthSession<T>(fn: () => T): T {
   const agencHome = mkdtempSync(join(tmpdir(), "agenc-model-pro-"));
   writeFileSync(
@@ -88,6 +108,11 @@ function withProAuthSession<T>(fn: () => T): T {
   );
   const previousHome = process.env.AGENC_HOME;
   process.env.AGENC_HOME = agencHome;
+  const previousKeys = new Map<string, string | undefined>();
+  for (const envVar of PROVIDER_KEY_ENV_VARS) {
+    previousKeys.set(envVar, process.env[envVar]);
+    delete process.env[envVar];
+  }
   try {
     return fn();
   } finally {
@@ -95,6 +120,13 @@ function withProAuthSession<T>(fn: () => T): T {
       delete process.env.AGENC_HOME;
     } else {
       process.env.AGENC_HOME = previousHome;
+    }
+    for (const [envVar, value] of previousKeys) {
+      if (value === undefined) {
+        delete process.env[envVar];
+      } else {
+        process.env[envVar] = value;
+      }
     }
   }
 }

--- a/runtime/tests/cronScheduler.test.ts
+++ b/runtime/tests/cronScheduler.test.ts
@@ -303,4 +303,66 @@ describe('cronEnqueueToCommandQueue (production wiring)', () => {
     const command = vi.mocked(enqueuePendingNotification).mock.calls[0]?.[0]
     expect(command).not.toHaveProperty('agentId')
   })
+
+  test('drain() after stop() waits for the in-flight tick (teardown race guard)', async () => {
+    // stop() only clears the NEXT wake; a tick already executing keeps
+    // running and writes fire state to disk. Callers that delete the state
+    // dir right after stopping must be able to await quiescence — without
+    // it, teardown races the tick's scheduled_tasks.json write (observed as
+    // an unhandled ENOENT rejection from the bare timer callback).
+    setScheduledTasksEnabled(true) // start() is a no-op without the flag
+    const start = 59 * 60_000 // 00:59:00, hourly task fires at 01:00:00
+    const clock = new FakeClock(start)
+    let releaseTick!: () => void
+    const gate = new Promise<void>(resolve => {
+      releaseTick = resolve
+    })
+    let tickFinished = false
+    let loadCalls = 0
+    const sched = new CronScheduler(
+      {
+        now: () => clock.nowMs,
+        monotonicNow: () => clock.monoMs,
+        setTimer: clock.setTimer,
+        clearTimer: clock.clearTimer,
+        // Call 1 is start()'s reschedule (earliest-due scan) — return the
+        // task so a wake gets armed. Call 2 is the timer tick's dispatch
+        // path — park it on the gate, simulating slow disk I/O mid-tick.
+        loadTasks: async () => {
+          loadCalls += 1
+          if (loadCalls === 1) {
+            return [task({ id: 'dddd0004', cron: '0 * * * *' })]
+          }
+          await gate
+          tickFinished = true
+          return []
+        },
+        enqueue: vi.fn(),
+      },
+      { minIntervalFloorMs: 1_000, dir: undefined },
+    )
+
+    sched.start()
+    await flush()
+
+    // Fire the armed wake; the tick enters loadTasks and parks on the gate.
+    clock.advance(12 * 60_000)
+    await flush()
+
+    sched.stop()
+
+    // drain() must NOT resolve while the tick is still parked.
+    let drained = false
+    const drainPromise = sched.drain().then(() => {
+      drained = true
+    })
+    await flush()
+    expect(drained).toBe(false)
+    expect(tickFinished).toBe(false)
+
+    // Release the tick; drain() now completes AFTER the tick finished.
+    releaseTick()
+    await drainPromise
+    expect(tickFinished).toBe(true)
+  })
 })

--- a/runtime/tests/llm/discovery/provider-discovery.test.ts
+++ b/runtime/tests/llm/discovery/provider-discovery.test.ts
@@ -118,9 +118,17 @@ describe("provider discovery", () => {
     });
     const entries = byProvider(report.entries);
 
-    expect(entries.get("openai")).toMatchObject({
+    // Managed subscription vending is OpenRouter-only (b461d139 "use
+    // OpenRouter for managed Pro models"); previously-managed providers such
+    // as openai now surface as plain BYOK-missing rows.
+    expect(entries.get("openrouter")).toMatchObject({
       usable: true,
       keyStatus: "managed",
+      subscriptionTier: "team",
+    });
+    expect(entries.get("openai")).toMatchObject({
+      usable: false,
+      keyStatus: "missing",
       subscriptionTier: "team",
     });
     expect(entries.get("agenc")).toMatchObject({
@@ -128,7 +136,8 @@ describe("provider discovery", () => {
       keyStatus: "not-required",
       subscriptionTier: "team",
     });
-    expect(calls).toContain("openai:cli");
+    expect(calls).toContain("openrouter:cli");
+    expect(calls).not.toContain("openai:cli");
   });
 
   it("uses runtime local-provider env resolution for probe URLs", async () => {

--- a/runtime/tests/llm/models-manager.test.ts
+++ b/runtime/tests/llm/models-manager.test.ts
@@ -127,11 +127,15 @@ describe("StaticModelsManager", () => {
     });
 
     const listed = await manager.listModels();
+    // Seed routes follow the curated managed Pro set (b461d139 "use OpenRouter
+    // for managed Pro models" replaced the original gpt-5-mini/grok-code-fast-1
+    // seeds with this catalog).
     expect(listed.map((entry) => entry.slug)).toEqual(
       expect.arrayContaining([
+        "x-ai/grok-4.3",
         "openai/gpt-5",
-        "openai/gpt-5-mini",
-        "x-ai/grok-code-fast-1",
+        "anthropic/claude-haiku-4.5",
+        "openai/gpt-oss-120b",
       ]),
     );
   });

--- a/runtime/tests/llm/provider-parity.test.ts
+++ b/runtime/tests/llm/provider-parity.test.ts
@@ -71,6 +71,36 @@ const ECHO_TOOL: LLMTool = {
   },
 };
 
+/**
+ * Wire form of `system.echo` under the bijective MCP tool-name encoding
+ * (src/llm/wire/mcp-tool-naming.ts). The strict-regex providers reject
+ * dotted function names, so the shared wire shims (chat-completions,
+ * responses-openai/xai, messages-anthropic) encode the internal dotted
+ * name on the request and decode the provider's echoed name back before
+ * dispatch. The literal is hardcoded on purpose: this suite pins the wire
+ * contract instead of round-tripping through the encoder.
+ *
+ * Gemini, Bedrock, and Ollama use their own converters that pass tool
+ * names through unencoded, so their wire form stays `system.echo`.
+ */
+const ECHO_TOOL_WIRE_NAME = "tool2__system_x2eecho";
+const PASSTHROUGH_WIRE_PROVIDERS: ReadonlySet<ProviderName> = new Set([
+  "ollama",
+  "gemini",
+  "amazon-bedrock",
+]);
+
+/**
+ * Real providers echo `function.name` back in tool-call responses exactly
+ * as it appeared on the wire request. The mocked payloads must do the
+ * same (encoded form for the strict-regex providers) so the runtime's
+ * decode path is genuinely exercised — the response-side assertions in
+ * `assertToolCalls` expect the DECODED dotted name.
+ */
+function encodedWireToolCallName(name: string): string {
+  return name === "system.echo" ? ECHO_TOOL_WIRE_NAME : name;
+}
+
 const BASE_USAGE = {
   promptTokens: 11,
   completionTokens: 3,
@@ -190,7 +220,10 @@ const CANONICAL_PROMPTS: readonly CanonicalPromptCase[] = [
   {
     id: "tool-call-only",
     messages: [{ role: "user", content: "PARITY::tool-call-only" }],
-    requestMarkers: ["PARITY::tool-call-only", "system.echo"],
+    // The wire tool name differs per provider family (encoded vs
+    // pass-through), so it is asserted per provider below rather than as a
+    // shared marker here.
+    requestMarkers: ["PARITY::tool-call-only"],
     tools: [ECHO_TOOL],
     expected: {
       content: "",
@@ -206,7 +239,7 @@ const CANONICAL_PROMPTS: readonly CanonicalPromptCase[] = [
   {
     id: "tool-call-with-text",
     messages: [{ role: "user", content: "PARITY::tool-call-with-text" }],
-    requestMarkers: ["PARITY::tool-call-with-text", "system.echo"],
+    requestMarkers: ["PARITY::tool-call-with-text"],
     tools: [ECHO_TOOL],
     expected: {
       content: "Need system.echo before answering.",
@@ -341,7 +374,7 @@ function buildResponsesApiPayload(
       type: "function_call",
       id: `fc_${parityCase.id}_${index}`,
       call_id: `call_${parityCase.id}_${index}`,
-      name: toolCall.name,
+      name: encodedWireToolCallName(toolCall.name),
       arguments: toolCall.arguments,
     })),
   );
@@ -378,7 +411,7 @@ function buildChatCompletionsPayload(
                 id: `call_${parityCase.id}_${index}`,
                 type: "function",
                 function: {
-                  name: toolCall.name,
+                  name: encodedWireToolCallName(toolCall.name),
                   arguments: toolCall.arguments,
                 },
               })),
@@ -450,7 +483,7 @@ function buildAnthropicPayload(
     ...parityCase.expected.toolCalls.map((toolCall, index) => ({
       type: "tool_use",
       id: `toolu_${parityCase.id}_${index}`,
-      name: toolCall.name,
+      name: encodedWireToolCallName(toolCall.name),
       input: JSON.parse(toolCall.arguments) as Record<string, unknown>,
     })),
   );
@@ -927,7 +960,14 @@ describe("provider parity", () => {
           expect(serializedRequest).toContain(marker);
         }
         if ((parityCase.tools?.length ?? 0) > 0) {
-          expect(serializedRequest).toContain("system.echo");
+          if (PASSTHROUGH_WIRE_PROVIDERS.has(entry.provider)) {
+            expect(serializedRequest).toContain("system.echo");
+          } else {
+            // Strict-regex providers must receive the bijectively encoded
+            // name, and the raw dotted form must not leak onto the wire.
+            expect(serializedRequest).toContain(ECHO_TOOL_WIRE_NAME);
+            expect(serializedRequest).not.toContain("system.echo");
+          }
         }
       },
     );

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -663,11 +663,14 @@ describe("buildAnthropicMessagesRequest", () => {
     });
 
     expect(request.tools).toHaveLength(2);
+    // `system.echo` ships in its bijectively encoded wire form
+    // (mcp-tool-naming.ts) because Anthropic enforces
+    // `^[a-zA-Z0-9_-]{1,64}$` on tool names. Literal pinned on purpose.
     expect(
       (request.tools as Array<Record<string, unknown>>).map(
         (tool) => tool.name,
       ),
-    ).toEqual(["system.echo", ANTHROPIC_STRUCTURED_OUTPUT_TOOL_NAME]);
+    ).toEqual(["tool2__system_x2eecho", ANTHROPIC_STRUCTURED_OUTPUT_TOOL_NAME]);
     expect(request.tool_choice).toBeUndefined();
   });
 

--- a/runtime/tests/llm/wire/responses-xai.test.ts
+++ b/runtime/tests/llm/wire/responses-xai.test.ts
@@ -9,6 +9,11 @@ import {
   XAI_ENCRYPTED_REASONING_INCLUDE,
 } from "./responses-xai.js";
 
+// Wire form of `system.echo` under the bijective MCP tool-name encoding
+// (mcp-tool-naming.ts) — xAI enforces `^[a-zA-Z0-9_-]{1,64}$` on function
+// names. Hardcoded literal on purpose so this test pins the wire contract.
+const TEST_TOOL_WIRE_NAME = "tool2__system_x2eecho";
+
 const TEST_TOOL: LLMTool = {
   type: "function",
   function: {
@@ -55,7 +60,7 @@ describe("responses-xai wire shim", () => {
         {
           type: "function_call",
           call_id: "call_echo",
-          name: "system.echo",
+          name: TEST_TOOL_WIRE_NAME,
           arguments: "{\"text\":\"hi\"}",
         },
         {
@@ -258,6 +263,12 @@ describe("responses-xai wire shim", () => {
       prompt_cache_key: "session-1",
       include: [XAI_ENCRYPTED_REASONING_INCLUDE],
       parallel_tool_calls: false,
+      // NOTE: tool_choice is currently NOT run through the MCP wire-name
+      // encoding (normalizeXaiResponsesToolChoice passes the name through),
+      // so a named tool_choice for a dotted tool references a name the
+      // provider never saw in `tools`. This pins today's behavior; if the
+      // shim starts encoding tool_choice too, update this to
+      // TEST_TOOL_WIRE_NAME.
       tool_choice: {
         type: "function",
         function: { name: "system.echo" },
@@ -265,7 +276,7 @@ describe("responses-xai wire shim", () => {
       tools: [
         {
           type: "function",
-          name: "system.echo",
+          name: TEST_TOOL_WIRE_NAME,
           description: "Echo text.",
         },
       ],

--- a/runtime/tests/llm/wire/tools.test.ts
+++ b/runtime/tests/llm/wire/tools.test.ts
@@ -27,13 +27,19 @@ const TOOL: LLMTool = {
   },
 };
 
+// Providers enforce `^[a-zA-Z0-9_-]{1,64}$` on function names, so the wire
+// layer bijectively encodes the dotted internal name (mcp-tool-naming.ts).
+// The literal is hardcoded on purpose: these tests pin the wire contract
+// rather than round-tripping through the encoder.
+const TOOL_WIRE_NAME = "tool2__system_x2einspect";
+
 describe("wire tool conversion", () => {
   test("preserves prompt-derived descriptions for chat completions tools", () => {
     expect(toChatCompletionsTools([TOOL])).toEqual([
       {
         type: "function",
         function: {
-          name: "system.inspect",
+          name: TOOL_WIRE_NAME,
           description:
             "Inspect the current project state and return a concise structured summary.",
           parameters: TOOL.function.parameters,
@@ -46,7 +52,7 @@ describe("wire tool conversion", () => {
     const expected = [
       {
         type: "function",
-        name: "system.inspect",
+        name: TOOL_WIRE_NAME,
         description:
           "Inspect the current project state and return a concise structured summary.",
         parameters: TOOL.function.parameters,
@@ -60,7 +66,7 @@ describe("wire tool conversion", () => {
   test("maps tools to the Messages input_schema envelope", () => {
     expect(toAnthropicTools([TOOL])).toEqual([
       {
-        name: "system.inspect",
+        name: TOOL_WIRE_NAME,
         description:
           "Inspect the current project state and return a concise structured summary.",
         input_schema: TOOL.function.parameters,

--- a/runtime/tests/tools/ScheduleCronTool.execution.test.ts
+++ b/runtime/tests/tools/ScheduleCronTool.execution.test.ts
@@ -23,7 +23,7 @@ async function setTempProjectRoot(): Promise<void> {
 }
 
 afterEach(async () => {
-  resetCronSchedulerForTests()
+  await resetCronSchedulerForTests()
   resetStateForTests()
   if (tempRoot) {
     await rm(tempRoot, { recursive: true, force: true })

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -3274,6 +3274,11 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       setPendingProviderSwitch: vi.fn(),
     };
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-app-"));
+    // Isolate AGENC_HOME: a real ~/.agenc/auth.json (hosted managed session)
+    // would reorder the onboarding provider menu and swap the API-key step
+    // for the hosted-access path, breaking the scripted anonymous flow.
+    const previousAgencHome = process.env.AGENC_HOME;
+    process.env.AGENC_HOME = agencHome;
     providerProbe.promptSubmits.length = 0;
     try {
       const helpers = {
@@ -3319,6 +3324,11 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         },
       );
     } finally {
+      if (previousAgencHome === undefined) {
+        delete process.env.AGENC_HOME;
+      } else {
+        process.env.AGENC_HOME = previousAgencHome;
+      }
       rmSync(agencHome, { recursive: true, force: true });
     }
   });
@@ -3331,6 +3341,10 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       setPendingProviderSwitch: vi.fn(),
     };
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-app-"));
+    // Isolate AGENC_HOME: a real ~/.agenc/auth.json (hosted managed session)
+    // would replace the BYOK API-key step with the hosted-access path.
+    const previousAgencHome = process.env.AGENC_HOME;
+    process.env.AGENC_HOME = agencHome;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ data: [] }), { status: 200 }),
     );
@@ -3375,6 +3389,11 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       );
     } finally {
       fetchSpy.mockRestore();
+      if (previousAgencHome === undefined) {
+        delete process.env.AGENC_HOME;
+      } else {
+        process.env.AGENC_HOME = previousAgencHome;
+      }
       rmSync(agencHome, { recursive: true, force: true });
     }
   });

--- a/runtime/tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
@@ -8,6 +8,7 @@ const authHarness = vi.hoisted(() => {
     authEnabled: true,
     key: undefined as string | undefined,
     nonInteractive: false,
+    remoteSession: false,
     source: undefined as string | undefined,
     subscriber: false,
   }
@@ -25,6 +26,7 @@ const authHarness = vi.hoisted(() => {
       state.authEnabled = true
       state.key = undefined
       state.nonInteractive = false
+      state.remoteSession = false
       state.source = undefined
       state.subscriber = false
       this.getApiKeyFromApiKeyHelper.mockClear()
@@ -43,6 +45,14 @@ vi.mock('../../../src/bootstrap/state', async importOriginal => ({
 
 vi.mock('../../../src/services/api/anthropic', () => ({
   verifyApiKey: authHarness.verifyApiKey,
+}))
+
+// The hook treats a live hosted (remote) auth session as already-valid and
+// never touches the anthropic key sources. Keep it harness-controlled so the
+// tests are hermetic against the developer's real ~/.agenc/auth.json.
+vi.mock('../../../src/auth/session-state', async importOriginal => ({
+  ...(await importOriginal()),
+  hasRemoteAuthSessionSync: () => authHarness.state.remoteSession,
 }))
 
 vi.mock('../../../src/utils/auth.js', () => ({
@@ -187,6 +197,10 @@ describe('useApiKeyVerification coverage swarm row 089', () => {
     {
       name: 'subscriber auth',
       patch: { subscriber: true },
+    },
+    {
+      name: 'remote auth session',
+      patch: { remoteSession: true },
     },
   ])('treats $name as already valid', async ({ patch }) => {
     Object.assign(authHarness.state, patch)

--- a/runtime/tests/tui/coverage-swarm/swarm-109-hooks-useCancelRequest.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-109-hooks-useCancelRequest.test.ts
@@ -66,6 +66,8 @@ vi.mock('src/tui/context/notifications', () => ({
 
 vi.mock('src/tui/context/overlayContext', () => ({
   useIsOverlayActive: () => fixture.overlayActive,
+  // the hook's Escape guard now keys off the modal-only variant
+  useIsModalOverlayActive: () => fixture.overlayActive,
 }))
 
 vi.mock('src/tui/hooks/useCommandQueue', () => ({
@@ -87,6 +89,11 @@ vi.mock('src/tui/keybindings/useKeybinding.js', () => ({
       isActive: options?.isActive,
     })
   },
+  // useCancelRequest also registers a raw urgent-cancel input capture;
+  // these tests drive handlers through fixture.keybindings, so a no-op
+  // capture is sufficient (without it the module mock is missing an
+  // export and the hook render throws before registering any binding).
+  useInputCapture: () => {},
 }))
 
 vi.mock('src/tui/state/teammateViewHelpers', () => ({
@@ -214,7 +221,7 @@ describe('CancelRequestHandler coverage swarm 109', () => {
     expect(fixture.onCancel).toHaveBeenCalledTimes(1)
   })
 
-  test('context guards deactivate Escape while keeping Ctrl+C available for an active turn', async () => {
+  test('Escape and Ctrl+C both stay available for an active turn in bash mode with empty input', async () => {
     const abortController = new AbortController()
 
     await renderHandler({
@@ -223,7 +230,9 @@ describe('CancelRequestHandler coverage swarm 109', () => {
       inputValue: '',
     })
 
-    expect(getKeybinding('chat:cancel').isActive).toBe(false)
+    // An active turn overrides the Escape-to-mode-exit deferral so the user
+    // can always interrupt AgenC (98af9cb21 / 2af458c7e).
+    expect(getKeybinding('chat:cancel').isActive).toBe(true)
     expect(getKeybinding('app:interrupt').isActive).toBe(true)
 
     getKeybinding('app:interrupt').handler()
@@ -234,18 +243,52 @@ describe('CancelRequestHandler coverage swarm 109', () => {
     )
   })
 
+  test('Escape defers to mode exit while idle in bash mode, keeping Ctrl+C for the queue', async () => {
+    fixture.queuedCommandsLength = 1
+    fixture.hasCommandsInQueue = true
+
+    await renderHandler({
+      inputMode: 'bash',
+      inputValue: '',
+    })
+
+    // Without an active turn, Escape exits the special input mode
+    // (PromptInput handles it) even though a command is queued; Ctrl+C is
+    // unaffected by the mode-exit deferral and can still manage the queue.
+    expect(getKeybinding('chat:cancel').isActive).toBe(false)
+    expect(getKeybinding('app:interrupt').isActive).toBe(true)
+  })
+
   test.each([
-    ['transcript screen', { screen: 'transcript' as const }],
     ['history search', { isSearchingHistory: true }],
     ['message selector', { isMessageSelectorVisible: true }],
     ['local JSX command', { isLocalJSXCommand: true }],
     ['help dialog', { isHelpOpen: true }],
     ['overlay', {}, true],
-    ['vim insert mode', { vimMode: 'INSERT' as const }, false, true],
   ])(
     'deactivates cancel keybindings while %s handles Escape',
-    async (_name, overrides, overlayActive = false, vimEnabled = false) => {
+    async (_name, overrides, overlayActive = false) => {
       fixture.overlayActive = overlayActive
+      const abortController = new AbortController()
+
+      await renderHandler({
+        abortSignal: abortController.signal,
+        ...overrides,
+      })
+
+      expect(getKeybinding('chat:cancel').isActive).toBe(false)
+      expect(getKeybinding('app:interrupt').isActive).toBe(false)
+    },
+  )
+
+  // transcript screen and vim INSERT only claim Escape while AgenC is idle;
+  // during an active turn the interrupt keys stay live (98af9cb21).
+  test.each([
+    ['transcript screen', { screen: 'transcript' as const }, false],
+    ['vim insert mode', { vimMode: 'INSERT' as const }, true],
+  ])(
+    'keeps cancel keybindings active during an active turn despite %s',
+    async (_name, overrides, vimEnabled) => {
       fixture.vimEnabled = vimEnabled
       const abortController = new AbortController()
 
@@ -253,6 +296,23 @@ describe('CancelRequestHandler coverage swarm 109', () => {
         abortSignal: abortController.signal,
         ...overrides,
       })
+
+      expect(getKeybinding('chat:cancel').isActive).toBe(true)
+      expect(getKeybinding('app:interrupt').isActive).toBe(true)
+    },
+  )
+
+  test.each([
+    ['transcript screen', { screen: 'transcript' as const }, false],
+    ['vim insert mode', { vimMode: 'INSERT' as const }, true],
+  ])(
+    'defers cancel keybindings to %s while idle even with queued commands',
+    async (_name, overrides, vimEnabled) => {
+      fixture.vimEnabled = vimEnabled
+      fixture.queuedCommandsLength = 1
+      fixture.hasCommandsInQueue = true
+
+      await renderHandler(overrides)
 
       expect(getKeybinding('chat:cancel').isActive).toBe(false)
       expect(getKeybinding('app:interrupt').isActive).toBe(false)

--- a/runtime/tests/tui/hooks/useApiKeyVerification.test.tsx
+++ b/runtime/tests/tui/hooks/useApiKeyVerification.test.tsx
@@ -82,6 +82,15 @@ test('useApiKeyVerification resets stale missing status when the session switche
     verifyApiKey: async () => true,
   }))
 
+  // A live hosted (remote) auth session short-circuits the hook to 'valid'
+  // before it ever consults the anthropic key sources. Pin it to absent so
+  // this test is hermetic against the developer's real ~/.agenc/auth.json.
+  const actualSessionState = await import('../../../src/auth/session-state.js')
+  mock.module('../../../src/auth/session-state.js', () => ({
+    ...actualSessionState,
+    hasRemoteAuthSessionSync: () => false,
+  }))
+
   // @ts-expect-error cache-busting query string for Bun module mocks
   const { useApiKeyVerification } = await import(
     '../../../src/tui/hooks/useApiKeyVerification.ts'

--- a/runtime/tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx
@@ -44,6 +44,14 @@ vi.mock('../../services/api/anthropic', () => ({
   verifyApiKey: authHarness.verifyApiKey,
 }))
 
+// A live hosted (remote) auth session short-circuits the hook to 'valid'.
+// Pin it to absent so these tests stay hermetic against the developer's
+// real ~/.agenc/auth.json and keep exercising the anthropic key path.
+vi.mock('../../auth/session-state', async importOriginal => ({
+  ...(await importOriginal()),
+  hasRemoteAuthSessionSync: () => false,
+}))
+
 vi.mock('../../utils/auth.js', () => ({
   getAnthropicApiKeyWithSource: authHarness.getAnthropicApiKeyWithSource,
   getApiKeyFromApiKeyHelper: authHarness.getApiKeyFromApiKeyHelper,

--- a/runtime/tests/tui/hooks/useCancelRequest.wave200-149.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useCancelRequest.wave200-149.coverage.test.tsx
@@ -63,6 +63,8 @@ vi.mock('../context/notifications', () => ({
 
 vi.mock('../context/overlayContext', () => ({
   useIsOverlayActive: () => fixture.overlayActive,
+  // the hook's Escape guard now keys off the modal-only variant
+  useIsModalOverlayActive: () => fixture.overlayActive,
 }))
 
 vi.mock('./useCommandQueue', () => ({
@@ -84,6 +86,11 @@ vi.mock('../keybindings/useKeybinding.js', () => ({
       isActive: options?.isActive,
     })
   },
+  // useCancelRequest also registers a raw urgent-cancel input capture;
+  // this test drives handlers through fixture.keybindings, so a no-op
+  // capture is sufficient (without it the module mock is missing an
+  // export and the hook render throws before registering any binding).
+  useInputCapture: () => {},
 }))
 
 vi.mock('../state/teammateViewHelpers', () => ({
@@ -165,7 +172,9 @@ describe('CancelRequestHandler teammate-view interrupt coverage', () => {
 
     const interrupt = getKeybinding('app:interrupt')
     expect(interrupt.isActive).toBe(true)
-    expect(getKeybinding('chat:cancel').isActive).toBe(false)
+    // The active turn overrides the Escape-to-teammate-navigation deferral so
+    // the user can always interrupt AgenC (98af9cb21 / 2af458c7e).
+    expect(getKeybinding('chat:cancel').isActive).toBe(true)
 
     interrupt.handler()
 
@@ -211,5 +220,33 @@ describe('CancelRequestHandler teammate-view interrupt coverage', () => {
       expect.any(Function),
     )
     expect(fixture.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test('Escape defers to teammate navigation while idle; Ctrl+C still stops agents and exits', async () => {
+    const { CancelRequestHandler } = await import('./useCancelRequest.js')
+
+    // No abortSignal: AgenC is idle, so Escape is left for
+    // useBackgroundTaskNavigation even though stoppable agents exist.
+    await renderToString(
+      <CancelRequestHandler
+        setToolUseConfirmQueue={fixture.setToolUseConfirmQueue}
+        onCancel={fixture.onCancel}
+        onAgentsKilled={fixture.onAgentsKilled}
+        isMessageSelectorVisible={false}
+        screen="prompt"
+      />,
+      100,
+    )
+
+    expect(getKeybinding('chat:cancel').isActive).toBe(false)
+    const interrupt = getKeybinding('app:interrupt')
+    expect(interrupt.isActive).toBe(true)
+
+    interrupt.handler()
+
+    expect(fixture.killAllRunningAgentTasks).toHaveBeenCalledTimes(1)
+    expect(fixture.exitTeammateView).toHaveBeenCalledWith(expect.any(Function))
+    // No active turn and no queue: nothing to cancel on the main thread.
+    expect(fixture.onCancel).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Task 27 — suite hygiene: red main → green

Clean-worktree baseline at post-#1384 main: **68 failing tests across 18 files** (+1 bun file, +1 unhandled rejection). Local gates are the only CI; a red main masks regressions in every PR. Every failure was root-caused (stale-test vs real-bug vs non-hermetic) before any test was touched.

### Verdict map
| Cluster | Count | Verdict | Root cause |
|---|---|---|---|
| provider-parity + wire (tools/xai/anthropic) | 30 | stale tests | deliberate bijective tool-name encoding `6039cc2f7` |
| cancel-guard TUI hooks (swarm-109, wave200-149) | 13 | stale mocks + stale expectations | `2af458c7e`/`98af9cb21` interrupt-reliability guards |
| useApiKeyVerification (vitest+bun) | 9 | **non-hermetic** | hook reads the real `~/.agenc/auth.json` (live session on this machine) |
| auth/managed-key surface | 16 | stale tests + 2 env-contaminated | OpenRouter-only managed routing `e4a54ec1f`/`b461d1397` |
| sdk-client contract | 1 | sibling drift | `session.transcript` added to sibling agenc-sdk (committed there) |

**Drive-by source fix:** `CronScheduler.stop()` left the in-flight tick running → teardown raced its `scheduled_tasks.json` write (the suite's unhandled ENOENT rejection). Added tracked `lastTick` + `drain()`; `resetCronSchedulerForTests()` now drains. Revert-sensitive test (fails against main's scheduler, passes with fix — verified red/green).

**Coverage preserved, not weakened:** +7 new pin tests (idle-side cancel guards, remote-session short-circuit, managed-keys hint). No `test.skip`, no `@ts-nocheck`.

**New defects filed in TODO instead of papered over:** task 29 (named toolChoice never encoded on strict wires), task 30 (suite env hermeticity + daemon tests were doing a REAL device-code login against production id.agenc.ag, which auto-approves mock codes — flagged for the identity-service owner), task 31 (03-subagent-completion TUI e2e times out on pure main — verified pre-existing via a main-source rebuild A/B).

### Gates
- `npm run build` ✅ · `npm run typecheck` ✅ (0 errors)
- full vitest: **13,871 passed / 0 failed / exit 0**, no unhandled errors (baseline: 68 failed)
- `npm run test:bun`: 86 files, 0 failed (baseline: 1)
- TUI runtime startup smoke ✅

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES