### PR TITLE
polish(tui): main-screen design pass — dedupe chrome, graceful hints, welcome hierarchy

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInputFooterSuggestions.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInputFooterSuggestions.tsx
@@ -201,9 +201,12 @@ const SuggestionItemRow = memo(function SuggestionItemRow({
       lineContent = `${selectionPrefix}${icon} ${displayText}`
     }
   } else {
-    const maxNameWidth = Math.max(1, Math.floor(width * 0.4))
+    // The name column may take up to 45% of the row; the description owns the
+    // rest. The previous 40% cap plus 4 columns of slack starved descriptions
+    // ("Install the signed AgenC M…") while the row still had spare width.
+    const maxNameWidth = Math.max(1, Math.floor(width * 0.45))
     const displayTextWidth = Math.max(1, Math.min(
-      maxColumnWidth ?? stringWidth(item.displayText) + 5,
+      maxColumnWidth ?? stringWidth(item.displayText) + 2,
       maxNameWidth,
     ))
 
@@ -221,7 +224,7 @@ const SuggestionItemRow = memo(function SuggestionItemRow({
     const tagWidth = stringWidth(tagText)
     const descriptionWidth = Math.max(
       0,
-      width - prefixWidth - displayTextWidth - tagWidth - 4,
+      width - prefixWidth - displayTextWidth - tagWidth - 1,
     )
     const truncatedDescription = item.description
       ? truncateToWidth(item.description.replace(/\s+/g, ' '), descriptionWidth)
@@ -270,7 +273,7 @@ export function PromptInputFooterSuggestions({
 
   const maxColumnWidth =
     maxColumnWidthProp ??
-    Math.max(...suggestions.map(item => stringWidth(item.displayText))) + 5
+    Math.max(...suggestions.map(item => stringWidth(item.displayText))) + 2
 
   const startIndex = Math.max(
     0,
@@ -281,6 +284,13 @@ export function PromptInputFooterSuggestions({
   )
   const endIndex = Math.min(startIndex + maxVisibleItems, suggestions.length)
   const visibleItems = suggestions.slice(startIndex, endIndex)
+  // Size the name column to the widest VISIBLE row, not the widest row in the
+  // whole result set: one long command anywhere in a 40-entry list was padding
+  // every rendered page's name column and starving the descriptions.
+  const visibleColumnWidth = Math.min(
+    maxColumnWidth,
+    Math.max(...visibleItems.map(item => stringWidth(item.displayText))) + 2,
+  )
   // Round-2 MD-NEW8: when the suggestion list is longer than the
   // visible window (e.g. tab-completing inside a directory with 200
   // entries), show the count of items hidden below the fold so the
@@ -347,7 +357,7 @@ export function PromptInputFooterSuggestions({
           >
             <SuggestionItemRow
               item={item}
-              maxColumnWidth={maxColumnWidth}
+              maxColumnWidth={visibleColumnWidth}
               isSelected={isSelected}
               width={contentWidth}
             />

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -10,6 +10,7 @@ import Box from '../../ink/components/Box.js'
 import wrapText from '../../ink/wrap-text.js'
 import ThemedBox from '../design-system/ThemedBox.js'
 import ThemedText from '../design-system/ThemedText.js'
+import { stringWidth } from '../../ink/stringWidth.js'
 
 type ThemeColor = keyof Theme
 
@@ -773,6 +774,45 @@ function useWelcomeCardWidth(): number {
   return Math.min(capped, usable)
 }
 
+// The welcome hint line drops WHOLE segments when the pane is narrow instead
+// of ellipsizing mid-word ("@ to atta…" taught nothing). Segments are ordered
+// by teaching value; the first ones survive narrow panes. "? for shortcuts" is
+// deliberately absent — the composer footer already shows it, and the welcome
+// screen was saying it twice.
+const WELCOME_HINT_SEGMENTS = [
+  'type a task and press ↵',
+  '/ for commands',
+  '@ to attach',
+] as const
+const WELCOME_HINT_SEPARATOR = '  ·  '
+
+export function fitHintSegments(
+  segments: readonly string[],
+  available: number,
+  separator: string = WELCOME_HINT_SEPARATOR,
+): string {
+  let line = ''
+  for (const segment of segments) {
+    const candidate = line === '' ? segment : `${line}${separator}${segment}`
+    if (stringWidth(candidate) > available) break
+    line = candidate
+  }
+  // Never render an empty row: fall back to the single most valuable segment
+  // and let the Text truncate it (only reachable on absurdly narrow panes).
+  return line === '' ? (segments[0] ?? '') : line
+}
+
+function WelcomeHintLine(): React.ReactNode {
+  const contentWidth = useContentWidth()
+  const frameColumns = React.useContext(TerminalFrameColumnsContext)
+  const available = Math.max(1, (contentWidth ?? frameColumns) - WELCOME_CARD_INSET)
+  return (
+    <ThemedText color="inactive" wrap="truncate-end">
+      {fitHintSegments(WELCOME_HINT_SEGMENTS, available)}
+    </ThemedText>
+  )
+}
+
 function WelcomeMetaRow({
   label,
   value,
@@ -859,7 +899,11 @@ export function WelcomeColdPanel({
           flexDirection="column"
           width={cardWidth}
           borderStyle="single"
-          borderColor="lineSoft"
+          // The resume list is the most likely next action on a cold start, so
+          // it carries the one accent border on this screen — the info card
+          // above stays lineSoft. Two identically-dim boxes gave the eye
+          // nowhere to land.
+          borderColor={visibleSessions.length > 0 ? 'agenc' : 'lineSoft'}
           paddingX={1}
           paddingY={1}
         >
@@ -879,7 +923,10 @@ export function WelcomeColdPanel({
                 <ThemedText color="muted3">] </ThemedText>
               </Box>
               <Box flexShrink={1} minWidth={0} flexDirection="row">
-                <ThemedText color="text2" wrap="truncate-end">{session.title}</ThemedText>
+                {/* Titles at full text intensity, metadata dim: the previous
+                    text2-on-muted3 pairing read as one gray blur, hiding the
+                    only word the user actually scans for. */}
+                <ThemedText color="text" wrap="truncate-end">{session.title}</ThemedText>
                 <ThemedText color="muted3" wrap="truncate-end"> · {session.detail}</ThemedText>
               </Box>
             </Box>
@@ -889,9 +936,7 @@ export function WelcomeColdPanel({
         </ThemedBox>
       </Box>
 
-      <ThemedText color="inactive" wrap="truncate-end">
-        type a task and press ↵  ·  / for commands  ·  @ to attach  ·  ? for shortcuts
-      </ThemedText>
+      <WelcomeHintLine />
     </Box>
   )
 }

--- a/runtime/src/tui/hooks/renderPlaceholder.ts
+++ b/runtime/src/tui/hooks/renderPlaceholder.ts
@@ -32,10 +32,12 @@ export function renderPlaceholder({
     } else {
       renderedPlaceholder = chalk.dim(placeholder)
 
-      // Show inverse cursor only when both input and terminal are focused
+      // Show inverse cursor only when both input and terminal are focused.
+      // The cursor gets its own cell BEFORE the ghost text: inverting the
+      // placeholder's first letter fused cursor and hint into what read like
+      // a typo ("❯ D■escribe…") instead of a cursor beside a hint.
       if (showCursor && focus && terminalFocus) {
-        renderedPlaceholder =
-          invert(placeholder[0]!) + chalk.dim(placeholder.slice(1))
+        renderedPlaceholder = invert(' ') + chalk.dim(placeholder)
       }
     }
   }

--- a/runtime/src/tui/workbench/WorkbenchContextStrip.tsx
+++ b/runtime/src/tui/workbench/WorkbenchContextStrip.tsx
@@ -129,16 +129,21 @@ export function selectStripSegments(
     return w;
   };
 
+  // An empty mode label means "nothing worth showing" (the default permission
+  // mode carries no signal — rendering the word "default" in the header only
+  // raised the question of what it referred to). Normalize it to null so no
+  // candidate renders an empty segment between separators.
+  const modeLabel = parts.modeLabel.length > 0 ? parts.modeLabel : null;
+
   // Candidates in descending richness; first that fits wins.
   const candidates: ReadonlyArray<{
     readonly model: string;
     readonly modeLabel: string | null;
     readonly cwd: string | null;
   }> = [
-    { model: parts.model, modeLabel: parts.modeLabel, cwd: parts.cwd },
-    { model: parts.model, modeLabel: parts.modeLabel, cwd: parts.cwdBasename },
-    { model: parts.model, modeLabel: parts.modeLabel, cwd: null },
-    { model: parts.model, modeLabel: parts.modeLabel.length > 0 ? parts.modeLabel : null, cwd: null },
+    { model: parts.model, modeLabel, cwd: parts.cwd },
+    { model: parts.model, modeLabel, cwd: parts.cwdBasename },
+    { model: parts.model, modeLabel, cwd: null },
     { model: parts.model, modeLabel: null, cwd: null },
   ];
 
@@ -194,7 +199,11 @@ export function WorkbenchContextStrip({
   const mode = useAppStateMaybeOutsideOfProvider(selectMode) ?? "default";
 
   const modelLabel = renderModelName(parseUserSpecifiedModel(modelSetting));
-  const modeLabel = permissionModeShortTitle(mode).toLowerCase();
+  // The default permission mode is noise in the header ("· default ·" answered
+  // a question nobody asked); non-default modes ARE signal and stay visible,
+  // dangerous ones in the warning color below.
+  const modeLabel =
+    mode === "default" ? "" : permissionModeShortTitle(mode).toLowerCase();
   const dangerous = isDangerousPermissionMode(mode);
   const cwdDisplay = compactCwd(sessionCwd());
 

--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -1,21 +1,43 @@
 import React from "react";
 
 import { Box, Text } from "../ink.js";
+import { stringWidth } from "../ink/stringWidth.js";
+import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { footerHintsForSurface } from "./surfaces/ActiveWorkSurface.js";
 import { composerAttachmentsForState, visibleWorkbenchPane } from "./reducer.js";
 import { useWorkbenchState } from "./state.js";
 
+// Hints are `<label>: <segment>  <segment>  …` with double-space separators.
+// On narrow terminals whole trailing segments are dropped instead of
+// ellipsizing the last one mid-word ("ctrl+w k focu…" taught nothing). The
+// label plus first segment always render (truncated as a last resort).
+export function fitFooterHints(hints: string, available: number): string {
+  if (stringWidth(hints) <= available) return hints;
+  const segments = hints.split(/ {2,}/);
+  let line = "";
+  for (const segment of segments) {
+    const candidate = line === "" ? segment : `${line}  ${segment}`;
+    if (stringWidth(candidate) > available) break;
+    line = candidate;
+  }
+  return line === "" ? (segments[0] ?? hints) : line;
+}
+
 export function WorkbenchFooter(): React.ReactElement {
   const workbench = useWorkbenchState();
+  const { columns } = useTerminalSize();
   const hints = hintsForPane(visibleWorkbenchPane(workbench), workbench.activeSurfaceMode);
   const composerAttachments = composerAttachmentsForState(workbench);
+  // paddingX={2} on both sides, and leave the attachments suffix whatever
+  // room it needs before the hints claim the rest.
+  const fittedHints = fitFooterHints(hints, Math.max(1, columns - 4));
   return (
     // paddingX={2} matches the composer's own footer hint inset
     // (PromptInputFooter), so the stacked "? for shortcuts" line and this
     // surface-hint line share a consistent left margin instead of one being
     // indented two columns and the other flush at column 0.
     <Box height={1} width="100%" paddingX={2}>
-      <Text dimColor wrap="truncate-end">{hints}</Text>
+      <Text dimColor wrap="truncate-end">{fittedHints}</Text>
       {composerAttachments.length > 0 ? (
         <Text color="suggestion" wrap="truncate-end"> | context {composerAttachments.map((item) => item.label).join(", ")}</Text>
       ) : null}

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -91,7 +91,12 @@ export function WorkbenchLayout({
   return (
     <Box flexDirection="column" width="100%" height={rows} overflow="hidden">
       {rows >= 8 ? <WorkbenchStatusBar activityMode={activityMode} columns={columns} /> : null}
-      <Box flexDirection="row" flexGrow={1} overflow="hidden">
+      {/* On the cold-start welcome the surface row sizes to its content so the
+          composer sits directly under the welcome panel instead of pinned to
+          the bottom of a tall terminal with a dead gulf between them; the
+          spacer after the footer absorbs the remaining rows. Once messages
+          arrive the row grows again and the composer returns to the bottom. */}
+      <Box flexDirection="row" flexGrow={atWelcome ? 0 : 1} flexShrink={1} overflow="hidden">
         {showExplorer ? (
           <NoSelect flexShrink={0} width={explorerWidth} height="100%">
             <ProjectExplorer focused={focusedPane === "explorer"} width={explorerWidth} />
@@ -119,6 +124,7 @@ export function WorkbenchLayout({
       </Box>
       <PromptDialogOverlay />
       {rows >= 5 ? <WorkbenchFooter /> : null}
+      {atWelcome ? <Box flexGrow={1} /> : null}
       {layoutSize !== "wide" && workbench.agentsVisible && focusedPane === "agents" ? (
         <Box position="absolute" right={0} top={1} bottom={2} width={Math.min(34, columns)} opaque>
           <NoSelect width={Math.min(34, columns)} height="100%">

--- a/runtime/src/tui/workbench/surfaces/TranscriptSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TranscriptSurface.tsx
@@ -111,11 +111,13 @@ export function TranscriptSurface({
     </Box>
   );
 
+  // No pane-header row here: the workbench status bar already announces the
+  // active surface ("AgenC Workbench | TRANSCRIPT" one row above), so a second
+  // TRANSCRIPT label rendered the same word twice in the top three rows of the
+  // screen. Other surfaces keep their own headers because their titles carry
+  // real information (file paths, diff targets); this one was pure duplication.
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
-      <Box height={1} flexShrink={0}>
-        <Text color="text2">TRANSCRIPT</Text>
-      </Box>
       {body}
     </Box>
   );

--- a/runtime/src/utils/suggestions/commandSuggestions.ts
+++ b/runtime/src/utils/suggestions/commandSuggestions.ts
@@ -1,7 +1,6 @@
 import Fuse from 'fuse.js'
 import {
   type Command,
-  formatDescriptionWithSource,
   getCommand,
   getCommandName,
 } from '../../commands.js'
@@ -268,6 +267,22 @@ function findMatchedAlias(
  * Creates a suggestion item from a command.
  * Only shows the matched alias in parentheses if the user typed an alias.
  */
+// Provenance as a short tag rather than a "(source)" description SUFFIX: the
+// suffix was the first thing truncated away on long descriptions — exactly the
+// rows where knowing "is this a builtin or something a project installed?"
+// matters most. Tags render before the description and survive truncation.
+function commandSourceTag(cmd: Command): string | undefined {
+  if (cmd.type !== 'prompt') return undefined
+  const source = cmd.source
+  if (source === 'userSettings' || source === 'localSettings') return 'user'
+  if (source === 'projectSettings') return 'project'
+  if (source === 'policySettings') return 'policy'
+  if (source === 'bundled') return 'bundled'
+  if (source === 'plugin')
+    return cmd.pluginInfo?.pluginManifest?.name ?? 'plugin'
+  return undefined
+}
+
 function createCommandSuggestionItem(
   cmd: Command,
   matchedAlias?: string,
@@ -279,15 +294,13 @@ function createCommandSuggestionItem(
   const isWorkflow = cmd.type === 'prompt' && cmd.kind === 'workflow'
   const isProtocol = cmd.kind === 'protocol'
   const fullDescription =
-    sanitizeSuggestionMetadataText(
-      isWorkflow ? cmd.description : formatDescriptionWithSource(cmd),
-    ) +
+    sanitizeSuggestionMetadataText(cmd.description ?? '') +
     (cmd.type === 'prompt' ? formatCommandArgumentHint(cmd.argNames) : '')
 
   return {
     id: getCommandId(cmd),
     displayText: `/${commandName}${aliasText}`,
-    tag: isWorkflow ? 'workflow' : isProtocol ? '◆' : undefined,
+    tag: isProtocol ? '◆' : isWorkflow ? 'workflow' : commandSourceTag(cmd),
     description: fullDescription,
     metadata: cmd,
     color: isProtocol ? 'worker' : undefined,

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -117,9 +117,22 @@ describe('v2 primitives', () => {
     // First-action guidance so the cold-start screen says HOW to begin.
     expect(output).toContain('type a task and press')
     expect(output).toContain('/ for commands')
-    expect(output).toContain('? for shortcuts')
+    expect(output).toContain('@ to attach')
+    // "? for shortcuts" moved out of this line: the composer footer already
+    // shows it, and the welcome screen was saying it twice.
+    expect(output).not.toContain('? for shortcuts')
     // Resume affordance on the recent box so the [1]-[3] numbers read as shortcuts.
     expect(output).toContain('press 1-3 to resume')
+  })
+
+  it('drops whole hint segments on a narrow pane instead of cutting mid-word', async () => {
+    const output = await renderToString(<WelcomeColdPanel />, { columns: 44, rows: 24 })
+
+    // The first segment always survives…
+    expect(output).toContain('type a task and press')
+    // …and narrower panes lose trailing segments whole: no mid-word ellipsis
+    // like "@ to atta…" (the literal regression this guards against).
+    expect(output).not.toMatch(/@ to att\S*…/)
   })
 
   it('omits the resume affordance when there are no recent sessions', async () => {

--- a/runtime/tests/tui/hooks/renderPlaceholder.test.ts
+++ b/runtime/tests/tui/hooks/renderPlaceholder.test.ts
@@ -61,17 +61,20 @@ describe('renderPlaceholder', () => {
     expect(rendered.showPlaceholder).toBe(false)
   })
 
-  test('renders inverse cursor on the first placeholder character only when focused', () => {
-    expect(
-      renderPlaceholder({
-        placeholder: 'hello',
-        value: '',
-        showCursor: true,
-        focus: true,
-        terminalFocus: true,
-        invert,
-      }).renderedPlaceholder,
-    ).toContain('[h]')
+  test('renders the cursor as its own cell before the ghost text only when focused', () => {
+    // The cursor must NOT swallow the placeholder's first letter — inverting
+    // it fused cursor and hint into what read like a typo ("D■escribe…").
+    const focused = renderPlaceholder({
+      placeholder: 'hello',
+      value: '',
+      showCursor: true,
+      focus: true,
+      terminalFocus: true,
+      invert,
+    }).renderedPlaceholder
+    expect(focused).toContain('[ ]')
+    expect(focused).toContain('hello')
+    expect(focused).not.toContain('[h]')
 
     expect(
       renderPlaceholder({
@@ -82,7 +85,7 @@ describe('renderPlaceholder', () => {
         terminalFocus: true,
         invert,
       }).renderedPlaceholder,
-    ).not.toContain('[h]')
+    ).not.toContain('[ ]')
 
     expect(
       renderPlaceholder({
@@ -93,6 +96,6 @@ describe('renderPlaceholder', () => {
         terminalFocus: false,
         invert,
       }).renderedPlaceholder,
-    ).not.toContain('[h]')
+    ).not.toContain('[ ]')
   })
 })

--- a/runtime/tests/tui/workbench-context-strip.test.tsx
+++ b/runtime/tests/tui/workbench-context-strip.test.tsx
@@ -160,16 +160,24 @@ describe("selectStripSegments degradation", () => {
 });
 
 describe("WorkbenchStatusBar context strip rendering", () => {
-  test("shows model, permission mode, and a compact cwd at a wide width", async () => {
+  test("shows model, a non-default permission mode, and a compact cwd at a wide width", async () => {
     const { getCwdState } = await import("../../src/bootstrap/state.js");
-    const out = await renderStatusBar(120, { mode: "default" });
+    const out = await renderStatusBar(120, { mode: "plan" });
     expect(out).toContain(TEST_MODEL);
-    expect(out).toContain("default");
+    expect(out).toContain("plan");
     // Compact cwd: the basename of the session cwd (the same stable source the
     // strip reads) is present; the strip never shows the full long path raw.
     const expectedCwd = compactCwd(getCwdState());
     const tail = basenameOf(expectedCwd);
     expect(out).toContain(tail);
+  });
+
+  test("hides the permission-mode segment entirely in the default mode", async () => {
+    // "· default ·" in the header answered a question nobody asked; only
+    // non-default modes carry signal.
+    const out = await renderStatusBar(120, { mode: "default" });
+    expect(out).toContain(TEST_MODEL);
+    expect(out).not.toContain("default");
   });
 
   test("shows the dangerous mode label (bypass) when elevated", async () => {
@@ -213,12 +221,14 @@ describe("WorkbenchContextStrip dangerous-mode styling (ANSI)", () => {
     // Dark theme 'warning' resolves to truecolor amber (rgb(255,151,72)).
     const WARNING_SGR = "\u001b[38;2;255;151;72m";
     const dangerous = await renderStripAnsi("bypassPermissions");
-    const normal = await renderStripAnsi("default");
+    // "plan" is the non-default comparison mode: the default mode no longer
+    // renders a mode segment at all, so it cannot carry styling either way.
+    const normal = await renderStripAnsi("plan");
 
     // Both render the model + mode label; only the dangerous one styles the
     // mode segment in the warning color.
     expect(dangerous).toContain("bypass");
-    expect(normal).toContain("default");
+    expect(normal).toContain("plan");
     expect(dangerous).toContain(WARNING_SGR);
     expect(normal).not.toContain(WARNING_SGR);
     // The warning styling is *extra*, so the dangerous render has more SGR codes.

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -688,7 +688,10 @@ describe("workbench render contract", () => {
       { columns: 120, rows: 30 },
     );
 
-    expect(output).toContain("TRANSCRIPT");
+    // The surface no longer prints its own TRANSCRIPT header — the workbench
+    // status bar announces the active surface one row above, and the duplicate
+    // label was the same word twice in the top three rows of the screen.
+    expect(output).not.toContain("TRANSCRIPT");
     expect(output).toContain("hello transcript");
   });
 

--- a/runtime/tests/tui/workbench/transcript-scroll.test.tsx
+++ b/runtime/tests/tui/workbench/transcript-scroll.test.tsx
@@ -130,7 +130,9 @@ describe("workbench transcript scroll ownership", () => {
       expect(scrollBox?.style.flexGrow).toBe(1);
       expect(scrollBox?.style.flexDirection).toBe("column");
       expect(scrollBox?.attributes.stickyScroll).toBe(true);
-      expect(output()).toContain("TRANSCRIPT");
+      // No standalone TRANSCRIPT header: the workbench status bar announces
+      // the active surface, so the surface itself stays label-free.
+      expect(output()).not.toContain("TRANSCRIPT");
       expect(output()).toContain("transcript-scroll-anchor");
 
       root.unmount();
@@ -166,7 +168,7 @@ describe("workbench transcript scroll ownership", () => {
       );
 
       expect(findScrollBox(getRootNode(stdout))).toBeNull();
-      expect(output()).toContain("TRANSCRIPT");
+      expect(output()).not.toContain("TRANSCRIPT");
       expect(output()).toContain("transcript-fallback-anchor");
     } finally {
       root.unmount();


### PR DESCRIPTION
Implements all eight items from a design review of the live workbench (duplicate TRANSCRIPT header, mid-word hint truncation, triple hint duplication, cold-start dead gulf, flat welcome hierarchy, cursor-on-placeholder, starved suggestion descriptions + missing provenance, noisy default permission mode). Each change is commented at the site with the screen evidence that motivated it. Gate: tsc clean; targeted suites 107/107; full tests/tui 4160 passed with the 9 failing files verified pre-existing on clean main via stash-compare. Live welcome render verified via the staticRender harness at 96/44 cols.