### PR TITLE
docs: mark archive roadmap bodies as non-product truth

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,13 +1,14 @@
 # Archived documentation
 
-These files are **historical only**. They are not product truth and should not be
-used to decide what is shipped.
+These files are **historical only**. They are **not product truth** and must not
+be used to decide what is shipped. Prefer [`../INDEX.md`](../INDEX.md) and
+[`../roadmap.md`](../roadmap.md) for current 0.3.0 product state.
 
-| File | Why archived |
-| --- | --- |
-| `codebase-quality-audit.md` | Closed provenance log (2026-06-22, issue #1276). |
-| `feature-user-stories.csv` | Orphan inventory snapshot last tested 2026-06-22; not linked from the doc hub. |
-| `onboarding-plan-2026-07.md` | Implementation plan replaced by [`../onboarding.md`](../onboarding.md). |
-| `parity-roadmap-2026-07.md` | Competitive roadmap with a stale progress header; replaced by [`../roadmap.md`](../roadmap.md). |
+| File | Why archived | Notes |
+| --- | --- | --- |
+| `codebase-quality-audit.md` | Closed provenance log (2026-06-22, issue #1276). | In-body archived banner. |
+| `feature-user-stories.csv` | Orphan inventory snapshot last tested **2026-06-22**. | Embeds historical version notes (e.g. 0.2.0); ignore for current release. |
+| `onboarding-plan-2026-07.md` | Replaced by [`../onboarding.md`](../onboarding.md). | In-body **ARCHIVED** banner. |
+| `parity-roadmap-2026-07.md` | Replaced by [`../roadmap.md`](../roadmap.md). | Progress header is a **stale 2026-07-09 snapshot** (e.g. Discord “pending” is wrong now). |
 
 Current documentation starts at [`../INDEX.md`](../INDEX.md).

--- a/docs/archive/onboarding-plan-2026-07.md
+++ b/docs/archive/onboarding-plan-2026-07.md
@@ -1,9 +1,11 @@
 # AgenC First-Run Onboarding — Complete Plan (2026-07)
 
-> **Audience:** an AI code assistant (or the owner) implementing onboarding
-> work in `agenc-core`. Same conventions as `docs/parity-roadmap-2026-07.md`;
-> workstreams below are written in TODO.md task format so they can be lifted
-> straight into the backlog.
+> **ARCHIVED — NOT PRODUCT TRUTH.** Superseded by
+> [`../onboarding.md`](../onboarding.md) and [`../roadmap.md`](../roadmap.md).
+> Historical implementation plan only.
+>
+> **Audience (historical):** an AI code assistant implementing onboarding
+> work. Related archive: [`parity-roadmap-2026-07.md`](parity-roadmap-2026-07.md).
 >
 > **Delivery status (2026-07-10):** O-2/O-3/O-4/O-5/O-6 shipped (PR #1454);
 > O-1 shipped (detection + annotation + guaranteed first turn); O-7 shipped

--- a/docs/archive/parity-roadmap-2026-07.md
+++ b/docs/archive/parity-roadmap-2026-07.md
@@ -1,27 +1,29 @@
 # AgenC Core: Parity-and-Beyond Roadmap vs Hermes Agent and OpenClaw
 
+> **ARCHIVED — NOT PRODUCT TRUTH.** Historical plan only. Do not use the
+> progress header below to decide what is shipped. Current product truth:
+> [`../roadmap.md`](../roadmap.md), [`../gateway.md`](../gateway.md),
+> [`../INDEX.md`](../INDEX.md). Discord/Slack, heartbeat, budget, personas,
+> and hooks have since shipped (0.3.0 line).
+
 **Date:** 2026-07-08 (plan). **Inputs:** full repo inventory of agenc-core, full
 repo inventory of `hermes-agent` (v0.17.0), web research on OpenClaw and on
 adoption drivers/complaints for both (HN Algolia + GitHub API verified where noted).
 
-> ## Progress (updated 2026-07-09)
+> ## Progress (updated 2026-07-09) — STALE SNAPSHOT
 >
-> The strategy below is unchanged; this header tracks execution against it.
+> Frozen historical header. **Superseded** by [`../roadmap.md`](../roadmap.md).
 >
 > - **Phase 0 (onboarding) — COMPLETE and PUBLISHED.** One-line installer
 >   (`get.agenc.ag`), `agenc onboard`, `agenc security audit --fix`, Docker
 >   (`ghcr.io/tetsuo-ai/agenc`), Homebrew tap, quickstart + migration guides.
 >   Binaries ship from the public `tetsuo-ai/agenc-releases` repo (5 platforms).
-> - **Phase 1 (channels) — IN PROGRESS.** Done: channel gateway core (pairing,
->   bindings, in-channel token approvals), stdio + Telegram channels + the
->   `agenc gateway run` loop, WebChat (loopback + token-gated browser UI), and
->   untrusted-content hardening (sanitize + frame every inbound message).
->   Pending in Phase 1: Discord/Slack, Signal/email, iMessage/WhatsApp.
-> - **Phases 2-6** — not started (persona/heartbeat, browser/exec, auditable
->   learning, the marketplace moat, growth).
->
-> Per-task detail (PR + SHA + what shipped/deferred) lives in `TODO.md`'s
-> Completed section. See `docs/gateway.md` for the shipped channel surface.
+> - **Phase 1 (channels) — IN PROGRESS (as of 2026-07-09 only).** Done then:
+>   channel gateway core, stdio + Telegram, WebChat, untrusted-content hardening.
+>   Listed as pending then: Discord/Slack (since shipped), Signal/email,
+>   iMessage/WhatsApp (still open).
+> - **Phases 2-6** — were “not started” on that date; much of Phase 2 has since
+>   landed (see current roadmap).
 
 ---
 


### PR DESCRIPTION
## Summary

- Final docs audit found active product docs clean (links, INDEX, versions, 2048 managed cap, channels).
- Residual risk was archive bodies (especially parity-roadmap progress header still saying Discord pending).
- Add explicit ARCHIVED banners + archive README notes.

## Test plan

- [x] Active INDEX/link scans clean before change
- [ ] Open archive parity file and confirm banner first