### PR TITLE
fix: Phase 1 leftovers — bash/PowerShell sandbox + multi-project daemon

### DIFF
--- a/runtime/src/app-server/command-exec.ts
+++ b/runtime/src/app-server/command-exec.ts
@@ -677,7 +677,8 @@ function commandExecSandboxRequest(
     };
   }
   if (params.sandboxPolicy !== undefined && params.sandboxPolicy !== null) {
-    const sandboxPolicyCwd = process.cwd();
+    // DAE-08: anchor legacy sandbox policy on the command cwd, not daemon OS cwd.
+    const sandboxPolicyCwd = commandCwd;
     const permissionProfile = permissionProfileForLegacySandboxPolicy(
       params.sandboxPolicy,
       sandboxPolicyCwd,

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -122,6 +122,7 @@ import {
   type StateSqliteDriver,
 } from "../state/sqlite-driver.js";
 import { FileThreadStore } from "../thread-store/store.js";
+import { MultiProjectFileThreadStore } from "../thread-store/multi-project-store.js";
 import type { LLMContentPart, LLMMessage } from "../llm/types.js";
 import {
   createSizeCappedFileLogSink,
@@ -1246,8 +1247,11 @@ async function runAgenCDaemonForeground(
     );
     return 1;
   }
-  const threadStore = new FileThreadStore({
-    cwd: process.cwd(),
+  // DAE-03: union session/thread discovery across all projects under AGENC_HOME
+  // (not only the daemon-start cwd registry).
+  const primaryCwd = resolveDaemonDefaultCwd(host.env);
+  const threadStore = new MultiProjectFileThreadStore({
+    primaryCwd,
     agencHome: authStartup.daemonHome,
   });
   const sessionManager = new AgenCDaemonSessionManager({ threadStore });
@@ -1295,7 +1299,7 @@ async function runAgenCDaemonForeground(
   try {
     snapshotPolicies = new AgenCDaemonSnapshotPolicyRegistry({
       agencHome: authStartup.daemonHome,
-      defaultCwd: process.cwd(),
+      defaultCwd: primaryCwd,
       snapshotRetention: activeConfig.agent?.retention,
       periodicIntervalMs: options.snapshotPeriodicIntervalMs,
       onError: (error) =>
@@ -1313,7 +1317,8 @@ async function runAgenCDaemonForeground(
     runner,
     sessionManager,
     threadStore,
-    defaultCwd: () => process.cwd(),
+    // DAE-02: prefer client/workspace env over frozen OS cwd when params omit cwd.
+    defaultCwd: () => resolveDaemonDefaultCwd(host.env),
     snapshotFlush: (snapshot) =>
       writeAgenCDaemonSnapshot(snapshotPath, snapshot),
     broadcastSessionEvent: async (sessionId, event) => {
@@ -1899,6 +1904,22 @@ function discoverAgenCDaemonStateDatabasePaths(
     ...discoverStateDatabasePaths(daemonHome),
     resolveStateDatabasePaths({ cwd, agencHome: daemonHome }),
   ]);
+}
+
+/**
+ * DAE-02: Prefer an explicit workspace env over the daemon process cwd so
+ * multi-project agents don't inherit the first shell that autostarted the
+ * daemon when `cwd` is omitted on create.
+ */
+function resolveDaemonDefaultCwd(env: NodeJS.ProcessEnv): string {
+  const workspace =
+    env.AGENC_WORKSPACE?.trim() ||
+    env.AGENC_PROJECT_DIR?.trim() ||
+    env.PWD?.trim();
+  if (workspace && workspace.length > 0) {
+    return workspace;
+  }
+  return process.cwd();
 }
 
 function uniqueStateDatabasePaths(

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -123,6 +123,7 @@ import {
 } from "../state/sqlite-driver.js";
 import { FileThreadStore } from "../thread-store/store.js";
 import { MultiProjectFileThreadStore } from "../thread-store/multi-project-store.js";
+import { resolveDaemonDefaultCwd } from "./daemon-workspace.js";
 import type { LLMContentPart, LLMMessage } from "../llm/types.js";
 import {
   createSizeCappedFileLogSink,
@@ -1904,22 +1905,6 @@ function discoverAgenCDaemonStateDatabasePaths(
     ...discoverStateDatabasePaths(daemonHome),
     resolveStateDatabasePaths({ cwd, agencHome: daemonHome }),
   ]);
-}
-
-/**
- * DAE-02: Prefer an explicit workspace env over the daemon process cwd so
- * multi-project agents don't inherit the first shell that autostarted the
- * daemon when `cwd` is omitted on create.
- */
-function resolveDaemonDefaultCwd(env: NodeJS.ProcessEnv): string {
-  const workspace =
-    env.AGENC_WORKSPACE?.trim() ||
-    env.AGENC_PROJECT_DIR?.trim() ||
-    env.PWD?.trim();
-  if (workspace && workspace.length > 0) {
-    return workspace;
-  }
-  return process.cwd();
 }
 
 function uniqueStateDatabasePaths(

--- a/runtime/src/app-server/daemon-workspace.ts
+++ b/runtime/src/app-server/daemon-workspace.ts
@@ -1,0 +1,18 @@
+/**
+ * DAE-02: Prefer an explicit workspace env over the daemon process cwd so
+ * multi-project agents don't inherit the first shell that autostarted the
+ * daemon when `cwd` is omitted on create.
+ *
+ * Note: clients that omit cwd and do not set these env vars still fall back
+ * to process.cwd() (daemon OS cwd). First-party agent-cli always sends cwd.
+ */
+export function resolveDaemonDefaultCwd(env: NodeJS.ProcessEnv = process.env): string {
+  const workspace =
+    env.AGENC_WORKSPACE?.trim() ||
+    env.AGENC_PROJECT_DIR?.trim() ||
+    env.PWD?.trim();
+  if (workspace && workspace.length > 0) {
+    return workspace;
+  }
+  return process.cwd();
+}

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -54,6 +54,7 @@ import { createNotebookEditTool as createSystemNotebookEditTool } from "../tools
 import { SESSION_ID_ARG } from "../agents/_deps/filesystem-args.js";
 import type { UnifiedExecProcessManagerLike } from "../unified-exec/types.js";
 import { processOwnerIdFromToolArgs } from "../unified-exec/process-ownership.js";
+import { runtimeSandboxForExec } from "../tools/system/exec-command.js";
 import {
   formatUnifiedExecToolContent,
   unifiedExecCodeModeResult,
@@ -3558,6 +3559,11 @@ function createPowerShellTool(opts: ModelFacingToolOptions): readonly Tool[] {
         const ownerId = processOwnerIdFromToolArgs(
           args as Record<string, unknown>,
         );
+        // TOOL-04: same platform sandbox profile as exec_command when isolation is required.
+        const runtimeSandbox = runtimeSandboxForExec(
+          args as Record<string, unknown>,
+          opts.workspaceRoot,
+        );
         const output = await opts.unifiedExecManager!.execCommand({
           cmd: command,
           shell,
@@ -3566,6 +3572,7 @@ function createPowerShellTool(opts: ModelFacingToolOptions): readonly Tool[] {
             ? { timeoutMs: numberValue(args.timeout_ms) }
             : {}),
           ...(ownerId !== undefined ? { ownerId } : {}),
+          ...(runtimeSandbox !== undefined ? { runtimeSandbox } : {}),
         });
         return {
           content: formatUnifiedExecToolContent(output),

--- a/runtime/src/thread-store/multi-project-store.ts
+++ b/runtime/src/thread-store/multi-project-store.ts
@@ -1,0 +1,252 @@
+/**
+ * DAE-03: ThreadStore facade that unions list/read across every project
+ * under AGENC_HOME/projects (plus the daemon start cwd project).
+ *
+ * Write-ish operations (create/resume/append/…) still target the primary
+ * store for the daemon-start cwd so existing writers keep a stable home;
+ * multi-project agents already use per-cwd RolloutStore paths for live
+ * sessions. The main bug was session.list / attach discovery only seeing
+ * one project's registry.
+ */
+
+import type { ThreadId } from "../agents/registry.js";
+import { discoverStateDatabasePaths } from "../state/sqlite-driver.js";
+import {
+  FileThreadStore,
+  type AppendThreadItemsParams,
+  type ArchiveThreadParams,
+  type CreateThreadParams,
+  type ListThreadsParams,
+  type LoadThreadHistoryParams,
+  type ReadThreadByRolloutPathParams,
+  type ReadThreadParams,
+  type ResumeThreadParams,
+  type StoredThread,
+  type ThreadPage,
+  type ThreadStore,
+  type UpdateThreadMetadataParams,
+  ThreadNotFoundError,
+} from "./store.js";
+
+export interface MultiProjectFileThreadStoreOpts {
+  readonly primaryCwd: string;
+  readonly agencHome: string;
+  readonly defaultModelProviderId?: string;
+}
+
+export class MultiProjectFileThreadStore implements ThreadStore {
+  readonly #agencHome: string;
+  readonly #primaryCwd: string;
+  readonly #defaultModelProviderId?: string;
+  readonly #primary: FileThreadStore;
+  readonly #byProjectDir = new Map<string, FileThreadStore>();
+
+  constructor(opts: MultiProjectFileThreadStoreOpts) {
+    this.#agencHome = opts.agencHome;
+    this.#primaryCwd = opts.primaryCwd;
+    this.#defaultModelProviderId = opts.defaultModelProviderId;
+    this.#primary = this.#openForCwd(opts.primaryCwd);
+  }
+
+  createThread(params: CreateThreadParams): void {
+    this.#storeForWrite(params.cwd).createThread(params);
+  }
+
+  resumeThread(params: ResumeThreadParams): void {
+    this.#primary.resumeThread(params);
+  }
+
+  appendItems(params: AppendThreadItemsParams): void {
+    this.#primary.appendItems(params);
+  }
+
+  persistThread(threadId: ThreadId): void {
+    this.#primary.persistThread(threadId);
+  }
+
+  flushThread(threadId: ThreadId): void {
+    this.#primary.flushThread(threadId);
+  }
+
+  shutdownThread(threadId: ThreadId): void {
+    this.#primary.shutdownThread(threadId);
+  }
+
+  discardThread(threadId: ThreadId): void {
+    this.#primary.discardThread(threadId);
+  }
+
+  loadHistory(params: LoadThreadHistoryParams) {
+    return this.#storeHolding(params.threadId).loadHistory(params);
+  }
+
+  readThread(params: ReadThreadParams): StoredThread {
+    return this.#storeHolding(params.threadId).readThread(params);
+  }
+
+  readThreadByRolloutPath(params: ReadThreadByRolloutPathParams): StoredThread {
+    for (const store of this.#allStores()) {
+      try {
+        return store.readThreadByRolloutPath(params);
+      } catch (error) {
+        if (error instanceof ThreadNotFoundError) continue;
+        throw error;
+      }
+    }
+    throw new ThreadNotFoundError(`rollout:${params.rolloutPath}`);
+  }
+
+  listThreads(params: ListThreadsParams): ThreadPage {
+    // Gather full filtered sets from each project, then re-sort/page.
+    // Project counts are typically small; recovery already scans all DBs.
+    const items: StoredThread[] = [];
+    const seen = new Set<string>();
+    for (const store of this.#allStores()) {
+      let cursor: string | undefined;
+      do {
+        const page = store.listThreads({
+          pageSize: 500,
+          archived: params.archived,
+          ...(params.useStateDbOnly !== undefined
+            ? { useStateDbOnly: params.useStateDbOnly }
+            : {}),
+          ...(params.sortKey !== undefined ? { sortKey: params.sortKey } : {}),
+          ...(params.sortDirection !== undefined
+            ? { sortDirection: params.sortDirection }
+            : {}),
+          ...(params.searchTerm !== undefined
+            ? { searchTerm: params.searchTerm }
+            : {}),
+          ...(cursor !== undefined ? { cursor } : {}),
+        });
+        for (const item of page.items) {
+          if (seen.has(item.threadId)) continue;
+          seen.add(item.threadId);
+          items.push(item);
+        }
+        cursor = page.nextCursor;
+      } while (cursor !== undefined);
+    }
+
+    const sortKey = params.sortKey ?? "created_at";
+    const sortDir = params.sortDirection ?? "desc";
+    items.sort((a, b) => {
+      const aKey = sortKey === "created_at" ? a.createdAt : a.updatedAt;
+      const bKey = sortKey === "created_at" ? b.createdAt : b.updatedAt;
+      const cmp =
+        aKey.localeCompare(bKey) || a.threadId.localeCompare(b.threadId);
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+
+    const pageSize = Math.min(Math.max(params.pageSize ?? 50, 1), 500);
+    const offset = parseOuterOffset(params.cursor);
+    const sliced = items.slice(offset, offset + pageSize);
+    const nextOffset = offset + sliced.length;
+    return {
+      items: sliced,
+      ...(nextOffset < items.length
+        ? { nextCursor: `mp:${nextOffset}` }
+        : {}),
+    };
+  }
+
+  updateThreadMetadata(params: UpdateThreadMetadataParams): StoredThread {
+    return this.#storeHolding(params.threadId).updateThreadMetadata(params);
+  }
+
+  archiveThread(params: ArchiveThreadParams): void {
+    this.#storeHolding(params.threadId).archiveThread(params);
+  }
+
+  unarchiveThread(params: ArchiveThreadParams): StoredThread {
+    return this.#storeHolding(params.threadId).unarchiveThread(params);
+  }
+
+  close(): void {
+    for (const store of this.#byProjectDir.values()) {
+      store.close();
+    }
+    this.#byProjectDir.clear();
+  }
+
+  #storeForWrite(cwd: string | undefined): FileThreadStore {
+    if (cwd !== undefined && cwd.trim().length > 0) {
+      return this.#openForCwd(cwd.trim());
+    }
+    return this.#primary;
+  }
+
+  #storeHolding(threadId: ThreadId): FileThreadStore {
+    for (const store of this.#allStores()) {
+      try {
+        store.readThread({
+          threadId,
+          includeArchived: true,
+          includeHistory: false,
+        });
+        return store;
+      } catch (error) {
+        if (error instanceof ThreadNotFoundError) continue;
+        throw error;
+      }
+    }
+    throw new ThreadNotFoundError(threadId);
+  }
+
+  #allStores(): FileThreadStore[] {
+    this.#refreshDiscovered();
+    const primaryDir = this.#primary.getProjectDir();
+    return [...this.#byProjectDir.values()].sort((a, b) => {
+      if (a.getProjectDir() === primaryDir) return -1;
+      if (b.getProjectDir() === primaryDir) return 1;
+      return a.getProjectDir().localeCompare(b.getProjectDir());
+    });
+  }
+
+  #refreshDiscovered(): void {
+    const discovered = discoverStateDatabasePaths(this.#agencHome);
+    for (const paths of discovered) {
+      if (this.#byProjectDir.has(paths.projectDir)) continue;
+      this.#byProjectDir.set(
+        paths.projectDir,
+        new FileThreadStore({
+          projectDir: paths.projectDir,
+          agencHome: this.#agencHome,
+          ...(this.#defaultModelProviderId !== undefined
+            ? { defaultModelProviderId: this.#defaultModelProviderId }
+            : {}),
+        }),
+      );
+    }
+    // Always keep primary cwd project present.
+    this.#openForCwd(this.#primaryCwd);
+  }
+
+  #openForCwd(cwd: string): FileThreadStore {
+    const store = new FileThreadStore({
+      cwd,
+      agencHome: this.#agencHome,
+      ...(this.#defaultModelProviderId !== undefined
+        ? { defaultModelProviderId: this.#defaultModelProviderId }
+        : {}),
+    });
+    const projectDir = store.getProjectDir();
+    const existing = this.#byProjectDir.get(projectDir);
+    if (existing !== undefined) {
+      store.close();
+      return existing;
+    }
+    this.#byProjectDir.set(projectDir, store);
+    return store;
+  }
+}
+
+function parseOuterOffset(cursor: string | undefined): number {
+  if (cursor === undefined || cursor.length === 0) return 0;
+  if (cursor.startsWith("mp:")) {
+    const n = Number(cursor.slice(3));
+    return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+  }
+  // Unknown cursor shape: start from beginning (safe).
+  return 0;
+}

--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -835,6 +835,11 @@ export class FileThreadStore implements ThreadStore {
     this.stateDriver.close();
   }
 
+  /** Per-project state directory this store is bound to (DAE-03 multi-project). */
+  getProjectDir(): string {
+    return this.projectDir;
+  }
+
   // ── internal helpers ────────────────────────────────────────────────
 
   private assertOpen(): void {

--- a/runtime/src/tools/system/apply-runtime-sandbox.ts
+++ b/runtime/src/tools/system/apply-runtime-sandbox.ts
@@ -1,0 +1,158 @@
+/**
+ * TOOL-03 / TOOL-04: apply the same platform sandbox transform used by
+ * unified-exec `exec_command` to other shell spawns (system.bash direct
+ * spawn, and callers that build command lines before exec).
+ */
+
+import { basename } from "node:path";
+import {
+  SandboxManager,
+  type SandboxType,
+} from "../../sandbox/engine/index.js";
+import type { UnifiedExecRuntimeSandbox } from "../../unified-exec/types.js";
+import { UnifiedExecError } from "../../unified-exec/types.js";
+import { runtimeSandboxForExec } from "./exec-command.js";
+
+export interface SandboxSpawnCommand {
+  readonly program: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly argv0?: string;
+}
+
+const defaultSandboxManager = new SandboxManager();
+
+/**
+ * If the tool runtime context requires platform isolation, transform
+ * program/args through SandboxManager (landlock/bwrap/etc.). When isolation
+ * is required but unavailable, throw — fail closed (TOOL-03 honesty).
+ */
+export function applyRuntimeSandboxToSpawn(params: {
+  readonly toolArgs: Record<string, unknown>;
+  readonly fallbackCwd: string;
+  readonly program: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly sandboxManager?: SandboxManager;
+}): SandboxSpawnCommand {
+  const runtimeSandbox = runtimeSandboxForExec(
+    params.toolArgs,
+    params.fallbackCwd,
+  );
+  if (runtimeSandbox === undefined) {
+    return {
+      program: params.program,
+      args: params.args,
+      cwd: params.cwd,
+      env: params.env,
+      argv0: basename(params.program),
+    };
+  }
+  return transformWithRuntimeSandbox({
+    program: params.program,
+    args: params.args,
+    cwd: params.cwd,
+    env: params.env,
+    runtimeSandbox,
+    sandboxManager: params.sandboxManager ?? defaultSandboxManager,
+  });
+}
+
+export function transformWithRuntimeSandbox(params: {
+  readonly program: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly runtimeSandbox: UnifiedExecRuntimeSandbox;
+  readonly sandboxManager?: SandboxManager;
+}): SandboxSpawnCommand {
+  const sandboxManager = params.sandboxManager ?? defaultSandboxManager;
+  const permissions = params.runtimeSandbox.permissionProfile;
+  const windowsSandboxLevel =
+    params.runtimeSandbox.windowsSandboxLevel ?? "disabled";
+  let sandbox: SandboxType = "none";
+  try {
+    sandbox = sandboxManager.selectInitial({
+      fileSystemPolicy: permissions.fileSystem,
+      networkPolicy: permissions.network,
+      preference: params.runtimeSandbox.preference ?? "require",
+      windowsSandboxLevel,
+      hasManagedNetworkRequirements:
+        params.runtimeSandbox.enforceManagedNetwork === true ||
+        params.runtimeSandbox.network !== undefined,
+    });
+    if (
+      sandbox === "none" &&
+      (params.runtimeSandbox.preference ?? "require") === "require"
+    ) {
+      throw new UnifiedExecError(
+        "create_process",
+        "sandbox isolation was required but no platform sandbox is available",
+      );
+    }
+    const transformed = sandboxManager.transform({
+      command: {
+        program: params.program,
+        args: params.args,
+        cwd: params.cwd,
+        env: params.env,
+        ...(params.runtimeSandbox.additionalPermissions !== undefined
+          ? {
+              additionalPermissions:
+                params.runtimeSandbox.additionalPermissions,
+            }
+          : {}),
+      },
+      permissions,
+      sandbox,
+      enforceManagedNetwork:
+        params.runtimeSandbox.enforceManagedNetwork ?? false,
+      ...(params.runtimeSandbox.network !== undefined
+        ? { network: params.runtimeSandbox.network }
+        : {}),
+      ...(params.runtimeSandbox.networkPolicyDecider !== undefined
+        ? {
+            networkPolicyDecider: params.runtimeSandbox.networkPolicyDecider,
+          }
+        : {}),
+      ...(params.runtimeSandbox.blockedRequestObserver !== undefined
+        ? {
+            blockedRequestObserver:
+              params.runtimeSandbox.blockedRequestObserver,
+          }
+        : {}),
+      sandboxPolicyCwd: params.runtimeSandbox.sandboxPolicyCwd,
+      ...(params.runtimeSandbox.agencLinuxSandboxExe !== undefined
+        ? {
+            agencLinuxSandboxExe: params.runtimeSandbox.agencLinuxSandboxExe,
+          }
+        : {}),
+      useLegacyLandlock: params.runtimeSandbox.useLegacyLandlock ?? false,
+      windowsSandboxLevel,
+      windowsSandboxPrivateDesktop:
+        params.runtimeSandbox.windowsSandboxPrivateDesktop ?? false,
+    });
+    const [program, ...args] = transformed.command;
+    if (program === undefined) {
+      throw new UnifiedExecError(
+        "create_process",
+        "sandbox transform returned an empty command",
+      );
+    }
+    return {
+      program,
+      args,
+      cwd: transformed.cwd,
+      env: { ...transformed.env },
+      argv0: transformed.arg0 ?? basename(program),
+    };
+  } catch (error) {
+    if (error instanceof UnifiedExecError) throw error;
+    throw new UnifiedExecError(
+      "create_process",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -42,6 +42,7 @@ import {
   extractAgenCCodeHints,
   type AgenCCodeHint,
 } from "../../errors/hints.js";
+import { applyRuntimeSandboxToSpawn } from "./apply-runtime-sandbox.js";
 
 const SHELL_WRAPPER_COMMANDS = new Set([
   "bash",
@@ -1124,6 +1125,42 @@ export function createBashTool(config?: BashToolConfig): Tool {
       const useSpawnedWrapperMode =
         !useShellMode && SHELL_WRAPPER_COMMANDS.has(basename(command).toLowerCase());
 
+      /** TOOL-03: wrap final spawn program/args when platform isolation is required. */
+      const withSandbox = (
+        program: string,
+        args: readonly string[],
+      ):
+        | { readonly ok: true; readonly program: string; readonly args: readonly string[]; readonly cwd: string; readonly env: Record<string, string> }
+        | { readonly ok: false; readonly error: ToolResult } => {
+        try {
+          const sandboxed = applyRuntimeSandboxToSpawn({
+            toolArgs: rawArgs as Record<string, unknown>,
+            fallbackCwd: defaultCwd,
+            program,
+            args,
+            cwd,
+            env: { ...env },
+          });
+          return {
+            ok: true,
+            program: sandboxed.program,
+            args: sandboxed.args,
+            cwd: sandboxed.cwd,
+            env: sandboxed.env,
+          };
+        } catch (sandboxError) {
+          const message =
+            sandboxError instanceof Error
+              ? sandboxError.message
+              : String(sandboxError);
+          logger.warn(`Bash tool sandbox denied: ${message}`);
+          return {
+            ok: false,
+            error: errorResult(message),
+          };
+        }
+      };
+
       // T6 gap #119: exec_command_begin / _end lifecycle emit.
       // Reuse the LLM tool-call id so the `exec_command_begin/_end`
       // events collide with `tool_call_started/_completed` in
@@ -1194,11 +1231,20 @@ export function createBashTool(config?: BashToolConfig): Tool {
             ),
           );
         }
+        const sandboxed = withSandbox("/bin/bash", [scriptPath]);
+        if (!sandboxed.ok) {
+          try {
+            unlinkSync(scriptPath);
+          } catch {
+            /* best-effort */
+          }
+          return Promise.resolve(emitEnd(sandboxed.error));
+        }
         return runSpawnedCommand({
-          execCommand: "/bin/bash",
-          execArgs: [scriptPath],
-          cwd,
-          env,
+          execCommand: sandboxed.program,
+          execArgs: [...sandboxed.args],
+          cwd: sandboxed.cwd,
+          env: sandboxed.env,
           timeout,
           maxOutputBytes,
           logCmd,
@@ -1214,11 +1260,13 @@ export function createBashTool(config?: BashToolConfig): Tool {
       }
 
       if (useSpawnedWrapperMode) {
+        const sandboxed = withSandbox(execCommand, execArgs);
+        if (!sandboxed.ok) return Promise.resolve(emitEnd(sandboxed.error));
         return runSpawnedCommand({
-          execCommand,
-          execArgs,
-          cwd,
-          env,
+          execCommand: sandboxed.program,
+          execArgs: [...sandboxed.args],
+          cwd: sandboxed.cwd,
+          env: sandboxed.env,
           timeout,
           maxOutputBytes,
           logCmd,
@@ -1233,19 +1281,23 @@ export function createBashTool(config?: BashToolConfig): Tool {
       }
 
       // Direct mode: use execFile (waits for pipes — safe since no backgrounding)
+      const sandboxedDirect = withSandbox(execCommand, execArgs);
+      if (!sandboxedDirect.ok) {
+        return Promise.resolve(emitEnd(sandboxedDirect.error));
+      }
       return new Promise<ToolResult>((outerResolve) => {
         const resolve = (result: ToolResult): void => {
           outerResolve(emitEnd(result));
         };
         execFile(
-          execCommand,
-          execArgs,
+          sandboxedDirect.program,
+          [...sandboxedDirect.args],
           {
-            cwd,
+            cwd: sandboxedDirect.cwd,
             timeout,
             maxBuffer: maxOutputBytes * 2, // Allow headroom, rely on truncate() for user-facing limits
             shell: false,
-            env,
+            env: sandboxedDirect.env,
             ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
           },
           (error, stdout, stderr) => {

--- a/runtime/tests/thread-store/multi-project-store.test.ts
+++ b/runtime/tests/thread-store/multi-project-store.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { MultiProjectFileThreadStore } from "../../src/thread-store/multi-project-store.js";
+import { FileThreadStore } from "../../src/thread-store/store.js";
+import { discoverStateDatabasePaths } from "../../src/state/sqlite-driver.js";
+
+describe("MultiProjectFileThreadStore (DAE-03)", () => {
+  let home: string;
+
+  afterEach(() => {
+    if (home) rmSync(home, { recursive: true, force: true });
+  });
+
+  it("unions listThreads across discovered projects under AGENC_HOME", () => {
+    home = mkdtempSync(join(tmpdir(), "agenc-mp-"));
+    const projects = join(home, "projects");
+    // Two synthetic project state dirs as discoverStateDatabasePaths expects.
+    const p1 = join(projects, "proj-one");
+    const p2 = join(projects, "proj-two");
+    mkdirSync(p1, { recursive: true });
+    mkdirSync(p2, { recursive: true });
+    // Minimal empty sqlite files so discovery keeps them (existsSync state.db).
+    // FileThreadStore will open and migrate; create threads via stores.
+    const s1 = new FileThreadStore({ projectDir: p1, agencHome: home });
+    const s2 = new FileThreadStore({ projectDir: p2, agencHome: home });
+    // Use in-memory-ish: createThread needs rolloutStore. Skip createThread —
+    // instead verify discovery sees both project dirs and multi-store opens them.
+    s1.close();
+    s2.close();
+
+    const discovered = discoverStateDatabasePaths(home);
+    // FileThreadStore open creates state.db on construct — re-open to ensure files exist
+    const s1b = new FileThreadStore({ projectDir: p1, agencHome: home });
+    const s2b = new FileThreadStore({ projectDir: p2, agencHome: home });
+    s1b.close();
+    s2b.close();
+
+    const rediscovered = discoverStateDatabasePaths(home);
+    expect(rediscovered.length).toBeGreaterThanOrEqual(2);
+
+    const multi = new MultiProjectFileThreadStore({
+      primaryCwd: process.cwd(),
+      agencHome: home,
+    });
+    // listThreads should not throw and should scan discovered projects.
+    const page = multi.listThreads({ pageSize: 50, archived: false });
+    expect(Array.isArray(page.items)).toBe(true);
+    multi.close();
+    void discovered;
+  });
+
+  it("resolveDaemonDefaultCwd prefers AGENC_WORKSPACE (source contract)", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../src/app-server/daemon-cli.ts", import.meta.url),
+      "utf8",
+    );
+    expect(src).toMatch(/function resolveDaemonDefaultCwd/);
+    expect(src).toMatch(/AGENC_WORKSPACE/);
+    expect(src).toMatch(/MultiProjectFileThreadStore/);
+  });
+});

--- a/runtime/tests/thread-store/multi-project-store.test.ts
+++ b/runtime/tests/thread-store/multi-project-store.test.ts
@@ -1,64 +1,140 @@
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { MultiProjectFileThreadStore } from "../../src/thread-store/multi-project-store.js";
-import { FileThreadStore } from "../../src/thread-store/store.js";
-import { discoverStateDatabasePaths } from "../../src/state/sqlite-driver.js";
+import { resolveDaemonDefaultCwd } from "../../src/app-server/daemon-workspace.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
 
-describe("MultiProjectFileThreadStore (DAE-03)", () => {
-  let home: string;
+let agencHome = "";
+let originalAgencHome = "";
 
-  afterEach(() => {
-    if (home) rmSync(home, { recursive: true, force: true });
+function openRollout(opts: {
+  cwd: string;
+  sessionId: string;
+}): RolloutStore {
+  const store = new RolloutStore({
+    cwd: opts.cwd,
+    sessionId: opts.sessionId,
+    agencVersion: "0.6.0",
+  });
+  store.open({
+    sessionId: opts.sessionId,
+    timestamp: new Date().toISOString(),
+    cwd: opts.cwd,
+    originator: "multi-project-test",
+    agencVersion: "0.6.0",
+    model: "test-model",
+    modelProvider: "test-provider",
+  });
+  return store;
+}
+
+beforeEach(() => {
+  agencHome = mkdtempSync(join(tmpdir(), "agenc-mp-home-"));
+  originalAgencHome = process.env.AGENC_HOME ?? "";
+  process.env.AGENC_HOME = agencHome;
+});
+
+afterEach(() => {
+  if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
+  else delete process.env.AGENC_HOME;
+  if (agencHome) rmSync(agencHome, { recursive: true, force: true });
+});
+
+describe("MultiProjectFileThreadStore (DAE-03) — behavioral", () => {
+  it("unions listThreads and readThread across two project cwds", () => {
+    const cwdA = mkdtempSync(join(tmpdir(), "agenc-mp-a-"));
+    const cwdB = mkdtempSync(join(tmpdir(), "agenc-mp-b-"));
+    const rolloutA = openRollout({ cwd: cwdA, sessionId: "thread-a" });
+    const rolloutB = openRollout({ cwd: cwdB, sessionId: "thread-b" });
+    try {
+      const multi = new MultiProjectFileThreadStore({
+        primaryCwd: cwdA,
+        agencHome,
+      });
+      multi.createThread({
+        threadId: "thread-a",
+        cwd: cwdA,
+        rolloutStore: rolloutA,
+      });
+      multi.createThread({
+        threadId: "thread-b",
+        cwd: cwdB,
+        rolloutStore: rolloutB,
+      });
+
+      const page = multi.listThreads({
+        pageSize: 50,
+        archived: false,
+      });
+      const ids = page.items.map((t) => t.threadId).sort();
+      expect(ids).toEqual(["thread-a", "thread-b"]);
+
+      const readB = multi.readThread({
+        threadId: "thread-b",
+        includeArchived: false,
+        includeHistory: false,
+      });
+      expect(readB.threadId).toBe("thread-b");
+
+      multi.close();
+    } finally {
+      rolloutA.close();
+      rolloutB.close();
+      rmSync(cwdA, { recursive: true, force: true });
+      rmSync(cwdB, { recursive: true, force: true });
+    }
   });
 
-  it("unions listThreads across discovered projects under AGENC_HOME", () => {
-    home = mkdtempSync(join(tmpdir(), "agenc-mp-"));
-    const projects = join(home, "projects");
-    // Two synthetic project state dirs as discoverStateDatabasePaths expects.
-    const p1 = join(projects, "proj-one");
-    const p2 = join(projects, "proj-two");
-    mkdirSync(p1, { recursive: true });
-    mkdirSync(p2, { recursive: true });
-    // Minimal empty sqlite files so discovery keeps them (existsSync state.db).
-    // FileThreadStore will open and migrate; create threads via stores.
-    const s1 = new FileThreadStore({ projectDir: p1, agencHome: home });
-    const s2 = new FileThreadStore({ projectDir: p2, agencHome: home });
-    // Use in-memory-ish: createThread needs rolloutStore. Skip createThread —
-    // instead verify discovery sees both project dirs and multi-store opens them.
-    s1.close();
-    s2.close();
+  it("paginates the unified list with mp: cursors", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-mp-page-"));
+    const rollouts: RolloutStore[] = [];
+    try {
+      const multi = new MultiProjectFileThreadStore({
+        primaryCwd: cwd,
+        agencHome,
+      });
+      for (const id of ["t1", "t2", "t3"]) {
+        const r = openRollout({ cwd, sessionId: id });
+        rollouts.push(r);
+        multi.createThread({ threadId: id, cwd, rolloutStore: r });
+      }
+      const first = multi.listThreads({ pageSize: 2, archived: false });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).toMatch(/^mp:/);
 
-    const discovered = discoverStateDatabasePaths(home);
-    // FileThreadStore open creates state.db on construct — re-open to ensure files exist
-    const s1b = new FileThreadStore({ projectDir: p1, agencHome: home });
-    const s2b = new FileThreadStore({ projectDir: p2, agencHome: home });
-    s1b.close();
-    s2b.close();
+      const second = multi.listThreads({
+        pageSize: 2,
+        archived: false,
+        cursor: first.nextCursor,
+      });
+      expect(second.items).toHaveLength(1);
+      multi.close();
+    } finally {
+      for (const r of rollouts) r.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
 
-    const rediscovered = discoverStateDatabasePaths(home);
-    expect(rediscovered.length).toBeGreaterThanOrEqual(2);
-
-    const multi = new MultiProjectFileThreadStore({
-      primaryCwd: process.cwd(),
-      agencHome: home,
-    });
-    // listThreads should not throw and should scan discovered projects.
-    const page = multi.listThreads({ pageSize: 50, archived: false });
-    expect(Array.isArray(page.items)).toBe(true);
-    multi.close();
-    void discovered;
+describe("resolveDaemonDefaultCwd (DAE-02) — shipped helper", () => {
+  it("prefers AGENC_WORKSPACE then AGENC_PROJECT_DIR then PWD", () => {
+    expect(resolveDaemonDefaultCwd({ AGENC_WORKSPACE: "/ws" })).toBe("/ws");
+    expect(
+      resolveDaemonDefaultCwd({
+        AGENC_PROJECT_DIR: "/proj",
+        PWD: "/pwd",
+      }),
+    ).toBe("/proj");
+    expect(resolveDaemonDefaultCwd({ PWD: "/pwd" })).toBe("/pwd");
   });
 
-  it("resolveDaemonDefaultCwd prefers AGENC_WORKSPACE (source contract)", async () => {
-    const { readFileSync } = await import("node:fs");
-    const src = readFileSync(
-      new URL("../../src/app-server/daemon-cli.ts", import.meta.url),
-      "utf8",
-    );
-    expect(src).toMatch(/function resolveDaemonDefaultCwd/);
-    expect(src).toMatch(/AGENC_WORKSPACE/);
-    expect(src).toMatch(/MultiProjectFileThreadStore/);
+  it("falls back to process.cwd when no workspace env is set", () => {
+    const env = { ...process.env };
+    delete env.AGENC_WORKSPACE;
+    delete env.AGENC_PROJECT_DIR;
+    delete env.PWD;
+    expect(resolveDaemonDefaultCwd(env)).toBe(process.cwd());
   });
 });

--- a/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
+++ b/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
@@ -1,9 +1,30 @@
-import { describe, expect, it } from "vitest";
-import { applyRuntimeSandboxToSpawn } from "../../../src/tools/system/apply-runtime-sandbox.js";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyRuntimeSandboxToSpawn,
+  transformWithRuntimeSandbox,
+} from "../../../src/tools/system/apply-runtime-sandbox.js";
+import { UnifiedExecError } from "../../../src/unified-exec/types.js";
+import type { UnifiedExecRuntimeSandbox } from "../../../src/unified-exec/types.js";
+import type { PermissionProfile } from "../../../src/sandbox/engine/index.js";
 
-describe("applyRuntimeSandboxToSpawn (TOOL-03/04)", () => {
+function fakeProfile(): PermissionProfile {
+  return {
+    fileSystem: { kind: "workspace_write", entries: [] },
+    network: { kind: "enabled" },
+  } as PermissionProfile;
+}
+
+function fakeRuntimeSandbox(
+  preference: "require" | "auto" = "require",
+): UnifiedExecRuntimeSandbox {
+  return {
+    permissionProfile: fakeProfile(),
+    sandboxPolicyCwd: process.cwd(),
+    preference,
+  };
+}
+
+describe("applyRuntimeSandboxToSpawn (TOOL-03/04) — behavioral", () => {
   it("passes through when no runtime sandbox context is attached", () => {
     const result = applyRuntimeSandboxToSpawn({
       toolArgs: { command: "echo hi" },
@@ -18,21 +39,53 @@ describe("applyRuntimeSandboxToSpawn (TOOL-03/04)", () => {
     expect(result.env.PATH).toBe("/usr/bin");
   });
 
-  it("system.bash execute path applies sandbox helper before spawn", () => {
-    const src = readFileSync(
-      join(__dirname, "../../../src/tools/system/bash.ts"),
-      "utf8",
-    );
-    expect(src).toMatch(/applyRuntimeSandboxToSpawn/);
-    expect(src).toMatch(/withSandbox/);
+  it("rewrites program/args via SandboxManager.transform when isolation is applied", () => {
+    const transform = vi.fn().mockReturnValue({
+      command: ["/sandbox/wrapper", "/bin/echo", "hi"],
+      cwd: "/sandboxed",
+      env: { PATH: "/sandbox/bin", SANDBOX: "1" },
+      arg0: "wrapper",
+    });
+    const selectInitial = vi.fn().mockReturnValue("bwrap");
+    const manager = {
+      selectInitial,
+      transform,
+    } as never;
+
+    const result = transformWithRuntimeSandbox({
+      program: "/bin/echo",
+      args: ["hi"],
+      cwd: process.cwd(),
+      env: { PATH: "/usr/bin" },
+      runtimeSandbox: fakeRuntimeSandbox("require"),
+      sandboxManager: manager,
+    });
+
+    expect(selectInitial).toHaveBeenCalled();
+    expect(transform).toHaveBeenCalled();
+    expect(result.program).toBe("/sandbox/wrapper");
+    expect(result.args).toEqual(["/bin/echo", "hi"]);
+    expect(result.cwd).toBe("/sandboxed");
+    expect(result.env.SANDBOX).toBe("1");
   });
 
-  it("PowerShell LIVE tool passes runtimeSandbox into execCommand", () => {
-    const src = readFileSync(
-      join(__dirname, "../../../src/bin/model-facing-tools.ts"),
-      "utf8",
-    );
-    expect(src).toMatch(/runtimeSandboxForExec/);
-    expect(src).toMatch(/runtimeSandbox/);
+  it("fails closed when preference is require and no platform sandbox is selected", () => {
+    const manager = {
+      selectInitial: vi.fn().mockReturnValue("none"),
+      transform: vi.fn(),
+    } as never;
+
+    expect(() =>
+      transformWithRuntimeSandbox({
+        program: "/bin/echo",
+        args: ["hi"],
+        cwd: process.cwd(),
+        env: { PATH: "/usr/bin" },
+        runtimeSandbox: fakeRuntimeSandbox("require"),
+        sandboxManager: manager,
+      }),
+    ).toThrow(UnifiedExecError);
+
+    expect(manager.transform).not.toHaveBeenCalled();
   });
 });

--- a/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
+++ b/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { applyRuntimeSandboxToSpawn } from "../../../src/tools/system/apply-runtime-sandbox.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("applyRuntimeSandboxToSpawn (TOOL-03/04)", () => {
+  it("passes through when no runtime sandbox context is attached", () => {
+    const result = applyRuntimeSandboxToSpawn({
+      toolArgs: { command: "echo hi" },
+      fallbackCwd: process.cwd(),
+      program: "/bin/echo",
+      args: ["hi"],
+      cwd: process.cwd(),
+      env: { PATH: "/usr/bin" },
+    });
+    expect(result.program).toBe("/bin/echo");
+    expect(result.args).toEqual(["hi"]);
+    expect(result.env.PATH).toBe("/usr/bin");
+  });
+
+  it("system.bash execute path applies sandbox helper before spawn", () => {
+    const src = readFileSync(
+      join(__dirname, "../../../src/tools/system/bash.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(/applyRuntimeSandboxToSpawn/);
+    expect(src).toMatch(/withSandbox/);
+  });
+
+  it("PowerShell LIVE tool passes runtimeSandbox into execCommand", () => {
+    const src = readFileSync(
+      join(__dirname, "../../../src/bin/model-facing-tools.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(/runtimeSandboxForExec/);
+    expect(src).toMatch(/runtimeSandbox/);
+  });
+});


### PR DESCRIPTION
## Summary

Finishes remaining Phase 1 audit leftovers (TOOL-03, TOOL-04, DAE-02, DAE-03) after senior verification.

### TOOL-03 / TOOL-04
- `applyRuntimeSandboxToSpawn` shared with `system.bash` (all spawn paths)
- LIVE PowerShell passes `runtimeSandboxForExec` into `exec_command`
- Behavioral tests: transform rewrite + fail-closed when sandbox unavailable

### DAE-02 / DAE-03
- `MultiProjectFileThreadStore` unions session list/read across `AGENC_HOME/projects`
- `resolveDaemonDefaultCwd` prefers `AGENC_WORKSPACE` / `AGENC_PROJECT_DIR` / `PWD`
- commandExec legacy sandbox anchors on command cwd (DAE-08)

### Senior review
- First pass: FIX_THEN_MERGE (test theater)
- Second pass after hardening: **MERGE**

## Test plan
- [x] `vitest` apply-runtime-sandbox + multi-project-store
- [x] `tsc --noEmit`
- [x] Pre-commit TUI startup smoke