### PR TITLE
fix: gate Telegram groups to mentions and replies

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -53,7 +53,7 @@ AGENC_TELEGRAM_OWNER_CLAIM_CODE=<random-one-time-code> \
 
 The first owner DMs `/owner <code>` to claim the bot. After that:
 
-- private DMs are owner-only; everyone else is told to use the public group;
+- private DMs are owner-only; non-owner DMs are ignored silently;
 - `/stop` pauses public group replies without stopping the process;
 - `/start` turns public group replies back on;
 - `/status` shows whether the public group is live or paused;
@@ -71,6 +71,13 @@ and are denied by the Telegram gateway instead of rendering `approve <token>`
 to public users. Operators may override the list with
 `AGENC_GATEWAY_AGENT_UNATTENDED_ALLOW` and
 `AGENC_GATEWAY_AGENT_UNATTENDED_DENY`.
+
+For group chats, set `AGENC_TELEGRAM_GROUP_ADDRESSING=mentions` and
+`AGENC_TELEGRAM_BOT_USERNAME=<bot_username>` to respond only when someone
+mentions `@bot_username`, replies to the bot, or uses a slash command. Telegram
+must have BotFather privacy mode disabled (`/setprivacy` → Disable) for normal
+`@bot_username hi` mention messages to be delivered to the bot; otherwise only
+slash commands and replies are delivered by Telegram.
 
 ## Heartbeat (proactive ticks)
 

--- a/runtime/src/gateway/control-plane.ts
+++ b/runtime/src/gateway/control-plane.ts
@@ -139,7 +139,9 @@ export class TelegramOwnerControl {
 
     if (command !== undefined && CONTROL_COMMANDS.has(command.name)) {
       if (!isOwner) {
-        await reply(this.#ownerOnlyMessage(ownerCount));
+        if (!isDm) {
+          await reply(this.#ownerOnlyMessage(ownerCount));
+        }
         this.#log(
           `telegram-control: denied owner command '/${command.name}' from '${message.sender.peerId}'`,
         );
@@ -151,7 +153,6 @@ export class TelegramOwnerControl {
 
     if (isDm) {
       if (isOwner) return { handled: false, bypassAccess: true };
-      await reply(this.#privateDeniedMessage(ownerCount));
       this.#log(
         `telegram-control: denied private DM from non-owner '${message.sender.peerId}'`,
       );
@@ -300,10 +301,4 @@ export class TelegramOwnerControl {
     return "Owner-only command.";
   }
 
-  #privateDeniedMessage(ownerCount: number): string {
-    if (ownerCount === 0 && this.#ownerClaimCode !== undefined) {
-      return "Private DMs are locked. The owner must DM /owner <code> first.";
-    }
-    return "Private DMs are owner-only. Use the public group.";
-  }
 }

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -141,6 +141,10 @@ function envPermissionMode(
   return undefined;
 }
 
+function envGroupAddressing(value: string | undefined): "all" | "mentions" {
+  return value === "mentions" ? "mentions" : "all";
+}
+
 export interface GatewayRunHandle {
   readonly gateway: ChannelGateway;
   readonly channels: readonly string[];
@@ -176,6 +180,12 @@ export async function startGateway(
       new TelegramChannelAdapter({
         transport: telegramTransport,
         commands: TELEGRAM_OWNER_COMMANDS,
+        groupAddressing: envGroupAddressing(
+          env.AGENC_TELEGRAM_GROUP_ADDRESSING,
+        ),
+        ...(env.AGENC_TELEGRAM_BOT_USERNAME !== undefined
+          ? { botUsername: env.AGENC_TELEGRAM_BOT_USERNAME.trim() }
+          : {}),
         log,
       }),
     );

--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -24,14 +24,31 @@ export interface TelegramUpdate {
   readonly update_id: number;
   readonly message?: {
     readonly message_id: number;
-    readonly from?: { readonly id: number; readonly username?: string; readonly first_name?: string };
+    readonly from?: {
+      readonly id: number;
+      readonly is_bot?: boolean;
+      readonly username?: string;
+      readonly first_name?: string;
+    };
     readonly chat: { readonly id: number; readonly type: string };
     readonly text?: string;
+    readonly reply_to_message?: {
+      readonly from?: {
+        readonly id: number;
+        readonly is_bot?: boolean;
+        readonly username?: string;
+      };
+    };
   };
 }
 
 export interface TelegramSentMessage {
   readonly message_id: number;
+}
+
+export interface TelegramBotIdentity {
+  readonly id: number;
+  readonly username?: string;
 }
 
 export interface TelegramBotCommand {
@@ -45,6 +62,7 @@ export interface TelegramBotCommandScope {
 
 /** The slice of the Bot API the adapter uses. */
 export interface TelegramTransport {
+  getMe?(): Promise<TelegramBotIdentity>;
   getUpdates(offset: number, timeoutSeconds: number): Promise<TelegramUpdate[]>;
   sendMessage(chatId: string, text: string): Promise<TelegramSentMessage>;
   setMyCommands?(
@@ -103,6 +121,10 @@ export class FetchTelegramTransport implements TelegramTransport {
     });
   }
 
+  async getMe(): Promise<TelegramBotIdentity> {
+    return this.#call<TelegramBotIdentity>("getMe", {});
+  }
+
   async sendMessage(chatId: string, text: string): Promise<TelegramSentMessage> {
     return this.#call<TelegramSentMessage>("sendMessage", {
       chat_id: chatId,
@@ -154,6 +176,13 @@ export interface TelegramChannelOptions {
   readonly log?: (line: string) => void;
   readonly commands?: readonly TelegramBotCommand[];
   /**
+   * In groups, "mentions" means only slash commands, @bot mentions, and
+   * replies to this bot reach the agent. Use "all" for broadcast rooms.
+   */
+  readonly groupAddressing?: "all" | "mentions";
+  /** Optional bot username override, without @. */
+  readonly botUsername?: string;
+  /**
    * Launch the background long-poll loop on start(). Default true. Tests set
    * false to drive pollOnce() deterministically without a competing loop.
    */
@@ -175,7 +204,9 @@ export class TelegramChannelAdapter implements ChannelAdapter {
   readonly #log: (line: string) => void;
   readonly #autoPoll: boolean;
   readonly #commands: readonly TelegramBotCommand[];
+  readonly #groupAddressing: "all" | "mentions";
   readonly #editTargets = new Map<string, EditTarget>();
+  #botIdentity: TelegramBotIdentity | null = null;
   #context: ChannelAdapterContext | null = null;
   #offset = 0;
   #running = false;
@@ -190,10 +221,15 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     this.#log = options.log ?? (() => {});
     this.#autoPoll = options.autoPoll ?? true;
     this.#commands = options.commands ?? [];
+    this.#groupAddressing = options.groupAddressing ?? "all";
+    if (options.botUsername !== undefined && options.botUsername.length > 0) {
+      this.#botIdentity = { id: -1, username: options.botUsername.replace(/^@/, "") };
+    }
   }
 
   async start(context: ChannelAdapterContext): Promise<void> {
     this.#context = context;
+    await this.#resolveBotIdentity();
     await this.#installCommands();
     if (this.#autoPoll) {
       this.#running = true;
@@ -239,6 +275,21 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     }
   }
 
+  async #resolveBotIdentity(): Promise<void> {
+    if (
+      this.#groupAddressing !== "mentions" ||
+      this.#botIdentity !== null ||
+      this.#transport.getMe === undefined
+    ) {
+      return;
+    }
+    try {
+      this.#botIdentity = await this.#transport.getMe();
+    } catch (error) {
+      this.#log(`telegram: getMe failed: ${String(error)}`);
+    }
+  }
+
   async #pollLoop(): Promise<void> {
     while (this.#running) {
       try {
@@ -264,6 +315,8 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     const chatId = String(message.chat.id);
     const isGroup =
       message.chat.type === "group" || message.chat.type === "supergroup";
+    const text = this.#normalizedTextForAddressing(message.text, message);
+    if (text === null) return;
     await this.#context.onMessage({
       channelId: this.id,
       sender: {
@@ -275,8 +328,38 @@ export class TelegramChannelAdapter implements ChannelAdapter {
             : {}),
       },
       conversation: { kind: isGroup ? "group" : "dm", id: chatId },
-      text: message.text,
+      text,
     });
+  }
+
+  #normalizedTextForAddressing(
+    text: string,
+    message: NonNullable<TelegramUpdate["message"]>,
+  ): string | null {
+    const isGroup =
+      message.chat.type === "group" || message.chat.type === "supergroup";
+    if (!isGroup || this.#groupAddressing === "all") return text;
+    if (text.trimStart().startsWith("/")) return text;
+
+    const username = this.#botIdentity?.username;
+    if (username !== undefined && username.length > 0) {
+      const mention = new RegExp(`(^|\\s)@${escapeRegExp(username)}\\b`, "i");
+      if (mention.test(text)) {
+        const stripped = text.replace(mention, " ").replace(/\s+/g, " ").trim();
+        return stripped.length > 0 ? stripped : text;
+      }
+    }
+
+    const replyFrom = message.reply_to_message?.from;
+    if (
+      replyFrom !== undefined &&
+      (replyFrom.id === this.#botIdentity?.id ||
+        (username !== undefined &&
+          replyFrom.username?.toLowerCase() === username.toLowerCase()))
+    ) {
+      return text;
+    }
+    return null;
   }
 
   async send(message: OutboundChannelMessage): Promise<string> {
@@ -312,4 +395,8 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     this.#editTargets.set(handle, { chatId, messageId: sent.message_id });
     return handle;
   }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/runtime/tests/gateway/gateway.test.ts
+++ b/runtime/tests/gateway/gateway.test.ts
@@ -350,7 +350,7 @@ describe("channel gateway", () => {
     });
   });
 
-  test("telegram owner control blocks non-owner private DMs before the agent", async () => {
+  test("telegram owner control silently blocks non-owner private DMs before the agent", async () => {
     const telegram = new InMemoryChannelAdapter({ id: "telegram" });
     const gw = new ChannelGateway({
       agencHome: home,
@@ -372,7 +372,7 @@ describe("channel gateway", () => {
     await telegram.receive(dmMessage("mallory", "hello", "mallory-dm"));
 
     expect(client.sessions).toHaveLength(0);
-    expect(telegram.lastText("mallory-dm")).toContain("owner-only");
+    expect(telegram.lastText("mallory-dm")).toBeUndefined();
   });
 
   test("telegram owner can pause and resume public group traffic", async () => {
@@ -439,7 +439,7 @@ describe("channel gateway", () => {
 
     await telegram.receive(dmMessage("mallory", "hi", "mallory-dm"));
     expect(client.sessions).toHaveLength(0);
-    expect(telegram.lastText("mallory-dm")).toContain("owner-only");
+    expect(telegram.lastText("mallory-dm")).toBeUndefined();
   });
 
   test("telegram permission requests are denied without leaking approval tokens", async () => {

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -8,6 +8,7 @@ import {
   FetchTelegramTransport,
   TelegramBotApiError,
   TelegramChannelAdapter,
+  type TelegramBotIdentity,
   type TelegramTransport,
   type TelegramUpdate,
 } from "../../src/gateway/telegram-channel.js";
@@ -22,9 +23,13 @@ class FakeTransport implements TelegramTransport {
   readonly photos: { chatId: string; photoUrl: string; caption?: string }[] = [];
   readonly edits: { chatId: string; messageId: number; text: string }[] = [];
   readonly commands: { commands: unknown; scope?: unknown }[] = [];
+  identity: TelegramBotIdentity = { id: 999, username: "core_69_bot" };
   #nextId = 100;
   editShouldThrow = false;
 
+  async getMe(): Promise<TelegramBotIdentity> {
+    return this.identity;
+  }
   async getUpdates(): Promise<TelegramUpdate[]> {
     return this.updates.shift() ?? [];
   }
@@ -136,6 +141,92 @@ describe("TelegramChannelAdapter", () => {
     await adapter.stop();
     expect(messages[0].conversation).toEqual({ kind: "group", id: "-100200" });
     expect(messages[0].sender.displayName).toBe("Bob");
+  });
+
+  test("mention-only group addressing ignores ambient group chatter", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 3,
+          message: {
+            message_id: 7,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text: "hi everyone",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(0);
+  });
+
+  test("mention-only group addressing forwards @bot mentions with mention stripped", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 4,
+          message: {
+            message_id: 8,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text: "@core_69_bot hi there",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("hi there");
+  });
+
+  test("mention-only group addressing forwards replies to the bot", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 5,
+          message: {
+            message_id: 9,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text: "answer this",
+            reply_to_message: {
+              from: { id: 999, is_bot: true, username: "core_69_bot" },
+            },
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("answer this");
   });
 
   test("advances the offset so updates are not reprocessed", async () => {


### PR DESCRIPTION
## Summary
- add Telegram group addressing mode for slash commands, @bot mentions, and replies to the bot
- strip the @bot mention before forwarding text to the agent
- silently ignore non-owner private DMs
- document BotFather privacy-mode requirement

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot
- npm run build --workspace=@tetsuo-ai/runtime