### PR TITLE
test(runtime): repair stable contracts

### DIFF
--- a/runtime/tests/app-server/agent-cli.contract.test.ts
+++ b/runtime/tests/app-server/agent-cli.contract.test.ts
@@ -2,7 +2,8 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import {
   collectDaemonClientEnvOverrides,
   createConnectedAgenCJsonLineDaemonTuiClient,
@@ -34,6 +35,12 @@ import type {
   AgenCBackgroundAgentSessionEventBinding,
   AgenCBackgroundAgentStartParams,
 } from "./background-agent-runner.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-agent-cli-workspace-");
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function createIo(): AgenCAgentCliIo & {
   readonly stdoutText: () => string;
@@ -204,6 +211,7 @@ describe("agenc agent start CLI", () => {
   it("prints only the daemon-returned agent ID", async () => {
     const io = createIo();
     const requests: AgentCreateParams[] = [];
+    const cwd = await workspaces.create();
 
     await expect(
       runAgenCAgentCli(
@@ -214,7 +222,7 @@ describe("agenc agent start CLI", () => {
           unattendedDeny: ["exec_command"],
         },
         {
-          cwd: "/workspace",
+          cwd,
           // Empty env: no allowlisted overrides get collected, so the
           // create params stay exactly minimal.
           env: {},
@@ -248,7 +256,7 @@ describe("agenc agent start CLI", () => {
       {
         objective: "audit the repo",
         instructions: "audit the repo",
-        cwd: "/workspace",
+        cwd,
         metadata: { source: "agenc agent start" },
         unattendedAllow: ["FileRead"],
         unattendedDeny: ["exec_command"],
@@ -259,6 +267,7 @@ describe("agenc agent start CLI", () => {
   it("forwards allowlisted client env overrides with agent start", async () => {
     const io = createIo();
     const requests: AgentCreateParams[] = [];
+    const cwd = await workspaces.create();
 
     await expect(
       runAgenCAgentCli(
@@ -269,7 +278,7 @@ describe("agenc agent start CLI", () => {
           unattendedDeny: [],
         },
         {
-          cwd: "/workspace",
+          cwd,
           env: {
             XAI_API_KEY: "rotated-key",
             PATH: "/project/.venv/bin:/usr/bin",
@@ -723,6 +732,7 @@ autostart = false
 
   it("sends agent.create over the daemon JSON-line socket", async () => {
     const dir = await mkdtemp(join(tmpdir(), "agenc-agent-start-"));
+    const cwd = await workspaces.create();
     const socketPath = join(dir, "daemon.sock");
     const io = createIo();
     const sessionManager = new AgenCDaemonSessionManager({
@@ -844,7 +854,7 @@ autostart = false
           authCookie: "wrong-cookie",
         }).createAgent({
           objective: "should not launch",
-          cwd: "/workspace",
+          cwd,
         }),
       ).rejects.toThrow("daemon connection authentication failed");
       expect(starts).toEqual([]);
@@ -862,7 +872,7 @@ autostart = false
               socketPath,
               authCookie: "socket-cookie",
             }),
-            cwd: "/workspace",
+            cwd,
             ensureDaemonReady: async () => {},
             io,
           },
@@ -1019,7 +1029,7 @@ autostart = false
     expect(starts).toMatchObject([
       {
         objective: "background compile",
-        cwd: "/workspace",
+        cwd,
         unattendedAllow: [],
         unattendedDeny: [],
       },
@@ -1781,6 +1791,7 @@ autostart = false
 
   it("does not retry agent.create after the side-effecting request is sent", async () => {
     const dir = await mkdtemp(join(tmpdir(), "agenc-agent-start-reset-"));
+    const cwd = await workspaces.create();
     const socketPath = join(dir, "daemon.sock");
     const io = createIo();
     const starts: AgenCBackgroundAgentStartParams[] = [];
@@ -1841,7 +1852,7 @@ autostart = false
               authCookie: "reset-cookie",
               timeoutMs: 200,
             }),
-            cwd: "/workspace",
+            cwd,
             ensureDaemonReady: async () => {},
             io,
           },

--- a/runtime/tests/app-server/client-multiplexer.byte-budget.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.byte-budget.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import type { JsonObject } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-client-multiplexer-byte-budget-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -50,7 +59,10 @@ describe("client multiplexer buffered byte budget", () => {
   it("evicts oldest buffered events once the byte budget is exceeded", async () => {
     // Budget fits roughly four ~1KB payloads.
     const { sessionManager, multiplexer } = createHarness(4 * 1100);
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     // No client attached: every event is buffered. Push far more bytes than
     // the budget so eviction must kick in.
@@ -90,7 +102,10 @@ describe("client multiplexer buffered byte budget", () => {
 
   it("always retains at least the most recent event even when it alone exceeds the budget", async () => {
     const { sessionManager, multiplexer } = createHarness(1024);
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     // A single payload far larger than the whole budget.
     await multiplexer.broadcastSessionEvent("session_1", bigEvent(1, 100_000));

--- a/runtime/tests/app-server/client-multiplexer.contract.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.contract.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import {
   AgenCClientMultiplexerError,
   AgenCDaemonClientMultiplexer,
@@ -10,6 +11,14 @@ import {
   type AgenCDaemonSessionNotification,
   type JsonObject,
 } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-client-multiplexer-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -45,12 +54,21 @@ function createHarness(): {
   return { sessionManager, multiplexer };
 }
 
+async function createSession(
+  sessionManager: AgenCDaemonSessionManager,
+): Promise<void> {
+  await sessionManager.createSession({
+    agentId: "agent_1",
+    cwd: await workspaces.create(),
+  });
+}
+
 describe("AgenC daemon client multiplexer", () => {
   it("routes Ledger client actions by initialized capability without session attachment", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const phone: JsonObject[] = [];
     const tui: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "phone",
       capabilities: { "portal.ledger.solana.sign.v1": true },
@@ -81,7 +99,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const olderPhone: JsonObject[] = [];
     const newerPhone: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "phone-older",
       capabilities: { "portal.ledger.solana.sign.v1": true },
@@ -108,7 +126,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("buffers a failed sole Ledger delivery for the next capable reconnect", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const replacementPhone: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "phone-failing",
       capabilities: { "portal.ledger.solana.sign.v1": true },
@@ -145,7 +163,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("replays a bounded Ledger action when a capable phone initializes later", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const phone: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     const event = ledgerActionNotification("session_1", "intent-replay");
 
     await expect(
@@ -164,7 +182,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const firstPhone: JsonObject[] = [];
     const secondPhone: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     const event = ledgerActionNotification("session_1", "intent-replay-lease");
     await multiplexer.broadcastSessionEvent("session_1", event);
 
@@ -209,7 +227,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("pushes agent status to an opted-in mobile client without session attachment", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const phone: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "phone-status",
       capabilities: { [AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY]: true },
@@ -231,7 +249,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("keeps ordinary session events attachment-only for a status observer", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const phone: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "phone-status",
       capabilities: { [AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY]: true },
@@ -249,7 +267,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const observerFrames: JsonObject[] = [];
     const attachedFrames: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "initialized-socket",
       deliveryKey: "physical-socket",
@@ -281,7 +299,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const phone: JsonObject[] = [];
     const chat: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     const ordinary = sessionEventNotification("session_1", "ordinary-buffered");
     const status = agentStatusNotification("session_1", "status-buffered");
     await multiplexer.broadcastSessionEvent("session_1", ordinary);
@@ -305,7 +323,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("retains failed live status delivery for the next observer reconnect", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const replacement: JsonObject[] = [];
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "failing-status-phone",
       capabilities: { [AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY]: true },
@@ -331,7 +349,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const clientMessages = new Map<string, JsonObject[]>();
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     for (const clientId of ["client_1", "client_2"]) {
       clientMessages.set(clientId, []);
       await multiplexer.registerClient({
@@ -372,7 +390,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const deliveredToClient2: JsonObject[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "client_1",
       send: () => {
@@ -408,7 +426,7 @@ describe("AgenC daemon client multiplexer", () => {
     const client1Messages: JsonObject[] = [];
     const client2Messages: JsonObject[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "client_1",
       send: (message) => client1Messages.push(message),
@@ -446,7 +464,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const client2Messages: JsonObject[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "client_1",
       send: () => {},
@@ -487,7 +505,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("terminates by params and clears route/client memberships", async () => {
     const { sessionManager, multiplexer } = createHarness();
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     for (const clientId of ["client_1", "client_2"]) {
       await multiplexer.registerClient({ clientId, send: () => {} });
       await multiplexer.attachClientToSession("session_1", clientId);
@@ -524,7 +542,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const received: number[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "client_1",
       send: async (message) => {
@@ -554,7 +572,7 @@ describe("AgenC daemon client multiplexer", () => {
     const { sessionManager, multiplexer } = createHarness();
     const received: JsonObject[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     const event: AgenCDaemonSessionNotification = {
       jsonrpc: JSON_RPC_VERSION,
       method: "event.message_chunk",
@@ -584,7 +602,7 @@ describe("AgenC daemon client multiplexer", () => {
   it("rejects typed notifications whose embedded session does not match the route", async () => {
     const { sessionManager, multiplexer } = createHarness();
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await expect(
       multiplexer.broadcastSessionNotification("session_1", {
         jsonrpc: JSON_RPC_VERSION,
@@ -600,7 +618,7 @@ describe("AgenC daemon client multiplexer", () => {
 
   it("rejects unknown and duplicate clients before mutating session routes", async () => {
     const { sessionManager, multiplexer } = createHarness();
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await createSession(sessionManager);
     await multiplexer.registerClient({
       clientId: "client_1",
       send: () => {},

--- a/runtime/tests/app-server/client-multiplexer.dead-session-route-leak.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.dead-session-route-leak.test.ts
@@ -13,7 +13,8 @@
  * replays the stale buffered event. With the fix no route is created, so the
  * later attachment replays nothing.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import type {
@@ -23,6 +24,14 @@ import type {
   SessionSummary,
   SessionTerminateResult,
 } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-client-multiplexer-route-leak-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -182,7 +191,10 @@ describe("client multiplexer dead-session route leak", () => {
     });
     const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager });
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     const liveEvent: JsonObject = {
       type: "session.delta",

--- a/runtime/tests/app-server/client-multiplexer.slow-consumer-eviction.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.slow-consumer-eviction.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import type { JsonObject } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-client-multiplexer-slow-consumer-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 // Harness with default (auto-generated) session/attachment ids and a real clock
 // so tests that attach/detach/re-attach many times do not exhaust fixed
@@ -59,7 +68,10 @@ describe("client multiplexer slow-consumer eviction", () => {
     // Budget fits roughly ~8 of the ~1KB payloads below.
     const { sessionManager, multiplexer, evicted } =
       createUnsequencedHarness(8 * 1100);
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     // SLOW client: every send returns a promise that never settles, modelling a
     // backpressured / stuck socket whose OS write callback never fires. Count
@@ -184,7 +196,10 @@ describe("client multiplexer slow-consumer eviction", () => {
         maxPendingDeliveryCountPerClient: 3,
       },
     );
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     // Buffer a contiguous multi-event run whose TOTAL bytes (~12 KB over 12
     // events) far exceed the 2 KB / 3-event live pending cap, while staying well

--- a/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthBackend } from "../auth/backend.js";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
@@ -10,6 +11,14 @@ import {
   type JsonObject,
 } from "./protocol/index.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-daemon-dispatcher-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -79,7 +88,10 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     const sessionManager = new AgenCDaemonSessionManager({
       createSessionId: () => "session_ledger",
     });
-    await sessionManager.createSession({ agentId: "agent_ledger" });
+    await sessionManager.createSession({
+      agentId: "agent_ledger",
+      cwd: await workspaces.create(),
+    });
     const clientMultiplexer = new AgenCDaemonClientMultiplexer({ sessionManager });
     const notifications: JsonObject[] = [];
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
@@ -134,7 +146,10 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     const sessionManager = new AgenCDaemonSessionManager({
       createSessionId: () => "session_mobile_status",
     });
-    await sessionManager.createSession({ agentId: "agent_mobile_status" });
+    await sessionManager.createSession({
+      agentId: "agent_mobile_status",
+      cwd: await workspaces.create(),
+    });
     const clientMultiplexer = new AgenCDaemonClientMultiplexer({ sessionManager });
     const notifications: JsonObject[] = [];
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
@@ -476,7 +491,10 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     // healthy one drains).
     const connection = dispatcher.createConnection({ sendNotification: () => {} });
     connections.set("conn_1", connection);
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     let slowSendCount = 0;
     await multiplexer.registerClient({
@@ -663,9 +681,12 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     });
     const connection = dispatcher.createConnection();
     await initialize(connection);
+    const cwd = await workspaces.create();
 
     await expect(
-      connection.dispatch(request("create-default", "session.create")),
+      connection.dispatch(
+        request("create-default", "session.create", { cwd }),
+      ),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
       id: "create-default",
@@ -674,6 +695,7 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
         agentId: "agent_default",
         status: "idle",
         createdAt: "2026-05-01T09:00:00.000Z",
+        cwd,
       },
     });
   });
@@ -699,12 +721,13 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     });
     const connection = dispatcher.createConnection({ sendNotification: () => {} });
     await initialize(connection);
+    const cwd = await workspaces.create();
 
     await expect(
       connection.dispatch(
         request("create", "session.create", {
           agentId: "agent_1",
-          cwd: "/workspace/project",
+          cwd,
           initialPrompt: "inspect",
           metadata: { source: "dispatcher-test" },
         }),
@@ -713,7 +736,7 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
       result: {
         sessionId: "session_1",
         agentId: "agent_1",
-        cwd: "/workspace/project",
+        cwd,
         metadata: { source: "dispatcher-test" },
       },
     });
@@ -812,7 +835,11 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     const connection = dispatcher.createConnection();
     await initialize(connection);
 
-    await connection.dispatch(request("create", "session.create", {}));
+    await connection.dispatch(
+      request("create", "session.create", {
+        cwd: await workspaces.create(),
+      }),
+    );
     await connection.dispatch(
       request("attach", "session.attach", {
         sessionId: "session_1",
@@ -881,7 +908,11 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     });
     await initialize(connection);
 
-    await connection.dispatch(request("create", "session.create", {}));
+    await connection.dispatch(
+      request("create", "session.create", {
+        cwd: await workspaces.create(),
+      }),
+    );
     await connection.dispatch(
       request("attach-one", "session.attach", {
         sessionId: "session_1",
@@ -1169,8 +1200,16 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     const connection = dispatcher.createConnection({ sendNotification: () => {} });
     await initialize(connection);
 
-    await connection.dispatch(request("create-one", "session.create", {}));
-    await connection.dispatch(request("create-two", "session.create", {}));
+    await connection.dispatch(
+      request("create-one", "session.create", {
+        cwd: await workspaces.create(),
+      }),
+    );
+    await connection.dispatch(
+      request("create-two", "session.create", {
+        cwd: await workspaces.create(),
+      }),
+    );
     await connection.dispatch(
       request("attach-one", "session.attach", {
         sessionId: "session_1",

--- a/runtime/tests/app-server/daemon-f03.contract.test.ts
+++ b/runtime/tests/app-server/daemon-f03.contract.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonHealthService } from "./health.js";
 import { AGENC_DAEMON_METHODS } from "./protocol/index.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import type { JsonObject } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-daemon-f03-workspace-");
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -61,7 +68,10 @@ describe("AgenC daemon F-03 contract coverage", () => {
       }),
     });
 
-    await sessions.createSession({ agentId: "agent_1" });
+    await sessions.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     const client1Messages: JsonObject[] = [];
     const client2Messages: JsonObject[] = [];

--- a/runtime/tests/app-server/disconnect-resilience.contract.test.ts
+++ b/runtime/tests/app-server/disconnect-resilience.contract.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import {
@@ -6,6 +7,14 @@ import {
   type AgenCDaemonSessionNotification,
   type JsonObject,
 } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-disconnect-resilience-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -44,7 +53,8 @@ describe("AgenC daemon disconnect resilience", () => {
     const { sessionManager, multiplexer } = createHarness();
     const replayed: JsonObject[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    const cwd = await workspaces.create();
+    await sessionManager.createSession({ agentId: "agent_1", cwd });
     await multiplexer.registerClient({ clientId: "client_1", send: () => {} });
     await multiplexer.attachClientToSession("session_1", "client_1");
 
@@ -56,6 +66,7 @@ describe("AgenC daemon disconnect resilience", () => {
       agentId: "agent_1",
       status: "idle",
       createdAt: "2026-05-01T10:00:00.000Z",
+      cwd,
     });
 
     const event = {
@@ -95,7 +106,10 @@ describe("AgenC daemon disconnect resilience", () => {
     const { sessionManager, multiplexer } = createHarness(2);
     const replayedSequences: number[] = [];
 
-    await sessionManager.createSession({ agentId: "agent_1" });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
     await multiplexer.registerClient({ clientId: "client_1", send: () => {} });
     await multiplexer.attachClientToSession("session_1", "client_1");
     await multiplexer.disconnectClient("client_1");

--- a/runtime/tests/app-server/health.contract.test.ts
+++ b/runtime/tests/app-server/health.contract.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonHealthService, toHealthMemoryStats } from "./health.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-health-workspace-");
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -49,8 +56,14 @@ describe("AgenC daemon health service", () => {
         "2026-05-01T10:00:02.000Z",
       ]),
     });
-    await sessions.createSession({ agentId: "agent_1" });
-    await sessions.createSession({ agentId: "agent_1" });
+    await sessions.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    await sessions.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
     await sessions.terminateSession({ sessionId: "session_2" });
 
     const health = new AgenCDaemonHealthService({

--- a/runtime/tests/app-server/in-process-transport.contract.test.ts
+++ b/runtime/tests/app-server/in-process-transport.contract.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import {
   AgenCInProcessDaemonTransport as PublicAgenCInProcessDaemonTransport,
   AgenCDaemonJsonRpcDispatcher as PublicAgenCDaemonJsonRpcDispatcher,
@@ -22,6 +23,14 @@ import {
   createAgenCDaemonClient as createSdkDaemonClient,
   type AgenCDaemonTransport as SdkAgenCDaemonTransport,
 } from "../../../../agenc-sdk/src/daemon";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-in-process-transport-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -190,7 +199,10 @@ describe("AgenC in-process app-server transport", () => {
       createAttachmentId: sequence(["attachment_1"]),
       now: sequence(["2026-05-01T12:00:00.000Z", "2026-05-01T12:00:01.000Z"]),
     });
-    await sessions.createSession({ agentId: "agent_1" });
+    await sessions.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
     const clientMultiplexer = new AgenCDaemonClientMultiplexer({
       sessionManager: sessions,
     });

--- a/runtime/tests/app-server/session-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/session-lifecycle.contract.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { RolloutStore } from "../session/rollout-store.js";
 import { FileThreadStore } from "../thread-store/store.js";
 import {
@@ -9,6 +10,14 @@ import {
   AgenCSessionLifecycleError,
   DEFAULT_AGENC_DAEMON_AGENT_ID,
 } from "./session-lifecycle.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-session-lifecycle-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -32,11 +41,14 @@ describe("AgenC daemon session lifecycle", () => {
         "2026-05-01T10:02:00.000Z",
       ]),
     });
+    const firstAgentCwd = await workspaces.create();
+    const secondAgentCwd = await workspaces.create();
+    const thirdAgentCwd = await workspaces.create();
 
     await expect(
       manager.createSession({
         agentId: "agent_1",
-        cwd: "/workspace/a",
+        cwd: firstAgentCwd,
         initialPrompt: "inspect",
         metadata: { origin: "test" },
       }),
@@ -45,11 +57,11 @@ describe("AgenC daemon session lifecycle", () => {
       agentId: "agent_1",
       status: "idle",
       createdAt: "2026-05-01T10:00:00.000Z",
-      cwd: "/workspace/a",
+      cwd: firstAgentCwd,
       metadata: { origin: "test" },
     });
-    await manager.createSession({ agentId: "agent_2" });
-    await manager.createSession({ agentId: "agent_1" });
+    await manager.createSession({ agentId: "agent_2", cwd: secondAgentCwd });
+    await manager.createSession({ agentId: "agent_1", cwd: thirdAgentCwd });
 
     await expect(
       manager.listSessions({ agentId: "agent_1", limit: 1 }),
@@ -60,7 +72,7 @@ describe("AgenC daemon session lifecycle", () => {
           agentId: "agent_1",
           status: "idle",
           createdAt: "2026-05-01T10:00:00.000Z",
-          cwd: "/workspace/a",
+          cwd: firstAgentCwd,
           metadata: { origin: "test" },
         },
       ],
@@ -89,7 +101,10 @@ describe("AgenC daemon session lifecycle", () => {
         "2026-05-01T10:00:02.000Z",
       ]),
     });
-    await manager.createSession({ agentId: "agent_1" });
+    await manager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     await expect(
       manager.attachSession({ sessionId: "session_1", clientId: "tui_1" }),
@@ -151,7 +166,10 @@ describe("AgenC daemon session lifecycle", () => {
         "2026-05-01T10:00:02.000Z",
       ]),
     });
-    await manager.createSession({ agentId: "agent_1" });
+    await manager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
     await manager.attachSession({ sessionId: "session_1", clientId: "tui_1" });
 
     await expect(
@@ -190,7 +208,10 @@ describe("AgenC daemon session lifecycle", () => {
       createSessionId: sequence(["session_1"]),
       now: sequence(["2026-05-01T10:00:00.000Z"]),
     });
-    await manager.createSession({ agentId: "agent_1" });
+    await manager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
 
     await expect(
       manager.attachSession({ sessionId: "session_missing" }),

--- a/runtime/tests/helpers/temp-workspace.ts
+++ b/runtime/tests/helpers/temp-workspace.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface TempWorkspaceFixture {
+  /** Create and track a unique, existing absolute workspace directory. */
+  create(): Promise<string>;
+
+  /** Remove every workspace created since the previous cleanup. */
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Build a per-test-file workspace fixture.
+ *
+ * `mkdtemp` makes each directory unique across parallel Vitest workers. The
+ * fixture tracks only directories it created, and cleanup is idempotent so an
+ * `afterEach` hook can safely reclaim every workspace even after a test fails.
+ */
+export function createTempWorkspaceFixture(
+  prefix = "agenc-test-workspace-",
+): TempWorkspaceFixture {
+  const paths = new Set<string>();
+
+  return {
+    async create(): Promise<string> {
+      const path = await mkdtemp(join(tmpdir(), prefix));
+      paths.add(path);
+      return path;
+    },
+
+    async cleanup(): Promise<void> {
+      await Promise.all(
+        [...paths].map(async (path) => {
+          await rm(path, { recursive: true, force: true });
+          paths.delete(path);
+        }),
+      );
+    },
+  };
+}

--- a/runtime/tests/hooks/hooks-core.test.ts
+++ b/runtime/tests/hooks/hooks-core.test.ts
@@ -8,6 +8,7 @@ import {
   resetStateForTests,
   registerHookCallbacks,
   setCwdState,
+  setIsInteractive,
   setMainThreadAgentType,
   setOriginalCwd,
   setSessionTrustAccepted,
@@ -110,6 +111,11 @@ function nodeCommand(script: string): string {
 
 function stdoutCommand(output: string): string {
   return nodeCommand(`process.stdout.write(${JSON.stringify(output)})`);
+}
+
+function acceptInteractiveWorkspaceTrust(): void {
+  setIsInteractive(true);
+  setSessionTrustAccepted(true);
 }
 
 afterEach(async () => {
@@ -308,7 +314,7 @@ test("filters HTTP hooks from startup events during matching", async () => {
 
 test("executes registered callback hooks through the pre-tool generator", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   const appState = { sessionHooks: new Map<string, unknown>() };
   registerHookCallbacks({
     PreToolUse: [
@@ -358,7 +364,7 @@ test("executes registered callback hooks through the pre-tool generator", async 
 
 test("executes command hooks through the pre-tool generator", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   const appState = { sessionHooks: new Map<string, unknown>() };
   registerHookCallbacks({
     PreToolUse: [
@@ -421,7 +427,7 @@ test("executes command hooks through the pre-tool generator", async () => {
 
 test("executes blocking command hook output through the pre-tool generator", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   const appState = { sessionHooks: new Map<string, unknown>() };
   registerHookCallbacks({
     PreToolUse: [
@@ -463,7 +469,7 @@ test("executes blocking command hook output through the pre-tool generator", asy
 
 test("executes outside-REPL wrapper hooks with structured outputs", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   let notificationCalls = 0;
   let instructionsCalls = 0;
   let sessionEndCleared = false;
@@ -696,7 +702,7 @@ test("executes outside-REPL wrapper hooks with structured outputs", async () => 
 
 test("executes session-scoped function hooks through stop hooks", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   const appState = {
     sessionHooks: new Map<string, unknown>([
       [
@@ -759,7 +765,7 @@ test("executes session-scoped function hooks through stop hooks", async () => {
 
 test("executes callback hooks across public generator event wrappers", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   const appState = { sessionHooks: new Map<string, unknown>() };
   const ctx = toolUseContext(appState);
   registerHookCallbacks({
@@ -1112,7 +1118,7 @@ test("executes callback hooks across public generator event wrappers", async () 
 
 test("executes outside-REPL WorktreeCreate hook variants", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   registerHookCallbacks({
     WorktreeCreate: [
       {
@@ -1147,7 +1153,7 @@ test("executes outside-REPL WorktreeCreate hook variants", async () => {
 
 test("executes HTTP WorktreeCreate hook JSON output", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
 
   const server = createServer((request, response) => {
     response.writeHead(200, { "content-type": "application/json" });
@@ -1202,7 +1208,7 @@ test("executes HTTP WorktreeCreate hook JSON output", async () => {
 
 test("reports malformed command hook JSON outside the REPL", async () => {
   await configureHookSession();
-  setSessionTrustAccepted(true);
+  acceptInteractiveWorkspaceTrust();
   registerHookCallbacks({
     WorktreeCreate: [
       {

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -6,7 +6,8 @@
  * agent runtime is faked.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
 import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
 import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
@@ -23,6 +24,14 @@ import {
   type AgencPromptEvent,
   type AgencTransport,
 } from "../../../packages/agenc-sdk/src/index";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-sdk-in-process-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
 
 function sequence(values: readonly string[]): () => string {
   let index = 0;
@@ -85,6 +94,7 @@ async function createFakeDaemon(options: {
         const agentId = "agent_1";
         const session = await sessionManager.createSession({
           agentId,
+          ...(typeof params.cwd === "string" ? { cwd: params.cwd } : {}),
           initialPrompt:
             typeof params.objective === "string"
               ? params.objective
@@ -225,6 +235,7 @@ function statusNotification(
 
 describe("agenc-sdk client over the in-process transport", () => {
   it("initializes, creates a session, and streams a typed prompt event stream", async () => {
+    const cwd = await workspaces.create();
     const daemon = await createFakeDaemon({
       onStreamMessage: async (fake, params) => {
         const sessionId = String(params.sessionId);
@@ -273,6 +284,7 @@ describe("agenc-sdk client over the in-process transport", () => {
     });
 
     const session = await daemon.client.createSession({
+      cwd,
       metadata: { source: "sdk-inprocess-test" },
     });
     expect(session.sessionId).toBe("session_1");
@@ -328,6 +340,7 @@ describe("agenc-sdk client over the in-process transport", () => {
   });
 
   it("routes a permission request through the callback and back over tool.approve", async () => {
+    const cwd = await workspaces.create();
     const seen: AgencPermissionRequest[] = [];
     const daemon = await createFakeDaemon({
       onPermissionRequest: (request) => {
@@ -360,7 +373,7 @@ describe("agenc-sdk client over the in-process transport", () => {
     });
 
     await daemon.client.initialize();
-    const session = await daemon.client.createSession();
+    const session = await daemon.client.createSession({ cwd });
     const result = await session.prompt("run ls").result();
 
     expect(seen).toHaveLength(1);
@@ -384,6 +397,7 @@ describe("agenc-sdk client over the in-process transport", () => {
   });
 
   it("denies permission requests when no handler is registered (never hangs)", async () => {
+    const cwd = await workspaces.create();
     const daemon = await createFakeDaemon({
       onStreamMessage: async (fake, params) => {
         const sessionId = String(params.sessionId);
@@ -408,7 +422,7 @@ describe("agenc-sdk client over the in-process transport", () => {
     });
 
     await daemon.client.initialize();
-    const session = await daemon.client.createSession();
+    const session = await daemon.client.createSession({ cwd });
     const result = await session.prompt("run ls").result();
 
     expect(daemon.calls.approved).toHaveLength(0);
@@ -424,6 +438,7 @@ describe("agenc-sdk client over the in-process transport", () => {
   });
 
   it("resumes an existing session and surfaces turn errors as errored results", async () => {
+    const cwd = await workspaces.create();
     const daemon = await createFakeDaemon({
       onStreamMessage: async (fake, params) => {
         const sessionId = String(params.sessionId);
@@ -436,7 +451,7 @@ describe("agenc-sdk client over the in-process transport", () => {
 
     await daemon.client.initialize();
     // Create the session out of band (as another client would), then resume.
-    const created = await daemon.client.request("session.create", {});
+    const created = await daemon.client.request("session.create", { cwd });
     const session = await daemon.client.resumeSession(created.sessionId);
     const result = await session
       .prompt("hello", { includeUsage: false })

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -340,7 +340,6 @@ describe("agenc-sdk client over the in-process transport", () => {
   });
 
   it("routes a permission request through the callback and back over tool.approve", async () => {
-    const cwd = await workspaces.create();
     const seen: AgencPermissionRequest[] = [];
     const daemon = await createFakeDaemon({
       onPermissionRequest: (request) => {
@@ -373,7 +372,9 @@ describe("agenc-sdk client over the in-process transport", () => {
     });
 
     await daemon.client.initialize();
-    const session = await daemon.client.createSession({ cwd });
+    // Preserve the public SDK convenience contract: omitting cwd resolves to
+    // the caller's existing absolute process.cwd() before session.create.
+    const session = await daemon.client.createSession();
     const result = await session.prompt("run ls").result();
 
     expect(seen).toHaveLength(1);

--- a/runtime/tests/tool-registry.test.ts
+++ b/runtime/tests/tool-registry.test.ts
@@ -97,11 +97,11 @@ describe("T7 tool-registry ConcurrencyClass tagging", () => {
     expect(execCommand?.recoveryCategory).toBe("side-effecting");
   });
 
-  test("write_stdin gets BackgroundTerminal without a second approval prompt", () => {
+  test("write_stdin keeps approval on the second shell-mutation channel", () => {
     const registry = buildToolRegistry({ workspaceRoot: "/tmp" });
     const writeStdin = registry.tools.find((t) => t.name === "write_stdin");
     expect(writeStdin?.concurrencyClass?.kind).toBe("background_terminal");
-    expect(writeStdin?.requiresApproval).toBe(false);
+    expect(writeStdin?.requiresApproval).toBe(true);
     expect(writeStdin?.recoveryCategory).toBe("side-effecting");
   });
 

--- a/runtime/tests/tools/execution.test.ts
+++ b/runtime/tests/tools/execution.test.ts
@@ -1794,14 +1794,10 @@ describe("T6 parity — PreToolUse ordering + inc-4788", () => {
     expect(order).toEqual(["pre", "gate", "exec"]);
   });
 
-  test("pre-hook allow + canUseTool returns ask → still asks (inc-4788)", async () => {
-    // In inc-4788, hook `allow` does NOT bypass settings.json rules.
-    // mergeHookPermissionDecision returns `allow` when no rule check is
-    // wired, so this case ultimately routes through the evaluator's
-    // native ask-without-prompt path when the evaluator disagrees.
-    // We use a hook `allow` without ruleBasedCheck to confirm the
-    // evaluator is NOT reached (hook allow short-circuits without rule
-    // check, matching AgenC's `resolveHookPermissionDecision`).
+  test("pre-hook allow still traverses the SEC-02 evaluator floor", async () => {
+    // A hook may suppress a human prompt, but it cannot bypass evaluator
+    // deny, unattended-policy, content, or safety floors. Keep this
+    // revert-sensitive to the SEC-02 post-hook re-evaluation.
     let evalRan = 0;
     let execRan = 0;
     const { context } = buildEvaluatorContext("default");
@@ -1834,10 +1830,7 @@ describe("T6 parity — PreToolUse ordering + inc-4788", () => {
     });
     expect(out.isError).toBe(false);
     expect(execRan).toBe(1);
-    // Hook allow short-circuits the evaluator when no ruleBasedCheck
-    // is provided (the evaluator runs only when the hook was ask or
-    // absent).
-    expect(evalRan).toBe(0);
+    expect(evalRan).toBe(1);
   });
 
   test("pre-hook hookPermissionResult.updatedInput threads into tool.execute", async () => {

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import React, { type SetStateAction } from "react";
+import stripAnsi from "strip-ansi";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import type { ToolPermissionContext } from "../../permissions/types.js";
 import type {
@@ -629,6 +630,30 @@ type TestStdin = PassThrough & {
   ref: () => void;
   unref: () => void;
 };
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+function extractLastSynchronizedFrame(output: string): string {
+  let lastFrame: string | undefined;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) lastFrame = frame;
+    cursor = end + SYNC_END.length;
+  }
+
+  if (lastFrame === undefined) {
+    throw new Error("Expected at least one complete synchronized terminal frame");
+  }
+  return lastFrame;
+}
 
 function createTestStreams(): {
   stdout: PassThrough;
@@ -3383,10 +3408,17 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           await submit("1");
           await submit("xai-app-key");
 
-          // Ink emits unchanged spaces as cursor-forward patches, so assert the
-          // visible words in order instead of treating patch bytes as a frame.
-          expect(output()).toMatch(/Approve[\s\S]*BYOK[\s\S]*API[\s\S]*key/);
-          expect(output()).toContain("...-key");
+          // Ink represents unchanged spaces with cursor-forward controls. Read
+          // one synchronized frame, then normalize those renderer artifacts so
+          // tokens from unrelated historical frames cannot satisfy the check.
+          const approvalFrame = stripAnsi(
+            extractLastSynchronizedFrame(output()),
+          ).replace(/\s+/gu, "");
+          expect(approvalFrame).toContain("ApproveBYOKAPIkey");
+          expect(approvalFrame).toContain("...-key");
+          expect(approvalFrame).not.toContain("xai-app-key");
+          // The full terminal history must also remain secret-free: checking
+          // only the latest frame would miss a transient disclosure.
           expect(output()).not.toContain("xai-app-key");
 
           await submit("yes");

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -355,6 +355,8 @@ vi.mock("../state/AppState.js", async () => {
 vi.mock("../../commands.js", () => ({
   findCommand: (name: string, commands: Array<Record<string, any>> = mockTuiCommandList) =>
     commands.find((command) => command.name === name || command.aliases?.includes(name)) ?? null,
+  getCommands: async () => [],
+  isCommandEnabled: () => true,
   listTuiCommandList: () => mockTuiCommandList,
 }));
 
@@ -3381,7 +3383,9 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           await submit("1");
           await submit("xai-app-key");
 
-          expect(output()).toContain("Approve BYOK API key");
+          // Ink emits unchanged spaces as cursor-forward patches, so assert the
+          // visible words in order instead of treating patch bytes as a frame.
+          expect(output()).toMatch(/Approve[\s\S]*BYOK[\s\S]*API[\s\S]*key/);
           expect(output()).toContain("...-key");
           expect(output()).not.toContain("xai-app-key");
 

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -1215,6 +1215,11 @@ describe("BufferSurface", () => {
 
   it("returns to the transcript when embedded Neovim exits from inside BUFFER", async () => {
     await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
+    const transcriptRendered = vi.fn();
+    const TranscriptProbe = () => {
+      transcriptRendered();
+      return <Text>transcript after close</Text>;
+    };
     let providerListener: (() => void) | null = null;
     let providerStatus: "ready" | "closed" = "ready";
     let providerMessage: string | null = null;
@@ -1302,7 +1307,10 @@ describe("BufferSurface", () => {
             }}
           >
             <KeybindingSetup>
-              <WorkbenchLayout transcript={<Text>transcript after close</Text>} composer={<Text>composer</Text>} />
+              <WorkbenchLayout
+                transcript={<TranscriptProbe />}
+                composer={<Text>composer</Text>}
+              />
             </KeybindingSetup>
           </AppStateProvider>,
         );
@@ -1310,6 +1318,7 @@ describe("BufferSurface", () => {
       });
 
       expect(output()).toContain("embedded Neovim test");
+      expect(transcriptRendered).not.toHaveBeenCalled();
 
       providerStatus = "closed";
       providerMessage = "Embedded Neovim exited.";
@@ -1317,7 +1326,7 @@ describe("BufferSurface", () => {
       await sleep();
 
       expect(changes.some((state) => state.workbench.activeSurfaceMode === "transcript")).toBe(true);
-      expect(output()).toContain("transcript after close");
+      expect(transcriptRendered).toHaveBeenCalled();
     } finally {
       root.unmount();
       stdin.end();

--- a/todo.txt
+++ b/todo.txt
@@ -128,7 +128,7 @@ and hosted CI does not run the real gates.
     - Strip ambient provider credentials from default tests before modules load.
     - Fail a test if the default suite attempts non-loopback network access.
 
-[ ] Repair the currently broken stable tests.
+[x] Repair the currently broken stable tests.
     - Update session/client fixtures, including the client-multiplexer contract
       fixtures, to supply the required absolute `cwd`.
     - Fix stale mocks at the contract boundary instead of weakening runtime


### PR DESCRIPTION
## Summary

- Repairs every currently stale stable-test contract without changing production behavior.
- Supplies unique, existing absolute workspaces to daemon, client-multiplexer, CLI, transport, and SDK fixtures.
- Aligns mocks and assertions with the hardened approval, evaluator, command, TUI, and workbench boundaries.
- Checks off only `Repair the currently broken stable tests` in `todo.txt`.

## Design and SOTA research

Reviewed 2026-07-14 from primary/upstream sources:

- [Node.js path contract](https://nodejs.org/docs/latest-v25.x/api/path.html#pathisabsolutepath): path resolution depends on process working state, so fixtures now provide real absolute directories instead of making the daemon invent or normalize a caller workspace.
- [Vitest module-mocking guide](https://vitest.dev/guide/mocking/modules.html): module mocks are resolved before imports and missing exports are contract errors. The TUI mock now supplies newly consumed exports rather than weakening runtime validation.
- [Ink v6.7 synchronized-update release](https://github.com/vadimdemedes/ink/releases/tag/v6.7.0): TUI positive assertions inspect one complete synchronized frame, while a separate whole-history assertion proves the full BYOK key was never rendered transiently.

Rejected alternatives: falling back to daemon `process.cwd()`, weakening absolute-workspace validation, suppressing missing mock exports, or matching positive UI tokens across accumulated terminal history. Those approaches would hide the production contracts this slice is intended to protect.

## Verification

- Final credential-free changed-test suite: **17 files, 358 tests passed**.
- Runtime typecheck: **0 errors**.
- Revert proof at exact base `cea76231f`: the same 17 files produced **84 failures / 274 passes**; this branch produces **358 / 358 passes**. Failures covered missing absolute `cwd`, stale mocks and approval expectations, hook trust setup, synchronized TUI output, and workbench rendering.
- Normal pre-commit hook passed: runtime build, package entrypoints, generated SDK types, and `check:tui-runtime-startup` at 148x40, 120x30, and 80x24 for both normal and `--yolo` startup.
- `git diff --check origin/main...HEAD`: clean.
- Independent read-only review: no correctness or security blockers after restoring whole-terminal-history secret detection and retaining SDK no-argument `cwd` normalization coverage.

The raw full `npm test` command was not rerun on this branch because the separate unchecked M0 hermeticity item is the known defect: current `main` can discover OAuth/live paths. This is disclosed rather than risking provider traffic. All files changed by this PR were run together in a credential-free environment; the hermetic default-runner PR remains separate and must make the full gate safe.

## Risk and rollback

Risk is limited to test fixtures and assertions. Temporary workspaces are unique per test and cleanup owns only paths it created. No runtime, protocol, package, or release behavior changes.

Rollback is a normal revert of this PR. Reverting is expected to restore the demonstrated stable-test failures; it must not be used to weaken the underlying absolute-workspace or security contracts.
