### PR TITLE
fix: route natural Telegram media requests

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -85,12 +85,16 @@ AGENC_GATEWAY_VOICE_ENABLED=1
 AGENC_GATEWAY_VOICE_DAILY_LIMIT=10
 ```
 
-The gateway then handles `/image <idea>`, `image: <idea>`, `/meme <idea>`,
-`meme: <idea>`, `/voice <line>`, `voice: <line>`, `/song <idea>`, and
-`song: <idea>` before the prompt reaches the agent. Image routes generate a
-native Telegram photo through the xAI image API; voice routes generate a
-native Telegram audio file through the xAI TTS API. Both enforce local soft
-daily caps.
+The gateway then handles explicit shortcuts such as `/image <idea>`,
+`image: <idea>`, `/meme <idea>`, `meme: <idea>`, `/voice <line>`,
+`voice: <line>`, `/song <idea>`, and `song: <idea>` before the prompt reaches
+the agent. It also detects clear natural-language media requests like
+`make an image of ...`, `haz una imagen de ...`, `generate a 10 second song
+with female voice about ...`, or `haz un audio con voz masculina diciendo ...`.
+Normal questions such as `explain this image` or `what is a song?` still route
+to the agent. Image routes generate a native Telegram photo through the xAI
+image API; voice routes generate a native Telegram audio file through the xAI
+TTS API. Both enforce local soft daily caps.
 
 Telegram gateway agents are spawned with a tiny unattended tool allowlist by
 default: `SendUserMessage` and `Brief`. That lets the bot answer normally

--- a/runtime/docs/gateway/agenc-telegram-agent.md
+++ b/runtime/docs/gateway/agenc-telegram-agent.md
@@ -50,7 +50,7 @@ You are the public AgenC Telegram agent.
 
 ## Media Route
 
-- Users can ask for generated images with `/image <idea>`, `image: <idea>`, `/meme <idea>`, or `meme: <idea>`.
-- Users can ask for generated audio with `/voice <line>`, `voice: <line>`, `/song <idea>`, or `song: <idea>` when the xAI voice route is configured.
+- Users can ask for generated images with `/image <idea>`, `image: <idea>`, `/meme <idea>`, `meme: <idea>`, or clear natural language such as "make an image of..." / "haz una imagen de...".
+- Users can ask for generated audio with `/voice <line>`, `voice: <line>`, `/song <idea>`, `song: <idea>`, or clear natural language such as "generate a 10 second song with female voice about..." / "haz un audio con voz masculina diciendo..." when the xAI voice route is configured.
 - Do not say Telegram is text-only; this gateway can send native Telegram images and audio when the xAI media routes are configured.
 - Keep generated image/meme concepts high-contrast, readable, and AgenC-native.

--- a/runtime/src/gateway/meme.ts
+++ b/runtime/src/gateway/meme.ts
@@ -1,9 +1,9 @@
 /**
  * Telegram/WebChat gateway image route backed by xAI image generation.
  *
- * This is deliberately explicit (`/image ...`, `/meme ...`, `image: ...`, or `meme: ...`) so normal agent
- * turns never surprise-spend image credits. It also keeps the image API key
- * server-side and sends only a public generated image URL back to the channel.
+ * Slash commands remain supported, but clear natural-language image requests
+ * are routed here too. Normal questions about images still fall through to the
+ * agent so media credits are not spent by surprise.
  */
 
 import {
@@ -52,7 +52,30 @@ export function parseMemePrompt(text: string): string | null {
   if (slash !== null) return slash[1]?.trim() ?? "";
   const labeled = trimmed.match(/^(?:meme|image)\s*:\s*([\s\S]+)$/i);
   if (labeled !== null) return labeled[1]?.trim() ?? "";
+  const natural = parseNaturalImagePrompt(trimmed);
+  if (natural !== null) return natural;
   return null;
+}
+
+function parseNaturalImagePrompt(trimmed: string): string | null {
+  const english = trimmed.match(
+    /^(?:(?:please\s+)?(?:can|could|would)\s+you\s+)?(?:i\s+(?:want|need|would\s+like)\s+|make|create|generate|draw|design|render|build)\s+(?:me\s+)?(?:an?\s+)?(?:(?:16:9|1:1|square|vertical|wide)\s+)?(?:image|picture|pic|meme|poster|banner|visual|graphic|card)\s*(?:of|about|for|showing|that\s+shows|with)?\s*([\s\S]*)$/i,
+  );
+  if (english !== null) return cleanNaturalMediaPrompt(english[1] ?? "");
+
+  const spanish = trimmed.match(
+    /^(?:(?:por\s+favor\s+)?(?:puedes|podrias|podrías)\s+(?:hacer|crear|generar|dibujar|diseñar)\s+|(?:quiero|necesito)\s+|(?:haz|hace|crea|genera|dibuja|diseña)\s+)(?:me\s+)?(?:un|una)?\s*(?:(?:16:9|1:1|cuadrada|vertical|wide)\s+)?(?:imagen|foto|meme|p[oó]ster|banner|visual|gr[aá]fico|card|tarjeta)\s*(?:de|sobre|para|con|que\s+muestre|mostrando)?\s*([\s\S]*)$/i,
+  );
+  if (spanish !== null) return cleanNaturalMediaPrompt(spanish[1] ?? "");
+
+  return null;
+}
+
+function cleanNaturalMediaPrompt(prompt: string): string {
+  return prompt
+    .replace(/\s+/g, " ")
+    .replace(/^[\s:,-]+/u, "")
+    .trim();
 }
 
 function readUsage(path: string, day: string): MemeUsageState {

--- a/runtime/src/gateway/voice.ts
+++ b/runtime/src/gateway/voice.ts
@@ -1,10 +1,10 @@
 /**
  * Telegram/WebChat gateway audio route backed by xAI Text to Speech.
  *
- * Audio generation is deliberately explicit (`/voice`, `/audio`, `/song`,
- * `voice:`, `audio:`, `song:`) with a small natural-language affordance for
- * "make a short song for..." and "say ... with a female/male voice". This
- * avoids surprise-spending TTS credits on normal chat turns.
+ * Audio generation supports slash commands and clear natural-language asks,
+ * including English/Spanish requests for voice notes and short songs. Normal
+ * questions still fall through to the agent so TTS credits are not spent by
+ * surprise.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -95,6 +95,9 @@ export function parseVoicePrompt(
     };
   }
 
+  const broadSong = parseNaturalSongPrompt(trimmed, voices);
+  if (broadSong !== null) return broadSong;
+
   const prefixVoice = trimmed.match(
     /^(?:say|tell|read|speak)\s+(?:with|in)\s+(?:the\s+)?(?:voice\s+of\s+)?(female|woman|girl|feminine|male|man|guy|masculine|deep)\s+voice?\s*:?\s+([\s\S]+)$/i,
   );
@@ -121,13 +124,113 @@ export function parseVoicePrompt(
     };
   }
 
+  const spanishPrefixVoice = trimmed.match(
+    /^(?:di|dime|lee|habla|narra)\s+([\s\S]+?)\s+con\s+voz\s+(?:de\s+)?(mujer|femenina|chica|hombre|masculina|tipo|profunda)\.?$/i,
+  );
+  if (spanishPrefixVoice !== null) {
+    const raw = spanishPrefixVoice[1]?.trim() ?? "";
+    const voiceHint = spanishPrefixVoice[2] ?? "";
+    return {
+      text: raw,
+      voiceId: inferVoiceId(voiceHint, voices),
+      song: false,
+    };
+  }
+
+  const naturalAudio = parseNaturalAudioPrompt(trimmed, voices);
+  if (naturalAudio !== null) return naturalAudio;
+
   return null;
+}
+
+function parseNaturalSongPrompt(
+  trimmed: string,
+  voices: VoiceConfig,
+): ParsedVoicePrompt | null {
+  if (!hasMediaAction(trimmed) || !/\b(song|canci[oó]n)\b/iu.test(trimmed)) {
+    return null;
+  }
+  const topic = extractSongTopic(trimmed);
+  return {
+    text: shortSongText(topic),
+    voiceId: inferVoiceId(trimmed, voices),
+    song: true,
+  };
+}
+
+function parseNaturalAudioPrompt(
+  trimmed: string,
+  voices: VoiceConfig,
+): ParsedVoicePrompt | null {
+  const english = trimmed.match(
+    /^(?:(?:please\s+)?(?:can|could|would)\s+you\s+)?(?:make|create|generate|record)\s+(?:me\s+)?(?:an?\s+)?(?:audio|voice\s*note|voiceover|tts)(?:\s+(?:of|around|about)?\s*\d+\s*(?:seconds?|secs?|s))?(?:\s+(?:with|in)\s+(?:a\s+|the\s+)?(?:female|woman|girl|feminine|male|man|guy|masculine|deep)\s+voice)?\s*(?:saying|that\s+says|to\s+say|for|about|with\s+the\s+text)?\s*:?\s+([\s\S]+)$/i,
+  );
+  if (english !== null) {
+    return {
+      text: normalizeVoiceText(english[1] ?? ""),
+      voiceId: inferVoiceId(trimmed, voices),
+      song: false,
+    };
+  }
+
+  const spanish = trimmed.match(
+    /^(?:(?:por\s+favor\s+)?(?:puedes|podrias|podrías)\s+(?:hacer|crear|generar|grabar)\s+|(?:quiero|necesito)\s+|(?:haz|hace|crea|genera|graba)\s+)(?:me\s+)?(?:un\s+)?(?:audio|mensaje\s+de\s+voz|nota\s+de\s+voz|voice\s*note)(?:\s+de\s+\d+\s*segundos?)?(?:\s+con\s+voz\s+(?:de\s+)?(?:mujer|femenina|chica|hombre|masculina|tipo|profunda))?\s*(?:diciendo|que\s+diga|para\s+decir|con\s+el\s+texto)?\s*:?\s+([\s\S]+)$/i,
+  );
+  if (spanish !== null) {
+    return {
+      text: normalizeVoiceText(spanish[1] ?? ""),
+      voiceId: inferVoiceId(trimmed, voices),
+      song: false,
+    };
+  }
+
+  return null;
+}
+
+function hasMediaAction(text: string): boolean {
+  return /\b(make|create|generate|write|sing|record|want|need|haz|hace|crea|genera|escribe|canta|graba|quiero|necesito|puedes|podrias|podrías)\b/iu.test(
+    text,
+  );
+}
+
+function extractSongTopic(text: string): string {
+  const strong = text.match(/\b(?:about|for|sobre|para)\s+([\s\S]+)$/iu);
+  if (strong !== null) return cleanSongTopic(strong[1] ?? "");
+
+  const afterSong = text.match(/\b(?:song|canci[oó]n)\s+(?:de|about|for)\s+([\s\S]+)$/iu);
+  if (afterSong !== null) return cleanSongTopic(afterSong[1] ?? "");
+
+  return cleanSongTopic(text);
+}
+
+function cleanSongTopic(text: string): string {
+  return text
+    .replace(/\b(?:make|create|generate|write|sing|record|want|need)\b/giu, " ")
+    .replace(
+      /\b(?:haz|hace|crea|genera|escribe|canta|graba|quiero|necesito|puedes|podrias|podrías)\b/giu,
+      " ",
+    )
+    .replace(/\b(?:a|an|un|una|short|quick|corta|corto|song|canci[oó]n)\b/giu, " ")
+    .replace(/\b\d+\s*(?:seconds?|secs?|s|segundos?)\b/giu, " ")
+    .replace(
+      /\b(?:with|in|con)\s+(?:a\s+|the\s+)?(?:voice\s+of\s+)?(?:female|woman|girl|feminine|male|man|guy|masculine|deep|mujer|femenina|chica|hombre|masculina|tipo|profunda)\s*(?:voice|voz)?\b/giu,
+      " ",
+    )
+    .replace(/\bvoz\s+(?:de\s+)?(?:mujer|femenina|chica|hombre|masculina|tipo|profunda)\b/giu, " ")
+    .replace(/\s+/g, " ")
+    .replace(/^[\s:,-]+/u, "")
+    .trim()
+    .slice(0, 180);
 }
 
 function inferVoiceId(text: string, config: VoiceConfig): string {
   const lower = text.toLowerCase();
-  if (/\b(female|woman|girl|feminine)\b/u.test(lower)) return config.femaleVoice;
-  if (/\b(male|man|guy|masculine|deep)\b/u.test(lower)) return config.maleVoice;
+  if (/\b(female|woman|girl|feminine|mujer|femenina|chica)\b/u.test(lower)) {
+    return config.femaleVoice;
+  }
+  if (/\b(male|man|guy|masculine|deep|hombre|masculina|tipo|profunda)\b/u.test(lower)) {
+    return config.maleVoice;
+  }
   if (/\b(warm|soft|calm|conversational)\b/u.test(lower)) return "ara";
   if (/\b(professional|clear|crisp)\b/u.test(lower)) return "rex";
   if (/\b(smooth|balanced)\b/u.test(lower)) return "sal";

--- a/runtime/tests/gateway/meme.test.ts
+++ b/runtime/tests/gateway/meme.test.ts
@@ -23,6 +23,23 @@ describe("parseMemePrompt", () => {
     );
     expect(parseMemePrompt("tell me about agenc")).toBeNull();
   });
+
+  test("parses clear natural-language image requests", () => {
+    expect(parseMemePrompt("make an image of agents settling on Solana")).toBe(
+      "agents settling on Solana",
+    );
+    expect(parseMemePrompt("can you generate a 16:9 poster about AgenC")).toBe(
+      "AgenC",
+    );
+    expect(parseMemePrompt("haz una imagen de agentes cobrando onchain")).toBe(
+      "agentes cobrando onchain",
+    );
+    expect(parseMemePrompt("quiero un meme sobre wallets con policies")).toBe(
+      "wallets con policies",
+    );
+    expect(parseMemePrompt("explain this image")).toBeNull();
+    expect(parseMemePrompt("what is image generation?")).toBeNull();
+  });
 });
 
 describe("XaiMemeFeature", () => {

--- a/runtime/tests/gateway/voice.test.ts
+++ b/runtime/tests/gateway/voice.test.ts
@@ -36,6 +36,32 @@ describe("parseVoicePrompt", () => {
     });
     expect(parseVoicePrompt("what is AgenC?")).toBeNull();
   });
+
+  test("parses casual English and Spanish voice/song requests", () => {
+    expect(
+      parseVoicePrompt("generate a 10 second song with female voice about AgenC"),
+    ).toMatchObject({
+      voiceId: "eve",
+      song: true,
+    });
+    expect(
+      parseVoicePrompt("quiero una canción de 10 segundos con voz de mujer sobre Solana agents"),
+    ).toMatchObject({
+      voiceId: "eve",
+      song: true,
+    });
+    expect(parseVoicePrompt("haz un audio con voz masculina diciendo hello AgenC")).toMatchObject({
+      text: "hello AgenC",
+      voiceId: "leo",
+      song: false,
+    });
+    expect(parseVoicePrompt("di hello onchain con voz de hombre")).toMatchObject({
+      text: "hello onchain",
+      voiceId: "leo",
+      song: false,
+    });
+    expect(parseVoicePrompt("tell me what a song is")).toBeNull();
+  });
 });
 
 describe("XaiVoiceFeature", () => {


### PR DESCRIPTION
## Summary
- route clear natural-language image requests to the xAI image path without requiring /image or /meme
- route clear English/Spanish voice and song requests to the xAI TTS path, including male/female voice hints
- keep normal questions about images/songs falling through to the agent
- document the natural-language media affordances

## Verification
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway/meme.test.ts tests/gateway/voice.test.ts --reporter=dot
- npm test --workspace=@tetsuo-ai/runtime -- --run tests/gateway --reporter=dot
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build --workspace=@tetsuo-ai/runtime