### PR TITLE
feat(runtime): session-start memory recall + schema-driven StructuredOutput visibility

### DIFF
--- a/runtime/src/bin/bootstrap-tool-registry.ts
+++ b/runtime/src/bin/bootstrap-tool-registry.ts
@@ -38,6 +38,9 @@ export function buildBootstrapToolRegistry(
     ...(options.toolRegistryOptions?.toolsConfig !== undefined
       ? { toolsConfig: options.toolRegistryOptions.toolsConfig }
       : {}),
+    ...(options.toolRegistryOptions?.outputSchema !== undefined
+      ? { outputSchema: options.toolRegistryOptions.outputSchema }
+      : {}),
   });
   return buildToolRegistry({
     workspaceRoot: options.workspaceRoot,

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -62,7 +62,10 @@ import { ensureAgentControl } from "./delegate-tool.js";
 import { createMultiAgentV2Tools } from "../agents/v2/index.js";
 import { loadMarkdownAgentRoles } from "../agents/role.js";
 import { createTaskTools } from "../tools/tasks/index.js";
-import { createStructuredOutputTool } from "./structured-output-tool.js";
+import {
+  createStructuredOutputTool,
+  createStructuredOutputToolForSchema,
+} from "./structured-output-tool.js";
 import { isPreapprovedHost } from "./web-fetch-preapproved.js";
 import { createRequestUserInputTool } from "../elicitation/request-user-input.js";
 import { getRuleByContentsForTool } from "../permissions/rules.js";
@@ -91,6 +94,14 @@ export interface ModelFacingToolOptions {
   }) => void;
   readonly env?: NodeJS.ProcessEnv;
   readonly providerFactory?: typeof createProvider;
+  /**
+   * Session-configured structured-output JSON schema. When present, the
+   * StructuredOutput tool is registered schema-bound and non-deferred so
+   * programmatic callers that start a session with an output schema see it
+   * without a tool-search round-trip. When absent, the passthrough tool
+   * stays deferred (discoverable only).
+   */
+  readonly outputSchema?: Record<string, unknown>;
   /** `[tools]` block from config.toml (env vars win over these). */
   readonly toolsConfig?: {
     readonly web_search_endpoint?: string;
@@ -3044,6 +3055,24 @@ export function createModelFacingTools(
     ...createCronAndWorkflowTools(opts),
     createRemoteTriggerTool(opts),
     ...createPowerShellTool(opts),
-    createStructuredOutputTool(),
+    createSessionStructuredOutputTool(opts),
   ];
+}
+
+/**
+ * StructuredOutput registration policy: schema-bound + visible when the
+ * session was configured with an output schema, deferred passthrough
+ * otherwise. An uncompilable schema falls back to the deferred passthrough
+ * tool with a warning rather than dropping the tool.
+ */
+function createSessionStructuredOutputTool(opts: ModelFacingToolOptions): Tool {
+  if (opts.outputSchema !== undefined) {
+    const built = createStructuredOutputToolForSchema(opts.outputSchema);
+    if ("tool" in built) return built.tool;
+    opts.emitWarning?.({
+      cause: "structured_output_schema_invalid",
+      message: `session output schema failed to compile; registering the deferred passthrough StructuredOutput tool instead: ${built.error}`,
+    });
+  }
+  return createStructuredOutputTool();
 }

--- a/runtime/src/bin/structured-output-tool.ts
+++ b/runtime/src/bin/structured-output-tool.ts
@@ -21,13 +21,13 @@ export const STRUCTURED_OUTPUT_TOOL_NAME = "StructuredOutput";
 const STRUCTURED_OUTPUT_DESCRIPTION =
   "Return your final response in the requested structured format. Call this tool exactly once at the end of your response to provide the structured output. The runtime validates the payload against the configured JSON schema (when one is bound) and surfaces any schema-mismatch errors back to you so you can correct the shape and retry.";
 
-function toolMetadata(): Tool["metadata"] {
+function toolMetadata(opts?: { readonly visible?: boolean }): Tool["metadata"] {
   return {
     family: "structured",
     source: "builtin",
     hiddenByDefault: false,
     mutating: false,
-    deferred: true,
+    deferred: opts?.visible !== true,
     keywords: ["structured", "output", "schema", "json"],
     preferredProfiles: ["coding", "operator", "general"],
   };
@@ -56,12 +56,19 @@ function formatSchemaErrors(validate: ValidateFunction): string {
  * `structured_output`. Registered into the catalog so the model has a
  * default name to call when the harness has not bound a specific
  * schema.
+ *
+ * Deferred by default (discoverable via tool search). Pass
+ * `visible: true` when the session is configured with an output schema so
+ * the tool is advertised immediately — programmatic/SDK callers that start
+ * a session WITH a schema must not need a discovery round-trip.
  */
-export function createStructuredOutputTool(): Tool {
+export function createStructuredOutputTool(opts?: {
+  readonly visible?: boolean;
+}): Tool {
   return {
     name: STRUCTURED_OUTPUT_TOOL_NAME,
     description: STRUCTURED_OUTPUT_DESCRIPTION,
-    metadata: toolMetadata(),
+    metadata: toolMetadata(opts),
     isReadOnly: true,
     recoveryCategory: "idempotent",
     inputSchema: {
@@ -94,8 +101,10 @@ export function createStructuredOutputToolForSchema(
     return result;
   }
 
+  // A bound schema means the session explicitly asked for structured
+  // output, so the schema-bound tool is always advertised (non-deferred).
   const tool: Tool = {
-    ...createStructuredOutputTool(),
+    ...createStructuredOutputTool({ visible: true }),
     inputSchema: schema,
     execute: async (args) => {
       if (!validate(args)) {

--- a/runtime/src/prompts/attachments/relevant-memories.ts
+++ b/runtime/src/prompts/attachments/relevant-memories.ts
@@ -5,6 +5,14 @@
  * to the current turn, reads a bounded prefix of each selected file, and emits
  * them as `relevant_memories` user-context attachments. Rendering owns the
  * trust boundary; this producer owns selection, read bounds, and session dedupe.
+ *
+ * Two selection paths share the same budgets and dedupe state:
+ *   - query-gated (every turn): a non-empty multi-word user prompt drives a
+ *     model-side relevance selection (`findRelevantMemories`);
+ *   - session-start (first producer run only, main thread only): when turn 0
+ *     carries no substantive query, memories are selected by project/CWD
+ *     signals — no model calls, header scans only — so sessions opened
+ *     programmatically still start with project-relevant recall.
  */
 
 import { join, normalize, sep } from "node:path";
@@ -15,6 +23,8 @@ import {
   isAutoMemoryEnabled,
   MEMORY_DIRNAME,
   PROJECT_MEMORY_DIR,
+  scanMemoryFiles,
+  type MemoryHeader,
 } from "../../memory/index.js";
 import { readFileInRange } from "../../utils/readFileInRange.js";
 import type { AttachmentProducer } from "./orchestrator.js";
@@ -44,17 +54,32 @@ export const relevantMemoriesProducer: AttachmentProducer = async (
   }
 
   const query = opts.userInput?.trim() ?? "";
-  if (!query || !/\s/.test(query)) return [];
+  const hasSubstantiveQuery = query.length > 0 && /\s/.test(query);
+  // Session-start recall is a one-shot: it may only fire on the first
+  // producer run of the session, and only when the query-gated path will
+  // not fire that turn (so a substantive turn-0 prompt never double-injects).
+  const isFirstProducerRun = !trackingState.sessionStartMemoryRecallChecked;
+  trackingState.sessionStartMemoryRecallChecked = true;
+  if (!hasSubstantiveQuery && !isFirstProducerRun) return [];
 
   const dirs = getDurableMemorySearchDirs(opts.agencHome, opts.cwd);
   if (dirs.length === 0) return [];
 
-  const selected = await selectRelevantMemories(
-    query,
-    dirs,
-    opts.signal,
-    trackingState.surfacedRelevantMemoryPaths,
-  );
+  const selected = hasSubstantiveQuery
+    ? await selectRelevantMemories(
+        query,
+        dirs,
+        opts.signal,
+        trackingState.surfacedRelevantMemoryPaths,
+      )
+    : opts.subagentDepth === 0
+      ? await selectSessionStartMemories(
+          opts.cwd,
+          dirs,
+          opts.signal,
+          trackingState.surfacedRelevantMemoryPaths,
+        )
+      : [];
   if (selected.length === 0) return [];
 
   const remainingBytes =
@@ -119,6 +144,86 @@ async function selectRelevantMemories(
     if (selectedByPath.size >= MAX_MEMORIES_PER_TURN) break;
   }
   return [...selectedByPath.values()];
+}
+
+/**
+ * Session-start selection: pick memories by project/CWD signals instead of
+ * a user query. Runs once per session (main thread only), on the first
+ * producer invocation without a substantive query. Deliberately cheap —
+ * frontmatter-header scans only, no model calls:
+ *   - project-memory-dir files are project-relevant by construction and
+ *     rank first (newest-first, the scan order);
+ *   - global-memory-dir files qualify only when their filename or
+ *     description mentions a project signal token derived from the cwd.
+ */
+async function selectSessionStartMemories(
+  cwd: string,
+  dirs: readonly string[],
+  signal: AbortSignal,
+  alreadySurfaced: ReadonlySet<string>,
+): Promise<SelectedMemory[]> {
+  const projectDir = normalizeDir(join(cwd, PROJECT_MEMORY_DIR, MEMORY_DIRNAME));
+  const tokens = projectSignalTokens(cwd);
+  const perDir = await Promise.all(
+    dirs.map(async (dir) => ({
+      dir,
+      headers: await scanMemoryFiles(dir, signal).catch(() => []),
+    })),
+  );
+  const ranked: MemoryHeader[] = [
+    ...perDir
+      .filter(({ dir }) => dir === projectDir)
+      .flatMap(({ headers }) => headers),
+    ...perDir
+      .filter(({ dir }) => dir !== projectDir)
+      .flatMap(({ headers }) =>
+        headers.filter((header) => matchesProjectSignals(header, tokens)),
+      ),
+  ];
+  const selectedByPath = new Map<string, SelectedMemory>();
+  for (const header of ranked) {
+    if (alreadySurfaced.has(header.filePath)) continue;
+    if (!selectedByPath.has(header.filePath)) {
+      selectedByPath.set(header.filePath, {
+        path: header.filePath,
+        mtimeMs: header.mtimeMs,
+      });
+    }
+    if (selectedByPath.size >= MAX_MEMORIES_PER_TURN) break;
+  }
+  return [...selectedByPath.values()];
+}
+
+/**
+ * Project signal tokens from the workspace cwd: the last two path segments
+ * (repo dir + its parent) plus their alphanumeric sub-tokens. Lowercased;
+ * short fragments are dropped to limit accidental matches.
+ */
+function projectSignalTokens(cwd: string): readonly string[] {
+  const segments = normalize(cwd)
+    .split(sep)
+    .filter((segment) => segment.length > 0)
+    .slice(-2);
+  const tokens = new Set<string>();
+  for (const segment of segments) {
+    const lower = segment.normalize("NFC").toLowerCase();
+    if (lower.length >= 3) tokens.add(lower);
+    for (const part of lower.split(/[^a-z0-9]+/)) {
+      if (part.length >= 3) tokens.add(part);
+    }
+  }
+  return [...tokens];
+}
+
+function matchesProjectSignals(
+  header: MemoryHeader,
+  tokens: readonly string[],
+): boolean {
+  if (tokens.length === 0) return false;
+  const haystack = `${header.filename} ${header.description ?? ""}`
+    .normalize("NFC")
+    .toLowerCase();
+  return tokens.some((token) => haystack.includes(token));
 }
 
 async function readMemoriesForAttachment(

--- a/runtime/src/session/attachment-state.ts
+++ b/runtime/src/session/attachment-state.ts
@@ -109,6 +109,12 @@ export interface AttachmentTrackingState {
    */
   loadedNestedMemoryPaths: Set<string>;
   /**
+   * Flips true on the first `relevant_memories` producer run of the
+   * session. Gates the one-shot session-start recall path (project/CWD-
+   * keyed memory injection when turn 0 carries no substantive query).
+   */
+  sessionStartMemoryRecallChecked: boolean;
+  /**
    * Paths of learned memory files surfaced by `relevant_memories` in this
    * session. Relevant-memory recall is allowed to reset after compaction
    * in future, but a stable set prevents rapid same-session repeats today.
@@ -158,6 +164,7 @@ export function getAttachmentTrackingState(
       hasExitedAutoModeInSession: false,
       nestedMemoryAttachmentTriggers: new Set(),
       loadedNestedMemoryPaths: new Set(),
+      sessionStartMemoryRecallChecked: false,
       surfacedRelevantMemoryPaths: new Set(),
       surfacedRelevantMemoryBytes: 0,
       memoryMode: "enabled",

--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -526,6 +526,15 @@ export interface BuildToolRegistryOptions {
    * as `spawn_agent`.
    */
   readonly extraTools?: ReadonlyArray<Tool>;
+  /**
+   * Session-configured structured-output JSON schema. Consumed by the
+   * bootstrap model-facing tool assembly (`bin/bootstrap-tool-registry.ts`):
+   * when present, the StructuredOutput tool is registered schema-bound and
+   * non-deferred (visible without tool-search discovery); when absent, it
+   * stays a deferred passthrough. Carried here so SDK/programmatic callers
+   * can pass it through `toolRegistryOptions`.
+   */
+  readonly outputSchema?: Record<string, unknown>;
 }
 
 /**

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -485,6 +485,65 @@ describe("model-facing tools", () => {
     expect(lsp.description).toContain("index");
   });
 
+  it("exposes StructuredOutput without discovery when an output schema is configured", async () => {
+    const registry = buildBootstrapToolRegistry({
+      workspaceRoot: process.cwd(),
+      agencHome: join(tmpdir(), "agenc-tools-test"),
+      mcpManager: fakeMcpManager() as never,
+      getSession: () => null,
+      emitWarning: () => {},
+      toolRegistryOptions: {
+        outputSchema: {
+          type: "object",
+          properties: { verdict: { type: "string" } },
+          required: ["verdict"],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    const structuredOutput = registry.tools.find(
+      (tool) => tool.name === "StructuredOutput",
+    );
+    expect(structuredOutput?.metadata?.deferred).toBe(false);
+    const visibleNames = registry.toLLMTools().map((tool) => tool.function.name);
+    expect(visibleNames).toContain("StructuredOutput");
+
+    // The advertised tool is schema-bound, not the passthrough.
+    const invalid = await registry.dispatch({
+      id: "structured-output-invalid",
+      name: "StructuredOutput",
+      arguments: JSON.stringify({ wrong: true }),
+    });
+    expect(invalid.isError).toBe(true);
+    expect(invalid.content).toContain("does not match required schema");
+    const valid = await registry.dispatch({
+      id: "structured-output-valid",
+      name: "StructuredOutput",
+      arguments: JSON.stringify({ verdict: "ship it" }),
+    });
+    expect(valid.isError).toBeUndefined();
+    expect(JSON.parse(valid.content).structured_output).toEqual({
+      verdict: "ship it",
+    });
+  });
+
+  it("keeps StructuredOutput deferred when no output schema is configured", () => {
+    const registry = buildBootstrapToolRegistry({
+      workspaceRoot: process.cwd(),
+      agencHome: join(tmpdir(), "agenc-tools-test"),
+      mcpManager: fakeMcpManager() as never,
+      getSession: () => null,
+      emitWarning: () => {},
+    });
+
+    expect(registry.tools.map((tool) => tool.name)).toContain(
+      "StructuredOutput",
+    );
+    const visibleNames = registry.toLLMTools().map((tool) => tool.function.name);
+    expect(visibleNames).not.toContain("StructuredOutput");
+  });
+
   it("accepts max_concurrency and the upstream max_workers alias", async () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),

--- a/runtime/tests/bin/structured-output-tool.test.ts
+++ b/runtime/tests/bin/structured-output-tool.test.ts
@@ -13,6 +13,22 @@ describe("structured-output-tool", () => {
     expect(tool.metadata?.deferred).toBe(true);
   });
 
+  it("registers a visible (non-deferred) tool when requested", () => {
+    const tool = createStructuredOutputTool({ visible: true });
+    expect(tool.name).toBe(STRUCTURED_OUTPUT_TOOL_NAME);
+    expect(tool.metadata?.deferred).toBe(false);
+  });
+
+  it("schema-bound tool is always visible (non-deferred)", () => {
+    const built = createStructuredOutputToolForSchema({
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    });
+    if (!("tool" in built)) throw new Error("expected built tool");
+    expect(built.tool.metadata?.deferred).toBe(false);
+  });
+
   it("base tool echoes input as structured_output", async () => {
     const tool = createStructuredOutputTool();
     const result = await tool.execute({ kind: "bug", severity: "high" });

--- a/runtime/tests/prompts/attachments/relevant-memories.test.ts
+++ b/runtime/tests/prompts/attachments/relevant-memories.test.ts
@@ -173,6 +173,135 @@ describe("relevantMemoriesProducer", () => {
     }
   });
 
+  test("injects project/CWD-keyed memories on the first turn without a user query", async () => {
+    const projectMemoryDir = join(cwd, ".agenc", "memory");
+    const globalMemoryDir = join(agencHome, "memory");
+    const projectPath = writeMemory(
+      projectMemoryDir,
+      "build-notes.md",
+      "Build pipeline notes",
+      "Run the runtime build twice.",
+    );
+    const matchingGlobalPath = writeMemory(
+      globalMemoryDir,
+      "repo-conventions.md",
+      "Conventions for this workspace",
+      "Follow the workspace conventions.",
+    );
+    writeMemory(
+      globalMemoryDir,
+      "cooking.md",
+      "Slow braising technique",
+      "Simmer gently for hours.",
+    );
+    const trackingState = getAttachmentTrackingState({});
+
+    const out = await relevantMemoriesProducer(
+      makeOpts({ userInput: null }),
+      trackingState,
+    );
+
+    // Session-start recall must stay cheap: no model-side selection.
+    expect(sideQuery).not.toHaveBeenCalled();
+    expect(out).toHaveLength(1);
+    if (out[0]?.kind !== "relevant_memories") {
+      throw new Error("expected relevant_memories");
+    }
+    const paths = out[0].memories.map((memory) => memory.path);
+    // Project-memory-dir files rank first; global files qualify only via
+    // project signal tokens (cwd basename "repo" matches the filename).
+    expect(paths).toEqual([projectPath, matchingGlobalPath]);
+    expect(out[0].memories[0]?.content).toContain(
+      "Run the runtime build twice.",
+    );
+    expect(trackingState.surfacedRelevantMemoryPaths.has(projectPath)).toBe(
+      true,
+    );
+    expect(trackingState.surfacedRelevantMemoryBytes).toBeGreaterThan(0);
+  });
+
+  test("session-start recall fires only on the first producer run", async () => {
+    const projectMemoryDir = join(cwd, ".agenc", "memory");
+    writeMemory(
+      projectMemoryDir,
+      "build-notes.md",
+      "Build pipeline notes",
+      "Run the runtime build twice.",
+    );
+    const trackingState = getAttachmentTrackingState({});
+
+    const first = await relevantMemoriesProducer(
+      makeOpts({ userInput: "" }),
+      trackingState,
+    );
+    expect(first).toHaveLength(1);
+
+    // Later query-less turns must not re-run session-start recall, even for
+    // memories that were not surfaced the first time.
+    writeMemory(
+      projectMemoryDir,
+      "later-notes.md",
+      "Follow-up notes",
+      "Written after turn 0.",
+    );
+    const second = await relevantMemoriesProducer(
+      makeOpts({ userInput: "" }),
+      trackingState,
+    );
+    expect(second).toEqual([]);
+    expect(sideQuery).not.toHaveBeenCalled();
+  });
+
+  test("skips session-start recall for subagents", async () => {
+    writeMemory(
+      join(cwd, ".agenc", "memory"),
+      "build-notes.md",
+      "Build pipeline notes",
+      "Run the runtime build twice.",
+    );
+    const trackingState = getAttachmentTrackingState({});
+    const out = await relevantMemoriesProducer(
+      makeOpts({ userInput: null, subagentDepth: 1 }),
+      trackingState,
+    );
+    expect(out).toEqual([]);
+    expect(sideQuery).not.toHaveBeenCalled();
+  });
+
+  test("does not double-inject when the first prompt is a real query", async () => {
+    const globalMemoryDir = join(agencHome, "memory");
+    const browserPath = writeMemory(
+      globalMemoryDir,
+      "browser.md",
+      "Browser automation guidance",
+      "Use the browser automation workflow.",
+    );
+    writeMemory(
+      join(cwd, ".agenc", "memory"),
+      "build-notes.md",
+      "Build pipeline notes",
+      "Run the runtime build twice.",
+    );
+    selectMemory("browser.md");
+    const trackingState = getAttachmentTrackingState({});
+
+    // Turn 0 with a substantive query: only the query-gated path fires.
+    const out = await relevantMemoriesProducer(makeOpts(), trackingState);
+    expect(out).toHaveLength(1);
+    if (out[0]?.kind !== "relevant_memories") {
+      throw new Error("expected relevant_memories");
+    }
+    expect(out[0].memories.map((memory) => memory.path)).toEqual([browserPath]);
+
+    // The session-start one-shot was consumed by turn 0, so a later
+    // query-less turn injects nothing on top.
+    const second = await relevantMemoriesProducer(
+      makeOpts({ userInput: null }),
+      trackingState,
+    );
+    expect(second).toEqual([]);
+  });
+
   test("truncates large selected memories before attachment emission", async () => {
     const memoryDir = join(agencHome, "memory");
     writeMemory(


### PR DESCRIPTION
## Task 21

**(a) Session-start memory recall.** `relevantMemoriesProducer` was query-gated — no recall unless the first prompt was a multi-word query. It now runs a one-shot session-start recall on the first turn when there's no substantive query (root thread only): project-memory-dir files first, global files matched by cwd-derived signal tokens. Header scans only — no model call (the query path's Sonnet selector is not used here). Reuses the exact existing budgets (5-file/4KB/60KB) and surfaced-paths dedupe. A query-present turn 0 skips it entirely, so double-injection is structurally impossible. (Seam note: the pipeline has no pre-turn injection point — "session open" = first producer run; documented in-code.)

**(b) StructuredOutput visibility.** Was `deferred:true` unconditionally, defeating SDK callers configuring an output schema. `BuildToolRegistryOptions.outputSchema` now flows through bootstrap → `createModelFacingTools`, registering the schema-bound AJV-validating variant (non-deferred, visible in `toLLMTools()`) when a schema is configured; unchanged deferred passthrough otherwise. Finding along the way: `turn-context.ts`'s `finalOutputJsonSchema` is unwired scaffolding with zero producers — the registry-options seam is the one SDK callers actually use.

**Tests:** revert-sensitive on both halves (verified red with the wiring stashed): recall injection/one-shot/subagent-skip/no-double-inject; schema → visible + validating dispatch, no schema → deferred.

**Gates:** build ✅ · typecheck 0 · full vitest **13,882 passed / 0 failed / exit 0** · test:bun 86/0 · TUI startup ✅

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES