### PR TITLE
feat(install): one-line installer speaking the runtime-manager contract (task 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ licensed; see [`LICENSE`](LICENSE).
 
 ## Quick start
 
-Install the published launcher:
+Install with the one-line installer (macOS/Linux; verifies the runtime
+tarball's sha256 and wires the daemon as a user service — see
+[`docs/install.md`](docs/install.md)):
+
+```bash
+curl -fsSL <installer-url>/install.sh | sh
+```
+
+Or install the published launcher:
 
 ```bash
 npm install -g @tetsuo-ai/agenc

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,68 @@
+# Installing AgenC
+
+Three interchangeable install paths share one runtime contract: the runtime
+tarball extracts to `$AGENC_HOME/runtime/<version>/` with a `.agenc-runtime-ok`
+marker recording the artifact sha256. Any installer finds and reuses a runtime
+another one installed.
+
+## One-line installer (macOS / Linux)
+
+```bash
+curl -fsSL <installer-url>/install.sh | sh
+```
+
+The script (source: `scripts/install/install.sh`):
+
+1. requires `tar` and Node.js >= 25 (Node is also used for uniform JSON
+   parsing and sha256 across platforms),
+2. fetches the release manifest (`agenc-runtime-manifest.json`) for the latest
+   release, or a pinned one with `--version x.y.z`,
+3. downloads the per-platform runtime tarball and **verifies its sha256
+   against the manifest — a mismatch aborts the install**,
+4. extracts to `$AGENC_HOME/runtime/<version>/` and writes the marker,
+5. installs an `agenc` wrapper to `--prefix`/bin (default `~/.local/bin`) with
+   the absolute Node path baked in (user services run with a minimal PATH),
+6. installs and starts the daemon as a systemd user service (Linux) or
+   launchd agent (macOS). Skip with `--no-daemon`.
+
+Flags: `--version`, `--manifest-url`, `--repo`, `--prefix`, `--no-daemon`.
+Re-running is idempotent: a verified existing install skips the download.
+
+## One-line installer (Windows)
+
+```powershell
+iwr -useb <installer-url>/install.ps1 | iex
+```
+
+Source: `scripts/install/install.ps1`. Same manifest/verify/extract contract;
+installs an `agenc.cmd` shim under `%LOCALAPPDATA%\agenc\bin`. Running the
+daemon as a Windows service uses WinSW with `packaging/windows/agenc-daemon.xml`
+(manual step; `agenc daemon start` works without it).
+
+## npm launcher
+
+```bash
+npm install -g @tetsuo-ai/agenc
+```
+
+The launcher's postinstall resolves the same runtime contract via
+`packages/agenc/lib/runtime-manager.mjs`.
+
+## Release/publish steps (owner-gated — do not automate from an agent session)
+
+For the one-line installers to work against a release tag:
+
+1. Build per-platform tarballs (`npm --workspace=@tetsuo-ai/agenc run
+   build:runtime-tarball`) and generate the manifest
+   (`gen:manifest --repo <repo> --tag agenc-v<version>`).
+2. Upload the tarballs **and** `packages/agenc/generated/agenc-runtime-manifest.json`
+   as assets on the GitHub release (`agenc-v<version>`). The scripts default to
+   `releases/latest/download/agenc-runtime-manifest.json`.
+3. Host `scripts/install/install.sh` and `install.ps1` at a stable URL
+   (e.g. `get.agenc.ag`) or upload them as release assets on a public
+   releases repo.
+
+Tests: `runtime/tests/packaging/install-sh.test.ts` exercises the full sh flow
+(fresh install, checksum-mismatch abort, marker idempotency, systemd unit
+generation, platform/Node gates) against a synthetic tarball and `file://`
+manifest, mirroring `packages/agenc/test/runtime-manager.test.mjs`.

--- a/docs/parity-roadmap-2026-07.md
+++ b/docs/parity-roadmap-2026-07.md
@@ -1,0 +1,212 @@
+# AgenC Core: Parity-and-Beyond Roadmap vs Hermes Agent and OpenClaw
+
+**Date:** 2026-07-08. **Status:** proposal for owner review, nothing here is started.
+**Inputs:** full repo inventory of agenc-core (this repo, TODO backlog cleared as of
+2026-07-08), full repo inventory of `hermes-agent` (workspace checkout, v0.17.0),
+web research on OpenClaw (docs.openclaw.ai, GitHub, security postmortems) and on
+adoption drivers/complaints for both (HN Algolia + GitHub API verified where noted).
+
+---
+
+## 1. The verdict in three sentences
+
+agenc-core's coding-agent loop (daemon, TUI, tools, permissions, OS sandbox, MCP
+client+server, subagents, sessions, 16 providers, cron, plugins, skills, realtime
+voice) is already at Codex-class parity and more rigorously built than either
+competitor (14k tests, 0 `@ts-nocheck`, eval-regression baseline, codex-rs surface
+contract green). What it lacks is the **personal-agent reach layer** that made
+OpenClaw (382k stars) and Hermes (211k stars) spread: messaging channels, one-command
+onboarding, persona/heartbeat, browser hands, and a learning loop. The winning move is
+not to clone them; it is to close four reach gaps and then ship the four things both
+are being publicly hammered for lacking: **security by default, auditable learning,
+bounded spending, and a real economy** (all four are things AgenC uniquely already
+has primitives for).
+
+## 2. Where they won, where they bleed (research summary)
+
+**OpenClaw won on:** messaging reach (25+ channels), "Claude with hands" demos,
+one-command install + onboarding wizard, persona files (SOUL.md) + heartbeat that
+make it feel alive, ClawHub ecosystem (~13.7k skills), drama-as-distribution.
+
+**OpenClaw bleeds on (verified):** 20k-42k exposed gateways (93% no auth), ClawHavoc
+supply chain (~1,184 malicious skills, ~8.5% of registry, "five of the top seven
+most-downloaded skills were malware"), token burn ($30-100/mo idle heartbeats,
+$3,600/mo horror stories), WhatsApp bans (Baileys = ToS violation), memory chaos
+(#43747), update roulette, prompt injection acknowledged unsolved.
+
+**Hermes won on:** the self-learning loop ("the agent that grows with you"),
+genuine model-agnosticism incl. local (captured OpenClaw refugees after Anthropic's
+April subscription crackdown), $5-VPS framing, Nous community + X-driven growth,
+stability positioning ("night and day more stable").
+
+**Hermes bleeds on (verified):** the EvoMap plagiarism scrub (issue #10232 edited to
+"`.`"), silent third-party data routing (#45058, web tools routed to a hosted MCP
+without a key set), self-learning trust ("it always thinks it did a good job",
+no audit trail or version control for generated skills, "subtle behavioral drift"),
+~14K tokens fixed overhead per call, 27k open issues, unauthenticated API server
+when key unset.
+
+**Unmet in BOTH (demand-ranked from user signals):**
+1. Reliability / memory that doesn't rot, with ops visibility
+2. Mobile-native + realtime bidirectional voice
+3. Multi-user / family / team isolation (OpenClaw closed RBAC as not-planned)
+4. Bounded spending: hard caps, approval taps in chat, audit trails
+5. Skill/agent trust: signing, publisher verification, reject-before-publish
+6. Hybrid model routing: local for the 80%, frontier for the hard 20%
+
+Items 4 and 5 are literally AgenC's existing on-chain trust stack (transaction
+guard, signer policies, preview-approve, attestation roster). Item 1 is what our
+eval-gated engineering culture produces. The "missing merchants" critique of x402
+(~$28K/day real volume, 50% wash) is the marketplace we already run.
+
+## 3. What we deliberately do NOT build
+
+- **WhatsApp via Baileys or any ToS-violating bridge.** OpenClaw's ban stories are
+  a trust tax. Ship official-API channels first; WhatsApp only via Cloud API
+  (business) with explicit caveats, or not at all initially.
+- **An uncurated skill registry.** ClawHub's malware rate is the cautionary tale.
+  Ours launches signed + attested or it doesn't launch.
+- **A Moltbook clone / agent social network.** Drama distribution without the
+  incident is not replicable; the Wiz DB leak killed its credibility.
+- **Interop reshaping of the protocol for anyone else's payment rails** (standing
+  founder directive 2026-07-05).
+- **i18n** (deliberately deleted in task 18; revisit only on demonstrated demand).
+
+## 4. The build list, in order
+
+Sizes: S = days, M = 1-2 weeks, L = 3-6 weeks, XL = multi-month. All phases assume
+the existing daemon protocol + SDK as the substrate (verified: `packages/agenc-sdk`
+already exposes `session.attach`, `message.stream`, `event.permission_request`
+round-trips, i.e. everything a channel adapter needs; the gateway is a **client-side
+build, not a runtime rewrite**).
+
+### Phase 0: Frictionless, safe onboarding (the founder-stated burning problem)
+
+| # | Work package | Size | Notes |
+|---|---|---|---|
+| 0.1 | `curl -fsSL get.agenc.ag/install.sh \| sh` + PowerShell equivalent: single script that installs Node-independent launcher or bundles runtime tarball, verifies SHA, installs daemon (systemd/launchd templates already exist in `packaging/`) | M | Copy OpenClaw's exact UX; ours verifies signatures |
+| 0.2 | `agenc onboard` wizard: provider pick (incl. reuse of existing Claude/Codex/OpenRouter creds), key/OAuth entry, daemon install, first chat in terminal, optional channel pairing | M | The single highest-leverage adoption artifact |
+| 0.3 | `agenc security audit [--fix]`: exposure check (bind mode, auth token, tool blast radius), fail-closed defaults, loopback-only unless tailnet/custom explicitly configured | S-M | Day-one differentiator; OpenClaw added theirs after the 42k-exposed disaster. We ship it before we ship channels |
+| 0.4 | Distribution spread: Homebrew tap, Docker image + compose, one-click VPS templates (Railway/Hostinger/Hetzner docs) | M | The VPS-template ecosystem was a real OpenClaw adoption channel |
+| 0.5 | Hosted docs quickstart with the 5-minute path, and a "Migrate from OpenClaw" + "Migrate from Hermes" guide (maps SOUL.md/AGENTS.md/skills to our equivalents) | S | The Hermes migration guide made HN front page (122 pts); refugees are a named acquisition channel |
+
+**Exit criterion:** a non-developer reaches a working assistant conversation in
+under 5 minutes on a fresh macOS/Linux box, and `agenc security audit` is green by
+default.
+
+### Phase 1: Channels (the defining reach gap)
+
+Architecture: a `gateway` client process (or daemon module behind a flag) that
+speaks the existing 41-method JSON-RPC protocol via agenc-sdk; each channel is a
+plugin using the existing `plugins/` registration surface. Inbound sender identity
+maps to sessions via deterministic bindings (OpenClaw's most-specific-wins model is
+the right design; copy it). DM policy defaults to **pairing** (unknown senders get
+expiring codes), never `open`.
+
+| # | Work package | Size | Notes |
+|---|---|---|---|
+| 1.1 | Channel gateway core: session binding/routing, delivery, streaming-to-message coalescing, permission-approval round-trip rendered as tappable chat replies | L | The approval-tap-in-chat is also the spend-control UX later |
+| 1.2 | Telegram channel (official Bot API) | S-M | Fastest setup, zero ban risk, OpenClaw's own recommended first channel |
+| 1.3 | WebChat: chat UI served from the daemon dashboard | M | Also becomes the mobile PWA stopgap |
+| 1.4 | Discord + Slack channels (official APIs) | M | |
+| 1.5 | Signal + email channels | M | Signal for the privacy audience (on-brand for AgenC) |
+| 1.6 | Untrusted-content hardening: every inbound channel message and fetched artifact wrapped in untrusted markers; channel text can never escalate permission mode, change signer config, or approve a previewed action (extends the existing marketplace untrusted-data rule to all channels) | M | This is where our permissions rigor becomes visible product |
+| 1.7 | iMessage (macOS bridge) and WhatsApp Cloud API, both opt-in with explicit caveats | M-L | Later; not launch-blocking |
+
+**Exit criterion:** talk to your agenc daemon from Telegram, approve a Bash
+permission request with a tap, and a hostile DM sender cannot reach the agent
+without pairing.
+
+### Phase 2: Alive: persona, heartbeat, proactive delivery
+
+We already have `memory/`, `AGENC.md`, cron with a live scheduler, and background
+tasks (DreamTask!). This phase is mostly wiring + workspace convention.
+
+| # | Work package | Size | Notes |
+|---|---|---|---|
+| 2.1 | Workspace persona files: `SOUL.md` (persona), `USER.md`, `IDENTITY.md`, one-time `BOOTSTRAP.md` naming ritual; injected at session bootstrap with a budget | S-M | Cheap, and it is what made OpenClaw feel alive; a souls-directory ecosystem exists to import from |
+| 2.2 | Heartbeat: periodic agent turn reading `HEARTBEAT.md`, `HEARTBEAT_OK` suppression, activeHours, per-task intervals | M | Design cost-first (see 2.3); OpenClaw's is a token furnace |
+| 2.3 | Cost-bounded autonomy: heartbeats/cron default to a cheap utility model + light context + `isolatedSession`; hard daily token/dollar budget enforced daemon-side with channel notification when hit | M | Direct answer to the $30-100/mo idle-burn complaint; "your agent has a budget" is also the marketplace mental model |
+| 2.4 | Cron delivery to channels (`--announce`, webhook POST); wire the existing ScheduleCronTool runner to gateway delivery | S | Scheduler already exists and re-arms on restart |
+| 2.5 | Inbound webhooks (`POST /hooks/agent`, bearer-only auth) | S-M | Zapier/CI integration surface |
+
+**Exit criterion:** morning-brief demo: cron fires at 7am on a cheap model, posts
+to Telegram, total cost visible, monthly idle cost under $5 on defaults.
+
+### Phase 3: Hands: browser, then wider execution
+
+| # | Work package | Size | Notes |
+|---|---|---|---|
+| 3.1 | Browser tool: dedicated Chromium profile, CDP-driven, snapshot returns stable ARIA-tree `ref` IDs (not CSS selectors), click/type/tabs/screenshot/PDF; SSRF policy blocking private networks by default; bundled browser-automation skill teaching snapshot-act-resnapshot | L | OpenClaw's design here is genuinely good; adopt the ref-ID model. Runs inside our sandbox policy, which they can't say |
+| 3.2 | Remote CDP option (Browserless/user-profile mode) | S | Config, mostly |
+| 3.3 | Docker execution driver for the sandbox (`sandbox.mode: docker`), then SSH remote exec target | L | Closes the Hermes 6-backend gap where it matters; Modal/Daytona-style serverless can wait for demand |
+| 3.4 | Computer-use tool (screen, OS-level input) behind explicit opt-in | L-XL | Defer until browser tool proves demand; highest risk surface |
+
+**Exit criterion:** "book/table/form/research behind JS" class tasks work from a
+chat channel, sandboxed, with the same permission previews as Bash.
+
+### Phase 4: The learning loop, done auditable (attack Hermes' trust wound)
+
+Positioning: Hermes learns silently and drifts; AgenC learns in **reviewed,
+versioned, eval-gated diffs**.
+
+| # | Work package | Size | Notes |
+|---|---|---|---|
+| 4.1 | Cross-session recall: FTS5 index over session JSONL/SQLite + `session_search` tool with bounded, redacted results | M | Hermes' most-loved feature; we have the SQLite substrate |
+| 4.2 | Memory distillation: daily notes -> periodic distill into MEMORY.md-equivalent, as **git commits in the workspace** with provenance (which sessions fed it); `/memory review` to diff/revert | M-L | Directly answers "memory management is in chaos" + "no audit trail" |
+| 4.3 | Skill curator: agent proposes new/edited skills from repeated patterns, lands them as **draft PRs against the workspace skills dir**, gated by the existing eval harness (`runtime/eval/`) before activation; never overwrites manual edits | L | The eval-regression baseline is the moat here; nobody else can gate learned behavior on evals |
+| 4.4 | User model (USER.md) maintained the same way: proposed diffs, never silent writes | S | |
+
+**Exit criterion:** after two weeks of use the agent has proposed >=3 skills, every
+one visible as a diff with an eval run attached, and reverting one is one command.
+
+### Phase 5: The moat (what neither can follow into)
+
+| # | Work package | Size | Notes |
+|---|---|---|---|
+| 5.1 | **Signed skill registry**: publisher identity = wallet signature, skills content-hashed, reject-before-publish scanning, attestation by the existing roster attestor (attest.agenc.ag) rather than scan-warn-install-anyway; provenance recorded on install | L | ClawHavoc (top-7 skills = malware) is the wedge. Reuses WP-C1/C2 attestation infra + marketplace store rails |
+| 5.2 | **Bounded agent spending as product**: surface the transaction-guard + signer-policy + preview-approve stack as consumer UX: per-agent budgets, category caps, approval taps in any channel, immutable audit log. "A virtual card for your agent" | L | The #4 unmet need verbatim; we already run this on mainnet for real SOL |
+| 5.3 | **Earn/hire loop (task 22 A3/A4, owner-gated)**: claim -> sandboxed worktree agent -> preview-first settle; plus creator-side: your assistant can post a task to the marketplace when it can't do something itself | L | This answers the x402 critique ("no actual merchants"): AgenC's marketplace IS the merchant layer. No other personal agent can say "my agent earned its own API budget this month" |
+| 5.4 | Multi-user / team gateway: per-user agents, isolated workspaces + sessions, per-binding tool policy (RBAC-lite) | L | OpenClaw explicitly declined this (#8081 closed not-planned) with acknowledged demand (#61123 families/teams) |
+| 5.5 | Hybrid model routing policy: cheap/local model for routine turns, frontier escalation on task-complexity signals; per-role model config (utility/heartbeat/main/image) | M | 16 providers incl. ollama/lmstudio already wired; this is a routing layer |
+| 5.6 | Mobile companion (nodes): start with the WebChat PWA + push notifications; native iOS/Android node apps (camera, location, voice wake) only after gateway+channels are proven | XL | OpenClaw needed 7 months to ship an official iPhone app; not a year-one requirement. Our realtime WebRTC voice stack is already ahead; wire it into WebChat first |
+
+### Phase 6: Growth mechanics (not code, but sequenced like code)
+
+- **Benchmark presence:** neither OpenClaw nor Hermes appears on any rigorous
+  coding-agent leaderboard; agenc-core is codex-surface-parity with an eval
+  harness. Run Terminal-Bench / SWE-bench-class results and publish. "The personal
+  agent that is also a top-tier coding agent" is a claim neither can make.
+- **Security-first launch narrative:** publish the threat model + the security
+  audit command + fail-closed defaults BEFORE launch, and invite the researchers
+  who broke OpenClaw (O'Reilly, Koi, Wiz) to try. Every OpenClaw incident
+  re-front-paged them; every AgenC non-incident is quiet compounding trust.
+- **Migration guides + soul-file import** (from 0.5) as standing SEO/HN artifacts.
+- **Weekly changelog cadence** on X (existing distribution), demo-led: morning
+  brief, approval tap, agent-earned-its-keep.
+
+## 5. Sequencing rationale (why this order)
+
+1. **Phase 0 before everything:** founder-identified burning problem is onboarding;
+   nothing downstream compounds without installs.
+2. **Channels before persona/heartbeat:** a heartbeat with nowhere to deliver is a
+   token furnace; channels give every later feature (approvals, cron, spend taps)
+   its UX surface.
+3. **Browser before learning loop:** "it did the thing" demos recruit users;
+   learning loops retain them. Acquisition before retention.
+4. **Moat last but designed-in from Phase 1:** the approval-tap plumbing (1.1),
+   budget enforcement (2.3), and untrusted-content discipline (1.6) are the same
+   primitives 5.2/5.3 need. Build them once, in order.
+5. **Every phase ships behind the existing quality gates** (typecheck 0, ~14k
+   vitest green, eval baseline, revert-sensitive tests). Stability was Hermes'
+   entire wedge against OpenClaw; ours is structural, keep it.
+
+## 6. Rough critical path
+
+P0 (0.1-0.3) -> P1 (1.1+1.2+1.6) -> P2 (2.2+2.3+2.4) gives the minimum lovable
+personal agent: install in 5 min, talk from Telegram, safe by default, morning
+brief under budget. That slice is roughly 3 gateway-scale L packages plus a
+handful of S/M, and everything in it is client-side or wiring on the existing
+daemon. Browser (3.1) and auditable learning (4.1-4.3) are the second wave.
+The moat items (5.1-5.3) can start in parallel any time after Phase 1 because
+they reuse marketplace infra that already exists outside this repo.

--- a/runtime/tests/packaging/install-sh.test.ts
+++ b/runtime/tests/packaging/install-sh.test.ts
@@ -1,0 +1,296 @@
+// End-to-end tests for scripts/install/install.sh (TODO task 1).
+//
+// The installer must speak the exact runtime-manager install contract
+// (runtime/<version>/ tree + .agenc-runtime-ok marker recording the sha256)
+// so the npm launcher and the shell installer can reuse each other's
+// installs. Everything runs against a synthetic tarball + file:// manifest,
+// mirroring packages/agenc/test/runtime-manager.test.mjs.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const INSTALL_SH = join(REPO_ROOT, "scripts", "install", "install.sh");
+const INSTALL_PS1 = join(REPO_ROOT, "scripts", "install", "install.ps1");
+
+const VERSION = "9.9.9-test";
+const BIN_REL = "node_modules/@tetsuo-ai/runtime/bin/agenc";
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+// Synthetic runtime tarball with the real extraction layout; the bin is a
+// node script so the generated wrapper can actually be executed.
+function makeSyntheticArtifact(dir: string): { tarball: string; sha: string } {
+  const tree = join(dir, "tree");
+  const binDir = join(tree, "node_modules", "@tetsuo-ai", "runtime", "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    join(binDir, "agenc"),
+    'console.log("ok " + process.argv.slice(2).join(" "));\n',
+  );
+  const tarball = join(dir, `agenc-runtime-${VERSION}-test.tar.gz`);
+  const res = spawnSync("tar", ["-czf", tarball, "-C", tree, "node_modules"]);
+  expect(res.status).toBe(0);
+  return { tarball, sha: sha256(readFileSync(tarball)) };
+}
+
+function writeManifest(
+  dir: string,
+  artifact: { tarball: string; sha: string },
+  overrides: Record<string, unknown> = {},
+): string {
+  const manifest = {
+    manifestVersion: 1,
+    runtimeVersion: VERSION,
+    releaseRepository: "tetsuo-ai/agenc-core",
+    releaseTag: `agenc-v${VERSION}`,
+    artifacts: [
+      {
+        platform: "linux",
+        arch: "x64",
+        runtimeVersion: VERSION,
+        url: `file://${artifact.tarball}`,
+        sha256: artifact.sha,
+        bytes: statSync(artifact.tarball).size,
+        bins: { agenc: BIN_REL },
+        ...overrides,
+      },
+    ],
+  };
+  const file = join(dir, "manifest.json");
+  writeFileSync(file, JSON.stringify(manifest, null, 2));
+  return file;
+}
+
+type RunResult = { status: number; stdout: string; stderr: string };
+
+function runInstaller(opts: {
+  home: string;
+  args?: string[];
+  manifest: string;
+  pathPrepend?: string[];
+}): RunResult {
+  const env = {
+    HOME: opts.home,
+    AGENC_HOME: join(opts.home, ".agenc"),
+    TMPDIR: join(opts.home, "tmp"),
+    PATH: [...(opts.pathPrepend ?? []), process.env.PATH ?? ""].join(":"),
+    // Deterministic platform selection regardless of the host machine.
+    AGENC_INSTALL_PLATFORM: "linux",
+    AGENC_INSTALL_ARCH: "x64",
+  };
+  mkdirSync(env.TMPDIR, { recursive: true });
+  const res = spawnSync(
+    "sh",
+    [
+      INSTALL_SH,
+      "--manifest-url",
+      `file://${opts.manifest}`,
+      "--prefix",
+      join(opts.home, ".local"),
+      ...(opts.args ?? []),
+    ],
+    { env, encoding: "utf8" },
+  );
+  return {
+    status: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+describe.skipIf(process.platform === "win32")("install.sh", () => {
+  let work: string;
+  beforeEach(() => {
+    work = mkdtempSync(join(tmpdir(), "agenc-install-test-"));
+  });
+  afterEach(() => {
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  function paths(home: string) {
+    const installDir = join(home, ".agenc", "runtime", VERSION);
+    return {
+      installDir,
+      marker: join(installDir, ".agenc-runtime-ok"),
+      wrapper: join(home, ".local", "bin", "agenc"),
+    };
+  }
+
+  test("fresh install: downloads, verifies, extracts, writes marker + working wrapper", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const res = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(res.stderr).toContain("checksum verified");
+    expect(res.status).toBe(0);
+
+    const { marker, wrapper } = paths(home);
+    expect(readFileSync(marker, "utf8")).toBe(artifact.sha);
+    expect(statSync(wrapper).mode & 0o111).not.toBe(0);
+    // The wrapper actually launches the installed runtime bin.
+    const out = execFileSync(wrapper, ["--version"], { encoding: "utf8" });
+    expect(out).toContain("ok --version");
+  });
+
+  test("checksum mismatch: aborts nonzero, installs nothing", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact, {
+      sha256: "0".repeat(64),
+    });
+
+    const res = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("checksum mismatch");
+
+    const { installDir, wrapper } = paths(home);
+    expect(existsSync(installDir)).toBe(false);
+    expect(existsSync(wrapper)).toBe(false);
+  });
+
+  test("idempotent: verified marker short-circuits the download entirely", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const first = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(first.status).toBe(0);
+
+    // Remove the artifact: a second run can only succeed via the marker path.
+    rmSync(artifact.tarball);
+    const second = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("already installed");
+  });
+
+  test("daemon: writes a systemd user unit pointing at the wrapper and enables it", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    // Stub systemctl that records its argv lines.
+    const stubDir = join(work, "stub-bin");
+    mkdirSync(stubDir, { recursive: true });
+    const callLog = join(work, "systemctl-calls.log");
+    writeFileSync(
+      join(stubDir, "systemctl"),
+      `#!/bin/sh\necho "$@" >> "${callLog}"\nexit 0\n`,
+    );
+    chmodSync(join(stubDir, "systemctl"), 0o755);
+
+    const res = runInstaller({ home, manifest, pathPrepend: [stubDir] });
+    expect(res.status).toBe(0);
+
+    const unit = readFileSync(
+      join(home, ".config", "systemd", "user", "agenc-daemon.service"),
+      "utf8",
+    );
+    const { wrapper } = paths(home);
+    expect(unit).toContain(`ExecStart=${wrapper} daemon start --foreground`);
+    expect(unit).toContain("WantedBy=default.target");
+
+    const calls = readFileSync(callLog, "utf8");
+    expect(calls).toContain("--user daemon-reload");
+    expect(calls).toContain("--user enable --now agenc-daemon.service");
+  });
+
+  test("--no-daemon skips service installation", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const res = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("daemon installation skipped");
+    expect(
+      existsSync(join(home, ".config", "systemd", "user", "agenc-daemon.service")),
+    ).toBe(false);
+  });
+
+  test("unsupported platform: clear error listing available builds", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const env = {
+      HOME: home,
+      AGENC_HOME: join(home, ".agenc"),
+      PATH: process.env.PATH ?? "",
+      AGENC_INSTALL_PLATFORM: "linux",
+      AGENC_INSTALL_ARCH: "riscv64",
+    };
+    const res = spawnSync(
+      "sh",
+      [INSTALL_SH, "--manifest-url", `file://${manifest}`, "--no-daemon"],
+      { env, encoding: "utf8" },
+    );
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("no runtime build for linux-riscv64");
+    expect(res.stderr).toContain("linux-x64");
+  });
+
+  test("node version gate: refuses Node older than 25", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    // Stub node reporting major version 20 for any invocation.
+    const stubDir = join(work, "stub-bin");
+    mkdirSync(stubDir, { recursive: true });
+    writeFileSync(join(stubDir, "node"), '#!/bin/sh\nprintf "20"\n');
+    chmodSync(join(stubDir, "node"), 0o755);
+
+    const res = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      pathPrepend: [stubDir],
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("Node.js >= 25 required");
+  });
+
+  test("install.ps1 parses under pwsh (skipped when pwsh is absent)", () => {
+    const pwsh = spawnSync("pwsh", ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"], {
+      encoding: "utf8",
+    });
+    if (pwsh.status !== 0) return; // pwsh not available on this machine
+    const res = spawnSync(
+      "pwsh",
+      [
+        "-NoProfile",
+        "-Command",
+        `$null = [scriptblock]::Create((Get-Content -Raw '${INSTALL_PS1}')); 'parsed'`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(res.stdout).toContain("parsed");
+    expect(res.status).toBe(0);
+  });
+});

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,0 +1,137 @@
+# AgenC one-line installer (Windows).
+#
+#   iwr -useb <installer-url> | iex
+#
+# Same install contract as install.sh and the npm launcher's runtime-manager:
+# downloads the win-<arch> runtime tarball from the release manifest, verifies
+# its sha256, extracts to $env:AGENC_HOME\runtime\<version>\ with the
+# .agenc-runtime-ok marker, and installs an agenc.cmd shim.
+#
+# Environment overrides:
+#   AGENC_INSTALL_MANIFEST_URL  manifest override (file paths supported)
+#   AGENC_INSTALL_REPO          GitHub repo (default tetsuo-ai/agenc-core)
+#   AGENC_INSTALL_VERSION       pin a release version
+#   AGENC_HOME                  runtime install root (default ~\.agenc)
+#   AGENC_INSTALL_PREFIX        shim prefix (default $env:LOCALAPPDATA\agenc)
+
+$ErrorActionPreference = "Stop"
+$MinNodeMajor = 25
+
+function Write-Log([string]$msg) { Write-Host "agenc-install: $msg" }
+function Fail([string]$msg) { Write-Error "agenc-install: ERROR: $msg"; exit 1 }
+
+# --- prerequisites -----------------------------------------------------------
+
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) { Fail "Node.js >= $MinNodeMajor is required. Install it (https://nodejs.org) and re-run." }
+$nodeMajor = [int](node -e "process.stdout.write(process.versions.node.split('.')[0])")
+if ($nodeMajor -lt $MinNodeMajor) { Fail "Node.js >= $MinNodeMajor required, found $(node -v)." }
+$tar = Get-Command tar -ErrorAction SilentlyContinue
+if (-not $tar) { Fail "tar is required (bundled with Windows 10 1803+)." }
+
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+  "AMD64" { "x64" }
+  "ARM64" { "arm64" }
+  default { Fail "unsupported architecture: $env:PROCESSOR_ARCHITECTURE" }
+}
+
+# --- resolve manifest --------------------------------------------------------
+
+$repo = if ($env:AGENC_INSTALL_REPO) { $env:AGENC_INSTALL_REPO } else { "tetsuo-ai/agenc-core" }
+$manifestUrl = $env:AGENC_INSTALL_MANIFEST_URL
+if (-not $manifestUrl) {
+  if ($env:AGENC_INSTALL_VERSION) {
+    $manifestUrl = "https://github.com/$repo/releases/download/agenc-v$($env:AGENC_INSTALL_VERSION)/agenc-runtime-manifest.json"
+  } else {
+    $manifestUrl = "https://github.com/$repo/releases/latest/download/agenc-runtime-manifest.json"
+  }
+}
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) "agenc-install-$PID"
+New-Item -ItemType Directory -Force -Path $work | Out-Null
+try {
+  $manifestFile = Join-Path $work "manifest.json"
+  Write-Log "fetching release manifest: $manifestUrl"
+  if ($manifestUrl -match "^https?://") {
+    Invoke-WebRequest -UseBasicParsing -Uri $manifestUrl -OutFile $manifestFile
+  } else {
+    Copy-Item ($manifestUrl -replace "^file://", "") $manifestFile
+  }
+
+  $manifest = Get-Content -Raw $manifestFile | ConvertFrom-Json
+  $artifact = $manifest.artifacts | Where-Object { $_.platform -eq "win" -and $_.arch -eq $arch } | Select-Object -First 1
+  if (-not $artifact) {
+    $have = ($manifest.artifacts | ForEach-Object { "$($_.platform)-$($_.arch)" }) -join ", "
+    Fail "no runtime build for win-$arch (available: $have)"
+  }
+  if (-not $manifest.runtimeVersion -or -not $artifact.url -or $artifact.sha256 -notmatch "^[0-9a-f]{64}$") {
+    Fail "manifest artifact is missing runtimeVersion/url/sha256"
+  }
+  $version = $manifest.runtimeVersion
+  $binRel = if ($artifact.bins -and $artifact.bins.agenc) { $artifact.bins.agenc } else { "node_modules/@tetsuo-ai/runtime/bin/agenc" }
+
+  $agencHome = if ($env:AGENC_HOME) { $env:AGENC_HOME } else { Join-Path $env:USERPROFILE ".agenc" }
+  $installDir = Join-Path (Join-Path $agencHome "runtime") $version
+  $marker = Join-Path $installDir ".agenc-runtime-ok"
+  $runtimeBin = Join-Path $installDir ($binRel -replace "/", "\")
+
+  # --- download + verify + extract (idempotent via the marker contract) -----
+
+  $installed = (Test-Path $marker) -and ((Get-Content -Raw $marker).Trim() -eq $artifact.sha256)
+  if ($installed) {
+    Write-Log "runtime $version already installed (verified marker) - skipping download"
+  } else {
+    Write-Log "downloading runtime $version (win-$arch)..."
+    $tarball = Join-Path $work "runtime.tar.gz"
+    if ($artifact.url -match "^https?://") {
+      Invoke-WebRequest -UseBasicParsing -Uri $artifact.url -OutFile $tarball
+    } else {
+      Copy-Item ($artifact.url -replace "^file://", "") $tarball
+    }
+    $actual = (Get-FileHash -Algorithm SHA256 $tarball).Hash.ToLowerInvariant()
+    if ($actual -ne $artifact.sha256) {
+      Fail "checksum mismatch for runtime tarball (expected $($artifact.sha256), got $actual). Refusing to install."
+    }
+    Write-Log "checksum verified"
+    if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    tar -xzf $tarball -C $installDir
+    if ($LASTEXITCODE -ne 0) { Fail "extraction failed" }
+    if (-not (Test-Path $runtimeBin)) { Fail "runtime extracted but entry missing: $runtimeBin" }
+    Set-Content -NoNewline -Path $marker -Value $artifact.sha256
+    Write-Log "runtime $version installed at $installDir"
+  }
+
+  # --- shim ------------------------------------------------------------------
+
+  $prefix = if ($env:AGENC_INSTALL_PREFIX) { $env:AGENC_INSTALL_PREFIX } else { Join-Path $env:LOCALAPPDATA "agenc" }
+  $binDir = Join-Path $prefix "bin"
+  New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+  $shim = Join-Path $binDir "agenc.cmd"
+  @"
+@echo off
+rem Generated by AgenC install.ps1 - rewritten on every install/upgrade.
+if not defined AGENC_HOME set "AGENC_HOME=$agencHome"
+"$($node.Source)" "$runtimeBin" %*
+"@ | Set-Content -Path $shim -Encoding ASCII
+  Write-Log "installed shim: $shim"
+
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  if ($userPath -notlike "*$binDir*") {
+    Write-Log "NOTE: $binDir is not on your PATH. Add it via:  setx PATH `"$binDir;%PATH%`""
+  }
+
+  # Daemon-as-service on Windows uses WinSW with packaging/windows/agenc-daemon.xml;
+  # see docs/install.md. Manual start works out of the box:
+  Write-Log "install complete"
+  Write-Host ""
+  Write-Host "  AgenC $version installed."
+  Write-Host ""
+  Write-Host "  Next steps:"
+  Write-Host "    $shim                # start the interactive TUI"
+  Write-Host "    $shim doctor         # verify the installation"
+  Write-Host "    $shim daemon start   # start the daemon"
+  Write-Host ""
+} finally {
+  Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+}

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,305 @@
+#!/bin/sh
+# AgenC one-line installer (macOS / Linux).
+#
+#   curl -fsSL <installer-url> | sh
+#
+# Downloads the per-platform runtime tarball listed in the release manifest,
+# verifies its sha256, extracts it under $AGENC_HOME/runtime/<version>/ using
+# the exact install contract the npm launcher's runtime-manager uses (same
+# directory layout, same .agenc-runtime-ok marker), installs an `agenc`
+# wrapper into --prefix/bin, and wires the daemon as a user service.
+#
+# The npm launcher (`npm install -g @tetsuo-ai/agenc`) and this script are
+# interchangeable: either one finds and reuses a runtime the other installed.
+#
+# Options (flags win over environment):
+#   --version <x.y.z>       pin a release (default: latest release manifest)
+#   --manifest-url <url>    manifest override; supports file:// and plain paths
+#                           (env: AGENC_INSTALL_MANIFEST_URL)
+#   --repo <owner/name>     GitHub repo for release downloads
+#                           (env: AGENC_INSTALL_REPO, default tetsuo-ai/agenc-core)
+#   --prefix <dir>          wrapper install prefix (default: ~/.local)
+#   --no-daemon             skip user-service installation
+#   AGENC_HOME              runtime install root (default: ~/.agenc)
+#
+# Test seams (used by runtime/tests/packaging/install-sh.test.ts):
+#   AGENC_INSTALL_PLATFORM / AGENC_INSTALL_ARCH override platform detection.
+#
+# Publishing this script to a stable URL (get.agenc.ag, release asset) and
+# uploading agenc-runtime-manifest.json as a release asset are owner/release
+# steps; see docs/install.md.
+
+set -u
+
+REPO="${AGENC_INSTALL_REPO:-tetsuo-ai/agenc-core}"
+MANIFEST_URL="${AGENC_INSTALL_MANIFEST_URL:-}"
+PIN_VERSION=""
+PREFIX="${HOME}/.local"
+INSTALL_DAEMON=1
+MIN_NODE_MAJOR=25
+
+log() { printf 'agenc-install: %s\n' "$*" >&2; }
+fail() { log "ERROR: $*"; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) PIN_VERSION="${2:?--version needs a value}"; shift 2 ;;
+    --manifest-url) MANIFEST_URL="${2:?--manifest-url needs a value}"; shift 2 ;;
+    --repo) REPO="${2:?--repo needs a value}"; shift 2 ;;
+    --prefix) PREFIX="${2:?--prefix needs a value}"; shift 2 ;;
+    --no-daemon) INSTALL_DAEMON=0; shift ;;
+    -h|--help) sed -n '2,30p' "$0" 2>/dev/null; exit 0 ;;
+    *) fail "unknown option: $1 (see --help)" ;;
+  esac
+done
+
+# --- prerequisites -----------------------------------------------------------
+
+command -v tar >/dev/null 2>&1 || fail "tar is required"
+command -v node >/dev/null 2>&1 || fail \
+  "Node.js >= ${MIN_NODE_MAJOR} is required. Install it (https://nodejs.org) and re-run."
+
+NODE_BIN="$(command -v node)"
+NODE_MAJOR="$(node -e 'process.stdout.write(String(process.versions.node.split(".")[0]))')" \
+  || fail "could not determine Node.js version"
+[ "$NODE_MAJOR" -ge "$MIN_NODE_MAJOR" ] 2>/dev/null || fail \
+  "Node.js >= ${MIN_NODE_MAJOR} required, found $(node -v). Upgrade Node and re-run."
+
+DOWNLOADER=""
+if command -v curl >/dev/null 2>&1; then DOWNLOADER="curl"
+elif command -v wget >/dev/null 2>&1; then DOWNLOADER="wget"
+fi
+
+# --- platform ----------------------------------------------------------------
+
+detect_platform() {
+  if [ -n "${AGENC_INSTALL_PLATFORM:-}" ]; then
+    printf '%s' "$AGENC_INSTALL_PLATFORM"; return
+  fi
+  case "$(uname -s)" in
+    Linux) printf 'linux' ;;
+    Darwin) printf 'darwin' ;;
+    *) fail "unsupported OS: $(uname -s) (use install.ps1 on Windows)" ;;
+  esac
+}
+
+detect_arch() {
+  if [ -n "${AGENC_INSTALL_ARCH:-}" ]; then
+    printf '%s' "$AGENC_INSTALL_ARCH"; return
+  fi
+  case "$(uname -m)" in
+    x86_64|amd64) printf 'x64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *) fail "unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+OS="$(detect_platform)"
+ARCH="$(detect_arch)"
+
+# --- fetch helpers (file:// and plain paths supported for testability) -------
+
+fetch_to() {
+  # fetch_to <url> <dest>
+  _url="$1"; _dest="$2"
+  case "$_url" in
+    file://*)
+      cp "${_url#file://}" "$_dest" || return 1 ;;
+    http://*|https://*)
+      [ -n "$DOWNLOADER" ] || fail "curl or wget is required to download $_url"
+      if [ "$DOWNLOADER" = curl ]; then
+        curl -fsSL --proto '=https' --tlsv1.2 -o "$_dest" "$_url" || return 1
+      else
+        wget -q -O "$_dest" "$_url" || return 1
+      fi ;;
+    *)
+      cp "$_url" "$_dest" || return 1 ;;
+  esac
+}
+
+sha256_of() {
+  node -e '
+    const { createHash } = require("node:crypto");
+    const { readFileSync } = require("node:fs");
+    process.stdout.write(createHash("sha256").update(readFileSync(process.argv[1])).digest("hex"));
+  ' "$1"
+}
+
+# --- resolve manifest --------------------------------------------------------
+
+AGENC_HOME_DIR="${AGENC_HOME:-${HOME}/.agenc}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/agenc-install.XXXXXX")" || fail "mktemp failed"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+if [ -z "$MANIFEST_URL" ]; then
+  if [ -n "$PIN_VERSION" ]; then
+    MANIFEST_URL="https://github.com/${REPO}/releases/download/agenc-v${PIN_VERSION}/agenc-runtime-manifest.json"
+  else
+    MANIFEST_URL="https://github.com/${REPO}/releases/latest/download/agenc-runtime-manifest.json"
+  fi
+fi
+
+log "fetching release manifest: ${MANIFEST_URL}"
+MANIFEST_FILE="$WORK/manifest.json"
+fetch_to "$MANIFEST_URL" "$MANIFEST_FILE" || fail "could not fetch manifest: ${MANIFEST_URL}"
+
+# Select the artifact for this platform. Mirrors the launcher's selectArtifact.
+SELECTED="$(node -e '
+  const { readFileSync } = require("node:fs");
+  const [file, os, arch] = process.argv.slice(1);
+  const m = JSON.parse(readFileSync(file, "utf8"));
+  const artifacts = Array.isArray(m.artifacts) ? m.artifacts : [];
+  const a = artifacts.find((x) => x.platform === os && x.arch === arch);
+  if (!a) {
+    const have = artifacts.map((x) => `${x.platform}-${x.arch}`).join(", ");
+    console.error(`no runtime build for ${os}-${arch} (available: ${have || "none"})`);
+    process.exit(3);
+  }
+  if (!m.runtimeVersion || !a.url || !/^[0-9a-f]{64}$/.test(a.sha256 || "")) {
+    console.error("manifest artifact is missing runtimeVersion/url/sha256");
+    process.exit(4);
+  }
+  const bin = (a.bins && a.bins.agenc) || "node_modules/@tetsuo-ai/runtime/bin/agenc";
+  process.stdout.write([m.runtimeVersion, a.url, a.sha256, bin].join("\n"));
+' "$MANIFEST_FILE" "$OS" "$ARCH")" || fail "manifest rejected (${OS}-${ARCH})"
+
+VERSION="$(printf '%s\n' "$SELECTED" | sed -n 1p)"
+ARTIFACT_URL="$(printf '%s\n' "$SELECTED" | sed -n 2p)"
+ARTIFACT_SHA="$(printf '%s\n' "$SELECTED" | sed -n 3p)"
+BIN_REL="$(printf '%s\n' "$SELECTED" | sed -n 4p)"
+
+INSTALL_DIR="${AGENC_HOME_DIR}/runtime/${VERSION}"
+MARKER="${INSTALL_DIR}/.agenc-runtime-ok"
+RUNTIME_BIN="${INSTALL_DIR}/${BIN_REL}"
+
+# --- download + verify + extract (idempotent via the marker contract) --------
+
+if [ -f "$MARKER" ] && [ "$(cat "$MARKER" 2>/dev/null)" = "$ARTIFACT_SHA" ]; then
+  log "runtime ${VERSION} already installed (verified marker) — skipping download"
+else
+  log "downloading runtime ${VERSION} (${OS}-${ARCH})..."
+  TARBALL="$WORK/runtime.tar.gz"
+  fetch_to "$ARTIFACT_URL" "$TARBALL" || fail "download failed: ${ARTIFACT_URL}"
+
+  ACTUAL_SHA="$(sha256_of "$TARBALL")" || fail "sha256 computation failed"
+  if [ "$ACTUAL_SHA" != "$ARTIFACT_SHA" ]; then
+    fail "checksum mismatch for runtime tarball (expected ${ARTIFACT_SHA}, got ${ACTUAL_SHA}). Refusing to install."
+  fi
+  log "checksum verified"
+
+  rm -rf "$INSTALL_DIR"
+  mkdir -p "$INSTALL_DIR"
+  tar -xzf "$TARBALL" -C "$INSTALL_DIR" || fail "extraction failed"
+  [ -f "$RUNTIME_BIN" ] || fail "runtime extracted but entry missing: ${RUNTIME_BIN}"
+  printf '%s' "$ARTIFACT_SHA" > "$MARKER"
+  log "runtime ${VERSION} installed at ${INSTALL_DIR}"
+fi
+
+# --- wrapper -----------------------------------------------------------------
+
+BIN_DIR="${PREFIX}/bin"
+WRAPPER="${BIN_DIR}/agenc"
+mkdir -p "$BIN_DIR"
+# Bake absolute node + runtime paths: user services (systemd/launchd) run with
+# a minimal PATH where version-manager-installed node is not resolvable.
+cat > "$WRAPPER" <<EOF
+#!/bin/sh
+# Generated by AgenC install.sh — rewritten on every install/upgrade.
+export AGENC_HOME="\${AGENC_HOME:-${AGENC_HOME_DIR}}"
+exec "${NODE_BIN}" "${RUNTIME_BIN}" "\$@"
+EOF
+chmod 755 "$WRAPPER"
+log "installed wrapper: ${WRAPPER}"
+
+case ":${PATH}:" in
+  *":${BIN_DIR}:"*) : ;;
+  *) log "NOTE: ${BIN_DIR} is not on your PATH. Add it, e.g.: export PATH=\"${BIN_DIR}:\$PATH\"" ;;
+esac
+
+# --- daemon service ----------------------------------------------------------
+# Content mirrors packaging/systemd/agenc-daemon.service and
+# packaging/launchd/dev.agenc.daemon.plist, with ExecStart resolved to the
+# installed wrapper (user services run with a minimal PATH).
+
+install_daemon_linux() {
+  if ! command -v systemctl >/dev/null 2>&1; then
+    log "systemctl not found — start the daemon manually: agenc daemon start"
+    return 0
+  fi
+  UNIT_DIR="${HOME}/.config/systemd/user"
+  mkdir -p "$UNIT_DIR"
+  cat > "${UNIT_DIR}/agenc-daemon.service" <<EOF
+[Unit]
+Description=AgenC daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${WRAPPER} daemon start --foreground
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target
+EOF
+  if systemctl --user daemon-reload && systemctl --user enable --now agenc-daemon.service; then
+    log "daemon installed and started (systemd user service agenc-daemon)"
+  else
+    log "WARNING: could not enable the systemd user service — start manually: agenc daemon start"
+  fi
+}
+
+install_daemon_darwin() {
+  PLIST_DIR="${HOME}/Library/LaunchAgents"
+  PLIST="${PLIST_DIR}/dev.agenc.daemon.plist"
+  mkdir -p "$PLIST_DIR"
+  cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.agenc.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${WRAPPER}</string>
+    <string>daemon</string>
+    <string>start</string>
+    <string>--foreground</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>NODE_ENV</key>
+    <string>production</string>
+  </dict>
+</dict>
+</plist>
+EOF
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null \
+     || launchctl load -w "$PLIST" 2>/dev/null; then
+    log "daemon installed and started (launchd dev.agenc.daemon)"
+  else
+    log "WARNING: could not load the launchd agent — start manually: agenc daemon start"
+  fi
+}
+
+if [ "$INSTALL_DAEMON" -eq 1 ]; then
+  case "$OS" in
+    linux) install_daemon_linux ;;
+    darwin) install_daemon_darwin ;;
+  esac
+else
+  log "daemon installation skipped (--no-daemon)"
+fi
+
+# --- done --------------------------------------------------------------------
+
+log "install complete"
+printf '\n  AgenC %s installed.\n\n  Next steps:\n    %s              # start the interactive TUI\n    %s doctor       # verify the installation\n    %s daemon status\n\n' \
+  "$VERSION" "$WRAPPER" "$WRAPPER" "$WRAPPER"


### PR DESCRIPTION
Parity backlog task 1 (Phase 0 — onboarding).

## What
- `scripts/install/install.sh` (macOS/Linux) + `scripts/install/install.ps1` (Windows): fetch release manifest, select per-platform artifact, download tarball, **verify sha256 (mismatch aborts)**, extract to `$AGENC_HOME/runtime/<ver>/` with the `.agenc-runtime-ok` marker — the exact contract `packages/agenc/lib/runtime-manager.mjs` uses, so npm-launcher and shell installs reuse each other's runtimes.
- Wrapper with baked absolute node path (user services run with minimal PATH); systemd user unit / launchd agent wiring; `--no-daemon`, `--version`, `--prefix`, `--manifest-url`, `--repo`.
- `docs/install.md` incl. the owner-gated release/publish steps (manifest as release asset, script hosting). README quick-start pointer.
- `docs/parity-roadmap-2026-07.md`: the plan this backlog derives from.

## Tests (runtime/tests/packaging/install-sh.test.ts, 8)
Fresh install e2e against synthetic tarball + file:// manifest; checksum-mismatch abort; marker idempotency proven by deleting the artifact before the re-run; systemd unit content + stubbed-systemctl invocations; `--no-daemon`; unsupported-platform error; Node<25 gate; ps1 parse under pwsh.

**Revert-sensitivity proven:** neutering the checksum abort → mismatch test red; neutering the marker short-circuit → idempotency test red.

## Gates
build ✓ typecheck ✓ (0 errors) vitest 14027 passed ✓ bun suite ✓ (pre-commit also re-ran build + TUI startup smoke)