### PR TITLE
fix(runtime): fail closed across required sandbox surfaces

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -71,6 +71,7 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | [design/reproducible-installs-releases.md](design/reproducible-installs-releases.md) | M0 dependency, artifact, Docker, release, and crash-safe lock decisions |
 | [design/workspace-scoped-agent-roles.md](design/workspace-scoped-agent-roles.md) | Immutable workspace identity for role lookup, spawn, resume, and worktrees |
 | [design/secure-project-instructions.md](design/secure-project-instructions.md) | Live instruction delivery, precedence, descriptor-bound reads, approvals, and threat model |
+| [design/fail-closed-sandbox-execution.md](design/fail-closed-sandbox-execution.md) | Required process isolation boundary, platform probes, failure semantics, and research |
 | [roadmap.md](roadmap.md) | Shipped vs open backlog (current product truth) |
 
 ---

--- a/docs/design/fail-closed-sandbox-execution.md
+++ b/docs/design/fail-closed-sandbox-execution.md
@@ -1,0 +1,129 @@
+# Fail-closed process execution
+
+Status: implemented. Threat model and primary-source research refreshed
+2026-07-16.
+
+## Decision
+
+AgenC has one authenticated process-execution boundary. A restricted policy
+(`workspace-write` or `read-only`) has only two outcomes:
+
+1. a behavioral platform probe succeeds and the final program/argv is
+   transformed through the platform sandbox; or
+2. execution stops before the host process is spawned.
+
+There is no warning-only fallback. Raw host execution is permitted only when a
+trusted operator explicitly selected `danger-full-access`/`--yolo`, or when an
+explicit external sandbox policy says isolation is owned outside AgenC.
+Repository content and model-supplied arguments cannot create either decision.
+
+The authenticated broker is created from resolved session policy before MCP or
+hook startup. It is carried as non-enumerable runtime metadata through tool
+compatibility adapters, so JSON/model input cannot spoof it. The final boundary
+covers interactive and print-mode shells, foreground/background commands,
+workflow commands, monitored jobs, configured and legacy hooks, cron-triggered
+turns, stdio MCP servers, daemon `commandExec`, and child-agent tool execution.
+Long-lived boundaries rebase with an interactive worktree transition; child
+sessions fork an independent boundary rooted at their execution cwd, while role
+authority remains anchored to its canonical workspace.
+
+## Platform readiness
+
+- Linux requires the packaged `agenc-linux-sandbox` helper outside the writable
+  workspace and a trusted system `bubblewrap`. Readiness executes a bounded
+  namespace probe; finding binaries on disk is insufficient. The helper is
+  resolved through the installed runtime package root so source and bundled
+  layouts agree. It is launched through the absolute trusted Node executable,
+  and runtime/native-loader injection variables are removed before the first
+  pre-sandbox process. A command profile that could write either launcher is
+  rejected.
+- macOS requires `/usr/bin/sandbox-exec` and a bounded restricted-process probe.
+- Native Windows restricted-token isolation is not implemented, so restricted
+  execution fails closed. Operators can use WSL2, an explicit external sandbox,
+  or deliberately select danger-full-access.
+
+Probe results are cached per session. Daemon `commandExec` applies the same
+behavioral probe before transform/spawn. A successful probe does not weaken the
+spawn boundary: transform failure, helper disappearance, or an unsupported
+surface still stops execution. Child exit caused by a sandbox launcher failure
+is reported as a failed command and never retried as an unsandboxed command.
+
+## Diagnostics and stable failures
+
+`agenc doctor` reports the selected mode, platform, readiness state, precise
+reason, and remediation. Tool/startup paths preserve the same reason. Automation
+can classify:
+
+- `sandbox_required_unavailable` — required platform support/helper is absent;
+- `sandbox_probe_failed` — installed support cannot create isolation;
+- `sandbox_transform_failed` — the final command could not be wrapped; and
+- `sandbox_surface_uncovered` — an execution path arrived without authenticated
+  policy/broker state.
+
+These errors happen before spawn. Explicit danger/external modes remain visible
+policy selections rather than recovery behavior.
+
+## Compatibility, operations, and rollback
+
+This intentionally breaks callers that used daemon `commandExec.start` without
+`permissionProfile` or `sandboxPolicy`, and embedders that launched stdio MCP or
+command hooks outside a session. They must supply an explicit policy boundary;
+`:danger-full-access` preserves intentional host execution.
+
+The change does not alter persisted session or workflow formats. Rollback is a
+single focused revert, but doing so reopens host-execution bypasses. Operational
+recovery is to repair the reported platform dependency, run `agenc doctor`, and
+retry the command. Do not recover by silently changing policy.
+
+## Verification contract
+
+Revert-sensitive tests use marker-writing commands and assert that the marker is
+never created when the broker is missing, the probe fails, or transformation
+fails. Tests cross real tool/transport boundaries for interactive, print,
+background, Monitor, workflow, hook, MCP stdio, and daemon command execution;
+surface-matrix tests cover cron/job/child-agent classifications. Built-layout
+resolution, explicit danger/external pass-through, doctor output, and restricted
+daemon transforms are separate contracts.
+
+## Alternatives rejected
+
+- Warning and execute on the host: violates the declared policy and makes a
+  security failure indistinguishable from success.
+- Presence-only binary checks: cannot detect disabled user namespaces, broken
+  launchers, or policy/runtime mismatch.
+- Independent checks at each tool: inevitably drift and lose context through
+  compatibility adapters.
+- Approval text or command scanning as isolation: approval authorizes intent;
+  it is not an operating-system boundary.
+- Automatic danger mode on unsupported platforms: turns environmental failure
+  into silent privilege escalation.
+
+## Research record
+
+Primary and upstream sources reviewed 2026-07-16:
+
+- [OpenAI agent approvals and security](https://learn.chatgpt.com/docs/agent-approvals-security)
+  and [sandboxing](https://learn.chatgpt.com/docs/sandboxing) describe explicit
+  approval/isolation boundaries and platform behavior.
+- [OpenAI Linux sandbox implementation](https://github.com/openai/codex/blob/main/codex-rs/linux-sandbox/README.md) <!-- branding-scan: allow upstream sandbox research citation -->
+  informed the separation between policy decisions and final OS enforcement.
+- [Linux Landlock](https://www.kernel.org/doc/html/latest/userspace-api/landlock.html),
+  [`no_new_privs`](https://docs.kernel.org/userspace-api/no_new_privs.html), and
+  [seccomp filters](https://docs.kernel.org/userspace-api/seccomp_filter.html)
+  document the kernel primitives and their limits.
+- [Bubblewrap](https://github.com/containers/bubblewrap) and its
+  [v0.11.2 release](https://github.com/containers/bubblewrap/releases/tag/v0.11.2)
+  informed trusted-path and behavioral namespace probing.
+- [Apple App Sandbox](https://developer.apple.com/documentation/security/protecting-user-data-with-app-sandbox)
+  and [Xcode sandbox configuration](https://developer.apple.com/documentation/xcode/configuring-the-macos-app-sandbox)
+  establish the macOS isolation model.
+- [Windows sandboxed process creation](https://learn.microsoft.com/en-us/windows/win32/secauthz/createprocessinsandbox),
+  [AppContainer](https://learn.microsoft.com/en-us/windows/win32/secauthz/implementing-an-appcontainer),
+  and [job objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects)
+  show why process lifecycle control alone is not a complete restricted-token
+  implementation.
+- [Claude Code sandboxing](https://code.claude.com/docs/en/sandboxing) <!-- branding-scan: allow current competitor sandbox research -->,
+  [Hermes security guidance](https://hermes-agent.nousresearch.com/docs/user-guide/security) <!-- branding-scan: allow comparator research citation -->,
+  and [OpenClaw sandboxing](https://github.com/openclaw/openclaw/blob/main/docs/gateway/sandboxing.md) <!-- branding-scan: allow comparator research citation -->
+  were checked for current peer behavior. Their layered isolation and explicit
+  escape modes support a common boundary; none justifies warning-only fallback.

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -141,6 +141,13 @@ Include session rewind/compact, `session.setModel`,
 MCP reconnect/enable/disable. Full list:
 `AGENC_DAEMON_INTERNAL_METHODS` in the protocol module.
 
+`commandExec.start` requires an explicit `permissionProfile` or legacy
+`sandboxPolicy`. Policy-less requests are rejected with
+`sandbox_surface_uncovered`; clients that intentionally need host execution
+must send `permissionProfile: ":danger-full-access"`. Restricted profiles use
+the packaged, non-workspace-writable sandbox helper and fail before spawn when
+platform isolation is unavailable.
+
 ### Server → client notifications
 
 Examples: `event.message_chunk`, `event.tool_request`,

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -340,6 +340,7 @@ OS-level confinement for shell execution lives in `runtime/src/sandbox/`:
 | --- | --- |
 | Linux | bubblewrap + Landlock helpers (`engine/bwrap.ts`, `engine/landlock.ts`, `linux-launcher/`) |
 | macOS | Seatbelt policies (`engine/seatbelt.ts`, `engine/policies/*.sbpl`) |
+| Windows | Restricted execution fails closed; use WSL2 or an explicit external sandbox |
 
 Runtime `read_only` and `workspace_write` profiles use a full-disk read
 baseline. Explicit deny-read entries still override it. `read_only` grants no
@@ -356,10 +357,19 @@ Related:
 - Network policy: `runtime/src/sandbox/network-policy.ts`
 - Escalation / approvals: `runtime/src/sandbox/escalation/`
 
-`--yolo` / `bypassPermissions` waives **approval prompts**, not kernel
-confinement. Sandbox must be explicitly enabled/configured to confine process
-execution. Docker sandbox driver and SSH remote exec targets remain roadmap
-items ([`../roadmap.md`](../roadmap.md)).
+`bypassPermissions` is an approval mode and does not by itself remove kernel
+confinement. The CLI `--yolo` flag is the deliberate combined escape hatch: it
+selects both bypassed prompts and `danger-full-access`. In `read-only` or
+`workspace-write`, missing/unhealthy platform support, a failed behavioral
+probe, a transform failure, or missing authenticated policy stops execution
+before spawn. Inspect readiness and remediation with `agenc doctor`.
+
+This invariant covers shell/unified-exec, Monitor, workflow/job, hook/cron,
+stdio MCP, daemon command exec, and child-agent paths. The design and stable
+error codes are documented in
+[`../design/fail-closed-sandbox-execution.md`](../design/fail-closed-sandbox-execution.md).
+Docker sandbox driver and SSH remote exec targets remain roadmap items
+([`../roadmap.md`](../roadmap.md)).
 
 ## Pre-execute guards
 

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -332,7 +332,7 @@ export interface CommandExecTerminalSize extends JsonObject {
   readonly cols: number;
 }
 
-export interface CommandExecStartParams extends JsonObject {
+interface CommandExecStartBase extends JsonObject {
   readonly command: readonly string[];
   readonly processId?: string | null;
   readonly tty?: boolean;
@@ -345,9 +345,18 @@ export interface CommandExecStartParams extends JsonObject {
   readonly cwd?: string | null;
   readonly env?: Readonly<Record<string, string | null>> | null;
   readonly size?: CommandExecTerminalSize | null;
-  readonly sandboxPolicy?: JsonObject | null;
-  readonly permissionProfile?: string | null;
 }
+
+export type CommandExecStartParams = CommandExecStartBase & (
+  | {
+      readonly permissionProfile: string;
+      readonly sandboxPolicy?: null;
+    }
+  | {
+      readonly sandboxPolicy: JsonObject;
+      readonly permissionProfile?: null;
+    }
+);
 
 export interface CommandExecWriteParams extends JsonObject {
   readonly processId: string;

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -75,6 +75,10 @@ import { emitWarning } from "../session/event-log.js";
 import type { ThreadId } from "./registry.js";
 import { formatSubagentNotification, isFinal } from "./status.js";
 import { asRecord } from "../utils/record.js";
+import {
+  attachSandboxExecutionBroker,
+  type SandboxExecutionBrokerLike,
+} from "../sandbox/execution-broker.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // Types
@@ -1168,6 +1172,7 @@ export function buildFilteredRegistry(
     readonly worktree?: WorktreeHandle;
     readonly disabledTools?: ReadonlySet<string>;
     readonly childToolPolicy?: ChildToolPolicy;
+    readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
   },
 ): ToolRegistry {
   const allowed = opts.allowlist ? new Set(opts.allowlist) : null;
@@ -1515,6 +1520,7 @@ function wrapToolForChild(
     readonly childConversationId: string;
     readonly worktree?: WorktreeHandle;
     readonly childToolPolicy?: ChildToolPolicy;
+    readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
   },
 ): Tool {
   return {
@@ -1531,9 +1537,19 @@ function wrapToolForChild(
       if ("result" in policyResult) {
         return policyResult.result;
       }
-      return tool.execute(
-        injectChildToolArgs(policyResult.args, tool.name, opts),
+      const childArgs = injectChildToolArgs(
+        policyResult.args,
+        tool.name,
+        opts,
       );
+      if (opts.sandboxExecutionBroker !== undefined) {
+        attachSandboxExecutionBroker(
+          childArgs,
+          opts.sandboxExecutionBroker,
+          "child_agent",
+        );
+      }
+      return tool.execute(childArgs);
     },
   };
 }
@@ -1719,6 +1735,10 @@ function buildChildSession(
         : {}),
     },
   );
+  const sandboxExecutionBroker =
+    params.parent.services.sandboxExecutionBroker?.forkForCwd(
+      sessionConfiguration.cwd,
+    );
   const registry = buildFilteredRegistry(params.parent.services.registry, {
     allowlist:
       params.toolAllowlist ?? params.live.role.config.allowlist ?? undefined,
@@ -1733,6 +1753,9 @@ function buildChildSession(
     ),
     ...(params.childToolPolicy !== undefined
       ? { childToolPolicy: params.childToolPolicy }
+      : {}),
+    ...(sandboxExecutionBroker !== undefined
+      ? { sandboxExecutionBroker }
       : {}),
   });
 
@@ -1766,6 +1789,9 @@ function buildChildSession(
       ...params.parent.services,
       provider,
       registry,
+      ...(sandboxExecutionBroker !== undefined
+        ? { sandboxExecutionBroker }
+        : {}),
       ...(startupPrewarm !== undefined ? { startupPrewarm } : {}),
       querySource: params.querySource ?? params.parent.services.querySource,
       permissionModeRegistry: new PermissionModeRegistry(

--- a/runtime/src/app-server-client/index.ts
+++ b/runtime/src/app-server-client/index.ts
@@ -33,6 +33,7 @@ import {
 } from "../session/mcp-startup.js";
 import { createLocalSkillsServices } from "../skills/local-loader.js";
 import { projectMcpManagerToConnections } from "../mcp-client/tui-connections.js";
+import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import {
   createAgentRoleWorkspace,
   normalizeAgentRoleWorkspace,
@@ -239,12 +240,27 @@ export async function createAgenCDaemonOnlyTuiContext(
     },
   });
   await skillsServices.skillsWatcher.start();
+  const sandboxExecutionBroker = new SandboxExecutionBroker({
+    mode: options.permissionMode === "bypassPermissions"
+      ? "danger_full_access"
+      : effectiveConfig.sandbox_mode === "read-only"
+        ? "read_only"
+        : effectiveConfig.sandbox_mode === "danger-full-access"
+          ? "danger_full_access"
+          : "workspace_write",
+    // Role authority remains anchored to the canonical checkout, while
+    // execution policy must follow the attached worktree/session cwd.
+    cwd: options.cwd,
+    env,
+    allowGpu: effectiveConfig.sandbox?.allow_gpu === true,
+  });
   const mcpRuntimeManager = await createSessionMcpManagerFromSources(
     effectiveConfig,
     env,
     {
-      cwd: roleWorkspace.cwd,
+      cwd: options.cwd,
       includeProjectMcpServers: options.permissionMode === "bypassPermissions",
+      sandboxExecutionBroker,
     },
   );
   await mcpRuntimeManager.start();
@@ -273,6 +289,7 @@ export async function createAgenCDaemonOnlyTuiContext(
         }),
       ),
       configStore,
+      sandboxExecutionBroker,
       mcpManager: mcpService,
       skillsManager: skillsServices.skillsManager,
       pluginsManager: skillsServices.pluginsManager,

--- a/runtime/src/app-server/command-exec.ts
+++ b/runtime/src/app-server/command-exec.ts
@@ -12,6 +12,7 @@ import treeKill from "tree-kill";
 
 import { AgenCDaemonAgentLifecycleError } from "./agent-lifecycle.js";
 import {
+  canWritePathWithCwd,
   externalFileSystemPolicy,
   permissionProfileFromRuntimePermissions,
   restrictedFileSystemPolicy,
@@ -23,6 +24,12 @@ import {
   type SandboxablePreference,
   type WindowsSandboxLevel,
 } from "../sandbox/engine/index.js";
+import {
+  probeSandboxExecutionStatus,
+  requiredSandboxExecutionError,
+  resolveTrustedLinuxSandboxExecutable,
+  type SandboxExecutionStatus,
+} from "../sandbox/execution-broker.js";
 import {
   JSON_RPC_VERSION,
   type CommandExecOutputDeltaParams,
@@ -119,6 +126,8 @@ export interface AgenCCommandExecServiceOptions {
   readonly windowsSandboxPrivateDesktop?: boolean;
   /** Opt-in GPU compute inside the sandbox (config `sandbox.allow_gpu`). */
   readonly allowGpu?: boolean;
+  /** Injectable only for deterministic readiness/fault tests. */
+  readonly sandboxProbe?: typeof probeSandboxExecutionStatus;
 }
 
 interface SpawnCommand {
@@ -198,6 +207,7 @@ export class AgenCCommandExecService implements AgenCCommandExec {
   readonly #windowsSandboxLevel: WindowsSandboxLevel;
   readonly #windowsSandboxPrivateDesktop: boolean;
   readonly #allowGpu: boolean;
+  readonly #sandboxProbe: typeof probeSandboxExecutionStatus;
   #nextGeneratedProcessId = 1;
 
   constructor(options: AgenCCommandExecServiceOptions = {}) {
@@ -208,6 +218,7 @@ export class AgenCCommandExecService implements AgenCCommandExec {
     this.#windowsSandboxPrivateDesktop =
       options.windowsSandboxPrivateDesktop ?? false;
     this.#allowGpu = options.allowGpu ?? false;
+    this.#sandboxProbe = options.sandboxProbe ?? probeSandboxExecutionStatus;
   }
 
   async start(
@@ -480,13 +491,9 @@ export class AgenCCommandExecService implements AgenCCommandExec {
     const env = buildEnv(params.env);
     const sandboxRequest = commandExecSandboxRequest(params, cwd);
     if (sandboxRequest === undefined) {
-      return {
-        program,
-        args,
-        cwd,
-        env,
-        argv0: basename(program),
-      };
+      throw invalidArgument(
+        "[sandbox_surface_uncovered] commandExec.start requires an explicit permissionProfile or sandboxPolicy",
+      );
     }
 
     const sandbox = this.#sandboxManager.selectInitial({
@@ -496,10 +503,59 @@ export class AgenCCommandExecService implements AgenCCommandExec {
       windowsSandboxLevel: this.#windowsSandboxLevel,
       hasManagedNetworkRequirements: false,
     });
+    let readiness: SandboxExecutionStatus | undefined;
+    if (sandboxRequest.preference === "require") {
+      readiness = this.#sandboxProbe({
+        mode: commandExecRequiredSandboxMode(sandboxRequest.permissionProfile),
+        cwd: sandboxRequest.sandboxPolicyCwd,
+        env,
+        platform: process.platform,
+        ...(this.#agencLinuxSandboxExe !== undefined
+          ? { agencLinuxSandboxExe: this.#agencLinuxSandboxExe }
+          : {}),
+      });
+      if (readiness.kind !== "ready") {
+        throw requiredSandboxExecutionError("command_exec", readiness);
+      }
+    }
     if (sandbox === "none" && sandboxRequest.preference === "require") {
-      throw new Error(
-        "sandbox isolation was required for commandExec.start but no platform sandbox is available",
-      );
+      throw requiredSandboxExecutionError("command_exec", {
+        ...(readiness ?? {
+          mode: commandExecRequiredSandboxMode(
+            sandboxRequest.permissionProfile,
+          ),
+          platform: process.platform,
+        }),
+        kind: "unavailable",
+        reason:
+          "sandbox manager selected no platform isolation for a required command",
+        remediation:
+          "Run `agenc doctor`; repair the platform sandbox or select danger-full-access explicitly.",
+      });
+    }
+    let linuxSandboxExe = readiness?.helperPath ?? this.#agencLinuxSandboxExe;
+    if (sandbox === "linux_seccomp") {
+      if (linuxSandboxExe === undefined) {
+        throw new Error(
+          "[sandbox_required_unavailable] commandExec.start requires the packaged Linux sandbox helper",
+        );
+      }
+      const trusted = resolveTrustedLinuxSandboxExecutable(linuxSandboxExe, cwd);
+      if (trusted.error !== undefined) {
+        throw new Error(`[sandbox_required_unavailable] ${trusted.error}`);
+      }
+      linuxSandboxExe = trusted.path;
+      if (
+        canWritePathWithCwd(
+          sandboxRequest.permissionProfile.fileSystem,
+          linuxSandboxExe,
+          sandboxRequest.sandboxPolicyCwd,
+        )
+      ) {
+        throw new Error(
+          "[sandbox_required_unavailable] Linux sandbox helper is writable by the command permission profile",
+        );
+      }
     }
     const transformed = this.#sandboxManager.transform({
       command: { program, args, cwd, env },
@@ -507,8 +563,8 @@ export class AgenCCommandExecService implements AgenCCommandExec {
       sandbox,
       enforceManagedNetwork: false,
       sandboxPolicyCwd: sandboxRequest.sandboxPolicyCwd,
-      ...(this.#agencLinuxSandboxExe !== undefined
-        ? { agencLinuxSandboxExe: this.#agencLinuxSandboxExe }
+      ...(linuxSandboxExe !== undefined
+        ? { agencLinuxSandboxExe: linuxSandboxExe }
         : {}),
       useLegacyLandlock: this.#useLegacyLandlock,
       windowsSandboxLevel: this.#windowsSandboxLevel,
@@ -793,6 +849,16 @@ function sandboxPreferenceForPermissionProfile(
   permissionProfile: PermissionProfile,
 ): SandboxablePreference {
   return permissionProfile.fileSystem.kind === "restricted" ? "require" : "auto";
+}
+
+function commandExecRequiredSandboxMode(
+  permissionProfile: PermissionProfile,
+): "read_only" | "workspace_write" {
+  return permissionProfile.fileSystem.entries.some(
+      (entry) => entry.access === "write",
+    )
+    ? "workspace_write"
+    : "read_only";
 }
 
 function legacySandboxPolicyType(policy: JsonObject): LegacySandboxPolicyType {

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -28,6 +28,7 @@ import {
 } from "./background-agent-runner.js";
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCCommandExecService } from "./command-exec.js";
+import { resolveDefaultLinuxSandboxExecutable } from "../sandbox/execution-broker.js";
 import {
   readDistVersion,
   removeDaemonRuntimeInfo,
@@ -1328,7 +1329,10 @@ async function runAgenCDaemonForeground(
       destroyEvictedClientConnection?.(clientId);
     },
   });
-  const commandExec = new AgenCCommandExecService();
+  const commandExec = new AgenCCommandExecService({
+    agencLinuxSandboxExe: resolveDefaultLinuxSandboxExecutable(),
+    allowGpu: activeConfig.sandbox?.allow_gpu === true,
+  });
   const cleanup = new AgenCCleanupRegistry();
   // Only the spawned, detached daemon (AGENC_DAEMON_RUN=1) redirects console
   // output into the size-capped rotating sink; a `--foreground` invocation run

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -1117,7 +1117,7 @@ export interface CommandExecTerminalSize extends JsonObject {
 
 export type CommandExecEnv = Readonly<Record<string, string | null>>;
 
-export interface CommandExecStartParams extends JsonObject {
+interface CommandExecStartBase extends JsonObject {
   readonly command: readonly string[];
   readonly processId?: string | null;
   readonly tty?: boolean;
@@ -1130,9 +1130,18 @@ export interface CommandExecStartParams extends JsonObject {
   readonly cwd?: string | null;
   readonly env?: CommandExecEnv | null;
   readonly size?: CommandExecTerminalSize | null;
-  readonly sandboxPolicy?: JsonObject | null;
-  readonly permissionProfile?: string | null;
 }
+
+export type CommandExecStartParams = CommandExecStartBase & (
+  | {
+      readonly permissionProfile: string;
+      readonly sandboxPolicy?: null;
+    }
+  | {
+      readonly sandboxPolicy: JsonObject;
+      readonly permissionProfile?: null;
+    }
+);
 
 export interface CommandExecResponse extends JsonObject {
   readonly exitCode: number;

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -28,6 +28,7 @@ import { isAbsolute, resolve } from "node:path";
 import { cwd as processCwd } from "node:process";
 import { VERSION } from "../index.js";
 import { applyBestEffortPreMainProcessHardening } from "../sandbox/hardening/index.js";
+import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import {
   classifyCLI,
   extractFlagValues,
@@ -1402,11 +1403,31 @@ async function prepareOneShotPromptForDaemon(params: {
   | { readonly blocked: true; readonly blockMessage: string }
 > {
   const target = createOneShotHookTarget();
+  const argv = process.argv.slice(2);
+  const explicitDanger =
+    argv.includes("--yolo") ||
+    argv.includes("--dangerously-bypass-approvals-and-sandbox") ||
+    argv.includes("--dangerously-skip-permissions") ||
+    argv.includes("--allow-dangerously-skip-permissions");
+  const configuredSandbox = params.configStore.current().sandbox_mode;
+  const sandboxExecutionBroker = new SandboxExecutionBroker({
+    mode: explicitDanger
+      ? "danger_full_access"
+      : configuredSandbox === "read-only"
+        ? "read_only"
+        : configuredSandbox === "danger-full-access"
+          ? "danger_full_access"
+          : "workspace_write",
+    cwd: params.cwd,
+    env: params.env,
+    allowGpu: params.configStore.current().sandbox?.allow_gpu === true,
+  });
   const hooksRuntime = new ConfiguredHooksRuntime({
     cwd: params.cwd,
     env: params.env,
     agencHome: params.agencHome,
     shellPath: params.env.SHELL ?? "/bin/sh",
+    sandboxExecutionBroker,
   });
   hooksRuntime.attachTarget(target);
   hooksRuntime.load(params.configStore.current().hooks);

--- a/runtime/src/bin/bootstrap-services.ts
+++ b/runtime/src/bin/bootstrap-services.ts
@@ -97,6 +97,7 @@ import type {
 import type { ConfigStore } from "../config/store.js";
 import type { ToolRegistry } from "../tool-registry.js";
 import type { UnifiedExecProcessManagerLike } from "../unified-exec/types.js";
+import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import type {
   AuthBackend,
   AuthSubscriptionTier,
@@ -119,6 +120,7 @@ export interface BootstrapSessionServicesOptions {
   readonly registry: ToolRegistry;
   readonly mcpManager: SessionServices["mcpManager"];
   readonly unifiedExecManager: UnifiedExecProcessManagerLike;
+  readonly sandboxExecutionBroker: SandboxExecutionBrokerLike;
   readonly permissionModeRegistry: PermissionModeRegistry;
   readonly configStore: ConfigStore;
   readonly toolApprovals: RuntimeApprovalStore<unknown>;
@@ -679,10 +681,12 @@ export function buildBootstrapSessionServices(
     env: opts.env,
     agencHome: opts.agencHome,
     shellPath: opts.env.SHELL ?? "/bin/sh",
+    sandboxExecutionBroker: opts.sandboxExecutionBroker,
   });
   const autoFixPostToolHook = createAutoFixPostToolHook({
     configSource: () => opts.configStore.current().autoFix,
     cwd: opts.workspaceRoot,
+    sandboxExecutionBroker: opts.sandboxExecutionBroker,
   });
   hooksRuntime.attachTarget(hooksService);
   const loadHooks = (cfg: ReturnType<ConfigStore["current"]>): void => {
@@ -713,6 +717,7 @@ export function buildBootstrapSessionServices(
     mcpConnectionManager,
     mcpStartupCancellationToken: createMcpStartupCancellationToken(),
     unifiedExecManager: opts.unifiedExecManager,
+    sandboxExecutionBroker: opts.sandboxExecutionBroker,
     hooks: hooksService,
     hooksRuntime,
     rollout: rolloutRecorder,

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -79,6 +79,7 @@ import { getSystemPrompt } from "../constants/prompts.js";
 import type { Tools as PromptTools } from "../tools/Tool.js";
 import { buildBootstrapToolRegistry } from "./bootstrap-tool-registry.js";
 import { UnifiedExecProcessManager } from "../unified-exec/process-manager.js";
+import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import { createCodeModeService } from "../tools/code-mode/service.js";
 import {
   clearCurrentRuntimeSession,
@@ -640,6 +641,7 @@ function buildDeferredConfig(
   cwd: string,
   model: string,
   config: AgenCConfig,
+  sandboxStatus?: ReturnType<SandboxExecutionBroker["status"]>,
 ): Config {
   const modelReasoningEffort =
     config.reasoning_effort === "minimal"
@@ -681,6 +683,12 @@ function buildDeferredConfig(
       ? { agent_max_depth: config.agent_max_depth }
       : {}),
     cwd,
+    ...(sandboxStatus?.helperPath !== undefined
+      ? { agencLinuxSandboxExe: sandboxStatus.helperPath }
+      : {}),
+    ...(sandboxStatus?.kind === "unavailable" && sandboxStatus.reason !== undefined
+      ? { sandboxUnavailableReason: sandboxStatus.reason }
+      : {}),
     features: createManagedFeatures(config),
     /** T9: `multiAgentV2` hints (subagent usage hints + metadata visibility). */
     multiAgentV2: {
@@ -1068,12 +1076,21 @@ export async function bootstrapLocalRuntimeSession(
   const selectedProviderModel = managedKey.baseURL !== undefined
     ? normalizeManagedGatewayModel(resolvedProvider, providerModel)
     : providerModel;
+  const sandboxExecutionBroker = new SandboxExecutionBroker({
+    mode: cli.allowDangerouslySkipPermissions
+      ? "danger_full_access"
+      : mapSandboxPolicy(startup.config.sandbox_mode),
+    cwd: workspaceRoot,
+    env,
+    allowGpu: startup.config.sandbox?.allow_gpu === true,
+  });
   const mcpManager = await createSessionMcpManagerFromSources(
     configStore.current(),
     env,
     {
       cwd: workspaceRoot,
       includeProjectMcpServers: cli.allowDangerouslySkipPermissions,
+      sandboxExecutionBroker,
     },
   );
   const unifiedExecManager = new UnifiedExecProcessManager({
@@ -1135,6 +1152,7 @@ export async function bootstrapLocalRuntimeSession(
     toolRegistryOptions: {
       ...(options.toolRegistryOptions ?? {}),
       unifiedExecManager,
+      sandboxExecutionBroker,
       codeModeService,
       // Coordinator mode restricts the LIVE surface to orchestration +
       // user-interaction tools: the coordinator directs workers, it
@@ -1228,10 +1246,15 @@ export async function bootstrapLocalRuntimeSession(
         });
     });
   }
-  const config = buildDeferredConfig(workspaceRoot, model, {
-    ...startup.config,
-    autonomous_mode: autonomousModeEnabled,
-  });
+  const config = buildDeferredConfig(
+    workspaceRoot,
+    model,
+    {
+      ...startup.config,
+      autonomous_mode: autonomousModeEnabled,
+    },
+    sandboxExecutionBroker.status(),
+  );
   const modelsManager = new StaticModelsManager({
     config: startup.config,
     fallbackProvider: profileProvider,
@@ -1352,6 +1375,7 @@ export async function bootstrapLocalRuntimeSession(
       model,
       sessionConfiguration,
       codeModeService,
+      sandboxExecutionBroker,
     });
 
   const shutdown = async (): Promise<void> => {

--- a/runtime/src/bin/doctor-cli.ts
+++ b/runtime/src/bin/doctor-cli.ts
@@ -95,6 +95,13 @@ export function formatDiagnosticText(
         `(${guard.endpointReachable ? "reachable" : "UNREACHABLE"})`,
     );
   }
+  lines.push(
+    `  Sandbox:            ${info.sandbox.kind} ` +
+      `(mode: ${info.sandbox.mode}, platform: ${info.sandbox.platform})`,
+  );
+  if (info.sandbox.reason) {
+    lines.push(`    reason:   ${info.sandbox.reason}`);
+  }
 
   if (info.multipleInstallations.length > 0) {
     lines.push("");

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -3515,10 +3515,16 @@ function createCronAndWorkflowTools(opts: ModelFacingToolOptions): readonly Tool
         const ownerId = processOwnerIdFromToolArgs(
           args as Record<string, unknown>,
         );
+        const runtimeSandbox = runtimeSandboxForExec(
+          args as Record<string, unknown>,
+          opts.workspaceRoot,
+          "workflow",
+        );
         const output = await opts.unifiedExecManager.execCommand({
           cmd: workflow.command,
           workdir: opts.workspaceRoot,
           ...(ownerId !== undefined ? { ownerId } : {}),
+          ...(runtimeSandbox !== undefined ? { runtimeSandbox } : {}),
         });
         return {
           content: formatUnifiedExecToolContent(output),

--- a/runtime/src/hooks/configured-hooks.ts
+++ b/runtime/src/hooks/configured-hooks.ts
@@ -115,6 +115,7 @@ export interface ConfiguredHooksRuntimeOptions {
   readonly env: NodeJS.ProcessEnv;
   readonly agencHome: string;
   readonly shellPath: string;
+  readonly sandboxExecutionBroker?: import("../sandbox/execution-broker.js").SandboxExecutionBrokerLike;
   /**
    * SECURITY: trust gate for config/plugin-sourced command hooks. Returns true
    * when the current workspace is trusted (persisted in trusted-projects.json).
@@ -151,6 +152,9 @@ export class ConfiguredHooksRuntime {
       env: opts.env,
       shellPath: opts.shellPath,
       sourcePath: this.sourcePath(),
+      ...(opts.sandboxExecutionBroker !== undefined
+        ? { sandboxExecutionBroker: opts.sandboxExecutionBroker }
+        : {}),
     });
     this.isWorkspaceTrusted =
       opts.isWorkspaceTrusted ??

--- a/runtime/src/hooks/engine/command-runner.ts
+++ b/runtime/src/hooks/engine/command-runner.ts
@@ -5,6 +5,10 @@
  */
 
 import { spawn } from "node:child_process";
+import {
+  missingSandboxExecutionBoundary,
+  type SandboxExecutionBrokerLike,
+} from "../../sandbox/execution-broker.js";
 
 import type { CommandRunResult } from "./types.js";
 
@@ -18,6 +22,7 @@ export interface RunHookCommandOptions {
   readonly stdin: string;
   readonly timeoutMs: number;
   readonly signal?: AbortSignal;
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
 }
 
 export async function runHookCommand(
@@ -33,12 +38,23 @@ export async function runHookCommand(
       error: "hook aborted",
     };
   }
+  const env = stringOnlyEnv(opts.env);
+  if (opts.sandboxExecutionBroker === undefined) {
+    throw missingSandboxExecutionBoundary("hook");
+  }
+  const command = opts.sandboxExecutionBroker.prepareSpawn("hook", {
+    program: opts.shellPath,
+    args: ["-c", opts.command],
+    cwd: opts.cwd,
+    env,
+  });
   return new Promise((resolve) => {
-    const child = spawn(opts.shellPath, ["-c", opts.command], {
-      cwd: opts.cwd,
-      env: opts.env,
+    const child = spawn(command.program, [...command.args], {
+      cwd: command.cwd,
+      env: command.env,
       stdio: ["pipe", "pipe", "pipe"],
       detached: process.platform !== "win32",
+      ...(command.argv0 !== undefined ? { argv0: command.argv0 } : {}),
     });
     let stdout = "";
     let stderr = "";
@@ -136,6 +152,14 @@ export async function runHookCommand(
     });
     child.stdin.end(opts.stdin);
   });
+}
+
+function stringOnlyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
 }
 
 function appendBoundedOutput(

--- a/runtime/src/hooks/engine/dispatcher.ts
+++ b/runtime/src/hooks/engine/dispatcher.ts
@@ -124,6 +124,9 @@ export class HookEngine {
       stdin: `${JSON.stringify(input)}\n`,
       timeoutMs: hook.command.timeout_ms ?? DEFAULT_HOOK_TIMEOUT_MS,
       signal,
+      ...(this.opts.sandboxExecutionBroker !== undefined
+        ? { sandboxExecutionBroker: this.opts.sandboxExecutionBroker }
+        : {}),
     });
     return this.recordDiagnostic(hook, result, startedAtUnixMs);
   }

--- a/runtime/src/hooks/engine/types.ts
+++ b/runtime/src/hooks/engine/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { HookCommand, HookEventName } from "../../config/schema.js";
+import type { SandboxExecutionBrokerLike } from "../../sandbox/execution-broker.js";
 
 export type HookRunStatus =
   | "success"
@@ -58,6 +59,7 @@ export interface HookEngineOptions {
   readonly shellPath: string;
   readonly sourcePath: string;
   readonly maxDiagnostics?: number;
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
 }
 
 export interface HookDispatchResult {

--- a/runtime/src/mcp-client/connection.ts
+++ b/runtime/src/mcp-client/connection.ts
@@ -18,6 +18,7 @@ import { createSseMCPConnection } from "./transports/sse.js";
 import { createHttpMCPConnection } from "./transports/http.js";
 import { createWebSocketMCPConnection } from "./transports/websocket.js";
 import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
+import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 
 /**
  * Create an MCP client connection to an external server.
@@ -32,6 +33,7 @@ export async function createMCPConnection(
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
   samplingHandlers?: McpSamplingHandlers,
+  sandboxExecutionBroker?: SandboxExecutionBrokerLike,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const transportKind = config.transport ?? "stdio";
@@ -55,6 +57,7 @@ export async function createMCPConnection(
       logger,
       elicitationHandlers,
       samplingHandlers,
+      sandboxExecutionBroker,
     );
   }
 

--- a/runtime/src/mcp-client/manager.ts
+++ b/runtime/src/mcp-client/manager.ts
@@ -44,6 +44,7 @@ import {
   type MCPPromptRendered,
 } from "./prompts.js";
 import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
+import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 
 /** I-50: cancellable MCP startup wait; 30s default. */
 const MCP_STARTUP_TIMEOUT_MS = 30_000;
@@ -200,6 +201,7 @@ export class MCPManager {
   private permissionOptions: MCPToolBridgePermissionOptions | undefined;
   private elicitationHandlers: MCPElicitationHandlers | undefined;
   private samplingHandlers: McpSamplingHandlers | undefined;
+  private sandboxExecutionBroker: SandboxExecutionBrokerLike | undefined;
 
   constructor(configs: MCPServerConfig[], logger: Logger = silentLogger) {
     this.configs = configs;
@@ -231,6 +233,12 @@ export class MCPManager {
 
   setSamplingHandlers(handlers: McpSamplingHandlers | undefined): void {
     this.samplingHandlers = handlers;
+  }
+
+  setSandboxExecutionBroker(
+    broker: SandboxExecutionBrokerLike | undefined,
+  ): void {
+    this.sandboxExecutionBroker = broker;
   }
 
   getConnectionState(name: string): MCPConnectionState | undefined {
@@ -781,6 +789,7 @@ export class MCPManager {
       this.logger,
       this.elicitationHandlers,
       this.samplingHandlers,
+      this.sandboxExecutionBroker,
     );
     try {
       if (startupGate?.isCancelled()) {
@@ -845,6 +854,9 @@ export class MCPManager {
             : {}),
           ...(this.samplingHandlers !== undefined
             ? { samplingHandlers: this.samplingHandlers }
+            : {}),
+          ...(this.sandboxExecutionBroker !== undefined
+            ? { sandboxExecutionBroker: this.sandboxExecutionBroker }
             : {}),
           // On automatic reconnect the resilient bridge rebuilds only the
           // tool surface and spawns a fresh client. Rebuild the resource +

--- a/runtime/src/mcp-client/resilient-client.ts
+++ b/runtime/src/mcp-client/resilient-client.ts
@@ -14,6 +14,7 @@ import type {
   MCPToolBridge,
 } from "./types.js";
 import type { McpSamplingHandlers } from "../services/mcp/hostCapabilities.js";
+import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import type {
   MCPCallObserver,
   MCPToolBridgePermissionOptions,
@@ -129,6 +130,7 @@ interface ResilientMCPBridgeOptions {
   readonly elicitationHandlers?: MCPElicitationHandlers;
   /** Session-provided MCP sampling handler, re-registered on reconnect. */
   readonly samplingHandlers?: McpSamplingHandlers;
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
 }
 
 /**
@@ -266,6 +268,7 @@ export class ResilientMCPBridge implements MCPToolBridge {
         this.logger,
         this.options.elicitationHandlers,
         this.options.samplingHandlers,
+        this.options.sandboxExecutionBroker,
       );
       // A `dispose()` racing this reconnect already cleared `reconnectTimer`
       // and disposed `this.inner`, but it cannot see the client we just

--- a/runtime/src/mcp-client/transports/stdio.ts
+++ b/runtime/src/mcp-client/transports/stdio.ts
@@ -30,6 +30,10 @@ import {
   configureMcpHostRequestHandlers,
   type McpSamplingHandlers,
 } from "../../services/mcp/hostCapabilities.js";
+import {
+  missingSandboxExecutionBoundary,
+  type SandboxExecutionBrokerLike,
+} from "../../sandbox/execution-broker.js";
 
 const PROCESS_GROUP_TERM_GRACE_MS = 2_000;
 
@@ -172,7 +176,11 @@ export class AgenCStdioClientTransport implements Transport {
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
 
-  constructor(server: StdioTransportServerParameters, private readonly logger: Logger = silentLogger) {
+  constructor(
+    server: StdioTransportServerParameters,
+    private readonly logger: Logger = silentLogger,
+    private readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike,
+  ) {
     this.server = server;
   }
 
@@ -184,15 +192,27 @@ export class AgenCStdioClientTransport implements Transport {
     const env = { ...(this.server.env ?? {}) };
     const cwd = this.server.cwd ?? process.cwd();
     const command = resolveStdioProgram(this.server.command, env, cwd);
+    if (this.sandboxExecutionBroker === undefined) {
+      throw missingSandboxExecutionBoundary("mcp_stdio");
+    }
+    const spawnCommand = this.sandboxExecutionBroker.prepareSpawn("mcp_stdio", {
+      program: command,
+      args: this.server.args ?? [],
+      cwd,
+      env,
+    });
 
     await new Promise<void>((resolve, reject) => {
-      const child = spawn(command, [...(this.server.args ?? [])], {
-        cwd,
-        env,
+      const child = spawn(spawnCommand.program, [...spawnCommand.args], {
+        cwd: spawnCommand.cwd,
+        env: spawnCommand.env,
         stdio: ["pipe", "pipe", "pipe"],
         shell: false,
         detached: process.platform !== "win32",
         windowsHide: process.platform === "win32",
+        ...(spawnCommand.argv0 !== undefined
+          ? { argv0: spawnCommand.argv0 }
+          : {}),
       });
 
       this.child = child;
@@ -322,6 +342,7 @@ export class AgenCStdioClientTransport implements Transport {
 function createStdioMCPTransport(
   config: MCPServerStdioConfig,
   logger: Logger = silentLogger,
+  sandboxExecutionBroker?: SandboxExecutionBrokerLike,
 ): AgenCStdioClientTransport {
   const env = createStdioMCPEnvironment(config.env, config.env_vars);
   return new AgenCStdioClientTransport(
@@ -332,6 +353,7 @@ function createStdioMCPTransport(
       cwd: config.cwd,
     },
     logger,
+    sandboxExecutionBroker,
   );
 }
 
@@ -340,11 +362,16 @@ export async function createStdioMCPConnection(
   logger: Logger = silentLogger,
   elicitationHandlers?: MCPElicitationHandlers,
   samplingHandlers?: McpSamplingHandlers,
+  sandboxExecutionBroker?: SandboxExecutionBrokerLike,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
   const timeout = config.timeout ?? 30_000;
-  const transport = createStdioMCPTransport(config, logger);
+  const transport = createStdioMCPTransport(
+    config,
+    logger,
+    sandboxExecutionBroker,
+  );
   const client = new Client(
     { name: "agenc-runtime", version: VERSION },
     {

--- a/runtime/src/sandbox/engine/index.ts
+++ b/runtime/src/sandbox/engine/index.ts
@@ -144,6 +144,8 @@ export class SandboxTransformError extends Error {
   constructor(
     readonly code:
       | "missing_linux_sandbox_executable"
+      | "writable_linux_sandbox_launcher"
+      | "writable_linux_sandbox_helper"
       | "wsl1_unsupported_for_bubblewrap"
       | "windows_restricted_token_unimplemented"
       | "seatbelt_unavailable",

--- a/runtime/src/sandbox/engine/manager.ts
+++ b/runtime/src/sandbox/engine/manager.ts
@@ -6,9 +6,9 @@
  * items wire into process execution.
  */
 
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import {
-  AGENC_LINUX_SANDBOX_ARG0,
   SandboxTransformError,
   canWritePathWithCwd,
   getPlatformSandbox,
@@ -46,6 +46,7 @@ import {
   newWorkspaceWritePolicy,
   type SandboxPolicy as CompatibilitySandboxPolicy,
 } from "../../permissions/sandbox.js";
+import { sanitizeSandboxLauncherEnvironment } from "../launcher-environment.js";
 
 export class SandboxManager {
   selectInitial(options: {
@@ -132,7 +133,33 @@ export class SandboxManager {
           isWsl1:
             platform === "linux" ? request.isWsl1 ?? isWsl1() : false,
         });
+        const nodeExecutable = trustedNodeExecutable();
+        if (
+          canWritePathWithCwd(
+            fileSystem,
+            nodeExecutable,
+            request.sandboxPolicyCwd,
+          )
+        ) {
+          throw new SandboxTransformError(
+            "writable_linux_sandbox_launcher",
+            "the Node executable used to launch the Linux sandbox is writable by the command permission profile",
+          );
+        }
+        if (
+          canWritePathWithCwd(
+            fileSystem,
+            request.agencLinuxSandboxExe,
+            request.sandboxPolicyCwd,
+          )
+        ) {
+          throw new SandboxTransformError(
+            "writable_linux_sandbox_helper",
+            "the Linux sandbox helper is writable by the command permission profile",
+          );
+        }
         command = [
+          nodeExecutable,
           request.agencLinuxSandboxExe,
           ...createLinuxSandboxCommandArgsForPermissionProfile(
             argv,
@@ -143,7 +170,9 @@ export class SandboxManager {
             allowProxyNetwork,
           ),
         ];
-        arg0 = linuxSandboxArg0Override(request.agencLinuxSandboxExe);
+        // A normal argv0 avoids commandExec's PTY argv0 compatibility wrapper,
+        // eliminating a second pre-sandbox Node process.
+        arg0 = path.basename(nodeExecutable);
         break;
       }
       case "windows_restricted_token":
@@ -156,7 +185,9 @@ export class SandboxManager {
     return {
       command,
       cwd: request.command.cwd,
-      env: request.command.env,
+      env: request.sandbox === "none"
+        ? request.command.env
+        : sanitizeSandboxLauncherEnvironment(request.command.env),
       ...(request.network !== undefined ? { network: request.network } : {}),
       sandbox: request.sandbox,
       windowsSandboxLevel: request.windowsSandboxLevel,
@@ -336,8 +367,10 @@ function ensureLinuxBubblewrapIsSupported(options: {
   }
 }
 
-function linuxSandboxArg0Override(executablePath: string): string {
-  return path.basename(executablePath) === AGENC_LINUX_SANDBOX_ARG0
-    ? executablePath
-    : AGENC_LINUX_SANDBOX_ARG0;
+function trustedNodeExecutable(): string {
+  try {
+    return realpathSync(process.execPath);
+  } catch {
+    return path.resolve(process.execPath);
+  }
 }

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -1,0 +1,707 @@
+/**
+ * Final process-execution boundary for commands that do not naturally pass
+ * through the model-tool router (hooks, MCP stdio, workflow commands, and
+ * direct interactive shell input).
+ *
+ * Restricted modes have exactly two outcomes: return a platform-sandboxed
+ * command or throw a stable, actionable error. Only explicit
+ * `danger_full_access` and `external_sandbox` modes may return the host command
+ * unchanged.
+ */
+
+import { spawnSync } from "node:child_process";
+import { realpathSync, statSync } from "node:fs";
+import path, { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  SandboxManager,
+  type SandboxType,
+} from "./engine/index.js";
+import { findSystemBubblewrapInPath } from "./linux-launcher/launcher.js";
+import { resolveRuntimePackageRootFromUrl } from "../app-server/daemon-runtime-info.js";
+import type { UnifiedExecRuntimeSandbox } from "../unified-exec/types.js";
+import { UnifiedExecError } from "../unified-exec/types.js";
+import type { SandboxMode } from "../tools/orchestrator.js";
+import {
+  permissionProfileForSandboxMode,
+  sandboxModeRequiresPlatformIsolation,
+} from "../tools/runtimes/sandboxing.js";
+import { sanitizeSandboxLauncherEnvironment } from "./launcher-environment.js";
+
+export type SandboxExecutionSurface =
+  | "interactive"
+  | "print"
+  | "background"
+  | "workflow"
+  | "job"
+  | "hook"
+  | "cron"
+  | "mcp_stdio"
+  | "child_agent"
+  | "command_exec"
+  | "tool";
+
+export type SandboxExecutionErrorCode =
+  | "sandbox_required_unavailable"
+  | "sandbox_probe_failed"
+  | "sandbox_transform_failed"
+  | "sandbox_surface_uncovered";
+
+export type SandboxExecutionStatusKind =
+  | "ready"
+  | "unavailable"
+  | "not_required"
+  | "external";
+
+export interface SandboxExecutionStatus {
+  readonly kind: SandboxExecutionStatusKind;
+  readonly mode: SandboxMode | "unknown";
+  readonly platform: NodeJS.Platform;
+  readonly reason?: string;
+  readonly remediation?: string;
+  readonly helperPath?: string;
+  readonly isolationProgram?: string;
+}
+
+export interface SandboxSpawnCommand {
+  readonly program: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly argv0?: string;
+}
+
+export type SandboxExecutionManager = Pick<
+  SandboxManager,
+  "selectInitial" | "transform"
+>;
+
+export interface SandboxExecutionBrokerLike {
+  readonly mode: SandboxMode;
+  readonly required: boolean;
+  readonly cwd: string;
+  /** Re-root the same live boundary so captured registry/hook references update. */
+  rebase(cwd: string): void;
+  /** Fork an independent boundary for a child session or worktree. */
+  forkForCwd(cwd: string): SandboxExecutionBrokerLike;
+  status(): SandboxExecutionStatus;
+  assertReady(surface: SandboxExecutionSurface): SandboxExecutionStatus;
+  runtimeSandbox(
+    surface: SandboxExecutionSurface,
+  ): UnifiedExecRuntimeSandbox | undefined;
+  prepareSpawn(
+    surface: SandboxExecutionSurface,
+    command: SandboxSpawnCommand,
+  ): SandboxSpawnCommand;
+}
+
+export class SandboxExecutionError extends Error {
+  readonly code: SandboxExecutionErrorCode;
+  readonly surface: SandboxExecutionSurface;
+  readonly status: SandboxExecutionStatus;
+
+  constructor(options: {
+    readonly code: SandboxExecutionErrorCode;
+    readonly surface: SandboxExecutionSurface;
+    readonly status: SandboxExecutionStatus;
+    readonly cause?: unknown;
+  }) {
+    const reason = options.status.reason ?? "platform isolation is unavailable";
+    const remediation = options.status.remediation ??
+      "Run `agenc doctor`; select danger-full-access explicitly only when host execution is intended.";
+    super(
+      `[${options.code}] required sandbox blocked ${options.surface}: ${reason}. ${remediation}`,
+      options.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.name = "SandboxExecutionError";
+    this.code = options.code;
+    this.surface = options.surface;
+    this.status = options.status;
+  }
+}
+
+export function missingSandboxExecutionBoundary(
+  surface: SandboxExecutionSurface,
+): SandboxExecutionError {
+  return new SandboxExecutionError({
+    code: "sandbox_surface_uncovered",
+    surface,
+    status: {
+      kind: "unavailable",
+      mode: "unknown",
+      platform: process.platform,
+      reason: "no authenticated runtime policy or sandbox broker was supplied",
+      remediation:
+        "Start execution through an AgenC session or select danger-full-access explicitly through the trusted operator interface.",
+    },
+  });
+}
+
+export function requiredSandboxExecutionError(
+  surface: SandboxExecutionSurface,
+  status: SandboxExecutionStatus,
+): SandboxExecutionError {
+  return new SandboxExecutionError({
+    code: status.reason?.startsWith("probe:")
+      ? "sandbox_probe_failed"
+      : "sandbox_required_unavailable",
+    surface,
+    status,
+  });
+}
+
+export interface SandboxExecutionBrokerOptions {
+  readonly mode: SandboxMode;
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly agencLinuxSandboxExe?: string;
+  readonly useLegacyLandlock?: boolean;
+  readonly windowsSandboxLevel?: UnifiedExecRuntimeSandbox["windowsSandboxLevel"];
+  readonly windowsSandboxPrivateDesktop?: boolean;
+  readonly allowGpu?: boolean;
+  readonly platform?: NodeJS.Platform;
+  readonly sandboxManager?: SandboxExecutionManager;
+  /** Injectable only for deterministic platform/fault tests. */
+  readonly probe?: (options: {
+    readonly mode: SandboxMode;
+    readonly cwd: string;
+    readonly env: NodeJS.ProcessEnv;
+    readonly platform: NodeJS.Platform;
+    readonly agencLinuxSandboxExe?: string;
+  }) => SandboxExecutionStatus;
+}
+
+const defaultSandboxManager = new SandboxManager();
+
+export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
+  readonly mode: SandboxMode;
+  readonly required: boolean;
+  #cwd: string;
+  readonly #env: NodeJS.ProcessEnv;
+  readonly #platform: NodeJS.Platform;
+  readonly #sandboxManager: SandboxExecutionManager;
+  readonly #explicitLinuxHelper: string | undefined;
+  readonly #useLegacyLandlock: boolean;
+  readonly #windowsSandboxLevel: NonNullable<
+    UnifiedExecRuntimeSandbox["windowsSandboxLevel"]
+  >;
+  readonly #windowsSandboxPrivateDesktop: boolean;
+  readonly #allowGpu: boolean;
+  readonly #probe: NonNullable<SandboxExecutionBrokerOptions["probe"]>;
+  #status: SandboxExecutionStatus | undefined;
+
+  constructor(options: SandboxExecutionBrokerOptions) {
+    this.mode = options.mode;
+    this.required = sandboxModeRequiresPlatformIsolation(options.mode);
+    this.#cwd = path.resolve(options.cwd);
+    this.#env = { ...(options.env ?? process.env) };
+    this.#platform = options.platform ?? process.platform;
+    this.#sandboxManager = options.sandboxManager ?? defaultSandboxManager;
+    this.#explicitLinuxHelper = options.agencLinuxSandboxExe;
+    this.#useLegacyLandlock = options.useLegacyLandlock ?? false;
+    this.#windowsSandboxLevel = options.windowsSandboxLevel ?? "disabled";
+    this.#windowsSandboxPrivateDesktop =
+      options.windowsSandboxPrivateDesktop ?? false;
+    this.#allowGpu = options.allowGpu ?? false;
+    this.#probe = options.probe ?? probeSandboxExecutionStatus;
+  }
+
+  get cwd(): string {
+    return this.#cwd;
+  }
+
+  rebase(cwd: string): void {
+    const resolved = path.resolve(cwd);
+    if (resolved === this.#cwd) return;
+    this.#cwd = resolved;
+    this.#status = undefined;
+  }
+
+  forkForCwd(cwd: string): SandboxExecutionBroker {
+    return new SandboxExecutionBroker({
+      mode: this.mode,
+      cwd,
+      env: this.#env,
+      ...(this.#explicitLinuxHelper !== undefined
+        ? { agencLinuxSandboxExe: this.#explicitLinuxHelper }
+        : {}),
+      useLegacyLandlock: this.#useLegacyLandlock,
+      windowsSandboxLevel: this.#windowsSandboxLevel,
+      windowsSandboxPrivateDesktop: this.#windowsSandboxPrivateDesktop,
+      allowGpu: this.#allowGpu,
+      platform: this.#platform,
+      sandboxManager: this.#sandboxManager,
+      probe: this.#probe,
+    });
+  }
+
+  status(): SandboxExecutionStatus {
+    this.#status ??= this.#probe({
+      mode: this.mode,
+      cwd: this.#cwd,
+      env: this.#env,
+      platform: this.#platform,
+      ...(this.#explicitLinuxHelper !== undefined
+        ? { agencLinuxSandboxExe: this.#explicitLinuxHelper }
+        : {}),
+    });
+    return this.#status;
+  }
+
+  assertReady(surface: SandboxExecutionSurface): SandboxExecutionStatus {
+    const status = this.status();
+    if (!this.required || status.kind === "ready") return status;
+    throw requiredSandboxExecutionError(surface, status);
+  }
+
+  runtimeSandbox(
+    surface: SandboxExecutionSurface,
+  ): UnifiedExecRuntimeSandbox | undefined {
+    if (!this.required) return undefined;
+    const status = this.assertReady(surface);
+    return {
+      permissionProfile: permissionProfileForSandboxMode(this.mode, {
+        cwd: this.#cwd,
+      }),
+      sandboxPolicyCwd: this.#cwd,
+      preference: "require",
+      ...(status.helperPath !== undefined
+        ? { agencLinuxSandboxExe: status.helperPath }
+        : {}),
+      useLegacyLandlock: this.#useLegacyLandlock,
+      windowsSandboxLevel: this.#windowsSandboxLevel,
+      windowsSandboxPrivateDesktop: this.#windowsSandboxPrivateDesktop,
+      ...(this.#allowGpu ? { allowGpu: true } : {}),
+    };
+  }
+
+  prepareSpawn(
+    surface: SandboxExecutionSurface,
+    command: SandboxSpawnCommand,
+  ): SandboxSpawnCommand {
+    const runtimeSandbox = this.runtimeSandbox(surface);
+    if (runtimeSandbox === undefined) {
+      return {
+        ...command,
+        argv0: command.argv0 ?? basename(command.program),
+      };
+    }
+    try {
+      return transformSandboxedCommand({
+        ...command,
+        runtimeSandbox,
+        sandboxManager: this.#sandboxManager,
+      });
+    } catch (error) {
+      throw new SandboxExecutionError({
+        code: "sandbox_transform_failed",
+        surface,
+        status: {
+          ...this.status(),
+          reason: error instanceof Error ? error.message : String(error),
+        },
+        cause: error,
+      });
+    }
+  }
+}
+
+export function probeSandboxExecutionStatus(options: {
+  readonly mode: SandboxMode;
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform: NodeJS.Platform;
+  readonly agencLinuxSandboxExe?: string;
+}): SandboxExecutionStatus {
+  if (options.mode === "danger_full_access") {
+    return {
+      kind: "not_required",
+      mode: options.mode,
+      platform: options.platform,
+      reason: "danger-full-access was selected explicitly",
+    };
+  }
+  if (options.mode === "external_sandbox") {
+    return {
+      kind: "external",
+      mode: options.mode,
+      platform: options.platform,
+      reason: "an external sandbox was selected explicitly",
+    };
+  }
+  if (options.platform === "linux") {
+    return probeLinuxSandbox(options);
+  }
+  if (options.platform === "darwin") {
+    return probeMacOSSandbox(options);
+  }
+  return unavailableStatus(
+    options,
+    options.platform === "win32"
+      ? "Windows restricted-token sandbox is not implemented"
+      : `platform ${options.platform} has no supported sandbox`,
+    options.platform === "win32"
+      ? "Use WSL2 with bubblewrap, an explicit external sandbox, or select danger-full-access deliberately."
+      : "Use a supported platform or an explicit external sandbox.",
+  );
+}
+
+function probeLinuxSandbox(options: {
+  readonly mode: SandboxMode;
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform: NodeJS.Platform;
+  readonly agencLinuxSandboxExe?: string;
+}): SandboxExecutionStatus {
+  const helper = resolveTrustedLinuxSandboxExecutable(
+    options.agencLinuxSandboxExe ?? resolveDefaultLinuxSandboxExecutable(),
+    options.cwd,
+  );
+  if (helper.error !== undefined) {
+    return unavailableStatus(
+      options,
+      helper.error,
+      "Install AgenC with its executable sandbox helper outside the workspace, then run `agenc doctor` again.",
+    );
+  }
+  const bwrap = findSystemBubblewrapInPath(options.env.PATH, options.cwd);
+  if (bwrap === null) {
+    return unavailableStatus(
+      options,
+      "bubblewrap was not found in a trusted system directory",
+      "Install bubblewrap with the OS package manager, then run `agenc doctor` again.",
+      helper.path,
+    );
+  }
+  const result = spawnSync(
+    bwrap,
+    [
+      "--die-with-parent",
+      "--unshare-user",
+      "--unshare-pid",
+      "--unshare-net",
+      "--ro-bind",
+      "/",
+      "/",
+      "--",
+      "/bin/true",
+    ],
+    {
+      cwd: options.cwd,
+      env: sanitizeSandboxLauncherEnvironment(options.env),
+      encoding: "utf8",
+      timeout: 3_000,
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  if (result.error !== undefined || result.status !== 0) {
+    const detail = boundedDiagnostic(
+      result.error?.message ?? result.stderr ?? `exit status ${String(result.status)}`,
+    );
+    return unavailableStatus(
+      options,
+      `probe: bubblewrap could not create the required namespaces${detail ? ` (${detail})` : ""}`,
+      "Enable unprivileged user namespaces or use a supported container/WSL2 host, then run `agenc doctor` again.",
+      helper.path,
+      bwrap,
+    );
+  }
+  return {
+    kind: "ready",
+    mode: options.mode,
+    platform: options.platform,
+    helperPath: helper.path,
+    isolationProgram: bwrap,
+  };
+}
+
+function probeMacOSSandbox(options: {
+  readonly mode: SandboxMode;
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform: NodeJS.Platform;
+}): SandboxExecutionStatus {
+  const program = "/usr/bin/sandbox-exec";
+  const executable = executableFile(program);
+  if (!executable.ok) {
+    return unavailableStatus(
+      options,
+      executable.reason,
+      "Restore the system sandbox-exec binary or select an explicit external sandbox.",
+    );
+  }
+  const result = spawnSync(
+    program,
+    [
+      "-p",
+      "(version 1) (deny default) (allow process-exec) (allow file-read*)",
+      "/usr/bin/true",
+    ],
+    {
+      cwd: options.cwd,
+      env: sanitizeSandboxLauncherEnvironment(options.env),
+      encoding: "utf8",
+      timeout: 3_000,
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  if (result.error !== undefined || result.status !== 0) {
+    const detail = boundedDiagnostic(
+      result.error?.message ?? result.stderr ?? `exit status ${String(result.status)}`,
+    );
+    return unavailableStatus(
+      options,
+      `probe: sandbox-exec failed its restricted-process check${detail ? ` (${detail})` : ""}`,
+      "Repair the macOS sandbox facility or select an explicit external sandbox.",
+      undefined,
+      program,
+    );
+  }
+  return {
+    kind: "ready",
+    mode: options.mode,
+    platform: options.platform,
+    isolationProgram: program,
+  };
+}
+
+function unavailableStatus(
+  options: {
+    readonly mode: SandboxMode;
+    readonly platform: NodeJS.Platform;
+  },
+  reason: string,
+  remediation: string,
+  helperPath?: string,
+  isolationProgram?: string,
+): SandboxExecutionStatus {
+  return {
+    kind: "unavailable",
+    mode: options.mode,
+    platform: options.platform,
+    reason,
+    remediation,
+    ...(helperPath !== undefined ? { helperPath } : {}),
+    ...(isolationProgram !== undefined ? { isolationProgram } : {}),
+  };
+}
+
+export function resolveTrustedLinuxSandboxExecutable(
+  candidate: string,
+  workspaceRoot: string,
+): { readonly path: string; readonly error?: undefined } | {
+  readonly path?: undefined;
+  readonly error: string;
+} {
+  const resolved = path.resolve(candidate);
+  const executable = executableFile(resolved);
+  if (!executable.ok) return { error: executable.reason };
+  const helperReal = safeRealpath(resolved);
+  const workspaceReal = safeRealpath(workspaceRoot);
+  if (isPathUnder(helperReal, workspaceReal)) {
+    return { error: "Linux sandbox helper must be outside the writable workspace" };
+  }
+  return { path: helperReal };
+}
+
+function executableFile(
+  target: string,
+): { readonly ok: true } | { readonly ok: false; readonly reason: string } {
+  try {
+    const stat = statSync(target);
+    if (!stat.isFile()) {
+      return { ok: false, reason: `sandbox executable is not a file: ${target}` };
+    }
+    if ((stat.mode & 0o111) === 0) {
+      return { ok: false, reason: `sandbox executable is not executable: ${target}` };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: `sandbox executable does not exist: ${target}` };
+  }
+}
+
+export function resolveDefaultLinuxSandboxExecutable(
+  moduleUrl = import.meta.url,
+): string {
+  const runtimeRoot = resolveRuntimePackageRootFromUrl(moduleUrl);
+  return runtimeRoot === null
+    ? fileURLToPath(new URL("../../bin/agenc-linux-sandbox", moduleUrl))
+    : path.join(runtimeRoot, "bin", "agenc-linux-sandbox");
+}
+
+function safeRealpath(target: string): string {
+  try {
+    return realpathSync(target);
+  } catch {
+    return path.resolve(target);
+  }
+}
+
+function isPathUnder(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" ||
+    (relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function boundedDiagnostic(value: string): string {
+  return value.replace(/\s+/gu, " ").trim().slice(0, 300);
+}
+
+export function transformSandboxedCommand(params: SandboxSpawnCommand & {
+  readonly runtimeSandbox: UnifiedExecRuntimeSandbox;
+  readonly sandboxManager?: SandboxExecutionManager;
+}): SandboxSpawnCommand {
+  const sandboxManager = params.sandboxManager ?? defaultSandboxManager;
+  const permissions = params.runtimeSandbox.permissionProfile;
+  const windowsSandboxLevel =
+    params.runtimeSandbox.windowsSandboxLevel ?? "disabled";
+  let sandbox: SandboxType = "none";
+  try {
+    sandbox = sandboxManager.selectInitial({
+      fileSystemPolicy: permissions.fileSystem,
+      networkPolicy: permissions.network,
+      preference: params.runtimeSandbox.preference ?? "require",
+      windowsSandboxLevel,
+      hasManagedNetworkRequirements:
+        params.runtimeSandbox.enforceManagedNetwork === true ||
+        params.runtimeSandbox.network !== undefined,
+    });
+    if (
+      sandbox === "none" &&
+      (params.runtimeSandbox.preference ?? "require") === "require"
+    ) {
+      throw new UnifiedExecError(
+        "create_process",
+        "sandbox isolation was required but no platform sandbox is available",
+      );
+    }
+    const transformed = sandboxManager.transform({
+      command: {
+        program: params.program,
+        args: params.args,
+        cwd: params.cwd,
+        env: params.env,
+        ...(params.runtimeSandbox.additionalPermissions !== undefined
+          ? { additionalPermissions: params.runtimeSandbox.additionalPermissions }
+          : {}),
+      },
+      permissions,
+      sandbox,
+      enforceManagedNetwork:
+        params.runtimeSandbox.enforceManagedNetwork ?? false,
+      ...(params.runtimeSandbox.network !== undefined
+        ? { network: params.runtimeSandbox.network }
+        : {}),
+      ...(params.runtimeSandbox.networkPolicyDecider !== undefined
+        ? { networkPolicyDecider: params.runtimeSandbox.networkPolicyDecider }
+        : {}),
+      ...(params.runtimeSandbox.blockedRequestObserver !== undefined
+        ? { blockedRequestObserver: params.runtimeSandbox.blockedRequestObserver }
+        : {}),
+      sandboxPolicyCwd: params.runtimeSandbox.sandboxPolicyCwd,
+      ...(params.runtimeSandbox.agencLinuxSandboxExe !== undefined
+        ? { agencLinuxSandboxExe: params.runtimeSandbox.agencLinuxSandboxExe }
+        : {}),
+      useLegacyLandlock: params.runtimeSandbox.useLegacyLandlock ?? false,
+      windowsSandboxLevel,
+      windowsSandboxPrivateDesktop:
+        params.runtimeSandbox.windowsSandboxPrivateDesktop ?? false,
+      ...(params.runtimeSandbox.allowGpu === true ? { allowGpu: true } : {}),
+    });
+    const [program, ...args] = transformed.command;
+    if (program === undefined) {
+      throw new UnifiedExecError(
+        "create_process",
+        "sandbox transform returned an empty command",
+      );
+    }
+    return {
+      program,
+      args,
+      cwd: transformed.cwd,
+      env: { ...transformed.env },
+      argv0: transformed.arg0 ?? basename(program),
+    };
+  } catch (error) {
+    if (error instanceof UnifiedExecError) throw error;
+    throw new UnifiedExecError(
+      "create_process",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+const BROKER_MARKER = Symbol("agenc.sandboxExecutionBroker");
+const BROKER_ARG = "__sandboxExecutionBroker";
+const SURFACE_ARG = "__sandboxExecutionSurface";
+const EXECUTION_SURFACES = new Set<SandboxExecutionSurface>([
+  "interactive",
+  "print",
+  "background",
+  "workflow",
+  "job",
+  "hook",
+  "cron",
+  "mcp_stdio",
+  "child_agent",
+  "command_exec",
+  "tool",
+]);
+
+export function attachSandboxExecutionBroker(
+  args: Record<string, unknown>,
+  broker: SandboxExecutionBrokerLike,
+  surface?: SandboxExecutionSurface,
+): void {
+  if ((broker as { [BROKER_MARKER]?: unknown })[BROKER_MARKER] !== true) {
+    Object.defineProperty(broker, BROKER_MARKER, {
+      value: true,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+  Object.defineProperty(args, BROKER_ARG, {
+    value: broker,
+    enumerable: false,
+    configurable: true,
+  });
+  if (surface !== undefined) {
+    Object.defineProperty(args, SURFACE_ARG, {
+      value: surface,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}
+
+export function readSandboxExecutionBroker(
+  args: Record<string, unknown>,
+): SandboxExecutionBrokerLike | undefined {
+  const value = args[BROKER_ARG];
+  if (typeof value !== "object" || value === null) return undefined;
+  if ((value as { [BROKER_MARKER]?: unknown })[BROKER_MARKER] !== true) {
+    return undefined;
+  }
+  const candidate = value as Partial<SandboxExecutionBrokerLike>;
+  return typeof candidate.prepareSpawn === "function" &&
+    typeof candidate.runtimeSandbox === "function" &&
+    typeof candidate.assertReady === "function" &&
+    typeof candidate.cwd === "string" &&
+    typeof candidate.rebase === "function" &&
+    typeof candidate.forkForCwd === "function"
+    ? (value as SandboxExecutionBrokerLike)
+    : undefined;
+}
+
+export function readSandboxExecutionSurface(
+  args: Record<string, unknown>,
+): SandboxExecutionSurface | undefined {
+  if (readSandboxExecutionBroker(args) === undefined) return undefined;
+  const value = args[SURFACE_ARG];
+  return typeof value === "string" &&
+      EXECUTION_SURFACES.has(value as SandboxExecutionSurface)
+    ? value as SandboxExecutionSurface
+    : undefined;
+}

--- a/runtime/src/sandbox/launcher-environment.ts
+++ b/runtime/src/sandbox/launcher-environment.ts
@@ -1,0 +1,37 @@
+/**
+ * Build the environment used by a process that must establish the sandbox
+ * before any caller-controlled code can run.
+ *
+ * These variables can make a language runtime or the native loader execute
+ * code before bubblewrap/seatbelt has installed isolation. They are therefore
+ * never inherited by sandbox launchers. Ordinary variables (including PATH)
+ * remain available to the command once the launcher has established policy.
+ */
+export function sanitizeSandboxLauncherEnvironment(
+  env: Readonly<Record<string, string | undefined>>,
+): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined || isSandboxLauncherInjectionKey(key)) continue;
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
+export function isSandboxLauncherInjectionKey(key: string): boolean {
+  const upper = key.toUpperCase();
+  return upper === "NODE_OPTIONS" ||
+    upper === "NODE_PATH" ||
+    upper === "ELECTRON_RUN_AS_NODE" ||
+    upper === "BUN_OPTIONS" ||
+    upper === "GCONV_PATH" ||
+    upper === "LOCPATH" ||
+    upper === "NLSPATH" ||
+    upper === "MALLOC_TRACE" ||
+    upper === "MALLOC_CHECK_" ||
+    upper === "GLIBC_TUNABLES" ||
+    upper === "LIBPATH" ||
+    upper === "SHLIB_PATH" ||
+    upper.startsWith("LD_") ||
+    upper.startsWith("DYLD_");
+}

--- a/runtime/src/services/autoFix/autoFixHook.ts
+++ b/runtime/src/services/autoFix/autoFixHook.ts
@@ -27,6 +27,7 @@ import {
   type AutoFixCheckOptions,
   type AutoFixResult,
 } from "./autoFixRunner.js";
+import type { SandboxExecutionBrokerLike } from "../../sandbox/execution-broker.js";
 
 const AUTO_FIX_TOOLS = new Set([
   FILE_EDIT_TOOL_NAME,
@@ -41,6 +42,7 @@ const AUTO_FIX_TOOLS = new Set([
 export interface AutoFixPostToolHookOptions {
   readonly configSource: () => unknown;
   readonly cwd: string;
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
   readonly retryScope?: (input: Parameters<PostToolUseHook>[0]) => string;
   readonly runCheck?: (options: AutoFixCheckOptions) => Promise<AutoFixResult>;
   readonly onError?: (error: unknown) => void;
@@ -117,6 +119,7 @@ export function createAutoFixPostToolHook(
         timeout: config.timeout,
         cwd: options.cwd,
         signal: input.signal,
+        sandboxExecutionBroker: options.sandboxExecutionBroker,
       });
       const context = buildAutoFixContext(result);
       if (context) {

--- a/runtime/src/services/autoFix/autoFixRunner.ts
+++ b/runtime/src/services/autoFix/autoFixRunner.ts
@@ -14,6 +14,11 @@
 
 import { spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
+import {
+  missingSandboxExecutionBoundary,
+  type SandboxExecutionBrokerLike,
+} from "../../sandbox/execution-broker.js";
+import { scrubEnvForChildProcess } from "../../unified-exec/scrub-env.js";
 
 export interface AutoFixCheckOptions {
   readonly lint?: string;
@@ -21,6 +26,7 @@ export interface AutoFixCheckOptions {
   readonly timeout: number;
   readonly cwd: string;
   readonly signal?: AbortSignal;
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
 }
 
 export interface AutoFixResult {
@@ -74,8 +80,25 @@ async function runCommand(
   command: string,
   cwd: string,
   timeout: number,
+  sandboxExecutionBroker: SandboxExecutionBrokerLike | undefined,
   signal?: AbortSignal,
 ): Promise<CommandResult> {
+  if (sandboxExecutionBroker === undefined) {
+    throw missingSandboxExecutionBoundary("hook");
+  }
+  const isWindows = process.platform === "win32";
+  const shellProgram = isWindows
+    ? process.env.ComSpec ?? "cmd.exe"
+    : process.env.SHELL ?? "/bin/sh";
+  const shellArgs = isWindows
+    ? ["/d", "/s", "/c", command]
+    : ["-c", command];
+  const spawnCommand = sandboxExecutionBroker.prepareSpawn("hook", {
+    program: shellProgram,
+    args: shellArgs,
+    cwd,
+    env: scrubEnvForChildProcess(process.env),
+  });
   return new Promise((resolve) => {
     if (signal?.aborted) {
       resolve({ stdout: "", stderr: "Aborted", exitCode: 1, timedOut: false });
@@ -94,11 +117,10 @@ async function runCommand(
     const errDecoder = new StringDecoder("utf8");
     let timer: NodeJS.Timeout | undefined;
     let forceTimer: NodeJS.Timeout | undefined;
-    const isWindows = process.platform === "win32";
-    const proc = spawn(command, [], {
-      cwd,
-      env: { ...process.env },
-      shell: true,
+    const proc = spawn(spawnCommand.program, [...spawnCommand.args], {
+      cwd: spawnCommand.cwd,
+      env: spawnCommand.env,
+      argv0: spawnCommand.argv0,
       windowsHide: true,
       detached: !isWindows,
     });
@@ -238,7 +260,14 @@ function buildErrorSummary(result: AutoFixResult): string | undefined {
 export async function runAutoFixCheck(
   options: AutoFixCheckOptions,
 ): Promise<AutoFixResult> {
-  const { lint, test, timeout, cwd, signal } = options;
+  const {
+    lint,
+    test,
+    timeout,
+    cwd,
+    signal,
+    sandboxExecutionBroker,
+  } = options;
 
   if (!lint && !test) {
     return { hasErrors: false };
@@ -258,7 +287,13 @@ export async function runAutoFixCheck(
   } = { hasErrors: false };
 
   if (lint) {
-    const lintResult = await runCommand(lint, cwd, timeout, signal);
+    const lintResult = await runCommand(
+      lint,
+      cwd,
+      timeout,
+      sandboxExecutionBroker,
+      signal,
+    );
     result.lintOutput = cappedCombinedOutput(lintResult.stdout, lintResult.stderr);
     result.lintExitCode = lintResult.exitCode;
 
@@ -276,7 +311,13 @@ export async function runAutoFixCheck(
   }
 
   if (test) {
-    const testResult = await runCommand(test, cwd, timeout, signal);
+    const testResult = await runCommand(
+      test,
+      cwd,
+      timeout,
+      sandboxExecutionBroker,
+      signal,
+    );
     result.testOutput = cappedCombinedOutput(testResult.stdout, testResult.stderr);
     result.testExitCode = testResult.exitCode;
 

--- a/runtime/src/session/mcp-startup.ts
+++ b/runtime/src/session/mcp-startup.ts
@@ -79,6 +79,7 @@ export interface CreateSessionMcpServiceOptions {
 export interface ResolveSessionMcpConfigSourcesOptions {
   readonly cwd?: string;
   readonly includeProjectMcpServers?: boolean;
+  readonly sandboxExecutionBroker?: import("../sandbox/execution-broker.js").SandboxExecutionBrokerLike;
 }
 
 type ConfiguredServerWithExtras = MCPServerConfig & {
@@ -170,8 +171,14 @@ function buildEffectiveServerMap(
  */
 export function createSessionMcpManager(
   configs: ReadonlyArray<MCPServerConfig>,
+  options: Pick<
+    ResolveSessionMcpConfigSourcesOptions,
+    "sandboxExecutionBroker"
+  > = {},
 ): MCPManager {
-  return new LiveMCPManager([...configs]);
+  const manager = new LiveMCPManager([...configs]);
+  manager.setSandboxExecutionBroker(options.sandboxExecutionBroker);
+  return manager;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -691,8 +698,12 @@ export async function resolveSessionMcpConfigFromSources(
 export function createSessionMcpManagerFromConfig(
   config: Pick<AgenCConfig, "mcp_servers"> | undefined,
   env: NodeJS.ProcessEnv = process.env,
+  options: Pick<
+    ResolveSessionMcpConfigSourcesOptions,
+    "sandboxExecutionBroker"
+  > = {},
 ): MCPManager {
-  return createSessionMcpManager(resolveSessionMcpConfig(config, env));
+  return createSessionMcpManager(resolveSessionMcpConfig(config, env), options);
 }
 
 export async function createSessionMcpManagerFromSources(
@@ -702,6 +713,7 @@ export async function createSessionMcpManagerFromSources(
 ): Promise<MCPManager> {
   return createSessionMcpManager(
     await resolveSessionMcpConfigFromSources(config, env, options),
+    options,
   );
 }
 
@@ -713,8 +725,12 @@ export async function createSessionMcpManagerFromSources(
 export function createSessionMcpManagerFromEnv(
   env: NodeJS.ProcessEnv = process.env,
   config?: Pick<AgenCConfig, "mcp_servers">,
+  options: Pick<
+    ResolveSessionMcpConfigSourcesOptions,
+    "sandboxExecutionBroker"
+  > = {},
 ): MCPManager {
-  return createSessionMcpManager(resolveSessionMcpConfig(config, env));
+  return createSessionMcpManager(resolveSessionMcpConfig(config, env), options);
 }
 
 export function requiredMcpServerNames(

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -78,6 +78,7 @@ import type { BudgetTracker } from "../conversation/token-budget.js";
 import type { SessionSubmitOptions } from "./autonomous-mode.js";
 import type { CostSidecar } from "./cost.js";
 import type { ConfiguredHooksRuntime } from "../hooks/configured-hooks.js";
+import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import type { UserPromptSubmitHook } from "../hooks/user-prompt-submit.js";
 import type { ToolRegistry } from "./_deps/tool-registry.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
@@ -719,6 +720,8 @@ export interface SessionServices {
   readonly mcpConnectionManager: McpConnectionManager;
   readonly mcpStartupCancellationToken: McpStartupCancellationToken;
   readonly unifiedExecManager: UnifiedExecProcessManager;
+  /** Final fail-closed boundary for every process spawned on behalf of a session. */
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
   readonly shellZshPath?: string;
   readonly mainExecveWrapperExe?: string;
   readonly hooks: Hooks;

--- a/runtime/src/session/turn-compat.ts
+++ b/runtime/src/session/turn-compat.ts
@@ -12,6 +12,15 @@ import type { ToolPermissionContext } from "../permissions/types.js";
 import type { ToolRegistry, ToolDispatchResult } from "../tool-registry.js";
 import type { CanUseToolFn } from "../tui/hooks/useCanUseTool.js";
 import type { Tool, ToolResult, ToolUseContext } from "../tools/Tool.js";
+import {
+  attachToolRuntimeContext,
+  readToolRuntimeContext,
+} from "../tools/runtimes/context.js";
+import {
+  attachSandboxExecutionBroker,
+  readSandboxExecutionBroker,
+  readSandboxExecutionSurface,
+} from "../sandbox/execution-broker.js";
 import { frameUntrustedToolHistoryMessages } from "../tools/untrusted-tool-result-framing.js";
 import type { AttachmentMessage, Message } from "../types/message.js";
 import { appendSystemContext, prependUserContext } from "../utils/api.js";
@@ -110,15 +119,30 @@ export async function createTurnCompatSession(
   const { history, userMessage } = splitMessagesForTurn(
     prependUserContext([...params.messages], params.userContext),
   );
-  const registry = await createToolRegistryFromToolContext({
-    tools: params.toolUseContext.options.tools,
-    toolUseContext: params.toolUseContext,
-    canUseTool: params.canUseTool,
-  });
   const effectiveCwd =
     getCwdOverrideForCurrentContext() ??
     parent.sessionConfiguration.cwd ??
     parent.config.cwd;
+  const sandboxExecutionBroker =
+    parent.services.sandboxExecutionBroker?.forkForCwd(effectiveCwd);
+  const scopedToolUseContext = sandboxExecutionBroker === undefined
+    ? params.toolUseContext
+    : {
+        ...params.toolUseContext,
+        services: {
+          ...(
+            params.toolUseContext as ToolUseContext & {
+              readonly services?: Record<string, unknown>;
+            }
+          ).services,
+          sandboxExecutionBroker,
+        },
+      } as ToolUseContext;
+  const registry = await createToolRegistryFromToolContext({
+    tools: scopedToolUseContext.options.tools,
+    toolUseContext: scopedToolUseContext,
+    canUseTool: params.canUseTool,
+  });
   const sessionConfiguration = {
     ...parent.sessionConfiguration,
     cwd: effectiveCwd,
@@ -142,6 +166,9 @@ export async function createTurnCompatSession(
     services: {
       ...parent.services,
       registry,
+      ...(sandboxExecutionBroker !== undefined
+        ? { sandboxExecutionBroker }
+        : {}),
       hooks: {
         ...parent.services.hooks,
         preToolUseHooks: [],
@@ -179,7 +206,7 @@ export async function createTurnCompatSession(
         : {}),
     },
   });
-  attachToolContextSurface(session, params.toolUseContext);
+  attachToolContextSurface(session, scopedToolUseContext);
   return {
     session,
     history,
@@ -1015,6 +1042,7 @@ function runtimeToolFromOldTool(
         ? args.__callId
         : randomUUID();
       const input = stripInjectedArgs(args);
+      copyExecutionBoundary(args, input);
       const injectedProgress =
         typeof args.__onProgress === "function"
           ? args.__onProgress as (event: { chunk: string; stream?: "status" }) => void
@@ -1060,8 +1088,10 @@ function runtimeToolFromOldTool(
           },
         };
       }
+      const callInput = permission.updatedInput ?? input;
+      copyExecutionBoundary(input, callInput);
       const result = await tool.call(
-        permission.updatedInput ?? input,
+        callInput,
         toolContext,
         canUseTool,
         parentMessage,
@@ -1103,6 +1133,24 @@ function stripInjectedArgs(args: Record<string, unknown>): Record<string, unknow
     clean[key] = value;
   }
   return clean;
+}
+
+function copyExecutionBoundary(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+): void {
+  const runtimeContext = readToolRuntimeContext(source);
+  if (runtimeContext !== undefined) {
+    attachToolRuntimeContext(target, runtimeContext);
+  }
+  const broker = readSandboxExecutionBroker(source);
+  if (broker !== undefined) {
+    attachSandboxExecutionBroker(
+      target,
+      broker,
+      readSandboxExecutionSurface(source),
+    );
+  }
 }
 
 function oldToolResultToDispatchResult(

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -502,6 +502,7 @@ export interface Config {
   readonly ghostSnapshot: GhostSnapshotConfig;
   readonly agencSelfExe?: string;
   readonly agencLinuxSandboxExe?: string;
+  readonly sandboxUnavailableReason?: string;
   readonly agentRoles: ReadonlyArray<{ name: string; description: string }>;
   readonly agent_max_threads?: number;
   readonly agent_max_depth?: number;
@@ -686,6 +687,7 @@ export interface TurnContext {
 
   /** Linux sandbox helper exe path. */
   readonly agencLinuxSandboxExe?: string;
+  readonly sandboxUnavailableReason?: string;
 
   /** Tool-call readiness gate (set when tools are ready to dispatch). T7 wires. */
   readonly toolCallGate: ReadinessFlag;
@@ -1304,6 +1306,7 @@ export function buildTurnContext(opts: BuildTurnContextOptions): TurnContext {
     finalOutputJsonSchema: undefined,
     agencSelfExe: frozenConfig.agencSelfExe,
     agencLinuxSandboxExe: frozenConfig.agencLinuxSandboxExe,
+    sandboxUnavailableReason: frozenConfig.sandboxUnavailableReason,
     toolCallGate: new ReadinessFlag(),
     truncationPolicy: opts.modelInfo.truncationPolicy,
     jsRepl: opts.jsRepl ?? { id: `repl-${opts.conversationId}-${opts.subId}` },

--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -76,6 +76,10 @@ import {
   toolConfigAllowsTool,
 } from "./tools/config.js";
 import { canonicalModelToolName } from "./tools/model-tool-aliases.js";
+import {
+  attachSandboxExecutionBroker,
+  type SandboxExecutionBrokerLike,
+} from "./sandbox/execution-broker.js";
 
 export interface ToolDispatchResult {
   readonly content: string;
@@ -476,6 +480,8 @@ export interface BuildToolRegistryOptions {
   readonly bashExecObserver?: BashExecObserver;
   /** Shared AgenC-style unified exec process manager for exec_command/write_stdin. */
   readonly unifiedExecManager?: UnifiedExecProcessManagerLike;
+  /** Authenticated policy for callers that use registry.dispatch directly. */
+  readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
   /**
    * Live MCP tool source. This is intentionally a provider instead of a
    * one-time array because MCP startup happens after SessionConfigured.
@@ -954,6 +960,15 @@ export function buildToolRegistry(
         enumerable: false,
         configurable: true,
       });
+    }
+    if (options.sandboxExecutionBroker !== undefined) {
+      attachSandboxExecutionBroker(
+        args,
+        options.sandboxExecutionBroker,
+        args.run_in_background === true || args.runInBackground === true
+          ? "background"
+          : "tool",
+      );
     }
     const result = await spec.tool.execute(args);
     return {

--- a/runtime/src/tools/EnterWorktreeTool/EnterWorktreeTool.ts
+++ b/runtime/src/tools/EnterWorktreeTool/EnterWorktreeTool.ts
@@ -18,6 +18,10 @@ import {
 import { ENTER_WORKTREE_TOOL_NAME } from './constants.js'
 import { getEnterWorktreeToolPrompt } from './prompt.js'
 import { renderToolResultMessage, renderToolUseMessage } from './UI.js'
+import {
+  rebaseWorktreeSandboxBrokers,
+  requireWorktreeSandboxBrokers,
+} from '../worktree-sandbox-boundary.js'
 
 const inputSchema = lazySchema(() =>
   z.strictObject({
@@ -73,7 +77,9 @@ export const EnterWorktreeTool: Tool<InputSchema, Output> = buildTool({
   },
   renderToolUseMessage,
   renderToolResultMessage,
-  async call(input) {
+  async call(input, toolUseContext) {
+    const sandboxExecutionBrokers =
+      requireWorktreeSandboxBrokers(toolUseContext)
     // Validate not already in a worktree created by this session
     if (getCurrentWorktreeSession()) {
       throw new Error('Already in a worktree session')
@@ -92,6 +98,10 @@ export const EnterWorktreeTool: Tool<InputSchema, Output> = buildTool({
 
     process.chdir(worktreeSession.worktreePath)
     setCwd(worktreeSession.worktreePath)
+    rebaseWorktreeSandboxBrokers(
+      sandboxExecutionBrokers,
+      worktreeSession.worktreePath,
+    )
     setOriginalCwd(getCwd())
     saveWorktreeState(worktreeSession)
     // Clear cached system prompt sections so env_info_simple recomputes with worktree context

--- a/runtime/src/tools/ExitWorktreeTool/ExitWorktreeTool.ts
+++ b/runtime/src/tools/ExitWorktreeTool/ExitWorktreeTool.ts
@@ -25,6 +25,10 @@ import {
 import { EXIT_WORKTREE_TOOL_NAME } from './constants.js'
 import { getExitWorktreeToolPrompt } from './prompt.js'
 import { renderToolResultMessage, renderToolUseMessage } from './UI.js'
+import {
+  rebaseWorktreeSandboxBrokers,
+  requireWorktreeSandboxBrokers,
+} from '../worktree-sandbox-boundary.js'
 
 const inputSchema = lazySchema(() =>
   z.strictObject({
@@ -223,7 +227,9 @@ export const ExitWorktreeTool: Tool<InputSchema, Output> = buildTool({
   },
   renderToolUseMessage,
   renderToolResultMessage,
-  async call(input) {
+  async call(input, toolUseContext) {
+    const sandboxExecutionBrokers =
+      requireWorktreeSandboxBrokers(toolUseContext)
     const session = getCurrentWorktreeSession()
     if (!session) {
       // validateInput guards this, but the session is module-level mutable
@@ -260,6 +266,7 @@ export const ExitWorktreeTool: Tool<InputSchema, Output> = buildTool({
     if (input.action === 'keep') {
       await keepWorktree()
       restoreSessionToOriginalCwd(originalCwd, projectRootIsWorktree)
+      rebaseWorktreeSandboxBrokers(sandboxExecutionBrokers, originalCwd)
 
       const tmuxNote = tmuxSessionName
         ? ` Tmux session ${tmuxSessionName} is still running; reattach with: tmux attach -t ${tmuxSessionName}`
@@ -282,6 +289,7 @@ export const ExitWorktreeTool: Tool<InputSchema, Output> = buildTool({
     }
     await cleanupWorktree()
     restoreSessionToOriginalCwd(originalCwd, projectRootIsWorktree)
+    rebaseWorktreeSandboxBrokers(sandboxExecutionBrokers, originalCwd)
 
     const discardParts: string[] = []
     if (commits > 0) {

--- a/runtime/src/tools/MonitorTool/MonitorTool.ts
+++ b/runtime/src/tools/MonitorTool/MonitorTool.ts
@@ -12,6 +12,8 @@ import {
   permissionRuleExtractPrefix,
 } from '../BashTool/bashPermissions.js'
 import { parseForSecurity } from '../../utils/bash/ast.js'
+import type { SandboxExecutionBrokerLike } from '../../sandbox/execution-broker.js'
+import { peekAmbientRuntimeSession } from '../../session/current-session.js'
 
 const MONITOR_TOOL_NAME = 'Monitor'
 
@@ -148,6 +150,25 @@ export const MonitorTool = buildTool({
   async call(input, toolUseContext) {
     const { command, description } = input
     const { abortController, setAppState } = toolUseContext
+    const extendedContext = toolUseContext as typeof toolUseContext & {
+      readonly services?: {
+        readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike
+      }
+      readonly session?: {
+        readonly services?: {
+          readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike
+        }
+      }
+    }
+    const sandboxExecutionBroker =
+      extendedContext.services?.sandboxExecutionBroker ??
+      extendedContext.session?.services?.sandboxExecutionBroker ??
+      peekAmbientRuntimeSession()?.services.sandboxExecutionBroker
+    if (sandboxExecutionBroker === undefined) {
+      throw new Error(
+        '[sandbox_surface_uncovered] Monitor execution has no session sandbox boundary',
+      )
+    }
 
     // Create the shell command — uses the same Shell.exec() as BashTool.
     // This is intentionally a shell execution (not execFile) because
@@ -157,7 +178,13 @@ export const MonitorTool = buildTool({
       command,
       abortController.signal,
       'bash',
-      { timeout: MONITOR_TIMEOUT_MS },
+      {
+        timeout: MONITOR_TIMEOUT_MS,
+        sandboxExecutionBroker,
+        sandboxExecutionSurface: toolUseContext.agentId
+          ? 'child_agent'
+          : 'background',
+      },
     )
 
     // Spawn as a background task with kind='monitor' — identical to

--- a/runtime/src/tools/PowerShellTool/PowerShellTool.tsx
+++ b/runtime/src/tools/PowerShellTool/PowerShellTool.tsx
@@ -40,6 +40,13 @@ import { powershellToolHasPermission } from './powershellPermissions.js';
 import { getDefaultTimeoutMs, getMaxTimeoutMs, getPrompt } from './prompt.js';
 import { hasSyncSecurityConcerns, isReadOnlyCommand, resolveToCanonical } from './readOnlyValidation.js';
 import { POWERSHELL_TOOL_NAME } from './toolName.js';
+import {
+  SandboxExecutionError,
+  missingSandboxExecutionBoundary,
+  type SandboxExecutionBrokerLike,
+  type SandboxExecutionSurface,
+} from '../../sandbox/execution-broker.js';
+import { peekAmbientRuntimeSession } from '../../session/current-session.js';
 import { renderToolResultMessage, renderToolUseErrorMessage, renderToolUseMessage, renderToolUseProgressMessage, renderToolUseQueuedMessage } from './UI.js';
 // Never use os.EOL for terminal output — \r\n on Windows breaks Ink rendering
 const EOL = '\n';
@@ -447,6 +454,19 @@ export const PowerShellTool = buildTool({
       setToolJSX
     } = toolUseContext;
     const isMainThread = !toolUseContext.agentId;
+    const sandboxExecutionSurface: SandboxExecutionSurface =
+      toolUseContext.agentId
+        ? 'child_agent'
+        : input.run_in_background
+          ? 'background'
+          : toolUseContext.options?.isNonInteractiveSession
+            ? 'print'
+            : 'interactive';
+    const sandboxExecutionBroker = readSandboxExecutionBroker(toolUseContext);
+    if (sandboxExecutionBroker === undefined) {
+      throw missingSandboxExecutionBoundary(sandboxExecutionSurface);
+    }
+    sandboxExecutionBroker.assertReady(sandboxExecutionSurface);
     let progressCounter = 0;
     try {
       const commandGenerator = runPowerShellCommand({
@@ -459,7 +479,9 @@ export const PowerShellTool = buildTool({
         preventCwdChanges: !isMainThread,
         isMainThread,
         toolUseId: toolUseContext.toolUseId,
-        agentId: toolUseContext.agentId
+        agentId: toolUseContext.agentId,
+        sandboxExecutionBroker,
+        sandboxExecutionSurface
       });
       let generatorResult;
       do {
@@ -658,7 +680,9 @@ async function* runPowerShellCommand({
   preventCwdChanges,
   isMainThread,
   toolUseId,
-  agentId
+  agentId,
+  sandboxExecutionBroker,
+  sandboxExecutionSurface
 }: {
   input: PowerShellToolInput;
   abortController: AbortController;
@@ -668,6 +692,8 @@ async function* runPowerShellCommand({
   isMainThread?: boolean;
   toolUseId?: string;
   agentId?: AgentId;
+  sandboxExecutionBroker: SandboxExecutionBrokerLike;
+  sandboxExecutionSurface: SandboxExecutionSurface;
 }): AsyncGenerator<{
   type: 'progress';
   output: string;
@@ -739,9 +765,12 @@ async function* runPowerShellCommand({
         dangerouslyDisableSandbox,
         _dangerouslyDisableSandboxApproved
       }),
-      shouldAutoBackground
+      shouldAutoBackground,
+      sandboxExecutionBroker,
+      sandboxExecutionSurface
     });
   } catch (e) {
+    if (e instanceof SandboxExecutionError) throw e;
     logError(e);
     // Pre-flight failure: spawn/exec rejected before the command ran. Use
     // code 0 so call() returns stderr gracefully instead of throwing ShellError.
@@ -978,4 +1007,18 @@ async function* runPowerShellCommand({
       shellCommand.cleanup();
     }
   }
+}
+
+function readSandboxExecutionBroker(
+  context: Parameters<Tool['call']>[1],
+): SandboxExecutionBrokerLike | undefined {
+  const extended = context as Parameters<Tool['call']>[1] & {
+    readonly services?: { readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike };
+    readonly session?: {
+      readonly services?: { readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike };
+    };
+  };
+  return extended.services?.sandboxExecutionBroker ??
+    extended.session?.services?.sandboxExecutionBroker ??
+    peekAmbientRuntimeSession()?.services.sandboxExecutionBroker;
 }

--- a/runtime/src/tools/canonicalToolSurface.ts
+++ b/runtime/src/tools/canonicalToolSurface.ts
@@ -2,6 +2,7 @@ import type { ToolResultBlockParam } from "@anthropic-ai/sdk/resources/index.mjs
 import { z } from "zod/v4";
 
 import { getSessionId } from "../bootstrap/state.js";
+import { peekAmbientRuntimeSession } from "../session/current-session.js";
 import { getCwd } from "../utils/cwd.js";
 import { isRecord } from "../utils/record.js";
 import { createBashTool } from "./system/bash.js";
@@ -11,6 +12,16 @@ import { createFileWriteTool } from "./system/file-write.js";
 import { createGlobTool } from "./system/glob.js";
 import { createGrepTool } from "./system/grep.js";
 import { withSignedSessionId } from "../agents/_deps/filesystem-args.js";
+import {
+  attachToolRuntimeContext,
+  readToolRuntimeContext,
+} from "./runtimes/context.js";
+import {
+  attachSandboxExecutionBroker,
+  readSandboxExecutionBroker,
+  type SandboxExecutionBrokerLike,
+  type SandboxExecutionSurface,
+} from "../sandbox/execution-broker.js";
 import { createNotebookEditTool as createSystemNotebookEditTool } from "./system/notebook-edit.js";
 import type { Tool as RuntimeTool, ToolResult as RuntimeToolResult } from "./types.js";
 import { buildTool, type Tool, type ToolCallProgress, type ToolUseContext } from "./Tool.js";
@@ -422,11 +433,25 @@ function createCanonicalTool(options: CanonicalToolOptions): Tool {
         options.name === "system.bash"
           ? buildBashProgressForwarder(input, onProgress)
           : undefined;
-      const result = await runtimeTool.execute({
+      const executionInput: Record<string, unknown> = {
         ...runtimeInput,
         __abortSignal: context.abortController.signal,
         ...(progressForwarder !== undefined ? { __onProgress: progressForwarder } : {}),
-      });
+      };
+      const runtimeContext = readToolRuntimeContext(input);
+      if (runtimeContext !== undefined) {
+        attachToolRuntimeContext(executionInput, runtimeContext);
+      }
+      const carriedBroker = readSandboxExecutionBroker(input) ??
+        sandboxBrokerFromToolUseContext(context);
+      if (carriedBroker !== undefined) {
+        attachSandboxExecutionBroker(
+          executionInput,
+          carriedBroker,
+          canonicalExecutionSurface(input, context),
+        );
+      }
+      const result = await runtimeTool.execute(executionInput);
       return { data: runtimeResultToData(result) };
     },
     mapToolResultToToolResultBlockParam: textToolResultBlock,
@@ -440,6 +465,40 @@ function createCanonicalTool(options: CanonicalToolOptions): Tool {
       return canonicalResultText(content);
     },
   });
+}
+
+function canonicalExecutionSurface(
+  input: Record<string, unknown>,
+  context: ToolUseContext,
+): SandboxExecutionSurface {
+  if (context.agentId !== undefined) return "child_agent";
+  if (input.run_in_background === true || input.runInBackground === true) {
+    return "background";
+  }
+  return context.options?.isNonInteractiveSession === true
+    ? "print"
+    : "interactive";
+}
+
+function sandboxBrokerFromToolUseContext(
+  context: ToolUseContext,
+): SandboxExecutionBrokerLike | undefined {
+  const extended = context as ToolUseContext & {
+    readonly services?: { readonly sandboxExecutionBroker?: unknown };
+    readonly session?: {
+      readonly services?: { readonly sandboxExecutionBroker?: unknown };
+    };
+  };
+  const candidate = extended.services?.sandboxExecutionBroker ??
+    extended.session?.services?.sandboxExecutionBroker ??
+    peekAmbientRuntimeSession()?.services.sandboxExecutionBroker;
+  if (typeof candidate !== "object" || candidate === null) return undefined;
+  const broker = candidate as Partial<SandboxExecutionBrokerLike>;
+  return typeof broker.prepareSpawn === "function" &&
+    typeof broker.runtimeSandbox === "function" &&
+    typeof broker.assertReady === "function"
+    ? (candidate as SandboxExecutionBrokerLike)
+    : undefined;
 }
 
 function mapCanonicalInput(

--- a/runtime/src/tools/runtimes/sandboxing.ts
+++ b/runtime/src/tools/runtimes/sandboxing.ts
@@ -142,6 +142,7 @@ export function runtimePlatformSandboxStatus(
   const turn = context.invocation.turn as {
     readonly agencLinuxSandboxExe?: unknown;
     readonly config?: { readonly agencLinuxSandboxExe?: unknown };
+    readonly sandboxUnavailableReason?: unknown;
     readonly windowsSandboxLevel?: unknown;
   };
   switch (process.platform) {
@@ -175,6 +176,7 @@ function linuxSandboxStatus(
   turn: {
     readonly agencLinuxSandboxExe?: unknown;
     readonly config?: { readonly agencLinuxSandboxExe?: unknown };
+    readonly sandboxUnavailableReason?: unknown;
   },
 ): RuntimePlatformSandboxStatus {
   const candidate = stringValue(turn.agencLinuxSandboxExe) ??
@@ -182,7 +184,8 @@ function linuxSandboxStatus(
   if (candidate === undefined) {
     return {
       available: false,
-      reason: "agencLinuxSandboxExe is not configured",
+      reason: stringValue(turn.sandboxUnavailableReason) ??
+        "agencLinuxSandboxExe is not configured",
     };
   }
   const workspaceRoot = runtimeCwd(context);

--- a/runtime/src/tools/system/apply-runtime-sandbox.ts
+++ b/runtime/src/tools/system/apply-runtime-sandbox.ts
@@ -5,12 +5,15 @@
  */
 
 import { basename } from "node:path";
+import type { SandboxManager } from "../../sandbox/engine/index.js";
 import {
-  SandboxManager,
-  type SandboxType,
-} from "../../sandbox/engine/index.js";
+  readSandboxExecutionBroker,
+  readSandboxExecutionSurface,
+  transformSandboxedCommand,
+  type SandboxExecutionSurface,
+} from "../../sandbox/execution-broker.js";
 import type { UnifiedExecRuntimeSandbox } from "../../unified-exec/types.js";
-import { UnifiedExecError } from "../../unified-exec/types.js";
+import { readToolRuntimeContext } from "../runtimes/context.js";
 import { runtimeSandboxForExec } from "./exec-command.js";
 
 export interface SandboxSpawnCommand {
@@ -20,8 +23,6 @@ export interface SandboxSpawnCommand {
   readonly env: Record<string, string>;
   readonly argv0?: string;
 }
-
-const defaultSandboxManager = new SandboxManager();
 
 /**
  * If the tool runtime context requires platform isolation, transform
@@ -36,12 +37,33 @@ export function applyRuntimeSandboxToSpawn(params: {
   readonly cwd: string;
   readonly env: Record<string, string>;
   readonly sandboxManager?: SandboxManager;
+  readonly surface?: SandboxExecutionSurface;
 }): SandboxSpawnCommand {
+  const runtimeContext = readToolRuntimeContext(params.toolArgs);
+  const surface = params.surface ??
+    readSandboxExecutionSurface(params.toolArgs) ??
+    "tool";
   const runtimeSandbox = runtimeSandboxForExec(
     params.toolArgs,
     params.fallbackCwd,
+    surface,
   );
   if (runtimeSandbox === undefined) {
+    // A real runtime context is authoritative. `undefined` here means that
+    // context explicitly selected danger-full-access/external sandbox, not
+    // that the sandbox was missing (restricted-mode failures throw above).
+    if (runtimeContext === undefined) {
+      const broker = readSandboxExecutionBroker(params.toolArgs);
+      if (broker !== undefined) {
+        return broker.prepareSpawn(surface, {
+          program: params.program,
+          args: params.args,
+          cwd: params.cwd,
+          env: params.env,
+          argv0: basename(params.program),
+        });
+      }
+    }
     return {
       program: params.program,
       args: params.args,
@@ -56,7 +78,9 @@ export function applyRuntimeSandboxToSpawn(params: {
     cwd: params.cwd,
     env: params.env,
     runtimeSandbox,
-    sandboxManager: params.sandboxManager ?? defaultSandboxManager,
+    ...(params.sandboxManager !== undefined
+      ? { sandboxManager: params.sandboxManager }
+      : {}),
   });
 }
 
@@ -68,92 +92,5 @@ export function transformWithRuntimeSandbox(params: {
   readonly runtimeSandbox: UnifiedExecRuntimeSandbox;
   readonly sandboxManager?: SandboxManager;
 }): SandboxSpawnCommand {
-  const sandboxManager = params.sandboxManager ?? defaultSandboxManager;
-  const permissions = params.runtimeSandbox.permissionProfile;
-  const windowsSandboxLevel =
-    params.runtimeSandbox.windowsSandboxLevel ?? "disabled";
-  let sandbox: SandboxType = "none";
-  try {
-    sandbox = sandboxManager.selectInitial({
-      fileSystemPolicy: permissions.fileSystem,
-      networkPolicy: permissions.network,
-      preference: params.runtimeSandbox.preference ?? "require",
-      windowsSandboxLevel,
-      hasManagedNetworkRequirements:
-        params.runtimeSandbox.enforceManagedNetwork === true ||
-        params.runtimeSandbox.network !== undefined,
-    });
-    if (
-      sandbox === "none" &&
-      (params.runtimeSandbox.preference ?? "require") === "require"
-    ) {
-      throw new UnifiedExecError(
-        "create_process",
-        "sandbox isolation was required but no platform sandbox is available",
-      );
-    }
-    const transformed = sandboxManager.transform({
-      command: {
-        program: params.program,
-        args: params.args,
-        cwd: params.cwd,
-        env: params.env,
-        ...(params.runtimeSandbox.additionalPermissions !== undefined
-          ? {
-              additionalPermissions:
-                params.runtimeSandbox.additionalPermissions,
-            }
-          : {}),
-      },
-      permissions,
-      sandbox,
-      enforceManagedNetwork:
-        params.runtimeSandbox.enforceManagedNetwork ?? false,
-      ...(params.runtimeSandbox.network !== undefined
-        ? { network: params.runtimeSandbox.network }
-        : {}),
-      ...(params.runtimeSandbox.networkPolicyDecider !== undefined
-        ? {
-            networkPolicyDecider: params.runtimeSandbox.networkPolicyDecider,
-          }
-        : {}),
-      ...(params.runtimeSandbox.blockedRequestObserver !== undefined
-        ? {
-            blockedRequestObserver:
-              params.runtimeSandbox.blockedRequestObserver,
-          }
-        : {}),
-      sandboxPolicyCwd: params.runtimeSandbox.sandboxPolicyCwd,
-      ...(params.runtimeSandbox.agencLinuxSandboxExe !== undefined
-        ? {
-            agencLinuxSandboxExe: params.runtimeSandbox.agencLinuxSandboxExe,
-          }
-        : {}),
-      useLegacyLandlock: params.runtimeSandbox.useLegacyLandlock ?? false,
-      windowsSandboxLevel,
-      windowsSandboxPrivateDesktop:
-        params.runtimeSandbox.windowsSandboxPrivateDesktop ?? false,
-      ...(params.runtimeSandbox.allowGpu === true ? { allowGpu: true } : {}),
-    });
-    const [program, ...args] = transformed.command;
-    if (program === undefined) {
-      throw new UnifiedExecError(
-        "create_process",
-        "sandbox transform returned an empty command",
-      );
-    }
-    return {
-      program,
-      args,
-      cwd: transformed.cwd,
-      env: { ...transformed.env },
-      argv0: transformed.arg0 ?? basename(program),
-    };
-  } catch (error) {
-    if (error instanceof UnifiedExecError) throw error;
-    throw new UnifiedExecError(
-      "create_process",
-      error instanceof Error ? error.message : String(error),
-    );
-  }
+  return transformSandboxedCommand(params);
 }

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -17,6 +17,13 @@ import type {
   NetworkPolicyDecider,
 } from "../../sandbox/network-policy.js";
 import {
+  missingSandboxExecutionBoundary,
+  readSandboxExecutionBroker,
+  readSandboxExecutionSurface,
+  SandboxExecutionError,
+  type SandboxExecutionSurface,
+} from "../../sandbox/execution-broker.js";
+import {
   formatUnifiedExecToolContent,
   unifiedExecCodeModeResult,
 } from "./exec-result-format.js";
@@ -76,16 +83,42 @@ function isMcpShellPlaceholderCommand(command: string): boolean {
 export function runtimeSandboxForExec(
   args: Record<string, unknown>,
   fallbackCwd: string,
+  surface?: SandboxExecutionSurface,
 ): UnifiedExecRuntimeSandbox | undefined {
+  const executionSurface = surface ??
+    readSandboxExecutionSurface(args) ??
+    "tool";
   const context = readToolRuntimeContext(args);
+  if (context === undefined) {
+    const broker = readSandboxExecutionBroker(args);
+    if (broker === undefined) {
+      throw missingSandboxExecutionBoundary(executionSurface);
+    }
+    return broker.runtimeSandbox(executionSurface);
+  }
   if (
-    context === undefined ||
     !sandboxModeRequiresPlatformIsolation(context.sandboxMode)
   ) {
     return undefined;
   }
   const platformSandbox = runtimePlatformSandboxStatus(context);
-  if (!platformSandbox.available) return undefined;
+  if (!platformSandbox.available) {
+    throw new SandboxExecutionError({
+      code: "sandbox_required_unavailable",
+      surface: executionSurface,
+      status: {
+        kind: "unavailable",
+        mode: context.sandboxMode,
+        platform: process.platform,
+        reason: platformSandbox.reason ?? "platform sandbox is unavailable",
+        remediation:
+          "Run `agenc doctor`; configure a trusted sandbox helper or select danger-full-access explicitly.",
+        ...(platformSandbox.agencLinuxSandboxExe !== undefined
+          ? { helperPath: platformSandbox.agencLinuxSandboxExe }
+          : {}),
+      },
+    });
+  }
   const turn = context.invocation.turn as {
     readonly agencLinuxSandboxExe?: unknown;
     readonly config?: {

--- a/runtime/src/tools/system/monitor.ts
+++ b/runtime/src/tools/system/monitor.ts
@@ -27,6 +27,7 @@ import type {
 import type { UnifiedExecProcessManagerLike } from "../../unified-exec/types.js";
 import { processOwnerIdFromToolArgs } from "../../unified-exec/process-ownership.js";
 import { nonEmptyString as asNonEmptyString } from "../../utils/stringUtils.js";
+import { runtimeSandboxForExec } from "./exec-command.js";
 
 const MONITOR_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes — AgenC behavior.
 
@@ -124,6 +125,11 @@ export function createMonitorTool(config: MonitorToolConfig): Tool {
         const ownerId = processOwnerIdFromToolArgs(
           rawArgs as Record<string, unknown>,
         );
+        const runtimeSandbox = runtimeSandboxForExec(
+          rawArgs,
+          config.cwd,
+          "background",
+        );
         const output = await config.unifiedExecManager.execCommand({
           cmd: command,
           workdir: config.cwd,
@@ -137,6 +143,7 @@ export function createMonitorTool(config: MonitorToolConfig): Tool {
             ? { __onProgress: args.__onProgress }
             : {}),
           ...(ownerId !== undefined ? { ownerId } : {}),
+          ...(runtimeSandbox !== undefined ? { runtimeSandbox } : {}),
         });
 
         const taskId =

--- a/runtime/src/tools/worktree-sandbox-boundary.ts
+++ b/runtime/src/tools/worktree-sandbox-boundary.ts
@@ -1,0 +1,41 @@
+import { peekAmbientRuntimeSession } from "../session/current-session.js";
+import {
+  missingSandboxExecutionBoundary,
+  type SandboxExecutionBrokerLike,
+} from "../sandbox/execution-broker.js";
+import type { ToolUseContext } from "./Tool.js";
+
+export function requireWorktreeSandboxBrokers(
+  context: ToolUseContext,
+): readonly SandboxExecutionBrokerLike[] {
+  const extended = context as ToolUseContext & {
+    readonly services?: {
+      readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
+    };
+    readonly session?: {
+      readonly services?: {
+        readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
+      };
+    };
+  };
+  const brokers = new Set<SandboxExecutionBrokerLike>();
+  const ambient = peekAmbientRuntimeSession()?.services.sandboxExecutionBroker;
+  for (const broker of [
+    extended.services?.sandboxExecutionBroker,
+    extended.session?.services?.sandboxExecutionBroker,
+    ambient,
+  ]) {
+    if (broker !== undefined) brokers.add(broker);
+  }
+  if (brokers.size === 0) {
+    throw missingSandboxExecutionBoundary("tool");
+  }
+  return [...brokers];
+}
+
+export function rebaseWorktreeSandboxBrokers(
+  brokers: readonly SandboxExecutionBrokerLike[],
+  cwd: string,
+): void {
+  for (const broker of brokers) broker.rebase(cwd);
+}

--- a/runtime/src/tui/input/processBashCommand.tsx
+++ b/runtime/src/tui/input/processBashCommand.tsx
@@ -80,8 +80,8 @@ export async function processBashCommand(inputString: string, precedingInputBloc
 
   // B-NEW2 paste-burst security gate. The burst detector flagged this
   // submission as suspectedPaste — unbracketed stdin arriving in a tight
-  // window. Bash mode runs with dangerouslyDisableSandbox: true, so we
-  // refuse to execute until the user confirms via the dialog. The flag is
+  // window. A pasted shell command still needs explicit confirmation before
+  // it reaches the authenticated sandbox execution boundary. The flag is
   // consumed (one-shot) so the next legitimate submission is not gated.
   if (consumeSuspectedPaste()) {
     const allowed = await awaitPasteConfirmation(inputString, setToolJSX);
@@ -129,9 +129,7 @@ export async function processBashCommand(inputString: string, precedingInputBloc
 
     const shellTool = usePowerShell ? PowerShellTool : CanonicalBashTool;
     const response = usePowerShell ? await PowerShellTool.call({
-      command: inputString,
-      dangerouslyDisableSandbox: true,
-      _dangerouslyDisableSandboxApproved: true
+      command: inputString
     }, bashModeContext, undefined, undefined, onProgress) : await CanonicalBashTool.call({
       command: inputString
     }, bashModeContext, undefined, undefined, onProgress);

--- a/runtime/src/tui/session-types.ts
+++ b/runtime/src/tui/session-types.ts
@@ -49,6 +49,7 @@ export interface AgenCBridgeSession extends AgenCCompactProgressControls {
   };
   readonly services: {
     readonly permissionModeRegistry: PermissionModeRegistryLike;
+    readonly sandboxExecutionBroker?: SessionServices["sandboxExecutionBroker"];
     readonly configStore?: ConfigStore;
     readonly authManager?: SessionServices["authManager"];
     readonly mcpManager?: SessionServices["mcpManager"];

--- a/runtime/src/utils/Shell.ts
+++ b/runtime/src/utils/Shell.ts
@@ -39,6 +39,11 @@ import { createPowerShellProvider } from './shell/powershellProvider.js'
 import type { ShellProvider, ShellType } from './shell/shellProvider.js'
 import { subprocessEnv } from './subprocessEnv.js'
 import { posixPathToWindowsPath } from './windowsPaths.js'
+import type {
+  SandboxExecutionBrokerLike,
+  SandboxSpawnCommand,
+  SandboxExecutionSurface,
+} from '../sandbox/execution-broker.js'
 
 const DEFAULT_TIMEOUT = 30 * 60 * 1000 // 30 minutes
 
@@ -171,6 +176,8 @@ export type ExecOptions = {
   shouldAutoBackground?: boolean
   /** When provided, stdout is piped (not sent to file) and this callback fires on each data chunk. */
   onStdout?: (data: string) => void
+  sandboxExecutionBroker?: SandboxExecutionBrokerLike
+  sandboxExecutionSurface?: SandboxExecutionSurface
 }
 
 /**
@@ -190,6 +197,8 @@ export async function exec(
     shouldUseSandbox,
     shouldAutoBackground,
     onStdout,
+    sandboxExecutionBroker,
+    sandboxExecutionSurface,
   } = options ?? {}
   const commandTimeout = timeout || DEFAULT_TIMEOUT
 
@@ -208,8 +217,12 @@ export async function exec(
   const { commandString: builtCommand, cwdFilePath } =
     await provider.buildExecCommand(command, {
       id,
-      sandboxTmpDir: shouldUseSandbox ? sandboxTmpDir : undefined,
-      useSandbox: shouldUseSandbox ?? false,
+      sandboxTmpDir:
+        shouldUseSandbox && sandboxExecutionBroker === undefined
+          ? sandboxTmpDir
+          : undefined,
+      useSandbox:
+        sandboxExecutionBroker === undefined && (shouldUseSandbox ?? false),
     })
 
   let commandString = builtCommand
@@ -264,10 +277,13 @@ export async function exec(
   //   • pass /bin/sh as the sandbox's inner shell to exec that invocation
   //   • outer spawn is also /bin/sh -c to parse the runtime's POSIX output
   // /bin/sh exists on every platform where sandbox is supported.
-  const isSandboxedPowerShell = shouldUseSandbox && shellType === 'powershell'
+  const isSandboxedPowerShell =
+    sandboxExecutionBroker === undefined &&
+    shouldUseSandbox === true &&
+    shellType === 'powershell'
   const sandboxBinShell = isSandboxedPowerShell ? '/bin/sh' : binShell
 
-  if (shouldUseSandbox) {
+  if (shouldUseSandbox && sandboxExecutionBroker === undefined) {
     commandString = await SandboxManager.wrapWithSandbox(
       commandString,
       sandboxBinShell,
@@ -288,6 +304,32 @@ export async function exec(
     ? ['-c', commandString]
     : provider.getSpawnArgs(commandString)
   const envOverrides = await provider.getEnvironmentOverrides(command)
+  const spawnEnv = {
+    ...subprocessEnv(),
+    ...(shellType === 'bash' ? { SHELL: binShell } : {}),
+    GIT_EDITOR: 'true',
+    AGENCCODE: '1',
+    ...envOverrides,
+    ...(process.env.USER_TYPE === 'ant'
+      ? { AGENC_SESSION_ID: getSessionId() }
+      : {}),
+  }
+  const unsandboxedSpawnCommand: SandboxSpawnCommand = {
+    program: spawnBinary,
+    args: shellArgs,
+    cwd,
+    env: Object.fromEntries(
+      Object.entries(spawnEnv).filter(
+        (entry): entry is [string, string] => entry[1] !== undefined,
+      ),
+    ),
+  }
+  const spawnCommand: SandboxSpawnCommand = sandboxExecutionBroker
+    ? sandboxExecutionBroker.prepareSpawn(
+        sandboxExecutionSurface ?? 'tool',
+        unsandboxedSpawnCommand,
+      )
+    : unsandboxedSpawnCommand
 
   // When onStdout is provided, use pipe mode: stdout flows through
   // StreamWrapper → TaskOutput in-memory buffer instead of a file fd.
@@ -324,20 +366,9 @@ export async function exec(
   }
 
   try {
-    const childProcess = spawn(spawnBinary, shellArgs, {
-      env: {
-        ...subprocessEnv(),
-        SHELL: shellType === 'bash' ? binShell : undefined,
-        GIT_EDITOR: 'true',
-        AGENCCODE: '1',
-        ...envOverrides,
-        ...(process.env.USER_TYPE === 'ant'
-          ? {
-              AGENC_SESSION_ID: getSessionId(),
-            }
-          : {}),
-      },
-      cwd,
+    const childProcess = spawn(spawnCommand.program, [...spawnCommand.args], {
+      env: spawnCommand.env,
+      cwd: spawnCommand.cwd,
       stdio: usePipeMode
         ? ['pipe', 'pipe', 'pipe']
         : ['pipe', outputHandle?.fd, outputHandle?.fd],
@@ -345,6 +376,9 @@ export async function exec(
       detached: provider.detached,
       // Prevent visible console window on Windows (no-op on other platforms)
       windowsHide: true,
+      ...(spawnCommand.argv0 !== undefined
+        ? { argv0: spawnCommand.argv0 }
+        : {}),
     })
 
     const shellCommand = wrapSpawn(

--- a/runtime/src/utils/doctorDiagnostic.ts
+++ b/runtime/src/utils/doctorDiagnostic.ts
@@ -44,6 +44,10 @@ import {
   probeRipgrepAvailable,
 } from './ripgrep.js'
 import { SandboxManager } from './sandbox/sandbox-runtime.js'
+import {
+  SandboxExecutionBroker,
+  type SandboxExecutionStatus,
+} from '../sandbox/execution-broker.js'
 import { getManagedFilePath } from './settings/managedPath.js'
 import { CUSTOMIZATION_SURFACES } from './settings/types.js'
 import {
@@ -90,6 +94,7 @@ export type DiagnosticInfo = {
     systemPath: string | null
   }
   transactionGuard: TransactionGuardDoctorStatus
+  sandbox: SandboxExecutionStatus
 }
 
 export type TransactionGuardDoctorStatus = {
@@ -672,6 +677,47 @@ export function buildTransactionGuardWarning(
   }
 }
 
+export async function getSandboxDoctorStatus(opts?: {
+  config?: Pick<Awaited<ReturnType<typeof loadConfig>>['config'], 'sandbox_mode' | 'sandbox'> | null
+  env?: NodeJS.ProcessEnv
+  cwd?: string
+  probe?: ConstructorParameters<typeof SandboxExecutionBroker>[0]['probe']
+}): Promise<SandboxExecutionStatus> {
+  const env = opts?.env ?? process.env
+  let config = opts?.config === null ? undefined : opts?.config
+  if (config === undefined && opts?.config === undefined) {
+    try {
+      config = (await loadConfig({ onWarn: () => {} })).config
+    } catch {
+      // Defaults remain fail-closed when config is unreadable.
+    }
+  }
+  const rawMode = config?.sandbox_mode
+  const mode = rawMode === 'read-only'
+    ? 'read_only'
+    : rawMode === 'danger-full-access'
+      ? 'danger_full_access'
+      : 'workspace_write'
+  return new SandboxExecutionBroker({
+    mode,
+    cwd: opts?.cwd ?? getCwd() ?? process.cwd(),
+    env,
+    allowGpu: config?.sandbox?.allow_gpu === true,
+    ...(opts?.probe !== undefined ? { probe: opts.probe } : {}),
+  }).status()
+}
+
+export function buildSandboxWarning(
+  status: SandboxExecutionStatus,
+): { issue: string; fix: string } | null {
+  if (status.kind !== 'unavailable') return null
+  return {
+    issue: `[sandbox_required_unavailable] ${status.reason ?? 'required platform sandbox is unavailable'}`,
+    fix: status.remediation ??
+      'Install the required platform sandbox support or select danger-full-access explicitly.',
+  }
+}
+
 export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
   const installationType = await getCurrentInstallationType()
   // The bundler substitutes `MACRO.VERSION` (property access) with a string
@@ -777,6 +823,11 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
   if (transactionGuardWarning) {
     warnings.push(transactionGuardWarning)
   }
+  const sandbox = await getSandboxDoctorStatus()
+  const sandboxWarning = buildSandboxWarning(sandbox)
+  if (sandboxWarning) {
+    warnings.push(sandboxWarning)
+  }
 
   // Get package manager info if running from package manager
   const packageManager =
@@ -802,6 +853,7 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
     packageManager,
     ripgrepStatus,
     transactionGuard,
+    sandbox,
   }
 
   return diagnostic

--- a/runtime/src/utils/hooks.ts
+++ b/runtime/src/utils/hooks.ts
@@ -20,6 +20,7 @@ import { subprocessEnv } from './subprocessEnv.js'
 import { getPlatform } from './platform.js'
 import { findGitBashPath, windowsPathToPosixPath } from './windowsPaths.js'
 import { getCachedPowerShellPath } from './shell/powershellDetection.js'
+import { peekAmbientRuntimeSession } from '../session/current-session.js'
 import { DEFAULT_HOOK_SHELL } from './shell/shellProvider.js'
 import { buildPowerShellArgs } from './shell/powershellProvider.js'
 import {
@@ -1116,6 +1117,18 @@ async function execCommandHook(
   // startup, which will exit first. Relaxing that is phase 1 of the
   // design's implementation order (separate PR).
   let child: ChildProcessWithoutNullStreams
+  const sandboxExecutionBroker =
+    peekAmbientRuntimeSession()?.services.sandboxExecutionBroker
+  if (sandboxExecutionBroker === undefined) {
+    throw new Error(
+      '[sandbox_surface_uncovered] legacy hook execution has no session sandbox boundary',
+    )
+  }
+  const spawnEnv = Object.fromEntries(
+    Object.entries(envVars).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  )
   if (shellType === 'powershell') {
     const pwshPath = await getCachedPowerShellPath()
     if (!pwshPath) {
@@ -1125,20 +1138,33 @@ async function execCommandHook(
           `PowerShell, or remove "shell": "powershell" to use bash.`,
       )
     }
-    child = spawn(pwshPath, buildPowerShellArgs(finalCommand), {
-      env: envVars,
+    const command = sandboxExecutionBroker.prepareSpawn('hook', {
+      program: pwshPath,
+      args: buildPowerShellArgs(finalCommand),
+      env: spawnEnv,
       cwd: safeCwd,
+    })
+    child = spawn(command.program, [...command.args], {
+      env: command.env,
+      cwd: command.cwd,
+      ...(command.argv0 !== undefined ? { argv0: command.argv0 } : {}),
       // Prevent visible console window on Windows (no-op on other platforms)
       windowsHide: true,
     }) as ChildProcessWithoutNullStreams
   } else {
     // On Windows, use Git Bash explicitly (cmd.exe can't run bash syntax).
     // On other platforms, shell: true uses /bin/sh.
-    const shell = isWindows ? findGitBashPath() : true
-    child = spawn(finalCommand, [], {
-      env: envVars,
+    const shell = isWindows ? findGitBashPath() : '/bin/sh'
+    const command = sandboxExecutionBroker.prepareSpawn('hook', {
+      program: shell,
+      args: ['-c', finalCommand],
+      env: spawnEnv,
       cwd: safeCwd,
-      shell,
+    })
+    child = spawn(command.program, [...command.args], {
+      env: command.env,
+      cwd: command.cwd,
+      ...(command.argv0 !== undefined ? { argv0: command.argv0 } : {}),
       // Prevent visible console window on Windows (no-op on other platforms)
       windowsHide: true,
     }) as ChildProcessWithoutNullStreams

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -47,6 +47,10 @@ import type {
   LLMResponse,
   StreamProgressCallback,
 } from "../llm/types.js";
+import {
+  SandboxExecutionBroker,
+  readSandboxExecutionBroker,
+} from "../sandbox/execution-broker.js";
 
 const ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
 import { Session, type Event, type SessionOpts, type SessionServices } from "../session/session.js";
@@ -986,6 +990,10 @@ describe("runAgent", () => {
   });
 
   it("injects child session metadata and worktree roots into wrapped child tools", async () => {
+    const childBroker = new SandboxExecutionBroker({
+      mode: "danger_full_access",
+      cwd: "/tmp/subagent-wt",
+    });
     const execute = vi.fn(async () => ({
       content: JSON.stringify({ ok: true }),
       isError: false,
@@ -1014,6 +1022,7 @@ describe("runAgent", () => {
           gitRoot: "/repo",
           created: false,
         },
+        sandboxExecutionBroker: childBroker,
       },
     );
 
@@ -1024,6 +1033,7 @@ describe("runAgent", () => {
     expect(parsed[SESSION_ID_ARG]).toBe("child-123");
     expect(parsed[SESSION_ALLOWED_ROOTS_ARG]).toEqual(["/tmp/subagent-wt"]);
     expect(parsed.value).toBe("hello");
+    expect(readSandboxExecutionBroker(parsed)).toBe(childBroker);
   });
 
   it("mergeRoleDisallowlist unions a role denylist into the disabled set", () => {

--- a/runtime/tests/app-server-client/index.test.ts
+++ b/runtime/tests/app-server-client/index.test.ts
@@ -271,6 +271,9 @@ describe("app-server-client daemon helpers", () => {
         context.baseSession.services.permissionModeRegistry.current();
       expect(permissionContext.mode).toBe("bypassPermissions");
       expect(permissionContext.isBypassPermissionsModeAvailable).toBe(true);
+      expect(
+        context.baseSession.services.sandboxExecutionBroker?.mode,
+      ).toBe("danger_full_access");
     } finally {
       await context?.close();
       rmSync(agencHome, { recursive: true, force: true });
@@ -298,6 +301,12 @@ describe("app-server-client daemon helpers", () => {
       });
       expect(context.baseSession.sessionConfiguration?.cwd).toBe(worktree);
       expect(context.workspaceRoot).toBe(worktree);
+      expect(
+        context.baseSession.services.sandboxExecutionBroker?.mode,
+      ).toBe("workspace_write");
+      expect(
+        context.baseSession.services.sandboxExecutionBroker?.cwd,
+      ).toBe(worktree);
     } finally {
       await context?.close();
       rmSync(agencHome, { recursive: true, force: true });

--- a/runtime/tests/app-server/cancellation-preemption.contract.test.ts
+++ b/runtime/tests/app-server/cancellation-preemption.contract.test.ts
@@ -169,6 +169,7 @@ describe("AgenC daemon cancellation and preemption", () => {
             terminatedPath,
           ],
           processId: "cancel-real-command",
+          permissionProfile: ":danger-full-access",
           timeoutMs: 60_000,
         },
       });

--- a/runtime/tests/app-server/command-exec.contract.test.ts
+++ b/runtime/tests/app-server/command-exec.contract.test.ts
@@ -16,6 +16,37 @@ import type {
 
 const idleScript = "setInterval(() => {}, 1000)";
 
+const readySandboxProbe = (options: {
+  readonly mode: "read_only" | "workspace_write";
+  readonly platform: NodeJS.Platform;
+  readonly agencLinuxSandboxExe?: string;
+}) => ({
+  kind: "ready" as const,
+  mode: options.mode,
+  platform: options.platform,
+  ...(options.agencLinuxSandboxExe !== undefined
+    ? { helperPath: options.agencLinuxSandboxExe }
+    : {}),
+});
+
+/**
+ * These lifecycle/transport tests intentionally execute on the host. Keep that
+ * policy explicit so the production service can reject policy-less requests.
+ */
+class ExplicitDangerCommandExecService extends AgenCCommandExecService {
+  override start(
+    params: Parameters<AgenCCommandExecService["start"]>[0],
+    context: Parameters<AgenCCommandExecService["start"]>[1],
+  ): ReturnType<AgenCCommandExecService["start"]> {
+    return super.start(
+      params.permissionProfile !== undefined || params.sandboxPolicy !== undefined
+        ? params
+        : { ...params, permissionProfile: ":danger-full-access" },
+      context,
+    );
+  }
+}
+
 async function waitForNotification(
   notifications: readonly JsonObject[],
   predicate: (notification: JsonObject) => boolean,
@@ -220,7 +251,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("returns buffered stdout and stderr for non-streaming commands", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
 
     await expect(
       service.start(
@@ -243,7 +274,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("preserves empty and whitespace argv entries after the executable", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
 
     await expect(
       service.start(
@@ -290,9 +321,10 @@ describe("AgenC daemon command exec", () => {
         networkSandboxPolicy: request.permissions.network,
       })),
     };
-    const service = new AgenCCommandExecService({
+    const service = new ExplicitDangerCommandExecService({
       sandboxManager,
-      agencLinuxSandboxExe: "/tmp/agenc-linux-sandbox-test",
+      agencLinuxSandboxExe: process.execPath,
+      sandboxProbe: readySandboxProbe,
     });
 
     const result = await service.start(
@@ -327,6 +359,39 @@ describe("AgenC daemon command exec", () => {
     );
   });
 
+  it("fails before transform/spawn when required sandbox readiness fails", async () => {
+    const sandboxManager = {
+      selectInitial: vi.fn(() => "linux_seccomp" as const),
+      transform: vi.fn(),
+    };
+    const service = new ExplicitDangerCommandExecService({
+      sandboxManager,
+      agencLinuxSandboxExe: process.execPath,
+      sandboxProbe: (options) => ({
+        kind: "unavailable",
+        mode: options.mode,
+        platform: options.platform,
+        reason: "probe: user namespaces disabled by test",
+        remediation: "enable user namespaces",
+      }),
+    });
+
+    await expect(
+      service.start(
+        {
+          command: [process.execPath, "-e", "process.exit(99)"],
+          sandboxPolicy: { type: "readOnly" },
+          timeoutMs: 2_000,
+        },
+        { connectionId: "sandbox-readiness" },
+      ),
+    ).rejects.toMatchObject({
+      code: "sandbox_probe_failed",
+      surface: "command_exec",
+    });
+    expect(sandboxManager.transform).not.toHaveBeenCalled();
+  });
+
   it("accepts built-in permissionProfile ids as command-scoped sandbox profiles", async () => {
     const sandboxManager = {
       selectInitial: vi.fn(() => "linux_seccomp" as const),
@@ -342,9 +407,10 @@ describe("AgenC daemon command exec", () => {
         networkSandboxPolicy: request.permissions.network,
       })),
     };
-    const service = new AgenCCommandExecService({
+    const service = new ExplicitDangerCommandExecService({
       sandboxManager,
-      agencLinuxSandboxExe: "/tmp/agenc-linux-sandbox-test",
+      agencLinuxSandboxExe: process.execPath,
+      sandboxProbe: readySandboxProbe,
     });
 
     await expect(
@@ -380,7 +446,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("honors external sandboxPolicy without adding another managed sandbox", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
 
     await expect(
       service.start(
@@ -399,7 +465,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("streams stdout and stderr as base64 notifications", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const notifications: JsonObject[] = [];
 
     const result = await service.start(
@@ -447,7 +513,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("writes stdin and closes it for pipe-backed sessions", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const context = { connectionId: "stdin" };
     const started = service.start(
       {
@@ -480,7 +546,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("runs a byte-preserving PTY-backed session and resizes it", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const notifications: JsonObject[] = [];
     const context = {
       connectionId: "pty",
@@ -577,6 +643,7 @@ describe("AgenC daemon command exec", () => {
             "process.stdin.setRawMode?.(true); process.stdin.resume(); process.stdout.write('ready\\n'); process.stdin.on('data', (d) => process.stdout.write('got:' + Buffer.from(d).toString('hex') + '\\n')); setInterval(() => {}, 1000);",
           ],
           processId: "rpc-pty-1",
+          permissionProfile: ":danger-full-access",
           tty: true,
           size: { rows: 24, cols: 80 },
           disableTimeout: true,
@@ -657,6 +724,7 @@ describe("AgenC daemon command exec", () => {
           params: {
             command: ["bash", "-i"],
             processId: "cancel-pty-1",
+            permissionProfile: ":danger-full-access",
             tty: true,
             size: { rows: 24, cols: 80 },
             disableTimeout: true,
@@ -715,7 +783,7 @@ describe("AgenC daemon command exec", () => {
   );
 
   it("rejects duplicate process ids and terminates active sessions", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const context = { connectionId: "terminate" };
     const started = service.start(
       {
@@ -749,7 +817,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("terminates even when a detached descendant keeps stdio open", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const context = { connectionId: "leaked-stdio" };
     const started = service.start(
       {
@@ -776,7 +844,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("rejects unsafe or malformed commandExec requests", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
 
     await expect(
       service.start(
@@ -928,7 +996,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("terminates all sessions for a closed connection", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const context = { connectionId: "closed" };
     const started = service.start(
       {
@@ -953,7 +1021,7 @@ describe("AgenC daemon command exec", () => {
   });
 
   it("terminates every live child process during daemon cleanup", async () => {
-    const service = new AgenCCommandExecService();
+    const service = new ExplicitDangerCommandExecService();
     const first = service.start(
       {
         command: [process.execPath, "-e", idleScript],

--- a/runtime/tests/bin/agenc.user-prompt-submit.test.ts
+++ b/runtime/tests/bin/agenc.user-prompt-submit.test.ts
@@ -11,7 +11,10 @@ import {
   type PreparedTurnRuntimeInputs,
 } from "./agenc.js";
 import { defaultConfig } from "../config/schema.js";
-import { trustProjectSync } from "../permissions/trust/project-trust.js";
+import {
+  resolveProjectTrustRootSync,
+  trustProjectSync,
+} from "../permissions/trust/project-trust.js";
 import type { PhaseEvent } from "../phases/events.js";
 import {
   canonicalizePath,
@@ -85,7 +88,7 @@ function restoreEnv(prevEnv: NodeJS.ProcessEnv): void {
 function trustWorkspaceForTest(agencHome: string, workspace: string): void {
   trustProjectSync({
     agencHome,
-    projectRoot: workspace,
+    projectRoot: resolveProjectTrustRootSync({ cwd: workspace }),
     env: process.env,
   });
 }
@@ -101,6 +104,8 @@ async function installOneShotHookConfig(
   await writeFile(
     join(agencHome, "config.toml"),
     `
+sandbox_mode = "danger-full-access"
+
 [[hooks.userPromptSubmit]]
 hooks = [{ type = "command", command = ${JSON.stringify(command)} }]
 `,
@@ -528,6 +533,7 @@ describe("TUI session UserPromptSubmit hooks", () => {
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
     const spies = installOneShotDaemonSpies();
+    await writeFile(join(tmpCwd, "package.json"), "{}\n", "utf8");
     await writeFile(join(tmpCwd, "secret.txt"), "one-shot file body\n", "utf8");
     await installOneShotHookConfig(
       tmpHome,
@@ -594,6 +600,7 @@ process.stdin.on("end", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
     const spies = installOneShotDaemonSpies();
+    await writeFile(join(tmpCwd, "package.json"), "{}\n", "utf8");
     await installOneShotHookConfig(
       tmpHome,
       "blocking-prompt-hook.cjs",

--- a/runtime/tests/bin/bootstrap-services.test.ts
+++ b/runtime/tests/bin/bootstrap-services.test.ts
@@ -16,6 +16,7 @@ import {
   ConfiguredHooksRuntime,
   type HookInstallTarget,
 } from "../hooks/configured-hooks.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
 import { defaultConfig } from "../config/schema.js";
 import { trustProjectSync } from "../permissions/trust/project-trust.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
@@ -94,6 +95,7 @@ describe("loadBootstrapHooks", () => {
       env: process.env,
       agencHome: "/tmp/agenc-bootstrap-hooks-test",
       shellPath: process.env.SHELL ?? "/bin/sh",
+      sandboxExecutionBroker: explicitDangerBroker,
     });
     const target: HookInstallTarget = {
       preToolUseHooks: [],
@@ -206,6 +208,7 @@ describe("SessionStart bootstrap hooks", () => {
       registry: { tools: [] } as never,
       mcpManager: {} as never,
       unifiedExecManager: {} as never,
+      sandboxExecutionBroker: explicitDangerBroker,
       permissionModeRegistry: new PermissionModeRegistry(
         createEmptyToolPermissionContext(),
       ),
@@ -373,6 +376,7 @@ describe("buildBootstrapSessionServices policy limits wiring", () => {
         registry: { tools: [] } as never,
         mcpManager: {} as never,
         unifiedExecManager: {} as never,
+        sandboxExecutionBroker: explicitDangerBroker,
         permissionModeRegistry: new PermissionModeRegistry(
           createEmptyToolPermissionContext(),
         ),
@@ -456,6 +460,7 @@ describe("buildBootstrapSessionServices policy limits wiring", () => {
       registry: { tools: [] } as never,
       mcpManager: {} as never,
       unifiedExecManager: {} as never,
+      sandboxExecutionBroker: explicitDangerBroker,
       permissionModeRegistry: new PermissionModeRegistry(
         createEmptyToolPermissionContext(),
       ),

--- a/runtime/tests/commands/hooks.test.ts
+++ b/runtime/tests/commands/hooks.test.ts
@@ -4,6 +4,7 @@ import hooksCommand from "./hooks.js";
 import type { SlashCommandContext } from "./types.js";
 import type { Session } from "../session/session.js";
 import { ConfiguredHooksRuntime } from "../hooks/configured-hooks.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
 
 function runtime(): ConfiguredHooksRuntime {
   const r = new ConfiguredHooksRuntime({
@@ -11,6 +12,7 @@ function runtime(): ConfiguredHooksRuntime {
     env: process.env,
     agencHome: "/tmp/agenc-test",
     shellPath: process.env.SHELL ?? "/bin/sh",
+    sandboxExecutionBroker: explicitDangerBroker,
     // These tests exercise hook diagnostics/dispatch; treat the workspace as
     // trusted (production establishes trust before command hooks run).
     isWorkspaceTrusted: () => true,

--- a/runtime/tests/gaphunt3/mcp-client-resilient-client.test.ts
+++ b/runtime/tests/gaphunt3/mcp-client-resilient-client.test.ts
@@ -116,6 +116,7 @@ describe("ResilientMCPBridge gaphunt3 fixes", () => {
       logger,
       elicitationHandlers,
       undefined,
+      undefined,
     );
     expect(registered).toBe(elicitationHandlers);
 
@@ -156,6 +157,7 @@ describe("ResilientMCPBridge gaphunt3 fixes", () => {
     expect(mockCreateMCPConnection).toHaveBeenCalledWith(
       config,
       logger,
+      undefined,
       undefined,
       undefined,
     );

--- a/runtime/tests/gaphunt3/tools-system-write-stdin.test.ts
+++ b/runtime/tests/gaphunt3/tools-system-write-stdin.test.ts
@@ -5,6 +5,7 @@ import type {
   ExecCommandToolOutput,
   UnifiedExecProcessManagerLike,
 } from "src/unified-exec/types";
+import { bindExplicitDangerBoundary } from "../helpers/explicit-danger-boundary.js";
 
 // gaphunt3 #4: write_stdin must report an error when the underlying PTY
 // process was killed by a signal (exitCode === null, no process_id) instead
@@ -47,7 +48,7 @@ function makeManager(
 
 describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
   test("flags a signal-killed process (exitCode null, no process_id) as isError", async () => {
-    const tool = createWriteStdinTool({
+    const tool = bindExplicitDangerBoundary(createWriteStdinTool({
       unifiedExecManager: makeManager(
         baseOutput({
           exitCode: null,
@@ -57,7 +58,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
           timedOut: false,
         }),
       ),
-    });
+    }));
 
     const result = await tool.execute({ session_id: 1, chars: "" });
 
@@ -66,7 +67,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
   });
 
   test("flags a timed-out kill (exitCode null, no process_id, timedOut) as isError", async () => {
-    const tool = createWriteStdinTool({
+    const tool = bindExplicitDangerBoundary(createWriteStdinTool({
       unifiedExecManager: makeManager(
         baseOutput({
           exitCode: null,
@@ -75,7 +76,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
           timedOut: true,
         }),
       ),
-    });
+    }));
 
     const result = await tool.execute({ session_id: 1, chars: "" });
 
@@ -83,7 +84,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
   });
 
   test("does NOT flag a still-alive yielded process (exitCode null, process_id set)", async () => {
-    const tool = createWriteStdinTool({
+    const tool = bindExplicitDangerBoundary(createWriteStdinTool({
       unifiedExecManager: makeManager(
         baseOutput({
           exitCode: null,
@@ -93,7 +94,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
           timedOut: false,
         }),
       ),
-    });
+    }));
 
     const result = await tool.execute({ session_id: 7, chars: "" });
 
@@ -101,11 +102,11 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
   });
 
   test("does NOT flag a clean completion (exitCode 0)", async () => {
-    const tool = createWriteStdinTool({
+    const tool = bindExplicitDangerBoundary(createWriteStdinTool({
       unifiedExecManager: makeManager(
         baseOutput({ exitCode: 0, exit_code: 0 }),
       ),
-    });
+    }));
 
     const result = await tool.execute({ session_id: 1, chars: "" });
 
@@ -113,11 +114,11 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
   });
 
   test("flags a non-zero exit code as isError", async () => {
-    const tool = createWriteStdinTool({
+    const tool = bindExplicitDangerBoundary(createWriteStdinTool({
       unifiedExecManager: makeManager(
         baseOutput({ exitCode: 1, exit_code: 1 }),
       ),
-    });
+    }));
 
     const result = await tool.execute({ session_id: 1, chars: "" });
 

--- a/runtime/tests/helpers/explicit-danger-boundary.ts
+++ b/runtime/tests/helpers/explicit-danger-boundary.ts
@@ -1,0 +1,37 @@
+import {
+  SandboxExecutionBroker,
+  attachSandboxExecutionBroker,
+} from "../../src/sandbox/execution-broker.js";
+
+export const explicitDangerBroker = new SandboxExecutionBroker({
+  mode: "danger_full_access",
+  cwd: process.cwd(),
+});
+
+/**
+ * Unit tests that intentionally exercise host process mechanics must declare
+ * that intent explicitly, just like an operator selecting --yolo.
+ */
+export function bindExplicitDangerBoundary<
+  T extends {
+    readonly execute: (
+      args: Record<string, unknown>,
+    ) => Promise<unknown>;
+  },
+>(tool: T): T {
+  const execute = tool.execute.bind(tool);
+  return {
+    ...tool,
+    async execute(args: Record<string, unknown>): Promise<unknown> {
+      attachSandboxExecutionBroker(args, explicitDangerBroker);
+      return execute(args);
+    },
+  } as T;
+}
+
+export function withExplicitDangerBoundary(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  attachSandboxExecutionBroker(args, explicitDangerBroker);
+  return args;
+}

--- a/runtime/tests/hooks/configured-hooks.test.ts
+++ b/runtime/tests/hooks/configured-hooks.test.ts
@@ -6,10 +6,28 @@ import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
 
 import {
-  ConfiguredHooksRuntime,
+  ConfiguredHooksRuntime as ProductionConfiguredHooksRuntime,
   matchesPattern,
   type HookInstallTarget,
 } from "./configured-hooks.js";
+import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
+
+const explicitDangerBroker = new SandboxExecutionBroker({
+  mode: "danger_full_access",
+  cwd: process.cwd(),
+});
+
+class ConfiguredHooksRuntime extends ProductionConfiguredHooksRuntime {
+  constructor(
+    options: ConstructorParameters<typeof ProductionConfiguredHooksRuntime>[0],
+  ) {
+    super({
+      ...options,
+      sandboxExecutionBroker:
+        options.sandboxExecutionBroker ?? explicitDangerBroker,
+    });
+  }
+}
 
 describe("configured hooks runtime", () => {
   test("matches exact, pipe, wildcard, and regex patterns", () => {

--- a/runtime/tests/hooks/engine/dispatcher.test.ts
+++ b/runtime/tests/hooks/engine/dispatcher.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./dispatcher.js";
 import { readHookSpecificOutput } from "./output-parser.js";
 import type { HooksMap } from "../../config/schema.js";
+import { explicitDangerBroker } from "../../helpers/explicit-danger-boundary.js";
 
 function makeEngine(config: HooksMap): HookEngine {
   const engine = new HookEngine({
@@ -14,6 +15,7 @@ function makeEngine(config: HooksMap): HookEngine {
     env: process.env,
     shellPath: process.env.SHELL ?? "/bin/sh",
     sourcePath: "/tmp/agenc-hooks-test/config.toml",
+    sandboxExecutionBroker: explicitDangerBroker,
   });
   engine.load(config);
   return engine;

--- a/runtime/tests/hooks/hooks-core.test.ts
+++ b/runtime/tests/hooks/hooks-core.test.ts
@@ -57,6 +57,11 @@ import {
   matchesPattern,
 } from "../../src/utils/hooks.js";
 import type { Message } from "../../src/types/message.js";
+import {
+  clearCurrentRuntimeSession,
+  setCurrentRuntimeSession,
+} from "../../src/session/current-session.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
 
 const tempDirs: string[] = [];
 const sessionId = "00000000-0000-4000-8000-000000000901";
@@ -80,6 +85,10 @@ async function configureHookSession(): Promise<{ configDir: string; cwd: string 
   process.env.AGENC_CONFIG_DIR = configDir;
   delete process.env.AGENC_HOME;
   resetStateForTests();
+  clearCurrentRuntimeSession();
+  setCurrentRuntimeSession({
+    services: { sandboxExecutionBroker: explicitDangerBroker },
+  } as never);
 
   const cwd = join(configDir, "workspace");
   await mkdir(cwd, { recursive: true });
@@ -119,6 +128,7 @@ function acceptInteractiveWorkspaceTrust(): void {
 }
 
 afterEach(async () => {
+  clearCurrentRuntimeSession();
   resetStateForTests();
   restoreOptionalEnv("AGENC_CONFIG_DIR", originalConfigDir);
   restoreOptionalEnv("AGENC_HOME", originalAgenCHome);

--- a/runtime/tests/mcp-client/manager.stdio-lifecycle.test.ts
+++ b/runtime/tests/mcp-client/manager.stdio-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { sourcePath } from "../helpers/source-path.ts";
+import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import { MCPManager } from "./manager.js";
 import type { MCPServerConfig } from "./types.js";
 
@@ -22,6 +23,15 @@ function makeConfig(pidFile: string): MCPServerConfig {
     transport: "stdio",
     timeout: 10_000,
   };
+}
+
+function makeManager(pidFile: string): MCPManager {
+  const manager = new MCPManager([makeConfig(pidFile)]);
+  manager.setSandboxExecutionBroker(new SandboxExecutionBroker({
+    mode: "danger_full_access",
+    cwd: process.cwd(),
+  }));
+  return manager;
 }
 
 async function readPid(pidFile: string): Promise<number> {
@@ -70,7 +80,7 @@ describe("MCPManager stdio lifecycle", () => {
     tempDirs.add(dir);
     const pidFile = join(dir, "server.pid");
 
-    const manager = new MCPManager([makeConfig(pidFile)]);
+    const manager = makeManager(pidFile);
     await manager.start({ requireOneReady: true });
 
     const pid = await readPid(pidFile);
@@ -87,7 +97,7 @@ describe("MCPManager stdio lifecycle", () => {
     tempDirs.add(dir);
     const pidFile = join(dir, "server.pid");
 
-    const manager = new MCPManager([makeConfig(pidFile)]);
+    const manager = makeManager(pidFile);
     await manager.start({ requireOneReady: true });
 
     const firstPid = await readPid(pidFile);

--- a/runtime/tests/mcp-client/resilient-client.test.ts
+++ b/runtime/tests/mcp-client/resilient-client.test.ts
@@ -90,6 +90,7 @@ describe("ResilientMCPBridge", () => {
       logger,
       undefined,
       undefined,
+      undefined,
     );
     expect(mockCreateToolBridge).toHaveBeenCalledWith(
       "client2",
@@ -144,6 +145,7 @@ describe("ResilientMCPBridge", () => {
       logger,
       undefined,
       samplingHandlers,
+      undefined,
     );
 
     await bridge.dispose();

--- a/runtime/tests/mcp-client/transports/stdio.test.ts
+++ b/runtime/tests/mcp-client/transports/stdio.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { Logger } from "../../_deps/logger.js";
+import { SandboxExecutionBroker } from "../../sandbox/execution-broker.js";
 import {
   AgenCStdioClientTransport,
   DEFAULT_STDIO_ENV_VARS,
@@ -12,6 +13,10 @@ import {
 } from "./stdio.js";
 
 const tempDirs = new Set<string>();
+const explicitDangerBroker = new SandboxExecutionBroker({
+  mode: "danger_full_access",
+  cwd: process.cwd(),
+});
 
 afterEach(async () => {
   await Promise.all(
@@ -45,14 +50,18 @@ describe("createStdioMCPEnvironment", () => {
 
 describe("AgenCStdioClientTransport", () => {
   it("decodes newline-delimited JSON-RPC messages from stdout", async () => {
-    const transport = new AgenCStdioClientTransport({
-      command: process.execPath,
-      args: [
-        "-e",
-        "process.stdout.write(JSON.stringify({jsonrpc:'2.0',method:'server/notice',params:{ok:true}})+'\\n'); setTimeout(() => {}, 1000);",
-      ],
-      env: createStdioMCPEnvironment(undefined, undefined),
-    });
+    const transport = new AgenCStdioClientTransport(
+      {
+        command: process.execPath,
+        args: [
+          "-e",
+          "process.stdout.write(JSON.stringify({jsonrpc:'2.0',method:'server/notice',params:{ok:true}})+'\\n'); setTimeout(() => {}, 1000);",
+        ],
+        env: createStdioMCPEnvironment(undefined, undefined),
+      },
+      undefined,
+      explicitDangerBroker,
+    );
 
     const message = new Promise((resolve) => {
       transport.onmessage = resolve;
@@ -119,14 +128,18 @@ describe("AgenCStdioClientTransport", () => {
       tempDirs.add(dir);
       const pidFile = join(dir, "child.pid");
 
-      const transport = new AgenCStdioClientTransport({
-        command: "/bin/sh",
-        args: [
-          "-c",
-          'sleep 300 & child_pid=$!; echo "$child_pid" > "$PID_FILE"; cat >/dev/null',
-        ],
-        env: createStdioMCPEnvironment({ PID_FILE: pidFile }, undefined),
-      });
+      const transport = new AgenCStdioClientTransport(
+        {
+          command: "/bin/sh",
+          args: [
+            "-c",
+            'sleep 300 & child_pid=$!; echo "$child_pid" > "$PID_FILE"; cat >/dev/null',
+          ],
+          env: createStdioMCPEnvironment({ PID_FILE: pidFile }, undefined),
+        },
+        undefined,
+        explicitDangerBroker,
+      );
       await transport.start();
 
       const childPid = await waitForPidFile(pidFile);

--- a/runtime/tests/phases/stop-hooks.test.ts
+++ b/runtime/tests/phases/stop-hooks.test.ts
@@ -7,6 +7,7 @@ import {
   ConfiguredHooksRuntime,
   type HookInstallTarget,
 } from "../hooks/configured-hooks.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
 import { EventLog } from "../session/event-log.js";
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
@@ -337,6 +338,7 @@ describe("evaluateStopHooks", () => {
       env: process.env,
       agencHome: "/tmp/agenc-test",
       shellPath: process.env.SHELL ?? "/bin/sh",
+      sandboxExecutionBroker: explicitDangerBroker,
       // This test exercises hook dispatch; treat the workspace as trusted
       // (production establishes trust before command hooks run).
       isWorkspaceTrusted: () => true,

--- a/runtime/tests/plugins/registration.test.ts
+++ b/runtime/tests/plugins/registration.test.ts
@@ -30,6 +30,7 @@ import { FILE_EDIT_TOOL_NAME } from "../tools/system/file-edit.js";
 import { FILE_READ_TOOL_NAME } from "../tools/system/file-read.js";
 import { FILE_WRITE_TOOL_NAME } from "../tools/system/file-write.js";
 import { createAgentRoleWorkspace } from "../agents/role.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
 
 const PLUGIN_MCP_ENV_SERVER_FIXTURE = sourcePath(
   "plugins/test-fixtures/plugin-mcp-env-server.cjs",
@@ -479,6 +480,7 @@ describe("plugin registration", () => {
           ...config,
         })),
       );
+      manager.setSandboxExecutionBroker(explicitDangerBroker);
 
       try {
         await manager.start({ requireOneReady: true, timeoutMs: 10_000 });
@@ -1600,7 +1602,12 @@ async function withTempPlugin(
     } else {
       process.env.AGENC_PLUGIN_CACHE_DIR = previousCacheDir;
     }
-    await rm(root, { recursive: true, force: true });
+    await rm(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 10,
+    });
   }
 }
 

--- a/runtime/tests/sandbox/engine/linux-engine.test.ts
+++ b/runtime/tests/sandbox/engine/linux-engine.test.ts
@@ -126,7 +126,13 @@ describe("Linux sandbox engine", () => {
         program: "/bin/echo",
         args: ["ok"],
         cwd: "/repo",
-        env: { PATH: "/usr/bin" },
+        env: {
+          PATH: "/repo/fake-bin:/usr/bin",
+          NODE_OPTIONS: "--require=/repo/preload.cjs",
+          NODE_PATH: "/repo/node-modules",
+          LD_PRELOAD: "/repo/inject.so",
+          DYLD_INSERT_LIBRARIES: "/repo/inject.dylib",
+        },
         additionalPermissions: {
           network: { enabled: true },
           fileSystem: {
@@ -153,8 +159,16 @@ describe("Linux sandbox engine", () => {
       platform: "linux",
     });
 
-    expect(result.command[0]).toBe("/opt/agenc-linux-sandbox");
-    expect(result.arg0).toBe("/opt/agenc-linux-sandbox");
+    expect(result.command.slice(0, 2)).toEqual([
+      fs.realpathSync(process.execPath),
+      "/opt/agenc-linux-sandbox",
+    ]);
+    expect(result.arg0).toBe(path.basename(fs.realpathSync(process.execPath)));
+    expect(result.env.PATH).toBe("/repo/fake-bin:/usr/bin");
+    expect(result.env).not.toHaveProperty("NODE_OPTIONS");
+    expect(result.env).not.toHaveProperty("NODE_PATH");
+    expect(result.env).not.toHaveProperty("LD_PRELOAD");
+    expect(result.env).not.toHaveProperty("DYLD_INSERT_LIBRARIES");
     expect(result.command).toContain("--allow-network-for-proxy");
     const profileIndex = result.command.indexOf("--permission-profile");
     const serialized = result.command[profileIndex + 1];
@@ -170,9 +184,9 @@ describe("Linux sandbox engine", () => {
     });
   });
 
-  it("does not require bubblewrap on WSL1 for restricted full-disk write without proxy network", () => {
+  it("rejects a Linux launcher writable by a nominally restricted profile", () => {
     const manager = new SandboxManager();
-    const result = manager.transform({
+    const act = () => manager.transform({
       command: {
         program: "/bin/echo",
         args: ["ok"],
@@ -196,7 +210,9 @@ describe("Linux sandbox engine", () => {
       isWsl1: true,
     });
 
-    expect(result.command[0]).toBe("/opt/agenc-linux-sandbox");
+    expect(act).toThrowError(
+      expect.objectContaining({ code: "writable_linux_sandbox_launcher" }),
+    );
   });
 
   it("detects WSL1 and user namespace failures from command output", () => {

--- a/runtime/tests/sandbox/execution-broker.test.ts
+++ b/runtime/tests/sandbox/execution-broker.test.ts
@@ -1,0 +1,311 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SandboxExecutionBroker,
+  SandboxExecutionError,
+  attachSandboxExecutionBroker,
+  probeSandboxExecutionStatus,
+  readSandboxExecutionBroker,
+  resolveDefaultLinuxSandboxExecutable,
+  type SandboxExecutionStatus,
+} from "../../src/sandbox/execution-broker.js";
+import { applyRuntimeSandboxToSpawn } from "../../src/tools/system/apply-runtime-sandbox.js";
+import {
+  rebaseWorktreeSandboxBrokers,
+  requireWorktreeSandboxBrokers,
+} from "../../src/tools/worktree-sandbox-boundary.js";
+
+const roots: string[] = [];
+
+function tempRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), label));
+  roots.push(root);
+  return root;
+}
+
+function readyStatus(mode: "workspace_write" | "read_only"): SandboxExecutionStatus {
+  return {
+    kind: "ready",
+    mode,
+    platform: process.platform,
+    ...(process.platform === "linux" ? { helperPath: "/opt/agenc-linux-sandbox" } : {}),
+  };
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("SandboxExecutionBroker", () => {
+  it("rejects a process tool when its authenticated boundary is missing", () => {
+    const root = tempRoot("agenc-sandbox-broker-uncovered-");
+
+    expect(() =>
+      applyRuntimeSandboxToSpawn({
+        toolArgs: { command: "touch escaped" },
+        fallbackCwd: root,
+        program: "/bin/sh",
+        args: ["-c", "touch escaped"],
+        cwd: root,
+        env: {},
+        surface: "interactive",
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "sandbox_surface_uncovered",
+        surface: "interactive",
+      }),
+    );
+  });
+
+  it("denies a direct spawn when restricted isolation is unavailable", () => {
+    const root = tempRoot("agenc-sandbox-broker-deny-");
+    const selectInitial = vi.fn();
+    const transform = vi.fn();
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd: root,
+      sandboxManager: { selectInitial, transform },
+      probe: () => ({
+        kind: "unavailable",
+        mode: "workspace_write",
+        platform: process.platform,
+        reason: "probe: namespace creation failed",
+        remediation: "enable user namespaces",
+      }),
+    });
+    const toolArgs: Record<string, unknown> = { command: "touch escaped" };
+    attachSandboxExecutionBroker(toolArgs, broker);
+
+    expect(() =>
+      applyRuntimeSandboxToSpawn({
+        toolArgs,
+        fallbackCwd: root,
+        program: "/bin/sh",
+        args: ["-c", "touch escaped"],
+        cwd: root,
+        env: {},
+        surface: "interactive",
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "sandbox_probe_failed",
+        surface: "interactive",
+      }),
+    );
+    expect(selectInitial).not.toHaveBeenCalled();
+    expect(transform).not.toHaveBeenCalled();
+  });
+
+  it.each(["danger_full_access", "external_sandbox"] as const)(
+    "passes through only the explicit %s mode",
+    (mode) => {
+      const root = tempRoot("agenc-sandbox-broker-explicit-");
+      const broker = new SandboxExecutionBroker({ mode, cwd: root });
+      const command = broker.prepareSpawn("hook", {
+        program: "/bin/echo",
+        args: ["ok"],
+        cwd: root,
+        env: { PATH: "/usr/bin" },
+      });
+
+      expect(command).toMatchObject({
+        program: "/bin/echo",
+        args: ["ok"],
+        cwd: root,
+      });
+    },
+  );
+
+  it("transforms a ready restricted command through the common manager", () => {
+    const root = tempRoot("agenc-sandbox-broker-transform-");
+    const selectInitial = vi.fn(() => "linux_seccomp" as const);
+    const transform = vi.fn(() => ({
+      command: ["/sandbox/helper", "/bin/echo", "ok"],
+      cwd: root,
+      env: { SANDBOXED: "1" },
+      arg0: "sandbox-helper",
+    }));
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd: root,
+      sandboxManager: { selectInitial, transform } as never,
+      probe: () => readyStatus("workspace_write"),
+    });
+
+    const command = broker.prepareSpawn("mcp_stdio", {
+      program: "/bin/echo",
+      args: ["ok"],
+      cwd: root,
+      env: {},
+    });
+
+    expect(command).toMatchObject({
+      program: "/sandbox/helper",
+      args: ["/bin/echo", "ok"],
+      argv0: "sandbox-helper",
+    });
+    expect(selectInitial).toHaveBeenCalledOnce();
+    expect(transform).toHaveBeenCalledOnce();
+  });
+
+  it("rebases captured boundaries and forks independent child roots", () => {
+    const root = tempRoot("agenc-sandbox-broker-root-");
+    const child = tempRoot("agenc-sandbox-broker-child-");
+    const sibling = tempRoot("agenc-sandbox-broker-sibling-");
+    const probedCwds: string[] = [];
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd: root,
+      probe: (options) => {
+        probedCwds.push(options.cwd);
+        return readyStatus("workspace_write");
+      },
+    });
+
+    broker.status();
+    const brokers = requireWorktreeSandboxBrokers({
+      services: { sandboxExecutionBroker: broker },
+    } as never);
+    rebaseWorktreeSandboxBrokers(brokers, child);
+    broker.status();
+    const fork = broker.forkForCwd(sibling);
+    fork.status();
+
+    expect(broker.cwd).toBe(child);
+    expect(fork.cwd).toBe(sibling);
+    expect(probedCwds).toEqual([root, child, sibling]);
+  });
+
+  it("wraps transform failures with a stable code and never returns the host command", () => {
+    const root = tempRoot("agenc-sandbox-broker-transform-fail-");
+    const broker = new SandboxExecutionBroker({
+      mode: "read_only",
+      cwd: root,
+      sandboxManager: {
+        selectInitial: () => "linux_seccomp",
+        transform: () => {
+          throw new Error("launcher disappeared");
+        },
+      } as never,
+      probe: () => readyStatus("read_only"),
+    });
+
+    expect(() =>
+      broker.prepareSpawn("child_agent", {
+        program: "/bin/echo",
+        args: ["unsafe"],
+        cwd: root,
+        env: {},
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "sandbox_transform_failed",
+        surface: "child_agent",
+      }),
+    );
+  });
+
+  it.runIf(process.platform === "linux")(
+    "reports missing, non-executable, and workspace-controlled helpers precisely",
+    () => {
+      const root = tempRoot("agenc-sandbox-broker-helper-");
+      const outside = tempRoot("agenc-sandbox-broker-outside-");
+      const nonExecutable = join(outside, "non-executable");
+      writeFileSync(nonExecutable, "#!/bin/sh\nexit 0\n");
+      chmodSync(nonExecutable, 0o644);
+      const workspaceHelper = join(root, "helper");
+      writeFileSync(workspaceHelper, "#!/bin/sh\nexit 0\n");
+      chmodSync(workspaceHelper, 0o755);
+      const base = {
+        mode: "workspace_write" as const,
+        cwd: root,
+        env: process.env,
+        platform: "linux" as const,
+      };
+
+      expect(
+        probeSandboxExecutionStatus({
+          ...base,
+          agencLinuxSandboxExe: join(outside, "missing"),
+        }).reason,
+      ).toContain("does not exist");
+      expect(
+        probeSandboxExecutionStatus({
+          ...base,
+          agencLinuxSandboxExe: nonExecutable,
+        }).reason,
+      ).toContain("not executable");
+      expect(
+        probeSandboxExecutionStatus({
+          ...base,
+          agencLinuxSandboxExe: workspaceHelper,
+        }).reason,
+      ).toContain("outside the writable workspace");
+    },
+  );
+
+  it("resolves the packaged helper from a bundled dist chunk", () => {
+    const root = tempRoot("agenc-sandbox-package-root-");
+    const chunk = join(root, "dist", "chunks", "execution-broker.js");
+    const helper = join(root, "bin", "agenc-linux-sandbox");
+    mkdirSync(join(root, "bin"), { recursive: true });
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ name: "@tetsuo-ai/runtime" }),
+    );
+    writeFileSync(helper, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    expect(
+      resolveDefaultLinuxSandboxExecutable(pathToFileURL(chunk).href),
+    ).toBe(helper);
+  });
+
+  it("rejects a structurally spoofed broker carrier", () => {
+    expect(
+      readSandboxExecutionBroker({
+        __sandboxExecutionBroker: {
+          mode: "danger_full_access",
+          required: false,
+          prepareSpawn: () => undefined,
+          runtimeSandbox: () => undefined,
+          assertReady: () => undefined,
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("exposes a typed error for operator diagnostics", () => {
+    const root = tempRoot("agenc-sandbox-broker-error-");
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd: root,
+      probe: () => ({
+        kind: "unavailable",
+        mode: "workspace_write",
+        platform: process.platform,
+        reason: "sandbox executable does not exist",
+        remediation: "install the helper",
+      }),
+    });
+
+    try {
+      broker.assertReady("cron");
+      expect.unreachable("assertReady must fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SandboxExecutionError);
+      expect(error).toMatchObject({
+        code: "sandbox_required_unavailable",
+        surface: "cron",
+      });
+      expect(String(error)).toContain("install the helper");
+    }
+  });
+});

--- a/runtime/tests/sandbox/execution-surfaces.test.ts
+++ b/runtime/tests/sandbox/execution-surfaces.test.ts
@@ -1,0 +1,278 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgenCCommandExecService } from "../../src/app-server/command-exec.js";
+import { runHookCommand } from "../../src/hooks/engine/command-runner.js";
+import { AgenCStdioClientTransport } from "../../src/mcp-client/transports/stdio.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { attachSandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { runWithCurrentRuntimeSession } from "../../src/session/current-session.js";
+import { createModelFacingTools } from "../../src/bin/model-facing-tools.js";
+import { CanonicalBashTool } from "../../src/tools/canonicalToolSurface.js";
+import { MonitorTool } from "../../src/tools/MonitorTool/MonitorTool.js";
+import { createMonitorTool } from "../../src/tools/system/monitor.js";
+
+const roots: string[] = [];
+
+function tempRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), label));
+  roots.push(root);
+  return root;
+}
+
+function unavailableBroker(cwd: string): SandboxExecutionBroker {
+  return new SandboxExecutionBroker({
+    mode: "workspace_write",
+    cwd,
+    probe: () => ({
+      kind: "unavailable",
+      mode: "workspace_write",
+      platform: process.platform,
+      reason: "probe: injected namespace failure",
+      remediation: "repair sandbox support",
+    }),
+  });
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("fail-closed process surfaces", () => {
+  it("blocks configured hooks before host spawn", async () => {
+    const root = tempRoot("agenc-sandbox-hook-");
+    const marker = join(root, "hook-escaped");
+
+    await expect(
+      runHookCommand({
+        command: `${process.execPath} -e "require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')"`,
+        cwd: root,
+        env: process.env,
+        shellPath: process.platform === "win32" ? "cmd.exe" : "/bin/sh",
+        stdin: "{}\n",
+        timeoutMs: 5_000,
+        sandboxExecutionBroker: unavailableBroker(root),
+      }),
+    ).rejects.toMatchObject({
+      code: "sandbox_probe_failed",
+      surface: "hook",
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("blocks MCP stdio before host spawn", async () => {
+    const root = tempRoot("agenc-sandbox-mcp-");
+    const marker = join(root, "mcp-escaped");
+    const transport = new AgenCStdioClientTransport(
+      {
+        command: process.execPath,
+        args: ["-e", `require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')`],
+        cwd: root,
+        env: { ...process.env } as Record<string, string>,
+      },
+      undefined,
+      unavailableBroker(root),
+    );
+
+    await expect(transport.start()).rejects.toMatchObject({
+      code: "sandbox_probe_failed",
+      surface: "mcp_stdio",
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("rejects MCP stdio when no sandbox boundary was supplied", async () => {
+    const root = tempRoot("agenc-sandbox-mcp-uncovered-");
+    const marker = join(root, "mcp-uncovered");
+    const transport = new AgenCStdioClientTransport({
+      command: process.execPath,
+      args: ["-e", `require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')`],
+      cwd: root,
+      env: {},
+    });
+
+    await expect(transport.start()).rejects.toThrow("sandbox_surface_uncovered");
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("rejects daemon commandExec requests that omit an explicit policy", async () => {
+    const root = tempRoot("agenc-sandbox-command-exec-");
+    const marker = join(root, "command-exec-escaped");
+    const service = new AgenCCommandExecService();
+
+    await expect(
+      service.start(
+        {
+          command: [
+            process.execPath,
+            "-e",
+            `require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')`,
+          ],
+          cwd: root,
+        },
+        { connectionId: "sandbox-contract" },
+      ),
+    ).rejects.toMatchObject({
+      code: "INVALID_ARGUMENT",
+      message: expect.stringContaining("sandbox_surface_uncovered"),
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it.each([
+    ["interactive", {}, {}],
+    ["print", {}, { options: { isNonInteractiveSession: true } }],
+    ["background", { run_in_background: true }, {}],
+    ["child_agent", {}, { agentId: "child-test" }],
+  ] as const)("blocks %s canonical Bash before host spawn", async (
+    surface,
+    inputExtension,
+    contextExtension,
+  ) => {
+    const root = tempRoot(`agenc-sandbox-${surface}-`);
+    const marker = join(root, `${surface}-escaped`);
+
+    const result = await CanonicalBashTool.call(
+        {
+          command: process.execPath,
+          args: ["-e", `require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')`],
+          cwd: root,
+          ...inputExtension,
+        },
+        {
+          abortController: new AbortController(),
+          services: { sandboxExecutionBroker: unavailableBroker(root) },
+          ...contextExtension,
+        } as never,
+        undefined,
+        undefined,
+      );
+    expect(result).toMatchObject({
+      data: {
+        isError: true,
+        content: expect.stringContaining(
+          `[sandbox_probe_failed] required sandbox blocked ${surface}`,
+        ),
+      },
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("uses the authenticated broker from the active model-turn session", async () => {
+    const root = tempRoot("agenc-sandbox-active-turn-");
+    const marker = join(root, "active-turn-escaped");
+    const broker = unavailableBroker(root);
+
+    const result = await runWithCurrentRuntimeSession(
+      { services: { sandboxExecutionBroker: broker } } as never,
+      () => CanonicalBashTool.call(
+        {
+          command: process.execPath,
+          args: [
+            "-e",
+            `require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')`,
+          ],
+          cwd: root,
+        },
+        { abortController: new AbortController() } as never,
+        undefined,
+        undefined,
+      ),
+    );
+
+    expect(result).toMatchObject({
+      data: {
+        isError: true,
+        content: expect.stringContaining("sandbox_probe_failed"),
+      },
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("blocks system Monitor before unified exec", async () => {
+    const root = tempRoot("agenc-sandbox-monitor-");
+    const marker = join(root, "monitor-escaped");
+    const execCommand = vi.fn();
+    const tool = createMonitorTool({
+      cwd: root,
+      unifiedExecManager: { execCommand } as never,
+    });
+    const args: Record<string, unknown> = {
+      command: `${process.execPath} -e "require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')"`,
+      description: "attempt host escape",
+    };
+    attachSandboxExecutionBroker(args, unavailableBroker(root), "background");
+
+    await expect(tool.execute(args)).resolves.toMatchObject({
+      isError: true,
+      content: expect.stringContaining("sandbox_probe_failed"),
+    });
+    expect(execCommand).not.toHaveBeenCalled();
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("blocks legacy Monitor before Shell.exec spawns", async () => {
+    const root = tempRoot("agenc-sandbox-legacy-monitor-");
+    const marker = join(root, "legacy-monitor-escaped");
+
+    await expect(
+      MonitorTool.call(
+        {
+          command: `${process.execPath} -e "require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')"`,
+          description: "attempt host escape",
+        },
+        {
+          abortController: new AbortController(),
+          setAppState() {},
+          services: { sandboxExecutionBroker: unavailableBroker(root) },
+        } as never,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toMatchObject({
+      code: "sandbox_probe_failed",
+      surface: "background",
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("blocks legacy workflow commands before unified exec", async () => {
+    const root = tempRoot("agenc-sandbox-workflow-");
+    const workflowDir = join(root, ".agenc", "workflows");
+    const marker = join(root, "workflow-escaped");
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(
+      join(workflowDir, "escape.json"),
+      JSON.stringify({
+        command: `${process.execPath} -e "require('fs').writeFileSync(${JSON.stringify(marker)}, 'bad')"`,
+      }),
+    );
+    const execCommand = vi.fn();
+    const workflow = createModelFacingTools({
+      workspaceRoot: root,
+      getSession: () => null,
+      unifiedExecManager: { execCommand } as never,
+    }).find((tool) => tool.name === "WorkflowTool");
+    expect(workflow).toBeDefined();
+    const args: Record<string, unknown> = { name: "escape" };
+    attachSandboxExecutionBroker(args, unavailableBroker(root), "workflow");
+
+    await expect(workflow!.execute(args)).rejects.toMatchObject({
+      code: "sandbox_probe_failed",
+      surface: "workflow",
+    });
+    expect(execCommand).not.toHaveBeenCalled();
+    expect(existsSync(marker)).toBe(false);
+  });
+});

--- a/runtime/tests/services/autoFix/autoFixIntegration.test.ts
+++ b/runtime/tests/services/autoFix/autoFixIntegration.test.ts
@@ -7,6 +7,7 @@ import {
   shouldRunAutoFix,
 } from "./autoFixHook.js";
 import { runAutoFixCheck } from "./autoFixRunner.js";
+import { explicitDangerBroker } from "../../helpers/explicit-danger-boundary.js";
 
 const TEST_CWD = process.cwd();
 
@@ -26,6 +27,7 @@ describe("autoFix end-to-end flow", () => {
       test: config!.test,
       timeout: config!.timeout,
       cwd: TEST_CWD,
+      sandboxExecutionBroker: explicitDangerBroker,
     });
     expect(result.hasErrors).toBe(true);
 
@@ -83,6 +85,7 @@ describe("autoFix end-to-end flow", () => {
       lint: config!.lint,
       timeout: config!.timeout,
       cwd: TEST_CWD,
+      sandboxExecutionBroker: explicitDangerBroker,
     });
     expect(result.hasErrors).toBe(false);
     expect(buildAutoFixContext(result)).toBeNull();

--- a/runtime/tests/services/autoFix/autoFixRunner.test.ts
+++ b/runtime/tests/services/autoFix/autoFixRunner.test.ts
@@ -2,9 +2,20 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-import { runAutoFixCheck } from "./autoFixRunner.js";
+import {
+  runAutoFixCheck,
+  type AutoFixCheckOptions,
+} from "./autoFixRunner.js";
+import { explicitDangerBroker } from "../../helpers/explicit-danger-boundary.js";
 
 const TEST_CWD = process.cwd();
+
+function runAutoFixCheckWithBoundary(options: AutoFixCheckOptions) {
+  return runAutoFixCheck({
+    ...options,
+    sandboxExecutionBroker: explicitDangerBroker,
+  });
+}
 
 function processIsAlive(pid: number): boolean {
   try {
@@ -16,8 +27,17 @@ function processIsAlive(pid: number): boolean {
 }
 
 describe("runAutoFixCheck", () => {
+  test("fails closed before spawn when no sandbox boundary is supplied", async () => {
+    await expect(
+      runAutoFixCheck({
+        lint: 'node -e "process.stdout.write(\"must-not-run\")"',
+        timeout: 5_000,
+        cwd: TEST_CWD,
+      }),
+    ).rejects.toMatchObject({ code: "sandbox_surface_uncovered" });
+  });
   test("returns success when lint command exits 0", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "console.log(\\"all clean\\")"',
       timeout: 5_000,
       cwd: TEST_CWD,
@@ -28,7 +48,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("returns errors when lint command exits non-zero", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "console.log(\\"error: unused var\\"); process.exit(1)"',
       timeout: 5_000,
       cwd: TEST_CWD,
@@ -39,7 +59,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("returns errors when test command exits non-zero", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       test: 'node -e "console.log(\\"FAIL test_foo\\"); process.exit(1)"',
       timeout: 5_000,
       cwd: TEST_CWD,
@@ -50,7 +70,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("runs both lint and test commands", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "console.log(\\"lint ok\\")"',
       test: 'node -e "console.log(\\"test ok\\")"',
       timeout: 5_000,
@@ -62,7 +82,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("skips test if lint fails", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "console.log(\\"lint error\\"); process.exit(1)"',
       test: 'node -e "console.log(\\"should not run\\")"',
       timeout: 5_000,
@@ -74,7 +94,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("handles timeout gracefully", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "setTimeout(() => {}, 10000)"',
       timeout: 100,
       cwd: TEST_CWD,
@@ -94,7 +114,7 @@ describe("runAutoFixCheck", () => {
       "setInterval(() => {}, 1000);",
     ].join(" ");
     try {
-      const result = await runAutoFixCheck({
+      const result = await runAutoFixCheckWithBoundary({
         lint: `node -e '${script}'`,
         timeout: 100,
         cwd: TEST_CWD,
@@ -112,7 +132,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("caps command output while reading", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint:
         "node -e 'process.stdout.write(\"x\".repeat(20000)); process.stderr.write(\"y\".repeat(20000))'",
       timeout: 5_000,
@@ -125,7 +145,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("caps multibyte command output by utf8 bytes", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: "node -e 'process.stdout.write(\"雪\".repeat(5000))'",
       timeout: 5_000,
       cwd: TEST_CWD,
@@ -140,7 +160,7 @@ describe("runAutoFixCheck", () => {
     // Regression: decoding each Buffer chunk independently emitted U+FFFD when a
     // multibyte UTF-8 sequence straddled two 'data' events. '✓' is E2 9C 93;
     // emit [E2 9C] then [93] as separate writes to force the split.
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint:
         'node -e "process.stdout.write(Buffer.from([0xe2,0x9c])); setTimeout(() => process.stdout.write(Buffer.from([0x93])), 30)"',
       timeout: 5_000,
@@ -155,7 +175,7 @@ describe("runAutoFixCheck", () => {
     const controller = new AbortController();
     setTimeout(() => controller.abort("test"), 50);
     const started = Date.now();
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "setTimeout(() => {}, 10000)"',
       timeout: 5_000,
       cwd: TEST_CWD,
@@ -168,7 +188,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("returns success with no commands configured", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       timeout: 5_000,
       cwd: TEST_CWD,
     });
@@ -178,7 +198,7 @@ describe("runAutoFixCheck", () => {
   test("returns success when already aborted before command start", async () => {
     const controller = new AbortController();
     controller.abort("test");
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "process.exit(1)"',
       timeout: 5_000,
       cwd: TEST_CWD,
@@ -188,7 +208,7 @@ describe("runAutoFixCheck", () => {
   });
 
   test("formats error summary for assistant consumption", async () => {
-    const result = await runAutoFixCheck({
+    const result = await runAutoFixCheckWithBoundary({
       lint: 'node -e "console.log(\\"src/foo.ts:10:5 error no-unused-vars\\"); process.exit(1)"',
       timeout: 5_000,
       cwd: TEST_CWD,

--- a/runtime/tests/session/observer-wiring.test.ts
+++ b/runtime/tests/session/observer-wiring.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Event, EventMsg } from "./event-log.js";
 import { createToolBridge } from "../mcp-client/tools.js";
 import { createBashTool } from "../tools/system/bash.js";
+import { bindExplicitDangerBoundary } from "../helpers/explicit-danger-boundary.js";
 import {
   createBashExecObserverForSession,
   createBashExecObserverForSlot,
@@ -124,10 +125,10 @@ describe("observer-wiring — T6 gap #119 session wiring", () => {
     const { session, msgs } = stubSession();
     const execObserver = createBashExecObserverForSession(session);
 
-    const tool = createBashTool({
+    const tool = bindExplicitDangerBoundary(createBashTool({
       cwd: process.cwd(),
       execObserver,
-    });
+    }));
 
     const result = await tool.execute({ command: "true" });
     expect(result.isError).toBeUndefined();

--- a/runtime/tests/session/turn-compat.workspace.test.ts
+++ b/runtime/tests/session/turn-compat.workspace.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAgentRoleWorkspace } from '../../src/agents/role.js'
 import { PermissionModeRegistry } from '../../src/permissions/permission-mode.js'
 import { createEmptyToolPermissionContext } from '../../src/permissions/types.js'
+import { SandboxExecutionBroker } from '../../src/sandbox/execution-broker.js'
 import { runWithCurrentRuntimeSession } from '../../src/session/current-session.js'
 import { Session } from '../../src/session/session.js'
 import {
@@ -126,6 +127,33 @@ describe('turn compatibility catalog boundary', () => {
       ),
     ).rejects.toThrow('agent role workspace mismatch')
     expect(toolsRead).not.toHaveBeenCalled()
+  })
+
+  it('forks the sandbox boundary onto the child execution cwd', async () => {
+    const authority = tempRoot('broker-authority')
+    const worktree = tempRoot('broker-worktree')
+    const parent = foregroundParent(authority)
+    parent.sessionConfiguration.cwd = worktree
+    const parentBroker = new SandboxExecutionBroker({
+      mode: 'danger_full_access',
+      cwd: authority,
+    })
+    ;(parent.services as { sandboxExecutionBroker?: SandboxExecutionBroker })
+      .sandboxExecutionBroker = parentBroker
+
+    const turn = await createTurnCompatSession(parent, {
+      messages: [],
+      systemPrompt: asSystemPrompt(['system']),
+      userContext: {},
+      systemContext: {},
+      canUseTool: async () => ({ behavior: 'allow' }),
+      toolUseContext: foregroundToolContext(authority, [], undefined),
+      querySource: 'repl_main_thread',
+    })
+
+    expect(turn.session.services.sandboxExecutionBroker?.cwd).toBe(worktree)
+    expect(turn.session.services.sandboxExecutionBroker).not.toBe(parentBroker)
+    expect(parentBroker.cwd).toBe(authority)
   })
 
   it('frames legacy tool history once before handing it to Session.runTurn', async () => {

--- a/runtime/tests/tool-registry.test.ts
+++ b/runtime/tests/tool-registry.test.ts
@@ -17,6 +17,7 @@ import {
 import type { Tool } from "./tools/types.js";
 import { QuickJsCodeModeService } from "./tools/code-mode/service.js";
 import { createTaskTools } from "./tools/tasks/index.js";
+import { explicitDangerBroker } from "./helpers/explicit-danger-boundary.js";
 
 afterEach(() => {
   clearExitPlanModeApprovalsForTest();
@@ -222,7 +223,10 @@ describe("tool-registry dynamic and deferred catalog", () => {
   });
 
   test("exec_command dispatch accepts AgenC-style cmd/workdir arguments", async () => {
-    const registry = buildToolRegistry({ workspaceRoot: "/tmp" });
+    const registry = buildToolRegistry({
+      workspaceRoot: "/tmp",
+      sandboxExecutionBroker: explicitDangerBroker,
+    });
 
     const result = await registry.dispatch({
       id: "exec-1",
@@ -240,7 +244,10 @@ describe("tool-registry dynamic and deferred catalog", () => {
   });
 
   test("dispatch wraps plain-string arguments using the consolidated registry surface", async () => {
-    const registry = buildToolRegistry({ workspaceRoot: "/tmp" });
+    const registry = buildToolRegistry({
+      workspaceRoot: "/tmp",
+      sandboxExecutionBroker: explicitDangerBroker,
+    });
 
     const result = await registry.dispatch({
       id: "exec-plain-string",
@@ -665,7 +672,10 @@ describe("tool-registry dynamic and deferred catalog", () => {
   });
 
   test("deferred bash surface is cataloged and loads by explicit selection", async () => {
-    const registry = buildToolRegistry({ workspaceRoot: "/tmp" });
+    const registry = buildToolRegistry({
+      workspaceRoot: "/tmp",
+      sandboxExecutionBroker: explicitDangerBroker,
+    });
     const bash = registry.tools.find((tool) => tool.name === "system.bash");
 
     expect(bash).toMatchObject({

--- a/runtime/tests/tools/PowerShellTool.execution.test.ts
+++ b/runtime/tests/tools/PowerShellTool.execution.test.ts
@@ -14,6 +14,7 @@ import {
   type ToolUseContext,
 } from '../../src/tools/Tool.ts'
 import { PowerShellTool } from '../../src/tools/PowerShellTool/PowerShellTool.tsx'
+import { SandboxExecutionBroker } from '../../src/sandbox/execution-broker.ts'
 
 let tempRoot: string | undefined
 
@@ -32,7 +33,9 @@ function findPowerShellExecutable(): string | null {
   return null
 }
 
-async function makeToolUseContext(): Promise<ToolUseContext> {
+async function makeToolUseContext(
+  boundary: 'danger' | 'unavailable' = 'danger',
+): Promise<ToolUseContext> {
   tempRoot = await mkdtemp(join(tmpdir(), 'agenc-powershell-tool-'))
   setProjectRoot(tempRoot)
   setOriginalCwd(tempRoot)
@@ -50,6 +53,25 @@ async function makeToolUseContext(): Promise<ToolUseContext> {
     setAppState() {},
     setToolJSX() {},
     toolUseId: 'powershell-smoke',
+    services: {
+      sandboxExecutionBroker: boundary === 'danger'
+        ? new SandboxExecutionBroker({
+            mode: 'danger_full_access',
+            cwd: tempRoot,
+          })
+        : new SandboxExecutionBroker({
+            mode: 'workspace_write',
+            cwd: tempRoot,
+            platform: 'linux',
+            probe: () => ({
+              kind: 'unavailable',
+              mode: 'workspace_write',
+              platform: 'linux',
+              reason: 'probe: namespaces disabled by test',
+              remediation: 'repair namespaces',
+            }),
+          }),
+    },
   } as unknown as ToolUseContext
 }
 
@@ -82,4 +104,22 @@ test('PowerShellTool executes a real PowerShell command when available', async (
   expect(result.data.interrupted).toBe(false)
   expect(result.data.stderr).toBe('')
   expect(result.data.stdout).toContain('agenc-powershell-smoke')
+})
+
+test('PowerShellTool preserves a required-sandbox readiness failure', async () => {
+  await expect(
+    PowerShellTool.call(
+      {
+        command: "Write-Output 'must-not-run'",
+        timeout: 5_000,
+        description: 'sandbox failure regression',
+      },
+      await makeToolUseContext('unavailable'),
+      undefined as never,
+      undefined as never,
+    ),
+  ).rejects.toMatchObject({
+    code: 'sandbox_probe_failed',
+    surface: 'interactive',
+  })
 })

--- a/runtime/tests/tools/orchestrator.test.ts
+++ b/runtime/tests/tools/orchestrator.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./orchestrator.js";
 import type { Tool } from "./types.js";
 import { ConfiguredHooksRuntime } from "../hooks/configured-hooks.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
 import { Policy } from "../sandbox/execpolicy/policy.js";
 import { REJECT_RULES_APPROVAL_REASON } from "../sandbox/escalation/unix-escalation.js";
 
@@ -566,6 +567,7 @@ describe("requestApproval — permissionDecisionHooks wiring", () => {
       env: process.env,
       agencHome: "/tmp/agenc-test",
       shellPath: process.env.SHELL ?? "/bin/sh",
+      sandboxExecutionBroker: explicitDangerBroker,
     });
     const target = {
       preToolUseHooks: [],

--- a/runtime/tests/tools/streaming-executor.test.ts
+++ b/runtime/tests/tools/streaming-executor.test.ts
@@ -14,6 +14,7 @@ import { EXCLUSIVE, SHARED_READ } from "./concurrency.js";
 import type { ToolUseBlock } from "../session/turn-state.js";
 import { createExecCommandTool } from "./system/exec-command.js";
 import { UnifiedExecProcessManager } from "../unified-exec/process-manager.js";
+import { withExplicitDangerBoundary } from "../helpers/explicit-danger-boundary.js";
 
 function mockRegistry(
   dispatch: (call: LLMToolCall) => Promise<ToolDispatchResult>,
@@ -251,7 +252,9 @@ describe("StreamingToolExecutor (I-65 + I-41)", () => {
             writable: false,
             configurable: true,
           });
-          const result = await execCommand.execute(args);
+          const result = await execCommand.execute(
+            withExplicitDangerBoundary(args),
+          );
           return {
             content: result.content,
             isError: result.isError,

--- a/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
+++ b/runtime/tests/tools/system/apply-runtime-sandbox.test.ts
@@ -25,18 +25,15 @@ function fakeRuntimeSandbox(
 }
 
 describe("applyRuntimeSandboxToSpawn (TOOL-03/04) — behavioral", () => {
-  it("passes through when no runtime sandbox context is attached", () => {
-    const result = applyRuntimeSandboxToSpawn({
+  it("fails closed when no runtime sandbox boundary is attached", () => {
+    expect(() => applyRuntimeSandboxToSpawn({
       toolArgs: { command: "echo hi" },
       fallbackCwd: process.cwd(),
       program: "/bin/echo",
       args: ["hi"],
       cwd: process.cwd(),
       env: { PATH: "/usr/bin" },
-    });
-    expect(result.program).toBe("/bin/echo");
-    expect(result.args).toEqual(["hi"]);
-    expect(result.env.PATH).toBe("/usr/bin");
+    })).toThrow("sandbox_surface_uncovered");
   });
 
   it("rewrites program/args via SandboxManager.transform when isolation is applied", () => {

--- a/runtime/tests/tools/system/bash-shell-output-cap-m-exec-2.test.ts
+++ b/runtime/tests/tools/system/bash-shell-output-cap-m-exec-2.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { createBashTool } from "../../../src/tools/system/bash.js";
+import { createBashTool as createUnboundBashTool } from "../../../src/tools/system/bash.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+
+const createBashTool = (
+  config?: Parameters<typeof createUnboundBashTool>[0],
+) => bindExplicitDangerBoundary(createUnboundBashTool(config));
 
 // M-EXEC-2 (core-todo.md): the shell-mode spawn path (runSpawnedCommand) accumulated
 // every stdout/stderr chunk into an unbounded Buffer[] and only truncated at flush, so

--- a/runtime/tests/tools/system/bash.i78.test.ts
+++ b/runtime/tests/tools/system/bash.i78.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { createBashTool } from "./bash.js";
+import { createBashTool as createUnboundBashTool } from "./bash.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+
+const createBashTool = (
+  config?: Parameters<typeof createUnboundBashTool>[0],
+) => bindExplicitDangerBoundary(createUnboundBashTool(config));
 
 describe("I-78 bash Buffer chunk accumulation", () => {
   test("multi-byte UTF-8 emoji split across chunks decodes intact", async () => {

--- a/runtime/tests/tools/system/bash.test.ts
+++ b/runtime/tests/tools/system/bash.test.ts
@@ -3,7 +3,12 @@ import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBashTool, isCommandAllowed, validateShellCommand } from "./bash.js";
+import {
+  createBashTool as createUnboundBashTool,
+  isCommandAllowed,
+  validateShellCommand,
+} from "./bash.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
 import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
 import { DEFAULT_DENY_LIST, DEFAULT_DENY_PREFIXES, DANGEROUS_SHELL_PATTERNS } from "./types.js";
 import type { Logger } from "../../utils/logger.js";
@@ -32,6 +37,12 @@ import { statSync, writeFileSync } from "node:fs";
 const mockExecFile = vi.mocked(execFile);
 const mockSpawn = vi.mocked(spawn);
 const mockStatSync = vi.mocked(statSync);
+
+function createBashTool(
+  config?: Parameters<typeof createUnboundBashTool>[0],
+): ReturnType<typeof createUnboundBashTool> {
+  return bindExplicitDangerBoundary(createUnboundBashTool(config));
+}
 
 /** Create a fake ChildProcess for spawn mocking. */
 function createFakeChild() {

--- a/runtime/tests/tools/system/bash.truncateUtf8.test.ts
+++ b/runtime/tests/tools/system/bash.truncateUtf8.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { createBashTool } from "./bash.js";
+import { createBashTool as createUnboundBashTool } from "./bash.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+
+const createBashTool = (
+  config?: Parameters<typeof createUnboundBashTool>[0],
+) => bindExplicitDangerBoundary(createUnboundBashTool(config));
 
 describe("bash truncate() UTF-8 boundary safety", () => {
   test("truncation at a multi-byte boundary does not emit U+FFFD", async () => {

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -5,13 +5,21 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
-  createExecCommandTool,
+  createExecCommandTool as createUnboundExecCommandTool,
   runtimeSandboxForExec,
 } from "./exec-command.js";
-import { createWriteStdinTool } from "./write-stdin.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+import { createWriteStdinTool as createUnboundWriteStdinTool } from "./write-stdin.js";
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
 import type { ExecCommandToolOutput, UnifiedExecProcessManagerLike } from "../../unified-exec/types.js";
 import { attachToolRuntimeContext } from "../runtimes/context.js";
+
+const createExecCommandTool = (
+  config: Parameters<typeof createUnboundExecCommandTool>[0],
+) => bindExplicitDangerBoundary(createUnboundExecCommandTool(config));
+const createWriteStdinTool = (
+  config: Parameters<typeof createUnboundWriteStdinTool>[0],
+) => bindExplicitDangerBoundary(createUnboundWriteStdinTool(config));
 
 function completedExecOutput(stdout: string): ExecCommandToolOutput {
   return {

--- a/runtime/tests/tools/system/monitor.test.ts
+++ b/runtime/tests/tools/system/monitor.test.ts
@@ -6,7 +6,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
-import { createMonitorTool } from "./monitor.js";
+import { createMonitorTool as createUnboundMonitorTool } from "./monitor.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+
+const createMonitorTool = (
+  config: Parameters<typeof createUnboundMonitorTool>[0],
+) => bindExplicitDangerBoundary(createUnboundMonitorTool(config));
 
 describe("Monitor (AgenC port)", () => {
   let manager: UnifiedExecProcessManager;

--- a/runtime/tests/tools/tool-surface-consolidation.test.ts
+++ b/runtime/tests/tools/tool-surface-consolidation.test.ts
@@ -4,6 +4,10 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { sourceUrl } from "../helpers/source-path.ts";
+import {
+  explicitDangerBroker,
+  withExplicitDangerBoundary,
+} from "../helpers/explicit-danger-boundary.js";
 
 import type { Tool, ToolUseContext } from "./Tool.js";
 import { applyToolApprovalConfigToPermissionContext } from "../permissions/tool-approval.js";
@@ -63,6 +67,7 @@ function toolContext(workspace?: string): ToolUseContext {
   return {
     abortController: new AbortController(),
     readFileState: new Map(),
+    services: { sandboxExecutionBroker: explicitDangerBroker },
     getAppState: () => ({
       toolPermissionContext: permissionContextForWorkspace(workspace),
     }),
@@ -260,7 +265,9 @@ describe("old-stack tool surface consolidation", () => {
         (async () => undefined) as never,
         {} as never,
       );
-      const daemon = await createBashTool({ cwd: workspace }).execute(input);
+      const daemon = await createBashTool({ cwd: workspace }).execute(
+        withExplicitDangerBoundary(input),
+      );
 
       expect(resultText(canonical.data)).toContain(workspace);
       expect(daemon.content).toContain(workspace);

--- a/runtime/tests/tui/coverage-swarm/swarm-094-input-processBashCommand.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-094-input-processBashCommand.test.tsx
@@ -371,9 +371,7 @@ describe("processBashCommand coverage swarm 094", () => {
 
     expect(harness.PowerShellTool.call).toHaveBeenCalledWith(
       {
-        _dangerouslyDisableSandboxApproved: true,
         command: "Get-ChildItem",
-        dangerouslyDisableSandbox: true,
       },
       expect.any(Object),
       undefined,

--- a/runtime/tests/utils/doctorDiagnostic.sandbox.test.ts
+++ b/runtime/tests/utils/doctorDiagnostic.sandbox.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSandboxWarning,
+  getSandboxDoctorStatus,
+} from "../../src/utils/doctorDiagnostic.js";
+
+describe("sandbox doctor diagnostic", () => {
+  it("reports an unhealthy required sandbox with actionable stable output", async () => {
+    const status = await getSandboxDoctorStatus({
+      config: { sandbox_mode: "workspace-write" },
+      cwd: process.cwd(),
+      probe: ({ mode, platform }) => ({
+        kind: "unavailable",
+        mode,
+        platform,
+        reason: "probe: user namespaces are disabled",
+        remediation: "enable unprivileged user namespaces",
+      }),
+    });
+
+    expect(status).toMatchObject({
+      kind: "unavailable",
+      mode: "workspace_write",
+      reason: "probe: user namespaces are disabled",
+    });
+    expect(buildSandboxWarning(status)).toEqual({
+      issue:
+        "[sandbox_required_unavailable] probe: user namespaces are disabled",
+      fix: "enable unprivileged user namespaces",
+    });
+  });
+
+  it("does not warn for an explicit danger-full-access selection", async () => {
+    const status = await getSandboxDoctorStatus({
+      config: { sandbox_mode: "danger-full-access" },
+      cwd: process.cwd(),
+    });
+
+    expect(status.kind).toBe("not_required");
+    expect(buildSandboxWarning(status)).toBeNull();
+  });
+});

--- a/runtime/tests/utils/doctorDiagnostic.transaction-guard.test.ts
+++ b/runtime/tests/utils/doctorDiagnostic.transaction-guard.test.ts
@@ -76,6 +76,11 @@ function diagnosticFixture(
     warnings: [],
     ripgrepStatus: { working: true, mode: "system", systemPath: "/usr/bin/rg" },
     transactionGuard,
+    sandbox: {
+      kind: "not_required",
+      mode: "danger_full_access",
+      platform: process.platform,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- centralize required-sandbox execution behind one authenticated broker
- fail closed on unavailable isolation, unsafe launcher environments, stale worktree roots, and uncovered process surfaces
- add operator diagnostics, SDK protocol coverage, design documentation, and revert-sensitive regressions

## Local verification
- runtime typecheck: passed
- focused sandbox matrix: 136 tests passed; Bun PowerShell matrix: 2 tests passed
- full runtime suite: 15,359 tests passed; one pre-existing temp cleanup race was then stabilized and its 25-test file passed in isolation
- SDK build and typecheck: passed
- agent-surface contract components and final TUI scenario: passed
- pre-commit build and PTY startup smoke: passed

Hosted CI was not invoked; this repository uses local gates for test verification.