### PR TITLE
fix(runtime): make buffer provider transitions transactional

### DIFF
--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -21,6 +21,11 @@ Additional env knobs:
 
 - `AGENC_BUFFER_NVIM=/path/to/nvim` — override executable discovery.
 - `AGENC_BUFFER_NVIM_TIMEOUT_MS=1200` — discovery probe timeout.
+- `AGENC_BUFFER_NVIM_STARTUP_TIMEOUT_MS=10000` — maximum time for embedded UI,
+  file, and dirty-state startup before AgenC aborts and supervises teardown.
+- `AGENC_BUFFER_NVIM_CLEANUP_TIMEOUT_MS=1000` — dirty/close RPC deadline and
+  graceful process-exit window before SIGKILL escalation. Increase this for a
+  deliberately slow user init or shutdown hook; the defaults remain bounded.
 - By default, embedded BUFFER prefers user init loading so your normal Neovim
   configuration, plugins, and syntax behavior are available.
 - `AGENC_BUFFER_NVIM_USE_INIT=0` — disable user init; starts clean embedded
@@ -46,6 +51,11 @@ Troubleshooting:
   permissions, wrapper scripts, or stderr failures reported in the BUFFER header.
 - Probe timeout: raise `AGENC_BUFFER_NVIM_TIMEOUT_MS` only after confirming the
   binary starts normally from the same shell.
+- Startup timeout: raise `AGENC_BUFFER_NVIM_STARTUP_TIMEOUT_MS` when a trusted
+  user init or plugin needs more than 10 seconds; use clean mode to isolate it.
+- Cleanup timeout: raise `AGENC_BUFFER_NVIM_CLEANUP_TIMEOUT_MS` only for a
+  trusted slow shutdown. Normal close fails closed when dirty state or `:qa`
+  cannot be confirmed; force close remains bounded and supervised.
 - Unsupported version: embedded BUFFER requires **`nvim 0.9.0` or newer** and
   shows `Embedded Neovim requires nvim 0.9.0 or newer` before falling back.
 
@@ -53,7 +63,12 @@ Troubleshooting:
 
 Embedded Neovim runs as a supervised child process. BUFFER cleanup sends a
 graceful quit, waits for the child, and then terminates the child process group
-when graceful shutdown does not complete within the configured timeout.
+on Unix (or the direct child on Windows) when graceful shutdown does not
+complete within the configured timeout. Neovim-started descendant cleanup on
+Windows remains subject to the operating system's direct-child limitation.
+The startup and cleanup deadlines are configurable with the env knobs above;
+external-editor handoff checks every loaded buffer (including hidden buffers),
+and unknown or modified state is never treated as permission to launch.
 If the TUI is killed, the PTY gate verifies that descendant Neovim processes are
 gone before the scenario passes.
 

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -3,7 +3,7 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { getCwd } from "../../../../utils/cwd.js";
 import { NeovimUi, type NeovimUiSize } from "./NeovimUi.js";
 import { spawnNeovimProcess, waitForNeovimExit, type NeovimProcessHandle } from "./NeovimProcess.js";
-import { NeovimRpcTransport, type RpcValue } from "./NeovimRpc.js";
+import { NeovimRpcError, NeovimRpcTransport, type RpcValue } from "./NeovimRpc.js";
 import type { NeovimRenderSnapshot } from "./NeovimGrid.js";
 
 export type StartEmbeddedNeovimOptions = {
@@ -14,6 +14,8 @@ export type StartEmbeddedNeovimOptions = {
   readonly column: number;
   readonly size: NeovimUiSize;
   readonly cwd?: string;
+  readonly signal?: AbortSignal;
+  readonly startupTimeoutMs?: number;
   readonly cleanupTimeoutMs?: number;
   readonly onSnapshot: (snapshot: NeovimRenderSnapshot) => void;
   readonly onDirtyChange?: (dirty: boolean) => void;
@@ -26,7 +28,61 @@ export type NeovimCloseResult =
   | { readonly closed: false; readonly reason: string };
 
 const DEFAULT_CLEANUP_TIMEOUT_MS = 1000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
 const DIRTY_CLOSE_REASON = "Unsaved Neovim edits. Save or use force quit before closing BUFFER.";
+const DIRTY_STATE_UNAVAILABLE_CLOSE_REASON =
+  "Unable to verify whether Neovim has unsaved edits. Retry or use force quit before closing BUFFER.";
+const SAFE_CLOSE_UNCONFIRMED_REASON =
+  "Embedded Neovim did not confirm a safe close. Retry or use force quit before closing BUFFER.";
+const ALL_BUFFER_DIRTY_PROBE = [
+  "for _, buffer in ipairs(vim.api.nvim_list_bufs()) do",
+  "  if vim.api.nvim_buf_is_loaded(buffer) and vim.api.nvim_get_option_value('modified', { buf = buffer }) then",
+  "    return true",
+  "  end",
+  "end",
+  "return false",
+].join("\n");
+
+class NeovimOperationTimeoutError extends Error {
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} timed out after ${timeoutMs}ms.`);
+    this.name = "NeovimOperationTimeoutError";
+  }
+}
+
+export class NeovimStartupCleanupError extends AggregateError {
+  readonly #retryCleanupOperation: () => Promise<void>;
+  #cleanupComplete = false;
+  #cleanupPromise: Promise<void> | null = null;
+
+  constructor(
+    startupError: unknown,
+    cleanupError: unknown,
+    retryCleanupOperation: () => Promise<void>,
+  ) {
+    const startupMessage = errorMessage(startupError);
+    const cleanupMessage = errorMessage(cleanupError);
+    super(
+      [startupError, cleanupError],
+      `${startupMessage}; Neovim startup cleanup failed: ${cleanupMessage}`,
+    );
+    this.name = "NeovimStartupCleanupError";
+    this.#retryCleanupOperation = retryCleanupOperation;
+  }
+
+  async retryCleanup(): Promise<void> {
+    if (this.#cleanupComplete) return;
+    if (this.#cleanupPromise) return this.#cleanupPromise;
+    const attempt = this.#retryCleanupOperation();
+    this.#cleanupPromise = attempt;
+    try {
+      await attempt;
+      this.#cleanupComplete = true;
+    } finally {
+      if (this.#cleanupPromise === attempt) this.#cleanupPromise = null;
+    }
+  }
+}
 
 export class EmbeddedNeovimSession {
   readonly #handle: NeovimProcessHandle;
@@ -54,9 +110,10 @@ export class EmbeddedNeovimSession {
     return this.#handle.pid;
   }
 
-  async input(keys: string): Promise<void> {
-    if (this.#closed || keys.length === 0) return;
+  async input(keys: string): Promise<boolean> {
+    if (this.#closed || keys.length === 0) return false;
     await this.#rpc.request("nvim_input", [keys]);
+    return true;
   }
 
   async paste(text: string): Promise<void> {
@@ -89,17 +146,42 @@ export class EmbeddedNeovimSession {
   }
 
   async isDirty(): Promise<boolean> {
-    if (this.#closed) return false;
-    // The transport can close independently of the session (stdin EPIPE before
-    // the child's exit); during that window this request rejects. The quit/close
-    // path awaits isDirty() (BufferSurface's void-invoked :q/:wq and buffer:close
-    // handlers), so an uncaught rejection here escapes as an unhandled rejection.
-    // Treat an unreachable Neovim as not-dirty — mirrors #readCurrentDirtyState's
-    // then(ok, fallback). There is nothing to save once the transport is gone.
-    const value = await this.#rpc
-      .request("nvim_buf_get_option", [0, "modified"])
-      .catch(() => false);
-    return value === true;
+    if (this.#closed) {
+      if (childHasExited(this.#handle.child)) return false;
+      throw new Error("Embedded Neovim is still exiting; its dirty state is unavailable.");
+    }
+    try {
+      const value = await settleWithin(
+        this.#rpc.request("nvim_buf_get_option", [0, "modified"]),
+        this.#cleanupTimeoutMs,
+        "Embedded Neovim dirty-state probe",
+      );
+      return value === true;
+    } catch (error) {
+      // Once the child has exited there is no live buffer left to preserve. A
+      // transport failure while it is still alive remains unknown and must fail
+      // closed at handoff/close call sites.
+      if (childHasExited(this.#handle.child)) return false;
+      throw error;
+    }
+  }
+
+  async hasUnsavedBuffers(): Promise<boolean> {
+    if (this.#closed) {
+      if (childHasExited(this.#handle.child)) return false;
+      throw new Error("Embedded Neovim is still exiting; its dirty state is unavailable.");
+    }
+    try {
+      const value = await settleWithin(
+        this.#rpc.request("nvim_exec_lua", [ALL_BUFFER_DIRTY_PROBE, []]),
+        this.#cleanupTimeoutMs,
+        "Embedded Neovim all-buffer dirty-state probe",
+      );
+      return value === true;
+    } catch (error) {
+      if (childHasExited(this.#handle.child)) return false;
+      throw error;
+    }
   }
 
   async quit(discard: boolean): Promise<NeovimCloseResult> {
@@ -119,21 +201,48 @@ export class EmbeddedNeovimSession {
   }
 
   async #quitWithDirtyCheck(discard: boolean): Promise<NeovimCloseResult> {
-    if (!discard && await this.isDirty()) {
-      return { closed: false, reason: DIRTY_CLOSE_REASON };
+    if (!discard) {
+      let dirty: boolean;
+      try {
+        dirty = await this.isDirty();
+      } catch {
+        return { closed: false, reason: DIRTY_STATE_UNAVAILABLE_CLOSE_REASON };
+      }
+      if (dirty) return { closed: false, reason: DIRTY_CLOSE_REASON };
     }
     return this.#quitOnce(discard);
   }
 
   async #quitOnce(discard: boolean): Promise<NeovimCloseResult> {
+    if (discard) {
+      await this.cleanup();
+      return { closed: true };
+    }
     try {
-      await this.#rpc.request("nvim_command", [discard ? "quit!" : "quit"]);
-    } catch {
-      // A clean-check and :quit are not atomic: edits can arrive between them.
-      // Neovim rejects :quit in that race. Preserve the live buffer instead of
-      // falling through to cleanup(), whose final qa! intentionally discards.
-      if (!discard && !childHasExited(this.#handle.child)) {
+      await settleWithin(
+        this.#rpc.request("nvim_command", ["qa"]),
+        this.#cleanupTimeoutMs,
+        "Embedded Neovim safe close",
+      );
+    } catch (error) {
+      // A clean-check and :qa are not atomic: edits can arrive between them.
+      // Neovim rejects the all-buffer close in that race. Preserve every live
+      // buffer instead of falling through to cleanup(), whose final qa!
+      // intentionally discards.
+      if (error instanceof NeovimOperationTimeoutError) {
+        return { closed: false, reason: SAFE_CLOSE_UNCONFIRMED_REASON };
+      }
+      if (error instanceof NeovimRpcError) {
         return { closed: false, reason: DIRTY_CLOSE_REASON };
+      }
+      if (
+        !childHasExited(this.#handle.child) &&
+        !await waitForObservedExit(this.#handle.child, this.#cleanupTimeoutMs)
+      ) {
+        return {
+          closed: false,
+          reason: SAFE_CLOSE_UNCONFIRMED_REASON,
+        };
       }
     }
     await this.cleanup();
@@ -156,7 +265,10 @@ export class EmbeddedNeovimSession {
   async #cleanupOnce(): Promise<void> {
     this.#closed = true;
     this.#ui.dispose();
-    await this.#rpc.request("nvim_command", ["qa!"]).catch(() => null);
+    // The force-quit request is best effort. Ending stdin immediately after the
+    // queued frame preserves stream ordering while ensuring an unresponsive RPC
+    // cannot postpone the supervised exit/SIGKILL deadline.
+    void this.#rpc.request("nvim_command", ["qa!"]).catch(() => null);
     if (!this.#handle.child.stdin.writableEnded) this.#handle.child.stdin.end();
     try {
       await waitForNeovimExit(this.#handle.child, this.#cleanupTimeoutMs);
@@ -171,62 +283,184 @@ function childHasExited(child: ChildProcessWithoutNullStreams): boolean {
   return child.exitCode !== null || child.signalCode !== null;
 }
 
+function waitForObservedExit(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (childHasExited(child)) return Promise.resolve(true);
+  const safeTimeoutMs = Number.isFinite(timeoutMs)
+    ? Math.max(1, Math.floor(timeoutMs))
+    : DEFAULT_CLEANUP_TIMEOUT_MS;
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off("exit", onExit);
+      resolve(exited);
+    };
+    const onExit = (): void => finish(true);
+    const timer = setTimeout(() => finish(false), safeTimeoutMs);
+    timer.unref();
+    child.once("exit", onExit);
+    // The child can exit between the optimistic check above and listener
+    // installation. Re-read its terminal state so that edge cannot turn a
+    // confirmed safe close into a false timeout.
+    if (childHasExited(child)) finish(true);
+  });
+}
+
 export async function startEmbeddedNeovim(
   options: StartEmbeddedNeovimOptions,
 ): Promise<EmbeddedNeovimSession> {
-  const handle = spawnNeovimProcess({
-    executable: options.executable,
-    args: options.args,
-    cwd: options.cwd ?? getCwd(),
-  });
-  const rpc = new NeovimRpcTransport(handle.child.stdout, handle.child.stdin);
-  const ui = new NeovimUi(rpc, options.size, options.onSnapshot);
-  wireProcessErrors(handle.child, rpc, options.onError, options.onExit);
-  if (options.onDirtyChange) {
-    rpc.onNotification("agenc_buffer_dirty_changed", (params) => {
-      options.onDirtyChange?.(dirtyFlagFromRpcNotificationParams(params));
-    });
-  }
-  rpc.onError(options.onError);
-  rpc.start();
+  const startupAbort = createStartupAbort(
+    options.signal,
+    options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
+  );
   try {
-    await ui.attach();
-    await editFile(rpc, options.filePath, options.line, options.column);
-    await configureEmbeddedEditing(rpc);
-    await installDirtyAutocmds(rpc);
-  } catch (error) {
-    ui.dispose();
-    rpc.close("startup failed");
-    handle.child.stdin.end();
-    let cleanupError: unknown;
+    startupAbort.signal.throwIfAborted();
+    const handle = spawnNeovimProcess({
+      executable: options.executable,
+      args: options.args,
+      cwd: options.cwd ?? getCwd(),
+    });
+    const rpc = new NeovimRpcTransport(handle.child.stdout, handle.child.stdin);
+    const ui = new NeovimUi(rpc, options.size, options.onSnapshot);
+    wireProcessErrors(handle.child, rpc, options.onError, options.onExit);
+    if (options.onDirtyChange) {
+      rpc.onNotification("agenc_buffer_dirty_changed", (params) => {
+        options.onDirtyChange?.(dirtyFlagFromRpcNotificationParams(params));
+      });
+    }
+    rpc.onError(options.onError);
+    rpc.start();
+    const abortStartup = (): void => {
+      rpc.close("startup aborted");
+    };
+    startupAbort.signal.addEventListener("abort", abortStartup, { once: true });
     try {
-      await waitForNeovimExit(
-        handle.child,
+      try {
+        await ui.attach();
+        await editFile(rpc, options.filePath, options.line, options.column);
+        await configureEmbeddedEditing(rpc);
+        await installDirtyAutocmds(rpc);
+        startupAbort.signal.throwIfAborted();
+      } catch (error) {
+        const startupError = startupAbort.signal.aborted
+          ? startupAbortReason(startupAbort.signal, error)
+          : error;
+        ui.dispose();
+        rpc.close("startup failed");
+        handle.child.stdin.end();
+        let cleanupError: unknown;
+        try {
+          await waitForNeovimExit(
+            handle.child,
+            options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS,
+          );
+        } catch (waitError) {
+          cleanupError = waitError;
+        } finally {
+          handle.kill("SIGKILL");
+        }
+        if (cleanupError !== undefined) {
+          throw new NeovimStartupCleanupError(
+            startupError,
+            cleanupError,
+            async () => {
+              ui.dispose();
+              rpc.close("startup cleanup retry");
+              if (!handle.child.stdin.writableEnded) handle.child.stdin.end();
+              try {
+                await waitForNeovimExit(
+                  handle.child,
+                  options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS,
+                );
+              } finally {
+                handle.kill("SIGKILL");
+              }
+            },
+          );
+        }
+        throw startupError;
+      }
+      return new EmbeddedNeovimSession(
+        handle,
+        rpc,
+        ui,
         options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS,
       );
-    } catch (waitError) {
-      cleanupError = waitError;
     } finally {
-      handle.kill("SIGKILL");
+      startupAbort.signal.removeEventListener("abort", abortStartup);
     }
-    if (cleanupError !== undefined) {
-      const primaryMessage = error instanceof Error ? error.message : String(error);
-      const cleanupMessage = cleanupError instanceof Error
-        ? cleanupError.message
-        : String(cleanupError);
-      throw new AggregateError(
-        [error, cleanupError],
-        `${primaryMessage}; Neovim startup cleanup failed: ${cleanupMessage}`,
-      );
-    }
-    throw error;
+  } finally {
+    startupAbort.dispose();
   }
-  return new EmbeddedNeovimSession(
-    handle,
-    rpc,
-    ui,
-    options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS,
-  );
+}
+
+function createStartupAbort(
+  parentSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): { readonly signal: AbortSignal; readonly dispose: () => void } {
+  const controller = new AbortController();
+  const abortFromParent = (): void => {
+    controller.abort(parentSignal?.reason);
+  };
+  if (parentSignal?.aborted) abortFromParent();
+  else parentSignal?.addEventListener("abort", abortFromParent, { once: true });
+
+  const safeTimeoutMs = Number.isFinite(timeoutMs)
+    ? Math.max(1, Math.floor(timeoutMs))
+    : DEFAULT_STARTUP_TIMEOUT_MS;
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`Embedded Neovim startup timed out after ${safeTimeoutMs}ms.`));
+  }, safeTimeoutMs);
+  timer.unref();
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      parentSignal?.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+function startupAbortReason(signal: AbortSignal, fallback: unknown): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  if (signal.reason !== undefined) return new Error(String(signal.reason), { cause: fallback });
+  return new Error("Embedded Neovim startup was aborted.", { cause: fallback });
+}
+
+function settleWithin<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  operationName: string,
+): Promise<T> {
+  const safeTimeoutMs = Number.isFinite(timeoutMs)
+    ? Math.max(1, Math.floor(timeoutMs))
+    : DEFAULT_CLEANUP_TIMEOUT_MS;
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new NeovimOperationTimeoutError(operationName, safeTimeoutMs));
+    }, safeTimeoutMs);
+    timer.unref();
+    operation.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function editFile(

--- a/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
+++ b/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
@@ -40,6 +40,7 @@ export class BufferProviderController {
   #lastSize: BufferProviderResize | null = null;
   #openGeneration = 0;
   #cleanupPromise: Promise<void> | null = null;
+  #replacementPromise: Promise<boolean> | null = null;
 
   constructor(selectionFactory: SelectionFactory = defaultSelectionFactory) {
     this.#selectionFactory = selectionFactory;
@@ -68,12 +69,39 @@ export class BufferProviderController {
     this.#lastOpen = { filePath, line };
     const cleanupPromise = this.#cleanupPromise;
     if (cleanupPromise) {
-      await cleanupPromise;
+      try {
+        await cleanupPromise;
+      } catch (error) {
+        if (generation === this.#openGeneration) {
+          this.#recordProviderFailure(this.#provider, error, "BUFFER provider cleanup failed");
+        }
+        return;
+      }
       if (generation !== this.#openGeneration) {
         return;
       }
     }
-    const selection = await this.#selectionFactory();
+    const replacementPromise = this.#replacementPromise;
+    if (replacementPromise) {
+      try {
+        await replacementPromise;
+      } catch (error) {
+        if (generation === this.#openGeneration) {
+          this.#recordProviderFailure(this.#provider, error, "BUFFER provider replacement failed");
+        }
+        return;
+      }
+      if (generation !== this.#openGeneration) return;
+    }
+    let selection: BufferProviderSelection;
+    try {
+      selection = await this.#selectionFactory();
+    } catch (error) {
+      if (generation === this.#openGeneration) {
+        this.#recordProviderFailure(this.#provider, error, "BUFFER provider open failed");
+      }
+      return;
+    }
     if (generation !== this.#openGeneration) {
       return;
     }
@@ -81,8 +109,21 @@ export class BufferProviderController {
     const provider = this.#provider?.identity.kind === selectedProvider.identity.kind
       ? this.#provider
       : selectedProvider;
-    await this.#replaceProvider(provider);
-    await provider.open({ filePath, line });
+    try {
+      if (!await this.#replaceProvider(provider, generation)) return;
+    } catch {
+      return;
+    }
+    if (generation !== this.#openGeneration || this.#provider !== provider) return;
+    try {
+      await provider.open({ filePath, line });
+    } catch (error) {
+      if (generation === this.#openGeneration) {
+        this.#recordProviderFailure(this.#provider ?? provider, error, "BUFFER provider open failed");
+      }
+      return;
+    }
+    if (generation !== this.#openGeneration || this.#provider !== provider) return;
     this.#syncSnapshot();
   }
 
@@ -95,7 +136,35 @@ export class BufferProviderController {
   }
 
   async close(options: BufferProviderCloseOptions = {}): Promise<boolean> {
-    const closed = await this.#provider?.close(options) ?? true;
+    const generation = this.#openGeneration + 1;
+    this.#openGeneration = generation;
+    const replacementPromise = this.#replacementPromise;
+    if (replacementPromise) {
+      try {
+        await replacementPromise;
+      } catch (error) {
+        if (generation === this.#openGeneration) {
+          this.#recordProviderFailure(this.#provider, error, "BUFFER provider replacement failed");
+        }
+        return false;
+      }
+      if (generation !== this.#openGeneration) return false;
+    }
+    const cleanupPromise = this.#cleanupPromise;
+    if (cleanupPromise) {
+      try {
+        await cleanupPromise;
+      } catch (error) {
+        if (generation === this.#openGeneration) {
+          this.#recordProviderFailure(this.#provider, error, "BUFFER provider cleanup failed");
+        }
+        return false;
+      }
+      if (generation !== this.#openGeneration) return false;
+    }
+    const provider = this.#provider;
+    const closed = await provider?.close(options) ?? true;
+    if (generation !== this.#openGeneration || provider !== this.#provider) return false;
     if (closed) this.#lastOpen = null;
     return closed;
   }
@@ -148,21 +217,39 @@ export class BufferProviderController {
   }
 
   async cleanup(): Promise<void> {
-    this.#openGeneration += 1;
-    if (this.#cleanupPromise) return this.#cleanupPromise;
+    const generation = this.#openGeneration + 1;
+    this.#openGeneration = generation;
+    const replacementPromise = this.#replacementPromise;
+    if (replacementPromise) {
+      // A replacement owns teardown until it settles. This cleanup generation
+      // makes installation stale; then cleanup can retry any retained provider.
+      await replacementPromise.catch(() => false);
+      if (generation !== this.#openGeneration) return;
+    }
+    if (this.#cleanupPromise) {
+      await this.#cleanupPromise;
+      if (generation === this.#openGeneration) this.#lastOpen = null;
+      return;
+    }
     const provider = this.#provider;
     const unsubscribe = this.#providerUnsubscribe;
-    this.#provider = null;
-    this.#providerUnsubscribe = null;
-    this.#lastOpen = null;
-    this.#snapshot = emptyProviderSnapshot(INITIAL_IDENTITY);
-    unsubscribe?.();
     this.#cleanupPromise = (async () => {
-      await provider?.cleanup();
+      try {
+        await provider?.cleanup();
+      } catch (error) {
+        this.#recordProviderFailure(provider, error, "BUFFER provider cleanup failed");
+        throw error;
+      }
+      if (this.#provider !== provider) return;
+      if (generation === this.#openGeneration) this.#lastOpen = null;
+      unsubscribe?.();
+      this.#provider = null;
+      this.#providerUnsubscribe = null;
+      this.#snapshot = emptyProviderSnapshot(INITIAL_IDENTITY);
+      this.#emit();
     })().finally(() => {
       this.#cleanupPromise = null;
     });
-    this.#emit();
     return this.#cleanupPromise;
   }
 
@@ -171,19 +258,121 @@ export class BufferProviderController {
     if (lastOpen) await this.open(lastOpen.filePath, lastOpen.line);
   }
 
-  async #replaceProvider(provider: BufferEditorProvider): Promise<void> {
-    if (this.#provider === provider) return;
-    this.#providerUnsubscribe?.();
-    await this.#provider?.cleanup();
+  async #replaceProvider(provider: BufferEditorProvider, generation: number): Promise<boolean> {
+    if (this.#provider === provider) return true;
+    if (this.#replacementPromise) {
+      await this.#replacementPromise;
+      if (generation !== this.#openGeneration) return false;
+      return this.#replaceProvider(provider, generation);
+    }
+    const replacement = this.#replaceProviderOnce(provider, generation);
+    this.#replacementPromise = replacement;
+    try {
+      return await replacement;
+    } finally {
+      if (this.#replacementPromise === replacement) this.#replacementPromise = null;
+    }
+  }
+
+  async #replaceProviderOnce(
+    provider: BufferEditorProvider,
+    generation: number,
+  ): Promise<boolean> {
+    const previousProvider = this.#provider;
+    const previousUnsubscribe = this.#providerUnsubscribe;
+    if (previousProvider) {
+      try {
+        const closed = await previousProvider.close({ discard: false });
+        if (!closed) {
+          this.#recordProviderCloseRefusal(previousProvider);
+          return false;
+        }
+      } catch (error) {
+        this.#recordProviderFailure(previousProvider, error, "BUFFER provider close failed");
+        throw error;
+      }
+      try {
+        await previousProvider.cleanup();
+      } catch (error) {
+        this.#recordProviderFailure(previousProvider, error, "BUFFER provider cleanup failed");
+        throw error;
+      }
+    }
+    if (this.#provider !== previousProvider) return false;
+    previousUnsubscribe?.();
+    this.#provider = null;
+    this.#providerUnsubscribe = null;
+    if (generation !== this.#openGeneration) {
+      this.#snapshot = emptyProviderSnapshot(INITIAL_IDENTITY);
+      this.#emit();
+      return false;
+    }
     this.#provider = provider;
     this.#providerUnsubscribe = provider.subscribe(() => this.#syncSnapshot());
     if (this.#lastSize) provider.resize(this.#lastSize);
     this.#syncSnapshot();
+    return true;
   }
 
   #syncSnapshot(): void {
     if (!this.#provider) return;
     this.#snapshot = this.#provider.getSnapshot();
+    this.#emit();
+  }
+
+  #publishDirtyOpenConflict(providerSnapshot: BufferProviderSnapshot): void {
+    const message = "Unsaved edits. Save, revert, or close-discard before opening another file.";
+    this.#snapshot = {
+      ...providerSnapshot,
+      status: "conflict",
+      providerStatus: "conflict",
+      providerMessage: message,
+      error: message,
+      conflictKind: "disk",
+    };
+    this.#emit();
+  }
+
+  #recordProviderCloseRefusal(provider: BufferEditorProvider): void {
+    const snapshot = provider.getSnapshot();
+    if (
+      (snapshot.providerStatus === "conflict" || snapshot.providerStatus === "error") &&
+      snapshot.error
+    ) {
+      this.#snapshot = snapshot;
+      this.#emit();
+      return;
+    }
+    if (snapshot.dirty) {
+      this.#publishDirtyOpenConflict(snapshot);
+      return;
+    }
+    this.#recordProviderFailure(
+      provider,
+      new Error("active provider refused a non-discarding close"),
+      "BUFFER provider replacement blocked",
+    );
+  }
+
+  #recordProviderFailure(
+    provider: BufferEditorProvider | null,
+    error: unknown,
+    context: string,
+  ): void {
+    const providerSnapshot = provider?.getSnapshot();
+    if (providerSnapshot?.providerStatus === "error" && providerSnapshot.error) {
+      this.#snapshot = providerSnapshot;
+    } else {
+      const message = error instanceof Error ? error.message : String(error);
+      this.#snapshot = {
+        ...this.#snapshot,
+        status: "error",
+        providerStatus: "error",
+        providerMessage: `${context}: ${message}`,
+        error: `${context}: ${message}`,
+        conflictKind: null,
+      };
+    }
     this.#emit();
   }
 
@@ -199,9 +388,10 @@ export function getWorkbenchBufferProviderController(): BufferProviderController
   return singleton;
 }
 
-export function resetWorkbenchBufferProviderControllerForTesting(): void {
-  void singleton?.cleanup();
+export async function resetWorkbenchBufferProviderControllerForTesting(): Promise<void> {
+  const controller = singleton;
   singleton = null;
+  await controller?.cleanup();
 }
 
 function defaultSelectionFactory(): Promise<BufferProviderSelection> {

--- a/runtime/src/tui/workbench/buffer/providers/external/ExternalEditorProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/external/ExternalEditorProvider.ts
@@ -2,7 +2,7 @@ import {
   openFileInBufferExternalEditor,
   type BufferExternalEditorLauncher,
 } from "../../externalEditor.js";
-import { readBufferFileSnapshot } from "../../fileSnapshot.js";
+import { readBufferFileSnapshot, type BufferFileSnapshot } from "../../fileSnapshot.js";
 import type { BufferMove } from "../../editing.js";
 import type {
   BufferEditorProvider,
@@ -34,10 +34,16 @@ export class ExternalEditorProvider implements BufferEditorProvider {
   };
   readonly #listeners = new Set<BufferProviderListener>();
   readonly #launcher: BufferExternalEditorLauncher;
+  readonly #readFileSnapshot: (filePath: string) => Promise<BufferFileSnapshot>;
   #snapshot: BufferProviderSnapshot = emptyProviderSnapshot(this.identity);
+  #openGeneration = 0;
 
-  constructor(launcher: BufferExternalEditorLauncher = openFileInBufferExternalEditor) {
+  constructor(
+    launcher: BufferExternalEditorLauncher = openFileInBufferExternalEditor,
+    readFileSnapshot: (filePath: string) => Promise<BufferFileSnapshot> = readBufferFileSnapshot,
+  ) {
     this.#launcher = launcher;
+    this.#readFileSnapshot = readFileSnapshot;
   }
 
   subscribe(listener: BufferProviderListener): () => void {
@@ -56,7 +62,16 @@ export class ExternalEditorProvider implements BufferEditorProvider {
   }
 
   async open(options: BufferProviderOpenOptions): Promise<void> {
-    const file = await readBufferFileSnapshot(options.filePath);
+    const generation = this.#openGeneration + 1;
+    this.#openGeneration = generation;
+    let file: BufferFileSnapshot;
+    try {
+      file = await this.#readFileSnapshot(options.filePath);
+    } catch (error) {
+      if (generation !== this.#openGeneration) return;
+      throw error;
+    }
+    if (generation !== this.#openGeneration) return;
     let opened = false;
     let launchError: string | null = null;
     try {
@@ -84,6 +99,7 @@ export class ExternalEditorProvider implements BufferEditorProvider {
   }
 
   async close(_options: BufferProviderCloseOptions = {}): Promise<boolean> {
+    this.#openGeneration += 1;
     this.#snapshot = emptyProviderSnapshot(this.identity);
     this.#emit();
     return true;

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -6,7 +6,13 @@ import {
   type BufferFileSnapshot,
   type BufferLineEndings,
 } from "../../fileSnapshot.js";
-import { startEmbeddedNeovim, type EmbeddedNeovimSession, type StartEmbeddedNeovimOptions } from "../../neovim/NeovimLifecycle.js";
+import {
+  NeovimStartupCleanupError,
+  startEmbeddedNeovim,
+  type EmbeddedNeovimSession,
+  type NeovimCloseResult,
+  type StartEmbeddedNeovimOptions,
+} from "../../neovim/NeovimLifecycle.js";
 import type { NeovimDiscoveryResult } from "../../neovim/NeovimDiscovery.js";
 import { translateKeyToNeovimInput } from "../../neovim/NeovimInput.js";
 import { createNeovimRenderSnapshot, type NeovimRenderSnapshot } from "../../neovim/NeovimGrid.js";
@@ -33,13 +39,37 @@ export type NeovimBufferProviderOptions = {
   readonly openExternalEditor?: BufferExternalEditorLauncher;
   readonly readFileSnapshot?: (filePath: string) => Promise<BufferFileSnapshot>;
   readonly startSession?: (options: StartEmbeddedNeovimOptions) => Promise<EmbeddedNeovimSession>;
+  readonly startupTimeoutMs?: number;
   readonly cleanupTimeoutMs?: number;
+};
+
+type NeovimProviderOwnership = {
+  readonly generation: number;
+  readonly session: EmbeddedNeovimSession;
+  readonly filePath: string | null;
+  readonly absolutePath: string | null;
+};
+
+type NeovimOperationOwnership = NeovimProviderOwnership & {
+  readonly openGeneration: number;
+};
+
+type NeovimFileOwnership = Omit<NeovimProviderOwnership, "session"> & {
+  readonly openGeneration: number;
+};
+
+type NeovimPendingSessionStart = {
+  readonly controller: AbortController;
+  readonly promise: Promise<EmbeddedNeovimSession>;
+  session: EmbeddedNeovimSession | null;
+  disposalPromise: Promise<void> | null;
 };
 
 export class NeovimBufferProvider implements BufferEditorProvider {
   readonly identity: BufferProviderIdentity;
   readonly #listeners = new Set<BufferProviderListener>();
   readonly #discovery: Extract<NeovimDiscoveryResult, { readonly usable: true }>;
+  readonly #startupTimeoutMs: number | undefined;
   readonly #cleanupTimeoutMs: number | undefined;
   readonly #openExternalEditor: BufferExternalEditorLauncher;
   readonly #readFileSnapshot: (filePath: string) => Promise<BufferFileSnapshot>;
@@ -56,9 +86,13 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   #dirty = false;
   #statusMessage: string | null = null;
   #openGeneration = 0;
+  #pendingTransitionGeneration: number | null = null;
+  #ownershipGeneration = 0;
+  #pendingSessionStart: NeovimPendingSessionStart | null = null;
 
   constructor(options: NeovimBufferProviderOptions) {
     this.#discovery = options.discovery;
+    this.#startupTimeoutMs = options.startupTimeoutMs;
     this.#cleanupTimeoutMs = options.cleanupTimeoutMs;
     this.#openExternalEditor = options.openExternalEditor ?? openFileInBufferExternalEditor;
     this.#readFileSnapshot = options.readFileSnapshot ?? readBufferFileSnapshot;
@@ -90,11 +124,43 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   async open(options: BufferProviderOpenOptions): Promise<void> {
     const generation = this.#openGeneration + 1;
     this.#openGeneration = generation;
-    await this.#session?.cleanup();
-    this.#session = null;
-    this.#fileSnapshot = null;
-    this.#setSnapshot("loading", null);
+    this.#pendingTransitionGeneration = generation;
     try {
+      if (this.#pendingSessionStart) {
+        await this.#cancelPendingSessionStart().catch((error) => {
+          throw cleanupError("before opening another file", error);
+        });
+      }
+      if (generation !== this.#openGeneration) return;
+      const previousSession = this.#session;
+      if (previousSession) {
+        if (options.filePath === this.#filePath && this.#dirty) {
+          this.#setSnapshot("ready", null);
+          return;
+        }
+        const previousOwnership = this.#captureOwnership(previousSession);
+        const closeResult = await previousSession.quit(false).catch((error) => {
+          throw cleanupError("before opening another file", error);
+        });
+        if (generation !== this.#openGeneration) return;
+        if (!closeResult.closed) {
+          if (!this.#owns(previousOwnership)) return;
+          this.#dirty = true;
+          this.#setSnapshot(
+            "conflict",
+            "Unsaved edits. Save, revert, or close-discard before opening another file.",
+            "disk",
+          );
+          return;
+        }
+        this.#releaseSession(previousSession);
+      }
+      // The previous file is no longer owned once its session closes. Clear it
+      // before the asynchronous read so external-editor handoff cannot capture
+      // and reopen a stale path while the requested file is still loading.
+      this.#resetFileState();
+      this.#terminal = createNeovimRenderSnapshot(this.#size.rows, this.#size.columns);
+      this.#setSnapshot("loading", null);
       const file = await this.#readFileSnapshot(options.filePath);
       if (generation !== this.#openGeneration) return;
       this.#filePath = file.filePath;
@@ -102,46 +168,93 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       this.#fileSnapshot = file;
       this.#encoding = file.encoding;
       this.#lineEndings = file.lineEndings;
-      this.#terminal = createNeovimRenderSnapshot(this.#size.rows, this.#size.columns);
-      const isCurrentOpen = () => generation === this.#openGeneration;
-      const session = await this.#startSession({
-        executable: this.#discovery.executable,
-        args: this.#discovery.args,
-        filePath: file.absolutePath,
-        line: options.line ?? 1,
-        column: options.column ?? 0,
-        size: this.#size,
-        cleanupTimeoutMs: this.#cleanupTimeoutMs,
-        onSnapshot: (terminal) => {
-          if (!isCurrentOpen()) return;
-          this.#terminal = terminal;
-          this.#setSnapshot("ready", null);
-        },
-        onDirtyChange: (dirty) => {
-          if (!isCurrentOpen()) return;
-          this.#handleDirtyChange(dirty);
-        },
-        onError: (error) => {
-          if (!isCurrentOpen()) return;
-          this.#setSnapshot("error", error.message);
-        },
-        onExit: () => {
-          if (!isCurrentOpen()) return;
-          this.#session = null;
-          this.#setSnapshot("closed", "Embedded Neovim exited.");
-        },
-      });
-      if (generation !== this.#openGeneration) {
-        await session.cleanup().catch(() => {});
+      let exited = false;
+      let committedOwnership: NeovimProviderOwnership | null = null;
+      const isCurrentOpen = () => !exited && (
+        committedOwnership
+          ? this.#owns(committedOwnership)
+          : generation === this.#openGeneration
+      );
+      const startupController = new AbortController();
+      const pendingStart: NeovimPendingSessionStart = {
+        controller: startupController,
+        promise: Promise.resolve().then(() => this.#startSession({
+          executable: this.#discovery.executable,
+          args: this.#discovery.args,
+          filePath: file.absolutePath,
+          line: options.line ?? 1,
+          column: options.column ?? 0,
+          size: this.#size,
+          signal: startupController.signal,
+          startupTimeoutMs: this.#startupTimeoutMs,
+          cleanupTimeoutMs: this.#cleanupTimeoutMs,
+          onSnapshot: (terminal) => {
+            if (!isCurrentOpen()) return;
+            this.#terminal = terminal;
+            if (generation === this.#openGeneration) {
+              this.#setSnapshot("ready", null);
+            } else {
+              this.#emitSnapshot();
+            }
+          },
+          onDirtyChange: (dirty) => {
+            if (!isCurrentOpen()) return;
+            this.#handleDirtyChange(dirty);
+          },
+          onError: (error) => {
+            if (!isCurrentOpen()) return;
+            this.#setSnapshot("error", error.message);
+          },
+          onExit: () => {
+            if (!isCurrentOpen()) return;
+            exited = true;
+            if (committedOwnership) this.#releaseSession(committedOwnership.session);
+            this.#setSnapshot("closed", "Embedded Neovim exited.");
+          },
+        })),
+        session: null,
+        disposalPromise: null,
+      };
+      this.#pendingSessionStart = pendingStart;
+      let session: EmbeddedNeovimSession;
+      try {
+        session = await pendingStart.promise;
+        pendingStart.session = session;
+      } catch (error) {
+        if (
+          !(error instanceof NeovimStartupCleanupError) &&
+          generation === this.#openGeneration &&
+          this.#pendingSessionStart === pendingStart
+        ) {
+          this.#pendingSessionStart = null;
+        }
+        throw error;
+      }
+      if (generation !== this.#openGeneration || exited) {
+        await this.#disposePendingSessionStart(pendingStart).catch((error) => {
+          throw cleanupError(
+            exited ? "after exiting during startup" : "after startup was superseded",
+            error,
+          );
+        });
         return;
       }
+      if (this.#pendingSessionStart === pendingStart) this.#pendingSessionStart = null;
       this.#session = session;
-      await this.#refreshDirty();
+      this.#ownershipGeneration += 1;
+      committedOwnership = this.#captureOwnership(session);
+      const openingOwnership = this.#captureOperationOwnership(session);
+      await this.#refreshDirty(openingOwnership);
+      if (exited || !this.#ownsOperation(openingOwnership)) return;
       this.#setSnapshot("ready", null);
     } catch (error) {
       if (generation !== this.#openGeneration) return;
       const message = error instanceof Error ? error.message : String(error);
       this.#setSnapshot("error", message);
+    } finally {
+      if (this.#pendingTransitionGeneration === generation) {
+        this.#pendingTransitionGeneration = null;
+      }
     }
   }
 
@@ -154,15 +267,32 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       );
       return false;
     }
-    if (!this.#session) return false;
+    const session = this.#session;
+    if (!session) return false;
+    const ownership = this.#captureOperationOwnership(session);
+    const fileSnapshot = this.#fileSnapshot;
+    const previousSnapshot = this.#snapshot;
+    const previousStatusMessage = this.#statusMessage;
     this.#setSnapshot("saving", null);
     try {
-      await this.#assertNoDiskConflict(options.force === true);
-      await this.#session.save(options.force === true);
-      await this.#refreshDirty();
+      await this.#assertNoDiskConflict(options.force === true, fileSnapshot);
+      if (!this.#ownsOperation(ownership)) return false;
+      const saved = await session.save(options.force === true);
+      if (!this.#ownsOperation(ownership)) return false;
+      if (!saved) {
+        this.#restoreActionableSnapshot(
+          previousSnapshot,
+          previousStatusMessage,
+          "Embedded Neovim is closed; no file was saved.",
+        );
+        return false;
+      }
+      await this.#refreshDirty(ownership);
+      if (!this.#ownsOperation(ownership)) return false;
       this.#setSnapshot("ready", null);
       return true;
     } catch (error) {
+      if (!this.#ownsOperation(ownership)) return false;
       if (error instanceof BufferSaveConflictError) {
         this.#setSnapshot("conflict", error.message, "disk");
         return false;
@@ -173,59 +303,134 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   }
 
   async revert(): Promise<void> {
-    if (!this.#session) return;
-    await this.#session.input("<Esc>:edit!<CR>");
-    await this.#refreshDirty();
+    const session = this.#session;
+    if (!session) return;
+    const ownership = this.#captureOperationOwnership(session);
+    const previousSnapshot = this.#snapshot;
+    const previousStatusMessage = this.#statusMessage;
+    const reverted = await session.input("<Esc>:edit!<CR>");
+    if (!this.#ownsOperation(ownership)) return;
+    if (reverted === false) {
+      this.#restoreActionableSnapshot(
+        previousSnapshot,
+        previousStatusMessage,
+        "Embedded Neovim is closed; the file was not reverted.",
+      );
+      return;
+    }
+    await this.#refreshDirty(ownership);
+    if (!this.#ownsOperation(ownership)) return;
     this.#setSnapshot("ready", null);
   }
 
   async close(options: BufferProviderCloseOptions = {}): Promise<boolean> {
-    const session = this.#session;
-    if (!session) {
+    const generation = this.#openGeneration + 1;
+    this.#openGeneration = generation;
+    this.#pendingTransitionGeneration = generation;
+    try {
+      if (this.#pendingSessionStart) {
+        try {
+          await this.#cancelPendingSessionStart();
+        } catch (error) {
+          if (generation !== this.#openGeneration) return false;
+          this.#setSnapshot("error", cleanupError("while closing BUFFER", error).message);
+          return false;
+        }
+      }
+      if (generation !== this.#openGeneration) return false;
+      const session = this.#session;
+      if (!session) {
+        this.#resetFileState();
+        this.#setSnapshot("idle", null);
+        return true;
+      }
+      let result: NeovimCloseResult;
+      try {
+        result = await session.quit(options.discard === true);
+      } catch (error) {
+        if (generation !== this.#openGeneration) return false;
+        this.#setSnapshot("error", cleanupError("while closing BUFFER", error).message);
+        return false;
+      }
+      if (generation !== this.#openGeneration) return false;
+      if (!result.closed) {
+        this.#setSnapshot("conflict", result.reason);
+        return false;
+      }
+      this.#releaseSession(session);
+      this.#resetFileState();
       this.#setSnapshot("idle", null);
       return true;
+    } finally {
+      if (this.#pendingTransitionGeneration === generation) {
+        this.#pendingTransitionGeneration = null;
+      }
     }
-    const result = await session.quit(options.discard === true);
-    if (!result.closed) {
-      this.#setSnapshot("conflict", result.reason);
-      return false;
-    }
-    this.#session = null;
-    this.#fileSnapshot = null;
-    this.#dirty = false;
-    this.#setSnapshot("idle", null);
-    return true;
   }
 
   async openExternalEditor(): Promise<boolean> {
-    if (!this.#absolutePath) return false;
-    if (await this.#readCurrentDirtyState()) {
+    if (this.#pendingTransitionGeneration !== null || this.#pendingSessionStart !== null) {
+      return false;
+    }
+    const session = this.#session;
+    const fileOwnership = this.#captureFileOwnership();
+    if (!fileOwnership.absolutePath) return false;
+    const sessionOwnership = session ? this.#captureOperationOwnership(session) : null;
+    let dirty = this.#dirty;
+    if (sessionOwnership) {
+      try {
+        // External handoff must cover hidden buffers as well as the active
+        // buffer: launching first and relying on a later :qa refusal would let
+        // another editor race unsaved in-memory state.
+        dirty = await sessionOwnership.session.hasUnsavedBuffers();
+      } catch (error) {
+        if (this.#ownsOperation(sessionOwnership) && this.#ownsFile(fileOwnership)) {
+          this.#setSnapshot(
+            "error",
+            `Unable to verify embedded Neovim dirty state: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        return false;
+      }
+      if (!this.#ownsOperation(sessionOwnership)) return false;
+    }
+    if (!this.#ownsFile(fileOwnership)) return false;
+    this.#dirty = dirty;
+    if (dirty) {
       this.#setSnapshot("conflict", "Save or force quit embedded Neovim edits before opening an external editor.");
       return false;
     }
     const line = this.#terminal.cursor.row + 1;
     let opened = false;
     try {
-      opened = this.#openExternalEditor(this.#absolutePath, line);
+      opened = this.#openExternalEditor(fileOwnership.absolutePath, line);
     } catch (error) {
-      this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
+      if (this.#ownsFile(fileOwnership)) {
+        this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
+      }
       return false;
     }
+    if (!this.#ownsFile(fileOwnership)) return false;
     if (!opened) {
       this.#setSnapshot("error", "No external editor is available for BUFFER. Set VISUAL or EDITOR.");
       return false;
     }
-    await this.open({ filePath: reloadPathAfterExternalEditor(this.#filePath, this.#absolutePath), line });
+    await this.open({
+      filePath: reloadPathAfterExternalEditor(fileOwnership.filePath, fileOwnership.absolutePath),
+      line,
+    });
     return true;
   }
 
   undo(): boolean {
-    void this.#session?.input("u");
+    const session = this.#session;
+    if (session) void this.#sendInput(session, "u");
     return true;
   }
 
   redo(): boolean {
-    void this.#session?.input("<C-r>");
+    const session = this.#session;
+    if (session) void this.#sendInput(session, "<C-r>");
     return true;
   }
 
@@ -245,7 +450,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     const session = this.#session;
     if (!session) return false;
     if (event.isPaste === true) {
-      void session.paste(event.input).catch((error) => this.#setInputError(error));
+      void this.#runSessionAction(session, () => session.paste(event.input));
       return true;
     }
     const keys = translateKeyToNeovimInput(event.input, event.key);
@@ -257,9 +462,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   click(row: number, column: number): boolean {
     const session = this.#session;
     if (!session) return false;
-    void session.click(row, column).catch((error) => {
-      this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
-    });
+    void this.#runSessionAction(session, () => session.click(row, column));
     return true;
   }
 
@@ -268,68 +471,231 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       rows: Math.max(1, Math.floor(size.rows)),
       columns: Math.max(1, Math.floor(size.columns)),
     };
-    void this.#session?.resize(this.#size).catch((error) => {
-      this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
-    });
+    const session = this.#session;
+    if (session) void this.#runSessionAction(session, () => session.resize(this.#size));
   }
 
   focus(focused: boolean): void {
-    void this.#session?.focus(focused).catch((error) => {
-      this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
-    });
+    const session = this.#session;
+    if (session) void this.#runSessionAction(session, () => session.focus(focused));
   }
 
   async cleanup(): Promise<void> {
-    this.#openGeneration += 1;
-    await this.#session?.cleanup();
-    this.#session = null;
+    const generation = this.#openGeneration + 1;
+    this.#openGeneration = generation;
+    this.#pendingTransitionGeneration = generation;
+    let session: EmbeddedNeovimSession | null = null;
+    try {
+      if (this.#pendingSessionStart) await this.#cancelPendingSessionStart();
+      if (generation !== this.#openGeneration) return;
+      session = this.#session;
+      await session?.cleanup();
+    } catch (error) {
+      const failure = cleanupError("while releasing BUFFER", error);
+      if (generation === this.#openGeneration) this.#setSnapshot("error", failure.message);
+      throw failure;
+    } finally {
+      if (this.#pendingTransitionGeneration === generation) {
+        this.#pendingTransitionGeneration = null;
+      }
+    }
+    if (generation !== this.#openGeneration) return;
+    if (session) this.#releaseSession(session);
+    this.#resetFileState();
+    this.#setSnapshot("idle", null);
+  }
+
+  async #cancelPendingSessionStart(): Promise<void> {
+    const pendingStart = this.#pendingSessionStart;
+    if (!pendingStart) return;
+    pendingStart.controller.abort(new Error("Embedded Neovim startup was superseded."));
+    await this.#disposePendingSessionStart(pendingStart);
+  }
+
+  async #disposePendingSessionStart(pendingStart: NeovimPendingSessionStart): Promise<void> {
+    pendingStart.controller.abort(new Error("Embedded Neovim startup was superseded."));
+    if (pendingStart.disposalPromise) return pendingStart.disposalPromise;
+
+    const attempt = (async () => {
+      let session = pendingStart.session;
+      if (!session) {
+        try {
+          session = await pendingStart.promise;
+          pendingStart.session = session;
+        } catch (error) {
+          if (error instanceof NeovimStartupCleanupError) {
+            try {
+              await error.retryCleanup();
+            } catch (retryError) {
+              throw new AggregateError(
+                [error, retryError],
+                `${error.message}; startup cleanup retry failed: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
+                { cause: error },
+              );
+            }
+            return;
+          }
+          if (pendingStart.controller.signal.aborted) return;
+          throw error;
+        }
+      }
+      try {
+        await session.cleanup();
+        if (this.#session === session) this.#releaseSession(session);
+      } catch (error) {
+        if (this.#session === null) {
+          this.#session = session;
+          this.#ownershipGeneration += 1;
+        }
+        throw error;
+      }
+    })();
+    pendingStart.disposalPromise = attempt;
+    try {
+      await attempt;
+      if (this.#pendingSessionStart === pendingStart) this.#pendingSessionStart = null;
+    } finally {
+      if (pendingStart.disposalPromise === attempt) pendingStart.disposalPromise = null;
+    }
+  }
+
+  #resetFileState(): void {
+    this.#ownershipGeneration += 1;
     this.#filePath = null;
     this.#absolutePath = null;
     this.#fileSnapshot = null;
     this.#encoding = null;
     this.#lineEndings = null;
     this.#dirty = false;
-    this.#setSnapshot("idle", null);
   }
 
-  async #refreshDirty(): Promise<void> {
-    const session = this.#session;
-    if (!session) return;
-    this.#dirty = await this.#readCurrentDirtyState();
-    if (!this.#dirty) await this.#refreshFileSnapshot();
+  #captureOwnership(session: EmbeddedNeovimSession): NeovimProviderOwnership {
+    return {
+      generation: this.#ownershipGeneration,
+      session,
+      filePath: this.#filePath,
+      absolutePath: this.#absolutePath,
+    };
+  }
+
+  #captureOperationOwnership(session: EmbeddedNeovimSession): NeovimOperationOwnership {
+    return {
+      ...this.#captureOwnership(session),
+      openGeneration: this.#openGeneration,
+    };
+  }
+
+  #captureFileOwnership(): NeovimFileOwnership {
+    return {
+      generation: this.#ownershipGeneration,
+      openGeneration: this.#openGeneration,
+      filePath: this.#filePath,
+      absolutePath: this.#absolutePath,
+    };
+  }
+
+  #owns(ownership: NeovimProviderOwnership): boolean {
+    return ownership.generation === this.#ownershipGeneration &&
+      ownership.session === this.#session &&
+      ownership.filePath === this.#filePath &&
+      ownership.absolutePath === this.#absolutePath;
+  }
+
+  #ownsOperation(ownership: NeovimOperationOwnership): boolean {
+    return ownership.openGeneration === this.#openGeneration && this.#owns(ownership);
+  }
+
+  #ownsFile(ownership: NeovimFileOwnership): boolean {
+    return ownership.generation === this.#ownershipGeneration &&
+      ownership.openGeneration === this.#openGeneration &&
+      ownership.filePath === this.#filePath &&
+      ownership.absolutePath === this.#absolutePath;
+  }
+
+  async #refreshDirty(ownership: NeovimOperationOwnership): Promise<void> {
+    const dirty = await this.#readCurrentDirtyState(ownership);
+    if (!this.#ownsOperation(ownership)) return;
+    this.#dirty = dirty;
+    if (!this.#dirty) {
+      await this.#refreshFileSnapshot(ownership, () => this.#ownsOperation(ownership));
+    }
+    if (!this.#ownsOperation(ownership)) return;
     this.#emitSnapshot();
   }
 
   async #sendInput(session: EmbeddedNeovimSession, keys: string): Promise<void> {
-    await session.input(keys).catch((error) => this.#setInputError(error));
+    await this.#runSessionAction(session, () => session.input(keys));
+  }
+
+  async #runSessionAction(
+    session: EmbeddedNeovimSession,
+    action: () => Promise<unknown>,
+  ): Promise<void> {
+    const ownership = this.#captureOperationOwnership(session);
+    try {
+      await action();
+    } catch (error) {
+      if (this.#ownsOperation(ownership)) this.#setInputError(error);
+    }
   }
 
   #setInputError(error: unknown): void {
     this.#setSnapshot("error", error instanceof Error ? error.message : String(error));
   }
 
-  async #readCurrentDirtyState(): Promise<boolean> {
-    const session = this.#session;
-    if (!session) return this.#dirty;
-    return session.isDirty().then((dirty) => {
-      this.#dirty = dirty;
+  #restoreActionableSnapshot(
+    snapshot: BufferProviderSnapshot,
+    statusMessage: string | null,
+    fallbackMessage: string,
+  ): void {
+    if (
+      (snapshot.providerStatus === "error" || snapshot.providerStatus === "conflict") &&
+      snapshot.error
+    ) {
+      this.#snapshot = snapshot;
+      this.#statusMessage = statusMessage;
+      this.#emit();
+      return;
+    }
+    this.#setSnapshot("error", fallbackMessage);
+  }
+
+  async #readCurrentDirtyState(
+    ownership: NeovimOperationOwnership | null = this.#session
+      ? this.#captureOperationOwnership(this.#session)
+      : null,
+  ): Promise<boolean> {
+    if (!ownership) return this.#dirty;
+    return ownership.session.isDirty().then((dirty) => {
+      if (!this.#ownsOperation(ownership)) return this.#dirty;
       return dirty;
     }, () => this.#dirty);
   }
 
   #handleDirtyChange(dirty: boolean): void {
+    const session = this.#session;
+    if (!session) return;
+    const ownership = this.#captureOwnership(session);
     this.#dirty = dirty;
     if (dirty) {
       this.#emitSnapshot();
       return;
     }
-    void this.#refreshFileSnapshot().finally(() => {
-      this.#emitSnapshot();
+    void this.#refreshFileSnapshot(ownership).finally(() => {
+      if (this.#owns(ownership)) this.#emitSnapshot();
     });
   }
 
-  async #assertNoDiskConflict(force: boolean): Promise<void> {
-    const snapshot = this.#fileSnapshot;
+  #releaseSession(session: EmbeddedNeovimSession): void {
+    if (this.#session !== session) return;
+    this.#session = null;
+    this.#ownershipGeneration += 1;
+  }
+
+  async #assertNoDiskConflict(
+    force: boolean,
+    snapshot: BufferFileSnapshot | null,
+  ): Promise<void> {
     if (force || !snapshot) return;
     const current = await this.#readFileSnapshot(snapshot.absolutePath).catch(() => {
       throw new BufferSaveConflictError(snapshot.filePath);
@@ -339,11 +705,15 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     }
   }
 
-  async #refreshFileSnapshot(): Promise<void> {
-    const paths = refreshableFileSnapshotPaths(this.#absolutePath, this.#filePath);
+  async #refreshFileSnapshot(
+    ownership: NeovimProviderOwnership,
+    owns: () => boolean = () => this.#owns(ownership),
+  ): Promise<void> {
+    const paths = refreshableFileSnapshotPaths(ownership.absolutePath, ownership.filePath);
     if (!paths) return;
     try {
       const file = await this.#readFileSnapshot(paths.absolutePath);
+      if (!owns()) return;
       this.#fileSnapshot = { ...file, filePath: paths.filePath };
       this.#encoding = file.encoding;
       this.#lineEndings = file.lineEndings;
@@ -388,6 +758,12 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       providerMessage: this.#statusMessage,
       encoding: this.#encoding,
       lineEndings: this.#lineEndings,
+      lineCount: this.#terminal.lines.length,
+      position: positionFromNeovimCursor(this.#terminal.cursor.row + 1, this.#terminal.cursor.column),
+      viewportRows: this.#size.rows,
+      terminal: this.#terminal,
+      vimMode: neovimModeToVimMode(this.#terminal.mode),
+      vimCommandLine: this.#terminal.commandLine,
     };
     this.#emit();
   }
@@ -412,4 +788,9 @@ function neovimModeToVimMode(mode: string): BufferProviderSnapshot["vimMode"] {
   if (mode.startsWith("insert")) return "INSERT";
   if (mode.startsWith("visual") || mode === "v" || mode === "V") return "VISUAL";
   return "NORMAL";
+}
+
+function cleanupError(context: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(`Embedded Neovim cleanup failed ${context}: ${message}`, { cause: error });
 }

--- a/runtime/src/tui/workbench/buffer/providers/selectBufferEditorProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/selectBufferEditorProvider.ts
@@ -10,6 +10,8 @@ export type BufferProviderMode = "auto" | "neovim" | "inline" | "external";
 export type BufferProviderSelectionConfig = NeovimDiscoveryConfig & {
   readonly mode?: BufferProviderMode;
   readonly inlineStore?: WorkbenchBufferStore;
+  readonly startupTimeoutMs?: number;
+  readonly cleanupTimeoutMs?: number;
 };
 
 export type BufferProviderSelection =
@@ -57,7 +59,11 @@ export async function selectBufferEditorProvider(
   if (discovery.usable) {
     return {
       kind: "neovim",
-      provider: new NeovimBufferProvider({ discovery }),
+      provider: new NeovimBufferProvider({
+        discovery,
+        startupTimeoutMs: config.startupTimeoutMs,
+        cleanupTimeoutMs: config.cleanupTimeoutMs,
+      }),
       discovery,
     };
   }
@@ -86,6 +92,8 @@ export function bufferProviderConfigFromEnv(env: NodeJS.ProcessEnv = process.env
     executable: env.AGENC_BUFFER_NVIM,
     useUserInit: parseUseUserInit(env.AGENC_BUFFER_NVIM_USE_INIT),
     timeoutMs: parsePositiveInteger(env.AGENC_BUFFER_NVIM_TIMEOUT_MS),
+    startupTimeoutMs: parsePositiveInteger(env.AGENC_BUFFER_NVIM_STARTUP_TIMEOUT_MS),
+    cleanupTimeoutMs: parsePositiveInteger(env.AGENC_BUFFER_NVIM_CLEANUP_TIMEOUT_MS),
   };
 }
 

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { peekLSPDiagnosticsForFile } from "../../../services/lsp/LSPDiagnosticRegistry.js";
 import type { DiagnosticEntry } from "../../../services/lsp/types.js";
+import { logError } from "../../../utils/log.js";
 import { useTerminalSize } from "../../hooks/useTerminalSize.js";
 import type { DOMElement } from "../../ink/dom.js";
 import type { InputEvent } from "../../ink/events/input-event.js";
@@ -67,7 +68,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
       !snapshot.dirty;
     if (!isNewRequest && !shouldRetryCleanBlockedPath) return;
     lastOpenRequest.current = requestKey;
-    void store.open(activePath, activeLine);
+    void store.open(activePath, activeLine).catch(logError);
   }, [activeLine, activeOpenRequestId, activePath, snapshot.dirty, snapshot.filePath, snapshot.status, store]);
 
   useEffect(() => {
@@ -93,7 +94,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
   }, [dispatch, focused, snapshot.provider.kind, snapshot.providerStatus, workbench.activeSurfaceMode]);
 
   useEffect(() => () => {
-    void store.cleanup();
+    void store.cleanup().catch(logError);
   }, [store]);
 
   useRegisterKeybindingContext("Buffer", focused);
@@ -268,7 +269,7 @@ export function createBufferSurfaceKeyHandlers({
 }: BufferSurfaceActionOptions): Record<string, () => void | false | Promise<void>> {
   return {
     "buffer:save": () => {
-      void store.save({ hasInFlightAgent });
+      void store.save({ hasInFlightAgent }).catch(logError);
     },
     "workbench:focusExplorer": () => {
       dispatch({ type: "focus", pane: "explorer" });
@@ -279,20 +280,37 @@ export function createBufferSurfaceKeyHandlers({
     "workbench:focusComposer": () => {
       dispatch({ type: "focus", pane: "composer" });
     },
-    "buffer:revert": () => snapshot.provider.capabilities.terminalUi ? false : store.revert(),
+    "buffer:revert": () => {
+      if (snapshot.provider.capabilities.terminalUi) return false;
+      void store.revert().catch(logError);
+    },
     "buffer:close": async () => {
-      if (await store.close()) dispatch({ type: "closeSurface" });
+      try {
+        if (await store.close()) dispatch({ type: "closeSurface" });
+      } catch (error) {
+        logError(error);
+      }
     },
     "buffer:closeDiscard": async () => {
-      if (await store.close({ discard: true })) dispatch({ type: "closeSurface" });
+      try {
+        if (await store.close({ discard: true })) dispatch({ type: "closeSurface" });
+      } catch (error) {
+        logError(error);
+      }
     },
     "buffer:externalEditor": () => {
-      void store.openExternalEditor();
+      void store.openExternalEditor().catch(logError);
     },
     "buffer:undo": () => snapshot.provider.capabilities.terminalUi ? false : store.undo(),
     "buffer:redo": () => snapshot.provider.capabilities.terminalUi ? false : store.redo(),
-    "buffer:hover": () => snapshot.provider.capabilities.terminalUi ? false : store.requestHover(),
-    "buffer:definition": () => snapshot.provider.capabilities.terminalUi ? false : store.goToDefinition(),
+    "buffer:hover": () => {
+      if (snapshot.provider.capabilities.terminalUi) return false;
+      void store.requestHover().catch(logError);
+    },
+    "buffer:definition": () => {
+      if (snapshot.provider.capabilities.terminalUi) return false;
+      void store.goToDefinition().catch(logError);
+    },
     "buffer:up": () => store.move("up"),
     "buffer:down": () => store.move("down"),
     "buffer:left": () => store.move("left"),
@@ -318,18 +336,18 @@ export function executeBufferVimCommand(
 ): void {
   switch (command.type) {
     case "save":
-      void store.save({ hasInFlightAgent, force: command.force });
+      void store.save({ hasInFlightAgent, force: command.force }).catch(logError);
       break;
     case "quit":
       void (async () => {
         if (await store.close({ discard: command.discard })) dispatch({ type: "closeSurface" });
-      })();
+      })().catch(logError);
       break;
     case "saveQuit":
       void (async () => {
         const saved = await store.save({ hasInFlightAgent, force: command.force });
         if (saved && await store.close()) dispatch({ type: "closeSurface" });
-      })();
+      })().catch(logError);
       break;
   }
 }

--- a/runtime/tests/tui/workbench/buffer-docs-config.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-docs-config.contract.test.ts
@@ -14,6 +14,9 @@ describe("embedded Neovim BUFFER docs and config", () => {
     expect(text).toContain("Explicit external-editor handoff provider");
     expect(text).toContain("AGENC_BUFFER_NVIM=/path/to/nvim");
     expect(text).toContain("AGENC_BUFFER_NVIM_TIMEOUT_MS=1200");
+    expect(text).toContain("AGENC_BUFFER_NVIM_STARTUP_TIMEOUT_MS=10000");
+    expect(text).toContain("AGENC_BUFFER_NVIM_CLEANUP_TIMEOUT_MS=1000");
+    expect(text).toContain("`:qa`");
     expect(text).toContain("AGENC_BUFFER_NVIM_USE_INIT=0");
     expect(text).toContain("nvim --embed");
     expect(text).toContain("Missing executable");

--- a/runtime/tests/tui/workbench/buffer-external-editor-provider.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-external-editor-provider.contract.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ExternalEditorProvider } from "../../../src/tui/workbench/buffer/providers/external/ExternalEditorProvider.js";
+import type { BufferFileSnapshot } from "../../../src/tui/workbench/buffer/fileSnapshot.js";
 import { runWithCwdOverride } from "../../../src/utils/cwd.js";
 
 let dir: string;
@@ -117,7 +118,62 @@ describe("explicit external editor provider", () => {
     await provider.cleanup();
     expect(listener).toHaveBeenCalledTimes(2);
   });
+
+  it("launches only the latest overlapping open and invalidates pending opens on cleanup", async () => {
+    const first = controlled<BufferFileSnapshot>();
+    const second = controlled<BufferFileSnapshot>();
+    const pendingCleanup = controlled<BufferFileSnapshot>();
+    const reads = vi.fn((filePath: string) => {
+      if (filePath === "first.txt") return first.promise;
+      if (filePath === "second.txt") return second.promise;
+      return pendingCleanup.promise;
+    });
+    const launch = vi.fn(() => true);
+    const provider = new ExternalEditorProvider(launch, reads);
+
+    const staleOpen = provider.open({ filePath: "first.txt", line: 1 });
+    const latestOpen = provider.open({ filePath: "second.txt", line: 2 });
+    second.resolve(snapshotFor("second.txt", 2));
+    await latestOpen;
+    first.resolve(snapshotFor("first.txt", 1));
+    await staleOpen;
+
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(launch).toHaveBeenCalledWith("/workspace/second.txt", 2);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "second.txt",
+    });
+
+    const invalidatedOpen = provider.open({ filePath: "pending.txt", line: 3 });
+    await provider.cleanup();
+    pendingCleanup.resolve(snapshotFor("pending.txt", 3));
+    await invalidatedOpen;
+
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(provider.getSnapshot().providerStatus).toBe("idle");
+  });
 });
+
+function snapshotFor(filePath: string, mtimeMs: number): BufferFileSnapshot {
+  return {
+    filePath,
+    absolutePath: `/workspace/${filePath}`,
+    content: "alpha\n",
+    mtimeMs,
+    size: 6,
+    encoding: "utf8",
+    lineEndings: "LF",
+  };
+}
+
+function controlled<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 function baseKey() {
   return {

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -8,7 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { discoverNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimDiscovery.js";
 import type { NeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
-import { dirtyFlagFromRpcNotificationParams, EmbeddedNeovimSession, startEmbeddedNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
+import { dirtyFlagFromRpcNotificationParams, EmbeddedNeovimSession, NeovimStartupCleanupError, startEmbeddedNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
+import { NeovimRpcError } from "../../../src/tui/workbench/buffer/neovim/NeovimRpc.js";
 import { cleanupTrackedNeovimProcesses, getTrackedNeovimProcessCountForTesting, killNeovimChild, normalizeNeovimPid, runTrackedNeovimProcessExitCleanupForTesting, spawnNeovimProcess, waitForNeovimExit } from "../../../src/tui/workbench/buffer/neovim/NeovimProcess.js";
 
 let dir: string;
@@ -87,6 +88,7 @@ describe("embedded Neovim lifecycle", () => {
     const rpc = {
       request: vi.fn(async (method: string, args: readonly any[]) => {
         if (method === "nvim_buf_get_option") return true;
+        if (method === "nvim_exec_lua") return true;
         return args[0] ?? true;
       }),
       close: vi.fn(),
@@ -106,6 +108,11 @@ describe("embedded Neovim lifecycle", () => {
     await session.click(2.9, 4.2);
     await expect(session.save(false)).resolves.toBe(true);
     await expect(session.isDirty()).resolves.toBe(true);
+    await expect(session.hasUnsavedBuffers()).resolves.toBe(true);
+    expect(rpc.request).toHaveBeenCalledWith(
+      "nvim_exec_lua",
+      [expect.stringContaining("nvim_list_bufs"), []],
+    );
     await expect(session.quit(false)).resolves.toMatchObject({ closed: false });
 
     await Promise.all([session.cleanup(), session.cleanup()]);
@@ -116,6 +123,7 @@ describe("embedded Neovim lifecycle", () => {
     await session.click(1, 1);
     await expect(session.save(true)).resolves.toBe(false);
     await expect(session.isDirty()).resolves.toBe(false);
+    await expect(session.hasUnsavedBuffers()).resolves.toBe(false);
     await expect(session.quit(true)).resolves.toEqual({ closed: true });
 
     expect(ui.dispose).toHaveBeenCalledTimes(1);
@@ -137,7 +145,7 @@ describe("embedded Neovim lifecycle", () => {
     };
     const cleanSession = new EmbeddedNeovimSession(cleanHandle as any, cleanRpc as any, ui as any, 5);
     await expect(cleanSession.quit(false)).resolves.toEqual({ closed: true });
-    expect(cleanRpc.request).toHaveBeenCalledWith("nvim_command", ["quit"]);
+    expect(cleanRpc.request).toHaveBeenCalledWith("nvim_command", ["qa"]);
 
     const racedChild = fakeChild({ pid: 783 });
     const racedHandle = {
@@ -148,8 +156,8 @@ describe("embedded Neovim lifecycle", () => {
     const racedRpc = {
       request: vi.fn(async (method: string, args: readonly any[]) => {
         if (method === "nvim_buf_get_option") return false;
-        if (method === "nvim_command" && args[0] === "quit") {
-          throw new Error("E37: No write since last change");
+        if (method === "nvim_command" && args[0] === "qa") {
+          throw new NeovimRpcError("nvim_command", 1, "E37: No write since last change");
         }
         return true;
       }),
@@ -181,7 +189,7 @@ describe("embedded Neovim lifecycle", () => {
     expect(concurrentRpc.request).toHaveBeenCalledTimes(1);
     dirtyGate.resolve(false);
     await expect(Promise.all([firstCleanClose, secondCleanClose])).resolves.toEqual([{ closed: true }, { closed: true }]);
-    expect(concurrentRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "quit")).toHaveLength(1);
+    expect(concurrentRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "qa")).toHaveLength(1);
 
     const dirtyDiscardGate = controlled<boolean>();
     const dirtyDiscardChild = fakeChild({ exitCode: 0, pid: 781 });
@@ -203,7 +211,7 @@ describe("embedded Neovim lifecycle", () => {
       { closed: false, reason: "Unsaved Neovim edits. Save or use force quit before closing BUFFER." },
       { closed: true },
     ]);
-    expect(dirtyDiscardRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "quit!")).toHaveLength(1);
+    expect(dirtyDiscardRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "qa!")).toHaveLength(1);
 
     const closeChild = fakeChild({ exitCode: 0, pid: 779 });
     const closeHandle = {
@@ -217,7 +225,7 @@ describe("embedded Neovim lifecycle", () => {
     };
     const closeSession = new EmbeddedNeovimSession(closeHandle as any, closeRpc as any, ui as any, 5);
     await Promise.all([closeSession.quit(true), closeSession.quit(true)]);
-    expect(closeRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "quit!")).toHaveLength(1);
+    expect(closeRpc.request.mock.calls.filter((call) => call[0] === "nvim_command" && call[1]?.[0] === "qa!")).toHaveLength(1);
 
     const unkillableChild = fakeChild({ pid: 782 });
     unkillableChild.kill = vi.fn(() => true);
@@ -249,6 +257,177 @@ describe("embedded Neovim lifecycle", () => {
     await expect(unkillableSession.quit(true)).resolves.toEqual({ closed: true });
   });
 
+  it("bounds cleanup when Neovim never answers the graceful quit RPC", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: 784 });
+    const handle = {
+      child,
+      pid: 784,
+      kill: vi.fn(),
+    };
+    const neverReplies = controlled<unknown>();
+    const rpc = {
+      request: vi.fn(() => neverReplies.promise),
+      close: vi.fn(),
+    };
+    const ui = {
+      dispose: vi.fn(),
+    };
+    const session = new EmbeddedNeovimSession(handle as any, rpc as any, ui as any, 5);
+
+    const outcome = await Promise.race([
+      session.cleanup().then(() => "cleaned" as const),
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+    ]);
+
+    expect(outcome).toBe("cleaned");
+    expect(rpc.request).toHaveBeenCalledWith("nvim_command", ["qa!"]);
+    expect(rpc.close).toHaveBeenCalledWith("session cleanup");
+    expect(child.stdin.end).toHaveBeenCalledTimes(1);
+    expect(handle.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("fails a non-discarding close closed when the dirty probe never settles", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: 785 });
+    const handle = { child, pid: 785, kill: vi.fn() };
+    const neverReplies = controlled<unknown>();
+    const rpc = {
+      request: vi.fn(() => neverReplies.promise),
+      close: vi.fn(),
+    };
+    const ui = { dispose: vi.fn() };
+    const session = new EmbeddedNeovimSession(handle as any, rpc as any, ui as any, 5);
+
+    const outcome = await Promise.race([
+      session.quit(false),
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+    ]);
+
+    expect(outcome).toMatchObject({
+      closed: false,
+      reason: expect.stringContaining("Unable to verify"),
+    });
+    expect(rpc.request).toHaveBeenCalledWith("nvim_buf_get_option", [0, "modified"]);
+    expect(rpc.close).not.toHaveBeenCalled();
+    expect(child.stdin.end).not.toHaveBeenCalled();
+    expect(handle.kill).not.toHaveBeenCalled();
+    expect(ui.dispose).not.toHaveBeenCalled();
+  });
+
+  it("fails a non-discarding close closed when a clean all-buffer quit RPC never settles", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: 786 });
+    const handle = { child, pid: 786, kill: vi.fn() };
+    const neverReplies = controlled<unknown>();
+    const rpc = {
+      request: vi.fn((method: string, args: readonly unknown[]) => {
+        if (method === "nvim_buf_get_option") return Promise.resolve(false);
+        if (method === "nvim_command" && args[0] === "qa") return neverReplies.promise;
+        return Promise.resolve(true);
+      }),
+      close: vi.fn(),
+    };
+    const ui = { dispose: vi.fn() };
+    const session = new EmbeddedNeovimSession(handle as any, rpc as any, ui as any, 5);
+
+    const outcome = await Promise.race([
+      session.quit(false),
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+    ]);
+
+    expect(outcome).toMatchObject({ closed: false });
+    expect(rpc.request).toHaveBeenCalledWith("nvim_command", ["qa"]);
+    expect(rpc.request).not.toHaveBeenCalledWith("nvim_command", ["qa!"]);
+    expect(rpc.close).not.toHaveBeenCalled();
+    expect(child.stdin.end).not.toHaveBeenCalled();
+    expect(handle.kill).not.toHaveBeenCalled();
+  });
+
+  it("waits for a transport-raced safe exit without killing the live child", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: 789 });
+    const handle = { child, pid: 789, kill: vi.fn() };
+    const rpc = {
+      request: vi.fn(async (method: string, args: readonly unknown[]) => {
+        if (method === "nvim_buf_get_option") return false;
+        if (method === "nvim_command" && args[0] === "qa") {
+          throw new Error("RPC transport closed during safe exit");
+        }
+        return true;
+      }),
+      close: vi.fn(),
+    };
+    const ui = { dispose: vi.fn() };
+    const session = new EmbeddedNeovimSession(handle as any, rpc as any, ui as any, 50);
+
+    const closing = session.quit(false);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(handle.kill).not.toHaveBeenCalled();
+    expect(child.stdin.end).not.toHaveBeenCalled();
+
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+    await expect(closing).resolves.toEqual({ closed: true });
+    expect(rpc.request).toHaveBeenCalledWith("nvim_command", ["qa"]);
+    expect(ui.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires an all-buffer safe close before force teardown can begin", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: 788 });
+    const handle = { child, pid: 788, kill: vi.fn() };
+    const rpc = {
+      request: vi.fn(async (method: string, args: readonly unknown[]) => {
+        if (method === "nvim_buf_get_option") return false;
+        if (method === "nvim_command" && args[0] === "qa") {
+          throw new NeovimRpcError("nvim_command", 2, "E37: another buffer has unsaved changes");
+        }
+        if (method === "nvim_command" && args[0] === "quit") return true;
+        return true;
+      }),
+      close: vi.fn(),
+    };
+    const ui = { dispose: vi.fn() };
+    const session = new EmbeddedNeovimSession(handle as any, rpc as any, ui as any, 5);
+
+    await expect(session.quit(false)).resolves.toEqual({
+      closed: false,
+      reason: "Unsaved Neovim edits. Save or use force quit before closing BUFFER.",
+    });
+
+    expect(rpc.request).toHaveBeenCalledWith("nvim_command", ["qa"]);
+    expect(rpc.request).not.toHaveBeenCalledWith("nvim_command", ["quit"]);
+    expect(rpc.request).not.toHaveBeenCalledWith("nvim_command", ["qa!"]);
+    expect(rpc.close).not.toHaveBeenCalled();
+    expect(child.stdin.end).not.toHaveBeenCalled();
+    expect(handle.kill).not.toHaveBeenCalled();
+  });
+
+  it("forces a bounded supervised cleanup without awaiting a stuck quit RPC", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: 787 });
+    const handle = { child, pid: 787, kill: vi.fn() };
+    const neverReplies = controlled<unknown>();
+    const rpc = {
+      request: vi.fn(() => neverReplies.promise),
+      close: vi.fn(),
+    };
+    const ui = { dispose: vi.fn() };
+    const session = new EmbeddedNeovimSession(handle as any, rpc as any, ui as any, 5);
+
+    const outcome = await Promise.race([
+      session.quit(true),
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+    ]);
+
+    expect(outcome).toEqual({ closed: true });
+    expect(rpc.request).toHaveBeenCalledWith("nvim_command", ["qa!"]);
+    expect(rpc.close).toHaveBeenCalledWith("session cleanup");
+    expect(child.stdin.end).toHaveBeenCalledTimes(1);
+    expect(handle.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
   it("maps embedded dirty notifications to boolean dirty state", () => {
     expect(dirtyFlagFromRpcNotificationParams([true])).toBe(true);
     expect(dirtyFlagFromRpcNotificationParams([false])).toBe(false);
@@ -275,6 +454,64 @@ describe("embedded Neovim lifecycle", () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(errors).toContain("startup boom");
+  });
+
+  it("aborts a hanging startup and tears down its supervised process group", async () => {
+    const pidFile = join(dir, "aborted-startup.pid");
+    const script = [
+      `require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+      "setInterval(() => {}, 1000);",
+    ].join("");
+    const controller = new AbortController();
+    const startup = startEmbeddedNeovim({
+      executable: process.execPath,
+      args: ["-e", script],
+      filePath: join(dir, "target.txt"),
+      line: 1,
+      column: 0,
+      size: { rows: 2, columns: 10 },
+      signal: controller.signal,
+      startupTimeoutMs: 5000,
+      cleanupTimeoutMs: 20,
+      onSnapshot: () => {},
+      onError: () => {},
+      onExit: () => {},
+    });
+    const pid = await waitForPidFile(pidFile);
+
+    controller.abort(new Error("startup superseded"));
+
+    await expect(startup).rejects.toThrow("startup superseded");
+    await waitUntilDead(pid);
+    expect(isProcessAlive(pid)).toBe(false);
+    expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
+  });
+
+  it("bounds a hanging startup with a timeout and tears down its process group", async () => {
+    const pidFile = join(dir, "timed-out-startup.pid");
+    const script = [
+      `require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+      "setInterval(() => {}, 1000);",
+    ].join("");
+    const startup = startEmbeddedNeovim({
+      executable: process.execPath,
+      args: ["-e", script],
+      filePath: join(dir, "target.txt"),
+      line: 1,
+      column: 0,
+      size: { rows: 2, columns: 10 },
+      startupTimeoutMs: 1000,
+      cleanupTimeoutMs: 20,
+      onSnapshot: () => {},
+      onError: () => {},
+      onExit: () => {},
+    });
+    const pid = await waitForPidFile(pidFile);
+
+    await expect(startup).rejects.toThrow("Embedded Neovim startup timed out after 1000ms");
+    await waitUntilDead(pid);
+    expect(isProcessAlive(pid)).toBe(false);
+    expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
   });
 
   it("does not track a child whose executable fails to spawn", async () => {
@@ -323,7 +560,7 @@ describe("embedded Neovim lifecycle", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "preserves startup and cleanup failures in an AggregateError",
+    "preserves retryable startup-cleanup ownership in its typed error",
     async () => {
       const frame = Buffer.from(encode([1, 1, "attach failed", null])).toString("base64");
       const pidFile = join(dir, "aggregate-child.pid");
@@ -353,7 +590,7 @@ describe("embedded Neovim lifecycle", () => {
           onExit: () => {},
         }).catch((error: unknown) => error);
 
-        expect(failure).toBeInstanceOf(AggregateError);
+        expect(failure).toBeInstanceOf(NeovimStartupCleanupError);
         expect(failure).toMatchObject({
           message: expect.stringContaining("Neovim startup cleanup failed"),
         });
@@ -362,6 +599,10 @@ describe("embedded Neovim lifecycle", () => {
         expect(String(errors[0])).toContain("attach failed");
         expect(errors[1]).toBeInstanceOf(Error);
         expect(String(errors[1])).toContain("did not exit after SIGKILL");
+        killSpy.mockRestore();
+        await expect(
+          (failure as NeovimStartupCleanupError).retryCleanup(),
+        ).resolves.toBeUndefined();
       } finally {
         killSpy.mockRestore();
         pid = Number(await readFile(pidFile, "utf8").catch(() => "0"));
@@ -473,6 +714,75 @@ describe("embedded Neovim lifecycle", () => {
     await waitForNeovimExit(handle.child, 500);
 
     expect(isProcessAlive(handle.pid)).toBe(false);
+    expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
+  });
+
+  it("closes a clean real Neovim session through the all-buffer safe-close path", async () => {
+    const discovery = await discoverNeovim({ timeoutMs: 1000, useUserInit: false });
+    if (!discovery.usable) {
+      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
+      return;
+    }
+    const filePath = join(dir, "clean-close.txt");
+    await writeFile(filePath, "alpha\n", "utf8");
+    const session = await startEmbeddedNeovim({
+      executable: discovery.executable,
+      args: discovery.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 4, columns: 24 },
+      onSnapshot: () => {},
+      onError: (error) => {
+        throw error;
+      },
+      onExit: () => {},
+    });
+    const pid = session.pid;
+
+    await expect(session.quit(false)).resolves.toEqual({ closed: true });
+    await session.cleanup();
+    await waitUntilDead(pid);
+
+    expect(isProcessAlive(pid)).toBe(false);
+    expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
+  });
+
+  it("detects a modified hidden buffer before an external-editor handoff", async () => {
+    const discovery = await discoverNeovim({ timeoutMs: 1000, useUserInit: false });
+    if (!discovery.usable) {
+      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
+      return;
+    }
+    const filePath = join(dir, "hidden-buffer.txt");
+    await writeFile(filePath, "alpha\n", "utf8");
+    const session = await startEmbeddedNeovim({
+      executable: discovery.executable,
+      args: discovery.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 4, columns: 24 },
+      onSnapshot: () => {},
+      onError: () => {},
+      onExit: () => {},
+    });
+    const pid = session.pid;
+
+    await session.input("<Esc>:set hidden<CR>:enew<CR>ihidden edit");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    await session.input(`<Esc>:hide edit ${filePath}<CR>`);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    await expect(session.isDirty()).resolves.toBe(false);
+    await expect(session.hasUnsavedBuffers()).resolves.toBe(true);
+    await session.quit(true);
+    await session.cleanup();
+    await waitUntilDead(pid);
+
+    expect(isProcessAlive(pid)).toBe(false);
     expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
   });
 
@@ -625,6 +935,16 @@ async function waitUntilDead(pid: number): Promise<void> {
   while (Date.now() < deadline && isProcessAlive(pid)) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
+}
+
+async function waitForPidFile(path: string): Promise<number> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const pid = Number(await readFile(path, "utf8").catch(() => "0"));
+    if (pid > 0) return pid;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for pid file ${path}`);
 }
 
 async function waitForSnapshot<T>(

--- a/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import { createNeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
 import { NeovimBufferProvider, refreshableFileSnapshotPaths, reloadPathAfterExternalEditor } from "../../../src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.js";
 import type { BufferFileSnapshot } from "../../../src/tui/workbench/buffer/fileSnapshot.js";
-import type { EmbeddedNeovimSession, StartEmbeddedNeovimOptions } from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
+import {
+  NeovimStartupCleanupError,
+  type EmbeddedNeovimSession,
+  type StartEmbeddedNeovimOptions,
+} from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
 
 const usableDiscovery = {
   usable: true,
@@ -142,6 +146,14 @@ describe("embedded Neovim BUFFER provider", () => {
     expect(provider.move("down")).toBe(false);
     await expect(provider.requestHover()).resolves.toBeNull();
     await expect(provider.goToDefinition()).resolves.toBe(false);
+
+    harness.session.input.mockRejectedValueOnce(new Error("undo transport failed"));
+    expect(provider.undo()).toBe(true);
+    await flush();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      error: "undo transport failed",
+    });
   });
 
   it("refuses in-flight agent saves, surfaces session save failures, and recovers after a clean save", async () => {
@@ -162,6 +174,13 @@ describe("embedded Neovim BUFFER provider", () => {
       error: "write failed",
     });
 
+    harness.session.save.mockResolvedValueOnce(false);
+    await expect(provider.save()).resolves.toBe(false);
+    expect(provider.getSnapshot()).toMatchObject({
+      status: "error",
+      error: "write failed",
+    });
+
     harness.setDirty(false);
     await expect(provider.save({ force: true })).resolves.toBe(true);
     expect(harness.session.save).toHaveBeenLastCalledWith(true);
@@ -169,6 +188,21 @@ describe("embedded Neovim BUFFER provider", () => {
       status: "ready",
       dirty: false,
       error: null,
+    });
+  });
+
+  it("does not erase an actionable error when a closed session cannot revert", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    harness.emitError(new Error("cleanup ownership retained"));
+    harness.session.input.mockResolvedValueOnce(false);
+
+    await expect(provider.revert()).resolves.toBeUndefined();
+
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      error: "cleanup ownership retained",
     });
   });
 
@@ -249,6 +283,178 @@ describe("embedded Neovim BUFFER provider", () => {
     expect(provider.getSnapshot().providerStatus).toBe("idle");
   });
 
+  it("retains dirty Neovim edits when another file is requested and retries after save", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    harness.setDirty(true);
+    harness.emitDirty(true);
+
+    await expect(provider.open({ filePath: "next.txt" })).resolves.toBeUndefined();
+
+    expect(harness.session.quit).toHaveBeenCalledWith(false);
+    expect(harness.session.cleanup).not.toHaveBeenCalled();
+    expect(harness.startSession).toHaveBeenCalledTimes(1);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      filePath: "target.txt",
+      dirty: true,
+      error: "Unsaved edits. Save, revert, or close-discard before opening another file.",
+    });
+
+    await expect(provider.save({ force: true })).resolves.toBe(true);
+    await expect(provider.open({ filePath: "next.txt" })).resolves.toBeUndefined();
+
+    expect(harness.startSession).toHaveBeenCalledTimes(2);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "next.txt",
+      dirty: false,
+    });
+  });
+
+  it("does not let an older open erase a newer dirty replacement conflict", async () => {
+    const initialDirtyRead = controlled<boolean>();
+    const harness = createHarness();
+    harness.session.isDirty.mockImplementationOnce(() => initialDirtyRead.promise);
+    const provider = new NeovimBufferProvider(harness.options);
+
+    const openingInitialFile = provider.open({ filePath: "target.txt" });
+    await flush();
+    expect(harness.session.isDirty).toHaveBeenCalledTimes(1);
+
+    harness.session.quit.mockResolvedValueOnce({ closed: false, reason: "dirty buffer" });
+    await expect(provider.open({ filePath: "next.txt" })).resolves.toBeUndefined();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      filePath: "target.txt",
+      dirty: true,
+    });
+
+    initialDirtyRead.resolve(false);
+    await openingInitialFile;
+
+    expect(harness.startSession).toHaveBeenCalledTimes(1);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      providerMessage: "Unsaved edits. Save, revert, or close-discard before opening another file.",
+      filePath: "target.txt",
+      dirty: true,
+    });
+
+    harness.emitGrid("session remains live");
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      terminal: { lines: ["session remains live"] },
+      dirty: true,
+    });
+  });
+
+  it("contains session cleanup failures and retains actionable BUFFER diagnostics", async () => {
+    const reopenHarness = createHarness();
+    const reopenProvider = new NeovimBufferProvider(reopenHarness.options);
+    await reopenProvider.open({ filePath: "target.txt" });
+    reopenHarness.session.quit.mockRejectedValueOnce(new Error("process tree survived"));
+
+    await expect(reopenProvider.open({ filePath: "next.txt" })).resolves.toBeUndefined();
+
+    expect(reopenHarness.startSession).toHaveBeenCalledTimes(1);
+    expect(reopenProvider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      filePath: "target.txt",
+      error: "Embedded Neovim cleanup failed before opening another file: process tree survived",
+    });
+    await expect(reopenProvider.open({ filePath: "next.txt" })).resolves.toBeUndefined();
+    expect(reopenHarness.startSession).toHaveBeenCalledTimes(2);
+    expect(reopenProvider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "next.txt",
+    });
+
+    const closeHarness = createHarness();
+    const closeProvider = new NeovimBufferProvider(closeHarness.options);
+    await closeProvider.open({ filePath: "target.txt" });
+    closeHarness.session.quit.mockRejectedValueOnce(new Error("process tree survived"));
+
+    await expect(closeProvider.close({ discard: true })).resolves.toBe(false);
+
+    expect(closeProvider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      filePath: "target.txt",
+      error: "Embedded Neovim cleanup failed while closing BUFFER: process tree survived",
+    });
+    await expect(closeProvider.close({ discard: true })).resolves.toBe(true);
+    expect(closeProvider.getSnapshot().providerStatus).toBe("idle");
+
+    const cleanupHarness = createHarness();
+    const cleanupProvider = new NeovimBufferProvider(cleanupHarness.options);
+    await cleanupProvider.open({ filePath: "target.txt" });
+    cleanupHarness.session.cleanup.mockRejectedValueOnce(new Error("process tree survived"));
+
+    await expect(cleanupProvider.cleanup()).rejects.toThrow(
+      "Embedded Neovim cleanup failed while releasing BUFFER: process tree survived",
+    );
+    expect(cleanupProvider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      filePath: "target.txt",
+      error: "Embedded Neovim cleanup failed while releasing BUFFER: process tree survived",
+    });
+    await expect(cleanupProvider.cleanup()).resolves.toBeUndefined();
+    expect(cleanupProvider.getSnapshot().providerStatus).toBe("idle");
+  });
+
+  it("does not let a slow close erase a newer open", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    const closeResult = controlled<{ readonly closed: true }>();
+    harness.session.quit.mockImplementationOnce(() => closeResult.promise);
+
+    const closing = provider.close({ discard: true });
+    await provider.open({ filePath: "next.txt" });
+    closeResult.resolve({ closed: true });
+
+    await expect(closing).resolves.toBe(false);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "next.txt",
+    });
+  });
+
+  it("does not let slow cleanup reset a newer open", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    const cleanupResult = controlled<void>();
+    harness.session.cleanup.mockImplementationOnce(() => cleanupResult.promise);
+
+    const cleaning = provider.cleanup();
+    await provider.open({ filePath: "next.txt" });
+    cleanupResult.resolve(undefined);
+    await cleaning;
+
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "next.txt",
+    });
+  });
+
+  it("accepts a successful close when the same session exits during quit", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    harness.session.quit.mockImplementationOnce(async () => {
+      harness.emitExit();
+      return { closed: true };
+    });
+
+    await expect(provider.close({ discard: true })).resolves.toBe(true);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
+    });
+  });
+
   it("guards external editor handoff behind a clean embedded buffer and reloads after a successful handoff", async () => {
     const launch = vi.fn(() => true);
     const harness = createHarness({ launch });
@@ -256,7 +462,7 @@ describe("embedded Neovim BUFFER provider", () => {
     await provider.open({ filePath: "target.txt" });
 
     const dirtyProbe = controlled<boolean>();
-    harness.session.isDirty.mockImplementation(() => dirtyProbe.promise);
+    harness.session.hasUnsavedBuffers.mockImplementation(() => dirtyProbe.promise);
     expect(provider.handleInput({ input: "i", key: baseKey(), context: { rows: 8, columns: 40 } })).toBe(true);
     const immediateHandoff = provider.openExternalEditor();
     expect(launch).not.toHaveBeenCalled();
@@ -265,7 +471,15 @@ describe("embedded Neovim BUFFER provider", () => {
     expect(launch).not.toHaveBeenCalled();
     expect(provider.getSnapshot().providerStatus).toBe("conflict");
 
-    harness.session.isDirty.mockImplementation(async () => false);
+    harness.session.hasUnsavedBuffers.mockRejectedValueOnce(new Error("dirty probe unavailable"));
+    await expect(provider.openExternalEditor()).resolves.toBe(false);
+    expect(launch).not.toHaveBeenCalled();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      error: expect.stringContaining("dirty probe unavailable"),
+    });
+
+    harness.session.hasUnsavedBuffers.mockImplementation(async () => false);
     harness.setDirty(false);
     await expect(provider.save()).resolves.toBe(true);
     await expect(provider.openExternalEditor()).resolves.toBe(true);
@@ -316,6 +530,106 @@ describe("embedded Neovim BUFFER provider", () => {
 
     expect(launch).toHaveBeenCalledWith("/workspace/target.txt", 2);
     expect(harness.startSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("blocks external handoff when a hidden Neovim buffer is modified", async () => {
+    const launch = vi.fn(() => true);
+    const harness = createHarness({ launch });
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    harness.session.isDirty.mockResolvedValue(false);
+    harness.session.hasUnsavedBuffers.mockResolvedValueOnce(true);
+
+    await expect(provider.openExternalEditor()).resolves.toBe(false);
+
+    expect(harness.session.hasUnsavedBuffers).toHaveBeenCalledTimes(1);
+    expect(launch).not.toHaveBeenCalled();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      dirty: true,
+    });
+  });
+
+  it("does not hand off a retired file while a newer file is loading", async () => {
+    const pendingRead = controlled<BufferFileSnapshot>();
+    const launch = vi.fn(() => true);
+    const readFileSnapshot = vi.fn(async (path: string) => {
+      if (path === "target.txt" || path === "/workspace/target.txt") {
+        return snapshotFor("target.txt", 1);
+      }
+      if (path === "next.txt") return pendingRead.promise;
+      if (path === "/workspace/next.txt") return snapshotFor("next.txt", 2);
+      throw new Error(`unexpected read ${path}`);
+    });
+    const harness = createHarness({ launch, readFileSnapshot });
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+
+    const openingNext = provider.open({ filePath: "next.txt" });
+    await flush();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "loading",
+      filePath: null,
+      absolutePath: null,
+    });
+
+    await expect(provider.openExternalEditor()).resolves.toBe(false);
+    expect(launch).not.toHaveBeenCalled();
+    pendingRead.resolve(snapshotFor("next.txt", 2));
+    await openingNext;
+
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "next.txt",
+    });
+  });
+
+  it("does not hand off the previous file while a newer open is closing it", async () => {
+    const launch = vi.fn(() => true);
+    const harness = createHarness({ launch });
+    const provider = new NeovimBufferProvider(harness.options);
+    await provider.open({ filePath: "target.txt" });
+    const closeResult = controlled<{ readonly closed: true }>();
+    harness.session.quit.mockImplementationOnce(() => closeResult.promise);
+
+    const openingNext = provider.open({ filePath: "next.txt" });
+    await flush();
+    expect(harness.session.quit).toHaveBeenCalledWith(false);
+
+    await expect(provider.openExternalEditor()).resolves.toBe(false);
+    expect(launch).not.toHaveBeenCalled();
+    closeResult.resolve({ closed: true });
+    await openingNext;
+
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "next.txt",
+    });
+  });
+
+  it("cancels a pending open when close wins before the file read resolves", async () => {
+    const pendingRead = controlled<BufferFileSnapshot>();
+    const harness = createHarness({
+      readFileSnapshot: vi.fn(() => pendingRead.promise),
+    });
+    const provider = new NeovimBufferProvider(harness.options);
+
+    const pendingOpen = provider.open({ filePath: "target.txt" });
+    await flush();
+    await expect(provider.close()).resolves.toBe(true);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
+    });
+
+    pendingRead.resolve(snapshotFor("target.txt", 1));
+    await pendingOpen;
+
+    expect(harness.startSession).not.toHaveBeenCalled();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
+    });
   });
 
   it("surfaces open failures and ignores stale session starts from superseded opens", async () => {
@@ -374,21 +688,146 @@ describe("embedded Neovim BUFFER provider", () => {
     expect(recoveringProvider.getSnapshot().providerStatus).toBe("ready");
   });
 
-  it("cleans up a stale session that resolves after a newer open supersedes it", async () => {
+  it("does not publish a session that exits before startup ownership commits", async () => {
+    let returnedSession: EmbeddedNeovimSession | null = null;
+    const harness = createHarness({
+      startSession: vi.fn(async (options: StartEmbeddedNeovimOptions) => {
+        options.onExit();
+        return returnedSession as EmbeddedNeovimSession;
+      }),
+    });
+    returnedSession = harness.session;
+    const provider = new NeovimBufferProvider(harness.options);
+
+    await provider.open({ filePath: "target.txt" });
+
+    expect(harness.session.cleanup).toHaveBeenCalledTimes(1);
+    expect(provider.getSnapshot()).toMatchObject({
+      status: "idle",
+      providerStatus: "closed",
+      filePath: "target.txt",
+      providerMessage: "Embedded Neovim exited.",
+    });
+  });
+
+  it("does not resurrect ready state when the session exits during dirty refresh", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    harness.session.isDirty.mockImplementationOnce(async () => {
+      harness.emitExit();
+      return false;
+    });
+
+    await provider.open({ filePath: "target.txt" });
+
+    expect(provider.getSnapshot()).toMatchObject({
+      status: "idle",
+      providerStatus: "closed",
+      filePath: "target.txt",
+      providerMessage: "Embedded Neovim exited.",
+    });
+    await expect(provider.save()).resolves.toBe(false);
+  });
+
+  it("does not commit a stale file refresh after a newer open wins", async () => {
+    const staleRefresh = controlled<BufferFileSnapshot>();
+    const aSnapshot = snapshotFor("a.txt", 1);
+    const bSnapshot = { ...snapshotFor("b.txt", 2), lineEndings: "CRLF" as const };
+    const readFileSnapshot = vi.fn(async (path: string) => {
+      if (path === "a.txt") return aSnapshot;
+      if (path === "/workspace/a.txt") return staleRefresh.promise;
+      if (path === "b.txt" || path === "/workspace/b.txt") return bSnapshot;
+      throw new Error(`unexpected read ${path}`);
+    });
+    const harness = createHarness({ readFileSnapshot });
+    const provider = new NeovimBufferProvider(harness.options);
+
+    const staleOpen = provider.open({ filePath: "a.txt" });
+    await flush();
+    expect(readFileSnapshot).toHaveBeenCalledWith("/workspace/a.txt");
+    await provider.open({ filePath: "b.txt" });
+    staleRefresh.resolve({ ...aSnapshot, encoding: "utf16le" });
+    await staleOpen;
+
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "b.txt",
+      encoding: "utf8",
+      lineEndings: "CRLF",
+    });
+    const readsBeforeSave = readFileSnapshot.mock.calls.length;
+    await expect(provider.save()).resolves.toBe(true);
+    const saveReads = readFileSnapshot.mock.calls
+      .slice(readsBeforeSave)
+      .map(([path]) => path);
+    expect(saveReads).not.toContain("/workspace/a.txt");
+    expect(saveReads).toContain("/workspace/b.txt");
+  });
+
+  it("does not redirect a stale save into the newly opened session", async () => {
+    const conflictRead = controlled<BufferFileSnapshot>();
+    const aSnapshot = snapshotFor("a.txt", 1);
+    const bSnapshot = snapshotFor("b.txt", 2);
+    let aAbsoluteReads = 0;
+    const readFileSnapshot = vi.fn(async (path: string) => {
+      if (path === "a.txt") return aSnapshot;
+      if (path === "/workspace/a.txt") {
+        aAbsoluteReads += 1;
+        return aAbsoluteReads === 1 ? aSnapshot : conflictRead.promise;
+      }
+      if (path === "b.txt" || path === "/workspace/b.txt") return bSnapshot;
+      throw new Error(`unexpected read ${path}`);
+    });
+    const base = createHarness({ readFileSnapshot });
+    const firstSession = {
+      ...base.session,
+      save: vi.fn(async () => true),
+      cleanup: vi.fn(async () => {}),
+      isDirty: vi.fn(async () => false),
+    } as any as EmbeddedNeovimSession;
+    const secondSession = {
+      ...base.session,
+      save: vi.fn(async () => true),
+      cleanup: vi.fn(async () => {}),
+      isDirty: vi.fn(async () => false),
+    } as any as EmbeddedNeovimSession;
+    const startSession = vi.fn()
+      .mockResolvedValueOnce(firstSession)
+      .mockResolvedValueOnce(secondSession);
+    const provider = new NeovimBufferProvider({ ...base.options, startSession });
+
+    await provider.open({ filePath: "a.txt" });
+    const staleSave = provider.save();
+    await flush();
+    await provider.open({ filePath: "b.txt" });
+    conflictRead.resolve(aSnapshot);
+
+    await expect(staleSave).resolves.toBe(false);
+    expect((firstSession.save as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect((secondSession.save as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "ready",
+      filePath: "b.txt",
+    });
+  });
+
+  it("disposes a superseded session start before the newer open acquires", async () => {
     const first = controlled<EmbeddedNeovimSession>();
     const second = controlled<EmbeddedNeovimSession>();
+    let firstOptions: StartEmbeddedNeovimOptions | null = null;
     const harness = createHarness({
       startSession: vi
         .fn()
-        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce((options: StartEmbeddedNeovimOptions) => {
+          firstOptions = options;
+          return first.promise;
+        })
         .mockImplementationOnce(() => second.promise),
     });
     const provider = new NeovimBufferProvider(harness.options);
     const staleSession = {
       ...harness.session,
-      cleanup: vi.fn(async () => {
-        throw new Error("stale cleanup failed");
-      }),
+      cleanup: vi.fn(async () => {}),
       isDirty: vi.fn(async () => false),
     } as any as EmbeddedNeovimSession;
     const activeSession = {
@@ -403,9 +842,12 @@ describe("embedded Neovim BUFFER provider", () => {
 
     const activeOpen = provider.open({ filePath: "active.txt" });
     await flush();
-    expect(harness.startSession).toHaveBeenCalledTimes(2);
+    expect(firstOptions?.signal?.aborted).toBe(true);
+    expect(harness.startSession).toHaveBeenCalledTimes(1);
 
     first.resolve(staleSession);
+    await flush();
+    expect(harness.startSession).toHaveBeenCalledTimes(2);
     second.resolve(activeSession);
     await Promise.all([staleOpen, activeOpen]);
 
@@ -417,10 +859,14 @@ describe("embedded Neovim BUFFER provider", () => {
     });
   });
 
-  it("cancels and cleans up an in-flight session start when provider cleanup runs", async () => {
+  it("aborts and joins an in-flight session start before provider cleanup resolves", async () => {
     const pending = controlled<EmbeddedNeovimSession>();
+    let capturedOptions: StartEmbeddedNeovimOptions | null = null;
     const harness = createHarness({
-      startSession: vi.fn(() => pending.promise),
+      startSession: vi.fn((options: StartEmbeddedNeovimOptions) => {
+        capturedOptions = options;
+        return pending.promise;
+      }),
     });
     const provider = new NeovimBufferProvider(harness.options);
     const lateSession = {
@@ -433,9 +879,19 @@ describe("embedded Neovim BUFFER provider", () => {
     await flush();
     expect(harness.startSession).toHaveBeenCalledTimes(1);
 
-    await provider.cleanup();
+    let cleanupSettled = false;
+    const cleanup = provider.cleanup().finally(() => {
+      cleanupSettled = true;
+    });
+    await flush();
+
+    const startupSignal = (capturedOptions as (StartEmbeddedNeovimOptions & {
+      readonly signal?: AbortSignal;
+    }) | null)?.signal;
+    expect(startupSignal?.aborted).toBe(true);
+    expect(cleanupSettled).toBe(false);
     pending.resolve(lateSession);
-    await open;
+    await Promise.all([open, cleanup]);
 
     expect(lateSession.cleanup).toHaveBeenCalledTimes(1);
     expect(provider.getSnapshot()).toMatchObject({
@@ -451,14 +907,95 @@ describe("embedded Neovim BUFFER provider", () => {
     const rejectingProvider = new NeovimBufferProvider(rejectingHarness.options);
     const rejectingOpen = rejectingProvider.open({ filePath: "target.txt" });
     await flush();
-    await rejectingProvider.cleanup();
+    const rejectingCleanup = rejectingProvider.cleanup();
+    await flush();
     rejecting.reject(new Error("late startup failure"));
-    await rejectingOpen;
+    await Promise.all([rejectingOpen, rejectingCleanup]);
 
     expect(rejectingProvider.getSnapshot()).toMatchObject({
       providerStatus: "idle",
       filePath: null,
       error: null,
+    });
+  });
+
+  it("retains a late startup session when disposal fails and retries cleanup", async () => {
+    const pending = controlled<EmbeddedNeovimSession>();
+    const harness = createHarness({
+      startSession: vi.fn(() => pending.promise),
+    });
+    const lateSession = {
+      ...harness.session,
+      cleanup: vi.fn()
+        .mockRejectedValueOnce(new Error("process tree survived"))
+        .mockResolvedValue(undefined),
+      isDirty: vi.fn(async () => false),
+    } as any as EmbeddedNeovimSession;
+    const provider = new NeovimBufferProvider(harness.options);
+
+    const opening = provider.open({ filePath: "target.txt" });
+    await flush();
+    const firstCleanup = provider.cleanup();
+    await flush();
+    pending.resolve(lateSession);
+
+    await expect(firstCleanup).rejects.toThrow(
+      "Embedded Neovim cleanup failed while releasing BUFFER: process tree survived",
+    );
+    await opening;
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      filePath: "target.txt",
+      error: "Embedded Neovim cleanup failed while releasing BUFFER: process tree survived",
+    });
+
+    await expect(provider.cleanup()).resolves.toBeUndefined();
+    expect(lateSession.cleanup).toHaveBeenCalledTimes(2);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
+    });
+  });
+
+  it("retries typed cleanup ownership after a canceled startup rollback fails", async () => {
+    const pending = controlled<EmbeddedNeovimSession>();
+    const launch = vi.fn(() => true);
+    const retryCleanup = vi.fn()
+      .mockRejectedValueOnce(new Error("startup process still alive"))
+      .mockResolvedValue(undefined);
+    const startupFailure = new NeovimStartupCleanupError(
+      new Error("startup superseded"),
+      new Error("initial SIGKILL was not observed"),
+      retryCleanup,
+    );
+    const harness = createHarness({
+      launch,
+      startSession: vi.fn(() => pending.promise),
+    });
+    const provider = new NeovimBufferProvider(harness.options);
+
+    const opening = provider.open({ filePath: "target.txt" });
+    await flush();
+    const firstCleanup = provider.cleanup();
+    await flush();
+    pending.reject(startupFailure);
+
+    await expect(firstCleanup).rejects.toThrow(
+      "startup cleanup retry failed: startup process still alive",
+    );
+    await opening;
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      filePath: "target.txt",
+    });
+    await expect(provider.openExternalEditor()).resolves.toBe(false);
+    expect(launch).not.toHaveBeenCalled();
+
+    await expect(provider.cleanup()).resolves.toBeUndefined();
+    expect(retryCleanup).toHaveBeenCalledTimes(2);
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
     });
   });
 
@@ -475,14 +1012,15 @@ describe("embedded Neovim BUFFER provider", () => {
 
     const open = provider.open({ filePath: "target.txt" });
     await flush();
-    await provider.cleanup();
+    const cleanup = provider.cleanup();
+    await flush();
 
     capturedOptions?.onSnapshot(createNeovimRenderSnapshot(2, 10));
     capturedOptions?.onDirtyChange?.(true);
     capturedOptions?.onError(new Error("stale error"));
     capturedOptions?.onExit();
     pending.resolve(harness.session);
-    await open;
+    await Promise.all([open, cleanup]);
 
     expect(provider.getSnapshot()).toMatchObject({
       providerStatus: "idle",
@@ -512,6 +1050,15 @@ describe("embedded Neovim BUFFER provider", () => {
 
     await provider.open({ filePath: "target.txt" });
     expect(provider.handleInput({ input: "", key: baseKey(), context: { rows: 8, columns: 40 } })).toBe(false);
+    harness.session.click.mockImplementationOnce(() => {
+      throw new Error("synchronous click failure");
+    });
+    expect(provider.click(1, 1)).toBe(true);
+    await flush();
+    expect(provider.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      error: "synchronous click failure",
+    });
     harness.emitGrid("visual text", "visual");
     expect(provider.getSnapshot().vimMode).toBe("VISUAL");
     harness.emitGrid("insert text", "insert");
@@ -583,7 +1130,13 @@ function createHarness(overrides: {
       return true;
     }),
     isDirty: vi.fn(async () => dirty),
-    quit: vi.fn(async () => ({ closed: true as const })),
+    hasUnsavedBuffers: vi.fn(async () => dirty),
+    quit: vi.fn(async (discard = false) => dirty && !discard
+      ? {
+          closed: false as const,
+          reason: "Unsaved Neovim edits. Save or use force quit before closing BUFFER.",
+        }
+      : { closed: true as const }),
     cleanup: vi.fn(async () => {}),
   } as any as EmbeddedNeovimSession;
   const readFileSnapshot = overrides.readFileSnapshot ?? vi.fn(async (filePath: string) => ({
@@ -618,6 +1171,7 @@ function createHarness(overrides: {
       click: ReturnType<typeof vi.fn>;
       save: ReturnType<typeof vi.fn>;
       isDirty: ReturnType<typeof vi.fn>;
+      hasUnsavedBuffers: ReturnType<typeof vi.fn>;
       quit: ReturnType<typeof vi.fn>;
       cleanup: ReturnType<typeof vi.fn>;
     },

--- a/runtime/tests/tui/workbench/buffer-provider-boundary.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-provider-boundary.contract.test.ts
@@ -9,7 +9,12 @@ import { BufferProviderController } from "../../../src/tui/workbench/buffer/prov
 import { InlineBufferProvider } from "../../../src/tui/workbench/buffer/providers/inline/InlineBufferProvider.js";
 import { NeovimBufferProvider } from "../../../src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.js";
 import { bufferProviderConfigFromEnv, selectBufferEditorProvider } from "../../../src/tui/workbench/buffer/providers/selectBufferEditorProvider.js";
-import { emptyProviderSnapshot, type BufferEditorProvider, type BufferProviderIdentity } from "../../../src/tui/workbench/buffer/providers/types.js";
+import {
+  emptyProviderSnapshot,
+  type BufferEditorProvider,
+  type BufferProviderIdentity,
+  type BufferProviderSnapshot,
+} from "../../../src/tui/workbench/buffer/providers/types.js";
 
 const usableDiscovery = {
   usable: true,
@@ -80,10 +85,24 @@ describe("embedded Neovim BUFFER provider boundary", () => {
   it("selects embedded Neovim in auto mode and labeled inline fallback in forced Neovim mode", async () => {
     const usableExecutable = join(dir, "nvim-good");
     const failingExecutable = join(dir, "nvim-fail");
+    const delayedFailureExecutable = join(dir, "nvim-delayed-fail");
+    const failedEmbedExecutable = join(dir, "nvim-failed-embed");
     await writeFile(usableExecutable, "#!/bin/sh\nprintf 'NVIM v0.12.0\\n'\n", "utf8");
     await writeFile(failingExecutable, "#!/bin/sh\necho 'bad probe' >&2\nexit 2\n", "utf8");
+    await writeFile(
+      delayedFailureExecutable,
+      "#!/bin/sh\n(sleep 0.05; echo 'delayed bad probe' >&2) &\nexit 2\n",
+      "utf8",
+    );
+    await writeFile(
+      failedEmbedExecutable,
+      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then printf 'NVIM v0.12.0\\n'; exit 0; fi\n(sleep 0.35; echo 'delayed embed failure' >&2) &\nexit 2\n",
+      "utf8",
+    );
     await chmod(usableExecutable, 0o755);
     await chmod(failingExecutable, 0o755);
+    await chmod(delayedFailureExecutable, 0o755);
+    await chmod(failedEmbedExecutable, 0o755);
 
     const usableSelection = await selectBufferEditorProvider({
       mode: "auto",
@@ -111,6 +130,25 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     });
     expect(autoFailure.kind).toBe("inline");
     expect(autoFailure.reason).toContain("bad probe");
+
+    const delayedFailure = await selectBufferEditorProvider({
+      mode: "neovim",
+      executable: delayedFailureExecutable,
+      timeoutMs: 500,
+      inlineStore: new WorkbenchBufferStore(),
+    });
+    expect(delayedFailure.kind).toBe("inline");
+    expect(delayedFailure.reason).toContain("delayed bad probe");
+
+    const failedEmbed = await selectBufferEditorProvider({
+      mode: "neovim",
+      executable: failedEmbedExecutable,
+      timeoutMs: 500,
+      useUserInit: false,
+      inlineStore: new WorkbenchBufferStore(),
+    });
+    expect(failedEmbed.kind).toBe("inline");
+    expect(failedEmbed.reason).toContain("failed the embedded mode probe");
   });
 
   it("returns concrete inline fallback reasons for missing and unsupported Neovim", async () => {
@@ -151,11 +189,15 @@ describe("embedded Neovim BUFFER provider boundary", () => {
       AGENC_BUFFER_NVIM: "custom-nvim",
       AGENC_BUFFER_NVIM_USE_INIT: "true",
       AGENC_BUFFER_NVIM_TIMEOUT_MS: "250",
+      AGENC_BUFFER_NVIM_STARTUP_TIMEOUT_MS: "15000",
+      AGENC_BUFFER_NVIM_CLEANUP_TIMEOUT_MS: "2500",
     } as NodeJS.ProcessEnv)).toMatchObject({
       mode: "neovim",
       executable: "custom-nvim",
       useUserInit: true,
       timeoutMs: 250,
+      startupTimeoutMs: 15000,
+      cleanupTimeoutMs: 2500,
     });
 
     expect(bufferProviderConfigFromEnv({
@@ -169,10 +211,14 @@ describe("embedded Neovim BUFFER provider boundary", () => {
       AGENC_BUFFER_PROVIDER: "bogus",
       AGENC_BUFFER_NVIM_USE_INIT: "0",
       AGENC_BUFFER_NVIM_TIMEOUT_MS: "-1",
+      AGENC_BUFFER_NVIM_STARTUP_TIMEOUT_MS: "0",
+      AGENC_BUFFER_NVIM_CLEANUP_TIMEOUT_MS: "not-a-number",
     } as NodeJS.ProcessEnv)).toMatchObject({
       mode: "auto",
       useUserInit: false,
       timeoutMs: undefined,
+      startupTimeoutMs: undefined,
+      cleanupTimeoutMs: undefined,
     });
   });
 
@@ -346,6 +392,32 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     expect(controller.getSnapshot().provider.fallbackReason).toContain("not opened");
   });
 
+  it("does not reopen a provider when cleanup wins during provider installation", async () => {
+    const provider = createFakeProvider("neovim");
+    let controller!: BufferProviderController;
+    let cleanup: Promise<void> | null = null;
+    provider.subscribe.mockImplementation(() => {
+      cleanup = controller.cleanup();
+      return () => {};
+    });
+    controller = new BufferProviderController(async () => ({
+      kind: "neovim",
+      provider,
+      discovery: usableDiscovery,
+    }));
+
+    const opening = controller.open("late.txt", 1);
+    await opening;
+    await cleanup;
+
+    expect(provider.cleanup).toHaveBeenCalledTimes(1);
+    expect(provider.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
+    });
+  });
+
   it("delegates controller actions to the active provider and emits provider snapshots", async () => {
     const provider = createFakeProvider("inline");
     const controller = new BufferProviderController(async () => ({
@@ -439,6 +511,243 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     expect(provider.open).toHaveBeenNthCalledWith(2, { filePath: "package.json", line: 6 });
   });
 
+  it("retains a dirty provider when another file is requested and retries after save", async () => {
+    const provider = createFakeProvider("inline");
+    const replacement = createFakeProvider("neovim");
+    provider.close.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const selectionFactory = vi.fn()
+      .mockResolvedValueOnce({
+        kind: "inline" as const,
+        provider,
+        discovery: null,
+        reason: "initial",
+      })
+      .mockResolvedValue({
+        kind: "neovim" as const,
+        provider: replacement,
+        discovery: usableDiscovery,
+      });
+    const controller = new BufferProviderController(selectionFactory);
+    await controller.open("first.txt", 1);
+    provider.setSnapshot({
+      status: "ready",
+      providerStatus: "ready",
+      filePath: "first.txt",
+      absolutePath: "/workspace/first.txt",
+      dirty: true,
+    });
+    provider.emit();
+
+    await expect(controller.open("second.txt", 2)).resolves.toBeUndefined();
+
+    expect(selectionFactory).toHaveBeenCalledTimes(2);
+    expect(provider.close).toHaveBeenCalledWith({ discard: false });
+    expect(provider.cleanup).not.toHaveBeenCalled();
+    expect(provider.open).toHaveBeenCalledTimes(1);
+    expect(replacement.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      filePath: "first.txt",
+      dirty: true,
+      error: "Unsaved edits. Save, revert, or close-discard before opening another file.",
+    });
+
+    provider.setSnapshot({
+      status: "ready",
+      providerStatus: "ready",
+      providerMessage: null,
+      error: null,
+      conflictKind: null,
+      dirty: false,
+    });
+    provider.emit();
+    await controller.reopen();
+
+    expect(provider.cleanup).toHaveBeenCalledTimes(1);
+    expect(replacement.open).toHaveBeenCalledWith({ filePath: "second.txt", line: 2 });
+  });
+
+  it("uses a live close handshake for same-path provider switches", async () => {
+    const active = createFakeProvider("inline");
+    const replacement = createFakeProvider("neovim");
+    active.close.mockResolvedValueOnce(false);
+    const controller = new BufferProviderController(
+      vi.fn()
+        .mockResolvedValueOnce({
+          kind: "inline",
+          provider: active,
+          discovery: null,
+          reason: "initial",
+        })
+        .mockResolvedValueOnce({
+          kind: "neovim",
+          provider: replacement,
+          discovery: usableDiscovery,
+        }),
+    );
+    await controller.open("same.txt", 1);
+    active.setSnapshot({
+      status: "ready",
+      providerStatus: "ready",
+      filePath: "same.txt",
+      absolutePath: "/workspace/same.txt",
+      dirty: true,
+    });
+    active.emit();
+
+    await controller.open("same.txt", 2);
+
+    expect(active.close).toHaveBeenCalledWith({ discard: false });
+    expect(active.cleanup).not.toHaveBeenCalled();
+    expect(replacement.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      filePath: "same.txt",
+      dirty: true,
+    });
+  });
+
+  it("trusts provider close over a stale clean snapshot during replacement", async () => {
+    const active = createFakeProvider("inline");
+    const replacement = createFakeProvider("neovim");
+    active.close.mockImplementationOnce(async () => {
+      active.setSnapshot({
+        status: "conflict",
+        providerStatus: "conflict",
+        providerMessage: "edit arrived before close",
+        error: "edit arrived before close",
+        conflictKind: "disk",
+        dirty: true,
+      });
+      active.emit();
+      return false;
+    });
+    const controller = new BufferProviderController(
+      vi.fn()
+        .mockResolvedValueOnce({
+          kind: "inline",
+          provider: active,
+          discovery: null,
+          reason: "initial",
+        })
+        .mockResolvedValueOnce({
+          kind: "neovim",
+          provider: replacement,
+          discovery: usableDiscovery,
+        }),
+    );
+    await controller.open("first.txt", 1);
+    active.setSnapshot({
+      status: "ready",
+      providerStatus: "ready",
+      filePath: "first.txt",
+      absolutePath: "/workspace/first.txt",
+      dirty: false,
+    });
+    active.emit();
+
+    await controller.open("second.txt", 2);
+
+    expect(active.cleanup).not.toHaveBeenCalled();
+    expect(replacement.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      providerStatus: "conflict",
+      dirty: true,
+      error: "edit arrived before close",
+    });
+  });
+
+  it("serializes A-to-B teardown before a newer A-kind open", async () => {
+    const activeA = createFakeProvider("neovim");
+    const staleB = createFakeProvider("inline");
+    const winningA = createFakeProvider("neovim");
+    const cleanupStarted = controlled<void>();
+    const releaseCleanup = controlled<void>();
+    activeA.cleanup.mockImplementationOnce(async () => {
+      cleanupStarted.resolve(undefined);
+      await releaseCleanup.promise;
+    });
+    const controller = new BufferProviderController(
+      vi.fn()
+        .mockResolvedValueOnce({
+          kind: "neovim",
+          provider: activeA,
+          discovery: usableDiscovery,
+        })
+        .mockResolvedValueOnce({
+          kind: "inline",
+          provider: staleB,
+          discovery: null,
+          reason: "stale replacement",
+        })
+        .mockResolvedValueOnce({
+          kind: "neovim",
+          provider: winningA,
+          discovery: usableDiscovery,
+        }),
+    );
+    await controller.open("first.txt", 1);
+
+    const staleOpen = controller.open("second.txt", 2);
+    await cleanupStarted.promise;
+    const winningOpen = controller.open("third.txt", 3);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(activeA.open).toHaveBeenCalledTimes(1);
+    expect(winningA.open).not.toHaveBeenCalled();
+
+    releaseCleanup.resolve(undefined);
+    await Promise.all([staleOpen, winningOpen]);
+
+    expect(activeA.cleanup).toHaveBeenCalledTimes(1);
+    expect(activeA.open).toHaveBeenCalledTimes(1);
+    expect(staleB.open).not.toHaveBeenCalled();
+    expect(winningA.open).toHaveBeenCalledWith({ filePath: "third.txt", line: 3 });
+    expect(controller.getSnapshot().provider.kind).toBe("neovim");
+  });
+
+  it("does not let a slow close clear a newer controller open request", async () => {
+    const provider = createFakeProvider("inline");
+    const closeResult = controlled<boolean>();
+    provider.close.mockImplementationOnce(() => closeResult.promise);
+    const controller = new BufferProviderController(async () => ({
+      kind: "inline",
+      provider,
+      discovery: null,
+      reason: "test",
+    }));
+
+    await controller.open("package.json", 1);
+    const closing = controller.close();
+    await controller.open("README.md", 4);
+    closeResult.resolve(true);
+
+    await expect(closing).resolves.toBe(false);
+    await controller.reopen();
+    expect(provider.open).toHaveBeenNthCalledWith(3, { filePath: "README.md", line: 4 });
+  });
+
+  it("cancels a pending selection when close wins before a provider is installed", async () => {
+    const selection = controlled<Awaited<ReturnType<typeof selectBufferEditorProvider>>>();
+    const provider = createFakeProvider("external");
+    const controller = new BufferProviderController(vi.fn(() => selection.promise));
+
+    const pendingOpen = controller.open("late.txt", 1);
+    await expect(controller.close()).resolves.toBe(true);
+    selection.resolve({
+      kind: "external",
+      provider,
+      discovery: null,
+      reason: "late selection",
+    });
+    await pendingOpen;
+
+    expect(provider.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      providerStatus: "idle",
+      filePath: null,
+    });
+  });
+
   it("reopens the last active file while preserving the last requested pane size", async () => {
     const provider = createFakeProvider("neovim");
     const controller = new BufferProviderController(async () => ({
@@ -475,6 +784,162 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     listener?.();
 
     expect(controller.getSnapshot().provider.fallbackReason).toContain("not opened");
+  });
+
+  it("contains selection, selected-open, and active-close failures", async () => {
+    const selectionController = new BufferProviderController(
+      vi.fn().mockRejectedValue(new Error("selection failed")),
+    );
+
+    await expect(selectionController.open("package.json", 1)).resolves.toBeUndefined();
+    expect(selectionController.getSnapshot()).toMatchObject({
+      providerStatus: "error",
+      error: "BUFFER provider open failed: selection failed",
+    });
+
+    const failingOpen = createFakeProvider("inline");
+    failingOpen.open.mockRejectedValueOnce(new Error("provider open failed"));
+    const openController = new BufferProviderController(async () => ({
+      kind: "inline" as const,
+      provider: failingOpen,
+      discovery: null,
+      reason: "test",
+    }));
+
+    await expect(openController.open("package.json", 1)).resolves.toBeUndefined();
+    expect(openController.getSnapshot()).toMatchObject({
+      provider: { kind: "inline" },
+      providerStatus: "error",
+      error: "BUFFER provider open failed: provider open failed",
+    });
+
+    const active = createFakeProvider("inline");
+    const replacement = createFakeProvider("neovim");
+    active.close.mockRejectedValueOnce(new Error("provider close failed"));
+    const replacementController = new BufferProviderController(
+      vi.fn()
+        .mockResolvedValueOnce({
+          kind: "inline",
+          provider: active,
+          discovery: null,
+          reason: "initial",
+        })
+        .mockResolvedValueOnce({
+          kind: "neovim",
+          provider: replacement,
+          discovery: usableDiscovery,
+        }),
+    );
+
+    await replacementController.open("package.json", 1);
+    await expect(replacementController.open("README.md", 2)).resolves.toBeUndefined();
+    expect(replacement.open).not.toHaveBeenCalled();
+    expect(replacementController.getSnapshot()).toMatchObject({
+      provider: { kind: "inline" },
+      providerStatus: "error",
+      error: "BUFFER provider close failed: provider close failed",
+    });
+  });
+
+  it("keeps failed provider cleanup transactional and visible until a retry succeeds", async () => {
+    const provider = createFakeProvider("neovim");
+    provider.cleanup.mockRejectedValueOnce(new Error("process tree survived"));
+    const selectionFactory = vi.fn(async () => ({
+      kind: "neovim" as const,
+      provider,
+      discovery: usableDiscovery,
+    }));
+    const controller = new BufferProviderController(selectionFactory);
+
+    await controller.open("package.json", 1);
+    await expect(controller.cleanup()).rejects.toThrow("process tree survived");
+
+    expect(controller.getSnapshot()).toMatchObject({
+      provider: { kind: "neovim" },
+      providerStatus: "error",
+      error: "BUFFER provider cleanup failed: process tree survived",
+    });
+
+    await expect(controller.cleanup()).resolves.toBeUndefined();
+    expect(provider.cleanup).toHaveBeenCalledTimes(2);
+    expect(controller.getSnapshot()).toMatchObject({
+      provider: { kind: "inline" },
+      providerStatus: "idle",
+      error: null,
+    });
+  });
+
+  it("blocks an open racing failed teardown without replacing the owned provider", async () => {
+    const active = createFakeProvider("inline");
+    const replacement = createFakeProvider("neovim");
+    const cleanup = controlled<void>();
+    active.cleanup.mockImplementationOnce(() => cleanup.promise);
+    const selectionFactory = vi.fn()
+      .mockResolvedValueOnce({
+        kind: "inline",
+        provider: active,
+        discovery: null,
+        reason: "initial",
+      })
+      .mockResolvedValueOnce({
+        kind: "neovim",
+        provider: replacement,
+        discovery: usableDiscovery,
+      });
+    const controller = new BufferProviderController(selectionFactory);
+
+    await controller.open("package.json", 1);
+    const teardown = controller.cleanup();
+    const racingOpen = controller.open("README.md", 2);
+    cleanup.reject(new Error("process tree survived"));
+
+    await expect(teardown).rejects.toThrow("process tree survived");
+    await expect(racingOpen).resolves.toBeUndefined();
+    expect(selectionFactory).toHaveBeenCalledTimes(1);
+    expect(replacement.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      provider: { kind: "inline" },
+      providerStatus: "error",
+      error: "BUFFER provider cleanup failed: process tree survived",
+    });
+  });
+
+  it("does not unsubscribe or replace an active provider when replacement cleanup fails", async () => {
+    const active = createFakeProvider("inline");
+    const replacement = createFakeProvider("neovim");
+    active.cleanup.mockRejectedValueOnce(new Error("process tree survived"));
+    const controller = new BufferProviderController(
+      vi.fn()
+        .mockResolvedValueOnce({
+          kind: "inline",
+          provider: active,
+          discovery: null,
+          reason: "initial",
+        })
+        .mockResolvedValueOnce({
+          kind: "neovim",
+          provider: replacement,
+          discovery: usableDiscovery,
+        }),
+    );
+
+    await controller.open("package.json", 1);
+    await expect(controller.open("README.md", 2)).resolves.toBeUndefined();
+
+    expect(replacement.open).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      provider: { kind: "inline" },
+      providerStatus: "error",
+      error: "BUFFER provider cleanup failed: process tree survived",
+    });
+    active.setSnapshot({
+      status: "error",
+      providerStatus: "error",
+      providerMessage: "retained provider diagnostic",
+      error: "retained provider diagnostic",
+    });
+    active.emit();
+    expect(controller.getSnapshot().error).toBe("retained provider diagnostic");
   });
 
   it("drops unopened same-kind selections without disturbing the active provider state", async () => {
@@ -554,6 +1019,7 @@ describe("embedded Neovim BUFFER provider boundary", () => {
 
 function createFakeProvider(kind: BufferProviderIdentity["kind"]): BufferEditorProvider & {
   readonly emit: () => void;
+  readonly setSnapshot: (snapshot: Partial<BufferProviderSnapshot>) => void;
   readonly open: ReturnType<typeof vi.fn>;
   readonly save: ReturnType<typeof vi.fn>;
   readonly revert: ReturnType<typeof vi.fn>;
@@ -577,7 +1043,7 @@ function createFakeProvider(kind: BufferProviderIdentity["kind"]): BufferEditorP
     fallbackReason: kind === "inline" ? "test fallback" : null,
     capabilities: capabilitiesForKind(kind),
   };
-  const snapshot = emptyProviderSnapshot(identity);
+  let snapshot = emptyProviderSnapshot(identity);
   return {
     identity,
     subscribe: vi.fn((listener: () => void) => {
@@ -603,6 +1069,9 @@ function createFakeProvider(kind: BufferProviderIdentity["kind"]): BufferEditorP
     cleanup: vi.fn(async () => {}),
     emit: () => {
       for (const listener of listeners) listener();
+    },
+    setSnapshot: (next) => {
+      snapshot = { ...snapshot, ...next };
     },
   };
 }

--- a/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
@@ -31,11 +31,17 @@ const bufferHarness = vi.hoisted(() => ({
   inputCapture: null as CapturedInputHandler | null,
   inputCaptureOptions: null as Record<string, unknown> | null,
   keybindingOptions: null as Record<string, unknown> | null,
+  logError: vi.fn(),
   snapshot: null as BufferSnapshot | null,
   store: null as BufferStoreHarness | null,
   terminalSize: { rows: 12, columns: 44 },
   vimCommandExecutor: null as ((command: VimCommand) => void) | null,
   visibleLines: [{ number: 1, text: "const value = 1;", from: 0, to: 16 }],
+}));
+
+vi.mock("../../../src/utils/log.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../../src/utils/log.js")>(),
+  logError: bufferHarness.logError,
 }));
 
 vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
@@ -208,6 +214,81 @@ describe("BufferSurface handlers", () => {
     });
     expect(bufferHarness.store?.close).toHaveBeenCalledTimes(closeCallsAfterQuit + 2);
     expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
+  });
+
+  it("contains rejected BUFFER open, close, command, and unmount actions", async () => {
+    const changes: AppState[] = [];
+    bufferHarness.store?.open.mockRejectedValueOnce(new Error("open cleanup failed"));
+
+    await renderBufferSurface({ changes });
+    await flushPromises();
+
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "open cleanup failed" }),
+    );
+
+    bufferHarness.store?.close.mockRejectedValueOnce(new Error("close cleanup failed"));
+    await expect(bufferHarness.handlers["buffer:closeDiscard"]?.()).resolves.toBeUndefined();
+    expect(changes).toHaveLength(0);
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "close cleanup failed" }),
+    );
+
+    for (const [action, method, message] of [
+      ["buffer:save", "save", "save failed"],
+      ["buffer:revert", "revert", "revert failed"],
+      ["buffer:externalEditor", "openExternalEditor", "external editor failed"],
+      ["buffer:hover", "requestHover", "hover failed"],
+      ["buffer:definition", "goToDefinition", "definition failed"],
+    ] as const) {
+      bufferHarness.store?.[method].mockRejectedValueOnce(new Error(message));
+      bufferHarness.handlers[action]?.();
+      await flushPromises();
+      expect(bufferHarness.logError).toHaveBeenCalledWith(
+        expect.objectContaining({ message }),
+      );
+    }
+
+    bufferHarness.inputCapture?.(":", {}, inputEvent());
+    const execute = bufferHarness.vimCommandExecutor;
+    expect(execute).toBeTruthy();
+    bufferHarness.store?.close.mockRejectedValueOnce(new Error("command cleanup failed"));
+    execute?.({ type: "quit", discard: true, all: false });
+    await flushPromises();
+    expect(changes).toHaveLength(0);
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "command cleanup failed" }),
+    );
+
+    bufferHarness.store?.save.mockRejectedValueOnce(new Error("command save failed"));
+    execute?.({ type: "save", force: true, all: false });
+    await flushPromises();
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "command save failed" }),
+    );
+
+    bufferHarness.store?.save.mockRejectedValueOnce(new Error("save-quit save failed"));
+    execute?.({ type: "saveQuit", force: false, all: false });
+    await flushPromises();
+    expect(changes).toHaveLength(0);
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "save-quit save failed" }),
+    );
+
+    bufferHarness.store?.close.mockRejectedValueOnce(new Error("save-quit cleanup failed"));
+    execute?.({ type: "saveQuit", force: false, all: false });
+    await flushPromises();
+    expect(changes).toHaveLength(0);
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "save-quit cleanup failed" }),
+    );
+
+    bufferHarness.store?.cleanup.mockRejectedValueOnce(new Error("unmount cleanup failed"));
+    await renderBufferSurface({ activeFilePath: null });
+    await flushPromises();
+    expect(bufferHarness.logError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "unmount cleanup failed" }),
+    );
   });
 
   it("renders the empty surface without opening a buffer when no file is selected", async () => {
@@ -391,6 +472,7 @@ function resetHarness(): void {
   bufferHarness.inputCapture = null;
   bufferHarness.inputCaptureOptions = null;
   bufferHarness.keybindingOptions = null;
+  bufferHarness.logError.mockReset();
   bufferHarness.snapshot = baseSnapshot();
   bufferHarness.store = createStoreHarness();
   bufferHarness.terminalSize = { rows: 12, columns: 44 };
@@ -440,7 +522,7 @@ function createStoreHarness() {
     focus: vi.fn(),
     getSnapshot: vi.fn(() => bufferHarness.snapshot),
     getVisibleLines: vi.fn(() => bufferHarness.visibleLines),
-    goToDefinition: vi.fn(),
+    goToDefinition: vi.fn(async () => false),
     handleInput: vi.fn((
       _input: string,
       _key: Record<string, unknown>,
@@ -455,8 +537,8 @@ function createStoreHarness() {
     open: vi.fn(async () => {}),
     openExternalEditor: vi.fn(async () => true),
     redo: vi.fn(),
-    requestHover: vi.fn(),
-    revert: vi.fn(),
+    requestHover: vi.fn(async () => null),
+    revert: vi.fn(async () => {}),
     resize: vi.fn(),
     save: vi.fn(async () => true),
     undo: vi.fn(),

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -166,7 +166,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   resetAllLSPDiagnosticState();
-  resetWorkbenchBufferProviderControllerForTesting();
+  await resetWorkbenchBufferProviderControllerForTesting();
   resetWorkbenchBufferStoreForTesting();
   if (previousBufferProvider === undefined) {
     delete process.env.AGENC_BUFFER_PROVIDER;

--- a/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
@@ -53,9 +53,9 @@ import { wheelInputIsInsideNode } from "../../../src/tui/workbench/surfaces/Buff
 import { WorkbenchLayout } from "../../../src/tui/workbench/WorkbenchLayout.js";
 import type { WorkbenchBufferSnapshot } from "../../../src/tui/workbench/buffer/BufferStore.js";
 
-afterEach(() => {
+afterEach(async () => {
   renderingHarness.inputCapture = null;
-  resetWorkbenchBufferProviderControllerForTesting();
+  await resetWorkbenchBufferProviderControllerForTesting();
 });
 
 describe("BUFFER workbench rendering", () => {

--- a/runtime/tests/tui/workbench/buffer/neovim/NeovimLifecycle-dirty-catch.test.ts
+++ b/runtime/tests/tui/workbench/buffer/neovim/NeovimLifecycle-dirty-catch.test.ts
@@ -4,8 +4,9 @@ import { EmbeddedNeovimSession } from "../../../../../src/tui/workbench/buffer/n
 // M-TUI-5 (core-todo.md): isDirty() and the quit path called #rpc.request with
 // no catch. The transport can close independently of the session (stdin EPIPE
 // before the child's exit), so during that window :q/:wq and buffer:close (which
-// await isDirty()) let the RPC rejection escape as an unhandled rejection that
-// can take down the daemon. A dead transport is now treated as not-dirty.
+// await isDirty()) must contain the RPC rejection instead of letting an
+// unhandled rejection take down the daemon. Only an already-exited child is
+// treated as not-dirty; a live child with unknown state fails closed.
 
 function makeSession(): EmbeddedNeovimSession {
   const rpc = {


### PR DESCRIPTION
## Summary

- Make controller and provider replacement transactional with operation generations, resource ownership checks, and stale-continuation suppression.
- Cancel, join, and retry pending embedded-Neovim startup/cleanup before replacement, close, cleanup, or external handoff.
- Bound startup, dirty probes, safe close, force close, and process teardown with configurable deadlines while preserving fail-closed behavior.
- Protect every loaded Neovim buffer, including hidden modified buffers, before safe close or external-editor handoff.
- Contain synchronous throws and rejected fire-and-forget input, resize, focus, click, and surface actions.
- Preserve actionable conflict/error state across stale snapshots, false save/revert results, and live terminal updates.

## Root causes and design

The previous flow allowed async work from an older transition to publish after a newer transition, and it did not retain explicit ownership when startup teardown failed. The fix uses monotonic operation generations plus session/file ownership identities at every async commit point. Startup is abortable, teardown remains owned until confirmed, cleanup failures are retryable and typed, and all RPC/process waits have bounded deadlines.

Safe close now uses non-bang all-buffer `:qa`; force close uses supervised `:qa!` plus stdin close and bounded SIGKILL escalation. Generic transport closure is accepted only after passive observation of process exit. External handoff performs a bounded all-loaded-buffer probe before launching another editor.

## Primary references

- [Node.js AbortController and AbortSignal](https://nodejs.org/dist/latest/docs/api/globals.html#class-abortcontroller)
- [WHATWG aborting ongoing activities](https://dom.spec.whatwg.org/#aborting-ongoing-activities)
- [React stale async response cleanup pattern](https://react.dev/reference/react/useEffect#fetching-data-with-effects)
- [Neovim editing and all-buffer quit semantics](https://neovim.io/doc/user/editing/)
- [Neovim API](https://neovim.io/doc/user/api.html)
- [Node.js unhandled rejection mode](https://nodejs.org/api/cli.html#--unhandled-rejectionsmode)

## Validation

- `npm run typecheck` — clean
- Focused provider/lifecycle/latest-main matrix — 11 files, 195/195
- Race-heavy provider matrix — 5 consecutive runs, 480/480
- `npm test` on latest main — agent-surface contract 22/22; Vitest 1,759 files, 15,027 passed, 16 skipped
- `npm run build` — package entrypoints and generated SDK types verified
- `check:tui-runtime-startup` — built import plus 6/6 real PTY launches at 148x40, 120x30, and 80x24
- Two independent final read-only reviews — no P0-P2 findings
- No leaked candidate or embedded-Neovim processes after validation

One earlier full run passed every assertion but the fail-closed ptrace boundary observer returned `syscall-info-unavailable`. Four isolated authoritative lifecycle reruns and two subsequent complete authoritative runs exited cleanly; the final latest-main run above is clean.

## Residual risk and rollback

Unix cleanup supervises the Neovim process group. Windows can supervise only the direct child with the current process abstraction; this documented platform residual predates this change. The PR is one focused commit and can be reverted atomically.