### PR TITLE
feat(packaging): docker image + compose, homebrew template, VPS guide (task 4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the Docker build context small and hermetic: npm ci + npm run build
+# inside the image produce everything; host artifacts must not leak in.
+.git
+.worktrees
+node_modules
+**/node_modules
+runtime/dist
+packages/agenc/release-artifacts
+packages/agenc/release
+logs
+*.log
+TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ obj/
 !runtime/eval/tasks/*/solution/*.json
 id.json
 deploy/
+# deploy/ guards deployment state/keys; documentation is exempt.
+!docs/deploy/
 keys/
 
 # Testing

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -1,0 +1,55 @@
+# Running the AgenC daemon on a VPS
+
+A $5-class VPS (Hetzner CX11, DigitalOcean basic, Railway container) runs the
+daemon fine: the heavy lifting is provider-side, the daemon is orchestration.
+Two supported shapes:
+
+## Shape 1 — bare VPS with the one-line installer (recommended)
+
+```bash
+# as a normal user (never root) on Ubuntu 24.04 / Debian 12:
+curl -fsSL <installer-url>/install.sh | sh     # verifies sha256, installs the
+                                               # systemd user service
+agenc onboard                                  # provider + key + first chat
+agenc security audit --fix                     # must be green before you leave
+loginctl enable-linger "$USER"                 # keep the user service running
+                                               # after logout
+```
+
+Remote access: **do not** publish the daemon port. The daemon binds loopback
+and refuses non-loopback WebSocket binds without an explicit override; keep it
+that way and reach it via:
+
+- **Tailscale (preferred):** `tailscale up`, then connect clients over the
+  tailnet to the loopback-forwarded port (`tailscale serve` or an SSH tunnel).
+- **SSH tunnel:** `ssh -N -L 18789:127.0.0.1:<port> user@vps`.
+
+`agenc security audit` flags the non-loopback override as critical for exactly
+this reason; a red audit on a VPS is an exposed agent.
+
+## Shape 2 — Docker
+
+```bash
+git clone <repo> && cd agenc-core
+docker build -f packaging/docker/Dockerfile -t agenc:local .
+docker run -d --restart unless-stopped -v agenc-data:/data \
+  -e XAI_API_KEY agenc:local
+# one-shot commands against the same state:
+docker run --rm -v agenc-data:/data agenc:local security audit
+```
+
+Or `docker compose -f packaging/docker/docker-compose.yml up -d` (no ports
+published by default; see the file's exposure note).
+
+## Provider credentials
+
+Set BYOK keys in the service environment, never in files inside the image or
+repo. For systemd user services: `systemctl --user edit agenc-daemon` and add
+`Environment=XAI_API_KEY=...` (the unit file itself stays credential-free).
+
+## One-click templates (owner-publish step)
+
+Railway/Hostinger/DigitalOcean template listings wrap Shape 2 with the
+`agenc-data` volume and env-var prompts for the provider key. Publishing the
+templates is an owner/release step; this document is the source of truth for
+what they must configure (volume, env passthrough, no published ports).

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,6 +48,24 @@ npm install -g @tetsuo-ai/agenc
 The launcher's postinstall resolves the same runtime contract via
 `packages/agenc/lib/runtime-manager.mjs`.
 
+## Docker
+
+```bash
+docker build -f packaging/docker/Dockerfile -t agenc:local .
+docker run -it -v agenc-data:/data -e XAI_API_KEY agenc:local
+```
+
+Or `docker compose -f packaging/docker/docker-compose.yml up -d`. Non-root
+image, state in the `/data` volume, no published ports by default (see the
+exposure note in the compose file). VPS deployment shapes:
+[`docs/deploy/vps.md`](deploy/vps.md).
+
+## Homebrew (owner-publish pending)
+
+`packaging/homebrew/agenc.rb` is the tap formula template; it wraps
+`install.sh` so every path shares one verified contract. It ships with
+placeholder URL/sha and must not be published until a release fills them.
+
 ## Release/publish steps (owner-gated — do not automate from an agent session)
 
 For the one-line installers to work against a release tag:

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,56 @@
+# AgenC daemon container (TODO task 4).
+#
+# Build from the repo root (the build context must be the repo so the runtime
+# workspace is available):
+#
+#   docker build -f packaging/docker/Dockerfile -t agenc:local .
+#
+# Run (state persists in the volume; loopback-only by default — the daemon
+# refuses non-loopback WebSocket binds without an explicit override):
+#
+#   docker run -it -v agenc-data:/data -e XAI_API_KEY agenc:local
+#   docker run -it -v agenc-data:/data agenc:local security audit
+#
+# Mirrors packages/agenc/scripts/build-runtime-tarball.mjs: build the runtime,
+# `npm pack` it, prod-install the pack into a clean prefix so native deps
+# (better-sqlite3, node-pty) compile for the image platform, then run from
+# node_modules/@tetsuo-ai/runtime/bin/agenc — the same layout every other
+# install path uses.
+
+# --- build stage --------------------------------------------------------------
+FROM node:25-bookworm AS build
+WORKDIR /src
+COPY . .
+RUN npm ci \
+  && npm run build --workspace=@tetsuo-ai/runtime \
+  && cd runtime && npm pack --pack-destination /tmp \
+  && mkdir -p /opt/agenc \
+  && cd /opt/agenc \
+  && npm install --omit=dev --no-audit --no-fund /tmp/tetsuo-ai-runtime-*.tgz
+
+# --- runtime stage ------------------------------------------------------------
+FROM node:25-slim
+# gcc/libc6-dev: the daemon compiles its Unix-socket peer-credential
+# binding (a small C addon) on first start and caches it under /data —
+# without a compiler that socket-auth hardening is silently skipped.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       ripgrep git ca-certificates tini gcc libc6-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --create-home --uid 10001 agenc \
+  && mkdir -p /data && chown agenc:agenc /data \
+  && ln -sf /usr/bin/gcc /usr/local/bin/cc
+
+COPY --from=build --chown=agenc:agenc /opt/agenc /opt/agenc
+RUN printf '#!/bin/sh\nexec node /opt/agenc/node_modules/@tetsuo-ai/runtime/bin/agenc "$@"\n' \
+      > /usr/local/bin/agenc \
+  && chmod 755 /usr/local/bin/agenc
+
+USER agenc
+ENV AGENC_HOME=/data/.agenc \
+    NODE_ENV=production
+VOLUME ["/data"]
+WORKDIR /data
+
+ENTRYPOINT ["/usr/bin/tini", "--", "agenc"]
+CMD ["daemon", "start", "--foreground"]

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+# AgenC daemon via compose (TODO task 4).
+#
+#   docker compose -f packaging/docker/docker-compose.yml up -d
+#
+# Loopback-only by default: no ports are published. For remote access prefer
+# a tailnet sidecar or SSH tunnel into the host; publishing the daemon port
+# directly re-creates the exposed-agent-gateway disaster class and requires
+# the explicit AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK override on top.
+services:
+  agenc-daemon:
+    build:
+      context: ../..
+      dockerfile: packaging/docker/Dockerfile
+    image: agenc:local
+    restart: unless-stopped
+    volumes:
+      - agenc-data:/data
+    environment:
+      # Pass through whichever provider credential you use (unset ones are
+      # ignored). BYOK stays on your host env, never baked into the image.
+      - XAI_API_KEY
+      - OPENAI_API_KEY
+      - ANTHROPIC_API_KEY
+      - OPENROUTER_API_KEY
+    # ports: []   # intentionally none — see the note above
+
+volumes:
+  agenc-data:

--- a/packaging/homebrew/agenc.rb
+++ b/packaging/homebrew/agenc.rb
@@ -1,0 +1,46 @@
+# Homebrew formula template for the AgenC CLI (TODO task 4).
+#
+# OWNER-PUBLISH STEP — this file is a template, not a live formula:
+#   1. Cut a release (agenc-v<version>) with the darwin tarballs + manifest
+#      uploaded as assets (see docs/install.md).
+#   2. Fill url/sha256 below from the release manifest (one bottle-style block
+#      per platform, or point at install.sh's contract).
+#   3. Push to the tap repo (tetsuo-ai/homebrew-agenc) as Formula/agenc.rb.
+#
+# The formula deliberately reuses scripts/install/install.sh so every install
+# path shares one verified contract (manifest -> sha256 -> runtime tree).
+class Agenc < Formula
+  desc "Daemon-backed, terminal-native coding agent"
+  homepage "https://github.com/tetsuo-ai/agenc-core"
+  # OWNER: point at the released installer script (or vendor it via the tap).
+  url "https://github.com/tetsuo-ai/agenc-core/releases/download/agenc-vX.Y.Z/agenc-installer.tar.gz"
+  sha256 "REPLACE_WITH_RELEASE_ASSET_SHA256"
+  license "MIT"
+
+  depends_on "node@25"
+  depends_on "ripgrep"
+
+  def install
+    # The installer speaks the runtime-manager contract: manifest fetch,
+    # sha256 verify, extract to AGENC_HOME/runtime/<version>/, wrapper.
+    system "sh", "install.sh",
+           "--prefix", prefix.to_s,
+           "--no-daemon",
+           "--version", version.to_s
+  end
+
+  def caveats
+    <<~EOS
+      Start the daemon as a user service:
+        agenc daemon start
+      Guided setup:
+        agenc onboard
+      Security posture:
+        agenc security audit
+    EOS
+  end
+
+  test do
+    assert_match "agenc", shell_output("#{bin}/agenc --version")
+  end
+end

--- a/runtime/tests/packaging/distribution.test.ts
+++ b/runtime/tests/packaging/distribution.test.ts
@@ -1,0 +1,77 @@
+// Distribution artifacts (TODO task 4): pin the security-relevant invariants
+// of the Docker/compose/Homebrew packaging so they cannot silently regress.
+// The full `docker build` + run is one-off acceptance evidence (needs network
+// + docker); these gates hold the properties that make the artifacts safe.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { load as loadYaml } from "js-yaml";
+import { describe, expect, test } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const DOCKER_DIR = join(REPO_ROOT, "packaging", "docker");
+
+describe("docker packaging", () => {
+  test("Dockerfile: non-root user, AGENC_HOME volume, prod-only install", () => {
+    const dockerfile = readFileSync(join(DOCKER_DIR, "Dockerfile"), "utf8");
+    expect(dockerfile).toContain("USER agenc");
+    expect(dockerfile).toContain("ENV AGENC_HOME=/data/.agenc");
+    expect(dockerfile).toContain('VOLUME ["/data"]');
+    expect(dockerfile).toContain("npm install --omit=dev");
+    // The image must run the same layout every other install path uses.
+    expect(dockerfile).toContain("node_modules/@tetsuo-ai/runtime/bin/agenc");
+    // No credentials may be baked into the image.
+    expect(dockerfile).not.toMatch(/API_KEY\s*=/);
+  });
+
+  test("compose: no published ports, named state volume, passthrough-only env", () => {
+    const raw = readFileSync(join(DOCKER_DIR, "docker-compose.yml"), "utf8");
+    const compose = loadYaml(raw) as {
+      services: Record<
+        string,
+        { ports?: unknown; environment?: string[]; volumes?: string[] }
+      >;
+      volumes?: Record<string, unknown>;
+    };
+    const service = compose.services["agenc-daemon"];
+    expect(service).toBeDefined();
+    // Loopback-only by default: publishing the daemon port re-creates the
+    // exposed-agent-gateway disaster class.
+    expect(service.ports).toBeUndefined();
+    expect(service.volumes).toContain("agenc-data:/data");
+    expect(compose.volumes).toHaveProperty("agenc-data");
+    for (const entry of service.environment ?? []) {
+      // Bare names = host passthrough. `VAR=value` would hardcode a secret.
+      expect(entry).not.toContain("=");
+    }
+  });
+
+  test(".dockerignore keeps the context hermetic", () => {
+    const ignore = readFileSync(join(REPO_ROOT, ".dockerignore"), "utf8");
+    expect(ignore).toContain("node_modules");
+    expect(ignore).toContain(".git");
+  });
+});
+
+describe("homebrew packaging", () => {
+  test("formula template exists with unpublishable placeholders", () => {
+    const formulaPath = join(
+      REPO_ROOT,
+      "packaging",
+      "homebrew",
+      "agenc.rb",
+    );
+    expect(existsSync(formulaPath)).toBe(true);
+    const formula = readFileSync(formulaPath, "utf8");
+    expect(formula).toContain("class Agenc < Formula");
+    expect(formula).toContain('depends_on "node@25"');
+    // The template must stay obviously unpublishable until the owner fills
+    // in a real release asset hash.
+    expect(formula).toContain("REPLACE_WITH_RELEASE_ASSET_SHA256");
+    expect(formula).toContain("OWNER-PUBLISH STEP");
+    // It rides the shared installer contract rather than a parallel one.
+    expect(formula).toContain("install.sh");
+  });
+});


### PR DESCRIPTION
Parity backlog task 4 (Phase 0 — distribution). Build portions only; publishing (registry push, tap repo, one-click template listings) stays owner-gated and is documented, not automated.

## What
- **Docker**: multi-stage Dockerfile mirroring the release tarball recipe (build → `npm pack` → prod-install, so the image runs the exact layout every other install path uses). node:25-slim runtime, non-root uid 10001, `AGENC_HOME=/data` volume, tini PID 1, ripgrep/git, and gcc/libc6-dev so the daemon's unix-socket **peer-credential C binding** compiles instead of being silently skipped.
- **Compose**: named state volume, passthrough-only env (no values), **no published ports** with the exposure rationale inline.
- **Homebrew**: `packaging/homebrew/agenc.rb` template wrapping install.sh (one shared verified contract); placeholder sha + OWNER-PUBLISH markers make it unpublishable until a release fills them.
- **Docs**: `docs/deploy/vps.md` (installer + docker shapes, tailnet/SSH-only remote access, `security audit --fix` green as the leave-the-box bar), docker/homebrew sections in `docs/install.md`.
- `.gitignore`: `!docs/deploy/` negation (the `deploy/` rule guards state/keys, not documentation).

## Acceptance evidence (run locally)
- `docker build` succeeds from a hermetic context (.dockerignore).
- In-container: `--version` ✓; `security audit` **all green, exit 0** on the fresh volume; daemon starts on loopback ws and shuts down orderly on SIGTERM; peer-credential warning gone after adding the compiler.

## Gates
build ✓ typecheck ✓ vitest 14056 ✓ bun ✓ + 4 new invariant tests pinning non-root/no-ports/no-baked-creds/hermetic-context/unpublishable-placeholders.