### PR TITLE
fix(gateway): tolerate hosted X search latency

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -113,12 +113,18 @@ AGENC_GATEWAY_X_SEARCH_ENABLED=1
 AGENC_GATEWAY_X_SEARCH_MODEL=grok-4.5
 AGENC_GATEWAY_X_SEARCH_DAILY_LIMIT=100
 AGENC_GATEWAY_X_SEARCH_PER_PEER_LIMIT=4
+AGENC_GATEWAY_X_SEARCH_TIMEOUT_MS=90000
 ```
 
 Examples include `what is the latest post from @xai?`, `dime el último
 comentario de @user`, and `what are people saying about AgenC on X?`. Exact
 handles are extracted and passed through `allowed_x_handles` (maximum 20), so a
 handle-specific question cannot silently broaden into unrelated accounts.
+
+Hosted X search can take tens of seconds. The default bounded wait is 90
+seconds; `AGENC_GATEWAY_X_SEARCH_TIMEOUT_MS` can tune it between 15 and 120
+seconds. Timeout, rate-limit, and xAI-availability failures are reported
+separately without exposing provider responses or credentials.
 
 The gateway treats the query and all X content as untrusted data, applies
 per-peer and daily limits, bounds response size and latency, and caches repeated

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -157,6 +157,17 @@ function envPositiveInt(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function envBoundedPositiveInt(
+  value: string | undefined,
+  minimum: number,
+  maximum: number,
+): number | undefined {
+  const parsed = envPositiveInt(value);
+  return parsed === undefined
+    ? undefined
+    : Math.min(maximum, Math.max(minimum, parsed));
+}
+
 function envList(value: string | undefined): readonly string[] {
   if (value === undefined) return [];
   return value
@@ -377,6 +388,11 @@ export async function startGateway(
   const xSearchPerPeerLimit = envPositiveInt(
     env.AGENC_GATEWAY_X_SEARCH_PER_PEER_LIMIT,
   );
+  const xSearchTimeoutMs = envBoundedPositiveInt(
+    env.AGENC_GATEWAY_X_SEARCH_TIMEOUT_MS,
+    15_000,
+    120_000,
+  );
   const xSearchFeature =
     xSearchEnabled && xaiKey !== undefined
       ? new XaiXSearchFeature({
@@ -390,6 +406,9 @@ export async function startGateway(
             : {}),
           ...(xSearchPerPeerLimit !== undefined
             ? { perPeerLimit: xSearchPerPeerLimit }
+            : {}),
+          ...(xSearchTimeoutMs !== undefined
+            ? { timeoutMs: xSearchTimeoutMs }
             : {}),
           log,
         })

--- a/runtime/src/gateway/x-search.ts
+++ b/runtime/src/gateway/x-search.ts
@@ -18,7 +18,8 @@ import { dirname } from "node:path";
 
 const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 const DEFAULT_MODEL = "grok-4.5";
-const DEFAULT_TIMEOUT_MS = 45_000;
+const DEFAULT_TIMEOUT_MS = 90_000;
+const MAX_TIMEOUT_MS = 120_000;
 const DEFAULT_DAILY_LIMIT = 100;
 const DEFAULT_PER_PEER_LIMIT = 4;
 const DEFAULT_PER_PEER_WINDOW_MS = 60_000;
@@ -303,8 +304,14 @@ function publicErrorReply(error: unknown): string {
   if (code === "authentication_failed") {
     return "Live X search is temporarily unavailable. The server-side credential needs attention; no key was exposed.";
   }
-  if (code === "rate_limited" || code === "upstream_unavailable" || code === "timeout") {
-    return "X search is busy upstream right now. Try the same question again in a minute.";
+  if (code === "timeout") {
+    return "X search took longer than the bounded server wait, so no result was returned. Try the same question again.";
+  }
+  if (code === "rate_limited") {
+    return "X search is rate-limited upstream right now. Try the same question again in a minute.";
+  }
+  if (code === "upstream_unavailable") {
+    return "X search is temporarily unavailable at xAI. Try the same question again in a minute.";
   }
   return "I could not complete that read-only X search safely. Check the handle and try again.";
 }
@@ -333,7 +340,10 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
     this.#fetch = options.fetchImpl ?? fetch;
     this.#now = options.now ?? Date.now;
     this.#log = options.log ?? (() => {});
-    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#timeoutMs = Math.min(
+      MAX_TIMEOUT_MS,
+      Math.max(1, options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    );
     this.#dailyLimit = options.dailyLimit ?? DEFAULT_DAILY_LIMIT;
     this.#perPeerLimit = options.perPeerLimit ?? DEFAULT_PER_PEER_LIMIT;
     this.#perPeerWindowMs =

--- a/runtime/tests/gateway/x-search.test.ts
+++ b/runtime/tests/gateway/x-search.test.ts
@@ -445,4 +445,73 @@ describe("XaiXSearchFeature", () => {
       "gateway x-search: read failed (authentication_failed)",
     ]);
   });
+
+  test("reports a bounded timeout separately from other upstream failures", async () => {
+    const logs: string[] = [];
+    const replies: string[] = [];
+    const feature = new XaiXSearchFeature({
+      apiKey: "xai-test-key-that-is-long-enough",
+      usageFile: join(home, "usage.json"),
+      timeoutMs: 5,
+      fetchImpl: ((_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        })) as typeof fetch,
+      log: (line) => logs.push(line),
+    });
+
+    await feature.handle({
+      text: "latest post from @example",
+      channelId: "telegram",
+      peerId: "alice",
+      reply: async (text) => {
+        replies.push(text);
+        return "out";
+      },
+    });
+
+    expect(replies).toEqual([
+      "X search took longer than the bounded server wait, so no result was returned. Try the same question again.",
+    ]);
+    expect(logs).toEqual(["gateway x-search: read failed (timeout)"]);
+  });
+
+  test.each([
+    [429, "rate-limited upstream", "rate_limited"],
+    [503, "temporarily unavailable at xAI", "upstream_unavailable"],
+  ])(
+    "reports HTTP %i with a specific safe message",
+    async (status, expectedReply, expectedCode) => {
+      const logs: string[] = [];
+      const replies: string[] = [];
+      const feature = new XaiXSearchFeature({
+        apiKey: "xai-test-key-that-is-long-enough",
+        usageFile: join(home, "usage.json"),
+        fetchImpl: (async () =>
+          new Response("provider detail must stay private", { status })) as typeof fetch,
+        log: (line) => logs.push(line),
+      });
+
+      await feature.handle({
+        text: "latest post from @example",
+        channelId: "telegram",
+        peerId: "alice",
+        reply: async (text) => {
+          replies.push(text);
+          return "out";
+        },
+      });
+
+      expect(replies[0]).toContain(expectedReply);
+      expect(replies[0]).not.toContain("provider detail");
+      expect(logs).toEqual([
+        `gateway x-search: read failed (${expectedCode})`,
+      ]);
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- raise the bounded xAI hosted X-search wait from 45 seconds to 90 seconds
- wire `AGENC_GATEWAY_X_SEARCH_TIMEOUT_MS` with a safe 15-120 second deployment range
- distinguish timeout, rate-limit, and xAI availability replies instead of collapsing all three into “busy upstream”
- document hosted-search latency and timeout controls

## Production evidence
- the reported fallback mapped to `gateway x-search: read failed (timeout)`
- a fresh production xAI canary completed successfully in 35.9 seconds with structured X-search evidence and a direct status citation
- the credential is healthy; the previous 45-second deadline was too close to observed latency

## Verification
- `npm test -- --run tests/gateway`: 199 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `git diff --check`: passed
- no production credential or provider response added to source/log output
