### PR TITLE
fix(runtime): make prompt retries idempotent

### DIFF
--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -33,11 +33,13 @@
 import type {
   LLMChatOptions,
   LLMMessage,
+  LLMProvider,
   LLMResponse,
   LLMStreamChunk,
   LLMTool,
   LLMToolCall,
 } from "../llm/types.js";
+import { cloneLlmMessageSnapshot } from "../llm/content-conversion.js";
 import {
   installStreamWatchdog,
   STREAM_IDLE_ABORT_REASON,
@@ -138,7 +140,17 @@ function toVisibleAssistantText(
 function buildProviderMessages(
   request: StreamModelRequestContract,
 ): LLMMessage[] {
-  return [...request.input];
+  return request.input.map(cloneLlmMessageSnapshot);
+}
+
+function cloneProviderTools(tools: ReadonlyArray<LLMTool>): LLMTool[] {
+  return tools.map((tool) => ({
+    ...tool,
+    function: {
+      ...tool.function,
+      parameters: structuredClone(tool.function.parameters),
+    },
+  }));
 }
 
 function buildProviderOptions(
@@ -151,7 +163,7 @@ function buildProviderOptions(
   const systemPrompt = request.baseInstructions.trim();
   return {
     signal,
-    tools: request.tools,
+    tools: cloneProviderTools(request.tools),
     parallelToolCalls: request.parallelToolCalls,
     ...(systemPrompt.length > 0 ? { systemPrompt } : {}),
     ...(request.contextWindowTokens !== undefined
@@ -782,7 +794,6 @@ export async function streamModel(
   }
 
   const planMode = isPlanMode(ctx);
-  const messages = buildProviderMessages(request);
 
   // Scoped AbortController: aborted by either the external signal or
   // the watchdog, whichever fires first.
@@ -916,7 +927,14 @@ export async function streamModel(
   };
 
   let response: LLMResponse;
-  const providerOptions = buildProviderOptions(request, ctx, scoped.signal);
+  const callProvider = (
+    provider: Pick<LLMProvider, "chatStream">,
+  ): Promise<LLMResponse> =>
+    provider.chatStream(
+      buildProviderMessages(request),
+      onChunk,
+      buildProviderOptions(request, ctx, scoped.signal),
+    );
   const startupPrewarmHandle =
     await session.services.startupPrewarm?.consumeProviderHandle({
       signal: scoped.signal,
@@ -925,16 +943,8 @@ export async function streamModel(
   try {
     response =
       startupPrewarmHandle !== undefined
-        ? await startupPrewarmHandle.chatStream(
-            messages,
-            onChunk,
-            providerOptions,
-          )
-        : await session.services.provider.chatStream(
-            messages,
-            onChunk,
-            providerOptions,
-          );
+        ? await callProvider(startupPrewarmHandle)
+        : await callProvider(session.services.provider);
   } catch (error) {
     if (
       startupPrewarmHandle !== undefined &&
@@ -948,11 +958,7 @@ export async function streamModel(
         /* disposal is best-effort before direct provider fallback */
       }
       try {
-        response = await session.services.provider.chatStream(
-          messages,
-          onChunk,
-          providerOptions,
-        );
+        response = await callProvider(session.services.provider);
       } catch (fallbackError) {
         throw new StreamModelError(fallbackError);
       }

--- a/runtime/src/prompts/attachments/orchestrator.ts
+++ b/runtime/src/prompts/attachments/orchestrator.ts
@@ -8,7 +8,7 @@
  * are pure functions of `(opts, trackingState)` and are responsible for
  * their own gating (turn-counting, hash diffing, mode checks).
  *
- * Call site: `runtime/src/session/run-turn.ts:tryRunSamplingRequest`
+ * Call site: `runtime/src/session/run-turn.ts:prepareSamplingRequestBoundary`
  * between `prepareContext()` and `buildSamplingRequestContract()`. The
  * orchestrator's `Attachment[]` output is converted to `LLMMessage[]` via
  * `./messages.ts:attachmentsToMessages` and inserted after the leading

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -61,6 +61,7 @@ import type {
 } from "../llm/types.js";
 import {
   cloneLlmContent as cloneContent,
+  cloneLlmMessageSnapshot,
   fromRuntimeMessageContent,
   toRuntimeMessageContent,
 } from "../llm/content-conversion.js";
@@ -2490,6 +2491,31 @@ function buildSamplingRequestContract(
   };
 }
 
+/**
+ * Capture the complete provider-facing request before the first transport
+ * attempt. Reconnects reuse this semantic snapshot instead of re-running
+ * context preparation and stateful attachment producers, which can change
+ * while a request is in flight.
+ *
+ * `streamModel` gives each transport attempt its own clone, so neither a
+ * provider adapter nor a failed prewarm handle can mutate this saved copy.
+ */
+function snapshotSamplingRequestContract(
+  request: StreamModelRequestContract,
+): StreamModelRequestContract {
+  return {
+    ...request,
+    input: request.input.map(cloneLlmMessageSnapshot),
+    tools: request.tools.map((tool) => ({
+      ...tool,
+      function: {
+        ...tool.function,
+        parameters: structuredClone(tool.function.parameters),
+      },
+    })),
+  };
+}
+
 function removeLastAssistantMessage(state: TurnState): void {
   const last = state.messages.at(-1);
   if (last?.role === "assistant") {
@@ -2546,32 +2572,24 @@ export interface SamplingRequestResult {
   readonly terminal?: Terminal;
 }
 
-/**
- * Port of agenc runtime `try_run_sampling_request` (turn.rs:1828-2222). In
- * agenc runtime this is the single-attempt stream consumer: it builds the
- * request, streams events, dispatches tool calls via the
- * ToolCallRuntime, and returns a SamplingRequestResult when the
- * stream completes or an Err on retryable failure.
- *
- * AgenC's translation runs ONE phase-machine iteration. The phase
- * machine handles the stream (stream-model phase), tool dispatch
- * (execute-tools phase), nudging (continuation-nudge phase), and
- * history commit (commit phase). The resulting TurnState tells us
- * whether a follow-up iteration is needed.
- *
- * On retry-worthy errors (stream idle, transient provider error),
- * throw so `runSamplingRequest` can apply the retry policy. Fatal
- * errors throw too; the caller routes them as terminal.
- */
-async function tryRunSamplingRequest(
+type PreparedSamplingRequestBoundary =
+  | {
+      readonly kind: "request";
+      readonly request: StreamModelRequestContract;
+    }
+  | {
+      readonly kind: "terminal";
+      readonly result: SamplingRequestResult;
+    };
+
+async function prepareSamplingRequestBoundary(
   state: TurnState,
   ctx: TurnContext,
   session: Session,
   signal: AbortSignal,
   events: PhaseEvent[],
   querySource: string,
-): Promise<SamplingRequestResult> {
-  // Phase 1: prepare context.
+): Promise<PreparedSamplingRequestBoundary> {
   await prepareAgenCTurnContext(state, ctx, session, querySource, signal);
   const prepareTerminal = getAgenCPreparedTerminal(state);
   if (prepareTerminal) {
@@ -2592,27 +2610,24 @@ async function tryRunSamplingRequest(
       });
     }
     return {
-      needsFollowUp: false,
-      lastAgentMessage: assistantText,
-      assistantText,
-      usage: {
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
+      kind: "terminal",
+      result: {
+        needsFollowUp: false,
+        lastAgentMessage: assistantText,
+        assistantText,
+        usage: {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+        },
+        terminal: prepareTerminal.terminal,
       },
-      terminal: prepareTerminal.terminal,
     };
   }
-  // Per-turn attachments orchestrator (agenc `getAttachments()`
-  // parity, ported into AgenC). Runs after `prepareContext` projects
-  // the post-compaction history onto `state.messagesForQuery` and
-  // before `buildSamplingRequestContract` snapshots it for the model
-  // request. Each registered producer reads cross-turn state via
-  // `attachment-state.ts` and emits zero or more attachments. The
-  // attachments are converted to user-channel `LLMMessage`s and
-  // prepended to `state.messagesForQuery` so they ride into the model
-  // request through the existing build path. Producer registry lives
-  // in `runtime/src/prompts/attachments/orchestrator.ts`.
+
+  // Per-turn attachments run once, immediately before the retry-stable
+  // request snapshot is captured. A reconnect must never consume one-shot
+  // attachment state or observe a different prompt than the first attempt.
   const agencHome = session.services.configStore?.agencHome;
   const currentConfig = session.services.configStore?.current();
   const fileMentionAllowedRoots = extractMentionAllowedRoots(currentConfig);
@@ -2653,8 +2668,39 @@ async function tryRunSamplingRequest(
     }
   }
 
-  const request = buildSamplingRequestContract(state, session, ctx);
+  return {
+    kind: "request",
+    request: snapshotSamplingRequestContract(
+      buildSamplingRequestContract(state, session, ctx),
+    ),
+  };
+}
 
+/**
+ * Port of agenc runtime `try_run_sampling_request` (turn.rs:1828-2222). In
+ * agenc runtime this is the single-attempt stream consumer: it streams the
+ * already-snapshotted request, dispatches tool calls via the
+ * ToolCallRuntime, and returns a SamplingRequestResult when the
+ * stream completes or an Err on retryable failure.
+ *
+ * AgenC's translation runs ONE phase-machine iteration. The phase
+ * machine handles the stream (stream-model phase), tool dispatch
+ * (execute-tools phase), nudging (continuation-nudge phase), and
+ * history commit (commit phase). The resulting TurnState tells us
+ * whether a follow-up iteration is needed.
+ *
+ * On retry-worthy errors (stream idle, transient provider error),
+ * throw so `runSamplingRequest` can apply the retry policy. Fatal
+ * errors throw too; the caller routes them as terminal.
+ */
+async function tryRunSamplingRequest(
+  state: TurnState,
+  ctx: TurnContext,
+  session: Session,
+  request: StreamModelRequestContract,
+  signal: AbortSignal,
+  events: PhaseEvent[],
+): Promise<SamplingRequestResult> {
   // Plan-mode stream state (T11). When the turn's collaboration mode is
   // `plan`, stash per-turn plan-mode bookkeeping on turn-state so the
   // post-stream finalize hook below (and future delta callbacks) share
@@ -2796,11 +2842,28 @@ async function runSamplingRequest(
   events: PhaseEvent[],
   querySource: string,
 ): Promise<SamplingRequestResult> {
+  const prepared = await prepareSamplingRequestBoundary(
+    state,
+    ctx,
+    session,
+    signal,
+    events,
+    querySource,
+  );
+  if (prepared.kind === "terminal") return prepared.result;
+
   const outcome = await reconnectWithBackoff<SamplingRequestResult>({
     session,
     signal,
     attempt: () =>
-      tryRunSamplingRequest(state, ctx, session, signal, events, querySource),
+      tryRunSamplingRequest(
+        state,
+        ctx,
+        session,
+        prepared.request,
+        signal,
+        events,
+      ),
     isTransient: (err) => {
       if (isPartialProviderResponseError(err)) return false;
       if (isRetryableStreamError(err)) return true;

--- a/runtime/tests/llm/client-session.test.ts
+++ b/runtime/tests/llm/client-session.test.ts
@@ -173,13 +173,29 @@ describe("ProviderHttpClientSession", () => {
     });
 
     const pending = session.requestJson<{ ok: boolean }>({
-      body: { ping: "pong" },
+      body: {
+        model: "test-model",
+        instructions: "REQUEST_RETRY_SYSTEM_SENTINEL",
+        input: [
+          {
+            role: "developer",
+            content: "REQUEST_RETRY_DEVELOPER_SENTINEL",
+          },
+          { role: "user", content: "hello" },
+        ],
+      },
     });
     await vi.runOnlyPendingTimersAsync();
     const response = await pending;
 
     expect(response.data.ok).toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const requestBodies = fetchImpl.mock.calls.map(([, init]) =>
+      String((init as RequestInit | undefined)?.body),
+    );
+    expect(requestBodies[1]).toBe(requestBodies[0]);
+    expect(requestBodies[0]?.match(/REQUEST_RETRY_SYSTEM_SENTINEL/g)).toHaveLength(1);
+    expect(requestBodies[0]?.match(/REQUEST_RETRY_DEVELOPER_SENTINEL/g)).toHaveLength(1);
   });
 
   test("retries TLS validation failures once with a fresh handshake even when transport retries are disabled", async () => {
@@ -821,7 +837,18 @@ describe("ProviderHttpClientSession", () => {
     });
 
     const stream = await session.requestStream({
-      body: { stream: true },
+      body: {
+        model: "test-model",
+        instructions: "STREAM_RETRY_SYSTEM_SENTINEL",
+        input: [
+          {
+            role: "developer",
+            content: "STREAM_RETRY_DEVELOPER_SENTINEL",
+          },
+          { role: "user", content: "hello" },
+        ],
+        stream: true,
+      },
     });
 
     const decoder = new TextDecoder();
@@ -832,6 +859,12 @@ describe("ProviderHttpClientSession", () => {
 
     expect(chunks).toEqual(["part-2"]);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const requestBodies = fetchImpl.mock.calls.map(([, init]) =>
+      String((init as RequestInit | undefined)?.body),
+    );
+    expect(requestBodies[1]).toBe(requestBodies[0]);
+    expect(requestBodies[0]?.match(/STREAM_RETRY_SYSTEM_SENTINEL/g)).toHaveLength(1);
+    expect(requestBodies[0]?.match(/STREAM_RETRY_DEVELOPER_SENTINEL/g)).toHaveLength(1);
   });
 
   test("requestStream does not splice a second body after partial yield (LLM-01)", async () => {

--- a/runtime/tests/phases/stream-model.test.ts
+++ b/runtime/tests/phases/stream-model.test.ts
@@ -320,6 +320,80 @@ describe("streamModel — live assistant text sanitization", () => {
     });
   });
 
+  test("prewarm fallback rebuilds the exact prompt payload from the request snapshot", async () => {
+    const ctx = mkCtx("chat");
+    const systemSentinel = "PREWARM_SYSTEM_SENTINEL_1b85";
+    const developerSentinel = "PREWARM_DEVELOPER_SENTINEL_9d33";
+    const payloads: Array<{
+      readonly messages: LLMMessage[];
+      readonly systemPrompt: string;
+    }> = [];
+    const capturePayload = (
+      messages: LLMMessage[],
+      options?: LLMChatOptions,
+    ): void => {
+      payloads.push({
+        messages: structuredClone(messages),
+        systemPrompt: options?.systemPrompt ?? "",
+      });
+    };
+    const provider = mkProvider(async (messages, _onChunk, options) => {
+      capturePayload(messages, options);
+      return {
+        content: "direct fallback",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "test-model",
+        finishReason: "stop",
+      };
+    });
+    const { session } = mkSession(provider);
+    session.services.startupPrewarm = {
+      setProviderHandle: () => {},
+      setProviderTask: () => {},
+      consumeProviderHandle: async () => ({
+        chatStream: async (messages, _onChunk, options) => {
+          capturePayload(messages, options);
+          messages.push({
+            role: "developer",
+            content: developerSentinel,
+          });
+          if (options) {
+            (options as { systemPrompt?: string }).systemPrompt =
+              `${options.systemPrompt ?? ""}\n${systemSentinel}`;
+          }
+          throw Object.assign(new Error("prewarmed socket closed"), {
+            code: "ECONNRESET",
+          });
+        },
+      }),
+      expireProviderHandle: async () => {},
+      clear: async () => {},
+    };
+    const request: StreamModelRequestContract = {
+      ...mkRequest([
+        { role: "developer", content: developerSentinel },
+        { role: "user", content: "hello" },
+      ]),
+      baseInstructions: systemSentinel,
+    };
+
+    await streamModel(mkState(ctx), ctx, session, request);
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1]).toEqual(payloads[0]);
+    for (const payload of payloads) {
+      expect(payload.systemPrompt.match(new RegExp(systemSentinel, "g"))).toHaveLength(1);
+      expect(payload.messages.filter((message) => message.role === "system")).toHaveLength(0);
+      const developerMessages = payload.messages.filter(
+        (message) => message.role === "developer",
+      );
+      expect(developerMessages).toEqual([
+        { role: "developer", content: developerSentinel },
+      ]);
+    }
+  });
+
   test("requires a tool choice in plan mode when tools are available", async () => {
     const ctx = mkCtx("plan");
     const state = mkState(ctx);

--- a/runtime/tests/session/plan-mode.test.ts
+++ b/runtime/tests/session/plan-mode.test.ts
@@ -548,6 +548,29 @@ describe("runSamplingRequest — reconnectWithBackoff wiring", () => {
     (session as unknown as { budgetTracker: null }).budgetTracker = null;
     (
       session as unknown as {
+        permissionModeRegistry: {
+          current: () => {
+            mode: "default";
+            additionalWorkingDirectories: ReadonlyMap<string, never>;
+            alwaysAllowRules: Record<string, never>;
+            alwaysDenyRules: Record<string, never>;
+            alwaysAskRules: Record<string, never>;
+            isBypassPermissionsModeAvailable: false;
+          };
+        };
+      }
+    ).permissionModeRegistry = {
+      current: () => ({
+        mode: "default",
+        additionalWorkingDirectories: new Map(),
+        alwaysAllowRules: {},
+        alwaysDenyRules: {},
+        alwaysAskRules: {},
+        isBypassPermissionsModeAvailable: false,
+      }),
+    };
+    (
+      session as unknown as {
         hasPendingInput: () => boolean;
       }
     ).hasPendingInput = () => false;

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -121,6 +121,7 @@ import {
   clearSessionReadState,
   getSessionReadSnapshot,
 } from "../tools/system/filesystem.js";
+import { getAttachmentTrackingState } from "./attachment-state.js";
 
 afterEach(() => {
   sessionMemoryPostSamplingMockState.calls.length = 0;
@@ -3332,6 +3333,102 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
         },
       }),
     );
+  });
+
+  test("reconnects reuse one prompt snapshot across every transport attempt", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const systemSentinel = "RETRY_SYSTEM_SENTINEL_2f91";
+    const developerSentinel = "RETRY_DEVELOPER_SENTINEL_7c40";
+    const payloads: Array<{
+      readonly messages: LLMMessage[];
+      readonly systemPrompt: string;
+    }> = [];
+    let attempts = 0;
+    let session!: Session;
+    const provider: LLMProvider = {
+      ...mkProvider({}),
+      chatStream: async (messages, _onChunk, options) => {
+        attempts += 1;
+        payloads.push({
+          messages: structuredClone(messages),
+          systemPrompt: options?.systemPrompt ?? "",
+        });
+        if (attempts < 3) {
+          // Model realistic state drift between attempts. Re-running the
+          // attachment producers would inject a date-change reminder into
+          // attempt 2/3; a provider normalizing its input in place must not
+          // mutate either the durable turn state or the retry snapshot.
+          getAttachmentTrackingState(session).lastEmittedDate = "1900-01-01";
+          const developerMessage = messages.find(
+            (message) => message.role === "developer",
+          );
+          if (developerMessage && typeof developerMessage.content === "string") {
+            developerMessage.content += "\nPROVIDER_LOCAL_MUTATION";
+          }
+          if (options) {
+            (options as { systemPrompt?: string }).systemPrompt =
+              `${options.systemPrompt ?? ""}\n${systemSentinel}`;
+          }
+          if (attempts === 1) {
+            throw Object.assign(new Error("socket hang up"), {
+              code: "ECONNRESET",
+            });
+          }
+          throw Object.assign(new Error("Service Unavailable"), {
+            statusCode: 503,
+          });
+        }
+        return {
+          content: "retry complete",
+          toolCalls: [],
+          usage: { promptTokens: 3, completionTokens: 2, totalTokens: 5 },
+          model: "test-model",
+          finishReason: "stop",
+        };
+      },
+    };
+    const built = mkSession({ provider, registry: mkRegistry() });
+    session = built.session;
+    const state = built.getState();
+    state.history = [
+      { role: "user", content: "before" },
+      { role: "assistant", content: "before answer" },
+    ];
+    state.referenceContextItem = {
+      model: "test-model",
+      realtimeActive: false,
+    };
+    const ctx = {
+      ...mkCtx(),
+      realtimeActive: true,
+      config: {
+        ...mkConfig(),
+        experimental_realtime_start_instructions: developerSentinel,
+      },
+    } as TurnContext;
+
+    await drain(
+      session.runTurn("voice transcript", {
+        ctx,
+        systemPrompt: systemSentinel,
+      }),
+    );
+
+    expect(payloads).toHaveLength(3);
+    expect(payloads[1]).toEqual(payloads[0]);
+    expect(payloads[2]).toEqual(payloads[0]);
+    for (const payload of payloads) {
+      expect(payload.messages.some((message) => message.role === "system")).toBe(false);
+      expect(payload.systemPrompt.match(new RegExp(systemSentinel, "g"))).toHaveLength(1);
+      const developerMessages = payload.messages.filter(
+        (message) => message.role === "developer",
+      );
+      expect(developerMessages).toHaveLength(1);
+      expect(testMessageText(developerMessages[0]!).match(
+        new RegExp(developerSentinel, "g"),
+      )).toHaveLength(1);
+    }
   });
 
   test("does not retry a partial provider-error response as streaming fallback", async () => {

--- a/todo.txt
+++ b/todo.txt
@@ -302,7 +302,7 @@ boundary. They are higher leverage than new surface area.
       broken links, special files, exact-path approval scope, noninteractive
       denial, repository self-approval rejection, and duplicate injection.
 
-[ ] Make provider retries idempotent at the prompt boundary.
+[x] Make provider retries idempotent at the prompt boundary.
     - A retry must contain the assembled system/developer prompt exactly once,
       never 2x, 4x, or cumulatively more.
     - Add canned transport failures and capture every retry payload.


### PR DESCRIPTION
## Summary

- capture the complete provider-facing prompt once before reconnect retries
- clone messages and tool schemas for every provider attempt and prewarm fallback
- add canned ECONNRESET and HTTP 503 failures that assert byte-for-byte stable retry payloads and exact-once system/developer instructions
- mark the M2 retry-idempotence requirement complete

## Design basis

The retry boundary follows [RFC 9110 idempotent retry semantics](https://www.rfc-editor.org/rfc/rfc9110.html): a safe retry repeats the same semantic request instead of reconstructing it from mutable state. Request troubleshooting also follows the official [OpenAI request ID guidance](https://platform.openai.com/docs/api-reference/backward-compatibility) for diagnosing transport failures without changing request meaning.

## Local verification

- full npm test: 1,778 files, 15,296 passed, 16 skipped
- runtime typecheck: clean
- focused retry tests: 169 passed
- runtime build and package entrypoint contracts: passed
- full agent-surface contract: passed
- isolated Bun suite: 92 files, 0 failures
- SDK typecheck: clean
- SPDX SBOM generation/check: 677 packages, 1,099 relationships
- TUI runtime startup: six PTY variants passed
- pre-commit build and PTY startup hook: passed

All verification ran locally; no hosted test workflow was triggered.