### PR TITLE
feat(sandbox): opt-in GPU compute (Metal) inside the macOS seatbelt

### DIFF
--- a/runtime/src/app-server/command-exec.ts
+++ b/runtime/src/app-server/command-exec.ts
@@ -117,6 +117,8 @@ export interface AgenCCommandExecServiceOptions {
   readonly useLegacyLandlock?: boolean;
   readonly windowsSandboxLevel?: WindowsSandboxLevel;
   readonly windowsSandboxPrivateDesktop?: boolean;
+  /** Opt-in GPU compute inside the sandbox (config `sandbox.allow_gpu`). */
+  readonly allowGpu?: boolean;
 }
 
 interface SpawnCommand {
@@ -195,6 +197,7 @@ export class AgenCCommandExecService implements AgenCCommandExec {
   readonly #useLegacyLandlock: boolean;
   readonly #windowsSandboxLevel: WindowsSandboxLevel;
   readonly #windowsSandboxPrivateDesktop: boolean;
+  readonly #allowGpu: boolean;
   #nextGeneratedProcessId = 1;
 
   constructor(options: AgenCCommandExecServiceOptions = {}) {
@@ -204,6 +207,7 @@ export class AgenCCommandExecService implements AgenCCommandExec {
     this.#windowsSandboxLevel = options.windowsSandboxLevel ?? "disabled";
     this.#windowsSandboxPrivateDesktop =
       options.windowsSandboxPrivateDesktop ?? false;
+    this.#allowGpu = options.allowGpu ?? false;
   }
 
   async start(
@@ -509,6 +513,7 @@ export class AgenCCommandExecService implements AgenCCommandExec {
       useLegacyLandlock: this.#useLegacyLandlock,
       windowsSandboxLevel: this.#windowsSandboxLevel,
       windowsSandboxPrivateDesktop: this.#windowsSandboxPrivateDesktop,
+      ...(this.#allowGpu ? { allowGpu: true } : {}),
     });
     const [transformedProgram, ...transformedArgs] = transformed.command;
     if (transformedProgram === undefined) {

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -813,6 +813,9 @@ export function sessionConfigurationFromAgenCConfig(params: {
     ...(params.config.compact_prompt !== undefined
       ? { compactPrompt: params.config.compact_prompt }
       : {}),
+    ...(params.config.sandbox?.allow_gpu === true
+      ? { sandboxAllowGpu: true }
+      : {}),
   };
 }
 

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -93,6 +93,15 @@ export interface SandboxPolicy {
 
 export interface SandboxConfig {
   readonly mode?: SandboxConfigMode;
+  /**
+   * Opt-in GPU compute (Metal) inside the macOS sandbox. GPU IOKit user
+   * clients are kernel attack surface, so this is off by default; when
+   * true, sandboxed commands may open the Apple Silicon GPU
+   * (`AGXDeviceUserClient`) for Metal device enumeration, shader
+   * compilation, and compute dispatch. Display services (WindowServer)
+   * stay denied either way.
+   */
+  readonly allow_gpu?: boolean;
 }
 
 export interface ShellEnvironmentPolicy {

--- a/runtime/src/sandbox/engine/index.ts
+++ b/runtime/src/sandbox/engine/index.ts
@@ -127,6 +127,8 @@ export interface SandboxTransformRequest {
   readonly windowsSandboxPrivateDesktop: boolean;
   readonly platform?: NodeJS.Platform;
   readonly isWsl1?: boolean;
+  /** Opt-in GPU compute inside the sandbox (macOS seatbelt only for now). */
+  readonly allowGpu?: boolean;
 }
 
 export type WindowsSandboxLevel = "disabled" | "low" | "medium" | "high";

--- a/runtime/src/sandbox/engine/manager.ts
+++ b/runtime/src/sandbox/engine/manager.ts
@@ -111,6 +111,7 @@ export class SandboxManager {
             enforceManagedNetwork: request.enforceManagedNetwork,
             network: request.network,
             extraAllowUnixSockets: [],
+            ...(request.allowGpu === true ? { allowGpu: true } : {}),
           }),
         ];
         break;

--- a/runtime/src/sandbox/engine/seatbelt.ts
+++ b/runtime/src/sandbox/engine/seatbelt.ts
@@ -93,6 +93,8 @@ export interface CreateSeatbeltCommandArgsParams {
   readonly enforceManagedNetwork: boolean;
   readonly network?: NetworkProxyConfig;
   readonly extraAllowUnixSockets?: readonly string[];
+  /** Opt-in GPU compute (Metal) — see {@link MACOS_SEATBELT_GPU_POLICY}. */
+  readonly allowGpu?: boolean;
 }
 
 interface ProxyPolicyInputs {
@@ -117,6 +119,28 @@ interface UnixSocketPathParam {
   readonly path: string;
 }
 
+/**
+ * Opt-in GPU compute (Metal) allowance.
+ *
+ * The restricted profile denies all GPU IOKit user clients, so
+ * `MTLCreateSystemDefaultDevice()` returns nil inside the sandbox and GPU
+ * tools fail or crash outright (e.g. Blender 5.0.1 segfaults on the nil
+ * device name during startup backend detection, even in `--background`).
+ *
+ * Measured minimal set (macOS 26 / M4 Pro): `AGXDeviceUserClient` is the
+ * Apple Silicon GPU user client — the only IOKit class Metal needs for
+ * device enumeration and compute dispatch — and `MTLCompilerService` is
+ * the XPC shader compiler required for uncached pipeline compilation.
+ * GPU user clients are kernel attack surface, so this stays opt-in
+ * (config `sandbox.allow_gpu`) and deliberately excludes WindowServer,
+ * IOSurface, and every other display-adjacent service.
+ */
+export const MACOS_SEATBELT_GPU_POLICY = `; GPU compute (Metal) — opt-in via config \`sandbox.allow_gpu\`
+(allow iokit-open
+  (iokit-user-client-class "AGXDeviceUserClient"))
+(allow mach-lookup
+  (global-name "com.apple.MTLCompilerService"))`;
+
 export function createSeatbeltCommandArgs(
   args: CreateSeatbeltCommandArgsParams,
 ): string[] {
@@ -128,6 +152,7 @@ export function createSeatbeltCommandArgs(
     enforceManagedNetwork,
     network,
     extraAllowUnixSockets = [],
+    allowGpu = false,
   } = args;
 
   const unreadableRoots = getUnreadableRootsWithCwd(
@@ -166,6 +191,9 @@ export function createSeatbeltCommandArgs(
   ];
   if (includePlatformDefaults(fileSystemSandboxPolicy)) {
     policySections.push(getMacosRestrictedReadOnlyPlatformDefaults());
+  }
+  if (allowGpu) {
+    policySections.push(MACOS_SEATBELT_GPU_POLICY);
   }
   const fullPolicy = policySections.join("\n");
 

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -342,6 +342,11 @@ export interface SessionConfiguration {
   readonly fileSystemSandboxPolicy: FileSystemSandboxPolicy;
   readonly networkSandboxPolicy: NetworkSandboxPolicy;
   readonly windowsSandboxLevel: WindowsSandboxLevel;
+  /**
+   * Opt-in GPU compute (Metal) inside the platform sandbox (config
+   * `sandbox.allow_gpu`). Kernel attack surface — off by default.
+   */
+  readonly sandboxAllowGpu?: boolean;
   readonly collaborationMode: CollaborationMode;
   readonly personality?: Personality;
   readonly reviewModel?: string;

--- a/runtime/src/tools/system/apply-runtime-sandbox.ts
+++ b/runtime/src/tools/system/apply-runtime-sandbox.ts
@@ -133,6 +133,7 @@ export function transformWithRuntimeSandbox(params: {
       windowsSandboxLevel,
       windowsSandboxPrivateDesktop:
         params.runtimeSandbox.windowsSandboxPrivateDesktop ?? false,
+      ...(params.runtimeSandbox.allowGpu === true ? { allowGpu: true } : {}),
     });
     const [program, ...args] = transformed.command;
     if (program === undefined) {

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -94,6 +94,7 @@ export function runtimeSandboxForExec(
       readonly permissions?: {
         readonly windowsSandboxPrivateDesktop?: unknown;
       };
+      readonly sandboxAllowGpu?: unknown;
     };
     readonly features?: unknown;
     readonly network?: unknown;
@@ -117,6 +118,9 @@ export function runtimeSandboxForExec(
       : {}),
     sandboxPolicyCwd,
     preference: "require",
+    ...(booleanValue(turn.config?.sandboxAllowGpu) === true
+      ? { allowGpu: true }
+      : {}),
     useLegacyLandlock: useLegacyLandlock(turn.features ?? turn.config?.features),
     windowsSandboxLevel: windowsSandboxLevel(turn.windowsSandboxLevel),
     windowsSandboxPrivateDesktop: booleanValue(

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -860,6 +860,7 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
         windowsSandboxLevel,
         windowsSandboxPrivateDesktop:
           params.runtimeSandbox.windowsSandboxPrivateDesktop ?? false,
+        ...(params.runtimeSandbox.allowGpu === true ? { allowGpu: true } : {}),
       });
       const [program, ...args] = transformed.command;
       if (program === undefined) {

--- a/runtime/src/unified-exec/types.ts
+++ b/runtime/src/unified-exec/types.ts
@@ -58,6 +58,8 @@ export interface UnifiedExecRuntimeSandbox {
   readonly useLegacyLandlock?: boolean;
   readonly windowsSandboxLevel?: WindowsSandboxLevel;
   readonly windowsSandboxPrivateDesktop?: boolean;
+  /** Opt-in GPU compute inside the sandbox (config `sandbox.allow_gpu`). */
+  readonly allowGpu?: boolean;
 }
 
 export interface UnifiedExecManagerOptions {

--- a/runtime/tests/sandbox/engine/seatbelt.test.ts
+++ b/runtime/tests/sandbox/engine/seatbelt.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { restrictedFileSystemPolicy, unrestrictedFileSystemPolicy } from "./index.js";
 import {
   MACOS_PATH_TO_SEATBELT_EXECUTABLE,
+  MACOS_SEATBELT_GPU_POLICY,
   createSeatbeltCommandArgs,
   seatbeltRegexForUnreadableGlob,
 } from "./seatbelt.js";
@@ -130,5 +131,33 @@ describe("macOS seatbelt policy generation", () => {
       "^/repo/private(/.*)?$",
     );
     expect(seatbeltRegexForUnreadableGlob("")).toBeNull();
+  });
+});
+
+describe("macOS seatbelt GPU allowance (opt-in)", () => {
+  const baseParams = {
+    command: ["/bin/echo", "ok"],
+    fileSystemSandboxPolicy: restrictedFileSystemPolicy(),
+    networkSandboxPolicy: "disabled",
+    sandboxPolicyCwd: "/repo",
+    enforceManagedNetwork: false,
+  } as const;
+
+  it("denies GPU user clients and the Metal compiler by default", () => {
+    const args = createSeatbeltCommandArgs({ ...baseParams });
+    const policy = args[1] ?? "";
+    expect(policy).not.toContain("AGXDeviceUserClient");
+    expect(policy).not.toContain("MTLCompilerService");
+  });
+
+  it("adds only Metal compute rules when allowGpu is set", () => {
+    const args = createSeatbeltCommandArgs({ ...baseParams, allowGpu: true });
+    const policy = args[1] ?? "";
+    expect(policy).toContain(MACOS_SEATBELT_GPU_POLICY);
+    expect(policy).toContain('(iokit-user-client-class "AGXDeviceUserClient")');
+    expect(policy).toContain('(global-name "com.apple.MTLCompilerService")');
+    // The GPU opt-in must not widen display-adjacent surfaces.
+    expect(policy).not.toContain("WindowServer");
+    expect(policy).not.toContain("IOSurfaceRootUserClient");
   });
 });

--- a/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
+++ b/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
@@ -69,6 +69,54 @@ describe("applyRuntimeSandboxToSpawn (TOOL-03/04) — behavioral", () => {
     expect(result.env.SANDBOX).toBe("1");
   });
 
+  it("threads allowGpu through to SandboxManager.transform when set", () => {
+    const transform = vi.fn().mockReturnValue({
+      command: ["/sandbox/wrapper", "/bin/echo", "hi"],
+      cwd: "/sandboxed",
+      env: {},
+    });
+    const manager = {
+      selectInitial: vi.fn().mockReturnValue("macos_seatbelt"),
+      transform,
+    } as never;
+
+    transformWithRuntimeSandbox({
+      program: "/bin/echo",
+      args: ["hi"],
+      cwd: process.cwd(),
+      env: {},
+      runtimeSandbox: { ...fakeRuntimeSandbox("require"), allowGpu: true },
+      sandboxManager: manager,
+    });
+
+    expect(transform).toHaveBeenCalledWith(
+      expect.objectContaining({ allowGpu: true }),
+    );
+  });
+
+  it("omits allowGpu from the transform request when not set", () => {
+    const transform = vi.fn().mockReturnValue({
+      command: ["/sandbox/wrapper", "/bin/echo", "hi"],
+      cwd: "/sandboxed",
+      env: {},
+    });
+    const manager = {
+      selectInitial: vi.fn().mockReturnValue("macos_seatbelt"),
+      transform,
+    } as never;
+
+    transformWithRuntimeSandbox({
+      program: "/bin/echo",
+      args: ["hi"],
+      cwd: process.cwd(),
+      env: {},
+      runtimeSandbox: fakeRuntimeSandbox("require"),
+      sandboxManager: manager,
+    });
+
+    expect(transform.mock.calls[0]?.[0]).not.toHaveProperty("allowGpu");
+  });
+
   it("fails closed when preference is require and no platform sandbox is selected", () => {
     const manager = {
       selectInitial: vi.fn().mockReturnValue("none"),


### PR DESCRIPTION
## Problem

The restricted seatbelt profile denies every GPU IOKit user client, so `MTLCreateSystemDefaultDevice()` returns **nil** inside the sandbox. GPU tools then fail or crash outright — Blender 5.0.1 segfaults at startup (`strstr(NULL)` in `blender::gpu::supports_barycentric_whitelist` ← `MTLBackend::metal_is_supported` ← `GPU_backend_type_selection_detect`), even in `--background`. Found live while an agent tried to drive a Blender render: 5 crash reports in 3 minutes.

Today the only workaround is `dangerouslyDisableSandbox: true`, which drops file **and** network containment entirely — strictly worse than granting GPU alone.

## Design

**Opt-in, default unchanged.** GPU user clients are kernel attack surface, so the default profile keeps denying them. A new config key:

```toml
[sandbox]
allow_gpu = true
```

appends the measured minimal Metal-compute rules to the generated profile:

```scheme
; GPU compute (Metal) — opt-in via config `sandbox.allow_gpu`
(allow iokit-open
  (iokit-user-client-class "AGXDeviceUserClient"))
(allow mach-lookup
  (global-name "com.apple.MTLCompilerService"))
```

Both rules are empirically minimal (measured on macOS 26 / M4 Pro by axis-isolated `sandbox-exec` bisection, not copied from other projects): `AGXDeviceUserClient` is the only IOKit class Metal needs for device enumeration + compute dispatch, and `MTLCompilerService` is required for uncached shader compilation (masked by the shader cache in naive tests). The allowance deliberately **excludes WindowServer, IOSurface, and every display-adjacent service** — no screen access, no new file/network surface.

Threading: `sandbox.allow_gpu` (config schema) → `SessionConfiguration.sandboxAllowGpu` (bootstrap) → turn config → `UnifiedExecRuntimeSandbox.allowGpu` → `SandboxTransformRequest.allowGpu` → `createSeatbeltCommandArgs`. All three transform sites pass it through (tool exec, unified-exec process manager, app-server command exec).

## Verification

E2E through the real generator argv (`createSeatbeltCommandArgs` → `sandbox-exec`), 4/4 bisect:

| run | default | `allow_gpu` |
|---|---|---|
| Metal probe (enumerate → live-compile kernel → dispatch → readback) | `default=NIL` | `Apple M4 Pro` / `dispatch=OK` |
| `Blender --background --factory-startup --python <script>` | segfault (crash log written) | `BLENDER_OK 5.0.1`, exit 0 |

- `tsc --noEmit` clean
- Unit tests: seatbelt policy generation (default denies AGX + MTLCompilerService; opt-in adds exactly the GPU section and still excludes WindowServer/IOSurface) and transform pass-through (present when set, absent otherwise)
- All suites covering the touched files: 7 files, 54/54 pass. The `tests/sandbox/linux-launcher` + `file-edit`/`coding-common` failures are pre-existing on main (verified via stash on this machine, identical counts) and untouched by this diff.