### PR TITLE
fix(ci): unquoted colon broke release-runtime workflow YAML

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 25
-      - name: Install workspace deps (npm install: no committed lockfile)
+      - name: Install workspace deps
         shell: bash
         # No lockfile is committed (local gates are authoritative), so npm ci
         # cannot run here; the artifact dep tree is resolved from the packed


### PR DESCRIPTION
The step rename in #1407 added an unquoted colon inside the name scalar; GitHub registered a zero-job parse failure on push and workflow_dispatch 422'd. Name reverted to a colon-free scalar; file now parse-validated with PyYAML. Workflow-only diff (build/typecheck/tui-startup ran green in the pre-commit hook).