### PR TITLE
fix: accept Telegram channel post mentions

### DIFF
--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -22,7 +22,11 @@ export const TELEGRAM_CHANNEL_ID = "telegram";
 
 export interface TelegramUpdate {
   readonly update_id: number;
-  readonly message?: {
+  readonly message?: TelegramMessage;
+  readonly channel_post?: TelegramMessage;
+}
+
+export interface TelegramMessage {
     readonly message_id: number;
     readonly from?: {
       readonly id: number;
@@ -45,7 +49,6 @@ export interface TelegramUpdate {
         readonly username?: string;
       };
     };
-  };
 }
 
 export interface TelegramSentMessage {
@@ -123,7 +126,7 @@ export class FetchTelegramTransport implements TelegramTransport {
     return this.#call<TelegramUpdate[]>("getUpdates", {
       offset,
       timeout: timeoutSeconds,
-      allowed_updates: ["message"],
+      allowed_updates: ["message", "channel_post"],
     });
   }
 
@@ -308,7 +311,7 @@ export class TelegramChannelAdapter implements ChannelAdapter {
   }
 
   async #handleUpdate(update: TelegramUpdate): Promise<void> {
-    const message = update.message;
+    const message = update.message ?? update.channel_post;
     if (
       this.#context === null ||
       message === undefined ||
@@ -323,8 +326,7 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     }
     const peerId = String(sender?.id ?? senderChat?.id);
     const chatId = String(message.chat.id);
-    const isGroup =
-      message.chat.type === "group" || message.chat.type === "supergroup";
+    const isPrivate = message.chat.type === "private";
     const text = this.#normalizedTextForAddressing(message.text, message);
     if (text === null) return;
     await this.#context.onMessage({
@@ -341,18 +343,17 @@ export class TelegramChannelAdapter implements ChannelAdapter {
                 ? { displayName: senderChat.title }
                 : {}),
       },
-      conversation: { kind: isGroup ? "group" : "dm", id: chatId },
+      conversation: { kind: isPrivate ? "dm" : "group", id: chatId },
       text,
     });
   }
 
   #normalizedTextForAddressing(
     text: string,
-    message: NonNullable<TelegramUpdate["message"]>,
+    message: TelegramMessage,
   ): string | null {
-    const isGroup =
-      message.chat.type === "group" || message.chat.type === "supergroup";
-    if (!isGroup || this.#groupAddressing === "all") return text;
+    const isPrivate = message.chat.type === "private";
+    if (isPrivate || this.#groupAddressing === "all") return text;
     if (text.trimStart().startsWith("/")) return text;
 
     const username = this.#botIdentity?.username;

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -234,6 +234,70 @@ describe("TelegramChannelAdapter", () => {
     expect(messages[0].text).toBe("hi from anonymous admin");
   });
 
+  test("mention-only group addressing forwards channel posts with @bot mentions", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 46,
+          channel_post: {
+            message_id: 86,
+            sender_chat: {
+              id: -100300,
+              type: "channel",
+              title: "AgenC channel",
+            },
+            chat: { id: -100300, type: "channel" },
+            text: "@core_69_bot explain AgenC",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].conversation).toEqual({ kind: "group", id: "-100300" });
+    expect(messages[0].text).toBe("explain AgenC");
+  });
+
+  test("mention-only group addressing ignores ambient channel posts", async () => {
+    const transport = new FakeTransport();
+    transport.updates = [
+      [
+        {
+          update_id: 47,
+          channel_post: {
+            message_id: 87,
+            sender_chat: {
+              id: -100300,
+              type: "channel",
+              title: "AgenC channel",
+            },
+            chat: { id: -100300, type: "channel" },
+            text: "ambient channel post",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(0);
+  });
+
   test("mention-only group addressing forwards replies to the bot", async () => {
     const transport = new FakeTransport();
     transport.updates = [


### PR DESCRIPTION
## Summary
- Listen for Telegram channel_post updates in the gateway
- Treat channel posts as public conversations while keeping mention-only filtering
- Add regression coverage for channel posts with and without @bot mentions

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot