### PR TITLE
fix(tui): surface dynamic commands in the slash palette and make them invocable via /

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -57,7 +57,7 @@ import { RealtimePanel } from "../realtime/RealtimePanel.js";
 import { useRealtimeState } from "../realtime/useRealtimeState.js";
 import { AgenCPermissionOverlay as PermissionOverlay, buildToolUseConfirmQueue, usePermissionRequests } from "../permission-requests.js";
 import { submitViaElicitationPrompt } from "../elicitation-submit-routing.js";
-import { findCommand, listTuiCommandList } from "../../commands.js";
+import { findCommand, getCommands, isCommandEnabled, listTuiCommandList } from "../../commands.js";
 import { listAgentRoleDefinitions } from "../../agents/role-definitions.js";
 import { buildPendingProviderSwitch } from "../model-switch.js";
 import { pastedContentsToLLMMessage } from "../../llm/pasted-content.js";
@@ -1622,7 +1622,42 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
       setGlobalCommandRegistry(null);
     };
   }, [commandRegistry]);
-  const commands = useMemo(() => listTuiCommandList(commandRegistry), [commandRegistry]);
+  const builtinTuiCommands = useMemo(() => listTuiCommandList(commandRegistry), [commandRegistry]);
+  // The slash palette (and findCommand execution) previously saw ONLY built-in
+  // commands: dir commands (.agenc/commands), skills (.agenc/skills), bundled
+  // skills, and plugin commands were loaded for the model but never surfaced
+  // in the composer. Load the full command set for this workspace and merge
+  // it in, keeping registry built-ins authoritative on name collisions.
+  const dynamicCommandsCwd =
+    props.session.cwd ?? props.session.sessionConfiguration?.cwd ?? process.cwd();
+  const [dynamicTuiCommands, setDynamicTuiCommands] = useState<readonly Command[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void getCommands(dynamicCommandsCwd, config)
+      .then((all) => {
+        if (cancelled) return;
+        setDynamicTuiCommands(
+          all.filter(
+            (cmd) =>
+              cmd.userInvocable !== false &&
+              cmd.isHidden !== true &&
+              isCommandEnabled(cmd),
+          ),
+        );
+      })
+      .catch(() => {
+        // Palette degrades to built-ins only; command loading errors are
+        // already logged by the loaders themselves.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [dynamicCommandsCwd, config]);
+  const commands = useMemo(() => {
+    const seen = new Set(builtinTuiCommands.map((cmd) => cmd.name.toLowerCase()));
+    const extras = dynamicTuiCommands.filter((cmd) => !seen.has(cmd.name.toLowerCase()));
+    return [...builtinTuiCommands, ...extras];
+  }, [builtinTuiCommands, dynamicTuiCommands]);
   const agents = useMemo(() => listAgentRoleDefinitions(), []);
   const appTasks = useAppState(s => s.tasks);
   const hasActiveLocalAgents = getActiveLocalAgentTasks(appTasks).length > 0;
@@ -1863,6 +1898,52 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
     // Slash commands route through the canonical registry. Unrecognized names go
     // through the dispatcher so the TUI matches the daemon/CLI slash path.
     if (parsedSlashCommand !== null) {
+      // Prompt commands (markdown rails under a commands dir, skills, and
+      // plugins) live in the full `commands` list, not the built-in
+      // `commandRegistry`. dispatchSlashCommand only knows the registry, so
+      // a `/agenc-*` rail would come back as "Unknown command" even though
+      // it shows in the palette. Resolve `/name` against `commands` first and
+      // expand it into the turn exactly like `$skill` — this is what makes
+      // `.agenc/commands/*.md` rails and skills invocable via `/`. Built-in
+      // registry commands (they answer `commandRegistry.find`) are left to
+      // the dispatcher below and are never intercepted here.
+      const slashPromptCommand = findCommand(
+        parsedSlashCommand.name,
+        commands as unknown as Command[],
+      );
+      if (
+        commandRegistry.find(parsedSlashCommand.name) === undefined &&
+        slashPromptCommand?.type === "prompt" &&
+        slashPromptCommand.userInvocable !== false &&
+        isCommandEnabled(slashPromptCommand)
+      ) {
+        try {
+          const loaded = await loadDollarSkillCommandForTurn(
+            {
+              commandName: parsedSlashCommand.name,
+              args: parsedSlashCommand.argsRaw,
+            },
+            slashPromptCommand,
+            getToolUseContext(
+              transcriptMessagesRef.current as any[],
+              [],
+              new AbortController(),
+            ) as PromptInputContext,
+          );
+          props.session.enqueueIdleInput?.(loaded.metadata);
+          props.session.enqueueIdleInput?.({ content: loaded.blocks });
+          startPendingSubmission();
+          await submitToSession("", { displayUserMessage: text_0 });
+        } catch (err_slash_prompt) {
+          const message_slash_prompt =
+            err_slash_prompt instanceof Error
+              ? err_slash_prompt.message
+              : String(err_slash_prompt);
+          showTransientResult(message_slash_prompt, { display: "error" });
+          setPendingSubmission(false);
+        }
+        return;
+      }
       try {
         // Echo the slash-command input to the transcript so the user
         // sees what they typed. Without this the dispatcher

--- a/runtime/src/tui/input/processPromptInput.ts
+++ b/runtime/src/tui/input/processPromptInput.ts
@@ -460,7 +460,7 @@ async function processRegistrySlashInput(
   }
   const command = findCommand(parsed.commandName, context.options.commands)
 
-  if (!command || command.type !== 'local') {
+  if (!command || (command.type !== 'local' && command.type !== 'prompt')) {
     return localCommandResultToPromptInputResult(
       inputString,
       precedingInputBlocks,
@@ -477,6 +477,23 @@ async function processRegistrySlashInput(
       attachmentMessages,
       uuid,
       { type: 'text', value: `/${getCommandName(command)} is not available` },
+    )
+  }
+
+  // Prompt commands (markdown rails under a commands dir, skills, plugins)
+  // invoked via `/` expand into the turn exactly like `$skill`. Slash
+  // execution had been narrowed to `type: 'local'`, which left every
+  // `.agenc/commands/*.md` rail and skill visible in the palette but
+  // non-invocable from the composer ("Unknown command"). Routing them
+  // through the shared prompt loader restores `/command` expansion without
+  // widening tool/hook scope beyond what `$` already grants.
+  if (command.type === 'prompt') {
+    return processDollarSkillInput(
+      parsed,
+      command,
+      context,
+      uuid,
+      attachmentMessages,
     )
   }
 


### PR DESCRIPTION
## Problem

Dynamic commands — markdown rails in `commands/` dirs, local skills, bundled skills, and plugin commands — load for the model but are unusable from the composer:

1. **Invisible:** the slash palette is fed by `listTuiCommandList` → `getCommandsSync` → `builtInCommands`, which returns only built-in registry commands. Typing `/agenc` with 33 rails installed under `~/.agenc/commands` shows "1 match: /agents".
2. **Non-invocable:** selecting or typing one returns `Unknown command: /<name>`. The submit path dispatches only against the built-in `commandRegistry`, and the `$` path (`isDollarSkillCommand`) only accepts `loadedFrom: skills | plugin | mcp` — so `commands_DEPRECATED` entries are excluded from **both** triggers. Bundled skills (e.g. the `agenc-marketplace-kit-installer` shipped in #1465) were equally invisible.

## Fix

- **`App.tsx` (palette):** load `getCommands(cwd, config)` async and merge into the palette list, filtered by `userInvocable !== false`, `isHidden !== true`, `isCommandEnabled`. Built-ins win on name collision.
- **`App.tsx` (submit):** when a `/name` misses `commandRegistry.find` but resolves to an enabled, user-invocable `type: 'prompt'` command, expand it into the turn via `loadDollarSkillCommandForTurn` — identical semantics to `$skill` (same tool/hook scope, same skill-invocation tracking). Built-ins keep their existing dispatcher path and can never be shadowed.
- **`processPromptInput.ts`:** same prompt-type branch in `processRegistrySlashInput` so the non-App path (bridge/queue) behaves consistently.

## Verification (local — Actions is red org-wide on billing, jobs die with 0 steps)

- `tsc --noEmit`: 0 errors; `npm run build`: clean, on top of `295e02e` (0.6.0).
- `vitest run tests/slash tests/skills tests/commands`: **517 passed**, 3 failed — the known pre-existing macOS `local-loader.test.ts` realpath failures (`/var` vs `/private/var`), reproduce on a clean tree.
- Runtime probes against the compiled bundle: pure state (no rails installed anywhere) shows exactly the 3 bundled `agenc-*` skills; with rails installed, 40; `getPromptForCommand` expansion returns full runbook content (2.6–4.5 kB per rail).
- Live TUI: palette filtering confirmed on-screen; previously `Unknown command: /agenc-init`, now expands and submits.
