### PR TITLE
fix(budget): reconcile holds when cron/heartbeat turns throw (GW-06, GW-07)

### DIFF
--- a/docs/design/budget-enforcement.md
+++ b/docs/design/budget-enforcement.md
@@ -94,7 +94,11 @@ A self-contained subsystem, `runtime/src/budget/`, exposing a
   Returns a hold on success, or a typed `BUDGET_EXCEEDED` refusal.
 - **Reconcile** — `reconcile(hold, actualUsage)` replaces the held estimate with
   the real spend and refunds the delta. The real `usage` from the provider
-  response is authoritative (pre-flight estimates drift; §4).
+  response is authoritative (pre-flight estimates drift; §4). After a successful
+  admit, call sites **always** reconcile exactly once (prefer `try`/`finally`):
+  success uses returned usage (or zeros if missing); throw uses zeros → full
+  hold refund. Unknown usage may under-book real spend; it must not leave a
+  sticky worst-case hold (GW-06/07; hooks/cron/heartbeat parity).
 - **Enforcement policy** — on refusal: pause the agent's autonomy
   (`paused` state), emit a notification once, and surface the typed error; the
   operator raises the cap or resets to resume. Crossing the soft threshold

--- a/runtime/src/gateway/cron-delivery.ts
+++ b/runtime/src/gateway/cron-delivery.ts
@@ -239,46 +239,50 @@ export function startCronDelivery(
       return;
     }
 
-    // Frame scheduled prompts as untrusted work data (parity with hooks/channels, todo-126).
-    const framedPrompt = frameChannelMessage({
-      channelId: "cron",
-      peerId: `cron:${task.id}`,
-      text: task.prompt,
-    });
-    const result = await router.runTurn({
-      key: SessionRouter.conversationKey({
+    // GW-06: after successful admit, exactly one reconcile in `finally`
+    // (success → real/zero usage; throw → zeros refund the worst-case hold).
+    // try starts immediately so no post-admit path can skip reconcile.
+    let usage = { inputTokens: 0, outputTokens: 0 };
+    try {
+      // Frame scheduled prompts as untrusted work data (parity with hooks/channels, todo-126).
+      const framedPrompt = frameChannelMessage({
         channelId: "cron",
-        agent: "default",
-        conversationId: task.id,
-      }),
-      text: framedPrompt,
-      adapter: routeAdapter,
-      conversationId,
-      // Autonomous, no human watching → deny permission requests (fail safe).
-      onPermissionRequest: async () => ({
-        behavior: "deny",
-        reason: "cron delivery turns do not grant tool permissions",
-      }),
-    });
+        peerId: `cron:${task.id}`,
+        text: task.prompt,
+      });
+      const result = await router.runTurn({
+        key: SessionRouter.conversationKey({
+          channelId: "cron",
+          agent: "default",
+          conversationId: task.id,
+        }),
+        text: framedPrompt,
+        adapter: routeAdapter,
+        conversationId,
+        // Autonomous, no human watching → deny permission requests (fail safe).
+        onPermissionRequest: async () => ({
+          behavior: "deny",
+          reason: "cron delivery turns do not grant tool permissions",
+        }),
+      });
+      usage = result.usage ?? usage;
 
-    enforcer.reconcile(
-      admit.hold,
-      result.usage ?? { inputTokens: 0, outputTokens: 0 },
-    );
-
-    if (deliver.webhook !== undefined) {
-      await postWebhook(deliver.webhook, {
-        taskId: task.id,
-        cron: task.cron,
-        prompt: task.prompt,
-        finalMessage: result.finalMessage,
-        stopReason: result.stopReason,
-        firedAt: clock.now().toISOString(),
-      }).catch((error: unknown) =>
-        log(`cron: webhook POST failed for task ${task.id}: ${String(error)}`),
-      );
+      if (deliver.webhook !== undefined) {
+        await postWebhook(deliver.webhook, {
+          taskId: task.id,
+          cron: task.cron,
+          prompt: task.prompt,
+          finalMessage: result.finalMessage,
+          stopReason: result.stopReason,
+          firedAt: clock.now().toISOString(),
+        }).catch((error: unknown) =>
+          log(`cron: webhook POST failed for task ${task.id}: ${String(error)}`),
+        );
+      }
+      log(`cron: task ${task.id} delivered (${result.stopReason})`);
+    } finally {
+      enforcer.reconcile(admit.hold, usage);
     }
-    log(`cron: task ${task.id} delivered (${result.stopReason})`);
   };
 
   const tick = async (): Promise<void> => {

--- a/runtime/tests/gateway/cron-delivery.test.ts
+++ b/runtime/tests/gateway/cron-delivery.test.ts
@@ -30,6 +30,7 @@ import {
   normalizeDelivery,
 } from "../../src/utils/cronTasks.js";
 import type { AgenCConfig } from "../../src/config/schema.js";
+import { BudgetLedger } from "../../src/budget/ledger.js";
 
 class EchoSession implements GatewaySession {
   readonly sessionId: string;
@@ -59,6 +60,8 @@ class RecordingClient implements GatewayDaemonClient {
   labels: (string | undefined)[] = [];
   readonly sessions: EchoSession[] = [];
   readonly reply: string;
+  /** When set, createSession returns a session whose prompt() throws (GW-06). */
+  throwOnPrompt: Error | null = null;
   constructor(reply = "cron result") {
     this.reply = reply;
   }
@@ -67,6 +70,17 @@ class RecordingClient implements GatewayDaemonClient {
   ): Promise<GatewaySession> {
     this.created += 1;
     this.labels.push(options?.label);
+    if (this.throwOnPrompt !== null) {
+      const err = this.throwOnPrompt;
+      return {
+        sessionId: `cron-sess-throw-${this.created}`,
+        prompt: async (text: string) => {
+          // Prove the turn path was entered before fail.
+          (this as { lastPrompt?: string }).lastPrompt = text;
+          throw err;
+        },
+      } as GatewaySession;
+    }
     const s = new EchoSession(`cron-sess-${this.created}`, this.reply);
     this.sessions.push(s);
     return s;
@@ -328,6 +342,42 @@ describe("startCronDelivery", () => {
     expect(client.created).toBe(0);
     const last = mem.lastText("ops") ?? "";
     expect(last).toContain("paused");
+    await handle.stop();
+  });
+
+  test("GW-06: turn throw refunds hold (ledger tokens/usd back to 0)", async () => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "cronch-throw",
+        cron: "* * * * *",
+        prompt: "will explode",
+        createdAt: startMs - 1_000,
+        recurring: true,
+        deliver: { channel: "mem", to: "ops" },
+      },
+    ]);
+    const client = new RecordingClient("unused");
+    client.throwOnPrompt = new Error("turn exploded");
+    const mem = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+    // Cap high enough that admit succeeds (hold is estInput + 2048 tokens).
+    const handle = startCronDelivery({
+      ...baseOptions(client, mem),
+      config: {
+        budget: { enabled: true, daily_tokens: 1_000_000 },
+      } as unknown as AgenCConfig,
+      clock,
+    });
+
+    await advance(90_000);
+    // Turn path was entered (session created / prompt attempted).
+    expect(client.created).toBeGreaterThan(0);
+    // Hold must be fully refunded after throw (zeros reconcile).
+    const ledger = new BudgetLedger({ agencHome: home });
+    const snap = ledger.snapshot("cron:cronch-throw");
+    expect(snap.day.tokens).toBe(0);
+    expect(snap.day.usd).toBe(0);
     await handle.stop();
   });
 

--- a/runtime/tests/heartbeat/heartbeat.test.ts
+++ b/runtime/tests/heartbeat/heartbeat.test.ts
@@ -86,18 +86,23 @@ describe("WorkspaceHeartbeatFileReader", () => {
 class FakeRunner implements HeartbeatTurnRunner {
   reply = HEARTBEAT_OK;
   usage: HeartbeatUsage = { inputTokens: 500, outputTokens: 100 };
+  /** When set, run() throws after recording the prompt (GW-07). */
+  throwOnRun: Error | null = null;
   readonly prompts: string[] = [];
   readonly models: (string | undefined)[] = [];
   async run(prompt: string, model: string | undefined) {
     this.prompts.push(prompt);
     this.models.push(model);
+    if (this.throwOnRun !== null) throw this.throwOnRun;
     return { finalMessage: this.reply, usage: this.usage };
   }
 }
 
 class FakeDelivery implements HeartbeatDelivery {
   readonly sent: { target: unknown; text: string }[] = [];
+  throwOnDeliver: Error | null = null;
   async deliver(target: unknown, text: string) {
+    if (this.throwOnDeliver !== null) throw this.throwOnDeliver;
     this.sent.push({ target, text });
   }
 }
@@ -227,6 +232,45 @@ describe("HeartbeatRunner turn + budget wire-in", () => {
     expect(runner.prompts).toHaveLength(0); // turn never ran (no silent spend)
     expect(delivery.sent).toHaveLength(1);
     expect(delivery.sent[0].text).toContain("heartbeat paused");
+    expect(budget.reconciles).toHaveLength(0); // no admit hold to reconcile
+  });
+
+  test("GW-07: turn throw still reconciles hold once with zeros", async () => {
+    const budget = new FakeBudget();
+    const runner = new FakeRunner();
+    runner.throwOnRun = new Error("turn exploded");
+    const { hb } = makeRunner({}, { budget, runner });
+    const outcome = await hb.tick();
+    expect(outcome).toMatchObject({ kind: "error", message: expect.stringContaining("turn exploded") });
+    expect(budget.admits).toBe(1);
+    expect(budget.reconciles).toHaveLength(1);
+    expect(budget.reconciles[0]).toEqual({ inputTokens: 0, outputTokens: 0 });
+    expect(runner.prompts).toHaveLength(1); // turn was entered
+  });
+
+  test("GW-07: success still reconciles exactly once with real usage", async () => {
+    const budget = new FakeBudget();
+    const { hb, runner } = makeRunner({}, { budget });
+    runner.reply = HEARTBEAT_OK;
+    await hb.tick();
+    expect(budget.admits).toBe(1);
+    expect(budget.reconciles).toHaveLength(1);
+    expect(budget.reconciles[0]).toEqual({ inputTokens: 500, outputTokens: 100 });
+  });
+
+  test("GW-07: deliver throw after successful turn reconciles real usage", async () => {
+    const budget = new FakeBudget();
+    const delivery = new FakeDelivery();
+    delivery.throwOnDeliver = new Error("channel down");
+    const runner = new FakeRunner();
+    runner.reply = "something needs attention";
+    runner.usage = { inputTokens: 42, outputTokens: 7 };
+    const { hb } = makeRunner({}, { budget, runner, delivery });
+    const outcome = await hb.tick();
+    expect(outcome).toMatchObject({ kind: "error", message: expect.stringContaining("channel down") });
+    expect(budget.admits).toBe(1);
+    expect(budget.reconciles).toHaveLength(1);
+    expect(budget.reconciles[0]).toEqual({ inputTokens: 42, outputTokens: 7 });
   });
 
   test("the utility model flows through to the turn runner", async () => {


### PR DESCRIPTION
## Summary

After a successful budget **admit**, cron and heartbeat always **reconcile exactly once** in `try`/`finally` (hooks already did this).

- **Turn throw:** reconcile with zero usage → full hold refund (no sticky worst-case debit)
- **Success:** reconcile with real usage (or zeros if missing)
- **Deliver throw after success (heartbeat):** still real usage (captured before deliver)
- **Exclusive finally:** no double-reconcile (enforcer is not idempotent)

## Tests
- Heartbeat: throw → zeros; success → one reconcile; deliver-throw → real usage
- Cron: throw with budget on → ledger `cron:<id>` tokens/usd = 0; session entered
- Revert-sensitive: removing finally reconcile fails GW-07 tests

## Out of scope
GW-04 atomic admit, GW-05 lock timeout