### PR TITLE
fix(runtime): isolate agent roles by workspace

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,6 +66,7 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Process model, subsystem map, turn phases, recovery ladder, on-disk state |
 | [design/budget-enforcement.md](design/budget-enforcement.md) | Why/how cost-bounded autonomy is enforced |
 | [design/reproducible-installs-releases.md](design/reproducible-installs-releases.md) | M0 dependency, artifact, Docker, release, and crash-safe lock decisions |
+| [design/workspace-scoped-agent-roles.md](design/workspace-scoped-agent-roles.md) | Immutable workspace identity for role lookup, spawn, resume, and worktrees |
 | [roadmap.md](roadmap.md) | Shipped vs open backlog (current product truth) |
 
 ---

--- a/docs/bug-audit-2026-07-13.md
+++ b/docs/bug-audit-2026-07-13.md
@@ -204,11 +204,12 @@ FIX: apply the same pre-scan/pairing filter as `convertMessages`.
   so a configured `Bash(git push:*)`/`Bash(rm:*)` ASK guardrail is silently skipped (verified by
   running the function). FIX: before the `!hadDeny` early-return, surface any rule-based ask (reuse
   the sandbox-override aggregation).
-- **Markdown agent roles resolve against the wrong workspace ✔** — `agents/v2/spawn.ts:511`
-  `requireAgentRole(role)` is called with no cwd; markdown roles are stored process-globally keyed
-  by cwd, and the cwd-less lookup falls back to "most recently loaded namespace wins", so in a
-  multi-session daemon session A can spawn session B's same-named role. FIX: thread the requesting
-  session's cwd into `requireAgentRole`/`getAgentRole`/`listAgentRoles` at every spawn/resume site.
+- **Markdown agent roles resolved against the wrong workspace ✔** — fixed 2026-07-15 by binding an
+  immutable absolute role-workspace identity to each session and requiring it in every registry
+  lookup. Spawn catalogs and controls must match, worktree cwd changes do not change role authority,
+  and resume/restart metadata carries and verifies the originating workspace ID. Two-workspace live
+  spawn, mismatch, recovery, persistence, and TUI regressions cover the real boundaries. Design:
+  [`design/workspace-scoped-agent-roles.md`](design/workspace-scoped-agent-roles.md).
 
 ### Sandbox (safety settings defined but never wired — moderate)
 - `utils/sandbox/sandbox-runtime.ts:488` `isSandboxRequired` (the `failIfUnavailable` fail-closed

--- a/docs/design/workspace-scoped-agent-roles.md
+++ b/docs/design/workspace-scoped-agent-roles.md
@@ -1,0 +1,199 @@
+# Workspace-scoped agent-role identity
+
+Status: accepted and implemented on 2026-07-15.
+
+## Decision
+
+Agent-role lookup is bound to one immutable, absolute workspace identity for
+the lifetime of a session. That identity is separate from the execution cwd,
+which may move into a temporary Git worktree and back.
+
+The contract is:
+
+- `Session.roleWorkspace` is created once at session construction. Child,
+  review, and compatibility sessions inherit the parent's identity.
+- Role registry APIs require an `AgentRoleWorkspace`; there is no ambient cwd
+  or process-global, most-recent-workspace fallback.
+- Programmatic and Markdown role caches include the workspace ID. User-managed
+  global roles remain intentionally discoverable in each workspace, while
+  project roles remain scoped to their project identity.
+- Bootstrap builds one canonical catalog from built-ins, workspace-scoped
+  programmatic roles, plugins, and Markdown definitions. TUI, AgentTool,
+  compatibility turns, and child/worktree sessions receive cloned views of
+  that same catalog instead of independently rebuilding reduced fallbacks.
+- The `spawn_agent` schema and the executing `AgentControl` must carry the same
+  workspace ID. A mismatch is rejected before delegation or registry mutation.
+- Spawn, preflight, resume, and restart use the control's immutable identity,
+  never the session's mutable execution cwd.
+- New child metadata persists `agentRoleWorkspaceId`. A named role cannot be
+  resumed or restarted when that provenance is missing or belongs to another
+  workspace. This check runs before a spawn slot or path is registered.
+- The legacy AgentTool transcript sidecar carries the same immutable workspace
+  ID. Missing, malformed, cross-workspace, or removed-role metadata is rejected
+  before background-task registration; it never falls back to the default role.
+  A complete sidecar is fsynced and atomically published before the task becomes
+  visible or model work starts. Persistence failure aborts publication and
+  removes any unpublished worktree.
+- Persisted metadata is type-checked at both SQLite and legacy-snapshot ingress.
+  A defined role must be a non-empty string; malformed values never collapse
+  to the unrestricted default role.
+- A defined daemon role-workspace field is validated as a complete absolute,
+  self-consistent provenance envelope at create/restore ingress. Only total
+  absence receives legacy handling; malformed presence never falls back to an
+  execution cwd.
+- The TUI snapshots the session workspace once and uses that same value for its
+  initial state and live role picker.
+- `/agents` file mutations require the same explicit catalog authority. They
+  pin and revalidate trusted directories, reject symlinks and multiply-linked
+  files, and atomically replace a regular file without changing its mode.
+- CLI startup resolves a relative `AGENC_WORKSPACE` against the startup cwd. If
+  that cwd is unavailable, the relative value is rejected; absolute rescue
+  paths continue to work.
+
+## Threat model
+
+One daemon can serve sessions for repositories A and B. Both repositories may
+define `.agenc/agents/reviewer.md`, with different prompts, tool restrictions,
+models, or reasoning settings. A role name alone is therefore not an authority
+or a globally unique key.
+
+The prior fallback searched loaded namespaces in recency order. Loading B
+after A could make an A spawn execute B's role. Recomputing scope from the live
+cwd was also unsafe: entering a worktree changes execution location without
+changing the role trust domain. Name-only rollout metadata had the same
+confused-deputy risk during resume and restart.
+
+## Boundary matrix
+
+| Boundary | Enforced identity |
+| --- | --- |
+| Role discovery/cache | Immutable workspace ID in every lookup and cache key |
+| Tool schema | Workspace captured when model-facing tools are assembled |
+| Live spawn/preflight | `AgentControl.roleWorkspace` |
+| Child/worktree session | Inherits parent role workspace; cwd may differ |
+| Resume/restart | Persisted metadata ID must equal control workspace ID |
+| TUI/AgentTool/nested catalogs | Cloned views of one canonical startup catalog |
+| Pane teammate with a named role | Rejected until its process protocol can enforce the full exact-role envelope |
+
+## Compatibility and failure behavior
+
+Built-in roles and role aliases are unchanged. Existing project Markdown roles
+continue to load from the same locations. The observable compatibility change
+is deliberate: legacy open-child metadata with a named role but no workspace
+provenance is not automatically rebound. The parent session remains usable;
+the operator can explicitly spawn a fresh child in the current workspace.
+
+This is fail-closed because silently reconstructing a missing custom role could
+drop its prompt, allowlist, or denylist. Rollout parsing remains backward
+compatible so old sessions can be inspected even when a named child cannot be
+resumed automatically.
+
+Agent memory and snapshot directories now use hashed, cross-platform path
+components. An unambiguous legacy directory for a safe exact name (for example
+`worker/`) is moved once to its hashed name after symlink and containment
+checks. Lossy legacy names are never auto-adopted. In particular, the former
+remote-local workspace namespace replaced path separators with `-`, so two
+different workspaces could collide. AgenC does not automatically load or move
+those ambiguous `$AGENC_REMOTE_MEMORY_DIR/projects/<legacy-key>/` directories;
+an operator may inspect and copy trusted content into the newly reported
+hashed directory after confirming its originating workspace. This is an
+intentional security migration, not silent data deletion.
+
+Role and memory files are accepted only as regular, single-link files below an
+explicit tier/workspace trust anchor. Symlinked roots, directory entries, and
+files are rejected. Reads pin one descriptor and verify device/inode identity,
+canonical containment, and pre/post state. Snapshot writes and deletes pin the
+trusted directory identity and use descriptor-relative paths where the host
+exposes `/proc/self/fd` or `/dev/fd`, with deterministic directory-swap tests.
+Hard-linked files are rejected because a second pathname would otherwise let
+content escape the reviewed namespace.
+
+The remaining filesystem boundary is explicit: privileged bind-mount
+replacement is outside the unprivileged repository threat model. Node does not
+expose portable `openat2`/`unlinkat`; on hosts without usable descriptor paths,
+a hostile same-user process continuously racing the final pathname syscall is
+also outside the guaranteed boundary. AgenC still revalidates before and after
+the operation and fails closed for observable swaps. Operators needing
+protection from a mutually hostile same-UID process must isolate it by OS user
+or sandbox rather than sharing the daemon's filesystem authority.
+
+Agent-definition fingerprints hash the immutable role prompt and executable
+policy, not memory text appended at turn time. An authorized agent can update
+its own memory without making its persisted role provenance unresumable; a
+base-prompt, model, tool, or permission change still invalidates provenance.
+
+State schema v12 also copies `agentRoleWorkspaceId` into a dedicated
+`thread_spawn_edges.agent_role_workspace_id` column. The migration backfills
+existing JSON metadata, and legacy field-list rewrites cannot erase the
+column or rebind a child to another role/workspace pair. Rollout reads and
+state transitions consult SQLite rather than a stale process cache; closing an
+open edge is one compare-and-swap transition, repeated close is idempotent, and
+reopening a closed edge is rejected. Before v12 is committed, AgenC
+holds a SQLite writer reservation, refreshes and verifies a consistent v11
+snapshot, fsyncs it as `agenc-state_1.pre-v12.sqlite` beside the live database,
+and commits the migration without releasing that reservation. This makes the
+backup correspond to the exact pre-migration state even if an older daemon was
+still running or an earlier migration attempt left a stale backup.
+
+The schema guard makes older runtimes refuse a v12 database instead of silently
+downgrading it. To roll back, stop the daemon **and every other process with an
+open connection**, then preserve `agenc-state_1.sqlite` together with its
+`agenc-state_1.sqlite-wal` and `agenc-state_1.sqlite-shm` sidecars as one
+forensic set. Committed transactions may exist only in the WAL; never delete or
+separate those files from the preserved database. In the now-idle project
+directory, move the complete v12 set out of the live filenames, copy
+`agenc-state_1.pre-v12.sqlite` to `agenc-state_1.sqlite`, and only then start the
+older runtime. Never open the migrated database with the older binary.
+
+## Alternatives rejected
+
+- Keep a process-global registry: role-name collisions remain cross-workspace.
+- Pass cwd only at selected callers: a new caller can silently omit it.
+- Use the live execution cwd: worktree entry changes authority mid-session.
+- Persist only the role name: restart cannot prove the originating workspace.
+- Bind legacy named metadata to the current workspace: this recreates the
+  confused-deputy behavior at the recovery boundary.
+
+## Verification
+
+Revert-sensitive coverage includes:
+
+- two workspaces defining the same Markdown and programmatic role names;
+- a real model-facing spawn executed after its session cwd moves elsewhere;
+- an explicit tool-catalog/session workspace mismatch that never delegates;
+- aligned and cross-workspace resume metadata, plus missing legacy provenance;
+- malformed persisted role values failing before registry mutation;
+- provenance round-trip through durable thread-spawn edges;
+- migration backfill, immutable provenance, and same-process recovery after a
+  legacy JSON metadata rewrite;
+- exact-boundary pre-v12 backup refresh and restoration under the v11 schema;
+- AgentTool sidecar resume rejecting missing, removed, and cross-workspace roles;
+- attach rejecting malformed-but-present provenance instead of substituting cwd;
+- task publication waiting for a complete, atomic, durable role sidecar;
+- stable session role identity while entering and leaving a worktree; and
+- TUI, AgentTool, compatibility, and nested child sessions receiving the same
+  canonical catalog, including workspace-scoped programmatic roles;
+- simple mode retaining workspace-scoped programmatic roles in that catalog;
+- malformed daemon provenance failing at create/restore before session state;
+- exact-role pane spawns failing before pane/backend mutation;
+- SQLite-authoritative rollout reads and open-to-closed compare-and-swap races;
+- role-loader file/directory symlink, hardlink, and validation-to-open swaps;
+- `/agents` create/update/delete confinement, mode preservation, and symlink,
+  hardlink, traversal, and directory-swap rejection;
+- snapshot validation-to-write/delete directory swaps with no external
+  mutation; and
+- agent memory updates preserving resumability while base-role changes fail,
+  with foreign, sibling, unauthenticated, and hard-linked memory paths denied
+  before general working-directory allowances.
+
+## Research basis
+
+Research was refreshed on 2026-07-15 from primary sources:
+
+- The [OWASP Multi-Tenant Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Multi_Tenant_Security_Cheat_Sheet.html)
+  recommends establishing tenant context early, propagating it through every
+  layer, including it in lookup keys, and rejecting access without context.
+  Workspace identity is the analogous isolation key here.
+- The implementation also keeps routing and execution location separate from
+  authority: a worktree cwd can change while the early-bound workspace tenant
+  key, prompt identity, and tool policy remain immutable.

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -121,6 +121,25 @@ session so one conversation maps to one agent = one session. Details:
 | Job orchestrator (CSV multi-spawn etc.) | `runtime/src/agents/jobs/` |
 | TUI Agents rail | `runtime/src/tui/workbench/` (Agents pane at wide widths) |
 
+### Workspace-scoped custom roles
+
+Role discovery is tied to the session's immutable absolute workspace. The
+execution cwd may move into a worktree, but role lookup, the model-facing role
+catalog, nested spawn, resume, restart, and the TUI picker continue to use the
+original session identity. Two live workspaces may therefore define the same
+role name without sharing prompts or configuration.
+
+New child metadata records the originating role-workspace ID. AgenC rejects a
+named resume/restart when that ID is missing or does not match the session,
+instead of silently selecting a same-named role from the current workspace.
+Named custom-role teammates currently require in-process teammate mode. Pane
+processes are rejected before launch because their startup protocol cannot yet
+consume the complete exact-role prompt, policy, memory, workspace, and
+fingerprint envelope; AgenC will not silently launch a default/unrestricted
+agent in its place.
+See [workspace-scoped agent-role identity](../design/workspace-scoped-agent-roles.md)
+for the boundary and compatibility contract.
+
 ## Related slash commands
 
 - `/agents` — interactive agent listing / management menu

--- a/runtime/src/agents/agent-definition-fingerprint.ts
+++ b/runtime/src/agents/agent-definition-fingerprint.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+
+import { stableStringify } from "../utils/stableStringify.js";
+
+export interface FingerprintableAgentDefinition {
+  readonly getSystemPrompt: () => string;
+  /** Immutable prompt bytes before mutable runtime memory is appended. */
+  readonly roleDefinitionPrompt?: string;
+  readonly callback?: () => void;
+}
+
+/**
+ * Hash the exact executable agent-definition surface.
+ *
+ * Provenance fields that are computed from this digest and transient runtime
+ * bookkeeping are deliberately excluded. The immutable role-definition prompt
+ * replaces the prompt closure so mutable runtime memory can change between
+ * turns without invalidating persisted provenance, while definitions with
+ * different executable base prompts still cannot collapse merely because
+ * functions are not JSON data.
+ */
+export function agentDefinitionFingerprint(
+  definition: FingerprintableAgentDefinition,
+): string {
+  const data = { ...definition } as Record<string, unknown>;
+  delete data.agentRoleFingerprint;
+  const callback = data.callback;
+  if (typeof callback === "function") {
+    data.callback = Function.prototype.toString.call(callback);
+  } else {
+    delete data.callback;
+  }
+  delete data.pendingSnapshotUpdate;
+  delete data.getSystemPrompt;
+  delete data.roleDefinitionPrompt;
+  // Display and discovery locations are not executable policy. Excluding them
+  // keeps independently loaded definitions equivalent while still hashing
+  // source provenance, tool policy, permissions, model settings, and prompt.
+  delete data.filename;
+  delete data.baseDir;
+  delete data.color;
+
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        ...data,
+        systemPrompt:
+          definition.roleDefinitionPrompt ?? definition.getSystemPrompt(),
+      }),
+      "utf8",
+    )
+    .digest("hex");
+}

--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -40,7 +40,10 @@ import type {
 import type { Session } from "../session/session.js";
 import { Mailbox, MailboxClosedError } from "./mailbox.js";
 import {
+  AgentIdExistsError,
   AgentPathExistsError,
+  InvalidAgentMetadataError,
+  ROOT_AGENT_PATH,
   type AgentPath,
   type AgentRegistry,
   type AgentMetadata,
@@ -48,40 +51,65 @@ import {
   buildChildMetadata,
   depthOfAgentPath,
   joinAgentPath,
+  normalizeAgentMetadata,
   normalizeAgentNameForPath,
+  normalizeAgentRoleMetadata,
   resolveAgentPath,
 } from "./registry.js";
 import {
+  agentRoleFingerprint,
   allocateNickname,
   applyRoleToConfig,
-  getAgentRole,
+  assertAgentRoleWorkspaceMatches,
+  createAgentRoleWorkspace,
+  getAgentRoleByExactName,
   releaseNickname,
   requireAgentRole,
+  normalizeAgentRoleWorkspace,
   resolveAgentRole,
   type AgentRole,
+  type AgentRoleWorkspace,
   type RoleShapedConfig,
 } from "./role.js";
 import { canonicalAgentRoleName } from "./role-presentation.js";
-import { BUILTIN_READONLY_DISALLOWLIST } from "./built-in-prompts.js";
 
 /**
  * Resolve the role for a RESUMED agent fail-closed. A named-but-unknown
- * persisted role (renamed/removed role, or a markdown role not registered in
- * this cwd at resume time) must NOT silently resume as the unrestricted default
- * role — that would drop a read-only role's tool denylist (fail-open in a
- * tool-denial control). Resume such agents under a read-only deny config
- * instead, so they cannot mutate files or sub-spawn. Built-in roles always
- * round-trip (their names are registered at module load), so this only affects
- * stale/external role names.
+ * persisted role (renamed/removed role, or a workspace override that fell
+ * through to a built-in with the same name) must NOT silently resume with a
+ * different prompt or tool policy.
  */
-function resolveResumedAgentRole(roleName: string | undefined): AgentRole {
-  if (!roleName) return resolveAgentRole(roleName);
-  const known = getAgentRole(roleName);
-  if (known) return known;
-  return {
-    name: roleName,
-    config: { disallowlist: BUILTIN_READONLY_DISALLOWLIST },
-  };
+function resolveResumedAgentRole(
+  workspace: AgentRoleWorkspace,
+  metadata: Pick<
+    AgentMetadata,
+    "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+  >,
+): AgentRole {
+  const normalized = normalizeAgentRoleMetadata(metadata);
+  const roleName = normalized.agentRole;
+  if (roleName === undefined) return resolveAgentRole(workspace, roleName);
+  assertAgentRoleWorkspaceMatches(
+    workspace,
+    normalized.agentRoleWorkspaceId,
+  );
+  const known = getAgentRoleByExactName(workspace, roleName);
+  if (!known) {
+    throw new InvalidAgentMetadataError(
+      `cannot resume unknown agent role: ${roleName}`,
+    );
+  }
+  const expectedFingerprint = normalized.agentRoleFingerprint;
+  const actualFingerprint = agentRoleFingerprint(known);
+  if (
+    expectedFingerprint === undefined ||
+    expectedFingerprint !== actualFingerprint
+  ) {
+    throw new InvalidAgentMetadataError(
+      `cannot resume changed agent role: ${roleName}`,
+    );
+  }
+  return known;
 }
 import {
   AgentStatusTracker,
@@ -284,6 +312,8 @@ export class AgentControl {
   private readonly session: Session;
   private readonly registry: AgentRegistry;
   private readonly maxDepth: number;
+  /** Immutable role trust domain; execution cwd may move independently. */
+  readonly roleWorkspace: AgentRoleWorkspace;
   private readonly live = new Map<ThreadId, LiveAgent>();
   /** Cancellation tokens scoped to parents — I-32. */
   private readonly parentTokens = new Map<AgentPath, AbortController>();
@@ -297,6 +327,12 @@ export class AgentControl {
   constructor(opts: AgentControlOpts) {
     this.session = opts.session;
     this.registry = opts.registry;
+    const sessionRoleWorkspace = (
+      opts.session as Session & { readonly roleWorkspace?: AgentRoleWorkspace }
+    ).roleWorkspace;
+    this.roleWorkspace = sessionRoleWorkspace
+      ? normalizeAgentRoleWorkspace(sessionRoleWorkspace)
+      : createAgentRoleWorkspace(opts.session.sessionConfiguration.cwd);
     this.maxDepth =
       opts.maxDepth ?? resolveSessionMaxDepth(opts.session) ?? MAX_AGENT_DEPTH;
     this.threadManager = opts.threadManager;
@@ -305,6 +341,29 @@ export class AgentControl {
   bindThreadManager(threadManager: ThreadManager): void {
     this.threadManager = threadManager;
     threadManager.bindAgentControl(this);
+  }
+
+  assertRoleWorkspace(workspace: AgentRoleWorkspace): void {
+    assertAgentRoleWorkspaceMatches(this.roleWorkspace, workspace.id);
+  }
+
+  /**
+   * Validate the complete persisted role identity before lifecycle mutation.
+   * Exact-name lookup deliberately excludes public alias fallback.
+   */
+  assertAgentMetadataRoleWorkspace(
+    metadata: Pick<
+      AgentMetadata,
+      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+    >,
+  ): string {
+    const normalized = normalizeAgentRoleMetadata(metadata);
+    if (normalized.agentRole === undefined) {
+      throw new InvalidAgentMetadataError(
+        "agent role provenance is missing",
+      );
+    }
+    return resolveResumedAgentRole(this.roleWorkspace, normalized).name;
   }
 
   // ─────────────────────────────────────────────────────────────────
@@ -323,6 +382,8 @@ export class AgentControl {
    *      interrupted mid-spawn; if so, release slot + throw.
    *   6. Wire up mailboxes + status tracker + abortController.
    *   7. Finalize reservation (registers metadata).
+   *   8. Persist the spawn edge; roll back the finalized reservation on error.
+   *   9. Publish the live handle and mailboxes.
    *
    * Returns a `LiveAgent` handle the caller (run-agent.ts) uses to
    * drive the child session.
@@ -335,6 +396,11 @@ export class AgentControl {
     readonly agentPath?: AgentPath;
     readonly preferredNickname?: string;
     readonly depthCap?: number;
+    /** Fail-closed role identity for restart/rehydration spawns. */
+    readonly expectedRoleProvenance?: Pick<
+      AgentMetadata,
+      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+    >;
   }): Promise<LiveAgent> {
     if (this.threadManager) {
       return this.threadManager.spawnLiveAgent(opts);
@@ -350,13 +416,53 @@ export class AgentControl {
     readonly agentPath?: AgentPath;
     readonly preferredNickname?: string;
     readonly depthCap?: number;
+    readonly expectedRoleProvenance?: Pick<
+      AgentMetadata,
+      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+    >;
   }): Promise<LiveAgent> {
     const parentDepth = depthOfAgentPath(opts.parentPath);
     const childDepth = parentDepth + 1;
     const depthCap = opts.depthCap ?? this.maxDepth;
-    const role = requireAgentRole(opts.roleName);
+    const expectedRoleProvenance =
+      opts.expectedRoleProvenance !== undefined
+        ? normalizeAgentRoleMetadata(opts.expectedRoleProvenance)
+        : undefined;
+    if (
+      expectedRoleProvenance !== undefined &&
+      expectedRoleProvenance.agentRole === undefined
+    ) {
+      throw new InvalidAgentMetadataError(
+        "agent role provenance is missing",
+      );
+    }
+    const role =
+      expectedRoleProvenance !== undefined
+        ? resolveResumedAgentRole(
+            this.roleWorkspace,
+            expectedRoleProvenance,
+          )
+        : requireAgentRole(this.roleWorkspace, opts.roleName);
+    if (
+      opts.roleName !== undefined &&
+      expectedRoleProvenance !== undefined &&
+      role.name !== opts.roleName
+    ) {
+      throw new InvalidAgentMetadataError(
+        `expected agent role ${role.name} does not match requested role ${opts.roleName}`,
+      );
+    }
     const baseChildConfig = getChildBaseConfig(this.session) ?? {};
     void applyRoleToConfig(role, baseChildConfig);
+    const roleFingerprint = agentRoleFingerprint(role);
+    if (
+      expectedRoleProvenance !== undefined &&
+      roleFingerprint !== expectedRoleProvenance.agentRoleFingerprint
+    ) {
+      throw new InvalidAgentMetadataError(
+        `cannot resume changed agent role: ${role.name}`,
+      );
+    }
     const explicitAgentPath =
       opts.agentPath ??
       (opts.agentName !== undefined
@@ -371,22 +477,41 @@ export class AgentControl {
       throw new MaxDepthExceededError(childDepth, depthCap);
     }
 
+    // An explicit id is part of the durable edge identity, not merely an
+    // in-process registry key. Preflight gives a deterministic error; the
+    // create-only SQLite insert remains the race-proof commit check.
+    if (
+      opts.threadId !== undefined &&
+      this.session.rolloutStore?.getThreadSpawnEdge(opts.threadId) !== undefined
+    ) {
+      throw new AgentIdExistsError(opts.threadId);
+    }
+
     // I-63: atomic slot acquisition.
     const reservation = await this.registry.reserveSpawnSlot();
 
     let nickname!: string;
+    let releaseNicknameOnRollback = false;
     let threadId!: ThreadId;
     let metadata!: AgentMetadata;
     try {
       if (explicitAgentPath !== undefined) {
         reservation.reserveAgentPath(explicitAgentPath);
       }
-      nickname = opts.preferredNickname ?? allocateNickname(role, this.registry);
+      if (opts.preferredNickname !== undefined) {
+        nickname = opts.preferredNickname;
+        releaseNicknameOnRollback = !this.registry.hasNickname(nickname);
+      } else {
+        nickname = allocateNickname(role, this.registry);
+        releaseNicknameOnRollback = true;
+      }
       threadId = opts.threadId ?? crypto.randomUUID();
       metadata = buildChildMetadata({
         agentId: threadId,
         parentPath: opts.parentPath,
         role,
+        roleWorkspaceId: this.roleWorkspace.id,
+        roleFingerprint,
         nickname,
         depth: childDepth,
         ...(opts.agentName !== undefined ? { agentName: opts.agentName } : {}),
@@ -419,7 +544,7 @@ export class AgentControl {
       // preferredNickname) leaks into the registry's usedNicknames pool on
       // any rollback (I-32 abort, path collision). Release it on the failure
       // path so it returns to the pool.
-      if (opts.preferredNickname === undefined && nickname) {
+      if (releaseNicknameOnRollback && nickname) {
         releaseNickname(this.registry, nickname);
       }
       if (err instanceof AgentPathExistsError) {
@@ -470,29 +595,81 @@ export class AgentControl {
       tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     };
 
-    // I-5: wire the child's upInbox into the session's childInboxes
-    // Map so parent-side consumers (TUI, commit phase) can drain.
-    this.session.childInboxes.set(threadId, upInbox as unknown as never);
-    this.live.set(threadId, agent);
+    const publishAgent = (): void => {
+      this.session.childInboxes.set(threadId, upInbox as unknown as never);
+      this.live.set(threadId, agent);
+      const parentId = this.agentIdForPath(opts.parentPath);
+      if (parentId) {
+        this.parentOf.set(threadId, parentId);
+      }
+      if (!this.parentTokens.has(agent.agentPath)) {
+        this.parentTokens.set(agent.agentPath, agent.abortController);
+      }
+    };
 
-    // Track parent linkage for the in-memory subtree helpers.
-    const parentId = this.agentIdForPath(opts.parentPath);
-    if (parentId) {
-      this.parentOf.set(threadId, parentId);
-    }
-    // Register a per-agent parent cancellation token so nested
-    // spawns (grandchildren) observe the parent's token.
-    if (!this.parentTokens.has(agent.agentPath)) {
-      this.parentTokens.set(agent.agentPath, agent.abortController);
+    // Durability is the commit point. Do not publish any live maps until the
+    // edge is safely stored; a rejected provenance rebind or SQLite failure
+    // must leave the registry and control plane exactly as they were.
+    try {
+      await this.persistThreadSpawnEdgeForSource(
+        opts.parentPath,
+        threadId,
+        metadata,
+      );
+    } catch (error) {
+      upInbox.close("spawn_persistence_failed");
+      downInbox.close("spawn_persistence_failed");
+      await this.registry.releaseSpawnedThread(threadId);
+      if (releaseNicknameOnRollback) {
+        releaseNickname(this.registry, nickname);
+      }
+      throw error;
     }
 
-    // Persist the spawn edge through the rollout-store-owned snapshot
-    // so a fresh control plane can restore descendants later.
-    await this.persistThreadSpawnEdgeForSource(
-      opts.parentPath,
-      threadId,
-      metadata,
-    );
+    // Persistence may yield to an interrupt. A child must never become live
+    // after its parent was cancelled while the durable edge was committing.
+    const parentTokenAfterPersistence = this.parentTokens.get(opts.parentPath);
+    if (parentTokenAfterPersistence?.signal.aborted) {
+      let closeError: unknown;
+      try {
+        await this.setThreadSpawnEdgeStatus(threadId, "closed");
+      } catch (error) {
+        closeError = error;
+      }
+      if (closeError !== undefined) {
+        agent.abortController.abort("spawn_rollback_failed");
+        agent.status.markInterrupted(threadId, "spawn_rollback_failed");
+        publishAgent();
+        const parentThreadId = this.agentIdForPath(opts.parentPath);
+        this.threadManager?.registerLiveAgent(agent, {
+          ...(parentThreadId !== undefined ? { parentThreadId } : {}),
+        });
+        emitWarning(
+          this.session.eventLog,
+          this.session.nextInternalSubId(),
+          "spawn_rollback_failed",
+          `cancelled child ${threadId} remains registered because its durable edge could not be closed`,
+        );
+        throw closeError;
+      }
+      upInbox.close("spawn_race_aborted");
+      downInbox.close("spawn_race_aborted");
+      await this.registry.releaseSpawnedThread(threadId);
+      if (releaseNicknameOnRollback) {
+        releaseNickname(this.registry, nickname);
+      }
+      emitWarning(
+        this.session.eventLog,
+        this.session.nextInternalSubId(),
+        "spawn_race_aborted",
+        `parent ${opts.parentPath} interrupted while spawn provenance was persisted`,
+      );
+      throw new SpawnRaceAbortedError(opts.parentPath);
+    }
+
+    // I-5: publish only after the durable commit and post-commit cancellation
+    // check have both completed.
+    publishAgent();
 
     return agent;
   }
@@ -511,11 +688,13 @@ export class AgentControl {
     options: SpawnAgentOptions,
   ): Promise<LiveAgent> {
     const spawnOpts: Parameters<AgentControl["spawn"]>[0] = { parentPath };
+    const metadataRole = options.metadata
+      ? this.assertAgentMetadataRoleWorkspace(options.metadata)
+      : undefined;
     if (options.roleName !== undefined) {
       (spawnOpts as { roleName?: string }).roleName = options.roleName;
-    } else if (options.metadata?.agentRole) {
-      (spawnOpts as { roleName?: string }).roleName =
-        options.metadata.agentRole;
+    } else if (metadataRole !== undefined) {
+      (spawnOpts as { roleName?: string }).roleName = metadataRole;
     }
     if (options.threadId !== undefined) {
       (spawnOpts as { threadId?: ThreadId }).threadId = options.threadId;
@@ -538,6 +717,16 @@ export class AgentControl {
     }
     if (options.depthCap !== undefined) {
       (spawnOpts as { depthCap?: number }).depthCap = options.depthCap;
+    }
+    if (options.metadata !== undefined) {
+      (
+        spawnOpts as {
+          expectedRoleProvenance?: Pick<
+            AgentMetadata,
+            "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+          >;
+        }
+      ).expectedRoleProvenance = options.metadata;
     }
     const live = await this.spawn(spawnOpts);
     // Fork annotation: the live handle is already wired; the parent-
@@ -781,6 +970,13 @@ export class AgentControl {
       await this.shutdown(descendant.agentId, `cascade: ${reason}`);
     }
 
+    // Durable state is the commit point. If closing the edge fails, keep this
+    // live handle, its registry slot, and its mailboxes intact so callers can
+    // retry instead of leaving an open durable edge backed by torn-down state.
+    if (edgeStatus !== null) {
+      await this.setThreadSpawnEdgeStatus(threadId, edgeStatus);
+    }
+
     agent.upInbox.close(reason);
     agent.downInbox.close(reason);
     agent.status.markShutdown();
@@ -798,9 +994,6 @@ export class AgentControl {
     this.parentOf.delete(threadId);
     this.live.delete(threadId);
     this.threadManager?.removeThread(threadId);
-    if (edgeStatus !== null) {
-      await this.setThreadSpawnEdgeStatus(threadId, edgeStatus);
-    }
   }
 
   async closeAgent(threadId: ThreadId): Promise<void> {
@@ -854,16 +1047,31 @@ export class AgentControl {
     readonly parentPath: AgentPath;
     readonly metadata: AgentMetadata;
   }): Promise<LiveAgent | null> {
-    const { metadata, parentPath } = opts;
+    const metadata = normalizeAgentMetadata(opts.metadata);
+    const { parentPath } = opts;
     const threadId = metadata.agentId;
     const agentPath = metadata.agentPath;
     if (!threadId || !agentPath) return null;
+    if (threadId === this.rootThreadId || agentPath === ROOT_AGENT_PATH) {
+      throw new InvalidAgentMetadataError(
+        "cannot resume the session root as a child agent",
+      );
+    }
 
-    // I-1: depth cap. Use metadata.depth as authority, fall back to
-    // parent-path-derived depth + 1 if metadata is missing depth.
-    // Rejects when depth exceeds the cap (`depth > this.maxDepth`).
-    const depth =
-      metadata.depth ?? depthOfAgentPath(parentPath) + 1;
+    const pathDepth = depthOfAgentPath(agentPath);
+    if (metadata.depth !== pathDepth) {
+      throw new InvalidAgentMetadataError(
+        `agent resume depth ${metadata.depth} does not match path depth ${pathDepth}`,
+      );
+    }
+    const expectedParentPath = parentAgentPathFor(agentPath);
+    if (expectedParentPath === undefined || expectedParentPath !== parentPath) {
+      throw new InvalidAgentMetadataError(
+        `agent resume parent ${parentPath} does not match path parent ${expectedParentPath ?? "missing"}`,
+      );
+    }
+    // I-1: the validated path depth is the sole depth-cap authority.
+    const depth = pathDepth;
     if (depth > this.maxDepth) {
       emitError(this.session.eventLog, this.session.nextInternalSubId(), {
         cause: "max_depth_exceeded",
@@ -872,13 +1080,40 @@ export class AgentControl {
       throw new MaxDepthExceededError(depth, this.maxDepth);
     }
 
-    // Idempotency: if already live on this agentPath, return it.
-    const existing = this.getLiveByPath(agentPath);
-    if (existing) return existing;
+    const role = resolveResumedAgentRole(this.roleWorkspace, metadata);
 
-    // Registry: if unknown, reserve a slot + finalize with the metadata.
-    // If registry already knows the thread, the slot is already charged.
-    if (!this.registry.agentMetadataForThread(threadId)) {
+    // Idempotency is exact identity, never merely a matching id or path. A
+    // partial match would let resume overwrite one live map while leaving the
+    // registry indexed under another identity.
+    const liveById = this.live.get(threadId);
+    const liveByPath = this.getLiveByPath(agentPath);
+    if (liveById !== undefined || liveByPath !== undefined) {
+      if (
+        liveById === undefined ||
+        liveByPath === undefined ||
+        liveById !== liveByPath
+      ) {
+        throw new InvalidAgentMetadataError(
+          "agent resume identity conflicts with a live agent",
+        );
+      }
+      assertSameAgentIdentity(metadata, liveById.metadata);
+      return liveById;
+    }
+
+    const registeredById = this.registry.agentMetadataForThread(threadId);
+    const registeredIdAtPath = this.registry.agentIdForPath(agentPath);
+    if (registeredById !== undefined) {
+      assertSameAgentIdentity(metadata, registeredById);
+      if (registeredIdAtPath !== threadId) {
+        throw new InvalidAgentMetadataError(
+          "agent resume registry indexes disagree",
+        );
+      }
+    } else {
+      if (registeredIdAtPath !== undefined) {
+        throw new AgentPathExistsError(agentPath);
+      }
       const reservation = await this.registry.reserveSpawnSlot();
       try {
         reservation.finalize(metadata);
@@ -888,7 +1123,6 @@ export class AgentControl {
       }
     }
 
-    const role = resolveResumedAgentRole(metadata.agentRole);
     const nickname = metadata.agentNickname ?? `resumed-${threadId}`;
     const upInbox = new Mailbox({
       threadId,
@@ -972,6 +1206,11 @@ export class AgentControl {
     readonly resumedCount: number;
     readonly rootLive: LiveAgent | null;
   }> {
+    if (opts.metadata.agentId !== opts.rootThreadId) {
+      throw new InvalidAgentMetadataError(
+        "rollout root thread id does not match agent metadata",
+      );
+    }
     const rootLive = await this.resumeSingleAgentFromRollout({
       parentPath: opts.parentPath,
       metadata: opts.metadata,
@@ -1004,13 +1243,12 @@ export class AgentControl {
       for (const edge of children) {
         if (seen.has(edge.childThreadId)) continue;
         seen.add(edge.childThreadId);
-        const existing = this.live.get(edge.childThreadId);
-        if (existing) {
-          resumeQueue.push(existing.agentId);
-          continue;
-        }
-
         try {
+          if (this.agentIdForPath(edge.parentPath) !== parentThreadId) {
+            throw new InvalidAgentMetadataError(
+              `spawn edge parent thread ${parentThreadId} does not match live parent path ${edge.parentPath}`,
+            );
+          }
           const childLive = await this.resumeSingleAgentFromRollout({
             parentPath: edge.parentPath,
             metadata: edge.metadata,
@@ -1434,7 +1672,7 @@ export class AgentControl {
     readonly roleName?: string;
     readonly preferredNickname?: string;
   }): { readonly metadata: AgentMetadata; readonly role: AgentRole } {
-    const role = requireAgentRole(opts.roleName);
+    const role = requireAgentRole(this.roleWorkspace, opts.roleName);
     const nickname =
       opts.preferredNickname ?? allocateNickname(role, this.registry);
     const depth = depthOfAgentPath(opts.parentPath) + 1;
@@ -1442,6 +1680,8 @@ export class AgentControl {
       agentId: "pending",
       parentPath: opts.parentPath,
       role,
+      roleWorkspaceId: this.roleWorkspace.id,
+      roleFingerprint: agentRoleFingerprint(role),
       nickname,
       depth,
     });
@@ -1557,7 +1797,7 @@ export class AgentControl {
     if (!rolloutStore) return;
     const storedMetadata = metadata ?? this.registry.agentMetadataForThread(childThreadId);
     if (!storedMetadata) return;
-    rolloutStore.upsertThreadSpawnEdge({
+    rolloutStore.createThreadSpawnEdge({
       childThreadId,
       parentThreadId,
       parentPath,
@@ -1675,18 +1915,29 @@ export function renderInputPreview(input: string): string {
 function cloneAgentMetadata(
   metadata: AgentMetadata | undefined,
 ): AgentMetadata {
-  return {
-    ...(metadata?.agentId !== undefined ? { agentId: metadata.agentId } : {}),
-    ...(metadata?.agentPath !== undefined ? { agentPath: metadata.agentPath } : {}),
-    ...(metadata?.agentNickname !== undefined
-      ? { agentNickname: metadata.agentNickname }
-      : {}),
-    ...(metadata?.agentRole !== undefined ? { agentRole: metadata.agentRole } : {}),
-    ...(metadata?.lastTaskMessage !== undefined
-      ? { lastTaskMessage: metadata.lastTaskMessage }
-      : {}),
-    depth: metadata?.depth ?? 0,
-  };
+  return normalizeAgentMetadata(metadata ?? { depth: 0 });
+}
+
+function assertSameAgentIdentity(
+  expected: AgentMetadata,
+  actual: AgentMetadata,
+): void {
+  const normalizedExpected = normalizeAgentMetadata(expected);
+  const normalizedActual = normalizeAgentMetadata(actual);
+  if (
+    normalizedExpected.agentId !== normalizedActual.agentId ||
+    normalizedExpected.agentPath !== normalizedActual.agentPath ||
+    normalizedExpected.agentRole !== normalizedActual.agentRole ||
+    normalizedExpected.agentRoleWorkspaceId !==
+      normalizedActual.agentRoleWorkspaceId ||
+    normalizedExpected.agentRoleFingerprint !==
+      normalizedActual.agentRoleFingerprint ||
+    normalizedExpected.depth !== normalizedActual.depth
+  ) {
+    throw new InvalidAgentMetadataError(
+      "agent resume identity does not match registered metadata",
+    );
+  }
 }
 
 function edgeStatusForShutdownReason(

--- a/runtime/src/agents/delegate.ts
+++ b/runtime/src/agents/delegate.ts
@@ -115,6 +115,7 @@ export async function delegate(
   // Set up worktree if requested.
   let worktree: WorktreeHandle | undefined;
   let baseCommit: string | null = null;
+  let preserveLiveAfterRoleProvenanceFailure = false;
   if (isolation === "worktree") {
     const worktreeSlug = opts.worktreeSlug!;
     const workspaceRoot =
@@ -236,6 +237,9 @@ export async function delegate(
       ...(opts.onProgress !== undefined
         ? { onProgress: opts.onProgress }
         : {}),
+      onRoleProvenanceFailure: () => {
+        preserveLiveAfterRoleProvenanceFailure = true;
+      },
     });
 
   if (!opts.forceSynchronous && (runInBackground || live.role.config.background)) {
@@ -247,25 +251,30 @@ export async function delegate(
         asyncResult = await execute(thread);
         return asyncResult;
       } finally {
-        await markAsyncThreadSpawnEdgeClosed({
-          control: opts.control,
-          thread,
-          parent: opts.parent,
-        });
+        if (!preserveLiveAfterRoleProvenanceFailure) {
+          await markAsyncThreadSpawnEdgeClosed({
+            control: opts.control,
+            thread,
+            parent: opts.parent,
+          });
+        }
         // On a terminal non-completed outcome (or a thrown run), release the
         // agent so its registry path/slot are freed and a re-spawn at the same
         // path does not collide with a leaked reservation. A clean completion
         // keeps the prior fire-and-forget behavior (no delegate-scoped shutdown).
         const shutdownAgent =
-          asyncResult === undefined || asyncResult.outcome !== "completed";
-        await teardown({
-          thread,
-          control: opts.control,
-          registry: opts.registry,
-          parent: opts.parent,
-          shutdownAgent,
-          ...(baseCommit !== null ? { baseCommit } : {}),
-        });
+          !preserveLiveAfterRoleProvenanceFailure &&
+          (asyncResult === undefined || asyncResult.outcome !== "completed");
+        if (!preserveLiveAfterRoleProvenanceFailure) {
+          await teardown({
+            thread,
+            control: opts.control,
+            registry: opts.registry,
+            parent: opts.parent,
+            shutdownAgent,
+            ...(baseCommit !== null ? { baseCommit } : {}),
+          });
+        }
       }
     });
     thread = buildThread({ joinPromise });
@@ -278,14 +287,16 @@ export async function delegate(
   try {
     result = await execute(thread);
   } finally {
-    await teardown({
-      thread,
-      control: opts.control,
-      registry: opts.registry,
-      parent: opts.parent,
-      shutdownAgent: true,
-      ...(baseCommit !== null ? { baseCommit } : {}),
-    });
+    if (!preserveLiveAfterRoleProvenanceFailure) {
+      await teardown({
+        thread,
+        control: opts.control,
+        registry: opts.registry,
+        parent: opts.parent,
+        shutdownAgent: true,
+        ...(baseCommit !== null ? { baseCommit } : {}),
+      });
+    }
   }
 
   return {
@@ -357,6 +368,7 @@ async function runDelegateAgentLoop(opts: {
     event: RunAgentProgressEvent,
     thread: AgentThread,
   ) => void | Promise<void>;
+  readonly onRoleProvenanceFailure: () => void;
 }): Promise<RunAgentResult> {
   while (true) {
     const live = opts.thread.live;
@@ -422,6 +434,7 @@ async function runDelegateAgentLoop(opts: {
         parent: opts.parent,
         parentPath: opts.parentPath,
         control: opts.control,
+        onRoleProvenanceFailure: opts.onRoleProvenanceFailure,
       });
       if (!restarted) {
         return result;
@@ -445,6 +458,7 @@ async function runDelegateAgentLoop(opts: {
       parent: opts.parent,
       parentPath: opts.parentPath,
       control: opts.control,
+      onRoleProvenanceFailure: opts.onRoleProvenanceFailure,
     });
     if (!nextLive) {
       return result;
@@ -458,8 +472,21 @@ async function recoverLiveAgent(opts: {
   readonly parent: Session;
   readonly parentPath: AgentPath;
   readonly control: AgentControl;
+  readonly onRoleProvenanceFailure: () => void;
 }): Promise<LiveAgent | null> {
   const live = opts.thread.live;
+  try {
+    opts.control.assertAgentMetadataRoleWorkspace(live.metadata);
+  } catch (err) {
+    opts.onRoleProvenanceFailure();
+    emitWarning(
+      opts.parent.eventLog,
+      opts.parent.nextInternalSubId(),
+      "subagent_resume_failed",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
   emitWarning(
     opts.parent.eventLog,
     opts.parent.nextInternalSubId(),
@@ -498,8 +525,21 @@ async function restartLiveAgent(opts: {
   readonly parent: Session;
   readonly parentPath: AgentPath;
   readonly control: AgentControl;
+  readonly onRoleProvenanceFailure: () => void;
 }): Promise<LiveAgent | null> {
   const live = opts.thread.live;
+  try {
+    opts.control.assertAgentMetadataRoleWorkspace(live.metadata);
+  } catch (err) {
+    opts.onRoleProvenanceFailure();
+    emitWarning(
+      opts.parent.eventLog,
+      opts.parent.nextInternalSubId(),
+      "subagent_restart_failed",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
   emitWarning(
     opts.parent.eventLog,
     opts.parent.nextInternalSubId(),
@@ -515,6 +555,7 @@ async function restartLiveAgent(opts: {
       roleName: live.metadata.agentRole ?? live.role.name,
       agentPath: live.agentPath,
       preferredNickname: live.nickname,
+      expectedRoleProvenance: live.metadata,
     });
   } catch (err) {
     emitWarning(

--- a/runtime/src/agents/registry.ts
+++ b/runtime/src/agents/registry.ts
@@ -40,8 +40,111 @@ export interface AgentMetadata {
   readonly agentPath?: AgentPath;
   readonly agentNickname?: string;
   readonly agentRole?: string;
+  readonly agentRoleWorkspaceId?: string;
+  readonly agentRoleFingerprint?: string;
   readonly lastTaskMessage?: string;
   readonly depth: number;
+}
+
+export class InvalidAgentMetadataError extends Error {
+  constructor(message = "invalid agent metadata", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "InvalidAgentMetadataError";
+  }
+}
+
+export function normalizeAgentRoleMetadata(
+  metadata: unknown,
+): Pick<
+  AgentMetadata,
+  "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+> {
+  if (
+    typeof metadata !== "object" ||
+    metadata === null ||
+    Array.isArray(metadata)
+  ) {
+    throw new InvalidAgentMetadataError();
+  }
+  const record = metadata as Record<string, unknown>;
+  const agentRole = optionalMetadataString(record.agentRole, "agentRole", true);
+  const agentRoleWorkspaceId = optionalMetadataString(
+    record.agentRoleWorkspaceId,
+    "agentRoleWorkspaceId",
+    true,
+  );
+  const agentRoleFingerprint = optionalMetadataString(
+    record.agentRoleFingerprint,
+    "agentRoleFingerprint",
+    true,
+  );
+  if (
+    (agentRoleWorkspaceId !== undefined || agentRoleFingerprint !== undefined) &&
+    agentRole === undefined
+  ) {
+    throw new InvalidAgentMetadataError(
+      "invalid agent metadata role provenance without agentRole",
+    );
+  }
+  return {
+    ...(agentRole !== undefined ? { agentRole } : {}),
+    ...(agentRoleWorkspaceId !== undefined ? { agentRoleWorkspaceId } : {}),
+    ...(agentRoleFingerprint !== undefined ? { agentRoleFingerprint } : {}),
+  };
+}
+
+export function normalizeAgentMetadata(metadata: unknown): AgentMetadata {
+  if (
+    typeof metadata !== "object" ||
+    metadata === null ||
+    Array.isArray(metadata)
+  ) {
+    throw new InvalidAgentMetadataError();
+  }
+  const record = metadata as Record<string, unknown>;
+  if (
+    typeof record.depth !== "number" ||
+    !Number.isSafeInteger(record.depth) ||
+    record.depth < 0
+  ) {
+    throw new InvalidAgentMetadataError("invalid agent metadata depth");
+  }
+  const roleMetadata = normalizeAgentRoleMetadata(record);
+  const agentId = optionalMetadataString(record.agentId, "agentId", true);
+  const agentPath = optionalMetadataString(record.agentPath, "agentPath", true);
+  const agentNickname = optionalMetadataString(
+    record.agentNickname,
+    "agentNickname",
+    true,
+  );
+  const lastTaskMessage = optionalMetadataString(
+    record.lastTaskMessage,
+    "lastTaskMessage",
+    false,
+  );
+  return {
+    depth: record.depth,
+    ...(agentId !== undefined ? { agentId } : {}),
+    ...(agentPath !== undefined ? { agentPath } : {}),
+    ...(agentNickname !== undefined ? { agentNickname } : {}),
+    ...roleMetadata,
+    ...(lastTaskMessage !== undefined ? { lastTaskMessage } : {}),
+  };
+}
+
+function optionalMetadataString(
+  value: unknown,
+  field: string,
+  requireNonEmpty: boolean,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    (requireNonEmpty && value.trim().length === 0)
+  ) {
+    throw new InvalidAgentMetadataError(`invalid agent metadata ${field}`);
+  }
+  return value;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -52,6 +155,13 @@ export class AgentPathExistsError extends Error {
   constructor(public readonly path: AgentPath) {
     super(`agent path already exists: ${path}`);
     this.name = "AgentPathExistsError";
+  }
+}
+
+export class AgentIdExistsError extends Error {
+  constructor(public readonly threadId: ThreadId) {
+    super(`agent thread id already exists: ${threadId}`);
+    this.name = "AgentIdExistsError";
   }
 }
 
@@ -170,6 +280,9 @@ export class AgentRegistry {
     metadata: AgentMetadata,
     reservation: SpawnReservation,
   ): void {
+    if (metadata.agentId && this.findEntryByThreadId(metadata.agentId)) {
+      throw new AgentIdExistsError(metadata.agentId);
+    }
     if (metadata.agentPath) {
       assertValidAgentPath(metadata.agentPath);
       if (
@@ -435,6 +548,8 @@ export function buildChildMetadata(opts: {
   readonly agentId: ThreadId;
   readonly parentPath: AgentPath;
   readonly role: AgentRole;
+  readonly roleWorkspaceId: string;
+  readonly roleFingerprint: string;
   readonly nickname: string;
   readonly depth: number;
   readonly agentName?: string;
@@ -452,6 +567,8 @@ export function buildChildMetadata(opts: {
     agentPath,
     agentNickname: opts.nickname,
     agentRole: opts.role.name,
+    agentRoleWorkspaceId: opts.roleWorkspaceId,
+    agentRoleFingerprint: opts.roleFingerprint,
     depth: opts.depth,
   };
 }

--- a/runtime/src/agents/role-definitions.ts
+++ b/runtime/src/agents/role-definitions.ts
@@ -1,12 +1,20 @@
 import type { AgentRole } from "./role.js";
-import { listAgentRoles, loadMarkdownAgentRoles } from "./role.js";
+import {
+  createAgentRoleWorkspace,
+  listAgentRoles,
+} from "./role.js";
+import { agentDefinitionFingerprint } from "./agent-definition-fingerprint.js";
 
 export type AgentRoleDefinition = {
   agentType: string;
   whenToUse: string;
   tools?: string[];
+  disallowedTools?: string[];
+  background?: boolean;
+  effort?: AgentRole["config"]["reasoningEffort"];
   source: "built-in";
   baseDir: "built-in";
+  agentRoleFingerprint: string;
   getSystemPrompt: () => string;
 };
 
@@ -16,20 +24,29 @@ function projectAgentRole(role: AgentRole): AgentRoleDefinition {
   const tools = role.config.allowlist
     ? Array.from(role.config.allowlist)
     : undefined;
-  const definition: AgentRoleDefinition = {
+  const definition = {
     agentType: role.name,
     whenToUse: description,
-    source: "built-in",
-    baseDir: "built-in",
+    source: "built-in" as const,
+    baseDir: "built-in" as const,
     getSystemPrompt: () => systemPrompt,
     ...(tools !== undefined ? { tools } : {}),
+    ...(role.config.disallowlist
+      ? { disallowedTools: Array.from(role.config.disallowlist) }
+      : {}),
+    ...(role.config.background ? { background: true } : {}),
+    ...(role.config.reasoningEffort
+      ? { effort: role.config.reasoningEffort }
+      : {}),
   };
-  return definition;
+  return {
+    ...definition,
+    agentRoleFingerprint: agentDefinitionFingerprint(definition),
+  };
 }
 
 export function listAgentRoleDefinitions(
-  cwd?: string,
+  cwd: string,
 ): readonly AgentRoleDefinition[] {
-  loadMarkdownAgentRoles(cwd);
-  return listAgentRoles(cwd).map(projectAgentRole);
+  return listAgentRoles(createAgentRoleWorkspace(cwd)).map(projectAgentRole);
 }

--- a/runtime/src/agents/role-workspace.ts
+++ b/runtime/src/agents/role-workspace.ts
@@ -1,0 +1,76 @@
+import { isAbsolute, resolve } from "node:path";
+
+declare const agentRoleWorkspaceBrand: unique symbol;
+
+/**
+ * Immutable trust-domain identity used for agent-role lookup.
+ *
+ * This is intentionally distinct from a session's execution cwd, which may
+ * move into and out of a Git worktree while the session is running.
+ */
+export interface AgentRoleWorkspace {
+  readonly id: string;
+  readonly cwd: string;
+  readonly [agentRoleWorkspaceBrand]: true;
+}
+
+export class AgentRoleWorkspaceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentRoleWorkspaceError";
+  }
+}
+
+export class AgentRoleWorkspaceMismatchError extends Error {
+  constructor(
+    public readonly expectedWorkspaceId: string,
+    public readonly actualWorkspaceId: string | undefined,
+  ) {
+    super(
+      actualWorkspaceId === undefined
+        ? `agent role workspace provenance is missing; expected ${expectedWorkspaceId}`
+        : `agent role workspace mismatch: expected ${expectedWorkspaceId}, received ${actualWorkspaceId}`,
+    );
+    this.name = "AgentRoleWorkspaceMismatchError";
+  }
+}
+
+export function createAgentRoleWorkspace(cwd: string): AgentRoleWorkspace {
+  if (typeof cwd !== "string" || cwd.length === 0) {
+    throw new AgentRoleWorkspaceError(
+      "agent role workspace requires a non-empty absolute cwd",
+    );
+  }
+  if (!isAbsolute(cwd)) {
+    throw new AgentRoleWorkspaceError(
+      `agent role workspace cwd must be absolute: ${cwd}`,
+    );
+  }
+  const canonical = resolve(cwd);
+  return Object.freeze({
+    id: canonical,
+    cwd: canonical,
+  }) as AgentRoleWorkspace;
+}
+
+export function normalizeAgentRoleWorkspace(
+  workspace: Pick<AgentRoleWorkspace, "id" | "cwd">,
+): AgentRoleWorkspace {
+  const normalized = createAgentRoleWorkspace(workspace.cwd);
+  if (workspace.id !== normalized.id) {
+    throw new AgentRoleWorkspaceMismatchError(normalized.id, workspace.id);
+  }
+  return normalized;
+}
+
+export function assertAgentRoleWorkspaceMatches(
+  expected: AgentRoleWorkspace,
+  actualWorkspaceId: string | undefined,
+): void {
+  if (actualWorkspaceId !== expected.id) {
+    throw new AgentRoleWorkspaceMismatchError(
+      expected.id,
+      actualWorkspaceId,
+    );
+  }
+}

--- a/runtime/src/agents/role.ts
+++ b/runtime/src/agents/role.ts
@@ -27,23 +27,28 @@
  *                   the internal `worker` id and inherits parent tool
  *                   catalog
  *
- * User roles register via `registerAgentRole({ name, config })` and
- * override the built-ins.
+ * Programmatic user roles register via
+ * `registerAgentRole(workspace, { name, config })` and override built-ins only
+ * inside that workspace.
  *
  * @module
  */
 
 import {
+  closeSync,
+  constants,
   existsSync,
+  fstatSync,
   lstatSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
-  statSync,
 } from "node:fs";
-import type { Dirent } from "node:fs";
+import { createHash } from "node:crypto";
+import type { BigIntStats, Dirent } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import yaml from "js-yaml";
 import type { AgentRegistry } from "./registry.js";
 import { normalizeAgenCKeyAliases, normalizeRawConfig } from "../config/schema.js";
@@ -51,6 +56,7 @@ import { parseToml } from "../config/loader.js";
 import { resolveProfile } from "../config/profiles.js";
 import type { AgenCConfig } from "../config/schema.js";
 import { normalizeExternalText } from "./_deps/file-read.js";
+import { stableStringify } from "../utils/stableStringify.js";
 import {
   agentRolePresentation,
   canonicalAgentRoleName,
@@ -63,6 +69,15 @@ import {
   VERIFICATION_SYSTEM_PROMPT,
   VERIFICATION_WHEN_TO_USE,
 } from "./built-in-prompts.js";
+import type { AgentRoleWorkspace } from "./role-workspace.js";
+export {
+  AgentRoleWorkspaceError,
+  AgentRoleWorkspaceMismatchError,
+  assertAgentRoleWorkspaceMatches,
+  createAgentRoleWorkspace,
+  normalizeAgentRoleWorkspace,
+} from "./role-workspace.js";
+export type { AgentRoleWorkspace } from "./role-workspace.js";
 
 export type AgentReasoningEffort =
   | "none"
@@ -113,6 +128,31 @@ export interface AgentRoleConfig {
 export interface AgentRole {
   readonly name: string;
   readonly config: AgentRoleConfig;
+}
+
+/**
+ * Content identity for a resolved role.
+ *
+ * The workspace id proves where a role came from; this digest proves which
+ * effective definition occupied that name. Both are required when reopening a
+ * child so removing a restrictive workspace override cannot silently fall
+ * through to a less restrictive built-in with the same name.
+ */
+export function agentRoleFingerprint(role: AgentRole): string {
+  // A config-file path is not executable identity: the file can change in
+  // place. Resolve the exact effective TOML layer on every digest operation.
+  // Read/parse failures intentionally propagate so spawn/resume fails closed.
+  const effectiveConfigLayer = loadRoleLayerToml(role);
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        name: role.name,
+        config: role.config,
+        effectiveConfigLayer,
+      }),
+      "utf8",
+    )
+    .digest("hex");
 }
 
 const BUILT_IN_ROLE_CONFIG_TOML = Object.freeze({
@@ -338,59 +378,77 @@ const BUILT_INS: ReadonlyArray<AgentRole> = Object.freeze([
 ]);
 
 // ─────────────────────────────────────────────────────────────────────
-// Role registry (process-level)
+// Role registries (built-ins + workspace-scoped definitions)
 // ─────────────────────────────────────────────────────────────────────
 
-const registry = new Map<string, AgentRole>();
-for (const role of BUILT_INS) registry.set(role.name, role);
+const builtInRoles = new Map<string, AgentRole>();
+for (const role of BUILT_INS) builtInRoles.set(role.name, role);
+
+const registeredRolesByWorkspace = new Map<string, Map<string, AgentRole>>();
 
 interface MarkdownRoleNamespace {
   readonly roles: Map<string, AgentRole>;
   readonly signature: string;
 }
 
-// Markdown-loaded roles are namespaced by the requesting cwd so two projects
-// with same-named `.agenc/agents/<name>.md` roles resolve independently
-// inside one daemon process. Map insertion order doubles as load order for
-// the cwd-less fallback lookup (most recently loaded cwd wins, matching the
-// old single-registry last-write-wins behavior).
+// Markdown-loaded roles are namespaced by the requesting workspace so two
+// projects with same-named `.agenc/agents/<name>.md` roles resolve independently
+// inside one daemon process. There is deliberately no cwd-less fallback.
 const markdownRolesByCwd = new Map<string, MarkdownRoleNamespace>();
+let markdownAgentRoleReadHookForTesting:
+  | ((filePath: string) => void)
+  | undefined;
 
-export function registerAgentRole(role: AgentRole): void {
-  registry.set(role.name, freezeRole(role));
+export function registerAgentRole(
+  workspace: AgentRoleWorkspace,
+  role: AgentRole,
+): void {
+  const roles = registeredRolesByWorkspace.get(workspace.id) ?? new Map();
+  roles.set(role.name, freezeRole(role));
+  registeredRolesByWorkspace.set(workspace.id, roles);
 }
 
-export function getAgentRole(name: string, cwd?: string): AgentRole | undefined {
+export function getAgentRole(
+  workspace: AgentRoleWorkspace,
+  name: string,
+): AgentRole | undefined {
   return (
-    lookupRoleByExactName(name, cwd) ??
-    lookupRoleByExactName(canonicalAgentRoleName(name), cwd)
+    getAgentRoleByExactName(workspace, name) ??
+    lookupRoleByExactName(workspace, canonicalAgentRoleName(name))
   );
 }
 
-function lookupRoleByExactName(
+/**
+ * Resolve only the persisted role name, without public-name alias fallback.
+ *
+ * Durable role provenance must use this lookup: if a workspace override named
+ * `scanner` disappears, reopening it as the built-in `explorer` alias would
+ * silently weaken the original prompt/tool policy.
+ */
+export function getAgentRoleByExactName(
+  workspace: AgentRoleWorkspace,
   name: string,
-  cwd: string | undefined,
 ): AgentRole | undefined {
-  return lookupMarkdownRole(name, cwd) ?? registry.get(name);
+  return lookupRoleByExactName(workspace, name);
+}
+
+function lookupRoleByExactName(
+  workspace: AgentRoleWorkspace,
+  name: string,
+): AgentRole | undefined {
+  return (
+    lookupMarkdownRole(workspace, name) ??
+    registeredRolesByWorkspace.get(workspace.id)?.get(name) ??
+    builtInRoles.get(name)
+  );
 }
 
 function lookupMarkdownRole(
+  workspace: AgentRoleWorkspace,
   name: string,
-  cwd: string | undefined,
 ): AgentRole | undefined {
-  if (cwd !== undefined) {
-    loadMarkdownAgentRoles(cwd);
-    return markdownRolesByCwd.get(resolve(cwd))?.roles.get(name);
-  }
-  // No requesting cwd available at this call site: preserve the legacy
-  // process-global behavior by searching every loaded namespace, most
-  // recently loaded first.
-  const namespaces = [...markdownRolesByCwd.values()];
-  for (let i = namespaces.length - 1; i >= 0; i--) {
-    const role = namespaces[i].roles.get(name);
-    if (role !== undefined) return role;
-  }
-  return undefined;
+  loadMarkdownAgentRoles(workspace);
+  return markdownRolesByCwd.get(workspace.id)?.roles.get(name);
 }
 
 export function getDefaultAgentRole(): AgentRole {
@@ -405,31 +463,40 @@ class AgentRoleNotFoundError extends Error {
 }
 
 export function requireAgentRole(
+  workspace: AgentRoleWorkspace,
   name: string | undefined,
-  cwd?: string,
 ): AgentRole {
   if (!name) return DEFAULT_ROLE;
-  const role = getAgentRole(name, cwd);
+  const role = getAgentRole(workspace, name);
   if (!role) throw new AgentRoleNotFoundError(name);
   return role;
 }
 
-export function listAgentRoles(cwd?: string): ReadonlyArray<AgentRole> {
-  const merged = new Map<string, AgentRole>(registry);
-  if (cwd !== undefined) {
-    loadMarkdownAgentRoles(cwd);
-    const namespace = markdownRolesByCwd.get(resolve(cwd));
-    if (namespace) {
-      for (const role of namespace.roles.values()) merged.set(role.name, role);
-    }
-  } else {
-    // Legacy cwd-less listing: union across loaded namespaces in load
-    // order so a more recently loaded cwd wins same-named roles.
-    for (const namespace of markdownRolesByCwd.values()) {
-      for (const role of namespace.roles.values()) merged.set(role.name, role);
-    }
+export function listAgentRoles(
+  workspace: AgentRoleWorkspace,
+): ReadonlyArray<AgentRole> {
+  const merged = new Map<string, AgentRole>(builtInRoles);
+  for (const role of registeredRolesByWorkspace.get(workspace.id)?.values() ?? []) {
+    merged.set(role.name, role);
+  }
+  loadMarkdownAgentRoles(workspace);
+  const namespace = markdownRolesByCwd.get(workspace.id);
+  if (namespace) {
+    for (const role of namespace.roles.values()) merged.set(role.name, role);
   }
   return Array.from(merged.values());
+}
+
+/** Return only roles shipped by the runtime, excluding workspace definitions. */
+export function listBuiltInAgentRoles(): ReadonlyArray<AgentRole> {
+  return BUILT_INS;
+}
+
+/** Return only programmatic definitions registered for this workspace. */
+export function listRegisteredAgentRoles(
+  workspace: AgentRoleWorkspace,
+): ReadonlyArray<AgentRole> {
+  return [...(registeredRolesByWorkspace.get(workspace.id)?.values() ?? [])];
 }
 
 export function defaultAgentNicknameCandidates(): ReadonlyArray<string> {
@@ -438,59 +505,62 @@ export function defaultAgentNicknameCandidates(): ReadonlyArray<string> {
 
 export function _resetAgentRolesForTesting(): void {
   markdownRolesByCwd.clear();
-  registry.clear();
-  for (const role of BUILT_INS) registry.set(role.name, role);
+  registeredRolesByWorkspace.clear();
+  markdownAgentRoleReadHookForTesting = undefined;
 }
 
-export function loadMarkdownAgentRoles(cwd = process.cwd()): void {
-  const key = resolve(cwd);
-  // Cheap mtime/size-based invalidation: stat the candidate role dirs and
-  // files on every load so editing a role .md takes effect for new sessions
-  // without a daemon restart. Only when the signature changes do we re-read
-  // and re-parse the files.
-  const signature = markdownAgentRoleSignature(key);
+/** Deterministic validation-to-open race seam; tests only. */
+export function _setMarkdownAgentRoleReadHookForTesting(
+  hook: ((filePath: string) => void) | undefined,
+): void {
+  markdownAgentRoleReadHookForTesting = hook;
+}
+
+export function loadMarkdownAgentRoles(workspace: AgentRoleWorkspace): void {
+  const key = workspace.id;
+  // Cheap identity/metadata invalidation: inspect candidate role dirs and files
+  // on every load so editing a role .md takes effect for new sessions without
+  // a daemon restart. Only when the signature changes do we securely open and
+  // re-parse the files.
+  const signature = markdownAgentRoleSignature(workspace.cwd);
   const existing = markdownRolesByCwd.get(key);
   if (existing !== undefined && existing.signature === signature) return;
 
   const roles = new Map<string, AgentRole>();
-  for (const file of readMarkdownAgentRoleFiles(key)) {
+  for (const file of readMarkdownAgentRoleFiles(workspace.cwd)) {
     const role = markdownAgentRoleFromFile(file);
     if (role) roles.set(role.name, freezeRole(role));
   }
-  // Delete-then-set so the most recently (re)loaded cwd wins the cwd-less
-  // fallback lookup, matching the old single-registry behavior.
-  markdownRolesByCwd.delete(key);
   markdownRolesByCwd.set(key, { roles, signature });
 }
 
 function markdownAgentRoleSignature(cwd: string): string {
   const parts: string[] = [];
-  for (const dir of markdownAgentRoleDirs(cwd)) {
-    parts.push(`${dir}\u0000${statSignature(dir)}`);
+  for (const source of markdownAgentRoleDirs(cwd)) {
+    const directory = validateTrustedMarkdownDirectory(source, source.dir);
+    parts.push(
+      `${source.dir}\u0000${directory === null ? "missing-or-untrusted" : trustedDirectorySignature(directory)}`,
+    );
     // A directory's mtime does not change when a contained file is edited
-    // in place, so include each markdown file's own mtime/size too.
-    for (const filePath of collectMarkdownFiles(dir)) {
-      parts.push(`${filePath}\u0000${statSignature(filePath)}`);
+    // in place, so include each trusted markdown file's identity and metadata.
+    for (const filePath of collectMarkdownFiles(source)) {
+      const file = validateTrustedMarkdownRoleFile(source, filePath);
+      if (file !== null) {
+        parts.push(
+          `${filePath}\u0000${stableEntrySignature(file.fileState)}`,
+        );
+      }
     }
   }
   return parts.join("\n");
 }
 
-function statSignature(path: string): string {
-  try {
-    const stats = statSync(path);
-    return `${stats.mtimeMs}:${stats.size}`;
-  } catch {
-    return "missing";
-  }
-}
-
 export function resolveAgentRole(
+  workspace: AgentRoleWorkspace,
   name: string | undefined,
-  cwd?: string,
 ): AgentRole {
   if (!name) return DEFAULT_ROLE;
-  return getAgentRole(name, cwd) ?? DEFAULT_ROLE;
+  return getAgentRole(workspace, name) ?? DEFAULT_ROLE;
 }
 
 /**
@@ -501,11 +571,11 @@ export function resolveAgentRole(
  * back to the default role for convenience.
  */
 export function tryResolveRoleConfig(
+  workspace: AgentRoleWorkspace,
   name: string | undefined,
-  cwd?: string,
 ): AgentRoleConfig | undefined {
   if (!name) return undefined;
-  return getAgentRole(name, cwd)?.config;
+  return getAgentRole(workspace, name)?.config;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -680,11 +750,12 @@ export function loadRoleLayerToml(role: AgentRole): Record<string, unknown> {
  */
 export function buildConfigLayerStack<Base extends RoleShapedConfig>(opts: {
   readonly base: Base;
+  readonly workspace: AgentRoleWorkspace;
   readonly roleName?: string;
   readonly userLayer?: OptionalRoleShapedConfig;
 }): Base {
-  const { base, roleName, userLayer = {} } = opts;
-  const role = roleName ? getAgentRole(roleName) : undefined;
+  const { base, workspace, roleName, userLayer = {} } = opts;
+  const role = roleName ? getAgentRole(workspace, roleName) : undefined;
   return applyRoleToConfigInner(base, role ? loadRoleLayerToml(role) : {}, userLayer);
 }
 
@@ -841,17 +912,56 @@ type MarkdownAgentRoleFile = {
   readonly content: string;
 };
 
+interface MarkdownAgentRoleDirectory {
+  readonly dir: string;
+  readonly trustAnchor: string;
+}
+
+interface StableEntryState {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly nlink: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+}
+
+interface TrustedDirectoryComponent {
+  readonly path: string;
+  readonly canonicalPath: string;
+  readonly state: StableEntryState;
+}
+
+interface TrustedDirectorySnapshot {
+  readonly components: ReadonlyArray<TrustedDirectoryComponent>;
+  readonly canonicalAnchor: string;
+  readonly canonicalTier: string;
+  readonly canonicalDirectory: string;
+}
+
+interface TrustedMarkdownRoleFileSnapshot {
+  readonly directory: TrustedDirectorySnapshot;
+  readonly canonicalFile: string;
+  readonly fileState: StableEntryState;
+}
+
+interface OpenedMarkdownRoleFile {
+  readonly raw: string;
+  readonly identity: string;
+}
+
 function readMarkdownAgentRoleFiles(cwd: string): MarkdownAgentRoleFile[] {
   const out: MarkdownAgentRoleFile[] = [];
   const seenFiles = new Set<string>();
-  for (const dir of markdownAgentRoleDirs(cwd)) {
-    for (const filePath of collectMarkdownFiles(dir)) {
-      const identity = fileIdentity(filePath) ?? filePath;
-      if (seenFiles.has(identity)) continue;
-      seenFiles.add(identity);
+  for (const source of markdownAgentRoleDirs(cwd)) {
+    for (const filePath of collectMarkdownFiles(source)) {
       try {
+        const opened = readTrustedMarkdownRoleFile(source, filePath);
+        if (opened === null || seenFiles.has(opened.identity)) continue;
+        seenFiles.add(opened.identity);
         const { frontmatter, content } = parseMarkdownAgentRole(
-          normalizeExternalText(readFileSync(filePath, "utf8")),
+          normalizeExternalText(opened.raw),
         );
         out.push({ filePath, frontmatter, content });
       } catch {
@@ -862,16 +972,21 @@ function readMarkdownAgentRoleFiles(cwd: string): MarkdownAgentRoleFile[] {
   return out;
 }
 
-function markdownAgentRoleDirs(cwd: string): string[] {
-  const dirs: string[] = [];
-  const userRoot = process.env.AGENC_CONFIG_DIR ?? join(homedir(), ".agenc");
-  dirs.push(join(userRoot, "agents"));
+function markdownAgentRoleDirs(cwd: string): MarkdownAgentRoleDirectory[] {
+  const dirs: MarkdownAgentRoleDirectory[] = [];
+  const userRoot = resolve(
+    process.env.AGENC_CONFIG_DIR ?? join(homedir(), ".agenc"),
+  );
+  dirs.push({ dir: join(userRoot, "agents"), trustAnchor: userRoot });
 
-  const projectDirs: string[] = [];
+  const projectDirs: MarkdownAgentRoleDirectory[] = [];
   let current = resolve(cwd);
   const home = resolve(homedir());
   while (true) {
-    projectDirs.push(join(current, ".agenc", "agents"));
+    projectDirs.push({
+      dir: join(current, ".agenc", "agents"),
+      trustAnchor: current,
+    });
     if (current === home || current === dirname(current)) break;
     if (existsSync(join(current, ".git"))) break;
     current = dirname(current);
@@ -879,27 +994,27 @@ function markdownAgentRoleDirs(cwd: string): string[] {
   dirs.push(...projectDirs.reverse());
 
   const managed = process.env.AGENC_MANAGED_AGENTS_DIR;
-  if (managed && managed.trim().length > 0) dirs.push(managed);
+  if (managed && managed.trim().length > 0) {
+    const managedDir = resolve(managed);
+    dirs.push({ dir: managedDir, trustAnchor: dirname(managedDir) });
+  }
 
   return dirs;
 }
 
 function collectMarkdownFiles(
-  dir: string,
+  source: MarkdownAgentRoleDirectory,
+  dir: string = source.dir,
   visitedDirs = new Set<string>(),
 ): string[] {
-  let dirStats: ReturnType<typeof statSync>;
-  try {
-    dirStats = statSync(dir, { bigint: true });
-  } catch {
-    return [];
-  }
-  if (!dirStats.isDirectory()) return [];
-
+  const before = validateTrustedMarkdownDirectory(source, dir);
+  if (before === null) return [];
+  const dirState = before.components.at(-1)?.state;
+  if (dirState === undefined) return [];
   const dirKey =
-    dirStats.dev === 0n && dirStats.ino === 0n
-      ? realpathSync(dir)
-      : `${dirStats.dev}:${dirStats.ino}`;
+    dirState.dev === 0n && dirState.ino === 0n
+      ? before.canonicalDirectory
+      : `${dirState.dev}:${dirState.ino}`;
   if (visitedDirs.has(dirKey)) return [];
   visitedDirs.add(dirKey);
 
@@ -912,35 +1027,288 @@ function collectMarkdownFiles(
 
   const files: string[] = [];
   for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
     const fullPath = join(dir, entry.name);
     try {
-      const stats = entry.isSymbolicLink()
-        ? statSync(fullPath)
-        : lstatSync(fullPath);
+      const stats = lstatSync(fullPath, { bigint: true });
+      if (stats.isSymbolicLink()) continue;
       if (stats.isDirectory()) {
-        files.push(...collectMarkdownFiles(fullPath, visitedDirs));
-      } else if (stats.isFile() && entry.name.endsWith(".md")) {
+        files.push(...collectMarkdownFiles(source, fullPath, visitedDirs));
+      } else if (
+        stats.isFile() &&
+        entry.name.endsWith(".md") &&
+        validateTrustedMarkdownRoleFile(source, fullPath) !== null
+      ) {
         files.push(fullPath);
       }
     } catch {
       continue;
     }
   }
-  return files.sort();
+  const after = validateTrustedMarkdownDirectory(source, dir);
+  return after !== null && sameTrustedDirectoryIdentity(before, after)
+    ? files.sort()
+    : [];
 }
 
-function fileIdentity(filePath: string): string | null {
+function validateTrustedMarkdownDirectory(
+  source: MarkdownAgentRoleDirectory,
+  candidateDirectory: string,
+): TrustedDirectorySnapshot | null {
   try {
-    const stats = statSync(filePath, { bigint: true });
-    if (stats.dev === 0n && stats.ino === 0n) return null;
-    return `${stats.dev}:${stats.ino}`;
-  } catch {
-    try {
-      return realpathSync(filePath);
-    } catch {
+    const anchor = resolve(source.trustAnchor);
+    const tier = resolve(source.dir);
+    const candidate = resolve(candidateDirectory);
+    if (
+      !isSameOrChildPath(anchor, tier) ||
+      !isSameOrChildPath(tier, candidate)
+    ) {
       return null;
     }
+
+    const components: TrustedDirectoryComponent[] = [];
+    let componentPath = anchor;
+    const componentPaths = [anchor];
+    const child = relative(anchor, candidate);
+    if (child.length > 0) {
+      for (const component of child.split(sep)) {
+        componentPath = join(componentPath, component);
+        componentPaths.push(componentPath);
+      }
+    }
+
+    for (const path of componentPaths) {
+      const before = lstatSync(path, { bigint: true });
+      if (!before.isDirectory() || before.isSymbolicLink()) return null;
+      const canonicalPath = realpathSync(path);
+      const after = lstatSync(path, { bigint: true });
+      if (
+        !after.isDirectory() ||
+        after.isSymbolicLink() ||
+        !sameStableEntryState(stableEntryState(before), stableEntryState(after))
+      ) {
+        return null;
+      }
+      components.push({
+        path,
+        canonicalPath,
+        state: stableEntryState(after),
+      });
+    }
+
+    const anchorComponent = components[0];
+    const tierComponent = components.find((component) => component.path === tier);
+    const directoryComponent = components.at(-1);
+    if (
+      anchorComponent === undefined ||
+      tierComponent === undefined ||
+      directoryComponent === undefined ||
+      !isSameOrChildPath(
+        anchorComponent.canonicalPath,
+        tierComponent.canonicalPath,
+      ) ||
+      !isSameOrChildPath(
+        tierComponent.canonicalPath,
+        directoryComponent.canonicalPath,
+      )
+    ) {
+      return null;
+    }
+
+    return {
+      components,
+      canonicalAnchor: anchorComponent.canonicalPath,
+      canonicalTier: tierComponent.canonicalPath,
+      canonicalDirectory: directoryComponent.canonicalPath,
+    };
+  } catch {
+    return null;
   }
+}
+
+function validateTrustedMarkdownRoleFile(
+  source: MarkdownAgentRoleDirectory,
+  filePath: string,
+): TrustedMarkdownRoleFileSnapshot | null {
+  try {
+    const lexicalFile = resolve(filePath);
+    const lexicalTier = resolve(source.dir);
+    if (
+      lexicalFile === lexicalTier ||
+      !isSameOrChildPath(lexicalTier, lexicalFile)
+    ) {
+      return null;
+    }
+    const directory = validateTrustedMarkdownDirectory(
+      source,
+      dirname(lexicalFile),
+    );
+    if (directory === null) return null;
+
+    const before = lstatSync(lexicalFile, { bigint: true });
+    if (
+      !before.isFile() ||
+      before.isSymbolicLink() ||
+      before.nlink !== 1n
+    ) {
+      return null;
+    }
+    const canonicalFile = realpathSync(lexicalFile);
+    const after = lstatSync(lexicalFile, { bigint: true });
+    const beforeState = stableEntryState(before);
+    const afterState = stableEntryState(after);
+    if (
+      !after.isFile() ||
+      after.isSymbolicLink() ||
+      after.nlink !== 1n ||
+      !sameStableEntryState(beforeState, afterState) ||
+      canonicalFile === directory.canonicalDirectory ||
+      !isSameOrChildPath(directory.canonicalDirectory, canonicalFile) ||
+      !isSameOrChildPath(directory.canonicalTier, canonicalFile)
+    ) {
+      return null;
+    }
+    return { directory, canonicalFile, fileState: afterState };
+  } catch {
+    return null;
+  }
+}
+
+function readTrustedMarkdownRoleFile(
+  source: MarkdownAgentRoleDirectory,
+  filePath: string,
+): OpenedMarkdownRoleFile | null {
+  let fd: number | undefined;
+  try {
+    const before = validateTrustedMarkdownRoleFile(source, filePath);
+    if (before === null) return null;
+    markdownAgentRoleReadHookForTesting?.(filePath);
+
+    fd = openSync(
+      filePath,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
+    const opened = fstatSync(fd, { bigint: true });
+    const openedState = stableEntryState(opened);
+    if (
+      !opened.isFile() ||
+      opened.nlink !== 1n ||
+      !sameStableEntryState(before.fileState, openedState)
+    ) {
+      return null;
+    }
+
+    // The descriptor, not the pathname, is the single source of role bytes.
+    const raw = readFileSync(fd, "utf8");
+    const afterRead = fstatSync(fd, { bigint: true });
+    if (
+      !afterRead.isFile() ||
+      afterRead.nlink !== 1n ||
+      !sameStableEntryState(openedState, stableEntryState(afterRead))
+    ) {
+      return null;
+    }
+
+    const after = validateTrustedMarkdownRoleFile(source, filePath);
+    if (
+      after === null ||
+      after.canonicalFile !== before.canonicalFile ||
+      !sameStableEntryState(after.fileState, before.fileState) ||
+      !sameTrustedDirectoryIdentity(after.directory, before.directory)
+    ) {
+      return null;
+    }
+    return {
+      raw,
+      identity:
+        openedState.dev === 0n && openedState.ino === 0n
+          ? after.canonicalFile
+          : `${openedState.dev}:${openedState.ino}`,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function stableEntryState(stats: BigIntStats): StableEntryState {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    nlink: stats.nlink,
+    size: stats.size,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+  };
+}
+
+function sameStableEntryState(
+  left: StableEntryState,
+  right: StableEntryState,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function sameTrustedDirectoryIdentity(
+  left: TrustedDirectorySnapshot,
+  right: TrustedDirectorySnapshot,
+): boolean {
+  return (
+    left.canonicalAnchor === right.canonicalAnchor &&
+    left.canonicalTier === right.canonicalTier &&
+    left.canonicalDirectory === right.canonicalDirectory &&
+    left.components.length === right.components.length &&
+    left.components.every((component, index) => {
+      const other = right.components[index];
+      return (
+        other !== undefined &&
+        component.path === other.path &&
+        component.canonicalPath === other.canonicalPath &&
+        component.state.dev === other.state.dev &&
+        component.state.ino === other.state.ino &&
+        component.state.mode === other.state.mode
+      );
+    })
+  );
+}
+
+function trustedDirectorySignature(
+  directory: TrustedDirectorySnapshot,
+): string {
+  const state = directory.components.at(-1)?.state;
+  return state === undefined
+    ? "missing-or-untrusted"
+    : `${directory.canonicalDirectory}:${stableEntrySignature(state)}`;
+}
+
+function stableEntrySignature(state: StableEntryState): string {
+  return [
+    state.dev,
+    state.ino,
+    state.mode,
+    state.nlink,
+    state.size,
+    state.mtimeNs,
+    state.ctimeNs,
+  ].join(":");
+}
+
+function isSameOrChildPath(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate);
+  return (
+    child === "" ||
+    (child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child))
+  );
 }
 
 function parseMarkdownAgentRole(raw: string): {

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -541,14 +541,24 @@ interface AgentRunContext {
       readonly apiKey: string;
     };
     readonly querySource?: string;
-    readonly agentDefinitions: { readonly activeAgents: readonly unknown[] };
+    readonly agentDefinitions: {
+      readonly agentRoleWorkspaceId?: string;
+      readonly activeAgents: readonly unknown[];
+      readonly allAgents?: readonly unknown[];
+      readonly allowedAgentTypes?: readonly unknown[];
+    };
     readonly isNonInteractiveSession: boolean;
     readonly cwd?: string;
     readonly verbose: boolean;
   };
   readonly getAppState: () => {
     readonly toolPermissionContext: unknown;
-    readonly agentDefinitions: { readonly activeAgents: readonly unknown[] };
+    readonly agentDefinitions: {
+      readonly agentRoleWorkspaceId?: string;
+      readonly activeAgents: readonly unknown[];
+      readonly allAgents?: readonly unknown[];
+      readonly allowedAgentTypes?: readonly unknown[];
+    };
     readonly tasks: Record<string, unknown>;
   };
   readonly readFileState: Map<string, unknown>;
@@ -591,7 +601,12 @@ type SessionSurface = {
   readonly readFileState?: Map<string, unknown>;
   readonly loadedNestedMemoryPaths?: Set<string>;
   readonly mcpClients?: readonly unknown[];
-  readonly agentDefinitions?: { readonly activeAgents?: readonly unknown[] };
+  readonly agentDefinitions?: {
+    readonly agentRoleWorkspaceId?: string;
+    readonly activeAgents?: readonly unknown[];
+    readonly allAgents?: readonly unknown[];
+    readonly allowedAgentTypes?: readonly unknown[];
+  };
   readonly tasks?: Record<string, unknown>;
   readonly queryTracking?: {
     readonly chainId?: string;
@@ -617,9 +632,22 @@ function buildAgentRunContext(
   const providerOverride = buildAgentProviderOverride(session, model.model);
   const surface = readAgentSessionSurface(session);
   const agentDefinitions = {
+    ...(firstNonEmpty(surface.agentDefinitions?.agentRoleWorkspaceId) !== undefined
+      ? {
+          agentRoleWorkspaceId: firstNonEmpty(
+            surface.agentDefinitions?.agentRoleWorkspaceId,
+          )!,
+        }
+      : {}),
     activeAgents: Array.isArray(surface.agentDefinitions?.activeAgents)
       ? [...surface.agentDefinitions.activeAgents]
       : [],
+    ...(Array.isArray(surface.agentDefinitions?.allAgents)
+      ? { allAgents: [...surface.agentDefinitions.allAgents] }
+      : {}),
+    ...(Array.isArray(surface.agentDefinitions?.allowedAgentTypes)
+      ? { allowedAgentTypes: [...surface.agentDefinitions.allowedAgentTypes] }
+      : {}),
   };
   const cwd = ctx.cwd;
   return {
@@ -760,7 +788,12 @@ function readAgentSessionSurface(session: Session): SessionSurface {
     readFileState: read<Map<string, unknown>>("readFileState"),
     loadedNestedMemoryPaths: read<Set<string>>("loadedNestedMemoryPaths"),
     mcpClients: read<readonly unknown[]>("mcpClients"),
-    agentDefinitions: read<{ readonly activeAgents?: readonly unknown[] }>(
+    agentDefinitions: read<{
+      readonly agentRoleWorkspaceId?: string;
+      readonly activeAgents?: readonly unknown[];
+      readonly allAgents?: readonly unknown[];
+      readonly allowedAgentTypes?: readonly unknown[];
+    }>(
       "agentDefinitions",
     ),
     tasks: read<Record<string, unknown>>("tasks"),
@@ -1556,6 +1589,12 @@ function cloneSessionConfiguration(
         agentPath: live.agentPath,
         agentNickname: live.nickname,
         agentRole: live.role.name,
+        ...(live.metadata.agentRoleWorkspaceId !== undefined
+          ? { agentRoleWorkspaceId: live.metadata.agentRoleWorkspaceId }
+          : {}),
+        ...(live.metadata.agentRoleFingerprint !== undefined
+          ? { agentRoleFingerprint: live.metadata.agentRoleFingerprint }
+          : {}),
       },
     },
     ...(base.originalConfigDoNotUse
@@ -1699,6 +1738,25 @@ function buildChildSession(
 
   const childSession = new ChildSession({
     conversationId: params.live.agentId,
+    roleWorkspace: params.parent.roleWorkspace,
+    // A worktree changes execution cwd, never the role trust domain or its
+    // canonical executable catalog. Clone the complete parent envelope so a
+    // nested Agent call cannot silently fall back to built-ins/config roles.
+    agentDefinitions: {
+      agentRoleWorkspaceId:
+        params.parent.agentDefinitions.agentRoleWorkspaceId,
+      activeAgents: [...params.parent.agentDefinitions.activeAgents],
+      ...(params.parent.agentDefinitions.allAgents !== undefined
+        ? { allAgents: [...params.parent.agentDefinitions.allAgents] }
+        : {}),
+      ...(params.parent.agentDefinitions.allowedAgentTypes !== undefined
+        ? {
+            allowedAgentTypes: [
+              ...params.parent.agentDefinitions.allowedAgentTypes,
+            ],
+          }
+        : {}),
+    },
     initialState: {
       sessionConfiguration,
       history: [],

--- a/runtime/src/agents/v2/common.ts
+++ b/runtime/src/agents/v2/common.ts
@@ -13,6 +13,7 @@ import {
 } from "../status.js";
 import { SESSION_ID_ARG } from "../_deps/filesystem-args.js";
 import type { Session } from "../../session/session.js";
+import type { AgentRoleWorkspace } from "../role.js";
 import type { Tool, ToolResult } from "../../tools/types.js";
 import { safeStringify } from "../../tools/types.js";
 
@@ -22,6 +23,7 @@ export const MAX_WAIT_TIMEOUT_MS = 3_600_000;
 
 export interface MultiAgentV2Options {
   readonly getSession: () => Session | null;
+  readonly workspace: AgentRoleWorkspace;
   readonly ensureAgentControl: (session: Session) => {
     readonly control: AgentControl;
     readonly registry: AgentRegistry;

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -9,6 +9,7 @@ import {
   depthOfAgentPath,
 } from "../registry.js";
 import {
+  assertAgentRoleWorkspaceMatches,
   formatRoleList,
   listAgentRoles,
   requireAgentRole,
@@ -325,8 +326,9 @@ function roleServiceTier(role: AgentRole | undefined): string | undefined {
 }
 
 export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
+  const workspaceRoles = listAgentRoles(opts.workspace);
   const roleNames = [...new Set(
-    listAgentRoles().flatMap((role) => [
+    workspaceRoles.flatMap((role) => [
       formatAgentRolePublicName(role.name) ?? role.name,
       role.name,
     ]),
@@ -345,7 +347,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         enum: roleNames,
         description:
           [
-            formatRoleList(listAgentRoles()),
+            formatRoleList(workspaceRoles),
             "Use only a listed role name. For implementation, edits, or tests use `runner`. For codebase reconnaissance use `scanner`. Omit this field for a general `netrunner` fork. Do not invent role names such as `code-implementer` or `reviewer` unless they are listed here.",
           ].join("\n\n"),
       },
@@ -419,7 +421,26 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         true,
       );
     }
+    try {
+      assertAgentRoleWorkspaceMatches(
+        session.roleWorkspace,
+        opts.workspace.id,
+      );
+    } catch (error) {
+      return json(
+        { error: error instanceof Error ? error.message : String(error) },
+        true,
+      );
+    }
     const { control, registry } = opts.ensureAgentControl(session);
+    try {
+      control.assertRoleWorkspace(opts.workspace);
+    } catch (error) {
+      return json(
+        { error: error instanceof Error ? error.message : String(error) },
+        true,
+      );
+    }
     const current = currentAgentContext(session, args, opts);
     const rawRole = stringValue(args.agent_type);
     const role =
@@ -508,7 +529,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
     let resolvedRole: AgentRole | undefined;
     try {
       if (role !== undefined) {
-        resolvedRole = requireAgentRole(role);
+        resolvedRole = requireAgentRole(control.roleWorkspace, role);
       }
     } catch (error) {
       return failSpawn(error instanceof Error ? error.message : String(error));

--- a/runtime/src/app-server-client/index.ts
+++ b/runtime/src/app-server-client/index.ts
@@ -13,6 +13,7 @@ import {
   createConnectedAgenCJsonLineDaemonTuiClient,
   defaultEnsureDaemonReady,
   resolveAgenCAgentAttachCwd,
+  resolveAgenCAgentAttachRoleWorkspace,
   type AgenCJsonLineDaemonTuiClient,
 } from "../app-server/agent-cli.js";
 import type {
@@ -32,6 +33,12 @@ import {
 } from "../session/mcp-startup.js";
 import { createLocalSkillsServices } from "../skills/local-loader.js";
 import { projectMcpManagerToConnections } from "../mcp-client/tui-connections.js";
+import {
+  createAgentRoleWorkspace,
+  normalizeAgentRoleWorkspace,
+  type AgentRoleWorkspace,
+} from "../agents/role-workspace.js";
+import { loadFreshAgentDefinitions } from "../tools/AgentTool/loadAgentsDir.js";
 import type {
   AgenCBridgeSession,
   ConfigStoreLike,
@@ -43,6 +50,7 @@ export {
   createConnectedAgenCJsonLineDaemonTuiClient,
   defaultEnsureDaemonReady,
   resolveAgenCAgentAttachCwd,
+  resolveAgenCAgentAttachRoleWorkspace,
   type AgenCJsonLineDaemonTuiClient,
 };
 
@@ -158,6 +166,8 @@ export interface AgenCDaemonOnlyTuiContextOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly cwd: string;
   readonly conversationId: string;
+  /** Immutable daemon-owned role authority, separate from execution cwd. */
+  readonly roleWorkspace?: Pick<AgentRoleWorkspace, "id" | "cwd">;
   readonly model?: string;
   readonly provider?: string;
   readonly profile?: string;
@@ -186,6 +196,9 @@ export async function createAgenCDaemonOnlyTuiContext(
   options: AgenCDaemonOnlyTuiContextOptions,
 ): Promise<AgenCDaemonOnlyTuiContext> {
   const env = options.env ?? process.env;
+  const roleWorkspace = options.roleWorkspace
+    ? normalizeAgentRoleWorkspace(options.roleWorkspace)
+    : createAgentRoleWorkspace(options.cwd);
   const agencHome = resolveAgencHome(env);
   const configStore = new ConfigStore({
     home: agencHome,
@@ -218,7 +231,7 @@ export async function createAgenCDaemonOnlyTuiContext(
   };
   const skillsServices = createLocalSkillsServices({
     agencHome,
-    workspaceRoot: options.cwd,
+    workspaceRoot: roleWorkspace.cwd,
     config: effectiveConfig,
     env: {
       HOME: env.HOME,
@@ -230,12 +243,13 @@ export async function createAgenCDaemonOnlyTuiContext(
     effectiveConfig,
     env,
     {
-      cwd: options.cwd,
+      cwd: roleWorkspace.cwd,
       includeProjectMcpServers: options.permissionMode === "bypassPermissions",
     },
   );
   await mcpRuntimeManager.start();
   const mcpService = createSessionMcpService(mcpRuntimeManager, { env });
+  const agentDefinitions = await loadFreshAgentDefinitions(roleWorkspace.cwd);
   const abortController = new AbortController();
   let nextEventId = 0;
   const sessionConfiguration = {
@@ -245,6 +259,8 @@ export async function createAgenCDaemonOnlyTuiContext(
   };
   const session: AgenCBridgeSession = {
     conversationId: options.conversationId,
+    roleWorkspace,
+    agentDefinitions,
     cwd: options.cwd,
     home: agencHome,
     sessionConfiguration,

--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -47,6 +47,12 @@ import {
   type RequestId,
 } from "./protocol/index.js";
 import { isRecord } from "../utils/record.js";
+import {
+  AgentRoleWorkspaceError,
+  createAgentRoleWorkspace,
+  normalizeAgentRoleWorkspace,
+  type AgentRoleWorkspace,
+} from "../agents/role-workspace.js";
 
 export type AgenCAgentCliCommand =
   | {
@@ -956,6 +962,58 @@ export function resolveAgenCAgentAttachCwd(
 ): string {
   const cwd = resolveAgenCAgentAttachSession(result)?.cwd?.trim();
   return cwd && cwd.length > 0 ? cwd : fallbackCwd;
+}
+
+/** Resolve persisted role authority independently from the execution cwd. */
+export function resolveAgenCAgentAttachRoleWorkspace(
+  result: AgentAttachResult,
+  fallbackCwd: string,
+): AgentRoleWorkspace {
+  const session = resolveAgenCAgentAttachSession(result);
+  if (session?.roleWorkspace !== undefined) {
+    return normalizeAgentRoleWorkspace(session.roleWorkspace);
+  }
+
+  const metadata = session?.metadata;
+  const hasMetadataId =
+    metadata !== undefined &&
+    Object.prototype.hasOwnProperty.call(metadata, "agentRoleWorkspaceId");
+  const hasMetadataCwd =
+    metadata !== undefined &&
+    Object.prototype.hasOwnProperty.call(metadata, "agentRoleWorkspaceCwd");
+  if (hasMetadataId || hasMetadataCwd) {
+    const metadataId = metadata?.agentRoleWorkspaceId;
+    if (typeof metadataId !== "string" || metadataId.length === 0) {
+      throw invalidAgenCAgentAttachRoleWorkspace(
+        "agentRoleWorkspaceId must be a non-empty absolute path",
+      );
+    }
+
+    let roleWorkspaceCwd = metadataId;
+    if (hasMetadataCwd) {
+      const metadataCwd = metadata?.agentRoleWorkspaceCwd;
+      if (typeof metadataCwd !== "string" || metadataCwd.length === 0) {
+        throw invalidAgenCAgentAttachRoleWorkspace(
+          "agentRoleWorkspaceCwd must be a non-empty absolute path when present",
+        );
+      }
+      roleWorkspaceCwd = metadataCwd;
+    }
+
+    return normalizeAgentRoleWorkspace({
+      id: metadataId,
+      cwd: roleWorkspaceCwd,
+    });
+  }
+  return createAgentRoleWorkspace(session?.cwd?.trim() || fallbackCwd);
+}
+
+function invalidAgenCAgentAttachRoleWorkspace(
+  detail: string,
+): AgentRoleWorkspaceError {
+  return new AgentRoleWorkspaceError(
+    `Invalid agent role workspace provenance: ${detail}`,
+  );
 }
 
 export function formatAgenCAgentList(result: AgentListResult): string {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -20,6 +20,7 @@ import { runTurn } from "../session/run-turn.js";
 import {
   ROOT_AGENT_PATH,
   joinAgentPath,
+  normalizeAgentMetadata,
   normalizeAgentNameForPath,
   type AgentMetadata,
   type AgentPath,
@@ -3549,17 +3550,23 @@ function restoredAgentMetadata(
     metadataStringField(metadata, "agentPath") ??
     metadataStringField(metadata, "agent_path") ??
     joinAgentPath(ROOT_AGENT_PATH, normalizeAgentNameForPath(params.agentId));
-  return {
+  return normalizeAgentMetadata({
     agentId: params.agentId,
     agentPath,
-    ...(metadataStringField(metadata, "agentNickname") !== undefined
-      ? { agentNickname: metadataStringField(metadata, "agentNickname") }
+    ...(metadata?.agentNickname !== undefined
+      ? { agentNickname: metadata.agentNickname }
       : {}),
-    ...(metadataStringField(metadata, "agentRole") !== undefined
-      ? { agentRole: metadataStringField(metadata, "agentRole") }
+    ...(metadata?.agentRole !== undefined
+      ? { agentRole: metadata.agentRole }
       : {}),
-    depth: metadataNumberField(metadata, "depth") ?? 1,
-  };
+    ...(metadata?.agentRoleWorkspaceId !== undefined
+      ? { agentRoleWorkspaceId: metadata.agentRoleWorkspaceId }
+      : {}),
+    ...(metadata?.agentRoleFingerprint !== undefined
+      ? { agentRoleFingerprint: metadata.agentRoleFingerprint }
+      : {}),
+    depth: metadata?.depth ?? 1,
+  });
 }
 
 function metadataStringField(
@@ -3569,16 +3576,6 @@ function metadataStringField(
   const field = value?.[key];
   return typeof field === "string" && field.trim().length > 0
     ? field.trim()
-    : undefined;
-}
-
-function metadataNumberField(
-  value: JsonObject | undefined,
-  key: string,
-): number | undefined {
-  const field = value?.[key];
-  return typeof field === "number" && Number.isFinite(field)
-    ? field
     : undefined;
 }
 

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -1484,6 +1484,11 @@ export interface SessionSummary extends JsonObject {
   readonly status: SessionStatus;
   readonly createdAt: string;
   readonly cwd?: string;
+  /** Immutable role-discovery authority; execution cwd may be a worktree. */
+  readonly roleWorkspace?: {
+    readonly id: string;
+    readonly cwd: string;
+  };
   readonly metadata?: JsonObject;
   readonly activeAttachmentIds?: readonly string[];
   readonly closedAt?: string;

--- a/runtime/src/app-server/session-lifecycle.ts
+++ b/runtime/src/app-server/session-lifecycle.ts
@@ -24,6 +24,7 @@ import type {
   ThreadStore,
 } from "../thread-store/store.js";
 import { agentIdFromThreadSource } from "../thread-store/thread-source.js";
+import { normalizeAgentRoleWorkspace } from "../agents/role-workspace.js";
 import type {
   JsonObject,
   JsonValue,
@@ -132,9 +133,10 @@ export class AgenCDaemonSessionManager {
   async createSession(
     params: SessionCreateParams,
   ): Promise<SessionCreateResult> {
-    const sessionId = this.#createSessionId();
-    const createdAt = this.#now();
-    const agentId = nonEmptyString(params.agentId) ?? this.#defaultAgentId;
+    // Validate persisted trust-domain provenance before allocating or storing
+    // any session state. A malformed, present provenance field must never be
+    // treated as legacy absence and rebound to the execution cwd on attach.
+    sessionRoleWorkspaceFromMetadata(params.metadata);
     // DAE-02: cwd is required identity for new sessions (absolute workspace).
     let cwd: string;
     try {
@@ -145,6 +147,9 @@ export class AgenCDaemonSessionManager {
       }
       throw error;
     }
+    const sessionId = this.#createSessionId();
+    const createdAt = this.#now();
+    const agentId = nonEmptyString(params.agentId) ?? this.#defaultAgentId;
     const session: MutableSession = {
       sessionId,
       agentId,
@@ -182,6 +187,7 @@ export class AgenCDaemonSessionManager {
         "AgenC daemon session restore requires sessionId and agentId",
       );
     }
+    sessionRoleWorkspaceFromMetadata(record.metadata);
 
     const session: MutableSession = {
       sessionId,
@@ -429,18 +435,73 @@ export class AgenCDaemonSessionManager {
 }
 
 function toSessionSummary(session: MutableSession): SessionSummary {
+  const roleWorkspace = sessionRoleWorkspaceFromMetadata(session.metadata);
   return {
     sessionId: session.sessionId,
     agentId: session.agentId,
     status: session.status,
     createdAt: session.createdAt,
     ...(session.cwd !== undefined ? { cwd: session.cwd } : {}),
+    ...(roleWorkspace !== undefined ? { roleWorkspace } : {}),
     ...(session.metadata !== undefined ? { metadata: session.metadata } : {}),
     ...(session.attachments.size > 0
       ? { activeAttachmentIds: activeAttachmentIds(session) }
       : {}),
     ...(session.closedAt !== undefined ? { closedAt: session.closedAt } : {}),
   };
+}
+
+function sessionRoleWorkspaceFromMetadata(
+  metadata: JsonObject | undefined,
+): { readonly id: string; readonly cwd: string } | undefined {
+  if (metadata === undefined) return undefined;
+  const hasId = Object.prototype.hasOwnProperty.call(
+    metadata,
+    "agentRoleWorkspaceId",
+  );
+  const hasCwd = Object.prototype.hasOwnProperty.call(
+    metadata,
+    "agentRoleWorkspaceCwd",
+  );
+  if (!hasId && !hasCwd) return undefined;
+
+  const rawId = metadata.agentRoleWorkspaceId;
+  const id = typeof rawId === "string" ? nonEmptyString(rawId) : undefined;
+  if (id === undefined) {
+    throw invalidRoleWorkspaceProvenance(
+      "agentRoleWorkspaceId must be a non-empty absolute path",
+    );
+  }
+
+  const rawCwd = metadata.agentRoleWorkspaceCwd;
+  const cwd = hasCwd
+    ? typeof rawCwd === "string"
+      ? nonEmptyString(rawCwd)
+      : undefined
+    : id;
+  if (cwd === undefined) {
+    throw invalidRoleWorkspaceProvenance(
+      "agentRoleWorkspaceCwd must be a non-empty absolute path when present",
+    );
+  }
+
+  try {
+    const normalized = normalizeAgentRoleWorkspace({ id, cwd });
+    return { id: normalized.id, cwd: normalized.cwd };
+  } catch (error) {
+    throw invalidRoleWorkspaceProvenance(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function invalidRoleWorkspaceProvenance(
+  detail: string,
+): AgenCSessionLifecycleError {
+  return new AgenCSessionLifecycleError(
+    "INVALID_ARGUMENT",
+    `Invalid agent role workspace provenance: ${detail}`,
+  );
 }
 
 function storedThreadToMutableSession(
@@ -521,6 +582,7 @@ function storedThreadToSessionSummary(
   thread: StoredThread,
   defaultAgentId: string,
 ): SessionSummary {
+  const roleWorkspace = roleWorkspaceFromThreadSource(thread.source);
   const metadata: JsonObject = {
     source:
       thread.source === undefined ? undefined : threadSourceToJson(thread.source),
@@ -528,6 +590,12 @@ function storedThreadToSessionSummary(
     modelProvider: thread.modelProvider,
     rolloutPath: thread.rolloutPath,
     recovered: true,
+    ...(roleWorkspace !== undefined
+      ? {
+          agentRoleWorkspaceId: roleWorkspace.id,
+          agentRoleWorkspaceCwd: roleWorkspace.cwd,
+        }
+      : {}),
   };
   return {
     sessionId: thread.threadId,
@@ -537,6 +605,42 @@ function storedThreadToSessionSummary(
     ...(thread.cwd !== undefined ? { cwd: thread.cwd } : {}),
     metadata,
   };
+}
+
+function roleWorkspaceFromThreadSource(
+  source: ThreadSource | undefined,
+): { readonly id: string; readonly cwd: string } | undefined {
+  if (typeof source !== "object" || source === null || Array.isArray(source)) {
+    return undefined;
+  }
+  const sourceRecord = source as Record<string, unknown>;
+  const nested = sourceRecord.source;
+  const spawnSource =
+    sourceRecord.kind === "thread_spawn"
+      ? sourceRecord
+      : typeof nested === "object" &&
+          nested !== null &&
+          !Array.isArray(nested) &&
+          (nested as Record<string, unknown>).kind === "thread_spawn"
+        ? (nested as Record<string, unknown>)
+        : undefined;
+  if (spawnSource === undefined) return undefined;
+  const rawId = spawnSource.agentRoleWorkspaceId;
+  if (rawId === undefined) return undefined;
+  if (typeof rawId !== "string" || nonEmptyString(rawId) === undefined) {
+    throw new AgenCSessionLifecycleError(
+      "INVALID_ARGUMENT",
+      "Recovered agent role workspace provenance is malformed",
+    );
+  }
+  try {
+    return normalizeAgentRoleWorkspace({ id: rawId, cwd: rawId });
+  } catch (error) {
+    throw new AgenCSessionLifecycleError(
+      "INVALID_ARGUMENT",
+      `Recovered agent role workspace provenance is invalid: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 function threadSourceToJson(source: ThreadSource): JsonValue {

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -24,6 +24,7 @@
  */
 
 import { mkdirSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
 import { cwd as processCwd } from "node:process";
 import { VERSION } from "../index.js";
 import { applyBestEffortPreMainProcessHardening } from "../sandbox/hardening/index.js";
@@ -112,6 +113,7 @@ import {
   formatAgenCAgentCliHelpText,
   parseAgenCAgentCliArgs,
   resolveAgenCAgentAttachCwd,
+  resolveAgenCAgentAttachRoleWorkspace,
   runAgenCAgentCli,
 } from "../app-server/agent-cli.js";
 import {
@@ -1127,14 +1129,25 @@ export function resolveCliCwdForStartup(
   if (options.useEnvWorkspace !== false) {
     const workspace = resolveWorkspaceFromEnv(env);
     if (workspace !== undefined) {
-      return { ok: true, cwd: workspace };
+      if (isAbsolute(workspace)) {
+        return { ok: true, cwd: resolve(workspace) };
+      }
+      const baseCwd = readProcessCwdSafely(options.cwdFn);
+      if (baseCwd === null) {
+        return {
+          ok: false,
+          message:
+            "AGENC_WORKSPACE must be absolute when the current working directory is unavailable.",
+        };
+      }
+      return { ok: true, cwd: resolve(baseCwd, workspace) };
     }
   }
   const cwd = readProcessCwdSafely(options.cwdFn);
   if (cwd === null) {
     return { ok: false, message: formatUnavailableCliCwdMessage() };
   }
-  return { ok: true, cwd };
+  return { ok: true, cwd: resolve(cwd) };
 }
 
 export function isUnavailableCliCwdError(error: unknown): boolean {
@@ -3747,6 +3760,21 @@ export async function attachAgentTuiEntry(
     const runtimeSessionId =
       attachment.runtimeSessionId ?? attachment.agentId ?? sessionId;
     const bootstrapCwd = resolveAgenCAgentAttachCwd(attachment, targetCwd);
+    const roleWorkspace = resolveAgenCAgentAttachRoleWorkspace(
+      attachment,
+      targetCwd,
+    );
+    if (
+      roleWorkspace.cwd !== targetCwd &&
+      !(await requireProjectTrustForTui({
+        env,
+        argv: process.argv,
+        cwd: roleWorkspace.cwd,
+        useEnvWorkspace: false,
+      }))
+    ) {
+      return 1;
+    }
     const bootstrapEnv = envForAttachBootstrap(env, bootstrapCwd);
     const attachArgvForYolo = process.argv.slice(2);
     const isYoloAttach =
@@ -3764,6 +3792,7 @@ export async function attachAgentTuiEntry(
     } = await daemonCliDeps().createTuiContext({
       env: bootstrapEnv,
       cwd: bootstrapCwd,
+      roleWorkspace,
       conversationId: runtimeSessionId,
       ...(isYoloAttach
         ? { permissionMode: "bypassPermissions" as const }

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -66,7 +66,11 @@ import { AgentControl } from "../agents/control.js";
 import { ThreadManager } from "../agents/thread-manager.js";
 import { ConversationThreadManager } from "../conversation/thread-manager.js";
 import { AgentRegistry } from "../agents/registry.js";
-import { listAgentRoles } from "../agents/role.js";
+import {
+  createAgentRoleWorkspace,
+  listAgentRoles,
+} from "../agents/role.js";
+import { loadFreshAgentDefinitions } from "../tools/AgentTool/loadAgentsDir.js";
 import {
   type BuildToolRegistryOptions,
   type ToolRegistry,
@@ -700,7 +704,7 @@ function buildDeferredConfig(
     /** T-future: ghost-snapshot state machine (agenc runtime workspace restore). */
     ghostSnapshot: { enabled: false },
     /** T9: real `agentRoles` list from role layer (`agents/role.ts`). */
-    agentRoles: listAgentRoles().map((role) => ({
+    agentRoles: listAgentRoles(createAgentRoleWorkspace(cwd)).map((role) => ({
       name: role.name,
       description: role.config.description ?? "",
     })),
@@ -1376,6 +1380,10 @@ export async function bootstrapLocalRuntimeSession(
   };
 
   try {
+    const roleWorkspace = createAgentRoleWorkspace(workspaceRoot);
+    const agentDefinitions = await loadFreshAgentDefinitions(
+      roleWorkspace.cwd,
+    );
     // Construct the session through `bootstrapSession` so shell
     // discovery, SessionConfigured emit, startup prewarm, and
     // resume-history recording all flow through the shared entry
@@ -1389,6 +1397,8 @@ export async function bootstrapLocalRuntimeSession(
     // that work instead.
     const session = await bootstrapSession({
       conversationId,
+      roleWorkspace,
+      agentDefinitions,
       initialState,
       features: config.features,
       services: bootstrapServices.services,

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -76,7 +76,10 @@ import { CsvAgentJobsRepository } from "../state/csv-agent-jobs.js";
 import { openStateDatabases } from "../state/sqlite-driver.js";
 import { ensureAgentControl } from "./delegate-tool.js";
 import { createMultiAgentV2Tools } from "../agents/v2/index.js";
-import { loadMarkdownAgentRoles } from "../agents/role.js";
+import {
+  createAgentRoleWorkspace,
+  loadMarkdownAgentRoles,
+} from "../agents/role.js";
 import { createTaskTools } from "../tools/tasks/index.js";
 import {
   createStructuredOutputTool,
@@ -1459,7 +1462,8 @@ function getSessionOrError(opts: ModelFacingToolOptions): Session | ToolResult {
 }
 
 function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly Tool[] {
-  loadMarkdownAgentRoles(opts.workspaceRoot);
+  const roleWorkspace = createAgentRoleWorkspace(opts.workspaceRoot);
+  loadMarkdownAgentRoles(roleWorkspace);
 
   const emit = (session: Session, msg: Parameters<Session["emit"]>[0]["msg"]): void => {
     session.emit({
@@ -1470,6 +1474,7 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
 
   const multiAgentV2Tools = createMultiAgentV2Tools({
     getSession: opts.getSession,
+    workspace: roleWorkspace,
     ensureAgentControl,
   });
 

--- a/runtime/src/commands/agents-menu.tsx
+++ b/runtime/src/commands/agents-menu.tsx
@@ -7,10 +7,15 @@ import {
   type ResolvedAgent,
 } from "../tools/AgentTool/agentDisplay.js";
 import {
+  bindAgentDefinitionToWorkspace,
   getActiveAgentsFromList,
   type AgentDefinition,
   type SettingSource,
 } from "../tools/AgentTool/loadAgentsDir.js";
+import {
+  assertAgentRoleWorkspaceMatches,
+  type AgentRoleWorkspace,
+} from "../agents/role.js";
 import type { Tools } from "../tools/Tool.js";
 import { Box, useInput } from "../tui/ink.js";
 import { agentRolePresentation } from "../agents/role-presentation.js";
@@ -744,9 +749,11 @@ function AgentFormModal({
 function AgentsMenuModal({
   onDone,
   initialTools = [],
+  roleWorkspace,
 }: {
   readonly onDone: Done;
   readonly initialTools?: readonly unknown[];
+  readonly roleWorkspace: AgentRoleWorkspace;
 }): React.ReactNode {
   const agentDefinitions = useAppState((state: AppState) => state.agentDefinitions);
   const setAppState = useSetAppState();
@@ -843,8 +850,16 @@ function AgentsMenuModal({
     const parsedModel = modelValue(form.model);
 
     try {
+      assertAgentRoleWorkspaceMatches(
+        roleWorkspace,
+        agentDefinitions.agentRoleWorkspaceId,
+      );
       if (mode.name === "create") {
         await saveAgentToFile(
+          {
+            roleWorkspace,
+            catalogWorkspaceId: agentDefinitions.agentRoleWorkspaceId,
+          },
           form.source,
           trimmedName,
           trimmedDescription,
@@ -854,7 +869,7 @@ function AgentsMenuModal({
           undefined,
           parsedModel,
         );
-        const created: AgentDefinition = {
+        const created = bindAgentDefinitionToWorkspace({
           agentType: trimmedName,
           source: form.source,
           filename: trimmedName,
@@ -862,7 +877,7 @@ function AgentsMenuModal({
           tools: parsedTools,
           ...(parsedModel ? { model: parsedModel } : {}),
           getSystemPrompt: () => trimmedPrompt,
-        };
+        }, roleWorkspace);
         setAppState((state: unknown) => {
           const appState = state as AppState;
           const allAgents = [
@@ -888,6 +903,10 @@ function AgentsMenuModal({
         return;
       }
       await updateAgentFile(
+        {
+          roleWorkspace,
+          catalogWorkspaceId: agentDefinitions.agentRoleWorkspaceId,
+        },
         modeAgent,
         trimmedDescription,
         parsedTools,
@@ -897,13 +916,13 @@ function AgentsMenuModal({
         modeAgent.memory,
         modeAgent.effort as never,
       );
-      const updated: AgentDefinition = {
+      const updated = bindAgentDefinitionToWorkspace({
         ...modeAgent,
         whenToUse: trimmedDescription,
         tools: parsedTools,
         model: parsedModel,
         getSystemPrompt: () => trimmedPrompt,
-      };
+      }, roleWorkspace);
       setAppState((state: unknown) => {
         const appState = state as AppState;
         const allAgents = appState.agentDefinitions.allAgents.map(agent =>
@@ -930,6 +949,7 @@ function AgentsMenuModal({
     formMode,
     mode.name,
     modeAgent,
+    roleWorkspace,
     setAppState,
   ]);
 
@@ -939,7 +959,17 @@ function AgentsMenuModal({
       return;
     }
     try {
-      await deleteAgentFromFile(modeAgent);
+      assertAgentRoleWorkspaceMatches(
+        roleWorkspace,
+        agentDefinitions.agentRoleWorkspaceId,
+      );
+      await deleteAgentFromFile(
+        {
+          roleWorkspace,
+          catalogWorkspaceId: agentDefinitions.agentRoleWorkspaceId,
+        },
+        modeAgent,
+      );
       setAppState((state: unknown) => {
         const appState = state as AppState;
         const allAgents = appState.agentDefinitions.allAgents.filter(
@@ -959,7 +989,7 @@ function AgentsMenuModal({
     } catch (error) {
       setDeleteError(error instanceof Error ? error.message : String(error));
     }
-  }, [modeAgent, setAppState]);
+  }, [agentDefinitions.agentRoleWorkspaceId, modeAgent, roleWorkspace, setAppState]);
 
   useInput((input, key) => {
     if (key.ctrl && input === "c") {
@@ -1136,6 +1166,10 @@ function AgentsMenuModal({
 
 export function openAgentsMenu(ctx: SlashCommandContext): boolean {
   return openLocalJsxCommand(ctx, close => (
-    <AgentsMenuModal onDone={close} initialTools={ctx.appState?.tools ?? []} />
+    <AgentsMenuModal
+      onDone={close}
+      initialTools={ctx.appState?.tools ?? []}
+      roleWorkspace={ctx.session.roleWorkspace}
+    />
   ));
 }

--- a/runtime/src/commands/session-compact.ts
+++ b/runtime/src/commands/session-compact.ts
@@ -401,14 +401,20 @@ interface AgenCToolUseContext {
       readonly apiKey: string;
     };
     readonly querySource?: string;
-    readonly agentDefinitions: { readonly activeAgents: readonly unknown[] };
+    readonly agentDefinitions: {
+      readonly agentRoleWorkspaceId?: string;
+      readonly activeAgents: readonly unknown[];
+    };
     readonly isNonInteractiveSession: boolean;
     readonly cwd?: string;
     readonly verbose: boolean;
   };
   readonly getAppState: () => {
     readonly toolPermissionContext: unknown;
-    readonly agentDefinitions: { readonly activeAgents: readonly unknown[] };
+    readonly agentDefinitions: {
+      readonly agentRoleWorkspaceId?: string;
+      readonly activeAgents: readonly unknown[];
+    };
     readonly tasks: Record<string, unknown>;
   };
   readonly readFileState: Map<string, unknown>;
@@ -447,6 +453,13 @@ function buildAgenCToolUseContext(
   const providerOverride = buildProviderOverride(session, model.model);
   const surface = readSessionSurface(session);
   const agentDefinitions = {
+    ...(firstNonEmpty(surface.agentDefinitions?.agentRoleWorkspaceId) !== undefined
+      ? {
+          agentRoleWorkspaceId: firstNonEmpty(
+            surface.agentDefinitions?.agentRoleWorkspaceId,
+          )!,
+        }
+      : {}),
     activeAgents: Array.isArray(surface.agentDefinitions?.activeAgents)
       ? [...surface.agentDefinitions.activeAgents]
       : [],
@@ -561,7 +574,10 @@ type SessionSurface = {
   readonly readFileState?: Map<string, unknown>;
   readonly loadedNestedMemoryPaths?: Set<string>;
   readonly mcpClients?: readonly unknown[];
-  readonly agentDefinitions?: { readonly activeAgents?: readonly unknown[] };
+  readonly agentDefinitions?: {
+    readonly agentRoleWorkspaceId?: string;
+    readonly activeAgents?: readonly unknown[];
+  };
   readonly tasks?: Record<string, unknown>;
   readonly queryTracking?: {
     readonly chainId?: string;
@@ -589,8 +605,10 @@ function readSessionSurface(session: Session): SessionSurface {
     readFileState: read<Map<string, unknown>>("readFileState"),
     loadedNestedMemoryPaths: read<Set<string>>("loadedNestedMemoryPaths"),
     mcpClients: read<readonly unknown[]>("mcpClients"),
-    agentDefinitions:
-      read<{ readonly activeAgents?: readonly unknown[] }>("agentDefinitions"),
+    agentDefinitions: read<{
+      readonly agentRoleWorkspaceId?: string;
+      readonly activeAgents?: readonly unknown[];
+    }>("agentDefinitions"),
     tasks: read<Record<string, unknown>>("tasks"),
     queryTracking: read<{ readonly chainId?: string; readonly depth?: number }>(
       "queryTracking",

--- a/runtime/src/memory/privacy.ts
+++ b/runtime/src/memory/privacy.ts
@@ -21,7 +21,7 @@ import {
   isAutoMemoryEnabled,
 } from './paths.js'
 import * as teamMemPathsModule from '../memdir/teamMemPaths.js'
-import { isAgentMemoryPath } from '../tools/AgentTool/agentMemory.js'
+import { isAnyAgentMemoryPath } from '../tools/AgentTool/agentMemory.js'
 import { getAgenCConfigHomeDir } from '../utils/envUtils.js'
 import { capitalize } from '../utils/stringUtils.js'
 import {
@@ -137,7 +137,7 @@ export function memoryScopeForPath(filePath: string): MemoryScope | null {
 
 function isAgentMemFile(filePath: string): boolean {
   if (isAutoMemoryEnabled()) {
-    return isAgentMemoryPath(filePath)
+    return isAnyAgentMemoryPath(filePath)
   }
   return false
 }

--- a/runtime/src/plugins/registration/common.ts
+++ b/runtime/src/plugins/registration/common.ts
@@ -27,6 +27,8 @@ export interface PluginRuntimeLoadOptions {
   readonly config?: PluginLoaderOptions["config"];
   readonly extraPluginDirs?: readonly string[];
   readonly env?: NodeJS.ProcessEnv;
+  /** Bypass process-local discovery snapshots and re-read plugin sources. */
+  readonly fresh?: boolean;
 }
 
 export interface PluginRuntimeIdentityOptions {
@@ -64,7 +66,7 @@ export async function loadRuntimePlugins(
   options: PluginRuntimeLoadOptions = {},
 ): Promise<readonly LoadedPlugin[]> {
   const loaderOptions = toPluginLoaderOptions(options);
-  if (hasExplicitPluginDiscoveryInput(options)) {
+  if (options.fresh === true || hasExplicitPluginDiscoveryInput(options)) {
     const result = await loadPlugins(loaderOptions);
     return result.enabled;
   }

--- a/runtime/src/plugins/registration/load-plugin-agents.ts
+++ b/runtime/src/plugins/registration/load-plugin-agents.ts
@@ -45,7 +45,12 @@ const MEMORY_TOOLS = [
   FILE_READ_TOOL_NAME,
 ] as const;
 
-const activePluginAgentsByCwd = new Map<string, readonly PluginAgentDefinition[]>();
+interface ActivePluginAgentSnapshot {
+  readonly agents: readonly PluginAgentDefinition[];
+  readonly discovery: PluginRuntimeLoadOptions;
+}
+
+const activePluginAgentsByCwd = new Map<string, ActivePluginAgentSnapshot>();
 
 interface ActivePluginSnapshotOptions {
   readonly cwd: string;
@@ -54,23 +59,24 @@ interface ActivePluginSnapshotOptions {
 }
 
 function setActiveSnapshot(
-  options: ActivePluginSnapshotOptions,
+  options: ActivePluginSnapshotOptions & PluginRuntimeLoadOptions,
   agents: readonly PluginAgentDefinition[],
 ): void {
   const copy = [...agents];
-  activePluginAgentsByCwd.set(runtimeIdentityKey(options), copy);
-  activePluginAgentsByCwd.set(cwdOnlyRuntimeIdentityKey(options.cwd), copy);
+  const snapshot = { agents: copy, discovery: { ...options } };
+  activePluginAgentsByCwd.set(runtimeIdentityKey(options), snapshot);
+  activePluginAgentsByCwd.set(cwdOnlyRuntimeIdentityKey(options.cwd), snapshot);
 }
 
 function getActiveSnapshot(
   options: PluginAgentRegistrationOptions,
-): readonly PluginAgentDefinition[] | undefined {
+): ActivePluginAgentSnapshot | undefined {
   const exact = activePluginAgentsByCwd.get(runtimeIdentityKey(options));
   return exact ?? activePluginAgentsByCwd.get(cwdOnlyRuntimeIdentityKey(options.cwd));
 }
 
 export function setActivePluginAgentSnapshot(
-  options: ActivePluginSnapshotOptions,
+  options: ActivePluginSnapshotOptions & PluginRuntimeLoadOptions,
   agents: readonly PluginAgentDefinition[],
 ): void {
   setActiveSnapshot(options, agents);
@@ -148,6 +154,7 @@ function agentName(plugin: LoadedPlugin, file: ParsedMarkdownFile): string {
 function createPluginAgent(
   plugin: LoadedPlugin,
   file: ParsedMarkdownFile,
+  roleCwd: string,
 ): PluginAgentDefinition | null {
   const agentType = agentName(plugin, file);
   const whenToUse =
@@ -177,8 +184,9 @@ function createPluginAgent(
     plugin: plugin.name,
     getSystemPrompt: () => {
       if (!memory || !isAutoMemoryEnabled()) return systemPrompt;
-      return `${systemPrompt}\n\n${loadAgentMemoryPrompt(agentType, memory)}`;
+      return `${systemPrompt}\n\n${loadAgentMemoryPrompt(agentType, memory, roleCwd)}`;
     },
+    roleDefinitionPrompt: systemPrompt,
     ...(tools !== undefined ? { tools } : {}),
     ...(disallowedTools !== undefined ? { disallowedTools } : {}),
     ...(skills.length > 0 ? { skills } : {}),
@@ -199,37 +207,50 @@ async function loadAgentFile(
   path: string,
   baseDir: string,
   loadedPaths: Set<string>,
+  roleCwd: string,
 ): Promise<PluginAgentDefinition | null> {
   if (loadedPaths.has(path)) return null;
   loadedPaths.add(path);
   const file = await readMarkdownFile(path, baseDir);
-  return file ? createPluginAgent(plugin, file) : null;
+  return file ? createPluginAgent(plugin, file, roleCwd) : null;
 }
 
 async function loadAgentsFromPath(
   plugin: LoadedPlugin,
   path: string,
   loadedPaths: Set<string>,
+  roleCwd: string,
 ): Promise<readonly PluginAgentDefinition[]> {
   if (await pathIsDirectory(path)) {
     const files = await collectMarkdownFiles(path);
     const agents = await Promise.all(
-      files.map((filePath) => loadAgentFile(plugin, filePath, path, loadedPaths)),
+      files.map((filePath) =>
+        loadAgentFile(plugin, filePath, path, loadedPaths, roleCwd)
+      ),
     );
     return agents.filter((agent): agent is PluginAgentDefinition => agent !== null);
   }
   if (!path.toLowerCase().endsWith(".md")) return [];
-  const agent = await loadAgentFile(plugin, path, dirname(path), loadedPaths);
+  const agent = await loadAgentFile(
+    plugin,
+    path,
+    dirname(path),
+    loadedPaths,
+    roleCwd,
+  );
   return agent ? [agent] : [];
 }
 
 async function loadAgentsForPlugin(
   plugin: LoadedPlugin,
+  roleCwd: string,
 ): Promise<readonly PluginAgentDefinition[]> {
   const loadedPaths = new Set<string>();
   const paths = [...new Set(plugin.agentsPaths)];
   const groups = await Promise.all(
-    paths.map((path) => loadAgentsFromPath(plugin, path, loadedPaths)),
+    paths.map((path) =>
+      loadAgentsFromPath(plugin, path, loadedPaths, roleCwd)
+    ),
   );
   return groups.flat();
 }
@@ -243,12 +264,20 @@ async function resolvePlugins(
 export async function loadPluginAgents(
   options: PluginAgentRegistrationOptions = {},
 ): Promise<readonly PluginAgentDefinition[]> {
-  if (!hasExplicitPluginDiscoveryInput(options)) {
-    const active = getActiveSnapshot(options);
-    if (active !== undefined) return active;
+  const hasExplicitInput = hasExplicitPluginDiscoveryInput(options);
+  const active = !hasExplicitInput ? getActiveSnapshot(options) : undefined;
+  if (options.fresh !== true && active !== undefined) {
+    return active.agents;
   }
-  const plugins = await resolvePlugins(options);
-  const groups = await Promise.all(plugins.map(loadAgentsForPlugin));
+  const discoveryOptions =
+    options.fresh === true && active !== undefined
+      ? { ...active.discovery, fresh: true }
+      : options;
+  const plugins = await resolvePlugins(discoveryOptions);
+  const roleCwd = options.cwd ?? process.cwd();
+  const groups = await Promise.all(
+    plugins.map(plugin => loadAgentsForPlugin(plugin, roleCwd)),
+  );
   return groups.flat().sort((a, b) => a.agentType.localeCompare(b.agentType));
 }
 

--- a/runtime/src/plugins/registration/manager.ts
+++ b/runtime/src/plugins/registration/manager.ts
@@ -1,9 +1,16 @@
 import { join } from "node:path";
 
+import {
+  assertAgentRoleWorkspaceMatches,
+  type AgentRoleWorkspace,
+} from "../../agents/role.js";
 import type { AgenCConfig, HooksMap, LspServerConfigInput, McpServerConfig } from "../../config/schema.js";
 import type { Command } from "../../commands.js";
 import type { SlashCommandContext } from "../../commands/types.js";
-import type { PluginAgentDefinition } from "../../tools/AgentTool/loadAgentsDir.js";
+import {
+  requireAgentDefinitionRoleFingerprint,
+  type PluginAgentDefinition,
+} from "../../tools/AgentTool/loadAgentsDir.js";
 import { isRecord } from "../../utils/record.js";
 import { loadPlugins, type LoadedPlugin, type PluginLoadIssue, type PluginLoadResult } from "../loader.js";
 import {
@@ -122,22 +129,40 @@ function arrayValue(value: unknown): unknown[] {
   return Array.isArray(value) ? [...value] : [];
 }
 
+function agentRoleWorkspaceEnvelopeId(value: unknown): string | undefined {
+  if (!isRecord(value) && !Array.isArray(value)) return undefined;
+  const record = value as unknown as Record<string, unknown>;
+  return typeof record.agentRoleWorkspaceId === "string"
+    ? record.agentRoleWorkspaceId
+    : undefined;
+}
+
 function mergeAgentDefinitions(
   current: Record<string, unknown>,
   pluginAgents: readonly PluginAgentDefinition[],
+  workspace: AgentRoleWorkspace,
 ): Record<string, unknown> {
-  const currentDefinitions = isRecord(current.agentDefinitions)
-    ? current.agentDefinitions
-    : {};
+  const rawDefinitions = current.agentDefinitions;
+  const recordedWorkspaceId = agentRoleWorkspaceEnvelopeId(rawDefinitions);
+  assertAgentRoleWorkspaceMatches(
+    workspace,
+    recordedWorkspaceId,
+  );
+  const currentDefinitions = isRecord(rawDefinitions) ? rawDefinitions : {};
+  const scopedPluginAgents = pluginAgents.map((agent) => ({
+    ...agent,
+    agentRoleFingerprint: requireAgentDefinitionRoleFingerprint(agent),
+  }));
   return {
     ...currentDefinitions,
+    agentRoleWorkspaceId: workspace.id,
     allAgents: [
       ...arrayValue(currentDefinitions.allAgents).filter((agent) => !isPluginAgent(agent)),
-      ...pluginAgents,
+      ...scopedPluginAgents,
     ],
     activeAgents: [
       ...arrayValue(currentDefinitions.activeAgents).filter((agent) => !isPluginAgent(agent)),
-      ...pluginAgents,
+      ...scopedPluginAgents,
     ],
   };
 }
@@ -295,6 +320,7 @@ function mergePluginErrors(
 function updatePluginAppState(
   setAppState: ((updater: (prev: unknown) => unknown) => void) | undefined,
   snapshot: PluginRegistrationSnapshot,
+  workspace: AgentRoleWorkspace,
 ): void {
   if (!setAppState) return;
   setAppState((prev) => {
@@ -320,7 +346,7 @@ function updatePluginAppState(
         errors,
         needsRefresh: false,
       },
-      agentDefinitions: mergeAgentDefinitions(current, snapshot.agents),
+      agentDefinitions: mergeAgentDefinitions(current, snapshot.agents, workspace),
       mcp: {
         ...currentMcp,
         pluginReconnectKey: currentReconnectKey + 1,
@@ -337,9 +363,10 @@ function pluginRuntimeOptionsFromContext(
   ctx: SlashCommandContext,
 ): PluginRuntimeLoadOptions {
   const config = currentConfig(ctx);
+  const workspace = ctx.session.roleWorkspace;
   return {
-    cwd: ctx.cwd,
-    workspaceRoot: ctx.cwd,
+    cwd: workspace.cwd,
+    workspaceRoot: workspace.cwd,
     agencHome: ctx.agencHome ?? join(ctx.home, ".agenc"),
     ...(config !== undefined ? { config } : {}),
   };
@@ -348,17 +375,33 @@ function pluginRuntimeOptionsFromContext(
 export async function refreshActivePlugins(
   ctx: SlashCommandContext,
 ): Promise<PluginRegistrationSnapshot> {
+  const workspace = ctx.session.roleWorkspace;
+  if (ctx.appState !== undefined) {
+    const liveState = ctx.appState.getAppState?.();
+    if (!isRecord(liveState) || !isRecord(liveState.agentDefinitions)) {
+      throw new Error(
+        "Cannot refresh plugins: live agent catalog provenance is unavailable",
+      );
+    }
+    assertAgentRoleWorkspaceMatches(
+      workspace,
+      agentRoleWorkspaceEnvelopeId(liveState.agentDefinitions),
+    );
+  }
   const options = pluginRuntimeOptionsFromContext(ctx);
   const snapshot = await refreshPluginRegistrations(options);
   const activeIdentity = {
-    cwd: ctx.cwd,
+    cwd: workspace.cwd,
     ...(options.agencHome !== undefined ? { agencHome: options.agencHome } : {}),
   };
   setActivePluginCommandSnapshot(activeIdentity, snapshot.commands);
   setActivePluginSkillSnapshot(activeIdentity, snapshot.skills);
-  setActivePluginAgentSnapshot(activeIdentity, snapshot.agents);
+  setActivePluginAgentSnapshot(
+    { ...options, cwd: workspace.cwd },
+    snapshot.agents,
+  );
   registerPluginHooksWithRuntime(ctx, snapshot.hooks);
-  updatePluginAppState(ctx.appState?.setAppState, snapshot);
+  updatePluginAppState(ctx.appState?.setAppState, snapshot, workspace);
   return snapshot;
 }
 

--- a/runtime/src/session/agenc-delegate.ts
+++ b/runtime/src/session/agenc-delegate.ts
@@ -662,6 +662,8 @@ export function spawnAgenCDelegateThread(
   );
   const childSession = new Session({
     conversationId: `${parent.conversationId}:review:${req.subId}`,
+    roleWorkspace: parent.roleWorkspace,
+    agentDefinitions: parent.agentDefinitions,
     initialState: {
       sessionConfiguration: childSessionConfiguration,
       history: [...(req.initialHistory ?? [])],

--- a/runtime/src/session/agenc-tool-use-context.ts
+++ b/runtime/src/session/agenc-tool-use-context.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
+import { assertAgentRoleWorkspaceMatches } from "../agents/role-workspace.js";
 import { readProviderFactoryOptions } from "../llm/provider.js";
 import type { LLMProvider, LLMTool } from "../llm/types.js";
 import {
@@ -39,6 +40,7 @@ export interface AgenCToolUseContext {
     };
     readonly querySource?: string;
     readonly agentDefinitions: {
+      readonly agentRoleWorkspaceId?: string;
       readonly activeAgents: readonly unknown[];
       readonly allowedAgentTypes?: readonly unknown[];
     };
@@ -49,6 +51,7 @@ export interface AgenCToolUseContext {
   readonly getAppState: () => {
     readonly toolPermissionContext: unknown;
     readonly agentDefinitions: {
+      readonly agentRoleWorkspaceId?: string;
       readonly activeAgents: readonly unknown[];
       readonly allowedAgentTypes?: readonly unknown[];
     };
@@ -103,6 +106,7 @@ type SessionSurface = {
   readonly loadedNestedMemoryPaths?: Set<string>;
   readonly mcpClients?: readonly unknown[];
   readonly agentDefinitions?: {
+    readonly agentRoleWorkspaceId?: string;
     readonly activeAgents?: readonly unknown[];
     readonly allowedAgentTypes?: readonly unknown[];
   };
@@ -167,7 +171,11 @@ export function buildAgenCToolUseContext(
   const model = toAgenCModelContext(ctx);
   const providerOverride = buildProviderOverride(session, model.model);
   const surface = readSessionSurface(session);
-  const agentDefinitions = normalizeAgentDefinitions(surface.agentDefinitions);
+  const agentDefinitions = resolveAgentDefinitionsForContext(
+    session,
+    surface,
+    surface.getAppState?.(),
+  );
   const cwd = ctx.cwd;
   const llmTools = opts.llmTools ?? session.services.registry.toLLMTools();
   const setAppState = surface.setAppState;
@@ -283,6 +291,9 @@ function normalizeAgentDefinitions(
   definitions: SessionSurface["agentDefinitions"],
 ): NonNullable<AppStateShape["agentDefinitions"]> {
   return {
+    ...(readString(definitions?.agentRoleWorkspaceId) !== undefined
+      ? { agentRoleWorkspaceId: readString(definitions?.agentRoleWorkspaceId) }
+      : {}),
     activeAgents: Array.isArray(definitions?.activeAgents)
       ? [...definitions.activeAgents]
       : [],
@@ -290,6 +301,33 @@ function normalizeAgentDefinitions(
       ? [...definitions.allowedAgentTypes]
       : [],
   };
+}
+
+function resolveAgentDefinitionsForContext(
+  session: Session,
+  surface: SessionSurface,
+  state: unknown,
+): NonNullable<AppStateShape["agentDefinitions"]> {
+  const fallback = normalizeAgentDefinitions(surface.agentDefinitions);
+  assertAgentRoleWorkspaceMatches(
+    session.roleWorkspace,
+    fallback.agentRoleWorkspaceId,
+  );
+  if (
+    !isRecord(state) ||
+    !isRecord(state.agentDefinitions) ||
+    !Array.isArray(state.agentDefinitions.activeAgents)
+  ) {
+    return fallback;
+  }
+  const live = normalizeAgentDefinitions(
+    state.agentDefinitions as SessionSurface["agentDefinitions"],
+  );
+  assertAgentRoleWorkspaceMatches(
+    session.roleWorkspace,
+    live.agentRoleWorkspaceId,
+  );
+  return live;
 }
 
 function createFallbackAppState(
@@ -333,19 +371,18 @@ function createAppStateReader(
     const fallback = createFallbackAppState(session, surface, agentDefinitions);
     const state = surface.getAppState?.();
     if (!isRecord(state)) return fallback;
+    const liveAgentDefinitions = resolveAgentDefinitionsForContext(
+      session,
+      surface,
+      state,
+    );
 
     return {
       ...state,
       toolPermissionContext:
         readToolPermissionContext(state.toolPermissionContext) ??
         fallback.toolPermissionContext,
-      agentDefinitions:
-        isRecord(state.agentDefinitions) &&
-        Array.isArray(state.agentDefinitions.activeAgents)
-          ? normalizeAgentDefinitions(
-              state.agentDefinitions as SessionSurface["agentDefinitions"],
-            )
-          : fallback.agentDefinitions,
+      agentDefinitions: liveAgentDefinitions,
       tasks: isRecord(state.tasks)
         ? (state.tasks as Record<string, unknown>)
         : fallback.tasks,

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -22,10 +22,13 @@ import {
 } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
-import type {
-  AgentMetadata,
-  AgentPath,
-  ThreadId,
+import {
+  AgentIdExistsError,
+  InvalidAgentMetadataError,
+  normalizeAgentMetadata,
+  type AgentMetadata,
+  type AgentPath,
+  type ThreadId,
 } from "../agents/registry.js";
 import type { Event } from "./event-log.js";
 import type { RolloutItem } from "./rollout-item.js";
@@ -70,7 +73,6 @@ export class RolloutStore {
   private readonly threadSpawnEdgePath: string;
   private readonly stateDriver: StateSqliteDriver;
   private readonly threadSpawnEdgeRepo: ThreadSpawnEdgeRepository;
-  private readonly threadSpawnEdges = new Map<ThreadId, ThreadSpawnEdgeRecord>();
 
   constructor(opts: RolloutStoreOpts) {
     this.store = new SessionStore(opts);
@@ -147,31 +149,30 @@ export class RolloutStore {
     return this.store.getCompactionIndexSnapshot();
   }
 
+  createThreadSpawnEdge(edge: ThreadSpawnEdgeRecord): void {
+    const normalized = normalizeThreadSpawnEdge(edge);
+    this.threadSpawnEdgeRepo.create(normalized);
+  }
+
+  /** @deprecated Spawn-edge identity is create-only; use createThreadSpawnEdge. */
   upsertThreadSpawnEdge(edge: ThreadSpawnEdgeRecord): void {
-    this.threadSpawnEdges.set(edge.childThreadId, cloneThreadSpawnEdge(edge));
-    this.threadSpawnEdgeRepo.upsert(edge);
+    this.createThreadSpawnEdge(edge);
   }
 
   setThreadSpawnEdgeStatus(
     childThreadId: ThreadId,
     status: ThreadSpawnEdgeStatus,
   ): void {
-    const existing = this.threadSpawnEdges.get(childThreadId);
-    if (!existing || existing.status === status) {
-      return;
-    }
-    this.threadSpawnEdges.set(childThreadId, {
-      ...existing,
-      status,
-      metadata: cloneAgentMetadata(existing.metadata),
-    });
-    this.threadSpawnEdgeRepo.upsert({ ...existing, status });
+    // Never decide from a constructor-time snapshot. Multiple daemon/session
+    // handles can share this project database, so the repository performs the
+    // authoritative monotonic transition (or idempotent acknowledgement).
+    this.threadSpawnEdgeRepo.setStatus(childThreadId, status);
   }
 
   getThreadSpawnEdge(
     childThreadId: ThreadId,
   ): ThreadSpawnEdgeRecord | undefined {
-    const edge = this.threadSpawnEdges.get(childThreadId);
+    const edge = this.threadSpawnEdgeRepo.get(childThreadId);
     return edge ? cloneThreadSpawnEdge(edge) : undefined;
   }
 
@@ -227,7 +228,8 @@ export class RolloutStore {
     parentThreadId: ThreadId,
     status?: ThreadSpawnEdgeStatus,
   ): ReadonlyArray<ThreadSpawnEdgeRecord> {
-    return Array.from(this.threadSpawnEdges.values())
+    return this.threadSpawnEdgeRepo
+      .list()
       .filter((edge) => edge.parentThreadId === parentThreadId)
       .filter((edge) => status === undefined || edge.status === status)
       .sort(compareThreadSpawnEdges)
@@ -239,7 +241,7 @@ export class RolloutStore {
     status?: ThreadSpawnEdgeStatus,
   ): ReadonlyArray<ThreadSpawnEdgeRecord> {
     const childrenByParent = new Map<ThreadId, ThreadSpawnEdgeRecord[]>();
-    for (const edge of this.threadSpawnEdges.values()) {
+    for (const edge of this.threadSpawnEdgeRepo.list()) {
       if (status !== undefined && edge.status !== status) continue;
       const bucket = childrenByParent.get(edge.parentThreadId) ?? [];
       bucket.push(edge);
@@ -278,15 +280,23 @@ export class RolloutStore {
   }
 
   private loadThreadSpawnEdges(): void {
-    this.threadSpawnEdges.clear();
-    for (const edge of this.threadSpawnEdgeRepo.list()) {
-      this.threadSpawnEdges.set(edge.childThreadId, cloneThreadSpawnEdge(edge));
-    }
+    const persistedChildIds = new Set(
+      this.threadSpawnEdgeRepo.list().map((edge) => edge.childThreadId),
+    );
 
     for (const edge of this.readLegacyThreadSpawnEdges()) {
-      if (this.threadSpawnEdges.has(edge.childThreadId)) continue;
-      this.threadSpawnEdges.set(edge.childThreadId, cloneThreadSpawnEdge(edge));
-      this.threadSpawnEdgeRepo.upsert(edge);
+      if (persistedChildIds.has(edge.childThreadId)) continue;
+      try {
+        this.threadSpawnEdgeRepo.create(edge);
+        persistedChildIds.add(edge.childThreadId);
+      } catch (error) {
+        // Another process can win the create between list() and legacy import.
+        // Accept only its durable row; never rewrite it from the legacy file.
+        if (!(error instanceof AgentIdExistsError)) throw error;
+        const persisted = this.threadSpawnEdgeRepo.get(edge.childThreadId);
+        if (!persisted) throw error;
+        persistedChildIds.add(persisted.childThreadId);
+      }
     }
   }
 
@@ -386,18 +396,7 @@ function cloneThreadSpawnEdge(
 }
 
 function cloneAgentMetadata(metadata: AgentMetadata): AgentMetadata {
-  return {
-    ...(metadata.agentId !== undefined ? { agentId: metadata.agentId } : {}),
-    ...(metadata.agentPath !== undefined ? { agentPath: metadata.agentPath } : {}),
-    ...(metadata.agentNickname !== undefined
-      ? { agentNickname: metadata.agentNickname }
-      : {}),
-    ...(metadata.agentRole !== undefined ? { agentRole: metadata.agentRole } : {}),
-    ...(metadata.lastTaskMessage !== undefined
-      ? { lastTaskMessage: metadata.lastTaskMessage }
-      : {}),
-    depth: metadata.depth,
-  };
+  return normalizeAgentMetadata(metadata);
 }
 
 function normalizeThreadSpawnEdge(
@@ -415,43 +414,24 @@ function normalizeThreadSpawnEdge(
   const status =
     edge.status === undefined ? "open" : edge.status;
 
+  const metadata = normalizeAgentMetadata(edge.metadata);
   if (
     typeof childThreadId !== "string" ||
     typeof edge.parentThreadId !== "string" ||
     typeof edge.parentPath !== "string" ||
-    (status !== "open" && status !== "closed")
+    (status !== "open" && status !== "closed") ||
+    metadata.agentId !== childThreadId
   ) {
-    throw new Error("invalid thread-spawn edge record");
+    throw new InvalidAgentMetadataError(
+      "invalid thread-spawn edge record or child identity",
+    );
   }
 
   return {
     childThreadId,
     parentThreadId: edge.parentThreadId,
     parentPath: edge.parentPath,
-    metadata: normalizeAgentMetadata(edge.metadata),
+    metadata,
     status,
   };
-}
-
-function normalizeAgentMetadata(metadata: unknown): AgentMetadata {
-  if (!isRecord(metadata) || typeof metadata.depth !== "number") {
-    throw new Error("invalid thread-spawn edge metadata");
-  }
-
-  const normalized: AgentMetadata = { depth: metadata.depth };
-  for (const key of [
-    "agentId",
-    "agentPath",
-    "agentNickname",
-    "agentRole",
-    "lastTaskMessage",
-  ] as const) {
-    const value = metadata[key];
-    if (value === undefined) continue;
-    if (typeof value !== "string") {
-      throw new Error("invalid thread-spawn edge metadata");
-    }
-    (normalized as Record<typeof key, string>)[key] = value;
-  }
-  return normalized;
 }

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -113,6 +113,14 @@ import {
   type McpStartupCancellationToken,
 } from "./mcp-startup.js";
 import type { PendingWorktreeState } from "./pending-worktree.js";
+import {
+  assertAgentRoleWorkspaceMatches,
+  createAgentRoleWorkspace,
+  normalizeAgentRoleWorkspace,
+  type AgentRoleWorkspace,
+} from "../agents/role-workspace.js";
+import { listAgentRoleDefinitions } from "../agents/role-definitions.js";
+import { agentDefinitionFingerprint } from "../agents/agent-definition-fingerprint.js";
 import type { GuardianRejectionCircuitBreaker } from "../permissions/guardian/rejection-circuit-breaker.js";
 import type { GuardianApprovalReviewer } from "../permissions/guardian/reviewer.js";
 import {
@@ -1127,6 +1135,15 @@ export interface SessionOpts {
   readonly features: ManagedFeatures;
   readonly services: SessionServices;
   readonly jsRepl: JsReplHandle;
+  /** Immutable role trust-domain identity; distinct from mutable execution cwd. */
+  readonly roleWorkspace?: AgentRoleWorkspace;
+  /** Canonical executable agent catalog loaded for the immutable role workspace. */
+  readonly agentDefinitions?: {
+    readonly agentRoleWorkspaceId: string;
+    readonly activeAgents: readonly unknown[];
+    readonly allAgents?: readonly unknown[];
+    readonly allowedAgentTypes?: readonly unknown[];
+  };
   /** Session-level config snapshot used for per-turn TurnContext builders. */
   readonly config?: Config;
   /** Session-level model metadata used for per-turn TurnContext builders. */
@@ -1607,11 +1624,30 @@ function compactionMessage(result: CompactionResult): string {
 
 function activeAgentDefinitionsFromRoles(
   roles: readonly { readonly name: string; readonly description: string }[],
+  workspace: AgentRoleWorkspace,
 ): unknown[] {
-  return roles.map((role) => ({
-    agentType: role.name,
-    ...(role.description.length > 0 ? { whenToUse: role.description } : {}),
-  }));
+  const available = new Map(
+    listAgentRoleDefinitions(workspace.cwd).map((definition) => [
+      definition.agentType,
+      definition,
+    ]),
+  );
+  return roles.flatMap((role) => {
+    const definition = available.get(role.name);
+    if (definition === undefined) return [];
+    const configured = {
+      ...definition,
+      ...(role.description.length > 0
+        ? { whenToUse: role.description }
+        : {}),
+    };
+    return [
+      {
+        ...configured,
+        agentRoleFingerprint: agentDefinitionFingerprint(configured),
+      },
+    ];
+  });
 }
 
 /**
@@ -1622,6 +1658,9 @@ function activeAgentDefinitionsFromRoles(
 export class Session {
   /** agenc runtime: `conversation_id: ThreadId` */
   readonly conversationId: ThreadId;
+
+  /** Immutable workspace used for all role discovery and role provenance. */
+  readonly roleWorkspace: AgentRoleWorkspace;
 
   /**
    * Compatibility event stream. EventLog is the source-of-truth fanout path; this
@@ -1774,8 +1813,11 @@ export class Session {
   projectMemoryWarnings: readonly string[] = [];
 
   /** TUI agent-definition status surface. Populated by agent catalog wiring. */
-  readonly agentDefinitions: { activeAgents: unknown[] } = {
-    activeAgents: [],
+  readonly agentDefinitions: {
+    agentRoleWorkspaceId: string;
+    activeAgents: unknown[];
+    allAgents?: unknown[];
+    allowedAgentTypes?: unknown[];
   };
 
   /** Turn ids that have already emitted task-lifecycle abort events. */
@@ -1806,6 +1848,30 @@ export class Session {
    */
   constructor(opts: SessionOpts) {
     this.conversationId = opts.conversationId;
+    this.roleWorkspace = opts.roleWorkspace
+      ? normalizeAgentRoleWorkspace(opts.roleWorkspace)
+      : createAgentRoleWorkspace(opts.initialState.sessionConfiguration.cwd);
+    if (opts.agentDefinitions !== undefined) {
+      assertAgentRoleWorkspaceMatches(
+        this.roleWorkspace,
+        opts.agentDefinitions.agentRoleWorkspaceId,
+      );
+      this.agentDefinitions = {
+        agentRoleWorkspaceId: this.roleWorkspace.id,
+        activeAgents: [...opts.agentDefinitions.activeAgents],
+        ...(opts.agentDefinitions.allAgents !== undefined
+          ? { allAgents: [...opts.agentDefinitions.allAgents] }
+          : {}),
+        ...(opts.agentDefinitions.allowedAgentTypes !== undefined
+          ? { allowedAgentTypes: [...opts.agentDefinitions.allowedAgentTypes] }
+          : {}),
+      };
+    } else {
+      this.agentDefinitions = {
+        agentRoleWorkspaceId: this.roleWorkspace.id,
+        activeAgents: [],
+      };
+    }
     this.txEvent =
       opts.eventQueue ??
       new AsyncQueue<Event>({ maxDepth: DEFAULT_LEGACY_EVENT_QUEUE_DEPTH });
@@ -1880,9 +1946,12 @@ export class Session {
       deriveMinimalModelInfo(
         opts.initialState.sessionConfiguration.collaborationMode?.model ?? "",
       );
-    this.agentDefinitions.activeAgents = activeAgentDefinitionsFromRoles(
-      this.config.agentRoles,
-    );
+    if (opts.agentDefinitions === undefined) {
+      this.agentDefinitions.activeAgents = activeAgentDefinitionsFromRoles(
+        this.config.agentRoles,
+        this.roleWorkspace,
+      );
+    }
     this.nextInternalSubIdValue = 0;
     this.agentTaskRegistrationLock = new AsyncLock<void>(undefined);
     this.budgetTracker = opts.budgetTracker ?? null;

--- a/runtime/src/session/turn-compat.ts
+++ b/runtime/src/session/turn-compat.ts
@@ -4,6 +4,7 @@ import type { z } from "zod/v4";
 
 import type { LLMContentPart, LLMMessage, LLMTool, LLMToolCall } from "../llm/types.js";
 import type { LLMUsage } from "../llm/types.js";
+import { assertAgentRoleWorkspaceMatches } from "../agents/role.js";
 import type { PhaseEvent } from "../phases/events.js";
 import type { StopHookHandler, StopHookOutcome, StopRequest } from "../phases/stop-hooks.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
@@ -24,6 +25,10 @@ import {
 import type { SystemPrompt } from "../utils/systemPromptType.js";
 import { zodToJsonSchema } from "../utils/zodToJsonSchema.js";
 import { getCwdOverrideForCurrentContext } from "../utils/cwd.js";
+import {
+  runWithAgentMemoryAuthorization,
+  type AgentMemoryAuthorization,
+} from "../utils/agentContext.js";
 import {
   getAgentName,
   getTeamName,
@@ -58,7 +63,15 @@ export interface TurnCompatSession {
   readonly history: LLMMessage[];
   readonly userMessage: string | readonly LLMContentPart[];
   readonly systemPrompt: string;
+  readonly foregroundMemoryScope: ForegroundAgentMemoryScope;
 }
+
+type ForegroundAgentMemoryScope =
+  | { readonly selected: false }
+  | {
+      readonly selected: true;
+      readonly authorization: AgentMemoryAuthorization | undefined;
+    };
 
 export type TurnCompatRunEvent =
   | { readonly type: "phase"; readonly event: PhaseEvent }
@@ -72,6 +85,21 @@ export async function createTurnCompatSession(
   params: TurnCompatParams,
   opts: { readonly conversationId?: string } = {},
 ): Promise<TurnCompatSession> {
+  assertTurnCompatAgentCatalog(parent, params.toolUseContext);
+  const catalogWorkspaceId =
+    params.toolUseContext.options.agentDefinitions.agentRoleWorkspaceId;
+  if (catalogWorkspaceId === undefined) {
+    throw new Error("turn compatibility agent catalog provenance is missing");
+  }
+  const scopedAgentDefinitions = {
+    ...params.toolUseContext.options.agentDefinitions,
+    agentRoleWorkspaceId: catalogWorkspaceId,
+  };
+  const appState = params.toolUseContext.getAppState();
+  const foregroundMemoryScope = resolveForegroundAgentMemoryScope(
+    appState.agent,
+    scopedAgentDefinitions.activeAgents,
+  );
   const model = params.toolUseContext.options.mainLoopModel;
   const systemPrompt = appendSystemContext(
     params.systemPrompt,
@@ -85,7 +113,6 @@ export async function createTurnCompatSession(
     toolUseContext: params.toolUseContext,
     canUseTool: params.canUseTool,
   });
-  const appState = params.toolUseContext.getAppState();
   const effectiveCwd =
     getCwdOverrideForCurrentContext() ??
     parent.sessionConfiguration.cwd ??
@@ -103,6 +130,8 @@ export async function createTurnCompatSession(
       opts.conversationId ??
       params.toolUseContext.agentId ??
       `${parent.conversationId}:turn:${randomUUID()}`,
+    roleWorkspace: parent.roleWorkspace,
+    agentDefinitions: scopedAgentDefinitions,
     initialState: {
       sessionConfiguration,
       history: [],
@@ -149,7 +178,28 @@ export async function createTurnCompatSession(
     },
   });
   attachToolContextSurface(session, params.toolUseContext);
-  return { session, history, userMessage, systemPrompt };
+  return {
+    session,
+    history,
+    userMessage,
+    systemPrompt,
+    foregroundMemoryScope,
+  };
+}
+
+export function assertTurnCompatAgentCatalog(
+  parent: Pick<Session, "roleWorkspace">,
+  toolUseContext: Pick<ToolUseContext, "options" | "getAppState">,
+): void {
+  assertAgentRoleWorkspaceMatches(
+    parent.roleWorkspace,
+    toolUseContext.options.agentDefinitions.agentRoleWorkspaceId,
+  );
+  const appState = toolUseContext.getAppState();
+  assertAgentRoleWorkspaceMatches(
+    parent.roleWorkspace,
+    appState.agentDefinitions.agentRoleWorkspaceId,
+  );
 }
 
 function configuredCompatStopHooks(
@@ -414,19 +464,32 @@ export async function* runTurnCompat(
     opts.signal?.addEventListener("abort", forwardAbort, { once: true });
   }
 
-  const iterator = turn.session.runTurn(turn.userMessage, {
-    history: turn.history,
-    systemPrompt: turn.systemPrompt,
-    signal: runAbortController.signal,
-    querySource: params.querySource,
-    ...(params.skipCacheWrite !== undefined
-      ? { skipCacheWrite: params.skipCacheWrite }
-      : {}),
-    configOverrides:
-      params.maxTurns !== undefined ? { maxTurns: params.maxTurns } : undefined,
-  });
+  const foregroundMemoryScope = turn.foregroundMemoryScope;
+  const runInForegroundMemoryScope = <T>(fn: () => T): T =>
+    foregroundMemoryScope.selected
+      ? runWithAgentMemoryAuthorization(
+          foregroundMemoryScope.authorization,
+          fn,
+        )
+      : fn();
 
-  let next = iterator.next();
+  const iterator = runInForegroundMemoryScope(() =>
+    turn.session.runTurn(turn.userMessage, {
+      history: turn.history,
+      systemPrompt: turn.systemPrompt,
+      signal: runAbortController.signal,
+      querySource: params.querySource,
+      ...(params.skipCacheWrite !== undefined
+        ? { skipCacheWrite: params.skipCacheWrite }
+        : {}),
+      configOverrides:
+        params.maxTurns !== undefined ? { maxTurns: params.maxTurns } : undefined,
+    }),
+  );
+  const requestNext = () =>
+    runInForegroundMemoryScope(() => iterator.next());
+
+  let next = requestNext();
   let completed = false;
   try {
     while (true) {
@@ -447,13 +510,13 @@ export async function* runTurnCompat(
       if (event.type === "assistant_text") {
         assistantText = event.content;
         flushedToolAssistantText = "";
-        next = iterator.next();
+        next = requestNext();
         continue;
       }
 
       if (event.type === "tool_call") {
         pendingToolCalls = [...pendingToolCalls, event.toolCall];
-        next = iterator.next();
+        next = requestNext();
         continue;
       }
 
@@ -493,7 +556,7 @@ export async function* runTurnCompat(
             pendingToolAssistantUuid,
           ),
         };
-        next = iterator.next();
+        next = requestNext();
         continue;
       }
 
@@ -507,7 +570,7 @@ export async function* runTurnCompat(
             }),
           };
         }
-        next = iterator.next();
+        next = requestNext();
         continue;
       }
 
@@ -522,7 +585,7 @@ export async function* runTurnCompat(
               content: event.error?.message ?? "turn errored",
             }),
           };
-          next = iterator.next();
+          next = requestNext();
           continue;
         }
         if (event.stopReason === "max_turns") {
@@ -534,7 +597,7 @@ export async function* runTurnCompat(
               turnCount: completedTurnCount + 1,
             }),
           };
-          next = iterator.next();
+          next = requestNext();
           continue;
         }
         if (
@@ -550,7 +613,7 @@ export async function* runTurnCompat(
           };
         }
       }
-      next = iterator.next();
+      next = requestNext();
     }
     yield* drainQueuedEvents();
   } finally {
@@ -558,10 +621,40 @@ export async function* runTurnCompat(
     if (!completed && !runAbortController.signal.aborted) {
       runAbortController.abort(new Error("turn compatibility stream closed"));
     }
-    await iterator.return?.({ reason: "cancelled" });
+    await runInForegroundMemoryScope(
+      () => iterator.return?.({ reason: "cancelled" }),
+    );
     unsubscribe();
     queueWake = null;
   }
+}
+
+/**
+ * Resolve the legacy/main-thread selected role from the same canonical catalog
+ * envelope that is copied into the compatibility Session. A present but stale
+ * selection is an explicit deny; it must never inherit an unrelated ambient
+ * agent grant.
+ */
+function resolveForegroundAgentMemoryScope(
+  selectedAgentType: string | undefined,
+  activeAgents: ToolUseContext['options']['agentDefinitions']['activeAgents'],
+): ForegroundAgentMemoryScope {
+  if (selectedAgentType === undefined) {
+    return { selected: false };
+  }
+  const selectedAgent = activeAgents
+    .find((agent) => agent.agentType === selectedAgentType);
+  return {
+    selected: true,
+    ...(selectedAgent?.memory !== undefined
+      ? {
+          authorization: {
+            agentType: selectedAgent.agentType,
+            scope: selectedAgent.memory,
+          },
+        }
+      : { authorization: undefined }),
+  };
 }
 
 function parseLegacyProgressMessage(chunk: string): Message | null {

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -440,6 +440,8 @@ export type SubAgentSource =
       readonly agentPath?: string;
       readonly agentNickname?: string;
       readonly agentRole?: string;
+      readonly agentRoleWorkspaceId?: string;
+      readonly agentRoleFingerprint?: string;
     }
   | { readonly kind: "memory_consolidation" }
   | { readonly kind: "other"; readonly label: string };

--- a/runtime/src/state/migrations/012_agent_role_workspace_provenance.ts
+++ b/runtime/src/state/migrations/012_agent_role_workspace_provenance.ts
@@ -1,0 +1,144 @@
+import type { SqlMigration } from "./types.js";
+
+export const AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION = 12;
+
+interface TableColumnRow {
+  readonly name: string;
+}
+
+interface SpawnEdgeMetadataRow {
+  readonly child_thread_id: string;
+  readonly metadata_json: string;
+}
+
+interface RoleProvenance {
+  readonly workspaceId?: string;
+  readonly fingerprint?: string;
+}
+
+/**
+ * Keep role-workspace provenance outside field-list JSON clones.
+ *
+ * The dedicated column is deliberately additive. A legacy upsert that omits
+ * it cannot erase it, and the schema-version guard prevents an older runtime
+ * from opening the migrated database silently.
+ */
+export const agentRoleWorkspaceProvenanceMigration: SqlMigration = {
+  version: AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION,
+  name: "agent_role_workspace_provenance",
+  apply: (db) => {
+    // Repair partial legacy fixtures/databases as well as migrating a healthy
+    // v11 schema. In a normal database this is a no-op because v1 created it.
+    db.exec(`
+CREATE TABLE IF NOT EXISTS thread_spawn_edges (
+  child_thread_id TEXT PRIMARY KEY,
+  parent_thread_id TEXT NOT NULL,
+  source_thread_id TEXT,
+  source_path TEXT,
+  call_id TEXT,
+  parent_path TEXT NOT NULL,
+  metadata_json TEXT NOT NULL,
+  status TEXT NOT NULL,
+  agent_role_workspace_id TEXT,
+  agent_role_fingerprint TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_thread_spawn_edges_parent
+  ON thread_spawn_edges(parent_thread_id);
+`);
+    const columns = db
+      .prepare<[], TableColumnRow>("PRAGMA table_info(thread_spawn_edges)")
+      .all();
+    if (!columns.some((column) => column.name === "agent_role_workspace_id")) {
+      db.exec(
+        "ALTER TABLE thread_spawn_edges ADD COLUMN agent_role_workspace_id TEXT",
+      );
+    }
+    if (!columns.some((column) => column.name === "agent_role_fingerprint")) {
+      db.exec(
+        "ALTER TABLE thread_spawn_edges ADD COLUMN agent_role_fingerprint TEXT",
+      );
+    }
+
+    const rows = db
+      .prepare<[], SpawnEdgeMetadataRow>(
+        `SELECT child_thread_id, metadata_json
+         FROM thread_spawn_edges
+         WHERE agent_role_workspace_id IS NULL
+            OR agent_role_fingerprint IS NULL`,
+      )
+      .all();
+    const backfillWorkspace = db.prepare<[string, string]>(
+      `UPDATE thread_spawn_edges
+       SET agent_role_workspace_id = ?
+       WHERE child_thread_id = ? AND agent_role_workspace_id IS NULL`,
+    );
+    const backfillFingerprint = db.prepare<[string, string]>(
+      `UPDATE thread_spawn_edges
+       SET agent_role_fingerprint = ?
+       WHERE child_thread_id = ? AND agent_role_fingerprint IS NULL`,
+    );
+    for (const row of rows) {
+      const provenance = roleProvenanceFromJson(row.metadata_json);
+      if (provenance.workspaceId !== undefined) {
+        backfillWorkspace.run(provenance.workspaceId, row.child_thread_id);
+      }
+      if (provenance.fingerprint !== undefined) {
+        backfillFingerprint.run(provenance.fingerprint, row.child_thread_id);
+      }
+    }
+
+    // Repository writes are create-only, but triggers make the immutable edge
+    // identity hold even for old field-list writers or direct SQL access.
+    db.exec(`
+CREATE TRIGGER IF NOT EXISTS prevent_thread_spawn_edge_identity_rebind
+BEFORE UPDATE OF child_thread_id, parent_thread_id, parent_path, metadata_json,
+                 agent_role_workspace_id, agent_role_fingerprint
+ON thread_spawn_edges
+WHEN OLD.child_thread_id IS NOT NEW.child_thread_id
+  OR OLD.parent_thread_id IS NOT NEW.parent_thread_id
+  OR OLD.parent_path IS NOT NEW.parent_path
+  OR OLD.agent_role_workspace_id IS NOT NEW.agent_role_workspace_id
+  OR OLD.agent_role_fingerprint IS NOT NEW.agent_role_fingerprint
+  OR json_extract(OLD.metadata_json, '$.agentId') IS NOT
+     json_extract(NEW.metadata_json, '$.agentId')
+  OR json_extract(OLD.metadata_json, '$.agentPath') IS NOT
+     json_extract(NEW.metadata_json, '$.agentPath')
+  OR json_extract(OLD.metadata_json, '$.depth') IS NOT
+     json_extract(NEW.metadata_json, '$.depth')
+  OR json_extract(OLD.metadata_json, '$.agentRole') IS NOT
+     json_extract(NEW.metadata_json, '$.agentRole')
+  OR json_extract(OLD.metadata_json, '$.agentRoleWorkspaceId') IS NOT
+     json_extract(NEW.metadata_json, '$.agentRoleWorkspaceId')
+  OR json_extract(OLD.metadata_json, '$.agentRoleFingerprint') IS NOT
+     json_extract(NEW.metadata_json, '$.agentRoleFingerprint')
+BEGIN
+  SELECT RAISE(ABORT, 'thread-spawn edge identity is immutable');
+END;
+`);
+  },
+};
+
+function roleProvenanceFromJson(value: string): RoleProvenance {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+    const record = parsed as Record<string, unknown>;
+    const workspaceId = record.agentRoleWorkspaceId;
+    const fingerprint = record.agentRoleFingerprint;
+    return {
+      ...(typeof workspaceId === "string" && workspaceId.trim().length > 0
+        ? { workspaceId }
+        : {}),
+      ...(typeof fingerprint === "string" && fingerprint.trim().length > 0
+        ? { fingerprint }
+        : {}),
+    };
+  } catch {
+    return {};
+  }
+}

--- a/runtime/src/state/migrations/index.ts
+++ b/runtime/src/state/migrations/index.ts
@@ -10,6 +10,7 @@ import { toolOutputRotationSchemaMigration } from "./008_tool_output_rotation_sc
 import { agentRunMetadataSchemaMigration } from "./009_agent_run_metadata_schema.js";
 import { toolRecoveryCategorySchemaMigration } from "./010_tool_recovery_category_schema.js";
 import { memoryPipelineSchemaMigration } from "./011_memory_pipeline_schema.js";
+import { agentRoleWorkspaceProvenanceMigration } from "./012_agent_role_workspace_provenance.js";
 import type { SqlMigration } from "./types.js";
 
 /**
@@ -27,6 +28,7 @@ export const STATE_DB_MIGRATIONS: readonly SqlMigration[] = [
   agentRunMetadataSchemaMigration,
   toolRecoveryCategorySchemaMigration,
   memoryPipelineSchemaMigration,
+  agentRoleWorkspaceProvenanceMigration,
 ];
 
 export const LOGS_DB_MIGRATIONS: readonly SqlMigration[] = [

--- a/runtime/src/state/spawn-edges.ts
+++ b/runtime/src/state/spawn-edges.ts
@@ -1,7 +1,11 @@
-import type {
-  AgentMetadata,
-  AgentPath,
-  ThreadId,
+import {
+  AgentIdExistsError,
+  InvalidAgentMetadataError,
+  depthOfAgentPath,
+  normalizeAgentMetadata,
+  type AgentMetadata,
+  type AgentPath,
+  type ThreadId,
 } from "../agents/registry.js";
 import type { ThreadSpawnEdgeStatus } from "../session/rollout-store.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
@@ -19,42 +23,108 @@ interface SpawnEdgeRow {
   readonly parent_thread_id: string;
   readonly parent_path: string;
   readonly metadata_json: string;
+  readonly agent_role_workspace_id: string | null;
+  readonly agent_role_fingerprint: string | null;
   readonly status: string;
 }
 
 export class ThreadSpawnEdgeRepository {
   constructor(private readonly driver: StateSqliteDriver) {}
 
-  upsert(edge: IndexedThreadSpawnEdge): void {
-    this.driver
+  create(edge: IndexedThreadSpawnEdge): IndexedThreadSpawnEdge {
+    const normalized = normalizeIndexedThreadSpawnEdge(edge);
+    const metadata = normalized.metadata;
+    const result = this.driver
       .prepareState(
         `INSERT INTO thread_spawn_edges (
           child_thread_id,
           parent_thread_id,
           parent_path,
           metadata_json,
+          agent_role_workspace_id,
+          agent_role_fingerprint,
           status
-        ) VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(child_thread_id) DO UPDATE SET
-          parent_thread_id = excluded.parent_thread_id,
-          parent_path = excluded.parent_path,
-          metadata_json = excluded.metadata_json,
-          status = excluded.status,
-          updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(child_thread_id) DO NOTHING`,
       )
       .run(
-        edge.childThreadId,
-        edge.parentThreadId,
-        edge.parentPath,
-        JSON.stringify(edge.metadata),
-        edge.status,
+        normalized.childThreadId,
+        normalized.parentThreadId,
+        normalized.parentPath,
+        JSON.stringify(metadata),
+        metadata.agentRoleWorkspaceId ?? null,
+        metadata.agentRoleFingerprint ?? null,
+        normalized.status,
       );
+    if (result.changes === 0) {
+      throw new AgentIdExistsError(normalized.childThreadId);
+    }
+    const persisted = this.get(normalized.childThreadId);
+    if (!persisted) {
+      throw new Error("persisted thread-spawn edge could not be read back");
+    }
+    return persisted;
+  }
+
+  setStatus(
+    childThreadId: ThreadId,
+    status: ThreadSpawnEdgeStatus,
+  ): IndexedThreadSpawnEdge {
+    if (status !== "open" && status !== "closed") {
+      throw new InvalidAgentMetadataError("invalid thread-spawn edge status");
+    }
+    if (status === "open") {
+      const persisted = this.get(childThreadId);
+      if (!persisted) {
+        throw new InvalidAgentMetadataError(
+          `thread-spawn edge does not exist: ${childThreadId}`,
+        );
+      }
+      if (persisted.status === "closed") {
+        throw new InvalidAgentMetadataError(
+          `thread-spawn edge cannot transition from closed to open: ${childThreadId}`,
+        );
+      }
+      return persisted;
+    }
+
+    // Closing is the only state mutation. The status predicate is the CAS:
+    // concurrent closers serialize in SQLite, and losers acknowledge the
+    // already-durable closed row below instead of reopening or failing.
+    const result = this.driver
+      .prepareState<[ThreadId]>(
+        `UPDATE thread_spawn_edges
+         SET status = 'closed',
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         WHERE child_thread_id = ? AND status = 'open'`,
+      )
+      .run(childThreadId);
+    if (result.changes === 0) {
+      const persisted = this.get(childThreadId);
+      if (!persisted) {
+        throw new InvalidAgentMetadataError(
+          `thread-spawn edge does not exist: ${childThreadId}`,
+        );
+      }
+      if (persisted.status !== "closed") {
+        throw new InvalidAgentMetadataError(
+          `thread-spawn edge could not transition to closed: ${childThreadId}`,
+        );
+      }
+      return persisted;
+    }
+    const persisted = this.get(childThreadId);
+    if (!persisted) {
+      throw new Error("persisted thread-spawn edge could not be read back");
+    }
+    return persisted;
   }
 
   get(childThreadId: ThreadId): IndexedThreadSpawnEdge | undefined {
     const row = this.driver
       .prepareState<[ThreadId], SpawnEdgeRow>(
-        `SELECT child_thread_id, parent_thread_id, parent_path, metadata_json, status
+        `SELECT child_thread_id, parent_thread_id, parent_path, metadata_json,
+                agent_role_workspace_id, agent_role_fingerprint, status
          FROM thread_spawn_edges
          WHERE child_thread_id = ?`,
       )
@@ -65,7 +135,8 @@ export class ThreadSpawnEdgeRepository {
   list(): ReadonlyArray<IndexedThreadSpawnEdge> {
     return this.driver
       .prepareState<[], SpawnEdgeRow>(
-        `SELECT child_thread_id, parent_thread_id, parent_path, metadata_json, status
+        `SELECT child_thread_id, parent_thread_id, parent_path, metadata_json,
+                agent_role_workspace_id, agent_role_fingerprint, status
          FROM thread_spawn_edges
          ORDER BY child_thread_id ASC`,
       )
@@ -75,13 +146,108 @@ export class ThreadSpawnEdgeRepository {
 }
 
 function rowToEdge(row: SpawnEdgeRow): IndexedThreadSpawnEdge {
-  const status =
-    row.status === "closed" || row.status === "open" ? row.status : "open";
-  return {
+  if (row.status !== "closed" && row.status !== "open") {
+    throw new InvalidAgentMetadataError(
+      `invalid thread-spawn edge status: ${row.status}`,
+    );
+  }
+  const status = row.status;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.metadata_json) as unknown;
+  } catch (cause) {
+    throw new InvalidAgentMetadataError("invalid agent metadata JSON", {
+      cause,
+    });
+  }
+  const metadata = normalizeAgentMetadata(parsed);
+  const rawColumnWorkspaceId: unknown = row.agent_role_workspace_id;
+  const rawColumnFingerprint: unknown = row.agent_role_fingerprint;
+  if (
+    rawColumnWorkspaceId !== null &&
+    (typeof rawColumnWorkspaceId !== "string" ||
+      rawColumnWorkspaceId.trim().length === 0 ||
+      (metadata.agentRoleWorkspaceId !== undefined &&
+        metadata.agentRoleWorkspaceId !== rawColumnWorkspaceId))
+  ) {
+    throw new InvalidAgentMetadataError(
+      "invalid agent role workspace provenance column",
+    );
+  }
+  const columnWorkspaceId = rawColumnWorkspaceId as string | null;
+  if (
+    rawColumnFingerprint !== null &&
+    (typeof rawColumnFingerprint !== "string" ||
+      rawColumnFingerprint.trim().length === 0 ||
+      (metadata.agentRoleFingerprint !== undefined &&
+        metadata.agentRoleFingerprint !== rawColumnFingerprint))
+  ) {
+    throw new InvalidAgentMetadataError(
+      "invalid agent role fingerprint column",
+    );
+  }
+  const columnFingerprint = rawColumnFingerprint as string | null;
+  const recoveredMetadata =
+    columnWorkspaceId === null && columnFingerprint === null
+      ? metadata
+      : normalizeAgentMetadata({
+          ...metadata,
+          ...(columnWorkspaceId !== null
+            ? { agentRoleWorkspaceId: columnWorkspaceId }
+            : {}),
+          ...(columnFingerprint !== null
+            ? { agentRoleFingerprint: columnFingerprint }
+            : {}),
+        });
+  return normalizeIndexedThreadSpawnEdge({
     childThreadId: row.child_thread_id,
     parentThreadId: row.parent_thread_id,
     parentPath: row.parent_path,
-    metadata: JSON.parse(row.metadata_json) as AgentMetadata,
+    metadata: recoveredMetadata,
     status,
+  });
+}
+
+function normalizeIndexedThreadSpawnEdge(
+  edge: IndexedThreadSpawnEdge,
+): IndexedThreadSpawnEdge {
+  if (edge.status !== "open" && edge.status !== "closed") {
+    throw new InvalidAgentMetadataError(
+      `invalid thread-spawn edge status: ${String(edge.status)}`,
+    );
+  }
+  const metadata = normalizeAgentMetadata(edge.metadata);
+  if (
+    edge.childThreadId.trim().length === 0 ||
+    metadata.agentId !== edge.childThreadId
+  ) {
+    throw new InvalidAgentMetadataError(
+      "thread-spawn edge child id must match metadata agentId",
+    );
+  }
+  if (
+    metadata.agentPath === undefined ||
+    metadata.depth !== depthOfAgentPath(metadata.agentPath)
+  ) {
+    throw new InvalidAgentMetadataError(
+      "thread-spawn edge path and depth are inconsistent",
+    );
+  }
+  const separator = metadata.agentPath.lastIndexOf("/");
+  const expectedParentPath = metadata.agentPath.slice(0, separator);
+  if (
+    edge.parentThreadId.trim().length === 0 ||
+    edge.parentPath !== expectedParentPath
+  ) {
+    throw new InvalidAgentMetadataError(
+      "thread-spawn edge parent identity is inconsistent",
+    );
+  }
+  return {
+    childThreadId: edge.childThreadId,
+    parentThreadId: edge.parentThreadId,
+    parentPath: edge.parentPath,
+    metadata,
+    status: edge.status,
   };
 }

--- a/runtime/src/state/sqlite-driver.ts
+++ b/runtime/src/state/sqlite-driver.ts
@@ -1,4 +1,16 @@
-import { existsSync, mkdirSync, readdirSync, type Dirent } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  unlinkSync,
+  type Dirent,
+} from "node:fs";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
@@ -12,6 +24,7 @@ import {
   STATE_DB_MIGRATIONS,
   type SqlMigration,
 } from "./migrations/index.js";
+import { AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION } from "./migrations/012_agent_role_workspace_provenance.js";
 import { replayAtomicSessionSnapshotWrites } from "./atomic-snapshot-writes.js";
 
 export interface OpenStateDatabaseOptions {
@@ -28,6 +41,7 @@ export interface StateDatabasePaths {
 
 export const STATE_DATABASE_FILENAME = "agenc-state_1.sqlite";
 export const LOGS_DATABASE_FILENAME = "agenc-logs_1.sqlite";
+export const STATE_PRE_V12_BACKUP_FILENAME = "agenc-state_1.pre-v12.sqlite";
 
 export type SqliteDatabase = BetterSqlite3.Database;
 export type SqliteStatement<
@@ -46,13 +60,22 @@ export class StateSqliteDriver {
     this.projectDir = paths.projectDir;
     this.stateDbPath = paths.stateDbPath;
     this.logsDbPath = paths.logsDbPath;
-    this.state = new Database(paths.stateDbPath);
-    this.logs = new Database(paths.logsDbPath);
-    configureDatabase(this.state);
-    configureDatabase(this.logs);
-    applyMigrations(this.state, STATE_DB_MIGRATIONS);
-    applyMigrations(this.logs, LOGS_DB_MIGRATIONS);
-    replayAtomicSessionSnapshotWrites(this.state, this.projectDir);
+    const state = new Database(paths.stateDbPath);
+    let logs: SqliteDatabase | undefined;
+    try {
+      logs = new Database(paths.logsDbPath);
+      configureDatabase(state);
+      configureDatabase(logs);
+      applyStateMigrations(state, paths);
+      applyMigrations(logs, LOGS_DB_MIGRATIONS);
+      replayAtomicSessionSnapshotWrites(state, this.projectDir);
+    } catch (error) {
+      if (state.open) state.close();
+      if (logs?.open) logs.close();
+      throw error;
+    }
+    this.state = state;
+    this.logs = logs;
   }
 
   prepareState<Params extends unknown[] = unknown[], Row = unknown>(
@@ -203,6 +226,152 @@ function configureReadOnlyDatabase(db: SqliteDatabase): void {
   db.pragma("temp_store = MEMORY");
 }
 
+function applyStateMigrations(
+  db: SqliteDatabase,
+  paths: StateDatabasePaths,
+): void {
+  // Acquire the writer reservation before inspecting the schema. Otherwise a
+  // concurrently starting v11 process can initialize/populate the file after
+  // an existence/version check and make us migrate it without a backup.
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    if (
+      hasUserStateTables(db) &&
+      maxAppliedMigrationVersion(db) <
+        AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION
+    ) {
+      createPreV12StateBackupLocked(paths);
+    }
+    applyMigrations(db, STATE_DB_MIGRATIONS);
+    db.exec("COMMIT");
+  } catch (error) {
+    if (db.inTransaction) db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function createPreV12StateBackupLocked(paths: StateDatabasePaths): void {
+  const backupPath = join(paths.projectDir, STATE_PRE_V12_BACKUP_FILENAME);
+  const tempPath = `${backupPath}.${process.pid}.${randomUUID()}.tmp`;
+  let snapshotSource: SqliteDatabase | undefined;
+  try {
+    // VACUUM INTO runs on a second connection because the primary connection
+    // intentionally holds BEGIN IMMEDIATE. The lock prevents all source
+    // writers while SQLite itself produces a transactionally consistent file.
+    snapshotSource = new Database(paths.stateDbPath);
+    snapshotSource.pragma("busy_timeout = 5000");
+    snapshotSource.exec(`VACUUM main INTO ${sqliteStringLiteral(tempPath)}`);
+    snapshotSource.close();
+    snapshotSource = undefined;
+
+    chmodSync(tempPath, 0o600);
+    validatePreV12StateBackup(tempPath);
+    fsyncFile(tempPath);
+
+    // Refresh a stale artifact from an earlier failed attempt while the source
+    // write lock is still held. A crash before publication leaves v11 intact;
+    // a crash after publication leaves a fresh, fsynced rollback artifact.
+    try {
+      unlinkSync(backupPath);
+      fsyncDirectory(paths.projectDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    linkSync(tempPath, backupPath);
+    fsyncDirectory(paths.projectDir);
+  } finally {
+    if (snapshotSource?.open) snapshotSource.close();
+    try {
+      unlinkSync(tempPath);
+      fsyncDirectory(paths.projectDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function hasUserStateTables(db: SqliteDatabase): boolean {
+  const row = db
+    .prepare<[], { count: number }>(
+      `SELECT COUNT(*) AS count
+       FROM sqlite_master
+       WHERE type = 'table'
+         AND name NOT LIKE 'sqlite_%'
+         AND name <> 'schema_migrations'`,
+    )
+    .get();
+  return (row?.count ?? 0) > 0;
+}
+
+function maxAppliedMigrationVersion(db: SqliteDatabase): number {
+  const table = db
+    .prepare<[], { name: string }>(
+      `SELECT name
+       FROM sqlite_master
+       WHERE type = 'table' AND name = 'schema_migrations'`,
+    )
+    .get();
+  if (!table) return 0;
+  return (
+    db
+      .prepare<[], { version: number | null }>(
+        "SELECT MAX(version) AS version FROM schema_migrations",
+      )
+      .get()?.version ?? 0
+  );
+}
+
+function validatePreV12StateBackup(path: string): void {
+  const backup = new Database(path, { readonly: true, fileMustExist: true });
+  try {
+    const integrity = backup
+      .prepare<[], { integrity_check: string }>("PRAGMA integrity_check")
+      .all();
+    if (
+      integrity.length !== 1 ||
+      integrity[0]?.integrity_check.toLowerCase() !== "ok"
+    ) {
+      throw new Error(`state backup failed integrity check: ${path}`);
+    }
+    if (
+      maxAppliedMigrationVersion(backup) >=
+      AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION
+    ) {
+      throw new Error(`state backup is not a pre-v12 database: ${path}`);
+    }
+  } finally {
+    backup.close();
+  }
+}
+
+function fsyncFile(path: string): void {
+  const fd = openSync(path, "r");
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fsyncDirectory(path: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    fsyncSync(fd);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "EINVAL" && code !== "EPERM" && code !== "EISDIR") {
+      throw error;
+    }
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function sqliteStringLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
 export function applyMigrations(
   db: SqliteDatabase,
   migrations: readonly SqlMigration[],
@@ -241,7 +410,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
     "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
   );
 
-  const migrate = db.transaction(() => {
+  const migrate = () => {
     for (const migration of migrations) {
       if (applied.has(migration.version)) continue;
       try {
@@ -255,6 +424,9 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
         );
       }
     }
-  });
-  migrate();
+  };
+  // better-sqlite3 implements nested transactions with a savepoint. Keep the
+  // savepoint even when a caller already owns an outer transaction so a caught
+  // migration error cannot leave partial DDL/data for that caller to commit.
+  db.transaction(migrate)();
 }

--- a/runtime/src/tasks/LocalMainSessionTask.ts
+++ b/runtime/src/tasks/LocalMainSessionTask.ts
@@ -376,6 +376,14 @@ export function startBackgroundSession({
     agentType: 'subagent',
     subagentName: 'main-session',
     isBuiltIn: true,
+    ...(agentDefinition?.memory !== undefined
+      ? {
+          memoryAuthorization: {
+            agentType: agentDefinition.agentType,
+            scope: agentDefinition.memory,
+          },
+        }
+      : {}),
   }
 
   void runWithAgentContext(agentContext, async () => {

--- a/runtime/src/tools/AgentTool/AgentTool.tsx
+++ b/runtime/src/tools/AgentTool/AgentTool.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod/v4';
 import { clearInvokedSkillsForAgent, getSdkAgentProgressSummariesEnabled } from '../../bootstrap/state.js';
 import { enhanceSystemPromptWithEnvDetails, getSystemPrompt } from '../../constants/prompts.js';
 import { isCoordinatorMode } from '../../coordinator/coordinatorMode.js';
+import { requireCurrentRuntimeSession } from '../../session/current-session.js';
 import { startAgentSummarization, toSummaryCacheSafeParams } from '../../services/AgentSummary/agentSummary.js';
 import { clearDumpState } from '../../services/api/dumpPrompts.js';
 import { completeAgentTask as completeAsyncAgent, createActivityDescriptionResolver, createProgressTracker, enqueueAgentNotification, failAgentTask as failAsyncAgent, getProgressUpdate, getTokenCountFromTracker, isLocalAgentTask, killAsyncAgent, registerAgentForeground, registerAsyncAgent, unregisterAgentForeground, updateAgentProgress as updateAsyncAgentProgress, updateAgentSummary as updateAsyncAgentSummary, updateProgressFromMessage } from '../../tasks/LocalAgentTask/LocalAgentTask.js';
@@ -24,7 +25,10 @@ import { createUserMessage, extractTextContent, isSyntheticMessage, normalizeMes
 import { getAgentModel } from '../../utils/model/agent.js';
 import { permissionModeSchema } from '../../utils/permissions/PermissionMode.js';
 import type { PermissionResult } from '../../utils/permissions/PermissionResult.js';
-import { filterDeniedAgents, getDenyRuleForAgent } from '../../utils/permissions/permissions.js';
+import {
+  filterDeniedAgents,
+  getDenyRuleForAgent,
+} from '../../utils/permissions/permissions.js';
 import { enqueueSdkEvent } from '../../utils/sdkEventQueue.js';
 import { writeAgentMetadata } from '../../utils/sessionStorage.js';
 import { sleep } from '../../utils/sleep.js';
@@ -43,12 +47,22 @@ import { FILE_READ_TOOL_NAME } from '../FileReadTool/prompt.js';
 import { spawnTeammate } from '../shared/spawnMultiAgent.js';
 import { setAgentColor } from 'src/tools/AgentTool/agentColorManager.js';
 import { agentToolResultSchema, classifyHandoffIfNeeded, emitTaskProgress, extractPartialResult, finalizeAgentTool, getLastToolUseName, runAsyncAgentLifecycle } from './agentToolUtils.js';
-import { getDefaultAgentRole } from 'src/agents/role.js';
+import {
+  assertAgentRoleWorkspaceMatches,
+  getDefaultAgentRole,
+} from 'src/agents/role.js';
 import { canonicalAgentRoleName } from 'src/agents/role-presentation.js';
 import { AGENT_TOOL_NAME, LEGACY_AGENT_TOOL_NAME, ONE_SHOT_BUILTIN_AGENT_TYPES } from 'src/tools/AgentTool/constants.js';
 import { buildForkedMessages, buildWorktreeNotice, FORK_AGENT, isForkSubagentEnabled, isInForkChild } from './forkSubagent.js';
 import type { AgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js';
-import { filterAgentsByMcpRequirements, hasRequiredMcpServers, isBuiltInAgent } from 'src/tools/AgentTool/loadAgentsDir.js';
+import {
+  filterAgentsByMcpRequirements,
+  findAgentDefinitionByType,
+  hasRequiredMcpServers,
+  isBuiltInAgent,
+  loadFreshAgentDefinitions,
+  requireAgentDefinitionRoleFingerprint,
+} from 'src/tools/AgentTool/loadAgentsDir.js';
 import { getPrompt } from 'src/tools/AgentTool/prompt.js';
 import { runAgent } from './runAgent.js';
 import { renderGroupedAgentToolUse, renderToolResultMessage, renderToolUseErrorMessage, renderToolUseMessage, renderToolUseProgressMessage, renderToolUseRejectedMessage, renderToolUseTag, userFacingName, userFacingNameBackgroundColor } from './UI.js';
@@ -60,6 +74,37 @@ import { renderGroupedAgentToolUse, renderToolResultMessage, renderToolUseErrorM
 // against `never`.
 const proactiveModule = ((): { isProactiveActive(): boolean } | null => null)();
 /* eslint-enable @typescript-eslint/no-require-imports */
+
+export type AgentToolLaunchPreflight = {
+  readonly selectedAgent: AgentDefinition;
+  readonly agentRoleFingerprint: string;
+};
+
+type AgentToolLaunchPreflightForTesting = (
+  preflight: AgentToolLaunchPreflight,
+) => void;
+
+let agentToolLaunchPreflightForTesting:
+  | AgentToolLaunchPreflightForTesting
+  | undefined;
+
+type AgentMetadataWriter = typeof writeAgentMetadata;
+
+let agentMetadataWriter: AgentMetadataWriter = writeAgentMetadata;
+
+/** @internal Observes the post-policy boundary in focused tests. */
+export function __setAgentToolLaunchPreflightForTesting(
+  preflight: AgentToolLaunchPreflightForTesting | undefined,
+): void {
+  agentToolLaunchPreflightForTesting = preflight;
+}
+
+/** @internal Injects a durable sidecar writer for launch-ordering tests. */
+export function __setAgentMetadataWriterForTesting(
+  writer: AgentMetadataWriter | undefined,
+): void {
+  agentMetadataWriter = writer ?? writeAgentMetadata;
+}
 
 // Progress display constants (for showing background hint)
 const PROGRESS_THRESHOLD_MS = 2000; // Show background hint after 2 seconds
@@ -241,9 +286,19 @@ export const AgentTool = buildTool({
   }: AgentToolInput, toolUseContext, canUseTool, assistantMessage, onProgress?) {
     const startTime = Date.now();
     const model = isCoordinatorMode() ? undefined : modelParam;
+    const parentSession = requireCurrentRuntimeSession('subagent spawn');
+    assertAgentRoleWorkspaceMatches(
+      parentSession.roleWorkspace,
+      toolUseContext.options.agentDefinitions.agentRoleWorkspaceId,
+    );
+    const agentRoleWorkspaceId = parentSession.roleWorkspace.id;
 
     // Get app state for permission mode and agent filtering
     const appState = toolUseContext.getAppState();
+    assertAgentRoleWorkspaceMatches(
+      parentSession.roleWorkspace,
+      appState.agentDefinitions.agentRoleWorkspaceId,
+    );
     const permissionMode = appState.toolPermissionContext.mode;
     // In-process teammates get a no-op setAppState; setAppStateForTasks
     // reaches the root store so task registration/progress/kill stay visible.
@@ -273,11 +328,6 @@ export const AgentTool = buildTool({
     // Check if this is a multi-agent spawn request
     // Spawn is triggered when team_name is set (from param or context) and name is provided
     if (teamName && name) {
-      // Set agent definition color for grouped UI display before spawning
-      const agentDef = subagent_type ? toolUseContext.options.agentDefinitions.activeAgents.find(a => a.agentType === subagent_type) : undefined;
-      if (agentDef?.color) {
-        setAgentColor(subagent_type!, agentDef.color);
-      }
       const result = await spawnTeammate({
         name,
         prompt,
@@ -285,8 +335,11 @@ export const AgentTool = buildTool({
         team_name: teamName,
         use_splitpane: true,
         plan_mode_required: spawnMode === 'plan',
-        model: model ?? agentDef?.model,
+        model,
         agent_type: subagent_type,
+        cwd,
+        agent_role_workspace_id: agentRoleWorkspaceId,
+        agent_role_workspace_cwd: parentSession.roleWorkspace.cwd,
         invokingRequestId: assistantMessage?.requestId
       }, toolUseContext);
 
@@ -325,34 +378,47 @@ export const AgentTool = buildTool({
       }
       selectedAgent = FORK_AGENT;
     } else {
-      // Filter agents to exclude those denied via Agent(AgentName) syntax
-      const allAgents = toolUseContext.options.agentDefinitions.activeAgents;
+      const freshCatalog = await loadFreshAgentDefinitions(
+        parentSession.roleWorkspace.cwd,
+      );
+      assertAgentRoleWorkspaceMatches(
+        parentSession.roleWorkspace,
+        freshCatalog.agentRoleWorkspaceId,
+      );
+      const allAgents = freshCatalog.activeAgents;
       const {
         allowedAgentTypes
       } = toolUseContext.options.agentDefinitions;
-      const agents = filterDeniedAgents(
-      // When allowedAgentTypes is set (from Agent(x,y) tool spec), restrict to those types
-      allowedAgentTypes ? allAgents.filter(a => allowedAgentTypes.includes(a.agentType)) : allAgents, appState.toolPermissionContext, AGENT_TOOL_NAME);
-      // Match by exact agentType or canonical role name, mirroring the live v2
-      // spawn resolver (canonicalAgentRoleName -> requireAgentRole), so public
-      // names / aliases (scanner, runner, netrunner, general-purpose, plan, ...)
-      // routed here via the hook-chain fallback resolve like everywhere else.
-      const canonicalEffectiveType = canonicalAgentRoleName(effectiveType);
-      const matchesEffectiveType = (agentType: string): boolean =>
-        agentType === effectiveType ||
-        canonicalAgentRoleName(agentType) === canonicalEffectiveType;
-      const found = agents.find(agent => matchesEffectiveType(agent.agentType));
+      const found = findAgentDefinitionByType(allAgents, effectiveType);
       if (!found) {
-        // Check if the agent exists but is denied by permission rules
-        const agentExistsButDenied = allAgents.find(agent => matchesEffectiveType(agent.agentType));
-        if (agentExistsButDenied) {
-          const denyRule = getDenyRuleForAgent(appState.toolPermissionContext, AGENT_TOOL_NAME, effectiveType);
-          throw new Error(`Agent type '${effectiveType}' has been denied by permission rule '${AGENT_TOOL_NAME}(${effectiveType})' from ${denyRule?.source ?? 'settings'}.`);
-        }
-        throw new Error(`Agent type '${effectiveType}' not found. Available agents: ${agents.map(a => a.agentType).join(', ')}`);
+        throw new Error(`Agent type '${effectiveType}' not found. Available agents: ${allAgents.map(a => a.agentType).join(', ')}`);
+      }
+      if (allowedAgentTypes !== undefined && !allowedAgentTypes.some(
+        allowedType => allowedType === found.agentType ||
+          (found.agentType !== effectiveType &&
+            canonicalAgentRoleName(allowedType) ===
+              canonicalAgentRoleName(found.agentType))
+      )) {
+        throw new Error(`Agent type '${effectiveType}' not found. Available agents: ${allowedAgentTypes.join(', ')}`);
+      }
+      const denyRule = getDenyRuleForAgent(
+        appState.toolPermissionContext,
+        AGENT_TOOL_NAME,
+        effectiveType,
+      ) ?? (found.agentType !== effectiveType
+        ? getDenyRuleForAgent(
+            appState.toolPermissionContext,
+            AGENT_TOOL_NAME,
+            found.agentType,
+          )
+        : null);
+      if (denyRule !== null) {
+        throw new Error(`Agent type '${effectiveType}' has been denied by permission rule '${AGENT_TOOL_NAME}(${denyRule.ruleValue.ruleContent ?? effectiveType})' from ${denyRule.source ?? 'settings'}.`);
       }
       selectedAgent = found;
     }
+    const selectedAgentRoleFingerprint =
+      requireAgentDefinitionRoleFingerprint(selectedAgent);
 
     // Same lifecycle constraint as the run_in_background guard above, but for
     // agent definitions that force background via `background: true`. Checked
@@ -412,6 +478,11 @@ export const AgentTool = buildTool({
     if (selectedAgent.color) {
       setAgentColor(selectedAgent.agentType, selectedAgent.color);
     }
+
+    agentToolLaunchPreflightForTesting?.({
+      selectedAgent,
+      agentRoleFingerprint: selectedAgentRoleFingerprint,
+    });
 
     // Resolve agent params (these are already resolved in runAgent)
     const resolvedAgentModel = getAgentModel(selectedAgent.model, toolUseContext.options.mainLoopModel, isForkPath ? undefined : model, permissionMode);
@@ -493,16 +564,10 @@ export const AgentTool = buildTool({
     // below (registerAsyncAgentTask + notifyOnCompletion).
     const assistantForceAsync = feature('KAIROS') ? appState.kairosEnabled : false;
     const shouldRunAsync = (run_in_background === true || selectedAgent.background === true || isCoordinator || forceAsync || assistantForceAsync || (proactiveModule?.isProactiveActive() ?? false)) && !isBackgroundTasksDisabled;
-    // Assemble the worker's tool pool independently of the parent's.
-    // Workers always get their tools from assembleToolPool with their own
-    // permission mode, so they aren't affected by the parent's tool
-    // restrictions. This is computed here so that runAgent doesn't need to
-    // import from tools.ts (which would create a circular dependency).
     const workerPermissionContext = {
       ...appState.toolPermissionContext,
       mode: selectedAgent.permissionMode ?? 'acceptEdits'
     };
-    const workerTools = assembleToolPool(workerPermissionContext, appState.mcp.tools);
 
     // Create a stable agent ID early so it can be used for worktree slug
     const earlyAgentId = createAgentId();
@@ -540,6 +605,55 @@ export const AgentTool = buildTool({
         content: buildWorktreeNotice(getCwd(), worktreeInfo.worktreePath)
       }));
     }
+
+    // Persist exact role provenance before either registerAsyncAgent or
+    // registerAgentForeground can publish task state. A failed persistence
+    // therefore cannot leave a visible/running agent whose resume authority
+    // is missing. Worktrees created during preflight are removed before the
+    // persistence error is returned.
+    try {
+      await agentMetadataWriter(asAgentId(earlyAgentId), {
+        agentType: selectedAgent.agentType,
+        agentRoleWorkspaceId,
+        agentRoleFingerprint: selectedAgentRoleFingerprint,
+        ...(worktreeInfo?.worktreePath ? {
+          worktreePath: worktreeInfo.worktreePath
+        } : {}),
+        description
+      });
+    } catch (persistenceError) {
+      const unpublishedWorktree = worktreeInfo;
+      worktreeInfo = null;
+      if (unpublishedWorktree) {
+        try {
+          const removed = await removeAgentWorktree(
+            unpublishedWorktree.worktreePath,
+            unpublishedWorktree.worktreeBranch,
+            unpublishedWorktree.gitRoot,
+            unpublishedWorktree.hookBased
+          );
+          if (!removed) {
+            throw new Error(
+              `Failed to remove unpublished agent worktree: ${unpublishedWorktree.worktreePath}`
+            );
+          }
+        } catch (cleanupError) {
+          throw new AggregateError(
+            [persistenceError, cleanupError],
+            'Failed to persist agent role metadata and clean up its unpublished worktree'
+          );
+        }
+      }
+      throw persistenceError;
+    }
+
+    // Assemble the worker's tool pool independently of the parent's.
+    // Workers always get their tools from assembleToolPool with their own
+    // permission mode, so they aren't affected by the parent's tool
+    // restrictions. This is computed here so that runAgent doesn't need to
+    // import from tools.ts (which would create a circular dependency).
+    const workerTools = assembleToolPool(workerPermissionContext, appState.mcp.tools);
+
     const runAgentParams: Parameters<typeof runAgent>[0] = {
       agentDefinition: selectedAgent,
       promptMessages,
@@ -574,6 +688,7 @@ export const AgentTool = buildTool({
       worktreePath: worktreeInfo?.worktreePath,
       description,
       agentName: name,
+      agentMetadataAlreadyPersisted: true,
     };
 
     // Helper to wrap execution with a cwd override: explicit cwd arg (KAIROS)
@@ -608,13 +723,15 @@ export const AgentTool = buildTool({
         const changed = await hasWorktreeChanges(worktreePath, headCommit);
         if (!changed) {
           await removeAgentWorktree(worktreePath, worktreeBranch, gitRoot);
-          // Clear worktreePath from metadata so resume doesn't try to use
-          // a deleted directory. Fire-and-forget to match runAgent's
-          // writeAgentMetadata handling.
-          void writeAgentMetadata(asAgentId(earlyAgentId), {
+          // Clear worktreePath from metadata before returning cleanup. The
+          // awaited atomic write prevents later resumes from racing a partial
+          // sidecar or observing a deleted worktree as the current location.
+          await agentMetadataWriter(asAgentId(earlyAgentId), {
             agentType: selectedAgent.agentType,
+            agentRoleWorkspaceId,
+            agentRoleFingerprint: selectedAgentRoleFingerprint,
             description
-          }).catch(_err => logForDebugging(`Failed to clear worktree metadata: ${_err}`));
+          });
           return {};
         }
       }
@@ -624,6 +741,7 @@ export const AgentTool = buildTool({
         worktreeBranch
       };
     };
+
     if (shouldRunAsync) {
       const asyncAgentId = earlyAgentId;
       const agentBackgroundTask = registerAsyncAgent({
@@ -663,7 +781,13 @@ export const AgentTool = buildTool({
         isBuiltIn: isBuiltInAgent(selectedAgent),
         invokingRequestId: assistantMessage?.requestId,
         invocationKind: 'spawn' as const,
-        invocationEmitted: false
+        invocationEmitted: false,
+        ...(selectedAgent.memory !== undefined ? {
+          memoryAuthorization: {
+            agentType: selectedAgent.agentType,
+            scope: selectedAgent.memory
+          }
+        } : {})
       };
 
       // Workload propagation: handlePromptSubmit wraps the entire turn in
@@ -718,7 +842,13 @@ export const AgentTool = buildTool({
         isBuiltIn: isBuiltInAgent(selectedAgent),
         invokingRequestId: assistantMessage?.requestId,
         invocationKind: 'spawn' as const,
-        invocationEmitted: false
+        invocationEmitted: false,
+        ...(selectedAgent.memory !== undefined ? {
+          memoryAuthorization: {
+            agentType: selectedAgent.agentType,
+            scope: selectedAgent.memory
+          }
+        } : {})
       };
 
       // Wrap entire sync agent execution in context for request attribution

--- a/runtime/src/tools/AgentTool/agentMemory.ts
+++ b/runtime/src/tools/AgentTool/agentMemory.ts
@@ -1,6 +1,27 @@
-import { existsSync, readFileSync } from 'fs'
+import { createHash } from 'node:crypto'
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+} from 'fs'
 import { mkdir } from 'fs/promises'
-import { dirname, join, normalize, sep } from 'path'
+import {
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  parse,
+  relative,
+  sep,
+} from 'path'
+import { peekAmbientRuntimeSession } from '../../session/current-session.js'
 import { getAgenCConfigHomeDir } from '../../utils/envUtils.js'
 
 // Persistent agent memory scope: 'user' (~/.agenc/agent-memory/), 'project' (.agenc/agent-memory/), or 'local' (.agenc/agent-memory-local/)
@@ -12,12 +33,21 @@ const MEMORY_ENTRYPOINT = 'MEMORY.md'
  * Replaces colons (invalid on Windows, used in plugin-namespaced agent
  * types like "my-plugin:my-agent") with dashes.
  */
-function sanitizeAgentTypeForPath(agentType: string): string {
-  return agentType.replace(/:/g, '-')
+export function agentMemoryPathComponent(agentType: string): string {
+  const readable = agentType
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^\.+/, '')
+    .replace(/[. -]+$/, '')
+    .slice(0, 64) || 'agent'
+  const digest = createHash('sha256')
+    .update(agentType)
+    .digest('hex')
+    .slice(0, 16)
+  return `${readable}-${digest}`
 }
 
-function getCwd(): string {
-  return process.cwd()
+function getRoleWorkspaceCwd(): string {
+  return peekAmbientRuntimeSession()?.roleWorkspace.cwd ?? process.cwd()
 }
 
 function findCanonicalGitRoot(start: string): string | undefined {
@@ -34,28 +64,220 @@ function sanitizeProjectPath(path: string): string {
   return path.replace(/[^a-zA-Z0-9._-]+/g, '-')
 }
 
+function projectMemoryNamespace(cwd: string): string {
+  const canonicalProject = normalize(findCanonicalGitRoot(cwd) ?? cwd)
+  const readable = sanitizeProjectPath(canonicalProject).slice(-80) || 'project'
+  const digest = createHash('sha256')
+    .update(canonicalProject)
+    .digest('hex')
+    .slice(0, 16)
+  return `${readable}-${digest}`
+}
+
 /**
  * Returns the local agent memory directory, which is project-specific and not checked into VCS.
  * When AGENC_REMOTE_MEMORY_DIR is set, persists to the mount with project namespacing.
  * Otherwise, uses <cwd>/.agenc/agent-memory-local/<agentType>/.
  */
-function getLocalAgentMemoryDir(dirName: string): string {
+function getLocalAgentMemoryDir(
+  dirName: string,
+  cwd: string = getRoleWorkspaceCwd(),
+): string {
   if (process.env.AGENC_REMOTE_MEMORY_DIR) {
     return (
       join(
         process.env.AGENC_REMOTE_MEMORY_DIR,
         'projects',
-        sanitizeProjectPath(findCanonicalGitRoot(getCwd()) ?? getCwd()),
+        projectMemoryNamespace(cwd),
         'agent-memory-local',
         dirName,
       ) + sep
     )
   }
-  return join(getCwd(), '.agenc', 'agent-memory-local', dirName) + sep
+  return join(cwd, '.agenc', 'agent-memory-local', dirName) + sep
 }
 
 function getMemoryBaseDir(): string {
   return process.env.AGENC_REMOTE_MEMORY_DIR ?? getAgenCConfigHomeDir()
+}
+
+function getAgentMemoryScopeRoot(
+  scope: AgentMemoryScope,
+  cwd: string,
+): string {
+  if (scope === 'user') return join(getMemoryBaseDir(), 'agent-memory')
+  if (scope === 'project') return join(cwd, '.agenc', 'agent-memory')
+  if (process.env.AGENC_REMOTE_MEMORY_DIR) {
+    return join(
+      process.env.AGENC_REMOTE_MEMORY_DIR,
+      'projects',
+      projectMemoryNamespace(cwd),
+      'agent-memory-local',
+    )
+  }
+  return join(cwd, '.agenc', 'agent-memory-local')
+}
+
+function getAgentMemoryTrustAnchor(
+  scope: AgentMemoryScope,
+  cwd: string,
+): string {
+  if (scope === 'user') return getMemoryBaseDir()
+  if (scope === 'local' && process.env.AGENC_REMOTE_MEMORY_DIR) {
+    return process.env.AGENC_REMOTE_MEMORY_DIR
+  }
+  return cwd
+}
+
+function legacyAgentMemoryPathComponent(agentType: string): string | null {
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(agentType) &&
+    agentType !== '.' &&
+    agentType !== '..'
+    ? agentType
+    : null
+}
+
+/**
+ * Move an unambiguous pre-hash safe-name directory into the hashed namespace.
+ * Names that were lossy (`:` replacement), traversal-capable, case-mismatched,
+ * symlinked, or outside the trusted tier are deliberately never adopted.
+ */
+export function migrateLegacyAgentScopedDirectory(
+  parentDir: string,
+  trustAnchor: string,
+  agentType: string,
+): string {
+  const targetDir = join(parentDir, agentMemoryPathComponent(agentType))
+  const legacyComponent = legacyAgentMemoryPathComponent(agentType)
+  if (legacyComponent === null || existsSync(targetDir)) return targetDir
+  try {
+    const canonicalAnchor = realpathSync(trustAnchor)
+    const canonicalParent = realpathSync(parentDir)
+    if (!isSameOrChildPath(canonicalAnchor, canonicalParent)) return targetDir
+    // Exact-case directory enumeration avoids adopting Foo for a requested
+    // `foo` on case-insensitive filesystems.
+    if (!readdirSync(parentDir).includes(legacyComponent)) return targetDir
+    const legacyDir = join(parentDir, legacyComponent)
+    const lexicalLegacy = lstatSync(legacyDir)
+    if (!lexicalLegacy.isDirectory() || lexicalLegacy.isSymbolicLink()) {
+      return targetDir
+    }
+    const canonicalLegacy = realpathSync(legacyDir)
+    if (!isSameOrChildPath(canonicalParent, canonicalLegacy)) return targetDir
+    renameSync(legacyDir, targetDir)
+  } catch {
+    // Another process may win the one-time migration. The hashed target is
+    // the only path callers will subsequently trust.
+  }
+  return targetDir
+}
+
+export function ensureAgentMemoryDir(
+  agentType: string,
+  scope: AgentMemoryScope,
+  cwd: string = getRoleWorkspaceCwd(),
+): string {
+  const directory = migrateLegacyAgentScopedDirectory(
+    getAgentMemoryScopeRoot(scope, cwd),
+    getAgentMemoryTrustAnchor(scope, cwd),
+    agentType,
+  )
+  assertTrustedAgentScopedDirectory(
+    directory,
+    getAgentMemoryTrustAnchor(scope, cwd),
+  )
+  return directory + sep
+}
+
+function isSameOrChildPath(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate)
+  return child === '' || (
+    child !== '..' &&
+    !child.startsWith(`..${sep}`) &&
+    !isAbsolute(child)
+  )
+}
+
+export function assertTrustedAgentScopedDirectory(
+  directory: string,
+  trustAnchor: string,
+): void {
+  const canonicalAnchor = realpathSync(trustAnchor)
+  let existing = directory
+  while (!existsSync(existing)) {
+    const parent = dirname(existing)
+    if (parent === existing) {
+      throw new Error('agent memory path has no trusted existing ancestor')
+    }
+    existing = parent
+  }
+  const lexicalExisting = lstatSync(existing)
+  if (existing !== trustAnchor && lexicalExisting.isSymbolicLink()) {
+    throw new Error('agent memory path contains a symlinked directory')
+  }
+  const canonicalExisting = realpathSync(existing)
+  if (!isSameOrChildPath(canonicalAnchor, canonicalExisting)) {
+    throw new Error('agent memory path escapes its role workspace')
+  }
+  if (existsSync(directory)) {
+    const lexicalDirectory = lstatSync(directory)
+    if (!lexicalDirectory.isDirectory() || lexicalDirectory.isSymbolicLink()) {
+      throw new Error('agent memory directory is not a trusted directory')
+    }
+    if (!isSameOrChildPath(canonicalAnchor, realpathSync(directory))) {
+      throw new Error('agent memory directory escapes its role workspace')
+    }
+  }
+}
+
+function readRegularMemoryEntrypoint(
+  entrypoint: string,
+  memoryDir: string,
+  scope: AgentMemoryScope,
+  cwd: string,
+): string {
+  let fd: number | undefined
+  try {
+    const lexical = lstatSync(entrypoint)
+    if (!lexical.isFile() || lexical.isSymbolicLink()) return ''
+    if (lstatSync(memoryDir).isSymbolicLink()) return ''
+    const canonicalAnchor = realpathSync(
+      getAgentMemoryTrustAnchor(scope, cwd),
+    )
+    const canonicalScopeRoot = realpathSync(
+      getAgentMemoryScopeRoot(scope, cwd),
+    )
+    const canonicalDir = realpathSync(memoryDir)
+    const canonicalEntrypoint = realpathSync(entrypoint)
+    if (
+      !isSameOrChildPath(canonicalAnchor, canonicalScopeRoot) ||
+      !isSameOrChildPath(canonicalScopeRoot, canonicalDir) ||
+      !isSameOrChildPath(canonicalDir, canonicalEntrypoint) ||
+      canonicalDir === canonicalEntrypoint
+    ) {
+      return ''
+    }
+    fd = openSync(
+      entrypoint,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    )
+    const opened = fstatSync(fd)
+    if (
+      !opened.isFile() ||
+      opened.dev !== lexical.dev ||
+      opened.ino !== lexical.ino
+    ) {
+      return ''
+    }
+    const content = readFileSync(fd, 'utf8')
+    const afterRead = fstatSync(fd)
+    if (afterRead.dev !== opened.dev || afterRead.ino !== opened.ino) return ''
+    return content.trim()
+  } catch {
+    return ''
+  } finally {
+    if (fd !== undefined) closeSync(fd)
+  }
 }
 
 /**
@@ -67,55 +289,127 @@ function getMemoryBaseDir(): string {
 export function getAgentMemoryDir(
   agentType: string,
   scope: AgentMemoryScope,
+  cwd: string = getRoleWorkspaceCwd(),
 ): string {
-  const dirName = sanitizeAgentTypeForPath(agentType)
+  const dirName = agentMemoryPathComponent(agentType)
   switch (scope) {
     case 'project':
-      return join(getCwd(), '.agenc', 'agent-memory', dirName) + sep
+      return join(cwd, '.agenc', 'agent-memory', dirName) + sep
     case 'local':
-      return getLocalAgentMemoryDir(dirName)
+      return getLocalAgentMemoryDir(dirName, cwd)
     case 'user':
       return join(getMemoryBaseDir(), 'agent-memory', dirName) + sep
   }
 }
 
-// Check if file is within an agent memory directory (any scope).
-export function isAgentMemoryPath(absolutePath: string): boolean {
-  // SECURITY: Normalize to prevent path traversal bypasses via .. segments
-  const normalizedPath = normalize(absolutePath)
-  const memoryBase = getMemoryBaseDir()
-
-  // User scope: check memory base (may be custom dir or config home)
-  if (normalizedPath.startsWith(join(memoryBase, 'agent-memory') + sep)) {
-    return true
+function normalizePathBoundary(path: string): string {
+  const normalized = normalize(path)
+  const root = parse(normalized).root
+  let boundary = normalized
+  while (boundary.length > root.length && boundary.endsWith(sep)) {
+    boundary = boundary.slice(0, -1)
   }
+  return boundary
+}
 
-  // Project scope: always cwd-based (not redirected)
+function isWithinPathBoundary(candidate: string, base: string): boolean {
+  const normalizedCandidate = normalizePathBoundary(candidate)
+  const normalizedBase = normalizePathBoundary(base)
+  return normalizedCandidate === normalizedBase ||
+    normalizedCandidate.startsWith(normalizedBase + sep)
+}
+
+/**
+ * Classifies paths under any agent-memory root for privacy/redaction. This is
+ * intentionally independent of the current agent identity; it must not be
+ * used to grant filesystem permissions.
+ */
+export function isAnyAgentMemoryPath(
+  absolutePath: string,
+  roleWorkspaceCwd: string = getRoleWorkspaceCwd(),
+): boolean {
   if (
-    normalizedPath.startsWith(join(getCwd(), '.agenc', 'agent-memory') + sep)
-  ) {
-    return true
-  }
-
-  // Local scope: persisted to mount when AGENC_REMOTE_MEMORY_DIR is set, otherwise cwd-based
-  if (process.env.AGENC_REMOTE_MEMORY_DIR) {
-    if (
-      normalizedPath.includes(sep + 'agent-memory-local' + sep) &&
-      normalizedPath.startsWith(
-        join(process.env.AGENC_REMOTE_MEMORY_DIR, 'projects') + sep,
-      )
-    ) {
-      return true
-    }
-  } else if (
-    normalizedPath.startsWith(
-      join(getCwd(), '.agenc', 'agent-memory-local') + sep,
+    isWithinPathBoundary(
+      absolutePath,
+      join(getMemoryBaseDir(), 'agent-memory'),
+    ) ||
+    isWithinPathBoundary(
+      absolutePath,
+      join(roleWorkspaceCwd, '.agenc', 'agent-memory'),
     )
   ) {
     return true
   }
 
-  return false
+  // Project/local memory is a reserved namespace in every workspace, not only
+  // the current role workspace. This broader classification is used for
+  // privacy and fail-closed permission decisions; exact authorization below
+  // still requires the current workspace and agent identity to match.
+  const pathSegments = normalizePathBoundary(absolutePath)
+    .split(sep)
+    .filter(Boolean)
+    .map(segment => segment.toLowerCase())
+  for (let index = 0; index < pathSegments.length - 1; index += 1) {
+    if (
+      pathSegments[index] === '.agenc' &&
+      (pathSegments[index + 1] === 'agent-memory' ||
+        pathSegments[index + 1] === 'agent-memory-local')
+    ) {
+      return true
+    }
+  }
+
+  const remoteMemoryDir = process.env.AGENC_REMOTE_MEMORY_DIR
+  if (!remoteMemoryDir) {
+    return isWithinPathBoundary(
+      absolutePath,
+      join(roleWorkspaceCwd, '.agenc', 'agent-memory-local'),
+    )
+  }
+
+  const projectsRoot = join(remoteMemoryDir, 'projects')
+  if (!isWithinPathBoundary(absolutePath, projectsRoot)) return false
+  const relativePath = relative(
+    normalizePathBoundary(projectsRoot),
+    normalizePathBoundary(absolutePath),
+  )
+  const segments = relativePath.split(sep).filter(Boolean)
+  return segments.length >= 2 && segments[1] === 'agent-memory-local'
+}
+
+/** Check whether a path is in this agent's one authorized memory directory. */
+export function isAuthorizedAgentMemoryPath(
+  absolutePath: string,
+  roleWorkspaceCwd: string | null | undefined = undefined,
+  authorization?: {
+    readonly agentType: string
+    readonly scope: AgentMemoryScope
+  },
+): boolean {
+  if (authorization === undefined) return false
+  const scopedCwd = roleWorkspaceCwd === undefined
+    ? getRoleWorkspaceCwd()
+    : roleWorkspaceCwd
+  if (scopedCwd === null && authorization.scope !== 'user') return false
+  const memoryDir = normalizePathBoundary(getAgentMemoryDir(
+    authorization.agentType,
+    authorization.scope,
+    scopedCwd ?? process.cwd(),
+  ))
+  if (!isWithinPathBoundary(absolutePath, memoryDir)) return false
+
+  // The permission carve-out is authority-bearing: an in-boundary hardlink
+  // would otherwise grant silent access to the same inode through an external
+  // pathname. Missing targets remain eligible so an authorized agent can
+  // create new memory files; observable non-regular, symlink, and multiply
+  // linked targets fail closed. The permission layer also checks every
+  // lexical/resolved path form, closing intermediate-directory symlink cases.
+  try {
+    const target = lstatSync(absolutePath)
+    return target.isFile() && !target.isSymbolicLink() && target.nlink === 1
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+  }
 }
 
 /**
@@ -124,8 +418,9 @@ export function isAgentMemoryPath(absolutePath: string): boolean {
 export function getAgentMemoryEntrypoint(
   agentType: string,
   scope: AgentMemoryScope,
+  cwd: string = getRoleWorkspaceCwd(),
 ): string {
-  return join(getAgentMemoryDir(agentType, scope), 'MEMORY.md')
+  return join(getAgentMemoryDir(agentType, scope, cwd), 'MEMORY.md')
 }
 
 export function getMemoryScopeDisplay(
@@ -153,6 +448,7 @@ export function getMemoryScopeDisplay(
 export function loadAgentMemoryPrompt(
   agentType: string,
   scope: AgentMemoryScope,
+  cwd: string = getRoleWorkspaceCwd(),
 ): string {
   let scopeNote: string
   switch (scope) {
@@ -170,7 +466,16 @@ export function loadAgentMemoryPrompt(
       break
   }
 
-  const memoryDir = getAgentMemoryDir(agentType, scope)
+  let memoryDir: string
+  try {
+    memoryDir = ensureAgentMemoryDir(agentType, scope, cwd)
+  } catch {
+    return [
+      '# Persistent Agent Memory',
+      '',
+      'Memory unavailable: the configured directory failed workspace safety checks.',
+    ].join('\n')
+  }
 
   void mkdir(memoryDir, { recursive: true }).catch(() => {})
 
@@ -181,12 +486,12 @@ export function loadAgentMemoryPrompt(
       ? [scopeNote, coworkExtraGuidelines]
       : [scopeNote]
   const entrypoint = join(memoryDir, MEMORY_ENTRYPOINT)
-  let entrypointContent = ''
-  try {
-    entrypointContent = readFileSync(entrypoint, 'utf8').trim()
-  } catch {
-    entrypointContent = ''
-  }
+  const entrypointContent = readRegularMemoryEntrypoint(
+    entrypoint,
+    memoryDir,
+    scope,
+    cwd,
+  )
 
   return [
     '# Persistent Agent Memory',

--- a/runtime/src/tools/AgentTool/agentMemorySnapshot.ts
+++ b/runtime/src/tools/AgentTool/agentMemorySnapshot.ts
@@ -1,15 +1,49 @@
-import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises'
-import { join } from 'path'
+import { constants } from 'fs'
+import {
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  readdir,
+  realpath,
+  unlink,
+} from 'fs/promises'
+import { basename, isAbsolute, join, relative, sep } from 'path'
 import { z } from 'zod/v4'
 import { getCwd } from '../../utils/cwd.js'
 import { logForDebugging } from '../../utils/debug.js'
+import { getAgenCConfigHomeDir } from '../../utils/envUtils.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { jsonParse, jsonStringify } from '../../utils/slowOperations.js'
-import { type AgentMemoryScope, getAgentMemoryDir } from './agentMemory.js'
+import {
+  agentMemoryPathComponent,
+  assertTrustedAgentScopedDirectory,
+  ensureAgentMemoryDir,
+  type AgentMemoryScope,
+  migrateLegacyAgentScopedDirectory,
+} from './agentMemory.js'
 
 const SNAPSHOT_BASE = 'agent-memory-snapshots'
 const SNAPSHOT_JSON = 'snapshot.json'
 const SYNCED_JSON = '.snapshot-synced.json'
+
+type SnapshotFileOperation = 'write' | 'delete'
+type SnapshotFileOperationForTesting = (operation: {
+  readonly operation: SnapshotFileOperation
+  readonly trustedDirectory: string
+  readonly filename: string
+}) => void | Promise<void>
+
+let snapshotFileOperationForTesting:
+  | SnapshotFileOperationForTesting
+  | undefined
+
+/** Test-only seam for deterministic validation-to-operation race coverage. */
+export function __setAgentMemorySnapshotFileOperationForTesting(
+  operation: SnapshotFileOperationForTesting | undefined,
+): void {
+  snapshotFileOperationForTesting = operation
+}
 
 const snapshotMetaSchema = lazySchema(() =>
   z.object({
@@ -28,24 +62,48 @@ type SyncedMeta = z.infer<ReturnType<typeof syncedMetaSchema>>
  * Returns the path to the snapshot directory for an agent in the current project.
  * e.g., <cwd>/.agenc/agent-memory-snapshots/<agentType>/
  */
-export function getSnapshotDirForAgent(agentType: string): string {
-  return join(getCwd(), '.agenc', SNAPSHOT_BASE, agentType)
+export function getSnapshotDirForAgent(
+  agentType: string,
+  cwd: string = getCwd(),
+): string {
+  return join(
+    cwd,
+    '.agenc',
+    SNAPSHOT_BASE,
+    agentMemoryPathComponent(agentType),
+  )
 }
 
-function getSnapshotJsonPath(agentType: string): string {
-  return join(getSnapshotDirForAgent(agentType), SNAPSHOT_JSON)
+function ensureSnapshotDirForAgent(agentType: string, cwd: string): string {
+  const parentDir = join(cwd, '.agenc', SNAPSHOT_BASE)
+  const directory = migrateLegacyAgentScopedDirectory(
+    parentDir,
+    cwd,
+    agentType,
+  )
+  assertTrustedAgentScopedDirectory(directory, cwd)
+  return directory
 }
 
-function getSyncedJsonPath(agentType: string, scope: AgentMemoryScope): string {
-  return join(getAgentMemoryDir(agentType, scope), SYNCED_JSON)
+function getSyncedJsonPath(
+  agentType: string,
+  scope: AgentMemoryScope,
+  cwd: string,
+): string {
+  return join(ensureAgentMemoryDir(agentType, scope, cwd), SYNCED_JSON)
 }
 
 async function readJsonFile<T>(
   path: string,
+  trustedDirectory: string,
   schema: z.ZodType<T>,
 ): Promise<T | null> {
   try {
-    const content = await readFile(path, { encoding: 'utf-8' })
+    const content = await readRegularFileWithinDirectory(
+      path,
+      trustedDirectory,
+    )
+    if (content === null) return null
     const result = schema.safeParse(jsonParse(content))
     return result.success ? result.data : null
   } catch {
@@ -53,23 +111,373 @@ async function readJsonFile<T>(
   }
 }
 
+function isSameOrChildPath(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate)
+  return child === '' || (
+    child !== '..' &&
+    !child.startsWith(`..${sep}`) &&
+    !isAbsolute(child)
+  )
+}
+
+type DirectoryHandle = Awaited<ReturnType<typeof open>>
+type DirectoryStream = Awaited<ReturnType<typeof opendir>>
+
+interface PinnedTrustedDirectory {
+  readonly path: string
+  readonly canonicalPath: string
+  readonly canonicalTrustAnchor: string
+  readonly dev: number | bigint
+  readonly ino: number | bigint
+  readonly handle: DirectoryHandle | undefined
+  readonly stream: DirectoryStream | undefined
+  readonly operationPath: string
+}
+
+function isSameIdentity(
+  actual: { readonly dev: number | bigint; readonly ino: number | bigint },
+  expected: { readonly dev: number | bigint; readonly ino: number | bigint },
+): boolean {
+  return actual.dev === expected.dev && actual.ino === expected.ino
+}
+
+async function assertPinnedDirectoryCurrent(
+  pinned: PinnedTrustedDirectory,
+): Promise<void> {
+  const [lexical, canonical, opened] = await Promise.all([
+    lstat(pinned.path),
+    realpath(pinned.path),
+    pinned.handle?.stat(),
+  ])
+  if (
+    !lexical.isDirectory() ||
+    lexical.isSymbolicLink() ||
+    !isSameIdentity(lexical, pinned) ||
+    canonical !== pinned.canonicalPath ||
+    !isSameOrChildPath(pinned.canonicalTrustAnchor, canonical) ||
+    (opened !== undefined &&
+      (!opened.isDirectory() || !isSameIdentity(opened, pinned)))
+  ) {
+    throw new Error('agent memory snapshot directory changed during operation')
+  }
+}
+
+async function pinTrustedDirectory(
+  trustedDirectory: string,
+  trustAnchor: string,
+): Promise<PinnedTrustedDirectory> {
+  const [lexical, canonicalPath, canonicalTrustAnchor] = await Promise.all([
+    lstat(trustedDirectory),
+    realpath(trustedDirectory),
+    realpath(trustAnchor),
+  ])
+  if (
+    !lexical.isDirectory() ||
+    lexical.isSymbolicLink() ||
+    !isSameOrChildPath(canonicalTrustAnchor, canonicalPath)
+  ) {
+    throw new Error('agent memory snapshot directory is not trusted')
+  }
+
+  let handle: DirectoryHandle | undefined
+  let stream: DirectoryStream | undefined
+  try {
+    handle = await open(
+      trustedDirectory,
+      constants.O_RDONLY |
+        (constants.O_DIRECTORY ?? 0) |
+        (constants.O_NOFOLLOW ?? 0),
+    )
+  } catch (error) {
+    // Windows does not consistently permit opening a directory as a file
+    // handle. Keep an opendir handle pinned instead of proceeding unpinned.
+    if (process.platform !== 'win32') throw error
+    stream = await opendir(trustedDirectory)
+  }
+
+  try {
+    const opened = await handle?.stat()
+    if (
+      opened !== undefined &&
+      (!opened.isDirectory() || !isSameIdentity(opened, lexical))
+    ) {
+      throw new Error('agent memory snapshot directory changed while opening')
+    }
+
+    let operationPath = canonicalPath
+    if (handle !== undefined) {
+      const descriptorPaths = process.platform === 'linux'
+        ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
+        : [`/dev/fd/${handle.fd}`]
+      for (const descriptorPath of descriptorPaths) {
+        try {
+          if (await realpath(descriptorPath) === canonicalPath) {
+            // Resolve child operations through the pinned directory inode so
+            // a pathname replacement cannot redirect them to a symlink target.
+            operationPath = descriptorPath
+            break
+          }
+        } catch {
+          // Descriptor paths are optional and unavailable on some platforms
+          // or in restricted environments. Identity checks remain mandatory.
+        }
+      }
+    }
+
+    const pinned: PinnedTrustedDirectory = {
+      path: trustedDirectory,
+      canonicalPath,
+      canonicalTrustAnchor,
+      dev: lexical.dev,
+      ino: lexical.ino,
+      handle,
+      stream,
+      operationPath,
+    }
+    await assertPinnedDirectoryCurrent(pinned)
+    return pinned
+  } catch (error) {
+    await handle?.close().catch(() => {})
+    await stream?.close().catch(() => {})
+    throw error
+  }
+}
+
+async function closePinnedDirectory(
+  pinned: PinnedTrustedDirectory,
+): Promise<void> {
+  await pinned.handle?.close().catch(() => {})
+  await pinned.stream?.close().catch(() => {})
+}
+
+function validateSnapshotFilename(filename: string): void {
+  if (basename(filename) !== filename || filename === '.' || filename === '..') {
+    throw new Error('invalid agent memory snapshot filename')
+  }
+}
+
+function getMemoryTrustAnchor(
+  scope: AgentMemoryScope,
+  cwd: string,
+): string {
+  const remoteMemoryDirectory = process.env.AGENC_REMOTE_MEMORY_DIR
+  if (scope === 'user') {
+    return remoteMemoryDirectory ?? getAgenCConfigHomeDir()
+  }
+  if (scope === 'local' && remoteMemoryDirectory) {
+    return remoteMemoryDirectory
+  }
+  return cwd
+}
+
+async function readRegularFileWithinDirectory(
+  path: string,
+  trustedDirectory: string,
+): Promise<string | null> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  try {
+    const lexical = await lstat(path)
+    if (!lexical.isFile() || lexical.isSymbolicLink()) return null
+    const canonicalDirectory = await realpath(trustedDirectory)
+    const canonicalFile = await realpath(path)
+    if (!isSameOrChildPath(canonicalDirectory, canonicalFile)) return null
+    handle = await open(
+      path,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    )
+    const opened = await handle.stat()
+    if (
+      !opened.isFile() ||
+      opened.dev !== lexical.dev ||
+      opened.ino !== lexical.ino
+    ) {
+      return null
+    }
+    const content = await handle.readFile({ encoding: 'utf-8' })
+    const [afterRead, canonicalAfterRead] = await Promise.all([
+      handle.stat(),
+      realpath(path),
+    ])
+    if (
+      afterRead.dev !== opened.dev ||
+      afterRead.ino !== opened.ino ||
+      canonicalAfterRead !== canonicalFile ||
+      !isSameOrChildPath(canonicalDirectory, canonicalAfterRead)
+    ) {
+      return null
+    }
+    return content
+  } catch {
+    return null
+  } finally {
+    await handle?.close().catch(() => {})
+  }
+}
+
+async function writeRegularFileWithinDirectory(
+  trustedDirectory: string,
+  trustAnchor: string,
+  filename: string,
+  content: string,
+): Promise<void> {
+  validateSnapshotFilename(filename)
+  const pinned = await pinTrustedDirectory(trustedDirectory, trustAnchor)
+  const path = join(pinned.operationPath, filename)
+  let existingIdentity: {
+    readonly dev: number | bigint
+    readonly ino: number | bigint
+  } | undefined
+  try {
+    try {
+      const existing = await lstat(path)
+      if (
+        !existing.isFile() ||
+        existing.isSymbolicLink() ||
+        existing.nlink !== 1
+      ) {
+        throw new Error('snapshot destination is not a private regular file')
+      }
+      existingIdentity = { dev: existing.dev, ino: existing.ino }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+
+    await snapshotFileOperationForTesting?.({
+      operation: 'write',
+      trustedDirectory,
+      filename,
+    })
+    await assertPinnedDirectoryCurrent(pinned)
+
+    if (existingIdentity === undefined) {
+      try {
+        await lstat(path)
+        throw new Error('snapshot destination appeared during operation')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+    } else {
+      const current = await lstat(path)
+      if (
+        !current.isFile() ||
+        current.isSymbolicLink() ||
+        current.nlink !== 1 ||
+        !isSameIdentity(current, existingIdentity)
+      ) {
+        throw new Error('snapshot destination changed during operation')
+      }
+    }
+
+    const handle = await open(
+      path,
+      constants.O_WRONLY |
+        (existingIdentity === undefined
+          ? constants.O_CREAT | constants.O_EXCL
+          : 0) |
+        (constants.O_NOFOLLOW ?? 0),
+      0o600,
+    )
+    try {
+      const opened = await handle.stat()
+      if (
+        !opened.isFile() ||
+        opened.nlink !== 1 ||
+        (existingIdentity !== undefined &&
+          !isSameIdentity(opened, existingIdentity))
+      ) {
+        throw new Error('snapshot destination is unsafe')
+      }
+      await assertPinnedDirectoryCurrent(pinned)
+      const canonicalFile = await realpath(path)
+      if (!isSameOrChildPath(pinned.canonicalPath, canonicalFile)) {
+        throw new Error('snapshot destination escapes its memory directory')
+      }
+      await handle.truncate(0)
+      await handle.writeFile(content, { encoding: 'utf-8' })
+      const afterWrite = await handle.stat()
+      if (!isSameIdentity(afterWrite, opened)) {
+        throw new Error('snapshot destination changed while writing')
+      }
+      await assertPinnedDirectoryCurrent(pinned)
+    } finally {
+      await handle.close()
+    }
+  } finally {
+    await closePinnedDirectory(pinned)
+  }
+}
+
+async function deleteRegularFileWithinDirectory(
+  trustedDirectory: string,
+  trustAnchor: string,
+  filename: string,
+): Promise<void> {
+  validateSnapshotFilename(filename)
+  const pinned = await pinTrustedDirectory(trustedDirectory, trustAnchor)
+  const path = join(pinned.operationPath, filename)
+  try {
+    const existing = await lstat(path)
+    if (
+      !existing.isFile() ||
+      existing.isSymbolicLink() ||
+      existing.nlink !== 1
+    ) {
+      throw new Error('snapshot deletion target is not a private regular file')
+    }
+
+    await snapshotFileOperationForTesting?.({
+      operation: 'delete',
+      trustedDirectory,
+      filename,
+    })
+    await assertPinnedDirectoryCurrent(pinned)
+
+    const current = await lstat(path)
+    if (
+      !current.isFile() ||
+      current.isSymbolicLink() ||
+      current.nlink !== 1 ||
+      !isSameIdentity(current, existing)
+    ) {
+      throw new Error('snapshot deletion target changed during operation')
+    }
+    const canonicalFile = await realpath(path)
+    if (!isSameOrChildPath(pinned.canonicalPath, canonicalFile)) {
+      throw new Error('snapshot deletion target escapes its memory directory')
+    }
+    await unlink(path)
+    await assertPinnedDirectoryCurrent(pinned)
+  } finally {
+    await closePinnedDirectory(pinned)
+  }
+}
+
 async function copySnapshotToLocal(
   agentType: string,
   scope: AgentMemoryScope,
+  cwd: string,
 ): Promise<void> {
-  const snapshotMemDir = getSnapshotDirForAgent(agentType)
-  const localMemDir = getAgentMemoryDir(agentType, scope)
+  const snapshotMemDir = ensureSnapshotDirForAgent(agentType, cwd)
+  const localMemDir = ensureAgentMemoryDir(agentType, scope, cwd)
 
   await mkdir(localMemDir, { recursive: true })
+  ensureAgentMemoryDir(agentType, scope, cwd)
 
   try {
     const files = await readdir(snapshotMemDir, { withFileTypes: true })
     for (const dirent of files) {
       if (!dirent.isFile() || dirent.name === SNAPSHOT_JSON) continue
-      const content = await readFile(join(snapshotMemDir, dirent.name), {
-        encoding: 'utf-8',
-      })
-      await writeFile(join(localMemDir, dirent.name), content)
+      const content = await readRegularFileWithinDirectory(
+        join(snapshotMemDir, dirent.name),
+        snapshotMemDir,
+      )
+      if (content === null) continue
+      await writeRegularFileWithinDirectory(
+        localMemDir,
+        getMemoryTrustAnchor(scope, cwd),
+        dirent.name,
+        content,
+      )
     }
   } catch (e) {
     logForDebugging(`Failed to copy snapshot to local agent memory: ${e}`)
@@ -80,13 +488,19 @@ async function saveSyncedMeta(
   agentType: string,
   scope: AgentMemoryScope,
   snapshotTimestamp: string,
+  cwd: string,
 ): Promise<void> {
-  const syncedPath = getSyncedJsonPath(agentType, scope)
-  const localMemDir = getAgentMemoryDir(agentType, scope)
+  const localMemDir = ensureAgentMemoryDir(agentType, scope, cwd)
   await mkdir(localMemDir, { recursive: true })
+  ensureAgentMemoryDir(agentType, scope, cwd)
   const meta: SyncedMeta = { syncedFrom: snapshotTimestamp }
   try {
-    await writeFile(syncedPath, jsonStringify(meta))
+    await writeRegularFileWithinDirectory(
+      localMemDir,
+      getMemoryTrustAnchor(scope, cwd),
+      SYNCED_JSON,
+      jsonStringify(meta),
+    )
   } catch (e) {
     logForDebugging(`Failed to save snapshot sync metadata: ${e}`)
   }
@@ -98,12 +512,15 @@ async function saveSyncedMeta(
 export async function checkAgentMemorySnapshot(
   agentType: string,
   scope: AgentMemoryScope,
+  cwd: string = getCwd(),
 ): Promise<{
   action: 'none' | 'initialize' | 'prompt-update'
   snapshotTimestamp?: string
 }> {
+  const snapshotDir = ensureSnapshotDirForAgent(agentType, cwd)
   const snapshotMeta = await readJsonFile(
-    getSnapshotJsonPath(agentType),
+    join(snapshotDir, SNAPSHOT_JSON),
+    snapshotDir,
     snapshotMetaSchema(),
   )
 
@@ -111,7 +528,7 @@ export async function checkAgentMemorySnapshot(
     return { action: 'none' }
   }
 
-  const localMemDir = getAgentMemoryDir(agentType, scope)
+  const localMemDir = ensureAgentMemoryDir(agentType, scope, cwd)
 
   let hasLocalMemory = false
   try {
@@ -126,7 +543,8 @@ export async function checkAgentMemorySnapshot(
   }
 
   const syncedMeta = await readJsonFile(
-    getSyncedJsonPath(agentType, scope),
+    getSyncedJsonPath(agentType, scope, cwd),
+    localMemDir,
     syncedMetaSchema(),
   )
 
@@ -150,12 +568,13 @@ export async function initializeFromSnapshot(
   agentType: string,
   scope: AgentMemoryScope,
   snapshotTimestamp: string,
+  cwd: string = getCwd(),
 ): Promise<void> {
   logForDebugging(
     `Initializing agent memory for ${agentType} from project snapshot`,
   )
-  await copySnapshotToLocal(agentType, scope)
-  await saveSyncedMeta(agentType, scope, snapshotTimestamp)
+  await copySnapshotToLocal(agentType, scope, cwd)
+  await saveSyncedMeta(agentType, scope, snapshotTimestamp, cwd)
 }
 
 /**
@@ -165,24 +584,29 @@ export async function replaceFromSnapshot(
   agentType: string,
   scope: AgentMemoryScope,
   snapshotTimestamp: string,
+  cwd: string = getCwd(),
 ): Promise<void> {
   logForDebugging(
     `Replacing agent memory for ${agentType} with project snapshot`,
   )
   // Remove existing .md files before copying to avoid orphans
-  const localMemDir = getAgentMemoryDir(agentType, scope)
+  const localMemDir = ensureAgentMemoryDir(agentType, scope, cwd)
   try {
     const existing = await readdir(localMemDir, { withFileTypes: true })
     for (const dirent of existing) {
       if (dirent.isFile() && dirent.name.endsWith('.md')) {
-        await unlink(join(localMemDir, dirent.name))
+        await deleteRegularFileWithinDirectory(
+          localMemDir,
+          getMemoryTrustAnchor(scope, cwd),
+          dirent.name,
+        )
       }
     }
   } catch {
     // Directory may not exist yet
   }
-  await copySnapshotToLocal(agentType, scope)
-  await saveSyncedMeta(agentType, scope, snapshotTimestamp)
+  await copySnapshotToLocal(agentType, scope, cwd)
+  await saveSyncedMeta(agentType, scope, snapshotTimestamp, cwd)
 }
 
 /**
@@ -192,6 +616,7 @@ export async function markSnapshotSynced(
   agentType: string,
   scope: AgentMemoryScope,
   snapshotTimestamp: string,
+  cwd: string = getCwd(),
 ): Promise<void> {
-  await saveSyncedMeta(agentType, scope, snapshotTimestamp)
+  await saveSyncedMeta(agentType, scope, snapshotTimestamp, cwd)
 }

--- a/runtime/src/tools/AgentTool/loadAgentsDir.ts
+++ b/runtime/src/tools/AgentTool/loadAgentsDir.ts
@@ -1,20 +1,39 @@
 import {
   type Dirent,
+  closeSync,
+  constants,
   existsSync,
+  fstatSync,
   lstatSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
   statSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
-import { basename, dirname, join, resolve } from 'node:path'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path'
 
 import yaml from 'js-yaml'
 import memoize from 'lodash-es/memoize.js'
 import { z } from 'zod/v4'
 
-import { listAgentRoles } from '../../agents/role.js'
+import {
+  createAgentRoleWorkspace,
+  listBuiltInAgentRoles,
+  listRegisteredAgentRoles,
+} from '../../agents/role.js'
+import { canonicalAgentRoleName } from '../../agents/role-presentation.js'
+import { agentDefinitionFingerprint } from '../../agents/agent-definition-fingerprint.js'
+import type { AgentRoleWorkspace } from '../../agents/role.js'
 import {
   USER_ADDRESSABLE_PERMISSION_MODES,
   type PermissionMode,
@@ -134,6 +153,10 @@ export type BaseAgentDefinition = {
   isolation?: 'worktree' | 'remote'
   pendingSnapshotUpdate?: { snapshotTimestamp: string }
   omitAgenCMd?: boolean
+  /** Content identity used to fail closed when a named role changes. */
+  agentRoleFingerprint?: string
+  /** Immutable base prompt before mutable persistent-memory augmentation. */
+  roleDefinitionPrompt?: string
 }
 
 export type BuiltInAgentDefinition = BaseAgentDefinition & {
@@ -165,10 +188,37 @@ export type AgentDefinition =
   | PluginAgentDefinition
 
 export type AgentDefinitionsResult = {
+  /** Immutable trust domain for every definition in this catalog. */
+  agentRoleWorkspaceId?: string
   activeAgents: AgentDefinition[]
   allAgents: AgentDefinition[]
   failedFiles?: FailedAgentFile[]
   allowedAgentTypes?: string[]
+}
+
+export type WorkspaceAgentDefinitionsResult = AgentDefinitionsResult & {
+  readonly agentRoleWorkspaceId: string
+}
+
+/**
+ * Resolve a public type without allowing an earlier canonical alias to hide
+ * an exact workspace or plugin definition. Catalog ordering is not an
+ * authority boundary: exact names win, then public aliases may fall back to
+ * their canonical built-in role.
+ */
+export function findAgentDefinitionByType(
+  definitions: readonly AgentDefinition[],
+  requestedType: string,
+): AgentDefinition | undefined {
+  const exact = definitions.find(
+    definition => definition.agentType === requestedType,
+  )
+  if (exact !== undefined) return exact
+  const canonicalType = canonicalAgentRoleName(requestedType)
+  return definitions.find(
+    definition =>
+      canonicalAgentRoleName(definition.agentType) === canonicalType,
+  )
 }
 
 type FailedAgentFile = { path: string; error: string }
@@ -403,9 +453,10 @@ function systemPromptWithMemory(
   agentType: string,
   systemPrompt: string,
   memory: AgentMemoryScope | undefined,
+  roleCwd: string,
 ): string {
   if (!memory || !isAutoMemoryEnabled()) return systemPrompt
-  return `${systemPrompt}\n\n${loadAgentMemoryPrompt(agentType, memory)}`
+  return `${systemPrompt}\n\n${loadAgentMemoryPrompt(agentType, memory, roleCwd)}`
 }
 
 function isAutoMemoryEnabled(): boolean {
@@ -417,18 +468,18 @@ function isAutoMemoryEnabled(): boolean {
 }
 
 export function roleToAgentDefinition(
-  role: ReturnType<typeof listAgentRoles>[number],
+  role: ReturnType<typeof listBuiltInAgentRoles>[number],
 ): BuiltInAgentDefinition {
   const description = role.config.description ?? role.name
   const systemPrompt = role.config.systemPrompt ?? ''
   const tools = role.config.allowlist
     ? Array.from(role.config.allowlist)
     : undefined
-  return {
+  const definition = {
     agentType: role.name,
     whenToUse: description,
-    source: 'built-in',
-    baseDir: 'built-in',
+    source: 'built-in' as const,
+    baseDir: 'built-in' as const,
     getSystemPrompt: () => systemPrompt,
     ...(tools !== undefined ? { tools } : {}),
     ...(role.config.disallowlist
@@ -439,10 +490,64 @@ export function roleToAgentDefinition(
       ? { effort: role.config.reasoningEffort }
       : {}),
   }
+  return {
+    ...definition,
+    agentRoleFingerprint: agentDefinitionFingerprint(definition),
+  }
+}
+
+export function requireAgentDefinitionRoleFingerprint(
+  definition: AgentDefinition,
+): string {
+  const computed = agentDefinitionFingerprint(definition)
+  const recorded = definition.agentRoleFingerprint?.trim()
+  if (recorded !== undefined && recorded.length > 0 && recorded !== computed) {
+    throw new Error(
+      `Agent type '${definition.agentType}' has stale or invalid role fingerprint metadata`,
+    )
+  }
+  return computed
+}
+
+export function bindAgentDefinitionToWorkspace(
+  definition: AgentDefinition,
+  _workspace: AgentRoleWorkspace,
+): AgentDefinition {
+  const renderedSystemPrompt = definition.getSystemPrompt()
+  const boundDefinition = {
+    ...definition,
+    getSystemPrompt: () => renderedSystemPrompt,
+  } as AgentDefinition
+  return {
+    ...boundDefinition,
+    agentRoleFingerprint: agentDefinitionFingerprint(boundDefinition),
+  }
 }
 
 function getBuiltInAgents(): BuiltInAgentDefinition[] {
-  return listAgentRoles().map(roleToAgentDefinition)
+  return listBuiltInAgentRoles().map(roleToAgentDefinition)
+}
+
+function getRegisteredAgents(
+  workspace: AgentRoleWorkspace,
+): CustomAgentDefinition[] {
+  return listRegisteredAgentRoles(workspace).map(role => {
+    const projected = roleToAgentDefinition(role)
+    const definition: CustomAgentDefinition = {
+      ...projected,
+      source: 'projectSettings',
+      baseDir: 'programmatic',
+      roleDefinitionPrompt: role.config.systemPrompt ?? '',
+      ...(role.config.model !== undefined
+        ? { model: role.config.model }
+        : {}),
+      getSystemPrompt: () => role.config.systemPrompt ?? '',
+    }
+    return {
+      ...definition,
+      agentRoleFingerprint: agentDefinitionFingerprint(definition),
+    }
+  })
 }
 
 function parseMarkdown(raw: string): {
@@ -505,9 +610,8 @@ function collectMarkdownFiles(dir: string, visitedDirs = new Set<string>()): str
   for (const entry of entries) {
     const fullPath = join(dir, entry.name)
     try {
-      const entryStats = entry.isSymbolicLink()
-        ? statSync(fullPath)
-        : lstatSync(fullPath)
+      if (entry.isSymbolicLink()) continue
+      const entryStats = lstatSync(fullPath)
       if (entryStats.isDirectory()) {
         out.push(...collectMarkdownFiles(fullPath, visitedDirs))
       } else if (entryStats.isFile() && entry.name.endsWith('.md')) {
@@ -565,6 +669,7 @@ function projectAgentDirs(
 
 async function loadSharedMarkdownAgentFiles(
   cwd: string,
+  fresh = false,
 ): Promise<MarkdownAgentFile[] | null> {
   try {
     // Literal specifier so esbuild discovers the module at bundle time.
@@ -573,18 +678,26 @@ async function loadSharedMarkdownAgentFiles(
         (subdir: string, cwd: string): Promise<MarkdownAgentFile[]>
         cache: { clear?: () => void }
       }
+      loadMarkdownFilesForSubdirFresh: (
+        subdir: 'agents',
+        cwd: string,
+      ) => Promise<MarkdownAgentFile[]>
     }
     sharedMarkdownCacheClearer = module.loadMarkdownFilesForSubdir.cache.clear?.bind(
       module.loadMarkdownFilesForSubdir.cache,
     )
-    const files = await module.loadMarkdownFilesForSubdir('agents', cwd)
-    return files.map(file => ({
-      filePath: file.filePath,
-      baseDir: file.baseDir,
-      frontmatter: file.frontmatter,
-      content: file.content,
-      source: file.source as SettingSource,
-    }))
+    const files = fresh
+      ? await module.loadMarkdownFilesForSubdirFresh('agents', cwd)
+      : await module.loadMarkdownFilesForSubdir('agents', cwd)
+    return files
+      .filter(file => isSafeAgentDefinitionPath(file.baseDir, file.filePath))
+      .map(file => ({
+        filePath: file.filePath,
+        baseDir: file.baseDir,
+        frontmatter: file.frontmatter,
+        content: file.content,
+        source: file.source as SettingSource,
+      }))
   } catch {
     return null
   }
@@ -592,9 +705,10 @@ async function loadSharedMarkdownAgentFiles(
 
 async function loadMarkdownAgentFiles(
   cwd: string,
+  fresh = false,
 ): Promise<{ files: MarkdownAgentFile[]; failedFiles: FailedAgentFile[] }> {
   if (!markdownDirsForTesting) {
-    const sharedFiles = await loadSharedMarkdownAgentFiles(cwd)
+    const sharedFiles = await loadSharedMarkdownAgentFiles(cwd, fresh)
     if (sharedFiles) return { files: sharedFiles, failedFiles: [] }
   }
 
@@ -612,10 +726,13 @@ async function loadMarkdownAgentFiles(
     }
     for (const filePath of filePaths) {
       try {
+        const raw = readSafeAgentDefinitionFile(dir, filePath)
+        if (raw === null) {
+          throw new Error('agent definition path escapes its discovery tier')
+        }
         const identity = fileIdentity(filePath)
         if (identity && seenFileIds.has(identity)) continue
         if (identity) seenFileIds.add(identity)
-        const raw = readFileSync(filePath, 'utf8')
         const { frontmatter, content } = parseMarkdown(raw)
         files.push({
           filePath,
@@ -632,6 +749,77 @@ async function loadMarkdownAgentFiles(
   return { files, failedFiles }
 }
 
+function isSafeAgentDefinitionPath(baseDir: string, filePath: string): boolean {
+  try {
+    const lexicalBase = lstatSync(baseDir)
+    const lexicalFile = lstatSync(filePath)
+    if (
+      !lexicalBase.isDirectory() ||
+      lexicalBase.isSymbolicLink() ||
+      !lexicalFile.isFile() ||
+      lexicalFile.isSymbolicLink()
+    ) {
+      return false
+    }
+    const canonicalAnchor = realpathSync(dirname(dirname(baseDir)))
+    const canonicalBase = realpathSync(baseDir)
+    const canonicalFile = realpathSync(filePath)
+    return isSameOrChildPath(canonicalAnchor, canonicalBase) &&
+      isSameOrChildPath(canonicalBase, canonicalFile) &&
+      canonicalBase !== canonicalFile
+  } catch {
+    return false
+  }
+}
+
+function readSafeAgentDefinitionFile(
+  baseDir: string,
+  filePath: string,
+): string | null {
+  if (!isSafeAgentDefinitionPath(baseDir, filePath)) return null
+  let fd: number | undefined
+  try {
+    const lexicalFile = lstatSync(filePath)
+    const canonicalFile = realpathSync(filePath)
+    fd = openSync(
+      filePath,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    )
+    const opened = fstatSync(fd)
+    if (
+      !opened.isFile() ||
+      opened.dev !== lexicalFile.dev ||
+      opened.ino !== lexicalFile.ino
+    ) {
+      return null
+    }
+    const content = readFileSync(fd, 'utf8')
+    const afterRead = fstatSync(fd)
+    if (
+      afterRead.dev !== opened.dev ||
+      afterRead.ino !== opened.ino ||
+      realpathSync(filePath) !== canonicalFile ||
+      !isSafeAgentDefinitionPath(baseDir, filePath)
+    ) {
+      return null
+    }
+    return content
+  } catch {
+    return null
+  } finally {
+    if (fd !== undefined) closeSync(fd)
+  }
+}
+
+function isSameOrChildPath(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate)
+  return child === '' || (
+    child !== '..' &&
+    !child.startsWith(`..${sep}`) &&
+    !isAbsolute(child)
+  )
+}
+
 function parseAgentFields(
   name: string,
   description: string,
@@ -640,6 +828,7 @@ function parseAgentFields(
   raw: Record<string, unknown>,
   filePath?: string,
   baseDir?: string,
+  roleCwd: string = process.cwd(),
 ): CustomAgentDefinition {
   const memory = parseMemoryScope(raw.memory)
   const tools = addMemoryTools(parseAgentTools(raw.tools), memory)
@@ -665,7 +854,9 @@ function parseAgentFields(
     agentType: name,
     whenToUse: description.replace(/\\n/g, '\n'),
     source,
-    getSystemPrompt: () => systemPromptWithMemory(name, systemPrompt, memory),
+    getSystemPrompt: () =>
+      systemPromptWithMemory(name, systemPrompt, memory, roleCwd),
+    roleDefinitionPrompt: systemPrompt,
     ...(filePath ? { filename: basename(filePath, '.md') } : {}),
     ...(baseDir ? { baseDir } : {}),
     ...(tools !== undefined ? { tools } : {}),
@@ -689,12 +880,22 @@ export function parseAgentFromJson(
   name: string,
   definition: unknown,
   source: SettingSource = 'flagSettings',
+  roleCwd: string = process.cwd(),
 ): CustomAgentDefinition | null {
   if (!isRecord(definition)) return null
   const description = nonEmptyString(definition.description)
   const prompt = nonEmptyString(definition.prompt)
   if (!description || !prompt) return null
-  return parseAgentFields(name, description, source, prompt, definition)
+  return parseAgentFields(
+    name,
+    description,
+    source,
+    prompt,
+    definition,
+    undefined,
+    undefined,
+    roleCwd,
+  )
 }
 
 export function parseAgentsFromJson(
@@ -713,6 +914,7 @@ export function parseAgentFromMarkdown(
   frontmatter: Record<string, unknown>,
   content: string,
   source: SettingSource,
+  roleCwd: string = process.cwd(),
 ): CustomAgentDefinition | null {
   const name = nonEmptyString(frontmatter.name)
   const description = nonEmptyString(frontmatter.description)
@@ -725,11 +927,13 @@ export function parseAgentFromMarkdown(
     frontmatter,
     filePath,
     baseDir,
+    roleCwd,
   )
 }
 
 async function initializeAgentMemorySnapshots(
   agents: CustomAgentDefinition[],
+  roleCwd: string,
 ): Promise<void> {
   if (!isAutoMemoryEnabled()) return
   const memoryAgents = agents.filter(agent => agent.memory === 'user')
@@ -742,12 +946,14 @@ async function initializeAgentMemorySnapshots(
         const result = await snapshots.checkAgentMemorySnapshot(
           agent.agentType,
           agent.memory ?? 'user',
+          roleCwd,
         )
         if (result.action === 'initialize') {
           await snapshots.initializeFromSnapshot(
             agent.agentType,
             agent.memory ?? 'user',
             result.snapshotTimestamp ?? '',
+            roleCwd,
           )
         } else if (result.action === 'prompt-update') {
           agent.pendingSnapshotUpdate = {
@@ -761,13 +967,16 @@ async function initializeAgentMemorySnapshots(
   }
 }
 
-async function loadPluginAgentsSafe(cwd: string): Promise<PluginAgentDefinition[]> {
+async function loadPluginAgentsSafe(
+  cwd: string,
+  fresh = false,
+): Promise<PluginAgentDefinition[]> {
   try {
     if (pluginAgentsLoaderForTesting) {
       return await pluginAgentsLoaderForTesting()
     }
     pluginAgentCacheClearer = clearPluginAgentCache
-    const loaded = await loadPluginAgents({ cwd })
+    const loaded = await loadPluginAgents({ cwd, fresh })
     return Array.isArray(loaded)
       ? loaded.filter((agent): agent is PluginAgentDefinition =>
           isRecord(agent) &&
@@ -782,20 +991,34 @@ async function loadPluginAgentsSafe(cwd: string): Promise<PluginAgentDefinition[
   }
 }
 
-async function loadAgentDefinitions(cwd: string): Promise<AgentDefinitionsResult> {
+async function loadAgentDefinitions(
+  cwd: string,
+  options: { readonly fresh?: boolean } = {},
+): Promise<WorkspaceAgentDefinitionsResult> {
+  const workspace = createAgentRoleWorkspace(cwd)
   const builtInAgents = getBuiltInAgents()
+  const registeredAgents = getRegisteredAgents(workspace)
   if (process.env.AGENC_SIMPLE === '1' || process.env.AGENC_SIMPLE === 'true') {
+    // Simple mode skips disk/plugin discovery, but programmatic roles are
+    // already explicit in-process configuration. Keep the same workspace
+    // overrides that AgentControl resolves instead of silently falling back to
+    // a less restrictive built-in definition with the same name.
+    const simpleAgents = [...builtInAgents, ...registeredAgents]
     return {
-      activeAgents: builtInAgents,
-      allAgents: builtInAgents,
+      agentRoleWorkspaceId: workspace.id,
+      activeAgents: getActiveAgentsFromList(simpleAgents),
+      allAgents: simpleAgents,
     }
   }
 
   try {
     const failedFiles: FailedAgentFile[] = []
-    const markdownResult = await loadMarkdownAgentFiles(cwd)
+    const markdownResult = await loadMarkdownAgentFiles(
+      cwd,
+      options.fresh === true,
+    )
     failedFiles.push(...markdownResult.failedFiles)
-    const customAgents = markdownResult.files
+    const parsedCustomAgents = markdownResult.files
       .map(file => {
         const agent = parseAgentFromMarkdown(
           file.filePath,
@@ -803,6 +1026,7 @@ async function loadAgentDefinitions(cwd: string): Promise<AgentDefinitionsResult
           file.frontmatter,
           file.content,
           file.source,
+          cwd,
         )
         if (!agent && file.frontmatter.name) {
           failedFiles.push({
@@ -815,11 +1039,31 @@ async function loadAgentDefinitions(cwd: string): Promise<AgentDefinitionsResult
       .filter((agent): agent is CustomAgentDefinition => agent !== null)
 
     const [pluginAgents] = await Promise.all([
-      loadPluginAgentsSafe(cwd),
-      initializeAgentMemorySnapshots(customAgents),
+      loadPluginAgentsSafe(cwd, options.fresh === true),
+      initializeAgentMemorySnapshots(parsedCustomAgents, cwd),
     ])
 
-    const allAgents = [...builtInAgents, ...pluginAgents, ...customAgents]
+    const customAgents = parsedCustomAgents.map(
+      agent =>
+        bindAgentDefinitionToWorkspace(
+          agent,
+          workspace,
+        ) as CustomAgentDefinition,
+    )
+
+    const scopedPluginAgents = pluginAgents.map(
+      agent => bindAgentDefinitionToWorkspace(agent, workspace) as PluginAgentDefinition,
+    )
+    // Programmatic roles live in the same immutable workspace registry used
+    // by AgentControl. Keep them in the canonical catalog too; otherwise the
+    // bootstrap-supplied fresh loader makes those roles disappear from the
+    // TUI, AgentTool, and nested child sessions.
+    const allAgents = [
+      ...builtInAgents,
+      ...registeredAgents,
+      ...scopedPluginAgents,
+      ...customAgents,
+    ]
     const activeAgents = getActiveAgentsFromList(allAgents)
     for (const agent of activeAgents) {
       if (agent.color) {
@@ -828,14 +1072,17 @@ async function loadAgentDefinitions(cwd: string): Promise<AgentDefinitionsResult
     }
 
     return {
+      agentRoleWorkspaceId: workspace.id,
       activeAgents,
       allAgents,
       ...(failedFiles.length > 0 ? { failedFiles } : {}),
     }
   } catch (error) {
+    const safeAgents = [...builtInAgents, ...registeredAgents]
     return {
-      activeAgents: builtInAgents,
-      allAgents: builtInAgents,
+      agentRoleWorkspaceId: workspace.id,
+      activeAgents: getActiveAgentsFromList(safeAgents),
+      allAgents: safeAgents,
       failedFiles: [{ path: 'unknown', error: errorToMessage(error) }],
     }
   }
@@ -856,9 +1103,17 @@ function getParseError(frontmatter: Record<string, unknown>): string {
 }
 
 export const getAgentDefinitionsWithOverrides = memoize(
-  async (cwd: string): Promise<AgentDefinitionsResult> => loadAgentDefinitions(cwd),
+  async (cwd: string): Promise<WorkspaceAgentDefinitionsResult> =>
+    loadAgentDefinitions(cwd),
   cwd => cwd,
 )
+
+/** Bypass the UI memoizer when validating a persisted role during resume. */
+export async function loadFreshAgentDefinitions(
+  cwd: string,
+): Promise<WorkspaceAgentDefinitionsResult> {
+  return loadAgentDefinitions(cwd, { fresh: true })
+}
 
 export function clearAgentDefinitionsCache(): void {
   getAgentDefinitionsWithOverrides.cache.clear?.()

--- a/runtime/src/tools/AgentTool/resumeAgent.ts
+++ b/runtime/src/tools/AgentTool/resumeAgent.ts
@@ -1,14 +1,23 @@
 import { promises as fsp } from 'fs'
 import { getSdkAgentProgressSummariesEnabled } from '../../bootstrap/state.js'
+import {
+  assertAgentRoleWorkspaceMatches,
+  type AgentRoleWorkspace,
+} from '../../agents/role.js'
 import { getSystemPrompt } from '../../constants/prompts.js'
 import { isCoordinatorMode } from '../../coordinator/coordinatorMode.js'
 import type { CanUseToolFn } from '../../tui/hooks/useCanUseTool.js'
 import type { ToolPermissionContext, ToolUseContext } from '../Tool.js'
 import type { AdditionalWorkingDirectory } from '../../types/permissions.js'
 import { registerAsyncAgent } from '../../tasks/LocalAgentTask/LocalAgentTask.js'
+import { requireCurrentRuntimeSession } from '../../session/current-session.js'
 import { assembleToolPool } from '../../tools.js'
 import { asAgentId } from '../../types/ids.js'
-import { runWithAgentContext } from '../../utils/agentContext.js'
+import {
+  getAgentContext,
+  runWithAgentContext,
+  type SubagentContext,
+} from '../../utils/agentContext.js'
 import { runWithCwdOverride } from '../../utils/cwd.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import {
@@ -20,6 +29,7 @@ import {
 import { getAgentModel } from '../../utils/model/agent.js'
 import { getQuerySourceForAgent } from '../../utils/promptCategory.js'
 import {
+  type AgentMetadata as AgentSidecarMetadata,
   getAgentTranscript,
   readAgentMetadata,
 } from '../../utils/sessionStorage.js'
@@ -30,15 +40,96 @@ import { getParentSessionId } from '../../utils/teammate.js'
 import { reconstructForSubagentResume } from '../../utils/toolResultStorage.js'
 import { runAsyncAgentLifecycle } from './agentToolUtils.js'
 import { FORK_AGENT, isForkSubagentEnabled } from './forkSubagent.js'
-import type { AgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
-import { isBuiltInAgent, roleToAgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
-import { getDefaultAgentRole } from 'src/agents/role.js'
+import type {
+  AgentDefinition,
+  AgentDefinitionsResult,
+} from 'src/tools/AgentTool/loadAgentsDir.js'
+import {
+  isBuiltInAgent,
+  loadFreshAgentDefinitions,
+  requireAgentDefinitionRoleFingerprint,
+} from 'src/tools/AgentTool/loadAgentsDir.js'
 import { runAgent } from './runAgent.js'
 export type ResumeAgentResult = {
   agentId: string
   description: string
   outputFile: string
 }
+
+export type ResumeAgentLaunchPreflight = {
+  readonly agentId: string
+  readonly selectedAgent: AgentDefinition
+  readonly agentContext: SubagentContext
+  readonly availableTools: Parameters<typeof runAgent>[0]['availableTools']
+  readonly workerPermissionMode: ToolPermissionContext['mode']
+}
+
+type ResumeAgentLaunchForTesting = (
+  preflight: ResumeAgentLaunchPreflight,
+) => Promise<ResumeAgentResult> | ResumeAgentResult
+
+let resumeAgentLaunchForTesting: ResumeAgentLaunchForTesting | undefined
+
+/** @internal Injects the post-policy launch boundary for focused tests. */
+export function __setResumeAgentLaunchForTesting(
+  launch: ResumeAgentLaunchForTesting | undefined,
+): void {
+  resumeAgentLaunchForTesting = launch
+}
+
+export function resolveAgentDefinitionForResume(
+  metadata: AgentSidecarMetadata | null,
+  workspace: AgentRoleWorkspace,
+  catalog: Pick<
+    AgentDefinitionsResult,
+    'agentRoleWorkspaceId' | 'activeAgents'
+  >,
+): { readonly selectedAgent: AgentDefinition; readonly isResumedFork: boolean } {
+  if (!metadata) {
+    throw new Error(
+      'Cannot resume agent: role workspace metadata is missing',
+    )
+  }
+
+  assertAgentRoleWorkspaceMatches(
+    workspace,
+    metadata.agentRoleWorkspaceId,
+  )
+  assertAgentRoleWorkspaceMatches(workspace, catalog.agentRoleWorkspaceId)
+  const requireMatchingFingerprint = (
+    selectedAgent: AgentDefinition,
+  ): AgentDefinition => {
+    if (
+      metadata.agentRoleFingerprint === undefined ||
+      metadata.agentRoleFingerprint !==
+        requireAgentDefinitionRoleFingerprint(selectedAgent)
+    ) {
+      throw new Error(
+        `Cannot resume changed agent type '${metadata.agentType}' in workspace ${workspace.id}`,
+      )
+    }
+    return selectedAgent
+  }
+  if (metadata.agentType === FORK_AGENT.agentType) {
+    return {
+      selectedAgent: requireMatchingFingerprint(FORK_AGENT),
+      isResumedFork: true,
+    }
+  }
+  const selectedAgent = catalog.activeAgents.find(
+    agent => agent.agentType === metadata.agentType,
+  )
+  if (!selectedAgent) {
+    throw new Error(
+      `Cannot resume agent type '${metadata.agentType}': it is not available in workspace ${workspace.id}`,
+    )
+  }
+  return {
+    selectedAgent: requireMatchingFingerprint(selectedAgent),
+    isResumedFork: false,
+  }
+}
+
 export async function resumeAgentBackground({
   agentId,
   prompt,
@@ -59,14 +150,31 @@ export async function resumeAgentBackground({
   const rootSetAppState =
     toolUseContext.setAppStateForTasks ?? toolUseContext.setAppState
   const permissionMode = appState.toolPermissionContext.mode
+  const parentSession = requireCurrentRuntimeSession('subagent resume')
+  assertAgentRoleWorkspaceMatches(
+    parentSession.roleWorkspace,
+    toolUseContext.options.agentDefinitions.agentRoleWorkspaceId,
+  )
+  assertAgentRoleWorkspaceMatches(
+    parentSession.roleWorkspace,
+    appState.agentDefinitions.agentRoleWorkspaceId,
+  )
+  const freshCatalog = await loadFreshAgentDefinitions(
+    parentSession.roleWorkspace.cwd,
+  )
 
   const [transcript, meta] = await Promise.all([
     getAgentTranscript(asAgentId(agentId)),
-    readAgentMetadata(asAgentId(agentId)),
+    readAgentMetadata(asAgentId(agentId), { strict: true }),
   ])
   if (!transcript) {
     throw new Error(`No transcript found for agent ID: ${agentId}`)
   }
+  const { selectedAgent, isResumedFork } = resolveAgentDefinitionForResume(
+    meta,
+    parentSession.roleWorkspace,
+    freshCatalog,
+  )
   const resumedMessages = filterWhitespaceOnlyAssistantMessages(
     filterOrphanedThinkingOnlyMessages(
       filterUnresolvedToolUses(transcript.messages),
@@ -96,22 +204,26 @@ export async function resumeAgentBackground({
     await fsp.utimes(resumedWorktreePath, now, now)
   }
 
-  // Skip filterDeniedAgents re-gating — original spawn already passed permission checks
-  let selectedAgent: AgentDefinition
-  let isResumedFork = false
-  if (meta?.agentType === FORK_AGENT.agentType) {
-    selectedAgent = FORK_AGENT
-    isResumedFork = true
-  } else if (meta?.agentType) {
-    const found = toolUseContext.options.agentDefinitions.activeAgents.find(
-      a => a.agentType === meta.agentType,
-    )
-    selectedAgent = found ?? roleToAgentDefinition(getDefaultAgentRole())
-  } else {
-    selectedAgent = roleToAgentDefinition(getDefaultAgentRole())
-  }
-
   const uiDescription = meta?.description ?? '(resumed)'
+
+  const asyncAgentContext: SubagentContext = {
+    agentId,
+    parentSessionId: getParentSessionId(),
+    agentType: 'subagent' as const,
+    subagentName: selectedAgent.agentType,
+    isBuiltIn: isBuiltInAgent(selectedAgent),
+    invokingRequestId,
+    invocationKind: 'resume' as const,
+    invocationEmitted: false,
+    ...(selectedAgent.memory !== undefined
+      ? {
+          memoryAuthorization: {
+            agentType: selectedAgent.agentType,
+            scope: selectedAgent.memory,
+          },
+        }
+      : {}),
+  }
 
   let forkParentSystemPrompt: SystemPrompt | undefined
   if (isResumedFork) {
@@ -211,6 +323,22 @@ export async function resumeAgentBackground({
     contentReplacementState: resumedReplacementState,
   }
 
+  if (resumeAgentLaunchForTesting !== undefined) {
+    return runWithAgentContext(asyncAgentContext, () => {
+      const ambientContext = getAgentContext()
+      if (ambientContext?.agentType !== 'subagent') {
+        throw new Error('resume launch is missing its subagent context')
+      }
+      return resumeAgentLaunchForTesting!({
+        agentId,
+        selectedAgent,
+        agentContext: ambientContext,
+        availableTools: runAgentParams.availableTools,
+        workerPermissionMode: workerPermissionContext.mode,
+      })
+    })
+  }
+
   // Skip name-registry write — original entry persists from the initial spawn
   const agentBackgroundTask = registerAsyncAgent({
     agentId,
@@ -228,17 +356,6 @@ export async function resumeAgentBackground({
     startTime,
     agentType: selectedAgent.agentType,
     isAsync: true,
-  }
-
-  const asyncAgentContext = {
-    agentId,
-    parentSessionId: getParentSessionId(),
-    agentType: 'subagent' as const,
-    subagentName: selectedAgent.agentType,
-    isBuiltIn: isBuiltInAgent(selectedAgent),
-    invokingRequestId,
-    invocationKind: 'resume' as const,
-    invocationEmitted: false,
   }
 
   const wrapWithCwd = <T>(fn: () => T): T =>

--- a/runtime/src/tools/AgentTool/runAgent.ts
+++ b/runtime/src/tools/AgentTool/runAgent.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto'
 import uniqBy from 'lodash-es/uniqBy.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { canonicalAgentRoleName } from 'src/agents/role-presentation.js'
+import { assertAgentRoleWorkspaceMatches } from 'src/agents/role.js'
 import type { EffortValue } from '../../utils/effort.js'
 import { getProjectRoot } from '../../bootstrap/state.js'
 import {
@@ -92,7 +93,11 @@ import {
 import type { ContentReplacementState } from '../../utils/toolResultStorage.js'
 import { createAgentId } from '../../utils/uuid.js'
 import { resolveAgentTools } from './agentToolUtils.js'
-import { type AgentDefinition, isBuiltInAgent } from 'src/tools/AgentTool/loadAgentsDir.js'
+import {
+  type AgentDefinition,
+  isBuiltInAgent,
+  requireAgentDefinitionRoleFingerprint,
+} from 'src/tools/AgentTool/loadAgentsDir.js'
 
 function formatSkillLoadingMetadata(skillName: string): string {
   return [
@@ -302,6 +307,7 @@ export async function* runAgent({
   transcriptSubdir,
   onQueryProgress,
   agentName,
+  agentMetadataAlreadyPersisted,
 }: {
   agentDefinition: AgentDefinition
   promptMessages: Message[]
@@ -363,6 +369,10 @@ export async function* runAgent({
   onQueryProgress?: () => void
   /** Agent name (team member name) for routing resolution */
   agentName?: string
+  /** The launch boundary durably persisted this agent's role sidecar before
+   * publishing the task. Direct callers omit this and runAgent persists it
+   * before performing any agent work. */
+  agentMetadataAlreadyPersisted?: boolean
 }): AsyncGenerator<Message, void> {
   // Track subagent usage for feature discovery
 
@@ -374,6 +384,16 @@ export async function* runAgent({
   const rootSetAppState =
     toolUseContext.setAppStateForTasks ?? toolUseContext.setAppState
   const parentSession = requireCurrentRuntimeSession('subagent')
+  assertAgentRoleWorkspaceMatches(
+    parentSession.roleWorkspace,
+    toolUseContext.options.agentDefinitions.agentRoleWorkspaceId,
+  )
+  assertAgentRoleWorkspaceMatches(
+    parentSession.roleWorkspace,
+    appState.agentDefinitions.agentRoleWorkspaceId,
+  )
+  const agentRoleFingerprint =
+    requireAgentDefinitionRoleFingerprint(agentDefinition)
 
   const resolvedAgentModel = getAgentModel(
     agentDefinition.model,
@@ -396,6 +416,23 @@ export async function* runAgent({
   // (e.g. workflow subagents write to subagents/workflows/<runId>/).
   if (transcriptSubdir) {
     setAgentTranscriptSubdir(agentId, transcriptSubdir)
+  }
+
+  if (!agentMetadataAlreadyPersisted) {
+    try {
+      await writeAgentMetadata(agentId, {
+        agentType: agentDefinition.agentType,
+        agentRoleWorkspaceId: parentSession.roleWorkspace.id,
+        agentRoleFingerprint,
+        ...(worktreePath && { worktreePath }),
+        ...(description && { description }),
+      })
+    } catch (error) {
+      if (transcriptSubdir) {
+        clearAgentTranscriptSubdir(agentId)
+      }
+      throw error
+    }
   }
 
   // Log API calls path for subagents (internal-only)
@@ -801,17 +838,12 @@ export async function* runAgent({
     })
   }
 
-  // Record initial messages before the query loop starts, plus the agentType
-  // so resume can route correctly when subagent_type is omitted. Both writes
-  // are fire-and-forget — persistence failure shouldn't block the agent.
+  // Record initial messages before the query loop starts. Role metadata was
+  // already durably persisted above (or by the launch boundary before task
+  // publication), so the model never starts without resumable provenance.
   void recordSidechainTranscript(initialMessages, agentId).catch(_err =>
     logForDebugging(`Failed to record sidechain transcript: ${_err}`),
   )
-  void writeAgentMetadata(agentId, {
-    agentType: agentDefinition.agentType,
-    ...(worktreePath && { worktreePath }),
-    ...(description && { description }),
-  }).catch(_err => logForDebugging(`Failed to write agent metadata: ${_err}`))
 
   // Track the last recorded message UUID for parent chain continuity
   let lastRecordedUuid: UUID | null = initialMessages.at(-1)?.uuid ?? null

--- a/runtime/src/tools/shared/spawnMultiAgent.ts
+++ b/runtime/src/tools/shared/spawnMultiAgent.ts
@@ -5,6 +5,14 @@
 
 import React from 'react'
 import { getSessionId } from '../../bootstrap/state.js'
+import {
+  assertAgentRoleWorkspaceMatches,
+  createAgentRoleWorkspace,
+  normalizeAgentRoleWorkspace,
+} from '../../agents/role.js'
+import { canonicalAgentRoleName } from '../../agents/role-presentation.js'
+import type { AgentRoleWorkspace } from '../../agents/role.js'
+import { requireCurrentRuntimeSession } from '../../session/current-session.js'
 import type { AppState } from '../../tui/state/AppState.js'
 import { createTaskStateBase, generateTaskId } from '../../tasks/Task.js'
 import type { ToolUseContext } from '../Tool.js'
@@ -17,6 +25,7 @@ import { logForDebugging } from 'src/utils/debug.js'
 import { errorMessage } from '../../utils/errors.js'
 import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
 import { parseUserSpecifiedModel } from '../../utils/model/model.js'
+import { getDenyRuleForAgent } from '../../utils/permissions/permissions.js'
 import { isTmuxAvailable } from '../../utils/swarm/backends/detection.js'
 import {
   detectAndGetBackend,
@@ -62,8 +71,13 @@ import {
 import { getHardcodedTeammateModelFallback } from '../../utils/swarm/teammateModel.js'
 import { registerTask } from '../../utils/task/framework.js'
 import { writeToMailbox } from '../../utils/teammateMailbox.js'
-import type { CustomAgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
-import { isCustomAgent } from 'src/tools/AgentTool/loadAgentsDir.js'
+import {
+  findAgentDefinitionByType,
+  loadFreshAgentDefinitions,
+  type AgentDefinition,
+} from 'src/tools/AgentTool/loadAgentsDir.js'
+import { setAgentColor } from 'src/tools/AgentTool/agentColorManager.js'
+import { AGENT_TOOL_NAME } from 'src/tools/AgentTool/constants.js'
 
 function getDefaultTeammateModel(leaderModel: string | null): string {
   const configured = getGlobalConfig().teammateDefaultModel
@@ -125,6 +139,9 @@ export type SpawnTeammateConfig = {
   model?: string
   agent_type?: string
   description?: string
+  /** Immutable role authority inherited from the parent session. */
+  agent_role_workspace_id: string
+  agent_role_workspace_cwd: string
   /** request_id of the API call whose response contained the tool_use that
    *  spawned this teammate. Threaded through to TeammateAgentContext for
    *  lineage tracing on tengu_api_* events. */
@@ -142,7 +159,23 @@ type SpawnInput = {
   model?: string
   agent_type?: string
   description?: string
+  agent_role_workspace_id: string
+  agent_role_workspace_cwd: string
   invokingRequestId?: string
+}
+
+export type SpawnTeammateBackend = (
+  input: SpawnTeammateConfig,
+  context: ToolUseContext,
+) => Promise<{ data: SpawnOutput }>
+
+let spawnTeammateBackendForTesting: SpawnTeammateBackend | undefined
+
+/** @internal Injects the post-policy spawn boundary for focused tests. */
+export function __setSpawnTeammateBackendForTesting(
+  backend: SpawnTeammateBackend | undefined,
+): void {
+  spawnTeammateBackendForTesting = backend
 }
 
 // ============================================================================
@@ -832,13 +865,13 @@ async function handleSpawnInProcess(
   // Assign a unique color to this teammate
   const teammateColor = assignTeammateColor(teammateId)
 
-  // Look up custom agent definition if agent_type is provided
-  let agentDefinition: CustomAgentDefinition | undefined
+  // Look up the already workspace-validated definition if agent_type is provided.
+  let agentDefinition: AgentDefinition | undefined
   if (agent_type) {
     const allAgents = context.options.agentDefinitions.activeAgents
-    const foundAgent = allAgents.find(a => a.agentType === agent_type)
-    if (foundAgent && isCustomAgent(foundAgent)) {
-      agentDefinition = foundAgent
+    agentDefinition = findAgentDefinitionByType(allAgents, agent_type)
+    if (agentDefinition === undefined) {
+      throw new Error(`Agent type '${agent_type}' not found for teammate spawn`)
     }
     logForDebugging(
       `[handleSpawnInProcess] agent_type=${agent_type}, found=${!!agentDefinition}`,
@@ -853,6 +886,7 @@ async function handleSpawnInProcess(
     color: teammateColor,
     planModeRequired: plan_mode_required ?? false,
     model,
+    permissionMode: agentDefinition?.permissionMode,
   }
 
   const result = await spawnInProcessTeammate(config, context)
@@ -1043,5 +1077,131 @@ export async function spawnTeammate(
   config: SpawnTeammateConfig,
   context: ToolUseContext,
 ): Promise<{ data: SpawnOutput }> {
-  return handleSpawn(config, context)
+  let effectiveContext = context
+  let effectiveConfig = config
+  const parentSession = requireCurrentRuntimeSession('teammate spawn')
+  assertTeammateSpawnRoleWorkspace({
+    parentWorkspace: parentSession.roleWorkspace,
+    suppliedWorkspaceId: config.agent_role_workspace_id,
+    suppliedWorkspaceCwd: config.agent_role_workspace_cwd,
+    catalogWorkspaceId:
+      context.options.agentDefinitions.agentRoleWorkspaceId,
+    executionCwd: config.cwd ?? getCwd(),
+    inProcess: isInProcessEnabled(),
+  })
+  assertAgentRoleWorkspaceMatches(
+    parentSession.roleWorkspace,
+    context.getAppState().agentDefinitions.agentRoleWorkspaceId,
+  )
+  if (config.agent_type) {
+    const freshCatalog = await loadFreshAgentDefinitions(
+      parentSession.roleWorkspace.cwd,
+    )
+    assertAgentRoleWorkspaceMatches(
+      parentSession.roleWorkspace,
+      freshCatalog.agentRoleWorkspaceId,
+    )
+    const selected = findAgentDefinitionByType(
+      freshCatalog.activeAgents,
+      config.agent_type,
+    )
+    if (selected === undefined) {
+      throw new Error(`Agent type '${config.agent_type}' not found for teammate spawn`)
+    }
+    const allowedAgentTypes =
+      context.options.agentDefinitions.allowedAgentTypes
+    if (
+      allowedAgentTypes !== undefined &&
+      !allowedAgentTypes.some(allowedType =>
+        allowedType === selected.agentType ||
+        (selected.agentType !== config.agent_type &&
+          canonicalAgentRoleName(allowedType) ===
+            canonicalAgentRoleName(selected.agentType)),
+      )
+    ) {
+      throw new Error(`Agent type '${config.agent_type}' not found for teammate spawn`)
+    }
+    const permissionContext = context.getAppState().toolPermissionContext
+    const denyRule =
+      getDenyRuleForAgent(
+        permissionContext,
+        AGENT_TOOL_NAME,
+        config.agent_type,
+      ) ??
+      (selected.agentType !== config.agent_type
+        ? getDenyRuleForAgent(
+            permissionContext,
+            AGENT_TOOL_NAME,
+            selected.agentType,
+          )
+        : null)
+    if (denyRule !== null) {
+      throw new Error(
+        `Agent type '${config.agent_type}' has been denied by permission rule '${AGENT_TOOL_NAME}(${denyRule.ruleValue.ruleContent ?? config.agent_type})' from ${denyRule.source ?? 'settings'}.`,
+      )
+    }
+    // Pane processes currently have no startup protocol that carries the
+    // immutable role workspace, exact definition fingerprint, prompt, tool
+    // restrictions, permission mode, and memory policy. `--agent-type` is not
+    // a supported bootstrap contract, so allowing this path would validate one
+    // role in the parent and execute an unrestricted/default role in the child.
+    // Fail closed until the complete provenance envelope can be consumed by
+    // the spawned process. In-process teammates inherit the validated catalog.
+    if (!isInProcessEnabled()) {
+      throw new Error(
+        `Agent type '${config.agent_type}' requires in-process teammate mode; pane teammates cannot enforce exact agent-role provenance`,
+      )
+    }
+    if (selected.color) {
+      setAgentColor(selected.agentType, selected.color)
+    }
+    effectiveConfig = {
+      ...config,
+      model: config.model ?? selected.model,
+    }
+    effectiveContext = {
+      ...context,
+      options: {
+        ...context.options,
+        agentDefinitions: {
+          ...context.options.agentDefinitions,
+          activeAgents: freshCatalog.activeAgents,
+        },
+      },
+    }
+  }
+  return (spawnTeammateBackendForTesting ?? handleSpawn)(
+    effectiveConfig,
+    effectiveContext,
+  )
+}
+
+export function assertTeammateSpawnRoleWorkspace(opts: {
+  readonly parentWorkspace: AgentRoleWorkspace
+  readonly suppliedWorkspaceId: string
+  readonly suppliedWorkspaceCwd: string
+  readonly catalogWorkspaceId?: string
+  readonly executionCwd: string
+  readonly inProcess: boolean
+}): void {
+  const suppliedWorkspace = normalizeAgentRoleWorkspace({
+    id: opts.suppliedWorkspaceId,
+    cwd: opts.suppliedWorkspaceCwd,
+  })
+  assertAgentRoleWorkspaceMatches(opts.parentWorkspace, suppliedWorkspace.id)
+  assertAgentRoleWorkspaceMatches(
+    opts.parentWorkspace,
+    opts.catalogWorkspaceId,
+  )
+
+  // Pane teammates bootstrap role authority from their process cwd. Until the
+  // daemon protocol has a separate role-workspace field, reject a pane spawn
+  // whose execution cwd would select a different trust domain. In-process
+  // teammates inherit the already-validated parent context.
+  const executionWorkspace = createAgentRoleWorkspace(opts.executionCwd)
+  if (!opts.inProcess && executionWorkspace.id !== suppliedWorkspace.id) {
+    throw new Error(
+      `teammate execution cwd ${executionWorkspace.cwd} does not match role workspace ${suppliedWorkspace.cwd}`,
+    )
+  }
 }

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -59,6 +59,11 @@ import { AgenCPermissionOverlay as PermissionOverlay, buildToolUseConfirmQueue, 
 import { submitViaElicitationPrompt } from "../elicitation-submit-routing.js";
 import { findCommand, getCommands, isCommandEnabled, listTuiCommandList } from "../../commands.js";
 import { listAgentRoleDefinitions } from "../../agents/role-definitions.js";
+import { getAgentDefinitionsWithOverrides } from "../../tools/AgentTool/loadAgentsDir.js";
+import {
+  createAgentRoleWorkspace,
+  normalizeAgentRoleWorkspace,
+} from "../../agents/role.js";
 import { buildPendingProviderSwitch } from "../model-switch.js";
 import { pastedContentsToLLMMessage } from "../../llm/pasted-content.js";
 import type { PromptInputContext } from "../input/inputContext.js";
@@ -1067,18 +1072,51 @@ async function persistOnboardingSelection(props: AgenCTuiProps, agencHome: strin
   await props.configStore.reload?.();
   await props.session.services.configStore?.reload?.();
 }
-function initialState(props: AgenCTuiProps): any {
-  const agentDefinitions = listAgentRoleDefinitions();
+function initialState(
+  props: AgenCTuiProps,
+  roleWorkspaceCwd: string,
+): any {
+  const roleWorkspace = createAgentRoleWorkspace(roleWorkspaceCwd);
+  const sessionCatalog = props.session.agentDefinitions;
+  if (
+    sessionCatalog !== undefined &&
+    sessionCatalog.agentRoleWorkspaceId !== roleWorkspace.id
+  ) {
+    throw new Error(
+      `agent catalog workspace mismatch: expected ${roleWorkspace.id}, received ${sessionCatalog.agentRoleWorkspaceId}`,
+    );
+  }
+  const agentDefinitions = sessionCatalog ?? (() => {
+    const fallbackDefinitions = listAgentRoleDefinitions(roleWorkspaceCwd);
+    return {
+      agentRoleWorkspaceId: roleWorkspace.id,
+      activeAgents: fallbackDefinitions,
+      allAgents: fallbackDefinitions,
+    };
+  })();
   return {
     ...getDefaultAppState(),
     mainLoopModel: startupModel(props),
     mainLoopModelForSession: startupModel(props),
     toolPermissionContext: initialPermissionContext(props),
     agentDefinitions: {
-      activeAgents: [...agentDefinitions],
-      allAgents: [...agentDefinitions],
+      ...agentDefinitions,
+      agentRoleWorkspaceId: roleWorkspace.id,
+      activeAgents: [...agentDefinitions.activeAgents],
+      allAgents: [...(agentDefinitions.allAgents ?? agentDefinitions.activeAgents)],
     }
   };
+}
+
+function requireTuiRoleWorkspaceCwd(props: AgenCTuiProps): string {
+  if (props.session.roleWorkspace !== undefined) {
+    return normalizeAgentRoleWorkspace(props.session.roleWorkspace).cwd;
+  }
+  const cwd = props.session.cwd ?? props.session.sessionConfiguration?.cwd;
+  if (typeof cwd !== "string" || cwd.length === 0) {
+    throw new Error("TUI agent roles require an explicit session workspace cwd");
+  }
+  return createAgentRoleWorkspace(cwd).cwd;
 }
 
 type SetToolPermissionContext = (next: ToolPermissionContext) => void;
@@ -1438,7 +1476,11 @@ function terminalTitle(props: Parameters<typeof startupModel>[0]): string {
   if (model) return `AgenC ${model}`;
   return "AgenC";
 }
-function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
+type AgenCTuiShellProps = AgenCTuiProps & {
+  readonly roleWorkspaceCwd: string;
+};
+
+function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
   const {
     exit
   } = useApp();
@@ -1526,6 +1568,44 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
   });
   const setAppState = useSetAppState();
   const appStateStore = useAppStateStore();
+  useEffect(() => {
+    if (props.session.agentDefinitions !== undefined) {
+      return;
+    }
+    let cancelled = false;
+    void getAgentDefinitionsWithOverrides(props.roleWorkspaceCwd)
+      .then(agentDefinitions => {
+        if (cancelled) return;
+        const roleWorkspace = createAgentRoleWorkspace(props.roleWorkspaceCwd);
+        if (agentDefinitions.agentRoleWorkspaceId !== roleWorkspace.id) {
+          throw new Error(
+            `agent catalog workspace mismatch: expected ${roleWorkspace.id}, received ${agentDefinitions.agentRoleWorkspaceId ?? "missing"}`,
+          );
+        }
+        setAppState(state => ({
+          ...state,
+          agentDefinitions,
+        }));
+      })
+      .catch(error => {
+        if (!cancelled) {
+          addNotification({
+            key: "agent-catalog-load-error",
+            text: error instanceof Error ? error.message : String(error),
+            color: "error",
+            priority: "high",
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    addNotification,
+    props.roleWorkspaceCwd,
+    props.session.agentDefinitions,
+    setAppState,
+  ]);
   const getBridgeAppState = useCallback(() => appStateStore.getState(), [appStateStore]);
   useEffect(() => {
     const subscribe = props.session.subscribeToEvents;
@@ -1658,7 +1738,7 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
     const extras = dynamicTuiCommands.filter((cmd) => !seen.has(cmd.name.toLowerCase()));
     return [...builtinTuiCommands, ...extras];
   }, [builtinTuiCommands, dynamicTuiCommands]);
-  const agents = useMemo(() => listAgentRoleDefinitions(), []);
+  const agents = useAppState(state => state.agentDefinitions.activeAgents);
   const appTasks = useAppState(s => s.tasks);
   const hasActiveLocalAgents = getActiveLocalAgentTasks(appTasks).length > 0;
   const hasActiveSessionTurn = hasActiveConversationTurn(props.session);
@@ -2690,11 +2770,18 @@ function AgenCTuiShell(props: AgenCTuiProps): React.ReactElement {
   return <Box flexDirection="column" width="100%">{body}</Box>;
 }
 export function AgenCTuiApp(props: AgenCTuiProps): React.ReactElement {
-  const initial = useMemo(() => initialState(props), []);
+  const roleWorkspaceCwd = useMemo(
+    () => requireTuiRoleWorkspaceCwd(props),
+    [],
+  );
+  const initial = useMemo(
+    () => initialState(props, roleWorkspaceCwd),
+    [roleWorkspaceCwd],
+  );
   return <App initialState={initial} getFpsMetrics={props.getFpsMetrics ?? DEFAULT_FPS_METRICS_GETTER}>
       <PromptOverlayProvider>
         <KeybindingSetup>
-          <AgenCTuiShell {...props} />
+          <AgenCTuiShell {...props} roleWorkspaceCwd={roleWorkspaceCwd} />
         </KeybindingSetup>
       </PromptOverlayProvider>
     </App>;

--- a/runtime/src/tui/components/agents/agentFileUtils.ts
+++ b/runtime/src/tui/components/agents/agentFileUtils.ts
@@ -1,5 +1,23 @@
-import { mkdir, open, unlink } from 'fs/promises'
-import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { constants } from 'fs'
+import {
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  realpath,
+  rename,
+  unlink,
+} from 'fs/promises'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'path'
 import type { SettingSource } from '../../../utils/settings/constants.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { getManagedFilePath } from '../../../utils/settings/managedPath.js' // upstream-import: keep target is owned by another Z-PURGE item
 import type { AgentMemoryScope } from '../../../tools/AgentTool/agentMemory.js'
@@ -8,11 +26,79 @@ import {
   isBuiltInAgent,
   isPluginAgent,
 } from 'src/tools/AgentTool/loadAgentsDir.js'
-import { getCwd } from '../../../utils/cwd.js' // upstream-import: keep target is owned by another Z-PURGE item
 import type { EffortValue } from '../../../utils/effort.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { getAgenCConfigHomeDir } from '../../../utils/envUtils.js'
 import { getErrnoCode } from '../../../utils/errors.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { AGENT_PATHS } from './types.js'
+import {
+  assertAgentRoleWorkspaceMatches,
+  type AgentRoleWorkspace,
+} from '../../../agents/role.js'
+
+export interface AgentFileMutationAuthority {
+  readonly roleWorkspace: AgentRoleWorkspace
+  readonly catalogWorkspaceId?: string
+}
+
+interface AgentDirectoryLocation {
+  readonly trustAnchor: string
+  readonly tierRoot: string
+  readonly directory: string
+}
+
+interface DirectoryComponentSnapshot {
+  readonly path: string
+  readonly canonicalPath: string
+  readonly dev: number | bigint
+  readonly ino: number | bigint
+}
+
+type AgentDirectoryHandle = Awaited<ReturnType<typeof open>>
+type AgentDirectoryStream = Awaited<ReturnType<typeof opendir>>
+
+interface PinnedAgentDirectory {
+  readonly components: readonly DirectoryComponentSnapshot[]
+  readonly canonicalAnchor: string
+  readonly canonicalTier: string
+  readonly canonicalDirectory: string
+  readonly handle: AgentDirectoryHandle | undefined
+  readonly stream: AgentDirectoryStream | undefined
+  readonly operationPath: string
+}
+
+interface ExistingAgentFile {
+  readonly dev: number | bigint
+  readonly ino: number | bigint
+  readonly mode: number | bigint
+  readonly canonicalPath: string
+}
+
+type AgentFileOperationPhase = 'before-commit' | 'before-delete'
+
+let agentFileOperationHookForTesting:
+  | ((operation: {
+      readonly phase: AgentFileOperationPhase
+      readonly directory: string
+      readonly filename: string
+    }) => void | Promise<void>)
+  | undefined
+
+/** Test-only race hook used by deterministic filesystem-swap regressions. */
+export function __setAgentFileOperationHookForTesting(
+  hook: typeof agentFileOperationHookForTesting,
+): void {
+  agentFileOperationHookForTesting = hook
+}
+
+function requireMutationAuthority(
+  authority: AgentFileMutationAuthority,
+): AgentRoleWorkspace {
+  assertAgentRoleWorkspaceMatches(
+    authority.roleWorkspace,
+    authority.catalogWorkspaceId,
+  )
+  return authority.roleWorkspace
+}
 
 /**
  * Formats agent data as markdown file content
@@ -57,14 +143,21 @@ ${systemPrompt}
 /**
  * Gets the directory path for an agent location
  */
-function getAgentDirectoryPath(location: SettingSource): string {
+function getAgentDirectoryPath(
+  location: SettingSource,
+  roleWorkspaceCwd: string,
+): string {
   switch (location) {
     case 'flagSettings':
       throw new Error(`Cannot get directory path for ${location} agents`)
     case 'userSettings':
       return join(getAgenCConfigHomeDir(), AGENT_PATHS.AGENTS_DIR)
     case 'projectSettings':
-      return join(getCwd(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
+      return join(
+        roleWorkspaceCwd,
+        AGENT_PATHS.FOLDER_NAME,
+        AGENT_PATHS.AGENTS_DIR,
+      )
     case 'policySettings':
       return join(
         getManagedFilePath(),
@@ -72,16 +165,49 @@ function getAgentDirectoryPath(location: SettingSource): string {
         AGENT_PATHS.AGENTS_DIR,
       )
     case 'localSettings':
-      return join(getCwd(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
+      return join(
+        roleWorkspaceCwd,
+        AGENT_PATHS.FOLDER_NAME,
+        AGENT_PATHS.AGENTS_DIR,
+      )
   }
 }
 
-function getRelativeAgentDirectoryPath(location: SettingSource): string {
+function getAgentDirectoryLocation(
+  source: SettingSource,
+  roleWorkspaceCwd: string,
+): AgentDirectoryLocation {
+  const directory = getAgentDirectoryPath(source, roleWorkspaceCwd)
+  switch (source) {
+    case 'flagSettings':
+      throw new Error(`Cannot get directory authority for ${source} agents`)
+    case 'projectSettings':
+    case 'localSettings':
+      return {
+        trustAnchor: roleWorkspaceCwd,
+        tierRoot: roleWorkspaceCwd,
+        directory,
+      }
+    case 'userSettings': {
+      const tierRoot = getAgenCConfigHomeDir()
+      return { trustAnchor: dirname(tierRoot), tierRoot, directory }
+    }
+    case 'policySettings': {
+      const tierRoot = getManagedFilePath()
+      return { trustAnchor: dirname(tierRoot), tierRoot, directory }
+    }
+  }
+}
+
+function getRelativeAgentDirectoryPath(
+  location: SettingSource,
+  roleWorkspaceCwd: string,
+): string {
   switch (location) {
     case 'projectSettings':
       return join('.', AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
     default:
-      return getAgentDirectoryPath(location)
+      return getAgentDirectoryPath(location, roleWorkspaceCwd)
   }
 }
 
@@ -92,8 +218,8 @@ function getRelativeAgentDirectoryPath(location: SettingSource): string {
 export function getNewAgentFilePath(agent: {
   source: SettingSource
   agentType: string
-}): string {
-  const dirPath = getAgentDirectoryPath(agent.source)
+}, roleWorkspaceCwd: string): string {
+  const dirPath = getAgentDirectoryPath(agent.source, roleWorkspaceCwd)
   return join(dirPath, `${agent.agentType}.md`)
 }
 
@@ -101,7 +227,10 @@ export function getNewAgentFilePath(agent: {
  * Gets the actual file path for an agent (handles filename vs agentType mismatch)
  * Always use this for existing agents to get their real file location
  */
-export function getActualAgentFilePath(agent: AgentDefinition): string {
+export function getActualAgentFilePath(
+  agent: AgentDefinition,
+  roleWorkspaceCwd: string,
+): string {
   if (agent.source === 'built-in') {
     return 'Built-in'
   }
@@ -109,7 +238,7 @@ export function getActualAgentFilePath(agent: AgentDefinition): string {
     throw new Error('Cannot get file path for plugin agents')
   }
 
-  const dirPath = getAgentDirectoryPath(agent.source)
+  const dirPath = getAgentDirectoryPath(agent.source, roleWorkspaceCwd)
   const filename = agent.filename || agent.agentType
   return join(dirPath, `${filename}.md`)
 }
@@ -121,18 +250,21 @@ export function getActualAgentFilePath(agent: AgentDefinition): string {
 export function getNewRelativeAgentFilePath(agent: {
   source: SettingSource | 'built-in'
   agentType: string
-}): string {
+}, roleWorkspaceCwd = '.'): string {
   if (agent.source === 'built-in') {
     return 'Built-in'
   }
-  const dirPath = getRelativeAgentDirectoryPath(agent.source)
+  const dirPath = getRelativeAgentDirectoryPath(agent.source, roleWorkspaceCwd)
   return join(dirPath, `${agent.agentType}.md`)
 }
 
 /**
  * Gets the actual relative file path for an agent (handles filename vs agentType mismatch)
  */
-export function getActualRelativeAgentFilePath(agent: AgentDefinition): string {
+export function getActualRelativeAgentFilePath(
+  agent: AgentDefinition,
+  roleWorkspaceCwd = '.',
+): string {
   if (isBuiltInAgent(agent)) {
     return 'Built-in'
   }
@@ -143,20 +275,9 @@ export function getActualRelativeAgentFilePath(agent: AgentDefinition): string {
     return 'CLI argument'
   }
 
-  const dirPath = getRelativeAgentDirectoryPath(agent.source)
+  const dirPath = getRelativeAgentDirectoryPath(agent.source, roleWorkspaceCwd)
   const filename = agent.filename || agent.agentType
   return join(dirPath, `${filename}.md`)
-}
-
-/**
- * Ensures the directory for an agent location exists
- */
-async function ensureAgentDirectoryExists(
-  source: SettingSource,
-): Promise<string> {
-  const dirPath = getAgentDirectoryPath(source)
-  await mkdir(dirPath, { recursive: true })
-  return dirPath
 }
 
 /**
@@ -164,6 +285,7 @@ async function ensureAgentDirectoryExists(
  * @param checkExists - If true, throws error if file already exists
  */
 export async function saveAgentToFile(
+  authority: AgentFileMutationAuthority,
   source: SettingSource | 'built-in',
   agentType: string,
   whenToUse: string,
@@ -175,12 +297,15 @@ export async function saveAgentToFile(
   memory?: AgentMemoryScope,
   effort?: EffortValue,
 ): Promise<void> {
+  const roleWorkspace = requireMutationAuthority(authority)
   if (source === 'built-in') {
     throw new Error('Cannot save built-in agents')
   }
 
-  await ensureAgentDirectoryExists(source)
-  const filePath = getNewAgentFilePath({ source, agentType })
+  const filePath = getNewAgentFilePath(
+    { source, agentType },
+    roleWorkspace.cwd,
+  )
 
   const content = formatAgentAsMarkdown(
     agentType,
@@ -193,7 +318,12 @@ export async function saveAgentToFile(
     effort,
   )
   try {
-    await writeFileAndFlush(filePath, content, checkExists ? 'wx' : 'w')
+    await writeTrustedAgentFile(
+      getAgentDirectoryLocation(source, roleWorkspace.cwd),
+      `${agentType}.md`,
+      content,
+      checkExists,
+    )
   } catch (e: unknown) {
     if (getErrnoCode(e) === 'EEXIST') {
       throw new Error(`Agent file already exists: ${filePath}`)
@@ -206,6 +336,7 @@ export async function saveAgentToFile(
  * Updates an existing agent file
  */
 export async function updateAgentFile(
+  authority: AgentFileMutationAuthority,
   agent: AgentDefinition,
   newWhenToUse: string,
   newTools: string[] | undefined,
@@ -215,11 +346,13 @@ export async function updateAgentFile(
   newMemory?: AgentMemoryScope,
   newEffort?: EffortValue,
 ): Promise<void> {
+  const roleWorkspace = requireMutationAuthority(authority)
   if (agent.source === 'built-in') {
     throw new Error('Cannot update built-in agents')
   }
-
-  const filePath = getActualAgentFilePath(agent)
+  if (agent.source === 'plugin') {
+    throw new Error('Cannot get file path for plugin agents')
+  }
 
   const content = formatAgentAsMarkdown(
     agent.agentType,
@@ -232,41 +365,456 @@ export async function updateAgentFile(
     newEffort,
   )
 
-  await writeFileAndFlush(filePath, content)
+  const filename = agent.filename || agent.agentType
+  await writeTrustedAgentFile(
+    getAgentDirectoryLocation(agent.source, roleWorkspace.cwd),
+    `${filename}.md`,
+    content,
+    false,
+  )
 }
 
 /**
  * Deletes an agent file
  */
 export async function deleteAgentFromFile(
+  authority: AgentFileMutationAuthority,
   agent: AgentDefinition,
 ): Promise<void> {
+  const roleWorkspace = requireMutationAuthority(authority)
   if (agent.source === 'built-in') {
     throw new Error('Cannot delete built-in agents')
   }
+  if (agent.source === 'plugin') {
+    throw new Error('Cannot get file path for plugin agents')
+  }
 
-  const filePath = getActualAgentFilePath(agent)
+  const filename = agent.filename || agent.agentType
+  await deleteTrustedAgentFile(
+    getAgentDirectoryLocation(agent.source, roleWorkspace.cwd),
+    `${filename}.md`,
+  )
+}
 
-  try {
-    await unlink(filePath)
-  } catch (e: unknown) {
-    const code = getErrnoCode(e)
-    if (code !== 'ENOENT') {
-      throw e
-    }
+function isSameOrChildPath(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate)
+  return child === '' || (
+    child !== '..' &&
+    !child.startsWith(`..${sep}`) &&
+    !isAbsolute(child)
+  )
+}
+
+function isSameIdentity(
+  actual: { readonly dev: number | bigint; readonly ino: number | bigint },
+  expected: { readonly dev: number | bigint; readonly ino: number | bigint },
+): boolean {
+  return actual.dev === expected.dev && actual.ino === expected.ino
+}
+
+function validateAgentFilename(filename: string): void {
+  if (
+    filename.length === 0 ||
+    filename === '.' ||
+    filename === '..' ||
+    basename(filename) !== filename ||
+    filename.includes('/') ||
+    filename.includes('\\') ||
+    filename.includes('\0')
+  ) {
+    throw new Error('invalid agent filename')
   }
 }
 
-async function writeFileAndFlush(
-  filePath: string,
-  content: string,
-  flag: 'w' | 'wx' = 'w',
+async function snapshotTrustedDirectoryComponent(
+  path: string,
+): Promise<DirectoryComponentSnapshot> {
+  const before = await lstat(path)
+  if (!before.isDirectory() || before.isSymbolicLink()) {
+    throw new Error(`agent directory is not trusted: ${path}`)
+  }
+  const canonicalPath = await realpath(path)
+  const after = await lstat(path)
+  if (
+    !after.isDirectory() ||
+    after.isSymbolicLink() ||
+    !isSameIdentity(after, before)
+  ) {
+    throw new Error(`agent directory changed during validation: ${path}`)
+  }
+  return {
+    path,
+    canonicalPath,
+    dev: after.dev,
+    ino: after.ino,
+  }
+}
+
+async function prepareTrustedDirectoryComponents(
+  location: AgentDirectoryLocation,
+  create: boolean,
+): Promise<readonly DirectoryComponentSnapshot[] | undefined> {
+  const trustAnchor = resolve(location.trustAnchor)
+  const tierRoot = resolve(location.tierRoot)
+  const directory = resolve(location.directory)
+  if (
+    !isSameOrChildPath(trustAnchor, tierRoot) ||
+    !isSameOrChildPath(tierRoot, directory)
+  ) {
+    throw new Error('agent directory escapes its trusted tier')
+  }
+
+  const componentPaths = [trustAnchor]
+  let componentPath = trustAnchor
+  const child = relative(trustAnchor, directory)
+  if (child.length > 0) {
+    for (const component of child.split(sep)) {
+      componentPath = join(componentPath, component)
+      componentPaths.push(componentPath)
+    }
+  }
+
+  const snapshots: DirectoryComponentSnapshot[] = []
+  for (const path of componentPaths) {
+    try {
+      snapshots.push(await snapshotTrustedDirectoryComponent(path))
+      continue
+    } catch (error) {
+      if (getErrnoCode(error) !== 'ENOENT') throw error
+      if (!create) return undefined
+      if (path === trustAnchor) {
+        throw new Error(`agent directory trust anchor does not exist: ${path}`)
+      }
+    }
+
+    try {
+      await mkdir(path, { mode: 0o700 })
+    } catch (error) {
+      if (getErrnoCode(error) !== 'EEXIST') throw error
+    }
+    snapshots.push(await snapshotTrustedDirectoryComponent(path))
+  }
+
+  const anchor = snapshots[0]
+  const tier = snapshots.find(snapshot => snapshot.path === tierRoot)
+  const agentDirectory = snapshots.at(-1)
+  if (
+    anchor === undefined ||
+    tier === undefined ||
+    agentDirectory === undefined ||
+    !isSameOrChildPath(anchor.canonicalPath, tier.canonicalPath) ||
+    !isSameOrChildPath(tier.canonicalPath, agentDirectory.canonicalPath)
+  ) {
+    throw new Error('agent directory canonical path escapes its trusted tier')
+  }
+  return snapshots
+}
+
+async function assertPinnedAgentDirectoryCurrent(
+  pinned: PinnedAgentDirectory,
 ): Promise<void> {
-  const handle = await open(filePath, flag)
+  const current = await Promise.all(
+    pinned.components.map(snapshot =>
+      snapshotTrustedDirectoryComponent(snapshot.path),
+    ),
+  )
+  for (const [index, snapshot] of pinned.components.entries()) {
+    const currentSnapshot = current[index]
+    if (
+      currentSnapshot === undefined ||
+      !isSameIdentity(currentSnapshot, snapshot) ||
+      currentSnapshot.canonicalPath !== snapshot.canonicalPath
+    ) {
+      throw new Error('agent directory changed during file operation')
+    }
+  }
+
+  const opened = await pinned.handle?.stat()
+  const directory = pinned.components.at(-1)
+  if (
+    directory === undefined ||
+    (opened !== undefined &&
+      (!opened.isDirectory() || !isSameIdentity(opened, directory))) ||
+    !isSameOrChildPath(pinned.canonicalAnchor, pinned.canonicalTier) ||
+    !isSameOrChildPath(pinned.canonicalTier, pinned.canonicalDirectory)
+  ) {
+    throw new Error('agent directory pin is no longer trusted')
+  }
+}
+
+async function pinTrustedAgentDirectory(
+  location: AgentDirectoryLocation,
+  create: boolean,
+): Promise<PinnedAgentDirectory | undefined> {
+  const components = await prepareTrustedDirectoryComponents(location, create)
+  if (components === undefined) return undefined
+  const anchor = components[0]
+  const tier = components.find(snapshot =>
+    snapshot.path === resolve(location.tierRoot),
+  )
+  const directory = components.at(-1)
+  if (anchor === undefined || tier === undefined || directory === undefined) {
+    throw new Error('agent directory could not be pinned')
+  }
+
+  let handle: AgentDirectoryHandle | undefined
+  let stream: AgentDirectoryStream | undefined
   try {
-    await handle.writeFile(content, { encoding: 'utf-8' })
-    await handle.datasync()
+    handle = await open(
+      directory.path,
+      constants.O_RDONLY |
+        (constants.O_DIRECTORY ?? 0) |
+        (constants.O_NOFOLLOW ?? 0),
+    )
+  } catch (error) {
+    if (process.platform !== 'win32') throw error
+    stream = await opendir(directory.path)
+  }
+
+  try {
+    const opened = await handle?.stat()
+    if (
+      opened !== undefined &&
+      (!opened.isDirectory() || !isSameIdentity(opened, directory))
+    ) {
+      throw new Error('agent directory changed while opening')
+    }
+
+    let operationPath = directory.canonicalPath
+    if (handle !== undefined) {
+      const descriptorPaths = process.platform === 'linux'
+        ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
+        : [`/dev/fd/${handle.fd}`]
+      for (const descriptorPath of descriptorPaths) {
+        try {
+          if (await realpath(descriptorPath) === directory.canonicalPath) {
+            operationPath = descriptorPath
+            break
+          }
+        } catch {
+          // Descriptor-relative paths are unavailable on some platforms.
+          // The directory identity checks below remain mandatory.
+        }
+      }
+    }
+
+    const pinned: PinnedAgentDirectory = {
+      components,
+      canonicalAnchor: anchor.canonicalPath,
+      canonicalTier: tier.canonicalPath,
+      canonicalDirectory: directory.canonicalPath,
+      handle,
+      stream,
+      operationPath,
+    }
+    await assertPinnedAgentDirectoryCurrent(pinned)
+    return pinned
+  } catch (error) {
+    await handle?.close().catch(() => {})
+    await stream?.close().catch(() => {})
+    throw error
+  }
+}
+
+async function closePinnedAgentDirectory(
+  pinned: PinnedAgentDirectory,
+): Promise<void> {
+  await pinned.handle?.close().catch(() => {})
+  await pinned.stream?.close().catch(() => {})
+}
+
+async function inspectTrustedAgentFile(
+  path: string,
+  pinned: PinnedAgentDirectory,
+): Promise<ExistingAgentFile | undefined> {
+  let before: Awaited<ReturnType<typeof lstat>>
+  try {
+    before = await lstat(path)
+  } catch (error) {
+    if (getErrnoCode(error) === 'ENOENT') return undefined
+    throw error
+  }
+  if (
+    !before.isFile() ||
+    before.isSymbolicLink() ||
+    before.nlink !== 1
+  ) {
+    throw new Error('agent file must be a regular single-link file')
+  }
+
+  const canonicalPath = await realpath(path)
+  const after = await lstat(path)
+  if (
+    !after.isFile() ||
+    after.isSymbolicLink() ||
+    after.nlink !== 1 ||
+    !isSameIdentity(after, before) ||
+    canonicalPath === pinned.canonicalDirectory ||
+    !isSameOrChildPath(pinned.canonicalDirectory, canonicalPath) ||
+    !isSameOrChildPath(pinned.canonicalTier, canonicalPath)
+  ) {
+    throw new Error('agent file is outside its trusted directory')
+  }
+  return {
+    dev: after.dev,
+    ino: after.ino,
+    mode: after.mode,
+    canonicalPath,
+  }
+}
+
+function throwAgentFileExists(path: string): never {
+  const error = new Error(`agent file already exists: ${path}`) as NodeJS.ErrnoException
+  error.code = 'EEXIST'
+  throw error
+}
+
+async function syncPinnedDirectory(pinned: PinnedAgentDirectory): Promise<void> {
+  if (pinned.handle === undefined) return
+  try {
+    await pinned.handle.sync()
+  } catch (error) {
+    if (
+      process.platform === 'win32' ||
+      ['EBADF', 'EINVAL', 'ENOTSUP'].includes(getErrnoCode(error) ?? '')
+    ) {
+      return
+    }
+    throw error
+  }
+}
+
+async function writeTrustedAgentFile(
+  location: AgentDirectoryLocation,
+  filename: string,
+  content: string,
+  checkExists: boolean,
+): Promise<void> {
+  validateAgentFilename(filename)
+  const pinned = await pinTrustedAgentDirectory(location, true)
+  if (pinned === undefined) throw new Error('agent directory is unavailable')
+  const targetPath = join(pinned.operationPath, filename)
+  const displayPath = join(resolve(location.directory), filename)
+  const temporaryFilename = `.${filename}.${process.pid}.${randomUUID()}.tmp`
+  const temporaryPath = join(pinned.operationPath, temporaryFilename)
+  let temporaryHandle: Awaited<ReturnType<typeof open>> | undefined
+  let renamed = false
+  try {
+    const existing = await inspectTrustedAgentFile(targetPath, pinned)
+    if (checkExists && existing !== undefined) throwAgentFileExists(displayPath)
+    await assertPinnedAgentDirectoryCurrent(pinned)
+
+    const targetMode = existing === undefined
+      ? 0o600
+      : Number(existing.mode) & 0o777
+    temporaryHandle = await open(
+      temporaryPath,
+      constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        (constants.O_NOFOLLOW ?? 0),
+      targetMode,
+    )
+    // open(2) applies umask even when replacing an existing file. Restore the
+    // intended private/new mode or the exact existing mode on the temporary
+    // inode before it can be published.
+    await temporaryHandle.chmod(targetMode)
+    const opened = await temporaryHandle.stat()
+    const canonicalTemporary = await realpath(temporaryPath)
+    if (
+      !opened.isFile() ||
+      opened.nlink !== 1 ||
+      !isSameOrChildPath(pinned.canonicalDirectory, canonicalTemporary)
+    ) {
+      throw new Error('temporary agent file is unsafe')
+    }
+
+    await temporaryHandle.writeFile(content, { encoding: 'utf-8' })
+    await temporaryHandle.datasync()
+    const afterWrite = await temporaryHandle.stat()
+    if (
+      !afterWrite.isFile() ||
+      afterWrite.nlink !== 1 ||
+      !isSameIdentity(afterWrite, opened)
+    ) {
+      throw new Error('temporary agent file changed while writing')
+    }
+
+    await agentFileOperationHookForTesting?.({
+      phase: 'before-commit',
+      directory: resolve(location.directory),
+      filename,
+    })
+    await assertPinnedAgentDirectoryCurrent(pinned)
+    const current = await inspectTrustedAgentFile(targetPath, pinned)
+    if (
+      (existing === undefined && current !== undefined) ||
+      (existing !== undefined &&
+        (current === undefined ||
+          !isSameIdentity(current, existing) ||
+          current.canonicalPath !== existing.canonicalPath))
+    ) {
+      throw new Error('agent file changed during update')
+    }
+    const currentTemporary = await inspectTrustedAgentFile(
+      temporaryPath,
+      pinned,
+    )
+    if (
+      currentTemporary === undefined ||
+      !isSameIdentity(currentTemporary, opened) ||
+      currentTemporary.canonicalPath !== canonicalTemporary
+    ) {
+      throw new Error('temporary agent file changed before commit')
+    }
+
+    await rename(temporaryPath, targetPath)
+    renamed = true
+    const committed = await inspectTrustedAgentFile(targetPath, pinned)
+    if (committed === undefined || !isSameIdentity(committed, opened)) {
+      throw new Error('agent file changed while committing')
+    }
+    await assertPinnedAgentDirectoryCurrent(pinned)
+    await syncPinnedDirectory(pinned)
   } finally {
-    await handle.close()
+    await temporaryHandle?.close().catch(() => {})
+    if (!renamed) await unlink(temporaryPath).catch(() => {})
+    await closePinnedAgentDirectory(pinned)
+  }
+}
+
+async function deleteTrustedAgentFile(
+  location: AgentDirectoryLocation,
+  filename: string,
+): Promise<void> {
+  validateAgentFilename(filename)
+  const pinned = await pinTrustedAgentDirectory(location, false)
+  if (pinned === undefined) return
+  const targetPath = join(pinned.operationPath, filename)
+  try {
+    const existing = await inspectTrustedAgentFile(targetPath, pinned)
+    if (existing === undefined) return
+    await agentFileOperationHookForTesting?.({
+      phase: 'before-delete',
+      directory: resolve(location.directory),
+      filename,
+    })
+    await assertPinnedAgentDirectoryCurrent(pinned)
+    const current = await inspectTrustedAgentFile(targetPath, pinned)
+    if (
+      current === undefined ||
+      !isSameIdentity(current, existing) ||
+      current.canonicalPath !== existing.canonicalPath
+    ) {
+      throw new Error('agent file changed during deletion')
+    }
+    await unlink(targetPath)
+    if (await inspectTrustedAgentFile(targetPath, pinned) !== undefined) {
+      throw new Error('agent file still exists after deletion')
+    }
+    await assertPinnedAgentDirectoryCurrent(pinned)
+    await syncPinnedDirectory(pinned)
+  } finally {
+    await closePinnedAgentDirectory(pinned)
   }
 }

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -63,6 +63,7 @@ import type {
 import type { AgenCCompactProgressControls } from "./session-types.js";
 import type { McpServerMutationResult } from "../session/session.js";
 import { isRecord } from "../utils/record.js";
+import type { AgentRoleWorkspace } from "../agents/role-workspace.js";
 
 export const AGENC_DAEMON_RECONNECTING_MESSAGE =
   "daemon disconnected, reconnecting";
@@ -99,6 +100,8 @@ export interface AgenCDaemonConnectionState extends JsonObject {
 
 export interface AgenCTuiBridgeSession extends AgenCCompactProgressControls {
   readonly conversationId: string;
+  /** Preserved from the daemon/bootstrap session for immutable role discovery. */
+  readonly roleWorkspace?: Pick<AgentRoleWorkspace, "id" | "cwd">;
   readonly services: {
     approvalResolver?: ApprovalResolver;
     requestUserInputResolver?: {

--- a/runtime/src/tui/session-types.ts
+++ b/runtime/src/tui/session-types.ts
@@ -17,6 +17,7 @@ import type {
 } from "../elicitation/types.js";
 import type { AgenCRealtimeTuiControls } from "./realtime/controller.js";
 import type { FpsMetrics } from "../utils/fpsTracker.js";
+import type { AgentRoleWorkspace } from "../agents/role-workspace.js";
 
 export interface AgenCCompactProgressControls {
   setStreamMode?(mode: "requesting" | "responding" | null): void;
@@ -38,6 +39,14 @@ export interface PermissionModeRegistryLike {
 
 export interface AgenCBridgeSession extends AgenCCompactProgressControls {
   readonly conversationId: string;
+  /** Immutable role-discovery identity; execution cwd may move independently. */
+  readonly roleWorkspace?: Pick<AgentRoleWorkspace, "id" | "cwd">;
+  readonly agentDefinitions?: {
+    readonly agentRoleWorkspaceId: string;
+    readonly activeAgents: readonly unknown[];
+    readonly allAgents?: readonly unknown[];
+    readonly allowedAgentTypes?: readonly unknown[];
+  };
   readonly services: {
     readonly permissionModeRegistry: PermissionModeRegistryLike;
     readonly configStore?: ConfigStore;

--- a/runtime/src/utils/agentContext.ts
+++ b/runtime/src/utils/agentContext.ts
@@ -25,6 +25,18 @@ import { AsyncLocalStorage } from 'async_hooks'
 import { isAgentSwarmsEnabled } from './agentSwarmsEnabled.js'
 
 /**
+ * Exact persistent-memory grant for one agent role.
+ *
+ * This is deliberately separate from AgentContext identity: a foreground
+ * main-thread turn may select an agent role without becoming a subagent (and
+ * without changing request attribution or telemetry).
+ */
+export type AgentMemoryAuthorization = {
+  readonly agentType: string
+  readonly scope: 'user' | 'project' | 'local'
+}
+
+/**
  * Context for subagents (Agent tool agents).
  * Subagents run in-process for quick, delegated tasks.
  */
@@ -50,6 +62,8 @@ export type SubagentContext = {
    *  Reset to false on each spawn/resume; flipped true by
    *  consumeInvokingRequestId() on the first terminal API event. */
   invocationEmitted?: boolean
+  /** Exact persistent-memory directory this agent may access implicitly. */
+  memoryAuthorization?: AgentMemoryAuthorization
 }
 
 /**
@@ -81,6 +95,8 @@ export type TeammateAgentContext = {
   invocationKind?: 'spawn' | 'resume'
   /** Mutable flag: see SubagentContext.invocationEmitted. */
   invocationEmitted?: boolean
+  /** Exact persistent-memory directory this teammate may access implicitly. */
+  memoryAuthorization?: AgentMemoryAuthorization
 }
 
 /**
@@ -90,6 +106,14 @@ export type TeammateAgentContext = {
 export type AgentContext = SubagentContext | TeammateAgentContext
 
 const agentContextStorage = new AsyncLocalStorage<AgentContext>()
+
+type AgentMemoryAuthorizationScope = {
+  /** Undefined is an explicit fail-closed override inside this scope. */
+  readonly authorization: AgentMemoryAuthorization | undefined
+}
+
+const agentMemoryAuthorizationStorage =
+  new AsyncLocalStorage<AgentMemoryAuthorizationScope>()
 
 /**
  * Get the current agent context, if any.
@@ -106,6 +130,34 @@ export function getAgentContext(): AgentContext | undefined {
  */
 export function runWithAgentContext<T>(context: AgentContext, fn: () => T): T {
   return agentContextStorage.run(context, fn)
+}
+
+/**
+ * Get the persistent-memory grant for the current async execution chain.
+ *
+ * A dedicated foreground scope takes precedence, including an explicit
+ * undefined grant. Outside such a scope, background AgentTool/teammate work
+ * continues to inherit the grant carried by its AgentContext.
+ */
+export function getAgentMemoryAuthorization():
+  | AgentMemoryAuthorization
+  | undefined {
+  const foregroundScope = agentMemoryAuthorizationStorage.getStore()
+  if (foregroundScope !== undefined) {
+    return foregroundScope.authorization
+  }
+  return getAgentContext()?.memoryAuthorization
+}
+
+/**
+ * Run work with a foreground role's exact memory grant without assigning a
+ * subagent/teammate identity or changing main-thread request attribution.
+ */
+export function runWithAgentMemoryAuthorization<T>(
+  authorization: AgentMemoryAuthorization | undefined,
+  fn: () => T,
+): T {
+  return agentMemoryAuthorizationStorage.run({ authorization }, fn)
 }
 
 /**

--- a/runtime/src/utils/markdownConfigLoader.ts
+++ b/runtime/src/utils/markdownConfigLoader.ts
@@ -1,9 +1,9 @@
 import { feature } from 'bun:bundle'
-import { statSync } from 'fs'
-import { readdir, readFile, realpath, stat } from 'fs/promises'
+import { constants, statSync } from 'fs'
+import { lstat, open, readdir, realpath, stat } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { homedir } from 'os'
-import { dirname, join, resolve, sep } from 'path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'path'
 import { getProjectRoot } from '../bootstrap/state.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { getAgenCConfigHomeDir, isEnvTruthy } from './envUtils.js'
@@ -290,11 +290,10 @@ export function getProjectDirsUpToHome(
  * @param cwd Current working directory for project directory traversal
  * @returns Array of parsed markdown files with metadata
  */
-export const loadMarkdownFilesForSubdir = memoize(
-  async function (
-    subdir: AgenCConfigDirectory,
-    cwd: string,
-  ): Promise<MarkdownFile[]> {
+async function loadMarkdownFilesForSubdirUncached(
+  subdir: AgenCConfigDirectory,
+  cwd: string,
+): Promise<MarkdownFile[]> {
     const userDir = join(getAgenCConfigHomeDir(), subdir)
     const managedDir = join(getManagedFilePath(), '.agenc', subdir)
     const projectDirs = getProjectDirsUpToHome(subdir, cwd)
@@ -409,10 +408,21 @@ export const loadMarkdownFilesForSubdir = memoize(
     }
 
     return deduplicatedFiles
-  },
+}
+
+export const loadMarkdownFilesForSubdir = memoize(
+  loadMarkdownFilesForSubdirUncached,
   // Custom resolver creates cache key from both subdir and cwd parameters
   (subdir: AgenCConfigDirectory, cwd: string) => `${subdir}:${cwd}`,
 )
+
+/** Read through every discovery layer without consulting the UI catalog cache. */
+export function loadMarkdownFilesForSubdirFresh(
+  subdir: AgenCConfigDirectory,
+  cwd: string,
+): Promise<MarkdownFile[]> {
+  return loadMarkdownFilesForSubdirUncached(subdir, cwd)
+}
 
 /**
  * Native implementation to find markdown files using Node.js fs APIs
@@ -423,9 +433,9 @@ export const loadMarkdownFilesForSubdir = memoize(
  * 3. Can be explicitly enabled via AGENC_USE_NATIVE_FILE_SEARCH env var
  *
  * Symlink handling:
- * - Follows symlinks (equivalent to ripgrep's --follow flag)
- * - Uses device+inode tracking to detect cycles (same as ripgrep's same_file library)
- * - Falls back to realpath on systems without inode support
+ * - Does not follow symlinked files or directories across a configuration
+ *   tier boundary. Callers bind discovered content to that tier's authority.
+ * - Uses device+inode tracking as defense in depth for unusual filesystems.
  *
  * Does not respect .gitignore (matches ripgrep with --no-ignore flag)
  *
@@ -483,22 +493,11 @@ async function findMarkdownFilesNative(
         const fullPath = join(currentDir, entry.name)
 
         try {
-          // Handle symlinks: isFile() and isDirectory() return false for symlinks
+          // Never traverse or read symlinks from a configuration tier. A
+          // project-controlled link must not import role/prompt content from
+          // another workspace or a network mount.
           if (entry.isSymbolicLink()) {
-            try {
-              const stats = await stat(fullPath) // stat() follows symlinks
-              if (stats.isDirectory()) {
-                await walk(fullPath)
-              } else if (stats.isFile() && entry.name.endsWith('.md')) {
-                files.push(fullPath)
-              }
-            } catch (error) {
-              const errorMessage =
-                error instanceof Error ? error.message : String(error)
-              logForDebugging(
-                `Failed to follow symlink ${fullPath}: ${errorMessage}`,
-              )
-            }
+            continue
           } else if (entry.isDirectory()) {
             await walk(fullPath)
           } else if (entry.isFile() && entry.name.endsWith('.md')) {
@@ -535,6 +534,17 @@ async function loadMarkdownFiles(dir: string): Promise<
     content: string
   }[]
 > {
+  let canonicalDir: string
+  try {
+    const lexicalDir = await lstat(dir)
+    if (!lexicalDir.isDirectory() || lexicalDir.isSymbolicLink()) return []
+    const canonicalAnchor = await realpath(dirname(dirname(dir)))
+    canonicalDir = await realpath(dir)
+    if (!isSameOrChildPath(canonicalAnchor, canonicalDir)) return []
+  } catch (error) {
+    if (isFsInaccessible(error)) return []
+    throw error
+  }
   // File search strategy:
   // - Default: ripgrep (faster, battle-tested)
   // - Fallback: native Node.js (when AGENC_USE_NATIVE_FILE_SEARCH is set)
@@ -547,7 +557,7 @@ async function loadMarkdownFiles(dir: string): Promise<
     files = useNative
       ? await findMarkdownFilesNative(dir, signal)
       : await ripGrep(
-          ['--files', '--hidden', '--follow', '--no-ignore', '--glob', '*.md'],
+          ['--files', '--hidden', '--no-ignore', '--glob', '*.md'],
           dir,
           signal,
         )
@@ -561,8 +571,50 @@ async function loadMarkdownFiles(dir: string): Promise<
 
   const results = await Promise.all(
     files.map(async filePath => {
+      let handle: Awaited<ReturnType<typeof open>> | undefined
       try {
-        const rawContent = await readFile(filePath, { encoding: 'utf-8' })
+        const lexicalFile = await lstat(filePath)
+        if (
+          !lexicalFile.isFile() ||
+          lexicalFile.isSymbolicLink() ||
+          lexicalFile.nlink !== 1
+        ) return null
+        const canonicalFile = await realpath(filePath)
+        if (!isSameOrChildPath(canonicalDir, canonicalFile)) return null
+        handle = await open(
+          filePath,
+          constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+        )
+        const opened = await handle.stat()
+        if (
+          !opened.isFile() ||
+          opened.nlink !== 1 ||
+          opened.dev !== lexicalFile.dev ||
+          opened.ino !== lexicalFile.ino
+        ) {
+          return null
+        }
+        const rawContent = await handle.readFile({ encoding: 'utf-8' })
+        const [afterRead, pathAfterRead, canonicalAfterRead] = await Promise.all([
+          handle.stat(),
+          lstat(filePath),
+          realpath(filePath),
+        ])
+        if (
+          !afterRead.isFile() ||
+          afterRead.nlink !== 1 ||
+          afterRead.dev !== opened.dev ||
+          afterRead.ino !== opened.ino ||
+          !pathAfterRead.isFile() ||
+          pathAfterRead.isSymbolicLink() ||
+          pathAfterRead.nlink !== 1 ||
+          pathAfterRead.dev !== opened.dev ||
+          pathAfterRead.ino !== opened.ino ||
+          canonicalAfterRead !== canonicalFile ||
+          !isSameOrChildPath(canonicalDir, canonicalAfterRead)
+        ) {
+          return null
+        }
         const { frontmatter, content } = parseFrontmatter(rawContent, filePath)
 
         return {
@@ -577,9 +629,20 @@ async function loadMarkdownFiles(dir: string): Promise<
           `Failed to read/parse markdown file:  ${filePath}: ${errorMessage}`,
         )
         return null
+      } finally {
+        await handle?.close().catch(() => {})
       }
     }),
   )
 
   return results.filter(_ => _ !== null)
+}
+
+function isSameOrChildPath(parent: string, candidate: string): boolean {
+  const child = relative(parent, candidate)
+  return child === '' || (
+    child !== '..' &&
+    !child.startsWith(`..${sep}`) &&
+    !isAbsolute(child)
+  )
 }

--- a/runtime/src/utils/permissions/filesystem.ts
+++ b/runtime/src/utils/permissions/filesystem.ts
@@ -10,7 +10,12 @@ import {
   isAutoMemPath,
   isGlobalMemoryPath,
 } from 'src/memory/index.js'
-import { isAgentMemoryPath } from 'src/tools/AgentTool/agentMemory.js'
+import {
+  isAnyAgentMemoryPath,
+  isAuthorizedAgentMemoryPath,
+} from 'src/tools/AgentTool/agentMemory.js'
+import { peekAmbientRuntimeSession } from '../../session/current-session.js'
+import { getAgentMemoryAuthorization } from '../agentContext.js'
 import {
   AGENC_FOLDER_PERMISSION_PATTERN,
   FILE_EDIT_TOOL_NAME,
@@ -1181,6 +1186,14 @@ function computeReadDecision(
     }
   }
 
+  // Agent-memory namespaces are private to one exact workspace role. Enforce
+  // this before generic working-directory and edit-implies-read allowances;
+  // otherwise a project/local memory hardlink or sibling role file inside the
+  // workspace would bypass the identity check. A safetyCheck result remains
+  // fail-closed even under bypassPermissions.
+  const agentMemoryDecision = checkAgentMemoryBoundary(pathsToCheck, input)
+  if (agentMemoryDecision !== null) return agentMemoryDecision
+
   // 5. Edit access implies read access (but only if no read-specific deny/ask rules exist)
   // We check this after read-specific rules so that explicit read restrictions take precedence
   const editResult = checkWritePermissionForTool(
@@ -1212,7 +1225,11 @@ function computeReadDecision(
 
   // 7. Allow reads from internal harness paths (session-memory, plans, tool-results)
   const absolutePath = expandPath(path)
-  const internalReadResult = checkReadableInternalPath(absolutePath, input)
+  const internalReadResult = checkReadableInternalPath(
+    absolutePath,
+    input,
+    pathsToCheck,
+  )
   if (internalReadResult.behavior !== 'passthrough') {
     return internalReadResult
   }
@@ -1298,12 +1315,17 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
     }
   }
 
+
+  const agentMemoryDecision = checkAgentMemoryBoundary(pathsToCheck, input)
+  if (agentMemoryDecision !== null) return agentMemoryDecision
+
   // 1.5. Allow writes to internal editable paths (plan files, scratchpad)
   // This MUST come before isDangerousFilePathToAutoEdit check since .agenc is a dangerous directory
   const absolutePathForEdit = expandPath(path)
   const internalEditResult = checkEditableInternalPath(
     absolutePathForEdit,
     input,
+    pathsToCheck,
   )
   if (internalEditResult.behavior !== 'passthrough') {
     return internalEditResult
@@ -1471,6 +1493,51 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   }
 }
 
+function checkAgentMemoryBoundary(
+  pathsToCheck: readonly string[],
+  input: { [key: string]: unknown },
+): PermissionDecision | null {
+  const roleWorkspaceCwd =
+    peekAmbientRuntimeSession()?.roleWorkspace.cwd ?? getOriginalCwd()
+  if (
+    !pathsToCheck.some(path =>
+      isAnyAgentMemoryPath(path, roleWorkspaceCwd),
+    )
+  ) {
+    return null
+  }
+
+  const authorization = getAgentMemoryAuthorization()
+  if (
+    pathsToCheck.length > 0 &&
+    pathsToCheck.every(path =>
+      isAuthorizedAgentMemoryPath(
+        path,
+        roleWorkspaceCwd,
+        authorization,
+      ),
+    )
+  ) {
+    return {
+      behavior: 'allow',
+      updatedInput: input,
+      decisionReason: { type: 'mode', mode: 'default' },
+    }
+  }
+
+  const message =
+    'Agent memory access requires the exact authorized workspace role and a private regular file.'
+  return {
+    behavior: 'ask',
+    message,
+    decisionReason: {
+      type: 'safetyCheck',
+      reason: message,
+      classifierApprovable: false,
+    },
+  }
+}
+
 export function generateSuggestions(
   filePath: string,
   operationType: 'read' | 'write' | 'create',
@@ -1539,6 +1606,7 @@ export function generateSuggestions(
 export function checkEditableInternalPath(
   absolutePath: string,
   input: { [key: string]: unknown },
+  pathsToCheck?: readonly string[],
 ): PermissionResult {
   // SECURITY: Normalize path to prevent traversal bypasses via .. segments
   // This is defense-in-depth; individual helper functions also normalize
@@ -1611,7 +1679,21 @@ export function checkEditableInternalPath(
   }
 
   // Agent memory directory (for self-improving agents)
-  if (isAgentMemoryPath(normalizedPath)) {
+  const roleWorkspaceCwd =
+    peekAmbientRuntimeSession()?.roleWorkspace.cwd ?? null
+  const memoryAuthorization = getAgentMemoryAuthorization()
+  const agentMemoryPathForms =
+    pathsToCheck ?? getPathsForPermissionCheck(normalizedPath)
+  if (
+    agentMemoryPathForms.length > 0 &&
+    agentMemoryPathForms.every(path =>
+      isAuthorizedAgentMemoryPath(
+        path,
+        roleWorkspaceCwd,
+        memoryAuthorization,
+      )
+    )
+  ) {
     return {
       behavior: 'allow',
       updatedInput: input,
@@ -1674,6 +1756,7 @@ export function checkEditableInternalPath(
 export function checkReadableInternalPath(
   absolutePath: string,
   input: { [key: string]: unknown },
+  pathsToCheck?: readonly string[],
 ): PermissionResult {
   // SECURITY: Normalize path to prevent traversal bypasses via .. segments
   // This is defense-in-depth; individual helper functions also normalize
@@ -1764,7 +1847,21 @@ export function checkReadableInternalPath(
   }
 
   // Agent memory directory (for self-improving agents)
-  if (isAgentMemoryPath(normalizedPath)) {
+  const roleWorkspaceCwd =
+    peekAmbientRuntimeSession()?.roleWorkspace.cwd ?? null
+  const memoryAuthorization = getAgentMemoryAuthorization()
+  const agentMemoryPathForms =
+    pathsToCheck ?? getPathsForPermissionCheck(normalizedPath)
+  if (
+    agentMemoryPathForms.length > 0 &&
+    agentMemoryPathForms.every(path =>
+      isAuthorizedAgentMemoryPath(
+        path,
+        roleWorkspaceCwd,
+        memoryAuthorization,
+      )
+    )
+  ) {
     return {
       behavior: 'allow',
       updatedInput: input,

--- a/runtime/src/utils/permissions/pathValidation.ts
+++ b/runtime/src/utils/permissions/pathValidation.ts
@@ -167,7 +167,11 @@ export function isPathAllowed(
   // and internal editable paths live under ~/.agenc/ — matching the ordering in
   // checkWritePermissionForTool (filesystem.ts step 1.5)
   if (operationType !== 'read') {
-    const internalEditResult = checkEditableInternalPath(resolvedPath, {})
+    const internalEditResult = checkEditableInternalPath(
+      resolvedPath,
+      {},
+      precomputedPathsToCheck,
+    )
     if (internalEditResult.behavior === 'allow') {
       return {
         allowed: true,
@@ -214,7 +218,11 @@ export function isPathAllowed(
   // 3.5. For read operations, check internal readable paths (project temp dir, session memory, etc.)
   // This allows reading agent output files without explicit permission
   if (operationType === 'read') {
-    const internalReadResult = checkReadableInternalPath(resolvedPath, {})
+    const internalReadResult = checkReadableInternalPath(
+      resolvedPath,
+      {},
+      precomputedPathsToCheck,
+    )
     if (internalReadResult.behavior === 'allow') {
       return {
         allowed: true,

--- a/runtime/src/utils/sessionStorage.ts
+++ b/runtime/src/utils/sessionStorage.ts
@@ -1,5 +1,5 @@
 import { feature } from 'bun:bundle'
-import type { UUID } from 'crypto'
+import { randomUUID, type UUID } from 'crypto'
 import type { Dirent } from 'fs'
 // Sync fs primitives for readFileTailSync — separate from fs/promises
 // imports above. Named (not wildcard) per AGENC.md style; no collisions
@@ -8,10 +8,13 @@ import { closeSync, fstatSync, openSync, readSync } from 'fs'
 import {
   appendFile as fsAppendFile,
   open as fsOpen,
+  lstat,
   mkdir,
+  rename,
   readdir,
   readFile,
   stat,
+  unlink,
   writeFile,
 } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
@@ -64,7 +67,7 @@ import { getCwd } from './cwd.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { logForDiagnosticsNoPII } from './diagLogs.js'
 import { getAgenCConfigHomeDir, isEnvTruthy } from './envUtils.js'
-import { isFsInaccessible } from './errors.js'
+import { getErrnoCode, isFsInaccessible } from './errors.js'
 import type { FileHistorySnapshot } from './fileHistory.js'
 import { formatFileSize } from './format.js'
 import { getFsImplementation } from './fsOperations.js'
@@ -257,12 +260,49 @@ function getAgentMetadataPath(agentId: AgentId): string {
 
 export type AgentMetadata = {
   agentType: string
+  /** Immutable role trust domain captured when the agent was spawned. */
+  agentRoleWorkspaceId?: string
+  /** Content identity of the resolved role definition at spawn time. */
+  agentRoleFingerprint?: string
   /** Worktree path if the agent was spawned with isolation: "worktree" */
   worktreePath?: string
   /** Original task description from the AgentTool input. Persisted so a
    * resumed agent's notification can show the original description instead
    * of a placeholder. Optional — older metadata files lack this field. */
   description?: string
+}
+
+export type AgentMetadataWrite = AgentMetadata & {
+  agentRoleWorkspaceId: string
+  agentRoleFingerprint: string
+}
+
+export class InvalidAgentSidecarMetadataError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'InvalidAgentSidecarMetadataError'
+  }
+}
+
+type AgentMetadataWritePhase = 'temporary-file-synced'
+
+type AgentMetadataWritePhaseForTesting = (
+  phase: AgentMetadataWritePhase,
+  paths: {
+    readonly targetPath: string
+    readonly temporaryPath: string
+  },
+) => void | Promise<void>
+
+let agentMetadataWritePhaseForTesting:
+  | AgentMetadataWritePhaseForTesting
+  | undefined
+
+/** @internal Deterministic crash-ordering seam for sidecar persistence tests. */
+export function __setAgentMetadataWritePhaseForTesting(
+  callback: AgentMetadataWritePhaseForTesting | undefined,
+): void {
+  agentMetadataWritePhaseForTesting = callback
 }
 
 /**
@@ -276,15 +316,95 @@ export type AgentMetadata = {
  */
 export async function writeAgentMetadata(
   agentId: AgentId,
-  metadata: AgentMetadata,
+  metadata: AgentMetadataWrite,
 ): Promise<void> {
   const path = getAgentMetadataPath(agentId)
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, JSON.stringify(metadata))
+  const normalized = normalizeAgentSidecarMetadata(metadata)
+  const directory = dirname(path)
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  await writeAgentMetadataAtomically(
+    path,
+    JSON.stringify(normalized),
+    await existingAgentMetadataMode(path),
+  )
+}
+
+async function existingAgentMetadataMode(path: string): Promise<number> {
+  try {
+    const metadata = await lstat(path)
+    return metadata.isFile() ? metadata.mode & 0o777 : 0o600
+  } catch (error) {
+    if (getErrnoCode(error) === 'ENOENT') return 0o600
+    throw error
+  }
+}
+
+async function writeAgentMetadataAtomically(
+  path: string,
+  contents: string,
+  mode: number,
+): Promise<void> {
+  const directory = dirname(path)
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`
+  let handle: Awaited<ReturnType<typeof fsOpen>> | undefined
+  let renamed = false
+  try {
+    // O_EXCL prevents a pre-existing link from redirecting the temporary
+    // write. A unique name lets concurrent writers publish only complete JSON.
+    handle = await fsOpen(temporaryPath, 'wx', mode)
+    await handle.writeFile(contents, { encoding: 'utf8' })
+    // open(2) applies the process umask even when replacing an existing file.
+    // Restore the captured mode explicitly before publishing the new inode.
+    await handle.chmod(mode)
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+
+    await agentMetadataWritePhaseForTesting?.('temporary-file-synced', {
+      targetPath: path,
+      temporaryPath,
+    })
+
+    await rename(temporaryPath, path)
+    renamed = true
+    await fsyncAgentMetadataDirectory(directory)
+  } catch (error) {
+    if (handle !== undefined) {
+      await handle.close().catch(() => {})
+    }
+    if (!renamed) {
+      await unlink(temporaryPath).catch(() => {})
+    }
+    throw error
+  }
+}
+
+async function fsyncAgentMetadataDirectory(directory: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof fsOpen>> | undefined
+  try {
+    handle = await fsOpen(directory, 'r')
+    await handle.sync()
+  } catch (error) {
+    // Directory handles are not supported by Node on Windows. The temporary
+    // file itself was fsynced before rename; NTFS rename durability is the
+    // strongest portable guarantee available there.
+    if (
+      process.platform === 'win32' &&
+      ['EISDIR', 'EINVAL', 'EPERM', 'ENOTSUP'].includes(
+        getErrnoCode(error) ?? '',
+      )
+    ) {
+      return
+    }
+    throw error
+  } finally {
+    await handle?.close().catch(() => {})
+  }
 }
 
 export async function readAgentMetadata(
   agentId: AgentId,
+  options: { readonly strict?: boolean } = {},
 ): Promise<AgentMetadata | null> {
   const path = getAgentMetadataPath(agentId)
   let raw: string
@@ -295,13 +415,81 @@ export async function readAgentMetadata(
     throw e
   }
   try {
-    return JSON.parse(raw) as AgentMetadata
+    return normalizeAgentSidecarMetadata(JSON.parse(raw) as unknown)
   } catch (e) {
-    // Skip corrupt files — a partial write from a crashed fire-and-forget
-    // persist shouldn't take down the whole resume.
+    if (options.strict) {
+      throw e instanceof InvalidAgentSidecarMetadataError
+        ? e
+        : new InvalidAgentSidecarMetadataError(
+            `invalid agent metadata sidecar: ${path}`,
+            { cause: e },
+          )
+    }
+    // Compatibility readers ignore legacy corrupt sidecars. Resume passes
+    // strict=true and fails closed instead; current writes publish atomically.
     logForDebugging(`readAgentMetadata: skipping ${path}: ${String(e)}`)
     return null
   }
+}
+
+function normalizeAgentSidecarMetadata(value: unknown): AgentMetadata {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new InvalidAgentSidecarMetadataError('agent metadata must be an object')
+  }
+  const record = value as Record<string, unknown>
+  const agentType = requiredNonEmptyMetadataString(record.agentType, 'agentType')
+  const agentRoleWorkspaceId = optionalNonEmptyMetadataString(
+    record.agentRoleWorkspaceId,
+    'agentRoleWorkspaceId',
+  )
+  const agentRoleFingerprint = optionalNonEmptyMetadataString(
+    record.agentRoleFingerprint,
+    'agentRoleFingerprint',
+  )
+  const worktreePath = optionalNonEmptyMetadataString(
+    record.worktreePath,
+    'worktreePath',
+  )
+  if (
+    record.description !== undefined &&
+    typeof record.description !== 'string'
+  ) {
+    throw new InvalidAgentSidecarMetadataError(
+      'agent metadata description must be a string',
+    )
+  }
+  return {
+    agentType,
+    ...(agentRoleWorkspaceId !== undefined ? { agentRoleWorkspaceId } : {}),
+    ...(agentRoleFingerprint !== undefined ? { agentRoleFingerprint } : {}),
+    ...(worktreePath !== undefined ? { worktreePath } : {}),
+    ...(record.description !== undefined
+      ? { description: record.description as string }
+      : {}),
+  }
+}
+
+function requiredNonEmptyMetadataString(value: unknown, field: string): string {
+  const normalized = optionalNonEmptyMetadataString(value, field)
+  if (normalized === undefined) {
+    throw new InvalidAgentSidecarMetadataError(
+      `agent metadata ${field} is required`,
+    )
+  }
+  return normalized
+}
+
+function optionalNonEmptyMetadataString(
+  value: unknown,
+  field: string,
+): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new InvalidAgentSidecarMetadataError(
+      `agent metadata ${field} must be a non-empty string`,
+    )
+  }
+  return value
 }
 
 export function sessionIdExists(sessionId: string): boolean {

--- a/runtime/src/utils/swarm/inProcessRolePolicy.ts
+++ b/runtime/src/utils/swarm/inProcessRolePolicy.ts
@@ -1,0 +1,58 @@
+import type { TeammateIdentity } from '../../tasks/InProcessTeammateTask/types.js'
+import type { AgentDefinition } from '../../tools/AgentTool/loadAgentsDir.js'
+import { SEND_MESSAGE_TOOL_NAME } from '../../tools/SendMessageTool/constants.js'
+import { TASK_CREATE_TOOL_NAME } from '../../tools/TaskCreateTool/constants.js'
+import { TASK_GET_TOOL_NAME } from '../../tools/TaskGetTool/constants.js'
+import { TASK_LIST_TOOL_NAME } from '../../tools/TaskListTool/constants.js'
+import { TASK_UPDATE_TOOL_NAME } from '../../tools/TaskUpdateTool/constants.js'
+import { TEAM_CREATE_TOOL_NAME } from '../../tools/TeamCreateTool/constants.js'
+import { TEAM_DELETE_TOOL_NAME } from '../../tools/TeamDeleteTool/constants.js'
+
+const TEAM_COORDINATION_TOOLS = Object.freeze([
+  SEND_MESSAGE_TOOL_NAME,
+  TEAM_CREATE_TOOL_NAME,
+  TEAM_DELETE_TOOL_NAME,
+  TASK_CREATE_TOOL_NAME,
+  TASK_GET_TOOL_NAME,
+  TASK_LIST_TOOL_NAME,
+  TASK_UPDATE_TOOL_NAME,
+])
+
+/**
+ * Retain the selected role's executable policy while adding only the
+ * coordination tools an in-process teammate needs. The normal AgentTool
+ * resolver still applies disallowedTools after this allowlist merge, so an
+ * explicit deny always wins.
+ */
+export function resolveInProcessAgentDefinition(opts: {
+  readonly identity: TeammateIdentity
+  readonly teammateSystemPrompt: string
+  readonly agentDefinition?: AgentDefinition
+}): AgentDefinition {
+  const {
+    agentRoleFingerprint: _agentRoleFingerprint,
+    ...selected
+  } = opts.agentDefinition ?? {
+    agentType: opts.identity.agentName,
+    whenToUse: `In-process teammate: ${opts.identity.agentName}`,
+    source: 'projectSettings' as const,
+    getSystemPrompt: () => opts.teammateSystemPrompt,
+  }
+  const selectedTools = opts.agentDefinition?.tools
+  return {
+    ...selected,
+    ...(opts.agentDefinition === undefined
+      ? {
+          agentType: opts.identity.agentName,
+          whenToUse: `In-process teammate: ${opts.identity.agentName}`,
+        }
+      : {}),
+    getSystemPrompt: () => opts.teammateSystemPrompt,
+    ...(selectedTools !== undefined
+      ? { tools: [...new Set([...selectedTools, ...TEAM_COORDINATION_TOOLS])] }
+      : {}),
+    permissionMode: opts.identity.planModeRequired
+      ? 'plan'
+      : (opts.agentDefinition?.permissionMode ?? 'default'),
+  } as AgentDefinition
+}

--- a/runtime/src/utils/swarm/inProcessRunner.ts
+++ b/runtime/src/utils/swarm/inProcessRunner.ts
@@ -40,17 +40,10 @@ import {
   getProgressUpdate,
   updateProgressFromMessage,
 } from '../../tasks/LocalAgentTask/LocalAgentTask.js'
-import type { CustomAgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
+import type { AgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
 import { runAgent } from '../../tools/AgentTool/runAgent.js'
 import { awaitClassifierAutoApproval } from '../../tools/BashTool/bashPermissions.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
-import { SEND_MESSAGE_TOOL_NAME } from '../../tools/SendMessageTool/constants.js'
-import { TASK_CREATE_TOOL_NAME } from '../../tools/TaskCreateTool/constants.js'
-import { TASK_GET_TOOL_NAME } from '../../tools/TaskGetTool/constants.js'
-import { TASK_LIST_TOOL_NAME } from '../../tools/TaskListTool/constants.js'
-import { TASK_UPDATE_TOOL_NAME } from '../../tools/TaskUpdateTool/constants.js'
-import { TEAM_CREATE_TOOL_NAME } from '../../tools/TeamCreateTool/constants.js'
-import { TEAM_DELETE_TOOL_NAME } from '../../tools/TeamDeleteTool/constants.js'
 import type { Message } from '../../types/message.js'
 import type { PermissionDecision } from '../../types/permissions.js'
 import {
@@ -102,6 +95,7 @@ import {
   sendPermissionRequestViaMailbox,
 } from './permissionSync.js'
 import { TEAMMATE_SYSTEM_PROMPT_ADDENDUM } from './teammatePromptAddendum.js'
+import { resolveInProcessAgentDefinition } from './inProcessRolePolicy.js'
 
 type SetAppStateFn = (updater: (prev: AppState) => AppState) => void
 
@@ -494,7 +488,7 @@ export type InProcessRunnerConfig = {
   /** Initial prompt for the teammate */
   prompt: string
   /** Optional agent definition (for specialized agents) */
-  agentDefinition?: CustomAgentDefinition
+  agentDefinition?: AgentDefinition
   /** Teammate context for AsyncLocalStorage */
   teammateContext: TeammateContext
   /** Parent's tool use context */
@@ -937,6 +931,14 @@ export async function runInProcessTeammate(
     invokingRequestId,
     invocationKind: 'spawn',
     invocationEmitted: false,
+    ...(agentDefinition?.memory !== undefined
+      ? {
+          memoryAuthorization: {
+            agentType: agentDefinition.agentType,
+            scope: agentDefinition.memory,
+          },
+        }
+      : {}),
   }
 
   // Build system prompt based on systemPromptMode
@@ -972,36 +974,11 @@ export async function runInProcessTeammate(
     teammateSystemPrompt = systemPromptParts.join('\n')
   }
 
-  // Resolve agent definition - use full system prompt with teammate addendum
-  // IMPORTANT: Set permissionMode to 'default' so teammates always get full tool
-  // access regardless of the leader's permission mode.
-  const resolvedAgentDefinition: CustomAgentDefinition = {
-    agentType: identity.agentName,
-    whenToUse: `In-process teammate: ${identity.agentName}`,
-    getSystemPrompt: () => teammateSystemPrompt,
-    // Inject team-essential tools so teammates can always respond to
-    // shutdown requests, send messages, and coordinate via the task list,
-    // even with explicit tool lists
-    tools: agentDefinition?.tools
-      ? [
-          ...new Set([
-            ...agentDefinition.tools,
-            SEND_MESSAGE_TOOL_NAME,
-            TEAM_CREATE_TOOL_NAME,
-            TEAM_DELETE_TOOL_NAME,
-            TASK_CREATE_TOOL_NAME,
-            TASK_GET_TOOL_NAME,
-            TASK_LIST_TOOL_NAME,
-            TASK_UPDATE_TOOL_NAME,
-          ]),
-        ]
-      : ['*'],
-    source: 'projectSettings',
-    permissionMode: 'default',
-    // Propagate model from custom agent definition so getAgentModel()
-    // can use it as a fallback when no tool-level model is specified
-    ...(agentDefinition?.model ? { model: agentDefinition.model } : {}),
-  }
+  const resolvedAgentDefinition = resolveInProcessAgentDefinition({
+    identity,
+    teammateSystemPrompt,
+    agentDefinition,
+  })
 
   // All messages across all prompts
   const allMessages: Message[] = []
@@ -1197,6 +1174,7 @@ export async function runInProcessTeammate(
             availableTools: toolUseContext.options.tools,
             allowedTools,
             contentReplacementState: teammateReplacementState,
+            agentName: identity.agentName,
           })) {
             // Check lifecycle abort first (kills whole teammate)
             if (abortController.signal.aborted) {

--- a/runtime/src/utils/swarm/spawnInProcess.ts
+++ b/runtime/src/utils/swarm/spawnInProcess.ts
@@ -18,6 +18,7 @@ import { getSessionId } from '../../bootstrap/state.js'
 import { getSpinnerVerbs } from '../../constants/spinnerVerbs.js'
 import { TURN_COMPLETION_VERBS } from '../../constants/turnCompletionVerbs.js'
 import type { AppState } from '../../tui/state/AppState.js'
+import type { PermissionMode } from '../../permissions/types.js'
 import { createTaskStateBase, generateTaskId } from '../../tasks/Task.js'
 import type {
   InProcessTeammateTaskState,
@@ -64,6 +65,8 @@ export type InProcessSpawnConfig = {
   planModeRequired: boolean
   /** Optional model override for this teammate */
   model?: string
+  /** Initial policy mode inherited from the selected agent definition. */
+  permissionMode?: PermissionMode
 }
 
 /**
@@ -100,7 +103,15 @@ export async function spawnInProcessTeammate(
   config: InProcessSpawnConfig,
   context: SpawnContext,
 ): Promise<InProcessSpawnOutput> {
-  const { name, teamName, prompt, color, planModeRequired, model } = config
+  const {
+    name,
+    teamName,
+    prompt,
+    color,
+    planModeRequired,
+    model,
+    permissionMode,
+  } = config
   const { setAppState } = context
 
   // Generate deterministic agent ID
@@ -165,7 +176,9 @@ export async function spawnInProcessTeammate(
       awaitingPlanApproval: false,
       spinnerVerb: sample(getSpinnerVerbs()),
       pastTenseVerb: sample(TURN_COMPLETION_VERBS),
-      permissionMode: planModeRequired ? 'plan' : 'default',
+      permissionMode: planModeRequired
+        ? 'plan'
+        : (permissionMode ?? 'default'),
       isIdle: false,
       shutdownRequested: false,
       lastReportedToolCount: 0,

--- a/runtime/tests/agents/control.test.ts
+++ b/runtime/tests/agents/control.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
 import {
   AgentControl,
   AgentReferenceUnresolvedError,
@@ -11,9 +12,18 @@ import {
   renderInputPreview,
 } from "./control.js";
 import { AgentRegistry, type AgentMetadata } from "./registry.js";
-import { _resetNicknamePoolForTesting } from "./role.js";
+import {
+  _resetAgentRolesForTesting,
+  _resetNicknamePoolForTesting,
+  agentRoleFingerprint,
+  createAgentRoleWorkspace,
+  registerAgentRole,
+  requireAgentRole,
+} from "./role.js";
 import { RolloutStore } from "../session/rollout-store.js";
+import { ThreadManager } from "./thread-manager.js";
 import { SimpleMailbox, type InterAgentCommunication } from "../session/session.js";
+import { resolveStateDatabasePaths } from "../state/sqlite-driver.js";
 
 let agencHome = "";
 let originalAgencHome = "";
@@ -21,6 +31,7 @@ let originalAgencHome = "";
 function stubSession(opts: {
   rolloutStore?: RolloutStore | null;
   conversationId?: string;
+  cwd?: string;
   submit?: (
     message: string,
     opts?: { displayUserMessage?: string | null },
@@ -28,6 +39,7 @@ function stubSession(opts: {
 } = {}) {
   const emitted: unknown[] = [];
   const mailbox = new SimpleMailbox<InterAgentCommunication & { seq: number }>();
+  const cwd = opts.cwd ?? agencHome;
   return {
     emit: (e: unknown) => {
       emitted.push(e);
@@ -44,6 +56,8 @@ function stubSession(opts: {
     ...(opts.submit !== undefined ? { submit: opts.submit } : {}),
     rolloutStore: opts.rolloutStore ?? null,
     conversationId: opts.conversationId ?? "session-test",
+    roleWorkspace: createAgentRoleWorkspace(cwd),
+    sessionConfiguration: { cwd },
     _emitted: emitted,
   } as unknown as ConstructorParameters<typeof AgentControl>[0]["session"];
 }
@@ -71,15 +85,26 @@ function openRolloutStore(opts: {
   return store;
 }
 
+function roleProvenance(control: AgentControl, roleName: string) {
+  return {
+    agentRoleWorkspaceId: control.roleWorkspace.id,
+    agentRoleFingerprint: agentRoleFingerprint(
+      requireAgentRole(control.roleWorkspace, roleName),
+    ),
+  };
+}
+
 beforeEach(() => {
   agencHome = mkdtempSync(join(tmpdir(), "agenc-control-home-"));
   originalAgencHome = process.env.AGENC_HOME ?? "";
   process.env.AGENC_HOME = agencHome;
+  _resetAgentRolesForTesting();
   _resetNicknamePoolForTesting();
 });
 
 afterEach(() => {
   _resetNicknamePoolForTesting();
+  _resetAgentRolesForTesting();
   if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
   else delete process.env.AGENC_HOME;
   if (agencHome) rmSync(agencHome, { recursive: true, force: true });
@@ -94,6 +119,7 @@ describe("AgentControl", () => {
     expect(live.agentPath.startsWith("/root/")).toBe(true);
     expect(live.nickname).toBeDefined();
     expect(live.depth).toBe(1);
+    expect(live.metadata.agentRoleWorkspaceId).toBe(control.roleWorkspace.id);
   });
 
   it("spawn() can use an explicit task-name path segment", async () => {
@@ -144,6 +170,324 @@ describe("AgentControl", () => {
       control.spawn({ parentPath: "/root", roleName: "missing-role" }),
     ).rejects.toThrow("unknown agent_type 'missing-role'");
     expect(registry.activeCount).toBe(0);
+  });
+
+  it("spawn() atomically rejects changed expected role provenance before mutation", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    registerAgentRole(control.roleWorkspace, {
+      name: "scanner",
+      config: { disallowlist: ["Edit", "Write"] },
+    });
+    const expectedRole = requireAgentRole(control.roleWorkspace, "scanner");
+    const expectedRoleProvenance = {
+      agentRole: expectedRole.name,
+      agentRoleWorkspaceId: control.roleWorkspace.id,
+      agentRoleFingerprint: agentRoleFingerprint(expectedRole),
+    };
+
+    registerAgentRole(control.roleWorkspace, {
+      name: "scanner",
+      config: { disallowlist: [] },
+    });
+
+    await expect(
+      control.spawn({
+        parentPath: "/root",
+        roleName: "scanner",
+        expectedRoleProvenance,
+      }),
+    ).rejects.toThrow("cannot resume changed agent role: scanner");
+    expect(registry.activeCount).toBe(0);
+    expect(
+      (session as unknown as { childInboxes: Map<string, unknown> }).childInboxes,
+    ).toHaveLength(0);
+  });
+
+  it("spawn() does not alias-fallback when an expected workspace role was removed", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    registerAgentRole(control.roleWorkspace, {
+      name: "scanner",
+      config: { disallowlist: ["Edit", "Write"] },
+    });
+    const expectedRole = requireAgentRole(control.roleWorkspace, "scanner");
+    const expectedRoleProvenance = {
+      agentRole: expectedRole.name,
+      agentRoleWorkspaceId: control.roleWorkspace.id,
+      agentRoleFingerprint: agentRoleFingerprint(expectedRole),
+    };
+    _resetAgentRolesForTesting();
+
+    await expect(
+      control.spawn({
+        parentPath: "/root",
+        roleName: "scanner",
+        expectedRoleProvenance,
+      }),
+    ).rejects.toThrow("cannot resume unknown agent role: scanner");
+    expect(registry.activeCount).toBe(0);
+    expect(
+      (session as unknown as { childInboxes: Map<string, unknown> }).childInboxes,
+    ).toHaveLength(0);
+  });
+
+  it("spawn() preserves live state when thread IDs or durable provenance conflict", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-control-persist-a-"));
+    const rolloutStore = openRolloutStore({
+      cwd,
+      sessionId: "spawn-persistence-conflicts",
+    });
+    try {
+      const sessionA = stubSession({
+        rolloutStore,
+        cwd,
+        conversationId: "root-a",
+      });
+      const registryA = new AgentRegistry();
+      const controlA = new AgentControl({ session: sessionA, registry: registryA });
+      controlA.registerSessionRoot("root-a");
+      const existing = await controlA.spawn({
+        parentPath: "/root",
+        threadId: "duplicate-thread",
+        agentName: "existing",
+      });
+
+      await expect(
+        controlA.spawn({
+          parentPath: "/root",
+          threadId: "duplicate-thread",
+          agentName: "duplicate",
+        }),
+      ).rejects.toThrow("agent thread id already exists");
+      expect(registryA.activeCount).toBe(1);
+      expect(controlA.getLive(existing.agentId)).toBe(existing);
+      expect(registryA.agentIdForPath(existing.agentPath)).toBe(existing.agentId);
+      expect(registryA.agentIdForPath("/root/duplicate")).toBeUndefined();
+      expect(sessionA.childInboxes.size).toBe(1);
+
+      rolloutStore.upsertThreadSpawnEdge({
+        parentThreadId: "root-a",
+        childThreadId: "durable-conflict",
+        parentPath: "/root",
+        metadata: {
+          agentId: "durable-conflict",
+          agentPath: "/root/original",
+          agentNickname: "original",
+          agentRole: "default",
+          ...roleProvenance(controlA, "default"),
+          depth: 1,
+        },
+        status: "open",
+      });
+      const durableBefore = rolloutStore.getThreadSpawnEdge("durable-conflict");
+
+      const sessionB = stubSession({
+        rolloutStore,
+        cwd,
+        conversationId: "root-b",
+      });
+      const registryB = new AgentRegistry();
+      const controlB = new AgentControl({ session: sessionB, registry: registryB });
+      controlB.registerSessionRoot("root-b");
+      await expect(
+        controlB.spawn({
+          parentPath: "/root",
+          threadId: "durable-conflict",
+          agentName: "failed",
+        }),
+      ).rejects.toThrow("agent thread id already exists");
+      expect(registryB.activeCount).toBe(0);
+      expect(registryB.liveAgents()).toEqual([]);
+      expect(registryB.agentIdForPath("/root/failed")).toBeUndefined();
+      expect(controlB.getLive("durable-conflict")).toBeUndefined();
+      expect(sessionB.childInboxes.size).toBe(0);
+      expect(rolloutStore.getThreadSpawnEdge("durable-conflict")).toEqual(
+        durableBefore,
+      );
+    } finally {
+      rolloutStore.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("spawn() restores allocated and preferred nicknames after durable insert failure", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-control-nickname-rollback-"));
+    const rolloutStore = openRolloutStore({
+      cwd,
+      sessionId: "nickname-persistence-rollback",
+    });
+    const raw = new Database(resolveStateDatabasePaths({ cwd }).stateDbPath);
+    try {
+      const session = stubSession({
+        cwd,
+        conversationId: "nickname-root",
+        rolloutStore,
+      });
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry });
+      control.registerSessionRoot("nickname-root");
+      registerAgentRole(control.roleWorkspace, {
+        name: "single-nickname",
+        config: { nicknameCandidates: ["only-nickname"] },
+      });
+      raw.exec(`
+        CREATE TRIGGER reject_control_spawn
+        BEFORE INSERT ON thread_spawn_edges
+        BEGIN
+          SELECT RAISE(ABORT, 'forced spawn persistence failure');
+        END;
+      `);
+
+      await expect(
+        control.spawn({
+          parentPath: "/root",
+          roleName: "single-nickname",
+          agentName: "allocated_failure",
+        }),
+      ).rejects.toThrow("forced spawn persistence failure");
+      expect(registry.hasNickname("only-nickname")).toBe(false);
+
+      await expect(
+        control.spawn({
+          parentPath: "/root",
+          preferredNickname: "preferred-failure",
+          agentName: "preferred_failure",
+        }),
+      ).rejects.toThrow("forced spawn persistence failure");
+      expect(registry.hasNickname("preferred-failure")).toBe(false);
+      expect(registry.activeCount).toBe(0);
+      expect(registry.liveAgents()).toEqual([]);
+      expect(control.listLive()).toEqual([]);
+      expect(
+        (session as unknown as { childInboxes: Map<string, unknown> })
+          .childInboxes.size,
+      ).toBe(0);
+    } finally {
+      raw.close();
+      rolloutStore.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not publish a child when its parent is interrupted during edge persistence", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-control-persist-cancel-"));
+    const rolloutStore = openRolloutStore({
+      cwd,
+      sessionId: "spawn-persistence-cancel",
+    });
+    try {
+      const session = stubSession({
+        cwd,
+        conversationId: "cancel-root",
+        rolloutStore,
+      });
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry, maxDepth: 2 });
+      control.registerSessionRoot("cancel-root");
+      const parent = await control.spawn({
+        parentPath: "/root",
+        threadId: "cancel-parent",
+        agentName: "parent",
+      });
+      const createEdge = rolloutStore.createThreadSpawnEdge.bind(rolloutStore);
+      vi.spyOn(rolloutStore, "createThreadSpawnEdge").mockImplementation(edge => {
+        createEdge(edge);
+        if (edge.childThreadId === "cancel-child") {
+          control.interrupt(parent.agentId, "test persistence race");
+        }
+      });
+
+      await expect(
+        control.spawn({
+          parentPath: parent.agentPath,
+          threadId: "cancel-child",
+          agentName: "child",
+        }),
+      ).rejects.toThrow("interrupted mid-spawn");
+
+      expect(control.getLive("cancel-child")).toBeUndefined();
+      expect(registry.agentIdForPath("/root/parent/child")).toBeUndefined();
+      expect(registry.activeCount).toBe(1);
+      expect(
+        rolloutStore.getThreadSpawnEdge("cancel-child")?.status,
+      ).toBe("closed");
+      expect(
+        (session as unknown as { childInboxes: Map<string, unknown> })
+          .childInboxes.has("cancel-child"),
+      ).toBe(false);
+    } finally {
+      rolloutStore.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a cancelled child registered when durable edge close fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-control-close-failure-"));
+    const rolloutStore = openRolloutStore({
+      cwd,
+      sessionId: "spawn-close-failure",
+    });
+    try {
+      const session = stubSession({
+        cwd,
+        conversationId: "close-failure-root",
+        rolloutStore,
+      });
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry, maxDepth: 2 });
+      const threadManager = new ThreadManager({ control, registry });
+      control.bindThreadManager(threadManager);
+      control.registerSessionRoot("close-failure-root");
+      const parent = await control.spawn({
+        parentPath: "/root",
+        threadId: "close-failure-parent",
+        agentName: "parent",
+      });
+      const createEdge = rolloutStore.createThreadSpawnEdge.bind(rolloutStore);
+      vi.spyOn(rolloutStore, "createThreadSpawnEdge").mockImplementation(edge => {
+        createEdge(edge);
+        if (edge.childThreadId === "close-failure-child") {
+          control.interrupt(parent.agentId, "test close failure");
+        }
+      });
+      const closeSpy = vi
+        .spyOn(rolloutStore, "setThreadSpawnEdgeStatus")
+        .mockImplementation((childThreadId, status) => {
+          if (childThreadId === "close-failure-child" && status === "closed") {
+            throw new Error("forced edge close failure");
+          }
+          throw new Error("unexpected edge status call");
+        });
+
+      await expect(
+        control.spawn({
+          parentPath: parent.agentPath,
+          threadId: "close-failure-child",
+          agentName: "child",
+        }),
+      ).rejects.toThrow("forced edge close failure");
+
+      const child = control.getLive("close-failure-child");
+      expect(rolloutStore.getThreadSpawnEdge("close-failure-child")?.status)
+        .toBe("open");
+      expect(child).toBeDefined();
+      expect(child?.abortController.signal.aborted).toBe(true);
+      expect(registry.agentIdForPath("/root/parent/child"))
+        .toBe("close-failure-child");
+      expect(threadManager.getThread("close-failure-child").threadId)
+        .toBe("close-failure-child");
+      expect(
+        (session as unknown as { childInboxes: Map<string, unknown> })
+          .childInboxes.has("close-failure-child"),
+      ).toBe(true);
+      closeSpy.mockRestore();
+    } finally {
+      rolloutStore.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("AgentControlOpts.maxDepth override is honored", async () => {
@@ -224,6 +568,56 @@ describe("AgentControl", () => {
     expect(registry.activeCount).toBe(0);
   });
 
+  it("keeps the live control plane intact when durable close fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-control-close-failure-"));
+    const rolloutStore = openRolloutStore({
+      cwd,
+      sessionId: "shutdown-durability-first",
+    });
+    const raw = new Database(resolveStateDatabasePaths({ cwd }).stateDbPath);
+    try {
+      const session = stubSession({
+        cwd,
+        conversationId: "root-close-failure",
+        rolloutStore,
+      });
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry });
+      control.registerSessionRoot("root-close-failure");
+      const live = await control.spawn({
+        parentPath: "/root",
+        agentName: "durable_child",
+      });
+      raw.exec(`
+        CREATE TRIGGER reject_control_close
+        BEFORE UPDATE OF status ON thread_spawn_edges
+        WHEN OLD.child_thread_id = '${live.agentId}' AND NEW.status = 'closed'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced close failure');
+        END;
+      `);
+
+      await expect(
+        control.shutdown(live.agentId, "closed_by_tool"),
+      ).rejects.toThrow("forced close failure");
+      expect(control.getLive(live.agentId)).toBe(live);
+      expect(registry.agentIdForPath(live.agentPath)).toBe(live.agentId);
+      expect(registry.activeCount).toBe(1);
+      expect(live.upInbox.isClosed).toBe(false);
+      expect(live.downInbox.isClosed).toBe(false);
+      expect(live.abortController.signal.aborted).toBe(false);
+      expect(
+        (session as unknown as { childInboxes: Map<string, unknown> })
+          .childInboxes.get(live.agentId),
+      ).toBe(live.upInbox);
+      expect(rolloutStore.getThreadSpawnEdge(live.agentId)?.status).toBe("open");
+    } finally {
+      raw.close();
+      rolloutStore.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("shutdownAll() cascades every live agent", async () => {
     const session = stubSession();
     const registry = new AgentRegistry();
@@ -258,6 +652,7 @@ describe("AgentControl", () => {
       agentPath: "/root/scout",
       agentNickname: "scout",
       agentRole: "explorer",
+      ...roleProvenance(control, "explorer"),
       depth: 1,
     };
     const live = await control.resume({ parentPath: "/root", metadata });
@@ -271,6 +666,107 @@ describe("AgentControl", () => {
     expect(registry.activeCount).toBe(1);
   });
 
+  it("resume() fails closed for named legacy metadata without workspace provenance", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    await expect(
+      control.resume({
+        parentPath: "/root",
+        metadata: {
+          agentId: "thread-legacy-role",
+          agentPath: "/root/legacy_role",
+          agentNickname: "legacy-role",
+          agentRole: "worker",
+          depth: 1,
+        },
+      }),
+    ).rejects.toThrow("agent role workspace provenance is missing");
+    expect(registry.activeCount).toBe(0);
+  });
+
+  it("resume() rejects malformed persisted roles before registry mutation", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    for (const [index, agentRole] of ["", null, false, 0].entries()) {
+      await expect(
+        control.resume({
+          parentPath: "/root",
+          metadata: {
+            agentId: `thread-malformed-role-${index}`,
+            agentPath: `/root/malformed_role_${index}`,
+            agentNickname: `malformed-role-${index}`,
+            agentRole: agentRole as never,
+            agentRoleWorkspaceId: control.roleWorkspace.id,
+            depth: 1,
+          },
+        }),
+      ).rejects.toThrow("invalid agent metadata agentRole");
+      expect(registry.activeCount).toBe(0);
+    }
+  });
+
+  it("resume() resolves same-named roles only inside the session workspace", async () => {
+    const workspaceA = mkdtempSync(join(tmpdir(), "agenc-resume-role-a-"));
+    const workspaceB = mkdtempSync(join(tmpdir(), "agenc-resume-role-b-"));
+    try {
+      registerAgentRole(createAgentRoleWorkspace(workspaceA), {
+        name: "shared-resume-role",
+        config: { systemPrompt: "Workspace A resume prompt." },
+      });
+      registerAgentRole(createAgentRoleWorkspace(workspaceB), {
+        name: "shared-resume-role",
+        config: { systemPrompt: "Workspace B resume prompt." },
+      });
+
+      const registryA = new AgentRegistry();
+      const registryB = new AgentRegistry();
+      const controlA = new AgentControl({
+        session: stubSession({ cwd: workspaceA, conversationId: "workspace-a" }),
+        registry: registryA,
+      });
+      const controlB = new AgentControl({
+        session: stubSession({ cwd: workspaceB, conversationId: "workspace-b" }),
+        registry: registryB,
+      });
+      const metadata = (marker: "a" | "b"): AgentMetadata => ({
+        agentId: `thread-resume-${marker}`,
+        agentPath: `/root/resume_${marker}`,
+        agentNickname: `resume-${marker}`,
+        agentRole: "shared-resume-role",
+        ...roleProvenance(
+          marker === "a" ? controlA : controlB,
+          "shared-resume-role",
+        ),
+        depth: 1,
+      });
+
+      const resumedA = await controlA.resume({
+        parentPath: "/root",
+        metadata: metadata("a"),
+      });
+      const resumedB = await controlB.resume({
+        parentPath: "/root",
+        metadata: metadata("b"),
+      });
+
+      expect(resumedA?.role.config.systemPrompt).toBe(
+        "Workspace A resume prompt.",
+      );
+      expect(resumedB?.role.config.systemPrompt).toBe(
+        "Workspace B resume prompt.",
+      );
+      await expect(
+        controlB.resume({ parentPath: "/root", metadata: metadata("a") }),
+      ).rejects.toThrow("agent role workspace mismatch");
+      expect(registryB.activeCount).toBe(1);
+    } finally {
+      rmSync(workspaceA, { recursive: true, force: true });
+      rmSync(workspaceB, { recursive: true, force: true });
+    }
+  });
+
   it("resume() is idempotent for an already-live path", async () => {
     const session = stubSession();
     const registry = new AgentRegistry();
@@ -281,6 +777,8 @@ describe("AgentControl", () => {
       agentPath: spawned.agentPath,
       agentNickname: spawned.nickname,
       agentRole: spawned.role.name,
+      agentRoleWorkspaceId: spawned.metadata.agentRoleWorkspaceId,
+      agentRoleFingerprint: spawned.metadata.agentRoleFingerprint,
       depth: spawned.depth,
     };
     const resumed = await control.resume({
@@ -289,6 +787,62 @@ describe("AgentControl", () => {
     });
     expect(resumed).toBe(spawned);
     expect(registry.activeCount).toBe(1);
+  });
+
+  it("resume() rejects root, id, path, and role identity conflicts without mutation", async () => {
+    const session = stubSession({ conversationId: "identity-root" });
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    control.registerSessionRoot("identity-root");
+    const live = await control.spawn({
+      parentPath: "/root",
+      agentName: "identity_child",
+    });
+    const base = live.metadata;
+    const beforeInboxes = (
+      session as unknown as { childInboxes: Map<string, unknown> }
+    ).childInboxes.size;
+
+    await expect(
+      control.resume({
+        parentPath: "/root",
+        metadata: { ...base, agentId: "different-id" },
+      }),
+    ).rejects.toThrow(/identity conflicts/);
+    await expect(
+      control.resume({
+        parentPath: "/root",
+        metadata: { ...base, agentPath: "/root/different_path" },
+      }),
+    ).rejects.toThrow(/identity conflicts/);
+    await expect(
+      control.resume({
+        parentPath: "/root",
+        metadata: {
+          ...base,
+          agentRole: "explorer",
+          ...roleProvenance(control, "explorer"),
+        },
+      }),
+    ).rejects.toThrow(/does not match registered metadata/);
+    await expect(
+      control.resume({
+        parentPath: "/root",
+        metadata: {
+          ...base,
+          agentId: "identity-root",
+          agentPath: "/root/root_copy",
+        },
+      }),
+    ).rejects.toThrow(/session root/);
+
+    expect(control.listLive()).toEqual([live]);
+    expect(registry.activeCount).toBe(1);
+    expect(registry.agentIdForPath(live.agentPath)).toBe(live.agentId);
+    expect(
+      (session as unknown as { childInboxes: Map<string, unknown> })
+        .childInboxes.size,
+    ).toBe(beforeInboxes);
   });
 
   it("resume() respects I-1 depth cap", async () => {
@@ -300,11 +854,38 @@ describe("AgentControl", () => {
       agentPath: "/root/a/b/c",
       agentNickname: "too-deep",
       agentRole: "default",
+      ...roleProvenance(control, "default"),
       depth: 3,
     };
     await expect(
       control.resume({ parentPath: "/root/a/b", metadata }),
     ).rejects.toBeInstanceOf(MaxDepthExceededError);
+  });
+
+  it("resume() rejects depth and parent lineage inconsistent with the agent path", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry, maxDepth: 4 });
+    const base: AgentMetadata = {
+      agentId: "thread-lineage",
+      agentPath: "/root/a/b/c",
+      agentNickname: "lineage",
+      agentRole: "default",
+      ...roleProvenance(control, "default"),
+      depth: 3,
+    };
+
+    await expect(
+      control.resume({
+        parentPath: "/root/a/b",
+        metadata: { ...base, depth: 0 },
+      }),
+    ).rejects.toThrow("does not match path depth");
+    await expect(
+      control.resume({ parentPath: "/root", metadata: base }),
+    ).rejects.toThrow("does not match path parent");
+    expect(registry.activeCount).toBe(0);
+    expect(control.listLive()).toEqual([]);
   });
 
   it("resume() attaches the upInbox to session.childInboxes", async () => {
@@ -316,6 +897,7 @@ describe("AgentControl", () => {
       agentPath: "/root/attach",
       agentNickname: "attach",
       agentRole: "default",
+      ...roleProvenance(control, "default"),
       depth: 1,
     };
     const live = await control.resume({ parentPath: "/root", metadata });
@@ -334,6 +916,7 @@ describe("AgentControl", () => {
       agentPath: "/root/emit",
       agentNickname: "emit",
       agentRole: "default",
+      ...roleProvenance(control, "default"),
       depth: 1,
     };
     await control.resume({ parentPath: "/root", metadata });
@@ -910,6 +1493,50 @@ describe("AgentControl", () => {
     }
   });
 
+  it("resumeAgentFromRollout() rejects an edge whose parent id and path name different live agents", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-control-rollout-"));
+    const rolloutStore = openRolloutStore({
+      cwd,
+      sessionId: "resume-rejects-parent-identity-split",
+    });
+    try {
+      const session = stubSession({ rolloutStore });
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry, maxDepth: 3 });
+      const root = await control.spawn({
+        parentPath: "/root",
+        threadId: "real-root-child",
+        agentName: "real_parent",
+      });
+      rolloutStore.createThreadSpawnEdge({
+        childThreadId: "orphan-child",
+        parentThreadId: root.agentId,
+        parentPath: "/root/missing",
+        metadata: {
+          agentId: "orphan-child",
+          agentPath: "/root/missing/orphan",
+          agentNickname: "orphan",
+          depth: 2,
+        },
+        status: "open",
+      });
+      await control.shutdownAll("manager_shutdown");
+
+      const result = await control.resumeAgentFromRollout({
+        rootThreadId: root.agentId,
+        parentPath: "/root",
+        metadata: root.metadata,
+      });
+
+      expect(result.resumedCount).toBe(1);
+      expect(control.getLive("orphan-child")).toBeUndefined();
+      expect(registry.agentIdForPath("/root/missing/orphan")).toBeUndefined();
+    } finally {
+      rolloutStore.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   // ───────────────────────────────────────────────────────────
   // Priority-4 fork-mode spawn helpers
   // ───────────────────────────────────────────────────────────
@@ -947,6 +1574,31 @@ describe("AgentControl", () => {
     });
     expect(live.agentId).toBe("preset-thread-1");
     expect(live.role.name).toBe("worker");
+  });
+
+  it("spawnAgentWithMetadata() validates named metadata even with an explicit role", async () => {
+    const session = stubSession();
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    const invalidMetadata = [
+      { agentRole: "worker" },
+      {
+        agentRole: "worker",
+        agentRoleWorkspaceId: createAgentRoleWorkspace(
+          join(agencHome, "other-workspace"),
+        ).id,
+      },
+    ] as const;
+
+    for (const metadata of invalidMetadata) {
+      await expect(
+        control.spawnAgentWithMetadata("/root", {
+          roleName: "worker",
+          metadata,
+        }),
+      ).rejects.toThrow(/workspace (provenance is missing|mismatch)/);
+      expect(registry.activeCount).toBe(0);
+    }
   });
 
   // ───────────────────────────────────────────────────────────

--- a/runtime/tests/agents/delegate-spawn-reservation-leak.test.ts
+++ b/runtime/tests/agents/delegate-spawn-reservation-leak.test.ts
@@ -16,13 +16,14 @@ vi.mock("../session/event-log.js", () => ({
 
 import { AgentStatusTracker } from "./status.js";
 import { Mailbox } from "./mailbox.js";
-import { resolveAgentRole } from "./role.js";
+import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
 import { delegate } from "./delegate.js";
 import { runAgent } from "./run-agent.js";
 import type { LiveAgent } from "./control.js";
 import type { AgentMetadata } from "./registry.js";
 
 const mockRunAgent = vi.mocked(runAgent);
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 function makeLive(
   agentId: string,
@@ -34,12 +35,13 @@ function makeLive(
     agentPath,
     agentNickname: nickname,
     agentRole: "default",
+    agentRoleWorkspaceId: ROLE_WORKSPACE.id,
     depth: 1,
   };
   return {
     agentId,
     agentPath,
-    role: resolveAgentRole(undefined),
+    role: resolveAgentRole(ROLE_WORKSPACE, undefined),
     depth: 1,
     nickname,
     status: new AgentStatusTracker(),

--- a/runtime/tests/agents/delegate-worktree.test.ts
+++ b/runtime/tests/agents/delegate-worktree.test.ts
@@ -20,13 +20,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AgentStatusTracker } from "./status.js";
 import { Mailbox } from "./mailbox.js";
-import { resolveAgentRole } from "./role.js";
+import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
 import { delegate } from "./delegate.js";
 import { runAgent } from "./run-agent.js";
 import type { LiveAgent } from "./control.js";
 import type { AgentMetadata } from "./registry.js";
 
 const mockRunAgent = vi.mocked(runAgent);
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 function makeLive(agentId: string, agentPath: string): LiveAgent {
   const metadata: AgentMetadata = {
@@ -34,12 +35,13 @@ function makeLive(agentId: string, agentPath: string): LiveAgent {
     agentPath,
     agentNickname: "wt",
     agentRole: "default",
+    agentRoleWorkspaceId: ROLE_WORKSPACE.id,
     depth: 1,
   };
   return {
     agentId,
     agentPath,
-    role: resolveAgentRole(undefined),
+    role: resolveAgentRole(ROLE_WORKSPACE, undefined),
     depth: 1,
     nickname: "wt",
     status: new AgentStatusTracker(),

--- a/runtime/tests/agents/delegate.test.ts
+++ b/runtime/tests/agents/delegate.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("./fork-context.js", () => ({
@@ -10,21 +13,30 @@ vi.mock("./run-agent.js", () => ({
   runAgent: vi.fn(),
 }));
 
-vi.mock("../session/event-log.js", () => ({
+vi.mock("../session/event-log.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../session/event-log.js")>()),
   emitWarning: vi.fn(),
 }));
 
 import { AgentStatusTracker } from "./status.js";
 import { Mailbox } from "./mailbox.js";
-import { resolveAgentRole } from "./role.js";
+import {
+  _resetAgentRolesForTesting,
+  createAgentRoleWorkspace,
+  registerAgentRole,
+  resolveAgentRole,
+} from "./role.js";
 import { delegate } from "./delegate.js";
 import { forkSubagent } from "./fork-context.js";
 import { runAgent } from "./run-agent.js";
-import type { LiveAgent } from "./control.js";
+import { AgentControl, type LiveAgent } from "./control.js";
+import { AgentRegistry } from "./registry.js";
 import type { AgentMetadata } from "./registry.js";
+import { RolloutStore } from "../session/rollout-store.js";
 
 const mockRunAgent = vi.mocked(runAgent);
 const mockForkSubagent = vi.mocked(forkSubagent);
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 function makeLive(
   agentId: string,
@@ -36,12 +48,13 @@ function makeLive(
     agentPath,
     agentNickname: nickname,
     agentRole: "default",
+    agentRoleWorkspaceId: ROLE_WORKSPACE.id,
     depth: 1,
   };
   return {
     agentId,
     agentPath,
-    role: resolveAgentRole(undefined),
+    role: resolveAgentRole(ROLE_WORKSPACE, undefined),
     depth: 1,
     nickname,
     status: new AgentStatusTracker(),
@@ -77,6 +90,59 @@ function runResult(result: {
   return (async function* () {
     return result;
   })();
+}
+
+function makeRealDelegateHarness(label: string) {
+  const cwd = mkdtempSync(join(tmpdir(), `agenc-delegate-${label}-`));
+  const priorAgencHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = cwd;
+  const rolloutStore = new RolloutStore({
+    cwd,
+    sessionId: label,
+    agencVersion: "0.6.0",
+    autoStartScheduler: false,
+  });
+  rolloutStore.open({
+    sessionId: label,
+    timestamp: new Date().toISOString(),
+    cwd,
+    originator: "delegate-test",
+    agencVersion: "0.6.0",
+    model: "test-model",
+    modelProvider: "test-provider",
+  });
+  const roleWorkspace = createAgentRoleWorkspace(cwd);
+  const parent = {
+    ...makeParentSession(),
+    conversationId: `${label}-parent`,
+    sessionConfiguration: { cwd },
+    config: { cwd },
+    roleWorkspace,
+    rolloutStore,
+    childInboxes: new Map(),
+    mailbox: { send: vi.fn() },
+    services: {},
+  };
+  const registry = new AgentRegistry();
+  const control = new AgentControl({
+    session: parent as never,
+    registry,
+  });
+  control.registerSessionRoot(parent.conversationId);
+  return {
+    cwd,
+    parent,
+    registry,
+    control,
+    rolloutStore,
+    cleanup: () => {
+      rolloutStore.close();
+      _resetAgentRolesForTesting();
+      if (priorAgencHome === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = priorAgencHome;
+      rmSync(cwd, { recursive: true, force: true });
+    },
+  };
 }
 
 describe("delegate lifecycle recovery", () => {
@@ -190,7 +256,7 @@ describe("delegate lifecycle recovery", () => {
     const live = {
       ...makeLive("thread-sync", "/root/sync"),
       role: {
-        ...resolveAgentRole(undefined),
+        ...resolveAgentRole(ROLE_WORKSPACE, undefined),
         config: { background: true },
       },
     };
@@ -339,6 +405,7 @@ describe("delegate lifecycle recovery", () => {
     const control = {
       spawn: vi.fn(async () => live1),
       shutdown: vi.fn(async () => {}),
+      assertAgentMetadataRoleWorkspace: vi.fn(),
       resumeAgentFromRollout: vi.fn(async () => ({
         resumedCount: 1,
         rootLive: resumedLive,
@@ -382,6 +449,9 @@ describe("delegate lifecycle recovery", () => {
     }
 
     expect(control.spawn).toHaveBeenCalledTimes(1);
+    expect(control.assertAgentMetadataRoleWorkspace).toHaveBeenCalledWith(
+      live1.metadata,
+    );
     expect(control.shutdown).toHaveBeenCalledWith("thread-1", "delegate_resume");
     expect(control.resumeAgentFromRollout).toHaveBeenCalledWith({
       rootThreadId: "thread-1",
@@ -395,6 +465,51 @@ describe("delegate lifecycle recovery", () => {
     expect(resumeManager.recordSuccess).toHaveBeenCalledWith("thread-1");
   });
 
+  it("validates role provenance before mutating retryable resume state", async () => {
+    const live = makeLive("thread-provenance", "/root/provenance");
+    const control = {
+      spawn: vi.fn(async () => live),
+      shutdown: vi.fn(async () => {}),
+      assertAgentMetadataRoleWorkspace: vi.fn(() => {
+        throw new Error("agent role workspace mismatch");
+      }),
+      resumeAgentFromRollout: vi.fn(),
+    };
+    const resumeManager = {
+      recordFailure: vi.fn(() => ({ kind: "resume" as const, reason: "retry" })),
+      recordSuccess: vi.fn(),
+    };
+    mockRunAgent.mockImplementationOnce(() =>
+      runResult({
+        threadId: live.agentId,
+        durationMs: 10,
+        outcome: "errored",
+        error: new Error("transient"),
+      }),
+    );
+
+    const outcome = await delegate({
+      parent: makeParentSession() as never,
+      parentPath: "/root",
+      control: control as never,
+      registry: {} as never,
+      taskPrompt: "fix it",
+      runInBackground: false,
+      resumeManager: resumeManager as never,
+    });
+
+    expect(outcome.kind).toBe("sync_completed");
+    if (outcome.kind !== "sync_completed") {
+      throw new Error("expected sync_completed");
+    }
+    expect(outcome.result.outcome).toBe("errored");
+    expect(control.assertAgentMetadataRoleWorkspace).toHaveBeenCalledWith(
+      live.metadata,
+    );
+    expect(control.shutdown).not.toHaveBeenCalled();
+    expect(control.resumeAgentFromRollout).not.toHaveBeenCalled();
+  });
+
   it("restarts with a fresh live handle after a hard failure", async () => {
     const live1 = makeLive("thread-1", "/root/alpha");
     const restartedLive = makeLive("thread-2", "/root/bravo");
@@ -404,6 +519,7 @@ describe("delegate lifecycle recovery", () => {
         .mockImplementationOnce(async () => live1)
         .mockImplementationOnce(async () => restartedLive),
       shutdown: vi.fn(async () => {}),
+      assertAgentMetadataRoleWorkspace: vi.fn(),
       resumeAgentFromRollout: vi.fn(async () => ({
         resumedCount: 0,
         rootLive: null,
@@ -451,6 +567,15 @@ describe("delegate lifecycle recovery", () => {
     }
 
     expect(control.spawn).toHaveBeenCalledTimes(2);
+    expect(control.spawn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        expectedRoleProvenance: live1.metadata,
+      }),
+    );
+    expect(control.assertAgentMetadataRoleWorkspace).toHaveBeenCalledWith(
+      live1.metadata,
+    );
     expect(control.shutdown).toHaveBeenCalledWith("thread-1", "delegate_restart");
     expect(control.shutdown).toHaveBeenCalledWith(
       "thread-2",
@@ -463,5 +588,137 @@ describe("delegate lifecycle recovery", () => {
     expect(outcome.result.outcome).toBe("completed");
     expect(outcome.result.finalMessage).toBe("done after restart");
     expect(resumeManager.recordSuccess).toHaveBeenCalledWith("thread-2");
+  });
+
+  it("preserves a live edge when a restrictive role changed before restart preflight", async () => {
+    const harness = makeRealDelegateHarness("changed-role-restart");
+    try {
+      registerAgentRole(harness.control.roleWorkspace, {
+        name: "scanner",
+        config: { disallowlist: ["Edit", "Write"] },
+      });
+      const spawnSpy = vi.spyOn(harness.control, "spawn");
+      const shutdownSpy = vi.spyOn(harness.control, "shutdown");
+      const resumeFromRolloutSpy = vi.spyOn(
+        harness.control,
+        "resumeAgentFromRollout",
+      );
+      const resumeManager = {
+        recordFailure: vi.fn(() => ({
+          kind: "restart" as const,
+          reason: "hard_error",
+        })),
+        recordSuccess: vi.fn(),
+        transferFailureCount: vi.fn(),
+      };
+      mockRunAgent.mockImplementationOnce((params) => {
+        registerAgentRole(harness.control.roleWorkspace, {
+          name: "scanner",
+          config: { disallowlist: [] },
+        });
+        return runResult({
+          threadId: params.live.agentId,
+          durationMs: 10,
+          outcome: "errored",
+          error: new Error("hard fail"),
+        });
+      });
+
+      const outcome = await delegate({
+        parent: harness.parent as never,
+        parentPath: "/root",
+        control: harness.control,
+        registry: harness.registry,
+        taskPrompt: "inspect only",
+        role: "scanner",
+        runInBackground: false,
+        forceSynchronous: true,
+        resumeManager: resumeManager as never,
+      });
+
+      expect(outcome.kind).toBe("sync_completed");
+      if (outcome.kind !== "sync_completed") {
+        throw new Error("expected sync_completed");
+      }
+      expect(outcome.result.outcome).toBe("errored");
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(shutdownSpy).not.toHaveBeenCalled();
+      expect(resumeFromRolloutSpy).not.toHaveBeenCalled();
+      expect(harness.control.getLive(outcome.thread.threadId)).toBe(
+        outcome.thread.live,
+      );
+      expect(harness.registry.activeCount).toBe(1);
+      expect(
+        harness.rolloutStore.getThreadSpawnEdge(outcome.thread.threadId)
+          ?.status,
+      ).toBe("open");
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it("preserves a live edge when an alias-named role was removed before resume preflight", async () => {
+    const harness = makeRealDelegateHarness("removed-role-resume");
+    try {
+      registerAgentRole(harness.control.roleWorkspace, {
+        name: "scanner",
+        config: { disallowlist: ["Edit", "Write"] },
+      });
+      const spawnSpy = vi.spyOn(harness.control, "spawn");
+      const shutdownSpy = vi.spyOn(harness.control, "shutdown");
+      const resumeFromRolloutSpy = vi.spyOn(
+        harness.control,
+        "resumeAgentFromRollout",
+      );
+      const resumeManager = {
+        recordFailure: vi.fn(() => ({
+          kind: "resume" as const,
+          reason: "transient_provider_error",
+        })),
+        recordSuccess: vi.fn(),
+      };
+      mockRunAgent.mockImplementationOnce((params) => {
+        // Removing the exact workspace role leaves the public `scanner`
+        // built-in alias available. Provenance must not fall through to it.
+        _resetAgentRolesForTesting();
+        return runResult({
+          threadId: params.live.agentId,
+          durationMs: 10,
+          outcome: "errored",
+          error: new Error("transient"),
+        });
+      });
+
+      const outcome = await delegate({
+        parent: harness.parent as never,
+        parentPath: "/root",
+        control: harness.control,
+        registry: harness.registry,
+        taskPrompt: "inspect only",
+        role: "scanner",
+        runInBackground: false,
+        forceSynchronous: true,
+        resumeManager: resumeManager as never,
+      });
+
+      expect(outcome.kind).toBe("sync_completed");
+      if (outcome.kind !== "sync_completed") {
+        throw new Error("expected sync_completed");
+      }
+      expect(outcome.result.outcome).toBe("errored");
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(shutdownSpy).not.toHaveBeenCalled();
+      expect(resumeFromRolloutSpy).not.toHaveBeenCalled();
+      expect(harness.control.getLive(outcome.thread.threadId)).toBe(
+        outcome.thread.live,
+      );
+      expect(harness.registry.activeCount).toBe(1);
+      expect(
+        harness.rolloutStore.getThreadSpawnEdge(outcome.thread.threadId)
+          ?.status,
+      ).toBe("open");
+    } finally {
+      harness.cleanup();
+    }
   });
 });

--- a/runtime/tests/agents/registry.test.ts
+++ b/runtime/tests/agents/registry.test.ts
@@ -12,7 +12,9 @@ import {
   normalizeAgentNameForPath,
   resolveAgentPath,
 } from "./registry.js";
-import { resolveAgentRole } from "./role.js";
+import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 describe("AgentRegistry", () => {
   it("I-63: slot acquisition is atomic and uncapped under the lock", async () => {
@@ -36,7 +38,7 @@ describe("AgentRegistry", () => {
 
   it("failed spawn rollback keeps the allocated nickname reserved like reference", async () => {
     const reg = new AgentRegistry({ maxThreads: 1 });
-    const role = resolveAgentRole(undefined);
+    const role = resolveAgentRole(ROLE_WORKSPACE, undefined);
     const nickname = reg.allocateNickname(role);
     const r = await reg.reserveSpawnSlot();
     r.release();
@@ -72,7 +74,9 @@ describe("AgentRegistry", () => {
     const meta = buildChildMetadata({
       agentId: "t1",
       parentPath: "/root",
-      role: resolveAgentRole(undefined),
+      role: resolveAgentRole(ROLE_WORKSPACE, undefined),
+      roleWorkspaceId: ROLE_WORKSPACE.id,
+      roleFingerprint: "test-role-fingerprint",
       nickname: "alpha",
       depth: 1,
     });
@@ -93,7 +97,9 @@ describe("AgentRegistry", () => {
     const meta = buildChildMetadata({
       agentId: "t2",
       parentPath: "/root",
-      role: resolveAgentRole(undefined),
+      role: resolveAgentRole(ROLE_WORKSPACE, undefined),
+      roleWorkspaceId: ROLE_WORKSPACE.id,
+      roleFingerprint: "test-role-fingerprint",
       nickname: "beta",
       depth: 1,
     });
@@ -113,7 +119,7 @@ describe("AgentRegistry", () => {
     "releaseSpawnedThread keeps nicknames reserved like reference",
     async () => {
       const reg = new AgentRegistry();
-      const role = resolveAgentRole(undefined);
+      const role = resolveAgentRole(ROLE_WORKSPACE, undefined);
       // Allocate via the registry (the single source of truth).
       const nickname = reg.allocateNickname(role);
       const reservation = await reg.reserveSpawnSlot();
@@ -122,6 +128,8 @@ describe("AgentRegistry", () => {
           agentId: "t-reuse",
           parentPath: "/root",
           role,
+          roleWorkspaceId: ROLE_WORKSPACE.id,
+          roleFingerprint: "test-role-fingerprint",
           nickname,
           depth: 1,
         }),
@@ -180,7 +188,9 @@ describe("path helpers", () => {
     const meta = buildChildMetadata({
       agentId: "t3",
       parentPath: "/root",
-      role: resolveAgentRole(undefined),
+      role: resolveAgentRole(ROLE_WORKSPACE, undefined),
+      roleWorkspaceId: ROLE_WORKSPACE.id,
+      roleFingerprint: "test-role-fingerprint",
       nickname: "Scout the 2nd",
       depth: 1,
     });

--- a/runtime/tests/agents/role-definitions.test.ts
+++ b/runtime/tests/agents/role-definitions.test.ts
@@ -5,21 +5,25 @@ import { describe, it, expect } from "vitest";
 
 import {
   _resetAgentRolesForTesting,
+  createAgentRoleWorkspace,
   listAgentRoles,
   loadMarkdownAgentRoles,
 } from "./role.js";
 import { listAgentRoleDefinitions } from "./role-definitions.js";
 
+const DEFAULT_CWD = process.cwd();
+const DEFAULT_WORKSPACE = createAgentRoleWorkspace(DEFAULT_CWD);
+
 describe("listAgentRoleDefinitions (TUI agent picker wiring)", () => {
   it("returns one entry per registered agent role", () => {
-    const roleCount = listAgentRoles().length;
-    const list = listAgentRoleDefinitions();
+    const roleCount = listAgentRoles(DEFAULT_WORKSPACE).length;
+    const list = listAgentRoleDefinitions(DEFAULT_CWD);
     expect(list.length).toBe(roleCount);
     expect(list.length).toBeGreaterThan(0);
   });
 
   it("every entry is shaped as a BuiltInAgentDefinition", () => {
-    const list = listAgentRoleDefinitions();
+    const list = listAgentRoleDefinitions(DEFAULT_CWD);
     for (const def of list) {
       expect(typeof def.agentType).toBe("string");
       expect(def.agentType.length).toBeGreaterThan(0);
@@ -34,14 +38,14 @@ describe("listAgentRoleDefinitions (TUI agent picker wiring)", () => {
   });
 
   it("agentType matches the AgentRole.name", () => {
-    const roleNames = listAgentRoles().map((r) => r.name);
-    const got = listAgentRoleDefinitions().map((d) => d.agentType);
+    const roleNames = listAgentRoles(DEFAULT_WORKSPACE).map((r) => r.name);
+    const got = listAgentRoleDefinitions(DEFAULT_CWD).map((d) => d.agentType);
     expect(got).toEqual(roleNames);
   });
 
   it("whenToUse falls back to role name when description is absent", () => {
-    const list = listAgentRoleDefinitions();
-    const roles = listAgentRoles();
+    const list = listAgentRoleDefinitions(DEFAULT_CWD);
+    const roles = listAgentRoles(DEFAULT_WORKSPACE);
     for (const role of roles) {
       const projected = list.find((d) => d.agentType === role.name);
       expect(projected).toBeDefined();
@@ -51,8 +55,8 @@ describe("listAgentRoleDefinitions (TUI agent picker wiring)", () => {
   });
 
   it("tools are populated only when the role has an allowlist", () => {
-    const list = listAgentRoleDefinitions();
-    const roles = listAgentRoles();
+    const list = listAgentRoleDefinitions(DEFAULT_CWD);
+    const roles = listAgentRoles(DEFAULT_WORKSPACE);
     for (const role of roles) {
       const projected = list.find((d) => d.agentType === role.name);
       expect(projected).toBeDefined();
@@ -69,18 +73,18 @@ describe("listAgentRoleDefinitions (TUI agent picker wiring)", () => {
       "./role.js"
     );
     _resetAgentRolesForTesting();
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "empty-allowlist-role",
       config: {
         description: "role with explicit empty allowlist",
         allowlist: [],
       },
     });
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "no-allowlist-role",
       config: { description: "role with no allowlist at all" },
     });
-    const list = listAgentRoleDefinitions();
+    const list = listAgentRoleDefinitions(DEFAULT_CWD);
     const empty = list.find((d) => d.agentType === "empty-allowlist-role");
     const missing = list.find((d) => d.agentType === "no-allowlist-role");
     expect(empty?.tools).toEqual([]);
@@ -89,8 +93,8 @@ describe("listAgentRoleDefinitions (TUI agent picker wiring)", () => {
   });
 
   it("getSystemPrompt returns the role's systemPrompt or empty string", () => {
-    const list = listAgentRoleDefinitions();
-    const roles = listAgentRoles();
+    const list = listAgentRoleDefinitions(DEFAULT_CWD);
+    const roles = listAgentRoles(DEFAULT_WORKSPACE);
     for (const role of roles) {
       const projected = list.find((d) => d.agentType === role.name);
       expect(projected).toBeDefined();
@@ -118,9 +122,10 @@ describe("listAgentRoleDefinitions (TUI agent picker wiring)", () => {
       ].join("\n"),
     );
 
-    loadMarkdownAgentRoles(root);
+    const workspace = createAgentRoleWorkspace(root);
+    loadMarkdownAgentRoles(workspace);
 
-    const projected = listAgentRoleDefinitions().find(
+    const projected = listAgentRoleDefinitions(root).find(
       (role) => role.agentType === "audit-role",
     );
     expect(projected).toBeDefined();

--- a/runtime/tests/agents/role.test.ts
+++ b/runtime/tests/agents/role.test.ts
@@ -1,13 +1,25 @@
-import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentRegistry } from "./registry.js";
 import {
   _resetAgentRolesForTesting,
+  _setMarkdownAgentRoleReadHookForTesting,
+  agentRoleFingerprint,
   allocateNickname,
   applyRoleToConfig,
   buildConfigLayerStack,
+  createAgentRoleWorkspace,
   defaultAgentNicknameCandidates,
   formatRoleList,
   getAgentRole,
@@ -23,6 +35,7 @@ import {
 } from "./role.js";
 
 let registry: AgentRegistry;
+const DEFAULT_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 beforeEach(() => {
   registry = new AgentRegistry();
@@ -30,26 +43,35 @@ beforeEach(() => {
 });
 
 describe("role registry", () => {
+  it("rejects a missing or relative role workspace", () => {
+    expect(() => createAgentRoleWorkspace("")).toThrow(
+      "agent role workspace requires a non-empty absolute cwd",
+    );
+    expect(() => createAgentRoleWorkspace("relative/project")).toThrow(
+      "agent role workspace cwd must be absolute",
+    );
+  });
+
   it("returns built-in default when name is undefined", () => {
-    const role = resolveAgentRole(undefined);
+    const role = resolveAgentRole(DEFAULT_WORKSPACE, undefined);
     expect(role.name).toBe("default");
     expect(role.config.nicknameCandidates).toBeUndefined();
     expect(defaultAgentNicknameCandidates()).toContain("Snowcrash");
   });
 
   it("falls back to default for unknown role names", () => {
-    expect(resolveAgentRole("unknown-role").name).toBe("default");
+    expect(resolveAgentRole(DEFAULT_WORKSPACE, "unknown-role").name).toBe("default");
   });
 
   it("strict spawn role lookup rejects unrecognized agent_type", () => {
-    expect(() => requireAgentRole("missing-role")).toThrow(
+    expect(() => requireAgentRole(DEFAULT_WORKSPACE, "missing-role")).toThrow(
       "unknown agent_type 'missing-role'",
     );
-    expect(requireAgentRole("runner").name).toBe("worker");
+    expect(requireAgentRole(DEFAULT_WORKSPACE, "runner").name).toBe("worker");
   });
 
   it("lists all built-in roles", () => {
-    const names = listAgentRoles().map((role) => role.name);
+    const names = listAgentRoles(DEFAULT_WORKSPACE).map((role) => role.name);
     expect(names).toContain("default");
     expect(names).toContain("explorer");
     expect(names).toContain("worker");
@@ -62,20 +84,20 @@ describe("role registry", () => {
   it("resolves promoted built-in agents (scanner/Explore, Plan, verification)", () => {
     // The Explore agent folds into the explorer/scanner role.
     for (const name of ["explorer", "scanner", "Explore", "explore"]) {
-      expect(requireAgentRole(name).name).toBe("explorer");
+      expect(requireAgentRole(DEFAULT_WORKSPACE, name).name).toBe("explorer");
     }
     // Plan's capital registry key is reachable only via the `plan` alias,
     // because spawn lowercases the requested name before lookup.
-    expect(requireAgentRole("Plan").name).toBe("Plan");
-    expect(requireAgentRole("plan").name).toBe("Plan");
-    expect(requireAgentRole("verification").name).toBe("verification");
+    expect(requireAgentRole(DEFAULT_WORKSPACE, "Plan").name).toBe("Plan");
+    expect(requireAgentRole(DEFAULT_WORKSPACE, "plan").name).toBe("Plan");
+    expect(requireAgentRole(DEFAULT_WORKSPACE, "verification").name).toBe("verification");
     // general-purpose is an alias of the default role.
-    expect(requireAgentRole("general-purpose").name).toBe("default");
+    expect(requireAgentRole(DEFAULT_WORKSPACE, "general-purpose").name).toBe("default");
     expect(getDefaultAgentRole().name).toBe("default");
   });
 
   it("carries promoted built-in behavior on role config", () => {
-    const explorer = requireAgentRole("scanner");
+    const explorer = requireAgentRole(DEFAULT_WORKSPACE, "scanner");
     expect(explorer.config.systemPrompt).toContain("file search specialist");
     expect(explorer.config.disallowlist).toContain("spawn_agent");
     expect(explorer.config.disallowlist).toContain("Edit");
@@ -86,11 +108,11 @@ describe("role registry", () => {
     expect(explorer.config.systemPrompt).toContain("targeted spans");
     expect(explorer.config.systemPrompt).toMatch(/Skip generated\/build\/vendored/);
 
-    const plan = requireAgentRole("Plan");
+    const plan = requireAgentRole(DEFAULT_WORKSPACE, "Plan");
     expect(plan.config.systemPrompt).toContain("software architect");
     expect(plan.config.disallowlist).toContain("Write");
 
-    const verification = requireAgentRole("verification");
+    const verification = requireAgentRole(DEFAULT_WORKSPACE, "verification");
     expect(verification.config.background).toBe(true);
     expect(verification.config.disallowlist).toContain("Edit");
     expect(verification.config.systemPrompt).toContain("VERDICT:");
@@ -98,14 +120,14 @@ describe("role registry", () => {
     // The default/general-purpose role is unrestricted (no denylist) and carries
     // no system prompt — it is also used by internal silent default-role spawns,
     // so a subagent prompt must not ride along.
-    const def = requireAgentRole("general-purpose");
+    const def = requireAgentRole(DEFAULT_WORKSPACE, "general-purpose");
     expect(def.name).toBe("default");
     expect(def.config.systemPrompt).toBeUndefined();
     expect(def.config.disallowlist).toBeUndefined();
   });
 
   it("explorer resolves through upstream-compatible config-file metadata", () => {
-    const role = getAgentRole("explorer")!;
+    const role = getAgentRole(DEFAULT_WORKSPACE, "explorer")!;
     expect(role.config.configFile).toBe("explorer.toml");
     expect(role.config.reasoningEffort).toBeUndefined();
     expect(role.config.allowlist).toBeUndefined();
@@ -115,12 +137,12 @@ describe("role registry", () => {
   });
 
   it("accepts cyberpunk role aliases without changing compatibility ids", () => {
-    expect(getAgentRole("scanner")?.name).toBe("explorer");
-    expect(resolveAgentRole("runner").name).toBe("worker");
+    expect(getAgentRole(DEFAULT_WORKSPACE, "scanner")?.name).toBe("explorer");
+    expect(resolveAgentRole(DEFAULT_WORKSPACE, "runner").name).toBe("worker");
   });
 
   it("worker has the default description and no built-in config-layer override", () => {
-    const role = resolveAgentRole("worker");
+    const role = resolveAgentRole(DEFAULT_WORKSPACE, "worker");
     expect(role.name).toBe("worker");
     expect(role.config.configFile).toBeUndefined();
     expect(role.config.reasoningEffort).toBeUndefined();
@@ -131,7 +153,7 @@ describe("role registry", () => {
   });
 
   it("user-registered awaiter roles can still derive runtime hints from built-in TOML", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "awaiter",
       config: {
         description: "Custom awaiter",
@@ -139,14 +161,14 @@ describe("role registry", () => {
         background: true,
       },
     });
-    const role = getAgentRole("awaiter")!;
+    const role = getAgentRole(DEFAULT_WORKSPACE, "awaiter")!;
     expect(role.config.background).toBe(true);
     expect(role.config.reasoningEffort).toBe("low");
     expect(role.config.timeoutMs).toBe(3_600_000);
   });
 
   it("derives xhigh reasoning effort from user role layers", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "deep-review",
       config: {
         description: "review",
@@ -154,11 +176,11 @@ describe("role registry", () => {
       },
     });
 
-    expect(getAgentRole("deep-review")?.config.reasoningEffort).toBe("xhigh");
+    expect(getAgentRole(DEFAULT_WORKSPACE, "deep-review")?.config.reasoningEffort).toBe("xhigh");
   });
 
   it("derives model and service tier hints from user role layers", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "priority-review",
       config: {
         description: "review",
@@ -169,16 +191,37 @@ describe("role registry", () => {
       },
     });
 
-    expect(getAgentRole("priority-review")?.config.model).toBe("gpt-5.4");
-    expect(getAgentRole("priority-review")?.config.serviceTier).toBe("priority");
+    expect(getAgentRole(DEFAULT_WORKSPACE, "priority-review")?.config.model).toBe("gpt-5.4");
+    expect(getAgentRole(DEFAULT_WORKSPACE, "priority-review")?.config.serviceTier).toBe("priority");
   });
 
   it("registerAgentRole overrides built-ins by name", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "explorer",
       config: { description: "override" },
     });
-    expect(getAgentRole("explorer")!.config.description).toBe("override");
+    expect(getAgentRole(DEFAULT_WORKSPACE, "explorer")!.config.description).toBe("override");
+  });
+
+  it("keeps same-named programmatic roles inside their workspace", () => {
+    const workspaceA = createAgentRoleWorkspace("/tmp/agenc-role-registry-a");
+    const workspaceB = createAgentRoleWorkspace("/tmp/agenc-role-registry-b");
+    registerAgentRole(workspaceA, {
+      name: "shared-reviewer",
+      config: { description: "Programmatic reviewer A" },
+    });
+    registerAgentRole(workspaceB, {
+      name: "shared-reviewer",
+      config: { description: "Programmatic reviewer B" },
+    });
+
+    expect(getAgentRole(workspaceA, "shared-reviewer")?.config.description).toBe(
+      "Programmatic reviewer A",
+    );
+    expect(getAgentRole(workspaceB, "shared-reviewer")?.config.description).toBe(
+      "Programmatic reviewer B",
+    );
+    expect(getAgentRole(DEFAULT_WORKSPACE, "shared-reviewer")).toBeUndefined();
   });
 
   it("registers project markdown agents into the spawn_agent role registry", () => {
@@ -199,16 +242,143 @@ describe("role registry", () => {
       ].join("\n"),
     );
 
-    loadMarkdownAgentRoles(root);
+    const workspace = createAgentRoleWorkspace(root);
+    loadMarkdownAgentRoles(workspace);
 
-    const role = requireAgentRole("project-reviewer");
+    const role = requireAgentRole(workspace, "project-reviewer");
     expect(role.config.description).toBe("Project reviewer");
     expect(role.config.systemPrompt).toBe("Review the current project changes.");
     expect(role.config.allowlist).toEqual(["Read"]);
     expect(role.config.reasoningEffort).toBe("high");
   });
 
-  it("resolves same-named markdown roles independently per cwd", () => {
+  it("rejects role files reached through file, directory, or hard links", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-markdown-role-links-"));
+    const workspaceRoot = join(root, "workspace");
+    const trustedAgents = join(workspaceRoot, ".agenc", "agents");
+    const externalAgents = join(root, "external-agents");
+    try {
+      mkdirSync(join(workspaceRoot, ".git"), { recursive: true });
+      mkdirSync(trustedAgents, { recursive: true });
+      mkdirSync(externalAgents, { recursive: true });
+      writeFileSync(
+        join(trustedAgents, "local.md"),
+        "---\nname: trusted-local\ndescription: Trusted local\n---\nTrusted prompt.\n",
+      );
+      const linkedFile = join(externalAgents, "linked-file.md");
+      writeFileSync(
+        linkedFile,
+        "---\nname: escaped-file\ndescription: Escaped file\n---\nEscaped.\n",
+      );
+      const linkedDirectory = join(externalAgents, "nested");
+      mkdirSync(linkedDirectory);
+      writeFileSync(
+        join(linkedDirectory, "linked-directory.md"),
+        "---\nname: escaped-directory\ndescription: Escaped directory\n---\nEscaped.\n",
+      );
+      const hardLinkTarget = join(externalAgents, "hard-link.md");
+      writeFileSync(
+        hardLinkTarget,
+        "---\nname: escaped-hard-link\ndescription: Escaped hard link\n---\nEscaped.\n",
+      );
+
+      symlinkSync(linkedFile, join(trustedAgents, "file-link.md"));
+      symlinkSync(
+        linkedDirectory,
+        join(trustedAgents, "directory-link"),
+        "dir",
+      );
+      linkSync(hardLinkTarget, join(trustedAgents, "hard-link.md"));
+
+      const workspace = createAgentRoleWorkspace(workspaceRoot);
+      loadMarkdownAgentRoles(workspace);
+
+      expect(getAgentRole(workspace, "trusted-local")?.config.systemPrompt).toBe(
+        "Trusted prompt.",
+      );
+      expect(getAgentRole(workspace, "escaped-file")).toBeUndefined();
+      expect(getAgentRole(workspace, "escaped-directory")).toBeUndefined();
+      expect(getAgentRole(workspace, "escaped-hard-link")).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symlinked user and managed role tier roots", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-markdown-role-roots-"));
+    const workspaceRoot = join(root, "workspace");
+    const userTarget = join(root, "user-target");
+    const userLink = join(root, "user-link");
+    const managedTarget = join(root, "managed-target");
+    const managedLink = join(root, "managed-link");
+    try {
+      mkdirSync(join(workspaceRoot, ".git"), { recursive: true });
+      mkdirSync(join(userTarget, "agents"), { recursive: true });
+      mkdirSync(managedTarget, { recursive: true });
+      writeFileSync(
+        join(userTarget, "agents", "user.md"),
+        "---\nname: escaped-user-root\ndescription: Escaped user root\n---\nEscaped.\n",
+      );
+      writeFileSync(
+        join(managedTarget, "managed.md"),
+        "---\nname: escaped-managed-root\ndescription: Escaped managed root\n---\nEscaped.\n",
+      );
+      symlinkSync(userTarget, userLink, "dir");
+      symlinkSync(managedTarget, managedLink, "dir");
+      vi.stubEnv("AGENC_CONFIG_DIR", userLink);
+      vi.stubEnv("AGENC_MANAGED_AGENTS_DIR", managedLink);
+
+      const workspace = createAgentRoleWorkspace(workspaceRoot);
+      loadMarkdownAgentRoles(workspace);
+
+      expect(getAgentRole(workspace, "escaped-user-root")).toBeUndefined();
+      expect(getAgentRole(workspace, "escaped-managed-root")).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the trusted role directory is swapped before open", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-markdown-role-swap-"));
+    const workspaceRoot = join(root, "workspace");
+    const trustedAgents = join(workspaceRoot, ".agenc", "agents");
+    const movedAgents = join(workspaceRoot, ".agenc", "agents-before-swap");
+    const externalAgents = join(root, "external-agents");
+    const victimPath = join(trustedAgents, "victim.md");
+    let swapped = false;
+    try {
+      mkdirSync(join(workspaceRoot, ".git"), { recursive: true });
+      mkdirSync(trustedAgents, { recursive: true });
+      mkdirSync(externalAgents, { recursive: true });
+      writeFileSync(
+        victimPath,
+        "---\nname: trusted-before-swap\ndescription: Trusted before swap\n---\nTrusted.\n",
+      );
+      writeFileSync(
+        join(externalAgents, "victim.md"),
+        "---\nname: escaped-after-swap\ndescription: Escaped after swap\n---\nEscaped.\n",
+      );
+      _setMarkdownAgentRoleReadHookForTesting((filePath) => {
+        if (swapped || filePath !== victimPath) return;
+        swapped = true;
+        renameSync(trustedAgents, movedAgents);
+        symlinkSync(externalAgents, trustedAgents, "dir");
+      });
+
+      const workspace = createAgentRoleWorkspace(workspaceRoot);
+      loadMarkdownAgentRoles(workspace);
+
+      expect(swapped).toBe(true);
+      expect(getAgentRole(workspace, "trusted-before-swap")).toBeUndefined();
+      expect(getAgentRole(workspace, "escaped-after-swap")).toBeUndefined();
+    } finally {
+      _setMarkdownAgentRoleReadHookForTesting(undefined);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves same-named markdown roles only inside their workspace", () => {
     const roots: string[] = [];
     for (const label of ["a", "b"] as const) {
       const root = mkdtempSync(join(tmpdir(), `agenc-md-role-${label}-`));
@@ -227,35 +397,32 @@ describe("role registry", () => {
       roots.push(root);
     }
     const [rootA, rootB] = roots;
+    const workspaceA = createAgentRoleWorkspace(rootA);
+    const workspaceB = createAgentRoleWorkspace(rootB);
 
-    loadMarkdownAgentRoles(rootA);
-    loadMarkdownAgentRoles(rootB);
+    loadMarkdownAgentRoles(workspaceA);
+    loadMarkdownAgentRoles(workspaceB);
 
-    expect(getAgentRole("shared-reviewer", rootA)?.config.description).toBe(
+    expect(getAgentRole(workspaceA, "shared-reviewer")?.config.description).toBe(
       "Reviewer a",
     );
-    expect(getAgentRole("shared-reviewer", rootB)?.config.description).toBe(
+    expect(getAgentRole(workspaceB, "shared-reviewer")?.config.description).toBe(
       "Reviewer b",
     );
-    expect(requireAgentRole("shared-reviewer", rootA).config.systemPrompt).toBe(
+    expect(requireAgentRole(workspaceA, "shared-reviewer").config.systemPrompt).toBe(
       "Reviewer a prompt.",
     );
 
-    // Per-cwd listings surface the cwd's own role definition.
-    const listedA = listAgentRoles(rootA).find(
+    const listedA = listAgentRoles(workspaceA).find(
       (role) => role.name === "shared-reviewer",
     );
-    const listedB = listAgentRoles(rootB).find(
+    const listedB = listAgentRoles(workspaceB).find(
       (role) => role.name === "shared-reviewer",
     );
     expect(listedA?.config.description).toBe("Reviewer a");
     expect(listedB?.config.description).toBe("Reviewer b");
 
-    // cwd-less lookups keep the legacy process-global fallback: the most
-    // recently loaded cwd wins.
-    expect(getAgentRole("shared-reviewer")?.config.description).toBe(
-      "Reviewer b",
-    );
+    expect(getAgentRole(DEFAULT_WORKSPACE, "shared-reviewer")).toBeUndefined();
   });
 
   it("reloads a cwd's markdown roles on a fresh load after the file changes", () => {
@@ -274,8 +441,9 @@ describe("role registry", () => {
       ].join("\n"),
     );
 
-    loadMarkdownAgentRoles(root);
-    expect(getAgentRole("editable-role", root)?.config.description).toBe(
+    const workspace = createAgentRoleWorkspace(root);
+    loadMarkdownAgentRoles(workspace);
+    expect(getAgentRole(workspace, "editable-role")?.config.description).toBe(
       "Before edit",
     );
 
@@ -293,8 +461,8 @@ describe("role registry", () => {
     const future = new Date(Date.now() + 5_000);
     utimesSync(filePath, future, future);
 
-    loadMarkdownAgentRoles(root);
-    const reloaded = getAgentRole("editable-role", root);
+    loadMarkdownAgentRoles(workspace);
+    const reloaded = getAgentRole(workspace, "editable-role");
     expect(reloaded?.config.description).toBe("After edit");
     expect(reloaded?.config.systemPrompt).toBe("New prompt.");
   });
@@ -355,7 +523,7 @@ describe("nickname allocation", () => {
   });
 
   it("two sibling spawns from roles without candidate lists use distinct shared nicknames", () => {
-    const role = resolveAgentRole("worker");
+    const role = resolveAgentRole(DEFAULT_WORKSPACE, "worker");
     const first = allocateNickname(role, registry);
     const second = allocateNickname(role, registry);
     expect(first).not.toBe(second);
@@ -366,7 +534,7 @@ describe("nickname allocation", () => {
 
 describe("config-layer stack", () => {
   it("applyRoleToConfig keeps explorer as a no-op when explorer.toml is empty", () => {
-    const explorer = getAgentRole("explorer")!;
+    const explorer = getAgentRole(DEFAULT_WORKSPACE, "explorer")!;
     const base = { cwd: "/tmp/project", reasoning_effort: "high" as const };
     const next = applyRoleToConfig(explorer, base);
     expect(next).toEqual(base);
@@ -374,7 +542,7 @@ describe("config-layer stack", () => {
   });
 
   it("applyRoleToConfig parses AgenC TOML aliases into canonical AgenC config keys", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "custom-inline",
       config: {
         description: "inline role",
@@ -389,7 +557,10 @@ describe("config-layer stack", () => {
     });
 
     const base = { cwd: "/tmp/project" };
-    const next = applyRoleToConfig(getAgentRole("custom-inline")!, base);
+    const next = applyRoleToConfig(
+      getAgentRole(DEFAULT_WORKSPACE, "custom-inline")!,
+      base,
+    );
     expect(next.cwd).toBe("/tmp/project");
     expect(next.model).toBe("role-model");
     expect(next.reasoning_effort).toBe("high");
@@ -399,7 +570,7 @@ describe("config-layer stack", () => {
   });
 
   it("applyRoleToConfig preserves the parent service tier when the role does not override it", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "custom-inline",
       config: {
         description: "inline role",
@@ -408,12 +579,15 @@ describe("config-layer stack", () => {
     });
 
     const base = { cwd: "/tmp/project", service_tier: "priority" as const };
-    const next = applyRoleToConfig(getAgentRole("custom-inline")!, base);
+    const next = applyRoleToConfig(
+      getAgentRole(DEFAULT_WORKSPACE, "custom-inline")!,
+      base,
+    );
     expect(next.service_tier).toBe("priority");
   });
 
   it("buildConfigLayerStack applies base → role → user precedence", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "custom-precedence",
       config: {
         description: "precedence role",
@@ -426,6 +600,7 @@ describe("config-layer stack", () => {
 
     const effective = buildConfigLayerStack({
       base: { cwd: "/x", model: "base-model" },
+      workspace: DEFAULT_WORKSPACE,
       roleName: "custom-precedence",
       userLayer: { model: "user-model" },
     });
@@ -436,7 +611,7 @@ describe("config-layer stack", () => {
   });
 
   it("buildConfigLayerStack resolves a role-selected profile against the merged config", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "profile-role",
       config: {
         description: "profile role",
@@ -454,6 +629,7 @@ describe("config-layer stack", () => {
           },
         },
       },
+      workspace: DEFAULT_WORKSPACE,
       roleName: "profile-role",
     });
 
@@ -465,6 +641,7 @@ describe("config-layer stack", () => {
   it("buildConfigLayerStack leaves unknown roles unchanged except for the user overlay", () => {
     const effective = buildConfigLayerStack({
       base: { cwd: "/x", reasoning_effort: "medium" as const },
+      workspace: DEFAULT_WORKSPACE,
       roleName: "missing-role",
       userLayer: { mode: "user-overlay" },
     });
@@ -475,14 +652,16 @@ describe("config-layer stack", () => {
   });
 
   it("tryResolveRoleConfig returns undefined for unknown; resolveAgentRole falls back to default", () => {
-    expect(tryResolveRoleConfig("unknown")).toBeUndefined();
-    expect(tryResolveRoleConfig(undefined)).toBeUndefined();
-    expect(tryResolveRoleConfig("explorer")).toBeDefined();
-    expect(resolveAgentRole("unknown").name).toBe("default");
+    expect(tryResolveRoleConfig(DEFAULT_WORKSPACE, "unknown")).toBeUndefined();
+    expect(tryResolveRoleConfig(DEFAULT_WORKSPACE, undefined)).toBeUndefined();
+    expect(tryResolveRoleConfig(DEFAULT_WORKSPACE, "explorer")).toBeDefined();
+    expect(resolveAgentRole(DEFAULT_WORKSPACE, "unknown").name).toBe("default");
   });
 
   it("loadRoleLayerToml reads built-in TOML and strips user-role metadata from disk-backed TOML", () => {
-    expect(loadRoleLayerToml(getAgentRole("explorer")!)).toEqual({});
+    expect(
+      loadRoleLayerToml(getAgentRole(DEFAULT_WORKSPACE, "explorer")!),
+    ).toEqual({});
 
     const dir = mkdtempSync(join(tmpdir(), "agenc-role-test-"));
     const path = join(dir, "custom-role.toml");
@@ -498,7 +677,7 @@ describe("config-layer stack", () => {
       ].join("\n"),
     );
 
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "file-backed-role",
       config: {
         description: "file-backed role",
@@ -506,14 +685,33 @@ describe("config-layer stack", () => {
       },
     });
 
-    expect(loadRoleLayerToml(getAgentRole("file-backed-role")!)).toEqual({
+    expect(
+      loadRoleLayerToml(getAgentRole(DEFAULT_WORKSPACE, "file-backed-role")!),
+    ).toEqual({
       model: "file-model",
       model_reasoning_effort: "medium",
     });
   });
 
+  it("fingerprints the effective contents of a same-path role config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-role-fingerprint-"));
+    const path = join(dir, "guarded.toml");
+    writeFileSync(path, 'approval_policy = "never"\n');
+    const role = {
+      name: "guarded",
+      config: {
+        description: "Guarded role",
+        configFile: path,
+      },
+    };
+
+    const first = agentRoleFingerprint(role);
+    writeFileSync(path, 'approval_policy = "on-request"\n');
+    expect(agentRoleFingerprint(role)).not.toBe(first);
+  });
+
   it("formatRoleList uses AgenC-style locked-setting notes from role TOML", () => {
-    registerAgentRole({
+    registerAgentRole(DEFAULT_WORKSPACE, {
       name: "model-locked-role",
       config: {
         description: "Locked config role.",
@@ -527,7 +725,7 @@ describe("config-layer stack", () => {
 
     const text = formatRoleList([
       getDefaultAgentRole(),
-      getAgentRole("model-locked-role")!,
+      getAgentRole(DEFAULT_WORKSPACE, "model-locked-role")!,
     ]);
 
     expect(text).toContain("Available roles:");
@@ -543,7 +741,7 @@ describe("config-layer stack", () => {
   });
 
   it("formatRoleList skips duplicate names", () => {
-    const explorer = getAgentRole("explorer")!;
+    const explorer = getAgentRole(DEFAULT_WORKSPACE, "explorer")!;
     const text = formatRoleList([explorer, explorer]);
     expect(text.match(/scanner:/g)?.length).toBe(1);
     expect(text).toContain("Legacy alias accepted: `explorer`");

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -34,6 +34,7 @@ import {
 import {
   _resetAgentRolesForTesting,
   _resetNicknamePoolForTesting,
+  createAgentRoleWorkspace,
   registerAgentRole,
 } from "./role.js";
 import { BUILTIN_READONLY_DISALLOWLIST } from "./built-in-prompts.js";
@@ -45,6 +46,8 @@ import type {
   LLMResponse,
   StreamProgressCallback,
 } from "../llm/types.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
 import { Session, type Event, type SessionOpts, type SessionServices } from "../session/session.js";
 import { RolloutStore } from "../session/rollout-store.js";
 import type {
@@ -158,6 +161,8 @@ function makeStubSession(opts: {
   sessionConfiguration?: SessionConfiguration;
   config?: Config;
   modelInfo?: ModelInfo;
+  roleWorkspace?: SessionOpts["roleWorkspace"];
+  agentDefinitions?: SessionOpts["agentDefinitions"];
 } = {}): Session {
   const state = {
     sessionConfiguration:
@@ -169,6 +174,12 @@ function makeStubSession(opts: {
   };
   const session = new Session({
     conversationId: "conv-parent",
+    ...(opts.roleWorkspace !== undefined
+      ? { roleWorkspace: opts.roleWorkspace }
+      : {}),
+    ...(opts.agentDefinitions !== undefined
+      ? { agentDefinitions: opts.agentDefinitions }
+      : {}),
     initialState: state as unknown as SessionOpts["initialState"],
     features: mkFeatures(),
     services: {
@@ -598,7 +609,7 @@ describe("runAgent", () => {
   });
 
   it("applies role model, reasoning, and service tier to the child session", async () => {
-    registerAgentRole({
+    registerAgentRole(ROLE_WORKSPACE, {
       name: "priority-reviewer",
       config: {
         description: "Review quickly.",
@@ -742,6 +753,72 @@ describe("runAgent", () => {
           content: providerMessages[0]?.content,
         }),
       }),
+    );
+  });
+
+  it("preserves the canonical parent catalog in a real worktree child session", async () => {
+    const provider = makeProvider([{ content: "nested catalog" }]);
+    const exactPluginAgent = {
+      agentType: "plugin:strict-reviewer",
+      description: "workspace exact plugin role",
+      source: "plugin",
+      getSystemPrompt: () => "strict reviewer prompt",
+    };
+    const session = makeStubSession({
+      services: { provider },
+      roleWorkspace: ROLE_WORKSPACE,
+      agentDefinitions: {
+        agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+        activeAgents: [exactPluginAgent],
+        allAgents: [exactPluginAgent],
+        allowedAgentTypes: ["plugin:strict-reviewer"],
+      },
+    });
+    const { live } = await spawnLive(session);
+    const childWorktree = mkdtempSync(join(tmpdir(), "agenc-child-catalog-"));
+    let childCatalog:
+      | {
+          agentRoleWorkspaceId?: string;
+          activeAgents: unknown[];
+          allAgents?: unknown[];
+          allowedAgentTypes?: unknown[];
+        }
+      | undefined;
+
+    try {
+      await collectRun(
+        runAgent({
+          live,
+          parent: session,
+          worktree: {
+            path: childWorktree,
+            branch: "agent/catalog-child",
+            gitRoot: childWorktree,
+            created: false,
+          },
+          initialMessages: [{ role: "user", content: "go" }],
+          taskPrompt: "go",
+          onCacheSafeParams: (params) => {
+            childCatalog = (
+              params.toolUseContext as unknown as {
+                options: { agentDefinitions: typeof childCatalog };
+              }
+            ).options.agentDefinitions;
+          },
+        }),
+      );
+    } finally {
+      rmSync(childWorktree, { recursive: true, force: true });
+    }
+
+    expect(childCatalog).toMatchObject({
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+      activeAgents: [exactPluginAgent],
+      allAgents: [exactPluginAgent],
+      allowedAgentTypes: ["plugin:strict-reviewer"],
+    });
+    expect(childCatalog?.activeAgents).not.toBe(
+      session.agentDefinitions.activeAgents,
     );
   });
 

--- a/runtime/tests/agents/thread-manager.test.ts
+++ b/runtime/tests/agents/thread-manager.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { AgentStatusTracker } from "./status.js";
 import { Mailbox } from "./mailbox.js";
-import { resolveAgentRole } from "./role.js";
+import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
 import { ThreadManager } from "./thread-manager.js";
 import type { LiveAgent } from "./control.js";
 import type { AgentMetadata } from "./registry.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 function makeSession() {
   return {
@@ -27,12 +29,13 @@ function makeLive(): LiveAgent {
     agentPath: "/root/task_1",
     agentNickname: "scout",
     agentRole: "explorer",
+    agentRoleWorkspaceId: ROLE_WORKSPACE.id,
     depth: 1,
   };
   return {
     agentId: "child-thread",
     agentPath: "/root/task_1",
-    role: resolveAgentRole("explorer"),
+    role: resolveAgentRole(ROLE_WORKSPACE, "explorer"),
     depth: 1,
     nickname: "scout",
     status: new AgentStatusTracker(),

--- a/runtime/tests/agents/thread.test.ts
+++ b/runtime/tests/agents/thread.test.ts
@@ -2,15 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 import { AgentThread } from "./thread.js";
 import type { LiveAgent } from "./control.js";
 import { AgentStatusTracker } from "./status.js";
-import { resolveAgentRole } from "./role.js";
+import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
 import { Mailbox } from "./mailbox.js";
 import type { LLMMessage } from "../llm/types.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 function makeLive(): LiveAgent {
   return {
     agentId: "thread-1",
     agentPath: "/root/alpha",
-    role: resolveAgentRole(undefined),
+    role: resolveAgentRole(ROLE_WORKSPACE, undefined),
     depth: 1,
     nickname: "alpha",
     status: new AgentStatusTracker(),
@@ -22,6 +24,7 @@ function makeLive(): LiveAgent {
       agentPath: "/root/alpha",
       agentNickname: "alpha",
       agentRole: "default",
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
       depth: 1,
     },
     messages: [],

--- a/runtime/tests/agents/v2/spawn-isolation.test.ts
+++ b/runtime/tests/agents/v2/spawn-isolation.test.ts
@@ -8,6 +8,9 @@ import { createSpawnAgentTool } from "./spawn.js";
 import { delegate } from "../delegate.js";
 import type { MultiAgentV2Options } from "./common.js";
 import type { Session } from "../../session/session.js";
+import { createAgentRoleWorkspace } from "../role.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace("/repo");
 
 const mockDelegate = vi.mocked(delegate);
 
@@ -48,10 +51,12 @@ function makeSession(): Session {
   const emitted: unknown[] = [];
   return {
     conversationId: "conv-1",
+    roleWorkspace: ROLE_WORKSPACE,
     emit: (event: unknown) => emitted.push(event),
     nextInternalSubId: () => `sub-${emitted.length}`,
     modelInfo: { slug: "test-model" },
     sessionConfiguration: {
+      cwd: "/repo",
       collaborationMode: { model: "test-model" },
     },
     config: { multiAgentV2: { hideSpawnAgentMetadata: false } },
@@ -68,8 +73,13 @@ function makeSession(): Session {
 function makeOptions(session: Session): MultiAgentV2Options {
   return {
     getSession: () => session,
+    workspace: ROLE_WORKSPACE,
     ensureAgentControl: () => ({
-      control: { getLive: () => undefined },
+      control: {
+        roleWorkspace: ROLE_WORKSPACE,
+        assertRoleWorkspace: () => {},
+        getLive: () => undefined,
+      },
       registry: {},
     }),
   } as unknown as MultiAgentV2Options;

--- a/runtime/tests/agents/v2/spawn-model-schema.test.ts
+++ b/runtime/tests/agents/v2/spawn-model-schema.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { createSpawnAgentTool } from "./spawn.js";
 import type { MultiAgentV2Options } from "./common.js";
 import type { Session } from "../../session/session.js";
+import { createAgentRoleWorkspace } from "../role.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace("/repo");
 
 interface FakeSchema {
   readonly type: string;
@@ -27,6 +30,7 @@ function makeOptions(opts: {
   } as unknown as Session;
   return {
     getSession: () => session,
+    workspace: ROLE_WORKSPACE,
     ensureAgentControl: () => {
       throw new Error("not used in schema test");
     },

--- a/runtime/tests/app-server-client/index.test.ts
+++ b/runtime/tests/app-server-client/index.test.ts
@@ -278,6 +278,34 @@ describe("app-server-client daemon helpers", () => {
     }
   });
 
+  it("keeps daemon attach execution cwd separate from role authority", async () => {
+    const agencHome = mkdtempSync(join(tmpdir(), "agenc-attach-home-"));
+    const authority = mkdtempSync(join(tmpdir(), "agenc-attach-authority-"));
+    const worktree = mkdtempSync(join(tmpdir(), "agenc-attach-worktree-"));
+    let context: Awaited<ReturnType<typeof createAgenCDaemonOnlyTuiContext>> | null =
+      null;
+    try {
+      context = await createAgenCDaemonOnlyTuiContext({
+        env: { ...process.env, AGENC_HOME: agencHome, HOME: agencHome },
+        cwd: worktree,
+        roleWorkspace: { id: authority, cwd: authority },
+        conversationId: "agenc-tui-worktree-child",
+      });
+
+      expect(context.baseSession.roleWorkspace).toMatchObject({
+        id: authority,
+        cwd: authority,
+      });
+      expect(context.baseSession.sessionConfiguration?.cwd).toBe(worktree);
+      expect(context.workspaceRoot).toBe(worktree);
+    } finally {
+      await context?.close();
+      rmSync(agencHome, { recursive: true, force: true });
+      rmSync(authority, { recursive: true, force: true });
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
   it("applies daemon-only TUI provider and model startup overrides", async () => {
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-model-tui-context-"));
     const workspace = mkdtempSync(join(tmpdir(), "agenc-model-tui-workspace-"));

--- a/runtime/tests/app-server/agent-cli.contract.test.ts
+++ b/runtime/tests/app-server/agent-cli.contract.test.ts
@@ -16,6 +16,7 @@ import {
   formatAgenCAgentStopResult,
   parseAgenCAgentCliArgs,
   resolveAgenCAgentAttachCwd,
+  resolveAgenCAgentAttachRoleWorkspace,
   runAgenCAgentCli,
   type AgenCAgentCliIo,
 } from "./agent-cli.js";
@@ -527,6 +528,32 @@ describe("agenc agent start CLI", () => {
         "/local/workspace",
       ),
     ).toBe("/daemon/workspace");
+    expect(
+      resolveAgenCAgentAttachRoleWorkspace(
+        {
+          agentId: "agent_3",
+          attachmentId: "attachment_3",
+          sessionIds: ["session_remote"],
+          sessions: [
+            {
+              sessionId: "session_remote",
+              agentId: "agent_3",
+              status: "idle",
+              createdAt: "2026-05-01T12:00:00.000Z",
+              cwd: "/daemon/worktree",
+              roleWorkspace: {
+                id: "/daemon/authority",
+                cwd: "/daemon/authority",
+              },
+            },
+          ],
+        },
+        "/local/workspace",
+      ),
+    ).toMatchObject({
+      id: "/daemon/authority",
+      cwd: "/daemon/authority",
+    });
     expect(io.stderrText()).toBe("");
   });
 
@@ -1868,6 +1895,97 @@ autostart = false
     expect(io.stderrText()).toContain(
       "Daemon connection closed before response",
     );
+  });
+});
+
+describe("resolveAgenCAgentAttachRoleWorkspace", () => {
+  function attachmentWithMetadata(
+    metadata?: Record<string, string | number | undefined>,
+  ) {
+    return {
+      agentId: "agent_1",
+      attachmentId: "attachment_1",
+      sessionIds: ["session_1"],
+      sessions: [
+        {
+          sessionId: "session_1",
+          agentId: "agent_1",
+          status: "idle" as const,
+          createdAt: "2026-05-01T12:00:00.000Z",
+          cwd: "/daemon/worktree",
+          ...(metadata === undefined ? {} : { metadata }),
+        },
+      ],
+    };
+  }
+
+  it("uses the execution cwd only for legacy sessions without role provenance", () => {
+    expect(
+      resolveAgenCAgentAttachRoleWorkspace(
+        attachmentWithMetadata(),
+        "/local/workspace",
+      ),
+    ).toMatchObject({
+      id: "/daemon/worktree",
+      cwd: "/daemon/worktree",
+    });
+  });
+
+  it("accepts complete persisted role provenance", () => {
+    expect(
+      resolveAgenCAgentAttachRoleWorkspace(
+        attachmentWithMetadata({
+          agentRoleWorkspaceId: "/daemon/authority",
+          agentRoleWorkspaceCwd: "/daemon/authority",
+        }),
+        "/local/workspace",
+      ),
+    ).toMatchObject({
+      id: "/daemon/authority",
+      cwd: "/daemon/authority",
+    });
+  });
+
+  it.each([
+    ["an empty ID", { agentRoleWorkspaceId: "" }],
+    ["a non-string ID", { agentRoleWorkspaceId: 42 }],
+    ["a cwd without an ID", { agentRoleWorkspaceCwd: "/daemon/authority" }],
+    [
+      "an empty present cwd",
+      {
+        agentRoleWorkspaceId: "/daemon/authority",
+        agentRoleWorkspaceCwd: "",
+      },
+    ],
+    [
+      "a non-string present cwd",
+      {
+        agentRoleWorkspaceId: "/daemon/authority",
+        agentRoleWorkspaceCwd: 42,
+      },
+    ],
+    ["a relative ID", { agentRoleWorkspaceId: "relative/authority" }],
+    [
+      "a relative present cwd",
+      {
+        agentRoleWorkspaceId: "/daemon/authority",
+        agentRoleWorkspaceCwd: "relative/authority",
+      },
+    ],
+    [
+      "mismatched ID and cwd",
+      {
+        agentRoleWorkspaceId: "/daemon/authority-a",
+        agentRoleWorkspaceCwd: "/daemon/authority-b",
+      },
+    ],
+  ])("rejects %s instead of falling back", (_label, metadata) => {
+    expect(() =>
+      resolveAgenCAgentAttachRoleWorkspace(
+        attachmentWithMetadata(metadata),
+        "/local/workspace",
+      ),
+    ).toThrow();
   });
 });
 

--- a/runtime/tests/app-server/session-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/session-lifecycle.contract.test.ts
@@ -91,6 +91,54 @@ describe("AgenC daemon session lifecycle", () => {
     });
   });
 
+  it("rejects malformed present role provenance on create and restore", async () => {
+    const cwd = await workspaces.create();
+    const manager = new AgenCDaemonSessionManager({
+      createSessionId: sequence(["session_valid"]),
+      now: sequence(["2026-05-01T10:00:00.000Z"]),
+    });
+    const malformedMetadata = [
+      { agentRoleWorkspaceId: "" },
+      { agentRoleWorkspaceId: 42 },
+      { agentRoleWorkspaceCwd: cwd },
+      { agentRoleWorkspaceId: cwd, agentRoleWorkspaceCwd: "" },
+      { agentRoleWorkspaceId: cwd, agentRoleWorkspaceCwd: 42 },
+      { agentRoleWorkspaceId: "relative", agentRoleWorkspaceCwd: "relative" },
+      { agentRoleWorkspaceId: cwd, agentRoleWorkspaceCwd: join(cwd, "other") },
+    ] as const;
+
+    for (const metadata of malformedMetadata) {
+      await expect(
+        manager.createSession({ agentId: "agent_bad", cwd, metadata }),
+      ).rejects.toMatchObject({
+        code: "INVALID_ARGUMENT",
+        message: expect.stringContaining(
+          "Invalid agent role workspace provenance",
+        ),
+      });
+      await expect(
+        manager.restoreSession({
+          sessionId: `restored_${JSON.stringify(metadata)}`,
+          agentId: "agent_bad",
+          cwd,
+          metadata,
+        }),
+      ).rejects.toMatchObject({ code: "INVALID_ARGUMENT" });
+    }
+
+    await expect(manager.listSessions()).resolves.toEqual({ sessions: [] });
+    await expect(
+      manager.createSession({
+        agentId: "agent_valid",
+        cwd,
+        metadata: { agentRoleWorkspaceId: cwd },
+      }),
+    ).resolves.toMatchObject({
+      sessionId: "session_valid",
+      roleWorkspace: { id: cwd, cwd },
+    });
+  });
+
   it("attaches and detaches clients without terminating the session", async () => {
     const manager = new AgenCDaemonSessionManager({
       createSessionId: sequence(["session_1"]),
@@ -290,6 +338,65 @@ describe("AgenC daemon session lifecycle", () => {
       restoreEnv();
       rmSync(home, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers worktree execution cwd without rebinding role authority", async () => {
+    const { cwd: worktreeCwd, home, restoreEnv } = createThreadStoreTestDirs();
+    const authorityCwd = mkdtempSync(join(tmpdir(), "agenc-role-authority-"));
+    const rollout = openRollout(worktreeCwd, "stored-worktree-child");
+    const threadStore = new FileThreadStore({ cwd: worktreeCwd, agencHome: home });
+    try {
+      threadStore.createThread({
+        threadId: "stored-worktree-child",
+        rolloutStore: rollout,
+        source: {
+          kind: "subagent",
+          source: {
+            kind: "thread_spawn",
+            parentThreadId: "parent-session",
+            depth: 1,
+            agentPath: "/root/child",
+            agentRole: "scanner",
+            agentRoleWorkspaceId: authorityCwd,
+          },
+        },
+        cwd: worktreeCwd,
+      });
+      threadStore.shutdownThread("stored-worktree-child");
+
+      const recreated = new AgenCDaemonSessionManager({
+        threadStore,
+        createAttachmentId: sequence(["attachment-worktree-child"]),
+        now: sequence(["2026-05-01T10:31:30.000Z"]),
+      });
+      await expect(
+        recreated.attachSession({
+          sessionId: "stored-worktree-child",
+          clientId: "tui-worktree",
+        }),
+      ).resolves.toMatchObject({
+        attachmentId: "attachment-worktree-child",
+      });
+      await expect(
+        recreated.getSession("stored-worktree-child"),
+      ).resolves.toMatchObject({
+        sessionId: "stored-worktree-child",
+        cwd: worktreeCwd,
+        roleWorkspace: { id: authorityCwd, cwd: authorityCwd },
+        metadata: {
+          agentRoleWorkspaceId: authorityCwd,
+          agentRoleWorkspaceCwd: authorityCwd,
+          recovered: true,
+        },
+      });
+    } finally {
+      threadStore.close();
+      rollout.close();
+      restoreEnv();
+      rmSync(home, { recursive: true, force: true });
+      rmSync(worktreeCwd, { recursive: true, force: true });
+      rmSync(authorityCwd, { recursive: true, force: true });
     }
   });
 

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -74,6 +74,7 @@ function stubSession() {
     nextInternalSubId: () => "sub-1",
     services: {},
     conversationId: "conv-stub-1",
+    sessionConfiguration: { cwd: process.cwd() },
   } as unknown as Session;
 }
 
@@ -112,7 +113,7 @@ function createMockSignalProcess(): {
 function trustWorkspaceForTest(agencHome: string, workspace: string): void {
   trustProjectSync({
     agencHome,
-    projectRoot: workspace,
+    cwd: workspace,
     env: process.env,
   });
 }
@@ -137,6 +138,7 @@ function installDaemonCliDepsForTest(
     readonly sessionId?: string;
     readonly runtimeSessionId?: string;
     readonly cwd?: string;
+    readonly roleWorkspaceCwd?: string;
     readonly oneShotEvents?: readonly unknown[];
     /**
      * Causality-faithful hook for tests that model the production daemon: the
@@ -177,6 +179,7 @@ function installDaemonCliDepsForTest(
   const sessionId = options.sessionId ?? "session_test";
   const runtimeSessionId = options.runtimeSessionId ?? sessionId;
   const cwd = options.cwd ?? process.cwd();
+  const roleWorkspaceCwd = options.roleWorkspaceCwd ?? cwd;
   const requests: Array<{ method: string; params: unknown }> = [];
   const requestErrorQueues = new Map<string, Error[]>(
     Object.entries(options.requestErrors ?? {}).map(([method, error]) => [
@@ -247,6 +250,19 @@ function installDaemonCliDepsForTest(
           attachmentId: "attachment_test",
           sessionIds: [sessionId],
           runtimeSessionId,
+          sessions: [
+            {
+              sessionId,
+              agentId,
+              status: "idle",
+              createdAt: "2026-05-06T00:00:00.000Z",
+              cwd,
+              roleWorkspace: {
+                id: roleWorkspaceCwd,
+                cwd: roleWorkspaceCwd,
+              },
+            },
+          ],
         };
       }
       if (method === "session.snapshot") {
@@ -339,6 +355,7 @@ function installDaemonCliDepsForTest(
   const createTuiContext = vi.fn(async (params: {
     env?: NodeJS.ProcessEnv;
     cwd: string;
+    roleWorkspace?: { readonly id: string; readonly cwd: string };
     conversationId: string;
   }) => {
     const abortController = new AbortController();
@@ -355,6 +372,7 @@ function installDaemonCliDepsForTest(
       },
       baseSession: {
         conversationId: params.conversationId,
+        roleWorkspace: params.roleWorkspace,
         cwd: params.cwd,
         home: params.env?.HOME ?? "/tmp/agenc-test-user",
         sessionConfiguration: {
@@ -1031,6 +1049,37 @@ describe("resolveCliCwdForStartup", () => {
     );
 
     expect(result).toEqual({ ok: true, cwd: "/tmp/agenc-workspace" });
+  });
+
+  it("resolves a relative AGENC_WORKSPACE against the startup cwd", () => {
+    const result = resolveCliCwdForStartup(
+      { AGENC_WORKSPACE: "nested/workspace" },
+      { cwdFn: () => "/tmp/agenc-parent" },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      cwd: "/tmp/agenc-parent/nested/workspace",
+    });
+  });
+
+  it("rejects a relative AGENC_WORKSPACE when the startup cwd is unavailable", () => {
+    const result = resolveCliCwdForStartup(
+      { AGENC_WORKSPACE: "nested/workspace" },
+      {
+        cwdFn: () => {
+          throw Object.assign(new Error("ENOENT: no such file or directory, uv_cwd"), {
+            syscall: "uv_cwd",
+          });
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message:
+        "AGENC_WORKSPACE must be absolute when the current working directory is unavailable.",
+    });
   });
 
   it("returns the concise deleted-directory message when no workspace is configured", () => {
@@ -2577,6 +2626,51 @@ describe("main() smoke", () => {
       Object.assign(process.env, prevEnv);
       await rm(tmpHome, { recursive: true, force: true });
       await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("attaches a worktree child with separate execution and role workspaces", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-tui-role-home-"));
+    const authority = await mkdtemp(join(tmpdir(), "agenc-tui-role-authority-"));
+    const worktree = await mkdtemp(join(tmpdir(), "agenc-tui-role-worktree-"));
+    const prevEnv = { ...process.env };
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = worktree;
+    process.env.XAI_API_KEY = "stub-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+    const daemon = installDaemonCliDepsForTest({
+      agentId: "agent_worktree_child",
+      sessionId: "session_worktree_child",
+      cwd: worktree,
+      roleWorkspaceCwd: authority,
+    });
+    vi.doMock("../tui/main.js", () => ({
+      bootTUI: vi.fn(async () => ({
+        unmount: vi.fn(),
+        waitUntilExit: vi.fn().mockResolvedValue(undefined),
+      })),
+    }));
+
+    try {
+      trustWorkspaceForTest(tmpHome, worktree);
+      trustWorkspaceForTest(tmpHome, authority);
+      await expect(bootTUIEntry({ initialPrompt: "inspect" })).resolves.toBe(0);
+      expect(daemon.createTuiContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: worktree,
+          roleWorkspace: { id: authority, cwd: authority },
+        }),
+      );
+    } finally {
+      vi.doUnmock("../tui/main.js");
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(authority, { recursive: true, force: true });
+      await rm(worktree, { recursive: true, force: true });
     }
   });
 

--- a/runtime/tests/bin/bootstrap.test.ts
+++ b/runtime/tests/bin/bootstrap.test.ts
@@ -29,6 +29,13 @@ import type { RolloutItem } from "../session/rollout-item.js";
 import { RolloutStore } from "../session/rollout-store.js";
 import { FileThreadStore } from "../thread-store/store.js";
 import { Session } from "../session/session.js";
+import { buildAgenCToolUseContext } from "../session/agenc-tool-use-context.js";
+import {
+  _resetAgentRolesForTesting,
+  createAgentRoleWorkspace,
+  registerAgentRole,
+} from "../agents/role.js";
+import { findAgentDefinitionByType } from "../tools/AgentTool/loadAgentsDir.js";
 import { SidecarManager } from "../session/sidecar.js";
 import { getCurrentRuntimeSession } from "./_deps/current-session.js";
 import { PERSONALITY_MIGRATION_FILENAME } from "../personality/migration.js";
@@ -448,6 +455,81 @@ describe("readStartupCliFlags", () => {
 describe("bootstrapLocalRuntimeSession", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    _resetAgentRolesForTesting();
+  });
+
+  it("keeps a workspace programmatic role in bootstrap and model-facing catalogs", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agenc-bootstrap-role-home-"));
+    const workspace = await mkdtemp(join(tmpdir(), "agenc-bootstrap-role-ws-"));
+    const roleWorkspace = createAgentRoleWorkspace(workspace);
+    registerAgentRole(roleWorkspace, {
+      name: "programmatic-auditor",
+      config: {
+        description: "Strict registered auditor",
+        systemPrompt: "Audit without editing.",
+        model: "grok-4.5",
+        allowlist: ["FileRead"],
+        disallowlist: ["Write"],
+        reasoningEffort: "high",
+      },
+    });
+
+    const providerMod = await import("../llm/provider.js");
+    vi.spyOn(providerMod, "createProvider").mockImplementation(
+      () =>
+        ({
+          name: "stub",
+          chat: async () => ({
+            content: "ok",
+            toolCalls: [],
+            usage: {
+              promptTokens: 1,
+              completionTokens: 1,
+              totalTokens: 2,
+            },
+          }),
+        }) as never,
+    );
+    vi.spyOn(Session.prototype, "startMcpManager").mockResolvedValue(undefined);
+
+    let shutdown: (() => Promise<void>) | null = null;
+    try {
+      const boot = await bootstrapLocalRuntimeSession({
+        apiKey: "test-key",
+        cwd: workspace,
+        env: {
+          ...process.env,
+          AGENC_HOME: home,
+          HOME: home,
+        },
+      });
+      shutdown = boot.shutdown;
+
+      const bootDefinition = findAgentDefinitionByType(
+        boot.session.agentDefinitions.activeAgents as never[],
+        "programmatic-auditor",
+      );
+      expect(bootDefinition).toMatchObject({
+        source: "projectSettings",
+        model: "grok-4.5",
+        tools: ["FileRead"],
+        disallowedTools: ["Write"],
+        effort: "high",
+      });
+      expect(bootDefinition?.getSystemPrompt()).toBe("Audit without editing.");
+
+      const toolContext = buildAgenCToolUseContext(boot.session, boot.ctx);
+      expect(
+        findAgentDefinitionByType(
+          toolContext.options.agentDefinitions.activeAgents,
+          "programmatic-auditor",
+        ),
+      ).toMatchObject({ agentRoleFingerprint: expect.any(String) });
+    } finally {
+      await shutdown?.().catch(() => {});
+      await rm(home, { recursive: true, force: true });
+      await rm(workspace, { recursive: true, force: true });
+    }
   });
 
   it("runs personality migration before constructing the first turn context", async () => {
@@ -609,13 +691,22 @@ describe("bootstrapLocalRuntimeSession", () => {
         "cli_main",
       );
       expect(boot.config.agentRoles.length).toBeGreaterThan(0);
-      expect(boot.session.agentDefinitions.activeAgents).toEqual(
-        boot.config.agentRoles.map((role) => ({
-          agentType: role.name,
-          ...(role.description.length > 0
-            ? { whenToUse: role.description }
-            : {}),
-        })),
+      expect(
+        boot.session.agentDefinitions.activeAgents.map((definition) =>
+          (definition as { agentType: string }).agentType,
+        ),
+      ).toEqual(boot.config.agentRoles.map((role) => role.name));
+      expect(
+        boot.session.agentDefinitions.activeAgents,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            agentType: "explorer",
+            source: "built-in",
+            agentRoleFingerprint: expect.any(String),
+            disallowedTools: expect.arrayContaining(["Write"]),
+          }),
+        ]),
       );
       expect(startMcpSpy).toHaveBeenCalledWith(boot.mcpManager, {
         signal: boot.session.services.mcpStartupCancellationToken.signal,
@@ -3001,6 +3092,10 @@ required = true
   it("keeps untrusted project settings from relaxing bootstrap permissions", async () => {
     const home = await mkdtemp(join(tmpdir(), "agenc-bootstrap-home-"));
     const workspace = await mkdtemp(join(tmpdir(), "agenc-bootstrap-ws-"));
+    // Pin this temporary directory as the project root. Test runners and local
+    // developer machines may legitimately have a root marker (for example a
+    // package.json) higher in the system temp directory.
+    await writeFile(join(workspace, "package.json"), "{}\n", "utf8");
     await writeFile(
       join(home, "config.toml"),
       'approval_policy = "never"\n',

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -35,7 +35,13 @@ import {
   getSessionReadSnapshot,
   SESSION_ID_ARG,
 } from "../tools/system/filesystem.js";
-import { _resetAgentRolesForTesting, registerAgentRole } from "../agents/role.js";
+import {
+  _resetAgentRolesForTesting,
+  createAgentRoleWorkspace,
+  registerAgentRole,
+} from "../agents/role.js";
+
+const DEFAULT_ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
 
 const { delegateMock } = vi.hoisted(() => ({
   delegateMock: vi.fn(),
@@ -73,7 +79,7 @@ function fakeMcpManager() {
   };
 }
 
-function fakeSession(): Session {
+function fakeSession(cwd = process.cwd()): Session {
   const modelInfo = {
     slug: "test-model",
     effectiveContextWindowPercent: 95,
@@ -92,12 +98,13 @@ function fakeSession(): Session {
   } as const;
   return {
     conversationId: "session-test",
+    roleWorkspace: createAgentRoleWorkspace(cwd),
     config: {
-      cwd: process.cwd(),
+      cwd,
     },
     modelInfo,
     sessionConfiguration: {
-      cwd: process.cwd(),
+      cwd,
       collaborationMode: {
         model: "test-model",
         reasoningEffort: "medium",
@@ -2486,7 +2493,7 @@ describe("model-facing tools", () => {
       getModelInfo: async (model: string) =>
         model === roleModelInfo.slug ? roleModelInfo : requestedModelInfo,
     };
-    registerAgentRole({
+    registerAgentRole(DEFAULT_ROLE_WORKSPACE, {
       name: "priority-reviewer",
       config: {
         description: "Review quickly.",
@@ -2570,7 +2577,7 @@ describe("model-facing tools", () => {
       listModels: async () => [roleModelInfo],
       getModelInfo: async () => roleModelInfo,
     };
-    registerAgentRole({
+    registerAgentRole(DEFAULT_ROLE_WORKSPACE, {
       name: "priority-reviewer",
       config: {
         description: "Review quickly.",
@@ -2700,6 +2707,8 @@ describe("model-facing tools", () => {
     const emit = vi.fn();
     (session as unknown as { emit: typeof emit }).emit = emit;
     const control = {
+      roleWorkspace: DEFAULT_ROLE_WORKSPACE,
+      assertRoleWorkspace: vi.fn(),
       getLive: vi.fn((threadId: string) =>
         threadId === "child-1"
           ? {
@@ -2965,11 +2974,7 @@ describe("model-facing tools", () => {
       ].join("\n"),
     );
 
-    const session = fakeSession();
-    (session.config as { cwd?: string }).cwd = workspaceRoot;
-    (
-      session.sessionConfiguration as { cwd?: string }
-    ).cwd = workspaceRoot;
+    const session = fakeSession(workspaceRoot);
     const joinThread = vi.fn(async () => ({
       threadId: "thread-custom",
       durationMs: 1,
@@ -3017,6 +3022,141 @@ describe("model-facing tools", () => {
       );
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps same-named role resolution inside each live spawn workspace", async () => {
+    const roots = await Promise.all([
+      mkdtemp(join(tmpdir(), "agenc-spawn-role-a-")),
+      mkdtemp(join(tmpdir(), "agenc-spawn-role-b-")),
+    ]);
+    const [workspaceA, workspaceB] = roots;
+    const writeRole = async (
+      root: string,
+      marker: "A" | "B",
+      effort: "low" | "high",
+    ): Promise<void> => {
+      const agentsDir = join(root, ".agenc", "agents");
+      await mkdir(agentsDir, { recursive: true });
+      await writeFile(
+        join(agentsDir, "reviewer.md"),
+        [
+          "---",
+          "name: shared-reviewer",
+          `description: Workspace ${marker} reviewer`,
+          `effort: ${effort}`,
+          "---",
+          `Workspace ${marker} prompt.`,
+        ].join("\n"),
+      );
+    };
+
+    await Promise.all([
+      writeRole(workspaceA, "A", "low"),
+      writeRole(workspaceB, "B", "high"),
+    ]);
+
+    const sessionA = fakeSession(workspaceA);
+    const sessionB = fakeSession(workspaceB);
+    (sessionA as { conversationId: string }).conversationId = "workspace-a";
+    (sessionB as { conversationId: string }).conversationId = "workspace-b";
+    const toolsA = createModelFacingTools({
+      workspaceRoot: workspaceA,
+      getSession: () => sessionA,
+    });
+    // Load B second. The removed process-global fallback returned B's role
+    // when A executed after this point.
+    const toolsB = createModelFacingTools({
+      workspaceRoot: workspaceB,
+      getSession: () => sessionB,
+    });
+
+    const observed: Array<{
+      readonly effort: unknown;
+      readonly prompt: string | undefined;
+    }> = [];
+    delegateMock.mockImplementation(async (input: unknown) => {
+      const request = input as {
+        readonly parentPath: string;
+        readonly agentName: string;
+        readonly role?: string;
+        readonly reasoningEffort?: unknown;
+        readonly control: AgentControl;
+      };
+      const live = await request.control.spawn({
+        parentPath: request.parentPath as never,
+        agentName: request.agentName,
+        roleName: request.role,
+      });
+      observed.push({
+        effort: request.reasoningEffort,
+        prompt: live.role.config.systemPrompt,
+      });
+      return {
+        kind: "async_launched",
+        thread: {
+          live,
+          join: vi.fn(async () => ({
+            threadId: live.agentId,
+            durationMs: 1,
+            outcome: "completed",
+            finalMessage: "done",
+          })),
+        },
+      };
+    });
+
+    try {
+      const execute = async (
+        tools: ReturnType<typeof createModelFacingTools>,
+        taskName: string,
+      ) =>
+        tools.find((tool) => tool.name === "spawn_agent")!.execute({
+          message: "inspect",
+          task_name: taskName,
+          agent_type: "shared-reviewer",
+          fork_turns: "none",
+        });
+
+      // Execution cwd is mutable (for example, when a worktree is entered),
+      // but the session's role trust domain is immutable.
+      (sessionA.sessionConfiguration as { cwd: string }).cwd = workspaceB;
+      (sessionA.config as { cwd: string }).cwd = workspaceB;
+
+      const resultA = await execute(toolsA, "workspace_a_review");
+      const resultB = await execute(toolsB, "workspace_b_review");
+
+      expect(resultA.isError).not.toBe(true);
+      expect(resultB.isError).not.toBe(true);
+      expect(observed).toEqual([
+        { effort: "low", prompt: "Workspace A prompt." },
+        { effort: "high", prompt: "Workspace B prompt." },
+      ]);
+
+      const coldMismatchedSession = fakeSession(workspaceB);
+      const mismatchedTools = createModelFacingTools({
+        workspaceRoot: workspaceA,
+        getSession: () => coldMismatchedSession,
+      });
+      const delegateCallsBeforeMismatch = delegateMock.mock.calls.length;
+      const mismatch = await execute(mismatchedTools, "workspace_mismatch");
+      expect(mismatch.isError).toBe(true);
+      expect(JSON.parse(mismatch.content).error).toContain(
+        "agent role workspace mismatch",
+      );
+      expect(delegateMock).toHaveBeenCalledTimes(delegateCallsBeforeMismatch);
+      const coldServices = coldMismatchedSession.services as unknown as {
+        readonly agentControl?: unknown;
+        readonly threadManager?: unknown;
+        readonly conversationThreadManager?: unknown;
+      };
+      expect(coldServices.agentControl).toBeUndefined();
+      expect(coldServices.threadManager).toBeUndefined();
+      expect(coldServices.conversationThreadManager).toBeUndefined();
+    } finally {
+      await Promise.all(
+        roots.map((root) => rm(root, { recursive: true, force: true })),
+      );
     }
   });
 

--- a/runtime/tests/constants/promptIdentity.test.ts
+++ b/runtime/tests/constants/promptIdentity.test.ts
@@ -14,7 +14,12 @@ import { afterEach, expect, test } from 'bun:test'
 import { clearSystemPromptSections } from '../../src/constants/systemPromptSections.ts'
 import { getSystemPrompt, DEFAULT_AGENT_PROMPT } from '../../src/constants/prompts.ts'
 import { CLI_SYSPROMPT_PREFIXES, getCLISyspromptPrefix } from '../../src/constants/system.ts'
-import { requireAgentRole } from '../../src/agents/role.ts'
+import {
+  createAgentRoleWorkspace,
+  requireAgentRole,
+} from '../../src/agents/role.ts'
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd())
 
 const originalSimpleEnv = process.env.AGENC_SIMPLE
 const originalMcpInstructionsDeltaEnv = process.env.AGENC_MCP_INSTR_DELTA
@@ -93,16 +98,16 @@ test('built-in agent prompts describe AgenC', () => {
   // The built-in agents are now first-class roles; their prompts live on the
   // role config. Resolve via aliases to also assert alias→role wiring.
   // (The default/general-purpose role intentionally carries no system prompt.)
-  const explorePrompt = requireAgentRole('scanner').config.systemPrompt ?? ''
+  const explorePrompt = requireAgentRole(ROLE_WORKSPACE, 'scanner').config.systemPrompt ?? ''
   expect(explorePrompt).toContain('AgenC')
   expect(explorePrompt).not.toContain("provider's official CLI for AgenC")
 
-  const planPrompt = requireAgentRole('Plan').config.systemPrompt ?? ''
+  const planPrompt = requireAgentRole(ROLE_WORKSPACE, 'Plan').config.systemPrompt ?? ''
   expect(planPrompt).toContain('AgenC')
   expect(planPrompt).not.toContain("provider's official CLI for AgenC")
 
   // The verification prompt does not use the "for AgenC" domain phrasing, but it
   // must still be free of stray upstream branding.
-  const verificationPrompt = requireAgentRole('verification').config.systemPrompt ?? ''
+  const verificationPrompt = requireAgentRole(ROLE_WORKSPACE, 'verification').config.systemPrompt ?? ''
   expect(verificationPrompt).not.toContain("provider's official CLI for AgenC")
 })

--- a/runtime/tests/conversation/thread-manager.contract.test.ts
+++ b/runtime/tests/conversation/thread-manager.contract.test.ts
@@ -11,18 +11,26 @@ import { AgentControl, type LiveAgent } from "../agents/control.js";
 import { AgenCThread } from "../agents/thread-manager.js";
 import { Mailbox } from "../agents/mailbox.js";
 import { AgentRegistry, type AgentMetadata } from "../agents/registry.js";
-import { resolveAgentRole } from "../agents/role.js";
+import {
+  createAgentRoleWorkspace,
+  resolveAgentRole,
+} from "../agents/role.js";
 import { AgentStatusTracker } from "../agents/status.js";
 import { ConversationThreadManager } from "./thread-manager.js";
 
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
+
 function makeSession(conversationId = "root-thread") {
   const state = new AsyncLock<SessionState>({
-    sessionConfiguration: {} as SessionState["sessionConfiguration"],
+    sessionConfiguration: {
+      cwd: ROLE_WORKSPACE.cwd,
+    } as SessionState["sessionConfiguration"],
     history: [],
   });
   let rolloutPersistenceSuspendDepth = 0;
   return {
     conversationId,
+    roleWorkspace: ROLE_WORKSPACE,
     state,
     agentStatus: {
       value: { status: "pending_init" },
@@ -69,12 +77,13 @@ function makeLive(): LiveAgent {
     agentPath: "/root/task_1",
     agentNickname: "worker",
     agentRole: "default",
+    agentRoleWorkspaceId: ROLE_WORKSPACE.id,
     depth: 1,
   };
   return {
     agentId: "child-thread",
     agentPath: "/root/task_1",
-    role: resolveAgentRole("default"),
+    role: resolveAgentRole(ROLE_WORKSPACE, "default"),
     depth: 1,
     nickname: "worker",
     status: new AgentStatusTracker(),

--- a/runtime/tests/gaphunt3/agents-control.test.ts
+++ b/runtime/tests/gaphunt3/agents-control.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentControl } from "src/agents/control";
 import { AgentRegistry } from "src/agents/registry";
 import {
+  createAgentRoleWorkspace,
   registerAgentRole,
   _resetAgentRolesForTesting,
   _resetNicknamePoolForTesting,
@@ -37,6 +38,7 @@ function stubSession(): ConstructorParameters<typeof AgentControl>[0]["session"]
     childInboxes: new Map(),
     rolloutStore: null,
     conversationId: "gaphunt3-control",
+    sessionConfiguration: { cwd: agencHome },
     _emitted: emitted,
   } as unknown as ConstructorParameters<typeof AgentControl>[0]["session"];
 }
@@ -48,7 +50,7 @@ beforeEach(() => {
   _resetNicknamePoolForTesting();
   // Two candidates so there is always exactly one free name to allocate for
   // the grandchild after the live child has taken the first.
-  registerAgentRole({
+  registerAgentRole(createAgentRoleWorkspace(agencHome), {
     name: LEAK_ROLE,
     config: { nicknameCandidates: ["scout", "ranger"] },
   });

--- a/runtime/tests/memory/privacy.test.ts
+++ b/runtime/tests/memory/privacy.test.ts
@@ -36,6 +36,7 @@ import {
   redactSecrets,
   scanForSecrets,
 } from './privacy.js'
+import { getAgentMemoryDir } from '../tools/AgentTool/agentMemory.js'
 
 let tempRoot = ''
 let oldProjectRoot = ''
@@ -100,6 +101,11 @@ describe('memory privacy', () => {
     expect(memoryScopeForPath(teamMemoryFile)).toBe('team')
     expect(isAutoManagedMemoryFile(projectMemoryFile)).toBe(true)
     expect(isAutoManagedMemoryFile(teamMemoryFile)).toBe(true)
+    expect(
+      isAutoManagedMemoryFile(
+        join(getAgentMemoryDir('privacy-worker', 'user'), 'MEMORY.md'),
+      ),
+    ).toBe(true)
     expect(detectSessionFileType(sessionSummary)).toBe('session_memory')
     expect(detectSessionFileType(transcript)).toBe('session_transcript')
     expect(detectSessionPatternType('session-memory/*.md')).toBe(

--- a/runtime/tests/phases/commit.test.ts
+++ b/runtime/tests/phases/commit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createAgentRoleWorkspace } from "../agents/role.js";
 import { EventLog } from "../session/event-log.js";
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
@@ -56,6 +57,7 @@ vi.mock("../utils/forkedAgent.js", async () => {
 });
 
 const originalPromptSuggestionEnv = process.env.AGENC_ENABLE_PROMPT_SUGGESTION;
+const ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
 
 function mkCtx(): TurnContext {
   return {
@@ -122,6 +124,13 @@ function terminalAssistant(
 
 function mkSession(): Session {
   return {
+    roleWorkspace: ROLE_WORKSPACE,
+    agentDefinitions: {
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+      activeAgents: [],
+      allAgents: [],
+      allowedAgentTypes: [],
+    },
     emit: vi.fn(),
     nextInternalSubId: () => "sub-1",
     nextEventId: () => "event-1",
@@ -275,7 +284,12 @@ describe("commit", () => {
       getAppState: () => ({
         toolPermissionContext:
           session.services.permissionModeRegistry.current(),
-        agentDefinitions: { activeAgents: [], allowedAgentTypes: [] },
+        agentDefinitions: {
+          agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+          activeAgents: [],
+          allAgents: [],
+          allowedAgentTypes: [],
+        },
         tasks: {},
         promptSuggestionEnabled: true,
         pendingWorkerRequest: null,

--- a/runtime/tests/plugins/registration.test.ts
+++ b/runtime/tests/plugins/registration.test.ts
@@ -29,6 +29,7 @@ import {
 import { FILE_EDIT_TOOL_NAME } from "../tools/system/file-edit.js";
 import { FILE_READ_TOOL_NAME } from "../tools/system/file-read.js";
 import { FILE_WRITE_TOOL_NAME } from "../tools/system/file-write.js";
+import { createAgentRoleWorkspace } from "../agents/role.js";
 
 const PLUGIN_MCP_ENV_SERVER_FIXTURE = sourcePath(
   "plugins/test-fixtures/plugin-mcp-env-server.cjs",
@@ -629,6 +630,7 @@ describe("plugin registration", () => {
 
   test("active refresh registers hooks, preserves AppState shapes, and publishes active discovery snapshots", async () => {
     await withTempPlugin(async ({ root, pluginRoot, options }) => {
+      const roleWorkspace = createAgentRoleWorkspace(root);
       const hooksRuntime = { load: vi.fn() };
       const configStore = {
         current: () => ({
@@ -674,6 +676,7 @@ describe("plugin registration", () => {
           needsRefresh: true,
         },
         agentDefinitions: {
+          agentRoleWorkspaceId: roleWorkspace.id,
           allAgents: [builtInAgent],
           activeAgents: [builtInAgent],
         },
@@ -686,11 +689,13 @@ describe("plugin registration", () => {
         argsRaw: "",
         configStore,
         appState: {
+          getAppState: () => appState,
           setAppState: (updater: (prev: unknown) => unknown) => {
             appState = updater(appState) as Record<string, unknown>;
           },
         },
         session: {
+          roleWorkspace,
           services: {
             configStore,
             hooksRuntime,
@@ -750,16 +755,18 @@ describe("plugin registration", () => {
 
   test("active refresh treats array-shaped AppState containers as malformed", async () => {
     await withTempPlugin(async ({ root, pluginRoot, options }) => {
+      const roleWorkspace = createAgentRoleWorkspace(root);
       const configStore = {
-        current: () => ({
+        current: vi.fn(() => ({
           plugins: {
             enabled: true,
             plugins: {
               sample: { path: pluginRoot },
             },
           },
-        }),
+        })),
       };
+      const hooksRuntime = { load: vi.fn() };
       const staleError = {
         type: "lsp-manager",
         server: "stale",
@@ -770,6 +777,7 @@ describe("plugin registration", () => {
         needsRefresh: true,
       });
       const arrayAgentDefinitions = Object.assign(["stale-agent-entry"], {
+        agentRoleWorkspaceId: roleWorkspace.id,
         allAgents: [{ agentType: "built-in", source: "built-in" }],
         activeAgents: [{ agentType: "built-in", source: "built-in" }],
       });
@@ -781,6 +789,10 @@ describe("plugin registration", () => {
         agentDefinitions: arrayAgentDefinitions,
         mcp: arrayMcp,
       };
+      const initialAppState = appState;
+      const setAppState = vi.fn((updater: (prev: unknown) => unknown) => {
+        appState = updater(appState) as Record<string, unknown>;
+      });
       const ctx = {
         cwd: root,
         home: root,
@@ -788,29 +800,114 @@ describe("plugin registration", () => {
         argsRaw: "",
         configStore,
         appState: {
+          getAppState: () => appState,
+          setAppState,
+        },
+        session: {
+          roleWorkspace,
+          services: {
+            configStore,
+            hooksRuntime,
+          },
+        },
+      } as unknown as SlashCommandContext;
+
+      await expect(refreshActivePlugins(ctx)).rejects.toThrow(
+        "live agent catalog provenance is unavailable",
+      );
+      expect(configStore.current).not.toHaveBeenCalled();
+      expect(hooksRuntime.load).not.toHaveBeenCalled();
+      expect(setAppState).not.toHaveBeenCalled();
+      expect(appState).toBe(initialAppState);
+    });
+  });
+
+  test("active refresh refuses a write-only AppState bridge before loading plugins", async () => {
+    await withTempPlugin(async ({ root, pluginRoot, options }) => {
+      const roleWorkspace = createAgentRoleWorkspace(root);
+      const configStore = {
+        current: vi.fn(() => ({
+          plugins: { plugins: { sample: { path: pluginRoot } } },
+        })),
+      };
+      const hooksRuntime = { load: vi.fn() };
+      const setAppState = vi.fn();
+      const ctx = {
+        cwd: root,
+        home: root,
+        agencHome: options.agencHome,
+        argsRaw: "",
+        configStore,
+        appState: { setAppState },
+        session: {
+          roleWorkspace,
+          services: { configStore, hooksRuntime },
+        },
+      } as unknown as SlashCommandContext;
+
+      await expect(refreshActivePlugins(ctx)).rejects.toThrow(
+        "live agent catalog provenance is unavailable",
+      );
+      expect(configStore.current).not.toHaveBeenCalled();
+      expect(hooksRuntime.load).not.toHaveBeenCalled();
+      expect(setAppState).not.toHaveBeenCalled();
+    });
+  });
+
+  test("binds plugin refresh to the immutable role workspace instead of execution cwd", async () => {
+    await withTempPlugin(async ({ root, pluginRoot, options }) => {
+      const executionCwd = join(root, "worktree");
+      await mkdir(executionCwd, { recursive: true });
+      const roleWorkspace = createAgentRoleWorkspace(root);
+      const configStore = {
+        current: () => ({
+          plugins: {
+            enabled: true,
+            plugins: { sample: { path: pluginRoot } },
+          },
+        }),
+      };
+      let appState: Record<string, unknown> = {
+        agentDefinitions: {
+          agentRoleWorkspaceId: roleWorkspace.id,
+          allAgents: [],
+          activeAgents: [],
+        },
+        plugins: {},
+        mcp: {},
+      };
+      const ctx = {
+        cwd: executionCwd,
+        home: root,
+        agencHome: options.agencHome,
+        argsRaw: "",
+        configStore,
+        appState: {
+          getAppState: () => appState,
           setAppState: (updater: (prev: unknown) => unknown) => {
             appState = updater(appState) as Record<string, unknown>;
           },
         },
         session: {
-          services: {
-            configStore,
-          },
+          roleWorkspace,
+          services: { configStore },
         },
       } as unknown as SlashCommandContext;
 
       await refreshActivePlugins(ctx);
 
-      expect(appState.plugins).toMatchObject({
-        needsRefresh: false,
+      expect(appState.agentDefinitions).toMatchObject({
+        agentRoleWorkspaceId: roleWorkspace.id,
+        activeAgents: [expect.objectContaining({ agentType: "sample:review" })],
       });
-      expect(appState.plugins).not.toHaveProperty("0");
-      expect((appState.plugins as { errors: unknown[] }).errors)
-        .not.toContainEqual(staleError);
-      expect(appState.mcp).toEqual({ pluginReconnectKey: 1 });
-      expect(appState.agentDefinitions).not.toHaveProperty("0");
-      expect((appState.agentDefinitions as { activeAgents: Array<{ agentType: string }> }).activeAgents)
-        .toEqual([expect.objectContaining({ agentType: "sample:review" })]);
+      await expect(
+        loadPluginAgents({ cwd: roleWorkspace.cwd, agencHome: options.agencHome }),
+      ).resolves.toEqual([
+        expect.objectContaining({ agentType: "sample:review" }),
+      ]);
+      await expect(
+        loadPluginAgents({ cwd: executionCwd, agencHome: options.agencHome }),
+      ).resolves.toEqual([]);
     });
   });
 
@@ -818,6 +915,7 @@ describe("plugin registration", () => {
     await withTempPlugin(async ({ root, pluginRoot, options }) => {
       const cwd = join(root, "workspace-without-default-plugin");
       await mkdir(cwd, { recursive: true });
+      const roleWorkspace = createAgentRoleWorkspace(cwd);
       const configStore = {
         current: () => ({
           plugins: {
@@ -835,6 +933,7 @@ describe("plugin registration", () => {
         argsRaw: "",
         configStore,
         session: {
+          roleWorkspace,
           services: {
             configStore,
           },
@@ -879,6 +978,7 @@ describe("plugin registration", () => {
         argsRaw: "",
         configStore,
         session: {
+          roleWorkspace: createAgentRoleWorkspace(root),
           services: {
             configStore,
           },

--- a/runtime/tests/session/agenc-tool-use-context.test.ts
+++ b/runtime/tests/session/agenc-tool-use-context.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
 
+import { createAgentRoleWorkspace } from "../agents/role.js";
 import { buildAgenCToolUseContext } from "../session/agenc-tool-use-context.js";
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp/agenc-context-test");
 
 function createTurnContext(): TurnContext {
   return {
@@ -19,6 +22,13 @@ function createTurnContext(): TurnContext {
 function createSession(overrides: Record<string, unknown> = {}) {
   return {
     conversationId: "session-1",
+    roleWorkspace: ROLE_WORKSPACE,
+    agentDefinitions: {
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+      activeAgents: [],
+      allAgents: [],
+      allowedAgentTypes: [],
+    },
     services: {
       registry: { toLLMTools: () => [] },
       provider: undefined,
@@ -41,7 +51,9 @@ describe("buildAgenCToolUseContext", () => {
       tasks: { fallback: true },
       getAppState: () => arrayState,
       agentDefinitions: {
+        agentRoleWorkspaceId: ROLE_WORKSPACE.id,
         activeAgents: [{ agentType: "safe-agent" }],
+        allAgents: [{ agentType: "safe-agent" }],
         allowedAgentTypes: ["safe-agent"],
       },
     });

--- a/runtime/tests/session/exec-agent-hook-run-turn.test.ts
+++ b/runtime/tests/session/exec-agent-hook-run-turn.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod/v4";
 
+import {
+  createAgentRoleWorkspace,
+  type AgentRoleWorkspace,
+} from "../agents/role.js";
 import type {
   LLMContentPart,
   LLMMessage,
@@ -44,6 +48,8 @@ import { asSystemPrompt } from "../utils/systemPromptType.js";
 import { addFunctionHook } from "../utils/hooks/sessionHooks.js";
 import { runWithCwdOverride } from "../utils/cwd.js";
 
+const DEFAULT_ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
+
 afterEach(() => {
   clearCurrentRuntimeSession();
   resetCommandQueue();
@@ -72,7 +78,11 @@ describe("execAgentHook run-turn integration", () => {
       "Stop" as never,
       JSON.stringify({ plan: "done" }),
       new AbortController().signal,
-      createToolUseContext({ setResponseLength, setStreamMode }),
+      createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+        setResponseLength,
+        setStreamMode,
+      }),
       undefined,
       [],
     );
@@ -124,7 +134,7 @@ describe("execAgentHook run-turn integration", () => {
       "Stop" as never,
       "{}",
       new AbortController().signal,
-      createToolUseContext(),
+      createToolUseContext({ roleWorkspace: parent.roleWorkspace }),
       undefined,
       [],
     );
@@ -143,7 +153,7 @@ describe("execAgentHook run-turn integration", () => {
       "Stop" as never,
       "{}",
       new AbortController().signal,
-      createToolUseContext(),
+      createToolUseContext({ roleWorkspace: DEFAULT_ROLE_WORKSPACE }),
       undefined,
       [],
     );
@@ -180,7 +190,7 @@ describe("execAgentHook run-turn integration", () => {
       "Stop" as never,
       "{}",
       controller.signal,
-      createToolUseContext(),
+      createToolUseContext({ roleWorkspace: DEFAULT_ROLE_WORKSPACE }),
       undefined,
       [],
     );
@@ -207,7 +217,7 @@ describe("execAgentHook run-turn integration", () => {
       "Stop" as never,
       "{}",
       new AbortController().signal,
-      createToolUseContext(),
+      createToolUseContext({ roleWorkspace: DEFAULT_ROLE_WORKSPACE }),
       undefined,
       [],
     );
@@ -248,7 +258,10 @@ describe("execAgentHook run-turn integration", () => {
       "Stop" as never,
       "{}",
       new AbortController().signal,
-      createToolUseContext({ tools: [echoTool()] }),
+      createToolUseContext({
+        roleWorkspace: DEFAULT_ROLE_WORKSPACE,
+        tools: [echoTool()],
+      }),
       undefined,
       [],
     );
@@ -284,9 +297,9 @@ describe("execAgentHook run-turn integration", () => {
       },
     ]);
     setCurrentRuntimeSession(createParentSession(provider));
-    const appState = createMutableAppState();
+    const appState = createMutableAppState(DEFAULT_ROLE_WORKSPACE);
     const toolUseContext = {
-      ...createToolUseContext(),
+      ...createToolUseContext({ roleWorkspace: DEFAULT_ROLE_WORKSPACE }),
       getAppState: appState.getState,
       setAppState: appState.setAppState,
     } as unknown as ToolUseContext;
@@ -332,7 +345,10 @@ describe("execAgentHook run-turn integration", () => {
       },
     ]);
     const parent = createParentSession(provider);
-    const toolUseContext = createToolUseContext({ tools: [echoTool()] });
+    const toolUseContext = createToolUseContext({
+      roleWorkspace: parent.roleWorkspace,
+      tools: [echoTool()],
+    });
     const canUseTool = vi.fn(async () => ({ behavior: "allow" as const }));
 
     const events = [];
@@ -411,7 +427,10 @@ describe("execAgentHook run-turn integration", () => {
       },
     ]);
     const parent = createParentSession(provider);
-    const toolUseContext = createToolUseContext({ tools: [echoTool()] });
+    const toolUseContext = createToolUseContext({
+      roleWorkspace: parent.roleWorkspace,
+      tools: [echoTool()],
+    });
     const canUseTool = vi.fn(async () => ({ behavior: "allow" as const }));
 
     const events = [];
@@ -479,8 +498,13 @@ describe("execAgentHook run-turn integration", () => {
         finishReason: "stop",
       },
     ]);
-    const parent = createParentSession(provider, parentDir);
-    const toolUseContext = createToolUseContext();
+    const parent = createParentSession(
+      provider,
+      createAgentRoleWorkspace(parentDir),
+    );
+    const toolUseContext = createToolUseContext({
+      roleWorkspace: parent.roleWorkspace,
+    });
     const canUseTool = vi.fn(async () => ({ behavior: "allow" as const }));
 
     await runWithCwdOverride(childDir, async () => {
@@ -534,7 +558,10 @@ describe("execAgentHook run-turn integration", () => {
       },
     ]);
     const parent = createParentSession(provider);
-    const toolUseContext = createToolUseContext({ tools: [echoTool()] });
+    const toolUseContext = createToolUseContext({
+      roleWorkspace: parent.roleWorkspace,
+      tools: [echoTool()],
+    });
     const canUseTool = vi.fn(async () => ({ behavior: "allow" as const }));
 
     const events = [];
@@ -588,7 +615,9 @@ describe("execAgentHook run-turn integration", () => {
       },
     ]);
     const parent = createParentSession(provider);
-    const { getState, setAppState } = createMutableAppState();
+    const { getState, setAppState } = createMutableAppState(
+      parent.roleWorkspace,
+    );
     const captured: Message[][] = [];
     const agentId = "compat-stop-hook-agent";
     addFunctionHook(
@@ -603,6 +632,7 @@ describe("execAgentHook run-turn integration", () => {
       "missing tool result",
     );
     const toolUseContext = createToolUseContext({
+      roleWorkspace: parent.roleWorkspace,
       agentId,
       getAppState: getState,
       setAppState,
@@ -673,7 +703,9 @@ describe("execAgentHook run-turn integration", () => {
       },
     ]);
     const parent = createParentSession(provider);
-    const { getState, setAppState } = createMutableAppState();
+    const { getState, setAppState } = createMutableAppState(
+      parent.roleWorkspace,
+    );
     const captured: Message[][] = [];
     const agentId = "compat-stop-hook-error-agent";
     addFunctionHook(
@@ -688,6 +720,7 @@ describe("execAgentHook run-turn integration", () => {
       "missing failed tool result",
     );
     const toolUseContext = createToolUseContext({
+      roleWorkspace: parent.roleWorkspace,
       agentId,
       getAppState: getState,
       setAppState,
@@ -759,7 +792,10 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool,
-      toolUseContext: createToolUseContext({ tools: [errorTool()] }),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+        tools: [errorTool()],
+      }),
       querySource: "hook_agent",
       maxTurns: 3,
     })) {
@@ -822,7 +858,10 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool,
-      toolUseContext: createToolUseContext({ tools: [echoTool()] }),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+        tools: [echoTool()],
+      }),
       querySource: "sdk",
       maxTurns: 3,
     })) {
@@ -881,7 +920,9 @@ describe("execAgentHook run-turn integration", () => {
         userContext: {},
         systemContext: {},
         canUseTool,
-        toolUseContext: createToolUseContext(),
+        toolUseContext: createToolUseContext({
+          roleWorkspace: parent.roleWorkspace,
+        }),
         querySource: "hook_agent",
         maxTurns: 1,
       })) {
@@ -942,7 +983,9 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool,
-      toolUseContext: createToolUseContext(),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+      }),
       querySource: "hook_agent",
       maxTurns: 1,
     })) {
@@ -975,7 +1018,9 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool,
-      toolUseContext: createToolUseContext(),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+      }),
       querySource: "hook_agent",
       maxTurns: 1,
     })) {
@@ -1028,7 +1073,10 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool,
-      toolUseContext: createToolUseContext({ tools: [echoTool()] }),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+        tools: [echoTool()],
+      }),
       querySource: "hook_agent",
       maxTurns: 1,
     })) {
@@ -1079,7 +1127,9 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
-      toolUseContext: createToolUseContext(),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+      }),
       querySource: "hook_agent",
       maxTurns: 1,
     })) {
@@ -1131,7 +1181,9 @@ describe("execAgentHook run-turn integration", () => {
       userContext: {},
       systemContext: {},
       canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
-      toolUseContext: createToolUseContext(),
+      toolUseContext: createToolUseContext({
+        roleWorkspace: parent.roleWorkspace,
+      }),
       querySource: "hook_agent",
       maxTurns: 1,
     })) {
@@ -1164,7 +1216,9 @@ describe("execAgentHook run-turn integration", () => {
     } as unknown as LLMProvider;
     const parent = createParentSession(provider);
     setCurrentRuntimeSession(parent);
-    const { getState, setAppState } = createMutableAppState();
+    const { getState, setAppState } = createMutableAppState(
+      parent.roleWorkspace,
+    );
 
     const taskId = startBackgroundSession({
       messages: [createUserMessage({ content: "start" })],
@@ -1173,7 +1227,9 @@ describe("execAgentHook run-turn integration", () => {
         userContext: {},
         systemContext: {},
         canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
-        toolUseContext: createToolUseContext(),
+        toolUseContext: createToolUseContext({
+          roleWorkspace: parent.roleWorkspace,
+        }),
         querySource: "hook_agent",
         maxTurns: 1,
       },
@@ -1210,7 +1266,9 @@ describe("execAgentHook run-turn integration", () => {
     ]);
     const parent = createParentSession(provider);
     setCurrentRuntimeSession(parent);
-    const { getState, setAppState } = createMutableAppState();
+    const { getState, setAppState } = createMutableAppState(
+      parent.roleWorkspace,
+    );
 
     const taskId = startBackgroundSession({
       messages: [createUserMessage({ content: "start" })],
@@ -1219,7 +1277,10 @@ describe("execAgentHook run-turn integration", () => {
         userContext: {},
         systemContext: {},
         canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
-        toolUseContext: createToolUseContext({ tools: [echoTool()] }),
+        toolUseContext: createToolUseContext({
+          roleWorkspace: parent.roleWorkspace,
+          tools: [echoTool()],
+        }),
         querySource: "hook_agent",
         maxTurns: 1,
       },
@@ -1256,7 +1317,9 @@ describe("execAgentHook run-turn integration", () => {
           systemPrompt: asSystemPrompt(["system"]),
           userContext: {},
           systemContext: {},
-          toolUseContext: createToolUseContext(),
+          toolUseContext: createToolUseContext({
+            roleWorkspace: parent.roleWorkspace,
+          }),
           forkContextMessages: [],
         },
         canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
@@ -1304,7 +1367,9 @@ describe("execAgentHook run-turn integration", () => {
                 systemPrompt: asSystemPrompt(["system"]),
                 userContext: {},
                 systemContext: {},
-                toolUseContext: createToolUseContext(),
+                toolUseContext: createToolUseContext({
+                  roleWorkspace: DEFAULT_ROLE_WORKSPACE,
+                }),
                 forkContextMessages: [],
               },
               canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
@@ -1371,7 +1436,10 @@ describe("execAgentHook run-turn integration", () => {
         systemPrompt: asSystemPrompt(["system"]),
         userContext: {},
         systemContext: {},
-        toolUseContext: createToolUseContext({ tools: [echoTool()] }),
+        toolUseContext: createToolUseContext({
+          roleWorkspace: parent.roleWorkspace,
+          tools: [echoTool()],
+        }),
         forkContextMessages: [],
       },
       canUseTool: vi.fn(async () => ({ behavior: "allow" as const })),
@@ -1521,7 +1589,21 @@ function errorTool(): Tool {
   } as unknown as Tool;
 }
 
-function createParentSession(provider: LLMProvider, cwd = "/tmp"): Session {
+function createAgentDefinitions(roleWorkspace: AgentRoleWorkspace) {
+  return {
+    agentRoleWorkspaceId: roleWorkspace.id,
+    activeAgents: [],
+    allAgents: [],
+    allowedAgentTypes: [],
+  };
+}
+
+function createParentSession(
+  provider: LLMProvider,
+  roleWorkspace = DEFAULT_ROLE_WORKSPACE,
+): Session {
+  const cwd = roleWorkspace.cwd;
+  const agentDefinitions = createAgentDefinitions(roleWorkspace);
   const permissionModeRegistry = new PermissionModeRegistry(
     createEmptyToolPermissionContext({ mode: "dontAsk" }),
   );
@@ -1586,6 +1668,8 @@ function createParentSession(provider: LLMProvider, cwd = "/tmp"): Session {
   } as unknown as SessionServices;
   return new Session({
     conversationId: "parent-test",
+    roleWorkspace,
+    agentDefinitions,
     services,
     initialState: {
       sessionConfiguration: {
@@ -1650,7 +1734,7 @@ function createParentSession(provider: LLMProvider, cwd = "/tmp"): Session {
   });
 }
 
-function createMutableAppState() {
+function createMutableAppState(roleWorkspace: AgentRoleWorkspace) {
   let state: any = {
     tasks: {},
     todos: {},
@@ -1666,6 +1750,7 @@ function createMutableAppState() {
     },
     mcp: { clients: [], tools: [] },
     sessionHooks: new Map(),
+    agentDefinitions: createAgentDefinitions(roleWorkspace),
   };
 
   return {
@@ -1677,13 +1762,15 @@ function createMutableAppState() {
 }
 
 function createToolUseContext(opts: {
+  readonly roleWorkspace: AgentRoleWorkspace;
   readonly agentId?: string;
   readonly getAppState?: () => unknown;
   readonly setAppState?: (updater: (prev: any) => any) => void;
   readonly setResponseLength?: (updater: (value: number) => number) => void;
   readonly setStreamMode?: (mode: "requesting" | "responding" | null) => void;
   readonly tools?: Tool[];
-} = {}): ToolUseContext {
+}): ToolUseContext {
+  const agentDefinitions = createAgentDefinitions(opts.roleWorkspace);
   return {
     ...(opts.agentId !== undefined ? { agentId: opts.agentId } : {}),
     options: {
@@ -1696,10 +1783,7 @@ function createToolUseContext(opts: {
       mcpClients: [],
       mcpResources: {},
       isNonInteractiveSession: true,
-      agentDefinitions: {
-        activeAgents: [],
-        allowedAgentTypes: [],
-      },
+      agentDefinitions,
     },
     abortController: new AbortController(),
     readFileState: createFileStateCacheWithSizeLimit(
@@ -1717,6 +1801,7 @@ function createToolUseContext(opts: {
         },
         sessionHooks: new Map(),
         tasks: {},
+        agentDefinitions,
       }))) as never,
     setAppState: (opts.setAppState ?? (() => {})) as never,
     setInProgressToolUseIDs: () => {},

--- a/runtime/tests/session/idle-input.test.ts
+++ b/runtime/tests/session/idle-input.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { createAgentRoleWorkspace } from "../agents/role.js";
 import { AsyncQueue } from "../utils/async-queue.js";
 import {
   MAILBOX_SOURCE_IDLE_INPUT,
@@ -14,6 +15,10 @@ import {
   type Event,
   type SessionOpts,
 } from "./session.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace(
+  "/tmp/agenc-idle-input-test",
+);
 
 function buildSession(): Session {
   const eventQueue = new AsyncQueue<Event>();
@@ -33,8 +38,17 @@ function buildSession(): Session {
   } as unknown as SessionOpts["services"];
   const opts: SessionOpts = {
     conversationId: "conv-test",
+    roleWorkspace: ROLE_WORKSPACE,
+    agentDefinitions: {
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+      activeAgents: [],
+      allAgents: [],
+      allowedAgentTypes: [],
+    },
     initialState: {
-      sessionConfiguration: {} as SessionOpts["initialState"]["sessionConfiguration"],
+      sessionConfiguration: {
+        cwd: ROLE_WORKSPACE.cwd,
+      } as SessionOpts["initialState"]["sessionConfiguration"],
       history: [],
     },
     features: {} as SessionOpts["features"],

--- a/runtime/tests/session/plan-mode.test.ts
+++ b/runtime/tests/session/plan-mode.test.ts
@@ -28,6 +28,7 @@ vi.mock("axios", () => {
     isAxiosError: () => false,
   };
 });
+import { createAgentRoleWorkspace } from "../agents/role.js";
 import { EventLog, type Event } from "./event-log.js";
 import {
   type AssistantMessageStreamParsersLike,
@@ -46,6 +47,8 @@ import type { TurnContext } from "./turn-context.js";
 // Session + ctx stubs
 // ─────────────────────────────────────────────────────────────────────
 
+const ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
+
 function mkSession(): { session: Session; events: Event[] } {
   const events: Event[] = [];
   const eventLog = new EventLog();
@@ -53,6 +56,13 @@ function mkSession(): { session: Session; events: Event[] } {
   let subId = 0;
   const session = {
     conversationId: "conv-plan",
+    roleWorkspace: ROLE_WORKSPACE,
+    agentDefinitions: {
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+      activeAgents: [],
+      allAgents: [],
+      allowedAgentTypes: [],
+    },
     eventLog,
     nextInternalSubId: () => `s-${++subId}`,
     emit: (event: Event) => {

--- a/runtime/tests/session/rollout-store.test.ts
+++ b/runtime/tests/session/rollout-store.test.ts
@@ -10,7 +10,9 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
 import type { AgentMetadata } from "../agents/registry.js";
+import { resolveStateDatabasePaths } from "../state/sqlite-driver.js";
 import { RolloutStore } from "./rollout-store.js";
 import { getProjectDir, getSessionDir } from "./session-store.js";
 
@@ -135,7 +137,10 @@ describe("RolloutStore thread-spawn edges", () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
     const sessionId = "thread-spawn-persist";
     const original = openStore({ cwd, sessionId });
-    const childMetadata = metadata("child-1", "/root/alpha", 1);
+    const childMetadata: AgentMetadata = {
+      ...metadata("child-1", "/root/alpha", 1),
+      agentRoleWorkspaceId: cwd,
+    };
 
     try {
       original.upsertThreadSpawnEdge({
@@ -166,6 +171,7 @@ describe("RolloutStore thread-spawn edges", () => {
               agentPath: "/root/alpha",
               agentNickname: "alpha",
               agentRole: "default",
+              agentRoleWorkspaceId: cwd,
               depth: 1,
             },
             status: "closed",
@@ -176,6 +182,407 @@ describe("RolloutStore thread-spawn edges", () => {
       }
     } finally {
       original.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed instead of reopening a corrupted persisted edge status", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const sessionId = "thread-spawn-invalid-status";
+    const original = openStore({ cwd, sessionId });
+    try {
+      original.createThreadSpawnEdge({
+        parentThreadId: "root-1",
+        childThreadId: "child-invalid-status",
+        parentPath: "/root",
+        metadata: metadata(
+          "child-invalid-status",
+          "/root/child_invalid_status",
+          1,
+        ),
+        status: "open",
+      });
+      original.close();
+
+      const raw = new Database(resolveStateDatabasePaths({ cwd }).stateDbPath);
+      try {
+        raw.prepare(
+          `UPDATE thread_spawn_edges
+           SET status = 'corrupted'
+           WHERE child_thread_id = ?`,
+        ).run("child-invalid-status");
+      } finally {
+        raw.close();
+      }
+
+      expect(() => openStore({ cwd, sessionId, resume: true })).toThrow(
+        /invalid thread-spawn edge status: corrupted/,
+      );
+    } finally {
+      original.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a legacy metadata rewrite that would remove provenance", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const sessionId = "thread-spawn-legacy-rewrite";
+    const original = openStore({ cwd, sessionId });
+    try {
+      original.upsertThreadSpawnEdge({
+        parentThreadId: "root-1",
+        childThreadId: "child-legacy",
+        parentPath: "/root",
+        metadata: {
+          ...metadata("child-legacy", "/root/legacy", 1),
+          agentRoleWorkspaceId: cwd,
+        },
+        status: "open",
+      });
+      original.close();
+
+      const raw = new Database(resolveStateDatabasePaths({ cwd }).stateDbPath);
+      try {
+        expect(() =>
+          raw.prepare(
+            `UPDATE thread_spawn_edges
+             SET metadata_json = ?, status = 'closed'
+             WHERE child_thread_id = ?`,
+          ).run(
+            JSON.stringify(metadata("child-legacy", "/root/legacy", 1)),
+            "child-legacy",
+          ),
+        ).toThrow(/identity is immutable/);
+      } finally {
+        raw.close();
+      }
+
+      const reopened = openStore({ cwd, sessionId, resume: true });
+      try {
+        expect(reopened.getThreadSpawnEdge("child-legacy")?.metadata).toEqual({
+          ...metadata("child-legacy", "/root/legacy", 1),
+          agentRoleWorkspaceId: cwd,
+        });
+        expect(reopened.getThreadSpawnEdge("child-legacy")?.status).toBe("open");
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      original.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps spawn identity create-only and publishes only durable status", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const otherWorkspace = join(cwd, "other-workspace");
+    const sessionId = "thread-spawn-provenance-immutability";
+    const store = openStore({ cwd, sessionId });
+    const baseMetadata = {
+      ...metadata("child-immutable", "/root/immutable", 1),
+      agentRoleWorkspaceId: cwd,
+      agentRoleFingerprint: "default-role-fingerprint",
+    };
+    try {
+      store.createThreadSpawnEdge({
+        parentThreadId: "root-1",
+        childThreadId: "child-immutable",
+        parentPath: "/root",
+        metadata: baseMetadata,
+        status: "open",
+      });
+      store.setThreadSpawnEdgeStatus("child-immutable", "closed");
+      expect(store.getThreadSpawnEdge("child-immutable")).toMatchObject({
+        status: "closed",
+        metadata: {
+          agentRoleWorkspaceId: cwd,
+          agentRoleFingerprint: "default-role-fingerprint",
+          agentRole: "default",
+        },
+      });
+
+      const paths = resolveStateDatabasePaths({ cwd });
+      const raw = new Database(paths.stateDbPath);
+      try {
+        const before = raw
+          .prepare(
+            `SELECT parent_thread_id, parent_path, metadata_json,
+                    agent_role_workspace_id, agent_role_fingerprint, status
+             FROM thread_spawn_edges
+             WHERE child_thread_id = ?`,
+          )
+          .get("child-immutable");
+        const inMemoryBefore = store.getThreadSpawnEdge("child-immutable");
+
+        expect(() =>
+          store.createThreadSpawnEdge({
+            parentThreadId: "attacker-root",
+            childThreadId: "child-immutable",
+            parentPath: "/root",
+            metadata: {
+              ...baseMetadata,
+              agentRoleWorkspaceId: otherWorkspace,
+            },
+            status: "open",
+          }),
+        ).toThrow(/agent thread id already exists/);
+        expect(store.getThreadSpawnEdge("child-immutable")).toEqual(
+          inMemoryBefore,
+        );
+        expect(
+          raw
+            .prepare(
+              `SELECT parent_thread_id, parent_path, metadata_json,
+                      agent_role_workspace_id, agent_role_fingerprint, status
+               FROM thread_spawn_edges
+               WHERE child_thread_id = ?`,
+            )
+            .get("child-immutable"),
+        ).toEqual(before);
+
+        expect(() =>
+          store.createThreadSpawnEdge({
+            parentThreadId: "root-1",
+            childThreadId: "child-immutable",
+            parentPath: "/root",
+            metadata: {
+              ...baseMetadata,
+              agentRole: "worker",
+              agentRoleFingerprint: "worker-role-fingerprint",
+            },
+            status: "open",
+          }),
+        ).toThrow(/agent thread id already exists/);
+        expect(store.getThreadSpawnEdge("child-immutable")).toEqual(
+          inMemoryBefore,
+        );
+
+        expect(() =>
+          store.createThreadSpawnEdge({
+            parentThreadId: "root-1",
+            childThreadId: "child-immutable",
+            parentPath: "/root",
+            metadata: baseMetadata,
+            status: "open",
+          }),
+        ).toThrow(/agent thread id already exists/);
+        expect(store.getThreadSpawnEdge("child-immutable")).toEqual(
+          inMemoryBefore,
+        );
+
+        expect(() =>
+          store.createThreadSpawnEdge({
+            parentThreadId: "root-1",
+            childThreadId: "edge-key",
+            parentPath: "/root",
+            metadata: metadata("metadata-id", "/root/metadata-id", 1),
+            status: "open",
+          }),
+        ).toThrow(/child identity/);
+        expect(store.getThreadSpawnEdge("edge-key")).toBeUndefined();
+
+        expect(() =>
+          store.createThreadSpawnEdge({
+            parentThreadId: "root-1",
+            childThreadId: "invalid-status-edge",
+            parentPath: "/root",
+            metadata: metadata(
+              "invalid-status-edge",
+              "/root/invalid_status_edge",
+              1,
+            ),
+            status: "corrupted" as "open",
+          }),
+        ).toThrow(/invalid thread-spawn edge record or child identity/);
+        expect(store.getThreadSpawnEdge("invalid-status-edge")).toBeUndefined();
+        expect(
+          raw
+            .prepare(
+              "SELECT child_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?",
+            )
+            .get("invalid-status-edge"),
+        ).toBeUndefined();
+
+        store.createThreadSpawnEdge({
+          parentThreadId: "root-1",
+          childThreadId: "status-failure-child",
+          parentPath: "/root",
+          metadata: metadata(
+            "status-failure-child",
+            "/root/status_failure_child",
+            1,
+          ),
+          status: "open",
+        });
+        raw.exec(`
+          CREATE TRIGGER reject_spawn_edge_status_update
+          BEFORE UPDATE OF status ON thread_spawn_edges
+          WHEN OLD.child_thread_id = 'status-failure-child'
+            AND NEW.status = 'closed'
+          BEGIN
+            SELECT RAISE(ABORT, 'forced status persistence failure');
+          END;
+        `);
+        expect(() =>
+          store.setThreadSpawnEdgeStatus("status-failure-child", "closed"),
+        ).toThrow(/forced status persistence failure/);
+        expect(store.getThreadSpawnEdge("status-failure-child")?.status).toBe(
+          "open",
+        );
+        expect(
+          raw
+            .prepare(
+              "SELECT status FROM thread_spawn_edges WHERE child_thread_id = ?",
+            )
+            .get("status-failure-child"),
+        ).toEqual({ status: "open" });
+      } finally {
+        raw.close();
+      }
+    } finally {
+      store.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("lets exactly one concurrent store create a child identity", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const first = openStore({ cwd, sessionId: "create-race-first" });
+    const second = openStore({ cwd, sessionId: "create-race-second" });
+    try {
+      first.createThreadSpawnEdge({
+        parentThreadId: "root-first",
+        childThreadId: "race-child",
+        parentPath: "/root",
+        metadata: metadata("race-child", "/root/race_child", 1),
+        status: "open",
+      });
+      const winner = first.getThreadSpawnEdge("race-child");
+
+      expect(() =>
+        second.createThreadSpawnEdge({
+          parentThreadId: "root-second",
+          childThreadId: "race-child",
+          parentPath: "/root",
+          metadata: metadata("race-child", "/root/attacker", 1),
+          status: "closed",
+        }),
+      ).toThrow(/agent thread id already exists/);
+      expect(second.getThreadSpawnEdge("race-child")).toEqual(winner);
+      expect(first.getThreadSpawnEdge("race-child")).toEqual(winner);
+    } finally {
+      first.close();
+      second.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes a monotonic close across live stores", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const first = openStore({ cwd, sessionId: "close-coherence-first" });
+    first.createThreadSpawnEdge({
+      parentThreadId: "root-1",
+      childThreadId: "close-coherence-child",
+      parentPath: "/root",
+      metadata: metadata(
+        "close-coherence-child",
+        "/root/close_coherence_child",
+        1,
+      ),
+      status: "open",
+    });
+    const second = openStore({ cwd, sessionId: "close-coherence-second" });
+
+    try {
+      expect(second.getThreadSpawnEdge("close-coherence-child")?.status).toBe(
+        "open",
+      );
+
+      first.setThreadSpawnEdgeStatus("close-coherence-child", "closed");
+
+      expect(second.getThreadSpawnEdge("close-coherence-child")?.status).toBe(
+        "closed",
+      );
+      expect(() =>
+        second.setThreadSpawnEdgeStatus("close-coherence-child", "open"),
+      ).toThrow(/cannot transition.*closed.*open/i);
+
+      // A second close is a successful idempotent acknowledgement of the
+      // already-durable terminal state, even from another live store.
+      second.setThreadSpawnEdgeStatus("close-coherence-child", "closed");
+      first.setThreadSpawnEdgeStatus("close-coherence-child", "closed");
+      expect(first.getThreadSpawnEdge("close-coherence-child")?.status).toBe(
+        "closed",
+      );
+    } finally {
+      first.close();
+      second.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reads current direct and descendant lists across live stores", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const first = openStore({ cwd, sessionId: "list-coherence-first" });
+    first.createThreadSpawnEdge({
+      parentThreadId: "root-1",
+      childThreadId: "list-coherence-existing",
+      parentPath: "/root",
+      metadata: metadata(
+        "list-coherence-existing",
+        "/root/list_coherence_existing",
+        1,
+      ),
+      status: "open",
+    });
+    const second = openStore({ cwd, sessionId: "list-coherence-second" });
+
+    try {
+      first.setThreadSpawnEdgeStatus("list-coherence-existing", "closed");
+      first.createThreadSpawnEdge({
+        parentThreadId: "root-1",
+        childThreadId: "list-coherence-late",
+        parentPath: "/root",
+        metadata: metadata(
+          "list-coherence-late",
+          "/root/list_coherence_late",
+          1,
+        ),
+        status: "open",
+      });
+
+      expect(
+        second
+          .listThreadSpawnChildrenWithStatus("root-1", "open")
+          .map((edge) => edge.childThreadId),
+      ).toEqual(["list-coherence-late"]);
+      expect(
+        second
+          .listThreadSpawnChildrenWithStatus("root-1", "closed")
+          .map((edge) => edge.childThreadId),
+      ).toEqual(["list-coherence-existing"]);
+      expect(
+        second.listThreadSpawnDescendants("root-1").map((edge) => ({
+          childThreadId: edge.childThreadId,
+          status: edge.status,
+        })),
+      ).toEqual([
+        { childThreadId: "list-coherence-existing", status: "closed" },
+        { childThreadId: "list-coherence-late", status: "open" },
+      ]);
+
+      // The second store did not have this row at construction time. Closing
+      // it must still reach SQLite instead of returning from a stale cache.
+      second.setThreadSpawnEdgeStatus("list-coherence-late", "closed");
+      expect(first.getThreadSpawnEdge("list-coherence-late")?.status).toBe(
+        "closed",
+      );
+      expect(
+        second.listThreadSpawnChildrenWithStatus("root-1", "open"),
+      ).toEqual([]);
+    } finally {
+      first.close();
+      second.close();
       rmSync(cwd, { recursive: true, force: true });
     }
   });

--- a/runtime/tests/session/session.test.ts
+++ b/runtime/tests/session/session.test.ts
@@ -336,8 +336,15 @@ describe("SessionServices.permissionModeRegistry default bootstrap", () => {
     });
 
     expect(session.agentDefinitions.activeAgents).toEqual([
-      { agentType: "worker", whenToUse: "Implementation work" },
-      { agentType: "explorer" },
+      expect.objectContaining({
+        agentType: "worker",
+        whenToUse: "Implementation work",
+        agentRoleFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      }),
+      expect.objectContaining({
+        agentType: "explorer",
+        agentRoleFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      }),
     ]);
   });
 });
@@ -473,6 +480,7 @@ describe("Session provider continuity hooks", () => {
 describe("Session.setPendingWorktreeState", () => {
   it("stores and clears the active worktree binding", () => {
     const session = buildSession();
+    expect(session.roleWorkspace.id).toBe("/tmp");
     const pending: PendingWorktreeState = {
       handle: {
         path: "/repo/.agenc-worktrees/feat",
@@ -487,10 +495,12 @@ describe("Session.setPendingWorktreeState", () => {
     session.setPendingWorktreeState(pending);
     expect(session.pendingWorktreeState).toEqual(pending);
     expect(session.sessionConfiguration.cwd).toBe("/repo/.agenc-worktrees/feat");
+    expect(session.roleWorkspace.id).toBe("/tmp");
 
     session.setPendingWorktreeState(null);
     expect(session.pendingWorktreeState).toBeNull();
     expect(session.sessionConfiguration.cwd).toBe("/repo");
+    expect(session.roleWorkspace.id).toBe("/tmp");
   });
 });
 

--- a/runtime/tests/session/sessionStorage-transcript.test.ts
+++ b/runtime/tests/session/sessionStorage-transcript.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, expect, test } from "vitest";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { clearAllSessions as clearSessionIngressState } from "../../src/services/api/sessionIngress.js";
 import {
@@ -12,6 +21,7 @@ import {
   switchSession,
 } from "../../src/bootstrap/state.js";
 import {
+  __setAgentMetadataWritePhaseForTesting,
   buildConversationChain,
   clearAgentTranscriptSubdir,
   cacheSessionTitle,
@@ -261,6 +271,7 @@ async function configureIsolatedSession(): Promise<{
 }
 
 afterEach(async () => {
+  __setAgentMetadataWritePhaseForTesting(undefined);
   resetProjectForTesting();
   resetStateForTests();
   restoreOptionalEnv("AGENC_CONFIG_DIR", originalConfigDir);
@@ -319,11 +330,15 @@ test("uses isolated session paths for transcripts and agent metadata", async () 
 
   await writeAgentMetadata(agentId, {
     agentType: "review",
+    agentRoleWorkspaceId: "/workspace/review",
+    agentRoleFingerprint: "review-fingerprint",
     worktreePath: "/tmp/worktree",
     description: "inspect changes",
   });
   expect(await readAgentMetadata(agentId)).toEqual({
     agentType: "review",
+    agentRoleWorkspaceId: "/workspace/review",
+    agentRoleFingerprint: "review-fingerprint",
     worktreePath: "/tmp/worktree",
     description: "inspect changes",
   });
@@ -338,7 +353,7 @@ test("readAgentMetadata returns null for a corrupt sidecar instead of throwing",
   await configureIsolatedSession();
   const agentId = "agent-corrupt" as never;
 
-  // Simulate a partial write from a crashed fire-and-forget persist.
+  // Simulate a partial sidecar left by an older non-atomic writer.
   const metaPath = getAgentTranscriptPath(agentId).replace(
     /\.jsonl$/,
     ".meta.json",
@@ -347,6 +362,73 @@ test("readAgentMetadata returns null for a corrupt sidecar instead of throwing",
   await writeFile(metaPath, "{");
 
   await expect(readAgentMetadata(agentId)).resolves.toBeNull();
+  await expect(
+    readAgentMetadata(agentId, { strict: true }),
+  ).rejects.toThrow("invalid agent metadata sidecar");
+});
+
+test("agent metadata publication is atomic, durable, and preserves permissions", async () => {
+  await configureIsolatedSession();
+  const agentId = "agent-atomic" as never;
+  const metadataPath = getAgentTranscriptPath(agentId).replace(
+    /\.jsonl$/,
+    ".meta.json",
+  );
+  const oldMetadata = {
+    agentType: "review",
+    agentRoleWorkspaceId: "/workspace/review",
+    agentRoleFingerprint: "old-fingerprint",
+    description: "old metadata",
+  };
+  const newMetadata = {
+    ...oldMetadata,
+    agentRoleFingerprint: "new-fingerprint",
+    description: "new metadata",
+  };
+
+  await writeAgentMetadata(agentId, oldMetadata);
+  await chmod(metadataPath, 0o640);
+
+  let crashCheckpointObserved = false;
+  __setAgentMetadataWritePhaseForTesting(async (phase, paths) => {
+    expect(phase).toBe("temporary-file-synced");
+    crashCheckpointObserved = true;
+
+    // Until atomic rename, strict readers continue to see the complete old
+    // generation. The fully-written temporary generation is parseable too.
+    await expect(readAgentMetadata(agentId, { strict: true })).resolves.toEqual(
+      oldMetadata,
+    );
+    expect(JSON.parse(await readFile(paths.temporaryPath, "utf8"))).toEqual(
+      newMetadata,
+    );
+    throw new Error("simulated crash before metadata rename");
+  });
+
+  await expect(writeAgentMetadata(agentId, newMetadata)).rejects.toThrow(
+    "simulated crash before metadata rename",
+  );
+  expect(crashCheckpointObserved).toBe(true);
+  await expect(readAgentMetadata(agentId, { strict: true })).resolves.toEqual(
+    oldMetadata,
+  );
+  expect(
+    (await readdir(dirname(metadataPath))).filter((entry) =>
+      entry.startsWith(`${basename(metadataPath)}.`) &&
+      entry.endsWith(".tmp"),
+    ),
+  ).toEqual([]);
+
+  __setAgentMetadataWritePhaseForTesting(async () => {
+    await expect(readAgentMetadata(agentId, { strict: true })).resolves.toEqual(
+      oldMetadata,
+    );
+  });
+  await writeAgentMetadata(agentId, newMetadata);
+  await expect(readAgentMetadata(agentId, { strict: true })).resolves.toEqual(
+    newMetadata,
+  );
+  expect((await stat(metadataPath)).mode & 0o777).toBe(0o640);
 });
 
 test("checks session file existence in the current project directory", async () => {

--- a/runtime/tests/session/turn-compat.workspace.test.ts
+++ b/runtime/tests/session/turn-compat.workspace.test.ts
@@ -1,0 +1,335 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createAgentRoleWorkspace } from '../../src/agents/role.js'
+import { PermissionModeRegistry } from '../../src/permissions/permission-mode.js'
+import { createEmptyToolPermissionContext } from '../../src/permissions/types.js'
+import { runWithCurrentRuntimeSession } from '../../src/session/current-session.js'
+import { Session } from '../../src/session/session.js'
+import {
+  assertTurnCompatAgentCatalog,
+  createTurnCompatSession,
+  runTurnCompat,
+} from '../../src/session/turn-compat.js'
+import { getAgentMemoryDir } from '../../src/tools/AgentTool/agentMemory.js'
+import type { AgentDefinition } from '../../src/tools/AgentTool/loadAgentsDir.js'
+import type { ToolUseContext } from '../../src/tools/Tool.js'
+import {
+  getAgentContext,
+  runWithAgentContext,
+} from '../../src/utils/agentContext.js'
+import {
+  checkEditableInternalPath,
+  checkReadableInternalPath,
+} from '../../src/utils/permissions/filesystem.js'
+import { asSystemPrompt } from '../../src/utils/systemPromptType.js'
+
+const tempRoots: string[] = []
+
+beforeEach(() => {
+  vi.stubGlobal('MACRO', { VERSION: 'test' })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function tempRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `agenc-turn-${label}-`))
+  tempRoots.push(root)
+  return root
+}
+
+function context(optionsWorkspaceId: string | undefined, stateWorkspaceId: string | undefined) {
+  return {
+    options: {
+      agentDefinitions: {
+        agentRoleWorkspaceId: optionsWorkspaceId,
+        activeAgents: [],
+        allAgents: [],
+      },
+    },
+    getAppState: () => ({
+      agentDefinitions: {
+        agentRoleWorkspaceId: stateWorkspaceId,
+        activeAgents: [],
+        allAgents: [],
+      },
+    }),
+  } as never
+}
+
+describe('turn compatibility catalog boundary', () => {
+  const workspaceA = createAgentRoleWorkspace('/workspace/a')
+
+  it('rejects foreign option or live-state catalogs before session construction', () => {
+    for (const candidate of ['/workspace/b', undefined]) {
+      expect(() =>
+        assertTurnCompatAgentCatalog(
+          { roleWorkspace: workspaceA },
+          context(candidate, workspaceA.id),
+        ),
+      ).toThrow(/workspace (mismatch|provenance is missing)/u)
+      expect(() =>
+        assertTurnCompatAgentCatalog(
+          { roleWorkspace: workspaceA },
+          context(workspaceA.id, candidate),
+        ),
+      ).toThrow(/workspace (mismatch|provenance is missing)/u)
+    }
+  })
+
+  it('accepts two envelopes bound to the parent role workspace', () => {
+    expect(() =>
+      assertTurnCompatAgentCatalog(
+        { roleWorkspace: workspaceA },
+        context(workspaceA.id, workspaceA.id),
+      ),
+    ).not.toThrow()
+  })
+
+  it('createTurnCompatSession rejects before registry or Session construction', async () => {
+    const toolsRead = vi.fn()
+    const toolUseContext = context(workspaceA.id, '/workspace/b') as unknown as {
+      options: Record<string, unknown>
+    }
+    Object.defineProperty(toolUseContext.options, 'tools', {
+      get: () => {
+        toolsRead()
+        throw new Error('registry construction was reached')
+      },
+    })
+
+    await expect(
+      createTurnCompatSession(
+        { roleWorkspace: workspaceA } as never,
+        { toolUseContext } as never,
+      ),
+    ).rejects.toThrow('agent role workspace mismatch')
+    expect(toolsRead).not.toHaveBeenCalled()
+  })
+
+  it('binds foreground selected-agent memory without assigning subagent identity', async () => {
+    const workspaceA = tempRoot('memory-a')
+    const workspaceB = tempRoot('memory-b')
+    const ownMemory = getAgentMemoryDir('memory-worker', 'project', workspaceA)
+    const siblingMemory = getAgentMemoryDir(
+      'sibling-worker',
+      'project',
+      workspaceA,
+    )
+    const foreignMemory = getAgentMemoryDir(
+      'memory-worker',
+      'project',
+      workspaceB,
+    )
+    for (const directory of [ownMemory, siblingMemory, foreignMemory]) {
+      mkdirSync(directory, { recursive: true })
+      writeFileSync(join(directory, 'MEMORY.md'), 'memory')
+    }
+    const ownPath = join(ownMemory, 'MEMORY.md')
+    const siblingPath = join(siblingMemory, 'MEMORY.md')
+    const foreignPath = join(foreignMemory, 'MEMORY.md')
+    const observed: Array<{
+      readonly ownRead: string
+      readonly ownWrite: string
+      readonly siblingRead: string
+      readonly siblingWrite: string
+      readonly foreignRead: string
+      readonly foreignWrite: string
+      readonly agentContext: unknown
+    }> = []
+
+    vi.spyOn(Session.prototype, 'runTurn').mockImplementation(
+      (async function* (this: Session) {
+        observed.push(runWithCurrentRuntimeSession(this, () => ({
+          ownRead: checkReadableInternalPath(ownPath, {}).behavior,
+          ownWrite: checkEditableInternalPath(ownPath, {}).behavior,
+          siblingRead: checkReadableInternalPath(siblingPath, {}).behavior,
+          siblingWrite: checkEditableInternalPath(siblingPath, {}).behavior,
+          foreignRead: checkReadableInternalPath(foreignPath, {}).behavior,
+          foreignWrite: checkEditableInternalPath(foreignPath, {}).behavior,
+          agentContext: getAgentContext(),
+        })))
+        return { reason: 'completed' } as never
+      }) as Session['runTurn'],
+    )
+
+    const selected = memoryAgentDefinition('memory-worker', 'project')
+    await consumeCompatTurn(
+      foregroundParent(workspaceA),
+      foregroundToolContext(workspaceA, [selected], selected.agentType),
+    )
+    await consumeCompatTurn(
+      foregroundParent(workspaceA),
+      foregroundToolContext(workspaceA, [selected], undefined),
+    )
+    const ambientAgentContext = {
+      agentId: 'background-memory-worker',
+      agentType: 'subagent' as const,
+      subagentName: selected.agentType,
+      memoryAuthorization: {
+        agentType: selected.agentType,
+        scope: 'project' as const,
+      },
+    }
+    await runWithAgentContext(ambientAgentContext, () =>
+      consumeCompatTurn(
+        foregroundParent(workspaceA),
+        foregroundToolContext(workspaceA, [selected], 'stale-selection'),
+      ),
+    )
+    await runWithAgentContext(ambientAgentContext, () =>
+      consumeCompatTurn(
+        foregroundParent(workspaceA),
+        foregroundToolContext(workspaceA, [selected], undefined),
+      ),
+    )
+
+    expect(observed).toEqual([
+      {
+        ownRead: 'allow',
+        ownWrite: 'allow',
+        siblingRead: 'passthrough',
+        siblingWrite: 'passthrough',
+        foreignRead: 'passthrough',
+        foreignWrite: 'passthrough',
+        agentContext: undefined,
+      },
+      {
+        ownRead: 'passthrough',
+        ownWrite: 'passthrough',
+        siblingRead: 'passthrough',
+        siblingWrite: 'passthrough',
+        foreignRead: 'passthrough',
+        foreignWrite: 'passthrough',
+        agentContext: undefined,
+      },
+      {
+        ownRead: 'passthrough',
+        ownWrite: 'passthrough',
+        siblingRead: 'passthrough',
+        siblingWrite: 'passthrough',
+        foreignRead: 'passthrough',
+        foreignWrite: 'passthrough',
+        agentContext: ambientAgentContext,
+      },
+      {
+        ownRead: 'allow',
+        ownWrite: 'allow',
+        siblingRead: 'passthrough',
+        siblingWrite: 'passthrough',
+        foreignRead: 'passthrough',
+        foreignWrite: 'passthrough',
+        agentContext: ambientAgentContext,
+      },
+    ])
+  })
+})
+
+function memoryAgentDefinition(
+  agentType: string,
+  memory: 'user' | 'project' | 'local',
+): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: 'memory boundary test',
+    source: 'projectSettings',
+    memory,
+    getSystemPrompt: () => '',
+  }
+}
+
+function foregroundParent(cwd: string): Session {
+  const roleWorkspace = createAgentRoleWorkspace(cwd)
+  const permissionModeRegistry = new PermissionModeRegistry(
+    createEmptyToolPermissionContext({ mode: 'dontAsk' }),
+  )
+  return {
+    conversationId: `parent:${roleWorkspace.id}`,
+    roleWorkspace,
+    sessionConfiguration: {
+      cwd,
+      collaborationMode: { model: 'test-model' },
+    },
+    config: { cwd, model: 'test-model' },
+    features: {},
+    services: { hooks: {}, permissionModeRegistry },
+    jsRepl: { id: 'test-repl' },
+    modelInfo: { slug: 'test-model' },
+  } as unknown as Session
+}
+
+function foregroundToolContext(
+  cwd: string,
+  activeAgents: readonly AgentDefinition[],
+  agent: string | undefined,
+): ToolUseContext {
+  const roleWorkspace = createAgentRoleWorkspace(cwd)
+  const agentDefinitions = {
+    agentRoleWorkspaceId: roleWorkspace.id,
+    activeAgents: [...activeAgents],
+    allAgents: [...activeAgents],
+    allowedAgentTypes: activeAgents.map((definition) => definition.agentType),
+  }
+  const toolPermissionContext = createEmptyToolPermissionContext({
+    mode: 'dontAsk',
+  })
+  return {
+    options: {
+      commands: [],
+      debug: false,
+      mainLoopModel: 'test-model',
+      tools: [],
+      verbose: false,
+      thinkingConfig: { type: 'disabled' },
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: true,
+      agentDefinitions,
+    },
+    abortController: new AbortController(),
+    getAppState: () => ({
+      agent,
+      agentDefinitions,
+      toolPermissionContext,
+      tasks: {},
+      sessionHooks: new Map(),
+    }),
+    setAppState: () => {},
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+    messages: [],
+  } as unknown as ToolUseContext
+}
+
+async function consumeCompatTurn(
+  parent: Session,
+  toolUseContext: ToolUseContext,
+): Promise<void> {
+  for await (const _event of runTurnCompat(parent, {
+    messages: [],
+    systemPrompt: asSystemPrompt(['test']),
+    userContext: {},
+    systemContext: {},
+    canUseTool: async () => ({ behavior: 'allow' }),
+    toolUseContext,
+    querySource: 'repl_main_thread',
+  })) {
+    // The mocked Session boundary records permission decisions directly.
+  }
+}

--- a/runtime/tests/state/migrations.test.ts
+++ b/runtime/tests/state/migrations.test.ts
@@ -9,13 +9,53 @@ import {
   type SqlMigration,
 } from "./migrations/index.js";
 import { applyMigrations } from "./sqlite-driver.js";
+import { StateSchemaMismatchError } from "./errors.js";
 
 const migrationDir = sourcePath("state");
 
 describe("state migration registry", () => {
+  it("rolls back a failed migration to a savepoint inside an outer transaction", () => {
+    const db = new Database(":memory:");
+    try {
+      db.exec("BEGIN");
+      expect(() =>
+        applyMigrations(db, [
+          {
+            version: 1,
+            name: "fails_after_ddl",
+            apply: (migrationDb) => {
+              migrationDb.exec(
+                "CREATE TABLE partial_migration (id INTEGER PRIMARY KEY)",
+              );
+              migrationDb.exec("INSERT INTO partial_migration (id) VALUES (1)");
+              throw new Error("forced migration failure");
+            },
+          },
+        ]),
+      ).toThrow(/state migration 1 failed/);
+      db.exec("COMMIT");
+
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'partial_migration'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(
+        db
+          .prepare("SELECT version FROM schema_migrations WHERE version = 1")
+          .get(),
+      ).toBeUndefined();
+    } finally {
+      if (db.inTransaction) db.exec("ROLLBACK");
+      db.close();
+    }
+  });
+
   it("loads state migrations from numbered migration files in order", () => {
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.version)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
     ]);
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.name)).toEqual([
       "initial_state_schema",
@@ -29,6 +69,7 @@ describe("state migration registry", () => {
       "agent_run_metadata_schema",
       "tool_recovery_category_schema",
       "memory_pipeline_schema",
+      "agent_role_workspace_provenance",
     ]);
     expectMigrationVersionsAreUnique(STATE_DB_MIGRATIONS);
   });
@@ -56,7 +97,113 @@ describe("state migration registry", () => {
       "009_agent_run_metadata_schema.ts",
       "010_tool_recovery_category_schema.ts",
       "011_memory_pipeline_schema.ts",
+      "012_agent_role_workspace_provenance.ts",
     ]);
+  });
+
+  it("backfills durable role-workspace provenance idempotently", () => {
+    const db = new Database(":memory:");
+    try {
+      applyMigrations(db, STATE_DB_MIGRATIONS.slice(0, -1));
+      db.prepare(
+        `INSERT INTO thread_spawn_edges (
+          child_thread_id, parent_thread_id, parent_path, metadata_json, status
+        ) VALUES (?, ?, ?, ?, ?)`,
+      ).run(
+        "child-1",
+        "root-1",
+        "/root",
+        JSON.stringify({
+          agentId: "child-1",
+          agentPath: "/root/child",
+          agentRole: "reviewer",
+          agentRoleWorkspaceId: "/workspace/a",
+          agentRoleFingerprint: "reviewer-fingerprint",
+          depth: 1,
+        }),
+        "open",
+      );
+      db.prepare(
+        `INSERT INTO thread_spawn_edges (
+          child_thread_id, parent_thread_id, parent_path, metadata_json, status
+        ) VALUES (?, ?, ?, ?, ?)`,
+      ).run(
+        "legacy-named-child",
+        "root-1",
+        "/root",
+        JSON.stringify({
+          agentId: "legacy-named-child",
+          agentPath: "/root/legacy-named-child",
+          agentRole: "reviewer",
+          depth: 1,
+        }),
+        "open",
+      );
+
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+
+      expect(
+        db
+          .prepare(
+            `SELECT agent_role_workspace_id, agent_role_fingerprint
+             FROM thread_spawn_edges
+             WHERE child_thread_id = ?`,
+          )
+          .get("child-1"),
+      ).toEqual({
+        agent_role_workspace_id: "/workspace/a",
+        agent_role_fingerprint: "reviewer-fingerprint",
+      });
+      expect(() =>
+        db
+          .prepare(
+            `UPDATE thread_spawn_edges
+             SET metadata_json = ?
+             WHERE child_thread_id = ?`,
+          )
+          .run(
+            JSON.stringify({
+              agentId: "child-1",
+              agentPath: "/root/child",
+              agentRole: "default",
+              depth: 1,
+            }),
+            "child-1",
+          ),
+      ).toThrow(/identity is immutable/);
+      expect(() =>
+        db
+          .prepare(
+            `UPDATE thread_spawn_edges
+             SET metadata_json = ?
+             WHERE child_thread_id = ?`,
+          )
+          .run(
+            JSON.stringify({
+              agentId: "legacy-named-child",
+              agentPath: "/root/legacy-named-child",
+              agentRole: "reviewer",
+              agentRoleWorkspaceId: "/workspace/injected",
+              agentRoleFingerprint: "injected-fingerprint",
+              depth: 1,
+            }),
+            "legacy-named-child",
+          ),
+      ).toThrow(/identity is immutable/);
+      expect(
+        db
+          .prepare(
+            "SELECT version FROM schema_migrations WHERE version = 12",
+          )
+          .get(),
+      ).toEqual({ version: 12 });
+      expect(() =>
+        applyMigrations(db, STATE_DB_MIGRATIONS.slice(0, -1)),
+      ).toThrow(StateSchemaMismatchError);
+    } finally {
+      db.close();
+    }
   });
 
   it("adds memory pipeline schema to legacy memory job tables idempotently", () => {

--- a/runtime/tests/state/sqlite-driver.test.ts
+++ b/runtime/tests/state/sqlite-driver.test.ts
@@ -1,13 +1,22 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { StateSchemaMismatchError } from "./errors.js";
 import {
+  applyMigrations,
   openStateDatabases,
   resolveStateDatabasePaths,
+  STATE_PRE_V12_BACKUP_FILENAME,
 } from "./sqlite-driver.js";
+import { STATE_DB_MIGRATIONS } from "./migrations/index.js";
 
 let home = "";
 let cwd = "";
@@ -122,5 +131,192 @@ describe("openStateDatabases", () => {
     }
 
     expect(() => openStateDatabases({ cwd })).toThrow(StateSchemaMismatchError);
+  });
+
+  it("creates a verified pre-v12 backup that an older runtime can restore", () => {
+    const paths = resolveStateDatabasePaths({ cwd });
+    mkdirSync(paths.projectDir, { recursive: true, mode: 0o700 });
+    const raw = new Database(paths.stateDbPath);
+    try {
+      applyMigrations(raw, STATE_DB_MIGRATIONS.slice(0, -1));
+      const insertEdge = raw.prepare(
+        `INSERT INTO thread_spawn_edges (
+          child_thread_id, parent_thread_id, parent_path, metadata_json, status
+        ) VALUES (?, ?, ?, ?, ?)`,
+      );
+      insertEdge.run(
+        "backup-child",
+        "backup-root",
+        "/root",
+        JSON.stringify({
+          agentId: "backup-child",
+          agentPath: "/root/backup-child",
+          agentRole: "reviewer",
+          agentRoleWorkspaceId: cwd,
+          depth: 1,
+        }),
+        "open",
+      );
+
+      // Model a prior upgrade attempt that published a backup but died before
+      // committing v12. State can continue changing under v11; the next
+      // attempt must refresh, not trust, this now-stale artifact.
+      const staleBackupPath = join(
+        paths.projectDir,
+        STATE_PRE_V12_BACKUP_FILENAME,
+      );
+      raw.exec(`VACUUM main INTO '${staleBackupPath.replaceAll("'", "''")}'`);
+      insertEdge.run(
+        "after-stale-backup",
+        "backup-root",
+        "/root",
+        JSON.stringify({
+          agentId: "after-stale-backup",
+          agentPath: "/root/after-stale-backup",
+          agentRole: "reviewer",
+          agentRoleWorkspaceId: cwd,
+          depth: 1,
+        }),
+        "open",
+      );
+    } finally {
+      raw.close();
+    }
+
+    const driver = openStateDatabases({ cwd });
+    try {
+      expect(
+        driver
+          .prepareState<[], { version: number }>(
+            "SELECT MAX(version) AS version FROM schema_migrations",
+          )
+          .get()?.version,
+      ).toBe(12);
+    } finally {
+      driver.close();
+    }
+
+    const backupPath = join(paths.projectDir, STATE_PRE_V12_BACKUP_FILENAME);
+    expect(existsSync(backupPath)).toBe(true);
+    const backup = new Database(backupPath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      expect(
+        backup
+          .prepare("SELECT MAX(version) AS version FROM schema_migrations")
+          .get(),
+      ).toEqual({ version: 11 });
+      expect(
+        backup
+          .prepare("PRAGMA table_info(thread_spawn_edges)")
+          .all()
+          .some(
+            (column) =>
+              (column as { name?: unknown }).name === "agent_role_workspace_id",
+          ),
+      ).toBe(false);
+      expect(
+        backup
+          .prepare(
+            `SELECT parent_thread_id, metadata_json, status
+             FROM thread_spawn_edges
+             WHERE child_thread_id = ?`,
+          )
+          .get("backup-child"),
+      ).toMatchObject({
+        parent_thread_id: "backup-root",
+        status: "open",
+      });
+      expect(
+        backup
+          .prepare(
+            "SELECT child_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?",
+          )
+          .get("after-stale-backup"),
+      ).toEqual({ child_thread_id: "after-stale-backup" });
+      expect(backup.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+    } finally {
+      backup.close();
+    }
+
+    const restoredPath = join(paths.projectDir, "restored-pre-v12.sqlite");
+    copyFileSync(backupPath, restoredPath);
+    const restored = new Database(restoredPath);
+    try {
+      expect(() =>
+        applyMigrations(restored, STATE_DB_MIGRATIONS.slice(0, -1)),
+      ).not.toThrow();
+      expect(
+        restored
+          .prepare(
+            "SELECT child_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?",
+          )
+          .get("backup-child"),
+      ).toEqual({ child_thread_id: "backup-child" });
+      expect(
+        restored
+          .prepare(
+            "SELECT child_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?",
+          )
+          .get("after-stale-backup"),
+      ).toEqual({ child_thread_id: "after-stale-backup" });
+    } finally {
+      restored.close();
+    }
+  });
+
+  it("decides the pre-v12 backup under the writer lock with a v11 connection open", () => {
+    const paths = resolveStateDatabasePaths({ cwd });
+    mkdirSync(paths.projectDir, { recursive: true, mode: 0o700 });
+    const v11 = new Database(paths.stateDbPath);
+    try {
+      applyMigrations(v11, STATE_DB_MIGRATIONS.slice(0, -1));
+      v11.prepare(
+        `INSERT INTO thread_spawn_edges (
+          child_thread_id, parent_thread_id, parent_path, metadata_json, status
+        ) VALUES (?, ?, ?, ?, ?)`,
+      ).run(
+        "concurrent-child",
+        "root-1",
+        "/root",
+        JSON.stringify({
+          agentId: "concurrent-child",
+          agentPath: "/root/concurrent",
+          agentRole: "default",
+          depth: 1,
+        }),
+        "open",
+      );
+
+      const upgraded = openStateDatabases({ cwd });
+      upgraded.close();
+
+      const backup = new Database(
+        join(paths.projectDir, STATE_PRE_V12_BACKUP_FILENAME),
+        { readonly: true, fileMustExist: true },
+      );
+      try {
+        expect(
+          backup
+            .prepare(
+              "SELECT child_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?",
+            )
+            .get("concurrent-child"),
+        ).toEqual({ child_thread_id: "concurrent-child" });
+        expect(
+          backup
+            .prepare("SELECT MAX(version) AS version FROM schema_migrations")
+            .get(),
+        ).toEqual({ version: 11 });
+      } finally {
+        backup.close();
+      }
+    } finally {
+      v11.close();
+    }
   });
 });

--- a/runtime/tests/tools/AgentTool/AgentTool.workspace.test.ts
+++ b/runtime/tests/tools/AgentTool/AgentTool.workspace.test.ts
@@ -1,0 +1,290 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createAgentRoleWorkspace } from '../../../src/agents/role.js'
+import { runWithCurrentRuntimeSession } from '../../../src/session/current-session.js'
+import type { Session } from '../../../src/session/session.js'
+import {
+  __setAgentMetadataWriterForTesting,
+  __setAgentToolLaunchPreflightForTesting,
+  AgentTool,
+} from '../../../src/tools/AgentTool/AgentTool.js'
+import {
+  __setPluginAgentsLoaderForTesting,
+  clearAgentDefinitionsCache,
+} from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import type { ToolUseContext } from '../../../src/tools/Tool.js'
+import { getDefaultAppState } from '../../../src/tui/state/AppStateStore.js'
+import { runWithCwdOverride } from '../../../src/utils/cwd.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  __setPluginAgentsLoaderForTesting(undefined)
+  __setAgentMetadataWriterForTesting(undefined)
+  __setAgentToolLaunchPreflightForTesting(undefined)
+  clearAgentDefinitionsCache()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function tempRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `agenc-${label}-`))
+  roots.push(root)
+  return root
+}
+
+function sessionFor(cwd: string): Session {
+  return {
+    roleWorkspace: createAgentRoleWorkspace(cwd),
+  } as unknown as Session
+}
+
+function contextFor(
+  catalogWorkspace: string,
+  options: { readonly deniedAgentType?: string } = {},
+): {
+  readonly context: ToolUseContext
+  readonly setAppState: ReturnType<typeof vi.fn>
+} {
+  const agentDefinitions = {
+    agentRoleWorkspaceId: createAgentRoleWorkspace(catalogWorkspace).id,
+    activeAgents: [],
+    allAgents: [],
+  }
+  const defaultState = getDefaultAppState()
+  const appState = {
+    ...defaultState,
+    agentDefinitions,
+    toolPermissionContext: {
+      ...defaultState.toolPermissionContext,
+      alwaysDenyRules: options.deniedAgentType === undefined
+        ? defaultState.toolPermissionContext.alwaysDenyRules
+        : {
+            projectSettings: [
+              `spawn_agent(${options.deniedAgentType})`,
+            ],
+          },
+    },
+  }
+  const setAppState = vi.fn()
+  return {
+    setAppState,
+    context: {
+      options: {
+        agentDefinitions,
+        tools: [],
+        mainLoopModel: 'test-model',
+        mcpClients: [],
+      },
+      getAppState: () => appState,
+      setAppState,
+    } as unknown as ToolUseContext,
+  }
+}
+
+async function callAgentTool(
+  session: Session,
+  context: ToolUseContext,
+  cwd: string | undefined,
+  input: Record<string, unknown> = {},
+): Promise<unknown> {
+  const call = () => runWithCurrentRuntimeSession(session, () =>
+      (AgentTool.call as unknown as (
+        input: Record<string, unknown>,
+        context: ToolUseContext,
+        canUseTool: () => Promise<{ behavior: 'allow' }>,
+      ) => Promise<unknown>)(
+        {
+          description: 'workspace preflight',
+          prompt: 'do not execute',
+          subagent_type: 'missing-role',
+          ...(cwd !== undefined ? { cwd } : {}),
+          ...input,
+        },
+        context,
+        async () => ({ behavior: 'allow' }),
+      ))
+  return cwd === undefined
+    ? runWithCwdOverride(session.roleWorkspace.cwd, call)
+    : call()
+}
+
+describe('AgentTool workspace authority', () => {
+  it('rejects a same-named foreign catalog before task or spawn mutation', async () => {
+    const session = sessionFor('/workspace/a')
+    const { context, setAppState } = contextFor('/workspace/b')
+
+    await expect(
+      callAgentTool(session, context, '/workspace/a'),
+    ).rejects.toThrow('agent role workspace mismatch')
+    expect(setAppState).not.toHaveBeenCalled()
+  })
+
+  it('keeps role authority in workspace A when execution cwd is workspace B', async () => {
+    const session = sessionFor('/workspace/a')
+    const { context, setAppState } = contextFor('/workspace/a')
+
+    await expect(
+      callAgentTool(session, context, '/workspace/b'),
+    ).rejects.toThrow("Agent type 'missing-role' not found")
+    expect(setAppState).not.toHaveBeenCalled()
+  })
+
+  it('enforces an alias deny before falling back from scanner to explorer', async () => {
+    const workspace = tempRoot('agent-alias-deny')
+    __setPluginAgentsLoaderForTesting(async () => [])
+    const session = sessionFor(workspace)
+    const { context, setAppState } = contextFor(workspace, {
+      deniedAgentType: 'scanner',
+    })
+
+    await expect(
+      callAgentTool(session, context, workspace, {
+        subagent_type: 'scanner',
+      }),
+    ).rejects.toThrow("Agent type 'scanner' has been denied")
+    expect(setAppState).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to explorer when an exact custom scanner is denied', async () => {
+    const workspace = tempRoot('agent-exact-deny')
+    const agentsDir = join(workspace, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      join(agentsDir, 'scanner.md'),
+      `---
+name: scanner
+description: Restrictive exact scanner
+disallowedTools:
+  - Write
+permissionMode: plan
+---
+Never mutate files.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+    const session = sessionFor(workspace)
+    const { context, setAppState } = contextFor(workspace, {
+      deniedAgentType: 'scanner',
+    })
+
+    await expect(
+      callAgentTool(session, context, workspace, {
+        subagent_type: 'scanner',
+      }),
+    ).rejects.toThrow("Agent type 'scanner' has been denied")
+    expect(setAppState).not.toHaveBeenCalled()
+  })
+
+  it('accepts an unchanged fresh custom role at the real AgentTool boundary', async () => {
+    const workspace = tempRoot('agent-fresh-custom')
+    const agentsDir = join(workspace, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      join(agentsDir, 'auditor.md'),
+      `---
+name: exact-auditor
+description: Exact restrictive auditor
+disallowedTools:
+  - Write
+permissionMode: plan
+---
+Audit without mutations.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+    const session = sessionFor(workspace)
+    const { context } = contextFor(workspace)
+    const preflight = vi.fn(({ selectedAgent, agentRoleFingerprint }) => {
+      expect(selectedAgent).toMatchObject({
+        agentType: 'exact-auditor',
+        permissionMode: 'plan',
+        disallowedTools: ['Write'],
+      })
+      expect(agentRoleFingerprint).toMatch(/^[a-f0-9]{64}$/)
+      throw new Error('test launch boundary reached')
+    })
+    __setAgentToolLaunchPreflightForTesting(preflight)
+
+    await expect(
+      callAgentTool(session, context, undefined, {
+        subagent_type: 'exact-auditor',
+      }),
+    ).rejects.toThrow('test launch boundary reached')
+    expect(preflight).toHaveBeenCalledOnce()
+  })
+
+  it('does not publish or start an async agent when durable metadata persistence fails', async () => {
+    const workspace = tempRoot('agent-metadata-failure')
+    __setPluginAgentsLoaderForTesting(async () => [
+      {
+        agentType: 'atomic-auditor',
+        whenToUse: 'Tests durable launch ordering',
+        source: 'plugin',
+        plugin: 'atomic-test-plugin',
+        baseDir: workspace,
+        getSystemPrompt: () => 'Do not start.',
+      },
+    ])
+    const persistenceFailure = new Error('simulated metadata fsync failure')
+    const writer = vi.fn(async () => {
+      throw persistenceFailure
+    })
+    __setAgentMetadataWriterForTesting(writer)
+    const session = sessionFor(workspace)
+    const { context, setAppState } = contextFor(workspace)
+
+    await expect(
+      callAgentTool(session, context, undefined, {
+        subagent_type: 'atomic-auditor',
+        run_in_background: true,
+      }),
+    ).rejects.toBe(persistenceFailure)
+
+    expect(writer).toHaveBeenCalledOnce()
+    expect(writer).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        agentType: 'atomic-auditor',
+        agentRoleWorkspaceId: session.roleWorkspace.id,
+        agentRoleFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    )
+    // registerAsyncAgent publishes through the root AppState setter. It must
+    // remain untouched when persistence fails.
+    expect(setAppState).not.toHaveBeenCalled()
+  })
+
+  it('prefers an exact restrictive plugin alias on the immediate call path', async () => {
+    const workspace = tempRoot('agent-fresh-plugin')
+    __setPluginAgentsLoaderForTesting(async () => [
+      {
+        agentType: 'scanner',
+        whenToUse: 'Exact plugin scanner',
+        source: 'plugin',
+        plugin: 'security-plugin',
+        baseDir: workspace,
+        requiredMcpServers: ['exact-plugin-server'],
+        disallowedTools: ['Write'],
+        permissionMode: 'plan',
+        getSystemPrompt: () => 'Exact plugin scanner prompt.',
+      },
+    ])
+    const session = sessionFor(workspace)
+    const { context } = contextFor(workspace)
+
+    await expect(
+      callAgentTool(session, context, undefined, {
+        subagent_type: 'scanner',
+        isolation: 'worktree',
+      }),
+    ).rejects.toThrow(
+      "Agent 'scanner' requires MCP servers matching: exact-plugin-server",
+    )
+  })
+})

--- a/runtime/tests/tools/AgentTool/agentMemory.workspace.test.ts
+++ b/runtime/tests/tools/AgentTool/agentMemory.workspace.test.ts
@@ -1,0 +1,594 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  linkSync,
+  lstatSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative, sep } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createAgentRoleWorkspace } from '../../../src/agents/role.js'
+import { runWithCurrentRuntimeSession } from '../../../src/session/current-session.js'
+import type { Session } from '../../../src/session/session.js'
+import {
+  getAgentMemoryDir,
+  loadAgentMemoryPrompt,
+} from '../../../src/tools/AgentTool/agentMemory.js'
+import {
+  __setAgentMemorySnapshotFileOperationForTesting,
+  checkAgentMemorySnapshot,
+  getSnapshotDirForAgent,
+  initializeFromSnapshot,
+  replaceFromSnapshot,
+} from '../../../src/tools/AgentTool/agentMemorySnapshot.js'
+import {
+  __setPluginAgentsLoaderForTesting,
+  clearAgentDefinitionsCache,
+  loadFreshAgentDefinitions,
+  requireAgentDefinitionRoleFingerprint,
+} from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import {
+  checkEditableInternalPath,
+  checkReadPermissionForTool,
+  checkReadableInternalPath,
+  checkWritePermissionForTool,
+} from '../../../src/utils/permissions/filesystem.js'
+import { runWithAgentContext } from '../../../src/utils/agentContext.js'
+import type {
+  Tool,
+  ToolPermissionContext,
+} from '../../../src/tools/Tool.js'
+
+const roots: string[] = []
+const initialCwd = process.cwd()
+
+beforeEach(() => {
+  vi.stubGlobal('MACRO', { VERSION: 'test' })
+})
+
+function tempRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `agenc-${label}-`))
+  roots.push(root)
+  return root
+}
+
+function fileTool(name: string): Tool {
+  return {
+    name,
+    getPath(input: Record<string, unknown>): string {
+      return String(input.file_path ?? '')
+    },
+  } as unknown as Tool
+}
+
+function permissionContext(
+  workingDirectories: readonly string[] = [],
+): ToolPermissionContext {
+  return {
+    mode: 'default',
+    additionalWorkingDirectories: new Map(
+      workingDirectories.map(path => [path, { path, source: 'session' }]),
+    ),
+    alwaysAllowRules: {},
+    alwaysDenyRules: {},
+    alwaysAskRules: {},
+    isBypassPermissionsModeAvailable: false,
+  } as ToolPermissionContext
+}
+
+afterEach(() => {
+  process.chdir(initialCwd)
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  __setPluginAgentsLoaderForTesting(undefined)
+  __setAgentMemorySnapshotFileOperationForTesting(undefined)
+  clearAgentDefinitionsCache()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('agent memory workspace authority', () => {
+  it('uses role workspace A under ambient cwd B and rejects B/symlink carve-outs', () => {
+    const workspaceA = tempRoot('memory-workspace-a')
+    const workspaceB = tempRoot('memory-workspace-b')
+    const outside = tempRoot('memory-outside')
+    const memoryA = getAgentMemoryDir('worker', 'project', workspaceA)
+    const memoryB = getAgentMemoryDir('worker', 'project', workspaceB)
+    const siblingMemoryA = getAgentMemoryDir(
+      'sibling-worker',
+      'project',
+      workspaceA,
+    )
+    mkdirSync(memoryA, { recursive: true })
+    mkdirSync(memoryB, { recursive: true })
+    mkdirSync(siblingMemoryA, { recursive: true })
+    const entryA = join(memoryA, 'MEMORY.md')
+    const entryB = join(memoryB, 'MEMORY.md')
+    const siblingEntryA = join(siblingMemoryA, 'MEMORY.md')
+    const outsideFile = join(outside, 'outside.md')
+    const outsideHardlinkedFile = join(outside, 'hardlinked.md')
+    const inMemoryHardlink = join(memoryA, 'hardlinked.md')
+    writeFileSync(entryA, 'workspace-a-memory')
+    writeFileSync(entryB, 'workspace-b-memory')
+    writeFileSync(siblingEntryA, 'sibling-workspace-a-memory')
+    writeFileSync(outsideFile, 'outside-memory')
+    writeFileSync(outsideHardlinkedFile, 'external-hardlink-memory')
+    linkSync(outsideHardlinkedFile, inMemoryHardlink)
+    const escapedLink = join(memoryA, 'escaped.md')
+    symlinkSync(outsideFile, escapedLink)
+    process.chdir(workspaceB)
+
+    const session = {
+      roleWorkspace: createAgentRoleWorkspace(workspaceA),
+      sessionConfiguration: { cwd: workspaceB },
+    } as unknown as Session
+    runWithCurrentRuntimeSession(session, () => {
+      const prompt = loadAgentMemoryPrompt('worker', 'project')
+      expect(prompt).toContain('workspace-a-memory')
+      expect(prompt).not.toContain('workspace-b-memory')
+
+      // No agent identity means no implicit memory permission.
+      expect(checkEditableInternalPath(entryA, {}).behavior).toBe('passthrough')
+      expect(checkReadableInternalPath(entryA, {}).behavior).toBe('passthrough')
+
+      const allowedWorkspaceContext = permissionContext([
+        workspaceA,
+        workspaceB,
+      ])
+      expect(
+        checkReadPermissionForTool(
+          fileTool('FileRead'),
+          { file_path: entryA },
+          allowedWorkspaceContext,
+        ).behavior,
+      ).not.toBe('allow')
+
+      runWithAgentContext(
+        {
+          agentId: 'memory-worker-test',
+          agentType: 'subagent',
+          subagentName: 'worker',
+          memoryAuthorization: {
+            agentType: 'worker',
+            scope: 'project',
+          },
+        },
+        () => {
+          expect(checkEditableInternalPath(entryA, {}).behavior).toBe('allow')
+          expect(checkReadableInternalPath(entryA, {}).behavior).toBe('allow')
+          expect(checkEditableInternalPath(entryB, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkReadableInternalPath(entryB, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkEditableInternalPath(siblingEntryA, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkReadableInternalPath(siblingEntryA, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkEditableInternalPath(escapedLink, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkReadableInternalPath(escapedLink, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkEditableInternalPath(inMemoryHardlink, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(checkReadableInternalPath(inMemoryHardlink, {}).behavior).toBe(
+            'passthrough',
+          )
+          expect(readFileSync(outsideHardlinkedFile, 'utf8')).toBe(
+            'external-hardlink-memory',
+          )
+
+          const context = allowedWorkspaceContext
+          expect(
+            checkReadPermissionForTool(
+              fileTool('FileRead'),
+              { file_path: entryA },
+              context,
+            ).behavior,
+          ).toBe('allow')
+          expect(
+            checkWritePermissionForTool(
+              fileTool('Write'),
+              { file_path: entryA },
+              context,
+            ).behavior,
+          ).toBe('allow')
+          expect(
+            checkReadPermissionForTool(
+              fileTool('FileRead'),
+              { file_path: inMemoryHardlink },
+              context,
+            ).behavior,
+          ).not.toBe('allow')
+          expect(
+            checkWritePermissionForTool(
+              fileTool('Write'),
+              { file_path: inMemoryHardlink },
+              context,
+            ).behavior,
+          ).not.toBe('allow')
+          expect(
+            checkReadPermissionForTool(
+              fileTool('FileRead'),
+              { file_path: entryB },
+              context,
+            ).behavior,
+          ).not.toBe('allow')
+          expect(
+            checkReadPermissionForTool(
+              fileTool('FileRead'),
+              { file_path: siblingEntryA },
+              context,
+            ).behavior,
+          ).not.toBe('allow')
+        },
+      )
+
+      unlinkSync(entryA)
+      symlinkSync(entryB, entryA)
+      const symlinkedPrompt = loadAgentMemoryPrompt('worker', 'project')
+      expect(symlinkedPrompt).not.toContain('workspace-b-memory')
+      expect(symlinkedPrompt).toContain('currently empty')
+
+      const memoryALink = memoryA.endsWith(sep)
+        ? memoryA.slice(0, -1)
+        : memoryA
+      rmSync(memoryALink, { recursive: true, force: true })
+      symlinkSync(memoryB, memoryALink, 'dir')
+      const symlinkedDirectoryPrompt = loadAgentMemoryPrompt(
+        'worker',
+        'project',
+      )
+      expect(symlinkedDirectoryPrompt).not.toContain('workspace-b-memory')
+      expect(symlinkedDirectoryPrompt).toContain('Memory unavailable')
+    })
+  })
+
+  it('uses collision-resistant components for workspaces and agent names', () => {
+    const remote = tempRoot('remote-memory')
+    vi.stubEnv('AGENC_REMOTE_MEMORY_DIR', remote)
+    const collidingWorkspaceA = '/tmp/a-b/c'
+    const collidingWorkspaceB = '/tmp/a/b-c'
+    expect(
+      getAgentMemoryDir('worker', 'local', collidingWorkspaceA),
+    ).not.toBe(getAgentMemoryDir('worker', 'local', collidingWorkspaceB))
+
+    const workspace = tempRoot('memory-components')
+    const agentDirs = [
+      getAgentMemoryDir('x:y', 'project', workspace),
+      getAgentMemoryDir('x-y', 'project', workspace),
+      getAgentMemoryDir('Foo', 'project', workspace),
+      getAgentMemoryDir('foo', 'project', workspace),
+      getAgentMemoryDir('../../../../tmp/leak', 'project', workspace),
+      getAgentMemoryDir('CON', 'project', workspace),
+    ]
+    expect(new Set(agentDirs).size).toBe(agentDirs.length)
+    const projectMemoryRoot = join(workspace, '.agenc', 'agent-memory')
+    for (const dir of agentDirs) {
+      const fromRoot = relative(projectMemoryRoot, dir)
+      expect(fromRoot.startsWith('..')).toBe(false)
+      expect(fromRoot).not.toBe('')
+    }
+    expect(dirname(getSnapshotDirForAgent('../../../../tmp/leak', workspace)))
+      .toBe(join(workspace, '.agenc', 'agent-memory-snapshots'))
+  })
+
+  it('migrates only an unambiguous safe-name legacy memory directory', () => {
+    const workspace = tempRoot('memory-legacy-safe')
+    const projectMemoryRoot = join(workspace, '.agenc', 'agent-memory')
+    const legacyDir = join(projectMemoryRoot, 'worker')
+    mkdirSync(legacyDir, { recursive: true })
+    writeFileSync(join(legacyDir, 'MEMORY.md'), 'preserved-legacy-memory')
+
+    const prompt = loadAgentMemoryPrompt('worker', 'project', workspace)
+    const hashedDir = getAgentMemoryDir('worker', 'project', workspace)
+    expect(prompt).toContain('preserved-legacy-memory')
+    expect(() => lstatSync(legacyDir)).toThrow()
+    expect(readFileSync(join(hashedDir, 'MEMORY.md'), 'utf8')).toBe(
+      'preserved-legacy-memory',
+    )
+
+    const external = tempRoot('memory-legacy-external')
+    writeFileSync(join(external, 'MEMORY.md'), 'must-not-adopt-symlink')
+    const linkedLegacy = join(projectMemoryRoot, 'linked-worker')
+    symlinkSync(external, linkedLegacy, 'dir')
+    expect(
+      loadAgentMemoryPrompt('linked-worker', 'project', workspace),
+    ).not.toContain('must-not-adopt-symlink')
+  })
+
+  it('does not auto-adopt the old non-injective remote workspace namespace', () => {
+    const remote = tempRoot('memory-remote-legacy')
+    vi.stubEnv('AGENC_REMOTE_MEMORY_DIR', remote)
+    const workspace = '/tmp/a-b/c'
+    const legacyDir = join(
+      remote,
+      'projects',
+      '-tmp-a-b-c',
+      'agent-memory-local',
+      'worker',
+    )
+    mkdirSync(legacyDir, { recursive: true })
+    writeFileSync(join(legacyDir, 'MEMORY.md'), 'ambiguous-legacy-remote')
+
+    expect(loadAgentMemoryPrompt('worker', 'local', workspace)).not.toContain(
+      'ambiguous-legacy-remote',
+    )
+    expect(getAgentMemoryDir('worker', 'local', workspace)).not.toContain(
+      `${sep}-tmp-a-b-c${sep}`,
+    )
+  })
+
+  it('rejects snapshot directory symlinks and ignores snapshot file symlinks', async () => {
+    const workspace = tempRoot('snapshot-symlink-workspace')
+    const configDir = tempRoot('snapshot-symlink-config')
+    const external = tempRoot('snapshot-symlink-external')
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+    writeFileSync(
+      join(external, 'snapshot.json'),
+      JSON.stringify({ updatedAt: '2026-07-15T00:00:00.000Z' }),
+    )
+    writeFileSync(join(external, 'MEMORY.md'), 'external-snapshot-secret')
+
+    const linkedSnapshotDir = getSnapshotDirForAgent(
+      'linked-snapshot',
+      workspace,
+    )
+    mkdirSync(dirname(linkedSnapshotDir), { recursive: true })
+    symlinkSync(external, linkedSnapshotDir, 'dir')
+    await expect(
+      checkAgentMemorySnapshot('linked-snapshot', 'user', workspace),
+    ).rejects.toThrow(/trusted directory|symlinked directory/)
+
+    const fileLinkedSnapshotDir = getSnapshotDirForAgent(
+      'file-linked-snapshot',
+      workspace,
+    )
+    mkdirSync(fileLinkedSnapshotDir, { recursive: true })
+    writeFileSync(
+      join(fileLinkedSnapshotDir, 'snapshot.json'),
+      JSON.stringify({ updatedAt: '2026-07-15T00:00:00.000Z' }),
+    )
+    symlinkSync(
+      join(external, 'MEMORY.md'),
+      join(fileLinkedSnapshotDir, 'MEMORY.md'),
+    )
+    const decision = await checkAgentMemorySnapshot(
+      'file-linked-snapshot',
+      'user',
+      workspace,
+    )
+    expect(decision.action).toBe('initialize')
+    await initializeFromSnapshot(
+      'file-linked-snapshot',
+      'user',
+      decision.snapshotTimestamp ?? '',
+      workspace,
+    )
+    expect(
+      loadAgentMemoryPrompt('file-linked-snapshot', 'user', workspace),
+    ).not.toContain('external-snapshot-secret')
+  })
+
+  it('fails closed when the local memory directory is swapped before a snapshot write', async () => {
+    const workspace = tempRoot('snapshot-write-race-workspace')
+    const configDir = tempRoot('snapshot-write-race-config')
+    const external = tempRoot('snapshot-write-race-external')
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+
+    const agentType = 'snapshot-write-race'
+    const snapshotDir = getSnapshotDirForAgent(agentType, workspace)
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFileSync(join(snapshotDir, 'MEMORY.md'), 'snapshot-memory')
+
+    const localMemoryDir = getAgentMemoryDir(agentType, 'user', workspace)
+    const localMemoryPath = localMemoryDir.endsWith(sep)
+      ? localMemoryDir.slice(0, -1)
+      : localMemoryDir
+    const pinnedMemoryPath = `${localMemoryPath}.pinned`
+    mkdirSync(localMemoryPath, { recursive: true })
+    writeFileSync(join(external, 'MEMORY.md'), 'external-memory')
+
+    let hookCalls = 0
+    __setAgentMemorySnapshotFileOperationForTesting(operation => {
+      if (operation.operation !== 'write' || operation.filename !== 'MEMORY.md') {
+        return
+      }
+      hookCalls += 1
+      renameSync(localMemoryPath, pinnedMemoryPath)
+      symlinkSync(external, localMemoryPath, 'dir')
+    })
+
+    await expect(
+      initializeFromSnapshot(
+        agentType,
+        'user',
+        '2026-07-15T00:00:00.000Z',
+        workspace,
+      ),
+    ).rejects.toThrow(/trusted directory|symlinked directory/)
+    expect(hookCalls).toBe(1)
+    expect(readFileSync(join(external, 'MEMORY.md'), 'utf8')).toBe(
+      'external-memory',
+    )
+    expect(() => lstatSync(join(pinnedMemoryPath, 'MEMORY.md'))).toThrow()
+    expect(() => lstatSync(join(external, '.snapshot-synced.json'))).toThrow()
+  })
+
+  it('fails closed when the local memory directory is swapped before snapshot deletion', async () => {
+    const workspace = tempRoot('snapshot-delete-race-workspace')
+    const configDir = tempRoot('snapshot-delete-race-config')
+    const external = tempRoot('snapshot-delete-race-external')
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+
+    const agentType = 'snapshot-delete-race'
+    const snapshotDir = getSnapshotDirForAgent(agentType, workspace)
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFileSync(join(snapshotDir, 'MEMORY.md'), 'replacement-memory')
+
+    const localMemoryDir = getAgentMemoryDir(agentType, 'user', workspace)
+    const localMemoryPath = localMemoryDir.endsWith(sep)
+      ? localMemoryDir.slice(0, -1)
+      : localMemoryDir
+    const pinnedMemoryPath = `${localMemoryPath}.pinned`
+    mkdirSync(localMemoryPath, { recursive: true })
+    writeFileSync(join(localMemoryPath, 'MEMORY.md'), 'local-memory')
+    writeFileSync(join(external, 'MEMORY.md'), 'external-memory')
+
+    let hookCalls = 0
+    __setAgentMemorySnapshotFileOperationForTesting(operation => {
+      if (operation.operation !== 'delete' || operation.filename !== 'MEMORY.md') {
+        return
+      }
+      hookCalls += 1
+      renameSync(localMemoryPath, pinnedMemoryPath)
+      symlinkSync(external, localMemoryPath, 'dir')
+    })
+
+    await expect(
+      replaceFromSnapshot(
+        agentType,
+        'user',
+        '2026-07-15T00:00:00.000Z',
+        workspace,
+      ),
+    ).rejects.toThrow(/trusted directory|symlinked directory/)
+    expect(hookCalls).toBe(1)
+    expect(readFileSync(join(external, 'MEMORY.md'), 'utf8')).toBe(
+      'external-memory',
+    )
+    expect(readFileSync(join(pinnedMemoryPath, 'MEMORY.md'), 'utf8')).toBe(
+      'local-memory',
+    )
+  })
+
+  it('still replaces regular local memory and records the synced snapshot', async () => {
+    const workspace = tempRoot('snapshot-replace-workspace')
+    const configDir = tempRoot('snapshot-replace-config')
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+
+    const agentType = 'snapshot-replace'
+    const snapshotDir = getSnapshotDirForAgent(agentType, workspace)
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFileSync(join(snapshotDir, 'MEMORY.md'), 'replacement-memory')
+    writeFileSync(join(snapshotDir, 'NOTES.md'), 'replacement-notes')
+
+    const localMemoryDir = getAgentMemoryDir(agentType, 'user', workspace)
+    mkdirSync(localMemoryDir, { recursive: true })
+    writeFileSync(join(localMemoryDir, 'MEMORY.md'), 'old-memory')
+    writeFileSync(join(localMemoryDir, 'ORPHAN.md'), 'orphan-memory')
+    writeFileSync(join(localMemoryDir, 'keep.txt'), 'keep-me')
+
+    const snapshotTimestamp = '2026-07-15T00:00:00.000Z'
+    await replaceFromSnapshot(
+      agentType,
+      'user',
+      snapshotTimestamp,
+      workspace,
+    )
+
+    expect(readFileSync(join(localMemoryDir, 'MEMORY.md'), 'utf8')).toBe(
+      'replacement-memory',
+    )
+    expect(readFileSync(join(localMemoryDir, 'NOTES.md'), 'utf8')).toBe(
+      'replacement-notes',
+    )
+    expect(() => lstatSync(join(localMemoryDir, 'ORPHAN.md'))).toThrow()
+    expect(readFileSync(join(localMemoryDir, 'keep.txt'), 'utf8')).toBe(
+      'keep-me',
+    )
+    expect(
+      JSON.parse(
+        readFileSync(join(localMemoryDir, '.snapshot-synced.json'), 'utf8'),
+      ),
+    ).toEqual({ syncedFrom: snapshotTimestamp })
+  })
+
+  it('does not replace or delete a multiply-linked memory file', async () => {
+    const workspace = tempRoot('snapshot-hardlink-workspace')
+    const configDir = tempRoot('snapshot-hardlink-config')
+    const external = tempRoot('snapshot-hardlink-external')
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+
+    const agentType = 'snapshot-hardlink'
+    const snapshotDir = getSnapshotDirForAgent(agentType, workspace)
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFileSync(join(snapshotDir, 'MEMORY.md'), 'replacement-memory')
+
+    const externalMemory = join(external, 'outside-memory.md')
+    writeFileSync(externalMemory, 'external-memory')
+    const localMemoryDir = getAgentMemoryDir(agentType, 'user', workspace)
+    mkdirSync(localMemoryDir, { recursive: true })
+    const linkedMemory = join(localMemoryDir, 'MEMORY.md')
+    linkSync(externalMemory, linkedMemory)
+
+    await replaceFromSnapshot(
+      agentType,
+      'user',
+      '2026-07-15T00:00:00.000Z',
+      workspace,
+    )
+
+    expect(readFileSync(externalMemory, 'utf8')).toBe('external-memory')
+    expect(readFileSync(linkedMemory, 'utf8')).toBe('external-memory')
+  })
+
+  it('initializes a user snapshot before binding the exact prompt fingerprint', async () => {
+    const workspaceA = tempRoot('snapshot-workspace-a')
+    const workspaceB = tempRoot('snapshot-workspace-b')
+    const configDir = tempRoot('snapshot-config')
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+    __setPluginAgentsLoaderForTesting(async () => [])
+
+    const agentsDir = join(workspaceA, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      join(agentsDir, 'snapshot-worker.md'),
+      `---
+name: snapshot-worker
+description: Snapshot worker
+memory: user
+---
+Snapshot role prompt.
+`,
+    )
+    const snapshotDir = getSnapshotDirForAgent('snapshot-worker', workspaceA)
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFileSync(
+      join(snapshotDir, 'snapshot.json'),
+      JSON.stringify({ updatedAt: '2026-07-15T00:00:00.000Z' }),
+    )
+    writeFileSync(join(snapshotDir, 'MEMORY.md'), 'workspace-a-snapshot')
+    process.chdir(workspaceB)
+
+    const firstCatalog = await loadFreshAgentDefinitions(workspaceA)
+    const first = firstCatalog.activeAgents.find(
+      definition => definition.agentType === 'snapshot-worker',
+    )
+    expect(first).toBeDefined()
+    expect(first?.getSystemPrompt()).toContain('workspace-a-snapshot')
+    const fingerprint = requireAgentDefinitionRoleFingerprint(first!)
+
+    const secondCatalog = await loadFreshAgentDefinitions(workspaceA)
+    const second = secondCatalog.activeAgents.find(
+      definition => definition.agentType === 'snapshot-worker',
+    )
+    expect(second).toBeDefined()
+    expect(requireAgentDefinitionRoleFingerprint(second!)).toBe(fingerprint)
+  })
+})

--- a/runtime/tests/tools/AgentTool/inProcessRunner.wiring.test.ts
+++ b/runtime/tests/tools/AgentTool/inProcessRunner.wiring.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const capture = vi.hoisted(() => ({
+  definitions: [] as Array<Record<string, unknown>>,
+  abort: undefined as (() => void) | undefined,
+}))
+
+vi.mock('../../../src/tools/AgentTool/runAgent.js', () => ({
+  runAgent: (params: { agentDefinition: Record<string, unknown> }) =>
+    (async function* () {
+      capture.definitions.push(params.agentDefinition)
+      capture.abort?.()
+    })(),
+}))
+
+vi.mock('../../../src/utils/tasks.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../src/utils/tasks.js')>()),
+  listTasks: vi.fn(async () => []),
+  claimTask: vi.fn(async () => ({ success: false })),
+  updateTask: vi.fn(async () => undefined),
+}))
+
+vi.mock('../../../src/utils/task/diskOutput.js', () => ({
+  evictTaskOutput: vi.fn(async () => undefined),
+}))
+
+vi.mock('../../../src/utils/task/framework.js', () => ({
+  evictTerminalTask: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/sdkEventQueue.js', () => ({
+  emitTaskTerminatedSdk: vi.fn(),
+}))
+
+describe('in-process teammate production runner policy wiring', () => {
+  it('passes the selected restrictive definition into runAgent', async () => {
+    const abortController = new AbortController()
+    capture.definitions.length = 0
+    capture.abort = () => abortController.abort('captured')
+    const taskId = 'task-restrictive-runner'
+    let appState = {
+      tasks: {
+        [taskId]: {
+          type: 'in_process_teammate',
+          status: 'running',
+          permissionMode: 'plan',
+          messages: [],
+          pendingUserMessages: [],
+          isIdle: false,
+          shutdownRequested: false,
+          lastReportedToolCount: 0,
+          lastReportedTokenCount: 0,
+        },
+      },
+    }
+    const setAppState = (updater: (state: typeof appState) => typeof appState) => {
+      appState = updater(appState)
+    }
+    const { runInProcessTeammate } = await import(
+      '../../../src/utils/swarm/inProcessRunner.js'
+    )
+
+    const result = await runInProcessTeammate({
+      identity: {
+        agentId: 'scanner@team',
+        agentName: 'scanner',
+        teamName: 'team',
+        planModeRequired: false,
+        parentSessionId: 'parent-session',
+      },
+      taskId,
+      prompt: 'Inspect only.',
+      agentDefinition: {
+        agentType: 'readonly-scanner',
+        whenToUse: 'Read-only scanner',
+        source: 'built-in',
+        baseDir: 'built-in',
+        tools: ['Read'],
+        disallowedTools: ['Write'],
+        permissionMode: 'plan',
+        getSystemPrompt: () => 'Never mutate files.',
+      },
+      teammateContext: {
+        agentId: 'scanner@team',
+        agentName: 'scanner',
+        teamName: 'team',
+        planModeRequired: false,
+        parentSessionId: 'parent-session',
+        isInProcess: true,
+        abortController,
+      },
+      toolUseContext: {
+        abortController,
+        options: {
+          tools: [],
+          mainLoopModel: 'test-model',
+          mcpClients: [],
+        },
+        getAppState: () => appState,
+        setAppState,
+      } as never,
+      abortController,
+      systemPrompt: 'Teammate system prompt.',
+      systemPromptMode: 'replace',
+    })
+
+    expect(result.success).toBe(true)
+    expect(capture.definitions).toHaveLength(1)
+    expect(capture.definitions[0]).toMatchObject({
+      agentType: 'readonly-scanner',
+      source: 'built-in',
+      tools: expect.arrayContaining(['Read']),
+      disallowedTools: ['Write'],
+      permissionMode: 'plan',
+    })
+    expect(capture.definitions[0]?.tools).not.toContain('*')
+  })
+})

--- a/runtime/tests/tools/AgentTool/inProcessRunner.workspace.test.ts
+++ b/runtime/tests/tools/AgentTool/inProcessRunner.workspace.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TeammateIdentity } from '../../../src/tasks/InProcessTeammateTask/types.js'
+import type { AgentDefinition } from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import { resolveInProcessAgentDefinition } from '../../../src/utils/swarm/inProcessRolePolicy.js'
+
+const identity: TeammateIdentity = {
+  agentId: 'scanner@team',
+  agentName: 'scanner',
+  teamName: 'team',
+  planModeRequired: false,
+  parentSessionId: 'parent',
+}
+
+describe('in-process teammate role policy', () => {
+  it('preserves a restrictive built-in allowlist, denylist, and permission mode', () => {
+    const selected: AgentDefinition = {
+      agentType: 'scanner',
+      whenToUse: 'Read-only scanner',
+      source: 'built-in',
+      baseDir: 'built-in',
+      tools: ['Read'],
+      disallowedTools: ['Write'],
+      permissionMode: 'plan',
+      getSystemPrompt: () => 'Inspect without mutation.',
+    }
+
+    const resolved = resolveInProcessAgentDefinition({
+      identity,
+      teammateSystemPrompt: 'Teammate scanner prompt',
+      agentDefinition: selected,
+    })
+    expect(resolved).toMatchObject({
+      agentType: 'scanner',
+      source: 'built-in',
+      disallowedTools: ['Write'],
+      permissionMode: 'plan',
+    })
+    expect(resolved.tools).not.toContain('*')
+    expect(resolved.tools).toContain('Read')
+    expect(resolved.disallowedTools).toContain('Write')
+  })
+
+  it('lets mandatory plan mode override a weaker definition mode', () => {
+    const resolved = resolveInProcessAgentDefinition({
+      identity: { ...identity, planModeRequired: true },
+      teammateSystemPrompt: 'Plan first.',
+      agentDefinition: {
+        agentType: 'worker',
+        whenToUse: 'Worker',
+        source: 'projectSettings',
+        permissionMode: 'acceptEdits',
+        getSystemPrompt: () => 'Work.',
+      },
+    })
+    expect(resolved.permissionMode).toBe('plan')
+  })
+})

--- a/runtime/tests/tools/AgentTool/loadAgentsDir.test.ts
+++ b/runtime/tests/tools/AgentTool/loadAgentsDir.test.ts
@@ -1,8 +1,15 @@
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  linkSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { getAgentColor } from './agentColorManager.js'
 import {
@@ -13,17 +20,26 @@ import {
   __setMarkdownAgentDirsForTesting,
   __setPluginAgentCacheClearerForTesting,
   __setPluginAgentsLoaderForTesting,
+  bindAgentDefinitionToWorkspace,
   clearAgentDefinitionsCache,
   filterAgentsByMcpRequirements,
+  findAgentDefinitionByType,
   getActiveAgentsFromList,
   getAgentDefinitionsWithOverrides,
+  loadFreshAgentDefinitions,
   parseAgentFromJson,
   parseAgentFromMarkdown,
   parseAgentsFromJson,
+  requireAgentDefinitionRoleFingerprint,
   type AgentDefinition,
   type PluginAgentDefinition,
 } from './loadAgentsDir.js'
 import { getPrompt } from './prompt.js'
+import {
+  _resetAgentRolesForTesting,
+  createAgentRoleWorkspace,
+  registerAgentRole,
+} from '../../agents/role.js'
 
 const allSettingSources = [
   'userSettings',
@@ -34,6 +50,8 @@ const allSettingSources = [
 ] as const
 
 type SettingSourceForTesting = (typeof allSettingSources)[number]
+
+const temporaryRoots: string[] = []
 
 function agent(agentType: string, source: AgentDefinition['source']): AgentDefinition {
   return {
@@ -47,9 +65,16 @@ function agent(agentType: string, source: AgentDefinition['source']): AgentDefin
 
 function tempAgentDir(): string {
   const root = mkdtempSync(join(tmpdir(), 'agenc-agent-loader-'))
+  temporaryRoots.push(root)
   const dir = join(root, '.agenc', 'agents')
   mkdirSync(dir, { recursive: true })
   return dir
+}
+
+function tempWorkspaceRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `agenc-agent-${label}-`))
+  temporaryRoots.push(root)
+  return root
 }
 
 async function getAllowedSettingSourcesForTesting(): Promise<
@@ -70,9 +95,136 @@ afterEach(async () => {
   __setPluginAgentCacheClearerForTesting(undefined)
   __setPluginAgentsLoaderForTesting(undefined)
   clearAgentDefinitionsCache()
+  _resetAgentRolesForTesting()
+  vi.unstubAllEnvs()
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
 })
 
 describe('AgentTool loadAgentsDir adapter', () => {
+  test('prefers an exact restrictive public name over an earlier canonical alias', () => {
+    const explorer = agent('explorer', 'built-in')
+    const exactScanner = {
+      ...agent('scanner', 'projectSettings'),
+      disallowedTools: ['Write'],
+      permissionMode: 'plan' as const,
+    }
+
+    expect(
+      findAgentDefinitionByType([explorer, exactScanner], 'scanner'),
+    ).toBe(exactScanner)
+  })
+
+  test('binds rendered prompt bytes so later memory changes cannot alter execution', () => {
+    let prompt = 'snapshot one'
+    const bound = bindAgentDefinitionToWorkspace(
+      {
+        ...agent('mutable-memory', 'projectSettings'),
+        getSystemPrompt: () => prompt,
+      },
+      createAgentRoleWorkspace('/workspace/a'),
+    )
+    const fingerprint = requireAgentDefinitionRoleFingerprint(bound)
+
+    prompt = 'snapshot two'
+
+    expect(bound.getSystemPrompt()).toBe('snapshot one')
+    expect(requireAgentDefinitionRoleFingerprint(bound)).toBe(fingerprint)
+  })
+
+  test('includes executable callback identity in built-in fingerprints', () => {
+    const base = {
+      ...agent('callback-agent', 'built-in'),
+      callback: () => undefined,
+    }
+    const changed = {
+      ...base,
+      callback: function changedCallback() {
+        return undefined
+      },
+    }
+
+    expect(
+      requireAgentDefinitionRoleFingerprint(base),
+    ).not.toBe(requireAgentDefinitionRoleFingerprint(changed))
+  })
+
+  test('never imports agent files through cross-workspace file or directory symlinks', async () => {
+    const workspaceA = mkdtempSync(join(tmpdir(), 'agenc-agent-authority-a-'))
+    const workspaceB = mkdtempSync(join(tmpdir(), 'agenc-agent-authority-b-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'agenc-agent-config-'))
+    try {
+      vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+      __setPluginAgentsLoaderForTesting(async () => [])
+      const agentsA = join(workspaceA, '.agenc', 'agents')
+      const agentsB = join(workspaceB, '.agenc', 'agents')
+      mkdirSync(agentsA, { recursive: true })
+      mkdirSync(agentsB, { recursive: true })
+      writeFileSync(
+        join(agentsA, 'local.md'),
+        `---\nname: authority-local\ndescription: Local role\n---\nLocal prompt.\n`,
+      )
+      writeFileSync(
+        join(agentsB, 'external-file.md'),
+        `---\nname: authority-external-file\ndescription: External role\n---\nExternal prompt.\n`,
+      )
+      writeFileSync(
+        join(agentsB, 'external-directory.md'),
+        `---\nname: authority-external-directory\ndescription: External directory role\n---\nExternal directory prompt.\n`,
+      )
+      symlinkSync(
+        join(agentsB, 'external-file.md'),
+        join(agentsA, 'linked-file.md'),
+      )
+      symlinkSync(agentsB, join(agentsA, 'linked-directory'), 'dir')
+
+      const assertCatalog = async (): Promise<void> => {
+        const catalog = await loadFreshAgentDefinitions(workspaceA)
+        const types = catalog.activeAgents.map(definition => definition.agentType)
+        expect(types).toContain('authority-local')
+        expect(types).not.toContain('authority-external-file')
+        expect(types).not.toContain('authority-external-directory')
+      }
+
+      vi.stubEnv('AGENC_USE_NATIVE_FILE_SEARCH', '1')
+      await assertCatalog()
+      vi.stubEnv('AGENC_USE_NATIVE_FILE_SEARCH', '')
+      clearAgentDefinitionsCache()
+      await assertCatalog()
+      __setMarkdownAgentDirsForTesting([
+        { dir: agentsA, source: 'projectSettings' },
+      ])
+      await assertCatalog()
+    } finally {
+      rmSync(workspaceA, { recursive: true, force: true })
+      rmSync(workspaceB, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
+  test('never imports a hardlinked markdown agent into a workspace catalog', async () => {
+    const workspace = tempWorkspaceRoot('hardlinked-catalog')
+    const external = tempWorkspaceRoot('hardlinked-external')
+    const configDir = tempWorkspaceRoot('hardlinked-config')
+    const agentsDir = join(workspace, '.agenc', 'agents')
+    const externalFile = join(external, 'outside.md')
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      externalFile,
+      `---\nname: hardlinked-external\ndescription: External role\n---\nExternal prompt.\n`,
+    )
+    linkSync(externalFile, join(agentsDir, 'hardlinked.md'))
+    vi.stubEnv('AGENC_CONFIG_DIR', configDir)
+    __setPluginAgentsLoaderForTesting(async () => [])
+
+    const catalog = await loadFreshAgentDefinitions(workspace)
+
+    expect(
+      catalog.allAgents.map(definition => definition.agentType),
+    ).not.toContain('hardlinked-external')
+  })
+
   test('applies source precedence when active agents collide by type', () => {
     const active = getActiveAgentsFromList([
       agent('same', 'built-in'),
@@ -317,7 +469,7 @@ Should be disabled with project settings.
     )
   })
 
-  test('deduplicates symlinked markdown agents through shared discovery', async () => {
+  test('skips symlinked markdown agents instead of granting link-tier authority', async () => {
     const root = mkdtempSync(join(tmpdir(), 'agenc-agent-symlink-dedupe-'))
     const config = join(root, 'config')
     const userDir = join(config, 'agents')
@@ -346,7 +498,7 @@ Only load once.
         agent => agent.agentType === 'deduped-agent',
       )
       expect(deduped).toHaveLength(1)
-      expect(deduped[0]?.source).toBe('userSettings')
+      expect(deduped[0]?.source).toBe('projectSettings')
     } finally {
       if (previousConfigDir === undefined) {
         delete process.env.AGENC_CONFIG_DIR
@@ -401,6 +553,55 @@ Review local changes.
     expect(getAgentColor('plugin-helper')).toBe('red_FOR_SUBAGENTS_ONLY')
   })
 
+  test('fingerprints the exact executable definition and rejects stale metadata', () => {
+    const workspace = createAgentRoleWorkspace('/tmp')
+    const original = bindAgentDefinitionToWorkspace(
+      {
+        ...agent('guarded', 'projectSettings'),
+        disallowedTools: ['Write'],
+        permissionMode: 'plan',
+      },
+      workspace,
+    )
+    expect(requireAgentDefinitionRoleFingerprint(original)).toMatch(
+      /^[a-f0-9]{64}$/u,
+    )
+
+    const changed = {
+      ...original,
+      disallowedTools: [],
+      permissionMode: 'acceptEdits' as const,
+    }
+    expect(() => requireAgentDefinitionRoleFingerprint(changed)).toThrow(
+      'stale or invalid role fingerprint metadata',
+    )
+  })
+
+  test('keeps a same-named plugin definition distinct from the built-in role', async () => {
+    const pluginAgent: PluginAgentDefinition = {
+      agentType: 'worker',
+      whenToUse: 'Plugin worker',
+      source: 'plugin',
+      plugin: 'same-name',
+      disallowedTools: ['Write'],
+      permissionMode: 'plan',
+      getSystemPrompt: () => 'plugin worker prompt',
+    }
+    __setMarkdownAgentDirsForTesting([])
+    __setPluginAgentsLoaderForTesting(async () => [pluginAgent])
+
+    const catalog = await loadFreshAgentDefinitions('/tmp')
+    const selected = catalog.activeAgents.find(a => a.agentType === 'worker')
+    expect(selected).toMatchObject({
+      source: 'plugin',
+      plugin: 'same-name',
+      disallowedTools: ['Write'],
+    })
+    expect(() =>
+      requireAgentDefinitionRoleFingerprint(selected!),
+    ).not.toThrow()
+  })
+
   test('keeps built-ins and reports malformed markdown files', async () => {
     const dir = tempAgentDir()
     writeFileSync(
@@ -439,7 +640,7 @@ Broken prompt.
     expect(cleared).toBe(1)
   })
 
-  test('projects registered AgenC roles into built-in agent definitions', async () => {
+  test('projects built-in AgenC roles into built-in agent definitions', async () => {
     __setPluginAgentsLoaderForTesting(async () => [])
     __setMarkdownAgentDirsForTesting([])
 
@@ -448,6 +649,93 @@ Broken prompt.
     expect(definitions.activeAgents.every(agent => agent.source === 'built-in')).toBe(
       true,
     )
+  })
+
+  test('merges workspace-scoped programmatic roles into the canonical fresh catalog', async () => {
+    const workspaceA = tempWorkspaceRoot('programmatic-a')
+    const workspaceB = tempWorkspaceRoot('programmatic-b')
+    const roleA = createAgentRoleWorkspace(workspaceA)
+    const roleB = createAgentRoleWorkspace(workspaceB)
+    registerAgentRole(roleA, {
+      name: 'programmatic-reviewer',
+      config: {
+        description: 'Reviewer for A',
+        systemPrompt: 'A strict prompt',
+        model: 'model-a',
+        allowlist: ['FileRead'],
+        disallowlist: ['Write'],
+        reasoningEffort: 'high',
+      },
+    })
+    registerAgentRole(roleB, {
+      name: 'programmatic-reviewer',
+      config: {
+        description: 'Reviewer for B',
+        systemPrompt: 'B isolated prompt',
+        model: 'model-b',
+      },
+    })
+    __setPluginAgentsLoaderForTesting(async () => [])
+    __setMarkdownAgentDirsForTesting([])
+
+    const [catalogA, catalogB] = await Promise.all([
+      loadFreshAgentDefinitions(workspaceA),
+      loadFreshAgentDefinitions(workspaceB),
+    ])
+    const selectedA = findAgentDefinitionByType(
+      catalogA.activeAgents,
+      'programmatic-reviewer',
+    )
+    const selectedB = findAgentDefinitionByType(
+      catalogB.activeAgents,
+      'programmatic-reviewer',
+    )
+
+    expect(catalogA.agentRoleWorkspaceId).toBe(roleA.id)
+    expect(selectedA).toMatchObject({
+      source: 'projectSettings',
+      whenToUse: 'Reviewer for A',
+      model: 'model-a',
+      tools: ['FileRead'],
+      disallowedTools: ['Write'],
+      effort: 'high',
+    })
+    expect(selectedA?.getSystemPrompt()).toBe('A strict prompt')
+    expect(selectedB).toMatchObject({ model: 'model-b' })
+    expect(selectedB?.getSystemPrompt()).toBe('B isolated prompt')
+    expect(selectedA?.agentRoleFingerprint).not.toBe(
+      selectedB?.agentRoleFingerprint,
+    )
+  })
+
+  test('keeps workspace programmatic roles in the simple-mode catalog', async () => {
+    const workspace = tempWorkspaceRoot('programmatic-simple')
+    const roleWorkspace = createAgentRoleWorkspace(workspace)
+    registerAgentRole(roleWorkspace, {
+      name: 'programmatic-simple-reviewer',
+      config: {
+        description: 'Simple-mode reviewer',
+        systemPrompt: 'Review without writing.',
+        allowlist: ['FileRead'],
+        disallowlist: ['Write'],
+      },
+    })
+    vi.stubEnv('AGENC_SIMPLE', '1')
+
+    const catalog = await loadFreshAgentDefinitions(workspace)
+    const selected = findAgentDefinitionByType(
+      catalog.activeAgents,
+      'programmatic-simple-reviewer',
+    )
+
+    expect(catalog.agentRoleWorkspaceId).toBe(roleWorkspace.id)
+    expect(selected).toMatchObject({
+      source: 'projectSettings',
+      tools: ['FileRead'],
+      disallowedTools: ['Write'],
+      agentRoleFingerprint: expect.any(String),
+    })
+    expect(selected?.getSystemPrompt()).toBe('Review without writing.')
   })
 
   test('renders full AgentTool guidance for non-coordinator prompts', async () => {

--- a/runtime/tests/tools/AgentTool/resumeAgent.test.ts
+++ b/runtime/tests/tools/AgentTool/resumeAgent.test.ts
@@ -1,0 +1,396 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const resumeToolPoolCapture = vi.hoisted(() => ({ modes: [] as unknown[] }))
+
+vi.mock('../../../src/tools.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../src/tools.js')>()),
+  assembleToolPool: (permissionContext: { readonly mode: unknown }) => {
+    resumeToolPoolCapture.modes.push(permissionContext.mode)
+    return [{ name: 'Read' }]
+  },
+}))
+import {
+  resetStateForTests,
+  setOriginalCwd,
+  switchSession,
+} from '../../../src/bootstrap/state.js'
+import { createAgentRoleWorkspace } from '../../../src/agents/role.js'
+import { runWithCurrentRuntimeSession } from '../../../src/session/current-session.js'
+import type { Session } from '../../../src/session/session.js'
+import {
+  getAgentMemoryDir,
+} from '../../../src/tools/AgentTool/agentMemory.js'
+import {
+  __setPluginAgentsLoaderForTesting,
+  clearAgentDefinitionsCache,
+  loadFreshAgentDefinitions,
+  requireAgentDefinitionRoleFingerprint,
+  type AgentDefinition,
+} from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import {
+  __setResumeAgentLaunchForTesting,
+  resolveAgentDefinitionForResume,
+  resumeAgentBackground,
+  type ResumeAgentLaunchPreflight,
+} from '../../../src/tools/AgentTool/resumeAgent.js'
+import type { ToolUseContext } from '../../../src/tools/Tool.js'
+import { getDefaultAppState } from '../../../src/tui/state/AppStateStore.js'
+import {
+  getAgentTranscriptPath,
+  readAgentMetadata,
+  resetProjectForTesting,
+  writeAgentMetadata,
+} from '../../../src/utils/sessionStorage.js'
+
+const tempRoots: string[] = []
+const boundarySessionId = '00000000-0000-4000-8000-000000000223'
+
+afterEach(() => {
+  __setPluginAgentsLoaderForTesting(undefined)
+  __setResumeAgentLaunchForTesting(undefined)
+  resumeToolPoolCapture.modes.length = 0
+  clearAgentDefinitionsCache()
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  resetProjectForTesting()
+  resetStateForTests()
+  vi.unstubAllEnvs()
+})
+
+function configureBoundarySession(root: string): Session {
+  vi.stubEnv('AGENC_CONFIG_DIR', join(root, 'config'))
+  resetStateForTests()
+  resetProjectForTesting()
+  setOriginalCwd(root)
+  switchSession(boundarySessionId as never, null)
+  return {
+    roleWorkspace: createAgentRoleWorkspace(root),
+  } as unknown as Session
+}
+
+function writeBoundaryTranscript(agentId: string, cwd: string): void {
+  const transcriptPath = getAgentTranscriptPath(agentId as never)
+  mkdirSync(dirname(transcriptPath), { recursive: true })
+  writeFileSync(
+    transcriptPath,
+    `${JSON.stringify({
+      type: 'user',
+      uuid: '00000000-0000-4000-8000-000000000001',
+      parentUuid: null,
+      timestamp: '2026-07-15T00:00:00.000Z',
+      cwd,
+      userType: 'external',
+      sessionId: boundarySessionId,
+      version: 'test',
+      isSidechain: true,
+      isMeta: false,
+      agentId,
+      message: { role: 'user', content: 'Original delegated task.' },
+    })}\n`,
+  )
+}
+
+function boundaryContext(
+  workspace: string,
+  activeAgents: AgentDefinition[] = [],
+): ToolUseContext {
+  const agentDefinitions = {
+    agentRoleWorkspaceId: createAgentRoleWorkspace(workspace).id,
+    activeAgents,
+    allAgents: activeAgents,
+  }
+  const defaultState = getDefaultAppState()
+  const appState = {
+    ...defaultState,
+    mainLoopModel: 'test-model',
+    agentDefinitions,
+  }
+  return {
+    options: {
+      agentDefinitions,
+      tools: [],
+      mainLoopModel: 'test-model',
+      mcpClients: [],
+    },
+    contentReplacementState: undefined,
+    getAppState: () => appState,
+    setAppState: vi.fn(),
+  } as unknown as ToolUseContext
+}
+
+function agentDefinition(agentType: string, prompt: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: agentType,
+    source: 'built-in',
+    baseDir: 'built-in',
+    getSystemPrompt: () => prompt,
+  }
+}
+
+describe('AgentTool resume role provenance', () => {
+  it('rejects missing, cross-workspace, and removed role metadata', () => {
+    const workspaceA = createAgentRoleWorkspace('/workspace/a')
+    const workspaceB = createAgentRoleWorkspace('/workspace/b')
+    const agentA = agentDefinition('shared-reviewer', 'workspace A')
+    const agentB = agentDefinition('shared-reviewer', 'workspace B')
+    const metadataA = {
+      agentType: 'shared-reviewer',
+      agentRoleWorkspaceId: workspaceA.id,
+      agentRoleFingerprint: requireAgentDefinitionRoleFingerprint(agentA),
+    }
+    const catalogA = {
+      agentRoleWorkspaceId: workspaceA.id,
+      activeAgents: [agentA],
+    }
+    const catalogB = {
+      agentRoleWorkspaceId: workspaceB.id,
+      activeAgents: [agentB],
+    }
+
+    expect(() =>
+      resolveAgentDefinitionForResume(null, workspaceA, catalogA),
+    ).toThrow('role workspace metadata is missing')
+    expect(() =>
+      resolveAgentDefinitionForResume(
+        { agentType: 'shared-reviewer' },
+        workspaceA,
+        catalogA,
+      ),
+    ).toThrow('agent role workspace provenance is missing')
+    expect(() =>
+      resolveAgentDefinitionForResume(metadataA, workspaceB, catalogB),
+    ).toThrow('agent role workspace mismatch')
+    expect(() =>
+      resolveAgentDefinitionForResume(metadataA, workspaceA, {
+        agentRoleWorkspaceId: workspaceA.id,
+        activeAgents: [],
+      }),
+    ).toThrow("Cannot resume agent type 'shared-reviewer'")
+    expect(() =>
+      resolveAgentDefinitionForResume(metadataA, workspaceA, {
+        agentRoleWorkspaceId: workspaceA.id,
+        activeAgents: [agentB],
+      }),
+    ).toThrow("Cannot resume changed agent type 'shared-reviewer'")
+
+    expect(
+      resolveAgentDefinitionForResume(metadataA, workspaceA, catalogA)
+        .selectedAgent,
+    ).toBe(agentA)
+  })
+
+  it('re-reads an edited same-name role and rejects changed restrictions', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agenc-resume-role-'))
+    tempRoots.push(root)
+    const agentsDir = join(root, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    const rolePath = join(agentsDir, 'worker.md')
+    writeFileSync(
+      rolePath,
+      `---
+name: worker
+description: Guarded worker
+disallowedTools:
+  - Write
+permissionMode: plan
+---
+Guarded prompt.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+
+    const workspace = createAgentRoleWorkspace(root)
+    vi.stubEnv('AGENC_CONFIG_DIR', join(root, 'config'))
+    resetStateForTests()
+    resetProjectForTesting()
+    setOriginalCwd(root)
+    switchSession('00000000-0000-4000-8000-000000000222' as never, null)
+    const firstCatalog = await loadFreshAgentDefinitions(root)
+    const first = firstCatalog.activeAgents.find(
+      definition => definition.agentType === 'worker',
+    )
+    expect(first).toBeDefined()
+    const metadata = {
+      agentType: 'worker',
+      agentRoleWorkspaceId: workspace.id,
+      agentRoleFingerprint: requireAgentDefinitionRoleFingerprint(first!),
+    }
+    const agentId = 'unchanged-custom-role' as never
+    await writeAgentMetadata(agentId, metadata)
+    const persistedMetadata = await readAgentMetadata(agentId, { strict: true })
+    expect(persistedMetadata).toEqual(metadata)
+    expect(
+      resolveAgentDefinitionForResume(
+        persistedMetadata,
+        workspace,
+        await loadFreshAgentDefinitions(root),
+      )
+        .selectedAgent,
+    ).toMatchObject({ agentType: 'worker', permissionMode: 'plan' })
+
+    writeFileSync(
+      rolePath,
+      `---
+name: worker
+description: Guarded worker
+disallowedTools: []
+permissionMode: acceptEdits
+---
+Guarded prompt.
+`,
+    )
+    const secondCatalog = await loadFreshAgentDefinitions(root)
+    const second = secondCatalog.activeAgents.find(
+      definition => definition.agentType === 'worker',
+    )
+    expect(second).toBeDefined()
+    expect(requireAgentDefinitionRoleFingerprint(second!)).not.toBe(
+      metadata.agentRoleFingerprint,
+    )
+    expect(() =>
+      resolveAgentDefinitionForResume(metadata, workspace, secondCatalog),
+    ).toThrow("Cannot resume changed agent type 'worker'")
+  })
+
+  it('rejects an edited role at the resume boundary before launch mutation', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agenc-resume-boundary-edit-'))
+    tempRoots.push(root)
+    const session = configureBoundarySession(root)
+    const agentsDir = join(root, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    const rolePath = join(agentsDir, 'boundary-reviewer.md')
+    writeFileSync(
+      rolePath,
+      `---
+name: boundary-reviewer
+description: Original guarded reviewer
+permissionMode: plan
+disallowedTools:
+  - Write
+---
+Review without mutation.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+    const initialCatalog = await loadFreshAgentDefinitions(root)
+    const initialRole = initialCatalog.activeAgents.find(
+      definition => definition.agentType === 'boundary-reviewer',
+    )
+    expect(initialRole).toBeDefined()
+    const agentId = 'resume-boundary-edited-role'
+    await writeAgentMetadata(agentId as never, {
+      agentType: 'boundary-reviewer',
+      agentRoleWorkspaceId: session.roleWorkspace.id,
+      agentRoleFingerprint: requireAgentDefinitionRoleFingerprint(initialRole!),
+    })
+    writeBoundaryTranscript(agentId, root)
+
+    writeFileSync(
+      rolePath,
+      `---
+name: boundary-reviewer
+description: Changed permissive reviewer
+permissionMode: acceptEdits
+disallowedTools: []
+---
+Review and mutate freely.
+`,
+    )
+    const launch = vi.fn(() => ({
+      agentId,
+      description: 'must not launch',
+      outputFile: '/must-not-launch',
+    }))
+    __setResumeAgentLaunchForTesting(launch)
+
+    await expect(
+      runWithCurrentRuntimeSession(session, () =>
+        resumeAgentBackground({
+          agentId,
+          prompt: 'Continue the review.',
+          toolUseContext: boundaryContext(
+            root,
+            initialCatalog.activeAgents,
+          ),
+          canUseTool: async () => ({ behavior: 'allow' }),
+        }),
+      ),
+    ).rejects.toThrow("Cannot resume changed agent type 'boundary-reviewer'")
+    expect(launch).not.toHaveBeenCalled()
+  })
+
+  it('propagates exact role memory authorization at the resume launch boundary', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agenc-resume-boundary-memory-'))
+    tempRoots.push(root)
+    const session = configureBoundarySession(root)
+    const agentsDir = join(root, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      join(agentsDir, 'memory-reviewer.md'),
+      `---
+name: memory-reviewer
+description: Project-memory reviewer
+memory: project
+permissionMode: plan
+---
+Use only this role's project memory.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+    const catalog = await loadFreshAgentDefinitions(root)
+    const selectedRole = catalog.activeAgents.find(
+      definition => definition.agentType === 'memory-reviewer',
+    )
+    expect(selectedRole).toBeDefined()
+    const agentId = 'resume-boundary-memory-role'
+    await writeAgentMetadata(agentId as never, {
+      agentType: 'memory-reviewer',
+      agentRoleWorkspaceId: session.roleWorkspace.id,
+      agentRoleFingerprint: requireAgentDefinitionRoleFingerprint(selectedRole!),
+    })
+    writeBoundaryTranscript(agentId, root)
+    const memoryDir = getAgentMemoryDir('memory-reviewer', 'project', root)
+    mkdirSync(memoryDir, { recursive: true })
+    writeFileSync(
+      join(memoryDir, 'MEMORY.md'),
+      'memory written by the running agent before resume',
+    )
+    const launch = vi.fn((preflight: ResumeAgentLaunchPreflight) => {
+      expect(preflight.selectedAgent.agentType).toBe('memory-reviewer')
+      expect(preflight.selectedAgent.getSystemPrompt()).toContain(
+        'memory written by the running agent before resume',
+      )
+      expect(preflight.agentContext.memoryAuthorization).toEqual({
+        agentType: 'memory-reviewer',
+        scope: 'project',
+      })
+      expect(preflight.workerPermissionMode).toBe('plan')
+      expect(preflight.availableTools).toEqual([{ name: 'Read' }])
+      return {
+        agentId,
+        description: 'resumed memory reviewer',
+        outputFile: '/test/resume-output',
+      }
+    })
+    __setResumeAgentLaunchForTesting(launch)
+
+    await expect(
+      runWithCurrentRuntimeSession(session, () =>
+        resumeAgentBackground({
+          agentId,
+          prompt: 'Continue using your own memory.',
+          toolUseContext: boundaryContext(root, catalog.activeAgents),
+          canUseTool: async () => ({ behavior: 'allow' }),
+          invokingRequestId: 'resume-request',
+        }),
+      ),
+    ).resolves.toMatchObject({ agentId })
+    expect(launch).toHaveBeenCalledOnce()
+    expect(resumeToolPoolCapture.modes).toEqual(['plan'])
+  })
+})

--- a/runtime/tests/tools/AgentTool/spawnMultiAgent.workspace.test.ts
+++ b/runtime/tests/tools/AgentTool/spawnMultiAgent.workspace.test.ts
@@ -1,0 +1,321 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createAgentRoleWorkspace } from '../../../src/agents/role.js'
+import { runWithCurrentRuntimeSession } from '../../../src/session/current-session.js'
+import type { Session } from '../../../src/session/session.js'
+import {
+  __setPluginAgentsLoaderForTesting,
+  clearAgentDefinitionsCache,
+  type AgentDefinition,
+} from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import {
+  __setSpawnTeammateBackendForTesting,
+  assertTeammateSpawnRoleWorkspace,
+  spawnTeammate,
+  type SpawnTeammateBackend,
+  type SpawnTeammateConfig,
+} from '../../../src/tools/shared/spawnMultiAgent.js'
+import type { ToolUseContext } from '../../../src/tools/Tool.js'
+import { getDefaultAppState } from '../../../src/tui/state/AppStateStore.js'
+import { setIsInteractive } from '../../../src/bootstrap/state.js'
+import {
+  captureTeammateModeSnapshot,
+  clearCliTeammateModeOverride,
+  setCliTeammateModeOverride,
+} from '../../../src/utils/swarm/backends/teammateModeSnapshot.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  __setSpawnTeammateBackendForTesting(undefined)
+  __setPluginAgentsLoaderForTesting(undefined)
+  clearAgentDefinitionsCache()
+  clearCliTeammateModeOverride('auto')
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function tempWorkspace(label: string): string {
+  const workspace = mkdtempSync(join(tmpdir(), `agenc-${label}-`))
+  roots.push(workspace)
+  return workspace
+}
+
+function contextFor(
+  workspace: string,
+  activeAgents: AgentDefinition[] = [],
+  deniedAgentTypes: string[] = [],
+): ToolUseContext {
+  const agentDefinitions = {
+    agentRoleWorkspaceId: createAgentRoleWorkspace(workspace).id,
+    activeAgents,
+    allAgents: activeAgents,
+  }
+  const defaultState = getDefaultAppState()
+  const appState = {
+    ...defaultState,
+    mainLoopModel: 'leader-model',
+    agentDefinitions,
+    toolPermissionContext: {
+      ...defaultState.toolPermissionContext,
+      alwaysDenyRules: deniedAgentTypes.length === 0
+        ? {}
+        : {
+            projectSettings: deniedAgentTypes.map(
+              agentType => `spawn_agent(${agentType})`,
+            ),
+          },
+    },
+  }
+  return {
+    options: {
+      agentDefinitions,
+      tools: [],
+      mainLoopModel: 'leader-model',
+      mcpClients: [],
+    },
+    getAppState: () => appState,
+    setAppState: vi.fn(),
+  } as unknown as ToolUseContext
+}
+
+function configFor(
+  workspace: string,
+  agentType: string,
+): SpawnTeammateConfig {
+  const roleWorkspace = createAgentRoleWorkspace(workspace)
+  return {
+    name: 'boundary-worker',
+    prompt: 'Exercise the public teammate spawn boundary.',
+    team_name: 'boundary-team',
+    cwd: workspace,
+    agent_type: agentType,
+    agent_role_workspace_id: roleWorkspace.id,
+    agent_role_workspace_cwd: roleWorkspace.cwd,
+  }
+}
+
+function sessionFor(workspace: string): Session {
+  return {
+    roleWorkspace: createAgentRoleWorkspace(workspace),
+  } as unknown as Session
+}
+
+function successfulBackend(
+  inspect: (
+    config: SpawnTeammateConfig,
+    context: ToolUseContext,
+  ) => void,
+): SpawnTeammateBackend {
+  return async (config, context) => {
+    inspect(config, context)
+    return {
+      data: {
+        teammate_id: 'boundary-worker@boundary-team',
+        agent_id: 'boundary-worker@boundary-team',
+        agent_type: config.agent_type,
+        model: config.model,
+        name: config.name,
+        tmux_session_name: 'test',
+        tmux_window_name: 'test',
+        tmux_pane_id: 'test',
+      },
+    }
+  }
+}
+
+describe('teammate role workspace preflight', () => {
+  const workspaceA = createAgentRoleWorkspace('/workspace/a')
+
+  it('rejects a pane teammate before spawn when execution cwd changes authority', () => {
+    expect(() =>
+      assertTeammateSpawnRoleWorkspace({
+        parentWorkspace: workspaceA,
+        suppliedWorkspaceId: workspaceA.id,
+        suppliedWorkspaceCwd: workspaceA.cwd,
+        catalogWorkspaceId: workspaceA.id,
+        executionCwd: '/workspace/b',
+        inProcess: false,
+      }),
+    ).toThrow('does not match role workspace')
+  })
+
+  it('allows in-process execution to inherit the validated parent authority', () => {
+    expect(() =>
+      assertTeammateSpawnRoleWorkspace({
+        parentWorkspace: workspaceA,
+        suppliedWorkspaceId: workspaceA.id,
+        suppliedWorkspaceCwd: workspaceA.cwd,
+        catalogWorkspaceId: workspaceA.id,
+        executionCwd: '/workspace/b',
+        inProcess: true,
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects a foreign or unscoped catalog for every backend', () => {
+    for (const catalogWorkspaceId of ['/workspace/b', undefined]) {
+      expect(() =>
+        assertTeammateSpawnRoleWorkspace({
+          parentWorkspace: workspaceA,
+          suppliedWorkspaceId: workspaceA.id,
+          suppliedWorkspaceCwd: workspaceA.cwd,
+          catalogWorkspaceId,
+          executionCwd: workspaceA.cwd,
+          inProcess: true,
+        }),
+      ).toThrow(/workspace (mismatch|provenance is missing)/)
+    }
+  })
+
+  it('fresh-loads the selected role model and restrictions before backend spawn', async () => {
+    const workspace = tempWorkspace('teammate-fresh-model')
+    const agentsDir = join(workspace, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    const rolePath = join(agentsDir, 'boundary-worker.md')
+    writeFileSync(
+      rolePath,
+      `---
+name: boundary-worker
+description: Stale cached definition
+model: stale-model
+permissionMode: default
+---
+Stale prompt.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+    const staleDefinition: AgentDefinition = {
+      agentType: 'boundary-worker',
+      whenToUse: 'Stale cached role',
+      source: 'projectSettings',
+      baseDir: agentsDir,
+      model: 'stale-model',
+      permissionMode: 'default',
+      getSystemPrompt: () => 'Stale prompt.',
+    }
+    const context = contextFor(workspace, [staleDefinition])
+    writeFileSync(
+      rolePath,
+      `---
+name: boundary-worker
+description: Fresh restrictive definition
+model: fresh-role-model
+permissionMode: plan
+disallowedTools:
+  - Write
+---
+Fresh restrictive prompt.
+`,
+    )
+
+    const backend = vi.fn(successfulBackend((config, effectiveContext) => {
+      expect(config.model).toBe('fresh-role-model')
+      expect(
+        effectiveContext.options.agentDefinitions.activeAgents.find(
+          agent => agent.agentType === 'boundary-worker',
+        ),
+      ).toMatchObject({
+        model: 'fresh-role-model',
+        permissionMode: 'plan',
+        disallowedTools: ['Write'],
+      })
+    }))
+    __setSpawnTeammateBackendForTesting(backend)
+
+    await runWithCurrentRuntimeSession(sessionFor(workspace), () =>
+      spawnTeammate(
+        configFor(workspace, 'boundary-worker'),
+        context,
+      ),
+    )
+    expect(backend).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a validated role-bearing pane spawn before any backend mutation', async () => {
+    const workspace = tempWorkspace('teammate-pane-role')
+    const agentsDir = join(workspace, '.agenc', 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+    writeFileSync(
+      join(agentsDir, 'boundary-worker.md'),
+      `---
+name: boundary-worker
+description: Exact pane boundary role
+permissionMode: plan
+---
+Do not execute without exact role provenance.
+`,
+    )
+    __setPluginAgentsLoaderForTesting(async () => [])
+    setCliTeammateModeOverride('tmux')
+    captureTeammateModeSnapshot()
+    setIsInteractive(true)
+    const backend = vi.fn(successfulBackend(() => {
+      throw new Error('pane backend must not run for a role-bearing spawn')
+    }))
+    __setSpawnTeammateBackendForTesting(backend)
+
+    try {
+      await expect(
+        runWithCurrentRuntimeSession(sessionFor(workspace), () =>
+          spawnTeammate(
+            configFor(workspace, 'boundary-worker'),
+            contextFor(workspace),
+          ),
+        ),
+      ).rejects.toThrow(
+        "requires in-process teammate mode; pane teammates cannot enforce exact agent-role provenance",
+      )
+      expect(backend).not.toHaveBeenCalled()
+    } finally {
+      setIsInteractive(false)
+    }
+  })
+
+  it.each([
+    {
+      label: 'requested exact plugin role',
+      requested: 'security-plugin:auditor',
+      denied: 'security-plugin:auditor',
+      pluginAgent: {
+        agentType: 'security-plugin:auditor',
+        whenToUse: 'Plugin auditor',
+        source: 'plugin' as const,
+        plugin: 'security-plugin',
+        getSystemPrompt: () => 'Audit safely.',
+      },
+    },
+    {
+      label: 'selected canonical alias',
+      requested: 'scanner',
+      denied: 'explorer',
+      pluginAgent: undefined,
+    },
+  ])('rejects a denied $label before any backend call', async ({
+    requested,
+    denied,
+    pluginAgent,
+  }) => {
+    const workspace = tempWorkspace('teammate-deny')
+    __setPluginAgentsLoaderForTesting(async () =>
+      pluginAgent === undefined ? [] : [pluginAgent],
+    )
+    const context = contextFor(workspace, [], [denied])
+    const backend = vi.fn(successfulBackend(() => {
+      throw new Error('backend must not run after denial')
+    }))
+    __setSpawnTeammateBackendForTesting(backend)
+
+    await expect(
+      runWithCurrentRuntimeSession(sessionFor(workspace), () =>
+        spawnTeammate(configFor(workspace, requested), context),
+      ),
+    ).rejects.toThrow(`Agent type '${requested}' has been denied`)
+    expect(backend).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -30,6 +30,31 @@ let mockHasConsoleBillingAccess = false;
 let mockWorktreeSession: unknown = null;
 let mockGlobalConfig: Record<string, unknown> = {};
 const mockTuiCommandList = vi.hoisted(() => [] as Array<Record<string, any>>);
+const roleDefinitionProbe = vi.hoisted(() =>
+  vi.fn((_cwd: string) => [
+    {
+      agentType: "default",
+      whenToUse: "Default agent.",
+      source: "built-in",
+      baseDir: "built-in",
+      getSystemPrompt: () => "",
+    },
+    {
+      agentType: "explorer",
+      whenToUse: "Explore code.",
+      source: "built-in",
+      baseDir: "built-in",
+      getSystemPrompt: () => "",
+    },
+    {
+      agentType: "worker",
+      whenToUse: "Execute work.",
+      source: "built-in",
+      baseDir: "built-in",
+      getSystemPrompt: () => "",
+    },
+  ]),
+);
 const fullscreenProbe = vi.hoisted(() => ({
   fullscreen: false,
   mouseTracking: false,
@@ -362,29 +387,7 @@ vi.mock("../../commands.js", () => ({
 }));
 
 vi.mock("../../agents/role-definitions.js", () => ({
-  listAgentRoleDefinitions: () => [
-    {
-      agentType: "default",
-      whenToUse: "Default agent.",
-      source: "built-in",
-      baseDir: "built-in",
-      getSystemPrompt: () => "",
-    },
-    {
-      agentType: "explorer",
-      whenToUse: "Explore code.",
-      source: "built-in",
-      baseDir: "built-in",
-      getSystemPrompt: () => "",
-    },
-    {
-      agentType: "worker",
-      whenToUse: "Execute work.",
-      source: "built-in",
-      baseDir: "built-in",
-      getSystemPrompt: () => "",
-    },
-  ],
+  listAgentRoleDefinitions: roleDefinitionProbe,
 }));
 
 vi.mock("../keybindings/KeybindingProviderSetup.js", async () => {
@@ -792,11 +795,20 @@ function createSession(opts: {
   readonly setDaemonPermissionMode?: (mode: ToolPermissionContext["mode"]) => Promise<unknown>;
   readonly emit?: AgenCBridgeSession["emit"];
   readonly nextInternalSubId?: AgenCBridgeSession["nextInternalSubId"];
+  readonly executionCwd?: string;
+  readonly roleWorkspaceCwd?: string;
+  readonly agentDefinitions?: AgenCBridgeSession["agentDefinitions"];
 } = {}): AgenCBridgeSession {
   const modeSubscribers: Array<() => void> = [];
   const permissionContext = opts.permissionContext ?? PERMISSION_CONTEXT;
+  const executionCwd = opts.executionCwd ?? process.cwd();
+  const roleWorkspaceCwd = opts.roleWorkspaceCwd ?? executionCwd;
   return {
     conversationId: "conversation-app-smoke",
+    roleWorkspace: { id: roleWorkspaceCwd, cwd: roleWorkspaceCwd },
+    ...(opts.agentDefinitions !== undefined
+      ? { agentDefinitions: opts.agentDefinitions }
+      : {}),
     services: {
       permissionModeRegistry: {
         current: () => permissionContext,
@@ -833,6 +845,7 @@ function createSession(opts: {
       displayText: "Conversation rewound",
     }),
     sessionConfiguration: {
+      cwd: executionCwd,
       provider: { slug: "test-provider" },
       collaborationMode: { model: "test-model" },
     },
@@ -1388,10 +1401,14 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
   test("hydrates the TUI app state with registered agent roles", async () => {
     const { AgenCTuiApp } = await import("./App.js");
     providerProbe.appStateProps.length = 0;
+    roleDefinitionProbe.mockClear();
+    const roleWorkspaceCwd = join(tmpdir(), "agenc-tui-role-workspace-a");
+    const executionCwd = join(tmpdir(), "agenc-tui-role-workspace-b");
+    const session = createSession({ roleWorkspaceCwd, executionCwd });
 
     await renderApp(
       <AgenCTuiApp
-        session={createSession()}
+        session={session}
         configStore={{}}
         isInteractive={false}
       />,
@@ -1408,6 +1425,56 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
 
     expect(active).toEqual(expect.arrayContaining(["default", "explorer", "worker"]));
     expect(all).toEqual(expect.arrayContaining(["default", "explorer", "worker"]));
+    expect(roleDefinitionProbe.mock.calls).toEqual([[roleWorkspaceCwd]]);
+  });
+
+  test("uses the session's canonical custom-agent catalog on the first render", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    providerProbe.appStateProps.length = 0;
+    roleDefinitionProbe.mockClear();
+    const roleWorkspaceCwd = join(tmpdir(), "agenc-tui-canonical-catalog");
+    const canonicalCustomAgent = {
+      agentType: "scanner",
+      whenToUse: "Exact restrictive scanner",
+      source: "projectSettings" as const,
+      baseDir: join(roleWorkspaceCwd, ".agenc", "agents"),
+      permissionMode: "plan" as const,
+      disallowedTools: ["Write"],
+      agentRoleFingerprint: "canonical-fingerprint",
+      getSystemPrompt: () => "Exact restrictive scanner prompt",
+    };
+    const session = createSession({
+      roleWorkspaceCwd,
+      executionCwd: join(tmpdir(), "agenc-tui-execution-worktree"),
+      agentDefinitions: {
+        agentRoleWorkspaceId: roleWorkspaceCwd,
+        activeAgents: [canonicalCustomAgent],
+        allAgents: [canonicalCustomAgent],
+      },
+    });
+
+    await renderApp(
+      <AgenCTuiApp
+        session={session}
+        configStore={{}}
+        isInteractive={false}
+      />,
+    );
+
+    const initial = providerProbe.appStateProps.at(-1)?.initialState as {
+      agentDefinitions?: {
+        activeAgents?: Array<Record<string, unknown>>;
+      };
+    };
+    expect(initial.agentDefinitions?.activeAgents).toEqual([
+      expect.objectContaining({
+        agentType: "scanner",
+        permissionMode: "plan",
+        disallowedTools: ["Write"],
+        agentRoleFingerprint: "canonical-fingerprint",
+      }),
+    ]);
+    expect(roleDefinitionProbe).not.toHaveBeenCalled();
   });
 
   test("prioritizes a pending permission overlay over an elicitation overlay", async () => {

--- a/runtime/tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx
+++ b/runtime/tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx
@@ -99,6 +99,7 @@ vi.mock("../../utils/worktree.js", () => ({
 
 vi.mock("../../utils/sessionStorage.js", () => ({
   saveWorktreeState: sessionStorageMock.saveWorktreeState,
+  writeAgentMetadata: vi.fn(async () => undefined),
 }));
 
 vi.mock("./spinner/Spinner.js", () => ({

--- a/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
@@ -86,10 +86,12 @@ vi.mock('../../utils/Shell.js', () => ({
 
 vi.mock('../../utils/sessionStorage', () => ({
   saveWorktreeState: harness.saveWorktreeState,
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('../../utils/sessionStorage.js', () => ({
   saveWorktreeState: harness.saveWorktreeState,
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('../../utils/worktree.js', () => ({

--- a/runtime/tests/tui/components/agents/agentFileUtils.test.ts
+++ b/runtime/tests/tui/components/agents/agentFileUtils.test.ts
@@ -1,17 +1,37 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test } from 'vitest'
 
 import { runWithCwdOverride } from '../../../utils/cwd.js'
-import { saveAgentToFile } from './agentFileUtils.js'
+import {
+  __setAgentFileOperationHookForTesting,
+  deleteAgentFromFile,
+  saveAgentToFile,
+  updateAgentFile,
+} from './agentFileUtils.js'
+import { createAgentRoleWorkspace } from '../../../agents/role.js'
 
 describe('agent file creation', () => {
   test('writes generated project agents to .agenc/agents', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'agenc-generated-agent-'))
+    const roleWorkspace = createAgentRoleWorkspace(cwd)
     try {
       await runWithCwdOverride(cwd, async () => {
         await saveAgentToFile(
+          { roleWorkspace, catalogWorkspaceId: roleWorkspace.id },
           'projectSettings',
           'python-game-reviewer',
           'Use this agent when reviewing the Python guessing game.',
@@ -29,6 +49,263 @@ describe('agent file creation', () => {
       )
     } finally {
       rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a foreign catalog before create, update, or delete mutation', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-authority-'))
+    const foreignRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-foreign-'))
+    const roleWorkspace = createAgentRoleWorkspace(workspaceRoot)
+    const foreignWorkspace = createAgentRoleWorkspace(foreignRoot)
+    const authority = {
+      roleWorkspace,
+      catalogWorkspaceId: foreignWorkspace.id,
+    }
+    const filePath = join(workspaceRoot, '.agenc', 'agents', 'guarded.md')
+    const definition = {
+      agentType: 'guarded',
+      whenToUse: 'Guarded',
+      source: 'projectSettings' as const,
+      getSystemPrompt: () => 'Original',
+    }
+    try {
+      await expect(
+        saveAgentToFile(
+          authority,
+          'projectSettings',
+          'guarded',
+          'Guarded',
+          undefined,
+          'Created',
+        ),
+      ).rejects.toThrow('agent role workspace mismatch')
+      expect(existsSync(filePath)).toBe(false)
+
+      mkdirSync(join(workspaceRoot, '.agenc', 'agents'), { recursive: true })
+      writeFileSync(filePath, 'original', 'utf8')
+      await expect(
+        updateAgentFile(authority, definition, 'Changed', [], 'Changed'),
+      ).rejects.toThrow('agent role workspace mismatch')
+      expect(readFileSync(filePath, 'utf8')).toBe('original')
+
+      await expect(
+        deleteAgentFromFile(authority, definition),
+      ).rejects.toThrow('agent role workspace mismatch')
+      expect(readFileSync(filePath, 'utf8')).toBe('original')
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true })
+      rmSync(foreignRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('create, update, and delete stay in authority A under ambient cwd B', async () => {
+    const authorityRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-authority-a-'))
+    const ambientRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-ambient-b-'))
+    const roleWorkspace = createAgentRoleWorkspace(authorityRoot)
+    const authority = {
+      roleWorkspace,
+      catalogWorkspaceId: roleWorkspace.id,
+    }
+    const authorityPath = join(
+      authorityRoot,
+      '.agenc',
+      'agents',
+      'scoped-helper.md',
+    )
+    const ambientPath = join(
+      ambientRoot,
+      '.agenc',
+      'agents',
+      'scoped-helper.md',
+    )
+    const definition = {
+      agentType: 'scoped-helper',
+      whenToUse: 'Scoped helper',
+      source: 'projectSettings' as const,
+      getSystemPrompt: () => 'Original prompt',
+    }
+    try {
+      await runWithCwdOverride(ambientRoot, async () => {
+        await saveAgentToFile(
+          authority,
+          'projectSettings',
+          'scoped-helper',
+          'Scoped helper',
+          ['Read'],
+          'Original prompt',
+        )
+        expect(existsSync(authorityPath)).toBe(true)
+        expect(existsSync(ambientPath)).toBe(false)
+        chmodSync(authorityPath, 0o640)
+
+        await updateAgentFile(
+          authority,
+          definition,
+          'Updated helper',
+          ['Read'],
+          'Updated prompt',
+        )
+        expect(readFileSync(authorityPath, 'utf8')).toContain('Updated prompt')
+        expect(statSync(authorityPath).mode & 0o777).toBe(0o640)
+        expect(existsSync(ambientPath)).toBe(false)
+
+        await deleteAgentFromFile(authority, definition)
+        expect(existsSync(authorityPath)).toBe(false)
+        expect(existsSync(ambientPath)).toBe(false)
+      })
+    } finally {
+      rmSync(authorityRoot, { recursive: true, force: true })
+      rmSync(ambientRoot, { recursive: true, force: true })
+    }
+  })
+
+  test.each(['.agenc', 'agents'] as const)(
+    'rejects a symlinked %s directory without writing through it',
+    async symlinkedComponent => {
+      const workspaceRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-linked-dir-'))
+      const externalRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-external-dir-'))
+      const roleWorkspace = createAgentRoleWorkspace(workspaceRoot)
+      const authority = {
+        roleWorkspace,
+        catalogWorkspaceId: roleWorkspace.id,
+      }
+      const externalAgentPath = symlinkedComponent === '.agenc'
+        ? join(externalRoot, 'agents', 'escaped.md')
+        : join(externalRoot, 'escaped.md')
+      try {
+        if (symlinkedComponent === '.agenc') {
+          symlinkSync(externalRoot, join(workspaceRoot, '.agenc'), 'dir')
+        } else {
+          mkdirSync(join(workspaceRoot, '.agenc'))
+          symlinkSync(
+            externalRoot,
+            join(workspaceRoot, '.agenc', 'agents'),
+            'dir',
+          )
+        }
+
+        await expect(
+          saveAgentToFile(
+            authority,
+            'projectSettings',
+            'escaped',
+            'Escaped role',
+            undefined,
+            'Must stay in the workspace.',
+          ),
+        ).rejects.toThrow(/trusted|symlink|directory/i)
+        expect(existsSync(externalAgentPath)).toBe(false)
+      } finally {
+        rmSync(workspaceRoot, { recursive: true, force: true })
+        rmSync(externalRoot, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test.each(['symlink', 'hardlink'] as const)(
+    'rejects an existing %s target without changing the external file',
+    async linkType => {
+      const workspaceRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-linked-file-'))
+      const externalRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-external-file-'))
+      const roleWorkspace = createAgentRoleWorkspace(workspaceRoot)
+      const authority = {
+        roleWorkspace,
+        catalogWorkspaceId: roleWorkspace.id,
+      }
+      const agentDir = join(workspaceRoot, '.agenc', 'agents')
+      const externalPath = join(externalRoot, 'outside.md')
+      const targetPath = join(agentDir, 'guarded.md')
+      const definition = {
+        agentType: 'guarded',
+        whenToUse: 'Guarded',
+        source: 'projectSettings' as const,
+        getSystemPrompt: () => 'Original',
+      }
+      try {
+        mkdirSync(agentDir, { recursive: true })
+        writeFileSync(externalPath, 'external original', 'utf8')
+        if (linkType === 'symlink') {
+          symlinkSync(externalPath, targetPath)
+        } else {
+          linkSync(externalPath, targetPath)
+        }
+
+        await expect(
+          updateAgentFile(
+            authority,
+            definition,
+            'Changed',
+            undefined,
+            'Changed prompt',
+          ),
+        ).rejects.toThrow(/regular|single-link|unsafe|symlink|hardlink/i)
+        expect(readFileSync(externalPath, 'utf8')).toBe('external original')
+      } finally {
+        rmSync(workspaceRoot, { recursive: true, force: true })
+        rmSync(externalRoot, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('rejects path components in an agent name before creating a file', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-name-escape-'))
+    const roleWorkspace = createAgentRoleWorkspace(workspaceRoot)
+    const authority = {
+      roleWorkspace,
+      catalogWorkspaceId: roleWorkspace.id,
+    }
+    const escapedPath = join(workspaceRoot, 'escaped.md')
+    try {
+      await expect(
+        saveAgentToFile(
+          authority,
+          'projectSettings',
+          '../../escaped',
+          'Escaped role',
+          undefined,
+          'Must stay in the agent directory.',
+        ),
+      ).rejects.toThrow(/invalid agent filename/i)
+      expect(existsSync(escapedPath)).toBe(false)
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('detects a directory replacement after pinning without writing externally', async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-dir-swap-'))
+    const externalRoot = mkdtempSync(join(tmpdir(), 'agenc-agent-dir-swap-outside-'))
+    const roleWorkspace = createAgentRoleWorkspace(workspaceRoot)
+    const authority = {
+      roleWorkspace,
+      catalogWorkspaceId: roleWorkspace.id,
+    }
+    const agentDir = join(workspaceRoot, '.agenc', 'agents')
+    const movedAgentDir = join(workspaceRoot, '.agenc', 'original-agents')
+    try {
+      mkdirSync(agentDir, { recursive: true })
+      __setAgentFileOperationHookForTesting(async operation => {
+        if (operation.phase !== 'before-commit') return
+        __setAgentFileOperationHookForTesting(undefined)
+        renameSync(agentDir, movedAgentDir)
+        symlinkSync(externalRoot, agentDir, 'dir')
+      })
+
+      await expect(
+        saveAgentToFile(
+          authority,
+          'projectSettings',
+          'pinned',
+          'Pinned role',
+          undefined,
+          'Must stay in the pinned directory.',
+        ),
+      ).rejects.toThrow(/directory|trusted|changed/i)
+      expect(existsSync(join(externalRoot, 'pinned.md'))).toBe(false)
+    } finally {
+      __setAgentFileOperationHookForTesting(undefined)
+      rmSync(workspaceRoot, { recursive: true, force: true })
+      rmSync(externalRoot, { recursive: true, force: true })
     }
   })
 })

--- a/runtime/tests/tui/components/agents/agentFileUtils.wave200-043.coverage.test.ts
+++ b/runtime/tests/tui/components/agents/agentFileUtils.wave200-043.coverage.test.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path'
 import { describe, expect, test } from 'vitest'
 
 import type { AgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
+import { createAgentRoleWorkspace } from '../../../agents/role.js'
 import { runWithCwdOverride } from '../../../utils/cwd.js'
 import {
   deleteAgentFromFile,
@@ -26,6 +27,8 @@ import {
 describe('agent file utilities wave 200 coverage', () => {
   test('formats options and handles custom agent file lifecycle paths', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-file-utils-'))
+    const roleWorkspace = createAgentRoleWorkspace(cwd)
+    const authority = { roleWorkspace, catalogWorkspaceId: roleWorkspace.id }
 
     try {
       await runWithCwdOverride(cwd, async () => {
@@ -62,7 +65,7 @@ describe('agent file utilities wave 200 coverage', () => {
           getNewAgentFilePath({
             source: 'projectSettings',
             agentType: 'triage-helper',
-          }),
+          }, cwd),
         ).toBe(newAgentPath)
         expect(
           getNewRelativeAgentFilePath({
@@ -80,7 +83,7 @@ describe('agent file utilities wave 200 coverage', () => {
           getNewAgentFilePath({
             source: 'flagSettings',
             agentType: 'cli-helper',
-          }),
+          }, cwd),
         ).toThrow('Cannot get directory path for flagSettings agents')
 
         const agentDir = join(cwd, '.agenc', 'agents')
@@ -95,7 +98,7 @@ describe('agent file utilities wave 200 coverage', () => {
           filename: 'stored-helper',
           getSystemPrompt: () => 'old content',
         }
-        expect(getActualAgentFilePath(customAgent)).toBe(storedAgentPath)
+        expect(getActualAgentFilePath(customAgent, cwd)).toBe(storedAgentPath)
         expect(getActualRelativeAgentFilePath(customAgent)).toBe(
           join('.agenc', 'agents', 'stored-helper.md'),
         )
@@ -107,7 +110,7 @@ describe('agent file utilities wave 200 coverage', () => {
           baseDir: 'built-in',
           getSystemPrompt: () => 'built-in prompt',
         }
-        expect(getActualAgentFilePath(builtInAgent)).toBe('Built-in')
+        expect(getActualAgentFilePath(builtInAgent, cwd)).toBe('Built-in')
         expect(getActualRelativeAgentFilePath(builtInAgent)).toBe('Built-in')
 
         const pluginAgent: AgentDefinition = {
@@ -117,7 +120,7 @@ describe('agent file utilities wave 200 coverage', () => {
           plugin: '',
           getSystemPrompt: () => 'plugin prompt',
         }
-        expect(() => getActualAgentFilePath(pluginAgent)).toThrow(
+        expect(() => getActualAgentFilePath(pluginAgent, cwd)).toThrow(
           'Cannot get file path for plugin agents',
         )
         expect(getActualRelativeAgentFilePath(pluginAgent)).toBe(
@@ -125,6 +128,7 @@ describe('agent file utilities wave 200 coverage', () => {
         )
 
         await updateAgentFile(
+          authority,
           customAgent,
           'Use after update.',
           ['Search'],
@@ -142,6 +146,7 @@ describe('agent file utilities wave 200 coverage', () => {
         expect(updated).toContain('memory: local')
 
         await saveAgentToFile(
+          authority,
           'projectSettings',
           'triage-helper',
           'Use for duplicate checks.',
@@ -152,6 +157,7 @@ describe('agent file utilities wave 200 coverage', () => {
         expect(readFileSync(newAgentPath, 'utf8')).not.toContain('\ntools:')
         await expect(
           saveAgentToFile(
+            authority,
             'projectSettings',
             'triage-helper',
             'Use for duplicate checks.',
@@ -160,9 +166,11 @@ describe('agent file utilities wave 200 coverage', () => {
           ),
         ).rejects.toThrow(`Agent file already exists: ${newAgentPath}`)
 
-        await deleteAgentFromFile(customAgent)
+        await deleteAgentFromFile(authority, customAgent)
         expect(existsSync(storedAgentPath)).toBe(false)
-        await expect(deleteAgentFromFile(customAgent)).resolves.toBeUndefined()
+        await expect(
+          deleteAgentFromFile(authority, customAgent),
+        ).resolves.toBeUndefined()
       })
     } finally {
       rmSync(cwd, { recursive: true, force: true })

--- a/runtime/tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
@@ -131,6 +131,7 @@ vi.mock('src/utils/sessionStorage.js', () => ({
   getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
     log.sessionId ?? 'session-1',
   searchSessionsByCustomTitle: vi.fn(async () => harness.sessionTitleMatches),
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('src/utils/suggestions/directoryCompletion.js', () => ({

--- a/runtime/tests/tui/coverage-swarm/swarm-108-components-agents-agentFileUtils.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-108-components-agents-agentFileUtils.test.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import type { AgentDefinition } from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import { createAgentRoleWorkspace } from '../../../src/agents/role.js'
 import { runWithCwdOverride } from '../../../src/utils/cwd.js'
 import {
   deleteAgentFromFile,
@@ -45,6 +46,7 @@ describe('agentFileUtils coverage swarm row 108', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-paths-'))
     const configHome = join(cwd, 'config-home')
     const managedHome = join(cwd, 'managed-home')
+    const roleWorkspace = createAgentRoleWorkspace(cwd)
 
     vi.stubEnv('AGENC_CONFIG_DIR', configHome)
     vi.stubEnv('USER_TYPE', 'ant')
@@ -56,7 +58,7 @@ describe('agentFileUtils coverage swarm row 108', () => {
           getNewAgentFilePath({
             source: 'userSettings',
             agentType: 'user-helper',
-          }),
+          }, cwd),
         ).toBe(join(configHome, 'agents', 'user-helper.md'))
         expect(
           getNewRelativeAgentFilePath({
@@ -69,7 +71,7 @@ describe('agentFileUtils coverage swarm row 108', () => {
           getNewAgentFilePath({
             source: 'policySettings',
             agentType: 'managed-helper',
-          }),
+          }, cwd),
         ).toBe(join(managedHome, '.agenc', 'agents', 'managed-helper.md'))
         expect(
           getNewRelativeAgentFilePath({
@@ -82,16 +84,16 @@ describe('agentFileUtils coverage swarm row 108', () => {
           getNewAgentFilePath({
             source: 'localSettings',
             agentType: 'local-helper',
-          }),
+          }, cwd),
         ).toBe(join(cwd, '.agenc', 'agents', 'local-helper.md'))
         expect(
           getNewRelativeAgentFilePath({
             source: 'localSettings',
             agentType: 'local-helper',
-          }),
+          }, roleWorkspace.cwd),
         ).toBe(join(cwd, '.agenc', 'agents', 'local-helper.md'))
 
-        expect(getActualAgentFilePath(customAgent('user-helper', 'userSettings'))).toBe(
+        expect(getActualAgentFilePath(customAgent('user-helper', 'userSettings'), roleWorkspace.cwd)).toBe(
           join(configHome, 'agents', 'user-helper.md'),
         )
         expect(
@@ -117,14 +119,17 @@ describe('agentFileUtils coverage swarm row 108', () => {
     }
   })
 
-  test('saves user agents and preserves non-existence write errors', async () => {
+  test('saves user agents and rejects nested filename escapes', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-save-'))
     const configHome = join(cwd, 'config-home')
+    const roleWorkspace = createAgentRoleWorkspace(cwd)
+    const authority = { roleWorkspace, catalogWorkspaceId: roleWorkspace.id }
 
     vi.stubEnv('AGENC_CONFIG_DIR', configHome)
 
     try {
       await saveAgentToFile(
+        authority,
         'userSettings',
         'user-helper',
         'Use this helper for user-wide work.',
@@ -138,20 +143,21 @@ describe('agentFileUtils coverage swarm row 108', () => {
       await runWithCwdOverride(cwd, async () => {
         await expect(
           saveAgentToFile(
+            authority,
             'projectSettings',
             'missing-dir/nested-helper',
             'Use this helper when a nested path is requested.',
             ['Read'],
             'This write should fail before content is created.',
           ),
-        ).rejects.toMatchObject({ code: 'ENOENT' })
+        ).rejects.toThrow('invalid agent filename')
       })
     } finally {
       rmSync(cwd, { recursive: true, force: true })
     }
   })
 
-  test('rejects built-in mutations and rethrows delete failures', async () => {
+  test('rejects built-in mutations and unsafe delete targets', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-errors-'))
     const builtInAgent: AgentDefinition = {
       agentType: 'built-in-helper',
@@ -160,10 +166,13 @@ describe('agentFileUtils coverage swarm row 108', () => {
       baseDir: 'built-in',
       getSystemPrompt: () => 'Built-in prompt.',
     }
+    const roleWorkspace = createAgentRoleWorkspace(cwd)
+    const authority = { roleWorkspace, catalogWorkspaceId: roleWorkspace.id }
 
     try {
       await expect(
         saveAgentToFile(
+          authority,
           'built-in',
           'built-in-helper',
           'Use built-in behavior.',
@@ -173,13 +182,14 @@ describe('agentFileUtils coverage swarm row 108', () => {
       ).rejects.toThrow('Cannot save built-in agents')
       await expect(
         updateAgentFile(
+          authority,
           builtInAgent,
           'Use built-in behavior.',
           undefined,
           'Built-in prompt.',
         ),
       ).rejects.toThrow('Cannot update built-in agents')
-      await expect(deleteAgentFromFile(builtInAgent)).rejects.toThrow(
+      await expect(deleteAgentFromFile(authority, builtInAgent)).rejects.toThrow(
         'Cannot delete built-in agents',
       )
 
@@ -189,9 +199,10 @@ describe('agentFileUtils coverage swarm row 108', () => {
 
         await expect(
           deleteAgentFromFile(
+            authority,
             customAgent('blocked-helper', 'projectSettings'),
           ),
-        ).rejects.toMatchObject({ code: 'EISDIR' })
+        ).rejects.toThrow('agent file must be a regular single-link file')
         expect(existsSync(join(agentDir, 'blocked-helper.md'))).toBe(true)
       })
     } finally {

--- a/runtime/tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx
@@ -97,6 +97,7 @@ vi.mock('src/utils/Shell.js', () => ({
 
 vi.mock('src/utils/sessionStorage.js', () => ({
   saveWorktreeState: harness.saveWorktreeState,
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('src/utils/worktree.js', () => ({

--- a/runtime/tests/tui/hooks/useTypeahead.coverage2.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.coverage2.test.tsx
@@ -107,6 +107,7 @@ vi.mock('../../utils/sessionStorage.js', () => ({
   getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
     log.sessionId ?? 'session-1',
   searchSessionsByCustomTitle: vi.fn(async () => []),
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -137,6 +137,7 @@ vi.mock('../../utils/sessionStorage.js', () => ({
     }
     return harness.sessionTitleMatches
   }),
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({

--- a/runtime/tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx
@@ -110,6 +110,7 @@ vi.mock('../../utils/bash/shellCompletion.js', () => ({
 vi.mock('../../utils/sessionStorage.js', () => ({
   getSessionIdFromLog: () => 'session-1',
   searchSessionsByCustomTitle: vi.fn(async () => []),
+  writeAgentMetadata: vi.fn(async () => undefined),
 }))
 
 vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({

--- a/runtime/tests/utils/messageQueueManager.test.ts
+++ b/runtime/tests/utils/messageQueueManager.test.ts
@@ -11,6 +11,7 @@ vi.mock("../bootstrap/state.js", () => ({
 
 vi.mock("./sessionStorage.js", () => ({
   recordQueueOperation: vi.fn(),
+  writeAgentMetadata: vi.fn(async () => undefined),
 }));
 
 import {

--- a/todo.txt
+++ b/todo.txt
@@ -302,7 +302,7 @@ boundary. They are higher leverage than new surface area.
       never 2x, 4x, or cumulatively more.
     - Add canned transport failures and capture every retry payload.
 
-[ ] Close workspace role leakage.
+[x] Close workspace role leakage.
     - Require workspace identity in role lookup and every spawn path.
     - Reject cross-workspace role resolution even when role names collide.
     - Add a two-workspace regression test that fails against the old call site.


### PR DESCRIPTION
## Summary

- bind every role catalog, lookup, spawn, resume, restart, daemon attach, TUI picker, and child/worktree session to one immutable workspace identity
- persist and verify exact role workspace plus definition fingerprints across SQLite edges and atomic AgentTool sidecars
- harden agent role and memory files against cross-workspace access, symlinks, hardlinks, traversal, and observable replacement races
- make rollout state SQLite-authoritative with compare-and-swap closure semantics
- document the accepted boundary and mark the M2 workspace-role leakage item complete

## Local verification

- `npm test` — 1,769 files passed; 15,163 tests passed; 16 skipped; 0 failed
- `npm run check:agent-surface-contract` — all matrices and both loopback TUI scenarios passed
- pre-commit hook — runtime build, package entrypoint check, generated SDK type check, and real-PTY startup smoke passed at 148x40, 120x30, and 80x24 with normal and `--yolo` startup
- independent merge review — READY after atomic sidecar, memory authorization, rollout CAS, and `/agents` filesystem hardening re-review

All verification ran locally. No GitHub-hosted test or release workflow was dispatched and no paid provider was called.