### PR TITLE
fix(runtime): libatomic compat shim for eval overlay node on images that lack it

### DIFF
--- a/docs/design/eval-pilot-executor-phase2b-egress.md
+++ b/docs/design/eval-pilot-executor-phase2b-egress.md
@@ -124,8 +124,14 @@ docker create --name agenc-eval-proxy-<run> \
   --user 65534:65534 --pids-limit 128 --memory 128m \
   -e AGENC_PROXY_ALLOW_HOST -e AGENC_PROXY_ALLOW_PORT -e AGENC_PROXY_PIN_IPS \
   -v <overlay>:/agenc-overlay:ro \
+  -e LD_LIBRARY_PATH=/agenc-overlay/node/compat \
   --entrypoint /agenc-overlay/node/bin/node \
   <pinned-image@sha256> /agenc-overlay/proxy/allowlist-proxy.mjs
+# Overlay staging must include node/compat/libatomic.so.1 (copied from a
+# glibc host): the portable Node dist needs libatomic and some task images
+# (sonarqube's Ubuntu 24.04) do not ship it. Every overlay-node exec site
+# (sidecar, containment probe, both agent lanes) puts node/compat on
+# LD_LIBRARY_PATH; the loader falls back to image paths for everything else.
 docker network connect agenc-eval-upstream-<run> agenc-eval-proxy-<run>
 docker start agenc-eval-proxy-<run>          # + loopback CONNECT self-probe
 docker create --network agenc-eval-egress-<run> --dns 127.0.0.1 \

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -35,6 +35,7 @@ import {
   AGENT_RUNTIME_ENTRY,
   OVERLAY_AGENT_ENTRY_SUBPATH,
   OVERLAY_CONTAINER_PATH,
+  OVERLAY_NODE_COMPAT_LIB,
   OVERLAY_PROXY_PRELOAD,
 } from "./overlay-paths.js";
 
@@ -113,6 +114,10 @@ export async function assertOverlayLayout(
 ): Promise<void> {
   const required = [
     path.join(overlay.hostDir, "node", "bin", "node"),
+    // Shim for task images that lack libatomic.so.1 (portable Node needs
+    // it); missing staging fails fast here instead of as an opaque loader
+    // error inside the container.
+    path.join(overlay.hostDir, "node", "compat", "libatomic.so.1"),
     path.join(overlay.hostDir, OVERLAY_AGENT_ENTRY_SUBPATH),
     path.join(overlay.hostDir, "mock", "serve.mjs"),
     // The real-model lane also needs the proxy sidecar, the containment
@@ -167,6 +172,9 @@ function buildAgentScript(): string {
   return [
     `set -u`,
     `export PATH=${OVERLAY_CONTAINER_PATH}/node/bin:$PATH`,
+    // libatomic shim for images that lack it; the image's own paths still
+    // win for every other library via loader fallback.
+    `export LD_LIBRARY_PATH=${OVERLAY_NODE_COMPAT_LIB}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}`,
     `mkdir -p ${AGENT_HOME}`,
     // .git hygiene (drop remotes/unreachable objects) + post-setup baseline
     // commit + tag, so the candidate diff is exactly the agent's net change
@@ -526,6 +534,9 @@ export function buildRealProviderAgentScript(config: {
   return [
     `set -u`,
     `export PATH=${OVERLAY_CONTAINER_PATH}/node/bin:$PATH`,
+    // libatomic shim for images that lack it; the image's own paths still
+    // win for every other library via loader fallback.
+    `export LD_LIBRARY_PATH=${OVERLAY_NODE_COMPAT_LIB}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}`,
     `mkdir -p ${AGENT_HOME}`,
     buildBaselineGitScript(),
     `export HTTPS_PROXY=${proxyUrl} HTTP_PROXY=${proxyUrl} NO_PROXY=`,

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -8,7 +8,7 @@ import {
   type EgressLane,
   type EgressLaneRequest,
 } from "./egress.js";
-import { OVERLAY_NODE, OVERLAY_PROBE_ENTRY } from "./overlay-paths.js";
+import { OVERLAY_NODE, OVERLAY_NODE_COMPAT_LIB, OVERLAY_PROBE_ENTRY } from "./overlay-paths.js";
 import { EvalExecutorError } from "./source-lock.js";
 import {
   EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES,
@@ -376,6 +376,7 @@ export class DockerContainerRunner implements ContainerRunner {
             script:
               `AGENC_PROBE_PROXY=${proxyIp}:${proxyListenPort} AGENC_PROBE_GATEWAY=${gatewayIp} ` +
               `AGENC_PROBE_ALLOW_HOST=${allowHost} AGENC_PROBE_ALLOW_PORT=${allowPort} ` +
+              `LD_LIBRARY_PATH=${OVERLAY_NODE_COMPAT_LIB} ` +
               `${OVERLAY_NODE} ${OVERLAY_PROBE_ENTRY}`,
             timeoutMs: EGRESS_PROBE_EXEC_TIMEOUT_MS,
           });

--- a/runtime/src/eval-executor/egress.ts
+++ b/runtime/src/eval-executor/egress.ts
@@ -3,7 +3,12 @@
 // parser, the containment decision, and the patch key-scan. The docker
 // lifecycle that runs these lives in container-runner.ts; the lane wiring in
 // agent-run.ts. See docs/design/eval-pilot-executor-phase2b-egress.md.
-import { OVERLAY_CONTAINER_PATH, OVERLAY_NODE, OVERLAY_PROXY_ENTRY } from "./overlay-paths.js";
+import {
+  OVERLAY_CONTAINER_PATH,
+  OVERLAY_NODE,
+  OVERLAY_NODE_COMPAT_LIB,
+  OVERLAY_PROXY_ENTRY,
+} from "./overlay-paths.js";
 import type { ContainerHandle, EgressContainmentProbes } from "./types.js";
 
 export const DEFAULT_PROXY_LISTEN_PORT = 8080;
@@ -93,6 +98,9 @@ export function buildSidecarCreateArgs(plan: SidecarPlan): readonly string[] {
     "-e", `AGENC_PROXY_ALLOW_PORT=${plan.allowPort}`,
     "-e", `AGENC_PROXY_PIN_IPS=${plan.pinIps.join(",")}`,
     "-e", `AGENC_PROXY_LISTEN_PORT=${plan.listenPort}`,
+    // Some task images lack libatomic.so.1, which the portable Node dist
+    // needs; the overlay ships a shim dir the loader checks first.
+    "-e", `LD_LIBRARY_PATH=${OVERLAY_NODE_COMPAT_LIB}`,
     "-v", `${plan.overlayHostDir}:${OVERLAY_CONTAINER_PATH}:ro`,
     "--entrypoint", OVERLAY_NODE,
     plan.dockerImageRef,

--- a/runtime/src/eval-executor/overlay-paths.ts
+++ b/runtime/src/eval-executor/overlay-paths.ts
@@ -10,6 +10,14 @@ export const OVERLAY_AGENT_ENTRY_SUBPATH =
   "runtime/node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js";
 export const AGENT_RUNTIME_ENTRY = `${OVERLAY_CONTAINER_PATH}/${OVERLAY_AGENT_ENTRY_SUBPATH}`;
 export const OVERLAY_NODE = `${OVERLAY_CONTAINER_PATH}/node/bin/node`;
+/**
+ * Shim libraries the portable Node dist needs but some task images lack
+ * (observed: libatomic.so.1 absent from the sonarqube Ubuntu 24.04 image).
+ * Staged by the operator from a glibc host; every overlay-node exec site
+ * puts this dir on LD_LIBRARY_PATH so the loader finds the shim and falls
+ * back to the image's own libraries for everything else.
+ */
+export const OVERLAY_NODE_COMPAT_LIB = `${OVERLAY_CONTAINER_PATH}/node/compat`;
 export const OVERLAY_PROXY_ENTRY = `${OVERLAY_CONTAINER_PATH}/proxy/allowlist-proxy.mjs`;
 export const OVERLAY_PROBE_ENTRY = `${OVERLAY_CONTAINER_PATH}/proxy/eval-egress-probe.mjs`;
 export const OVERLAY_PROXY_PRELOAD = `${OVERLAY_CONTAINER_PATH}/proxy/eval-proxy-preload.cjs`;

--- a/runtime/tests/eval/eval-executor-agent-run.test.ts
+++ b/runtime/tests/eval/eval-executor-agent-run.test.ts
@@ -178,6 +178,8 @@ async function makeOverlay(): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), "agenc-agent-overlay-"));
   await mkdir(path.join(dir, "node", "bin"), { recursive: true });
   await writeFile(path.join(dir, "node", "bin", "node"), "");
+  await mkdir(path.join(dir, "node", "compat"), { recursive: true });
+  await writeFile(path.join(dir, "node", "compat", "libatomic.so.1"), "");
   const runtimeBin = path.join(
     dir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "bin",
   );

--- a/runtime/tests/eval/eval-executor-egress.test.ts
+++ b/runtime/tests/eval/eval-executor-egress.test.ts
@@ -69,6 +69,8 @@ describe("egress pure builders", () => {
     expect(args).toContain("AGENC_PROXY_ALLOW_HOST=api.x.ai");
     expect(args).toContain("AGENC_PROXY_PIN_IPS=1.2.3.4,5.6.7.8");
     expect(args).toContain("/ov:/agenc-overlay:ro");
+    // The sidecar's node needs the libatomic shim on images that lack it.
+    expect(args).toContain("LD_LIBRARY_PATH=/agenc-overlay/node/compat");
     // No provider key anywhere near the sidecar.
     expect(args.join(" ")).not.toContain("API_KEY");
   });
@@ -144,6 +146,11 @@ describe("real-provider agent script", () => {
     // The daemon proxy preload is installed so headless model calls route
     // through the egress proxy.
     expect(script).toContain('NODE_OPTIONS="--require /agenc-overlay/proxy/eval-proxy-preload.cjs"');
+    // libatomic shim for images that lack it (sonarqube), preserving any
+    // LD_LIBRARY_PATH the image itself sets.
+    expect(script).toContain(
+      "export LD_LIBRARY_PATH=/agenc-overlay/node/compat${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}",
+    );
   });
 });
 
@@ -221,6 +228,8 @@ describe("real-provider lane gating (fake lane, no docker)", () => {
     overlayDir = await mkdtemp(path.join(tmpdir(), "agenc-egress-overlay-"));
     await mkdir(path.join(overlayDir, "node", "bin"), { recursive: true });
     await writeFile(path.join(overlayDir, "node", "bin", "node"), "");
+    await mkdir(path.join(overlayDir, "node", "compat"), { recursive: true });
+    await writeFile(path.join(overlayDir, "node", "compat", "libatomic.so.1"), "");
     const bin = path.join(overlayDir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "bin");
     await mkdir(bin, { recursive: true });
     await writeFile(path.join(bin, "agenc.js"), "");


### PR DESCRIPTION
## Problem
The portable Node 25 dist in the eval agent overlay needs `libatomic.so.1`, and some task images don't ship it (sonarqube's Ubuntu 24.04). The egress sidecar died at startup with an opaque loader error (`libatomic.so.1: cannot open shared object file`) and the agent never started — the only real infrastructure failure in the 10-task seed baseline.

## Fix
- Overlay staging gains `node/compat/libatomic.so.1` (copied from a glibc host).
- Every overlay-node exec site puts that dir on `LD_LIBRARY_PATH`: proxy sidecar (`docker create -e`), containment probe (exec prefix), and both agent lanes (script `export`, prepend-preserving any `LD_LIBRARY_PATH` the image itself sets). The loader falls back to image paths for every other library.
- `assertOverlayLayout` now requires the shim, so missing staging fails fast with a clear message instead of an in-container loader error.

## Evidence
On the failing sonarqube image: without the shim, overlay node dies with the loader error; with `-e LD_LIBRARY_PATH=/agenc-overlay/node/compat`, `node --version` → `v25.9.0`. Shell semantics proven for both unset and image-set `LD_LIBRARY_PATH` cases.

## Tests
New sidecar-args and agent-script assertions, proven revert-sensitive (2 red without the source change). Eval suite 176/176, typecheck clean, build + TUI smoke green (pre-commit).

https://claude.ai/code/session_01RSXHHfZwBtv2Vh2VSsCZDn