### PR TITLE
fix(tests): hermetic env — suite-level credential strip + offline auth default

### DIFF
--- a/runtime/scripts/run-bun-tests-isolated.mjs
+++ b/runtime/scripts/run-bun-tests-isolated.mjs
@@ -1,12 +1,26 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { sanitizeHermeticEnv } from '../tests/helpers/hermetic-env.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const runtimeRoot = dirname(scriptDir)
 const testsRoot = join(runtimeRoot, 'tests')
+
+// Suite-level hermeticity (TODO task 30): `bun test` children never load
+// vitest's setupFiles, so apply the same explicit sanitization here — strip
+// ambient provider keys / developer AgenC state, point AGENC_HOME at a
+// throwaway temp dir, and pin AGENC_AUTH_BACKEND=local so no child performs
+// a real device-code login against https://id.agenc.ag.
+// See tests/helpers/hermetic-env.mjs for the documented strip list.
+const hermeticEnv = sanitizeHermeticEnv(
+  { ...process.env },
+  mkdtempSync(join(tmpdir(), 'agenc-bun-hermetic-home-')),
+)
 
 function walk(dir) {
   const entries = readdirSync(dir, { withFileTypes: true })
@@ -46,7 +60,7 @@ for (const file of files) {
   const result = spawnSync('bun', ['test', file], {
     cwd: runtimeRoot,
     encoding: 'utf8',
-    env: process.env,
+    env: hermeticEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 

--- a/runtime/tests/app-server-client/index.test.ts
+++ b/runtime/tests/app-server-client/index.test.ts
@@ -298,6 +298,14 @@ describe("app-server-client daemon helpers", () => {
   });
 
   it("dispatches daemon-only TUI slash commands without local session services", async () => {
+    // `/provider grok` must clear the BYOK subscription gate (which reads
+    // process.env directly, not the context env) to reach the daemon-mode
+    // "not yet supported" branch asserted below. Set an explicit test key:
+    // the hermetic suite setup (vitest.setup.ts, TODO task 30) strips
+    // ambient provider keys, and this assertion previously depended on a
+    // developer's real XAI_API_KEY.
+    const previousXaiKey = process.env.XAI_API_KEY;
+    process.env.XAI_API_KEY = "test-key";
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-daemon-slash-home-"));
     const cwd = mkdtempSync(join(tmpdir(), "agenc-daemon-slash-cwd-"));
     const pidFile = join(agencHome, "mcp", "audit-ping.pid");
@@ -388,6 +396,11 @@ describe("app-server-client daemon helpers", () => {
         },
       });
     } finally {
+      if (previousXaiKey === undefined) {
+        delete process.env.XAI_API_KEY;
+      } else {
+        process.env.XAI_API_KEY = previousXaiKey;
+      }
       await context?.close();
       rmSync(agencHome, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });

--- a/runtime/tests/bin/auth-cli.contract.test.ts
+++ b/runtime/tests/bin/auth-cli.contract.test.ts
@@ -153,7 +153,17 @@ describe("AgenC auth CLI", () => {
 
   it("prints remote device-code login instructions from config", async () => {
     const agencHome = await tempAgencHome();
-    const env = { ...process.env, AGENC_HOME: agencHome, HOME: agencHome };
+    // This test deliberately exercises the remote backend (with a mocked
+    // fetchImpl — no real network). The hermetic suite setup
+    // (vitest.setup.ts, TODO task 30) pins AGENC_AUTH_BACKEND=local in
+    // process.env, and that env override outranks config.toml, so the
+    // remote intent must be explicit here.
+    const env = {
+      ...process.env,
+      AGENC_HOME: agencHome,
+      HOME: agencHome,
+      AGENC_AUTH_BACKEND: "remote",
+    };
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
@@ -216,7 +226,14 @@ describe("AgenC auth CLI", () => {
 
   it("opens the remote login URL after Enter in an interactive terminal", async () => {
     const agencHome = await tempAgencHome();
-    const env = { ...process.env, AGENC_HOME: agencHome, HOME: agencHome };
+    // Explicit remote-backend intent; see the comment in the previous test
+    // (the hermetic suite setup pins AGENC_AUTH_BACKEND=local by default).
+    const env = {
+      ...process.env,
+      AGENC_HOME: agencHome,
+      HOME: agencHome,
+      AGENC_AUTH_BACKEND: "remote",
+    };
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(

--- a/runtime/tests/bin/cron-live-tools.test.ts
+++ b/runtime/tests/bin/cron-live-tools.test.ts
@@ -17,7 +17,10 @@ import {
   setOriginalCwd,
   setProjectRoot,
 } from "../bootstrap/state.js";
-import { resetCronSchedulerForTests } from "../utils/cronScheduler.js";
+import {
+  getCronScheduler,
+  resetCronSchedulerForTests,
+} from "../utils/cronScheduler.js";
 import { listAllCronTasks } from "../utils/cronTasks.js";
 import {
   dequeueAll,
@@ -35,6 +38,10 @@ let tempRoot: string;
 async function advanceMinutesWithIo(minutes: number): Promise<void> {
   for (let minute = 0; minute < minutes; minute += 1) {
     await vi.advanceTimersByTimeAsync(60_000);
+    // Deterministically await the tick the timer just fired (its real fs
+    // I/O ignores fake timers) instead of guessing with setImmediate
+    // rounds — under full-suite load 20 yields were not always enough.
+    await getCronScheduler().drain();
     for (let flush = 0; flush < 20; flush += 1) {
       await new Promise<void>((resolveFlush) => setImmediate(resolveFlush));
     }

--- a/runtime/tests/helpers/hermetic-env.mjs
+++ b/runtime/tests/helpers/hermetic-env.mjs
@@ -1,0 +1,175 @@
+// Test-suite hermeticity: shared env sanitization (TODO task 30).
+//
+// Shared between the vitest suite (runtime/vitest.setup.ts, wired via
+// setupFiles in runtime/vitest.config.ts) and the isolated bun runner
+// (runtime/scripts/run-bun-tests-isolated.mjs), which spawns `bun test`
+// children that never see vitest's setupFiles.
+//
+// Why this exists (verified finding, task 27 / TODO task 30):
+//   (a) Without setup-time sanitization, tests touching provider-key
+//       resolution or homedir auth state see the developer's REAL
+//       credentials. On the reference machine an ambient XAI_API_KEY and a
+//       live team-tier ~/.agenc/auth.json flipped 11 tests.
+//   (b) Since commit 97f1baf88 (default auth backend local -> remote), a
+//       daemon/CLI test whose config lacks an explicit `[auth]
+//       backend = "local"` performs a REAL device-code login against
+//       production https://id.agenc.ag. (That service currently returns
+//       auto-approving mock device codes; reporting that to the service
+//       owner is tracked by the TODO task 30 orchestrator, not here.)
+//
+// Design rules:
+//   - The strip list is EXPLICIT and documented. No wildcard "delete every
+//     AGENC_*" sweep: test-harness vars (AGENC_TRAJECTORY_*, CI plumbing)
+//     and vault/key PASSPHRASES must survive. Never strip a passphrase
+//     (e.g. AGENC_CLIENT_KEY_PASSPHRASE consumed by src/utils/mtls.ts) —
+//     stripping one downgrades a secure re-prompt path.
+//   - Stripping happens at setup time, BEFORE any test module loads. A test
+//     that sets its own env inside the test body (the hermetic pattern, e.g.
+//     withProAuthSession in tests/commands/model.test.ts) is unaffected.
+
+/**
+ * Provider credential env vars.
+ *
+ * Canonical source: BUILT_IN_PROVIDER_API_KEY_ENVS in
+ * src/llm/registry/provider-info.ts (one env var per built-in provider slug,
+ * including github -> GITHUB_TOKEN and amazon-bedrock -> AWS_ACCESS_KEY_ID),
+ * unioned with the alias/companion names the codebase also resolves:
+ *   - grok aliases: GROK_API_KEY, AGENC_XAI_API_KEY (src/config/env.ts
+ *     resolveApiKey precedence XAI_API_KEY -> GROK_API_KEY -> AGENC_XAI_API_KEY)
+ *   - SECRET_ENV_KEYS (src/utils/providerSecrets.ts): OPENAI_AUTH_HEADER_VALUE,
+ *     AGENC_API_KEY, GOOGLE_API_KEY, BNKR_API_KEY, ...
+ *   - the subprocess scrub precedent (src/utils/subprocessEnv.ts):
+ *     ANTHROPIC_AUTH_TOKEN, GEMINI_ACCESS_TOKEN, GH_TOKEN, AWS session creds, ...
+ *
+ * An ambient value for ANY of these adds a legitimate BYOK provider row to
+ * discovery/model-menu logic and breaks hermetic expectations.
+ */
+export const HERMETIC_PROVIDER_CREDENTIAL_ENV_VARS = Object.freeze([
+  // grok (+ aliases)
+  'XAI_API_KEY',
+  'GROK_API_KEY',
+  'AGENC_XAI_API_KEY',
+  // openai (+ companions)
+  'OPENAI_API_KEY',
+  'OPENAI_AUTH_HEADER_VALUE',
+  'OPENAI_COMPATIBLE_API_KEY',
+  // anthropic (+ companions)
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_FOUNDRY_API_KEY',
+  'ANTHROPIC_CUSTOM_HEADERS',
+  // remaining built-in providers
+  'LMSTUDIO_API_KEY',
+  'OPENROUTER_API_KEY',
+  'GROQ_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'MISTRAL_API_KEY',
+  'NVIDIA_API_KEY',
+  'MINIMAX_API_KEY',
+  'BNKR_API_KEY',
+  // gemini / google (+ companions)
+  'GEMINI_API_KEY',
+  'GEMINI_ACCESS_TOKEN',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENAI_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  // github provider key env (BUILT_IN_PROVIDER_API_KEY_ENVS.github) + alias
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  // amazon-bedrock (BUILT_IN_PROVIDER_API_KEY_ENVS['amazon-bedrock']) + session creds
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_BEARER_TOKEN_BEDROCK',
+])
+
+/**
+ * AgenC developer-state env vars: hosted-auth/session credentials plus the
+ * config-behavior overrides documented at the top of src/config/env.ts. Any
+ * of these, exported in a developer's shell, silently reconfigures tests
+ * (e.g. AGENC_MODEL flips default-model expectations, AGENC_USE_OPENAI flips
+ * provider validation, AGENC_ENV_FILE injects arbitrary env).
+ *
+ * Deliberately NOT stripped:
+ *   - AGENC_CLIENT_KEY_PASSPHRASE (or any *_PASSPHRASE): never strip
+ *     passphrases.
+ *   - AGENC_HOME / AGENC_AUTH_BACKEND: not stripped but FORCED to hermetic
+ *     values below.
+ *   - Test-harness vars tests themselves set after setup runs
+ *     (AGENC_TRAJECTORY_*, AGENC_DAEMON_* timeout overrides, etc.).
+ */
+export const HERMETIC_AGENC_STATE_ENV_VARS = Object.freeze([
+  // hosted-identity / session credentials (subprocessEnv.ts precedent)
+  'AGENC_API_KEY',
+  'AGENC_OAUTH_TOKEN',
+  'AGENC_OAUTH_TOKEN_FILE_DESCRIPTOR',
+  'AGENC_REMOTE_AUTH_TOKEN',
+  'AGENC_SESSION_ACCESS_TOKEN',
+  // wallet path (a real mainnet vault path must never reach tests);
+  // note: the vault PASSPHRASE vars are intentionally left alone
+  'AGENC_WALLET',
+  // real-config location override (would re-point tests at the developer's
+  // live config/auth even after AGENC_HOME is replaced, because
+  // AGENC_CONFIG_DIR wins over AGENC_HOME in getAgenCConfigHomeDir)
+  'AGENC_CONFIG_DIR',
+  // arbitrary env-file injection
+  'AGENC_ENV_FILE',
+  // config-behavior overrides (src/config/env.ts applyEnvOverrides et al.)
+  'AGENC_PROFILE',
+  'AGENC_PROVIDER',
+  'AGENC_MODEL',
+  'AGENC_WORKSPACE',
+  'AGENC_SIMPLE',
+  'AGENC_AUTONOMOUS',
+  'AGENC_MAX_OUTPUT_TOKENS',
+  'AGENC_CAPPED_DEFAULT_MAX_OUTPUT_TOKENS',
+  'AGENC_MAX_BUDGET_USD',
+  'AGENC_AUTH_MANAGED_KEYS_ENABLED',
+  // provider-family toggles (providerValidation.ts / provider profiles)
+  'AGENC_USE_OPENAI',
+  'AGENC_USE_GEMINI',
+  'AGENC_USE_MISTRAL',
+  'AGENC_USE_GITHUB',
+  'AGENC_USE_BEDROCK',
+  'AGENC_USE_VERTEX',
+  'AGENC_USE_FOUNDRY',
+])
+
+export const HERMETIC_STRIPPED_ENV_VARS = Object.freeze([
+  ...HERMETIC_PROVIDER_CREDENTIAL_ENV_VARS,
+  ...HERMETIC_AGENC_STATE_ENV_VARS,
+])
+
+/** Marker proving the hermetic setup ran in this process. */
+export const HERMETIC_MARKER_ENV_VAR = 'AGENC_TEST_HERMETIC_ENV'
+
+/**
+ * Sanitize `env` in place for hermetic test runs.
+ *
+ * - Deletes every var in HERMETIC_STRIPPED_ENV_VARS.
+ * - Forces AGENC_HOME to `agencHome` (a per-run temp dir) so code that
+ *   resolves ~/.agenc (getAgenCConfigHomeDir honors AGENC_CONFIG_DIR then
+ *   AGENC_HOME then $HOME) can never read the developer's live auth.json.
+ *   Tests that need their own AGENC_HOME set it inside the test, after this
+ *   runs, and win.
+ * - Forces AGENC_AUTH_BACKEND=local: the documented env override for
+ *   auth.backend (src/config/env.ts applyEnvOverrides). Every real CLI entry
+ *   point defaults its env snapshot to process.env (src/bin/auth-cli.ts,
+ *   src/bin/providers-cli.ts, src/app-server/daemon-cli.ts via host.env), so
+ *   this pins the default away from the remote device-code login. Tests that
+ *   exercise the remote backend pass their own env snapshot or write
+ *   `[auth] backend = "remote"` config and are unaffected; tests built on
+ *   synthetic host env objects (daemon-cli contract tests) still pin
+ *   `[auth] backend = "local"` in their own config.toml — see the
+ *   task-27 breadcrumbs in tests/app-server/daemon-cli.contract.test.ts.
+ */
+export function sanitizeHermeticEnv(env, agencHome) {
+  for (const name of HERMETIC_STRIPPED_ENV_VARS) {
+    delete env[name]
+  }
+  env.AGENC_HOME = agencHome
+  env.AGENC_AUTH_BACKEND = 'local'
+  env[HERMETIC_MARKER_ENV_VAR] = '1'
+  return env
+}

--- a/runtime/tests/hermetic-env.test.ts
+++ b/runtime/tests/hermetic-env.test.ts
@@ -1,0 +1,53 @@
+// Guards the suite-level hermeticity setup (TODO task 30).
+//
+// Revert-sensitive by construction: vitest.setup.ts stamps
+// AGENC_TEST_HERMETIC_ENV=1 when it runs, and this test asserts on that
+// marker FIRST. Removing the setupFiles wiring (or the setup file) makes the
+// marker assertion fail even in an outer shell that happens to have no
+// ambient credentials. The absent-credential assertions then prove the strip
+// itself against a polluted outer shell — verified empirically by running
+// this file with e.g. `XAI_API_KEY=fake-key npx vitest run
+// tests/hermetic-env.test.ts`.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  HERMETIC_AGENC_STATE_ENV_VARS,
+  HERMETIC_MARKER_ENV_VAR,
+  HERMETIC_PROVIDER_CREDENTIAL_ENV_VARS,
+} from "./helpers/hermetic-env.mjs";
+
+describe("suite-level hermetic env (vitest.setup.ts)", () => {
+  it("ran before this module loaded (marker present)", () => {
+    expect(process.env[HERMETIC_MARKER_ENV_VAR]).toBe("1");
+  });
+
+  it("stripped every ambient provider credential env var", () => {
+    // Set-inside-a-test still works: setup runs before the module loads,
+    // so nothing here fights tests that export their own keys.
+    const leaked = HERMETIC_PROVIDER_CREDENTIAL_ENV_VARS.filter(
+      (name: string) => process.env[name] !== undefined,
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("stripped every ambient AgenC developer-state env var", () => {
+    const leaked = HERMETIC_AGENC_STATE_ENV_VARS.filter(
+      (name: string) => process.env[name] !== undefined,
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("points AGENC_HOME at a hermetic temp dir, never the real ~/.agenc", () => {
+    const agencHome = process.env.AGENC_HOME;
+    expect(agencHome).toBeTruthy();
+    expect(agencHome).toBe(process.env.AGENC_TEST_HERMETIC_HOME);
+    expect(agencHome).not.toBe(join(homedir(), ".agenc"));
+  });
+
+  it("pins the auth backend env override to local (no id.agenc.ag logins)", () => {
+    expect(process.env.AGENC_AUTH_BACKEND).toBe("local");
+  });
+});

--- a/runtime/tests/permissions/evaluator.test.ts
+++ b/runtime/tests/permissions/evaluator.test.ts
@@ -699,6 +699,11 @@ describe("hasPermissionsToUseTool — step 4 auto mode activates classifier", ()
   });
 
   it("passes session history into the classifier transcript", async () => {
+    // The classifier pipeline requires a resolvable grok API key before the
+    // (stubbed) remote stage runs. Set one explicitly — the hermetic suite
+    // setup (vitest.setup.ts, TODO task 30) strips ambient provider keys,
+    // and this test previously depended on a developer's real XAI_API_KEY.
+    await withEnv({ XAI_API_KEY: "test-classifier-key" }, async () => {
     const prompts: string[] = [];
     const restoreGate = __setAutoModeGateResolverForTesting(() => true);
     const restoreRunner = __setRemoteClassifierStageRunnerForTesting(
@@ -744,6 +749,7 @@ describe("hasPermissionsToUseTool — step 4 auto mode activates classifier", ()
       restoreRunner();
       restoreGate();
     }
+    });
   });
 });
 

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -4467,6 +4467,13 @@ describe("runTurn — I-13 pendingProviderSwitch consumer", () => {
     // slot drives model resolution through resolveProfile. The staged
     // marker's `model` field acts as the fallback; the profile overlay
     // supersedes it when it declares a model.
+    //
+    // Applying the switch resolves xai provider settings from process.env,
+    // so set an explicit key (same pattern as the sibling switch tests): the
+    // hermetic suite setup (vitest.setup.ts, TODO task 30) strips ambient
+    // provider keys, and this test previously depended on a developer's
+    // real XAI_API_KEY.
+    const restoreApiKey = withEnvVar("XAI_API_KEY", "test-key");
     const ctx = mkCtx();
     const configSnapshot = {
       model: "base-model",
@@ -4495,13 +4502,17 @@ describe("runTurn — I-13 pendingProviderSwitch consumer", () => {
       },
     });
 
-    // Empty input still exercises the runTurn switch consumer, then skips sampling.
-    await drain(session.runTurn("", { ctx }));
+    try {
+      // Empty input still exercises the runTurn switch consumer, then skips sampling.
+      await drain(session.runTurn("", { ctx }));
 
-    expect(session.pendingProviderSwitch).toBeNull();
-    expect(getState().sessionConfiguration.collaborationMode?.model).toBe(
-      "grok-code-fast-1",
-    );
+      expect(session.pendingProviderSwitch).toBeNull();
+      expect(getState().sessionConfiguration.collaborationMode?.model).toBe(
+        "grok-code-fast-1",
+      );
+    } finally {
+      restoreApiKey();
+    }
   });
 
   test("profile switch falls back to marker's model when configStore is absent", async () => {

--- a/runtime/tests/utils/agencInstallSurfaces.test.ts
+++ b/runtime/tests/utils/agencInstallSurfaces.test.ts
@@ -29,6 +29,14 @@ test('cleanupNpmInstallations checks runtime, launcher, and local install dirs',
     PACKAGE_URL: '@tetsuo-ai/agenc',
   }
 
+  // This test asserts the deduped single-path case, which requires the
+  // config home to resolve to ~/.agenc. Declare that explicitly instead of
+  // assuming ambient env: the hermetic suite setup (vitest.setup.ts, TODO
+  // task 30) points AGENC_HOME at a temp dir, which would otherwise add a
+  // second local-install dir. `rm` is mocked, so nothing real is touched.
+  delete process.env.AGENC_HOME
+  delete process.env.AGENC_CONFIG_DIR
+
   vi.doMock('fs/promises', () => ({
     ...fsPromises,
     rm: async (path: string) => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -382,6 +382,10 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     pool: 'forks',
+    // Suite-level hermeticity (TODO task 30): strip ambient provider keys /
+    // developer AgenC state and pin the local auth backend before any test
+    // module loads. See vitest.setup.ts + tests/helpers/hermetic-env.mjs.
+    setupFiles: ['./vitest.setup.ts'],
     include: [
       'tests/**/*.test.ts',
       'tests/**/*.test.tsx',

--- a/runtime/vitest.setup.ts
+++ b/runtime/vitest.setup.ts
@@ -1,0 +1,42 @@
+// Suite-level test hermeticity (TODO task 30).
+//
+// Runs (via setupFiles in vitest.config.ts) in every worker BEFORE each test
+// module loads, so no test can observe the developer's real provider keys,
+// live ~/.agenc auth state, or shell-exported AgenC config overrides. See
+// tests/helpers/hermetic-env.mjs for the full rationale and the explicit,
+// documented strip list (no wildcard AGENC_* sweep; passphrases survive).
+//
+// Network guard for auth: since 97f1baf88 the default auth backend is
+// "remote", so an unpinned daemon/CLI test would device-code-login against
+// production https://id.agenc.ag. AGENC_AUTH_BACKEND=local (set below) is the
+// documented env override for auth.backend and is honored by every real CLI
+// entry point that defaults its env snapshot to process.env. Contract tests
+// that build synthetic host envs additionally pin `[auth] backend = "local"`
+// in their own config.toml (task 27). Reporting id.agenc.ag's auto-approving
+// mock device codes to the service owner is handled by the TODO task 30
+// orchestrator, not this repo.
+//
+// AGENC_HOME is pointed at a per-fork temp dir so homedir-derived reads
+// (getAgenCConfigHomeDir: AGENC_CONFIG_DIR > AGENC_HOME > $HOME/.agenc) can
+// never touch the developer's live ~/.agenc. Tests that need their own
+// AGENC_HOME set it inside the test — after this ran — and win.
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { sanitizeHermeticEnv } from './tests/helpers/hermetic-env.mjs'
+
+// One hermetic home per worker process; setup files re-run per test file in
+// the same fork, so reuse the dir already minted for this process instead of
+// littering a new mkdtemp per file. (This also re-asserts the hermetic env
+// at every file boundary, undoing cross-file env leaks.)
+// Stored in its own env var (not AGENC_HOME, which tests legitimately
+// reassign) so a test file that leaks its own AGENC_HOME can never become the
+// next file's baseline.
+const hermeticHome =
+  process.env.AGENC_TEST_HERMETIC_HOME ??
+  mkdtempSync(join(tmpdir(), 'agenc-vitest-hermetic-home-'))
+process.env.AGENC_TEST_HERMETIC_HOME = hermeticHome
+
+sanitizeHermeticEnv(process.env, hermeticHome)


### PR DESCRIPTION
## Task 30 (filed during task 27)

The suite had no env sanitization: tests saw the developer's real provider keys and live `~/.agenc` auth (11 baseline tests flipped on this machine pre-task-27), and unpinned daemon/CLI tests performed REAL device-code logins against production id.agenc.ag.

- **`tests/helpers/hermetic-env.mjs`**: explicit, documented strip lists — 30 provider credential vars (sourced from `BUILT_IN_PROVIDER_API_KEY_ENVS` + live aliases) and 26 AgenC developer-state vars. Passphrases and harness vars never stripped; no wildcard sweep.
- **`vitest.setup.ts`**: per-fork temp `AGENC_HOME`, re-asserted at every test-file boundary; `AGENC_AUTH_BACKEND` pinned to `local` so no unpinned test path reaches id.agenc.ag.
- **Bun parity**: the isolated bun runner passed raw `process.env` to children — now sanitized the same way.
- 4 tests silently relying on ambient creds now self-declare; 2 remote-backend contract tests set the backend explicitly (mocked fetch).
- **Also**: deterministic tick-drain in the cron-live fake-time helper (the restart re-arm test flaked ~2/10 full runs under load — 20 setImmediate yields don't guarantee real fs I/O completion; it now awaits `getCronScheduler().drain()`, the task-27 quiescence primitive). 6/6 isolated runs + full suite green.

**Revert-proven**: hermetic-env pin tests 5/5 red with the setupFiles wiring removed; 5/5 green under deliberate ambient pollution (`XAI_API_KEY=fake` exported for the full gate run).

**Outstanding for the service owner (not this repo)**: id.agenc.ag issues auto-approving `mock-device-*` codes on `/v1/auth/login/start` — a test obtained a real token. Flagged in TODO task 30's completion note.

**Gates (run under deliberate env pollution):** build ✅ · typecheck 0 · full vitest **exit 0** (1635 files passed) · test:bun 86/0 · TUI startup ✅

https://claude.ai/code/session_014eaKTWGgpwE9YsGG2L7XES