### PR TITLE
test(runtime): live docker e2e for the eval preflight executor

### DIFF
--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -88,6 +88,18 @@ function spawnBounded(
 const DOCKER_COMMAND_TIMEOUT_MS = 120_000;
 const DEFAULT_TASK_WORKDIR = "/testbed";
 
+export interface DockerContainerRunnerOptions {
+  /**
+   * Accept a bare local image ID (`sha256:<64 hex>`) instead of a
+   * registry-digest-pinned reference. Locally built images have no manifest
+   * digest, so the live e2e fixture cannot satisfy the `@sha256` pin; real
+   * pilot execution must never set this.
+   */
+  readonly allowLocalImageId?: boolean;
+}
+
+const LOCAL_IMAGE_ID_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
 /**
  * Docker-CLI-backed runner for pinned evaluation task images. Every task
  * container is created with `--network none`: preflight and verification are
@@ -95,6 +107,8 @@ const DEFAULT_TASK_WORKDIR = "/testbed";
  * as QA signal instead of being quietly granted network.
  */
 export class DockerContainerRunner implements ContainerRunner {
+  constructor(private readonly options: DockerContainerRunnerOptions = {}) {}
+
   async environment(): Promise<ContainerEnvironment> {
     const version = await spawnBounded(
       "docker",
@@ -115,12 +129,21 @@ export class DockerContainerRunner implements ContainerRunner {
   }
 
   async createTaskContainer(imageReference: string): Promise<ContainerHandle> {
+    const isLocalImageId = LOCAL_IMAGE_ID_PATTERN.test(imageReference);
     const digestIndex = imageReference.lastIndexOf("@sha256:");
-    if (digestIndex < 0) {
+    if (isLocalImageId && this.options.allowLocalImageId !== true) {
+      throw new EvalExecutorError([
+        `refusing to run local image ID ${imageReference}: task images must be pinned by @sha256 digest`,
+      ]);
+    }
+    if (!isLocalImageId && digestIndex < 0) {
       throw new EvalExecutorError([
         `refusing to run ${imageReference}: task images must be pinned by @sha256 digest`,
       ]);
     }
+    const dockerReference = isLocalImageId
+      ? imageReference.slice("sha256:".length)
+      : imageReference;
     const created = await spawnBounded(
       "docker",
       [
@@ -129,7 +152,7 @@ export class DockerContainerRunner implements ContainerRunner {
         "none",
         "--entrypoint",
         "sleep",
-        imageReference,
+        dockerReference,
         "infinity",
       ],
       { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS },
@@ -151,7 +174,7 @@ export class DockerContainerRunner implements ContainerRunner {
     }
     const inspected = await spawnBounded(
       "docker",
-      ["image", "inspect", "--format", "{{.Config.WorkingDir}}", imageReference],
+      ["image", "inspect", "--format", "{{.Config.WorkingDir}}", dockerReference],
       { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS },
     );
     const workdir = inspected.exitCode === 0 && inspected.stdout.trim().length > 0
@@ -159,7 +182,7 @@ export class DockerContainerRunner implements ContainerRunner {
       : DEFAULT_TASK_WORKDIR;
     return {
       id,
-      imageDigest: imageReference.slice(digestIndex + 1),
+      imageDigest: isLocalImageId ? imageReference : imageReference.slice(digestIndex + 1),
       workdir,
     };
   }

--- a/runtime/tests/eval/eval-executor-preflight.test.ts
+++ b/runtime/tests/eval/eval-executor-preflight.test.ts
@@ -313,6 +313,13 @@ describe("docker runner hermetic guards", () => {
     );
   });
 
+  test("refuses a bare local image ID unless explicitly allowed", async () => {
+    const runner = new DockerContainerRunner();
+    await expect(runner.createTaskContainer(`sha256:${"a".repeat(64)}`)).rejects.toThrow(
+      /pinned by @sha256 digest/u,
+    );
+  });
+
   test("refuses container paths that escape simple quoting", async () => {
     const runner = new DockerContainerRunner();
     const handle: ContainerHandle = { id: "x", imageDigest: "sha256:0", workdir: "/testbed" };

--- a/runtime/tests/live/eval-executor-docker.live.test.ts
+++ b/runtime/tests/live/eval-executor-docker.live.test.ts
@@ -1,0 +1,263 @@
+// Live e2e for the eval pilot preflight executor. Requires a working docker
+// daemon; builds a tiny synthetic task image locally (one base-image pull at
+// most) and drives the real DockerContainerRunner end to end: patch
+// application, cold rebuild, in-container log parsing, --network none
+// isolation, and the qualification verdicts. Never pulls pilot images.
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  DockerContainerRunner,
+  mintUpstreamPreflightEvidence,
+  runTriplePreflight,
+  type PilotSourceLockTask,
+  type PreflightTaskInputs,
+  type PreflightTimeouts,
+  type VerifierBundle,
+} from "../../src/eval-executor/index.js";
+
+const BASE_IMAGE = process.env.AGENC_EVAL_E2E_BASE_IMAGE ?? "node:25.9.0-bookworm";
+const HOOK_TIMEOUT_MS = 900_000;
+const TEST_TIMEOUT_MS = 600_000;
+
+const TIMEOUTS: PreflightTimeouts = {
+  patchMs: 60_000,
+  rebuildMs: 120_000,
+  testMs: 120_000,
+  parserMs: 60_000,
+};
+
+const APP_PY = `def add(a, b):
+    return a - b
+
+
+def sub(a, b):
+    return a - b
+`;
+
+const RUN_TESTS_PY = `import app
+
+
+def run(name, ok):
+    print(f"TEST {name} {'PASSED' if ok else 'FAILED'}")
+
+
+run("test_sub", app.sub(5, 3) == 2)
+run("test_add", app.add(2, 3) == 5)
+`;
+
+const DOCKERFILE = `FROM ${BASE_IMAGE}
+WORKDIR /testbed
+COPY app.py run_tests.py ./
+RUN git init -q \\
+  && git config user.email e2e@agenc.test \\
+  && git config user.name agenc-e2e \\
+  && git add . \\
+  && git commit -qm base
+`;
+
+const LOG_PARSER = `def parser(log):
+    import re
+    results = {}
+    for match in re.finditer(r"TEST (\\S+) (PASSED|FAILED)", log):
+        results[match.group(1)] = match.group(2)
+    return results
+`;
+
+function makeBundle(overrides: Partial<VerifierBundle>): VerifierBundle {
+  return {
+    kind: "agenc.eval.swe-bench-live-verifier-bundle",
+    version: "1.0.0",
+    instanceId: "E2E__fake-task-1",
+    testPatch: "",
+    rebuildCommands: ["python3 -m compileall -q app.py run_tests.py"],
+    testCommands: ["python3 run_tests.py 2>&1 | tee test-output.log"],
+    printCommands: ["cat test-output.log"],
+    logParser: LOG_PARSER,
+    failToPass: ["test_add"],
+    passToPass: ["test_sub"],
+    ...overrides,
+  };
+}
+
+function makeTask(image: string): PilotSourceLockTask {
+  const digest = (char: string): `sha256:${string}` => `sha256:${char.repeat(64)}`;
+  return {
+    ordinal: 1,
+    language: "python",
+    instanceId: "E2E__fake-task-1",
+    categories: ["multi_file_fix"],
+    stressors: [],
+    sourceRowDigest: digest("b"),
+    repository: "agenc-e2e/fake-task",
+    pullNumber: "1",
+    issueNumbers: ["1"],
+    baseCommit: "c".repeat(40),
+    createdAt: "2026-07-01T00:00:00Z",
+    commitUrl: "https://example.invalid/agenc-e2e/fake-task",
+    issueText: "add() subtracts instead of adding",
+    image,
+    artifacts: {
+      setupPatch: {
+        digest: digest("d"),
+        sizeBytes: 0,
+        mediaType: "text/x-diff",
+        uri: `cas://sha256/${"d".repeat(64)}`,
+      },
+      referencePatch: {
+        digest: digest("e"),
+        sizeBytes: 1,
+        mediaType: "text/x-diff",
+        uri: `cas://sha256/${"e".repeat(64)}`,
+      },
+      verifierBundle: {
+        digest: digest("f"),
+        sizeBytes: 1,
+        mediaType: "application/vnd.agenc.eval.verifier+json+gzip",
+        uri: `cas://sha256/${"f".repeat(64)}`,
+      },
+      sourceEvidence: {
+        digest: digest("0"),
+        sizeBytes: 1,
+        mediaType: "application/vnd.agenc.eval.source-evidence+json",
+        uri: `cas://sha256/${"0".repeat(64)}`,
+      },
+    },
+  };
+}
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], { cwd, encoding: "utf8" });
+}
+
+describe("eval executor docker live e2e", () => {
+  let context: string;
+  let imageId: string;
+  let goodReferencePatch: Uint8Array;
+  let uselessReferencePatch: Uint8Array;
+
+  beforeAll(async () => {
+    execFileSync("docker", ["version", "--format", "{{.Server.Version}}"], {
+      encoding: "utf8",
+    });
+    context = await mkdtemp(path.join(tmpdir(), "agenc-eval-e2e-"));
+    await writeFile(path.join(context, "app.py"), APP_PY);
+    await writeFile(path.join(context, "run_tests.py"), RUN_TESTS_PY);
+    await writeFile(path.join(context, "Dockerfile"), DOCKERFILE);
+
+    // Generate real git diffs on the host so patch bytes are exact.
+    git(context, ["init", "-q"]);
+    git(context, ["config", "user.email", "e2e@agenc.test"]);
+    git(context, ["config", "user.name", "agenc-e2e"]);
+    git(context, ["add", "app.py", "run_tests.py"]);
+    git(context, ["commit", "-qm", "base"]);
+
+    await writeFile(path.join(context, "app.py"), APP_PY.replace(
+      "def add(a, b):\n    return a - b",
+      "def add(a, b):\n    return a + b",
+    ));
+    goodReferencePatch = new TextEncoder().encode(git(context, ["diff"]));
+    git(context, ["checkout", "--", "app.py"]);
+
+    await writeFile(path.join(context, "app.py"), `${APP_PY}\n# reviewed, no fix\n`);
+    uselessReferencePatch = new TextEncoder().encode(git(context, ["diff"]));
+    git(context, ["checkout", "--", "app.py"]);
+
+    imageId = execFileSync("docker", ["build", "-q", context], { encoding: "utf8" }).trim();
+    expect(imageId).toMatch(/^sha256:[0-9a-f]{64}$/u);
+  }, HOOK_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (imageId) {
+      execFileSync("docker", ["rmi", "-f", imageId], { encoding: "utf8" });
+    }
+    if (context) {
+      await rm(context, { recursive: true, force: true });
+    }
+  }, HOOK_TIMEOUT_MS);
+
+  function inputs(overrides: {
+    bundle?: Partial<VerifierBundle>;
+    referencePatch?: Uint8Array;
+  }): PreflightTaskInputs {
+    return {
+      task: makeTask(imageId),
+      bundle: makeBundle(overrides.bundle ?? {}),
+      setupPatch: new Uint8Array(0),
+      referencePatch: overrides.referencePatch ?? goodReferencePatch,
+    };
+  }
+
+  test("the default runner still refuses local image IDs", async () => {
+    const strict = new DockerContainerRunner();
+    await expect(strict.createTaskContainer(imageId)).rejects.toThrow(
+      /pinned by @sha256 digest/u,
+    );
+  });
+
+  test("qualifies the synthetic task across three cold runs", async () => {
+    const runner = new DockerContainerRunner({ allowLocalImageId: true });
+    const result = await runTriplePreflight(runner, inputs({}), TIMEOUTS);
+    expect(result.runs.map((run) => run.failure)).toEqual([null, null, null]);
+    expect(result.qualified).toBe(true);
+    for (const run of result.runs) {
+      expect(run.verdicts).toMatchObject({
+        baseFailsTargetChecks: true,
+        basePassesRegressionChecks: true,
+        referencePassesAllChecks: true,
+      });
+      expect(run.phases).toHaveLength(2);
+      expect(run.phases[0]!.testResults).toMatchObject({
+        test_add: "FAILED",
+        test_sub: "PASSED",
+      });
+      expect(run.phases[1]!.testResults).toMatchObject({
+        test_add: "PASSED",
+        test_sub: "PASSED",
+      });
+    }
+    const evidence = mintUpstreamPreflightEvidence(result, `sha256:${"9".repeat(64)}`);
+    expect(evidence.status).toBe("complete");
+  }, TEST_TIMEOUT_MS);
+
+  test("a reference patch that does not fix the bug is reference_solution_failed", async () => {
+    const runner = new DockerContainerRunner({ allowLocalImageId: true });
+    const result = await runTriplePreflight(
+      runner,
+      inputs({ referencePatch: uselessReferencePatch }),
+      TIMEOUTS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0]!.failure).toMatchObject({ reason: "reference_solution_failed" });
+    expect(result.runs[0]!.failure!.detail).toContain("test_add");
+  }, TEST_TIMEOUT_MS);
+
+  test("a target check that already passes on base disqualifies the task", async () => {
+    const runner = new DockerContainerRunner({ allowLocalImageId: true });
+    const result = await runTriplePreflight(
+      runner,
+      inputs({ bundle: { failToPass: ["test_sub"], passToPass: ["test_add"] } }),
+      TIMEOUTS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.runs[0]!.failure).toMatchObject({ reason: "base_unexpectedly_passes" });
+  }, TEST_TIMEOUT_MS);
+
+  test("task containers really have no network: egress fails as network_required", async () => {
+    const runner = new DockerContainerRunner({ allowLocalImageId: true });
+    const result = await runTriplePreflight(
+      runner,
+      inputs({
+        bundle: {
+          rebuildCommands: ["curl -sS --max-time 10 https://example.com/"],
+        },
+      }),
+      TIMEOUTS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.runs[0]!.failure).toMatchObject({ reason: "network_required" });
+  }, TEST_TIMEOUT_MS);
+});


### PR DESCRIPTION
## What

Follow-up to #1518: the opt-in live e2e that proves the docker execution path against real containers, per the testing plan in docs/design/eval-pilot-executor.md.

- `runtime/tests/live/eval-executor-docker.live.test.ts` — builds a tiny synthetic task image locally (fake buggy repo + real git history; no pilot-image pulls) and drives the real `DockerContainerRunner` end to end. Five tests: strict-runner refusal of local image IDs, a fully qualified triple preflight (git-apply patches, cold rebuild, in-container python log parsing, verdicts, evidence minting), `reference_solution_failed` on a useless gold patch, `base_unexpectedly_passes` on an already-passing target, and a curl probe proving `--network none` isolation surfaces as `network_required`.
- `DockerContainerRunner` gains `allowLocalImageId` (locally built fixture images have no registry manifest digest). Default stays strict — `@sha256`-pinned references only — and a new hermetic test pins the refusal.

## Verification

Tested SHA: `0dc488d82` (on top of `70af09478` main). Node v25.9.0.

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| Pre-commit hook (build, entrypoints, SDK types, TUI startup smoke) | green |
| Hermetic executor suite `tests/eval/eval-executor-preflight.test.ts` | 12/12 |
| **Live e2e** `vitest run --config vitest.live.config.ts tests/live/eval-executor-docker.live.test.ts` | **5/5 in 5.5s** against docker 29.1.3 |

Skips: full stable suite not rerun (change is one opt-in live test, one hermetic test, and a constructor option whose default-path behavior is pinned by the existing + new hermetic guards).