### PR TITLE
feat(runtime): run-agent-real-batch — one-command reproducible real-agent baseline

### DIFF
--- a/docs/eval/real-agent-baseline-runbook.md
+++ b/docs/eval/real-agent-baseline-runbook.md
@@ -1,0 +1,59 @@
+# Real-agent baseline runbook
+
+How an authorized operator reproduces the full real-agent report from pinned
+inputs (M1). One command per batch; resumable; no secrets on any argv.
+
+## Prerequisites
+
+- docker, Node from `devEngines` (`.nvmrc`-compatible ≥ 25.9.0).
+- A staged agent overlay directory (see
+  `docs/design/eval-pilot-executor-phase2b-egress.md`): `node/` (portable Node
+  dist + `node/compat/libatomic.so.1`), `runtime/` (extracted runtime tarball
+  — pin the CURRENT release, the overlay attests the build under test),
+  `mock/`, `proxy/`.
+- A provider key source: either a static key exported in the executor's env,
+  or an executable that prints a fresh key (for OAuth-token providers).
+
+## The command
+
+```bash
+node --experimental-strip-types runtime/src/eval-executor/cli.ts \
+  run-agent-real-batch \
+  --overlay /path/to/agent-overlay \
+  --provider-host api.x.ai \
+  --provider-base-url https://api.x.ai/v1 \
+  --provider-model grok-4.5 \
+  --key-command /path/to/print-fresh-key \
+  --output /path/to/baseline-output \
+  --agent-timeout-ms 1800000
+```
+
+(`npx tsx` works equally; run from `runtime/`.)
+
+- Tasks default to every task in the frozen pilot source lock, in lock order;
+  `--tasks id1,id2,...` selects and orders an explicit subset.
+- `--key-command` runs before each task (execFile, no shell); its stdout
+  becomes the key via the `--key-env-var` name (default
+  `OPENAI_COMPATIBLE_API_KEY`). For a static key, omit `--key-command` and
+  export the env var instead. The key travels executor env → `docker exec -e`
+  → agent process; it is never on an argv and patches are scanned for it.
+- Resume after an interruption by re-running the same command: tasks with an
+  existing `agent-run-report.json` are skipped.
+- Exit code 0 means every task ended with a report (the scorecard is
+  complete); any driver-level loss exits 1 and is listed in
+  `batch-summary.json`.
+
+## Outputs
+
+Under `--output`:
+
+- `<taskId>/agent-run-report.json` — outcome, containment probes, key scan,
+  token usage, report digest (the append-only raw evidence).
+- `<taskId>/agent-patch.diff`, `<taskId>/agent-result.json`.
+- `batch-progress.log` — timestamped per-task progress.
+- `batch-summary.json` — per-task status + aggregate counts (VFR numerator is
+  `verifiedFixes`).
+
+Archive the whole output directory as the raw evidence bundle; the
+human-readable summary (like `docs/eval/seed-baseline-2026-07-17.md`) is
+written separately and references it.

--- a/runtime/src/eval-executor/batch.ts
+++ b/runtime/src/eval-executor/batch.ts
@@ -1,0 +1,168 @@
+import { execFile } from "node:child_process";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { EvalExecutorError, findPilotTask } from "./source-lock.js";
+import type { LoadedPilotSourceLock } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const IMAGE_PULL_TIMEOUT_MS = 1_800_000;
+const KEY_COMMAND_TIMEOUT_MS = 120_000;
+
+export interface RealAgentBatchOptions {
+  readonly loaded: LoadedPilotSourceLock;
+  /** Explicit task order; defaults to lock order when omitted. */
+  readonly taskIds?: readonly string[];
+  readonly outputDir: string;
+  /**
+   * Executable run before each task (execFile, no shell); its stdout becomes
+   * the provider key for that task via `keyEnvVar`. Lets short-lived OAuth
+   * tokens survive a multi-hour batch without baking any provider's refresh
+   * flow into the executor.
+   */
+  readonly keyCommand?: string;
+  readonly keyEnvVar: string;
+}
+
+export interface RealAgentBatchDeps {
+  /** Run one task end to end and return its outcome string. */
+  readonly runTask: (taskId: string) => Promise<{ readonly outcome: string }>;
+  /** Pre-pull the task's pinned image; failures abort only that task. */
+  readonly pullImage: (imageReference: string) => Promise<void>;
+  /** True when this task already has a completed report (resume support). */
+  readonly hasReport: (taskId: string) => Promise<boolean>;
+  readonly refreshKey?: () => Promise<string>;
+  readonly log: (line: string) => Promise<void>;
+  readonly setKeyEnv: (name: string, value: string) => void;
+}
+
+export interface RealAgentBatchTaskResult {
+  readonly taskId: string;
+  readonly status: "completed" | "skipped" | "driver_error";
+  readonly outcome: string | null;
+  readonly detail: string | null;
+}
+
+export interface RealAgentBatchSummary {
+  readonly total: number;
+  readonly completed: number;
+  readonly skipped: number;
+  readonly driverErrors: number;
+  readonly verifiedFixes: number;
+  readonly results: readonly RealAgentBatchTaskResult[];
+}
+
+/**
+ * Sequential batch driver over pinned pilot tasks: resumable (tasks with an
+ * existing report are skipped), key-refreshing (per task, so OAuth tokens
+ * stay fresh), and continue-on-error (one task's driver failure never takes
+ * down the batch — the scorecard needs every task attempted).
+ */
+export async function runRealAgentBatch(
+  options: RealAgentBatchOptions,
+  deps: RealAgentBatchDeps,
+): Promise<RealAgentBatchSummary> {
+  const order = options.taskIds !== undefined && options.taskIds.length > 0
+    ? options.taskIds
+    : options.loaded.lock.tasks.map((task) => task.instanceId);
+  // Validate the whole order against the lock BEFORE any pull/refresh/run:
+  // a typo'd task id must fail the batch while it is still free.
+  const tasksById = new Map(
+    order.map((taskId) => [taskId, findPilotTask(options.loaded.lock, taskId)]),
+  );
+  const results: RealAgentBatchTaskResult[] = [];
+  for (const taskId of order) {
+    const task = tasksById.get(taskId)!;
+    if (await deps.hasReport(taskId)) {
+      await deps.log(`${taskId} SKIP (report exists)`);
+      results.push({ taskId, status: "skipped", outcome: null, detail: null });
+      continue;
+    }
+    try {
+      await deps.log(`${taskId} pull`);
+      await deps.pullImage(task.image);
+      if (deps.refreshKey !== undefined) {
+        const key = (await deps.refreshKey()).trim();
+        if (key.length === 0) {
+          throw new EvalExecutorError([
+            `key command produced an empty key for ${taskId}`,
+          ]);
+        }
+        deps.setKeyEnv(options.keyEnvVar, key);
+      }
+      await deps.log(`${taskId} run`);
+      const { outcome } = await deps.runTask(taskId);
+      await deps.log(`${taskId} DONE outcome=${outcome}`);
+      results.push({ taskId, status: "completed", outcome, detail: null });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await deps.log(`${taskId} DRIVER_ERROR ${detail.slice(0, 300)}`);
+      results.push({ taskId, status: "driver_error", outcome: null, detail });
+    }
+  }
+  return {
+    total: order.length,
+    completed: results.filter((r) => r.status === "completed").length,
+    skipped: results.filter((r) => r.status === "skipped").length,
+    driverErrors: results.filter((r) => r.status === "driver_error").length,
+    verifiedFixes: results.filter((r) => r.outcome === "verified_fix").length,
+    results,
+  };
+}
+
+/** Production deps shared by the CLI; separated so tests can inject fakes. */
+export function createRealAgentBatchDeps(options: {
+  readonly outputDir: string;
+  readonly keyCommand?: string;
+  readonly runTask: (taskId: string) => Promise<{ readonly outcome: string }>;
+}): RealAgentBatchDeps {
+  const progressLog = path.join(options.outputDir, "batch-progress.log");
+  return {
+    runTask: options.runTask,
+    pullImage: async (imageReference) => {
+      await execFileAsync("docker", ["pull", "-q", imageReference], {
+        timeout: IMAGE_PULL_TIMEOUT_MS,
+      });
+    },
+    hasReport: async (taskId) => {
+      try {
+        await readFile(
+          path.join(options.outputDir, taskId, "agent-run-report.json"),
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    ...(options.keyCommand !== undefined
+      ? {
+        refreshKey: async () => {
+          const { stdout } = await execFileAsync(options.keyCommand!, [], {
+            timeout: KEY_COMMAND_TIMEOUT_MS,
+          });
+          return stdout;
+        },
+      }
+      : {}),
+    log: async (line) => {
+      const stamped = `[${new Date().toISOString()}] ${line}\n`;
+      process.stdout.write(stamped);
+      await mkdir(options.outputDir, { recursive: true });
+      await appendFile(progressLog, stamped);
+    },
+    setKeyEnv: (name, value) => {
+      process.env[name] = value;
+    },
+  };
+}
+
+export async function writeRealAgentBatchSummary(
+  outputDir: string,
+  summary: RealAgentBatchSummary,
+): Promise<string> {
+  await mkdir(outputDir, { recursive: true });
+  const summaryPath = path.join(outputDir, "batch-summary.json");
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  return summaryPath;
+}

--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import process from "node:process";
 import { parseArgs } from "node:util";
 import { runAgentOnTask, runRealProviderAgentOnTask } from "./agent-run.js";
+import {
+  createRealAgentBatchDeps,
+  runRealAgentBatch,
+  writeRealAgentBatchSummary,
+} from "./batch.js";
 import { DockerContainerRunner } from "./container-runner.js";
 import {
   DEFAULT_PREFLIGHT_TIMEOUTS,
@@ -18,6 +23,7 @@ import {
   loadPilotSourceLock,
   readPilotArtifact,
 } from "./source-lock.js";
+import type { LoadedPilotSourceLock } from "./types.js";
 import { decodeVerifierBundle } from "./verifier-bundle.js";
 
 const DEFAULT_LOCK_PATH =
@@ -33,6 +39,11 @@ const USAGE = `Usage:
                           --provider-host <host> --provider-base-url <url>
                           --provider-model <model> [--key-env-var <NAME>]
                           [--lock <path>] [--output <dir>] [--agent-timeout-ms <n>]
+  eval:executor run-agent-real-batch --overlay <dir>
+                          --provider-host <host> --provider-base-url <url>
+                          --provider-model <model> [--tasks <id,id,...>]
+                          [--key-env-var <NAME>] [--key-command <exe>]
+                          [--lock <path>] [--output <dir>] [--agent-timeout-ms <n>]
 
 verify-lock  Load the frozen pilot source lock, re-hash every CAS artifact,
              and decode every verifier bundle. Hermetic and offline.
@@ -47,7 +58,15 @@ run-agent-real  Run the real AgenC agent against a REAL model provider inside a
              allowlist proxy sidecar). The agent runs only after every
              containment probe passes; the provider key is read from
              --key-env-var in the executor env and injected via docker exec
-             (never on any argv). Requires docker.`;
+             (never on any argv). Requires docker.
+run-agent-real-batch  Run run-agent-real across every lock task (or --tasks, in
+             the given order): resumable (tasks with an existing report are
+             skipped), continue-on-error, per-task image pull, and optional
+             per-task key refresh via --key-command (an executable whose
+             stdout becomes the key — no shell). Writes batch-progress.log
+             and batch-summary.json under --output. Exit 0 only when every
+             task ends with a report. This is the documented reproduction
+             path for the real-agent baseline report.`;
 
 async function verifyLock(lockPath: string): Promise<number> {
   const loaded = await loadPilotSourceLock(lockPath);
@@ -186,9 +205,7 @@ async function runAgent(options: {
   return report.outcome === "verified_fix" ? 0 : 1;
 }
 
-async function runRealProviderAgent(options: {
-  readonly lockPath: string;
-  readonly taskId: string;
+interface RealProviderRunConfig {
   readonly overlayDir: string;
   readonly outputDir: string;
   readonly allowHost: string;
@@ -197,9 +214,19 @@ async function runRealProviderAgent(options: {
   readonly keyEnvVar: string;
   readonly agentTimeoutMs?: number;
   readonly parserFallbackImage?: string;
-}): Promise<number> {
-  const loaded = await loadPilotSourceLock(options.lockPath);
-  const task = findPilotTask(loaded.lock, options.taskId);
+}
+
+/**
+ * One real-provider task run against an already-loaded lock: egress lane,
+ * report + patch + raw-result files under `<outputDir>/<taskId>/`. Shared by
+ * the single-task and batch subcommands so their behavior cannot drift.
+ */
+async function runRealProviderAgentTask(
+  loaded: LoadedPilotSourceLock,
+  taskId: string,
+  options: RealProviderRunConfig,
+): Promise<{ readonly outcome: string; readonly summary: Record<string, unknown> }> {
+  const task = findPilotTask(loaded.lock, taskId);
   const runner = new DockerContainerRunner();
   await runner.environment();
   // Resolve the provider host once, on the host, to a set of pinned IPs the
@@ -247,17 +274,66 @@ async function runRealProviderAgent(options: {
   if (rawAgentResult !== null && rawAgentResult.length > 0) {
     await writeFile(path.join(taskDir, "agent-result.json"), rawAgentResult, { flag: "wx" });
   }
-  process.stdout.write(`${JSON.stringify({
-    taskId: report.taskId,
+  return {
     outcome: report.outcome,
-    oracleContainment: report.egress?.oracleContainment,
-    denyProbes: report.egress?.denyProbes,
-    patchKeyScan: report.egress?.patchKeyScan,
-    failureDetail: report.failureDetail,
-    tokenUsage: report.agent.tokenUsage,
-    outputDir: taskDir,
-  }, null, 2)}\n`);
-  return report.outcome === "verified_fix" ? 0 : 1;
+    summary: {
+      taskId: report.taskId,
+      outcome: report.outcome,
+      oracleContainment: report.egress?.oracleContainment,
+      denyProbes: report.egress?.denyProbes,
+      patchKeyScan: report.egress?.patchKeyScan,
+      failureDetail: report.failureDetail,
+      tokenUsage: report.agent.tokenUsage,
+      outputDir: taskDir,
+    },
+  };
+}
+
+async function runRealProviderAgent(
+  options: RealProviderRunConfig & {
+    readonly lockPath: string;
+    readonly taskId: string;
+  },
+): Promise<number> {
+  const loaded = await loadPilotSourceLock(options.lockPath);
+  const { outcome, summary } = await runRealProviderAgentTask(
+    loaded,
+    options.taskId,
+    options,
+  );
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  return outcome === "verified_fix" ? 0 : 1;
+}
+
+async function runRealProviderAgentBatch(
+  options: RealProviderRunConfig & {
+    readonly lockPath: string;
+    readonly taskIds?: readonly string[];
+    readonly keyCommand?: string;
+  },
+): Promise<number> {
+  const loaded = await loadPilotSourceLock(options.lockPath);
+  const deps = createRealAgentBatchDeps({
+    outputDir: options.outputDir,
+    keyCommand: options.keyCommand,
+    runTask: (taskId) => runRealProviderAgentTask(loaded, taskId, options),
+  });
+  const summary = await runRealAgentBatch(
+    {
+      loaded,
+      taskIds: options.taskIds,
+      outputDir: options.outputDir,
+      keyCommand: options.keyCommand,
+      keyEnvVar: options.keyEnvVar,
+    },
+    deps,
+  );
+  const summaryPath = await writeRealAgentBatchSummary(options.outputDir, summary);
+  process.stdout.write(`${JSON.stringify({ ...summary, summaryPath }, null, 2)}\n`);
+  // The batch's job is a complete scorecard: every task must end with a
+  // report (verified or not). Driver-level failures are the only batch
+  // failure — a lost task means the scorecard is not the one asked for.
+  return summary.driverErrors === 0 ? 0 : 1;
 }
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -280,6 +356,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       "provider-base-url": { type: "string" },
       "provider-model": { type: "string" },
       "key-env-var": { type: "string" },
+      "key-command": { type: "string" },
+      tasks: { type: "string" },
     },
     strict: true,
   });
@@ -347,6 +425,43 @@ export async function main(argv: readonly string[]): Promise<number> {
       baseUrl,
       model,
       keyEnvVar: values["key-env-var"] ?? "OPENAI_COMPATIBLE_API_KEY",
+      agentTimeoutMs,
+      parserFallbackImage: values["parser-fallback-image"],
+    });
+  }
+  if (command === "run-agent-real-batch") {
+    if (!values.overlay) {
+      throw new EvalExecutorError(["run-agent-real-batch requires --overlay <dir>"]);
+    }
+    const host = values["provider-host"];
+    const baseUrl = values["provider-base-url"];
+    const model = values["provider-model"];
+    if (!host || !baseUrl || !model) {
+      throw new EvalExecutorError([
+        "run-agent-real-batch requires --provider-host, --provider-base-url, and --provider-model",
+      ]);
+    }
+    const timeoutRaw = values["agent-timeout-ms"];
+    const agentTimeoutMs = timeoutRaw === undefined ? undefined : Number(timeoutRaw);
+    if (agentTimeoutMs !== undefined && (!Number.isSafeInteger(agentTimeoutMs) || agentTimeoutMs <= 0)) {
+      throw new EvalExecutorError(["--agent-timeout-ms must be a positive integer"]);
+    }
+    const taskIds = values.tasks === undefined
+      ? undefined
+      : values.tasks.split(",").map((id) => id.trim()).filter((id) => id.length > 0);
+    if (taskIds !== undefined && taskIds.length === 0) {
+      throw new EvalExecutorError(["--tasks must name at least one task id"]);
+    }
+    return runRealProviderAgentBatch({
+      lockPath,
+      taskIds,
+      overlayDir: values.overlay,
+      outputDir: values.output ?? "eval-executor-output",
+      allowHost: host,
+      baseUrl,
+      model,
+      keyEnvVar: values["key-env-var"] ?? "OPENAI_COMPATIBLE_API_KEY",
+      keyCommand: values["key-command"],
       agentTimeoutMs,
       parserFallbackImage: values["parser-fallback-image"],
     });

--- a/runtime/src/eval-executor/index.ts
+++ b/runtime/src/eval-executor/index.ts
@@ -14,6 +14,15 @@ export {
   type AgentRunInputs,
   type RealProviderAgentConfig,
 } from "./agent-run.js";
+export {
+  createRealAgentBatchDeps,
+  runRealAgentBatch,
+  writeRealAgentBatchSummary,
+  type RealAgentBatchDeps,
+  type RealAgentBatchOptions,
+  type RealAgentBatchSummary,
+  type RealAgentBatchTaskResult,
+} from "./batch.js";
 export { DockerContainerRunner } from "./container-runner.js";
 export {
   allContainmentProbesPass,

--- a/runtime/tests/eval/eval-executor-batch.test.ts
+++ b/runtime/tests/eval/eval-executor-batch.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "vitest";
+import { runRealAgentBatch, type RealAgentBatchDeps } from "../../src/eval-executor/batch.js";
+import type { LoadedPilotSourceLock } from "../../src/eval-executor/types.js";
+
+const digestOf = (c: string): `sha256:${string}` => `sha256:${c.repeat(64)}`;
+
+function makeLoaded(taskIds: readonly string[]): LoadedPilotSourceLock {
+  return {
+    casShaRoot: "/lock/cas/sha256",
+    lock: {
+      kind: "agenc.eval.pilot-source-lock",
+      version: "1.0.0",
+      documentDigest: digestOf("a"),
+      createdAt: "2026-07-01T00:00:00Z",
+      source: {
+        datasetId: "d",
+        datasetRevision: "r",
+        repositoryUri: "u",
+        repositoryCommit: "c",
+        license: "l",
+        selectionAlgorithm: "s",
+        selectionBeforeAgentOutcomes: true,
+      },
+      tasks: taskIds.map((instanceId, ordinal) => ({
+        ordinal,
+        language: "js",
+        instanceId,
+        categories: [],
+        stressors: [],
+        sourceRowDigest: digestOf("b"),
+        repository: "o/r",
+        pullNumber: "1",
+        issueNumbers: ["2"],
+        baseCommit: "c".repeat(40),
+        createdAt: "2026-07-01T00:00:00Z",
+        commitUrl: "https://x.invalid",
+        issueText: "fix it",
+        image: `reg/${instanceId}@sha256:${"e".repeat(64)}`,
+        artifacts: {
+          setupPatch: { digest: digestOf("1"), sizeBytes: 1, mediaType: "t", uri: "cas://x" },
+          referencePatch: { digest: digestOf("2"), sizeBytes: 1, mediaType: "t", uri: "cas://x" },
+          verifierBundle: { digest: digestOf("3"), sizeBytes: 1, mediaType: "t", uri: "cas://x" },
+          sourceEvidence: { digest: digestOf("4"), sizeBytes: 1, mediaType: "t", uri: "cas://x" },
+        },
+      })),
+    },
+  };
+}
+
+interface Recorder {
+  readonly deps: RealAgentBatchDeps;
+  readonly calls: string[];
+  readonly keyEnv: Record<string, string>;
+}
+
+function makeDeps(overrides: {
+  readonly outcomes?: Readonly<Record<string, string>>;
+  readonly failing?: readonly string[];
+  readonly existingReports?: readonly string[];
+  readonly keys?: readonly string[];
+} = {}): Recorder {
+  const calls: string[] = [];
+  const keyEnv: Record<string, string> = {};
+  let keyIndex = 0;
+  const keys = overrides.keys;
+  return {
+    calls,
+    keyEnv,
+    deps: {
+      runTask: async (taskId) => {
+        calls.push(`run:${taskId}`);
+        if (overrides.failing?.includes(taskId)) {
+          throw new Error(`egress lane failed for ${taskId}`);
+        }
+        return { outcome: overrides.outcomes?.[taskId] ?? "verified_fix" };
+      },
+      pullImage: async (image) => {
+        calls.push(`pull:${image.split("/")[1]?.split("@")[0]}`);
+      },
+      hasReport: async (taskId) =>
+        overrides.existingReports?.includes(taskId) ?? false,
+      ...(keys !== undefined
+        ? {
+          refreshKey: async () => {
+            calls.push("refresh");
+            return keys[Math.min(keyIndex++, keys.length - 1)] ?? "";
+          },
+        }
+        : {}),
+      log: async () => {},
+      setKeyEnv: (name, value) => {
+        keyEnv[name] = value;
+      },
+    },
+  };
+}
+
+describe("eval executor real-agent batch", () => {
+  test("runs every lock task in order, pulling each image first", async () => {
+    const loaded = makeLoaded(["t-a", "t-b", "t-c"]);
+    const { deps, calls } = makeDeps({ outcomes: { "t-b": "verification_failure" } });
+    const summary = await runRealAgentBatch(
+      { loaded, outputDir: "/out", keyEnvVar: "K" },
+      deps,
+    );
+    expect(calls).toEqual([
+      "pull:t-a", "run:t-a", "pull:t-b", "run:t-b", "pull:t-c", "run:t-c",
+    ]);
+    expect(summary).toMatchObject({
+      total: 3,
+      completed: 3,
+      skipped: 0,
+      driverErrors: 0,
+      verifiedFixes: 2,
+    });
+  });
+
+  test("resumes by skipping tasks that already have a report", async () => {
+    const loaded = makeLoaded(["t-a", "t-b"]);
+    const { deps, calls } = makeDeps({ existingReports: ["t-a"] });
+    const summary = await runRealAgentBatch(
+      { loaded, outputDir: "/out", keyEnvVar: "K" },
+      deps,
+    );
+    expect(calls).toEqual(["pull:t-b", "run:t-b"]);
+    expect(summary.skipped).toBe(1);
+    expect(summary.results[0]).toMatchObject({ taskId: "t-a", status: "skipped" });
+  });
+
+  test("a driver failure on one task never stops the rest of the batch", async () => {
+    const loaded = makeLoaded(["t-a", "t-b", "t-c"]);
+    const { deps, calls } = makeDeps({ failing: ["t-b"] });
+    const summary = await runRealAgentBatch(
+      { loaded, outputDir: "/out", keyEnvVar: "K" },
+      deps,
+    );
+    expect(calls).toContain("run:t-c");
+    expect(summary.driverErrors).toBe(1);
+    expect(summary.results[1]).toMatchObject({
+      taskId: "t-b",
+      status: "driver_error",
+    });
+    expect(summary.results[1].detail).toContain("egress lane failed");
+  });
+
+  test("refreshes the provider key before every task and exports it", async () => {
+    const loaded = makeLoaded(["t-a", "t-b"]);
+    const { deps, calls, keyEnv } = makeDeps({ keys: ["key-one\n", "key-two\n"] });
+    await runRealAgentBatch(
+      { loaded, outputDir: "/out", keyEnvVar: "PROVIDER_KEY" },
+      deps,
+    );
+    expect(calls.filter((c) => c === "refresh")).toHaveLength(2);
+    // Trimmed, and the latest refresh wins.
+    expect(keyEnv.PROVIDER_KEY).toBe("key-two");
+  });
+
+  test("an empty refreshed key fails that task, not the batch", async () => {
+    const loaded = makeLoaded(["t-a", "t-b"]);
+    const { deps } = makeDeps({ keys: [""] });
+    const summary = await runRealAgentBatch(
+      { loaded, outputDir: "/out", keyEnvVar: "K" },
+      deps,
+    );
+    expect(summary.results[0]).toMatchObject({ taskId: "t-a", status: "driver_error" });
+    expect(summary.results[0].detail).toContain("empty key");
+  });
+
+  test("--tasks selects and orders an explicit subset", async () => {
+    const loaded = makeLoaded(["t-a", "t-b", "t-c"]);
+    const { deps, calls } = makeDeps();
+    const summary = await runRealAgentBatch(
+      { loaded, taskIds: ["t-c", "t-a"], outputDir: "/out", keyEnvVar: "K" },
+      deps,
+    );
+    expect(calls).toEqual(["pull:t-c", "run:t-c", "pull:t-a", "run:t-a"]);
+    expect(summary.total).toBe(2);
+  });
+
+  test("an unknown task id fails fast before any spend", async () => {
+    const loaded = makeLoaded(["t-a"]);
+    const { deps, calls } = makeDeps();
+    await expect(
+      runRealAgentBatch(
+        { loaded, taskIds: ["t-a", "t-missing"], outputDir: "/out", keyEnvVar: "K" },
+        deps,
+      ),
+    ).rejects.toThrow(/t-missing/);
+    // Validation happens before any pull/refresh/run: nothing was spent.
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Productizes the seed-baseline driver as an eval-executor subcommand (M1 done-when: operator-reproducible real-agent report). Resumable, continue-on-error, per-task key refresh via --key-command (no shell, nothing on argv), batch-summary.json + progress log, fail-fast task-id validation before any spend. Shared single-task core so run-agent-real and the batch cannot drift. Runbook: docs/eval/real-agent-baseline-runbook.md. 7 hermetic tests; eval suite 183/183; typecheck clean; build+TUI smoke green (pre-commit).

https://claude.ai/code/session_01RSXHHfZwBtv2Vh2VSsCZDn