### PR TITLE
fix(e2e): match the current assistant-reply rendering in the TUI e2e harness

### DIFF
--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -890,12 +890,57 @@ export class TuiSession {
   }
 
   /**
-   * Wait for the assistant's reply marker. The TUI prefixes assistant turns
-   * with "● " in the transcript. After `submit`, this fires once the model's
-   * first content chunk renders.
+   * Wait for the assistant's reply to render. Since 345e27c66 the TUI renders
+   * every assistant turn (live streaming AND settled) under a `▮ AGENC`
+   * identity header with the reply text indented beneath it — the old bare
+   * "● " streaming marker is gone. After `submit`, this fires once the
+   * header AND at least one line of real reply content under it render.
+   *
+   * The content check is row/column aware on purpose: the header alone can
+   * paint before the first model chunk arrives, and full-width repaints put
+   * sidebar/footer text on rows below the header. Requiring visible message
+   * text at/after the header's column, before any box-drawing border row,
+   * keeps the assertion anchored to actual reply content.
    */
   async waitForAssistantReply({ timeout = 60_000 } = {}) {
-    return this.waitFor(/●\s+\S/, { timeout, label: "assistant reply" });
+    const start = Date.now();
+    const headerRe = /▮\s+AGENC\b/;
+    while (Date.now() - start < timeout) {
+      const rows = renderPtyRows(this.buffer.slice(this.watermark), {
+        cols: this.cols,
+        rows: this.rows,
+      });
+      const headerIdx = rows.findIndex((row) => headerRe.test(row));
+      if (headerIdx !== -1) {
+        const headerCol = rows[headerIdx].indexOf("▮");
+        let matched = false;
+        for (let r = headerIdx + 1; r < rows.length; r += 1) {
+          const body = rows[r].slice(headerCol);
+          if (body.trim().length === 0) continue;
+          // Box-drawing chars mean we left the transcript block and hit the
+          // composer/panel chrome without seeing reply text — keep waiting.
+          if (/^\s*[─│┌┐└┘├┤╭╮╰╯]/.test(body)) break;
+          // Real reply content: the first visible character under the AGENC
+          // header column is message text (word char or common markdown /
+          // quote / list openers), not pane chrome glyphs (❯ ↳ ◐ ✳ ·).
+          if (/^\s*["'`*#>\w([{$~-]/.test(body)) {
+            matched = true;
+            break;
+          }
+        }
+        if (matched) {
+          this.watermark = this.buffer.length;
+          return;
+        }
+      }
+      if (this.exited) {
+        throw new Error(
+          `waitFor(assistant reply): TUI exited before reply rendered (code=${this.exitInfo?.exitCode}, signal=${this.exitInfo?.signal})`,
+        );
+      }
+      await sleep(100);
+    }
+    throw new Error(`waitFor(assistant reply): timeout after ${timeout}ms`);
   }
 
   /**


### PR DESCRIPTION
## Task 31

`03-subagent-completion` timed out on pure main (verified pre-existing via a main-source rebuild A/B). Root cause = **matcher drift, not a stall**: commit `345e27c66` routed the live streaming assistant turn through the same `Msg role='agenc'` wrapper as settled turns, so the bare streaming marker the harness's `waitForAssistantReply()` waited for no longer renders.

The matcher now finds the AGENC identity header row and requires real reply content column-anchored beneath it — rejecting header-before-first-chunk and full-width repaint rows, stopping at composer chrome. Validated non-vacuous against the captured failure log (positive on the reply slice, negative on the pre-reply and cold-start slices). All four consumer scenarios (02/03/04/43) go through this one helper; same error shape and watermark semantics.

**Verified:** scenario 03 passes twice in a row; `npm run check:agent-surface-contract` is **fully green** again (it had been failing on exactly this scenario — its models-manager half was fixed in task 27).

**Gates:** build ✅ (hook) · typecheck 0 · full vitest **exit 0** (scripts-only diff) · test:bun 86/0

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES