### PR TITLE
fix(runtime): daemon early-exit diagnosability + one-shot token usage shape bridge

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -3927,16 +3927,34 @@ interface ManagedTokenUsageShape {
   readonly totalTokens: number;
 }
 
-function managedTokenUsage(thread: ManagedThread): ManagedTokenUsageShape {
+export function managedTokenUsage(
+  thread: Pick<ManagedThread, "totalTokenUsage">,
+): ManagedTokenUsageShape {
   const usage = thread.totalTokenUsage?.();
   if (typeof usage !== "object" || usage === null) {
     return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
   }
   const u = usage as Record<string, unknown>;
+  // Two shapes reach this seam: run-agent's live counter uses
+  // inputTokens/outputTokens, while a daemon session's cross-turn
+  // accumulator (stream-model.ts, the TokenUsageInfo port) uses
+  // promptTokens/completionTokens. Reading only the former zeroed
+  // input/output in every session.snapshot (totalTokens matched both
+  // shapes, which is why the bug shipped as {0, 0, N}).
+  const field = (...names: readonly string[]): number => {
+    for (const name of names) {
+      const value = u[name];
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+    }
+    return 0;
+  };
+  const inputTokens = field("inputTokens", "promptTokens");
+  const outputTokens = field("outputTokens", "completionTokens");
+  const totalTokens = field("totalTokens");
   return {
-    inputTokens: typeof u.inputTokens === "number" ? u.inputTokens : 0,
-    outputTokens: typeof u.outputTokens === "number" ? u.outputTokens : 0,
-    totalTokens: typeof u.totalTokens === "number" ? u.totalTokens : 0,
+    inputTokens,
+    outputTokens,
+    totalTokens: totalTokens > 0 ? totalTokens : inputTokens + outputTokens,
   };
 }
 

--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -10,6 +10,7 @@ import { dirname, join, resolve } from "node:path";
 import {
   createNodeDaemonCliHost,
   readAgenCDaemonPid,
+  readAgenCDaemonSpawnStderrTail,
   removeAgenCDaemonPid,
   resolveAgenCDaemonCookiePath,
   resolveAgenCDaemonPidPath,
@@ -228,7 +229,18 @@ export async function ensureAgenCDaemonAutostart(
 
   const target = { pid, pidPath };
   const ready = await waitForAgenCDaemonReady(target, host, options);
-  if (!ready) {
+  if (ready === "exited") {
+    // The daemon process died before becoming ready. Waiting longer cannot
+    // help, and calling this a timeout sends the operator debugging the
+    // wrong thing — surface the captured early-crash stderr instead.
+    await removeAgenCDaemonPid(pidPath, pid);
+    const stderrTail = readAgenCDaemonSpawnStderrTail(host.env, host.userHome);
+    throw new AgenCDaemonAutostartError(
+      `AgenC daemon exited before becoming ready (pid ${pid})` +
+        (stderrTail.length > 0 ? `: ${stderrTail}` : ""),
+    );
+  }
+  if (ready !== "ready") {
     throw new AgenCDaemonAutostartError(
       `AgenC daemon did not become ready before timeout (pid ${pid})`,
     );
@@ -399,11 +411,13 @@ async function readProcEnv(path: string): Promise<Record<string, string>> {
   return env;
 }
 
+type DaemonReadyWaitOutcome = "ready" | "exited" | "timeout";
+
 async function waitForAgenCDaemonReady(
   target: AgenCDaemonConnectionTarget,
   host: AgenCDaemonCliHost,
   options: AgenCDaemonAutostartOptions,
-): Promise<boolean> {
+): Promise<DaemonReadyWaitOutcome> {
   const timeoutMs =
     options.waitTimeoutMs ?? resolveAgenCDaemonReadyTimeoutMs(host.env);
   const pollMs = options.pollMs ?? 25;
@@ -414,10 +428,16 @@ async function waitForAgenCDaemonReady(
       isAgenCDaemonPidAndCookieReady(readyTarget, host));
 
   while (Date.now() - startedAt < timeoutMs) {
-    if (await Promise.resolve(isReady(target))) return true;
+    if (await Promise.resolve(isReady(target))) return "ready";
+    // A dead daemon can never become ready — bail out with the accurate
+    // diagnosis instead of burning the whole timeout on a foregone result.
+    // (Checked after isReady so a custom isReady that ignores the pid still
+    // gets one evaluation per poll.)
+    if (!host.isPidRunning(target.pid)) return "exited";
     await host.sleep(pollMs);
   }
-  return Promise.resolve(isReady(target));
+  if (await Promise.resolve(isReady(target))) return "ready";
+  return host.isPidRunning(target.pid) ? "timeout" : "exited";
 }
 
 async function isAgenCDaemonPidAndCookieReady(

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync } from "node:fs";
 import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection, isIP } from "node:net";
 import { homedir } from "node:os";
@@ -478,6 +478,49 @@ export function resolveAgenCDaemonCookiePath(
   );
 }
 
+/**
+ * Raw stderr of the most recent detached daemon spawn, captured until the
+ * foreground daemon installs its rotating log sink. This is the only place a
+ * pre-sink crash (loader failure, V8 fatal, top-level throw) leaves evidence:
+ * `stdio: "ignore"` used to drop it, which made "daemon exited before ready"
+ * undiagnosable without rebuilding the runtime.
+ */
+export const AGENC_DAEMON_SPAWN_STDERR_FILENAME = "daemon-spawn-stderr.log";
+
+export function resolveAgenCDaemonSpawnStderrPath(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome = homedir(),
+): string {
+  return join(
+    resolveAgenCDaemonHome(env, userHome),
+    AGENC_DAEMON_SPAWN_STDERR_FILENAME,
+  );
+}
+
+const DAEMON_SPAWN_STDERR_TAIL_BYTES = 2_048;
+
+/**
+ * Bounded, single-line tail of the spawn stderr capture for embedding in
+ * failure messages. Empty string when the file is missing or empty.
+ */
+export function readAgenCDaemonSpawnStderrTail(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome = homedir(),
+): string {
+  try {
+    const raw = readFileSync(resolveAgenCDaemonSpawnStderrPath(env, userHome));
+    const tail = raw
+      .subarray(Math.max(0, raw.byteLength - DAEMON_SPAWN_STDERR_TAIL_BYTES))
+      .toString("utf8")
+      .trim();
+    if (tail.length === 0) return "";
+    const lines = tail.split("\n").map((line) => line.trim()).filter(Boolean);
+    return lines.slice(-4).join(" | ");
+  } catch {
+    return "";
+  }
+}
+
 export function resolveAgenCDaemonSnapshotPath(
   env: NodeJS.ProcessEnv = process.env,
   userHome = homedir(),
@@ -806,9 +849,15 @@ async function startAgenCDaemon(
       );
     } else {
       await removeAgenCDaemonPid(pidPath, childPid);
+      const stderrTail = readAgenCDaemonSpawnStderrTail(
+        host.env,
+        host.userHome,
+      );
       io.stderr.write(
         `agenc: daemon process (pid ${childPid}) exited before its control ` +
-          `socket became ready\n`,
+          `socket became ready` +
+          (stderrTail.length > 0 ? `: ${stderrTail}` : "") +
+          `\n`,
       );
     }
     return 1;
@@ -3148,18 +3197,39 @@ export function createNodeDaemonCliHost(): AgenCDaemonCliHost {
           mode: 0o700,
         });
       }
-      const child = spawn(
-        process.execPath,
-        buildAgenCDaemonChildNodeArgs(entrypointPath, env, userHome),
-        {
-          detached: true,
-          env,
-          // stdout/stderr stay detached from this short-lived parent; the
-          // foreground daemon installs its own size-capped rotating log sink
-          // (see installAgenCDaemonLogSink) so daemon.log cannot grow unbounded.
-          stdio: "ignore",
-        },
-      );
+      // Capture the child's raw stderr until its log sink takes over: a
+      // crash before the sink installs (loader failure, fatal V8 error,
+      // top-level throw) is otherwise unobservable. A plain file fd keeps
+      // this short-lived parent decoupled (no pipe); truncated per spawn so
+      // it only ever holds the latest attempt's early stderr.
+      let stderrFd: number | "ignore" = "ignore";
+      try {
+        stderrFd = openSync(
+          resolveAgenCDaemonSpawnStderrPath(env, userHome),
+          "w",
+          0o600,
+        );
+      } catch {
+        /* capture is best-effort; spawn proceeds without it */
+      }
+      let child;
+      try {
+        child = spawn(
+          process.execPath,
+          buildAgenCDaemonChildNodeArgs(entrypointPath, env, userHome),
+          {
+            detached: true,
+            env,
+            // stdout stays detached from this short-lived parent; the
+            // foreground daemon installs its own size-capped rotating log sink
+            // (see installAgenCDaemonLogSink) so daemon.log cannot grow
+            // unbounded.
+            stdio: ["ignore", "ignore", stderrFd],
+          },
+        );
+      } finally {
+        if (stderrFd !== "ignore") closeSync(stderrFd);
+      }
       child.unref();
       if (child.pid === undefined) {
         throw new Error("AgenC daemon child process did not expose a pid");

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -6,6 +6,7 @@ import {
   notificationFromDaemonEvent,
   type AgenCBootstrapFunction,
   type AgenCEnsureAgentControlFunction,
+  managedTokenUsage,
 } from "./background-agent-runner.js";
 import type { AgentStatus } from "../agents/status.js";
 import type { AuthBackend } from "../auth/backend.js";
@@ -1335,5 +1336,43 @@ describe("AgenC delegate background-agent runner", () => {
 
     expect(stub.thread.shutdown).toHaveBeenCalledWith("user_stopped");
     expect(control.shutdown).not.toHaveBeenCalled();
+  });
+});
+
+describe("managedTokenUsage shape bridging", () => {
+  it("reads the daemon session accumulator's promptTokens/completionTokens shape", () => {
+    // The cross-turn accumulator (stream-model.ts TokenUsageInfo port) uses
+    // promptTokens/completionTokens. Reading only inputTokens/outputTokens
+    // shipped {0, 0, N} in every session.snapshot — input/output zeroed while
+    // totalTokens matched — so cost-per-fix was unreportable.
+    expect(
+      managedTokenUsage({
+        totalTokenUsage: () => ({
+          promptTokens: 64,
+          completionTokens: 1,
+          totalTokens: 65,
+        }),
+      }),
+    ).toEqual({ inputTokens: 64, outputTokens: 1, totalTokens: 65 });
+  });
+
+  it("still reads the live-agent inputTokens/outputTokens shape", () => {
+    expect(
+      managedTokenUsage({
+        totalTokenUsage: () => ({
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        }),
+      }),
+    ).toEqual({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+  });
+
+  it("derives totalTokens when the shape omits it", () => {
+    expect(
+      managedTokenUsage({
+        totalTokenUsage: () => ({ promptTokens: 7, completionTokens: 3 }),
+      }),
+    ).toEqual({ inputTokens: 7, outputTokens: 3, totalTokens: 10 });
   });
 });

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -245,6 +245,57 @@ port = 0
     await rm(agencHome, { recursive: true, force: true });
   });
 
+  it("fails fast with the exit diagnosis when the spawned daemon dies before ready", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    // The child dies immediately after spawn: the pid was handed out but is
+    // no longer running. Pre-fix the autostart burned the entire readiness
+    // timeout polling a corpse, then reported a misleading "did not become
+    // ready before timeout". With a generous timeout the fast-fail is only
+    // observable because "exited" short-circuits the wait.
+    host.spawnDetachedDaemon = () => {
+      host.spawnedPids.push(9301);
+      return 9301; // never added to runningPids
+    };
+    await writeFile(
+      join(agencHome, "daemon-spawn-stderr.log"),
+      "node: error while loading shared libraries: libatomic.so.1\n",
+    );
+    const startedAt = Date.now();
+    await expect(
+      ensureAgenCDaemonAutostart({
+        host,
+        waitTimeoutMs: 60_000,
+        isReady: () => false,
+      }),
+    ).rejects.toThrow(
+      /exited before becoming ready \(pid 9301\).*libatomic\.so\.1/,
+    );
+    // Far below the 60s readiness window: the dead pid short-circuits.
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    // The dead child's pid file must not poison the next autostart.
+    await expect(
+      readAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome)),
+    ).resolves.toBeNull();
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("still reports a timeout when the daemon is alive but slow", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    await expect(
+      ensureAgenCDaemonAutostart({
+        host,
+        waitTimeoutMs: 50,
+        pollMs: 5,
+        isReady: () => false, // alive (runningPids has it) but never ready
+      }),
+    ).rejects.toThrow(/did not become ready before timeout/);
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
   it("adopts a pidless daemon when its socket is present", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);


### PR DESCRIPTION
Three runtime defects surfaced while diagnosing the real-agent seed baseline (docs/eval/seed-baseline-2026-07-17.md):

## 1. Autostart burns the full timeout on a dead daemon
A daemon child that died at spawn made `agenc -p` poll a corpse for the whole 45s readiness window, then report a misleading `did not become ready before timeout`. The wait now short-circuits when the pid is gone and reports **`exited before becoming ready`**. Locally reproduced: 45s → 1s, with the true cause in the message.

## 2. Detached daemon crash stderr was unobservable
`stdio: "ignore"` dropped everything a child printed before its log sink installed — the eval-container libatomic loader error was only recoverable by hex-editing a bundled runtime. The spawn now captures child stderr to `daemon-spawn-stderr.log` (truncated per attempt) and both the autostart error and `daemon start`'s exited-before-ready message embed its bounded tail.

## 3. session.snapshot tokenUsage was {0, 0, N}
`managedTokenUsage` read `inputTokens`/`outputTokens`, but a daemon session's cross-turn accumulator (the TokenUsageInfo port in stream-model.ts) uses `promptTokens`/`completionTokens` — only `totalTokens` matched. Headless one-shot results showed zero input/output and $0 cost, which is why the seed baseline could not report cost-per-fix. The seam now bridges both shapes.

**End-to-end proof** (mock provider, one-shot json): before `{"inputTokens":0,"outputTokens":0,"totalTokens":65,"costUsd":0}` → after `{"inputTokens":64,"outputTokens":1,"totalTokens":65,"costUsd":0.000345}`.

## Tests
New tests for all three, proven revert-sensitive (4 red without the source changes). app-server+eval suites: 654 passed, 1 pre-existing failure ("restart recovery before advertising readiness") reproduced on the clean tree.

https://claude.ai/code/session_01RSXHHfZwBtv2Vh2VSsCZDn