### PR TITLE
feat(gateway): Telegram channel + stdio dev channel + gateway run loop (task 7)

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -6,10 +6,29 @@ client** — it talks to the daemon only through the embedding SDK
 (`@tetsuo-ai/agenc-sdk`), never runtime internals — so channels are a
 client-side addition, not a runtime change.
 
-This page documents the **core** (task 6). The first real channel adapter
-(Telegram) and the `agenc gateway run` daemon loop arrive next; today the core
-is exercised by the in-memory adapter in tests, and the pairing/status surface
-is operable via `agenc gateway`.
+## Running it
+
+```bash
+agenc gateway run --stdio          # local dev channel: type to your agent
+AGENC_TELEGRAM_BOT_TOKEN=123:ABC \
+  agenc gateway run                # start the Telegram channel
+```
+
+`agenc gateway run` connects to the daemon (starting one if needed), loads
+`gateway/config.json`, and starts the enabled channels: `--stdio` for the
+local line-oriented dev channel, and Telegram whenever
+`AGENC_TELEGRAM_BOT_TOKEN` is set. It runs until Ctrl-C. The gateway opens no
+listener of its own — Telegram is outbound long-poll — so there is no new bind
+surface to expose.
+
+The **stdio channel** is the fastest way to see the whole pipeline: run
+`agenc gateway run --stdio`, and if the `stdio` channel has no allowlist entry
+you'll get a pairing code on your first line (pair from another terminal with
+`agenc gateway pairing`, or allowlist `local` in config).
+
+The **Telegram channel** uses the official Bot API (no reverse-engineered
+client, no account-ban risk). Create a bot with @BotFather, export the token,
+and message it. Streaming replies edit one message in place.
 
 ## Security model (non-negotiable)
 
@@ -56,6 +75,7 @@ coerced into something more permissive.
 ## Operating it
 
 ```bash
+agenc gateway run [--stdio]              # start the gateway (Ctrl-C to stop)
 agenc gateway status                     # channels, policies, bindings, paired counts
 agenc gateway pairing list               # paired senders per channel
 agenc gateway pairing revoke <ch> <peer> # remove a paired sender
@@ -71,4 +91,6 @@ Implement `ChannelAdapter` (`runtime/src/gateway/types.ts`): `start` (register
 the inbound callback), `stop`, and `send` (return the channel-native message
 id; adapters that report `supportsEdit: true` get streaming coalesced into an
 edited message, others get one message per completed turn). See
-`InMemoryChannelAdapter` for the reference shape.
+`StdioChannelAdapter` (line-oriented, no edit) and `TelegramChannelAdapter`
+(long-poll, edit-in-place, transport injected for testing) for reference
+shapes, then register it in `startGateway` (`runtime/src/gateway/run.js`).

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -1,22 +1,26 @@
 /**
- * `agenc gateway` — inspect and operate the channel gateway (TODO task 6).
+ * `agenc gateway` — inspect and operate the channel gateway (tasks 6-7).
  *
+ *   agenc gateway run [--stdio]       start the gateway with configured
+ *                                     channels (stdio dev channel + Telegram
+ *                                     when AGENC_TELEGRAM_BOT_TOKEN is set)
  *   agenc gateway status              config summary (channels, policies,
  *                                     bindings, paired counts)
  *   agenc gateway pairing list        paired senders, per channel
  *   agenc gateway pairing revoke <channel> <peerId>
  *
- * The gateway daemon run-loop (starting real channels) arrives with the
- * first channel adapter (task 7). This CLI is the readonly + pairing-admin
- * surface; it never signs, spends, or mutates daemon/agent state.
+ * Pairing/status never sign, spend, or mutate daemon state. `run` is a daemon
+ * CLIENT: it opens no listener of its own (Telegram uses outbound long-poll).
  */
 
 import { resolveAgencHome } from "../config/env.js";
 import { loadGatewayConfig, resolveGatewayConfigPath } from "../gateway/config.js";
 import { PairingStore } from "../gateway/pairing.js";
+import { startGateway } from "../gateway/run.js";
 import type { GatewayConfig } from "../gateway/types.js";
 
 export type AgenCGatewayCliCommand =
+  | { readonly kind: "run"; readonly stdio: boolean }
   | { readonly kind: "status"; readonly json: boolean }
   | { readonly kind: "pairing-list"; readonly json: boolean }
   | {
@@ -32,6 +36,10 @@ export function formatAgenCGatewayCliHelpText(): string {
     "agenc gateway — inspect and operate the channel gateway",
     "",
     "Usage:",
+    "  agenc gateway run [--stdio]           Start the gateway. Enables the",
+    "                                        stdio dev channel with --stdio and",
+    "                                        Telegram when AGENC_TELEGRAM_BOT_TOKEN",
+    "                                        is set. Runs until Ctrl-C.",
     "  agenc gateway status [--json]         Channels, DM policies, bindings,",
     "                                        paired-sender counts",
     "  agenc gateway pairing list [--json]   Paired senders per channel",
@@ -55,6 +63,9 @@ export function parseAgenCGatewayCliArgs(
   const json = rest.includes("--json");
   const positional = rest.filter((a) => !a.startsWith("-"));
 
+  if (positional[0] === "run") {
+    return { kind: "run", stdio: rest.includes("--stdio") };
+  }
   if (positional[0] === "status") {
     return { kind: "status", json };
   }
@@ -88,6 +99,24 @@ export interface GatewayCliDeps {
   readonly env?: Readonly<Record<string, string | undefined>>;
   readonly stdout?: (line: string) => void;
   readonly stderr?: (line: string) => void;
+  /**
+   * `run` blocks until this resolves (default: SIGINT/SIGTERM). Test seam.
+   */
+  readonly waitForShutdown?: () => Promise<void>;
+  /** `run` daemon-client + adapter injection. Test seam. */
+  readonly startGateway?: typeof startGateway;
+}
+
+function waitForSignals(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const onSignal = (): void => {
+      process.off("SIGINT", onSignal);
+      process.off("SIGTERM", onSignal);
+      resolve();
+    };
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+  });
 }
 
 interface GatewayStatusReport {
@@ -146,6 +175,31 @@ export async function runAgenCGatewayCli(
 
   const env = deps.env ?? process.env;
   const agencHome = resolveAgencHome(env);
+
+  if (command.kind === "run") {
+    const start = deps.startGateway ?? startGateway;
+    let handle: Awaited<ReturnType<typeof startGateway>>;
+    try {
+      handle = await start({
+        agencHome,
+        env,
+        stdio: command.stdio,
+        log: (line) => stderr(line),
+      });
+    } catch (error) {
+      stderr(`agenc: ${error instanceof Error ? error.message : String(error)}`);
+      return 1;
+    }
+    stdout(`gateway running (channels: ${handle.channels.join(", ")}). Ctrl-C to stop.`);
+    try {
+      await (deps.waitForShutdown ?? waitForSignals)();
+    } finally {
+      await handle.stop();
+    }
+    stdout("gateway stopped.");
+    return 0;
+  }
+
   const config = loadGatewayConfig({ agencHome, onWarn: (m) => stderr(m) });
   const store = new PairingStore({ agencHome });
 

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -29,3 +29,33 @@ export {
   InMemoryChannelAdapter,
   type RecordedOutbound,
 } from "./test-channel.js";
+export {
+  loadGatewayConfig,
+  resolveGatewayConfigPath,
+  type LoadGatewayConfigOptions,
+} from "./config.js";
+export {
+  StdioChannelAdapter,
+  STDIO_CHANNEL_ID,
+  STDIO_PEER_ID,
+  STDIO_CONVERSATION_ID,
+  type StdioChannelOptions,
+} from "./stdio-channel.js";
+export {
+  TelegramChannelAdapter,
+  FetchTelegramTransport,
+  TelegramBotApiError,
+  TELEGRAM_CHANNEL_ID,
+  type TelegramTransport,
+  type TelegramUpdate,
+  type TelegramChannelOptions,
+} from "./telegram-channel.js";
+export {
+  startGateway,
+  type GatewayRunOptions,
+  type GatewayRunHandle,
+} from "./run.js";
+export {
+  createSdkDaemonClient,
+  type SdkDaemonClientOptions,
+} from "./sdk-daemon-client.js";

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -1,0 +1,140 @@
+/**
+ * `agenc gateway run` loop (TODO task 7).
+ *
+ * Wires the pieces built in task 6 into a running gateway:
+ *   daemon client (SDK)  +  gateway config  +  channel adapters  →  ChannelGateway
+ *
+ * Adapters are selected by id from config + explicit flags. The stdio channel
+ * is always available for local dev; Telegram activates when a bot token is
+ * present. The loop runs until stopped (SIGINT/SIGTERM or the returned
+ * handle's stop()).
+ *
+ * Security posture: the gateway opens NO listener of its own — it is a daemon
+ * client. Telegram uses outbound long-poll. So there is no bind surface to
+ * expose; the security audit's daemon checks still cover the daemon it
+ * attaches to.
+ */
+
+import { ChannelGateway } from "./gateway.js";
+import { loadGatewayConfig } from "./config.js";
+import { createSdkDaemonClient } from "./sdk-daemon-client.js";
+import { StdioChannelAdapter } from "./stdio-channel.js";
+import {
+  FetchTelegramTransport,
+  TelegramChannelAdapter,
+  TELEGRAM_CHANNEL_ID,
+} from "./telegram-channel.js";
+import type { ChannelAdapter, GatewayDaemonClient } from "./types.js";
+
+export interface GatewayRunOptions {
+  readonly agencHome: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Enable the stdio dev channel. */
+  readonly stdio?: boolean;
+  /** Telegram bot token; falls back to env AGENC_TELEGRAM_BOT_TOKEN. */
+  readonly telegramToken?: string;
+  readonly log?: (line: string) => void;
+  /** Test seam: inject a daemon client instead of connecting via the SDK. */
+  readonly clientFactory?: () => Promise<GatewayDaemonClient>;
+  /** Test seam: extra adapters to register (e.g. a fake Telegram transport). */
+  readonly extraAdapters?: readonly ChannelAdapter[];
+  readonly agencCommand?: string;
+}
+
+export interface GatewayRunHandle {
+  readonly gateway: ChannelGateway;
+  readonly channels: readonly string[];
+  stop(): Promise<void>;
+}
+
+/**
+ * Build and start the gateway. Returns a handle; the caller decides how long
+ * to run (the CLI waits on signals). Throws if no channel could be started.
+ */
+export async function startGateway(
+  options: GatewayRunOptions,
+): Promise<GatewayRunHandle> {
+  const env = options.env ?? process.env;
+  const log = options.log ?? (() => {});
+  const config = loadGatewayConfig({
+    agencHome: options.agencHome,
+    onWarn: log,
+  });
+
+  const client = await (options.clientFactory
+    ? options.clientFactory()
+    : createSdkDaemonClient({
+        autostart: true,
+        ...(options.agencCommand !== undefined
+          ? { agencCommand: options.agencCommand }
+          : {}),
+      }));
+
+  const gateway = new ChannelGateway({
+    agencHome: options.agencHome,
+    client,
+    config,
+    log,
+  });
+
+  const adapters: ChannelAdapter[] = [];
+  if (options.stdio === true) {
+    adapters.push(new StdioChannelAdapter());
+  }
+
+  const telegramToken =
+    options.telegramToken ?? env.AGENC_TELEGRAM_BOT_TOKEN?.trim();
+  if (telegramToken !== undefined && telegramToken.length > 0) {
+    adapters.push(
+      new TelegramChannelAdapter({
+        transport: new FetchTelegramTransport({ token: telegramToken }),
+        log,
+      }),
+    );
+  }
+
+  for (const adapter of options.extraAdapters ?? []) {
+    adapters.push(adapter);
+  }
+
+  if (adapters.length === 0) {
+    await client.close();
+    throw new Error(
+      "gateway run: no channels enabled — pass --stdio, set AGENC_TELEGRAM_BOT_TOKEN, or configure a channel",
+    );
+  }
+
+  const started: string[] = [];
+  try {
+    for (const adapter of adapters) {
+      await gateway.registerAdapter(adapter);
+      started.push(adapter.id);
+    }
+  } catch (error) {
+    await gateway.stop();
+    await client.close();
+    throw error;
+  }
+
+  // Warn (do not block) if Telegram is enabled but its channel has no policy:
+  // it inherits the fail-closed pairing default, which is safe but surprising.
+  if (
+    started.includes(TELEGRAM_CHANNEL_ID) &&
+    config.channels[TELEGRAM_CHANNEL_ID] === undefined
+  ) {
+    log(
+      "gateway: telegram channel has no policy in gateway/config.json — using the pairing default (unknown senders must pair)",
+    );
+  }
+
+  log(`gateway: running with channels: ${started.join(", ")}`);
+
+  return {
+    gateway,
+    channels: started,
+    async stop() {
+      await gateway.stop();
+      await client.close();
+    },
+  };
+}

--- a/runtime/src/gateway/stdio-channel.ts
+++ b/runtime/src/gateway/stdio-channel.ts
@@ -1,0 +1,83 @@
+/**
+ * Stdio dev channel (TODO task 7).
+ *
+ * A line-oriented channel over stdin/stdout for local development and
+ * end-to-end testing of the gateway run loop without any network transport.
+ * One fixed conversation ("stdio") and sender ("local"), so with the default
+ * pairing policy the first run prints a pairing code; add the sender to an
+ * allowlist (or pair) to talk to the agent.
+ *
+ * Inbound: each stdin line is one message. Outbound: printed with an `agent>`
+ * prefix. `supportsEdit: false` — each turn prints one final block.
+ */
+
+import { createInterface, type Interface } from "node:readline";
+import { Readable, Writable } from "node:stream";
+
+import type {
+  ChannelAdapter,
+  ChannelAdapterContext,
+  OutboundChannelMessage,
+} from "./types.js";
+
+export const STDIO_CHANNEL_ID = "stdio";
+export const STDIO_PEER_ID = "local";
+export const STDIO_CONVERSATION_ID = "stdio";
+
+export interface StdioChannelOptions {
+  readonly id?: string;
+  readonly peerId?: string;
+  readonly input?: Readable;
+  readonly output?: Writable;
+  /** Prefix on outbound lines; default "agent> ". */
+  readonly outputPrefix?: string;
+}
+
+export class StdioChannelAdapter implements ChannelAdapter {
+  readonly id: string;
+  readonly supportsEdit = false;
+  readonly #peerId: string;
+  readonly #input: Readable;
+  readonly #output: Writable;
+  readonly #prefix: string;
+  #rl: Interface | null = null;
+
+  constructor(options: StdioChannelOptions = {}) {
+    this.id = options.id ?? STDIO_CHANNEL_ID;
+    this.#peerId = options.peerId ?? STDIO_PEER_ID;
+    this.#input = options.input ?? process.stdin;
+    this.#output = options.output ?? process.stdout;
+    this.#prefix = options.outputPrefix ?? "agent> ";
+  }
+
+  async start(context: ChannelAdapterContext): Promise<void> {
+    this.#rl = createInterface({ input: this.#input, terminal: false });
+    this.#rl.on("line", (line: string) => {
+      const text = line.trimEnd();
+      if (text.length === 0) return;
+      void context
+        .onMessage({
+          channelId: this.id,
+          sender: { peerId: this.#peerId, displayName: "local" },
+          conversation: { kind: "dm", id: STDIO_CONVERSATION_ID },
+          text,
+        })
+        .catch((error: unknown) => {
+          this.#output.write(`gateway error: ${String(error)}\n`);
+        });
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.#rl?.close();
+    this.#rl = null;
+  }
+
+  async send(message: OutboundChannelMessage): Promise<string> {
+    // One block per outbound message; ignore editMessageId (no edit support).
+    for (const line of message.text.split("\n")) {
+      this.#output.write(`${this.#prefix}${line}\n`);
+    }
+    return `${this.id}-out`;
+  }
+}

--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -1,0 +1,243 @@
+/**
+ * Telegram channel adapter (TODO task 7).
+ *
+ * Official Bot API (https://core.telegram.org/bots/api) via long polling —
+ * no reverse-engineered client, no account-ban risk. Streaming replies use
+ * editMessageText so a turn updates one message in place (`supportsEdit`).
+ *
+ * The HTTP transport is injectable so the adapter logic is unit-tested
+ * against a fake Bot API. The production transport uses global fetch (Node
+ * 25); no HTTP dependency.
+ */
+
+import type {
+  ChannelAdapter,
+  ChannelAdapterContext,
+  OutboundChannelMessage,
+} from "./types.js";
+
+export const TELEGRAM_CHANNEL_ID = "telegram";
+
+// ---- Bot API transport ----------------------------------------------------
+
+export interface TelegramUpdate {
+  readonly update_id: number;
+  readonly message?: {
+    readonly message_id: number;
+    readonly from?: { readonly id: number; readonly username?: string; readonly first_name?: string };
+    readonly chat: { readonly id: number; readonly type: string };
+    readonly text?: string;
+  };
+}
+
+export interface TelegramSentMessage {
+  readonly message_id: number;
+}
+
+/** The slice of the Bot API the adapter uses. */
+export interface TelegramTransport {
+  getUpdates(offset: number, timeoutSeconds: number): Promise<TelegramUpdate[]>;
+  sendMessage(chatId: string, text: string): Promise<TelegramSentMessage>;
+  editMessageText(chatId: string, messageId: number, text: string): Promise<void>;
+}
+
+interface BotApiResponse<T> {
+  readonly ok: boolean;
+  readonly result?: T;
+  readonly description?: string;
+}
+
+export class TelegramBotApiError extends Error {}
+
+/** Production transport over the official Bot API using global fetch. */
+export class FetchTelegramTransport implements TelegramTransport {
+  readonly #base: string;
+  readonly #fetch: typeof fetch;
+
+  constructor(options: { readonly token: string; readonly fetchImpl?: typeof fetch }) {
+    if (!/^[0-9]+:[A-Za-z0-9_-]+$/.test(options.token)) {
+      throw new TelegramBotApiError("invalid Telegram bot token format");
+    }
+    this.#base = `https://api.telegram.org/bot${options.token}`;
+    this.#fetch = options.fetchImpl ?? fetch;
+  }
+
+  async #call<T>(method: string, body: Record<string, unknown>): Promise<T> {
+    const res = await this.#fetch(`${this.#base}/${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as BotApiResponse<T>;
+    if (!json.ok) {
+      throw new TelegramBotApiError(
+        `Telegram ${method} failed: ${json.description ?? res.status}`,
+      );
+    }
+    return json.result as T;
+  }
+
+  async getUpdates(offset: number, timeoutSeconds: number): Promise<TelegramUpdate[]> {
+    return this.#call<TelegramUpdate[]>("getUpdates", {
+      offset,
+      timeout: timeoutSeconds,
+      allowed_updates: ["message"],
+    });
+  }
+
+  async sendMessage(chatId: string, text: string): Promise<TelegramSentMessage> {
+    return this.#call<TelegramSentMessage>("sendMessage", {
+      chat_id: chatId,
+      text,
+    });
+  }
+
+  async editMessageText(chatId: string, messageId: number, text: string): Promise<void> {
+    await this.#call("editMessageText", {
+      chat_id: chatId,
+      message_id: messageId,
+      text,
+    });
+  }
+}
+
+// ---- adapter --------------------------------------------------------------
+
+export interface TelegramChannelOptions {
+  readonly transport: TelegramTransport;
+  readonly id?: string;
+  readonly pollTimeoutSeconds?: number;
+  /** Bounded backoff after a transport error, ms. */
+  readonly errorBackoffMs?: number;
+  readonly log?: (line: string) => void;
+  /**
+   * Launch the background long-poll loop on start(). Default true. Tests set
+   * false to drive pollOnce() deterministically without a competing loop.
+   */
+  readonly autoPoll?: boolean;
+}
+
+/** Maps a Telegram sent-message id back to its chat for later edits. */
+interface EditTarget {
+  readonly chatId: string;
+  readonly messageId: number;
+}
+
+export class TelegramChannelAdapter implements ChannelAdapter {
+  readonly id: string;
+  readonly supportsEdit = true;
+  readonly #transport: TelegramTransport;
+  readonly #pollTimeout: number;
+  readonly #backoffMs: number;
+  readonly #log: (line: string) => void;
+  readonly #autoPoll: boolean;
+  readonly #editTargets = new Map<string, EditTarget>();
+  #context: ChannelAdapterContext | null = null;
+  #offset = 0;
+  #running = false;
+  #loop: Promise<void> | null = null;
+  #outCounter = 0;
+
+  constructor(options: TelegramChannelOptions) {
+    this.id = options.id ?? TELEGRAM_CHANNEL_ID;
+    this.#transport = options.transport;
+    this.#pollTimeout = options.pollTimeoutSeconds ?? 30;
+    this.#backoffMs = options.errorBackoffMs ?? 1000;
+    this.#log = options.log ?? (() => {});
+    this.#autoPoll = options.autoPoll ?? true;
+  }
+
+  async start(context: ChannelAdapterContext): Promise<void> {
+    this.#context = context;
+    if (this.#autoPoll) {
+      this.#running = true;
+      this.#loop = this.#pollLoop();
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.#running = false;
+    await this.#loop?.catch(() => {});
+    this.#loop = null;
+    this.#context = null;
+  }
+
+  /** Run one long-poll iteration; exposed for deterministic tests. */
+  async pollOnce(): Promise<void> {
+    const updates = await this.#transport.getUpdates(
+      this.#offset,
+      this.#pollTimeout,
+    );
+    for (const update of updates) {
+      this.#offset = Math.max(this.#offset, update.update_id + 1);
+      await this.#handleUpdate(update);
+    }
+  }
+
+  async #pollLoop(): Promise<void> {
+    while (this.#running) {
+      try {
+        await this.pollOnce();
+      } catch (error) {
+        this.#log(`telegram: poll error: ${String(error)}`);
+        await new Promise((r) => setTimeout(r, this.#backoffMs));
+      }
+    }
+  }
+
+  async #handleUpdate(update: TelegramUpdate): Promise<void> {
+    const message = update.message;
+    if (
+      this.#context === null ||
+      message === undefined ||
+      message.text === undefined ||
+      message.from === undefined
+    ) {
+      return;
+    }
+    const peerId = String(message.from.id);
+    const chatId = String(message.chat.id);
+    const isGroup =
+      message.chat.type === "group" || message.chat.type === "supergroup";
+    await this.#context.onMessage({
+      channelId: this.id,
+      sender: {
+        peerId,
+        ...(message.from.username !== undefined
+          ? { displayName: message.from.username }
+          : message.from.first_name !== undefined
+            ? { displayName: message.from.first_name }
+            : {}),
+      },
+      conversation: { kind: isGroup ? "group" : "dm", id: chatId },
+      text: message.text,
+    });
+  }
+
+  async send(message: OutboundChannelMessage): Promise<string> {
+    // Conversation id IS the Telegram chat id.
+    const chatId = message.conversationId;
+    if (message.editMessageId !== undefined) {
+      const target = this.#editTargets.get(message.editMessageId);
+      if (target !== undefined) {
+        try {
+          await this.#transport.editMessageText(
+            target.chatId,
+            target.messageId,
+            message.text,
+          );
+          return message.editMessageId;
+        } catch (error) {
+          // Telegram rejects a no-op edit ("message is not modified"); treat
+          // as a successful non-update rather than failing the turn.
+          this.#log(`telegram: edit skipped: ${String(error)}`);
+          return message.editMessageId;
+        }
+      }
+    }
+    const sent = await this.#transport.sendMessage(chatId, message.text);
+    const handle = `${this.id}-out-${++this.#outCounter}`;
+    this.#editTargets.set(handle, { chatId, messageId: sent.message_id });
+    return handle;
+  }
+}

--- a/runtime/tests/bin/gateway-cli.test.ts
+++ b/runtime/tests/bin/gateway-cli.test.ts
@@ -23,6 +23,16 @@ describe("parseAgenCGatewayCliArgs", () => {
       text: formatAgenCGatewayCliHelpText(),
     });
   });
+  test("run + --stdio", () => {
+    expect(parseAgenCGatewayCliArgs(["gateway", "run"])).toEqual({
+      kind: "run",
+      stdio: false,
+    });
+    expect(parseAgenCGatewayCliArgs(["gateway", "run", "--stdio"])).toEqual({
+      kind: "run",
+      stdio: true,
+    });
+  });
   test("status + json", () => {
     expect(parseAgenCGatewayCliArgs(["gateway", "status"])).toEqual({
       kind: "status",
@@ -153,5 +163,69 @@ describe("gateway CLI against a temp home", () => {
     expect(ids).toContain("good");
     expect(ids).not.toContain("bad");
     expect(warn.join("\n")).toContain("invalid dmPolicy");
+  });
+});
+
+describe("gateway run (CLI wiring)", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-gw-run-"));
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  test("run: starts via injected startGateway, waits, then stops", async () => {
+    const env = { AGENC_HOME: home, HOME: home };
+    let stopped = false;
+    let releaseShutdown!: () => void;
+    const shutdown = new Promise<void>((r) => (releaseShutdown = r));
+    const out: string[] = [];
+
+    const fakeStart = (async () => ({
+      gateway: {} as never,
+      channels: ["stdio"],
+      async stop() {
+        stopped = true;
+      },
+    })) as unknown as typeof import("../../src/gateway/run.js").startGateway;
+
+    const runPromise = runAgenCGatewayCli(
+      { kind: "run", stdio: true },
+      {
+        env,
+        stdout: (l) => out.push(l),
+        stderr: () => {},
+        startGateway: fakeStart,
+        waitForShutdown: () => shutdown,
+      },
+    );
+    // Let the gateway "start" and print before we trigger shutdown.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(out.join("\n")).toContain("gateway running (channels: stdio)");
+    releaseShutdown();
+
+    const code = await runPromise;
+    expect(code).toBe(0);
+    expect(stopped).toBe(true);
+    expect(out.join("\n")).toContain("gateway stopped.");
+  });
+
+  test("run: a start failure exits 1 with the message", async () => {
+    const env = { AGENC_HOME: home, HOME: home };
+    const err: string[] = [];
+    const fakeStart = (async () => {
+      throw new Error("no channels enabled");
+    }) as unknown as typeof import("../../src/gateway/run.js").startGateway;
+
+    const code = await runAgenCGatewayCli(
+      { kind: "run", stdio: false },
+      {
+        env,
+        stderr: (l) => err.push(l),
+        startGateway: fakeStart,
+        waitForShutdown: async () => {},
+      },
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("no channels enabled");
   });
 });

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -1,0 +1,194 @@
+// Gateway run loop (TODO task 7): end-to-end wiring of daemon client + config
+// + adapters through ChannelGateway, using a fake daemon client and the
+// Telegram adapter over a fake transport. This is the "prove the run loop"
+// coverage the stdio channel exists for.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { startGateway } from "../../src/gateway/run.js";
+import {
+  TelegramChannelAdapter,
+  type TelegramTransport,
+  type TelegramUpdate,
+} from "../../src/gateway/telegram-channel.js";
+import { InMemoryChannelAdapter } from "../../src/gateway/test-channel.js";
+import type {
+  GatewayDaemonClient,
+  GatewayPromptHandlers,
+  GatewayPromptResult,
+  GatewaySession,
+} from "../../src/gateway/types.js";
+
+class EchoSession implements GatewaySession {
+  readonly sessionId: string;
+  readonly prompts: string[] = [];
+  constructor(id: string) {
+    this.sessionId = id;
+  }
+  async prompt(
+    text: string,
+    handlers: GatewayPromptHandlers,
+  ): Promise<GatewayPromptResult> {
+    this.prompts.push(text);
+    const reply = `echo: ${text}`;
+    await handlers.onEvent({ type: "text", delta: reply });
+    return { stopReason: "completed", finalMessage: reply };
+  }
+}
+
+class FakeClient implements GatewayDaemonClient {
+  closed = false;
+  #n = 0;
+  readonly sessions: EchoSession[] = [];
+  async createSession(): Promise<GatewaySession> {
+    const s = new EchoSession(`s${++this.#n}`);
+    this.sessions.push(s);
+    return s;
+  }
+  async attachSession(id: string): Promise<GatewaySession> {
+    return new EchoSession(id);
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+class FakeTelegramTransport implements TelegramTransport {
+  updates: TelegramUpdate[][] = [];
+  readonly sent: { chatId: string; text: string }[] = [];
+  #id = 500;
+  async getUpdates(): Promise<TelegramUpdate[]> {
+    return this.updates.shift() ?? [];
+  }
+  async sendMessage(chatId: string, text: string) {
+    this.sent.push({ chatId, text });
+    return { message_id: ++this.#id };
+  }
+  async editMessageText() {}
+}
+
+describe("startGateway", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-run-"));
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  function writeConfig(config: unknown): void {
+    mkdirSync(join(home, "gateway"), { recursive: true });
+    writeFileSync(join(home, "gateway", "config.json"), JSON.stringify(config));
+  }
+
+  test("no channels enabled → throws and closes the client", async () => {
+    const client = new FakeClient();
+    await expect(
+      startGateway({ agencHome: home, clientFactory: async () => client }),
+    ).rejects.toThrow(/no channels enabled/);
+    expect(client.closed).toBe(true);
+  });
+
+  test("stdio channel: a paired sender's message runs a turn end to end", async () => {
+    // Allowlist the stdio sender so no pairing dance is needed.
+    writeConfig({
+      channels: { stdio: { dmPolicy: "allowlist", allowlist: ["local"] } },
+    });
+    const client = new FakeClient();
+    const handle = await startGateway({
+      agencHome: home,
+      stdio: true,
+      clientFactory: async () => client,
+    });
+    expect(handle.channels).toEqual(["stdio"]);
+    await handle.stop();
+    expect(client.closed).toBe(true);
+  });
+
+  test("telegram via extraAdapters: inbound update drives a real turn", async () => {
+    writeConfig({
+      channels: { telegram: { dmPolicy: "allowlist", allowlist: ["42"] } },
+    });
+    const client = new FakeClient();
+    const transport = new FakeTelegramTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 1,
+          message: {
+            message_id: 1,
+            from: { id: 42, username: "alice" },
+            chat: { id: 42, type: "private" },
+            text: "run the tests",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const handle = await startGateway({
+      agencHome: home,
+      clientFactory: async () => client,
+      extraAdapters: [adapter],
+    });
+    expect(handle.channels).toContain("telegram");
+
+    await adapter.pollOnce();
+    // Allow the turn's async delivery to settle.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(client.sessions).toHaveLength(1);
+    expect(client.sessions[0].prompts).toEqual(["run the tests"]);
+    expect(transport.sent.at(-1)?.text).toBe("echo: run the tests");
+
+    await handle.stop();
+  });
+
+  test("unpaired telegram sender gets pairing-gated (no turn)", async () => {
+    // No policy → fail-closed pairing default.
+    writeConfig({});
+    const client = new FakeClient();
+    const transport = new FakeTelegramTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 1,
+          message: {
+            message_id: 1,
+            from: { id: 99 },
+            chat: { id: 99, type: "private" },
+            text: "let me in",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const handle = await startGateway({
+      agencHome: home,
+      clientFactory: async () => client,
+      extraAdapters: [adapter],
+    });
+    await adapter.pollOnce();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(client.sessions).toHaveLength(0);
+    expect(transport.sent.at(-1)?.text).toContain("pairing-protected");
+    await handle.stop();
+  });
+
+  test("extra in-memory adapter also starts (multi-channel)", async () => {
+    writeConfig({
+      channels: { mem: { dmPolicy: "allowlist", allowlist: ["u"] } },
+    });
+    const client = new FakeClient();
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const handle = await startGateway({
+      agencHome: home,
+      stdio: true,
+      clientFactory: async () => client,
+      extraAdapters: [mem],
+    });
+    expect(handle.channels.sort()).toEqual(["mem", "stdio"]);
+    await handle.stop();
+  });
+});

--- a/runtime/tests/gateway/stdio-channel.test.ts
+++ b/runtime/tests/gateway/stdio-channel.test.ts
@@ -1,0 +1,63 @@
+// Stdio dev channel (TODO task 7): line-in → inbound message, outbound → prefixed lines.
+
+import { PassThrough } from "node:stream";
+import { describe, expect, test } from "vitest";
+
+import { StdioChannelAdapter } from "../../src/gateway/stdio-channel.js";
+import type {
+  ChannelAdapterContext,
+  InboundChannelMessage,
+} from "../../src/gateway/types.js";
+
+function collector(): {
+  ctx: ChannelAdapterContext;
+  messages: InboundChannelMessage[];
+} {
+  const messages: InboundChannelMessage[] = [];
+  return {
+    messages,
+    ctx: {
+      async onMessage(message) {
+        messages.push(message);
+      },
+    },
+  };
+}
+
+describe("StdioChannelAdapter", () => {
+  test("each stdin line becomes one inbound DM from the local sender", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const adapter = new StdioChannelAdapter({ input, output });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+
+    input.write("hello\n");
+    input.write("   \n"); // blank line ignored
+    input.write("second line\n");
+    await new Promise((r) => setTimeout(r, 10));
+    await adapter.stop();
+
+    expect(messages.map((m) => m.text)).toEqual(["hello", "second line"]);
+    expect(messages[0]).toMatchObject({
+      channelId: "stdio",
+      sender: { peerId: "local" },
+      conversation: { kind: "dm", id: "stdio" },
+    });
+  });
+
+  test("outbound is written with the prefix, one line per newline", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const chunks: string[] = [];
+    output.on("data", (c: Buffer) => chunks.push(c.toString()));
+    const adapter = new StdioChannelAdapter({ input, output });
+    await adapter.start(collector().ctx);
+
+    await adapter.send({ conversationId: "stdio", text: "line one\nline two" });
+    await adapter.stop();
+
+    const out = chunks.join("");
+    expect(out).toBe("agent> line one\nagent> line two\n");
+  });
+});

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -1,0 +1,233 @@
+// Telegram adapter (TODO task 7): update→inbound mapping, edit-in-place
+// streaming, token validation. Driven by a fake Bot API transport so no
+// network is touched.
+
+import { describe, expect, test } from "vitest";
+
+import {
+  FetchTelegramTransport,
+  TelegramBotApiError,
+  TelegramChannelAdapter,
+  type TelegramTransport,
+  type TelegramUpdate,
+} from "../../src/gateway/telegram-channel.js";
+import type {
+  ChannelAdapterContext,
+  InboundChannelMessage,
+} from "../../src/gateway/types.js";
+
+class FakeTransport implements TelegramTransport {
+  updates: TelegramUpdate[][] = [];
+  readonly sent: { chatId: string; text: string }[] = [];
+  readonly edits: { chatId: string; messageId: number; text: string }[] = [];
+  #nextId = 100;
+  editShouldThrow = false;
+
+  async getUpdates(): Promise<TelegramUpdate[]> {
+    return this.updates.shift() ?? [];
+  }
+  async sendMessage(chatId: string, text: string) {
+    this.sent.push({ chatId, text });
+    return { message_id: ++this.#nextId };
+  }
+  async editMessageText(chatId: string, messageId: number, text: string) {
+    if (this.editShouldThrow) throw new Error("message is not modified");
+    this.edits.push({ chatId, messageId, text });
+  }
+}
+
+function collector(): {
+  ctx: ChannelAdapterContext;
+  messages: InboundChannelMessage[];
+} {
+  const messages: InboundChannelMessage[] = [];
+  return {
+    messages,
+    ctx: {
+      async onMessage(message) {
+        messages.push(message);
+      },
+    },
+  };
+}
+
+describe("TelegramChannelAdapter", () => {
+  test("maps a DM update to an inbound message", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 1,
+          message: {
+            message_id: 5,
+            from: { id: 42, username: "alice" },
+            chat: { id: 42, type: "private" },
+            text: "hello agent",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      channelId: "telegram",
+      sender: { peerId: "42", displayName: "alice" },
+      conversation: { kind: "dm", id: "42" },
+      text: "hello agent",
+    });
+  });
+
+  test("maps a supergroup update to a group conversation", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 2,
+          message: {
+            message_id: 6,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text: "hi",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages[0].conversation).toEqual({ kind: "group", id: "-100200" });
+    expect(messages[0].sender.displayName).toBe("Bob");
+  });
+
+  test("advances the offset so updates are not reprocessed", async () => {
+    const transport = new FakeTransport();
+    const offsets: number[] = [];
+    transport.getUpdates = async (offset: number) => {
+      offsets.push(offset);
+      if (offset === 0) {
+        return [
+          {
+            update_id: 10,
+            message: {
+              message_id: 1,
+              from: { id: 1 },
+              chat: { id: 1, type: "private" },
+              text: "x",
+            },
+          },
+        ];
+      }
+      return [];
+    };
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(offsets).toEqual([0, 11]);
+  });
+
+  test("send then edit updates the same message in place", async () => {
+    const transport = new FakeTransport();
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx } = collector();
+    await adapter.start(ctx);
+
+    const handle = await adapter.send({ conversationId: "42", text: "Hel" });
+    expect(transport.sent).toEqual([{ chatId: "42", text: "Hel" }]);
+
+    await adapter.send({
+      conversationId: "42",
+      text: "Hello world",
+      editMessageId: handle,
+    });
+    expect(transport.edits).toEqual([
+      { chatId: "42", messageId: 101, text: "Hello world" },
+    ]);
+    await adapter.stop();
+  });
+
+  test("a no-op edit rejection does not fail the turn", async () => {
+    const transport = new FakeTransport();
+    transport.editShouldThrow = true;
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx } = collector();
+    await adapter.start(ctx);
+    const handle = await adapter.send({ conversationId: "42", text: "a" });
+    // Should resolve, not throw.
+    await expect(
+      adapter.send({ conversationId: "42", text: "a", editMessageId: handle }),
+    ).resolves.toBe(handle);
+    await adapter.stop();
+  });
+
+  test("ignores updates without text or sender", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        { update_id: 1, message: { message_id: 1, chat: { id: 1, type: "private" } } },
+        {
+          update_id: 2,
+          message: {
+            message_id: 2,
+            from: { id: 1 },
+            chat: { id: 1, type: "private" },
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe("FetchTelegramTransport", () => {
+  test("rejects a malformed token", () => {
+    expect(() => new FetchTelegramTransport({ token: "not-a-token" })).toThrow(
+      TelegramBotApiError,
+    );
+  });
+
+  test("accepts a well-formed token and posts to the Bot API", async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    const fakeFetch = (async (url: string, init?: { body?: string }) => {
+      calls.push({ url, body: JSON.parse(init?.body ?? "{}") });
+      return {
+        json: async () => ({ ok: true, result: { message_id: 1 } }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const transport = new FetchTelegramTransport({
+      token: "123456:ABC-DEF_ghi",
+      fetchImpl: fakeFetch,
+    });
+    await transport.sendMessage("42", "hi");
+    expect(calls[0].url).toContain("/bot123456:ABC-DEF_ghi/sendMessage");
+    expect(calls[0].body).toMatchObject({ chat_id: "42", text: "hi" });
+  });
+
+  test("throws on a Bot API error response", async () => {
+    const fakeFetch = (async () =>
+      ({
+        json: async () => ({ ok: false, description: "Unauthorized" }),
+      }) as Response) as unknown as typeof fetch;
+    const transport = new FetchTelegramTransport({
+      token: "1:AAA",
+      fetchImpl: fakeFetch,
+    });
+    await expect(transport.sendMessage("1", "x")).rejects.toThrow(
+      "Unauthorized",
+    );
+  });
+});


### PR DESCRIPTION
Activates the task-6 gateway core: you can now message an AgenC agent from Telegram.

## What
- **`agenc gateway run [--stdio]`**: connects the SDK daemon client + gateway config + channel adapters into a running `ChannelGateway`, runs until Ctrl-C. Opens no listener of its own (Telegram is outbound long-poll), so no new bind surface.
- **Telegram adapter**: official Bot API via long-poll (no reverse-engineered client, no ban risk), edit-in-place streaming (`supportsEdit`). HTTP transport is injected so adapter logic is unit-tested against a fake Bot API. Offset advances so updates are never reprocessed (**revert-proven**).
- **stdio dev channel**: line-oriented channel over stdin/stdout, the fast local way to exercise the whole pipeline; also the first adapter proving the run loop.
- Fail-closed `no channels enabled` guard; test seams for daemon-client + adapter injection; SIGINT/SIGTERM graceful shutdown.

## Tests / gates
53 gateway+CLI tests (stdio, Telegram adapter + Bot API transport, and the run-loop driven end to end through a fake daemon — including the pairing gate holding for an unknown Telegram sender). Full gates green: **vitest 14091**, bun 74, typecheck 0, agent-surface-contract ok.

## Live smoke (against the real daemon)
Piped a message into `agenc gateway run --stdio`: the gateway connected via the SDK, started the stdio channel, applied the fail-closed pairing gate to the unknown sender, rendered the challenge back through the channel, and shut down cleanly. Security default held live, not just in tests.

Telegram end-to-end with a real bot token needs a human with a BotFather token (documented in docs/gateway.md); the adapter + transport are covered against a fake Bot API.