### PR TITLE
feat(gateway): cron delivery to channels + webhook (task 16)

### DIFF
--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2750,7 +2750,7 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
     {
       name: "CronCreate",
       description:
-        "Schedule a recurring (or one-shot) prompt on a five-field cron expression. Jobs are executed by the runtime's own scheduler: when a job comes due its prompt is enqueued as a new turn in this session. Durable jobs persist in .agenc/scheduled_tasks.json and re-arm on restart; non-durable jobs die with the session.",
+        "Schedule a recurring (or one-shot) prompt on a five-field cron expression. Jobs are executed by the runtime's own scheduler: when a job comes due its prompt is enqueued as a new turn in this session. Durable jobs persist in .agenc/scheduled_tasks.json and re-arm on restart; non-durable jobs die with the session. Delivery-routed jobs (announceChannel/webhook) instead run in an isolated gateway session and post their result to that channel/webhook — they require durable and a running `agenc gateway run`.",
       metadata: toolMetadata("workflow", {
         mutating: true,
         deferred: true,
@@ -2769,6 +2769,21 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
               "true (default) reschedules after each fire; false fires once and deletes itself.",
           },
           durable: { type: "boolean" },
+          announceChannel: {
+            type: "string",
+            description:
+              "Gateway channel id to deliver the result to (e.g. \"telegram\", \"stdio\"). Requires announceTo. The job then runs in an isolated gateway session, not this one.",
+          },
+          announceTo: {
+            type: "string",
+            description:
+              "Conversation id on announceChannel to deliver to (e.g. a Telegram chat id).",
+          },
+          webhook: {
+            type: "string",
+            description:
+              "http(s) URL to POST the result to as JSON ({taskId, prompt, finalMessage, ...}). Combinable with announceChannel.",
+          },
         },
         required: ["prompt"],
         additionalProperties: false,
@@ -2782,19 +2797,52 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
         if (!validateCron(schedule)) {
           return json({ error: "cron expression must have five fields" }, true);
         }
-        const { addCronTask, nextCronRunMs } = await import(
+        const { addCronTask, nextCronRunMs, normalizeDelivery } = await import(
           "../utils/cronTasks.js"
         );
         if (nextCronRunMs(schedule, Date.now()) === null) {
           return json({ error: `invalid cron expression: ${schedule}` }, true);
         }
         const recurring = boolValue(args.recurring) ?? true;
-        const durable = boolValue(args.durable) ?? true;
-        const id = await addCronTask(schedule, prompt, recurring, durable);
+        const announceChannel = stringValue(args.announceChannel);
+        const announceTo = stringValue(args.announceTo);
+        const webhookUrl = stringValue(args.webhook);
+        if (announceChannel !== undefined && announceTo === undefined) {
+          return json({ error: "announceChannel requires announceTo" }, true);
+        }
+        if (webhookUrl !== undefined && !/^https?:\/\//i.test(webhookUrl)) {
+          return json({ error: "webhook must be an http(s) URL" }, true);
+        }
+        const deliver = normalizeDelivery({
+          channel: announceChannel,
+          to: announceTo,
+          webhook: webhookUrl,
+        });
+        // Delivery-routed jobs are executed by the gateway from the persisted
+        // task file — they must be durable or the gateway can never see them.
+        const durable =
+          deliver !== undefined ? true : (boolValue(args.durable) ?? true);
+        const id = await addCronTask(
+          schedule,
+          prompt,
+          recurring,
+          durable,
+          undefined,
+          deliver,
+        );
         // Arm the real runner: without this the definition is inert.
+        // (Delivery-routed jobs are skipped by this in-session runner and
+        // picked up by the gateway's cron-delivery scan.)
         await startCronSchedulerRunner();
         return json({
-          cron: { id, cron: schedule, prompt, recurring, durable },
+          cron: {
+            id,
+            cron: schedule,
+            prompt,
+            recurring,
+            durable,
+            ...(deliver !== undefined ? { deliver } : {}),
+          },
         });
       },
     },

--- a/runtime/src/gateway/cron-delivery.ts
+++ b/runtime/src/gateway/cron-delivery.ts
@@ -1,0 +1,282 @@
+/**
+ * Gateway cron delivery (TODO task 16).
+ *
+ * Runs delivery-tagged cron tasks (`CronTask.deliver` set) in ISOLATED
+ * gateway daemon sessions — heartbeat parity — and routes each result to a
+ * channel adapter and/or a webhook POST. The in-session cron scheduler skips
+ * these tasks (cronScheduler loadRunnableTasks), so the gateway is their
+ * exclusive executor and a fire is never double-run.
+ *
+ * Scheduling: sleep-until-earliest-due with a scan cap. Every wake re-reads
+ * `.agenc/scheduled_tasks.json` (cheap, non-model), fires the due tasks
+ * (each past-due schedule coalesces to ONE fire), stamps `lastFiredAt` /
+ * deletes one-shots, and re-arms. The scan cap bounds how stale the armed
+ * timer can get when tasks are added by another process — the model is still
+ * only invoked when a task is concretely due.
+ *
+ * Turns reuse the SessionRouter: one persistent daemon session per task
+ * (`cron|<id>`), dead-agent retry, and channel streaming for free. Turns are
+ * autonomous: permission requests are DENIED and the task-15 budget envelope
+ * gates every fire (refusal delivers a paused notice, never silent).
+ */
+
+import type { AgenCConfig } from "../config/schema.js";
+import {
+  BudgetEnforcer,
+  BudgetLedger,
+  createModelPriceResolver,
+  resolveBudgetPolicy,
+} from "../budget/index.js";
+import {
+  listAllCronTasks,
+  markCronTasksFired,
+  nextCronRunMs,
+  removeCronTasks,
+  type CronTask,
+} from "../utils/cronTasks.js";
+import { SessionRouter } from "./session-router.js";
+import type { ChannelAdapter, GatewayDaemonClient } from "./types.js";
+
+/** Upper bound on one sleep so externally-added tasks are noticed. */
+export const CRON_DELIVERY_SCAN_CAP_MS = 5 * 60 * 1000;
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+
+/** Deterministic ~chars/4 token estimate (mirrors the heartbeat runner). */
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+export interface CronDeliveryClock {
+  now(): Date;
+  setTimer(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
+  clearTimer(handle: ReturnType<typeof setTimeout>): void;
+}
+
+const REAL_CLOCK: CronDeliveryClock = {
+  now: () => new Date(),
+  setTimer: (fn, ms) => setTimeout(fn, ms),
+  clearTimer: (handle) => clearTimeout(handle),
+};
+
+export interface StartCronDeliveryOptions {
+  readonly agencHome: string;
+  /** Workspace holding `.agenc/scheduled_tasks.json`. */
+  readonly workspaceDir: string;
+  readonly config: AgenCConfig;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly client: GatewayDaemonClient;
+  readonly adapters: readonly ChannelAdapter[];
+  readonly log?: (line: string) => void;
+  /** Test seam: real timers by default. */
+  readonly clock?: CronDeliveryClock;
+  /** Test seam: webhook transport (global fetch by default). */
+  readonly postWebhook?: (url: string, body: unknown) => Promise<void>;
+}
+
+export interface CronDeliveryHandle {
+  /** True while a delivery turn is in flight (heartbeat skip-when-busy seam). */
+  isRunning(): boolean;
+  stop(): Promise<void>;
+}
+
+async function defaultPostWebhook(url: string, body: unknown): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Adapter used when a task delivers to a webhook only — swallows channel output. */
+const NULL_ADAPTER: ChannelAdapter = {
+  id: "cron-webhook-null",
+  supportsEdit: false,
+  async start() {},
+  async stop() {},
+  async send() {
+    return "cron-null";
+  },
+};
+
+export function startCronDelivery(
+  options: StartCronDeliveryOptions,
+): CronDeliveryHandle {
+  const log = options.log ?? (() => {});
+  const clock = options.clock ?? REAL_CLOCK;
+  const env = options.env ?? {};
+  const postWebhook = options.postWebhook ?? defaultPostWebhook;
+  const adaptersById = new Map(options.adapters.map((a) => [a.id, a]));
+
+  const { policy: budgetPolicy } = resolveBudgetPolicy(
+    options.config.budget,
+    env,
+  );
+  const enforcer = new BudgetEnforcer({
+    policy: budgetPolicy,
+    ledger: new BudgetLedger({ agencHome: options.agencHome }),
+    priceOf: createModelPriceResolver(),
+    notify: (e) => log(`cron/budget: ${e.message}`),
+  });
+
+  const router = new SessionRouter({
+    agencHome: options.agencHome,
+    client: options.client,
+  });
+
+  let stopped = false;
+  let running = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const deliveredTasks = async (): Promise<CronTask[]> => {
+    const tasks = await listAllCronTasks(options.workspaceDir);
+    return tasks.filter((t) => t.deliver !== undefined);
+  };
+
+  const fireTask = async (task: CronTask): Promise<void> => {
+    const deliver = task.deliver;
+    if (deliver === undefined) return;
+    const adapter =
+      deliver.channel !== undefined
+        ? adaptersById.get(deliver.channel)
+        : undefined;
+    if (deliver.channel !== undefined && adapter === undefined) {
+      log(
+        `cron: task ${task.id} targets unknown channel '${deliver.channel}' — skipping channel delivery this fire`,
+      );
+    }
+    const routeAdapter = adapter ?? NULL_ADAPTER;
+    const conversationId = adapter !== undefined ? deliver.to ?? "" : "cron";
+
+    // Budget pre-flight: cron fires are autonomous turns. A refusal delivers
+    // a paused notice instead of running the turn (never silent).
+    const admit = enforcer.admit({
+      agentId: `cron:${task.id}`,
+      model: "unknown",
+      autonomous: true,
+      estInputTokens: estimateTokens(task.prompt),
+      maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    });
+    if (!admit.ok) {
+      const notice = `⏸ cron task ${task.id} paused: ${admit.message}`;
+      log(`cron: ${notice}`);
+      if (adapter !== undefined && deliver.to !== undefined) {
+        await adapter
+          .send({ conversationId: deliver.to, text: notice })
+          .catch((error: unknown) => log(`cron: notice failed: ${String(error)}`));
+      }
+      return;
+    }
+
+    const result = await router.runTurn({
+      key: SessionRouter.conversationKey({
+        channelId: "cron",
+        agent: "default",
+        conversationId: task.id,
+      }),
+      text: task.prompt,
+      adapter: routeAdapter,
+      conversationId,
+      // Autonomous, no human watching → deny permission requests (fail safe).
+      onPermissionRequest: async () => ({
+        behavior: "deny",
+        reason: "cron delivery turns do not grant tool permissions",
+      }),
+    });
+
+    enforcer.reconcile(
+      admit.hold,
+      result.usage ?? { inputTokens: 0, outputTokens: 0 },
+    );
+
+    if (deliver.webhook !== undefined) {
+      await postWebhook(deliver.webhook, {
+        taskId: task.id,
+        cron: task.cron,
+        prompt: task.prompt,
+        finalMessage: result.finalMessage,
+        stopReason: result.stopReason,
+        firedAt: clock.now().toISOString(),
+      }).catch((error: unknown) =>
+        log(`cron: webhook POST failed for task ${task.id}: ${String(error)}`),
+      );
+    }
+    log(`cron: task ${task.id} delivered (${result.stopReason})`);
+  };
+
+  const tick = async (): Promise<void> => {
+    if (stopped || running) return;
+    running = true;
+    try {
+      const now = clock.now().getTime();
+      const tasks = await deliveredTasks();
+      const firedRecurring: CronTask[] = [];
+      const firedOneShots: string[] = [];
+      for (const task of tasks) {
+        // Anchor from the last fire (or creation) — a past-due schedule
+        // coalesces to ONE fire regardless of how many slots were missed.
+        const due = nextCronRunMs(task.cron, task.lastFiredAt ?? task.createdAt);
+        if (due === null || due > now) continue;
+        try {
+          await fireTask(task);
+        } catch (error) {
+          log(`cron: task ${task.id} failed: ${String(error)}`);
+        }
+        if (task.recurring === true) firedRecurring.push(task);
+        else firedOneShots.push(task.id);
+      }
+      if (firedRecurring.length > 0) {
+        await markCronTasksFired(
+          firedRecurring.map((t) => t.id),
+          now,
+          options.workspaceDir,
+        );
+      }
+      if (firedOneShots.length > 0) {
+        await removeCronTasks(firedOneShots, options.workspaceDir);
+      }
+    } finally {
+      running = false;
+    }
+    arm();
+  };
+
+  const arm = (): void => {
+    if (stopped) return;
+    if (timer !== null) clock.clearTimer(timer);
+    void (async () => {
+      const now = clock.now().getTime();
+      let earliest: number | null = null;
+      for (const task of await deliveredTasks()) {
+        const due = nextCronRunMs(task.cron, task.lastFiredAt ?? task.createdAt);
+        if (due === null) continue;
+        if (earliest === null || due < earliest) earliest = due;
+      }
+      if (stopped) return;
+      const sleep = Math.min(
+        earliest === null ? CRON_DELIVERY_SCAN_CAP_MS : Math.max(0, earliest - now),
+        CRON_DELIVERY_SCAN_CAP_MS,
+      );
+      timer = clock.setTimer(() => void tick(), sleep);
+    })();
+  };
+
+  arm();
+  log("cron: gateway delivery armed");
+
+  return {
+    isRunning: () => running,
+    async stop() {
+      stopped = true;
+      if (timer !== null) clock.clearTimer(timer);
+      timer = null;
+    },
+  };
+}

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -62,6 +62,13 @@ export {
   type SdkModule,
 } from "./sdk-daemon-client.js";
 export {
+  startCronDelivery,
+  CRON_DELIVERY_SCAN_CAP_MS,
+  type CronDeliveryClock,
+  type CronDeliveryHandle,
+  type StartCronDeliveryOptions,
+} from "./cron-delivery.js";
+export {
   frameChannelMessage,
   sanitizeChannelText,
   CHANNEL_MESSAGE_GUIDANCE,

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -22,6 +22,7 @@ import { loadConfig } from "../config/loader.js";
 import { resolveHeartbeatPolicy } from "../heartbeat/config.js";
 import { startHeartbeat } from "../heartbeat/wire.js";
 import type { HeartbeatScheduler } from "../heartbeat/scheduler.js";
+import { startCronDelivery, type CronDeliveryHandle } from "./cron-delivery.js";
 import { ChannelGateway } from "./gateway.js";
 import { loadGatewayConfig } from "./config.js";
 import { createSdkDaemonClient } from "./sdk-daemon-client.js";
@@ -58,6 +59,8 @@ export interface GatewayRunOptions {
   readonly workspaceDir?: string;
   /** Test seam: inject the heartbeat clock (real timers by default). */
   readonly heartbeatClock?: import("../heartbeat/types.js").HeartbeatClock;
+  /** Test seam: inject the cron-delivery clock (real timers by default). */
+  readonly cronClock?: import("./cron-delivery.js").CronDeliveryClock;
   /** WebChat bind host (default 127.0.0.1) / port (default ephemeral). */
   readonly webchatHost?: string;
   readonly webchatPort?: number;
@@ -222,20 +225,40 @@ export async function startGateway(
     log(`gateway: WebChat on ${webchat.url}`);
   }
 
+  // Cron delivery (task 16): delivery-tagged cron tasks run in isolated
+  // gateway sessions and announce to channels / POST to webhooks. Restart
+  // re-arms from the persisted .agenc/scheduled_tasks.json.
+  let cronDelivery: CronDeliveryHandle | null = null;
+  const mainConfigLoaded = (
+    await loadConfig({ home: options.agencHome, onWarn: log })
+  ).config;
+  try {
+    cronDelivery = startCronDelivery({
+      agencHome: options.agencHome,
+      workspaceDir: options.workspaceDir ?? process.cwd(),
+      config: mainConfigLoaded,
+      env,
+      client,
+      adapters,
+      log,
+      ...(options.cronClock !== undefined ? { clock: options.cronClock } : {}),
+    });
+  } catch (error) {
+    log(`cron: failed to start delivery (continuing without it): ${String(error)}`);
+  }
+
   // Heartbeat (task 14): proactive autonomous ticks, bounded by the budget
   // layer. Enabled via [heartbeat] config or AGENC_HEARTBEAT; --heartbeat
   // forces it on for this run. Uses the same daemon client + channel adapters.
   let heartbeat: HeartbeatScheduler | null = null;
   try {
-    const mainConfig = (await loadConfig({ home: options.agencHome, onWarn: log }))
-      .config;
     const heartbeatConfig =
       options.heartbeat === true
         ? {
-            ...mainConfig,
-            heartbeat: { ...mainConfig.heartbeat, enabled: true },
+            ...mainConfigLoaded,
+            heartbeat: { ...mainConfigLoaded.heartbeat, enabled: true },
           }
-        : mainConfig;
+        : mainConfigLoaded;
     heartbeat = await startHeartbeat({
       agencHome: options.agencHome,
       workspaceDir: options.workspaceDir ?? process.cwd(),
@@ -244,6 +267,9 @@ export async function startGateway(
       client,
       adapters,
       log,
+      // skip-when-busy: a heartbeat tick defers while a cron delivery turn
+      // is in flight (both are autonomous turns on the same daemon).
+      isCronRunning: () => cronDelivery?.isRunning() === true,
       ...(options.heartbeatClock !== undefined
         ? { clock: options.heartbeatClock }
         : {}),
@@ -260,6 +286,7 @@ export async function startGateway(
     ...(webchat !== undefined ? { webchatUrl: webchat.url } : {}),
     async stop() {
       if (heartbeat !== null) await heartbeat.stop();
+      if (cronDelivery !== null) await cronDelivery.stop();
       await gateway.stop();
       await client.close();
     },

--- a/runtime/src/tools/ScheduleCronTool/CronCreateTool.ts
+++ b/runtime/src/tools/ScheduleCronTool/CronCreateTool.ts
@@ -8,6 +8,7 @@ import {
   getCronFilePath,
   listAllCronTasks,
   nextCronRunMs,
+  normalizeDelivery,
 } from '../../utils/cronTasks.js'
 import { getCronScheduler } from '../../utils/cronScheduler.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -39,6 +40,24 @@ const inputSchema = lazySchema(() =>
     durable: semanticBoolean(z.boolean().optional()).describe(
       'true = persist to .agenc/scheduled_tasks.json and survive restarts. false (default) = in-memory only, dies when this AgenC session ends. Use true only when the user asks the task to survive across sessions.',
     ),
+    announceChannel: z
+      .string()
+      .optional()
+      .describe(
+        'Gateway channel id to deliver the result to (e.g. "telegram", "stdio"). Requires announceTo. The job then runs in an isolated gateway session (needs a running `agenc gateway run`), not this one.',
+      ),
+    announceTo: z
+      .string()
+      .optional()
+      .describe(
+        'Conversation id on announceChannel to deliver to (e.g. a Telegram chat id).',
+      ),
+    webhook: z
+      .string()
+      .optional()
+      .describe(
+        'http(s) URL to POST the result to as JSON. Combinable with announceChannel.',
+      ),
   }),
 )
 type InputSchema = ReturnType<typeof inputSchema>
@@ -113,18 +132,49 @@ export const CronCreateTool = buildTool({
         errorCode: 4,
       }
     }
+    if (input.announceChannel !== undefined && input.announceTo === undefined) {
+      return {
+        result: false,
+        message: 'announceChannel requires announceTo (the conversation id).',
+        errorCode: 5,
+      }
+    }
+    if (input.webhook !== undefined && !/^https?:\/\//i.test(input.webhook)) {
+      return {
+        result: false,
+        message: 'webhook must be an http(s) URL.',
+        errorCode: 6,
+      }
+    }
     return { result: true }
   },
-  async call({ cron, prompt, recurring = true, durable = false }) {
+  async call({
+    cron,
+    prompt,
+    recurring = true,
+    durable = false,
+    announceChannel,
+    announceTo,
+    webhook,
+  }) {
+    const deliver = normalizeDelivery({
+      channel: announceChannel,
+      to: announceTo,
+      webhook,
+    })
     // Kill switch forces session-only; schema stays stable so the model sees
     // no validation errors when the gate flips mid-session.
-    const effectiveDurable = durable && isDurableCronEnabled()
+    // Delivery-routed jobs are executed by the GATEWAY from the persisted
+    // task file, so they are always durable.
+    const effectiveDurable =
+      deliver !== undefined ? true : durable && isDurableCronEnabled()
     const id = await addCronTask(
       cron,
       prompt,
       recurring,
       effectiveDurable,
       getTeammateContext()?.agentId,
+      deliver,
     )
     // Enable the scheduler so the task fires in this session, then start the
     // timer-driven driver and reschedule it to the new task's next-due moment.

--- a/runtime/src/utils/cronScheduler.ts
+++ b/runtime/src/utils/cronScheduler.ts
@@ -315,12 +315,24 @@ export class CronScheduler {
   }
 
   /**
+   * Tasks this in-session scheduler is allowed to run. Delivery-tagged tasks
+   * (`deliver` set) are OWNED by the gateway's cron-delivery runner — they run
+   * in an isolated gateway daemon session and route their result to a channel
+   * or webhook. Running them here too would double-fire every occurrence, so
+   * they are excluded from BOTH dispatch and the wake computation.
+   */
+  private async loadRunnableTasks(): Promise<CronTask[]> {
+    const tasks = await this.deps.loadTasks(this.opts.dir)
+    return tasks.filter(task => task.deliver === undefined)
+  }
+
+  /**
    * Find tasks whose due time is now in the past, coalesce each to a single
    * enqueue, persist lastFiredAt / delete one-shots, and emit telemetry.
    */
   private async dispatchDue(): Promise<void> {
     const now = this.deps.now()
-    const tasks = await this.deps.loadTasks(this.opts.dir)
+    const tasks = await this.loadRunnableTasks()
 
     let dispatched = 0
     let coalescedMisses = 0
@@ -453,7 +465,7 @@ export class CronScheduler {
    */
   private async earliestDueAt(): Promise<number | null> {
     const now = this.deps.now()
-    const tasks = await this.deps.loadTasks(this.opts.dir)
+    const tasks = await this.loadRunnableTasks()
     let earliest: number | null = null
     for (const task of tasks) {
       const due = this.nextDueForTask(task, now)

--- a/runtime/src/utils/cronTasks.ts
+++ b/runtime/src/utils/cronTasks.ts
@@ -27,6 +27,22 @@ import { safeParseJSON } from './json.js'
 import { logError } from './log.js'
 import { jsonStringify } from './slowOperations.js'
 
+/**
+ * Delivery routing for gateway-executed cron tasks (TODO task 16). A task
+ * with `deliver` set is OWNED by the channel gateway: it runs in an isolated
+ * gateway daemon session (heartbeat parity) and its result is delivered to a
+ * channel and/or POSTed to a webhook. The in-session scheduler SKIPS these
+ * tasks so a fire is never double-executed.
+ */
+export type CronDelivery = {
+  /** Channel adapter id to announce the result on (e.g. "stdio", "telegram"). */
+  channel?: string
+  /** Conversation id on that channel (required when channel is set). */
+  to?: string
+  /** http(s) URL to POST the result to as JSON. */
+  webhook?: string
+}
+
 export type CronTask = {
   id: string
   /** 5-field cron string (local time) — validated on write, re-validated on read. */
@@ -67,6 +83,12 @@ export type CronTask = {
    * REPL's. Never written to disk (teammate crons are always session-only).
    */
   agentId?: string
+  /**
+   * Gateway delivery routing (TODO task 16). Persisted. When set the task is
+   * executed by the gateway's cron-delivery runner, NOT the in-session
+   * scheduler (which skips it — see cronScheduler loadRunnableTasks).
+   */
+  deliver?: CronDelivery
 }
 
 type CronFile = { tasks: CronTask[] }
@@ -124,6 +146,7 @@ export async function readCronTasks(dir?: string): Promise<CronTask[]> {
       )
       continue
     }
+    const deliver = normalizeDelivery(t.deliver)
     out.push({
       id: t.id,
       cron: t.cron,
@@ -134,6 +157,7 @@ export async function readCronTasks(dir?: string): Promise<CronTask[]> {
         : {}),
       ...(t.recurring ? { recurring: true } : {}),
       ...(t.permanent ? { permanent: true } : {}),
+      ...(deliver !== undefined ? { deliver } : {}),
     })
   }
   return out
@@ -197,16 +221,19 @@ export async function addCronTask(
   recurring: boolean,
   durable: boolean,
   agentId?: string,
+  deliver?: CronDelivery,
 ): Promise<string> {
   // Short ID — 8 hex chars is plenty for MAX_JOBS=50, avoids slice/prefix
   // juggling between the tool layer (shows short IDs) and disk.
   const id = randomUUID().slice(0, 8)
+  const normalizedDelivery = normalizeDelivery(deliver)
   const task = {
     id,
     cron,
     prompt,
     createdAt: Date.now(),
     ...(recurring ? { recurring: true } : {}),
+    ...(normalizedDelivery !== undefined ? { deliver: normalizedDelivery } : {}),
   }
   if (!durable) {
     addSessionCronTask({ ...task, ...(agentId ? { agentId } : {}) })
@@ -216,6 +243,36 @@ export async function addCronTask(
   tasks.push(task)
   await writeCronTasks(tasks)
   return id
+}
+
+/**
+ * Validate/normalize a delivery spec: strings only, channel requires to,
+ * webhook must be http(s). Returns undefined when nothing valid remains, so
+ * malformed on-disk data degrades to a normal in-session task instead of a
+ * task the gateway would misroute.
+ */
+export function normalizeDelivery(value: unknown): CronDelivery | undefined {
+  if (value === null || typeof value !== 'object') return undefined
+  const raw = value as { channel?: unknown; to?: unknown; webhook?: unknown }
+  const channel =
+    typeof raw.channel === 'string' && raw.channel.trim().length > 0
+      ? raw.channel.trim()
+      : undefined
+  const to =
+    typeof raw.to === 'string' && raw.to.trim().length > 0
+      ? raw.to.trim()
+      : undefined
+  const webhook =
+    typeof raw.webhook === 'string' && /^https?:\/\//i.test(raw.webhook.trim())
+      ? raw.webhook.trim()
+      : undefined
+  const out: CronDelivery = {
+    ...(channel !== undefined && to !== undefined ? { channel, to } : {}),
+    ...(webhook !== undefined ? { webhook } : {}),
+  }
+  return out.channel !== undefined || out.webhook !== undefined
+    ? out
+    : undefined
 }
 
 /**

--- a/runtime/tests/cronScheduler.test.ts
+++ b/runtime/tests/cronScheduler.test.ts
@@ -208,6 +208,33 @@ describe('CronScheduler', () => {
     sched.stop()
   })
 
+  test('delivery-tagged tasks are gateway-owned: NEVER enqueued in-session', async () => {
+    // Same due-hourly shape as the test above, but the task carries a
+    // `deliver` route — the gateway's cron-delivery runner is its exclusive
+    // executor, so the in-session driver must neither enqueue it nor arm a
+    // wake for it (a second executor would double-fire every occurrence).
+    const start = 59 * 60_000
+    const clock = new FakeClock(start)
+    const enqueue = vi.fn()
+    const sched = makeScheduler(
+      clock,
+      [
+        task({
+          id: 'ddddd016',
+          cron: '0 * * * *',
+          deliver: { channel: 'stdio', to: 'stdio' },
+        }),
+      ],
+      enqueue,
+    )
+
+    sched.start()
+    await advanceAndFlush(clock, 12 * 60_000)
+
+    expect(enqueue).toHaveBeenCalledTimes(0)
+    sched.stop()
+  })
+
   test('coalesce: multiple missed occurrences collapse to a SINGLE enqueue', async () => {
     // Per-minute task created at t=0, but the process was "asleep" until
     // t=10min — 10 slots (00:01..00:10) are all in the past. They MUST collapse

--- a/runtime/tests/gateway/cron-delivery.test.ts
+++ b/runtime/tests/gateway/cron-delivery.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Gateway cron delivery tests (TODO task 16).
+ *
+ * Delivery-tagged cron tasks run in isolated gateway daemon sessions and
+ * route their result to a channel adapter and/or webhook POST. Restart
+ * re-arms from the persisted `.agenc/scheduled_tasks.json` and delivery
+ * still routes. Budget refusal pauses the fire instead of running the turn.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  startCronDelivery,
+  type CronDeliveryClock,
+} from "../../src/gateway/cron-delivery.js";
+import { InMemoryChannelAdapter } from "../../src/gateway/test-channel.js";
+import type {
+  GatewayDaemonClient,
+  GatewayPromptHandlers,
+  GatewayPromptResult,
+  GatewaySession,
+  GatewaySessionCreateOptions,
+} from "../../src/gateway/types.js";
+import {
+  addCronTask,
+  readCronTasks,
+  normalizeDelivery,
+} from "../../src/utils/cronTasks.js";
+import type { AgenCConfig } from "../../src/config/schema.js";
+
+class EchoSession implements GatewaySession {
+  readonly sessionId: string;
+  readonly reply: string;
+  prompts: string[] = [];
+  constructor(sessionId: string, reply: string) {
+    this.sessionId = sessionId;
+    this.reply = reply;
+  }
+  async prompt(
+    text: string,
+    handlers: GatewayPromptHandlers,
+  ): Promise<GatewayPromptResult> {
+    this.prompts.push(text);
+    await handlers.onEvent({ type: "text", delta: this.reply });
+    return {
+      stopReason: "completed",
+      finalMessage: this.reply,
+      usage: { inputTokens: 10, outputTokens: 5 },
+    };
+  }
+}
+
+class RecordingClient implements GatewayDaemonClient {
+  created = 0;
+  attached: string[] = [];
+  labels: (string | undefined)[] = [];
+  readonly sessions: EchoSession[] = [];
+  readonly reply: string;
+  constructor(reply = "cron result") {
+    this.reply = reply;
+  }
+  async createSession(
+    options?: GatewaySessionCreateOptions,
+  ): Promise<GatewaySession> {
+    this.created += 1;
+    this.labels.push(options?.label);
+    const s = new EchoSession(`cron-sess-${this.created}`, this.reply);
+    this.sessions.push(s);
+    return s;
+  }
+  async attachSession(sessionId: string): Promise<GatewaySession> {
+    this.attached.push(sessionId);
+    const s = new EchoSession(sessionId, this.reply);
+    this.sessions.push(s);
+    return s;
+  }
+  async close(): Promise<void> {}
+}
+
+/** Manual clock: fires armed timers when advanced past their deadline. */
+function manualClock(startMs: number): {
+  clock: CronDeliveryClock;
+  advance(ms: number): Promise<void>;
+} {
+  let now = startMs;
+  let nextId = 1;
+  const timers = new Map<number, { at: number; fn: () => void }>();
+  // The runner's arm()/tick() await real fs I/O (readCronTasks), which
+  // resolves on the macrotask queue — hop it, not just microtasks, or the
+  // armed timer is invisible to advance().
+  const flush = async () => {
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+  };
+  return {
+    clock: {
+      now: () => new Date(now),
+      setTimer: (fn, ms) => {
+        const id = nextId++;
+        timers.set(id, { at: now + ms, fn });
+        return id as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimer: (handle) => {
+        timers.delete(handle as unknown as number);
+      },
+    },
+    async advance(ms: number) {
+      const target = now + ms;
+      await flush();
+      for (;;) {
+        let dueId: number | null = null;
+        let dueAt = Infinity;
+        for (const [id, t] of timers) {
+          if (t.at <= target && t.at < dueAt) {
+            dueAt = t.at;
+            dueId = id;
+          }
+        }
+        if (dueId === null) break;
+        const t = timers.get(dueId)!;
+        timers.delete(dueId);
+        now = t.at;
+        t.fn();
+        await flush();
+      }
+      now = target;
+      await flush();
+    },
+  };
+}
+
+const NO_BUDGET_CONFIG = {} as unknown as AgenCConfig;
+
+describe("startCronDelivery", () => {
+  let home: string;
+  let ws: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-cron-del-"));
+    ws = join(home, "ws");
+    mkdirSync(join(ws, ".agenc"), { recursive: true });
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  function writeTasks(tasks: object[]): void {
+    writeFileSync(
+      join(ws, ".agenc", "scheduled_tasks.json"),
+      JSON.stringify({ tasks }, null, 2),
+    );
+  }
+
+  function baseOptions(client: GatewayDaemonClient, mem: InMemoryChannelAdapter) {
+    return {
+      agencHome: home,
+      workspaceDir: ws,
+      config: NO_BUDGET_CONFIG,
+      env: {},
+      client,
+      adapters: [mem] as const,
+    };
+  }
+
+  test("fake-clock fire: posts the result to the channel and stamps lastFiredAt", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch01",
+        cron: "* * * * *", // every minute
+        prompt: "summarize the day",
+        createdAt: startMs - 1_000,
+        recurring: true,
+        deliver: { channel: "mem", to: "ops" },
+      },
+    ]);
+    const client = new RecordingClient("all quiet");
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+
+    const handle = startCronDelivery({ ...baseOptions(client, mem), clock });
+    // 70s crosses exactly ONE minute boundary (10:01:00) — 90s would land on
+    // 10:02:00 and legitimately fire twice.
+    await advance(70_000);
+
+    expect(mem.lastText("ops")).toBe("all quiet");
+    // Turn ran in an ISOLATED gateway session labeled for the task.
+    expect(client.labels).toEqual(["cron|default|cronch01"]);
+    expect(client.sessions[0].prompts).toEqual(["summarize the day"]);
+    // lastFiredAt persisted → restart will not replay this occurrence.
+    const persisted = await readCronTasks(ws);
+    expect(persisted[0].lastFiredAt).toBeGreaterThanOrEqual(startMs);
+    await handle.stop();
+  });
+
+  test("restart re-arms from disk and delivery still routes (acceptance)", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch02",
+        cron: "* * * * *",
+        prompt: "tick",
+        createdAt: startMs - 1_000,
+        recurring: true,
+        deliver: { channel: "mem", to: "ops" },
+      },
+    ]);
+    const client1 = new RecordingClient("first run");
+    const mem1 = new InMemoryChannelAdapter({ id: "mem" });
+    const t1 = manualClock(startMs);
+    const h1 = startCronDelivery({
+      ...baseOptions(client1, mem1),
+      clock: t1.clock,
+    });
+    await t1.advance(90_000);
+    expect(mem1.lastText("ops")).toBe("first run");
+    await h1.stop();
+
+    // Simulated gateway restart: fresh runner over the same workspace. It
+    // must re-arm from the persisted file, reattach the persisted session
+    // (no new daemon agent), and route the NEXT occurrence.
+    const client2 = new RecordingClient("second run");
+    const mem2 = new InMemoryChannelAdapter({ id: "mem" });
+    const t2 = manualClock(startMs + 90_000);
+    const h2 = startCronDelivery({
+      ...baseOptions(client2, mem2),
+      clock: t2.clock,
+    });
+    await t2.advance(120_000);
+    expect(mem2.lastText("ops")).toBe("second run");
+    expect(client2.created).toBe(0); // reattached, not re-provisioned
+    expect(client2.attached).toEqual(["cron-sess-1"]);
+    await h2.stop();
+  });
+
+  test("one-shot: fires once, delivers, and deletes itself", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch03",
+        cron: "* * * * *",
+        prompt: "one shot",
+        createdAt: startMs - 1_000,
+        deliver: { channel: "mem", to: "ops" },
+      },
+    ]);
+    const client = new RecordingClient("done once");
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+    const handle = startCronDelivery({ ...baseOptions(client, mem), clock });
+
+    await advance(90_000);
+    expect(mem.lastText("ops")).toBe("done once");
+    expect(await readCronTasks(ws)).toHaveLength(0);
+
+    // No further fires after deletion.
+    await advance(180_000);
+    expect(mem.sent.filter((m) => m.text === "done once")).toHaveLength(1);
+    await handle.stop();
+  });
+
+  test("webhook delivery POSTs the result as JSON (webhook-only task)", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch04",
+        cron: "* * * * *",
+        prompt: "report",
+        createdAt: startMs - 1_000,
+        recurring: true,
+        deliver: { webhook: "https://hooks.example/cron" },
+      },
+    ]);
+    const client = new RecordingClient("webhook payload");
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+    const posts: { url: string; body: unknown }[] = [];
+    const handle = startCronDelivery({
+      ...baseOptions(client, mem),
+      clock,
+      postWebhook: async (url, body) => {
+        posts.push({ url, body });
+      },
+    });
+
+    await advance(70_000); // exactly one minute boundary
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toBe("https://hooks.example/cron");
+    expect(posts[0].body).toMatchObject({
+      taskId: "cronch04",
+      prompt: "report",
+      finalMessage: "webhook payload",
+      stopReason: "completed",
+    });
+    // Webhook-only: nothing went to any channel.
+    expect(mem.sent).toHaveLength(0);
+    await handle.stop();
+  });
+
+  test("BUDGET REFUSAL: the turn does NOT run; a paused notice is delivered", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch05",
+        cron: "* * * * *",
+        prompt: "expensive work",
+        createdAt: startMs - 1_000,
+        recurring: true,
+        deliver: { channel: "mem", to: "ops" },
+      },
+    ]);
+    const client = new RecordingClient("should never run");
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+    const handle = startCronDelivery({
+      ...baseOptions(client, mem),
+      config: {
+        budget: { enabled: true, daily_tokens: 1 },
+      } as unknown as AgenCConfig,
+      clock,
+    });
+
+    await advance(90_000);
+    // No session, no turn — the refusal happened before any daemon work.
+    expect(client.created).toBe(0);
+    const last = mem.lastText("ops") ?? "";
+    expect(last).toContain("paused");
+    await handle.stop();
+  });
+
+  test("unknown channel: fire is skipped gracefully without crashing", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch06",
+        cron: "* * * * *",
+        prompt: "hello",
+        createdAt: startMs - 1_000,
+        recurring: true,
+        deliver: { channel: "nope", to: "x" },
+      },
+    ]);
+    const client = new RecordingClient("orphan");
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+    const lines: string[] = [];
+    const handle = startCronDelivery({
+      ...baseOptions(client, mem),
+      clock,
+      log: (l) => lines.push(l),
+    });
+
+    await advance(90_000);
+    expect(mem.sent).toHaveLength(0);
+    expect(lines.some((l) => l.includes("unknown channel"))).toBe(true);
+    await handle.stop();
+  });
+});
+
+describe("cron task delivery persistence", () => {
+  let ws: string;
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), "agenc-cron-tasks-"));
+    mkdirSync(join(ws, ".agenc"), { recursive: true });
+  });
+  afterEach(async () => {
+    const { resetStateForTests } = await import("../../src/bootstrap/state.js");
+    resetStateForTests();
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  test("addCronTask persists deliver and readCronTasks round-trips it", async () => {
+    const { setProjectRoot } = await import("../../src/bootstrap/state.js");
+    setProjectRoot(ws);
+    await addCronTask("* * * * *", "p", true, true, undefined, {
+      channel: "telegram",
+      to: "123",
+      webhook: "https://hooks.example/x",
+    });
+    const tasks = await readCronTasks(ws);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].deliver).toEqual({
+      channel: "telegram",
+      to: "123",
+      webhook: "https://hooks.example/x",
+    });
+  });
+
+  test("normalizeDelivery: channel requires to; webhook must be http(s)", () => {
+    expect(normalizeDelivery({ channel: "tg" })).toBeUndefined();
+    expect(normalizeDelivery({ channel: "tg", to: "1" })).toEqual({
+      channel: "tg",
+      to: "1",
+    });
+    expect(normalizeDelivery({ webhook: "ftp://x" })).toBeUndefined();
+    expect(normalizeDelivery({ webhook: "https://x.example" })).toEqual({
+      webhook: "https://x.example",
+    });
+    expect(normalizeDelivery(undefined)).toBeUndefined();
+    expect(normalizeDelivery("junk")).toBeUndefined();
+  });
+
+  test("malformed on-disk deliver degrades to a plain task (no misroute)", async () => {
+    writeFileSync(
+      join(ws, ".agenc", "scheduled_tasks.json"),
+      JSON.stringify({
+        tasks: [
+          {
+            id: "aaaa0001",
+            cron: "* * * * *",
+            prompt: "p",
+            createdAt: 1,
+            deliver: { channel: 42 },
+          },
+        ],
+      }),
+    );
+    const tasks = await readCronTasks(ws);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].deliver).toBeUndefined();
+  });
+});

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -256,6 +256,71 @@ describe("startGateway", () => {
     await handle.stop();
   });
 
+  test("cron delivery: a deliver-tagged task fires through the run loop to a channel", async () => {
+    writeConfig({ channels: { mem: { dmPolicy: "allowlist", allowlist: ["x"] } } });
+    const ws = join(home, "ws");
+    mkdirSync(join(ws, ".agenc"), { recursive: true });
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeFileSync(
+      join(ws, ".agenc", "scheduled_tasks.json"),
+      JSON.stringify({
+        tasks: [
+          {
+            id: "runcron1",
+            cron: "* * * * *",
+            prompt: "cron says hi",
+            createdAt: startMs - 1_000,
+            recurring: true,
+            deliver: { channel: "mem", to: "c9" },
+          },
+        ],
+      }),
+    );
+
+    const client = new FakeClient();
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+
+    // Manual cron clock: capture armed timers, fire the earliest by hand.
+    let now = startMs;
+    const timers = new Map<number, { at: number; fn: () => void }>();
+    let nextTimer = 1;
+    const cronClock = {
+      now: () => new Date(now),
+      setTimer: (fn: () => void, ms: number) => {
+        const id = nextTimer++;
+        timers.set(id, { at: now + ms, fn });
+        return id as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimer: (handle: ReturnType<typeof setTimeout>) => {
+        timers.delete(handle as unknown as number);
+      },
+    };
+
+    const handle = await startGateway({
+      agencHome: home,
+      workspaceDir: ws,
+      clientFactory: async () => client,
+      extraAdapters: [mem],
+      cronClock,
+    });
+
+    // Let arm() finish its async file read, then fire the armed timer.
+    await new Promise((r) => setTimeout(r, 20));
+    const armed = [...timers.values()].sort((a, b) => a.at - b.at)[0];
+    expect(armed).toBeDefined();
+    now = armed.at;
+    timers.delete([...timers.keys()][0]);
+    armed.fn();
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The cron turn ran in its own gateway session and delivered in-channel.
+    expect(mem.sent.some((m) => m.conversationId === "c9")).toBe(true);
+    expect(
+      client.sessions.some((s) => s.prompts.includes("cron says hi")),
+    ).toBe(true);
+    await handle.stop();
+  });
+
   test("heartbeat: a config-enabled tick runs a turn and delivers to a channel", async () => {
     // Gateway channel + config.toml heartbeat targeting the in-memory channel.
     writeConfig({ channels: { mem: { dmPolicy: "allowlist", allowlist: ["x"] } } });


### PR DESCRIPTION
## What (TODO task 16)

Delivery-tagged cron tasks — `CronTask.deliver = {channel, to, webhook}` — run in **isolated gateway daemon sessions** (heartbeat parity) and announce their result on a channel adapter and/or POST it as JSON to a webhook.

## Design

- **Data layer**: `deliver` persisted in `.agenc/scheduled_tasks.json` via the `readCronTasks` whitelist + `normalizeDelivery` validation (channel requires `to`; webhook must be http(s); malformed on-disk data degrades to a plain in-session task, never a misroute).
- **Exclusive ownership**: the in-session cron scheduler SKIPS deliver-tagged tasks (`loadRunnableTasks`) — the gateway is their only executor, so an occurrence is never double-fired.
- **Gateway runner** (`gateway/cron-delivery.ts`): sleep-until-earliest-due with a 5-min scan cap (wakes re-read the file — cheap and non-model; the zero-idle-model-invocations invariant holds). Restart re-arms from disk; past-due slots coalesce to ONE fire; one-shots delete after firing; `lastFiredAt` stamped with the runner's clock. Turns reuse the SessionRouter — task-34 provisioning, persistent per-task sessions, dead-agent retry — and deny permission requests (autonomous).
- **Budget**: every fire goes through the task-15 enforcer (`admit` → turn → `reconcile`); a refusal delivers a paused notice in-channel instead of running the turn (never silent).
- **Heartbeat wire**: `skip_when_busy` now sees live cron (`isCronRunning`).
- **Tools**: `CronCreate` in BOTH catalogs (model-facing live surface + TUI tool) gains `announceChannel`/`announceTo`/`webhook`; delivery jobs are forced durable (the gateway reads them from disk).

## Acceptance

- Fake-clock cron job posts its result to a fake channel ✓ (unit + run-loop integration test)
- Restart re-arms and delivery still routes ✓ (persisted file + persisted session: second runner reattaches, no new daemon agent)
- **Live-proven**: a real per-minute deliver-tagged task fired through `agenc gateway run --stdio` against the real daemon → `agent> CRON DELIVERY LIVE` + `cron: task live16aa delivered (completed)`; `lastFiredAt` stamped; daemon shows the labeled agent `gateway: cron|default|live16aa`.

## Tests

17 new (6 runner incl. webhook/budget-refusal/unknown-channel, 3 persistence/validation, 1 scheduler-skip, 1 run-loop integration, plus roundtrip/malformed). Revert/mutation-proven: scheduler skip red against HEAD scheduler; whitelist-drop mutation turns the roundtrip red; run-loop test red against HEAD run.ts.

## Gates

build ✓ · typecheck ✓ · vitest 14203 passed ✓ · test:bun ✓ · check:agent-surface-contract ✓