### PR TITLE
fix(gateway): bound and retry X search

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -114,6 +114,8 @@ AGENC_GATEWAY_X_SEARCH_MODEL=grok-4.5
 AGENC_GATEWAY_X_SEARCH_DAILY_LIMIT=100
 AGENC_GATEWAY_X_SEARCH_PER_PEER_LIMIT=4
 AGENC_GATEWAY_X_SEARCH_TIMEOUT_MS=90000
+AGENC_GATEWAY_X_SEARCH_MAX_TURNS=2
+AGENC_GATEWAY_X_SEARCH_MAX_ATTEMPTS=2
 ```
 
 Examples include `what is the latest post from @xai?`, `dime el último
@@ -123,8 +125,16 @@ handle-specific question cannot silently broaden into unrelated accounts.
 
 Hosted X search can take tens of seconds. The default bounded wait is 90
 seconds; `AGENC_GATEWAY_X_SEARCH_TIMEOUT_MS` can tune it between 15 and 120
-seconds. Timeout, rate-limit, and xAI-availability failures are reported
-separately without exposing provider responses or credentials.
+seconds. Quick Telegram reads use at most two xAI assistant/tool turns by
+default, matching xAI's guidance for quick lookups; the configurable maximum is
+five. A transient network, HTTP 5xx, or short rate-limit response receives one
+bounded retry by default. Timeout, rate-limit, and xAI-availability failures are
+reported separately without exposing provider responses or credentials.
+
+xAI's Docs MCP searches xAI documentation, while Remote MCP connects Grok to an
+external tool server. Neither is the X data source used here. Public X reads use
+xAI's built-in server-side `x_search` tool directly through the Responses API,
+which is the smallest read-only surface for this route.
 
 The gateway treats the query and all X content as untrusted data, applies
 per-peer and daily limits, bounds response size and latency, and caches repeated

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -393,6 +393,16 @@ export async function startGateway(
     15_000,
     120_000,
   );
+  const xSearchMaxTurns = envBoundedPositiveInt(
+    env.AGENC_GATEWAY_X_SEARCH_MAX_TURNS,
+    1,
+    5,
+  );
+  const xSearchMaxAttempts = envBoundedPositiveInt(
+    env.AGENC_GATEWAY_X_SEARCH_MAX_ATTEMPTS,
+    1,
+    3,
+  );
   const xSearchFeature =
     xSearchEnabled && xaiKey !== undefined
       ? new XaiXSearchFeature({
@@ -409,6 +419,12 @@ export async function startGateway(
             : {}),
           ...(xSearchTimeoutMs !== undefined
             ? { timeoutMs: xSearchTimeoutMs }
+            : {}),
+          ...(xSearchMaxTurns !== undefined
+            ? { maxTurns: xSearchMaxTurns }
+            : {}),
+          ...(xSearchMaxAttempts !== undefined
+            ? { maxAttempts: xSearchMaxAttempts }
             : {}),
           log,
         })

--- a/runtime/src/gateway/x-search.ts
+++ b/runtime/src/gateway/x-search.ts
@@ -20,6 +20,12 @@ const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 const DEFAULT_MODEL = "grok-4.5";
 const DEFAULT_TIMEOUT_MS = 90_000;
 const MAX_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_TURNS = 2;
+const MAX_TURNS = 5;
+const DEFAULT_MAX_ATTEMPTS = 2;
+const MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 750;
+const MAX_RETRY_AFTER_MS = 5_000;
 const DEFAULT_DAILY_LIMIT = 100;
 const DEFAULT_PER_PEER_LIMIT = 4;
 const DEFAULT_PER_PEER_WINDOW_MS = 60_000;
@@ -45,6 +51,7 @@ const X_SEARCH_SYSTEM_PROMPT = [
 ].join("\n");
 
 type FetchLike = typeof fetch;
+type Sleep = (milliseconds: number) => Promise<void>;
 
 export interface XSearchIntent {
   readonly query: string;
@@ -69,6 +76,9 @@ export interface XaiXSearchFeatureOptions {
   readonly now?: () => number;
   readonly log?: (line: string) => void;
   readonly timeoutMs?: number;
+  readonly maxTurns?: number;
+  readonly maxAttempts?: number;
+  readonly sleep?: Sleep;
   readonly dailyLimit?: number;
   readonly perPeerLimit?: number;
   readonly perPeerWindowMs?: number;
@@ -87,12 +97,52 @@ interface CacheEntry {
 
 class XSearchRequestError extends Error {
   readonly code: string;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+  readonly httpStatus?: number;
 
-  constructor(code: string) {
+  constructor(
+    code: string,
+    options: {
+      readonly retryable?: boolean;
+      readonly retryAfterMs?: number;
+      readonly httpStatus?: number;
+    } = {},
+  ) {
     super(code);
     this.name = "XSearchRequestError";
     this.code = code;
+    this.retryable = options.retryable ?? false;
+    if (options.retryAfterMs !== undefined) {
+      this.retryAfterMs = options.retryAfterMs;
+    }
+    if (options.httpStatus !== undefined) {
+      this.httpStatus = options.httpStatus;
+    }
   }
+}
+
+function sleepDefault(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function retryAfterMilliseconds(response: Response): number | undefined {
+  const value = response.headers.get("retry-after")?.trim();
+  if (value === undefined || value === "") return undefined;
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
+  return Math.round(seconds * 1_000);
+}
+
+function safeErrorLog(error: unknown): string {
+  const code = errorCode(error);
+  if (
+    error instanceof XSearchRequestError &&
+    error.httpStatus !== undefined
+  ) {
+    return `${code}, status=${error.httpStatus}`;
+  }
+  return code;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -324,6 +374,9 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
   readonly #now: () => number;
   readonly #log: (line: string) => void;
   readonly #timeoutMs: number;
+  readonly #maxTurns: number;
+  readonly #maxAttempts: number;
+  readonly #sleep: Sleep;
   readonly #dailyLimit: number;
   readonly #perPeerLimit: number;
   readonly #perPeerWindowMs: number;
@@ -344,6 +397,15 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
       MAX_TIMEOUT_MS,
       Math.max(1, options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
     );
+    this.#maxTurns = Math.min(
+      MAX_TURNS,
+      Math.max(1, options.maxTurns ?? DEFAULT_MAX_TURNS),
+    );
+    this.#maxAttempts = Math.min(
+      MAX_ATTEMPTS,
+      Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS),
+    );
+    this.#sleep = options.sleep ?? sleepDefault;
     this.#dailyLimit = options.dailyLimit ?? DEFAULT_DAILY_LIMIT;
     this.#perPeerLimit = options.perPeerLimit ?? DEFAULT_PER_PEER_LIMIT;
     this.#perPeerWindowMs =
@@ -406,7 +468,7 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
       });
       await input.reply(answer);
     } catch (error) {
-      this.#log(`gateway x-search: read failed (${errorCode(error)})`);
+      this.#log(`gateway x-search: read failed (${safeErrorLog(error)})`);
       await input.reply(publicErrorReply(error));
     } finally {
       this.#inflight.delete(cacheKey);
@@ -441,6 +503,27 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
   }
 
   async #search(intent: XSearchIntent, observedAtMs: number): Promise<string> {
+    for (let attempt = 1; attempt <= this.#maxAttempts; attempt += 1) {
+      try {
+        return await this.#searchOnce(intent, observedAtMs);
+      } catch (error) {
+        if (
+          !(error instanceof XSearchRequestError) ||
+          !error.retryable ||
+          attempt >= this.#maxAttempts
+        ) {
+          throw error;
+        }
+        await this.#sleep(error.retryAfterMs ?? DEFAULT_RETRY_DELAY_MS);
+      }
+    }
+    throw new XSearchRequestError("request_failed");
+  }
+
+  async #searchOnce(
+    intent: XSearchIntent,
+    observedAtMs: number,
+  ): Promise<string> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.#timeoutMs);
     const tool: Record<string, unknown> = { type: "x_search" };
@@ -470,19 +553,37 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
             },
           ],
           tools: [tool],
+          max_turns: this.#maxTurns,
           max_output_tokens: 700,
           store: false,
         }),
         signal: controller.signal,
       });
       if (response.status === 401 || response.status === 403) {
-        throw new XSearchRequestError("authentication_failed");
+        throw new XSearchRequestError("authentication_failed", {
+          httpStatus: response.status,
+        });
       }
-      if (response.status === 429) throw new XSearchRequestError("rate_limited");
+      if (response.status === 429) {
+        const retryAfterMs = retryAfterMilliseconds(response);
+        throw new XSearchRequestError("rate_limited", {
+          retryable:
+            retryAfterMs === undefined || retryAfterMs <= MAX_RETRY_AFTER_MS,
+          ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+          httpStatus: response.status,
+        });
+      }
       if (response.status >= 500) {
-        throw new XSearchRequestError("upstream_unavailable");
+        throw new XSearchRequestError("upstream_unavailable", {
+          retryable: true,
+          httpStatus: response.status,
+        });
       }
-      if (!response.ok) throw new XSearchRequestError("request_failed");
+      if (!response.ok) {
+        throw new XSearchRequestError("request_failed", {
+          httpStatus: response.status,
+        });
+      }
 
       const contentLength = Number(response.headers.get("content-length") ?? "0");
       if (contentLength > MAX_RESPONSE_BYTES) {
@@ -518,7 +619,7 @@ export class XaiXSearchFeature implements GatewayXSearchFeature {
       if (error instanceof Error && error.name === "AbortError") {
         throw new XSearchRequestError("timeout");
       }
-      throw new XSearchRequestError("network_failure");
+      throw new XSearchRequestError("network_failure", { retryable: true });
     } finally {
       clearTimeout(timeout);
     }

--- a/runtime/tests/gateway/x-search.test.ts
+++ b/runtime/tests/gateway/x-search.test.ts
@@ -120,12 +120,14 @@ describe("XaiXSearchFeature", () => {
     const body = JSON.parse(String(calls[0]?.init?.body)) as {
       tools: readonly Record<string, unknown>[];
       input: readonly { role: string; content: string }[];
+      max_turns?: number;
       store?: boolean;
     };
     expect(body.tools).toEqual([
       { type: "x_search", allowed_x_handles: ["example"] },
     ]);
     expect(JSON.stringify(body.tools)).not.toMatch(/post|like|follow|delete/i);
+    expect(body.max_turns).toBe(2);
     expect(body.store).toBe(false);
     expect(body.input).toHaveLength(2);
     expect(body.input[0]?.role).toBe("system");
@@ -442,7 +444,7 @@ describe("XaiXSearchFeature", () => {
     expect(replies[0]).toContain("server-side credential needs attention");
     expect(replies.join("\n")).not.toContain("account secret");
     expect(logs).toEqual([
-      "gateway x-search: read failed (authentication_failed)",
+      "gateway x-search: read failed (authentication_failed, status=401)",
     ]);
   });
 
@@ -492,6 +494,7 @@ describe("XaiXSearchFeature", () => {
       const feature = new XaiXSearchFeature({
         apiKey: "xai-test-key-that-is-long-enough",
         usageFile: join(home, "usage.json"),
+        maxAttempts: 1,
         fetchImpl: (async () =>
           new Response("provider detail must stay private", { status })) as typeof fetch,
         log: (line) => logs.push(line),
@@ -510,8 +513,71 @@ describe("XaiXSearchFeature", () => {
       expect(replies[0]).toContain(expectedReply);
       expect(replies[0]).not.toContain("provider detail");
       expect(logs).toEqual([
-        `gateway x-search: read failed (${expectedCode})`,
+        `gateway x-search: read failed (${expectedCode}, status=${status})`,
       ]);
     },
   );
+
+  test("retries one transient xAI failure and returns the cited result", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("temporary", { status: 503 }))
+      .mockResolvedValueOnce(xaiResponse());
+    const sleep = vi.fn(async () => {});
+    const logs: string[] = [];
+    const replies: string[] = [];
+    const feature = new XaiXSearchFeature({
+      apiKey: "xai-test-key-that-is-long-enough",
+      usageFile: join(home, "usage.json"),
+      fetchImpl,
+      sleep,
+      log: (line) => logs.push(line),
+    });
+
+    await feature.handle({
+      text: "latest post from @example",
+      channelId: "telegram",
+      peerId: "alice",
+      reply: async (text) => {
+        replies.push(text);
+        return "out";
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(750);
+    expect(replies[0]).toContain("https://x.com/example/status/123");
+    expect(logs).toEqual([]);
+  });
+
+  test("does not retry a long provider rate-limit delay", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response("slow down", {
+        status: 429,
+        headers: { "retry-after": "30" },
+      }),
+    );
+    const sleep = vi.fn(async () => {});
+    const replies: string[] = [];
+    const feature = new XaiXSearchFeature({
+      apiKey: "xai-test-key-that-is-long-enough",
+      usageFile: join(home, "usage.json"),
+      fetchImpl: fetchImpl as typeof fetch,
+      sleep,
+    });
+
+    await feature.handle({
+      text: "latest post from @example",
+      channelId: "telegram",
+      peerId: "alice",
+      reply: async (text) => {
+        replies.push(text);
+        return "out";
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(replies[0]).toContain("rate-limited upstream");
+  });
 });


### PR DESCRIPTION
## Summary
- use xAI built-in `x_search` with `max_turns: 2` for quick Telegram lookups
- retry one transient network, short 429, or HTTP 5xx failure without retrying auth, timeout, or unverifiable output
- expose bounded max-turn/max-attempt env controls and document why Docs MCP/Remote MCP are not the X data path
- retain citation enforcement, read-only tool scope, redacted errors, and private credentials

## Verification
- `npm run test --workspace=@tetsuo-ai/runtime -- tests/gateway/x-search.test.ts --reporter=dot` (25 passed)
- `npm run test --workspace=@tetsuo-ai/runtime -- tests/gateway --reporter=dot` (201 passed)
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm run build --workspace=@tetsuo-ai/runtime`

The unrelated full TUI suite was stopped under the non-interactive PTY after its raw-mode fixtures stayed open; no affected gateway tests failed.