### PR TITLE
chore(launcher): 0.2.1 — republish with the public-repo runtime manifest

### DIFF
--- a/packages/agenc/package.json
+++ b/packages/agenc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetsuo-ai/agenc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Public AgenC CLI launcher package",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Records the already-executed npm publish: `@tetsuo-ai/agenc@0.2.1` bundles the 5-platform manifest pointing at the public `tetsuo-ai/agenc-releases` repo (the 0.2.0 bundle pointed at this private repo and 404'd for strangers).

Verified: `npm install -g @tetsuo-ai/agenc` in a clean unauthenticated container → downloads the public runtime → `agenc 0.2.0` runs. Launcher tests 14/14; full gates green.