### PR TITLE
feat(cli): agenc security audit --fix — exposure/blast-radius audit (task 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,11 @@ source.
 
 ## Security
 
+Run `agenc security audit` (add `--fix` for safe permission fixes) to check
+daemon exposure, AgenC-state file permissions, config integrity, and
+permission-mode blast radius; it exits non-zero on critical findings and warns
+automatically on `agenc daemon start`.
+
 Shell execution and file mutation flow through a mode-based permission layer; an
 opt-in OS sandbox confines shell commands at the kernel level (bubblewrap /
 Landlock on Linux, Seatbelt on macOS). Mutating tools are guarded — file edits

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -153,6 +153,13 @@ import {
   runAgenCOnboardCli,
 } from "./onboard-cli.js";
 import {
+  buildSecurityAuditReport,
+  formatAgenCSecurityCliHelpText,
+  formatSecurityAuditSummaryLine,
+  parseAgenCSecurityCliArgs,
+  runAgenCSecurityCli,
+} from "./security-cli.js";
+import {
   formatAgenCInitCliHelpText,
   parseAgenCInitCliArgs,
   runAgenCInitCli,
@@ -307,6 +314,7 @@ export function formatCliHelpText(): string {
     "       agenc -p|--print [options] [PROMPT]",
     "       agenc help [command]",
     "       agenc onboard [--status [--json] | --reset]",
+    "       agenc security audit [--json] [--fix]",
     "       agenc init [--force]",
     "       agenc <login|logout|whoami>",
     "       agenc providers [--json] [--no-local-check]",
@@ -327,6 +335,7 @@ export function formatCliHelpText(): string {
     "",
     "Commands:",
     "  onboard                                 Set up AgenC: provider, key, theme, first chat",
+    "  security                                Audit local exposure; --fix applies safe fixes",
     "  init                                    Create .agenc/config.json and AGENC.md",
     "  login | logout | whoami                  Manage the configured auth session",
     "  providers                               Check provider readiness and local health",
@@ -403,6 +412,8 @@ export function formatCliHelpTopicText(topic: string): string | null {
       return formatAgenCDoctorCliHelpText();
     case "onboard":
       return formatAgenCOnboardCliHelpText();
+    case "security":
+      return formatAgenCSecurityCliHelpText();
     case "permissions":
       return formatAgenCPermissionsCliHelpText();
     case "plugin":
@@ -3931,6 +3942,25 @@ export async function main(): Promise<number> {
   }
   const daemonCommand = parseAgenCDaemonCliArgs(argv);
   if (daemonCommand !== null) {
+    if (
+      daemonCommand.kind === "command" &&
+      (daemonCommand.action === "start" ||
+        daemonCommand.action === "run" ||
+        daemonCommand.action === "restart")
+    ) {
+      // Warn (never block) when starting the daemon with critical audit
+      // findings — exposure misconfigurations matter most at startup.
+      try {
+        const audit = await buildSecurityAuditReport({ env: process.env });
+        if (audit.criticalCount > 0) {
+          process.stderr.write(
+            `agenc: WARNING — ${formatSecurityAuditSummaryLine(audit)}\n`,
+          );
+        }
+      } catch {
+        // Advisory only.
+      }
+    }
     return runAgenCDaemonCli(daemonCommand);
   }
   const remoteCommand = parseAgenCRemoteCliArgs(argv);
@@ -4017,10 +4047,24 @@ export async function main(): Promise<number> {
         ? `agenc: daemon running (pid ${daemonStatus.pid})\n`
         : "agenc: daemon not running — it starts automatically with the session\n",
     );
+    // Onboarding is the moment defaults get set: surface the audit posture
+    // up front (read-only; never blocks the wizard).
+    try {
+      const audit = await buildSecurityAuditReport({ env: process.env });
+      process.stderr.write(
+        `agenc: ${formatSecurityAuditSummaryLine(audit)}\n`,
+      );
+    } catch {
+      // Audit is advisory here; the wizard must not be blocked by it.
+    }
     // Force the first-run wizard for this process only (never persisted);
     // consumed by shouldShowFirstRunOnboarding via the TUI's env snapshot.
     process.env.AGENC_ONBOARDING = "force";
     return runDefaultAgenCCliRoute(process.argv.slice(0, 2));
+  }
+  const securityCommand = parseAgenCSecurityCliArgs(argv);
+  if (securityCommand !== null) {
+    return runAgenCSecurityCli(securityCommand);
   }
   const providersCommand = parseAgenCProvidersCliArgs(argv);
   if (providersCommand !== null) {

--- a/runtime/src/bin/security-cli.ts
+++ b/runtime/src/bin/security-cli.ts
@@ -1,0 +1,478 @@
+/**
+ * `agenc security audit [--json] [--fix]` — local exposure and blast-radius
+ * audit with safe autofixes (TODO task 3, Phase 0).
+ *
+ * Fail-closed philosophy: the command exits 1 while any critical finding
+ * remains (after `--fix` when requested), so scripts and provisioning can
+ * gate on it. `--fix` applies only reversible, owner-scoped filesystem
+ * permission fixes; it never edits config or environment.
+ *
+ * v1 checks:
+ *   daemon-ws-exposure       non-loopback daemon WebSocket overrides (env)
+ *   home-dir-perms           $AGENC_HOME group/world access        [fixable]
+ *   sensitive-file-perms     auth.json/daemon.cookie/config/vaults [fixable]
+ *   config-integrity         config.toml unparseable (falls back to defaults)
+ *   default-permission-mode  configured approval-bypass default    (warn)
+ *
+ * The check registry is deliberately extensible: channel DM policies
+ * (task 6), webhook token posture (task 17), and skill/plugin provenance
+ * (task 26) land here as those surfaces ship.
+ */
+import { chmodSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveAgencHome } from "../config/env.js";
+import { loadConfig } from "../config/loader.js";
+
+export type SecuritySeverity = "ok" | "warn" | "critical";
+
+export interface SecurityFinding {
+  readonly id: string;
+  readonly title: string;
+  readonly severity: SecuritySeverity;
+  readonly detail: string;
+  readonly remediation?: string;
+  readonly fixable: boolean;
+  /** Present only when --fix ran and this finding was fixable. */
+  readonly fixed?: boolean;
+}
+
+export interface SecurityAuditContext {
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly agencHome: string;
+  readonly configExists: boolean;
+  readonly configParseError?: string;
+  readonly defaultPermissionMode?: string;
+  readonly applyFixes: boolean;
+}
+
+type SecurityCheck = (ctx: SecurityAuditContext) => SecurityFinding[];
+
+const GROUP_WORLD_BITS = 0o077;
+
+function modeOf(path: string): { mode: number; isDirectory: boolean } | null {
+  try {
+    const stat = statSync(path);
+    return { mode: stat.mode & 0o777, isDirectory: stat.isDirectory() };
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackHostValue(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.")
+  );
+}
+
+const checkDaemonWsExposure: SecurityCheck = (ctx) => {
+  const allow = ctx.env.AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK?.trim()
+    .toLowerCase();
+  const host = ctx.env.AGENC_DAEMON_WEBSOCKET_HOST?.trim();
+  if (allow === "1" || allow === "true") {
+    return [
+      {
+        id: "daemon-ws-exposure",
+        title: "Daemon WebSocket non-loopback override is enabled",
+        severity: "critical",
+        detail:
+          "AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK is set: the daemon may accept WebSocket connections from other hosts. Exposed agent daemons are the single most exploited misconfiguration in this product category.",
+        remediation:
+          "Unset AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK; for remote access prefer a tailnet or SSH tunnel to a loopback bind.",
+        fixable: false,
+      },
+    ];
+  }
+  if (host !== undefined && host.length > 0 && !isLoopbackHostValue(host)) {
+    return [
+      {
+        id: "daemon-ws-exposure",
+        title: "Daemon WebSocket host is not loopback",
+        severity: "critical",
+        detail: `AGENC_DAEMON_WEBSOCKET_HOST=${host} requests a non-loopback bind. The daemon refuses it without the explicit override, but the environment expresses exposure intent.`,
+        remediation:
+          "Unset AGENC_DAEMON_WEBSOCKET_HOST or point it at 127.0.0.1/::1.",
+        fixable: false,
+      },
+    ];
+  }
+  return [
+    {
+      id: "daemon-ws-exposure",
+      title: "Daemon WebSocket bound to loopback",
+      severity: "ok",
+      detail: "No non-loopback override is set; remote origins are rejected.",
+      fixable: false,
+    },
+  ];
+};
+
+const checkHomeDirPerms: SecurityCheck = (ctx) => {
+  const stat = modeOf(ctx.agencHome);
+  if (stat === null) {
+    return [
+      {
+        id: "home-dir-perms",
+        title: "AgenC home does not exist yet",
+        severity: "ok",
+        detail: `${ctx.agencHome} is absent — it is created owner-only (0700) on first use.`,
+        fixable: false,
+      },
+    ];
+  }
+  if ((stat.mode & GROUP_WORLD_BITS) === 0) {
+    return [
+      {
+        id: "home-dir-perms",
+        title: "AgenC home permissions are owner-only",
+        severity: "ok",
+        detail: `${ctx.agencHome} mode ${stat.mode.toString(8)}`,
+        fixable: false,
+      },
+    ];
+  }
+  let fixed = false;
+  if (ctx.applyFixes) {
+    try {
+      chmodSync(ctx.agencHome, 0o700);
+      fixed = true;
+    } catch {
+      fixed = false;
+    }
+  }
+  return [
+    {
+      id: "home-dir-perms",
+      title: "AgenC home is group/world accessible",
+      severity: "critical",
+      detail: `${ctx.agencHome} mode ${stat.mode.toString(8)} grants access beyond the owner. Auth tokens, the daemon cookie, and session transcripts live here.`,
+      remediation: `chmod 700 ${ctx.agencHome}`,
+      fixable: true,
+      ...(ctx.applyFixes ? { fixed } : {}),
+    },
+  ];
+};
+
+const KNOWN_SENSITIVE_ENTRIES = [
+  "auth.json",
+  "daemon.cookie",
+  "config.toml",
+  "onboarding.json",
+  "trusted-projects.json",
+  "credentials",
+];
+
+const checkSensitiveFilePerms: SecurityCheck = (ctx) => {
+  const candidates = new Set(KNOWN_SENSITIVE_ENTRIES);
+  try {
+    for (const entry of readdirSync(ctx.agencHome)) {
+      if (entry.endsWith(".vault.json")) candidates.add(entry);
+    }
+  } catch {
+    // Absent home is already reported by home-dir-perms.
+  }
+  const findings: SecurityFinding[] = [];
+  for (const name of [...candidates].sort()) {
+    const path = join(ctx.agencHome, name);
+    const stat = modeOf(path);
+    if (stat === null) continue;
+    if ((stat.mode & GROUP_WORLD_BITS) === 0) continue;
+    let fixed = false;
+    if (ctx.applyFixes) {
+      try {
+        chmodSync(path, stat.isDirectory ? 0o700 : 0o600);
+        fixed = true;
+      } catch {
+        fixed = false;
+      }
+    }
+    findings.push({
+      id: `sensitive-file-perms:${name}`,
+      title: `${name} is group/world accessible`,
+      severity: "critical",
+      detail: `${path} mode ${stat.mode.toString(8)}`,
+      remediation: `chmod ${stat.isDirectory ? 700 : 600} ${path}`,
+      fixable: true,
+      ...(ctx.applyFixes ? { fixed } : {}),
+    });
+  }
+  if (findings.length === 0) {
+    findings.push({
+      id: "sensitive-file-perms",
+      title: "Sensitive files are owner-only",
+      severity: "ok",
+      detail:
+        "auth.json, daemon.cookie, config.toml, trusted-projects.json, vaults: no group/world bits.",
+      fixable: false,
+    });
+  }
+  return findings;
+};
+
+const checkConfigIntegrity: SecurityCheck = (ctx) => {
+  if (ctx.configParseError !== undefined) {
+    return [
+      {
+        id: "config-integrity",
+        title: "config.toml is unparseable",
+        severity: "warn",
+        detail: `The runtime silently falls back to defaults, which can mask a hardened configuration you believe is active: ${ctx.configParseError}`,
+        remediation: "Fix or regenerate config.toml (agenc config validate).",
+        fixable: false,
+      },
+    ];
+  }
+  return [
+    {
+      id: "config-integrity",
+      title: ctx.configExists ? "config.toml parses cleanly" : "No config.toml (defaults active)",
+      severity: "ok",
+      detail: ctx.configExists
+        ? "Configured values are what the runtime actually uses."
+        : "Built-in defaults are in effect.",
+      fixable: false,
+    },
+  ];
+};
+
+const checkDefaultPermissionMode: SecurityCheck = (ctx) => {
+  const mode = ctx.defaultPermissionMode;
+  if (mode === "bypassPermissions" || mode === "dontAsk") {
+    return [
+      {
+        id: "default-permission-mode",
+        title: `Configured default permission mode is ${mode}`,
+        severity: "warn",
+        detail:
+          "Every session starts with tool approvals bypassed. Combined with untrusted inputs (web content, task text) this is the largest configured blast radius on this machine.",
+        remediation:
+          "Remove permissions.default_mode from config.toml and opt in per session (--yolo) instead.",
+        fixable: false,
+      },
+    ];
+  }
+  return [
+    {
+      id: "default-permission-mode",
+      title: `Default permission mode: ${mode ?? "default"}`,
+      severity: "ok",
+      detail: "Sessions start with approval prompts enabled.",
+      fixable: false,
+    },
+  ];
+};
+
+export const SECURITY_CHECKS: readonly SecurityCheck[] = [
+  checkDaemonWsExposure,
+  checkHomeDirPerms,
+  checkSensitiveFilePerms,
+  checkConfigIntegrity,
+  checkDefaultPermissionMode,
+];
+
+export function runSecurityChecks(
+  ctx: SecurityAuditContext,
+): readonly SecurityFinding[] {
+  return SECURITY_CHECKS.flatMap((check) => check(ctx));
+}
+
+export interface SecurityAuditReport {
+  readonly agencHome: string;
+  readonly findings: readonly SecurityFinding[];
+  readonly criticalCount: number;
+  readonly warnCount: number;
+  readonly fixedCount: number;
+}
+
+export interface SecurityAuditOptions {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly applyFixes?: boolean;
+}
+
+export async function buildSecurityAuditReport(
+  options: SecurityAuditOptions = {},
+): Promise<SecurityAuditReport> {
+  const env = options.env ?? process.env;
+  const agencHome = resolveAgencHome(env);
+  const loaded = await loadConfig({ home: agencHome, onWarn: () => {} });
+  const ctx: SecurityAuditContext = {
+    env,
+    agencHome,
+    configExists: loaded.exists,
+    ...(loaded.parseError !== undefined
+      ? { configParseError: loaded.parseError }
+      : {}),
+    ...(loaded.config.permissions?.default_mode !== undefined ||
+    loaded.config.permissions?.defaultMode !== undefined
+      ? {
+          defaultPermissionMode:
+            loaded.config.permissions?.default_mode ??
+            loaded.config.permissions?.defaultMode,
+        }
+      : {}),
+    applyFixes: options.applyFixes === true,
+  };
+  const findings = runSecurityChecks(ctx);
+  return {
+    agencHome,
+    findings,
+    criticalCount: findings.filter(
+      (f) => f.severity === "critical" && f.fixed !== true,
+    ).length,
+    warnCount: findings.filter((f) => f.severity === "warn").length,
+    fixedCount: findings.filter((f) => f.fixed === true).length,
+  };
+}
+
+export function securityAuditExitCode(report: SecurityAuditReport): number {
+  return report.criticalCount > 0 ? 1 : 0;
+}
+
+const SEVERITY_GLYPH: Record<SecuritySeverity, string> = {
+  ok: "✓",
+  warn: "⚠",
+  critical: "✗",
+};
+
+export function formatSecurityAuditText(report: SecurityAuditReport): string {
+  const lines: string[] = [];
+  lines.push("AgenC security audit");
+  lines.push("");
+  lines.push(`  Home: ${report.agencHome}`);
+  lines.push("");
+  for (const finding of report.findings) {
+    const glyph =
+      finding.fixed === true ? "✓" : SEVERITY_GLYPH[finding.severity];
+    lines.push(
+      `  ${glyph} ${finding.title}${finding.fixed === true ? " (fixed)" : ""}`,
+    );
+    if (finding.severity !== "ok" && finding.fixed !== true) {
+      lines.push(`      ${finding.detail}`);
+      if (finding.remediation !== undefined) {
+        lines.push(`      fix: ${finding.remediation}`);
+      }
+    }
+  }
+  lines.push("");
+  if (report.criticalCount > 0) {
+    lines.push(
+      `  ${report.criticalCount} critical finding(s).` +
+        ` Re-run with --fix to apply safe permission fixes; env/config findings need the listed manual fix.`,
+    );
+  } else if (report.warnCount > 0) {
+    lines.push(`  No critical findings (${report.warnCount} warning(s)).`);
+  } else {
+    lines.push("  All checks passed.");
+  }
+  return lines.join("\n");
+}
+
+export function formatSecurityAuditSummaryLine(
+  report: SecurityAuditReport,
+): string {
+  if (report.criticalCount > 0) {
+    return `security audit: ${report.criticalCount} CRITICAL finding(s) — run 'agenc security audit' for details`;
+  }
+  if (report.warnCount > 0) {
+    return `security audit: ok (${report.warnCount} warning(s) — 'agenc security audit')`;
+  }
+  return "security audit: all checks passed";
+}
+
+export type AgenCSecurityCliCommand =
+  | { readonly kind: "audit"; readonly json: boolean; readonly fix: boolean }
+  | { readonly kind: "help"; readonly text: string }
+  | { readonly kind: "error"; readonly message: string };
+
+export function formatAgenCSecurityCliHelpText(): string {
+  return [
+    "agenc security — audit local exposure and blast radius",
+    "",
+    "Usage:",
+    "  agenc security audit          Check daemon exposure, file permissions,",
+    "                                config integrity, and permission-mode",
+    "                                blast radius; exit 1 on critical findings",
+    "  agenc security audit --fix    Also apply safe permission fixes",
+    "                                (chmod 700/600 on AgenC state; never edits",
+    "                                config or environment)",
+    "  agenc security audit --json   Emit the report as JSON",
+    "",
+    "Options:",
+    "  -h, --help  Show this help text",
+  ].join("\n");
+}
+
+export function parseAgenCSecurityCliArgs(
+  argv: readonly string[],
+): AgenCSecurityCliCommand | null {
+  if (argv[0] !== "security") return null;
+  const rest = argv.slice(1);
+  if (rest[0] === "--help" || rest[0] === "-h" || rest.length === 0) {
+    return { kind: "help", text: formatAgenCSecurityCliHelpText() };
+  }
+  if (rest[0] !== "audit") {
+    return {
+      kind: "error",
+      message: `unknown security subcommand '${rest[0]}' (expected: audit)`,
+    };
+  }
+  let json = false;
+  let fix = false;
+  for (const arg of rest.slice(1)) {
+    if (arg === "--help" || arg === "-h") {
+      return { kind: "help", text: formatAgenCSecurityCliHelpText() };
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--fix") {
+      fix = true;
+      continue;
+    }
+    return {
+      kind: "error",
+      message: `security audit does not accept argument '${arg}'`,
+    };
+  }
+  return { kind: "audit", json, fix };
+}
+
+export interface SecurityCliDeps {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly stdout?: (line: string) => void;
+  readonly stderr?: (line: string) => void;
+}
+
+export async function runAgenCSecurityCli(
+  command: AgenCSecurityCliCommand,
+  deps: SecurityCliDeps = {},
+): Promise<number> {
+  const stdout =
+    deps.stdout ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const stderr =
+    deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+  switch (command.kind) {
+    case "help":
+      stdout(command.text);
+      return 0;
+    case "error":
+      stderr(`agenc: ${command.message}`);
+      return 1;
+    case "audit": {
+      const report = await buildSecurityAuditReport({
+        ...(deps.env !== undefined ? { env: deps.env } : {}),
+        applyFixes: command.fix,
+      });
+      stdout(
+        command.json
+          ? JSON.stringify(report, null, 2)
+          : formatSecurityAuditText(report),
+      );
+      return securityAuditExitCode(report);
+    }
+  }
+}

--- a/runtime/tests/bin/security-cli.test.ts
+++ b/runtime/tests/bin/security-cli.test.ts
@@ -1,0 +1,195 @@
+// `agenc security audit` (TODO task 3): parse matrix, seeded
+// misconfigurations, --fix remediation, exit codes.
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  buildSecurityAuditReport,
+  formatAgenCSecurityCliHelpText,
+  formatSecurityAuditSummaryLine,
+  formatSecurityAuditText,
+  parseAgenCSecurityCliArgs,
+  runAgenCSecurityCli,
+  securityAuditExitCode,
+} from "../../src/bin/security-cli.js";
+
+describe("parseAgenCSecurityCliArgs", () => {
+  test("returns null for non-security argv", () => {
+    expect(parseAgenCSecurityCliArgs([])).toBeNull();
+    expect(parseAgenCSecurityCliArgs(["doctor"])).toBeNull();
+  });
+
+  test("bare security shows help; audit parses with flags", () => {
+    expect(parseAgenCSecurityCliArgs(["security"])).toEqual({
+      kind: "help",
+      text: formatAgenCSecurityCliHelpText(),
+    });
+    expect(parseAgenCSecurityCliArgs(["security", "audit"])).toEqual({
+      kind: "audit",
+      json: false,
+      fix: false,
+    });
+    expect(
+      parseAgenCSecurityCliArgs(["security", "audit", "--json", "--fix"]),
+    ).toEqual({ kind: "audit", json: true, fix: true });
+  });
+
+  test("unknown subcommand/flag is an error", () => {
+    expect(parseAgenCSecurityCliArgs(["security", "harden"])).toMatchObject({
+      kind: "error",
+    });
+    expect(
+      parseAgenCSecurityCliArgs(["security", "audit", "--force"]),
+    ).toMatchObject({ kind: "error" });
+  });
+});
+
+describe("security audit against a temp home", () => {
+  let home: string;
+  let env: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-security-audit-"));
+    chmodSync(home, 0o700);
+    env = { AGENC_HOME: home, HOME: home };
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("clean home: all ok, exit 0", async () => {
+    const report = await buildSecurityAuditReport({ env });
+    expect(report.criticalCount).toBe(0);
+    expect(report.warnCount).toBe(0);
+    expect(securityAuditExitCode(report)).toBe(0);
+    expect(formatSecurityAuditText(report)).toContain("All checks passed.");
+    expect(formatSecurityAuditSummaryLine(report)).toBe(
+      "security audit: all checks passed",
+    );
+  });
+
+  test("world-accessible home is critical; --fix chmods to 700", async () => {
+    chmodSync(home, 0o755);
+    const before = await buildSecurityAuditReport({ env });
+    expect(
+      before.findings.find((f) => f.id === "home-dir-perms")?.severity,
+    ).toBe("critical");
+    expect(securityAuditExitCode(before)).toBe(1);
+    expect(formatSecurityAuditSummaryLine(before)).toContain("CRITICAL");
+
+    const fixed = await buildSecurityAuditReport({ env, applyFixes: true });
+    const finding = fixed.findings.find((f) => f.id === "home-dir-perms");
+    expect(finding?.fixed).toBe(true);
+    expect(securityAuditExitCode(fixed)).toBe(0);
+    expect(statSync(home).mode & 0o777).toBe(0o700);
+  });
+
+  test("group/world-readable auth.json is critical; --fix chmods to 600", async () => {
+    writeFileSync(join(home, "auth.json"), "{}");
+    chmodSync(join(home, "auth.json"), 0o644);
+    const before = await buildSecurityAuditReport({ env });
+    expect(
+      before.findings.find((f) => f.id === "sensitive-file-perms:auth.json")
+        ?.severity,
+    ).toBe("critical");
+    expect(securityAuditExitCode(before)).toBe(1);
+
+    const fixed = await buildSecurityAuditReport({ env, applyFixes: true });
+    expect(
+      fixed.findings.find((f) => f.id === "sensitive-file-perms:auth.json")
+        ?.fixed,
+    ).toBe(true);
+    expect(securityAuditExitCode(fixed)).toBe(0);
+    expect(statSync(join(home, "auth.json")).mode & 0o777).toBe(0o600);
+  });
+
+  test("exposed credentials dir and vault files are caught", async () => {
+    mkdirSync(join(home, "credentials"));
+    chmodSync(join(home, "credentials"), 0o755);
+    writeFileSync(join(home, "wallet.vault.json"), "{}");
+    chmodSync(join(home, "wallet.vault.json"), 0o604);
+    const report = await buildSecurityAuditReport({ env });
+    const ids = report.findings.map((f) => f.id);
+    expect(ids).toContain("sensitive-file-perms:credentials");
+    expect(ids).toContain("sensitive-file-perms:wallet.vault.json");
+    expect(report.criticalCount).toBe(2);
+
+    const fixed = await buildSecurityAuditReport({ env, applyFixes: true });
+    expect(fixed.criticalCount).toBe(0);
+    expect(statSync(join(home, "credentials")).mode & 0o777).toBe(0o700);
+    expect(statSync(join(home, "wallet.vault.json")).mode & 0o777).toBe(0o600);
+  });
+
+  test("non-loopback daemon override is critical and NOT fixable by --fix", async () => {
+    const report = await buildSecurityAuditReport({
+      env: { ...env, AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK: "1" },
+      applyFixes: true,
+    });
+    const finding = report.findings.find((f) => f.id === "daemon-ws-exposure");
+    expect(finding?.severity).toBe("critical");
+    expect(finding?.fixable).toBe(false);
+    expect(finding?.fixed).toBeUndefined();
+    expect(securityAuditExitCode(report)).toBe(1);
+  });
+
+  test("non-loopback host env without the override is still flagged", async () => {
+    const report = await buildSecurityAuditReport({
+      env: { ...env, AGENC_DAEMON_WEBSOCKET_HOST: "0.0.0.0" },
+    });
+    expect(
+      report.findings.find((f) => f.id === "daemon-ws-exposure")?.severity,
+    ).toBe("critical");
+  });
+
+  test("bypassPermissions default mode is a warning, not critical", async () => {
+    writeFileSync(
+      join(home, "config.toml"),
+      '[permissions]\ndefault_mode = "bypassPermissions"\n',
+      { mode: 0o600 },
+    );
+    const report = await buildSecurityAuditReport({ env });
+    const finding = report.findings.find(
+      (f) => f.id === "default-permission-mode",
+    );
+    expect(finding?.severity).toBe("warn");
+    expect(securityAuditExitCode(report)).toBe(0);
+    expect(formatSecurityAuditSummaryLine(report)).toContain("warning");
+  });
+
+  test("unparseable config.toml surfaces as a warning", async () => {
+    writeFileSync(join(home, "config.toml"), "not [ valid toml ===", {
+      mode: 0o600,
+    });
+    const report = await buildSecurityAuditReport({ env });
+    expect(
+      report.findings.find((f) => f.id === "config-integrity")?.severity,
+    ).toBe("warn");
+  });
+
+  test("runner: audit prints text and returns the exit code", async () => {
+    chmodSync(home, 0o755);
+    const out: string[] = [];
+    const code = await runAgenCSecurityCli(
+      { kind: "audit", json: false, fix: false },
+      { env, stdout: (line) => out.push(line) },
+    );
+    expect(code).toBe(1);
+    expect(out.join("\n")).toContain("group/world accessible");
+
+    const fixedCode = await runAgenCSecurityCli(
+      { kind: "audit", json: true, fix: true },
+      { env, stdout: (line) => out.push(line) },
+    );
+    expect(fixedCode).toBe(0);
+  });
+});

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -301,5 +301,5 @@ fi
 # --- done --------------------------------------------------------------------
 
 log "install complete"
-printf '\n  AgenC %s installed.\n\n  Next steps:\n    %s onboard      # guided setup: provider, key, theme, first chat\n    %s doctor       # verify the installation\n    %s daemon status\n\n' \
+printf '\n  AgenC %s installed.\n\n  Next steps:\n    %s onboard              # guided setup: provider, key, theme, first chat\n    %s security audit       # check exposure + permissions (--fix for safe fixes)\n    %s daemon status\n\n' \
   "$VERSION" "$WRAPPER" "$WRAPPER" "$WRAPPER"


### PR DESCRIPTION
Parity backlog task 3 (Phase 0 — onboarding/safety).

## What
`agenc security audit [--json] [--fix]` — fail-closed local security posture check, extensible registry (channel DM policies, webhook tokens, and skill provenance join here in Phases 1/5):

1. **daemon-ws-exposure**: `AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK` / non-loopback host env → critical (the exposed-gateway disaster class)
2. **home-dir-perms**: $AGENC_HOME group/world bits → critical, `--fix` chmod 700
3. **sensitive-file-perms**: auth.json, daemon.cookie, config.toml, trusted-projects.json, credentials/, *.vault.json → critical, `--fix` chmod 600/700
4. **config-integrity**: unparseable config.toml (runtime silently falls back to defaults) → warn
5. **default-permission-mode**: configured `permissions.default_mode` bypass → warn

`--fix` applies only owner-scoped chmods; never touches config or environment. Exit 1 while criticals remain, so provisioning can gate on it. Integration: `agenc onboard` prints the audit summary line before the wizard; `agenc daemon start|run|restart` warns (never blocks) on criticals.

## Verification
- 12 tests: parse matrix, seeded misconfigurations, real chmod assertions, exit codes.
- **Revert-proven**: neutering the exit gate turns 4 tests red; claiming fixed without chmod turns the mode-assertion test red.
- **Live smoke on this machine found a real finding** (config.toml mode 660, exit 1) — left unfixed for the owner to decide.
- Fresh-home default: all checks pass (tested).

## Gates
build ✓ typecheck ✓ vitest 14052 ✓ bun ✓ tui-runtime-startup ✓ agent-surface-contract ✓