### PR TITLE
feat(gateway): provision passive daemon agents for live gateway turns (task 34)

### DIFF
--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -57,7 +57,9 @@ export {
 } from "./run.js";
 export {
   createSdkDaemonClient,
+  isDaemonAgentGoneError,
   type SdkDaemonClientOptions,
+  type SdkModule,
 } from "./sdk-daemon-client.js";
 export {
   frameChannelMessage,

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -180,6 +180,9 @@ export async function startGateway(
     ? options.clientFactory()
     : createSdkDaemonClient({
         autostart: true,
+        // Gateway daemon agents work in the gateway's workspace so channel
+        // turns and heartbeat ticks see the same files HEARTBEAT.md lives in.
+        cwd: options.workspaceDir ?? process.cwd(),
         ...(options.agencCommand !== undefined
           ? { agencCommand: options.agencCommand }
           : {}),

--- a/runtime/src/gateway/sdk-daemon-client.ts
+++ b/runtime/src/gateway/sdk-daemon-client.ts
@@ -1,6 +1,6 @@
 /**
  * Production {@link GatewayDaemonClient} backed by `@tetsuo-ai/agenc-sdk`
- * (TODO task 6).
+ * (TODO task 6; agent provisioning TODO task 34).
  *
  * This is the ONLY place the gateway touches the daemon, and it goes through
  * the public embedding SDK — never runtime session internals. Kept dependency-
@@ -9,6 +9,23 @@
  *
  * The SDK import is dynamic so the gateway core module graph does not hard-
  * depend on the SDK build being present (tests use the fake client).
+ *
+ * ## Why createSession() spawns a background agent (task 34)
+ *
+ * A bare daemon `session.create` binds the session to `agent_default`, an
+ * agent nothing in a headless gateway run ever provisions — the first
+ * `message.send` then throws `AgenC daemon agent not found: agent_default`.
+ * The daemon's only live-turn substrate is a background agent
+ * (`agent.create` → full runtime bootstrap → `message.send` routes into its
+ * run loop), and each background agent supports exactly ONE live session:
+ * the one `agent.create` itself creates (the runner keeps a single
+ * session-event binding stamped with that session's id).
+ *
+ * So `createSession()` here spawns a PASSIVE agent — `initialContent: []`
+ * suppresses the turn-1 objective submit (pinned by a runner contract test)
+ * — and adopts the agent's own session. One gateway conversation = one
+ * daemon agent = one session: history isolation between channel peers and
+ * the heartbeat falls out of the 1:1:1 shape.
  */
 
 import type {
@@ -17,6 +34,7 @@ import type {
   GatewayPromptHandlers,
   GatewayPromptResult,
   GatewaySession,
+  GatewaySessionCreateOptions,
 } from "./types.js";
 
 export interface SdkDaemonClientOptions {
@@ -25,6 +43,10 @@ export interface SdkDaemonClientOptions {
   readonly socketPath?: string;
   readonly cookiePath?: string;
   readonly autostart?: boolean;
+  /** Working directory for gateway daemon agents (default: daemon's choice). */
+  readonly cwd?: string;
+  /** Test seam: inject the SDK module instead of importing it. */
+  readonly sdk?: SdkModule;
 }
 
 // Minimal structural shapes for the slice of the SDK we use — avoids a
@@ -54,10 +76,55 @@ interface SdkSession {
     ) => Promise<GatewayPermissionDecision>;
   }): SdkPromptRun;
 }
+interface SdkAgentCreateResult {
+  readonly agentId: string;
+  readonly sessionId?: string;
+}
 interface SdkClient {
-  createSession(): Promise<SdkSession>;
-  attachSession(sessionId: string): Promise<SdkSession>;
+  spawnAgent(params: {
+    readonly objective: string;
+    readonly initialContent: readonly never[];
+    readonly cwd?: string;
+    readonly metadata?: Record<string, string>;
+  }): Promise<SdkAgentCreateResult>;
+  resumeSession(sessionId: string): Promise<SdkSession>;
   close(): Promise<void>;
+}
+export interface SdkModule {
+  connect(opts: {
+    readonly agencCommand?: string;
+    readonly socketPath?: string;
+    readonly cookiePath?: string;
+    readonly autostart?: boolean;
+  }): Promise<SdkClient>;
+}
+
+/**
+ * True when a daemon error means the session's backing agent is gone or
+ * unusable (daemon restarted, agent stopped/reaped, session pruned) — the
+ * caller should discard the session and provision a fresh one. Matches the
+ * daemon's lifecycle error codes carried in JSON-RPC `error.data.code`, with
+ * a message fallback for transports that flatten the data object.
+ */
+export function isDaemonAgentGoneError(error: unknown): boolean {
+  if (error === null || typeof error !== "object") return false;
+  const data = (error as { data?: unknown }).data;
+  if (data !== null && typeof data === "object") {
+    const code = (data as { code?: unknown }).code;
+    if (
+      code === "AGENT_NOT_FOUND" ||
+      code === "BACKGROUND_RUNNER_UNAVAILABLE" ||
+      code === "SESSION_NOT_FOUND" ||
+      code === "SESSION_CLOSED"
+    ) {
+      return true;
+    }
+  }
+  const message = (error as { message?: unknown }).message;
+  if (typeof message !== "string") return false;
+  return /agent not (?:found|running)|recovered without a live runtime|session not found or closed|session not found|session is closed/i.test(
+    message,
+  );
 }
 
 function wrapSession(sdkSession: SdkSession): GatewaySession {
@@ -107,7 +174,7 @@ function wrapSession(sdkSession: SdkSession): GatewaySession {
       return {
         stopReason,
         finalMessage: result.finalMessage,
-        ...(usage !== undefined ? { usage } : {}),
+        ...(usage !== undefined ? { usage: usage } : {}),
       };
     },
   };
@@ -117,16 +184,46 @@ export async function createSdkDaemonClient(
   options: SdkDaemonClientOptions = {},
 ): Promise<GatewayDaemonClient> {
   // Dynamic import keeps the SDK optional for the core module graph.
-  const sdk = (await import("@tetsuo-ai/agenc-sdk")) as unknown as {
-    connect(opts: SdkDaemonClientOptions): Promise<SdkClient>;
-  };
-  const client = await sdk.connect(options);
+  const sdk =
+    options.sdk ??
+    ((await import("@tetsuo-ai/agenc-sdk")) as unknown as SdkModule);
+  const client = await sdk.connect({
+    ...(options.agencCommand !== undefined
+      ? { agencCommand: options.agencCommand }
+      : {}),
+    ...(options.socketPath !== undefined
+      ? { socketPath: options.socketPath }
+      : {}),
+    ...(options.cookiePath !== undefined
+      ? { cookiePath: options.cookiePath }
+      : {}),
+    ...(options.autostart !== undefined ? { autostart: options.autostart } : {}),
+  });
   return {
-    async createSession() {
-      return wrapSession(await client.createSession());
+    async createSession(createOptions?: GatewaySessionCreateOptions) {
+      const label = createOptions?.label;
+      // Passive agent: empty initialContent suppresses the turn-1 objective
+      // submit, so provisioning costs zero LLM calls. The objective string is
+      // operator-facing metadata (agent.list) only.
+      const created = await client.spawnAgent({
+        objective:
+          label !== undefined ? `gateway: ${label}` : "gateway session",
+        initialContent: [],
+        ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+        metadata: {
+          source: "agenc-gateway",
+          ...(label !== undefined ? { gatewayLabel: label } : {}),
+        },
+      });
+      if (created.sessionId === undefined) {
+        throw new Error(
+          `gateway: daemon agent ${created.agentId} was created without a session — cannot run turns`,
+        );
+      }
+      return wrapSession(await client.resumeSession(created.sessionId));
     },
     async attachSession(sessionId: string) {
-      return wrapSession(await client.attachSession(sessionId));
+      return wrapSession(await client.resumeSession(sessionId));
     },
     async close() {
       await client.close();

--- a/runtime/src/gateway/session-router.ts
+++ b/runtime/src/gateway/session-router.ts
@@ -18,6 +18,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { isDaemonAgentGoneError } from "./sdk-daemon-client.js";
 import type {
   ChannelAdapter,
   GatewayDaemonClient,
@@ -112,11 +113,24 @@ export class SessionRouter {
         // Stale persisted id (daemon state pruned): fall through to create.
       }
     }
-    const created = await this.#client.createSession();
+    const created = await this.#client.createSession({ label: key });
     this.#sessions.set(key, created);
     this.#persisted.sessions[key] = created.sessionId;
     this.#save();
     return created;
+  }
+
+  /**
+   * Drop a conversation's session from the live cache and the persisted map.
+   * Used when the daemon reports its backing agent gone (daemon restart,
+   * agent stopped) so the next turn provisions a fresh session.
+   */
+  #evictSession(key: string): void {
+    this.#sessions.delete(key);
+    if (this.#persisted.sessions[key] !== undefined) {
+      delete this.#persisted.sessions[key];
+      this.#save();
+    }
   }
 
   /**
@@ -143,55 +157,71 @@ export class SessionRouter {
     );
     await previous;
     try {
-      const session = await this.#sessionFor(options.key);
+      const attempt = async (
+        session: GatewaySession,
+      ): Promise<GatewayPromptResult> => {
+        let buffer = "";
+        let sentMessageId: string | null = null;
+        let lastFlush = 0;
+        let flushing = Promise.resolve();
 
-      let buffer = "";
-      let sentMessageId: string | null = null;
-      let lastFlush = 0;
-      let flushing = Promise.resolve();
-
-      const flush = (force: boolean): Promise<void> => {
-        if (buffer.length === 0) return flushing;
-        if (!options.adapter.supportsEdit && !force) return flushing;
-        const now = Date.now();
-        if (!force && now - lastFlush < this.#flushIntervalMs) {
-          return flushing;
-        }
-        lastFlush = now;
-        const text = buffer;
-        flushing = flushing.then(async () => {
-          if (options.adapter.supportsEdit && sentMessageId !== null) {
-            await options.adapter.send({
-              conversationId: options.conversationId,
-              text,
-              editMessageId: sentMessageId,
-            });
-          } else {
-            sentMessageId = await options.adapter.send({
-              conversationId: options.conversationId,
-              text,
-            });
+        const flush = (force: boolean): Promise<void> => {
+          if (buffer.length === 0) return flushing;
+          if (!options.adapter.supportsEdit && !force) return flushing;
+          const now = Date.now();
+          if (!force && now - lastFlush < this.#flushIntervalMs) {
+            return flushing;
           }
+          lastFlush = now;
+          const text = buffer;
+          flushing = flushing.then(async () => {
+            if (options.adapter.supportsEdit && sentMessageId !== null) {
+              await options.adapter.send({
+                conversationId: options.conversationId,
+                text,
+                editMessageId: sentMessageId,
+              });
+            } else {
+              sentMessageId = await options.adapter.send({
+                conversationId: options.conversationId,
+                text,
+              });
+            }
+          });
+          return flushing;
+        };
+
+        const result = await session.prompt(options.text, {
+          onEvent: (event) => {
+            if (event.type === "text") {
+              buffer += event.delta;
+              void flush(false);
+            }
+          },
+          onPermissionRequest: options.onPermissionRequest,
         });
-        return flushing;
+
+        // Final state always lands, even for non-edit adapters.
+        if (result.finalMessage.length > 0) {
+          buffer = result.finalMessage;
+        }
+        await flush(true);
+        return result;
       };
 
-      const result = await session.prompt(options.text, {
-        onEvent: (event) => {
-          if (event.type === "text") {
-            buffer += event.delta;
-            void flush(false);
-          }
-        },
-        onPermissionRequest: options.onPermissionRequest,
-      });
-
-      // Final state always lands, even for non-edit adapters.
-      if (result.finalMessage.length > 0) {
-        buffer = result.finalMessage;
+      const session = await this.#sessionFor(options.key);
+      try {
+        return await attempt(session);
+      } catch (error) {
+        // The daemon lost this session's backing agent (daemon restart,
+        // agent stopped). Provision fresh and retry ONCE; a second failure
+        // propagates. History is gone with the agent — acceptable, the
+        // alternative is a permanently dead conversation.
+        if (!isDaemonAgentGoneError(error)) throw error;
+        this.#evictSession(options.key);
+        const fresh = await this.#sessionFor(options.key);
+        return await attempt(fresh);
       }
-      await flush(true);
-      return result;
     } finally {
       release();
     }

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -141,8 +141,16 @@ export interface GatewaySession {
   ): Promise<GatewayPromptResult>;
 }
 
+export interface GatewaySessionCreateOptions {
+  /**
+   * Operator-facing label for the daemon agent backing this session (e.g.
+   * the conversation key or "heartbeat") — shows up in `agenc agents list`.
+   */
+  readonly label?: string;
+}
+
 export interface GatewayDaemonClient {
-  createSession(): Promise<GatewaySession>;
+  createSession(options?: GatewaySessionCreateOptions): Promise<GatewaySession>;
   attachSession(sessionId: string): Promise<GatewaySession>;
   close(): Promise<void>;
 }

--- a/runtime/src/heartbeat/wire.ts
+++ b/runtime/src/heartbeat/wire.ts
@@ -12,6 +12,9 @@
  * is the safety boundary and is fully live regardless of which model runs.
  */
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 import type { AgenCConfig } from "../config/schema.js";
 import {
   BudgetEnforcer,
@@ -19,7 +22,12 @@ import {
   createModelPriceResolver,
   resolveBudgetPolicy,
 } from "../budget/index.js";
-import type { ChannelAdapter, GatewayDaemonClient } from "../gateway/types.js";
+import { isDaemonAgentGoneError } from "../gateway/sdk-daemon-client.js";
+import type {
+  ChannelAdapter,
+  GatewayDaemonClient,
+  GatewaySession,
+} from "../gateway/types.js";
 import { resolveHeartbeatPolicy } from "./config.js";
 import { WorkspaceHeartbeatFileReader } from "./heartbeat-file.js";
 import { HeartbeatRunner } from "./runner.js";
@@ -70,24 +78,82 @@ function budgetGate(
   };
 }
 
-/** A turn runner backed by a single gateway session (isolated heartbeat ctx). */
-function gatewayTurnRunner(
-  session: Awaited<ReturnType<GatewayDaemonClient["createSession"]>>,
-): HeartbeatTurnRunner {
+const HEARTBEAT_SESSION_LABEL = "heartbeat";
+
+/**
+ * Session supplier for heartbeat turns: reuses one daemon session across
+ * gateway restarts via a persisted id (`gateway/heartbeat-session`, 0600) so
+ * each `gateway run` does not accumulate a fresh daemon agent, and
+ * provisions a new one when the persisted session's agent is gone.
+ */
+function heartbeatSessionSupplier(options: {
+  readonly agencHome: string;
+  readonly client: GatewayDaemonClient;
+}): { get(): Promise<GatewaySession>; invalidate(): void } {
+  const path = join(options.agencHome, "gateway", "heartbeat-session");
+  let live: GatewaySession | null = null;
+  return {
+    async get() {
+      if (live !== null) return live;
+      if (existsSync(path)) {
+        const persistedId = readFileSync(path, "utf8").trim();
+        if (persistedId.length > 0) {
+          try {
+            live = await options.client.attachSession(persistedId);
+            return live;
+          } catch {
+            // Stale persisted id (daemon state pruned): fall through.
+          }
+        }
+      }
+      live = await options.client.createSession({
+        label: HEARTBEAT_SESSION_LABEL,
+      });
+      mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+      writeFileSync(path, `${live.sessionId}\n`, { mode: 0o600 });
+      return live;
+    },
+    invalidate() {
+      live = null;
+      try {
+        writeFileSync(path, "", { mode: 0o600 });
+      } catch {
+        // Best-effort: a stale id is re-detected on the next attach.
+      }
+    },
+  };
+}
+
+/** A turn runner backed by a persistent gateway session (isolated heartbeat ctx). */
+function gatewayTurnRunner(supplier: {
+  get(): Promise<GatewaySession>;
+  invalidate(): void;
+}): HeartbeatTurnRunner {
+  const runOnce = async (session: GatewaySession, prompt: string) => {
+    const result = await session.prompt(prompt, {
+      onEvent: () => {},
+      // Autonomous, no human watching → deny permission requests (fail safe).
+      onPermissionRequest: async () => ({
+        behavior: "deny",
+        reason: "heartbeat turns do not grant tool permissions",
+      }),
+    });
+    return {
+      finalMessage: result.finalMessage,
+      ...(result.usage !== undefined ? { usage: result.usage } : {}),
+    };
+  };
   return {
     async run(prompt) {
-      const result = await session.prompt(prompt, {
-        onEvent: () => {},
-        // Autonomous, no human watching → deny permission requests (fail safe).
-        onPermissionRequest: async () => ({
-          behavior: "deny",
-          reason: "heartbeat turns do not grant tool permissions",
-        }),
-      });
-      return {
-        finalMessage: result.finalMessage,
-        ...(result.usage !== undefined ? { usage: result.usage } : {}),
-      };
+      const session = await supplier.get();
+      try {
+        return await runOnce(session, prompt);
+      } catch (error) {
+        // Backing agent gone (daemon restart): reprovision and retry once.
+        if (!isDaemonAgentGoneError(error)) throw error;
+        supplier.invalidate();
+        return await runOnce(await supplier.get(), prompt);
+      }
     },
   };
 }
@@ -121,11 +187,15 @@ export async function startHeartbeat(
     notify: (e) => log(`heartbeat/budget: ${e.message}`),
   });
 
-  const session = await options.client.createSession();
   const runner = new HeartbeatRunner({
     policy,
     clock: options.clock ?? REAL_CLOCK,
-    turnRunner: gatewayTurnRunner(session),
+    turnRunner: gatewayTurnRunner(
+      heartbeatSessionSupplier({
+        agencHome: options.agencHome,
+        client: options.client,
+      }),
+    ),
     delivery: delivery(options.adapters),
     file: new WorkspaceHeartbeatFileReader(options.workspaceDir),
     budget: budgetGate(enforcer),

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -704,6 +704,27 @@ describe("AgenC delegate background-agent runner", () => {
     });
   });
 
+  it("[managed-thread] empty initialContent provisions a passive agent with no turn-1 submit", async () => {
+    // The channel gateway (task 34) relies on this contract: agent.create
+    // with `initialContent: []` bootstraps a live, runnable agent WITHOUT
+    // submitting the objective as a first turn — zero LLM calls until the
+    // first real message arrives via message.send.
+    const { runner, stub } = makeTopLevelRunner({
+      conversationId: "session-passive-gateway",
+    });
+
+    const result = await runner.startAgent({
+      objective: "gateway session",
+      initialContent: [],
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    expect(result.agentId).toBe("session-passive-gateway");
+    expect(result.status).toBe("running");
+    expect(stub.thread.submit).not.toHaveBeenCalled();
+  });
+
   it("[managed-thread] emits visible user message before routing attached input", async () => {
     const { runner, control } = makeTopLevelRunner({
       conversationId: "session-user-order",

--- a/runtime/tests/gateway/sdk-daemon-client.test.ts
+++ b/runtime/tests/gateway/sdk-daemon-client.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Gateway SDK daemon-client tests (TODO task 34).
+ *
+ * The daemon has no default agent — a bare `session.create` binds to
+ * `agent_default`, which nothing provisions, and the first message throws
+ * `AgenC daemon agent not found`. These tests pin the fix: `createSession()`
+ * spawns a PASSIVE background agent (empty initialContent = no turn-1 LLM
+ * call) and adopts the agent's own session; `attachSession` resumes by id
+ * through the SDK method that actually exists (`resumeSession`).
+ *
+ * Revert-sensitivity: against the pre-task-34 client (which called the
+ * nonexistent `client.createSession`/`client.attachSession` SDK methods)
+ * every test here fails.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  createSdkDaemonClient,
+  isDaemonAgentGoneError,
+  type SdkModule,
+} from "../../src/gateway/sdk-daemon-client.js";
+
+interface SpawnCall {
+  readonly objective: string;
+  readonly initialContent: readonly never[];
+  readonly cwd?: string;
+  readonly metadata?: Record<string, string>;
+}
+
+function fakeSdk(options: { sessionIdForSpawn?: string | null } = {}) {
+  const spawnCalls: SpawnCall[] = [];
+  const resumedIds: string[] = [];
+  let closed = false;
+  const module: SdkModule = {
+    async connect() {
+      return {
+        async spawnAgent(params: SpawnCall) {
+          spawnCalls.push(params);
+          const sessionId =
+            options.sessionIdForSpawn === null
+              ? undefined
+              : (options.sessionIdForSpawn ?? `sess-of-agent-${spawnCalls.length}`);
+          return {
+            agentId: `agent-${spawnCalls.length}`,
+            ...(sessionId !== undefined ? { sessionId } : {}),
+          };
+        },
+        async resumeSession(sessionId: string) {
+          resumedIds.push(sessionId);
+          return {
+            sessionId,
+            prompt: () => {
+              throw new Error("prompt not exercised in these tests");
+            },
+          };
+        },
+        async close() {
+          closed = true;
+        },
+      };
+    },
+  };
+  return {
+    module,
+    spawnCalls,
+    resumedIds,
+    isClosed: () => closed,
+  };
+}
+
+describe("createSdkDaemonClient (daemon agent provisioning)", () => {
+  test("createSession spawns a passive agent and adopts the agent's own session", async () => {
+    const sdk = fakeSdk();
+    const client = await createSdkDaemonClient({ sdk: sdk.module });
+
+    const session = await client.createSession({ label: "tg|default|c1" });
+
+    expect(sdk.spawnCalls).toHaveLength(1);
+    // Passive: empty initialContent means the daemon runs NO turn-1 submit.
+    expect(sdk.spawnCalls[0].initialContent).toEqual([]);
+    expect(sdk.spawnCalls[0].objective).toBe("gateway: tg|default|c1");
+    expect(sdk.spawnCalls[0].metadata).toMatchObject({
+      source: "agenc-gateway",
+      gatewayLabel: "tg|default|c1",
+    });
+    // The session is the AGENT'S session — the only one whose events the
+    // daemon runner binds — not a fresh agent_default-bound session.
+    expect(sdk.resumedIds).toEqual(["sess-of-agent-1"]);
+    expect(session.sessionId).toBe("sess-of-agent-1");
+  });
+
+  test("createSession without a label uses the generic objective", async () => {
+    const sdk = fakeSdk();
+    const client = await createSdkDaemonClient({ sdk: sdk.module });
+
+    await client.createSession();
+
+    expect(sdk.spawnCalls[0].objective).toBe("gateway session");
+    expect(sdk.spawnCalls[0].metadata).toEqual({ source: "agenc-gateway" });
+  });
+
+  test("createSession threads the configured cwd to the agent", async () => {
+    const sdk = fakeSdk();
+    const client = await createSdkDaemonClient({
+      sdk: sdk.module,
+      cwd: "/work/space",
+    });
+
+    await client.createSession();
+
+    expect(sdk.spawnCalls[0].cwd).toBe("/work/space");
+  });
+
+  test("createSession fails loudly when the agent has no session", async () => {
+    const sdk = fakeSdk({ sessionIdForSpawn: null });
+    const client = await createSdkDaemonClient({ sdk: sdk.module });
+
+    await expect(client.createSession()).rejects.toThrow(
+      /created without a session/,
+    );
+  });
+
+  test("attachSession resumes the persisted session id without spawning", async () => {
+    const sdk = fakeSdk();
+    const client = await createSdkDaemonClient({ sdk: sdk.module });
+
+    const session = await client.attachSession("persisted-id");
+
+    expect(sdk.spawnCalls).toHaveLength(0);
+    expect(sdk.resumedIds).toEqual(["persisted-id"]);
+    expect(session.sessionId).toBe("persisted-id");
+  });
+
+  test("close closes the SDK client", async () => {
+    const sdk = fakeSdk();
+    const client = await createSdkDaemonClient({ sdk: sdk.module });
+    await client.close();
+    expect(sdk.isClosed()).toBe(true);
+  });
+});
+
+describe("isDaemonAgentGoneError", () => {
+  test("matches the daemon lifecycle error codes in error.data.code", () => {
+    for (const code of [
+      "AGENT_NOT_FOUND",
+      "BACKGROUND_RUNNER_UNAVAILABLE",
+      "SESSION_NOT_FOUND",
+      "SESSION_CLOSED",
+    ]) {
+      const error = Object.assign(new Error("rpc failed"), {
+        data: { code },
+      });
+      expect(isDaemonAgentGoneError(error)).toBe(true);
+    }
+  });
+
+  test("falls back to the daemon's error message shapes", () => {
+    for (const message of [
+      "AgenC daemon agent not found: agent_default",
+      "AgenC daemon agent not running: session-x",
+      "AgenC daemon agent recovered without a live runtime: session-x",
+      "AgenC daemon session not found or closed: session-y",
+    ]) {
+      expect(isDaemonAgentGoneError(new Error(message))).toBe(true);
+    }
+  });
+
+  test("does not match unrelated errors", () => {
+    expect(isDaemonAgentGoneError(new Error("network timeout"))).toBe(false);
+    expect(
+      isDaemonAgentGoneError(
+        Object.assign(new Error("denied"), { data: { code: "INVALID_ARGUMENT" } }),
+      ),
+    ).toBe(false);
+    expect(isDaemonAgentGoneError(null)).toBe(false);
+    expect(isDaemonAgentGoneError("agent not found")).toBe(false);
+  });
+});

--- a/runtime/tests/gateway/units.test.ts
+++ b/runtime/tests/gateway/units.test.ts
@@ -321,4 +321,77 @@ describe("SessionRouter", () => {
     expect(client2.created).toBe(0);
     expect(client2.attached).toEqual(["sess-1"]);
   });
+
+  test("dead backing agent: evicts the session and retries the turn once", async () => {
+    // First session's daemon agent is gone (daemon restarted): its prompt
+    // throws the daemon's AGENT_NOT_FOUND. The router must evict the cached
+    // + persisted session, provision a fresh one, and complete the turn.
+    class GoneSession implements GatewaySession {
+      readonly sessionId = "sess-1";
+      async prompt(): Promise<GatewayPromptResult> {
+        throw Object.assign(
+          new Error("AgenC daemon agent not found: sess-1"),
+          { data: { code: "AGENT_NOT_FOUND" } },
+        );
+      }
+    }
+    const client = new RecordingClient((id) =>
+      id === "sess-1"
+        ? new GoneSession()
+        : new ScriptedSession(id, ["ok"], "recovered"),
+    );
+    const router = new SessionRouter({ agencHome: home, client });
+    const adapter = new InMemoryChannelAdapter({ id: "tg" });
+    const key = SessionRouter.conversationKey({
+      channelId: "tg",
+      agent: "default",
+      conversationId: "c1",
+    });
+
+    const result = await router.runTurn({
+      key,
+      text: "hi",
+      adapter,
+      conversationId: "c1",
+      onPermissionRequest: async () => ({ behavior: "deny" }),
+    });
+
+    expect(result.finalMessage).toBe("recovered");
+    expect(client.created).toBe(2);
+    expect(adapter.lastText("c1")).toBe("recovered");
+    // The persisted map now points at the fresh session, so a restart
+    // reattaches the live one instead of the dead one.
+    const persisted = JSON.parse(
+      readFileSync(join(home, "gateway", "sessions.json"), "utf8"),
+    ) as { sessions: Record<string, string> };
+    expect(persisted.sessions[key]).toBe("sess-2");
+  });
+
+  test("non-agent-gone turn errors propagate without a retry", async () => {
+    class FlakySession implements GatewaySession {
+      readonly sessionId = "sess-1";
+      async prompt(): Promise<GatewayPromptResult> {
+        throw new Error("network timeout");
+      }
+    }
+    const client = new RecordingClient(() => new FlakySession());
+    const router = new SessionRouter({ agencHome: home, client });
+    const adapter = new InMemoryChannelAdapter({ id: "tg" });
+    const key = SessionRouter.conversationKey({
+      channelId: "tg",
+      agent: "default",
+      conversationId: "c1",
+    });
+
+    await expect(
+      router.runTurn({
+        key,
+        text: "hi",
+        adapter,
+        conversationId: "c1",
+        onPermissionRequest: async () => ({ behavior: "deny" }),
+      }),
+    ).rejects.toThrow("network timeout");
+    expect(client.created).toBe(1);
+  });
 });

--- a/runtime/tests/heartbeat/wire.test.ts
+++ b/runtime/tests/heartbeat/wire.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Heartbeat ↔ gateway wire tests (TODO task 34): the persistent heartbeat
+ * daemon session.
+ *
+ * Each gateway run must NOT accumulate a fresh daemon agent for the
+ * heartbeat: the session id persists at `gateway/heartbeat-session` and is
+ * reattached across restarts. When the daemon loses the backing agent
+ * (daemon restart), the tick reprovisions once and retries instead of
+ * failing every tick forever.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { startHeartbeat } from "../../src/heartbeat/wire.js";
+import type { HeartbeatClock } from "../../src/heartbeat/types.js";
+import { InMemoryChannelAdapter } from "../../src/gateway/test-channel.js";
+import type {
+  GatewayDaemonClient,
+  GatewayPromptHandlers,
+  GatewayPromptResult,
+  GatewaySession,
+  GatewaySessionCreateOptions,
+} from "../../src/gateway/types.js";
+import type { AgenCConfig } from "../../src/config/schema.js";
+
+class EchoSession implements GatewaySession {
+  readonly sessionId: string;
+  readonly reply: string | Error;
+  constructor(sessionId: string, reply: string | Error) {
+    this.sessionId = sessionId;
+    this.reply = reply;
+  }
+  async prompt(
+    _text: string,
+    handlers: GatewayPromptHandlers,
+  ): Promise<GatewayPromptResult> {
+    if (this.reply instanceof Error) throw this.reply;
+    await handlers.onEvent({ type: "text", delta: this.reply });
+    return { stopReason: "completed", finalMessage: this.reply };
+  }
+}
+
+class RecordingClient implements GatewayDaemonClient {
+  created = 0;
+  attached: string[] = [];
+  labels: (string | undefined)[] = [];
+  readonly makeSession: (id: string) => GatewaySession;
+  constructor(makeSession: (id: string) => GatewaySession) {
+    this.makeSession = makeSession;
+  }
+  async createSession(
+    options?: GatewaySessionCreateOptions,
+  ): Promise<GatewaySession> {
+    this.created += 1;
+    this.labels.push(options?.label);
+    return this.makeSession(`hb-sess-${this.created}`);
+  }
+  async attachSession(sessionId: string): Promise<GatewaySession> {
+    this.attached.push(sessionId);
+    return this.makeSession(sessionId);
+  }
+  async close(): Promise<void> {}
+}
+
+function manualClock(): { clock: HeartbeatClock; fire(): void } {
+  let armed: (() => void) | null = null;
+  return {
+    clock: {
+      now: () => new Date("2026-07-09T10:00:00"),
+      setTimer: (fn: () => void) => {
+        armed = fn;
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimer: () => {},
+    },
+    fire: () => {
+      const fn = armed;
+      armed = null;
+      fn?.();
+    },
+  };
+}
+
+const HEARTBEAT_CONFIG = {
+  heartbeat: {
+    enabled: true,
+    interval_seconds: 10,
+    target_channel: "mem",
+    target_conversation: "c1",
+  },
+} as unknown as AgenCConfig;
+
+describe("startHeartbeat persistent session", () => {
+  let home: string;
+  let ws: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-hb-wire-"));
+    ws = join(home, "ws");
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(join(ws, "HEARTBEAT.md"), "check things");
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  async function tickOnce(client: GatewayDaemonClient, mem: InMemoryChannelAdapter) {
+    const { clock, fire } = manualClock();
+    const scheduler = await startHeartbeat({
+      agencHome: home,
+      workspaceDir: ws,
+      config: HEARTBEAT_CONFIG,
+      env: {},
+      client,
+      adapters: [mem],
+      clock,
+    });
+    expect(scheduler).not.toBeNull();
+    fire();
+    await new Promise((r) => setTimeout(r, 20));
+    await scheduler!.stop();
+  }
+
+  test("first tick provisions a labeled session and persists its id; restart reattaches", async () => {
+    const client1 = new RecordingClient((id) => new EchoSession(id, "did work"));
+    const mem1 = new InMemoryChannelAdapter({ id: "mem" });
+    await tickOnce(client1, mem1);
+
+    expect(client1.created).toBe(1);
+    expect(client1.labels).toEqual(["heartbeat"]);
+    expect(mem1.lastText("c1")).toBe("did work");
+    const persisted = readFileSync(
+      join(home, "gateway", "heartbeat-session"),
+      "utf8",
+    ).trim();
+    expect(persisted).toBe("hb-sess-1");
+
+    // Simulated gateway restart: a fresh client must reattach the persisted
+    // session, not create (= leak) another daemon agent.
+    const client2 = new RecordingClient((id) => new EchoSession(id, "again"));
+    const mem2 = new InMemoryChannelAdapter({ id: "mem" });
+    await tickOnce(client2, mem2);
+
+    expect(client2.created).toBe(0);
+    expect(client2.attached).toEqual(["hb-sess-1"]);
+    expect(mem2.lastText("c1")).toBe("again");
+  });
+
+  test("dead backing agent mid-tick: reprovisions once and completes the turn", async () => {
+    const gone = Object.assign(
+      new Error("AgenC daemon agent not running: hb-sess-1"),
+      { data: { code: "AGENT_NOT_FOUND" } },
+    );
+    const client = new RecordingClient((id) =>
+      id === "hb-sess-1"
+        ? new EchoSession(id, gone)
+        : new EchoSession(id, "recovered"),
+    );
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    await tickOnce(client, mem);
+
+    expect(client.created).toBe(2);
+    expect(mem.lastText("c1")).toBe("recovered");
+    // The persisted id now points at the live replacement session.
+    const persisted = readFileSync(
+      join(home, "gateway", "heartbeat-session"),
+      "utf8",
+    ).trim();
+    expect(persisted).toBe("hb-sess-2");
+  });
+});


### PR DESCRIPTION
## The live-turn BLOCKER (TODO task 34)

Every live gateway turn failed with `AgenC daemon agent not found: agent_default`: the SDK `session.create` path binds sessions to a default agent that nothing in a headless `agenc gateway run` ever provisions. All gateway logic (channels 6/7/8, untrusted-content 11, heartbeat+budget 14/15) was tested only against a fake daemon client — no gateway turn had ever run end-to-end.

## Root cause (scouted, not assumed)

- The daemon has NO passive agent provisioner. Its only live-turn substrate is a background agent: `agent.create` → full runtime bootstrap → `message.send` routes into its run loop.
- Each background agent supports exactly ONE live session — the one `agent.create` itself creates (the runner keeps a single session event binding stamped with that session id). A shared default agent is therefore impossible; TODO option (a) realized as per-conversation agents.
- The coattach contract tests bypass the agent lifecycle entirely (multiplexer-only), and TUI terminal sessions are in-process `conv-*` sessions — which is why this was never hit before.

## Fix

- `createSession()` spawns a **passive** agent — `initialContent: []` suppresses the turn-1 objective submit (zero LLM calls at provision; pinned by a new runner contract test) — and adopts the agent's own session. One conversation = one agent = one session; history isolation falls out of the shape. Agents carry operator-facing labels (`gateway: <conversation key>`, `gateway: heartbeat`).
- **Latent bug fixed:** `attachSession` called a nonexistent SDK method (`client.attachSession`); the real method is `resumeSession` — restart reattach would have thrown `TypeError` on first live use.
- **Dead-agent recovery:** when the daemon loses the backing agent (daemon restart), `SessionRouter` and the heartbeat turn runner classify the error (`isDaemonAgentGoneError`, lifecycle `data.code` + message fallback), evict, reprovision, and retry the turn once.
- **Heartbeat agent leak fixed:** the heartbeat session id persists at `gateway/heartbeat-session` (0600) and reattaches across gateway restarts instead of spawning a new daemon agent per run; provisioning is now lazy (first tick).
- Gateway agents inherit the gateway's workspace cwd.

## Live acceptance (real daemon, real turns — ollama qwen2.5-coder:7b, isolated AGENC_HOME)

- `agenc gateway run --stdio`, allowlisted sender: **`agent> GATEWAY_LIVE_OK`** — first live gateway turn ever.
- Gateway restart: reattached the SAME agent (`agent.list`: 1 agent, idle) with transcript continuity (4 items across 2 runs).
- Heartbeat tick: real turn off `HEARTBEAT.md` → **`agent> HEARTBEAT SMOKE ALIVE`** + `heartbeat: delivered a message`; session id persisted.
- Daemon-side evidence: two labeled idle agents, exactly one per conversation + one for heartbeat.

## Tests

13 new (9 sdk-daemon-client incl. `isDaemonAgentGoneError` matrix, 2 SessionRouter dead-agent, 2 heartbeat wire persist/recover, 1 runner passive-spawn pin). Revert-sensitivity proven with HEAD-file copies for sdk-daemon-client / session-router / heartbeat wire (all red against HEAD), and a deliberate runner mutation (`hasFirstInput = true`) turned the passive-pin test red.

## Gates

build ✓ · typecheck ✓ · vitest 14192 passed ✓ · test:bun ✓ · check:agent-surface-contract ✓ · check:tui-runtime-startup ✓