### PR TITLE
fix(tui): kill the residual workspace-scan leak — gitignore sweep + stacked refreshes

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -62,6 +62,16 @@ export class ProjectTreeStore {
   #listeners = new Set<Listener>();
   #snapshot: ProjectTreeSnapshot = EMPTY_SNAPSHOT;
   #refreshVersion = 0;
+  /**
+   * Count of refresh passes currently running. The periodic timer skips its
+   * tick while one is active: on a slow workspace a scan can outlive the
+   * refresh interval, and without this guard the timer stacks unbounded
+   * CONCURRENT scans — each with its own directory-walker queue — leaking
+   * memory even though every individual scan is bounded. Direct refresh()
+   * calls keep their original racing semantics (the version check already
+   * makes the newest result win).
+   */
+  #refreshActive = 0;
   #refreshTimer: ReturnType<typeof setInterval> | null = null;
   #started = false;
   // Directory paths known at the last successful scan, used to detect directories
@@ -81,7 +91,9 @@ export class ProjectTreeStore {
     void this.refresh();
     if (this.#refreshIntervalMs > 0) {
       this.#refreshTimer = setInterval(() => {
-        void this.refresh();
+        // Skip the tick while a pass is still running (see #refreshActive) —
+        // a fresh pass right after it finishes reads the same disk state.
+        if (this.#refreshActive === 0) void this.refresh();
       }, this.#refreshIntervalMs);
       this.#refreshTimer.unref?.();
     }
@@ -104,6 +116,15 @@ export class ProjectTreeStore {
   }
 
   async refresh(): Promise<void> {
+    this.#refreshActive += 1;
+    try {
+      await this.#refreshOnce();
+    } finally {
+      this.#refreshActive -= 1;
+    }
+  }
+
+  async #refreshOnce(): Promise<void> {
     const version = this.#refreshVersion + 1;
     this.#refreshVersion = version;
     this.#loading = true;
@@ -553,7 +574,12 @@ export async function scanWorkspacePaths(
     cwd,
     deep: maxDepth,
     dot: true,
-    gitignore: true,
+    // NO gitignore semantics here: this fallback only runs for NON-git
+    // workspaces (git repos list via `git ls-files`), and globby implements
+    // `gitignore: true` by first running its own `**/.gitignore` glob over
+    // the whole cwd — an unbounded walk that ignores `deep`/our entry cap
+    // and re-introduces the very OOM this scan was bounded to prevent.
+    gitignore: false,
     ignore: [...WORKSPACE_TREE_IGNORE],
     objectMode: true,
     onlyFiles: false,


### PR DESCRIPTION
Follow-up to #1502, which bounded the workspace scan but **did not stop the leak** — a real session at cwd=`$HOME` still ballooned 280MB→5GB in ~5 minutes (event loop starved, input dead, melted render). Two residual mechanisms in the same `refresh()` path:

## 1. globby's gitignore sweep is itself unbounded
`gitignore: true` makes globby run its own `**/.gitignore` glob over the whole cwd **before** the main stream — a walk that ignores `deep` and our entry cap, re-creating the exact fastq walker-queue blow-up the caps were added to prevent. This fallback only serves **non-git** workspaces (git repos list via `git ls-files`), where nested-repo gitignore semantics are marginal → dropped.

## 2. The refresh timer stacked concurrent scans
The 5s interval fired regardless of whether the previous pass had finished. On a slow workspace each pass outlives the interval, so scans piled up concurrently without bound, each holding its own walker queue. The tick now skips while a pass is active (`#refreshActive` counter). Direct `refresh()` calls keep their original racing semantics — the version check already makes the newest result win, and the existing stale-refresh regression tests assert exactly that (they pass unchanged).

## Verification
- **Field-validated:** with both fixes, a real logged-in session at cwd=`$HOME` survived **50+ minutes of actual use** (building a playable game) at ~1.1GB steady state — the same scenario previously died at 5GB in ~5 minutes.
- Isolation harness: the gitignore-off scan over `$HOME` completes bounded; repeated passes leave no uncaught errors.
- `tsc --noEmit` clean; project-tree suite **41/41** (including the stale-refresh tests that pin the preserved racing semantics).