### PR TITLE
fix(plugins): remove config entries even when migration stripped the managed-block markers

### DIFF
--- a/runtime/src/plugins/cli/pluginOperations.ts
+++ b/runtime/src/plugins/cli/pluginOperations.ts
@@ -2,7 +2,9 @@ import { cp, mkdir, mkdtemp, readFile, realpath, rename, rm, stat, writeFile } f
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { resolveAgencHome } from "../../config/env.js";
-import { loadConfig } from "../../config/loader.js";
+import { cloneRecord, stableJson, type JsonRecord } from "../../config/json.js";
+import { loadConfig, parseToml } from "../../config/loader.js";
+import { serializeConfigToml } from "../../config/migrate.js";
 import type { PluginEntryConfig } from "../../config/schema.js";
 import { isRecord } from "../../utils/record.js";
 import { createPluginFromPath, loadPlugins, type LoadedPlugin } from "../loader.js";
@@ -642,7 +644,13 @@ async function writePluginConfigEntry(
   const marker = managedMarker(pluginId);
   const block = renderManagedPluginBlock(pluginId, entry, marker);
   const text = await readOptionalText(path);
-  const base = removeManagedBlock(text, marker);
+  let base = removeManagedBlock(text, marker);
+  if (base === text.trimEnd()) {
+    // No managed block found (config migrations strip the comment markers
+    // when they canonically rewrite config.toml). Remove any bare entry so
+    // the appended managed block does not create duplicate TOML tables.
+    base = removePluginEntryFromToml(text, pluginId) ?? base;
+  }
   const next = appendManagedBlock(
     entry.enabled === false ? base : ensurePluginsFeatureEnabled(base),
     block,
@@ -658,10 +666,142 @@ async function removePluginConfigEntry(
   const path = pluginConfigPath(options);
   const marker = managedMarker(pluginId);
   const text = await readOptionalText(path);
-  const next = removeManagedBlock(text, marker);
-  if (next === text) return false;
-  await writeTextAtomic(path, next);
+  const withoutBlock = removeManagedBlock(text, marker);
+  if (withoutBlock !== text.trimEnd()) {
+    await writeTextAtomic(path, withoutBlock);
+    return true;
+  }
+  // No managed block found. Config migrations canonically rewrite
+  // config.toml and strip the managed-block comment markers, so fall back
+  // to TOML-aware removal of the plugin entry itself.
+  const withoutEntry = removePluginEntryFromToml(text, pluginId);
+  if (withoutEntry === undefined) return false;
+  await writeTextAtomic(path, withoutEntry);
   return true;
+}
+
+/**
+ * Remove `plugins.plugins.<pluginId>` from a config.toml that no longer has
+ * managed-block markers (config migrations strip comments when rewriting).
+ *
+ * Prefers a surgical, formatting-preserving removal of the entry's table
+ * section; falls back to a canonical re-serialization without the entry.
+ * Every candidate is verified by re-parsing and comparing against the
+ * expected parse result, so a failed edit never corrupts the file.
+ * Returns `undefined` when the entry is absent or cannot be removed safely.
+ */
+function removePluginEntryFromToml(
+  text: string,
+  pluginId: string,
+): string | undefined {
+  if (text.trim().length === 0) return undefined;
+  let sawDuplicateKey = false;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseToml(text, {
+      onDuplicateKey: () => {
+        sawDuplicateKey = true;
+      },
+    });
+  } catch {
+    return undefined;
+  }
+  if (sawDuplicateKey) return undefined;
+  const pluginsTable = isRecord(parsed.plugins) ? parsed.plugins : undefined;
+  const entries = pluginsTable !== undefined && isRecord(pluginsTable.plugins)
+    ? pluginsTable.plugins
+    : undefined;
+  if (entries === undefined || !Object.hasOwn(entries, pluginId)) {
+    return undefined;
+  }
+  // Accept either shape after removal: an empty `plugins.plugins` table can
+  // legitimately disappear entirely (its only declaration was the removed
+  // table header) or stay as an explicit empty table.
+  const expected = [
+    expectedConfigWithoutPluginEntry(parsed, pluginId, true),
+    expectedConfigWithoutPluginEntry(parsed, pluginId, false),
+  ];
+  const surgical = removePluginTableSection(text, pluginId);
+  if (surgical !== undefined && parsesToOneOf(surgical, expected)) {
+    return surgical;
+  }
+  const canonical = serializeConfigToml(expected[0]!);
+  return parsesToOneOf(canonical, expected) ? canonical : undefined;
+}
+
+function expectedConfigWithoutPluginEntry(
+  parsed: Readonly<Record<string, unknown>>,
+  pluginId: string,
+  dropEmptyEntryTable: boolean,
+): JsonRecord {
+  const next = cloneRecord(parsed);
+  const pluginsTable = cloneRecord(next.plugins as Record<string, unknown>);
+  const entries = cloneRecord(pluginsTable.plugins as Record<string, unknown>);
+  delete entries[pluginId];
+  if (dropEmptyEntryTable && Object.keys(entries).length === 0) {
+    delete pluginsTable.plugins;
+  } else {
+    pluginsTable.plugins = entries;
+  }
+  next.plugins = pluginsTable;
+  return next;
+}
+
+function parsesToOneOf(
+  candidate: string,
+  expected: readonly JsonRecord[],
+): boolean {
+  let sawDuplicateKey = false;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseToml(candidate, {
+      onDuplicateKey: () => {
+        sawDuplicateKey = true;
+      },
+    });
+  } catch {
+    return false;
+  }
+  if (sawDuplicateKey) return false;
+  const json = stableJson(parsed);
+  return expected.some((variant) => stableJson(variant) === json);
+}
+
+/**
+ * Delete the `[plugins.plugins.<pluginId>]` table header line and its body
+ * (up to the next table header or EOF), leaving every other line untouched.
+ * Only the header spellings our own writers emit are matched; anything more
+ * exotic falls through to the canonical re-serialization path, and the
+ * result is always verified by the caller before being written.
+ */
+function removePluginTableSection(
+  text: string,
+  pluginId: string,
+): string | undefined {
+  const quoted = tomlString(pluginId);
+  const headers = new Set([
+    `["plugins"."plugins".${quoted}]`,
+    `[plugins.plugins.${quoted}]`,
+  ]);
+  if (/^[A-Za-z0-9_-]+$/u.test(pluginId)) {
+    headers.add(`[plugins.plugins.${pluginId}]`);
+  }
+  const lines = text.split("\n");
+  let start = -1;
+  for (const [index, line] of lines.entries()) {
+    if (!headers.has(line.trim())) continue;
+    if (start !== -1) return undefined;
+    start = index;
+  }
+  if (start === -1) return undefined;
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^\s*\[/u.test(lines[index]!)) {
+      end = index;
+      break;
+    }
+  }
+  return [...lines.slice(0, start), ...lines.slice(end)].join("\n");
 }
 
 async function readOptionalText(path: string): Promise<string> {

--- a/runtime/tests/plugins/cli/pluginConfigMigrationMarkers.test.ts
+++ b/runtime/tests/plugins/cli/pluginConfigMigrationMarkers.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Managed plugin config entries must survive the config-file migration
+ * rewrite.
+ *
+ * `installPluginOp` writes an unversioned config.toml whose plugin entry is
+ * wrapped in `# BEGIN agenc plugin` / `# END agenc plugin` managed-block
+ * markers. Any subsequent `loadConfig` (which `uninstallPluginOp` itself
+ * triggers through `listInstalledPlugins`) runs `runConfigFileMigrations`,
+ * which canonically re-serializes the file and strips all comments —
+ * including the managed-block markers. Removal must still work afterwards
+ * via TOML-aware editing instead of silently leaving the entry behind.
+ */
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadConfig, parseToml } from "../../config/loader.js";
+import { installPluginOp, uninstallPluginOp } from "./pluginOperations.js";
+
+interface ParsedPluginsConfig {
+  readonly plugins?: {
+    readonly enabled?: unknown;
+    readonly plugins?: Readonly<Record<string, unknown>>;
+  };
+}
+
+async function tempRuntime(): Promise<{
+  readonly root: string;
+  readonly agencHome: string;
+  readonly workspaceRoot: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "agenc-plugin-migration-"));
+  const agencHome = join(root, "home");
+  const workspaceRoot = join(root, "workspace");
+  await mkdir(agencHome, { recursive: true });
+  await mkdir(workspaceRoot, { recursive: true });
+  return { root, agencHome, workspaceRoot };
+}
+
+async function writePlugin(root: string, name: string): Promise<string> {
+  const pluginRoot = join(root, name);
+  await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+  await writeFile(
+    join(pluginRoot, ".agenc-plugin", "plugin.json"),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      description: "Test plugin",
+      commands: "./commands",
+    }, null, 2),
+  );
+  await mkdir(join(pluginRoot, "commands"), { recursive: true });
+  await writeFile(join(pluginRoot, "commands", "hello.md"), "# Hello\n");
+  return pluginRoot;
+}
+
+describe("plugin config entries across config-file migration", () => {
+  it("uninstall removes the plugin entry after migration strips the managed-block markers", async () => {
+    const { root, agencHome, workspaceRoot } = await tempRuntime();
+    const pluginSource = await writePlugin(root, "alpha");
+    const configPath = join(agencHome, "config.toml");
+
+    await installPluginOp({ source: pluginSource, agencHome, workspaceRoot });
+    const freshText = await readFile(configPath, "utf8");
+    expect(freshText).toContain("# BEGIN agenc plugin");
+
+    // Force the canonical rewrite the real runtime performs on any config
+    // load: the unversioned file is migrated, re-serialized, and stripped
+    // of all comments — the managed-block markers are gone afterwards.
+    const loaded = await loadConfig({ home: agencHome, onWarn: () => {} });
+    expect(loaded.exists).toBe(true);
+    const migratedText = await readFile(configPath, "utf8");
+    expect(migratedText).not.toContain("# BEGIN agenc plugin");
+    expect(
+      (parseToml(migratedText) as ParsedPluginsConfig).plugins?.plugins?.alpha,
+    ).toBeDefined();
+
+    const result = await uninstallPluginOp({
+      pluginId: "alpha",
+      agencHome,
+      workspaceRoot,
+    });
+    expect(result.removedConfig).toBe(true);
+
+    const finalText = await readFile(configPath, "utf8");
+    const parsed = parseToml(finalText) as ParsedPluginsConfig;
+    expect(parsed.plugins?.plugins?.alpha).toBeUndefined();
+    expect(finalText).not.toContain("alpha");
+  });
+
+  it("uninstall surgically removes a marker-less entry while preserving unrelated config", async () => {
+    const { root, agencHome, workspaceRoot } = await tempRuntime();
+    const alphaSource = await writePlugin(root, "alpha");
+    const configPath = join(agencHome, "config.toml");
+
+    await installPluginOp({ source: alphaSource, agencHome, workspaceRoot });
+
+    // Model a config that was migrated (or hand-written) without managed
+    // markers: already versioned so migrations leave it untouched.
+    await writeFile(
+      configPath,
+      [
+        "configVersion = 1",
+        'model = "claude-opus"',
+        "",
+        "[plugins]",
+        "enabled = true",
+        "",
+        '["plugins"."plugins"."alpha"]',
+        "enabled = true",
+        "",
+        '["plugins"."plugins"."beta"]',
+        "enabled = false",
+        "",
+        "[providers.anthropic]",
+        'default_model = "claude-opus"',
+        "",
+      ].join("\n"),
+    );
+
+    const result = await uninstallPluginOp({
+      pluginId: "alpha",
+      agencHome,
+      workspaceRoot,
+    });
+    expect(result.removedConfig).toBe(true);
+
+    const finalText = await readFile(configPath, "utf8");
+    const parsed = parseToml(finalText) as ParsedPluginsConfig & {
+      readonly model?: unknown;
+      readonly providers?: Readonly<Record<string, unknown>>;
+    };
+    expect(parsed.plugins?.plugins?.alpha).toBeUndefined();
+    // Unrelated config survives untouched.
+    expect(parsed.model).toBe("claude-opus");
+    expect(parsed.plugins?.enabled).toBe(true);
+    expect(parsed.plugins?.plugins?.beta).toEqual({ enabled: false });
+    expect(parsed.providers?.anthropic).toEqual({ default_model: "claude-opus" });
+    // The surgical path keeps the original formatting for untouched lines.
+    expect(finalText).toContain('model = "claude-opus"');
+    expect(finalText).toContain('["plugins"."plugins"."beta"]');
+    expect(finalText).not.toContain('"alpha"');
+  });
+
+  it("uninstall reports removedConfig=false when the config has no entry for the plugin", async () => {
+    const { root, agencHome, workspaceRoot } = await tempRuntime();
+    const alphaSource = await writePlugin(root, "alpha");
+    const configPath = join(agencHome, "config.toml");
+
+    await installPluginOp({ source: alphaSource, agencHome, workspaceRoot });
+    // Marker-less config that never mentions the plugin.
+    await writeFile(
+      configPath,
+      "configVersion = 1\n\n[plugins]\nenabled = true\n",
+    );
+
+    const result = await uninstallPluginOp({
+      pluginId: "alpha",
+      agencHome,
+      workspaceRoot,
+    });
+    expect(result.removedConfig).toBe(false);
+
+    const finalText = await readFile(configPath, "utf8");
+    const parsed = parseToml(finalText) as ParsedPluginsConfig;
+    expect(parsed.plugins?.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Task 32 (filed during task 19)

**Root cause worse than filed**: `uninstallPluginOp` itself triggers the migration (`listInstalledPlugins` → `loadConfig` → `runConfigFileMigrations`), so a plain install→uninstall on a fresh config reproduces the bug — the canonical rewrite strips the `# BEGIN agenc plugin` markers and the entry becomes unremovable. Plus a latent **false-success**: `removeManagedBlock`'s `trimEnd` made marker-less uninstalls report `removedConfig: true` while leaving the entry in place.

**Fix (parse-based, ops layer)** — also heals marker-less configs already in the wild:
- `removePluginConfigEntry`: exact no-change detection, then a marker-less fallback — surgical line-level removal of the plugin's TOML table preserving unrelated bytes, canonical re-serialization fallback; every candidate is re-parsed and compared against the expected record before writing (a failed edit returns `false`, never corrupts the file).
- `writePluginConfigEntry`: same fallback, so toggles on migrated configs don't create duplicate tables.

**Red/green proven**: 3/3 new tests fail on the untouched tree, pass with the fix (re-proven via stash on the fix file). Existing migration tests untouched and green.

**Gates:** build ✅ · typecheck 0 · full vitest **14,007 passed / 0 failed / exit 0** · test:bun 86/0

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES