### PR TITLE
feat(skills): installer runbook offers the opt-in rails install (kit v0.1.123+)

### DIFF
--- a/runtime/src/skills/bundled/agencMarketplaceKitInstaller.ts
+++ b/runtime/src/skills/bundled/agencMarketplaceKitInstaller.ts
@@ -59,6 +59,22 @@ report \`attestationSkipped\`.
 
 Both are readonly. Report the installed version to the user.
 
+## Optional: install the full slash-command rails
+
+The binary can install the marketplace rails into this harness (v0.1.123+).
+This is opt-in — ask the user first, and only offer it after the verify step
+passed:
+
+\`\`\`
+~/.agenc/bin/agenc-marketplace agenc install --global
+\`\`\`
+
+That writes the \`agenc-*\` commands, skills, and guard hooks into the harness
+config home (\`~/.agenc\`) so \`/agenc-*\` commands load in every session.
+\`agenc install --project-dir <dir>\` installs into one project instead. If the
+command reports unknown, the installed binary predates v0.1.123 — skip this
+step; everything below works without it.
+
 ## Operate
 
 After installing, fetch https://marketplace.agenc.tech/agents.txt and follow


### PR DESCRIPTION
Kit v0.1.123 (released today) ships `agenc install --global`. The bundled `/agenc-marketplace-kit-installer` runbook now offers that opt-in step after the readonly verify passes — ask-first, with a graceful skip when the installed binary predates the command. Keeps the design: core ships only the installer by default; the full rail set is explicit opt-in. Bundled-skill test + typecheck green.