### PR TITLE
fix(onboarding): correct provider key verification for grok, gemini, and openrouter

### DIFF
--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -46,6 +46,9 @@ import {
 import { OnboardingBox as Box, OnboardingText as Text } from "./elements.js";
 import { WelcomeV2 } from "./WelcomeV2.js";
 import {
+  DEFAULT_PROVIDER_VERIFY_TIMEOUT_MS,
+  isKeyRejectedStatus,
+  providerVerificationUrl,
   verifyApiKey,
   type VerificationStatus,
 } from "./useApiKeyVerification.js";
@@ -556,18 +559,6 @@ function localModelsUrl(provider: BuiltInProviderSlug, baseURL: string): string 
   return `${trimmed}/v1/models`;
 }
 
-function remoteModelsUrl(provider: BuiltInProviderSlug, baseURL: string): string {
-  const trimmed = baseURL.replace(/\/+$/, "");
-  if (provider === "gemini" && !/\/openai$/i.test(trimmed)) {
-    return `${trimmed}/openai/models`;
-  }
-  if (trimmed.endsWith("/models")) return trimmed;
-  if (/\/(?:v\d+(?:beta)?|api\/v\d+)$/i.test(trimmed)) {
-    return `${trimmed}/models`;
-  }
-  return `${trimmed}/v1/models`;
-}
-
 function remoteProviderHeaders(
   provider: BuiltInProviderSlug,
   apiKey: string,
@@ -620,13 +611,16 @@ async function probeRemoteProvider(params: {
   const fetchImpl = params.fetchImpl ?? globalThis.fetch?.bind(globalThis);
   if (fetchImpl === undefined) return { ok: false };
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), params.timeoutMs ?? 1_500);
+  const timer = setTimeout(
+    () => controller.abort(),
+    params.timeoutMs ?? DEFAULT_PROVIDER_VERIFY_TIMEOUT_MS,
+  );
   if (typeof (timer as { unref?: () => void }).unref === "function") {
     (timer as { unref: () => void }).unref();
   }
   try {
     const response = await fetchImpl(
-      remoteModelsUrl(params.provider, params.baseURL),
+      providerVerificationUrl(params.provider, params.baseURL),
       {
         method: "GET",
         headers: remoteProviderHeaders(params.provider, params.apiKey),
@@ -742,7 +736,8 @@ export async function checkOnboardingProviderConnection(
       fetchImpl: context.fetchImpl,
     });
     if (!remote.ok) {
-      const authFailed = remote.status === 401 || remote.status === 403;
+      const authFailed =
+        remote.status !== undefined && isKeyRejectedStatus(provider, remote.status);
       return {
         provider,
         model,

--- a/runtime/src/onboarding/useApiKeyVerification.ts
+++ b/runtime/src/onboarding/useApiKeyVerification.ts
@@ -39,6 +39,36 @@ const LOCAL_KEYLESS_PROVIDERS = new Set<BuiltInProviderSlug>([
   "lmstudio",
 ]);
 
+/**
+ * Default timeout for the one-time provider key checks. Live probes put a
+ * cold TLS handshake plus the models round trip at 0.8–1.6s on a healthy
+ * connection (OpenRouter alone exceeded the previous 1.5s default), so the
+ * first-run check gets a comfortable margin instead of aborting on
+ * perfectly good keys.
+ */
+export const DEFAULT_PROVIDER_VERIFY_TIMEOUT_MS = 5_000;
+
+/**
+ * Providers that reject bad API keys with HTTP 400 instead of 401/403 on
+ * their models endpoint (verified live): x.ai returns 400 for both
+ * malformed and well-formed-but-wrong keys, and Gemini's OpenAI-compat
+ * surface does the same. For these, 400 on a bare authenticated GET means
+ * "key rejected", not "request malformed".
+ */
+const PROVIDERS_REJECTING_KEYS_WITH_400 = new Set<BuiltInProviderSlug>([
+  "grok",
+  "gemini",
+]);
+
+/** True when the HTTP status means the provider rejected this API key. */
+export function isKeyRejectedStatus(
+  provider: BuiltInProviderSlug,
+  status: number,
+): boolean {
+  if (status === 401 || status === 403) return true;
+  return status === 400 && PROVIDERS_REJECTING_KEYS_WITH_400.has(provider);
+}
+
 export async function verifyApiKey(
   params: VerifyApiKeyParams,
 ): Promise<ApiKeyVerificationResult> {
@@ -73,18 +103,21 @@ export async function verifyApiKey(
   );
   const baseURL = settings?.baseURL ?? BUILT_IN_PROVIDER_BASE_URLS[provider];
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), params.timeoutMs ?? 1_500);
+  const timer = setTimeout(
+    () => controller.abort(),
+    params.timeoutMs ?? DEFAULT_PROVIDER_VERIFY_TIMEOUT_MS,
+  );
   if (typeof (timer as { unref?: () => void }).unref === "function") {
     (timer as { unref: () => void }).unref();
   }
   try {
-    const response = await fetchImpl(remoteModelsUrl(provider, baseURL), {
+    const response = await fetchImpl(providerVerificationUrl(provider, baseURL), {
       method: "GET",
       headers: apiKeyHeaders(provider, apiKey),
       signal: controller.signal,
     });
     if (response.ok) return { status: "valid" };
-    if (response.status === 401 || response.status === 403) {
+    if (isKeyRejectedStatus(provider, response.status)) {
       return { status: "invalid", error: "Provider rejected this API key." };
     }
     return {
@@ -136,8 +169,21 @@ export function useApiKeyVerification(
   return result;
 }
 
-function remoteModelsUrl(provider: BuiltInProviderSlug, baseURL: string): string {
+/**
+ * URL used to verify a provider API key. This is the models listing for
+ * most providers, with two exceptions: Gemini keys are checked against the
+ * OpenAI-compat surface, and OpenRouter's models endpoint is PUBLIC (it
+ * returns 200 for any Authorization header, verified live) so its key-info
+ * endpoint `/auth/key` is used instead — that one actually authenticates.
+ */
+export function providerVerificationUrl(
+  provider: BuiltInProviderSlug,
+  baseURL: string,
+): string {
   const trimmed = baseURL.replace(/\/+$/, "");
+  if (provider === "openrouter" && !/\/auth\/key$/i.test(trimmed)) {
+    return `${trimmed}/auth/key`;
+  }
   if (provider === "gemini" && !/\/openai$/i.test(trimmed)) {
     return `${trimmed}/openai/models`;
   }

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -609,6 +609,8 @@ describe("first-run onboarding wizard", () => {
     const context = {
       config,
       env: { XAI_API_KEY: "xai-bad-env-key" },
+      // x.ai rejects bad keys with HTTP 400 (verified live), which now
+      // classifies as auth-failed rather than provider-unreachable.
       fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(
         new Response("bad request", { status: 400 }),
       ),
@@ -642,6 +644,28 @@ describe("first-run onboarding wizard", () => {
     );
     expect(result.state.currentStepId).toBe("security");
     expect(result.state.connection).toMatchObject({
+      ok: false,
+      status: "auth-failed",
+      keyEnvVar: "XAI_API_KEY",
+    });
+  });
+
+  test("marks a genuinely unreachable provider as provider-unreachable, not auth-failed", async () => {
+    const config = defaultConfig();
+    const context = {
+      config,
+      env: { XAI_API_KEY: "xai-env-key" },
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response("bad gateway", { status: 502 }),
+      ),
+      checkLocalProviders: false,
+    };
+    const connection = await checkOnboardingProviderConnection(
+      context,
+      "grok",
+      "grok-4",
+    );
+    expect(connection).toMatchObject({
       ok: false,
       status: "provider-unreachable",
       keyEnvVar: "XAI_API_KEY",

--- a/runtime/tests/onboarding/useApiKeyVerification.test.ts
+++ b/runtime/tests/onboarding/useApiKeyVerification.test.ts
@@ -121,4 +121,82 @@ describe("verifyApiKey", () => {
       error: "Provider verification failed with HTTP 500.",
     });
   });
+
+  test("treats HTTP 400 as a rejected key for providers that reject with 400", async () => {
+    // x.ai and Gemini's OpenAI-compat surface return 400 for bad keys
+    // (verified live), so 400 must read as "key rejected" there…
+    for (const provider of ["grok", "gemini"] as const) {
+      await expect(
+        verifyApiKey({
+          provider,
+          apiKey: "wrong-but-well-formed-key",
+          config: defaultConfig(),
+          fetchImpl: async () => new Response("bad key", { status: 400 }),
+        }),
+      ).resolves.toMatchObject({
+        status: "invalid",
+        error: "Provider rejected this API key.",
+      });
+    }
+
+    // …but stays a generic verification error for providers that use
+    // 400 for malformed requests (OpenAI et al reject keys with 401).
+    await expect(
+      verifyApiKey({
+        provider: "openai",
+        apiKey: "sk-wrong-key",
+        config: defaultConfig(),
+        fetchImpl: async () => new Response("bad request", { status: 400 }),
+      }),
+    ).resolves.toMatchObject({
+      status: "error",
+      error: "Provider verification failed with HTTP 400.",
+    });
+  });
+
+  test("verifies OpenRouter keys against the authenticated key endpoint", async () => {
+    // OpenRouter's models endpoint is public — it returns 200 for ANY
+    // Authorization header (verified live), so verification must hit the
+    // key-info endpoint instead of blessing garbage keys.
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ data: {} }), { status: 200 }),
+    );
+
+    await expect(
+      verifyApiKey({
+        provider: "openrouter",
+        apiKey: "sk-or-test-key",
+        config: defaultConfig(),
+        fetchImpl,
+      }),
+    ).resolves.toEqual({ status: "valid" });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/auth/key",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer sk-or-test-key" },
+      }),
+    );
+
+    await expect(
+      verifyApiKey({
+        provider: "openrouter",
+        apiKey: "sk-or-wrong-key",
+        config: defaultConfig(),
+        fetchImpl: async () => new Response("unauthorized", { status: 401 }),
+      }),
+    ).resolves.toMatchObject({
+      status: "invalid",
+      error: "Provider rejected this API key.",
+    });
+  });
+
+  test("gives the one-time check a realistic timeout default", async () => {
+    // Live probes measured 0.8–1.6s per provider on a healthy connection;
+    // the previous 1.5s default aborted OpenRouter checks on GOOD keys.
+    const { DEFAULT_PROVIDER_VERIFY_TIMEOUT_MS } = await import(
+      "./useApiKeyVerification.js"
+    );
+    expect(DEFAULT_PROVIDER_VERIFY_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+  });
 });


### PR DESCRIPTION
Live-verified against the real provider APIs: (1) x.ai + Gemini reject bad keys with HTTP 400 — previously shown as a generic verification error instead of "key rejected" (worst on grok, this harness's flagship provider); now classified via a shared `isKeyRejectedStatus()` in both the api-key step and the connection test. (2) OpenRouter's `/models` is public (200 for junk keys → false-positive "valid"); verification now hits the authenticated `/api/v1/auth/key` (junk → 401, live-verified) via a shared `providerVerificationUrl()` that also de-duplicates Onboarding's URL builder. (3) Timeout 1.5s → 5s: OpenRouter measured 1.59s on a healthy connection, so good keys were aborting as "did not complete". Suites: onboarding + auth + onboard-cli 173/173; tsc clean.