### PR TITLE
feat(sdk): @tetsuo-ai/agenc-sdk — typed embedding client over the daemon protocol

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,181 @@
+# AgenC Embedding SDK (`@tetsuo-ai/agenc-sdk`)
+
+`packages/agenc-sdk` is the in-repo, zero-dependency TypeScript SDK for
+embedding AgenC in another application. It speaks the daemon's JSON-RPC
+protocol without hand-writing a socket client, and it never imports
+runtime internals — the protocol surface is a hand-mirrored copy pinned by
+a drift test (see [Protocol mirror & drift guard](#protocol-mirror--drift-guard)).
+
+```
+npm run build --workspace=@tetsuo-ai/agenc-sdk   # plain tsc build → dist/
+```
+
+Node ≥ 25, ESM only, zero runtime dependencies.
+
+## Two transports
+
+| | daemon transport | subprocess transport |
+|---|---|---|
+| entry | `connect()` → `AgencClient` | `promptViaSubprocess()` |
+| wire | JSON-lines over `~/.agenc/daemon.sock` | `agenc -p --output-format stream-json --input-format stream-json` |
+| sessions | persistent, resumable, multi-turn | one-shot per spawn |
+| permission callbacks | yes (approve or deny live) | no — the CLI auto-denies (exit code 2 marks a tool-denied giveup) |
+| background agents | spawn/attach/stop/logs | no |
+| daemon required | attaches, or starts one via the CLI | the CLI manages its own daemon |
+
+Both produce the same typed event iterable (`AgencPromptEvent`) and the same
+final `AgencPromptResult`, so downstream consumption code is shared.
+
+## Daemon transport
+
+```js
+import { connect } from "@tetsuo-ai/agenc-sdk";
+
+const client = await connect({
+  // all optional:
+  // socketPath, cookiePath — default ${AGENC_HOME:-~/.agenc}/daemon.{sock,cookie}
+  // autostart: true       — run `agenc daemon start` when not running
+  // agencCommand: "agenc" — CLI used for autostart (absolute path when embedding)
+  onPermissionRequest: async (request) => {
+    // request: { sessionId, requestId, toolName?, permissions, input?, reason? }
+    return request.toolName === "Read"
+      ? { behavior: "allow", scope: "once" }
+      : { behavior: "deny", reason: "not allowed here" };
+  },
+});
+
+const session = await client.createSession();
+const run = session.prompt("Summarize this repo's protocol layer.");
+
+for await (const event of run) {
+  switch (event.type) {
+    case "text":               process.stdout.write(event.delta); break;
+    case "tool_call":          /* event.toolName, event.input */ break;
+    case "permission_request": /* also routed to onPermissionRequest */ break;
+    case "status":             /* event.runStatus */ break;
+  }
+}
+
+const result = await run.result();
+// { stopReason: "completed" | "errored" | "stopped", exitCode, finalMessage,
+//   deniedPermissionRequestIds, usage?, cacheStats? }
+
+await client.close();
+```
+
+Key `AgencClient` methods:
+
+- `createSession(params?)` / `resumeSession(sessionId)` → `AgencSession`
+  (`prompt`, `transcript`, `snapshot`, `cancelTurn`, `terminate`)
+- `spawnAgent(params)` → background agent (`agent.create`)
+- `attachAgent(agentId)` → `{ attach, session }` for a running agent
+- `listAgents()` / `stopAgent(id)` / `agentLogs(id)`
+- `request(method, params)` → raw typed JSON-RPC for anything else
+- `onNotification(cb)` / `onSessionNotification(sessionId, cb)` → raw events
+
+Permission requests with no registered handler are **denied** (never
+granted) so an unattended embedder can't hang a turn, mirroring `agenc -p`.
+Elicitations (`event.user_input_request` / `event.mcp_elicitation_request`)
+route to `onElicitationRequest`; return the response object for
+`elicitation.respond`, or `null` to leave it unanswered.
+
+Usage/cost: after the turn ends the SDK fetches `session.snapshot` and puts
+`tokenUsage`/`cacheStats` on the result (`includeUsage: false` to skip).
+
+### Handshake and autostart details
+
+The daemon requires the first message on a socket to be `initialize`
+carrying the `authCookie` read from `~/.agenc/daemon.cookie`; `connect()`
+does this for you. When the socket is not accepting connections and
+`autostart` is enabled (default), `connect()` runs `<agencCommand> daemon
+start` and polls the cookie + socket until ready (45s budget, or
+`AGENC_DAEMON_READY_TIMEOUT_MS`).
+
+Deviation from the launcher: the runtime's internal autostart also handles
+build-skew respawn and orphan-daemon adoption. Those need runtime-internal
+state, so the SDK intentionally implements only attach-to-running +
+spawn-via-CLI. If you need the full recovery behavior, start the daemon
+with the CLI first and call `connect({ autostart: false })`.
+
+The transport is a single persistent connection with no reconnect layer;
+`connect()` again (or use `onDisconnect`) if the daemon restarts.
+
+### Embedding in-process (no socket at all)
+
+If your process already hosts the runtime's app-server dispatcher, wire the
+runtime's `AgenCInProcessDaemonTransport` straight into the client — the
+tests in `runtime/tests/sdk-package/` do exactly this:
+
+```ts
+let client;
+const transport = new AgenCInProcessDaemonTransport({
+  dispatcher,
+  sendNotification: (n) => client?.dispatchNotification(n),
+});
+client = createAgencClient({ transport });
+await client.initialize();
+```
+
+## Subprocess transport
+
+No daemon socket access from your process; the SDK spawns the headless CLI
+and adapts its stream-json output onto the same event iterable:
+
+```js
+import { promptViaSubprocess } from "@tetsuo-ai/agenc-sdk";
+
+const run = promptViaSubprocess("explain the fee split", {
+  agencCommand: "agenc",      // or ["/abs/path/agenc"]
+  model: "grok-4",             // optional; also provider/profile/permissionMode
+});
+for await (const event of run) { /* same AgencPromptEvent union */ }
+const result = await run.result(); // exitCode/finalMessage/usage from the CLI's result line
+```
+
+Under the hood this is
+`agenc -p --output-format stream-json --input-format stream-json`, with the
+prompt written to stdin as `{"type":"prompt","prompt":"..."}`. Exit code 2
+means the run auto-denied a tool permission and gave up (the CLI's
+non-interactive contract); pass `permissionMode: "bypassPermissions"` or use
+the daemon transport when tools must run.
+
+## Runnable example
+
+`packages/agenc-sdk/examples/one-shot.mjs` exercises both transports:
+
+```
+npm run build --workspace=@tetsuo-ai/agenc-sdk
+node packages/agenc-sdk/examples/one-shot.mjs "say hello in one word"
+node packages/agenc-sdk/examples/one-shot.mjs --transport subprocess "say hello"
+```
+
+## Protocol mirror & drift guard
+
+`packages/agenc-sdk/src/protocol.ts` hand-mirrors the daemon protocol
+(method registry, params/result shapes, notification params).
+`runtime/tests/sdk-package/protocol-drift.contract.test.ts` pins the
+mirror's `AGENC_SDK_DAEMON_METHODS` / `AGENC_SDK_DAEMON_NOTIFICATION_METHODS`
+to the runtime's canonical `AGENC_DAEMON_METHODS` /
+`AGENC_DAEMON_NOTIFICATION_METHODS` (names **and** order) and checks the
+params/result maps declare every method — the same pattern that keeps the
+sibling-repo SDK in sync (`tests/app-server/sdk-client.contract.test.ts`).
+Change the daemon protocol and `vitest` fails until the mirror is updated.
+
+Event semantics (streamed text extraction, terminal-status detection) mirror
+the CLI's daemon one-shot path in `runtime/src/bin/agenc.ts`
+(`daemonOneShotMessageChunk` / `daemonOneShotFinalStatus`), so an embedder
+sees the same output and completion behavior as `agenc -p`.
+
+## Tests
+
+`runtime/tests/sdk-package/`:
+
+- `protocol-drift.contract.test.ts` — mirror pinned to the runtime registry.
+- `client-inprocess.contract.test.ts` — full connect → createSession →
+  prompt event stream and permission round-trips against a fake daemon
+  hosted on the **real** in-process transport (real dispatcher, session
+  lifecycle, and client multiplexer).
+- `subprocess-transport.test.ts` — stream-json adaptation with a fake child
+  process (argv contract, event mapping, exit-code-2 mapping, error paths).
+
+Run: `cd runtime && npx vitest run tests/sdk-package`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "npm@11.7.0",
   "workspaces": [
     "packages/agenc",
+    "packages/agenc-sdk",
     "runtime",
     "test-fixtures/plugin-kit-channel-adapter"
   ],

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -1,0 +1,12 @@
+# @tetsuo-ai/agenc-sdk
+
+Typed, zero-dependency embedding SDK for the AgenC daemon protocol.
+
+- `connect()` — attach to (or CLI-start) the local daemon over
+  `~/.agenc/daemon.sock`; typed `createSession()` / `prompt()` event
+  streams, permission callbacks, background-agent spawn/attach.
+- `promptViaSubprocess()` — same event-iterable interface over
+  `agenc -p --output-format stream-json` with no daemon socket access.
+
+Full documentation: [`docs/sdk.md`](../../docs/sdk.md) at the repository
+root. Runnable example: [`examples/one-shot.mjs`](./examples/one-shot.mjs).

--- a/packages/agenc-sdk/examples/one-shot.mjs
+++ b/packages/agenc-sdk/examples/one-shot.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * One-shot prompt through the AgenC embedding SDK, on either transport.
+ *
+ * Build the package first, then run from the repo root:
+ *
+ *   npm run build --workspace=@tetsuo-ai/agenc-sdk
+ *   node packages/agenc-sdk/examples/one-shot.mjs "say hello in one word"
+ *   node packages/agenc-sdk/examples/one-shot.mjs --transport subprocess "say hello"
+ *
+ * The daemon transport talks JSON-RPC to `~/.agenc/daemon.sock` (starting
+ * the daemon via `agenc daemon start` when needed). The subprocess
+ * transport spawns `agenc -p --output-format stream-json` instead — no
+ * daemon socket access required by this process.
+ */
+
+import { connect, promptViaSubprocess } from "../dist/index.js";
+
+const args = process.argv.slice(2);
+const transportIndex = args.indexOf("--transport");
+const transport = transportIndex >= 0 ? args[transportIndex + 1] : "daemon";
+const prompt =
+  args.filter((a, i) => i !== transportIndex && i !== transportIndex + 1).join(" ") ||
+  "In one short sentence, what is AgenC?";
+
+async function consume(run) {
+  for await (const event of run) {
+    if (event.type === "text") process.stdout.write(event.delta);
+    else if (event.type === "tool_call") {
+      process.stderr.write(`\n[tool] ${event.toolName} (${event.requestId})\n`);
+    } else if (event.type === "permission_request") {
+      process.stderr.write(`\n[permission] ${event.toolName ?? "?"} requested\n`);
+    }
+  }
+  const result = await run.result();
+  process.stdout.write("\n---\n");
+  process.stdout.write(
+    `stop=${result.stopReason} exit=${result.exitCode}` +
+      (result.usage ? ` tokens=${result.usage.totalTokens} cost=$${result.usage.costUsd}` : "") +
+      "\n",
+  );
+  return result.exitCode;
+}
+
+let exitCode = 1;
+if (transport === "subprocess") {
+  exitCode = await consume(promptViaSubprocess(prompt, {}));
+} else {
+  const client = await connect({
+    clientName: "agenc-sdk-example",
+    // Allow-nothing by default: deny every tool permission but log it.
+    onPermissionRequest: (request) => {
+      process.stderr.write(`\n[deny] ${request.toolName ?? "tool"}\n`);
+      return { behavior: "deny", reason: "example runs read-only" };
+    },
+  });
+  try {
+    const session = await client.createSession();
+    exitCode = await consume(session.prompt(prompt));
+    await session.terminate("example done");
+  } finally {
+    await client.close();
+  }
+}
+process.exit(exitCode);

--- a/packages/agenc-sdk/package.json
+++ b/packages/agenc-sdk/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@tetsuo-ai/agenc-sdk",
+  "version": "0.2.0",
+  "description": "Typed embedding SDK for the AgenC daemon protocol (socket, in-process, and subprocess transports)",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./protocol": {
+      "types": "./dist/protocol.d.ts",
+      "import": "./dist/protocol.js",
+      "default": "./dist/protocol.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "examples",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "keywords": [
+    "agenc",
+    "sdk",
+    "daemon",
+    "json-rpc"
+  ],
+  "author": "Tetsuo AI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tetsuo-ai/agenc-core",
+    "directory": "packages/agenc-sdk"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  },
+  "engines": {
+    "node": ">=25.0.0"
+  }
+}

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -1,0 +1,670 @@
+/**
+ * Typed AgenC daemon client for embedders.
+ *
+ * The client is transport-agnostic: anything that can frame a JSON-RPC
+ * request/response pair satisfies {@link AgencTransport}. Server-to-client
+ * notifications are pushed in through {@link AgencClient.dispatchNotification}
+ * — socket transports wire this automatically; in-process embedders pass it
+ * as the dispatcher transport's `sendNotification` callback.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  AGENC_SDK_DAEMON_PROTOCOL_VERSION,
+  AGENC_SDK_JSON_RPC_VERSION,
+  isJsonObject,
+  type AgencDaemonErrorObject,
+  type AgencDaemonMethod,
+  type AgencDaemonRequest,
+  type AgencDaemonResponse,
+  type AgencParamsByMethod,
+  type AgencResultByMethod,
+  type AgentAttachResult,
+  type AgentCreateParams,
+  type AgentCreateResult,
+  type AgentListParams,
+  type AgentListResult,
+  type AgentLogsResult,
+  type AgentStopResult,
+  type InitializeParams,
+  type InitializeResult,
+  type JsonObject,
+  type MessageContent,
+  type RequestId,
+  type SessionCreateParams,
+  type SessionSnapshotResult,
+  type SessionTranscriptResult,
+} from "./protocol.js";
+import {
+  promptEventFromNotification,
+  sessionIdFromNotification,
+  stopReasonFromExitCode,
+  terminalStatusFromNotification,
+  type AgencPromptEvent,
+  type AgencPromptResult,
+} from "./events.js";
+
+/**
+ * Minimal transport contract. The runtime's
+ * `AgenCInProcessDaemonTransport` (exported from `@tetsuo-ai/runtime`)
+ * satisfies this structurally, as does the built-in socket transport.
+ */
+export interface AgencTransport {
+  request<Method extends AgencDaemonMethod>(
+    request: AgencDaemonRequest<Method>,
+  ): Promise<AgencDaemonResponse<Method>>;
+  close?(): Promise<void>;
+}
+
+export class AgencRpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+  readonly method: AgencDaemonMethod;
+  readonly requestId: RequestId | null;
+
+  constructor(
+    error: AgencDaemonErrorObject,
+    method: AgencDaemonMethod,
+    requestId: RequestId | null,
+  ) {
+    super(error.message);
+    this.name = "AgencRpcError";
+    this.code = error.code;
+    this.data = error.data;
+    this.method = method;
+    this.requestId = requestId;
+  }
+}
+
+export class AgencMalformedResponseError extends Error {
+  readonly response: unknown;
+
+  constructor(message: string, response: unknown) {
+    super(message);
+    this.name = "AgencMalformedResponseError";
+    this.response = response;
+  }
+}
+
+/** Decision returned by a permission callback. */
+export type AgencPermissionDecision =
+  | { readonly behavior: "allow"; readonly scope?: "once" | "session" | "agent" }
+  | { readonly behavior: "deny"; readonly reason?: string };
+
+export type AgencPermissionRequest = Extract<
+  AgencPromptEvent,
+  { type: "permission_request" }
+> & { readonly sessionId: string };
+
+export type AgencElicitationRequest = Extract<
+  AgencPromptEvent,
+  { type: "elicitation_request" }
+> & { readonly sessionId: string };
+
+export type AgencPermissionCallback = (
+  request: AgencPermissionRequest,
+) => AgencPermissionDecision | Promise<AgencPermissionDecision>;
+
+/**
+ * Return the response payload for `elicitation.respond`, or `null` to leave
+ * the request unanswered (the embedder handles it out of band).
+ */
+export type AgencElicitationCallback = (
+  request: AgencElicitationRequest,
+) => JsonObject | null | Promise<JsonObject | null>;
+
+export interface AgencClientOptions {
+  readonly transport: AgencTransport;
+  readonly clientId?: string;
+  readonly clientName?: string;
+  readonly createRequestId?: () => RequestId;
+  /** Default permission handler for every prompt run on this client. */
+  readonly onPermissionRequest?: AgencPermissionCallback;
+  /** Default elicitation handler for every prompt run on this client. */
+  readonly onElicitationRequest?: AgencElicitationCallback;
+}
+
+export interface AgencPromptOptions {
+  readonly signal?: AbortSignal;
+  /**
+   * Fetch `session.snapshot` after the turn completes so the result carries
+   * token usage and cost. Defaults to `true`; snapshot failures are ignored.
+   */
+  readonly includeUsage?: boolean;
+  readonly metadata?: JsonObject;
+  readonly onPermissionRequest?: AgencPermissionCallback;
+  readonly onElicitationRequest?: AgencElicitationCallback;
+}
+
+/** Cap on internally buffered, not-yet-consumed prompt events. */
+const MAX_BUFFERED_PROMPT_EVENTS = 1_000;
+
+interface EventChannel {
+  push(event: AgencPromptEvent): void;
+  end(result: AgencPromptResult): void;
+  fail(error: Error): void;
+  iterate(): AsyncGenerator<AgencPromptEvent, AgencPromptResult>;
+  readonly result: Promise<AgencPromptResult>;
+}
+
+function createEventChannel(): EventChannel {
+  const buffered: AgencPromptEvent[] = [];
+  let done = false;
+  let finalResult: AgencPromptResult | null = null;
+  let failure: Error | null = null;
+  let wake: (() => void) | null = null;
+  let resolveResult!: (value: AgencPromptResult) => void;
+  let rejectResult!: (error: Error) => void;
+  const result = new Promise<AgencPromptResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  // A prompt run that is only awaited via `.result()` never iterates, so a
+  // rejected result promise would otherwise surface as an unhandled
+  // rejection even though `iterate()` reports the same failure. Attach a
+  // no-op handler; `.result()` callers still observe the rejection.
+  result.catch(() => {});
+  const notify = () => {
+    wake?.();
+    wake = null;
+  };
+  return {
+    push(event) {
+      if (done) return;
+      buffered.push(event);
+      while (buffered.length > MAX_BUFFERED_PROMPT_EVENTS) buffered.shift();
+      notify();
+    },
+    end(value) {
+      if (done) return;
+      done = true;
+      finalResult = value;
+      resolveResult(value);
+      notify();
+    },
+    fail(error) {
+      if (done) return;
+      done = true;
+      failure = error;
+      rejectResult(error);
+      notify();
+    },
+    result,
+    async *iterate() {
+      for (;;) {
+        while (buffered.length > 0) {
+          yield buffered.shift()!;
+        }
+        if (done) {
+          if (failure !== null) throw failure;
+          return finalResult!;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+    },
+  };
+}
+
+/**
+ * One in-flight (or finished) prompt turn: an async iterable of typed
+ * events plus a promise for the final result.
+ */
+export interface AgencPromptRun extends AsyncIterable<AgencPromptEvent> {
+  readonly sessionId: string;
+  /** Resolves once the daemon acknowledged `message.send`. */
+  readonly accepted: Promise<{ messageId: string }>;
+  /** Final outcome; resolves even when the events are never iterated. */
+  result(): Promise<AgencPromptResult>;
+  /** Interrupt the active turn (`session.cancelTurn`). */
+  cancel(reason?: string): Promise<void>;
+}
+
+export class AgencSession {
+  readonly sessionId: string;
+  readonly agentId: string | undefined;
+  readonly #client: AgencClient;
+
+  constructor(client: AgencClient, sessionId: string, agentId?: string) {
+    this.#client = client;
+    this.sessionId = sessionId;
+    this.agentId = agentId;
+  }
+
+  /** Send one message and stream the turn's events. */
+  prompt(content: MessageContent, options: AgencPromptOptions = {}): AgencPromptRun {
+    return this.#client.runPrompt(this.sessionId, content, options);
+  }
+
+  transcript(): Promise<SessionTranscriptResult> {
+    return this.#client.request("session.transcript", {
+      sessionId: this.sessionId,
+    });
+  }
+
+  snapshot(): Promise<SessionSnapshotResult> {
+    return this.#client.request("session.snapshot", {
+      sessionId: this.sessionId,
+    });
+  }
+
+  async cancelTurn(reason?: string): Promise<void> {
+    await this.#client.request("session.cancelTurn", {
+      sessionId: this.sessionId,
+      ...(reason !== undefined ? { reason } : {}),
+    });
+  }
+
+  async terminate(reason?: string): Promise<void> {
+    await this.#client.request("session.terminate", {
+      sessionId: this.sessionId,
+      ...(reason !== undefined ? { reason } : {}),
+    });
+  }
+}
+
+export class AgencClient {
+  readonly #transport: AgencTransport;
+  readonly #createRequestId: () => RequestId;
+  readonly #clientId: string;
+  readonly #clientName: string;
+  readonly #onPermissionRequest: AgencPermissionCallback | undefined;
+  readonly #onElicitationRequest: AgencElicitationCallback | undefined;
+  readonly #notificationListeners = new Set<(message: JsonObject) => void>();
+  readonly #sessionListeners = new Map<
+    string,
+    Set<(message: JsonObject) => void>
+  >();
+  readonly #attachedSessionIds = new Set<string>();
+  #initialized = false;
+  #closed = false;
+
+  constructor(options: AgencClientOptions) {
+    this.#transport = options.transport;
+    this.#createRequestId = options.createRequestId ?? numericIdFactory();
+    this.#clientId = options.clientId ?? `agenc-sdk-${process.pid}-${randomUUID()}`;
+    this.#clientName = options.clientName ?? "agenc-sdk";
+    this.#onPermissionRequest = options.onPermissionRequest;
+    this.#onElicitationRequest = options.onElicitationRequest;
+  }
+
+  get clientId(): string {
+    return this.#clientId;
+  }
+
+  get initialized(): boolean {
+    return this.#initialized;
+  }
+
+  /**
+   * Feed a server-to-client notification into the client. Socket transports
+   * call this automatically; in-process embedders wire it as the runtime
+   * transport's `sendNotification` callback.
+   */
+  dispatchNotification(message: JsonObject): void {
+    for (const listener of this.#notificationListeners) {
+      safeNotify(listener, message);
+    }
+    const sessionId = sessionIdFromNotification(message);
+    if (sessionId === null) return;
+    const listeners = this.#sessionListeners.get(sessionId);
+    if (listeners === undefined) return;
+    for (const listener of listeners) {
+      safeNotify(listener, message);
+    }
+  }
+
+  /** Subscribe to every raw daemon notification. */
+  onNotification(listener: (message: JsonObject) => void): () => void {
+    this.#notificationListeners.add(listener);
+    return () => {
+      this.#notificationListeners.delete(listener);
+    };
+  }
+
+  /** Subscribe to raw notifications for one session. */
+  onSessionNotification(
+    sessionId: string,
+    listener: (message: JsonObject) => void,
+  ): () => void {
+    let listeners = this.#sessionListeners.get(sessionId);
+    if (listeners === undefined) {
+      listeners = new Set();
+      this.#sessionListeners.set(sessionId, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      const current = this.#sessionListeners.get(sessionId);
+      current?.delete(listener);
+      if (current?.size === 0) this.#sessionListeners.delete(sessionId);
+    };
+  }
+
+  async request<Method extends AgencDaemonMethod>(
+    method: Method,
+    params?: AgencParamsByMethod[Method],
+  ): Promise<AgencResultByMethod[Method]> {
+    if (this.#closed) throw new Error("AgenC SDK client is closed");
+    const id = this.#createRequestId();
+    const request: AgencDaemonRequest<Method> =
+      params === undefined
+        ? { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method }
+        : { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method, params };
+    const response = await this.#transport.request(request);
+    return parseResponse(response, method, id);
+  }
+
+  async initialize(params: InitializeParams = {}): Promise<InitializeResult> {
+    const result = await this.request("initialize", {
+      protocolVersion: AGENC_SDK_DAEMON_PROTOCOL_VERSION,
+      protocol: { version: AGENC_SDK_DAEMON_PROTOCOL_VERSION },
+      clientName: this.#clientName,
+      capabilities: {},
+      ...params,
+    });
+    this.#initialized = true;
+    return result;
+  }
+
+  /** Create a daemon-owned session and attach this client to it. */
+  async createSession(params: SessionCreateParams = {}): Promise<AgencSession> {
+    const created = await this.request("session.create", params);
+    await this.#attachSession(created.sessionId);
+    return new AgencSession(this, created.sessionId, created.agentId);
+  }
+
+  /** Attach to an existing daemon-owned session by id. */
+  async resumeSession(sessionId: string): Promise<AgencSession> {
+    await this.#attachSession(sessionId);
+    return new AgencSession(this, sessionId);
+  }
+
+  /** Spawn a long-lived background agent (`agent.create`). */
+  spawnAgent(params: AgentCreateParams): Promise<AgentCreateResult> {
+    return this.request("agent.create", params);
+  }
+
+  /**
+   * Attach to a running background agent. Returns the raw attach result and
+   * an {@link AgencSession} bound to the agent's first active session (or
+   * `null` when the agent has none).
+   */
+  async attachAgent(agentId: string): Promise<{
+    readonly attach: AgentAttachResult;
+    readonly session: AgencSession | null;
+  }> {
+    const attach = await this.request("agent.attach", {
+      agentId,
+      clientId: this.#clientId,
+    });
+    const sessionId = attach.sessionIds[0];
+    if (sessionId === undefined) return { attach, session: null };
+    this.#attachedSessionIds.add(sessionId);
+    return { attach, session: new AgencSession(this, sessionId, agentId) };
+  }
+
+  listAgents(params: AgentListParams = {}): Promise<AgentListResult> {
+    return this.request("agent.list", params);
+  }
+
+  stopAgent(agentId: string, reason?: string): Promise<AgentStopResult> {
+    return this.request("agent.stop", {
+      agentId,
+      ...(reason !== undefined ? { reason } : {}),
+    });
+  }
+
+  agentLogs(agentId: string): Promise<AgentLogsResult> {
+    return this.request("agent.logs", { agentId });
+  }
+
+  /**
+   * Internal engine behind {@link AgencSession.prompt}. Exposed on the
+   * client so sessions stay thin data holders.
+   */
+  runPrompt(
+    sessionId: string,
+    content: MessageContent,
+    options: AgencPromptOptions = {},
+  ): AgencPromptRun {
+    const channel = createEventChannel();
+    const onPermissionRequest =
+      options.onPermissionRequest ?? this.#onPermissionRequest;
+    const onElicitationRequest =
+      options.onElicitationRequest ?? this.#onElicitationRequest;
+    const deniedPermissionRequestIds = new Set<string>();
+    const handledPermissionRequestIds = new Set<string>();
+    let assistantOutput = "";
+    let finishing = false;
+
+    const finish = async (status: { code: number; message?: string }) => {
+      if (finishing) return;
+      finishing = true;
+      unsubscribe();
+      let usageFields: Pick<AgencPromptResult, "usage" | "cacheStats"> = {};
+      if (options.includeUsage !== false) {
+        try {
+          const snapshot = await this.request("session.snapshot", { sessionId });
+          usageFields = {
+            usage: snapshot.tokenUsage,
+            cacheStats: snapshot.cacheStats,
+          };
+        } catch {
+          /* usage is best-effort */
+        }
+      }
+      channel.end({
+        stopReason: stopReasonFromExitCode(status.code),
+        exitCode: status.code,
+        finalMessage: status.message ?? assistantOutput.trimEnd(),
+        deniedPermissionRequestIds: [...deniedPermissionRequestIds],
+        ...usageFields,
+      });
+    };
+
+    const respondToPermission = async (
+      event: Extract<AgencPromptEvent, { type: "permission_request" }>,
+    ): Promise<void> => {
+      if (handledPermissionRequestIds.has(event.requestId)) return;
+      handledPermissionRequestIds.add(event.requestId);
+      // Mirror `agenc -p`: an unanswered permission request suspends the turn
+      // forever, so without a handler the SDK denies (never grants).
+      let decision: AgencPermissionDecision = {
+        behavior: "deny",
+        reason: "agenc-sdk: no permission handler registered",
+      };
+      if (onPermissionRequest !== undefined) {
+        try {
+          decision = await onPermissionRequest({ ...event, sessionId });
+        } catch {
+          decision = {
+            behavior: "deny",
+            reason: "agenc-sdk: permission handler threw",
+          };
+        }
+      }
+      try {
+        if (decision.behavior === "allow") {
+          await this.request("tool.approve", {
+            sessionId,
+            requestId: event.requestId,
+            ...(decision.scope !== undefined ? { scope: decision.scope } : {}),
+          });
+        } else {
+          deniedPermissionRequestIds.add(event.requestId);
+          await this.request("tool.deny", {
+            sessionId,
+            requestId: event.requestId,
+            ...(decision.reason !== undefined
+              ? { reason: decision.reason }
+              : {}),
+          });
+        }
+      } catch {
+        /* stale/already-resolved requests are harmless */
+      }
+    };
+
+    const respondToElicitation = async (
+      event: Extract<AgencPromptEvent, { type: "elicitation_request" }>,
+    ): Promise<void> => {
+      if (onElicitationRequest === undefined) return;
+      let response: JsonObject | null = null;
+      try {
+        response = await onElicitationRequest({ ...event, sessionId });
+      } catch {
+        return;
+      }
+      if (response === null) return;
+      try {
+        await this.request("elicitation.respond", {
+          sessionId,
+          requestId: event.requestId,
+          kind: event.kind,
+          ...(event.serverName !== undefined
+            ? { serverName: event.serverName }
+            : {}),
+          response,
+        });
+      } catch {
+        /* stale/already-resolved requests are harmless */
+      }
+    };
+
+    const unsubscribe = this.onSessionNotification(sessionId, (message) => {
+      const event = promptEventFromNotification(message);
+      if (event !== null) {
+        if (event.type === "text") assistantOutput += event.delta;
+        channel.push(event);
+        if (event.type === "permission_request") void respondToPermission(event);
+        if (event.type === "elicitation_request") {
+          void respondToElicitation(event);
+        }
+      }
+      const terminal = terminalStatusFromNotification(message);
+      if (terminal !== null) void finish(terminal);
+    });
+
+    if (options.signal !== undefined) {
+      const signal = options.signal;
+      const onAbort = () => {
+        void this.request("session.cancelTurn", {
+          sessionId,
+          reason: String(signal.reason ?? "aborted"),
+        }).catch(() => {});
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    const accepted = (async () => {
+      await this.#attachSession(sessionId);
+      const sendResult = await this.request("message.send", {
+        sessionId,
+        content,
+        ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+      });
+      return { messageId: sendResult.messageId };
+    })();
+    accepted.catch((error: unknown) => {
+      unsubscribe();
+      channel.fail(error instanceof Error ? error : new Error(String(error)));
+    });
+
+    const self = this;
+    return {
+      sessionId,
+      accepted,
+      result: () => channel.result,
+      cancel: async (reason?: string) => {
+        await self.request("session.cancelTurn", {
+          sessionId,
+          ...(reason !== undefined ? { reason } : {}),
+        });
+      },
+      [Symbol.asyncIterator]: () => channel.iterate(),
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#notificationListeners.clear();
+    this.#sessionListeners.clear();
+    await this.#transport.close?.();
+  }
+
+  async #attachSession(sessionId: string): Promise<void> {
+    if (this.#attachedSessionIds.has(sessionId)) return;
+    await this.request("session.attach", {
+      sessionId,
+      clientId: this.#clientId,
+    });
+    this.#attachedSessionIds.add(sessionId);
+  }
+}
+
+export function createAgencClient(options: AgencClientOptions): AgencClient {
+  return new AgencClient(options);
+}
+
+function numericIdFactory(): () => number {
+  let nextId = 1;
+  return () => {
+    const id = nextId;
+    nextId += 1;
+    return id;
+  };
+}
+
+function safeNotify(
+  listener: (message: JsonObject) => void,
+  message: JsonObject,
+): void {
+  try {
+    listener(message);
+  } catch {
+    // Listener failures must not poison notification routing.
+  }
+}
+
+function parseResponse<Method extends AgencDaemonMethod>(
+  response: AgencDaemonResponse<Method>,
+  method: Method,
+  requestId: RequestId,
+): AgencResultByMethod[Method] {
+  if (!isJsonObject(response)) {
+    throw new AgencMalformedResponseError(
+      "AgenC daemon response must be an object",
+      response,
+    );
+  }
+  if (response.jsonrpc !== AGENC_SDK_JSON_RPC_VERSION) {
+    throw new AgencMalformedResponseError(
+      "AgenC daemon response used an unsupported JSON-RPC version",
+      response,
+    );
+  }
+  if ("error" in response && isJsonObject(response.error)) {
+    throw new AgencRpcError(
+      response.error as AgencDaemonErrorObject,
+      method,
+      (response as { id: RequestId | null }).id,
+    );
+  }
+  if (response.id !== requestId) {
+    throw new AgencMalformedResponseError(
+      "AgenC daemon response id mismatch",
+      response,
+    );
+  }
+  if (!("result" in response)) {
+    throw new AgencMalformedResponseError(
+      "AgenC daemon response must include result or error",
+      response,
+    );
+  }
+  return (response as AgencDaemonResponse<Method> & { result: AgencResultByMethod[Method] })
+    .result;
+}

--- a/packages/agenc-sdk/src/events.ts
+++ b/packages/agenc-sdk/src/events.ts
@@ -1,0 +1,311 @@
+/**
+ * Notification → typed prompt-event mapping shared by every transport.
+ *
+ * The daemon delivers session activity as JSON-RPC notifications
+ * (`event.message_chunk`, `event.tool_request`, `event.permission_request`,
+ * `event.user_input_request`, `event.mcp_elicitation_request`,
+ * `event.agent_status`, `event.session_event`). The subprocess transport's
+ * `--output-format stream-json` lines carry the exact same notification
+ * objects under their `event` field, so one mapper serves both.
+ *
+ * Terminal-status and message-chunk detection intentionally mirrors the
+ * CLI's daemon one-shot path (`runtime/src/bin/agenc.ts`:
+ * `daemonOneShotMessageChunk` / `daemonOneShotFinalStatus`) so an embedder
+ * sees the same text and the same completion semantics as `agenc -p`.
+ */
+
+import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
+
+export type AgencStopReason = "completed" | "errored" | "stopped";
+
+/** One streamed event observed while a prompt turn runs. */
+export type AgencPromptEvent =
+  | {
+      readonly type: "text";
+      readonly delta: string;
+      readonly messageId?: string;
+      readonly streamId?: string;
+    }
+  | {
+      readonly type: "tool_call";
+      readonly requestId: string;
+      readonly toolName: string;
+      readonly turnId?: string;
+      readonly input?: JsonValue;
+      readonly recoveryCategory?: string;
+    }
+  | {
+      readonly type: "permission_request";
+      readonly requestId: string;
+      readonly toolName?: string;
+      readonly permissions: readonly string[];
+      readonly input?: JsonValue;
+      readonly reason?: string;
+    }
+  | {
+      readonly type: "elicitation_request";
+      readonly kind: "request_user_input" | "mcp";
+      readonly requestId: string | number;
+      readonly serverName?: string;
+      readonly questions?: readonly JsonObject[];
+      readonly request?: JsonObject;
+    }
+  | {
+      readonly type: "status";
+      readonly status?: string;
+      readonly runStatus?: string;
+      readonly message?: string;
+    }
+  | {
+      readonly type: "session_event";
+      readonly event: JsonObject;
+    };
+
+export interface AgencUsage extends JsonObject {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+}
+
+/** Final outcome of one prompt turn. */
+export interface AgencPromptResult {
+  readonly stopReason: AgencStopReason;
+  /** 0 success, 1 error, 130 stopped/interrupted — mirrors `agenc -p`. */
+  readonly exitCode: number;
+  /** The turn's final assistant message (or accumulated streamed text). */
+  readonly finalMessage: string;
+  /** Permission requests that were auto- or callback-denied during the turn. */
+  readonly deniedPermissionRequestIds: readonly string[];
+  readonly usage?: JsonObject;
+  readonly cacheStats?: JsonObject;
+}
+
+export interface AgencTerminalStatus {
+  readonly code: number;
+  readonly message?: string;
+}
+
+function eventParams(message: JsonObject): JsonObject | null {
+  return isJsonObject(message.params) ? message.params : message;
+}
+
+function nestedTranscriptEvent(message: JsonObject): JsonObject | null {
+  const params = eventParams(message);
+  if (params === null) return null;
+  if (isJsonObject(params.event)) return params.event;
+  if (isJsonObject(params.msg)) return params.msg;
+  return params;
+}
+
+/**
+ * Extract streamed assistant text from a daemon notification. Mirrors the
+ * CLI's `daemonOneShotMessageChunk`.
+ */
+export function messageChunkFromNotification(
+  message: JsonObject,
+): string | null {
+  const params = eventParams(message);
+  if (
+    message.method === "event.message_chunk" &&
+    params !== null &&
+    typeof params.delta === "string"
+  ) {
+    return params.delta;
+  }
+  const transcriptEvent = nestedTranscriptEvent(message);
+  if (transcriptEvent === null) return null;
+  const payload = isJsonObject(transcriptEvent.payload)
+    ? transcriptEvent.payload
+    : null;
+  if (
+    transcriptEvent.type === "agent_message_delta" &&
+    payload !== null &&
+    typeof payload.delta === "string"
+  ) {
+    return payload.delta;
+  }
+  if (
+    transcriptEvent.type === "agent_message" &&
+    payload !== null &&
+    typeof payload.message === "string"
+  ) {
+    return `${payload.message}\n`;
+  }
+  return null;
+}
+
+/**
+ * Detect the terminal status of a turn from a daemon notification. Mirrors
+ * the CLI's `daemonOneShotFinalStatus`: `event.agent_status` with a terminal
+ * run status, or a nested transcript `turn_complete`/`error` event.
+ */
+export function terminalStatusFromNotification(
+  message: JsonObject,
+): AgencTerminalStatus | null {
+  const params = eventParams(message);
+  if (message.method === "event.agent_status" && params !== null) {
+    const runStatus =
+      typeof params.runStatus === "string" ? params.runStatus : undefined;
+    const status = typeof params.status === "string" ? params.status : undefined;
+    const statusMessage =
+      typeof params.message === "string" ? params.message : undefined;
+    if (runStatus === "completed" || status === "idle") {
+      return { code: 0, ...(statusMessage !== undefined ? { message: statusMessage } : {}) };
+    }
+    if (runStatus === "stopped" || status === "stopped") {
+      return { code: 130, ...(statusMessage !== undefined ? { message: statusMessage } : {}) };
+    }
+    if (runStatus === "errored" || status === "error") {
+      return { code: 1, ...(statusMessage !== undefined ? { message: statusMessage } : {}) };
+    }
+  }
+  const transcriptEvent = nestedTranscriptEvent(message);
+  if (transcriptEvent === null) return null;
+  const payload = isJsonObject(transcriptEvent.payload)
+    ? transcriptEvent.payload
+    : null;
+  if (transcriptEvent.type === "turn_complete") {
+    const finalMessage =
+      payload !== null && typeof payload.lastAgentMessage === "string"
+        ? payload.lastAgentMessage
+        : undefined;
+    return { code: 0, ...(finalMessage !== undefined ? { message: finalMessage } : {}) };
+  }
+  if (transcriptEvent.type === "error") {
+    const errorMessage =
+      payload !== null && typeof payload.message === "string"
+        ? payload.message
+        : undefined;
+    return { code: 1, ...(errorMessage !== undefined ? { message: errorMessage } : {}) };
+  }
+  return null;
+}
+
+export function stopReasonFromExitCode(code: number): AgencStopReason {
+  if (code === 0) return "completed";
+  if (code === 130) return "stopped";
+  return "errored";
+}
+
+/**
+ * Map a raw daemon notification to a typed prompt event. Returns `null` for
+ * notifications that carry no session-facing meaning (e.g. realtime audio).
+ */
+export function promptEventFromNotification(
+  message: JsonObject,
+): AgencPromptEvent | null {
+  const params = eventParams(message);
+  const method = message.method;
+
+  if (method === "event.message_chunk" || method === "event.session_event") {
+    const delta = messageChunkFromNotification(message);
+    if (delta !== null && delta.length > 0) {
+      const chunkParams = params ?? {};
+      return {
+        type: "text",
+        delta,
+        ...(typeof chunkParams.messageId === "string"
+          ? { messageId: chunkParams.messageId }
+          : {}),
+        ...(typeof chunkParams.streamId === "string"
+          ? { streamId: chunkParams.streamId }
+          : {}),
+      };
+    }
+    if (method === "event.session_event" && params !== null) {
+      const nested = isJsonObject(params.event) ? params.event : params;
+      return { type: "session_event", event: nested };
+    }
+    return null;
+  }
+
+  if (params === null) return null;
+
+  if (method === "event.tool_request") {
+    if (typeof params.requestId !== "string") return null;
+    return {
+      type: "tool_call",
+      requestId: params.requestId,
+      toolName: typeof params.toolName === "string" ? params.toolName : "",
+      ...(typeof params.turnId === "string" ? { turnId: params.turnId } : {}),
+      ...(params.input !== undefined ? { input: params.input } : {}),
+      ...(typeof params.recoveryCategory === "string"
+        ? { recoveryCategory: params.recoveryCategory }
+        : {}),
+    };
+  }
+
+  if (method === "event.permission_request") {
+    if (typeof params.requestId !== "string" || params.requestId.length === 0) {
+      return null;
+    }
+    const permissions = Array.isArray(params.permissions)
+      ? params.permissions.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+    return {
+      type: "permission_request",
+      requestId: params.requestId,
+      permissions,
+      ...(typeof params.toolName === "string"
+        ? { toolName: params.toolName }
+        : {}),
+      ...(params.input !== undefined ? { input: params.input } : {}),
+      ...(typeof params.reason === "string" ? { reason: params.reason } : {}),
+    };
+  }
+
+  if (method === "event.user_input_request") {
+    if (typeof params.requestId !== "string") return null;
+    const questions = Array.isArray(params.questions)
+      ? params.questions.filter(isJsonObject)
+      : [];
+    return {
+      type: "elicitation_request",
+      kind: "request_user_input",
+      requestId: params.requestId,
+      questions,
+    };
+  }
+
+  if (method === "event.mcp_elicitation_request") {
+    const requestId = params.requestId;
+    if (typeof requestId !== "string" && typeof requestId !== "number") {
+      return null;
+    }
+    return {
+      type: "elicitation_request",
+      kind: "mcp",
+      requestId,
+      ...(typeof params.serverName === "string"
+        ? { serverName: params.serverName }
+        : {}),
+      ...(isJsonObject(params.request) ? { request: params.request } : {}),
+    };
+  }
+
+  if (method === "event.agent_status") {
+    return {
+      type: "status",
+      ...(typeof params.status === "string" ? { status: params.status } : {}),
+      ...(typeof params.runStatus === "string"
+        ? { runStatus: params.runStatus }
+        : {}),
+      ...(typeof params.message === "string" ? { message: params.message } : {}),
+    };
+  }
+
+  return null;
+}
+
+/** sessionId carried by a daemon notification, if any. */
+export function sessionIdFromNotification(message: JsonObject): string | null {
+  if (typeof message.sessionId === "string") return message.sessionId;
+  const params = message.params;
+  if (isJsonObject(params) && typeof params.sessionId === "string") {
+    return params.sessionId;
+  }
+  return null;
+}

--- a/packages/agenc-sdk/src/index.ts
+++ b/packages/agenc-sdk/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @tetsuo-ai/agenc-sdk — typed embedding SDK for the AgenC daemon protocol.
+ *
+ * See `docs/sdk.md` at the repository root for usage.
+ */
+
+export * from "./protocol.js";
+export * from "./events.js";
+export * from "./client.js";
+export {
+  connect,
+  resolveAgencHome,
+  resolveDaemonSocketPath,
+  resolveDaemonCookiePath,
+  AgencSocketTransport,
+  type AgencConnectOptions,
+  type AgencSocketTransportOptions,
+  type AgencSpawnFn,
+} from "./socket.js";
+export {
+  promptViaSubprocess,
+  type AgencSubprocessOptions,
+  type AgencSubprocessRun,
+  type AgencSubprocessChild,
+  type AgencSubprocessSpawnFn,
+} from "./subprocess.js";

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -1,0 +1,811 @@
+/**
+ * Hand-mirrored subset of the AgenC daemon JSON-RPC protocol
+ * (`runtime/src/app-server/protocol/index.ts`).
+ *
+ * This package deliberately does NOT import runtime internals; the shapes
+ * here are a standalone mirror of the daemon's public control surface.
+ * Drift is guarded by `runtime/tests/sdk-package/protocol-drift.contract.test.ts`,
+ * which compares {@link AGENC_SDK_DAEMON_METHODS} and
+ * {@link AGENC_SDK_DAEMON_NOTIFICATION_METHODS} against the runtime's
+ * `AGENC_DAEMON_METHODS` / `AGENC_DAEMON_NOTIFICATION_METHODS` arrays,
+ * so any protocol change fails tests until this mirror is updated.
+ */
+
+export const AGENC_SDK_JSON_RPC_VERSION = "2.0" as const;
+export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.0.0" as const;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | readonly JsonValue[] | JsonObject;
+export interface JsonObject {
+  readonly [key: string]: JsonValue | undefined;
+}
+
+export type RequestId = string | number;
+
+/**
+ * Every public daemon request method, in the runtime's declaration order.
+ * Mirror of `AGENC_DAEMON_METHODS` — see the module docblock for the drift
+ * guard.
+ */
+export const AGENC_SDK_DAEMON_METHODS = [
+  "initialize",
+  "request.cancel",
+  "agent.create",
+  "agent.list",
+  "agent.attach",
+  "agent.stop",
+  "agent.logs",
+  "session.create",
+  "session.list",
+  "session.attach",
+  "session.detach",
+  "session.terminate",
+  "session.clear",
+  "session.snapshot",
+  "session.transcript",
+  "session.cancelTurn",
+  "session.mcp.addServer",
+  "message.send",
+  "message.stream",
+  "thread/realtime/start",
+  "thread/realtime/appendAudio",
+  "thread/realtime/appendText",
+  "thread/realtime/stop",
+  "thread/realtime/listVoices",
+  "tool.approve",
+  "tool.deny",
+  "tool.cancel",
+  "elicitation.respond",
+  "permission.list",
+  "fs.fuzzy_search",
+  "commandExec.start",
+  "commandExec.write",
+  "commandExec.resize",
+  "commandExec.terminate",
+  "health.ping",
+  "health.ready",
+  "health.stats",
+  "daemon.reload",
+  "auth.login",
+  "auth.whoami",
+  "auth.logout",
+] as const;
+
+export type AgencDaemonMethod = (typeof AGENC_SDK_DAEMON_METHODS)[number];
+
+/**
+ * Every server-to-client notification method, in the runtime's declaration
+ * order. Mirror of `AGENC_DAEMON_NOTIFICATION_METHODS`.
+ */
+export const AGENC_SDK_DAEMON_NOTIFICATION_METHODS = [
+  "commandExec.outputDelta",
+  "event.message_chunk",
+  "event.tool_request",
+  "event.permission_request",
+  "event.user_input_request",
+  "event.mcp_elicitation_request",
+  "event.agent_status",
+  "event.session_event",
+  "thread/realtime/started",
+  "thread/realtime/itemAdded",
+  "thread/realtime/transcript/delta",
+  "thread/realtime/transcript/done",
+  "thread/realtime/outputAudio/delta",
+  "thread/realtime/sdp",
+  "thread/realtime/error",
+  "thread/realtime/closed",
+] as const;
+
+export type AgencDaemonNotificationMethod =
+  (typeof AGENC_SDK_DAEMON_NOTIFICATION_METHODS)[number];
+
+// ── Shared params/result shapes ──────────────────────────────────────
+
+export interface DaemonProtocolInfo extends JsonObject {
+  readonly version: string;
+}
+
+export interface InitializeParams extends JsonObject {
+  readonly protocolVersion?: string;
+  readonly protocol?: DaemonProtocolInfo;
+  readonly clientName?: string;
+  readonly authCookie?: string;
+  readonly capabilities?: JsonObject;
+}
+
+export interface RequestCancelParams extends JsonObject {
+  readonly requestId: RequestId;
+  readonly reason?: string;
+}
+
+export type PermissionMode =
+  | "default"
+  | "plan"
+  | "acceptEdits"
+  | "bypassPermissions";
+
+export type MessageContentBlock =
+  | (JsonObject & { readonly type: "text"; readonly text: string })
+  | (JsonObject & {
+      readonly type: "image_url";
+      readonly image_url: JsonObject & { readonly url: string };
+    });
+
+export type MessageContent = string | readonly MessageContentBlock[];
+
+export interface AgentCreateParams extends JsonObject {
+  readonly objective?: string;
+  readonly cwd?: string;
+  readonly model?: string;
+  readonly provider?: string;
+  readonly profile?: string;
+  readonly instructions?: string;
+  readonly initialContent?: MessageContent;
+  readonly unattendedAllow?: readonly string[];
+  readonly unattendedDeny?: readonly string[];
+  readonly metadata?: JsonObject;
+  readonly permissionMode?: PermissionMode;
+  readonly envOverrides?: { readonly [key: string]: string };
+}
+
+export interface AgentListParams extends JsonObject {
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+export interface AgentAttachParams extends JsonObject {
+  readonly agentId: string;
+  readonly clientId?: string;
+}
+
+export interface AgentStopParams extends JsonObject {
+  readonly agentId: string;
+  readonly reason?: string;
+}
+
+export interface AgentLogsParams extends JsonObject {
+  readonly agentId: string;
+}
+
+export interface SessionCreateParams extends JsonObject {
+  readonly agentId?: string;
+  readonly cwd?: string;
+  readonly initialPrompt?: string;
+  readonly metadata?: JsonObject;
+}
+
+export interface SessionListParams extends JsonObject {
+  readonly agentId?: string;
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+export interface SessionAttachParams extends JsonObject {
+  readonly sessionId: string;
+  readonly clientId?: string;
+}
+
+export interface SessionDetachParams extends JsonObject {
+  readonly sessionId: string;
+  readonly attachmentId?: string;
+  readonly clientId?: string;
+}
+
+export interface SessionTerminateParams extends JsonObject {
+  readonly sessionId: string;
+  readonly reason?: string;
+}
+
+export interface SessionClearParams extends JsonObject {
+  readonly sessionId: string;
+}
+
+export interface SessionSnapshotParams extends JsonObject {
+  readonly sessionId: string;
+}
+
+export interface SessionTranscriptParams extends JsonObject {
+  readonly sessionId: string;
+}
+
+export interface SessionCancelTurnParams extends JsonObject {
+  readonly sessionId: string;
+  readonly reason?: string;
+}
+
+export interface SessionMcpServerConfig extends JsonObject {
+  readonly name: string;
+  readonly transport?: "stdio" | "sse" | "http" | "websocket" | "ws";
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly endpoint?: string;
+  readonly enabled?: boolean;
+  readonly required?: boolean;
+}
+
+export interface SessionMcpAddServerParams extends JsonObject {
+  readonly sessionId: string;
+  readonly config: SessionMcpServerConfig;
+}
+
+export interface MessageSendParams extends JsonObject {
+  readonly sessionId: string;
+  readonly content: MessageContent;
+  readonly clientMessageId?: string;
+  readonly metadata?: JsonObject;
+}
+
+export interface MessageStreamParams extends MessageSendParams {
+  readonly streamId?: string;
+}
+
+export interface ThreadRealtimeStartParams extends JsonObject {
+  readonly threadId: string;
+  readonly transport?: JsonObject | null;
+  readonly realtimeSessionId?: string | null;
+  readonly prompt?: string | null;
+  readonly outputModality: "audio" | "text";
+  readonly voice?: string | null;
+}
+
+export interface ThreadRealtimeAudioChunk extends JsonObject {
+  readonly data: string;
+  readonly sampleRate: number;
+  readonly numChannels: number;
+  readonly samplesPerChannel?: number | null;
+  readonly itemId?: string | null;
+}
+
+export interface ThreadRealtimeAppendAudioParams extends JsonObject {
+  readonly threadId: string;
+  readonly audio: ThreadRealtimeAudioChunk;
+}
+
+export interface ThreadRealtimeAppendTextParams extends JsonObject {
+  readonly threadId: string;
+  readonly text: string;
+}
+
+export interface ThreadRealtimeStopParams extends JsonObject {
+  readonly threadId: string;
+}
+
+export interface ExitPlanApprovalPayload extends JsonObject {
+  readonly action: "approve" | "revise";
+  readonly mode?: "acceptEdits" | "default";
+  readonly applyAllowedPrompts?: boolean;
+  readonly clearContext?: boolean;
+  readonly feedback?: string;
+}
+
+export interface ToolApproveParams extends JsonObject {
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly scope?: "once" | "session" | "agent";
+  readonly exitPlan?: ExitPlanApprovalPayload;
+}
+
+export interface ToolDenyParams extends JsonObject {
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly reason?: string;
+}
+
+export interface ToolCancelParams extends JsonObject {
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly reason?: string;
+}
+
+export interface ElicitationRespondParams extends JsonObject {
+  readonly sessionId: string;
+  readonly requestId: RequestId;
+  readonly kind: "request_user_input" | "mcp";
+  readonly serverName?: string;
+  readonly response: JsonObject;
+}
+
+export interface PermissionListParams extends JsonObject {
+  readonly agentId?: string;
+  readonly sessionId?: string;
+}
+
+export interface FuzzyFileSearchParams extends JsonObject {
+  readonly query: string;
+  readonly roots: readonly string[];
+  readonly cancellationToken?: string | null;
+}
+
+export interface CommandExecTerminalSize extends JsonObject {
+  readonly rows: number;
+  readonly cols: number;
+}
+
+export interface CommandExecStartParams extends JsonObject {
+  readonly command: readonly string[];
+  readonly processId?: string | null;
+  readonly tty?: boolean;
+  readonly streamStdin?: boolean;
+  readonly streamStdoutStderr?: boolean;
+  readonly outputBytesCap?: number | null;
+  readonly disableOutputCap?: boolean;
+  readonly disableTimeout?: boolean;
+  readonly timeoutMs?: number | null;
+  readonly cwd?: string | null;
+  readonly env?: Readonly<Record<string, string | null>> | null;
+  readonly size?: CommandExecTerminalSize | null;
+  readonly sandboxPolicy?: JsonObject | null;
+  readonly permissionProfile?: string | null;
+}
+
+export interface CommandExecWriteParams extends JsonObject {
+  readonly processId: string;
+  readonly deltaBase64?: string | null;
+  readonly closeStdin?: boolean;
+}
+
+export interface CommandExecResizeParams extends JsonObject {
+  readonly processId: string;
+  readonly size: CommandExecTerminalSize;
+}
+
+export interface CommandExecTerminateParams extends JsonObject {
+  readonly processId: string;
+}
+
+export type EmptyParams = Record<string, never>;
+
+export interface AgencParamsByMethod {
+  readonly initialize: InitializeParams;
+  readonly "request.cancel": RequestCancelParams;
+  readonly "agent.create": AgentCreateParams;
+  readonly "agent.list": AgentListParams;
+  readonly "agent.attach": AgentAttachParams;
+  readonly "agent.stop": AgentStopParams;
+  readonly "agent.logs": AgentLogsParams;
+  readonly "session.create": SessionCreateParams;
+  readonly "session.list": SessionListParams;
+  readonly "session.attach": SessionAttachParams;
+  readonly "session.detach": SessionDetachParams;
+  readonly "session.terminate": SessionTerminateParams;
+  readonly "session.clear": SessionClearParams;
+  readonly "session.snapshot": SessionSnapshotParams;
+  readonly "session.transcript": SessionTranscriptParams;
+  readonly "session.cancelTurn": SessionCancelTurnParams;
+  readonly "session.mcp.addServer": SessionMcpAddServerParams;
+  readonly "message.send": MessageSendParams;
+  readonly "message.stream": MessageStreamParams;
+  readonly "thread/realtime/start": ThreadRealtimeStartParams;
+  readonly "thread/realtime/appendAudio": ThreadRealtimeAppendAudioParams;
+  readonly "thread/realtime/appendText": ThreadRealtimeAppendTextParams;
+  readonly "thread/realtime/stop": ThreadRealtimeStopParams;
+  readonly "thread/realtime/listVoices": EmptyParams;
+  readonly "tool.approve": ToolApproveParams;
+  readonly "tool.deny": ToolDenyParams;
+  readonly "tool.cancel": ToolCancelParams;
+  readonly "elicitation.respond": ElicitationRespondParams;
+  readonly "permission.list": PermissionListParams;
+  readonly "fs.fuzzy_search": FuzzyFileSearchParams;
+  readonly "commandExec.start": CommandExecStartParams;
+  readonly "commandExec.write": CommandExecWriteParams;
+  readonly "commandExec.resize": CommandExecResizeParams;
+  readonly "commandExec.terminate": CommandExecTerminateParams;
+  readonly "health.ping": EmptyParams;
+  readonly "health.ready": EmptyParams;
+  readonly "health.stats": EmptyParams;
+  readonly "daemon.reload": EmptyParams;
+  readonly "auth.login": EmptyParams;
+  readonly "auth.whoami": EmptyParams;
+  readonly "auth.logout": EmptyParams;
+}
+
+// ── Result shapes ────────────────────────────────────────────────────
+
+export type AgentStatus = "idle" | "running" | "stopping" | "stopped" | "error";
+export type AgentRunStatus =
+  | "pending"
+  | "running"
+  | "working"
+  | "paused"
+  | "blocked"
+  | "suspended"
+  | "completed"
+  | "errored"
+  | "stopped";
+export type SessionStatus = "idle" | "running" | "waiting" | "closed" | "error";
+
+export interface AgentSummary extends JsonObject {
+  readonly agentId: string;
+  readonly agentPath?: string;
+  readonly objective?: string;
+  readonly status: AgentStatus;
+  readonly createdAt: string;
+  readonly startedAt?: string;
+  readonly lastActiveAt?: string;
+  readonly cwd?: string;
+  readonly activeSessionIds?: readonly string[];
+  readonly metadata?: JsonObject;
+}
+
+export interface SessionSummary extends JsonObject {
+  readonly sessionId: string;
+  readonly agentId: string;
+  readonly status: SessionStatus;
+  readonly createdAt: string;
+  readonly cwd?: string;
+  readonly metadata?: JsonObject;
+  readonly activeAttachmentIds?: readonly string[];
+  readonly closedAt?: string;
+}
+
+export interface InitializeResult extends JsonObject {
+  readonly type: "initialized";
+  readonly protocolVersion: string;
+  readonly protocol: DaemonProtocolInfo;
+  readonly capabilities: JsonObject;
+}
+
+export interface RequestCancelResult extends JsonObject {
+  readonly requestId: RequestId;
+  readonly cancelled: boolean;
+  readonly reason?: string;
+}
+
+export interface AgentCreateResult extends AgentSummary {
+  readonly sessionId?: string;
+}
+
+export interface AgentListResult extends JsonObject {
+  readonly agents: readonly AgentSummary[];
+  readonly nextCursor?: string;
+}
+
+export interface AgentAttachResult extends JsonObject {
+  readonly agentId: string;
+  readonly attachmentId: string;
+  readonly sessionIds: readonly string[];
+  readonly runtimeSessionId?: string;
+  readonly sessions?: readonly SessionSummary[];
+}
+
+export interface AgentStopResult extends JsonObject {
+  readonly agentId: string;
+  readonly stopped: boolean;
+}
+
+export interface AgentLogSession extends JsonObject {
+  readonly sessionId: string;
+  readonly itemCount: number;
+  readonly transcript: string;
+  readonly rolloutPath?: string;
+  readonly source?: string;
+}
+
+export interface AgentLogsResult extends JsonObject {
+  readonly agentId: string;
+  readonly transcript: string;
+  readonly sessions: readonly AgentLogSession[];
+  readonly toolOutputs?: readonly JsonObject[];
+}
+
+export interface SessionCreateResult extends SessionSummary {}
+
+export interface SessionListResult extends JsonObject {
+  readonly sessions: readonly SessionSummary[];
+  readonly nextCursor?: string;
+}
+
+export interface SessionAttachResult extends JsonObject {
+  readonly sessionId: string;
+  readonly attachmentId: string;
+  readonly attachedAt: string;
+  readonly clientId?: string;
+  readonly activeAttachmentIds: readonly string[];
+}
+
+export interface SessionDetachResult extends JsonObject {
+  readonly sessionId: string;
+  readonly detached: boolean;
+  readonly attachmentId?: string;
+  readonly remainingAttachmentIds: readonly string[];
+}
+
+export interface SessionTerminateResult extends JsonObject {
+  readonly sessionId: string;
+  readonly terminated: boolean;
+  readonly status: "closed";
+  readonly closedAt: string;
+  readonly reason?: string;
+}
+
+export interface SessionClearResult extends JsonObject {
+  readonly sessionId: string;
+  readonly cleared: true;
+  readonly clearedAt: string;
+}
+
+export interface TokenUsage extends JsonObject {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+}
+
+export interface CacheStats extends JsonObject {
+  readonly requestCount: number;
+  readonly cacheReadInputTokens: number;
+  readonly cacheCreationInputTokens: number;
+  readonly cacheTotalInputTokens: number;
+  readonly hitRate: number | null;
+}
+
+export interface SessionSnapshotResult extends JsonObject {
+  readonly sessionId: string;
+  readonly turnCount: number;
+  readonly tokenUsage: TokenUsage;
+  readonly cacheStats: CacheStats;
+}
+
+export interface SessionTranscriptMessage extends JsonObject {
+  readonly role: string;
+  readonly text: string;
+}
+
+export interface SessionTranscriptResult extends JsonObject {
+  readonly sessionId: string;
+  readonly messages: readonly SessionTranscriptMessage[];
+}
+
+export interface SessionCancelTurnResult extends JsonObject {
+  readonly sessionId: string;
+  readonly cancelled: boolean;
+  readonly reason?: string;
+}
+
+export interface SessionMcpAddServerResult extends JsonObject {
+  readonly sessionId: string;
+  readonly serverName: string;
+  readonly success: boolean;
+  readonly toolCount: number;
+  readonly error?: string;
+}
+
+export interface MessageSendResult extends JsonObject {
+  readonly messageId: string;
+  readonly acceptedAt: string;
+}
+
+export interface MessageStreamResult extends MessageSendResult {
+  readonly streamId: string;
+}
+
+export interface ToolDecisionResult extends JsonObject {
+  readonly requestId: string;
+  readonly decision: "approved" | "denied" | "cancelled";
+}
+
+export interface ElicitationRespondResult extends JsonObject {
+  readonly requestId: RequestId;
+  readonly resolved: boolean;
+}
+
+export interface PermissionGrant extends JsonObject {
+  readonly permissionId: string;
+  readonly subject: string;
+  readonly action: string;
+  readonly scope?: string;
+  readonly grantedAt?: string;
+  readonly expiresAt?: string;
+}
+
+export interface PermissionListResult extends JsonObject {
+  readonly permissions: readonly PermissionGrant[];
+}
+
+export interface FuzzyFileSearchResponse extends JsonObject {
+  readonly files: readonly JsonObject[];
+}
+
+export interface CommandExecResponse extends JsonObject {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface HealthPingResult extends JsonObject {
+  readonly ok: true;
+  readonly now: string;
+}
+
+export interface HealthReadyResult extends JsonObject {
+  readonly ready: boolean;
+  readonly uptimeMs: number;
+  readonly now: string;
+}
+
+export interface HealthStatsResult extends JsonObject {
+  readonly uptimeMs: number;
+  readonly now: string;
+  readonly sessions: JsonObject;
+  readonly memory: JsonObject;
+  readonly state?: JsonObject;
+}
+
+export interface DaemonReloadResult extends JsonObject {
+  readonly reloaded: true;
+  readonly configReloadedAt: string;
+  readonly mcpServer: JsonObject;
+}
+
+export interface AuthWhoamiResult extends JsonObject {
+  readonly authenticated: boolean;
+  readonly provider?: string;
+  readonly identity?: JsonObject;
+}
+
+export interface AuthLoginResult extends JsonObject {
+  readonly authenticated: true;
+  readonly provider?: string;
+  readonly identity?: JsonObject;
+}
+
+export interface AuthLogoutResult extends JsonObject {
+  readonly authenticated: false;
+}
+
+export interface AgencResultByMethod {
+  readonly initialize: InitializeResult;
+  readonly "request.cancel": RequestCancelResult;
+  readonly "agent.create": AgentCreateResult;
+  readonly "agent.list": AgentListResult;
+  readonly "agent.attach": AgentAttachResult;
+  readonly "agent.stop": AgentStopResult;
+  readonly "agent.logs": AgentLogsResult;
+  readonly "session.create": SessionCreateResult;
+  readonly "session.list": SessionListResult;
+  readonly "session.attach": SessionAttachResult;
+  readonly "session.detach": SessionDetachResult;
+  readonly "session.terminate": SessionTerminateResult;
+  readonly "session.clear": SessionClearResult;
+  readonly "session.snapshot": SessionSnapshotResult;
+  readonly "session.transcript": SessionTranscriptResult;
+  readonly "session.cancelTurn": SessionCancelTurnResult;
+  readonly "session.mcp.addServer": SessionMcpAddServerResult;
+  readonly "message.send": MessageSendResult;
+  readonly "message.stream": MessageStreamResult;
+  readonly "thread/realtime/start": JsonObject;
+  readonly "thread/realtime/appendAudio": JsonObject;
+  readonly "thread/realtime/appendText": JsonObject;
+  readonly "thread/realtime/stop": JsonObject;
+  readonly "thread/realtime/listVoices": JsonObject;
+  readonly "tool.approve": ToolDecisionResult;
+  readonly "tool.deny": ToolDecisionResult;
+  readonly "tool.cancel": ToolDecisionResult;
+  readonly "elicitation.respond": ElicitationRespondResult;
+  readonly "permission.list": PermissionListResult;
+  readonly "fs.fuzzy_search": FuzzyFileSearchResponse;
+  readonly "commandExec.start": CommandExecResponse;
+  readonly "commandExec.write": JsonObject;
+  readonly "commandExec.resize": JsonObject;
+  readonly "commandExec.terminate": JsonObject;
+  readonly "health.ping": HealthPingResult;
+  readonly "health.ready": HealthReadyResult;
+  readonly "health.stats": HealthStatsResult;
+  readonly "daemon.reload": DaemonReloadResult;
+  readonly "auth.login": AuthLoginResult;
+  readonly "auth.whoami": AuthWhoamiResult;
+  readonly "auth.logout": AuthLogoutResult;
+}
+
+// ── Notification params ──────────────────────────────────────────────
+
+export interface AgencEventBaseParams extends JsonObject {
+  readonly sessionId: string;
+  readonly eventId: string;
+  readonly agentId?: string;
+  readonly sequence?: number;
+  readonly acceptedAt?: string;
+  readonly metadata?: JsonObject;
+}
+
+export interface EventMessageChunkParams extends AgencEventBaseParams {
+  readonly messageId?: string;
+  readonly streamId?: string;
+  readonly delta: string;
+}
+
+export interface EventToolRequestParams extends AgencEventBaseParams {
+  readonly requestId: string;
+  readonly toolName: string;
+  readonly turnId?: string;
+  readonly input?: JsonValue;
+  readonly recoveryCategory?: "idempotent" | "side-effecting" | "interactive";
+}
+
+export interface EventPermissionRequestParams extends AgencEventBaseParams {
+  readonly requestId: string;
+  readonly toolName?: string;
+  readonly turnId?: string;
+  readonly permissions: readonly string[];
+  readonly input?: JsonValue;
+  readonly reason?: string;
+}
+
+export interface EventUserInputRequestParams extends AgencEventBaseParams {
+  readonly requestId: string;
+  readonly callId: string;
+  readonly turnId: string;
+  readonly questions: readonly JsonObject[];
+}
+
+export interface EventMcpElicitationRequestParams extends AgencEventBaseParams {
+  readonly requestId: RequestId;
+  readonly serverName: string;
+  readonly turnId: string;
+  readonly request: JsonObject;
+}
+
+export interface EventAgentStatusParams extends AgencEventBaseParams {
+  readonly agentId: string;
+  readonly status: AgentStatus;
+  readonly runStatus?: AgentRunStatus;
+  readonly turnId?: string;
+  readonly message?: string;
+}
+
+export interface EventSessionEventParams extends AgencEventBaseParams {
+  readonly event: JsonObject;
+}
+
+// ── Envelopes ────────────────────────────────────────────────────────
+
+export interface AgencDaemonRequest<
+  Method extends AgencDaemonMethod = AgencDaemonMethod,
+> {
+  readonly jsonrpc: typeof AGENC_SDK_JSON_RPC_VERSION;
+  readonly id: RequestId;
+  readonly method: Method;
+  readonly params?: AgencParamsByMethod[Method];
+}
+
+export type AgencDaemonErrorCode =
+  | -32700
+  | -32600
+  | -32601
+  | -32602
+  | -32603
+  | -32000;
+
+export interface AgencDaemonErrorObject extends JsonObject {
+  readonly code: AgencDaemonErrorCode;
+  readonly message: string;
+  readonly data?: JsonValue;
+}
+
+export interface AgencDaemonSuccessResponse<
+  Method extends AgencDaemonMethod = AgencDaemonMethod,
+> {
+  readonly jsonrpc: typeof AGENC_SDK_JSON_RPC_VERSION;
+  readonly id: RequestId;
+  readonly result: AgencResultByMethod[Method];
+}
+
+export interface AgencDaemonErrorResponse {
+  readonly jsonrpc: typeof AGENC_SDK_JSON_RPC_VERSION;
+  readonly id: RequestId | null;
+  readonly error: AgencDaemonErrorObject;
+}
+
+export type AgencDaemonResponse<
+  Method extends AgencDaemonMethod = AgencDaemonMethod,
+> = AgencDaemonSuccessResponse<Method> | AgencDaemonErrorResponse;
+
+export interface AgencDaemonNotification extends JsonObject {
+  readonly jsonrpc: typeof AGENC_SDK_JSON_RPC_VERSION;
+  readonly method: AgencDaemonNotificationMethod;
+  readonly params: JsonObject;
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -1,0 +1,427 @@
+/**
+ * Unix-socket transport + `connect()` for the AgenC daemon.
+ *
+ * Wire contract (mirrors `runtime/src/app-server/transport/unix-socket.ts`
+ * and the CLI client in `runtime/src/app-server/agent-cli.ts`):
+ *   - socket at `${AGENC_HOME:-~/.agenc}/daemon.sock`
+ *   - newline-delimited JSON frames
+ *   - the first message on a connection MUST be `initialize` carrying the
+ *     `authCookie` read from `${AGENC_HOME:-~/.agenc}/daemon.cookie`
+ *   - responses carry `id`; notifications carry `method` + `params` and no id
+ *
+ * Daemon autostart: the SDK cannot reuse the runtime's internal autostart
+ * orchestration (build-skew detection, orphan adoption) without importing
+ * runtime internals, so `connect()` implements attach-to-running plus
+ * spawn-via-CLI: when the socket is not accepting connections it runs
+ * `agenc daemon start` (configurable via `agencCommand`) and polls the
+ * cookie + socket until ready. This is a documented deviation from the
+ * launcher's in-process autostart path.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createConnection, type Socket } from "node:net";
+import { spawn as nodeSpawn } from "node:child_process";
+import {
+  isJsonObject,
+  type AgencDaemonMethod,
+  type AgencDaemonRequest,
+  type AgencDaemonResponse,
+  type JsonObject,
+  type RequestId,
+} from "./protocol.js";
+import {
+  AgencClient,
+  type AgencElicitationCallback,
+  type AgencPermissionCallback,
+  type AgencTransport,
+} from "./client.js";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_READY_TIMEOUT_MS = 45_000;
+const READY_POLL_MS = 50;
+/** Mirrors the daemon transports' 16 MiB max-line bound. */
+const MAX_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024;
+
+export function resolveAgencHome(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome = homedir(),
+): string {
+  const configured = env.AGENC_HOME?.trim();
+  return configured && configured.length > 0
+    ? configured
+    : join(userHome, ".agenc");
+}
+
+export function resolveDaemonSocketPath(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome?: string,
+): string {
+  return join(resolveAgencHome(env, userHome), "daemon.sock");
+}
+
+export function resolveDaemonCookiePath(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome?: string,
+): string {
+  return join(resolveAgencHome(env, userHome), "daemon.cookie");
+}
+
+interface PendingRequest {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: Error) => void;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+export interface AgencSocketTransportOptions {
+  readonly socketPath: string;
+  readonly connectTimeoutMs?: number;
+  readonly requestTimeoutMs?: number;
+  readonly onNotification?: (message: JsonObject) => void;
+  readonly onClose?: (error: Error | null) => void;
+}
+
+/**
+ * Persistent newline-JSON socket transport. Single connection, no reconnect
+ * layer — embedders that need reconnect can recreate the client via
+ * {@link connect}.
+ */
+export class AgencSocketTransport implements AgencTransport {
+  readonly #socket: Socket;
+  readonly #pending = new Map<RequestId, PendingRequest>();
+  readonly #requestTimeoutMs: number;
+  readonly #onNotification: ((message: JsonObject) => void) | undefined;
+  #buffer = "";
+  #closed = false;
+
+  private constructor(socket: Socket, options: AgencSocketTransportOptions) {
+    this.#socket = socket;
+    this.#requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.#onNotification = options.onNotification;
+
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk: string) => {
+      this.#handleData(chunk, options.onClose);
+    });
+    socket.once("error", (error) => {
+      this.#failAll(error);
+      if (!this.#closed) {
+        this.#closed = true;
+        options.onClose?.(error);
+      }
+    });
+    socket.once("close", () => {
+      this.#failAll(new Error("AgenC daemon connection closed"));
+      if (!this.#closed) {
+        this.#closed = true;
+        options.onClose?.(null);
+      }
+    });
+  }
+
+  static connect(options: AgencSocketTransportOptions): Promise<AgencSocketTransport> {
+    return new Promise((resolve, reject) => {
+      const socket = createConnection(options.socketPath);
+      const timeout = setTimeout(() => {
+        socket.destroy();
+        reject(
+          new Error(`Timed out connecting to daemon at ${options.socketPath}`),
+        );
+      }, options.connectTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+      socket.once("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      socket.once("connect", () => {
+        clearTimeout(timeout);
+        socket.removeAllListeners("error");
+        resolve(new AgencSocketTransport(socket, options));
+      });
+    });
+  }
+
+  request<Method extends AgencDaemonMethod>(
+    request: AgencDaemonRequest<Method>,
+  ): Promise<AgencDaemonResponse<Method>> {
+    if (this.#closed) {
+      return Promise.reject(new Error("AgenC daemon connection is closed"));
+    }
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.#pending.delete(request.id);
+        reject(
+          new Error(
+            `Timed out waiting for daemon response to ${request.method}`,
+          ),
+        );
+      }, this.#requestTimeoutMs);
+      this.#pending.set(request.id, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          resolve(value as AgencDaemonResponse<Method>);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+        timeout,
+      });
+      this.#socket.write(`${JSON.stringify(request)}\n`);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#socket.destroy();
+    this.#failAll(new Error("AgenC daemon connection closed"));
+  }
+
+  #handleData(
+    chunk: string,
+    onClose: ((error: Error | null) => void) | undefined,
+  ): void {
+    this.#buffer += chunk;
+    if (Buffer.byteLength(this.#buffer, "utf8") > MAX_CLIENT_BUFFER_BYTES) {
+      const overflow = new Error(
+        `AgenC daemon connection exceeded ${MAX_CLIENT_BUFFER_BYTES} bytes without a complete message`,
+      );
+      this.#buffer = "";
+      this.#failAll(overflow);
+      this.#closed = true;
+      this.#socket.destroy(overflow);
+      onClose?.(overflow);
+      return;
+    }
+    let newlineIndex = this.#buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = this.#buffer.slice(0, newlineIndex).trim();
+      this.#buffer = this.#buffer.slice(newlineIndex + 1);
+      if (line.length > 0) this.#handleLine(line);
+      newlineIndex = this.#buffer.indexOf("\n");
+    }
+  }
+
+  #handleLine(line: string): void {
+    let message: unknown;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return; // Ignore malformed frames; requests still time out safely.
+    }
+    if (!isJsonObject(message)) return;
+    if (typeof message.id === "string" || typeof message.id === "number") {
+      const waiter = this.#pending.get(message.id);
+      if (waiter === undefined) return;
+      this.#pending.delete(message.id);
+      waiter.resolve(message);
+      return;
+    }
+    if (typeof message.method === "string") {
+      this.#onNotification?.(message);
+    }
+  }
+
+  #failAll(error: Error): void {
+    for (const waiter of this.#pending.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(error);
+    }
+    this.#pending.clear();
+  }
+}
+
+export type AgencSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly env: NodeJS.ProcessEnv;
+    readonly stdio: "ignore";
+  },
+) => {
+  once(event: "exit", listener: (code: number | null) => void): unknown;
+  once(event: "error", listener: (error: Error) => void): unknown;
+};
+
+export interface AgencConnectOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly userHome?: string;
+  readonly socketPath?: string;
+  readonly cookiePath?: string;
+  /** Start the daemon via the CLI when it is not running. Default `true`. */
+  readonly autostart?: boolean;
+  /**
+   * Command used to start the daemon (`<cmd> daemon start`). Defaults to
+   * `"agenc"` on PATH; pass an absolute launcher path when embedding.
+   */
+  readonly agencCommand?: string | readonly string[];
+  /** Total budget for autostart + readiness polling. Default 45s or `AGENC_DAEMON_READY_TIMEOUT_MS`. */
+  readonly readyTimeoutMs?: number;
+  /** Per-request timeout. Default 30s or `AGENC_DAEMON_REQUEST_TIMEOUT_MS`. */
+  readonly requestTimeoutMs?: number;
+  readonly clientId?: string;
+  readonly clientName?: string;
+  readonly onPermissionRequest?: AgencPermissionCallback;
+  readonly onElicitationRequest?: AgencElicitationCallback;
+  readonly onDisconnect?: (error: Error | null) => void;
+  /** Injectable for tests. */
+  readonly spawn?: AgencSpawnFn;
+}
+
+/**
+ * Connect to the local AgenC daemon (starting it through the CLI when
+ * needed), perform the `initialize` handshake, and return a ready client.
+ */
+export async function connect(
+  options: AgencConnectOptions = {},
+): Promise<AgencClient> {
+  const env = options.env ?? process.env;
+  const socketPath =
+    options.socketPath ?? resolveDaemonSocketPath(env, options.userHome);
+  const cookiePath =
+    options.cookiePath ?? resolveDaemonCookiePath(env, options.userHome);
+  const readyTimeoutMs =
+    options.readyTimeoutMs ??
+    positiveIntFromEnv(env.AGENC_DAEMON_READY_TIMEOUT_MS) ??
+    DEFAULT_READY_TIMEOUT_MS;
+  const requestTimeoutMs =
+    options.requestTimeoutMs ??
+    positiveIntFromEnv(env.AGENC_DAEMON_REQUEST_TIMEOUT_MS) ??
+    DEFAULT_REQUEST_TIMEOUT_MS;
+
+  let authCookie = await readDaemonCookie(cookiePath);
+  let reachable = authCookie !== null && (await canConnect(socketPath));
+
+  if (!reachable) {
+    if (options.autostart === false) {
+      throw new Error(
+        `AgenC daemon is not running at ${socketPath} and autostart is disabled`,
+      );
+    }
+    await startDaemonViaCli(options.agencCommand ?? "agenc", env, options.spawn);
+    const deadline = Date.now() + readyTimeoutMs;
+    for (;;) {
+      authCookie = await readDaemonCookie(cookiePath);
+      if (authCookie !== null && (await canConnect(socketPath))) {
+        reachable = true;
+        break;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `AgenC daemon did not become ready at ${socketPath} within ${readyTimeoutMs}ms`,
+        );
+      }
+      await sleep(READY_POLL_MS);
+    }
+  }
+
+  if (authCookie === null) {
+    throw new Error(`daemon cookie is not available at ${cookiePath}`);
+  }
+
+  let client: AgencClient | null = null;
+  const transport = await AgencSocketTransport.connect({
+    socketPath,
+    requestTimeoutMs,
+    connectTimeoutMs: readyTimeoutMs,
+    onNotification: (message) => client?.dispatchNotification(message),
+    onClose: (error) => options.onDisconnect?.(error),
+  });
+  client = new AgencClient({
+    transport,
+    ...(options.clientId !== undefined ? { clientId: options.clientId } : {}),
+    ...(options.clientName !== undefined
+      ? { clientName: options.clientName }
+      : {}),
+    ...(options.onPermissionRequest !== undefined
+      ? { onPermissionRequest: options.onPermissionRequest }
+      : {}),
+    ...(options.onElicitationRequest !== undefined
+      ? { onElicitationRequest: options.onElicitationRequest }
+      : {}),
+  });
+  try {
+    await client.initialize({ authCookie });
+  } catch (error) {
+    await transport.close();
+    throw error;
+  }
+  return client;
+}
+
+async function readDaemonCookie(cookiePath: string): Promise<string | null> {
+  try {
+    const cookie = (await readFile(cookiePath, "utf8")).trim();
+    return cookie.length > 0 ? cookie : null;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function canConnect(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection(socketPath);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function startDaemonViaCli(
+  command: string | readonly string[],
+  env: NodeJS.ProcessEnv,
+  spawnFn: AgencSpawnFn | undefined,
+): Promise<void> {
+  const [executable, ...prefixArgs] =
+    typeof command === "string" ? [command] : command;
+  if (executable === undefined || executable.length === 0) {
+    throw new Error("agencCommand must name an executable");
+  }
+  const spawner: AgencSpawnFn =
+    spawnFn ??
+    ((cmd, args, spawnOptions) => nodeSpawn(cmd, [...args], spawnOptions));
+  return new Promise((resolve, reject) => {
+    const child = spawner(executable, [...prefixArgs, "daemon", "start"], {
+      env,
+      stdio: "ignore",
+    });
+    child.once("error", (error: Error) => {
+      reject(
+        new Error(`failed to start AgenC daemon via ${executable}: ${error.message}`),
+      );
+    });
+    child.once("exit", (code: number | null) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `AgenC daemon start exited with code ${code ?? "null"} (command: ${executable})`,
+        ),
+      );
+    });
+  });
+}
+
+function positiveIntFromEnv(raw: string | undefined): number | null {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return null;
+  const value = Number.parseInt(trimmed, 10);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/agenc-sdk/src/subprocess.ts
+++ b/packages/agenc-sdk/src/subprocess.ts
@@ -1,0 +1,286 @@
+/**
+ * Subprocess ("headless CLI") transport.
+ *
+ * Instead of speaking JSON-RPC to the daemon socket, this transport spawns
+ * `agenc -p --output-format stream-json --input-format stream-json` and
+ * adapts its line-delimited output onto the same event-iterable interface
+ * as {@link AgencSession.prompt}.
+ *
+ * stream-json contract (mirrors `runtime/src/bin/agenc.ts`):
+ *   - stdin: one JSON object per line; `{"type":"prompt","prompt":"..."}`
+ *     (also accepts `input_text` / user `message` records).
+ *   - stdout: `{"type":"event","sessionId","agentId","event":<daemon
+ *     notification>}` lines while the turn runs, then one final
+ *     `{"type":"result","exitCode","finalMessage","deniedPermissionRequestIds",
+ *     "tokenUsage"?,"cacheStats"?}` line.
+ *
+ * Limitations (inherent to `agenc -p`): the run is one-shot and
+ * non-interactive — the CLI auto-DENIES permission requests, so permission
+ * callbacks cannot grant tools over this transport. Exit code 2 marks a
+ * tool-denied giveup, exactly like the CLI.
+ */
+
+import { spawn as nodeSpawn } from "node:child_process";
+import { isJsonObject, type JsonObject } from "./protocol.js";
+import {
+  promptEventFromNotification,
+  stopReasonFromExitCode,
+  type AgencPromptEvent,
+  type AgencPromptResult,
+} from "./events.js";
+
+export interface AgencSubprocessChild {
+  readonly stdin: {
+    write(chunk: string): unknown;
+    end(): unknown;
+  } | null;
+  readonly stdout: {
+    setEncoding(encoding: string): unknown;
+    on(event: "data", listener: (chunk: string) => void): unknown;
+  } | null;
+  readonly stderr: {
+    setEncoding(encoding: string): unknown;
+    on(event: "data", listener: (chunk: string) => void): unknown;
+  } | null;
+  once(event: "error", listener: (error: Error) => void): unknown;
+  once(
+    event: "exit",
+    listener: (code: number | null, signal: string | null) => void,
+  ): unknown;
+  kill(signal?: string): unknown;
+}
+
+export type AgencSubprocessSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly cwd?: string;
+    readonly env?: NodeJS.ProcessEnv;
+    readonly stdio: readonly ["pipe", "pipe", "pipe"];
+  },
+) => AgencSubprocessChild;
+
+export interface AgencSubprocessOptions {
+  /**
+   * Executable (plus fixed prefix args) for the AgenC CLI. Defaults to
+   * `"agenc"` on PATH.
+   */
+  readonly agencCommand?: string | readonly string[];
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly model?: string;
+  readonly provider?: string;
+  readonly profile?: string;
+  readonly permissionMode?:
+    | "default"
+    | "plan"
+    | "acceptEdits"
+    | "bypassPermissions";
+  /** Extra argv appended verbatim after the built-in flags. */
+  readonly extraArgs?: readonly string[];
+  readonly signal?: AbortSignal;
+  /** Injectable for tests. */
+  readonly spawn?: AgencSubprocessSpawnFn;
+}
+
+/** Event-iterable prompt run over the subprocess transport. */
+export interface AgencSubprocessRun extends AsyncIterable<AgencPromptEvent> {
+  result(): Promise<AgencPromptResult>;
+  /** SIGTERM the child. */
+  cancel(): void;
+}
+
+/**
+ * Run one headless prompt through the AgenC CLI and stream typed events.
+ */
+export function promptViaSubprocess(
+  prompt: string,
+  options: AgencSubprocessOptions = {},
+): AgencSubprocessRun {
+  const command = options.agencCommand ?? "agenc";
+  const [executable, ...prefixArgs] =
+    typeof command === "string" ? [command] : [...command];
+  if (executable === undefined || executable.length === 0) {
+    throw new Error("agencCommand must name an executable");
+  }
+  const args = [
+    ...prefixArgs,
+    "-p",
+    "--output-format",
+    "stream-json",
+    "--input-format",
+    "stream-json",
+    ...(options.model !== undefined ? ["--model", options.model] : []),
+    ...(options.provider !== undefined ? ["--provider", options.provider] : []),
+    ...(options.profile !== undefined ? ["--profile", options.profile] : []),
+    ...(options.permissionMode !== undefined
+      ? ["--permission-mode", options.permissionMode]
+      : []),
+    ...(options.extraArgs ?? []),
+  ];
+
+  const spawner: AgencSubprocessSpawnFn =
+    options.spawn ??
+    ((spawnCommand, spawnArgs, spawnOptions) =>
+      nodeSpawn(spawnCommand, [...spawnArgs], {
+        ...spawnOptions,
+        stdio: [...spawnOptions.stdio],
+      }) as unknown as AgencSubprocessChild);
+
+  const child = spawner(executable, args, {
+    ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+    ...(options.env !== undefined ? { env: options.env } : {}),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const buffered: AgencPromptEvent[] = [];
+  let wake: (() => void) | null = null;
+  let done = false;
+  let failure: Error | null = null;
+  let finalResult: AgencPromptResult | null = null;
+  let resultLine: JsonObject | null = null;
+  let stderrTail = "";
+  let stdoutRemainder = "";
+
+  let resolveResult!: (value: AgencPromptResult) => void;
+  let rejectResult!: (error: Error) => void;
+  const resultPromise = new Promise<AgencPromptResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  resultPromise.catch(() => {});
+
+  const notify = () => {
+    wake?.();
+    wake = null;
+  };
+  const finishOk = (value: AgencPromptResult) => {
+    if (done) return;
+    done = true;
+    finalResult = value;
+    resolveResult(value);
+    notify();
+  };
+  const finishError = (error: Error) => {
+    if (done) return;
+    done = true;
+    failure = error;
+    rejectResult(error);
+    notify();
+  };
+
+  const handleLine = (line: string) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return; // non-JSON noise on stdout is ignored
+    }
+    if (!isJsonObject(parsed)) return;
+    if (parsed.type === "event" && isJsonObject(parsed.event)) {
+      const event = promptEventFromNotification(parsed.event);
+      if (event !== null && !done) {
+        buffered.push(event);
+        notify();
+      }
+      return;
+    }
+    if (parsed.type === "result") {
+      resultLine = parsed;
+    }
+  };
+
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdoutRemainder += chunk;
+    let newlineIndex = stdoutRemainder.indexOf("\n");
+    while (newlineIndex >= 0) {
+      handleLine(stdoutRemainder.slice(0, newlineIndex));
+      stdoutRemainder = stdoutRemainder.slice(newlineIndex + 1);
+      newlineIndex = stdoutRemainder.indexOf("\n");
+    }
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderrTail = `${stderrTail}${chunk}`.slice(-8_192);
+  });
+
+  child.once("error", (error) => {
+    finishError(
+      new Error(`failed to spawn AgenC CLI (${executable}): ${error.message}`),
+    );
+  });
+  child.once("exit", (code, signal) => {
+    if (stdoutRemainder.length > 0) {
+      handleLine(stdoutRemainder);
+      stdoutRemainder = "";
+    }
+    if (resultLine !== null) {
+      const line = resultLine;
+      const exitCode =
+        typeof line.exitCode === "number" ? line.exitCode : code ?? 1;
+      const denied = Array.isArray(line.deniedPermissionRequestIds)
+        ? line.deniedPermissionRequestIds.filter(
+            (value): value is string => typeof value === "string",
+          )
+        : [];
+      finishOk({
+        stopReason: stopReasonFromExitCode(exitCode),
+        exitCode,
+        finalMessage:
+          typeof line.finalMessage === "string" ? line.finalMessage : "",
+        deniedPermissionRequestIds: denied,
+        ...(isJsonObject(line.tokenUsage) ? { usage: line.tokenUsage } : {}),
+        ...(isJsonObject(line.cacheStats)
+          ? { cacheStats: line.cacheStats }
+          : {}),
+      });
+      return;
+    }
+    finishError(
+      new Error(
+        `AgenC CLI exited (code ${code ?? "null"}${
+          signal !== null ? `, signal ${signal}` : ""
+        }) without a stream-json result${
+          stderrTail.trim().length > 0 ? `: ${stderrTail.trim()}` : ""
+        }`,
+      ),
+    );
+  });
+
+  if (options.signal !== undefined) {
+    const onAbort = () => child.kill("SIGTERM");
+    if (options.signal.aborted) onAbort();
+    else options.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  if (child.stdin === null) {
+    finishError(new Error("AgenC CLI child has no stdin pipe"));
+  } else {
+    child.stdin.write(`${JSON.stringify({ type: "prompt", prompt })}\n`);
+    child.stdin.end();
+  }
+
+  return {
+    result: () => resultPromise,
+    cancel: () => {
+      child.kill("SIGTERM");
+    },
+    async *[Symbol.asyncIterator]() {
+      for (;;) {
+        while (buffered.length > 0) {
+          yield buffered.shift()!;
+        }
+        if (done) {
+          if (failure !== null) throw failure;
+          return finalResult!;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+    },
+  };
+}

--- a/packages/agenc-sdk/tsconfig.json
+++ b/packages/agenc-sdk/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Contract tests for the in-repo embedding SDK (`packages/agenc-sdk`)
+ * against a fake daemon hosted on the REAL in-process transport
+ * (`runtime/src/app-server/transport/in-process.ts`): real JSON-RPC
+ * dispatcher, real session lifecycle, real client multiplexer; only the
+ * agent runtime is faked.
+ */
+
+import { describe, expect, it } from "vitest";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { AgenCInProcessDaemonTransport } from "../../src/app-server/transport/in-process.js";
+import {
+  JSON_RPC_VERSION,
+  type AgenCDaemonSessionNotification,
+  type JsonObject,
+} from "../../src/app-server/protocol/index.js";
+import {
+  createAgencClient,
+  type AgencClient,
+  type AgencPermissionRequest,
+  type AgencPromptEvent,
+  type AgencTransport,
+} from "../../../packages/agenc-sdk/src/index";
+
+function sequence(values: readonly string[]): () => string {
+  let index = 0;
+  return () => {
+    const value = values[index];
+    if (value === undefined) throw new Error("test sequence exhausted");
+    index += 1;
+    return value;
+  };
+}
+
+interface FakeDaemon {
+  readonly client: AgencClient;
+  readonly transport: AgenCInProcessDaemonTransport;
+  readonly multiplexer: AgenCDaemonClientMultiplexer;
+  readonly calls: {
+    streamed: JsonObject[];
+    approved: JsonObject[];
+    denied: JsonObject[];
+  };
+  broadcast(
+    sessionId: string,
+    notification: AgenCDaemonSessionNotification,
+  ): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+/**
+ * Assemble a fake daemon: real dispatcher + session manager + multiplexer
+ * hosted on the real in-process transport, with an agent runtime whose turn
+ * behavior is provided by `onStreamMessage`.
+ */
+async function createFakeDaemon(options: {
+  readonly onStreamMessage?: (
+    daemon: FakeDaemon,
+    params: JsonObject,
+  ) => Promise<void> | void;
+  readonly onApproveTool?: (daemon: FakeDaemon, params: JsonObject) => void;
+  readonly onDenyTool?: (daemon: FakeDaemon, params: JsonObject) => void;
+  readonly onPermissionRequest?: (
+    request: AgencPermissionRequest,
+  ) =>
+    | { behavior: "allow"; scope?: "once" | "session" | "agent" }
+    | { behavior: "deny"; reason?: string };
+} = {}): Promise<FakeDaemon> {
+  const sessionManager = new AgenCDaemonSessionManager({
+    createSessionId: sequence(["session_1", "session_2"]),
+    createAttachmentId: sequence(["attachment_1", "attachment_2"]),
+  });
+  const multiplexer = new AgenCDaemonClientMultiplexer({
+    sessionManager,
+  });
+  const calls: FakeDaemon["calls"] = { streamed: [], approved: [], denied: [] };
+
+  let daemon!: FakeDaemon;
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+    agentManager: {
+      createAgent: async () => {
+        throw new Error("createAgent should not be called");
+      },
+      listAgents: async () => ({ agents: [] }),
+      attachAgent: async () => {
+        throw new Error("attachAgent should not be called");
+      },
+      stopAgent: async () => ({ agentId: "agent_1", stopped: true }),
+      getAgentLogs: async () => ({
+        agentId: "agent_1",
+        sessions: [],
+        transcript: "",
+      }),
+      streamAgentMessage: async (params: JsonObject) => {
+        calls.streamed.push(params);
+        await options.onStreamMessage?.(daemon, params);
+      },
+      approveTool: async (params: JsonObject) => {
+        calls.approved.push(params);
+        options.onApproveTool?.(daemon, params);
+        return {
+          requestId: String(params.requestId),
+          decision: "approved" as const,
+        };
+      },
+      denyTool: async (params: JsonObject) => {
+        calls.denied.push(params);
+        options.onDenyTool?.(daemon, params);
+        return {
+          requestId: String(params.requestId),
+          decision: "denied" as const,
+        };
+      },
+      cancelTool: async (params: JsonObject) => ({
+        requestId: String(params.requestId),
+        decision: "cancelled" as const,
+      }),
+      snapshotSession: async (params: JsonObject) => ({
+        sessionId: String(params.sessionId),
+        turnCount: 1,
+        tokenUsage: {
+          inputTokens: 11,
+          outputTokens: 7,
+          totalTokens: 18,
+          costUsd: 0.0042,
+        },
+        cacheStats: {
+          requestCount: 1,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          cacheTotalInputTokens: 0,
+          hitRate: null,
+        },
+      }),
+    } as never,
+    sessionManager,
+    clientMultiplexer: multiplexer,
+  });
+
+  let client: AgencClient | undefined;
+  const transport = new AgenCInProcessDaemonTransport({
+    dispatcher,
+    sendNotification: (notification) =>
+      client?.dispatchNotification(notification),
+  });
+  client = createAgencClient({
+    transport: transport as unknown as AgencTransport,
+    clientId: "agenc-sdk-test-client",
+    ...(options.onPermissionRequest !== undefined
+      ? { onPermissionRequest: options.onPermissionRequest }
+      : {}),
+  });
+
+  daemon = {
+    client,
+    transport,
+    multiplexer,
+    calls,
+    broadcast: (sessionId, notification) =>
+      multiplexer.broadcastSessionNotification(sessionId, notification),
+    close: async () => {
+      await client?.close();
+      await transport.close();
+    },
+  };
+  return daemon;
+}
+
+function statusNotification(
+  sessionId: string,
+  runStatus: "completed" | "errored" | "stopped",
+  message?: string,
+): AgenCDaemonSessionNotification {
+  return {
+    jsonrpc: JSON_RPC_VERSION,
+    method: "event.agent_status",
+    params: {
+      sessionId,
+      eventId: `evt_status_${runStatus}`,
+      agentId: "agent_1",
+      status: "running",
+      runStatus,
+      ...(message !== undefined ? { message } : {}),
+    },
+  };
+}
+
+describe("agenc-sdk client over the in-process transport", () => {
+  it("initializes, creates a session, and streams a typed prompt event stream", async () => {
+    const daemon = await createFakeDaemon({
+      onStreamMessage: async (fake, params) => {
+        const sessionId = String(params.sessionId);
+        await fake.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.message_chunk",
+          params: {
+            sessionId,
+            eventId: "evt_1",
+            messageId: String(params.messageId),
+            delta: "Hello ",
+          },
+        });
+        await fake.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.tool_request",
+          params: {
+            sessionId,
+            eventId: "evt_2",
+            requestId: "tool_req_1",
+            toolName: "Read",
+            input: { file_path: "/tmp/x" },
+          },
+        });
+        await fake.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.message_chunk",
+          params: {
+            sessionId,
+            eventId: "evt_3",
+            messageId: String(params.messageId),
+            delta: "world",
+          },
+        });
+        await fake.broadcast(
+          sessionId,
+          statusNotification(sessionId, "completed", "Hello world"),
+        );
+      },
+    });
+
+    const initialized = await daemon.client.initialize();
+    expect(initialized).toMatchObject({
+      type: "initialized",
+      protocol: { version: "1.0.0" },
+    });
+
+    const session = await daemon.client.createSession({
+      metadata: { source: "sdk-inprocess-test" },
+    });
+    expect(session.sessionId).toBe("session_1");
+    await expect(
+      daemon.multiplexer.attachedClientIds("session_1"),
+    ).resolves.toEqual(["agenc-sdk-test-client"]);
+
+    const run = session.prompt("hi there");
+    const events: AgencPromptEvent[] = [];
+    for await (const event of run) {
+      events.push(event);
+    }
+    const result = await run.result();
+
+    expect(daemon.calls.streamed).toHaveLength(1);
+    expect(daemon.calls.streamed[0]).toMatchObject({
+      sessionId: "session_1",
+      content: "hi there",
+    });
+    await expect(run.accepted).resolves.toEqual({
+      messageId: expect.any(String),
+    });
+
+    expect(
+      events
+        .filter(
+          (event): event is Extract<AgencPromptEvent, { type: "text" }> =>
+            event.type === "text",
+        )
+        .map((event) => event.delta)
+        .join(""),
+    ).toBe("Hello world");
+    expect(events.some((event) => event.type === "tool_call")).toBe(true);
+    const toolCall = events.find(
+      (event): event is Extract<AgencPromptEvent, { type: "tool_call" }> =>
+        event.type === "tool_call",
+    );
+    expect(toolCall).toMatchObject({
+      requestId: "tool_req_1",
+      toolName: "Read",
+      input: { file_path: "/tmp/x" },
+    });
+
+    expect(result.stopReason).toBe("completed");
+    expect(result.exitCode).toBe(0);
+    expect(result.finalMessage).toBe("Hello world");
+    expect(result.deniedPermissionRequestIds).toEqual([]);
+    // includeUsage default: usage came from session.snapshot via the fake.
+    expect(result.usage).toMatchObject({ totalTokens: 18, costUsd: 0.0042 });
+    expect(result.cacheStats).toMatchObject({ requestCount: 1 });
+
+    await daemon.close();
+  });
+
+  it("routes a permission request through the callback and back over tool.approve", async () => {
+    const seen: AgencPermissionRequest[] = [];
+    const daemon = await createFakeDaemon({
+      onPermissionRequest: (request) => {
+        seen.push(request);
+        return { behavior: "allow", scope: "once" };
+      },
+      onStreamMessage: async (fake, params) => {
+        const sessionId = String(params.sessionId);
+        await fake.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.permission_request",
+          params: {
+            sessionId,
+            eventId: "evt_perm_1",
+            requestId: "perm_req_1",
+            toolName: "Bash",
+            permissions: ["bash"],
+            input: { command: "ls" },
+            reason: "tool requires approval",
+          },
+        });
+      },
+      onApproveTool: (fake, params) => {
+        // The daemon resumes the turn once the approval lands.
+        void fake.broadcast(
+          String(params.sessionId),
+          statusNotification(String(params.sessionId), "completed", "done"),
+        );
+      },
+    });
+
+    await daemon.client.initialize();
+    const session = await daemon.client.createSession();
+    const result = await session.prompt("run ls").result();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      sessionId: "session_1",
+      requestId: "perm_req_1",
+      toolName: "Bash",
+      permissions: ["bash"],
+    });
+    expect(daemon.calls.approved).toHaveLength(1);
+    expect(daemon.calls.approved[0]).toMatchObject({
+      sessionId: "session_1",
+      requestId: "perm_req_1",
+      scope: "once",
+    });
+    expect(daemon.calls.denied).toHaveLength(0);
+    expect(result.stopReason).toBe("completed");
+    expect(result.deniedPermissionRequestIds).toEqual([]);
+
+    await daemon.close();
+  });
+
+  it("denies permission requests when no handler is registered (never hangs)", async () => {
+    const daemon = await createFakeDaemon({
+      onStreamMessage: async (fake, params) => {
+        const sessionId = String(params.sessionId);
+        await fake.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.permission_request",
+          params: {
+            sessionId,
+            eventId: "evt_perm_2",
+            requestId: "perm_req_2",
+            toolName: "Bash",
+            permissions: ["bash"],
+          },
+        });
+      },
+      onDenyTool: (fake, params) => {
+        void fake.broadcast(
+          String(params.sessionId),
+          statusNotification(String(params.sessionId), "completed"),
+        );
+      },
+    });
+
+    await daemon.client.initialize();
+    const session = await daemon.client.createSession();
+    const result = await session.prompt("run ls").result();
+
+    expect(daemon.calls.approved).toHaveLength(0);
+    expect(daemon.calls.denied).toHaveLength(1);
+    expect(daemon.calls.denied[0]).toMatchObject({
+      sessionId: "session_1",
+      requestId: "perm_req_2",
+      reason: "agenc-sdk: no permission handler registered",
+    });
+    expect(result.deniedPermissionRequestIds).toEqual(["perm_req_2"]);
+
+    await daemon.close();
+  });
+
+  it("resumes an existing session and surfaces turn errors as errored results", async () => {
+    const daemon = await createFakeDaemon({
+      onStreamMessage: async (fake, params) => {
+        const sessionId = String(params.sessionId);
+        await fake.broadcast(
+          sessionId,
+          statusNotification(sessionId, "errored", "provider exploded"),
+        );
+      },
+    });
+
+    await daemon.client.initialize();
+    // Create the session out of band (as another client would), then resume.
+    const created = await daemon.client.request("session.create", {});
+    const session = await daemon.client.resumeSession(created.sessionId);
+    const result = await session
+      .prompt("hello", { includeUsage: false })
+      .result();
+
+    expect(result.stopReason).toBe("errored");
+    expect(result.exitCode).toBe(1);
+    expect(result.finalMessage).toBe("provider exploded");
+    expect(result.usage).toBeUndefined();
+
+    await daemon.close();
+  });
+});

--- a/runtime/tests/sdk-package/protocol-drift.contract.test.ts
+++ b/runtime/tests/sdk-package/protocol-drift.contract.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Drift guard for the in-repo embedding SDK (`packages/agenc-sdk`).
+ *
+ * The package hand-mirrors the daemon protocol so it can stand alone with
+ * zero runtime-internal imports. This test pins that mirror to the runtime's
+ * canonical method registry the same way the sibling-repo SDK is pinned by
+ * `tests/app-server/sdk-client.contract.test.ts`: any protocol change fails
+ * here until `packages/agenc-sdk/src/protocol.ts` is updated.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  AGENC_DAEMON_METHODS,
+  AGENC_DAEMON_NOTIFICATION_METHODS,
+} from "../../src/app-server/protocol/index.js";
+import {
+  AGENC_SDK_DAEMON_METHODS,
+  AGENC_SDK_DAEMON_NOTIFICATION_METHODS,
+} from "../../../packages/agenc-sdk/src/protocol";
+
+const packageProtocolPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../packages/agenc-sdk/src/protocol.ts",
+);
+
+describe("agenc-sdk protocol mirror", () => {
+  it("mirrors the runtime daemon method registry exactly (names and order)", () => {
+    expect([...AGENC_SDK_DAEMON_METHODS]).toEqual([...AGENC_DAEMON_METHODS]);
+    expect([...AGENC_SDK_DAEMON_NOTIFICATION_METHODS]).toEqual([
+      ...AGENC_DAEMON_NOTIFICATION_METHODS,
+    ]);
+  });
+
+  it("declares params and result mappings for every daemon method", () => {
+    const source = readFileSync(packageProtocolPath, "utf8");
+    expectOrderedKeys(
+      "AgencParamsByMethod",
+      AGENC_DAEMON_METHODS,
+      extractInterfaceMethodKeys(source, "AgencParamsByMethod"),
+    );
+    expectOrderedKeys(
+      "AgencResultByMethod",
+      AGENC_DAEMON_METHODS,
+      extractInterfaceMethodKeys(source, "AgencResultByMethod"),
+    );
+  });
+
+  it("does not import runtime internals", () => {
+    const source = readFileSync(packageProtocolPath, "utf8");
+    expect(source).not.toMatch(/from "\.\.\/\.\.\/runtime\//);
+    expect(source).not.toMatch(/@tetsuo-ai\/runtime/);
+  });
+});
+
+function extractInterfaceMethodKeys(
+  source: string,
+  interfaceName: string,
+): string[] {
+  const match = new RegExp(
+    `export\\s+interface\\s+${interfaceName}\\s*\\{([\\s\\S]*?)\\n\\}`,
+  ).exec(source);
+  if (!match) throw new Error(`missing interface: ${interfaceName}`);
+  const keys: string[] = [];
+  const keyRe = /readonly\s+(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\s*:/g;
+  let keyMatch;
+  while ((keyMatch = keyRe.exec(match[1]!)) !== null) {
+    keys.push((keyMatch[1] ?? keyMatch[2] ?? keyMatch[3])!);
+  }
+  return keys;
+}
+
+function expectOrderedKeys(
+  label: string,
+  expected: readonly string[],
+  actual: readonly string[],
+): void {
+  expect(actual, label).toEqual([...expected]);
+}

--- a/runtime/tests/sdk-package/subprocess-transport.test.ts
+++ b/runtime/tests/sdk-package/subprocess-transport.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for the embedding SDK's subprocess transport
+ * (`packages/agenc-sdk/src/subprocess.ts`) with a fake `agenc -p` child:
+ * no daemon, no real spawn. The fake replays the CLI's
+ * `--output-format stream-json` contract (`{type:"event"}` lines followed
+ * by one `{type:"result"}` line) exactly as `runtime/src/bin/agenc.ts`
+ * emits it.
+ */
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import {
+  promptViaSubprocess,
+  type AgencPromptEvent,
+  type AgencSubprocessChild,
+  type AgencSubprocessSpawnFn,
+} from "../../../packages/agenc-sdk/src/index";
+
+interface FakeChildScript {
+  readonly stdoutLines: readonly unknown[];
+  readonly exitCode: number;
+  readonly stderr?: string;
+}
+
+interface SpawnCapture {
+  command: string;
+  args: readonly string[];
+  stdinChunks: string[];
+  stdinEnded: boolean;
+}
+
+function createFakeSpawn(script: FakeChildScript): {
+  readonly spawn: AgencSubprocessSpawnFn;
+  readonly capture: SpawnCapture;
+} {
+  const capture: SpawnCapture = {
+    command: "",
+    args: [],
+    stdinChunks: [],
+    stdinEnded: false,
+  };
+  const spawn: AgencSubprocessSpawnFn = (command, args) => {
+    capture.command = command;
+    capture.args = args;
+    const emitter = new EventEmitter();
+    const stdout = new EventEmitter() as EventEmitter & {
+      setEncoding: (encoding: string) => void;
+    };
+    stdout.setEncoding = () => {};
+    const stderr = new EventEmitter() as EventEmitter & {
+      setEncoding: (encoding: string) => void;
+    };
+    stderr.setEncoding = () => {};
+    const child: AgencSubprocessChild = {
+      stdin: {
+        write: (chunk: string) => {
+          capture.stdinChunks.push(chunk);
+          return true;
+        },
+        end: () => {
+          capture.stdinEnded = true;
+          // Replay the scripted run asynchronously, split mid-line to prove
+          // the line reassembly works.
+          setImmediate(() => {
+            const payload = script.stdoutLines
+              .map((line) => `${JSON.stringify(line)}\n`)
+              .join("");
+            const middle = Math.floor(payload.length / 2);
+            stdout.emit("data", payload.slice(0, middle));
+            stdout.emit("data", payload.slice(middle));
+            if (script.stderr !== undefined) {
+              stderr.emit("data", script.stderr);
+            }
+            emitter.emit("exit", script.exitCode, null);
+          });
+        },
+      },
+      stdout: stdout as unknown as AgencSubprocessChild["stdout"],
+      stderr: stderr as unknown as AgencSubprocessChild["stderr"],
+      once: (event: string, listener: (...args: never[]) => void) => {
+        emitter.once(event, listener as (...args: unknown[]) => void);
+        return child;
+      },
+      kill: () => {
+        emitter.emit("exit", null, "SIGTERM");
+        return true;
+      },
+    };
+    return child;
+  };
+  return { spawn, capture };
+}
+
+const sessionId = "session_sub_1";
+const agentId = "agent_sub_1";
+
+function eventLine(event: unknown): unknown {
+  return { type: "event", sessionId, agentId, event };
+}
+
+describe("agenc-sdk subprocess transport", () => {
+  it("spawns the headless CLI with the stream-json contract and adapts events", async () => {
+    const { spawn, capture } = createFakeSpawn({
+      stdoutLines: [
+        eventLine({
+          jsonrpc: "2.0",
+          method: "event.message_chunk",
+          params: { sessionId, eventId: "e1", delta: "The answer " },
+        }),
+        eventLine({
+          jsonrpc: "2.0",
+          method: "event.tool_request",
+          params: {
+            sessionId,
+            eventId: "e2",
+            requestId: "tool_1",
+            toolName: "Grep",
+          },
+        }),
+        eventLine({
+          jsonrpc: "2.0",
+          method: "event.message_chunk",
+          params: { sessionId, eventId: "e3", delta: "is 42" },
+        }),
+        {
+          type: "result",
+          sessionId,
+          agentId,
+          exitCode: 0,
+          finalMessage: "The answer is 42",
+          deniedPermissionRequestIds: [],
+          tokenUsage: {
+            inputTokens: 5,
+            outputTokens: 3,
+            totalTokens: 8,
+            costUsd: 0.001,
+          },
+          cacheStats: { requestCount: 1 },
+        },
+      ],
+      exitCode: 0,
+    });
+
+    const run = promptViaSubprocess("what is the answer?", {
+      agencCommand: ["/opt/agenc/bin/agenc"],
+      model: "grok-4",
+      spawn,
+    });
+    const events: AgencPromptEvent[] = [];
+    for await (const event of run) {
+      events.push(event);
+    }
+    const result = await run.result();
+
+    expect(capture.command).toBe("/opt/agenc/bin/agenc");
+    expect(capture.args).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--input-format",
+      "stream-json",
+      "--model",
+      "grok-4",
+    ]);
+    expect(capture.stdinEnded).toBe(true);
+    expect(capture.stdinChunks.join("")).toBe(
+      `${JSON.stringify({ type: "prompt", prompt: "what is the answer?" })}\n`,
+    );
+
+    expect(
+      events
+        .filter(
+          (event): event is Extract<AgencPromptEvent, { type: "text" }> =>
+            event.type === "text",
+        )
+        .map((event) => event.delta)
+        .join(""),
+    ).toBe("The answer is 42");
+    expect(events.some((event) => event.type === "tool_call")).toBe(true);
+
+    expect(result).toMatchObject({
+      stopReason: "completed",
+      exitCode: 0,
+      finalMessage: "The answer is 42",
+      deniedPermissionRequestIds: [],
+      usage: { totalTokens: 8 },
+      cacheStats: { requestCount: 1 },
+    });
+  });
+
+  it("maps the CLI's tool-denied exit code (2) to an errored result", async () => {
+    const { spawn } = createFakeSpawn({
+      stdoutLines: [
+        eventLine({
+          jsonrpc: "2.0",
+          method: "event.permission_request",
+          params: {
+            sessionId,
+            eventId: "e1",
+            requestId: "perm_1",
+            toolName: "Bash",
+            permissions: ["bash"],
+          },
+        }),
+        {
+          type: "result",
+          sessionId,
+          agentId,
+          exitCode: 2,
+          finalMessage: "gave up",
+          deniedPermissionRequestIds: ["perm_1"],
+        },
+      ],
+      exitCode: 2,
+    });
+
+    const run = promptViaSubprocess("do something", { spawn });
+    const events: AgencPromptEvent[] = [];
+    let returned: unknown;
+    const iterator = run[Symbol.asyncIterator]();
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done === true) {
+        returned = next.value;
+        break;
+      }
+      events.push(next.value);
+    }
+
+    expect(
+      events.find((event) => event.type === "permission_request"),
+    ).toMatchObject({ requestId: "perm_1" });
+    expect(returned).toMatchObject({
+      stopReason: "errored",
+      exitCode: 2,
+      finalMessage: "gave up",
+      deniedPermissionRequestIds: ["perm_1"],
+    });
+    await expect(run.result()).resolves.toMatchObject({ exitCode: 2 });
+  });
+
+  it("rejects when the CLI exits without a stream-json result", async () => {
+    const { spawn } = createFakeSpawn({
+      stdoutLines: [],
+      exitCode: 1,
+      stderr: "agenc: no prompt provided",
+    });
+
+    const run = promptViaSubprocess("hello", { spawn });
+    await expect(run.result()).rejects.toThrow(
+      /exited \(code 1\).*no prompt provided/s,
+    );
+    await expect(
+      (async () => {
+        for await (const event of run) {
+          void event;
+        }
+      })(),
+    ).rejects.toThrow(/exited \(code 1\)/);
+  });
+});


### PR DESCRIPTION
## Task 23

Embedding agenc previously meant hand-writing a JSON-RPC client against the daemon socket. New `packages/agenc-sdk` (ESM, Node ≥25, **zero dependencies**):

- `connect()` — attach-or-spawn (`agenc daemon start` + cookie/socket readiness poll). `AgencClient`: typed `request()` over all 41 daemon methods, `createSession()`/`resumeSession()`, background agents, notification fan-out.
- `session.prompt()` → `AsyncIterable` of typed events (text, tool_call, permission_request, elicitation_request, status) + `result()` with usage/cacheStats. Permission callback round-trips to `tool.approve`/`deny`; **no handler = deny** (never grant, never hang — mirrors `agenc -p`).
- `promptViaSubprocess()` — `stream-json` CLI transport adapting the same event-iterable interface; exit-code-2 semantics preserved.
- `src/protocol.ts` hand-mirrors the protocol with zero runtime imports; a drift-guard contract test pins method names AND order against the runtime's canonical arrays (revert-proven on a removed method).
- `docs/sdk.md` + runnable `examples/one-shot.mjs` (both transports).
- Documented deviation: full autostart internals (build-skew respawn, orphan adoption) stay in the runtime; the SDK does attach-or-CLI-spawn.

**Tests**: 10 — drift guard, in-process transport contract against the real dispatcher (init/session/prompt-stream/permission round-trip/default-deny/resume), fake-child subprocess transport.

**Gates:** build ✅ · repo + package typecheck 0 · full vitest **14,017 passed / 0 failed / exit 0** · test:bun 86/0

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES