### PR TITLE
feat(onboarding): second/third-act onboarding — identity, channel, autonomy, recap (plan O-2..O-6)

### DIFF
--- a/docs/onboarding-plan-2026-07.md
+++ b/docs/onboarding-plan-2026-07.md
@@ -1,0 +1,354 @@
+# AgenC First-Run Onboarding — Complete Plan (2026-07)
+
+> **Audience:** an AI code assistant (or the owner) implementing onboarding
+> work in `agenc-core`. Same conventions as `docs/parity-roadmap-2026-07.md`;
+> workstreams below are written in TODO.md task format so they can be lifted
+> straight into the backlog.
+>
+> **Status of the ground this stands on (verified 2026-07-09):** Phase 0
+> install/onboard/audit shipped (PRs #1401–#1411). Phase 1–2 shipped live:
+> channels (Telegram #1413, Discord/Slack #1444, WebChat #1415, stdio),
+> personas (#1426), heartbeat (#1418), budgets (#1417), cron delivery
+> (#1420), inbound webhooks (#1453), gateway daemon agents (#1419). **None
+> of the Phase 1–2 surfaces has an onboarding path** — they are env vars,
+> hand-edited `gateway/config.json`, and flags, discoverable only by reading
+> docs. That is the gap this plan closes.
+
+---
+
+## 1. North star
+
+Two clocks, measured from `curl … | sh`:
+
+- **T2M — time to magic (first useful reply): < 5 minutes.** Already
+  roughly true for a user holding an API key; broken for a user with none.
+- **T2A — time to *agent* (a NAMED agent, reachable from your phone, with a
+  spend cap): < 15 minutes.** Today this takes an experienced operator an
+  afternoon of doc reading. This is the number that decides adoption,
+  because it is the moment AgenC stops being "another CLI chatbot" and
+  becomes the product the roadmap describes.
+
+The structural insight: **onboarding currently ends exactly where the
+product begins.** The wizard (`runtime/src/onboarding/Onboarding.tsx`:
+preflight → theme → provider → api-key → connection-test → security →
+terminal-setup) produces a configured *TUI*. The differentiated product —
+persistent identity + channels + bounded autonomy — starts one step later
+and has no guided path. The plan is therefore not "polish the wizard"; it
+is **give onboarding a second and third act**.
+
+## 2. Principles (non-negotiable)
+
+1. **Secure by default is a feature, not a toll.** Every step that opens a
+   surface shows its posture in one line ("loopback only · token minted ·
+   pairing required") and never asks the user to weaken anything. The
+   security audit runs green at the end of every act — we advertise that.
+2. **Budget before autonomy.** No step may enable heartbeat/cron/hooks
+   before a spend envelope exists. The wizard order enforces what the
+   runtime already enforces (task-15 admit gate).
+3. **The live smoke IS the step.** Every act ends by *doing the thing once
+   for real* (send yourself a Telegram message; watch the hook POST land),
+   exactly like this repo's landing discipline. A step that ends with
+   "now it's configured" instead of "you just saw it work" is not done.
+4. **Progressive disclosure, resumable forever.** Act 1 alone must leave a
+   complete, useful tool. Acts 2–3 are invitations, not gates; every act is
+   re-enterable via `agenc onboard <act>` at any time, and the wizard
+   remembers per-act completion (`projectOnboardingState.ts` already has
+   the persistence shape).
+5. **No phone-home.** Success is measured from local state and the existing
+   get.agenc.ag/Vercel edge (§7), never runtime telemetry. Privacy is the
+   brand.
+6. **One writer per file.** The wizard writes the same files the runtime
+   reads (`gateway/config.json`, `SOUL.md`, `HEARTBEAT.md`, `[budget]` in
+   config.toml) through the same loaders/normalizers — no parallel config
+   surface, no wizard-only formats.
+
+## 3. The journey (target state)
+
+```
+S0 Discover     get.agenc.ag / README / migration guides
+S1 Install      curl|sh · npm · brew · docker · VPS          [SHIPPED]
+S2 Converse     provider → key → first reply                 [SHIPPED, gaps]
+────────────────────────── Act 1 ends: a working assistant ─────────────
+S3 Identity     name the agent (BOOTSTRAP ritual) + SOUL.md  [runtime ✓, no scaffold]
+S4 Channel      Telegram/Discord/Slack/WebChat + pairing     [runtime ✓, no wizard]
+────────────────────────── Act 2 ends: YOUR agent, on your phone ───────
+S5 Guardrails   budget caps → heartbeat → cron → webhooks    [runtime ✓, no wizard]
+S6 Posture      gateway-aware audit recap + what-to-try card [audit ✓, recap missing]
+────────────────────────── Act 3 ends: a bounded autonomous agent ──────
+```
+
+### S0 — Discover (get.agenc.ag, README, guides)
+
+What exists: `get.agenc.ag` 307→installer, README, quickstart,
+migrate-from-openclaw/hermes guides (all current as of #1453).
+
+Target: the landing copy and README lead with the Act-2/Act-3 outcome
+("a named agent on your phone in 15 minutes, spend-capped"), show the
+three-command journey (`install → agenc onboard → agenc onboard channel`),
+and link one **end-to-end asciinema/GIF** of the full journey. The
+quickstart gains Act 2/Act 3 sections mirroring the wizard (§ workstream
+O-7). Keep the OpenClaw/Hermes migration guides as the comparison surface —
+they already convert the "what you gain/lose" question.
+
+### S1 — Install [SHIPPED — keep, one gap]
+
+`curl|sh` (sha256-verified, user service), `npm i -g`, brew tap, ghcr
+docker, VPS notes. **Gap:** Node ≥ 25 is a prerequisite the installer
+reports but does not solve. Workstream O-8 evaluates bundling a runtime
+(node SEA / bun compile) — L-sized, deferred unless install-drop data
+(§7) says the Node prerequisite is the cliff.
+
+### S2 — First conversation [SHIPPED, two gaps]
+
+What exists: the wizard's provider → api-key (live-verified) →
+connection-test path, 16 providers.
+
+**Gap A — the zero-key user bounces.** A user with no API key hits a wall
+at the provider step. Fix (O-1): a "no key?" branch that (a) autodetects
+local runtimes — probe `127.0.0.1:11434` (Ollama) and LM Studio's default
+port, offer detected models instantly; (b) offers guided key acquisition
+deep-links per provider; (c) once id.agenc.ag device-code flow is fixed
+(TODO task 33, external), offers hosted free-tier login. Local-runtime
+autodetect alone converts the "just evaluating" cohort.
+
+**Gap B — the first prompt is the user's problem.** After connection-test
+the wizard drops into an empty chat. Fix (O-1): end Act 1 by *running one
+turn for them* — a canned prompt against the current directory ("summarize
+what's in this folder" / repo-aware if `.git` present) so the first magic
+moment is guaranteed, not hoped for.
+
+### S3 — Identity: name your agent [runtime ✓ (#1426), scaffold missing]
+
+The BOOTSTRAP.md machinery already runs a one-time naming ritual and gates
+on IDENTITY.md mechanically — but nothing ever *writes* BOOTSTRAP.md, so no
+real user ever sees it. Fix (O-2): a wizard act that
+
+1. asks "where does your agent live?" (workspace dir, default `~/agent` —
+   created, git-init'd, trusted via the existing project-trust store);
+2. writes `SOUL.md` from 3 quick choices (tone: direct/warm/terse ·
+   verbosity · boundaries preset) and `USER.md` from name + a free line;
+3. writes `BOOTSTRAP.md` (naming ceremony template) and runs ONE turn in
+   that workspace so the agent introduces itself, names itself, writes
+   `IDENTITY.md`, and deletes `BOOTSTRAP.md` — the task-13 ritual, live;
+4. prints where the files live and that editing them is the API.
+
+This is ~an afternoon of work sitting on finished machinery, and it is the
+single highest emotional-payoff step in the journey: the user watches the
+agent choose its own name.
+
+### S4 — Channel: take it with you [runtime ✓ (#1413/#1444/#1415), wizard missing]
+
+The defining Act-2 step and the largest workstream (O-3):
+`agenc onboard channel` (also reachable from the main wizard):
+
+1. **Pick a surface**: Telegram (recommended first — 2-minute BotFather
+   flow), Discord, Slack, WebChat (zero-account fallback that always
+   works — it's a URL on loopback).
+2. **Guided token acquisition** per channel, with the exact steps inline
+   (Telegram: @BotFather `/newbot` → paste token. Discord: portal link,
+   *call out the MESSAGE_CONTENT privileged-intent toggle* — the known
+   first-real-token trap. Slack: app manifest JSON we print for one-click
+   app creation → xoxb + xapp tokens). Tokens go to the daemon-env-
+   sanitized stores (`AGENC_*` env or a wizard-written systemd override /
+   launchd plist for the user service — decide in O-3; never plaintext in
+   config.json).
+3. **Policy, explained in one sentence**, default pairing: "strangers who
+   message your bot get a pairing code; approve them with
+   `agenc gateway pairing list`." Writes `gateway/config.json` through the
+   existing normalizer.
+4. **The live smoke as the finale**: start `gateway run` (or restart the
+   service with the channel enabled), user DMs the bot, wizard shows the
+   pairing code arriving, user approves, agent replies *on their phone*.
+   Wizard confirms it saw the turn (gateway log line) before marking the
+   act complete.
+5. Ends with the persistence question answered: enable the gateway in the
+   user service so it survives reboots (O-4).
+
+### S5 — Guardrails, then autonomy [runtime ✓ (#1417/#1418/#1420/#1453), wizard missing]
+
+Order is the design (O-5): **budget → heartbeat → cron → hooks.**
+
+1. **Budget**: propose `[budget] daily_usd` with a sane default ($2/day,
+   editable), write config.toml, show `agenc budget status`. One line on
+   the guarantee: "when the cap is hit, autonomy pauses and tells you —
+   never silently spends or silently stops."
+2. **Heartbeat**: opt-in; writes a starter `HEARTBEAT.md` ("check my
+   inbox-directory / summarize overnight repo activity" templates), sets
+   `[heartbeat]` with the channel from S4 as target, fires ONE tick live.
+3. **Cron**: one example scheduled job created via the real CronCreate
+   surface with `announceChannel` from S4 ("every morning at 9: …").
+4. **Webhooks**: prints the minted hooks token + a copy-paste `curl` the
+   user runs from another terminal; the reply lands in their channel.
+   (The task-17 smoke, productized.)
+
+Each sub-step independently skippable; each ends with the live proof.
+
+### S6 — Posture recap + what-now card [audit ✓, recap missing]
+
+O-6: final screen = `agenc security audit` result (should be green) plus a
+one-screen summary of what was opened and its posture (channels + policy,
+hooks loopback+token, budget cap, heartbeat cadence), then a "what to try"
+card (5 curated prompts exercising channels/cron/memory) and pointers:
+`/help`, `agenc onboard --status`, the migration guides.
+
+## 4. Workstreams (TODO-task format, priority order)
+
+### O-1. Act-1 completion: zero-key path + guaranteed first magic — M
+- **Build:** provider step branch "I don't have a key": Ollama/LM Studio
+  port autodetect (offer detected models), per-provider key deep-links;
+  post-connection-test canned first turn (cwd-aware). Hosted free tier
+  plugs in here later (blocked on TODO task 33, external).
+- **Pointers:** `runtime/src/onboarding/Onboarding.tsx` (provider/api-key
+  steps), `useApiKeyVerification.ts`, provider registry
+  `runtime/src/llm/registry/`.
+- **Acceptance:** a machine with Ollama running and NO key reaches a real
+  first reply without leaving the wizard; a keyless machine gets working
+  deep-links, not a dead end; wizard e2e scenario covers both (drive
+  input→waitForIdle per the TUI e2e gotcha).
+
+### O-2. Act 2a: identity scaffold ("name your agent") — S/M
+- **Build:** new wizard act writing SOUL.md/USER.md/BOOTSTRAP.md into a
+  chosen+trusted workspace, then running one live turn so the task-13
+  ritual completes on screen. `agenc onboard identity` entry.
+- **Pointers:** `runtime/src/memory/persona.ts` (templates must satisfy
+  its budget/caps), project-trust store
+  `runtime/src/permissions/trust/project-trust.ts`, onboarding state
+  `projectOnboardingState.ts` (add per-act completion keys).
+- **Acceptance:** fresh user ends the act with IDENTITY.md written BY THE
+  AGENT and BOOTSTRAP.md deleted; re-running the act with an existing
+  identity offers edit, never re-runs the ritual (the mechanical gate,
+  surfaced); files pass `capPersonaContent` untruncated.
+
+### O-3. Act 2b: channel wizard — M/L (the centerpiece)
+- **Build:** `agenc onboard channel`: surface picker, per-channel guided
+  token acquisition (Telegram BotFather script, Discord portal +
+  MESSAGE_CONTENT intent callout, Slack app-manifest JSON printout,
+  WebChat zero-account fallback), secret storage decision (user-service
+  env override file, 0600 — never gateway/config.json), policy writer via
+  the existing config normalizer, then the LIVE pairing walkthrough:
+  start/restart gateway, show the pairing code arrive, approve, see the
+  agent answer in-channel before completing.
+- **Pointers:** `runtime/src/gateway/run.ts` (token env names +
+  `sanitizeGatewayDaemonEnv` — new secrets must join the strip list),
+  `pairing.ts` (`PairingStore`, `evaluateDmAccess`), `config.ts`
+  normalizers, channel adapters for verification calls (Telegram `getMe`,
+  Slack `auth.test`, Discord `/gateway/bot` — all already exist as
+  transport methods usable as token validators).
+- **Acceptance:** a user with only a phone completes Telegram end-to-end
+  inside the wizard (token validated live before proceeding; pairing
+  completed; a real turn delivered in-channel); every failure mode
+  (bad token, missing Discord intent, half Slack pair) produces a specific
+  next step, not a stack trace; `security audit` green after.
+
+### O-4. Always-on: gateway in the user service — S/M
+- **Build:** installer's user service currently runs the daemon only; add
+  opt-in gateway unit (`agenc gateway install-service` or a flag in O-3's
+  finale) with the sanitized env file; `agenc onboard --status` reports
+  daemon + gateway + channels in one line.
+- **Pointers:** `packaging/` (systemd/launchd units from Phase 0),
+  `runtime/src/bin/gateway-cli.ts`.
+- **Acceptance:** after reboot (or service restart in tests), the paired
+  channel still answers with no manual step; status output covers it.
+
+### O-5. Act 3: guardrails-then-autonomy wizard — M
+- **Build:** budget-cap step (writes `[budget]`, shows `budget status`),
+  heartbeat opt-in (HEARTBEAT.md template + `[heartbeat]` targeting the
+  S4 channel + one live tick), cron example via real CronCreate with
+  `announceChannel`, hooks intro (print token + copy-paste curl, watch it
+  land). HARD ORDER: autonomy steps refuse to enable while budget is
+  unset unless the user explicitly picks "no cap" (visibly).
+- **Pointers:** `runtime/src/budget/config.ts` (`resolveBudgetPolicy`),
+  `runtime/src/heartbeat/wire.ts`, `runtime/src/gateway/cron-delivery.ts`
+  + CronCreate surfaces (BOTH tool catalogs), `runtime/src/gateway/hooks.ts`.
+- **Acceptance:** completing the act yields: a cap in config.toml, one
+  live heartbeat tick delivered, one cron job listed with delivery
+  routing, one hook POST answered — all observed by the wizard itself;
+  skipping everything is one keypress per sub-step.
+
+### O-6. Posture recap + what-now card — S
+- **Build:** final wizard screen running the audit + rendering the
+  opened-surfaces summary and 5 curated starter prompts; same summary
+  available as `agenc onboard --status` (human) and `--json`.
+- **Pointers:** `runtime/src/bin/security-cli.ts`
+  (`buildSecurityAuditReport` is importable), onboarding state.
+- **Acceptance:** the recap names every surface the wizard opened with its
+  posture line; audit red blocks act completion with the remediation
+  inline.
+
+### O-7. Docs + landing alignment — S
+- **Build:** quickstart gains Act 2/Act 3 sections; README + get.agenc.ag
+  copy lead with the 15-minute T2A outcome and the three-command journey;
+  record ONE end-to-end terminal cast of install→channel→phone-reply.
+  (agenc.ag marketplace copy rules apply where the landing overlaps the
+  marketplace story.)
+- **Acceptance:** every wizard act has a doc section that matches its
+  actual screens; the cast shows the real product, not a mock.
+
+### O-8. Node-free install (bundled runtime) — L **[DEFERRED]**
+- Evaluate node SEA / bun compile for the tarball so `curl|sh` works on a
+  bare VPS. Take up only if §7 funnel data shows the Node ≥ 25
+  prerequisite is the biggest drop.
+
+### O-9. First-week retention loop — S **[AFTER O-1..O-6]**
+- **Build:** day-2+ nudges through surfaces we already own: heartbeat's
+  first morning message includes "3 things you can ask me"; `agenc` TUI
+  greeting shows one unexplored-capability hint (local state only).
+- **Acceptance:** hints derive from local completion state; each shows at
+  most once; zero network calls.
+
+## 5. Sequencing & effort
+
+```
+Week 1: O-2 (identity, S/M) + O-1 (zero-key + first magic, M)   → Act 1+2a done
+Week 2: O-3 (channel wizard, M/L)                               → the centerpiece
+Week 3: O-4 (service, S/M) + O-5 (autonomy, M)                  → Act 3 done
+Week 4: O-6 + O-7 (recap + docs, S+S), O-9 (S)                  → polish + retention
+```
+
+Each workstream = one branch/PR with the standard gates (TODO.md protocol);
+O-1/O-2/O-3/O-5 all need wizard e2e scenarios (mind the TUI e2e gotchas:
+input→waitForIdle, no phrase anchors on diff repaints; pre-clear stray
+daemons before gate runs).
+
+## 6. Explicit non-goals
+
+- **Marketplace onboarding** (wallets, tasks, mainnet) — owned by the
+  AgenC Marketplace kit and its own rails; the CLI wizard never touches
+  signing surfaces. At most, the what-now card may *mention* the kit.
+- **Web-based signup/account** — nothing here requires an account; hosted
+  free tier (id.agenc.ag) is an optional provider branch, blocked
+  externally (task 33).
+- **Runtime telemetry** — see §7.
+- **Windows-native wizard parity** in v1 — install docs cover Windows;
+  wizard parity tracked separately after funnel data.
+
+## 7. Measurement (no phone-home)
+
+- **Server side (already ours):** get.agenc.ag request counts + installer
+  download completions per channel (curl/npm/brew/docker) from the
+  existing Vercel edge — the only remote funnel signal, and it's ours.
+- **Local, inspectable, consent-free:** `agenc onboard --status --json`
+  gains per-act completion timestamps (extends
+  `projectOnboardingState.ts`). Anyone (including support conversations
+  and CI images) can read the funnel from the machine itself; nothing
+  leaves it.
+- **Definition of success:** cold VM → Act 2 complete in < 15 min without
+  reading docs; `security audit` green at every act boundary; the
+  install→phone-reply cast reproducible on every release.
+
+## 8. Risks & dependencies
+
+| Risk | Mitigation |
+|---|---|
+| id.agenc.ag device-code flow auto-approves mocks (task 33, external) | Free-tier branch ships DARK behind the fix; Ollama autodetect carries the zero-key path meanwhile |
+| Discord MESSAGE_CONTENT privileged intent confuses users | O-3 calls it out inline with a portal deep-link; token validator distinguishes "bad token" from "missing intent" |
+| Channel tokens at rest | Service env override files 0600 + `sanitizeGatewayDaemonEnv`; audit check extension for token-file perms (fold into `sensitive-file-perms`) |
+| Wizard drift vs. runtime config | Principle 6: wizard writes ONLY through existing loaders/normalizers; contract tests import both sides |
+| First-token live smokes flake in CI | Wizard e2e uses injected fake transports (the task-9 pattern); ONLY the human-run journey uses real tokens |
+| Repo velocity (multiple sessions landing daily) | Same discipline as tasks 9/17: branch early, rebase before merge, expect `run.ts`/CLI-parse conflicts |
+
+---
+
+*Written 2026-07-09. Grounded against agenc-core @ `3d2eedb9c` (task 17
+merge). Companion to `docs/parity-roadmap-2026-07.md`; lift workstreams
+into TODO.md as tasks when scheduled.*

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -14,9 +14,14 @@
  */
 
 import { resolveAgencHome } from "../config/env.js";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { loadGatewayConfig, resolveGatewayConfigPath } from "../gateway/config.js";
 import { PairingStore } from "../gateway/pairing.js";
 import { startGateway } from "../gateway/run.js";
+import { mergeGatewayEnv } from "../gateway/env-file.js";
 import type { GatewayConfig } from "../gateway/types.js";
 
 export type AgenCGatewayCliCommand =
@@ -28,6 +33,7 @@ export type AgenCGatewayCliCommand =
       readonly hooks: boolean;
     }
   | { readonly kind: "status"; readonly json: boolean }
+  | { readonly kind: "install-service" }
   | { readonly kind: "pairing-list"; readonly json: boolean }
   | {
       readonly kind: "pairing-revoke";
@@ -43,6 +49,9 @@ export function formatAgenCGatewayCliHelpText(): string {
     "",
     "Usage:",
     "  agenc gateway run [--stdio] [--webchat] [--heartbeat] [--hooks]",
+    "  agenc gateway install-service         Install + start the always-on",
+    "                                        gateway user service (systemd or",
+    "                                        launchd; reads gateway/env)",
     "                                        Start the gateway. --stdio enables",
     "                                        the local dev channel; --webchat a",
     "                                        loopback token-gated browser UI;",
@@ -84,6 +93,9 @@ export function parseAgenCGatewayCliArgs(
   }
   if (positional[0] === "status") {
     return { kind: "status", json };
+  }
+  if (positional[0] === "install-service") {
+    return { kind: "install-service" };
   }
   if (positional[0] === "pairing") {
     if (positional[1] === "list") {
@@ -192,13 +204,19 @@ export async function runAgenCGatewayCli(
   const env = deps.env ?? process.env;
   const agencHome = resolveAgencHome(env);
 
+  if (command.kind === "install-service") {
+    return installGatewayService({ agencHome, stdout, stderr });
+  }
+
   if (command.kind === "run") {
     const start = deps.startGateway ?? startGateway;
     let handle: Awaited<ReturnType<typeof startGateway>>;
     try {
       handle = await start({
         agencHome,
-        env,
+        // Channel tokens from the 0600 gateway/env file, under the real env
+        // (an explicitly exported variable always wins).
+        env: mergeGatewayEnv(agencHome, env),
         stdio: command.stdio,
         webchat: command.webchat,
         heartbeat: command.heartbeat,
@@ -287,4 +305,127 @@ export async function runAgenCGatewayCli(
       return 1;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Always-on gateway service (onboarding-plan-2026-07 O-4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Install the gateway as a per-user service so channels/heartbeat/cron/hooks
+ * survive reboots. systemd (Linux) or launchd (macOS); both read the 0600
+ * `gateway/env` secrets file, keeping tokens out of unit files and shells.
+ * User-scoped only — no sudo, no system daemons.
+ */
+export async function installGatewayService(options: {
+  readonly agencHome: string;
+  readonly stdout: (line: string) => void;
+  readonly stderr: (line: string) => void;
+  /** Test seams. */
+  readonly platform?: NodeJS.Platform;
+  readonly home?: string;
+  readonly execPath?: string;
+  readonly entryPath?: string;
+  readonly runCommand?: (cmd: string, args: readonly string[]) => boolean;
+}): Promise<number> {
+  const platform = options.platform ?? process.platform;
+  const home = options.home ?? homedir();
+  const nodeBin = options.execPath ?? process.execPath;
+  const entry = options.entryPath ?? process.argv[1];
+  const envFile = join(options.agencHome, "gateway", "env");
+  const run =
+    options.runCommand ??
+    ((cmd: string, args: readonly string[]): boolean =>
+      spawnSync(cmd, args, { stdio: "ignore" }).status === 0);
+
+  if (platform === "linux") {
+    const unitDir = join(home, ".config", "systemd", "user");
+    const unitPath = join(unitDir, "agenc-gateway.service");
+    mkdirSync(unitDir, { recursive: true });
+    writeFileSync(
+      unitPath,
+      [
+        "[Unit]",
+        "Description=AgenC channel gateway",
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        `ExecStart=${nodeBin} ${entry} gateway run`,
+        `EnvironmentFile=-${envFile}`,
+        "Restart=on-failure",
+        "RestartSec=5",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+        "",
+      ].join("\n"),
+    );
+    options.stdout(`Wrote ${unitPath}`);
+    const reloaded = run("systemctl", ["--user", "daemon-reload"]);
+    const enabled =
+      reloaded &&
+      run("systemctl", ["--user", "enable", "--now", "agenc-gateway"]);
+    if (enabled) {
+      options.stdout("Gateway service enabled and started.");
+      options.stdout("  status: systemctl --user status agenc-gateway");
+      options.stdout("  logs:   journalctl --user -u agenc-gateway -f");
+      return 0;
+    }
+    options.stderr(
+      "Unit written, but systemctl --user did not succeed. Enable it manually:",
+    );
+    options.stderr("  systemctl --user daemon-reload");
+    options.stderr("  systemctl --user enable --now agenc-gateway");
+    return 1;
+  }
+
+  if (platform === "darwin") {
+    const agentsDir = join(home, "Library", "LaunchAgents");
+    const plistPath = join(agentsDir, "dev.agenc.gateway.plist");
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      plistPath,
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+        '<plist version="1.0">',
+        "<dict>",
+        "  <key>Label</key>",
+        "  <string>dev.agenc.gateway</string>",
+        "  <key>ProgramArguments</key>",
+        "  <array>",
+        `    <string>${nodeBin}</string>`,
+        `    <string>${entry}</string>`,
+        "    <string>gateway</string>",
+        "    <string>run</string>",
+        "  </array>",
+        "  <key>RunAtLoad</key>",
+        "  <true/>",
+        "  <key>KeepAlive</key>",
+        "  <true/>",
+        "</dict>",
+        "</plist>",
+        "",
+      ].join("\n"),
+    );
+    options.stdout(`Wrote ${plistPath}`);
+    options.stdout(
+      "(launchd does not read env files — gateway run loads gateway/env itself.)",
+    );
+    const loaded = run("launchctl", ["load", "-w", plistPath]);
+    if (loaded) {
+      options.stdout("Gateway service loaded.");
+      return 0;
+    }
+    options.stderr("Plist written; load it manually:");
+    options.stderr(`  launchctl load -w ${plistPath}`);
+    return 1;
+  }
+
+  options.stderr(
+    `install-service supports linux (systemd --user) and macOS (launchd); on ${platform} run the gateway directly: agenc gateway run`,
+  );
+  return 1;
 }

--- a/runtime/src/bin/onboard-cli.ts
+++ b/runtime/src/bin/onboard-cli.ts
@@ -16,6 +16,15 @@
  * `shouldShowFirstRunOnboarding` — and never persists anything to config.
  */
 import { resolveAgencHome } from "../config/env.js";
+import { createTerminalActIO, type ActIO } from "../onboarding/acts/io.js";
+import { runIdentityAct } from "../onboarding/acts/identity.js";
+import { runChannelAct } from "../onboarding/acts/channel.js";
+import { runAutonomyAct } from "../onboarding/acts/autonomy.js";
+import { runRecap } from "../onboarding/acts/recap.js";
+import {
+  readOnboardingActs,
+  type OnboardingActsState,
+} from "../onboarding/acts/state.js";
 import {
   readOnboardingState,
   resetFirstRunOnboarding,
@@ -30,6 +39,7 @@ export type AgenCOnboardCliCommand =
   | { readonly kind: "launch" }
   | { readonly kind: "status"; readonly json: boolean }
   | { readonly kind: "reset" }
+  | { readonly kind: "act"; readonly act: "identity" | "channel" | "autonomy" | "recap" }
   | { readonly kind: "help"; readonly text: string }
   | { readonly kind: "error"; readonly message: string };
 
@@ -40,6 +50,13 @@ export function formatAgenCOnboardCliHelpText(): string {
     "Usage:",
     "  agenc onboard            Launch the interactive setup wizard (re-runs",
     "                           even after a completed first run)",
+    "  agenc onboard identity   Act 2a — name your agent (persona workspace +",
+    "                           the one-time naming ritual)",
+    "  agenc onboard channel    Act 2b — connect Telegram/Discord/Slack/WebChat",
+    "                           with live token checks + the pairing walkthrough",
+    "  agenc onboard autonomy   Act 3 — budget cap, heartbeat, cron, webhooks",
+    "                           (guardrails first, always)",
+    "  agenc onboard recap      Posture summary + starter prompts",
     "  agenc onboard --status   Print wizard completion + daemon status",
     "                           (non-interactive, for scripts)",
     "  agenc onboard --json     With --status: emit the report as JSON",
@@ -61,6 +78,20 @@ export function parseAgenCOnboardCliArgs(
   argv: readonly string[],
 ): AgenCOnboardCliCommand | null {
   if (argv[0] !== "onboard") return null;
+  if (
+    argv[1] === "identity" ||
+    argv[1] === "channel" ||
+    argv[1] === "autonomy" ||
+    argv[1] === "recap"
+  ) {
+    if (argv.length > 2) {
+      return {
+        kind: "error",
+        message: `onboard ${argv[1]} does not accept extra arguments`,
+      };
+    }
+    return { kind: "act", act: argv[1] };
+  }
   let status = false;
   let json = false;
   let reset = false;
@@ -114,6 +145,8 @@ export interface OnboardStatusReport {
     readonly selectedProvider?: string;
     readonly selectedModel?: string;
   };
+  /** Act-level completion — the local, consent-free onboarding funnel. */
+  readonly acts: OnboardingActsState["acts"];
   readonly daemon: OnboardDaemonStatus;
 }
 
@@ -122,6 +155,12 @@ export interface OnboardCliDeps {
   readonly isPidRunning?: (pid: number) => boolean;
   readonly stdout?: (line: string) => void;
   readonly stderr?: (line: string) => void;
+  /** Test seams for the interactive acts. */
+  readonly actIO?: ActIO;
+  readonly runIdentityActFn?: typeof runIdentityAct;
+  readonly runChannelActFn?: typeof runChannelAct;
+  readonly runAutonomyActFn?: typeof runAutonomyAct;
+  readonly runRecapFn?: typeof runRecap;
 }
 
 function defaultIsPidRunning(pid: number): boolean {
@@ -158,6 +197,7 @@ export async function buildOnboardStatusReport(
   );
   return {
     agencHome,
+    acts: readOnboardingActs(agencHome).acts,
     onboarding: {
       completed: state.completed,
       ...(state.completedAt !== undefined
@@ -203,10 +243,26 @@ export function formatOnboardStatusText(report: OnboardStatusReport): string {
         : "not running"
     }`,
   );
+  const actLabel = (act: "identity" | "channel" | "autonomy"): string => {
+    const record = report.acts[act];
+    return record !== undefined ? `done (${record.completedAt})` : "not yet";
+  };
+  lines.push(`  Identity:  ${actLabel("identity")}`);
+  lines.push(`  Channel:   ${actLabel("channel")}`);
+  lines.push(`  Autonomy:  ${actLabel("autonomy")}`);
   lines.push("");
+  const nextAct = report.acts.identity === undefined
+    ? "agenc onboard identity"
+    : report.acts.channel === undefined
+      ? "agenc onboard channel"
+      : report.acts.autonomy === undefined
+        ? "agenc onboard autonomy"
+        : null;
   lines.push(
     report.onboarding.completed
-      ? "  Re-run the wizard with: agenc onboard"
+      ? nextAct !== null
+        ? `  Next: ${nextAct}`
+        : "  All acts complete — recap with: agenc onboard recap"
       : "  Start the wizard with: agenc onboard",
   );
   return lines.join("\n");
@@ -229,6 +285,26 @@ export async function runAgenCOnboardCli(
     case "help":
       stdout(command.text);
       return 0;
+    case "act": {
+      const env = deps.env ?? process.env;
+      const agencHome = resolveAgencHome(env);
+      const io = deps.actIO ?? createTerminalActIO();
+      try {
+        switch (command.act) {
+          case "identity":
+            return await (deps.runIdentityActFn ?? runIdentityAct)({ agencHome, io, env });
+          case "channel":
+            return await (deps.runChannelActFn ?? runChannelAct)({ agencHome, io, env });
+          case "autonomy":
+            return await (deps.runAutonomyActFn ?? runAutonomyAct)({ agencHome, io, env });
+          case "recap":
+            return await (deps.runRecapFn ?? runRecap)({ agencHome, io, env });
+        }
+        return 1;
+      } finally {
+        io.close();
+      }
+    }
     case "error":
       stderr(`agenc: ${command.message}`);
       return 1;

--- a/runtime/src/bin/security-cli.ts
+++ b/runtime/src/bin/security-cli.ts
@@ -165,6 +165,10 @@ const KNOWN_SENSITIVE_ENTRIES = [
   "onboarding.json",
   "trusted-projects.json",
   "credentials",
+  // Gateway secrets (channel tokens, webhook/webchat bearer tokens).
+  "gateway/env",
+  "gateway/hooks-token",
+  "gateway/webchat-token",
 ];
 
 const checkSensitiveFilePerms: SecurityCheck = (ctx) => {

--- a/runtime/src/gateway/env-file.ts
+++ b/runtime/src/gateway/env-file.ts
@@ -1,0 +1,73 @@
+/**
+ * Gateway secrets file — `<agencHome>/gateway/env` (task O-3/O-4 of
+ * docs/onboarding-plan-2026-07.md).
+ *
+ * Channel tokens (Telegram/Discord/Slack, webchat/hooks overrides) need a
+ * home that works for BOTH `agenc gateway run` and the gateway service
+ * unit. A 0600 KEY=VALUE file is that home: the onboarding channel act
+ * writes it, `agenc gateway run` merges it UNDER the real environment
+ * (explicit env always wins), the systemd unit points EnvironmentFile at
+ * it, and `sanitizeGatewayDaemonEnv` keeps every one of these names out of
+ * the daemon.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export function gatewayEnvFilePath(agencHome: string): string {
+  return join(agencHome, "gateway", "env");
+}
+
+/** Parse the env file; missing/corrupt → empty (never throws). */
+export function readGatewayEnvFile(
+  agencHome: string,
+): Record<string, string> {
+  const path = gatewayEnvFilePath(agencHome);
+  if (!existsSync(path)) return {};
+  const out: Record<string, string> = {};
+  try {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      out[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
+    }
+  } catch {
+    return {};
+  }
+  return out;
+}
+
+/** Merge entries into the file (existing keys overwritten), 0600. */
+export function writeGatewayEnvEntries(
+  agencHome: string,
+  entries: Readonly<Record<string, string>>,
+): void {
+  const merged = { ...readGatewayEnvFile(agencHome), ...entries };
+  const path = gatewayEnvFilePath(agencHome);
+  mkdirSync(join(agencHome, "gateway"), { recursive: true, mode: 0o700 });
+  const body = [
+    "# Gateway channel credentials — loaded by `agenc gateway run` and the",
+    "# gateway service unit. Never committed, never passed to the daemon.",
+    ...Object.entries(merged).map(([key, value]) => `${key}=${value}`),
+    "",
+  ].join("\n");
+  writeFileSync(path, body, { mode: 0o600 });
+}
+
+/**
+ * The environment `gateway run` should use: the env file's entries UNDER
+ * the caller's environment — an explicitly exported variable always wins.
+ */
+export function mergeGatewayEnv(
+  agencHome: string,
+  env: Readonly<Record<string, string | undefined>>,
+): Record<string, string | undefined> {
+  return { ...readGatewayEnvFile(agencHome), ...env };
+}

--- a/runtime/src/gateway/run.ts
+++ b/runtime/src/gateway/run.ts
@@ -531,7 +531,8 @@ export async function startGateway(
     adapters.push(adapter);
   }
 
-  // A heartbeat-only run (proactive ticks, no channel) is valid.
+  // A heartbeat-only run (proactive ticks, no channel) is valid, and so is
+  // a hooks-only run (the webhook endpoint is a trigger surface).
   const heartbeatRequested =
     options.heartbeat === true ||
     resolveHeartbeatPolicy(
@@ -539,9 +540,11 @@ export async function startGateway(
         .heartbeat,
       env,
     ).enabled;
-  if (adapters.length === 0 && !heartbeatRequested) {
+  const hooksRequested =
+    options.hooks === true || loaded.hooks?.enabled === true;
+  if (adapters.length === 0 && !heartbeatRequested && !hooksRequested) {
     throw new Error(
-      "gateway run: no channels enabled — pass --stdio, --webchat, --heartbeat, set AGENC_TELEGRAM_BOT_TOKEN, or configure a channel",
+      "gateway run: no channels enabled — pass --stdio, --webchat, --heartbeat, --hooks, set AGENC_TELEGRAM_BOT_TOKEN, or configure a channel",
     );
   }
 

--- a/runtime/src/onboarding/acts/autonomy.ts
+++ b/runtime/src/onboarding/acts/autonomy.ts
@@ -1,0 +1,304 @@
+/**
+ * Onboarding Act 3 — guardrails, then autonomy (onboarding-plan-2026-07 O-5).
+ *
+ * HARD ORDER: budget → heartbeat → cron → webhooks. No step here enables an
+ * autonomous surface before a spend envelope exists (or the user explicitly,
+ * visibly picks "no cap"). Every sub-step is skippable and ends with the
+ * live proof where one is possible.
+ *
+ * Config writes are append-only and conservative: a `[budget]`/`[heartbeat]`
+ * section is appended to config.toml ONLY when absent; an existing section
+ * is displayed with edit instructions — this wizard never rewrites TOML it
+ * did not author. Cron jobs are written through the real task-file helpers;
+ * hooks enablement goes through the gateway config's own JSON (merged, other
+ * keys preserved).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { loadConfig } from "../../config/loader.js";
+import { resolveBudgetPolicy } from "../../budget/index.js";
+import { resolveHeartbeatPolicy } from "../../heartbeat/config.js";
+import {
+  gatewayEnvFilePath,
+  readGatewayEnvFile,
+} from "../../gateway/env-file.js";
+import { resolveGatewayConfigPath } from "../../gateway/config.js";
+import { resolveHooksToken } from "../../gateway/run.js";
+import { HOOKS_PATH } from "../../gateway/hooks.js";
+import {
+  readCronTasks,
+  writeCronTasks,
+  nextCronRunMs,
+  normalizeDelivery,
+} from "../../utils/cronTasks.js";
+import type { ActIO } from "./io.js";
+import { markOnboardingActComplete, readOnboardingActs } from "./state.js";
+
+export interface AutonomyActOptions {
+  readonly agencHome: string;
+  readonly io: ActIO;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Test seam: override Date.now for deterministic cron creation. */
+  readonly now?: () => number;
+}
+
+function configTomlPath(agencHome: string): string {
+  return join(agencHome, "config.toml");
+}
+
+/**
+ * Append a TOML section iff no section with that header exists. Returns
+ * false (and writes nothing) when the section is already present.
+ */
+export function appendTomlSectionIfAbsent(
+  agencHome: string,
+  header: string,
+  lines: readonly string[],
+): boolean {
+  const path = configTomlPath(agencHome);
+  const current = existsSync(path) ? readFileSync(path, "utf8") : "";
+  if (current.includes(`[${header}]`)) return false;
+  const block = [`\n[${header}]`, ...lines, ""].join("\n");
+  writeFileSync(path, current.length > 0 ? `${current}${block}` : block.trimStart() + "\n");
+  return true;
+}
+
+/** Merge a `hooks.enabled` flag into gateway/config.json, preserving keys. */
+export function enableHooksInGatewayConfig(agencHome: string): void {
+  const path = resolveGatewayConfigPath(agencHome);
+  let raw: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+      if (parsed !== null && typeof parsed === "object") {
+        raw = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Unparseable config would fail-closed everywhere else too; start over.
+      raw = {};
+    }
+  }
+  const hooks =
+    raw.hooks !== null && typeof raw.hooks === "object"
+      ? (raw.hooks as Record<string, unknown>)
+      : {};
+  raw.hooks = { ...hooks, enabled: true };
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${JSON.stringify(raw, null, 2)}\n`, { mode: 0o600 });
+}
+
+export async function runAutonomyAct(
+  options: AutonomyActOptions,
+): Promise<number> {
+  const { io, agencHome } = options;
+  const env = options.env ?? process.env;
+  const now = options.now ?? Date.now;
+
+  io.say("");
+  io.say("── Guardrails, then autonomy ────────────────────────────────");
+  io.say("Order matters: the spend cap comes first. When a cap is hit,");
+  io.say("autonomy pauses and tells you — never silently spends or stops.");
+
+  // ── 1. Budget ─────────────────────────────────────────────────────────
+  const { config } = await loadConfig({ home: agencHome, onWarn: io.say });
+  const { policy: budget } = resolveBudgetPolicy(config.budget, env);
+  let hasCap = budget.enabled;
+  if (budget.enabled) {
+    io.say("");
+    io.say("A budget envelope is already configured — keeping it.");
+    io.say("(See `agenc budget status`; edit [budget] in config.toml.)");
+  } else {
+    io.say("");
+    const capAnswer = await io.ask(
+      "Daily autonomous spend cap in USD ('none' for no cap)",
+      "2",
+    );
+    if (capAnswer.toLowerCase() === "none") {
+      const sure = await io.confirm(
+        "No cap means autonomous turns can spend without limit. Continue capless?",
+        false,
+      );
+      if (!sure) return runAutonomyAct(options);
+      io.say("Proceeding WITHOUT a cap — you chose this explicitly.");
+    } else {
+      const cap = Number.parseFloat(capAnswer);
+      if (!Number.isFinite(cap) || cap <= 0) {
+        io.say("That is not a positive number — try the act again.");
+        return 1;
+      }
+      const wrote = appendTomlSectionIfAbsent(agencHome, "budget", [
+        "# Written by `agenc onboard autonomy` — daily cap for autonomous turns.",
+        "enabled = true",
+        `daily_usd = ${cap}`,
+      ]);
+      if (wrote) {
+        io.say(`Cap set: $${cap}/day (config.toml [budget]).`);
+        io.say("Check anytime with: agenc budget status");
+        hasCap = true;
+      } else {
+        io.say(
+          "config.toml already has a [budget] section this wizard will not rewrite — edit it directly.",
+        );
+      }
+    }
+  }
+
+  // ── 2. Heartbeat ──────────────────────────────────────────────────────
+  const heartbeat = resolveHeartbeatPolicy(config.heartbeat, env);
+  io.say("");
+  if (heartbeat.enabled) {
+    io.say("Heartbeat already enabled — keeping your configuration.");
+  } else if (
+    await io.confirm(
+      "Enable the heartbeat? (periodic check-ins driven by a HEARTBEAT.md you control)",
+      false,
+    )
+  ) {
+    if (!hasCap) {
+      io.say("Refusing: set a budget cap first (autonomy needs guardrails).");
+    } else {
+      const acts = readOnboardingActs(agencHome);
+      const defaultWs =
+        acts.acts.identity?.detail?.workspace ??
+        join(env.HOME ?? homedir(), "agent");
+      const workspace = await io.ask(
+        "Workspace holding HEARTBEAT.md",
+        defaultWs,
+      );
+      const heartbeatPath = join(workspace, "HEARTBEAT.md");
+      if (!existsSync(heartbeatPath)) {
+        writeFileSync(
+          heartbeatPath,
+          [
+            "# Heartbeat",
+            "",
+            "On each heartbeat, check for anything that needs my attention:",
+            "- summarize notable changes in this workspace since the last check",
+            "- flag anything that looks urgent",
+            "",
+            "If nothing needs attention, reply HEARTBEAT_OK.",
+            "",
+          ].join("\n"),
+        );
+        io.say(`Wrote a starter ${heartbeatPath} — edit it to change the job.`);
+      }
+      const envEntries = readGatewayEnvFile(agencHome);
+      const channelHint =
+        envEntries.AGENC_TELEGRAM_BOT_TOKEN !== undefined
+          ? "telegram"
+          : envEntries.AGENC_DISCORD_BOT_TOKEN !== undefined
+            ? "discord"
+            : envEntries.AGENC_SLACK_BOT_TOKEN !== undefined
+              ? "slack"
+              : "";
+      const channel = await io.ask(
+        "Deliver heartbeat findings to which channel? (empty = none)",
+        channelHint,
+      );
+      const conversation =
+        channel.length > 0
+          ? await io.ask(
+              "Conversation id on that channel (your chat id — check `agenc gateway pairing list` after pairing)",
+              "",
+            )
+          : "";
+      const lines = [
+        "# Written by `agenc onboard autonomy`.",
+        "enabled = true",
+        "interval_seconds = 1800",
+      ];
+      if (channel.length > 0 && conversation.length > 0) {
+        lines.push(`target_channel = "${channel}"`);
+        lines.push(`target_conversation = "${conversation}"`);
+      }
+      const wrote = appendTomlSectionIfAbsent(agencHome, "heartbeat", lines);
+      io.say(
+        wrote
+          ? "Heartbeat configured (every 30 min while the gateway runs)."
+          : "config.toml already has a [heartbeat] section — edit it directly.",
+      );
+      io.say("It ticks whenever `agenc gateway run` (or the service) is up.");
+    }
+  }
+
+  // ── 3. Cron example ───────────────────────────────────────────────────
+  io.say("");
+  if (
+    await io.confirm(
+      "Add a scheduled job? (example: a 9am daily briefing delivered to your channel)",
+      false,
+    )
+  ) {
+    if (!hasCap) {
+      io.say("Refusing: set a budget cap first.");
+    } else {
+      const acts = readOnboardingActs(agencHome);
+      const workspace = await io.ask(
+        "Workspace for the job file (.agenc/scheduled_tasks.json)",
+        acts.acts.identity?.detail?.workspace ??
+          join(env.HOME ?? homedir(), "agent"),
+      );
+      const schedule = await io.ask("Cron schedule", "0 9 * * *");
+      if (nextCronRunMs(schedule, now()) === null) {
+        io.say("That cron expression never fires — try the act again.");
+        return 1;
+      }
+      const prompt = await io.ask(
+        "What should it do?",
+        "Give me a short morning briefing: anything new in this workspace, and my top follow-ups.",
+      );
+      const channel = await io.ask("Deliver to channel (empty = run in-session)", "");
+      const to =
+        channel.length > 0 ? await io.ask("Conversation id", "") : "";
+      const deliver = normalizeDelivery({ channel, to });
+      const tasks = await readCronTasks(workspace);
+      tasks.push({
+        id: randomUUID().slice(0, 8),
+        cron: schedule,
+        prompt,
+        createdAt: now(),
+        recurring: true,
+        ...(deliver !== undefined ? { deliver } : {}),
+      });
+      await writeCronTasks(tasks, workspace);
+      io.say(
+        `Job saved (${schedule}). Delivery-routed jobs run under \`agenc gateway run\` from ${workspace}.`,
+      );
+    }
+  }
+
+  // ── 4. Webhooks ───────────────────────────────────────────────────────
+  io.say("");
+  if (
+    await io.confirm(
+      "Enable inbound webhooks? (POST /hooks/agent — trigger turns from CI, monitors, anything)",
+      false,
+    )
+  ) {
+    if (!hasCap) {
+      io.say("Refusing: set a budget cap first.");
+    } else {
+      enableHooksInGatewayConfig(agencHome);
+      const token = resolveHooksToken(agencHome, env);
+      io.say("Hooks enabled (loopback + bearer token; audit-checked).");
+      io.say("Try it once the gateway is running:");
+      io.say("");
+      io.say(`  curl -s -X POST http://127.0.0.1:8377${HOOKS_PATH} \\`);
+      io.say(`    -H "authorization: Bearer ${token}" \\`);
+      io.say('    -H "content-type: application/json" \\');
+      io.say('    -d \'{"message":"ping from my first webhook"}\'');
+      io.say("");
+      io.say(`(Token stored 0600 at ${gatewayEnvFilePath(agencHome).replace(/env$/, "hooks-token")}.)`);
+    }
+  }
+
+  markOnboardingActComplete(agencHome, "autonomy");
+  io.say("");
+  io.say("Autonomy configured. Everything above only acts while the gateway");
+  io.say("runs — keep it always-on with: agenc gateway install-service");
+  return 0;
+}

--- a/runtime/src/onboarding/acts/channel.ts
+++ b/runtime/src/onboarding/acts/channel.ts
@@ -1,0 +1,278 @@
+/**
+ * Onboarding Act 2b — "take it with you" (onboarding-plan-2026-07 O-3).
+ *
+ * Guided channel setup: pick a surface, acquire + LIVE-VALIDATE the token,
+ * store it in the sanitized gateway env file (0600 — never in config.json),
+ * explain the pairing default in one sentence, then run the live smoke: the
+ * gateway starts in-process, the user messages their bot from their phone,
+ * pairs with the code, and sees the agent answer before the act completes.
+ *
+ * Security posture is narrated, never weakened: tokens are validated before
+ * anything persists, secrets live in `<agencHome>/gateway/env` (loaded by
+ * `agenc gateway run` and the service unit, stripped from daemon autostart
+ * env), and unknown senders stay pairing-gated.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { FetchDiscordTransport } from "../../gateway/discord-channel.js";
+import {
+  gatewayEnvFilePath,
+  readGatewayEnvFile,
+  writeGatewayEnvEntries,
+} from "../../gateway/env-file.js";
+import { FetchSlackTransport } from "../../gateway/slack-channel.js";
+import { FetchTelegramTransport } from "../../gateway/telegram-channel.js";
+import {
+  startGateway,
+  type GatewayRunHandle,
+  type GatewayRunOptions,
+} from "../../gateway/run.js";
+import type { ActIO } from "./io.js";
+import { markOnboardingActComplete } from "./state.js";
+
+export interface ChannelValidators {
+  telegram(token: string): Promise<{ ok: boolean; detail?: string }>;
+  discord(token: string): Promise<{ ok: boolean; detail?: string }>;
+  slack(
+    botToken: string,
+    appToken: string,
+  ): Promise<{ ok: boolean; detail?: string }>;
+}
+
+export interface ChannelActOptions {
+  readonly agencHome: string;
+  readonly io: ActIO;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Test seams. */
+  readonly validators?: ChannelValidators;
+  readonly startGatewayFn?: (
+    options: GatewayRunOptions,
+  ) => Promise<GatewayRunHandle>;
+  readonly pairingPollIntervalMs?: number;
+  readonly pairingTimeoutMs?: number;
+}
+
+const DEFAULT_VALIDATORS: ChannelValidators = {
+  async telegram(token) {
+    try {
+      const transport = new FetchTelegramTransport({ token });
+      const me = await transport.getMe?.();
+      return me !== undefined && me !== null
+        ? { ok: true, detail: `@${me.username ?? "bot"}` }
+        : { ok: false, detail: "getMe returned nothing" };
+    } catch (error) {
+      return { ok: false, detail: String(error) };
+    }
+  },
+  async discord(token) {
+    try {
+      await new FetchDiscordTransport({ token }).getGatewayUrl();
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, detail: String(error) };
+    }
+  },
+  async slack(botToken, appToken) {
+    try {
+      const transport = new FetchSlackTransport({ botToken, appToken });
+      const auth = await transport.authTest();
+      await transport.openSocketUrl();
+      return { ok: true, detail: `bot user ${auth.userId}` };
+    } catch (error) {
+      return { ok: false, detail: String(error) };
+    }
+  },
+};
+
+function readPairedPeers(agencHome: string, channelId: string): string[] {
+  try {
+    const raw = JSON.parse(
+      readFileSync(join(agencHome, "gateway", "pairing.json"), "utf8"),
+    ) as { paired?: Record<string, string[]> };
+    return raw.paired?.[channelId] ?? [];
+  } catch {
+    return [];
+  }
+}
+
+const CHANNEL_GUIDES: Readonly<Record<string, readonly string[]>> = {
+  telegram: [
+    "Telegram setup (about 2 minutes):",
+    "  1. Open Telegram and message @BotFather",
+    "  2. Send /newbot and follow the prompts (pick any name + username)",
+    "  3. BotFather replies with a token like 110201543:AAHdqTcv…",
+  ],
+  discord: [
+    "Discord setup:",
+    "  1. https://discord.com/developers/applications → New Application",
+    "  2. Bot tab → Reset Token → copy it",
+    "  3. IMPORTANT: on the same Bot tab, enable the 'MESSAGE CONTENT'",
+    "     privileged intent — without it your bot sees empty messages.",
+    "  4. OAuth2 → URL Generator → scope 'bot' → open the URL to invite it",
+  ],
+  slack: [
+    "Slack setup (Socket Mode — no public URL needed):",
+    "  1. https://api.slack.com/apps → Create App (from scratch)",
+    "  2. Socket Mode: enable it; create an app-level token (xapp-…)",
+    "     with the connections:write scope",
+    "  3. OAuth & Permissions: add bot scopes chat:write + app_mentions:read",
+    "     + im:history + channels:history, then Install to Workspace (xoxb-…)",
+    "  4. Event Subscriptions: enable; subscribe the bot to message.im,",
+    "     message.channels, and app_mention",
+  ],
+};
+
+export async function runChannelAct(
+  options: ChannelActOptions,
+): Promise<number> {
+  const { io, agencHome } = options;
+  const env = options.env ?? process.env;
+  const validators = options.validators ?? DEFAULT_VALIDATORS;
+  const start = options.startGatewayFn ?? startGateway;
+
+  io.say("");
+  io.say("── Take your agent with you ─────────────────────────────────");
+  io.say("Connect a messaging surface. Everything stays fail-closed:");
+  io.say("strangers who find your bot get a pairing code, not your agent.");
+  io.say("");
+
+  const channel = await io.select("Which surface first?", [
+    { key: "telegram", label: "Telegram", hint: "recommended — 2-minute setup" },
+    { key: "discord", label: "Discord" },
+    { key: "slack", label: "Slack", hint: "Socket Mode, no public URL" },
+    { key: "webchat", label: "WebChat", hint: "no account needed — a local URL" },
+  ]);
+
+  const entries: Record<string, string> = {};
+  if (channel !== "webchat") {
+    for (const line of CHANNEL_GUIDES[channel] ?? []) io.say(line);
+    io.say("");
+  }
+
+  if (channel === "telegram") {
+    for (;;) {
+      const token = await io.askSecret("Paste your bot token");
+      const check = await validators.telegram(token);
+      if (check.ok) {
+        io.say(`Token verified${check.detail !== undefined ? ` (${check.detail})` : ""}.`);
+        entries.AGENC_TELEGRAM_BOT_TOKEN = token;
+        break;
+      }
+      io.say(`That token did not verify: ${check.detail ?? "unknown error"}`);
+      if (!(await io.confirm("Try again?", true))) return 1;
+    }
+  } else if (channel === "discord") {
+    for (;;) {
+      const token = await io.askSecret("Paste your bot token");
+      const check = await validators.discord(token);
+      if (check.ok) {
+        io.say("Token verified.");
+        entries.AGENC_DISCORD_BOT_TOKEN = token;
+        break;
+      }
+      io.say(`That token did not verify: ${check.detail ?? "unknown error"}`);
+      io.say("(A valid token that still fails later usually means the");
+      io.say(" MESSAGE CONTENT intent toggle was missed — see step 3.)");
+      if (!(await io.confirm("Try again?", true))) return 1;
+    }
+  } else if (channel === "slack") {
+    for (;;) {
+      const botToken = await io.askSecret("Paste the bot token (xoxb-…)");
+      const appToken = await io.askSecret("Paste the app-level token (xapp-…)");
+      const check = await validators.slack(botToken, appToken);
+      if (check.ok) {
+        io.say(`Tokens verified${check.detail !== undefined ? ` (${check.detail})` : ""}.`);
+        entries.AGENC_SLACK_BOT_TOKEN = botToken;
+        entries.AGENC_SLACK_APP_TOKEN = appToken;
+        break;
+      }
+      io.say(`Those tokens did not verify: ${check.detail ?? "unknown error"}`);
+      if (!(await io.confirm("Try again?", true))) return 1;
+    }
+  }
+
+  if (Object.keys(entries).length > 0) {
+    writeGatewayEnvEntries(agencHome, entries);
+    io.say(`Stored (0600) in ${gatewayEnvFilePath(agencHome)} — picked up by`);
+    io.say("`agenc gateway run` and the gateway service, never by the daemon.");
+  }
+
+  io.say("");
+  io.say("Policy: pairing (the default). Unknown senders get a one-time");
+  io.say("code; you approve them here. Nothing to configure.");
+
+  // ── The live smoke IS the step ────────────────────────────────────────
+  io.say("");
+  const smoke = await io.confirm(
+    "Start the gateway now and pair your first device?",
+    true,
+  );
+  if (smoke) {
+    // Snapshot BEFORE the gateway starts: a pairing can land immediately.
+    const before = new Set(readPairedPeers(agencHome, channel));
+    let handle: GatewayRunHandle | null = null;
+    try {
+      handle = await start({
+        agencHome,
+        env: { ...env, ...readGatewayEnvFile(agencHome) },
+        webchat: channel === "webchat",
+        log: (line) => io.say(`  ${line}`),
+      });
+      if (channel === "webchat") {
+        io.say("");
+        io.say(`Open this in your browser: ${handle.webchatUrl ?? "(no url?)"}`);
+        io.say("Send a message there — the token in the URL is your auth.");
+        const replied = await io.confirm("Did the agent reply?", true);
+        io.say(replied ? "Channel live." : "See the log lines above for what happened.");
+      } else {
+        io.say("");
+        io.say(`Now message your bot on ${channel} from your phone.`);
+        io.say("It will reply with a pairing code; the code also shows here.");
+        const timeoutAt =
+          Date.now() + (options.pairingTimeoutMs ?? 5 * 60 * 1000);
+        const interval = options.pairingPollIntervalMs ?? 2000;
+        io.say("Waiting for you to pair (reply to the bot with the code)…");
+        let paired: string | null = null;
+        while (Date.now() < timeoutAt) {
+          const now = readPairedPeers(agencHome, channel).filter(
+            (peer) => !before.has(peer),
+          );
+          if (now.length > 0) {
+            paired = now[0];
+            break;
+          }
+          await new Promise((r) => setTimeout(r, interval));
+        }
+        if (paired !== null) {
+          io.say(`Paired: ${paired}. Send one more message to your bot.`);
+          const replied = await io.confirm("Did the agent reply?", true);
+          io.say(
+            replied
+              ? "Channel live — your agent answers on your phone now."
+              : "Check the log lines above; `agenc gateway status` also helps.",
+          );
+        } else {
+          io.say("No pairing seen yet — that's fine. The gateway keeps the");
+          io.say("same behavior whenever you run it; pair any time.");
+        }
+      }
+    } catch (error) {
+      io.say(`Gateway failed to start: ${String(error)}`);
+      io.say("Fix the issue and re-run: agenc onboard channel");
+      return 1;
+    } finally {
+      await handle?.stop();
+    }
+    io.say("");
+    io.say("The gateway stopped with this wizard. Keep it always-on with:");
+    io.say("  agenc gateway install-service     (recommended)");
+    io.say("or run it manually:  agenc gateway run");
+  } else {
+    io.say("Skipped. Run the gateway any time with: agenc gateway run");
+  }
+
+  markOnboardingActComplete(agencHome, "channel", { channel });
+  return 0;
+}

--- a/runtime/src/onboarding/acts/identity.ts
+++ b/runtime/src/onboarding/acts/identity.ts
@@ -1,0 +1,214 @@
+/**
+ * Onboarding Act 2a — "name your agent" (onboarding-plan-2026-07 O-2).
+ *
+ * Scaffolds the persona workspace (task 13's convention) and then runs the
+ * BOOTSTRAP naming ritual LIVE so the user watches the agent choose its own
+ * name and write IDENTITY.md. The act only writes files that do not exist —
+ * an existing persona is shown, never clobbered — and the ritual's
+ * exactly-once gate (IDENTITY.md existence) is surfaced, not bypassed.
+ *
+ * The ritual turn runs headless (`agenc -p --permission-mode acceptEdits`)
+ * inside the freshly-created, freshly-TRUSTED workspace: acceptEdits is the
+ * narrowest mode that lets the agent write IDENTITY.md, and the wizard says
+ * so out loud before running it.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+import { trustProjectSync } from "../../permissions/trust/project-trust.js";
+import type { ActIO } from "./io.js";
+import { markOnboardingActComplete } from "./state.js";
+
+export interface IdentityActOptions {
+  readonly agencHome: string;
+  readonly io: ActIO;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Test seam: the ritual turn (default spawns `agenc -p` in the workspace). */
+  readonly runRitualTurn?: (workspace: string) => Promise<RitualTurnResult>;
+  /** Test seam: workspace default suggestion. */
+  readonly defaultWorkspace?: string;
+}
+
+export interface RitualTurnResult {
+  readonly ok: boolean;
+  readonly output: string;
+}
+
+const SOUL_TONES: Readonly<Record<string, string>> = {
+  direct:
+    "Be direct and precise. Lead with the answer; skip filler and hedging.",
+  warm:
+    "Be warm and encouraging. Explain your thinking; celebrate progress without flattery.",
+  terse:
+    "Be terse. Short sentences. No preamble, no summaries unless asked.",
+};
+
+function soulTemplate(tone: string, verbosity: string): string {
+  return [
+    "# Soul",
+    "",
+    SOUL_TONES[tone] ?? SOUL_TONES.direct,
+    verbosity === "detailed"
+      ? "Prefer thorough answers with reasoning shown."
+      : "Prefer concise answers; expand only when asked.",
+    "",
+    "Boundaries: never take irreversible actions without asking. When unsure,",
+    "say so plainly instead of guessing.",
+    "",
+  ].join("\n");
+}
+
+function userTemplate(name: string, context: string): string {
+  return [
+    "# User",
+    "",
+    `The human you work for is ${name}.`,
+    ...(context.length > 0 ? ["", context] : []),
+    "",
+  ].join("\n");
+}
+
+const BOOTSTRAP_TEMPLATE = [
+  "# Bootstrap",
+  "",
+  "This is your first run in this workspace. Choose a name for yourself —",
+  "one you like, fitting the soul described in SOUL.md. Introduce yourself",
+  "to your human in two or three sentences: your name, how you see your",
+  "role, and one thing you are looking forward to helping with.",
+  "",
+].join("\n");
+
+function defaultRunRitualTurn(workspace: string): Promise<RitualTurnResult> {
+  // The wizard IS the agenc CLI: re-invoke our own entrypoint for one
+  // headless turn inside the workspace. acceptEdits lets the agent write
+  // IDENTITY.md (and tidy BOOTSTRAP.md); the workspace was trusted above.
+  const entry = process.argv[1];
+  const result = spawnSync(
+    process.execPath,
+    [
+      entry,
+      "-p",
+      "--permission-mode",
+      "acceptEdits",
+      "Complete the bootstrap ritual now: introduce yourself and record your identity as instructed.",
+    ],
+    { cwd: workspace, encoding: "utf8", timeout: 180_000 },
+  );
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+  return Promise.resolve({ ok: result.status === 0, output });
+}
+
+export async function runIdentityAct(
+  options: IdentityActOptions,
+): Promise<number> {
+  const { io } = options;
+  const env = options.env ?? process.env;
+  const runRitual = options.runRitualTurn ?? defaultRunRitualTurn;
+
+  io.say("");
+  io.say("── Name your agent ──────────────────────────────────────────");
+  io.say("Your agent gets a home directory. Files there define who it is:");
+  io.say("  SOUL.md (personality) · USER.md (you) · IDENTITY.md (its name,");
+  io.say("  written by the agent itself in a one-time naming ritual).");
+  io.say("");
+
+  const suggested =
+    options.defaultWorkspace ?? join(env.HOME ?? homedir(), "agent");
+  const answered = await io.ask("Where should your agent live?", suggested);
+  const workspace = isAbsolute(answered)
+    ? answered
+    : resolve(env.HOME ?? homedir(), answered);
+  mkdirSync(workspace, { recursive: true });
+
+  // Trust the workspace so sessions there start without the trust prompt.
+  trustProjectSync({ agencHome: options.agencHome, env, projectRoot: workspace });
+  // Best-effort git init: history for persona edits, and a project-root marker.
+  if (!existsSync(join(workspace, ".git"))) {
+    spawnSync("git", ["init", "-q"], { cwd: workspace });
+  }
+
+  // SOUL.md — 3 quick choices, never clobbered.
+  const soulPath = join(workspace, "SOUL.md");
+  if (existsSync(soulPath)) {
+    io.say(`SOUL.md already exists — keeping it (edit ${soulPath} any time).`);
+  } else {
+    const tone = await io.select("Pick a personality baseline:", [
+      { key: "direct", label: "Direct", hint: "answer-first, no filler" },
+      { key: "warm", label: "Warm", hint: "encouraging, shows reasoning" },
+      { key: "terse", label: "Terse", hint: "short sentences, no preamble" },
+    ]);
+    const verbosity = await io.select("Default verbosity:", [
+      { key: "concise", label: "Concise" },
+      { key: "detailed", label: "Detailed" },
+    ]);
+    writeFileSync(soulPath, soulTemplate(tone, verbosity));
+    io.say(`Wrote ${soulPath}`);
+  }
+
+  // USER.md — who the human is, never clobbered.
+  const userPath = join(workspace, "USER.md");
+  if (existsSync(userPath)) {
+    io.say("USER.md already exists — keeping it.");
+  } else {
+    const name = await io.ask("What should the agent call you?", "friend");
+    const context = await io.ask(
+      "One line of context about you (optional)",
+      "",
+    );
+    writeFileSync(userPath, userTemplate(name, context));
+    io.say(`Wrote ${userPath}`);
+  }
+
+  // The naming ritual — mechanically once (IDENTITY.md existence gate).
+  const identityPath = join(workspace, "IDENTITY.md");
+  if (existsSync(identityPath)) {
+    const identity = readFileSync(identityPath, "utf8").trim().split("\n")[0];
+    io.say("");
+    io.say(`This agent already has an identity: ${identity}`);
+    io.say(`(Edit ${identityPath} to change it — the ritual never re-runs.)`);
+  } else {
+    const bootstrapPath = join(workspace, "BOOTSTRAP.md");
+    if (!existsSync(bootstrapPath)) {
+      writeFileSync(bootstrapPath, BOOTSTRAP_TEMPLATE);
+    }
+    io.say("");
+    io.say("Ready for the naming ritual: one live turn in the new workspace.");
+    io.say("(Runs with acceptEdits so the agent can write IDENTITY.md there.)");
+    const go = await io.confirm("Run it now?", true);
+    if (go) {
+      io.say("… running (this is a real model turn) …");
+      const result = await runRitual(workspace);
+      if (result.output.length > 0) {
+        io.say("");
+        io.say(result.output);
+        io.say("");
+      }
+      if (result.ok && existsSync(identityPath)) {
+        io.say(
+          `IDENTITY.md written by the agent itself. That name is now part of every conversation in ${workspace}.`,
+        );
+      } else if (result.ok) {
+        io.say(
+          "The turn ran but IDENTITY.md was not written — the ritual will re-offer on the agent's next session in this workspace.",
+        );
+      } else {
+        io.say(
+          "The ritual turn failed (see output above). BOOTSTRAP.md stays in place — the agent will pick it up on its next session here.",
+        );
+      }
+    } else {
+      io.say(
+        "Skipped — the agent will run the ritual on its first real session in this workspace.",
+      );
+    }
+  }
+
+  markOnboardingActComplete(options.agencHome, "identity", { workspace });
+  io.say("");
+  io.say("Editing these files IS the API: change SOUL.md/USER.md any time;");
+  io.say("changes apply from the next new conversation.");
+  return 0;
+}

--- a/runtime/src/onboarding/acts/io.ts
+++ b/runtime/src/onboarding/acts/io.ts
@@ -1,0 +1,172 @@
+/**
+ * Interactive IO for onboarding acts (onboarding-plan-2026-07 §4).
+ *
+ * The acts (identity/channel/autonomy) are plain readline flows, NOT Ink —
+ * they run after the first-run TUI wizard, are re-enterable from the shell
+ * (`agenc onboard identity|channel|autonomy`), and must be deterministic
+ * under test. Everything interactive goes through this seam; tests inject
+ * a scripted implementation and never touch a real terminal.
+ *
+ * ONE readline interface lives for the whole act: creating an interface per
+ * question loses buffered lines on piped (non-TTY) stdin — the first
+ * interface swallows the entire pipe. (Found live; pinned by test.)
+ */
+
+import { createInterface, type Interface } from "node:readline";
+import { Writable } from "node:stream";
+
+export interface ActSelectChoice {
+  readonly key: string;
+  readonly label: string;
+  readonly hint?: string;
+}
+
+export interface ActIO {
+  /** Print a line to the user. */
+  say(line: string): void;
+  /** Free-text question; empty input returns `fallback` when provided. */
+  ask(question: string, fallback?: string): Promise<string>;
+  /** Secret question (input not echoed on a TTY). */
+  askSecret(question: string): Promise<string>;
+  confirm(question: string, fallback: boolean): Promise<boolean>;
+  /** Numbered menu; returns the chosen key. */
+  select(question: string, choices: readonly ActSelectChoice[]): Promise<string>;
+  /** Release the underlying terminal. Idempotent. */
+  close(): void;
+}
+
+export function createTerminalActIO(
+  input: NodeJS.ReadableStream = process.stdin,
+  output: NodeJS.WritableStream = process.stdout,
+): ActIO {
+  // Mutable echo gate for secret prompts: readline echoes what the user
+  // types through THIS stream, so muting it hides the secret while the
+  // prompt itself is written directly to the real output.
+  let muted = false;
+  const echo = new Writable({
+    write(chunk, encoding, callback) {
+      if (!muted) output.write(chunk, encoding as BufferEncoding);
+      callback();
+    },
+  });
+  const isTty = (input as { isTTY?: boolean }).isTTY === true;
+  let rl: Interface | null = createInterface({
+    input,
+    output: echo,
+    terminal: isTty,
+  });
+  // Buffer lines that arrive before a question is pending: piped stdin
+  // delivers everything instantly, long before the prompts render.
+  const bufferedLines: string[] = [];
+  const waiters: Array<(line: string) => void> = [];
+  let closed = false;
+  rl.on("line", (line) => {
+    const waiter = waiters.shift();
+    if (waiter !== undefined) waiter(line);
+    else bufferedLines.push(line);
+  });
+  rl.on("close", () => {
+    closed = true;
+    while (waiters.length > 0) waiters.shift()!("");
+  });
+  const nextLine = (): Promise<string> => {
+    const buffered = bufferedLines.shift();
+    if (buffered !== undefined) return Promise.resolve(buffered);
+    if (closed) return Promise.resolve("");
+    return new Promise((resolve) => waiters.push(resolve));
+  };
+  const write = (text: string) => output.write(text);
+  const question = async (prompt: string, secret: boolean): Promise<string> => {
+    write(prompt);
+    if (secret) muted = true;
+    const answer = await nextLine();
+    if (secret) {
+      muted = false;
+      write("\n");
+    }
+    return answer.trim();
+  };
+
+  return {
+    say: (line) => write(`${line}\n`),
+    async ask(q, fallback) {
+      const suffix = fallback !== undefined ? ` [${fallback}]` : "";
+      const answer = await question(`${q}${suffix}: `, false);
+      return answer.length > 0 ? answer : (fallback ?? "");
+    },
+    askSecret: (q) => question(`${q}: `, true),
+    async confirm(q, fallback) {
+      const suffix = fallback ? " [Y/n]" : " [y/N]";
+      const answer = (await question(`${q}${suffix}: `, false)).toLowerCase();
+      if (answer.length === 0) return fallback;
+      return answer === "y" || answer === "yes";
+    },
+    async select(q, choices) {
+      write(`${q}\n`);
+      choices.forEach((choice, index) => {
+        write(
+          `  ${index + 1}) ${choice.label}${choice.hint !== undefined ? `  — ${choice.hint}` : ""}\n`,
+        );
+      });
+      for (;;) {
+        const answer = await question(`Choose [1-${choices.length}]: `, false);
+        const index = Number.parseInt(answer, 10) - 1;
+        const choice = choices[index];
+        if (choice !== undefined) return choice.key;
+        const byKey = choices.find((c) => c.key === answer);
+        if (byKey !== undefined) return byKey.key;
+        write("  Please pick one of the listed numbers.\n");
+      }
+    },
+    close() {
+      rl?.close();
+      rl = null;
+    },
+  };
+}
+
+/** Scripted IO for tests: queued answers, captured output. */
+export function createScriptedActIO(answers: readonly string[]): {
+  io: ActIO;
+  output: string[];
+} {
+  const queue = [...answers];
+  const output: string[] = [];
+  const next = (): string => {
+    const answer = queue.shift();
+    if (answer === undefined) {
+      throw new Error(
+        `scripted ActIO ran out of answers; output so far:\n${output.join("\n")}`,
+      );
+    }
+    return answer;
+  };
+  return {
+    output,
+    io: {
+      say: (line) => {
+        output.push(line);
+      },
+      async ask(q, fallback) {
+        output.push(`ask: ${q}`);
+        const answer = next();
+        return answer.length > 0 ? answer : (fallback ?? "");
+      },
+      async askSecret(q) {
+        output.push(`secret: ${q}`);
+        return next();
+      },
+      async confirm(q, fallback) {
+        output.push(`confirm: ${q}`);
+        const answer = next().toLowerCase();
+        if (answer.length === 0) return fallback;
+        return answer === "y" || answer === "yes";
+      },
+      async select(q, choices) {
+        output.push(`select: ${q} (${choices.map((c) => c.key).join("|")})`);
+        return next();
+      },
+      close: () => {},
+    },
+  };
+}

--- a/runtime/src/onboarding/acts/recap.ts
+++ b/runtime/src/onboarding/acts/recap.ts
@@ -1,0 +1,139 @@
+/**
+ * Onboarding posture recap + what-now card (onboarding-plan-2026-07 O-6).
+ *
+ * One screen that answers "what did I just open, and is it safe?": the
+ * security audit result plus a per-surface posture summary, then five
+ * starter prompts. Also powers the extended `agenc onboard --status`.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { loadConfig } from "../../config/loader.js";
+import { resolveBudgetPolicy } from "../../budget/index.js";
+import { resolveHeartbeatPolicy } from "../../heartbeat/config.js";
+import { loadGatewayConfig } from "../../gateway/config.js";
+import { readGatewayEnvFile } from "../../gateway/env-file.js";
+import {
+  buildSecurityAuditReport,
+  securityAuditExitCode,
+  type SecurityAuditReport,
+} from "../../bin/security-cli.js";
+import { readOnboardingActs, type OnboardingActsState } from "./state.js";
+import type { ActIO } from "./io.js";
+
+export interface OnboardingSurfaceSummary {
+  readonly acts: OnboardingActsState;
+  readonly personaWorkspace?: string;
+  readonly personaFiles: readonly string[];
+  readonly channels: readonly string[];
+  readonly hooksEnabled: boolean;
+  readonly budgetEnabled: boolean;
+  readonly heartbeatEnabled: boolean;
+}
+
+export async function buildOnboardingSurfaceSummary(
+  agencHome: string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<OnboardingSurfaceSummary> {
+  const acts = readOnboardingActs(agencHome);
+  const workspace = acts.acts.identity?.detail?.workspace;
+  const personaFiles: string[] = [];
+  if (workspace !== undefined) {
+    for (const name of ["SOUL.md", "USER.md", "IDENTITY.md"]) {
+      if (existsSync(join(workspace, name))) personaFiles.push(name);
+    }
+  }
+  const gatewayEnv = readGatewayEnvFile(agencHome);
+  const channels: string[] = [];
+  if (gatewayEnv.AGENC_TELEGRAM_BOT_TOKEN !== undefined) channels.push("telegram");
+  if (gatewayEnv.AGENC_DISCORD_BOT_TOKEN !== undefined) channels.push("discord");
+  if (
+    gatewayEnv.AGENC_SLACK_BOT_TOKEN !== undefined &&
+    gatewayEnv.AGENC_SLACK_APP_TOKEN !== undefined
+  ) {
+    channels.push("slack");
+  }
+  const gatewayConfig = loadGatewayConfig({ agencHome });
+  const { config } = await loadConfig({ home: agencHome, onWarn: () => {} });
+  return {
+    acts,
+    ...(workspace !== undefined ? { personaWorkspace: workspace } : {}),
+    personaFiles,
+    channels,
+    hooksEnabled: gatewayConfig.hooks?.enabled === true,
+    budgetEnabled: resolveBudgetPolicy(config.budget, env).policy.enabled,
+    heartbeatEnabled: resolveHeartbeatPolicy(config.heartbeat, env).enabled,
+  };
+}
+
+const STARTER_PROMPTS = [
+  '"summarize this repository and suggest one improvement"',
+  '"watch for TODOs in this project and keep a running list in NOTES.md"',
+  "(from your phone) \"what's on my plate today?\"",
+  '"schedule a 9am briefing of anything that changed overnight"',
+  "(from a script) curl your /hooks/agent endpoint with a deploy report",
+] as const;
+
+export async function runRecap(options: {
+  readonly agencHome: string;
+  readonly io: ActIO;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Test seam. */
+  readonly buildAuditReport?: () => Promise<SecurityAuditReport>;
+}): Promise<number> {
+  const { io, agencHome } = options;
+  const env = options.env ?? process.env;
+  const summary = await buildOnboardingSurfaceSummary(agencHome, env);
+  const report = await (options.buildAuditReport?.() ??
+    buildSecurityAuditReport({ env }));
+
+  io.say("");
+  io.say("── Your agent, at a glance ──────────────────────────────────");
+  io.say(
+    `  Identity:   ${
+      summary.personaWorkspace !== undefined
+        ? `${summary.personaWorkspace} (${summary.personaFiles.join(", ") || "no persona files yet"})`
+        : "not set up — agenc onboard identity"
+    }`,
+  );
+  io.say(
+    `  Channels:   ${
+      summary.channels.length > 0
+        ? `${summary.channels.join(", ")} (pairing-gated)`
+        : "none — agenc onboard channel"
+    }`,
+  );
+  io.say(
+    `  Budget:     ${summary.budgetEnabled ? "capped (agenc budget status)" : "no cap set"}`,
+  );
+  io.say(
+    `  Heartbeat:  ${summary.heartbeatEnabled ? "enabled (while the gateway runs)" : "off"}`,
+  );
+  io.say(
+    `  Webhooks:   ${summary.hooksEnabled ? "enabled (loopback + bearer token)" : "off"}`,
+  );
+  io.say("");
+
+  const critical = report.criticalCount;
+  if (securityAuditExitCode(report) === 0) {
+    io.say("  Security audit: all checks passed.");
+  } else {
+    io.say(`  Security audit: ${critical} critical finding(s) — details:`);
+    for (const finding of report.findings) {
+      if (finding.severity === "critical") {
+        io.say(`    ✗ ${finding.title}`);
+        if (finding.remediation !== undefined) {
+          io.say(`      fix: ${finding.remediation}`);
+        }
+      }
+    }
+  }
+
+  io.say("");
+  io.say("Things to try:");
+  for (const prompt of STARTER_PROMPTS) io.say(`  · ${prompt}`);
+  io.say("");
+  io.say("Any act re-runs any time: agenc onboard identity|channel|autonomy");
+  return securityAuditExitCode(report) === 0 ? 0 : 1;
+}

--- a/runtime/src/onboarding/acts/state.ts
+++ b/runtime/src/onboarding/acts/state.ts
@@ -1,0 +1,67 @@
+/**
+ * Per-act completion state (onboarding-plan-2026-07 §7).
+ *
+ * Lives in its own small file (`<agencHome>/onboarding-acts.json`, 0600)
+ * rather than the versioned first-run wizard state: acts are re-enterable
+ * shell flows with their own lifecycle, and the timestamps here ARE the
+ * local, consent-free funnel — nothing ever leaves the machine.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type OnboardingActId = "identity" | "channel" | "autonomy";
+
+export interface OnboardingActRecord {
+  readonly completedAt: string;
+  /** Act-specific breadcrumbs (workspace path, channel id, …). */
+  readonly detail?: Readonly<Record<string, string>>;
+}
+
+export interface OnboardingActsState {
+  readonly version: 1;
+  readonly acts: Readonly<Partial<Record<OnboardingActId, OnboardingActRecord>>>;
+}
+
+const DEFAULT_STATE: OnboardingActsState = { version: 1, acts: {} };
+
+export function onboardingActsPath(agencHome: string): string {
+  return join(agencHome, "onboarding-acts.json");
+}
+
+export function readOnboardingActs(agencHome: string): OnboardingActsState {
+  const path = onboardingActsPath(agencHome);
+  if (!existsSync(path)) return DEFAULT_STATE;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as OnboardingActsState;
+    if (raw !== null && typeof raw === "object" && raw.version === 1) {
+      return { version: 1, acts: raw.acts ?? {} };
+    }
+  } catch {
+    // Corrupt state = start fresh; acts are all re-runnable.
+  }
+  return DEFAULT_STATE;
+}
+
+export function markOnboardingActComplete(
+  agencHome: string,
+  act: OnboardingActId,
+  detail?: Readonly<Record<string, string>>,
+  now: Date = new Date(),
+): OnboardingActsState {
+  const current = readOnboardingActs(agencHome);
+  const next: OnboardingActsState = {
+    version: 1,
+    acts: {
+      ...current.acts,
+      [act]: {
+        completedAt: now.toISOString(),
+        ...(detail !== undefined ? { detail } : {}),
+      },
+    },
+  };
+  const path = onboardingActsPath(agencHome);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  return next;
+}

--- a/runtime/tests/bin/onboard-cli.test.ts
+++ b/runtime/tests/bin/onboard-cli.test.ts
@@ -120,7 +120,8 @@ describe("onboard status/reset against a temp home", () => {
     const text = formatOnboardStatusText(report);
     expect(text).toContain("completed (2026-07-01T00:00:00.000Z)");
     expect(text).toContain("Provider:  grok (grok-4)");
-    expect(text).toContain("Re-run the wizard with: agenc onboard");
+    // Wizard complete + no acts done → the status points at the next act.
+    expect(text).toContain("Next: agenc onboard identity");
   });
 
   test("status --json emits the report as JSON via the runner", async () => {

--- a/runtime/tests/bin/security-cli.test.ts
+++ b/runtime/tests/bin/security-cli.test.ts
@@ -176,6 +176,23 @@ describe("security audit against a temp home", () => {
     ).toBe("warn");
   });
 
+  test("group-readable gateway secrets (env/tokens) are critical; --fix chmods", async () => {
+    mkdirSync(join(home, "gateway"), { recursive: true, mode: 0o700 });
+    writeFileSync(join(home, "gateway", "env"), "AGENC_TELEGRAM_BOT_TOKEN=x");
+    chmodSync(join(home, "gateway", "env"), 0o644);
+    const before = await buildSecurityAuditReport({ env });
+    expect(
+      before.findings.find((f) => f.id === "sensitive-file-perms:gateway/env")
+        ?.severity,
+    ).toBe("critical");
+    const fixed = await buildSecurityAuditReport({ env, applyFixes: true });
+    expect(
+      fixed.findings.find((f) => f.id === "sensitive-file-perms:gateway/env")
+        ?.fixed,
+    ).toBe(true);
+    expect(statSync(join(home, "gateway", "env")).mode & 0o777).toBe(0o600);
+  });
+
   test("hooks enabled WITHOUT a token is critical (task 17 acceptance)", async () => {
     mkdirSync(join(home, "gateway"), { recursive: true, mode: 0o700 });
     writeFileSync(

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -113,6 +113,20 @@ describe("startGateway", () => {
     expect(sanitized.AGENC_SLACK_APP_TOKEN).toBeUndefined();
   });
 
+  test("hooks-only run is valid (a trigger surface counts as a reason to run)", async () => {
+    writeConfig({});
+    const client = new FakeClient();
+    const handle = await startGateway({
+      agencHome: home,
+      hooks: true,
+      hooksPort: 0,
+      clientFactory: async () => client,
+    });
+    expect(handle.hooksPort).toBeGreaterThan(0);
+    expect(handle.channels).toEqual([]);
+    await handle.stop();
+  });
+
   test("no channels enabled → throws before touching the daemon client", async () => {
     let factoryCalled = false;
     await expect(

--- a/runtime/tests/onboarding/acts.test.ts
+++ b/runtime/tests/onboarding/acts.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Onboarding acts (onboarding-plan-2026-07 O-2/O-3/O-5/O-6): identity
+ * scaffold + naming ritual gate, channel wizard with live-validated tokens
+ * and the pairing walkthrough, guardrails-before-autonomy ordering, posture
+ * recap, and the gateway env-file — all through scripted IO seams.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createScriptedActIO } from "../../src/onboarding/acts/io.js";
+import { runIdentityAct } from "../../src/onboarding/acts/identity.js";
+import { runChannelAct } from "../../src/onboarding/acts/channel.js";
+import {
+  appendTomlSectionIfAbsent,
+  enableHooksInGatewayConfig,
+  runAutonomyAct,
+} from "../../src/onboarding/acts/autonomy.js";
+import {
+  buildOnboardingSurfaceSummary,
+  runRecap,
+} from "../../src/onboarding/acts/recap.js";
+import {
+  markOnboardingActComplete,
+  readOnboardingActs,
+} from "../../src/onboarding/acts/state.js";
+import {
+  mergeGatewayEnv,
+  readGatewayEnvFile,
+  writeGatewayEnvEntries,
+} from "../../src/gateway/env-file.js";
+import {
+  parseAgenCOnboardCliArgs,
+  buildOnboardStatusReport,
+  formatOnboardStatusText,
+} from "../../src/bin/onboard-cli.js";
+
+let home: string;
+let ws: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-acts-"));
+  chmodSync(home, 0o700);
+  ws = join(home, "agent-ws");
+});
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const ENV = () => ({ AGENC_HOME: home, HOME: home });
+
+describe("identity act (O-2)", () => {
+  test("scaffolds SOUL/USER/BOOTSTRAP, trusts the workspace, runs the ritual", async () => {
+    const { io } = createScriptedActIO([
+      ws, // workspace
+      "direct", // tone
+      "concise", // verbosity
+      "Tetsuo", // name
+      "ships fast", // context
+      "y", // run ritual
+    ]);
+    const ritual = vi.fn(async (workspace: string) => {
+      // Simulate the agent completing the ritual.
+      writeFileSync(join(workspace, "IDENTITY.md"), "Your name is Koi.");
+      rmSync(join(workspace, "BOOTSTRAP.md"));
+      return { ok: true, output: "I am Koi." };
+    });
+    const code = await runIdentityAct({
+      agencHome: home,
+      io,
+      env: ENV(),
+      runRitualTurn: ritual,
+    });
+
+    expect(code).toBe(0);
+    expect(readFileSync(join(ws, "SOUL.md"), "utf8")).toContain("direct");
+    expect(readFileSync(join(ws, "USER.md"), "utf8")).toContain("Tetsuo");
+    expect(existsSync(join(ws, "IDENTITY.md"))).toBe(true);
+    expect(existsSync(join(ws, "BOOTSTRAP.md"))).toBe(false);
+    expect(ritual).toHaveBeenCalledOnce();
+    // Workspace trusted so first sessions skip the trust prompt.
+    const trusted = JSON.parse(
+      readFileSync(join(home, "trusted-projects.json"), "utf8"),
+    ) as { trustedProjects: { path: string }[] };
+    expect(trusted.trustedProjects.some((p) => p.path.includes("agent-ws"))).toBe(
+      true,
+    );
+    // Funnel state recorded locally.
+    expect(readOnboardingActs(home).acts.identity?.detail?.workspace).toBe(ws);
+  });
+
+  test("never clobbers existing persona files; existing IDENTITY skips the ritual", async () => {
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(join(ws, "SOUL.md"), "hand-written soul");
+    writeFileSync(join(ws, "USER.md"), "hand-written user");
+    writeFileSync(join(ws, "IDENTITY.md"), "Your name is Hikari.");
+    const ritual = vi.fn();
+    const { io, output } = createScriptedActIO([ws]);
+    const code = await runIdentityAct({
+      agencHome: home,
+      io,
+      env: ENV(),
+      runRitualTurn: ritual as never,
+    });
+
+    expect(code).toBe(0);
+    expect(readFileSync(join(ws, "SOUL.md"), "utf8")).toBe("hand-written soul");
+    expect(readFileSync(join(ws, "USER.md"), "utf8")).toBe("hand-written user");
+    expect(ritual).not.toHaveBeenCalled();
+    expect(output.join("\n")).toContain("already has an identity");
+  });
+});
+
+describe("gateway env file", () => {
+  test("round-trips entries at 0600 and merges UNDER the real env", () => {
+    writeGatewayEnvEntries(home, { AGENC_TELEGRAM_BOT_TOKEN: "tok-123" });
+    expect(statSync(join(home, "gateway", "env")).mode & 0o777).toBe(0o600);
+    expect(readGatewayEnvFile(home).AGENC_TELEGRAM_BOT_TOKEN).toBe("tok-123");
+    // Explicit env always wins.
+    const merged = mergeGatewayEnv(home, {
+      AGENC_TELEGRAM_BOT_TOKEN: "explicit",
+    });
+    expect(merged.AGENC_TELEGRAM_BOT_TOKEN).toBe("explicit");
+    // Second write merges, not replaces.
+    writeGatewayEnvEntries(home, { AGENC_DISCORD_BOT_TOKEN: "d-1" });
+    expect(readGatewayEnvFile(home)).toMatchObject({
+      AGENC_TELEGRAM_BOT_TOKEN: "tok-123",
+      AGENC_DISCORD_BOT_TOKEN: "d-1",
+    });
+  });
+});
+
+describe("channel act (O-3)", () => {
+  const validators = {
+    telegram: vi.fn(async (token: string) =>
+      token === "good-token"
+        ? { ok: true, detail: "@testbot" }
+        : { ok: false, detail: "401" },
+    ),
+    discord: vi.fn(async () => ({ ok: true })),
+    slack: vi.fn(async () => ({ ok: true, detail: "bot user U1" })),
+  };
+
+  test("telegram: validates live (retry on bad token), stores 0600, runs the pairing walkthrough", async () => {
+    const stopped = vi.fn();
+    const startGatewayFn = vi.fn(async () => {
+      // The 'user pairs from their phone': the gateway would write this.
+      mkdirSync(join(home, "gateway"), { recursive: true });
+      writeFileSync(
+        join(home, "gateway", "pairing.json"),
+        JSON.stringify({ version: 1, paired: { telegram: ["42"] } }),
+      );
+      return {
+        gateway: {} as never,
+        channels: ["telegram"],
+        stop: stopped,
+      };
+    });
+    const { io, output } = createScriptedActIO([
+      "telegram", // surface
+      "bad-token", // first attempt fails validation
+      "y", // try again
+      "good-token", // verified
+      "y", // start the live smoke
+      "y", // did the agent reply?
+    ]);
+    const code = await runChannelAct({
+      agencHome: home,
+      io,
+      env: ENV(),
+      validators,
+      startGatewayFn: startGatewayFn as never,
+      pairingPollIntervalMs: 5,
+      pairingTimeoutMs: 2000,
+    });
+
+    expect(code).toBe(0);
+    expect(validators.telegram).toHaveBeenCalledTimes(2);
+    expect(readGatewayEnvFile(home).AGENC_TELEGRAM_BOT_TOKEN).toBe("good-token");
+    expect(statSync(join(home, "gateway", "env")).mode & 0o777).toBe(0o600);
+    // The gateway env file rode into the smoke run.
+    const startEnv = (startGatewayFn.mock.calls[0][0] as { env: Record<string, string> })
+      .env;
+    expect(startEnv.AGENC_TELEGRAM_BOT_TOKEN).toBe("good-token");
+    expect(stopped).toHaveBeenCalled();
+    expect(output.join("\n")).toContain("Paired: 42");
+    expect(readOnboardingActs(home).acts.channel?.detail?.channel).toBe(
+      "telegram",
+    );
+  });
+
+  test("webchat needs no token and surfaces the operator URL", async () => {
+    const startGatewayFn = vi.fn(async () => ({
+      gateway: {} as never,
+      channels: ["webchat"],
+      webchatUrl: "http://127.0.0.1:9999/?token=abc",
+      stop: vi.fn(),
+    }));
+    const { io, output } = createScriptedActIO([
+      "webchat",
+      "y", // start smoke
+      "y", // replied
+    ]);
+    const code = await runChannelAct({
+      agencHome: home,
+      io,
+      env: ENV(),
+      validators,
+      startGatewayFn: startGatewayFn as never,
+    });
+    expect(code).toBe(0);
+    expect(output.join("\n")).toContain("http://127.0.0.1:9999/?token=abc");
+    expect(existsSync(join(home, "gateway", "env"))).toBe(false);
+  });
+});
+
+describe("autonomy act (O-5): guardrails before autonomy", () => {
+  test("sets the budget cap, then heartbeat/cron/hooks configure", async () => {
+    mkdirSync(ws, { recursive: true });
+    markOnboardingActComplete(home, "identity", { workspace: ws });
+    const { io, output } = createScriptedActIO([
+      "2.5", // daily cap
+      "y", // enable heartbeat
+      ws, // workspace
+      "", // deliver channel (none)
+      "y", // add cron job
+      ws, // workspace
+      "0 9 * * *",
+      "morning briefing please",
+      "", // no channel
+      "y", // enable hooks
+    ]);
+    const code = await runAutonomyAct({
+      agencHome: home,
+      io,
+      env: ENV(),
+      now: () => Date.parse("2026-07-09T10:00:00Z"),
+    });
+
+    expect(code).toBe(0);
+    const toml = readFileSync(join(home, "config.toml"), "utf8");
+    expect(toml).toContain("[budget]");
+    expect(toml).toContain("daily_usd = 2.5");
+    expect(toml).toContain("[heartbeat]");
+    expect(readFileSync(join(ws, "HEARTBEAT.md"), "utf8")).toContain(
+      "HEARTBEAT_OK",
+    );
+    const tasks = JSON.parse(
+      readFileSync(join(ws, ".agenc", "scheduled_tasks.json"), "utf8"),
+    ) as { tasks: { cron: string; prompt: string }[] };
+    expect(tasks.tasks[0]).toMatchObject({
+      cron: "0 9 * * *",
+      prompt: "morning briefing please",
+    });
+    const gatewayConfig = JSON.parse(
+      readFileSync(join(home, "gateway", "config.json"), "utf8"),
+    ) as { hooks?: { enabled?: boolean } };
+    expect(gatewayConfig.hooks?.enabled).toBe(true);
+    // The hooks token was minted for the curl example.
+    expect(existsSync(join(home, "gateway", "hooks-token"))).toBe(true);
+    expect(output.join("\n")).toContain("curl -s -X POST");
+  });
+
+  test("REFUSES heartbeat/cron/hooks without a cap unless capless is explicit", async () => {
+    const { io, output } = createScriptedActIO([
+      "none", // no cap...
+      "", // ...confirm capless? default N → back to the top
+      "3", // ok, set a cap after all
+      "", // heartbeat? default N
+      "", // cron? default N
+      "", // hooks? default N
+    ]);
+    const code = await runAutonomyAct({ agencHome: home, io, env: ENV() });
+    expect(code).toBe(0);
+    expect(readFileSync(join(home, "config.toml"), "utf8")).toContain(
+      "daily_usd = 3",
+    );
+    expect(output.join("\n")).toContain("without limit");
+  });
+
+  test("appendTomlSectionIfAbsent never rewrites an existing section", () => {
+    writeFileSync(join(home, "config.toml"), "[budget]\ndaily_usd = 99\n");
+    const wrote = appendTomlSectionIfAbsent(home, "budget", ["daily_usd = 1"]);
+    expect(wrote).toBe(false);
+    expect(readFileSync(join(home, "config.toml"), "utf8")).toContain("99");
+  });
+
+  test("enableHooksInGatewayConfig preserves unrelated keys", () => {
+    mkdirSync(join(home, "gateway"), { recursive: true });
+    writeFileSync(
+      join(home, "gateway", "config.json"),
+      JSON.stringify({ channels: { telegram: { dmPolicy: "pairing", allowlist: [] } } }),
+    );
+    enableHooksInGatewayConfig(home);
+    const config = JSON.parse(
+      readFileSync(join(home, "gateway", "config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(config.channels).toBeDefined();
+    expect((config.hooks as { enabled: boolean }).enabled).toBe(true);
+  });
+});
+
+describe("recap (O-6) + status funnel", () => {
+  test("summarizes surfaces and renders the posture card", async () => {
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(join(ws, "SOUL.md"), "s");
+    writeFileSync(join(ws, "IDENTITY.md"), "i");
+    markOnboardingActComplete(home, "identity", { workspace: ws });
+    writeGatewayEnvEntries(home, { AGENC_TELEGRAM_BOT_TOKEN: "t" });
+    enableHooksInGatewayConfig(home);
+
+    const summary = await buildOnboardingSurfaceSummary(home, ENV());
+    expect(summary.personaFiles).toEqual(["SOUL.md", "IDENTITY.md"]);
+    expect(summary.channels).toEqual(["telegram"]);
+    expect(summary.hooksEnabled).toBe(true);
+
+    const { io, output } = createScriptedActIO([]);
+    const code = await runRecap({
+      agencHome: home,
+      io,
+      env: ENV(),
+      buildAuditReport: async () =>
+        ({ findings: [], criticalCount: 0, warnCount: 0 }) as never,
+    });
+    expect(code).toBe(0);
+    const text = output.join("\n");
+    expect(text).toContain("telegram (pairing-gated)");
+    expect(text).toContain("Things to try:");
+  });
+
+  test("onboard CLI parses acts and --status reports the funnel", async () => {
+    expect(parseAgenCOnboardCliArgs(["onboard", "identity"])).toEqual({
+      kind: "act",
+      act: "identity",
+    });
+    expect(parseAgenCOnboardCliArgs(["onboard", "channel"])).toEqual({
+      kind: "act",
+      act: "channel",
+    });
+    expect(parseAgenCOnboardCliArgs(["onboard", "autonomy", "extra"])).toMatchObject(
+      { kind: "error" },
+    );
+
+    markOnboardingActComplete(home, "identity", { workspace: ws });
+    const report = await buildOnboardStatusReport({ env: ENV() });
+    expect(report.acts.identity?.detail?.workspace).toBe(ws);
+    const text = formatOnboardStatusText(report);
+    expect(text).toContain("Identity:  done");
+    expect(text).toContain("Channel:   not yet");
+  });
+});
+
+describe("gateway install-service (O-4)", () => {
+  test("linux: writes the systemd user unit with EnvironmentFile and enables it", async () => {
+    const { installGatewayService } = await import("../../src/bin/gateway-cli.js");
+    const out: string[] = [];
+    const commands: string[][] = [];
+    const code = await installGatewayService({
+      agencHome: home,
+      stdout: (l) => out.push(l),
+      stderr: (l) => out.push(l),
+      platform: "linux",
+      home,
+      execPath: "/usr/bin/node",
+      entryPath: "/opt/agenc/bin/agenc.js",
+      runCommand: (cmd, args) => {
+        commands.push([cmd, ...args]);
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    const unit = readFileSync(
+      join(home, ".config", "systemd", "user", "agenc-gateway.service"),
+      "utf8",
+    );
+    expect(unit).toContain("ExecStart=/usr/bin/node /opt/agenc/bin/agenc.js gateway run");
+    expect(unit).toContain(`EnvironmentFile=-${join(home, "gateway", "env")}`);
+    expect(commands).toEqual([
+      ["systemctl", "--user", "daemon-reload"],
+      ["systemctl", "--user", "enable", "--now", "agenc-gateway"],
+    ]);
+  });
+
+  test("darwin writes a launchd plist; other platforms explain themselves", async () => {
+    const { installGatewayService } = await import("../../src/bin/gateway-cli.js");
+    const out: string[] = [];
+    const code = await installGatewayService({
+      agencHome: home,
+      stdout: (l) => out.push(l),
+      stderr: (l) => out.push(l),
+      platform: "darwin",
+      home,
+      execPath: "/usr/bin/node",
+      entryPath: "/opt/agenc/bin/agenc.js",
+      runCommand: () => true,
+    });
+    expect(code).toBe(0);
+    const plist = readFileSync(
+      join(home, "Library", "LaunchAgents", "dev.agenc.gateway.plist"),
+      "utf8",
+    );
+    expect(plist).toContain("<string>gateway</string>");
+
+    const other = await installGatewayService({
+      agencHome: home,
+      stdout: (l) => out.push(l),
+      stderr: (l) => out.push(l),
+      platform: "win32",
+      home,
+      runCommand: () => true,
+    });
+    expect(other).toBe(1);
+    expect(out.join("\n")).toContain("agenc gateway run");
+  });
+});
+
+describe("terminal ActIO", () => {
+  test("piped stdin answers survive across MULTIPLE questions (single readline)", async () => {
+    const { PassThrough } = await import("node:stream");
+    const { createTerminalActIO } = await import(
+      "../../src/onboarding/acts/io.js"
+    );
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const io = createTerminalActIO(input, output);
+    // All answers arrive in ONE buffered write — the per-question-interface
+    // bug swallowed everything after the first line.
+    input.write("first\nsecond\n2\n");
+    input.end();
+    expect(await io.ask("q1")).toBe("first");
+    expect(await io.ask("q2")).toBe("second");
+    expect(
+      await io.select("pick", [
+        { key: "a", label: "A" },
+        { key: "b", label: "B" },
+      ]),
+    ).toBe("b");
+    io.close();
+  });
+});


### PR DESCRIPTION
## What

Implements workstreams **O-2/O-3/O-4/O-5/O-6** of `docs/onboarding-plan-2026-07.md` (the plan ships in this PR). Onboarding previously ended exactly where the product begins — everything after the first-run wizard (personas, channels, budgets, heartbeat, cron, webhooks) was env vars and hand-edited JSON. This adds the guided second and third acts as plain readline flows (`runtime/src/onboarding/acts/` — no Ink, scripted-IO test seams).

## The acts

- **`agenc onboard identity` (O-2)** — persona workspace scaffold (SOUL/USER/BOOTSTRAP.md from 3 quick choices, never clobbering), workspace trust, git init, then the **naming ritual run live** (`agenc -p --permission-mode acceptEdits`, narrated). Non-completion degrades gracefully — the IDENTITY.md gate is mechanical, so the ritual re-offers next session.
- **`agenc onboard channel` (O-3)** — Telegram/Discord/Slack/WebChat guided token acquisition with **live validation** (getMe / /gateway/bot / auth.test+connections.open) and inline trap callouts (Discord MESSAGE_CONTENT intent). Secrets land in a **0600 `gateway/env` file** — loaded by `gateway run` (merged UNDER real env) and the service unit, never in config.json, never reaching the daemon. Finale = the pairing walkthrough: gateway starts in-process, the user pairs from their phone (pairing.json polled), and confirms the reply.
- **`agenc onboard autonomy` (O-5)** — **budget cap FIRST, hard-ordered** (heartbeat/cron/hooks refuse while capless unless explicitly chosen); append-only config.toml writes (never rewrites operator TOML); HEARTBEAT.md template; cron example with channel delivery via the real task-file helpers; webhook enablement printing the minted-token curl.
- **`agenc onboard recap` + extended `--status` (O-6)** — posture card (security audit + opened surfaces + starter prompts); `--status` now carries per-act timestamps: the local, consent-free funnel.
- **`agenc gateway install-service` (O-4)** — always-on systemd `--user` unit (EnvironmentFile=gateway/env) / launchd plist, no sudo.

## Runtime fixes riding along

- Hooks-only `gateway run` is now valid (a trigger surface is a reason to run).
- `gateway/env`, `gateway/hooks-token`, `gateway/webchat-token` join the sensitive-file-perms audit (fixable, tested).
- `agenc gateway run` merges the env file under the caller's environment.

## Found live and pinned

Per-question readline interfaces **swallow piped stdin** (the first interface buffers the whole pipe; lines emitted before a listener are dropped). The IO layer now uses ONE line-buffered interface for the act's lifetime — regression pinned with a real-stream test.

## Live smoke (real daemon + ollama)

`agenc onboard identity` end-to-end: piped answers through every prompt, files scaffolded, workspace trusted, REAL ritual turn ran (acceptEdits), graceful non-completion path exercised (7b model quirk), `onboard --status` funnel + `onboard recap` posture card verified — recap caught a genuine 0644 finding on the smoke home.

## Tests

17 new (identity scaffold/no-clobber/ritual-gate, env-file round-trip + precedence, channel token-retry/0600/pairing-walkthrough/webchat, autonomy ordering + refusals + TOML append-only + hooks-merge, recap summary, CLI parse/status funnel, install-service linux/darwin/other, hooks-only run, gateway-secrets audit, piped-stdin pin). Revert-proven ×4 (onboard-cli, gateway-cli, run.ts, security-cli vs HEAD).

## Gates

build ✓ · typecheck ✓ · vitest **14374 passed** (one pre-existing status-footer expectation updated for the new next-act hint) · test:bun ✓ · agent-surface-contract ✓ (standalone; in-gate failure was the documented workbench load-flake at loadavg 19) · tui-runtime-startup ✓