### PR TITLE
fix(onboarding): theme selection had no effect — apply it live and persist

### DIFF
--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -47,6 +47,8 @@ import {
 import { Box } from "../tui/ink.js";
 import ThemedBox from "../tui/components/design-system/ThemedBox.js";
 import ThemedText from "../tui/components/design-system/ThemedText.js";
+import { useTheme } from "../tui/components/design-system/ThemeProvider.js";
+import type { ThemeSetting } from "../utils/theme.js";
 import { TerminalSizeContext } from "../tui/ink/components/TerminalSizeContext.js";
 import { WelcomeV2 } from "./WelcomeV2.js";
 import {
@@ -180,6 +182,20 @@ const STEP_TITLES: Readonly<Record<FirstRunOnboardingStepId, string>> =
   });
 
 const THEME_CHOICES = Object.freeze(["dark", "light", "system"] as const);
+
+/**
+ * Map a wizard theme choice to the config `ThemeSetting` the ThemeProvider
+ * consumes. The wizard says "system"; the theme engine calls that "auto".
+ * Returns undefined for anything unknown so callers can no-op safely.
+ */
+export function wizardThemeToSetting(
+  choice: string,
+): ThemeSetting | undefined {
+  if (choice === "dark") return "dark";
+  if (choice === "light") return "light";
+  if (choice === "system") return "auto";
+  return undefined;
+}
 const LOCAL_PROVIDERS = new Set<BuiltInProviderSlug>([
   "ollama",
   "lmstudio",
@@ -1402,6 +1418,26 @@ export function Onboarding({
   currentStep,
   context,
 }: OnboardingProps): React.ReactElement {
+  // Apply the theme choice LIVE (and persist it — the provider's setter saves
+  // to global config). Selecting "light" previously only landed in
+  // onboarding.json, which nothing reads for rendering, so the session stayed
+  // dark and the choice silently evaporated. The seed value on mount is
+  // deliberately NOT applied: re-running the wizard must not overwrite the
+  // user's configured theme until they actually change the selection.
+  const [, setThemeSetting] = useTheme();
+  const appliedThemeRef = useRef<string | null>(null);
+  useEffect(() => {
+    const mapped = wizardThemeToSetting(state.selectedTheme);
+    if (mapped === undefined) return;
+    if (appliedThemeRef.current === null) {
+      appliedThemeRef.current = state.selectedTheme;
+      return;
+    }
+    if (appliedThemeRef.current === state.selectedTheme) return;
+    appliedThemeRef.current = state.selectedTheme;
+    setThemeSetting?.(mapped);
+  }, [state.selectedTheme, setThemeSetting]);
+
   const terminalSize = useContext(TerminalSizeContext);
   const columns =
     terminalSize && Number.isFinite(terminalSize.columns)

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -24,6 +24,7 @@ import {
   detectRunningLocalProviders,
   detailLinesForStep,
   submitFirstRunOnboardingInput,
+  wizardThemeToSetting,
 } from "./Onboarding.js";
 import {
   incrementFirstRunOnboardingSeenCount,
@@ -1091,5 +1092,18 @@ describe("first-magic wiring contract (O-1b)", () => {
     expect(source).toContain("guaranteed first magic");
     expect(source).toContain("onboardingWasActiveRef");
     expect(source).toContain("Introduce yourself in a sentence");
+  });
+});
+
+describe("wizard theme mapping", () => {
+  test("maps wizard choices to config ThemeSettings the provider consumes", () => {
+    // The theme step's choice must reach the live theme engine: "system" is
+    // the wizard's word for the engine's "auto"; unknown values no-op so a
+    // stale onboarding state can never corrupt the configured theme.
+    expect(wizardThemeToSetting("dark")).toBe("dark");
+    expect(wizardThemeToSetting("light")).toBe("light");
+    expect(wizardThemeToSetting("system")).toBe("auto");
+    expect(wizardThemeToSetting("neon")).toBeUndefined();
+    expect(wizardThemeToSetting("")).toBeUndefined();
   });
 });


### PR DESCRIPTION
Picking a theme in the setup wizard did nothing: `selectedTheme` only landed in `onboarding.json`, which nothing reads for rendering — the ThemeProvider reads the global config `theme` key (default dark), so the session stayed dark. Provider/model were applied on completion; theme never was. Fix: the Onboarding component applies selection changes through `useTheme()`'s setter — instant visual feedback plus persistence via the provider's `onThemeSave → saveGlobalConfig`. Wizard 'system' maps to engine 'auto' (`wizardThemeToSetting`, exported + unit-tested; unknown values no-op). The mount seed is not applied, so re-running the wizard can't clobber a configured theme until the user changes the selection. Gate: tsc clean; onboarding + onboard-cli 91/91.