### PR TITLE
docs: 5-minute quickstart + OpenClaw/Hermes migration guides (task 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ licensed; see [`LICENSE`](LICENSE).
 
 ## Quick start
 
+Five-minute path: [`docs/quickstart.md`](docs/quickstart.md). Coming from
+another assistant: [OpenClaw](docs/migrate-from-openclaw.md) ·
+[Hermes](docs/migrate-from-hermes.md).
+
 Install with the one-line installer (macOS/Linux; verifies the runtime
 tarball's sha256 and wires the daemon as a user service — see
 [`docs/install.md`](docs/install.md)):

--- a/docs/migrate-from-hermes.md
+++ b/docs/migrate-from-hermes.md
@@ -1,0 +1,54 @@
+# Migrating from Hermes Agent
+
+Hermes and AgenC are both daemon-backed, model-agnostic agents. The honest
+difference: Hermes leads on the self-learning loop and messaging reach; AgenC
+leads on execution safety (OS sandbox, fail-closed permissions), state
+auditability, and engineering rigor (14k tests, typed daemon protocol,
+eval-regression gate). This guide maps the surfaces, including what AgenC
+does not have yet.
+
+## Install + first run
+
+```bash
+curl -fsSL <installer-url>/install.sh | sh
+agenc onboard          # provider/key wizard — BYOK or OAuth-backed providers
+agenc security audit   # fail-closed posture check, green on fresh installs
+```
+
+## Concept map
+
+| Hermes | AgenC | Notes |
+|---|---|---|
+| `hermes gateway` | `agenc daemon` | Loopback-only by default, refuses non-loopback binds without an explicit override |
+| Ink TUI / curses CLI | TUI (`agenc`) | Custom react-reconciler TUI + embedded Neovim workbench |
+| Model providers (~30 plugins) | 16 built-in providers | Anthropic/OpenAI/Grok/Gemini/Bedrock/OpenRouter/Groq/DeepSeek/…, local via Ollama/LM Studio/openai-compatible; per-session `--provider/--model` |
+| Skills + Skills Hub | Skills + plugins | Local + bundled skills, plugin marketplaces via `agenc plugin`; no public hub until publishing is signed + attested (deliberate) |
+| Curator (self-created skills) | Roadmap — auditable by design | Planned as reviewed, git-versioned, eval-gated proposals; never silent self-modification. The eval harness that gates it already ships |
+| FTS session search | Roadmap | Sessions already persist to SQLite; cross-session search is planned |
+| Memory + user modeling | `memory/` + memdir | Project/session memory with aging; user-model files planned as proposed diffs, never silent writes |
+| `delegate_task` / async children | Subagents + teams + jobs | Worktree-isolated background agents, workflow runner (waves/deps), CSV fan-out |
+| Checkpoints `/undo` `/retry` | `/rewind` | Sidecar-based file restore to any message barrier |
+| Sandboxing (docker/ssh/modal/…) | OS sandbox (bwrap/Landlock/Seatbelt) | Kernel-level confinement locally; docker/ssh execution targets are on the roadmap |
+| Messaging platforms (~21) | Roadmap | The next major phase; the typed daemon protocol + zero-dep SDK already expose session attach/stream/permission round-trips for channel adapters |
+| ACP (Zed/IDE) | IDE-as-MCP seam | No shipped editor extension yet |
+| `hermes update` | Launcher-managed | Runtime tarballs are sha256-verified on install; `agenc doctor` reports update permissions |
+| Cost `/usage` | `/cost` | Per-agent cost attribution, cache metrics |
+| Batch/trajectory research tooling | `agenc trajectories export` | SFT/DPO JSONL export with redaction re-applied per row |
+
+## Two design disagreements, stated plainly
+
+1. **Learning must be reviewable.** Hermes' curator edits its own skills in
+   place; the community's top complaint is silent drift. AgenC will land the
+   same capability as draft diffs gated by the eval harness, with one-command
+   revert.
+2. **External content is untrusted, always.** Web results, task text, and
+   (when they ship) channel messages are wrapped and can never escalate
+   permissions or approve a previewed action. That rule is enforced in code
+   and tested, not stated in a system prompt.
+
+## What you lose today
+
+The messaging gateway, voice/TTS breadth, ACP editor integration, the
+self-improving loop, and remote execution backends. If those are your daily
+drivers, run both while the roadmap closes the gap — the phases are public in
+this repo's parity roadmap.

--- a/docs/migrate-from-openclaw.md
+++ b/docs/migrate-from-openclaw.md
@@ -1,0 +1,53 @@
+# Migrating from OpenClaw
+
+AgenC is a daemon-backed agent like OpenClaw's Gateway, with a different
+center of gravity: OS-sandboxed execution, a fail-closed permission layer, and
+an auditable state model. This guide maps concepts honestly — including what
+AgenC does **not** have yet.
+
+## Install + first run
+
+```bash
+curl -fsSL <installer-url>/install.sh | sh   # sha256-verified, daemon as user service
+agenc onboard                                # provider/key/theme wizard
+agenc security audit                         # green by default; --fix for chmods
+```
+
+Reuse the same provider credential you used with OpenClaw (BYOK env vars or
+`agenc login` for OAuth-backed providers).
+
+## Concept map
+
+| OpenClaw | AgenC | Notes |
+|---|---|---|
+| Gateway daemon | `agenc daemon` | Unix socket + loopback WebSocket; **non-loopback binds are refused** without an explicit override (audited) |
+| Control UI chat | TUI (`agenc`) | Terminal-native; a web chat surface is on the roadmap |
+| `AGENTS.md` (workspace instructions) | `AGENC.md` | Generated/analyzed by `agenc init`; per-project instructions |
+| `MEMORY.md` + daily notes | `memory/` + memdir | Automatic project/session memory with aging + retrieval |
+| Skills (`SKILL.md` dirs, ClawHub) | Skills + plugins | Bundled + local skills; plugins add commands/tools/hooks/MCP via `agenc plugin` and `/plugins`. No public registry yet — by design until publishing is signed + attested |
+| Cron (`openclaw cron`) | Cron tools + live scheduler | Create/list/delete from the agent; jobs re-arm on daemon restart |
+| Webhooks (`/hooks/agent`) | Roadmap | Planned with header-only bearer auth |
+| `SOUL.md` / `IDENTITY.md` persona | Roadmap | Persona workspace files are planned; today AGENC.md carries operating instructions |
+| Heartbeat (`HEARTBEAT.md`) | Roadmap | Planned budget-first (cheap utility model + hard daily caps) — idle-burn horror stories are a design input, not a surprise |
+| Channels (Telegram/WhatsApp/…) | Roadmap | Channel gateway is the next major phase; the daemon protocol + SDK already expose everything an adapter needs |
+| Nodes (phone/Canvas) | Roadmap | Realtime voice (WebRTC) already exists in the TUI |
+| `openclaw security audit` | `agenc security audit --fix` | Fail-closed exit codes; runs automatically around onboard/daemon start |
+| Docker install | `packaging/docker/` | Non-root image, no published ports by default |
+
+## What you gain immediately
+
+- **OS sandbox** (bubblewrap/Landlock/Seatbelt) for shell execution, not just
+  an approval prompt; AST-backed Bash permissioning; transactional multi-file
+  patches with rollback.
+- **Session model**: append-only JSONL + SQLite, `--continue`/`--resume`,
+  state export/import, `/rewind` file restore.
+- **MCP both directions** (client + server), subagent teams and background
+  agents in isolated worktrees, an eval-regression harness, and 16 model
+  providers including Ollama/LM Studio.
+
+## What you lose today (roadmap, in priority order)
+
+Messaging channels, heartbeat/proactive behavior, persona files, webhooks,
+browser automation, a mobile app. If any of these is your daily driver,
+run both: several of the gaps are next on the roadmap, and the daemon
+architecture is built for exactly those clients.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,53 @@
+# AgenC in 5 minutes
+
+Prerequisites: Node.js >= 25, `tar`, and one model-provider credential (an
+xAI/OpenAI/Anthropic/OpenRouter key, or a local Ollama/LM Studio endpoint —
+16 providers are supported).
+
+## 1. Install
+
+```bash
+curl -fsSL <installer-url>/install.sh | sh
+```
+
+This verifies the runtime tarball's sha256, installs the `agenc` wrapper into
+`~/.local/bin`, and starts the daemon as a user service. Other paths (npm,
+Docker, Windows): [`install.md`](install.md).
+
+## 2. Guided setup
+
+```bash
+agenc onboard
+```
+
+The wizard walks provider → API key (verified live) → theme → connection
+check → security defaults, then drops you into the chat. Re-run it any time;
+`agenc onboard --status` reports setup state for scripts.
+
+## 3. Check your posture
+
+```bash
+agenc security audit
+```
+
+Fresh installs audit green. If you ever see a critical finding, `--fix`
+applies the safe permission fixes; exposure findings (non-loopback daemon
+overrides) list their manual remediation. `agenc doctor` diagnoses the
+installation itself.
+
+## 4. Use it
+
+```bash
+agenc                                  # interactive TUI
+agenc "summarize this repository"      # TUI with a first prompt
+agenc --no-tui "run the tests and report failures"   # headless one-shot
+agenc daemon status                    # the daemon owns sessions/agents
+```
+
+From here: `/help` inside the TUI lists slash commands; background agents run
+via `agenc agent start <objective>`; sessions resume with `--continue` /
+`--resume`.
+
+Coming from another assistant? See
+[Migrate from OpenClaw](migrate-from-openclaw.md) and
+[Migrate from Hermes](migrate-from-hermes.md).


### PR DESCRIPTION
Parity backlog task 5 (Phase 0, final non-gated item).

- `docs/quickstart.md`: install → onboard → security audit → use. **Every command executed as written against the built CLI** (onboard --status, security audit, doctor, daemon status, agent help, headless one-shot).
- Migration guides for the two named refugee streams. Deliberately honest: concept tables mark what maps today vs what is explicitly roadmap (channels, heartbeat, persona files, webhooks, self-learning) so the guides never overclaim; each states the two design disagreements (reviewable learning, enforced untrusted-content rule) plainly.
- README links all three.

Gates: build ✓ typecheck ✓ vitest 14056 ✓ bun ✓ (docs-only change).