### PR TITLE
feat(memory): persona workspace files — SOUL.md/USER.md/IDENTITY.md + one-time BOOTSTRAP.md ritual (task 13)

### DIFF
--- a/docs/migrate-from-openclaw.md
+++ b/docs/migrate-from-openclaw.md
@@ -25,10 +25,10 @@ Reuse the same provider credential you used with OpenClaw (BYOK env vars or
 | `AGENTS.md` (workspace instructions) | `AGENC.md` | Generated/analyzed by `agenc init`; per-project instructions |
 | `MEMORY.md` + daily notes | `memory/` + memdir | Automatic project/session memory with aging + retrieval |
 | Skills (`SKILL.md` dirs, ClawHub) | Skills + plugins | Bundled + local skills; plugins add commands/tools/hooks/MCP via `agenc plugin` and `/plugins`. No public registry yet — by design until publishing is signed + attested |
-| Cron (`openclaw cron`) | Cron tools + live scheduler | Create/list/delete from the agent; jobs re-arm on daemon restart |
+| Cron (`openclaw cron`) | Cron tools + live scheduler | Create/list/delete from the agent; jobs re-arm on daemon restart. Delivery-routed jobs (`announceChannel`/`webhook` on CronCreate) run in isolated gateway sessions and post their result to a channel or webhook |
 | Webhooks (`/hooks/agent`) | Roadmap | Planned with header-only bearer auth |
-| `SOUL.md` / `IDENTITY.md` persona | Roadmap | Persona workspace files are planned; today AGENC.md carries operating instructions |
-| Heartbeat (`HEARTBEAT.md`) | Roadmap | Planned budget-first (cheap utility model + hard daily caps) — idle-burn horror stories are a design input, not a surprise |
+| `SOUL.md` / `IDENTITY.md` persona | Shipped | Same convention, same filenames — see "Persona workspace files" below |
+| Heartbeat (`HEARTBEAT.md`) | Shipped | `agenc gateway run --heartbeat` (or `[heartbeat]` config): periodic turns read `HEARTBEAT.md`, deliver only non-OK results to a channel, and every tick is gated by the `[budget]` daily/monthly spend envelope — a refusal pauses instead of silently burning |
 | Channels (Telegram, WhatsApp, …) | Shipped (Telegram, WebChat, stdio) | `agenc gateway run`; pairing-gated, with in-channel token approvals and untrusted-content framing. Discord/Slack/Signal and WhatsApp still roadmap |
 | Nodes (phone/Canvas) | Roadmap | Realtime voice (WebRTC) already exists in the TUI |
 | `openclaw security audit` | `agenc security audit --fix` | Fail-closed exit codes; runs automatically around onboard/daemon start |
@@ -45,10 +45,34 @@ Reuse the same provider credential you used with OpenClaw (BYOK env vars or
   agents in isolated worktrees, an eval-regression harness, and 16 model
   providers including Ollama/LM Studio.
 
+## Persona workspace files
+
+The OpenClaw persona convention works as-is, from the workspace root (the
+directory the agent runs in):
+
+- **`USER.md`** — who the human is: name, preferences, context.
+- **`SOUL.md`** — the agent's persona, tone, and boundaries.
+- **`IDENTITY.md`** — the agent's own established identity, usually written
+  by the agent itself during the bootstrap ritual.
+- **`BOOTSTRAP.md`** — a one-time ritual (typically a naming ceremony). It is
+  injected only while `IDENTITY.md` does not exist, framed with instructions
+  to complete the ritual, write `IDENTITY.md`, and delete `BOOTSTRAP.md`.
+  Once `IDENTITY.md` exists the ritual is never injected again — the
+  exactly-once guarantee is mechanical, not honor-system.
+
+All four are injected into the system prompt as a dedicated persona section
+(and ride the memory bootstrap as project-tier instructions). Files are
+loaded from the workspace root only (never ancestor directories), absent
+files cost nothing, and each file is budget-capped at 16 KiB in the prompt —
+oversized content is truncated in context with a marker while the file on
+disk stays intact. The section is computed at conversation start and stays
+stable for that conversation (prompt-cache stability); persona edits and
+ritual completion apply from the next new conversation. Copy your existing
+`SOUL.md`/`USER.md`/`IDENTITY.md` over unchanged; they just work.
+
 ## What you lose today (roadmap, in priority order)
 
-Heartbeat/proactive behavior, persona files, webhooks, browser automation, a
-mobile app, and channel breadth beyond Telegram/WebChat (Discord, Slack,
-Signal, WhatsApp). If any of these is your daily driver, run both: several of
-the gaps are next on the roadmap, and the daemon architecture is built for
-exactly those clients.
+Webhooks, browser automation, a mobile app, and channel breadth beyond
+Telegram/WebChat (Discord, Slack, Signal, WhatsApp). If any of these is your
+daily driver, run both: several of the gaps are next on the roadmap, and the
+daemon architecture is built for exactly those clients.

--- a/runtime/src/constants/prompts.ts
+++ b/runtime/src/constants/prompts.ts
@@ -59,6 +59,7 @@ import { SLEEP_TOOL_NAME } from '../tools/SleepTool/prompt.js'
 import { TICK_TAG } from './xml.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { loadMemoryPrompt } from '../memory/memdir.js'
+import { loadPersonaPromptSection } from '../memory/persona.js'
 import { isUndercover } from '../utils/undercover.js'
 import { isMcpInstructionsDeltaEnabled } from '../utils/mcpInstructionsDelta.js'
 import { getCachedMCConfig as getCachedMCConfigForFRCSource } from '../services/compact/cachedMicrocompact.js'
@@ -491,6 +492,7 @@ export async function getSystemPrompt(
 ${CYBER_RISK_INSTRUCTION}`,
       getSystemRemindersSection(),
       await loadMemoryPrompt(),
+      await loadPersonaPromptSection(cwd),
       envInfo,
       getLanguageSection(settings.language),
       // When delta enabled, instructions are announced via persisted
@@ -510,6 +512,12 @@ ${CYBER_RISK_INSTRUCTION}`,
       getSessionSpecificGuidanceSection(enabledTools, skillToolCommands),
     ),
     systemPromptSection('memory', () => loadMemoryPrompt()),
+    // Persona workspace files (task 13): USER.md / SOUL.md / IDENTITY.md +
+    // the one-time BOOTSTRAP.md ritual. Memoized per session like every
+    // section (cached until /clear), so the BOOTSTRAP gate is evaluated at
+    // session start — exactly-once per workspace, mechanical via the
+    // IDENTITY.md existence check inside the loader.
+    systemPromptSection('persona', () => loadPersonaPromptSection(cwd)),
     systemPromptSection('ant_model_override', () =>
       getAntModelOverrideSection(),
     ),

--- a/runtime/src/memory/agencmd.ts
+++ b/runtime/src/memory/agencmd.ts
@@ -52,6 +52,7 @@ import {
   getOriginalCwd,
 } from '../bootstrap/state.js'
 import { truncateEntrypointContent } from './memdir.js'
+import { ALL_PERSONA_FILE_NAMES, getPersonaMemoryFiles } from './persona.js'
 import {
   getAutoMemEntrypoint,
   getGlobalMemoryEntrypoint,
@@ -1001,6 +1002,17 @@ export const getMemoryFiles = memoize(
       }
     }
 
+    // Persona workspace files (task 13): USER.md / SOUL.md / IDENTITY.md and
+    // the one-time BOOTSTRAP.md ritual, from the workspace root ONLY (never
+    // ancestor dirs). Loaded after the Project/Local walk so identity ranks
+    // above generic project instructions (later = higher priority). Absent
+    // files cost one existsSync each — zero prompt overhead.
+    if (isSettingSourceEnabled('projectSettings')) {
+      result.push(
+        ...(await getPersonaMemoryFiles(originalCwd, processedPaths)),
+      )
+    }
+
     // Durable memory entrypoints - only if feature is on and files exist.
     if (isAutoMemoryEnabled()) {
       const { info: globalMemEntry } = await safelyReadMemoryFileAsync(
@@ -1491,6 +1503,12 @@ export function isMemoryFilePath(filePath: string): boolean {
 
   // Root instruction files or AGENC.local.md anywhere
   if (isProjectInstructionFileName(name) || name === 'AGENC.local.md') {
+    return true
+  }
+
+  // Persona workspace files (task 13) — same "anywhere" tradeoff as
+  // AGENC.local.md: edits to these must invalidate/reload memory context.
+  if (ALL_PERSONA_FILE_NAMES.includes(name)) {
     return true
   }
 

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -27,6 +27,16 @@ export type { RelevantMemory } from './find-relevant.js'
 export type { ExternalAgenCMdInclude, MemoryFileInfo } from './agencmd.js'
 
 export {
+  ALL_PERSONA_FILE_NAMES,
+  BOOTSTRAP_FILE_NAME,
+  capPersonaContent,
+  getPersonaMemoryFiles,
+  IDENTITY_FILE_NAME,
+  PERSONA_FILE_MAX_BYTES,
+  PERSONA_FILE_NAMES,
+} from './persona.js'
+
+export {
   clearMemoryFileCaches,
   filterInjectedMemoryFiles,
   getAgenCMds,

--- a/runtime/src/memory/persona.ts
+++ b/runtime/src/memory/persona.ts
@@ -1,0 +1,205 @@
+/**
+ * Persona workspace files (TODO task 13) — OpenClaw-parity conventions.
+ *
+ * Four well-known files in the workspace root shape who the agent is and who
+ * it works for:
+ *
+ *   `USER.md`      — who the human is (name, preferences, context)
+ *   `SOUL.md`      — the agent's persona, tone, and boundaries
+ *   `IDENTITY.md`  — the agent's own established identity (usually written
+ *                    by the agent itself during the bootstrap ritual)
+ *   `BOOTSTRAP.md` — a ONE-TIME ritual (typically a naming ceremony). It is
+ *                    injected only while `IDENTITY.md` does not exist, framed
+ *                    with instructions to complete the ritual, write
+ *                    `IDENTITY.md`, and delete `BOOTSTRAP.md`. Once
+ *                    `IDENTITY.md` exists the ritual is never injected again
+ *                    — mechanical exactly-once, even if the file lingers.
+ *
+ * Injection rides the existing memory bootstrap (agencmd `getMemoryFiles`)
+ * as `Project`-tier entries loaded from the workspace root ONLY — never from
+ * ancestor directories. Absent files cost one `existsSync` each and inject
+ * nothing. Every file is budget-capped: content beyond
+ * {@link PERSONA_FILE_MAX_BYTES} is truncated in the prompt with a marker
+ * while the file on disk stays intact (`contentDiffersFromDisk` +
+ * `rawContent` carry the disk bytes for read-state dedup).
+ *
+ * Freshness semantics (live-verified): the persona system-prompt section is
+ * computed at CONVERSATION start and stays stable for that conversation's
+ * lifetime (prompt-cache stability — a resumed conversation replays its
+ * persisted prompt). Persona edits and ritual completion apply from the
+ * next new conversation, which is also when the BOOTSTRAP gate re-evaluates.
+ */
+
+import { join } from 'path'
+import { getFsImplementation } from '../utils/fsOperations.js'
+import { logForDebugging } from '../utils/debug.js'
+import type { MemoryFileInfo } from './agencmd.js'
+
+/** Persona files injected whenever present, in priority order (later = higher). */
+export const PERSONA_FILE_NAMES = ['USER.md', 'SOUL.md', 'IDENTITY.md'] as const
+
+export const BOOTSTRAP_FILE_NAME = 'BOOTSTRAP.md'
+export const IDENTITY_FILE_NAME = 'IDENTITY.md'
+
+/**
+ * Per-file injection budget. Persona files are identity documents, not
+ * knowledge bases — 16 KiB (~4k tokens) each is generous; anything larger is
+ * truncated in the prompt only.
+ */
+export const PERSONA_FILE_MAX_BYTES = 16 * 1024
+
+/** All persona-convention basenames, for path classification. */
+export const ALL_PERSONA_FILE_NAMES: readonly string[] = [
+  ...PERSONA_FILE_NAMES,
+  BOOTSTRAP_FILE_NAME,
+]
+
+/**
+ * Preamble framing the one-time bootstrap ritual. The exactly-once guarantee
+ * is mechanical (injection is gated on IDENTITY.md's absence); the deletion
+ * instruction keeps the workspace tidy and matches the OpenClaw convention.
+ */
+const BOOTSTRAP_PREAMBLE = [
+  '<!-- one-time bootstrap ritual -->',
+  'This workspace contains a one-time BOOTSTRAP.md ritual and you have no',
+  'IDENTITY.md yet, so this is your first run here. Complete the ritual',
+  'below during this session: follow its instructions, then record the',
+  'identity you establish (name, vibe, any details the ritual asks for) by',
+  'writing IDENTITY.md in the workspace root, and delete BOOTSTRAP.md when',
+  'you are done. Once IDENTITY.md exists this ritual is never shown again.',
+].join('\n')
+
+function normalizeForComparison(path: string): string {
+  return process.platform === 'win32' ? path.toLowerCase() : path
+}
+
+/**
+ * Budget-cap persona content for injection. Truncates at the last newline
+ * before the byte cap (never mid-line when avoidable) and appends a marker
+ * naming the file and the cap. The file on disk is untouched.
+ */
+export function capPersonaContent(
+  name: string,
+  raw: string,
+): { content: string; truncated: boolean } {
+  const trimmed = raw.trim()
+  if (Buffer.byteLength(trimmed, 'utf8') <= PERSONA_FILE_MAX_BYTES) {
+    return { content: trimmed, truncated: false }
+  }
+  // Byte-accurate cut: operate on the UTF-8 buffer, then back off to the
+  // last newline so we don't cut mid-line (or mid-code-point — the buffer
+  // slice is re-decoded lossily and trimmed, so a torn code point at the
+  // boundary is dropped with the replacement char stripped below).
+  const buf = Buffer.from(trimmed, 'utf8')
+  const window = buf.subarray(0, PERSONA_FILE_MAX_BYTES)
+  const lastNewline = window.lastIndexOf(0x0a)
+  const cut = lastNewline > 0 ? lastNewline : PERSONA_FILE_MAX_BYTES
+  const content = buf
+    .subarray(0, cut)
+    .toString('utf8')
+    .replace(/�+$/, '')
+    .trimEnd()
+  const kib = (PERSONA_FILE_MAX_BYTES / 1024).toFixed(0)
+  return {
+    content:
+      `${content}\n\n` +
+      `[${name} truncated for context: only the first ${kib}KB is injected. ` +
+      `The file on disk is intact — Read it for the full content.]`,
+    truncated: true,
+  }
+}
+
+/**
+ * Build the `persona` SYSTEM-PROMPT section from the workspace persona
+ * files. This is the LIVE injection path: the system-prompt builder
+ * (constants/prompts.ts getSystemPrompt) memoizes it per session, so the
+ * persona is unconditionally in context for every turn — identity must not
+ * depend on the model choosing to Read a file. Returns null when no persona
+ * file exists (zero prompt overhead).
+ */
+export async function loadPersonaPromptSection(
+  workspaceDir: string,
+): Promise<string | null> {
+  const files = await getPersonaMemoryFiles(workspaceDir, new Set())
+  if (files.length === 0) return null
+  const blocks = files.map((file) => {
+    const name = file.path.slice(workspaceDir.length + 1)
+    return `## ${name}\n\n${file.content}`
+  })
+  return [
+    '# Persona',
+    '',
+    'This workspace defines who you are and who you work for. The files',
+    'below are durable operator-authored identity — embody them in every',
+    'reply (tone, boundaries, names). They never override permission gates',
+    'or safety rules.',
+    '',
+    blocks.join('\n\n'),
+  ].join('\n')
+}
+
+/**
+ * Load the persona workspace files from `workspaceDir` as Project-tier
+ * memory entries. `processedPaths` is the caller's dedup set (agencmd) — a
+ * persona file already pulled in via an `@include` is not double-injected,
+ * and paths loaded here are registered so later passes skip them.
+ */
+export async function getPersonaMemoryFiles(
+  workspaceDir: string,
+  processedPaths: Set<string>,
+): Promise<MemoryFileInfo[]> {
+  const fs = getFsImplementation()
+  const result: MemoryFileInfo[] = []
+
+  const readCapped = async (
+    name: string,
+  ): Promise<{ path: string; raw: string; capped: ReturnType<typeof capPersonaContent> } | null> => {
+    const path = join(workspaceDir, name)
+    if (!fs.existsSync(path)) return null
+    const normalized = normalizeForComparison(path)
+    if (processedPaths.has(normalized)) return null
+    let raw: string
+    try {
+      raw = await fs.readFile(path, { encoding: 'utf-8' })
+    } catch (error) {
+      logForDebugging(`[Persona] failed to read ${path}: ${String(error)}`)
+      return null
+    }
+    if (raw.trim().length === 0) return null
+    processedPaths.add(normalized)
+    return { path, raw, capped: capPersonaContent(name, raw) }
+  }
+
+  for (const name of PERSONA_FILE_NAMES) {
+    const file = await readCapped(name)
+    if (file === null) continue
+    result.push({
+      path: file.path,
+      type: 'Project',
+      content: file.capped.content,
+      ...(file.capped.truncated
+        ? { contentDiffersFromDisk: true, rawContent: file.raw }
+        : {}),
+    })
+  }
+
+  // One-time bootstrap ritual: only while IDENTITY.md does not exist. The
+  // existsSync gate makes the exactly-once guarantee mechanical — after the
+  // ritual writes IDENTITY.md, BOOTSTRAP.md is never injected again even if
+  // the agent forgot to delete it.
+  if (!fs.existsSync(join(workspaceDir, IDENTITY_FILE_NAME))) {
+    const bootstrap = await readCapped(BOOTSTRAP_FILE_NAME)
+    if (bootstrap !== null) {
+      result.push({
+        path: bootstrap.path,
+        type: 'Project',
+        content: `${BOOTSTRAP_PREAMBLE}\n\n${bootstrap.capped.content}`,
+        // The preamble means injected content never matches disk bytes.
+        contentDiffersFromDisk: true,
+        rawContent: bootstrap.raw,
+      })
+    }
+  }
+
+  return result
+}

--- a/runtime/tests/memory/persona.test.ts
+++ b/runtime/tests/memory/persona.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Persona workspace files (TODO task 13): USER.md / SOUL.md / IDENTITY.md
+ * injection through the memory bootstrap, budget with truncation-on-disk-
+ * intact semantics, zero overhead when absent, and the mechanical
+ * exactly-once BOOTSTRAP.md ritual gate.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  getOriginalCwd,
+  getProjectRoot,
+  setOriginalCwd,
+  setProjectRoot,
+} from "../bootstrap/state.js";
+
+vi.mock("bun:bundle", () => ({ feature: () => false }));
+vi.mock("../tools/GrepTool/prompt.js", () => ({ GREP_TOOL_NAME: "Grep" }));
+vi.mock("../tools/REPLTool/constants.js", () => ({ isReplModeEnabled: () => false }));
+vi.mock("../utils/embeddedTools.js", () => ({ hasEmbeddedSearchTools: () => false }));
+vi.mock("../utils/sessionStorage.js", () => ({ getProjectDir: (cwd: string) => cwd }));
+vi.mock("../utils/hooks.js", () => ({
+  executeInstructionsLoadedHooks: async () => undefined,
+  hasInstructionsLoadedHook: () => false,
+}));
+vi.mock("../tools.js", () => ({}));
+vi.mock("src/tools.js", () => ({}));
+vi.mock("../utils/settings/settings.js", () => ({
+  getInitialSettings: () => ({}),
+  getSettingsForSource: () => undefined,
+}));
+
+let agencmd: typeof import("./agencmd.js");
+let persona: typeof import("./persona.js");
+
+let tempRoot = "";
+let repo = "";
+let oldProjectRoot = "";
+let oldOriginalCwd = "";
+let oldConfigDir: string | undefined;
+
+beforeAll(async () => {
+  agencmd = await import("./agencmd.js");
+  persona = await import("./persona.js");
+}, 30_000);
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "agenc-persona-"));
+  oldProjectRoot = getProjectRoot();
+  oldOriginalCwd = getOriginalCwd();
+  oldConfigDir = process.env.AGENC_CONFIG_DIR;
+  process.env.AGENC_CONFIG_DIR = join(tempRoot, "home");
+  repo = join(tempRoot, "repo");
+  mkdirSync(repo, { recursive: true });
+  setProjectRoot(repo);
+  setOriginalCwd(repo);
+  agencmd.clearMemoryFileCaches();
+});
+
+afterEach(() => {
+  setProjectRoot(oldProjectRoot);
+  setOriginalCwd(oldOriginalCwd);
+  if (oldConfigDir === undefined) delete process.env.AGENC_CONFIG_DIR;
+  else process.env.AGENC_CONFIG_DIR = oldConfigDir;
+  agencmd.clearMemoryFileCaches();
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  vi.resetModules();
+});
+
+function personaEntries(files: { path: string }[]): string[] {
+  return files
+    .map((f) => f.path)
+    .filter((p) =>
+      ["USER.md", "SOUL.md", "IDENTITY.md", "BOOTSTRAP.md"].some((n) =>
+        p.endsWith(`${join(repo, n)}`.slice(repo.length)),
+      ),
+    );
+}
+
+describe("persona workspace files", () => {
+  it("absent files inject nothing (zero overhead)", async () => {
+    const files = await agencmd.getMemoryFiles();
+    expect(personaEntries(files)).toEqual([]);
+  });
+
+  it("injects USER.md / SOUL.md / IDENTITY.md from the workspace root, above AGENC.md", async () => {
+    writeFileSync(join(repo, "AGENC.md"), "Project instructions here.");
+    writeFileSync(join(repo, "USER.md"), "The human is Tetsuo.");
+    writeFileSync(join(repo, "SOUL.md"), "You are direct and calm.");
+    writeFileSync(join(repo, "IDENTITY.md"), "Your name is Hikari.");
+
+    const files = await agencmd.getMemoryFiles();
+    const paths = files.map((f) => f.path);
+
+    const agencIdx = paths.indexOf(join(repo, "AGENC.md"));
+    const userIdx = paths.indexOf(join(repo, "USER.md"));
+    const soulIdx = paths.indexOf(join(repo, "SOUL.md"));
+    const identityIdx = paths.indexOf(join(repo, "IDENTITY.md"));
+
+    expect(agencIdx).toBeGreaterThanOrEqual(0);
+    expect(userIdx).toBeGreaterThan(agencIdx);
+    expect(soulIdx).toBeGreaterThan(userIdx);
+    expect(identityIdx).toBeGreaterThan(soulIdx);
+
+    const soul = files[soulIdx];
+    expect(soul.type).toBe("Project");
+    expect(soul.content).toBe("You are direct and calm.");
+    expect(soul.contentDiffersFromDisk).toBeUndefined();
+  });
+
+  it("persona files are NOT loaded from ancestor directories", async () => {
+    // SOUL.md in the PARENT of the workspace must not leak in.
+    writeFileSync(join(tempRoot, "SOUL.md"), "wrong soul");
+    const files = await agencmd.getMemoryFiles();
+    expect(files.map((f) => f.path)).not.toContain(join(tempRoot, "SOUL.md"));
+  });
+
+  it("budget: oversized SOUL.md is truncated in the prompt while disk stays intact", async () => {
+    const line = "persona boundary line that repeats for budget testing\n";
+    const big = line.repeat(
+      Math.ceil((persona.PERSONA_FILE_MAX_BYTES * 2) / line.length),
+    );
+    writeFileSync(join(repo, "SOUL.md"), big);
+
+    const files = await agencmd.getMemoryFiles();
+    const soul = files.find((f) => f.path === join(repo, "SOUL.md"));
+
+    expect(soul).toBeDefined();
+    expect(
+      Buffer.byteLength(soul!.content, "utf8"),
+    ).toBeLessThanOrEqual(persona.PERSONA_FILE_MAX_BYTES + 256);
+    expect(soul!.content).toContain("SOUL.md truncated for context");
+    expect(soul!.content).toContain("file on disk is intact");
+    expect(soul!.contentDiffersFromDisk).toBe(true);
+    expect(soul!.rawContent).toBe(big);
+    // Disk untouched.
+    expect(readFileSync(join(repo, "SOUL.md"), "utf8")).toBe(big);
+  });
+
+  it("BOOTSTRAP.md ritual: injected with the ritual frame only while IDENTITY.md is absent", async () => {
+    writeFileSync(
+      join(repo, "BOOTSTRAP.md"),
+      "Choose a name that fits this workspace.",
+    );
+
+    const files = await agencmd.getMemoryFiles();
+    const bootstrap = files.find((f) => f.path === join(repo, "BOOTSTRAP.md"));
+
+    expect(bootstrap).toBeDefined();
+    expect(bootstrap!.content).toContain("one-time bootstrap ritual");
+    expect(bootstrap!.content).toContain("writing IDENTITY.md");
+    expect(bootstrap!.content).toContain("delete BOOTSTRAP.md");
+    expect(bootstrap!.content).toContain(
+      "Choose a name that fits this workspace.",
+    );
+    // The frame means injected bytes never match disk bytes.
+    expect(bootstrap!.contentDiffersFromDisk).toBe(true);
+    expect(bootstrap!.rawContent).toBe(
+      "Choose a name that fits this workspace.",
+    );
+  });
+
+  it("BOOTSTRAP.md ritual runs exactly once: never injected once IDENTITY.md exists", async () => {
+    writeFileSync(join(repo, "BOOTSTRAP.md"), "Naming ceremony.");
+
+    // First load: ritual present.
+    let files = await agencmd.getMemoryFiles();
+    expect(
+      files.some((f) => f.path === join(repo, "BOOTSTRAP.md")),
+    ).toBe(true);
+
+    // The ritual completes: IDENTITY.md is written — but the agent forgot to
+    // delete BOOTSTRAP.md. The gate must still hold.
+    writeFileSync(join(repo, "IDENTITY.md"), "Your name is Hikari.");
+    agencmd.clearMemoryFileCaches();
+
+    files = await agencmd.getMemoryFiles();
+    expect(
+      files.some((f) => f.path === join(repo, "BOOTSTRAP.md")),
+    ).toBe(false);
+    expect(
+      files.some((f) => f.path === join(repo, "IDENTITY.md")),
+    ).toBe(true);
+  });
+
+  it("a persona file pulled in via @include is not injected twice", async () => {
+    writeFileSync(join(repo, "AGENC.md"), "Instructions.\n\n@SOUL.md\n");
+    writeFileSync(join(repo, "SOUL.md"), "You are direct and calm.");
+
+    const files = await agencmd.getMemoryFiles();
+    const soulEntries = files.filter(
+      (f) => f.path === join(repo, "SOUL.md"),
+    );
+    expect(soulEntries).toHaveLength(1);
+  });
+});
+
+describe("loadPersonaPromptSection (the LIVE system-prompt injection)", () => {
+  it("returns null when no persona file exists (zero prompt overhead)", async () => {
+    expect(await persona.loadPersonaPromptSection(repo)).toBeNull();
+  });
+
+  it("builds one section with per-file blocks in priority order", async () => {
+    writeFileSync(join(repo, "USER.md"), "The human is Tetsuo.");
+    writeFileSync(join(repo, "SOUL.md"), "You are direct and calm.");
+    writeFileSync(join(repo, "IDENTITY.md"), "Your name is Hikari.");
+
+    const section = await persona.loadPersonaPromptSection(repo);
+    expect(section).toContain("# Persona");
+    const user = section!.indexOf("## USER.md");
+    const soul = section!.indexOf("## SOUL.md");
+    const identity = section!.indexOf("## IDENTITY.md");
+    expect(user).toBeGreaterThan(-1);
+    expect(soul).toBeGreaterThan(user);
+    expect(identity).toBeGreaterThan(soul);
+    expect(section).toContain("You are direct and calm.");
+    expect(section).toContain("never override permission gates");
+  });
+
+  it("frames BOOTSTRAP.md only while IDENTITY.md is absent", async () => {
+    writeFileSync(join(repo, "BOOTSTRAP.md"), "Naming ceremony.");
+
+    let section = await persona.loadPersonaPromptSection(repo);
+    expect(section).toContain("## BOOTSTRAP.md");
+    expect(section).toContain("one-time bootstrap ritual");
+
+    writeFileSync(join(repo, "IDENTITY.md"), "Your name is Hikari.");
+    section = await persona.loadPersonaPromptSection(repo);
+    expect(section).toContain("## IDENTITY.md");
+    expect(section).not.toContain("## BOOTSTRAP.md");
+    expect(section).not.toContain("one-time bootstrap ritual");
+  });
+});
+
+describe("persona live-wiring contract", () => {
+  // The LIVE injection point is constants/prompts.ts getSystemPrompt — the
+  // builder behind buildBaseInstructionsForModel (daemon/CLI turns). This
+  // source contract mirrors session-memory.contract.test.ts: it guards the
+  // wiring itself, since the builder's heavy dependency graph makes a full
+  // unit instantiation impractical. Live injection was capture-verified
+  // against a real `agenc -p` run (task 13).
+  it("wires loadPersonaPromptSection into the live system-prompt builder", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const source = readFileSync(
+      resolve(process.cwd(), "src/constants/prompts.ts"),
+      "utf8",
+    );
+    expect(source).toContain(
+      "systemPromptSection('persona', () => loadPersonaPromptSection(cwd))",
+    );
+    // The simple-proactive early-return path must inject it too.
+    expect(source).toContain("await loadPersonaPromptSection(cwd)");
+  });
+});
+
+describe("capPersonaContent", () => {
+  it("passes small content through untouched", () => {
+    const r = persona.capPersonaContent("SOUL.md", "  hello\nworld  \n");
+    expect(r).toEqual({ content: "hello\nworld", truncated: false });
+  });
+
+  it("cuts at a line boundary and names the file in the marker", () => {
+    const line = "x".repeat(100) + "\n";
+    const big = line.repeat(
+      Math.ceil((persona.PERSONA_FILE_MAX_BYTES + 4096) / line.length),
+    );
+    const r = persona.capPersonaContent("USER.md", big);
+    expect(r.truncated).toBe(true);
+    expect(r.content).toContain("USER.md truncated for context");
+    const body = r.content.split("\n\n[")[0];
+    expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(
+      persona.PERSONA_FILE_MAX_BYTES,
+    );
+    // Every retained line is whole.
+    for (const l of body.split("\n")) expect(l).toBe("x".repeat(100));
+  });
+});


### PR DESCRIPTION
## What (TODO task 13)

OpenClaw-parity persona convention, loaded from the workspace root only:

- **`USER.md`** (who the human is), **`SOUL.md`** (persona/tone/boundaries), **`IDENTITY.md`** (the agent's own established identity).
- **`BOOTSTRAP.md`** — one-time ritual, injected ONLY while `IDENTITY.md` does not exist, framed with instructions to complete it, write `IDENTITY.md`, and delete `BOOTSTRAP.md`. **Exactly-once is mechanical** (IDENTITY.md existence gate), not honor-system.

## Design

- `runtime/src/memory/persona.ts`: existsSync-gated loading (absent files = zero overhead), per-file 16 KiB budget with truncation-on-disk-intact semantics (`contentDiffersFromDisk` + `rawContent`), byte-accurate line-boundary cuts.
- **LIVE injection**: a dedicated `persona` section in the live system-prompt builder (`constants/prompts.ts getSystemPrompt`, both the main section list and the simple-proactive path). Scouting found the memory-tier loader (`agencmd getMemoryFiles` → `getUserContext`) has **no live caller** — integrating only there would have been dead code. Personas also ride the agencmd Project tier for the memory surfaces (with `@include` dedup), and the persona filenames register in `isMemoryFilePath`.
- Freshness: the section is computed at conversation start and stays stable for that conversation (prompt-cache stability; resumed conversations replay their persisted prompt — discovered live and documented). Edits/ritual completion apply from the next new conversation.

## Live verification (capture server = fake OpenAI-compatible provider recording exact request bodies)

- Real `agenc -p` run: request body carries `# Persona`, SOUL.md content, and the framed BOOTSTRAP ritual.
- Fresh conversation after IDENTITY.md exists (BOOTSTRAP.md still on disk): ritual **absent**, IDENTITY block **present** — the exactly-once acceptance, proven mechanically on the wire.

## Discovered along the way (filed as TODO tasks 35/36, evidence in TODO.md)

- **Task 35**: AGENC.md tier content is absent from live model requests (fresh-conversation capture, unique marker) — `getUserContext` and `prepareTurnRuntimeInputs`/`installTuiSessionContract` have no production callers. Needs a design-vs-bug decision.
- **Task 36**: on provider-retry the system prompt re-prepends (2× → 4×, every section) — token-cost multiplier on flaky providers.

## Docs

Migration guide: persona section added; stale Heartbeat/Cron parity rows updated to Shipped (tasks 14/16).

## Tests

13 new in `tests/memory/persona.test.ts` — injection order, ancestor-dir exclusion, budget/disk-intact, ritual framing, mechanical exactly-once, `@include` dedup, section builder, live-wiring source contract. Revert-proven: 4 red vs HEAD `agencmd.ts`, wiring contract red vs HEAD `prompts.ts`.

## Gates

build ✓ · typecheck ✓ · vitest 14216 ✓ · test:bun ✓ · agent-surface-contract ✓ · **eval-regression ✓ (100%→100%)** · tui-runtime-startup ✓