### PR TITLE
fix: keep Telegram gateway permission prompts private

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -64,6 +64,14 @@ For fixed operators, set `AGENC_TELEGRAM_ADMIN_PEER_IDS=123,456`. Owner/control
 state is stored at `<AGENC_HOME>/gateway/control.json` (0600). Telegram command
 menus are installed for private chats and groups when the Bot API allows it.
 
+Telegram gateway agents are spawned with a tiny unattended tool allowlist by
+default: `SendUserMessage` and `Brief`. That lets the bot answer normally
+without leaking approval prompts into chat, while privileged tools still pause
+and are denied by the Telegram gateway instead of rendering `approve <token>`
+to public users. Operators may override the list with
+`AGENC_GATEWAY_AGENT_UNATTENDED_ALLOW` and
+`AGENC_GATEWAY_AGENT_UNATTENDED_DENY`.
+
 ## Heartbeat (proactive ticks)
 
 `agenc gateway run --heartbeat` (or `[heartbeat] enabled = true`) runs a

--- a/runtime/src/gateway/gateway.ts
+++ b/runtime/src/gateway/gateway.ts
@@ -21,6 +21,7 @@ import type { GatewayMemeFeature, GatewayMemeReplyOptions } from "./meme.js";
 import { evaluateDmAccess, PairingStore } from "./pairing.js";
 import { detectPromptInjectionAttempt } from "./prompt-injection.js";
 import { SessionRouter } from "./session-router.js";
+import { TELEGRAM_CHANNEL_ID } from "./telegram-channel.js";
 import { frameChannelMessage } from "./untrusted.js";
 import type {
   ChannelAdapter,
@@ -224,6 +225,18 @@ export class ChannelGateway {
         adapter,
         conversationId: message.conversation.id,
         onPermissionRequest: async (request) => {
+          if (message.channelId === TELEGRAM_CHANNEL_ID) {
+            this.#log(
+              `gateway: denied Telegram permission request '${request.toolName ?? "unknown"}' from '${message.sender.peerId}'`,
+            );
+            await reply(
+              "I can't run privileged tools from Telegram. Ask an AgenC question or use /meme.",
+            );
+            return {
+              behavior: "deny",
+              reason: "Telegram gateway denies channel tool approvals",
+            };
+          }
           const { token, decision } = this.#approvals.register({
             channelId: message.channelId,
             conversationId: message.conversation.id,

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -117,6 +117,30 @@ function envList(value: string | undefined): readonly string[] {
     .filter(Boolean);
 }
 
+function envOptionalList(value: string | undefined): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  return envList(value);
+}
+
+function envPermissionMode(
+  value: string | undefined,
+):
+  | "default"
+  | "plan"
+  | "acceptEdits"
+  | "bypassPermissions"
+  | undefined {
+  if (
+    value === "default" ||
+    value === "plan" ||
+    value === "acceptEdits" ||
+    value === "bypassPermissions"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
 export interface GatewayRunHandle {
   readonly gateway: ChannelGateway;
   readonly channels: readonly string[];
@@ -231,6 +255,16 @@ export async function startGateway(
         ...(options.agencCommand !== undefined
           ? { agencCommand: options.agencCommand }
           : {}),
+        permissionMode: envPermissionMode(
+          env.AGENC_GATEWAY_AGENT_PERMISSION_MODE,
+        ),
+        unattendedAllow:
+          envOptionalList(env.AGENC_GATEWAY_AGENT_UNATTENDED_ALLOW) ?? [
+            "SendUserMessage",
+            "Brief",
+          ],
+        unattendedDeny:
+          envOptionalList(env.AGENC_GATEWAY_AGENT_UNATTENDED_DENY) ?? [],
       }));
 
   const telegramAdminPeerIds = envList(env.AGENC_TELEGRAM_ADMIN_PEER_IDS);

--- a/runtime/src/gateway/sdk-daemon-client.ts
+++ b/runtime/src/gateway/sdk-daemon-client.ts
@@ -45,6 +45,22 @@ export interface SdkDaemonClientOptions {
   readonly autostart?: boolean;
   /** Working directory for gateway daemon agents (default: daemon's choice). */
   readonly cwd?: string;
+  /**
+   * Permission mode for daemon agents spawned by the gateway. Leave undefined
+   * for the daemon default; unattended allow/deny still installs a policy.
+   */
+  readonly permissionMode?:
+    | "default"
+    | "plan"
+    | "acceptEdits"
+    | "bypassPermissions";
+  /**
+   * Tools the gateway daemon agent may use without channel approval prompts.
+   * In production Telegram this is intentionally tiny: SendUserMessage/Brief.
+   */
+  readonly unattendedAllow?: readonly string[];
+  /** Tools the gateway daemon agent must never run unattended. */
+  readonly unattendedDeny?: readonly string[];
   /** Test seam: inject the SDK module instead of importing it. */
   readonly sdk?: SdkModule;
 }
@@ -85,6 +101,13 @@ interface SdkClient {
     readonly objective: string;
     readonly initialContent: readonly never[];
     readonly cwd?: string;
+    readonly permissionMode?:
+      | "default"
+      | "plan"
+      | "acceptEdits"
+      | "bypassPermissions";
+    readonly unattendedAllow?: readonly string[];
+    readonly unattendedDeny?: readonly string[];
     readonly metadata?: Record<string, string>;
   }): Promise<SdkAgentCreateResult>;
   resumeSession(sessionId: string): Promise<SdkSession>;
@@ -210,9 +233,24 @@ export async function createSdkDaemonClient(
           label !== undefined ? `gateway: ${label}` : "gateway session",
         initialContent: [],
         ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+        ...(options.permissionMode !== undefined
+          ? { permissionMode: options.permissionMode }
+          : {}),
+        ...(options.unattendedAllow !== undefined
+          ? { unattendedAllow: options.unattendedAllow }
+          : {}),
+        ...(options.unattendedDeny !== undefined
+          ? { unattendedDeny: options.unattendedDeny }
+          : {}),
         metadata: {
           source: "agenc-gateway",
           ...(label !== undefined ? { gatewayLabel: label } : {}),
+          ...(options.unattendedAllow !== undefined
+            ? { unattendedAllow: options.unattendedAllow.join(",") }
+            : {}),
+          ...(options.unattendedDeny !== undefined
+            ? { unattendedDeny: options.unattendedDeny.join(",") }
+            : {}),
         },
       });
       if (created.sessionId === undefined) {

--- a/runtime/tests/gateway/gateway.test.ts
+++ b/runtime/tests/gateway/gateway.test.ts
@@ -441,4 +441,43 @@ describe("channel gateway", () => {
     expect(client.sessions).toHaveLength(0);
     expect(telegram.lastText("mallory-dm")).toContain("owner-only");
   });
+
+  test("telegram permission requests are denied without leaking approval tokens", async () => {
+    const telegram = new InMemoryChannelAdapter({ id: "telegram" });
+    const gw = new ChannelGateway({
+      agencHome: home,
+      client,
+      config: {
+        channels: {
+          telegram: { dmPolicy: "allowlist", allowlist: ["alice"] },
+        },
+        bindings: [],
+        defaultAgent: "default",
+      },
+      generateApprovalToken: () => "TOK-LEAK",
+    });
+    await gw.registerAdapter(telegram);
+    client.script = [
+      {
+        permission: {
+          requestId: "r1",
+          toolName: "Bash",
+          permissions: ["tool.use"],
+          reason: "untrusted policy: approve every call",
+        },
+        text: "I cannot run that.",
+      },
+    ];
+
+    await telegram.receive(dmMessage("alice", "run a privileged tool", "alice-dm"));
+
+    const transcript = telegram.sent.map((message) => message.text).join("\n");
+    expect(client.sessions[0].lastPermissionDecision).toEqual({
+      behavior: "deny",
+      reason: "Telegram gateway denies channel tool approvals",
+    });
+    expect(transcript).toContain("privileged tools");
+    expect(transcript).not.toContain("approve TOK-LEAK");
+    expect(transcript).not.toContain("Permission request");
+  });
 });

--- a/runtime/tests/gateway/sdk-daemon-client.test.ts
+++ b/runtime/tests/gateway/sdk-daemon-client.test.ts
@@ -25,6 +25,9 @@ interface SpawnCall {
   readonly objective: string;
   readonly initialContent: readonly never[];
   readonly cwd?: string;
+  readonly permissionMode?: string;
+  readonly unattendedAllow?: readonly string[];
+  readonly unattendedDeny?: readonly string[];
   readonly metadata?: Record<string, string>;
 }
 
@@ -110,6 +113,26 @@ describe("createSdkDaemonClient (daemon agent provisioning)", () => {
     await client.createSession();
 
     expect(sdk.spawnCalls[0].cwd).toBe("/work/space");
+  });
+
+  test("createSession threads gateway unattended policy to the agent", async () => {
+    const sdk = fakeSdk();
+    const client = await createSdkDaemonClient({
+      sdk: sdk.module,
+      unattendedAllow: ["SendUserMessage", "Brief"],
+      unattendedDeny: ["Bash"],
+    });
+
+    await client.createSession({ label: "telegram|agent|group" });
+
+    expect(sdk.spawnCalls[0]).toMatchObject({
+      unattendedAllow: ["SendUserMessage", "Brief"],
+      unattendedDeny: ["Bash"],
+    });
+    expect(sdk.spawnCalls[0].metadata).toMatchObject({
+      unattendedAllow: "SendUserMessage,Brief",
+      unattendedDeny: "Bash",
+    });
   });
 
   test("createSession fails loudly when the agent has no session", async () => {


### PR DESCRIPTION
## Summary
- spawn gateway daemon agents with a minimal unattended allowlist for SendUserMessage and Brief
- deny Telegram permission requests inside the gateway instead of rendering approve tokens to chats
- document Telegram gateway permission behavior

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npx vitest run runtime/tests/gateway/gateway.test.ts runtime/tests/gateway/sdk-daemon-client.test.ts runtime/tests/gateway/run.test.ts --reporter=dot
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot
- npm run build --workspace=@tetsuo-ai/runtime