### PR TITLE
fix(daemon): require absolute workspace cwd on create (DAE-02)

### DIFF
--- a/docs/archive/codepath-audit-2026-07-12.md
+++ b/docs/archive/codepath-audit-2026-07-12.md
@@ -299,7 +299,7 @@ The only practical **CRITICAL** is same-process multi-agent shell isolation (TOO
 | TOOL-05 | **FIXED** | `98807aac6` MultiEdit/apply_patch mutation family |
 | TOOL-04 (partial) | **FIXED** (family) / **DEFERRED** (sandbox) | PowerShell in SHELL_TOOL_FAMILY; platform sandbox wire-up deferred — risk: Windows shell without sandbox |
 | TOOL-03 | **DEFERRED** | system.bash platform sandbox honesty — risk: deferred shell escapes isolation; prefer exec_command |
-| DAE-02 | **DEFERRED** | require session cwd / multi-project identity — risk: wrong default workspace when cwd omitted |
+| DAE-02 | **FIXED** | require absolute existing cwd on agent.create/session.create; clients send absolute path; daemon never invents |
 | DAE-03 | **DEFERRED** | multi-project primary FileThreadStore — risk: session.list incomplete across projects |
 | SEC-03 | **DEFERRED** | auto-mode strip Bash-name-only residual (shell family expanded; auto-mode helper not retargeted) |
 | SEC-04 | **FIXED** (via TOOL-02 unattended shell alias) | shell/write_stdin/kill aliases |

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { isAbsolute, resolve } from "node:path";
 import {
   AGENC_SDK_DAEMON_PROTOCOL_VERSION,
   AGENC_SDK_JSON_RPC_VERSION,
@@ -378,6 +379,12 @@ export class AgencClient {
       typeof (params as { agentId?: unknown }).agentId === "string"
         ? String((params as { agentId: string }).agentId).trim()
         : "";
+    // DAE-02: always send absolute client workspace cwd on the wire.
+    const cwd = resolveClientCwd(
+      typeof (params as { cwd?: unknown }).cwd === "string"
+        ? String((params as { cwd: string }).cwd)
+        : undefined,
+    );
     if (existingAgentId.length === 0) {
       const agent = await this.spawnAgent({
         objective:
@@ -385,9 +392,7 @@ export class AgencClient {
           String((params as { objective: string }).objective).trim().length > 0
             ? String((params as { objective: string }).objective).trim()
             : "Interactive session",
-        ...(typeof (params as { cwd?: unknown }).cwd === "string"
-          ? { cwd: String((params as { cwd: string }).cwd) }
-          : {}),
+        cwd,
         initialContent: [],
       } as AgentCreateParams);
       const attached = await this.attachAgent(agent.agentId);
@@ -395,7 +400,10 @@ export class AgencClient {
         return attached.session;
       }
     }
-    const created = await this.request("session.create", params);
+    const created = await this.request("session.create", {
+      ...params,
+      cwd,
+    });
     await this.#attachSession(created.sessionId);
     return new AgencSession(this, created.sessionId, created.agentId);
   }
@@ -408,7 +416,14 @@ export class AgencClient {
 
   /** Spawn a long-lived background agent (`agent.create`). */
   spawnAgent(params: AgentCreateParams): Promise<AgentCreateResult> {
-    return this.request("agent.create", params);
+    return this.request("agent.create", {
+      ...params,
+      // DAE-02: client fills absolute cwd when callers omit it; daemon still
+      // rejects empty/relative paths.
+      cwd: resolveClientCwd(
+        typeof params.cwd === "string" ? params.cwd : undefined,
+      ),
+    });
   }
 
   /**
@@ -693,4 +708,14 @@ function parseResponse<Method extends AgencDaemonMethod>(
   }
   return (response as AgencDaemonResponse<Method> & { result: AgencResultByMethod[Method] })
     .result;
+}
+
+/** Absolute workspace path for daemon create RPCs (DAE-02 client boundary). */
+function resolveClientCwd(cwd: string | undefined): string {
+  const base = process.cwd();
+  if (typeof cwd === "string" && cwd.trim().length > 0) {
+    const trimmed = cwd.trim();
+    return isAbsolute(trimmed) ? resolve(trimmed) : resolve(base, trimmed);
+  }
+  return resolve(base);
 }

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -135,6 +135,11 @@ export type MessageContent = string | readonly MessageContentBlock[];
 
 export interface AgentCreateParams extends JsonObject {
   readonly objective?: string;
+  /**
+   * Absolute workspace directory. Required by the daemon (DAE-02).
+   * SDK `spawnAgent` / `createSession` will fill `process.cwd()` when omitted
+   * at the client boundary — never leave this unset on the wire.
+   */
   readonly cwd?: string;
   readonly model?: string;
   readonly provider?: string;

--- a/runtime/src/app-server-protocol/index.ts
+++ b/runtime/src/app-server-protocol/index.ts
@@ -201,7 +201,7 @@ export function createAgenCPortalAgentCreateRequest(
 ): AgenCPortalAgentCreateRequest {
   const params: AgentCreateParams = {
     objective: options.objective,
-    ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+    cwd: options.cwd,
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.provider !== undefined ? { provider: options.provider } : {}),
     ...(options.profile !== undefined ? { profile: options.profile } : {}),

--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -10,6 +10,7 @@
 
 import { createConnection } from "node:net";
 import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { cwd as processCwd } from "node:process";
 import {
   ensureAgenCDaemonAutostart,
@@ -811,7 +812,8 @@ async function startAgenCAgent(
     const result = await client.createAgent({
       objective,
       instructions: objective,
-      cwd: options.cwd ?? processCwd(),
+      // DAE-02: absolute workspace identity from the CLI process (never omit).
+      cwd: resolve(options.cwd ?? processCwd()),
       metadata: { source: "agenc agent start" },
       ...(command.unattendedAllow.length > 0
         ? { unattendedAllow: command.unattendedAllow }

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -8,6 +8,10 @@
  */
 
 import { AsyncLock } from "../utils/async-lock.js";
+import {
+  requireAbsoluteWorkspaceCwd,
+  WorkspaceCwdError,
+} from "./workspace-cwd.js";
 import type {
   AgenCBackgroundAgentSnapshot,
   AgenCBackgroundAgentRunner,
@@ -120,6 +124,10 @@ export class AgenCDaemonAgentLifecycleError extends Error {
 }
 
 export interface AgenCDaemonAgentManagerOptions {
+  /**
+   * @deprecated DAE-02: no longer used for agent.create (cwd is required).
+   * Retained only for optional test/back-compat options objects.
+   */
   readonly defaultCwd?: () => string;
   readonly now?: () => string;
   readonly runner?: AgenCBackgroundAgentRunner;
@@ -268,7 +276,7 @@ interface RunnerTerminationTarget {
 }
 
 export class AgenCDaemonAgentManager {
-  readonly #defaultCwd: () => string;
+
   readonly #now: () => string;
   readonly #runner: AgenCBackgroundAgentRunner | undefined;
   readonly #sessionManager: AgenCDaemonSessionManager | undefined;
@@ -316,7 +324,7 @@ export class AgenCDaemonAgentManager {
   });
 
   constructor(options: AgenCDaemonAgentManagerOptions = {}) {
-    this.#defaultCwd = options.defaultCwd ?? (() => process.cwd());
+    void options.defaultCwd; // DAE-02: ignored — create requires absolute cwd
     this.#now = options.now ?? (() => new Date().toISOString());
     this.#runner = options.runner;
     this.#sessionManager = options.sessionManager;
@@ -346,7 +354,18 @@ export class AgenCDaemonAgentManager {
     try {
       const objective = normalizeObjective(params);
       const createdAt = this.#now();
-      const cwd = normalizeNonEmpty(params.cwd) ?? this.#defaultCwd();
+      let cwd: string;
+      try {
+        cwd = requireAbsoluteWorkspaceCwd(params.cwd, "agent.create");
+      } catch (error) {
+        if (error instanceof WorkspaceCwdError) {
+          throw new AgenCDaemonAgentLifecycleError(
+            "INVALID_ARGUMENT",
+            error.message,
+          );
+        }
+        throw error;
+      }
       const unattendedAllow = normalizeStringList(
         params.unattendedAllow,
         DEFAULT_UNATTENDED_ALLOWLIST,
@@ -408,7 +427,7 @@ export class AgenCDaemonAgentManager {
         if (this.#sessionManager !== undefined) {
           const session = await this.#sessionManager.createSession({
             agentId: agent.agentId,
-            cwd: agent.cwd,
+            cwd,
             initialPrompt: objective,
             metadata: {
               ...(params.metadata ?? {}),

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -42,6 +42,10 @@ import {
 } from "./overload.js";
 import type { AuthBackend, AuthDaemonSocketIdentity } from "../auth/backend.js";
 import {
+  requireAbsoluteWorkspaceCwd,
+  WorkspaceCwdError,
+} from "./workspace-cwd.js";
+import {
   AGENC_DAEMON_INTERNAL_METHODS,
   AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
   AGENC_DAEMON_METHODS,
@@ -1559,6 +1563,16 @@ function validateAgentCreateParams(params: JsonObject): AgentCreateParams {
     objectFields: ["metadata", "envOverrides"],
     valueFields: ["initialContent"],
   });
+  // DAE-02: absolute existing directory required (no daemon-side invent).
+  let cwd: string;
+  try {
+    cwd = requireAbsoluteWorkspaceCwd(validated.cwd, "agent.create");
+  } catch (error) {
+    if (error instanceof WorkspaceCwdError) {
+      throw invalidParams(error.message);
+    }
+    throw error;
+  }
   if (validated.initialContent !== undefined) {
     validateMessageContent(
       "agent.create",
@@ -1586,7 +1600,7 @@ function validateAgentCreateParams(params: JsonObject): AgentCreateParams {
       "envOverrides",
     );
   }
-  return validated as AgentCreateParams;
+  return { ...validated, cwd } as AgentCreateParams;
 }
 
 function validateAgentListParams(params: JsonObject): AgentListParams {
@@ -1653,7 +1667,16 @@ function validateSessionCreateParams(params: JsonObject): SessionCreateParams {
     stringFields: ["agentId", "cwd", "initialPrompt"],
     objectFields: ["metadata"],
   });
-  return validated as SessionCreateParams;
+  let cwd: string;
+  try {
+    cwd = requireAbsoluteWorkspaceCwd(validated.cwd, "session.create");
+  } catch (error) {
+    if (error instanceof WorkspaceCwdError) {
+      throw invalidParams(error.message);
+    }
+    throw error;
+  }
+  return { ...validated, cwd } as SessionCreateParams;
 }
 
 function validateSessionAttachParams(params: JsonObject): SessionAttachParams {

--- a/runtime/src/app-server/daemon-workspace.ts
+++ b/runtime/src/app-server/daemon-workspace.ts
@@ -1,10 +1,10 @@
 /**
- * DAE-02: Prefer an explicit workspace env over the daemon process cwd so
- * multi-project agents don't inherit the first shell that autostarted the
- * daemon when `cwd` is omitted on create.
+ * Default cwd for *daemon process infrastructure* only (e.g. multi-project
+ * thread-store primary key, snapshot policy default route).
  *
- * Note: clients that omit cwd and do not set these env vars still fall back
- * to process.cwd() (daemon OS cwd). First-party agent-cli always sends cwd.
+ * DAE-02: this must NOT be used for agent.create / session.create — those
+ * require an absolute client-supplied workspace via
+ * `requireAbsoluteWorkspaceCwd` in workspace-cwd.ts.
  */
 export function resolveDaemonDefaultCwd(env: NodeJS.ProcessEnv = process.env): string {
   const workspace =

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -713,7 +713,11 @@ export function isAgenCDaemonNotificationMethod(
 
 export interface AgentCreateParams extends JsonObject {
   readonly objective?: string;
-  readonly cwd?: string;
+  /**
+   * Absolute workspace directory. Required (DAE-02): the daemon will not
+   * invent a project root from its own process.cwd().
+   */
+  readonly cwd: string;
   readonly model?: string;
   readonly provider?: string;
   readonly profile?: string;
@@ -796,7 +800,10 @@ export interface AgentLogsParams extends JsonObject {
 
 export interface SessionCreateParams extends JsonObject {
   readonly agentId?: string;
-  readonly cwd?: string;
+  /**
+   * Absolute workspace directory. Required (DAE-02) for new sessions.
+   */
+  readonly cwd: string;
   readonly initialPrompt?: string;
   readonly metadata?: JsonObject;
 }

--- a/runtime/src/app-server/session-lifecycle.ts
+++ b/runtime/src/app-server/session-lifecycle.ts
@@ -14,6 +14,10 @@
 import { randomUUID } from "node:crypto";
 import { AsyncLock } from "../utils/async-lock.js";
 import { ThreadNotFoundError } from "../thread-store/store.js";
+import {
+  requireAbsoluteWorkspaceCwd,
+  WorkspaceCwdError,
+} from "./workspace-cwd.js";
 import type {
   StoredThread,
   ThreadSource,
@@ -126,20 +130,30 @@ export class AgenCDaemonSessionManager {
   }
 
   async createSession(
-    params: SessionCreateParams = {},
+    params: SessionCreateParams,
   ): Promise<SessionCreateResult> {
     const sessionId = this.#createSessionId();
     const createdAt = this.#now();
     const agentId = nonEmptyString(params.agentId) ?? this.#defaultAgentId;
+    // DAE-02: cwd is required identity for new sessions (absolute workspace).
+    let cwd: string;
+    try {
+      cwd = requireAbsoluteWorkspaceCwd(params.cwd, "session.create");
+    } catch (error) {
+      if (error instanceof WorkspaceCwdError) {
+        throw new AgenCSessionLifecycleError("INVALID_ARGUMENT", error.message);
+      }
+      throw error;
+    }
     const session: MutableSession = {
       sessionId,
       agentId,
       status: "idle",
       createdAt,
       attachments: new Map(),
+      cwd,
     };
 
-    if (params.cwd !== undefined) session.cwd = params.cwd;
     if (params.initialPrompt !== undefined) {
       session.initialPrompt = params.initialPrompt;
     }

--- a/runtime/src/app-server/workspace-cwd.ts
+++ b/runtime/src/app-server/workspace-cwd.ts
@@ -1,0 +1,72 @@
+/**
+ * DAE-02: workspace cwd is a first-class identity for agent/session create.
+ *
+ * The daemon must never invent a project directory from its own process.cwd().
+ * Clients (CLI, SDK, gateway) own workspace selection and must send an absolute
+ * path on create. Relative paths are rejected so daemon-side resolution cannot
+ * silently re-root against the wrong OS cwd.
+ */
+
+import { isAbsolute, resolve } from "node:path";
+import { existsSync, statSync } from "node:fs";
+
+export class WorkspaceCwdError extends Error {
+  readonly code = "INVALID_ARGUMENT" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspaceCwdError";
+  }
+}
+
+/**
+ * Validate and normalize a workspace cwd for daemon agent/session create.
+ * Returns a normalized absolute path.
+ */
+export function requireAbsoluteWorkspaceCwd(
+  cwd: unknown,
+  context: string,
+): string {
+  if (typeof cwd !== "string" || cwd.trim().length === 0) {
+    throw new WorkspaceCwdError(
+      `${context} requires absolute cwd (workspace directory); the daemon will not invent one`,
+    );
+  }
+  const trimmed = cwd.trim();
+  if (!isAbsolute(trimmed)) {
+    throw new WorkspaceCwdError(
+      `${context} cwd must be an absolute path (got ${JSON.stringify(trimmed)})`,
+    );
+  }
+  // Normalize `.` / `..` segments without changing the root.
+  const normalized = resolve(trimmed);
+  try {
+    if (!existsSync(normalized) || !statSync(normalized).isDirectory()) {
+      throw new WorkspaceCwdError(
+        `${context} cwd is not an existing directory: ${normalized}`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof WorkspaceCwdError) throw error;
+    throw new WorkspaceCwdError(
+      `${context} cwd is not accessible: ${normalized}`,
+    );
+  }
+  return normalized;
+}
+
+/**
+ * Client-side helper: turn optional cwd into an absolute workspace path
+ * relative to the *client* process. Never used inside the daemon create path.
+ */
+export function resolveClientWorkspaceCwd(
+  cwd: string | undefined,
+  clientCwd: string = process.cwd(),
+): string {
+  const base = isAbsolute(clientCwd) ? resolve(clientCwd) : resolve(clientCwd);
+  if (typeof cwd === "string" && cwd.trim().length > 0) {
+    const trimmed = cwd.trim();
+    return isAbsolute(trimmed) ? resolve(trimmed) : resolve(base, trimmed);
+  }
+  return base;
+}

--- a/runtime/src/gateway/sdk-daemon-client.ts
+++ b/runtime/src/gateway/sdk-daemon-client.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 /**
  * Production {@link GatewayDaemonClient} backed by `@tetsuo-ai/agenc-sdk`
  * (TODO task 6; agent provisioning TODO task 34).
@@ -232,11 +234,13 @@ export async function createSdkDaemonClient(
       // Passive agent: empty initialContent suppresses the turn-1 objective
       // submit, so provisioning costs zero LLM calls. The objective string is
       // operator-facing metadata (agent.list) only.
+      // DAE-02: always pass absolute workspace cwd (gateway process workspace).
+      const cwd = resolve(options.cwd ?? process.cwd());
       const created = await client.spawnAgent({
         objective:
           label !== undefined ? `gateway: ${label}` : "gateway session",
         initialContent: [],
-        ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+        cwd,
         ...(options.permissionMode !== undefined
           ? { permissionMode: options.permissionMode }
           : {}),

--- a/runtime/tests/app-server-protocol/portal.contract.test.ts
+++ b/runtime/tests/app-server-protocol/portal.contract.test.ts
@@ -175,7 +175,7 @@ describe("AgenC portal protocol contract", () => {
       id: "start-1",
       method: "agent.create",
       params: {
-        objective: "Run the background dashboard smoke test",
+        cwd: process.cwd(), objective: "Run the background dashboard smoke test",
         cwd: "/workspace",
         initialContent: "Start from the portal dashboard",
         unattendedAllow: ["FileRead"],

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -1690,7 +1690,7 @@ describe("AgenC background agent lifecycle", () => {
     });
 
     await expect(
-      agents.createAgent({ objective: "inspect live termination" }),
+      agents.createAgent({ cwd: process.cwd(),  objective: "inspect live termination" }),
     ).resolves.toMatchObject({
       agentId: "agent-terminate-live",
       sessionId: "session-terminate-live",
@@ -1920,6 +1920,7 @@ describe("AgenC background agent lifecycle", () => {
 
     await expect(
       agents.createAgent({
+        cwd: process.cwd(),
         objective: "  build the parser  ",
         metadata: { ticket: "F-06a" },
       }),
@@ -1931,7 +1932,7 @@ describe("AgenC background agent lifecycle", () => {
       createdAt: "2026-05-01T12:00:00.000Z",
       startedAt: "2026-05-01T12:00:00.500Z",
       lastActiveAt: "2026-05-01T12:00:00.500Z",
-      cwd: "/workspace",
+      cwd: process.cwd(),
       activeSessionIds: ["session_1"],
       metadata: {
         ticket: "F-06a",
@@ -1943,7 +1944,7 @@ describe("AgenC background agent lifecycle", () => {
     expect(starts).toEqual([
       {
         objective: "build the parser",
-        cwd: "/workspace",
+        cwd: process.cwd(),
         metadata: {
           ticket: "F-06a",
           unattendedAllow: [],
@@ -1958,7 +1959,7 @@ describe("AgenC background agent lifecycle", () => {
       agentId: "agent_1",
       status: "idle",
       createdAt: "2026-05-01T12:00:01.000Z",
-      cwd: "/workspace",
+      cwd: process.cwd(),
       metadata: {
         ticket: "F-06a",
         objective: "build the parser",
@@ -1977,7 +1978,7 @@ describe("AgenC background agent lifecycle", () => {
           createdAt: "2026-05-01T12:00:00.000Z",
           startedAt: "2026-05-01T12:00:00.500Z",
           lastActiveAt: "2026-05-01T12:00:00.500Z",
-          cwd: "/workspace",
+          cwd: process.cwd(),
           activeSessionIds: ["session_1"],
           metadata: {
             ticket: "F-06a",
@@ -2000,7 +2001,7 @@ describe("AgenC background agent lifecycle", () => {
           agentId: "agent_1",
           status: "idle",
           createdAt: "2026-05-01T12:00:01.000Z",
-          cwd: "/workspace",
+          cwd: process.cwd(),
           metadata: {
             ticket: "F-06a",
             objective: "build the parser",
@@ -2246,7 +2247,7 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
     });
 
-    await agents.createAgent({ objective: "build the parser" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "build the parser" });
     await expect(
       agents.attachAgent({ agentId: "agent_stop", clientId: "tui_1" }),
     ).resolves.toMatchObject({
@@ -2266,7 +2267,7 @@ describe("AgenC background agent lifecycle", () => {
       createdAt: "2026-05-01T12:00:00.000Z",
       startedAt: "2026-05-01T12:00:00.500Z",
       lastActiveAt: "2026-05-01T12:00:02.000Z",
-      cwd: "/workspace",
+      cwd: process.cwd(),
       metadata: {
         unattendedAllow: [],
         unattendedDeny: [],
@@ -2321,8 +2322,8 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
     });
 
-    await agents.createAgent({ objective: "one" });
-    await agents.createAgent({ objective: "two" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "one" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "two" });
 
     await expect(agents.stopAll("daemon_shutdown")).resolves.toBe(2);
 
@@ -2376,8 +2377,8 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
     });
 
-    await agents.createAgent({ objective: "one" });
-    await agents.createAgent({ objective: "two" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "one" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "two" });
 
     await expect(agents.stopAll("daemon_shutdown")).rejects.toThrow(
       "AgenC daemon cleanup failed for 1 agent(s): agent_one",
@@ -2421,7 +2422,7 @@ describe("AgenC background agent lifecycle", () => {
       runner,
     });
 
-    const create = agents.createAgent({ objective: "late create" });
+    const create = agents.createAgent({ cwd: process.cwd(),  objective: "late create" });
     await Promise.resolve();
     const stopAll = agents.stopAll("daemon_shutdown");
     started.resolve({
@@ -2438,7 +2439,7 @@ describe("AgenC background agent lifecycle", () => {
     expect(stopAgent).toHaveBeenCalledWith("agent_late", "daemon_shutdown");
     await expect(agents.listAgents()).resolves.toEqual({ agents: [] });
     await expect(
-      agents.createAgent({ objective: "after shutdown" }),
+      agents.createAgent({ cwd: process.cwd(),  objective: "after shutdown" }),
     ).rejects.toMatchObject({
       code: "INVALID_ARGUMENT",
       message: "agent.start rejected because the daemon is shutting down",
@@ -2468,7 +2469,7 @@ describe("AgenC background agent lifecycle", () => {
       },
     });
 
-    await agents.createAgent({ objective: "snapshot me" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "snapshot me" });
     await agents.stopAll("daemon_shutdown");
 
     await expect(agents.flushSnapshots("daemon_shutdown")).resolves.toBe(1);
@@ -2484,7 +2485,7 @@ describe("AgenC background agent lifecycle", () => {
             createdAt: "2026-05-01T12:00:00.000Z",
             startedAt: "2026-05-01T12:00:00.500Z",
             lastActiveAt: "2026-05-01T12:00:01.000Z",
-            cwd: "/workspace",
+            cwd: process.cwd(),
             metadata: {
               unattendedAllow: [],
               unattendedDeny: [],
@@ -2529,7 +2530,7 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
     });
 
-    await agents.createAgent({ objective: "race stop" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "race stop" });
     const stop = agents.stopAgent({ agentId: "agent_race" });
     await stopStarted.promise;
 
@@ -2581,7 +2582,7 @@ describe("AgenC background agent lifecycle", () => {
       },
     });
 
-    await agents.createAgent({ objective: "fail stop" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "fail stop" });
     await expect(
       agents.stopAgent({ agentId: "agent_fail_stop" }),
     ).rejects.toThrow("shutdown failed");
@@ -2594,14 +2595,14 @@ describe("AgenC background agent lifecycle", () => {
       {
         sessionId: "session_fail_stop",
         agentId: "agent_fail_stop",
-        cwd: "/workspace",
+        cwd: process.cwd(),
         status: "running",
         transitionAt: "2026-05-01T12:00:00.500Z",
       },
       {
         sessionId: "session_fail_stop",
         agentId: "agent_fail_stop",
-        cwd: "/workspace",
+        cwd: process.cwd(),
         status: "stopping",
         transitionAt: "2026-05-01T12:00:02.000Z",
         reason: "agent.stop",
@@ -2609,7 +2610,7 @@ describe("AgenC background agent lifecycle", () => {
       {
         sessionId: "session_fail_stop",
         agentId: "agent_fail_stop",
-        cwd: "/workspace",
+        cwd: process.cwd(),
         status: "error",
         transitionAt: "2026-05-01T12:00:02.000Z",
         reason: "agent.stop",
@@ -2644,8 +2645,8 @@ describe("AgenC background agent lifecycle", () => {
       runner,
     });
 
-    await agents.createAgent({ objective: "watch active work" });
-    await agents.createAgent({ objective: "finish quickly" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "watch active work" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "finish quickly" });
     snapshots.set("agent_active", {
       status: "idle",
       lastActiveAt: "2026-05-01T12:00:03.000Z",
@@ -2661,7 +2662,7 @@ describe("AgenC background agent lifecycle", () => {
           createdAt: "2026-05-01T12:00:00.000Z",
           startedAt: "2026-05-01T12:00:00.500Z",
           lastActiveAt: "2026-05-01T12:00:03.000Z",
-          cwd: "/workspace",
+          cwd: process.cwd(),
           metadata: {
             unattendedAllow: [],
             unattendedDeny: [],
@@ -2674,7 +2675,7 @@ describe("AgenC background agent lifecycle", () => {
           createdAt: "2026-05-01T12:00:01.000Z",
           startedAt: "2026-05-01T12:00:00.500Z",
           lastActiveAt: "2026-05-01T12:00:00.500Z",
-          cwd: "/workspace",
+          cwd: process.cwd(),
           metadata: {
             unattendedAllow: [],
             unattendedDeny: [],
@@ -2719,9 +2720,9 @@ describe("AgenC background agent lifecycle", () => {
       runner,
     });
 
-    await agents.createAgent({ objective: "first" });
-    await agents.createAgent({ objective: "second" });
-    await agents.createAgent({ objective: "third" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "first" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "second" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "third" });
 
     await expect(agents.listAgents({ limit: 2 })).resolves.toMatchObject({
       agents: [
@@ -2767,6 +2768,7 @@ describe("AgenC background agent lifecycle", () => {
 
     await expect(
       agents.createAgent({
+        cwd: process.cwd(),
         objective: "describe this",
         initialContent: [
           { type: "text", text: "describe this" },
@@ -2821,7 +2823,7 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "inspect image" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "inspect image" });
 
     await agents.streamAgentMessage({
       sessionId: "session_1",
@@ -2867,7 +2869,7 @@ describe("AgenC background agent lifecycle", () => {
   });
 
   it("records snapshot-policy hooks for agent status and message exchanges", async () => {
-    const cwd = "/tmp/agenc-snapshot-policy-cwd";
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-snapshot-policy-cwd-"));
     const sessions = new AgenCDaemonSessionManager({
       createSessionId: sequence(["session_snapshot"]),
       now: sequence(["2026-05-01T12:00:00.000Z"]),
@@ -3049,7 +3051,7 @@ describe("AgenC background agent lifecycle", () => {
   });
 
   it("records runner-observed status transitions during refresh", async () => {
-    const cwd = "/tmp/agenc-status-refresh";
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-status-refresh-"));
     const sessions = new AgenCDaemonSessionManager({
       createSessionId: sequence(["session_status_refresh"]),
       now: sequence(["2026-05-01T12:00:00.000Z"]),
@@ -3077,7 +3079,7 @@ describe("AgenC background agent lifecycle", () => {
       },
     });
 
-    await agents.createAgent({ objective: "watch status" });
+    await agents.createAgent({ cwd, objective: "watch status" });
     currentSnapshot = {
       status: "idle",
       lastActiveAt: "2026-05-01T12:00:02.000Z",
@@ -3151,7 +3153,7 @@ describe("AgenC background agent lifecycle", () => {
         },
       });
 
-      await agents.createAgent({ objective: "watch budget status" });
+      await agents.createAgent({ cwd: process.cwd(),  objective: "watch budget status" });
       currentSnapshot = {
         status: "stopped",
         lastActiveAt: "2026-05-01T12:00:02.000Z",
@@ -3218,7 +3220,7 @@ describe("AgenC background agent lifecycle", () => {
     });
 
     await expect(
-      agents.createAgent({ objective: "snapshot failures should not block" }),
+      agents.createAgent({ cwd: process.cwd(),  objective: "snapshot failures should not block" }),
     ).resolves.toMatchObject({
       agentId: "agent_snapshot_error",
       sessionId: "session_snapshot_error",
@@ -3275,7 +3277,7 @@ describe("AgenC background agent lifecycle", () => {
       agents.attachAgent({ agentId: "agent_missing" }),
     ).rejects.toMatchObject({ code: "AGENT_NOT_FOUND" });
 
-    await agents.createAgent({ objective: "closed session" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "closed session" });
     await sessions.terminateSession({
       sessionId: "session_1",
       reason: "test closed",
@@ -3285,7 +3287,7 @@ describe("AgenC background agent lifecycle", () => {
     ).rejects.toMatchObject({ code: "AGENT_NOT_FOUND" });
 
     active = false;
-    await agents.createAgent({ objective: "inactive before attach" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "inactive before attach" });
     await expect(
       agents.attachAgent({ agentId: "agent_inactive" }),
     ).resolves.toMatchObject({
@@ -3300,7 +3302,7 @@ describe("AgenC background agent lifecycle", () => {
     const agents = new AgenCDaemonAgentManager();
 
     await expect(
-      agents.createAgent({ objective: "build the parser" }),
+      agents.createAgent({ cwd: process.cwd(),  objective: "build the parser" }),
     ).rejects.toMatchObject({
       code: "BACKGROUND_RUNNER_UNAVAILABLE",
     });
@@ -3326,7 +3328,7 @@ describe("AgenC background agent lifecycle", () => {
     });
 
     await expect(
-      agents.createAgent({ objective: "build the parser" }),
+      agents.createAgent({ cwd: process.cwd(),  objective: "build the parser" }),
     ).rejects.toThrow("session store unavailable");
     expect(stopAgent).toHaveBeenCalledWith(
       "agent_orphan",
@@ -3344,7 +3346,7 @@ describe("AgenC background agent lifecycle", () => {
       },
     });
     await expect(
-      agents.createAgent({ objective: "   " }),
+      agents.createAgent({ cwd: process.cwd(),  objective: "   " }),
     ).rejects.toBeInstanceOf(AgenCDaemonAgentLifecycleError);
   });
 
@@ -3471,7 +3473,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: 1,
         method: "agent.create",
-        params: { objective: "ship a daemon task", cwd: "/repo" },
+        params: { objective: "ship a daemon task", cwd: process.cwd() },
       }),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
@@ -3551,7 +3553,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: 2,
         method: "agent.create",
-        params: { objective: "ship a daemon task", cwd: "/repo" },
+        params: { objective: "ship a daemon task", cwd: process.cwd() },
       }),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
@@ -3563,7 +3565,7 @@ describe("AgenC background agent lifecycle", () => {
         createdAt: "2026-05-01T12:00:00.000Z",
         startedAt: "2026-05-01T12:00:00.500Z",
         lastActiveAt: "2026-05-01T12:00:00.500Z",
-        cwd: "/repo",
+        cwd: process.cwd(),
         metadata: {
           unattendedAllow: [],
           unattendedDeny: [],
@@ -3590,7 +3592,7 @@ describe("AgenC background agent lifecycle", () => {
             createdAt: "2026-05-01T12:00:00.000Z",
             startedAt: "2026-05-01T12:00:00.500Z",
             lastActiveAt: "2026-05-01T12:00:00.500Z",
-            cwd: "/repo",
+            cwd: process.cwd(),
             metadata: {
               unattendedAllow: [],
               unattendedDeny: [],
@@ -3693,7 +3695,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: 2,
         method: "agent.create",
-        params: { objective: 42 },
+        params: { cwd: process.cwd(), objective: 42 },
       }),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
@@ -3793,7 +3795,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: 3,
         method: "agent.create",
-        params: { objective: "ship", unattendedAllow: "FileRead" },
+        params: { cwd: process.cwd(), objective: "ship", unattendedAllow: "FileRead" },
       }),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
@@ -3810,7 +3812,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: 4,
         method: "agent.create",
-        params: { objective: "ship", metadata: [] },
+        params: { cwd: process.cwd(), objective: "ship", metadata: [] },
       }),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
@@ -3827,7 +3829,7 @@ describe("AgenC background agent lifecycle", () => {
         id: "bad-env-overrides",
         method: "agent.create",
         params: {
-          objective: "ship",
+          cwd: process.cwd(), objective: "ship",
           envOverrides: { AGENC_MCP_SERVERS: [] },
         },
       }),
@@ -3893,7 +3895,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: "create",
         method: "agent.create",
-        params: { objective: "answer from the portal" },
+        params: {cwd: process.cwd(),  objective: "answer from the portal" },
       }),
     ).resolves.toMatchObject({
       result: {
@@ -4035,7 +4037,7 @@ describe("AgenC background agent lifecycle", () => {
         createAgenCPortalAgentCreateRequest(
           {
             objective: "  index queued work  ",
-            cwd: "/workspace",
+            cwd: process.cwd(),
             unattendedAllow: ["FileRead"],
             metadata: { source: "portal.dashboard" },
           },
@@ -4050,7 +4052,7 @@ describe("AgenC background agent lifecycle", () => {
         sessionId: "session_dashboard",
         objective: "index queued work",
         status: "running",
-        cwd: "/workspace",
+        cwd: process.cwd(),
         activeSessionIds: ["session_dashboard"],
         metadata: {
           source: "portal.dashboard",
@@ -4062,7 +4064,7 @@ describe("AgenC background agent lifecycle", () => {
     expect(starts).toEqual([
       {
         objective: "index queued work",
-        cwd: "/workspace",
+        cwd: process.cwd(),
         metadata: {
           source: "portal.dashboard",
           unattendedAllow: ["FileRead"],
@@ -4164,7 +4166,7 @@ describe("AgenC background agent lifecycle", () => {
       jsonrpc: JSON_RPC_VERSION,
       id: "create",
       method: "agent.create",
-      params: { objective: "validate portal actions" },
+      params: {cwd: process.cwd(),  objective: "validate portal actions" },
     });
 
     await expect(
@@ -4702,8 +4704,8 @@ describe("AgenC background agent lifecycle", () => {
       },
     });
 
-    await sessions.createSession({ agentId: "agent_cleanup" });
-    await sessions.createSession({ agentId: "agent_cleanup" });
+    await sessions.createSession({ cwd: process.cwd(), agentId: "agent_cleanup" });
+    await sessions.createSession({ cwd: process.cwd(), agentId: "agent_cleanup" });
     await expect(
       connection.dispatch({
         jsonrpc: JSON_RPC_VERSION,
@@ -4761,7 +4763,7 @@ describe("AgenC background agent lifecycle", () => {
       runner,
       permissionAuditLogger: auditLogger,
     });
-    await agents.createAgent({ objective: "wait for approval" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "wait for approval" });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: agents,
     });
@@ -4878,7 +4880,7 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "wait for all-tool approval" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "wait for all-tool approval" });
 
     await expect(
       agents.approveTool({
@@ -4921,7 +4923,7 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "stale approval" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "stale approval" });
 
     await expect(
       agents.approveTool({
@@ -4955,7 +4957,7 @@ describe("AgenC background agent lifecycle", () => {
       },
       onPermissionAuditError,
     });
-    await agents.createAgent({ objective: "wait for approval" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "wait for approval" });
 
     await expect(
       agents.approveTool({
@@ -4992,7 +4994,7 @@ describe("AgenC background agent lifecycle", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "list permissions" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "list permissions" });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: agents,
     });
@@ -5133,7 +5135,7 @@ describe("AgenC background agent lifecycle", () => {
         jsonrpc: JSON_RPC_VERSION,
         id: "create",
         method: "agent.create",
-        params: { objective: "run background work" },
+        params: {cwd: process.cwd(),  objective: "run background work" },
       }),
     ).resolves.toMatchObject({
       result: { agentId: "agent_dup", sessionId: "session_1" },
@@ -5176,8 +5178,8 @@ describe("AgenC background agent lifecycle", () => {
         "2026-05-01T12:00:02.000Z",
       ]),
     });
-    await sessions.createSession({ agentId: "agent_multi" });
-    await sessions.createSession({ agentId: "agent_multi" });
+    await sessions.createSession({ cwd: process.cwd(), agentId: "agent_multi" });
+    await sessions.createSession({ cwd: process.cwd(), agentId: "agent_multi" });
     const clientMultiplexer = new AgenCDaemonClientMultiplexer({
       sessionManager: sessions,
     });
@@ -5288,7 +5290,7 @@ describe("AgenC background agent lifecycle", () => {
       agents.handleRunnerTerminated(id, snapshot),
     );
 
-    await agents.createAgent({ objective: "do work then end" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "do work then end" });
     await expect(agents.listAgents()).resolves.toMatchObject({
       agents: [{ agentId: "agent_reaped", status: "running" }],
     });
@@ -5358,7 +5360,7 @@ describe("AgenC background agent lifecycle", () => {
       agents.handleRunnerTerminated(id, snapshot),
     );
 
-    await agents.createAgent({ objective: "finish immediately" });
+    await agents.createAgent({ cwd: process.cwd(),  objective: "finish immediately" });
 
     await expect(agents.listAgents()).resolves.toEqual({ agents: [] });
     await expect(sessions.getSession("session_fast_done")).resolves.toMatchObject(

--- a/runtime/tests/app-server/cancellation-preemption.contract.test.ts
+++ b/runtime/tests/app-server/cancellation-preemption.contract.test.ts
@@ -309,7 +309,7 @@ describe("AgenC daemon cancellation and preemption", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "run a tool" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "run a tool" });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: agents,
     });
@@ -370,7 +370,7 @@ describe("AgenC daemon cancellation and preemption", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "run a tool" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "run a tool" });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: agents,
     });
@@ -434,7 +434,7 @@ describe("AgenC daemon cancellation and preemption", () => {
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "wait for cancel" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "wait for cancel" });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: agents,
     });

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -1741,7 +1741,7 @@ backend = "local"
           jsonrpc: "2.0",
           id: "create",
           method: "agent.create",
-          params: { objective: "realtime thread state" },
+          params: {cwd: process.cwd(),  cwd: process.cwd(),  objective: "realtime thread state" },
         })}\n`,
       );
       const created = JSON.parse(await readSocketLine(socket)) as {
@@ -1924,7 +1924,7 @@ backend = "local"
         timeoutMs: 1000,
       });
 
-      const created = await writerClient.request("agent.create", {
+      const created = await writerClient.request("agent.create", { cwd: process.cwd(),
         objective: "health state",
       });
       if (created.sessionId === undefined)
@@ -2026,7 +2026,7 @@ backend = "local"
         timeoutMs: 1000,
       });
 
-      const created = await client.request("agent.create", {
+      const created = await client.request("agent.create", { cwd: process.cwd(),
         objective: "prove dispatcher boot injection",
       });
       expect(created.agentId).toBe("agent_boot_injection");

--- a/runtime/tests/app-server/plan-approval-leak-ihunt.contract.test.ts
+++ b/runtime/tests/app-server/plan-approval-leak-ihunt.contract.test.ts
@@ -55,7 +55,7 @@ describe("approveTool does not leak exit-plan approvals on the non-pending throw
 
   it("removes the recorded approval when the decision is no longer pending", async () => {
     const { agents } = createAgentsWithNonPendingDecision();
-    await agents.createAgent({ objective: "wait for plan approval" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "wait for plan approval" });
 
     await expect(
       agents.approveTool({
@@ -79,7 +79,7 @@ describe("approveTool does not leak exit-plan approvals on the non-pending throw
 
   it("does not leak across many distinct non-pending requestIds", async () => {
     const { agents } = createAgentsWithNonPendingDecision();
-    await agents.createAgent({ objective: "wait for plan approval" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "wait for plan approval" });
 
     const ids = ["call_a", "call_b", "call_c", "call_d", "call_e"];
     for (const requestId of ids) {

--- a/runtime/tests/app-server/plan-approval-record.contract.test.ts
+++ b/runtime/tests/app-server/plan-approval-record.contract.test.ts
@@ -69,7 +69,7 @@ describe("approveTool records the exit-plan choice before resolving (contract #2
   it("records an approve+acceptEdits choice BEFORE resolving the decision", async () => {
     const resolveCalls: ResolveCall[] = [];
     const { agents } = createAgents(resolveCalls);
-    await agents.createAgent({ objective: "wait for plan approval" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "wait for plan approval" });
 
     await expect(
       agents.approveTool({
@@ -96,7 +96,7 @@ describe("approveTool records the exit-plan choice before resolving (contract #2
   it("records a revise choice (with feedback) before resolving", async () => {
     const resolveCalls: ResolveCall[] = [];
     const { agents } = createAgents(resolveCalls);
-    await agents.createAgent({ objective: "wait for plan approval" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "wait for plan approval" });
 
     await agents.approveTool({
       sessionId: "session_1",
@@ -113,7 +113,7 @@ describe("approveTool records the exit-plan choice before resolving (contract #2
   it("records nothing when no exitPlan is supplied", async () => {
     const resolveCalls: ResolveCall[] = [];
     const { agents } = createAgents(resolveCalls);
-    await agents.createAgent({ objective: "wait for ordinary approval" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "wait for ordinary approval" });
 
     await agents.approveTool({
       sessionId: "session_1",
@@ -149,7 +149,7 @@ describe("validateToolApproveParams accepts/rejects exitPlan (contract #3)", () 
       sessionManager: sessions,
       runner,
     });
-    await agents.createAgent({ objective: "validate" });
+    await agents.createAgent({ cwd: process.cwd(), objective: "validate" });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: agents });
     const connection = dispatcher.createConnection();
     await connection.dispatch({

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -344,7 +344,7 @@ describe("AgenC daemon protocol surface", () => {
         id: 2,
         method: "agent.create",
         params: {
-          objective: "Inspect daemon status",
+          cwd: process.cwd(), objective: "Inspect daemon status",
           cwd: "/workspace",
           model: "grok-4",
           unattendedAllow: ["FileRead", "Grep"],

--- a/runtime/tests/app-server/workspace-cwd.test.ts
+++ b/runtime/tests/app-server/workspace-cwd.test.ts
@@ -1,0 +1,126 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  requireAbsoluteWorkspaceCwd,
+  resolveClientWorkspaceCwd,
+  WorkspaceCwdError,
+} from "../../src/app-server/workspace-cwd.js";
+import {
+  AgenCDaemonAgentLifecycleError,
+  AgenCDaemonAgentManager,
+} from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { AgenCBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
+
+describe("requireAbsoluteWorkspaceCwd (DAE-02)", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const d = dirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  function tempDir(): string {
+    const d = mkdtempSync(join(tmpdir(), "agenc-cwd-"));
+    dirs.push(d);
+    return d;
+  }
+
+  it("rejects missing, empty, and relative paths", () => {
+    expect(() => requireAbsoluteWorkspaceCwd(undefined, "agent.create")).toThrow(
+      WorkspaceCwdError,
+    );
+    expect(() => requireAbsoluteWorkspaceCwd("", "agent.create")).toThrow(
+      /requires absolute cwd/,
+    );
+    expect(() =>
+      requireAbsoluteWorkspaceCwd("relative/path", "agent.create"),
+    ).toThrow(/must be an absolute path/);
+  });
+
+  it("rejects absolute paths that are not directories", () => {
+    const dir = tempDir();
+    const file = join(dir, "not-a-dir");
+    writeFileSync(file, "x");
+    expect(() => requireAbsoluteWorkspaceCwd(file, "agent.create")).toThrow(
+      /not an existing directory/,
+    );
+  });
+
+  it("accepts an absolute existing directory", () => {
+    const dir = tempDir();
+    expect(requireAbsoluteWorkspaceCwd(dir, "agent.create")).toBe(dir);
+  });
+
+  it("resolveClientWorkspaceCwd uses client process base for relative paths", () => {
+    const dir = tempDir();
+    expect(resolveClientWorkspaceCwd(undefined, dir)).toBe(dir);
+    expect(resolveClientWorkspaceCwd("child", dir)).toBe(join(dir, "child"));
+  });
+});
+
+describe("createAgent/createSession require cwd", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const d = dirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("agent.create fails closed without cwd even when defaultCwd option is set", async () => {
+    const runner: AgenCBackgroundAgentRunner = {
+      startAgent: async () => {
+        throw new Error("startAgent should not run");
+      },
+    };
+    const agents = new AgenCDaemonAgentManager({
+      runner,
+      defaultCwd: () => "/should/not/use",
+    });
+    await expect(
+      agents.createAgent({ objective: "no cwd" } as never),
+    ).rejects.toBeInstanceOf(AgenCDaemonAgentLifecycleError);
+    await expect(
+      agents.createAgent({ objective: "no cwd" } as never),
+    ).rejects.toMatchObject({
+      code: "INVALID_ARGUMENT",
+      message: expect.stringMatching(/requires absolute cwd/i),
+    });
+  });
+
+  it("session.create fails closed without cwd", async () => {
+    const sessions = new AgenCDaemonSessionManager();
+    await expect(sessions.createSession({} as never)).rejects.toMatchObject({
+      code: "INVALID_ARGUMENT",
+      message: expect.stringMatching(/requires absolute cwd/i),
+    });
+  });
+
+  it("agent.create accepts absolute cwd and ignores defaultCwd", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-agent-cwd-"));
+    dirs.push(dir);
+    const runner: AgenCBackgroundAgentRunner = {
+      startAgent: async (params) => ({
+        agentId: "a1",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        cwd: params.cwd,
+      }),
+    };
+    const agents = new AgenCDaemonAgentManager({
+      runner,
+      defaultCwd: () => "/wrong/default",
+    });
+    const created = await agents.createAgent({
+      objective: "with cwd",
+      cwd: dir,
+    });
+    expect(created.cwd).toBe(dir);
+    expect(created.agentId).toBe("a1");
+  });
+});


### PR DESCRIPTION
## Summary

Full DAE-02 fix: the daemon **never invents** a project directory from its own `process.cwd()`.

### Server (hard requirement)
- `agent.create` / `session.create` require a **non-empty absolute path to an existing directory**
- Enforced in lifecycle managers **and** JSON-RPC validation (`requireAbsoluteWorkspaceCwd`)
- Missing/relative/non-directory → `INVALID_ARGUMENT`

### Clients (always send identity)
- CLI `agent start` always sends `resolve(cwd)`
- SDK `spawnAgent` / `createSession` fill absolute client `process.cwd()` when omitted at the API boundary
- Gateway always passes absolute workspace cwd into `spawnAgent`

### Tests
- Unit tests for require/reject paths and create fail-closed without cwd
- Lifecycle/contract suites updated to pass real absolute directories