### PR TITLE
fix(runtime): parser fallback container for python3-less task images

### DIFF
--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { parseArgs } from "node:util";
 import { DockerContainerRunner } from "./container-runner.js";
 import {
+  DEFAULT_PREFLIGHT_TIMEOUTS,
   mintUpstreamPreflightEvidence,
   runTriplePreflight,
   type PreflightTaskInputs,
@@ -52,6 +53,7 @@ async function preflight(options: {
   readonly taskId: string;
   readonly outputDir: string;
   readonly operatorTaskDigest?: string;
+  readonly parserFallbackImage?: string;
 }): Promise<number> {
   const loaded = await loadPilotSourceLock(options.lockPath);
   const task = findPilotTask(loaded.lock, options.taskId);
@@ -67,7 +69,9 @@ async function preflight(options: {
   const runner = new DockerContainerRunner();
   await runner.environment();
 
-  const result = await runTriplePreflight(runner, inputs);
+  const result = await runTriplePreflight(runner, inputs, DEFAULT_PREFLIGHT_TIMEOUTS, {
+    parserFallbackImage: options.parserFallbackImage,
+  });
   const taskDir = path.join(options.outputDir, task.instanceId);
   await mkdir(taskDir, { recursive: true });
   for (const run of result.runs) {
@@ -124,6 +128,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       task: { type: "string" },
       output: { type: "string" },
       "operator-task-digest": { type: "string" },
+      "parser-fallback-image": { type: "string" },
     },
     strict: true,
   });
@@ -144,6 +149,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       taskId: values.task,
       outputDir: values.output ?? "eval-executor-output",
       operatorTaskDigest: digest,
+      parserFallbackImage: values["parser-fallback-image"],
     });
   }
   process.stderr.write(`Unknown command ${command}\n${USAGE}\n`);

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -187,12 +187,66 @@ export class DockerContainerRunner implements ContainerRunner {
     };
   }
 
+  async createAuxiliaryContainer(imageReference: string): Promise<ContainerHandle> {
+    const created = await spawnBounded(
+      "docker",
+      ["create", "--network", "none", "--entrypoint", "sleep", imageReference, "infinity"],
+      { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS },
+    );
+    if (created.exitCode !== 0 || created.stdout.trim().length === 0) {
+      throw new EvalExecutorError([
+        `docker create failed for auxiliary image ${imageReference}: ${created.stderr.trim()}`,
+      ]);
+    }
+    const id = created.stdout.trim();
+    const started = await spawnBounded("docker", ["start", id], {
+      timeoutMs: DOCKER_COMMAND_TIMEOUT_MS,
+    });
+    if (started.exitCode !== 0) {
+      await spawnBounded("docker", ["rm", "-f", id], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+      throw new EvalExecutorError([
+        `docker start failed for auxiliary image ${imageReference}: ${started.stderr.trim()}`,
+      ]);
+    }
+    return { id, imageDigest: imageReference, workdir: "/" };
+  }
+
   async exec(handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult> {
     return spawnBounded(
       "docker",
       ["exec", "-w", handle.workdir, handle.id, "bash", "-c", request.script],
       { timeoutMs: request.timeoutMs },
     );
+  }
+
+  async copyFile(
+    source: ContainerHandle,
+    sourcePath: string,
+    target: ContainerHandle,
+    targetPath: string,
+  ): Promise<void> {
+    for (const candidate of [sourcePath, targetPath]) {
+      if (!candidate.startsWith("/") || candidate.includes("'")) {
+        throw new EvalExecutorError([`invalid container path ${candidate}`]);
+      }
+    }
+    const pipeline =
+      `set -o pipefail; docker exec ${source.id} cat '${sourcePath}' | ` +
+      `docker exec -i ${target.id} bash -c "mkdir -p \\"\\$(dirname '${targetPath}')\\" && cat > '${targetPath}'"`;
+    const result = await spawnBounded("bash", ["-c", pipeline], {
+      timeoutMs: DOCKER_COMMAND_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) {
+      // Do not leave a truncated/empty target behind for fallback readers.
+      await spawnBounded(
+        "docker",
+        ["exec", target.id, "rm", "-f", targetPath],
+        { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS },
+      );
+      throw new EvalExecutorError([
+        `failed to copy ${sourcePath} between containers: ${result.stderr.trim()}`,
+      ]);
+    }
   }
 
   async writeFile(handle: ContainerHandle, containerPath: string, bytes: Uint8Array): Promise<void> {

--- a/runtime/src/eval-executor/index.ts
+++ b/runtime/src/eval-executor/index.ts
@@ -6,10 +6,12 @@ export {
   testPassed,
 } from "./log-parser.js";
 export {
+  DEFAULT_PARSER_FALLBACK_IMAGE,
   DEFAULT_PREFLIGHT_TIMEOUTS,
   mintUpstreamPreflightEvidence,
   runSinglePreflight,
   runTriplePreflight,
+  type PreflightExecutionOptions,
   type PreflightTaskInputs,
   type PreflightTimeouts,
 } from "./preflight.js";

--- a/runtime/src/eval-executor/preflight.ts
+++ b/runtime/src/eval-executor/preflight.ts
@@ -37,6 +37,19 @@ export const DEFAULT_PREFLIGHT_TIMEOUTS: PreflightTimeouts = {
   parserMs: 300_000,
 };
 
+/**
+ * Some task images (the .NET pilot candidates) ship no python3, so the
+ * frozen log parser cannot run inside them. It then runs in this auxiliary
+ * offline container instead — never on the host. The node bookworm image is
+ * already an executor dependency (phase-2 agent overlay) and carries
+ * python3; operators may override per environment.
+ */
+export const DEFAULT_PARSER_FALLBACK_IMAGE = "node:25.9.0-bookworm";
+
+export interface PreflightExecutionOptions {
+  readonly parserFallbackImage?: string;
+}
+
 export interface PreflightTaskInputs {
   readonly task: PilotSourceLockTask;
   readonly bundle: VerifierBundle;
@@ -84,6 +97,7 @@ async function runPhase(
   inputs: PreflightTaskInputs,
   phase: "base" | "reference",
   timeouts: PreflightTimeouts,
+  options: PreflightExecutionOptions,
 ): Promise<PhaseOutcome> {
   const commands: PreflightCommandRecord[] = [];
   const appliedPatches: string[] = [];
@@ -107,8 +121,9 @@ async function runPhase(
       label: string,
       script: string,
       timeoutMs: number,
+      target: ContainerHandle = handle,
     ): Promise<ContainerExecResult> => {
-      const result = await runner.exec(handle, { script, timeoutMs });
+      const result = await runner.exec(target, { script, timeoutMs });
       commands.push(record(label, script, result));
       if (result.timedOut) {
         throw new PreflightPhaseFailure("timeout", `${label} exceeded ${timeoutMs}ms`);
@@ -188,16 +203,37 @@ async function runPhase(
       `${HELPER_DIR}/captured-test-output.log`,
       new TextEncoder().encode(capturedTestOutput),
     );
-    await runner.writeFile(
-      handle,
-      `${HELPER_DIR}/parse-log.py`,
-      new TextEncoder().encode(buildParserProgram(inputs.bundle.logParser)),
-    );
-    const parsed = await exec(
-      "parse-log",
-      `python3 ${HELPER_DIR}/parse-log.py ${HELPER_DIR}/parser-input.log test-output.log ${HELPER_DIR}/captured-test-output.log`,
-      timeouts.parserMs,
-    );
+    const parserProgram = new TextEncoder().encode(buildParserProgram(inputs.bundle.logParser));
+    const parserScript =
+      `python3 ${HELPER_DIR}/parse-log.py ${HELPER_DIR}/parser-input.log test-output.log ${HELPER_DIR}/captured-test-output.log`;
+    const probe = await exec("probe-python3", "command -v python3", timeouts.patchMs);
+    let parsed: ContainerExecResult;
+    if (probe.exitCode === 0) {
+      await runner.writeFile(handle, `${HELPER_DIR}/parse-log.py`, parserProgram);
+      parsed = await exec("parse-log", parserScript, timeouts.parserMs);
+    } else {
+      // The task image ships no python3 (the .NET candidates). Run the
+      // frozen parser in an offline auxiliary container instead — still
+      // never on the host. test-output.log is workdir-relative and is not
+      // copied; the printed parser input and the captured output cover it.
+      const aux = await runner.createAuxiliaryContainer(
+        options.parserFallbackImage ?? DEFAULT_PARSER_FALLBACK_IMAGE,
+      );
+      try {
+        await runner.writeFile(aux, `${HELPER_DIR}/parse-log.py`, parserProgram);
+        for (const file of ["parser-input.log", "captured-test-output.log"]) {
+          try {
+            await runner.copyFile(handle, `${HELPER_DIR}/${file}`, aux, `${HELPER_DIR}/${file}`);
+          } catch {
+            // An absent candidate file is fine; the harness reads the first
+            // readable candidate.
+          }
+        }
+        parsed = await exec("parse-log[fallback]", parserScript, timeouts.parserMs, aux);
+      } finally {
+        await runner.remove(aux);
+      }
+    }
     if (parsed.exitCode !== 0) {
       throw new PreflightPhaseFailure(
         "parser_failed",
@@ -265,6 +301,7 @@ export async function runSinglePreflight(
   inputs: PreflightTaskInputs,
   runIndex: 1 | 2 | 3,
   timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
+  options: PreflightExecutionOptions = {},
 ): Promise<PreflightRunReport> {
   const startedAt = new Date().toISOString();
   const environment = await runner.environment();
@@ -279,7 +316,7 @@ export async function runSinglePreflight(
   let referencePassesAllChecks = false;
   let failure: PreflightRunReport["failure"] = null;
 
-  const base = await runPhase(runner, inputs, "base", timeouts);
+  const base = await runPhase(runner, inputs, "base", timeouts, options);
   phases.push(base.transcript);
   if (base.failure) {
     failure = base.failure;
@@ -302,7 +339,7 @@ export async function runSinglePreflight(
   }
 
   if (!failure) {
-    const reference = await runPhase(runner, inputs, "reference", timeouts);
+    const reference = await runPhase(runner, inputs, "reference", timeouts, options);
     phases.push(reference.transcript);
     if (reference.failure) {
       failure = reference.failure;
@@ -360,10 +397,11 @@ export async function runTriplePreflight(
   runner: ContainerRunner,
   inputs: PreflightTaskInputs,
   timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
+  options: PreflightExecutionOptions = {},
 ): Promise<TriplePreflightResult> {
   const runs: PreflightRunReport[] = [];
   for (const runIndex of [1, 2, 3] as const) {
-    const report = await runSinglePreflight(runner, inputs, runIndex, timeouts);
+    const report = await runSinglePreflight(runner, inputs, runIndex, timeouts, options);
     runs.push(report);
     if (report.failure) break;
   }

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -109,8 +109,22 @@ export interface ContainerExecResult {
  */
 export interface ContainerRunner {
   createTaskContainer(imageReference: string): Promise<ContainerHandle>;
+  /**
+   * Executor-owned tooling container (also `--network none`), e.g. to run
+   * the frozen log parser when a task image ships no python3. Never used
+   * for task material, so the image is operator configuration and may be a
+   * tag instead of a digest pin.
+   */
+  createAuxiliaryContainer(imageReference: string): Promise<ContainerHandle>;
   exec(handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult>;
   writeFile(handle: ContainerHandle, containerPath: string, bytes: Uint8Array): Promise<void>;
+  /** Copy one file between containers without staging it on the host. */
+  copyFile(
+    source: ContainerHandle,
+    sourcePath: string,
+    target: ContainerHandle,
+    targetPath: string,
+  ): Promise<void>;
   remove(handle: ContainerHandle): Promise<void>;
   environment(): Promise<ContainerEnvironment>;
 }

--- a/runtime/tests/eval/eval-executor-preflight.test.ts
+++ b/runtime/tests/eval/eval-executor-preflight.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  DEFAULT_PARSER_FALLBACK_IMAGE,
   DockerContainerRunner,
   EvalExecutorError,
   extractParserResults,
@@ -100,14 +101,32 @@ interface PhasePlan {
   readonly testTimedOut?: boolean;
   readonly parserExitCode?: number;
   readonly parserResults?: Record<string, string>;
+  readonly pythonMissing?: boolean;
 }
 
 class FakeContainerRunner implements ContainerRunner {
   readonly writtenFiles: string[] = [];
   readonly executedScripts: string[] = [];
+  readonly auxiliaryImages: string[] = [];
+  readonly copiedFiles: string[] = [];
+  readonly removedIds: string[] = [];
   private phaseIndex = -1;
 
   constructor(private readonly phases: readonly PhasePlan[]) {}
+
+  async createAuxiliaryContainer(imageReference: string): Promise<ContainerHandle> {
+    this.auxiliaryImages.push(imageReference);
+    return { id: `aux-${this.auxiliaryImages.length}`, imageDigest: imageReference, workdir: "/" };
+  }
+
+  async copyFile(
+    _source: ContainerHandle,
+    sourcePath: string,
+    _target: ContainerHandle,
+    targetPath: string,
+  ): Promise<void> {
+    this.copiedFiles.push(`${sourcePath} -> ${targetPath}`);
+  }
 
   async environment(): Promise<ContainerEnvironment> {
     return { engine: "docker", serverVersion: "0.0.0-fake", platform: "linux", arch: "x64" };
@@ -135,6 +154,9 @@ class FakeContainerRunner implements ContainerRunner {
     if (request.script.endsWith(">> /agenc-eval/parser-input.log")) {
       return OK;
     }
+    if (request.script === "command -v python3") {
+      return { ...OK, exitCode: plan.pythonMissing ? 1 : 0 };
+    }
     if (request.script === "make rebuild") {
       return {
         ...OK,
@@ -159,7 +181,9 @@ class FakeContainerRunner implements ContainerRunner {
     this.writtenFiles.push(containerPath);
   }
 
-  async remove(): Promise<void> {}
+  async remove(handle: ContainerHandle): Promise<void> {
+    this.removedIds.push(handle.id);
+  }
 }
 
 const BASE_OK: PhasePlan = {
@@ -281,6 +305,43 @@ describe("eval executor triple preflight", () => {
     }
   });
 
+  test("runs the parser in an auxiliary container when the task image has no python3", async () => {
+    // Regression for the .NET pilot candidates (spectre.console, MudBlazor):
+    // their images ship no python3, and the parser step previously failed as
+    // parser_failed, falsely disqualifying healthy candidates.
+    const runner = new FakeContainerRunner([
+      { ...BASE_OK, pythonMissing: true },
+      { ...REFERENCE_OK, pythonMissing: true },
+      { ...BASE_OK, pythonMissing: true },
+      { ...REFERENCE_OK, pythonMissing: true },
+      { ...BASE_OK, pythonMissing: true },
+      { ...REFERENCE_OK, pythonMissing: true },
+    ]);
+    const result = await runTriplePreflight(runner, INPUTS);
+    expect(result.runs[0]!.failure).toBeNull();
+    expect(result.qualified).toBe(true);
+    expect(runner.auxiliaryImages).toHaveLength(6);
+    expect(new Set(runner.auxiliaryImages)).toEqual(new Set([DEFAULT_PARSER_FALLBACK_IMAGE]));
+    expect(
+      runner.copiedFiles.filter((copy) => copy.startsWith("/agenc-eval/parser-input.log")),
+    ).toHaveLength(6);
+    // Every auxiliary container is removed alongside the six phase containers.
+    expect(runner.removedIds.filter((id) => id.startsWith("aux-"))).toHaveLength(6);
+    expect(runner.removedIds.filter((id) => id.startsWith("fake-"))).toHaveLength(6);
+    const fallbackParses = runner.executedScripts.filter((script) =>
+      script.includes("parse-log.py")
+    );
+    expect(fallbackParses).toHaveLength(6);
+  });
+
+  test("a custom parser fallback image is honored", async () => {
+    const runner = new FakeContainerRunner([{ ...BASE_OK, pythonMissing: true }]);
+    await runTriplePreflight(runner, INPUTS, undefined, {
+      parserFallbackImage: "python:3.12-slim",
+    });
+    expect(new Set(runner.auxiliaryImages)).toEqual(new Set(["python:3.12-slim"]));
+  });
+
   test("mints upstream preflight evidence only for a fully qualified triple", async () => {
     const runner = new FakeContainerRunner([
       BASE_OK, REFERENCE_OK, BASE_OK, REFERENCE_OK, BASE_OK, REFERENCE_OK,
@@ -376,6 +437,12 @@ describe("docker runner hermetic guards", () => {
     ).rejects.toThrow(/invalid container path/u);
     await expect(
       runner.writeFile(handle, "relative/path", new Uint8Array(1)),
+    ).rejects.toThrow(/invalid container path/u);
+    await expect(
+      runner.copyFile(handle, "/ok/source", handle, "relative/target"),
+    ).rejects.toThrow(/invalid container path/u);
+    await expect(
+      runner.copyFile(handle, "/it's-a-trap", handle, "/ok/target"),
     ).rejects.toThrow(/invalid container path/u);
   });
 });


### PR DESCRIPTION
Third executor finding from the live qualification sweep (after #1520 printCommands and #1521 status vocabulary): the two .NET candidates were falsely disqualified `parser_failed` — their images ship no python3, and the frozen parser runs in-container by design.

Fix: probe `command -v python3` in the task container; when absent, run the parser in an executor-owned auxiliary container (default `node:25.9.0-bookworm`, overridable via `--parser-fallback-image`), still `--network none` and never on the host. Files move container-to-container (no host staging, no host output cap on parser input); a failed copy removes the partial target so an empty file cannot read as an empty-but-valid parse.

Verification (worktree off `07ddd3b26`): typecheck clean (SDK workspace built); `tests/eval` 138/138; revert-sensitivity proven (removing the probe branch turns 2 tests red). Skips: full stable suite (change confined to eval-executor + its tests); live e2e covers the python3-present path — the fallback path gets its real-container proof when the two .NET candidates are requalified next.