### PR TITLE
polish(install): brand wordmark in the post-install banner

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -305,5 +305,30 @@ fi
 # --- done --------------------------------------------------------------------
 
 log "install complete"
-printf '\n  AgenC %s installed.\n\n  Next steps:\n    %s onboard              # guided setup: provider, key, theme, first chat\n    %s security audit       # check exposure + permissions (--fix for safe fixes)\n    %s daemon status\n\n' \
-  "$VERSION" "$WRAPPER" "$WRAPPER" "$WRAPPER"
+# Brand "agenc" wordmark — half-block rendering of assets/agenc-wordmark.svg
+# (the letterforms, not the icon). Unicode blocks only on UTF-8 locales, with
+# a plain-text fallback; brand purple only on a color-capable TTY (NO_COLOR
+# respected; empty in pipes/CI so the banner stays plain + testable).
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-dumb}" != "dumb" ]; then
+  wm_color="$(printf '\033[38;5;99m')"; wm_reset="$(printf '\033[0m')"
+else
+  wm_color=""; wm_reset=""
+fi
+
+printf '\n  AgenC %s installed.\n\n  Welcome to\n\n%s' "$VERSION" "$wm_color"
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+  *[Uu][Tt][Ff]*8*)
+    cat <<'WORDMARK'
+   ▄██▀▀█▄   ▄██▀▀█▄██   ▄█▀▀██▄  ██▄█▀▀█▄     █████
+  ▀█    ▄██ ▄█▀    ▀██ ▄█▀    ▀█▄ ██     ██  ██     ▀█
+    ▄▄█▀▀██ ██      ██ ████████▀▀ ██     ██  ██
+  ██▀    ██ ██      ██ ▀█      ▄▄ ██     ██  ██     ▄▄
+  ▀█▄▄▄▄███  ▀█▄▄▄▄▀██  ▀█▄▄▄▄█▀  ██     ██  ▀▀▄▄▄▄▄▀▀
+     ▀       ▄      ██     ▀▀
+             ▀██▄▄▄█▀
+WORDMARK
+    ;;
+  *) printf '  agenc\n' ;;
+esac
+printf '%s\n  Next steps:\n    %s onboard              # guided setup: provider, key, theme, first chat\n    %s security audit       # check exposure + permissions (--fix for safe fixes)\n    %s daemon status\n\n' \
+  "$wm_reset" "$WRAPPER" "$WRAPPER" "$WRAPPER"


### PR DESCRIPTION
Adds the real **agenc wordmark** (letters, not the icon) to the `install.sh` success banner, under a `Welcome to` line.

- The art is a half-block (`█▀▄`) rasterization of `agenc-wordmark.svg` — the actual brand letterforms including the squared "c", not a generic figlet font.
- Printed via a quoted heredoc: the block glyphs contain no shell-special characters.
- **UTF-8 guard:** blocks only when `LC_ALL/LC_CTYPE/LANG` indicate UTF-8; otherwise a plain `agenc` fallback.
- **Color guard:** brand purple (`38;5;99`) only on a color-capable TTY, `NO_COLOR` respected — pipes/CI get plain output.

Verified: `shellcheck -s sh` clean (only the pre-existing SC2016 info on line 147); both banner paths rendered from the real file (UTF-8 + C-locale fallback); `tests/packaging/install-sh.test.ts` + `distribution.test.ts` 13/13 pass (banner is stdout; tests assert stderr log lines, unaffected).

Rendered (UTF-8 TTY):

```
  AgenC 0.6.1 installed.

  Welcome to

   ▄██▀▀█▄   ▄██▀▀█▄██   ▄█▀▀██▄  ██▄█▀▀█▄     █████
  ▀█    ▄██ ▄█▀    ▀██ ▄█▀    ▀█▄ ██     ██  ██     ▀█
    ▄▄█▀▀██ ██      ██ ████████▀▀ ██     ██  ██
  ██▀    ██ ██      ██ ▀█      ▄▄ ██     ██  ██     ▄▄
  ▀█▄▄▄▄███  ▀█▄▄▄▄▀██  ▀█▄▄▄▄█▀  ██     ██  ▀▀▄▄▄▄▄▀▀
     ▀       ▄      ██     ▀▀
             ▀██▄▄▄█▀

  Next steps:
    ...
```