### PR TITLE
feat(transaction-guard): first-class config.toml block + doctor check

### DIFF
--- a/docs/security/slm-transaction-guard.md
+++ b/docs/security/slm-transaction-guard.md
@@ -27,20 +27,39 @@ Install the requested Gemma 4 E4B model:
 ollama pull gemma4:e4b
 ```
 
-Enable the guard:
+Enable the guard in `~/.agenc/config.toml`:
+
+```toml
+[transaction_guard]
+enabled = true
+model = "gemma4:e4b"
+endpoint = "http://127.0.0.1:11434"
+fail_mode = "closed"   # "closed" (default) blocks when the guard is
+                       # unavailable; "open" lets the call proceed unguarded
+```
+
+Environment variables remain overrides on top of the config block
+(precedence: env > config > built-in defaults):
 
 ```bash
-export AGENC_TRANSACTION_GUARD=slm
+export AGENC_TRANSACTION_GUARD=slm            # "slm" enables; any other value disables
 export AGENC_TRANSACTION_GUARD_MODEL=gemma4:e4b
 export AGENC_TRANSACTION_GUARD_OLLAMA_URL=http://127.0.0.1:11434
+export AGENC_TRANSACTION_GUARD_FAIL_MODE=closed
 export AGENC_TRANSACTION_GUARD_TIMEOUT_MS=120000
 ```
 
-When enabled, malformed verdicts, model timeouts, and Ollama errors all resolve
-to an `unavailable` decision that blocks the transaction-like action before
-execution (fail-closed). Sensitive-looking fields (keys, secrets, mnemonics,
-seeds, tokens, passwords, authorization headers) are redacted before the intent
-is serialized into the docket.
+`agenc doctor` reports the effective guard status (enabled/disabled, the
+source of that decision, model, endpoint) and probes endpoint reachability
+with a short timeout, warning when the guard is enabled but its endpoint is
+down.
+
+When enabled with the default `fail_mode = "closed"`, malformed verdicts,
+model timeouts, and Ollama errors all resolve to an `unavailable` decision
+that blocks the transaction-like action before execution (fail-closed).
+Sensitive-looking fields (keys, secrets, mnemonics, seeds, tokens, passwords,
+authorization headers) are redacted before the intent is serialized into the
+docket.
 
 ## What Is Guarded
 

--- a/runtime/src/bin/doctor-cli.ts
+++ b/runtime/src/bin/doctor-cli.ts
@@ -19,7 +19,8 @@ export function formatAgenCDoctorCliHelpText(): string {
     "",
     "Usage:",
     "  agenc doctor            Print installation, version, ripgrep, update,",
-    "                          and PATH/glob diagnostics with suggested fixes",
+    "                          transaction-guard, and PATH/glob diagnostics",
+    "                          with suggested fixes",
     "  agenc doctor --json     Emit the raw diagnostic as JSON",
     "",
     "Options:",
@@ -54,7 +55,7 @@ export function parseAgenCDoctorCliArgs(
   return { kind: "doctor", json };
 }
 
-function formatDiagnosticText(
+export function formatDiagnosticText(
   info: Awaited<ReturnType<typeof getDoctorDiagnostic>>,
 ): string {
   const lines: string[] = [];
@@ -82,6 +83,18 @@ function formatDiagnosticText(
           : ""
       })`,
   );
+  const guard = info.transactionGuard;
+  lines.push(
+    `  Transaction guard:  ${guard.enabled ? "enabled" : "disabled"} ` +
+      `(source: ${guard.source}, fail-${guard.failMode})`,
+  );
+  if (guard.enabled) {
+    lines.push(`    model:    ${guard.model}`);
+    lines.push(
+      `    endpoint: ${guard.endpoint} ` +
+        `(${guard.endpointReachable ? "reachable" : "UNREACHABLE"})`,
+    );
+  }
 
   if (info.multipleInstallations.length > 0) {
     lines.push("");

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -494,6 +494,26 @@ export interface PluginsConfig {
   readonly plugins?: Readonly<Record<string, boolean | PluginEntryConfig>>;
 }
 
+export type TransactionGuardFailMode = "open" | "closed";
+
+/**
+ * `[transaction_guard]` — SLM transaction-guard block
+ * (docs/security/slm-transaction-guard.md). The guard runs a local
+ * CourtGuard-style classification against an Ollama endpoint before
+ * transaction-like tool calls execute. Env vars remain overrides:
+ * `AGENC_TRANSACTION_GUARD` (= "slm" enables, any other value disables),
+ * `AGENC_TRANSACTION_GUARD_MODEL`, `AGENC_TRANSACTION_GUARD_OLLAMA_URL`,
+ * and `AGENC_TRANSACTION_GUARD_FAIL_MODE` win over these fields; built-in
+ * defaults apply when neither is set (env > config > defaults — see
+ * `transaction-guard/config.ts`).
+ */
+export interface TransactionGuardConfig {
+  readonly enabled?: boolean;
+  readonly model?: string;
+  readonly endpoint?: string;
+  readonly fail_mode?: TransactionGuardFailMode;
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Canonical AgenCConfig
 // ─────────────────────────────────────────────────────────────────────
@@ -567,6 +587,11 @@ export interface AgenCConfig {
    * editing code itself. `AGENC_COORDINATOR_MODE` env overrides.
    */
   readonly coordinator_mode?: boolean;
+  /**
+   * SLM transaction guard (`[transaction_guard]`). Optional — the guard
+   * defaults to disabled; `AGENC_TRANSACTION_GUARD*` env vars override.
+   */
+  readonly transaction_guard?: TransactionGuardConfig;
   readonly agenc_home?: string;
   readonly workspace?: string;
   readonly simpleMode?: boolean;
@@ -702,6 +727,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = Object.freeze([
   "max_budget_usd",
   "autonomous_mode",
   "coordinator_mode",
+  "transaction_guard",
   "agenc_home",
   "workspace",
   "simpleMode",
@@ -981,6 +1007,17 @@ export class InvalidAgentConfigError extends InvalidNamedConfigError {
 export class InvalidPluginsConfigError extends InvalidNamedConfigError {
   constructor(field: string, detail: string) {
     super("plugins", "InvalidPluginsConfigError", field, detail);
+  }
+}
+
+export class InvalidTransactionGuardConfigError extends InvalidNamedConfigError {
+  constructor(field: string, detail: string) {
+    super(
+      "transaction_guard",
+      "InvalidTransactionGuardConfigError",
+      field,
+      detail,
+    );
   }
 }
 
@@ -1889,6 +1926,39 @@ function validateMcpConfigTable(raw: unknown): Readonly<{
  * nested fields are deny-by-default so misspellings cannot silently change
  * runtime behavior.
  */
+const TRANSACTION_GUARD_KEYS: ReadonlySet<string> = new Set([
+  "enabled",
+  "model",
+  "endpoint",
+  "fail_mode",
+]);
+
+export function validateTransactionGuardConfig(
+  raw: unknown,
+): TransactionGuardConfig | undefined {
+  if (raw === undefined) return undefined;
+  const makeError: InvalidConfigFactory = (field, detail) =>
+    new InvalidTransactionGuardConfigError(field, detail);
+  const record = requirePlainObject(raw, "", makeError);
+  rejectUnknownFields(record, TRANSACTION_GUARD_KEYS, makeError);
+  const out: {
+    -readonly [K in keyof TransactionGuardConfig]: TransactionGuardConfig[K];
+  } = {};
+  const enabled = optionalBoolean(record.enabled, "enabled", makeError);
+  if (enabled !== undefined) out.enabled = enabled;
+  const model = optionalString(record.model, "model", makeError);
+  if (model !== undefined) out.model = model;
+  const endpoint = optionalString(record.endpoint, "endpoint", makeError);
+  if (endpoint !== undefined) out.endpoint = endpoint;
+  if (record.fail_mode !== undefined) {
+    if (record.fail_mode !== "open" && record.fail_mode !== "closed") {
+      throw makeError("fail_mode", 'expected "open" or "closed"');
+    }
+    out.fail_mode = record.fail_mode;
+  }
+  return Object.freeze(out as TransactionGuardConfig);
+}
+
 export function validateAgenCConfigBlocks(config: AgenCConfig): AgenCConfig {
   const out: Record<string, unknown> = { ...config };
   let changed = false;
@@ -1922,6 +1992,12 @@ export function validateAgenCConfigBlocks(config: AgenCConfig): AgenCConfig {
   }
   if (config.tui !== undefined) {
     out.tui = validateTuiConfig(config.tui);
+    changed = true;
+  }
+  if (config.transaction_guard !== undefined) {
+    out.transaction_guard = validateTransactionGuardConfig(
+      config.transaction_guard,
+    );
     changed = true;
   }
 

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -149,13 +149,14 @@ import {
 } from "../llm/token-estimation.js";
 import { enforceRuntimeSandboxAttempt } from "./runtimes/sandboxing.js";
 import {
-  createTransactionGuardContextFromEnv,
+  createTransactionGuardContext,
   evaluateToolInvocationTransactionGuard,
   formatTransactionGuardDenialMessage,
   formatTransactionGuardEventMessage,
   transactionGuardAuditMetadata,
   type TransactionGuardContext,
 } from "../transaction-guard/index.js";
+import type { TransactionGuardConfig } from "../config/schema.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // Constants
@@ -1351,6 +1352,35 @@ function emitHookAttachment(
  * Execute one tool invocation end-to-end. See module comment for the
  * full AgenC-compatible ordering.
  */
+/**
+ * Read the `[transaction_guard]` block from the invocation session's
+ * ConfigStore when one is wired (T11 W3-A `services.configStore`).
+ * Duck-typed so minimal test fixtures (`session: { services: {} }`)
+ * keep working; `undefined` falls back to env-only resolution.
+ */
+function sessionTransactionGuardConfig(
+  invocation: ToolInvocation,
+): TransactionGuardConfig | undefined {
+  const services = (
+    invocation.session as
+      | {
+          readonly services?: {
+            readonly configStore?: {
+              current(): {
+                readonly transaction_guard?: TransactionGuardConfig;
+              };
+            };
+          };
+        }
+      | undefined
+  )?.services;
+  const store = services?.configStore;
+  if (store === undefined || typeof store.current !== "function") {
+    return undefined;
+  }
+  return store.current().transaction_guard;
+}
+
 export async function runToolUse(
   rawArgs: string,
   opts: RunToolUseOptions,
@@ -1782,7 +1812,9 @@ export async function runToolUse(
 
   const transactionGuardContext =
     opts.transactionGuardContext === undefined
-      ? createTransactionGuardContextFromEnv()
+      ? createTransactionGuardContext(
+          sessionTransactionGuardConfig(invocation),
+        )
       : opts.transactionGuardContext;
   const transactionGuardOutcome = await evaluateToolInvocationTransactionGuard({
     context: transactionGuardContext,

--- a/runtime/src/transaction-guard/config.ts
+++ b/runtime/src/transaction-guard/config.ts
@@ -1,3 +1,4 @@
+import type { TransactionGuardConfig } from "../config/schema.js";
 import { OllamaCourtGuard } from "./ollama-courtguard.js";
 import type {
   TransactionGuardContext,
@@ -10,6 +11,10 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_DOCKET_BYTES = 48 * 1024;
 
 let defaultEnvContext: TransactionGuardContext | null | undefined;
+let configContextCache = new WeakMap<
+  TransactionGuardConfig,
+  TransactionGuardContext | null
+>();
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -17,24 +22,131 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+/** Where a resolved transaction-guard policy field came from. */
+export type TransactionGuardValueSource = "env" | "config" | "default";
+
+export interface TransactionGuardPolicySources {
+  readonly enabled: TransactionGuardValueSource;
+  readonly model: TransactionGuardValueSource;
+  readonly endpoint: TransactionGuardValueSource;
+  readonly failMode: TransactionGuardValueSource;
+}
+
+export interface ResolvedTransactionGuardPolicy {
+  readonly policy: TransactionGuardPolicy;
+  readonly sources: TransactionGuardPolicySources;
+}
+
+/**
+ * Resolve the transaction-guard policy from the `[transaction_guard]`
+ * config block and the environment, with per-field source attribution.
+ *
+ * Precedence per field: env > config > built-in defaults.
+ *
+ * - `AGENC_TRANSACTION_GUARD` set non-empty overrides `enabled`
+ *   ("slm" enables, any other value disables — an explicit env kill
+ *   switch even when config enables the guard).
+ * - `AGENC_TRANSACTION_GUARD_MODEL` overrides `model`.
+ * - `AGENC_TRANSACTION_GUARD_OLLAMA_URL` overrides `endpoint`.
+ * - `AGENC_TRANSACTION_GUARD_FAIL_MODE` ("open" | "closed") overrides
+ *   `fail_mode`; unrecognized values are ignored.
+ * - Timeout and docket budget remain env-only knobs
+ *   (`AGENC_TRANSACTION_GUARD_TIMEOUT_MS`,
+ *   `AGENC_TRANSACTION_GUARD_MAX_DOCKET_BYTES`).
+ */
+export function resolveTransactionGuardPolicy(
+  config?: TransactionGuardConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedTransactionGuardPolicy {
+  const envEnabledRaw = nonEmpty(env.AGENC_TRANSACTION_GUARD);
+  let enabled = false;
+  let enabledSource: TransactionGuardValueSource = "default";
+  if (envEnabledRaw !== undefined) {
+    enabled = envEnabledRaw === "slm";
+    enabledSource = "env";
+  } else if (config?.enabled !== undefined) {
+    enabled = config.enabled;
+    enabledSource = "config";
+  }
+
+  const envModel = nonEmpty(env.AGENC_TRANSACTION_GUARD_MODEL);
+  const configModel = nonEmpty(config?.model);
+  const model = envModel ?? configModel ?? DEFAULT_MODEL;
+  const modelSource: TransactionGuardValueSource =
+    envModel !== undefined ? "env" : configModel !== undefined ? "config" : "default";
+
+  const envEndpoint = nonEmpty(env.AGENC_TRANSACTION_GUARD_OLLAMA_URL);
+  const configEndpoint = nonEmpty(config?.endpoint);
+  const ollamaUrl = envEndpoint ?? configEndpoint ?? DEFAULT_OLLAMA_URL;
+  const endpointSource: TransactionGuardValueSource =
+    envEndpoint !== undefined
+      ? "env"
+      : configEndpoint !== undefined
+        ? "config"
+        : "default";
+
+  const envFailModeRaw = nonEmpty(
+    env.AGENC_TRANSACTION_GUARD_FAIL_MODE,
+  )?.toLowerCase();
+  const envFailMode =
+    envFailModeRaw === "open" || envFailModeRaw === "closed"
+      ? envFailModeRaw
+      : undefined;
+  const failMode = envFailMode ?? config?.fail_mode ?? "closed";
+  const failModeSource: TransactionGuardValueSource =
+    envFailMode !== undefined
+      ? "env"
+      : config?.fail_mode !== undefined
+        ? "config"
+        : "default";
+
+  return {
+    policy: {
+      enabled,
+      provider: "ollama",
+      ollamaUrl,
+      model,
+      timeoutMs: parsePositiveInt(
+        env.AGENC_TRANSACTION_GUARD_TIMEOUT_MS,
+        DEFAULT_TIMEOUT_MS,
+      ),
+      failClosed: failMode === "closed",
+      maxDocketBytes: parsePositiveInt(
+        env.AGENC_TRANSACTION_GUARD_MAX_DOCKET_BYTES,
+        DEFAULT_MAX_DOCKET_BYTES,
+      ),
+    },
+    sources: {
+      enabled: enabledSource,
+      model: modelSource,
+      endpoint: endpointSource,
+      failMode: failModeSource,
+    },
+  };
+}
+
+/**
+ * Merge the `[transaction_guard]` config block with env overrides into a
+ * `TransactionGuardPolicy` (env > config > defaults).
+ */
+export function loadTransactionGuardPolicy(
+  config?: TransactionGuardConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): TransactionGuardPolicy {
+  return resolveTransactionGuardPolicy(config, env).policy;
+}
+
+/** Env-only policy resolution — `loadTransactionGuardPolicy` without config. */
 export function loadTransactionGuardPolicyFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): TransactionGuardPolicy {
-  return {
-    enabled: env.AGENC_TRANSACTION_GUARD === "slm",
-    provider: "ollama",
-    ollamaUrl: env.AGENC_TRANSACTION_GUARD_OLLAMA_URL ?? DEFAULT_OLLAMA_URL,
-    model: env.AGENC_TRANSACTION_GUARD_MODEL ?? DEFAULT_MODEL,
-    timeoutMs: parsePositiveInt(
-      env.AGENC_TRANSACTION_GUARD_TIMEOUT_MS,
-      DEFAULT_TIMEOUT_MS,
-    ),
-    failClosed: true,
-    maxDocketBytes: parsePositiveInt(
-      env.AGENC_TRANSACTION_GUARD_MAX_DOCKET_BYTES,
-      DEFAULT_MAX_DOCKET_BYTES,
-    ),
-  };
+  return loadTransactionGuardPolicy(undefined, env);
 }
 
 export function createTransactionGuardContextFromPolicy(
@@ -64,6 +176,34 @@ export function createTransactionGuardContextFromEnv(
   return context;
 }
 
+/**
+ * Config-aware context factory: merges the `[transaction_guard]` block
+ * with env overrides. `config === undefined` falls back to the env-only
+ * path so callers without a loaded config keep the previous behavior.
+ *
+ * Contexts are cached per frozen config snapshot (a config reload swaps
+ * the snapshot object, invalidating the cache entry naturally).
+ */
+export function createTransactionGuardContext(
+  config: TransactionGuardConfig | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): TransactionGuardContext | null {
+  if (config === undefined) {
+    return createTransactionGuardContextFromEnv(env);
+  }
+  if (env === process.env && configContextCache.has(config)) {
+    return configContextCache.get(config) ?? null;
+  }
+  const context = createTransactionGuardContextFromPolicy(
+    loadTransactionGuardPolicy(config, env),
+  );
+  if (env === process.env) {
+    configContextCache.set(config, context);
+  }
+  return context;
+}
+
 export function resetDefaultTransactionGuardContextForTests(): void {
   defaultEnvContext = undefined;
+  configContextCache = new WeakMap();
 }

--- a/runtime/src/transaction-guard/ollama-courtguard.ts
+++ b/runtime/src/transaction-guard/ollama-courtguard.ts
@@ -110,7 +110,9 @@ export class OllamaCourtGuard implements TransactionGuard {
       const verdict = parseTransactionGuardVerdict(verdictText);
       if (!verdict) {
         return {
-          allowed: false,
+          // Fail-closed (default) blocks on malformed verdicts; an
+          // explicit fail_mode="open" policy lets the call proceed.
+          allowed: !this.policy.failClosed,
           verdict: "unavailable",
           code: TRANSACTION_GUARD_UNAVAILABLE,
           reason: `Guard returned malformed verdict: ${verdictText}`,
@@ -135,7 +137,9 @@ export class OllamaCourtGuard implements TransactionGuard {
       };
     } catch (error) {
       return {
-        allowed: false,
+        // Fail-closed (default) blocks on guard errors/timeouts; an
+        // explicit fail_mode="open" policy lets the call proceed.
+        allowed: !this.policy.failClosed,
         verdict: "unavailable",
         code: TRANSACTION_GUARD_UNAVAILABLE,
         reason: error instanceof Error ? error.message : String(error),

--- a/runtime/src/utils/doctorDiagnostic.ts
+++ b/runtime/src/utils/doctorDiagnostic.ts
@@ -10,6 +10,12 @@ import {
   getGlobalConfig,
   type InstallMethod,
 } from './config.js'
+import { loadConfig } from '../config/loader.js'
+import type { TransactionGuardConfig } from '../config/schema.js'
+import {
+  resolveTransactionGuardPolicy,
+  type TransactionGuardValueSource,
+} from '../transaction-guard/config.js'
 import { getCwd } from './cwd.js'
 import { isEnvTruthy } from './envUtils.js'
 import { execFileNoThrow } from './execFileNoThrow.js'
@@ -83,6 +89,18 @@ export type DiagnosticInfo = {
     mode: 'system' | 'builtin' | 'embedded'
     systemPath: string | null
   }
+  transactionGuard: TransactionGuardDoctorStatus
+}
+
+export type TransactionGuardDoctorStatus = {
+  enabled: boolean
+  /** Where the enabled/disabled decision came from. */
+  source: TransactionGuardValueSource
+  model: string
+  endpoint: string
+  failMode: 'open' | 'closed'
+  /** `null` when the guard is disabled (endpoint not probed). */
+  endpointReachable: boolean | null
 }
 
 function getNormalizedPaths(): [invokedPath: string, execPath: string] {
@@ -558,6 +576,93 @@ export function buildRipgrepWarning(
   }
 }
 
+/**
+ * Short-timeout reachability probe for the transaction-guard endpoint.
+ * Any HTTP response (even 404/405) proves the endpoint is reachable;
+ * only network errors / timeouts report unreachable. Never throws.
+ */
+export async function probeTransactionGuardEndpoint(
+  endpoint: string,
+  timeoutMs = 1_500,
+): Promise<boolean> {
+  try {
+    await fetch(endpoint, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the effective transaction-guard status for `agenc doctor`:
+ * the `[transaction_guard]` config block merged with env overrides
+ * (env > config > defaults), plus an endpoint reachability probe when
+ * the guard is enabled.
+ *
+ * `opts.config` short-circuits the disk load for tests (`null` = "no
+ * config block on disk"); `opts.probe` injects the reachability check.
+ */
+export async function getTransactionGuardDoctorStatus(opts?: {
+  config?: TransactionGuardConfig | null
+  env?: NodeJS.ProcessEnv
+  probe?: (endpoint: string) => Promise<boolean>
+}): Promise<TransactionGuardDoctorStatus> {
+  const env = opts?.env ?? process.env
+  let guardConfig: TransactionGuardConfig | undefined =
+    opts?.config === null ? undefined : opts?.config
+  if (guardConfig === undefined && opts?.config === undefined) {
+    try {
+      const loaded = await loadConfig({ onWarn: () => {} })
+      guardConfig = loaded.config.transaction_guard
+    } catch {
+      // No resolvable AGENC home / unreadable config — env-only status.
+    }
+  }
+  const { policy, sources } = resolveTransactionGuardPolicy(guardConfig, env)
+  const probe = opts?.probe ?? probeTransactionGuardEndpoint
+  let endpointReachable: boolean | null = null
+  if (policy.enabled) {
+    try {
+      endpointReachable = await probe(policy.ollamaUrl)
+    } catch {
+      // The doctor path never throws on probe failure.
+      endpointReachable = false
+    }
+  }
+  return {
+    enabled: policy.enabled,
+    source: sources.enabled,
+    model: policy.model,
+    endpoint: policy.ollamaUrl,
+    failMode: policy.failClosed ? 'closed' : 'open',
+    endpointReachable,
+  }
+}
+
+/**
+ * Actionable warning when the guard is enabled but its endpoint is down.
+ * Pure so it can be unit-tested directly (same shape as
+ * {@link buildRipgrepWarning}).
+ */
+export function buildTransactionGuardWarning(
+  status: TransactionGuardDoctorStatus,
+): { issue: string; fix: string } | null {
+  if (!status.enabled || status.endpointReachable !== false) {
+    return null
+  }
+  const consequence =
+    status.failMode === 'closed'
+      ? 'fail mode is "closed", so guarded transaction-like tool calls are blocked until it is reachable'
+      : 'fail mode is "open", so guarded transaction-like tool calls currently run WITHOUT the SLM guard'
+  return {
+    issue: `transaction guard is enabled but its endpoint ${status.endpoint} is unreachable — ${consequence}`,
+    fix: `Start the Ollama endpoint (e.g. \`ollama serve\` and \`ollama pull ${status.model}\`) or point [transaction_guard].endpoint / AGENC_TRANSACTION_GUARD_OLLAMA_URL at a reachable host`,
+  }
+}
+
 export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
   const installationType = await getCurrentInstallationType()
   // The bundler substitutes `MACRO.VERSION` (property access) with a string
@@ -656,6 +761,14 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
     warnings.push(ripgrepWarning)
   }
 
+  // Transaction-guard status (config + env merged) with a short-timeout
+  // endpoint probe when enabled. Unreachable-but-enabled gets a warning.
+  const transactionGuard = await getTransactionGuardDoctorStatus()
+  const transactionGuardWarning = buildTransactionGuardWarning(transactionGuard)
+  if (transactionGuardWarning) {
+    warnings.push(transactionGuardWarning)
+  }
+
   // Get package manager info if running from package manager
   const packageManager =
     installationType === 'package-manager'
@@ -679,6 +792,7 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
     warnings,
     packageManager,
     ripgrepStatus,
+    transactionGuard,
   }
 
   return diagnostic

--- a/runtime/tests/transaction-guard/transaction-guard-config.test.ts
+++ b/runtime/tests/transaction-guard/transaction-guard-config.test.ts
@@ -1,0 +1,388 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { loadConfig } from "../../src/config/loader.js";
+import {
+  InvalidTransactionGuardConfigError,
+  validateTransactionGuardConfig,
+  type TransactionGuardConfig,
+} from "../../src/config/schema.js";
+import {
+  createTransactionGuardContext,
+  loadTransactionGuardPolicy,
+  loadTransactionGuardPolicyFromEnv,
+  resetDefaultTransactionGuardContextForTests,
+  resolveTransactionGuardPolicy,
+  TRANSACTION_GUARD_UNAVAILABLE,
+} from "../../src/transaction-guard/index.js";
+import { runToolUse } from "../../src/tools/execution.js";
+import type { ToolInvocation } from "../../src/tools/context.js";
+import type { Tool } from "../../src/tools/types.js";
+
+const GUARD_ENV_KEYS = [
+  "AGENC_TRANSACTION_GUARD",
+  "AGENC_TRANSACTION_GUARD_MODEL",
+  "AGENC_TRANSACTION_GUARD_OLLAMA_URL",
+  "AGENC_TRANSACTION_GUARD_FAIL_MODE",
+  "AGENC_TRANSACTION_GUARD_TIMEOUT_MS",
+  "AGENC_TRANSACTION_GUARD_MAX_DOCKET_BYTES",
+] as const;
+
+const savedEnv = new Map<string, string | undefined>();
+const tempDirs: string[] = [];
+
+function stripGuardEnv(): void {
+  for (const key of GUARD_ENV_KEYS) {
+    if (!savedEnv.has(key)) savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  savedEnv.clear();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  resetDefaultTransactionGuardContextForTests();
+});
+
+function writeConfigToml(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenc-guard-cfg-"));
+  tempDirs.push(dir);
+  writeFileSync(join(dir, "config.toml"), contents);
+  return dir;
+}
+
+/** A 127.0.0.1 URL with no listener behind it (grab a port, release it). */
+async function unreachableLocalUrl(): Promise<string> {
+  const server = createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  return `http://127.0.0.1:${port}`;
+}
+
+function makeInvocation(
+  callId: string,
+  toolName: string,
+  transactionGuardConfig?: TransactionGuardConfig,
+): ToolInvocation {
+  const services =
+    transactionGuardConfig === undefined
+      ? {}
+      : {
+          configStore: {
+            current: () => ({
+              transaction_guard: Object.freeze({ ...transactionGuardConfig }),
+            }),
+          },
+        };
+  return {
+    session: { services } as never,
+    turn: {
+      cwd: "/repo",
+      sandboxPolicy: { value: "workspace_write" },
+      approvalPolicy: { value: "on_request" },
+    } as never,
+    tracker: {
+      appendFileDiff: () => {},
+      snapshot: () => [],
+      clear: () => {},
+    },
+    callId,
+    toolName: { name: toolName },
+    payload: { kind: "function", arguments: "" },
+    source: "direct",
+  };
+}
+
+function makeTool(name: string, onExecute: () => void): Tool {
+  return {
+    name,
+    description: "test tool",
+    inputSchema: {
+      type: "object",
+      additionalProperties: true,
+    },
+    metadata: {
+      family: "terminal",
+      source: "builtin",
+      mutating: true,
+      hiddenByDefault: false,
+      deferred: false,
+    },
+    async execute() {
+      onExecute();
+      return { content: "executed" };
+    },
+  };
+}
+
+describe("[transaction_guard] config block", () => {
+  test("config.toml block reaches AgenCConfig.transaction_guard (not _unknown)", async () => {
+    // Revert-sensitive: without the KNOWN_CONFIG_KEYS/schema wiring the
+    // block lands on `_unknown` and `transaction_guard` stays undefined.
+    const home = writeConfigToml(
+      [
+        "[transaction_guard]",
+        "enabled = true",
+        'model = "guard-model-from-config"',
+        'endpoint = "http://127.0.0.1:14434"',
+        'fail_mode = "open"',
+        "",
+      ].join("\n"),
+    );
+    const loaded = await loadConfig({ home, onWarn: () => {} });
+    expect(loaded.parseError).toBeUndefined();
+    expect(loaded.config.transaction_guard).toEqual({
+      enabled: true,
+      model: "guard-model-from-config",
+      endpoint: "http://127.0.0.1:14434",
+      fail_mode: "open",
+    });
+    expect(loaded.config._unknown?.transaction_guard).toBeUndefined();
+  });
+
+  test("config block enables the guard without any env vars", async () => {
+    const home = writeConfigToml(
+      [
+        "[transaction_guard]",
+        "enabled = true",
+        'model = "config-model"',
+        'endpoint = "http://127.0.0.1:14434"',
+        "",
+      ].join("\n"),
+    );
+    const loaded = await loadConfig({ home, onWarn: () => {} });
+    const policy = loadTransactionGuardPolicy(
+      loaded.config.transaction_guard,
+      {},
+    );
+    expect(policy.enabled).toBe(true);
+    expect(policy.model).toBe("config-model");
+    expect(policy.ollamaUrl).toBe("http://127.0.0.1:14434");
+    // fail_mode omitted → default "closed".
+    expect(policy.failClosed).toBe(true);
+
+    const context = createTransactionGuardContext(
+      loaded.config.transaction_guard,
+      {},
+    );
+    expect(context).not.toBeNull();
+    expect(context?.policy.model).toBe("config-model");
+    // Env-only resolution with no env vars stays disabled — the config
+    // block is what activated the guard.
+    expect(createTransactionGuardContext(undefined, {})).toBeNull();
+  });
+
+  test("env vars override the config block (env > config > defaults)", () => {
+    const config: TransactionGuardConfig = {
+      enabled: true,
+      model: "config-model",
+      endpoint: "http://config.example:1",
+      fail_mode: "open",
+    };
+    const resolved = resolveTransactionGuardPolicy(config, {
+      AGENC_TRANSACTION_GUARD: "slm",
+      AGENC_TRANSACTION_GUARD_MODEL: "env-model",
+      AGENC_TRANSACTION_GUARD_OLLAMA_URL: "http://env.example:2",
+      AGENC_TRANSACTION_GUARD_FAIL_MODE: "closed",
+    });
+    expect(resolved.policy.enabled).toBe(true);
+    expect(resolved.policy.model).toBe("env-model");
+    expect(resolved.policy.ollamaUrl).toBe("http://env.example:2");
+    expect(resolved.policy.failClosed).toBe(true);
+    expect(resolved.sources).toEqual({
+      enabled: "env",
+      model: "env",
+      endpoint: "env",
+      failMode: "env",
+    });
+  });
+
+  test("a non-slm AGENC_TRANSACTION_GUARD is an env kill switch over config", () => {
+    const config: TransactionGuardConfig = { enabled: true };
+    const resolved = resolveTransactionGuardPolicy(config, {
+      AGENC_TRANSACTION_GUARD: "off",
+    });
+    expect(resolved.policy.enabled).toBe(false);
+    expect(resolved.sources.enabled).toBe("env");
+    // Unset env falls back to the config value.
+    expect(resolveTransactionGuardPolicy(config, {}).policy.enabled).toBe(true);
+    expect(resolveTransactionGuardPolicy(config, {}).sources.enabled).toBe(
+      "config",
+    );
+  });
+
+  test("defaults apply when neither env nor config set a field", () => {
+    const resolved = resolveTransactionGuardPolicy(undefined, {});
+    expect(resolved.policy).toMatchObject({
+      enabled: false,
+      provider: "ollama",
+      model: "gemma4:e4b",
+      ollamaUrl: "http://127.0.0.1:11434",
+      failClosed: true,
+    });
+    expect(resolved.sources).toEqual({
+      enabled: "default",
+      model: "default",
+      endpoint: "default",
+      failMode: "default",
+    });
+  });
+
+  test("loadTransactionGuardPolicyFromEnv keeps its pre-config behavior", () => {
+    expect(loadTransactionGuardPolicyFromEnv({})).toEqual({
+      enabled: false,
+      provider: "ollama",
+      ollamaUrl: "http://127.0.0.1:11434",
+      model: "gemma4:e4b",
+      timeoutMs: 120_000,
+      failClosed: true,
+      maxDocketBytes: 48 * 1024,
+    });
+    expect(
+      loadTransactionGuardPolicyFromEnv({
+        AGENC_TRANSACTION_GUARD: "slm",
+        AGENC_TRANSACTION_GUARD_MODEL: "local-judge",
+        AGENC_TRANSACTION_GUARD_OLLAMA_URL: "http://ollama.test",
+        AGENC_TRANSACTION_GUARD_TIMEOUT_MS: "5000",
+      }),
+    ).toMatchObject({
+      enabled: true,
+      model: "local-judge",
+      ollamaUrl: "http://ollama.test",
+      timeoutMs: 5_000,
+    });
+  });
+
+  test("validateTransactionGuardConfig rejects unknown fields and bad values", () => {
+    expect(validateTransactionGuardConfig(undefined)).toBeUndefined();
+    expect(
+      validateTransactionGuardConfig({
+        enabled: true,
+        model: "m",
+        endpoint: "http://e",
+        fail_mode: "open",
+      }),
+    ).toEqual({
+      enabled: true,
+      model: "m",
+      endpoint: "http://e",
+      fail_mode: "open",
+    });
+    expect(() => validateTransactionGuardConfig({ ollama_url: "x" })).toThrow(
+      InvalidTransactionGuardConfigError,
+    );
+    expect(() =>
+      validateTransactionGuardConfig({ fail_mode: "sideways" }),
+    ).toThrow('Invalid transaction_guard.fail_mode: expected "open" or "closed"');
+    expect(() => validateTransactionGuardConfig({ enabled: "yes" })).toThrow(
+      InvalidTransactionGuardConfigError,
+    );
+    expect(() => validateTransactionGuardConfig("slm")).toThrow(
+      InvalidTransactionGuardConfigError,
+    );
+  });
+
+  test("an invalid [transaction_guard] block is a loader parseError", async () => {
+    const home = writeConfigToml(
+      ["[transaction_guard]", 'fail_mode = "sideways"', ""].join("\n"),
+    );
+    const warnings: string[] = [];
+    const loaded = await loadConfig({ home, onWarn: (m) => warnings.push(m) });
+    expect(loaded.parseError).toContain("transaction_guard.fail_mode");
+    expect(loaded.config.transaction_guard).toBeUndefined();
+  });
+});
+
+describe("config-driven guard activation through runToolUse", () => {
+  test("session config block guards transaction-like calls without env vars", async () => {
+    // Revert-sensitive end-to-end proof: no env vars, no explicit
+    // transactionGuardContext — only the session ConfigStore's
+    // [transaction_guard] block. The endpoint is unreachable and
+    // fail_mode defaults to "closed", so the call must be blocked
+    // before the tool executes.
+    stripGuardEnv();
+    process.env.AGENC_TRANSACTION_GUARD_TIMEOUT_MS = "2000";
+    const endpoint = await unreachableLocalUrl();
+    let executed = false;
+    const out = await runToolUse(
+      JSON.stringify({
+        cmd: "solana transfer recipient 0.001 --url https://api.devnet.solana.com",
+      }),
+      {
+        currentTurnId: "turn-config-guard",
+        invocation: makeInvocation("config-guard-blocked", "exec_command", {
+          enabled: true,
+          endpoint,
+        }),
+        tool: makeTool("exec_command", () => {
+          executed = true;
+        }),
+      },
+    );
+    expect(executed).toBe(false);
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain(TRANSACTION_GUARD_UNAVAILABLE);
+  });
+
+  test("without the config block (and no env) the same call executes", async () => {
+    stripGuardEnv();
+    let executed = false;
+    const out = await runToolUse(
+      JSON.stringify({
+        cmd: "solana transfer recipient 0.001 --url https://api.devnet.solana.com",
+      }),
+      {
+        currentTurnId: "turn-config-guard",
+        invocation: makeInvocation("config-guard-disabled", "exec_command"),
+        tool: makeTool("exec_command", () => {
+          executed = true;
+        }),
+      },
+    );
+    expect(executed).toBe(true);
+    expect(out.isError).not.toBe(true);
+  });
+
+  test("fail_mode=open lets the call proceed when the guard is unavailable", async () => {
+    stripGuardEnv();
+    process.env.AGENC_TRANSACTION_GUARD_TIMEOUT_MS = "2000";
+    const endpoint = await unreachableLocalUrl();
+    let executed = false;
+    const out = await runToolUse(
+      JSON.stringify({
+        cmd: "solana transfer recipient 0.001 --url https://api.devnet.solana.com",
+      }),
+      {
+        currentTurnId: "turn-config-guard",
+        invocation: makeInvocation("config-guard-fail-open", "exec_command", {
+          enabled: true,
+          endpoint,
+          fail_mode: "open",
+        }),
+        tool: makeTool("exec_command", () => {
+          executed = true;
+        }),
+      },
+    );
+    expect(executed).toBe(true);
+    expect(out.isError).not.toBe(true);
+  });
+});

--- a/runtime/tests/utils/doctorDiagnostic.transaction-guard.test.ts
+++ b/runtime/tests/utils/doctorDiagnostic.transaction-guard.test.ts
@@ -1,0 +1,212 @@
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildTransactionGuardWarning,
+  getTransactionGuardDoctorStatus,
+  probeTransactionGuardEndpoint,
+  type DiagnosticInfo,
+  type TransactionGuardDoctorStatus,
+} from "../../src/utils/doctorDiagnostic.js";
+import { formatDiagnosticText } from "../../src/bin/doctor-cli.js";
+
+// MACRO is a build-time esbuild define (tsup); it is not defined under
+// vitest. Stand it in for the suite, mirroring the established pattern.
+let priorMacro: unknown;
+beforeAll(() => {
+  priorMacro = (globalThis as { MACRO?: unknown }).MACRO;
+  (globalThis as { MACRO?: unknown }).MACRO = {
+    VERSION: "test",
+    PACKAGE_URL: "@tetsuo-ai/agenc",
+  };
+});
+afterAll(() => {
+  (globalThis as { MACRO?: unknown }).MACRO = priorMacro;
+});
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+});
+
+async function startReachableEndpoint(): Promise<string> {
+  const server = createServer((_req, res) => {
+    res.statusCode = 200;
+    res.end("Ollama is running");
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  return `http://127.0.0.1:${port}`;
+}
+
+/** A 127.0.0.1 URL with no listener behind it (grab a port, release it). */
+async function unreachableEndpoint(): Promise<string> {
+  const server = createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  return `http://127.0.0.1:${port}`;
+}
+
+function diagnosticFixture(
+  transactionGuard: TransactionGuardDoctorStatus,
+): DiagnosticInfo {
+  return {
+    installationType: "development",
+    version: "test",
+    installationPath: "/tmp/agenc",
+    invokedBinary: "/tmp/agenc/bin",
+    configInstallMethod: "not set",
+    autoUpdates: "enabled",
+    hasUpdatePermissions: null,
+    multipleInstallations: [],
+    warnings: [],
+    ripgrepStatus: { working: true, mode: "system", systemPath: "/usr/bin/rg" },
+    transactionGuard,
+  };
+}
+
+describe("getTransactionGuardDoctorStatus", () => {
+  it("reports an enabled guard with a reachable endpoint", async () => {
+    const endpoint = await startReachableEndpoint();
+    const status = await getTransactionGuardDoctorStatus({
+      config: { enabled: true, model: "guard-model", endpoint },
+      env: {},
+    });
+    expect(status).toEqual({
+      enabled: true,
+      source: "config",
+      model: "guard-model",
+      endpoint,
+      failMode: "closed",
+      endpointReachable: true,
+    });
+    expect(buildTransactionGuardWarning(status)).toBeNull();
+  });
+
+  it("reports an enabled guard with an unreachable endpoint and warns", async () => {
+    const endpoint = await unreachableEndpoint();
+    const status = await getTransactionGuardDoctorStatus({
+      config: { enabled: true, endpoint },
+      env: {},
+    });
+    expect(status.enabled).toBe(true);
+    expect(status.endpointReachable).toBe(false);
+    const warning = buildTransactionGuardWarning(status);
+    expect(warning).not.toBeNull();
+    expect(warning?.issue).toContain(endpoint);
+    expect(warning?.issue).toContain("blocked");
+    expect(warning?.fix).toContain("ollama serve");
+  });
+
+  it("does not probe (and does not warn) when the guard is disabled", async () => {
+    const status = await getTransactionGuardDoctorStatus({
+      config: null,
+      env: {},
+      probe: () => {
+        throw new Error("probe must not run for a disabled guard");
+      },
+    });
+    expect(status).toEqual({
+      enabled: false,
+      source: "default",
+      model: "gemma4:e4b",
+      endpoint: "http://127.0.0.1:11434",
+      failMode: "closed",
+      endpointReachable: null,
+    });
+    expect(buildTransactionGuardWarning(status)).toBeNull();
+  });
+
+  it("reports env as the enablement source and fail-open in the warning", async () => {
+    const endpoint = await unreachableEndpoint();
+    const status = await getTransactionGuardDoctorStatus({
+      config: null,
+      env: {
+        AGENC_TRANSACTION_GUARD: "slm",
+        AGENC_TRANSACTION_GUARD_OLLAMA_URL: endpoint,
+        AGENC_TRANSACTION_GUARD_FAIL_MODE: "open",
+      },
+    });
+    expect(status.source).toBe("env");
+    expect(status.failMode).toBe("open");
+    expect(status.endpointReachable).toBe(false);
+    const warning = buildTransactionGuardWarning(status);
+    expect(warning?.issue).toContain("WITHOUT the SLM guard");
+  });
+
+  it("never throws when the injected probe rejects", async () => {
+    const status = await getTransactionGuardDoctorStatus({
+      config: { enabled: true },
+      env: {},
+      probe: () => Promise.reject(new Error("boom")),
+    });
+    expect(status.endpointReachable).toBe(false);
+  });
+});
+
+describe("probeTransactionGuardEndpoint", () => {
+  it("is true for any responding server and false for a closed port", async () => {
+    const up = await startReachableEndpoint();
+    const down = await unreachableEndpoint();
+    await expect(probeTransactionGuardEndpoint(up)).resolves.toBe(true);
+    await expect(probeTransactionGuardEndpoint(down)).resolves.toBe(false);
+  });
+
+  it("returns false (never throws) on a malformed endpoint", async () => {
+    await expect(
+      probeTransactionGuardEndpoint("not-a-url"),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("doctor output includes the transaction guard section", () => {
+  it("shows an enabled guard with a reachable endpoint", async () => {
+    const endpoint = await startReachableEndpoint();
+    const status = await getTransactionGuardDoctorStatus({
+      config: { enabled: true, model: "guard-model", endpoint },
+      env: {},
+    });
+    const text = formatDiagnosticText(diagnosticFixture(status));
+    expect(text).toContain(
+      "Transaction guard:  enabled (source: config, fail-closed)",
+    );
+    expect(text).toContain("model:    guard-model");
+    expect(text).toContain(`endpoint: ${endpoint} (reachable)`);
+  });
+
+  it("shows an enabled guard with an unreachable endpoint", async () => {
+    const endpoint = await unreachableEndpoint();
+    const status = await getTransactionGuardDoctorStatus({
+      config: { enabled: true, endpoint },
+      env: {},
+    });
+    const text = formatDiagnosticText(diagnosticFixture(status));
+    expect(text).toContain(`endpoint: ${endpoint} (UNREACHABLE)`);
+  });
+
+  it("shows a disabled guard as a single status line", async () => {
+    const status = await getTransactionGuardDoctorStatus({
+      config: null,
+      env: {},
+    });
+    const text = formatDiagnosticText(diagnosticFixture(status));
+    expect(text).toContain(
+      "Transaction guard:  disabled (source: default, fail-closed)",
+    );
+    expect(text).not.toContain("endpoint:");
+  });
+});


### PR DESCRIPTION
## Task 26

The transaction guard (the defense layer for future protocol mutations) was fully implemented but env-only and invisible.

- **`[transaction_guard]` config block** (`enabled`/`model`/`endpoint`/`fail_mode`) with reject-unknown-fields validation; built-in defaults stay single-sourced in `transaction-guard/config.ts`. Precedence **env > config > default** per field with source attribution; `AGENC_TRANSACTION_GUARD` set to a non-`slm` value acts as an explicit env kill switch. `loadTransactionGuardPolicyFromEnv` behavior byte-identical for existing callers.
- `runToolUse`'s guard fallback is now session-config-aware (WeakMap-cached per frozen config snapshot).
- **Drive-by real bug**: `OllamaCourtGuard` declared `policy.failClosed` but ignored it on unavailable verdicts — `fail_mode = "open"` would have been dead config. Now honored.
- **`agenc doctor`** reports guard status/source/model/endpoint plus a 1.5s HEAD reachability probe; enabled+unreachable warns (gating the exit code) and states whether calls are blocked (closed) or running unguarded (open). Rides `--json` for free.

**Revert-sensitivity proven red** on all three seams (schema keys, caller wiring, doctor section). 21 new tests.

**Gates:** build ✅ · typecheck 0 · full vitest **13,903 passed / 0 failed / exit 0** · test:bun 86/0 · TUI startup ✅

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES