### PR TITLE
test: use generic Telegram bot fixture

### DIFF
--- a/runtime/tests/gateway/meme.test.ts
+++ b/runtime/tests/gateway/meme.test.ts
@@ -8,11 +8,11 @@ import { parseMemePrompt, XaiMemeFeature } from "../../src/gateway/meme.js";
 describe("parseMemePrompt", () => {
   test("parses slash and label forms", () => {
     expect(parseMemePrompt("/meme agent economy")).toBe("agent economy");
-    expect(parseMemePrompt("/meme@core_69_bot agent economy")).toBe(
+    expect(parseMemePrompt("/meme@agenc_test_bot agent economy")).toBe(
       "agent economy",
     );
     expect(parseMemePrompt("/image agent economy")).toBe("agent economy");
-    expect(parseMemePrompt("/image@core_69_bot agent economy")).toBe(
+    expect(parseMemePrompt("/image@agenc_test_bot agent economy")).toBe(
       "agent economy",
     );
     expect(parseMemePrompt("meme: solana agents getting paid")).toBe(

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -40,7 +40,7 @@ class FakeTransport implements TelegramTransport {
     parseMode?: "HTML";
   }[] = [];
   readonly commands: { commands: unknown; scope?: unknown }[] = [];
-  identity: TelegramBotIdentity = { id: 999, username: "core_69_bot" };
+  identity: TelegramBotIdentity = { id: 999, username: "agenc_test_bot" };
   #nextId = 100;
   editShouldThrow = false;
 
@@ -268,7 +268,7 @@ describe("TelegramChannelAdapter", () => {
             message_id: 8,
             from: { id: 7, first_name: "Bob" },
             chat: { id: -100200, type: "supergroup" },
-            text: "@core_69_bot hi there",
+            text: "@agenc_test_bot hi there",
           },
         },
       ],
@@ -300,7 +300,7 @@ describe("TelegramChannelAdapter", () => {
               title: "AgenC group",
             },
             chat: { id: -100200, type: "supergroup" },
-            text: "@core_69_bot hi from anonymous admin",
+            text: "@agenc_test_bot hi from anonymous admin",
           },
         },
       ],
@@ -336,7 +336,7 @@ describe("TelegramChannelAdapter", () => {
               title: "AgenC channel",
             },
             chat: { id: -100300, type: "channel" },
-            text: "@core_69_bot explain AgenC",
+            text: "@agenc_test_bot explain AgenC",
           },
         },
       ],
@@ -396,7 +396,7 @@ describe("TelegramChannelAdapter", () => {
             message_id: 88,
             from: { id: 7, first_name: "Bob" },
             chat: { id: -100200, type: "supergroup" },
-            caption: "@core_69_bot explain this image",
+            caption: "@agenc_test_bot explain this image",
           },
         },
       ],
@@ -426,7 +426,7 @@ describe("TelegramChannelAdapter", () => {
             chat: { id: -100200, type: "supergroup" },
             text: "answer this",
             reply_to_message: {
-              from: { id: 999, is_bot: true, username: "core_69_bot" },
+              from: { id: 999, is_bot: true, username: "agenc_test_bot" },
             },
           },
         },


### PR DESCRIPTION
## Summary
- replace production-like Telegram bot username fixtures with a generic test bot name
- keeps public Core tests free of deployment/channel-specific details

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway/telegram.test.ts tests/gateway/meme.test.ts --reporter=dot
- rg check for prod bot/token/owner/IP patterns in gateway files