### PR TITLE
feat(runtime): eval executor phase-2a offline agent-run lane

### DIFF
--- a/docs/design/eval-pilot-executor.md
+++ b/docs/design/eval-pilot-executor.md
@@ -135,7 +135,57 @@ patch does not pass — broken verifier or patch), `patch_apply_failed`,
 say something about the *task*; the rest say something about the
 *environment* and are retryable.
 
-## Phase 2 — real-agent run (designed, not yet implemented)
+## Phase 2a — offline agent run (implemented)
+
+Module `runtime/src/eval-executor/agent-run.ts`, CLI
+`eval:executor run-agent --task <id> --overlay <dir>`. Runs the real AgenC
+runtime inside a pinned task container, collects its patch, and verifies it
+with the hidden verifier — all offline.
+
+- **Overlay:** the operator stages a directory with `node/` (official Node 25
+  linux-x64), `runtime/` (extracted `agenc-runtime-*-linux-x64` release
+  tarball), and `mock/serve.mjs` (the bundled offline provider). It is
+  bind-mounted read-only at `/agenc-overlay`. `assertOverlayLayout` checks the
+  three required entrypoints; `computeOverlayDigest` records which `agenc.js`
+  build was evaluated in the run report.
+- **Provider:** always the in-container offline mock (`--network none`). There
+  are no secrets in any container and no egress. This lane validates the
+  pipeline mechanically; it does not yet measure a real model.
+- **Oracle isolation (structural):** the agent container receives only the
+  setup patch, issue text, and read-only overlay — never the test patch,
+  reference solution, or verifier bundle. Before the agent runs, `.git`
+  remotes and reflog are pruned as defence-in-depth. Verification runs
+  afterwards in a fresh `--network none` container via the shared
+  `verifyCandidatePatch` (reusing the preflight phase machinery, so the
+  taxonomy stays unified).
+- **Patch collection:** after applying the setup patch, a baseline commit is
+  tagged (`agenc-eval-baseline`); the candidate is `git diff <baseline> HEAD`
+  after committing any work the agent left uncommitted, transported as base64.
+  This makes collection correct in three ways the first draft was not: the
+  setup patch is excluded from the candidate, an agent that commits its work
+  is still captured, and non-UTF-8 patch bytes survive intact.
+- **Outcomes:** `verified_fix | verification_failure | empty_patch |
+  agent_error | agent_timeout | infrastructure_error`. A truncated patch is
+  never verified; a failed in-container mock is `infrastructure_error`, not
+  `agent_error`.
+
+## Phase 2b — real-model lane (deferred; requires egress control)
+
+A lane that runs a real provider needs container egress to reach the model
+API, which reintroduces an oracle-leak surface: a `--yolo` agent with open
+egress could fetch the upstream fix (the tasks are cut from merged public
+GitHub PRs) or exfiltrate provider keys under prompt injection from the
+untrusted issue text. This lane is therefore NOT part of 2a. It requires:
+
+- an egress-allowlist proxy sidecar that permits only the configured provider
+  host, not raw bridge networking;
+- full `.git` oracle hygiene (remove all non-HEAD refs/branches, not only
+  remotes and reflog) so the fix commit is unrecoverable offline;
+- provider secrets passed via `docker exec -e`, never inlined into an argv
+  script visible in host process listings;
+- a contamination marker in the run report until the above are proven.
+
+## Phase 2 — evidence-ledger binding (designed, not yet implemented)
 
 - **Agent placement:** the agent runs *inside* the task container so it can
   build and test with the image toolchain. There is no standalone agenc

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -1,0 +1,391 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { digestCanonicalJson, sha256Digest, type Sha256Digest } from "../eval-contract/index.js";
+import {
+  verifyCandidatePatch,
+  DEFAULT_PREFLIGHT_TIMEOUTS,
+  type PreflightExecutionOptions,
+  type PreflightTimeouts,
+} from "./preflight.js";
+import { EvalExecutorError } from "./source-lock.js";
+import type {
+  AgentRunOutcome,
+  AgentRunReport,
+  ContainerHandle,
+  ContainerRunner,
+  PilotSourceLockTask,
+  VerifierBundle,
+} from "./types.js";
+
+const OVERLAY_CONTAINER_PATH = "/agenc-overlay";
+const AGENT_HELPER_DIR = "/agenc-eval";
+const AGENT_HOME = `${AGENT_HELPER_DIR}/agent-home`;
+export const EVAL_BASELINE_TAG = "agenc-eval-baseline";
+const GIT_IDENTITY = "-c user.email=eval@agenc.invalid -c user.name=agenc-eval";
+
+/**
+ * `.git` hygiene + a post-setup baseline commit tagged `agenc-eval-baseline`.
+ * Runs after the setup patch is applied so the baseline tree = base + setup;
+ * the candidate is later diffed from this tag, excluding the setup hunks.
+ * Exported so tests exercise the exact shell the executor runs.
+ */
+export function buildBaselineGitScript(): string {
+  return [
+    `git remote 2>/dev/null | while read -r r; do git remote remove "$r"; done`,
+    `git reflog expire --expire=now --all 2>/dev/null || true`,
+    `git gc --prune=now --quiet 2>/dev/null || true`,
+    `git ${GIT_IDENTITY} -c core.fileMode=false add -A`,
+    `git ${GIT_IDENTITY} commit -q --allow-empty -m ${EVAL_BASELINE_TAG}`,
+    `git tag -f ${EVAL_BASELINE_TAG}`,
+  ].join("\n");
+}
+
+/**
+ * Collect the agent's net change from the tagged baseline, committing any
+ * work the agent left uncommitted so committed and uncommitted changes are
+ * captured alike. `set -eo pipefail` fails the whole script if any git step
+ * or the base64 pipe fails; base64 avoids a lossy UTF-8 round trip.
+ */
+export function buildCandidateCollectionScript(): string {
+  return [
+    `set -eo pipefail`,
+    `git ${GIT_IDENTITY} add -A`,
+    `git ${GIT_IDENTITY} commit -q --allow-empty -m agenc-eval-candidate`,
+    `git -c core.quotepath=false diff ${EVAL_BASELINE_TAG} HEAD --binary | base64 | tr -d '\\n'`,
+  ].join("\n");
+}
+const ENVIRONMENT_DIGEST_DOMAIN = "agenc.eval.executor-agent-environment.v1";
+const REPORT_DIGEST_DOMAIN = "agenc.eval.executor-agent-run-report.v1";
+const PROMPT_DIGEST_DOMAIN = "agenc.eval.executor-agent-prompt.v1";
+
+/**
+ * Version 1 of the fixed prompt wrapper. Identical for every task and every
+ * system; the issue text is untrusted repository-adjacent content and grants
+ * no capabilities.
+ */
+export const AGENT_PROMPT_PREAMBLE_V1 =
+  "You are fixing a real repository issue. The repository is checked out at " +
+  "the current working directory. Implement the code change that resolves " +
+  "the issue described below, keeping the change minimal and consistent " +
+  "with the surrounding code. Do not modify or delete existing tests. " +
+  "Ensure every change is saved to disk before you finish.\n\nISSUE:\n";
+
+export interface AgentOverlay {
+  /** Host directory containing `node/`, `runtime/`, and `mock/`. */
+  readonly hostDir: string;
+}
+
+export interface AgentRunInputs {
+  readonly task: PilotSourceLockTask;
+  readonly bundle: VerifierBundle;
+  readonly setupPatch: Uint8Array;
+}
+
+export interface AgentRunConfig {
+  readonly overlay: AgentOverlay;
+  readonly agentTimeoutMs?: number;
+}
+
+export const DEFAULT_AGENT_TIMEOUT_MS = 1_800_000;
+
+const AGENT_RUNTIME_ENTRY =
+  `${OVERLAY_CONTAINER_PATH}/runtime/node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js`;
+const OVERLAY_AGENT_ENTRY_SUBPATH = path.join(
+  "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "bin", "agenc.js",
+);
+
+export async function assertOverlayLayout(overlay: AgentOverlay): Promise<void> {
+  const required = [
+    path.join(overlay.hostDir, "node", "bin", "node"),
+    path.join(overlay.hostDir, OVERLAY_AGENT_ENTRY_SUBPATH),
+    path.join(overlay.hostDir, "mock", "serve.mjs"),
+  ];
+  for (const file of required) {
+    try {
+      await access(file);
+    } catch {
+      throw new EvalExecutorError([`agent overlay is missing ${file}`]);
+    }
+  }
+}
+
+/**
+ * Attest which agent build is under test by digesting the overlay's runtime
+ * entrypoint (and its VERSION when present). Without this the report cannot
+ * say which agenc.js produced an outcome.
+ */
+async function computeOverlayDigest(overlay: AgentOverlay): Promise<Sha256Digest> {
+  const entry = await readFile(path.join(overlay.hostDir, OVERLAY_AGENT_ENTRY_SUBPATH));
+  let version = "";
+  try {
+    version = await readFile(
+      path.join(overlay.hostDir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "VERSION"),
+      "utf8",
+    );
+  } catch {
+    version = "unknown";
+  }
+  return digestCanonicalJson("agenc.eval.executor-agent-overlay.v1", {
+    entryDigest: sha256Digest(entry),
+    version: version.trim(),
+  });
+}
+
+/**
+ * The agent script. The provider is always the bundled in-container offline
+ * mock and the container is always `--network none`, so there are no secrets
+ * to inline and no egress to leak the oracle. `.git` remotes/reflog are
+ * pruned before the agent runs; a post-setup baseline commit is tagged so the
+ * candidate diff excludes the setup patch and survives the agent committing.
+ */
+function buildAgentScript(): string {
+  return [
+    `set -u`,
+    `export PATH=${OVERLAY_CONTAINER_PATH}/node/bin:$PATH`,
+    `mkdir -p ${AGENT_HOME}`,
+    // .git hygiene (drop remotes/unreachable objects) + post-setup baseline
+    // commit + tag, so the candidate diff is exactly the agent's net change
+    // and upstream fix commits cannot be recovered from history.
+    buildBaselineGitScript(),
+    // Offline mock provider inside the container.
+    `node ${OVERLAY_CONTAINER_PATH}/mock/serve.mjs > ${AGENT_HELPER_DIR}/mock.log 2>&1 &`,
+    `MOCK_PID=$!`,
+    `for _ in $(seq 1 100); do grep -q MOCK_URL ${AGENT_HELPER_DIR}/mock.log 2>/dev/null && break; sleep 0.2; done`,
+    `MOCK_URL=$(grep -o 'MOCK_URL=.*' ${AGENT_HELPER_DIR}/mock.log | head -1 | cut -d= -f2-)`,
+    `if [ -z "$MOCK_URL" ]; then echo "AGENC_MOCK_FAILED" > ${AGENT_HELPER_DIR}/infra-failure; kill "$MOCK_PID" 2>/dev/null || true; exit 86; fi`,
+    `export AGENC_PROVIDER=openai-compatible AGENC_MODEL=local-pipeline-model`,
+    `export OPENAI_COMPATIBLE_MODEL=local-pipeline-model OPENAI_COMPATIBLE_API_KEY=local-pipeline-key`,
+    `export OPENAI_COMPATIBLE_BASE_URL="$MOCK_URL/v1" API_TIMEOUT_MS=600000`,
+    `export AGENC_HOME=${AGENT_HOME} AGENC_WORKSPACE="$PWD" AGENC_AUTH_MANAGED_KEYS_ENABLED=0`,
+    // Workspace trust is granted by the evaluator, never by repository
+    // content: the store is written before the agent runs.
+    `printf '%s' "{\\"version\\":1,\\"trustedProjects\\":[{\\"path\\":\\"$PWD\\",\\"trustedAt\\":\\"1970-01-01T00:00:00Z\\"}]}" > ${AGENT_HOME}/trusted-projects.json`,
+    `node ${AGENT_RUNTIME_ENTRY} -p "$(cat ${AGENT_HELPER_DIR}/prompt.txt)" ` +
+      `--output-format json --yolo > ${AGENT_HELPER_DIR}/agent-result.json 2> ${AGENT_HELPER_DIR}/agent-stderr.log`,
+    `AGENC_RC=$?`,
+    `kill "$MOCK_PID" 2>/dev/null || true`,
+    `exit $AGENC_RC`,
+  ].join("\n");
+}
+
+interface ParsedAgentResult {
+  readonly sessionId: string | null;
+  readonly finalMessage: string | null;
+  readonly tokenUsage: Readonly<Record<string, number>> | null;
+}
+
+function parseAgentResult(raw: string): ParsedAgentResult {
+  try {
+    const value = JSON.parse(raw) as Record<string, unknown>;
+    const usage = value.tokenUsage;
+    const tokenUsage: Record<string, number> = {};
+    if (typeof usage === "object" && usage !== null) {
+      for (const [key, entry] of Object.entries(usage)) {
+        if (typeof entry === "number" && Number.isFinite(entry)) tokenUsage[key] = entry;
+      }
+    }
+    return {
+      sessionId: typeof value.sessionId === "string" ? value.sessionId : null,
+      finalMessage: typeof value.finalMessage === "string" ? value.finalMessage : null,
+      tokenUsage: Object.keys(tokenUsage).length > 0 ? tokenUsage : null,
+    };
+  } catch {
+    return { sessionId: null, finalMessage: null, tokenUsage: null };
+  }
+}
+
+export interface AgentRunArtifacts {
+  readonly report: AgentRunReport;
+  readonly patchBytes: Uint8Array | null;
+  readonly rawAgentResult: string | null;
+}
+
+/**
+ * Run the real AgenC agent against one pinned task and verify its patch with
+ * the hidden verifier. Oracle isolation is structural: the agent container is
+ * `--network none` against an offline mock provider, gets only the setup
+ * patch, issue text, and read-only runtime overlay, and never sees the test
+ * patch, reference solution, or verifier bundle. Verification runs afterwards
+ * in a fresh offline container via the shared preflight machinery.
+ *
+ * This is the pipeline-validation lane. A real-model lane requires an
+ * egress-allowlist proxy and full `.git` oracle hygiene and is a follow-up.
+ */
+export async function runAgentOnTask(
+  runner: ContainerRunner,
+  inputs: AgentRunInputs,
+  config: AgentRunConfig,
+  timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
+  options: PreflightExecutionOptions = {},
+): Promise<AgentRunArtifacts> {
+  await assertOverlayLayout(config.overlay);
+  const startedAt = new Date().toISOString();
+  const environment = await runner.environment();
+  const overlayDigest = await computeOverlayDigest(config.overlay);
+  const environmentDigest = digestCanonicalJson(ENVIRONMENT_DIGEST_DOMAIN, {
+    ...environment,
+    image: inputs.task.image,
+    overlayDigest,
+    provider: "in-container-offline-mock",
+  });
+  const prompt = `${AGENT_PROMPT_PREAMBLE_V1}${inputs.task.issueText}`;
+  const promptDigest = digestCanonicalJson(PROMPT_DIGEST_DOMAIN, {
+    preambleVersion: "v1",
+    prompt,
+  });
+
+  let handle: ContainerHandle | null = null;
+  let agent: AgentRunReport["agent"] = {
+    exitCode: null,
+    timedOut: false,
+    resultTruncated: false,
+    sessionId: null,
+    finalMessageDigest: null,
+    tokenUsage: null,
+  };
+  let patch: AgentRunReport["patch"] = null;
+  let patchBytes: Uint8Array | null = null;
+  let rawAgentResult: string | null = null;
+  let outcome: AgentRunOutcome | null = null;
+  let failureDetail: string | null = null;
+
+  try {
+    handle = await runner.createTaskContainer(inputs.task.image, {
+      readOnlyMounts: [
+        { hostPath: path.resolve(config.overlay.hostDir), containerPath: OVERLAY_CONTAINER_PATH },
+      ],
+    });
+
+    if (inputs.setupPatch.byteLength > 0) {
+      await runner.writeFile(handle, `${AGENT_HELPER_DIR}/setup.patch`, inputs.setupPatch);
+      const applied = await runner.exec(handle, {
+        script: `git -c core.fileMode=false apply --verbose '${AGENT_HELPER_DIR}/setup.patch'`,
+        timeoutMs: timeouts.patchMs,
+      });
+      if (applied.exitCode !== 0) {
+        throw new EvalExecutorError([`setup patch did not apply: ${applied.stderr.slice(0, 500)}`]);
+      }
+    }
+    await runner.writeFile(
+      handle,
+      `${AGENT_HELPER_DIR}/prompt.txt`,
+      new TextEncoder().encode(prompt),
+    );
+
+    const agentTimeoutMs = config.agentTimeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS;
+    const executed = await runner.exec(handle, {
+      script: buildAgentScript(),
+      timeoutMs: agentTimeoutMs,
+    });
+
+    const resultRead = await runner.exec(handle, {
+      script: `cat ${AGENT_HELPER_DIR}/agent-result.json 2>/dev/null || true`,
+      timeoutMs: timeouts.patchMs,
+    });
+    rawAgentResult = resultRead.stdout;
+    const parsed = parseAgentResult(resultRead.stdout);
+    agent = {
+      exitCode: executed.exitCode,
+      timedOut: executed.timedOut,
+      resultTruncated: resultRead.truncated,
+      sessionId: parsed.sessionId,
+      finalMessageDigest: parsed.finalMessage === null ? null : sha256Digest(parsed.finalMessage),
+      tokenUsage: parsed.tokenUsage,
+    };
+
+    if (executed.timedOut) {
+      outcome = "agent_timeout";
+      failureDetail = `agent exceeded ${agentTimeoutMs}ms`;
+    } else if (executed.exitCode === 86) {
+      // The in-container mock never came up: environment, not the agent.
+      outcome = "infrastructure_error";
+      failureDetail = "in-container mock provider failed to start";
+    } else if (executed.exitCode !== 0) {
+      outcome = "agent_error";
+      const stderrRead = await runner.exec(handle, {
+        script: `tail -c 2000 ${AGENT_HELPER_DIR}/agent-stderr.log 2>/dev/null || true`,
+        timeoutMs: timeouts.patchMs,
+      });
+      failureDetail = `agent exited ${executed.exitCode}: ${stderrRead.stdout.trim()}`;
+    } else {
+      // Collect the agent's net change from the tagged post-setup baseline,
+      // committing any work the agent left uncommitted. base64 avoids a lossy
+      // UTF-8 round trip through captured stdout.
+      const collected = await runner.exec(handle, {
+        script: buildCandidateCollectionScript(),
+        timeoutMs: timeouts.patchMs,
+      });
+      if (collected.exitCode !== 0) {
+        throw new EvalExecutorError([`patch collection failed: ${collected.stderr.slice(0, 500)}`]);
+      }
+      if (collected.truncated) {
+        // Never verify a truncated patch: base64 would decode wrong, and the
+        // real working tree could pass or fail differently.
+        outcome = "infrastructure_error";
+        failureDetail = "collected patch exceeded the capture bound";
+      } else {
+        patchBytes = new Uint8Array(Buffer.from(collected.stdout, "base64"));
+        patch = {
+          digest: sha256Digest(patchBytes),
+          sizeBytes: patchBytes.byteLength,
+          truncated: false,
+        };
+        if (patchBytes.byteLength === 0) {
+          outcome = "empty_patch";
+          failureDetail = "agent completed without modifying the repository";
+          patchBytes = null;
+        }
+      }
+    }
+  } catch (error) {
+    outcome = "infrastructure_error";
+    failureDetail = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (handle) await runner.remove(handle);
+  }
+
+  let verification: AgentRunReport["verification"] = null;
+  if (outcome === null && patchBytes !== null) {
+    const verified = await verifyCandidatePatch(
+      runner,
+      {
+        task: inputs.task,
+        bundle: inputs.bundle,
+        setupPatch: inputs.setupPatch,
+        candidatePatch: patchBytes,
+      },
+      timeouts,
+      options,
+    );
+    verification = verified.transcript;
+    if (verified.passed) {
+      outcome = "verified_fix";
+    } else if (verified.infrastructureFailure) {
+      outcome = "infrastructure_error";
+      failureDetail =
+        `verification ${verified.infrastructureFailure.reason}: ${verified.infrastructureFailure.detail}`;
+    } else {
+      outcome = "verification_failure";
+      failureDetail = `${verified.failedCheck!.name} (${verified.failedCheck!.evidence})`;
+    }
+  }
+
+  const finishedAt = new Date().toISOString();
+  const reportBody = {
+    taskId: inputs.task.instanceId,
+    startedAt,
+    finishedAt,
+    promptDigest,
+    agent,
+    patch,
+    verification,
+    outcome: outcome ?? "infrastructure_error",
+    failureDetail,
+    environmentDigest,
+  };
+  const report: AgentRunReport = {
+    ...reportBody,
+    reportDigest: digestCanonicalJson(REPORT_DIGEST_DOMAIN, reportBody) as Sha256Digest,
+  };
+  return { report, patchBytes, rawAgentResult };
+}

--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { parseArgs } from "node:util";
+import { runAgentOnTask } from "./agent-run.js";
 import { DockerContainerRunner } from "./container-runner.js";
 import {
   DEFAULT_PREFLIGHT_TIMEOUTS,
@@ -24,11 +25,18 @@ const USAGE = `Usage:
   eval:executor verify-lock [--lock <source-lock.json>]
   eval:executor preflight --task <instanceId> [--lock <path>] [--output <dir>]
                           [--operator-task-digest <sha256:...>]
+  eval:executor run-agent --task <instanceId> --overlay <dir> [--lock <path>]
+                          [--output <dir>] [--agent-timeout-ms <n>]
 
 verify-lock  Load the frozen pilot source lock, re-hash every CAS artifact,
              and decode every verifier bundle. Hermetic and offline.
 preflight    Run the pilot triple preflight for one task inside its pinned
-             OCI image (requires docker; containers run --network none).`;
+             OCI image (requires docker; containers run --network none).
+run-agent    Run the real AgenC agent against one pinned task fully offline
+             (--network none, bundled in-container mock provider), collect
+             its patch, and verify it with the hidden verifier in a fresh
+             offline container. This is the pipeline-validation lane; the
+             real-model lane requires an egress-controlled follow-up.`;
 
 async function verifyLock(lockPath: string): Promise<number> {
   const loaded = await loadPilotSourceLock(lockPath);
@@ -115,6 +123,58 @@ async function preflight(options: {
   return result.qualified ? 0 : 1;
 }
 
+async function runAgent(options: {
+  readonly lockPath: string;
+  readonly taskId: string;
+  readonly overlayDir: string;
+  readonly outputDir: string;
+  readonly agentTimeoutMs?: number;
+  readonly parserFallbackImage?: string;
+}): Promise<number> {
+  const loaded = await loadPilotSourceLock(options.lockPath);
+  const task = findPilotTask(loaded.lock, options.taskId);
+  const runner = new DockerContainerRunner();
+  await runner.environment();
+  const { report, patchBytes, rawAgentResult } = await runAgentOnTask(
+    runner,
+    {
+      task,
+      bundle: decodeVerifierBundle(
+        await readPilotArtifact(loaded, task.artifacts.verifierBundle),
+        task.instanceId,
+      ),
+      setupPatch: await readPilotArtifact(loaded, task.artifacts.setupPatch),
+    },
+    {
+      overlay: { hostDir: options.overlayDir },
+      agentTimeoutMs: options.agentTimeoutMs,
+    },
+    DEFAULT_PREFLIGHT_TIMEOUTS,
+    { parserFallbackImage: options.parserFallbackImage },
+  );
+  const taskDir = path.join(options.outputDir, task.instanceId);
+  await mkdir(taskDir, { recursive: true });
+  await writeFile(
+    path.join(taskDir, "agent-run-report.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+    { flag: "wx" },
+  );
+  if (patchBytes !== null) {
+    await writeFile(path.join(taskDir, "agent-patch.diff"), patchBytes, { flag: "wx" });
+  }
+  if (rawAgentResult !== null && rawAgentResult.length > 0) {
+    await writeFile(path.join(taskDir, "agent-result.json"), rawAgentResult, { flag: "wx" });
+  }
+  process.stdout.write(`${JSON.stringify({
+    taskId: report.taskId,
+    outcome: report.outcome,
+    failureDetail: report.failureDetail,
+    tokenUsage: report.agent.tokenUsage,
+    outputDir: taskDir,
+  }, null, 2)}\n`);
+  return report.outcome === "verified_fix" ? 0 : 1;
+}
+
 export async function main(argv: readonly string[]): Promise<number> {
   const [command, ...rest] = argv;
   if (!command || command === "--help" || command === "-h") {
@@ -127,6 +187,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       lock: { type: "string" },
       task: { type: "string" },
       output: { type: "string" },
+      overlay: { type: "string" },
+      "agent-timeout-ms": { type: "string" },
       "operator-task-digest": { type: "string" },
       "parser-fallback-image": { type: "string" },
     },
@@ -149,6 +211,24 @@ export async function main(argv: readonly string[]): Promise<number> {
       taskId: values.task,
       outputDir: values.output ?? "eval-executor-output",
       operatorTaskDigest: digest,
+      parserFallbackImage: values["parser-fallback-image"],
+    });
+  }
+  if (command === "run-agent") {
+    if (!values.task || !values.overlay) {
+      throw new EvalExecutorError(["run-agent requires --task <instanceId> and --overlay <dir>"]);
+    }
+    const timeoutRaw = values["agent-timeout-ms"];
+    const agentTimeoutMs = timeoutRaw === undefined ? undefined : Number(timeoutRaw);
+    if (agentTimeoutMs !== undefined && (!Number.isSafeInteger(agentTimeoutMs) || agentTimeoutMs <= 0)) {
+      throw new EvalExecutorError(["--agent-timeout-ms must be a positive integer"]);
+    }
+    return runAgent({
+      lockPath,
+      taskId: values.task,
+      overlayDir: values.overlay,
+      outputDir: values.output ?? "eval-executor-output",
+      agentTimeoutMs,
       parserFallbackImage: values["parser-fallback-image"],
     });
   }

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -8,6 +8,7 @@ import {
   type ContainerExecResult,
   type ContainerHandle,
   type ContainerRunner,
+  type CreateTaskContainerOptions,
 } from "./types.js";
 
 interface SpawnResult {
@@ -128,7 +129,10 @@ export class DockerContainerRunner implements ContainerRunner {
     };
   }
 
-  async createTaskContainer(imageReference: string): Promise<ContainerHandle> {
+  async createTaskContainer(
+    imageReference: string,
+    options: CreateTaskContainerOptions = {},
+  ): Promise<ContainerHandle> {
     const isLocalImageId = LOCAL_IMAGE_ID_PATTERN.test(imageReference);
     const digestIndex = imageReference.lastIndexOf("@sha256:");
     if (isLocalImageId && this.options.allowLocalImageId !== true) {
@@ -144,12 +148,27 @@ export class DockerContainerRunner implements ContainerRunner {
     const dockerReference = isLocalImageId
       ? imageReference.slice("sha256:".length)
       : imageReference;
+    const mountArguments: string[] = [];
+    for (const mount of options.readOnlyMounts ?? []) {
+      if (!mount.hostPath.startsWith("/") || !mount.containerPath.startsWith("/") ||
+          mount.hostPath.includes(",") || mount.containerPath.includes(",") ||
+          mount.hostPath.includes(":") || mount.containerPath.includes(":")) {
+        throw new EvalExecutorError([
+          `invalid mount ${mount.hostPath} -> ${mount.containerPath}`,
+        ]);
+      }
+      mountArguments.push("-v", `${mount.hostPath}:${mount.containerPath}:ro`);
+    }
     const created = await spawnBounded(
       "docker",
       [
         "create",
+        // Task containers are always network-isolated. A real-model agent
+        // lane would need deliberate egress control (a proxy sidecar), never
+        // a raw bridge switch here.
         "--network",
         "none",
+        ...mountArguments,
         "--entrypoint",
         "sleep",
         dockerReference,

--- a/runtime/src/eval-executor/index.ts
+++ b/runtime/src/eval-executor/index.ts
@@ -1,3 +1,16 @@
+export {
+  AGENT_PROMPT_PREAMBLE_V1,
+  assertOverlayLayout,
+  buildBaselineGitScript,
+  buildCandidateCollectionScript,
+  DEFAULT_AGENT_TIMEOUT_MS,
+  EVAL_BASELINE_TAG,
+  runAgentOnTask,
+  type AgentOverlay,
+  type AgentRunArtifacts,
+  type AgentRunConfig,
+  type AgentRunInputs,
+} from "./agent-run.js";
 export { DockerContainerRunner } from "./container-runner.js";
 export {
   buildParserProgram,
@@ -11,6 +24,9 @@ export {
   mintUpstreamPreflightEvidence,
   runSinglePreflight,
   runTriplePreflight,
+  verifyCandidatePatch,
+  type CandidatePatchInputs,
+  type CandidateVerification,
   type PreflightExecutionOptions,
   type PreflightTaskInputs,
   type PreflightTimeouts,

--- a/runtime/src/eval-executor/preflight.ts
+++ b/runtime/src/eval-executor/preflight.ts
@@ -423,6 +423,75 @@ export async function runTriplePreflight(
   return { taskId: inputs.task.instanceId, qualified, runs };
 }
 
+export interface CandidatePatchInputs {
+  readonly task: PilotSourceLockTask;
+  readonly bundle: VerifierBundle;
+  readonly setupPatch: Uint8Array;
+  readonly candidatePatch: Uint8Array;
+}
+
+export interface CandidateVerification {
+  readonly transcript: PreflightPhaseTranscript;
+  readonly passed: boolean;
+  /** Environment/taxonomy failure (timeout, rebuild, parser, ...). */
+  readonly infrastructureFailure: {
+    readonly reason: PreflightFailureReason;
+    readonly detail: string;
+  } | null;
+  /** First target or regression check the candidate does not pass. */
+  readonly failedCheck: { readonly name: string; readonly evidence: string } | null;
+}
+
+/**
+ * Verify an agent-produced candidate patch exactly the way the pinned
+ * reference solution is verified: fresh offline container, setup + candidate
+ * + test patches, cold rebuild, tests, parsed results, and every target and
+ * regression check must pass. Reuses the preflight phase machinery so the
+ * failure taxonomy and evidence shape stay unified.
+ */
+export async function verifyCandidatePatch(
+  runner: ContainerRunner,
+  inputs: CandidatePatchInputs,
+  timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
+  options: PreflightExecutionOptions = {},
+): Promise<CandidateVerification> {
+  const phase = await runPhase(
+    runner,
+    {
+      task: inputs.task,
+      bundle: inputs.bundle,
+      setupPatch: inputs.setupPatch,
+      referencePatch: inputs.candidatePatch,
+    },
+    "reference",
+    timeouts,
+    options,
+  );
+  if (phase.failure || !phase.results) {
+    return {
+      transcript: phase.transcript,
+      passed: false,
+      infrastructureFailure: phase.failure ?? {
+        reason: "infrastructure_error",
+        detail: "verification produced no parsed results",
+      },
+      failedCheck: null,
+    };
+  }
+  const failing = firstFailing(phase.results, [
+    ...inputs.bundle.failToPass,
+    ...inputs.bundle.passToPass,
+  ]);
+  return {
+    transcript: phase.transcript,
+    passed: failing === null,
+    infrastructureFailure: null,
+    failedCheck: failing === null
+      ? null
+      : { name: failing, evidence: statusEvidence(phase.results, failing) },
+  };
+}
+
 /**
  * Mint the typed qualification evidence the pilot curation catalog consumes.
  * This exists only for a fully qualified triple; anything else throws, so a

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -102,13 +102,26 @@ export interface ContainerExecResult {
   readonly durationMs: number;
 }
 
+export interface ContainerMount {
+  readonly hostPath: string;
+  readonly containerPath: string;
+}
+
+export interface CreateTaskContainerOptions {
+  /** Read-only bind mounts (the agent overlay). Never used for verification. */
+  readonly readOnlyMounts?: readonly ContainerMount[];
+}
+
 /**
  * Minimal container surface the preflight orchestration needs. The docker
  * implementation always creates task containers with `--network none`; fakes
  * exist only for hermetic tests.
  */
 export interface ContainerRunner {
-  createTaskContainer(imageReference: string): Promise<ContainerHandle>;
+  createTaskContainer(
+    imageReference: string,
+    options?: CreateTaskContainerOptions,
+  ): Promise<ContainerHandle>;
   /**
    * Executor-owned tooling container (also `--network none`), e.g. to run
    * the frozen log parser when a task image ships no python3. Never used
@@ -195,4 +208,37 @@ export interface TriplePreflightResult {
   readonly taskId: string;
   readonly qualified: boolean;
   readonly runs: readonly PreflightRunReport[];
+}
+
+export type AgentRunOutcome =
+  | "verified_fix"
+  | "verification_failure"
+  | "empty_patch"
+  | "agent_error"
+  | "agent_timeout"
+  | "infrastructure_error";
+
+export interface AgentRunReport {
+  readonly taskId: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly promptDigest: Sha256Digest;
+  readonly agent: {
+    readonly exitCode: number | null;
+    readonly timedOut: boolean;
+    readonly resultTruncated: boolean;
+    readonly sessionId: string | null;
+    readonly finalMessageDigest: Sha256Digest | null;
+    readonly tokenUsage: Readonly<Record<string, number>> | null;
+  };
+  readonly patch: {
+    readonly digest: Sha256Digest;
+    readonly sizeBytes: number;
+    readonly truncated: boolean;
+  } | null;
+  readonly verification: PreflightPhaseTranscript | null;
+  readonly outcome: AgentRunOutcome;
+  readonly failureDetail: string | null;
+  readonly environmentDigest: Sha256Digest;
+  readonly reportDigest: Sha256Digest;
 }

--- a/runtime/tests/eval/eval-executor-agent-run.test.ts
+++ b/runtime/tests/eval/eval-executor-agent-run.test.ts
@@ -1,0 +1,345 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  runAgentOnTask,
+  EvalExecutorError,
+  PARSE_RESULT_SENTINEL,
+  type AgentRunConfig,
+  type AgentRunInputs,
+  type ContainerEnvironment,
+  type ContainerExecRequest,
+  type ContainerExecResult,
+  type ContainerHandle,
+  type ContainerRunner,
+  type CreateTaskContainerOptions,
+  type PilotSourceLockTask,
+  type VerifierBundle,
+} from "../../src/eval-executor/index.js";
+
+const digestOf = (char: string): `sha256:${string}` => `sha256:${char.repeat(64)}`;
+const IMAGE = `registry.example/fake-task@sha256:${"a".repeat(64)}`;
+
+function makeTask(setupPatchBytes: number): PilotSourceLockTask {
+  return {
+    ordinal: 1,
+    language: "js",
+    instanceId: "Fake__agent-task-1",
+    categories: ["multi_file_fix"],
+    stressors: [],
+    sourceRowDigest: digestOf("b"),
+    repository: "fake/agent-task",
+    pullNumber: "1",
+    issueNumbers: ["2"],
+    baseCommit: "c".repeat(40),
+    createdAt: "2026-07-01T00:00:00Z",
+    commitUrl: "https://example.invalid/fake/agent-task",
+    issueText: "add() subtracts instead of adding",
+    image: IMAGE,
+    artifacts: {
+      setupPatch: {
+        digest: digestOf("d"),
+        sizeBytes: setupPatchBytes,
+        mediaType: "text/x-diff",
+        uri: `cas://sha256/${"d".repeat(64)}`,
+      },
+      referencePatch: {
+        digest: digestOf("e"),
+        sizeBytes: 10,
+        mediaType: "text/x-diff",
+        uri: `cas://sha256/${"e".repeat(64)}`,
+      },
+      verifierBundle: {
+        digest: digestOf("f"),
+        sizeBytes: 10,
+        mediaType: "application/vnd.agenc.eval.verifier+json+gzip",
+        uri: `cas://sha256/${"f".repeat(64)}`,
+      },
+      sourceEvidence: {
+        digest: digestOf("0"),
+        sizeBytes: 10,
+        mediaType: "application/vnd.agenc.eval.source-evidence+json",
+        uri: `cas://sha256/${"0".repeat(64)}`,
+      },
+    },
+  };
+}
+
+const BUNDLE: VerifierBundle = {
+  kind: "agenc.eval.swe-bench-live-verifier-bundle",
+  version: "1.0.0",
+  instanceId: "Fake__agent-task-1",
+  testPatch: "diff --git a/test b/test\n",
+  rebuildCommands: ["make rebuild"],
+  testCommands: ["make test 2>&1 | tee test-output.log"],
+  printCommands: ["cat test-output.log"],
+  logParser: "def parser(log):\n    return {}\n",
+  failToPass: ["target-1"],
+  passToPass: ["regression-1"],
+};
+
+const OK: ContainerExecResult = {
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+  timedOut: false,
+  truncated: false,
+  durationMs: 1,
+};
+
+interface AgentContainerPlan {
+  readonly kind: "agent";
+  readonly agentExitCode?: number;
+  readonly agentTimedOut?: boolean;
+  readonly agentResultJson?: string;
+  /** Raw diff bytes; the fake base64-encodes them like the real collection. */
+  readonly patchDiff?: string;
+  readonly patchTruncated?: boolean;
+}
+
+interface VerifyContainerPlan {
+  readonly kind: "verify";
+  readonly parserResults: Record<string, string>;
+}
+
+type ContainerPlan = AgentContainerPlan | VerifyContainerPlan;
+
+class FakeAgentRunner implements ContainerRunner {
+  readonly createOptions: Array<CreateTaskContainerOptions | undefined> = [];
+  readonly writtenFiles: string[] = [];
+  private index = -1;
+
+  constructor(private readonly plans: readonly ContainerPlan[]) {}
+
+  async environment(): Promise<ContainerEnvironment> {
+    return { engine: "docker", serverVersion: "0.0.0-fake", platform: "linux", arch: "x64" };
+  }
+
+  async createTaskContainer(
+    imageReference: string,
+    options?: CreateTaskContainerOptions,
+  ): Promise<ContainerHandle> {
+    expect(imageReference).toBe(IMAGE);
+    this.index += 1;
+    this.createOptions.push(options);
+    if (this.index >= this.plans.length) throw new Error("fake ran out of container plans");
+    return { id: `c-${this.index}`, imageDigest: "sha256:x", workdir: "/testbed" };
+  }
+
+  async createAuxiliaryContainer(imageReference: string): Promise<ContainerHandle> {
+    return { id: "aux", imageDigest: imageReference, workdir: "/" };
+  }
+
+  async exec(_handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult> {
+    const plan = this.plans[this.index]!;
+    if (plan.kind === "agent") {
+      if (request.script.includes("dist/bin/agenc.js") || request.script.startsWith("set -u")) {
+        return { ...OK, exitCode: plan.agentExitCode ?? 0, timedOut: plan.agentTimedOut ?? false };
+      }
+      if (request.script.startsWith("cat /agenc-eval/agent-result.json")) {
+        return { ...OK, stdout: plan.agentResultJson ?? "" };
+      }
+      if (request.script.startsWith("tail -c 2000")) {
+        return { ...OK, stdout: "agent stderr tail" };
+      }
+      if (request.script.includes("diff agenc-eval-baseline HEAD")) {
+        // latin1 gives a 1:1 char->byte mapping, modelling git emitting raw
+        // bytes that the real collection base64-encodes in-container.
+        return {
+          ...OK,
+          stdout: Buffer.from(plan.patchDiff ?? "", "latin1").toString("base64"),
+          truncated: plan.patchTruncated ?? false,
+        };
+      }
+      if (request.script.includes(" apply ")) return OK;
+      throw new Error(`unexpected agent-container script: ${request.script}`);
+    }
+    if (request.script.includes(" apply ")) return OK;
+    if (request.script === "make rebuild") return OK;
+    if (request.script.startsWith("make test")) return { ...OK, exitCode: 1 };
+    if (request.script.endsWith(">> /agenc-eval/parser-input.log")) return OK;
+    if (request.script === "command -v python3") return OK;
+    if (request.script.includes("parse-log.py")) {
+      return { ...OK, stdout: `${PARSE_RESULT_SENTINEL}${JSON.stringify(plan.parserResults)}\n` };
+    }
+    throw new Error(`unexpected verify-container script: ${request.script}`);
+  }
+
+  async writeFile(handle: ContainerHandle, containerPath: string): Promise<void> {
+    this.writtenFiles.push(`${handle.id}:${containerPath}`);
+  }
+
+  async copyFile(): Promise<void> {}
+  async remove(): Promise<void> {}
+}
+
+async function makeOverlay(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "agenc-agent-overlay-"));
+  await mkdir(path.join(dir, "node", "bin"), { recursive: true });
+  await writeFile(path.join(dir, "node", "bin", "node"), "");
+  const runtimeBin = path.join(
+    dir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "bin",
+  );
+  await mkdir(runtimeBin, { recursive: true });
+  await writeFile(path.join(runtimeBin, "agenc.js"), "// fake agent build\n");
+  await mkdir(path.join(dir, "mock"), { recursive: true });
+  await writeFile(path.join(dir, "mock", "serve.mjs"), "");
+  return dir;
+}
+
+const AGENT_RESULT = JSON.stringify({
+  type: "result",
+  sessionId: "session_test",
+  exitCode: 0,
+  finalMessage: "done",
+  tokenUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+});
+
+const PATCH = "diff --git a/app.js b/app.js\n--- a/app.js\n+++ b/app.js\n@@ -1 +1 @@\n-x\n+y\n";
+
+describe("eval executor agent run", () => {
+  async function withOverlay(fn: (config: AgentRunConfig) => Promise<void>): Promise<void> {
+    const dir = await makeOverlay();
+    try {
+      await fn({ overlay: { hostDir: dir } });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  const EMPTY_SETUP: AgentRunInputs = {
+    task: makeTask(0),
+    bundle: BUNDLE,
+    setupPatch: new Uint8Array(0),
+  };
+
+  test("verified fix: agent patch passes every hidden check", async () => {
+    await withOverlay(async (config) => {
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: PATCH },
+        { kind: "verify", parserResults: { "target-1": "pass", "regression-1": "pass" } },
+      ]);
+      const { report, patchBytes } = await runAgentOnTask(runner, EMPTY_SETUP, config);
+      expect(report.outcome).toBe("verified_fix");
+      expect(report.agent.sessionId).toBe("session_test");
+      expect(report.agent.tokenUsage).toMatchObject({ totalTokens: 15 });
+      expect(new TextDecoder().decode(patchBytes!)).toBe(PATCH);
+      expect(report.verification).not.toBeNull();
+      expect(report.reportDigest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      // Agent container carries only the overlay mount; verification runs
+      // with no mounts. (Network isolation is unconditional in the runner.)
+      expect(runner.createOptions[0]!.readOnlyMounts).toHaveLength(1);
+      expect(runner.createOptions[1]?.readOnlyMounts ?? []).toHaveLength(0);
+      // Oracle isolation: only the prompt reaches the agent container (c-0);
+      // the test patch lands only in the verify container (c-1).
+      expect(runner.writtenFiles.filter((f) => f.startsWith("c-0:"))).toEqual([
+        "c-0:/agenc-eval/prompt.txt",
+      ]);
+      expect(
+        runner.writtenFiles.filter((f) => f.startsWith("c-1:") && f.includes("test.patch")),
+      ).toHaveLength(1);
+    });
+  });
+
+  test("a patch failing a hidden check is verification_failure with evidence", async () => {
+    await withOverlay(async (config) => {
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: PATCH },
+        { kind: "verify", parserResults: { "target-1": "fail", "regression-1": "pass" } },
+      ]);
+      const { report } = await runAgentOnTask(runner, EMPTY_SETUP, config);
+      expect(report.outcome).toBe("verification_failure");
+      expect(report.failureDetail).toContain("target-1");
+    });
+  });
+
+  test("an unchanged repository is empty_patch and skips verification", async () => {
+    await withOverlay(async (config) => {
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: "" },
+      ]);
+      const { report, patchBytes } = await runAgentOnTask(runner, EMPTY_SETUP, config);
+      expect(report.outcome).toBe("empty_patch");
+      expect(report.verification).toBeNull();
+      expect(patchBytes).toBeNull();
+    });
+  });
+
+  test("a nonempty setup patch does not leak into the collected candidate", async () => {
+    // The collected patch is base64 of `diff <baseline> HEAD`, where the
+    // baseline is committed AFTER the setup patch — so setup hunks are never
+    // in the candidate even when the task has a real setup patch. Regression
+    // for the double-collection bug.
+    await withOverlay(async (config) => {
+      const inputs: AgentRunInputs = {
+        task: makeTask(40),
+        bundle: BUNDLE,
+        setupPatch: new TextEncoder().encode("diff --git a/setup b/setup\n"),
+      };
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: PATCH },
+        { kind: "verify", parserResults: { "target-1": "pass", "regression-1": "pass" } },
+      ]);
+      const { report, patchBytes } = await runAgentOnTask(runner, inputs, config);
+      expect(report.outcome).toBe("verified_fix");
+      expect(new TextDecoder().decode(patchBytes!)).toBe(PATCH);
+      // setup.patch is applied in the agent container; the baseline commit +
+      // tag are what exclude it from the candidate.
+      expect(runner.writtenFiles).toContain("c-0:/agenc-eval/setup.patch");
+    });
+  });
+
+  test("a binary patch survives collection without a lossy text round trip", async () => {
+    // base64 transport means non-UTF-8 bytes are preserved exactly.
+    await withOverlay(async (config) => {
+      const binaryDiff = `diff --git a/x b/x\nGIT binary patch\n\x00\x80\xff\xfe raw\n`;
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: binaryDiff },
+        { kind: "verify", parserResults: { "target-1": "pass", "regression-1": "pass" } },
+      ]);
+      const { patchBytes } = await runAgentOnTask(runner, EMPTY_SETUP, config);
+      expect(Buffer.from(patchBytes!).toString("latin1")).toBe(binaryDiff);
+    });
+  });
+
+  test("a truncated patch is never verified", async () => {
+    await withOverlay(async (config) => {
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: PATCH, patchTruncated: true },
+      ]);
+      const { report } = await runAgentOnTask(runner, EMPTY_SETUP, config);
+      expect(report.outcome).toBe("infrastructure_error");
+      expect(report.failureDetail).toContain("capture bound");
+      expect(report.verification).toBeNull();
+    });
+  });
+
+  test("agent failures classify as agent_error, agent_timeout, and mock startup as infrastructure", async () => {
+    await withOverlay(async (config) => {
+      const errored = new FakeAgentRunner([{ kind: "agent", agentExitCode: 1 }]);
+      const erroredRun = await runAgentOnTask(errored, EMPTY_SETUP, config);
+      expect(erroredRun.report.outcome).toBe("agent_error");
+      expect(erroredRun.report.failureDetail).toContain("agent stderr tail");
+    });
+    await withOverlay(async (config) => {
+      const timed = new FakeAgentRunner([{ kind: "agent", agentTimedOut: true }]);
+      const timedRun = await runAgentOnTask(timed, EMPTY_SETUP, config);
+      expect(timedRun.report.outcome).toBe("agent_timeout");
+    });
+    await withOverlay(async (config) => {
+      // Exit 86 = the in-container mock never came up: environment, not agent.
+      const mockDown = new FakeAgentRunner([{ kind: "agent", agentExitCode: 86 }]);
+      const mockRun = await runAgentOnTask(mockDown, EMPTY_SETUP, config);
+      expect(mockRun.report.outcome).toBe("infrastructure_error");
+      expect(mockRun.report.failureDetail).toContain("mock provider failed");
+    });
+  });
+
+  test("rejects a broken overlay", async () => {
+    const runner = new FakeAgentRunner([]);
+    await expect(
+      runAgentOnTask(runner, EMPTY_SETUP, { overlay: { hostDir: "/nonexistent-overlay" } }),
+    ).rejects.toThrow(EvalExecutorError);
+  });
+});

--- a/runtime/tests/eval/eval-executor-patch-collection.test.ts
+++ b/runtime/tests/eval/eval-executor-patch-collection.test.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  buildBaselineGitScript,
+  buildCandidateCollectionScript,
+} from "../../src/eval-executor/index.js";
+
+// Revert-sensitive real-git test for the patch-collection logic. It runs the
+// EXACT exported shell scripts the executor runs, against a real git repo, so
+// reverting the collection to the buggy `git diff --cached` (or dropping the
+// post-setup baseline) turns these red. No docker, no network.
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t.invalid",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t.invalid",
+    },
+  });
+}
+
+function bash(cwd: string, script: string): string {
+  return execFileSync("bash", ["-c", script], { cwd, encoding: "utf8" });
+}
+
+function decodeCollected(base64: string): string {
+  return Buffer.from(base64.trim(), "base64").toString("utf8");
+}
+
+describe("eval executor patch collection (real git)", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(path.join(tmpdir(), "agenc-collect-"));
+    git(repo, ["init", "-q", "-b", "main"]);
+    await writeFile(path.join(repo, "app.js"), "function add(a,b){return a-b}\n");
+    await writeFile(path.join(repo, "keep.txt"), "unrelated\n");
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-q", "-m", "base"]);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  async function applySetup(): Promise<void> {
+    // A "setup patch" the harness applies before the agent: adds a config file.
+    await writeFile(path.join(repo, "setup.cfg"), "harness=1\n");
+  }
+
+  test("candidate excludes the setup patch and captures uncommitted agent work", async () => {
+    await applySetup();
+    bash(repo, buildBaselineGitScript());
+    // Agent edits app.js but does not commit.
+    await writeFile(path.join(repo, "app.js"), "function add(a,b){return a+b}\n");
+
+    const collected = decodeCollected(bash(repo, buildCandidateCollectionScript()));
+    expect(collected).toContain("a/app.js");
+    expect(collected).toContain("+function add(a,b){return a+b}");
+    // Setup file must NOT appear in the candidate.
+    expect(collected).not.toContain("setup.cfg");
+  });
+
+  test("candidate captures work the agent COMMITTED itself", async () => {
+    // This is the case the buggy `git diff --cached` silently dropped.
+    await applySetup();
+    bash(repo, buildBaselineGitScript());
+    await writeFile(path.join(repo, "app.js"), "function add(a,b){return a+b}\n");
+    await writeFile(path.join(repo, "newfile.js"), "export const x = 1\n");
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-q", "-m", "agent fix"]);
+
+    const collected = decodeCollected(bash(repo, buildCandidateCollectionScript()));
+    expect(collected).toContain("+function add(a,b){return a+b}");
+    expect(collected).toContain("newfile.js");
+    expect(collected).not.toContain("setup.cfg");
+  });
+
+  test("a no-op agent yields an empty candidate", async () => {
+    await applySetup();
+    bash(repo, buildBaselineGitScript());
+    const collected = bash(repo, buildCandidateCollectionScript());
+    expect(collected.trim()).toBe("");
+  });
+});

--- a/runtime/tests/live/eval-executor-docker.live.test.ts
+++ b/runtime/tests/live/eval-executor-docker.live.test.ts
@@ -11,12 +11,21 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   DockerContainerRunner,
   mintUpstreamPreflightEvidence,
+  runAgentOnTask,
   runTriplePreflight,
   type PilotSourceLockTask,
   type PreflightTaskInputs,
   type PreflightTimeouts,
   type VerifierBundle,
 } from "../../src/eval-executor/index.js";
+
+/**
+ * Directory holding an agent overlay (`node/`, `runtime/`, `mock/`) prepared
+ * per docs/design/eval-pilot-executor.md. The agent-run e2e is skipped when
+ * unset because the overlay is hundreds of megabytes of operator-staged
+ * artifacts, not repository content.
+ */
+const AGENT_OVERLAY = process.env.AGENC_EVAL_AGENT_OVERLAY;
 
 const BASE_IMAGE = process.env.AGENC_EVAL_E2E_BASE_IMAGE ?? "node:25.9.0-bookworm";
 const HOOK_TIMEOUT_MS = 900_000;
@@ -248,6 +257,27 @@ describe("eval executor docker live e2e", () => {
     expect(result.qualified).toBe(false);
     expect(result.runs[0]!.failure).toMatchObject({ reason: "base_unexpectedly_passes" });
   }, TEST_TIMEOUT_MS);
+
+  test.skipIf(!AGENT_OVERLAY)(
+    "runs the real AgenC runtime in-container against the mock provider",
+    async () => {
+      const runner = new DockerContainerRunner({ allowLocalImageId: true });
+      const { report } = await runAgentOnTask(
+        runner,
+        { task: makeTask(imageId), bundle: makeBundle({}), setupPatch: new Uint8Array(0) },
+        { overlay: { hostDir: AGENT_OVERLAY! }, agentTimeoutMs: 300_000 },
+        TIMEOUTS,
+      );
+      // The mock provider only returns canned text, so the agent completes
+      // without editing the repository: the pipeline itself is what passes.
+      expect(report.agent.exitCode).toBe(0);
+      expect(report.agent.sessionId).toMatch(/^session_/u);
+      expect(report.agent.tokenUsage).not.toBeNull();
+      expect(report.outcome).toBe("empty_patch");
+      expect(report.verification).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
 
   test("task containers really have no network: egress fails as network_required", async () => {
     const runner = new DockerContainerRunner({ allowLocalImageId: true });


### PR DESCRIPTION
## What

Phase-2a of the eval executor (follow-up to #1518–#1523): runs the **real AgenC runtime inside a pinned task container**, collects its patch, and verifies it with the hidden verifier — M1's "run the actual agent, not a mock executor" pipeline, validated mechanically against the bundled offline mock provider.

- `agent-run.ts` — `runAgentOnTask`: offline (`--network none`) agent execution, patch collection, verification via the shared `verifyCandidatePatch` (reuses preflight phase machinery, unified taxonomy). Outcomes: `verified_fix | verification_failure | empty_patch | agent_error | agent_timeout | infrastructure_error`.
- Structural oracle isolation: agent container receives only the setup patch, issue text, and read-only overlay; `.git` remotes/reflog pruned; verification runs separately with no mounts.
- CLI `eval:executor run-agent --task <id> --overlay <dir>`.

## Adversarially reviewed before merge

A multi-agent review surfaced **13 confirmed findings**; every correctness finding fixed, scoping decision made on the security cluster:

| Finding | Resolution |
|---|---|
| **Setup-patch double-collection** (HIGH) | Post-setup baseline commit tagged; candidate = `diff <baseline> HEAD`, excludes setup |
| **Agent-commits-its-work → false empty_patch** | Collection commits remaining work, diffs `baseline..HEAD` |
| **Lossy UTF-8 patch transport** | Candidate transported as base64, byte-exact |
| Mock-startup failure misclassified | Now `infrastructure_error` |
| Report didn't attest agent build | Records overlay `agenc.js` digest + version |
| **Bridge lane could fetch fix / exfiltrate keys** (HIGH ×3) | Real-provider lane **not shipped** (needs egress proxy + full `.git` hygiene, documented as phase 2b); dormant `bridge` networkMode **removed** |

A second adversarial pass verified the fixes and drove the remaining two: bridge-capability removal and a **revert-sensitive** real-git collection test (the original tests used a fake runner and would've passed against buggy `diff --cached`).

## Verification

Tested SHA on top of `758123f6c`. Node v25.9.0.

| Gate | Result |
|---|---|
| typecheck | clean |
| build + pre-commit hook | green |
| `tests/eval` | **150/150 (18 files)** |
| Revert-sensitivity (real git) | 2 red against buggy `diff --cached`, green restored |
| Live docker e2e | **6/6** — real runtime ran in-container offline |

Skips: full stable suite (change confined to eval-executor + tests); the offline mock lane doesn't measure a real model — that's phase 2b.