### PR TITLE
fix(tui): trust prompt freezes on 'Accepting…' and never advances

### DIFF
--- a/runtime/src/bin/tui-trust-prompt.tsx
+++ b/runtime/src/bin/tui-trust-prompt.tsx
@@ -45,7 +45,16 @@ export async function renderProjectTrustPrompt(
       riskSources={options.riskSources}
       bypassPermissionsRequested={options.bypassPermissionsRequested}
       finish={(value) => {
-        settle?.(value);
+        // Defer the resolve to the next macrotask. `finish` is called from
+        // inside TrustDialog's in-flight `await onAccept()` handler; resolving
+        // synchronously lets the outer race below unmount the ink tree while
+        // that handler (and React's pending state commit) is still on the
+        // stack, which intermittently deadlocked the render and left the
+        // dialog frozen on "Accepting…". Deferring lets the dialog's submit
+        // fully unwind before we tear the instance down.
+        setImmediate(() => {
+          settle?.(value);
+        });
       }}
     />,
     {


### PR DESCRIPTION
The first-run trust prompt intermittently froze on `✓ Accepting…` and never reached the onboarding wizard. Root cause (pre-existing, exposed by the richer dialog render): `renderProjectTrustPrompt` resolves its accept promise synchronously from inside TrustDialog's in-flight `await onAccept()`, so the ink instance is unmounted mid-handler before React commits the pending-state update — racing the reconciler into a deadlock that left the dialog frozen. Fix: defer the resolve by one macrotask (`setImmediate`) so submit + the React commit unwind before the outer race tears the instance down. Verified: PTY stress test 8/8 accept transitions to the step screen + reject exits cleanly; TrustDialog render/unit + tui-trust-prompt 10/10; tsc clean.