### PR TITLE
feat(budget): cost-bounded autonomy — per-agent daily/monthly spend caps (task 15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ agenc help [command]
 agenc onboard [--status [--json] | --reset]
 agenc security audit [--json] [--fix]
 agenc gateway <run [--stdio] [--webchat]|status|pairing <list|revoke>>
+agenc budget <status [--json]|reset <agent>>
 agenc init [--force]
 agenc <login|logout|whoami>
 agenc providers [--json] [--no-local-check]
@@ -350,6 +351,7 @@ hooks/          configured hooks and hook execution engine
 elicitation/    structured user-input requests and responses
 memory/ memdir/ project/session memory storage and retrieval
 gateway/        channel gateway: pairing, bindings, in-channel approvals (docs/gateway.md)
+budget/         cost-bounded autonomy: per-agent daily/monthly spend caps (docs/design/budget-enforcement.md)
 transaction-guard/  opt-in SLM tool-call guard (see Security)
 unified-exec/ pty/  process execution and PTY helpers
 tui/            the custom React terminal UI

--- a/docs/design/budget-enforcement.md
+++ b/docs/design/budget-enforcement.md
@@ -1,0 +1,154 @@
+# Cost-bounded autonomy: budget enforcement design
+
+**Task 15.** A daemon-owned budget layer that bounds what an autonomous agent
+(heartbeat, cron, background) can spend, so AgenC never reproduces the OpenClaw
+idle-burn failure mode. This note records the SOTA research the design is
+grounded in and the decisions that follow from it.
+
+## What the literature says (2023-2026)
+
+Three surveys of the field converge on one architecture. Full citations at the
+end; the load-bearing findings:
+
+1. **Enforce externally — never trust the model to police its own spend.**
+   *BAGEN* (arXiv:2606.00198) shows frontier agents are systematically
+   over-optimistic about remaining budget: they keep spending on doomed
+   trajectories and only declare a task infeasible after most of the budget is
+   gone (feasibility stays >70% at 60% burn). Budget-awareness barely
+   correlates with task skill (r≈0.35) and reaches only ~47% interval
+   calibration even after SFT+RL. The daemon must be the meter and the gate.
+
+2. **Budget is a first-class enforced contract, not a prompt.** *Agent
+   Contracts* (arXiv:2601.08815) models resource caps (tokens, dollars,
+   tool-call and wall-clock quotas) as machine-checkable commitments with
+   continuous monitoring, interrupts on breach, graceful degradation, and a
+   **conservation law**: a sub-agent's budget is debited from the parent's
+   remaining envelope, so team fan-out can't multiply spend past the cap.
+
+3. **The gate is a pre-flight admission check; post-hoc accounting is
+   reconciliation, not control.** Monitoring ≠ enforcement — a spend alert
+   fires *after* the money is spent (practitioner consensus; TrueFoundry,
+   RelayPlane). The *Token Budgets* incident catalog (arXiv:2606.04056, 63
+   production overrun incidents) argues the budgeted call must be the **only
+   callable path** so no code can bypass it.
+
+4. **Debit worst-case up front, reconcile from actuals.** Before a call, debit
+   `prompt_tokens + max_output_tokens` at the model's price; admit only if it
+   fits remaining budget; after the response, replace the hold with the real
+   `usage` and refund the delta. This makes mid-turn exhaustion structurally
+   impossible — you never begin a call you can't fully afford. Cap output
+   tokens per call so one call can't blow the remainder.
+
+5. **Fail closed = pause + notify + offer explicit raise. Never silently
+   downgrade.** The incident catalog and Claude Code's `/usage-credits`
+   pattern agree: on cap hit, reject with a typed error, pause autonomy, tell
+   the human, and let them raise/resume — do **not** quietly swap to a cheaper
+   model (it hides the boundary). Cheap-model defaults are a *cost-reduction*
+   lever, orthogonal to the *safety* boundary.
+
+6. **Cheap-utility-model-by-default for autonomous turns, two tiers, route by
+   turn class up front.** Autonomous idle overhead (heartbeat + bootstrap
+   re-injection) is where the money actually leaks, not useful work. *Is
+   Escalation Worth It?* (arXiv:2605.06350) shows **pre-generation routing
+   beats cascades on 4/5 benchmarks** — deciding the tier before generating
+   avoids paying for the cheap call at all. And you already know the turn class
+   (heartbeat/cron vs user-facing), which is exactly the difficulty signal that
+   whole router models are built to recover (BEST-Route, RouteLLM). So: route
+   by turn class, two tiers only, escalate on **outcome** signals (a tool
+   failure, a high-stakes/mutating action) — never on the model's self-reported
+   confidence (consistently miscalibrated across the literature).
+
+7. **The cost-quality curve is steep then flat.** Repeatedly, 30-70% of
+   tokens/cost can be cut for low-single-digit quality loss (TALE 67%/-2.7pp;
+   Certaindex 11-29%/0; s1 budget-forcing; FrugalGPT up to 98% on narrow
+   tasks). Aggressive budgeting is usually free or positive-EV, not a tax.
+
+8. **Always-on cost bounding is an open research gap.** The one heartbeat
+   scheduling paper (arXiv:2604.14178) explicitly excludes cost as a goal. So
+   the *enforcement* machinery is borrowed from the resource-bounded papers
+   (1-5) and the agent-payments world (hard credential cap + soft policy +
+   audit, e.g. Stripe Issuing / Google AP2 Mandates), not from proactive-agent
+   work. We are slightly ahead of the literature here.
+
+## Design decisions (what we build)
+
+A self-contained daemon subsystem, `runtime/src/budget/`, exposing a
+`BudgetEnforcer` that autonomous surfaces (background agents now; heartbeat +
+cron when they land) call around each turn.
+
+- **Config `[budget]`** (env > config > default, mirroring `transaction-guard`):
+  per-agent `daily_usd` / `monthly_usd` hard caps, optional token caps, a
+  `soft_threshold` fraction (default 0.8) for the warn-a-human tier, and an
+  `enabled` flag. **Disabled by default** → zero behavior change until an
+  operator opts in, so the interactive turn loop and the 14k-test suite are
+  untouched.
+- **Ledger** — per-agent, per-window (calendar day + calendar month) cumulative
+  spend, persisted to `<agencHome>/budget/ledger.json` (0600), atomic writes.
+  Windows roll by date key so "daily/monthly budget" means what a user expects.
+- **Admission gate** — `admit({ agentId, model, estInputTokens, maxOutputTokens })`
+  computes the worst-case debit at the model's price and checks it against
+  BOTH remaining daily and monthly budget (both must pass — fail closed).
+  Returns a hold on success, or a typed `BUDGET_EXCEEDED` refusal.
+- **Reconcile** — `reconcile(hold, actualUsage)` replaces the held estimate with
+  the real spend and refunds the delta. The real `usage` from the provider
+  response is authoritative (pre-flight estimates drift; §4).
+- **Enforcement policy** — on refusal: pause the agent's autonomy
+  (`paused` state), emit a notification once, and surface the typed error; the
+  operator raises the cap or resets to resume. Crossing the soft threshold
+  emits a one-shot warning. **Never** silently downgrades the model (§5).
+- **Scope** — enforcement applies to autonomous turns (`autonomousMode`) by
+  default; interactive turns are unaffected unless a global cap is set. This is
+  the `turn-context.autonomousMode` seam.
+- **CLI** — `agenc budget status` (per-agent spend vs caps, window, state),
+  read-only; `agenc budget reset <agent>` for the operator.
+
+### Relationship to the existing per-run agent caps
+
+The background-agent runner already enforces **per-run** caps
+(`[agent] AgentBudgetConfig`: `token_cap`, `dollar_cap`, `wall_clock_seconds`)
+that halt a *single* run when it exceeds a bound. Task 15 is the complementary
+**cumulative daily/monthly envelope per agent** that spans runs and daemon
+restarts — the layer that bounds a heartbeat firing every 30 min forever, which
+no per-run cap can. The two compose: a per-run cap stops one runaway loop; the
+daily/monthly cap stops the *aggregate* idle burn. We do not duplicate per-run
+enforcement.
+
+### Scoped for this task vs. deferred (grounded follow-ups)
+
+**In task 15:** the enforcer primitive (admit/reconcile/pause/notify), the
+persistent per-agent daily+monthly ledger, the `[budget]` config, the
+model-price adapter, and the `agenc budget` CLI — all fully unit-tested,
+including the research-grounded invariants (worst-case debit, reconcile refund,
+fail-closed on both windows, pause-and-notify, one-shot soft warning, never
+silent downgrade). Enforcement granularity is **per turn** (admit before an
+autonomous turn, reconcile its usage).
+
+**The live wire-in into the autonomous loop lands with task 14 (heartbeat)** —
+that is the loop that actually fires autonomously and needs pausing; wiring
+pre-flight enforcement now, against a surface that does not yet tick on its own,
+would be speculative plumbing. Task 15 delivers the primitive the heartbeat
+consumes, which is exactly how the roadmap sequences it (budgets before
+heartbeat, because heartbeat-without-budget is the token furnace).
+
+**Deferred, each traceable to the research:**
+- *Per-model-call* pre-flight gate on the single call path (§3, the stricter
+  ideal) — needs `stream-model` plumbing; per-turn is the pragmatic first cut.
+- *Velocity circuit-breaker* (spend-rate window) and *loop/duplicate-turn
+  detector* — the fast-loop catchers the daily cap misses (governance report).
+- *Delegation conservation* — sub-agent budget debited from parent (Agent
+  Contracts §2); lands with the team-budget work.
+- *Cheap-utility-model routing + outcome-based escalation* (§6) — the
+  cost-reduction tier; pairs with heartbeat (task 14), which is where a
+  utility-model default first matters.
+- *Reasoning-token budget forcing* (§7, s1/TALE) — a per-call knob for later.
+
+## Citations
+
+BAGEN 2606.00198 · Agent Contracts 2601.08815 · Token Budgets (incident
+catalog) 2606.04056 · Is Escalation Worth It? 2605.06350 · FrugalGPT
+2305.05176 · RouteLLM 2406.18665 · BEST-Route 2506.22716 · s1 2501.19393 ·
+TALE 2412.18547 · Certaindex/Dynasor 2412.20993 · Don't Overthink It
+2505.17813 · Stop Overthinking survey 2503.16419 · Heartbeat Scheduling
+2604.14178 · Inference-Time Budget Control 2605.05701 · BATS 2511.17006 ·
+Workflow Tradeoffs 2605.23929. Practitioner: Claude Code cost docs, Stripe
+Agent Toolkit / Google AP2, TrueFoundry/RelayPlane gateway enforcement.

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -165,6 +165,11 @@ import {
   runAgenCGatewayCli,
 } from "./gateway-cli.js";
 import {
+  formatAgenCBudgetCliHelpText,
+  parseAgenCBudgetCliArgs,
+  runAgenCBudgetCli,
+} from "./budget-cli.js";
+import {
   formatAgenCInitCliHelpText,
   parseAgenCInitCliArgs,
   runAgenCInitCli,
@@ -321,6 +326,7 @@ export function formatCliHelpText(): string {
     "       agenc onboard [--status [--json] | --reset]",
     "       agenc security audit [--json] [--fix]",
     "       agenc gateway <status|pairing> [args]",
+    "       agenc budget <status|reset> [args]",
     "       agenc init [--force]",
     "       agenc <login|logout|whoami>",
     "       agenc providers [--json] [--no-local-check]",
@@ -343,6 +349,7 @@ export function formatCliHelpText(): string {
     "  onboard                                 Set up AgenC: provider, key, theme, first chat",
     "  security                                Audit local exposure; --fix applies safe fixes",
     "  gateway                                 Inspect/operate the channel gateway (pairing)",
+    "  budget                                  Inspect/operate cost-bounded autonomy",
     "  init                                    Create .agenc/config.json and AGENC.md",
     "  login | logout | whoami                  Manage the configured auth session",
     "  providers                               Check provider readiness and local health",
@@ -423,6 +430,8 @@ export function formatCliHelpTopicText(topic: string): string | null {
       return formatAgenCSecurityCliHelpText();
     case "gateway":
       return formatAgenCGatewayCliHelpText();
+    case "budget":
+      return formatAgenCBudgetCliHelpText();
     case "permissions":
       return formatAgenCPermissionsCliHelpText();
     case "plugin":
@@ -4078,6 +4087,10 @@ export async function main(): Promise<number> {
   const gatewayCommand = parseAgenCGatewayCliArgs(argv);
   if (gatewayCommand !== null) {
     return runAgenCGatewayCli(gatewayCommand);
+  }
+  const budgetCommand = parseAgenCBudgetCliArgs(argv);
+  if (budgetCommand !== null) {
+    return runAgenCBudgetCli(budgetCommand);
   }
   const providersCommand = parseAgenCProvidersCliArgs(argv);
   if (providersCommand !== null) {

--- a/runtime/src/bin/budget-cli.ts
+++ b/runtime/src/bin/budget-cli.ts
@@ -1,0 +1,181 @@
+/**
+ * `agenc budget` — inspect and operate cost-bounded autonomy (TODO task 15).
+ *
+ *   agenc budget status [--json]     per-agent spend vs caps + policy
+ *   agenc budget reset <agent>       clear an agent's spend + pause (operator)
+ *
+ * Read-only except `reset`. Never signs, spends, or mutates agent/daemon state
+ * beyond the budget ledger.
+ */
+
+import { resolveAgencHome } from "../config/env.js";
+import { loadConfig } from "../config/loader.js";
+import { BudgetLedger } from "../budget/ledger.js";
+import { resolveBudgetPolicy } from "../budget/config.js";
+import type { BudgetPolicy } from "../budget/types.js";
+
+export type AgenCBudgetCliCommand =
+  | { readonly kind: "status"; readonly json: boolean }
+  | { readonly kind: "reset"; readonly agentId: string }
+  | { readonly kind: "help"; readonly text: string }
+  | { readonly kind: "error"; readonly message: string };
+
+export function formatAgenCBudgetCliHelpText(): string {
+  return [
+    "agenc budget — inspect and operate cost-bounded autonomy",
+    "",
+    "Usage:",
+    "  agenc budget status [--json]     Policy + per-agent spend vs caps",
+    "  agenc budget reset <agent>       Clear an agent's spend and un-pause it",
+    "",
+    "Budget is enforced daemon-side around autonomous turns and is disabled by",
+    "default. Configure via [budget] in config.toml or AGENC_BUDGET* env vars.",
+    "Ledger: <AGENC_HOME>/budget/ledger.json",
+    "",
+    "Options:",
+    "  -h, --help  Show this help text",
+  ].join("\n");
+}
+
+export function parseAgenCBudgetCliArgs(
+  argv: readonly string[],
+): AgenCBudgetCliCommand | null {
+  if (argv[0] !== "budget") return null;
+  const rest = argv.slice(1);
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") {
+    return { kind: "help", text: formatAgenCBudgetCliHelpText() };
+  }
+  const json = rest.includes("--json");
+  const positional = rest.filter((a) => !a.startsWith("-"));
+  if (positional[0] === "status") {
+    return { kind: "status", json };
+  }
+  if (positional[0] === "reset") {
+    if (positional[1] === undefined) {
+      return { kind: "error", message: "budget reset needs an <agent> id" };
+    }
+    return { kind: "reset", agentId: positional[1] };
+  }
+  return {
+    kind: "error",
+    message: `unknown budget subcommand '${positional[0] ?? ""}' (expected: status, reset)`,
+  };
+}
+
+export interface BudgetCliDeps {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly stdout?: (line: string) => void;
+  readonly stderr?: (line: string) => void;
+}
+
+interface BudgetStatusReport {
+  readonly enabled: boolean;
+  readonly policy: {
+    readonly dailyUsd?: number;
+    readonly monthlyUsd?: number;
+    readonly dailyTokens?: number;
+    readonly monthlyTokens?: number;
+    readonly softThreshold: number;
+    readonly enforceInteractive: boolean;
+  };
+  readonly agents: ReadonlyArray<{
+    readonly agentId: string;
+    readonly paused: boolean;
+    readonly day: { usd: number; tokens: number; key: string };
+    readonly month: { usd: number; tokens: number; key: string };
+  }>;
+}
+
+function policyView(policy: BudgetPolicy): BudgetStatusReport["policy"] {
+  return {
+    ...(policy.caps.dailyUsd !== undefined ? { dailyUsd: policy.caps.dailyUsd } : {}),
+    ...(policy.caps.monthlyUsd !== undefined
+      ? { monthlyUsd: policy.caps.monthlyUsd }
+      : {}),
+    ...(policy.caps.dailyTokens !== undefined
+      ? { dailyTokens: policy.caps.dailyTokens }
+      : {}),
+    ...(policy.caps.monthlyTokens !== undefined
+      ? { monthlyTokens: policy.caps.monthlyTokens }
+      : {}),
+    softThreshold: policy.softThreshold,
+    enforceInteractive: policy.enforceInteractive,
+  };
+}
+
+export async function runAgenCBudgetCli(
+  command: AgenCBudgetCliCommand,
+  deps: BudgetCliDeps = {},
+): Promise<number> {
+  const stdout =
+    deps.stdout ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const stderr =
+    deps.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+  if (command.kind === "help") {
+    stdout(command.text);
+    return 0;
+  }
+  if (command.kind === "error") {
+    stderr(`agenc: ${command.message}`);
+    return 1;
+  }
+
+  const env = deps.env ?? process.env;
+  const agencHome = resolveAgencHome(env);
+  const loaded = await loadConfig({ home: agencHome, onWarn: () => {} });
+  const { policy } = resolveBudgetPolicy(loaded.config.budget, env);
+  const ledger = new BudgetLedger({ agencHome });
+
+  if (command.kind === "reset") {
+    ledger.reset(command.agentId);
+    stdout(`Budget reset for agent ${command.agentId} (spend cleared, un-paused).`);
+    return 0;
+  }
+
+  const report: BudgetStatusReport = {
+    enabled: policy.enabled,
+    policy: policyView(policy),
+    agents: ledger.listAgents().map((agentId) => {
+      const s = ledger.snapshot(agentId);
+      return {
+        agentId,
+        paused: s.paused,
+        day: { usd: s.day.usd, tokens: s.day.tokens, key: s.day.key },
+        month: { usd: s.month.usd, tokens: s.month.tokens, key: s.month.key },
+      };
+    }),
+  };
+
+  if (command.json) {
+    stdout(JSON.stringify(report, null, 2));
+    return 0;
+  }
+
+  stdout("AgenC budget");
+  stdout("");
+  stdout(`  Enforcement: ${report.enabled ? "enabled" : "disabled (no caps active)"}`);
+  const p = report.policy;
+  const caps: string[] = [];
+  if (p.dailyUsd !== undefined) caps.push(`$${p.dailyUsd}/day`);
+  if (p.monthlyUsd !== undefined) caps.push(`$${p.monthlyUsd}/month`);
+  if (p.dailyTokens !== undefined) caps.push(`${p.dailyTokens} tok/day`);
+  if (p.monthlyTokens !== undefined) caps.push(`${p.monthlyTokens} tok/month`);
+  stdout(`  Caps:        ${caps.length > 0 ? caps.join(", ") : "none"}`);
+  stdout(
+    `  Scope:       ${p.enforceInteractive ? "all turns" : "autonomous turns only"}` +
+      ` (soft warn at ${Math.round(p.softThreshold * 100)}%)`,
+  );
+  stdout("");
+  if (report.agents.length === 0) {
+    stdout("  No per-agent spend recorded yet.");
+  } else {
+    stdout("  Agents:");
+    for (const a of report.agents) {
+      stdout(
+        `    ${a.agentId}${a.paused ? " [PAUSED]" : ""}: ` +
+          `$${a.day.usd.toFixed(4)} today, $${a.month.usd.toFixed(4)} this month`,
+      );
+    }
+  }
+  return 0;
+}

--- a/runtime/src/budget/config.ts
+++ b/runtime/src/budget/config.ts
@@ -1,0 +1,130 @@
+/**
+ * Budget policy resolution (TODO task 15), env > config > default — mirroring
+ * transaction-guard/config.ts. Disabled by default: zero behavior change until
+ * an operator opts in.
+ *
+ * Env overrides:
+ *   AGENC_BUDGET                 "on"/"1"/"true" enables, any other value disables
+ *   AGENC_BUDGET_DAILY_USD       hard daily dollar cap
+ *   AGENC_BUDGET_MONTHLY_USD     hard monthly dollar cap
+ *   AGENC_BUDGET_SOFT_THRESHOLD  soft-warning fraction [0,1)
+ *   AGENC_BUDGET_ENFORCE_INTERACTIVE  "1"/"true" also gates interactive turns
+ */
+
+import type { BudgetConfig } from "../config/schema.js";
+import type {
+  BudgetPolicy,
+  BudgetPolicySources,
+  BudgetValueSource,
+  ResolvedBudgetPolicy,
+} from "./types.js";
+
+const DEFAULT_SOFT_THRESHOLD = 0.8;
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parsePositiveNumber(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "on" || v === "1" || v === "true" || v === "yes") return true;
+  if (v === "off" || v === "0" || v === "false" || v === "no") return false;
+  return undefined;
+}
+
+/**
+ * Resolve the budget policy from the `[budget]` config block and the
+ * environment. Caps: env wins, else config; a cap of 0/absent means no cap.
+ */
+export function resolveBudgetPolicy(
+  config?: BudgetConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedBudgetPolicy {
+  // enabled
+  let enabled = false;
+  let enabledSource: BudgetValueSource = "default";
+  const envEnabled = parseBool(nonEmpty(env.AGENC_BUDGET));
+  if (envEnabled !== undefined) {
+    enabled = envEnabled;
+    enabledSource = "env";
+  } else if (config?.enabled !== undefined) {
+    enabled = config.enabled;
+    enabledSource = "config";
+  }
+
+  // daily USD cap
+  let dailyUsd: number | undefined;
+  let dailyUsdSource: BudgetValueSource = "default";
+  const envDaily = parsePositiveNumber(nonEmpty(env.AGENC_BUDGET_DAILY_USD));
+  if (envDaily !== undefined) {
+    dailyUsd = envDaily;
+    dailyUsdSource = "env";
+  } else if (config?.daily_usd !== undefined && config.daily_usd > 0) {
+    dailyUsd = config.daily_usd;
+    dailyUsdSource = "config";
+  }
+
+  // monthly USD cap
+  let monthlyUsd: number | undefined;
+  let monthlyUsdSource: BudgetValueSource = "default";
+  const envMonthly = parsePositiveNumber(nonEmpty(env.AGENC_BUDGET_MONTHLY_USD));
+  if (envMonthly !== undefined) {
+    monthlyUsd = envMonthly;
+    monthlyUsdSource = "env";
+  } else if (config?.monthly_usd !== undefined && config.monthly_usd > 0) {
+    monthlyUsd = config.monthly_usd;
+    monthlyUsdSource = "config";
+  }
+
+  // token caps (config or env, env wins)
+  const dailyTokens =
+    parsePositiveNumber(nonEmpty(env.AGENC_BUDGET_DAILY_TOKENS)) ??
+    (config?.daily_tokens !== undefined && config.daily_tokens > 0
+      ? config.daily_tokens
+      : undefined);
+  const monthlyTokens =
+    parsePositiveNumber(nonEmpty(env.AGENC_BUDGET_MONTHLY_TOKENS)) ??
+    (config?.monthly_tokens !== undefined && config.monthly_tokens > 0
+      ? config.monthly_tokens
+      : undefined);
+
+  // soft threshold
+  let softThreshold =
+    config?.soft_threshold !== undefined &&
+    config.soft_threshold > 0 &&
+    config.soft_threshold < 1
+      ? config.soft_threshold
+      : DEFAULT_SOFT_THRESHOLD;
+  const envSoft = parsePositiveNumber(nonEmpty(env.AGENC_BUDGET_SOFT_THRESHOLD));
+  if (envSoft !== undefined && envSoft < 1) softThreshold = envSoft;
+
+  const enforceInteractive =
+    parseBool(nonEmpty(env.AGENC_BUDGET_ENFORCE_INTERACTIVE)) ??
+    config?.enforce_interactive ??
+    false;
+
+  const policy: BudgetPolicy = {
+    enabled,
+    softThreshold,
+    enforceInteractive,
+    caps: {
+      ...(dailyUsd !== undefined ? { dailyUsd } : {}),
+      ...(monthlyUsd !== undefined ? { monthlyUsd } : {}),
+      ...(dailyTokens !== undefined ? { dailyTokens } : {}),
+      ...(monthlyTokens !== undefined ? { monthlyTokens } : {}),
+    },
+  };
+  const sources: BudgetPolicySources = {
+    enabled: enabledSource,
+    dailyUsd: dailyUsdSource,
+    monthlyUsd: monthlyUsdSource,
+  };
+  return { policy, sources };
+}

--- a/runtime/src/budget/enforcer.ts
+++ b/runtime/src/budget/enforcer.ts
@@ -1,0 +1,261 @@
+/**
+ * Budget enforcer (TODO task 15) — the daemon-side admission gate.
+ *
+ * Contract (see docs/design/budget-enforcement.md):
+ *   admit()      pre-flight: debit worst-case (est input + max output) priced
+ *                at the model rate; check BOTH daily and monthly caps; fail
+ *                closed. Returns a hold or a typed BUDGET_EXCEEDED refusal.
+ *   reconcile()  post-call: replace the held estimate with real usage, refund
+ *                the delta, and fire soft-warning / paused notifications.
+ *
+ * Never silently downgrades the model. On a hard-cap breach it pauses the
+ * agent's autonomy and notifies; the operator raises the cap or resets.
+ */
+
+import { BudgetLedger } from "./ledger.js";
+import type {
+  AdmitRequest,
+  AdmitResult,
+  BudgetHold,
+  BudgetNotification,
+  BudgetNotifier,
+  BudgetPolicy,
+  BudgetRefusalReason,
+  BudgetUsage,
+  ModelPrice,
+  ModelPriceResolver,
+} from "./types.js";
+
+export interface BudgetEnforcerOptions {
+  readonly policy: BudgetPolicy;
+  readonly ledger: BudgetLedger;
+  readonly priceOf: ModelPriceResolver;
+  readonly notify?: BudgetNotifier;
+}
+
+function priceTokens(
+  price: ModelPrice,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  return (
+    (inputTokens / 1_000_000) * price.inputPerMTokens +
+    (outputTokens / 1_000_000) * price.outputPerMTokens
+  );
+}
+
+export class BudgetEnforcer {
+  readonly #policy: BudgetPolicy;
+  readonly #ledger: BudgetLedger;
+  readonly #priceOf: ModelPriceResolver;
+  readonly #notify: BudgetNotifier;
+
+  constructor(options: BudgetEnforcerOptions) {
+    this.#policy = options.policy;
+    this.#ledger = options.ledger;
+    this.#priceOf = options.priceOf;
+    this.#notify = options.notify ?? (() => {});
+  }
+
+  get enabled(): boolean {
+    return this.#policy.enabled;
+  }
+
+  /** Does this request fall under enforcement given its provenance? */
+  #inScope(request: AdmitRequest): boolean {
+    if (!this.#policy.enabled) return false;
+    return request.autonomous || this.#policy.enforceInteractive;
+  }
+
+  /**
+   * Pre-flight admission check. When enforcement is off or out of scope, admits
+   * with a zero hold (callers can still reconcile a no-op). Fail-closed: if any
+   * relevant cap would be exceeded by the worst-case debit, refuses.
+   */
+  admit(request: AdmitRequest): AdmitResult {
+    const { dayKey, monthKey } = this.#ledger.currentKeys();
+    if (!this.#inScope(request)) {
+      return {
+        ok: true,
+        hold: {
+          agentId: request.agentId,
+          model: request.model,
+          estimatedUsd: 0,
+          estimatedTokens: 0,
+          dayKey,
+          monthKey,
+        },
+      };
+    }
+
+    const state = this.#ledger.snapshot(request.agentId);
+    if (state.paused) {
+      return this.#refuse("paused", request.agentId, 0, 0);
+    }
+
+    const price = this.#priceOf(request.model);
+    // Worst-case: full estimated input + the output cap. If we can't price the
+    // model, we can still enforce token caps; dollar caps can't gate an
+    // unpriced model, so those pass (documented limitation).
+    const estTokens = request.estInputTokens + request.maxOutputTokens;
+    const estUsd =
+      price !== null
+        ? priceTokens(price, request.estInputTokens, request.maxOutputTokens)
+        : 0;
+
+    const caps = this.#policy.caps;
+    // Dollar caps.
+    if (caps.dailyUsd !== undefined && state.day.usd + estUsd > caps.dailyUsd) {
+      return this.#refuse("daily_usd", request.agentId, estUsd, estTokens);
+    }
+    if (
+      caps.monthlyUsd !== undefined &&
+      state.month.usd + estUsd > caps.monthlyUsd
+    ) {
+      return this.#refuse("monthly_usd", request.agentId, estUsd, estTokens);
+    }
+    // Token caps.
+    if (
+      caps.dailyTokens !== undefined &&
+      state.day.tokens + estTokens > caps.dailyTokens
+    ) {
+      return this.#refuse("daily_tokens", request.agentId, estUsd, estTokens);
+    }
+    if (
+      caps.monthlyTokens !== undefined &&
+      state.month.tokens + estTokens > caps.monthlyTokens
+    ) {
+      return this.#refuse("monthly_tokens", request.agentId, estUsd, estTokens);
+    }
+
+    // Admit: hold the worst-case debit so a concurrent turn can't double-spend.
+    this.#ledger.addSpend(request.agentId, estUsd, estTokens);
+    return {
+      ok: true,
+      hold: {
+        agentId: request.agentId,
+        model: request.model,
+        estimatedUsd: estUsd,
+        estimatedTokens: estTokens,
+        dayKey,
+        monthKey,
+      },
+    };
+  }
+
+  #refuse(
+    reason: BudgetRefusalReason,
+    agentId: string,
+    estUsd: number,
+    estTokens: number,
+  ): AdmitResult {
+    // A hard-cap refusal pauses autonomy (fail closed) and notifies once.
+    if (reason !== "paused") {
+      this.#pause(agentId, reason);
+    }
+    void estUsd;
+    void estTokens;
+    return {
+      ok: false,
+      code: "BUDGET_EXCEEDED",
+      reason,
+      message:
+        reason === "paused"
+          ? `agent ${agentId} autonomy is paused by a budget cap; raise the cap or run \`agenc budget reset ${agentId}\``
+          : `agent ${agentId} would exceed its ${reason.replace("_", " ")} budget cap`,
+    };
+  }
+
+  #pause(agentId: string, reason: BudgetRefusalReason): void {
+    const already = this.#ledger.snapshot(agentId).paused;
+    this.#ledger.setPaused(agentId, true);
+    if (!already) {
+      const window: "day" | "month" = reason.startsWith("daily")
+        ? "day"
+        : "month";
+      const snap = this.#ledger.snapshot(agentId);
+      const spent = window === "day" ? snap.day.usd : snap.month.usd;
+      const cap =
+        window === "day"
+          ? (this.#policy.caps.dailyUsd ?? 0)
+          : (this.#policy.caps.monthlyUsd ?? 0);
+      this.#emit({
+        agentId,
+        kind: "paused",
+        window,
+        spentUsd: spent,
+        capUsd: cap,
+        message: `agent ${agentId} autonomy paused: ${reason.replace("_", " ")} cap reached`,
+      });
+    }
+  }
+
+  /**
+   * Replace a hold's worst-case estimate with the real usage and refund the
+   * delta, then fire a one-shot soft warning if a window crossed the soft
+   * threshold. Idempotent per hold (call exactly once per admitted call).
+   */
+  reconcile(hold: BudgetHold, usage: BudgetUsage): void {
+    if (hold.estimatedTokens === 0 && hold.estimatedUsd === 0) {
+      // Out-of-scope / unpriced admit held nothing; account nothing.
+      return;
+    }
+    const price = this.#priceOf(hold.model);
+    const actualTokens = usage.inputTokens + usage.outputTokens;
+    const actualUsd =
+      price !== null
+        ? priceTokens(price, usage.inputTokens, usage.outputTokens)
+        : 0;
+    // Refund the difference between the worst-case hold and the actual spend.
+    this.#ledger.addSpend(
+      hold.agentId,
+      actualUsd - hold.estimatedUsd,
+      actualTokens - hold.estimatedTokens,
+    );
+    this.#maybeSoftWarn(hold.agentId);
+  }
+
+  #maybeSoftWarn(agentId: string): void {
+    const caps = this.#policy.caps;
+    const snap = this.#ledger.snapshot(agentId);
+    const frac = this.#policy.softThreshold;
+    if (
+      caps.dailyUsd !== undefined &&
+      !snap.softWarned.day &&
+      snap.day.usd >= caps.dailyUsd * frac
+    ) {
+      this.#ledger.markSoftWarned(agentId, "day");
+      this.#emit({
+        agentId,
+        kind: "soft_warning",
+        window: "day",
+        spentUsd: snap.day.usd,
+        capUsd: caps.dailyUsd,
+        message: `agent ${agentId} has spent $${snap.day.usd.toFixed(4)} of its $${caps.dailyUsd} daily budget`,
+      });
+    }
+    if (
+      caps.monthlyUsd !== undefined &&
+      !snap.softWarned.month &&
+      snap.month.usd >= caps.monthlyUsd * frac
+    ) {
+      this.#ledger.markSoftWarned(agentId, "month");
+      this.#emit({
+        agentId,
+        kind: "soft_warning",
+        window: "month",
+        spentUsd: snap.month.usd,
+        capUsd: caps.monthlyUsd,
+        message: `agent ${agentId} has spent $${snap.month.usd.toFixed(4)} of its $${caps.monthlyUsd} monthly budget`,
+      });
+    }
+  }
+
+  #emit(event: BudgetNotification): void {
+    try {
+      this.#notify(event);
+    } catch {
+      // A notifier failure must never break enforcement.
+    }
+  }
+}

--- a/runtime/src/budget/index.ts
+++ b/runtime/src/budget/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Budget enforcement (TODO task 15, Phase 2).
+ *
+ * A daemon-owned layer that bounds autonomous-agent spend. Grounded in
+ * docs/design/budget-enforcement.md. Disabled by default.
+ */
+
+export * from "./types.js";
+export { resolveBudgetPolicy } from "./config.js";
+export { BudgetLedger, windowKeys, type BudgetLedgerOptions } from "./ledger.js";
+export { BudgetEnforcer, type BudgetEnforcerOptions } from "./enforcer.js";
+export { createModelPriceResolver } from "./pricing.js";

--- a/runtime/src/budget/ledger.ts
+++ b/runtime/src/budget/ledger.ts
@@ -1,0 +1,174 @@
+/**
+ * Persistent per-agent budget ledger (TODO task 15).
+ *
+ * Tracks cumulative spend per agent per calendar window (day + month),
+ * persisted to `<agencHome>/budget/ledger.json` (0600, atomic write). Windows
+ * roll by date key so "daily/monthly budget" means what a user expects.
+ *
+ * The ledger is the external meter (never the model's self-estimate). It holds
+ * worst-case debits on admit and reconciles them from real usage.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { AgentBudgetState, BudgetWindowSpend } from "./types.js";
+
+interface LedgerFile {
+  readonly version: 1;
+  agents: Record<string, AgentBudgetState>;
+}
+
+function emptyWindow(key: string): BudgetWindowSpend {
+  return { key, usd: 0, tokens: 0 };
+}
+
+function emptyState(agentId: string, dayKey: string, monthKey: string): AgentBudgetState {
+  return {
+    agentId,
+    day: emptyWindow(dayKey),
+    month: emptyWindow(monthKey),
+    paused: false,
+    softWarned: { day: false, month: false },
+  };
+}
+
+/** `YYYY-MM-DD` and `YYYY-MM` from a Date, in the given clock's local terms. */
+export function windowKeys(now: Date): { dayKey: string; monthKey: string } {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
+  return { dayKey: `${y}-${m}-${d}`, monthKey: `${y}-${m}` };
+}
+
+export interface BudgetLedgerOptions {
+  readonly agencHome: string;
+  readonly now?: () => Date;
+}
+
+export class BudgetLedger {
+  readonly #path: string;
+  readonly #now: () => Date;
+  #file: LedgerFile;
+
+  constructor(options: BudgetLedgerOptions) {
+    this.#path = join(options.agencHome, "budget", "ledger.json");
+    this.#now = options.now ?? (() => new Date());
+    this.#file = this.#load();
+  }
+
+  #load(): LedgerFile {
+    if (!existsSync(this.#path)) return { version: 1, agents: {} };
+    try {
+      const raw = JSON.parse(readFileSync(this.#path, "utf8")) as unknown;
+      if (
+        typeof raw === "object" &&
+        raw !== null &&
+        (raw as { version?: unknown }).version === 1 &&
+        typeof (raw as { agents?: unknown }).agents === "object" &&
+        (raw as { agents?: unknown }).agents !== null
+      ) {
+        return { version: 1, agents: (raw as LedgerFile).agents };
+      }
+    } catch {
+      // Corrupt ledger fails toward zero spend — the caps still apply going
+      // forward; we never fabricate spend the agent didn't make.
+    }
+    return { version: 1, agents: {} };
+  }
+
+  #save(): void {
+    mkdirSync(dirname(this.#path), { recursive: true, mode: 0o700 });
+    const tmp = `${this.#path}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(this.#file, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmp, this.#path);
+  }
+
+  /**
+   * Get the agent's state, rolling any window whose date key changed (a new
+   * day/month resets that window's spend + soft-warn flag). Mutates + persists
+   * on roll.
+   */
+  #stateRolled(agentId: string): AgentBudgetState {
+    const { dayKey, monthKey } = windowKeys(this.#now());
+    let state = this.#file.agents[agentId];
+    let changed = false;
+    if (state === undefined) {
+      state = emptyState(agentId, dayKey, monthKey);
+      this.#file.agents[agentId] = state;
+      changed = true;
+    }
+    if (state.day.key !== dayKey) {
+      state.day = emptyWindow(dayKey);
+      state.softWarned.day = false;
+      changed = true;
+    }
+    if (state.month.key !== monthKey) {
+      state.month = emptyWindow(monthKey);
+      state.softWarned.month = false;
+      changed = true;
+    }
+    if (changed) this.#save();
+    return state;
+  }
+
+  /** Read-only snapshot (with windows rolled to now). */
+  snapshot(agentId: string): AgentBudgetState {
+    const s = this.#stateRolled(agentId);
+    return {
+      agentId: s.agentId,
+      day: { ...s.day },
+      month: { ...s.month },
+      paused: s.paused,
+      softWarned: { ...s.softWarned },
+    };
+  }
+
+  currentKeys(): { dayKey: string; monthKey: string } {
+    return windowKeys(this.#now());
+  }
+
+  /** Add spend to both windows and persist. */
+  addSpend(agentId: string, usd: number, tokens: number): void {
+    const s = this.#stateRolled(agentId);
+    s.day.usd += usd;
+    s.day.tokens += tokens;
+    s.month.usd += usd;
+    s.month.tokens += tokens;
+    this.#save();
+  }
+
+  setPaused(agentId: string, paused: boolean): void {
+    const s = this.#stateRolled(agentId);
+    if (s.paused !== paused) {
+      s.paused = paused;
+      this.#save();
+    }
+  }
+
+  markSoftWarned(agentId: string, window: "day" | "month"): void {
+    const s = this.#stateRolled(agentId);
+    if (!s.softWarned[window]) {
+      s.softWarned[window] = true;
+      this.#save();
+    }
+  }
+
+  /** Operator reset: clear an agent's spend, pause flag, and warn flags. */
+  reset(agentId: string): void {
+    const { dayKey, monthKey } = windowKeys(this.#now());
+    this.#file.agents[agentId] = emptyState(agentId, dayKey, monthKey);
+    this.#save();
+  }
+
+  /** All agents with a ledger entry (windows rolled). */
+  listAgents(): readonly string[] {
+    return Object.keys(this.#file.agents).sort();
+  }
+}

--- a/runtime/src/budget/pricing.ts
+++ b/runtime/src/budget/pricing.ts
@@ -1,0 +1,37 @@
+/**
+ * Model-price adapter for the budget enforcer (TODO task 15).
+ *
+ * Bridges the pure enforcer (which takes an injected `ModelPriceResolver`) to
+ * the runtime's canonical cost registry, converting per-1K rates to the
+ * per-1M-token rates the enforcer prices in. Kept separate so budget/ has no
+ * dependency on the cost tables in its core.
+ */
+
+import {
+  DEFAULT_MODEL_COSTS,
+  resolveModelCostEntry,
+} from "../session/cost.js";
+import type { ModelPrice, ModelPriceResolver } from "./types.js";
+
+/**
+ * Build a price resolver from the default cost registry. Returns null for a
+ * model with no known price (e.g. local models) — the enforcer then can't gate
+ * that model on dollar caps, only token caps.
+ */
+export function createModelPriceResolver(): ModelPriceResolver {
+  return (model: string): ModelPrice | null => {
+    const resolved = resolveModelCostEntry(
+      { model, provider: "" },
+      DEFAULT_MODEL_COSTS,
+    );
+    if (resolved === null) return null;
+    const { entry } = resolved;
+    // Local/free models are registered with zero rates; treat a zero-priced
+    // model as "unpriced" so dollar caps don't spuriously admit unlimited use.
+    if (entry.inputUsdPer1K === 0 && entry.outputUsdPer1K === 0) return null;
+    return {
+      inputPerMTokens: entry.inputUsdPer1K * 1000,
+      outputPerMTokens: entry.outputUsdPer1K * 1000,
+    };
+  };
+}

--- a/runtime/src/budget/types.ts
+++ b/runtime/src/budget/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Budget enforcement types (TODO task 15).
+ *
+ * A daemon-owned budget layer that bounds autonomous-agent spend. Grounded in
+ * the SOTA research in docs/design/budget-enforcement.md. Core invariants,
+ * each traceable to that note:
+ *   - external enforcement (never trust the model's self-estimate)   [BAGEN]
+ *   - pre-flight admission gate; post-hoc accounting is reconciliation
+ *   - debit worst-case up front, reconcile from the real usage
+ *   - fail closed: pause + notify + explicit raise, never silent downgrade
+ */
+
+/** Where a resolved budget policy field came from. */
+export type BudgetValueSource = "env" | "config" | "default";
+
+/** A per-agent spend envelope. Caps of 0 or undefined mean "no cap". */
+export interface BudgetCaps {
+  /** Hard daily dollar cap (calendar day). */
+  readonly dailyUsd?: number;
+  /** Hard monthly dollar cap (calendar month). */
+  readonly monthlyUsd?: number;
+  /** Optional hard daily token cap (total tokens). */
+  readonly dailyTokens?: number;
+  /** Optional hard monthly token cap. */
+  readonly monthlyTokens?: number;
+}
+
+export interface BudgetPolicy {
+  readonly enabled: boolean;
+  readonly caps: BudgetCaps;
+  /**
+   * Fraction of a cap [0,1) at which a one-shot soft warning fires. Default
+   * 0.8. The hard cap is what pauses; the soft threshold only notifies.
+   */
+  readonly softThreshold: number;
+  /**
+   * When true, ALSO enforce on interactive turns; otherwise only autonomous
+   * turns are gated ("manual turns unaffected unless configured").
+   */
+  readonly enforceInteractive: boolean;
+}
+
+export interface BudgetPolicySources {
+  readonly enabled: BudgetValueSource;
+  readonly dailyUsd: BudgetValueSource;
+  readonly monthlyUsd: BudgetValueSource;
+}
+
+export interface ResolvedBudgetPolicy {
+  readonly policy: BudgetPolicy;
+  readonly sources: BudgetPolicySources;
+}
+
+/** One window's accumulated spend for one agent. */
+export interface BudgetWindowSpend {
+  /** Date key: `YYYY-MM-DD` for the day window, `YYYY-MM` for the month. */
+  readonly key: string;
+  usd: number;
+  tokens: number;
+}
+
+/** An agent's persisted ledger entry. */
+export interface AgentBudgetState {
+  readonly agentId: string;
+  day: BudgetWindowSpend;
+  month: BudgetWindowSpend;
+  /** Autonomy paused by a hard-cap breach until the operator resumes/raises. */
+  paused: boolean;
+  /** Soft warnings already emitted this window (so they fire once). */
+  softWarned: { day: boolean; month: boolean };
+}
+
+/** Usage numbers used to price a call. */
+export interface BudgetUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+}
+
+export interface AdmitRequest {
+  readonly agentId: string;
+  readonly model: string;
+  /** Turn provenance: autonomous turns are gated by default. */
+  readonly autonomous: boolean;
+  /** Estimated prompt tokens (deterministic count, not a model guess). */
+  readonly estInputTokens: number;
+  /** Worst-case output tokens (the per-call output cap). */
+  readonly maxOutputTokens: number;
+}
+
+export type BudgetRefusalReason =
+  | "daily_usd"
+  | "monthly_usd"
+  | "daily_tokens"
+  | "monthly_tokens"
+  | "paused";
+
+export type AdmitResult =
+  | { readonly ok: true; readonly hold: BudgetHold }
+  | {
+      readonly ok: false;
+      readonly code: "BUDGET_EXCEEDED";
+      readonly reason: BudgetRefusalReason;
+      readonly message: string;
+    };
+
+/** A reserved worst-case debit, reconciled after the call returns. */
+export interface BudgetHold {
+  readonly agentId: string;
+  readonly model: string;
+  readonly estimatedUsd: number;
+  readonly estimatedTokens: number;
+  readonly dayKey: string;
+  readonly monthKey: string;
+}
+
+/** Emitted when a budget event happens; wired to the notification surface. */
+export interface BudgetNotification {
+  readonly agentId: string;
+  readonly kind: "soft_warning" | "paused";
+  readonly window: "day" | "month";
+  readonly spentUsd: number;
+  readonly capUsd: number;
+  readonly message: string;
+}
+
+export type BudgetNotifier = (event: BudgetNotification) => void;
+
+/** Price per 1M tokens for a model, used to convert tokens → dollars. */
+export interface ModelPrice {
+  readonly inputPerMTokens: number;
+  readonly outputPerMTokens: number;
+}
+
+/** Resolves a model id → its price. Injected so the ledger stays pure. */
+export type ModelPriceResolver = (model: string) => ModelPrice | null;

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -542,6 +542,24 @@ export interface TransactionGuardConfig {
   readonly fail_mode?: TransactionGuardFailMode;
 }
 
+/**
+ * `[budget]` — cost-bounded autonomy (task 15). Per-agent hard spend caps
+ * enforced daemon-side around autonomous turns. Disabled by default; a cap of
+ * 0/absent means no cap. `AGENC_BUDGET*` env vars override
+ * (see `budget/config.ts`).
+ */
+export interface BudgetConfig {
+  readonly enabled?: boolean;
+  readonly daily_usd?: number;
+  readonly monthly_usd?: number;
+  readonly daily_tokens?: number;
+  readonly monthly_tokens?: number;
+  /** Soft-warning fraction [0,1); default 0.8. */
+  readonly soft_threshold?: number;
+  /** Also enforce on interactive turns (default false: autonomous only). */
+  readonly enforce_interactive?: boolean;
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Canonical AgenCConfig
 // ─────────────────────────────────────────────────────────────────────
@@ -621,6 +639,11 @@ export interface AgenCConfig {
    * defaults to disabled; `AGENC_TRANSACTION_GUARD*` env vars override.
    */
   readonly transaction_guard?: TransactionGuardConfig;
+  /**
+   * Cost-bounded autonomy (`[budget]`). Optional — disabled by default;
+   * `AGENC_BUDGET*` env vars override. See `budget/config.ts`.
+   */
+  readonly budget?: BudgetConfig;
   readonly agenc_home?: string;
   readonly workspace?: string;
   readonly simpleMode?: boolean;
@@ -758,6 +781,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = Object.freeze([
   "autonomous_mode",
   "coordinator_mode",
   "transaction_guard",
+  "budget",
   "agenc_home",
   "workspace",
   "simpleMode",

--- a/runtime/tests/bin/budget-cli.test.ts
+++ b/runtime/tests/bin/budget-cli.test.ts
@@ -1,0 +1,112 @@
+// `agenc budget` CLI (TODO task 15): parse matrix + status/reset against a
+// temp home with a real ledger.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  formatAgenCBudgetCliHelpText,
+  parseAgenCBudgetCliArgs,
+  runAgenCBudgetCli,
+} from "../../src/bin/budget-cli.js";
+import { BudgetLedger } from "../../src/budget/ledger.js";
+
+describe("parseAgenCBudgetCliArgs", () => {
+  test("null for non-budget argv", () => {
+    expect(parseAgenCBudgetCliArgs(["gateway"])).toBeNull();
+  });
+  test("bare budget → help", () => {
+    expect(parseAgenCBudgetCliArgs(["budget"])).toEqual({
+      kind: "help",
+      text: formatAgenCBudgetCliHelpText(),
+    });
+  });
+  test("status + json", () => {
+    expect(parseAgenCBudgetCliArgs(["budget", "status"])).toEqual({
+      kind: "status",
+      json: false,
+    });
+    expect(parseAgenCBudgetCliArgs(["budget", "status", "--json"])).toEqual({
+      kind: "status",
+      json: true,
+    });
+  });
+  test("reset needs an agent id", () => {
+    expect(parseAgenCBudgetCliArgs(["budget", "reset", "a1"])).toEqual({
+      kind: "reset",
+      agentId: "a1",
+    });
+    expect(parseAgenCBudgetCliArgs(["budget", "reset"])).toMatchObject({
+      kind: "error",
+    });
+  });
+  test("unknown subcommand errors", () => {
+    expect(parseAgenCBudgetCliArgs(["budget", "wat"])).toMatchObject({
+      kind: "error",
+    });
+  });
+});
+
+describe("budget CLI against a temp home", () => {
+  let home: string;
+  let env: Record<string, string | undefined>;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-budget-cli-"));
+    env = { AGENC_HOME: home, HOME: home };
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  test("status: disabled by default, no agents", async () => {
+    const out: string[] = [];
+    const code = await runAgenCBudgetCli(
+      { kind: "status", json: true },
+      { env, stdout: (l) => out.push(l) },
+    );
+    expect(code).toBe(0);
+    const report = JSON.parse(out.join("\n"));
+    expect(report.enabled).toBe(false);
+    expect(report.agents).toEqual([]);
+  });
+
+  test("status reflects env-configured caps and ledger spend", async () => {
+    const ledger = new BudgetLedger({ agencHome: home });
+    ledger.addSpend("worker", 1.25, 5000);
+    ledger.setPaused("worker", true);
+
+    const out: string[] = [];
+    const code = await runAgenCBudgetCli(
+      { kind: "status", json: true },
+      {
+        env: { ...env, AGENC_BUDGET: "on", AGENC_BUDGET_DAILY_USD: "5" },
+        stdout: (l) => out.push(l),
+      },
+    );
+    expect(code).toBe(0);
+    const report = JSON.parse(out.join("\n"));
+    expect(report.enabled).toBe(true);
+    expect(report.policy.dailyUsd).toBe(5);
+    const worker = report.agents.find((a: { agentId: string }) => a.agentId === "worker");
+    expect(worker.paused).toBe(true);
+    expect(worker.day.usd).toBeCloseTo(1.25);
+  });
+
+  test("reset clears an agent's spend and pause", async () => {
+    const ledger = new BudgetLedger({ agencHome: home });
+    ledger.addSpend("worker", 3, 1000);
+    ledger.setPaused("worker", true);
+
+    const out: string[] = [];
+    const code = await runAgenCBudgetCli(
+      { kind: "reset", agentId: "worker" },
+      { env, stdout: (l) => out.push(l) },
+    );
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("reset");
+
+    const after = new BudgetLedger({ agencHome: home }).snapshot("worker");
+    expect(after.day.usd).toBe(0);
+    expect(after.paused).toBe(false);
+  });
+});

--- a/runtime/tests/budget/budget.test.ts
+++ b/runtime/tests/budget/budget.test.ts
@@ -1,0 +1,275 @@
+// Budget enforcement (TODO task 15). The research-grounded invariants
+// (docs/design/budget-enforcement.md) are the point: external metering,
+// worst-case debit + reconcile, fail-closed on both windows, pause+notify,
+// one-shot soft warning, never a silent downgrade.
+
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { resolveBudgetPolicy } from "../../src/budget/config.js";
+import { BudgetLedger, windowKeys } from "../../src/budget/ledger.js";
+import { BudgetEnforcer } from "../../src/budget/enforcer.js";
+import type {
+  AdmitRequest,
+  BudgetNotification,
+  BudgetPolicy,
+  ModelPrice,
+} from "../../src/budget/types.js";
+
+// A model priced at $1/M input, $3/M output — clean numbers for the math.
+const PRICE: ModelPrice = { inputPerMTokens: 1, outputPerMTokens: 3 };
+const priceOf = (model: string): ModelPrice | null =>
+  model === "unpriced" ? null : PRICE;
+
+describe("resolveBudgetPolicy", () => {
+  test("disabled by default, no caps", () => {
+    const { policy } = resolveBudgetPolicy(undefined, {});
+    expect(policy.enabled).toBe(false);
+    expect(policy.caps).toEqual({});
+    expect(policy.softThreshold).toBe(0.8);
+    expect(policy.enforceInteractive).toBe(false);
+  });
+
+  test("config sets caps; env overrides (env > config > default)", () => {
+    const { policy, sources } = resolveBudgetPolicy(
+      { enabled: true, daily_usd: 5, monthly_usd: 100 },
+      { AGENC_BUDGET_DAILY_USD: "2" },
+    );
+    expect(policy.enabled).toBe(true);
+    expect(policy.caps.dailyUsd).toBe(2); // env wins
+    expect(policy.caps.monthlyUsd).toBe(100); // config
+    expect(sources.dailyUsd).toBe("env");
+    expect(sources.monthlyUsd).toBe("config");
+  });
+
+  test("AGENC_BUDGET env kill switch disables even when config enables", () => {
+    const { policy } = resolveBudgetPolicy(
+      { enabled: true, daily_usd: 5 },
+      { AGENC_BUDGET: "off" },
+    );
+    expect(policy.enabled).toBe(false);
+  });
+
+  test("soft threshold + enforce_interactive parse", () => {
+    const { policy } = resolveBudgetPolicy({
+      enabled: true,
+      soft_threshold: 0.5,
+      enforce_interactive: true,
+    });
+    expect(policy.softThreshold).toBe(0.5);
+    expect(policy.enforceInteractive).toBe(true);
+  });
+});
+
+describe("BudgetLedger", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-budget-ledger-"));
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  test("addSpend accumulates into both windows; persists 0600", () => {
+    const ledger = new BudgetLedger({
+      agencHome: home,
+      now: () => new Date("2026-07-09T10:00:00Z"),
+    });
+    ledger.addSpend("a1", 1.5, 1000);
+    ledger.addSpend("a1", 0.5, 200);
+    const s = ledger.snapshot("a1");
+    expect(s.day.usd).toBeCloseTo(2.0);
+    expect(s.day.tokens).toBe(1200);
+    expect(s.month.usd).toBeCloseTo(2.0);
+    const mode = statSync(join(home, "budget", "ledger.json")).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("a new day rolls the day window but keeps the month", () => {
+    let now = new Date("2026-07-09T10:00:00Z");
+    const ledger = new BudgetLedger({ agencHome: home, now: () => now });
+    ledger.addSpend("a1", 3, 1000);
+    now = new Date("2026-07-10T10:00:00Z"); // next day, same month
+    const s = ledger.snapshot("a1");
+    expect(s.day.usd).toBe(0); // day rolled
+    expect(s.month.usd).toBeCloseTo(3); // month persists
+    expect(s.day.key).toBe("2026-07-10");
+    expect(s.month.key).toBe("2026-07");
+  });
+
+  test("a new month rolls both windows", () => {
+    let now = new Date("2026-07-31T10:00:00Z");
+    const ledger = new BudgetLedger({ agencHome: home, now: () => now });
+    ledger.addSpend("a1", 3, 1000);
+    now = new Date("2026-08-01T10:00:00Z");
+    const s = ledger.snapshot("a1");
+    expect(s.day.usd).toBe(0);
+    expect(s.month.usd).toBe(0);
+  });
+
+  test("persists across reconstruction; reset clears", () => {
+    const now = () => new Date("2026-07-09T10:00:00Z");
+    const l1 = new BudgetLedger({ agencHome: home, now });
+    l1.addSpend("a1", 4, 500);
+    l1.setPaused("a1", true);
+    const l2 = new BudgetLedger({ agencHome: home, now });
+    expect(l2.snapshot("a1").day.usd).toBeCloseTo(4);
+    expect(l2.snapshot("a1").paused).toBe(true);
+    l2.reset("a1");
+    expect(l2.snapshot("a1").day.usd).toBe(0);
+    expect(l2.snapshot("a1").paused).toBe(false);
+  });
+
+  test("windowKeys formats day and month", () => {
+    const { dayKey, monthKey } = windowKeys(new Date("2026-01-05T00:00:00Z"));
+    expect(dayKey).toBe("2026-01-05");
+    expect(monthKey).toBe("2026-01");
+  });
+
+  test("corrupt ledger fails toward zero spend (never fabricates)", () => {
+    const now = () => new Date("2026-07-09T10:00:00Z");
+    const l1 = new BudgetLedger({ agencHome: home, now });
+    l1.addSpend("a1", 4, 500);
+    require("node:fs").writeFileSync(join(home, "budget", "ledger.json"), "{bad");
+    const l2 = new BudgetLedger({ agencHome: home, now });
+    expect(l2.snapshot("a1").day.usd).toBe(0);
+  });
+});
+
+describe("BudgetEnforcer", () => {
+  let home: string;
+  let notes: BudgetNotification[];
+  const now = () => new Date("2026-07-09T10:00:00Z");
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-budget-enf-"));
+    notes = [];
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  let sharedLedger: BudgetLedger;
+
+  function make(policy: Partial<BudgetPolicy>): BudgetEnforcer {
+    // One ledger instance shared with the test so reads see the enforcer's
+    // writes (each BudgetLedger holds its own in-memory copy).
+    sharedLedger = new BudgetLedger({ agencHome: home, now });
+    return new BudgetEnforcer({
+      policy: {
+        enabled: true,
+        softThreshold: 0.8,
+        enforceInteractive: false,
+        caps: {},
+        ...policy,
+      },
+      ledger: sharedLedger,
+      priceOf,
+      notify: (e) => notes.push(e),
+    });
+  }
+
+  const autoReq = (over: Partial<AdmitRequest> = {}): AdmitRequest => ({
+    agentId: "a1",
+    model: "m",
+    autonomous: true,
+    estInputTokens: 1000,
+    maxOutputTokens: 1000,
+    ...over,
+  });
+
+  test("disabled: admits everything with a zero hold; reconcile is a no-op", () => {
+    const enf = make({ enabled: false, caps: { dailyUsd: 0.0001 } });
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.hold.estimatedUsd).toBe(0);
+      enf.reconcile(r.hold, { inputTokens: 999999, outputTokens: 999999 });
+    }
+  });
+
+  test("interactive turn is out of scope unless enforceInteractive", () => {
+    const enf = make({ caps: { dailyUsd: 0.0001 } });
+    const r = enf.admit(autoReq({ autonomous: false }));
+    expect(r.ok).toBe(true); // interactive not gated
+    if (r.ok) expect(r.hold.estimatedUsd).toBe(0);
+  });
+
+  test("admit debits worst-case; reconcile refunds the delta to actual", () => {
+    const enf = make({ caps: { dailyUsd: 100 } });
+    // worst-case for 1000 in + 1000 out at $1/$3 per M = 0.001 + 0.003 = $0.004
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(true);
+    expect(sharedLedger.snapshot("a1").day.usd).toBeCloseTo(0.004, 6);
+    expect(sharedLedger.snapshot("a1").day.tokens).toBe(2000); // worst-case held
+    if (r.ok) {
+      // Actual: 1000 in + 200 out = 0.001 + 0.0006 = $0.0016
+      enf.reconcile(r.hold, { inputTokens: 1000, outputTokens: 200 });
+    }
+    expect(sharedLedger.snapshot("a1").day.usd).toBeCloseTo(0.0016, 6);
+    expect(sharedLedger.snapshot("a1").day.tokens).toBe(1200); // reconciled to actual
+  });
+
+  test("FAIL CLOSED: worst-case over the daily cap refuses, pauses, notifies", () => {
+    const enf = make({ caps: { dailyUsd: 0.003 } }); // worst-case 0.004 > 0.003
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("BUDGET_EXCEEDED");
+      expect(r.reason).toBe("daily_usd");
+    }
+    // Autonomy paused + a paused notification fired (fail closed, not downgrade).
+    expect(new BudgetLedger({ agencHome: home, now }).snapshot("a1").paused).toBe(true);
+    expect(notes.some((n) => n.kind === "paused")).toBe(true);
+  });
+
+  test("a paused agent is refused with reason 'paused' on the next admit", () => {
+    const enf = make({ caps: { dailyUsd: 0.003 } });
+    enf.admit(autoReq()); // trips + pauses
+    const r2 = enf.admit(autoReq());
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.reason).toBe("paused");
+  });
+
+  test("monthly cap is enforced independently of the daily cap", () => {
+    const enf = make({ caps: { dailyUsd: 1000, monthlyUsd: 0.003 } });
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("monthly_usd");
+  });
+
+  test("token caps gate even when the model is unpriced", () => {
+    const enf = make({ caps: { dailyTokens: 1500 } }); // worst-case 2000 tokens
+    const r = enf.admit(autoReq({ model: "unpriced" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("daily_tokens");
+  });
+
+  test("unpriced model passes dollar caps (documented limitation)", () => {
+    const enf = make({ caps: { dailyUsd: 0.0000001 } });
+    const r = enf.admit(autoReq({ model: "unpriced" }));
+    expect(r.ok).toBe(true); // no price → dollar cap can't gate
+  });
+
+  test("soft warning fires once when a window crosses the threshold", () => {
+    const enf = make({ caps: { dailyUsd: 0.01 }, softThreshold: 0.5 });
+    // Each turn worst-case 0.004, actual set to 0.004 (in=1000,out=1000).
+    const r1 = enf.admit(autoReq());
+    if (r1.ok) enf.reconcile(r1.hold, { inputTokens: 1000, outputTokens: 1000 });
+    // 0.004 < 0.5*0.01=0.005 → no warning yet
+    expect(notes.filter((n) => n.kind === "soft_warning")).toHaveLength(0);
+    const r2 = enf.admit(autoReq());
+    if (r2.ok) enf.reconcile(r2.hold, { inputTokens: 1000, outputTokens: 1000 });
+    // 0.008 >= 0.005 → one warning
+    const warns = notes.filter((n) => n.kind === "soft_warning" && n.window === "day");
+    expect(warns).toHaveLength(1);
+    // A third crossing does not re-warn.
+    const r3 = enf.admit(autoReq());
+    if (r3.ok) enf.reconcile(r3.hold, { inputTokens: 100, outputTokens: 100 });
+    expect(notes.filter((n) => n.kind === "soft_warning" && n.window === "day")).toHaveLength(1);
+  });
+
+  test("enforceInteractive gates interactive turns too", () => {
+    const enf = make({ caps: { dailyUsd: 0.003 }, enforceInteractive: true });
+    const r = enf.admit(autoReq({ autonomous: false }));
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
The daemon-owned budget primitive that bounds autonomous-agent spend, so AgenC never reproduces the OpenClaw idle-burn failure mode ($30-100/mo verified idle heartbeat horror stories). **Grounded in a SOTA literature review** (3 parallel research passes) captured in `docs/design/budget-enforcement.md`.

## Why it's not a duplicate
The background-agent runner already has **per-run** caps (`[agent]` token_cap/dollar_cap/wall_clock). This adds the missing piece: a persistent **per-agent cumulative daily+monthly envelope** that spans runs and daemon restarts — the layer that bounds a heartbeat firing every 30 min forever, which no per-run cap can. They compose.

## Research-grounded invariants (each unit-tested; the two safety-critical ones revert-proven)
- **External metering, never the model's self-estimate** — BAGEN (2606.00198) shows agents are systematically optimistic about their own remaining budget (r≈0.35, ~47% calibration even after training). The daemon is the meter and gate.
- **Pre-flight admission gate**; post-hoc accounting is reconciliation, not control (monitoring ≠ enforcement).
- **Debit worst-case (est input + max output) up front, reconcile from the real usage, refund the delta** — makes mid-turn exhaustion structurally impossible.
- **Fail closed on BOTH daily and monthly caps**: refuse with a typed `BUDGET_EXCEEDED`, pause autonomy, notify — **never a silent model downgrade** (which would hide the boundary; per the incident catalog 2606.04056 and Claude Code's `/usage-credits` pattern).
- One-shot soft warning at a configurable threshold (default 80%).

## Shape
`runtime/src/budget/`: types, config (env>config>default, **disabled by default → zero behavior change**), ledger (0600, calendar day+month windows rolling by date key, atomic writes), enforcer (admit/reconcile/pause/notify), pricing adapter (bridges the cost registry). `[budget]` config block + `AGENC_BUDGET*` env. CLI: `agenc budget status [--json] | reset <agent>`.

## Scope
Ships the **primitive + CLI + tests + design note**. The live wire-in into the autonomous loop lands with **task 14 (heartbeat)** — the loop that actually ticks on its own; wiring enforcement now against a surface that doesn't self-fire would be speculative plumbing. This is exactly how the roadmap sequences it (budgets before heartbeat). Deferred items each trace to the research (per-model-call gate, velocity circuit-breaker, delegation conservation, cheap-utility-model routing).

## Verification
31 tests (config precedence, ledger window-roll/persistence/reset/corruption, and the enforcer invariants above). Fail-closed and worst-case-debit both **revert-proven**. Live-smoked the CLI (disabled default + env-configured caps). Gates: vitest **14161**, bun 74, typecheck 0, agent-surface-contract ok.