### PR TITLE
fix: resolve Telegram bot identity for mentions

### DIFF
--- a/runtime/src/gateway/telegram-channel.ts
+++ b/runtime/src/gateway/telegram-channel.ts
@@ -464,8 +464,9 @@ export class TelegramChannelAdapter implements ChannelAdapter {
     this.#debugUpdates = options.debugUpdates ?? false;
     this.#groupAddressing = options.groupAddressing ?? "all";
     this.#richMessages = options.richMessages ?? "private";
-    if (options.botUsername !== undefined && options.botUsername.length > 0) {
-      this.#botIdentity = { id: -1, username: options.botUsername.replace(/^@/, "") };
+    const configuredBotUsername = options.botUsername?.trim().replace(/^@/, "");
+    if (configuredBotUsername !== undefined && configuredBotUsername.length > 0) {
+      this.#botIdentity = { id: -1, username: configuredBotUsername };
     }
   }
 
@@ -517,13 +518,21 @@ export class TelegramChannelAdapter implements ChannelAdapter {
   async #resolveBotIdentity(): Promise<void> {
     if (
       this.#groupAddressing !== "mentions" ||
-      this.#botIdentity !== null ||
       this.#transport.getMe === undefined
     ) {
       return;
     }
     try {
-      this.#botIdentity = await this.#transport.getMe();
+      const configuredUsername = this.#botIdentity?.username;
+      const resolved = await this.#transport.getMe();
+      this.#botIdentity = {
+        id: resolved.id,
+        ...(resolved.username !== undefined
+          ? { username: resolved.username }
+          : configuredUsername !== undefined
+            ? { username: configuredUsername }
+            : {}),
+      };
     } catch (error) {
       this.#log(`telegram: getMe failed: ${String(error)}`);
     }
@@ -792,8 +801,14 @@ function telegramBotMentionRanges(
   const entities = telegramEntitiesForText(message, text);
   for (const entity of entities) {
     if (!isValidTelegramEntityRange(text, entity)) continue;
-    if (entity.type === "text_mention" && entity.user?.id === identity.id) {
-      ranges.push({ offset: entity.offset, length: entity.length });
+    if (entity.type === "text_mention") {
+      const mentionedUsername = entity.user?.username?.toLowerCase();
+      if (
+        entity.user?.id === identity.id ||
+        (username !== undefined && mentionedUsername === username)
+      ) {
+        ranges.push({ offset: entity.offset, length: entity.length });
+      }
       continue;
     }
     if (entity.type !== "mention" || username === undefined) continue;

--- a/runtime/tests/gateway/telegram.test.ts
+++ b/runtime/tests/gateway/telegram.test.ts
@@ -67,12 +67,14 @@ class FakeTransport implements TelegramTransport {
   }[] = [];
   readonly commands: { commands: unknown; scope?: unknown }[] = [];
   identity: TelegramBotIdentity = { id: 999, username: "agenc_test_bot" };
+  getMeCalls = 0;
   #nextId = 100;
   richShouldThrow = false;
   richEditShouldThrow = false;
   editShouldThrow = false;
 
   async getMe(): Promise<TelegramBotIdentity> {
+    this.getMeCalls += 1;
     return this.identity;
   }
   async getUpdates(): Promise<TelegramUpdate[]> {
@@ -450,6 +452,77 @@ describe("TelegramChannelAdapter", () => {
     await adapter.stop();
     expect(messages).toHaveLength(1);
     expect(messages[0].text).toBe("can you explain the top holder data?");
+  });
+
+  test("configured username still resolves the live bot id for text_mention entities", async () => {
+    const transport = new FakeTransport();
+    transport.identity = { id: 8514910485, username: "core_69_bot" };
+    transport.updates = [
+      [
+        {
+          update_id: 43,
+          message: {
+            message_id: 83,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text: "AgenC explain this",
+            entities: [
+              {
+                type: "text_mention",
+                offset: 0,
+                length: 5,
+                user: { id: 8514910485, is_bot: true },
+              },
+            ],
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+      botUsername: "@core_69_bot",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(transport.getMeCalls).toBe(1);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("explain this");
+  });
+
+  test("configured username remains a fallback when getMe fails", async () => {
+    const transport = new FakeTransport();
+    transport.getMe = async () => {
+      throw new Error("temporary Telegram API failure");
+    };
+    transport.updates = [
+      [
+        {
+          update_id: 44,
+          message: {
+            message_id: 84,
+            from: { id: 7, first_name: "Bob" },
+            chat: { id: -100200, type: "supergroup" },
+            text: "@core_69_bot explain this",
+          },
+        },
+      ],
+    ];
+    const adapter = new TelegramChannelAdapter({
+      transport,
+      autoPoll: false,
+      groupAddressing: "mentions",
+      botUsername: "core_69_bot",
+    });
+    const { ctx, messages } = collector();
+    await adapter.start(ctx);
+    await adapter.pollOnce();
+    await adapter.stop();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("explain this");
   });
 
   test("mention-only group addressing includes replied-message context", async () => {


### PR DESCRIPTION
## Summary
- resolve the live Telegram bot identity even when a username is configured
- recognize text mentions by resolved bot ID or matching username
- preserve username-based routing when Telegram getMe is temporarily unavailable

## Verification
- 144 gateway tests passed
- runtime typecheck passed
- runtime build passed

## Production symptom
Direct group mentions could be delivered by Telegram but classified as mentionsBot=false, while replies to the bot still worked.