### PR TITLE
feat(heartbeat): proactive budget-bounded ticks + live budget wire-in (task 14)

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -43,6 +43,28 @@ The **Telegram channel** uses the official Bot API (no reverse-engineered
 client, no account-ban risk). Create a bot with @BotFather, export the token,
 and message it. Streaming replies edit one message in place.
 
+## Heartbeat (proactive ticks)
+
+`agenc gateway run --heartbeat` (or `[heartbeat] enabled = true`) runs a
+periodic autonomous turn: on each tick the agent reads `HEARTBEAT.md` from the
+workspace and acts, replying `HEARTBEAT_OK` (delivery suppressed) when there is
+nothing to do. It is **bounded by the budget layer** (task 15): each tick is
+admitted pre-flight, and if the agent's daily/monthly cap would be exceeded the
+turn is skipped and a "heartbeat paused" notice is delivered instead of
+silently spending — so a heartbeat can never become the idle-burn furnace.
+
+Config (`[heartbeat]` / `AGENC_HEARTBEAT*`): `interval_seconds` (default 1800),
+`active_hours` (e.g. `8-22`, local), `skip_when_busy`, `model` (utility model),
+`target_channel`/`target_conversation` (or `none` to run without delivering),
+and `agent` (the budget envelope this heartbeat draws from). Disabled by
+default.
+
+> Note: live heartbeat turns (and live channel turns generally) currently
+> require the gateway's daemon-agent provisioning fix — see TODO task 34. The
+> heartbeat scheduling, gating, budget enforcement, suppression, and delivery
+> are complete and tested against a fake daemon client; the remaining piece is
+> the shared gateway↔daemon session-agent bootstrap.
+
 ## Security model (non-negotiable)
 
 - **Pairing by default.** An unknown DM sender gets a one-time, expiring

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -20,7 +20,12 @@ import { startGateway } from "../gateway/run.js";
 import type { GatewayConfig } from "../gateway/types.js";
 
 export type AgenCGatewayCliCommand =
-  | { readonly kind: "run"; readonly stdio: boolean; readonly webchat: boolean }
+  | {
+      readonly kind: "run";
+      readonly stdio: boolean;
+      readonly webchat: boolean;
+      readonly heartbeat: boolean;
+    }
   | { readonly kind: "status"; readonly json: boolean }
   | { readonly kind: "pairing-list"; readonly json: boolean }
   | {
@@ -36,12 +41,14 @@ export function formatAgenCGatewayCliHelpText(): string {
     "agenc gateway — inspect and operate the channel gateway",
     "",
     "Usage:",
-    "  agenc gateway run [--stdio] [--webchat]",
+    "  agenc gateway run [--stdio] [--webchat] [--heartbeat]",
     "                                        Start the gateway. --stdio enables",
     "                                        the local dev channel; --webchat a",
     "                                        loopback token-gated browser UI;",
-    "                                        Telegram when AGENC_TELEGRAM_BOT_TOKEN",
-    "                                        is set. Runs until Ctrl-C.",
+    "                                        --heartbeat proactive budget-bounded",
+    "                                        ticks (HEARTBEAT.md); Telegram when",
+    "                                        AGENC_TELEGRAM_BOT_TOKEN is set.",
+    "                                        Runs until Ctrl-C.",
     "  agenc gateway status [--json]         Channels, DM policies, bindings,",
     "                                        paired-sender counts",
     "  agenc gateway pairing list [--json]   Paired senders per channel",
@@ -70,6 +77,7 @@ export function parseAgenCGatewayCliArgs(
       kind: "run",
       stdio: rest.includes("--stdio"),
       webchat: rest.includes("--webchat"),
+      heartbeat: rest.includes("--heartbeat"),
     };
   }
   if (positional[0] === "status") {
@@ -191,13 +199,16 @@ export async function runAgenCGatewayCli(
         env,
         stdio: command.stdio,
         webchat: command.webchat,
+        heartbeat: command.heartbeat,
         log: (line) => stderr(line),
       });
     } catch (error) {
       stderr(`agenc: ${error instanceof Error ? error.message : String(error)}`);
       return 1;
     }
-    stdout(`gateway running (channels: ${handle.channels.join(", ")}). Ctrl-C to stop.`);
+    const channelsLabel =
+      handle.channels.length > 0 ? handle.channels.join(", ") : "none";
+    stdout(`gateway running (channels: ${channelsLabel}). Ctrl-C to stop.`);
     if (handle.webchatUrl !== undefined) {
       stdout(`  WebChat: ${handle.webchatUrl}`);
     }

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -543,6 +543,22 @@ export interface TransactionGuardConfig {
 }
 
 /**
+ * `[heartbeat]` — proactive autonomous ticks (task 14). Disabled by default.
+ * `AGENC_HEARTBEAT*` env vars override (see `heartbeat/config.ts`).
+ */
+export interface HeartbeatConfig {
+  readonly enabled?: boolean;
+  readonly interval_seconds?: number;
+  readonly model?: string;
+  /** [startHour, endHour) in local 24h; omit for always-active. */
+  readonly active_hours?: readonly number[];
+  readonly skip_when_busy?: boolean;
+  readonly agent?: string;
+  readonly target_channel?: string;
+  readonly target_conversation?: string;
+}
+
+/**
  * `[budget]` — cost-bounded autonomy (task 15). Per-agent hard spend caps
  * enforced daemon-side around autonomous turns. Disabled by default; a cap of
  * 0/absent means no cap. `AGENC_BUDGET*` env vars override
@@ -644,6 +660,11 @@ export interface AgenCConfig {
    * `AGENC_BUDGET*` env vars override. See `budget/config.ts`.
    */
   readonly budget?: BudgetConfig;
+  /**
+   * Proactive heartbeat (`[heartbeat]`). Optional — disabled by default;
+   * `AGENC_HEARTBEAT*` env vars override. See `heartbeat/config.ts`.
+   */
+  readonly heartbeat?: HeartbeatConfig;
   readonly agenc_home?: string;
   readonly workspace?: string;
   readonly simpleMode?: boolean;
@@ -782,6 +803,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = Object.freeze([
   "coordinator_mode",
   "transaction_guard",
   "budget",
+  "heartbeat",
   "agenc_home",
   "workspace",
   "simpleMode",

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -18,6 +18,10 @@ import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { loadConfig } from "../config/loader.js";
+import { resolveHeartbeatPolicy } from "../heartbeat/config.js";
+import { startHeartbeat } from "../heartbeat/wire.js";
+import type { HeartbeatScheduler } from "../heartbeat/scheduler.js";
 import { ChannelGateway } from "./gateway.js";
 import { loadGatewayConfig } from "./config.js";
 import { createSdkDaemonClient } from "./sdk-daemon-client.js";
@@ -48,6 +52,12 @@ export interface GatewayRunOptions {
   readonly telegramToken?: string;
   /** Enable the WebChat browser surface (loopback + token). */
   readonly webchat?: boolean;
+  /** Force the proactive heartbeat on for this run (else [heartbeat] config). */
+  readonly heartbeat?: boolean;
+  /** Workspace dir for HEARTBEAT.md (default process.cwd()). */
+  readonly workspaceDir?: string;
+  /** Test seam: inject the heartbeat clock (real timers by default). */
+  readonly heartbeatClock?: import("../heartbeat/types.js").HeartbeatClock;
   /** WebChat bind host (default 127.0.0.1) / port (default ephemeral). */
   readonly webchatHost?: string;
   readonly webchatPort?: number;
@@ -152,9 +162,17 @@ export async function startGateway(
     adapters.push(adapter);
   }
 
-  if (adapters.length === 0) {
+  // A heartbeat-only run (proactive ticks, no channel) is valid.
+  const heartbeatRequested =
+    options.heartbeat === true ||
+    resolveHeartbeatPolicy(
+      (await loadConfig({ home: options.agencHome, onWarn: log })).config
+        .heartbeat,
+      env,
+    ).enabled;
+  if (adapters.length === 0 && !heartbeatRequested) {
     throw new Error(
-      "gateway run: no channels enabled — pass --stdio, --webchat, set AGENC_TELEGRAM_BOT_TOKEN, or configure a channel",
+      "gateway run: no channels enabled — pass --stdio, --webchat, --heartbeat, set AGENC_TELEGRAM_BOT_TOKEN, or configure a channel",
     );
   }
 
@@ -201,6 +219,36 @@ export async function startGateway(
     log(`gateway: WebChat on ${webchat.url}`);
   }
 
+  // Heartbeat (task 14): proactive autonomous ticks, bounded by the budget
+  // layer. Enabled via [heartbeat] config or AGENC_HEARTBEAT; --heartbeat
+  // forces it on for this run. Uses the same daemon client + channel adapters.
+  let heartbeat: HeartbeatScheduler | null = null;
+  try {
+    const mainConfig = (await loadConfig({ home: options.agencHome, onWarn: log }))
+      .config;
+    const heartbeatConfig =
+      options.heartbeat === true
+        ? {
+            ...mainConfig,
+            heartbeat: { ...mainConfig.heartbeat, enabled: true },
+          }
+        : mainConfig;
+    heartbeat = await startHeartbeat({
+      agencHome: options.agencHome,
+      workspaceDir: options.workspaceDir ?? process.cwd(),
+      config: heartbeatConfig,
+      env,
+      client,
+      adapters,
+      log,
+      ...(options.heartbeatClock !== undefined
+        ? { clock: options.heartbeatClock }
+        : {}),
+    });
+  } catch (error) {
+    log(`heartbeat: failed to start (continuing without it): ${String(error)}`);
+  }
+
   log(`gateway: running with channels: ${started.join(", ")}`);
 
   return {
@@ -208,6 +256,7 @@ export async function startGateway(
     channels: started,
     ...(webchat !== undefined ? { webchatUrl: webchat.url } : {}),
     async stop() {
+      if (heartbeat !== null) await heartbeat.stop();
       await gateway.stop();
       await client.close();
     },

--- a/runtime/src/gateway/sdk-daemon-client.ts
+++ b/runtime/src/gateway/sdk-daemon-client.ts
@@ -35,8 +35,16 @@ interface SdkPermissionRequest {
   readonly permissions: readonly string[];
   readonly reason?: string;
 }
+interface SdkUsage {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+}
 interface SdkPromptRun extends AsyncIterable<{ type: string; delta?: string; message?: string }> {
-  result(): Promise<{ stopReason: string; finalMessage: string }>;
+  result(): Promise<{
+    stopReason: string;
+    finalMessage: string;
+    usage?: SdkUsage;
+  }>;
 }
 interface SdkSession {
   readonly sessionId: string;
@@ -89,7 +97,18 @@ function wrapSession(sdkSession: SdkSession): GatewaySession {
         result.stopReason === "stopped"
           ? result.stopReason
           : "errored";
-      return { stopReason, finalMessage: result.finalMessage };
+      const usage =
+        result.usage !== undefined
+          ? {
+              inputTokens: result.usage.inputTokens ?? 0,
+              outputTokens: result.usage.outputTokens ?? 0,
+            }
+          : undefined;
+      return {
+        stopReason,
+        finalMessage: result.finalMessage,
+        ...(usage !== undefined ? { usage } : {}),
+      };
     },
   };
 }

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -122,6 +122,8 @@ export type GatewayPromptEvent =
 export interface GatewayPromptResult {
   readonly stopReason: "completed" | "errored" | "stopped";
   readonly finalMessage: string;
+  /** Real token usage, when the daemon reports it (used for budget reconcile). */
+  readonly usage?: { readonly inputTokens: number; readonly outputTokens: number };
 }
 
 export interface GatewayPromptHandlers {

--- a/runtime/src/heartbeat/config.ts
+++ b/runtime/src/heartbeat/config.ts
@@ -1,0 +1,138 @@
+/**
+ * Heartbeat policy resolution (TODO task 14), env > config > default. Disabled
+ * by default: no ticks until an operator opts in.
+ *
+ * Env overrides:
+ *   AGENC_HEARTBEAT             "on"/"1"/"true" enables, else disables
+ *   AGENC_HEARTBEAT_INTERVAL    seconds between ticks
+ *   AGENC_HEARTBEAT_MODEL       utility model for heartbeat turns
+ *   AGENC_HEARTBEAT_ACTIVE_HOURS  "startHour-endHour" (24h), e.g. "8-22"
+ *   AGENC_HEARTBEAT_TARGET      "none" | "<channelId>:<conversationId>"
+ *   AGENC_HEARTBEAT_AGENT       agent id for the budget envelope + session
+ */
+
+import type { HeartbeatConfig } from "../config/schema.js";
+import type { HeartbeatPolicy, HeartbeatTarget } from "./types.js";
+
+export const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 1800; // 30 min
+export const DEFAULT_HEARTBEAT_AGENT = "default";
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "on" || v === "1" || v === "true" || v === "yes") return true;
+  if (v === "off" || v === "0" || v === "false" || v === "no") return false;
+  return undefined;
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+/** "8-22" → [8, 22]; invalid → null. Hours are [0,24], start < end. */
+export function parseActiveHours(
+  value: string | undefined,
+): readonly [number, number] | null | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "" || trimmed === "always" || trimmed === "all") return null;
+  const m = /^(\d{1,2})\s*-\s*(\d{1,2})$/.exec(trimmed);
+  if (m === null) return null;
+  const start = Number.parseInt(m[1], 10);
+  const end = Number.parseInt(m[2], 10);
+  if (start < 0 || end > 24 || start >= end) return null;
+  return [start, end];
+}
+
+/** "none" or "<channelId>:<conversationId>" → target; default none. */
+export function parseTarget(value: string | undefined): HeartbeatTarget {
+  const v = nonEmpty(value);
+  if (v === undefined || v.toLowerCase() === "none") return { kind: "none" };
+  const idx = v.indexOf(":");
+  if (idx <= 0 || idx === v.length - 1) return { kind: "none" };
+  return {
+    kind: "channel",
+    channelId: v.slice(0, idx),
+    conversationId: v.slice(idx + 1),
+  };
+}
+
+export function resolveHeartbeatPolicy(
+  config?: HeartbeatConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): HeartbeatPolicy {
+  const enabled =
+    parseBool(nonEmpty(env.AGENC_HEARTBEAT)) ?? config?.enabled ?? false;
+
+  const intervalSeconds =
+    parsePositiveInt(nonEmpty(env.AGENC_HEARTBEAT_INTERVAL)) ??
+    (config?.interval_seconds !== undefined && config.interval_seconds > 0
+      ? config.interval_seconds
+      : DEFAULT_HEARTBEAT_INTERVAL_SECONDS);
+
+  const model = nonEmpty(env.AGENC_HEARTBEAT_MODEL) ?? nonEmpty(config?.model);
+
+  const activeHoursEnv = parseActiveHours(nonEmpty(env.AGENC_HEARTBEAT_ACTIVE_HOURS));
+  const activeHours =
+    activeHoursEnv !== undefined
+      ? activeHoursEnv
+      : config?.active_hours !== undefined
+        ? parseActiveHoursFromConfig(config.active_hours)
+        : null;
+
+  const target =
+    nonEmpty(env.AGENC_HEARTBEAT_TARGET) !== undefined
+      ? parseTarget(env.AGENC_HEARTBEAT_TARGET)
+      : configTarget(config);
+
+  const agentId =
+    nonEmpty(env.AGENC_HEARTBEAT_AGENT) ??
+    nonEmpty(config?.agent) ??
+    DEFAULT_HEARTBEAT_AGENT;
+
+  const skipWhenBusy = config?.skip_when_busy ?? true;
+
+  return {
+    enabled,
+    intervalSeconds,
+    agentId,
+    ...(model !== undefined ? { model } : {}),
+    activeHours,
+    skipWhenBusy,
+    target,
+  };
+}
+
+function parseActiveHoursFromConfig(
+  value: readonly number[],
+): readonly [number, number] | null {
+  if (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number" &&
+    value[0] >= 0 &&
+    value[1] <= 24 &&
+    value[0] < value[1]
+  ) {
+    return [value[0], value[1]];
+  }
+  return null;
+}
+
+function configTarget(config?: HeartbeatConfig): HeartbeatTarget {
+  if (config?.target_channel !== undefined && config.target_conversation !== undefined) {
+    return {
+      kind: "channel",
+      channelId: config.target_channel,
+      conversationId: config.target_conversation,
+    };
+  }
+  return { kind: "none" };
+}

--- a/runtime/src/heartbeat/heartbeat-file.ts
+++ b/runtime/src/heartbeat/heartbeat-file.ts
@@ -1,0 +1,28 @@
+/**
+ * HEARTBEAT.md reader (TODO task 14). Reads the workspace HEARTBEAT.md fresh on
+ * each tick (so edits take effect without a restart); returns null when absent.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { HeartbeatFileReader } from "./types.js";
+
+export const HEARTBEAT_FILENAME = "HEARTBEAT.md";
+
+export class WorkspaceHeartbeatFileReader implements HeartbeatFileReader {
+  readonly #path: string;
+
+  constructor(workspaceDir: string) {
+    this.#path = join(workspaceDir, HEARTBEAT_FILENAME);
+  }
+
+  read(): string | null {
+    if (!existsSync(this.#path)) return null;
+    try {
+      return readFileSync(this.#path, "utf8");
+    } catch {
+      return null;
+    }
+  }
+}

--- a/runtime/src/heartbeat/index.ts
+++ b/runtime/src/heartbeat/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Heartbeat (TODO task 14, Phase 2). Periodic autonomous agent turns, bounded
+ * by the task-15 budget layer. Disabled by default.
+ */
+
+export * from "./types.js";
+export {
+  resolveHeartbeatPolicy,
+  parseActiveHours,
+  parseTarget,
+  DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+  DEFAULT_HEARTBEAT_AGENT,
+} from "./config.js";
+export {
+  HeartbeatRunner,
+  heartbeatPrompt,
+  type HeartbeatRunnerOptions,
+} from "./runner.js";
+export {
+  HeartbeatScheduler,
+  type HeartbeatSchedulerOptions,
+} from "./scheduler.js";
+export {
+  WorkspaceHeartbeatFileReader,
+  HEARTBEAT_FILENAME,
+} from "./heartbeat-file.js";

--- a/runtime/src/heartbeat/runner.ts
+++ b/runtime/src/heartbeat/runner.ts
@@ -1,0 +1,155 @@
+/**
+ * Heartbeat tick runner (TODO task 14).
+ *
+ * One tick, in order:
+ *   1. gates: enabled, active hours, cron-running defer, skip-when-busy
+ *   2. HEARTBEAT.md present? (absent → nothing to do)
+ *   3. BUDGET ADMIT (task-15 enforcer): worst-case pre-flight. On refusal the
+ *      turn is NOT run — the budget layer has already paused autonomy — and a
+ *      one-line budget notice is delivered to the target (fail closed, visible,
+ *      never a silent skip).
+ *   4. run the heartbeat turn on the utility model
+ *   5. HEARTBEAT_OK reply → suppress delivery; otherwise deliver
+ *   6. reconcile the budget from the real usage
+ */
+
+import {
+  HEARTBEAT_OK,
+  type HeartbeatBudgetGate,
+  type HeartbeatClock,
+  type HeartbeatDelivery,
+  type HeartbeatFileReader,
+  type HeartbeatPolicy,
+  type HeartbeatTickOutcome,
+  type HeartbeatTurnRunner,
+} from "./types.js";
+
+export interface HeartbeatRunnerOptions {
+  readonly policy: HeartbeatPolicy;
+  readonly clock: HeartbeatClock;
+  readonly turnRunner: HeartbeatTurnRunner;
+  readonly delivery: HeartbeatDelivery;
+  readonly file: HeartbeatFileReader;
+  /** Optional budget gate; when absent, no budget enforcement. */
+  readonly budget?: HeartbeatBudgetGate;
+  /** True while a cron job is executing (defer). Default: never. */
+  readonly isCronRunning?: () => boolean;
+  readonly log?: (line: string) => void;
+  /** Rough worst-case output cap for the pre-flight debit. */
+  readonly maxOutputTokens?: number;
+}
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+
+/** The system framing prepended to HEARTBEAT.md for a heartbeat turn. */
+export function heartbeatPrompt(heartbeatFile: string): string {
+  return (
+    "This is an automated heartbeat tick. Read the instructions below and do " +
+    "only what they require right now. If nothing needs attention, reply with " +
+    `exactly ${HEARTBEAT_OK} and nothing else.\n\n` +
+    `<heartbeat_instructions>\n${heartbeatFile}\n</heartbeat_instructions>`
+  );
+}
+
+/** Rough token estimate (chars/4) — deterministic, not a model guess. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function withinActiveHours(policy: HeartbeatPolicy, now: Date): boolean {
+  if (policy.activeHours === null) return true;
+  const [start, end] = policy.activeHours;
+  const hour = now.getHours();
+  return hour >= start && hour < end;
+}
+
+export class HeartbeatRunner {
+  readonly #o: HeartbeatRunnerOptions;
+  #busy = false;
+
+  constructor(options: HeartbeatRunnerOptions) {
+    this.#o = options;
+  }
+
+  /** Run one tick; never throws (errors become an `error` outcome). */
+  async tick(): Promise<HeartbeatTickOutcome> {
+    const { policy } = this.#o;
+    if (!policy.enabled) return { kind: "skipped", reason: "disabled" };
+    if (!withinActiveHours(policy, this.#o.clock.now())) {
+      return { kind: "skipped", reason: "outside_active_hours" };
+    }
+    if (this.#o.isCronRunning?.() === true) {
+      return { kind: "skipped", reason: "cron_running" };
+    }
+    if (policy.skipWhenBusy && this.#busy) {
+      return { kind: "skipped", reason: "busy" };
+    }
+
+    const heartbeatFile = this.#o.file.read();
+    if (heartbeatFile === null || heartbeatFile.trim().length === 0) {
+      return { kind: "skipped", reason: "no_heartbeat_file" };
+    }
+
+    this.#busy = true;
+    try {
+      return await this.#run(heartbeatFile);
+    } catch (error) {
+      return { kind: "error", message: String(error) };
+    } finally {
+      this.#busy = false;
+    }
+  }
+
+  async #run(heartbeatFile: string): Promise<HeartbeatTickOutcome> {
+    const { policy } = this.#o;
+    const prompt = heartbeatPrompt(heartbeatFile);
+    const model = policy.model ?? "";
+    const maxOutputTokens = this.#o.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+
+    // 3. Budget pre-flight (task 15). A refusal means autonomy is paused; do
+    // NOT run the turn — surface it instead of silently spending or skipping.
+    let hold: unknown = null;
+    if (this.#o.budget !== undefined) {
+      const admit = this.#o.budget.admit({
+        agentId: policy.agentId,
+        model: model.length > 0 ? model : "unknown",
+        estInputTokens: estimateTokens(prompt),
+        maxOutputTokens,
+      });
+      if (!admit.ok) {
+        const notice = `⏸ heartbeat paused: ${admit.message}`;
+        await this.#deliver(notice);
+        this.#o.log?.(`heartbeat: ${notice}`);
+        return { kind: "budget_paused", message: admit.message };
+      }
+      hold = admit.hold;
+    }
+
+    // 4. Run the turn.
+    const result = await this.#o.turnRunner.run(
+      prompt,
+      model.length > 0 ? model : undefined,
+    );
+
+    // 6. Reconcile budget from real usage (fall back to nothing if absent).
+    if (this.#o.budget !== undefined && hold !== null) {
+      this.#o.budget.reconcile(
+        hold,
+        result.usage ?? { inputTokens: 0, outputTokens: 0 },
+      );
+    }
+
+    // 5. HEARTBEAT_OK suppression.
+    const reply = result.finalMessage.trim();
+    if (reply === HEARTBEAT_OK || reply.length === 0) {
+      return { kind: "ok_suppressed" };
+    }
+    await this.#deliver(reply);
+    return { kind: "delivered", text: reply };
+  }
+
+  async #deliver(text: string): Promise<void> {
+    if (this.#o.policy.target.kind === "none") return;
+    await this.#o.delivery.deliver(this.#o.policy.target, text);
+  }
+}

--- a/runtime/src/heartbeat/scheduler.ts
+++ b/runtime/src/heartbeat/scheduler.ts
@@ -1,0 +1,65 @@
+/**
+ * Heartbeat scheduler (TODO task 14).
+ *
+ * A fixed-interval tick driver over an injectable clock (mirrors the
+ * cron-scheduler pattern so tests drive a fake clock). Re-entrancy safe: at
+ * most one tick runs at a time. `start()` arms the first timer; each completed
+ * tick arms the next; `stop()` cancels and awaits any in-flight tick.
+ */
+
+import type { HeartbeatClock, HeartbeatTickOutcome } from "./types.js";
+
+export interface HeartbeatSchedulerOptions {
+  readonly intervalSeconds: number;
+  readonly clock: HeartbeatClock;
+  /** Runs one tick; must not throw. */
+  onTick(): Promise<HeartbeatTickOutcome>;
+  readonly onOutcome?: (outcome: HeartbeatTickOutcome) => void;
+}
+
+export class HeartbeatScheduler {
+  readonly #o: HeartbeatSchedulerOptions;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #running = false;
+  #inFlight: Promise<void> = Promise.resolve();
+
+  constructor(options: HeartbeatSchedulerOptions) {
+    this.#o = options;
+  }
+
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.#arm();
+  }
+
+  async stop(): Promise<void> {
+    this.#running = false;
+    if (this.#timer !== null) {
+      this.#o.clock.clearTimer(this.#timer);
+      this.#timer = null;
+    }
+    await this.#inFlight;
+  }
+
+  #arm(): void {
+    if (!this.#running) return;
+    const ms = Math.max(1, this.#o.intervalSeconds * 1000);
+    this.#timer = this.#o.clock.setTimer(() => {
+      this.#timer = null;
+      this.#inFlight = this.#fire();
+    }, ms);
+  }
+
+  async #fire(): Promise<void> {
+    try {
+      const outcome = await this.#o.onTick();
+      this.#o.onOutcome?.(outcome);
+    } catch (error) {
+      this.#o.onOutcome?.({ kind: "error", message: String(error) });
+    } finally {
+      // Arm the next tick only if still running (stop() may have flipped it).
+      this.#arm();
+    }
+  }
+}

--- a/runtime/src/heartbeat/types.ts
+++ b/runtime/src/heartbeat/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Heartbeat types (TODO task 14, Phase 2).
+ *
+ * A heartbeat is a periodic autonomous agent turn: on each tick, if the gates
+ * pass and the budget admits, the agent reads HEARTBEAT.md and acts, replying
+ * `HEARTBEAT_OK` (suppressed) when there is nothing to do. This is the
+ * proactive half of the personal agent — bounded by the task-15 budget layer so
+ * it can never become the OpenClaw idle-burn furnace.
+ *
+ * Everything is injected (clock, turn-runner, delivery, budget, file reader) so
+ * the scheduler + runner are unit-tested against fakes with a fake clock.
+ */
+
+/** `none` runs the turn but delivers nothing; otherwise deliver to a channel. */
+export type HeartbeatTarget =
+  | { readonly kind: "none" }
+  | { readonly kind: "channel"; readonly channelId: string; readonly conversationId: string };
+
+export interface HeartbeatPolicy {
+  readonly enabled: boolean;
+  /** Seconds between ticks (default 1800 = 30 min). */
+  readonly intervalSeconds: number;
+  /** Agent id whose budget envelope + session this heartbeat uses. */
+  readonly agentId: string;
+  /** Utility model for heartbeat turns (cheap-by-default; see budget §6). */
+  readonly model?: string;
+  /**
+   * Local active hours [startHour, endHour) in 24h; outside them, ticks are
+   * skipped. `null` = always active.
+   */
+  readonly activeHours: readonly [number, number] | null;
+  /** Skip a tick if a heartbeat turn is already running. */
+  readonly skipWhenBusy: boolean;
+  readonly target: HeartbeatTarget;
+}
+
+export interface HeartbeatUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+}
+
+export interface HeartbeatTurnResult {
+  readonly finalMessage: string;
+  readonly usage?: HeartbeatUsage;
+}
+
+/** Runs one heartbeat turn (prompt → assistant text). Injected. */
+export interface HeartbeatTurnRunner {
+  run(prompt: string, model: string | undefined): Promise<HeartbeatTurnResult>;
+}
+
+/** Delivers heartbeat output to a channel target. Injected (gateway-backed). */
+export interface HeartbeatDelivery {
+  deliver(target: HeartbeatTarget, text: string): Promise<void>;
+}
+
+/** Reads HEARTBEAT.md; returns null when absent (→ nothing to do). Injected. */
+export interface HeartbeatFileReader {
+  read(): string | null;
+}
+
+/**
+ * Budget gate the heartbeat consults per tick. Mirrors the task-15
+ * BudgetEnforcer's admit/reconcile so it can be injected directly or faked.
+ */
+export interface HeartbeatBudgetGate {
+  admit(input: {
+    readonly agentId: string;
+    readonly model: string;
+    readonly estInputTokens: number;
+    readonly maxOutputTokens: number;
+  }):
+    | { readonly ok: true; readonly hold: unknown }
+    | { readonly ok: false; readonly message: string };
+  reconcile(hold: unknown, usage: HeartbeatUsage): void;
+}
+
+export interface HeartbeatClock {
+  now(): Date;
+  setTimer(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
+  clearTimer(handle: ReturnType<typeof setTimeout>): void;
+}
+
+/** Why a given tick did what it did — surfaced for logs + tests. */
+export type HeartbeatTickOutcome =
+  | { readonly kind: "skipped"; readonly reason: HeartbeatSkipReason }
+  | { readonly kind: "ok_suppressed" }
+  | { readonly kind: "delivered"; readonly text: string }
+  | { readonly kind: "budget_paused"; readonly message: string }
+  | { readonly kind: "error"; readonly message: string };
+
+export type HeartbeatSkipReason =
+  | "disabled"
+  | "outside_active_hours"
+  | "busy"
+  | "cron_running"
+  | "no_heartbeat_file";
+
+/** The literal reply that suppresses delivery ("nothing to do"). */
+export const HEARTBEAT_OK = "HEARTBEAT_OK";

--- a/runtime/src/heartbeat/wire.ts
+++ b/runtime/src/heartbeat/wire.ts
@@ -1,0 +1,156 @@
+/**
+ * Heartbeat ↔ gateway/budget integration (TODO task 14).
+ *
+ * Builds a live {@link HeartbeatScheduler} from the gateway's daemon client
+ * (turn runner), its channel adapters (delivery), the task-15 budget enforcer,
+ * and the workspace HEARTBEAT.md. Returns null when heartbeat is disabled.
+ *
+ * The utility-model OVERRIDE (running heartbeat turns on a cheaper model) is
+ * carried through `policy.model` to the turn runner, but applying it to the
+ * live daemon turn needs a per-turn model seam the SDK does not yet expose —
+ * that is the deferred cost-reduction tier (budget design §6). The budget CAP
+ * is the safety boundary and is fully live regardless of which model runs.
+ */
+
+import type { AgenCConfig } from "../config/schema.js";
+import {
+  BudgetEnforcer,
+  BudgetLedger,
+  createModelPriceResolver,
+  resolveBudgetPolicy,
+} from "../budget/index.js";
+import type { ChannelAdapter, GatewayDaemonClient } from "../gateway/types.js";
+import { resolveHeartbeatPolicy } from "./config.js";
+import { WorkspaceHeartbeatFileReader } from "./heartbeat-file.js";
+import { HeartbeatRunner } from "./runner.js";
+import { HeartbeatScheduler } from "./scheduler.js";
+import type {
+  HeartbeatBudgetGate,
+  HeartbeatClock,
+  HeartbeatDelivery,
+  HeartbeatTarget,
+  HeartbeatTurnRunner,
+  HeartbeatUsage,
+} from "./types.js";
+
+const REAL_CLOCK: HeartbeatClock = {
+  now: () => new Date(),
+  setTimer: (fn, ms) => setTimeout(fn, ms),
+  clearTimer: (handle) => clearTimeout(handle),
+};
+
+export interface StartHeartbeatOptions {
+  readonly agencHome: string;
+  readonly workspaceDir: string;
+  readonly config: AgenCConfig;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly client: GatewayDaemonClient;
+  readonly adapters: readonly ChannelAdapter[];
+  readonly log?: (line: string) => void;
+  readonly isCronRunning?: () => boolean;
+  /** Test seam: real timers by default. */
+  readonly clock?: HeartbeatClock;
+}
+
+/** Adapt the task-15 BudgetEnforcer to the heartbeat's budget-gate seam. */
+function budgetGate(
+  enforcer: BudgetEnforcer,
+): HeartbeatBudgetGate {
+  return {
+    admit(input) {
+      const r = enforcer.admit({ ...input, autonomous: true });
+      return r.ok
+        ? { ok: true, hold: r.hold }
+        : { ok: false, message: r.message };
+    },
+    reconcile(hold, usage: HeartbeatUsage) {
+      // The hold is a BudgetHold; the enforcer validates its own shape.
+      enforcer.reconcile(hold as never, usage);
+    },
+  };
+}
+
+/** A turn runner backed by a single gateway session (isolated heartbeat ctx). */
+function gatewayTurnRunner(
+  session: Awaited<ReturnType<GatewayDaemonClient["createSession"]>>,
+): HeartbeatTurnRunner {
+  return {
+    async run(prompt) {
+      const result = await session.prompt(prompt, {
+        onEvent: () => {},
+        // Autonomous, no human watching → deny permission requests (fail safe).
+        onPermissionRequest: async () => ({
+          behavior: "deny",
+          reason: "heartbeat turns do not grant tool permissions",
+        }),
+      });
+      return {
+        finalMessage: result.finalMessage,
+        ...(result.usage !== undefined ? { usage: result.usage } : {}),
+      };
+    },
+  };
+}
+
+function delivery(adapters: readonly ChannelAdapter[]): HeartbeatDelivery {
+  const byId = new Map(adapters.map((a) => [a.id, a]));
+  return {
+    async deliver(target: HeartbeatTarget, text: string) {
+      if (target.kind !== "channel") return;
+      const adapter = byId.get(target.channelId);
+      if (adapter === undefined) return;
+      await adapter.send({ conversationId: target.conversationId, text });
+    },
+  };
+}
+
+export async function startHeartbeat(
+  options: StartHeartbeatOptions,
+): Promise<HeartbeatScheduler | null> {
+  const env = options.env ?? process.env;
+  const log = options.log ?? (() => {});
+  const policy = resolveHeartbeatPolicy(options.config.heartbeat, env);
+  if (!policy.enabled) return null;
+
+  // Budget enforcer (task 15). Disabled budget → the gate admits everything.
+  const { policy: budgetPolicy } = resolveBudgetPolicy(options.config.budget, env);
+  const enforcer = new BudgetEnforcer({
+    policy: budgetPolicy,
+    ledger: new BudgetLedger({ agencHome: options.agencHome }),
+    priceOf: createModelPriceResolver(),
+    notify: (e) => log(`heartbeat/budget: ${e.message}`),
+  });
+
+  const session = await options.client.createSession();
+  const runner = new HeartbeatRunner({
+    policy,
+    clock: options.clock ?? REAL_CLOCK,
+    turnRunner: gatewayTurnRunner(session),
+    delivery: delivery(options.adapters),
+    file: new WorkspaceHeartbeatFileReader(options.workspaceDir),
+    budget: budgetGate(enforcer),
+    ...(options.isCronRunning !== undefined
+      ? { isCronRunning: options.isCronRunning }
+      : {}),
+    log,
+  });
+
+  const scheduler = new HeartbeatScheduler({
+    intervalSeconds: policy.intervalSeconds,
+    clock: options.clock ?? REAL_CLOCK,
+    onTick: () => runner.tick(),
+    onOutcome: (o) => {
+      if (o.kind === "delivered") log("heartbeat: delivered a message");
+      else if (o.kind === "budget_paused") log(`heartbeat: ${o.message}`);
+      else if (o.kind === "error") log(`heartbeat error: ${o.message}`);
+    },
+  });
+  scheduler.start();
+  log(
+    `heartbeat: running every ${policy.intervalSeconds}s` +
+      (policy.target.kind === "channel"
+        ? ` → ${policy.target.channelId}`
+        : " (no delivery)"),
+  );
+  return scheduler;
+}

--- a/runtime/tests/bin/gateway-cli.test.ts
+++ b/runtime/tests/bin/gateway-cli.test.ts
@@ -23,20 +23,22 @@ describe("parseAgenCGatewayCliArgs", () => {
       text: formatAgenCGatewayCliHelpText(),
     });
   });
-  test("run + --stdio + --webchat", () => {
+  test("run + --stdio + --webchat + --heartbeat", () => {
     expect(parseAgenCGatewayCliArgs(["gateway", "run"])).toEqual({
       kind: "run",
       stdio: false,
       webchat: false,
+      heartbeat: false,
     });
     expect(parseAgenCGatewayCliArgs(["gateway", "run", "--stdio"])).toEqual({
       kind: "run",
       stdio: true,
       webchat: false,
+      heartbeat: false,
     });
     expect(
-      parseAgenCGatewayCliArgs(["gateway", "run", "--webchat"]),
-    ).toEqual({ kind: "run", stdio: false, webchat: true });
+      parseAgenCGatewayCliArgs(["gateway", "run", "--webchat", "--heartbeat"]),
+    ).toEqual({ kind: "run", stdio: false, webchat: true, heartbeat: true });
   });
   test("status + json", () => {
     expect(parseAgenCGatewayCliArgs(["gateway", "status"])).toEqual({

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -255,4 +255,53 @@ describe("startGateway", () => {
     expect(client.sessions).toHaveLength(0);
     await handle.stop();
   });
+
+  test("heartbeat: a config-enabled tick runs a turn and delivers to a channel", async () => {
+    // Gateway channel + config.toml heartbeat targeting the in-memory channel.
+    writeConfig({ channels: { mem: { dmPolicy: "allowlist", allowlist: ["x"] } } });
+    require("node:fs").writeFileSync(
+      join(home, "config.toml"),
+      [
+        "[heartbeat]",
+        "enabled = true",
+        "interval_seconds = 10",
+        'target_channel = "mem"',
+        'target_conversation = "c1"',
+      ].join("\n"),
+    );
+    require("node:fs").mkdirSync(join(home, "ws"), { recursive: true });
+    require("node:fs").writeFileSync(join(home, "ws", "HEARTBEAT.md"), "summarize");
+
+    const client = new FakeClient();
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+
+    // A manual clock: capture the armed timer callback so we fire it by hand.
+    let armed: (() => void) | null = null;
+    const clock = {
+      now: () => new Date("2026-07-09T10:00:00"),
+      setTimer: (fn: () => void) => {
+        armed = fn;
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimer: () => {},
+    };
+
+    const handle = await startGateway({
+      agencHome: home,
+      workspaceDir: join(home, "ws"),
+      clientFactory: async () => client,
+      extraAdapters: [mem],
+      heartbeatClock: clock,
+    });
+    // The scheduler armed a timer. Fire one tick.
+    expect(armed).not.toBeNull();
+    armed!();
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The heartbeat created its own session, ran a turn, and delivered the
+    // (non-OK echo) reply to the mem channel's c1 conversation.
+    expect(client.sessions.length).toBeGreaterThanOrEqual(1);
+    expect(mem.sent.some((m) => m.conversationId === "c1")).toBe(true);
+    await handle.stop();
+  });
 });

--- a/runtime/tests/heartbeat/heartbeat.test.ts
+++ b/runtime/tests/heartbeat/heartbeat.test.ts
@@ -1,0 +1,285 @@
+// Heartbeat (TODO task 14). The gates + the budget wire-in are the point:
+// admit -> run -> reconcile; a budget refusal skips the turn and delivers a
+// paused notice; HEARTBEAT_OK suppresses delivery.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  resolveHeartbeatPolicy,
+  parseActiveHours,
+  parseTarget,
+} from "../../src/heartbeat/config.js";
+import { HeartbeatRunner, heartbeatPrompt } from "../../src/heartbeat/runner.js";
+import { HeartbeatScheduler } from "../../src/heartbeat/scheduler.js";
+import { WorkspaceHeartbeatFileReader } from "../../src/heartbeat/heartbeat-file.js";
+import {
+  HEARTBEAT_OK,
+  type HeartbeatBudgetGate,
+  type HeartbeatClock,
+  type HeartbeatDelivery,
+  type HeartbeatFileReader,
+  type HeartbeatPolicy,
+  type HeartbeatTurnRunner,
+  type HeartbeatUsage,
+} from "../../src/heartbeat/types.js";
+
+// ---- config ---------------------------------------------------------------
+
+describe("resolveHeartbeatPolicy", () => {
+  test("disabled by default; 30-min interval; always active", () => {
+    const p = resolveHeartbeatPolicy(undefined, {});
+    expect(p.enabled).toBe(false);
+    expect(p.intervalSeconds).toBe(1800);
+    expect(p.activeHours).toBeNull();
+    expect(p.target).toEqual({ kind: "none" });
+    expect(p.skipWhenBusy).toBe(true);
+  });
+
+  test("env overrides config (env > config > default)", () => {
+    const p = resolveHeartbeatPolicy(
+      { enabled: true, interval_seconds: 60, model: "cfg-model" },
+      { AGENC_HEARTBEAT_INTERVAL: "120", AGENC_HEARTBEAT_MODEL: "env-model" },
+    );
+    expect(p.intervalSeconds).toBe(120);
+    expect(p.model).toBe("env-model");
+  });
+
+  test("active hours + channel target parse from env", () => {
+    const p = resolveHeartbeatPolicy(
+      { enabled: true },
+      { AGENC_HEARTBEAT_ACTIVE_HOURS: "8-22", AGENC_HEARTBEAT_TARGET: "tg:chat-1" },
+    );
+    expect(p.activeHours).toEqual([8, 22]);
+    expect(p.target).toEqual({ kind: "channel", channelId: "tg", conversationId: "chat-1" });
+  });
+
+  test("parseActiveHours + parseTarget edge cases", () => {
+    expect(parseActiveHours("always")).toBeNull();
+    expect(parseActiveHours("22-8")).toBeNull(); // start >= end invalid
+    expect(parseActiveHours("9-17")).toEqual([9, 17]);
+    expect(parseTarget("none")).toEqual({ kind: "none" });
+    expect(parseTarget("bogus")).toEqual({ kind: "none" }); // no colon
+    expect(parseTarget("a:b")).toEqual({ kind: "channel", channelId: "a", conversationId: "b" });
+  });
+});
+
+describe("WorkspaceHeartbeatFileReader", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agenc-hb-file-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("returns null when absent, content when present", () => {
+    const reader = new WorkspaceHeartbeatFileReader(dir);
+    expect(reader.read()).toBeNull();
+    writeFileSync(join(dir, "HEARTBEAT.md"), "check the inbox");
+    expect(reader.read()).toBe("check the inbox");
+  });
+});
+
+// ---- runner (gates + budget) ----------------------------------------------
+
+class FakeRunner implements HeartbeatTurnRunner {
+  reply = HEARTBEAT_OK;
+  usage: HeartbeatUsage = { inputTokens: 500, outputTokens: 100 };
+  readonly prompts: string[] = [];
+  readonly models: (string | undefined)[] = [];
+  async run(prompt: string, model: string | undefined) {
+    this.prompts.push(prompt);
+    this.models.push(model);
+    return { finalMessage: this.reply, usage: this.usage };
+  }
+}
+
+class FakeDelivery implements HeartbeatDelivery {
+  readonly sent: { target: unknown; text: string }[] = [];
+  async deliver(target: unknown, text: string) {
+    this.sent.push({ target, text });
+  }
+}
+
+class FakeFile implements HeartbeatFileReader {
+  content: string | null = "do the thing";
+  read() {
+    return this.content;
+  }
+}
+
+/** A budget gate that refuses after `admitCount` admits. */
+class FakeBudget implements HeartbeatBudgetGate {
+  admits = 0;
+  reconciles: HeartbeatUsage[] = [];
+  refuseAfter = Infinity;
+  admit(_input: unknown) {
+    this.admits += 1;
+    if (this.admits > this.refuseAfter) {
+      return { ok: false as const, message: "daily usd cap reached" };
+    }
+    return { ok: true as const, hold: { id: this.admits } };
+  }
+  reconcile(_hold: unknown, usage: HeartbeatUsage) {
+    this.reconciles.push(usage);
+  }
+}
+
+const NOW = new Date("2026-07-09T10:00:00"); // local 10:00
+const clock: HeartbeatClock = {
+  now: () => NOW,
+  setTimer: (fn, ms) => setTimeout(fn, ms),
+  clearTimer: (h) => clearTimeout(h),
+};
+
+function policy(over: Partial<HeartbeatPolicy> = {}): HeartbeatPolicy {
+  return {
+    enabled: true,
+    intervalSeconds: 60,
+    agentId: "hb",
+    activeHours: null,
+    skipWhenBusy: true,
+    target: { kind: "channel", channelId: "tg", conversationId: "c1" },
+    ...over,
+  };
+}
+
+function makeRunner(
+  over: Partial<HeartbeatPolicy>,
+  parts: {
+    runner?: FakeRunner;
+    delivery?: FakeDelivery;
+    file?: FakeFile;
+    budget?: FakeBudget;
+    isCronRunning?: () => boolean;
+  } = {},
+) {
+  const runner = parts.runner ?? new FakeRunner();
+  const delivery = parts.delivery ?? new FakeDelivery();
+  const file = parts.file ?? new FakeFile();
+  const budget = parts.budget ?? new FakeBudget();
+  const hb = new HeartbeatRunner({
+    policy: policy(over),
+    clock,
+    turnRunner: runner,
+    delivery,
+    file,
+    budget,
+    ...(parts.isCronRunning !== undefined ? { isCronRunning: parts.isCronRunning } : {}),
+  });
+  return { hb, runner, delivery, file, budget };
+}
+
+describe("HeartbeatRunner gates", () => {
+  test("disabled → skipped", async () => {
+    const { hb } = makeRunner({ enabled: false });
+    expect(await hb.tick()).toEqual({ kind: "skipped", reason: "disabled" });
+  });
+
+  test("outside active hours → skipped", async () => {
+    const { hb } = makeRunner({ activeHours: [11, 12] }); // now is 10:00
+    expect(await hb.tick()).toMatchObject({ reason: "outside_active_hours" });
+  });
+
+  test("cron running → deferred", async () => {
+    const { hb } = makeRunner({}, { isCronRunning: () => true });
+    expect(await hb.tick()).toMatchObject({ reason: "cron_running" });
+  });
+
+  test("no HEARTBEAT.md → skipped", async () => {
+    const file = new FakeFile();
+    file.content = null;
+    const { hb } = makeRunner({}, { file });
+    expect(await hb.tick()).toMatchObject({ reason: "no_heartbeat_file" });
+  });
+});
+
+describe("HeartbeatRunner turn + budget wire-in", () => {
+  test("HEARTBEAT_OK reply suppresses delivery; budget admits + reconciles", async () => {
+    const { hb, runner, delivery, budget } = makeRunner({});
+    runner.reply = HEARTBEAT_OK;
+    const outcome = await hb.tick();
+    expect(outcome).toEqual({ kind: "ok_suppressed" });
+    expect(delivery.sent).toHaveLength(0);
+    expect(budget.admits).toBe(1);
+    expect(budget.reconciles).toEqual([{ inputTokens: 500, outputTokens: 100 }]);
+    // The heartbeat framing wraps HEARTBEAT.md.
+    expect(runner.prompts[0]).toContain("do the thing");
+    expect(runner.prompts[0]).toContain(HEARTBEAT_OK);
+  });
+
+  test("a non-OK reply is delivered to the target", async () => {
+    const { hb, runner, delivery } = makeRunner({});
+    runner.reply = "3 new emails need replies";
+    const outcome = await hb.tick();
+    expect(outcome).toEqual({ kind: "delivered", text: "3 new emails need replies" });
+    expect(delivery.sent).toHaveLength(1);
+    expect(delivery.sent[0].text).toBe("3 new emails need replies");
+  });
+
+  test("BUDGET REFUSAL: the turn does NOT run; a paused notice is delivered", async () => {
+    const budget = new FakeBudget();
+    budget.refuseAfter = 0; // refuse the very first admit
+    const { hb, runner, delivery } = makeRunner({}, { budget });
+    const outcome = await hb.tick();
+    expect(outcome).toMatchObject({ kind: "budget_paused" });
+    expect(runner.prompts).toHaveLength(0); // turn never ran (no silent spend)
+    expect(delivery.sent).toHaveLength(1);
+    expect(delivery.sent[0].text).toContain("heartbeat paused");
+  });
+
+  test("the utility model flows through to the turn runner", async () => {
+    const { hb, runner } = makeRunner({ model: "grok-4-fast" });
+    await hb.tick();
+    expect(runner.models[0]).toBe("grok-4-fast");
+  });
+
+  test("target 'none' runs the turn but delivers nothing", async () => {
+    const { hb, runner, delivery } = makeRunner({ target: { kind: "none" } });
+    runner.reply = "something happened";
+    const outcome = await hb.tick();
+    expect(outcome).toMatchObject({ kind: "delivered" });
+    expect(delivery.sent).toHaveLength(0); // no target
+  });
+
+  test("heartbeatPrompt frames the file and asks for HEARTBEAT_OK", () => {
+    const p = heartbeatPrompt("inbox rules");
+    expect(p).toContain("inbox rules");
+    expect(p).toContain(HEARTBEAT_OK);
+    expect(p).toContain("<heartbeat_instructions>");
+  });
+});
+
+// ---- scheduler (fake timers) ----------------------------------------------
+
+describe("HeartbeatScheduler", () => {
+  test("ticks on the interval and re-arms; stop cancels", async () => {
+    vi.useFakeTimers();
+    try {
+      let ticks = 0;
+      const sched = new HeartbeatScheduler({
+        intervalSeconds: 10,
+        clock: {
+          now: () => new Date(),
+          setTimer: (fn, ms) => setTimeout(fn, ms),
+          clearTimer: (h) => clearTimeout(h),
+        },
+        onTick: async () => {
+          ticks += 1;
+          return { kind: "ok_suppressed" };
+        },
+      });
+      sched.start();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(ticks).toBe(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(ticks).toBe(2);
+      await sched.stop();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(ticks).toBe(2); // no more ticks after stop
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
The proactive half of the personal agent, and the live wire-in of the task-15 budget layer — a periodic autonomous turn reading HEARTBEAT.md, bounded so it can never become the OpenClaw idle-burn furnace. This is the 'morning brief under budget' that completes the minimum lovable personal agent.

## Per-tick logic (runner.ts)
gates (enabled → active-hours → cron-defer → skip-when-busy) → HEARTBEAT.md present? → **BUDGET ADMIT** (task-15 enforcer, worst-case pre-flight) → run turn → `HEARTBEAT_OK` suppresses delivery else deliver to the target channel → **reconcile** budget from real usage.

**The budget wire-in is the point:** on a refusal the turn does **not** run (autonomy is already paused) and a 'heartbeat paused' notice is delivered — fail closed and visible, never a silent skip or silent spend. Revert-proven.

## Shape
`runtime/src/heartbeat/`: types, config (env>config>default, disabled by default), scheduler (interval tick over an injectable clock, re-entrancy safe), HEARTBEAT.md reader, runner, and the gateway/budget wire. `[heartbeat]` schema + `AGENC_HEARTBEAT*` env. `agenc gateway run --heartbeat`. Threaded real token usage through `GatewayPromptResult` + the SDK daemon client so reconcile uses actuals.

## Tests (24)
Config precedence, file reader, every gate, the budget wire-in (incl. **refusal-skips-the-turn revert-proven**), HEARTBEAT_OK suppression, delivery, model pass-through, a fake-clock scheduler, and a run-loop integration test that fires a real tick through the assembled pieces and delivers to a channel. Gates: vitest **14178**, bun 74, typecheck 0, agent-surface-contract ok.

## Discovered + filed (TODO task 34)
Live-smoking the heartbeat surfaced a **pre-existing, shared gateway↔daemon gap**: live turns fail against the real daemon with `agent not found: agent_default` — `createSession` binds to a default agent the headless `gateway run` never provisions. The channel flow uses the **identical** `createSession→prompt` path (only ever live-smoked to the pairing gate), so this blocks all live gateway turns, not just heartbeat. Root cause + three fix options are in TODO task 34 and noted in docs/gateway.md. The heartbeat logic is complete and fully tested against a fake daemon client; the live turn awaits that shared provisioning fix.