### PR TITLE
fix: use Telegram rich messages for structured replies

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -43,6 +43,14 @@ The **Telegram channel** uses the official Bot API (no reverse-engineered
 client, no account-ban risk). Create a bot with @BotFather, export the token,
 and message it. Streaming replies edit one message in place.
 
+Text replies prefer Telegram Bot API Rich Messages (`sendRichMessage` and
+`editMessageText` with `rich_message.markdown`) so headings, lists, links,
+inline code, and Markdown tables render as native Telegram rich content. If a
+Bot API deployment or a specific payload rejects Rich Messages, the gateway
+falls back to the legacy safe HTML renderer; in that fallback, Markdown tables
+are escaped and rendered as preformatted blocks. Native media captions still use
+the safe HTML renderer because Telegram captions do not accept `rich_message`.
+
 Telegram can also run with **owner controls**:
 
 ```bash

--- a/runtime/docs/gateway/agenc-telegram-agent.md
+++ b/runtime/docs/gateway/agenc-telegram-agent.md
@@ -17,6 +17,7 @@ You are the public AgenC Telegram agent.
 - The AgenC TUI supports slash commands such as `/login`, `/logout`, `/whoami`, `/subscription`, `/usage`, `/provider`, `/model`, `/skills`, `/tools`, `/status`, `/diff`, and `/init`. Exact command availability depends on the installed build.
 - Core supports BYOK provider keys and managed subscription-backed model access. Paid managed routing can go through the AgenC/OpenRouter gateway; BYOK still works without a subscription.
 - The gateway connects Core to Telegram, WebChat, and stdio. Telegram is an answer-only public surface here: group users can ask questions and request generated media, but cannot approve tools, run privileged commands, change sandbox, change wallet policy, or access private host state.
+- Telegram text replies support rich Markdown output, including headings, links, inline code, lists, and tables. When a user asks for protocol or SDK data, prefer compact Markdown tables instead of raw prose blocks.
 - Private Telegram DMs are owner-only when configured. Public group users should talk to the bot by mention, reply, or slash command in the group.
 - Telegram `/start`, `/stop`, `/status`, and `/help` are owner controls and should be used from the owner's private DM, not the public group.
 - Core is separate from Marketplace Kit: Core is the general agent harness; Marketplace Kit is the Solana marketplace/protocol/wallet toolkit that can be installed into Claude, Codex, Hermes, Grok, and AgenC Core.

--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -79,6 +79,11 @@ export interface TelegramSendOptions {
   readonly parseMode?: "HTML";
 }
 
+export interface TelegramRichMessageOptions {
+  readonly messageThreadId?: number;
+  readonly skipEntityDetection?: boolean;
+}
+
 export interface TelegramAudioOptions extends TelegramSendOptions {
   readonly caption?: string;
   readonly contentType?: string;
@@ -101,6 +106,11 @@ export interface TelegramTransport {
     text: string,
     options?: TelegramSendOptions,
   ): Promise<TelegramSentMessage>;
+  sendRichMessage?(
+    chatId: string,
+    markdown: string,
+    options?: TelegramRichMessageOptions,
+  ): Promise<TelegramSentMessage>;
   setMyCommands?(
     commands: readonly TelegramBotCommand[],
     scope?: TelegramBotCommandScope,
@@ -121,6 +131,12 @@ export interface TelegramTransport {
     messageId: number,
     text: string,
     options?: TelegramSendOptions,
+  ): Promise<void>;
+  editRichMessage?(
+    chatId: string,
+    messageId: number,
+    markdown: string,
+    options?: TelegramRichMessageOptions,
   ): Promise<void>;
 }
 
@@ -228,6 +244,25 @@ export class FetchTelegramTransport implements TelegramTransport {
     });
   }
 
+  async sendRichMessage(
+    chatId: string,
+    markdown: string,
+    options: TelegramRichMessageOptions = {},
+  ): Promise<TelegramSentMessage> {
+    return this.#call<TelegramSentMessage>("sendRichMessage", {
+      chat_id: chatId,
+      rich_message: {
+        markdown,
+        ...(options.skipEntityDetection === true
+          ? { skip_entity_detection: true }
+          : {}),
+      },
+      ...(options.messageThreadId !== undefined
+        ? { message_thread_id: options.messageThreadId }
+        : {}),
+    });
+  }
+
   async setMyCommands(
     commands: readonly TelegramBotCommand[],
     scope?: TelegramBotCommandScope,
@@ -302,6 +337,27 @@ export class FetchTelegramTransport implements TelegramTransport {
       message_id: messageId,
       text,
       ...(options.parseMode !== undefined ? { parse_mode: options.parseMode } : {}),
+    });
+  }
+
+  async editRichMessage(
+    chatId: string,
+    messageId: number,
+    markdown: string,
+    options: TelegramRichMessageOptions = {},
+  ): Promise<void> {
+    await this.#call("editMessageText", {
+      chat_id: chatId,
+      message_id: messageId,
+      rich_message: {
+        markdown,
+        ...(options.skipEntityDetection === true
+          ? { skip_entity_detection: true }
+          : {}),
+      },
+      ...(options.messageThreadId !== undefined
+        ? { message_thread_id: options.messageThreadId }
+        : {}),
     });
   }
 }
@@ -560,6 +616,12 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     // Conversation id is Telegram chat id, optionally suffixed with the forum
     // topic thread id. Replies must stay in-topic or users never see them.
     const target = parseTelegramConversationId(message.conversationId);
+    const richOptions: TelegramRichMessageOptions = {
+      ...(target.messageThreadId !== undefined
+        ? { messageThreadId: target.messageThreadId }
+        : {}),
+      skipEntityDetection: true,
+    };
     const sendOptions: TelegramSendOptions = {
       ...(target.messageThreadId !== undefined
         ? { messageThreadId: target.messageThreadId }
@@ -570,6 +632,20 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     if (message.editMessageId !== undefined) {
       const target = this.#editTargets.get(message.editMessageId);
       if (target !== undefined) {
+        if (this.#transport.editRichMessage !== undefined) {
+          try {
+            await this.#transport.editRichMessage(
+              target.chatId,
+              target.messageId,
+              message.text,
+              richOptions,
+            );
+            return message.editMessageId;
+          } catch (error) {
+            if (isTelegramNoopEdit(error)) return message.editMessageId;
+            this.#log(`telegram: rich edit fallback: ${String(error)}`);
+          }
+        }
         try {
           await this.#transport.editMessageText(
             target.chatId,
@@ -612,10 +688,14 @@ export class TelegramChannelAdapter implements ChannelAdapter {
             telegramRichText(message.caption ?? message.text),
             sendOptions,
           )
-        : await this.#transport.sendMessage(
+        : await sendTelegramTextMessage(
+            this.#transport,
             target.chatId,
+            message.text,
             formattedText,
+            richOptions,
             sendOptions,
+            this.#log,
           );
     const handle = `${this.id}-out-${++this.#outCounter}`;
     this.#editTargets.set(handle, {
@@ -628,6 +708,29 @@ export class TelegramChannelAdapter implements ChannelAdapter {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function sendTelegramTextMessage(
+  transport: TelegramTransport,
+  chatId: string,
+  markdown: string,
+  fallbackHtml: string,
+  richOptions: TelegramRichMessageOptions,
+  fallbackOptions: TelegramSendOptions,
+  log: (line: string) => void,
+): Promise<TelegramSentMessage> {
+  if (transport.sendRichMessage !== undefined) {
+    try {
+      return await transport.sendRichMessage(chatId, markdown, richOptions);
+    } catch (error) {
+      log(`telegram: rich send fallback: ${String(error)}`);
+    }
+  }
+  return transport.sendMessage(chatId, fallbackHtml, fallbackOptions);
+}
+
+function isTelegramNoopEdit(error: unknown): boolean {
+  return /message is not modified/i.test(String(error));
 }
 
 function telegramRichText(value: string): string {

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -10,6 +10,7 @@ import {
   TelegramChannelAdapter,
   type TelegramAudioOptions,
   type TelegramBotIdentity,
+  type TelegramRichMessageOptions,
   type TelegramSendOptions,
   type TelegramTransport,
   type TelegramUpdate,
@@ -26,6 +27,12 @@ class FakeTransport implements TelegramTransport {
     text: string;
     messageThreadId?: number;
     parseMode?: "HTML";
+  }[] = [];
+  readonly richSent: {
+    chatId: string;
+    markdown: string;
+    messageThreadId?: number;
+    skipEntityDetection?: boolean;
   }[] = [];
   readonly photos: {
     chatId: string;
@@ -51,9 +58,18 @@ class FakeTransport implements TelegramTransport {
     text: string;
     parseMode?: "HTML";
   }[] = [];
+  readonly richEdits: {
+    chatId: string;
+    messageId: number;
+    markdown: string;
+    messageThreadId?: number;
+    skipEntityDetection?: boolean;
+  }[] = [];
   readonly commands: { commands: unknown; scope?: unknown }[] = [];
   identity: TelegramBotIdentity = { id: 999, username: "agenc_test_bot" };
   #nextId = 100;
+  richShouldThrow = false;
+  richEditShouldThrow = false;
   editShouldThrow = false;
 
   async getMe(): Promise<TelegramBotIdentity> {
@@ -74,6 +90,24 @@ class FakeTransport implements TelegramTransport {
         ? { messageThreadId: options.messageThreadId }
         : {}),
       ...(options.parseMode !== undefined ? { parseMode: options.parseMode } : {}),
+    });
+    return { message_id: ++this.#nextId };
+  }
+  async sendRichMessage(
+    chatId: string,
+    markdown: string,
+    options: TelegramRichMessageOptions = {},
+  ) {
+    if (this.richShouldThrow) throw new Error("rich message rejected");
+    this.richSent.push({
+      chatId,
+      markdown,
+      ...(options.messageThreadId !== undefined
+        ? { messageThreadId: options.messageThreadId }
+        : {}),
+      ...(options.skipEntityDetection !== undefined
+        ? { skipEntityDetection: options.skipEntityDetection }
+        : {}),
     });
     return { message_id: ++this.#nextId };
   }
@@ -129,6 +163,25 @@ class FakeTransport implements TelegramTransport {
       messageId,
       text,
       ...(options.parseMode !== undefined ? { parseMode: options.parseMode } : {}),
+    });
+  }
+  async editRichMessage(
+    chatId: string,
+    messageId: number,
+    markdown: string,
+    options: TelegramRichMessageOptions = {},
+  ) {
+    if (this.richEditShouldThrow) throw new Error("message is not modified");
+    this.richEdits.push({
+      chatId,
+      messageId,
+      markdown,
+      ...(options.messageThreadId !== undefined
+        ? { messageThreadId: options.messageThreadId }
+        : {}),
+      ...(options.skipEntityDetection !== undefined
+        ? { skipEntityDetection: options.skipEntityDetection }
+        : {}),
     });
   }
 }
@@ -264,11 +317,12 @@ describe("TelegramChannelAdapter", () => {
       kind: "group",
       id: "-100200:777",
     });
-    expect(transport.sent[0]).toEqual({
+    expect(transport.sent).toEqual([]);
+    expect(transport.richSent[0]).toEqual({
       chatId: "-100200",
-      text: "topic reply",
+      markdown: "topic reply",
       messageThreadId: 777,
-      parseMode: "HTML",
+      skipEntityDetection: true,
     });
   });
 
@@ -522,8 +576,8 @@ describe("TelegramChannelAdapter", () => {
     await adapter.start(ctx);
 
     const handle = await adapter.send({ conversationId: "42", text: "Hel" });
-    expect(transport.sent).toEqual([
-      { chatId: "42", text: "Hel", parseMode: "HTML" },
+    expect(transport.richSent).toEqual([
+      { chatId: "42", markdown: "Hel", skipEntityDetection: true },
     ]);
 
     await adapter.send({
@@ -531,36 +585,42 @@ describe("TelegramChannelAdapter", () => {
       text: "Hello world",
       editMessageId: handle,
     });
-    expect(transport.edits).toEqual([
-      { chatId: "42", messageId: 101, text: "Hello world", parseMode: "HTML" },
+    expect(transport.richEdits).toEqual([
+      {
+        chatId: "42",
+        messageId: 101,
+        markdown: "Hello world",
+        skipEntityDetection: true,
+      },
     ]);
     await adapter.stop();
   });
 
-  test("renders safe Markdown as Telegram HTML", async () => {
+  test("sends safe Markdown through Telegram Rich Messages", async () => {
     const transport = new FakeTransport();
     const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
     const { ctx } = collector();
     await adapter.start(ctx);
 
+    const text =
+      "**What else AgenC does**\n\n- **Code work** with `npm test`\nIn short: agents can *do* work. [docs](https://agenc.ag/docs)";
     await adapter.send({
       conversationId: "42",
-      text: "**What else AgenC does**\n\n- **Code work** with `npm test`\nIn short: agents can *do* work. [docs](https://agenc.ag/docs)",
+      text,
     });
 
-    expect(transport.sent[0]).toEqual({
+    expect(transport.sent).toEqual([]);
+    expect(transport.richSent[0]).toEqual({
       chatId: "42",
-      parseMode: "HTML",
-      text:
-        "<b>What else AgenC does</b>\n\n" +
-        "- <b>Code work</b> with <code>npm test</code>\n" +
-        'In short: agents can <i>do</i> work. <a href="https://agenc.ag/docs">docs</a>',
+      markdown: text,
+      skipEntityDetection: true,
     });
     await adapter.stop();
   });
 
-  test("escapes raw HTML before Telegram rich rendering", async () => {
+  test("escapes raw HTML in legacy fallback rendering", async () => {
     const transport = new FakeTransport();
+    transport.richShouldThrow = true;
     const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
     const { ctx } = collector();
     await adapter.start(ctx);
@@ -580,8 +640,35 @@ describe("TelegramChannelAdapter", () => {
     await adapter.stop();
   });
 
-  test("renders Markdown tables as Telegram preformatted blocks", async () => {
+  test("sends Markdown tables through Telegram Rich Messages", async () => {
     const transport = new FakeTransport();
+    const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
+    const { ctx } = collector();
+    await adapter.start(ctx);
+
+    const text =
+      "### AgenC protocol — public data table\n" +
+      "| Surface | What it is | Key details |\n" +
+      "|---|---|---|\n" +
+      "| **Protocol program** | On-chain Solana program | `HJsZ53Zb27b8QMRbQpuDngE44AdwCGxvEZr61Zmxw1xK` |\n" +
+      "| **Network** | Chain | Solana mainnet |";
+    await adapter.send({
+      conversationId: "42",
+      text,
+    });
+
+    expect(transport.sent).toEqual([]);
+    expect(transport.richSent[0]).toEqual({
+      chatId: "42",
+      markdown: text,
+      skipEntityDetection: true,
+    });
+    await adapter.stop();
+  });
+
+  test("falls back to preformatted table blocks when Rich Messages fail", async () => {
+    const transport = new FakeTransport();
+    transport.richShouldThrow = true;
     const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
     const { ctx } = collector();
     await adapter.start(ctx);
@@ -671,7 +758,7 @@ describe("TelegramChannelAdapter", () => {
 
   test("a no-op edit rejection does not fail the turn", async () => {
     const transport = new FakeTransport();
-    transport.editShouldThrow = true;
+    transport.richEditShouldThrow = true;
     const adapter = new TelegramChannelAdapter({ transport, autoPoll: false });
     const { ctx } = collector();
     await adapter.start(ctx);
@@ -729,6 +816,33 @@ describe("FetchTelegramTransport", () => {
     await transport.sendMessage("42", "hi");
     expect(calls[0].url).toContain("/bot123456:ABC-DEF_ghi/sendMessage");
     expect(calls[0].body).toMatchObject({ chat_id: "42", text: "hi" });
+  });
+
+  test("posts Rich Markdown through sendRichMessage", async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    const fakeFetch = (async (url: string, init?: { body?: string }) => {
+      calls.push({ url, body: JSON.parse(init?.body ?? "{}") });
+      return {
+        json: async () => ({ ok: true, result: { message_id: 1 } }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const transport = new FetchTelegramTransport({
+      token: "123456:ABC-DEF_ghi",
+      fetchImpl: fakeFetch,
+    });
+    await transport.sendRichMessage("42", "| Metric | Value |\n|---|---|\n| SOL | 1 |", {
+      messageThreadId: 7,
+      skipEntityDetection: true,
+    });
+    expect(calls[0].url).toContain("/bot123456:ABC-DEF_ghi/sendRichMessage");
+    expect(calls[0].body).toMatchObject({
+      chat_id: "42",
+      message_thread_id: 7,
+      rich_message: {
+        markdown: "| Metric | Value |\n|---|---|\n| SOL | 1 |",
+        skip_entity_detection: true,
+      },
+    });
   });
 
   test("throws on a Bot API error response", async () => {


### PR DESCRIPTION
## Summary
- send Telegram text replies with Bot API Rich Messages markdown so tables/lists/headings render natively
- keep safe HTML rendering as fallback and for media captions
- document the Rich Messages path and add transport/adapter coverage

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway/telegram.test.ts tests/gateway/gateway.test.ts tests/gateway/untrusted.test.ts --reporter=dot
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime