### PR TITLE
fix: detect Telegram bot mentions from entities

### DIFF
--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -45,7 +45,9 @@ export interface TelegramMessage {
   };
   readonly chat: { readonly id: number; readonly type: string };
   readonly text?: string;
+  readonly entities?: readonly TelegramMessageEntity[];
   readonly caption?: string;
+  readonly caption_entities?: readonly TelegramMessageEntity[];
   readonly reply_to_message?: {
     readonly text?: string;
     readonly caption?: string;
@@ -61,6 +63,18 @@ export interface TelegramMessage {
       readonly username?: string;
       readonly title?: string;
     };
+  };
+}
+
+export interface TelegramMessageEntity {
+  readonly type: string;
+  readonly offset: number;
+  readonly length: number;
+  readonly user?: {
+    readonly id: number;
+    readonly is_bot?: boolean;
+    readonly username?: string;
+    readonly first_name?: string;
   };
 }
 
@@ -581,11 +595,10 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     rawText: string | undefined,
   ): void {
     if (!this.#debugUpdates) return;
-    const username = this.#botIdentity?.username;
     const hasMention =
-      username !== undefined &&
       rawText !== undefined &&
-      new RegExp(`(^|\\s)@${escapeRegExp(username)}\\b`, "i").test(rawText);
+      message !== undefined &&
+      telegramMentionsBot(rawText, message, this.#botIdentity);
     const isCommand = rawText?.trimStart().startsWith("/") ?? false;
     this.#log(
       [
@@ -611,17 +624,18 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     if (text.trimStart().startsWith("/")) return text;
 
     const username = this.#botIdentity?.username;
-    if (username !== undefined && username.length > 0) {
-      const mention = new RegExp(`(^|\\s)@${escapeRegExp(username)}\\b`, "i");
-      if (mention.test(text)) {
-        const stripped = text.replace(mention, " ").replace(/\s+/g, " ").trim();
-        return withTelegramReplyContext(
-          message,
-          stripped.length > 0
-            ? stripped
-            : "User mentioned the bot while replying to this message.",
-        );
-      }
+    if (telegramMentionsBot(text, message, this.#botIdentity)) {
+      const stripped = stripTelegramBotMentions(
+        text,
+        message,
+        this.#botIdentity,
+      );
+      return withTelegramReplyContext(
+        message,
+        stripped.length > 0
+          ? stripped
+          : "User mentioned the bot while replying to this message.",
+      );
     }
 
     const replyFrom = message.reply_to_message?.from;
@@ -740,6 +754,94 @@ export class TelegramChannelAdapter implements ChannelAdapter {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function telegramMentionsBot(
+  text: string,
+  message: TelegramMessage,
+  identity: TelegramBotIdentity | null | undefined,
+): boolean {
+  return telegramBotMentionRanges(text, message, identity).length > 0;
+}
+
+function stripTelegramBotMentions(
+  text: string,
+  message: TelegramMessage,
+  identity: TelegramBotIdentity | null | undefined,
+): string {
+  const ranges = telegramBotMentionRanges(text, message, identity);
+  if (ranges.length === 0) return text.trim();
+  let stripped = text;
+  for (const range of [...ranges].sort((a, b) => b.offset - a.offset)) {
+    stripped =
+      stripped.slice(0, range.offset) +
+      " " +
+      stripped.slice(range.offset + range.length);
+  }
+  return stripped.replace(/\s+/g, " ").trim();
+}
+
+function telegramBotMentionRanges(
+  text: string,
+  message: TelegramMessage,
+  identity: TelegramBotIdentity | null | undefined,
+): Array<{ offset: number; length: number }> {
+  if (identity == null) return [];
+  const ranges: Array<{ offset: number; length: number }> = [];
+  const username = identity.username?.toLowerCase();
+  const entities = telegramEntitiesForText(message, text);
+  for (const entity of entities) {
+    if (!isValidTelegramEntityRange(text, entity)) continue;
+    if (entity.type === "text_mention" && entity.user?.id === identity.id) {
+      ranges.push({ offset: entity.offset, length: entity.length });
+      continue;
+    }
+    if (entity.type !== "mention" || username === undefined) continue;
+    const mentionText = text
+      .slice(entity.offset, entity.offset + entity.length)
+      .toLowerCase();
+    if (mentionText === `@${username}`) {
+      ranges.push({ offset: entity.offset, length: entity.length });
+    }
+  }
+  if (ranges.length > 0 || username === undefined || username.length === 0) {
+    return ranges;
+  }
+
+  const mention = new RegExp(
+    `@${escapeRegExp(username)}(?=$|[^A-Za-z0-9_])`,
+    "gi",
+  );
+  for (const match of text.matchAll(mention)) {
+    const offset = match.index ?? -1;
+    if (offset < 0) continue;
+    const before = offset === 0 ? "" : text[offset - 1];
+    if (before !== "" && /[A-Za-z0-9_]/.test(before)) continue;
+    ranges.push({ offset, length: match[0].length });
+  }
+  return ranges;
+}
+
+function telegramEntitiesForText(
+  message: TelegramMessage,
+  text: string,
+): readonly TelegramMessageEntity[] {
+  if (message.text === text) return message.entities ?? [];
+  if (message.caption === text) return message.caption_entities ?? [];
+  return [];
+}
+
+function isValidTelegramEntityRange(
+  text: string,
+  entity: TelegramMessageEntity,
+): boolean {
+  return (
+    Number.isInteger(entity.offset) &&
+    Number.isInteger(entity.length) &&
+    entity.offset >= 0 &&
+    entity.length > 0 &&
+    entity.offset + entity.length <= text.length
+  );
 }
 
 async function sendTelegramTextMessage(

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -381,6 +381,77 @@ describe("TelegramChannelAdapter", () => {
     expect(messages[0].text).toBe("hi there");
   });
 
+  test("mention-only group addressing uses Telegram mention entities", async () => {
+    const transport = new FakeTransport();
+    transport.identity = { id: 999, username: "core_69_bot" };
+    const text =
+      "@core_69_bot can you give me the Avg. Time Held for top 10 holders, Top 25 Holders and Top 50 Holders";
+    transport.updates = [
+      [
+        {
+          update_id: 40,
+          message: {
+            message_id: 80,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text,
+            entities: [{ type: "mention", offset: 0, length: 12 }],
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe(
+      "can you give me the Avg. Time Held for top 10 holders, Top 25 Holders and Top 50 Holders",
+    );
+  });
+
+  test("mention-only group addressing uses Telegram text_mention entities", async () => {
+    const transport = new FakeTransport();
+    const text = "AgenC can you explain the top holder data?";
+    transport.updates = [
+      [
+        {
+          update_id: 42,
+          message: {
+            message_id: 82,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text,
+            entities: [
+              {
+                type: "text_mention",
+                offset: 0,
+                length: 5,
+                user: { id: 999, is_bot: true, username: "agenc_test_bot" },
+              },
+            ],
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("can you explain the top holder data?");
+  });
+
   test("mention-only group addressing includes replied-message context", async () => {
     const transport = new FakeTransport();
     transport.updates = [


### PR DESCRIPTION
## Summary\n- detect Telegram @bot mentions using Bot API message entities, including text_mention\n- strip the addressed bot mention before forwarding prompts\n- keep reply-context support for group mentions\n\n## Verification\n- npm run -w runtime test -- tests/gateway/telegram.test.ts\n- npm run -w runtime typecheck\n- npm run -w runtime build\n\nNote: full runtime test suite was attempted but stopped after unrelated environment/TTY/sandbox failures; the focused Telegram gate, typecheck, and build pass.