### PR TITLE
fix(budget): hooks exclusive finally + reconcile contract + HB ledger

### DIFF
--- a/docs/design/budget-enforcement.md
+++ b/docs/design/budget-enforcement.md
@@ -95,10 +95,11 @@ A self-contained subsystem, `runtime/src/budget/`, exposing a
 - **Reconcile** — `reconcile(hold, actualUsage)` replaces the held estimate with
   the real spend and refunds the delta. The real `usage` from the provider
   response is authoritative (pre-flight estimates drift; §4). After a successful
-  admit, call sites **always** reconcile exactly once (prefer `try`/`finally`):
+  admit, call sites **always** reconcile exactly once via exclusive
+  `try`/`finally` on **hooks, cron, and heartbeat**:
   success uses returned usage (or zeros if missing); throw uses zeros → full
   hold refund. Unknown usage may under-book real spend; it must not leave a
-  sticky worst-case hold (GW-06/07; hooks/cron/heartbeat parity).
+  sticky worst-case hold. `reconcile` is **not** idempotent — call once only.
 - **Enforcement policy** — on refusal: pause the agent's autonomy
   (`paused` state), emit a notification once, and surface the typed error; the
   operator raises the cap or resets to resume. Crossing the soft threshold

--- a/runtime/src/budget/enforcer.ts
+++ b/runtime/src/budget/enforcer.ts
@@ -202,8 +202,12 @@ export class BudgetEnforcer {
 
   /**
    * Replace a hold's worst-case estimate with the real usage and refund the
-   * delta, then fire a one-shot soft warning if a window crossed the soft
-   * threshold. Idempotent per hold (call exactly once per admitted call).
+   * delta (ledger applies `actual − estimated`), then fire a one-shot soft
+   * warning if a window crossed the soft threshold.
+   *
+   * **Not idempotent:** each call applies another `(actual − estimated)`
+   * delta. Call **exactly once** per successful admit (prefer exclusive
+   * `try`/`finally`). Zero holds (budget disabled / out of scope) are a no-op.
    */
   reconcile(hold: BudgetHold, usage: BudgetUsage): void {
     if (hold.estimatedTokens === 0 && hold.estimatedUsd === 0) {

--- a/runtime/src/gateway/hooks.ts
+++ b/runtime/src/gateway/hooks.ts
@@ -299,56 +299,47 @@ export class HooksServer {
       return;
     }
 
-    // The payload is untrusted work data — sanitize + frame (task 11)
-    // before it reaches session.prompt, exactly like channel text.
-    const framedText = frameChannelMessage({
-      channelId: HOOKS_CHANNEL_ID,
-      peerId: `hook:${parsed.name}`,
-      text: parsed.message,
-    });
-    const key = SessionRouter.conversationKey({
-      channelId: HOOKS_CHANNEL_ID,
-      agent: parsed.agent,
-      conversationId: parsed.sessionKey,
-    });
-
-    const runTurn = () =>
-      this.#router.runTurn({
-        key,
-        text: framedText,
-        adapter: deliverAdapter ?? NULL_ADAPTER,
-        conversationId: parsed.deliver?.to ?? parsed.sessionKey,
-        // Autonomous, nobody watching → deny permission requests (fail safe).
-        onPermissionRequest: async () => ({
-          behavior: "deny",
-          reason: "hook turns do not grant tool permissions",
-        }),
-      });
-
-    if (deliverAdapter !== undefined) {
-      // Fire-and-deliver: acknowledge now, stream the turn to the channel.
-      this.#json(res, 202, { ok: true, sessionKey: parsed.sessionKey });
-      try {
-        const result = await runTurn();
-        this.#enforcer.reconcile(
-          admit.hold,
-          result.usage ?? { inputTokens: 0, outputTokens: 0 },
-        );
-        this.#log(`hooks: '${parsed.name}' delivered (${result.stopReason})`);
-      } catch (error) {
-        this.#enforcer.reconcile(admit.hold, { inputTokens: 0, outputTokens: 0 });
-        this.#log(`hooks: '${parsed.name}' turn failed: ${String(error)}`);
-      }
-      return;
-    }
-
-    // Synchronous mode: the caller wants the answer in the response.
+    // After successful admit: exactly one reconcile in `finally` (parity with
+    // cron/heartbeat). All post-admit work lives inside try so framing /
+    // turn / response throws cannot leave a sticky hold or double-refund.
+    let usage = { inputTokens: 0, outputTokens: 0 };
     try {
+      // Untrusted work data: sanitize + frame (task 11) before session.prompt.
+      const framedText = frameChannelMessage({
+        channelId: HOOKS_CHANNEL_ID,
+        peerId: `hook:${parsed.name}`,
+        text: parsed.message,
+      });
+      const key = SessionRouter.conversationKey({
+        channelId: HOOKS_CHANNEL_ID,
+        agent: parsed.agent,
+        conversationId: parsed.sessionKey,
+      });
+      const runTurn = () =>
+        this.#router.runTurn({
+          key,
+          text: framedText,
+          adapter: deliverAdapter ?? NULL_ADAPTER,
+          conversationId: parsed.deliver?.to ?? parsed.sessionKey,
+          // Autonomous, nobody watching → deny permission requests (fail safe).
+          onPermissionRequest: async () => ({
+            behavior: "deny",
+            reason: "hook turns do not grant tool permissions",
+          }),
+        });
+
+      if (deliverAdapter !== undefined) {
+        // Fire-and-deliver: 202 first, then await the turn (finally after).
+        this.#json(res, 202, { ok: true, sessionKey: parsed.sessionKey });
+        const result = await runTurn();
+        usage = result.usage ?? usage;
+        this.#log(`hooks: '${parsed.name}' delivered (${result.stopReason})`);
+        return;
+      }
+
+      // Synchronous mode: wait for the turn, then respond.
       const result = await runTurn();
-      this.#enforcer.reconcile(
-        admit.hold,
-        result.usage ?? { inputTokens: 0, outputTokens: 0 },
-      );
+      usage = result.usage ?? usage;
       this.#json(res, 200, {
         ok: true,
         sessionKey: parsed.sessionKey,
@@ -356,8 +347,14 @@ export class HooksServer {
         stopReason: result.stopReason,
       });
     } catch (error) {
-      this.#enforcer.reconcile(admit.hold, { inputTokens: 0, outputTokens: 0 });
-      this.#json(res, 500, { error: `turn failed: ${String(error)}` });
+      // Do not reconcile here — exclusive finally owns money accounting.
+      if (!res.headersSent) {
+        this.#json(res, 500, { error: `turn failed: ${String(error)}` });
+      } else {
+        this.#log(`hooks: '${parsed.name}' turn failed: ${String(error)}`);
+      }
+    } finally {
+      this.#enforcer.reconcile(admit.hold, usage);
     }
   }
 

--- a/runtime/src/heartbeat/wire.ts
+++ b/runtime/src/heartbeat/wire.ts
@@ -61,7 +61,7 @@ export interface StartHeartbeatOptions {
 }
 
 /** Adapt the task-15 BudgetEnforcer to the heartbeat's budget-gate seam. */
-function budgetGate(
+export function budgetGate(
   enforcer: BudgetEnforcer,
 ): HeartbeatBudgetGate {
   return {

--- a/runtime/tests/budget/budget.test.ts
+++ b/runtime/tests/budget/budget.test.ts
@@ -193,6 +193,22 @@ describe("BudgetEnforcer", () => {
     if (r.ok) expect(r.hold.estimatedUsd).toBe(0);
   });
 
+  test("reconcile is NOT idempotent: second call over-refunds the hold", () => {
+    const enf = make({ caps: { dailyTokens: 1_000_000 } });
+    // Token-only path: unpriced model still holds est tokens.
+    const r = enf.admit(
+      autoReq({ model: "unpriced", estInputTokens: 100, maxOutputTokens: 100 }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(sharedLedger.snapshot("a1").day.tokens).toBe(200);
+    enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
+    expect(sharedLedger.snapshot("a1").day.tokens).toBe(0);
+    // Second call applies (0 − 200) again → negative residual (footgun).
+    enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
+    expect(sharedLedger.snapshot("a1").day.tokens).toBe(-200);
+  });
+
   test("admit debits worst-case; reconcile refunds the delta to actual", () => {
     const enf = make({ caps: { dailyUsd: 100 } });
     // worst-case for 1000 in + 1000 out at $1/$3 per M = 0.001 + 0.003 = $0.004

--- a/runtime/tests/gateway/hooks.test.ts
+++ b/runtime/tests/gateway/hooks.test.ts
@@ -25,6 +25,7 @@ import type {
   GatewaySessionCreateOptions,
 } from "../../src/gateway/types.js";
 import type { AgenCConfig } from "../../src/config/schema.js";
+import { BudgetLedger } from "../../src/budget/ledger.js";
 
 const TOKEN = "hooks-test-token-0123456789";
 
@@ -52,11 +53,22 @@ class EchoSession implements GatewaySession {
 class FakeClient implements GatewayDaemonClient {
   readonly sessions: EchoSession[] = [];
   readonly labels: (string | undefined)[] = [];
+  /** When set, createSession returns a session whose prompt throws. */
+  throwOnPrompt: Error | null = null;
   #n = 0;
   async createSession(
     options?: GatewaySessionCreateOptions,
   ): Promise<GatewaySession> {
     this.labels.push(options?.label);
+    if (this.throwOnPrompt !== null) {
+      const err = this.throwOnPrompt;
+      return {
+        sessionId: `s-throw-${++this.#n}`,
+        prompt: async () => {
+          throw err;
+        },
+      } as GatewaySession;
+    }
     const s = new EchoSession(`s${++this.#n}`);
     this.sessions.push(s);
     return s;
@@ -240,6 +252,22 @@ describe("HooksServer", () => {
       "budget",
     );
     expect(client.sessions).toHaveLength(0);
+  });
+
+  test("turn throw refunds hold (ledger tokens/usd 0) with exclusive finally", async () => {
+    client.throwOnPrompt = new Error("turn exploded");
+    const url = await startServer({
+      config: {
+        budget: { enabled: true, daily_tokens: 1_000_000 },
+      } as unknown as AgenCConfig,
+    });
+    const res = await post(url, { message: "will explode", name: "ci" });
+    expect(res.status).toBe(500);
+    // Hold fully refunded after throw (zeros reconcile in finally).
+    const ledger = new BudgetLedger({ agencHome: home });
+    const snap = ledger.snapshot("hook:ci");
+    expect(snap.day.tokens).toBe(0);
+    expect(snap.day.usd).toBe(0);
   });
 
   test("non-loopback host is refused without allowNonLoopback", () => {

--- a/runtime/tests/heartbeat/heartbeat.test.ts
+++ b/runtime/tests/heartbeat/heartbeat.test.ts
@@ -25,6 +25,9 @@ import {
   type HeartbeatTurnRunner,
   type HeartbeatUsage,
 } from "../../src/heartbeat/types.js";
+import { BudgetEnforcer } from "../../src/budget/enforcer.js";
+import { BudgetLedger } from "../../src/budget/ledger.js";
+import { budgetGate } from "../../src/heartbeat/wire.js";
 
 // ---- config ---------------------------------------------------------------
 
@@ -156,7 +159,7 @@ function makeRunner(
     runner?: FakeRunner;
     delivery?: FakeDelivery;
     file?: FakeFile;
-    budget?: FakeBudget;
+    budget?: HeartbeatBudgetGate;
     isCronRunning?: () => boolean;
   } = {},
 ) {
@@ -271,6 +274,35 @@ describe("HeartbeatRunner turn + budget wire-in", () => {
     expect(budget.admits).toBe(1);
     expect(budget.reconciles).toHaveLength(1);
     expect(budget.reconciles[0]).toEqual({ inputTokens: 42, outputTokens: 7 });
+  });
+
+  test("GW-07 ledger: turn throw refunds hold on real BudgetEnforcer+Ledger", async () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-hb-ledger-"));
+    try {
+      const ledger = new BudgetLedger({ agencHome: home });
+      const enforcer = new BudgetEnforcer({
+        policy: {
+          enabled: true,
+          softThreshold: 0.8,
+          enforceInteractive: false,
+          caps: { dailyTokens: 1_000_000 },
+        },
+        ledger,
+        priceOf: () => null,
+      });
+      const budget = budgetGate(enforcer);
+      const runner = new FakeRunner();
+      runner.throwOnRun = new Error("turn exploded");
+      const { hb } = makeRunner({ agentId: "hb-ledger" }, { budget, runner });
+      const outcome = await hb.tick();
+      expect(outcome).toMatchObject({ kind: "error" });
+      // Re-open ledger to prove disk conservation (same as cron GW-06 test).
+      const snap = new BudgetLedger({ agencHome: home }).snapshot("hb-ledger");
+      expect(snap.day.tokens).toBe(0);
+      expect(snap.day.usd).toBe(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test("the utility model flows through to the turn runner", async () => {


### PR DESCRIPTION
## Summary

Closes the three residual items after GW-06/07 (verified independently, then fixed properly):

1. **Hooks** — exclusive `try`/`finally` after admit (parity with cron/heartbeat). Framing + turn inside try; no dual success/catch reconcile. Ledger oracle: turn throw → `hook:ci` tokens/usd 0.
2. **Enforcer** — JSDoc corrected (**not** idempotent); unit test proves second reconcile over-refunds (−est).
3. **Heartbeat** — real `BudgetEnforcer`+`BudgetLedger` via exported `budgetGate`; throw → day tokens/usd 0.

## Senior gate
Staff review: **APPROVE** (no BLOCKER/HIGH). Residuals fixed structurally, not surface-only.

## Test plan
- [x] `vitest` budget + hooks + heartbeat
- [x] Pre-commit TUI startup smoke
- [x] Senior read-only review APPROVE