### PR TITLE
docs: close coverage gaps and fix managed OpenRouter accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ check:unused                # knip (informational)
 builds multi-platform runtime tarballs on `workflow_dispatch`. There is no
 hosted test CI in this checkout — **local gates are authoritative**.
 
-Contributor guide: [`AGENTS.md`](AGENTS.md). Doc index: [`docs/INDEX.md`](docs/INDEX.md).
+Doc index: [`docs/INDEX.md`](docs/INDEX.md). Local contributor notes may live in a gitignored `AGENTS.md`.
 
 ## Security
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,6 +171,54 @@ confinement unless the sandbox is explicitly on.
 Mutating tools are guarded: file edits enforce read-before-write + mtime-drift
 checks; `apply_patch` applies multi-file patches transactionally.
 
+Full LIVE tool name catalog (by family), dual-catalog warning (LIVE vs TUI
+pool), and sandbox details:
+[`reference/tools-permissions-sandbox.md`](reference/tools-permissions-sandbox.md).
+
+## Turn phases (`runtime/src/phases`)
+
+One sampling iteration of the turn loop (`session/run-turn.ts`) runs an ordered
+phase machine. Module files under `runtime/src/phases/` own the heavy steps;
+`TurnState` documents the same numbering.
+
+| # | Stage | Module / site | Role |
+| --- | --- | --- | --- |
+| 1 | `prepareContext` | inline in `session/run-turn.ts` | Build messages for query, attachments, compact, request contract |
+| 2 | `streamModel` | `phases/stream-model.ts` | Stream provider response; capture assistant + tool-use blocks (may start streaming tool dispatch) |
+| 3 | `postSampleRecovery` | `phases/post-sample-recovery.ts` | Run recovery ladder on stream outcome / withheld errors |
+| 4 | `continuationNudge` | `phases/continuation-nudge.ts` | Nudge re-entry when the model stopped without required follow-up |
+| 5 | `executeTools` | `phases/execute-tools.ts` | Drain / finalize tool dispatch → tool results |
+| 6 | `commit` | `phases/commit.ts` | Terminal commit for the iteration; may re-enter via stop-hooks |
+
+`phases/stop-hooks.ts` is not a separate numbered stage: stop-hook blocking is
+evaluated from `commit` (and can set `transition` so the outer loop re-enters).
+`phases/events.ts` is the phase-yielded event envelope for the TUI / clients.
+
+Continue reasons and terminal reasons live on `session/turn-state.ts`
+(`ContinueReason`, `TerminalReason`).
+
+## Recovery ladder (`runtime/src/recovery`)
+
+When the last assistant message (or stream error) matches more than one
+recovery condition, triggers are evaluated in a **fixed priority order**
+(I-10). Source of truth: `recovery/triggers.ts` (`I10_TRIGGER_ORDER` /
+`buildDefaultTriggerOrder`). Orchestration + re-entry cap:
+`recovery/fallback-ladder.ts` (`RecoveryLadder`, `MAX_RECOVERY_REENTRIES = 5`).
+
+| Order | Trigger name | Intent |
+| --- | --- | --- |
+| 1 | `isWithheld413` | Prompt-too-long → collapse / reactive recovery |
+| 2 | `isWithheldMedia` | Media-too-large → reactive recovery (skips collapse) |
+| 3 | `isWithheldMaxOutputTokens` | Max-output-tokens → escalate or continuation |
+| 4 | `stopHookBlocking` | Stop-hook inject + re-enter |
+| 5 | `streamingFallbackOccured` | Streaming fallback tombstone + recreate executor |
+| 6 | `FallbackTriggeredError` | Model fallback swap |
+
+Related modules: `api-errors.ts` (match predicates), `model-fallback.ts`,
+`max-output-tokens.ts`, `reconnection.ts`, `tombstone.ts`,
+`withhold-cascading.ts`. Do not reorder the trigger array without updating
+the I-10 tests that pin `I10_TRIGGER_ORDER`.
+
 ## LLM / providers
 
 Default provider is **`grok`** (xAI), default model **`grok-4.3`**
@@ -193,7 +241,7 @@ Autonomous surfaces share one design: **fail closed, never silent spend**.
 | Heartbeat ticks | `heartbeat/` (wired from gateway run) | **Yes** (`wire.ts` + `runner.ts`) |
 | Cron delivery | `gateway/cron-delivery.ts` | **Yes** (agent id `cron:<taskId>`) |
 | Hooks HTTP | `gateway/hooks.ts` | **Yes** (agent id `hook:<name>`; 429 on refuse) |
-| Interactive TUI / print turns | `session/` | **No** (unless `enforce_interactive`) |
+| Interactive TUI / print turns | `session/` | **No** (`enforce_interactive` is reserved; path not admit-wired) |
 | Background agent runs | `app-server/background-agent-runner.ts` | **No** — **per-run** `[agent.budget]` only |
 
 Budget primitive: `runtime/src/budget/`. Defaults **disabled**. Ledger:
@@ -241,4 +289,4 @@ npm run validate:runtime
 Daemon-backed process model, multi-provider LLM layer, permissions/sandbox,
 gateway multi-channel surface, heartbeat + cron delivery + hooks with
 budget gating, and the public launcher/SDK packages are in place. Remaining
-pre-GA work is tracked in `TODO.md`.
+pre-GA product backlog is tracked in [`roadmap.md`](roadmap.md); local engineers may keep a gitignored `TODO.md`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,7 +1,7 @@
 # AgenC documentation index
 
 Canonical map of docs under `docs/`. Product overview and install entry:
-[`../README.md`](../README.md). Contributor loop: [`../AGENTS.md`](../AGENTS.md).
+[`../README.md`](../README.md).
 
 Version in tree: **runtime / launcher 0.3.0** (pre-release); embedding SDK
 **0.2.0**. Default provider **grok**, default model **grok-4.3**.
@@ -41,19 +41,24 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | Doc | Summary |
 | --- | --- |
 | [reference/cli.md](reference/cli.md) | Full CLI: top-level flags, all subcommands |
+| [reference/config.md](reference/config.md) | `config.toml` sections, env overrides, `agenc config` |
 | [reference/daemon.md](reference/daemon.md) | Daemon process model, socket auth, lifecycle |
 | [reference/providers.md](reference/providers.md) | Built-in providers, defaults, API key envs |
-| [reference/autonomy.md](reference/autonomy.md) | Budget + heartbeat + cron delivery + hooks |
+| [reference/slash-commands.md](reference/slash-commands.md) | TUI slash registry: names, aliases, purpose |
+| [reference/autonomy.md](reference/autonomy.md) | Budget + heartbeat + cron delivery + hooks HTTP |
 | [reference/agents.md](reference/agents.md) | Background agents + multi-agent v2 tools |
+| [reference/memory.md](reference/memory.md) | Persona, AGENC.md, auto-memory paths, privacy |
 | [reference/mcp.md](reference/mcp.md) | MCP client and server |
-| [reference/tools-permissions-sandbox.md](reference/tools-permissions-sandbox.md) | Tools catalog, permission modes, OS sandbox |
+| [reference/skills-plugins.md](reference/skills-plugins.md) | Skills load paths, plugin CLI, registration surfaces |
+| [reference/hooks.md](reference/hooks.md) | Session lifecycle hooks vs gateway HTTP hooks |
+| [reference/tools-permissions-sandbox.md](reference/tools-permissions-sandbox.md) | LIVE tool catalog (by family), dual catalog note, permission modes, OS sandbox |
 | [reference/tui-workbench.md](reference/tui-workbench.md) | TUI shell, workbench, BUFFER summary |
 
 ## Explanation
 
 | Doc | Summary |
 | --- | --- |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Process model, subsystem map, on-disk state |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Process model, subsystem map, turn phases, recovery ladder, on-disk state |
 | [design/budget-enforcement.md](design/budget-enforcement.md) | Why/how cost-bounded autonomy is enforced |
 | [roadmap.md](roadmap.md) | Shipped vs open backlog (current product truth) |
 
@@ -75,16 +80,21 @@ shipped. See [`archive/README.md`](archive/README.md).
 
 ## Outside `docs/` (still useful)
 
+Tracked in the repo (safe for GitHub clones):
+
 | Path | Summary |
 | --- | --- |
 | [`../README.md`](../README.md) | Product README (0.3.0) |
-| [`../AGENTS.md`](../AGENTS.md) | Contributor / agent working rules |
-| [`../TODO.md`](../TODO.md) | Active engineering backlog for assistants |
 | [`../packages/agenc-sdk/README.md`](../packages/agenc-sdk/README.md) | SDK package readme |
 | [`../runtime/eval/README.md`](../runtime/eval/README.md) | Agent-eval harness notes |
 | [`../runtime/src/tui/README.md`](../runtime/src/tui/README.md) | TUI architecture (Ink fork, themes) |
 | [`../runtime/src/mcp-client/README.md`](../runtime/src/mcp-client/README.md) | Outbound MCP client notes |
 | [`../runtime/src/agents/v2/PARITY.md`](../runtime/src/agents/v2/PARITY.md) | Multi-agent v2 tool parity |
 | [`../runtime/src/tools/WebSearchTool/README_SEARCH_PROVIDERS.md`](../runtime/src/tools/WebSearchTool/README_SEARCH_PROVIDERS.md) | Web-search provider config |
+| [`../runtime/src/llm/providers/openai-compatible/README.md`](../runtime/src/llm/providers/openai-compatible/README.md) | Provider naming note |
 | [`../parity/agent-surface-contract.reviews/README.md`](../parity/agent-surface-contract.reviews/README.md) | Agent-surface contract reviews |
 | [`../parity/embedded-neovim-buffer.reviews/README.md`](../parity/embedded-neovim-buffer.reviews/README.md) | Embedded-Neovim contract reviews |
+
+Local-only (gitignored — not shipped on GitHub): contributor working files such
+as `AGENTS.md` and `TODO.md`. Product backlog for public readers is
+[roadmap.md](roadmap.md).

--- a/docs/managed-openrouter.md
+++ b/docs/managed-openrouter.md
@@ -16,14 +16,15 @@ Related: [onboarding](onboarding.md) · [quickstart](quickstart.md) ·
 | `auth.managedKeys.enabled` | **`true`** (default) |
 | Default paid managed model | `openrouter` / `x-ai/grok-4.3` |
 | Free-tier managed routes | OpenRouter `:free` models (see below) |
-| Default max output tokens | **`32_000`** (`DEFAULT_MAX_OUTPUT_TOKENS`) |
-| Upper limit | **`64_000`** |
-| Capped default (when `capped_default_max_output_tokens` is set) | **`8_000`** (`CAPPED_DEFAULT_MAX_OUTPUT_TOKENS`) |
+| **Managed OpenRouter default max output** | **`2_048`** (`MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS` in `session.ts` / `bootstrap.ts`) |
+| Generic openai-compatible catalog default | `32_000` (`DEFAULT_MAX_OUTPUT_TOKENS`) — **not** the managed path |
+| Generic upper limit | `64_000` |
+| Generic capped default flag | `8_000` when `capped_default_max_output_tokens` is set |
 
-There is **no product default of 2048 output tokens** for managed chat.
-Catalog/metadata defaults use the 32k/64k path above; operators can opt into
-the 8k capped default or set an explicit cap with `max_output_tokens` /
-`AGENC_MAX_OUTPUT_TOKENS`.
+Managed chat **does** apply a **2048** default/ceiling when no explicit
+`max_output_tokens` / `AGENC_MAX_OUTPUT_TOKENS` is set. That hard-cap is
+separate from the generic 32k/64k openai-compatible metadata defaults used
+for non-managed routes.
 
 **BYOK always wins.** If `OPENROUTER_API_KEY` or a provider-config API key is
 present, those credentials are used instead of the subscription-managed route.
@@ -93,12 +94,12 @@ After a successful `/login`:
 
 | Source | Effect |
 |---|---|
-| Explicit `max_output_tokens` / `AGENC_MAX_OUTPUT_TOKENS` | Wins (bounded by model upper limit) |
-| `capped_default_max_output_tokens = true` | Default **8_000** |
-| Metadata / compatible default | **32_000** default, **64_000** upper limit |
+| Explicit `max_output_tokens` / `AGENC_MAX_OUTPUT_TOKENS` | Wins (still bounded by model upper limit) |
+| Managed OpenRouter with no explicit max | **Default and ceiling `2_048`** |
+| Non-managed openai-compatible metadata | **32_000** default, **64_000** upper; optional **8_000** capped default |
 
-Managed chat does **not** force a 2048-token ceiling. Prefer an explicit
-operator cap when you need smaller reserved budgets for allowance headroom.
+Raise managed output size with an explicit max when the 2048 default is too
+small for the task (and the hosted allowance can reserve it).
 
 ## Budget and error messages
 
@@ -118,5 +119,5 @@ When debugging production, check in order:
 5. `/v1/auth/llm-usage` can read spend for `/usage`.
 6. LiteLLM allowlist includes the selected `openrouter/...` model.
 7. OpenRouter workspace has credits / free-pool capacity.
-8. Request `max_tokens` matches the intended default (32k / 8k capped /
-   explicit), not an outdated hard-coded 2048 assumption.
+8. Request `max_tokens` matches intent: managed default is **2048** unless
+   you set an explicit max; generic 32k/8k paths are for non-managed routes.

--- a/docs/reference/autonomy.md
+++ b/docs/reference/autonomy.md
@@ -31,7 +31,7 @@ sanitized/framed as untrusted content before they reach the model.
 | Heartbeat | `runtime/src/heartbeat/` (`wire.ts`, `runner.ts`) | policy `agent` (default `default`) | **Wired** |
 | Cron delivery | `runtime/src/gateway/cron-delivery.ts` | `cron:<taskId>` | **Wired** |
 | Hooks HTTP | `runtime/src/gateway/hooks.ts` | `hook:<name>` | **Wired** (HTTP **429** on refuse) |
-| Interactive TUI / print | `session/` turn loop | n/a | **Not** cumulative-wired (opt-in only via `enforce_interactive`) |
+| Interactive TUI / print | `session/` turn loop | n/a | **Not** cumulative-wired — no `BudgetEnforcer.admit` on this path today |
 | Background agents | `app-server/background-agent-runner.ts` | n/a | **Not** cumulative-wired — **per-run** `[agent.budget]` only |
 
 Defaults: **budget disabled**, **heartbeat disabled**. Enabling either is an
@@ -54,7 +54,7 @@ monthly_usd = 50.0
 # daily_tokens = 2_000_000
 # monthly_tokens = 20_000_000
 soft_threshold = 0.8          # warn at 80% of a dollar window
-enforce_interactive = false   # keep false unless you want TUI gated too
+enforce_interactive = false   # reserved flag — interactive path not wired yet
 ```
 
 | Env | Effect |
@@ -65,7 +65,7 @@ enforce_interactive = false   # keep false unless you want TUI gated too
 | `AGENC_BUDGET_DAILY_TOKENS` | Daily token hard cap |
 | `AGENC_BUDGET_MONTHLY_TOKENS` | Monthly token hard cap |
 | `AGENC_BUDGET_SOFT_THRESHOLD` | Soft-warning fraction in `[0,1)` |
-| `AGENC_BUDGET_ENFORCE_INTERACTIVE` | Also gate interactive turns |
+| `AGENC_BUDGET_ENFORCE_INTERACTIVE` | Sets policy flag only; **TUI/print still do not call** `BudgetEnforcer` |
 
 ### Ledger
 
@@ -79,7 +79,9 @@ one-shot soft-warning markers. Windows roll by date keys (`YYYY-MM-DD` /
 
 `BudgetEnforcer.admit({ agentId, model, autonomous, estInputTokens, maxOutputTokens })`:
 
-- Out of scope when disabled or non-autonomous without `enforce_interactive`.
+- Out of scope when disabled or when the call is non-autonomous and
+  `enforce_interactive` is false. Interactive turns still never call admit
+  today even if the flag is true.
 - Refuses if already `paused` or worst-case debit would exceed **any** set cap
   (fail closed on both day and month).
 - Debits worst-case **est input + max output** priced via the model price

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,397 @@
+# Config reference
+
+Operator config for AgenC **0.3.0**. Sources of truth:
+
+| Concern | Path |
+| --- | --- |
+| Schema + defaults | `runtime/src/config/schema.ts` |
+| Env layering | `runtime/src/config/env.ts` |
+| Profiles | `runtime/src/config/profiles.ts` |
+| TOML load | `runtime/src/config/loader.ts` |
+| CLI | `runtime/src/bin/config-cli.ts` → `agenc config` |
+
+On-disk file: **`$AGENC_HOME/config.toml`** (default `~/.agenc/config.toml`).
+`AGENC_HOME` env relocates the whole home.
+
+---
+
+## Load order
+
+1. Built-in `defaultConfig()`
+2. `config.toml` (right-biased merge)
+3. Named profile (`--profile` / `AGENC_PROFILE`) — only overridable keys
+4. Env overrides (`applyEnvOverrides`) — env wins over TOML
+
+Unknown top-level TOML keys are preserved on `_unknown` (forward-compat), not
+dropped. TOML aliases remapped before normalize:
+
+| TOML alias | Canonical key |
+| --- | --- |
+| `tools` | `tools_config` |
+| `model_reasoning_effort` | `reasoning_effort` |
+| `model_reasoning_summary` | `reasoning_summary` |
+| `agents.max_threads` | `agent_max_threads` |
+| `agents.max_depth` | `agent_max_depth` |
+
+---
+
+## Defaults (`defaultConfig()`)
+
+| Key | Default |
+| --- | --- |
+| `model` | `grok-4.3` |
+| `model_provider` | `grok` |
+| `approval_policy` | `on-request` |
+| `sandbox_mode` / `sandbox.mode` | `workspace-write` |
+| `reasoning_effort` | `medium` |
+| `approvals_reviewer` | `user` |
+| `agent_max_depth` | `1` |
+| `auth.backend` | `remote` |
+| `auth.managedKeys.enabled` | `true` |
+| `plugins.enabled` | `false` |
+| `mcp.server.enabled` | `false` |
+| `daemon.transport` | `unix` |
+| `daemon.autostart` | `true` |
+| `permissions.default_mode` | `on-request` |
+| `max_turns` | `50` |
+| `stream_watchdog_timeout_ms` | `30000` |
+| `toolBudget` | 32 calls/turn · 256k B/call · 2M B/turn |
+| `project_doc_max_bytes` | `32768` |
+
+`[budget]`, `[heartbeat]`, and `[transaction_guard]` are **off** unless set
+(see [autonomy.md](autonomy.md), [security/slm-transaction-guard.md](../security/slm-transaction-guard.md)).
+
+---
+
+## Major sections
+
+### Top-level model / runtime
+
+```toml
+model = "grok-4.3"
+model_provider = "grok"
+approval_policy = "on-request"   # untrusted | on-failure | on-request | never
+sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-access
+reasoning_effort = "medium"      # minimal | low | medium | high | xhigh
+personality = "none"             # none | friendly | pragmatic
+max_output_tokens = 8192
+max_budget_usd = 5.0
+autonomous_mode = false
+coordinator_mode = false
+```
+
+| Env | Config field |
+| --- | --- |
+| `AGENC_MODEL` | `model` |
+| `AGENC_PROVIDER` | `model_provider` (`xai` → `grok`) |
+| `AGENC_HOME` | `agenc_home` |
+| `AGENC_WORKSPACE` | `workspace` |
+| `AGENC_SIMPLE` | `simpleMode` |
+| `AGENC_AUTONOMOUS` | `autonomous_mode` |
+| `AGENC_MAX_OUTPUT_TOKENS` | `max_output_tokens` |
+| `AGENC_CAPPED_DEFAULT_MAX_OUTPUT_TOKENS` | `capped_default_max_output_tokens` |
+| `AGENC_MAX_BUDGET_USD` | `max_budget_usd` |
+| `AGENC_COORDINATOR_MODE` | `coordinator_mode` (truthy) |
+
+API keys are **not** written into the config snapshot; resolve via provider envs
+(see [providers.md](providers.md)).
+
+### `[auth]`
+
+```toml
+[auth]
+backend = "remote"   # local | remote
+
+[auth.managedKeys]
+enabled = true
+```
+
+| Env | Effect |
+| --- | --- |
+| `AGENC_AUTH_BACKEND` | `local` or `remote` |
+| `AGENC_AUTH_MANAGED_KEYS_ENABLED` | boolean-like |
+
+### `[providers.<slug>]`
+
+```toml
+[providers.openai]
+api_key_env = "OPENAI_API_KEY"
+base_url = "https://api.openai.com/v1"
+default_model = "gpt-5"
+context_window_tokens = 128000
+max_output_tokens = 16384
+fallback_models = ["gpt-4.1"]
+```
+
+Optional: `capability_overrides`, nested `fallback` (`targets`, `models`,
+`max_failures`, `statuses`).
+
+### `[permissions]`
+
+```toml
+[permissions]
+default_mode = "on-request"   # ApprovalPolicy
+# defaultMode = "default"     # PermissionMode (settings-style)
+allow = ["Read", "Glob"]
+deny = ["Bash(rm *)"]
+ask = ["Write"]
+additionalDirectories = ["/extra/root"]
+```
+
+Rule strings: `Tool` or `Tool(filter)` form (`permissions/rules.ts`). Deep
+reference: [tools-permissions-sandbox.md](tools-permissions-sandbox.md).
+
+### Sandbox
+
+```toml
+sandbox_mode = "workspace-write"
+
+[sandbox]
+mode = "workspace-write"   # off | read-only | workspace-write
+
+[sandbox_policy]
+mode = "workspace-write"
+network_access = false
+writable_roots = ["/tmp/work"]
+```
+
+### `[tools]` → `tools_config`
+
+```toml
+[tools]
+web_search = true
+web_search_endpoint = "https://…"
+web_search_endpoint_kind = "duckduckgo"  # duckduckgo | searxng | brave | json
+view_image = true
+enabled_tools = ["Bash", "Read"]
+disabled_tools = []
+```
+
+Env (search backend): `AGENC_WEB_SEARCH_ENDPOINT`, `AGENC_WEB_SEARCH_KIND`,
+`AGENC_WEB_SEARCH_API_KEY` (secrets never in TOML).
+
+### `[mcp]` and `[mcp_servers.<name>]`
+
+```toml
+[mcp.server]
+enabled = false
+transport = "stdio"   # stdio | sse
+# port = 0
+# host = "127.0.0.1"
+
+[mcp_servers.docs]
+transport = "stdio"
+command = "npx"
+args = ["-y", "some-mcp-server"]
+# enabled = true
+# required = false
+# timeout = 30000
+```
+
+Full MCP surface: [mcp.md](mcp.md).
+
+### `[plugins]`
+
+```toml
+[plugins]
+enabled = false
+dirs = ["~/src/my-plugins"]
+allowlist = []
+
+[plugins.plugins.example]
+enabled = true
+path = "./plugins/example"
+# source = "…"
+# version = "1.0.0"
+# required = false
+```
+
+Also top-level `enabledPlugins` map (settings-style enable flags). Default:
+plugins **disabled**. CLI: `agenc plugin …` · [skills-plugins.md](skills-plugins.md).
+
+### `[budget]`
+
+```toml
+[budget]
+enabled = true
+daily_usd = 5.0
+monthly_usd = 50.0
+# daily_tokens = 2_000_000
+# monthly_tokens = 20_000_000
+soft_threshold = 0.8
+enforce_interactive = false
+```
+
+Env: `AGENC_BUDGET`, `AGENC_BUDGET_DAILY_USD`, `AGENC_BUDGET_MONTHLY_USD`,
+`AGENC_BUDGET_DAILY_TOKENS`, `AGENC_BUDGET_MONTHLY_TOKENS`,
+`AGENC_BUDGET_SOFT_THRESHOLD`, `AGENC_BUDGET_ENFORCE_INTERACTIVE`.
+Details: [autonomy.md](autonomy.md).
+
+### `[heartbeat]`
+
+```toml
+[heartbeat]
+enabled = true
+interval_seconds = 1800
+# model = "…"
+# active_hours = [8, 22]   # [startHour, endHour) local 24h
+skip_when_busy = true
+# agent = "default"
+# target_channel = "telegram"
+# target_conversation = "…"
+```
+
+Env: `AGENC_HEARTBEAT`, `AGENC_HEARTBEAT_INTERVAL`, `AGENC_HEARTBEAT_MODEL`,
+`AGENC_HEARTBEAT_ACTIVE_HOURS`, `AGENC_HEARTBEAT_TARGET`, `AGENC_HEARTBEAT_AGENT`.
+
+### `[transaction_guard]`
+
+```toml
+[transaction_guard]
+enabled = false
+model = "gemma4:e4b"
+endpoint = "http://127.0.0.1:11434"
+fail_mode = "closed"   # open | closed
+```
+
+Env (env > config > defaults): `AGENC_TRANSACTION_GUARD` (`slm` enables; other
+non-empty disables), `AGENC_TRANSACTION_GUARD_MODEL`,
+`AGENC_TRANSACTION_GUARD_OLLAMA_URL`, `AGENC_TRANSACTION_GUARD_FAIL_MODE`,
+plus timeout/size knobs `AGENC_TRANSACTION_GUARD_TIMEOUT_MS`,
+`AGENC_TRANSACTION_GUARD_MAX_DOCKET_BYTES`.
+
+### `[agent]`
+
+Per-run / retention for background agents (and shared tracker surfaces):
+
+```toml
+[agent.budget]
+# token_cap = 2_000_000
+# dollar_cap = 10.0
+# wall_clock_seconds = 3600
+
+[agent.retention]
+completed_days = 30
+failed_days = 90
+snapshot_days = 3
+snapshot_max_count = 10000
+snapshot_max_bytes = 67108864
+# rollout_days = 90   # optional; unset = no rollout pruning
+```
+
+Default `agent.budget` is empty (no per-run cap).
+
+### `durableTurns`
+
+Typed shape on `AgenCConfig` (`DurableTurnsConfig`) for checkpointed turns:
+
+```toml
+# Shape from schema (Stage 1: checkpoint write cheap; resume policy "safe" only)
+[durableTurns.checkpoint]
+enabled = true
+minIntervalMs = 0
+
+[durableTurns.resume]
+onRestart = false
+policy = "safe"
+requireLease = true
+buildPinning = true
+```
+
+Used by the turn loop (`session/run-turn.ts`, `session/durable-turns`). Prefer
+`agenc config validate` after edits.
+
+### `[daemon]`
+
+```toml
+[daemon]
+transport = "unix"   # unix | stdio
+autostart = true
+```
+
+### `[protocol]`
+
+Marketplace protocol slash surface (`/claim`, …). **Disabled by default.**
+
+```toml
+[protocol]
+enabled = false
+adapter = "marketplace-cli"   # null | marketplace-cli
+# cli_path = "/path/to/agenc-marketplace"
+```
+
+### `[[` / `[profiles.<name>]`
+
+Named override bundles. Only these keys apply (others silently ignored):
+
+`model`, `model_provider`, `approval_policy`, `sandbox_mode`,
+`reasoning_effort`, `approvals_reviewer`, `model_verbosity`, `service_tier`,
+`personality`, `web_search`, `tools`.
+
+```toml
+[profiles.yolo]
+model = "grok-4.3"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+```
+
+Select: `agenc --profile yolo` or `AGENC_PROFILE=yolo`.
+
+### `[hooks]`
+
+Session lifecycle command hooks (not gateway HTTP). See [hooks.md](hooks.md).
+
+```toml
+[[hooks.PreToolUse]]
+matcher = "Bash"
+enabled = true
+hooks = [
+  { type = "command", command = "echo pre-tool", timeout_ms = 5000 },
+]
+```
+
+### Other known blocks
+
+| Key | Role |
+| --- | --- |
+| `lsp_servers` | Language server spawn configs |
+| `statusLine` / `outputStyle` | TUI status line items / theme |
+| `attachments.allowedRoots` | Extra `@file` mention roots |
+| `editorMode` | `default` \| `vim` |
+| `tui` / `tuiLayout` | TUI vim flag; layout mode / side pane |
+| `shell_environment_policy` | Shell env inherit / exclude / set |
+| `toolBudget` | Per-turn tool call/byte caps |
+| `experiments` | Open map of flags |
+| `ideConnector` / `privateStorage` / `managedWorkspaces` | Optional IDE / storage / workspace lists |
+| `autoUpdates` | Present on type; auto-updater reads global config, not a hard default here |
+
+Deferred keys (accepted into `_unknown` today; see schema `DEFERRED_*` comments):
+e.g. `notify`, `history`, `log_dir`, `file_opener`, `env`, `apiKeyHelper`,
+`cleanupPeriodDays`.
+
+---
+
+## CLI: `agenc config`
+
+```text
+agenc config show
+agenc config get <dot.path>
+agenc config set <dot.path> <value>
+agenc config unset <dot.path>
+agenc config validate
+agenc config edit
+agenc config path
+```
+
+- Values parse as TOML when possible (`true`, `123`, arrays, inline tables).
+- Dot paths split on `.` — use `edit` for keys with literal dots.
+- Examples:
+
+```bash
+agenc config get model
+agenc config set permissions.default_mode never
+agenc config set plugins.enabled true
+agenc config validate
+```
+
+TUI: `/config` (alias `/settings`). Full CLI map: [cli.md](cli.md).

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -21,10 +21,16 @@ Autostart is **on by default**. Disable with:
 AGENC_DAEMON_AUTOSTART=0
 ```
 
-Ready-wait timeout for clients that start the daemon:
+Ready-wait timeout for clients that start the daemon
+(`AGENC_DAEMON_READY_TIMEOUT_MS`):
+
+| Client | Default |
+| --- | --- |
+| Published launcher (`packages/agenc`) | **2000** ms |
+| Runtime daemon autostart / `agenc daemon` / SDK socket connect | **45000** ms |
 
 ```bash
-AGENC_DAEMON_READY_TIMEOUT_MS=2000   # default 2000
+AGENC_DAEMON_READY_TIMEOUT_MS=45000
 ```
 
 Detached daemon V8 heap cap (MB):

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,0 +1,148 @@
+# Hooks reference
+
+Two different “hooks” surfaces:
+
+| Surface | What it is | Primary code |
+| --- | --- | --- |
+| **Session lifecycle hooks** | Config/plugin shell (and related) handlers on turn events | `runtime/src/hooks/`, `config/schema.ts` `hooks`, `schemas/hooks.ts` |
+| **Gateway Hooks HTTP** | Loopback `POST /hooks/agent` automation → one agent turn | `runtime/src/gateway/hooks.ts` |
+
+Do not confuse them. Gateway HTTP is documented in depth under
+[autonomy.md](autonomy.md#hooks-http-runtimesrcgatewayhooksts) and
+[gateway.md](../gateway.md).
+
+---
+
+## Session lifecycle hooks
+
+### Events (`HOOK_EVENT_NAMES` in config schema)
+
+These are the events accepted on the **`[hooks]` TOML map** and the
+configured-hook engine (`runtime/src/hooks/engine/discovery.ts`):
+
+| Event | Summary (from `/hooks` metadata) |
+| --- | --- |
+| `PreToolUse` | Before tool execution; matcher `tool_name` |
+| `PostToolUse` | After successful tool execution |
+| `PostToolUseFailure` | After tool failure |
+| `PermissionRequest` | When a permission dialog is shown |
+| `UserPromptSubmit` | User prompt submitted; can block |
+| `SessionStart` | New session; matcher `source` |
+| `SubagentStop` | Spawned agent finished; matcher `agent_type` |
+| `SessionEnd` | Session shutdown (fire-and-forget) |
+| `Notification` | Waiting on user (e.g. permission); fire-and-forget |
+| `Stop` | Before concluding the response |
+| `StopFailure` | Turn ended on API error |
+| `PreCompact` | Before context compaction |
+| `PostCompact` | After compaction |
+
+CamelCase and lowerCamel aliases normalize (e.g. `preToolUse` → `PreToolUse`).
+
+The SDK type list in `entrypoints/sdk/coreTypes.ts` (`HOOK_EVENTS`) is **wider**
+(e.g. `SubagentStart`, `Setup`, `ConfigChange`, `InstructionsLoaded`, …). Those
+extra names are for the broader runtime/SDK surface; **TOML `hooks` validation
+only accepts the table above**.
+
+### Config map shape
+
+`HooksMap`: event name → array of matchers; each matcher has optional
+`matcher` / `enabled` and a list of **command** hooks.
+
+Schema-validated command hook (`HookCommand`):
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `type` | `"command"` | Required; only command type in TOML config path |
+| `command` | string | Shell command to run |
+| `timeout_ms` | positive int | Optional |
+| `enabled` | bool | Optional (default on) |
+| `statusMessage` | string | Optional spinner text |
+
+```toml
+[[hooks.PreToolUse]]
+matcher = "Bash"
+enabled = true
+hooks = [
+  { type = "command", command = "/path/to/check-bash.sh", timeout_ms = 5000, statusMessage = "pre-bash hook" },
+]
+```
+
+Flattened runtime entries carry `source: "config"`, `sourcePath`, and index
+(`IndividualHookConfig` in `hooks/engine/types.ts`).
+
+### Extended hook kinds (settings / schema package)
+
+`runtime/src/schemas/hooks.ts` also defines discriminated hook kinds for
+settings-style config: `command`, `prompt`, `http`, `agent` (with optional
+`if` permission-rule filters, timeouts in **seconds**, async flags, etc.).
+That Zod surface is broader than the TOML `validateHooksConfig` command-only
+path. Prefer matching the path you edit (TOML vs settings JSON).
+
+### Security
+
+- Config/plugin **command** hooks run arbitrary shell → require a **trusted**
+  workspace (`isProjectTrustedSync`), unless
+  `AGENC_ALLOW_UNTRUSTED_HOOKS=1|true|yes` (automation opt-in).
+- Secrets redacted in diagnostics where wired (`configured-hooks.ts`).
+
+### Engine
+
+| Module | Role |
+| --- | --- |
+| `hooks/engine/discovery.ts` | Flatten + group by event |
+| `hooks/engine/dispatcher.ts` | Match patterns, run hooks |
+| `hooks/engine/command-runner.ts` | Spawn shell |
+| `hooks/engine/output-parser.ts` | Parse hook stdout / hookSpecificOutput |
+| `hooks/configured-hooks.ts` | Install into session lifecycle targets |
+| `hooks/user-prompt-submit.ts` | UserPromptSubmit adapter |
+
+Plugin hooks merge via `plugins/registration/load-plugin-hooks.ts`.
+
+### TUI: `/hooks`
+
+```text
+/hooks
+/hooks list
+/hooks show <event> [index]
+/hooks validate
+/hooks enable | disable
+/hooks test <event> [index]
+/hooks diagnostics
+/hooks clear-diagnostics
+```
+
+- No args / interactive: menu (`hooks-menu.tsx`) when runtime available
+- Against daemon: `test` and `clear-diagnostics` may report deferred;
+  `enable`/`disable` need daemon RPC support
+- Description: “Inspect and test AgenC hook configuration”
+
+---
+
+## Gateway Hooks HTTP (pointer)
+
+Automation entry only — **not** PreToolUse/PostToolUse.
+
+| Item | Value |
+| --- | --- |
+| Enable | Gateway config / `agenc gateway run --hooks` + token |
+| Endpoint | `POST /hooks/agent` |
+| Default port | `8377` |
+| Auth | `Authorization: Bearer <token>` (query tokens rejected) |
+| Budget | Same autonomous envelope; refuse → HTTP **429** |
+| Permissions | Deny tool permission requests |
+
+Full request shape, security table, and operator checklist:
+[autonomy.md — Hooks HTTP](autonomy.md#hooks-http-runtimesrcgatewayhooksts).
+
+---
+
+## Source map
+
+| Concern | Path |
+| --- | --- |
+| Config events + validation | `runtime/src/config/schema.ts` (`HOOK_EVENT_NAMES`, `validateHooksConfig`) |
+| Session hook runtime | `runtime/src/hooks/` |
+| Settings hook Zod | `runtime/src/schemas/hooks.ts` |
+| SDK event enum (wider) | `runtime/src/entrypoints/sdk/coreTypes.ts` |
+| Slash command | `runtime/src/commands/hooks.ts` |
+| Gateway HTTP | `runtime/src/gateway/hooks.ts` |

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -1,0 +1,135 @@
+# Memory & persona reference
+
+How AgenC loads durable instructions, persona, and auto-memory. Sources:
+
+| Area | Path |
+| --- | --- |
+| Paths / auto-memory gates | `runtime/src/memory/paths.ts` |
+| `AGENC.md` cascade + includes | `runtime/src/memory/agencmd.ts` |
+| Persona files | `runtime/src/memory/persona.ts` |
+| Entrypoint truncation / prompts | `runtime/src/memory/memdir.ts` |
+| Privacy / secret scan | `runtime/src/memory/privacy.ts` |
+| Public barrel | `runtime/src/memory/index.ts` |
+| Team path helpers | `runtime/src/memdir/` |
+| TUI editor | `/memory` → `runtime/src/commands/memory/` |
+
+---
+
+## Store paths
+
+`AGENC_HOME` defaults to `~/.agenc` (`resolveAgencHome` / `getAgenCConfigHomeDir`).
+
+| Store | Default path | Notes |
+| --- | --- | --- |
+| Config home / memory base | `$AGENC_HOME` | Override base with `AGENC_REMOTE_MEMORY_DIR` |
+| Global durable memory | `$AGENC_HOME/memory/` | Entrypoint `MEMORY.md` |
+| Project auto-memory | `<projectRoot>/.agenc/memory/` | Entrypoint `MEMORY.md` |
+| Project instructions | `<projectRoot>/AGENC.md` | Preferred root instruction file |
+| User instructions | `$AGENC_HOME/AGENC.md` | Private global |
+| Daily auto-mem logs | `<autoMemPath>/logs/YYYY/MM/YYYY-MM-DD.md` | Distilled later by dream/extract flows when enabled |
+
+**Project auto-memory resolution** (`getProjectMemoryPath` / `getAutoMemPath`):
+
+1. `AGENC_COWORK_MEMORY_PATH_OVERRIDE` (absolute full-path override)
+2. `autoMemoryDirectory` in trusted settings only (policy / flag / local / user — **not** committed project settings)
+3. If `AGENC_REMOTE_MEMORY_DIR` is set: `$base/projects/<sanitized-git-root>/memory/`
+4. Else: `<projectRoot>/.agenc/memory/`
+
+Git worktrees of the same repo share one auto-memory directory when a
+canonical git root is found.
+
+---
+
+## Instruction cascade (`AGENC.md`)
+
+Loaded by `agencmd` in priority order (later = higher attention):
+
+1. **Managed** — e.g. system-wide managed `AGENC.md` / rules dirs
+2. **User** — `~/.agenc/AGENC.md` (+ user rules dir)
+3. **Project** — walk from cwd up: `AGENC.md` (preferred), **`AGENTS.md` fallback**, `.agenc/AGENC.md`, `.agenc/rules/*.md`
+4. **Local** — `AGENC.local.md` (private project)
+
+Also:
+
+- **Auto-memory entrypoints** (`MEMORY.md` global + project) when auto-memory is enabled — framed as **untrusted persisted state**, not as override instructions
+- **Persona** files (below) as Project-tier workspace identity
+
+`@include` in memory files: `@path`, `@./rel`, `@~/home`, `@/abs` on leaf text
+(not inside code fences). Circular includes skipped; missing files ignored;
+binary extensions blocked.
+
+Recommended soft cap: `MAX_MEMORY_CHARACTER_COUNT` (40_000). Entrypoint
+`MEMORY.md` also line/byte truncated for prompt injection
+(`MAX_ENTRYPOINT_LINES` 200, `MAX_ENTRYPOINT_BYTES` 25_000).
+
+---
+
+## Persona files (workspace root)
+
+OpenClaw-parity names in the **workspace root only** (not ancestors):
+
+| File | Role |
+| --- | --- |
+| `USER.md` | Who the human is |
+| `SOUL.md` | Agent persona, tone, boundaries |
+| `IDENTITY.md` | Established agent identity (often agent-written) |
+| `BOOTSTRAP.md` | One-time ritual; injected **only while `IDENTITY.md` is absent** |
+
+- Per-file prompt budget: **16 KiB** (`PERSONA_FILE_MAX_BYTES`); disk file unchanged
+- Injected into the system prompt persona section at conversation start (stable for that conversation)
+- Never overrides permission gates or safety rules
+- Fresh edits apply on the **next** new conversation
+
+Onboarding: `agenc onboard identity` walks the naming ritual for these files.
+
+---
+
+## Automatic memory
+
+**Enabled by default.** `isAutoMemoryEnabled()` priority:
+
+1. `AGENC_DISABLE_AUTO_MEMORY` — truthy → OFF, falsy → ON
+2. `AGENC_SIMPLE` — OFF
+3. Remote without `AGENC_REMOTE_MEMORY_DIR` — OFF
+4. `autoMemoryEnabled` in settings.json
+5. Default: **on**
+
+When on, the agent may maintain `MEMORY.md` / topic files under the auto-memory
+dirs; extract/background helpers may run on interactive sessions (also gated by
+build features such as `EXTRACT_MEMORIES`). Session memory lives in conversation
+state, not a separate durable path contract.
+
+---
+
+## `/memory`
+
+Slash command: open the interactive memory file picker/editor (`memory.tsx`).
+Headless/daemon dispatch returns text directing the operator to the TUI.
+
+Related mentions: memory mention aliases / `@` syntax from project-memory helpers
+(`MEMORY_MENTION_ALIASES`, `isMemoryMention`).
+
+---
+
+## Privacy & secrets
+
+`runtime/src/memory/privacy.ts`:
+
+- Classifies paths as personal auto-memory vs team (feature `TEAMMEM`) vs session transcript / session-memory under config home
+- Secret scanning / redaction before write or sync paths (`scanForSecrets`, `redactSecrets`, `checkTeamMemSecrets`)
+- Auto-managed memory files are distinct from operator instruction files such as `AGENC.md`
+
+Persistent memory in the prompt is labeled untrusted: stale or model-authored
+content must not override current user instructions, permission gates, or live
+repo state.
+
+---
+
+## Project bootstrap files
+
+`agenc init` creates:
+
+- `.agenc/config.json`
+- `AGENC.md`
+
+See [cli.md](cli.md) · persona/onboarding [onboarding.md](../onboarding.md).

--- a/docs/reference/skills-plugins.md
+++ b/docs/reference/skills-plugins.md
@@ -1,0 +1,151 @@
+# Skills & plugins reference
+
+Sources of truth:
+
+| Area | Path |
+| --- | --- |
+| Skill load / `SKILL.md` | `runtime/src/skills/local-loader.ts`, `loadSkillsDir.ts` |
+| Bundled skills | `runtime/src/skills/bundledSkills.ts` |
+| MCP skills | `runtime/src/skills/mcpSkills.ts` |
+| Plugin load / dirs | `runtime/src/plugins/loader.ts`, `directories.ts` |
+| Manifest | `runtime/src/plugins/manifest.ts`, `manifest-schema.ts` |
+| Registration | `runtime/src/plugins/registration/*` |
+| CLI | `runtime/src/plugins/cli/pluginCliCommands.ts` → `agenc plugin` |
+| Marketplace | `runtime/src/plugins/marketplace/` |
+| Config | `[plugins]` in [config.md](config.md) |
+
+---
+
+## Skills
+
+### Concept
+
+A skill is a directory containing **`SKILL.md`**: YAML frontmatter + markdown
+body. On invocation the body is rendered (argument substitution); listing uses
+frontmatter only (name, description, when-to-use) for token budget.
+
+### Load paths (`discoverSkillRoots`)
+
+Existing directories only (missing roots skipped). Project walk: cwd up to home.
+
+| Scope | Typical roots |
+| --- | --- |
+| Project | `<dir>/.agenc/skills`, `<dir>/.agents/skills` (and deprecated `…/commands`) |
+| User | `$AGENC_HOME/skills`, `~/.agenc/skills`, `~/.agents/skills`, compat `~/.claude/skills`, `~/.codex/skills` (+ `commands` legacy) |
+| Managed | `$AGENC_MANAGED_HOME/.agenc/skills` |
+| Plugin | Skill roots exposed by enabled plugins |
+| Bundled / MCP | Built-in definitions and MCP-sourced skills |
+
+`getSkillsPath` (settings source → path) also maps policy/user/project to
+managed / config-home / `.agenc/skills`.
+
+Slash: `/skills` — list roots, manage project skills.
+
+### `SKILL.md` frontmatter (high level)
+
+Parsed fields include:
+
+| Field | Role |
+| --- | --- |
+| `name` | Display name (directory name is the invocable id) |
+| `description` | Listing / model-facing blurb |
+| `when_to_use` | Guidance for auto-invocation |
+| `argument-hint` / `arguments` | Argument names / hint |
+| `allowed-tools` | Tool allowlist for the skill run |
+| `model` | Optional model override |
+| `user-invocable` | Default true |
+| `disable-model-invocation` | Hide from model-driven invoke |
+| `context` | `inline` \| `fork` |
+| `agent` / `effort` / `shell` | Execution hints |
+| `paths` | Path filters |
+| `hooks` | Optional hook map (validated when present) |
+| `version` | Optional |
+
+Author under e.g. `.agenc/skills/my-skill/SKILL.md` in the project or
+`$AGENC_HOME/skills/my-skill/SKILL.md` for user-global skills.
+
+---
+
+## Plugins
+
+### Defaults
+
+- `[plugins] enabled = false` in `defaultConfig()`
+- Install cache / data under `~/.agenc/plugins` (override with
+  `AGENC_PLUGIN_CACHE_DIR`; seed dirs via `AGENC_PLUGIN_SEED_DIR`)
+- Plugin private data: `…/plugins/data/<sanitized-id>/`
+
+### Manifest
+
+Looked up as:
+
+1. `.agenc-plugin/plugin.json`
+2. Root `plugin.json`
+
+`PluginManifest` may declare:
+
+| Field | Registration surface |
+| --- | --- |
+| `commands` | Slash / prompt commands |
+| `agents` | Agent definitions |
+| `skills` | Skill roots / files |
+| `hooks` | Lifecycle hooks map |
+| `mcpServers` | Outbound MCP server configs |
+| `lspServers` | LSP server configs |
+| `outputStyles` | Output styles |
+| `apps` / `channels` / `userConfig` | Extended packaging metadata |
+
+Component kinds in schema: `commands`, `agents`, `skills`, `hooks`, `mcp`,
+`lsp`, `apps`, `output-styles`.
+
+Load + register: `refreshPluginRegistrations` →
+`loadPluginCommands`, `loadPluginSkills`, `loadPluginAgents`,
+`loadPluginHooks`, `loadPluginMcpServers`, `loadPluginLspServers`,
+`loadPluginOutputStyles`.
+
+### Config enable
+
+```toml
+[plugins]
+enabled = true
+allowlist = ["my-plugin"]   # optional restriction
+
+[plugins.plugins.my-plugin]
+enabled = true
+path = "./plugins/my-plugin"
+```
+
+Or `enabledPlugins` map. Untrusted workspace trust gates apply to
+config/plugin **command** hooks (see [hooks.md](hooks.md)).
+
+### CLI: `agenc plugin`
+
+```text
+agenc plugin list [--json]
+agenc plugin validate <path> [--marketplace] [--json]
+agenc plugin install <path> [--scope user|project|local] [--name …] [--force]
+agenc plugin uninstall <name> [--scope …] [--keep-data]
+agenc plugin update <name> [--source <path>]
+agenc plugin enable <name> [--path <path>]
+agenc plugin disable <name>
+agenc plugin disable-all
+agenc plugin marketplace list|add|remove|upgrade …
+```
+
+Aliases: top-level `plugin` and `plugins`. TUI: `/plugins` (aliases
+`/plugin`, `/marketplace`).
+
+### Marketplace
+
+Local path, git, URL, or GitHub sources via `marketplace add`. Index ops in
+`runtime/src/plugins/marketplace/marketplace.ts`. Validate marketplace
+manifests with `plugin validate --marketplace`.
+
+---
+
+## Related
+
+- [slash-commands.md](slash-commands.md) — core registry (plugins add more)
+- [mcp.md](mcp.md) — MCP servers (including plugin-contributed)
+- [hooks.md](hooks.md) — session hooks including plugin hooks
+- [config.md](config.md) — `[plugins]` block

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -1,0 +1,78 @@
+# Slash commands reference
+
+User-invocable TUI / daemon slash palette. Registry:
+`runtime/src/commands/registry.ts` (`buildDefaultRegistry`). Unlisted commands
+are not dispatchable through that registry.
+
+Parse/dispatch: `runtime/src/commands/dispatcher.ts` (`/name args`).
+
+**Provider command is `/provider`**, not `/model-provider`. Config key remains
+`model_provider` / env `AGENC_PROVIDER`.
+
+---
+
+## Registered commands
+
+Order matches `buildDefaultRegistry`.
+
+| Command | Aliases | Purpose |
+| --- | --- | --- |
+| `/help` | | Show help and available commands |
+| `/status` | | Show current session and runtime status |
+| `/login` | | Sign in with your AgenC account |
+| `/logout` | | Sign out of your AgenC account |
+| `/whoami` | `account` | Show the signed-in AgenC account |
+| `/subscription` | `billing` | Show your AgenC plan and billing URL |
+| `/usage` | | Show hosted model usage for your AgenC plan |
+| `/cost` | `stats` | Show session cost, token usage, and per-agent spend |
+| `/model` | | Switch the model (picker or pass a name) |
+| `/provider` | | Switch the LLM provider for subsequent turns |
+| `/permissions` | `approvals`, `allowed-tools` | Manage permission mode and rules |
+| `/plan` | | Enter plan mode or display the current plan (read-only tools) |
+| `/agents` | | Manage agents — opens a picker |
+| `/tasks` | `jobs`, `bashes` | Show live background tasks and spawned agents |
+| `/todos` | `todo` | Show the session todo lists |
+| `/config` | `settings` | Manage configuration — opens a picker |
+| `/hooks` | | Inspect and test AgenC hook configuration |
+| `/skills` | | Manage project skills and show loaded skill roots |
+| `/mcp` | | Show and manage MCP servers |
+| `/remote` | | Link this machine to the AgenC phone app |
+| `/plugins` | `plugin`, `marketplace` | Show and manage AgenC plugins |
+| `/memory` | | Open AgenC memory editor (TUI; headless points at TUI) |
+| `/resume` | `sessions` | List resumable sessions for this project |
+| `/rewind` | | Restore the code and/or conversation to a previous point |
+| `/init` | | Analyze this repository and write `.agenc/config.json` plus `AGENC.md` |
+| `/output-style` | `style` | Switch the active output style |
+| `/output-style:new` | | Ask the agent to author a new project output style |
+| `/clear` | `reset`, `new` | Clear session history and caches |
+| `/compact` | | Compact the current conversation |
+| `/context` | `ctx` | Show current context usage |
+| `/coordinator` | `fleet` | Show or toggle coordinator (orchestrator) mode |
+| `/diff` | | Show uncommitted changes (`git diff HEAD` + untracked) |
+| `/claim` | | Protocol: claim an open marketplace task (gated by `[protocol]`) |
+| `/delegate` | | Protocol: delegate a task step (owner-gated; often stub) |
+| `/proof` | | Protocol: generate or verify a proof (owner-gated; often stub) |
+| `/settle` | | Protocol: submit completion / settle escrow (owner-gated) |
+| `/stake` | | Protocol: inspect or adjust protocol stake (owner-gated) |
+| `/exit` | `quit` | Shut down the session cleanly and exit |
+
+Sources: `runtime/src/commands/*.ts(x)` modules imported by the registry
+(`help`, `status`, `auth`, `cost`, `model`, `provider`, `permissions`, `plan`,
+`agent-management`, `tasks`, `todos`, `config`, `hooks`, `skills`, `mcp`,
+`remote`, `plugins`, `memory/slash`, `resume`, `rewind`, `init`,
+`output-style`, `clear`, `session-compact`, `coordinator`, `diff`, `protocol`,
+`exit`).
+
+---
+
+## Notes
+
+| Topic | Fact |
+| --- | --- |
+| Surfaces | Some commands declare `supportedSurfaces` (e.g. `/hooks` → `runtime`, `daemon-tui`); default is all surfaces when omitted |
+| Protocol verbs | Default: honest stub unless `[protocol] enabled = true` + `adapter = "marketplace-cli"`; mutating verbs stay owner-gated |
+| `/provider` vs config | Slash name `/provider`; persisted field `model_provider` |
+| Help groups | Presentation metadata in `runtime/src/commands/help-groups.ts` |
+| Plugin-added commands | Plugins can register additional commands outside this minimal registry (see [skills-plugins.md](skills-plugins.md)) |
+
+Related: [cli.md](cli.md) (top-level `agenc` subcommands), [tui-workbench.md](tui-workbench.md).

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -7,14 +7,20 @@ can stop them.
 
 | Surface | Location | Who sees it |
 | --- | --- | --- |
-| **LIVE model-facing registry** | `runtime/src/tool-registry.ts` + `runtime/src/bin/model-facing-tools.ts` + `runtime/src/tools/` | The model / daemon turn loop |
-| **TUI tool pool** | historical `src/tools.ts` / TUI-side catalog notes | UI presentation — **confirm which catalog you are editing** |
-| **MCP bridge tools** | `runtime/src/mcp-client/tools.ts` | Namespaced `mcp.<server>.<tool>` on the LIVE surface |
+| **LIVE model-facing registry** | `runtime/src/tool-registry.ts` + `runtime/src/bin/model-facing-tools.ts` + `runtime/src/tools/system/*` | The model / daemon turn loop (`toLLMTools()` → provider payload; `dispatch()` → execution) |
+| **TUI tool pool** | `runtime/src/tools.ts` (`getAllBaseTools()`) | Historical / TUI-side presentation pool — **not** the LIVE catalog. Overlaps names with LIVE but omits many LIVE tools and uses donor-era shapes (`CanonicalBashTool`, etc.) |
+| **MCP bridge tools** | `runtime/src/mcp-client/tools.ts` via `mcpToolsProvider` on the registry | Namespaced `mcp.<server>.<tool>` on the LIVE surface (usually deferred until `system.searchTools`) |
 
-Built-in families under `runtime/src/tools/` include: Bash / PowerShell,
-file read/write/edit, `apply_patch`, Glob/Grep, WebFetch/WebSearch, LSP, MCP
-helpers, multi-agent v2 (`spawn_agent` …), Task\*, Skill, cron schedule tools,
-plan mode enter/exit, worktree enter/exit, and more.
+**Rule of thumb:** if you are changing what the model can call in a real turn,
+edit the LIVE path (`buildToolRegistry` / `createModelFacingTools` /
+`tools/system/*`). Editing `tools.ts` alone does **not** register a LIVE tool.
+
+Assembly wiring:
+
+1. `bin/bootstrap-tool-registry.ts` → `createModelFacingTools()` + `buildToolRegistry()`
+2. `tool-registry.ts` registers system groups + injects model-facing tools
+3. Provider payload = request-scoped visible set; deferred tools appear after
+   discovery (`system.searchTools` / `discoverToolNames`)
 
 Unified execution path: `runtime/src/tools/execution.ts` (`runToolUse`) —
 permissions, transaction guard, then `Tool.execute()`.
@@ -24,6 +30,209 @@ Web search provider selection:
 
 Provider tool-schema normalization (strict OpenAI-compatible roots):
 [`../provider-tool-compat.md`](../provider-tool-compat.md).
+
+---
+
+## LIVE tool catalog (by family)
+
+Names below are the **registered** LIVE tool names from
+`buildToolRegistry()` and `createModelFacingTools()`. Visibility is
+request-scoped: a smaller default-visible set is advertised every turn;
+deferred / hidden tools stay in the catalog and load via
+`system.searchTools` (or config / discovery). Config
+(`[tools]` / `toolsConfig`) can disable individual tools.
+
+Do **not** treat the TUI pool (`tools.ts`) as authoritative for this list.
+
+### Files (first-class)
+
+| Name | Notes |
+| --- | --- |
+| `FileRead` | Canonical read |
+| `Edit` | Single-file edit (read-before-write + mtime drift) |
+| `MultiEdit` | Multi-hunk edit on one file |
+| `Write` | Create / overwrite |
+| `Glob` | Path glob |
+| `Grep` | Content search (prefer over shell `rg`/`grep`) |
+| `Orient` | Workspace orientation helper |
+| `apply_patch` | Multi-file transactional patch |
+
+### Filesystem compatibility (`tools/system/filesystem.ts`)
+
+Legacy `system.*` utilities (not the primary edit surface):
+
+| Name |
+| --- |
+| `system.listDir` |
+| `system.stat` |
+| `system.mkdir` |
+| `system.delete` |
+| `system.move` |
+
+### Shell / process
+
+| Name | Notes |
+| --- | --- |
+| `exec_command` | **Canonical** shell (unified-exec) |
+| `write_stdin` | Write to a running unified-exec process |
+| `kill_process` | Kill a managed process |
+| `system.bash` | Direct/shell fallback — **deferred** by default; prefer `exec_command` |
+| `PowerShell` | Registered only when `pwsh`/`powershell` is on `PATH` **and** a unified-exec manager is available; **deferred** |
+
+### Search / discovery / code intel
+
+| Name | Notes |
+| --- | --- |
+| `system.searchTools` | Discover deferred tools into the visible catalog |
+| `system.repoInventory` | Deferred code-intel |
+| `system.gitStatus` | Deferred |
+| `system.gitDiff` | Deferred |
+| `system.gitShow` | Deferred |
+| `system.gitBranchInfo` | Deferred |
+| `system.gitChangeSummary` | Deferred |
+| `system.gitWorktreeList` | Deferred |
+| `system.gitWorktreeCreate` | Deferred |
+| `system.gitWorktreeRemove` | Deferred |
+| `system.gitWorktreeStatus` | Deferred |
+| `system.symbolSearch` | Deferred |
+| `system.symbolDefinition` | Deferred |
+| `system.symbolReferences` | Deferred |
+| `LSP` | Language-server diagnostics / definition / references / symbols |
+| `WebSearch` | Web search (provider-native Grok path when available, else configured endpoint / DuckDuckGo) |
+| `web_fetch` | Fetch URL → text/markdown |
+| `WebFetch` | Legacy alias of `web_fetch` |
+
+There is **no** separate LIVE tool named `web_search`; that string is only a
+provider-native server-side tool id used internally by the Grok web-search
+path. Model-facing search is `WebSearch`.
+
+### Planning / workflow
+
+| Name | Notes |
+| --- | --- |
+| `TodoWrite` | Checklist / todo list |
+| `EnterPlanMode` | Enter plan permission posture |
+| `ExitPlanMode` | Exit plan mode (approval path) |
+| `VerifyPlanExecution` | Compare plan vs progress summary |
+| `WorkflowTool` | Agent workflow runner |
+| `CronCreate` / `CronDelete` / `CronList` | Local scheduled prompts (`.agenc/scheduled_tasks.json`) |
+| `RemoteTrigger` | Deferred; inspect local scheduled defs only |
+
+### Interaction / user input
+
+| Name | Notes |
+| --- | --- |
+| `AskUserQuestion` | Multi-choice questions (TUI picker) |
+| `request_user_input` | Elicitation / free-form user input |
+| `Brief` | Short progress message to the user |
+| `SendUserMessage` | Alias of Brief-style progress message |
+| `Sleep` | Sleep / yield |
+| `Monitor` | Monitor a background command/process |
+
+### Worktree
+
+| Name |
+| --- |
+| `EnterWorktree` |
+| `ExitWorktree` |
+
+### Notebook
+
+| Name |
+| --- |
+| `NotebookRead` |
+| `NotebookEdit` |
+
+### Skill
+
+| Name | Notes |
+| --- | --- |
+| `Skill` | Invoke a skill by name (`skill` / `name` + optional `args`) |
+
+### Task board / background tasks
+
+| Name | Notes |
+| --- | --- |
+| `TaskCreate` | Task board |
+| `TaskGet` | Task board |
+| `TaskUpdate` | Task board |
+| `TaskList` | Task board |
+| `TaskOutput` | Background task output |
+| `TaskStop` | Stop background task |
+
+### Multi-agent v2 + jobs
+
+Canonical v2 surface (`runtime/src/agents/v2/`). Details:
+[`agents.md`](agents.md).
+
+| Name | Notes |
+| --- | --- |
+| `spawn_agent` | Spawn worker |
+| `wait_agent` | Wait for worker result |
+| `close_agent` | Tear down worker |
+| `assign_task` | New task (triggers turn) |
+| `send_message` | Follow-up (no turn trigger) |
+| `list_agents` | Inspect agent tree |
+| `spawn_agents_on_csv` | Batch CSV agent jobs |
+| `report_agent_job_result` | Record CSV job item result |
+
+### MCP helpers (built-in) + bridge
+
+| Name | Notes |
+| --- | --- |
+| `ListMcpResourcesTool` / `ListMcpResources` | List MCP resources (deferred) |
+| `ReadMcpResourceTool` / `ReadMcpResource` | Read MCP resource (deferred) |
+| `mcp.<server>.<tool>` | Live tools from configured MCP servers (usually deferred until discovery) |
+
+### Structured output / code-mode
+
+| Name | Notes |
+| --- | --- |
+| `StructuredOutput` | Schema-bound when session has `outputSchema`; otherwise deferred passthrough |
+| `exec` | Code-mode JS exec — only when code-mode service enabled |
+| `wait` | Code-mode wait — only when code-mode service enabled |
+
+### Default-visible vs deferred (high level)
+
+Exact visibility is request-scoped and config-dependent. As coded in
+`buildToolRegistry` defaults:
+
+- **Typically advertised early:** `exec_command`, `write_stdin`, `kill_process`,
+  `FileRead`, `Edit`, `MultiEdit`, `Write`, `Glob`, `Grep`, `Orient`,
+  `AskUserQuestion`, `TodoWrite`, `EnterPlanMode`, `ExitPlanMode`,
+  `system.searchTools`, plus non-deferred model-facing tools (web, multi-agent
+  v2, tasks, Skill, etc.).
+- **Deferred / discoverable examples:** `system.bash`, git/symbol `system.*`
+  intel tools, MCP tools when `deferMcpTools` is on, MCP resource helpers,
+  `RemoteTrigger`, passthrough `StructuredOutput`, and other tools marked
+  `metadata.deferred`.
+
+Coordinator mode further **allowlists** orchestration tools only — see
+[`agents.md`](agents.md).
+
+---
+
+## TUI pool (`tools.ts`) — dual catalog note
+
+`runtime/src/tools.ts` still exports a donor-era **TUI / presentation** pool
+via `getAllBaseTools()`. It is useful for UI filtering and historical parity,
+but it is **not** what `buildToolRegistry` advertises to the model.
+
+Notable differences (non-exhaustive):
+
+| Topic | LIVE | TUI pool |
+| --- | --- | --- |
+| Shell | `exec_command` (+ deferred `system.bash`) | `CanonicalBashTool` (bash-shaped) |
+| Files | `FileRead` / `Edit` / `Write` / `MultiEdit` / `apply_patch` | Canonical read/edit/write/notebook set |
+| Multi-agent | `spawn_agent` family | Not assembled here (Team\* gated) |
+| Discovery | `system.searchTools` + deferred system intel | Optional `ToolSearchTool` |
+| Code-mode | `exec` / `wait` when enabled | Not in pool |
+| Authority | Daemon turn loop | Presentation / legacy |
+
+When docs or code comments say “registered tools”, assume LIVE unless they
+explicitly cite `tools.ts`.
+
+---
 
 ## Permission modes
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,8 @@ narratives live under [`archive/`](archive/) and are **not** product truth.
 | [`archive/onboarding-plan-2026-07.md`](archive/onboarding-plan-2026-07.md) | Onboarding implementation plan (superseded by shipped acts + quickstart) |
 | [`archive/README.md`](archive/README.md) | Archive index |
 
-Operational task tracking for engineers remains in root [`TODO.md`](../TODO.md)
+Operational task tracking for local engineers may use a gitignored root
+`TODO.md` when present; public product truth for shipped vs open is this file
 (open backlog + completed log with SHAs). This roadmap is the **product-facing**
 shipped / open summary.
 
@@ -68,7 +69,7 @@ shipped / open summary.
 ## Open backlog
 
 Grouped to match current product priority. Detail + acceptance criteria live in
-[`TODO.md`](../TODO.md).
+`TODO.md` (local/gitignored).
 
 ### Channels still open
 
@@ -134,6 +135,6 @@ Carried from the archived parity plan (still policy):
 | Layer | Use |
 | --- | --- |
 | This file | Shipped vs open product summary |
-| [`TODO.md`](../TODO.md) | Engineer backlog, gates, completed SHAs |
+| `TODO.md` (local/gitignored) | Engineer backlog, gates, completed SHAs |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | How the system is put together |
 | [`archive/`](archive/) | Historical plans only |


### PR DESCRIPTION
## Summary

- Add reference pages: config, slash commands, memory, skills/plugins, session hooks.
- Expand LIVE tool catalog + architecture turn phases/recovery ladder notes.
- Correct managed OpenRouter **2048** default max output (was inverted), daemon ready-timeout dual defaults, budget `enforce_interactive` wording.
- Stop product docs from depending on gitignored `TODO.md` / `AGENTS.md`.

## Test plan

- [x] Pre-commit build + package entrypoints + TUI runtime startup passed
- [x] INDEX lists all new reference pages
- [ ] Spot-check `docs/managed-openrouter.md` against `MANAGED_OPENROUTER_DEFAULT_MAX_OUTPUT_TOKENS` in session/bootstrap
- [ ] Spot-check `docs/INDEX.md` navigation