### PR TITLE
fix(tui): bound the workspace scan — unbounded globby of a huge cwd OOMed the TUI

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -1,6 +1,6 @@
 import { lstat, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { globby } from "globby";
+import { globbyStream } from "globby";
 
 import { buildProjectTreeRows } from "./buildTree.js";
 import { collectGitStatus, listGitFiles, type GitStatusByPath } from "./gitStatus.js";
@@ -522,21 +522,65 @@ async function listWorkspacePaths(cwd: string): Promise<string[]> {
   return readTopLevelPaths(cwd);
 }
 
-async function scanWorkspacePaths(cwd: string): Promise<string[]> {
-  const entries = await globby(["**/*"], {
+/**
+ * Hard bounds for the fallback workspace scan (non-git workspaces only — git
+ * repos list files via `git ls-files`, which is fast and already bounded by
+ * the repo).
+ *
+ * The scan MUST be bounded: a user launching agenc from a huge cwd (e.g.
+ * `$HOME`, millions of entries under ~/Library and project node_modules)
+ * previously ran an unbounded `globby("**\/*")` here. The walker's internal
+ * queue (fast-glob → @nodelib/fs.walk → fastq) produced entries faster than
+ * the ignore-matcher consumed them and retained every result, ballooning the
+ * heap to the V8 limit in minutes — a field OOM traced back here via heap
+ * snapshot (millions of queued fastq Tasks + hundreds of thousands of
+ * Dirents). The project tree is a UI convenience; it is never allowed to
+ * take the process down.
+ */
+export const WORKSPACE_SCAN_MAX_ENTRIES = 10_000;
+export const WORKSPACE_SCAN_MAX_DEPTH = 8;
+
+export async function scanWorkspacePaths(
+  cwd: string,
+  limits: {
+    readonly maxEntries?: number;
+    readonly maxDepth?: number;
+  } = {},
+): Promise<string[]> {
+  const maxEntries = limits.maxEntries ?? WORKSPACE_SCAN_MAX_ENTRIES;
+  const maxDepth = limits.maxDepth ?? WORKSPACE_SCAN_MAX_DEPTH;
+  const stream = globbyStream(["**/*"], {
     cwd,
+    deep: maxDepth,
     dot: true,
     gitignore: true,
     ignore: [...WORKSPACE_TREE_IGNORE],
     objectMode: true,
     onlyFiles: false,
     unique: true,
+    // Best-effort UI tree: a permission-denied directory (macOS TCC dirs
+    // like ~/Pictures/Photo Booth Library, ~/Library) must be SKIPPED. The
+    // buffered globby() surfaced these as a promise rejection that refresh()
+    // caught; the stream re-exposes them as an unhandled 'error' event that
+    // would crash the whole TUI — and skipping is also strictly better than
+    // the old behavior of erroring the tree on the first unreadable dir.
+    suppressErrors: true,
   });
 
-  return entries
-    .map((entry) => normalizeScannedPath(entry.path, entry.dirent.isDirectory()))
-    .filter(Boolean)
-    .sort((a, b) => a.localeCompare(b));
+  const paths: string[] = [];
+  for await (const entry of stream as AsyncIterable<{
+    path: string;
+    dirent: { isDirectory(): boolean };
+  }>) {
+    paths.push(normalizeScannedPath(entry.path, entry.dirent.isDirectory()));
+    if (paths.length >= maxEntries) {
+      // Breaking out of for-await destroys the stream, which tears down the
+      // underlying directory walker and frees its queue.
+      break;
+    }
+  }
+
+  return paths.filter(Boolean).sort((a, b) => a.localeCompare(b));
 }
 
 function normalizeScannedPath(pathValue: string, isDirectory: boolean): string {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -11,7 +11,10 @@ import {
   resetStructureBuildCountForTest,
 } from "../../../src/tui/workbench/project-tree/buildTree.js";
 import { collectGitStatus, listGitFiles, parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
-import { ProjectTreeStore } from "../../../src/tui/workbench/project-tree/ProjectTreeStore.js";
+import {
+  ProjectTreeStore,
+  scanWorkspacePaths,
+} from "../../../src/tui/workbench/project-tree/ProjectTreeStore.js";
 
 describe("project tree helpers", () => {
   it("reuses the sorted structure across cursor moves and rebuilds on a paths change (M-TUI-11)", () => {
@@ -1126,3 +1129,38 @@ async function waitForTreePaths(
   }
   throw new Error(`Timed out waiting for project tree paths: ${expectedPaths.join(", ")}`);
 }
+
+describe("scanWorkspacePaths bounds (workspace-scan OOM regression)", () => {
+  // An unbounded scan of a huge cwd (e.g. $HOME) previously ballooned the
+  // heap to the V8 limit — the scan must stop at its caps, not enumerate
+  // everything.
+  it("stops at maxEntries instead of enumerating the whole tree", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agenc-scan-cap-"));
+    try {
+      for (let i = 0; i < 60; i++) {
+        await writeFile(join(dir, `f${String(i).padStart(3, "0")}.txt`), "x");
+      }
+      const paths = await scanWorkspacePaths(dir, { maxEntries: 25 });
+      expect(paths.length).toBe(25);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not descend past maxDepth", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agenc-scan-depth-"));
+    try {
+      let deep = dir;
+      for (let level = 1; level <= 6; level++) {
+        deep = join(deep, `d${level}`);
+        await mkdir(deep);
+        await writeFile(join(deep, "leaf.txt"), "x");
+      }
+      const paths = await scanWorkspacePaths(dir, { maxDepth: 3 });
+      expect(paths.some((p) => p.includes("d1/d2/d3/"))).toBe(true);
+      expect(paths.some((p) => p.includes("d1/d2/d3/d4/"))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The field OOM, finally root-caused

An idle, logged-in workbench session launched from `$HOME` died at the V8 heap limit in ~4 minutes (~20MB/s retention, `Heap::CheckIneffectiveMarkCompact` → abort). The self-diagnosis shipped in #1497 captured a **6GB heap snapshot mid-leak**, and a streaming analysis of its 69.7M nodes pinned it:

| retained | what |
|---|---|
| 6.63M × `Task` objects (505MB) | fastq queue items |
| 6.63M × `worked` closures (404MB) | fastq completion callbacks (1:1 with Tasks) |
| 13.1M × contexts (500MB) + 13.9M concatenated strings (423MB) | per-task capture |
| 373k × `Dirent` + path-component strings (`.gitignore`, `src`, `docs`, `.github`…) | the directory walk itself |

`ProjectTreeStore.scanWorkspacePaths` — the fallback for **non-git** workspaces — ran an unbounded `globby("**/*", { dot: true … })` over the whole cwd. From `$HOME` that's millions of entries; the walker's queue (fast-glob → @nodelib/fs.walk → fastq) produced faster than the ignore-matcher consumed and retained everything. The walk **was** the leak.

## Fix

- Stream the scan (`globbyStream`) and stop at hard bounds: **10k entries, depth 8**. Breaking the `for await` destroys the stream and frees the walker queue. The project tree is a UI convenience — it is never allowed to take the process down.
- Git workspaces are unaffected (`git ls-files` path never reaches this fallback).
- `suppressErrors: true` — streaming exposed a second crash: a macOS TCC permission-denied dir (`~/Pictures/Photo Booth Library`) emits an unhandled stream `error` that killed the whole TUI ~40s in (the buffered `globby()` surfaced it as a rejection that `refresh()` caught). Skipping unreadable dirs is strictly better than erroring the tree on the first one.

## Verification

- **Before:** cwd=`$HOME` → 325MB→4GB in 4 min → abort. **After:** RSS flat at ~217MB across multiple launches, no OOM snapshot fired.
- Repeated-scan isolation harness over `$HOME` (10 passes, mimicking the 5s refresh): zero uncaught errors; without `suppressErrors` it reproduced the EPERM crash on the first pass.
- 2 new regression tests (entry cap honored; depth cap honored) + the existing 39 project-tree tests; `tsc --noEmit` clean.

Follow-up (pre-existing, out of scope): the 5s `refresh()` interval re-walks the workspace each tick — now bounded, but a longer interval or fs-watch invalidation would cut steady-state CPU on non-git workspaces.