### PR TITLE
ci: make required verification local-only

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,13 +1,25 @@
 # Publish the reviewed @tetsuo-ai/agenc launcher tarball with npm Trusted
 # Publishing. Configure npmjs.com for this exact workflow filename and the
 # `npm-production` environment, allow `npm publish`, and do not provide an npm
-# token. Dispatch only at the matching immutable source tag, after the runtime
-# release in tetsuo-ai/agenc-releases has been published and made immutable.
+# token. This is an artifact-publish workflow, not a test workflow. Before
+# dispatch, the operator must complete and retain the exact-tag local release
+# evidence defined in docs/ci-required-gates.md. Dispatch only at the matching
+# immutable source tag, after the runtime release in tetsuo-ai/agenc-releases
+# has been published and made immutable.
 
 name: publish-npm
 
 on:
   workflow_dispatch:
+    inputs:
+      tested_sha:
+        description: Full immutable release-tag commit tested locally
+        required: true
+        type: string
+      local_evidence_sha256:
+        description: SHA-256 of the reviewed local release evidence record
+        required: true
+        type: string
 
 concurrency:
   group: publish-npm-production
@@ -26,7 +38,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      checks: read
       contents: read
     steps:
       - name: Check out the exact release SHA
@@ -37,10 +48,15 @@ jobs:
           persist-credentials: false
       - name: Bind the run to the reviewed source tag
         env:
+          LOCAL_EVIDENCE_SHA256: ${{ inputs.local_evidence_sha256 }}
           REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          TESTED_SHA: ${{ inputs.tested_sha }}
         shell: bash
         run: |
           set -euo pipefail
+          [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$LOCAL_EVIDENCE_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          test "$TESTED_SHA" = "$GITHUB_SHA"
           test "$GITHUB_REPOSITORY" = tetsuo-ai/agenc-core
           test "$REPOSITORY_VISIBILITY" = public
           test "$GITHUB_REF_TYPE" = tag
@@ -52,19 +68,6 @@ jobs:
           test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"
           git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
-      - name: Verify the App-owned local gate for this exact release SHA
-        env:
-          AGENC_LOCAL_GATE_APP_ID: ${{ vars.AGENC_LOCAL_GATE_APP_ID }}
-          GITHUB_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$AGENC_LOCAL_GATE_APP_ID" =~ ^[1-9][0-9]*$ ]]
-          node scripts/verify-required-gate-check.mjs \
-            --repository "$GITHUB_REPOSITORY" \
-            --sha "$GITHUB_SHA" \
-            --app-id "$AGENC_LOCAL_GATE_APP_ID"
-
   pack:
     needs: release-source
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -6,14 +6,26 @@
 # Linux native dependencies build in a glibc 2.28 container so the generic
 # linux artifacts retain Node's Tier-1 compatibility baseline.
 #
-# Publishing stays local/operator-driven (no cross-repository write secret in
-# this workflow). The reviewed draft, explicit destination tag, attestation
-# verification, immutable publication, and downstream npm/Docker/Homebrew
-# sequence are documented in docs/install.md under "Reproducible release gate".
+# This is an artifact-build workflow, not a test workflow. Before dispatch, the
+# operator must complete and retain the exact-tag local release evidence defined
+# in docs/ci-required-gates.md. Publishing stays local/operator-driven (no
+# cross-repository write secret in this workflow). The reviewed draft, explicit
+# destination tag, artifact attestation, immutable publication, and downstream
+# npm/Docker/Homebrew sequence are documented in docs/install.md under
+# "Reproducible release gate".
 
 name: release-runtime
 on:
   workflow_dispatch:
+    inputs:
+      tested_sha:
+        description: Full immutable release-tag commit tested locally
+        required: true
+        type: string
+      local_evidence_sha256:
+        description: SHA-256 of the reviewed local release evidence record
+        required: true
+        type: string
 
 concurrency:
   group: release-runtime-${{ github.ref }}
@@ -34,7 +46,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      checks: read
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -44,10 +55,15 @@ jobs:
           persist-credentials: false
       - name: Bind the run to the version tag commit
         env:
+          LOCAL_EVIDENCE_SHA256: ${{ inputs.local_evidence_sha256 }}
           REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          TESTED_SHA: ${{ inputs.tested_sha }}
         shell: bash
         run: |
           set -euo pipefail
+          [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$LOCAL_EVIDENCE_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          test "$TESTED_SHA" = "$GITHUB_SHA"
           test "$GITHUB_REPOSITORY" = tetsuo-ai/agenc-core
           test "$REPOSITORY_VISIBILITY" = public
           test "$GITHUB_REF_TYPE" = "tag"
@@ -59,19 +75,6 @@ jobs:
           test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"
           git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
-      - name: Verify the App-owned local gate for this exact release SHA
-        env:
-          AGENC_LOCAL_GATE_APP_ID: ${{ vars.AGENC_LOCAL_GATE_APP_ID }}
-          GITHUB_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$AGENC_LOCAL_GATE_APP_ID" =~ ^[1-9][0-9]*$ ]]
-          node scripts/verify-required-gate-check.mjs \
-            --repository "$GITHUB_REPOSITORY" \
-            --sha "$GITHUB_SHA" \
-            --app-id "$AGENC_LOCAL_GATE_APP_ID"
-
   linux-tarball:
     needs: release-source
     permissions:

--- a/README.md
+++ b/README.md
@@ -372,12 +372,15 @@ The optional design-audit browser is likewise an explicit external process:
 it receives background-network suppression flags, but only `npm test` provides
 the authoritative OS egress boundary.
 
-**Required checks:** the complete suite runs on the trusted local gate host,
-never in GitHub Actions. A dedicated GitHub App records
-`agenc-local-required-v1` for the exact PR or merged-`main` SHA; the no-bypass
-ruleset and both dispatch-only release workflows only enforce/read back that
-result. Contract, trust boundary, setup, reproduction, and rollback details
-live in [`docs/ci-required-gates.md`](docs/ci-required-gates.md).
+**Required checks:** the complete suite runs locally, never in GitHub Actions.
+Before merge, the PR records the exact tested SHA, commands, results, and
+skips; GitHub is only the branch/PR/merge record. Release verification repeats
+the same local gates against the immutable release-tag commit and retains the
+defined local evidence record. Manual release workflows may build artifacts
+afterward, but run no tests. The repository retains an optional GitHub
+App/ruleset design, but it is inactive and not required by the current
+local-only operating policy. Contract and reproduction details live in
+[`docs/ci-required-gates.md`](docs/ci-required-gates.md).
 
 Doc index: [`docs/INDEX.md`](docs/INDEX.md). Local contributor notes may live in a gitignored `AGENTS.md`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -332,13 +332,16 @@ crashing the process.
   installs and package builds under different umasks, then uses two additional
   pristine checkouts to prove byte-identical recursive OCI layouts with an
   exact Buildx client and digest-pinned BuildKit daemon.
-- **Local required attestations** — the complete stable contract runs only on
-  the dedicated local gate host. A repository-scoped GitHub App records
-  `agenc-local-required-v1` for the exact PR head or merged-`main` SHA; the
-  no-bypass ruleset and release workflows enforce/read back that result without
-  running tests on GitHub. Trust boundaries and reproduction are documented in
-  [`ci-required-gates.md`](ci-required-gates.md). Release workflows still run
-  on demand; binaries publish to public `tetsuo-ai/agenc-releases`.
+- **Local required verification** — the complete stable contract runs locally,
+  never in GitHub Actions. Each PR records the exact tested SHA, commands,
+  results, and skips before merge; release verification repeats the gates on
+  the immutable release-tag commit and retains the defined local evidence
+  record. GitHub remains the branch/PR/merge record; manual release workflows
+  may build artifacts afterward, but run no tests. The repository-scoped
+  App/ruleset implementation is retained as an inactive optional design, not a
+  current merge requirement. Reproduction and trust boundaries are documented
+  in
+  [`ci-required-gates.md`](ci-required-gates.md).
 
 Root development loop (from repo root):
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,7 +35,7 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | [agent-eval-reports.md](agent-eval-reports.md) | Local agent-eval suite, reports, and regression gate |
 | [evaluation-contract-v1.md](evaluation-contract-v1.md) | Versioned real-agent task, preregistration, evidence, and score derivation contract |
 | [evaluation-suites-v1.md](evaluation-suites-v1.md) | Separate versioned competitive-coding and deterministic trust-conformance suite protocols |
-| [ci-required-gates.md](ci-required-gates.md) | Local exact-SHA gates, GitHub App attestation, `main` ruleset, and rollback |
+| [ci-required-gates.md](ci-required-gates.md) | Local exact-SHA gates and the inactive optional GitHub App/ruleset design |
 | [provider-tool-compat.md](provider-tool-compat.md) | Tool JSON-schema root-type requirements for strict providers |
 | [embedded-neovim-buffer.md](embedded-neovim-buffer.md) | BUFFER providers, nvim trust boundary, env knobs |
 | [browser.md](browser.md) | Browser tool, Chromium profile, SSRF proxy, `[browser]` config |

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -1,17 +1,120 @@
-# Local required gates and GitHub App attestation
+# Local required gates and optional GitHub App attestation
 
 Decision record: 2026-07-15
 
-- Protected check: `agenc-local-required-v1`
-- Compute boundary: a dedicated local Linux gate host
-- GitHub boundary: record and enforce an authenticated exact-SHA result
-- Explicit non-goal: GitHub Actions never runs, proxies, or repeats the test
-  suite
+Operating policy update: 2026-07-16
 
-All required quality gates execute locally. A repository-scoped GitHub App
-publishes one Check Run only after the local supervisor has tested a fresh
-exact-SHA checkout, removed every candidate process and container, reread the
-remote ref, and removed the candidate workspace.
+The current policy is **local-only verification**. GitHub Actions runs no test
+suite, and merge does not require a GitHub App Check Run or an App-bound
+ruleset. Before merge, the PR must record the exact locally tested SHA,
+commands, results, and every skip. Release verification repeats the required
+gates locally against the immutable release-tag commit. For PR verification,
+GitHub is only the branch/PR/merge record. The dispatch-only release workflows
+may later build or publish artifacts, but they run no test suite and must not be
+invoked merely to verify a change.
+
+The sections explicitly labeled **Inactive optional** retain the reviewed App,
+dedicated-host, and ruleset deployment design. That design is not part of
+current completion and must not be provisioned or invoked unless an operator
+explicitly adopts it in a later policy change.
+
+## Current local PR evidence protocol
+
+Run the required gates from a clean checkout at the final PR-head commit, after
+the last source-changing commit. The PR description is the authoritative
+evidence record. It must contain:
+
+```bash
+npm test
+npm run build
+npm run build --workspace=@tetsuo-ai/agenc-sdk
+npm run typecheck --workspace=@tetsuo-ai/agenc-sdk
+npm run check:agent-surface-contract
+npm run sbom
+npm run check:sbom
+npm run check:tui-runtime-startup --workspace=@tetsuo-ai/runtime
+```
+
+`npm test` contains the runtime typecheck and stable Vitest suite. The final
+startup command exercises the built TUI/daemon path in real PTYs. Run additional
+task-specific regression tests before this complete final-head sequence.
+
+The evidence must contain:
+
+- the full 40-character tested commit SHA and a clean-tree assertion;
+- Node.js and npm versions;
+- each command in execution order, its exit status, and pass/fail result;
+- every skipped gate with its reason (write `none` when there are no skips);
+- start and finish timestamps; and
+- the independent review result and any unresolved risk.
+
+A later push invalidates the record. Immediately before merge, reread the live
+head and compare it to the recorded SHA:
+
+```bash
+tested_sha=<40-character SHA recorded in the PR>
+current_sha="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
+test "$current_sha" = "$tested_sha"
+test "$(git rev-parse HEAD)" = "$tested_sha"
+test -z "$(git status --porcelain=v1 --untracked-files=all)"
+```
+
+If any comparison fails, stop, test the new final head in full, and replace the
+stale evidence before merging. A GitHub status, workflow, or check run is not a
+substitute for this exact-SHA reread.
+
+## Current local release evidence protocol
+
+Create the immutable `agenc-v<version>` tag from reviewed `main`, then test a
+clean detached checkout of that tag. Store the authoritative record outside
+the repository at:
+
+```text
+${AGENC_RELEASE_EVIDENCE_DIR:-$HOME/.agenc/release-evidence}/agenc-v<version>-<40-character-sha>.json
+```
+
+The directory must be mode `0700` and the record mode `0600`. This is a
+human-reviewed local record, not a machine or GitHub attestation. Its JSON root
+must contain only `schemaVersion` (integer `1`), `repository`, `tag`, `testedSha`,
+`mainShaAtVerification`, `startedAt`, `finishedAt`, `nodeVersion`, `npmVersion`,
+an ordered `gates` array with command/result/exit code/log SHA-256, a `skips`
+array with reasons, the clean-tree result, the reviewer, and unresolved risks.
+SHAs use lowercase hex; timestamps use UTC RFC 3339; results are `pass` or
+`fail`; exit codes are non-negative integers. Retain the referenced private logs
+with the record. After final review, compute the SHA-256 of the exact record
+bytes and do not edit the file; any correction creates a new digest.
+Before dispatching either release workflow, require all of the following:
+
+```bash
+tag=agenc-v<version>
+tested_sha=<40-character SHA in the release evidence>
+git fetch origin main --tags
+test "$(git rev-parse --verify "refs/tags/${tag}^{commit}")" = "$tested_sha"
+git merge-base --is-ancestor "$tested_sha" refs/remotes/origin/main
+test -f "${AGENC_RELEASE_EVIDENCE_DIR:-$HOME/.agenc/release-evidence}/${tag}-${tested_sha}.json"
+evidence_sha256="$(sha256sum "${AGENC_RELEASE_EVIDENCE_DIR:-$HOME/.agenc/release-evidence}/${tag}-${tested_sha}.json" | cut -d ' ' -f 1)"
+[[ "$evidence_sha256" =~ ^[0-9a-f]{64}$ ]]
+```
+
+Dispatch with `tested_sha` and `local_evidence_sha256` set to those exact
+values. The workflow rejects a tag at any other commit and records both values
+as explicit invocation inputs before artifact work. It repeats the tag,
+exact-SHA, clean-tree, and `main` ancestry binding. It deliberately cannot turn
+a local record into a remote test result; the operator retains the record and
+the remote invocation makes later record mutation detectable by digest.
+
+## Inactive optional hardened enforcement design
+
+- Optional protected check: `agenc-local-required-v1`
+- Optional compute boundary: a dedicated local Linux gate host
+- Optional GitHub boundary: record and enforce an authenticated exact-SHA
+  result
+- Design non-goal: GitHub Actions never runs, proxies, or repeats the test suite
+
+All required quality gates execute locally. In the optional inactive mode, a
+repository-scoped GitHub App would publish one Check Run only after the local
+supervisor tested a fresh exact-SHA checkout, removed every candidate process
+and container, reread the remote ref, and removed the candidate workspace.
 
 ```text
 GitHub PR/main ref ──read──> root-installed dispatcher (global lock)
@@ -40,7 +143,7 @@ publisher environment. The publisher never accepts a SHA or result from its
 command line. Its only selection is `pr-<number>` or the fixed `main` subject,
 plus an unpredictable handoff ID created after successful cleanup.
 
-## Required gate contract
+## Inactive optional hardened gate contract
 
 The repository command is:
 
@@ -49,8 +152,8 @@ npm run check:required-gates
 ```
 
 It requires Linux, Node.js 25.9.0, npm 11.17.0, a clean checkout, and an exact
-lowercase 40-character commit. The authoritative deployment runs each gate in
-its own transient systemd cgroup.
+lowercase 40-character commit. In this optional design, the authoritative
+deployment runs each gate in its own transient systemd cgroup.
 
 | Order | Gate | Bound | Candidate write access |
 | ---: | --- | ---: | --- |
@@ -98,7 +201,7 @@ boundary, TUI supervisor, and their policy tests. The root-installed supervisor
 compares a candidate digest with the reviewed root-owned approval before
 `npm ci`. A PR cannot approve its own gate-policy change.
 
-## Worker and publisher trust boundaries
+## Inactive optional worker and publisher trust boundaries
 
 The trusted repository mirror is installed root-owned beneath
 `/opt/agenc-local-gatekeeper/repo`. systemd must never execute the dispatcher,
@@ -167,7 +270,7 @@ Failure classification is fail-closed:
 - two App-owned checks for the same name and SHA are rejected; and
 - a foreign same-name check never satisfies App-bound verification.
 
-## GitHub App
+## Inactive optional GitHub App
 
 Register a private App from
 [`packaging/github/agenc-local-gate-app-manifest.json`](../packaging/github/agenc-local-gate-app-manifest.json)
@@ -209,7 +312,7 @@ publisher receives
 Use overlapping App keys for rotation: install the new encrypted key, verify a
 genuine check and readback, then revoke the old key.
 
-## Dedicated Linux host
+## Inactive optional dedicated Linux host
 
 Use a dedicated cgroup-v2 Linux host. The two sibling resource domains can be
 active together, so the host must have at least 48 GiB RAM, 16 available CPUs,
@@ -247,7 +350,7 @@ Each `id -G` must print only its primary GID. Never add either identity to
 `docker`, `sudo`, or another supplementary group. The candidate worker and
 Docker account must not share a UID or GID.
 
-### Dedicated Docker filesystem and daemon
+### Inactive optional dedicated Docker filesystem and daemon
 
 Provision a new 24 GiB logical volume or encrypted mapping for this daemon.
 Formatting storage is destructive, so the operator must independently verify
@@ -335,7 +438,7 @@ and requires a second stable pristine baseline. Any cleanup forces the current
 attestation attempt to fail with `DOCKER_RECOVERED`, so only a later clean run
 can publish.
 
-### Trusted mirror, configuration, and static units
+### Inactive optional trusted mirror, configuration, and static units
 
 Install the reviewed commit and toolchain root-owned beneath
 `/opt/agenc-local-gatekeeper`; no file there may be writable by the candidate or
@@ -415,7 +518,7 @@ case, prove the job mount is gone, no candidate/transient process or container
 survives, and no success was published. Archive the unit properties, mountinfo,
 cgroup records, logs, and exact App readback as deployment evidence.
 
-## Exact App-bound `main` ruleset
+## Inactive optional exact App-bound `main` ruleset
 
 [`scripts/local-gate-ruleset.mjs`](../scripts/local-gate-ruleset.mjs) is the
 versioned ruleset policy. It renders the exact GitHub REST payload and verifies
@@ -658,25 +761,24 @@ require that merge SHA rather than the PR head. The deployment proof must
 confirm the repository's actual merge mode. The App always publishes to the
 exact SHA in its receipt; a prior SHA never authorizes a newer one.
 
-## Release enforcement
+## Current release-workflow source binding
 
 [`publish-npm.yml`](../.github/workflows/publish-npm.yml) and
 [`release-runtime.yml`](../.github/workflows/release-runtime.yml) continue to
 use GitHub-hosted jobs to produce release artifacts. They do not run tests.
 Before artifact work starts, each workflow:
 
-1. binds dispatch to the immutable `agenc-v<version>` tag, exact SHA, and
-   `main` ancestry;
-2. reads the configured gate App ID; and
-3. requires exactly one completed App-owned `agenc-local-required-v1` literal
-   success for that exact SHA, current policy digest, canonical receipt, and
-   `main` subject.
+1. requires typed `tested_sha` and `local_evidence_sha256` dispatch inputs;
+2. requires `tested_sha` to equal the workflow's exact `GITHUB_SHA`;
+3. binds dispatch to the matching `agenc-v<version>` tag and `main` ancestry;
+   and
+4. requires the checked-out tree to be clean before artifact work.
 
-A PR-head receipt cannot release a squash-merged commit. A missing, stale,
-duplicate, wrong-App, wrong-SHA, PR-subject, failed, neutral, skipped, or
-malformed result blocks release before artifact production.
+They run no tests and do not read a GitHub App check. The operator must first
+complete and retain the exact-tag local evidence defined above. A PR-head test
+record cannot authorize release of a different squash-merged commit.
 
-## Required policy-context rotation
+## Inactive optional policy-context rotation
 
 GitHub matches a required check by context and App; it cannot inspect the
 policy digest inside AgenC's receipt. Reusing a context after changing
@@ -844,7 +946,7 @@ live source-binding flow still must be independently reviewed and proven.
 Installing B early to make its ordinary publisher seed vN is not an acceptable
 workaround.
 
-## Developer reproduction and policy changes
+## Local developer reproduction
 
 Provision the digest-pinned image outside the no-network boundary, then use a
 clean checkout:
@@ -857,35 +959,36 @@ npm rebuild better-sqlite3 esbuild node-pty
 npm run check:required-gates
 ```
 
-That direct command is a developer reproduction. Only the root-installed
-dispatcher with separate worker/Docker identities can issue an authoritative
-App receipt. Run the focused policy suite with:
+That direct command is a developer reproduction. The current authoritative PR
+record is the exact-SHA evidence in the PR description. Run the focused
+optional-policy suite with:
 
 ```bash
 npm run test:required-gates
 ```
 
-When a hashed policy file changes, independently review the diff, run local
-gates, and follow the required policy-context rotation above. Install the
-reviewed trusted mirror and update the root-owned digest only at rotation step
-7. Never copy a digest from candidate output merely to make a PR pass.
+If the inactive hardened mode is later adopted and a hashed policy file
+changes, independently review the diff, run local gates, and follow the
+optional policy-context rotation above. Install the reviewed trusted mirror and
+update the root-owned digest only at rotation step 7. Never copy a digest from
+candidate output merely to make a PR pass.
 
-The audited break-glass path is to disable the ruleset out of band, land only a
+In that optional mode, the audited break-glass path is to disable the ruleset
+out of band, land only a
 separately reviewed repair, attest the resulting `main` SHA locally, restore
 the exact App-bound ruleset, and rerun the negative proof. Leaving protection
 disabled, admin-merging unrelated work, or publishing a user-owned status is
 not rollback.
 
-## Current deployment evidence
+## Current operating evidence
 
-The repository policy tests and PTY supervisor run locally in ordinary
-development mode. This checkout does not have the required dedicated rootless
-Docker account/socket, so it cannot claim the authoritative multi-UID systemd
-and encrypted-credential end-to-end proof. Policy-context rotation still
-requires the dedicated-host seeder and source-binding proof described above.
-Do not mark the M0 attestation item complete until the dedicated-host proof,
-live App readback, active ruleset readback, and blocked-unattested-SHA proof are
-recorded.
+The repository policy tests, stable suite, builds, contracts, SBOM check, and
+PTY supervisor run locally. PR descriptions are the human-reviewed evidence
+record and must follow the exact-SHA protocol above. Release records use the
+defined local evidence path and immutable-tag protocol. No dedicated GitHub
+App, active App-bound ruleset, or hosted test workflow is claimed or required
+in local-only mode. The optional multi-UID systemd/App design has not been
+activated.
 
 ## Primary sources
 
@@ -915,6 +1018,12 @@ Research refreshed 2026-07-15:
   subscriptions for the versioned App registration.
 - [Installation access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app)
   document repository and permission narrowing below installed App grants.
+- [GitHub Actions inputs context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#inputs-context)
+  defines typed inputs for manually dispatched workflows; the release jobs use
+  those inputs to bind the locally tested SHA and evidence digest.
+- [SLSA build provenance 1.2](https://slsa.dev/spec/v1.2/build-provenance)
+  treats user-supplied build inputs as external parameters that must be recorded
+  and verified downstream; the release workflows fail closed on both inputs.
 - [Troubleshooting required checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)
   documents latest-SHA, merge-commit, conclusion, name-collision, and freshness
   behavior.
@@ -930,7 +1039,7 @@ Research refreshed 2026-07-15:
   defines frozen-lockfile installs.
 
 GitHub-hosted test execution was rejected because it spends remote runner time
-without strengthening the local hermetic boundary. A generic signed file or
-PAT-owned status was rejected because the protected context could not be bound
-to one dedicated producer. The App design keeps all expensive computation
-local while GitHub stores and enforces only the authenticated exact-SHA result.
+without strengthening the local hermetic boundary. The current policy keeps
+all verification local and records evidence in the PR. The optional App design
+would add authenticated exact-SHA enforcement without moving test compute to
+GitHub, but that extra control-plane complexity is deliberately inactive.

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -4,6 +4,22 @@ import { join, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const REPO_ROOT = resolve(process.cwd(), "..");
+const HOSTED_TEST_COMMANDS = [
+  "npm test",
+  "npm run test",
+  "npm run typecheck",
+  "npm run validate:runtime",
+  "npm run check:required-gates",
+  "npm run check:agent-surface-contract",
+  "npm run check:sbom",
+  "check:tui-runtime-startup",
+  "vitest",
+  "tsc --noEmit",
+] as const;
+
+function expectArtifactWorkflowWithoutHostedTests(workflow: string) {
+  for (const command of HOSTED_TEST_COMMANDS) expect(workflow).not.toContain(command);
+}
 
 describe("reproducible install and release contract", () => {
   test("standalone installers are generated from the canonical lock modules", () => {
@@ -233,12 +249,16 @@ describe("reproducible install and release contract", () => {
     expect(workflow).toContain('test "$GITHUB_REF_TYPE" = tag');
     expect(workflow).toContain('expected_ref="refs/tags/agenc-v${version}"');
     expect(workflow).toContain('test "$REPOSITORY_VISIBILITY" = public');
-    expect(releaseSourceJob).toContain("checks: read");
-    expect(releaseSourceJob).toContain("AGENC_LOCAL_GATE_APP_ID");
-    expect(releaseSourceJob).toContain("scripts/verify-required-gate-check.mjs");
-    expect(releaseSourceJob).toContain('--sha "$GITHUB_SHA"');
+    expect(releaseSourceJob).not.toContain("checks: read");
+    expect(releaseSourceJob).not.toContain("AGENC_LOCAL_GATE_APP_ID");
+    expect(releaseSourceJob).not.toContain("scripts/verify-required-gate-check.mjs");
+    expect(releaseSourceJob).toContain("LOCAL_EVIDENCE_SHA256");
+    expect(releaseSourceJob).toContain('test "$TESTED_SHA" = "$GITHUB_SHA"');
+    expect(releaseSourceJob).toContain(
+      'test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"',
+    );
     expect(workflow).not.toContain("required-gates:");
-    expect(workflow).not.toContain("npm run check:required-gates");
+    expectArtifactWorkflowWithoutHostedTests(workflow);
     for (const job of [releaseSourceJob, packJob, publishJob]) {
       expect(job.match(/git merge-base --is-ancestor/g)).toHaveLength(1);
       expect(job.match(/persist-credentials: false/g)).toHaveLength(1);
@@ -317,7 +337,7 @@ describe("reproducible install and release contract", () => {
     );
   });
 
-  test("runtime artifact jobs depend on an exact App-owned local-gate check", () => {
+  test("runtime artifact jobs bind to the exact release tag without running tests", () => {
     const workflow = readFileSync(
       join(REPO_ROOT, ".github/workflows/release-runtime.yml"),
       "utf8",
@@ -326,12 +346,16 @@ describe("reproducible install and release contract", () => {
       workflow.indexOf("\n  release-source:"),
       workflow.indexOf("\n  linux-tarball:"),
     );
-    expect(releaseSourceJob).toContain("checks: read");
-    expect(releaseSourceJob).toContain("AGENC_LOCAL_GATE_APP_ID");
-    expect(releaseSourceJob).toContain("scripts/verify-required-gate-check.mjs");
-    expect(releaseSourceJob).toContain('--sha "$GITHUB_SHA"');
+    expect(releaseSourceJob).not.toContain("checks: read");
+    expect(releaseSourceJob).not.toContain("AGENC_LOCAL_GATE_APP_ID");
+    expect(releaseSourceJob).not.toContain("scripts/verify-required-gate-check.mjs");
+    expect(releaseSourceJob).toContain("LOCAL_EVIDENCE_SHA256");
+    expect(releaseSourceJob).toContain('test "$TESTED_SHA" = "$GITHUB_SHA"');
+    expect(releaseSourceJob).toContain(
+      'test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"',
+    );
     expect(workflow).not.toContain("required-gates:");
-    expect(workflow).not.toContain("npm run check:required-gates");
+    expectArtifactWorkflowWithoutHostedTests(workflow);
     expect(workflow).toMatch(/\n  linux-tarball:\n    needs: release-source\n/u);
     expect(workflow).toMatch(/\n  native-tarball:\n    needs: release-source\n/u);
   });

--- a/todo.txt
+++ b/todo.txt
@@ -142,17 +142,18 @@ and required results are not bound to the exact reviewed SHA.
     - Prove a clean clone can build the runtime, launcher, SDK, declarations,
       and Docker image without developer-local state.
 
-[ ] Add required local PR and release attestations.
+[x] Run required PR and release verification locally.
     - Run locally for every PR: typecheck, stable Vitest suite, build, SDK build
       and typecheck, agent-surface contract, SBOM check, and PTY/TUI startup
       smoke.
-    - GitHub must run no tests: a dedicated repository-scoped App records and
-      enforces only the authenticated exact-SHA local result. Release workflows
-      must read back a separate successful merged-`main` attestation for the
-      exact release SHA before producing artifacts.
-    - Document the exact App-bound GitHub ruleset; configure it on `main` with
-      strict source matching and no bypass actors, then prove a new unattested
-      SHA cannot merge.
+    - GitHub runs no tests and no App/ruleset attestation is required. Record
+      the exact tested SHA, commands, results, and every skip in the PR before
+      merge; GitHub is only the branch/PR/merge record.
+    - Before release, repeat the required gates locally against the immutable
+      release-tag commit, retain the reviewed evidence record defined in
+      `docs/ci-required-gates.md`, and bind its SHA-256 plus the tested commit to
+      the artifact workflow dispatch. Hosted release workflows are not PR
+      verification and are never invoked merely to test a change.
 
 M0 DONE WHEN:
 


### PR DESCRIPTION
## Summary

- make local exact-SHA verification the required PR/release policy and mark the retained GitHub App/ruleset design inactive
- keep manual release workflows artifact-only, bind dispatch to the locally tested SHA and evidence digest, and prevent hosted test commands by regression contract
- mark M0 complete under the explicitly selected local-only policy

## Local exact-SHA evidence

- Tested SHA: `77571aacb16978f95ddfecdc999d5d76dd87ef10`
- Clean tree before and after gates: yes
- Node.js: `v25.9.0`
- npm: `11.17.0`
- Started: `2026-07-16T07:15:07Z`
- Finished: `2026-07-16T07:20:46Z`

Commands, in order:

1. `npm test` — PASS (1,772 Vitest files; 15,185 passed, 16 skipped; required-gate, launcher, and agent-contract suites also passed)
2. `npm run build` — PASS
3. `npm run build --workspace=@tetsuo-ai/agenc-sdk` — PASS
4. `npm run typecheck --workspace=@tetsuo-ai/agenc-sdk` — PASS
5. `npm run check:agent-surface-contract` — PASS, including focused TUI E2E scenarios
6. `npm run sbom` — PASS (677 packages, 1,099 relationships)
7. `npm run check:sbom` — PASS
8. `npm run check:tui-runtime-startup --workspace=@tetsuo-ai/runtime` — PASS at 148x40, 120x30, and 80x24 with normal and `--yolo` startup

Skipped required gates: none.

Independent review: two read-only reviewers returned GO. The final security review confirmed exact `tested_sha === GITHUB_SHA` binding, evidence-digest binding, inactive optional App labeling, and revert-sensitive hosted-test prohibition.

Unresolved risk: local evidence remains human-reviewed by explicit operating-policy choice; this PR does not claim remote machine enforcement. Manual artifact workflows are never invoked merely to test a change.
