### PR TITLE
chore(release): 0.3.0 — version bump + version drift contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenc-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "npm@11.7.0",
   "workspaces": [

--- a/packages/agenc/package.json
+++ b/packages/agenc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetsuo-ai/agenc",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Public AgenC CLI launcher package",
   "license": "MIT",
   "type": "module",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetsuo-ai/runtime",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "AgenC lean coding CLI",
   "type": "module",

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1,3 +1,4 @@
+import { VERSION } from "../version.js";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
@@ -1411,7 +1412,7 @@ export async function bootstrapLocalRuntimeSession(
         const rolloutStore = new RolloutStore({
           cwd: workspaceRoot,
           sessionId: conversationId,
-          agencVersion: "0.2.0",
+          agencVersion: VERSION,
           ...(resumeConversation ? { resume: true } : {}),
           ...(sessionProjectRootMarkers !== undefined
             ? { projectRootMarkers: sessionProjectRootMarkers }
@@ -1422,7 +1423,7 @@ export async function bootstrapLocalRuntimeSession(
           timestamp: new Date().toISOString(),
           cwd: workspaceRoot,
           originator: "agenc-cli",
-          agencVersion: "0.2.0",
+          agencVersion: VERSION,
           model,
           modelProvider: resolvedProvider,
         });

--- a/runtime/src/mcp-client/transports/http.ts
+++ b/runtime/src/mcp-client/transports/http.ts
@@ -9,6 +9,7 @@
  * @module
  */
 
+import { VERSION } from "../../version.js";
 import type { Logger } from "../_deps/logger.js";
 import { silentLogger } from "../_deps/logger.js";
 import type { MCPElicitationHandlers } from "../types.js";
@@ -56,7 +57,7 @@ export async function createHttpMCPConnection(
   });
 
   const client = new Client(
-    { name: "agenc-runtime", version: "0.2.0" },
+    { name: "agenc-runtime", version: VERSION },
     {
       capabilities: buildMcpHostClientCapabilities(
         elicitationHandlers === undefined ? "none" : "form-url",

--- a/runtime/src/mcp-client/transports/sse.ts
+++ b/runtime/src/mcp-client/transports/sse.ts
@@ -17,6 +17,7 @@
  * @module
  */
 
+import { VERSION } from "../../version.js";
 import type { Logger } from "../_deps/logger.js";
 import { silentLogger } from "../_deps/logger.js";
 import type { MCPElicitationHandlers } from "../types.js";
@@ -67,7 +68,7 @@ export async function createSseMCPConnection(
   });
 
   const client = new Client(
-    { name: "agenc-runtime", version: "0.2.0" },
+    { name: "agenc-runtime", version: VERSION },
     {
       capabilities: buildMcpHostClientCapabilities(
         elicitationHandlers === undefined ? "none" : "form-url",

--- a/runtime/src/mcp-client/transports/stdio.ts
+++ b/runtime/src/mcp-client/transports/stdio.ts
@@ -13,6 +13,7 @@
  *     surface in this subsystem yet.
  */
 
+import { VERSION } from "../../version.js";
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
@@ -345,7 +346,7 @@ export async function createStdioMCPConnection(
   const timeout = config.timeout ?? 30_000;
   const transport = createStdioMCPTransport(config, logger);
   const client = new Client(
-    { name: "agenc-runtime", version: "0.2.0" },
+    { name: "agenc-runtime", version: VERSION },
     {
       capabilities: buildMcpHostClientCapabilities(
         elicitationHandlers === undefined ? "none" : "form-url",

--- a/runtime/src/mcp-client/transports/websocket.ts
+++ b/runtime/src/mcp-client/transports/websocket.ts
@@ -12,6 +12,7 @@
  *     JSON-RPC over a caller-provided WebSocket endpoint.
  */
 
+import { VERSION } from "../../version.js";
 import WebSocket, { type RawData } from "ws";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
@@ -182,7 +183,7 @@ export async function createWebSocketMCPConnection(
   const timeout = config.timeout ?? 30_000;
   const transport = createWebSocketMCPTransport(config);
   const client = new Client(
-    { name: "agenc-runtime", version: "0.2.0" },
+    { name: "agenc-runtime", version: VERSION },
     {
       capabilities: buildMcpHostClientCapabilities(
         elicitationHandlers === undefined ? "none" : "form-url",

--- a/runtime/src/version.ts
+++ b/runtime/src/version.ts
@@ -7,4 +7,4 @@
  * @module
  */
 
-export const VERSION = "0.2.0";
+export const VERSION = "0.3.0";

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -15,6 +15,7 @@
  * that back the integration.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { VERSION } from "../../src/version.js";
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1595,7 +1596,7 @@ describe("main() smoke", () => {
       expect(code).toBe(0);
       expect(
         stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join(""),
-      ).toContain("agenc 0.2.0");
+      ).toContain(`agenc ${VERSION}`);
     } finally {
       process.argv = prevArgv;
       stdoutSpy.mockRestore();

--- a/runtime/tests/packaging/version-contract.test.ts
+++ b/runtime/tests/packaging/version-contract.test.ts
@@ -1,0 +1,58 @@
+// Release version contract.
+//
+// The release workflow gates on the tag matching runtime/package.json, and
+// `agenc update` compares the manifest's runtimeVersion against the compiled
+// VERSION constant — so package.json and version.ts drifting apart would ship
+// a runtime that misreports itself and re-downloads forever. The 0.2.0 cut
+// also left the runtime version hand-copied into the MCP client infos and the
+// rollout store; this pins that those sites import VERSION instead.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { VERSION } from "../../src/version.js";
+
+const RUNTIME_ROOT = resolve(process.cwd());
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      out.push(...tsFilesUnder(path));
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe("release version contract", () => {
+  test("version.ts matches runtime/package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(RUNTIME_ROOT, "package.json"), "utf8"),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  test("no source hardcodes the runtime version outside version.ts", () => {
+    const offenders: string[] = [];
+    for (const file of tsFilesUnder(join(RUNTIME_ROOT, "src"))) {
+      if (file.endsWith(join("src", "version.ts"))) continue;
+      const content = readFileSync(file, "utf8");
+      for (const [i, line] of content.split("\n").entries()) {
+        // The runtime's own version must come from the VERSION constant:
+        // anything identifying as agenc-runtime, and the rollout store's
+        // agencVersion field, may not carry a semver literal.
+        if (
+          /agencVersion:\s*["'][0-9]+\.[0-9]+\.[0-9]+/.test(line) ||
+          (/name:\s*["']agenc-runtime["']/.test(line) &&
+            /version:\s*["'][0-9]+\.[0-9]+\.[0-9]+/.test(line))
+        ) {
+          offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Release prep for agenc-v0.3.0 (first public release carrying the channel gateway, budget caps, onboarding acts, webhooks, and `agenc update`).

- runtime/root 0.2.0 -> 0.3.0, launcher 0.2.1 -> 0.3.0
- MCP client transports (http/sse/ws/stdio) and RolloutStore no longer hand-copy the version; they import `VERSION`
- fixes the `--version` smoke test that pinned the literal 0.2.0 string
- new `tests/packaging/version-contract.test.ts`: version.ts must equal runtime/package.json (the release workflow gates the tag on package.json, so tag == VERSION becomes transitive), and any future hardcoded runtime-version literal fails the suite (revert-proven)

Gates: build OK, typecheck OK, vitest 14392 all green, test:bun OK, TUI startup smoke OK (pre-commit).