### PR TITLE
fix(tui): coalesce streaming deltas to stop the transcript OOM (#1468)

### DIFF
--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -2617,7 +2617,8 @@ interface TranscriptState {
 
 type TranscriptAction =
   | { readonly kind: "reset"; readonly events: readonly SessionTranscriptEvent[] }
-  | { readonly kind: "append"; readonly event: SessionTranscriptEvent };
+  | { readonly kind: "append"; readonly event: SessionTranscriptEvent }
+  | { readonly kind: "appendBatch"; readonly events: readonly SessionTranscriptEvent[] };
 
 /**
  * Fields on raw transcript events that carry tool-result content. These are the
@@ -2778,6 +2779,42 @@ function reducer(state: TranscriptState, action: TranscriptAction): TranscriptSt
         maxSeq: seq === null ? state.maxSeq : maxEventSeq(state.maxSeq, action.event),
       };
     }
+    case "appendBatch": {
+      // Apply a whole coalesced batch of events with ONE array copy and ONE
+      // re-projection (the caller flushes buffered streaming deltas here). Doing
+      // this per-event would be O(n) copy + O(n) projection PER delta — i.e.
+      // O(n²) allocation across a streaming turn, which starved the GC and OOM'd
+      // the TUI on long responses. A reset or an out-of-order event in the batch
+      // is rare and falls back to a full rebuild for correctness.
+      if (action.events.length === 0) return state;
+      if (
+        action.events.some(
+          (event) =>
+            isTranscriptResetEvent(event) ||
+            (() => {
+              const seq = eventSeq(event);
+              return seq !== null && state.maxSeq !== null && seq < state.maxSeq;
+            })(),
+        )
+      ) {
+        return buildTranscriptState([...state.events, ...action.events]);
+      }
+      const keys = state.keys as Set<string>;
+      const pending: SessionTranscriptEvent[] = [];
+      let maxSeq = state.maxSeq;
+      for (const event of action.events) {
+        const key = eventKey(event);
+        if (keys.has(key)) continue;
+        pending.push(clampEventForStorage(event));
+        keys.add(key);
+        const seq = eventSeq(event);
+        maxSeq = seq === null ? maxSeq : maxEventSeq(maxSeq, event);
+      }
+      if (pending.length === 0) return state;
+      const events = [...state.events, ...pending];
+      evictOldestEvents(events, keys);
+      return { events, keys, maxSeq };
+    }
   }
 }
 
@@ -2797,10 +2834,49 @@ export function appendSessionTranscriptEventForTesting(
   return reducer(state, { kind: "append", event });
 }
 
+export function appendSessionTranscriptBatchForTesting(
+  state: TranscriptState,
+  events: readonly SessionTranscriptEvent[],
+): TranscriptState {
+  return reducer(state, { kind: "appendBatch", events });
+}
+
 function initialEvents(session: AgenCBridgeSession): readonly SessionTranscriptEvent[] {
   const fromGetter = session.getInitialTranscriptEvents?.();
   const fromProperty = session.initialTranscriptEvents;
   return [...((fromGetter ?? fromProperty ?? []) as readonly SessionTranscriptEvent[])];
+}
+
+/**
+ * Coalescing window for streaming events (~30fps). Bounds how often the
+ * transcript re-projects + re-renders during a fast streaming turn regardless
+ * of delta rate; the ~33ms of added latency on streaming text is imperceptible.
+ */
+const TRANSCRIPT_COALESCE_MS = 33;
+
+/**
+ * True for the high-frequency streaming deltas that are safe to batch. Only the
+ * per-token text/thinking deltas coalesce; every structural event (tool calls,
+ * results, turn boundaries, user messages) flushes immediately so the UI never
+ * lags behind a change in shape.
+ */
+const COALESCABLE_STREAMING_TYPES: ReadonlySet<string> = new Set([
+  "agent_message_delta",
+  "assistant_thinking_delta",
+  "assistant_text",
+  "realtime_transcript_delta",
+]);
+
+function isCoalescableStreamingEvent(event: SessionTranscriptEvent): boolean {
+  const record = event as { type?: unknown; msg?: { type?: unknown } };
+  // Event-log shape carries `.type`; phase-event shape nests it under `.msg`.
+  const type =
+    typeof record.type === "string"
+      ? record.type
+      : typeof record.msg?.type === "string"
+        ? record.msg.type
+        : undefined;
+  return type !== undefined && COALESCABLE_STREAMING_TYPES.has(type);
 }
 
 export function useSessionTranscript(
@@ -2818,8 +2894,46 @@ export function useSessionTranscript(
   }, [session]);
 
   useEffect(() => {
+    // Coalesce incoming events into ~30fps batches. High-frequency streaming
+    // deltas (agent_message_delta / assistant_thinking_delta) otherwise dispatch
+    // once each, and every dispatch re-copies the events array AND re-projects
+    // the whole transcript — O(n²) work + garbage across a long streaming turn,
+    // which OOM'd the TUI. Buffering flushes them as one `appendBatch`; a
+    // non-streaming event (tool result, turn boundary, user message) flushes
+    // immediately so the UI stays responsive to structure changes.
+    const buffer: SessionTranscriptEvent[] = [];
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = (): void => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (buffer.length === 0) return;
+      const batch = buffer.splice(0, buffer.length);
+      dispatch(
+        batch.length === 1
+          ? { kind: "append", event: batch[0]! }
+          : { kind: "appendBatch", events: batch },
+      );
+    };
+
+    const enqueue = (event: SessionTranscriptEvent, immediate: boolean): void => {
+      buffer.push(event);
+      if (immediate) {
+        flush();
+        return;
+      }
+      if (timer === null) {
+        timer = setTimeout(flush, TRANSCRIPT_COALESCE_MS);
+        if (typeof (timer as { unref?: () => void }).unref === "function") {
+          (timer as { unref: () => void }).unref();
+        }
+      }
+    };
+
     const unsubscribeLog = session.eventLog?.subscribe((event) => {
-      dispatch({ kind: "append", event });
+      enqueue(event, !isCoalescableStreamingEvent(event));
     });
     const unsubscribePhase = session.subscribeToEvents?.((event) => {
       if (
@@ -2827,12 +2941,14 @@ export function useSessionTranscript(
         typeof event === "object" &&
         ("type" in event || "msg" in event)
       ) {
-        dispatch({ kind: "append", event: event as SessionTranscriptEvent });
+        const typed = event as SessionTranscriptEvent;
+        enqueue(typed, !isCoalescableStreamingEvent(typed));
       }
     });
     return () => {
       unsubscribeLog?.();
       unsubscribePhase?.();
+      flush();
     };
   }, [session]);
 

--- a/runtime/tests/tui/session-transcript.batch-coalesce.test.ts
+++ b/runtime/tests/tui/session-transcript.batch-coalesce.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import {
+  adaptTranscriptEvents,
+  appendSessionTranscriptBatchForTesting,
+  appendSessionTranscriptEventForTesting,
+  createSessionTranscriptStateForTesting,
+} from "../../src/tui/session-transcript.js";
+
+// Coalescing streaming deltas into one appendBatch must be BEHAVIOURALLY
+// identical to dispatching them one-by-one — same stored events, same rendered
+// transcript, same dedup — while doing one array copy + one projection instead
+// of O(n²). This guards the OOM fix from regressing the streaming semantics.
+describe("transcript delta coalescing (appendBatch)", () => {
+  const delta = (seq: number, text: string) => ({
+    type: "agent_message_delta" as const,
+    seq,
+    payload: { delta: text },
+  });
+
+  test("batched appends equal sequential appends (events + projection)", () => {
+    const deltas = Array.from({ length: 50 }, (_, i) => delta(i, `t${i} `));
+
+    let sequential = createSessionTranscriptStateForTesting([]);
+    for (const d of deltas) {
+      sequential = appendSessionTranscriptEventForTesting(sequential, d as never);
+    }
+
+    const batched = appendSessionTranscriptBatchForTesting(
+      createSessionTranscriptStateForTesting([]),
+      deltas as never,
+    );
+
+    expect(batched.events.length).toBe(sequential.events.length);
+    expect(adaptTranscriptEvents(batched.events)).toEqual(
+      adaptTranscriptEvents(sequential.events),
+    );
+    // The concatenated streaming text survives intact.
+    const text = JSON.stringify(adaptTranscriptEvents(batched.events));
+    expect(text).toContain("t0 ");
+    expect(text).toContain("t49 ");
+  });
+
+  test("dedups within a batch and against existing events", () => {
+    const base = appendSessionTranscriptBatchForTesting(
+      createSessionTranscriptStateForTesting([]),
+      [delta(0, "a "), delta(1, "b ")] as never,
+    );
+    // Re-send seq 1 plus a new seq 2 — seq 1 must not duplicate.
+    const next = appendSessionTranscriptBatchForTesting(base, [
+      delta(1, "b "),
+      delta(2, "c "),
+    ] as never);
+    expect(next.events.length).toBe(3);
+  });
+
+  test("an empty batch is a no-op (same state reference)", () => {
+    const state = createSessionTranscriptStateForTesting([delta(0, "x ") as never]);
+    expect(appendSessionTranscriptBatchForTesting(state, [])).toBe(state);
+  });
+});


### PR DESCRIPTION
Root-caused #1468. The TUI OOMs on long streaming turns because `useSessionTranscript` re-projects the whole transcript (`adaptTranscriptEvents` over all events) on every `state.events` change, and the reducer copies the full array per append — and each streaming delta is its own append. So an N-delta turn is O(N²) work + transient garbage that starves the GC (measured: 44/647/2751 ms for N=1000/4000/8000, quadratic; the on-screen 'Render health 1.6 FPS' was the symptom). Fix: coalesce events in the hook into ~30fps batches applied via a single `appendBatch` reducer action (one copy, one projection); only high-frequency deltas coalesce, structural events flush immediately, and the buffer flushes on unmount. Result: N=8000 goes 2751ms → ~16ms (linear), heap flat. `appendBatch` is behaviourally identical to sequential appends (dedup/clamp/evict/maxSeq; reset or out-of-order falls back to rebuild). Regression test covers batch==sequential equivalence, dedup, empty no-op. Gate: tsc clean; transcript + daemon-session 52/52. Closes #1468 (interim 12 GB heap bump in the local launcher can be reverted after this ships).