### PR TITLE
fix(runtime): reset hidden test-patch targets to base before applying (eval verifier)

### DIFF
--- a/runtime/src/eval-executor/preflight.ts
+++ b/runtime/src/eval-executor/preflight.ts
@@ -152,11 +152,17 @@ async function runPhase(
       if (patch.bytes.byteLength === 0) continue;
       const target = `${HELPER_DIR}/${patch.name}`;
       await runner.writeFile(handle, target, patch.bytes);
-      const applied = await exec(
-        `apply ${patch.name}`,
-        `git -c core.fileMode=false apply --verbose '${target}'`,
-        timeouts.patchMs,
-      );
+      // SWE-bench-faithful: reset the HIDDEN test patch's target files to base
+      // (and drop any agent-created versions) before applying it, so a
+      // candidate that touched test-adjacent files (snapshots, test context)
+      // cannot block the tests from applying. Source fixes are untouched — the
+      // test patch only targets test files.
+      const applyScript = patch.name === "test.patch"
+        ? `git -c core.fileMode=false apply --numstat '${target}' | awk '{print $NF}' | ` +
+          `while IFS= read -r f; do [ -n "$f" ] && { git checkout HEAD -- "$f" 2>/dev/null || rm -f "$f"; }; done; ` +
+          `git -c core.fileMode=false apply --verbose '${target}'`
+        : `git -c core.fileMode=false apply --verbose '${target}'`;
+      const applied = await exec(`apply ${patch.name}`, applyScript, timeouts.patchMs);
       if (applied.exitCode !== 0) {
         throw new PreflightPhaseFailure(
           "patch_apply_failed",

--- a/runtime/tests/eval/eval-executor-preflight.test.ts
+++ b/runtime/tests/eval/eval-executor-preflight.test.ts
@@ -236,6 +236,16 @@ describe("eval executor triple preflight", () => {
     // Non-parser steps keep the default (undefined) cap.
     const rebuildCaps = runner.execCaps.filter((c) => c.script === "make rebuild");
     expect(rebuildCaps.every((c) => c.maxOutputBytes === undefined)).toBe(true);
+    // The HIDDEN test patch resets its target files to base before applying,
+    // so a candidate that touched test-adjacent files cannot block it. Source
+    // patches (reference/setup) apply plainly, with no reset.
+    const testPatchApplies = runner.executedScripts.filter(
+      (s) => s.includes("/agenc-eval/test.patch") && s.includes("git -c core.fileMode=false apply --verbose"),
+    );
+    expect(testPatchApplies.length).toBeGreaterThan(0);
+    expect(testPatchApplies.every((s) => s.includes("--numstat") && s.includes("git checkout HEAD --"))).toBe(true);
+    const refPatchApplies = runner.executedScripts.filter((s) => s.includes("/agenc-eval/reference.patch"));
+    expect(refPatchApplies.every((s) => !s.includes("--numstat") && !s.includes("git checkout HEAD"))).toBe(true);
   });
 
   test("a target check passing on base disqualifies the candidate", async () => {


### PR DESCRIPTION
## Problem
The eval verifier applied the gold hidden `test.patch` with a plain `git apply` against the agent's working tree. When a candidate touched **test-adjacent files** (jest snapshots, test context) the gold patch's context search failed and the run was scored `infrastructure_error` — even though the agent ran fine and was fully contained (`oracle: contained`, `keyscan: clean`).

This silently **undercounts the scorecard**: real verified fixes are recorded as infrastructure failures.

## Fix
Reset the `test.patch`'s target files to base (`git checkout HEAD -- <f>`, or `rm` for agent-created files) before applying it — the canonical SWE-bench approach. Source/setup/reference patches still apply plainly; only the hidden test patch resets, and only its own target files.

## Evidence (real seed baseline, saved patches, zero new tokens)
| task | before | after |
|------|--------|-------|
| grommet__grommet-7718 | `infrastructure_error` (false) | **`verified_fix`** |
| withastro__starlight-3293 | `infrastructure_error` (false) | **`verified_fix`** |
| cthackers__adm-zip-559 | `verified_fix` | `verified_fix` (no regression) |
| gsd-build__get-shit-done-2186 | `verified_fix` | `verified_fix` (no regression) |

The fix is safe in both directions: it corrects the false failures and preserves true passes.

## Tests
New assertion in `eval-executor-preflight.test.ts` verifies the `test.patch` apply resets its targets while source patches do not; proven revert-sensitive (red without the source fix, green with it). Full eval suite 176/176; typecheck clean; build + TUI startup smoke green (pre-commit).

https://claude.ai/code/session_01RSXHHfZwBtv2Vh2VSsCZDn