### PR TITLE
feat(cli): agenc trajectories export — curated SFT/DPO JSONL from the redacted export sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ bin/
 !runtime/bin/agenc-linux-sandbox
 !runtime/src/bin/
 !runtime/src/bin/*.ts
+!runtime/tests/bin/
+!runtime/tests/bin/*.ts
 !packages/agenc/bin/
 !packages/agenc/bin/*.js
 obj/

--- a/docs/trajectory-training-data.md
+++ b/docs/trajectory-training-data.md
@@ -1,0 +1,93 @@
+# Trajectory training data — export & curate
+
+Turn real AgenC sessions into local training data in three steps: enable
+the export sink, run sessions, curate with `agenc trajectories export`.
+Everything is local file processing; nothing leaves the machine.
+
+## 1. Enable the export sink
+
+The runtime ships an opt-in, per-session trajectory export sink
+(`runtime/src/session/trajectory-export.ts`). It mirrors every rollout
+row — messages, tool calls, turn lifecycle events — to an append-only
+JSONL file, redacting secrets (`redactSecretsInValue`) at write time.
+
+```bash
+# one file per session under this directory (recommended):
+export AGENC_TRAJECTORY_EXPORT_DIR=~/agenc-trajectories
+
+# — or — append every session to a single file:
+export AGENC_TRAJECTORY_EXPORT_PATH=~/agenc-trajectories/all.jsonl
+```
+
+Each line is a `TrajectoryExportRecord`:
+
+```json
+{"schemaVersion": 1, "exportedAtUnixMs": 0, "sessionId": "…", "rolloutPath": "…", "item": { "type": "response_item", "payload": { … } }}
+```
+
+Unset the variables to disable the sink. Files are created `0600`.
+
+## 2. Run sessions
+
+Use AgenC normally. Every session started while the env var is set is
+exported as it runs.
+
+## 3. Curate
+
+```bash
+# chat-format SFT JSONL to stdout (reads $AGENC_TRAJECTORY_EXPORT_DIR):
+agenc trajectories export --format sft --out sft.jsonl
+
+# preference pairs:
+agenc trajectories export --format dpo --dir ~/agenc-trajectories --out dpo.jsonl
+```
+
+### Filtering
+
+Only trajectories that ended well are kept:
+
+- at least one completed turn (`turn_complete`),
+- no terminal `error` event (transient `stream_error`s the session
+  recovered from do not disqualify it),
+- no abort/interrupt (`turn_aborted` — covers Esc and cancellations),
+- no user tool-use rejection markers in the persisted messages,
+- for SFT additionally no thread rollback (a rollback is an explicit
+  user rejection of part of the trajectory; those sessions feed DPO).
+
+There is no `--require-eval-passed` filter: exported records carry no
+evaluation outcome field, so there is nothing to gate on.
+
+### Redaction
+
+Rows are passed through the same `redactSecretsInValue` pass the sink
+applies at write time, so exports produced by older builds still come
+out redacted.
+
+### Formats
+
+`--format sft` — one conversation per line in standard chat schema.
+History is rebuilt with the canonical event-log reducer, so compactions
+apply exactly as the model saw them:
+
+```json
+{"messages": [{"role": "user", "content": "…"}, {"role": "assistant", "content": "…", "tool_calls": [{"id": "…", "type": "function", "function": {"name": "…", "arguments": "…"}}]}, {"role": "tool", "content": "…", "tool_call_id": "…", "name": "…"}], "meta": {"sessionId": "…"}}
+```
+
+`--format dpo` — honest preference pairs derived from
+`thread_rolled_back` regenerations: when a user rewinds a turn and
+re-runs the **same** prompt, the append-only export keeps both the
+discarded continuation (rejected) and the kept one (chosen) from an
+identical prefix. Pairs are emitted only when the prefix survived
+unchanged, both sides re-open with an identical user prompt, and both
+contain assistant output — anything weaker is skipped, never
+fabricated. If no such regenerations exist, the command exits with an
+error explaining what is missing:
+
+```json
+{"prompt": [{"role": "user", "content": "…"}], "chosen": [{"role": "assistant", "content": "…"}], "rejected": [{"role": "assistant", "content": "…"}], "meta": {"sessionId": "…"}}
+```
+
+## Follow-ups (not covered here)
+
+A distillation runbook (training on the emitted JSONL) and an
+eval-comparison script for before/after models are tracked separately.

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -178,6 +178,11 @@ import {
   runAgenCStateCli,
 } from "./state-cli.js";
 import {
+  formatAgenCTrajectoriesCliHelpText,
+  parseAgenCTrajectoriesCliArgs,
+  runAgenCTrajectoriesCli,
+} from "./trajectories-cli.js";
+import {
   executeUserPromptSubmitHooks,
   getUserPromptSubmitHookBlockingMessage,
 } from "../hooks/user-prompt-submit.js";
@@ -303,6 +308,7 @@ export function formatCliHelpText(): string {
     "       agenc permissions <command>",
     "       agenc state export <agent-id>",
     "       agenc state import",
+    "       agenc trajectories export [--format sft|dpo] [--dir <path>] [--out <file>]",
     "       agenc daemon start [--foreground]",
     "       agenc daemon <stop|status|reload|restart>",
     "       agenc agent start <objective>",
@@ -320,6 +326,7 @@ export function formatCliHelpText(): string {
     "  plugin                                  Manage local plugins and marketplaces",
     "  permissions                             List/update rules or resolve live requests",
     "  state                                   Export or import project state",
+    "  trajectories                            Curate exported trajectories into training JSONL",
     "  daemon                                  Manage the local AgenC daemon",
     "  agent                                   Start, attach, inspect, or stop background agents",
     "  mcp                                     Manage MCP servers or serve AgenC tools over MCP",
@@ -397,6 +404,8 @@ export function formatCliHelpTopicText(topic: string): string | null {
       return formatAgenCConfigCliHelpText();
     case "state":
       return formatAgenCStateCliHelpText();
+    case "trajectories":
+      return formatAgenCTrajectoriesCliHelpText();
     default:
       return null;
   }
@@ -4000,6 +4009,10 @@ export async function main(): Promise<number> {
   const stateCommand = parseAgenCStateCliArgs(argv);
   if (stateCommand !== null) {
     return runAgenCStateCli(stateCommand);
+  }
+  const trajectoriesCommand = parseAgenCTrajectoriesCliArgs(argv);
+  if (trajectoriesCommand !== null) {
+    return runAgenCTrajectoriesCli(trajectoriesCommand);
   }
 
   const startupShortCircuit = detectStartupShortCircuit(argv);

--- a/runtime/src/bin/trajectories-cli.ts
+++ b/runtime/src/bin/trajectories-cli.ts
@@ -1,0 +1,308 @@
+/**
+ * `agenc trajectories` — curate the redacted trajectory exports written
+ * by the opt-in session sink (`session/trajectory-export.ts`, enabled
+ * via `AGENC_TRAJECTORY_EXPORT_DIR` / `AGENC_TRAJECTORY_EXPORT_PATH`)
+ * into local training data. Pure local file processing; never touches
+ * the network.
+ *
+ * `agenc trajectories export --format sft` emits one chat-schema JSONL
+ * row per kept session; `--format dpo` emits preference pairs derived
+ * from thread-rollback regenerations (see `buildDpoPairs`).
+ *
+ * Note: there is no `--require-eval-passed` flag — exported trajectory
+ * records carry no evaluation outcome field to filter on.
+ */
+
+import { existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  buildDpoPairs,
+  buildSftExample,
+  classifyTrajectory,
+  isDpoEligible,
+  isSftEligible,
+  listTrajectoryExportFiles,
+  readTrajectoryExports,
+  renderTrajectoryJsonl,
+} from "../session/trajectory-curate.js";
+import {
+  AGENC_TRAJECTORY_EXPORT_DIR_ENV,
+  AGENC_TRAJECTORY_EXPORT_PATH_ENV,
+} from "../session/trajectory-export.js";
+
+export type TrajectoryExportFormat = "sft" | "dpo";
+
+export type AgenCTrajectoriesCliCommand =
+  | {
+      readonly kind: "export";
+      readonly format: TrajectoryExportFormat;
+      readonly dir?: string;
+      readonly out?: string;
+    }
+  | { readonly kind: "help"; readonly text: string }
+  | { readonly kind: "error"; readonly message: string };
+
+export interface AgenCTrajectoriesCliIo {
+  readonly stdout: Pick<NodeJS.WriteStream, "write">;
+  readonly stderr: Pick<NodeJS.WriteStream, "write">;
+}
+
+export interface AgenCTrajectoriesCliOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly io?: AgenCTrajectoriesCliIo;
+}
+
+export function formatAgenCTrajectoriesCliHelpText(): string {
+  return [
+    "Usage: agenc trajectories export [options]",
+    "",
+    "Curate the redacted trajectory exports written by the session sink",
+    "(enable with AGENC_TRAJECTORY_EXPORT_DIR=<dir>, then run sessions)",
+    "into training-data JSONL. Local file processing only — no network.",
+    "",
+    "Only trajectories that completed at least one turn with no error",
+    "event, no abort/interrupt, and no user tool-use rejection are kept.",
+    "",
+    "Options:",
+    "  --format <sft|dpo>  Output format (default: sft)",
+    "                        sft: one chat-schema conversation per row",
+    "                        dpo: prompt/chosen/rejected preference pairs",
+    "                             derived from thread-rollback regenerations",
+    "  --dir <path>        Export dir (or single .jsonl file) to read.",
+    `                      Default: $${AGENC_TRAJECTORY_EXPORT_DIR_ENV},`,
+    `                      then $${AGENC_TRAJECTORY_EXPORT_PATH_ENV}`,
+    "  --out <file>        Write JSONL here instead of stdout",
+    "  -h, --help          Show this help text",
+    "",
+    "Note: --require-eval-passed is not available — exported records",
+    "carry no evaluation outcome field to filter on.",
+  ].join("\n");
+}
+
+export function parseAgenCTrajectoriesCliArgs(
+  argv: readonly string[],
+): AgenCTrajectoriesCliCommand | null {
+  if (argv[0] !== "trajectories") return null;
+  const action = argv[1];
+  if (action === undefined || action === "--help" || action === "-h") {
+    return { kind: "help", text: formatAgenCTrajectoriesCliHelpText() };
+  }
+  if (action !== "export") {
+    return {
+      kind: "error",
+      message: `unknown trajectories command: ${action}`,
+    };
+  }
+
+  let format: TrajectoryExportFormat = "sft";
+  let dir: string | undefined;
+  let out: string | undefined;
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i]!;
+    if (arg === "--help" || arg === "-h") {
+      return { kind: "help", text: formatAgenCTrajectoriesCliHelpText() };
+    }
+    if (arg === "--format" || arg.startsWith("--format=")) {
+      const value = arg.includes("=") ? arg.slice("--format=".length) : rest[++i];
+      if (value !== "sft" && value !== "dpo") {
+        return {
+          kind: "error",
+          message: `trajectories export --format must be 'sft' or 'dpo', got '${value ?? ""}'`,
+        };
+      }
+      format = value;
+      continue;
+    }
+    if (arg === "--dir" || arg.startsWith("--dir=")) {
+      const value = arg.includes("=") ? arg.slice("--dir=".length) : rest[++i];
+      if (value === undefined || value.length === 0 || value.startsWith("-")) {
+        return {
+          kind: "error",
+          message: "trajectories export --dir requires a path",
+        };
+      }
+      dir = value;
+      continue;
+    }
+    if (arg === "--out" || arg.startsWith("--out=")) {
+      const value = arg.includes("=") ? arg.slice("--out=".length) : rest[++i];
+      if (value === undefined || value.length === 0 || value.startsWith("-")) {
+        return {
+          kind: "error",
+          message: "trajectories export --out requires a path",
+        };
+      }
+      out = value;
+      continue;
+    }
+    return {
+      kind: "error",
+      message: `trajectories export does not accept argument '${arg}'`,
+    };
+  }
+
+  return {
+    kind: "export",
+    format,
+    ...(dir !== undefined ? { dir } : {}),
+    ...(out !== undefined ? { out } : {}),
+  };
+}
+
+function resolveExportSourcePath(
+  command: { readonly dir?: string },
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  if (command.dir !== undefined) return command.dir;
+  const dirEnv = env[AGENC_TRAJECTORY_EXPORT_DIR_ENV]?.trim();
+  if (dirEnv) return dirEnv;
+  const pathEnv = env[AGENC_TRAJECTORY_EXPORT_PATH_ENV]?.trim();
+  if (pathEnv) return pathEnv;
+  return undefined;
+}
+
+export async function runAgenCTrajectoriesCli(
+  command: AgenCTrajectoriesCliCommand,
+  options: AgenCTrajectoriesCliOptions = {},
+): Promise<number> {
+  const io = options.io ?? { stdout: process.stdout, stderr: process.stderr };
+  switch (command.kind) {
+    case "help":
+      io.stdout.write(`${command.text}\n`);
+      return 0;
+    case "error":
+      io.stderr.write(`agenc: ${command.message}\n`);
+      io.stderr.write(`${formatAgenCTrajectoriesCliHelpText()}\n`);
+      return 1;
+    case "export":
+      return runTrajectoriesExport(command, io, options.env ?? process.env);
+  }
+}
+
+function runTrajectoriesExport(
+  command: {
+    readonly format: TrajectoryExportFormat;
+    readonly dir?: string;
+    readonly out?: string;
+  },
+  io: AgenCTrajectoriesCliIo,
+  env: NodeJS.ProcessEnv,
+): number {
+  const sourcePath = resolveExportSourcePath(command, env);
+  if (sourcePath === undefined) {
+    io.stderr.write(
+      "agenc: no trajectory export source. Pass --dir <path> or set " +
+        `${AGENC_TRAJECTORY_EXPORT_DIR_ENV} (the sink's export dir).\n`,
+    );
+    return 1;
+  }
+  const resolved = resolve(sourcePath);
+  if (!existsSync(resolved)) {
+    io.stderr.write(
+      `agenc: trajectory export source not found: ${resolved}\n`,
+    );
+    return 1;
+  }
+
+  const fileCount = listTrajectoryExportFiles(resolved).length;
+  const parsed = readTrajectoryExports(resolved);
+
+  const rows: unknown[] = [];
+  let kept = 0;
+  let skippedError = 0;
+  let skippedAborted = 0;
+  let skippedRejected = 0;
+  let skippedIncomplete = 0;
+  let skippedNotTrainable = 0;
+  let rollbacksSeen = 0;
+
+  for (const [sessionId, items] of parsed.sessions) {
+    const classification = classifyTrajectory(items);
+    if (!classification.hasTurnComplete) {
+      skippedIncomplete += 1;
+      continue;
+    }
+    if (classification.hasErrorEvent) {
+      skippedError += 1;
+      continue;
+    }
+    if (classification.hasTurnAborted) {
+      skippedAborted += 1;
+      continue;
+    }
+    if (command.format === "sft") {
+      if (!isSftEligible(classification)) {
+        // Complete/error/abort already handled above, so the remaining
+        // SFT exclusions are user rejection markers and rollbacks.
+        skippedRejected += 1;
+        continue;
+      }
+      const example = buildSftExample(sessionId, items);
+      if (example === null) {
+        skippedNotTrainable += 1;
+        continue;
+      }
+      rows.push(example);
+      kept += 1;
+      continue;
+    }
+    // dpo
+    if (!isDpoEligible(classification)) {
+      skippedNotTrainable += 1;
+      continue;
+    }
+    const derivation = buildDpoPairs(sessionId, items);
+    rollbacksSeen += derivation.rollbackCount;
+    if (derivation.pairs.length === 0) {
+      skippedNotTrainable += 1;
+      continue;
+    }
+    rows.push(...derivation.pairs);
+    kept += 1;
+  }
+
+  const summary =
+    `trajectories export: read ${fileCount} file(s), ` +
+    `${parsed.sessions.size} session(s), ${parsed.recordCount} record(s) ` +
+    `(${parsed.malformedLineCount} malformed, ` +
+    `${parsed.unsupportedSchemaCount} unsupported-schema); ` +
+    `kept ${kept}, skipped ${skippedIncomplete} incomplete, ` +
+    `${skippedError} errored, ${skippedAborted} aborted/interrupted, ` +
+    `${skippedRejected} rejected, ${skippedNotTrainable} not-trainable; ` +
+    `emitted ${rows.length} ${command.format} row(s)\n`;
+
+  if (rows.length === 0) {
+    if (command.format === "dpo") {
+      io.stderr.write(
+        "agenc: no preference pairs could be derived. Real DPO pairs " +
+          "require a session where the user rolled back a turn " +
+          "(thread_rolled_back) and re-ran the SAME prompt, so one " +
+          "continuation was rejected and another kept from an identical " +
+          "prefix. The exported records contain " +
+          (rollbacksSeen > 0
+            ? `${rollbacksSeen} rollback(s), but none with an identical re-prompt and assistant output on both sides. `
+            : "no such rollback regenerations. ") +
+          "Nothing was fabricated.\n",
+      );
+    } else {
+      io.stderr.write(
+        "agenc: no trajectories survived curation (need at least one " +
+          "session that completed a turn with no error, no " +
+          "abort/interrupt, and no rejection).\n",
+      );
+    }
+    io.stderr.write(summary);
+    return 1;
+  }
+
+  const jsonl = renderTrajectoryJsonl(rows);
+  if (command.out !== undefined) {
+    writeFileSync(resolve(command.out), jsonl, { mode: 0o600 });
+  } else {
+    io.stdout.write(jsonl);
+  }
+  io.stderr.write(summary);
+  return 0;
+}

--- a/runtime/src/session/trajectory-curate.ts
+++ b/runtime/src/session/trajectory-curate.ts
@@ -1,0 +1,553 @@
+/**
+ * Trajectory curation — turns the redacted JSONL files written by the
+ * opt-in trajectory export sink (`trajectory-export.ts`) into training
+ * data.
+ *
+ * Input contract: each line is a `TrajectoryExportRecord`
+ * (`{schemaVersion, exportedAtUnixMs, sessionId, rolloutPath, item}`)
+ * whose `item` is one redacted `RolloutItem`. Records for multiple
+ * sessions may share a file (the `AGENC_TRAJECTORY_EXPORT_PATH` mode
+ * appends every session to one file), so grouping is by `sessionId`,
+ * never by file.
+ *
+ * Curation is pure local file processing:
+ *   - **Filter** — keep only trajectories that finished at least one
+ *     turn (`turn_complete`), hit no terminal `error` event, were never
+ *     aborted/interrupted (`turn_aborted` covers Esc/cancel), and carry
+ *     no user tool-use rejection markers. Transient `stream_error`
+ *     events do NOT exclude a trajectory: when the provider hiccup is
+ *     fatal the runtime follows up with `error`/`turn_aborted`, which
+ *     do.
+ *   - **Redact** — every emitted row is passed through the same
+ *     `redactSecretsInValue` the export sink already applies at write
+ *     time (belt and suspenders for files produced by older builds).
+ *   - **Emit** — `sft` chat-format rows (one conversation per kept
+ *     session, reduced through the canonical event-log reducer so
+ *     compaction and rollbacks apply exactly as the model saw them) or
+ *     `dpo` preference pairs derived from `thread_rolled_back`
+ *     regenerations (see `buildDpoPairs`).
+ *
+ * There is no `--require-eval-passed` style filter: neither
+ * `TrajectoryExportRecord` nor any `RolloutItem` variant carries an
+ * evaluation outcome, so such a flag would have nothing to read.
+ *
+ * @module
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { redactSecretsInValue } from "../secrets/index.js";
+import {
+  CANCEL_MESSAGE,
+  INTERRUPT_MESSAGE,
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  REJECT_MESSAGE,
+  REJECT_MESSAGE_WITH_REASON_PREFIX,
+  SUBAGENT_REJECT_MESSAGE,
+  SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX,
+} from "../utils/messages.js";
+import {
+  isPermissionDeniedToolResult,
+  PERMISSION_DENIED_TOOL_RESULT_MESSAGE,
+} from "../tui/tool-result-denial.js";
+import { emptyReducedState, reduce } from "./event-log-reducer.js";
+import {
+  parseRolloutLine,
+  type ResponseItem,
+  type RolloutItem,
+} from "./rollout-item.js";
+import { isUserTurnBoundary } from "./rollout-reconstruction.js";
+import { TRAJECTORY_EXPORT_SCHEMA_VERSION } from "./trajectory-export.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Reading + grouping export records
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ParsedTrajectoryExports {
+  /** Rollout items grouped by sessionId, in file/line order. */
+  readonly sessions: ReadonlyMap<string, readonly RolloutItem[]>;
+  /** Lines that parsed as valid export records. */
+  readonly recordCount: number;
+  /** Non-blank lines that failed to parse as export records. */
+  readonly malformedLineCount: number;
+  /** Records whose schemaVersion is not the supported one. */
+  readonly unsupportedSchemaCount: number;
+}
+
+/**
+ * List the `.jsonl` files the export sink writes under a directory
+ * (sorted for deterministic output). A path pointing at a single file
+ * is returned as-is so `AGENC_TRAJECTORY_EXPORT_PATH` mode works too.
+ */
+export function listTrajectoryExportFiles(path: string): string[] {
+  const resolved = resolve(path);
+  if (statSync(resolved).isDirectory()) {
+    return readdirSync(resolved)
+      .filter((name) => name.endsWith(".jsonl"))
+      .sort()
+      .map((name) => join(resolved, name));
+  }
+  return [resolved];
+}
+
+/**
+ * Parse the raw contents of one or more export files into per-session
+ * rollout-item streams. Malformed lines and unsupported schema versions
+ * are counted, never thrown — curation over a partially corrupt export
+ * dir should salvage what it can.
+ */
+export function parseTrajectoryExportContents(
+  contents: readonly string[],
+): ParsedTrajectoryExports {
+  const sessions = new Map<string, RolloutItem[]>();
+  let recordCount = 0;
+  let malformedLineCount = 0;
+  let unsupportedSchemaCount = 0;
+
+  for (const content of contents) {
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      let record: unknown;
+      try {
+        record = JSON.parse(trimmed);
+      } catch {
+        malformedLineCount += 1;
+        continue;
+      }
+      if (
+        record === null ||
+        typeof record !== "object" ||
+        typeof (record as { sessionId?: unknown }).sessionId !== "string" ||
+        (record as { item?: unknown }).item === undefined
+      ) {
+        malformedLineCount += 1;
+        continue;
+      }
+      const { schemaVersion, sessionId, item } = record as {
+        schemaVersion?: unknown;
+        sessionId: string;
+        item: unknown;
+      };
+      if (schemaVersion !== TRAJECTORY_EXPORT_SCHEMA_VERSION) {
+        unsupportedSchemaCount += 1;
+        continue;
+      }
+      // Route the embedded item through the canonical rollout parser so
+      // legacy type aliases and the unknown-variant shim apply exactly
+      // as they do on rollout replay.
+      let parsedItem: RolloutItem | null;
+      try {
+        parsedItem = parseRolloutLine(JSON.stringify(item));
+      } catch {
+        malformedLineCount += 1;
+        continue;
+      }
+      if (parsedItem === null) {
+        malformedLineCount += 1;
+        continue;
+      }
+      recordCount += 1;
+      const existing = sessions.get(sessionId);
+      if (existing) {
+        existing.push(parsedItem);
+      } else {
+        sessions.set(sessionId, [parsedItem]);
+      }
+    }
+  }
+
+  return { sessions, recordCount, malformedLineCount, unsupportedSchemaCount };
+}
+
+/** Convenience: read + parse every export file under `path`. */
+export function readTrajectoryExports(path: string): ParsedTrajectoryExports {
+  const contents = listTrajectoryExportFiles(path).map((file) =>
+    readFileSync(file, "utf8"),
+  );
+  return parseTrajectoryExportContents(contents);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Filtering
+// ─────────────────────────────────────────────────────────────────────
+
+export interface TrajectoryClassification {
+  /** At least one turn ran to completion. */
+  readonly hasTurnComplete: boolean;
+  /** A terminal `error` event was recorded (stream_error does not count). */
+  readonly hasErrorEvent: boolean;
+  /** Any turn was aborted (user interrupt, cancel, terminal abort). */
+  readonly hasTurnAborted: boolean;
+  /** The user rewound the thread (`thread_rolled_back`). */
+  readonly hasThreadRollback: boolean;
+  /** A persisted message carries a user interrupt/rejection marker. */
+  readonly hasUserRejection: boolean;
+}
+
+const USER_REJECTION_MARKERS: readonly string[] = Object.freeze([
+  INTERRUPT_MESSAGE,
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  CANCEL_MESSAGE,
+  REJECT_MESSAGE,
+  REJECT_MESSAGE_WITH_REASON_PREFIX,
+  SUBAGENT_REJECT_MESSAGE,
+  SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX,
+  PERMISSION_DENIED_TOOL_RESULT_MESSAGE,
+]);
+
+/** Flatten a ResponseItem content field to plain text. */
+export function responseItemText(content: ResponseItem["content"]): string {
+  if (typeof content === "string") return content;
+  return content
+    .map((part) => (typeof part.text === "string" ? part.text : ""))
+    .filter((text) => text.length > 0)
+    .join("\n");
+}
+
+function responseItemCarriesRejection(item: ResponseItem): boolean {
+  const text = responseItemText(item.content);
+  if (USER_REJECTION_MARKERS.some((marker) => text.includes(marker))) {
+    return true;
+  }
+  // Tool results produced by a permission denial ("Rejected by user"
+  // payload shapes) — reuse the transcript-layer detector.
+  if (item.role === "tool" || item.toolCallId !== undefined) {
+    return isPermissionDeniedToolResult(text);
+  }
+  return false;
+}
+
+/** Derive the filter signals for one session's exported item stream. */
+export function classifyTrajectory(
+  items: readonly RolloutItem[],
+): TrajectoryClassification {
+  let hasTurnComplete = false;
+  let hasErrorEvent = false;
+  let hasTurnAborted = false;
+  let hasThreadRollback = false;
+  let hasUserRejection = false;
+
+  for (const item of items) {
+    if (item.type === "response_item") {
+      if (!hasUserRejection && responseItemCarriesRejection(item.payload)) {
+        hasUserRejection = true;
+      }
+      continue;
+    }
+    if (item.type !== "event_msg") continue;
+    switch (item.payload.msg.type) {
+      case "turn_complete":
+        hasTurnComplete = true;
+        break;
+      case "error":
+        hasErrorEvent = true;
+        break;
+      case "turn_aborted":
+        hasTurnAborted = true;
+        break;
+      case "thread_rolled_back":
+        hasThreadRollback = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {
+    hasTurnComplete,
+    hasErrorEvent,
+    hasTurnAborted,
+    hasThreadRollback,
+    hasUserRejection,
+  };
+}
+
+/**
+ * SFT keeps only fully clean trajectories: completed, no error, no
+ * abort/interrupt, no rejection markers, and no thread rollback (a
+ * rollback is an explicit user rejection of part of the trajectory —
+ * those sessions feed the DPO path instead).
+ */
+export function isSftEligible(c: TrajectoryClassification): boolean {
+  return (
+    c.hasTurnComplete &&
+    !c.hasErrorEvent &&
+    !c.hasTurnAborted &&
+    !c.hasThreadRollback &&
+    !c.hasUserRejection
+  );
+}
+
+/**
+ * DPO requires a completed, error-free, uninterrupted session that
+ * contains at least one rollback (the preference signal source).
+ */
+export function isDpoEligible(c: TrajectoryClassification): boolean {
+  return (
+    c.hasTurnComplete &&
+    !c.hasErrorEvent &&
+    !c.hasTurnAborted &&
+    c.hasThreadRollback
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Chat-schema mapping
+// ─────────────────────────────────────────────────────────────────────
+
+export interface CuratedChatToolCall {
+  readonly id: string;
+  readonly type: "function";
+  readonly function: { readonly name: string; readonly arguments: string };
+}
+
+export interface CuratedChatMessage {
+  readonly role: string;
+  readonly content: string;
+  readonly tool_calls?: readonly CuratedChatToolCall[];
+  readonly tool_call_id?: string;
+  readonly name?: string;
+}
+
+/** One SFT JSONL row: a whole conversation in standard chat schema. */
+export interface SftExample {
+  readonly messages: readonly CuratedChatMessage[];
+  readonly meta: { readonly sessionId: string };
+}
+
+/** One DPO JSONL row: shared prompt + preferred/rejected continuations. */
+export interface DpoPair {
+  readonly prompt: readonly CuratedChatMessage[];
+  readonly chosen: readonly CuratedChatMessage[];
+  readonly rejected: readonly CuratedChatMessage[];
+  readonly meta: { readonly sessionId: string };
+}
+
+export function toChatMessage(item: ResponseItem): CuratedChatMessage {
+  return {
+    role: item.role,
+    content: responseItemText(item.content),
+    ...(item.toolCalls !== undefined && item.toolCalls.length > 0
+      ? {
+          tool_calls: item.toolCalls.map(
+            (call): CuratedChatToolCall => ({
+              id: call.id,
+              type: "function",
+              function: { name: call.name, arguments: call.arguments ?? "" },
+            }),
+          ),
+        }
+      : {}),
+    ...(item.toolCallId !== undefined ? { tool_call_id: item.toolCallId } : {}),
+    ...(item.toolName !== undefined ? { name: item.toolName } : {}),
+  };
+}
+
+/**
+ * Fold a session's item stream through the canonical event-log reducer
+ * so compaction replacement histories and rollback trims apply exactly
+ * as during live replay, then return the final message history.
+ */
+export function reduceTrajectoryHistory(
+  items: readonly RolloutItem[],
+): ResponseItem[] {
+  let state = emptyReducedState();
+  for (const item of items) {
+    state = reduce(state, item).state;
+  }
+  return state.history;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// SFT emission
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the SFT chat example for one kept session, or null when the
+ * reduced history has nothing trainable (no user message or no
+ * assistant message).
+ */
+export function buildSftExample(
+  sessionId: string,
+  items: readonly RolloutItem[],
+): SftExample | null {
+  const history = reduceTrajectoryHistory(items);
+  const hasUser = history.some((item) => item.role === "user");
+  const hasAssistant = history.some((item) => item.role === "assistant");
+  if (!hasUser || !hasAssistant) return null;
+  return {
+    messages: history.map(toChatMessage),
+    meta: { sessionId },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// DPO emission
+// ─────────────────────────────────────────────────────────────────────
+
+export interface DpoDerivation {
+  readonly pairs: readonly DpoPair[];
+  /** Total thread_rolled_back events observed across the session. */
+  readonly rollbackCount: number;
+}
+
+interface RollbackCandidate {
+  /** History prefix surviving the rollback (deep snapshot). */
+  readonly prefix: readonly ResponseItem[];
+  /** Items the rollback discarded (the rejected continuation). */
+  readonly rejected: readonly ResponseItem[];
+}
+
+function firstUserBoundaryIndex(
+  history: readonly ResponseItem[],
+  from: number,
+): number {
+  for (let i = from; i < history.length; i += 1) {
+    const item = history[i];
+    if (item && isUserTurnBoundary(item)) return i;
+  }
+  return -1;
+}
+
+/**
+ * Continuation slice for a preference pair: the assistant/tool messages
+ * that follow the shared prompt, ending at the next user-turn boundary.
+ */
+function continuationAfter(
+  history: readonly ResponseItem[],
+  promptIndex: number,
+): ResponseItem[] {
+  const out: ResponseItem[] = [];
+  for (let i = promptIndex + 1; i < history.length; i += 1) {
+    const item = history[i];
+    if (!item) continue;
+    if (isUserTurnBoundary(item)) break;
+    if (item.role === "assistant" || item.role === "tool") out.push(item);
+  }
+  return out;
+}
+
+function sameHistoryPrefix(
+  a: readonly ResponseItem[],
+  b: readonly ResponseItem[],
+): boolean {
+  if (a.length !== b.length) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Derive preference pairs from `thread_rolled_back` regenerations —
+ * the one honest preference signal this record format carries.
+ *
+ * When the user rewinds N turns and re-prompts, the append-only export
+ * stream keeps both continuations: the discarded one (rejected by the
+ * rewind) and the one the session actually kept. A pair is emitted only
+ * when the evidence genuinely supports "same prompt, one continuation
+ * rejected, one kept":
+ *
+ *   1. the rollback's surviving prefix is byte-identical in the final
+ *      reduced history (no later rollback/compaction rewrote it),
+ *   2. both the discarded slice and the kept continuation start with a
+ *      user-turn-boundary message whose text is identical (a true
+ *      regeneration — if the user re-prompted with different text there
+ *      is no shared prompt and no pair), and
+ *   3. both continuations contain at least one assistant message.
+ *
+ * Anything weaker is skipped rather than fabricated.
+ */
+export function buildDpoPairs(
+  sessionId: string,
+  items: readonly RolloutItem[],
+): DpoDerivation {
+  const candidates: RollbackCandidate[] = [];
+  let rollbackCount = 0;
+
+  let state = emptyReducedState();
+  for (const item of items) {
+    const isRollback =
+      item.type === "event_msg" &&
+      item.payload.msg.type === "thread_rolled_back";
+    const before = isRollback ? state.history : undefined;
+    state = reduce(state, item).state;
+    if (isRollback && before !== undefined) {
+      rollbackCount += 1;
+      const prefix = state.history;
+      candidates.push({
+        prefix: [...prefix],
+        rejected: before.slice(prefix.length),
+      });
+    }
+  }
+
+  const finalHistory = state.history;
+  const pairs: DpoPair[] = [];
+
+  for (const candidate of candidates) {
+    // (1) prefix must have survived to the end of the session.
+    if (finalHistory.length <= candidate.prefix.length) continue;
+    if (
+      !sameHistoryPrefix(
+        candidate.prefix,
+        finalHistory.slice(0, candidate.prefix.length),
+      )
+    ) {
+      continue;
+    }
+
+    // (2) both sides must re-open with the same user prompt.
+    const rejectedPromptIdx = firstUserBoundaryIndex(candidate.rejected, 0);
+    const chosenPromptIdx = firstUserBoundaryIndex(
+      finalHistory,
+      candidate.prefix.length,
+    );
+    if (rejectedPromptIdx === -1 || chosenPromptIdx === -1) continue;
+    const rejectedPrompt = candidate.rejected[rejectedPromptIdx]!;
+    const chosenPrompt = finalHistory[chosenPromptIdx]!;
+    if (
+      responseItemText(rejectedPrompt.content) !==
+      responseItemText(chosenPrompt.content)
+    ) {
+      continue;
+    }
+
+    // (3) both continuations must contain assistant output.
+    const rejected = continuationAfter(candidate.rejected, rejectedPromptIdx);
+    const chosen = continuationAfter(finalHistory, chosenPromptIdx);
+    if (
+      !rejected.some((item) => item.role === "assistant") ||
+      !chosen.some((item) => item.role === "assistant")
+    ) {
+      continue;
+    }
+
+    pairs.push({
+      prompt: [
+        ...finalHistory.slice(0, candidate.prefix.length).map(toChatMessage),
+        toChatMessage(chosenPrompt),
+      ],
+      chosen: chosen.map(toChatMessage),
+      rejected: rejected.map(toChatMessage),
+      meta: { sessionId },
+    });
+  }
+
+  return { pairs, rollbackCount };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// JSONL rendering
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Render rows as JSONL, re-applying the export sink's redaction pass to
+ * each row. The sink already redacts at write time; re-running the same
+ * `redactSecretsInValue` here costs little and protects exports written
+ * by older sinks or hand-assembled files.
+ */
+export function renderTrajectoryJsonl(rows: readonly unknown[]): string {
+  return rows
+    .map((row) => `${JSON.stringify(redactSecretsInValue(row))}\n`)
+    .join("");
+}

--- a/runtime/tests/bin/trajectories-cli.test.ts
+++ b/runtime/tests/bin/trajectories-cli.test.ts
@@ -1,0 +1,302 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { TRAJECTORY_EXPORT_SCHEMA_VERSION } from "../../src/session/trajectory-export.js";
+import {
+  formatAgenCTrajectoriesCliHelpText,
+  parseAgenCTrajectoriesCliArgs,
+  runAgenCTrajectoriesCli,
+  type AgenCTrajectoriesCliIo,
+} from "./trajectories-cli.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Fixtures — the exact JSONL shape the export sink writes
+// ─────────────────────────────────────────────────────────────────────
+
+function exportLine(sessionId: string, item: unknown): string {
+  return JSON.stringify({
+    schemaVersion: TRAJECTORY_EXPORT_SCHEMA_VERSION,
+    exportedAtUnixMs: 1_720_000_000_000,
+    sessionId,
+    rolloutPath: `/tmp/sessions/${sessionId}/rollout.jsonl`,
+    item,
+  });
+}
+
+function response(role: string, content: string, extra: object = {}): unknown {
+  return { type: "response_item", payload: { role, content, ...extra } };
+}
+
+function event(msg: unknown): unknown {
+  return { type: "event_msg", payload: { id: "evt", msg } };
+}
+
+function cleanSessionLines(sessionId: string): string[] {
+  return [
+    exportLine(sessionId, event({ type: "turn_started", payload: { turnId: "t1" } })),
+    exportLine(sessionId, response("user", "Fix the bug")),
+    exportLine(
+      sessionId,
+      response("assistant", "Patched the api_key='sk-cli-plant-123456' handling."),
+    ),
+    exportLine(sessionId, event({ type: "turn_complete", payload: { turnId: "t1" } })),
+  ];
+}
+
+function abortedSessionLines(sessionId: string): string[] {
+  return [
+    exportLine(sessionId, event({ type: "turn_started", payload: { turnId: "t1" } })),
+    exportLine(sessionId, response("user", "Do something")),
+    exportLine(
+      sessionId,
+      event({ type: "turn_aborted", payload: { turnId: "t1", reason: "interrupted" } }),
+    ),
+    exportLine(sessionId, event({ type: "turn_started", payload: { turnId: "t2" } })),
+    exportLine(sessionId, response("user", "ok try again")),
+    exportLine(sessionId, response("assistant", "done")),
+    exportLine(sessionId, event({ type: "turn_complete", payload: { turnId: "t2" } })),
+  ];
+}
+
+interface CapturedIo extends AgenCTrajectoriesCliIo {
+  readonly out: () => string;
+  readonly err: () => string;
+}
+
+function captureIo(): CapturedIo {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout: {
+      write: (chunk: string | Uint8Array) => {
+        stdout.push(String(chunk));
+        return true;
+      },
+    },
+    stderr: {
+      write: (chunk: string | Uint8Array) => {
+        stderr.push(String(chunk));
+        return true;
+      },
+    },
+    out: () => stdout.join(""),
+    err: () => stderr.join(""),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Arg parsing
+// ─────────────────────────────────────────────────────────────────────
+
+describe("parseAgenCTrajectoriesCliArgs", () => {
+  test("returns null for non-trajectories argv", () => {
+    expect(parseAgenCTrajectoriesCliArgs(["doctor"])).toBeNull();
+    expect(parseAgenCTrajectoriesCliArgs([])).toBeNull();
+  });
+
+  test("bare and --help forms show help", () => {
+    expect(parseAgenCTrajectoriesCliArgs(["trajectories"])).toEqual({
+      kind: "help",
+      text: formatAgenCTrajectoriesCliHelpText(),
+    });
+    expect(
+      parseAgenCTrajectoriesCliArgs(["trajectories", "export", "--help"]),
+    ).toMatchObject({ kind: "help" });
+  });
+
+  test("export defaults to sft format", () => {
+    expect(parseAgenCTrajectoriesCliArgs(["trajectories", "export"])).toEqual({
+      kind: "export",
+      format: "sft",
+    });
+  });
+
+  test("export accepts --format, --dir, and --out in both flag forms", () => {
+    expect(
+      parseAgenCTrajectoriesCliArgs([
+        "trajectories",
+        "export",
+        "--format=dpo",
+        "--dir",
+        "/exports",
+        "--out=pairs.jsonl",
+      ]),
+    ).toEqual({
+      kind: "export",
+      format: "dpo",
+      dir: "/exports",
+      out: "pairs.jsonl",
+    });
+  });
+
+  test("rejects unknown subcommands, formats, and stray arguments", () => {
+    expect(
+      parseAgenCTrajectoriesCliArgs(["trajectories", "import"]),
+    ).toMatchObject({ kind: "error" });
+    expect(
+      parseAgenCTrajectoriesCliArgs(["trajectories", "export", "--format", "csv"]),
+    ).toMatchObject({ kind: "error" });
+    expect(
+      parseAgenCTrajectoriesCliArgs(["trajectories", "export", "extra"]),
+    ).toMatchObject({ kind: "error" });
+    expect(
+      parseAgenCTrajectoriesCliArgs(["trajectories", "export", "--dir"]),
+    ).toMatchObject({ kind: "error" });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Export runs against a real temp export dir
+// ─────────────────────────────────────────────────────────────────────
+
+describe("runAgenCTrajectoriesCli export", () => {
+  let dir = "";
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agenc-traj-cli-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("sft: keeps the clean session, drops the aborted one, redacts output", async () => {
+    writeFileSync(
+      join(dir, "sess-clean.jsonl"),
+      `${cleanSessionLines("sess-clean").join("\n")}\n`,
+    );
+    writeFileSync(
+      join(dir, "sess-aborted.jsonl"),
+      `${abortedSessionLines("sess-aborted").join("\n")}\n`,
+    );
+
+    const io = captureIo();
+    const code = await runAgenCTrajectoriesCli(
+      { kind: "export", format: "sft", dir },
+      { env: {}, io },
+    );
+
+    expect(code).toBe(0);
+    const rows = io
+      .out()
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].meta.sessionId).toBe("sess-clean");
+    expect(rows[0].messages.map((m: { role: string }) => m.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    // The planted secret must not survive emission.
+    expect(io.out()).not.toContain("sk-cli-plant-123456");
+    expect(io.out()).toContain("[REDACTED_SECRET]");
+    expect(io.err()).toContain("kept 1");
+    expect(io.err()).toContain("1 aborted/interrupted");
+  });
+
+  test("sft: resolves the source dir from AGENC_TRAJECTORY_EXPORT_DIR", async () => {
+    writeFileSync(
+      join(dir, "sess-clean.jsonl"),
+      `${cleanSessionLines("sess-clean").join("\n")}\n`,
+    );
+    const io = captureIo();
+    const code = await runAgenCTrajectoriesCli(
+      { kind: "export", format: "sft" },
+      { env: { AGENC_TRAJECTORY_EXPORT_DIR: dir }, io },
+    );
+    expect(code).toBe(0);
+    expect(io.out().trim().split("\n")).toHaveLength(1);
+  });
+
+  test("sft: --out writes the JSONL file instead of stdout", async () => {
+    writeFileSync(
+      join(dir, "sess-clean.jsonl"),
+      `${cleanSessionLines("sess-clean").join("\n")}\n`,
+    );
+    const outPath = join(dir, "out", "..", "sft.jsonl");
+    mkdirSync(join(dir, "out"), { recursive: true });
+
+    const io = captureIo();
+    const code = await runAgenCTrajectoriesCli(
+      { kind: "export", format: "sft", dir, out: outPath },
+      { env: {}, io },
+    );
+
+    expect(code).toBe(0);
+    expect(io.out()).toBe("");
+    const written = readFileSync(join(dir, "sft.jsonl"), "utf8");
+    expect(JSON.parse(written.trim()).meta.sessionId).toBe("sess-clean");
+  });
+
+  test("dpo: derives a pair from a rollback regeneration", async () => {
+    const sessionId = "sess-regen";
+    const lines = [
+      exportLine(sessionId, event({ type: "turn_started", payload: { turnId: "t1" } })),
+      exportLine(sessionId, response("user", "Write the parser")),
+      exportLine(sessionId, response("assistant", "A regex-based parser.")),
+      exportLine(sessionId, event({ type: "turn_complete", payload: { turnId: "t1" } })),
+      exportLine(sessionId, event({ type: "thread_rolled_back", payload: { numTurns: 1 } })),
+      exportLine(sessionId, event({ type: "turn_started", payload: { turnId: "t2" } })),
+      exportLine(sessionId, response("user", "Write the parser")),
+      exportLine(sessionId, response("assistant", "A recursive-descent parser.")),
+      exportLine(sessionId, event({ type: "turn_complete", payload: { turnId: "t2" } })),
+    ];
+    writeFileSync(join(dir, `${sessionId}.jsonl`), `${lines.join("\n")}\n`);
+
+    const io = captureIo();
+    const code = await runAgenCTrajectoriesCli(
+      { kind: "export", format: "dpo", dir },
+      { env: {}, io },
+    );
+
+    expect(code).toBe(0);
+    const rows = io
+      .out()
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prompt.at(-1).content).toBe("Write the parser");
+    expect(rows[0].chosen[0].content).toBe("A recursive-descent parser.");
+    expect(rows[0].rejected[0].content).toBe("A regex-based parser.");
+  });
+
+  test("dpo: errors explicitly when no honest pairs exist", async () => {
+    writeFileSync(
+      join(dir, "sess-clean.jsonl"),
+      `${cleanSessionLines("sess-clean").join("\n")}\n`,
+    );
+    const io = captureIo();
+    const code = await runAgenCTrajectoriesCli(
+      { kind: "export", format: "dpo", dir },
+      { env: {}, io },
+    );
+    expect(code).toBe(1);
+    expect(io.out()).toBe("");
+    expect(io.err()).toContain("thread_rolled_back");
+    expect(io.err()).toContain("Nothing was fabricated");
+  });
+
+  test("errors when no source dir is configured or present", async () => {
+    const io = captureIo();
+    expect(
+      await runAgenCTrajectoriesCli(
+        { kind: "export", format: "sft" },
+        { env: {}, io },
+      ),
+    ).toBe(1);
+    expect(io.err()).toContain("AGENC_TRAJECTORY_EXPORT_DIR");
+
+    const io2 = captureIo();
+    expect(
+      await runAgenCTrajectoriesCli(
+        { kind: "export", format: "sft", dir: join(dir, "missing") },
+        { env: {}, io: io2 },
+      ),
+    ).toBe(1);
+    expect(io2.err()).toContain("not found");
+  });
+});

--- a/runtime/tests/session/trajectory-curate.test.ts
+++ b/runtime/tests/session/trajectory-curate.test.ts
@@ -1,0 +1,437 @@
+import { describe, expect, test } from "vitest";
+
+import { REDACTED_SECRET } from "../secrets/sanitizer.js";
+import { REJECT_MESSAGE } from "../utils/messages.js";
+import type { RolloutItem } from "./rollout-item.js";
+import {
+  buildDpoPairs,
+  buildSftExample,
+  classifyTrajectory,
+  isDpoEligible,
+  isSftEligible,
+  parseTrajectoryExportContents,
+  reduceTrajectoryHistory,
+  renderTrajectoryJsonl,
+  responseItemText,
+  toChatMessage,
+} from "./trajectory-curate.js";
+import { TRAJECTORY_EXPORT_SCHEMA_VERSION } from "./trajectory-export.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Fixture helpers — build the exact record shape the export sink writes
+// ─────────────────────────────────────────────────────────────────────
+
+function exportLine(sessionId: string, item: RolloutItem): string {
+  return JSON.stringify({
+    schemaVersion: TRAJECTORY_EXPORT_SCHEMA_VERSION,
+    exportedAtUnixMs: 1_720_000_000_000,
+    sessionId,
+    rolloutPath: `/tmp/sessions/${sessionId}/rollout.jsonl`,
+    item,
+  });
+}
+
+function userItem(text: string): RolloutItem {
+  return { type: "response_item", payload: { role: "user", content: text } };
+}
+
+function assistantItem(text: string): RolloutItem {
+  return {
+    type: "response_item",
+    payload: { role: "assistant", content: text },
+  };
+}
+
+function toolResultItem(text: string, toolCallId = "call-1"): RolloutItem {
+  return {
+    type: "response_item",
+    payload: { role: "tool", content: text, toolCallId, toolName: "Bash" },
+  };
+}
+
+let eventCounter = 0;
+function eventItem(msg: unknown): RolloutItem {
+  eventCounter += 1;
+  return {
+    type: "event_msg",
+    payload: { id: `evt-${eventCounter}`, msg },
+  } as unknown as RolloutItem;
+}
+
+function turnStarted(turnId: string): RolloutItem {
+  return eventItem({ type: "turn_started", payload: { turnId } });
+}
+
+function turnComplete(turnId: string): RolloutItem {
+  return eventItem({ type: "turn_complete", payload: { turnId } });
+}
+
+function turnAborted(turnId: string, reason: string): RolloutItem {
+  return eventItem({ type: "turn_aborted", payload: { turnId, reason } });
+}
+
+function errorEvent(message: string): RolloutItem {
+  return eventItem({ type: "error", payload: { cause: "test", message } });
+}
+
+function streamErrorEvent(message: string): RolloutItem {
+  return eventItem({
+    type: "stream_error",
+    payload: { cause: "provider", message },
+  });
+}
+
+function rolledBack(numTurns: number): RolloutItem {
+  return eventItem({ type: "thread_rolled_back", payload: { numTurns } });
+}
+
+function cleanSessionItems(): RolloutItem[] {
+  return [
+    turnStarted("t1"),
+    userItem("Fix the failing parser test"),
+    assistantItem("Fixed the tokenizer boundary check."),
+    turnComplete("t1"),
+  ];
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Parsing + grouping
+// ─────────────────────────────────────────────────────────────────────
+
+describe("parseTrajectoryExportContents", () => {
+  test("groups records by sessionId across files, in order", () => {
+    const fileA = [
+      exportLine("sess-a", turnStarted("t1")),
+      exportLine("sess-b", turnStarted("t9")),
+      exportLine("sess-a", userItem("hello")),
+    ].join("\n");
+    const fileB = exportLine("sess-a", turnComplete("t1"));
+
+    const parsed = parseTrajectoryExportContents([fileA, fileB]);
+
+    expect(parsed.recordCount).toBe(4);
+    expect([...parsed.sessions.keys()].sort()).toEqual(["sess-a", "sess-b"]);
+    const sessA = parsed.sessions.get("sess-a")!;
+    expect(sessA).toHaveLength(3);
+    expect(sessA[0]!.type).toBe("event_msg");
+    expect(sessA[1]!.type).toBe("response_item");
+    expect(sessA[2]!.type).toBe("event_msg");
+  });
+
+  test("counts malformed lines and unsupported schema versions without throwing", () => {
+    const good = exportLine("sess-a", userItem("ok"));
+    const futureSchema = JSON.stringify({
+      schemaVersion: TRAJECTORY_EXPORT_SCHEMA_VERSION + 1,
+      sessionId: "sess-future",
+      item: userItem("nope"),
+    });
+    const parsed = parseTrajectoryExportContents([
+      ["not json at all", good, "{\"sessionId\": 42}", futureSchema, ""].join(
+        "\n",
+      ),
+    ]);
+
+    expect(parsed.recordCount).toBe(1);
+    expect(parsed.malformedLineCount).toBe(2);
+    expect(parsed.unsupportedSchemaCount).toBe(1);
+    expect(parsed.sessions.has("sess-future")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Filtering
+// ─────────────────────────────────────────────────────────────────────
+
+describe("classifyTrajectory filtering", () => {
+  test("a clean completed session is SFT eligible", () => {
+    const c = classifyTrajectory(cleanSessionItems());
+    expect(c.hasTurnComplete).toBe(true);
+    expect(isSftEligible(c)).toBe(true);
+  });
+
+  test("a session with a terminal error event is excluded", () => {
+    const c = classifyTrajectory([
+      ...cleanSessionItems(),
+      errorEvent("provider exploded"),
+    ]);
+    expect(c.hasErrorEvent).toBe(true);
+    expect(isSftEligible(c)).toBe(false);
+    expect(isDpoEligible(c)).toBe(false);
+  });
+
+  test("an aborted/interrupted session is excluded", () => {
+    const c = classifyTrajectory([
+      turnStarted("t1"),
+      userItem("do the thing"),
+      turnAborted("t1", "interrupted"),
+      turnStarted("t2"),
+      userItem("ok try again"),
+      assistantItem("done"),
+      turnComplete("t2"),
+    ]);
+    expect(c.hasTurnAborted).toBe(true);
+    expect(isSftEligible(c)).toBe(false);
+    expect(isDpoEligible(c)).toBe(false);
+  });
+
+  test("a session with no completed turn is excluded", () => {
+    const c = classifyTrajectory([turnStarted("t1"), userItem("hello")]);
+    expect(c.hasTurnComplete).toBe(false);
+    expect(isSftEligible(c)).toBe(false);
+  });
+
+  test("a user tool-use rejection marker excludes the session", () => {
+    const c = classifyTrajectory([
+      turnStarted("t1"),
+      userItem("edit the file"),
+      toolResultItem(REJECT_MESSAGE),
+      assistantItem("Understood, waiting."),
+      turnComplete("t1"),
+    ]);
+    expect(c.hasUserRejection).toBe(true);
+    expect(isSftEligible(c)).toBe(false);
+  });
+
+  test("a permission-denied tool result excludes the session", () => {
+    const c = classifyTrajectory([
+      turnStarted("t1"),
+      userItem("run it"),
+      toolResultItem("Permission request denied by user."),
+      turnComplete("t1"),
+    ]);
+    expect(c.hasUserRejection).toBe(true);
+    expect(isSftEligible(c)).toBe(false);
+  });
+
+  test("a 'Rejected by user' tool result excludes the session", () => {
+    const c = classifyTrajectory([
+      turnStarted("t1"),
+      userItem("run it"),
+      toolResultItem("Rejected by user"),
+      turnComplete("t1"),
+    ]);
+    expect(c.hasUserRejection).toBe(true);
+    expect(isSftEligible(c)).toBe(false);
+  });
+
+  test("a recovered stream_error does not exclude the session", () => {
+    const c = classifyTrajectory([
+      turnStarted("t1"),
+      userItem("hello"),
+      streamErrorEvent("529 overloaded"),
+      assistantItem("hi"),
+      turnComplete("t1"),
+    ]);
+    expect(c.hasErrorEvent).toBe(false);
+    expect(isSftEligible(c)).toBe(true);
+  });
+
+  test("a thread rollback routes the session to DPO, not SFT", () => {
+    const c = classifyTrajectory([...cleanSessionItems(), rolledBack(1)]);
+    expect(c.hasThreadRollback).toBe(true);
+    expect(isSftEligible(c)).toBe(false);
+    expect(isDpoEligible(c)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// SFT emission
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSftExample", () => {
+  test("emits standard chat schema with tool calls and tool results", () => {
+    const items: RolloutItem[] = [
+      turnStarted("t1"),
+      userItem("List the files"),
+      {
+        type: "response_item",
+        payload: {
+          role: "assistant",
+          content: [{ type: "text", text: "Listing now." }],
+          toolCalls: [
+            { id: "call-1", name: "Bash", arguments: '{"command":"ls"}' },
+          ],
+        },
+      },
+      toolResultItem("README.md\nsrc", "call-1"),
+      assistantItem("Two entries: README.md and src."),
+      turnComplete("t1"),
+    ];
+
+    const example = buildSftExample("sess-sft", items);
+    expect(example).not.toBeNull();
+    expect(example!.meta.sessionId).toBe("sess-sft");
+    expect(example!.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+    ]);
+    expect(example!.messages[1]!.content).toBe("Listing now.");
+    expect(example!.messages[1]!.tool_calls).toEqual([
+      {
+        id: "call-1",
+        type: "function",
+        function: { name: "Bash", arguments: '{"command":"ls"}' },
+      },
+    ]);
+    expect(example!.messages[2]!.tool_call_id).toBe("call-1");
+    expect(example!.messages[2]!.name).toBe("Bash");
+  });
+
+  test("returns null when there is nothing trainable", () => {
+    expect(
+      buildSftExample("sess-empty", [
+        turnStarted("t1"),
+        userItem("hello?"),
+        turnComplete("t1"),
+      ]),
+    ).toBeNull();
+  });
+
+  test("applies compaction replacement history via the reducer", () => {
+    const items: RolloutItem[] = [
+      userItem("old prompt"),
+      assistantItem("old answer"),
+      {
+        type: "compacted",
+        payload: {
+          message: "summary",
+          replacementHistory: [
+            { role: "user", content: "compact summary of the session" },
+          ],
+        },
+      },
+      userItem("new prompt"),
+      assistantItem("new answer"),
+      turnComplete("t2"),
+    ];
+    const history = reduceTrajectoryHistory(items);
+    expect(history.map((item) => responseItemText(item.content))).toEqual([
+      "compact summary of the session",
+      "new prompt",
+      "new answer",
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// DPO emission
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildDpoPairs", () => {
+  function regenerationItems(rePrompt: string): RolloutItem[] {
+    return [
+      turnStarted("t1"),
+      userItem("Set up the project"),
+      assistantItem("Scaffolded with defaults."),
+      turnComplete("t1"),
+      turnStarted("t2"),
+      userItem("Write the parser"),
+      assistantItem("Here is a regex-based parser."),
+      turnComplete("t2"),
+      rolledBack(1),
+      turnStarted("t3"),
+      userItem(rePrompt),
+      assistantItem("Here is a recursive-descent parser."),
+      turnComplete("t3"),
+    ];
+  }
+
+  test("derives a pair from a same-prompt rollback regeneration", () => {
+    const { pairs, rollbackCount } = buildDpoPairs(
+      "sess-dpo",
+      regenerationItems("Write the parser"),
+    );
+
+    expect(rollbackCount).toBe(1);
+    expect(pairs).toHaveLength(1);
+    const pair = pairs[0]!;
+    expect(pair.meta.sessionId).toBe("sess-dpo");
+    // Prompt: surviving prefix + the shared user message.
+    expect(pair.prompt.map((m) => m.content)).toEqual([
+      "Set up the project",
+      "Scaffolded with defaults.",
+      "Write the parser",
+    ]);
+    expect(pair.chosen.map((m) => m.content)).toEqual([
+      "Here is a recursive-descent parser.",
+    ]);
+    expect(pair.rejected.map((m) => m.content)).toEqual([
+      "Here is a regex-based parser.",
+    ]);
+  });
+
+  test("does not fabricate a pair when the re-prompt differs", () => {
+    const { pairs, rollbackCount } = buildDpoPairs(
+      "sess-dpo",
+      regenerationItems("Actually, write a lexer instead"),
+    );
+    expect(rollbackCount).toBe(1);
+    expect(pairs).toHaveLength(0);
+  });
+
+  test("does not fabricate a pair when the rejected side has no assistant output", () => {
+    const { pairs } = buildDpoPairs("sess-dpo", [
+      turnStarted("t1"),
+      userItem("Write the parser"),
+      turnComplete("t1"),
+      rolledBack(1),
+      turnStarted("t2"),
+      userItem("Write the parser"),
+      assistantItem("Done."),
+      turnComplete("t2"),
+    ]);
+    expect(pairs).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Redaction on emission
+// ─────────────────────────────────────────────────────────────────────
+
+describe("renderTrajectoryJsonl", () => {
+  test("re-applies the export sink's redaction to emitted rows", () => {
+    const items: RolloutItem[] = [
+      turnStarted("t1"),
+      userItem("configure it with api_key='sk-plant-1234567890'"),
+      assistantItem("Set OPENAI_API_KEY=abcd1234efgh5678 in the env."),
+      turnComplete("t1"),
+    ];
+    const example = buildSftExample("sess-secret", items);
+    expect(example).not.toBeNull();
+
+    const jsonl = renderTrajectoryJsonl([example]);
+
+    expect(jsonl).not.toContain("sk-plant-1234567890");
+    expect(jsonl).not.toContain("abcd1234efgh5678");
+    expect(jsonl).toContain(REDACTED_SECRET);
+    // Still valid one-row JSONL in chat schema.
+    const rows = jsonl.trim().split("\n").map((line) => JSON.parse(line));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].messages[0].role).toBe("user");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Chat mapping
+// ─────────────────────────────────────────────────────────────────────
+
+describe("toChatMessage", () => {
+  test("flattens text content blocks and omits absent tool fields", () => {
+    const message = toChatMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "part one" },
+        { type: "image_url", image_url: { url: "data:..." } },
+        { type: "text", text: "part two" },
+      ],
+    });
+    expect(message).toEqual({
+      role: "assistant",
+      content: "part one\npart two",
+    });
+    expect("tool_calls" in message).toBe(false);
+    expect("tool_call_id" in message).toBe(false);
+  });
+});


### PR DESCRIPTION
## Task 24

The trajectory export sink existed (`session/trajectory-export.ts`, env-gated) but had no curation/formatting layer and no CLI.

**`agenc trajectories export [--format sft|dpo] [--dir] [--out]`** — pure local file processing, no network:
- **Filtering**: completed-without-error only — terminal `error`, `turn_aborted`, `thread_rolled_back`, and user-rejection tool-result markers all excluded; `--require-eval-passed` deliberately skipped (the record format carries no eval outcome — documented).
- **Redaction**: re-applies the sink's own `redactSecretsInValue` on every emitted row (defense in depth over the write-time pass).
- **SFT**: chat-schema conversations rebuilt through the canonical event-log reducer so compaction/rollback semantics hold.
- **DPO**: honest preference pairs ONLY from rollback regenerations — byte-identical surviving prefix + identical re-prompt + assistant output on both sides; zero derivable pairs = explicit error. Nothing fabricated.
- `docs/trajectory-training-data.md` documents enable → run → export; distillation runbook + eval-comparison noted as follow-ups.
- `.gitignore`: `!runtime/tests/bin/` negation (tests there stop needing `git add -f` — recorded gotcha from task 6).

**Tests**: fixture trajectories for filtering, redaction (planted secrets absent), JSONL schemas; **revert-sensitivity proven red** (removing redaction-on-emit + turn_aborted filtering → 3 failures).

**Gates:** build ✅ · typecheck 0 · full vitest **13,933 passed / 0 failed / exit 0** · test:bun 86/0 · TUI startup ✅

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES