### PR TITLE
fix(runtime): install the libatomic shim into the task container when env alone cannot carry it

### DIFF
--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -35,6 +35,7 @@ import {
   AGENT_RUNTIME_ENTRY,
   OVERLAY_AGENT_ENTRY_SUBPATH,
   OVERLAY_CONTAINER_PATH,
+  OVERLAY_NODE,
   OVERLAY_NODE_COMPAT_LIB,
   OVERLAY_PROXY_PRELOAD,
 } from "./overlay-paths.js";
@@ -175,6 +176,15 @@ function buildAgentScript(): string {
     // libatomic shim for images that lack it; the image's own paths still
     // win for every other library via loader fallback.
     `export LD_LIBRARY_PATH=${OVERLAY_NODE_COMPAT_LIB}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}`,
+    // The env var alone is not enough for the agent lane: the runtime scrubs
+    // LD_* from child env (managedEnv DANGEROUS_ENV_PREFIXES), so the daemon
+    // it spawns would die on the loader. When the overlay node cannot start
+    // without the shim, install it into the container's system lib dir,
+    // which no env scrubbing can undo.
+    `env -u LD_LIBRARY_PATH ${OVERLAY_NODE} --version >/dev/null 2>&1 || { ` +
+      `cp ${OVERLAY_NODE_COMPAT_LIB}/libatomic.so.1 /usr/lib/x86_64-linux-gnu/ 2>/dev/null || ` +
+      `cp ${OVERLAY_NODE_COMPAT_LIB}/libatomic.so.1 /usr/lib/ 2>/dev/null || true; ` +
+      `ldconfig 2>/dev/null || true; }`,
     `mkdir -p ${AGENT_HOME}`,
     // .git hygiene (drop remotes/unreachable objects) + post-setup baseline
     // commit + tag, so the candidate diff is exactly the agent's net change
@@ -537,6 +547,15 @@ export function buildRealProviderAgentScript(config: {
     // libatomic shim for images that lack it; the image's own paths still
     // win for every other library via loader fallback.
     `export LD_LIBRARY_PATH=${OVERLAY_NODE_COMPAT_LIB}\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}`,
+    // The env var alone is not enough for the agent lane: the runtime scrubs
+    // LD_* from child env (managedEnv DANGEROUS_ENV_PREFIXES), so the daemon
+    // it spawns would die on the loader. When the overlay node cannot start
+    // without the shim, install it into the container's system lib dir,
+    // which no env scrubbing can undo.
+    `env -u LD_LIBRARY_PATH ${OVERLAY_NODE} --version >/dev/null 2>&1 || { ` +
+      `cp ${OVERLAY_NODE_COMPAT_LIB}/libatomic.so.1 /usr/lib/x86_64-linux-gnu/ 2>/dev/null || ` +
+      `cp ${OVERLAY_NODE_COMPAT_LIB}/libatomic.so.1 /usr/lib/ 2>/dev/null || true; ` +
+      `ldconfig 2>/dev/null || true; }`,
     `mkdir -p ${AGENT_HOME}`,
     buildBaselineGitScript(),
     `export HTTPS_PROXY=${proxyUrl} HTTP_PROXY=${proxyUrl} NO_PROXY=`,

--- a/runtime/tests/eval/eval-executor-egress.test.ts
+++ b/runtime/tests/eval/eval-executor-egress.test.ts
@@ -151,6 +151,12 @@ describe("real-provider agent script", () => {
     expect(script).toContain(
       "export LD_LIBRARY_PATH=/agenc-overlay/node/compat${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}",
     );
+    // The runtime scrubs LD_* from child env, so when the overlay node cannot
+    // start bare, the shim must be installed into the system lib dir too.
+    expect(script).toContain(
+      "env -u LD_LIBRARY_PATH /agenc-overlay/node/bin/node --version >/dev/null 2>&1 || {",
+    );
+    expect(script).toContain("cp /agenc-overlay/node/compat/libatomic.so.1 /usr/lib/x86_64-linux-gnu/");
   });
 });
 


### PR DESCRIPTION
## Problem
#1531 fixed the sidecar and probes via `LD_LIBRARY_PATH`, but the agent lane still failed on the sonarqube image: the runtime intentionally scrubs `LD_*` from child env (`managedEnv` `DANGEROUS_ENV_PREFIXES` — loader-injection hardening), so the daemon spawned by the CLI lost the variable and died with the libatomic loader error. Surfaced as `daemon autostart failed: AgenC daemon did not become ready before timeout` with containment probes all green.

Diagnosis chain (all offline, zero tokens): daemon runs fine foreground → detached `daemon start` child dies instantly → patched debug overlay to `stdio:"inherit"` → child stderr shows `libatomic.so.1: cannot open shared object file` → found `DANGEROUS_ENV_PREFIXES = ["LD_", "DYLD_", ...]` in the bundled runtime.

## Fix
When `env -u LD_LIBRARY_PATH <overlay-node> --version` fails, the agent scripts copy the shim into the container's system lib dir (multiarch path, `/usr/lib` fallback, `ldconfig` when present) — env scrubbing cannot undo a system install, and it's a no-op on images that ship libatomic. The env-scrubbing hardening itself is untouched.

## Evidence
On the failing image: `daemon start` → rc=0, `daemon.sock` + `daemon.cookie` written.

## Tests
Egress script assertions extended; revert-sensitive (1 red without the source change). Eval suite 176/176, typecheck clean.

https://claude.ai/code/session_01RSXHHfZwBtv2Vh2VSsCZDn