### PR TITLE
Revert #1480 — the 'Accepting…' freeze was a daemon socket-path issue, not the dialog

### DIFF
--- a/runtime/src/bin/tui-trust-prompt.tsx
+++ b/runtime/src/bin/tui-trust-prompt.tsx
@@ -45,16 +45,7 @@ export async function renderProjectTrustPrompt(
       riskSources={options.riskSources}
       bypassPermissionsRequested={options.bypassPermissionsRequested}
       finish={(value) => {
-        // Defer the resolve to the next macrotask. `finish` is called from
-        // inside TrustDialog's in-flight `await onAccept()` handler; resolving
-        // synchronously lets the outer race below unmount the ink tree while
-        // that handler (and React's pending state commit) is still on the
-        // stack, which intermittently deadlocked the render and left the
-        // dialog frozen on "Accepting…". Deferring lets the dialog's submit
-        // fully unwind before we tear the instance down.
-        setImmediate(() => {
-          settle?.(value);
-        });
+        settle?.(value);
       }}
     />,
     {


### PR DESCRIPTION
#1480 claimed to fix the trust prompt freezing on 'Accepting…' via a setImmediate deferral. That diagnosis was wrong: the trust dialog resolves and unmounts fine. The real cause is that the daemon's Unix socket (`$AGENC_HOME/daemon.sock`) exceeds the macOS ~104-char sun_path limit when AGENC_HOME is a long path, so the daemon fails with `listen EINVAL` and the post-trust TUI boot (`createTuiContext`) hangs waiting for it — nothing to do with the dialog. Reproduced: a short AGENC_HOME reaches the onboarding wizard; a long one hangs after accept with a daemon `EINVAL` on stderr. This reverts the misleading change; the flow works with a normal-length home. Follow-up worth doing separately: surface a clear error when the daemon fails to bind instead of hanging the boot.