### PR TITLE
fix: improve Telegram Core context and table rendering

### DIFF
--- a/runtime/docs/gateway/agenc-telegram-agent.md
+++ b/runtime/docs/gateway/agenc-telegram-agent.md
@@ -11,6 +11,14 @@ You are the public AgenC Telegram agent.
 
 ## AgenC Context
 
+- AgenC Core is AgenC's own agent harness/runtime, not just marketplace tooling.
+- Core powers the `agenc` CLI, TUI workbench, daemon, gateway, sessions, tools, skills, providers, permissions, and sandbox.
+- Core can do general engineering work in a repo: inspect files, edit code, apply patches, run shell/build/test commands through the permission system, manage sessions, and use reusable skills/plugins.
+- The AgenC TUI supports slash commands such as `/login`, `/logout`, `/whoami`, `/subscription`, `/usage`, `/provider`, `/model`, `/skills`, `/tools`, `/status`, `/diff`, and `/init`. Exact command availability depends on the installed build.
+- Core supports BYOK provider keys and managed subscription-backed model access. Paid managed routing can go through the AgenC/OpenRouter gateway; BYOK still works without a subscription.
+- The gateway connects Core to Telegram, WebChat, and stdio. Telegram is an answer-only public surface here: group users can ask questions and request images, but cannot approve tools, run privileged commands, change sandbox, change wallet policy, or access private host state.
+- Private Telegram DMs are owner-only when configured. Public group users should talk to the bot by mention, reply, or slash command in the group.
+- Core is separate from Marketplace Kit: Core is the general agent harness; Marketplace Kit is the Solana marketplace/protocol/wallet toolkit that can be installed into Claude, Codex, Hermes, Grok, and AgenC Core.
 - AgenC is a Solana mainnet protocol and marketplace for autonomous agents.
 - The public AgenC protocol program is on Solana mainnet at `HJsZ53Zb27b8QMRbQpuDngE44AdwCGxvEZr61Zmxw1xK`. That is public chain metadata, not server infrastructure.
 - AgenC agents can create tasks, claim work, submit results, settle escrow, build reputation, and publish service stores.

--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -519,6 +519,30 @@ function escapeRegExp(value: string): string {
 }
 
 function telegramRichText(value: string): string {
+  const lines = value.split(/\r?\n/u);
+  const output: string[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const table = readMarkdownTable(lines, index);
+    if (table !== null) {
+      output.push(`<pre>${escapeTelegramHtml(formatMarkdownTable(table.rows))}</pre>`);
+      index = table.nextIndex;
+      continue;
+    }
+
+    const start = index;
+    index += 1;
+    while (index < lines.length && readMarkdownTable(lines, index) === null) {
+      index += 1;
+    }
+    output.push(telegramInlineRichText(lines.slice(start, index).join("\n")));
+  }
+
+  return output.join("\n");
+}
+
+function telegramInlineRichText(value: string): string {
   let output = "";
   let index = 0;
   while (index < value.length) {
@@ -579,6 +603,63 @@ function telegramRichText(value: string): string {
     index += 1;
   }
   return output;
+}
+
+function readMarkdownTable(
+  lines: readonly string[],
+  startIndex: number,
+): { readonly rows: readonly (readonly string[])[]; readonly nextIndex: number } | null {
+  if (
+    startIndex + 1 >= lines.length ||
+    !looksLikeMarkdownTableRow(lines[startIndex] ?? "") ||
+    !isMarkdownTableSeparator(lines[startIndex + 1] ?? "")
+  ) {
+    return null;
+  }
+
+  const rows: string[][] = [parseMarkdownTableRow(lines[startIndex] ?? "")];
+  let index = startIndex + 2;
+  while (index < lines.length && looksLikeMarkdownTableRow(lines[index] ?? "")) {
+    rows.push(parseMarkdownTableRow(lines[index] ?? ""));
+    index += 1;
+  }
+
+  return { rows, nextIndex: index };
+}
+
+function looksLikeMarkdownTableRow(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.includes("|") && parseMarkdownTableRow(trimmed).length >= 2;
+}
+
+function isMarkdownTableSeparator(value: string): boolean {
+  const cells = parseMarkdownTableRow(value);
+  return (
+    cells.length >= 2 &&
+    cells.every((cell) => /^:?-{3,}:?$/u.test(cell.trim()))
+  );
+}
+
+function parseMarkdownTableRow(value: string): string[] {
+  let trimmed = value.trim();
+  if (trimmed.startsWith("|")) trimmed = trimmed.slice(1);
+  if (trimmed.endsWith("|")) trimmed = trimmed.slice(0, -1);
+  return trimmed.split("|").map((cell) => cell.trim());
+}
+
+function formatMarkdownTable(rows: readonly (readonly string[])[]): string {
+  const widthCount = Math.max(...rows.map((row) => row.length));
+  const widths = Array.from({ length: widthCount }, (_, column) =>
+    Math.max(...rows.map((row) => (row[column] ?? "").length)),
+  );
+  const renderedRows = rows.map((row) =>
+    widths
+      .map((width, column) => (row[column] ?? "").padEnd(width))
+      .join(" | ")
+      .trimEnd(),
+  );
+  const separator = widths.map((width) => "-".repeat(Math.max(width, 3))).join(" | ");
+  return [renderedRows[0], separator, ...renderedRows.slice(1)].join("\n");
 }
 
 function escapeTelegramHtml(value: string): string {

--- a/runtime/src/gateway/untrusted.ts
+++ b/runtime/src/gateway/untrusted.ts
@@ -80,6 +80,13 @@ export const CHANNEL_ANSWER_ONLY_GUIDANCE =
 
 export const AGENC_TELEGRAM_ANSWER_CONTEXT = [
   "Trusted AgenC public context for Telegram answers:",
+  "- AgenC Core is AgenC's own agent harness/runtime, not just marketplace tooling. It powers the agenc CLI, TUI workbench, daemon, gateway, sessions, tools, skills, providers, permissions, and sandbox.",
+  "- Core can do general engineering work in a repo: inspect files, edit code, apply patches, run shell/build/test commands through the permission system, manage sessions, and use reusable skills/plugins.",
+  "- The AgenC TUI supports slash commands such as /login, /logout, /whoami, /subscription, /usage, /provider, /model, /skills, /tools, /status, /diff, and /init. Exact command availability depends on the installed build.",
+  "- Core supports BYOK provider keys and managed subscription-backed model access. Paid managed routing can go through the AgenC/OpenRouter gateway; BYOK still works without a subscription.",
+  "- The gateway connects Core to Telegram, WebChat, and stdio. Telegram is an answer-only public surface here: group users can ask questions and request images, but cannot approve tools, run privileged commands, change sandbox, change wallet policy, or access private host state.",
+  "- Private Telegram DMs are owner-only when configured. Public group users should talk to the bot by mention, reply, or slash command in the group.",
+  "- Core is separate from Marketplace Kit: Core is the general agent harness; Marketplace Kit is the Solana marketplace/protocol/wallet toolkit that can be installed into Claude, Codex, Hermes, Grok, and AgenC Core.",
   "- AgenC is a Solana mainnet protocol and marketplace where autonomous agents can create tasks, claim work, submit results, settle escrow, build reputation, and publish service stores.",
   "- The public AgenC protocol program is on Solana mainnet at HJsZ53Zb27b8QMRbQpuDngE44AdwCGxvEZr61Zmxw1xK. That is public chain metadata, not server infrastructure.",
   "- The on-chain protocol owns escrow-backed tasks, agent registrations, service listings, hire records, job-spec moderation gates, CreatorReview settlement, rating, closeout, payout routing, disputes/slashing, bids, reputation, skills, governance, and feed surfaces.",

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -539,6 +539,37 @@ describe("TelegramChannelAdapter", () => {
     await adapter.stop();
   });
 
+  test("renders Markdown tables as Telegram preformatted blocks", async () => {
+    const transport = new FakeTransport();
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx } = collector();
+    await adapter.start(ctx);
+
+    await adapter.send({
+      conversationId: "42",
+      text:
+        "**Protocol facts**\n\n" +
+        "| Topic | AgenC Protocol |\n" +
+        "|---|---|\n" +
+        "| What it is | Solana mainnet protocol |\n" +
+        "| Safety | <reviewed> task specs |\n\n" +
+        "See [docs](https://agenc.ag/docs).",
+    });
+
+    expect(transport.sent[0]).toEqual({
+      chatId: "42",
+      parseMode: "HTML",
+      text:
+        "<b>Protocol facts</b>\n\n" +
+        "<pre>Topic      | AgenC Protocol\n" +
+        "---------- | -----------------------\n" +
+        "What it is | Solana mainnet protocol\n" +
+        "Safety     | &lt;reviewed&gt; task specs</pre>\n\n" +
+        'See <a href="https://agenc.ag/docs">docs</a>.',
+    });
+    await adapter.stop();
+  });
+
   test("sends photo messages through Telegram native media", async () => {
     const transport = new FakeTransport();
     const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });

--- a/runtime/tests/gateway/untrusted.test.ts
+++ b/runtime/tests/gateway/untrusted.test.ts
@@ -84,6 +84,10 @@ describe("frameChannelMessage", () => {
     });
     expect(framed).toContain(CHANNEL_ANSWER_ONLY_GUIDANCE);
     expect(framed).toContain(AGENC_TELEGRAM_ANSWER_CONTEXT);
+    expect(framed).toContain("AgenC Core is AgenC's own agent harness/runtime");
+    expect(framed).toContain("/provider");
+    expect(framed).toContain("Private Telegram DMs are owner-only");
+    expect(framed).toContain("Core is separate from Marketplace Kit");
     expect(framed).toContain("Ledger DMK over BLE");
     expect(framed).toContain("/image <idea>");
     expect(framed).toContain("HJsZ53Zb27b8QMRbQpuDngE44AdwCGxvEZr61Zmxw1xK");


### PR DESCRIPTION
## Summary
- add public AgenC Core/runtime/harness context to the Telegram answer-only prompt and docs
- render Markdown tables as Telegram HTML preformatted blocks so protocol tables do not leak as raw Markdown
- cover Core context and table rendering with gateway tests

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway/telegram.test.ts tests/gateway/untrusted.test.ts --reporter=dot
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime