### PR TITLE
fix(runtime): fail-close inbound MCP mutations

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -518,7 +518,7 @@ agenc mcp xaa
 
 | Command | Meaning |
 | --- | --- |
-| `serve` | Expose AgenC tools as an MCP server |
+| `serve` | Expose workspace-scoped read-only AgenC tools as an MCP server |
 | `add` | Add an MCP server |
 | `list` | List configured MCP servers |
 | `get` | Show one MCP server |
@@ -542,6 +542,11 @@ agenc mcp xaa
 agenc mcp serve --transport stdio
 agenc mcp list
 ```
+
+Inbound serve advertises only explicitly non-mutating, idempotent read tools.
+Environment flags cannot authorize mutations. Daemon SSE autostart additionally
+requires an absolute `mcp.server.workspace`; foreground serve uses its working
+directory.
 
 ---
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -183,6 +183,7 @@ enabled = false
 transport = "stdio"   # stdio | sse
 # port = 0
 # host = "127.0.0.1"
+# workspace = "/absolute/path/to/project" # required for daemon SSE autostart
 
 [mcp_servers.docs]
 transport = "stdio"
@@ -192,6 +193,10 @@ args = ["-y", "some-mcp-server"]
 # required = false
 # timeout = 30000
 ```
+
+Daemon-autostarted SSE requires an explicit absolute `mcp.server.workspace`.
+The path is canonicalized and must resolve to a directory before the endpoint
+starts.
 
 Full MCP surface: [mcp.md](mcp.md).
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -57,7 +57,10 @@ paths on the dispatcher) for session-scoped server mutations. The public SDK
 method registry includes `session.mcp.addServer`; see [`../sdk.md`](../sdk.md).
 
 AgenC can also expose itself as an MCP server via `[mcp.server]`
-(`enabled`, `transport` = `stdio` | `sse`, optional `host` / `port`).
+(`enabled`, `transport` = `stdio` | `sse`, optional `host` / `port`). Daemon
+SSE autostart also requires an absolute `workspace`; the path is canonicalized
+and must resolve to a directory before the endpoint starts. Foreground
+`agenc mcp serve` scopes tools to the command's working directory.
 
 ### Tool bridge
 
@@ -121,16 +124,60 @@ Two related layers:
 Prefer config `[mcp.server]` and the `agenc mcp` CLI rather than importing
 framework modules from embedders.
 
+The inbound server advertises and dispatches only tools whose native contract
+is consistently read-only: `isReadOnly === true`, explicit non-mutating
+metadata, an `idempotent` recovery category, and no approval, interaction, or
+permission hooks. Calls are bound to that audited tool instance rather than
+redispatched by name. All other tool names are omitted from
+`tools/list`; a direct call returns a stable denial without reaching the bare
+tool-registry dispatcher. Environment variables are never mutation
+authorization. Mutation support can return only after it is bound to a native
+daemon session/capability and traverses the common permission, sandbox,
+admission, redaction, and audit path.
+
+Code-intelligence and git-backed tools are excluded from this inbound registry:
+symbol indexing persists cache files, and git reads can refresh index state.
+They remain available through native sessions where the normal policy boundary
+applies.
+
+Prompts and resources are scoped to the same canonical workspace: project
+`.agenc/skills`, `.agenc/commands`, `.agenc/memory`, and `AGENC.md`. User-global
+skills, commands, memory, and instructions are never exposed by inbound serve.
+Every candidate is canonicalized, regular-file checked, and rejected if a
+symlink resolves outside the workspace. Resource listing remains metadata-only;
+the server revalidates and reads only the resource selected by `resources/read`.
+
 ## Security notes
 
 - Treat MCP tool results as **untrusted work data** (same framing discipline as
   channel payloads).
-- Mutating Solana-like MCP tools still hit the SLM transaction guard when
-  metadata marks them Solana + mutating — see
-  [`../security/slm-transaction-guard.md`](../security/slm-transaction-guard.md).
+- Inbound `mcp serve` is read-only. Mutating built-ins are neither advertised
+  nor dispatched, even if a legacy environment override is present or a tool
+  has contradictory read-only/mutating metadata.
+- SSE remains loopback-only, disabled by default, and has no peer authentication.
+  Prefer stdio when process-level peer isolation is required: any local process
+  or OS user able to reach loopback may otherwise read the configured workspace
+  with the AgenC owner's filesystem authority.
 - Prefer supply-chain pins for untrusted third-party servers.
 - Stdio servers run as your user with the configured env — only pass secrets you
   intend the child to see.
+
+### Design record (2026-07-16)
+
+The boundary follows the current MCP specification's principles that tool
+execution requires explicit user control and robust access controls, and that
+tool metadata is not itself an authorization decision:
+
+- [MCP 2025-11-25 security and trust principles](https://modelcontextprotocol.io/specification/2025-11-25)
+- [MCP tools security guidance](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
+
+Alternatives rejected: retaining an environment opt-in (no authenticated
+identity, consent, or audit binding), sending mutations to the bare registry
+dispatcher (bypasses native policy), and disabling the entire inbound server
+(unnecessary for workspace-scoped read-only integrations). The fail-closed
+subset preserves useful local reads while leaving one future re-enable point:
+the daemon-owned admission kernel.
 
 ## Related
 

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -93,8 +93,10 @@ import { resolveProviderBaseURL } from "../config/env.js";
 import type { AgenCConfig, AgentRunRetentionConfig } from "../config/schema.js";
 import { BUILT_IN_PROVIDER_BASE_URLS } from "../llm/registry/provider-info.js";
 import {
+  prepareMcpSseServerReconfigurationFromConfig,
   resolveMcpServeDefaults,
   startMcpServerFromConfig,
+  type StartedMcpSseServer,
 } from "../mcp/server/start.js";
 import {
   recoverDaemonStateOnStartup,
@@ -1521,11 +1523,12 @@ async function runAgenCDaemonForeground(
           throw new Error("daemon is shutting down");
         }
         const next = await resolveAgenCDaemonAuthStartup(host, io);
-        const nextMcpServer =
-          activeMcpServer.fingerprint === daemonMcpServerFingerprint(next.config)
-            ? activeMcpServer
-            : await startConfiguredDaemonMcpServer(next.config, io);
         const previousMcpServer = activeMcpServer;
+        const preparedMcpChange = await prepareConfiguredDaemonMcpServerChange(
+          previousMcpServer,
+          next.config,
+          io,
+        );
         let adopted = false;
         try {
           reloadableAuthBackend.replace(next.authBackend);
@@ -1540,14 +1543,14 @@ async function runAgenCDaemonForeground(
             next.config.agent?.retention,
           );
           activeConfig = next.config;
-          activeMcpServer = nextMcpServer;
+          activeMcpServer = preparedMcpChange.adopt();
           adopted = true;
         } finally {
-          if (!adopted && nextMcpServer !== previousMcpServer) {
-            await closeDaemonMcpServerAfterReloadFailure(nextMcpServer, io);
+          if (!adopted) {
+            await preparedMcpChange.reject();
           }
         }
-        if (previousMcpServer !== nextMcpServer) {
+        if (preparedMcpChange.closePreviousAfterAdoption) {
           await closeReplacedDaemonMcpServer(previousMcpServer, io);
         }
         const result: DaemonReloadResult = {
@@ -1868,9 +1871,65 @@ async function runAgenCDaemonForeground(
 
 interface AgenCDaemonMcpServerHandle {
   readonly fingerprint: string;
+  readonly bindingFingerprint: string;
   readonly status: "disabled" | "unsupported" | "listening";
   readonly url?: string;
+  readonly server?: StartedMcpSseServer;
   close(): Promise<void>;
+}
+
+interface PreparedDaemonMcpServerChange {
+  readonly closePreviousAfterAdoption: boolean;
+  adopt(): AgenCDaemonMcpServerHandle;
+  reject(): Promise<void>;
+}
+
+async function prepareConfiguredDaemonMcpServerChange(
+  active: AgenCDaemonMcpServerHandle,
+  config: AgenCConfig,
+  io: AgenCDaemonCliIo,
+): Promise<PreparedDaemonMcpServerChange> {
+  const fingerprint = daemonMcpServerFingerprint(config);
+  if (active.fingerprint === fingerprint) {
+    return {
+      closePreviousAfterAdoption: false,
+      adopt: () => active,
+      reject: async () => {},
+    };
+  }
+
+  const defaults = resolveMcpServeDefaults(config.mcp?.server);
+  if (
+    active.server !== undefined &&
+    defaults.enabled &&
+    defaults.transport === "sse" &&
+    defaults.workspace !== undefined &&
+    active.bindingFingerprint === daemonMcpServerBindingFingerprint(config)
+  ) {
+    const prepared = await prepareMcpSseServerReconfigurationFromConfig(
+      active.server,
+      config,
+    );
+    const next = listeningDaemonMcpServerHandle(config, active.server);
+    return {
+      closePreviousAfterAdoption: false,
+      adopt() {
+        const revokedSessions = prepared.apply();
+        io.stderr.write(
+          `AgenC MCP server workspace reconfigured; revoked ${revokedSessions} session${revokedSessions === 1 ? "" : "s"}\n`,
+        );
+        return next;
+      },
+      reject: async () => {},
+    };
+  }
+
+  const next = await startConfiguredDaemonMcpServer(config, io);
+  return {
+    closePreviousAfterAdoption: next !== active,
+    adopt: () => next,
+    reject: () => closeDaemonMcpServerAfterReloadFailure(next, io),
+  };
 }
 
 async function startConfiguredDaemonMcpServer(
@@ -1878,10 +1937,7 @@ async function startConfiguredDaemonMcpServer(
   io: AgenCDaemonCliIo,
 ): Promise<AgenCDaemonMcpServerHandle> {
   try {
-    const result = await startMcpServerFromConfig(config, {
-      cwd: process.cwd(),
-    });
-    const fingerprint = daemonMcpServerFingerprint(config);
+    const result = await startMcpServerFromConfig(config);
     if (result.kind === "disabled") {
       return inactiveDaemonMcpServerHandle(config, "disabled");
     }
@@ -1893,12 +1949,7 @@ async function startConfiguredDaemonMcpServer(
     }
 
     io.stderr.write(`AgenC MCP server listening on ${result.server.url}\n`);
-    return {
-      fingerprint,
-      status: "listening",
-      url: result.server.url,
-      close: () => result.server.close(),
-    };
+    return listeningDaemonMcpServerHandle(config, result.server);
   } catch (error) {
     io.stderr.write(
       `agenc: daemon MCP server start failed: ${formatCleanupError(error)}\n`,
@@ -1913,13 +1964,41 @@ function inactiveDaemonMcpServerHandle(
 ): AgenCDaemonMcpServerHandle {
   return {
     fingerprint: config === undefined ? "unconfigured" : daemonMcpServerFingerprint(config),
+    bindingFingerprint:
+      config === undefined
+        ? "unconfigured"
+        : daemonMcpServerBindingFingerprint(config),
     status,
     close: async () => {},
   };
 }
 
+function listeningDaemonMcpServerHandle(
+  config: AgenCConfig,
+  server: StartedMcpSseServer,
+): AgenCDaemonMcpServerHandle {
+  return {
+    fingerprint: daemonMcpServerFingerprint(config),
+    bindingFingerprint: daemonMcpServerBindingFingerprint(config),
+    status: "listening",
+    url: server.url,
+    server,
+    close: () => server.close(),
+  };
+}
+
 function daemonMcpServerFingerprint(config: AgenCConfig): string {
   return JSON.stringify(resolveMcpServeDefaults(config.mcp?.server));
+}
+
+function daemonMcpServerBindingFingerprint(config: AgenCConfig): string {
+  const defaults = resolveMcpServeDefaults(config.mcp?.server);
+  return JSON.stringify({
+    enabled: defaults.enabled,
+    transport: defaults.transport,
+    host: defaults.host,
+    port: defaults.port,
+  });
 }
 
 function daemonMcpServerReloadResult(

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -374,7 +374,7 @@ export function formatCliHelpText(): string {
     "  trajectories                            Curate exported trajectories into training JSONL",
     "  daemon                                  Manage the local AgenC daemon",
     "  agent                                   Start, attach, inspect, or stop background agents",
-    "  mcp                                     Manage MCP servers or serve AgenC tools over MCP",
+    "  mcp                                     Manage MCP servers or serve read-only AgenC tools over MCP",
     "  help [command]                          Show top-level or command help",
     "",
     "Options:",

--- a/runtime/src/bin/mcp-cli.ts
+++ b/runtime/src/bin/mcp-cli.ts
@@ -62,7 +62,7 @@ export function formatAgenCMcpCliHelpText(): string {
     "Usage: agenc mcp <command> [options]",
     "",
     "Commands:",
-    "  serve                    Expose AgenC tools as an MCP server",
+    "  serve                    Expose workspace-scoped read-only tools over MCP",
     "  add                      Add an MCP server",
     "  list                     List configured MCP servers",
     "  get                      Show one MCP server",

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -9,6 +9,8 @@
 //
 // Unknown keys are preserved on a `_unknown` side table (I-26 forward-compat).
 
+import { isAbsolute } from "node:path";
+
 // ─────────────────────────────────────────────────────────────────────
 // Core enums / unions
 // ─────────────────────────────────────────────────────────────────────
@@ -318,6 +320,8 @@ export interface McpServerModeConfig {
   readonly transport?: McpServerModeTransport;
   readonly port?: number;
   readonly host?: string;
+  /** Absolute workspace exposed by daemon-autostarted read-only MCP tools. */
+  readonly workspace?: string;
 }
 
 export interface McpConfig {
@@ -2082,6 +2086,7 @@ const MCP_SERVER_MODE_KEYS: ReadonlySet<string> = new Set([
   "transport",
   "port",
   "host",
+  "workspace",
 ]);
 
 export function validateMcpServerModeConfig(
@@ -2134,6 +2139,20 @@ export function validateMcpServerModeConfig(
     (field, detail) => new InvalidMcpServerModeConfigError(field, detail),
   );
   if (host !== undefined) out.host = host;
+  const workspace = optionalString(
+    record.workspace,
+    "workspace",
+    (field, detail) => new InvalidMcpServerModeConfigError(field, detail),
+  );
+  if (workspace !== undefined) {
+    if (!isAbsolute(workspace)) {
+      throw new InvalidMcpServerModeConfigError(
+        "workspace",
+        "expected an absolute filesystem path",
+      );
+    }
+    out.workspace = workspace;
+  }
   return Object.freeze(out as McpServerModeConfig);
 }
 

--- a/runtime/src/mcp-server/http-sse.ts
+++ b/runtime/src/mcp-server/http-sse.ts
@@ -93,7 +93,6 @@ class HttpError extends Error {
 
 export class McpHttpSseServerTransport {
   readonly #options: {
-    readonly serverFactory: () => McpServerFramework;
     readonly httpPath: string;
     readonly ssePath: string;
     readonly legacyMessagePath: string;
@@ -102,11 +101,12 @@ export class McpHttpSseServerTransport {
     readonly onError?: (error: Error) => void;
     readonly streamableIdleMs: number;
   };
+  #serverFactory: () => McpServerFramework;
   readonly #sessions = new Map<string, McpHttpSseSession>();
 
   constructor(options: McpHttpSseServerTransportOptions) {
+    this.#serverFactory = options.serverFactory;
     this.#options = {
-      serverFactory: options.serverFactory,
       httpPath: options.httpPath ?? DEFAULT_HTTP_PATH,
       ssePath: options.ssePath ?? DEFAULT_SSE_PATH,
       legacyMessagePath:
@@ -125,6 +125,22 @@ export class McpHttpSseServerTransport {
       hasSseStream: session.getStreams.size > 0 || session.postStreams.size > 0,
       initialized: session.server.snapshot().initialized,
     }));
+  }
+
+  /**
+   * Atomically changes the factory used for future sessions and revokes every
+   * session admitted under the previous factory. The swap happens before the
+   * synchronous revocation loop, so a future session cannot acquire the
+   * previous workspace context. Requests already executing keep the context
+   * under which they were admitted.
+   */
+  replaceServerFactory(serverFactory: () => McpServerFramework): number {
+    const sessionIds = [...this.#sessions.keys()];
+    this.#serverFactory = serverFactory;
+    for (const sessionId of sessionIds) {
+      this.closeSession(sessionId);
+    }
+    return sessionIds.length;
   }
 
   createNodeServer(): Server {
@@ -240,10 +256,18 @@ export class McpHttpSseServerTransport {
     // session has already been removed.
     this.#clearIdleTimer(session);
     for (const stream of session.getStreams.values()) {
-      stream.response.end();
+      try {
+        stream.response.end();
+      } catch (error) {
+        this.#options.onError?.(asError(error));
+      }
     }
     for (const stream of session.postStreams.values()) {
-      stream.response.end();
+      try {
+        stream.response.end();
+      } catch (error) {
+        this.#options.onError?.(asError(error));
+      }
     }
     this.#sessions.delete(sessionId);
     return true;
@@ -263,7 +287,7 @@ export class McpHttpSseServerTransport {
     const session: McpHttpSseSession = {
       id,
       kind,
-      server: this.#options.serverFactory(),
+      server: this.#serverFactory(),
       getStreams: new Map(),
       postStreams: new Map(),
       requestPostStreams: new Map(),
@@ -307,7 +331,7 @@ export class McpHttpSseServerTransport {
     if (shouldCreateSession) {
       session = this.#createSession("streamable-http");
     }
-    const server = session?.server ?? this.#options.serverFactory();
+    const server = session?.server ?? this.#serverFactory();
     if (session !== null && shouldUsePostSse(request, parsed)) {
       const stream = this.#attachPostSseStream(session, response);
       if (parsed.kind === "request") {

--- a/runtime/src/mcp-server/tools.ts
+++ b/runtime/src/mcp-server/tools.ts
@@ -3,13 +3,13 @@
  * tools/call behavior onto AgenC's existing tool registry surface.
  *
  * MS-02 owns registration only. Transports and permission decisions stay
- * in later MS-* items; this adapter delegates execution to the already
- * configured AgenC `ToolRegistry`.
+ * in later MS-* items. This adapter binds each admitted call to the exact
+ * audited tool instance; name-based registry dispatch can rebuild or alias
+ * to a different implementation and is therefore unsafe at this boundary.
  */
 
-import type { LLMToolCall } from "../llm/types.js";
-import type { ToolRegistry, ToolDispatchResult } from "../tool-registry.js";
-import type { Tool } from "../tools/types.js";
+import type { ToolRegistry } from "../tool-registry.js";
+import { safeStringify, type Tool, type ToolResult } from "../tools/types.js";
 import {
   type McpCallToolResult,
   type McpToolCallContext,
@@ -26,13 +26,20 @@ export interface McpRegisteredTool {
   ): Promise<McpCallToolResult>;
 }
 
-function stringifyArguments(args: Readonly<Record<string, unknown>> | undefined): string {
-  if (args === undefined) return "{}";
-  try {
-    return JSON.stringify(args);
-  } catch {
-    return "{}";
-  }
+function isProvablyReadOnlyForInboundMcp(tool: Tool): boolean {
+  // Inbound MCP does not traverse runToolUse's native permission/sandbox path.
+  // Require the independent internal signals and no permission/UI hooks. Fail
+  // closed when a tool omits or contradicts any of them; metadata alone is
+  // never authorization.
+  return (
+    tool.isReadOnly === true &&
+    tool.metadata?.mutating === false &&
+    tool.recoveryCategory === "idempotent" &&
+    tool.requiresApproval === false &&
+    tool.defaultPermissionMode === undefined &&
+    tool.requiresUserInteraction === undefined &&
+    tool.checkPermissions === undefined
+  );
 }
 
 export function mcpDefinitionFromAgenCTool(tool: Tool): McpToolDefinition {
@@ -43,9 +50,7 @@ export function mcpDefinitionFromAgenCTool(tool: Tool): McpToolDefinition {
   };
 }
 
-function mcpResultFromToolDispatch(
-  result: ToolDispatchResult,
-): McpCallToolResult {
+function mcpResultFromToolExecution(result: ToolResult): McpCallToolResult {
   return {
     content: [{ type: "text", text: result.content }],
     ...(result.codeModeResult !== undefined
@@ -55,49 +60,55 @@ function mcpResultFromToolDispatch(
   };
 }
 
-function registeredToolFromAgenCTool(
-  tool: Tool,
-  dispatch: ToolRegistry["dispatch"],
-): McpRegisteredTool {
+function registeredToolFromAgenCTool(tool: Tool): McpRegisteredTool {
+  const execute = tool.execute.bind(tool);
   return {
     definition: mcpDefinitionFromAgenCTool(tool),
     async call(params, context) {
-      // Fail closed for mutating tools unless operator opts in (todo-118).
-      // Full session permission/sandbox pipeline remains a follow-up; this
-      // removes the previous always-execute path for write/shell tools.
-      const readOnly = tool.isReadOnly === true;
-      const allowMutations =
-        process.env.AGENC_MCP_ALLOW_MUTATIONS === "1" ||
-        process.env.AGENC_MCP_ALLOW_MUTATIONS === "true";
-      if (!readOnly && !allowMutations) {
+      const args = { ...(params.arguments ?? {}) };
+      Object.defineProperty(args, "__callId", {
+        value: String(context.requestId ?? `${tool.name}-mcp-call`),
+        enumerable: false,
+        configurable: true,
+      });
+      try {
+        return mcpResultFromToolExecution(await execute(args));
+      } catch (error) {
         return {
           content: [
             {
               type: "text",
-              text: `MCP tool '${tool.name}' is not read-only; set AGENC_MCP_ALLOW_MUTATIONS=1 to permit mutating tools over MCP serve (todo-118).`,
+              text: safeStringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
             },
           ],
           isError: true,
         };
       }
-      const toolCall: LLMToolCall = {
-        id: String(context.requestId ?? `${tool.name}-mcp-call`),
-        name: params.name,
-        arguments: stringifyArguments(params.arguments),
-      };
-      return mcpResultFromToolDispatch(await dispatch(toolCall));
     },
   };
 }
 
 export class McpToolRegistry implements McpToolProvider {
   private readonly tools = new Map<string, McpRegisteredTool>();
+  private readonly blockedToolNames = new Set<string>();
 
   registerTool(tool: McpRegisteredTool): void {
-    if (this.tools.has(tool.definition.name)) {
+    if (
+      this.tools.has(tool.definition.name) ||
+      this.blockedToolNames.has(tool.definition.name)
+    ) {
       throw new Error(`MCP tool already registered: ${tool.definition.name}`);
     }
     this.tools.set(tool.definition.name, tool);
+  }
+
+  blockTool(name: string): void {
+    if (this.tools.has(name) || this.blockedToolNames.has(name)) {
+      throw new Error(`MCP tool already registered: ${name}`);
+    }
+    this.blockedToolNames.add(name);
   }
 
   listTools(): readonly McpToolDefinition[] {
@@ -110,6 +121,21 @@ export class McpToolRegistry implements McpToolProvider {
   ): Promise<McpCallToolResult> {
     const tool = this.tools.get(params.name);
     if (tool === undefined) {
+      if (this.blockedToolNames.has(params.name)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `MCP tool '${params.name}' is unavailable: inbound MCP serves ` +
+                "only explicitly read-only, non-mutating, idempotent tools. " +
+                "Environment overrides are not authorization; use a daemon-native " +
+                "admitted session when mutation support is available.",
+            },
+          ],
+          isError: true,
+        };
+      }
       return {
         content: [{ type: "text", text: `Unknown tool '${params.name}'` }],
         isError: true,
@@ -120,13 +146,15 @@ export class McpToolRegistry implements McpToolProvider {
 }
 
 export function mcpToolRegistryFromAgenCTools(
-  registry: Pick<ToolRegistry, "tools" | "dispatch">,
+  registry: Pick<ToolRegistry, "tools">,
 ): McpToolRegistry {
   const mcpRegistry = new McpToolRegistry();
   for (const tool of registry.tools) {
-    mcpRegistry.registerTool(
-      registeredToolFromAgenCTool(tool, registry.dispatch.bind(registry)),
-    );
+    if (!isProvablyReadOnlyForInboundMcp(tool)) {
+      mcpRegistry.blockTool(tool.name);
+      continue;
+    }
+    mcpRegistry.registerTool(registeredToolFromAgenCTool(tool));
   }
   return mcpRegistry;
 }

--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -13,14 +13,15 @@
  *     the same way it gates in-process model invocation.
  *   - Resources: memory files (via the same scanner the runtime uses)
  *     plus explicitly-passed instruction files (AGENC.md tiers).
- *     Path-bounded by construction: `readResource` only serves URIs
- *     minted by its own listing — it never resolves client-supplied
- *     paths. Contents pass through the memory secret redactor.
+ *     Canonical containment rejects symlink escapes, and `readResource`
+ *     only serves URIs minted by a fresh listing — it never resolves
+ *     client-supplied paths. Only the selected resource body is read,
+ *     then its contents pass through the memory secret redactor.
  *
  * @module
  */
-import { readdir, readFile, stat } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { lstat, readdir, readFile, realpath } from "node:fs/promises";
+import { basename, isAbsolute, join, relative } from "node:path";
 
 import {
   detectSessionFileType,
@@ -43,6 +44,8 @@ import type {
 export interface SkillPromptProviderOptions {
   /** Directories whose children are skills (`<dir>/<name>/SKILL.md` or `<dir>/<name>.md`). */
   readonly skillRoots: readonly string[];
+  /** Canonical containment root; candidates resolving outside it are omitted. */
+  readonly scopeRoot?: string;
 }
 
 interface DiscoveredSkill {
@@ -50,13 +53,68 @@ interface DiscoveredSkill {
   readonly filePath: string;
   readonly description: string;
   readonly argumentHint: string | undefined;
+  readonly rawContent: string;
+}
+
+async function canonicalScopeRoot(
+  scopeRoot: string | undefined,
+): Promise<string | null> {
+  if (scopeRoot === undefined) return null;
+  try {
+    return await realpath(scopeRoot);
+  } catch {
+    return null;
+  }
+}
+
+function isSameOrChildPath(scopeRoot: string, candidate: string): boolean {
+  const offset = relative(scopeRoot, candidate);
+  return offset === "" || (!offset.startsWith("..") && !isAbsolute(offset));
+}
+
+async function readScopedRegularFile(
+  filePath: string,
+  scopeRoot: string | null,
+  readContent: (canonicalPath: string) => Promise<string> = async (
+    canonicalPath,
+  ) => await readFile(canonicalPath, "utf8"),
+): Promise<{
+  readonly canonicalPath: string;
+  readonly rawContent: string;
+} | null> {
+  const canonicalPath = await resolveScopedRegularFile(filePath, scopeRoot);
+  if (canonicalPath === null) return null;
+  try {
+    return { canonicalPath, rawContent: await readContent(canonicalPath) };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveScopedRegularFile(
+  filePath: string,
+  scopeRoot: string | null,
+): Promise<string | null> {
+  try {
+    const fileStat = await lstat(filePath);
+    if (fileStat.isSymbolicLink() || !fileStat.isFile()) return null;
+    const canonicalPath = await realpath(filePath);
+    if (scopeRoot !== null && !isSameOrChildPath(scopeRoot, canonicalPath)) {
+      return null;
+    }
+    return canonicalPath;
+  } catch {
+    return null;
+  }
 }
 
 async function discoverSkills(
-  roots: readonly string[],
+  options: SkillPromptProviderOptions,
 ): Promise<Map<string, DiscoveredSkill>> {
   const skills = new Map<string, DiscoveredSkill>();
-  for (const root of roots) {
+  const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
+  if (options.scopeRoot !== undefined && scopeRoot === null) return skills;
+  for (const root of options.skillRoots) {
     let entries;
     try {
       entries = await readdir(root, { withFileTypes: true });
@@ -73,19 +131,18 @@ async function discoverSkills(
             }
           : null;
       if (candidate === null || skills.has(candidate.name)) continue;
-      let raw: string;
-      try {
-        raw = await readFile(candidate.filePath, "utf8");
-      } catch {
-        continue;
-      }
-      const { frontmatter } = parseFrontmatter(raw, candidate.filePath);
+      const file = await readScopedRegularFile(candidate.filePath, scopeRoot);
+      if (file === null) continue;
+      const { frontmatter } = parseFrontmatter(
+        file.rawContent,
+        file.canonicalPath,
+      );
       if (parseBooleanFrontmatter(frontmatter["disable-model-invocation"])) {
         continue;
       }
       skills.set(candidate.name, {
         name: candidate.name,
-        filePath: candidate.filePath,
+        filePath: file.canonicalPath,
         description:
           typeof frontmatter.description === "string"
             ? frontmatter.description
@@ -94,6 +151,7 @@ async function discoverSkills(
           frontmatter["argument-hint"] != null
             ? String(frontmatter["argument-hint"])
             : undefined,
+        rawContent: file.rawContent,
       });
     }
   }
@@ -105,7 +163,7 @@ export function createSkillPromptProvider(
 ): McpPromptProvider {
   return {
     async listPrompts(): Promise<readonly McpPromptDefinition[]> {
-      const skills = await discoverSkills(options.skillRoots);
+      const skills = await discoverSkills(options);
       return [...skills.values()].map((skill) => ({
         name: skill.name,
         description: skill.description,
@@ -123,16 +181,13 @@ export function createSkillPromptProvider(
       name: string,
       args?: Readonly<Record<string, string>>,
     ): Promise<McpGetPromptResult | null> {
-      const skills = await discoverSkills(options.skillRoots);
+      const skills = await discoverSkills(options);
       const skill = skills.get(name);
       if (skill === undefined) return null;
-      let raw: string;
-      try {
-        raw = await readFile(skill.filePath, "utf8");
-      } catch {
-        return null;
-      }
-      const { content } = parseFrontmatter(raw, skill.filePath);
+      const { content } = parseFrontmatter(
+        skill.rawContent,
+        skill.filePath,
+      );
       const argumentText = args?.arguments ?? "";
       const text = content.includes("$ARGUMENTS")
         ? content.replaceAll("$ARGUMENTS", argumentText)
@@ -152,6 +207,10 @@ export interface MemoryResourceProviderOptions {
   readonly memoryDirs: readonly string[];
   /** Explicit instruction files (AGENC.md tiers). Listed only if they exist. */
   readonly instructionFiles?: readonly string[];
+  /** Canonical containment root; candidates resolving outside it are omitted. */
+  readonly scopeRoot?: string;
+  /** Resource body reader. Exposed for deterministic embedding and tests. */
+  readonly readResourceContent?: (canonicalPath: string) => Promise<string>;
 }
 
 const MEMORY_URI_SCHEME = "agenc-memory://";
@@ -166,12 +225,19 @@ async function listMemoryResources(
   options: MemoryResourceProviderOptions,
 ): Promise<Map<string, ListedResource>> {
   const resources = new Map<string, ListedResource>();
+  const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
+  if (options.scopeRoot !== undefined && scopeRoot === null) return resources;
   for (const [dirIndex, dir] of options.memoryDirs.entries()) {
     const headers = await scanMemoryFiles(dir);
     for (const header of headers) {
       // Session memory/transcripts are excluded outright — same boundary
       // the permission layer enforces for in-process reads.
       if (detectSessionFileType(header.filePath) !== null) continue;
+      const canonicalPath = await resolveScopedRegularFile(
+        header.filePath,
+        scopeRoot,
+      );
+      if (canonicalPath === null) continue;
       const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${header.filename}`;
       resources.set(uri, {
         definition: {
@@ -182,35 +248,32 @@ async function listMemoryResources(
             : {}),
           mimeType: "text/markdown",
         },
-        filePath: header.filePath,
+        filePath: canonicalPath,
       });
     }
     const entrypoint = join(dir, "MEMORY.md");
-    try {
-      if ((await stat(entrypoint)).isFile()) {
-        const uri = `${MEMORY_URI_SCHEME}${dirIndex}/MEMORY.md`;
-        resources.set(uri, {
-          definition: {
-            uri,
-            name: "MEMORY.md",
-            description: "Memory index",
-            mimeType: "text/markdown",
-          },
-          filePath: entrypoint,
-        });
-      }
-    } catch {
-      /* no entrypoint */
+    const canonicalEntrypoint = await resolveScopedRegularFile(
+      entrypoint,
+      scopeRoot,
+    );
+    if (canonicalEntrypoint !== null) {
+      const uri = `${MEMORY_URI_SCHEME}${dirIndex}/MEMORY.md`;
+      resources.set(uri, {
+        definition: {
+          uri,
+          name: "MEMORY.md",
+          description: "Memory index",
+          mimeType: "text/markdown",
+        },
+        filePath: canonicalEntrypoint,
+      });
     }
   }
   for (const [fileIndex, filePath] of (
     options.instructionFiles ?? []
   ).entries()) {
-    try {
-      if (!(await stat(filePath)).isFile()) continue;
-    } catch {
-      continue;
-    }
+    const canonicalPath = await resolveScopedRegularFile(filePath, scopeRoot);
+    if (canonicalPath === null) continue;
     if (detectSessionFileType(filePath) !== null) continue;
     const uri = `${INSTRUCTIONS_URI_SCHEME}${fileIndex}/${basename(filePath)}`;
     resources.set(uri, {
@@ -220,7 +283,7 @@ async function listMemoryResources(
         description: `Project instructions (${filePath})`,
         mimeType: "text/markdown",
       },
-      filePath,
+      filePath: canonicalPath,
     });
   }
   return resources;
@@ -240,18 +303,20 @@ export function createMemoryResourceProvider(
       const resources = await listMemoryResources(options);
       const resource = resources.get(uri);
       if (resource === undefined) return null;
-      let raw: string;
-      try {
-        raw = await readFile(resource.filePath, "utf8");
-      } catch {
-        return null;
-      }
+      const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
+      if (options.scopeRoot !== undefined && scopeRoot === null) return null;
+      const file = await readScopedRegularFile(
+        resource.filePath,
+        scopeRoot,
+        options.readResourceContent,
+      );
+      if (file === null) return null;
       return {
         contents: [
           {
             uri,
             mimeType: "text/markdown",
-            text: redactSecrets(raw),
+            text: redactSecrets(file.rawContent),
           },
         ],
       };

--- a/runtime/src/mcp/server/start.ts
+++ b/runtime/src/mcp/server/start.ts
@@ -7,16 +7,15 @@
  */
 
 import type { Server } from "node:http";
-import { join } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
 import { cwd as processCwd } from "node:process";
 import type { Readable, Writable } from "node:stream";
 import {
-  getMemoryBaseDir,
   MEMORY_DIRNAME,
   PROJECT_INSTRUCTION_FILE,
   PROJECT_MEMORY_DIR,
 } from "../../memory/index.js";
-import { getAgenCConfigHomeDir } from "../../utils/envUtils.js";
 import {
   createMemoryResourceProvider,
   createSkillPromptProvider,
@@ -60,6 +59,10 @@ export interface McpServerStartCommand {
 export interface StartedMcpSseServer {
   readonly server: Server;
   readonly url: string;
+  readonly configuredHost: string;
+  readonly configuredPort: number;
+  /** Prepare without applying; the returned synchronous swap cannot fail. */
+  prepareContextReplacement(cwd: string): () => number;
   close(): Promise<void>;
   waitUntilClosed(): Promise<void>;
 }
@@ -69,6 +72,13 @@ export interface ResolvedMcpServeDefaults {
   readonly transport: "stdio" | "sse";
   readonly host: string;
   readonly port: number;
+  readonly workspace?: string;
+}
+
+export interface PreparedMcpSseServerReconfiguration {
+  readonly defaults: ResolvedMcpServeDefaults;
+  /** Applies the validated context and returns the number of revoked sessions. */
+  apply(): number;
 }
 
 export type ConfiguredMcpServerStartResult =
@@ -90,11 +100,13 @@ export type ConfiguredMcpServerStartResult =
 export function resolveMcpServeDefaults(
   config: McpServerModeConfig | undefined,
 ): ResolvedMcpServeDefaults {
+  const workspace = readMcpServeWorkspace(config?.workspace);
   return {
     enabled: config?.enabled === true,
     transport: config?.transport === "sse" ? "sse" : "stdio",
     host: readMcpServeHost(config?.host),
     port: readMcpServePort(config?.port),
+    ...(workspace !== undefined ? { workspace } : {}),
   };
 }
 
@@ -114,15 +126,61 @@ export async function startMcpServerFromConfig(
     };
   }
 
-  const server = await startMcpSseServe(defaults, options);
+  if (defaults.workspace === undefined) {
+    return {
+      kind: "unsupported",
+      defaults,
+      reason:
+        "daemon MCP autostart requires an explicit absolute mcp.server.workspace; " +
+        "use foreground `agenc mcp serve` from the target workspace otherwise",
+    };
+  }
+
+  const workspace = await resolveMcpServeWorkspace(defaults.workspace);
+  const server = await startMcpSseServe(defaults, {
+    ...options,
+    cwd: workspace,
+  });
   return { kind: "started", defaults, server };
+}
+
+export async function prepareMcpSseServerReconfigurationFromConfig(
+  server: StartedMcpSseServer,
+  config: Pick<AgenCConfig, "mcp"> | undefined,
+): Promise<PreparedMcpSseServerReconfiguration> {
+  const defaults = resolveMcpServeDefaults(config?.mcp?.server);
+  if (!defaults.enabled || defaults.transport !== "sse") {
+    throw new Error(
+      "MCP SSE listener reconfiguration requires enabled SSE config",
+    );
+  }
+  const host = normalizeMcpSseLoopbackHost(defaults.host);
+  if (
+    host !== server.configuredHost ||
+    defaults.port !== server.configuredPort
+  ) {
+    throw new Error("MCP SSE listener binding changed and cannot be reused");
+  }
+  if (defaults.workspace === undefined) {
+    throw new Error(
+      "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
+    );
+  }
+
+  const workspace = await resolveMcpServeWorkspace(defaults.workspace);
+  const apply = server.prepareContextReplacement(workspace);
+  return { defaults, apply };
 }
 
 export async function runMcpStdioServe(
   io: McpServerStartIo,
   options: McpServerStartOptions = {},
 ): Promise<void> {
-  const server = createMcpFramework(createLazyMcpToolProvider(options), options.cwd);
+  const pinnedOptions = await pinMcpServerStartOptions(options);
+  const server = createMcpFramework(
+    createLazyMcpToolProvider(pinnedOptions),
+    pinnedOptions.cwd,
+  );
   await new Promise<void>((resolve, reject) => {
     const transport = new McpStdioServerTransport({
       input: io.stdin,
@@ -139,11 +197,10 @@ export async function startMcpSseServe(
   command: McpServerStartCommand,
   options: McpServerStartOptions = {},
 ): Promise<StartedMcpSseServer> {
-  const registry = resolveToolRegistry(options);
+  const pinnedOptions = await pinMcpServerStartOptions(options);
   const host = normalizeMcpSseLoopbackHost(command.host);
   const transport = new McpHttpSseServerTransport({
-    serverFactory: () =>
-      createMcpFramework(mcpToolRegistryFromAgenCTools(registry), options.cwd),
+    serverFactory: createMcpFrameworkFactory(pinnedOptions),
   });
   const server = transport.createNodeServer();
   await new Promise<void>((resolve, reject) => {
@@ -160,6 +217,15 @@ export async function startMcpSseServe(
   return {
     server,
     url,
+    configuredHost: host,
+    configuredPort: command.port,
+    prepareContextReplacement(cwd) {
+      const replacementFactory = createMcpFrameworkFactory({
+        ...pinnedOptions,
+        cwd,
+      });
+      return () => transport.replaceServerFactory(replacementFactory);
+    },
     close: () =>
       new Promise((resolve, reject) => {
         server.close((error) => {
@@ -199,6 +265,46 @@ function readMcpServePort(port: unknown): number {
   return valid ? port : 3334;
 }
 
+function readMcpServeWorkspace(workspace: unknown): string | undefined {
+  return typeof workspace === "string" && workspace.trim().length > 0
+    ? workspace.trim()
+    : undefined;
+}
+
+async function resolveMcpServeWorkspace(workspace: string): Promise<string> {
+  if (!isAbsolute(workspace)) {
+    throw new Error("mcp.server.workspace must be an absolute filesystem path");
+  }
+  const canonical = await realpath(workspace).catch((error: unknown) => {
+    throw new Error(
+      `mcp.server.workspace cannot be resolved: ${formatMcpWorkspaceError(error)}`,
+    );
+  });
+  const workspaceStat = await stat(canonical).catch((error: unknown) => {
+    throw new Error(
+      `mcp.server.workspace cannot be inspected: ${formatMcpWorkspaceError(error)}`,
+    );
+  });
+  if (!workspaceStat.isDirectory()) {
+    throw new Error("mcp.server.workspace must resolve to a directory");
+  }
+  return canonical;
+}
+
+function formatMcpWorkspaceError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function pinMcpServerStartOptions(
+  options: McpServerStartOptions,
+): Promise<McpServerStartOptions & { readonly cwd: string }> {
+  // Capture before the first await so process.chdir() cannot change the scope
+  // between transport startup and lazy provider/session creation.
+  const requestedCwd = options.cwd ?? processCwd();
+  const cwd = await resolveMcpServeWorkspace(requestedCwd);
+  return { ...options, cwd };
+}
+
 function normalizeMcpSseLoopbackHost(host: string): string {
   const trimmed = host.trim();
   if (trimmed === "127.0.0.1" || trimmed === "localhost" || trimmed === "::1") {
@@ -210,7 +316,19 @@ function normalizeMcpSseLoopbackHost(host: string): string {
 function resolveToolRegistry(options: McpServerStartOptions): ToolRegistry {
   return options.toolRegistry ?? buildToolRegistry({
     workspaceRoot: options.cwd ?? processCwd(),
+    // Symbol indexing persists snapshots and git reads may refresh index state.
+    // Neither family belongs on a literally non-mutating inbound boundary.
+    codeIntelligenceTools: false,
   });
+}
+
+function createMcpFrameworkFactory(
+  options: McpServerStartOptions,
+): () => McpServerFramework {
+  // Snapshot and audit the tool instances before a prepared reload is applied.
+  // The returned function is allocation-only and cannot rebind tool names.
+  const toolProvider = mcpToolRegistryFromAgenCTools(resolveToolRegistry(options));
+  return () => createMcpFramework(toolProvider, options.cwd);
 }
 
 function createLazyMcpToolProvider(
@@ -239,25 +357,22 @@ function createMcpFramework(
   cwd?: string,
 ): McpServerFramework {
   const workspaceRoot = cwd ?? processCwd();
-  const configHome = getAgenCConfigHomeDir();
   return new McpServerFramework({
     serverInfo: { version: VERSION },
     toolProvider,
     promptProvider: createSkillPromptProvider({
+      scopeRoot: workspaceRoot,
       skillRoots: [
-        join(configHome, "skills"),
-        join(configHome, "commands"),
         join(workspaceRoot, PROJECT_MEMORY_DIR, "skills"),
         join(workspaceRoot, PROJECT_MEMORY_DIR, "commands"),
       ],
     }),
     resourceProvider: createMemoryResourceProvider({
+      scopeRoot: workspaceRoot,
       memoryDirs: [
-        join(getMemoryBaseDir(), MEMORY_DIRNAME),
         join(workspaceRoot, PROJECT_MEMORY_DIR, MEMORY_DIRNAME),
       ],
       instructionFiles: [
-        join(configHome, PROJECT_INSTRUCTION_FILE),
         join(workspaceRoot, PROJECT_INSTRUCTION_FILE),
       ],
     }),

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -1053,6 +1053,9 @@ function createListDirTool(allowedPaths: readonly string[]): Tool {
     name: "system.listDir",
     description:
       "List directory contents. Returns entry names, types (file/dir), and sizes. Gated by path allowlist.",
+    metadata: { mutating: false },
+    isReadOnly: true,
+    requiresApproval: false,
     recoveryCategory: "idempotent",
     inputSchema: {
       type: "object",
@@ -1144,6 +1147,9 @@ function createStatTool(allowedPaths: readonly string[]): Tool {
     name: "system.stat",
     description:
       "Get file or directory metadata including size, timestamps, and type. Gated by path allowlist.",
+    metadata: { mutating: false },
+    isReadOnly: true,
+    requiresApproval: false,
     recoveryCategory: "idempotent",
     inputSchema: {
       type: "object",

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -8,7 +8,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { createConnection, type Socket } from "node:net";
+import { createConnection, createServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -222,6 +222,61 @@ async function waitForPid(pidPath: string): Promise<number> {
     await delay(10);
   }
   throw new Error("timed out waiting for daemon pid");
+}
+
+async function availableLoopbackPort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("failed to allocate loopback test port");
+  }
+  const port = address.port;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+function mcpHttpHeaders(sessionId?: string): Record<string, string> {
+  return {
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+    ...(sessionId === undefined ? {} : { "mcp-session-id": sessionId }),
+  };
+}
+
+async function initializeMcpHttpSession(url: string): Promise<string> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: mcpHttpHeaders(),
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+  });
+  expect(response.status).toBe(200);
+  await response.json();
+  const sessionId = response.headers.get("mcp-session-id");
+  if (sessionId === null) throw new Error("missing MCP session id");
+  return sessionId;
+}
+
+async function callMcpListDir(
+  url: string,
+  sessionId: string,
+  path: string,
+  id = 2,
+): Promise<{ readonly status: number; readonly body: string }> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: mcpHttpHeaders(sessionId),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: "system.listDir", arguments: { path } },
+    }),
+  });
+  return { status: response.status, body: await response.text() };
 }
 
 async function waitForCondition(
@@ -1257,6 +1312,7 @@ backend = "remote"
 enabled = true
 transport = "sse"
 port = 0
+workspace = ${JSON.stringify(process.cwd())}
 
 [agent.budget]
 token_cap = 123
@@ -1310,6 +1366,106 @@ token_cap = 123
     }
   });
 
+  it("reload reuses a fixed MCP listener, revokes old sessions, and applies the new workspace", async () => {
+    const agencHome = await tempAgencHome();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "agenc-mcp-reload-"));
+    const workspaceA = join(workspaceRoot, "workspace-a");
+    const workspaceB = join(workspaceRoot, "workspace-b");
+    await Promise.all([mkdir(workspaceA), mkdir(workspaceB)]);
+    await Promise.all([
+      writeFile(join(workspaceA, "only-a.txt"), "a"),
+      writeFile(join(workspaceB, "only-b.txt"), "b"),
+    ]);
+    const port = await availableLoopbackPort();
+    const url = `http://127.0.0.1:${port}/mcp`;
+    const host = createHost(agencHome);
+    const io = createIo();
+    const signalProcess = createSignalProcess();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    host.runningPids.add(host.pid);
+    await writeFile(
+      join(agencHome, "config.toml"),
+      `
+[mcp.server]
+enabled = true
+transport = "sse"
+host = "127.0.0.1"
+port = ${port}
+workspace = ${JSON.stringify(workspaceA)}
+      `,
+    );
+
+    const running = runAgenCDaemonCli(
+      { kind: "command", action: "run" },
+      { host, io, signalProcess },
+    );
+    let stopped = false;
+    try {
+      await expect(waitForPid(pidPath)).resolves.toBe(4100);
+      const oldSession = await initializeMcpHttpSession(url);
+      const initialRead = await callMcpListDir(url, oldSession, workspaceA);
+      expect(initialRead.status).toBe(200);
+      expect(initialRead.body).toContain("only-a.txt");
+
+      await writeFile(
+        join(agencHome, "config.toml"),
+        `
+[mcp.server]
+enabled = true
+transport = "sse"
+host = "127.0.0.1"
+port = ${port}
+workspace = ${JSON.stringify(workspaceB)}
+        `,
+      );
+      await expect(
+        runAgenCDaemonCli({ kind: "command", action: "reload" }, { host, io }),
+      ).resolves.toBe(0);
+
+      expect(
+        io.stderrText().match(/AgenC MCP server listening/g) ?? [],
+      ).toHaveLength(1);
+      expect(io.stderrText()).toContain(
+        "AgenC MCP server workspace reconfigured; revoked 1 session",
+      );
+      await expect(
+        callMcpListDir(url, oldSession, workspaceA, 3),
+      ).resolves.toEqual(expect.objectContaining({ status: 404 }));
+
+      const newSession = await initializeMcpHttpSession(url);
+      const workspaceBRead = await callMcpListDir(
+        url,
+        newSession,
+        workspaceB,
+        4,
+      );
+      expect(workspaceBRead.status).toBe(200);
+      expect(workspaceBRead.body).toContain("only-b.txt");
+      const workspaceARead = await callMcpListDir(
+        url,
+        newSession,
+        workspaceA,
+        5,
+      );
+      expect(workspaceARead.body).toContain(
+        "Path is outside allowed directories",
+      );
+
+      signalProcess.emit("SIGTERM");
+      stopped = true;
+      await expect(running).resolves.toBe(0);
+    } finally {
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await Promise.all([
+        rm(agencHome, { recursive: true, force: true }),
+        rm(workspaceRoot, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
   it("reload failure preserves active auth and mcp.server state", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);
@@ -1333,6 +1489,7 @@ backend = "local"
 enabled = true
 transport = "sse"
 port = 0
+workspace = ${JSON.stringify(process.cwd())}
       `,
     );
 
@@ -1374,6 +1531,7 @@ enabled = true
 transport = "sse"
 host = "0.0.0.0"
 port = 0
+workspace = ${JSON.stringify(process.cwd())}
         `,
       );
 
@@ -2154,7 +2312,7 @@ backend = "local"
     await rm(agencHome, { recursive: true, force: true });
   });
 
-  it("foreground daemon starts a configured mcp.server SSE endpoint", async () => {
+  it("does not autostart MCP without an explicit workspace scope", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);
     const io = createIo();
@@ -2167,6 +2325,40 @@ backend = "local"
 enabled = true
 transport = "sse"
 port = 0
+      `,
+    );
+
+    const running = runAgenCDaemonCli(
+      { kind: "command", action: "run" },
+      { host, io, signalProcess },
+    );
+    await expect(waitForPid(pidPath)).resolves.toBe(4100);
+
+    expect(io.stderrText()).toContain(
+      "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
+    );
+    expect(io.stderrText()).not.toContain("AgenC MCP server listening");
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("foreground daemon starts a workspace-scoped mcp.server SSE endpoint", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+    const signalProcess = createSignalProcess();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    await writeFile(
+      join(agencHome, "config.toml"),
+      `
+[mcp.server]
+enabled = true
+transport = "sse"
+port = 0
+workspace = ${JSON.stringify(process.cwd())}
       `,
     );
 

--- a/runtime/tests/bin/mcp-cli.test.ts
+++ b/runtime/tests/bin/mcp-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -25,13 +25,35 @@ const SAMPLE_TOOL: Tool = {
   name: "sample.echo",
   description: "Echo text back to the caller.",
   isReadOnly: true,
+  metadata: { mutating: false },
+  requiresApproval: false,
+  recoveryCategory: "idempotent",
   inputSchema: {
     type: "object",
     properties: { text: { type: "string" } },
   },
   async execute(args) {
-    return { content: String(args.text ?? "") };
+    return {
+      content: `echo:${String(args.text ?? "")}`,
+      codeModeResult: { tool: "sample.echo" },
+    };
   },
+};
+
+const MUTATING_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.write",
+  description: "Mutates state.",
+  isReadOnly: false,
+  metadata: { mutating: true },
+  recoveryCategory: "side-effecting",
+};
+
+const CONTRADICTORY_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.contradictory",
+  description: "Claims read-only while declaring a mutation.",
+  metadata: { mutating: true },
 };
 
 const RUNTIME_ROOT = fileURLToPath(new URL("../..", import.meta.url));
@@ -48,7 +70,7 @@ function request(id: number, method: string, params?: unknown) {
 
 function createToolRegistry(): ToolRegistry {
   return {
-    tools: [SAMPLE_TOOL],
+    tools: [SAMPLE_TOOL, MUTATING_TOOL, CONTRADICTORY_TOOL],
     toLLMTools(): LLMTool[] {
       return [];
     },
@@ -444,9 +466,25 @@ describe("AgenC MCP CLI", () => {
       }),
     );
 
+    input.write(`${JSON.stringify(request(2, "tools/list"))}\n`);
+    await expect(lines.nextLine().then(JSON.parse)).resolves.toEqual({
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        tools: [
+          {
+            name: SAMPLE_TOOL.name,
+            description: SAMPLE_TOOL.description,
+            inputSchema: SAMPLE_TOOL.inputSchema,
+          },
+        ],
+        nextCursor: null,
+      },
+    });
+
     input.write(
       `${JSON.stringify(
-        request(2, "tools/call", {
+        request(3, "tools/call", {
           name: "sample.echo",
           arguments: { text: "hello" },
         }),
@@ -454,10 +492,34 @@ describe("AgenC MCP CLI", () => {
     );
     await expect(lines.nextLine().then(JSON.parse)).resolves.toEqual({
       jsonrpc: "2.0",
-      id: 2,
+      id: 3,
       result: {
         content: [{ type: "text", text: "echo:hello" }],
         structuredContent: { tool: "sample.echo" },
+      },
+    });
+
+    input.write(
+      `${JSON.stringify(
+        request(4, "tools/call", {
+          name: CONTRADICTORY_TOOL.name,
+          arguments: {},
+        }),
+      )}\n`,
+    );
+    await expect(lines.nextLine().then(JSON.parse)).resolves.toEqual({
+      jsonrpc: "2.0",
+      id: 4,
+      result: {
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining(
+              "only explicitly read-only, non-mutating, idempotent tools",
+            ),
+          },
+        ],
+        isError: true,
       },
     });
 
@@ -465,6 +527,67 @@ describe("AgenC MCP CLI", () => {
     await expect(withTimeout(result)).resolves.toBe(0);
     expect(stderr.text()).toBe("");
     lines.close();
+  });
+
+  test("pins foreground stdio workspace before lazy tool creation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-mcp-pinned-stdio-"));
+    const workspaceA = join(root, "workspace-a");
+    const workspaceB = join(root, "workspace-b");
+    mkdirSync(workspaceA);
+    mkdirSync(workspaceB);
+    writeFileSync(join(workspaceA, "only-a.txt"), "a");
+    writeFileSync(join(workspaceB, "only-b.txt"), "b");
+    const originalCwd = process.cwd();
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const stderr = createWritableCapture();
+    const lines = createOutputLines(output);
+    let result: Promise<number> | undefined;
+    try {
+      process.chdir(workspaceA);
+      result = runAgenCMcpCli(
+        {
+          kind: "serve",
+          transport: "stdio",
+          host: "127.0.0.1",
+          port: 3334,
+        },
+        { io: createIo(input, output, stderr) },
+      );
+      process.chdir(workspaceB);
+
+      input.write(`${JSON.stringify(request(1, "initialize"))}\n`);
+      await lines.nextLine();
+      input.write(
+        `${JSON.stringify(
+          request(2, "tools/call", {
+            name: "system.listDir",
+            arguments: { path: workspaceA },
+          }),
+        )}\n`,
+      );
+      expect(await lines.nextLine()).toContain("only-a.txt");
+      input.write(
+        `${JSON.stringify(
+          request(3, "tools/call", {
+            name: "system.listDir",
+            arguments: { path: workspaceB },
+          }),
+        )}\n`,
+      );
+      expect(await lines.nextLine()).toContain(
+        "Path is outside allowed directories",
+      );
+      input.end();
+      await expect(result).resolves.toBe(0);
+      expect(stderr.text()).toBe("");
+    } finally {
+      input.end();
+      await result?.catch(() => {});
+      lines.close();
+      process.chdir(originalCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("starts an MCP streamable HTTP server for SSE transport", async () => {
@@ -512,6 +635,36 @@ describe("AgenC MCP CLI", () => {
         result: {
           content: [{ type: "text", text: "echo:hello" }],
           structuredContent: { tool: "sample.echo" },
+        },
+      });
+
+      const deniedResponse = await fetch(started.url, {
+        method: "POST",
+        headers: streamablePostHeaders(sessionId ?? undefined),
+        body: JSON.stringify(
+          request(3, "tools/call", {
+            name: MUTATING_TOOL.name,
+            arguments: {},
+          }),
+        ),
+      });
+      expect(deniedResponse.status).toBe(200);
+      const deniedMessage = JSON.parse(
+        parseSseData(await deniedResponse.text()),
+      );
+      expect(deniedMessage).toEqual({
+        jsonrpc: "2.0",
+        id: 3,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: expect.stringContaining(
+                "Environment overrides are not authorization",
+              ),
+            },
+          ],
+          isError: true,
         },
       });
     } finally {

--- a/runtime/tests/config/config.test.ts
+++ b/runtime/tests/config/config.test.ts
@@ -1118,12 +1118,14 @@ describe("schema: closed config block validators (CF-13)", () => {
         transport: "sse",
         host: "127.0.0.1",
         port: 8900,
+        workspace: process.cwd(),
       }),
     ).toEqual({
       enabled: true,
       transport: "sse",
       host: "127.0.0.1",
       port: 8900,
+      workspace: process.cwd(),
     });
     expect(
       validateMcpServerModeConfig({
@@ -1151,6 +1153,12 @@ describe("schema: closed config block validators (CF-13)", () => {
     );
     expect(() =>
       validateMcpServerModeConfig({ transport: "sse", port: 70_000 }),
+    ).toThrow(InvalidMcpServerModeConfigError);
+    expect(() =>
+      validateMcpServerModeConfig({
+        transport: "sse",
+        workspace: "relative/workspace",
+      }),
     ).toThrow(InvalidMcpServerModeConfigError);
   });
 
@@ -1726,6 +1734,7 @@ enabled = true
 transport = "sse"
 host = "localhost"
 port = 4444
+workspace = ${JSON.stringify(dir)}
       `,
     );
     const out = await loadConfig({ home: dir });
@@ -1735,6 +1744,7 @@ port = 4444
       transport: "sse",
       host: "localhost",
       port: 4444,
+      workspace: dir,
     });
     expect(out.config._unknown?.mcp).toBeUndefined();
   });

--- a/runtime/tests/mcp-server/prompts-resources.test.ts
+++ b/runtime/tests/mcp-server/prompts-resources.test.ts
@@ -132,7 +132,9 @@ describe("MCP prompts backed by skills", () => {
 });
 
 describe("MCP resources backed by memory + instruction files", () => {
-  async function makeResourceServer(): Promise<{
+  async function makeResourceServer(
+    readResourceContent?: (canonicalPath: string) => Promise<string>,
+  ): Promise<{
     server: McpServerFramework;
     memoryDir: string;
   }> {
@@ -162,6 +164,7 @@ describe("MCP resources backed by memory + instruction files", () => {
       resourceProvider: createMemoryResourceProvider({
         memoryDirs: [memoryDir, sessionDir],
         instructionFiles: [join(root, "AGENC.md")],
+        readResourceContent,
       }),
     });
     return { server, memoryDir };
@@ -185,6 +188,23 @@ describe("MCP resources backed by memory + instruction files", () => {
     expect(names).toContain("MEMORY.md");
     expect(names).toContain("AGENC.md");
     expect(names).not.toContain("leak.md");
+  });
+
+  it("does not read resource bodies while listing", async () => {
+    const readResourceContent = vi.fn(async () => "selected body");
+    const { server } = await makeResourceServer(readResourceContent);
+    await initialized(server);
+
+    const list = await request(server, "resources/list");
+    expect(list.result.resources.length).toBeGreaterThan(0);
+    expect(readResourceContent).not.toHaveBeenCalled();
+
+    const note = list.result.resources.find(
+      (resource: any) => resource.name === "deploy-notes.md",
+    );
+    const read = await request(server, "resources/read", { uri: note.uri });
+    expect(read.result.contents[0].text).toBe("selected body");
+    expect(readResourceContent).toHaveBeenCalledOnce();
   });
 
   it("reads a memory file with secrets redacted", async () => {

--- a/runtime/tests/mcp-server/tools.test.ts
+++ b/runtime/tests/mcp-server/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import type { LLMToolCall } from "../llm/types.js";
 import type { ToolDispatchResult, ToolRegistry } from "../tool-registry.js";
@@ -11,6 +11,9 @@ const SAMPLE_TOOL: Tool = {
   name: "sample.echo",
   description: "Echo text back to the caller.",
   isReadOnly: true,
+  metadata: { mutating: false },
+  requiresApproval: false,
+  recoveryCategory: "idempotent",
   inputSchema: {
     type: "object",
     properties: { text: { type: "string" } },
@@ -18,6 +21,59 @@ const SAMPLE_TOOL: Tool = {
   },
   async execute(args) {
     return { content: String(args.text ?? "") };
+  },
+};
+
+const MUTATING_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.write",
+  description: "Mutates state.",
+  isReadOnly: false,
+  metadata: { mutating: true },
+  recoveryCategory: "side-effecting",
+};
+
+const CONTRADICTORY_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.contradictory",
+  description: "Claims read-only while declaring a mutation.",
+  metadata: { mutating: true },
+};
+
+const NON_IDEMPOTENT_READ_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.non-idempotent-read",
+  description: "Claims read-only without replay-safe semantics.",
+  recoveryCategory: "side-effecting",
+};
+
+const UNCLASSIFIED_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.unclassified",
+  description: "Omits explicit mutation metadata.",
+  metadata: undefined,
+};
+
+const APPROVAL_GATED_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.approval-gated",
+  description: "Requires approval despite otherwise read-only metadata.",
+  requiresApproval: true,
+};
+
+const INTERACTION_HOOK_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.interaction-hook",
+  description: "Defines an interaction policy hook.",
+  requiresUserInteraction: () => false,
+};
+
+const PERMISSION_HOOK_TOOL: Tool = {
+  ...SAMPLE_TOOL,
+  name: "sample.permission-hook",
+  description: "Defines a permission policy hook.",
+  checkPermissions(input) {
+    return { behavior: "allow", updatedInput: input };
   },
 };
 
@@ -82,16 +138,22 @@ describe("MCP server tool registration", () => {
     ]);
   });
 
-  test("framework tools/call dispatches through the AgenC tool registry", async () => {
-    const calls: LLMToolCall[] = [];
-    const registry: Pick<ToolRegistry, "tools" | "dispatch"> = {
-      tools: [SAMPLE_TOOL],
-      async dispatch(toolCall): Promise<ToolDispatchResult> {
-        calls.push(toolCall);
+  test("framework tools/call executes the audited tool instance", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const safeTool: Tool = {
+      ...SAMPLE_TOOL,
+      async execute(args) {
+        calls.push(args);
         return {
-          content: `echo:${JSON.parse(toolCall.arguments).text}`,
+          content: `echo:${String(args.text ?? "")}`,
           codeModeResult: { echoed: true },
         };
+      },
+    };
+    const registry: Pick<ToolRegistry, "tools" | "dispatch"> = {
+      tools: [safeTool],
+      async dispatch(toolCall): Promise<ToolDispatchResult> {
+        return { content: `wrong:${toolCall.name}`, isError: true };
       },
     };
     const server = new McpServerFramework({
@@ -116,13 +178,131 @@ describe("MCP server tool registration", () => {
         },
       },
     ]);
-    expect(calls).toEqual([
-      {
-        id: "2",
-        name: "sample.echo",
-        arguments: JSON.stringify({ text: "hello" }),
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ text: "hello" });
+    expect(Object.getOwnPropertyDescriptor(calls[0], "__callId")).toMatchObject({
+      value: "2",
+      enumerable: false,
+    });
+  });
+
+  test.each(["1", "true"])(
+    "never treats AGENC_MCP_ALLOW_MUTATIONS=%s as inbound authorization",
+    async (legacyOverride) => {
+      const originalOverride = process.env.AGENC_MCP_ALLOW_MUTATIONS;
+      process.env.AGENC_MCP_ALLOW_MUTATIONS = legacyOverride;
+      const calls: LLMToolCall[] = [];
+      try {
+        const registry: Pick<ToolRegistry, "tools" | "dispatch"> = {
+          tools: [
+            SAMPLE_TOOL,
+            MUTATING_TOOL,
+            CONTRADICTORY_TOOL,
+            NON_IDEMPOTENT_READ_TOOL,
+            UNCLASSIFIED_TOOL,
+            APPROVAL_GATED_TOOL,
+            INTERACTION_HOOK_TOOL,
+            PERMISSION_HOOK_TOOL,
+          ],
+          async dispatch(toolCall): Promise<ToolDispatchResult> {
+            calls.push(toolCall);
+            return { content: "unexpected dispatch" };
+          },
+        };
+        const server = new McpServerFramework({
+          toolProvider: mcpToolRegistryFromAgenCTools(registry),
+        });
+        server.handleMessage(request(1, "initialize"));
+
+        expect(server.handleMessage(request(2, "tools/list"))).toEqual([
+          {
+            jsonrpc: "2.0",
+            id: 2,
+            result: {
+              tools: [mcpDefinitionFromAgenCTool(SAMPLE_TOOL)],
+              nextCursor: null,
+            },
+          },
+        ]);
+
+        for (const [index, tool] of [
+          MUTATING_TOOL,
+          CONTRADICTORY_TOOL,
+          NON_IDEMPOTENT_READ_TOOL,
+          UNCLASSIFIED_TOOL,
+          APPROVAL_GATED_TOOL,
+          INTERACTION_HOOK_TOOL,
+          PERMISSION_HOOK_TOOL,
+        ].entries()) {
+          await expect(
+            server.handleMessageAsync(
+              request(10 + index, "tools/call", {
+                name: tool.name,
+                arguments: {},
+              }),
+            ),
+          ).resolves.toEqual([
+            {
+              jsonrpc: "2.0",
+              id: 10 + index,
+              result: {
+                content: [
+                  {
+                    type: "text",
+                    text: expect.stringContaining(
+                      "Environment overrides are not authorization",
+                    ),
+                  },
+                ],
+                isError: true,
+              },
+            },
+          ]);
+        }
+        expect(calls).toEqual([]);
+      } finally {
+        if (originalOverride === undefined) {
+          delete process.env.AGENC_MCP_ALLOW_MUTATIONS;
+        } else {
+          process.env.AGENC_MCP_ALLOW_MUTATIONS = originalOverride;
+        }
+      }
+    },
+  );
+
+  test("binds calls to the audited tool instance instead of a registry alias or rebound name", async () => {
+    const auditedCalls: Array<Record<string, unknown>> = [];
+    const registryDispatch = vi.fn(async (): Promise<ToolDispatchResult> => ({
+      content: "mutating alias target executed",
+    }));
+    const auditedTool: Tool = {
+      ...SAMPLE_TOOL,
+      name: "FileWrite",
+      async execute(args) {
+        auditedCalls.push(args);
+        return { content: "audited instance executed" };
       },
-    ]);
+    };
+    let currentTools: readonly Tool[] = [auditedTool];
+    const registry: Pick<ToolRegistry, "tools" | "dispatch"> = {
+      get tools() {
+        return currentTools;
+      },
+      dispatch: registryDispatch,
+    };
+    const provider = mcpToolRegistryFromAgenCTools(registry);
+    currentTools = [MUTATING_TOOL];
+
+    await expect(
+      provider.callTool(
+        { name: "FileWrite", arguments: { path: "sentinel" } },
+        { requestId: "bound-call" },
+      ),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "audited instance executed" }],
+    });
+    expect(auditedCalls).toHaveLength(1);
+    expect(registryDispatch).not.toHaveBeenCalled();
   });
 
   test("tools/call validates params and returns unknown-tool results", async () => {

--- a/runtime/tests/mcp/server/start.test.ts
+++ b/runtime/tests/mcp/server/start.test.ts
@@ -1,9 +1,14 @@
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import type { ToolRegistry } from "../../tool-registry.js";
 import {
   formatMcpSseServeUrl,
+  prepareMcpSseServerReconfigurationFromConfig,
   resolveMcpServeDefaults,
   startMcpServerFromConfig,
+  startMcpSseServe,
 } from "./start.js";
 
 const EMPTY_REGISTRY: ToolRegistry = {
@@ -13,6 +18,92 @@ const EMPTY_REGISTRY: ToolRegistry = {
     return { content: "" };
   },
 };
+
+function mcpHeaders(sessionId?: string): Record<string, string> {
+  return {
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+    ...(sessionId === undefined ? {} : { "mcp-session-id": sessionId }),
+  };
+}
+
+function mcpRequest(id: number, method: string, params?: unknown): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method,
+    ...(params === undefined ? {} : { params }),
+  });
+}
+
+async function initializeMcp(url: string): Promise<string> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: mcpHeaders(),
+    body: mcpRequest(1, "initialize"),
+  });
+  expect(response.status).toBe(200);
+  await response.json();
+  const sessionId = response.headers.get("mcp-session-id");
+  if (sessionId === null) throw new Error("missing MCP session id");
+  return sessionId;
+}
+
+function parseMcpSseData(frame: string): unknown {
+  const data = frame
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart())
+    .join("\n");
+  return JSON.parse(data);
+}
+
+async function callListDir(
+  url: string,
+  sessionId: string,
+  path: string,
+  id: number,
+): Promise<{ readonly status: number; readonly message?: unknown }> {
+  return callMcpTool(url, sessionId, "system.listDir", { path }, id);
+}
+
+async function callMcpTool(
+  url: string,
+  sessionId: string,
+  name: string,
+  args: Readonly<Record<string, unknown>>,
+  id: number,
+): Promise<{ readonly status: number; readonly message?: unknown }> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: mcpHeaders(sessionId),
+    body: mcpRequest(id, "tools/call", {
+      name,
+      arguments: args,
+    }),
+  });
+  if (response.status !== 200) return { status: response.status };
+  return {
+    status: response.status,
+    message: parseMcpSseData(await response.text()),
+  };
+}
+
+async function postMcpJson(
+  url: string,
+  sessionId: string,
+  id: number,
+  method: string,
+  params?: unknown,
+): Promise<any> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: mcpHeaders(sessionId),
+    body: mcpRequest(id, method, params),
+  });
+  expect(response.status).toBe(200);
+  return response.json();
+}
 
 describe("mcp server start config", () => {
   test("resolves disabled stdio defaults and safe malformed fallbacks", () => {
@@ -53,6 +144,29 @@ describe("mcp server start config", () => {
       kind: "unsupported",
       defaults: { enabled: true, transport: "stdio" },
     });
+    await expect(
+      startMcpServerFromConfig({
+        mcp: { server: { enabled: true, transport: "sse", port: 0 } },
+      }),
+    ).resolves.toMatchObject({
+      kind: "unsupported",
+      defaults: { enabled: true, transport: "sse" },
+      reason: expect.stringContaining("mcp.server.workspace"),
+    });
+    await expect(
+      startMcpServerFromConfig({
+        mcp: {
+          server: {
+            enabled: true,
+            transport: "sse",
+            port: 0,
+            workspace: ".",
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      "mcp.server.workspace must be an absolute filesystem path",
+    );
   });
 
   test("starts enabled SSE mode on a real loopback HTTP server", async () => {
@@ -64,6 +178,7 @@ describe("mcp server start config", () => {
             transport: "sse",
             host: "127.0.0.1",
             port: 0,
+            workspace: process.cwd(),
           },
         },
       },
@@ -81,6 +196,292 @@ describe("mcp server start config", () => {
       expect(response.status).toBe(400);
     } finally {
       await result.server.close();
+    }
+  });
+
+  test("atomically replaces workspace context, revokes old sessions, and preserves the old context on prepare failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agenc-mcp-workspaces-"));
+    const workspaceA = join(root, "workspace-a");
+    const workspaceB = join(root, "workspace-b");
+    const invalidWorkspace = join(root, "not-a-directory");
+    const globalHome = join(root, "global-home");
+    await Promise.all([
+      mkdir(join(workspaceA, ".agenc", "skills", "workspace-only"), {
+        recursive: true,
+      }),
+      mkdir(join(workspaceA, ".agenc", "memory"), { recursive: true }),
+      mkdir(workspaceB),
+      mkdir(join(globalHome, "skills", "global-only"), { recursive: true }),
+      mkdir(join(globalHome, "commands"), { recursive: true }),
+      mkdir(join(globalHome, "memory"), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(workspaceA, "only-a.txt"), "a"),
+      writeFile(join(workspaceB, "only-b.txt"), "b"),
+      writeFile(invalidWorkspace, "file"),
+      writeFile(
+        join(workspaceA, ".agenc", "skills", "workspace-only", "SKILL.md"),
+        "---\ndescription: Workspace-only prompt\n---\nWorkspace prompt sentinel",
+      ),
+      writeFile(
+        join(globalHome, "skills", "global-only", "SKILL.md"),
+        "---\ndescription: Global prompt\n---\nGlobal prompt sentinel",
+      ),
+      writeFile(
+        join(globalHome, "commands", "outside-command.md"),
+        "---\ndescription: Outside command\n---\nOutside command sentinel",
+      ),
+      writeFile(
+        join(workspaceA, ".agenc", "memory", "workspace-note.md"),
+        "Workspace memory sentinel",
+      ),
+      writeFile(
+        join(globalHome, "memory", "global-note.md"),
+        "Global memory sentinel",
+      ),
+      writeFile(join(globalHome, "AGENC.md"), "Global instruction sentinel"),
+    ]);
+    await Promise.all([
+      symlink(
+        join(globalHome, "skills", "global-only", "SKILL.md"),
+        join(workspaceA, ".agenc", "skills", "leak-prompt.md"),
+      ),
+      symlink(
+        join(globalHome, "commands"),
+        join(workspaceA, ".agenc", "commands"),
+        "dir",
+      ),
+      symlink(
+        join(globalHome, "memory", "global-note.md"),
+        join(workspaceA, ".agenc", "memory", "leak-memory.md"),
+      ),
+      symlink(join(globalHome, "AGENC.md"), join(workspaceA, "AGENC.md")),
+    ]);
+
+    const configFor = (workspace: string) => ({
+      mcp: {
+        server: {
+          enabled: true as const,
+          transport: "sse" as const,
+          host: "127.0.0.1",
+          port: 0,
+          workspace,
+        },
+      },
+    });
+    const originalAgencHome = process.env.AGENC_HOME;
+    process.env.AGENC_HOME = globalHome;
+    const result = await startMcpServerFromConfig(configFor(workspaceA));
+    if (result.kind !== "started") {
+      throw new Error(`expected started result, got ${result.kind}`);
+    }
+
+    try {
+      const oldSession = await initializeMcp(result.server.url);
+      const promptList = await postMcpJson(
+        result.server.url,
+        oldSession,
+        2,
+        "prompts/list",
+      );
+      expect(JSON.stringify(promptList)).toContain("workspace-only");
+      expect(JSON.stringify(promptList)).not.toContain("global-only");
+      expect(JSON.stringify(promptList)).not.toContain("leak-prompt");
+      expect(JSON.stringify(promptList)).not.toContain("outside-command");
+      const promptGet = await postMcpJson(
+        result.server.url,
+        oldSession,
+        3,
+        "prompts/get",
+        { name: "workspace-only" },
+      );
+      expect(JSON.stringify(promptGet)).toContain("Workspace prompt sentinel");
+      expect(JSON.stringify(promptGet)).not.toContain("Global prompt sentinel");
+
+      const resourceList = await postMcpJson(
+        result.server.url,
+        oldSession,
+        4,
+        "resources/list",
+      );
+      const serializedResources = JSON.stringify(resourceList);
+      expect(serializedResources).toContain("workspace-note.md");
+      expect(serializedResources).not.toContain("global-note.md");
+      expect(serializedResources).not.toContain("leak-memory.md");
+      expect(serializedResources).not.toContain("AGENC.md");
+      const workspaceNote = resourceList.result.resources.find(
+        (resource: { readonly name: string }) =>
+          resource.name === "workspace-note.md",
+      );
+      const resourceRead = await postMcpJson(
+        result.server.url,
+        oldSession,
+        5,
+        "resources/read",
+        { uri: workspaceNote.uri },
+      );
+      expect(JSON.stringify(resourceRead)).toContain("Workspace memory sentinel");
+      expect(JSON.stringify(resourceRead)).not.toContain("Global memory sentinel");
+
+      const listResponse = await fetch(result.server.url, {
+        method: "POST",
+        headers: mcpHeaders(oldSession),
+        body: mcpRequest(6, "tools/list"),
+      });
+      const advertised = JSON.stringify(await listResponse.json());
+      expect(advertised).not.toContain("system.symbolSearch");
+      expect(advertised).not.toContain("system.gitStatus");
+      const symbolCall = await callMcpTool(
+        result.server.url,
+        oldSession,
+        "system.symbolSearch",
+        { query: "anything", workspace_root: workspaceA },
+        7,
+      );
+      expect(JSON.stringify(symbolCall.message)).toContain(
+        "Unknown tool 'system.symbolSearch'",
+      );
+      await expect(stat(join(workspaceA, "code-intel"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      const firstRead = await callListDir(
+        result.server.url,
+        oldSession,
+        workspaceA,
+        8,
+      );
+      expect(JSON.stringify(firstRead.message)).toContain("only-a.txt");
+
+      await expect(
+        prepareMcpSseServerReconfigurationFromConfig(
+          result.server,
+          configFor(invalidWorkspace),
+        ),
+      ).rejects.toThrow("must resolve to a directory");
+      const afterRejectedPrepare = await callListDir(
+        result.server.url,
+        oldSession,
+        workspaceA,
+        9,
+      );
+      expect(afterRejectedPrepare.status).toBe(200);
+      expect(JSON.stringify(afterRejectedPrepare.message)).toContain(
+        "only-a.txt",
+      );
+
+      const prepared = await prepareMcpSseServerReconfigurationFromConfig(
+        result.server,
+        configFor(workspaceB),
+      );
+      expect(prepared.apply()).toBe(1);
+      expect(
+        await callListDir(result.server.url, oldSession, workspaceA, 4),
+      ).toEqual({ status: 404 });
+
+      const newSession = await initializeMcp(result.server.url);
+      const secondRead = await callListDir(
+        result.server.url,
+        newSession,
+        workspaceB,
+        7,
+      );
+      expect(JSON.stringify(secondRead.message)).toContain("only-b.txt");
+      expect(JSON.stringify(secondRead.message)).not.toContain("only-a.txt");
+
+      const ambientRead = await callListDir(
+        result.server.url,
+        newSession,
+        process.cwd(),
+        8,
+      );
+      expect(JSON.stringify(ambientRead.message)).toContain(
+        "Path is outside allowed directories",
+      );
+    } finally {
+      await result.server.close();
+      if (originalAgencHome === undefined) {
+        delete process.env.AGENC_HOME;
+      } else {
+        process.env.AGENC_HOME = originalAgencHome;
+      }
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("pins foreground SSE workspace before later session creation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agenc-mcp-pinned-sse-"));
+    const workspaceA = join(root, "workspace-a");
+    const workspaceB = join(root, "workspace-b");
+    await Promise.all([
+      mkdir(join(workspaceA, ".agenc", "skills", "a-only"), {
+        recursive: true,
+      }),
+      mkdir(join(workspaceB, ".agenc", "skills", "b-only"), {
+        recursive: true,
+      }),
+    ]);
+    await Promise.all([
+      writeFile(join(workspaceA, "only-a.txt"), "a"),
+      writeFile(join(workspaceB, "only-b.txt"), "b"),
+      writeFile(
+        join(workspaceA, ".agenc", "skills", "a-only", "SKILL.md"),
+        "---\ndescription: A-only prompt\n---\nPrompt from workspace A",
+      ),
+      writeFile(
+        join(workspaceB, ".agenc", "skills", "b-only", "SKILL.md"),
+        "---\ndescription: B-only prompt\n---\nPrompt from workspace B",
+      ),
+    ]);
+    const originalCwd = process.cwd();
+    let started: Awaited<ReturnType<typeof startMcpSseServe>> | undefined;
+    try {
+      process.chdir(workspaceA);
+      const starting = startMcpSseServe({
+        transport: "sse",
+        host: "127.0.0.1",
+        port: 0,
+      });
+      process.chdir(workspaceB);
+      started = await starting;
+
+      const session = await initializeMcp(started.url);
+      const prompts = await postMcpJson(
+        started.url,
+        session,
+        2,
+        "prompts/list",
+      );
+      expect(JSON.stringify(prompts)).toContain("a-only");
+      expect(JSON.stringify(prompts)).not.toContain("b-only");
+      const prompt = await postMcpJson(
+        started.url,
+        session,
+        3,
+        "prompts/get",
+        { name: "a-only" },
+      );
+      expect(JSON.stringify(prompt)).toContain("Prompt from workspace A");
+      expect(JSON.stringify(prompt)).not.toContain("Prompt from workspace B");
+      const workspaceARead = await callListDir(
+        started.url,
+        session,
+        workspaceA,
+        4,
+      );
+      expect(JSON.stringify(workspaceARead.message)).toContain("only-a.txt");
+      const workspaceBRead = await callListDir(
+        started.url,
+        session,
+        workspaceB,
+        5,
+      );
+      expect(JSON.stringify(workspaceBRead.message)).toContain(
+        "Path is outside allowed directories",
+      );
+    } finally {
+      process.chdir(originalCwd);
+      await started?.close();
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/todo.txt
+++ b/todo.txt
@@ -327,7 +327,7 @@ boundary. They are higher leverage than new surface area.
       precise doctor/startup diagnostic; it must never become a warning-only
       host execution.
 
-[ ] Fail-close inbound MCP mutations immediately.
+[x] Fail-close inbound MCP mutations immediately.
     - Read-only operations may remain available under explicit workspace scope.
     - Disable mutations unless they already traverse the native daemon permission
       and sandbox boundary.


### PR DESCRIPTION
## Summary

- admit only explicitly read-only, non-mutating, idempotent inbound MCP tools with no permission or interaction hooks, bound to the exact audited tool instance
- require and canonicalize daemon MCP workspaces; scope tools, prompts, and resources to that workspace and reject symlink escapes
- reload fixed-port SSE workspace contexts transactionally and revoke sessions admitted under the prior context
- keep resource listing metadata-only and revalidate/read only the selected resource
- document the unauthenticated loopback threat model and mark the M2 TODO complete

## Local verification

- npm test: 1,777 runtime test files; 15,255 passed, 16 skipped; launcher and contract gates green
- focused MCP/config/daemon suite: 265 passed
- TypeScript: 0 errors
- pre-commit build and PTY startup smoke: green at 148x40, 120x30, and 80x24, including --yolo
- two independent reviews: merge-ready; no remaining security or correctness blockers
- no hosted test workflow was triggered

## Security research

Reviewed 2026-07-16 against the current MCP specification and guidance:

- https://modelcontextprotocol.io/specification/2025-11-25
- https://modelcontextprotocol.io/specification/2025-11-25/server/tools
- https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices

## Compatibility and rollback

Daemon-autostarted SSE now requires an explicit absolute mcp.server.workspace. User-global prompts/resources are intentionally no longer exposed by inbound serve. Foreground serve pins the canonical startup working directory. Rollback is the single squash commit.