### PR TITLE
fix(runtime): configure the proxy/mTLS dispatcher in the headless daemon

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -138,6 +138,7 @@ import {
   createSizeCappedFileLogSink,
   type SizeCappedFileLogSink,
 } from "../utils/logger.js";
+import { configureGlobalAgents } from "../utils/proxy.js";
 import { isRecord } from "../utils/record.js";
 import { startHeapWatchdog } from "../services/heapWatchdog/heapWatchdog.js";
 
@@ -1267,6 +1268,12 @@ async function runAgenCDaemonForeground(
   } = {},
 ): Promise<number> {
   const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+  // Install the process-wide proxy/mTLS dispatcher before any daemon service
+  // (including a possibly-remote-HTTP auth backend) issues a request. The TUI
+  // does this via applyConfigEnvironmentVariables; the headless daemon never
+  // runs that path, so a bare fetch()/global-axios call would otherwise ignore
+  // HTTPS_PROXY. No-op when no proxy/mTLS/CA env is present.
+  configureGlobalAgents();
   const authStartup = await tryResolveAgenCDaemonAuthStartup(host, io);
   if (authStartup === null) {
     return 1;

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -12,7 +12,7 @@ import { createConnection, createServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import type { AgenCShutdownSignal } from "../lifecycle/signal-handlers.js";
 import { openStateDatabases } from "../state/sqlite-driver.js";
@@ -54,6 +54,9 @@ import {
   createEmptyToolPermissionContext,
   type ToolPermissionContext,
 } from "../permissions/types.js";
+import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { clearProxyCache } from "../utils/proxy.js";
+import { clearMTLSCache } from "../utils/mtls.js";
 import { AsyncQueue } from "../utils/async-queue.js";
 import {
   buildRealtimeSessionConfig,
@@ -3881,3 +3884,67 @@ function latestSnapshotToolState(
     driver.close();
   }
 }
+
+describe("daemon startup proxy configuration", () => {
+  // getProxyUrl reads process.env (not host.env), matching production where the
+  // spawned daemon's process.env IS the inherited parent CLI env.
+  const PROXY_ENV = [
+    "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy",
+    "AGENC_CLIENT_CERT", "AGENC_CLIENT_KEY", "NODE_EXTRA_CA_CERTS",
+  ];
+  let stashed: Record<string, string | undefined>;
+  let originalDispatcher: ReturnType<typeof getGlobalDispatcher>;
+
+  beforeEach(() => {
+    stashed = Object.fromEntries(PROXY_ENV.map((k) => [k, process.env[k]]));
+    originalDispatcher = getGlobalDispatcher();
+    for (const k of PROXY_ENV) delete process.env[k];
+    clearProxyCache();
+    clearMTLSCache();
+  });
+
+  afterEach(() => {
+    for (const k of PROXY_ENV) {
+      if (stashed[k] === undefined) delete process.env[k];
+      else process.env[k] = stashed[k];
+    }
+    setGlobalDispatcher(originalDispatcher);
+    clearProxyCache();
+    clearMTLSCache();
+  });
+
+  async function bootDaemonAndStop(): Promise<void> {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    delete host.env[AGENC_DAEMON_WEBSOCKET_PORT_ENV];
+    const io = createIo();
+    const signalProcess = createSignalProcess();
+    const running = runAgenCDaemonCli(
+      { kind: "command", action: "run" },
+      { host, io, signalProcess },
+    );
+    try {
+      await waitForDaemonWebSocketUrl(io);
+    } finally {
+      signalProcess.emit("SIGTERM");
+      await Promise.allSettled([running]);
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  }
+
+  it("installs the env-proxy global dispatcher when HTTPS_PROXY is set", async () => {
+    process.env.HTTPS_PROXY = "http://127.0.0.1:9"; // unroutable; nothing connects
+    clearProxyCache();
+    await bootDaemonAndStop();
+    // REVERT-SENSITIVE: without the configureGlobalAgents() call in
+    // runAgenCDaemonForeground, the global dispatcher stays undici's default
+    // Agent and this fails.
+    expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("leaves the default dispatcher untouched without any proxy/mTLS env", async () => {
+    const before = getGlobalDispatcher();
+    await bootDaemonAndStop();
+    expect(getGlobalDispatcher()).toBe(before); // no-op path: same reference
+  });
+});


### PR DESCRIPTION
## What

The runtime installs its undici global dispatcher (`configureGlobalAgents`) only on the interactive **TUI** path. The headless **daemon** behind `agenc -p` never runs it, so a bare `fetch()` / global-axios call in the daemon silently ignored `HTTPS_PROXY`. Surfaced by the eval executor's real-model lane, which had to work around it with a `NODE_OPTIONS` preload.

`runAgenCDaemonForeground` now calls `configureGlobalAgents()` right after the pid path and **before** the (possibly-remote-HTTP) auth backend starts. The spawned daemon inherits the parent CLI env unfiltered (`{...host.env, AGENC_DAEMON_RUN:"1"}`), so an inherited `HTTPS_PROXY` is visible; the call early-returns / lazy-requires undici and is a near-no-op when no proxy/mTLS/CA env is set. This matches what the TUI already does.

Call site + env inheritance + idempotence were confirmed by a multi-agent investigation of the daemon bootstrap.

## Caveats (documented — same class the TUI already carries)

- With `NODE_EXTRA_CA_CERTS` or `AGENC_CLIENT_CERT/KEY` set (no proxy), the daemon fetch surface now uses the repo's CA-composed agent — **matches TUI behavior**, but is a real change on corporate machines.
- With `HTTPS_PROXY` and an incomplete `NO_PROXY`, daemon-internal loopback `fetch()` would route through the proxy; set `NO_PROXY=localhost,127.0.0.1` in proxied deployments (as with the TUI). The unix-socket control channel is unaffected.

## Verification

On top of `9a5490822`. Typecheck clean; build + pre-commit hook green. Two new **revert-sensitive** tests in `daemon-cli.contract.test.ts`: the global dispatcher becomes `EnvHttpProxyAgent` when `HTTPS_PROXY` is set (boots the real foreground daemon in-process; **proven red without the fix**), and stays the same reference with no proxy/mTLS env. 

**Honesty note:** the pre-existing `foreground daemon runs restart recovery before advertising readiness` test in that file **also fails on clean main** (unrelated to this change).

## Follow-up

The eval lane's `NODE_OPTIONS` proxy preload can be dropped once verified against the fixed daemon.