### PR TITLE
feat(budget): M3 reservation kernel — durable holdId, exactly-once reconcile (TRR 3/7 → 4/7)

### DIFF
--- a/docs/design/budget-enforcement.md
+++ b/docs/design/budget-enforcement.md
@@ -89,17 +89,30 @@ A self-contained subsystem, `runtime/src/budget/`, exposing a
   spend, persisted to `<agencHome>/budget/ledger.json` (0600), atomic writes.
   Windows roll by date key so "daily/monthly budget" means what a user expects.
 - **Admission gate** — `admit({ agentId, model, estInputTokens, maxOutputTokens })`
-  computes the worst-case debit at the model's price and checks it against
-  BOTH remaining daily and monthly budget (both must pass — fail closed).
-  Returns a hold on success, or a typed `BUDGET_EXCEEDED` refusal.
-- **Reconcile** — `reconcile(hold, actualUsage)` replaces the held estimate with
-  the real spend and refunds the delta. The real `usage` from the provider
-  response is authoritative (pre-flight estimates drift; §4). After a successful
-  admit, call sites **always** reconcile exactly once via exclusive
-  `try`/`finally` on **hooks, cron, and heartbeat**:
-  success uses returned usage (or zeros if missing); throw uses zeros → full
-  hold refund. Unknown usage may under-book real spend; it must not leave a
-  sticky worst-case hold. `reconcile` is **not** idempotent — call once only.
+  transactionally reserves the worst-case debit at the model's price under the
+  ledger's cross-process disk lock: the cap check (BOTH remaining daily and
+  monthly budget — fail closed) runs against the locked, freshly-loaded state,
+  and the debit plus a durable, uniquely-identified open hold land in ONE
+  atomic save. Two concurrent reservers serialize on the lock; the second sees
+  the first's debit. Returns a hold on success, or a typed `BUDGET_EXCEEDED`
+  refusal.
+- **Reservations** — every non-zero hold carries a `holdId` (the frozen
+  `BudgetReservation.reservationId` from `contracts/run-contracts.ts`) and is
+  persisted in the ledger file while open (`listOpenHolds()`). A crash between
+  admit and reconcile leaves a visible open hold whose FULL reservation stays
+  consumed (`held_unknown` semantics) — unknown usage is never refunded as if
+  the call were free. A hold whose day window rolls before reconciliation is
+  discarded without refund. Operator `reset` clears the agent's open holds.
+- **Reconcile** — `reconcile(hold, actualUsage)` consumes the persisted hold
+  **exactly once**: it replaces the held estimate with the real spend and
+  refunds the delta in one locked transaction. The real `usage` from the
+  provider response is authoritative (pre-flight estimates drift; §4).
+  Duplicate calls find no open hold and are mechanical no-ops
+  (`{ applied: false, reason: "duplicate" }`) — `holdId` is the idempotency
+  key, so retry/recovery paths can safely call it again. Call sites reconcile
+  via exclusive `try`/`finally` on **hooks, cron, and heartbeat**: success
+  uses returned usage (or zeros if missing); throw uses zeros → full hold
+  refund (the contract's `voided` resolution).
 - **Enforcement policy** — on refusal: pause the agent's autonomy
   (`paused` state), emit a notification once, and surface the typed error; the
   operator raises the cap or resets to resume. Crossing the soft threshold

--- a/docs/evaluation-suites-v1.md
+++ b/docs/evaluation-suites-v1.md
@@ -174,10 +174,10 @@ content-addressed summary under `--output` (default
 `eval-executor-output/trust`), refusing to clobber existing evidence. Honest
 invariant failures exit 0 — they are the suite's product; only
 infrastructure-invalid attempts exit 1. The current honest baseline on
-`main` is 3/7 families passing (restart, reconnect, permission) with
-budget reconciliation idempotency, cancellation cascade/admission, event-gap
-markers, and the unknown-outcome dependent-mutation gate failing until M3/M4
-land. `runtime/tests/eval/trust-conformance-executor.test.ts` pins those
+`main` is 4/7 families passing (restart, reconnect, permission, and budget —
+the M3 budget reservation kernel made reconciliation exactly-once) with
+cancellation cascade/admission, event-gap markers, and the unknown-outcome
+dependent-mutation gate failing until the rest of M3/M4 lands. `runtime/tests/eval/trust-conformance-executor.test.ts` pins those
 outcomes in both directions: a runtime regression flips a passing family, a
 harness bug faking a pass flips a failing one, and either turns CI red.
 
@@ -308,7 +308,7 @@ qualified until its cold preflights, independent solve, negative-patch review,
 and stressor mechanism evidence exist. The real-agent executor and the
 deterministic trust executor now exist (`eval:executor run-agent-real-batch`
 reproduced the first seed baseline; `eval:executor trust-run` scores the trust
-suite with an honest 3/7 baseline). The remaining work is to implement
+suite with an honest 4/7 baseline). The remaining work is to implement
 comparator adapters, run the paired pilot, freeze the powered private holdout
 under separate custody, publish aggregate reports, and turn measured failures
 into improvements. M3/M4 implementation will make the failing trust scenarios

--- a/runtime/src/budget/enforcer.ts
+++ b/runtime/src/budget/enforcer.ts
@@ -2,15 +2,22 @@
  * Budget enforcer (TODO task 15) — the daemon-side admission gate.
  *
  * Contract (see docs/design/budget-enforcement.md):
- *   admit()      pre-flight: debit worst-case (est input + max output) priced
- *                at the model rate; check BOTH daily and monthly caps; fail
- *                closed. Returns a hold or a typed BUDGET_EXCEEDED refusal.
- *   reconcile()  post-call: replace the held estimate with real usage, refund
- *                the delta, and fire soft-warning / paused notifications.
+ *   admit()      pre-flight: transactionally reserve the worst-case charge
+ *                (est input + max output priced at the model rate) under the
+ *                ledger's cross-process lock — cap check, debit, and the
+ *                durable uniquely-identified hold land in ONE atomic save.
+ *                Returns a hold or a typed BUDGET_EXCEEDED refusal.
+ *   reconcile()  post-call: consume the persisted hold exactly once — replace
+ *                the held estimate with real usage, refund the delta, fire
+ *                soft-warning / paused notifications. Duplicate calls are
+ *                mechanical no-ops (holdId is the idempotency key per the
+ *                frozen BudgetReservation contract in run-contracts.ts).
  *
  * Never silently downgrades the model. On a hard-cap breach it pauses the
  * agent's autonomy and notifies; the operator raises the cap or resets.
  */
+
+import { randomUUID } from "node:crypto";
 
 import { BudgetLedger } from "./ledger.js";
 import type {
@@ -24,6 +31,7 @@ import type {
   BudgetUsage,
   ModelPrice,
   ModelPriceResolver,
+  ReconcileResult,
 } from "./types.js";
 
 export interface BudgetEnforcerOptions {
@@ -73,11 +81,14 @@ export class BudgetEnforcer {
    * relevant cap would be exceeded by the worst-case debit, refuses.
    */
   admit(request: AdmitRequest): AdmitResult {
-    const { dayKey, monthKey } = this.#ledger.currentKeys();
+    const holdId = randomUUID();
     if (!this.#inScope(request)) {
+      const { dayKey, monthKey } = this.#ledger.currentKeys();
+      // Zero hold: nothing reserved, nothing persisted; reconcile no-ops.
       return {
         ok: true,
         hold: {
+          holdId,
           agentId: request.agentId,
           model: request.model,
           estimatedUsd: 0,
@@ -86,11 +97,6 @@ export class BudgetEnforcer {
           monthKey,
         },
       };
-    }
-
-    const state = this.#ledger.snapshot(request.agentId);
-    if (state.paused) {
-      return this.#refuse("paused", request.agentId, 0, 0);
     }
 
     const price = this.#priceOf(request.model);
@@ -110,41 +116,61 @@ export class BudgetEnforcer {
         ? priceTokens(price, request.estInputTokens, request.maxOutputTokens)
         : 0;
 
-    // Dollar caps.
-    if (caps.dailyUsd !== undefined && state.day.usd + estUsd > caps.dailyUsd) {
-      return this.#refuse("daily_usd", request.agentId, estUsd, estTokens);
-    }
-    if (
-      caps.monthlyUsd !== undefined &&
-      state.month.usd + estUsd > caps.monthlyUsd
-    ) {
-      return this.#refuse("monthly_usd", request.agentId, estUsd, estTokens);
-    }
-    // Token caps.
-    if (
-      caps.dailyTokens !== undefined &&
-      state.day.tokens + estTokens > caps.dailyTokens
-    ) {
-      return this.#refuse("daily_tokens", request.agentId, estUsd, estTokens);
-    }
-    if (
-      caps.monthlyTokens !== undefined &&
-      state.month.tokens + estTokens > caps.monthlyTokens
-    ) {
-      return this.#refuse("monthly_tokens", request.agentId, estUsd, estTokens);
-    }
-
-    // Admit: hold the worst-case debit so a concurrent turn can't double-spend.
-    this.#ledger.addSpend(request.agentId, estUsd, estTokens);
-    return {
-      ok: true,
-      hold: {
+    // Reserve transactionally: the cap check runs against the LOCKED ledger
+    // state and the worst-case debit + persisted hold land in one atomic
+    // save, so concurrent reservers cannot both pass the same headroom and
+    // a crash after admit leaves a durable, uniquely-identified open hold.
+    const reserved = this.#ledger.tryReserve(
+      {
+        holdId,
         agentId: request.agentId,
         model: request.model,
         estimatedUsd: estUsd,
         estimatedTokens: estTokens,
-        dayKey,
-        monthKey,
+        reservedAt: new Date().toISOString(),
+      },
+      (state) => {
+        if (state.paused) return "paused";
+        if (
+          caps.dailyUsd !== undefined &&
+          state.day.usd + estUsd > caps.dailyUsd
+        ) {
+          return "daily_usd";
+        }
+        if (
+          caps.monthlyUsd !== undefined &&
+          state.month.usd + estUsd > caps.monthlyUsd
+        ) {
+          return "monthly_usd";
+        }
+        if (
+          caps.dailyTokens !== undefined &&
+          state.day.tokens + estTokens > caps.dailyTokens
+        ) {
+          return "daily_tokens";
+        }
+        if (
+          caps.monthlyTokens !== undefined &&
+          state.month.tokens + estTokens > caps.monthlyTokens
+        ) {
+          return "monthly_tokens";
+        }
+        return null;
+      },
+    );
+    if (!reserved.reserved) {
+      return this.#refuse(reserved.reason, request.agentId, estUsd, estTokens);
+    }
+    return {
+      ok: true,
+      hold: {
+        holdId: reserved.hold.holdId,
+        agentId: reserved.hold.agentId,
+        model: reserved.hold.model,
+        estimatedUsd: reserved.hold.estimatedUsd,
+        estimatedTokens: reserved.hold.estimatedTokens,
+        dayKey: reserved.hold.dayKey,
+        monthKey: reserved.hold.monthKey,
       },
     };
   }
@@ -202,17 +228,22 @@ export class BudgetEnforcer {
 
   /**
    * Replace a hold's worst-case estimate with the real usage and refund the
-   * delta (ledger applies `actual − estimated`), then fire a one-shot soft
-   * warning if a window crossed the soft threshold.
+   * delta (ledger applies `actual − estimated` from the PERSISTED estimate),
+   * then fire a one-shot soft warning if a window crossed the soft threshold.
    *
-   * **Not idempotent:** each call applies another `(actual − estimated)`
-   * delta. Call **exactly once** per successful admit (prefer exclusive
-   * `try`/`finally`). Zero holds (budget disabled / out of scope) are a no-op.
+   * **Exactly-once by mechanism:** the hold's durable `holdId` is the
+   * reconciliation idempotency key (frozen contract, run-contracts.ts).
+   * The first call consumes the persisted hold in one locked transaction;
+   * every later call finds no open hold and leaves the ledger untouched
+   * (`reason: "duplicate"`). Zero holds (budget disabled / out of scope)
+   * are a no-op. A hold whose day window rolled before reconciliation is
+   * discarded WITHOUT refund — its debit was already zeroed by the roll and
+   * unknown usage is never refunded as if the call were free.
    */
-  reconcile(hold: BudgetHold, usage: BudgetUsage): void {
+  reconcile(hold: BudgetHold, usage: BudgetUsage): ReconcileResult {
     if (hold.estimatedTokens === 0 && hold.estimatedUsd === 0) {
       // Out-of-scope / unpriced admit held nothing; account nothing.
-      return;
+      return { applied: false, reason: "zero_hold" };
     }
     const price = this.#priceOf(hold.model);
     const actualTokens = usage.inputTokens + usage.outputTokens;
@@ -220,13 +251,12 @@ export class BudgetEnforcer {
       price !== null
         ? priceTokens(price, usage.inputTokens, usage.outputTokens)
         : 0;
-    // Refund the difference between the worst-case hold and the actual spend.
-    this.#ledger.addSpend(
-      hold.agentId,
-      actualUsd - hold.estimatedUsd,
-      actualTokens - hold.estimatedTokens,
-    );
+    const outcome = this.#ledger.consumeHold(hold.holdId, actualUsd, actualTokens);
+    if (outcome !== "reconciled") {
+      return { applied: false, reason: outcome };
+    }
     this.#maybeSoftWarn(hold.agentId);
+    return { applied: true, reason: "reconciled" };
   }
 
   #maybeSoftWarn(agentId: string): void {

--- a/runtime/src/budget/ledger.ts
+++ b/runtime/src/budget/ledger.ts
@@ -21,11 +21,23 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-import type { AgentBudgetState, BudgetWindowSpend } from "./types.js";
+import type {
+  AgentBudgetState,
+  BudgetRefusalReason,
+  BudgetWindowSpend,
+  PersistedBudgetHold,
+} from "./types.js";
 
 interface LedgerFile {
   readonly version: 1;
   agents: Record<string, AgentBudgetState>;
+  /**
+   * Open (reserved-but-unresolved) holds keyed by holdId — the durable
+   * reservation record the frozen contract requires. Written in the SAME
+   * atomic save as the worst-case debit, so reserve+debit is one durable
+   * transaction. Absent in pre-reservation ledger files (loads as {}).
+   */
+  holds: Record<string, PersistedBudgetHold>;
 }
 
 function emptyWindow(key: string): BudgetWindowSpend {
@@ -67,7 +79,7 @@ export class BudgetLedger {
   }
 
   #load(): LedgerFile {
-    if (!existsSync(this.#path)) return { version: 1, agents: {} };
+    if (!existsSync(this.#path)) return { version: 1, agents: {}, holds: {} };
     try {
       const raw = JSON.parse(readFileSync(this.#path, "utf8")) as unknown;
       if (
@@ -77,13 +89,21 @@ export class BudgetLedger {
         typeof (raw as { agents?: unknown }).agents === "object" &&
         (raw as { agents?: unknown }).agents !== null
       ) {
-        return { version: 1, agents: (raw as LedgerFile).agents };
+        const holds = (raw as { holds?: unknown }).holds;
+        return {
+          version: 1,
+          agents: (raw as LedgerFile).agents,
+          holds:
+            typeof holds === "object" && holds !== null && !Array.isArray(holds)
+              ? (holds as Record<string, PersistedBudgetHold>)
+              : {},
+        };
       }
     } catch {
       // Corrupt ledger fails toward zero spend — the caps still apply going
       // forward; we never fabricate spend the agent didn't make.
     }
-    return { version: 1, agents: {} };
+    return { version: 1, agents: {}, holds: {} };
   }
 
   #save(): void {
@@ -98,7 +118,7 @@ export class BudgetLedger {
    * (heartbeat / hooks / cron each construct their own BudgetLedger — todo-110).
    * Re-loads disk state under the lock so concurrent addSpend merges.
    */
-  #withDiskLock(mutate: () => void): void {
+  #withDiskLock<T>(mutate: () => T): T {
     const lockPath = `${this.#path}.lock`;
     mkdirSync(dirname(this.#path), { recursive: true, mode: 0o700 });
     const deadline = Date.now() + 5_000;
@@ -109,9 +129,9 @@ export class BudgetLedger {
       } catch {
         if (Date.now() > deadline) {
           // Fail open to local mutate if lock stuck (still better than hang).
-          mutate();
+          const result = mutate();
           this.#save();
-          return;
+          return result;
         }
         // Busy-wait briefly for the lock holder.
         const start = Date.now();
@@ -123,8 +143,9 @@ export class BudgetLedger {
     try {
       // Merge: re-read disk then apply mutate against this.#file.
       this.#file = this.#load();
-      mutate();
+      const result = mutate();
       this.#save();
+      return result;
     } finally {
       try {
         closeSync(fd);
@@ -194,6 +215,87 @@ export class BudgetLedger {
     });
   }
 
+  /** Drop holds whose day window has rolled: their debit no longer exists. */
+  #pruneExpiredHolds(dayKey: string): void {
+    for (const [holdId, hold] of Object.entries(this.#file.holds)) {
+      if (hold.dayKey !== dayKey) delete this.#file.holds[holdId];
+    }
+  }
+
+  /**
+   * Transactional reserve: under the cross-process disk lock, roll the
+   * agent's windows, run the caller's admission `check` against the LOCKED
+   * state, and — only if it passes — apply the worst-case debit AND record
+   * the open hold in one atomic save. This closes the check-outside-lock
+   * TOCTOU: two concurrent reservers serialize on the lock and the second
+   * sees the first's debit.
+   *
+   * The persisted hold's window keys are stamped from the rolled state (the
+   * authoritative clock inside the lock), not from the caller.
+   */
+  tryReserve(
+    request: Omit<PersistedBudgetHold, "dayKey" | "monthKey">,
+    check: (state: AgentBudgetState) => BudgetRefusalReason | null,
+  ):
+    | { readonly reserved: true; readonly hold: PersistedBudgetHold }
+    | { readonly reserved: false; readonly reason: BudgetRefusalReason } {
+    return this.#withDiskLock(() => {
+      const state = this.#stateRolled(request.agentId);
+      this.#pruneExpiredHolds(state.day.key);
+      const reason = check(state);
+      if (reason !== null) return { reserved: false, reason };
+      const hold: PersistedBudgetHold = {
+        ...request,
+        dayKey: state.day.key,
+        monthKey: state.month.key,
+      };
+      state.day.usd += hold.estimatedUsd;
+      state.day.tokens += hold.estimatedTokens;
+      state.month.usd += hold.estimatedUsd;
+      state.month.tokens += hold.estimatedTokens;
+      this.#file.holds[hold.holdId] = hold;
+      return { reserved: true, hold };
+    });
+  }
+
+  /**
+   * Exactly-once hold resolution: under the disk lock, look up the persisted
+   * hold by id. Present and current → apply `(actual − estimated)` from the
+   * PERSISTED estimate, delete the hold, save (one durable transaction) →
+   * "reconciled". Absent → a duplicate call; the ledger is untouched.
+   * Present but its day window rolled → the debit was already zeroed by the
+   * roll, so the stale hold is discarded with NO refund ("window_rolled" —
+   * unknown usage is never refunded as if the call were free).
+   */
+  consumeHold(
+    holdId: string,
+    actualUsd: number,
+    actualTokens: number,
+  ): "reconciled" | "duplicate" | "window_rolled" {
+    return this.#withDiskLock(() => {
+      const hold = this.#file.holds[holdId];
+      if (hold === undefined) return "duplicate";
+      const state = this.#stateRolled(hold.agentId);
+      if (hold.dayKey !== state.day.key) {
+        delete this.#file.holds[holdId];
+        return "window_rolled";
+      }
+      state.day.usd += actualUsd - hold.estimatedUsd;
+      state.day.tokens += actualTokens - hold.estimatedTokens;
+      state.month.usd += actualUsd - hold.estimatedUsd;
+      state.month.tokens += actualTokens - hold.estimatedTokens;
+      delete this.#file.holds[holdId];
+      return "reconciled";
+    });
+  }
+
+  /** Open (unresolved) holds, optionally filtered by agent. */
+  listOpenHolds(agentId?: string): readonly PersistedBudgetHold[] {
+    return Object.values(this.#file.holds)
+      .filter((hold) => agentId === undefined || hold.agentId === agentId)
+      .sort((a, b) => a.holdId.localeCompare(b.holdId));
+  }
+
   setPaused(agentId: string, paused: boolean): void {
     this.#withDiskLock(() => {
       const s = this.#stateRolled(agentId);
@@ -212,11 +314,14 @@ export class BudgetLedger {
     });
   }
 
-  /** Operator reset: clear an agent's spend, pause flag, and warn flags. */
+  /** Operator reset: clear an agent's spend, holds, pause and warn flags. */
   reset(agentId: string): void {
     this.#withDiskLock(() => {
       const { dayKey, monthKey } = windowKeys(this.#now());
       this.#file.agents[agentId] = emptyState(agentId, dayKey, monthKey);
+      for (const [holdId, hold] of Object.entries(this.#file.holds)) {
+        if (hold.agentId === agentId) delete this.#file.holds[holdId];
+      }
     });
   }
 

--- a/runtime/src/budget/types.ts
+++ b/runtime/src/budget/types.ts
@@ -104,14 +104,57 @@ export type AdmitResult =
       readonly message: string;
     };
 
-/** A reserved worst-case debit, reconciled after the call returns. */
+/**
+ * A reserved worst-case debit, reconciled after the call returns.
+ *
+ * `holdId` is the durable reservation id required by the frozen Wave-B
+ * contract (`BudgetReservation.reservationId`, run-contracts.ts): it is the
+ * idempotency key for reconciliation. Non-zero holds are persisted in the
+ * ledger file atomically with their debit, so a crash between reserve and
+ * reconcile leaves a visible open hold (held_unknown semantics: the full
+ * reservation stays consumed), never a silently stranded or refunded debit.
+ */
 export interface BudgetHold {
+  readonly holdId: string;
   readonly agentId: string;
   readonly model: string;
   readonly estimatedUsd: number;
   readonly estimatedTokens: number;
   readonly dayKey: string;
   readonly monthKey: string;
+}
+
+/** A hold as persisted in the ledger file while it remains open. */
+export interface PersistedBudgetHold {
+  readonly holdId: string;
+  readonly agentId: string;
+  readonly model: string;
+  readonly estimatedUsd: number;
+  readonly estimatedTokens: number;
+  readonly dayKey: string;
+  readonly monthKey: string;
+  readonly reservedAt: string;
+}
+
+/**
+ * Outcome of a reconcile attempt. Exactly one call per hold `applied`s the
+ * (actual − estimated) delta; every later call is a mechanical no-op.
+ */
+export interface ReconcileResult {
+  readonly applied: boolean;
+  readonly reason:
+    /** Delta applied; the hold is now resolved (contract: "reconciled"). */
+    | "reconciled"
+    /** The hold was already resolved — duplicate call, ledger untouched. */
+    | "duplicate"
+    /**
+     * The hold's day window rolled before reconciliation. Its debit was
+     * zeroed by the roll, so no refund is applied (unknown usage is never
+     * refunded as if the call were free); the stale hold is discarded.
+     */
+    | "window_rolled"
+    /** Zero hold (enforcement off / out of scope): nothing was ever held. */
+    | "zero_hold";
 }
 
 /** Emitted when a budget event happens; wired to the notification surface. */

--- a/runtime/tests/budget/budget.test.ts
+++ b/runtime/tests/budget/budget.test.ts
@@ -134,6 +134,19 @@ describe("BudgetLedger", () => {
     const l2 = new BudgetLedger({ agencHome: home, now });
     expect(l2.snapshot("a1").day.usd).toBe(0);
   });
+
+  test("pre-reservation ledger files (no holds field) load cleanly", () => {
+    const now = () => new Date("2026-07-09T10:00:00Z");
+    const l1 = new BudgetLedger({ agencHome: home, now });
+    l1.addSpend("a1", 4, 500);
+    const path = join(home, "budget", "ledger.json");
+    const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    delete raw.holds;
+    require("node:fs").writeFileSync(path, JSON.stringify(raw));
+    const l2 = new BudgetLedger({ agencHome: home, now });
+    expect(l2.snapshot("a1").day.usd).toBeCloseTo(4);
+    expect(l2.listOpenHolds()).toEqual([]);
+  });
 });
 
 describe("BudgetEnforcer", () => {
@@ -193,7 +206,7 @@ describe("BudgetEnforcer", () => {
     if (r.ok) expect(r.hold.estimatedUsd).toBe(0);
   });
 
-  test("reconcile is NOT idempotent: second call over-refunds the hold", () => {
+  test("reconcile is exactly-once: a duplicate call cannot re-apply the delta", () => {
     const enf = make({ caps: { dailyTokens: 1_000_000 } });
     // Token-only path: unpriced model still holds est tokens.
     const r = enf.admit(
@@ -202,11 +215,96 @@ describe("BudgetEnforcer", () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(sharedLedger.snapshot("a1").day.tokens).toBe(200);
-    enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
+    const first = enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
+    expect(first).toEqual({ applied: true, reason: "reconciled" });
     expect(sharedLedger.snapshot("a1").day.tokens).toBe(0);
-    // Second call applies (0 − 200) again → negative residual (footgun).
-    enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
-    expect(sharedLedger.snapshot("a1").day.tokens).toBe(-200);
+    // The holdId is the durable idempotency key: the second call finds no
+    // open hold and MUST leave the ledger untouched (was: −200 footgun).
+    const second = enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
+    expect(second).toEqual({ applied: false, reason: "duplicate" });
+    expect(sharedLedger.snapshot("a1").day.tokens).toBe(0);
+  });
+
+  test("admit persists a durable open hold; reconcile consumes it across instances", () => {
+    const enf = make({ caps: { dailyUsd: 100 } });
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // A FRESH ledger instance (new process semantics) sees the open hold.
+    const fresh = new BudgetLedger({ agencHome: home, now });
+    const open = fresh.listOpenHolds("a1");
+    expect(open).toHaveLength(1);
+    expect(open[0]!.holdId).toBe(r.hold.holdId);
+    expect(open[0]!.estimatedUsd).toBeCloseTo(0.004, 6);
+    enf.reconcile(r.hold, { inputTokens: 1000, outputTokens: 200 });
+    expect(new BudgetLedger({ agencHome: home, now }).listOpenHolds("a1")).toHaveLength(0);
+  });
+
+  test("a crash-stranded hold keeps its full reservation (held_unknown)", () => {
+    const enf = make({ caps: { dailyUsd: 100 } });
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(true);
+    // No reconcile (simulated crash): a fresh instance still sees the full
+    // worst-case debit AND the open hold — never a silent refund.
+    const fresh = new BudgetLedger({ agencHome: home, now });
+    expect(fresh.snapshot("a1").day.usd).toBeCloseTo(0.004, 6);
+    expect(fresh.listOpenHolds("a1")).toHaveLength(1);
+  });
+
+  test("reconcile after the day window rolled discards the hold without refund", () => {
+    let clock = new Date("2026-07-09T10:00:00Z");
+    sharedLedger = new BudgetLedger({ agencHome: home, now: () => clock });
+    const enf = new BudgetEnforcer({
+      policy: {
+        enabled: true,
+        softThreshold: 0.8,
+        enforceInteractive: false,
+        caps: { dailyUsd: 100 },
+      },
+      ledger: sharedLedger,
+      priceOf,
+      notify: (e) => notes.push(e),
+    });
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    clock = new Date("2026-07-10T10:00:00Z"); // day rolls, same month
+    const result = enf.reconcile(r.hold, { inputTokens: 0, outputTokens: 0 });
+    expect(result).toEqual({ applied: false, reason: "window_rolled" });
+    const s = sharedLedger.snapshot("a1");
+    expect(s.day.usd).toBe(0); // no negative refund into the new day
+    expect(s.month.usd).toBeCloseTo(0.004, 6); // month keeps the reservation
+    expect(sharedLedger.listOpenHolds("a1")).toHaveLength(0); // discarded
+  });
+
+  test("concurrent reservers cannot both pass the same headroom (locked check)", () => {
+    // Two enforcers over two ledger INSTANCES of the same file, both built
+    // before either admits — the second's cap check must see the first's
+    // debit via the locked reload, not its own stale in-memory copy.
+    const policy: BudgetPolicy = {
+      enabled: true,
+      softThreshold: 0.8,
+      enforceInteractive: false,
+      caps: { dailyUsd: 0.006 }, // fits ONE 0.004 worst-case, not two
+    };
+    const ledgerA = new BudgetLedger({ agencHome: home, now });
+    const ledgerB = new BudgetLedger({ agencHome: home, now });
+    const enfA = new BudgetEnforcer({ policy, ledger: ledgerA, priceOf });
+    const enfB = new BudgetEnforcer({ policy, ledger: ledgerB, priceOf });
+    const a = enfA.admit(autoReq());
+    expect(a.ok).toBe(true);
+    const b = enfB.admit(autoReq());
+    expect(b.ok).toBe(false);
+    if (!b.ok) expect(b.reason).toBe("daily_usd");
+  });
+
+  test("reset clears the agent's open holds", () => {
+    const enf = make({ caps: { dailyUsd: 100 } });
+    const r = enf.admit(autoReq());
+    expect(r.ok).toBe(true);
+    sharedLedger.reset("a1");
+    expect(sharedLedger.listOpenHolds("a1")).toHaveLength(0);
+    expect(sharedLedger.snapshot("a1").day.usd).toBe(0);
   });
 
   test("admit debits worst-case; reconcile refunds the delta to actual", () => {

--- a/runtime/tests/eval/trust-conformance-executor.test.ts
+++ b/runtime/tests/eval/trust-conformance-executor.test.ts
@@ -78,8 +78,11 @@ describe("trust-conformance executor", () => {
     // Both directions are regression-sensitive: a runtime regression flips a
     // passed family to failed; a harness bug faking a pass flips a failed
     // family to passed. Either way this assertion goes red.
+    // Baseline updated with the M3 budget reservation kernel: durable
+    // holdId reconciliation made reconciliation_exactly_once genuinely pass,
+    // flipping the budget family (3/7 -> 4/7).
     expect(summary.faultFamilyResults).toEqual({
-      budget: "failed",
+      budget: "passed",
       cancellation: "failed",
       event_loss: "failed",
       permission: "passed",
@@ -87,9 +90,9 @@ describe("trust-conformance executor", () => {
       restart: "passed",
       uncertain_effect: "failed",
     });
-    expect(summary.passed).toBe(3);
-    expect(summary.failed).toBe(4);
-    expect(summary.trustRecoveryRate).toBeCloseTo(3 / 7, 10);
+    expect(summary.passed).toBe(4);
+    expect(summary.failed).toBe(3);
+    expect(summary.trustRecoveryRate).toBeCloseTo(4 / 7, 10);
   }, 120_000);
 
   it("reports exactly the known capability-gap invariants as failed", async () => {
@@ -97,10 +100,6 @@ describe("trust-conformance executor", () => {
     const sortedFailures = [...summary.failedInvariants].sort((a, b) =>
       `${a.scenarioId}:${a.invariant}`.localeCompare(`${b.scenarioId}:${b.invariant}`));
     expect(sortedFailures).toEqual([
-      {
-        scenarioId: "budget-sibling-reservation-race",
-        invariant: "reconciliation_exactly_once",
-      },
       {
         scenarioId: "cancel-parent-after-child-admission",
         invariant: "descendant_admission_stopped",
@@ -180,11 +179,15 @@ describe("trust-conformance executor", () => {
     expect(summaryDoc.kind).toBe("agenc.eval.trust-run-summary");
     expect(summaryDoc.documentDigest).toMatch(/^sha256:/);
     expect(summaryDoc.summary?.total).toBe(7);
-    // Failed attempts keep their forensic state (SQLite DBs, ledger, audit).
+    // Failed attempts keep their forensic state (SQLite DBs, ledger, audit);
+    // passing attempts (budget, since the reservation kernel) are cleaned.
     const preserved = readdirSync(path.join(outputDir, "attempts"));
-    expect(preserved).toContain("trust-budget-sibling-reservation-race-slot0");
+    expect(preserved).toContain("trust-cancel-parent-after-child-admission-slot0");
     expect(preserved).toContain(
       "trust-uncertain-effect-lost-acknowledgement-slot0",
+    );
+    expect(preserved).not.toContain(
+      "trust-budget-sibling-reservation-race-slot0",
     );
     // wx flags: a rerun into the same output dir must refuse to clobber.
     await expect(


### PR DESCRIPTION
## What

First implementation slice of the frozen Wave-B `BudgetReservation` contract (`contracts/run-contracts.ts`), opening the M3/M4/M5 vertical slice: budget reconciliation is now **exactly-once by mechanism**, not caller discipline.

- Every non-zero `BudgetHold` carries a durable `holdId` (the contract's `reservationId`); open holds are persisted in `ledger.json` in the **same atomic save** as their worst-case debit.
- `admit()` reserves transactionally: the cap check runs against the locked, freshly-loaded ledger state — closing the check-outside-lock TOCTOU where two concurrent reservers could both pass the same headroom (flagged by the #1538 right-reason audit).
- `reconcile()` consumes the persisted hold under the lock, computing the refund delta from the **persisted** estimate; duplicate calls are mechanical no-ops (`{applied:false, reason:"duplicate"}`). The old behavior re-applied the delta on every call — the suite's own test documented the negative-residual footgun.
- Crash between admit and reconcile leaves a **visible open hold whose full reservation stays consumed** (`held_unknown` — unknown usage is never refunded as if the call were free). Day-window-rolled holds are discarded without refund. `reset()` clears holds; `listOpenHolds()` exposes unresolved reservations. Pre-reservation ledger files load unchanged; call sites need no changes (`reconcile`'s return is additive).

## Scoreboard

The trust-conformance executor (merged in #1538) did exactly what it exists for: `reconciliation_exactly_once` flipped to a genuine pass the moment the kernel landed, failing the pinned baseline in the improvement direction. Baseline deliberately updated **3/7 → 4/7 TRR** (budget family passes; verified end-to-end via `eval:executor trust-run`: passed 4 / failed 3 / infra-invalid 0, exit 0).

## Verification (local, Node v25.9.0, tested SHA f711111fb)

- `npm run typecheck` — clean.
- **Full stable suite: 1809/1809 files, 15582 tests passed, 0 failures** (first fully-green run; includes the #1538 allowlist fix).
- `tests/budget/budget.test.ts` 27/27 — the flipped footgun test plus new coverage: durable holds across ledger instances, crash-stranded `held_unknown`, window-roll no-refund, locked concurrent-reserver check, reset clearing, ledger-file back-compat.
- Revert-sensitivity proven: with `src/budget/` reverted to pre-fix, 10 tests go red; restored, 33/33 green.
- Pre-commit hook: build, entrypoint/SDK-type/package-mode checks, PTY/TUI startup smoke — green.

https://claude.ai/code/session_01FS6MHf68F1H29F7kt5jJyM