### PR TITLE
fix(runtime): serialize onboarding state transitions

### DIFF
--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -1172,19 +1172,13 @@ export function useFirstRunOnboardingController(
   const submitInFlight = useRef(false);
 
   useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
-
-  useEffect(() => {
     if (!active) return;
     let cancelled = false;
     void detectRunningLocalProviders(options).then((detected) => {
       if (cancelled || detected.length === 0) return;
-      setState((current) => {
-        const next = { ...current, detectedLocalProviders: detected };
-        stateRef.current = next;
-        return next;
-      });
+      const next = { ...stateRef.current, detectedLocalProviders: detected };
+      stateRef.current = next;
+      setState(next);
     });
     return () => {
       cancelled = true;
@@ -1207,19 +1201,24 @@ export function useFirstRunOnboardingController(
       if (!active) return false;
       if (submitInFlight.current) return true;
       submitInFlight.current = true;
-      setState((current) => {
-        const next = { ...current, isCheckingConnection: true };
-        stateRef.current = next;
-        return next;
-      });
+      // Keep the ref authoritative for async submissions. Mirroring React
+      // state back into it from a passive effect lets an older committed
+      // render overwrite a newer transition when input arrives quickly.
+      const checkingState = {
+        ...stateRef.current,
+        isCheckingConnection: true,
+      };
+      stateRef.current = checkingState;
+      setState(checkingState);
       try {
         const result = await submitFirstRunOnboardingInput(
-          stateRef.current,
+          checkingState,
           input,
           options,
         );
         const nextState = {
           ...result.state,
+          detectedLocalProviders: stateRef.current.detectedLocalProviders,
           isCheckingConnection: false,
         };
         stateRef.current = nextState;

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -3314,6 +3314,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
     const { AgenCTuiApp } = await import("./App.js");
     const session = {
       ...createSession(),
+      submit: vi.fn(async () => {}),
       setPendingProviderSwitch: vi.fn(),
     };
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-app-"));
@@ -3340,31 +3341,40 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           }}
         />,
         async ({ output }) => {
-          const submit = async (value: string): Promise<void> => {
+          const currentFrameText = (): string =>
+            stripAnsi(extractLastSynchronizedFrame(output())).replace(/\s+/gu, "");
+          const submit = async (value: string, nextFrameMarker: string): Promise<void> => {
             const onSubmit = providerProbe.promptSubmits.at(-1);
             expect(onSubmit).toBeDefined();
             await onSubmit!(value, helpers);
-            await new Promise((resolve) => setTimeout(resolve, 25));
+            await vi.waitFor(
+              () => expect(currentFrameText()).toContain(nextFrameMarker),
+              { interval: 10, timeout: 5_000 },
+            );
           };
 
           expect(output()).toContain("Preflight");
-          await submit("summarize this repository");
+          // This marker already exists before the invalid submission, so the
+          // next input can arrive before its error frame commits. That keeps
+          // this regression sensitive to stale passive-effect state writes.
+          await submit("summarize this repository", "Typenexttocontinue.");
           expect(output()).toContain("Preflight");
           expect(session.setPendingProviderSwitch).not.toHaveBeenCalled();
-          await submit("next");
-          await submit("1");
-          await submit("2");
-          await submit("skip");
-          await submit("test");
-          await submit("next");
-          await submit("done");
+          await submit("next", "Typeanumberorthemename.");
+          await submit("1", "Typeanumberorproviderslug.");
+          await submit("2", "OPENAI_API_KEY");
+          await submit("skip", "runtheconnectioncheck.");
+          await submit("test", "Sandboxworkspace-write");
+          await submit("next", "Typedonetofinishonboarding.");
+          await submit("done", "spinner:requesting:");
 
           expect(session.setPendingProviderSwitch).toHaveBeenLastCalledWith({
             provider: "openai",
             model: "gpt-5",
           });
           expect(readOnboardingState({ agencHome }).completed).toBe(true);
-          expect(output()).toContain("messages:0");
+          expect(session.submit).toHaveBeenCalledTimes(1);
+          expect(output()).toContain("spinner:requesting:");
         },
       );
     } finally {


### PR DESCRIPTION
## Summary

- make the onboarding controller ref the synchronous authority for async submissions
- remove passive and updater-function ref writes that can replay stale rendered state
- preserve concurrent local-provider detection across awaited submissions
- replace fixed sleep sequencing with a revert-sensitive rapid-submit render regression

## Root cause

The controller mirrored React state back into `stateRef` from a passive effect and also mutated the ref inside state updater functions. Under worker contention, an older committed render could overwrite a newer completed transition. The next onboarding answer was then evaluated against an earlier step, which made the full suite intermittently regress from Theme to Preflight.

This follows the official React model: state setters queue work, updater functions run during rendering and must remain pure, and tests should synchronize with completed updates rather than assume a wall-clock delay:

- https://react.dev/learn/queueing-a-series-of-state-updates
- https://react.dev/reference/react/act

## Regression proof

The updated test deliberately submits the next input before the invalid Preflight frame commits. With the old implementation, loaded batches failed 7-9 of 16 runs and deterministically reproduced the stale Theme-to-Preflight regression. With this commit, 16/16 loaded runs passed. Independent review found no blocker.

## Verification

Fresh owned worktree at this exact commit:

- `npm install`
- `npm run build`
- `npm test` — 1,759 files passed; 14,979 tests passed; 16 skipped
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup` — built import plus `agenc` and `agenc --yolo` at 148x40, 120x30, and 80x24
- `git diff --check`
- no surviving test or PTY processes

## Risk and rollback

The change is scoped to first-run onboarding state synchronization. Unexpected thrown submit/onComplete behavior is pre-existing and unchanged. Rollback is a single-commit revert, but would restore the reproduced stale-state race and fixed-sleep suite failure.