### PR TITLE
docs: align product docs with 0.6.0 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > agents, multi-channel gateway, budget-bounded autonomy, and a typed embedding SDK.
 
 ![status](https://img.shields.io/badge/status-pre--release-orange)
-![version](https://img.shields.io/badge/version-0.4.1-blue)
+![version](https://img.shields.io/badge/version-0.6.0-blue)
 ![node](https://img.shields.io/badge/node-%E2%89%A5%2025-339933?logo=node.js&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict%20%E2%80%A2%200%20%40ts--nocheck-3178C6?logo=typescript&logoColor=white)
 
@@ -15,8 +15,8 @@ agents, channel gateway, and remote phone bridge are all clients of that daemon.
 
 | Package | Path | Role |
 | --- | --- | --- |
-| `@tetsuo-ai/agenc` `0.4.1` | `packages/agenc/` | Public launcher binary |
-| `@tetsuo-ai/runtime` `0.4.1` | `runtime/` | Daemon, TUI, tools, providers, tests |
+| `@tetsuo-ai/agenc` `0.6.0` | `packages/agenc/` | Public launcher binary |
+| `@tetsuo-ai/runtime` `0.6.0` | `runtime/` | Daemon, TUI, tools, providers, tests |
 | `@tetsuo-ai/agenc-sdk` `0.2.0` | `packages/agenc-sdk/` | Typed embedding SDK (daemon protocol) |
 
 Documentation map: [`docs/INDEX.md`](docs/INDEX.md). Architecture:
@@ -73,9 +73,10 @@ Documentation map: [`docs/INDEX.md`](docs/INDEX.md). Architecture:
   `BUFFER` (embedded `nvim --embed` preferred). See
   [`docs/embedded-neovim-buffer.md`](docs/embedded-neovim-buffer.md).
 - **16 built-in providers** — default provider **grok**; fresh-config session
-  model **grok-4.3** (provider-map fallback **grok-4.5**). Selectable
-  **Grok 4.5** adds a 500k context catalog entry with low/medium/high reasoning
-  (high by default for that model), vision, tools, and structured output; also
+  model **grok-4.5** (fresh config and provider-map). Selectable **Grok 4.3**
+  remains in the catalog; **Grok 4.5** is the 500k-context default with
+  low/medium/high reasoning (high by default for that model), vision, tools,
+  and structured output; also
   openai, anthropic, ollama, lmstudio, openai-compatible, openrouter, groq,
   deepseek, gemini, mistral, nvidia-nim, minimax, github, amazon-bedrock, agenc.
   See [`docs/reference/providers.md`](docs/reference/providers.md).
@@ -89,7 +90,7 @@ Documentation map: [`docs/INDEX.md`](docs/INDEX.md). Architecture:
 
 ## Project status
 
-**0.4.1 pre-release.** Runtime and launcher are versioned `0.4.1`; the embedding
+**0.6.0 pre-release.** Runtime and launcher are versioned `0.6.0`; the embedding
 SDK package is intentionally `0.2.0`. The public launcher is
 [`@tetsuo-ai/agenc`](https://www.npmjs.com/package/@tetsuo-ai/agenc). The root
 workspace is a private monorepo. Type-clean: **0** `@ts-nocheck`. MIT licensed
@@ -105,7 +106,7 @@ onboard acts 2–3, `agenc update`, remote pairing, Grok OAuth, SDK.
 - **npm `11.x`** (`packageManager`).
 - **ripgrep (`rg`)** on `PATH` for file search (`agenc doctor` reports status).
 - **A provider** before real model calls. Default: **xAI** via `XAI_API_KEY`
-  (also accepts `GROK_API_KEY`); default model `grok-4.3` (`AGENC_MODEL`
+  (also accepts `GROK_API_KEY`); default model `grok-4.5` (`AGENC_MODEL`
   overrides). Inspect with `agenc providers`, `agenc login`, `agenc config`.
 
 ## Quick start
@@ -249,7 +250,7 @@ socket, config, sessions, gateway, budget ledger, logs.
 | --- | --- |
 | `AGENC_HOME` | Root for on-disk state (default `~/.agenc`) |
 | `XAI_API_KEY` / `GROK_API_KEY` | Default provider credentials |
-| `AGENC_MODEL` | Override default model (`grok-4.3`) |
+| `AGENC_MODEL` | Override default model (`grok-4.5`) |
 | `AGENC_AUTH_BACKEND` | `local` or `remote` |
 | `AGENC_DAEMON_AUTOSTART=0` | Disable launcher daemon autostart |
 | `AGENC_DAEMON_READY_TIMEOUT_MS` | Launcher daemon-ready timeout |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # AgenC Architecture
 
-A current map of how `agenc` is put together (runtime **0.4.1**). For the
+A current map of how `agenc` is put together (runtime **0.6.0**). For the
 user-facing CLI, quick start, and install paths see [`../README.md`](../README.md)
 and [`quickstart.md`](quickstart.md). Reference docs for operators and embedders:
 
@@ -105,11 +105,11 @@ Everything past the launcher lives in the single runtime workspace
 | `eval/` | Agent-eval report schema (runner lives under `runtime/scripts` + `runtime/eval`) |
 | `tui/` | Terminal UI (custom Ink reconciler fork under `tui/ink`) |
 | `entrypoints/` | Public/SDK type entry surfaces |
-| `protocol/` | Shared protocol helpers |
+| `protocol/` | Marketplace protocol A1/A2 (read-only CLI adapter + types); mutating claim verbs reserved / owner-gated |
 | `bootstrap/` / `lifecycle/` / `conversation/` | Bootstrap state, shutdown/signals, conversation token-budget and realtime |
 | `constants/` / `types/` / `errors/` / `utils/` / `context/` / `schemas/` | Shared constants, pure types, error shaping, utilities |
 | `browser/` | Isolated Chromium CDP driver + SSRF proxy for the LIVE `Browser` tool |
-| `build/` / `version.ts` / `index.ts` | Feature flags, version stamp (`0.4.1`), public barrel |
+| `build/` / `version.ts` / `index.ts` | Feature flags, version stamp (`0.6.0`), public barrel |
 
 ## State on disk (`AGENC_HOME`, default `~/.agenc`)
 
@@ -325,7 +325,7 @@ npm test
 npm run validate:runtime
 ```
 
-## Current status (0.4.1)
+## Current status (0.6.0)
 
 Daemon-backed process model, multi-provider LLM layer, permissions/sandbox,
 gateway multi-channel surface, heartbeat + cron delivery + hooks with

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -28,7 +28,6 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | [remote-control.md](remote-control.md) | Pair host with AgenC phone app (`agenc remote`) |
 | [managed-openrouter.md](managed-openrouter.md) | Hosted OpenRouter / managed keys via remote auth |
 | [grok-oauth.md](grok-oauth.md) | Sign in with X — Grok subscription access without an API key |
-| [bug-audit-2026-07-11.md](bug-audit-2026-07-11.md) | Daemon/session lifecycle bug audit: /resume freeze, workspace pinning, global-state family |
 | [deploy/vps.md](deploy/vps.md) | Run the daemon on a VPS (installer or Docker) |
 | [migrate-from-openclaw.md](migrate-from-openclaw.md) | Surface map from OpenClaw |
 | [migrate-from-hermes.md](migrate-from-hermes.md) | Surface map from Hermes Agent |
@@ -80,6 +79,7 @@ shipped. See [`archive/README.md`](archive/README.md).
 | [archive/feature-user-stories.csv](archive/feature-user-stories.csv) | Orphan inventory snapshot |
 | [archive/onboarding-plan-2026-07.md](archive/onboarding-plan-2026-07.md) | Superseded by [onboarding.md](onboarding.md) |
 | [archive/parity-roadmap-2026-07.md](archive/parity-roadmap-2026-07.md) | Superseded by [roadmap.md](roadmap.md) |
+| [archive/bug-audit-2026-07-11.md](archive/bug-audit-2026-07-11.md) | Historical RCA (daemon multi-session singletons); all findings fixed |
 
 ---
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -2,7 +2,7 @@
 
 These files are **historical only**. They are **not product truth** and must not
 be used to decide what is shipped. Prefer [`../INDEX.md`](../INDEX.md) and
-[`../roadmap.md`](../roadmap.md) for current 0.4.1 product state.
+[`../roadmap.md`](../roadmap.md) for current 0.6.0 product state.
 
 | File | Why archived | Notes |
 | --- | --- | --- |
@@ -10,5 +10,6 @@ be used to decide what is shipped. Prefer [`../INDEX.md`](../INDEX.md) and
 | `feature-user-stories.csv` | Orphan inventory snapshot last tested **2026-06-22**. | Embeds historical version notes (e.g. 0.2.0); ignore for current release. |
 | `onboarding-plan-2026-07.md` | Replaced by [`../onboarding.md`](../onboarding.md). | In-body **ARCHIVED** banner. |
 | `parity-roadmap-2026-07.md` | Replaced by [`../roadmap.md`](../roadmap.md). | Progress header is a **stale 2026-07-09 snapshot** (e.g. Discord “pending” is wrong now). |
+| `bug-audit-2026-07-11.md` | Historical daemon/session lifecycle RCA (0.4.x). | Not a live bug list; findings 1–13 fixed as of 0.6.0. |
 
 Current documentation starts at [`../INDEX.md`](../INDEX.md).

--- a/docs/archive/bug-audit-2026-07-11.md
+++ b/docs/archive/bug-audit-2026-07-11.md
@@ -1,5 +1,10 @@
 # Bug audit — daemon/session lifecycle "one-off" bugs (2026-07-11)
 
+> **ARCHIVED — not product truth.** Historical incident / RCA notes from the
+> 0.4.x line. **Findings 1–13 are FIXED as of AgenC 0.6.0.** Do not treat this
+> file as a live bug list. Prefer [`../roadmap.md`](../roadmap.md) and
+> [`../INDEX.md`](../INDEX.md).
+
 Triggered by two user reports on 0.4.0: `/resume` freezes the TUI, and new
 `agenc` invocations appear pinned to the folder of the first session. Both
 were root-caused; the sweep then found a family of related defects sharing
@@ -15,10 +20,9 @@ import it.
 Severity key: **P0** user-visible breakage now · **P1** breaks in common
 multi-session/multi-shell use · **P2** correctness hazard.
 
-**STATUS (2026-07-11, late):** findings 1, 2, 4–11 are FIXED on main (see the
-per-finding status lines); finding 3's residue is cleaned up (41,409 → 7
-project dirs, 17 GB → 247 MB) and current suites measured clean; finding 12
-(added late) is open.
+**STATUS (2026-07-12 / 0.6.0):** findings **1–13 are FIXED**. This document is
+retained only as historical RCA. The original 2026-07-11 late note that left
+finding 12 “open” is obsolete.
 
 ---
 

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -1,6 +1,6 @@
 # Running AgenC on a VPS
 
-**AgenC 0.4.1.** A $5-class VPS (Hetzner CX11, DigitalOcean basic, Railway
+**AgenC 0.6.0.** A $5-class VPS (Hetzner CX11, DigitalOcean basic, Railway
 container) runs the daemon fine: providers do the heavy lifting; the daemon is
 orchestration. Two supported shapes.
 
@@ -69,11 +69,11 @@ Pull the published image (no source checkout):
 
 ```bash
 docker run -d --restart unless-stopped -v agenc-data:/data \
-  -e XAI_API_KEY ghcr.io/tetsuo-ai/agenc:0.4.1
+  -e XAI_API_KEY ghcr.io/tetsuo-ai/agenc:0.6.0
 # or :latest when you accept floating tags
 
 # one-shot against the same state:
-docker run --rm -v agenc-data:/data ghcr.io/tetsuo-ai/agenc:0.4.1 security audit
+docker run --rm -v agenc-data:/data ghcr.io/tetsuo-ai/agenc:0.6.0 security audit
 ```
 
 Build from a source checkout:
@@ -118,4 +118,4 @@ Railway/Hostinger/DigitalOcean template listings wrap Shape 2 with the
 `agenc-data` volume and env-var prompts for the provider key. Publishing the
 templates is an owner/release step; this document is the source of truth for
 what they must configure (volume, env passthrough, no published ports, current
-image tag `0.4.1`).
+image tag `0.6.0`).

--- a/docs/design/budget-enforcement.md
+++ b/docs/design/budget-enforcement.md
@@ -120,7 +120,7 @@ Default `[agent.budget]` is **empty** (no token/dollar/wall-clock caps) so long
 foreground-style sessions are not killed by a hidden ceiling; operators who
 want per-run caps set them explicitly.
 
-## Live wire-up (current as of 0.4.1)
+## Live wire-up (current as of 0.6.0)
 
 The enforcer primitive is **implemented and live** on the autonomous gateway
 surfaces. Callers construct a `BudgetEnforcer` with

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -5,7 +5,7 @@ your local daemon. It is a **daemon client**: it talks to the daemon only
 through the embedding SDK (`@tetsuo-ai/agenc-sdk`), never runtime internals.
 Channels are a client-side addition, not a runtime change.
 
-**Shipped channels (0.4.1):** Telegram, Discord, Slack, WebChat, and stdio.
+**Shipped channels (0.6.0):** Telegram, Discord, Slack, WebChat, and stdio.
 Signal, WhatsApp, and email **channels** are **not** shipped. (The LIVE
 **Browser** tool is a coding-agent capability, not a gateway channel — see
 [browser.md](browser.md).)
@@ -20,6 +20,8 @@ Related: [quickstart](quickstart.md) · [onboarding](onboarding.md) ·
 agenc gateway run [--stdio] [--webchat] [--heartbeat] [--hooks]
 agenc gateway status [--json]
 agenc gateway pairing list [--json]
+agenc gateway pairing pending [--json]
+agenc gateway pairing approve <channel> <peerId>
 agenc gateway pairing revoke <channel> <peerId>
 agenc gateway install-service
 ```
@@ -28,7 +30,10 @@ agenc gateway install-service
 |---|---|
 | `run` | Connect to the daemon (autostart if needed), load `gateway/config.json`, start enabled channels. Runs until Ctrl-C. |
 | `status` | Channels, DM policies, bindings, paired-sender counts |
-| `pairing list` / `revoke` | Inspect or remove paired senders |
+| `pairing list` | Paired senders per channel |
+| `pairing pending` | Pending pairing requests not yet approved |
+| `pairing approve` | Approve a pending peer (`<channel> <peerId>`) |
+| `pairing revoke` | Remove a paired sender |
 | `install-service` | Install + start the always-on user service (systemd on Linux, launchd on macOS); unit reads `gateway/env` |
 
 `run` enables surfaces from flags **and** environment/config:
@@ -209,7 +214,7 @@ Config (`[heartbeat]` / env):
 | `interval_seconds` / `AGENC_HEARTBEAT_INTERVAL` | `1800` | seconds between ticks |
 | `active_hours` / `AGENC_HEARTBEAT_ACTIVE_HOURS` | always | e.g. `8-22` local |
 | `model` / `AGENC_HEARTBEAT_MODEL` | — | optional utility model |
-| `target` / `AGENC_HEARTBEAT_TARGET` | `none` | `none` or `channelId:conversationId` |
+| `target_channel` + `target_conversation` (TOML) / `AGENC_HEARTBEAT_TARGET` (env) | `none` | Env uses combined `channelId:conversationId` or `none`; TOML stores the split fields |
 | `agent` / `AGENC_HEARTBEAT_AGENT` | `default` | budget envelope + session |
 
 Also: `skip_when_busy`. Disabled by default until you opt in (onboarding Act 3
@@ -308,7 +313,7 @@ AGENC_GATEWAY_MEME_ENABLED=1
 AGENC_GATEWAY_MEME_DAILY_LIMIT=20
 AGENC_GATEWAY_VOICE_ENABLED=1
 AGENC_GATEWAY_VOICE_DAILY_LIMIT=20
-# requires XAI_API_KEY
+# Grok credentials: OAuth from /grok-login wins; else XAI_API_KEY / GROK_API_KEY
 ```
 
 Shortcuts and clear natural-language requests (`/image`, `/meme`, `/voice`,

--- a/docs/grok-oauth.md
+++ b/docs/grok-oauth.md
@@ -24,14 +24,18 @@ request carries `referrer=agenc` so xAI can attribute usage (their request).
 
 ## How it interacts with API keys
 
-- `XAI_API_KEY` / `GROK_API_KEY` / `AGENC_XAI_API_KEY` **always win** over
-  the sign-in. Unset them to use the subscription.
+- `/grok-login` OAuth **always wins** over `XAI_API_KEY` / `GROK_API_KEY` /
+  `AGENC_XAI_API_KEY`. While a stored OAuth token is present, leftover env
+  API keys are **ignored** for Grok inference.
+- Env BYOK applies only when no OAuth token is available (never signed in, or
+  after `/grok-logout`). Credential order is then:
+  explicit session key → `XAI_API_KEY` → `GROK_API_KEY` → `AGENC_XAI_API_KEY`.
 - Tokens are stored in AgenC secure storage (OS keychain / libsecret, with
   the usual plaintext fallback), refresh automatically (~6 h access tokens,
   rotating refresh tokens), and recover transparently on 401.
 - The OAuth bearer is only ever sent to `api.x.ai` / `*.grok.com`. A custom
   grok base-URL override refuses to start in OAuth mode — set a real API
-  key to use gateways.
+  key (and no OAuth token) to use gateways.
 
 ## Troubleshooting
 

--- a/docs/managed-openrouter.md
+++ b/docs/managed-openrouter.md
@@ -8,7 +8,7 @@ requests to the AgenC LiteLLM/OpenRouter gateway.
 Related: [onboarding](onboarding.md) · [quickstart](quickstart.md) ·
 [install](install.md).
 
-## Defaults (0.4.1)
+## Defaults (0.6.0)
 
 | Setting | Value |
 |---|---|

--- a/docs/migrate-from-hermes.md
+++ b/docs/migrate-from-hermes.md
@@ -7,7 +7,7 @@ fail-closed permissions), state auditability, and engineering rigor (typed
 daemon protocol, eval-regression gate, large test suite). This guide maps the
 surfaces, including what AgenC does not have yet.
 
-**AgenC 0.4.1.** Related: [quickstart](quickstart.md) ·
+**AgenC 0.6.0.** Related: [quickstart](quickstart.md) ·
 [onboarding](onboarding.md) · [gateway](gateway.md) ·
 [OpenClaw migrate](migrate-from-openclaw.md).
 

--- a/docs/migrate-from-openclaw.md
+++ b/docs/migrate-from-openclaw.md
@@ -5,7 +5,7 @@ center of gravity: OS-sandboxed execution, a fail-closed permission layer, and
 an auditable state model. This guide maps concepts honestly — including what
 AgenC does **not** have yet.
 
-**AgenC 0.4.1.** Related: [quickstart](quickstart.md) ·
+**AgenC 0.6.0.** Related: [quickstart](quickstart.md) ·
 [onboarding](onboarding.md) · [gateway](gateway.md) ·
 [Hermes migrate](migrate-from-hermes.md).
 
@@ -43,7 +43,7 @@ agenc onboard autonomy
 | Channels (Telegram, WhatsApp, …) | **Shipped:** Telegram, Discord, Slack, WebChat, stdio | `agenc gateway run` / `install-service`; pairing-gated, in-channel token approvals, untrusted-content framing. Discord: official Gateway WS + REST (`AGENC_DISCORD_BOT_TOKEN`); Slack: Socket Mode — no inbound listener (`AGENC_SLACK_BOT_TOKEN` + `AGENC_SLACK_APP_TOKEN`); guild/channel messages mention-gated by default. Signal and WhatsApp still roadmap |
 | Nodes (phone/Canvas) | Partial | Device pairing + relay remote control of the **local daemon** ships (`agenc remote on`); see [remote-control.md](remote-control.md). Realtime voice (WebRTC) exists in the TUI |
 | `openclaw security audit` | `agenc security audit --fix` | Fail-closed exit codes; runs automatically around onboard/daemon start |
-| Docker install | `packaging/docker/` | Non-root image, no published ports by default; tag `ghcr.io/tetsuo-ai/agenc:0.4.1` |
+| Docker install | `packaging/docker/` | Non-root image, no published ports by default; tag `ghcr.io/tetsuo-ai/agenc:0.6.0` |
 
 ## What you gain immediately
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,6 +1,6 @@
 # Onboarding AgenC (operator guide)
 
-**Current release: 0.4.1.** This is the live product guide for first-run and
+**Current release: 0.6.0.** This is the live product guide for first-run and
 the multi-act setup path. Historical implementation notes live under
 [archive/onboarding-plan-2026-07.md](archive/onboarding-plan-2026-07.md)
 (archived — not product truth).
@@ -193,8 +193,8 @@ See [deploy/vps.md](deploy/vps.md).
 ## Optional: remote phone control of the coding daemon
 
 Channels (Act 2b) put a **chat bot** on Telegram/Discord/Slack. Separately,
-**remote control** lets the iOS app drive coding sessions on your machine
-through a signed relay:
+**remote control** lets the **iOS or Android** app drive coding sessions on
+your machine through a signed relay:
 
 ```bash
 agenc login

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -67,8 +67,10 @@ agenc --no-tui "run the tests"         # headless one-shot
 agenc daemon status                    # daemon owns sessions/agents
 ```
 
-Inside the TUI: `/help` lists slash commands. Background agents:
-`agenc agent start <objective>`. Resume with `--continue` / `--resume`.
+Inside the TUI: `/help` lists slash commands. Background agents (flags before
+the objective):
+`agenc agent start [--unattended-allow <tools>] [--unattended-deny <tools>] <objective>`.
+Resume with `--continue` / `--resume`.
 
 ## 5. Act 2 — make it YOUR agent
 
@@ -99,6 +101,8 @@ Hooks: `agenc gateway run --hooks` / `hooks.enabled` → loopback
 `POST /hooks/agent` with header-only bearer auth.
 
 ## 7. Optional: phone remote control
+
+Pair an **iOS or Android** app with the host daemon:
 
 ```bash
 agenc login

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -70,15 +70,23 @@ See `getLiveCoordinatorSystemPrompt()` for the model-facing instructions.
 ### CLI
 
 ```bash
-agenc agent start <objective> [--unattended-allow …] [--unattended-deny …]
+agenc agent start [--unattended-allow <tools>] [--unattended-deny <tools>] <objective>
 agenc agent list
 agenc agent attach <id>
 agenc agent stop <id>
 agenc agent logs <id>
 ```
 
+Unattended flags must come **before** the objective; the first non-flag token
+ends option parsing (flags after the objective become part of the objective
+text).
+
 Source: `runtime/src/app-server/agent-cli.ts` (dispatched from `bin/agenc.ts`).
 See also [cli.md](cli.md).
+
+Related TUI: `/coordinator` (alias `/fleet`) toggles coordinator mode for the
+session when the feature is available (`AGENC_COORDINATOR_MODE` /
+`coordinator_mode`). `/tasks` surfaces live workers and shell tasks.
 
 ### Daemon methods (SDK + JSON-RPC)
 

--- a/docs/reference/autonomy.md
+++ b/docs/reference/autonomy.md
@@ -1,7 +1,7 @@
 # Autonomy reference
 
 Operator and developer guide for **cost-bounded autonomous surfaces** in
-AgenC **0.4.1**: cumulative budget enforcement, heartbeat, cron delivery, and
+AgenC **0.6.0**: cumulative budget enforcement, heartbeat, cron delivery, and
 hooks HTTP.
 
 Design background: [`../design/budget-enforcement.md`](../design/budget-enforcement.md).
@@ -36,6 +36,18 @@ sanitized/framed as untrusted content before they reach the model.
 
 Defaults: **budget disabled**, **heartbeat disabled**. Enabling either is an
 explicit operator action.
+
+### Session autonomous tick mode (distinct system)
+
+CLI flags `--autonomous` / `--proactive` enable **session keepalive** ticks
+in the interactive/daemon-TUI path (`runtime/src/session/autonomous-mode.ts`).
+This is **not** the same as gateway heartbeat + cumulative budget:
+
+- Keepalive can drive idle re-prompts on a session while you leave the TUI up.
+- It is **not** wired through `BudgetEnforcer.admit` today.
+- Plan mode excludes autonomous keepalive.
+- Gateway operators still use `agenc gateway run --heartbeat` / `--hooks` for
+  channel/webhook autonomy with ledger caps.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ dispatch (for example `doctor`, `remote`, and the full `gateway` surface are
 wired and have topic help but may not appear in the top-level usage block).
 This page documents the **dispatched** surface.
 
-Version: **0.4.1**. Default session provider **grok**, fresh-config session model
+Version: **0.6.0**. Default session provider **grok**, fresh-config session model
 **grok-4.5** (see [providers.md](providers.md)).
 
 ---
@@ -45,7 +45,7 @@ From `formatCliHelpText()`:
 | `--profile <name>` | Named config profile |
 | `--provider <name>` | Override provider for this session |
 | `--model <id\|provider:id>` | Override model for this session |
-| `--permission-mode <mode>` | Override startup permission mode |
+| `--permission-mode <mode>` | Override startup permission mode: `default`, `acceptEdits`, `plan`, `bypassPermissions`, `dontAsk`, `auto` (internal-only `unattended` / `bubble` are not CLI addressable) |
 | `--autonomous`, `--proactive` | Enable autonomous tick mode |
 | `--dangerously-bypass-approvals-and-sandbox` | Bypass approvals and sandbox checks |
 | `--yolo` | Alias for approval/sandbox bypass |
@@ -210,6 +210,8 @@ agenc gateway run [--stdio] [--webchat] [--heartbeat] [--hooks]
 agenc gateway install-service
 agenc gateway status [--json]
 agenc gateway pairing list [--json]
+agenc gateway pairing pending [--json]
+agenc gateway pairing approve <channel> <peerId>
 agenc gateway pairing revoke <channel> <peerId>
 ```
 
@@ -219,6 +221,8 @@ agenc gateway pairing revoke <channel> <peerId>
 | `install-service` | Install + start the always-on gateway user service (systemd or launchd; reads gateway/env) |
 | `status` | Channels, DM policies, bindings, paired-sender counts |
 | `pairing list` | Paired senders per channel |
+| `pairing pending` | Pending pairing requests (codes not yet approved) |
+| `pairing approve` | Approve a pending peer (`<channel> <peerId>`) |
 | `pairing revoke` | Remove a paired sender |
 
 Config: `<AGENC_HOME>/gateway/config.json` (fail-closed defaults when absent).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,6 +1,6 @@
 # Config reference
 
-Operator config for AgenC **0.4.1**. Sources of truth:
+Operator config for AgenC **0.6.0**. Sources of truth:
 
 | Concern | Path |
 | --- | --- |
@@ -286,23 +286,35 @@ snapshot_max_bytes = 67108864
 
 Default `agent.budget` is empty (no per-run cap).
 
-### `durableTurns` (typed, not a known TOML key today)
+### `[durableTurns]`
 
-`DurableTurnsConfig` is typed on `AgenCConfig` and used by the turn loop
-(`session/run-turn.ts`, `session/durable-turns`), but **`durableTurns` is not
-in `KNOWN_CONFIG_KEYS`**. A `[durableTurns]` block in `config.toml` is currently
-preserved under `_unknown` rather than applied as typed config.
+First-class known key (`KNOWN_CONFIG_KEYS` includes `durableTurns`). Typed as
+`DurableTurnsConfig` and used by the turn loop (`session/run-turn.ts`,
+`session/durable-turns`). Block validation is still shallow (no dedicated
+deep `validateDurableTurns*` pass beyond ordinary load/normalize).
 
-Operational control is primarily via env:
+```toml
+[durableTurns.checkpoint]
+# enabled = false
+# minIntervalMs = 0   # 0 = every boundary
+
+[durableTurns.resume]
+# onRestart = true
+# policy = "safe"     # stage-1 only; re-run read-only/idempotent dangling tools
+# requireLease = true
+# buildPinning = true
+```
+
+Env overrides (still useful for operators):
 
 | Env | Effect |
 | --- | --- |
 | `AGENC_DURABLE_TURNS` | Enable/disable durable-turn checkpointing |
+| `AGENC_DURABLE_TURNS_CHECKPOINT` | Checkpoint-related control |
 | `AGENC_DURABLE_TURNS_RESUME` | Resume-on-restart policy control |
 
 Runtime defaults (when enabled programmatically / via env) treat resume-on-restart
-as **on** unless disabled. Prefer env + tests over inventing TOML until the key
-lands in `KNOWN_CONFIG_KEYS`.
+as **on** unless disabled.
 
 ### `[daemon]`
 

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -1,6 +1,6 @@
 # Daemon reference
 
-The local **app-server** control plane for AgenC **0.4.1**. One daemon per
+The local **app-server** control plane for AgenC **0.6.0**. One daemon per
 `AGENC_HOME`. Clients (TUI, print CLI, gateway, remote, SDK, background
 agents) attach over a local socket and speak JSON-RPC.
 
@@ -31,6 +31,12 @@ Ready-wait timeout for clients that start the daemon
 
 ```bash
 AGENC_DAEMON_READY_TIMEOUT_MS=45000
+```
+
+Per-request RPC timeout (SDK / connect options; also used by some client paths):
+
+```bash
+AGENC_DAEMON_REQUEST_TIMEOUT_MS=30000   # optional; connect({ requestTimeoutMs })
 ```
 
 Detached daemon V8 heap cap (MB):
@@ -75,9 +81,20 @@ export AGENC_HOME=/var/lib/agenc
 - **Default transport:** Unix socket at `$AGENC_HOME/daemon.sock`.
 - **Auth:** cookie file `$AGENC_HOME/daemon.cookie` (ensured on start; private
   socket owner identity + peer UID checks on supported platforms).
-- **Optional WebSocket transport** is implemented in
-  `runtime/src/app-server/transport/` for non-Unix topologies; prefer the
-  Unix socket for local use.
+- **Optional WebSocket transport** (remote control, SSH tunnels, VPS operators)
+  defaults to loopback **`ws://127.0.0.1:7766/`** (see
+  `AGENC_PORTAL_DEFAULT_LOCAL_DAEMON_ENDPOINT`). Env knobs:
+
+  | Env | Role |
+  | --- | --- |
+  | `AGENC_DAEMON_WEBSOCKET_HOST` | Bind host (default loopback `127.0.0.1`) |
+  | `AGENC_DAEMON_WEBSOCKET_PORT` | Port (default **7766**) |
+  | `AGENC_DAEMON_WEBSOCKET_PATH` | Path (default `/`) |
+  | `AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK` | Set `1` to allow a non-loopback host; otherwise non-loopback binds are **refused** |
+
+  Prefer the Unix socket for local TUI/CLI; WebSocket is what remote/phone and
+  tunnel docs mean by `ws://127.0.0.1:7766`. Implementation:
+  `runtime/src/app-server/daemon-cli.ts` + `transport/`.
 - Config block `[daemon]` defaults: `transport = "unix"`, `autostart = true`
   (`runtime/src/config/schema.ts`).
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -39,6 +39,8 @@ args = ["-y", "some-mcp-server"]
 # default_tools_approval_mode = "ask"
 # enabled_tools = ["search"]
 # disabled_tools = ["delete"]
+# container = "my-desktop-container"  # optional: stdio via desktop sandbox / docker exec
+# pluginSandbox = true                # optional plugin-scoped sandboxing
 ```
 
 Network example:

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -90,7 +90,7 @@ Onboarding: `agenc onboard identity` walks the naming ritual for these files.
 
 1. `AGENC_DISABLE_AUTO_MEMORY` — truthy → OFF, falsy → ON
 2. `AGENC_SIMPLE` — OFF
-3. Remote without `AGENC_REMOTE_MEMORY_DIR` — OFF
+3. When `AGENC_REMOTE` is set and `AGENC_REMOTE_MEMORY_DIR` is unset — OFF
 4. `autoMemoryEnabled` in settings.json
 5. Default: **on**
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -1,6 +1,6 @@
 # Providers reference
 
-Built-in model providers for AgenC **0.4.1**. Source of truth:
+Built-in model providers for AgenC **0.6.0**. Source of truth:
 `runtime/src/llm/registry/provider-info.ts`
 (`BUILT_IN_PROVIDER_DEFAULT_MODELS`, base URLs, API key envs).
 
@@ -23,11 +23,14 @@ Bare interactive startup with a fresh install uses the **config** default
 (or when managed OpenRouter picks its paid default), the registry uses
 **`grok-4.5`** / **`x-ai/grok-4.5`**.
 
-Grok API key resolution order:
+Grok credential resolution:
 
-1. `XAI_API_KEY`
-2. `GROK_API_KEY`
-3. `AGENC_XAI_API_KEY`
+1. **Stored `/grok-login` OAuth token** (always wins while present — env API
+   keys are ignored). See [grok-oauth.md](../grok-oauth.md).
+2. Explicit session/API key when no OAuth token
+3. `XAI_API_KEY`
+4. `GROK_API_KEY`
+5. `AGENC_XAI_API_KEY`
 
 ### Grok 4.5 catalog entry
 
@@ -54,6 +57,10 @@ Sources checked for this catalog entry on 2026-07-10:
 [pricing](https://docs.x.ai/developers/pricing). Model access can still depend
 on account and region; the runtime reports the provider error without replacing
 the configured model.
+
+**Composer / ACP models** (`grok-composer-*`) are not ordinary chat endpoints —
+they run only through the Grok Build CLI ACP path. See
+[grok-oauth.md](../grok-oauth.md#composer-models-acp).
 
 ## Built-in providers (16)
 

--- a/docs/reference/skills-plugins.md
+++ b/docs/reference/skills-plugins.md
@@ -41,6 +41,13 @@ managed / config-home / `.agenc/skills`.
 
 Slash: `/skills` — list roots, manage project skills.
 
+### Bundled skills
+
+| Name | Purpose |
+| --- | --- |
+| `browser-automation` | Snapshot → act → re-snapshot workflow for the LIVE `Browser` tool ([browser.md](../browser.md)) |
+| `agenc-marketplace-kit-installer` | Marketplace kit install helper |
+
 ### `SKILL.md` frontmatter (high level)
 
 Parsed fields include:

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -55,7 +55,7 @@ Do **not** treat the TUI pool (`tools.ts`) as authoritative for this list.
 | `Glob` | Path glob |
 | `Grep` | Content search (prefer over shell `rg`/`grep`) |
 | `Orient` | Workspace orientation helper |
-| `apply_patch` | Multi-file transactional patch |
+| `apply_patch` | Multi-file transactional patch; **deferred** by default (not in `visibleByDefault`) |
 
 ### Filesystem compatibility (`tools/system/filesystem.ts`)
 
@@ -99,12 +99,13 @@ Legacy `system.*` utilities (not the primary edit surface):
 | `system.symbolReferences` | Deferred |
 | `LSP` | Language-server diagnostics / definition / references / symbols |
 | `WebSearch` | Web search (provider-native Grok path when available, else configured endpoint / DuckDuckGo) |
+| `XSearch` | **Grok-gated.** Live X/Twitter search via direct xAI when session provider is `grok` and `[llm.xai] x_search` (or `AGENC_XAI_X_SEARCH`) is on |
 | `web_fetch` | Fetch URL → text/markdown |
 | `WebFetch` | Legacy alias of `web_fetch` |
 
 There is **no** separate LIVE tool named `web_search`; that string is only a
 provider-native server-side tool id used internally by the Grok web-search
-path. Model-facing search is `WebSearch`.
+path. Model-facing search is `WebSearch` (plus gated `XSearch` when enabled).
 
 ### Planning / workflow
 
@@ -122,20 +123,30 @@ path. Model-facing search is `WebSearch`.
 
 | Name | Notes |
 | --- | --- |
-| `AskUserQuestion` | Multi-choice questions (TUI picker) |
+| `AskUserQuestion` | Multi-choice questions (TUI picker); **visible by default** |
 | `request_user_input` | Elicitation / free-form user input |
 | `request_ledger_transfer` | Built-in typed Android/Ledger SOL transfer handoff; exact active root-turn `@ledger` authorization only |
 | `Brief` | Short progress message to the user |
 | `SendUserMessage` | Alias of Brief-style progress message |
-| `Sleep` | Sleep / yield |
-| `Monitor` | Monitor a background command/process |
+| `Sleep` | Sleep / yield; **deferred** by default |
+| `Monitor` | Monitor a background command/process; **deferred** by default |
 
 ### Worktree
 
-| Name |
-| --- |
-| `EnterWorktree` |
-| `ExitWorktree` |
+| Name | Notes |
+| --- | --- |
+| `EnterWorktree` | **Deferred** by default |
+| `ExitWorktree` | **Deferred** by default |
+
+### Media (Grok-gated)
+
+| Name | Notes |
+| --- | --- |
+| `ImagineImage` | Image generation via direct xAI when session provider is `grok` and credentials are available |
+| `ImagineVideo` | Video generation via direct xAI when session provider is `grok` and credentials are available |
+
+These are registered on the LIVE surface but only usable on the Grok/direct-xAI
+path. Other providers do not advertise them as working media tools.
 
 ### Browser
 

--- a/docs/reference/tui-workbench.md
+++ b/docs/reference/tui-workbench.md
@@ -1,7 +1,8 @@
 # TUI & workbench
 
-Summary of the fullscreen terminal UI. Durable design notes and implementation
-detail live in the in-tree README:
+Operator-facing summary of the fullscreen terminal UI (not a full keybinding
+manual). Implementer depth, Ink fork notes, and theme details live in the
+in-tree README:
 
 **→ [`runtime/src/tui/README.md`](../../runtime/src/tui/README.md)**
 

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -157,7 +157,7 @@ cannot both receive the same signing request. See
 
 Android keeps the authenticated relay/Core socket alive with a foreground
 `remoteMessaging` service only while all three conditions are true: the app is
-backgrounded, the user is signed in, and a Mac is paired. The Activity remains
+backgrounded, the user is signed in, and a host is paired. The Activity remains
 the owner in the foreground; moving between the two does not deliberately tear
 down the socket. Ticket refreshes reuse the normal single-flight reconnect and
 backoff path.
@@ -240,7 +240,7 @@ events. Deploy Core before relying on Android background status or `@ledger`:
 | Old Core + new phone | Pairing/chat works, but no global status push, typed Ledger action, or all-tools session promotion |
 | New Core + new Android | Full background notification, identity, permission, and Ledger protocol |
 
-Provider credentials and model execution remain on the Mac. The phone does not
+Provider credentials and model execution remain on the host machine. The phone does not
 receive `XAI_API_KEY` or another provider secret.
 
 ## Related

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # AgenC product roadmap
 
-**As of 2026-07-11.** Product line **0.4.1** (SDK package **0.2.0**). What is
+**As of 2026-07-12.** Product line **0.6.0** (SDK package **0.2.0**). What is
 shipped in-tree versus open backlog.
 
 This replaces the competitive parity plan. Historical research and phase
@@ -19,7 +19,7 @@ shipped / open summary.
 
 ---
 
-## Shipped (in product as of 2026-07-11 / 0.4.1)
+## Shipped (in product as of 2026-07-12 / 0.6.0)
 
 ### Core coding agent
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -34,6 +34,7 @@ const client = await connect({
   // socketPath, cookiePath — default ${AGENC_HOME:-~/.agenc}/daemon.{sock,cookie}
   // autostart: true       — run `agenc daemon start` when not running
   // agencCommand: "agenc" — CLI used for autostart (absolute path when embedding)
+  // requestTimeoutMs      — per-RPC timeout (default 30s or AGENC_DAEMON_REQUEST_TIMEOUT_MS)
   onPermissionRequest: async (request) => {
     // request: { sessionId, requestId, toolName?, permissions, input?, reason? }
     return request.toolName === "Read"
@@ -139,7 +140,7 @@ import { promptViaSubprocess } from "@tetsuo-ai/agenc-sdk";
 
 const run = promptViaSubprocess("explain the fee split", {
   agencCommand: "agenc",      // or ["/abs/path/agenc"]
-  model: "grok-4",             // optional; also provider/profile/permissionMode
+  model: "grok-4.5",           // optional; also provider/profile/permissionMode
 });
 for await (const event of run) { /* same AgencPromptEvent union */ }
 const result = await run.result(); // exitCode/finalMessage/usage from the CLI's result line


### PR DESCRIPTION
## Summary

- Bring product docs current with runtime/launcher **0.6.0** (SDK **0.2.0** intentional): version stamps, default model **grok-4.5**, Docker tags.
- Fix false claims: Grok OAuth precedence (OAuth wins over env BYOK), `durableTurns` as a known config key, LIVE catalog gaps (`XSearch` / `ImagineImage` / `ImagineVideo`), gateway `pairing pending|approve`, `agent start` flag order.
- Archive `bug-audit-2026-07-11.md` (historical RCA, not operator how-to); update INDEX/archive policy.
- Operator polish: permission-mode enum, daemon WebSocket envs, remote host wording, Composer/ACP pointer, SDK request timeout, skills/MCP notes.

## Test plan

- [x] `rg '0\.4\.1' README.md docs --glob '!docs/archive/**'` → none
- [x] Pre-commit: runtime build + TUI startup smoke passed
- [ ] Spot-check README, INDEX, grok-oauth, config durableTurns, tools catalog after merge