### PR TITLE
fix(wire): encode named toolChoice + close the bedrock dotted-name leak

### DIFF
--- a/runtime/src/llm/providers/bedrock/index.ts
+++ b/runtime/src/llm/providers/bedrock/index.ts
@@ -23,6 +23,10 @@ import type {
   StreamProgressCallback,
 } from "../../types.js";
 import { nonEmptyString as nonBlankText } from "../../../utils/stringUtils.js";
+import {
+  decodeMcpToolNameFromWire,
+  encodeMcpToolNameForWire,
+} from "../../wire/mcp-tool-naming.js";
 
 const DEFAULT_REGION = "us-east-1";
 const BEDROCK_SERVICE = "bedrock";
@@ -326,7 +330,9 @@ function bedrockContentForMessage(message: LLMMessage): readonly BedrockContentB
     content.push({
       toolUse: {
         toolUseId: toolCall.id,
-        name: toolCall.name,
+        // Replayed history must carry the same encoded wire name as the
+        // toolSpec catalog (see buildToolConfig).
+        name: encodeMcpToolNameForWire(toolCall.name),
         input: parseToolArguments(toolCall),
       },
     });
@@ -378,7 +384,8 @@ function toBedrockToolChoice(
   if (toolChoice === undefined || toolChoice === "auto") return { auto: {} };
   if (toolChoice === "required") return { any: {} };
   if (toolChoice === "none") return undefined;
-  return { tool: { name: toolChoice.name } };
+  // Must reference the encoded toolSpec entry (see buildToolConfig).
+  return { tool: { name: encodeMcpToolNameForWire(toolChoice.name) } };
 }
 
 function buildToolConfig(
@@ -397,7 +404,13 @@ function buildToolConfig(
   const bedrockToolChoice = toBedrockToolChoice(toolChoice);
   const bedrockTools = tools.map((tool) => ({
     toolSpec: {
-      name: tool.function.name,
+      // The Converse `ToolSpecification.name` constraint is pattern
+      // `[a-zA-Z0-9_-]+`, length 1-64 (AWS Bedrock API Reference,
+      // API_runtime_ToolSpecification, checked 2026-07-08) — dots in the
+      // internal `mcp.<server>.<tool>` form are rejected, so ship the
+      // bijective wire encoding here and decode the echoed name in the
+      // response parsers.
+      name: encodeMcpToolNameForWire(tool.function.name),
       ...(tool.function.description.trim().length > 0
         ? { description: tool.function.description }
         : {}),
@@ -556,7 +569,10 @@ function parseResponse(
     if ("toolUse" in block && block.toolUse) {
       toolCalls.push({
         id: block.toolUse.toolUseId,
-        name: block.toolUse.name,
+        // Decode the encoded wire name back to the internal-registry
+        // form (`mcp.<server>.<tool>`) before dispatch. Non-MCP names
+        // pass through unchanged.
+        name: decodeMcpToolNameFromWire(block.toolUse.name),
         arguments: JSON.stringify(block.toolUse.input ?? {}),
       });
     }
@@ -753,7 +769,10 @@ async function parseStreamResponse(params: {
       const toolUse = isRecord(start.toolUse) ? start.toolUse : null;
       if (index >= 0 && toolUse !== null) {
         const id = String(toolUse.toolUseId ?? "");
-        const name = String(toolUse.name ?? "");
+        // Decode the encoded wire name back to the internal-registry
+        // form so downstream dispatch and progress chunks see the
+        // dotted name. Non-MCP names pass through unchanged.
+        const name = decodeMcpToolNameFromWire(String(toolUse.name ?? ""));
         toolBlocks.set(index, { id, name, arguments: "" });
         params.onChunk({
           content: "",

--- a/runtime/src/llm/wire/responses-xai.ts
+++ b/runtime/src/llm/wire/responses-xai.ts
@@ -37,11 +37,17 @@ function normalizeXaiResponsesToolChoice(
     return toolChoice;
   }
 
+  // `tools[]` ships MCP names in the bijective wire encoding
+  // (mcp-tool-naming.ts); a named tool_choice must reference that
+  // encoded entry, not the dotted internal name the provider never saw.
   const directName = typeof toolChoice.name === "string"
     ? toolChoice.name.trim()
     : "";
   if (toolChoice.type === "function" && directName.length > 0) {
-    return { type: "function", function: { name: directName } };
+    return {
+      type: "function",
+      function: { name: encodeMcpToolNameForWire(directName) },
+    };
   }
 
   const legacyName = typeof (toolChoice as { function?: { name?: unknown } }).function
@@ -49,7 +55,10 @@ function normalizeXaiResponsesToolChoice(
     ? (toolChoice as { function?: { name?: string } }).function!.name!.trim()
     : "";
   if (toolChoice.type === "function" && legacyName.length > 0) {
-    return { type: "function", function: { name: legacyName } };
+    return {
+      type: "function",
+      function: { name: encodeMcpToolNameForWire(legacyName) },
+    };
   }
 
   return toolChoice;

--- a/runtime/src/llm/wire/shared.ts
+++ b/runtime/src/llm/wire/shared.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import { normalizeMessagesForAPI } from "../messages.js";
 import { validateToolCall, validateToolCallDetailed } from "../types.js";
+import { encodeMcpToolNameForWire } from "./mcp-tool-naming.js";
 
 function readContentPartRecord(part: unknown): Record<string, unknown> | null {
   return part && typeof part === "object" && !Array.isArray(part)
@@ -578,7 +579,10 @@ export function parseOpenAIToolChoice(
   return {
     type: "function",
     function: {
-      name: toolChoice.name,
+      // `tools[]` ships MCP names in the bijective wire encoding
+      // (mcp-tool-naming.ts); a named tool_choice must reference that
+      // encoded entry, not the dotted internal name the provider never saw.
+      name: encodeMcpToolNameForWire(toolChoice.name),
     },
   };
 }
@@ -591,7 +595,8 @@ export function parseAnthropicToolChoice(
   if (toolChoice === "none") return undefined;
   return {
     type: "tool",
-    name: toolChoice.name,
+    // Must match the encoded `tools[]` entry (see parseOpenAIToolChoice).
+    name: encodeMcpToolNameForWire(toolChoice.name),
   };
 }
 

--- a/runtime/tests/llm/provider-parity.test.ts
+++ b/runtime/tests/llm/provider-parity.test.ts
@@ -80,14 +80,15 @@ const ECHO_TOOL: LLMTool = {
  * dispatch. The literal is hardcoded on purpose: this suite pins the wire
  * contract instead of round-tripping through the encoder.
  *
- * Gemini, Bedrock, and Ollama use their own converters that pass tool
- * names through unencoded, so their wire form stays `system.echo`.
+ * Gemini and Ollama use their own converters that pass tool names
+ * through unencoded, so their wire form stays `system.echo`. Bedrock's
+ * Converse `ToolSpecification.name` pattern (`[a-zA-Z0-9_-]+`) rejects
+ * dots, so its converter encodes/decodes like the strict-regex shims.
  */
 const ECHO_TOOL_WIRE_NAME = "tool2__system_x2eecho";
 const PASSTHROUGH_WIRE_PROVIDERS: ReadonlySet<ProviderName> = new Set([
   "ollama",
   "gemini",
-  "amazon-bedrock",
 ]);
 
 /**
@@ -513,7 +514,8 @@ function buildBedrockPayload(
     ...parityCase.expected.toolCalls.map((toolCall, index) => ({
       toolUse: {
         toolUseId: `toolu_${parityCase.id}_${index}`,
-        name: toolCall.name,
+        // Bedrock echoes the encoded wire name back in toolUse blocks.
+        name: encodedWireToolCallName(toolCall.name),
         input: JSON.parse(toolCall.arguments) as Record<string, unknown>,
       },
     })),

--- a/runtime/tests/llm/providers/bedrock/provider.test.ts
+++ b/runtime/tests/llm/providers/bedrock/provider.test.ts
@@ -233,6 +233,166 @@ describe("providers/bedrock", () => {
     );
   });
 
+  it("encodes dotted MCP tool names across tools, toolChoice, and replayed toolUse, and decodes responses", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        output: {
+          message: {
+            role: "assistant",
+            content: [
+              {
+                toolUse: {
+                  toolUseId: "call-2",
+                  // The model echoes the encoded wire name; the parser
+                  // must decode it back to the dotted internal form.
+                  name: "mcp__memory__search_nodes",
+                  input: { query: "next" },
+                },
+              },
+            ],
+          },
+        },
+        stopReason: "tool_use",
+        usage: { inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+      }),
+    );
+    const provider = new BedrockProvider({
+      accessKeyId: "AKIDEXAMPLE",
+      secretAccessKey: "secret",
+      region: "us-west-2",
+      model: "amazon.nova-pro-v1:0",
+      fetchImpl,
+      now: () => new Date("2024-01-02T03:04:05Z"),
+    });
+
+    const response = await provider.chat(
+      [
+        { role: "user", content: "search" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "mcp.memory.search_nodes",
+              arguments: "{\"query\":\"AgenC\"}",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "mcp.memory.search_nodes",
+          content: "prior result",
+        },
+      ],
+      {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "mcp.memory.search_nodes",
+              description: "Search the memory graph.",
+              parameters: {
+                type: "object",
+                properties: { query: { type: "string" } },
+              },
+            },
+          },
+        ],
+        toolChoice: { type: "function", name: "mcp.memory.search_nodes" },
+      },
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const request = JSON.parse(String(init?.body)) as {
+      messages: Array<{ content: unknown }>;
+      toolConfig: {
+        tools: Array<{ toolSpec: { name: string } }>;
+        toolChoice: { tool: { name: string } };
+      };
+    };
+
+    // The Converse ToolSpecification name pattern is `[a-zA-Z0-9_-]+`
+    // (1-64 chars) — dots are rejected, so the dotted internal name must
+    // ship in the bijective wire encoding. Hardcoded literal on purpose:
+    // pins the wire contract.
+    expect(request.toolConfig.tools[0]!.toolSpec.name).toBe(
+      "mcp__memory__search_nodes",
+    );
+    // toolChoice must reference the encoded toolSpec entry byte-for-byte.
+    expect(request.toolConfig.toolChoice).toEqual({
+      tool: { name: request.toolConfig.tools[0]!.toolSpec.name },
+    });
+    // Replayed assistant toolUse blocks carry the encoded name too, so the
+    // conversation history matches the toolSpec catalog.
+    expect(request.messages[1]!.content).toEqual([
+      {
+        toolUse: {
+          toolUseId: "call-1",
+          name: "mcp__memory__search_nodes",
+          input: { query: "AgenC" },
+        },
+      },
+    ]);
+    // The response parser decodes the echoed wire name back to the
+    // dotted internal-registry form before dispatch.
+    expect(response.toolCalls).toEqual([
+      {
+        id: "call-2",
+        name: "mcp.memory.search_nodes",
+        arguments: "{\"query\":\"next\"}",
+      },
+    ]);
+  });
+
+  it("decodes encoded MCP tool names from ConverseStream tool blocks", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      eventStreamResponse([
+        { messageStart: { role: "assistant" } },
+        {
+          contentBlockStart: {
+            contentBlockIndex: 0,
+            start: {
+              toolUse: {
+                toolUseId: "toolu-2",
+                name: "mcp__memory__search_nodes",
+              },
+            },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { toolUse: { input: "{\"query\":\"status\"}" } },
+          },
+        },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+        { messageStop: { stopReason: "tool_use" } },
+      ]),
+    );
+    const provider = new BedrockProvider({
+      accessKeyId: "AKIDEXAMPLE",
+      secretAccessKey: "secret",
+      model: "amazon.nova-pro-v1:0",
+      fetchImpl,
+      now: () => new Date("2024-01-02T03:04:05Z"),
+    });
+
+    const response = await provider.chatStream(
+      [{ role: "user", content: "hello" }],
+      () => {},
+    );
+
+    expect(response.toolCalls).toEqual([
+      {
+        id: "toolu-2",
+        name: "mcp.memory.search_nodes",
+        arguments: "{\"query\":\"status\"}",
+      },
+    ]);
+  });
+
   it("encodes reserved characters in model identifiers before signing", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({

--- a/runtime/tests/llm/wire/chat-completions.test.ts
+++ b/runtime/tests/llm/wire/chat-completions.test.ts
@@ -425,6 +425,38 @@ describe("buildChatCompletionsRequest", () => {
     expect(request.service_tier).toBe("fast");
   });
 
+  test("encodes a named toolChoice with the same wire name as tools", () => {
+    const request = buildChatCompletionsRequest({
+      model: "qwen-local",
+      messages: [{ role: "user", content: "search memory" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "mcp.memory.search_nodes",
+            description: "Search the memory graph.",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      options: {
+        toolChoice: { type: "function", name: "mcp.memory.search_nodes" },
+      },
+    });
+
+    const tools = request.tools as Array<{
+      function: { name: string };
+    }>;
+    // Hardcoded literal on purpose: pins the wire contract.
+    expect(tools[0]!.function.name).toBe("mcp__memory__search_nodes");
+    // tool_choice must reference the encoded tools[] entry byte-for-byte,
+    // never the dotted internal name the provider never saw.
+    expect(request.tool_choice).toEqual({
+      type: "function",
+      function: { name: tools[0]!.function.name },
+    });
+  });
+
   test("falls back to DeepSeek reasoning_content when content is absent", () => {
     const response = parseChatCompletionsResponse(
       "deepseek-reasoner",

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -824,6 +824,37 @@ describe("buildAnthropicMessagesRequest", () => {
 
     expect(response.thinking).toBeUndefined();
   });
+
+  test("encodes a named toolChoice with the same wire name as tools", () => {
+    const request = buildAnthropicMessagesRequest({
+      model: "claude-sonnet-4.5",
+      messages: [{ role: "user", content: "search memory" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "mcp.memory.search_nodes",
+            description: "Search the memory graph.",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      options: {
+        toolChoice: { type: "function", name: "mcp.memory.search_nodes" },
+      },
+      maxTokens: 4096,
+    });
+
+    const tools = request.tools as Array<{ name: string }>;
+    // Hardcoded literal on purpose: pins the wire contract.
+    expect(tools[0]!.name).toBe("mcp__memory__search_nodes");
+    // tool_choice must reference the encoded tools[] entry byte-for-byte,
+    // never the dotted internal name the provider never saw.
+    expect(request.tool_choice).toEqual({
+      type: "tool",
+      name: tools[0]!.name,
+    });
+  });
 });
 
 /**

--- a/runtime/tests/llm/wire/responses-openai.test.ts
+++ b/runtime/tests/llm/wire/responses-openai.test.ts
@@ -508,6 +508,36 @@ describe("buildOpenAIResponsesRequest", () => {
       },
     ]);
   });
+
+  test("encodes a named toolChoice with the same wire name as tools", () => {
+    const request = buildOpenAIResponsesRequest({
+      model: "gpt-5",
+      messages: [{ role: "user", content: "search memory" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "mcp.memory.search_nodes",
+            description: "Search the memory graph.",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      options: {
+        toolChoice: { type: "function", name: "mcp.memory.search_nodes" },
+      },
+    });
+
+    const tools = request.tools as Array<{ name: string }>;
+    // Hardcoded literal on purpose: pins the wire contract.
+    expect(tools[0]!.name).toBe("mcp__memory__search_nodes");
+    // tool_choice must reference the encoded tools[] entry byte-for-byte,
+    // never the dotted internal name the provider never saw.
+    expect(request.tool_choice).toEqual({
+      type: "function",
+      function: { name: tools[0]!.name },
+    });
+  });
 });
 
 describe("parseOpenAIResponsesResponse", () => {

--- a/runtime/tests/llm/wire/responses-xai.test.ts
+++ b/runtime/tests/llm/wire/responses-xai.test.ts
@@ -263,15 +263,12 @@ describe("responses-xai wire shim", () => {
       prompt_cache_key: "session-1",
       include: [XAI_ENCRYPTED_REASONING_INCLUDE],
       parallel_tool_calls: false,
-      // NOTE: tool_choice is currently NOT run through the MCP wire-name
-      // encoding (normalizeXaiResponsesToolChoice passes the name through),
-      // so a named tool_choice for a dotted tool references a name the
-      // provider never saw in `tools`. This pins today's behavior; if the
-      // shim starts encoding tool_choice too, update this to
-      // TEST_TOOL_WIRE_NAME.
+      // A named tool_choice goes through the same MCP wire-name encoding
+      // as `tools`, so the provider sees a tool_choice name that matches
+      // an entry in `tools` byte-for-byte.
       tool_choice: {
         type: "function",
-        function: { name: "system.echo" },
+        function: { name: TEST_TOOL_WIRE_NAME },
       },
       tools: [
         {


### PR DESCRIPTION
## Task 29 (filed during task 27's wire review)

The bijective tool-name encoding covered `tools[]` but not a named `toolChoice` — a dotted internal name shipped raw in `tool_choice` while `tools[]` shipped encoded, so strict-regex providers saw a tool_choice referencing a nonexistent tool (or 400d on the name pattern).

- `shared.ts`: `parseOpenAIToolChoice` + `parseAnthropicToolChoice` encode the named variant (covers chat-completions, responses-openai, messages-anthropic); the responses-xai normalizer encodes both name paths. String variants (auto/required/none) untouched.
- **Bedrock REQUIRED the encode** (AWS Converse `ToolSpecification.name` pattern `[a-zA-Z0-9_-]+`, max 64 — citation in-code): `toolSpec.name`, named `toolChoice`, and replayed `toolUse` history now encode; response + ConverseStream paths decode. provider-parity moved bedrock out of the passthrough set; its mock echoes the wire name so decode is exercised.
- `tool_choice` is request-only (never echoed) — no response-side decode exists for it; tool-call name decode paths verified complete.

**Revert-sensitivity proven**: 6 new tests red against the unfixed source. The task-27 NOTE-pin in responses-xai.test.ts flipped to the encoded expectation.

**Gates:** build ✅ · typecheck 0 · full vitest **13,958 passed / 0 failed / exit 0** · test:bun 86/0

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES