### PR TITLE
fix(gateway): accept live xAI search evidence

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -123,12 +123,14 @@ handle-specific question cannot silently broaden into unrelated accounts.
 The gateway treats the query and all X content as untrusted data, applies
 per-peer and daily limits, bounds response size and latency, and caches repeated
 reads briefly. A response is returned only when xAI reports completion and
-includes a completed `x_search_call` plus a structured public
+includes completed server-side X-search evidence plus a structured public
 `x.com`/`twitter.com` citation; post-specific questions additionally require a
-cited status URL. Unverified links from model text are removed. Requests set
-`store: false`, so the Responses API does not retain them. The xAI API key
-remains in the private authorization header and is never included in prompts,
-replies, usage files, or logs.
+cited status URL. Both documented `x_search_call` output and xAI's current
+`custom_tool_call` names are accepted through a four-name X-search allowlist.
+Unverified links from model text are removed. Requests set `store: false`, so
+the Responses API does not retain them. The xAI API key remains in the private
+authorization header and is never included in prompts, replies, usage files, or
+logs.
 
 ### Read-only Solana research
 

--- a/runtime/src/gateway/x-search.ts
+++ b/runtime/src/gateway/x-search.ts
@@ -29,6 +29,12 @@ const MAX_ANSWER_CHARS = 3_200;
 const MAX_CACHE_ENTRIES = 100;
 const MAX_PEER_RATE_ENTRIES = 10_000;
 const MAX_X_HANDLES = 20;
+const X_SEARCH_CUSTOM_CALL_NAMES = new Set([
+  "x_user_search",
+  "x_keyword_search",
+  "x_semantic_search",
+  "x_thread_fetch",
+]);
 
 const X_SEARCH_SYSTEM_PROMPT = [
   "You are a read-only X research function. You cannot post, reply, like, follow, delete, or modify anything.",
@@ -240,14 +246,20 @@ function extractOutputText(response: Record<string, unknown>): string {
   return parts.join("\n").trim();
 }
 
-function hasCompletedXSearchCall(response: Record<string, unknown>): boolean {
+function hasCompletedXSearchEvidence(response: Record<string, unknown>): boolean {
   if (!Array.isArray(response.output)) return false;
-  return response.output.some(
-    (item) =>
-      isRecord(item) &&
-      item.type === "x_search_call" &&
-      (item.status === undefined || item.status === "completed"),
-  );
+  return response.output.some((item) => {
+    if (!isRecord(item) || item.status === "failed") return false;
+    if (item.type === "x_search_call") {
+      return item.status === undefined || item.status === "completed";
+    }
+    return (
+      item.type === "custom_tool_call" &&
+      item.status === "completed" &&
+      typeof item.name === "string" &&
+      X_SEARCH_CUSTOM_CALL_NAMES.has(item.name)
+    );
+  });
 }
 
 function sourceMatchesPost(url: string): boolean {
@@ -483,7 +495,7 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
       const text = extractOutputText(parsed);
       const sources = collectStructuredXUrls(parsed);
       if (
-        !hasCompletedXSearchCall(parsed) ||
+        !hasCompletedXSearchEvidence(parsed) ||
         text.length === 0 ||
         sources.length === 0 ||
         (intent.requiresPostCitation && !sources.some(sourceMatchesPost))

--- a/runtime/tests/gateway/x-search.test.ts
+++ b/runtime/tests/gateway/x-search.test.ts
@@ -21,7 +21,11 @@ function xaiResponse(options: {
     JSON.stringify({
       status: "completed",
       output: [
-        { type: "x_search_call", status: "completed" },
+        {
+          type: "custom_tool_call",
+          name: "x_user_search",
+          status: "completed",
+        },
         {
           type: "message",
           content: [
@@ -165,7 +169,7 @@ describe("XaiXSearchFeature", () => {
     ]);
   });
 
-  test("requires proof that the server-side x_search tool actually ran", async () => {
+  test("requires proof that an allowed server-side x_search tool actually ran", async () => {
     const replies: string[] = [];
     const feature = new XaiXSearchFeature({
       apiKey: "xai-test-key-that-is-long-enough",
@@ -211,6 +215,103 @@ describe("XaiXSearchFeature", () => {
     ]);
   });
 
+  test("accepts the documented x_search_call response shape", async () => {
+    const replies: string[] = [];
+    const feature = new XaiXSearchFeature({
+      apiKey: "xai-test-key-that-is-long-enough",
+      usageFile: join(home, "usage.json"),
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            status: "completed",
+            output: [
+              { type: "x_search_call", status: "completed" },
+              {
+                type: "message",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Verified result",
+                    annotations: [
+                      {
+                        type: "url_citation",
+                        url: "https://x.com/example/status/123",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as typeof fetch,
+    });
+
+    await feature.handle({
+      text: "latest post from @example",
+      channelId: "telegram",
+      peerId: "alice",
+      reply: async (text) => {
+        replies.push(text);
+        return "out-1";
+      },
+    });
+
+    expect(replies[0]).toContain("Verified result");
+    expect(replies[0]).toContain("https://x.com/example/status/123");
+  });
+
+  test("rejects unrelated custom tools even when their output carries an X citation", async () => {
+    const replies: string[] = [];
+    const feature = new XaiXSearchFeature({
+      apiKey: "xai-test-key-that-is-long-enough",
+      usageFile: join(home, "usage.json"),
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            status: "completed",
+            output: [
+              {
+                type: "custom_tool_call",
+                name: "code_execution",
+                status: "completed",
+              },
+              {
+                type: "message",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Untrusted tool result",
+                    annotations: [
+                      {
+                        type: "url_citation",
+                        url: "https://x.com/example/status/123",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as typeof fetch,
+    });
+
+    await feature.handle({
+      text: "latest post from @example",
+      channelId: "telegram",
+      peerId: "alice",
+      reply: async (text) => {
+        replies.push(text);
+        return "out-1";
+      },
+    });
+
+    expect(replies).toEqual([
+      "I could not verify that X result with a direct public source, so I will not guess. Check the handle and try again.",
+    ]);
+  });
+
   test("fails closed when xAI does not report a completed response", async () => {
     const replies: string[] = [];
     const feature = new XaiXSearchFeature({
@@ -221,7 +322,11 @@ describe("XaiXSearchFeature", () => {
           JSON.stringify({
             status: "in_progress",
             output: [
-              { type: "x_search_call", status: "completed" },
+              {
+                type: "custom_tool_call",
+                name: "x_keyword_search",
+                status: "completed",
+              },
               {
                 type: "message",
                 content: [


### PR DESCRIPTION
## Summary
- accept xAI production Responses output where X reads arrive as completed `custom_tool_call` entries
- restrict those calls to the four documented X-search function names
- retain support for the documented `x_search_call` shape
- reject unrelated custom tools even when model text contains an X-looking citation

## Why
A live production canary returned completed `x_user_search`/`x_keyword_search` calls as `custom_tool_call`, not `x_search_call`. The prior build failed closed and would refuse an otherwise verified answer.

## Verification
- live xAI canary: HTTP 200, completed, 3 structured X citations, direct status citation, `store: false`
- `npm test -- --run tests/gateway` (192 passed)
- `npm run typecheck`
- `npm run build`