### PR TITLE
feat(onboarding): Act-1 zero-key path + guaranteed first magic (plan O-1) + Act 2/3 docs (O-7)

### DIFF
--- a/docs/onboarding-plan-2026-07.md
+++ b/docs/onboarding-plan-2026-07.md
@@ -5,6 +5,11 @@
 > workstreams below are written in TODO.md task format so they can be lifted
 > straight into the backlog.
 >
+> **Delivery status (2026-07-10):** O-2/O-3/O-4/O-5/O-6 shipped (PR #1454);
+> O-1 shipped (detection + annotation + guaranteed first turn); O-7 shipped
+> (this doc + quickstart Acts 2–3); O-8 deferred by design; O-9 partial (see
+> its section).
+>
 > **Status of the ground this stands on (verified 2026-07-09):** Phase 0
 > install/onboard/audit shipped (PRs #1401–#1411). Phase 1–2 shipped live:
 > channels (Telegram #1413, Discord/Slack #1444, WebChat #1415, stdio),
@@ -289,7 +294,7 @@ card (5 curated prompts exercising channels/cron/memory) and pointers:
   bare VPS. Take up only if §7 funnel data shows the Node ≥ 25
   prerequisite is the biggest drop.
 
-### O-9. First-week retention loop — S **[AFTER O-1..O-6]**
+### O-9. First-week retention loop — S **[PARTIAL — act-completion hints + recap prompts + --status next-act shipped; TUI-greeting and heartbeat-morning hints remain]**
 - **Build:** day-2+ nudges through surfaces we already own: heartbeat's
   first morning message includes "3 things you can ask me"; `agenc` TUI
   greeting shows one unexplored-capability hint (local state only).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# AgenC in 5 minutes
+# AgenC in 5 minutes (your agent in 15)
 
 Prerequisites: Node.js >= 25, `tar`, and one model-provider credential (an
 xAI/OpenAI/Anthropic/OpenRouter key, or a local Ollama/LM Studio endpoint —
@@ -47,6 +47,33 @@ agenc daemon status                    # the daemon owns sessions/agents
 From here: `/help` inside the TUI lists slash commands; background agents run
 via `agenc agent start <objective>`; sessions resume with `--continue` /
 `--resume`.
+
+## 5. Make it YOUR agent (Act 2)
+
+```bash
+agenc onboard identity     # name your agent: persona workspace + naming ritual
+agenc onboard channel      # Telegram/Discord/Slack/WebChat, token checked live,
+                           # pairing walkthrough ends with a reply on your phone
+agenc gateway install-service   # keep the gateway always-on (systemd/launchd)
+```
+
+`identity` scaffolds `SOUL.md` / `USER.md` and runs a one-time naming ritual —
+the agent chooses its own name and writes `IDENTITY.md`. Editing those files
+IS the API. `channel` validates your bot token before anything persists,
+stores it 0600 in `gateway/env`, and walks you through pairing: strangers who
+find your bot get a code, not your agent.
+
+## 6. Bounded autonomy (Act 3)
+
+```bash
+agenc onboard autonomy     # budget cap FIRST, then heartbeat, cron, webhooks
+agenc onboard recap        # posture summary + things to try
+```
+
+The order is the design: nothing autonomous enables before a spend cap
+exists. When a cap is hit, autonomy pauses and tells you — never silently
+spends or silently stops. `agenc onboard --status` shows how far you are at
+any time.
 
 Coming from another assistant? See
 [Migrate from OpenClaw](migrate-from-openclaw.md) and

--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -107,6 +107,8 @@ export interface FirstRunOnboardingState {
   readonly pendingApiKeyApproval: PendingApiKeyApproval | null;
   readonly error: string | null;
   readonly isCheckingConnection: boolean;
+  /** Local runtimes found listening (O-1): annotated in the provider step. */
+  readonly detectedLocalProviders: readonly BuiltInProviderSlug[];
 }
 
 export interface FirstRunByokAuthBackend {
@@ -258,7 +260,36 @@ export function createInitialFirstRunOnboardingState(
     pendingApiKeyApproval: null,
     error: null,
     isCheckingConnection: false,
+    detectedLocalProviders: [],
   };
+}
+
+
+/**
+ * Probe the well-known local runtimes (O-1, onboarding-plan-2026-07): a user
+ * with Ollama or LM Studio already running has a ZERO-KEY path to a working
+ * agent — the provider step must say so instead of walling them at the
+ * api-key step. Short-timeout, parallel, never throws.
+ */
+export async function detectRunningLocalProviders(
+  context: Pick<FirstRunOnboardingContext, "config" | "env" | "fetchImpl" | "checkLocalProviders">,
+): Promise<readonly BuiltInProviderSlug[]> {
+  if (context.checkLocalProviders === false) return [];
+  const candidates: readonly BuiltInProviderSlug[] = ["ollama", "lmstudio"];
+  const results = await Promise.all(
+    candidates.map(async (provider) => {
+      const settings = resolveProviderSettings(provider, context.config, context.env);
+      const baseURL = settings?.baseURL ?? BUILT_IN_PROVIDER_BASE_URLS[provider];
+      const reachable = await probeLocalProvider({
+        provider,
+        baseURL,
+        ...(context.fetchImpl !== undefined ? { fetchImpl: context.fetchImpl } : {}),
+        timeoutMs: 600,
+      }).catch(() => false);
+      return reachable ? provider : null;
+    }),
+  );
+  return results.filter((p): p is BuiltInProviderSlug => p !== null);
 }
 
 function providerChoices(
@@ -1050,6 +1081,22 @@ export function useFirstRunOnboardingController(
   }, [state]);
 
   useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    void detectRunningLocalProviders(options).then((detected) => {
+      if (cancelled || detected.length === 0) return;
+      setState((current) => {
+        const next = { ...current, detectedLocalProviders: detected };
+        stateRef.current = next;
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, options.config, options.env]);
+
+  useEffect(() => {
     if (!active || recordedSeen.current || options.agencHome === undefined) {
       return;
     }
@@ -1200,13 +1247,20 @@ export function detailLinesForStep(
         ),
         "Type a number or theme name.",
       ];
-    case "provider":
+    case "provider": {
+      const detected = new Set(state.detectedLocalProviders);
       return [
         ...providerChoices(context).map((provider, index) =>
-          `${index + 1}. ${provider}${provider === state.selectedProvider ? " (current)" : ""}`
+          `${index + 1}. ${provider}${provider === state.selectedProvider ? " (current)" : ""}${detected.has(provider) ? " — detected, running locally, no key needed" : ""}`
         ),
+        ...(detected.size > 0
+          ? [
+              `Tip: ${[...detected][0]} is already running on this machine — pick it for a zero-key start.`,
+            ]
+          : []),
         "Type a number or provider slug.",
       ];
+    }
     case "connection-test":
       return state.isCheckingConnection
         ? ["Checking provider readiness..."]

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -2104,6 +2104,26 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
     }
   }, [transcript.isStreaming, transcript.streamingText, assistantMessageCount]);
   useInitialSubmit(props.session, submit, props.initialPrompt, props.initialUserMessages);
+  // O-1 (onboarding-plan-2026-07): guaranteed first magic. When the first-run
+  // wizard completes IN THIS SESSION and the user brought no prompt of their
+  // own, run one starter turn for them — the first reply is a certainty, not
+  // a blank input box. Never fires for returning users (wizard never active)
+  // or when an initial prompt/messages were provided.
+  const onboardingWasActiveRef = useRef(false);
+  useEffect(() => {
+    const hadPrompt =
+      (props.initialPrompt?.length ?? 0) > 0 ||
+      (props.initialUserMessages?.length ?? 0) > 0;
+    if (onboarding.active) {
+      onboardingWasActiveRef.current = true;
+      return;
+    }
+    if (!onboardingWasActiveRef.current || hadPrompt) return;
+    onboardingWasActiveRef.current = false;
+    void submit(
+      "Introduce yourself in a sentence, then take a quick look at the current directory and suggest one useful thing you could help with here.",
+    ).catch(logError);
+  }, [onboarding.active, submit, props.initialPrompt, props.initialUserMessages]);
   useEffect(() => {
     if (queueDrainActiveRef.current) return;
     if (effectiveInputBusy) return;

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../tui/ink.js", async () => {
 import {
   checkOnboardingProviderConnection,
   createInitialFirstRunOnboardingState,
+  detectRunningLocalProviders,
   detailLinesForStep,
   submitFirstRunOnboardingInput,
 } from "./Onboarding.js";
@@ -997,5 +998,74 @@ describe("project onboarding counterpart steps", () => {
         });
       });
     });
+  });
+});
+
+describe("local runtime detection (O-1)", () => {
+  const config = defaultConfig();
+
+  function fetchRespondingOn(okUrls: readonly string[]): typeof fetch {
+    return (async (url: unknown) => {
+      const target = String(url);
+      if (okUrls.some((ok) => target.includes(ok))) {
+        return { ok: true, status: 200, json: async () => ({}) } as Response;
+      }
+      throw new Error("connection refused");
+    }) as typeof fetch;
+  }
+
+  test("a running Ollama is detected; silent ports are not", async () => {
+    const detected = await detectRunningLocalProviders({
+      config,
+      fetchImpl: fetchRespondingOn(["11434"]),
+    });
+    expect(detected).toEqual(["ollama"]);
+  });
+
+  test("nothing running → empty; checkLocalProviders false skips probing", async () => {
+    expect(
+      await detectRunningLocalProviders({
+        config,
+        fetchImpl: fetchRespondingOn([]),
+      }),
+    ).toEqual([]);
+    const fetchSpy = vi.fn();
+    expect(
+      await detectRunningLocalProviders({
+        config,
+        fetchImpl: fetchSpy as never,
+        checkLocalProviders: false,
+      }),
+    ).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("the provider step annotates detected runtimes and shows the zero-key tip", () => {
+    const context = { config };
+    const state = {
+      ...createInitialFirstRunOnboardingState(context),
+      currentStepId: "provider" as const,
+      detectedLocalProviders: ["ollama" as const],
+    };
+    const lines = detailLinesForStep(state, context as never).join("\n");
+    expect(lines).toContain("ollama");
+    expect(lines).toContain("detected, running locally, no key needed");
+    expect(lines).toContain("zero-key start");
+  });
+});
+
+describe("first-magic wiring contract (O-1b)", () => {
+  // The guaranteed-first-turn effect lives in the compiled App.tsx; a full
+  // component mount is impractical here, so the wiring is guarded at the
+  // source level (established pattern) and the behavior was verified live.
+  test("App.tsx submits a starter turn when the wizard completes without an initial prompt", async () => {
+    const { readFileSync } = await import("node:fs");
+    const source = readFileSync(
+      resolve(process.cwd(), "src/tui/components/App.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("guaranteed first magic");
+    expect(source).toContain("onboardingWasActiveRef");
+    expect(source).toContain("Introduce yourself in a sentence");
   });
 });


### PR DESCRIPTION
## What (onboarding-plan O-1 + O-7)

Closes the two Act-1 gaps and documents the full journey:

- **Zero-key path (O-1a)**: the first-run wizard's provider step now probes for a running **Ollama / LM Studio** (short-timeout, via the existing `probeLocalProvider`, honoring `checkLocalProviders`) and annotates the choice list — `ollama — detected, running locally, no key needed` plus a zero-key tip line. A keyless evaluator sees a way forward instead of a wall at the api-key step.
- **Guaranteed first magic (O-1b)**: when the wizard completes in-session and the user brought no prompt of their own, the TUI submits one starter turn automatically (introduce yourself + look at the cwd + suggest one useful thing). The first reply becomes a certainty, not an empty input box. Never fires for returning users or when an initial prompt exists.
- **Docs (O-7)**: quickstart gains Acts 2–3 (`onboard identity|channel|autonomy|recap`, `gateway install-service`); the plan doc records per-workstream delivery status (O-9 explicitly marked partial: act-completion hints + recap prompts + `--status` next-act shipped; TUI-greeting and heartbeat-morning hints remain).

## Tests

4 new: detection (running/none/skip-flag, injected fetch), provider-step annotation render, and a source contract for the App.tsx first-magic wiring (full component mount impractical; behavior spec'd + the effect is guarded at source level). Detection + annotation revert-proven red against HEAD Onboarding.tsx.

## Gates

build ✓ · typecheck ✓ · vitest **14378 passed** ✓ · test:bun ✓ · agent-surface-contract ✓ · tui-runtime-startup ✓ — all green in a single gate run.