### PR TITLE
feat(models): onboard the Claude 5 family (claude-fable-5) with always-on-thinking wire semantics

### DIFF
--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -121,7 +121,11 @@ export const BUILT_IN_PROVIDER_MODEL_CATALOG: Readonly<
   openai: mergeDerivedProviderModels("openai", {
     trailingExtras: ["o3"],
   }),
-  anthropic: Object.freeze(["claude-opus-4-8", "claude-opus-4-7"]),
+  anthropic: Object.freeze([
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+  ]),
   ollama: Object.freeze(["llama3.3"]),
   lmstudio: Object.freeze(["gpt-4o-mini"]),
   "openai-compatible": Object.freeze(["local-model"]),

--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -32,6 +32,7 @@ import {
   decodeMcpToolNameFromWire,
   encodeMcpToolNameForWire,
 } from "./mcp-tool-naming.js";
+import { isAlwaysOnThinkingAnthropicModel } from "../../utils/model/alwaysOnThinking.js";
 
 export interface AnthropicMessagesRequestOptions {
   readonly model: string;
@@ -282,7 +283,11 @@ export function buildAnthropicMessagesRequest(
   };
 
   if (system.length > 0) body.system = system;
-  if (input.options?.temperature !== undefined) {
+  // Task 28: the Fable/Mythos 5 family removed sampling parameters —
+  // sending `temperature` returns a 400 (provider docs, verified
+  // 2026-07-08). Opus-family behavior is unchanged.
+  const alwaysOnThinking = isAlwaysOnThinkingAnthropicModel(input.model);
+  if (input.options?.temperature !== undefined && !alwaysOnThinking) {
     body.temperature = input.options.temperature;
   }
   if (
@@ -312,7 +317,14 @@ export function buildAnthropicMessagesRequest(
   // permits 'auto'/'none', returning a 400 otherwise). Mirror that constraint
   // by omitting any forced tool_choice (falling back to auto) whenever
   // thinking will be enabled on this request.
-  const thinkingEnabled = input.options?.reasoningEffort !== undefined;
+  //
+  // Task 28: on the Fable/Mythos 5 family thinking is ALWAYS on server-side
+  // regardless of `reasoningEffort`, so the forced-tool_choice constraint
+  // applies unconditionally there. The docs do not state that the family
+  // relaxed the forced-tool_choice-with-thinking rule, so we conservatively
+  // keep it (falling back to auto never 400s; forcing could).
+  const thinkingEnabled =
+    alwaysOnThinking || input.options?.reasoningEffort !== undefined;
   if (input.options?.toolChoice !== undefined) {
     const toolChoice = parseAnthropicToolChoice(input.options.toolChoice);
     if (toolChoice !== undefined && !thinkingEnabled) {
@@ -325,7 +337,13 @@ export function buildAnthropicMessagesRequest(
       name: ANTHROPIC_STRUCTURED_OUTPUT_TOOL_NAME,
     };
   }
-  if (thinkingEnabled) {
+  // Task 28: never attach a `thinking` config for the Fable/Mythos 5
+  // family — thinking is always on and any explicit configuration other
+  // than `{type:"adaptive"}` (incl. `disabled` and `enabled`/budget_tokens)
+  // returns a 400; omitting the param runs adaptive thinking. Depth is the
+  // effort parameter's job on that family. Opus-family (>= 4.6) behavior
+  // below is unchanged.
+  if (thinkingEnabled && !alwaysOnThinking) {
     body.thinking = {
       type: "enabled",
       budget_tokens:

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -504,12 +504,19 @@ function assistantMessageFromResponse(
   providerName: string,
 ): AssistantMessage {
   const visible = toVisibleAssistantText(response.content ?? "", planMode);
+  // Task 28: `content_filter` is the normalized form of the provider
+  // `refusal` stop reason (Claude Fable 5 safety classifiers return it on
+  // HTTP 200, often with EMPTY content). Without an apiError mapping the
+  // turn ended as a silent empty assistant message; surface it like the
+  // other terminal stop reasons instead.
   const apiError =
     response.finishReason === "length"
       ? "max_output_tokens"
       : response.finishReason === "error"
         ? "provider_error"
-        : undefined;
+        : response.finishReason === "content_filter"
+          ? "refusal"
+          : undefined;
   const allowToolCalls = response.finishReason !== "length";
   // I-55: normalize tool_use blocks into canonical shape before the
   // validator sees them (provider-family quirks collapsed here).
@@ -517,10 +524,16 @@ function assistantMessageFromResponse(
     providerName,
     allowToolCalls ? response.toolCalls ?? [] : [],
   );
+  // A pre-output refusal carries no content at all; give the message a
+  // clear user-visible body so the renderer doesn't show a blank turn.
+  const text =
+    apiError === "refusal" && visible.text.length === 0
+      ? "The model declined to answer this request (stop reason: refusal). No content was returned — rephrase the request or try a different model."
+      : visible.text;
   return {
     uuid: crypto.randomUUID(),
     role: "assistant",
-    text: visible.text,
+    text,
     toolCalls: normalizedToolCalls,
     apiError,
   };

--- a/runtime/src/utils/betas.ts
+++ b/runtime/src/utils/betas.ts
@@ -150,6 +150,7 @@ export function modelSupportsStructuredOutputs(model: string): boolean {
     canonical.includes('claude-opus-4-6') ||
     canonical.includes('claude-opus-4-7') ||
     canonical.includes('claude-opus-4-8') ||
+    canonical.includes('claude-fable-5') ||
     canonical.includes('claude-haiku-4-5')
   )
 }

--- a/runtime/src/utils/commitAttribution.ts
+++ b/runtime/src/utils/commitAttribution.ts
@@ -103,6 +103,7 @@ export function sanitizeSurfaceKey(surfaceKey: string): string {
  */
 export function sanitizeModelName(shortName: string): string {
   // Map internal variants to public equivalents based on model family
+  if (shortName.includes('fable-5')) return 'claude-fable-5'
   if (shortName.includes('opus-4-8')) return 'claude-opus-4-8'
   if (shortName.includes('opus-4-7')) return 'claude-opus-4-7'
   if (shortName.includes('opus-4-6')) return 'claude-opus-4-6'

--- a/runtime/src/utils/context.ts
+++ b/runtime/src/utils/context.ts
@@ -63,7 +63,7 @@ export function has1mContext(model: string): boolean {
  */
 export function claudeFamilyVersion(
   model: string,
-  family: 'opus' | 'sonnet' | 'haiku',
+  family: 'opus' | 'sonnet' | 'haiku' | 'fable',
 ): number | undefined {
   // Minor is capped at 2 digits with a no-digit lookahead so dated ids
   // ('claude-opus-4-20250514' = Opus 4.0) don't parse the date as a minor.
@@ -91,6 +91,12 @@ export function modelSupports1M(model: string): boolean {
   // for aliases/provider spellings the regex can't see.
   const canonical = getCanonicalName(model)
   for (const candidate of [model, canonical]) {
+    // Fable 5+: 1M context is the default (and maximum) window per the
+    // provider docs (verified 2026-07-08).
+    const fableVersion = claudeFamilyVersion(candidate, 'fable')
+    if (fableVersion !== undefined) {
+      return fableVersion >= 5
+    }
     const opusVersion = claudeFamilyVersion(candidate, 'opus')
     if (opusVersion !== undefined) {
       return opusVersion >= 4.06
@@ -278,9 +284,15 @@ export function getModelMaxOutputTokens(model: string): {
 
   // Raw-first for the same reason as modelSupports1M: canonicalization
   // collapses not-yet-known minors down to 'claude-opus-4'.
+  const fableVersion =
+    claudeFamilyVersion(model, 'fable') ?? claudeFamilyVersion(m, 'fable')
   const opusVersion =
     claudeFamilyVersion(model, 'opus') ?? claudeFamilyVersion(m, 'opus')
-  if (opusVersion !== undefined && opusVersion >= 4.06) {
+  if (fableVersion !== undefined && fableVersion >= 5) {
+    // Fable 5+: 128K max output (provider docs, verified 2026-07-08).
+    defaultTokens = 64_000
+    upperLimit = 128_000
+  } else if (opusVersion !== undefined && opusVersion >= 4.06) {
     // Opus 4.6+ (incl. 4.7/4.8): 128K max output. 4.7 previously fell
     // through to the generic opus-4 32K branch.
     defaultTokens = 64_000

--- a/runtime/src/utils/effort.ts
+++ b/runtime/src/utils/effort.ts
@@ -49,6 +49,7 @@ export function modelSupportsEffort(model: string): boolean {
     m.includes('opus-4-6') ||
     m.includes('opus-4-7') ||
     m.includes('opus-4-8') ||
+    m.includes('fable-5') ||
     m.includes('sonnet-4-6')
   ) {
     return true
@@ -76,7 +77,14 @@ export function modelSupportsMaxEffort(model: string): boolean {
     return supported3P
   }
   const m = model.toLowerCase()
-  if (m.includes('opus-4-6') || m.includes('opus-4-7') || m.includes('opus-4-8')) {
+  // Fable 5 supports the full effort range incl. 'max' (provider docs,
+  // verified 2026-07-08).
+  if (
+    m.includes('opus-4-6') ||
+    m.includes('opus-4-7') ||
+    m.includes('opus-4-8') ||
+    m.includes('fable-5')
+  ) {
     return true
   }
   if (process.env.USER_TYPE === 'ant' && resolveAntModel(model)) {

--- a/runtime/src/utils/fastMode.ts
+++ b/runtime/src/utils/fastMode.ts
@@ -163,7 +163,8 @@ export function isFastModeSupportedByModel(
   const parsedModel = parseUserSpecifiedModel(model)
   const m = parsedModel.toLowerCase()
   // Fast mode: Opus 4.6/4.7/4.8. 4.8 is the durable fast-capable tier
-  // (4.7 fast mode is deprecated upstream).
+  // (4.7 fast mode is deprecated upstream). Claude Fable 5 has NO fast mode
+  // (provider docs, verified 2026-07-08) — deliberately excluded here.
   return (
     m.includes('opus-4-6') || m.includes('opus-4-7') || m.includes('opus-4-8')
   )

--- a/runtime/src/utils/model/alwaysOnThinking.ts
+++ b/runtime/src/utils/model/alwaysOnThinking.ts
@@ -1,0 +1,27 @@
+/**
+ * Claude Fable/Mythos 5 family detection (`claude-fable-5`,
+ * `claude-mythos-5`, provider spellings like
+ * `us.anthropic.agenc-fable-5-v1`, and future minors such as
+ * `claude-fable-5-1`).
+ *
+ * These models have a DIFFERENT Messages API request surface than the
+ * Opus family (verified against provider docs 2026-07-08):
+ *
+ * - Thinking is ALWAYS ON server-side. The `thinking` request parameter
+ *   must be omitted: `{type: "disabled"}` and
+ *   `{type: "enabled", budget_tokens: N}` both return a 400
+ *   (`{type: "adaptive"}` is accepted but redundant). Depth is controlled
+ *   via the effort parameter instead.
+ * - Sampling parameters (`temperature` / `top_p` / `top_k`) are removed
+ *   and return a 400 when sent.
+ * - Assistant prefill is not supported, and safety classifiers may return
+ *   `stop_reason: "refusal"` (HTTP 200) with a `stop_details` object.
+ *
+ * `claude-mythos-preview` is NOT in this family (it still accepted
+ * `budget_tokens`); the digit requirement below excludes it. Kept
+ * dependency-free so the LLM wire layer can import it without dragging in
+ * settings/auth state.
+ */
+export function isAlwaysOnThinkingAnthropicModel(model: string): boolean {
+  return /(?:^|[/.-])(?:fable|mythos)-\d{1,2}(?!\d)/.test(model.toLowerCase())
+}

--- a/runtime/src/utils/model/configs.ts
+++ b/runtime/src/utils/model/configs.ts
@@ -187,6 +187,25 @@ export const AGENC_OPUS_4_8_CONFIG = {
   minimax: 'MiniMax-M2.5',
 } as const satisfies ModelConfig
 
+// Claude Fable 5: most capable widely released model (GA, $10/$50 per MTok,
+// 1M context default, 128K max output; verified against provider docs
+// 2026-07-08). Bedrock/Vertex/Foundry ids follow the family convention (the
+// migration docs confirm the family is served on those platforms, but the
+// exact provider id strings are not published — mirror of the opus48
+// convention).
+export const AGENC_FABLE_5_CONFIG = {
+  firstParty: 'claude-fable-5',
+  bedrock: 'us.anthropic.agenc-fable-5-v1',
+  vertex: 'claude-fable-5',
+  foundry: 'claude-fable-5',
+  openai: 'gpt-4o',
+  gemini: 'gemini-2.5-pro',
+  github: 'github:copilot',
+  agenc: 'gpt-5.5',
+  'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
+  minimax: 'MiniMax-M2.5',
+} as const satisfies ModelConfig
+
 export const AGENC_SONNET_4_6_CONFIG = {
   firstParty: 'claude-sonnet-4-6',
   bedrock: 'us.anthropic.agenc-sonnet-4-6',
@@ -215,6 +234,7 @@ export const ALL_MODEL_CONFIGS = {
   opus46: AGENC_OPUS_4_6_CONFIG,
   opus47: AGENC_OPUS_4_7_CONFIG,
   opus48: AGENC_OPUS_4_8_CONFIG,
+  fable5: AGENC_FABLE_5_CONFIG,
 } as const satisfies Record<string, ModelConfig>
 
 export type ModelKey = keyof typeof ALL_MODEL_CONFIGS

--- a/runtime/src/utils/model/model.ts
+++ b/runtime/src/utils/model/model.ts
@@ -482,6 +482,9 @@ export function firstPartyNameToCanonical(name: ModelName): ModelShortName {
   name = name.replaceAll('anthropic.agenc-', 'anthropic.claude-')
   // Special cases for AgenC 4+ models to differentiate versions
   // Order matters: check more specific versions first (4-7 before 4-6 before 4-5 before 4)
+  if (name.includes('claude-fable-5')) {
+    return 'claude-fable-5'
+  }
   if (name.includes('claude-opus-4-8')) {
     return 'claude-opus-4-8'
   }
@@ -666,6 +669,10 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
       return 'GPT-5.4'
     case 'gpt-5.3-codex-spark':
       return 'GPT-5.3 Agenc Spark'
+    case getModelStrings().fable5 + '[1m]':
+      return 'Fable 5 (1M context)'
+    case getModelStrings().fable5:
+      return 'Fable 5'
     case getModelStrings().opus48 + '[1m]':
       return 'Opus 4.8 (1M context)'
     case getModelStrings().opus48:
@@ -912,6 +919,9 @@ export function getMarketingNameForModel(modelId: string): string | undefined {
   const has1m = modelId.toLowerCase().includes('[1m]')
   const canonical = getCanonicalName(modelId)
 
+  if (canonical.includes('claude-fable-5')) {
+    return has1m ? 'Fable 5 (with 1M context)' : 'Fable 5'
+  }
   if (canonical.includes('claude-opus-4-8')) {
     return has1m ? 'Opus 4.8 (with 1M context)' : 'Opus 4.8'
   }

--- a/runtime/src/utils/modelCost.ts
+++ b/runtime/src/utils/modelCost.ts
@@ -10,6 +10,7 @@ import {
   AGENC_OPUS_4_5_CONFIG,
   AGENC_OPUS_4_6_CONFIG,
   AGENC_OPUS_4_7_CONFIG,
+  AGENC_FABLE_5_CONFIG,
   AGENC_OPUS_4_8_CONFIG,
   AGENC_OPUS_4_CONFIG,
   AGENC_SONNET_4_5_CONFIG,
@@ -65,6 +66,17 @@ export const COST_TIER_30_150 = {
   webSearchRequests: 0.01,
 } as const satisfies ModelCosts
 
+// Pricing tier for Claude Fable 5: $10 input / $50 output per Mtok
+// (provider docs, verified 2026-07-08). Cache write = 1.25x input,
+// cache read = 0.1x input, matching the other first-party tiers.
+export const COST_TIER_10_50 = {
+  inputTokens: 10,
+  outputTokens: 50,
+  promptCacheWriteTokens: 12.5,
+  promptCacheReadTokens: 1,
+  webSearchRequests: 0.01,
+} as const satisfies ModelCosts
+
 // Pricing for Haiku 3.5: $0.80 input / $4 output per Mtok
 export const COST_HAIKU_35 = {
   inputTokens: 0.8,
@@ -87,6 +99,7 @@ const DEFAULT_UNKNOWN_MODEL_COST = COST_TIER_5_25
 
 function firstPartyNameToCanonicalForCost(name: string): ModelShortName {
   const normalized = name.toLowerCase()
+  if (normalized.includes('claude-fable-5')) return 'claude-fable-5'
   if (normalized.includes('claude-opus-4-8')) return 'claude-opus-4-8'
   if (normalized.includes('claude-opus-4-7')) return 'claude-opus-4-7'
   if (normalized.includes('claude-opus-4-6')) return 'claude-opus-4-6'
@@ -149,6 +162,10 @@ export const MODEL_COSTS: Record<ModelShortName, ModelCosts> = {
     COST_TIER_5_25,
   [firstPartyNameToCanonicalForCost(AGENC_OPUS_4_8_CONFIG.firstParty)]:
     COST_TIER_5_25,
+  // Fable 5 has NO fast mode, so unlike Opus 4.6/4.7/4.8 it does not route
+  // through the fast-aware tier in getModelCosts.
+  [firstPartyNameToCanonicalForCost(AGENC_FABLE_5_CONFIG.firstParty)]:
+    COST_TIER_10_50,
 }
 
 /**

--- a/runtime/src/utils/permissions/yoloClassifier.ts
+++ b/runtime/src/utils/permissions/yoloClassifier.ts
@@ -28,6 +28,7 @@ import { errorMessage } from '../errors.js'
 import { lazySchema } from '../lazySchema.js'
 import { extractTextContent } from '../messages.js'
 import { resolveAntModel } from '../model/antModels.js'
+import { isAlwaysOnThinkingAnthropicModel } from '../model/alwaysOnThinking.js'
 import { getMainLoopModel } from '../model/model.js'
 import { getAutoModeConfig } from '../settings/settings.js'
 import { sideQuery } from '../sideQuery.js'
@@ -811,8 +812,11 @@ function getClassifierThinkingConfig(
   model: string,
 ): [false | undefined, number] {
   if (
-    process.env.USER_TYPE === 'ant' &&
-    resolveAntModel(model)?.alwaysOnThinking
+    (process.env.USER_TYPE === 'ant' &&
+      resolveAntModel(model)?.alwaysOnThinking) ||
+    // Claude Fable/Mythos 5: same always-on behavior for the public family —
+    // `thinking: {type:'disabled'}` returns a 400, so omit and pad instead.
+    isAlwaysOnThinkingAnthropicModel(model)
   ) {
     return [undefined, 2048]
   }

--- a/runtime/src/utils/sideQuery.ts
+++ b/runtime/src/utils/sideQuery.ts
@@ -12,6 +12,7 @@ import { getproviderClient } from '../services/api/client.js'
 import { getModelBetas, modelSupportsStructuredOutputs } from './betas.js'
 import { computeFingerprint } from './fingerprint.js'
 import { normalizeModelStringForAPI } from './model/model.js'
+import { isAlwaysOnThinkingAnthropicModel } from './model/alwaysOnThinking.js'
 
 type MessageParam = provider.MessageParam
 type TextBlockParam = provider.TextBlockParam
@@ -162,12 +163,17 @@ export async function sideQuery(opts: SideQueryOptions): Promise<BetaMessage> {
   ].filter((block): block is TextBlockParam => block !== null)
 
   let thinkingConfig: BetaThinkingConfigParam | undefined
-  if (thinking === false) {
-    thinkingConfig = { type: 'disabled' }
-  } else if (thinking !== undefined) {
-    thinkingConfig = {
-      type: 'enabled',
-      budget_tokens: Math.min(thinking, max_tokens - 1),
+  // Task 28: the always-on-thinking family (Claude Fable/Mythos 5) rejects
+  // BOTH `{type:'disabled'}` and `{type:'enabled', budget_tokens}` with a
+  // 400 — the param must stay omitted (thinking runs adaptively server-side).
+  if (!isAlwaysOnThinkingAnthropicModel(model)) {
+    if (thinking === false) {
+      thinkingConfig = { type: 'disabled' }
+    } else if (thinking !== undefined) {
+      thinkingConfig = {
+        type: 'enabled',
+        budget_tokens: Math.min(thinking, max_tokens - 1),
+      }
     }
   }
 

--- a/runtime/src/utils/thinking.ts
+++ b/runtime/src/utils/thinking.ts
@@ -3,6 +3,7 @@ import type { Theme } from './theme.js'
 import { feature } from 'bun:bundle'
 import { getCanonicalName } from './model/model.js'
 import { resolveAntModel } from './model/antModels.js'
+import { isAlwaysOnThinkingAnthropicModel } from './model/alwaysOnThinking.js'
 import { get3PModelCapabilityOverride } from './model/modelSupportOverrides.js'
 import { getAPIProvider } from './model/providers.js'
 import { getSettingsWithErrors } from './settings/settings.js'
@@ -188,8 +189,13 @@ export function modelSupportsThinking(model: string): boolean {
   ) {
     return true
   }
-  // 3P (Bedrock/Vertex): only Opus 4+ and Sonnet 4+
-  return canonical.includes('sonnet-4') || canonical.includes('opus-4')
+  // 3P (Bedrock/Vertex): Opus 4+, Sonnet 4+, and the always-on-thinking
+  // Fable 5 family (thinking cannot be turned off there at all).
+  return (
+    canonical.includes('sonnet-4') ||
+    canonical.includes('opus-4') ||
+    canonical.includes('fable-5')
+  )
 }
 
 // @[MODEL LAUNCH]: Add the new model to the allowlist if it supports adaptive thinking.
@@ -199,6 +205,13 @@ export function modelSupportsAdaptiveThinking(model: string): boolean {
     return supported3P
   }
   const canonical = getCanonicalName(model)
+  // Claude Fable 5: thinking is ALWAYS ON server-side. Omitting the
+  // `thinking` param runs adaptive thinking and `{type: 'adaptive'}` is the
+  // only explicit config the API accepts (`disabled`/budget_tokens 400) —
+  // provider docs, verified 2026-07-08.
+  if (isAlwaysOnThinkingAnthropicModel(canonical)) {
+    return true
+  }
   // Supported by a subset of AgenC 4 models
   if (canonical.includes('opus-4-7') || canonical.includes('opus-4-6') || canonical.includes('sonnet-4-6')) {
     return true

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -825,3 +825,137 @@ describe("buildAnthropicMessagesRequest", () => {
     expect(response.thinking).toBeUndefined();
   });
 });
+
+/**
+ * Task 28: Claude Fable 5 request-surface family-awareness. The
+ * Fable/Mythos 5 family has a DIFFERENT Messages API surface than the
+ * Opus family (provider docs, verified 2026-07-08): thinking is always
+ * on server-side (any explicit `thinking` config other than adaptive
+ * returns a 400 — the param must be omitted), and sampling parameters
+ * (`temperature`) are removed. The Opus (>= 4.6) path must stay exactly
+ * as-is. These tests fail if someone routes fable through the opus
+ * thinking path.
+ */
+describe("buildAnthropicMessagesRequest — fable/mythos 5 family", () => {
+  const baseInput = {
+    messages: [{ role: "user" as const, content: "hello" }],
+    tools: [],
+  };
+
+  test("a fable-5 request carries NO thinking config while opus-4-8 keeps its config", () => {
+    const fable = buildAnthropicMessagesRequest({
+      ...baseInput,
+      model: "claude-fable-5",
+      options: { reasoningEffort: "high" },
+    });
+    expect(fable.thinking).toBeUndefined();
+
+    // Opus family behavior is unchanged (kept exactly as-is).
+    const opus = buildAnthropicMessagesRequest({
+      ...baseInput,
+      model: "claude-opus-4-8",
+      options: { reasoningEffort: "high" },
+    });
+    expect(opus.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 4096,
+    });
+  });
+
+  test("provider spellings of the family also omit the thinking config", () => {
+    const request = buildAnthropicMessagesRequest({
+      ...baseInput,
+      model: "us.anthropic.agenc-fable-5-v1",
+      options: { reasoningEffort: "medium" },
+    });
+    expect(request.thinking).toBeUndefined();
+  });
+
+  test("fable-5 omits forced tool_choice even without reasoningEffort (thinking is always on)", () => {
+    const tools = [
+      {
+        type: "function" as const,
+        function: {
+          name: "echo",
+          description: "Echo input.",
+          parameters: { type: "object" },
+        },
+      },
+    ];
+    const fable = buildAnthropicMessagesRequest({
+      messages: baseInput.messages,
+      tools,
+      model: "claude-fable-5",
+      options: { toolChoice: "required" },
+    });
+    expect(fable.tool_choice).toBeUndefined();
+
+    // A non-thinking opus request keeps the forced tool_choice.
+    const opus = buildAnthropicMessagesRequest({
+      messages: baseInput.messages,
+      tools,
+      model: "claude-opus-4-8",
+      options: { toolChoice: "required" },
+    });
+    expect(opus.tool_choice).toEqual({ type: "any" });
+  });
+
+  test("fable-5 does not force the structured-output tool choice", () => {
+    const request = buildAnthropicMessagesRequest({
+      ...baseInput,
+      model: "claude-fable-5",
+      options: {
+        structuredOutput: {
+          schema: {
+            type: "json_schema",
+            name: "answer",
+            schema: { type: "object" },
+          },
+        },
+      },
+    });
+    // The structured-output tool is still offered…
+    expect(
+      (request.tools as Array<Record<string, unknown>>).map(
+        (tool) => tool.name,
+      ),
+    ).toEqual([ANTHROPIC_STRUCTURED_OUTPUT_TOOL_NAME]);
+    // …but never force-selected (forced tool_choice with thinking 400s).
+    expect(request.tool_choice).toBeUndefined();
+  });
+
+  test("fable-5 omits temperature (sampling params removed) while opus keeps it", () => {
+    const fable = buildAnthropicMessagesRequest({
+      ...baseInput,
+      model: "claude-fable-5",
+      options: { temperature: 0.4 },
+    });
+    expect(fable.temperature).toBeUndefined();
+
+    const opus = buildAnthropicMessagesRequest({
+      ...baseInput,
+      model: "claude-opus-4-8",
+      options: { temperature: 0.4 },
+    });
+    expect(opus.temperature).toBe(0.4);
+  });
+
+  test("the refusal stop reason parses to the content_filter finish reason", () => {
+    const response = parseAnthropicMessagesResponse(
+      "claude-fable-5",
+      {
+        id: "msg_refusal",
+        model: "claude-fable-5",
+        stop_reason: "refusal",
+        content: [],
+      },
+      {
+        model: "claude-fable-5",
+        messages: [{ role: "user", content: "hello" }],
+        tools: [],
+      },
+    );
+    expect(response.finishReason).toBe("content_filter");
+    expect(response.content).toBe("");
+  });
+});

--- a/runtime/tests/phases/stream-model.test.ts
+++ b/runtime/tests/phases/stream-model.test.ts
@@ -1070,3 +1070,62 @@ describe("streamModel — SessionState.totalTokenUsage accumulator", () => {
     });
   });
 });
+
+describe("streamModel — refusal stop reason (task 28)", () => {
+  // Claude Fable 5 safety classifiers can decline a request on HTTP 200
+  // with `stop_reason: "refusal"` and an EMPTY content array. The wire
+  // normalizes that to finishReason "content_filter"; without an apiError
+  // mapping the turn ended as a silent empty assistant message.
+  test("surfaces a pre-output refusal as a visible apiError message, not silent empty content", async () => {
+    const ctx = mkCtx("chat");
+    const state = mkState(ctx);
+    const provider = mkProvider(async () => ({
+      content: "",
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 0, totalTokens: 10 },
+      model: "claude-fable-5",
+      finishReason: "content_filter",
+    }));
+    const { session } = mkSession(provider);
+
+    await streamModel(
+      state,
+      ctx,
+      session,
+      mkRequest([{ role: "user", content: "hello" }]),
+    );
+
+    const assistant = state.assistantMessages.at(-1);
+    expect(assistant?.apiError).toBe("refusal");
+    // Clear user-visible body — not an empty message.
+    expect(assistant?.text).toContain("refusal");
+    expect((assistant?.text ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("a mid-stream refusal keeps the partial text and still flags the apiError", async () => {
+    const ctx = mkCtx("chat");
+    const state = mkState(ctx);
+    const provider = mkProvider(async (_messages, onChunk) => {
+      onChunk({ content: "partial answer ", done: false });
+      return {
+        content: "partial answer ",
+        toolCalls: [],
+        usage: { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+        model: "claude-fable-5",
+        finishReason: "content_filter",
+      };
+    });
+    const { session } = mkSession(provider);
+
+    await streamModel(
+      state,
+      ctx,
+      session,
+      mkRequest([{ role: "user", content: "hello" }]),
+    );
+
+    const assistant = state.assistantMessages.at(-1);
+    expect(assistant?.apiError).toBe("refusal");
+    expect(assistant?.text).toContain("partial answer");
+  });
+});

--- a/runtime/tests/utils/fable5-onboarding.test.ts
+++ b/runtime/tests/utils/fable5-onboarding.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Task 28: Claude Fable 5 onboarding.
+ *
+ * Capabilities verified against provider docs 2026-07-08: 1M context
+ * (the default window for the model), 128K max output, $10/$50 pricing,
+ * structured outputs, effort incl. max, always-on thinking (adaptive is
+ * the only accepted explicit config; `disabled`/budget_tokens 400), NO
+ * fast mode, NO assistant prefill, and the `refusal` stop reason. The
+ * advisor pairing table in the docs does NOT list Fable 5 (as executor
+ * or advisor), so it is deliberately left out of the advisor tables.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  claudeFamilyVersion,
+  getModelMaxOutputTokens,
+  modelSupports1M,
+} from '../../src/utils/context.js'
+import { getModelCosts } from '../../src/utils/modelCost.js'
+import { modelSupportsStructuredOutputs } from '../../src/utils/betas.js'
+import {
+  modelSupportsEffort,
+  modelSupportsMaxEffort,
+} from '../../src/utils/effort.js'
+import {
+  isValidAdvisorModel,
+  modelSupportsAdvisor,
+} from '../../src/utils/advisor.js'
+import { isFastModeSupportedByModel } from '../../src/utils/fastMode.js'
+import {
+  modelSupportsAdaptiveThinking,
+  modelSupportsThinking,
+} from '../../src/utils/thinking.js'
+import { isAlwaysOnThinkingAnthropicModel } from '../../src/utils/model/alwaysOnThinking.js'
+import { sanitizeModelName } from '../../src/utils/commitAttribution.js'
+import {
+  AGENC_FABLE_5_CONFIG,
+  ALL_MODEL_CONFIGS,
+} from '../../src/utils/model/configs.js'
+import {
+  firstPartyNameToCanonical,
+  getMarketingNameForModel,
+} from '../../src/utils/model/model.js'
+import { BUILT_IN_PROVIDER_MODEL_CATALOG } from '../../src/llm/registry/provider-info.js'
+
+const FABLE_5 = 'claude-fable-5'
+
+beforeEach(() => {
+  vi.stubEnv('AGENC_DISABLE_1M_CONTEXT', '')
+  vi.stubEnv('USER_TYPE', '')
+  // Pin the provider to firstParty regardless of the host machine's env
+  // (an ambient XAI_API_KEY/AGENC_USE_* would flip getAPIProvider()).
+  vi.stubEnv('XAI_API_KEY', '')
+  vi.stubEnv('MINIMAX_API_KEY', '')
+  vi.stubEnv('AGENC_USE_OPENAI', '')
+  vi.stubEnv('AGENC_USE_GEMINI', '')
+  vi.stubEnv('AGENC_USE_GITHUB', '')
+  vi.stubEnv('AGENC_USE_MISTRAL', '')
+  vi.stubEnv('AGENC_USE_MINIMAX', '')
+  vi.stubEnv('NVIDIA_NIM', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('Fable 5 onboarding', () => {
+  it('is registered as a model config with the canonical first-party id', () => {
+    expect(AGENC_FABLE_5_CONFIG.firstParty).toBe(FABLE_5)
+    expect(ALL_MODEL_CONFIGS.fable5).toBe(AGENC_FABLE_5_CONFIG)
+    expect(firstPartyNameToCanonical('us.anthropic.agenc-fable-5-v1')).toBe(
+      FABLE_5,
+    )
+  })
+
+  it('supports 1M context (fable family threshold)', () => {
+    expect(modelSupports1M(FABLE_5)).toBe(true)
+    expect(claudeFamilyVersion(FABLE_5, 'fable')).toBe(5)
+    // A hypothetical fable-5-1 inherits without a table edit.
+    expect(modelSupports1M('claude-fable-5-1')).toBe(true)
+    // The fable regex never claims opus/sonnet strings.
+    expect(claudeFamilyVersion('claude-opus-4-8', 'fable')).toBeUndefined()
+  })
+
+  it('gets the 128K max-output limits', () => {
+    expect(getModelMaxOutputTokens(FABLE_5)).toEqual({
+      default: 64_000,
+      upperLimit: 128_000,
+    })
+  })
+
+  it('bills at the $10/$50 tier with 1.25x/0.1x cache pricing', () => {
+    const costs = getModelCosts(FABLE_5, {
+      input_tokens: 0,
+      output_tokens: 0,
+    } as never)
+    expect(costs.inputTokens).toBe(10)
+    expect(costs.outputTokens).toBe(50)
+    expect(costs.promptCacheWriteTokens).toBe(12.5)
+    expect(costs.promptCacheReadTokens).toBe(1)
+  })
+
+  it('does NOT carry the opus fast-mode premium routing (no fast mode)', () => {
+    // Fable 5 has no fast mode; a (never-produced) fast usage record must
+    // not flip it onto the $30/$150 opus fast tier.
+    const costs = getModelCosts(FABLE_5, {
+      input_tokens: 0,
+      output_tokens: 0,
+      speed: 'fast',
+    } as never)
+    expect(costs.inputTokens).toBe(10)
+    expect(costs.outputTokens).toBe(50)
+  })
+
+  it('supports structured outputs and effort (incl. max)', () => {
+    expect(modelSupportsStructuredOutputs(FABLE_5)).toBe(true)
+    expect(modelSupportsEffort(FABLE_5)).toBe(true)
+    expect(modelSupportsMaxEffort(FABLE_5)).toBe(true)
+  })
+
+  it('has NO fast mode', () => {
+    expect(isFastModeSupportedByModel(FABLE_5)).toBe(false)
+  })
+
+  it('is an always-on-thinking model (adaptive; disabled 400s upstream)', () => {
+    expect(isAlwaysOnThinkingAnthropicModel(FABLE_5)).toBe(true)
+    expect(isAlwaysOnThinkingAnthropicModel('us.anthropic.agenc-fable-5-v1')).toBe(
+      true,
+    )
+    expect(isAlwaysOnThinkingAnthropicModel('claude-mythos-5')).toBe(true)
+    // mythos-preview kept the old surface (budget_tokens) — excluded.
+    expect(isAlwaysOnThinkingAnthropicModel('claude-mythos-preview')).toBe(false)
+    expect(isAlwaysOnThinkingAnthropicModel('claude-opus-4-8')).toBe(false)
+    expect(modelSupportsThinking(FABLE_5)).toBe(true)
+    expect(modelSupportsAdaptiveThinking(FABLE_5)).toBe(true)
+  })
+
+  it('is deliberately NOT in the advisor pairing tables (docs omit it)', () => {
+    expect(modelSupportsAdvisor(FABLE_5)).toBe(false)
+    expect(isValidAdvisorModel(FABLE_5)).toBe(false)
+  })
+
+  it('sanitizes commit attribution to the public fable-5 name', () => {
+    expect(sanitizeModelName('agenc-fable-5-internal')).toBe(FABLE_5)
+  })
+
+  it('is selectable on the anthropic provider registry', () => {
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.anthropic).toContain(FABLE_5)
+    // The existing opus entries stay selectable.
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.anthropic).toContain(
+      'claude-opus-4-8',
+    )
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.anthropic).toContain(
+      'claude-opus-4-7',
+    )
+  })
+
+  it('maps display/marketing names', () => {
+    expect(getMarketingNameForModel(FABLE_5)).toBe('Fable 5')
+    expect(getMarketingNameForModel(`${FABLE_5}[1m]`)).toBe(
+      'Fable 5 (with 1M context)',
+    )
+  })
+})


### PR DESCRIPTION
## Task 28 — every capability verified against current Anthropic docs (2026-07-08)

- **Always-on thinking**: new `isAlwaysOnThinkingAnthropicModel()` (fable/mythos families). The wire OMITS the `thinking` param entirely (explicit disabled/enabled configs 400 per docs), treats requests as thinking-enabled unconditionally (forced `tool_choice` and structured-output forcing fall back to `auto`), and omits sampling params (`temperature` removed on Fable 5 — a docs finding beyond the audit lead). Opus ≥4.6 adaptive path byte-identical. Defense-in-depth at the other thinking-attach sites (sideQuery, yoloClassifier).
- **Refusal**: `stop_reason: "refusal"` was normalized to `content_filter` but died as a silent empty assistant message — now surfaced as a user-visible refusal error (empty-content fallback text; mid-stream partials kept).
- **Capability sites** (task 12's template, all hit): 1M ctx + 128K output via a fable family branch in `claudeFamilyVersion`, $10/$50 cost tier, structured outputs, effort incl. max (no anthropic xhigh tier exists in this runtime), **no fast mode**, allowlists, model strings, commit attribution. **Advisor deliberately excluded** — the docs pairing table does not list Fable 5; pinned by test.
- Defaults unchanged (product decision, same as task 12).

**Revert-sensitivity proven**: 16 new tests fail with the source diff stashed. 12 capability tests + 6 wire tests + 2 refusal tests; opus48-onboarding regression suite stays green.

**Gates:** build ✅ · typecheck 0 · full vitest **13,953 passed / 0 failed / exit 0** · test:bun 86/0 · TUI startup ✅

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES