### PR TITLE
fix(runtime): accept the pilot parsers' full passing-status vocabulary

### DIFF
--- a/runtime/src/eval-executor/log-parser.ts
+++ b/runtime/src/eval-executor/log-parser.ts
@@ -64,7 +64,17 @@ export function extractParserResults(stdout: string): Readonly<Record<string, st
   return results;
 }
 
-/** Upstream SWE-bench parsers report "PASSED" for a passing test. */
+/**
+ * The 30 pilot bundles' parsers emit a heterogeneous status vocabulary:
+ * `pass`/`passed`/`passes`/`PASS`/`PASSED`/`ok` on the passing side and
+ * fail/error/skip variants otherwise (surveyed 2026-07-16 across the frozen
+ * source lock). Match passing statuses case-insensitively and anchored;
+ * anything unknown counts as NOT passed, so vocabulary drift disqualifies a
+ * candidate loudly instead of silently qualifying one.
+ */
+const PASSED_STATUS_PATTERN = /^(?:pass(?:ed|es)?|ok)$/iu;
+
 export function testPassed(results: Readonly<Record<string, string>>, testName: string): boolean {
-  return results[testName] === "PASSED";
+  const status = results[testName];
+  return status !== undefined && PASSED_STATUS_PATTERN.test(status.trim());
 }

--- a/runtime/tests/eval/eval-executor-preflight.test.ts
+++ b/runtime/tests/eval/eval-executor-preflight.test.ts
@@ -6,6 +6,7 @@ import {
   mintUpstreamPreflightEvidence,
   PARSE_RESULT_SENTINEL,
   runTriplePreflight,
+  testPassed,
   type ContainerEnvironment,
   type ContainerExecRequest,
   type ContainerExecResult,
@@ -317,6 +318,38 @@ describe("eval executor parser-result extraction", () => {
     ).toEqual({ a: "PASSED" });
     expect(() => extractParserResults("no sentinel")).toThrow(/sentinel/u);
     expect(() => extractParserResults(`${PARSE_RESULT_SENTINEL}[1]`)).toThrow(/JSON object/u);
+  });
+
+  test("accepts the full pilot passing vocabulary and nothing looser", () => {
+    for (const status of ["PASSED", "passed", "pass", "PASS", "passes", "ok", "OK", " pass "]) {
+      expect(testPassed({ t: status }, "t"), status).toBe(true);
+    }
+    for (
+      const status of [
+        "fail", "FAILED", "failure", "error", "errored", "skip", "skipped", "SKIPPED",
+        "xpass", "not passed", "",
+      ]
+    ) {
+      expect(testPassed({ t: status }, "t"), status).toBe(false);
+    }
+    expect(testPassed({}, "t")).toBe(false);
+  });
+
+  test("a lowercase pass/fail vocabulary qualifies a healthy candidate", async () => {
+    // Regression for the first real pilot run: cthackers__adm-zip-559 emits
+    // lowercase "pass"/"fail" and was wrongly disqualified as
+    // regression_check_failed when only the uppercase vocabulary counted.
+    const runner = new FakeContainerRunner([
+      { parserResults: { "target-1": "fail", "target-2": "fail", "regression-1": "pass" } },
+      { parserResults: { "target-1": "pass", "target-2": "pass", "regression-1": "pass" } },
+      { parserResults: { "target-1": "fail", "target-2": "fail", "regression-1": "pass" } },
+      { parserResults: { "target-1": "pass", "target-2": "pass", "regression-1": "pass" } },
+      { parserResults: { "target-1": "fail", "target-2": "fail", "regression-1": "pass" } },
+      { parserResults: { "target-1": "pass", "target-2": "pass", "regression-1": "pass" } },
+    ]);
+    const result = await runTriplePreflight(runner, INPUTS);
+    expect(result.runs[0]!.failure).toBeNull();
+    expect(result.qualified).toBe(true);
   });
 });
 


### PR DESCRIPTION
Second finding from the first real pilot preflight (follow-up to #1520). `cthackers__adm-zip-559` ran end to end (image pulled by digest, `npm install` succeeded offline from the baked image, mocha JSON parsed via printCommands) but was **wrongly disqualified** as `regression_check_failed`: 86/87 tests reported `pass` (lowercase) and `testPassed` only accepted `PASSED`.

Surveyed all 30 frozen verifier bundles: the parsers emit `pass`/`passed`/`passes`/`PASS`/`PASSED`/`ok` for passing and fail/error/skip variants otherwise. `testPassed` now matches passing statuses anchored + case-insensitive; unknown statuses still count as not-passed (drift disqualifies loudly, never qualifies silently).

Verification (on top of `f042a6ece`): typecheck clean; executor suite 14/14 including a vocabulary matrix and a triple-preflight regression reproducing the adm-zip false disqualification — both proven red against the old comparison. Skips: full stable suite (one function + tests); live e2e unaffected (uses PASSED/FAILED).