### PR TITLE
feat(daemon): M4 event-gap markers — replay buffer announces eviction (TRR 4/7 → 5/7)

### DIFF
--- a/docs/evaluation-suites-v1.md
+++ b/docs/evaluation-suites-v1.md
@@ -174,9 +174,11 @@ content-addressed summary under `--output` (default
 `eval-executor-output/trust`), refusing to clobber existing evidence. Honest
 invariant failures exit 0 — they are the suite's product; only
 infrastructure-invalid attempts exit 1. The current honest baseline on
-`main` is 4/7 families passing (restart, reconnect, permission, and budget —
-the M3 budget reservation kernel made reconciliation exactly-once) with
-cancellation cascade/admission, event-gap markers, and the unknown-outcome
+`main` is 5/7 families passing (restart, reconnect, permission, budget — the
+M3 reservation kernel — and event loss: the client multiplexer's SESSION
+replay buffer now announces eviction with in-band `event_gap` markers whose
+retired counts must match the actual loss; capability buffers are a
+follow-up) with cancellation cascade/admission and the unknown-outcome
 dependent-mutation gate failing until the rest of M3/M4 lands. `runtime/tests/eval/trust-conformance-executor.test.ts` pins those
 outcomes in both directions: a runtime regression flips a passing family, a
 harness bug faking a pass flips a failing one, and either turns CI red.
@@ -308,7 +310,7 @@ qualified until its cold preflights, independent solve, negative-patch review,
 and stressor mechanism evidence exist. The real-agent executor and the
 deterministic trust executor now exist (`eval:executor run-agent-real-batch`
 reproduced the first seed baseline; `eval:executor trust-run` scores the trust
-suite with an honest 4/7 baseline). The remaining work is to implement
+suite with an honest 5/7 baseline). The remaining work is to implement
 comparator adapters, run the paired pilot, freeze the powered private holdout
 under separate custody, publish aggregate reports, and turn measured failures
 into improvements. M3/M4 implementation will make the failing trust scenarios

--- a/runtime/src/app-server/client-multiplexer.ts
+++ b/runtime/src/app-server/client-multiplexer.ts
@@ -14,6 +14,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { EVENT_GAP_EVENT } from "../contracts/run-contracts.js";
 import { AsyncLock } from "../utils/async-lock.js";
 import {
   AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY,
@@ -350,7 +351,7 @@ export class AgenCDaemonClientMultiplexer {
     // Replay never evicts (allowEvict=false below), so nothing is ever pushed
     // here; the array only satisfies the shared enqueueDelivery signature.
     const replayEvictedClientIds: string[] = [];
-    const { attachment, replayedEventCount, replay } = await this.#state.with(
+    const { attachment, replayedEvents, replay } = await this.#state.with(
       async (state) => {
         const client = requireClient(state, clientId);
         const attachment = await this.#sessionManager.attachSession({
@@ -361,7 +362,7 @@ export class AgenCDaemonClientMultiplexer {
 
         client.sessionIds.add(sessionId);
         route.clientAttachmentIds.set(clientId, attachment.attachmentId);
-        const replayedEventCount = route.bufferedEvents.length;
+        const replayedEvents = [...route.bufferedEvents];
         const replay = route.bufferedEvents
           .map((event) =>
             enqueueDelivery(
@@ -376,7 +377,7 @@ export class AgenCDaemonClientMultiplexer {
           )
           .filter((delivery): delivery is EnqueuedDelivery => delivery !== null);
 
-        return { attachment, replayedEventCount, replay };
+        return { attachment, replayedEvents, replay };
       },
     );
 
@@ -385,7 +386,21 @@ export class AgenCDaemonClientMultiplexer {
       if (replayResult.failed.length === 0) {
         await this.#state.with((state) => {
           const route = state.sessions.get(sessionId);
-          route?.bufferedEvents.splice(0, replayedEventCount);
+          if (route === undefined) return;
+          // Remove EXACTLY the delivered events, by identity — never by
+          // count. The settle above runs outside the state lock, so the
+          // buffer may have shifted meanwhile (new events appended, oldest
+          // evicted, a gap marker unshifted/merged at the head). A
+          // positional splice would destroy never-delivered events and the
+          // marker itself, silently re-hiding announced loss. A marker
+          // merged during the window is a NEW object and correctly
+          // survives for the next client (its retiredCount may then
+          // re-announce already-delivered events — over-announcing is the
+          // safe direction).
+          const delivered = new Set(replayedEvents);
+          route.bufferedEvents = route.bufferedEvents.filter(
+            (event) => !delivered.has(event),
+          );
         });
       }
     }
@@ -922,6 +937,61 @@ async function settleDeliveries(
   };
 }
 
+/**
+ * In-band retention-gap marker announcing evicted buffered events, using the
+ * frozen vocabulary (EVENT_GAP_EVENT + RunEventGap reason "retention",
+ * contracts/run-contracts.ts). Buffered events are opaque to the multiplexer,
+ * so the marker is a flat object rather than a session-event envelope;
+ * sequence-addressed RunEventGap markers arrive with the M4 journal
+ * (run.replay). JSON-RPC clients that dispatch on `method` ignore it;
+ * gap-aware clients read `type`/`retiredCount`.
+ *
+ * Invariants: at most ONE marker per session buffer, always at the head,
+ * merged (retiredCount accumulates) across evictions, never itself evicted,
+ * exempt from the event-count capacity. It leaves the buffer only by being
+ * replayed — a fully-acked replay splices it out with the replayed prefix,
+ * so a later eviction starts a fresh marker for the next reconnecting
+ * client. After a failed (unacked) replay the buffer — marker included — is
+ * retained for the next attach.
+ */
+function makeEventGapMarker(sessionId: string, retiredCount: number): JsonObject {
+  return {
+    type: EVENT_GAP_EVENT,
+    sessionId,
+    reason: "retention",
+    retiredCount,
+    // Brand so the predicate below can never confuse a future
+    // sequence-addressed RunEventGap journal event (same frozen type
+    // vocabulary) with a multiplexer-owned retention marker.
+    source: "multiplexer_retention",
+  };
+}
+
+function isBufferedEventGapMarker(event: JsonObject): boolean {
+  return (
+    event.type === EVENT_GAP_EVENT &&
+    event.reason === "retention" &&
+    event.source === "multiplexer_retention"
+  );
+}
+
+/** Merge newly retired events into the head marker (creating it if absent). */
+function recordRetiredEvents(
+  bufferedEvents: JsonObject[],
+  sessionId: string,
+  retiredCount: number,
+): void {
+  if (retiredCount <= 0) return;
+  const head = bufferedEvents[0];
+  if (head !== undefined && isBufferedEventGapMarker(head)) {
+    const previous =
+      typeof head.retiredCount === "number" ? head.retiredCount : 0;
+    bufferedEvents[0] = makeEventGapMarker(sessionId, previous + retiredCount);
+    return;
+  }
+  bufferedEvents.unshift(makeEventGapMarker(sessionId, retiredCount));
+}
+
 function bufferSessionEvent(
   route: MutableSessionRoute,
   event: JsonObject,
@@ -929,13 +999,24 @@ function bufferSessionEvent(
   maxBufferedBytes: number,
 ): void {
   route.bufferedEvents.push(event);
-  if (route.bufferedEvents.length > maxBufferedEvents) {
-    route.bufferedEvents.splice(
-      0,
-      route.bufferedEvents.length - maxBufferedEvents,
+  const startIndex =
+    route.bufferedEvents[0] !== undefined &&
+    isBufferedEventGapMarker(route.bufferedEvents[0])
+      ? 1
+      : 0;
+  const realCount = route.bufferedEvents.length - startIndex;
+  if (realCount > maxBufferedEvents) {
+    const evicted = route.bufferedEvents.splice(
+      startIndex,
+      realCount - maxBufferedEvents,
     );
+    recordRetiredEvents(route.bufferedEvents, route.sessionId, evicted.length);
   }
-  evictBufferedEventsByBytes(route.bufferedEvents, maxBufferedBytes);
+  evictBufferedEventsByBytes(
+    route.bufferedEvents,
+    maxBufferedBytes,
+    route.sessionId,
+  );
 }
 
 function advertisedCapabilities(capabilities: JsonObject | undefined): Set<string> {
@@ -1010,25 +1091,44 @@ function bufferedEventByteSize(event: JsonObject): number {
 /**
  * Drops the oldest buffered events in-place until the total approximate byte
  * size is within `maxBufferedBytes`. Always retains at least the most recent
- * event so a single oversized payload is still replayable rather than silently
- * lost. Pairs with the count cap in {@link bufferSessionEvent}.
+ * REAL event so a single oversized payload is still replayable rather than
+ * silently lost, and never evicts the head gap marker (announced loss must
+ * not itself be lost). Every eviction is folded into the marker via
+ * {@link recordRetiredEvents}; the marker's own ~130 bytes are deliberately
+ * not re-looped against KB-scale budgets. Pairs with the count cap in
+ * {@link bufferSessionEvent}.
  */
 function evictBufferedEventsByBytes(
   bufferedEvents: JsonObject[],
   maxBufferedBytes: number,
+  sessionId: string,
 ): void {
   if (maxBufferedBytes <= 0 || bufferedEvents.length === 0) return;
   let total = 0;
   for (const event of bufferedEvents) {
     total += bufferedEventByteSize(event);
   }
-  while (total > maxBufferedBytes && bufferedEvents.length > 1) {
-    const removed = bufferedEvents.shift();
+  let retired = 0;
+  while (total > maxBufferedBytes) {
+    const startIndex =
+      bufferedEvents[0] !== undefined &&
+      isBufferedEventGapMarker(bufferedEvents[0])
+        ? 1
+        : 0;
+    if (bufferedEvents.length - startIndex <= 1) break;
+    const [removed] = bufferedEvents.splice(startIndex, 1);
     if (removed === undefined) break;
     total -= bufferedEventByteSize(removed);
+    retired += 1;
   }
+  if (retired > 0) recordRetiredEvents(bufferedEvents, sessionId, retired);
 }
 
+/**
+ * Note: a buffer holding only a gap marker deliberately keeps the route
+ * alive — the announced loss must survive for the next attaching client.
+ * The pin is one small object per session and clears on attach/terminate.
+ */
 function deleteRouteIfEmpty(
   state: MultiplexerState,
   route: MutableSessionRoute,

--- a/runtime/src/eval-executor/trust-run.ts
+++ b/runtime/src/eval-executor/trust-run.ts
@@ -1040,14 +1040,26 @@ async function runEventLossExplicitRetentionGap(ctx: ScenarioContext): Promise<S
     .map((event) => eventIdOf(event))
     .filter((id): id is string => id !== null && publishedSet.has(id));
   const lostCount = total - deliveredPublishedIds.length;
-  const gapMarkerPresent = delivered.some(
+  const gapMarkers = delivered.filter(
     (event) => eventTypeOf(event) === EVENT_GAP_EVENT,
   );
-  const hiddenLossZero = lostCount === 0 || gapMarkerPresent;
+  const gapMarkerPresent = gapMarkers.length > 0;
+  const announcedRetiredCount = gapMarkers.reduce(
+    (sum, marker) =>
+      sum + (typeof marker.retiredCount === "number" ? marker.retiredCount : 0),
+    0,
+  );
+  // Hidden loss is zero only when the loss is announced HONESTLY: the
+  // marker's retired count must account for every lost event, not merely
+  // exist. A marker with a wrong count is still hidden loss.
+  const hiddenLossZero =
+    lostCount === 0 ||
+    (gapMarkerPresent && announcedRetiredCount === lostCount);
   const terminalQueryable = deliveredPublishedIds.includes("terminal");
   evidence.record("event.gap", {
     lostCount,
     gapMarkerPresent,
+    announcedRetiredCount,
     deliveredCount: deliveredPublishedIds.length,
   });
   evidence.record("recovery.assessed", {
@@ -1066,6 +1078,7 @@ async function runEventLossExplicitRetentionGap(ctx: ScenarioContext): Promise<S
       invariant(evidence, "hidden_event_loss_zero", hiddenLossZero, {
         lostCount,
         gapMarkerPresent,
+        announcedRetiredCount,
       }),
       invariant(evidence, "terminal_result_queryable", terminalQueryable, {}),
     ],

--- a/runtime/tests/app-server/client-multiplexer.byte-budget.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.byte-budget.test.ts
@@ -80,24 +80,30 @@ describe("client multiplexer buffered byte budget", () => {
     });
     await multiplexer.attachClientToSession("session_1", "client_1");
 
-    // Far fewer than 50 events survived the byte budget.
-    expect(replayed.length).toBeGreaterThan(0);
+    // Far fewer than 50 events survived the byte budget; the eviction is
+    // ANNOUNCED by a leading event_gap marker (M4), never silent.
+    expect(replayed.length).toBeGreaterThan(1);
     expect(replayed.length).toBeLessThan(10);
+    const marker = replayed[0] as { type: string; retiredCount: number };
+    expect(marker.type).toBe("event_gap");
+    const survivors = replayed.slice(1);
+    expect(marker.retiredCount).toBe(50 - survivors.length);
 
     // The survivors are the most recent events (oldest evicted from the head).
-    const lastReplayed = replayed[replayed.length - 1] as {
+    const lastReplayed = survivors[survivors.length - 1] as {
       sequence: number;
     };
     expect(lastReplayed.sequence).toBe(50);
-    const firstReplayed = replayed[0] as { sequence: number };
+    const firstReplayed = survivors[0] as { sequence: number };
     expect(firstReplayed.sequence).toBeGreaterThan(40);
 
-    // Total replayed bytes stay within ~one event of the budget.
+    // Total replayed bytes stay within ~one event of the budget (plus the
+    // small gap marker).
     const replayedBytes = replayed.reduce(
       (sum, event) => sum + Buffer.byteLength(JSON.stringify(event)),
       0,
     );
-    expect(replayedBytes).toBeLessThanOrEqual(4 * 1100 + 1100);
+    expect(replayedBytes).toBeLessThanOrEqual(4 * 1100 + 1100 + 200);
   });
 
   it("always retains at least the most recent event even when it alone exceeds the budget", async () => {

--- a/runtime/tests/app-server/client-multiplexer.event-gap.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.event-gap.test.ts
@@ -1,0 +1,274 @@
+// M4 event-gap markers: the detached-session replay buffer must ANNOUNCE
+// eviction instead of hiding it. On count-cap or byte-budget eviction the
+// multiplexer folds the loss into a single in-band marker (frozen vocabulary
+// EVENT_GAP_EVENT / reason "retention", contracts/run-contracts.ts) at the
+// buffer head, so a reconnecting client sees "N events were retired" rather
+// than a transcript with silent holes.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
+import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
+import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
+import { EVENT_GAP_EVENT } from "../../src/contracts/run-contracts.js";
+import type { JsonObject } from "./protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture(
+  "agenc-client-multiplexer-event-gap-workspace-",
+);
+
+afterEach(async () => {
+  await workspaces.cleanup();
+});
+
+function sequence(values: readonly string[]): () => string {
+  let index = 0;
+  return () => {
+    const value = values[index];
+    if (value === undefined) throw new Error("test sequence exhausted");
+    index += 1;
+    return value;
+  };
+}
+
+function createHarness(options: {
+  readonly maxBufferedEventsPerSession?: number;
+  readonly maxBufferedBytesPerSession?: number;
+}): {
+  readonly sessionManager: AgenCDaemonSessionManager;
+  readonly multiplexer: AgenCDaemonClientMultiplexer;
+} {
+  const sessionManager = new AgenCDaemonSessionManager({
+    createSessionId: sequence(["session_1"]),
+    createAttachmentId: () => `attachment_${Math.random().toString(36).slice(2)}`,
+  });
+  const multiplexer = new AgenCDaemonClientMultiplexer({
+    sessionManager,
+    ...options,
+  });
+  return { sessionManager, multiplexer };
+}
+
+function smallEvent(sequenceNumber: number): JsonObject {
+  return { type: "session.delta", sessionId: "session_1", sequence: sequenceNumber };
+}
+
+function bigEvent(sequenceNumber: number, payloadBytes: number): JsonObject {
+  return { ...smallEvent(sequenceNumber), text: "x".repeat(payloadBytes) };
+}
+
+function isGapMarker(event: JsonObject): boolean {
+  return event.type === EVENT_GAP_EVENT && event.reason === "retention";
+}
+
+async function attachAndCollect(
+  multiplexer: AgenCDaemonClientMultiplexer,
+  clientId: string,
+): Promise<JsonObject[]> {
+  const replayed: JsonObject[] = [];
+  await multiplexer.registerClient({
+    clientId,
+    send: (message) => {
+      replayed.push(message as JsonObject);
+    },
+  });
+  await multiplexer.attachClientToSession("session_1", clientId);
+  return replayed;
+}
+
+describe("client multiplexer event-gap markers", () => {
+  it("announces count-cap eviction with a single merged head marker", async () => {
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedEventsPerSession: 5,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    for (let index = 1; index <= 12; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    const replayed = await attachAndCollect(multiplexer, "client_1");
+    // One marker + the 5 newest real events, in order.
+    expect(replayed).toHaveLength(6);
+    expect(isGapMarker(replayed[0]!)).toBe(true);
+    expect(replayed[0]).toMatchObject({
+      sessionId: "session_1",
+      retiredCount: 7,
+    });
+    expect(
+      replayed.slice(1).map((event) => (event as { sequence: number }).sequence),
+    ).toEqual([8, 9, 10, 11, 12]);
+    // Exactly one marker in the whole stream.
+    expect(replayed.filter(isGapMarker)).toHaveLength(1);
+  });
+
+  it("announces byte-budget eviction and never evicts the marker itself", async () => {
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedEventsPerSession: 100_000,
+      maxBufferedBytesPerSession: 4 * 1100,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    for (let index = 1; index <= 50; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", bigEvent(index, 1000));
+    }
+    const replayed = await attachAndCollect(multiplexer, "client_1");
+    const markers = replayed.filter(isGapMarker);
+    expect(markers).toHaveLength(1);
+    expect(isGapMarker(replayed[0]!)).toBe(true);
+    const survivors = replayed.slice(1) as { sequence: number }[];
+    expect(survivors.length).toBeGreaterThan(0);
+    // Newest events survive; retiredCount accounts for every dropped event.
+    expect(survivors[survivors.length - 1]!.sequence).toBe(50);
+    expect((replayed[0] as { retiredCount: number }).retiredCount).toBe(
+      50 - survivors.length,
+    );
+  });
+
+  it("keeps the newest real event even when it alone exceeds the byte budget", async () => {
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedBytesPerSession: 1024,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    await multiplexer.broadcastSessionEvent("session_1", bigEvent(1, 5000));
+    await multiplexer.broadcastSessionEvent("session_1", bigEvent(2, 100_000));
+    const replayed = await attachAndCollect(multiplexer, "client_1");
+    // Event 1 was evicted (announced); oversized event 2 is retained.
+    expect(replayed).toHaveLength(2);
+    expect(isGapMarker(replayed[0]!)).toBe(true);
+    expect(replayed[0]).toMatchObject({ retiredCount: 1 });
+    expect((replayed[1] as { sequence: number }).sequence).toBe(2);
+  });
+
+  it("produces no marker when nothing was evicted", async () => {
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedEventsPerSession: 10,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    for (let index = 1; index <= 3; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    const replayed = await attachAndCollect(multiplexer, "client_1");
+    expect(replayed).toHaveLength(3);
+    expect(replayed.some(isGapMarker)).toBe(false);
+  });
+
+  it("a fully-acked replay consumes the marker; later eviction starts fresh", async () => {
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedEventsPerSession: 2,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    for (let index = 1; index <= 5; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    const first = await attachAndCollect(multiplexer, "client_1");
+    expect(first[0]).toMatchObject({ retiredCount: 3 });
+    await multiplexer.disconnectClient("client_1");
+    // New detached window: 3 more events, 1 evicted — the fresh marker must
+    // count ONLY the new loss (the old one was delivered and acknowledged).
+    for (let index = 6; index <= 8; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    const second = await attachAndCollect(multiplexer, "client_2");
+    expect(second).toHaveLength(3);
+    expect(second[0]).toMatchObject({ retiredCount: 1 });
+    expect(
+      second.slice(1).map((event) => (event as { sequence: number }).sequence),
+    ).toEqual([7, 8]);
+  });
+
+  it("announces loss even when eviction races an in-flight replay (identity splice)", async () => {
+    // The fully-acked replay cleanup must remove EXACTLY the delivered
+    // events. If it spliced by count, evictions during the unlocked replay
+    // window (which unshift/merge the head marker) would shift the buffer
+    // so the splice destroys the marker and never-delivered events —
+    // silently re-hiding announced loss.
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedEventsPerSession: 3,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    for (let index = 1; index <= 3; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    // Client A's sends stall until released, holding the replay in flight.
+    let releaseSends = (): void => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseSends = resolve;
+    });
+    const deliveredToA: JsonObject[] = [];
+    await multiplexer.registerClient({
+      clientId: "client_a",
+      send: async (message) => {
+        await gate;
+        deliveredToA.push(message as JsonObject);
+      },
+    });
+    const attachInFlight = multiplexer.attachClientToSession(
+      "session_1",
+      "client_a",
+    );
+    // Detach A mid-replay so new broadcasts buffer (and evict) again.
+    await new Promise((resolve) => setImmediate(resolve));
+    await multiplexer.disconnectClient("client_a");
+    for (let index = 4; index <= 7; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    // Release A's replay: it fully acks, triggering the buffer cleanup
+    // while the buffer now holds [marker, e5, e6, e7].
+    releaseSends();
+    await attachInFlight;
+    expect(deliveredToA).toHaveLength(3);
+    // The next client must still see the announced loss and every
+    // never-delivered event.
+    const replayed = await attachAndCollect(multiplexer, "client_b");
+    expect(replayed).toHaveLength(4);
+    expect(isGapMarker(replayed[0]!)).toBe(true);
+    expect(replayed[0]).toMatchObject({ retiredCount: 4 });
+    expect(
+      replayed.slice(1).map((event) => (event as { sequence: number }).sequence),
+    ).toEqual([5, 6, 7]);
+  });
+
+  it("retains the marker for the next client after a failed (unacked) replay", async () => {
+    const { sessionManager, multiplexer } = createHarness({
+      maxBufferedEventsPerSession: 2,
+    });
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    for (let index = 1; index <= 4; index += 1) {
+      await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
+    }
+    await multiplexer.registerClient({
+      clientId: "client_lost",
+      send: () => {
+        throw new Error("client lost before acknowledging replay");
+      },
+    });
+    await multiplexer.attachClientToSession("session_1", "client_lost");
+    await multiplexer.disconnectClient("client_lost");
+    // The buffer (marker included) was NOT spliced: the next client still
+    // sees the announced loss.
+    const replayed = await attachAndCollect(multiplexer, "client_2");
+    expect(replayed).toHaveLength(3);
+    expect(replayed[0]).toMatchObject({ retiredCount: 2 });
+    expect(
+      replayed.slice(1).map((event) => (event as { sequence: number }).sequence),
+    ).toEqual([3, 4]);
+  });
+});

--- a/runtime/tests/eval/trust-conformance-executor.test.ts
+++ b/runtime/tests/eval/trust-conformance-executor.test.ts
@@ -78,21 +78,22 @@ describe("trust-conformance executor", () => {
     // Both directions are regression-sensitive: a runtime regression flips a
     // passed family to failed; a harness bug faking a pass flips a failed
     // family to passed. Either way this assertion goes red.
-    // Baseline updated with the M3 budget reservation kernel: durable
-    // holdId reconciliation made reconciliation_exactly_once genuinely pass,
-    // flipping the budget family (3/7 -> 4/7).
+    // Baseline history: 3/7 -> 4/7 with the M3 budget reservation kernel
+    // (reconciliation_exactly_once), 4/7 -> 5/7 with the M4 event-gap
+    // markers (the multiplexer replay buffer now announces eviction, so
+    // retention_gap_explicit and hidden_event_loss_zero genuinely pass).
     expect(summary.faultFamilyResults).toEqual({
       budget: "passed",
       cancellation: "failed",
-      event_loss: "failed",
+      event_loss: "passed",
       permission: "passed",
       reconnect: "passed",
       restart: "passed",
       uncertain_effect: "failed",
     });
-    expect(summary.passed).toBe(4);
-    expect(summary.failed).toBe(3);
-    expect(summary.trustRecoveryRate).toBeCloseTo(4 / 7, 10);
+    expect(summary.passed).toBe(5);
+    expect(summary.failed).toBe(2);
+    expect(summary.trustRecoveryRate).toBeCloseTo(5 / 7, 10);
   }, 120_000);
 
   it("reports exactly the known capability-gap invariants as failed", async () => {
@@ -109,14 +110,6 @@ describe("trust-conformance executor", () => {
         invariant: "queued_and_running_descendants_cancelled",
       },
       {
-        scenarioId: "event-loss-explicit-retention-gap",
-        invariant: "hidden_event_loss_zero",
-      },
-      {
-        scenarioId: "event-loss-explicit-retention-gap",
-        invariant: "retention_gap_explicit",
-      },
-      {
         scenarioId: "uncertain-effect-lost-acknowledgement",
         invariant: "dependent_mutations_stopped",
       },
@@ -124,7 +117,7 @@ describe("trust-conformance executor", () => {
     expect(summary.zeroTolerance).toEqual({
       policyEscapeCount: 0,
       duplicatedUncertainMutationCount: 0,
-      hiddenEventLossCount: 1,
+      hiddenEventLossCount: 0,
     });
     expect(summary.unknownOutcomeCount).toBe(1);
   }, 120_000);
@@ -188,6 +181,9 @@ describe("trust-conformance executor", () => {
     );
     expect(preserved).not.toContain(
       "trust-budget-sibling-reservation-race-slot0",
+    );
+    expect(preserved).not.toContain(
+      "trust-event-loss-explicit-retention-gap-slot0",
     );
     // wx flags: a rerun into the same output dir must refuse to clobber.
     await expect(


### PR DESCRIPTION
## What

Fixes the silent-transcript-holes bug: the client multiplexer's detached-session replay buffer dropped its oldest events under the count cap / byte budget with no signal, so a reconnecting TUI/SDK client saw a conversation that skips. Eviction is now announced with an in-band gap marker using the frozen Wave-B vocabulary (`EVENT_GAP_EVENT` / `RunEventGap` reason `"retention"`): `{type:"event_gap", sessionId, reason:"retention", retiredCount, source:"multiplexer_retention"}`.

Marker invariants: at most one per session buffer, always at the head, merged (`retiredCount` accumulates) across both count-cap and byte-budget evictions, never itself evicted, exempt from the count capacity, branded against future misclassification of sequence-addressed journal `RunEventGap` events. Verified tolerated by every real consumer (TUI, stdio/websocket transports, SDK, VS Code, portal, mobile paths) — method-less frames are ignored; TUI surfacing of "N events lost" is the natural follow-up.

## Adversarial review outcome

A 3-lens pre-merge review (concurrency, client compatibility, semantics) independently found and repro'd a HIGH: the fully-acked replay cleanup spliced the buffer by **count**, and evictions during the unlocked replay-settle window (marker unshifted/merged at the head) shift the buffer so the splice destroyed the marker plus never-delivered events — silently re-hiding the exact loss this feature announces. Fixed by removing **exactly the delivered events by identity** (the status-replay path's existing pattern), which also mitigates the pre-existing splice-by-count destruction of never-delivered events present on main. The interleaving is pinned by a deterministic regression test (gated sends, detach mid-replay, eviction, release) — proven red under positional splice.

Also from review: the trust harness's `hidden_event_loss_zero` now requires the announced `retiredCount` to **equal** the actual loss (a marker with a wrong count is still hidden loss), and docs scope the claim to session buffers (capability buffers are a follow-up).

## Scoreboard

Trust baseline: **4/7 → 5/7 TRR** — `retention_gap_explicit` and `hidden_event_loss_zero` genuinely pass, pinned both directions in `trust-conformance-executor.test.ts`. Remaining failing families: cancellation (M3 admission/cascade), uncertain-effect (M4 unknown-outcome gate).

## Verification (local, Node v25.9.0, tested SHA 6448f2c79)

- `npm run typecheck` — clean.
- **Full stable suite: 1810/1810 files, 15,589 tests, 0 failures.**
- New `client-multiplexer.event-gap.test.ts`: 7 tests (count-cap merge, byte-budget, oversized-newest, no-eviction, acked-replay reset, unacked-replay retention, mid-replay-eviction race) — 5/6 of the feature tests red against main's multiplexer; the race test red against positional splice specifically.
- All 4 pre-existing multiplexer suites green (byte-budget updated for the announced eviction).
- Pre-commit hook: build + entrypoint/SDK/package-mode checks + PTY/TUI smoke — green.

https://claude.ai/code/session_01FS6MHf68F1H29F7kt5jJyM