### PR TITLE
feat(gateway): Discord + Slack channels (task 9)

### DIFF
--- a/docs/migrate-from-openclaw.md
+++ b/docs/migrate-from-openclaw.md
@@ -29,7 +29,7 @@ Reuse the same provider credential you used with OpenClaw (BYOK env vars or
 | Webhooks (`/hooks/agent`) | Roadmap | Planned with header-only bearer auth |
 | `SOUL.md` / `IDENTITY.md` persona | Shipped | Same convention, same filenames — see "Persona workspace files" below |
 | Heartbeat (`HEARTBEAT.md`) | Shipped | `agenc gateway run --heartbeat` (or `[heartbeat]` config): periodic turns read `HEARTBEAT.md`, deliver only non-OK results to a channel, and every tick is gated by the `[budget]` daily/monthly spend envelope — a refusal pauses instead of silently burning |
-| Channels (Telegram, WhatsApp, …) | Shipped (Telegram, WebChat, stdio) | `agenc gateway run`; pairing-gated, with in-channel token approvals and untrusted-content framing. Discord/Slack/Signal and WhatsApp still roadmap |
+| Channels (Telegram, WhatsApp, …) | Shipped (Telegram, Discord, Slack, WebChat, stdio) | `agenc gateway run`; pairing-gated, with in-channel token approvals and untrusted-content framing. Discord rides the official Gateway WS + REST (`AGENC_DISCORD_BOT_TOKEN`); Slack rides Socket Mode — no inbound listener (`AGENC_SLACK_BOT_TOKEN` + `AGENC_SLACK_APP_TOKEN`); guild/channel messages are mention-gated by default. Signal and WhatsApp still roadmap |
 | Nodes (phone/Canvas) | Roadmap | Realtime voice (WebRTC) already exists in the TUI |
 | `openclaw security audit` | `agenc security audit --fix` | Fail-closed exit codes; runs automatically around onboard/daemon start |
 | Docker install | `packaging/docker/` | Non-root image, no published ports by default |
@@ -73,6 +73,6 @@ ritual completion apply from the next new conversation. Copy your existing
 ## What you lose today (roadmap, in priority order)
 
 Webhooks, browser automation, a mobile app, and channel breadth beyond
-Telegram/WebChat (Discord, Slack, Signal, WhatsApp). If any of these is your
+Telegram/Discord/Slack/WebChat (Signal, WhatsApp). If any of these is your
 daily driver, run both: several of the gaps are next on the roadmap, and the
 daemon architecture is built for exactly those clients.

--- a/runtime/src/gateway/discord-channel.ts
+++ b/runtime/src/gateway/discord-channel.ts
@@ -1,0 +1,471 @@
+/**
+ * Discord channel adapter (TODO task 9) — official Discord API only.
+ *
+ * Inbound rides the Discord Gateway (WebSocket): HELLO → IDENTIFY (bot token
+ * + GUILD_MESSAGES | DIRECT_MESSAGES | MESSAGE_CONTENT intents) → heartbeat
+ * loop → MESSAGE_CREATE dispatches. Outbound rides the REST API
+ * (create/edit message), so `supportsEdit` streaming coalescing works.
+ *
+ * The transport (gateway socket + REST) is injected — unit tests drive a
+ * scripted fake and never open a network connection; the production
+ * transport uses the global `WebSocket` (Node ≥ 22) and `fetch`, zero deps.
+ *
+ * Mapping:
+ *  - DM (no `guild_id`)     → conversation kind "dm", id = channel id.
+ *  - Guild message          → kind "group", id = channel id (a thread IS a
+ *    channel in Discord, so thread messages get their own conversation and
+ *    replies land in-thread automatically). Guild/channel bindings use this
+ *    channel id as `groupId`.
+ *  - Group addressing defaults to "mentions": only @bot mentions and replies
+ *    to the bot reach the agent — never every message in a guild.
+ *
+ * Security: same posture as every channel — no listener is opened (the
+ * gateway socket is outbound), senders go through the gateway pairing/
+ * allowlist gate, and message text is untrusted (framed upstream).
+ */
+
+import type {
+  ChannelAdapter,
+  ChannelAdapterContext,
+  OutboundChannelMessage,
+} from "./types.js";
+
+export const DISCORD_CHANNEL_ID = "discord";
+
+/** Discord hard limit per message. */
+export const DISCORD_MESSAGE_LIMIT = 2000;
+
+// Gateway opcodes (the slice we speak).
+export const DISCORD_OP = Object.freeze({
+  DISPATCH: 0,
+  HEARTBEAT: 1,
+  IDENTIFY: 2,
+  RESUME: 6,
+  RECONNECT: 7,
+  INVALID_SESSION: 9,
+  HELLO: 10,
+  HEARTBEAT_ACK: 11,
+} as const);
+
+/** GUILDS + GUILD_MESSAGES + DIRECT_MESSAGES + MESSAGE_CONTENT. */
+export const DISCORD_INTENTS = (1 << 0) | (1 << 9) | (1 << 12) | (1 << 15);
+
+export interface DiscordGatewayPayload {
+  readonly op: number;
+  readonly d?: unknown;
+  readonly s?: number | null;
+  readonly t?: string | null;
+}
+
+export interface DiscordUser {
+  readonly id: string;
+  readonly username?: string;
+  readonly bot?: boolean;
+}
+
+export interface DiscordMessageEvent {
+  readonly id: string;
+  readonly channel_id: string;
+  readonly guild_id?: string;
+  readonly author?: DiscordUser;
+  readonly content?: string;
+  readonly mentions?: readonly DiscordUser[];
+  readonly referenced_message?: { readonly author?: DiscordUser } | null;
+}
+
+export interface DiscordSocketHandlers {
+  onPayload(payload: DiscordGatewayPayload): void;
+  onClose(code?: number): void;
+}
+
+export interface DiscordSocket {
+  send(payload: DiscordGatewayPayload): void;
+  close(): void;
+}
+
+export interface DiscordTransport {
+  /** GET /gateway/bot → wss url (also validates the token). */
+  getGatewayUrl(): Promise<string>;
+  connect(url: string, handlers: DiscordSocketHandlers): Promise<DiscordSocket>;
+  /** POST /channels/{id}/messages */
+  createMessage(channelId: string, text: string): Promise<{ id: string }>;
+  /** PATCH /channels/{id}/messages/{messageId} */
+  editMessage(channelId: string, messageId: string, text: string): Promise<void>;
+}
+
+export class DiscordApiError extends Error {}
+
+const DISCORD_API = "https://discord.com/api/v10";
+
+/** Production transport: fetch REST + global WebSocket, zero dependencies. */
+export class FetchDiscordTransport implements DiscordTransport {
+  readonly #token: string;
+
+  constructor(options: { readonly token: string }) {
+    this.#token = options.token;
+  }
+
+  async #rest(path: string, init: RequestInit): Promise<unknown> {
+    const response = await fetch(`${DISCORD_API}${path}`, {
+      ...init,
+      headers: {
+        authorization: `Bot ${this.#token}`,
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new DiscordApiError(
+        `discord api ${init.method ?? "GET"} ${path} failed: ${response.status} ${body.slice(0, 300)}`,
+      );
+    }
+    return response.json();
+  }
+
+  async getGatewayUrl(): Promise<string> {
+    const result = (await this.#rest("/gateway/bot", { method: "GET" })) as {
+      url?: string;
+    };
+    if (typeof result.url !== "string" || result.url.length === 0) {
+      throw new DiscordApiError("discord /gateway/bot returned no url");
+    }
+    return `${result.url}?v=10&encoding=json`;
+  }
+
+  async connect(
+    url: string,
+    handlers: DiscordSocketHandlers,
+  ): Promise<DiscordSocket> {
+    const socket = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", () => resolve(), { once: true });
+      socket.addEventListener("error", () => reject(new DiscordApiError("discord gateway connect failed")), { once: true });
+    });
+    socket.addEventListener("message", (event: MessageEvent) => {
+      try {
+        handlers.onPayload(JSON.parse(String(event.data)) as DiscordGatewayPayload);
+      } catch {
+        // Non-JSON frames are ignored.
+      }
+    });
+    socket.addEventListener("close", (event: CloseEvent) => {
+      handlers.onClose(event.code);
+    });
+    return {
+      send: (payload) => socket.send(JSON.stringify(payload)),
+      close: () => socket.close(),
+    };
+  }
+
+  async createMessage(channelId: string, text: string): Promise<{ id: string }> {
+    const result = (await this.#rest(`/channels/${channelId}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ content: text }),
+    })) as { id?: string };
+    if (typeof result.id !== "string") {
+      throw new DiscordApiError("discord createMessage returned no id");
+    }
+    return { id: result.id };
+  }
+
+  async editMessage(
+    channelId: string,
+    messageId: string,
+    text: string,
+  ): Promise<void> {
+    await this.#rest(`/channels/${channelId}/messages/${messageId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ content: text }),
+    });
+  }
+}
+
+export interface DiscordChannelOptions {
+  readonly transport: DiscordTransport;
+  readonly token: string;
+  readonly id?: string;
+  readonly log?: (line: string) => void;
+  /**
+   * In guilds, "mentions" (default) means only @bot mentions and replies to
+   * the bot reach the agent. "all" turns every guild message into a turn —
+   * broadcast rooms only.
+   */
+  readonly groupAddressing?: "all" | "mentions";
+  /** Bounded backoff between reconnect attempts, ms. */
+  readonly reconnectBackoffMs?: number;
+  /** Test seam: injectable timers for the heartbeat loop. */
+  readonly setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+  /** Launch the gateway connection on start(). Tests set false and drive
+   *  payloads through the fake socket deterministically. */
+  readonly autoConnect?: boolean;
+}
+
+interface EditTarget {
+  readonly channelId: string;
+  readonly messageId: string;
+}
+
+/** Split text into Discord-sized chunks at line boundaries when possible. */
+export function chunkDiscordText(text: string): string[] {
+  if (text.length <= DISCORD_MESSAGE_LIMIT) return [text];
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > DISCORD_MESSAGE_LIMIT) {
+    const window = rest.slice(0, DISCORD_MESSAGE_LIMIT);
+    const cut = window.lastIndexOf("\n");
+    const at = cut > DISCORD_MESSAGE_LIMIT / 2 ? cut : DISCORD_MESSAGE_LIMIT;
+    chunks.push(rest.slice(0, at));
+    rest = rest.slice(at);
+  }
+  if (rest.length > 0) chunks.push(rest);
+  return chunks;
+}
+
+export class DiscordChannelAdapter implements ChannelAdapter {
+  readonly id: string;
+  readonly supportsEdit = true;
+  readonly #transport: DiscordTransport;
+  readonly #token: string;
+  readonly #log: (line: string) => void;
+  readonly #groupAddressing: "all" | "mentions";
+  readonly #backoffMs: number;
+  readonly #setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly #clearTimer: (handle: ReturnType<typeof setTimeout>) => void;
+  readonly #autoConnect: boolean;
+  readonly #editTargets = new Map<string, EditTarget>();
+  #context: ChannelAdapterContext | null = null;
+  #socket: DiscordSocket | null = null;
+  #running = false;
+  #selfId: string | null = null;
+  #sequence: number | null = null;
+  #heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  #awaitingAck = false;
+  #outCounter = 0;
+
+  constructor(options: DiscordChannelOptions) {
+    this.id = options.id ?? DISCORD_CHANNEL_ID;
+    this.#transport = options.transport;
+    this.#token = options.token;
+    this.#log = options.log ?? (() => {});
+    this.#groupAddressing = options.groupAddressing ?? "mentions";
+    this.#backoffMs = options.reconnectBackoffMs ?? 2000;
+    this.#setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.#clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle));
+    this.#autoConnect = options.autoConnect ?? true;
+  }
+
+  async start(context: ChannelAdapterContext): Promise<void> {
+    this.#context = context;
+    this.#running = true;
+    if (this.#autoConnect) await this.#connect();
+  }
+
+  async stop(): Promise<void> {
+    this.#running = false;
+    this.#stopHeartbeat();
+    this.#socket?.close();
+    this.#socket = null;
+    this.#context = null;
+  }
+
+  async #connect(): Promise<void> {
+    const url = await this.#transport.getGatewayUrl();
+    this.#socket = await this.#transport.connect(url, {
+      onPayload: (payload) => this.handleGatewayPayload(payload),
+      onClose: (code) => {
+        this.#stopHeartbeat();
+        this.#socket = null;
+        if (!this.#running) return;
+        this.#log(`discord: gateway closed (${code ?? "?"}) — reconnecting`);
+        this.#setTimer(() => {
+          if (!this.#running) return;
+          void this.#connect().catch((error) => {
+            this.#log(`discord: reconnect failed: ${String(error)}`);
+            this.#scheduleReconnect();
+          });
+        }, this.#backoffMs);
+      },
+    });
+  }
+
+  #scheduleReconnect(): void {
+    if (!this.#running) return;
+    this.#setTimer(() => {
+      if (!this.#running) return;
+      void this.#connect().catch((error) => {
+        this.#log(`discord: reconnect failed: ${String(error)}`);
+        this.#scheduleReconnect();
+      });
+    }, this.#backoffMs);
+  }
+
+  /** Exposed for deterministic tests (fake socket feeds payloads here). */
+  handleGatewayPayload(payload: DiscordGatewayPayload): void {
+    if (typeof payload.s === "number") this.#sequence = payload.s;
+    switch (payload.op) {
+      case DISCORD_OP.HELLO: {
+        const interval =
+          (payload.d as { heartbeat_interval?: number } | undefined)
+            ?.heartbeat_interval ?? 41_250;
+        this.#identify();
+        this.#startHeartbeat(interval);
+        return;
+      }
+      case DISCORD_OP.HEARTBEAT: {
+        // Immediate heartbeat request from the gateway.
+        this.#sendHeartbeat();
+        return;
+      }
+      case DISCORD_OP.HEARTBEAT_ACK: {
+        this.#awaitingAck = false;
+        return;
+      }
+      case DISCORD_OP.RECONNECT:
+      case DISCORD_OP.INVALID_SESSION: {
+        this.#log("discord: gateway requested reconnect");
+        this.#socket?.close();
+        return;
+      }
+      case DISCORD_OP.DISPATCH: {
+        if (payload.t === "READY") {
+          const user = (payload.d as { user?: DiscordUser } | undefined)?.user;
+          if (user?.id !== undefined) this.#selfId = user.id;
+          this.#log("discord: gateway ready");
+          return;
+        }
+        if (payload.t === "MESSAGE_CREATE") {
+          void this.#handleMessage(payload.d as DiscordMessageEvent);
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  #identify(): void {
+    this.#socket?.send({
+      op: DISCORD_OP.IDENTIFY,
+      d: {
+        token: this.#token,
+        intents: DISCORD_INTENTS,
+        properties: { os: "linux", browser: "agenc", device: "agenc" },
+      },
+    });
+  }
+
+  #startHeartbeat(intervalMs: number): void {
+    this.#stopHeartbeat();
+    this.#awaitingAck = false;
+    const beat = () => {
+      if (this.#socket === null) return;
+      if (this.#awaitingAck) {
+        // Zombied connection: the previous heartbeat was never ACKed.
+        this.#log("discord: heartbeat ACK missed — recycling connection");
+        this.#socket.close();
+        return;
+      }
+      this.#sendHeartbeat();
+      this.#heartbeatTimer = this.#setTimer(beat, intervalMs);
+    };
+    this.#heartbeatTimer = this.#setTimer(beat, intervalMs);
+  }
+
+  #sendHeartbeat(): void {
+    this.#awaitingAck = true;
+    this.#socket?.send({ op: DISCORD_OP.HEARTBEAT, d: this.#sequence });
+  }
+
+  #stopHeartbeat(): void {
+    if (this.#heartbeatTimer !== null) this.#clearTimer(this.#heartbeatTimer);
+    this.#heartbeatTimer = null;
+    this.#awaitingAck = false;
+  }
+
+  async #handleMessage(event: DiscordMessageEvent): Promise<void> {
+    if (this.#context === null) return;
+    const author = event.author;
+    if (author === undefined) return;
+    // Never react to bots (including ourselves) — echo-loop prevention.
+    if (author.bot === true || author.id === this.#selfId) return;
+    const text = (event.content ?? "").trim();
+    if (text.length === 0) return;
+
+    const isGuild = event.guild_id !== undefined;
+    if (isGuild && this.#groupAddressing === "mentions") {
+      const mentioned =
+        (this.#selfId !== null &&
+          (event.mentions?.some((user) => user.id === this.#selfId) === true ||
+            text.includes(`<@${this.#selfId}>`) ||
+            text.includes(`<@!${this.#selfId}>`))) ||
+        event.referenced_message?.author?.id === this.#selfId;
+      if (mentioned !== true) return;
+    }
+
+    const cleaned =
+      this.#selfId !== null
+        ? text
+            .replaceAll(`<@${this.#selfId}>`, "")
+            .replaceAll(`<@!${this.#selfId}>`, "")
+            .trim()
+        : text;
+    if (cleaned.length === 0) return;
+
+    await this.#context.onMessage({
+      channelId: this.id,
+      sender: {
+        peerId: author.id,
+        ...(author.username !== undefined
+          ? { displayName: author.username }
+          : {}),
+      },
+      conversation: {
+        kind: isGuild ? "group" : "dm",
+        // Threads are channels in Discord: thread messages carry the thread's
+        // channel id, so replies land in-thread with no extra bookkeeping.
+        id: event.channel_id,
+      },
+      text: cleaned,
+    });
+  }
+
+  async send(message: OutboundChannelMessage): Promise<string> {
+    const chunks = chunkDiscordText(message.text);
+    if (message.editMessageId !== undefined) {
+      const target = this.#editTargets.get(message.editMessageId);
+      if (target !== undefined) {
+        try {
+          await this.#transport.editMessage(
+            target.channelId,
+            target.messageId,
+            chunks[0],
+          );
+          // Overflow beyond the edited message goes out as fresh messages —
+          // only the final flush is ever this long in practice.
+          for (const chunk of chunks.slice(1)) {
+            await this.#transport.createMessage(target.channelId, chunk);
+          }
+        } catch (error) {
+          this.#log(`discord: edit failed: ${String(error)}`);
+        }
+        return message.editMessageId;
+      }
+    }
+    let firstId: string | null = null;
+    for (const chunk of chunks) {
+      const sent = await this.#transport.createMessage(
+        message.conversationId,
+        chunk,
+      );
+      if (firstId === null) firstId = sent.id;
+    }
+    const handle = `${this.id}-out-${++this.#outCounter}`;
+    this.#editTargets.set(handle, {
+      channelId: message.conversationId,
+      messageId: firstId ?? "",
+    });
+    return handle;
+  }
+}

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -51,6 +51,35 @@ export {
   type TelegramChannelOptions,
 } from "./telegram-channel.js";
 export {
+  DiscordChannelAdapter,
+  FetchDiscordTransport,
+  DiscordApiError,
+  DISCORD_CHANNEL_ID,
+  DISCORD_INTENTS,
+  DISCORD_MESSAGE_LIMIT,
+  chunkDiscordText,
+  type DiscordTransport,
+  type DiscordSocket,
+  type DiscordSocketHandlers,
+  type DiscordGatewayPayload,
+  type DiscordMessageEvent,
+  type DiscordChannelOptions,
+} from "./discord-channel.js";
+export {
+  SlackChannelAdapter,
+  FetchSlackTransport,
+  SlackApiError,
+  SLACK_CHANNEL_ID,
+  SLACK_MESSAGE_LIMIT,
+  parseSlackConversationId,
+  type SlackTransport,
+  type SlackSocket,
+  type SlackSocketHandlers,
+  type SlackEnvelope,
+  type SlackMessageEvent,
+  type SlackChannelOptions,
+} from "./slack-channel.js";
+export {
   startGateway,
   type GatewayRunOptions,
   type GatewayRunHandle,

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -30,6 +30,16 @@ import {
 } from "./control-plane.js";
 import { ChannelGateway } from "./gateway.js";
 import { loadGatewayConfig } from "./config.js";
+import {
+  DISCORD_CHANNEL_ID,
+  DiscordChannelAdapter,
+  FetchDiscordTransport,
+} from "./discord-channel.js";
+import { SLACK_CHANNEL_ID } from "./slack-channel.js";
+import {
+  FetchSlackTransport,
+  SlackChannelAdapter,
+} from "./slack-channel.js";
 import { XaiMemeFeature } from "./meme.js";
 import {
   HeliusOnchainFeature,
@@ -64,6 +74,12 @@ export interface GatewayRunOptions {
   readonly stdio?: boolean;
   /** Telegram bot token; falls back to env AGENC_TELEGRAM_BOT_TOKEN. */
   readonly telegramToken?: string;
+  /** Discord bot token; falls back to env AGENC_DISCORD_BOT_TOKEN. */
+  readonly discordToken?: string;
+  /** Slack bot token (xoxb-); falls back to env AGENC_SLACK_BOT_TOKEN. */
+  readonly slackBotToken?: string;
+  /** Slack app-level token (xapp-, Socket Mode); falls back to env AGENC_SLACK_APP_TOKEN. */
+  readonly slackAppToken?: string;
   /** Enable the WebChat browser surface (loopback + token). */
   readonly webchat?: boolean;
   /** Force the proactive heartbeat on for this run (else [heartbeat] config). */
@@ -264,6 +280,54 @@ export async function startGateway(
     );
   }
 
+  // Discord (task 9): outbound Gateway WebSocket + REST — no listener.
+  const discordToken =
+    options.discordToken ?? env.AGENC_DISCORD_BOT_TOKEN?.trim();
+  if (discordToken !== undefined && discordToken.length > 0) {
+    adapters.push(
+      new DiscordChannelAdapter({
+        transport: new FetchDiscordTransport({ token: discordToken }),
+        token: discordToken,
+        groupAddressing:
+          env.AGENC_DISCORD_GROUP_ADDRESSING === "all" ? "all" : "mentions",
+        log,
+      }),
+    );
+  }
+
+  // Slack (task 9): Socket Mode (outbound WebSocket) + Web API — no
+  // listener. Needs BOTH tokens: bot (xoxb-) for the Web API and app-level
+  // (xapp-) for apps.connections.open.
+  const slackBotToken =
+    options.slackBotToken ?? env.AGENC_SLACK_BOT_TOKEN?.trim();
+  const slackAppToken =
+    options.slackAppToken ?? env.AGENC_SLACK_APP_TOKEN?.trim();
+  if (
+    slackBotToken !== undefined &&
+    slackBotToken.length > 0 &&
+    slackAppToken !== undefined &&
+    slackAppToken.length > 0
+  ) {
+    adapters.push(
+      new SlackChannelAdapter({
+        transport: new FetchSlackTransport({
+          botToken: slackBotToken,
+          appToken: slackAppToken,
+        }),
+        groupAddressing:
+          env.AGENC_SLACK_GROUP_ADDRESSING === "all" ? "all" : "mentions",
+        log,
+      }),
+    );
+  } else if (
+    (slackBotToken !== undefined && slackBotToken.length > 0) !==
+    (slackAppToken !== undefined && slackAppToken.length > 0)
+  ) {
+    log(
+      "gateway: slack needs BOTH AGENC_SLACK_BOT_TOKEN (xoxb-) and AGENC_SLACK_APP_TOKEN (xapp-, Socket Mode) — channel not started",
+    );
+  }
+
   const memeDailyLimit = envPositiveInt(env.AGENC_GATEWAY_MEME_DAILY_LIMIT);
   const memeFeature =
     memeEnabled && xaiKey !== undefined
@@ -448,15 +512,18 @@ export async function startGateway(
     throw error;
   }
 
-  // Warn (do not block) if Telegram is enabled but its channel has no policy:
-  // it inherits the fail-closed pairing default, which is safe but surprising.
-  if (
-    started.includes(TELEGRAM_CHANNEL_ID) &&
-    config.channels[TELEGRAM_CHANNEL_ID] === undefined
-  ) {
-    log(
-      "gateway: telegram channel has no policy in gateway/config.json — using the pairing default (unknown senders must pair)",
-    );
+  // Warn (do not block) when a networked channel has no policy: it inherits
+  // the fail-closed pairing default, which is safe but surprising.
+  for (const channelId of [
+    TELEGRAM_CHANNEL_ID,
+    DISCORD_CHANNEL_ID,
+    SLACK_CHANNEL_ID,
+  ]) {
+    if (started.includes(channelId) && config.channels[channelId] === undefined) {
+      log(
+        `gateway: ${channelId} channel has no policy in gateway/config.json — using the pairing default (unknown senders must pair)`,
+      );
+    }
   }
 
   if (webchat !== undefined && started.includes(WEBCHAT_CHANNEL_ID)) {

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -133,6 +133,9 @@ const GATEWAY_SECRET_ENV_NAMES = [
   "AGENC_TELEGRAM_BOT_TOKEN",
   "AGENC_TELEGRAM_OWNER_CLAIM_CODE",
   "AGENC_WEBCHAT_TOKEN",
+  "AGENC_DISCORD_BOT_TOKEN",
+  "AGENC_SLACK_BOT_TOKEN",
+  "AGENC_SLACK_APP_TOKEN",
 ] as const;
 
 /** Keep gateway transport/data credentials out of an autostarted agent daemon. */

--- a/runtime/src/gateway/slack-channel.ts
+++ b/runtime/src/gateway/slack-channel.ts
@@ -1,0 +1,384 @@
+/**
+ * Slack channel adapter (TODO task 9) — official Slack APIs only.
+ *
+ * Inbound rides Socket Mode: `apps.connections.open` (app-level token) mints
+ * a WebSocket URL, events arrive as envelopes that MUST be acked by
+ * `envelope_id` (unacked envelopes are redelivered, then the app is flagged).
+ * Socket Mode is chosen over the Events API deliberately: it opens NO inbound
+ * listener, matching the gateway's loopback-only security posture. Outbound
+ * rides the Web API (`chat.postMessage` / `chat.update`) with the bot token,
+ * so `supportsEdit` streaming coalescing works.
+ *
+ * The transport (socket + Web API) is injected — unit tests drive a scripted
+ * fake; the production transport uses global `WebSocket` + `fetch`, zero deps.
+ *
+ * Mapping:
+ *  - `channel_type: "im"`          → conversation kind "dm", id = channel id.
+ *  - channels/groups/mpim          → kind "group". Workspace-channel bindings
+ *    use the Slack channel id as `groupId`.
+ *  - Threads: a message with `thread_ts` maps to conversation id
+ *    `<channel>:<thread_ts>` so each thread gets its own session, and
+ *    replies post with that `thread_ts` (they stay in-thread).
+ *  - Group addressing defaults to "mentions": only <@bot> mentions reach the
+ *    agent. `app_mention` events are ignored entirely (the `message` event
+ *    for the same text already covers it — reacting to both double-fires).
+ */
+
+import type {
+  ChannelAdapter,
+  ChannelAdapterContext,
+  OutboundChannelMessage,
+} from "./types.js";
+
+export const SLACK_CHANNEL_ID = "slack";
+
+/** Practical per-message cap (Slack rejects ~40k chars). */
+export const SLACK_MESSAGE_LIMIT = 39_000;
+
+export interface SlackEnvelope {
+  readonly type: string;
+  readonly envelope_id?: string;
+  readonly payload?: {
+    readonly event?: SlackMessageEvent;
+  };
+  readonly reason?: string;
+}
+
+export interface SlackMessageEvent {
+  readonly type?: string;
+  readonly subtype?: string;
+  readonly user?: string;
+  readonly bot_id?: string;
+  readonly text?: string;
+  readonly channel?: string;
+  readonly channel_type?: string;
+  readonly ts?: string;
+  readonly thread_ts?: string;
+}
+
+export interface SlackSocketHandlers {
+  onEnvelope(envelope: SlackEnvelope): void;
+  onClose(code?: number): void;
+}
+
+export interface SlackSocket {
+  /** Ack an envelope (`{envelope_id}`) or send any raw frame. */
+  send(frame: Record<string, unknown>): void;
+  close(): void;
+}
+
+export interface SlackTransport {
+  /** `apps.connections.open` (app-level token) → wss url. */
+  openSocketUrl(): Promise<string>;
+  connect(url: string, handlers: SlackSocketHandlers): Promise<SlackSocket>;
+  /** `auth.test` (bot token) → the bot's own user id, for mention gating. */
+  authTest(): Promise<{ userId: string }>;
+  /** `chat.postMessage` → message ts. */
+  postMessage(
+    channel: string,
+    text: string,
+    threadTs?: string,
+  ): Promise<{ ts: string }>;
+  /** `chat.update` */
+  updateMessage(channel: string, ts: string, text: string): Promise<void>;
+}
+
+export class SlackApiError extends Error {}
+
+const SLACK_API = "https://slack.com/api";
+
+/** Production transport: fetch Web API + global WebSocket, zero deps. */
+export class FetchSlackTransport implements SlackTransport {
+  readonly #botToken: string;
+  readonly #appToken: string;
+
+  constructor(options: { readonly botToken: string; readonly appToken: string }) {
+    this.#botToken = options.botToken;
+    this.#appToken = options.appToken;
+  }
+
+  async #call(
+    method: string,
+    token: string,
+    body: Record<string, unknown> | undefined,
+  ): Promise<Record<string, unknown>> {
+    const response = await fetch(`${SLACK_API}/${method}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8",
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    const result = (await response.json()) as Record<string, unknown> & {
+      ok?: boolean;
+      error?: string;
+    };
+    if (result.ok !== true) {
+      throw new SlackApiError(
+        `slack api ${method} failed: ${result.error ?? response.status}`,
+      );
+    }
+    return result;
+  }
+
+  async openSocketUrl(): Promise<string> {
+    const result = await this.#call("apps.connections.open", this.#appToken, undefined);
+    const url = result.url;
+    if (typeof url !== "string" || url.length === 0) {
+      throw new SlackApiError("slack apps.connections.open returned no url");
+    }
+    return url;
+  }
+
+  async connect(
+    url: string,
+    handlers: SlackSocketHandlers,
+  ): Promise<SlackSocket> {
+    const socket = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", () => resolve(), { once: true });
+      socket.addEventListener("error", () => reject(new SlackApiError("slack socket connect failed")), { once: true });
+    });
+    socket.addEventListener("message", (event: MessageEvent) => {
+      try {
+        handlers.onEnvelope(JSON.parse(String(event.data)) as SlackEnvelope);
+      } catch {
+        // Non-JSON frames are ignored.
+      }
+    });
+    socket.addEventListener("close", (event: CloseEvent) => {
+      handlers.onClose(event.code);
+    });
+    return {
+      send: (frame) => socket.send(JSON.stringify(frame)),
+      close: () => socket.close(),
+    };
+  }
+
+  async authTest(): Promise<{ userId: string }> {
+    const result = await this.#call("auth.test", this.#botToken, undefined);
+    const userId = result.user_id;
+    if (typeof userId !== "string") {
+      throw new SlackApiError("slack auth.test returned no user_id");
+    }
+    return { userId };
+  }
+
+  async postMessage(
+    channel: string,
+    text: string,
+    threadTs?: string,
+  ): Promise<{ ts: string }> {
+    const result = await this.#call("chat.postMessage", this.#botToken, {
+      channel,
+      text,
+      ...(threadTs !== undefined ? { thread_ts: threadTs } : {}),
+    });
+    const ts = result.ts;
+    if (typeof ts !== "string") {
+      throw new SlackApiError("slack chat.postMessage returned no ts");
+    }
+    return { ts };
+  }
+
+  async updateMessage(channel: string, ts: string, text: string): Promise<void> {
+    await this.#call("chat.update", this.#botToken, { channel, ts, text });
+  }
+}
+
+export interface SlackChannelOptions {
+  readonly transport: SlackTransport;
+  readonly id?: string;
+  readonly log?: (line: string) => void;
+  /**
+   * In channels, "mentions" (default) means only <@bot> mentions reach the
+   * agent. "all" turns every channel message into a turn — broadcast rooms
+   * only. DMs always reach the (pairing-gated) agent.
+   */
+  readonly groupAddressing?: "all" | "mentions";
+  /** Bounded backoff between reconnect attempts, ms. */
+  readonly reconnectBackoffMs?: number;
+  /** Test seam: injectable reconnect timer. */
+  readonly setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Launch the socket connection on start(). Tests set false and drive
+   *  envelopes through handleEnvelope deterministically. */
+  readonly autoConnect?: boolean;
+}
+
+interface EditTarget {
+  readonly channel: string;
+  readonly ts: string;
+}
+
+/** conversationId encoding: `<channel>` or `<channel>:<thread_ts>`. */
+export function parseSlackConversationId(conversationId: string): {
+  channel: string;
+  threadTs?: string;
+} {
+  const at = conversationId.indexOf(":");
+  if (at === -1) return { channel: conversationId };
+  return {
+    channel: conversationId.slice(0, at),
+    threadTs: conversationId.slice(at + 1),
+  };
+}
+
+export class SlackChannelAdapter implements ChannelAdapter {
+  readonly id: string;
+  readonly supportsEdit = true;
+  readonly #transport: SlackTransport;
+  readonly #log: (line: string) => void;
+  readonly #groupAddressing: "all" | "mentions";
+  readonly #backoffMs: number;
+  readonly #setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly #autoConnect: boolean;
+  readonly #editTargets = new Map<string, EditTarget>();
+  #context: ChannelAdapterContext | null = null;
+  #socket: SlackSocket | null = null;
+  #running = false;
+  #selfId: string | null = null;
+  #outCounter = 0;
+
+  constructor(options: SlackChannelOptions) {
+    this.id = options.id ?? SLACK_CHANNEL_ID;
+    this.#transport = options.transport;
+    this.#log = options.log ?? (() => {});
+    this.#groupAddressing = options.groupAddressing ?? "mentions";
+    this.#backoffMs = options.reconnectBackoffMs ?? 2000;
+    this.#setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.#autoConnect = options.autoConnect ?? true;
+  }
+
+  async start(context: ChannelAdapterContext): Promise<void> {
+    this.#context = context;
+    this.#running = true;
+    try {
+      this.#selfId = (await this.#transport.authTest()).userId;
+    } catch (error) {
+      // Without a self id, mention gating cannot match — fail closed for
+      // group traffic (DMs still work).
+      this.#log(`slack: auth.test failed: ${String(error)}`);
+    }
+    if (this.#autoConnect) await this.#connect();
+  }
+
+  async stop(): Promise<void> {
+    this.#running = false;
+    this.#socket?.close();
+    this.#socket = null;
+    this.#context = null;
+  }
+
+  async #connect(): Promise<void> {
+    const url = await this.#transport.openSocketUrl();
+    this.#socket = await this.#transport.connect(url, {
+      onEnvelope: (envelope) => this.handleEnvelope(envelope),
+      onClose: (code) => {
+        this.#socket = null;
+        if (!this.#running) return;
+        this.#log(`slack: socket closed (${code ?? "?"}) — reconnecting`);
+        this.#scheduleReconnect();
+      },
+    });
+  }
+
+  #scheduleReconnect(): void {
+    if (!this.#running) return;
+    this.#setTimer(() => {
+      if (!this.#running) return;
+      void this.#connect().catch((error) => {
+        this.#log(`slack: reconnect failed: ${String(error)}`);
+        this.#scheduleReconnect();
+      });
+    }, this.#backoffMs);
+  }
+
+  /** Exposed for deterministic tests (fake socket feeds envelopes here). */
+  handleEnvelope(envelope: SlackEnvelope): void {
+    // ACK FIRST, unconditionally, for every acknowledgeable envelope — even
+    // ones we drop. Slack redelivers unacked envelopes and eventually flags
+    // the app; a dropped-but-acked message is correct, a processed-but-
+    // unacked one is a duplicate turn.
+    if (envelope.envelope_id !== undefined) {
+      this.#socket?.send({ envelope_id: envelope.envelope_id });
+    }
+    if (envelope.type === "disconnect") {
+      // Slack refreshes Socket Mode links periodically; recycle the socket
+      // (a fresh apps.connections.open) instead of waiting for the close.
+      this.#log(`slack: disconnect requested (${envelope.reason ?? "refresh"})`);
+      this.#socket?.close();
+      return;
+    }
+    if (envelope.type !== "events_api") return;
+    const event = envelope.payload?.event;
+    if (event === undefined) return;
+    void this.#handleEvent(event);
+  }
+
+  async #handleEvent(event: SlackMessageEvent): Promise<void> {
+    if (this.#context === null) return;
+    // app_mention duplicates the message event for the same text.
+    if (event.type !== "message") return;
+    // Edits/joins/etc. arrive as subtyped messages; bots (including us)
+    // carry bot_id. Both are dropped — echo-loop prevention.
+    if (event.subtype !== undefined || event.bot_id !== undefined) return;
+    if (event.user === undefined || event.user === this.#selfId) return;
+    const text = (event.text ?? "").trim();
+    if (text.length === 0 || event.channel === undefined) return;
+
+    const isDm = event.channel_type === "im";
+    if (!isDm && this.#groupAddressing === "mentions") {
+      if (this.#selfId === null || !text.includes(`<@${this.#selfId}>`)) {
+        return;
+      }
+    }
+
+    const cleaned =
+      this.#selfId !== null
+        ? text.replaceAll(`<@${this.#selfId}>`, "").trim()
+        : text;
+    if (cleaned.length === 0) return;
+
+    // Threads get their own conversation (and session); replies stay
+    // in-thread via the encoded thread_ts.
+    const conversationId =
+      event.thread_ts !== undefined
+        ? `${event.channel}:${event.thread_ts}`
+        : event.channel;
+
+    await this.#context.onMessage({
+      channelId: this.id,
+      sender: { peerId: event.user },
+      conversation: { kind: isDm ? "dm" : "group", id: conversationId },
+      text: cleaned,
+    });
+  }
+
+  async send(message: OutboundChannelMessage): Promise<string> {
+    const text =
+      message.text.length > SLACK_MESSAGE_LIMIT
+        ? `${message.text.slice(0, SLACK_MESSAGE_LIMIT)}\n… (truncated)`
+        : message.text;
+    if (message.editMessageId !== undefined) {
+      const target = this.#editTargets.get(message.editMessageId);
+      if (target !== undefined) {
+        try {
+          await this.#transport.updateMessage(target.channel, target.ts, text);
+        } catch (error) {
+          this.#log(`slack: edit failed: ${String(error)}`);
+        }
+        return message.editMessageId;
+      }
+    }
+    const parsed = parseSlackConversationId(message.conversationId);
+    const sent = await this.#transport.postMessage(
+      parsed.channel,
+      text,
+      parsed.threadTs,
+    );
+    const handle = `${this.id}-out-${++this.#outCounter}`;
+    this.#editTargets.set(handle, { channel: parsed.channel, ts: sent.ts });
+    return handle;
+  }
+}

--- a/runtime/tests/gateway/discord.test.ts
+++ b/runtime/tests/gateway/discord.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Discord channel adapter (TODO task 9): gateway protocol handshake,
+ * heartbeat/sequence bookkeeping, DM + guild message mapping with
+ * mention gating, REST send/edit with 2000-char chunking, and zombie
+ * connection recycling — all against a scripted fake transport.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  chunkDiscordText,
+  DISCORD_INTENTS,
+  DISCORD_MESSAGE_LIMIT,
+  DISCORD_OP,
+  DiscordChannelAdapter,
+  type DiscordGatewayPayload,
+  type DiscordSocketHandlers,
+  type DiscordTransport,
+} from "../../src/gateway/discord-channel.js";
+import type { InboundChannelMessage } from "../../src/gateway/types.js";
+
+class FakeDiscordTransport implements DiscordTransport {
+  readonly sentPayloads: DiscordGatewayPayload[] = [];
+  readonly created: { channelId: string; text: string }[] = [];
+  readonly edited: { channelId: string; messageId: string; text: string }[] = [];
+  handlers: DiscordSocketHandlers | null = null;
+  closed = 0;
+  connects = 0;
+  #nextMessageId = 100;
+
+  async getGatewayUrl(): Promise<string> {
+    return "wss://fake.gateway";
+  }
+
+  async connect(_url: string, handlers: DiscordSocketHandlers) {
+    this.connects += 1;
+    this.handlers = handlers;
+    return {
+      send: (payload: DiscordGatewayPayload) => {
+        this.sentPayloads.push(payload);
+      },
+      close: () => {
+        this.closed += 1;
+        handlers.onClose(1000);
+      },
+    };
+  }
+
+  async createMessage(channelId: string, text: string) {
+    this.created.push({ channelId, text });
+    return { id: String(++this.#nextMessageId) };
+  }
+
+  async editMessage(channelId: string, messageId: string, text: string) {
+    this.edited.push({ channelId, messageId, text });
+  }
+}
+
+interface Harness {
+  adapter: DiscordChannelAdapter;
+  transport: FakeDiscordTransport;
+  inbound: InboundChannelMessage[];
+  timers: { fn: () => void; ms: number }[];
+  fireTimer(index?: number): void;
+}
+
+async function makeAdapter(
+  options: { groupAddressing?: "all" | "mentions" } = {},
+): Promise<Harness> {
+  const transport = new FakeDiscordTransport();
+  const inbound: InboundChannelMessage[] = [];
+  const timers: { fn: () => void; ms: number }[] = [];
+  const adapter = new DiscordChannelAdapter({
+    transport,
+    token: "bot-token-x",
+    setTimer: (fn, ms) => {
+      timers.push({ fn, ms });
+      return timers.length as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer: () => {},
+    ...(options.groupAddressing !== undefined
+      ? { groupAddressing: options.groupAddressing }
+      : {}),
+  });
+  await adapter.start({
+    onMessage: async (message) => {
+      inbound.push(message);
+    },
+  });
+  return {
+    adapter,
+    transport,
+    inbound,
+    timers,
+    fireTimer: (index = timers.length - 1) => timers[index].fn(),
+  };
+}
+
+function hello(intervalMs = 1000): DiscordGatewayPayload {
+  return { op: DISCORD_OP.HELLO, d: { heartbeat_interval: intervalMs } };
+}
+
+function ready(selfId = "bot-self"): DiscordGatewayPayload {
+  return { op: DISCORD_OP.DISPATCH, t: "READY", s: 1, d: { user: { id: selfId } } };
+}
+
+function messageCreate(
+  overrides: Partial<{
+    id: string;
+    channel_id: string;
+    guild_id: string;
+    author: { id: string; username?: string; bot?: boolean };
+    content: string;
+    mentions: { id: string }[];
+    referenced_message: { author: { id: string } };
+    s: number;
+  }> = {},
+): DiscordGatewayPayload {
+  const { s, ...event } = overrides;
+  return {
+    op: DISCORD_OP.DISPATCH,
+    t: "MESSAGE_CREATE",
+    s: s ?? 2,
+    d: {
+      id: "m1",
+      channel_id: "chan-1",
+      author: { id: "user-1", username: "alice" },
+      content: "hello agent",
+      ...event,
+    },
+  };
+}
+
+describe("DiscordChannelAdapter protocol", () => {
+  test("HELLO → IDENTIFY with token + intents, heartbeat armed", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(hello(5000));
+
+    const identify = h.transport.sentPayloads.find(
+      (p) => p.op === DISCORD_OP.IDENTIFY,
+    );
+    expect(identify).toBeDefined();
+    expect(identify!.d).toMatchObject({
+      token: "bot-token-x",
+      intents: DISCORD_INTENTS,
+    });
+    expect(h.timers.at(-1)?.ms).toBe(5000);
+  });
+
+  test("heartbeat carries the last dispatch sequence and recycles on missed ACK", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(hello(1000));
+    h.adapter.handleGatewayPayload(ready());
+    h.adapter.handleGatewayPayload(messageCreate({ s: 41 }));
+
+    h.fireTimer(); // first heartbeat
+    const beat = h.transport.sentPayloads.findLast(
+      (p) => p.op === DISCORD_OP.HEARTBEAT,
+    );
+    expect(beat).toBeDefined();
+    expect(beat!.d).toBe(41);
+
+    // ACK it → next beat proceeds instead of recycling.
+    h.adapter.handleGatewayPayload({ op: DISCORD_OP.HEARTBEAT_ACK });
+    h.fireTimer();
+    expect(
+      h.transport.sentPayloads.filter((p) => p.op === DISCORD_OP.HEARTBEAT),
+    ).toHaveLength(2);
+    expect(h.transport.closed).toBe(0);
+
+    // No ACK before the next beat → zombied connection is recycled.
+    h.fireTimer();
+    expect(h.transport.closed).toBe(1);
+  });
+
+  test("op HEARTBEAT from the gateway triggers an immediate beat", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(hello());
+    h.adapter.handleGatewayPayload({ op: DISCORD_OP.HEARTBEAT });
+    expect(
+      h.transport.sentPayloads.filter((p) => p.op === DISCORD_OP.HEARTBEAT),
+    ).toHaveLength(1);
+  });
+
+  test("RECONNECT closes the socket (reconnect path)", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(hello());
+    h.adapter.handleGatewayPayload({ op: DISCORD_OP.RECONNECT });
+    expect(h.transport.closed).toBe(1);
+  });
+});
+
+describe("DiscordChannelAdapter inbound mapping", () => {
+  test("DM maps to a dm conversation with the author as peer", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(ready());
+    h.adapter.handleGatewayPayload(messageCreate());
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+
+    expect(h.inbound[0]).toMatchObject({
+      channelId: "discord",
+      sender: { peerId: "user-1", displayName: "alice" },
+      conversation: { kind: "dm", id: "chan-1" },
+      text: "hello agent",
+    });
+  });
+
+  test("own and bot-authored messages never reach the agent (echo-loop guard)", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(ready("bot-self"));
+    h.adapter.handleGatewayPayload(
+      messageCreate({ author: { id: "bot-self" } }),
+    );
+    h.adapter.handleGatewayPayload(
+      messageCreate({ author: { id: "other-bot", bot: true } }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(h.inbound).toHaveLength(0);
+  });
+
+  test("guild messages are mention-gated by default; mention is stripped", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleGatewayPayload(ready("bot-self"));
+
+    // Unmentioned guild chatter: dropped.
+    h.adapter.handleGatewayPayload(
+      messageCreate({ guild_id: "g1", content: "random chatter" }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(h.inbound).toHaveLength(0);
+
+    // @bot mention: passes, mention token stripped, group conversation.
+    h.adapter.handleGatewayPayload(
+      messageCreate({
+        guild_id: "g1",
+        channel_id: "thread-9",
+        content: "<@bot-self> summarize this thread",
+        mentions: [{ id: "bot-self" }],
+      }),
+    );
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+    expect(h.inbound[0]).toMatchObject({
+      conversation: { kind: "group", id: "thread-9" },
+      text: "summarize this thread",
+    });
+
+    // Reply to the bot: passes too.
+    h.adapter.handleGatewayPayload(
+      messageCreate({
+        guild_id: "g1",
+        content: "and this?",
+        referenced_message: { author: { id: "bot-self" } },
+      }),
+    );
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(2));
+  });
+
+  test("groupAddressing 'all' forwards unmentioned guild messages", async () => {
+    const h = await makeAdapter({ groupAddressing: "all" });
+    h.adapter.handleGatewayPayload(ready("bot-self"));
+    h.adapter.handleGatewayPayload(
+      messageCreate({ guild_id: "g1", content: "broadcast room chatter" }),
+    );
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+    expect(h.inbound[0].conversation.kind).toBe("group");
+  });
+});
+
+describe("discord run-loop wiring contract", () => {
+  // Source contract: startGateway constructs the production adapter from the
+  // env token. A live start() would open a real network connection, so the
+  // wiring is guarded at the source level (same pattern as other contracts).
+  test("run.ts wires AGENC_DISCORD_BOT_TOKEN to the Discord adapter", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const source = readFileSync(
+      resolve(process.cwd(), "src/gateway/run.ts"),
+      "utf8",
+    );
+    expect(source).toContain("AGENC_DISCORD_BOT_TOKEN");
+    expect(source).toContain("new DiscordChannelAdapter({");
+    expect(source).toContain("new FetchDiscordTransport({ token: discordToken })");
+  });
+});
+
+describe("DiscordChannelAdapter outbound", () => {
+  test("send creates a message and edit routes to the stored target", async () => {
+    const h = await makeAdapter();
+    const handle = await h.adapter.send({
+      conversationId: "chan-1",
+      text: "first",
+    });
+    expect(h.transport.created).toEqual([{ channelId: "chan-1", text: "first" }]);
+
+    await h.adapter.send({
+      conversationId: "chan-1",
+      text: "updated",
+      editMessageId: handle,
+    });
+    expect(h.transport.edited).toEqual([
+      { channelId: "chan-1", messageId: "101", text: "updated" },
+    ]);
+  });
+
+  test("messages beyond 2000 chars are chunked; edits overflow into new messages", async () => {
+    const h = await makeAdapter();
+    const long = "line\n".repeat(900); // ~4500 chars
+    const handle = await h.adapter.send({ conversationId: "c", text: long });
+    expect(h.transport.created.length).toBeGreaterThan(1);
+    for (const message of h.transport.created) {
+      expect(message.text.length).toBeLessThanOrEqual(DISCORD_MESSAGE_LIMIT);
+    }
+
+    h.transport.created.length = 0;
+    await h.adapter.send({
+      conversationId: "c",
+      text: long,
+      editMessageId: handle,
+    });
+    expect(h.transport.edited).toHaveLength(1);
+    expect(h.transport.created.length).toBeGreaterThan(0);
+  });
+
+  test("chunkDiscordText prefers line boundaries and loses no content", () => {
+    const text = "x".repeat(150) + "\n" + "y".repeat(3000);
+    const chunks = chunkDiscordText(text);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(DISCORD_MESSAGE_LIMIT);
+    }
+  });
+});

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -96,6 +96,9 @@ describe("startGateway", () => {
       AGENC_TELEGRAM_BOT_TOKEN: "telegram-secret",
       AGENC_TELEGRAM_OWNER_CLAIM_CODE: "owner-secret",
       AGENC_WEBCHAT_TOKEN: "webchat-secret",
+      AGENC_DISCORD_BOT_TOKEN: "discord-secret",
+      AGENC_SLACK_BOT_TOKEN: "slack-bot-secret",
+      AGENC_SLACK_APP_TOKEN: "slack-app-secret",
     });
 
     expect(sanitized.PATH).toBe("/usr/bin");
@@ -105,6 +108,9 @@ describe("startGateway", () => {
     expect(sanitized.AGENC_TELEGRAM_BOT_TOKEN).toBeUndefined();
     expect(sanitized.AGENC_TELEGRAM_OWNER_CLAIM_CODE).toBeUndefined();
     expect(sanitized.AGENC_WEBCHAT_TOKEN).toBeUndefined();
+    expect(sanitized.AGENC_DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(sanitized.AGENC_SLACK_BOT_TOKEN).toBeUndefined();
+    expect(sanitized.AGENC_SLACK_APP_TOKEN).toBeUndefined();
   });
 
   test("no channels enabled → throws before touching the daemon client", async () => {

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -12,6 +12,8 @@ import {
   sanitizeGatewayDaemonEnv,
   startGateway,
 } from "../../src/gateway/run.js";
+import { DiscordChannelAdapter } from "../../src/gateway/discord-channel.js";
+import { SlackChannelAdapter } from "../../src/gateway/slack-channel.js";
 import {
   TelegramChannelAdapter,
   type TelegramTransport,
@@ -134,6 +136,133 @@ describe("startGateway", () => {
     expect(handle.channels).toEqual(["stdio"]);
     await handle.stop();
     expect(client.closed).toBe(true);
+  });
+
+  test("discord via extraAdapters: allowlisted DM drives a real turn; unpaired gets challenged", async () => {
+    writeConfig({
+      channels: { discord: { dmPolicy: "allowlist", allowlist: ["u-42"] } },
+    });
+    const client = new FakeClient();
+    const created: { channelId: string; text: string }[] = [];
+    const transport = {
+      async getGatewayUrl() {
+        return "wss://unused";
+      },
+      async connect() {
+        throw new Error("autoConnect is off in this test");
+      },
+      async createMessage(channelId: string, text: string) {
+        created.push({ channelId, text });
+        return { id: "900" };
+      },
+      async editMessage(channelId: string, _messageId: string, text: string) {
+        created.push({ channelId, text });
+      },
+    };
+    const adapter = new DiscordChannelAdapter({
+      transport,
+      token: "t",
+      autoConnect: false,
+    });
+    const handle = await startGateway({
+      agencHome: home,
+      clientFactory: async () => client,
+      extraAdapters: [adapter],
+    });
+    expect(handle.channels).toContain("discord");
+
+    // Allowlisted DM → framed turn, streamed reply lands via REST.
+    adapter.handleGatewayPayload({
+      op: 0,
+      t: "MESSAGE_CREATE",
+      s: 1,
+      d: {
+        id: "m1",
+        channel_id: "dm-chan",
+        author: { id: "u-42", username: "alice" },
+        content: "run the tests",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(client.sessions).toHaveLength(1);
+    expect(client.sessions[0].prompts[0]).toContain("run the tests");
+    expect(client.sessions[0].prompts[0]).toContain('trust="external"');
+    expect(created.some((m) => m.text.includes("echo:"))).toBe(true);
+
+    // Unlisted sender under an allowlist policy → silently denied: no turn,
+    // no reply (pairing challenges only come from the pairing default).
+    const sentBefore = created.length;
+    adapter.handleGatewayPayload({
+      op: 0,
+      t: "MESSAGE_CREATE",
+      s: 2,
+      d: {
+        id: "m2",
+        channel_id: "dm-other",
+        author: { id: "u-99" },
+        content: "let me in",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(client.sessions).toHaveLength(1); // still just the first turn
+    expect(created.length).toBe(sentBefore);
+
+    await handle.stop();
+  });
+
+  test("slack via extraAdapters: allowlisted DM drives a real turn end to end", async () => {
+    writeConfig({
+      channels: { slack: { dmPolicy: "allowlist", allowlist: ["U42"] } },
+    });
+    const client = new FakeClient();
+    const posted: { channel: string; text: string }[] = [];
+    const transport = {
+      async openSocketUrl() {
+        return "wss://unused";
+      },
+      async connect() {
+        throw new Error("autoConnect is off in this test");
+      },
+      async authTest() {
+        return { userId: "UBOT" };
+      },
+      async postMessage(channel: string, text: string) {
+        posted.push({ channel, text });
+        return { ts: "1.1" };
+      },
+      async updateMessage(channel: string, _ts: string, text: string) {
+        posted.push({ channel, text });
+      },
+    };
+    const adapter = new SlackChannelAdapter({ transport, autoConnect: false });
+    const handle = await startGateway({
+      agencHome: home,
+      clientFactory: async () => client,
+      extraAdapters: [adapter],
+    });
+    expect(handle.channels).toContain("slack");
+
+    adapter.handleEnvelope({
+      type: "events_api",
+      envelope_id: "e1",
+      payload: {
+        event: {
+          type: "message",
+          user: "U42",
+          text: "summarize the incident",
+          channel: "D1",
+          channel_type: "im",
+          ts: "1.0",
+        },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(client.sessions).toHaveLength(1);
+    expect(client.sessions[0].prompts[0]).toContain("summarize the incident");
+    expect(client.sessions[0].prompts[0]).toContain('trust="external"');
+    expect(posted.some((m) => m.text.includes("echo:"))).toBe(true);
+
+    await handle.stop();
   });
 
   test("telegram via extraAdapters: inbound update drives a real turn", async () => {

--- a/runtime/tests/gateway/slack.test.ts
+++ b/runtime/tests/gateway/slack.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Slack channel adapter (TODO task 9): Socket Mode envelope handling
+ * (ack-everything discipline), DM/channel mapping with mention gating,
+ * thread conversations, chat.update edits, and disconnect-driven socket
+ * recycling — all against a scripted fake transport.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  parseSlackConversationId,
+  SlackChannelAdapter,
+  SLACK_MESSAGE_LIMIT,
+  type SlackEnvelope,
+  type SlackMessageEvent,
+  type SlackSocketHandlers,
+  type SlackTransport,
+} from "../../src/gateway/slack-channel.js";
+import type { InboundChannelMessage } from "../../src/gateway/types.js";
+
+class FakeSlackTransport implements SlackTransport {
+  readonly sentFrames: Record<string, unknown>[] = [];
+  readonly posted: { channel: string; text: string; threadTs?: string }[] = [];
+  readonly updated: { channel: string; ts: string; text: string }[] = [];
+  handlers: SlackSocketHandlers | null = null;
+  closed = 0;
+  opens = 0;
+  authTestFails = false;
+  #nextTs = 1000;
+
+  async openSocketUrl(): Promise<string> {
+    this.opens += 1;
+    return "wss://fake.slack";
+  }
+
+  async connect(_url: string, handlers: SlackSocketHandlers) {
+    this.handlers = handlers;
+    return {
+      send: (frame: Record<string, unknown>) => {
+        this.sentFrames.push(frame);
+      },
+      close: () => {
+        this.closed += 1;
+        handlers.onClose(1000);
+      },
+    };
+  }
+
+  async authTest(): Promise<{ userId: string }> {
+    if (this.authTestFails) throw new Error("auth.test down");
+    return { userId: "UBOT" };
+  }
+
+  async postMessage(channel: string, text: string, threadTs?: string) {
+    this.posted.push({
+      channel,
+      text,
+      ...(threadTs !== undefined ? { threadTs } : {}),
+    });
+    return { ts: String(++this.#nextTs) };
+  }
+
+  async updateMessage(channel: string, ts: string, text: string) {
+    this.updated.push({ channel, ts, text });
+  }
+}
+
+interface Harness {
+  adapter: SlackChannelAdapter;
+  transport: FakeSlackTransport;
+  inbound: InboundChannelMessage[];
+  timers: { fn: () => void; ms: number }[];
+}
+
+async function makeAdapter(
+  options: {
+    groupAddressing?: "all" | "mentions";
+    authTestFails?: boolean;
+  } = {},
+): Promise<Harness> {
+  const transport = new FakeSlackTransport();
+  transport.authTestFails = options.authTestFails ?? false;
+  const inbound: InboundChannelMessage[] = [];
+  const timers: { fn: () => void; ms: number }[] = [];
+  const adapter = new SlackChannelAdapter({
+    transport,
+    setTimer: (fn, ms) => {
+      timers.push({ fn, ms });
+      return timers.length as unknown as ReturnType<typeof setTimeout>;
+    },
+    ...(options.groupAddressing !== undefined
+      ? { groupAddressing: options.groupAddressing }
+      : {}),
+  });
+  await adapter.start({
+    onMessage: async (message) => {
+      inbound.push(message);
+    },
+  });
+  return { adapter, transport, inbound, timers };
+}
+
+function messageEnvelope(
+  event: Partial<SlackMessageEvent>,
+  envelopeId = "env-1",
+): SlackEnvelope {
+  return {
+    type: "events_api",
+    envelope_id: envelopeId,
+    payload: {
+      event: {
+        type: "message",
+        user: "U123",
+        text: "hello agent",
+        channel: "C1",
+        channel_type: "im",
+        ts: "1.0",
+        ...event,
+      },
+    },
+  };
+}
+
+describe("SlackChannelAdapter envelopes", () => {
+  test("EVERY acknowledgeable envelope is acked — even dropped ones", async () => {
+    const h = await makeAdapter();
+    // A bot message that will be dropped must STILL be acked, or Slack
+    // redelivers it and eventually flags the app.
+    h.adapter.handleEnvelope(
+      messageEnvelope({ bot_id: "B99" }, "env-dropped"),
+    );
+    // A normal message is acked too.
+    h.adapter.handleEnvelope(messageEnvelope({}, "env-ok"));
+
+    expect(h.transport.sentFrames).toEqual([
+      { envelope_id: "env-dropped" },
+      { envelope_id: "env-ok" },
+    ]);
+  });
+
+  test("disconnect envelope recycles the socket and reconnect reopens a fresh URL", async () => {
+    const h = await makeAdapter();
+    expect(h.transport.opens).toBe(1);
+    h.adapter.handleEnvelope({ type: "disconnect", reason: "link_refresh" });
+    expect(h.transport.closed).toBe(1);
+    // onClose armed a reconnect timer; firing it reopens via
+    // apps.connections.open (a fresh URL every time).
+    expect(h.timers.length).toBeGreaterThan(0);
+    h.timers.at(-1)!.fn();
+    await vi.waitFor(() => expect(h.transport.opens).toBe(2));
+  });
+});
+
+describe("SlackChannelAdapter inbound mapping", () => {
+  test("im message maps to a dm conversation", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleEnvelope(messageEnvelope({}));
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+    expect(h.inbound[0]).toMatchObject({
+      channelId: "slack",
+      sender: { peerId: "U123" },
+      conversation: { kind: "dm", id: "C1" },
+      text: "hello agent",
+    });
+  });
+
+  test("bot, self, and subtyped messages never reach the agent", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleEnvelope(messageEnvelope({ bot_id: "B1" }, "e1"));
+    h.adapter.handleEnvelope(messageEnvelope({ user: "UBOT" }, "e2"));
+    h.adapter.handleEnvelope(
+      messageEnvelope({ subtype: "message_changed" }, "e3"),
+    );
+    // app_mention duplicates the message event — ignored to avoid double turns.
+    h.adapter.handleEnvelope(
+      messageEnvelope({ type: "app_mention", text: "<@UBOT> hi" }, "e4"),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(h.inbound).toHaveLength(0);
+  });
+
+  test("channel messages are mention-gated by default; mention stripped", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleEnvelope(
+      messageEnvelope({ channel_type: "channel", text: "random chatter" }, "e1"),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(h.inbound).toHaveLength(0);
+
+    h.adapter.handleEnvelope(
+      messageEnvelope(
+        { channel_type: "channel", text: "<@UBOT> summarize the incident" },
+        "e2",
+      ),
+    );
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+    expect(h.inbound[0]).toMatchObject({
+      conversation: { kind: "group", id: "C1" },
+      text: "summarize the incident",
+    });
+  });
+
+  test("groupAddressing 'all' forwards unmentioned channel messages", async () => {
+    const h = await makeAdapter({ groupAddressing: "all" });
+    h.adapter.handleEnvelope(
+      messageEnvelope({ channel_type: "channel", text: "broadcast" }),
+    );
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+  });
+
+  test("auth.test failure fails CLOSED for channels, open for DMs", async () => {
+    const h = await makeAdapter({ authTestFails: true });
+    // Channel message: no self id → mention gate cannot match → dropped.
+    h.adapter.handleEnvelope(
+      messageEnvelope({ channel_type: "channel", text: "<@UBOT> hi" }, "e1"),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(h.inbound).toHaveLength(0);
+    // DM still works (pairing gate is upstream in the gateway).
+    h.adapter.handleEnvelope(messageEnvelope({}, "e2"));
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+  });
+
+  test("thread messages get their own conversation keyed by thread_ts", async () => {
+    const h = await makeAdapter();
+    h.adapter.handleEnvelope(
+      messageEnvelope({
+        channel_type: "channel",
+        text: "<@UBOT> continue here",
+        thread_ts: "171.5",
+      }),
+    );
+    await vi.waitFor(() => expect(h.inbound).toHaveLength(1));
+    expect(h.inbound[0].conversation).toEqual({
+      kind: "group",
+      id: "C1:171.5",
+    });
+  });
+});
+
+describe("slack run-loop wiring contract", () => {
+  // Source contract: startGateway constructs the production adapter only
+  // when BOTH Slack tokens are present (bot xoxb- for the Web API, app
+  // xapp- for Socket Mode) and warns on a half-configured pair.
+  test("run.ts wires the Slack token pair to the Slack adapter", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const source = readFileSync(
+      resolve(process.cwd(), "src/gateway/run.ts"),
+      "utf8",
+    );
+    expect(source).toContain("AGENC_SLACK_BOT_TOKEN");
+    expect(source).toContain("AGENC_SLACK_APP_TOKEN");
+    expect(source).toContain("new SlackChannelAdapter({");
+    expect(source).toContain("slack needs BOTH");
+  });
+});
+
+describe("SlackChannelAdapter outbound", () => {
+  test("send posts to the channel; thread conversations post with thread_ts", async () => {
+    const h = await makeAdapter();
+    await h.adapter.send({ conversationId: "C1", text: "plain" });
+    await h.adapter.send({ conversationId: "C1:171.5", text: "threaded" });
+    expect(h.transport.posted).toEqual([
+      { channel: "C1", text: "plain" },
+      { channel: "C1", text: "threaded", threadTs: "171.5" },
+    ]);
+  });
+
+  test("edit routes chat.update to the stored target", async () => {
+    const h = await makeAdapter();
+    const handle = await h.adapter.send({ conversationId: "C1", text: "v1" });
+    await h.adapter.send({
+      conversationId: "C1",
+      text: "v2",
+      editMessageId: handle,
+    });
+    expect(h.transport.updated).toEqual([
+      { channel: "C1", ts: "1001", text: "v2" },
+    ]);
+  });
+
+  test("oversized messages are truncated with a marker", async () => {
+    const h = await makeAdapter();
+    await h.adapter.send({
+      conversationId: "C1",
+      text: "z".repeat(SLACK_MESSAGE_LIMIT + 500),
+    });
+    expect(h.transport.posted[0].text.length).toBeLessThanOrEqual(
+      SLACK_MESSAGE_LIMIT + 20,
+    );
+    expect(h.transport.posted[0].text).toContain("(truncated)");
+  });
+
+  test("parseSlackConversationId round-trips channel and thread forms", () => {
+    expect(parseSlackConversationId("C1")).toEqual({ channel: "C1" });
+    expect(parseSlackConversationId("C1:17.5")).toEqual({
+      channel: "C1",
+      threadTs: "17.5",
+    });
+  });
+});


### PR DESCRIPTION
## What (TODO task 9)

Discord and Slack channel adapters on the task-6 interface — official APIs only, **zero new dependencies** (global `WebSocket` + `fetch`), transports injected so tests never touch the network.

## Discord (`gateway/discord-channel.ts`)

- **Gateway WebSocket** inbound: HELLO → IDENTIFY (bot token + `GUILD_MESSAGES|DIRECT_MESSAGES|MESSAGE_CONTENT` intents), heartbeat loop with **sequence tracking** and **missed-ACK zombie recycling**, RECONNECT/INVALID_SESSION handling, bounded-backoff reconnect.
- **REST** outbound: create/edit for edit-in-place streaming; 2000-char **chunking** at line boundaries (edit overflow spills to fresh messages).
- **Threads**: Discord threads are channels, so thread messages get their own conversation and replies land in-thread with no extra bookkeeping. Guild bindings use the channel/thread id as `groupId`.
- **Guild mention gating** (default): only @bot mentions and replies to the bot reach the agent; mention tokens stripped; bot/self authors dropped (echo-loop guard). `AGENC_DISCORD_GROUP_ADDRESSING=all` for broadcast rooms.

## Slack (`gateway/slack-channel.ts`)

- **Socket Mode** inbound — **no listener opened**, preserving the gateway's loopback-only posture. `apps.connections.open` (xapp- token) mints the socket; **every envelope is acked** — even dropped ones — so Slack never redelivers or flags the app; `disconnect` envelopes recycle through a fresh connections.open.
- **Web API** outbound: `chat.postMessage`/`chat.update` (xoxb- token) for edit-in-place streaming; oversized text truncated with a marker.
- **Threads**: `thread_ts` messages map to their own conversation (`<channel>:<thread_ts>`) and replies stay in-thread.
- **Channel mention gating** (default) via the `auth.test` self id — **fails closed for channels when auth.test is down** (DMs still pairing-gated upstream). `app_mention` events ignored (the `message` event covers the same text — double-turn prevention).

## Wiring + security

- `AGENC_DISCORD_BOT_TOKEN`; `AGENC_SLACK_BOT_TOKEN` + `AGENC_SLACK_APP_TOKEN` (half-configured pair warns instead of silently not starting).
- All three tokens added to `sanitizeGatewayDaemonEnv` so an autostarted daemon never inherits channel credentials.
- The no-policy pairing-default warning now covers every networked channel.
- Both channels inherit the full gateway pipeline: pairing/allowlist gate, untrusted-content framing, in-channel approval tokens, session routing (proven in run-loop integration tests).

## Tests (same matrix as task 7, vs mocked APIs)

27 new across `discord.test.ts` / `slack.test.ts` / `run.test.ts`: protocol handshake, heartbeat sequence + zombie recycle, DM/guild/channel mapping, mention gating both defaults, chunking/truncation, edit routing, thread conversations, ack-everything, disconnect recycling, auth-fail-closed, full-pipeline turns with `trust="external"` framing + allowlist deny, wiring source contracts, env sanitization. Mutation/revert-proven: Slack ack removal red, Discord heartbeat-sequence mutation red, wiring contracts red vs origin/main run.ts.

## Gates

build ✓ · typecheck ✓ · vitest **14300 passed** (one pre-existing load-flake in cron-live-tools during the full run at load 12.3, green standalone and on re-run) · test:bun ✓ · agent-surface-contract ✓