### PR TITLE
fix(runtime): raise the log-parser output cap so big suites are not truncated

### DIFF
--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -23,6 +23,7 @@ interface SpawnResult {
 interface SpawnBoundedOptions {
   readonly timeoutMs: number;
   readonly stdin?: Uint8Array;
+  readonly maxOutputBytes?: number;
 }
 
 function spawnBounded(
@@ -39,8 +40,9 @@ function spawnBounded(
     let stderr: Buffer = Buffer.alloc(0);
     let truncated = false;
     let timedOut = false;
+    const maxOutputBytes = options.maxOutputBytes ?? EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES;
     const capture = (existing: Buffer, chunk: Buffer): Buffer => {
-      const remaining = EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES - existing.byteLength;
+      const remaining = maxOutputBytes - existing.byteLength;
       if (remaining <= 0) {
         truncated = true;
         return existing;
@@ -234,7 +236,7 @@ export class DockerContainerRunner implements ContainerRunner {
     return spawnBounded(
       "docker",
       ["exec", "-w", handle.workdir, handle.id, "bash", "-c", request.script],
-      { timeoutMs: request.timeoutMs },
+      { timeoutMs: request.timeoutMs, maxOutputBytes: request.maxOutputBytes },
     );
   }
 

--- a/runtime/src/eval-executor/preflight.ts
+++ b/runtime/src/eval-executor/preflight.ts
@@ -2,6 +2,7 @@ import { digestCanonicalJson, sha256Digest } from "../eval-contract/index.js";
 import type { EvaluationPilotUpstreamPreflightEvidence } from "../eval-pilot/types.js";
 import { buildParserProgram, extractParserResults, testPassed } from "./log-parser.js";
 import { EvalExecutorError } from "./source-lock.js";
+import { EVAL_EXECUTOR_MAXIMUM_PARSER_OUTPUT_BYTES } from "./types.js";
 import type {
   ContainerExecResult,
   ContainerHandle,
@@ -122,8 +123,9 @@ async function runPhase(
       script: string,
       timeoutMs: number,
       target: ContainerHandle = handle,
+      maxOutputBytes?: number,
     ): Promise<ContainerExecResult> => {
-      const result = await runner.exec(target, { script, timeoutMs });
+      const result = await runner.exec(target, { script, timeoutMs, maxOutputBytes });
       commands.push(record(label, script, result));
       if (result.timedOut) {
         throw new PreflightPhaseFailure("timeout", `${label} exceeded ${timeoutMs}ms`);
@@ -210,7 +212,9 @@ async function runPhase(
     let parsed: ContainerExecResult;
     if (probe.exitCode === 0) {
       await runner.writeFile(handle, `${HELPER_DIR}/parse-log.py`, parserProgram);
-      parsed = await exec("parse-log", parserScript, timeouts.parserMs);
+      parsed = await exec(
+        "parse-log", parserScript, timeouts.parserMs, handle, EVAL_EXECUTOR_MAXIMUM_PARSER_OUTPUT_BYTES,
+      );
     } else {
       // The task image ships no python3 (the .NET candidates). Run the
       // frozen parser in an offline auxiliary container instead — still
@@ -229,7 +233,10 @@ async function runPhase(
             // readable candidate.
           }
         }
-        parsed = await exec("parse-log[fallback]", parserScript, timeouts.parserMs, aux);
+        parsed = await exec(
+          "parse-log[fallback]", parserScript, timeouts.parserMs, aux,
+          EVAL_EXECUTOR_MAXIMUM_PARSER_OUTPUT_BYTES,
+        );
       } finally {
         await runner.remove(aux);
       }

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -13,6 +13,15 @@ export const EVAL_EXECUTOR_MAXIMUM_LOCK_BYTES = 16_777_216;
 /** Host-side cap on captured container command output. */
 export const EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES = 1_048_576;
 
+/**
+ * Larger cap for the log-parser step: its output is a JSON map of every test
+ * the parser found, which for big suites (e.g. pinot's ~thousands of surefire
+ * results) legitimately exceeds 1 MiB. Truncating it here corrupts the JSON
+ * and produces a false infrastructure_error, so this step gets the artifact
+ * bound instead.
+ */
+export const EVAL_EXECUTOR_MAXIMUM_PARSER_OUTPUT_BYTES = 67_108_864;
+
 export interface CasArtifactReference {
   readonly digest: Sha256Digest;
   readonly sizeBytes: number;
@@ -91,6 +100,12 @@ export interface ContainerExecRequest {
   /** POSIX shell script executed with `bash -c` inside the workdir. */
   readonly script: string;
   readonly timeoutMs: number;
+  /**
+   * Per-call host capture cap. Defaults to
+   * `EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES`; raised only for the
+   * log-parser step, whose JSON output can exceed the default for big suites.
+   */
+  readonly maxOutputBytes?: number;
 }
 
 export interface ContainerExecResult {

--- a/runtime/tests/eval/eval-executor-preflight.test.ts
+++ b/runtime/tests/eval/eval-executor-preflight.test.ts
@@ -107,6 +107,7 @@ interface PhasePlan {
 class FakeContainerRunner implements ContainerRunner {
   readonly writtenFiles: string[] = [];
   readonly executedScripts: string[] = [];
+  readonly execCaps: Array<{ script: string; maxOutputBytes?: number }> = [];
   readonly auxiliaryImages: string[] = [];
   readonly copiedFiles: string[] = [];
   readonly removedIds: string[] = [];
@@ -148,6 +149,7 @@ class FakeContainerRunner implements ContainerRunner {
   async exec(_handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult> {
     const plan = this.phases[this.phaseIndex]!;
     this.executedScripts.push(request.script);
+    this.execCaps.push({ script: request.script, maxOutputBytes: request.maxOutputBytes });
     if (request.script.includes(" apply ")) {
       return { ...OK, exitCode: plan.applyExitCode ?? 0, stderr: "apply output" };
     }
@@ -226,6 +228,14 @@ describe("eval executor triple preflight", () => {
         script.includes("/agenc-eval/parser-input.log ")
       ),
     ).toBe(true);
+    // The parse-log step must carry the raised output cap so a big suite's
+    // JSON result is not truncated into a false infrastructure_error (pinot).
+    const parseCaps = runner.execCaps.filter((c) => c.script.includes("parse-log.py"));
+    expect(parseCaps).toHaveLength(6);
+    expect(parseCaps.every((c) => (c.maxOutputBytes ?? 0) >= 64 * 1024 * 1024)).toBe(true);
+    // Non-parser steps keep the default (undefined) cap.
+    const rebuildCaps = runner.execCaps.filter((c) => c.script === "make rebuild");
+    expect(rebuildCaps.every((c) => c.maxOutputBytes === undefined)).toBe(true);
   });
 
   test("a target check passing on base disqualifies the candidate", async () => {


### PR DESCRIPTION
Fifth executor finding from the pilot sweep. **apache/pinot-16421** was reported `infrastructure_error`: its parser emits a JSON map of every surefire result (thousands of tests), exceeding the 1 MiB host capture cap and truncating the JSON at byte 1048557 → invalid JSON → false verdict.

Fix: the `parse-log` step gets a 64 MiB per-call capture cap (`EVAL_EXECUTOR_MAXIMUM_PARSER_OUTPUT_BYTES`) via a new optional `ContainerExecRequest.maxOutputBytes`, threaded through `spawnBounded` and the docker `exec`; every other step keeps the 1 MiB default.

Verification (on top of `74e3668c5`): typecheck clean; build green; `tests/eval` 150/150; the parse-log-cap assertion is **revert-sensitive** (removing the raised cap turns it red). End-to-end proof is the pinot re-run (next).

Note: **tailwindcss-18718** (`test_command_failed`) is a *different* issue — `pnpm test` produced empty output in 409ms (likely a corepack/PATH assumption in the bundle command), which the cap fix does not change; its "couldn't evaluate" verdict is honest. Flagged, not fixed here.