### PR TITLE
fix(runtime): route headless agent model calls through the egress proxy

### DIFF
--- a/docs/design/eval-pilot-executor-phase2b-egress.md
+++ b/docs/design/eval-pilot-executor-phase2b-egress.md
@@ -1,8 +1,18 @@
 # Eval pilot executor — phase 2b egress control
 
-Status: implemented (offline Tier-1/2 + hermetic Tier-3 docker tests green;
-adversarially reviewed). A live smoke against a real provider is the only
-remaining step before the lane is trusted for scored runs.
+Status: implemented and **proven end to end against a real provider**. The
+first real-model run (grok-4.5 on the adm-zip pilot task) produced a
+hidden-verifier-passing patch inside a fully contained lane
+(`oracleContainment: contained`, all probes true, `patchKeyScan: clean`).
+
+Live-run note — headless proxy: the runtime installs its undici proxy
+dispatcher (`configureGlobalAgents`) only on the interactive TUI path, so the
+daemon behind `agenc -p` ignored `HTTPS_PROXY` and attempted a direct model
+call, which the egress lane's blackholed resolver correctly refused. The lane
+now injects `NODE_OPTIONS=--require .../proxy/eval-proxy-preload.cjs` into the
+agent (inherited by the daemon), which installs the dispatcher from
+`HTTPS_PROXY`. The proper fix is to have the runtime configure the proxy in
+headless mode too (a separate follow-up); the preload can then be dropped.
 
 Implementation notes / deviations from the original design, all made during
 the adversarial review:

--- a/runtime/scripts/eval-proxy-preload.cjs
+++ b/runtime/scripts/eval-proxy-preload.cjs
@@ -1,0 +1,29 @@
+// Overlay-staged preload for the real-model lane. Injected via
+// `NODE_OPTIONS=--require` into the agent CLI AND the daemon it spawns
+// (NODE_OPTIONS is inherited by child processes). It installs the undici
+// global proxy dispatcher from HTTPS_PROXY so the HEADLESS daemon routes its
+// model calls through the egress proxy.
+//
+// Why this is needed: the runtime installs its proxy dispatcher
+// (`configureGlobalAgents`) only on the interactive TUI path, not in the
+// daemon/print (`-p`) path, so a headless agent otherwise ignores
+// HTTPS_PROXY and attempts a direct connection — which the egress lane's
+// blackholed resolver correctly refuses. Fixing that in the runtime would
+// let this preload be dropped.
+try {
+  const undici = require("/agenc-overlay/runtime/node_modules/undici");
+  const proxy = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY;
+  if (proxy && typeof undici.EnvHttpProxyAgent === "function") {
+    undici.setGlobalDispatcher(
+      new undici.EnvHttpProxyAgent({
+        httpsProxy: proxy,
+        httpProxy: proxy,
+        noProxy: process.env.NO_PROXY || process.env.no_proxy,
+      }),
+    );
+  }
+} catch (err) {
+  // Best-effort: if the dispatcher cannot be installed the agent simply
+  // cannot reach the provider and the run fails closed (never leaks).
+  process.stderr.write(`eval-proxy-preload: ${err && err.message}\n`);
+}

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -35,6 +35,7 @@ import {
   AGENT_RUNTIME_ENTRY,
   OVERLAY_AGENT_ENTRY_SUBPATH,
   OVERLAY_CONTAINER_PATH,
+  OVERLAY_PROXY_PRELOAD,
 } from "./overlay-paths.js";
 
 export const EVAL_BASELINE_TAG = "agenc-eval-baseline";
@@ -106,11 +107,23 @@ export interface AgentRunConfig {
 export const DEFAULT_AGENT_TIMEOUT_MS = 1_800_000;
 
 
-export async function assertOverlayLayout(overlay: AgentOverlay): Promise<void> {
+export async function assertOverlayLayout(
+  overlay: AgentOverlay,
+  options: { readonly egress?: boolean } = {},
+): Promise<void> {
   const required = [
     path.join(overlay.hostDir, "node", "bin", "node"),
     path.join(overlay.hostDir, OVERLAY_AGENT_ENTRY_SUBPATH),
     path.join(overlay.hostDir, "mock", "serve.mjs"),
+    // The real-model lane also needs the proxy sidecar, the containment
+    // probe, and the daemon proxy preload staged in the overlay.
+    ...(options.egress
+      ? [
+        path.join(overlay.hostDir, "proxy", "allowlist-proxy.mjs"),
+        path.join(overlay.hostDir, "proxy", "eval-egress-probe.mjs"),
+        path.join(overlay.hostDir, "proxy", "eval-proxy-preload.cjs"),
+      ]
+      : []),
   ];
   for (const file of required) {
     try {
@@ -517,6 +530,10 @@ export function buildRealProviderAgentScript(config: {
     buildBaselineGitScript(),
     `export HTTPS_PROXY=${proxyUrl} HTTP_PROXY=${proxyUrl} NO_PROXY=`,
     `export AGENC_PROXY_RESOLVES_HOSTS=1`,
+    // Install the undici proxy dispatcher in the CLI AND the daemon it spawns
+    // (NODE_OPTIONS is inherited): the runtime only configures the proxy in
+    // TUI mode, so a headless agent would otherwise ignore HTTPS_PROXY.
+    `export NODE_OPTIONS="--require ${OVERLAY_PROXY_PRELOAD}"`,
     `export AGENC_PROVIDER=openai-compatible AGENC_MODEL=${config.model}`,
     `export OPENAI_COMPATIBLE_MODEL=${config.model}`,
     `export OPENAI_COMPATIBLE_BASE_URL="${config.baseUrl}" API_TIMEOUT_MS=600000`,
@@ -557,7 +574,7 @@ export async function runRealProviderAgentOnTask(
   timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
   options: PreflightExecutionOptions = {},
 ): Promise<AgentRunArtifacts> {
-  await assertOverlayLayout(config.overlay);
+  await assertOverlayLayout(config.overlay, { egress: true });
   const secret = process.env[config.keyEnvVar];
   if (secret === undefined || secret.length === 0) {
     throw new EvalExecutorError([`${config.keyEnvVar} is not set in the executor environment`]);

--- a/runtime/src/eval-executor/overlay-paths.ts
+++ b/runtime/src/eval-executor/overlay-paths.ts
@@ -12,3 +12,4 @@ export const AGENT_RUNTIME_ENTRY = `${OVERLAY_CONTAINER_PATH}/${OVERLAY_AGENT_EN
 export const OVERLAY_NODE = `${OVERLAY_CONTAINER_PATH}/node/bin/node`;
 export const OVERLAY_PROXY_ENTRY = `${OVERLAY_CONTAINER_PATH}/proxy/allowlist-proxy.mjs`;
 export const OVERLAY_PROBE_ENTRY = `${OVERLAY_CONTAINER_PATH}/proxy/eval-egress-probe.mjs`;
+export const OVERLAY_PROXY_PRELOAD = `${OVERLAY_CONTAINER_PATH}/proxy/eval-proxy-preload.cjs`;

--- a/runtime/tests/eval/eval-executor-egress.test.ts
+++ b/runtime/tests/eval/eval-executor-egress.test.ts
@@ -141,6 +141,9 @@ describe("real-provider agent script", () => {
     expect(script).not.toContain("OPENAI_COMPATIBLE_API_KEY=");
     // No mock provider in the real lane.
     expect(script).not.toContain("mock/serve.mjs");
+    // The daemon proxy preload is installed so headless model calls route
+    // through the egress proxy.
+    expect(script).toContain('NODE_OPTIONS="--require /agenc-overlay/proxy/eval-proxy-preload.cjs"');
   });
 });
 
@@ -223,6 +226,10 @@ describe("real-provider lane gating (fake lane, no docker)", () => {
     await writeFile(path.join(bin, "agenc.js"), "");
     await mkdir(path.join(overlayDir, "mock"), { recursive: true });
     await writeFile(path.join(overlayDir, "mock", "serve.mjs"), "");
+    await mkdir(path.join(overlayDir, "proxy"), { recursive: true });
+    for (const f of ["allowlist-proxy.mjs", "eval-egress-probe.mjs", "eval-proxy-preload.cjs"]) {
+      await writeFile(path.join(overlayDir, "proxy", f), "");
+    }
     process.env[KEY_VAR] = SECRET;
   });
 


### PR DESCRIPTION
## What

The **first real-model eval run** surfaced this. The runtime installs its undici proxy dispatcher (`configureGlobalAgents`) only on the interactive **TUI** path (`onChangeAppState.ts`), so the daemon behind `agenc -p --yolo` ignored `HTTPS_PROXY` and made a **direct** model call — which the egress lane's blackholed resolver correctly refused (`agent_error: fetch failed`). Containment was proven; the *allowed* path never activated.

Fix: the real-provider agent script now sets `NODE_OPTIONS=--require .../proxy/eval-proxy-preload.cjs`, inherited by the daemon it spawns. The preload installs the undici `EnvHttpProxyAgent` global dispatcher from `HTTPS_PROXY` so headless model calls route through the sidecar. `assertOverlayLayout({egress:true})` now requires the three overlay proxy scripts.

## Proven end to end

`grok-4.5` on `cthackers__adm-zip-559` → **`verified_fix`**:
- `oracleContainment: contained`, all six probes true, `patchKeyScan: clean`, ~495K real Grok tokens.
- The candidate patch (`pth.resolve(fixPath(...))` → `pth.resolve(...)` — dropping the double path-join the issue described) passed the hidden `failToPass` test with all 86 `passToPass` tests still green, applied in a fresh `--network none` verification container.

Diagnosis was isolated with a direct undici test in the agent container (proxy mechanism = HTTP 200) vs. the daemon (direct → DNS blackhole), then confirmed by a `pong` smoke with the preload before the full run.

## Follow-up

The proper fix is to configure the proxy in the runtime's **headless** path too (benefits all headless-behind-proxy users); the eval preload can then be dropped.

## Verification

On top of `e0c4fff53`. Typecheck clean; build + pre-commit hook green; `tests/eval` **176/176** (adds the `NODE_OPTIONS` preload assertion + egress overlay-layout requirement); plus the full real run above.