### PR TITLE
fix(runtime): parse preflight results from printCommands output

### DIFF
--- a/runtime/src/eval-executor/preflight.ts
+++ b/runtime/src/eval-executor/preflight.ts
@@ -170,6 +170,19 @@ async function runPhase(
       lastTestExit = tested.exitCode;
     }
 
+    // Upstream SWE-bench-Live semantics: the log parser consumes the output
+    // of the bundle's print commands (e.g. `cat reports/mocha-results.json`),
+    // not the raw test stdout. Redirect in-container so the host output cap
+    // cannot truncate the parser input.
+    for (const [index, command] of inputs.bundle.printCommands.entries()) {
+      // A failing print command is not fatal by itself; an empty parser
+      // input already surfaces through the taxonomy below.
+      await exec(
+        `print[${index}]`,
+        `( ${command} ) >> ${HELPER_DIR}/parser-input.log`,
+        timeouts.parserMs,
+      );
+    }
     await runner.writeFile(
       handle,
       `${HELPER_DIR}/captured-test-output.log`,
@@ -182,7 +195,7 @@ async function runPhase(
     );
     const parsed = await exec(
       "parse-log",
-      `python3 ${HELPER_DIR}/parse-log.py test-output.log ${HELPER_DIR}/captured-test-output.log`,
+      `python3 ${HELPER_DIR}/parse-log.py ${HELPER_DIR}/parser-input.log test-output.log ${HELPER_DIR}/captured-test-output.log`,
       timeouts.parserMs,
     );
     if (parsed.exitCode !== 0) {

--- a/runtime/tests/eval/eval-executor-preflight.test.ts
+++ b/runtime/tests/eval/eval-executor-preflight.test.ts
@@ -103,6 +103,7 @@ interface PhasePlan {
 
 class FakeContainerRunner implements ContainerRunner {
   readonly writtenFiles: string[] = [];
+  readonly executedScripts: string[] = [];
   private phaseIndex = -1;
 
   constructor(private readonly phases: readonly PhasePlan[]) {}
@@ -126,8 +127,12 @@ class FakeContainerRunner implements ContainerRunner {
 
   async exec(_handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult> {
     const plan = this.phases[this.phaseIndex]!;
+    this.executedScripts.push(request.script);
     if (request.script.includes(" apply ")) {
       return { ...OK, exitCode: plan.applyExitCode ?? 0, stderr: "apply output" };
+    }
+    if (request.script.endsWith(">> /agenc-eval/parser-input.log")) {
+      return OK;
     }
     if (request.script === "make rebuild") {
       return {
@@ -186,6 +191,16 @@ describe("eval executor triple preflight", () => {
     expect(runner.writtenFiles.filter((file) => file.endsWith("test.patch"))).toHaveLength(6);
     expect(runner.writtenFiles.filter((file) => file.endsWith("reference.patch"))).toHaveLength(3);
     expect(runner.writtenFiles.filter((file) => file.endsWith("parse-log.py"))).toHaveLength(6);
+    expect(
+      runner.executedScripts.filter((script) =>
+        script === "( cat test-output.log ) >> /agenc-eval/parser-input.log"
+      ),
+    ).toHaveLength(6);
+    expect(
+      runner.executedScripts.filter((script) => script.includes("parse-log.py")).every((script) =>
+        script.includes("/agenc-eval/parser-input.log ")
+      ),
+    ).toBe(true);
   });
 
   test("a target check passing on base disqualifies the candidate", async () => {


### PR DESCRIPTION
Found by inspecting the first real pilot candidate (cthackers__adm-zip-559) before running it: its tests write results to `reports/mocha-results.json` and the parser is meant to consume `printCommands` output (`cat reports/mocha-results.json`). The phase runner never ran `printCommands`, so any file-reporting task would fail `parser_failed` even when healthy — DynamoRIO only worked because its print command cats the same tee'd log the fallback read.

Fix: run each print command in-container with output redirected to `/agenc-eval/parser-input.log` (no host capture cap on parser input); the parser harness reads that file first, previous fallbacks retained for print-less bundles.

Verification (tested SHA on top of `40b524375`): typecheck clean; hermetic executor suite 12/12 (new assertions pin the print step per phase and the parser candidate order); live docker e2e 5/5 in 5.4s. Skips: full stable suite (change confined to eval-executor phase runner + its tests).