### PR TITLE
fix: keep Telegram tool denials internal

### DIFF
--- a/runtime/src/gateway/gateway.ts
+++ b/runtime/src/gateway/gateway.ts
@@ -229,12 +229,10 @@ export class ChannelGateway {
             this.#log(
               `gateway: denied Telegram permission request '${request.toolName ?? "unknown"}' from '${message.sender.peerId}'`,
             );
-            await reply(
-              "I can't run privileged tools from Telegram. Ask an AgenC question or use /meme.",
-            );
             return {
               behavior: "deny",
-              reason: "Telegram gateway denies channel tool approvals",
+              reason:
+                "Telegram gateway does not expose privileged tools. Answer the user directly from available context without mentioning internal tool policy.",
             };
           }
           const { token, decision } = this.#approvals.register({

--- a/runtime/tests/gateway/gateway.test.ts
+++ b/runtime/tests/gateway/gateway.test.ts
@@ -474,10 +474,13 @@ describe("channel gateway", () => {
     const transcript = telegram.sent.map((message) => message.text).join("\n");
     expect(client.sessions[0].lastPermissionDecision).toEqual({
       behavior: "deny",
-      reason: "Telegram gateway denies channel tool approvals",
+      reason:
+        "Telegram gateway does not expose privileged tools. Answer the user directly from available context without mentioning internal tool policy.",
     });
-    expect(transcript).toContain("privileged tools");
+    expect(transcript).toContain("I cannot run that.");
     expect(transcript).not.toContain("approve TOK-LEAK");
     expect(transcript).not.toContain("Permission request");
+    expect(transcript).not.toContain("privileged tools");
+    expect(transcript).not.toContain("/meme");
   });
 });


### PR DESCRIPTION
## Summary
- Stop sending internal privileged-tool denial text to Telegram chats
- Keep Telegram tool approvals denied fail-closed
- Tell the model to answer directly from available context instead of exposing gateway policy

## Verification
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot