### PR TITLE
feat(cli): agenc onboard — explicit setup-wizard entry (task 2)

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
@@ -1,0 +1,59 @@
+/**
+ * `agenc onboard` scenario (TODO task 2).
+ *
+ * The explicit onboard subcommand boots the TUI with the first-run wizard
+ * forced. Drive the whole wizard with the mock openai-compatible provider
+ * (keyless local provider path), finish it, then complete a real first turn
+ * against the mock model — the Phase 0 acceptance criterion.
+ */
+import { strict as assert } from "node:assert";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const meta = {
+  description:
+    "agenc onboard forces the setup wizard; completing it reaches a first model turn.",
+  timeoutMs: 180_000,
+  useTempHome: true,
+  slimCwd: true,
+  args: ["onboard"],
+};
+
+export default async function (session) {
+  await session.start();
+
+  // Preflight renders as a full paint — anchor that the wizard is showing.
+  // (Later steps repaint as cell diffs that split words with cursor jumps,
+  // so phrase anchors are only reliable on this first screen; subsequent
+  // steps are driven input→idle. The wizard's input protocol is fixed:
+  // src/onboarding/Onboarding.tsx submitFirstRunOnboardingInput.)
+  await session.waitFor(/Type next to continue\./, { timeout: 60_000 });
+
+  const wizardInputs = [
+    "next", // preflight → theme
+    "1", // theme: dark → provider
+    "openai-compatible", // provider (mock server) → api-key
+    "next", // api-key: keyless local provider → connection-test
+    "next", // connection-test: runs the mock-server check → security
+    "next", // security: keep defaults → terminal-setup
+    "done", // terminal-setup: finish onboarding
+  ];
+  for (const input of wizardInputs) {
+    await session.submit(input);
+    // Bytes-quiet is the only repaint-agnostic step barrier; a rejected
+    // input stalls the wizard and the post-wizard asserts below fail loudly.
+    await session.waitForIdle({ timeout: 60_000 });
+  }
+
+  // Wizard done: the normal composer prompt appears; complete a first turn.
+  await session.waitForPrompt({ timeout: 60_000 });
+  await session.submit("reply with the single word ONBOARDED");
+  await session.waitFor(/ONBOARDED/, { timeout: 60_000 });
+  await session.waitForIdle({ timeout: 30_000 });
+
+  // The wizard persisted completion in the temp home.
+  assert.ok(session.tempHome, "scenario must run under a temp home");
+  const statePath = path.join(session.tempHome, ".agenc", "onboarding.json");
+  const state = JSON.parse(await readFile(statePath, "utf8"));
+  assert.equal(state.completed, true, "onboarding.json must record completion");
+}

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -147,6 +147,12 @@ import {
   runAgenCDoctorCli,
 } from "./doctor-cli.js";
 import {
+  formatAgenCOnboardCliHelpText,
+  parseAgenCOnboardCliArgs,
+  readOnboardDaemonStatus,
+  runAgenCOnboardCli,
+} from "./onboard-cli.js";
+import {
   formatAgenCInitCliHelpText,
   parseAgenCInitCliArgs,
   runAgenCInitCli,
@@ -300,6 +306,7 @@ export function formatCliHelpText(): string {
     "Usage: agenc [options] [PROMPT]",
     "       agenc -p|--print [options] [PROMPT]",
     "       agenc help [command]",
+    "       agenc onboard [--status [--json] | --reset]",
     "       agenc init [--force]",
     "       agenc <login|logout|whoami>",
     "       agenc providers [--json] [--no-local-check]",
@@ -319,6 +326,7 @@ export function formatCliHelpText(): string {
     "       agenc mcp <serve|add|list|get|remove|add-json|add-from-agenc-desktop|reset-project-choices|doctor|xaa>",
     "",
     "Commands:",
+    "  onboard                                 Set up AgenC: provider, key, theme, first chat",
     "  init                                    Create .agenc/config.json and AGENC.md",
     "  login | logout | whoami                  Manage the configured auth session",
     "  providers                               Check provider readiness and local health",
@@ -393,6 +401,8 @@ export function formatCliHelpTopicText(topic: string): string | null {
       return formatAgenCMcpCliHelpText();
     case "doctor":
       return formatAgenCDoctorCliHelpText();
+    case "onboard":
+      return formatAgenCOnboardCliHelpText();
     case "permissions":
       return formatAgenCPermissionsCliHelpText();
     case "plugin":
@@ -3989,6 +3999,28 @@ export async function main(): Promise<number> {
   const doctorCommand = parseAgenCDoctorCliArgs(argv);
   if (doctorCommand !== null) {
     return runAgenCDoctorCli(doctorCommand);
+  }
+  const onboardCommand = parseAgenCOnboardCliArgs(argv);
+  if (onboardCommand !== null) {
+    if (onboardCommand.kind !== "launch") {
+      return runAgenCOnboardCli(onboardCommand);
+    }
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      process.stderr.write(
+        "agenc: onboard needs an interactive terminal (use 'agenc onboard --status' in scripts)\n",
+      );
+      return 1;
+    }
+    const daemonStatus = await readOnboardDaemonStatus(process.env);
+    process.stderr.write(
+      daemonStatus.running
+        ? `agenc: daemon running (pid ${daemonStatus.pid})\n`
+        : "agenc: daemon not running — it starts automatically with the session\n",
+    );
+    // Force the first-run wizard for this process only (never persisted);
+    // consumed by shouldShowFirstRunOnboarding via the TUI's env snapshot.
+    process.env.AGENC_ONBOARDING = "force";
+    return runDefaultAgenCCliRoute(process.argv.slice(0, 2));
   }
   const providersCommand = parseAgenCProvidersCliArgs(argv);
   if (providersCommand !== null) {

--- a/runtime/src/bin/onboard-cli.ts
+++ b/runtime/src/bin/onboard-cli.ts
@@ -1,0 +1,254 @@
+/**
+ * `agenc onboard` — explicit entry into the first-run setup wizard
+ * (TODO task 2, Phase 0).
+ *
+ * The wizard itself is the existing first-run TUI onboarding
+ * (`src/onboarding/Onboarding.tsx`); this CLI only routes into it:
+ *
+ *   agenc onboard            launch the TUI with the wizard forced (works
+ *                            even after a completed first run)
+ *   agenc onboard --status   non-interactive report: wizard state + daemon
+ *   agenc onboard --reset    clear the completed/seen flags so the wizard
+ *                            shows again on the next interactive start
+ *
+ * The launch path is executed by bin/agenc.ts (it needs the default TUI
+ * route): it sets `AGENC_ONBOARDING=force` process-internally — see
+ * `shouldShowFirstRunOnboarding` — and never persists anything to config.
+ */
+import { resolveAgencHome } from "../config/env.js";
+import {
+  readOnboardingState,
+  resetFirstRunOnboarding,
+  type FirstRunOnboardingState,
+} from "../onboarding/projectOnboardingState.js";
+import {
+  readAgenCDaemonPid,
+  resolveAgenCDaemonPidPath,
+} from "../app-server/daemon-cli.js";
+
+export type AgenCOnboardCliCommand =
+  | { readonly kind: "launch" }
+  | { readonly kind: "status"; readonly json: boolean }
+  | { readonly kind: "reset" }
+  | { readonly kind: "help"; readonly text: string }
+  | { readonly kind: "error"; readonly message: string };
+
+export function formatAgenCOnboardCliHelpText(): string {
+  return [
+    "agenc onboard — set up AgenC: provider, key, theme, first chat",
+    "",
+    "Usage:",
+    "  agenc onboard            Launch the interactive setup wizard (re-runs",
+    "                           even after a completed first run)",
+    "  agenc onboard --status   Print wizard completion + daemon status",
+    "                           (non-interactive, for scripts)",
+    "  agenc onboard --json     With --status: emit the report as JSON",
+    "  agenc onboard --reset    Clear the wizard's completed/seen flags so it",
+    "                           shows again on the next interactive start",
+    "",
+    "Options:",
+    "  -h, --help  Show this help text",
+    "",
+    "See also: agenc doctor (environment diagnostics), agenc login (auth)",
+  ].join("\n");
+}
+
+/**
+ * Parse argv for the top-level `onboard` command. Returns null when argv is
+ * not an `onboard` invocation so the caller can fall through to other CLIs.
+ */
+export function parseAgenCOnboardCliArgs(
+  argv: readonly string[],
+): AgenCOnboardCliCommand | null {
+  if (argv[0] !== "onboard") return null;
+  let status = false;
+  let json = false;
+  let reset = false;
+  for (const arg of argv.slice(1)) {
+    if (arg === "--help" || arg === "-h") {
+      return { kind: "help", text: formatAgenCOnboardCliHelpText() };
+    }
+    if (arg === "--status") {
+      status = true;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--reset") {
+      reset = true;
+      continue;
+    }
+    return {
+      kind: "error",
+      message: `onboard command does not accept argument '${arg}'`,
+    };
+  }
+  if (reset && (status || json)) {
+    return {
+      kind: "error",
+      message: "onboard --reset cannot be combined with --status/--json",
+    };
+  }
+  if (json && !status) {
+    return { kind: "error", message: "onboard --json requires --status" };
+  }
+  if (reset) return { kind: "reset" };
+  if (status) return { kind: "status", json };
+  return { kind: "launch" };
+}
+
+export interface OnboardDaemonStatus {
+  readonly pidPath: string;
+  readonly pid: number | null;
+  readonly running: boolean;
+}
+
+export interface OnboardStatusReport {
+  readonly agencHome: string;
+  readonly onboarding: {
+    readonly completed: boolean;
+    readonly completedAt?: string;
+    readonly seenCount: number;
+    readonly selectedProvider?: string;
+    readonly selectedModel?: string;
+  };
+  readonly daemon: OnboardDaemonStatus;
+}
+
+export interface OnboardCliDeps {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly isPidRunning?: (pid: number) => boolean;
+  readonly stdout?: (line: string) => void;
+  readonly stderr?: (line: string) => void;
+}
+
+function defaultIsPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readOnboardDaemonStatus(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  isPidRunning: (pid: number) => boolean = defaultIsPidRunning,
+): Promise<OnboardDaemonStatus> {
+  const pidPath = resolveAgenCDaemonPidPath(env);
+  const pid = await readAgenCDaemonPid(pidPath);
+  return {
+    pidPath,
+    pid,
+    running: pid !== null && isPidRunning(pid),
+  };
+}
+
+export async function buildOnboardStatusReport(
+  deps: OnboardCliDeps = {},
+): Promise<OnboardStatusReport> {
+  const env = deps.env ?? process.env;
+  const agencHome = resolveAgencHome(env);
+  const state: FirstRunOnboardingState = readOnboardingState({ agencHome });
+  const daemon = await readOnboardDaemonStatus(
+    env,
+    deps.isPidRunning ?? defaultIsPidRunning,
+  );
+  return {
+    agencHome,
+    onboarding: {
+      completed: state.completed,
+      ...(state.completedAt !== undefined
+        ? { completedAt: state.completedAt }
+        : {}),
+      seenCount: state.seenCount,
+      ...(state.selectedProvider !== undefined
+        ? { selectedProvider: state.selectedProvider }
+        : {}),
+      ...(state.selectedModel !== undefined
+        ? { selectedModel: state.selectedModel }
+        : {}),
+    },
+    daemon,
+  };
+}
+
+export function formatOnboardStatusText(report: OnboardStatusReport): string {
+  const lines: string[] = [];
+  lines.push("AgenC onboarding status");
+  lines.push("");
+  lines.push(`  Home:      ${report.agencHome}`);
+  lines.push(
+    `  Wizard:    ${
+      report.onboarding.completed
+        ? `completed${report.onboarding.completedAt ? ` (${report.onboarding.completedAt})` : ""}`
+        : `not completed (seen ${report.onboarding.seenCount}x)`
+    }`,
+  );
+  if (report.onboarding.selectedProvider !== undefined) {
+    lines.push(
+      `  Provider:  ${report.onboarding.selectedProvider}${
+        report.onboarding.selectedModel !== undefined
+          ? ` (${report.onboarding.selectedModel})`
+          : ""
+      }`,
+    );
+  }
+  lines.push(
+    `  Daemon:    ${
+      report.daemon.running
+        ? `running (pid ${report.daemon.pid})`
+        : "not running"
+    }`,
+  );
+  lines.push("");
+  lines.push(
+    report.onboarding.completed
+      ? "  Re-run the wizard with: agenc onboard"
+      : "  Start the wizard with: agenc onboard",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Execute the non-launch onboard subcommands. The `launch` kind is handled by
+ * bin/agenc.ts (it needs the default TUI route). Returns the process exit
+ * code.
+ */
+export async function runAgenCOnboardCli(
+  command: Exclude<AgenCOnboardCliCommand, { kind: "launch" }>,
+  deps: OnboardCliDeps = {},
+): Promise<number> {
+  const stdout =
+    deps.stdout ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const stderr =
+    deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+  switch (command.kind) {
+    case "help":
+      stdout(command.text);
+      return 0;
+    case "error":
+      stderr(`agenc: ${command.message}`);
+      return 1;
+    case "reset": {
+      const env = deps.env ?? process.env;
+      const agencHome = resolveAgencHome(env);
+      resetFirstRunOnboarding({ agencHome });
+      stdout(
+        "Onboarding reset — the setup wizard will show on the next interactive start (or run: agenc onboard).",
+      );
+      return 0;
+    }
+    case "status": {
+      const report = await buildOnboardStatusReport(deps);
+      stdout(
+        command.json
+          ? JSON.stringify(report, null, 2)
+          : formatOnboardStatusText(report),
+      );
+      return 0;
+    }
+  }
+}

--- a/runtime/src/onboarding/projectOnboardingState.ts
+++ b/runtime/src/onboarding/projectOnboardingState.ts
@@ -188,13 +188,36 @@ export function shouldShowFirstRunOnboarding(
   options: FirstRunDisplayOptions,
 ): boolean {
   if (options.agencHome === undefined) return false;
-  if (options.hasInitialPrompt === true) return false;
   if (options.isInteractive !== true) return false;
   const flag = options.env?.AGENC_ONBOARDING?.trim().toLowerCase();
+  // `force` is set process-internally by `agenc onboard`: re-run the wizard
+  // even after completion / past the seen limit. Still requires a resolvable
+  // home and an interactive session; never persisted to config.
+  if (flag === "force") return true;
+  if (options.hasInitialPrompt === true) return false;
   if (flag === "0" || flag === "false" || flag === "off") return false;
   const state = readOnboardingState({ agencHome: options.agencHome });
   if (state.completed) return false;
   return state.seenCount < (options.maxSeenCount ?? DEFAULT_FIRST_RUN_SEEN_LIMIT);
+}
+
+/**
+ * Reset the first-run wizard flags (`agenc onboard --reset`) so the wizard
+ * shows again on the next interactive start. Keeps prior provider/model/theme
+ * selections as defaults; per-project onboarding records are untouched.
+ */
+export function resetFirstRunOnboarding(
+  options: ReadOnboardingStateOptions,
+): FirstRunOnboardingState {
+  const { completedAt: _completedAt, ...state } = readOnboardingState(options);
+  const next: FirstRunOnboardingState = {
+    ...state,
+    completed: false,
+    seenCount: 0,
+    completedStepIds: [],
+  };
+  writeOnboardingState(options, next);
+  return next;
 }
 
 export function incrementFirstRunOnboardingSeenCount(

--- a/runtime/tests/bin/onboard-cli.test.ts
+++ b/runtime/tests/bin/onboard-cli.test.ts
@@ -1,0 +1,178 @@
+// `agenc onboard` CLI (TODO task 2): parsing, status report, reset.
+//
+// The launch path (TTY-gated TUI boot with AGENC_ONBOARDING=force) is covered
+// by e2e scenario 129-onboard-command; the force semantics of
+// shouldShowFirstRunOnboarding are covered in
+// tests/onboarding/projectOnboardingState.test.ts.
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  buildOnboardStatusReport,
+  formatAgenCOnboardCliHelpText,
+  formatOnboardStatusText,
+  parseAgenCOnboardCliArgs,
+  runAgenCOnboardCli,
+} from "../../src/bin/onboard-cli.js";
+import { readOnboardingState } from "../../src/onboarding/projectOnboardingState.js";
+
+describe("parseAgenCOnboardCliArgs", () => {
+  test("returns null for non-onboard argv", () => {
+    expect(parseAgenCOnboardCliArgs([])).toBeNull();
+    expect(parseAgenCOnboardCliArgs(["doctor"])).toBeNull();
+    expect(parseAgenCOnboardCliArgs(["--print", "onboard"])).toBeNull();
+  });
+
+  test("bare onboard is the launch kind", () => {
+    expect(parseAgenCOnboardCliArgs(["onboard"])).toEqual({ kind: "launch" });
+  });
+
+  test("--status and --status --json parse", () => {
+    expect(parseAgenCOnboardCliArgs(["onboard", "--status"])).toEqual({
+      kind: "status",
+      json: false,
+    });
+    expect(
+      parseAgenCOnboardCliArgs(["onboard", "--status", "--json"]),
+    ).toEqual({ kind: "status", json: true });
+  });
+
+  test("--reset parses and rejects combination with --status", () => {
+    expect(parseAgenCOnboardCliArgs(["onboard", "--reset"])).toEqual({
+      kind: "reset",
+    });
+    expect(
+      parseAgenCOnboardCliArgs(["onboard", "--reset", "--status"]),
+    ).toMatchObject({ kind: "error" });
+  });
+
+  test("--json without --status is an error", () => {
+    expect(parseAgenCOnboardCliArgs(["onboard", "--json"])).toMatchObject({
+      kind: "error",
+    });
+  });
+
+  test("unknown argument is an error; --help wins", () => {
+    expect(parseAgenCOnboardCliArgs(["onboard", "--bogus"])).toMatchObject({
+      kind: "error",
+    });
+    expect(parseAgenCOnboardCliArgs(["onboard", "--help"])).toEqual({
+      kind: "help",
+      text: formatAgenCOnboardCliHelpText(),
+    });
+  });
+});
+
+describe("onboard status/reset against a temp home", () => {
+  let home: string;
+  let env: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-onboard-cli-"));
+    env = { AGENC_HOME: home, HOME: home };
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeState(state: Record<string, unknown>): void {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "onboarding.json"), JSON.stringify(state));
+  }
+
+  test("status report: fresh home, no daemon", async () => {
+    const report = await buildOnboardStatusReport({
+      env,
+      isPidRunning: () => true,
+    });
+    expect(report.agencHome).toBe(home);
+    expect(report.onboarding.completed).toBe(false);
+    expect(report.onboarding.seenCount).toBe(0);
+    expect(report.daemon.pid).toBeNull();
+    expect(report.daemon.running).toBe(false);
+
+    const text = formatOnboardStatusText(report);
+    expect(text).toContain("not completed (seen 0x)");
+    expect(text).toContain("Daemon:    not running");
+    expect(text).toContain("Start the wizard with: agenc onboard");
+  });
+
+  test("status report: completed state + selections surface", async () => {
+    writeState({
+      version: 1,
+      completed: true,
+      completedAt: "2026-07-01T00:00:00.000Z",
+      seenCount: 2,
+      selectedProvider: "grok",
+      selectedModel: "grok-4",
+      completedStepIds: [],
+      projects: {},
+    });
+    const report = await buildOnboardStatusReport({
+      env,
+      isPidRunning: () => false,
+    });
+    expect(report.onboarding.completed).toBe(true);
+    expect(report.onboarding.selectedProvider).toBe("grok");
+    const text = formatOnboardStatusText(report);
+    expect(text).toContain("completed (2026-07-01T00:00:00.000Z)");
+    expect(text).toContain("Provider:  grok (grok-4)");
+    expect(text).toContain("Re-run the wizard with: agenc onboard");
+  });
+
+  test("status --json emits the report as JSON via the runner", async () => {
+    const out: string[] = [];
+    const code = await runAgenCOnboardCli(
+      { kind: "status", json: true },
+      { env, stdout: (line) => out.push(line) },
+    );
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out.join("\n"));
+    expect(parsed.agencHome).toBe(home);
+    expect(parsed.onboarding.completed).toBe(false);
+  });
+
+  test("reset clears completed/seen flags but keeps selections", async () => {
+    writeState({
+      version: 1,
+      completed: true,
+      completedAt: "2026-07-01T00:00:00.000Z",
+      seenCount: 4,
+      selectedProvider: "grok",
+      selectedModel: "grok-4",
+      completedStepIds: ["preflight", "theme"],
+      projects: {},
+    });
+    const out: string[] = [];
+    const code = await runAgenCOnboardCli(
+      { kind: "reset" },
+      { env, stdout: (line) => out.push(line) },
+    );
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("Onboarding reset");
+
+    const state = readOnboardingState({ agencHome: home });
+    expect(state.completed).toBe(false);
+    expect(state.seenCount).toBe(0);
+    expect(state.completedStepIds).toEqual([]);
+    expect(state.completedAt).toBeUndefined();
+    expect(state.selectedProvider).toBe("grok");
+    expect(state.selectedModel).toBe("grok-4");
+
+    const raw = readFileSync(join(home, "onboarding.json"), "utf8");
+    expect(raw).toContain("\"completed\": false");
+  });
+
+  test("error kind writes to stderr and exits 1", async () => {
+    const err: string[] = [];
+    const code = await runAgenCOnboardCli(
+      { kind: "error", message: "nope" },
+      { stderr: (line) => err.push(line) },
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("nope");
+  });
+});

--- a/runtime/tests/onboarding/projectOnboardingState.test.ts
+++ b/runtime/tests/onboarding/projectOnboardingState.test.ts
@@ -10,6 +10,7 @@ import {
   maybeMarkProjectOnboardingComplete,
   markFirstRunOnboardingComplete,
   readOnboardingState,
+  resetFirstRunOnboarding,
   shouldShowFirstRunOnboarding,
   shouldShowProjectOnboarding,
 } from "./projectOnboardingState.js";
@@ -78,6 +79,77 @@ describe("first-run onboarding display state", () => {
           isInteractive: true,
         }),
       ).toBe(false);
+    });
+  });
+
+  test("AGENC_ONBOARDING=force re-shows the wizard after completion (agenc onboard)", () => {
+    withTempDir("agenc-onboarding-state-", (agencHome) => {
+      markFirstRunOnboardingComplete({
+        agencHome,
+        now: new Date("2026-01-03T00:00:00.000Z"),
+      });
+      // Completed state suppresses the wizard normally...
+      expect(
+        shouldShowFirstRunOnboarding({
+          agencHome,
+          env: {},
+          isInteractive: true,
+        }),
+      ).toBe(false);
+      // ...force bypasses completion, the seen limit, and an initial prompt.
+      expect(
+        shouldShowFirstRunOnboarding({
+          agencHome,
+          env: { AGENC_ONBOARDING: "force" },
+          isInteractive: true,
+          hasInitialPrompt: true,
+        }),
+      ).toBe(true);
+      // Force never overrides the interactive/home requirements.
+      expect(
+        shouldShowFirstRunOnboarding({
+          agencHome,
+          env: { AGENC_ONBOARDING: "force" },
+          isInteractive: false,
+        }),
+      ).toBe(false);
+      expect(
+        shouldShowFirstRunOnboarding({
+          env: { AGENC_ONBOARDING: "force" },
+          isInteractive: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  test("resetFirstRunOnboarding clears flags but keeps selections", () => {
+    withTempDir("agenc-onboarding-state-", (agencHome) => {
+      incrementFirstRunOnboardingSeenCount({ agencHome });
+      markFirstRunOnboardingComplete({
+        agencHome,
+        selectedProvider: "grok",
+        selectedModel: "grok-4.3",
+        selectedTheme: "dark",
+        completedStepIds: ["preflight", "theme"],
+        now: new Date("2026-01-03T00:00:00.000Z"),
+      });
+
+      resetFirstRunOnboarding({ agencHome });
+
+      const state = readOnboardingState({ agencHome });
+      expect(state.completed).toBe(false);
+      expect(state.completedAt).toBeUndefined();
+      expect(state.seenCount).toBe(0);
+      expect(state.completedStepIds).toEqual([]);
+      expect(state.selectedProvider).toBe("grok");
+      expect(state.selectedTheme).toBe("dark");
+      expect(
+        shouldShowFirstRunOnboarding({
+          agencHome,
+          env: {},
+          isInteractive: true,
+        }),
+      ).toBe(true);
     });
   });
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -301,5 +301,5 @@ fi
 # --- done --------------------------------------------------------------------
 
 log "install complete"
-printf '\n  AgenC %s installed.\n\n  Next steps:\n    %s              # start the interactive TUI\n    %s doctor       # verify the installation\n    %s daemon status\n\n' \
+printf '\n  AgenC %s installed.\n\n  Next steps:\n    %s onboard      # guided setup: provider, key, theme, first chat\n    %s doctor       # verify the installation\n    %s daemon status\n\n' \
   "$VERSION" "$WRAPPER" "$WRAPPER" "$WRAPPER"


### PR DESCRIPTION
Parity backlog task 2 (Phase 0 — onboarding).

## What
The first-run wizard already existed (`src/onboarding/Onboarding.tsx`); this makes it an explicit, re-runnable command:

- `agenc onboard` — TTY-gated launch: prints a daemon status line, sets `AGENC_ONBOARDING=force` **process-internally** (never persisted), boots the normal TUI route; the wizard shows even after a completed first run.
- `agenc onboard --status [--json]` — non-interactive report (wizard completion, provider/model selections, daemon pid liveness) for scripts.
- `agenc onboard --reset` — clears completed/seen flags, keeps prior selections as defaults.
- `shouldShowFirstRunOnboarding`: `force` bypasses completion/seen-limit/initial-prompt but still requires interactive + resolvable home.
- install.sh next-steps now points at `agenc onboard`; help usage/commands/topic wired.

## Tests
- 11 unit tests: parse matrix, status/reset against temp homes, force semantics (**revert-proven**: deleting the force branch turns the test red).
- e2e scenario 129: `agenc onboard` drives all 7 wizard steps with the mock keyless provider to a completed first model turn, then asserts `onboarding.json` records `completed: true`. Steps use input→bytes-idle barriers (wizard repaints are cell diffs that split words, so phrase anchors are only used on the first full paint).

## Gates
build ✓ typecheck ✓ vitest 14040 ✓ bun ✓ tui-runtime-startup ✓ agent-surface-contract ✓ scenario 129 PASS

Exit-path safety: the launch path writes nothing; `--reset` touches only `onboarding.json`; wizard config behavior unchanged.