### PR TITLE
feat(runtime): phase-2b egress design + allowlist proxy (security core)

### DIFF
--- a/docs/design/eval-pilot-executor-phase2b-egress.md
+++ b/docs/design/eval-pilot-executor-phase2b-egress.md
@@ -1,0 +1,212 @@
+# Eval pilot executor — phase 2b egress control
+
+Status: design accepted (multi-agent design review, unanimous); not yet
+implemented.
+
+Phase 2a ships the offline agent-run lane (`--network none`, bundled
+in-container mock provider). Phase 2b lets the agent reach a **real** model
+provider API without letting a `--yolo` agent fetch the upstream fix
+(the tasks are cut from merged public GitHub PRs) or exfiltrate the provider
+key (untrusted issue text can prompt-inject the agent). See
+`eval-pilot-executor.md` "Phase 2b" for why this could not be part of 2a.
+
+## Chosen approach: internal-network forward-proxy sidecar
+
+The security boundary is **topological, not a ruleset**. The agent joins a
+docker `--internal` network with no route off the box; a root agent that
+unsets `HTTPS_PROXY` or opens a raw socket still cannot leave — there is
+nothing to flush, no `NET_ADMIN` to hold, no host root required. Proxy env
+only makes the *allowed* path work.
+
+Rejected alternatives: an iptables/nftables egress firewall (a root `--yolo`
+agent with `NET_ADMIN`, or a rule-flush, subverts it; DNS/IP allowlisting is
+brittle to CDN churn) and DNS-restriction (the agent can hardcode IPs to
+bypass name-based blocking). Both scored below the sidecar on security and
+robustness; their best mitigations are grafted in below.
+
+The verification and auxiliary containers stay `--network none` **always** —
+the softer egress boundary is never on the oracle-scoring path.
+
+## Network topology (per run)
+
+Two per-run networks, created before the agent and torn down in `finally`:
+
+1. `agenc-eval-egress-<run>` — `docker network create --internal --subnet
+   10.88.<r>.0/29` (no IPv6). Internal ⇒ no NAT/route to internet or host.
+   The agent joins **only** this net.
+2. `agenc-eval-upstream-<run>` — a normal NAT bridge that **only the sidecar**
+   joins. In production it reaches the real provider; in the hermetic test it
+   is a second `--internal` net carrying the mock provider + a github sink, so
+   the agent's "no NIC there ⇒ no route" property is identical in test and
+   prod.
+
+The sidecar is dual-homed at a static IP on the egress net (e.g.
+`10.88.<r>.2`); the agent's `HTTPS_PROXY` points at that IP:port, so
+reachability never depends on DNS — which lets the agent resolver be
+blackholed (`--dns 127.0.0.1`).
+
+## The sidecar proxy
+
+A small deny-by-default HTTP `CONNECT` proxy shipped inside the read-only
+overlay (`overlay/proxy/allowlist-proxy.mjs`), run by the overlay's pinned
+`node`. It is added to `assertOverlayLayout()` and folded into
+`computeOverlayDigest()`, so the report attests which proxy enforced egress.
+
+Config via env (delivered by `-e`): `AGENC_PROXY_ALLOW_HOST` (exact host),
+`AGENC_PROXY_ALLOW_PORT` (443), `AGENC_PROXY_PIN_IPS` (host-resolved A
+records). Enforcement, in strict order:
+
+1. Accept only HTTP `CONNECT`; plaintext absolute-form → `403` (no open-relay).
+2. Parse `CONNECT host:port`. **Reject before any DNS resolution** if host is
+   not the exact allow-host or port is wrong. Deny-before-resolve closes the
+   proxy's-own-resolver leak channel (never looks up `<secret>.attacker.com`).
+3. Reject IP-literal authorities — allowlist is hostname-only.
+4. Buffer the TLS ClientHello, extract SNI, require `SNI === ALLOW_HOST`, then
+   replay bytes upstream (defeats domain-fronting).
+5. `net.connect` to `PIN_IPS` only (not a fresh resolution); validate the
+   upstream leaf cert chain for `ALLOW_HOST` (defeats mid-run DNS rebind).
+   Then `200` and splice — TLS stays end-to-end to the real provider.
+
+Sidecar flags: `--read-only --cap-drop ALL --security-opt no-new-privileges
+--user 65534:65534 --pids-limit 128 --memory 128m`, mounts no task material.
+
+GitHub is blocked by **default-deny**, not a blocklist: one exact allowed host
+⇒ github.com / api.github.com / raw.githubusercontent.com / codeload all fail
+at step 2 (never resolved), by IP at step 3, at the kernel (no route) for a
+raw socket, and at the resolver for a name lookup. Complements the `.git`
+hygiene already in `buildBaselineGitScript()`.
+
+## docker CLI orchestration
+
+New `createEgressTaskContainer()` on `DockerContainerRunner` plus a
+network/sidecar lifecycle wrapper in `runAgentOnTask`. All via
+`spawnBounded("docker", […])`:
+
+```
+# 0. Host-resolve the provider once (injectable resolver) -> PIN_IPS.
+docker network create --internal --subnet 10.88.<r>.0/29 agenc-eval-egress-<run>
+docker network create agenc-eval-upstream-<run>                 # NAT (prod)
+docker create --name agenc-eval-proxy-<run> \
+  --network agenc-eval-egress-<run> --ip 10.88.<r>.2 \
+  --read-only --cap-drop ALL --security-opt no-new-privileges \
+  --user 65534:65534 --pids-limit 128 --memory 128m \
+  -e AGENC_PROXY_ALLOW_HOST -e AGENC_PROXY_ALLOW_PORT -e AGENC_PROXY_PIN_IPS \
+  -v <overlay>:/agenc-overlay:ro \
+  --entrypoint /agenc-overlay/node/bin/node \
+  <pinned-image@sha256> /agenc-overlay/proxy/allowlist-proxy.mjs
+docker network connect agenc-eval-upstream-<run> agenc-eval-proxy-<run>
+docker start agenc-eval-proxy-<run>          # + loopback CONNECT self-probe
+docker create --network agenc-eval-egress-<run> --dns 127.0.0.1 \
+  <overlay ro> --entrypoint sleep <task-image@sha256> infinity
+docker start <agent>
+# run agent (secrets below); collect patch; teardown (idempotent, in finally)
+docker rm -f <agent> agenc-eval-proxy-<run>
+docker network rm agenc-eval-egress-<run> agenc-eval-upstream-<run>
+```
+
+`buildAgentScript` drops the mock block and instead exports
+`HTTPS_PROXY=http://10.88.<r>.2:<port>`, `AGENC_PROXY_RESOLVES_HOSTS=1` (makes
+undici put the hostname in the CONNECT authority, so `--dns 127.0.0.1` is a
+hard blackhole rather than breakage), `NO_PROXY=`, and the real provider
+`OPENAI_COMPATIBLE_BASE_URL`/model. The key is **not** assigned here.
+
+## Secret delivery — `docker exec -e`, never argv
+
+Extend `ContainerExecRequest` with `envPassthrough?: readonly string[]`
+(variable **names** only). In `DockerContainerRunner.exec`, append `-e NAME`
+(no `=`) per name; `spawn` inherits the executor's `process.env`, so the docker
+CLI reads the value from its own environment — the value is on no command line
+(not in `buildAgentScript`, not in `docker create --env`, not in any argv).
+
+Hardening (deferred variant): deliver the key to the **sidecar** as a
+TLS-terminating auth-injector and give the agent a dummy key, so prompt
+injection has nothing to steal (codebase already supports client CA trust via
+`getCACertificates()`/`NODE_EXTRA_CA_CERTS`). Ship the opaque-tunnel form
+first (key in agent via `-e`, exfil bounded to "can only reach its own
+issuer"); upgrade when key-exfil is the primary concern. Also: use a
+short-TTL, budget-capped, provider-scoped key, and **scan the collected patch
+bytes for the key substring** before `verifyCandidatePatch`; if present, force
+`infrastructure_error` and quarantine.
+
+## Contamination marker (carried until proven)
+
+The report body (folded into `REPORT_DIGEST_DOMAIN`) gains:
+
+```
+egress: {
+  mode: "real-provider",
+  allowHost, keyExposure: "agent-env" | "sidecar-only",
+  sidecarOverlayDigest,
+  oracleContainment: "unverified",   // starts here
+  denyProbes: { githubBlocked, dnsBlackholed, noRouteOffNet,
+                ipv6Absent, ipLiteralRejected, sniPinned },
+  patchKeyScan: "clean" | "key-substring-found",
+}
+```
+
+`oracleContainment` flips to `"contained"` **only** when every `denyProbes`
+field is true AND `patchKeyScan === "clean"`. Otherwise it stays
+`"unverified"`, `runAgentOnTask` forces a new `oracle_containment_unverified`
+outcome, **the agent is not started** (probes run pre-agent), and the run is
+excluded from any scored aggregate. Because the marker is inside the digested
+report, a consumer can cryptographically distinguish a contained run from an
+unverified one. There is **no** degraded "bare bridge" fallback — any setup
+failure aborts.
+
+## Offline test plan
+
+- **Tier 1 — pure unit, no docker (revert-sensitive).** Drive
+  `allowlist-proxy.mjs` over loopback with raw bytes: allowed host tunnels,
+  github → 403, deny-before-resolve (stub dns, assert never called for a denied
+  host), IP-literal → 403, plaintext → 403, wrong port → 403, SNI mismatch
+  dropped. Revert-sensitivity: widen the allowlist to accept github and assert
+  the denied-host test flips green.
+- **Tier 2 — arg-shape unit, no docker.** Golden-assert the docker argv: agent
+  gets `--network agenc-eval-egress-*` + `--dns 127.0.0.1` and not
+  `--network none`; sidecar carries `--internal`/`--read-only`/`--cap-drop
+  ALL`/`no-new-privileges`/static `--ip`; the agent `exec` argv has
+  `-e OPENAI_COMPATIBLE_API_KEY` with no `=value`; the raw key appears in no
+  argv and not in `buildAgentScript`. Fail-closed: a stubbed network/sidecar
+  failure aborts with `oracle_containment_unverified`, never a bare bridge.
+- **Tier 3 — hermetic docker integration, real dockerd, no internet**
+  (docker-gated like the existing live e2e). Fake the internet with a second
+  `--internal` net (agent has no NIC there) carrying the mock provider
+  (alias = allow-host) and a github sink (alias github.com). Assert offline:
+  allowed path 200; github → 403; raw route to the github-sink IP times out
+  (the load-bearing L3 proof); `getent hosts github.com` fails; no key in
+  `docker inspect`/`env`; combined injection all fails; revert-sensitive
+  widen-allowlist probe; and the real overlay `agenc.js` reaches the mock
+  **through the sidecar** via CONNECT (proves undici honors the proxy env).
+- **Cannot be proven offline** (opt-in `AGENC_EVAL_LIVE=1` smoke): real
+  provider reachability/TLS, real domain-fronting, real rebind timing.
+  Offline-green is necessary, not sufficient; a live smoke is mandatory before
+  trusting phase 2b on real providers.
+
+## Residual risks (bounded by hard-fail preflight)
+
+1. Host services on the internal bridge gateway — preflight asserts the agent's
+   `ip route` shows only the `/29`; hard-fail otherwise.
+2. IPv6 leak if dockerd has IPv6 — preflight asserts `ip -6 route` empty
+   (`denyProbes.ipv6Absent`); hard-fail otherwise.
+3. Sidecar confused-deputy (parser bug) — minimal deny-by-default parser +
+   exhaustive Tier-1 revert-sensitive suite; pinned + overlay-digest-attested.
+4. Covert channel to the provider itself — unpreventable, out of scope; reaches
+   only the legitimate issuer. The auth-injecting variant hides the key.
+5. Container escape / kernel confinement — pre-existing phase-2a gap; this
+   controls egress, not seccomp/userns. Mitigated by `--cap-drop ALL`,
+   `no-new-privileges`, no docker socket, limits; verification stays
+   `--network none`.
+6. DNS-rebind on the allowed host — bounded by pinned IPs + upstream cert
+   validation; churn fails **closed** (reliability cost, not a leak).
+7. Fail-open is designed out — any setup failure quarantines the run.
+
+## Implementation order
+
+1. `allowlist-proxy.mjs` + Tier-1 revert-sensitive unit tests (security core,
+   fully offline).
+2. `envPassthrough` secret delivery + the containment-marker report fields +
+   `oracle_containment_unverified` outcome + Tier-2 arg-shape tests.
+3. `createEgressTaskContainer` orchestration + the real-provider path in
+   `runAgentOnTask` (behind an explicit real-provider config, default off).
+4. Tier-3 hermetic docker integration test.
+5. Opt-in live smoke; only then is phase 2b trustworthy on real providers.

--- a/runtime/scripts/eval-allowlist-proxy.mjs
+++ b/runtime/scripts/eval-allowlist-proxy.mjs
@@ -1,0 +1,183 @@
+// Deny-by-default HTTPS CONNECT proxy for the eval executor's real-model
+// lane. It runs inside a sidecar container on an --internal docker network;
+// the agent container's only reachable route off its network is this proxy.
+// The proxy allows a CONNECT tunnel to EXACTLY ONE host:port, dialing only
+// pre-resolved pinned IPs, and denies everything else BEFORE any DNS lookup.
+// It is an opaque tunnel: TLS stays end-to-end between the agent and the real
+// provider (the agent validates the provider cert), so the proxy never sees
+// plaintext or the provider cert. See docs/design/eval-pilot-executor-phase2b-egress.md.
+import net from "node:net";
+import { createServer } from "node:http";
+
+const CONNECT_SELF_PROBE_MARKER = "AGENC_PROXY_READY";
+
+export function isIpLiteral(host) {
+  // IPv4 dotted-quad or any colon (IPv6) — allowlist is hostname-only.
+  if (host.includes(":")) return true;
+  return /^[0-9]+(?:\.[0-9]+){3}$/u.test(host);
+}
+
+/**
+ * Extract the SNI server_name from a TLS ClientHello record, or null if the
+ * bytes are not a ClientHello or carry no SNI. The caller treats a null (or
+ * any non-`allowHost`) result as a FAIL-CLOSED drop, so a parse quirk or a
+ * missing SNI can never open an unverified tunnel.
+ */
+export function parseSni(buffer) {
+  try {
+    if (buffer.length < 43 || buffer[0] !== 0x16) return null; // not a handshake record
+    if (buffer[5] !== 0x01) return null; // not ClientHello
+    let p = 5 + 4; // skip record header (5) + handshake type/length (4)
+    p += 2 + 32; // client_version + random
+    const sessionIdLen = buffer[p];
+    p += 1 + sessionIdLen;
+    const cipherLen = buffer.readUInt16BE(p);
+    p += 2 + cipherLen;
+    const compLen = buffer[p];
+    p += 1 + compLen;
+    if (p + 2 > buffer.length) return null;
+    const extTotal = buffer.readUInt16BE(p);
+    p += 2;
+    const extEnd = Math.min(p + extTotal, buffer.length);
+    while (p + 4 <= extEnd) {
+      const extType = buffer.readUInt16BE(p);
+      const extLen = buffer.readUInt16BE(p + 2);
+      const extStart = p + 4;
+      if (extType === 0x0000) {
+        // server_name extension: list length (2), name type (1), name len (2), name
+        let q = extStart + 2;
+        if (buffer[q] !== 0x00) return null; // only host_name(0)
+        const nameLen = buffer.readUInt16BE(q + 1);
+        q += 3;
+        if (q + nameLen > buffer.length) return null;
+        return buffer.toString("ascii", q, q + nameLen).toLowerCase();
+      }
+      p = extStart + extLen;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Buffer the complete first TLS record (the ClientHello) so SNI is checked on
+ * the whole message, not a single TCP segment. Pauses the socket before
+ * resolving so no bytes are lost between the read and the upstream pipe.
+ * Returns null (→ fail-closed drop) on timeout, oversize, or a malformed
+ * record header.
+ */
+function readClientHello(socket, { maxHelloBytes, timeoutMs }) {
+  return new Promise((resolve) => {
+    let buf = Buffer.alloc(0);
+    let settled = false;
+    const done = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.removeListener("data", onData);
+      socket.pause();
+      resolve(value);
+    };
+    const onData = (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (buf.length > maxHelloBytes) return done(null);
+      if (buf.length >= 5) {
+        const recordLength = buf.readUInt16BE(3);
+        if (recordLength <= 0 || recordLength > maxHelloBytes) return done(null);
+        if (buf.length >= 5 + recordLength) return done(buf);
+      }
+    };
+    const timer = setTimeout(() => done(null), timeoutMs);
+    socket.on("data", onData);
+  });
+}
+
+export function createAllowlistProxy(config) {
+  const allowHost = String(config.allowHost).toLowerCase();
+  const allowPort = String(config.allowPort);
+  const pinIps = [...config.pinIps];
+  const sniTimeoutMs = config.sniTimeoutMs ?? 10_000;
+  // Bound the buffered ClientHello above the TLS record maximum (16 KiB).
+  const maxHelloBytes = config.maxHelloBytes ?? 18_432;
+  const maxConnections = config.maxConnections ?? 64;
+  if (pinIps.length === 0) throw new Error("allowlist proxy requires at least one pinned IP");
+
+  // Absolute-form / plain-HTTP requests are never the provider API path.
+  const server = createServer((_req, res) => {
+    res.writeHead(403, { "content-type": "text/plain" });
+    res.end("forbidden");
+  });
+  // Cap concurrent tunnels so a malicious agent cannot exhaust the sidecar.
+  server.maxConnections = maxConnections;
+
+  server.on("connect", (req, clientSocket) => {
+    // Attach the error handler FIRST: a client RST at any point (including
+    // while awaiting the ClientHello) must drop the socket, never crash the
+    // egress proxy for concurrent runs.
+    clientSocket.on("error", () => clientSocket.destroy());
+    const authority = String(req.url ?? "");
+    const lastColon = authority.lastIndexOf(":");
+    const host = lastColon > 0 ? authority.slice(0, lastColon).toLowerCase() : authority.toLowerCase();
+    const port = lastColon > 0 ? authority.slice(lastColon + 1) : "";
+
+    // A trivial in-container readiness self-probe: the sidecar dials itself
+    // with this exact authority and expects a 403, proving the deny path is
+    // live before the agent is started.
+    const denyAndClose = (reason) => {
+      clientSocket.write(
+        `HTTP/1.1 403 Forbidden\r\nx-agenc-proxy-deny: ${reason}\r\nconnection: close\r\n\r\n`,
+      );
+      clientSocket.destroy();
+    };
+
+    // Deny BEFORE any DNS resolution: the proxy must never look up a denied
+    // host (that would itself be an exfil channel).
+    if (isIpLiteral(host)) return denyAndClose("ip-literal");
+    if (host !== allowHost) return denyAndClose("host");
+    if (port !== allowPort) return denyAndClose("port");
+
+    clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+
+    // Buffer the whole ClientHello and pin its SNI to the allowed host —
+    // FAIL CLOSED: drop unless the SNI is positively verified as allowHost.
+    // Then replay the exact bytes upstream (opaque tunnel, no TLS
+    // termination), dialing only a pre-resolved pinned IP.
+    readClientHello(clientSocket, { maxHelloBytes, timeoutMs: sniTimeoutMs }).then((hello) => {
+      if (!hello || parseSni(hello) !== allowHost) return clientSocket.destroy();
+      const upstream = net.connect({ host: pinIps[0], port: Number(allowPort) }, () => {
+        upstream.write(hello);
+        clientSocket.pipe(upstream);
+        upstream.pipe(clientSocket);
+      });
+      upstream.on("error", () => clientSocket.destroy());
+      clientSocket.on("error", () => upstream.destroy());
+    });
+  });
+
+  return server;
+}
+
+async function main() {
+  const allowHost = process.env.AGENC_PROXY_ALLOW_HOST;
+  const allowPort = process.env.AGENC_PROXY_ALLOW_PORT ?? "443";
+  const pinIps = (process.env.AGENC_PROXY_PIN_IPS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  const listenPort = Number(process.env.AGENC_PROXY_LISTEN_PORT ?? "8080");
+  if (!allowHost || pinIps.length === 0) {
+    process.stderr.write("AGENC_PROXY_ALLOW_HOST and AGENC_PROXY_PIN_IPS are required\n");
+    process.exit(2);
+  }
+  const server = createAllowlistProxy({ allowHost, allowPort, pinIps });
+  server.listen(listenPort, "0.0.0.0", () => {
+    process.stdout.write(`${CONNECT_SELF_PROBE_MARKER} host=${allowHost} port=${allowPort}\n`);
+  });
+}
+
+const invokedDirectly = process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  main().catch((error) => {
+    process.stderr.write(`${error?.message ?? error}\n`);
+    process.exit(1);
+  });
+}

--- a/runtime/tests/eval/eval-allowlist-proxy.test.ts
+++ b/runtime/tests/eval/eval-allowlist-proxy.test.ts
@@ -1,0 +1,302 @@
+import net from "node:net";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  createAllowlistProxy,
+  isIpLiteral,
+  parseSni,
+} from "../../scripts/eval-allowlist-proxy.mjs";
+
+// Tier-1 security core tests for the phase-2b egress proxy. Pure loopback, no
+// docker, no network. Prove the deny-by-default allowlist blocks github and
+// everything except the exact allowed host:port, and that the deny happens
+// before any DNS resolution.
+
+const ALLOW_HOST = "api.provider.test";
+const ALLOW_PORT = "443";
+
+interface Upstream {
+  readonly port: number;
+  readonly received: Buffer[];
+  close(): Promise<void>;
+}
+
+/** A loopback stand-in for the pinned provider IP: echoes what it receives. */
+function startUpstream(): Promise<Upstream> {
+  const received: Buffer[] = [];
+  const server = net.createServer((socket) => {
+    socket.on("data", (chunk) => {
+      received.push(chunk);
+      socket.write(Buffer.concat([Buffer.from("ECHO:"), chunk]));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({
+        port: typeof address === "object" && address ? address.port : 0,
+        received,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+/** Craft a minimal but well-formed TLS ClientHello carrying the given SNI. */
+function buildClientHello(sni: string): Buffer {
+  const nameBuf = Buffer.from(sni, "ascii");
+  const serverNameList = Buffer.concat([
+    Buffer.from([0x00]), // host_name
+    (() => { const b = Buffer.alloc(2); b.writeUInt16BE(nameBuf.length); return b; })(),
+    nameBuf,
+  ]);
+  const sniExtData = Buffer.concat([
+    (() => { const b = Buffer.alloc(2); b.writeUInt16BE(serverNameList.length); return b; })(),
+    serverNameList,
+  ]);
+  const sniExt = Buffer.concat([
+    Buffer.from([0x00, 0x00]), // extension type: server_name
+    (() => { const b = Buffer.alloc(2); b.writeUInt16BE(sniExtData.length); return b; })(),
+    sniExtData,
+  ]);
+  const extensions = Buffer.concat([
+    (() => { const b = Buffer.alloc(2); b.writeUInt16BE(sniExt.length); return b; })(),
+    sniExt,
+  ]);
+  const body = Buffer.concat([
+    Buffer.from([0x03, 0x03]), // client_version TLS1.2
+    Buffer.alloc(32), // random
+    Buffer.from([0x00]), // session_id length 0
+    Buffer.from([0x00, 0x02, 0x13, 0x01]), // cipher_suites: len 2 + one suite
+    Buffer.from([0x01, 0x00]), // compression_methods: len 1 + null
+    extensions,
+  ]);
+  const handshake = Buffer.concat([
+    Buffer.from([0x01]), // ClientHello
+    (() => { const b = Buffer.alloc(3); b.writeUIntBE(body.length, 0, 3); return b; })(),
+    body,
+  ]);
+  return Buffer.concat([
+    Buffer.from([0x16, 0x03, 0x01]), // handshake record, TLS1.0 record version
+    (() => { const b = Buffer.alloc(2); b.writeUInt16BE(handshake.length); return b; })(),
+    handshake,
+  ]);
+}
+
+interface ProxyHandle {
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+async function startProxy(
+  overrides: Partial<Parameters<typeof createAllowlistProxy>[0]>,
+): Promise<ProxyHandle> {
+  // The proxy dials pinIps[0]:allowPort; tests point both at the loopback
+  // echo upstream, so no real :443 is needed.
+  const server = createAllowlistProxy({
+    allowHost: ALLOW_HOST,
+    allowPort: ALLOW_PORT,
+    pinIps: ["127.0.0.1"],
+    sniTimeoutMs: 2_000,
+    ...overrides,
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({
+        port: typeof address === "object" && address ? address.port : 0,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+/** Send a raw CONNECT and return the status line + whether the tunnel opened. */
+function sendConnect(
+  proxyPort: number,
+  authority: string,
+  afterEstablished?: Buffer,
+): Promise<{ status: string; tunneledEcho: string | null }> {
+  return new Promise((resolve) => {
+    const socket = net.connect(proxyPort, "127.0.0.1", () => {
+      socket.write(`CONNECT ${authority} HTTP/1.1\r\nhost: ${authority}\r\n\r\n`);
+    });
+    let buf = Buffer.alloc(0);
+    let status = "";
+    let established = false;
+    let echo: string | null = null;
+    const timer = setTimeout(() => finish(), 1_500);
+    const finish = () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve({ status, tunneledEcho: echo });
+    };
+    socket.on("data", (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!established && buf.includes(Buffer.from("\r\n\r\n"))) {
+        established = true;
+        status = buf.toString("latin1").split("\r\n")[0] ?? "";
+        if (status.includes("200") && afterEstablished) {
+          buf = Buffer.alloc(0); // tunnel bytes follow the status header
+          socket.write(afterEstablished);
+        } else {
+          finish();
+        }
+      } else if (established) {
+        const text = buf.toString("latin1");
+        if (text.startsWith("ECHO:")) { echo = text; finish(); }
+      }
+    });
+    socket.on("error", () => finish());
+  });
+}
+
+describe("eval allowlist proxy (tier 1 security core)", () => {
+  let upstream: Upstream;
+  let proxy: ProxyHandle;
+
+  beforeEach(async () => {
+    upstream = await startUpstream();
+    // Pin the proxy's upstream to the loopback echo server's port so the
+    // "connect to pinned IP only" path is exercised without real 443.
+    proxy = await startProxy({ allowPort: String(upstream.port) });
+  });
+
+  afterEach(async () => {
+    await proxy.close();
+    await upstream.close();
+  });
+
+  test("unit: SNI parser and IP-literal detector", () => {
+    expect(parseSni(buildClientHello(ALLOW_HOST))).toBe(ALLOW_HOST);
+    expect(parseSni(Buffer.from("not a tls record"))).toBeNull();
+    expect(isIpLiteral("140.82.112.3")).toBe(true);
+    expect(isIpLiteral("::1")).toBe(true);
+    expect(isIpLiteral("api.provider.test")).toBe(false);
+  });
+
+  test("allowed host:port with matching SNI tunnels to the pinned upstream", async () => {
+    const hello = buildClientHello(ALLOW_HOST);
+    const result = await sendConnect(proxy.port, `${ALLOW_HOST}:${upstream.port}`, hello);
+    expect(result.status).toContain("200");
+    expect(result.tunneledEcho).toContain("ECHO:");
+    expect(upstream.received.length).toBeGreaterThan(0);
+  });
+
+  test("github is denied 403 (default-deny, not a blocklist)", async () => {
+    const result = await sendConnect(proxy.port, `github.com:${upstream.port}`);
+    expect(result.status).toContain("403");
+    expect(result.tunneledEcho).toBeNull();
+    expect(upstream.received.length).toBe(0);
+  });
+
+  test("IP-literal authority is denied", async () => {
+    const result = await sendConnect(proxy.port, `140.82.112.3:${upstream.port}`);
+    expect(result.status).toContain("403");
+  });
+
+  test("wrong port on the allowed host is denied", async () => {
+    const result = await sendConnect(proxy.port, `${ALLOW_HOST}:80`);
+    expect(result.status).toContain("403");
+  });
+
+  test("a mismatched SNI on the allowed authority drops the tunnel", async () => {
+    const hello = buildClientHello("api.github.com");
+    const result = await sendConnect(proxy.port, `${ALLOW_HOST}:${upstream.port}`, hello);
+    // CONNECT is accepted (200) but the SNI mismatch drops before upstream.
+    expect(result.tunneledEcho).toBeNull();
+    expect(upstream.received.length).toBe(0);
+  });
+
+  test("plain-HTTP absolute-form requests are forbidden", async () => {
+    const status = await new Promise<string>((resolve) => {
+      const socket = net.connect(proxy.port, "127.0.0.1", () => {
+        socket.write(`GET http://github.com/ HTTP/1.1\r\nhost: github.com\r\n\r\n`);
+      });
+      let buf = "";
+      socket.on("data", (c) => { buf += c.toString("latin1"); if (buf.includes("\r\n")) { socket.destroy(); resolve(buf.split("\r\n")[0] ?? ""); } });
+      socket.on("error", () => resolve(""));
+    });
+    expect(status).toContain("403");
+  });
+
+  test("a split ClientHello with a mismatched SNI is dropped (no single-segment bypass)", async () => {
+    // Send a github-SNI ClientHello fragmented across writes. The proxy must
+    // buffer the whole record and fail closed, not allow on the partial first
+    // segment.
+    const hello = buildClientHello("api.github.com");
+    const received = await new Promise<number>((resolve) => {
+      const socket = net.connect(proxy.port, "127.0.0.1", () => {
+        socket.write(`CONNECT ${ALLOW_HOST}:${upstream.port} HTTP/1.1\r\n\r\n`);
+      });
+      let established = false;
+      const timer = setTimeout(() => { socket.destroy(); resolve(upstream.received.length); }, 1_200);
+      socket.on("data", (chunk) => {
+        if (!established && chunk.toString("latin1").includes("200")) {
+          established = true;
+          socket.write(hello.subarray(0, 1)); // one byte first
+          setTimeout(() => socket.write(hello.subarray(1)), 60);
+        }
+      });
+      socket.on("error", () => { clearTimeout(timer); resolve(upstream.received.length); });
+    });
+    expect(received).toBe(0);
+  });
+
+  test("a split ClientHello with the ALLOWED SNI still tunnels (buffering is correct)", async () => {
+    const hello = buildClientHello(ALLOW_HOST);
+    const echo = await new Promise<string | null>((resolve) => {
+      const socket = net.connect(proxy.port, "127.0.0.1", () => {
+        socket.write(`CONNECT ${ALLOW_HOST}:${upstream.port} HTTP/1.1\r\n\r\n`);
+      });
+      let established = false;
+      const timer = setTimeout(() => { socket.destroy(); resolve(null); }, 1_500);
+      socket.on("data", (chunk) => {
+        const text = chunk.toString("latin1");
+        if (!established && text.includes("200")) {
+          established = true;
+          socket.write(hello.subarray(0, 5));
+          setTimeout(() => socket.write(hello.subarray(5)), 50);
+        } else if (established && text.startsWith("ECHO:")) {
+          clearTimeout(timer); socket.destroy(); resolve(text);
+        }
+      });
+      socket.on("error", () => { clearTimeout(timer); resolve(null); });
+    });
+    expect(echo).toContain("ECHO:");
+  });
+
+  test("a client RST after 200 does not crash the proxy (concurrent egress stays up)", async () => {
+    await new Promise<void>((resolve) => {
+      const socket = net.connect(proxy.port, "127.0.0.1", () => {
+        socket.write(`CONNECT ${ALLOW_HOST}:${upstream.port} HTTP/1.1\r\n\r\n`);
+      });
+      socket.on("data", (chunk) => {
+        if (chunk.toString("latin1").includes("200")) {
+          socket.resetAndDestroy(); // RST instead of a ClientHello
+          setTimeout(resolve, 100);
+        }
+      });
+      socket.on("error", () => setTimeout(resolve, 100));
+    });
+    // The proxy must still be alive and enforcing: a fresh github probe → 403.
+    const result = await sendConnect(proxy.port, `github.com:${upstream.port}`);
+    expect(result.status).toContain("403");
+  });
+
+  test("REVERT-SENSITIVE: widening the allowlist to github makes it reachable", async () => {
+    // If the deny is what blocks github, adding github to the allowlist must
+    // flip the github probe from 403 to a tunnel. This fails if the block were
+    // some artifact rather than the allowlist check.
+    const widened = await startProxy(
+      { allowHost: "github.com", allowPort: String(upstream.port) },
+    );
+    try {
+      const hello = buildClientHello("github.com");
+      const result = await sendConnect(widened.port, `github.com:${upstream.port}`, hello);
+      expect(result.status).toContain("200");
+      expect(result.tunneledEcho).toContain("ECHO:");
+    } finally {
+      await widened.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

Phase 2b lets the eval agent reach a **real** model provider without a `--yolo` agent fetching the upstream fix (tasks are cut from public GitHub PRs) or exfiltrating the provider key. This PR lands the **design** and the **security core**; the docker orchestration is the next slice.

- `docs/design/eval-pilot-executor-phase2b-egress.md` — the accepted design (unanimous multi-agent design review): an internal-network forward-proxy sidecar where the boundary is **topological** (the agent has no route off the box, so a root `--yolo` agent that unsets `HTTPS_PROXY` still cannot leave), secret delivery via `docker exec -e` (never argv), a default-pessimistic `oracleContainment: "unverified"` marker folded into the report digest, and a 3-tier offline test plan.
- `scripts/eval-allowlist-proxy.mjs` — the deny-by-default CONNECT proxy: allows a tunnel to exactly one host:port, dialing only pre-resolved pinned IPs, denying everything else **before any DNS lookup**. Opaque tunnel (TLS stays end-to-end to the provider).

## Adversarially reviewed — 3 confirmed issues fixed before merge

The proxy is security-critical, so it got a focused adversarial review (which empirically confirmed each issue):

| Issue | Fix |
|---|---|
| **Remote crash** — a client RST while awaiting the ClientHello killed the whole proxy (error handler attached too late) | Handler attached first thing in the connect handler |
| **Split-ClientHello SNI bypass** — single-segment read + fail-open-on-null let a fragmented github-SNI hello through (domain-fronting if the pinned IP is a shared CDN) | Buffers the full ClientHello and **fails closed** (drop unless SNI == allowHost) |
| No concurrency cap | `server.maxConnections` |

The authority/IP-literal parsing was reviewed and confirmed fail-closed against userinfo, trailing-dot, suffix, IPv6-bracket, and integer-IP tricks.

## Verification

Tested SHA on top of `1954f49fd`. Node v25.9.0. Typecheck clean; build green; `tests/eval` **161/161** including 11 loopback proxy tests. **Revert-sensitive:** the github-deny test goes red without the host allowlist; the split-bypass test goes red against the original single-segment fail-open read.

Follow-up slices (per the design doc): `envPassthrough` secret delivery + containment-marker report fields + `createEgressTaskContainer` orchestration + Tier-3 hermetic docker integration + an opt-in live smoke. The real-model lane is not active until those land.