### PR TITLE
feat(gateway): inbound webhooks — POST /hooks/agent (task 17)

### DIFF
--- a/docs/migrate-from-openclaw.md
+++ b/docs/migrate-from-openclaw.md
@@ -26,7 +26,7 @@ Reuse the same provider credential you used with OpenClaw (BYOK env vars or
 | `MEMORY.md` + daily notes | `memory/` + memdir | Automatic project/session memory with aging + retrieval |
 | Skills (`SKILL.md` dirs, ClawHub) | Skills + plugins | Bundled + local skills; plugins add commands/tools/hooks/MCP via `agenc plugin` and `/plugins`. No public registry yet — by design until publishing is signed + attested |
 | Cron (`openclaw cron`) | Cron tools + live scheduler | Create/list/delete from the agent; jobs re-arm on daemon restart. Delivery-routed jobs (`announceChannel`/`webhook` on CronCreate) run in isolated gateway sessions and post their result to a channel or webhook |
-| Webhooks (`/hooks/agent`) | Roadmap | Planned with header-only bearer auth |
+| Webhooks (`/hooks/agent`) | Shipped | Same endpoint shape: `agenc gateway run --hooks` (or gateway config `hooks.enabled`) serves loopback `POST /hooks/agent` with header-only bearer auth — query-string tokens are rejected outright. `message`/`name`/`agent`/`sessionKey`/`deliver` params; `deliver` streams the result to any running channel, no `deliver` returns it in the response. Payloads ride the untrusted-content framing and the `[budget]` envelope; `agenc security audit` flags enabled-without-token |
 | `SOUL.md` / `IDENTITY.md` persona | Shipped | Same convention, same filenames — see "Persona workspace files" below |
 | Heartbeat (`HEARTBEAT.md`) | Shipped | `agenc gateway run --heartbeat` (or `[heartbeat]` config): periodic turns read `HEARTBEAT.md`, deliver only non-OK results to a channel, and every tick is gated by the `[budget]` daily/monthly spend envelope — a refusal pauses instead of silently burning |
 | Channels (Telegram, WhatsApp, …) | Shipped (Telegram, Discord, Slack, WebChat, stdio) | `agenc gateway run`; pairing-gated, with in-channel token approvals and untrusted-content framing. Discord rides the official Gateway WS + REST (`AGENC_DISCORD_BOT_TOKEN`); Slack rides Socket Mode — no inbound listener (`AGENC_SLACK_BOT_TOKEN` + `AGENC_SLACK_APP_TOKEN`); guild/channel messages are mention-gated by default. Signal and WhatsApp still roadmap |
@@ -72,7 +72,7 @@ ritual completion apply from the next new conversation. Copy your existing
 
 ## What you lose today (roadmap, in priority order)
 
-Webhooks, browser automation, a mobile app, and channel breadth beyond
+Browser automation, a mobile app, and channel breadth beyond
 Telegram/Discord/Slack/WebChat (Signal, WhatsApp). If any of these is your
 daily driver, run both: several of the gaps are next on the roadmap, and the
 daemon architecture is built for exactly those clients.

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -25,6 +25,7 @@ export type AgenCGatewayCliCommand =
       readonly stdio: boolean;
       readonly webchat: boolean;
       readonly heartbeat: boolean;
+      readonly hooks: boolean;
     }
   | { readonly kind: "status"; readonly json: boolean }
   | { readonly kind: "pairing-list"; readonly json: boolean }
@@ -41,7 +42,7 @@ export function formatAgenCGatewayCliHelpText(): string {
     "agenc gateway — inspect and operate the channel gateway",
     "",
     "Usage:",
-    "  agenc gateway run [--stdio] [--webchat] [--heartbeat]",
+    "  agenc gateway run [--stdio] [--webchat] [--heartbeat] [--hooks]",
     "                                        Start the gateway. --stdio enables",
     "                                        the local dev channel; --webchat a",
     "                                        loopback token-gated browser UI;",
@@ -78,6 +79,7 @@ export function parseAgenCGatewayCliArgs(
       stdio: rest.includes("--stdio"),
       webchat: rest.includes("--webchat"),
       heartbeat: rest.includes("--heartbeat"),
+      hooks: rest.includes("--hooks"),
     };
   }
   if (positional[0] === "status") {
@@ -200,6 +202,7 @@ export async function runAgenCGatewayCli(
         stdio: command.stdio,
         webchat: command.webchat,
         heartbeat: command.heartbeat,
+        hooks: command.hooks,
         log: (line) => stderr(line),
       });
     } catch (error) {

--- a/runtime/src/bin/security-cli.ts
+++ b/runtime/src/bin/security-cli.ts
@@ -13,12 +13,14 @@
  *   sensitive-file-perms     auth.json/daemon.cookie/config/vaults [fixable]
  *   config-integrity         config.toml unparseable (falls back to defaults)
  *   default-permission-mode  configured approval-bypass default    (warn)
+ *   hooks-exposure           inbound webhooks enabled without a bearer
+ *                            token, or bound non-loopback (task 17)
  *
  * The check registry is deliberately extensible: channel DM policies
- * (task 6), webhook token posture (task 17), and skill/plugin provenance
- * (task 26) land here as those surfaces ship.
+ * (task 6) and skill/plugin provenance (task 26) land here as those
+ * surfaces ship.
  */
-import { chmodSync, readdirSync, statSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { resolveAgencHome } from "../config/env.js";
@@ -265,12 +267,97 @@ const checkDefaultPermissionMode: SecurityCheck = (ctx) => {
   ];
 };
 
+/**
+ * Inbound webhooks (task 17): enabled without a reachable bearer token is
+ * critical — the endpoint would refuse to start, but the configuration
+ * expresses an unauthenticated-automation intent that must not survive
+ * unnoticed. A non-loopback bind is the daemon-ws exposure class.
+ */
+const checkHooksExposure: SecurityCheck = (ctx) => {
+  const configPath = join(ctx.agencHome, "gateway", "config.json");
+  let hooks: Record<string, unknown> | null = null;
+  try {
+    if (existsSync(configPath)) {
+      const raw = JSON.parse(readFileSync(configPath, "utf8")) as {
+        hooks?: unknown;
+      };
+      if (typeof raw.hooks === "object" && raw.hooks !== null) {
+        hooks = raw.hooks as Record<string, unknown>;
+      }
+    }
+  } catch {
+    // Unparseable gateway config is its own (fail-closed) problem; the
+    // hooks endpoint cannot be enabled by a file that does not parse.
+    hooks = null;
+  }
+  if (hooks === null || hooks.enabled !== true) {
+    return [
+      {
+        id: "hooks-exposure",
+        title: "Inbound webhooks disabled",
+        severity: "ok",
+        detail: "The /hooks/agent endpoint is not enabled in gateway config.",
+        fixable: false,
+      },
+    ];
+  }
+
+  const findings: SecurityFinding[] = [];
+  const envToken = ctx.env.AGENC_HOOKS_TOKEN?.trim() ?? "";
+  let fileToken = "";
+  try {
+    const tokenPath = join(ctx.agencHome, "gateway", "hooks-token");
+    if (existsSync(tokenPath)) {
+      fileToken = readFileSync(tokenPath, "utf8").trim();
+    }
+  } catch {
+    fileToken = "";
+  }
+  if (envToken.length < 16 && fileToken.length < 16) {
+    findings.push({
+      id: "hooks-exposure",
+      title: "Inbound webhooks enabled without a bearer token",
+      severity: "critical",
+      detail:
+        "gateway/config.json enables the /hooks/agent endpoint but neither AGENC_HOOKS_TOKEN nor gateway/hooks-token provides a token (>=16 chars). The endpoint will mint one on next start, but until callers hold a token this configuration expresses unauthenticated-automation intent.",
+      remediation:
+        "Set AGENC_HOOKS_TOKEN or start `agenc gateway run` once to mint gateway/hooks-token, then configure callers with it.",
+      fixable: false,
+    });
+  }
+
+  const host = typeof hooks.host === "string" ? hooks.host : "";
+  if (host.length > 0 && !isLoopbackHostValue(host)) {
+    findings.push({
+      id: "hooks-exposure:bind",
+      title: "Inbound webhooks host is not loopback",
+      severity: "critical",
+      detail: `gateway/config.json binds /hooks/agent to '${host}'. An exposed automation endpoint on an agent host is the daemon-exposure disaster class.`,
+      remediation:
+        "Bind 127.0.0.1 and reach it via a tailnet or SSH tunnel instead.",
+      fixable: false,
+    });
+  }
+
+  if (findings.length === 0) {
+    findings.push({
+      id: "hooks-exposure",
+      title: "Inbound webhooks enabled with token, loopback-bound",
+      severity: "ok",
+      detail: "The /hooks/agent endpoint has a bearer token and a loopback bind.",
+      fixable: false,
+    });
+  }
+  return findings;
+};
+
 export const SECURITY_CHECKS: readonly SecurityCheck[] = [
   checkDaemonWsExposure,
   checkHomeDirPerms,
   checkSensitiveFilePerms,
   checkConfigIntegrity,
   checkDefaultPermissionMode,
+  checkHooksExposure,
 ];
 
 export function runSecurityChecks(

--- a/runtime/src/gateway/config.ts
+++ b/runtime/src/gateway/config.ts
@@ -16,6 +16,7 @@ import {
   type GatewayBinding,
   type GatewayChannelPolicy,
   type GatewayConfig,
+  type GatewayHooksConfig,
 } from "./types.js";
 
 const DM_POLICIES: readonly DmPolicy[] = [
@@ -66,6 +67,40 @@ function normalizeBinding(
   };
 }
 
+/**
+ * Normalize the `hooks` section fail-closed: anything malformed disables the
+ * endpoint (never coerced into an enabled state), and a non-loopback bind
+ * survives only as expressed intent — the server itself still refuses it
+ * without `allowNonLoopback`.
+ */
+function normalizeHooksConfig(
+  value: unknown,
+  onWarn: (m: string) => void,
+): GatewayHooksConfig | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null) {
+    onWarn("gateway: invalid hooks section — hooks disabled");
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.enabled !== true) return { enabled: false };
+  const port =
+    typeof record.port === "number" &&
+    Number.isInteger(record.port) &&
+    record.port >= 0 &&
+    record.port <= 65535
+      ? record.port
+      : undefined;
+  return {
+    enabled: true,
+    ...(typeof record.host === "string" && record.host.length > 0
+      ? { host: record.host }
+      : {}),
+    ...(port !== undefined ? { port } : {}),
+    ...(record.allowNonLoopback === true ? { allowNonLoopback: true } : {}),
+  };
+}
+
 export function resolveGatewayConfigPath(agencHome: string): string {
   return join(agencHome, "gateway", "config.json");
 }
@@ -109,6 +144,8 @@ export function loadGatewayConfig(
     }
   }
 
+  const hooks = normalizeHooksConfig(record.hooks, onWarn);
+
   return {
     channels,
     bindings,
@@ -116,5 +153,6 @@ export function loadGatewayConfig(
       typeof record.defaultAgent === "string" && record.defaultAgent.length > 0
         ? record.defaultAgent
         : DEFAULT_GATEWAY_CONFIG.defaultAgent,
+    ...(hooks !== undefined ? { hooks } : {}),
   };
 }

--- a/runtime/src/gateway/hooks.ts
+++ b/runtime/src/gateway/hooks.ts
@@ -1,0 +1,435 @@
+/**
+ * Inbound webhooks — `POST /hooks/agent` (TODO task 17).
+ *
+ * A loopback HTTP trigger surface: an authenticated POST turns its `message`
+ * into ONE agent turn, optionally delivering the result to a channel. This is
+ * the automation entry point (CI alerts, monitors, home automation → agent →
+ * Telegram/Discord/Slack reply), not a conversation surface — there is no
+ * pairing dance because the bearer token IS the auth.
+ *
+ * Security posture (the load-bearing part):
+ *  - DISABLED by default. Starts only when enabled via gateway config or the
+ *    `--hooks` flag, and always with a token.
+ *  - Binds loopback and REFUSES a non-loopback host without an explicit
+ *    `allowNonLoopback` (prefer a tailnet/SSH tunnel).
+ *  - Bearer token in the `Authorization` header ONLY, compared with
+ *    `timingSafeEqual`. A token-looking QUERY parameter is rejected outright
+ *    (401) even when the header is also valid: query strings leak into shell
+ *    history, proxy logs, and browser history — refusing teaches callers the
+ *    safe shape. `agenc security audit` flags hooks-enabled-without-token.
+ *  - The payload `message` is untrusted work data: it is sanitized + framed
+ *    (task-11 machinery) before it ever reaches `session.prompt`, exactly
+ *    like channel text. It can never change permission mode or tool policy;
+ *    hook turns DENY permission requests (autonomous, nobody watching).
+ *  - Hook turns are autonomous spend: every request passes the task-15
+ *    budget envelope (admit → turn → reconcile); a refusal is a 429, never
+ *    a silent skip or silent spend.
+ *
+ * Request:  POST /hooks/agent
+ *           Authorization: Bearer <token>
+ *           { "message": "...",            required — the prompt text
+ *             "name": "ci",                optional hook identity (peer id)
+ *             "agent": "default",          optional session-scope label
+ *             "sessionKey": "deploys",     optional continuity key — same key
+ *                                          = same daemon session
+ *             "deliver": { "channel": "telegram", "to": "<chat>" } }
+ * Response: with `deliver` → 202 immediately; the turn runs async and the
+ *           final message streams to that channel (edit-in-place capable).
+ *           without `deliver` → waits for the turn, 200 with
+ *           { ok, sessionKey, finalMessage, stopReason }.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { isIP, type AddressInfo } from "node:net";
+
+import type { AgenCConfig } from "../config/schema.js";
+import {
+  BudgetEnforcer,
+  BudgetLedger,
+  createModelPriceResolver,
+  resolveBudgetPolicy,
+} from "../budget/index.js";
+import { SessionRouter } from "./session-router.js";
+import { frameChannelMessage } from "./untrusted.js";
+import type { ChannelAdapter, GatewayDaemonClient } from "./types.js";
+
+export const HOOKS_CHANNEL_ID = "hooks";
+export const HOOKS_PATH = "/hooks/agent";
+/** Default bind port when enabled via config without an explicit port. */
+export const HOOKS_DEFAULT_PORT = 8377;
+
+/** Raw request body cap. */
+const MAX_BODY_BYTES = 64 * 1024;
+/** Post-parse message cap (chars). */
+const MAX_MESSAGE_CHARS = 32 * 1024;
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+
+/** Identifier fields (name/agent/sessionKey) share one conservative shape. */
+const IDENTIFIER_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+/**
+ * Query parameters that smell like credentials. Their PRESENCE fails the
+ * request — tokens must never ride the query string.
+ */
+const FORBIDDEN_QUERY_PARAMS = [
+  "token",
+  "access_token",
+  "auth",
+  "bearer",
+  "key",
+  "apikey",
+  "api_key",
+] as const;
+
+function isLoopbackHost(host: string): boolean {
+  const h = host.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost" || h === "::1") return true;
+  const fam = isIP(h);
+  if (fam === 4) return h.startsWith("127.");
+  return false;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/** Deterministic ~chars/4 token estimate (mirrors heartbeat/cron). */
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+/** Swallows channel output for no-deliver turns. */
+const NULL_ADAPTER: ChannelAdapter = {
+  id: "hooks-null",
+  supportsEdit: false,
+  async start() {},
+  async stop() {},
+  async send() {
+    return "hooks-null";
+  },
+};
+
+export interface HooksServerOptions {
+  readonly agencHome: string;
+  readonly token: string;
+  readonly client: GatewayDaemonClient;
+  /** Channel adapters available as `deliver` targets. */
+  readonly adapters: readonly ChannelAdapter[];
+  /** Main config (budget envelope). */
+  readonly config: AgenCConfig;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Session-scope label when the request has no `agent`. */
+  readonly defaultAgent?: string;
+  readonly host?: string;
+  readonly port?: number;
+  readonly allowNonLoopback?: boolean;
+  readonly log?: (line: string) => void;
+}
+
+interface HookRequest {
+  readonly message: string;
+  readonly name: string;
+  readonly agent: string;
+  readonly sessionKey: string;
+  readonly deliver?: { readonly channel: string; readonly to: string };
+}
+
+export class HooksServer {
+  readonly #token: string;
+  readonly #host: string;
+  readonly #port: number;
+  readonly #log: (line: string) => void;
+  readonly #router: SessionRouter;
+  readonly #adaptersById: Map<string, ChannelAdapter>;
+  readonly #enforcer: BudgetEnforcer;
+  readonly #defaultAgent: string;
+  #server: Server | null = null;
+  #boundPort = 0;
+
+  constructor(options: HooksServerOptions) {
+    this.#token = options.token;
+    this.#host = options.host ?? "127.0.0.1";
+    this.#port = options.port ?? HOOKS_DEFAULT_PORT;
+    this.#log = options.log ?? (() => {});
+    this.#defaultAgent = options.defaultAgent ?? "default";
+    if (!isLoopbackHost(this.#host) && options.allowNonLoopback !== true) {
+      throw new Error(
+        `hooks: refusing non-loopback host '${this.#host}' without allowNonLoopback (prefer a tailnet/SSH tunnel)`,
+      );
+    }
+    if (this.#token.length < 16) {
+      throw new Error("hooks: token must be at least 16 characters");
+    }
+    this.#router = new SessionRouter({
+      agencHome: options.agencHome,
+      client: options.client,
+    });
+    this.#adaptersById = new Map(options.adapters.map((a) => [a.id, a]));
+    const { policy } = resolveBudgetPolicy(options.config.budget, options.env ?? {});
+    this.#enforcer = new BudgetEnforcer({
+      policy,
+      ledger: new BudgetLedger({ agencHome: options.agencHome }),
+      priceOf: createModelPriceResolver(),
+      notify: (e) => this.#log(`hooks/budget: ${e.message}`),
+    });
+  }
+
+  get port(): number {
+    return this.#boundPort;
+  }
+
+  async start(): Promise<void> {
+    this.#server = createServer((req, res) => {
+      this.#handle(req, res).catch((error: unknown) => {
+        this.#json(res, 500, { error: `hooks: ${String(error)}` });
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      const server = this.#server;
+      if (server === null) return reject(new Error("server not created"));
+      server.once("error", reject);
+      server.listen(this.#port, this.#host, () => {
+        const addr = server.address() as AddressInfo | null;
+        this.#boundPort = addr?.port ?? this.#port;
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    this.#log(
+      `hooks: POST http://${this.#host}:${this.#boundPort}${HOOKS_PATH} (bearer token required)`,
+    );
+  }
+
+  async stop(): Promise<void> {
+    const server = this.#server;
+    this.#server = null;
+    if (server !== null) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  #json(res: ServerResponse, status: number, body: Record<string, unknown>): void {
+    if (res.headersSent) return;
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify(body));
+  }
+
+  async #handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+
+    // Header-only auth, checked FIRST: a token-looking query parameter fails
+    // the request outright — even alongside a valid header — because query
+    // strings leak into logs and histories. Never compared, never accepted.
+    for (const param of FORBIDDEN_QUERY_PARAMS) {
+      if (url.searchParams.has(param)) {
+        this.#log("hooks: rejected request carrying a query-string credential");
+        this.#json(res, 401, {
+          error:
+            "credentials must be sent via 'Authorization: Bearer <token>' only — never in the query string",
+        });
+        return;
+      }
+    }
+    const auth = req.headers.authorization ?? "";
+    const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    if (bearer.length === 0 || !safeEqual(bearer, this.#token)) {
+      this.#json(res, 401, { error: "missing or invalid bearer token" });
+      return;
+    }
+
+    if (url.pathname !== HOOKS_PATH) {
+      this.#json(res, 404, { error: `unknown path (expected ${HOOKS_PATH})` });
+      return;
+    }
+    if (req.method !== "POST") {
+      this.#json(res, 405, { error: "POST only" });
+      return;
+    }
+
+    const body = await this.#readBody(req);
+    if (body === null) {
+      this.#json(res, 413, { error: `body exceeds ${MAX_BODY_BYTES} bytes` });
+      return;
+    }
+    const parsed = this.#parseRequest(body);
+    if (typeof parsed === "string") {
+      this.#json(res, 400, { error: parsed });
+      return;
+    }
+
+    const deliverAdapter =
+      parsed.deliver !== undefined
+        ? this.#adaptersById.get(parsed.deliver.channel)
+        : undefined;
+    if (parsed.deliver !== undefined && deliverAdapter === undefined) {
+      this.#json(res, 400, {
+        error: `deliver.channel '${parsed.deliver.channel}' is not a running channel (have: ${[...this.#adaptersById.keys()].join(", ") || "none"})`,
+      });
+      return;
+    }
+
+    // Budget pre-flight: hook turns are autonomous spend. A refusal is a
+    // visible 429, never a silent skip.
+    const admit = this.#enforcer.admit({
+      agentId: `hook:${parsed.name}`,
+      model: "unknown",
+      autonomous: true,
+      estInputTokens: estimateTokens(parsed.message),
+      maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    });
+    if (!admit.ok) {
+      this.#json(res, 429, { error: `budget: ${admit.message}` });
+      return;
+    }
+
+    // The payload is untrusted work data — sanitize + frame (task 11)
+    // before it reaches session.prompt, exactly like channel text.
+    const framedText = frameChannelMessage({
+      channelId: HOOKS_CHANNEL_ID,
+      peerId: `hook:${parsed.name}`,
+      text: parsed.message,
+    });
+    const key = SessionRouter.conversationKey({
+      channelId: HOOKS_CHANNEL_ID,
+      agent: parsed.agent,
+      conversationId: parsed.sessionKey,
+    });
+
+    const runTurn = () =>
+      this.#router.runTurn({
+        key,
+        text: framedText,
+        adapter: deliverAdapter ?? NULL_ADAPTER,
+        conversationId: parsed.deliver?.to ?? parsed.sessionKey,
+        // Autonomous, nobody watching → deny permission requests (fail safe).
+        onPermissionRequest: async () => ({
+          behavior: "deny",
+          reason: "hook turns do not grant tool permissions",
+        }),
+      });
+
+    if (deliverAdapter !== undefined) {
+      // Fire-and-deliver: acknowledge now, stream the turn to the channel.
+      this.#json(res, 202, { ok: true, sessionKey: parsed.sessionKey });
+      try {
+        const result = await runTurn();
+        this.#enforcer.reconcile(
+          admit.hold,
+          result.usage ?? { inputTokens: 0, outputTokens: 0 },
+        );
+        this.#log(`hooks: '${parsed.name}' delivered (${result.stopReason})`);
+      } catch (error) {
+        this.#enforcer.reconcile(admit.hold, { inputTokens: 0, outputTokens: 0 });
+        this.#log(`hooks: '${parsed.name}' turn failed: ${String(error)}`);
+      }
+      return;
+    }
+
+    // Synchronous mode: the caller wants the answer in the response.
+    try {
+      const result = await runTurn();
+      this.#enforcer.reconcile(
+        admit.hold,
+        result.usage ?? { inputTokens: 0, outputTokens: 0 },
+      );
+      this.#json(res, 200, {
+        ok: true,
+        sessionKey: parsed.sessionKey,
+        finalMessage: result.finalMessage,
+        stopReason: result.stopReason,
+      });
+    } catch (error) {
+      this.#enforcer.reconcile(admit.hold, { inputTokens: 0, outputTokens: 0 });
+      this.#json(res, 500, { error: `turn failed: ${String(error)}` });
+    }
+  }
+
+  async #readBody(req: IncomingMessage): Promise<string | null> {
+    return new Promise((resolve, reject) => {
+      let size = 0;
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => {
+        size += chunk.length;
+        if (size > MAX_BODY_BYTES) {
+          req.removeAllListeners("data");
+          req.removeAllListeners("end");
+          resolve(null);
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      req.on("error", reject);
+    });
+  }
+
+  #parseRequest(body: string): HookRequest | string {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(body);
+    } catch {
+      return "body must be JSON";
+    }
+    if (typeof raw !== "object" || raw === null) return "body must be a JSON object";
+    const record = raw as Record<string, unknown>;
+
+    const message = record.message;
+    if (typeof message !== "string" || message.trim().length === 0) {
+      return "'message' (non-empty string) is required";
+    }
+    if (message.length > MAX_MESSAGE_CHARS) {
+      return `'message' exceeds ${MAX_MESSAGE_CHARS} characters`;
+    }
+
+    const identifier = (field: string, fallback: string): string | null => {
+      const value = record[field];
+      if (value === undefined) return fallback;
+      if (typeof value !== "string" || !IDENTIFIER_RE.test(value)) return null;
+      return value;
+    };
+    const name = identifier("name", "default");
+    if (name === null) return "'name' must match [A-Za-z0-9._-]{1,128}";
+    const agent = identifier("agent", this.#defaultAgent);
+    if (agent === null) return "'agent' must match [A-Za-z0-9._-]{1,128}";
+    const sessionKey = identifier("sessionKey", name);
+    if (sessionKey === null) {
+      return "'sessionKey' must match [A-Za-z0-9._-]{1,128}";
+    }
+
+    let deliver: HookRequest["deliver"];
+    if (record.deliver !== undefined) {
+      const d = record.deliver;
+      if (typeof d !== "object" || d === null) {
+        return "'deliver' must be an object {channel, to}";
+      }
+      const channel = (d as Record<string, unknown>).channel;
+      const to = (d as Record<string, unknown>).to;
+      if (
+        typeof channel !== "string" ||
+        channel.length === 0 ||
+        typeof to !== "string" ||
+        to.length === 0
+      ) {
+        return "'deliver' requires non-empty string fields 'channel' and 'to'";
+      }
+      deliver = { channel, to };
+    }
+
+    return {
+      message,
+      name,
+      agent,
+      sessionKey,
+      ...(deliver !== undefined ? { deliver } : {}),
+    };
+  }
+}

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -81,9 +81,17 @@ export {
 } from "./slack-channel.js";
 export {
   startGateway,
+  resolveHooksToken,
   type GatewayRunOptions,
   type GatewayRunHandle,
 } from "./run.js";
+export {
+  HooksServer,
+  HOOKS_CHANNEL_ID,
+  HOOKS_DEFAULT_PORT,
+  HOOKS_PATH,
+  type HooksServerOptions,
+} from "./hooks.js";
 export {
   createSdkDaemonClient,
   isDaemonAgentGoneError,

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -29,6 +29,7 @@ import {
   TelegramOwnerControl,
 } from "./control-plane.js";
 import { ChannelGateway } from "./gateway.js";
+import { HooksServer } from "./hooks.js";
 import { loadGatewayConfig } from "./config.js";
 import {
   DISCORD_CHANNEL_ID,
@@ -95,6 +96,10 @@ export interface GatewayRunOptions {
   readonly webchatHost?: string;
   readonly webchatPort?: number;
   readonly webchatAllowNonLoopback?: boolean;
+  /** Force the inbound-webhooks endpoint on for this run (else gateway config `hooks`). */
+  readonly hooks?: boolean;
+  readonly hooksHost?: string;
+  readonly hooksPort?: number;
   readonly log?: (line: string) => void;
   /** Test seam: inject a daemon client instead of connecting via the SDK. */
   readonly clientFactory?: () => Promise<GatewayDaemonClient>;
@@ -104,16 +109,17 @@ export interface GatewayRunOptions {
 }
 
 /**
- * Resolve the WebChat token: env override, else a persisted per-home token
- * (0600) so the browser URL survives restarts, else generate + persist.
+ * Resolve a gateway surface token: env override, else a persisted per-home
+ * token file (0600) so URLs/callers survive restarts, else generate+persist.
  */
-function resolveWebChatToken(
+function resolveGatewayToken(
   agencHome: string,
-  env: Readonly<Record<string, string | undefined>>,
+  fromEnv: string | undefined,
+  fileName: string,
 ): string {
-  const fromEnv = env.AGENC_WEBCHAT_TOKEN?.trim();
-  if (fromEnv !== undefined && fromEnv.length >= 16) return fromEnv;
-  const path = join(agencHome, "gateway", "webchat-token");
+  const envToken = fromEnv?.trim();
+  if (envToken !== undefined && envToken.length >= 16) return envToken;
+  const path = join(agencHome, "gateway", fileName);
   if (existsSync(path)) {
     const existing = readFileSync(path, "utf8").trim();
     if (existing.length >= 16) return existing;
@@ -123,6 +129,24 @@ function resolveWebChatToken(
   writeFileSync(path, token, { mode: 0o600 });
   return token;
 }
+
+function resolveWebChatToken(
+  agencHome: string,
+  env: Readonly<Record<string, string | undefined>>,
+): string {
+  return resolveGatewayToken(agencHome, env.AGENC_WEBCHAT_TOKEN, "webchat-token");
+}
+
+/** Persisted at gateway/hooks-token; AGENC_HOOKS_TOKEN overrides. */
+export function resolveHooksToken(
+  agencHome: string,
+  env: Readonly<Record<string, string | undefined>>,
+): string {
+  return resolveGatewayToken(agencHome, env.AGENC_HOOKS_TOKEN, "hooks-token");
+}
+
+/** On-disk hooks token file name (shared with the security audit). */
+export const HOOKS_TOKEN_FILENAME = "hooks-token";
 
 function envFlag(value: string | undefined): boolean {
   return value === "1" || value === "true" || value === "yes" || value === "on";
@@ -137,6 +161,7 @@ const GATEWAY_SECRET_ENV_NAMES = [
   "AGENC_DISCORD_BOT_TOKEN",
   "AGENC_SLACK_BOT_TOKEN",
   "AGENC_SLACK_APP_TOKEN",
+  "AGENC_HOOKS_TOKEN",
 ] as const;
 
 /** Keep gateway transport/data credentials out of an autostarted agent daemon. */
@@ -217,6 +242,8 @@ export interface GatewayRunHandle {
   readonly channels: readonly string[];
   /** Operator URL (with token) when WebChat is running. */
   readonly webchatUrl?: string;
+  /** Bound port when the inbound-webhooks endpoint is running. */
+  readonly hooksPort?: number;
   stop(): Promise<void>;
 }
 
@@ -650,13 +677,52 @@ export async function startGateway(
     log(`heartbeat: failed to start (continuing without it): ${String(error)}`);
   }
 
+  // Inbound webhooks (task 17): disabled by default; enabled via the gateway
+  // config `hooks` section or the --hooks flag. Loopback + bearer token; the
+  // payload rides the task-11 untrusted framing and the task-15 budget.
+  let hooksServer: HooksServer | null = null;
+  const hooksConfig = config.hooks;
+  if (options.hooks === true || hooksConfig?.enabled === true) {
+    try {
+      hooksServer = new HooksServer({
+        agencHome: options.agencHome,
+        token: resolveHooksToken(options.agencHome, env),
+        client,
+        adapters,
+        config: mainConfigLoaded,
+        env,
+        defaultAgent: config.defaultAgent,
+        ...(options.hooksHost !== undefined
+          ? { host: options.hooksHost }
+          : hooksConfig?.host !== undefined
+            ? { host: hooksConfig.host }
+            : {}),
+        ...(options.hooksPort !== undefined
+          ? { port: options.hooksPort }
+          : hooksConfig?.port !== undefined
+            ? { port: hooksConfig.port }
+            : {}),
+        ...(hooksConfig?.allowNonLoopback === true
+          ? { allowNonLoopback: true }
+          : {}),
+        log,
+      });
+      await hooksServer.start();
+    } catch (error) {
+      hooksServer = null;
+      log(`hooks: failed to start (continuing without them): ${String(error)}`);
+    }
+  }
+
   log(`gateway: running with channels: ${started.join(", ")}`);
 
   return {
     gateway,
     channels: started,
     ...(webchat !== undefined ? { webchatUrl: webchat.url } : {}),
+    ...(hooksServer !== null ? { hooksPort: hooksServer.port } : {}),
     async stop() {
+      if (hooksServer !== null) await hooksServer.stop();
       if (heartbeat !== null) await heartbeat.stop();
       if (cronDelivery !== null) await cronDelivery.stop();
       await gateway.stop();

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -177,12 +177,27 @@ export interface GatewayDaemonClient {
 // Gateway configuration
 // ---------------------------------------------------------------------------
 
+/**
+ * Inbound webhook endpoint config (task 17). Disabled unless `enabled` is
+ * explicitly true; the endpoint additionally requires a bearer token at
+ * start time and `agenc security audit` flags enabled-without-token.
+ */
+export interface GatewayHooksConfig {
+  readonly enabled: boolean;
+  readonly host?: string;
+  readonly port?: number;
+  /** Explicit opt-in required for any non-loopback bind. */
+  readonly allowNonLoopback?: boolean;
+}
+
 export interface GatewayConfig {
   /** Per-channel policy; a missing entry means the fail-closed default. */
   readonly channels: Readonly<Record<string, GatewayChannelPolicy>>;
   readonly bindings: readonly GatewayBinding[];
   /** Default agent label when no binding matches. */
   readonly defaultAgent: string;
+  /** Inbound webhooks; absent = disabled. */
+  readonly hooks?: GatewayHooksConfig;
 }
 
 /** Fail-closed defaults: pairing-gated DMs, empty allowlist. */

--- a/runtime/tests/bin/gateway-cli.test.ts
+++ b/runtime/tests/bin/gateway-cli.test.ts
@@ -23,22 +23,37 @@ describe("parseAgenCGatewayCliArgs", () => {
       text: formatAgenCGatewayCliHelpText(),
     });
   });
-  test("run + --stdio + --webchat + --heartbeat", () => {
+  test("run + --stdio + --webchat + --heartbeat + --hooks", () => {
     expect(parseAgenCGatewayCliArgs(["gateway", "run"])).toEqual({
       kind: "run",
       stdio: false,
       webchat: false,
       heartbeat: false,
+      hooks: false,
+    });
+    expect(parseAgenCGatewayCliArgs(["gateway", "run", "--hooks"])).toEqual({
+      kind: "run",
+      stdio: false,
+      webchat: false,
+      heartbeat: false,
+      hooks: true,
     });
     expect(parseAgenCGatewayCliArgs(["gateway", "run", "--stdio"])).toEqual({
       kind: "run",
       stdio: true,
       webchat: false,
       heartbeat: false,
+      hooks: false,
     });
     expect(
       parseAgenCGatewayCliArgs(["gateway", "run", "--webchat", "--heartbeat"]),
-    ).toEqual({ kind: "run", stdio: false, webchat: true, heartbeat: true });
+    ).toEqual({
+      kind: "run",
+      stdio: false,
+      webchat: true,
+      heartbeat: true,
+      hooks: false,
+    });
   });
   test("status + json", () => {
     expect(parseAgenCGatewayCliArgs(["gateway", "status"])).toEqual({

--- a/runtime/tests/bin/security-cli.test.ts
+++ b/runtime/tests/bin/security-cli.test.ts
@@ -176,6 +176,63 @@ describe("security audit against a temp home", () => {
     ).toBe("warn");
   });
 
+  test("hooks enabled WITHOUT a token is critical (task 17 acceptance)", async () => {
+    mkdirSync(join(home, "gateway"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(home, "gateway", "config.json"),
+      JSON.stringify({ hooks: { enabled: true } }),
+      { mode: 0o600 },
+    );
+    const report = await buildSecurityAuditReport({ env });
+    const finding = report.findings.find((f) => f.id === "hooks-exposure");
+    expect(finding?.severity).toBe("critical");
+    expect(finding?.title).toContain("without a bearer token");
+    expect(securityAuditExitCode(report)).toBe(1);
+  });
+
+  test("hooks enabled WITH a persisted token is ok", async () => {
+    mkdirSync(join(home, "gateway"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(home, "gateway", "config.json"),
+      JSON.stringify({ hooks: { enabled: true } }),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      join(home, "gateway", "hooks-token"),
+      "hooks-token-0123456789abcdef",
+      { mode: 0o600 },
+    );
+    const report = await buildSecurityAuditReport({ env });
+    expect(
+      report.findings.find((f) => f.id === "hooks-exposure")?.severity,
+    ).toBe("ok");
+  });
+
+  test("hooks bound non-loopback is critical even with a token", async () => {
+    mkdirSync(join(home, "gateway"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(home, "gateway", "config.json"),
+      JSON.stringify({ hooks: { enabled: true, host: "0.0.0.0" } }),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      join(home, "gateway", "hooks-token"),
+      "hooks-token-0123456789abcdef",
+      { mode: 0o600 },
+    );
+    const report = await buildSecurityAuditReport({ env });
+    expect(
+      report.findings.find((f) => f.id === "hooks-exposure:bind")?.severity,
+    ).toBe("critical");
+  });
+
+  test("hooks disabled (or absent) is ok", async () => {
+    const report = await buildSecurityAuditReport({ env });
+    expect(
+      report.findings.find((f) => f.id === "hooks-exposure")?.severity,
+    ).toBe("ok");
+  });
+
   test("runner: audit prints text and returns the exit code", async () => {
     chmodSync(home, 0o755);
     const out: string[] = [];

--- a/runtime/tests/gateway/hooks.test.ts
+++ b/runtime/tests/gateway/hooks.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Inbound webhooks (TODO task 17): POST /hooks/agent over a REAL loopback
+ * HTTP listener against a fake daemon client.
+ *
+ * Acceptance matrix: authed POST triggers a framed turn (with channel
+ * delivery via `deliver` or the final message in the response); missing,
+ * wrong, and QUERY-STRING tokens are rejected; non-loopback binds are
+ * refused; budget refusal is a visible 429; sessionKey/agent give session
+ * continuity/isolation through the SessionRouter.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { HooksServer, HOOKS_PATH } from "../../src/gateway/hooks.js";
+import { loadGatewayConfig } from "../../src/gateway/config.js";
+import { InMemoryChannelAdapter } from "../../src/gateway/test-channel.js";
+import type {
+  GatewayDaemonClient,
+  GatewayPromptHandlers,
+  GatewayPromptResult,
+  GatewaySession,
+  GatewaySessionCreateOptions,
+} from "../../src/gateway/types.js";
+import type { AgenCConfig } from "../../src/config/schema.js";
+
+const TOKEN = "hooks-test-token-0123456789";
+
+class EchoSession implements GatewaySession {
+  readonly sessionId: string;
+  readonly prompts: string[] = [];
+  constructor(id: string) {
+    this.sessionId = id;
+  }
+  async prompt(
+    text: string,
+    handlers: GatewayPromptHandlers,
+  ): Promise<GatewayPromptResult> {
+    this.prompts.push(text);
+    const reply = `echo: ${text.slice(-40)}`;
+    await handlers.onEvent({ type: "text", delta: reply });
+    return {
+      stopReason: "completed",
+      finalMessage: reply,
+      usage: { inputTokens: 5, outputTokens: 5 },
+    };
+  }
+}
+
+class FakeClient implements GatewayDaemonClient {
+  readonly sessions: EchoSession[] = [];
+  readonly labels: (string | undefined)[] = [];
+  #n = 0;
+  async createSession(
+    options?: GatewaySessionCreateOptions,
+  ): Promise<GatewaySession> {
+    this.labels.push(options?.label);
+    const s = new EchoSession(`s${++this.#n}`);
+    this.sessions.push(s);
+    return s;
+  }
+  async attachSession(id: string): Promise<GatewaySession> {
+    const s = new EchoSession(id);
+    this.sessions.push(s);
+    return s;
+  }
+  async close(): Promise<void> {}
+}
+
+describe("HooksServer", () => {
+  let home: string;
+  let client: FakeClient;
+  let mem: InMemoryChannelAdapter;
+  let server: HooksServer | null = null;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-hooks-"));
+    client = new FakeClient();
+    mem = new InMemoryChannelAdapter({ id: "mem" });
+  });
+  afterEach(async () => {
+    await server?.stop();
+    server = null;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  async function startServer(
+    overrides: Partial<ConstructorParameters<typeof HooksServer>[0]> = {},
+  ): Promise<string> {
+    server = new HooksServer({
+      agencHome: home,
+      token: TOKEN,
+      client,
+      adapters: [mem],
+      config: {} as unknown as AgenCConfig,
+      env: {},
+      port: 0, // ephemeral for tests
+      ...overrides,
+    });
+    await server.start();
+    return `http://127.0.0.1:${server.port}${HOOKS_PATH}`;
+  }
+
+  function post(
+    url: string,
+    body: unknown,
+    headers: Record<string, string> = { authorization: `Bearer ${TOKEN}` },
+  ): Promise<Response> {
+    return fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test("authed POST runs a framed turn and returns the final message", async () => {
+    const url = await startServer();
+    const res = await post(url, { message: "deploy finished, summarize" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.finalMessage).toContain("echo:");
+    expect(body.stopReason).toBe("completed");
+
+    // The payload went through the task-11 untrusted framing — never raw.
+    expect(client.sessions).toHaveLength(1);
+    const prompt = client.sessions[0].prompts[0];
+    expect(prompt).toContain("deploy finished, summarize");
+    expect(prompt).toContain('trust="external"');
+    expect(prompt).toContain('channel="hooks"');
+  });
+
+  test("deliver routes the turn to the channel and responds 202 immediately", async () => {
+    const url = await startServer();
+    const res = await post(url, {
+      message: "post the release notes",
+      name: "ci",
+      deliver: { channel: "mem", to: "ops-room" },
+    });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+
+    // The turn streams to the channel asynchronously.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(mem.lastText("ops-room")).toContain("echo:");
+  });
+
+  test("unknown deliver channel is a 400 before any turn runs", async () => {
+    const url = await startServer();
+    const res = await post(url, {
+      message: "x",
+      deliver: { channel: "nope", to: "y" },
+    });
+    expect(res.status).toBe(400);
+    expect(client.sessions).toHaveLength(0);
+  });
+
+  test("missing and wrong bearer tokens are 401; no turn runs", async () => {
+    const url = await startServer();
+    expect((await post(url, { message: "x" }, {})).status).toBe(401);
+    expect(
+      (await post(url, { message: "x" }, { authorization: "Bearer nope-nope-nope-nope" }))
+        .status,
+    ).toBe(401);
+    expect(client.sessions).toHaveLength(0);
+  });
+
+  test("a query-string token is rejected outright — even alongside a valid header", async () => {
+    const url = await startServer();
+    for (const param of ["token", "access_token", "api_key"]) {
+      const res = await post(`${url}?${param}=${TOKEN}`, { message: "x" });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(String(body.error)).toContain("never in the query string");
+    }
+    expect(client.sessions).toHaveLength(0);
+  });
+
+  test("wrong path is 404, wrong method is 405", async () => {
+    const url = await startServer();
+    const base = url.replace(HOOKS_PATH, "");
+    expect(
+      (
+        await fetch(`${base}/hooks/other`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${TOKEN}` },
+        })
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await fetch(url, {
+          method: "GET",
+          headers: { authorization: `Bearer ${TOKEN}` },
+        })
+      ).status,
+    ).toBe(405);
+  });
+
+  test("malformed bodies are 400s: bad JSON, missing message, bad identifiers", async () => {
+    const url = await startServer();
+    const raw = await fetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: "{not json",
+    });
+    expect(raw.status).toBe(400);
+    expect((await post(url, {})).status).toBe(400);
+    expect((await post(url, { message: "x", name: "bad name!" })).status).toBe(400);
+    expect(
+      (await post(url, { message: "x", deliver: { channel: "mem" } })).status,
+    ).toBe(400);
+    expect(client.sessions).toHaveLength(0);
+  });
+
+  test("sessionKey continuity: same key = same session; different agent isolates", async () => {
+    const url = await startServer();
+    await post(url, { message: "one", sessionKey: "deploys" });
+    await post(url, { message: "two", sessionKey: "deploys" });
+    expect(client.sessions).toHaveLength(1);
+    expect(client.sessions[0].prompts).toHaveLength(2);
+
+    await post(url, { message: "three", sessionKey: "deploys", agent: "ops" });
+    expect(client.sessions).toHaveLength(2);
+  });
+
+  test("budget refusal is a visible 429 and no turn runs", async () => {
+    const url = await startServer({
+      config: { budget: { enabled: true, daily_tokens: 1 } } as unknown as AgenCConfig,
+    });
+    const res = await post(url, { message: "expensive" });
+    expect(res.status).toBe(429);
+    expect(String(((await res.json()) as Record<string, unknown>).error)).toContain(
+      "budget",
+    );
+    expect(client.sessions).toHaveLength(0);
+  });
+
+  test("non-loopback host is refused without allowNonLoopback", () => {
+    expect(
+      () =>
+        new HooksServer({
+          agencHome: home,
+          token: TOKEN,
+          client,
+          adapters: [],
+          config: {} as unknown as AgenCConfig,
+          host: "0.0.0.0",
+        }),
+    ).toThrow(/non-loopback/);
+  });
+
+  test("short tokens are refused at construction", () => {
+    expect(
+      () =>
+        new HooksServer({
+          agencHome: home,
+          token: "short",
+          client,
+          adapters: [],
+          config: {} as unknown as AgenCConfig,
+        }),
+    ).toThrow(/16 characters/);
+  });
+
+  test("oversized bodies are 413", async () => {
+    const url = await startServer();
+    const res = await post(url, { message: "z".repeat(70 * 1024) });
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("gateway config hooks section", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-hooks-cfg-"));
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  function write(config: unknown): void {
+    mkdirSync(join(home, "gateway"), { recursive: true });
+    writeFileSync(join(home, "gateway", "config.json"), JSON.stringify(config));
+  }
+
+  test("valid hooks section parses; absent section stays undefined", () => {
+    write({ hooks: { enabled: true, host: "127.0.0.1", port: 9911 } });
+    expect(loadGatewayConfig({ agencHome: home }).hooks).toEqual({
+      enabled: true,
+      host: "127.0.0.1",
+      port: 9911,
+    });
+    write({});
+    expect(loadGatewayConfig({ agencHome: home }).hooks).toBeUndefined();
+  });
+
+  test("malformed hooks sections fail CLOSED (disabled, never coerced on)", () => {
+    write({ hooks: "yes please" });
+    expect(loadGatewayConfig({ agencHome: home }).hooks).toBeUndefined();
+    write({ hooks: { enabled: "true" } }); // string, not boolean
+    expect(loadGatewayConfig({ agencHome: home }).hooks).toEqual({ enabled: false });
+    write({ hooks: { enabled: true, port: 99999 } }); // invalid port dropped
+    expect(loadGatewayConfig({ agencHome: home }).hooks).toEqual({ enabled: true });
+  });
+});

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -3,7 +3,7 @@
 // Telegram adapter over a fake transport. This is the "prove the run loop"
 // coverage the stdio channel exists for.
 
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -142,6 +142,53 @@ describe("startGateway", () => {
     expect(handle.channels).toEqual(["stdio"]);
     await handle.stop();
     expect(client.closed).toBe(true);
+  });
+
+  test("hooks: --hooks mints a 0600 token, binds loopback, and an authed POST runs a turn end to end", async () => {
+    writeConfig({});
+    const client = new FakeClient();
+    const handle = await startGateway({
+      agencHome: home,
+      stdio: true,
+      hooks: true,
+      hooksPort: 0, // ephemeral for the test
+      clientFactory: async () => client,
+    });
+    expect(handle.hooksPort).toBeGreaterThan(0);
+
+    // The token was minted and persisted 0600 under gateway/.
+    const tokenPath = join(home, "gateway", "hooks-token");
+    const token = readFileSync(tokenPath, "utf8").trim();
+    expect(token.length).toBeGreaterThanOrEqual(16);
+    expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+
+    const url = `http://127.0.0.1:${handle.hooksPort}/hooks/agent`;
+    // Unauthenticated → rejected.
+    const denied = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "nope" }),
+    });
+    expect(denied.status).toBe(401);
+    // Authenticated → framed turn with the reply in the response.
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ message: "ship it", name: "ci" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(String(body.finalMessage)).toContain("echo:");
+    expect(client.sessions.at(-1)?.prompts.at(-1)).toContain('trust="external"');
+
+    await handle.stop();
+    // The listener is actually gone after stop.
+    await expect(
+      fetch(url, { method: "POST" }).then((r) => r.status),
+    ).rejects.toThrow();
   });
 
   test("discord via extraAdapters: allowlisted DM drives a real turn; unpaired gets challenged", async () => {


### PR DESCRIPTION
## What (TODO task 17)

A loopback HTTP trigger surface: an authenticated `POST /hooks/agent` turns its `message` into one agent turn, optionally streaming the result to any running channel. The automation entry point — CI alerts, monitors, home automation → agent → Telegram/Discord/Slack reply.

## Security posture (the load-bearing part)

- **Disabled by default.** Enabled via the gateway config `hooks` section (fail-closed normalization: anything malformed disables) or `agenc gateway run --hooks`.
- **Bearer token, header-only, `timingSafeEqual`.** A token-looking **query parameter** (`token`/`access_token`/`bearer`/`auth`/`key`/`apikey`/`api_key`) is rejected 401 **outright — even alongside a valid header** — because query strings leak into shell history, proxy logs, and browser history (mutation-proven).
- **Loopback bind**, refuses non-loopback without `allowNonLoopback` (webchat posture).
- Token minted 0600 at `gateway/hooks-token` (`AGENC_HOOKS_TOKEN` overrides) and **stripped from daemon autostart env** (`sanitizeGatewayDaemonEnv`).
- **Payload is untrusted work data**: sanitized + framed by the task-11 machinery before `session.prompt` (mutation-proven); permission requests are denied (autonomous).
- **Budget-gated**: every request passes the task-15 envelope (admit → turn → reconcile); a refusal is a visible 429, never silent spend/skip.
- **`agenc security audit`**: new `hooks-exposure` check — **enabled-without-token = critical** (the acceptance case) and non-loopback bind = critical.

## Semantics

`{message, name?, agent?, sessionKey?, deliver?: {channel, to}}` — `deliver` → **202** immediately, the turn streams to that channel (edit-in-place capable); no `deliver` → waits and returns **200 `{finalMessage, stopReason}`**. `sessionKey` gives daemon-session continuity via the SessionRouter (`hooks|<agent>|<sessionKey>`); `agent` isolates sessions.

## Live acceptance (real daemon, isolated home)

- 401 unauthed · 401 query-string token (logged rejection) · **202 + in-channel delivery** (`HOOK DELIVERY LIVE` streamed to the stdio channel, `hooks: 'smoke' delivered (completed)`) · **200 sync** with the final message · **audit critical** on a tokenless-enabled home. Token minted 0600, 32 chars.

## Tests

31 new: 14 endpoint (auth matrix, framing, delivery, continuity/isolation, budget 429, loopback/short-token refusal, 400/404/405/413) + 2 config normalization + 4 audit + 1 full run-loop e2e (--hooks mints token, authed POST end-to-end, listener gone after stop) + CLI parse coverage. Revert/mutation-proven ×4: query-token acceptance, unframed prompt, audit check vs HEAD, run.ts wiring vs HEAD.

## Gates

build ✓ · typecheck ✓ · vitest **14358 passed** (one real failure caught mid-gate — the CLI parse test needed the new `hooks` field — fixed; final run clean) · test:bun ✓ · agent-surface-contract ✓ (standalone; in-gate failure was the documented workbench load-flake at loadavg 17)