### PR TITLE
fix(runtime): supervise embedded Neovim process trees

### DIFF
--- a/runtime/src/tui/workbench/buffer/neovim/NeovimDiscovery.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimDiscovery.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { isAbsolute } from "node:path";
 
 import { which } from "../../../../utils/which.js";
@@ -170,7 +170,9 @@ type ProbeResult =
 
 function probeNeovimVersion(executable: string, timeoutMs: number): Promise<ProbeResult> {
   return new Promise((resolve) => {
+    const detached = process.platform !== "win32";
     const child = spawn(executable, ["--version"], {
+      detached,
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });
@@ -181,10 +183,10 @@ function probeNeovimVersion(executable: string, timeoutMs: number): Promise<Prob
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      killProbeProcess(child, detached);
       resolve(result);
     };
     const timer = setTimeout(() => {
-      child.kill("SIGKILL");
       finish({ type: "timeout" });
     }, Math.max(1, timeoutMs));
     child.stdout.on("data", (chunk: Buffer) => {
@@ -196,7 +198,7 @@ function probeNeovimVersion(executable: string, timeoutMs: number): Promise<Prob
     child.on("error", (error) => {
       finish({ type: "failed", message: error.message });
     });
-    child.on("exit", (code, signal) => {
+    child.on("close", (code, signal) => {
       if (code !== 0) {
         finish({ type: "failed", message: stderr.trim() || signal || `exit ${code}` });
         return;
@@ -221,20 +223,33 @@ function probeNeovimEmbed(
   timeoutMs: number,
 ): Promise<EmbedProbeResult> {
   return new Promise((resolve) => {
+    const detached = process.platform !== "win32";
     const child = spawn(executable, [...args], {
+      detached,
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
     });
     let stderr = "";
+    let failedExit: {
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    } | null = null;
     let settled = false;
     const finish = (result: EmbedProbeResult): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      killProbeProcess(child, detached);
       resolve(result);
     };
     const timer = setTimeout(() => {
+      if (failedExit !== null) {
+        finish({
+          type: "failed",
+          message: stderr.trim() || failedExit.signal || `exit ${failedExit.code}`,
+        });
+        return;
+      }
       finish({ type: "ok" });
     }, Math.max(1, Math.min(timeoutMs, 200)));
     child.stderr.on("data", (chunk: Buffer) => {
@@ -249,9 +264,40 @@ function probeNeovimEmbed(
         finish({ type: "ok" });
         return;
       }
+      failedExit = { code, signal };
+    });
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        finish({ type: "ok" });
+        return;
+      }
       finish({ type: "failed", message: stderr.trim() || signal || `exit ${code}` });
     });
   });
+}
+
+function killProbeProcess(child: ChildProcess, detached: boolean): void {
+  const pid = child.pid;
+  // The leader may already be gone while jobs it started still occupy the
+  // owned group, so group cleanup must not depend on the leader's exit state.
+  if (detached && process.platform !== "win32" && pid !== undefined && pid > 0) {
+    try {
+      process.kill(-pid, "SIGKILL");
+      return;
+    } catch (error) {
+      if (isMissingProcessError(error)) return;
+    }
+  }
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // Spawn failures and concurrent exits can make the direct fallback unavailable.
+  }
+}
+
+function isMissingProcessError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH";
 }
 
 function isSafeExecutableName(value: string): boolean {

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -26,6 +26,7 @@ export type NeovimCloseResult =
   | { readonly closed: false; readonly reason: string };
 
 const DEFAULT_CLEANUP_TIMEOUT_MS = 1000;
+const DIRTY_CLOSE_REASON = "Unsaved Neovim edits. Save or use force quit before closing BUFFER.";
 
 export class EmbeddedNeovimSession {
   readonly #handle: NeovimProcessHandle;
@@ -33,6 +34,7 @@ export class EmbeddedNeovimSession {
   readonly #ui: NeovimUi;
   readonly #cleanupTimeoutMs: number;
   #closed = false;
+  #cleanupComplete = false;
   #cleanupPromise: Promise<void> | null = null;
   #quitPromise: Promise<NeovimCloseResult> | null = null;
 
@@ -101,7 +103,10 @@ export class EmbeddedNeovimSession {
   }
 
   async quit(discard: boolean): Promise<NeovimCloseResult> {
-    if (this.#closed) return { closed: true };
+    if (this.#closed) {
+      await this.cleanup();
+      return { closed: true };
+    }
     if (this.#quitPromise) {
       const result = await this.#quitPromise;
       if (!result.closed && discard) return this.quit(true);
@@ -115,31 +120,55 @@ export class EmbeddedNeovimSession {
 
   async #quitWithDirtyCheck(discard: boolean): Promise<NeovimCloseResult> {
     if (!discard && await this.isDirty()) {
-      return { closed: false, reason: "Unsaved Neovim edits. Save or use force quit before closing BUFFER." };
+      return { closed: false, reason: DIRTY_CLOSE_REASON };
     }
     return this.#quitOnce(discard);
   }
 
   async #quitOnce(discard: boolean): Promise<NeovimCloseResult> {
-    await this.#rpc.request("nvim_command", [discard ? "quit!" : "quit"]).catch(() => null);
+    try {
+      await this.#rpc.request("nvim_command", [discard ? "quit!" : "quit"]);
+    } catch {
+      // A clean-check and :quit are not atomic: edits can arrive between them.
+      // Neovim rejects :quit in that race. Preserve the live buffer instead of
+      // falling through to cleanup(), whose final qa! intentionally discards.
+      if (!discard && !childHasExited(this.#handle.child)) {
+        return { closed: false, reason: DIRTY_CLOSE_REASON };
+      }
+    }
     await this.cleanup();
     return { closed: true };
   }
 
   async cleanup(): Promise<void> {
-    this.#cleanupPromise ??= this.#cleanupOnce();
-    return this.#cleanupPromise;
+    if (this.#cleanupComplete) return;
+    if (this.#cleanupPromise) return this.#cleanupPromise;
+    const attempt = this.#cleanupOnce();
+    this.#cleanupPromise = attempt;
+    try {
+      await attempt;
+      this.#cleanupComplete = true;
+    } finally {
+      if (this.#cleanupPromise === attempt) this.#cleanupPromise = null;
+    }
   }
 
   async #cleanupOnce(): Promise<void> {
     this.#closed = true;
     this.#ui.dispose();
     await this.#rpc.request("nvim_command", ["qa!"]).catch(() => null);
-    this.#handle.child.stdin.end();
-    await waitForNeovimExit(this.#handle.child, this.#cleanupTimeoutMs);
-    this.#rpc.close("session cleanup");
-    this.#handle.kill("SIGKILL");
+    if (!this.#handle.child.stdin.writableEnded) this.#handle.child.stdin.end();
+    try {
+      await waitForNeovimExit(this.#handle.child, this.#cleanupTimeoutMs);
+    } finally {
+      this.#rpc.close("session cleanup");
+      this.#handle.kill("SIGKILL");
+    }
   }
+}
+
+function childHasExited(child: ChildProcessWithoutNullStreams): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
 }
 
 export async function startEmbeddedNeovim(
@@ -169,8 +198,27 @@ export async function startEmbeddedNeovim(
     ui.dispose();
     rpc.close("startup failed");
     handle.child.stdin.end();
-    await waitForNeovimExit(handle.child, options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS);
-    handle.kill("SIGKILL");
+    let cleanupError: unknown;
+    try {
+      await waitForNeovimExit(
+        handle.child,
+        options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS,
+      );
+    } catch (waitError) {
+      cleanupError = waitError;
+    } finally {
+      handle.kill("SIGKILL");
+    }
+    if (cleanupError !== undefined) {
+      const primaryMessage = error instanceof Error ? error.message : String(error);
+      const cleanupMessage = cleanupError instanceof Error
+        ? cleanupError.message
+        : String(cleanupError);
+      throw new AggregateError(
+        [error, cleanupError],
+        `${primaryMessage}; Neovim startup cleanup failed: ${cleanupMessage}`,
+      );
+    }
     throw error;
   }
   return new EmbeddedNeovimSession(

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimProcess.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimProcess.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 export type NeovimProcessHandle = {
   readonly child: ChildProcessWithoutNullStreams;
   readonly pid: number;
-  readonly kill: (signal?: NodeJS.Signals) => void;
+  readonly kill: (signal?: NodeJS.Signals) => boolean;
 };
 
 export type SpawnNeovimProcessOptions = {
@@ -31,7 +31,7 @@ export function spawnNeovimProcess(options: SpawnNeovimProcessOptions): NeovimPr
     pid,
     kill: (signal = "SIGTERM") => killNeovimChild(child, detached, signal),
   };
-  trackNeovimProcess(handle);
+  if (pid > 0) trackNeovimProcess(handle);
   return handle;
 }
 
@@ -43,41 +43,54 @@ export function killNeovimChild(
   child: ChildProcessWithoutNullStreams,
   detached: boolean,
   signal: NodeJS.Signals = "SIGTERM",
-): void {
-  if (child.killed) return;
+): boolean {
+  const exited = child.exitCode !== null || child.signalCode !== null;
   const pid = child.pid;
   if (!pid) {
-    child.kill(signal);
-    return;
+    return exited || killDirectChild(child, signal);
   }
-  try {
-    if (detached && process.platform !== "win32") {
+  if (detached && process.platform !== "win32") {
+    try {
       process.kill(-pid, signal);
-    } else {
-      child.kill(signal);
+      return true;
+    } catch (error) {
+      if (!exited) return killDirectChild(child, signal);
+      return isMissingProcessError(error);
     }
-  } catch {
-    child.kill(signal);
   }
+  return exited || killDirectChild(child, signal);
 }
 
 export function waitForNeovimExit(
   child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
 ): Promise<void> {
+  if (!child.pid) return Promise.resolve();
   if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let settled = false;
+    let forceExitTimer: NodeJS.Timeout | undefined;
     const finish = (): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (forceExitTimer) clearTimeout(forceExitTimer);
       child.off("exit", finish);
       resolve();
     };
     const timer = setTimeout(() => {
       killNeovimChild(child, process.platform !== "win32", "SIGKILL");
-      finish();
+      if (settled) return;
+      forceExitTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.off("exit", finish);
+        reject(
+          new Error(
+            `Neovim process ${normalizeNeovimPid(child.pid)} did not exit after SIGKILL`,
+          ),
+        );
+      }, Math.max(100, timeoutMs));
     }, Math.max(1, timeoutMs));
     child.once("exit", finish);
   });
@@ -86,14 +99,14 @@ export function waitForNeovimExit(
 export function cleanupTrackedNeovimProcesses(signal: NodeJS.Signals = "SIGTERM"): void {
   const handles = [...trackedHandles];
   for (const handle of handles) {
-    handle.kill(signal);
+    if (signal === "SIGKILL" && handle.kill(signal)) trackedHandles.delete(handle);
+    else if (signal !== "SIGKILL") handle.kill(signal);
   }
   if (signal !== "SIGKILL") {
     for (const handle of handles) {
-      handle.kill("SIGKILL");
+      if (handle.kill("SIGKILL")) trackedHandles.delete(handle);
     }
   }
-  trackedHandles.clear();
 }
 
 export function getTrackedNeovimProcessCountForTesting(): number {
@@ -107,9 +120,26 @@ export function runTrackedNeovimProcessExitCleanupForTesting(): void {
 function trackNeovimProcess(handle: NeovimProcessHandle): void {
   trackedHandles.add(handle);
   handle.child.once("exit", () => {
-    trackedHandles.delete(handle);
+    // A detached leader can exit while plugins or jobs remain in its owned
+    // process group. Tear down that group before releasing global ownership.
+    if (handle.kill("SIGKILL")) trackedHandles.delete(handle);
   });
   if (cleanupHookInstalled) return;
   cleanupHookInstalled = true;
   process.once("exit", runTrackedNeovimProcessExitCleanupForTesting);
+}
+
+function killDirectChild(
+  child: ChildProcessWithoutNullStreams,
+  signal: NodeJS.Signals,
+): boolean {
+  try {
+    return child.kill(signal);
+  } catch {
+    return false;
+  }
+}
+
+function isMissingProcessError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH";
 }

--- a/runtime/tests/tui/workbench/buffer-neovim-discovery.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-discovery.contract.test.ts
@@ -303,6 +303,117 @@ describe("embedded Neovim discovery", () => {
     expect(isProcessAlive(pid)).toBe(false);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "kills a long-lived version-probe descendant that inherits the probe pipes",
+    async () => {
+      const executable = join(dir, "nvim-version-descendant");
+      const descendantPidFile = join(dir, "nvim-version-descendant.pid");
+      await writeFile(
+        executable,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          "  sleep 60 &",
+          `  printf '%s' "$!" > '${descendantPidFile}'`,
+          "  printf 'NVIM v0.12.0\\n'",
+          "  exit 0",
+          "fi",
+          "exit 0",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(executable, 0o755);
+
+      let descendantPid = 0;
+      try {
+        const result = await discoverNeovim({ executable, timeoutMs: 50 });
+        descendantPid = Number(await readFile(descendantPidFile, "utf8"));
+        await waitUntilDead(descendantPid);
+
+        expect(result).toMatchObject({ usable: false, reasonCode: "probe-timeout" });
+        expect(isProcessAlive(descendantPid)).toBe(false);
+      } finally {
+        descendantPid ||= await readProcessIdIfPresent(descendantPidFile);
+        killProcessIfAlive(descendantPid);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "kills a closed-stdio version-probe descendant after a successful close",
+    async () => {
+      const executable = join(dir, "nvim-version-detached-descendant");
+      const descendantPidFile = join(dir, "nvim-version-detached-descendant.pid");
+      await writeFile(
+        executable,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          "  sleep 60 </dev/null >/dev/null 2>&1 &",
+          `  printf '%s' "$!" > '${descendantPidFile}'`,
+          "  printf 'NVIM v0.12.0\\n'",
+          "  exit 0",
+          "fi",
+          "exit 0",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(executable, 0o755);
+
+      let descendantPid = 0;
+      try {
+        const result = await discoverNeovim({ executable, timeoutMs: 500 });
+        descendantPid = Number(await readFile(descendantPidFile, "utf8"));
+        await waitUntilDead(descendantPid);
+
+        expect(result).toMatchObject({ usable: true, executable });
+        expect(isProcessAlive(descendantPid)).toBe(false);
+      } finally {
+        descendantPid ||= await readProcessIdIfPresent(descendantPidFile);
+        killProcessIfAlive(descendantPid);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "kills a long-lived embedded-probe descendant after its leader exits successfully",
+    async () => {
+      const executable = join(dir, "nvim-embed-descendant");
+      const descendantPidFile = join(dir, "nvim-embed-descendant.pid");
+      await writeFile(
+        executable,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          "  printf 'NVIM v0.12.0\\n'",
+          "  exit 0",
+          "fi",
+          "sleep 60 &",
+          `printf '%s' "$!" > '${descendantPidFile}'`,
+          "exit 0",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(executable, 0o755);
+
+      let descendantPid = 0;
+      try {
+        const result = await discoverNeovim({ executable, timeoutMs: 500 });
+        descendantPid = Number(await readFile(descendantPidFile, "utf8"));
+        await waitUntilDead(descendantPid);
+
+        expect(result).toMatchObject({ usable: true, executable });
+        expect(isProcessAlive(descendantPid)).toBe(false);
+      } finally {
+        descendantPid ||= await readProcessIdIfPresent(descendantPidFile);
+        killProcessIfAlive(descendantPid);
+      }
+    },
+  );
+
   it("ignores a late process exit after a timed out probe has already settled", async () => {
     const executable = join(dir, "nvim-late-exit");
     await writeFile(executable, "#!/bin/sh\nprintf 'NVIM v0.12.0\\n'\nsleep 1\n", "utf8");
@@ -324,10 +435,35 @@ describe("embedded Neovim discovery", () => {
 });
 
 function isProcessAlive(pid: number): boolean {
+  if (pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;
   } catch {
     return false;
+  }
+}
+
+async function waitUntilDead(pid: number): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function readProcessIdIfPresent(path: string): Promise<number> {
+  try {
+    return Number(await readFile(path, "utf8"));
+  } catch {
+    return 0;
+  }
+}
+
+function killProcessIfAlive(pid: number): void {
+  if (!isProcessAlive(pid)) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // The process exited between the liveness check and the cleanup signal.
   }
 }

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -18,12 +18,15 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  cleanupTrackedNeovimProcesses("SIGKILL");
+  vi.restoreAllMocks();
   await rm(dir, { recursive: true, force: true });
 });
 
 describe("embedded Neovim lifecycle", () => {
   it("covers process cleanup branches without spawning real Neovim", async () => {
-    const killedChild = fakeChild({ killed: true, pid: 111 });
+    mockMissingProcessGroups();
+    const killedChild = fakeChild({ killed: true, pid: 111, signalCode: "SIGTERM" });
     expect(normalizeNeovimPid(123)).toBe(123);
     expect(normalizeNeovimPid(undefined)).toBe(0);
     killNeovimChild(killedChild, true, "SIGTERM");
@@ -33,9 +36,9 @@ describe("embedded Neovim lifecycle", () => {
     killNeovimChild(noPidChild, true, "SIGTERM");
     expect(noPidChild.kill).toHaveBeenCalledWith("SIGTERM");
 
-    const attachedChild = fakeChild({ pid: 222 });
-    killNeovimChild(attachedChild, false, "SIGTERM");
-    expect(attachedChild.kill).toHaveBeenCalledWith("SIGTERM");
+    const attachedChild = fakeChild({ killed: true, pid: 222 });
+    killNeovimChild(attachedChild, false, "SIGKILL");
+    expect(attachedChild.kill).toHaveBeenCalledWith("SIGKILL");
 
     const detachedChild = fakeChild({ pid: 333 });
     killNeovimChild(detachedChild, true, "SIGTERM");
@@ -48,9 +51,33 @@ describe("embedded Neovim lifecycle", () => {
     await expect(waitForNeovimExit(hangingChild, 1)).resolves.toBeUndefined();
     expect(hangingChild.kill).toHaveBeenCalledWith("SIGKILL");
 
+    const delayedExitChild = fakeChild({ pid: 556 });
+    const forceKillObserved = controlled<void>();
+    delayedExitChild.kill = vi.fn(() => {
+      delayedExitChild.killed = true;
+      forceKillObserved.resolve();
+      return true;
+    });
+    let waitResolved = false;
+    const delayedExitWait = waitForNeovimExit(delayedExitChild, 1).then(() => {
+      waitResolved = true;
+    });
+    await forceKillObserved.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(waitResolved).toBe(false);
+    delayedExitChild.signalCode = "SIGKILL";
+    delayedExitChild.emit("exit");
+    await delayedExitWait;
+
+    const unkillableChild = fakeChild({ pid: 557 });
+    unkillableChild.kill = vi.fn(() => true);
+    await expect(waitForNeovimExit(unkillableChild, 1)).rejects.toThrow(
+      "Neovim process 557 did not exit after SIGKILL",
+    );
   });
 
   it("guards closed embedded sessions and keeps cleanup idempotent", async () => {
+    mockMissingProcessGroups();
     const child = fakeChild({ exitCode: 0, pid: 777 });
     const handle = {
       child,
@@ -112,6 +139,31 @@ describe("embedded Neovim lifecycle", () => {
     await expect(cleanSession.quit(false)).resolves.toEqual({ closed: true });
     expect(cleanRpc.request).toHaveBeenCalledWith("nvim_command", ["quit"]);
 
+    const racedChild = fakeChild({ pid: 783 });
+    const racedHandle = {
+      child: racedChild,
+      pid: 783,
+      kill: vi.fn(),
+    };
+    const racedRpc = {
+      request: vi.fn(async (method: string, args: readonly any[]) => {
+        if (method === "nvim_buf_get_option") return false;
+        if (method === "nvim_command" && args[0] === "quit") {
+          throw new Error("E37: No write since last change");
+        }
+        return true;
+      }),
+      close: vi.fn(),
+    };
+    const racedSession = new EmbeddedNeovimSession(racedHandle as any, racedRpc as any, ui as any, 5);
+    await expect(racedSession.quit(false)).resolves.toEqual({
+      closed: false,
+      reason: "Unsaved Neovim edits. Save or use force quit before closing BUFFER.",
+    });
+    expect(racedHandle.kill).not.toHaveBeenCalled();
+    expect(racedRpc.close).not.toHaveBeenCalled();
+    await expect(racedSession.quit(true)).resolves.toEqual({ closed: true });
+
     const dirtyGate = controlled<boolean>();
     const concurrentChild = fakeChild({ exitCode: 0, pid: 780 });
     const concurrentHandle = {
@@ -166,6 +218,35 @@ describe("embedded Neovim lifecycle", () => {
     const closeSession = new EmbeddedNeovimSession(closeHandle as any, closeRpc as any, ui as any, 5);
     await Promise.all([closeSession.quit(true), closeSession.quit(true)]);
     expect(closeRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "quit!")).toHaveLength(1);
+
+    const unkillableChild = fakeChild({ pid: 782 });
+    unkillableChild.kill = vi.fn(() => true);
+    const unkillableHandle = {
+      child: unkillableChild,
+      pid: 782,
+      kill: vi.fn(),
+    };
+    const unkillableRpc = {
+      request: vi.fn(async () => true),
+      close: vi.fn(),
+    };
+    const unkillableSession = new EmbeddedNeovimSession(
+      unkillableHandle as any,
+      unkillableRpc as any,
+      ui as any,
+      1,
+    );
+    await expect(unkillableSession.cleanup()).rejects.toThrow(
+      "Neovim process 782 did not exit after SIGKILL",
+    );
+    expect(unkillableRpc.close).toHaveBeenCalledWith("session cleanup");
+    expect(unkillableHandle.kill).toHaveBeenCalledWith("SIGKILL");
+
+    await expect(unkillableSession.quit(true)).rejects.toThrow(
+      "Neovim process 782 did not exit after SIGKILL",
+    );
+    unkillableChild.exitCode = 0;
+    await expect(unkillableSession.quit(true)).resolves.toEqual({ closed: true });
   });
 
   it("maps embedded dirty notifications to boolean dirty state", () => {
@@ -196,6 +277,23 @@ describe("embedded Neovim lifecycle", () => {
     expect(errors).toContain("startup boom");
   });
 
+  it("does not track a child whose executable fails to spawn", async () => {
+    const trackedBefore = getTrackedNeovimProcessCountForTesting();
+    const handle = spawnNeovimProcess({
+      executable: join(dir, "guaranteed-missing-neovim"),
+      args: [],
+      cwd: dir,
+    });
+    const spawnError = new Promise<Error>((resolve) => {
+      handle.child.once("error", resolve);
+    });
+
+    await expect(waitForNeovimExit(handle.child, 10)).resolves.toBeUndefined();
+    await expect(spawnError).resolves.toMatchObject({ code: "ENOENT" });
+    expect(handle.pid).toBe(0);
+    expect(getTrackedNeovimProcessCountForTesting()).toBe(trackedBefore);
+  });
+
   it("kills a live child when startup setup rejects after spawn", async () => {
     const frame = Buffer.from(encode([1, 1, "attach failed", null])).toString("base64");
     const pidFile = join(dir, "child.pid");
@@ -224,6 +322,64 @@ describe("embedded Neovim lifecycle", () => {
     expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "preserves startup and cleanup failures in an AggregateError",
+    async () => {
+      const frame = Buffer.from(encode([1, 1, "attach failed", null])).toString("base64");
+      const pidFile = join(dir, "aggregate-child.pid");
+      const script = [
+        `require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+        `process.stdout.write(Buffer.from("${frame}", "base64"));`,
+        "setInterval(() => {}, 1000);",
+      ].join("");
+      const realProcessKill = process.kill.bind(process);
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+        if (pid < 0 && signal === "SIGKILL") return true;
+        return realProcessKill(pid, signal);
+      });
+      let pid = 0;
+
+      try {
+        const failure = await startEmbeddedNeovim({
+          executable: process.execPath,
+          args: ["-e", script],
+          filePath: join(dir, "target.txt"),
+          line: 1,
+          column: 0,
+          size: { rows: 2, columns: 10 },
+          cleanupTimeoutMs: 5,
+          onSnapshot: () => {},
+          onError: () => {},
+          onExit: () => {},
+        }).catch((error: unknown) => error);
+
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect(failure).toMatchObject({
+          message: expect.stringContaining("Neovim startup cleanup failed"),
+        });
+        const errors = (failure as AggregateError).errors;
+        expect(errors).toHaveLength(2);
+        expect(String(errors[0])).toContain("attach failed");
+        expect(errors[1]).toBeInstanceOf(Error);
+        expect(String(errors[1])).toContain("did not exit after SIGKILL");
+      } finally {
+        killSpy.mockRestore();
+        pid = Number(await readFile(pidFile, "utf8").catch(() => "0"));
+        if (pid > 0) {
+          try {
+            realProcessKill(-pid, "SIGKILL");
+          } catch {
+            // The supervised process group already exited.
+          }
+          await waitUntilDead(pid);
+        }
+      }
+
+      expect(isProcessAlive(pid)).toBe(false);
+      expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
+    },
+  );
+
   it("kills a supervised child process group during cleanup", async () => {
     const handle = spawnNeovimProcess({
       executable: process.execPath,
@@ -236,6 +392,44 @@ describe("embedded Neovim lifecycle", () => {
 
     expect(isProcessAlive(handle.pid)).toBe(false);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "cleans tracked descendants when a detached Neovim leader exits",
+    async () => {
+      const descendantPidFile = join(dir, "descendant.pid");
+      const descendantScript = "setInterval(() => {}, 1000)";
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        'const { writeFileSync } = require("node:fs");',
+        `const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], { stdio: "ignore" });`,
+        `writeFileSync(${JSON.stringify(descendantPidFile)}, String(child.pid));`,
+        "child.unref();",
+      ].join("");
+      const handle = spawnNeovimProcess({
+        executable: process.execPath,
+        args: ["-e", leaderScript],
+        cwd: dir,
+      });
+
+      let descendantPid = 0;
+      try {
+        await waitForNeovimExit(handle.child, 500);
+        descendantPid = Number(await readFile(descendantPidFile, "utf8"));
+
+        cleanupTrackedNeovimProcesses("SIGKILL");
+        await waitUntilDead(descendantPid);
+
+        expect(isProcessAlive(descendantPid)).toBe(false);
+        expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
+      } finally {
+        try {
+          process.kill(-handle.pid, "SIGKILL");
+        } catch {
+          // The process group is already gone after successful cleanup.
+        }
+      }
+    },
+  );
 
   it("parent cleanup kills tracked Neovim children when graceful paths are unavailable", async () => {
     const handle = spawnNeovimProcess({
@@ -446,4 +640,13 @@ async function waitForSnapshot<T>(
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   throw new Error(`timed out waiting for embedded Neovim snapshot; last=${JSON.stringify(last)}`);
+}
+
+function mockMissingProcessGroups(): void {
+  vi.spyOn(process, "kill").mockImplementation((pid) => {
+    if (pid < 0) {
+      throw Object.assign(new Error(`process group ${-pid} does not exist`), { code: "ESRCH" });
+    }
+    return true;
+  });
 }


### PR DESCRIPTION
## Summary

- supervise POSIX Neovim probe and embedded process trees through dedicated process groups
- make shutdown wait for confirmed exit, escalate to group SIGKILL, and preserve retryable ownership when termination cannot be confirmed
- fail closed across dirty-buffer quit races and preserve both startup and cleanup failures
- add contract coverage for descendants that outlive leaders, delayed and failed termination, startup rollback, and atomic dirty-state changes

## Root cause and SOTA basis

Node distinguishes `exit` from `close`: inherited stdio can remain open after the leader exits. Node also documents that `subprocess.killed` only reports that a signal was sent, and that killing a child does not necessarily kill grandchildren. POSIX `kill` supports negative PIDs for process-group delivery.

Primary sources:
- https://nodejs.org/api/child_process.html
- https://www.man7.org/linux/man-pages/man3/kill.3p.html
- https://man7.org/linux/man-pages/man2/kill.2.html

The implementation therefore tracks process-group ownership until termination is delivered or the group is confirmed gone, waits on actual lifecycle events, and treats uncertain cleanup as a retryable failure.

## Regression evidence

The added contracts launch long-lived descendants that outlive their leaders and verify timeout, success, startup-failure, and quit cleanup. Race coverage also changes dirty state between the clean check and `:quit` and verifies that the buffer remains open.

## Validation

- `npm install`
- `npm run build`
- `npm test`: root agent-surface contract 22/22; runtime 1,759 files passed; 14,985 tests passed and 16 skipped
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`: six real-PTY launches passed
- focused discovery and lifecycle contracts: 39/39 passed
- race-heavy repetitions: reviewer runs reached 60/60 and 99/99 across five passes
- `git diff --check`
- no surviving test process groups

Two independent code and test reviews found no blockers. The known residual risk is Windows descendant-tree behavior, which is not exercised by the POSIX process-group implementation.

## Rollback

Revert the single commit in this PR.