### PR TITLE
polish(onboarding): terminal-background-aware tip on the theme step

### DIFF
--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -48,6 +48,7 @@ import { Box } from "../tui/ink.js";
 import ThemedBox from "../tui/components/design-system/ThemedBox.js";
 import ThemedText from "../tui/components/design-system/ThemedText.js";
 import { useTheme } from "../tui/components/design-system/ThemeProvider.js";
+import { getSystemThemeName } from "../utils/systemTheme.js";
 import type { ThemeSetting } from "../utils/theme.js";
 import { TerminalSizeContext } from "../tui/ink/components/TerminalSizeContext.js";
 import { WelcomeV2 } from "./WelcomeV2.js";
@@ -1255,13 +1256,23 @@ export function detailLinesForStep(
         "Onboarding input only. Use /exit, Ctrl-C twice, or Ctrl-D twice to leave.",
         "Type next to continue.",
       ];
-    case "theme":
+    case "theme": {
+      // The TUI colours text but does NOT repaint the terminal's own
+      // background, so a light theme on a dark terminal (or vice versa) reads
+      // as grey-on-black. The terminal background is already detected for the
+      // 'auto' mode (COLORFGBG seed + OSC 11 watcher) — surface it here so the
+      // user picks with that context instead of discovering the mismatch.
+      const terminalBackground = getSystemThemeName();
+      const readable =
+        terminalBackground === "light" ? '"light" or "system"' : '"dark" or "system"';
       return [
         ...THEME_CHOICES.map((theme, index) =>
           `${index + 1}. ${theme}${theme === state.selectedTheme ? " (current)" : ""}`
         ),
+        `Tip: your terminal background looks ${terminalBackground} — ${readable} will read best here.`,
         "Type a number or theme name.",
       ];
+    }
     case "provider": {
       const detected = new Set(state.detectedLocalProviders);
       return [

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -1107,3 +1107,23 @@ describe("wizard theme mapping", () => {
     expect(wizardThemeToSetting("")).toBeUndefined();
   });
 });
+
+describe("theme step terminal-background awareness", () => {
+  test("tells the user which themes read well on the detected terminal background", async () => {
+    const { setCachedSystemTheme } = await import("../utils/systemTheme.js");
+    const config = defaultConfig();
+    const context = { config, env: {}, checkLocalProviders: false };
+    let state = createInitialFirstRunOnboardingState(context);
+    state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
+
+    setCachedSystemTheme("dark");
+    const darkLines = detailLinesForStep(state, context).join("\n");
+    expect(darkLines).toContain("your terminal background looks dark");
+    expect(darkLines).toContain('"dark" or "system" will read best');
+
+    setCachedSystemTheme("light");
+    const lightLines = detailLinesForStep(state, context).join("\n");
+    expect(lightLines).toContain("your terminal background looks light");
+    expect(lightLines).toContain('"light" or "system" will read best');
+  });
+});


### PR DESCRIPTION
Follow-up to #1484 (live theme apply): the TUI doesn't repaint the terminal's background, so light-on-a-dark-terminal reads grey-on-black. The wizard now surfaces the already-detected terminal background (COLORFGBG + OSC 11 machinery used by 'auto') as a tip on the theme step — `Tip: your terminal background looks dark — \"dark\" or \"system\" will read best here.` — adapting to the detected background. Choice strings unchanged (test contract); tip renders in the hint tone. With the live preview from #1484, a mismatched pick is forewarned and instantly visible/reversible. Gate: tsc clean; pinned-background tests for both variants; onboarding + onboard-cli 92/92.