### PR TITLE
feat(runtime): define versioned evaluation suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ obj/
 !/release-toolchain.json
 !/runtime/tsconfig.bundle.json
 !/runtime/src/eval-contract/contract-v1.schema.json
+!/runtime/src/eval-suites/suite-protocol-v1.schema.json
+!/runtime/src/eval-suites/suite-evidence-v1.schema.json
+!/runtime/src/eval-suites/trust-fixture-bundle-v1.schema.json
 !runtime/scripts/hermetic-docker-seccomp.json
 !.mcp.json
 !Anchor.toml
@@ -77,6 +80,7 @@ obj/
 !runtime/eval/tasks/manifest.json
 !runtime/eval/tasks/*/fixture/*.json
 !runtime/eval/tasks/*/solution/*.json
+!runtime/eval/suites/**/*.json
 id.json
 deploy/
 # deploy/ guards deployment state/keys; documentation is exempt.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,9 @@ Everything past the launcher lives in the single runtime workspace
 | `services/` | Concrete provider/API wire layer, caching, and related services |
 | `recovery/` | Crash/recovery helpers for in-flight work |
 | `onboarding/` | Guided `agenc onboard` wizard UI |
-| `eval/` | Agent-eval report schema (runner lives under `runtime/scripts` + `runtime/eval`) |
+| `eval/` | Legacy diagnostic agent-eval report schema (runner lives under `runtime/scripts` + `runtime/eval`) |
+| `eval-contract/` | Immutable task/preregistration/evidence/score contract v1 |
+| `eval-suites/` | Versioned competitive/trust suite definitions, catalog, schedule compiler, and validators |
 | `tui/` | Terminal UI (custom Ink reconciler fork under `tui/ink`) |
 | `entrypoints/` | Public/SDK type entry surfaces |
 | `protocol/` | Marketplace protocol A1/A2 (read-only CLI adapter + types); mutating claim verbs reserved / owner-gated |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | [trajectory-training-data.md](trajectory-training-data.md) | Enable trajectory export and curate SFT/DPO JSONL |
 | [agent-eval-reports.md](agent-eval-reports.md) | Local agent-eval suite, reports, and regression gate |
 | [evaluation-contract-v1.md](evaluation-contract-v1.md) | Versioned real-agent task, preregistration, evidence, and score derivation contract |
+| [evaluation-suites-v1.md](evaluation-suites-v1.md) | Separate versioned competitive-coding and deterministic trust-conformance suite protocols |
 | [ci-required-gates.md](ci-required-gates.md) | Local exact-SHA gates, GitHub App attestation, `main` ruleset, and rollback |
 | [provider-tool-compat.md](provider-tool-compat.md) | Tool JSON-schema root-type requirements for strict providers |
 | [embedded-neovim-buffer.md](embedded-neovim-buffer.md) | BUFFER providers, nvim trust boundary, env knobs |

--- a/docs/evaluation-suites-v1.md
+++ b/docs/evaluation-suites-v1.md
@@ -1,0 +1,278 @@
+# Evaluation suites protocol v1
+
+Status: implemented suite protocol, deterministic plan compilers, strict
+attempt/reset/report evidence envelopes, and committed definitions. This is not
+a fault executor, published baseline, or populated pilot.
+
+The evaluation contract in [`evaluation-contract-v1.md`](evaluation-contract-v1.md)
+pins tasks, systems, preregistration, evidence, and score derivation. It is
+immutable at `1.0.0`, but it did not distinguish coding quality from
+implementation-specific trust conformance or preregister a recovery condition.
+The additive suite protocol closes that boundary without changing evaluation
+contract v1.
+
+## Authoritative artifacts
+
+| Artifact | Purpose |
+| --- | --- |
+| `runtime/src/eval-suites/suite-protocol-v1.schema.json` | Strict input schema; unknown fields and cross-kind shapes fail |
+| `runtime/src/eval-suites/suite-evidence-v1.schema.json` | Separate strict reset, competitive-report, and trust-report envelopes |
+| `runtime/src/eval-suites/validation.ts` | Semantic, release-digest, catalog, schedule, and preregistration-binding validation |
+| `runtime/src/eval-suites/evidence.ts` | Exact task/plan/reset/report joins and pass/failure semantics |
+| `runtime/eval/suites/catalog.json` | Digest-pinned active-definition catalog |
+| `runtime/eval/suites/competitive-coding/1.0.0/definition.json` | Product-neutral competitive coding definition |
+| `runtime/eval/suites/trust-conformance/1.0.0/definition.json` | Deterministic AgenC trust-conformance definition |
+
+Validate the committed catalog without running a task or loading a provider:
+
+```bash
+npm --workspace=@tetsuo-ai/runtime run check:eval-suites -- --json
+```
+
+That command and the committed catalog are source-repository tooling, not a new
+installed `agenc` CLI verb. The validator/plan/report APIs are included in the
+built runtime root export; an executor is deliberately deferred.
+
+The public runtime export exposes the same validators, catalog loader,
+preregistration binder, deterministic plan compilers, and report binders. The legacy
+`runtime/eval/tasks` runner remains a small public diagnostic; it is not silently
+promoted into either suite.
+
+## Competitive coding suite
+
+`agenc-competitive-coding@1.0.0` accepts only real-repository change tasks using
+the existing operator/agent task projection. The exact canonical agent-task
+bytes, repository state, tools, budgets, model configuration, hidden verifier,
+and declared artifacts are identical across systems. Product-reported success
+is diagnostic; the external workspace patch and hidden verifier decide coding
+quality. Unsupported in-scope behavior remains a failure.
+
+Each task/seed has three separately preregistered experiment conditions:
+
+1. `clean`
+2. `coordinator_process_kill`
+3. `client_disconnect`
+
+They are separate evaluation-contract v1 bundles because v1's matrix cell is
+`system × task × seed`; forcing multiple conditions into one bundle would create
+colliding cells. `validateCompetitiveConditionRegistrations` requires all three
+conditions, the same byte-identical suite manifest, identical inputs/systems/
+budgets/scoring/trial design, distinct experiment IDs, and the exact condition
+harness digest.
+
+### Product-neutral recovery schedule
+
+The evaluator owns the fault schedule. An adapter may expose only the standard
+black-box operations `start`, task delivery plus harness receipt, transport
+disconnect/reconnect, coordinator-process-group kill, and result collection. Triggers may
+not inspect AgenC events, daemon methods, run state, tool names, budgets, or a
+competitor's private protocol.
+
+Acceptance is the harness-owned receipt produced only after the exact canonical
+agent-task bytes have been delivered successfully over the harness transport;
+it is not a product-internal "run started" event. The receipt also identifies
+the harness-launched process group and client transport by evidence digest.
+After that receipt records its monotonic timestamp, the compiler chooses a delay
+inside the definition's bounded recovery window. It uses SHA-256 rejection
+sampling over the exact definition digest, suite-manifest digest, task digest,
+task version, preregistered wall-time budget, condition, and seed slot. Callers
+cannot supply a different wall-time range. System identity is deliberately
+absent. The same inputs therefore produce the same unbiased delay and plan
+digest for every product. A task whose budget cannot fit the minimum delay plus
+the maximum observation jitter plus the recovery window is rejected during
+preregistration; the latest permitted observation therefore leaves the entire
+recovery window intact. A fault that never fires is
+an explicit `fault_not_injected` failure; it cannot silently become a clean run.
+Reports store the scheduled delay separately from the observed monotonic
+injection time and accept only the definition's bounded one-second harness
+jitter; they never relabel the target time as the observation.
+
+The kill condition sends `SIGKILL` to only the harness-launched coordinator
+process group, then uses the adapter's restart-and-attach operation. The
+disconnect condition abruptly closes only the harness-owned client transport,
+then reconnects it. Cancellation and product-process restart are different
+semantic operations and are forbidden in the common competitive schedule.
+Competitive recovery is Linux-only until another platform can implement the
+same process/transport semantics; an unsupported platform is explicit, not an
+approximate substitute.
+
+### Competitive report
+
+The result namespace is `agenc.eval.competitive-coding-report@1.0.0`. Its strict
+envelope binds the exact task/agent projection, suite manifest,
+repository/reset recipe, reset receipt,
+harness delivery receipt, process-group/transport evidence, deterministic fault
+plan, run record, external verifier evidence, and final outcome. It reports
+clean Verified Fix Rate, verified fixes and recovery by fault condition, attempts,
+and unsupported outcomes. It does not report deterministic trust-conformance
+metrics, and the definition validator forbids a reporting profile that mixes
+the two suite namespaces into one quality aggregate. Aggregate metric derivation
+and publication remain part of the later reporting checkbox.
+
+## Trust-conformance suite
+
+`agenc-trust-conformance@1.0.0` is AgenC-only and deterministic. It pins the
+offline harness, fake-provider, fake-tool, scenario fixture, initial-state, and
+expected-state digests. Their canonical preimages are retained in the strict
+versioned `fixtures.json` bundle; catalog loading verifies its path, byte size,
+document digest, schema, and every definition-to-fixture/state join. Its compiler
+uses a domain-separated SHA-256 seed per
+definition/scenario/seed slot, ASCII-lexicographic scenario order, and a virtual
+monotonic clock. Network and live provider calls are forbidden. A retry is a new
+recorded attempt; failed evidence is retained.
+
+Exactly seven fault families are required:
+
+| Fault family | Injection boundary | Required result |
+| --- | --- | --- |
+| Restart | after reservation, before model-result commit | reservation recovered once; no duplicate transition; terminal result queryable |
+| Reconnect | after event publish, before cursor acknowledgement | replay complete; duplicates harmless; terminal result queryable |
+| Budget | concurrent child reservations before commit | parent cap conserved; unknown usage held; reconciliation exactly once |
+| Cancellation | parent cancellation after child admission | no new descendant admission; queued/running descendants cancelled; partial evidence retained |
+| Permission | repository requests capability escalation | no capability grant or mutation; denial audited |
+| Event loss | replay retention evicted before reconnect | explicit retention gap; zero hidden loss; terminal result queryable |
+| Uncertain effect | effect dispatched before acknowledgement commit | `unknown_outcome`; dependent mutations stopped; zero automatic replay |
+
+Each scenario pins its boundary, action, timeout, expected invariants, and
+required evidence event taxonomy. Missing a family or swapping an action/boundary
+fails validation. Known product defects remain observable conformance failures;
+the definition never weakens an oracle to make the baseline green.
+
+The result namespace is `agenc.eval.trust-conformance-report@1.0.0`. Its strict
+envelope binds the plan, reset, harness and run receipts, fault observation,
+exact invariant results, required evidence taxonomy, and observed final-state
+digest. A passing report requires the fault to fire, every invariant to pass,
+the exact expected state, every required evidence type, and completion within
+the pinned timeout. Failed attempts retain the evidence they actually observed;
+they never fabricate later events merely to make a valid report. It reports
+Trust Recovery Rate, results per fault family, unknown outcomes, and the
+zero-tolerance counts for policy escapes, duplicated uncertain mutations, and
+hidden event loss. Coding-quality metrics are forbidden in this report.
+
+## Reset, containment, and evidence
+
+Both suites require a content-addressed reset receipt proving a fresh clone and
+empty product state, session, cache, and process tree. `HOME`, tool home, temp,
+sockets, ports, and the environment are isolated or sanitized. Logs/samples are
+not reused across independent trials. Recovery within an intentionally faulted
+run stays in that run; retrying evaluator infrastructure creates a new attempt.
+Each receipt is also bound to the exact system configuration and seed plus
+either the competitive manifest/task/reset recipe/condition or the trust
+scenario, so it cannot be replayed across evaluation cells.
+
+The agent projection never receives verifier commands, bundles, reference
+solutions, provenance, or holdout identity. Hidden artifacts remain under the
+existing separate-principal/remote-custodian policy, keyed commitment, access
+log, complete-matrix seal, and authorized unblinding flow. Publicly derived tasks
+are contamination-resistant, never described as contamination-free.
+
+No new signing or evidence service is introduced. Suite documents reuse RFC 8785
+canonical JSON and domain-separated SHA-256 digests. The digest covers canonical
+document meaning rather than whitespace; the loader rejects invalid UTF-8,
+duplicate keys, symlinks, path escape, file replacement, and oversized input so
+ambiguous byte streams cannot alias one meaning. Future suite executors must
+bind each report's run-record digest to the existing append-only evidence ledger
+and external seal.
+
+## Versioning, migration, and rollback
+
+Every join is exact `kind + suiteId + suiteVersion + documentDigest`. Mutable
+`latest` image tags and implicit catalog selection are forbidden.
+
+- Patch: non-scoring metadata only, with a new immutable document and digest.
+- Minor: a compatible catalog update or competitive task-manifest addition that
+  does not change existing case semantics.
+- Major: scoring, required behavior, schedule/case meaning, or removals.
+- Any task, scenario, schedule, or scoring change creates a new suite version.
+- Adding a trust fault family also requires a new suite-protocol/schema version;
+  protocol v1 intentionally contains exactly these seven families.
+- Published bytes are never edited in place and scores from different versions
+  are not pooled without a separately reviewed bridge study.
+
+The released v1 catalog and definition digests are literal runtime constants;
+the default CLI rejects in-place bytes changed under the same version. Rollback
+selects a prior catalog/definition by its immutable digest. It does not
+rewrite current results or relabel them as belonging to the prior version.
+Evaluation-contract `1.0.0` and legacy diagnostic reports remain readable and
+unchanged.
+
+## Comparator compatibility snapshot
+
+Research refreshed 2026-07-15 against the official
+[Hermes Agent `v2026.7.7.2`](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.7.2) <!-- branding-scan: allow comparator research citation -->
+and [OpenClaw `v2026.7.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1). <!-- branding-scan: allow comparator research citation -->
+The former's asynchronous Runs API is the appropriate neutral disconnect surface;
+killing its one-shot CLI would kill the in-process task. The latter's CLI signal
+handler aborts a run, so `SIGTERM`/`SIGINT` is cancellation, not client
+disconnection; its gateway fallback must also be disabled/pinned to prevent an
+embedded fresh run. These differences are adapter limitations to preregister,
+not reasons to change task inputs or schedule semantics. External workspace
+diffs and hidden verification remain the source of truth for both.
+
+The behavior snapshot is tied to the tagged
+[Hermes one-shot source](https://github.com/NousResearch/hermes-agent/blob/v2026.7.7.2/hermes_cli/oneshot.py) <!-- branding-scan: allow comparator research citation -->
+and [Runs API documentation](https://github.com/NousResearch/hermes-agent/blob/v2026.7.7.2/website/docs/user-guide/features/api-server.md), <!-- branding-scan: allow comparator research citation -->
+plus the tagged [OpenClaw gateway/signal source](https://github.com/openclaw/openclaw/blob/v2026.7.1/src/commands/agent-via-gateway.ts). <!-- branding-scan: allow comparator research citation -->
+
+Comparator adapters and paid runs are intentionally deferred to their own M1
+checkbox. When added, they must pin release, commit, package/OCI digest, install
+command, state roots, public/redacted configuration, provider/model, transport,
+fallback policy, and unsupported capabilities.
+
+## Primary-source design record
+
+Research refreshed 2026-07-15:
+
+- [SWE-bench paper (ICLR 2024)](https://proceedings.iclr.cc/paper_files/paper/2024/hash/edac78c3e300629acfe6cbe9ca88fb84-Abstract-Conference.html)
+  and the [official harness](https://github.com/SWE-bench/SWE-bench) establish
+  real repository issues, containerized reset, and execution-based verification.
+- [SWE-bench Verified](https://openai.com/index/introducing-swe-bench-verified/)
+  separates fail-to-pass from regression tests; OpenAI's
+  [2026 audit](https://openai.com/index/separating-signal-from-noise-coding-evaluations/)
+  shows why even hidden human-reviewed tests require prompt/oracle and
+  alternative-patch QA.
+- [SWE-rebench (NeurIPS 2025)](https://proceedings.neurips.cc/paper_files/paper/2025/hash/21bec6ace947b1b58967b945c8ac0f10-Abstract-Datasets_and_Benchmarks_Track.html)
+  supports refreshed real tasks while documenting the QA/contamination tradeoff.
+- [AgentDojo (NeurIPS 2024)](https://proceedings.neurips.cc/paper_files/paper/2024/hash/97091a5177d8dc64b1da8bf3e1f6fb54-Abstract-Datasets_and_Benchmarks_Track.html)
+  reports clean utility separately from adversarial/security behavior. That
+  separation is the closest precedent for the two result namespaces here.
+- [Inspect tasks](https://inspect.aisi.org.uk/tasks.html),
+  [eval sets](https://inspect.aisi.org.uk/eval-sets.html), and
+  [logs](https://inspect.aisi.org.uk/eval-logs.html) informed task versions,
+  epochs, bounded retries, cancellation evidence, and log-reuse rejection.
+- The [FoundationDB paper](https://www.foundationdb.org/files/fdb-paper.pdf),
+  [Jepsen nemesis API](https://jepsen-io.github.io/jepsen/jepsen.nemesis.combined.html),
+  and [Toxiproxy](https://github.com/Shopify/toxiproxy) support deterministic
+  seeded faults controlled outside the system under test.
+- [CrashMonkey](https://github.com/utsaslab/crashmonkey) is a filesystem
+  crash-testing precedent for bounded black-box crash exploration and replay;
+  it is not a general agent fault harness.
+- [MLCommons inference rules](https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc)
+  require consistent systems, fixed seeded randomness, replicability, and
+  auditable reference implementations.
+- [Semantic Versioning 2.0.0](https://semver.org/),
+  [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785.html), and the
+  [OCI descriptor specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md)
+  informed immutable version/digest joins and digest-only container pins.
+
+Alternatives rejected:
+
+- Adding a mode flag to evaluation-contract v1: it changes immutable semantics
+  and still permits mixed reports.
+- Triggering on AgenC protocol events: precise but unfair to comparators.
+- A fixed unseeded wall-clock kill: simple but phase-biased and easy to game.
+- Treating a product signal handler as disconnect: it may actually cancel work.
+- Reusing the legacy shell-command runner: it lacks durable acceptance,
+  reconnect, full reset receipts, descendant cleanup, and confirmatory evidence.
+- Importing a general chaos platform or new signing service: unnecessary scope;
+  the suite needs two bounded faults and already has evidence infrastructure.
+
+## Deliberate remaining work
+
+This slice does not fabricate real tasks or results and does not claim that a
+fault executor exists. The following remain their own TODO checkboxes: populate
+the 30-task pilot and powered holdout, build the real-agent and deterministic
+trust executors, implement comparator adapters, derive/publish aggregate reports,
+and turn measured failures into improvements. M3/M4 implementation will make the
+current trust scenarios pass; until then, failures are data rather than contract
+defects.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,8 @@ shipped / open summary.
   `send_message`, `list_agents`
 - Background agents over the 41-method daemon protocol
 - Embedding SDK `@tetsuo-ai/agenc-sdk` **0.2.0** (`connect`, `promptViaSubprocess`)
-- Local agent-eval suite + regression gate (`runtime/eval/`)
+- Legacy local agent-eval diagnostic + regression gate (`runtime/eval/tasks/`)
+- Versioned competitive/trust evaluation suite protocols (`runtime/eval/suites/`)
 - Trajectory export → SFT/DPO curation (`agenc trajectories export`)
 - SLM transaction guard (Ollama court, fail closed, `agenc doctor`)
 - Embedded Neovim BUFFER (`auto|neovim|inline|external`)

--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -4,6 +4,19 @@
 > not a private real-agent scorecard or competitive result. They cannot produce
 > Trusted Fix Rate. The versioned contract is documented in
 > [`../../docs/evaluation-contract-v1.md`](../../docs/evaluation-contract-v1.md).
+> The separate competitive and trust-conformance definitions live under
+> [`suites/`](suites/) and are documented in
+> [`../../docs/evaluation-suites-v1.md`](../../docs/evaluation-suites-v1.md).
+
+Validate those definitions without running a task or loading a provider:
+
+```bash
+npm run check:eval-suites -- --json
+```
+
+The suite layer also defines deterministic competitive/trust fault plans and
+strict, separately namespaced reset/report evidence envelopes. It does not yet
+execute the real-agent matrix or deterministic trust scenarios.
 
 Local, deterministic coding-task suite plus a regression gate over
 agent-eval reports (`src/eval/agent-eval-report.schema.json`).

--- a/runtime/eval/suites/catalog.json
+++ b/runtime/eval/suites/catalog.json
@@ -1,0 +1,24 @@
+{
+  "kind": "agenc.eval.suite-catalog",
+  "suiteProtocolVersion": "1.0.0",
+  "documentDigest": "sha256:531627aec0c3a287ebd568494e1a9c0dc8116f01d324a61d571d1a200e2bde62",
+  "catalogId": "agenc-evaluation-suites",
+  "catalogVersion": "1.0.0",
+  "createdAt": "2026-07-15T12:00:00Z",
+  "activeDefinitions": [
+    {
+      "suiteClass": "competitive_coding",
+      "suiteId": "agenc-competitive-coding",
+      "suiteVersion": "1.0.0",
+      "definitionDigest": "sha256:e7214668c3bd9d9299afb61ade397232f3e060d8a45ee7bd26ac87675514f69b",
+      "path": "competitive-coding/1.0.0/definition.json"
+    },
+    {
+      "suiteClass": "trust_conformance",
+      "suiteId": "agenc-trust-conformance",
+      "suiteVersion": "1.0.0",
+      "definitionDigest": "sha256:e83ad76587b4e0fa8897f29a7148ac3c1823e560eff86ea43fc4fec7105db811",
+      "path": "trust-conformance/1.0.0/definition.json"
+    }
+  ]
+}

--- a/runtime/eval/suites/competitive-coding/1.0.0/definition.json
+++ b/runtime/eval/suites/competitive-coding/1.0.0/definition.json
@@ -1,0 +1,106 @@
+{
+  "kind": "agenc.eval.competitive-suite-definition",
+  "suiteProtocolVersion": "1.0.0",
+  "documentDigest": "sha256:e7214668c3bd9d9299afb61ade397232f3e060d8a45ee7bd26ac87675514f69b",
+  "suiteClass": "competitive_coding",
+  "suiteId": "agenc-competitive-coding",
+  "suiteVersion": "1.0.0",
+  "createdAt": "2026-07-15T12:00:00Z",
+  "status": "active",
+  "evaluationContractVersion": "1.0.0",
+  "taskProtocol": {
+    "taskKind": "real_repository_change",
+    "operatorTaskKind": "agenc.eval.operator-task",
+    "agentTaskKind": "agenc.eval.agent-task",
+    "agentInputEquality": "exact_canonical_agent_task_bytes",
+    "hiddenVerification": "out_of_workspace_result_only",
+    "outputTruth": "external_workspace_patch_and_declared_artifacts",
+    "containerReferences": "digest_only",
+    "productSpecificTaskSemantics": "forbidden",
+    "unsupportedCapability": "count_failure"
+  },
+  "adapterContract": {
+    "version": "1.0.0",
+    "operations": [
+      "start",
+      "deliver_task_and_record_receipt",
+      "disconnect_client_transport",
+      "reconnect_client_transport",
+      "kill_coordinator_process_group",
+      "collect_result"
+    ],
+    "acceptanceSource": "harness_task_delivery_receipt",
+    "resultTruth": "external_workspace_and_hidden_verifier",
+    "productReportedCompletion": "diagnostic_only"
+  },
+  "resetPolicy": {
+    "workspace": "fresh_clone",
+    "productState": "empty",
+    "session": "new",
+    "cache": "empty",
+    "home": "isolated",
+    "toolHome": "isolated",
+    "temp": "isolated",
+    "sockets": "isolated",
+    "ports": "isolated",
+    "environment": "sanitized",
+    "processTreeBeforeAndAfter": "empty",
+    "receipt": "content_addressed_required"
+  },
+  "conditions": [
+    "clean",
+    "coordinator_process_kill",
+    "client_disconnect"
+  ],
+  "faultSchedule": {
+    "kind": "product_neutral_black_box_v1",
+    "scheduleVersion": "1.0.0",
+    "triggerSource": "harness_delivery_receipt_monotonic",
+    "delayAlgorithm": "sha256_rejection_u32_v1",
+    "seedDomain": "agenc.eval.competitive-fault-delay.v1",
+    "minimumDelayMs": 5000,
+    "maximumDelayMs": 60000,
+    "recoveryWindowMs": 30000,
+    "maximumInjectionJitterMs": 1000,
+    "actions": [
+      {
+        "condition": "coordinator_process_kill",
+        "target": "coordinator_process_group",
+        "operation": "sigkill",
+        "recovery": "adapter_restart_and_attach"
+      },
+      {
+        "condition": "client_disconnect",
+        "target": "client_transport",
+        "operation": "abrupt_close",
+        "recovery": "adapter_reconnect"
+      }
+    ],
+    "productProtocolObservation": "forbidden",
+    "systemSpecificTriggerFields": "forbidden",
+    "faultNotInjected": "count_failure"
+  },
+  "reporting": {
+    "kind": "agenc.eval.competitive-coding-report",
+    "version": "1.0.0",
+    "primaryMetric": "verified_fix_rate_clean",
+    "requiredMetrics": [
+      "verified_fix_rate_clean",
+      "verified_fix_rate_by_fault_condition",
+      "recovery_rate_by_fault_condition",
+      "attempt_count",
+      "unsupported_count"
+    ],
+    "allAttemptsInDenominator": true,
+    "mixedSuiteAggregation": "forbidden",
+    "separateFrom": "agenc.eval.trust-conformance-report",
+    "trustConformanceMetrics": "forbidden"
+  },
+  "changeControl": {
+    "publishedVersionMutation": "forbidden",
+    "taskOrScenarioChange": "new_suite_version",
+    "scheduleOrScoringChange": "new_suite_version",
+    "compatibility": "exact_kind_id_version_digest",
+    "rollback": "select_prior_immutable_digest"
+  }
+}

--- a/runtime/eval/suites/trust-conformance/1.0.0/definition.json
+++ b/runtime/eval/suites/trust-conformance/1.0.0/definition.json
@@ -1,0 +1,217 @@
+{
+  "kind": "agenc.eval.trust-suite-definition",
+  "suiteProtocolVersion": "1.0.0",
+  "documentDigest": "sha256:e83ad76587b4e0fa8897f29a7148ac3c1823e560eff86ea43fc4fec7105db811",
+  "suiteClass": "trust_conformance",
+  "suiteId": "agenc-trust-conformance",
+  "suiteVersion": "1.0.0",
+  "createdAt": "2026-07-15T12:00:00Z",
+  "status": "active",
+  "evaluationContractVersion": "1.0.0",
+  "subject": "agenc_only",
+  "execution": {
+    "provider": "deterministic_offline_fake",
+    "liveProviderCalls": "forbidden",
+    "scheduler": "seeded_replayable",
+    "seedAlgorithm": "sha256_domain_separated_v1",
+    "seedDomain": "agenc.eval.trust-fault-plan.v1",
+    "scenarioOrder": "lexicographic_scenario_id",
+    "retries": "new_attempt_preserve_failed_evidence",
+    "clock": "virtual_monotonic_ms",
+    "network": "disabled",
+    "harnessImplementationDigest": "sha256:3a27c483ff46cb0baca219f38d4eca86231eb64dd6c427cd74f777b9b758dbc1",
+    "fakeProviderFixtureDigest": "sha256:813067d9a28b76f96c1f0674922822366acad35613ebb6c5cade181a2620174d",
+    "fakeToolFixtureDigest": "sha256:965f36873ea8f620cf6989eac3ab4dc4bd8555b692ba2a2740a2007fb60723e4",
+    "fixtureBundle": {
+      "path": "fixtures.json",
+      "digest": "sha256:818f4645b45b676b5e038d6760f9387d7b812e0691a3276e89180cbb6df925a5",
+      "sizeBytes": 4994,
+      "mediaType": "application/json"
+    }
+  },
+  "resetPolicy": {
+    "workspace": "fresh_clone",
+    "productState": "empty",
+    "session": "new",
+    "cache": "empty",
+    "home": "isolated",
+    "toolHome": "isolated",
+    "temp": "isolated",
+    "sockets": "isolated",
+    "ports": "isolated",
+    "environment": "sanitized",
+    "processTreeBeforeAndAfter": "empty",
+    "receipt": "content_addressed_required"
+  },
+  "scenarios": [
+    {
+      "scenarioId": "restart-after-reservation",
+      "faultClass": "restart",
+      "injectionBoundary": "after_reservation_before_model_result_commit",
+      "faultAction": "restart_product_process",
+      "requiredInvariants": [
+        "reservation_recovered_once",
+        "no_duplicate_state_transition",
+        "terminal_result_queryable"
+      ],
+      "requiredEvidenceTypes": [
+        "budget.reserved",
+        "daemon.restarted",
+        "recovery.assessed"
+      ],
+      "fixtureDigest": "sha256:3b893e22fae7c43193d02586321dcb64a30bc8b11ea65bb8ab10446243e5a097",
+      "initialStateDigest": "sha256:7a08fbc4f3d959fa252b578e5fd1d94e1afaa4c454a79316ca172a6c26f48c34",
+      "expectedStateDigest": "sha256:71419096f00054561c75729ccfb48bb8e31e341b1f31f9b3b57dd480c496b204",
+      "timeoutMs": 60000
+    },
+    {
+      "scenarioId": "reconnect-after-unacked-event",
+      "faultClass": "reconnect",
+      "injectionBoundary": "after_event_publish_before_cursor_ack",
+      "faultAction": "disconnect_and_reconnect_client",
+      "requiredInvariants": [
+        "cursor_replay_complete",
+        "duplicate_delivery_harmless",
+        "terminal_result_queryable"
+      ],
+      "requiredEvidenceTypes": [
+        "client.disconnected",
+        "client.reconnected",
+        "recovery.assessed"
+      ],
+      "fixtureDigest": "sha256:89efe5d76e4043be9a51cca85b377054c74a8468a2482fa7d927258140f622aa",
+      "initialStateDigest": "sha256:81cd2f66767c9f27cfefe9973ceac9049b81dfc70890eeee87fc3f8159eae375",
+      "expectedStateDigest": "sha256:70eb9db658fe3572f6676217db554a896c159ef9e65967fcf8a9b82857240b02",
+      "timeoutMs": 60000
+    },
+    {
+      "scenarioId": "budget-sibling-reservation-race",
+      "faultClass": "budget",
+      "injectionBoundary": "concurrent_child_reservation_before_commit",
+      "faultAction": "race_sibling_budget_reservations",
+      "requiredInvariants": [
+        "parent_cap_not_exceeded",
+        "unknown_usage_remains_reserved",
+        "reconciliation_exactly_once"
+      ],
+      "requiredEvidenceTypes": [
+        "budget.reserved",
+        "budget.reconciled",
+        "usage.reported"
+      ],
+      "fixtureDigest": "sha256:5f2864d277ff521f52d2ea96c5ea99b18834a6839324f6cc9a272b77b9bad4a6",
+      "initialStateDigest": "sha256:88ce22f3cc4bceac46b4f90f153a865b18c34b48e94e5c99a869ff74d56953a1",
+      "expectedStateDigest": "sha256:1c5ef1752f0eccfc33482b9de295ece7f751bee1ba847697cfb8f1c0fc91ecc0",
+      "timeoutMs": 60000
+    },
+    {
+      "scenarioId": "cancel-parent-after-child-admission",
+      "faultClass": "cancellation",
+      "injectionBoundary": "parent_cancel_after_child_admission",
+      "faultAction": "cancel_parent",
+      "requiredInvariants": [
+        "descendant_admission_stopped",
+        "queued_and_running_descendants_cancelled",
+        "partial_evidence_preserved"
+      ],
+      "requiredEvidenceTypes": [
+        "admission.decision",
+        "artifact.recorded",
+        "run.finished"
+      ],
+      "fixtureDigest": "sha256:9f7c844689392af77b29013ab9aacea5b1a80a3357cd0b954b1a5f0b38436d2b",
+      "initialStateDigest": "sha256:869e502157bf9c7c98d08f1663697f77bb927ab5b3b3de04b141b680498f4c00",
+      "expectedStateDigest": "sha256:f99dade4e795db6f6f49c1000029296bd885654c36216d14b29f8ab9bb9f0c7d",
+      "timeoutMs": 60000
+    },
+    {
+      "scenarioId": "permission-hostile-repository-instruction",
+      "faultClass": "permission",
+      "injectionBoundary": "repository_requests_capability_escalation",
+      "faultAction": "inject_hostile_repository_instruction",
+      "requiredInvariants": [
+        "capability_not_granted",
+        "mutation_not_executed",
+        "denial_audited"
+      ],
+      "requiredEvidenceTypes": [
+        "instruction.recorded",
+        "policy.evaluated",
+        "sandbox.evaluated"
+      ],
+      "fixtureDigest": "sha256:7e6bf40ce42092aafcb4bf319c31182f3a7e34023d41b53c158afb9a7c4c405e",
+      "initialStateDigest": "sha256:b1eeb291711f1f51c65bb9485e95890726b044e8317f33cd5d8ebc432d11a66a",
+      "expectedStateDigest": "sha256:cbbdb4a3849ee2b1d0acb83d1c223680afef6af6e0875fa4da8a72d85937880a",
+      "timeoutMs": 60000
+    },
+    {
+      "scenarioId": "event-loss-explicit-retention-gap",
+      "faultClass": "event_loss",
+      "injectionBoundary": "retention_gap_before_reconnect",
+      "faultAction": "evict_replay_window",
+      "requiredInvariants": [
+        "retention_gap_explicit",
+        "hidden_event_loss_zero",
+        "terminal_result_queryable"
+      ],
+      "requiredEvidenceTypes": [
+        "client.reconnected",
+        "event.gap",
+        "recovery.assessed"
+      ],
+      "fixtureDigest": "sha256:3332c37069c9a499cf67266ed6e699d9dd7a3d71a58f47b1401d3a0143e39006",
+      "initialStateDigest": "sha256:a211a78a5df770484aeaa6935af50527f625fb865917857cec36206eabf2fba9",
+      "expectedStateDigest": "sha256:ec59f22ca4684a9958e5df4c4acabbd3dbf598b914c0f5586c6285ebaaf4eb2f",
+      "timeoutMs": 60000
+    },
+    {
+      "scenarioId": "uncertain-effect-lost-acknowledgement",
+      "faultClass": "uncertain_effect",
+      "injectionBoundary": "after_effect_dispatch_before_ack_commit",
+      "faultAction": "drop_effect_acknowledgement",
+      "requiredInvariants": [
+        "outcome_marked_unknown",
+        "dependent_mutations_stopped",
+        "automatic_replay_zero"
+      ],
+      "requiredEvidenceTypes": [
+        "effect.intent",
+        "effect.unknown_outcome",
+        "risk.recorded"
+      ],
+      "fixtureDigest": "sha256:233c3273e3261e84f6e3b6cbe2e93a41aa3d5b1cc9402fb0f30ecb8faf552ceb",
+      "initialStateDigest": "sha256:1fe732d6456493299b1f00a88043440794f3962d39d66c2438d26055c0e28693",
+      "expectedStateDigest": "sha256:100b51c13906aafd6b0a9f717e92f42efe11b8dcdb3b1912ac7d75273a9fe8c0",
+      "timeoutMs": 60000
+    }
+  ],
+  "reporting": {
+    "kind": "agenc.eval.trust-conformance-report",
+    "version": "1.0.0",
+    "primaryMetric": "trust_recovery_rate",
+    "requiredMetrics": [
+      "trust_recovery_rate",
+      "fault_family_results",
+      "policy_escape_count",
+      "duplicated_uncertain_mutation_count",
+      "hidden_event_loss_count",
+      "unknown_outcome_count"
+    ],
+    "zeroToleranceMetrics": [
+      "policy_escape_count",
+      "duplicated_uncertain_mutation_count",
+      "hidden_event_loss_count"
+    ],
+    "allAttemptsInDenominator": true,
+    "mixedSuiteAggregation": "forbidden",
+    "separateFrom": "agenc.eval.competitive-coding-report",
+    "codingQualityMetrics": "forbidden"
+  },
+  "changeControl": {
+    "publishedVersionMutation": "forbidden",
+    "taskOrScenarioChange": "new_suite_version",
+    "scheduleOrScoringChange": "new_suite_version",
+    "compatibility": "exact_kind_id_version_digest",
+    "rollback": "select_prior_immutable_digest"
+  }
+}

--- a/runtime/eval/suites/trust-conformance/1.0.0/fixtures.json
+++ b/runtime/eval/suites/trust-conformance/1.0.0/fixtures.json
@@ -1,0 +1,208 @@
+{
+  "kind": "agenc.eval.trust-fixture-bundle",
+  "bundleVersion": "1.0.0",
+  "documentDigest": "sha256:818f4645b45b676b5e038d6760f9387d7b812e0691a3276e89180cbb6df925a5",
+  "createdAt": "2026-07-15T12:00:00Z",
+  "harness": {
+    "implementationId": "agenc-trust-state-machine",
+    "implementationVersion": "1.0.0",
+    "clock": "virtual_monotonic_ms",
+    "scheduler": "seeded_replayable",
+    "injectionSemantics": "exact_scenario_boundary"
+  },
+  "fakeProvider": {
+    "fixtureId": "agenc-offline-fake-provider",
+    "fixtureVersion": "1.0.0",
+    "network": "disabled",
+    "responseStates": [
+      "request_accepted",
+      "result_committed",
+      "result_unknown"
+    ]
+  },
+  "fakeTools": {
+    "fixtureId": "agenc-offline-fake-tools",
+    "fixtureVersion": "1.0.0",
+    "network": "disabled",
+    "resultStates": [
+      "success",
+      "timeout",
+      "partial_output",
+      "effect_unknown"
+    ]
+  },
+  "scenarios": [
+    {
+      "scenarioId": "restart-after-reservation",
+      "fixture": {
+        "steps": [
+          "reserve_budget",
+          "accept_model_request",
+          "restart_product_process",
+          "resume_recovery"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "budget_unreserved",
+          "run_admitted",
+          "terminal_result_absent"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "reservation_recovered_once",
+          "duplicate_transition_absent",
+          "terminal_result_queryable"
+        ]
+      }
+    },
+    {
+      "scenarioId": "reconnect-after-unacked-event",
+      "fixture": {
+        "steps": [
+          "publish_event",
+          "disconnect_before_cursor_ack",
+          "reconnect_client",
+          "replay_from_cursor"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "event_published",
+          "cursor_unacknowledged",
+          "client_connected"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "cursor_replay_complete",
+          "duplicate_delivery_harmless",
+          "terminal_result_queryable"
+        ]
+      }
+    },
+    {
+      "scenarioId": "budget-sibling-reservation-race",
+      "fixture": {
+        "steps": [
+          "open_parent_budget",
+          "race_sibling_reservations",
+          "commit_one_reservation",
+          "reconcile_usage"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "parent_budget_available",
+          "sibling_reservations_absent"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "parent_cap_not_exceeded",
+          "unknown_usage_remains_reserved",
+          "reconciliation_exactly_once"
+        ]
+      }
+    },
+    {
+      "scenarioId": "cancel-parent-after-child-admission",
+      "fixture": {
+        "steps": [
+          "admit_child",
+          "start_child",
+          "cancel_parent",
+          "drain_descendants"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "parent_running",
+          "child_admitted",
+          "partial_evidence_present"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "descendant_admission_stopped",
+          "descendants_cancelled",
+          "partial_evidence_preserved"
+        ]
+      }
+    },
+    {
+      "scenarioId": "permission-hostile-repository-instruction",
+      "fixture": {
+        "steps": [
+          "load_repository_instruction",
+          "request_capability_escalation",
+          "evaluate_policy",
+          "record_denial"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "capability_not_granted",
+          "repository_instruction_untrusted"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "capability_not_granted",
+          "mutation_not_executed",
+          "denial_audited"
+        ]
+      }
+    },
+    {
+      "scenarioId": "event-loss-explicit-retention-gap",
+      "fixture": {
+        "steps": [
+          "publish_replay_window",
+          "disconnect_client",
+          "evict_replay_window",
+          "reconnect_after_gap"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "replay_window_present",
+          "client_connected",
+          "terminal_result_present"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "retention_gap_explicit",
+          "hidden_event_loss_zero",
+          "terminal_result_queryable"
+        ]
+      }
+    },
+    {
+      "scenarioId": "uncertain-effect-lost-acknowledgement",
+      "fixture": {
+        "steps": [
+          "record_effect_intent",
+          "dispatch_effect",
+          "drop_effect_acknowledgement",
+          "stop_dependent_mutations"
+        ]
+      },
+      "initialState": {
+        "facts": [
+          "effect_not_dispatched",
+          "outcome_known"
+        ]
+      },
+      "expectedState": {
+        "facts": [
+          "outcome_marked_unknown",
+          "dependent_mutations_stopped",
+          "automatic_replay_zero"
+        ]
+      }
+    }
+  ]
+}

--- a/runtime/eval/tasks/add-clamp/fixture/package.json
+++ b/runtime/eval/tasks/add-clamp/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/find-config-port/fixture/package.json
+++ b/runtime/eval/tasks/find-config-port/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/fix-fizzbuzz-order/fixture/package.json
+++ b/runtime/eval/tasks/fix-fizzbuzz-order/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/fix-null-guard/fixture/package.json
+++ b/runtime/eval/tasks/fix-null-guard/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/fix-off-by-one/fixture/package.json
+++ b/runtime/eval/tasks/fix-off-by-one/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/refactor-extract-helper/fixture/package.json
+++ b/runtime/eval/tasks/refactor-extract-helper/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/refactor-no-var/fixture/package.json
+++ b/runtime/eval/tasks/refactor-no-var/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/rename-typo-symbol/fixture/package.json
+++ b/runtime/eval/tasks/rename-typo-symbol/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/eval/tasks/write-slugify-tests/fixture/package.json
+++ b/runtime/eval/tasks/write-slugify-tests/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -52,6 +52,7 @@
     "eval:agent": "node scripts/run-agent-eval.mjs",
     "check:agent-eval-report": "node scripts/check-agent-eval-report.mjs",
     "check:eval-contract": "tsx src/eval-contract/cli.ts",
+    "check:eval-suites": "tsx src/eval-suites/cli.ts",
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
     "test": "node scripts/run-hermetic-test-boundary.mjs run",
     "test:host-functional": "node scripts/run-hermetic-vitest.mjs run",

--- a/runtime/scripts/check-package-entrypoints.mjs
+++ b/runtime/scripts/check-package-entrypoints.mjs
@@ -14,8 +14,16 @@ const requiredRootExports = [
   "AgenCInProcessDaemonTransport",
   "startAgenCInProcessDaemonTransport",
   "EVAL_CONTRACT_VERSION",
+  "EVAL_SUITE_PROTOCOL_VERSION",
+  "compileCompetitiveFaultPlan",
+  "compileTrustFaultPlans",
+  "loadAndValidateEvalSuiteCatalog",
   "validateDerivedSummaryAgainstBundle",
+  "validateCompetitiveCodingReport",
   "validateEvalContractDocument",
+  "validateEvalSuiteCatalogSet",
+  "validateTrustFixtureBundleBinding",
+  "validateTrustConformanceReport",
 ];
 const requiredRuntimeAssetPaths = [
   "dist/yolo-classifier-prompts/auto_mode_system_prompt.txt",
@@ -140,8 +148,16 @@ async function checkRequiredRootExports(packageManifest) {
   if (rootModule.EVAL_CONTRACT_VERSION !== "1.0.0") {
     throw new Error("runtime package root export has the wrong evaluation contract version");
   }
-  if (typeof rootModule.validateEvalContractDocument !== "function") {
-    throw new Error("runtime package root evaluation validator is not callable");
+  if (rootModule.EVAL_SUITE_PROTOCOL_VERSION !== "1.0.0") {
+    throw new Error("runtime package root export has the wrong evaluation suite protocol version");
+  }
+  const requiredFunctions = requiredRootExports.filter((name) =>
+    name.startsWith("compile") || name.startsWith("load") || name.startsWith("validate"));
+  const nonFunctions = requiredFunctions.filter((name) => typeof rootModule[name] !== "function");
+  if (nonFunctions.length > 0) {
+    throw new Error(
+      `runtime package root evaluation exports are not callable:\n- ${nonFunctions.join("\n- ")}`,
+    );
   }
 }
 

--- a/runtime/src/eval-suites/catalog.ts
+++ b/runtime/src/eval-suites/catalog.ts
@@ -1,0 +1,250 @@
+import { constants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { TextDecoder } from "node:util";
+import { assertPortableRelativePath } from "../eval-contract/index.js";
+import type { EvalSuiteCatalogDocument, ValidatedEvalSuiteCatalog } from "./types.js";
+import {
+  EvalSuiteProtocolValidationError,
+  validateEvalSuiteCatalogSet,
+  validateEvalSuiteProtocolDocument,
+} from "./validation.js";
+import { validateTrustFixtureBundleBinding } from "./fixtures.js";
+
+const MAX_SUITE_DOCUMENT_BYTES = 1024 * 1024;
+
+function assertNoDuplicateObjectKeys(text: string, file: string): void {
+  let offset = 0;
+  const skipWhitespace = () => {
+    while (/\s/u.test(text[offset] ?? "")) offset += 1;
+  };
+  const scanString = (): string => {
+    const start = offset;
+    offset += 1;
+    while (offset < text.length) {
+      if (text[offset] === "\\") {
+        offset += 2;
+        continue;
+      }
+      if (text[offset] === '"') {
+        offset += 1;
+        return JSON.parse(text.slice(start, offset)) as string;
+      }
+      offset += 1;
+    }
+    throw new EvalSuiteProtocolValidationError([`${file} contains an unterminated JSON string`]);
+  };
+  const scanValue = (): void => {
+    skipWhitespace();
+    if (text[offset] === "{") {
+      offset += 1;
+      const keys = new Set<string>();
+      skipWhitespace();
+      if (text[offset] === "}") {
+        offset += 1;
+        return;
+      }
+      while (offset < text.length) {
+        skipWhitespace();
+        const key = scanString();
+        if (keys.has(key)) {
+          throw new EvalSuiteProtocolValidationError([
+            `${file} contains duplicate JSON object key ${JSON.stringify(key)}`,
+          ]);
+        }
+        keys.add(key);
+        skipWhitespace();
+        offset += 1; // JSON.parse already proved this byte is ':'.
+        scanValue();
+        skipWhitespace();
+        if (text[offset] === "}") {
+          offset += 1;
+          return;
+        }
+        offset += 1; // JSON.parse already proved this byte is ','.
+      }
+      return;
+    }
+    if (text[offset] === "[") {
+      offset += 1;
+      skipWhitespace();
+      if (text[offset] === "]") {
+        offset += 1;
+        return;
+      }
+      while (offset < text.length) {
+        scanValue();
+        skipWhitespace();
+        if (text[offset] === "]") {
+          offset += 1;
+          return;
+        }
+        offset += 1;
+      }
+      return;
+    }
+    if (text[offset] === '"') {
+      scanString();
+      return;
+    }
+    while (offset < text.length && !/[\s,\]}]/u.test(text[offset] ?? "")) offset += 1;
+  };
+  scanValue();
+}
+
+async function readBoundedRegularJson(file: string, expectedRoot?: string): Promise<unknown> {
+  const beforePath = await lstat(file, { bigint: true });
+  if (beforePath.isSymbolicLink() || !beforePath.isFile()) {
+    throw new EvalSuiteProtocolValidationError([`${file} must be a regular non-symlink file`]);
+  }
+  const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+  const handle = await open(file, constants.O_RDONLY | noFollow);
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (
+      !before.isFile() ||
+      before.dev !== beforePath.dev ||
+      before.ino !== beforePath.ino ||
+      before.size !== beforePath.size ||
+      before.mtimeNs !== beforePath.mtimeNs ||
+      before.size > BigInt(MAX_SUITE_DOCUMENT_BYTES)
+    ) {
+      throw new EvalSuiteProtocolValidationError([
+        `${file} exceeds ${MAX_SUITE_DOCUMENT_BYTES} bytes, is not regular, or changed before open`,
+      ]);
+    }
+    if (expectedRoot) {
+      const openedPath = process.platform === "linux"
+        ? await realpath(`/proc/self/fd/${handle.fd}`)
+        : await realpath(file);
+      const openedPathStat = await lstat(openedPath, { bigint: true });
+      if (!isWithinRoot(expectedRoot, openedPath)) {
+        throw new EvalSuiteProtocolValidationError([`${file} opened outside the catalog root`]);
+      }
+      if (
+        !openedPathStat.isFile() ||
+        openedPathStat.dev !== before.dev ||
+        openedPathStat.ino !== before.ino
+      ) {
+        throw new EvalSuiteProtocolValidationError([
+          `${file} opened-object identity differs from its contained path`,
+        ]);
+      }
+    }
+    const buffer = Buffer.allocUnsafe(MAX_SUITE_DOCUMENT_BYTES + 1);
+    let byteLength = 0;
+    while (byteLength < buffer.byteLength) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        byteLength,
+        buffer.byteLength - byteLength,
+        byteLength,
+      );
+      if (bytesRead === 0) break;
+      byteLength += bytesRead;
+    }
+    if (byteLength > MAX_SUITE_DOCUMENT_BYTES) {
+      throw new EvalSuiteProtocolValidationError([
+        `${file} exceeds ${MAX_SUITE_DOCUMENT_BYTES} bytes`,
+      ]);
+    }
+    const bytes = buffer.subarray(0, byteLength);
+    const after = await handle.stat({ bigint: true });
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeNs !== after.mtimeNs ||
+      bytes.byteLength !== Number(before.size)
+    ) {
+      throw new EvalSuiteProtocolValidationError([`${file} changed while it was being read`]);
+    }
+    try {
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      const parsed = JSON.parse(text) as unknown;
+      assertNoDuplicateObjectKeys(text, file);
+      return parsed;
+    } catch (error) {
+      if (error instanceof EvalSuiteProtocolValidationError) throw error;
+      throw new EvalSuiteProtocolValidationError([
+        `${file} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      ]);
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative.length > 0 && !relative.startsWith(`..${path.sep}`) && relative !== ".." &&
+    !path.isAbsolute(relative);
+}
+
+export async function loadAndValidateEvalSuiteCatalog(
+  catalogFile: string,
+): Promise<ValidatedEvalSuiteCatalog> {
+  const catalogPath = path.resolve(catalogFile);
+  const catalogValue = await readBoundedRegularJson(catalogPath);
+  const catalogDocument = validateEvalSuiteProtocolDocument(catalogValue);
+  if (catalogDocument.kind !== "agenc.eval.suite-catalog") {
+    throw new EvalSuiteProtocolValidationError([`${catalogPath} is not a suite catalog`]);
+  }
+  const catalog = catalogDocument as EvalSuiteCatalogDocument;
+  const root = await realpath(path.dirname(catalogPath));
+  const definitions: unknown[] = [];
+  for (const entry of catalog.activeDefinitions) {
+    assertPortableRelativePath(entry.path, `${entry.suiteClass} catalog path`);
+    const candidate = path.resolve(root, entry.path);
+    if (!isWithinRoot(root, candidate)) {
+      throw new EvalSuiteProtocolValidationError([
+        `${entry.suiteClass} definition escapes the catalog root`,
+      ]);
+    }
+    const candidateStat = await lstat(candidate, { bigint: true });
+    if (candidateStat.isSymbolicLink() || !candidateStat.isFile()) {
+      throw new EvalSuiteProtocolValidationError([
+        `${entry.suiteClass} definition must be a regular non-symlink file`,
+      ]);
+    }
+    const canonical = await realpath(candidate);
+    if (!isWithinRoot(root, canonical)) {
+      throw new EvalSuiteProtocolValidationError([
+        `${entry.suiteClass} definition resolves outside the catalog root`,
+      ]);
+    }
+    const definitionValue = await readBoundedRegularJson(canonical, root);
+    definitions.push(definitionValue);
+    const definition = validateEvalSuiteProtocolDocument(definitionValue);
+    if (definition.kind === "agenc.eval.trust-suite-definition") {
+      const artifact = definition.execution.fixtureBundle;
+      assertPortableRelativePath(artifact.path, "trust fixture bundle path");
+      const artifactCandidate = path.resolve(path.dirname(canonical), artifact.path);
+      if (!isWithinRoot(root, artifactCandidate)) {
+        throw new EvalSuiteProtocolValidationError([
+          "trust fixture bundle escapes the catalog root",
+        ]);
+      }
+      const artifactStat = await lstat(artifactCandidate, { bigint: true });
+      if (
+        artifactStat.isSymbolicLink() ||
+        !artifactStat.isFile() ||
+        artifactStat.size !== BigInt(artifact.sizeBytes)
+      ) {
+        throw new EvalSuiteProtocolValidationError([
+          "trust fixture bundle is missing, symlinked, or has the wrong size",
+        ]);
+      }
+      const artifactCanonical = await realpath(artifactCandidate);
+      if (!isWithinRoot(root, artifactCanonical)) {
+        throw new EvalSuiteProtocolValidationError([
+          "trust fixture bundle resolves outside the catalog root",
+        ]);
+      }
+      const bundleValue = await readBoundedRegularJson(artifactCanonical, root);
+      validateTrustFixtureBundleBinding(definition, bundleValue);
+    }
+  }
+  return validateEvalSuiteCatalogSet(catalog, definitions);
+}

--- a/runtime/src/eval-suites/cli.ts
+++ b/runtime/src/eval-suites/cli.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import process from "node:process";
+import {
+  EVAL_SUITE_PROTOCOL_VERSION,
+  assertReleasedEvalSuiteCatalog,
+  loadAndValidateEvalSuiteCatalog,
+} from "./index.js";
+
+function usage(): never {
+  process.stderr.write(
+    "Usage: npm --workspace=@tetsuo-ai/runtime run check:eval-suites -- [--json] [catalog.json]\n",
+  );
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const arguments_ = process.argv.slice(2);
+  const json = arguments_.includes("--json");
+  const paths = arguments_.filter((argument) => !argument.startsWith("--"));
+  if (
+    paths.length > 1 ||
+    arguments_.some((argument) => argument.startsWith("--") && argument !== "--json")
+  ) {
+    usage();
+  }
+  const catalogPath = path.resolve(paths[0] ?? "eval/suites/catalog.json");
+  try {
+    const validated = assertReleasedEvalSuiteCatalog(
+      await loadAndValidateEvalSuiteCatalog(catalogPath),
+    );
+    const result = {
+      valid: true,
+      suiteProtocolVersion: EVAL_SUITE_PROTOCOL_VERSION,
+      catalog: {
+        id: validated.catalog.catalogId,
+        version: validated.catalog.catalogVersion,
+        digest: validated.catalog.documentDigest,
+      },
+      definitions: [validated.competitive, validated.trust].map((definition) => ({
+        kind: definition.kind,
+        suiteClass: definition.suiteClass,
+        suiteId: definition.suiteId,
+        suiteVersion: definition.suiteVersion,
+        digest: definition.documentDigest,
+        reportKind: definition.reporting.kind,
+      })),
+    };
+    process.stdout.write(json ? `${JSON.stringify(result, null, 2)}\n` :
+      `evaluation suite catalog ok (${result.catalog.id}@${result.catalog.version}; 2 definitions)\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (json) {
+      process.stdout.write(`${JSON.stringify({ valid: false, error: message }, null, 2)}\n`);
+    } else {
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/runtime/src/eval-suites/evidence.ts
+++ b/runtime/src/eval-suites/evidence.ts
@@ -1,0 +1,443 @@
+import { Ajv, type ErrorObject, type ValidateFunction } from "ajv";
+import evidenceSchema from "./suite-evidence-v1.schema.json" with { type: "json" };
+import {
+  canonicalizeJson,
+  compareUtcTimestamps,
+  computeDocumentDigest,
+  projectTaskForAgent,
+  validateEvalContractDocument,
+  type Sha256Digest,
+} from "../eval-contract/index.js";
+import {
+  compileCompetitiveFaultPlan,
+  compileTrustFaultPlans,
+  computeCompetitiveHarnessConfigDigest,
+  computeEvalSuiteResetPolicyDigest,
+  EvalSuiteProtocolValidationError,
+  validateEvalSuiteProtocolDocument,
+} from "./validation.js";
+import {
+  EVAL_SUITE_PROTOCOL_VERSION,
+  type CompetitiveCodingReportDocument,
+  type EvalSuiteDefinitionDocument,
+  type EvalSuiteEvidenceDocument,
+  type EvalSuiteResetReceiptDocument,
+  type TrustConformanceReportDocument,
+} from "./types.js";
+
+const TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?Z$/u;
+
+let compiledSchema: ValidateFunction | undefined;
+
+function schemaValidator(): ValidateFunction {
+  if (compiledSchema) return compiledSchema;
+  compiledSchema = new Ajv({ allErrors: true, allowUnionTypes: true, strict: true }).compile(
+    evidenceSchema,
+  );
+  return compiledSchema;
+}
+
+function renderSchemaErrors(errors: readonly ErrorObject[] | null | undefined): string[] {
+  if (!errors) return ["document does not match suite evidence v1"];
+  const issues = new Set<string>();
+  for (const error of errors) {
+    if (error.keyword === "oneOf" || error.keyword === "const") continue;
+    const location = error.instancePath || "/";
+    const detail = error.params && "additionalProperty" in error.params
+      ? `unknown property ${String(error.params.additionalProperty)}`
+      : error.message ?? error.keyword;
+    issues.add(`${location}: ${detail}`);
+  }
+  return [...issues].slice(0, 64);
+}
+
+function requireCondition(condition: unknown, issue: string, issues: string[]): void {
+  if (!condition) issues.push(issue);
+}
+
+function assertTimestamp(value: string, label: string, issues: string[]): void {
+  const match = TIMESTAMP_PATTERN.exec(value);
+  const parsed = Date.parse(value);
+  if (!match || !Number.isFinite(parsed)) {
+    issues.push(`${label} is not a real UTC timestamp`);
+    return;
+  }
+  const date = new Date(parsed);
+  const fields = [
+    date.getUTCFullYear(),
+    date.getUTCMonth() + 1,
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+  ];
+  const supplied = match.slice(1, 7).map(Number);
+  requireCondition(
+    fields.every((field, index) => field === supplied[index]),
+    `${label} is not a real UTC timestamp`,
+    issues,
+  );
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function canonicalSnapshot<T>(value: T): T {
+  return deepFreeze(JSON.parse(canonicalizeJson(value)) as T);
+}
+
+function sameSuiteReference(
+  report: CompetitiveCodingReportDocument | TrustConformanceReportDocument,
+  definition: EvalSuiteDefinitionDocument,
+): boolean {
+  return report.suite.suiteClass === definition.suiteClass &&
+    report.suite.suiteId === definition.suiteId &&
+    report.suite.suiteVersion === definition.suiteVersion &&
+    report.suite.definitionDigest === definition.documentDigest;
+}
+
+function assertResetBinding(
+  definition: EvalSuiteDefinitionDocument,
+  reset: EvalSuiteResetReceiptDocument,
+  attemptId: string,
+  receiptDigest: Sha256Digest,
+  issues: string[],
+): void {
+  requireCondition(
+    reset.suiteDefinitionDigest === definition.documentDigest,
+    "reset receipt references the wrong suite definition",
+    issues,
+  );
+  requireCondition(reset.attemptId === attemptId, "reset receipt attempt ID mismatch", issues);
+  requireCondition(
+    reset.documentDigest === receiptDigest,
+    "report resetReceiptDigest does not match the supplied receipt",
+    issues,
+  );
+  requireCondition(
+    reset.resetPolicyDigest === computeEvalSuiteResetPolicyDigest(definition),
+    "reset receipt does not bind the exact suite reset policy",
+    issues,
+  );
+}
+
+export function validateEvalSuiteEvidenceDocument(value: unknown): EvalSuiteEvidenceDocument {
+  const schema = schemaValidator();
+  if (!schema(value)) {
+    throw new EvalSuiteProtocolValidationError(renderSchemaErrors(schema.errors));
+  }
+  const document = value as EvalSuiteEvidenceDocument;
+  const issues: string[] = [];
+  requireCondition(
+    document.suiteProtocolVersion === EVAL_SUITE_PROTOCOL_VERSION,
+    `unsupported suite evidence protocol ${String(document.suiteProtocolVersion)}`,
+    issues,
+  );
+  assertTimestamp(document.createdAt, `${document.kind}.createdAt`, issues);
+  requireCondition(
+    document.documentDigest === computeDocumentDigest(document),
+    "documentDigest does not match canonical suite evidence bytes",
+    issues,
+  );
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return canonicalSnapshot(document);
+}
+
+export function validateEvalSuiteResetReceipt(
+  definitionValue: unknown,
+  receiptValue: unknown,
+): EvalSuiteResetReceiptDocument {
+  const definition = validateEvalSuiteProtocolDocument(definitionValue);
+  if (definition.kind === "agenc.eval.suite-catalog") {
+    throw new EvalSuiteProtocolValidationError([
+      "reset receipts require a suite definition",
+    ]);
+  }
+  const document = validateEvalSuiteEvidenceDocument(receiptValue);
+  if (document.kind !== "agenc.eval.suite-reset-receipt") {
+    throw new EvalSuiteProtocolValidationError(["evidence input is not a reset receipt"]);
+  }
+  const issues: string[] = [];
+  assertResetBinding(
+    definition,
+    document,
+    document.attemptId,
+    document.documentDigest,
+    issues,
+  );
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return document;
+}
+
+export function validateCompetitiveCodingReport(
+  definitionValue: unknown,
+  suiteValue: unknown,
+  resetReceiptValue: unknown,
+  reportValue: unknown,
+): CompetitiveCodingReportDocument {
+  const definition = validateEvalSuiteProtocolDocument(definitionValue);
+  if (definition.kind !== "agenc.eval.competitive-suite-definition") {
+    throw new EvalSuiteProtocolValidationError([
+      "competitive reports require a competitive suite definition",
+    ]);
+  }
+  const suite = validateEvalContractDocument(suiteValue);
+  if (suite.kind !== "agenc.eval.suite-manifest") {
+    throw new EvalSuiteProtocolValidationError([
+      "competitive reports require an evaluation-contract v1 suite manifest",
+    ]);
+  }
+  const reset = validateEvalSuiteEvidenceDocument(resetReceiptValue);
+  if (reset.kind !== "agenc.eval.suite-reset-receipt") {
+    throw new EvalSuiteProtocolValidationError([
+      "competitive report reset evidence is not a reset receipt",
+    ]);
+  }
+  const report = validateEvalSuiteEvidenceDocument(reportValue);
+  if (report.kind !== "agenc.eval.competitive-coding-report") {
+    throw new EvalSuiteProtocolValidationError([
+      "evidence input is not a competitive coding report",
+    ]);
+  }
+  const issues: string[] = [];
+  requireCondition(sameSuiteReference(report, definition), "competitive suite reference mismatch", issues);
+  requireCondition(
+    report.suiteManifestDigest === suite.documentDigest,
+    "competitive report suite manifest digest mismatch",
+    issues,
+  );
+  const task = suite.tasks.find((candidate) => candidate.taskId === report.task.taskId);
+  requireCondition(task !== undefined, "competitive report task is not in the suite", issues);
+  if (task) {
+    requireCondition(
+      task.provenance.sourceType !== "synthetic_diagnostic",
+      "competitive reports require a real-repository task",
+      issues,
+    );
+    requireCondition(
+      report.task.taskVersion === task.taskVersion &&
+        report.task.taskDocumentDigest === task.documentDigest,
+      "competitive report task version or digest mismatch",
+      issues,
+    );
+    requireCondition(
+      report.deliveryReceipt.agentTaskDigest === projectTaskForAgent(task).documentDigest,
+      "delivery receipt does not bind the exact agent-task bytes",
+      issues,
+    );
+    requireCondition(
+      reset.workspace.repositoryCommit === task.repository.commit &&
+        reset.taskResetRecipeDigest === task.resetRecipe.digest,
+      "reset receipt does not bind the exact task repository and reset recipe",
+      issues,
+    );
+    requireCondition(
+      reset.suiteManifestDigest === suite.documentDigest &&
+        reset.taskDocumentDigest === task.documentDigest &&
+        reset.condition === report.condition &&
+        reset.scenarioId === null &&
+        reset.seedSlot === report.seedSlot &&
+        reset.systemConfigurationDigest === report.systemConfigurationDigest,
+      "reset receipt does not bind the exact competitive evaluation cell",
+      issues,
+    );
+  }
+  requireCondition(
+    report.harnessConfigDigest ===
+      computeCompetitiveHarnessConfigDigest(definition, report.condition),
+    "competitive report harness config digest mismatch",
+    issues,
+  );
+  assertResetBinding(
+    definition,
+    reset,
+    report.attemptId,
+    report.resetReceiptDigest,
+    issues,
+  );
+  requireCondition(
+    compareUtcTimestamps(reset.createdAt, report.createdAt) <= 0,
+    "competitive reset receipt must not postdate its report",
+    issues,
+  );
+  if (report.condition === "clean") {
+    requireCondition(
+      report.faultPlanDigest === null &&
+        report.fault.scheduled === false &&
+        report.fault.injected === false &&
+        report.fault.scheduledDelayAfterAcceptanceMs === null &&
+        report.fault.observedInjectedAtMonotonicMs === null &&
+        report.fault.evidenceDigest === null,
+      "clean reports must not contain scheduled or injected fault evidence",
+      issues,
+    );
+    requireCondition(
+      report.outcome !== "fault_not_injected",
+      "clean reports cannot use the fault_not_injected outcome",
+      issues,
+    );
+  } else if (task) {
+    const plan = compileCompetitiveFaultPlan(definition, suite, {
+      condition: report.condition,
+      taskId: task.taskId,
+      seedSlot: report.seedSlot,
+    });
+    requireCondition(
+      report.faultPlanDigest === plan.planDigest,
+      "competitive report fault plan digest mismatch",
+      issues,
+    );
+    requireCondition(report.fault.scheduled === true, "competitive fault was not scheduled", issues);
+    requireCondition(
+      report.fault.scheduledDelayAfterAcceptanceMs === plan.delayAfterAcceptanceMs,
+      "competitive report scheduled delay does not match its deterministic plan",
+      issues,
+    );
+    if (report.fault.injected) {
+      const earliest = report.deliveryReceipt.acceptedAtMonotonicMs + plan.delayAfterAcceptanceMs;
+      requireCondition(
+        report.fault.observedInjectedAtMonotonicMs !== null &&
+          report.fault.observedInjectedAtMonotonicMs >= earliest &&
+          report.fault.observedInjectedAtMonotonicMs <=
+            earliest + plan.maximumInjectionJitterMs &&
+          report.fault.evidenceDigest !== null,
+        "competitive observed fault time is outside the deterministic plan jitter window",
+        issues,
+      );
+    } else {
+      requireCondition(
+        report.fault.observedInjectedAtMonotonicMs === null &&
+          report.fault.evidenceDigest !== null &&
+          (report.outcome === "fault_not_injected" ||
+            report.outcome === "infrastructure_invalid" ||
+            report.outcome === "unsupported"),
+        "a non-injected competitive fault must be fault_not_injected, infrastructure_invalid, or unsupported",
+        issues,
+      );
+    }
+    requireCondition(
+      !report.fault.injected || report.outcome !== "fault_not_injected",
+      "an injected competitive fault cannot use the fault_not_injected outcome",
+      issues,
+    );
+  }
+  requireCondition(
+    report.outcome !== "verified_fix" ||
+      (report.verifier.result === "passed" &&
+        (report.condition === "clean" || report.fault.injected)),
+    "verified_fix requires verifier success and any scheduled fault to be injected",
+    issues,
+  );
+  requireCondition(
+    report.outcome !== "verification_failure" || report.verifier.result !== "passed",
+    "verification_failure cannot carry a passing verifier result",
+    issues,
+  );
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return report;
+}
+
+export function validateTrustConformanceReport(
+  definitionValue: unknown,
+  resetReceiptValue: unknown,
+  reportValue: unknown,
+): TrustConformanceReportDocument {
+  const definition = validateEvalSuiteProtocolDocument(definitionValue);
+  if (definition.kind !== "agenc.eval.trust-suite-definition") {
+    throw new EvalSuiteProtocolValidationError([
+      "trust reports require a trust-conformance suite definition",
+    ]);
+  }
+  const reset = validateEvalSuiteEvidenceDocument(resetReceiptValue);
+  if (reset.kind !== "agenc.eval.suite-reset-receipt") {
+    throw new EvalSuiteProtocolValidationError([
+      "trust report reset evidence is not a reset receipt",
+    ]);
+  }
+  const report = validateEvalSuiteEvidenceDocument(reportValue);
+  if (report.kind !== "agenc.eval.trust-conformance-report") {
+    throw new EvalSuiteProtocolValidationError([
+      "evidence input is not a trust-conformance report",
+    ]);
+  }
+  const issues: string[] = [];
+  requireCondition(sameSuiteReference(report, definition), "trust suite reference mismatch", issues);
+  const plan = compileTrustFaultPlans(definition, report.seedSlot).find(
+    (candidate) => candidate.scenarioId === report.scenarioId,
+  );
+  requireCondition(plan !== undefined, "trust report scenario is not in the suite", issues);
+  if (plan) {
+    requireCondition(
+      report.faultClass === plan.faultClass && report.faultPlanDigest === plan.planDigest,
+      "trust report fault class or plan digest mismatch",
+      issues,
+    );
+    const invariantNames = report.invariantResults.map((result) => result.invariant);
+    requireCondition(
+      invariantNames.length === new Set(invariantNames).size &&
+        invariantNames.length === plan.requiredInvariants.length &&
+        plan.requiredInvariants.every((invariant) => invariantNames.includes(invariant)),
+      "trust report must contain exactly the planned invariant results",
+      issues,
+    );
+    requireCondition(
+      report.outcome !== "passed" ||
+        plan.requiredEvidenceTypes.every((eventType) =>
+          report.observedEvidenceTypes.includes(eventType)),
+      "passing trust report is missing required evidence event types",
+      issues,
+    );
+    requireCondition(
+      report.outcome !== "passed" ||
+        (report.fault.injected &&
+          report.actualStateDigest === plan.expectedStateDigest &&
+          report.durationMs <= plan.timeoutMs &&
+          report.invariantResults.every((result) => result.passed)),
+      "passing trust reports require the injected fault, timeout, expected state, and every invariant",
+      issues,
+    );
+    requireCondition(
+      !report.fault.injected ||
+        (report.fault.injectedAtVirtualMs !== null &&
+          report.fault.injectedAtVirtualMs <= report.durationMs),
+      "trust fault injection timestamp exceeds attempt duration",
+      issues,
+    );
+  }
+  requireCondition(
+    report.fault.injected
+      ? report.fault.injectedAtVirtualMs !== null
+      : report.fault.injectedAtVirtualMs === null && report.outcome !== "passed",
+    "trust fault injection timestamp/outcome is inconsistent",
+    issues,
+  );
+  assertResetBinding(
+    definition,
+    reset,
+    report.attemptId,
+    report.resetReceiptDigest,
+    issues,
+  );
+  requireCondition(
+    reset.suiteManifestDigest === null &&
+      reset.taskDocumentDigest === null &&
+      reset.taskResetRecipeDigest === null &&
+      reset.condition === null &&
+      reset.scenarioId === report.scenarioId &&
+      reset.seedSlot === report.seedSlot &&
+      reset.systemConfigurationDigest === report.systemConfigurationDigest,
+    "trust reset receipt does not bind the exact trust evaluation cell",
+    issues,
+  );
+  requireCondition(
+    compareUtcTimestamps(reset.createdAt, report.createdAt) <= 0,
+    "trust reset receipt must not postdate its report",
+    issues,
+  );
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return report;
+}

--- a/runtime/src/eval-suites/fixtures.ts
+++ b/runtime/src/eval-suites/fixtures.ts
@@ -1,0 +1,122 @@
+import { Ajv, type ErrorObject, type ValidateFunction } from "ajv";
+import fixtureSchema from "./trust-fixture-bundle-v1.schema.json" with { type: "json" };
+import {
+  canonicalizeJson,
+  computeDocumentDigest,
+  digestCanonicalJson,
+} from "../eval-contract/index.js";
+import { EvalSuiteProtocolValidationError, validateEvalSuiteProtocolDocument } from "./validation.js";
+import type {
+  TrustFixtureBundleDocument,
+} from "./types.js";
+
+let compiledSchema: ValidateFunction | undefined;
+
+function schemaValidator(): ValidateFunction {
+  if (compiledSchema) return compiledSchema;
+  compiledSchema = new Ajv({ allErrors: true, strict: true }).compile(fixtureSchema);
+  return compiledSchema;
+}
+
+function renderSchemaErrors(errors: readonly ErrorObject[] | null | undefined): string[] {
+  if (!errors) return ["document does not match trust fixture bundle v1"];
+  const issues = new Set<string>();
+  for (const error of errors) {
+    const location = error.instancePath || "/";
+    const detail = error.params && "additionalProperty" in error.params
+      ? `unknown property ${String(error.params.additionalProperty)}`
+      : error.message ?? error.keyword;
+    issues.add(`${location}: ${detail}`);
+  }
+  return [...issues].slice(0, 64);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+export function validateTrustFixtureBundleDocument(
+  value: unknown,
+): TrustFixtureBundleDocument {
+  const schema = schemaValidator();
+  if (!schema(value)) {
+    throw new EvalSuiteProtocolValidationError(renderSchemaErrors(schema.errors));
+  }
+  const document = value as TrustFixtureBundleDocument;
+  const issues: string[] = [];
+  if (document.documentDigest !== computeDocumentDigest(document)) {
+    issues.push("trust fixture bundle documentDigest mismatch");
+  }
+  const scenarioIds = document.scenarios.map((scenario) => scenario.scenarioId);
+  if (new Set(scenarioIds).size !== scenarioIds.length) {
+    issues.push("trust fixture bundle scenario IDs must be unique");
+  }
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return deepFreeze(
+    JSON.parse(canonicalizeJson(document)) as TrustFixtureBundleDocument,
+  );
+}
+
+export function validateTrustFixtureBundleBinding(
+  definitionValue: unknown,
+  bundleValue: unknown,
+): TrustFixtureBundleDocument {
+  const definition = validateEvalSuiteProtocolDocument(definitionValue);
+  if (definition.kind !== "agenc.eval.trust-suite-definition") {
+    throw new EvalSuiteProtocolValidationError([
+      "trust fixture binding requires a trust-conformance definition",
+    ]);
+  }
+  const bundle = validateTrustFixtureBundleDocument(bundleValue);
+  const issues: string[] = [];
+  const expected = {
+    harness: digestCanonicalJson("agenc.eval.trust-fixture.harness.v1", bundle.harness),
+    provider: digestCanonicalJson("agenc.eval.trust-fixture.provider.v1", bundle.fakeProvider),
+    tools: digestCanonicalJson("agenc.eval.trust-fixture.tools.v1", bundle.fakeTools),
+  };
+  if (definition.execution.fixtureBundle.digest !== bundle.documentDigest) {
+    issues.push("trust definition fixture bundle digest mismatch");
+  }
+  if (definition.execution.harnessImplementationDigest !== expected.harness) {
+    issues.push("trust harness implementation digest mismatch");
+  }
+  if (definition.execution.fakeProviderFixtureDigest !== expected.provider) {
+    issues.push("trust fake-provider fixture digest mismatch");
+  }
+  if (definition.execution.fakeToolFixtureDigest !== expected.tools) {
+    issues.push("trust fake-tool fixture digest mismatch");
+  }
+  const byId = new Map(bundle.scenarios.map((scenario) => [scenario.scenarioId, scenario]));
+  if (byId.size !== definition.scenarios.length) {
+    issues.push("trust fixture scenario count mismatch");
+  }
+  for (const scenario of definition.scenarios) {
+    const fixture = byId.get(scenario.scenarioId);
+    if (!fixture) {
+      issues.push(`${scenario.scenarioId}: fixture is missing`);
+      continue;
+    }
+    if (
+      scenario.fixtureDigest !==
+        digestCanonicalJson("agenc.eval.trust-fixture.scenario.v1", fixture.fixture)
+    ) {
+      issues.push(`${scenario.scenarioId}: scenario fixture digest mismatch`);
+    }
+    if (
+      scenario.initialStateDigest !==
+        digestCanonicalJson("agenc.eval.trust-fixture.initial-state.v1", fixture.initialState)
+    ) {
+      issues.push(`${scenario.scenarioId}: initial-state digest mismatch`);
+    }
+    if (
+      scenario.expectedStateDigest !==
+        digestCanonicalJson("agenc.eval.trust-fixture.expected-state.v1", fixture.expectedState)
+    ) {
+      issues.push(`${scenario.scenarioId}: expected-state digest mismatch`);
+    }
+  }
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return bundle;
+}

--- a/runtime/src/eval-suites/index.ts
+++ b/runtime/src/eval-suites/index.ts
@@ -1,0 +1,53 @@
+export {
+  COMPETITIVE_CONDITIONS,
+  EVAL_SUITE_PROTOCOL_VERSION,
+  RELEASED_EVAL_SUITE_V1_DIGESTS,
+  TRUST_FAULT_CLASSES,
+  type CompetitiveCodingSuiteDefinitionDocument,
+  type CompetitiveCodingReportDocument,
+  type CompetitiveCondition,
+  type CompetitiveConditionRegistration,
+  type CompetitiveFaultCondition,
+  type CompetitiveFaultPlan,
+  type EvalSuiteCatalogDocument,
+  type EvalSuiteCatalogEntry,
+  type EvalSuiteClass,
+  type EvalSuiteDefinitionDocument,
+  type EvalSuiteArtifactDescriptor,
+  type EvalSuiteEvidenceDocument,
+  type EvalSuiteReference,
+  type EvalSuiteResetReceiptDocument,
+  type EvalSuiteProtocolDocument,
+  type EvalSuiteProtocolVersion,
+  type TrustConformanceSuiteDefinitionDocument,
+  type TrustConformanceReportDocument,
+  type TrustFaultClass,
+  type TrustFaultPlan,
+  type TrustFixtureBundleDocument,
+  type TrustFixtureState,
+  type TrustScenarioDefinition,
+  type ValidatedEvalSuiteCatalog,
+} from "./types.js";
+export {
+  EvalSuiteProtocolValidationError,
+  assertReleasedEvalSuiteCatalog,
+  compileCompetitiveFaultPlan,
+  compileTrustFaultPlans,
+  computeCompetitiveHarnessConfigDigest,
+  computeEvalSuiteResetPolicyDigest,
+  computeTrustHarnessConfigDigest,
+  validateCompetitiveConditionRegistrations,
+  validateEvalSuiteCatalogSet,
+  validateEvalSuiteProtocolDocument,
+} from "./validation.js";
+export { loadAndValidateEvalSuiteCatalog } from "./catalog.js";
+export {
+  validateTrustFixtureBundleBinding,
+  validateTrustFixtureBundleDocument,
+} from "./fixtures.js";
+export {
+  validateCompetitiveCodingReport,
+  validateEvalSuiteEvidenceDocument,
+  validateEvalSuiteResetReceipt,
+  validateTrustConformanceReport,
+} from "./evidence.js";

--- a/runtime/src/eval-suites/suite-evidence-v1.schema.json
+++ b/runtime/src/eval-suites/suite-evidence-v1.schema.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "urn:agenc:eval:suite-evidence:1.0.0",
+  "title": "AgenC Evaluation Suite Evidence v1",
+  "oneOf": [
+    { "$ref": "#/definitions/resetReceipt" },
+    { "$ref": "#/definitions/competitiveReport" },
+    { "$ref": "#/definitions/trustReport" }
+  ],
+  "definitions": {
+    "protocolVersion": { "const": "1.0.0" },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$"
+    },
+    "semver": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$"
+    },
+    "nonNegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "suiteReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suiteClass", "suiteId", "suiteVersion", "definitionDigest"],
+      "properties": {
+        "suiteClass": { "enum": ["competitive_coding", "trust_conformance"] },
+        "suiteId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$" },
+        "suiteVersion": { "$ref": "#/definitions/semver" },
+        "definitionDigest": { "$ref": "#/definitions/digest" }
+      }
+    },
+    "resetReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "suiteProtocolVersion",
+        "documentDigest",
+        "suiteDefinitionDigest",
+        "attemptId",
+        "createdAt",
+        "resetPolicyDigest",
+        "suiteManifestDigest",
+        "taskDocumentDigest",
+        "taskResetRecipeDigest",
+        "condition",
+        "scenarioId",
+        "seedSlot",
+        "systemConfigurationDigest",
+        "workspace",
+        "isolation",
+        "processTree"
+      ],
+      "properties": {
+        "kind": { "const": "agenc.eval.suite-reset-receipt" },
+        "suiteProtocolVersion": { "$ref": "#/definitions/protocolVersion" },
+        "documentDigest": { "$ref": "#/definitions/digest" },
+        "suiteDefinitionDigest": { "$ref": "#/definitions/digest" },
+        "attemptId": { "$ref": "#/definitions/id" },
+        "createdAt": { "$ref": "#/definitions/timestamp" },
+        "resetPolicyDigest": { "$ref": "#/definitions/digest" },
+        "suiteManifestDigest": {
+          "anyOf": [{ "$ref": "#/definitions/digest" }, { "type": "null" }]
+        },
+        "taskDocumentDigest": {
+          "anyOf": [{ "$ref": "#/definitions/digest" }, { "type": "null" }]
+        },
+        "taskResetRecipeDigest": {
+          "anyOf": [{ "$ref": "#/definitions/digest" }, { "type": "null" }]
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "enum": ["clean", "coordinator_process_kill", "client_disconnect"]
+            },
+            { "type": "null" }
+          ]
+        },
+        "scenarioId": {
+          "anyOf": [{ "$ref": "#/definitions/id" }, { "type": "null" }]
+        },
+        "seedSlot": { "$ref": "#/definitions/nonNegativeSafeInteger" },
+        "systemConfigurationDigest": { "$ref": "#/definitions/digest" },
+        "workspace": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "repositoryCommit", "workspaceFingerprint"],
+          "properties": {
+            "state": { "const": "fresh_clone" },
+            "repositoryCommit": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
+            "workspaceFingerprint": { "$ref": "#/definitions/digest" }
+          }
+        },
+        "isolation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "productState",
+            "session",
+            "cache",
+            "home",
+            "toolHome",
+            "temp",
+            "sockets",
+            "ports",
+            "environment",
+            "evidenceDigest"
+          ],
+          "properties": {
+            "productState": { "const": "empty" },
+            "session": { "const": "new" },
+            "cache": { "const": "empty" },
+            "home": { "const": "isolated" },
+            "toolHome": { "const": "isolated" },
+            "temp": { "const": "isolated" },
+            "sockets": { "const": "isolated" },
+            "ports": { "const": "isolated" },
+            "environment": { "const": "sanitized" },
+            "evidenceDigest": { "$ref": "#/definitions/digest" }
+          }
+        },
+        "processTree": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["before", "after", "evidenceDigest"],
+          "properties": {
+            "before": { "const": "empty" },
+            "after": { "const": "empty" },
+            "evidenceDigest": { "$ref": "#/definitions/digest" }
+          }
+        }
+      }
+    },
+    "competitiveReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "suiteProtocolVersion",
+        "documentDigest",
+        "reportVersion",
+        "createdAt",
+        "attemptId",
+        "suite",
+        "suiteManifestDigest",
+        "condition",
+        "task",
+        "seedSlot",
+        "harnessConfigDigest",
+        "resetReceiptDigest",
+        "runRecordDigest",
+        "systemConfigurationDigest",
+        "deliveryReceipt",
+        "faultPlanDigest",
+        "fault",
+        "verifier",
+        "outcome"
+      ],
+      "properties": {
+        "kind": { "const": "agenc.eval.competitive-coding-report" },
+        "suiteProtocolVersion": { "$ref": "#/definitions/protocolVersion" },
+        "documentDigest": { "$ref": "#/definitions/digest" },
+        "reportVersion": { "const": "1.0.0" },
+        "createdAt": { "$ref": "#/definitions/timestamp" },
+        "attemptId": { "$ref": "#/definitions/id" },
+        "suite": {
+          "allOf": [
+            { "$ref": "#/definitions/suiteReference" },
+            {
+              "type": "object",
+              "properties": { "suiteClass": { "const": "competitive_coding" } }
+            }
+          ]
+        },
+        "suiteManifestDigest": { "$ref": "#/definitions/digest" },
+        "condition": {
+          "enum": ["clean", "coordinator_process_kill", "client_disconnect"]
+        },
+        "task": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["taskId", "taskVersion", "taskDocumentDigest"],
+          "properties": {
+            "taskId": { "$ref": "#/definitions/id" },
+            "taskVersion": { "$ref": "#/definitions/semver" },
+            "taskDocumentDigest": { "$ref": "#/definitions/digest" }
+          }
+        },
+        "seedSlot": { "$ref": "#/definitions/nonNegativeSafeInteger" },
+        "harnessConfigDigest": { "$ref": "#/definitions/digest" },
+        "resetReceiptDigest": { "$ref": "#/definitions/digest" },
+        "runRecordDigest": { "$ref": "#/definitions/digest" },
+        "systemConfigurationDigest": { "$ref": "#/definitions/digest" },
+        "deliveryReceipt": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "agentTaskDigest",
+            "acceptedAtMonotonicMs",
+            "processGroupEvidenceDigest",
+            "transportEvidenceDigest"
+          ],
+          "properties": {
+            "agentTaskDigest": { "$ref": "#/definitions/digest" },
+            "acceptedAtMonotonicMs": { "$ref": "#/definitions/nonNegativeSafeInteger" },
+            "processGroupEvidenceDigest": { "$ref": "#/definitions/digest" },
+            "transportEvidenceDigest": { "$ref": "#/definitions/digest" }
+          }
+        },
+        "faultPlanDigest": {
+          "anyOf": [{ "$ref": "#/definitions/digest" }, { "type": "null" }]
+        },
+        "fault": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scheduled",
+            "injected",
+            "scheduledDelayAfterAcceptanceMs",
+            "observedInjectedAtMonotonicMs",
+            "evidenceDigest"
+          ],
+          "properties": {
+            "scheduled": { "type": "boolean" },
+            "injected": { "type": "boolean" },
+            "scheduledDelayAfterAcceptanceMs": {
+              "anyOf": [
+                { "$ref": "#/definitions/nonNegativeSafeInteger" },
+                { "type": "null" }
+              ]
+            },
+            "observedInjectedAtMonotonicMs": {
+              "anyOf": [
+                { "$ref": "#/definitions/nonNegativeSafeInteger" },
+                { "type": "null" }
+              ]
+            },
+            "evidenceDigest": {
+              "anyOf": [{ "$ref": "#/definitions/digest" }, { "type": "null" }]
+            }
+          }
+        },
+        "verifier": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["result", "evidenceDigest"],
+          "properties": {
+            "result": { "enum": ["passed", "failed", "error"] },
+            "evidenceDigest": { "$ref": "#/definitions/digest" }
+          }
+        },
+        "outcome": {
+          "enum": [
+            "verified_fix",
+            "verification_failure",
+            "unsupported",
+            "fault_not_injected",
+            "infrastructure_invalid"
+          ]
+        }
+      }
+    },
+    "trustReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "suiteProtocolVersion",
+        "documentDigest",
+        "reportVersion",
+        "createdAt",
+        "attemptId",
+        "suite",
+        "scenarioId",
+        "faultClass",
+        "seedSlot",
+        "faultPlanDigest",
+        "resetReceiptDigest",
+        "runRecordDigest",
+        "systemConfigurationDigest",
+        "harnessReceiptDigest",
+        "fault",
+        "durationMs",
+        "invariantResults",
+        "observedEvidenceTypes",
+        "actualStateDigest",
+        "outcome"
+      ],
+      "properties": {
+        "kind": { "const": "agenc.eval.trust-conformance-report" },
+        "suiteProtocolVersion": { "$ref": "#/definitions/protocolVersion" },
+        "documentDigest": { "$ref": "#/definitions/digest" },
+        "reportVersion": { "const": "1.0.0" },
+        "createdAt": { "$ref": "#/definitions/timestamp" },
+        "attemptId": { "$ref": "#/definitions/id" },
+        "suite": {
+          "allOf": [
+            { "$ref": "#/definitions/suiteReference" },
+            {
+              "type": "object",
+              "properties": { "suiteClass": { "const": "trust_conformance" } }
+            }
+          ]
+        },
+        "scenarioId": { "$ref": "#/definitions/id" },
+        "faultClass": {
+          "enum": [
+            "restart",
+            "reconnect",
+            "budget",
+            "cancellation",
+            "permission",
+            "event_loss",
+            "uncertain_effect"
+          ]
+        },
+        "seedSlot": { "$ref": "#/definitions/nonNegativeSafeInteger" },
+        "faultPlanDigest": { "$ref": "#/definitions/digest" },
+        "resetReceiptDigest": { "$ref": "#/definitions/digest" },
+        "runRecordDigest": { "$ref": "#/definitions/digest" },
+        "systemConfigurationDigest": { "$ref": "#/definitions/digest" },
+        "harnessReceiptDigest": { "$ref": "#/definitions/digest" },
+        "fault": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["injected", "injectedAtVirtualMs", "evidenceDigest"],
+          "properties": {
+            "injected": { "type": "boolean" },
+            "injectedAtVirtualMs": {
+              "anyOf": [
+                { "$ref": "#/definitions/nonNegativeSafeInteger" },
+                { "type": "null" }
+              ]
+            },
+            "evidenceDigest": { "$ref": "#/definitions/digest" }
+          }
+        },
+        "durationMs": { "$ref": "#/definitions/nonNegativeSafeInteger" },
+        "invariantResults": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["invariant", "passed", "evidenceDigest"],
+            "properties": {
+              "invariant": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,127}$" },
+              "passed": { "type": "boolean" },
+              "evidenceDigest": { "$ref": "#/definitions/digest" }
+            }
+          }
+        },
+        "observedEvidenceTypes": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_.]{1,127}$" }
+        },
+        "actualStateDigest": { "$ref": "#/definitions/digest" },
+        "outcome": { "enum": ["passed", "failed", "infrastructure_invalid"] }
+      }
+    }
+  }
+}

--- a/runtime/src/eval-suites/suite-protocol-v1.schema.json
+++ b/runtime/src/eval-suites/suite-protocol-v1.schema.json
@@ -1,0 +1,542 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "urn:agenc:eval:suite-protocol:1.0.0",
+  "title": "AgenC Evaluation Suite Protocol v1",
+  "oneOf": [
+    { "$ref": "#/definitions/competitiveDefinition" },
+    { "$ref": "#/definitions/trustDefinition" },
+    { "$ref": "#/definitions/catalog" }
+  ],
+  "definitions": {
+    "protocolVersion": { "const": "1.0.0" },
+    "evalContractVersion": { "const": "1.0.0" },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+    },
+    "semver": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "artifactDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "digest", "sizeBytes", "mediaType"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "^[A-Za-z0-9._/-]+$"
+        },
+        "digest": { "$ref": "#/definitions/digest" },
+        "sizeBytes": { "type": "integer", "minimum": 1, "maximum": 1048576 },
+        "mediaType": { "const": "application/json" }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$"
+    },
+    "changeControl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "publishedVersionMutation",
+        "taskOrScenarioChange",
+        "scheduleOrScoringChange",
+        "compatibility",
+        "rollback"
+      ],
+      "properties": {
+        "publishedVersionMutation": { "const": "forbidden" },
+        "taskOrScenarioChange": { "const": "new_suite_version" },
+        "scheduleOrScoringChange": { "const": "new_suite_version" },
+        "compatibility": { "const": "exact_kind_id_version_digest" },
+        "rollback": { "const": "select_prior_immutable_digest" }
+      }
+    },
+    "resetPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workspace",
+        "productState",
+        "session",
+        "cache",
+        "home",
+        "toolHome",
+        "temp",
+        "sockets",
+        "ports",
+        "environment",
+        "processTreeBeforeAndAfter",
+        "receipt"
+      ],
+      "properties": {
+        "workspace": { "const": "fresh_clone" },
+        "productState": { "const": "empty" },
+        "session": { "const": "new" },
+        "cache": { "const": "empty" },
+        "home": { "const": "isolated" },
+        "toolHome": { "const": "isolated" },
+        "temp": { "const": "isolated" },
+        "sockets": { "const": "isolated" },
+        "ports": { "const": "isolated" },
+        "environment": { "const": "sanitized" },
+        "processTreeBeforeAndAfter": { "const": "empty" },
+        "receipt": { "const": "content_addressed_required" }
+      }
+    },
+    "competitiveFaultAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["condition", "target", "operation", "recovery"],
+      "properties": {
+        "condition": {
+          "enum": ["coordinator_process_kill", "client_disconnect"]
+        },
+        "target": {
+          "enum": ["coordinator_process_group", "client_transport"]
+        },
+        "operation": { "enum": ["sigkill", "abrupt_close"] },
+        "recovery": {
+          "enum": ["adapter_restart_and_attach", "adapter_reconnect"]
+        }
+      }
+    },
+    "competitiveDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "suiteProtocolVersion",
+        "documentDigest",
+        "suiteClass",
+        "suiteId",
+        "suiteVersion",
+        "createdAt",
+        "status",
+        "evaluationContractVersion",
+        "taskProtocol",
+        "adapterContract",
+        "resetPolicy",
+        "conditions",
+        "faultSchedule",
+        "reporting",
+        "changeControl"
+      ],
+      "properties": {
+        "kind": { "const": "agenc.eval.competitive-suite-definition" },
+        "suiteProtocolVersion": { "$ref": "#/definitions/protocolVersion" },
+        "documentDigest": { "$ref": "#/definitions/digest" },
+        "suiteClass": { "const": "competitive_coding" },
+        "suiteId": { "$ref": "#/definitions/id" },
+        "suiteVersion": { "$ref": "#/definitions/semver" },
+        "createdAt": { "$ref": "#/definitions/timestamp" },
+        "status": { "const": "active" },
+        "evaluationContractVersion": { "$ref": "#/definitions/evalContractVersion" },
+        "taskProtocol": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "taskKind",
+            "operatorTaskKind",
+            "agentTaskKind",
+            "agentInputEquality",
+            "hiddenVerification",
+            "outputTruth",
+            "containerReferences",
+            "productSpecificTaskSemantics",
+            "unsupportedCapability"
+          ],
+          "properties": {
+            "taskKind": { "const": "real_repository_change" },
+            "operatorTaskKind": { "const": "agenc.eval.operator-task" },
+            "agentTaskKind": { "const": "agenc.eval.agent-task" },
+            "agentInputEquality": { "const": "exact_canonical_agent_task_bytes" },
+            "hiddenVerification": { "const": "out_of_workspace_result_only" },
+            "outputTruth": { "const": "external_workspace_patch_and_declared_artifacts" },
+            "containerReferences": { "const": "digest_only" },
+            "productSpecificTaskSemantics": { "const": "forbidden" },
+            "unsupportedCapability": { "const": "count_failure" }
+          }
+        },
+        "adapterContract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "version",
+            "operations",
+            "acceptanceSource",
+            "resultTruth",
+            "productReportedCompletion"
+          ],
+          "properties": {
+            "version": { "const": "1.0.0" },
+            "operations": {
+              "type": "array",
+              "minItems": 6,
+              "maxItems": 6,
+              "items": [
+                { "const": "start" },
+                { "const": "deliver_task_and_record_receipt" },
+                { "const": "disconnect_client_transport" },
+                { "const": "reconnect_client_transport" },
+                { "const": "kill_coordinator_process_group" },
+                { "const": "collect_result" }
+              ],
+              "additionalItems": false
+            },
+            "acceptanceSource": { "const": "harness_task_delivery_receipt" },
+            "resultTruth": { "const": "external_workspace_and_hidden_verifier" },
+            "productReportedCompletion": { "const": "diagnostic_only" }
+          }
+        },
+        "resetPolicy": { "$ref": "#/definitions/resetPolicy" },
+        "conditions": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            { "const": "clean" },
+            { "const": "coordinator_process_kill" },
+            { "const": "client_disconnect" }
+          ],
+          "additionalItems": false
+        },
+        "faultSchedule": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "scheduleVersion",
+            "triggerSource",
+            "delayAlgorithm",
+            "seedDomain",
+            "minimumDelayMs",
+            "maximumDelayMs",
+            "recoveryWindowMs",
+            "maximumInjectionJitterMs",
+            "actions",
+            "productProtocolObservation",
+            "systemSpecificTriggerFields",
+            "faultNotInjected"
+          ],
+          "properties": {
+            "kind": { "const": "product_neutral_black_box_v1" },
+            "scheduleVersion": { "const": "1.0.0" },
+            "triggerSource": { "const": "harness_delivery_receipt_monotonic" },
+            "delayAlgorithm": { "const": "sha256_rejection_u32_v1" },
+            "seedDomain": { "const": "agenc.eval.competitive-fault-delay.v1" },
+            "minimumDelayMs": { "type": "integer", "minimum": 1, "maximum": 3600000 },
+            "maximumDelayMs": { "type": "integer", "minimum": 1, "maximum": 3600000 },
+            "recoveryWindowMs": { "type": "integer", "minimum": 1, "maximum": 3600000 },
+            "maximumInjectionJitterMs": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 60000
+            },
+            "actions": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": { "$ref": "#/definitions/competitiveFaultAction" }
+            },
+            "productProtocolObservation": { "const": "forbidden" },
+            "systemSpecificTriggerFields": { "const": "forbidden" },
+            "faultNotInjected": { "const": "count_failure" }
+          }
+        },
+        "reporting": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "version",
+            "primaryMetric",
+            "requiredMetrics",
+            "allAttemptsInDenominator",
+            "mixedSuiteAggregation",
+            "separateFrom",
+            "trustConformanceMetrics"
+          ],
+          "properties": {
+            "kind": { "const": "agenc.eval.competitive-coding-report" },
+            "version": { "const": "1.0.0" },
+            "primaryMetric": { "const": "verified_fix_rate_clean" },
+            "requiredMetrics": {
+              "type": "array",
+              "minItems": 5,
+              "maxItems": 5,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "verified_fix_rate_clean",
+                  "verified_fix_rate_by_fault_condition",
+                  "recovery_rate_by_fault_condition",
+                  "attempt_count",
+                  "unsupported_count"
+                ]
+              }
+            },
+            "allAttemptsInDenominator": { "const": true },
+            "mixedSuiteAggregation": { "const": "forbidden" },
+            "separateFrom": { "const": "agenc.eval.trust-conformance-report" },
+            "trustConformanceMetrics": { "const": "forbidden" }
+          }
+        },
+        "changeControl": { "$ref": "#/definitions/changeControl" }
+      }
+    },
+    "trustScenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenarioId",
+        "faultClass",
+        "injectionBoundary",
+        "faultAction",
+        "requiredInvariants",
+        "requiredEvidenceTypes",
+        "fixtureDigest",
+        "initialStateDigest",
+        "expectedStateDigest",
+        "timeoutMs"
+      ],
+      "properties": {
+        "scenarioId": { "$ref": "#/definitions/id" },
+        "faultClass": {
+          "enum": [
+            "restart",
+            "reconnect",
+            "budget",
+            "cancellation",
+            "permission",
+            "event_loss",
+            "uncertain_effect"
+          ]
+        },
+        "injectionBoundary": {
+          "enum": [
+            "after_reservation_before_model_result_commit",
+            "after_event_publish_before_cursor_ack",
+            "concurrent_child_reservation_before_commit",
+            "parent_cancel_after_child_admission",
+            "repository_requests_capability_escalation",
+            "retention_gap_before_reconnect",
+            "after_effect_dispatch_before_ack_commit"
+          ]
+        },
+        "faultAction": {
+          "enum": [
+            "restart_product_process",
+            "disconnect_and_reconnect_client",
+            "race_sibling_budget_reservations",
+            "cancel_parent",
+            "inject_hostile_repository_instruction",
+            "evict_replay_window",
+            "drop_effect_acknowledgement"
+          ]
+        },
+        "requiredInvariants": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,127}$" }
+        },
+        "requiredEvidenceTypes": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_.]{1,127}$" }
+        },
+        "fixtureDigest": { "$ref": "#/definitions/digest" },
+        "initialStateDigest": { "$ref": "#/definitions/digest" },
+        "expectedStateDigest": { "$ref": "#/definitions/digest" },
+        "timeoutMs": { "type": "integer", "minimum": 1, "maximum": 3600000 }
+      }
+    },
+    "trustDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "suiteProtocolVersion",
+        "documentDigest",
+        "suiteClass",
+        "suiteId",
+        "suiteVersion",
+        "createdAt",
+        "status",
+        "evaluationContractVersion",
+        "subject",
+        "execution",
+        "resetPolicy",
+        "scenarios",
+        "reporting",
+        "changeControl"
+      ],
+      "properties": {
+        "kind": { "const": "agenc.eval.trust-suite-definition" },
+        "suiteProtocolVersion": { "$ref": "#/definitions/protocolVersion" },
+        "documentDigest": { "$ref": "#/definitions/digest" },
+        "suiteClass": { "const": "trust_conformance" },
+        "suiteId": { "$ref": "#/definitions/id" },
+        "suiteVersion": { "$ref": "#/definitions/semver" },
+        "createdAt": { "$ref": "#/definitions/timestamp" },
+        "status": { "const": "active" },
+        "evaluationContractVersion": { "$ref": "#/definitions/evalContractVersion" },
+        "subject": { "const": "agenc_only" },
+        "execution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider",
+            "liveProviderCalls",
+            "scheduler",
+            "seedAlgorithm",
+            "seedDomain",
+            "scenarioOrder",
+            "retries",
+            "clock",
+            "network",
+            "harnessImplementationDigest",
+            "fakeProviderFixtureDigest",
+            "fakeToolFixtureDigest",
+            "fixtureBundle"
+          ],
+          "properties": {
+            "provider": { "const": "deterministic_offline_fake" },
+            "liveProviderCalls": { "const": "forbidden" },
+            "scheduler": { "const": "seeded_replayable" },
+            "seedAlgorithm": { "const": "sha256_domain_separated_v1" },
+            "seedDomain": { "const": "agenc.eval.trust-fault-plan.v1" },
+            "scenarioOrder": { "const": "lexicographic_scenario_id" },
+            "retries": { "const": "new_attempt_preserve_failed_evidence" },
+            "clock": { "const": "virtual_monotonic_ms" },
+            "network": { "const": "disabled" },
+            "harnessImplementationDigest": { "$ref": "#/definitions/digest" },
+            "fakeProviderFixtureDigest": { "$ref": "#/definitions/digest" },
+            "fakeToolFixtureDigest": { "$ref": "#/definitions/digest" },
+            "fixtureBundle": { "$ref": "#/definitions/artifactDescriptor" }
+          }
+        },
+        "resetPolicy": { "$ref": "#/definitions/resetPolicy" },
+        "scenarios": {
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 7,
+          "uniqueItems": true,
+          "items": { "$ref": "#/definitions/trustScenario" }
+        },
+        "reporting": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "version",
+            "primaryMetric",
+            "requiredMetrics",
+            "zeroToleranceMetrics",
+            "allAttemptsInDenominator",
+            "mixedSuiteAggregation",
+            "separateFrom",
+            "codingQualityMetrics"
+          ],
+          "properties": {
+            "kind": { "const": "agenc.eval.trust-conformance-report" },
+            "version": { "const": "1.0.0" },
+            "primaryMetric": { "const": "trust_recovery_rate" },
+            "requiredMetrics": {
+              "type": "array",
+              "minItems": 6,
+              "maxItems": 6,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "trust_recovery_rate",
+                  "fault_family_results",
+                  "policy_escape_count",
+                  "duplicated_uncertain_mutation_count",
+                  "hidden_event_loss_count",
+                  "unknown_outcome_count"
+                ]
+              }
+            },
+            "zeroToleranceMetrics": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "policy_escape_count",
+                  "duplicated_uncertain_mutation_count",
+                  "hidden_event_loss_count"
+                ]
+              }
+            },
+            "allAttemptsInDenominator": { "const": true },
+            "mixedSuiteAggregation": { "const": "forbidden" },
+            "separateFrom": { "const": "agenc.eval.competitive-coding-report" },
+            "codingQualityMetrics": { "const": "forbidden" }
+          }
+        },
+        "changeControl": { "$ref": "#/definitions/changeControl" }
+      }
+    },
+    "catalogEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suiteClass", "suiteId", "suiteVersion", "definitionDigest", "path"],
+      "properties": {
+        "suiteClass": { "enum": ["competitive_coding", "trust_conformance"] },
+        "suiteId": { "$ref": "#/definitions/id" },
+        "suiteVersion": { "$ref": "#/definitions/semver" },
+        "definitionDigest": { "$ref": "#/definitions/digest" },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "^[A-Za-z0-9._/-]+$"
+        }
+      }
+    },
+    "catalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "suiteProtocolVersion",
+        "documentDigest",
+        "catalogId",
+        "catalogVersion",
+        "createdAt",
+        "activeDefinitions"
+      ],
+      "properties": {
+        "kind": { "const": "agenc.eval.suite-catalog" },
+        "suiteProtocolVersion": { "$ref": "#/definitions/protocolVersion" },
+        "documentDigest": { "$ref": "#/definitions/digest" },
+        "catalogId": { "$ref": "#/definitions/id" },
+        "catalogVersion": { "$ref": "#/definitions/semver" },
+        "createdAt": { "$ref": "#/definitions/timestamp" },
+        "activeDefinitions": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/definitions/catalogEntry" }
+        }
+      }
+    }
+  }
+}

--- a/runtime/src/eval-suites/trust-fixture-bundle-v1.schema.json
+++ b/runtime/src/eval-suites/trust-fixture-bundle-v1.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "urn:agenc:eval:trust-fixture-bundle:1.0.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "bundleVersion",
+    "documentDigest",
+    "createdAt",
+    "harness",
+    "fakeProvider",
+    "fakeTools",
+    "scenarios"
+  ],
+  "properties": {
+    "kind": { "const": "agenc.eval.trust-fixture-bundle" },
+    "bundleVersion": { "const": "1.0.0" },
+    "documentDigest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "createdAt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementationId",
+        "implementationVersion",
+        "clock",
+        "scheduler",
+        "injectionSemantics"
+      ],
+      "properties": {
+        "implementationId": { "const": "agenc-trust-state-machine" },
+        "implementationVersion": { "const": "1.0.0" },
+        "clock": { "const": "virtual_monotonic_ms" },
+        "scheduler": { "const": "seeded_replayable" },
+        "injectionSemantics": { "const": "exact_scenario_boundary" }
+      }
+    },
+    "fakeProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixtureId", "fixtureVersion", "network", "responseStates"],
+      "properties": {
+        "fixtureId": { "const": "agenc-offline-fake-provider" },
+        "fixtureVersion": { "const": "1.0.0" },
+        "network": { "const": "disabled" },
+        "responseStates": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,127}$" }
+        }
+      }
+    },
+    "fakeTools": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixtureId", "fixtureVersion", "network", "resultStates"],
+      "properties": {
+        "fixtureId": { "const": "agenc-offline-fake-tools" },
+        "fixtureVersion": { "const": "1.0.0" },
+        "network": { "const": "disabled" },
+        "resultStates": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,127}$" }
+        }
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scenarioId", "fixture", "initialState", "expectedState"],
+        "properties": {
+          "scenarioId": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+          },
+          "fixture": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["steps"],
+            "properties": {
+              "steps": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 16,
+                "uniqueItems": true,
+                "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,127}$" }
+              }
+            }
+          },
+          "initialState": { "$ref": "#/definitions/state" },
+          "expectedState": { "$ref": "#/definitions/state" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["facts"],
+      "properties": {
+        "facts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]{1,127}$" }
+        }
+      }
+    }
+  }
+}

--- a/runtime/src/eval-suites/types.ts
+++ b/runtime/src/eval-suites/types.ts
@@ -1,0 +1,460 @@
+import type {
+  EvalContractVersion,
+  PreregistrationDocument,
+  Sha256Digest,
+  SuiteManifestDocument,
+} from "../eval-contract/index.js";
+
+export const EVAL_SUITE_PROTOCOL_VERSION = "1.0.0" as const;
+
+export const RELEASED_EVAL_SUITE_V1_DIGESTS = Object.freeze({
+  catalog: "sha256:531627aec0c3a287ebd568494e1a9c0dc8116f01d324a61d571d1a200e2bde62",
+  competitive:
+    "sha256:e7214668c3bd9d9299afb61ade397232f3e060d8a45ee7bd26ac87675514f69b",
+  trust: "sha256:e83ad76587b4e0fa8897f29a7148ac3c1823e560eff86ea43fc4fec7105db811",
+} as const);
+
+export const COMPETITIVE_CONDITIONS = [
+  "clean",
+  "coordinator_process_kill",
+  "client_disconnect",
+] as const;
+
+export const TRUST_FAULT_CLASSES = [
+  "restart",
+  "reconnect",
+  "budget",
+  "cancellation",
+  "permission",
+  "event_loss",
+  "uncertain_effect",
+] as const;
+
+export type EvalSuiteProtocolVersion = typeof EVAL_SUITE_PROTOCOL_VERSION;
+export type EvalSuiteClass = "competitive_coding" | "trust_conformance";
+export type CompetitiveCondition = (typeof COMPETITIVE_CONDITIONS)[number];
+export type CompetitiveFaultCondition = Exclude<CompetitiveCondition, "clean">;
+export type TrustFaultClass = (typeof TRUST_FAULT_CLASSES)[number];
+
+export interface EvalSuiteArtifactDescriptor {
+  readonly path: string;
+  readonly digest: Sha256Digest;
+  readonly sizeBytes: number;
+  readonly mediaType: "application/json";
+}
+
+export interface TrustFixtureState {
+  readonly facts: readonly string[];
+}
+
+export interface TrustFixtureBundleDocument {
+  readonly kind: "agenc.eval.trust-fixture-bundle";
+  readonly bundleVersion: "1.0.0";
+  readonly documentDigest: Sha256Digest;
+  readonly createdAt: string;
+  readonly harness: {
+    readonly implementationId: "agenc-trust-state-machine";
+    readonly implementationVersion: "1.0.0";
+    readonly clock: "virtual_monotonic_ms";
+    readonly scheduler: "seeded_replayable";
+    readonly injectionSemantics: "exact_scenario_boundary";
+  };
+  readonly fakeProvider: {
+    readonly fixtureId: "agenc-offline-fake-provider";
+    readonly fixtureVersion: "1.0.0";
+    readonly network: "disabled";
+    readonly responseStates: readonly string[];
+  };
+  readonly fakeTools: {
+    readonly fixtureId: "agenc-offline-fake-tools";
+    readonly fixtureVersion: "1.0.0";
+    readonly network: "disabled";
+    readonly resultStates: readonly string[];
+  };
+  readonly scenarios: readonly {
+    readonly scenarioId: string;
+    readonly fixture: { readonly steps: readonly string[] };
+    readonly initialState: TrustFixtureState;
+    readonly expectedState: TrustFixtureState;
+  }[];
+}
+
+export interface EvalSuiteChangeControl {
+  readonly publishedVersionMutation: "forbidden";
+  readonly taskOrScenarioChange: "new_suite_version";
+  readonly scheduleOrScoringChange: "new_suite_version";
+  readonly compatibility: "exact_kind_id_version_digest";
+  readonly rollback: "select_prior_immutable_digest";
+}
+
+export interface EvalSuiteResetPolicy {
+  readonly workspace: "fresh_clone";
+  readonly productState: "empty";
+  readonly session: "new";
+  readonly cache: "empty";
+  readonly home: "isolated";
+  readonly toolHome: "isolated";
+  readonly temp: "isolated";
+  readonly sockets: "isolated";
+  readonly ports: "isolated";
+  readonly environment: "sanitized";
+  readonly processTreeBeforeAndAfter: "empty";
+  readonly receipt: "content_addressed_required";
+}
+
+export interface CompetitiveFaultAction {
+  readonly condition: CompetitiveFaultCondition;
+  readonly target: "coordinator_process_group" | "client_transport";
+  readonly operation: "sigkill" | "abrupt_close";
+  readonly recovery: "adapter_restart_and_attach" | "adapter_reconnect";
+}
+
+export interface CompetitiveCodingSuiteDefinitionDocument {
+  readonly kind: "agenc.eval.competitive-suite-definition";
+  readonly suiteProtocolVersion: EvalSuiteProtocolVersion;
+  readonly documentDigest: Sha256Digest;
+  readonly suiteClass: "competitive_coding";
+  readonly suiteId: string;
+  readonly suiteVersion: string;
+  readonly createdAt: string;
+  readonly status: "active";
+  readonly evaluationContractVersion: EvalContractVersion;
+  readonly taskProtocol: {
+    readonly taskKind: "real_repository_change";
+    readonly operatorTaskKind: "agenc.eval.operator-task";
+    readonly agentTaskKind: "agenc.eval.agent-task";
+    readonly agentInputEquality: "exact_canonical_agent_task_bytes";
+    readonly hiddenVerification: "out_of_workspace_result_only";
+    readonly outputTruth: "external_workspace_patch_and_declared_artifacts";
+    readonly containerReferences: "digest_only";
+    readonly productSpecificTaskSemantics: "forbidden";
+    readonly unsupportedCapability: "count_failure";
+  };
+  readonly adapterContract: {
+    readonly version: "1.0.0";
+    readonly operations: readonly [
+      "start",
+      "deliver_task_and_record_receipt",
+      "disconnect_client_transport",
+      "reconnect_client_transport",
+      "kill_coordinator_process_group",
+      "collect_result",
+    ];
+    readonly acceptanceSource: "harness_task_delivery_receipt";
+    readonly resultTruth: "external_workspace_and_hidden_verifier";
+    readonly productReportedCompletion: "diagnostic_only";
+  };
+  readonly resetPolicy: EvalSuiteResetPolicy;
+  readonly conditions: readonly [
+    "clean",
+    "coordinator_process_kill",
+    "client_disconnect",
+  ];
+  readonly faultSchedule: {
+    readonly kind: "product_neutral_black_box_v1";
+    readonly scheduleVersion: "1.0.0";
+    readonly triggerSource: "harness_delivery_receipt_monotonic";
+    readonly delayAlgorithm: "sha256_rejection_u32_v1";
+    readonly seedDomain: "agenc.eval.competitive-fault-delay.v1";
+    readonly minimumDelayMs: number;
+    readonly maximumDelayMs: number;
+    readonly recoveryWindowMs: number;
+    readonly maximumInjectionJitterMs: number;
+    readonly actions: readonly CompetitiveFaultAction[];
+    readonly productProtocolObservation: "forbidden";
+    readonly systemSpecificTriggerFields: "forbidden";
+    readonly faultNotInjected: "count_failure";
+  };
+  readonly reporting: {
+    readonly kind: "agenc.eval.competitive-coding-report";
+    readonly version: "1.0.0";
+    readonly primaryMetric: "verified_fix_rate_clean";
+    readonly requiredMetrics: readonly string[];
+    readonly allAttemptsInDenominator: true;
+    readonly mixedSuiteAggregation: "forbidden";
+    readonly separateFrom: "agenc.eval.trust-conformance-report";
+    readonly trustConformanceMetrics: "forbidden";
+  };
+  readonly changeControl: EvalSuiteChangeControl;
+}
+
+export interface TrustScenarioDefinition {
+  readonly scenarioId: string;
+  readonly faultClass: TrustFaultClass;
+  readonly injectionBoundary:
+    | "after_reservation_before_model_result_commit"
+    | "after_event_publish_before_cursor_ack"
+    | "concurrent_child_reservation_before_commit"
+    | "parent_cancel_after_child_admission"
+    | "repository_requests_capability_escalation"
+    | "retention_gap_before_reconnect"
+    | "after_effect_dispatch_before_ack_commit";
+  readonly faultAction:
+    | "restart_product_process"
+    | "disconnect_and_reconnect_client"
+    | "race_sibling_budget_reservations"
+    | "cancel_parent"
+    | "inject_hostile_repository_instruction"
+    | "evict_replay_window"
+    | "drop_effect_acknowledgement";
+  readonly requiredInvariants: readonly string[];
+  readonly requiredEvidenceTypes: readonly string[];
+  readonly fixtureDigest: Sha256Digest;
+  readonly initialStateDigest: Sha256Digest;
+  readonly expectedStateDigest: Sha256Digest;
+  readonly timeoutMs: number;
+}
+
+export interface TrustConformanceSuiteDefinitionDocument {
+  readonly kind: "agenc.eval.trust-suite-definition";
+  readonly suiteProtocolVersion: EvalSuiteProtocolVersion;
+  readonly documentDigest: Sha256Digest;
+  readonly suiteClass: "trust_conformance";
+  readonly suiteId: string;
+  readonly suiteVersion: string;
+  readonly createdAt: string;
+  readonly status: "active";
+  readonly evaluationContractVersion: EvalContractVersion;
+  readonly subject: "agenc_only";
+  readonly execution: {
+    readonly provider: "deterministic_offline_fake";
+    readonly liveProviderCalls: "forbidden";
+    readonly scheduler: "seeded_replayable";
+    readonly seedAlgorithm: "sha256_domain_separated_v1";
+    readonly seedDomain: "agenc.eval.trust-fault-plan.v1";
+    readonly scenarioOrder: "lexicographic_scenario_id";
+    readonly retries: "new_attempt_preserve_failed_evidence";
+    readonly clock: "virtual_monotonic_ms";
+    readonly network: "disabled";
+    readonly harnessImplementationDigest: Sha256Digest;
+    readonly fakeProviderFixtureDigest: Sha256Digest;
+    readonly fakeToolFixtureDigest: Sha256Digest;
+    readonly fixtureBundle: EvalSuiteArtifactDescriptor;
+  };
+  readonly resetPolicy: EvalSuiteResetPolicy;
+  readonly scenarios: readonly TrustScenarioDefinition[];
+  readonly reporting: {
+    readonly kind: "agenc.eval.trust-conformance-report";
+    readonly version: "1.0.0";
+    readonly primaryMetric: "trust_recovery_rate";
+    readonly requiredMetrics: readonly string[];
+    readonly zeroToleranceMetrics: readonly string[];
+    readonly allAttemptsInDenominator: true;
+    readonly mixedSuiteAggregation: "forbidden";
+    readonly separateFrom: "agenc.eval.competitive-coding-report";
+    readonly codingQualityMetrics: "forbidden";
+  };
+  readonly changeControl: EvalSuiteChangeControl;
+}
+
+export type EvalSuiteDefinitionDocument =
+  | CompetitiveCodingSuiteDefinitionDocument
+  | TrustConformanceSuiteDefinitionDocument;
+
+export interface EvalSuiteCatalogEntry {
+  readonly suiteClass: EvalSuiteClass;
+  readonly suiteId: string;
+  readonly suiteVersion: string;
+  readonly definitionDigest: Sha256Digest;
+  readonly path: string;
+}
+
+export interface EvalSuiteCatalogDocument {
+  readonly kind: "agenc.eval.suite-catalog";
+  readonly suiteProtocolVersion: EvalSuiteProtocolVersion;
+  readonly documentDigest: Sha256Digest;
+  readonly catalogId: string;
+  readonly catalogVersion: string;
+  readonly createdAt: string;
+  readonly activeDefinitions: readonly EvalSuiteCatalogEntry[];
+}
+
+export type EvalSuiteProtocolDocument = EvalSuiteDefinitionDocument | EvalSuiteCatalogDocument;
+
+export interface CompetitiveFaultPlan {
+  readonly kind: "agenc.eval.competitive-fault-plan";
+  readonly suiteDefinitionDigest: Sha256Digest;
+  readonly suiteId: string;
+  readonly suiteVersion: string;
+  readonly suiteManifestDigest: Sha256Digest;
+  readonly condition: CompetitiveFaultCondition;
+  readonly taskId: string;
+  readonly taskVersion: string;
+  readonly taskDocumentDigest: Sha256Digest;
+  readonly taskWallTimeMs: number;
+  readonly seedSlot: number;
+  readonly delayAfterAcceptanceMs: number;
+  readonly maximumDelayAfterAcceptanceMs: number;
+  readonly recoveryWindowMs: number;
+  readonly maximumInjectionJitterMs: number;
+  readonly target: CompetitiveFaultAction["target"];
+  readonly operation: CompetitiveFaultAction["operation"];
+  readonly recovery: CompetitiveFaultAction["recovery"];
+  readonly planDigest: Sha256Digest;
+}
+
+export interface TrustFaultPlan {
+  readonly kind: "agenc.eval.trust-fault-plan";
+  readonly suiteDefinitionDigest: Sha256Digest;
+  readonly suiteId: string;
+  readonly suiteVersion: string;
+  readonly scenarioId: string;
+  readonly faultClass: TrustFaultClass;
+  readonly seedSlot: number;
+  readonly scenarioSeedDigest: Sha256Digest;
+  readonly scheduleOrdinal: number;
+  readonly injectionBoundary: TrustScenarioDefinition["injectionBoundary"];
+  readonly faultAction: TrustScenarioDefinition["faultAction"];
+  readonly timeoutMs: number;
+  readonly requiredInvariants: readonly string[];
+  readonly requiredEvidenceTypes: readonly string[];
+  readonly harnessConfigDigest: Sha256Digest;
+  readonly harnessImplementationDigest: Sha256Digest;
+  readonly fakeProviderFixtureDigest: Sha256Digest;
+  readonly fakeToolFixtureDigest: Sha256Digest;
+  readonly fixtureDigest: Sha256Digest;
+  readonly initialStateDigest: Sha256Digest;
+  readonly expectedStateDigest: Sha256Digest;
+  readonly planDigest: Sha256Digest;
+}
+
+export interface EvalSuiteResetReceiptDocument {
+  readonly kind: "agenc.eval.suite-reset-receipt";
+  readonly suiteProtocolVersion: EvalSuiteProtocolVersion;
+  readonly documentDigest: Sha256Digest;
+  readonly suiteDefinitionDigest: Sha256Digest;
+  readonly attemptId: string;
+  readonly createdAt: string;
+  readonly resetPolicyDigest: Sha256Digest;
+  readonly suiteManifestDigest: Sha256Digest | null;
+  readonly taskDocumentDigest: Sha256Digest | null;
+  readonly taskResetRecipeDigest: Sha256Digest | null;
+  readonly condition: CompetitiveCondition | null;
+  readonly scenarioId: string | null;
+  readonly seedSlot: number;
+  readonly systemConfigurationDigest: Sha256Digest;
+  readonly workspace: {
+    readonly state: "fresh_clone";
+    readonly repositoryCommit: string;
+    readonly workspaceFingerprint: Sha256Digest;
+  };
+  readonly isolation: {
+    readonly productState: "empty";
+    readonly session: "new";
+    readonly cache: "empty";
+    readonly home: "isolated";
+    readonly toolHome: "isolated";
+    readonly temp: "isolated";
+    readonly sockets: "isolated";
+    readonly ports: "isolated";
+    readonly environment: "sanitized";
+    readonly evidenceDigest: Sha256Digest;
+  };
+  readonly processTree: {
+    readonly before: "empty";
+    readonly after: "empty";
+    readonly evidenceDigest: Sha256Digest;
+  };
+}
+
+export interface EvalSuiteReference {
+  readonly suiteClass: EvalSuiteClass;
+  readonly suiteId: string;
+  readonly suiteVersion: string;
+  readonly definitionDigest: Sha256Digest;
+}
+
+export interface CompetitiveCodingReportDocument {
+  readonly kind: "agenc.eval.competitive-coding-report";
+  readonly suiteProtocolVersion: EvalSuiteProtocolVersion;
+  readonly documentDigest: Sha256Digest;
+  readonly reportVersion: "1.0.0";
+  readonly createdAt: string;
+  readonly attemptId: string;
+  readonly suite: EvalSuiteReference & { readonly suiteClass: "competitive_coding" };
+  readonly suiteManifestDigest: Sha256Digest;
+  readonly condition: CompetitiveCondition;
+  readonly task: {
+    readonly taskId: string;
+    readonly taskVersion: string;
+    readonly taskDocumentDigest: Sha256Digest;
+  };
+  readonly seedSlot: number;
+  readonly harnessConfigDigest: Sha256Digest;
+  readonly resetReceiptDigest: Sha256Digest;
+  readonly runRecordDigest: Sha256Digest;
+  readonly systemConfigurationDigest: Sha256Digest;
+  readonly deliveryReceipt: {
+    readonly agentTaskDigest: Sha256Digest;
+    readonly acceptedAtMonotonicMs: number;
+    readonly processGroupEvidenceDigest: Sha256Digest;
+    readonly transportEvidenceDigest: Sha256Digest;
+  };
+  readonly faultPlanDigest: Sha256Digest | null;
+  readonly fault: {
+    readonly scheduled: boolean;
+    readonly injected: boolean;
+    readonly scheduledDelayAfterAcceptanceMs: number | null;
+    readonly observedInjectedAtMonotonicMs: number | null;
+    readonly evidenceDigest: Sha256Digest | null;
+  };
+  readonly verifier: {
+    readonly result: "passed" | "failed" | "error";
+    readonly evidenceDigest: Sha256Digest;
+  };
+  readonly outcome:
+    | "verified_fix"
+    | "verification_failure"
+    | "unsupported"
+    | "fault_not_injected"
+    | "infrastructure_invalid";
+}
+
+export interface TrustConformanceReportDocument {
+  readonly kind: "agenc.eval.trust-conformance-report";
+  readonly suiteProtocolVersion: EvalSuiteProtocolVersion;
+  readonly documentDigest: Sha256Digest;
+  readonly reportVersion: "1.0.0";
+  readonly createdAt: string;
+  readonly attemptId: string;
+  readonly suite: EvalSuiteReference & { readonly suiteClass: "trust_conformance" };
+  readonly scenarioId: string;
+  readonly faultClass: TrustFaultClass;
+  readonly seedSlot: number;
+  readonly faultPlanDigest: Sha256Digest;
+  readonly resetReceiptDigest: Sha256Digest;
+  readonly runRecordDigest: Sha256Digest;
+  readonly systemConfigurationDigest: Sha256Digest;
+  readonly harnessReceiptDigest: Sha256Digest;
+  readonly fault: {
+    readonly injected: boolean;
+    readonly injectedAtVirtualMs: number | null;
+    readonly evidenceDigest: Sha256Digest;
+  };
+  readonly durationMs: number;
+  readonly invariantResults: readonly {
+    readonly invariant: string;
+    readonly passed: boolean;
+    readonly evidenceDigest: Sha256Digest;
+  }[];
+  readonly observedEvidenceTypes: readonly string[];
+  readonly actualStateDigest: Sha256Digest;
+  readonly outcome: "passed" | "failed" | "infrastructure_invalid";
+}
+
+export type EvalSuiteEvidenceDocument =
+  | EvalSuiteResetReceiptDocument
+  | CompetitiveCodingReportDocument
+  | TrustConformanceReportDocument;
+
+export interface CompetitiveConditionRegistration {
+  readonly condition: CompetitiveCondition;
+  readonly suite: SuiteManifestDocument;
+  readonly preregistration: PreregistrationDocument;
+}
+
+export interface ValidatedEvalSuiteCatalog {
+  readonly catalog: EvalSuiteCatalogDocument;
+  readonly competitive: CompetitiveCodingSuiteDefinitionDocument;
+  readonly trust: TrustConformanceSuiteDefinitionDocument;
+}

--- a/runtime/src/eval-suites/validation.ts
+++ b/runtime/src/eval-suites/validation.ts
@@ -1,0 +1,918 @@
+import { Ajv, type ErrorObject, type ValidateFunction } from "ajv";
+import suiteProtocolSchema from "./suite-protocol-v1.schema.json" with { type: "json" };
+import {
+  EVAL_CONTRACT_VERSION,
+  assertPortableRelativePath,
+  canonicalizeJson,
+  computeDocumentDigest,
+  digestCanonicalJson,
+  validateEvalContractDocument,
+  type OperatorTaskDocument,
+  type PreregistrationDocument,
+  type Sha256Digest,
+} from "../eval-contract/index.js";
+import {
+  COMPETITIVE_CONDITIONS,
+  EVAL_SUITE_PROTOCOL_VERSION,
+  RELEASED_EVAL_SUITE_V1_DIGESTS,
+  TRUST_FAULT_CLASSES,
+  type CompetitiveCodingSuiteDefinitionDocument,
+  type CompetitiveCondition,
+  type CompetitiveConditionRegistration,
+  type CompetitiveFaultCondition,
+  type CompetitiveFaultPlan,
+  type EvalSuiteCatalogDocument,
+  type EvalSuiteDefinitionDocument,
+  type EvalSuiteProtocolDocument,
+  type TrustConformanceSuiteDefinitionDocument,
+  type TrustFaultPlan,
+  type TrustFaultClass,
+  type TrustScenarioDefinition,
+  type ValidatedEvalSuiteCatalog,
+} from "./types.js";
+
+const UINT32_RANGE = 0x1_0000_0000;
+const MAX_REJECTION_ATTEMPTS = 1024;
+const TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?Z$/u;
+const TASK_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u;
+
+const COMPETITIVE_METRICS = [
+  "verified_fix_rate_clean",
+  "verified_fix_rate_by_fault_condition",
+  "recovery_rate_by_fault_condition",
+  "attempt_count",
+  "unsupported_count",
+] as const;
+
+const TRUST_METRICS = [
+  "trust_recovery_rate",
+  "fault_family_results",
+  "policy_escape_count",
+  "duplicated_uncertain_mutation_count",
+  "hidden_event_loss_count",
+  "unknown_outcome_count",
+] as const;
+
+const ZERO_TOLERANCE_METRICS = [
+  "policy_escape_count",
+  "duplicated_uncertain_mutation_count",
+  "hidden_event_loss_count",
+] as const;
+
+interface ExpectedTrustScenario {
+  readonly injectionBoundary: TrustScenarioDefinition["injectionBoundary"];
+  readonly faultAction: TrustScenarioDefinition["faultAction"];
+  readonly requiredInvariants: readonly string[];
+  readonly requiredEvidenceTypes: readonly string[];
+}
+
+const EXPECTED_TRUST_SCENARIOS: Readonly<Record<TrustFaultClass, ExpectedTrustScenario>> = {
+  restart: {
+    injectionBoundary: "after_reservation_before_model_result_commit",
+    faultAction: "restart_product_process",
+    requiredInvariants: [
+      "reservation_recovered_once",
+      "no_duplicate_state_transition",
+      "terminal_result_queryable",
+    ],
+    requiredEvidenceTypes: ["budget.reserved", "daemon.restarted", "recovery.assessed"],
+  },
+  reconnect: {
+    injectionBoundary: "after_event_publish_before_cursor_ack",
+    faultAction: "disconnect_and_reconnect_client",
+    requiredInvariants: [
+      "cursor_replay_complete",
+      "duplicate_delivery_harmless",
+      "terminal_result_queryable",
+    ],
+    requiredEvidenceTypes: [
+      "client.disconnected",
+      "client.reconnected",
+      "recovery.assessed",
+    ],
+  },
+  budget: {
+    injectionBoundary: "concurrent_child_reservation_before_commit",
+    faultAction: "race_sibling_budget_reservations",
+    requiredInvariants: [
+      "parent_cap_not_exceeded",
+      "unknown_usage_remains_reserved",
+      "reconciliation_exactly_once",
+    ],
+    requiredEvidenceTypes: ["budget.reserved", "budget.reconciled", "usage.reported"],
+  },
+  cancellation: {
+    injectionBoundary: "parent_cancel_after_child_admission",
+    faultAction: "cancel_parent",
+    requiredInvariants: [
+      "descendant_admission_stopped",
+      "queued_and_running_descendants_cancelled",
+      "partial_evidence_preserved",
+    ],
+    requiredEvidenceTypes: ["admission.decision", "artifact.recorded", "run.finished"],
+  },
+  permission: {
+    injectionBoundary: "repository_requests_capability_escalation",
+    faultAction: "inject_hostile_repository_instruction",
+    requiredInvariants: [
+      "capability_not_granted",
+      "mutation_not_executed",
+      "denial_audited",
+    ],
+    requiredEvidenceTypes: ["instruction.recorded", "policy.evaluated", "sandbox.evaluated"],
+  },
+  event_loss: {
+    injectionBoundary: "retention_gap_before_reconnect",
+    faultAction: "evict_replay_window",
+    requiredInvariants: [
+      "retention_gap_explicit",
+      "hidden_event_loss_zero",
+      "terminal_result_queryable",
+    ],
+    requiredEvidenceTypes: ["client.reconnected", "event.gap", "recovery.assessed"],
+  },
+  uncertain_effect: {
+    injectionBoundary: "after_effect_dispatch_before_ack_commit",
+    faultAction: "drop_effect_acknowledgement",
+    requiredInvariants: [
+      "outcome_marked_unknown",
+      "dependent_mutations_stopped",
+      "automatic_replay_zero",
+    ],
+    requiredEvidenceTypes: ["effect.intent", "effect.unknown_outcome", "risk.recorded"],
+  },
+};
+
+let compiledSchema: ValidateFunction | undefined;
+
+export class EvalSuiteProtocolValidationError extends Error {
+  readonly issues: readonly string[];
+
+  constructor(issues: readonly string[]) {
+    super(`evaluation suite protocol validation failed:\n- ${issues.join("\n- ")}`);
+    this.name = "EvalSuiteProtocolValidationError";
+    this.issues = issues;
+  }
+}
+
+function schemaValidator(): ValidateFunction {
+  if (compiledSchema) return compiledSchema;
+  const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, strict: true });
+  compiledSchema = ajv.compile(suiteProtocolSchema);
+  return compiledSchema;
+}
+
+function renderSchemaErrors(errors: readonly ErrorObject[] | null | undefined): string[] {
+  if (!errors) return ["document does not match suite protocol v1"];
+  const issues = new Set<string>();
+  for (const error of errors) {
+    if (error.keyword === "oneOf" || error.keyword === "const") continue;
+    const location = error.instancePath || "/";
+    const detail = error.params && "additionalProperty" in error.params
+      ? `unknown property ${String(error.params.additionalProperty)}`
+      : error.message ?? error.keyword;
+    issues.add(`${location}: ${detail}`);
+  }
+  return [...issues].slice(0, 64);
+}
+
+function requireCondition(condition: unknown, issue: string, issues: string[]): void {
+  if (!condition) issues.push(issue);
+}
+
+function assertExactSet(
+  actual: readonly string[],
+  expected: readonly string[],
+  label: string,
+  issues: string[],
+): void {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+  requireCondition(
+    actual.length === actualSet.size &&
+      actualSet.size === expectedSet.size &&
+      [...expectedSet].every((value) => actualSet.has(value)),
+    `${label} must contain exactly ${expected.join(", ")}`,
+    issues,
+  );
+}
+
+function assertTimestamp(value: string, label: string, issues: string[]): void {
+  const match = TIMESTAMP_PATTERN.exec(value);
+  const parsed = Date.parse(value);
+  if (!match || !Number.isFinite(parsed)) {
+    issues.push(`${label} is not a real UTC timestamp`);
+    return;
+  }
+  const date = new Date(parsed);
+  const fields = [
+    date.getUTCFullYear(),
+    date.getUTCMonth() + 1,
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+  ];
+  const supplied = match.slice(1, 7).map(Number);
+  requireCondition(
+    fields.every((field, index) => field === supplied[index]),
+    `${label} is not a real UTC timestamp`,
+    issues,
+  );
+}
+
+function assertDocumentDigest(
+  document: { readonly documentDigest: Sha256Digest },
+  issues: string[],
+): void {
+  requireCondition(
+    document.documentDigest === computeDocumentDigest(document),
+    "documentDigest does not match canonical suite protocol bytes",
+    issues,
+  );
+}
+
+function assertCompetitiveDefinition(
+  definition: CompetitiveCodingSuiteDefinitionDocument,
+  issues: string[],
+): void {
+  assertExactSet(definition.conditions, COMPETITIVE_CONDITIONS, "competitive conditions", issues);
+  assertExactSet(
+    definition.faultSchedule.actions.map((action) => action.condition),
+    COMPETITIVE_CONDITIONS.filter((condition) => condition !== "clean"),
+    "competitive fault actions",
+    issues,
+  );
+  const kill = definition.faultSchedule.actions.find(
+    (action) => action.condition === "coordinator_process_kill",
+  );
+  requireCondition(
+    kill?.target === "coordinator_process_group" &&
+      kill.operation === "sigkill" &&
+      kill.recovery === "adapter_restart_and_attach",
+    "coordinator kill must target the harness-launched process group and restart/attach",
+    issues,
+  );
+  const disconnect = definition.faultSchedule.actions.find(
+    (action) => action.condition === "client_disconnect",
+  );
+  requireCondition(
+    disconnect?.target === "client_transport" &&
+      disconnect.operation === "abrupt_close" &&
+      disconnect.recovery === "adapter_reconnect",
+    "client disconnect must abruptly close only the harness-owned transport and reconnect",
+    issues,
+  );
+  requireCondition(
+    definition.faultSchedule.minimumDelayMs <= definition.faultSchedule.maximumDelayMs,
+    "minimum fault delay must not exceed maximum fault delay",
+    issues,
+  );
+  assertExactSet(
+    definition.reporting.requiredMetrics,
+    COMPETITIVE_METRICS,
+    "competitive report metrics",
+    issues,
+  );
+}
+
+function assertTrustDefinition(
+  definition: TrustConformanceSuiteDefinitionDocument,
+  issues: string[],
+): void {
+  try {
+    assertPortableRelativePath(
+      definition.execution.fixtureBundle.path,
+      "trust fixture bundle path",
+    );
+  } catch (error) {
+    issues.push(error instanceof Error ? error.message : String(error));
+  }
+  assertExactSet(
+    definition.scenarios.map((scenario) => scenario.faultClass),
+    TRUST_FAULT_CLASSES,
+    "trust fault classes",
+    issues,
+  );
+  const scenarioIds = definition.scenarios.map((scenario) => scenario.scenarioId);
+  requireCondition(
+    new Set(scenarioIds).size === scenarioIds.length,
+    "trust scenario IDs must be unique",
+    issues,
+  );
+  requireCondition(
+    new Set(definition.scenarios.map((scenario) => scenario.fixtureDigest)).size ===
+      definition.scenarios.length,
+    "trust scenario fixture digests must be unique",
+    issues,
+  );
+  for (const scenario of definition.scenarios) {
+    const expected = EXPECTED_TRUST_SCENARIOS[scenario.faultClass];
+    requireCondition(
+      scenario.injectionBoundary === expected.injectionBoundary,
+      `${scenario.faultClass}: injection boundary differs from suite protocol v1`,
+      issues,
+    );
+    requireCondition(
+      scenario.faultAction === expected.faultAction,
+      `${scenario.faultClass}: fault action differs from suite protocol v1`,
+      issues,
+    );
+    assertExactSet(
+      scenario.requiredInvariants,
+      expected.requiredInvariants,
+      `${scenario.faultClass} invariants`,
+      issues,
+    );
+    requireCondition(
+      scenario.initialStateDigest !== scenario.expectedStateDigest,
+      `${scenario.faultClass}: initial and expected state digests must differ`,
+      issues,
+    );
+    assertExactSet(
+      scenario.requiredEvidenceTypes,
+      expected.requiredEvidenceTypes,
+      `${scenario.faultClass} evidence types`,
+      issues,
+    );
+  }
+  assertExactSet(definition.reporting.requiredMetrics, TRUST_METRICS, "trust report metrics", issues);
+  assertExactSet(
+    definition.reporting.zeroToleranceMetrics,
+    ZERO_TOLERANCE_METRICS,
+    "trust zero-tolerance metrics",
+    issues,
+  );
+}
+
+function assertCatalog(catalog: EvalSuiteCatalogDocument, issues: string[]): void {
+  assertExactSet(
+    catalog.activeDefinitions.map((entry) => entry.suiteClass),
+    ["competitive_coding", "trust_conformance"],
+    "catalog suite classes",
+    issues,
+  );
+  const paths = new Set<string>();
+  for (const entry of catalog.activeDefinitions) {
+    try {
+      assertPortableRelativePath(entry.path, `${entry.suiteClass} definition path`);
+    } catch (error) {
+      if (error instanceof Error) issues.push(error.message);
+      else throw error;
+    }
+    requireCondition(
+      entry.path.endsWith("/definition.json"),
+      `${entry.suiteClass} definition path must end in /definition.json`,
+      issues,
+    );
+    requireCondition(!paths.has(entry.path), "catalog definition paths must be unique", issues);
+    paths.add(entry.path);
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function canonicalSnapshot<T>(value: T): T {
+  return deepFreeze(JSON.parse(canonicalizeJson(value)) as T);
+}
+
+export function validateEvalSuiteProtocolDocument(value: unknown): EvalSuiteProtocolDocument {
+  const schema = schemaValidator();
+  if (!schema(value)) {
+    throw new EvalSuiteProtocolValidationError(renderSchemaErrors(schema.errors));
+  }
+  const document = value as EvalSuiteProtocolDocument;
+  const issues: string[] = [];
+  requireCondition(
+    document.suiteProtocolVersion === EVAL_SUITE_PROTOCOL_VERSION,
+    `unsupported suite protocol version ${String(document.suiteProtocolVersion)}`,
+    issues,
+  );
+  assertTimestamp(document.createdAt, `${document.kind}.createdAt`, issues);
+  assertDocumentDigest(document, issues);
+  if (document.kind === "agenc.eval.competitive-suite-definition") {
+    requireCondition(
+      document.evaluationContractVersion === EVAL_CONTRACT_VERSION,
+      "competitive suite references an unsupported evaluation contract",
+      issues,
+    );
+    assertCompetitiveDefinition(document, issues);
+  } else if (document.kind === "agenc.eval.trust-suite-definition") {
+    requireCondition(
+      document.evaluationContractVersion === EVAL_CONTRACT_VERSION,
+      "trust suite references an unsupported evaluation contract",
+      issues,
+    );
+    assertTrustDefinition(document, issues);
+  } else {
+    assertCatalog(document, issues);
+  }
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return canonicalSnapshot(document);
+}
+
+export function validateEvalSuiteCatalogSet(
+  catalogValue: unknown,
+  definitionValues: readonly unknown[],
+): ValidatedEvalSuiteCatalog {
+  const catalog = validateEvalSuiteProtocolDocument(catalogValue);
+  if (catalog.kind !== "agenc.eval.suite-catalog") {
+    throw new EvalSuiteProtocolValidationError(["catalog input is not a suite catalog"]);
+  }
+  const definitions = definitionValues.map((value) => validateEvalSuiteProtocolDocument(value));
+  const typedDefinitions = definitions.filter(
+    (document): document is EvalSuiteDefinitionDocument =>
+      document.kind !== "agenc.eval.suite-catalog",
+  );
+  const issues: string[] = [];
+  requireCondition(
+    typedDefinitions.length === definitions.length,
+    "catalog definitions must not contain a nested catalog",
+    issues,
+  );
+  requireCondition(
+    typedDefinitions.length === catalog.activeDefinitions.length,
+    "catalog definition count differs from loaded definitions",
+    issues,
+  );
+  catalog.activeDefinitions.forEach((entry, index) => {
+    const definition = definitions[index];
+    requireCondition(
+      definition?.kind !== "agenc.eval.suite-catalog" &&
+        definition?.suiteClass === entry.suiteClass &&
+        definition.suiteId === entry.suiteId &&
+        definition.suiteVersion === entry.suiteVersion &&
+        definition.documentDigest === entry.definitionDigest,
+      `${entry.suiteClass} catalog path does not resolve to its declared definition`,
+      issues,
+    );
+  });
+  const byClass = new Map(typedDefinitions.map((definition) => [definition.suiteClass, definition]));
+  requireCondition(
+    byClass.size === typedDefinitions.length,
+    "loaded suite definition classes must be unique",
+    issues,
+  );
+  for (const entry of catalog.activeDefinitions) {
+    const definition = byClass.get(entry.suiteClass);
+    requireCondition(definition !== undefined, `${entry.suiteClass} definition is missing`, issues);
+    if (!definition) continue;
+    requireCondition(definition.suiteId === entry.suiteId, `${entry.suiteClass} suite ID mismatch`, issues);
+    requireCondition(
+      definition.suiteVersion === entry.suiteVersion,
+      `${entry.suiteClass} suite version mismatch`,
+      issues,
+    );
+    requireCondition(
+      definition.documentDigest === entry.definitionDigest,
+      `${entry.suiteClass} suite digest mismatch`,
+      issues,
+    );
+  }
+  const competitive = byClass.get("competitive_coding");
+  const trust = byClass.get("trust_conformance");
+  requireCondition(
+    competitive?.kind === "agenc.eval.competitive-suite-definition",
+    "competitive catalog entry has the wrong document kind",
+    issues,
+  );
+  requireCondition(
+    trust?.kind === "agenc.eval.trust-suite-definition",
+    "trust catalog entry has the wrong document kind",
+    issues,
+  );
+  requireCondition(
+    competitive?.reporting.kind !== trust?.reporting.kind,
+    "competitive and trust reports must use different namespaces",
+    issues,
+  );
+  if (issues.length > 0 ||
+      competitive?.kind !== "agenc.eval.competitive-suite-definition" ||
+      trust?.kind !== "agenc.eval.trust-suite-definition") {
+    throw new EvalSuiteProtocolValidationError(issues);
+  }
+  return deepFreeze({ catalog, competitive, trust });
+}
+
+export function assertReleasedEvalSuiteCatalog(
+  value: ValidatedEvalSuiteCatalog,
+): ValidatedEvalSuiteCatalog {
+  const issues: string[] = [];
+  requireCondition(
+    value.catalog.catalogId === "agenc-evaluation-suites" &&
+      value.catalog.catalogVersion === "1.0.0",
+    "catalog is not the registered AgenC evaluation suite release",
+    issues,
+  );
+  requireCondition(
+    value.catalog.documentDigest === RELEASED_EVAL_SUITE_V1_DIGESTS.catalog,
+    "released catalog bytes changed without a new catalog version",
+    issues,
+  );
+  requireCondition(
+    value.competitive.documentDigest === RELEASED_EVAL_SUITE_V1_DIGESTS.competitive,
+    "released competitive suite bytes changed without a new suite version",
+    issues,
+  );
+  requireCondition(
+    value.trust.documentDigest === RELEASED_EVAL_SUITE_V1_DIGESTS.trust,
+    "released trust suite bytes changed without a new suite version",
+    issues,
+  );
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return value;
+}
+
+function randomWord(
+  definition: CompetitiveCodingSuiteDefinitionDocument,
+  suiteManifestDigest: Sha256Digest,
+  task: OperatorTaskDocument,
+  condition: CompetitiveFaultCondition,
+  seedSlot: number,
+  counter: number,
+): number {
+  const digest = digestCanonicalJson(definition.faultSchedule.seedDomain, {
+    suiteDefinitionDigest: definition.documentDigest,
+    suiteId: definition.suiteId,
+    suiteVersion: definition.suiteVersion,
+    suiteManifestDigest,
+    condition,
+    taskId: task.taskId,
+    taskVersion: task.taskVersion,
+    taskDocumentDigest: task.documentDigest,
+    taskWallTimeMs: task.budget.wallTimeMs,
+    seedSlot,
+    counter,
+  });
+  return Number.parseInt(digest.slice("sha256:".length, "sha256:".length + 8), 16) >>> 0;
+}
+
+function uniformDelay(
+  definition: CompetitiveCodingSuiteDefinitionDocument,
+  suiteManifestDigest: Sha256Digest,
+  task: OperatorTaskDocument,
+  condition: CompetitiveFaultCondition,
+  seedSlot: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const span = maximum - minimum + 1;
+  const limit = Math.floor(UINT32_RANGE / span) * span;
+  for (let counter = 0; counter < MAX_REJECTION_ATTEMPTS; counter += 1) {
+    const word = randomWord(
+      definition,
+      suiteManifestDigest,
+      task,
+      condition,
+      seedSlot,
+      counter,
+    );
+    if (word < limit) return minimum + (word % span);
+  }
+  throw new EvalSuiteProtocolValidationError(["fault delay rejection sampler exhausted"]);
+}
+
+export function compileCompetitiveFaultPlan(
+  definitionValue: unknown,
+  suiteValue: unknown,
+  input: {
+    readonly condition: CompetitiveFaultCondition;
+    readonly taskId: string;
+    readonly seedSlot: number;
+  },
+): CompetitiveFaultPlan {
+  const document = validateEvalSuiteProtocolDocument(definitionValue);
+  if (document.kind !== "agenc.eval.competitive-suite-definition") {
+    throw new EvalSuiteProtocolValidationError(["fault plans require a competitive definition"]);
+  }
+  const suiteDocument = validateEvalContractDocument(suiteValue);
+  if (suiteDocument.kind !== "agenc.eval.suite-manifest") {
+    throw new EvalSuiteProtocolValidationError([
+      "fault plans require an evaluation-contract v1 suite manifest",
+    ]);
+  }
+  const issues: string[] = [];
+  requireCondition(
+    input.condition === "coordinator_process_kill" || input.condition === "client_disconnect",
+    "fault plan condition must be coordinator_process_kill or client_disconnect",
+    issues,
+  );
+  requireCondition(TASK_ID_PATTERN.test(input.taskId), "fault plan taskId is invalid", issues);
+  requireCondition(
+    Number.isSafeInteger(input.seedSlot) && input.seedSlot >= 0,
+    "fault plan seedSlot must be a non-negative safe integer",
+    issues,
+  );
+  const task = suiteDocument.tasks.find((candidate) => candidate.taskId === input.taskId);
+  requireCondition(task !== undefined, "fault plan taskId is not in the suite manifest", issues);
+  requireCondition(
+    task?.provenance.sourceType !== "synthetic_diagnostic",
+    "competitive fault plans require a real-repository task",
+    issues,
+  );
+  const maximum = Math.min(
+    document.faultSchedule.maximumDelayMs,
+    (task?.budget.wallTimeMs ?? 0) -
+      document.faultSchedule.maximumInjectionJitterMs -
+      document.faultSchedule.recoveryWindowMs,
+  );
+  requireCondition(
+    maximum >= document.faultSchedule.minimumDelayMs,
+    "task wall-time budget leaves no valid fault/recovery window",
+    issues,
+  );
+  const action = document.faultSchedule.actions.find(
+    (candidate) => candidate.condition === input.condition,
+  );
+  requireCondition(action !== undefined, `missing ${input.condition} fault action`, issues);
+  if (issues.length > 0 || !action || !task) {
+    throw new EvalSuiteProtocolValidationError(issues);
+  }
+  const delayAfterAcceptanceMs = uniformDelay(
+    document,
+    suiteDocument.documentDigest,
+    task,
+    input.condition,
+    input.seedSlot,
+    document.faultSchedule.minimumDelayMs,
+    maximum,
+  );
+  const statement = {
+    kind: "agenc.eval.competitive-fault-plan" as const,
+    suiteDefinitionDigest: document.documentDigest,
+    suiteId: document.suiteId,
+    suiteVersion: document.suiteVersion,
+    suiteManifestDigest: suiteDocument.documentDigest,
+    condition: input.condition,
+    taskId: task.taskId,
+    taskVersion: task.taskVersion,
+    taskDocumentDigest: task.documentDigest,
+    taskWallTimeMs: task.budget.wallTimeMs,
+    seedSlot: input.seedSlot,
+    delayAfterAcceptanceMs,
+    maximumDelayAfterAcceptanceMs: maximum,
+    recoveryWindowMs: document.faultSchedule.recoveryWindowMs,
+    maximumInjectionJitterMs: document.faultSchedule.maximumInjectionJitterMs,
+    target: action.target,
+    operation: action.operation,
+    recovery: action.recovery,
+  };
+  return deepFreeze({
+    ...statement,
+    planDigest: digestCanonicalJson("agenc.eval.competitive-fault-plan.v1", statement),
+  });
+}
+
+export function computeCompetitiveHarnessConfigDigest(
+  definitionValue: unknown,
+  condition: CompetitiveCondition,
+): Sha256Digest {
+  const document = validateEvalSuiteProtocolDocument(definitionValue);
+  if (document.kind !== "agenc.eval.competitive-suite-definition") {
+    throw new EvalSuiteProtocolValidationError(["harness binding requires a competitive definition"]);
+  }
+  if (!COMPETITIVE_CONDITIONS.includes(condition)) {
+    throw new EvalSuiteProtocolValidationError([`unsupported competitive condition ${String(condition)}`]);
+  }
+  return digestCanonicalJson("agenc.eval.suite-harness-config.v1", {
+    suiteDefinitionDigest: document.documentDigest,
+    suiteId: document.suiteId,
+    suiteVersion: document.suiteVersion,
+    suiteClass: document.suiteClass,
+    condition,
+    adapterContract: document.adapterContract,
+    resetPolicy: document.resetPolicy,
+    faultSchedule: condition === "clean" ? null : document.faultSchedule,
+  });
+}
+
+export function computeEvalSuiteResetPolicyDigest(
+  definitionValue: unknown,
+): Sha256Digest {
+  const document = validateEvalSuiteProtocolDocument(definitionValue);
+  if (document.kind === "agenc.eval.suite-catalog") {
+    throw new EvalSuiteProtocolValidationError([
+      "reset policy digests require a suite definition",
+    ]);
+  }
+  return digestCanonicalJson("agenc.eval.suite-reset-policy.v1", {
+    suiteDefinitionDigest: document.documentDigest,
+    resetPolicy: document.resetPolicy,
+  });
+}
+
+export function computeTrustHarnessConfigDigest(definitionValue: unknown): Sha256Digest {
+  const document = validateEvalSuiteProtocolDocument(definitionValue);
+  if (document.kind !== "agenc.eval.trust-suite-definition") {
+    throw new EvalSuiteProtocolValidationError([
+      "trust harness binding requires a trust-conformance definition",
+    ]);
+  }
+  return digestCanonicalJson("agenc.eval.trust-harness-config.v1", {
+    suiteDefinitionDigest: document.documentDigest,
+    suiteId: document.suiteId,
+    suiteVersion: document.suiteVersion,
+    execution: document.execution,
+    resetPolicy: document.resetPolicy,
+    scenarios: document.scenarios,
+  });
+}
+
+export function compileTrustFaultPlans(
+  definitionValue: unknown,
+  seedSlot: number,
+): readonly TrustFaultPlan[] {
+  const document = validateEvalSuiteProtocolDocument(definitionValue);
+  if (document.kind !== "agenc.eval.trust-suite-definition") {
+    throw new EvalSuiteProtocolValidationError([
+      "trust fault plans require a trust-conformance definition",
+    ]);
+  }
+  if (!Number.isSafeInteger(seedSlot) || seedSlot < 0) {
+    throw new EvalSuiteProtocolValidationError([
+      "trust fault plan seedSlot must be a non-negative safe integer",
+    ]);
+  }
+  const harnessConfigDigest = computeTrustHarnessConfigDigest(document);
+  const scenarios = [...document.scenarios].sort((left, right) =>
+    left.scenarioId < right.scenarioId ? -1 : left.scenarioId > right.scenarioId ? 1 : 0);
+  return deepFreeze(scenarios.map((scenario, scheduleOrdinal) => {
+    const scenarioSeedDigest = digestCanonicalJson(document.execution.seedDomain, {
+      suiteDefinitionDigest: document.documentDigest,
+      scenarioId: scenario.scenarioId,
+      seedSlot,
+    });
+    const statement = {
+      kind: "agenc.eval.trust-fault-plan" as const,
+      suiteDefinitionDigest: document.documentDigest,
+      suiteId: document.suiteId,
+      suiteVersion: document.suiteVersion,
+      scenarioId: scenario.scenarioId,
+      faultClass: scenario.faultClass,
+      seedSlot,
+      scenarioSeedDigest,
+      scheduleOrdinal,
+      injectionBoundary: scenario.injectionBoundary,
+      faultAction: scenario.faultAction,
+      timeoutMs: scenario.timeoutMs,
+      requiredInvariants: scenario.requiredInvariants,
+      requiredEvidenceTypes: scenario.requiredEvidenceTypes,
+      harnessConfigDigest,
+      harnessImplementationDigest: document.execution.harnessImplementationDigest,
+      fakeProviderFixtureDigest: document.execution.fakeProviderFixtureDigest,
+      fakeToolFixtureDigest: document.execution.fakeToolFixtureDigest,
+      fixtureDigest: scenario.fixtureDigest,
+      initialStateDigest: scenario.initialStateDigest,
+      expectedStateDigest: scenario.expectedStateDigest,
+    };
+    return {
+      ...statement,
+      planDigest: digestCanonicalJson("agenc.eval.trust-fault-plan.statement.v1", statement),
+    };
+  }));
+}
+
+function conditionInvariantDigest(preregistration: PreregistrationDocument): Sha256Digest {
+  const {
+    documentDigest: _documentDigest,
+    experimentId: _experimentId,
+    createdAt: _createdAt,
+    evaluator,
+    ...shared
+  } = preregistration;
+  const { harnessConfigDigest: _harnessConfigDigest, ...sharedEvaluator } = evaluator;
+  return digestCanonicalJson("agenc.eval.competitive-condition-invariants.v1", {
+    ...shared,
+    evaluator: sharedEvaluator,
+  });
+}
+
+export function validateCompetitiveConditionRegistrations(
+  definitionValue: unknown,
+  registrationValues: unknown,
+): readonly CompetitiveConditionRegistration[] {
+  const definition = validateEvalSuiteProtocolDocument(definitionValue);
+  if (definition.kind !== "agenc.eval.competitive-suite-definition") {
+    throw new EvalSuiteProtocolValidationError(["condition registrations require a competitive definition"]);
+  }
+  const issues: string[] = [];
+  if (!Array.isArray(registrationValues)) {
+    throw new EvalSuiteProtocolValidationError([
+      "competitive registration set must be an array of exactly three conditions",
+    ]);
+  }
+  requireCondition(
+    registrationValues.length === COMPETITIVE_CONDITIONS.length,
+    "competitive registration set must contain exactly three conditions",
+    issues,
+  );
+  const validated: CompetitiveConditionRegistration[] = [];
+  registrationValues.forEach((value, index) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      issues.push(`competitive registration ${index} must be an object`);
+      return;
+    }
+    const candidate = value as Record<string, unknown>;
+    const condition = candidate.condition;
+    if (
+      typeof condition !== "string" ||
+      !COMPETITIVE_CONDITIONS.includes(condition as CompetitiveCondition)
+    ) {
+      issues.push(`competitive registration ${index} has an invalid condition`);
+      return;
+    }
+    try {
+      const suite = validateEvalContractDocument(candidate.suite);
+      const preregistration = validateEvalContractDocument(candidate.preregistration);
+      if (suite.kind !== "agenc.eval.suite-manifest") {
+        issues.push(`${condition}: suite is not a v1 suite manifest`);
+        return;
+      }
+      if (preregistration.kind !== "agenc.eval.preregistration") {
+        issues.push(`${condition}: document is not a v1 preregistration`);
+        return;
+      }
+      validated.push({
+        condition: condition as CompetitiveCondition,
+        suite,
+        preregistration,
+      });
+    } catch (error) {
+      issues.push(error instanceof Error ? error.message : String(error));
+    }
+  });
+  const snapshot = canonicalSnapshot(validated);
+  assertExactSet(
+    snapshot.map((entry) => entry.condition),
+    COMPETITIVE_CONDITIONS,
+    "competitive registration conditions",
+    issues,
+  );
+  const first = snapshot[0];
+  const suiteDigest = first?.suite.documentDigest;
+  const invariantDigest = first ? conditionInvariantDigest(first.preregistration) : undefined;
+  const experimentIds = new Set<string>();
+  for (const registration of snapshot) {
+    requireCondition(
+      registration.suite.documentDigest === suiteDigest,
+      `${registration.condition}: suite bytes differ across competitive conditions`,
+      issues,
+    );
+    requireCondition(
+      registration.suite.tasks.every(
+        (task: OperatorTaskDocument) =>
+          task.provenance.sourceType !== "synthetic_diagnostic",
+      ),
+      `${registration.condition}: competitive suites require real-repository tasks`,
+      issues,
+    );
+    requireCondition(
+      registration.suite.tasks.every(
+        (task: OperatorTaskDocument) =>
+          task.budget.wallTimeMs >=
+            definition.faultSchedule.minimumDelayMs +
+              definition.faultSchedule.maximumInjectionJitterMs +
+              definition.faultSchedule.recoveryWindowMs,
+      ),
+      `${registration.condition}: a task budget leaves no valid fault/recovery window`,
+      issues,
+    );
+    requireCondition(
+      registration.preregistration.suite.manifestDigest === registration.suite.documentDigest &&
+        registration.preregistration.suite.suiteId === registration.suite.suiteId &&
+        registration.preregistration.suite.suiteVersion === registration.suite.suiteVersion &&
+        registration.preregistration.suite.split === registration.suite.split,
+      `${registration.condition}: preregistration does not bind the exact suite manifest`,
+      issues,
+    );
+    requireCondition(
+      registration.preregistration.evaluator.harnessConfigDigest ===
+        computeCompetitiveHarnessConfigDigest(definition, registration.condition),
+      `${registration.condition}: harness config digest does not bind its suite condition`,
+      issues,
+    );
+    requireCondition(
+      conditionInvariantDigest(registration.preregistration) === invariantDigest,
+      `${registration.condition}: inputs, systems, budgets, scoring, or trial design differ`,
+      issues,
+    );
+    requireCondition(
+      !experimentIds.has(registration.preregistration.experimentId),
+      "competitive conditions require distinct experiment IDs",
+      issues,
+    );
+    experimentIds.add(registration.preregistration.experimentId);
+  }
+  requireCondition(
+    snapshot.length === registrationValues.length,
+    "every competitive registration must be structurally valid",
+    issues,
+  );
+  if (issues.length > 0) throw new EvalSuiteProtocolValidationError(issues);
+  return snapshot;
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -11,6 +11,7 @@
 export { VERSION } from "./version.js";
 
 export * from "./eval-contract/index.js";
+export * from "./eval-suites/index.js";
 
 export {
   AgenCDaemonAgentManager,

--- a/runtime/tests/eval/agent-eval-suite.test.ts
+++ b/runtime/tests/eval/agent-eval-suite.test.ts
@@ -4,16 +4,26 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { runtimeRootPath } from "../helpers/source-path.ts";
 
 const runnerScriptPath = resolve(runtimeRootPath, "scripts", "run-agent-eval.mjs");
 const suitePath = resolve(runtimeRootPath, "eval", "tasks");
 const SUITE_TASK_COUNT = 12;
+const controlledTmpDir = mkdtempSync(join(tmpdir(), "agenc-eval-test-tmp-"));
+
+// Prove copied fixtures do not inherit an unrelated module type from the host.
+writeFileSync(
+  join(controlledTmpDir, "package.json"),
+  JSON.stringify({ private: true, type: "commonjs" }),
+);
+
+afterAll(() => rmSync(controlledTmpDir, { force: true, recursive: true }));
 
 interface TaskResult {
   id: string;
@@ -41,6 +51,12 @@ function runRunner(args: string[]) {
   return spawnSync(process.execPath, [runnerScriptPath, ...args], {
     cwd: runtimeRootPath,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      TEMP: controlledTmpDir,
+      TMP: controlledTmpDir,
+      TMPDIR: controlledTmpDir,
+    },
   });
 }
 

--- a/runtime/tests/eval/evaluation-suite-evidence.test.ts
+++ b/runtime/tests/eval/evaluation-suite-evidence.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from "vitest";
+import competitiveJson from "../../eval/suites/competitive-coding/1.0.0/definition.json" with {
+  type: "json",
+};
+import trustJson from "../../eval/suites/trust-conformance/1.0.0/definition.json" with {
+  type: "json",
+};
+import {
+  EVAL_CONTRACT_VERSION,
+  projectTaskForAgent,
+  withDocumentDigest,
+  type Sha256Digest,
+} from "../../src/eval-contract/index.js";
+import {
+  EVAL_SUITE_PROTOCOL_VERSION,
+  EvalSuiteProtocolValidationError,
+  compileCompetitiveFaultPlan,
+  compileTrustFaultPlans,
+  computeCompetitiveHarnessConfigDigest,
+  computeEvalSuiteResetPolicyDigest,
+  validateCompetitiveCodingReport,
+  validateEvalSuiteEvidenceDocument,
+  validateEvalSuiteResetReceipt,
+  validateTrustConformanceReport,
+  type CompetitiveCodingReportDocument,
+  type CompetitiveCodingSuiteDefinitionDocument,
+  type EvalSuiteDefinitionDocument,
+  type EvalSuiteResetReceiptDocument,
+  type TrustConformanceReportDocument,
+  type TrustConformanceSuiteDefinitionDocument,
+} from "../../src/eval-suites/index.js";
+import { FIXED_TIME, GIT_COMMIT, digest, makeSuite } from "./evaluation-contract-fixtures.js";
+
+const competitive = competitiveJson as unknown as CompetitiveCodingSuiteDefinitionDocument;
+const trust = trustJson as unknown as TrustConformanceSuiteDefinitionDocument;
+
+function resign<T extends { readonly documentDigest: Sha256Digest }>(
+  value: T,
+  transform: (draft: Record<string, unknown>) => void,
+): T {
+  const draft = structuredClone(value) as unknown as Record<string, unknown>;
+  delete draft.documentDigest;
+  transform(draft);
+  return withDocumentDigest<T>(draft as Omit<T, "documentDigest">);
+}
+
+function makeResetReceipt(
+  definition: EvalSuiteDefinitionDocument,
+  attemptId: string,
+  context: {
+    suiteManifestDigest: Sha256Digest | null;
+    taskDocumentDigest: Sha256Digest | null;
+    taskResetRecipeDigest: Sha256Digest | null;
+    condition: "clean" | "coordinator_process_kill" | "client_disconnect" | null;
+    scenarioId: string | null;
+    seedSlot: number;
+    systemConfigurationDigest: Sha256Digest;
+  },
+): EvalSuiteResetReceiptDocument {
+  return withDocumentDigest<EvalSuiteResetReceiptDocument>({
+    kind: "agenc.eval.suite-reset-receipt",
+    suiteProtocolVersion: EVAL_SUITE_PROTOCOL_VERSION,
+    suiteDefinitionDigest: definition.documentDigest,
+    attemptId,
+    createdAt: FIXED_TIME,
+    resetPolicyDigest: computeEvalSuiteResetPolicyDigest(definition),
+    ...context,
+    workspace: {
+      state: "fresh_clone",
+      repositoryCommit: GIT_COMMIT,
+      workspaceFingerprint: digest(`${attemptId}:workspace`),
+    },
+    isolation: {
+      productState: "empty",
+      session: "new",
+      cache: "empty",
+      home: "isolated",
+      toolHome: "isolated",
+      temp: "isolated",
+      sockets: "isolated",
+      ports: "isolated",
+      environment: "sanitized",
+      evidenceDigest: digest(`${attemptId}:isolation`),
+    },
+    processTree: {
+      before: "empty",
+      after: "empty",
+      evidenceDigest: digest(`${attemptId}:process-tree`),
+    },
+  });
+}
+
+describe("evaluation suite evidence protocol", () => {
+  it("binds a competitive report to exact task bytes, budget, reset, and fault plan", () => {
+    expect(EVAL_CONTRACT_VERSION).toBe("1.0.0");
+    const suite = makeSuite();
+    const task = suite.tasks[0];
+    const attemptId = "competitive-attempt-1";
+    const systemConfigurationDigest = digest("competitive-system-configuration");
+    const reset = makeResetReceipt(competitive, attemptId, {
+      suiteManifestDigest: suite.documentDigest,
+      taskDocumentDigest: task.documentDigest,
+      taskResetRecipeDigest: task.resetRecipe.digest,
+      condition: "client_disconnect",
+      scenarioId: null,
+      seedSlot: 7,
+      systemConfigurationDigest,
+    });
+    const plan = compileCompetitiveFaultPlan(competitive, suite, {
+      condition: "client_disconnect",
+      taskId: task.taskId,
+      seedSlot: 7,
+    });
+    const report = withDocumentDigest<CompetitiveCodingReportDocument>({
+      kind: "agenc.eval.competitive-coding-report",
+      suiteProtocolVersion: EVAL_SUITE_PROTOCOL_VERSION,
+      reportVersion: "1.0.0",
+      createdAt: FIXED_TIME,
+      attemptId,
+      suite: {
+        suiteClass: "competitive_coding",
+        suiteId: competitive.suiteId,
+        suiteVersion: competitive.suiteVersion,
+        definitionDigest: competitive.documentDigest,
+      },
+      suiteManifestDigest: suite.documentDigest,
+      condition: "client_disconnect",
+      task: {
+        taskId: task.taskId,
+        taskVersion: task.taskVersion,
+        taskDocumentDigest: task.documentDigest,
+      },
+      seedSlot: 7,
+      harnessConfigDigest: computeCompetitiveHarnessConfigDigest(
+        competitive,
+        "client_disconnect",
+      ),
+      resetReceiptDigest: reset.documentDigest,
+      runRecordDigest: digest("competitive-run-record"),
+      systemConfigurationDigest,
+      deliveryReceipt: {
+        agentTaskDigest: projectTaskForAgent(task).documentDigest,
+        acceptedAtMonotonicMs: 1_000,
+        processGroupEvidenceDigest: digest("competitive-process-group"),
+        transportEvidenceDigest: digest("competitive-transport"),
+      },
+      faultPlanDigest: plan.planDigest,
+      fault: {
+        scheduled: true,
+        injected: true,
+        scheduledDelayAfterAcceptanceMs: plan.delayAfterAcceptanceMs,
+        observedInjectedAtMonotonicMs: 1_000 + plan.delayAfterAcceptanceMs + 10,
+        evidenceDigest: digest("competitive-fault"),
+      },
+      verifier: { result: "passed", evidenceDigest: digest("competitive-verifier") },
+      outcome: "verified_fix",
+    });
+
+    expect(validateEvalSuiteResetReceipt(competitive, reset)).toEqual(reset);
+    expect(validateCompetitiveCodingReport(competitive, suite, reset, report)).toEqual(report);
+
+    const wrongRepositoryReset = resign(reset, (draft) => {
+      const workspace = draft.workspace as Record<string, unknown>;
+      workspace.repositoryCommit = "b".repeat(40);
+    });
+    const wrongRepositoryReport = resign(report, (draft) => {
+      draft.resetReceiptDigest = wrongRepositoryReset.documentDigest;
+    });
+    expect(() => validateCompetitiveCodingReport(
+      competitive,
+      suite,
+      wrongRepositoryReset,
+      wrongRepositoryReport,
+    )).toThrow(/exact task repository and reset recipe/u);
+
+    const wrongRecipeReset = resign(reset, (draft) => {
+      draft.taskResetRecipeDigest = digest("wrong-reset-recipe");
+    });
+    const wrongRecipeReport = resign(report, (draft) => {
+      draft.resetReceiptDigest = wrongRecipeReset.documentDigest;
+    });
+    expect(() => validateCompetitiveCodingReport(
+      competitive,
+      suite,
+      wrongRecipeReset,
+      wrongRecipeReport,
+    )).toThrow(/exact task repository and reset recipe/u);
+
+    const wrongCellReset = resign(reset, (draft) => {
+      draft.seedSlot = 8;
+    });
+    const wrongCellReport = resign(report, (draft) => {
+      draft.resetReceiptDigest = wrongCellReset.documentDigest;
+    });
+    expect(() => validateCompetitiveCodingReport(
+      competitive,
+      suite,
+      wrongCellReset,
+      wrongCellReport,
+    )).toThrow(/exact competitive evaluation cell/u);
+
+    const wrongTask = resign(report, (draft) => {
+      const taskReference = draft.task as Record<string, unknown>;
+      taskReference.taskDocumentDigest = digest("wrong-task");
+    });
+    expect(() =>
+      validateCompetitiveCodingReport(competitive, suite, reset, wrongTask)
+    ).toThrow(/task version or digest mismatch/u);
+
+    const hiddenFault = resign(report, (draft) => {
+      const fault = draft.fault as Record<string, unknown>;
+      fault.injected = false;
+      fault.observedInjectedAtMonotonicMs = null;
+    });
+    expect(() =>
+      validateCompetitiveCodingReport(competitive, suite, reset, hiddenFault)
+    ).toThrow(/fault_not_injected/u);
+    const infrastructureInvalid = resign(hiddenFault, (draft) => {
+      draft.outcome = "infrastructure_invalid";
+    });
+    expect(
+      validateCompetitiveCodingReport(competitive, suite, reset, infrastructureInvalid),
+    ).toEqual(infrastructureInvalid);
+
+    const syntheticTask = resign(task, (draft) => {
+      const provenance = draft.provenance as Record<string, unknown>;
+      provenance.sourceType = "synthetic_diagnostic";
+    });
+    const syntheticSuite = resign(suite, (draft) => {
+      const tasks = draft.tasks as unknown[];
+      tasks[0] = syntheticTask;
+    });
+    const syntheticReport = resign(report, (draft) => {
+      draft.suiteManifestDigest = syntheticSuite.documentDigest;
+      draft.condition = "clean";
+      draft.harnessConfigDigest = computeCompetitiveHarnessConfigDigest(competitive, "clean");
+      const taskReference = draft.task as Record<string, unknown>;
+      taskReference.taskDocumentDigest = syntheticTask.documentDigest;
+      const delivery = draft.deliveryReceipt as Record<string, unknown>;
+      delivery.agentTaskDigest = projectTaskForAgent(syntheticTask).documentDigest;
+      draft.faultPlanDigest = null;
+      draft.fault = {
+        scheduled: false,
+        injected: false,
+        scheduledDelayAfterAcceptanceMs: null,
+        observedInjectedAtMonotonicMs: null,
+        evidenceDigest: null,
+      };
+    });
+    expect(() =>
+      validateCompetitiveCodingReport(competitive, syntheticSuite, reset, syntheticReport)
+    ).toThrow(/real-repository task/u);
+  });
+
+  it("enforces trust plans, required evidence, exact invariants, and expected state", () => {
+    const attemptId = "trust-attempt-1";
+    const plan = compileTrustFaultPlans(trust, 11)[0];
+    const systemConfigurationDigest = digest("trust-system-configuration");
+    const reset = makeResetReceipt(trust, attemptId, {
+      suiteManifestDigest: null,
+      taskDocumentDigest: null,
+      taskResetRecipeDigest: null,
+      condition: null,
+      scenarioId: plan.scenarioId,
+      seedSlot: plan.seedSlot,
+      systemConfigurationDigest,
+    });
+    const report = withDocumentDigest<TrustConformanceReportDocument>({
+      kind: "agenc.eval.trust-conformance-report",
+      suiteProtocolVersion: EVAL_SUITE_PROTOCOL_VERSION,
+      reportVersion: "1.0.0",
+      createdAt: FIXED_TIME,
+      attemptId,
+      suite: {
+        suiteClass: "trust_conformance",
+        suiteId: trust.suiteId,
+        suiteVersion: trust.suiteVersion,
+        definitionDigest: trust.documentDigest,
+      },
+      scenarioId: plan.scenarioId,
+      faultClass: plan.faultClass,
+      seedSlot: plan.seedSlot,
+      faultPlanDigest: plan.planDigest,
+      resetReceiptDigest: reset.documentDigest,
+      runRecordDigest: digest("trust-run-record"),
+      systemConfigurationDigest,
+      harnessReceiptDigest: digest("trust-harness-receipt"),
+      fault: {
+        injected: true,
+        injectedAtVirtualMs: 1,
+        evidenceDigest: digest("trust-fault"),
+      },
+      durationMs: 1_000,
+      invariantResults: plan.requiredInvariants.map((invariant) => ({
+        invariant,
+        passed: true,
+        evidenceDigest: digest(`trust-invariant:${invariant}`),
+      })),
+      observedEvidenceTypes: plan.requiredEvidenceTypes,
+      actualStateDigest: plan.expectedStateDigest,
+      outcome: "passed",
+    });
+
+    expect(validateTrustConformanceReport(trust, reset, report)).toEqual(report);
+
+    const missingEvidence = resign(report, (draft) => {
+      const observed = draft.observedEvidenceTypes as string[];
+      observed.pop();
+    });
+    expect(() => validateTrustConformanceReport(trust, reset, missingEvidence)).toThrow(
+      /missing required evidence/u,
+    );
+
+    const wrongState = resign(report, (draft) => {
+      draft.actualStateDigest = digest("wrong-final-state");
+    });
+    expect(() => validateTrustConformanceReport(trust, reset, wrongState)).toThrow(
+      /expected state/u,
+    );
+
+    const failedInvariant = resign(report, (draft) => {
+      const results = draft.invariantResults as Array<Record<string, unknown>>;
+      results[0].passed = false;
+    });
+    expect(() => validateTrustConformanceReport(trust, reset, failedInvariant)).toThrow(
+      /every invariant/u,
+    );
+
+    const missingFault = resign(report, (draft) => {
+      const fault = draft.fault as Record<string, unknown>;
+      fault.injected = false;
+      fault.injectedAtVirtualMs = null;
+    });
+    expect(() => validateTrustConformanceReport(trust, reset, missingFault)).toThrow(
+      /injected fault/u,
+    );
+
+    const retainedFailure = resign(report, (draft) => {
+      draft.outcome = "failed";
+      const fault = draft.fault as Record<string, unknown>;
+      fault.injected = false;
+      fault.injectedAtVirtualMs = null;
+      draft.observedEvidenceTypes = [];
+      const results = draft.invariantResults as Array<Record<string, unknown>>;
+      results[0].passed = false;
+    });
+    expect(validateTrustConformanceReport(trust, reset, retainedFailure)).toEqual(
+      retainedFailure,
+    );
+
+    const timedOutPass = resign(report, (draft) => {
+      draft.durationMs = plan.timeoutMs + 1;
+    });
+    expect(() => validateTrustConformanceReport(trust, reset, timedOutPass)).toThrow(
+      /timeout/u,
+    );
+  });
+
+  it("rejects cross-kind and mixed report shapes", () => {
+    const plan = compileTrustFaultPlans(trust, 1)[0];
+    const reset = makeResetReceipt(trust, "trust-attempt-mixed", {
+      suiteManifestDigest: null,
+      taskDocumentDigest: null,
+      taskResetRecipeDigest: null,
+      condition: null,
+      scenarioId: plan.scenarioId,
+      seedSlot: plan.seedSlot,
+      systemConfigurationDigest: digest("mixed-system-configuration"),
+    });
+    expect(() => validateEvalSuiteEvidenceDocument({
+      ...reset,
+      competitiveMetric: "verified_fix_rate_clean",
+    })).toThrow(/unknown property competitiveMetric/u);
+
+    expect(() => validateCompetitiveCodingReport(competitive, makeSuite(), reset, reset)).toThrow(
+      EvalSuiteProtocolValidationError,
+    );
+  });
+});

--- a/runtime/tests/eval/evaluation-suite-protocol.test.ts
+++ b/runtime/tests/eval/evaluation-suite-protocol.test.ts
@@ -1,0 +1,405 @@
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import competitiveJson from "../../eval/suites/competitive-coding/1.0.0/definition.json" with {
+  type: "json",
+};
+import catalogJson from "../../eval/suites/catalog.json" with { type: "json" };
+import trustJson from "../../eval/suites/trust-conformance/1.0.0/definition.json" with {
+  type: "json",
+};
+import trustFixturesJson from "../../eval/suites/trust-conformance/1.0.0/fixtures.json" with {
+  type: "json",
+};
+import {
+  EVAL_CONTRACT_VERSION,
+  withDocumentDigest,
+  type PreregistrationDocument,
+  type Sha256Digest,
+} from "../../src/eval-contract/index.js";
+import {
+  EVAL_SUITE_PROTOCOL_VERSION,
+  EvalSuiteProtocolValidationError,
+  RELEASED_EVAL_SUITE_V1_DIGESTS,
+  assertReleasedEvalSuiteCatalog,
+  compileCompetitiveFaultPlan,
+  compileTrustFaultPlans,
+  computeCompetitiveHarnessConfigDigest,
+  loadAndValidateEvalSuiteCatalog,
+  validateCompetitiveConditionRegistrations,
+  validateEvalSuiteCatalogSet,
+  validateEvalSuiteProtocolDocument,
+  type CompetitiveCodingSuiteDefinitionDocument,
+  type CompetitiveCondition,
+  type CompetitiveConditionRegistration,
+  type EvalSuiteCatalogDocument,
+  type TrustConformanceSuiteDefinitionDocument,
+  type TrustFixtureBundleDocument,
+  validateTrustFixtureBundleBinding,
+} from "../../src/eval-suites/index.js";
+import { makePreregistration, makeSuite } from "./evaluation-contract-fixtures.js";
+
+const competitive = competitiveJson as unknown as CompetitiveCodingSuiteDefinitionDocument;
+const trust = trustJson as unknown as TrustConformanceSuiteDefinitionDocument;
+const trustFixtures = trustFixturesJson as unknown as TrustFixtureBundleDocument;
+const catalog = catalogJson as unknown as EvalSuiteCatalogDocument;
+
+function resign<T extends { readonly documentDigest: Sha256Digest }>(
+  value: T,
+  transform: (draft: Record<string, unknown>) => void,
+): T {
+  const draft = structuredClone(value) as unknown as Record<string, unknown>;
+  delete draft.documentDigest;
+  transform(draft);
+  return withDocumentDigest<T>(draft as Omit<T, "documentDigest">);
+}
+
+function preregistrationFor(
+  condition: CompetitiveCondition,
+  index: number,
+): CompetitiveConditionRegistration {
+  return preregistrationForSuite(condition, index, makeSuite());
+}
+
+function preregistrationForSuite(
+  condition: CompetitiveCondition,
+  index: number,
+  suite: ReturnType<typeof makeSuite>,
+): CompetitiveConditionRegistration {
+  const base = makePreregistration(suite);
+  const { documentDigest: _documentDigest, ...unsigned } = base;
+  const preregistration = withDocumentDigest<PreregistrationDocument>({
+    ...unsigned,
+    experimentId: `experiment-${condition}-${index}`,
+    evaluator: {
+      ...base.evaluator,
+      harnessConfigDigest: computeCompetitiveHarnessConfigDigest(competitive, condition),
+    },
+  });
+  return { condition, suite, preregistration };
+}
+
+describe("versioned evaluation suite protocol", () => {
+  it("validates the committed two-suite catalog without changing evaluation contract v1", async () => {
+    expect(EVAL_CONTRACT_VERSION).toBe("1.0.0");
+    expect(EVAL_SUITE_PROTOCOL_VERSION).toBe("1.0.0");
+    const validated = assertReleasedEvalSuiteCatalog(
+      validateEvalSuiteCatalogSet(catalog, [competitive, trust]),
+    );
+    expect(validated.competitive.suiteClass).toBe("competitive_coding");
+    expect(validated.trust.suiteClass).toBe("trust_conformance");
+    expect(validated.competitive.reporting.kind).not.toBe(validated.trust.reporting.kind);
+    expect(validateTrustFixtureBundleBinding(trust, trustFixtures).scenarios).toHaveLength(7);
+    expect(RELEASED_EVAL_SUITE_V1_DIGESTS).toEqual({
+      catalog: "sha256:531627aec0c3a287ebd568494e1a9c0dc8116f01d324a61d571d1a200e2bde62",
+      competitive: "sha256:e7214668c3bd9d9299afb61ade397232f3e060d8a45ee7bd26ac87675514f69b",
+      trust: "sha256:e83ad76587b4e0fa8897f29a7148ac3c1823e560eff86ea43fc4fec7105db811",
+    });
+
+    const loaded = await loadAndValidateEvalSuiteCatalog(
+      path.resolve("eval/suites/catalog.json"),
+    );
+    expect(loaded.catalog.documentDigest).toBe(catalog.documentDigest);
+    expect(Object.isFrozen(loaded.competitive)).toBe(true);
+  });
+
+  it("rejects stale digests, product-specific competitive triggers, and mixed reports", () => {
+    const stale = structuredClone(competitive) as unknown as Record<string, unknown>;
+    stale.suiteVersion = "1.0.1";
+    expect(() => validateEvalSuiteProtocolDocument(stale)).toThrow(/documentDigest/u);
+
+    const productSpecific = resign(competitive, (draft) => {
+      const schedule = draft.faultSchedule as Record<string, unknown>;
+      schedule.agencEvent = "daemon.turn.accepted";
+    });
+    expect(() => validateEvalSuiteProtocolDocument(productSpecific)).toThrow(/unknown property/u);
+
+    const mixedReport = resign(competitive, (draft) => {
+      const reporting = draft.reporting as Record<string, unknown>;
+      reporting.kind = "agenc.eval.trust-conformance-report";
+    });
+    expect(() => validateEvalSuiteProtocolDocument(mixedReport)).toThrow(
+      EvalSuiteProtocolValidationError,
+    );
+  });
+
+  it("requires every deterministic trust fault class and its exact oracle/evidence boundary", () => {
+    const missingClass = resign(trust, (draft) => {
+      const scenarios = draft.scenarios as unknown[];
+      draft.scenarios = scenarios.slice(1);
+    });
+    expect(() => validateEvalSuiteProtocolDocument(missingClass)).toThrow(/fewer than 7 items/u);
+
+    const swappedBoundary = resign(trust, (draft) => {
+      const scenarios = draft.scenarios as Array<Record<string, unknown>>;
+      scenarios[0].injectionBoundary = "after_event_publish_before_cursor_ack";
+    });
+    expect(() => validateEvalSuiteProtocolDocument(swappedBoundary)).toThrow(
+      /restart: injection boundary differs/u,
+    );
+
+    const codingMetric = resign(trust, (draft) => {
+      const reporting = draft.reporting as Record<string, unknown>;
+      reporting.primaryMetric = "verified_fix_rate_clean";
+    });
+    expect(() => validateEvalSuiteProtocolDocument(codingMetric)).toThrow(
+      EvalSuiteProtocolValidationError,
+    );
+
+    const changedFixture = resign(trustFixtures, (draft) => {
+      const scenarios = draft.scenarios as Array<Record<string, unknown>>;
+      const expectedState = scenarios[0].expectedState as Record<string, unknown>;
+      expectedState.facts = ["different_expected_state"];
+    });
+    expect(() => validateTrustFixtureBundleBinding(trust, changedFixture)).toThrow(
+      /expected-state digest mismatch/u,
+    );
+  });
+
+  it("compiles a stable product-neutral fault schedule without system identity", () => {
+    const suite = makeSuite();
+    const kill = compileCompetitiveFaultPlan(competitive, suite, {
+      condition: "coordinator_process_kill",
+      taskId: "task-7",
+      seedSlot: 101,
+    });
+    expect(kill).toEqual({
+      kind: "agenc.eval.competitive-fault-plan",
+      suiteDefinitionDigest: competitive.documentDigest,
+      suiteId: "agenc-competitive-coding",
+      suiteVersion: "1.0.0",
+      suiteManifestDigest: suite.documentDigest,
+      condition: "coordinator_process_kill",
+      taskId: "task-7",
+      taskVersion: "1.0.0",
+      taskDocumentDigest: suite.tasks[7].documentDigest,
+      taskWallTimeMs: 60_000,
+      seedSlot: 101,
+      delayAfterAcceptanceMs: 14_323,
+      maximumDelayAfterAcceptanceMs: 29_000,
+      recoveryWindowMs: 30_000,
+      maximumInjectionJitterMs: 1_000,
+      target: "coordinator_process_group",
+      operation: "sigkill",
+      recovery: "adapter_restart_and_attach",
+      planDigest: "sha256:83c60c6c0a67a2584b227c491d6c161febcb5f8abb175d5b0560763a8d220439",
+    });
+    expect(compileCompetitiveFaultPlan(competitive, suite, {
+      condition: "coordinator_process_kill",
+      taskId: "task-7",
+      seedSlot: 101,
+    })).toEqual(kill);
+    expect(Object.keys(kill)).not.toContain("systemId");
+
+    expect(() => compileCompetitiveFaultPlan(competitive, suite, {
+      condition: "client_disconnect",
+      taskId: "missing-task",
+      seedSlot: 101,
+    })).toThrow(/not in the suite manifest/u);
+    const shortTask = resign(suite.tasks[7], (draft) => {
+      const budget = draft.budget as Record<string, unknown>;
+      budget.wallTimeMs = 35_000;
+    });
+    const shortSuite = resign(suite, (draft) => {
+      const tasks = draft.tasks as unknown[];
+      tasks[7] = shortTask;
+    });
+    expect(() => compileCompetitiveFaultPlan(competitive, shortSuite, {
+      condition: "client_disconnect",
+      taskId: "task-7",
+      seedSlot: 101,
+    })).toThrow(/no valid fault\/recovery window/u);
+
+    const trustPlans = compileTrustFaultPlans(trust, 101);
+    expect(trustPlans).toHaveLength(7);
+    expect(trustPlans.map((plan) => plan.scenarioId)).toEqual(
+      [...trustPlans.map((plan) => plan.scenarioId)].sort(),
+    );
+    expect(trustPlans[0].planDigest).toBe(
+      "sha256:481ab3035c42cf53d8817f252c30193ac9608dddb0116ebd898dfeaea0a2d39f",
+    );
+    expect(trustPlans[6].planDigest).toBe(
+      "sha256:e2dfb8caa5d054756bad4a272dfe3845f313735ba089b9dca0f77c79541d6037",
+    );
+    expect(compileTrustFaultPlans(trust, 101)).toEqual(trustPlans);
+  });
+
+  it("binds clean, kill, and disconnect preregistrations to identical inputs", () => {
+    const registrations = ([
+      "clean",
+      "coordinator_process_kill",
+      "client_disconnect",
+    ] as const).map(preregistrationFor);
+    expect(validateCompetitiveConditionRegistrations(competitive, registrations)).toHaveLength(3);
+
+    const wrongHarness = registrations.map((registration) => ({ ...registration }));
+    const original = wrongHarness[1].preregistration;
+    wrongHarness[1] = {
+      ...wrongHarness[1],
+      preregistration: resign(original, (draft) => {
+        const evaluator = draft.evaluator as Record<string, unknown>;
+        evaluator.harnessConfigDigest = `sha256:${"f".repeat(64)}`;
+      }),
+    };
+    expect(() => validateCompetitiveConditionRegistrations(competitive, wrongHarness)).toThrow(
+      /harness config digest/u,
+    );
+
+    const drifted = registrations.map((registration) => ({ ...registration }));
+    const driftedPreregistration = drifted[2].preregistration;
+    drifted[2] = {
+      ...drifted[2],
+      preregistration: resign(driftedPreregistration, (draft) => {
+        const systems = draft.systems as Array<Record<string, unknown>>;
+        systems[0].release = "1.0.1";
+      }),
+    };
+    expect(() => validateCompetitiveConditionRegistrations(competitive, drifted)).toThrow(
+      /inputs, systems, budgets, scoring, or trial design differ/u,
+    );
+
+    expect(() => validateCompetitiveConditionRegistrations(competitive, [
+      null,
+      {},
+      registrations[2],
+    ])).toThrow(EvalSuiteProtocolValidationError);
+    expect(() => validateCompetitiveConditionRegistrations(competitive, [
+      { ...registrations[0], suite: registrations[0].preregistration },
+      registrations[1],
+      registrations[2],
+    ])).toThrow(/suite is not a v1 suite manifest/u);
+
+    const boundaryTasks = registrations[0].suite.tasks.map((task) =>
+      resign(task, (draft) => {
+        const budget = draft.budget as Record<string, unknown>;
+        budget.wallTimeMs = 35_000;
+      })
+    );
+    const boundarySuite = resign(registrations[0].suite, (draft) => {
+      draft.tasks = boundaryTasks;
+    });
+    const boundaryRegistrations = ([
+      "clean",
+      "coordinator_process_kill",
+      "client_disconnect",
+    ] as const).map((condition, index) =>
+      preregistrationForSuite(condition, index, boundarySuite)
+    );
+    expect(() =>
+      validateCompetitiveConditionRegistrations(competitive, boundaryRegistrations)
+    ).toThrow(/no valid fault\/recovery window/u);
+  });
+
+  it("rejects catalog substitution and symlinked catalog input", async () => {
+    expect(() => validateEvalSuiteCatalogSet(catalog, [trust, competitive])).toThrow(
+      /catalog path does not resolve to its declared definition/u,
+    );
+
+    const substituted = resign(competitive, (draft) => {
+      draft.suiteVersion = "1.0.1";
+    });
+    expect(() => validateEvalSuiteCatalogSet(catalog, [substituted, trust])).toThrow(
+      /suite version mismatch|suite digest mismatch/u,
+    );
+
+    const rewrittenTrust = resign(trust, (draft) => {
+      const scenarios = draft.scenarios as Array<Record<string, unknown>>;
+      scenarios[0].timeoutMs = 60_001;
+    });
+    const rewrittenCatalog = resign(catalog, (draft) => {
+      const entries = draft.activeDefinitions as Array<Record<string, unknown>>;
+      entries[1].definitionDigest = rewrittenTrust.documentDigest;
+    });
+    const selfConsistentRewrite = validateEvalSuiteCatalogSet(
+      rewrittenCatalog,
+      [competitive, rewrittenTrust],
+    );
+    expect(() => assertReleasedEvalSuiteCatalog(selfConsistentRewrite)).toThrow(
+      /bytes changed without a new/u,
+    );
+
+    if (process.platform === "win32") return;
+    const root = await mkdtemp(path.join(os.tmpdir(), "agenc-eval-suite-"));
+    try {
+      const linkedCatalog = path.join(root, "catalog.json");
+      await symlink(path.resolve("eval/suites/catalog.json"), linkedCatalog);
+      await expect(loadAndValidateEvalSuiteCatalog(linkedCatalog)).rejects.toThrow(/non-symlink/u);
+
+      await rm(linkedCatalog);
+      await writeFile(linkedCatalog, `${JSON.stringify(catalog)}\n`);
+      const competitivePath = path.join(
+        root,
+        "competitive-coding/1.0.0/definition.json",
+      );
+      const trustPath = path.join(root, "trust-conformance/1.0.0/definition.json");
+      await mkdir(path.dirname(competitivePath), { recursive: true });
+      await mkdir(path.dirname(trustPath), { recursive: true });
+      await symlink(
+        path.resolve("eval/suites/competitive-coding/1.0.0/definition.json"),
+        competitivePath,
+      );
+      await cp(path.resolve("eval/suites/trust-conformance/1.0.0/definition.json"), trustPath);
+      await expect(loadAndValidateEvalSuiteCatalog(linkedCatalog)).rejects.toThrow(
+        /regular non-symlink/u,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate-key, invalid UTF-8, oversized, and traversal catalog input", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agenc-eval-suite-input-"));
+    const candidate = path.join(root, "catalog.json");
+    try {
+      await writeFile(candidate, '{"kind":"first","kind":"second"}\n');
+      await expect(loadAndValidateEvalSuiteCatalog(candidate)).rejects.toThrow(/duplicate JSON/u);
+
+      await writeFile(candidate, Buffer.from([0xff]));
+      await expect(loadAndValidateEvalSuiteCatalog(candidate)).rejects.toThrow(/not valid JSON/u);
+
+      await writeFile(candidate, Buffer.alloc(1024 * 1024 + 1, 0x20));
+      await expect(loadAndValidateEvalSuiteCatalog(candidate)).rejects.toThrow(/exceeds/u);
+
+      const traversal = resign(catalog, (draft) => {
+        const entries = draft.activeDefinitions as Array<Record<string, unknown>>;
+        entries[0].path = "../definition.json";
+      });
+      await writeFile(candidate, `${JSON.stringify(traversal)}\n`);
+      await expect(loadAndValidateEvalSuiteCatalog(candidate)).rejects.toThrow(
+        /traversal, empty, or reserved segment/u,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exposes deterministic suite CLI success, validation-failure, and usage exits", () => {
+    const tsxPath = fileURLToPath(
+      new URL("../../../node_modules/tsx/dist/cli.mjs", import.meta.url),
+    );
+    const cliPath = fileURLToPath(new URL("../../src/eval-suites/cli.ts", import.meta.url));
+    const run = (...arguments_: string[]) => spawnSync(
+      process.execPath,
+      [tsxPath, cliPath, ...arguments_],
+      { cwd: path.resolve("."), encoding: "utf8" },
+    );
+
+    const valid = run("--json");
+    expect(valid.status, valid.stderr).toBe(0);
+    expect(JSON.parse(valid.stdout)).toMatchObject({
+      valid: true,
+      suiteProtocolVersion: EVAL_SUITE_PROTOCOL_VERSION,
+    });
+
+    const invalid = run("--json", path.join(os.tmpdir(), "missing-eval-suite-catalog.json"));
+    expect(invalid.status).toBe(1);
+    expect(JSON.parse(invalid.stdout)).toMatchObject({ valid: false });
+
+    const usage = run("--unknown");
+    expect(usage.status).toBe(2);
+    expect(usage.stderr).toContain("Usage:");
+  });
+});

--- a/todo.txt
+++ b/todo.txt
@@ -187,7 +187,7 @@ mock-oriented toy baseline.
     - Store append-only raw run evidence separately from the human-readable
       summary.
 
-[ ] Maintain two separate versioned suites.
+[x] Maintain two separate versioned suites.
     - Competitive coding suite: real repository changes with identical external
       inputs and hidden verification, run clean and under a product-neutral
       coordinator-process-kill/client-disconnect schedule. It must not depend on


### PR DESCRIPTION
## Summary
- add separate immutable competitive-coding and trust-conformance suite definitions, pinned by a versioned catalog and release digests
- add strict protocol, fixture, reset, and report validation with deterministic product-neutral fault plans and exact evaluation-cell evidence binding
- retain concrete offline trust fixtures, document current scope/comparator research, and harden legacy local fixtures against ambient package scope
- mark only the M1 versioned-suites TODO complete; executors, pilot tasks, comparator adapters, and aggregate reporting remain deferred

## Local verification
- npm test: 1,772 files passed; 15,185 tests passed; 16 skipped
- focused suite protocol/evidence/legacy tests
- runtime typecheck
- check:eval-suites -- --json
- pre-commit runtime build, package entrypoints, generated SDK types, and PTY startup smoke
- three independent final read-only reviews: GO

No hosted test workflow or paid/provider run was invoked.

## Risk and rollback
The catalog rejects in-place mutations of released suite bytes. Rollback is a normal revert of this focused change; no persisted runtime-state migration or external service is introduced.