### PR TITLE
feat(state): M4 unknown-outcome gate — dependent mutations stop until review (TRR 5/7 → 6/7)

### DIFF
--- a/docs/evaluation-suites-v1.md
+++ b/docs/evaluation-suites-v1.md
@@ -174,12 +174,19 @@ content-addressed summary under `--output` (default
 `eval-executor-output/trust`), refusing to clobber existing evidence. Honest
 invariant failures exit 0 — they are the suite's product; only
 infrastructure-invalid attempts exit 1. The current honest baseline on
-`main` is 5/7 families passing (restart, reconnect, permission, budget — the
-M3 reservation kernel — and event loss: the client multiplexer's SESSION
-replay buffer now announces eviction with in-band `event_gap` markers whose
-retired counts must match the actual loss; capability buffers are a
-follow-up) with cancellation cascade/admission and the unknown-outcome
-dependent-mutation gate failing until the rest of M3/M4 lands. `runtime/tests/eval/trust-conformance-executor.test.ts` pins those
+`main` is 6/7 families passing (restart, reconnect, permission, budget — the
+M3 reservation kernel — event loss: the client multiplexer's SESSION replay
+buffer announces eviction with in-band `event_gap` markers whose retired
+counts must match the actual loss (capability buffers are a follow-up) — and
+uncertain effect: the STATE LAYER refuses to record a new side-effecting
+mutation for a session holding an unresolved `poisoned` effect — a typed
+error until explicit review via
+`agenc state resolve-tool-call <session-id> <tool-call-id>` — and
+review-locks poisoned rows against status/category rewrites. The running
+daemon today only FLAGS violations (its snapshot observer records
+already-dispatched calls); live pre-dispatch refusal is the M3 admission
+kernel's integration of the same `checkUnknownOutcomeMutationGate` check).
+Only cancellation cascade/admission still fails until the M3 kernel lands. `runtime/tests/eval/trust-conformance-executor.test.ts` pins those
 outcomes in both directions: a runtime regression flips a passing family, a
 harness bug faking a pass flips a failing one, and either turns CI red.
 
@@ -310,7 +317,7 @@ qualified until its cold preflights, independent solve, negative-patch review,
 and stressor mechanism evidence exist. The real-agent executor and the
 deterministic trust executor now exist (`eval:executor run-agent-real-batch`
 reproduced the first seed baseline; `eval:executor trust-run` scores the trust
-suite with an honest 5/7 baseline). The remaining work is to implement
+suite with an honest 6/7 baseline). The remaining work is to implement
 comparator adapters, run the paired pilot, freeze the powered private holdout
 under separate custody, publish aggregate reports, and turn measured failures
 into improvements. M3/M4 implementation will make the failing trust scenarios

--- a/runtime/src/bin/state-cli.ts
+++ b/runtime/src/bin/state-cli.ts
@@ -16,10 +16,19 @@ import {
   openStateDatabases,
   type StateSqliteDriver,
 } from "../state/sqlite-driver.js";
+import {
+  listUnresolvedUnknownOutcomeEffects,
+  resolveUnknownOutcomeEffect,
+} from "../state/unknown-outcome-gate.js";
 
 export type AgenCStateCliCommand =
   | { readonly kind: "export"; readonly agentId: string }
   | { readonly kind: "import" }
+  | {
+      readonly kind: "resolve-tool-call";
+      readonly sessionId: string;
+      readonly toolCallId: string;
+    }
   | { readonly kind: "help"; readonly text: string }
   | { readonly kind: "error"; readonly message: string };
 
@@ -42,14 +51,21 @@ export function formatAgenCStateCliHelpText(): string {
   return [
     "Usage: agenc state export <agent-id>",
     "       agenc state import",
+    "       agenc state resolve-tool-call <session-id> <tool-call-id>",
     "",
     "Commands:",
     "  export <agent-id>    Print a JSON state export for one agent",
     "  import               Read a JSON state export from stdin and import it",
+    "  resolve-tool-call <session-id> <tool-call-id>",
+    "                       Review-resolve one unknown-outcome (poisoned) tool",
+    "                       call so the session's side-effecting mutation gate",
+    "                       lifts. Resolution asserts a human verified whether",
+    "                       the effect happened; it never re-runs the tool.",
     "",
     "Examples:",
     "  agenc state export agent_123 > state.json",
     "  agenc state import < state.json",
+    "  agenc state resolve-tool-call session_abc call_42",
   ].join("\n");
 }
 
@@ -87,6 +103,30 @@ export function parseAgenCStateCliArgs(
     }
     return { kind: "import" };
   }
+  if (action === "resolve-tool-call") {
+    const sessionId = argv[2]?.trim();
+    const toolCallId = argv[3]?.trim();
+    if (
+      sessionId === undefined ||
+      sessionId.length === 0 ||
+      toolCallId === undefined ||
+      toolCallId.length === 0
+    ) {
+      return {
+        kind: "error",
+        message:
+          "state resolve-tool-call requires <session-id> and <tool-call-id>",
+      };
+    }
+    if (argv.length > 4) {
+      return {
+        kind: "error",
+        message:
+          "state resolve-tool-call accepts exactly <session-id> <tool-call-id>",
+      };
+    }
+    return { kind: "resolve-tool-call", sessionId, toolCallId };
+  }
   return {
     kind: "error",
     message: `unknown state command: ${action}`,
@@ -110,6 +150,47 @@ export async function runAgenCStateCli(
       return runStateExport(command.agentId, io, options);
     case "import":
       return runStateImport(io, options);
+    case "resolve-tool-call":
+      return runStateResolveToolCall(command, io, options);
+  }
+}
+
+function runStateResolveToolCall(
+  command: { readonly sessionId: string; readonly toolCallId: string },
+  io: AgenCStateCliIo,
+  options: AgenCStateCliOptions,
+): number {
+  try {
+    return withStateDriver(options, (driver) => {
+      const resolved = resolveUnknownOutcomeEffect(driver, {
+        sessionId: command.sessionId,
+        toolCallId: command.toolCallId,
+      });
+      if (!resolved) {
+        const unresolved = listUnresolvedUnknownOutcomeEffects(
+          driver,
+          command.sessionId,
+        );
+        io.stderr.write(
+          `agenc: no unresolved unknown-outcome tool call ${command.toolCallId} in session ${command.sessionId}` +
+            (unresolved.length > 0
+              ? `; unresolved: ${unresolved
+                  .map((effect) => `${effect.toolCallId} (${effect.toolName})`)
+                  .join(", ")}\n`
+              : ` (state databases are project-scoped — run this from the session's project directory)\n`),
+        );
+        return 1;
+      }
+      io.stdout.write(
+        `Resolved unknown-outcome tool call ${command.toolCallId} in session ${command.sessionId}; the side-effecting mutation gate lifts once no unresolved effects remain.\n`,
+      );
+      return 0;
+    });
+  } catch (error) {
+    io.stderr.write(
+      `agenc: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return 1;
   }
 }
 

--- a/runtime/src/eval-executor/trust-run.ts
+++ b/runtime/src/eval-executor/trust-run.ts
@@ -68,6 +68,10 @@ import { recoverDaemonStateOnStartup } from "../state/recovery.js";
 import { upsertAgentRun, updateAgentRunStatus } from "../state/agent-runs.js";
 import { ThreadSpawnEdgeRepository } from "../state/spawn-edges.js";
 import { recordInFlightToolCallStart } from "../state/tool-output-rotation.js";
+import {
+  resolveUnknownOutcomeEffect,
+  UnknownOutcomeMutationBlockedError,
+} from "../state/unknown-outcome-gate.js";
 import { AgenCDaemonClientMultiplexer } from "../app-server/client-multiplexer.js";
 import { AgenCDaemonSessionManager } from "../app-server/session-lifecycle.js";
 import { SessionStore } from "../session/session-store.js";
@@ -1157,26 +1161,69 @@ async function runUncertainEffectLostAcknowledgement(
       resurfaced: secondRecovered?.statusAfter ?? null,
     });
 
-    // dependent_mutations_stopped: drive the seam the frozen contract names
-    // — with an unresolved unknown-outcome effect for this run, a DEPENDENT
-    // mutation must be refused or flagged. No such gate exists today (the
-    // insert succeeds unimpeded), so this invariant honestly FAILS; the
-    // re-surfacing above is recorded as evidence but deliberately NOT
-    // accepted as a substitute for stopping dependent mutations.
-    recordInFlightToolCallStart(driver, {
+    // dependent_mutations_stopped: drive the REAL M4 unknown-outcome gate.
+    // While the poisoned effect is unresolved, recording a NEW
+    // side-effecting mutation in the session must be refused with a typed
+    // error naming the blocking effect; explicit review resolution
+    // (resolveUnknownOutcomeEffect — the `agenc state resolve-tool-call`
+    // seam) must lift the gate. All four legs are required: a gate that
+    // blocks without naming the blocker, or that cannot be lifted by
+    // review, fails the invariant.
+    let blockedWhileUnresolved = false;
+    let blockerNamed = false;
+    try {
+      recordInFlightToolCallStart(driver, {
+        sessionId: "trust-effect-session",
+        agentId: "trust_effect_run",
+        toolCallId: "trust-effect-dependent-1",
+        toolName: "Bash",
+        args: { command: "curl -X POST https://example.invalid/charge-again" },
+        startedAt: nowIso(),
+        recoveryCategory: "side-effecting",
+        agencHome: attemptDir,
+      });
+    } catch (error) {
+      if (error instanceof UnknownOutcomeMutationBlockedError) {
+        blockedWhileUnresolved = true;
+        blockerNamed = error.blocking.some(
+          (effect) => effect.toolCallId === "trust-effect-tool-1",
+        );
+      } else {
+        throw error;
+      }
+    }
+    const resolvedByReview = resolveUnknownOutcomeEffect(driver, {
       sessionId: "trust-effect-session",
-      agentId: "trust_effect_run",
-      toolCallId: "trust-effect-dependent-1",
-      toolName: "Bash",
-      args: { command: "curl -X POST https://example.invalid/charge-again" },
-      startedAt: nowIso(),
-      recoveryCategory: "side-effecting",
-      agencHome: attemptDir,
+      toolCallId: "trust-effect-tool-1",
     });
-    const dependentsStopped = false;
+    let allowedAfterResolve = false;
+    try {
+      recordInFlightToolCallStart(driver, {
+        sessionId: "trust-effect-session",
+        agentId: "trust_effect_run",
+        toolCallId: "trust-effect-dependent-2",
+        toolName: "Bash",
+        args: { command: "echo post-review mutation" },
+        startedAt: nowIso(),
+        recoveryCategory: "side-effecting",
+        agencHome: attemptDir,
+      });
+      allowedAfterResolve = true;
+    } catch {
+      allowedAfterResolve = false;
+    }
+    const dependentsStopped =
+      blockedWhileUnresolved &&
+      blockerNamed &&
+      resolvedByReview &&
+      allowedAfterResolve;
     evidence.record("risk.recorded", {
       toolCallId: "trust-effect-tool-1",
-      risk: "unknown_outcome_unresolved_no_dependent_gate",
+      risk: "unknown_outcome_blocks_dependent_mutations_until_reviewed",
+      blockedWhileUnresolved,
+      blockerNamed,
+      resolvedByReview,
+      allowedAfterResolve,
       resurfacedUntilResolved,
     });
     evidence.record("recovery.assessed", {

--- a/runtime/src/state/recovery.ts
+++ b/runtime/src/state/recovery.ts
@@ -20,6 +20,11 @@ const TERMINAL_TOOL_CALL_STATUSES = [
   "cancelled",
   "poisoned",
   "recovery_cancelled",
+  // Written by explicit review of an unknown-outcome effect
+  // (resolveUnknownOutcomeEffect): terminal AND deliberately absent from
+  // RECOVERY_SURFACE_TOOL_CALL_STATUSES — a resolved effect stops
+  // re-surfacing and the mutation gate lifts.
+  "unknown_resolved",
 ] as const;
 
 const RECOVERY_SURFACE_TOOL_CALL_STATUSES = [

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -446,7 +446,12 @@ export class AgenCSessionSnapshotPolicy {
           status: "running",
         };
         this.#boundInFlightToolCalls(state);
-        recordInFlightToolCallStart(this.#driver, {
+        // "flag" mode: this observer runs AFTER dispatch (it reacts to the
+        // tool_call event), so it cannot refuse the mutation — but a gate
+        // violation must not vanish. It is persisted into the session
+        // snapshot alongside the in-flight entry. Pre-dispatch refusal is
+        // the admission kernel's job (M3), via checkUnknownOutcomeMutationGate.
+        const startOutcome = recordInFlightToolCallStart(this.#driver, {
           sessionId,
           agentId,
           toolCallId: requestId,
@@ -456,7 +461,19 @@ export class AgenCSessionSnapshotPolicy {
           recoveryCategory: toolRecoveryCategoryField(params, "recoveryCategory"),
           agencHome: this.#agencHome,
           outputRotation: this.#outputRotation,
+          unknownOutcomeGate: "flag",
         });
+        if (startOutcome.gateViolation !== undefined) {
+          state.toolState.inFlight[requestId] = {
+            ...state.toolState.inFlight[requestId],
+            unknownOutcomeGateViolation: {
+              blockedBy: startOutcome.gateViolation.blocking.map((effect) => ({
+                toolCallId: effect.toolCallId,
+                toolName: effect.toolName,
+              })),
+            },
+          };
+        }
       }
       return this.#writeSnapshot(state, "tool_call");
     }

--- a/runtime/src/state/tool-output-rotation.ts
+++ b/runtime/src/state/tool-output-rotation.ts
@@ -14,6 +14,11 @@ import { getAgencHomeDir } from "../session/session-store.js";
 import { redactSecrets, redactSecretsInValue } from "../secrets/index.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
+import {
+  checkUnknownOutcomeMutationGate,
+  UnknownOutcomeMutationBlockedError,
+  type UnresolvedUnknownOutcomeEffect,
+} from "./unknown-outcome-gate.js";
 
 export interface ToolOutputRotationPolicy {
   readonly outputPartialMaxBytes?: number;
@@ -37,6 +42,24 @@ export interface InFlightToolCallStartParams {
   readonly recoveryCategory?: ToolRecoveryCategory;
   readonly agencHome?: string;
   readonly outputRotation?: ToolOutputRotationPolicy;
+  /**
+   * Unknown-outcome mutation gate mode (default `"enforce"`). While the
+   * session has unresolved `poisoned` effects, recording a NEW
+   * side-effecting call throws {@link UnknownOutcomeMutationBlockedError}
+   * under `"enforce"`. The daemon's post-dispatch snapshot observer passes
+   * `"flag"` — it records reality (the tool is already running) but the
+   * returned violation is persisted into the session snapshot rather than
+   * silently discarded. `"flag"` is for observers only; admission and
+   * direct writers keep the fail-closed default.
+   */
+  readonly unknownOutcomeGate?: "enforce" | "flag";
+}
+
+export interface InFlightToolCallStartOutcome {
+  /** Present when the gate was violated in `"flag"` mode. */
+  readonly gateViolation?: {
+    readonly blocking: readonly UnresolvedUnknownOutcomeEffect[];
+  };
 }
 
 export interface InFlightToolCallCompletionParams {
@@ -78,7 +101,20 @@ const UTF8_FATAL_DECODER = new TextDecoder("utf-8", { fatal: true });
 export function recordInFlightToolCallStart(
   driver: StateSqliteDriver,
   params: InFlightToolCallStartParams,
-): void {
+): InFlightToolCallStartOutcome {
+  const recoveryCategory = normalizeToolRecoveryCategory(
+    params.recoveryCategory,
+  );
+  const gate = checkUnknownOutcomeMutationGate(driver, {
+    sessionId: params.sessionId,
+    recoveryCategory,
+  });
+  if (!gate.allowed && (params.unknownOutcomeGate ?? "enforce") === "enforce") {
+    throw new UnknownOutcomeMutationBlockedError(
+      params.sessionId,
+      gate.blocking,
+    );
+  }
   const outputLogPath = resolveToolOutputLogPath({
     agencHome: params.agencHome,
     agentId: params.agentId ?? params.sessionId,
@@ -109,7 +145,8 @@ export function recordInFlightToolCallStart(
         output_log_path = excluded.output_log_path,
         output_log_bytes = excluded.output_log_bytes,
         started_at = excluded.started_at,
-        recovery_category = excluded.recovery_category`,
+        recovery_category = excluded.recovery_category
+      WHERE in_flight_tool_calls.status NOT IN ('poisoned', 'unknown_resolved')`,
     )
     .run(
       params.sessionId,
@@ -121,8 +158,9 @@ export function recordInFlightToolCallStart(
       null,
       0,
       params.startedAt,
-      normalizeToolRecoveryCategory(params.recoveryCategory),
+      recoveryCategory,
     );
+  return gate.allowed ? {} : { gateViolation: { blocking: gate.blocking } };
 }
 
 export function recordInFlightToolCallProgress(
@@ -147,6 +185,11 @@ export function recordInFlightToolCallProgress(
     )
     .get(params.sessionId, params.toolCallId);
   if (row === undefined) {
+    // Observer-context backfill for an orphan (already-running) call: like
+    // the snapshot observer it records reality, so the unknown-outcome gate
+    // must flag rather than throw — an enforce throw here would leave the
+    // running call crash-invisible in exactly the sessions already holding
+    // an unresolved effect.
     recordInFlightToolCallStart(driver, {
       sessionId: params.sessionId,
       agentId,
@@ -157,6 +200,7 @@ export function recordInFlightToolCallProgress(
       recoveryCategory: params.recoveryCategory,
       agencHome: params.agencHome,
       outputRotation: params.outputRotation,
+      unknownOutcomeGate: "flag",
     });
     row = {
       output_partial: null,
@@ -184,7 +228,8 @@ export function recordInFlightToolCallProgress(
            output_log_bytes = ?,
            recovery_category = COALESCE(?, recovery_category)
        WHERE session_id = ?
-         AND tool_call_id = ?`,
+         AND tool_call_id = ?
+         AND status NOT IN ('poisoned', 'unknown_resolved')`,
     )
     .run(
       appended.outputPartial,
@@ -214,6 +259,11 @@ export function recordInFlightToolCallCompletion(
     .prepareState<
       [string, string | null, string | null, number, string | null, string, string]
     >(
+      // A poisoned (unknown-outcome) row is review-locked: recovery only
+      // poisons calls whose execution the crash killed, so a "completion"
+      // arriving afterwards is a stale/duplicate/replayed event, not a
+      // trustworthy acknowledgement — it must not silently lift the review
+      // gate. unknown_resolved is terminal by review and equally immutable.
       `UPDATE in_flight_tool_calls
        SET status = ?,
            output_partial = ?,
@@ -221,7 +271,8 @@ export function recordInFlightToolCallCompletion(
            output_log_bytes = ?,
            recovery_category = COALESCE(?, recovery_category)
        WHERE session_id = ?
-         AND tool_call_id = ?`,
+         AND tool_call_id = ?
+         AND status NOT IN ('poisoned', 'unknown_resolved')`,
     )
     .run(
       status,
@@ -235,11 +286,14 @@ export function recordInFlightToolCallCompletion(
       params.toolCallId,
     );
   if (update.changes > 0) return;
+  // OR IGNORE: zero changes can now also mean "row exists but is
+  // review-locked (poisoned/unknown_resolved)" — the completion is dropped
+  // rather than resurrecting or duplicating the locked row.
   driver
     .prepareState<
       [string, string, string, string, string, string | null, string | null, number, string, string]
     >(
-      `INSERT INTO in_flight_tool_calls (
+      `INSERT OR IGNORE INTO in_flight_tool_calls (
         session_id,
         tool_call_id,
         tool_name,

--- a/runtime/src/state/unknown-outcome-gate.ts
+++ b/runtime/src/state/unknown-outcome-gate.ts
@@ -1,0 +1,151 @@
+/**
+ * Unknown-outcome mutation gate (M4, frozen contract run-contracts.ts:
+ * "`unknown_outcome` is terminal-but-unresolved: dependent mutations stop,
+ * review is required, and no automatic replay may occur").
+ *
+ * A `poisoned` in-flight tool call is a side effect whose outcome the daemon
+ * cannot prove (the acknowledgement was lost in a crash window). Until a
+ * reviewer explicitly resolves it, recording a NEW side-effecting tool call
+ * in the same session is refused — the runtime must not stack possibly-
+ * duplicate mutations on top of an unproven one. Idempotent and interactive
+ * calls are not gated: replays are safe by contract and interactive calls
+ * carry their own human in the loop.
+ *
+ * Enforcement points:
+ *   - `recordInFlightToolCallStart` (the durable commit point) enforces the
+ *     gate by default and throws {@link UnknownOutcomeMutationBlockedError}.
+ *   - The daemon's snapshot observer records already-dispatched calls with
+ *     `unknownOutcomeGate: "flag"` — it cannot un-dispatch a running tool,
+ *     so the violation is recorded into the session snapshot instead of
+ *     silently bypassed.
+ *   - `checkUnknownOutcomeMutationGate` is the check the M3 admission
+ *     kernel consults BEFORE dispatching (pre-dispatch integration is M3
+ *     scope; this module is its ready-made dependency).
+ *
+ * Resolution is explicit review, never automatic:
+ * `resolveUnknownOutcomeEffect` (surfaced as
+ * `agenc state resolve-tool-call <session-id> <tool-call-id>`) marks the
+ * effect `unknown_resolved` — terminal, no longer re-surfaced by recovery,
+ * and the gate lifts.
+ */
+
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+import type { ToolRecoveryCategory } from "../tools/types.js";
+
+/** Terminal status written by explicit review of an unknown-outcome effect. */
+export const UNKNOWN_RESOLVED_TOOL_CALL_STATUS = "unknown_resolved" as const;
+
+export interface UnresolvedUnknownOutcomeEffect {
+  readonly sessionId: string;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly startedAt: string;
+}
+
+export type UnknownOutcomeGateDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      readonly blocking: readonly UnresolvedUnknownOutcomeEffect[];
+    };
+
+export class UnknownOutcomeMutationBlockedError extends Error {
+  readonly code = "UNKNOWN_OUTCOME_MUTATION_BLOCKED" as const;
+  readonly sessionId: string;
+  readonly blocking: readonly UnresolvedUnknownOutcomeEffect[];
+
+  constructor(
+    sessionId: string,
+    blocking: readonly UnresolvedUnknownOutcomeEffect[],
+  ) {
+    const summary = blocking
+      .map((effect) => `${effect.toolCallId} (${effect.toolName})`)
+      .join(", ");
+    super(
+      `session ${sessionId} has ${blocking.length} unresolved unknown-outcome ` +
+        `effect(s) [${summary}]; new side-effecting tool calls are blocked ` +
+        `until each is reviewed and resolved with ` +
+        `\`agenc state resolve-tool-call ${sessionId} <tool-call-id>\``,
+    );
+    this.name = "UnknownOutcomeMutationBlockedError";
+    this.sessionId = sessionId;
+    this.blocking = blocking;
+  }
+}
+
+/** Unresolved (poisoned) unknown-outcome effects recorded for a session. */
+export function listUnresolvedUnknownOutcomeEffects(
+  driver: StateSqliteDriver,
+  sessionId: string,
+): readonly UnresolvedUnknownOutcomeEffect[] {
+  return driver
+    .prepareState<
+      [string],
+      {
+        session_id?: string;
+        tool_call_id?: string;
+        tool_name?: string;
+        started_at?: string;
+      }
+    >(
+      `SELECT session_id, tool_call_id, tool_name, started_at
+       FROM in_flight_tool_calls
+       WHERE session_id = ? AND status = 'poisoned'
+       ORDER BY started_at ASC, tool_call_id ASC`,
+    )
+    .all(sessionId)
+    .map((row) => ({
+      sessionId: row.session_id ?? sessionId,
+      toolCallId: row.tool_call_id ?? "",
+      toolName: row.tool_name ?? "",
+      startedAt: row.started_at ?? "",
+    }));
+}
+
+/**
+ * Decide whether a new tool call of `recoveryCategory` may be recorded /
+ * dispatched for `sessionId`. Only side-effecting mutations are gated.
+ * The category must already be normalized (callers use
+ * `normalizeToolRecoveryCategory`); this module deliberately does not
+ * import the normalizer to keep the dependency one-directional.
+ */
+export function checkUnknownOutcomeMutationGate(
+  driver: StateSqliteDriver,
+  options: {
+    readonly sessionId: string;
+    readonly recoveryCategory: ToolRecoveryCategory;
+  },
+): UnknownOutcomeGateDecision {
+  if (options.recoveryCategory !== "side-effecting") return { allowed: true };
+  const blocking = listUnresolvedUnknownOutcomeEffects(
+    driver,
+    options.sessionId,
+  );
+  if (blocking.length === 0) return { allowed: true };
+  return { allowed: false, blocking };
+}
+
+/**
+ * Explicit review resolution: mark one poisoned effect `unknown_resolved`.
+ * Returns true when a poisoned row was resolved; false when no such
+ * unresolved effect exists (already resolved, unknown id, or not poisoned).
+ * Never touches rows in any other status — resolution applies only to
+ * effects that are actually awaiting review.
+ */
+export function resolveUnknownOutcomeEffect(
+  driver: StateSqliteDriver,
+  options: { readonly sessionId: string; readonly toolCallId: string },
+): boolean {
+  const result = driver
+    .prepareState<[string, string, string]>(
+      `UPDATE in_flight_tool_calls
+       SET status = ?
+       WHERE session_id = ? AND tool_call_id = ? AND status = 'poisoned'`,
+    )
+    .run(
+      UNKNOWN_RESOLVED_TOOL_CALL_STATUS,
+      options.sessionId,
+      options.toolCallId,
+    );
+  return result.changes > 0;
+}

--- a/runtime/tests/eval/trust-conformance-executor.test.ts
+++ b/runtime/tests/eval/trust-conformance-executor.test.ts
@@ -80,8 +80,10 @@ describe("trust-conformance executor", () => {
     // family to passed. Either way this assertion goes red.
     // Baseline history: 3/7 -> 4/7 with the M3 budget reservation kernel
     // (reconciliation_exactly_once), 4/7 -> 5/7 with the M4 event-gap
-    // markers (the multiplexer replay buffer now announces eviction, so
-    // retention_gap_explicit and hidden_event_loss_zero genuinely pass).
+    // markers, 5/7 -> 6/7 with the M4 unknown-outcome gate (a session with
+    // an unresolved poisoned effect refuses new side-effecting mutations
+    // until explicit review resolution, so dependent_mutations_stopped
+    // genuinely passes).
     expect(summary.faultFamilyResults).toEqual({
       budget: "passed",
       cancellation: "failed",
@@ -89,11 +91,11 @@ describe("trust-conformance executor", () => {
       permission: "passed",
       reconnect: "passed",
       restart: "passed",
-      uncertain_effect: "failed",
+      uncertain_effect: "passed",
     });
-    expect(summary.passed).toBe(5);
-    expect(summary.failed).toBe(2);
-    expect(summary.trustRecoveryRate).toBeCloseTo(5 / 7, 10);
+    expect(summary.passed).toBe(6);
+    expect(summary.failed).toBe(1);
+    expect(summary.trustRecoveryRate).toBeCloseTo(6 / 7, 10);
   }, 120_000);
 
   it("reports exactly the known capability-gap invariants as failed", async () => {
@@ -108,10 +110,6 @@ describe("trust-conformance executor", () => {
       {
         scenarioId: "cancel-parent-after-child-admission",
         invariant: "queued_and_running_descendants_cancelled",
-      },
-      {
-        scenarioId: "uncertain-effect-lost-acknowledgement",
-        invariant: "dependent_mutations_stopped",
       },
     ]);
     expect(summary.zeroTolerance).toEqual({
@@ -173,18 +171,11 @@ describe("trust-conformance executor", () => {
     expect(summaryDoc.documentDigest).toMatch(/^sha256:/);
     expect(summaryDoc.summary?.total).toBe(7);
     // Failed attempts keep their forensic state (SQLite DBs, ledger, audit);
-    // passing attempts (budget, since the reservation kernel) are cleaned.
+    // passing attempts are cleaned. Only cancellation still fails.
     const preserved = readdirSync(path.join(outputDir, "attempts"));
-    expect(preserved).toContain("trust-cancel-parent-after-child-admission-slot0");
-    expect(preserved).toContain(
-      "trust-uncertain-effect-lost-acknowledgement-slot0",
-    );
-    expect(preserved).not.toContain(
-      "trust-budget-sibling-reservation-race-slot0",
-    );
-    expect(preserved).not.toContain(
-      "trust-event-loss-explicit-retention-gap-slot0",
-    );
+    expect(preserved).toEqual([
+      "trust-cancel-parent-after-child-admission-slot0",
+    ]);
     // wx flags: a rerun into the same output dir must refuse to clobber.
     await expect(
       runTrustSuiteFromFiles({

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -6,8 +6,10 @@ import { AgenCSessionSnapshotPolicy } from "./snapshot-policy.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
 import {
   readRotatedToolOutputLog,
+  recordInFlightToolCallStart,
   resolveToolOutputLogPath,
 } from "./tool-output-rotation.js";
+import { recoverDaemonStateOnStartup } from "./recovery.js";
 
 let home = "";
 let cwd = "";
@@ -741,6 +743,56 @@ describe("AgenCSessionSnapshotPolicy", () => {
     expect(runLastSnapshotAt("run-retention")).toBe(
       "2026-05-01T00:00:02.000Z",
     );
+  });
+});
+
+describe("unknown-outcome gate violations in snapshots", () => {
+  it("persists (and round-trips) the flag-mode violation for a poisoned session", () => {
+    seedRun("run-gate", "session-gate");
+    // Crash-poison a side-effecting call through real recovery.
+    recordInFlightToolCallStart(driver, {
+      sessionId: "session-gate",
+      agentId: "run-gate",
+      toolCallId: "tool-poisoned",
+      toolName: "Bash",
+      args: { command: "curl -X POST https://example.invalid/charge" },
+      startedAt: "2026-05-01T00:00:00.000Z",
+      recoveryCategory: "side-effecting",
+      agencHome: home,
+    });
+    recoverDaemonStateOnStartup(driver);
+    // The observer records a NEW already-dispatched side-effecting call:
+    // flag mode must record it AND persist the violation into the snapshot.
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:01.000Z",
+      agencHome: home,
+    });
+    policy.recordSessionEvent("session-gate", {
+      method: "event.tool_request",
+      params: {
+        eventId: "event-gate-1",
+        requestId: "tool-dependent",
+        toolName: "Bash",
+        recoveryCategory: "side-effecting",
+        input: { command: "echo dependent" },
+      },
+    });
+    const inFlight = latestSnapshot("session-gate").toolState as {
+      inFlight: Record<string, Record<string, unknown>>;
+    };
+    expect(
+      inFlight.inFlight["tool-dependent"]?.unknownOutcomeGateViolation,
+    ).toEqual({
+      blockedBy: [{ toolCallId: "tool-poisoned", toolName: "Bash" }],
+    });
+    // The dependent call itself was still recorded (observer never loses
+    // bookkeeping).
+    const row = driver
+      .prepareState<[string], { status?: string }>(
+        "SELECT status FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .get("tool-dependent");
+    expect(row).toEqual({ status: "running" });
   });
 });
 

--- a/runtime/tests/state/unknown-outcome-gate.test.ts
+++ b/runtime/tests/state/unknown-outcome-gate.test.ts
@@ -1,0 +1,330 @@
+// M4 unknown-outcome mutation gate: while a session holds an unresolved
+// poisoned (unknown-outcome) effect, recording a NEW side-effecting tool
+// call is refused with a typed error until a reviewer explicitly resolves
+// the effect. Idempotent/interactive calls and other sessions stay
+// unaffected; the daemon's post-dispatch snapshot observer uses "flag"
+// mode, which records reality but surfaces the violation.
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  recordInFlightToolCallCompletion,
+  recordInFlightToolCallProgress,
+  recordInFlightToolCallStart,
+} from "../../src/state/tool-output-rotation.js";
+import {
+  checkUnknownOutcomeMutationGate,
+  listUnresolvedUnknownOutcomeEffects,
+  resolveUnknownOutcomeEffect,
+  UnknownOutcomeMutationBlockedError,
+} from "../../src/state/unknown-outcome-gate.js";
+import { recoverDaemonStateOnStartup } from "../../src/state/recovery.js";
+import {
+  parseAgenCStateCliArgs,
+  runAgenCStateCli,
+} from "../../src/bin/state-cli.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+
+let home: string;
+let cwd: string;
+let driver: StateSqliteDriver;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-unknown-outcome-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-unknown-outcome-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome: home });
+});
+
+afterEach(() => {
+  driver.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function startCall(options: {
+  sessionId?: string;
+  toolCallId: string;
+  recoveryCategory?: "idempotent" | "side-effecting" | "interactive";
+  unknownOutcomeGate?: "enforce" | "flag";
+}) {
+  return recordInFlightToolCallStart(driver, {
+    sessionId: options.sessionId ?? "session_gate",
+    agentId: "agent_gate",
+    toolCallId: options.toolCallId,
+    toolName: "Bash",
+    args: { command: "echo probe" },
+    startedAt: new Date(0).toISOString(),
+    recoveryCategory: options.recoveryCategory ?? "side-effecting",
+    agencHome: home,
+    ...(options.unknownOutcomeGate !== undefined
+      ? { unknownOutcomeGate: options.unknownOutcomeGate }
+      : {}),
+  });
+}
+
+/** Crash the in-flight side-effecting call into poisoned via real recovery. */
+function poisonCall(toolCallId: string, sessionId = "session_gate"): void {
+  startCall({ sessionId, toolCallId });
+  const report = recoverDaemonStateOnStartup(driver);
+  const recovered = report.recoveredToolCalls.find(
+    (call) => call.toolCallId === toolCallId,
+  );
+  expect(recovered?.statusAfter).toBe("poisoned");
+}
+
+describe("unknown-outcome mutation gate", () => {
+  it("blocks a new side-effecting call while a poisoned effect is unresolved", () => {
+    poisonCall("call_poisoned");
+    expect(() => startCall({ toolCallId: "call_dependent" })).toThrow(
+      UnknownOutcomeMutationBlockedError,
+    );
+    try {
+      startCall({ toolCallId: "call_dependent" });
+      expect.unreachable("gate must throw");
+    } catch (error) {
+      const blocked = error as UnknownOutcomeMutationBlockedError;
+      expect(blocked.code).toBe("UNKNOWN_OUTCOME_MUTATION_BLOCKED");
+      expect(blocked.sessionId).toBe("session_gate");
+      expect(blocked.blocking.map((effect) => effect.toolCallId)).toEqual([
+        "call_poisoned",
+      ]);
+      expect(blocked.message).toContain("agenc state resolve-tool-call");
+    }
+    // The refused call was never recorded.
+    const rows = driver
+      .prepareState<[string], { tool_call_id?: string }>(
+        "SELECT tool_call_id FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .all("call_dependent");
+    expect(rows).toHaveLength(0);
+  });
+
+  it("does not gate idempotent or interactive calls, or other sessions", () => {
+    poisonCall("call_poisoned");
+    expect(() =>
+      startCall({ toolCallId: "call_read", recoveryCategory: "idempotent" }),
+    ).not.toThrow();
+    expect(() =>
+      startCall({ toolCallId: "call_ask", recoveryCategory: "interactive" }),
+    ).not.toThrow();
+    expect(() =>
+      startCall({ sessionId: "session_other", toolCallId: "call_elsewhere" }),
+    ).not.toThrow();
+  });
+
+  it("explicit review resolution lifts the gate and stops recovery re-surfacing", () => {
+    poisonCall("call_poisoned");
+    expect(
+      resolveUnknownOutcomeEffect(driver, {
+        sessionId: "session_gate",
+        toolCallId: "call_poisoned",
+      }),
+    ).toBe(true);
+    expect(listUnresolvedUnknownOutcomeEffects(driver, "session_gate")).toEqual(
+      [],
+    );
+    expect(() => startCall({ toolCallId: "call_after_review" })).not.toThrow();
+    // unknown_resolved is terminal and NOT re-surfaced, and it must not be
+    // re-poisoned by a later recovery pass. (call_after_review is running
+    // and will itself be poisoned by this pass — expected.)
+    const report = recoverDaemonStateOnStartup(driver);
+    expect(
+      report.recoveredToolCalls.some(
+        (call) => call.toolCallId === "call_poisoned",
+      ),
+    ).toBe(false);
+    // Resolving twice (or resolving a non-poisoned call) is a no-op.
+    expect(
+      resolveUnknownOutcomeEffect(driver, {
+        sessionId: "session_gate",
+        toolCallId: "call_poisoned",
+      }),
+    ).toBe(false);
+    expect(
+      resolveUnknownOutcomeEffect(driver, {
+        sessionId: "session_gate",
+        toolCallId: "call_never_existed",
+      }),
+    ).toBe(false);
+  });
+
+  it("flag mode records the already-dispatched call and returns the violation", () => {
+    poisonCall("call_poisoned");
+    const outcome = startCall({
+      toolCallId: "call_observed",
+      unknownOutcomeGate: "flag",
+    });
+    expect(outcome.gateViolation).toBeDefined();
+    expect(
+      outcome.gateViolation!.blocking.map((effect) => effect.toolCallId),
+    ).toEqual(["call_poisoned"]);
+    // Reality was recorded — the observer never loses bookkeeping.
+    const rows = driver
+      .prepareState<[string], { status?: string }>(
+        "SELECT status FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .all("call_observed");
+    expect(rows).toEqual([{ status: "running" }]);
+    // A clean session in flag mode reports no violation.
+    const clean = startCall({
+      sessionId: "session_clean",
+      toolCallId: "call_clean",
+      unknownOutcomeGate: "flag",
+    });
+    expect(clean.gateViolation).toBeUndefined();
+  });
+
+  it("agenc state resolve-tool-call resolves via the CLI surface", async () => {
+    poisonCall("call_poisoned");
+    const out: string[] = [];
+    const err: string[] = [];
+    const io = {
+      stdout: { write: (text: string) => (out.push(text), true) },
+      stderr: { write: (text: string) => (err.push(text), true) },
+    };
+    const command = parseAgenCStateCliArgs([
+      "state",
+      "resolve-tool-call",
+      "session_gate",
+      "call_poisoned",
+    ]);
+    expect(command).toEqual({
+      kind: "resolve-tool-call",
+      sessionId: "session_gate",
+      toolCallId: "call_poisoned",
+    });
+    expect(await runAgenCStateCli(command!, { driver, io })).toBe(0);
+    expect(out.join("")).toContain("Resolved unknown-outcome tool call");
+    expect(() => startCall({ toolCallId: "call_after_cli" })).not.toThrow();
+    // Unknown/already-resolved ids fail with the unresolved listing.
+    expect(await runAgenCStateCli(command!, { driver, io })).toBe(1);
+    expect(err.join("")).toContain("no unresolved unknown-outcome tool call");
+    // Missing args are a parse error.
+    expect(
+      parseAgenCStateCliArgs(["state", "resolve-tool-call", "session_gate"]),
+    ).toMatchObject({ kind: "error" });
+  });
+
+  it("a poisoned row is review-locked: same-id re-records cannot launder it", () => {
+    poisonCall("call_poisoned");
+    // Attack 1 (flag mode): a duplicate/replayed tool_request carrying the
+    // poisoned row's own id reaches the observer. The upsert must NOT flip
+    // the row back to running (which would lift the gate with no review).
+    startCall({ toolCallId: "call_poisoned", unknownOutcomeGate: "flag" });
+    expect(
+      listUnresolvedUnknownOutcomeEffects(driver, "session_gate").map(
+        (effect) => effect.toolCallId,
+      ),
+    ).toEqual(["call_poisoned"]);
+    // Attack 2 (idempotent relabel): a same-id re-record claiming
+    // "idempotent" passes the category gate but must not rewrite the
+    // poisoned row's status/category — otherwise the next recovery would
+    // AUTO-REPLAY a possibly-executed side effect.
+    startCall({
+      toolCallId: "call_poisoned",
+      recoveryCategory: "idempotent",
+      unknownOutcomeGate: "flag",
+    });
+    const row = driver
+      .prepareState<[string], { status?: string; recovery_category?: string }>(
+        "SELECT status, recovery_category FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .get("call_poisoned");
+    expect(row).toEqual({
+      status: "poisoned",
+      recovery_category: "side-effecting",
+    });
+    const report = recoverDaemonStateOnStartup(driver);
+    const surfaced = report.recoveredToolCalls.find(
+      (call) => call.toolCallId === "call_poisoned",
+    );
+    expect(surfaced?.recoveryAction).not.toBe("replay");
+  });
+
+  it("a stale completion or progress event cannot lift the review lock", () => {
+    poisonCall("call_poisoned");
+    // Post-recovery "completion" for a call whose execution the crash
+    // killed is a stale/replayed event — it must not resolve the effect.
+    recordInFlightToolCallCompletion(driver, {
+      sessionId: "session_gate",
+      agentId: "agent_gate",
+      toolCallId: "call_poisoned",
+      result: "late ack",
+      isError: false,
+      completedAt: new Date(1).toISOString(),
+      agencHome: home,
+    });
+    expect(
+      listUnresolvedUnknownOutcomeEffects(driver, "session_gate").map(
+        (effect) => effect.toolCallId,
+      ),
+    ).toEqual(["call_poisoned"]);
+    // A progress event must neither rewrite the locked row's category nor
+    // throw out of the observer backfill path in a poisoned session.
+    expect(() =>
+      recordInFlightToolCallProgress(driver, {
+        sessionId: "session_gate",
+        agentId: "agent_gate",
+        toolCallId: "call_poisoned",
+        chunk: "late chunk",
+        observedAt: new Date(2).toISOString(),
+        recoveryCategory: "idempotent",
+        agencHome: home,
+      }),
+    ).not.toThrow();
+    const row = driver
+      .prepareState<[string], { status?: string; recovery_category?: string }>(
+        "SELECT status, recovery_category FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .get("call_poisoned");
+    expect(row).toEqual({
+      status: "poisoned",
+      recovery_category: "side-effecting",
+    });
+  });
+
+  it("the progress backfill for an orphan call flags instead of throwing in a poisoned session", () => {
+    poisonCall("call_poisoned");
+    // An orphan side-effecting call (progress before any recorded start)
+    // must still become crash-durable — the observer-context backfill flags
+    // the violation rather than refusing bookkeeping.
+    expect(() =>
+      recordInFlightToolCallProgress(driver, {
+        sessionId: "session_gate",
+        agentId: "agent_gate",
+        toolCallId: "call_orphan",
+        chunk: "output",
+        observedAt: new Date(3).toISOString(),
+        agencHome: home,
+      }),
+    ).not.toThrow();
+    const rows = driver
+      .prepareState<[string], { status?: string }>(
+        "SELECT status FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .all("call_orphan");
+    expect(rows).toEqual([{ status: "running" }]);
+  });
+
+  it("the gate decision function is consultable pre-dispatch (M3 admission seam)", () => {
+    poisonCall("call_poisoned");
+    expect(
+      checkUnknownOutcomeMutationGate(driver, {
+        sessionId: "session_gate",
+        recoveryCategory: "side-effecting",
+      }),
+    ).toMatchObject({ allowed: false });
+    expect(
+      checkUnknownOutcomeMutationGate(driver, {
+        sessionId: "session_gate",
+        recoveryCategory: "idempotent",
+      }),
+    ).toEqual({ allowed: true });
+  });
+});


### PR DESCRIPTION
## What

Implements the frozen contract's `unknown_outcome` semantics at the durable effect seam: while a session holds an unresolved `poisoned` effect (a side effect whose acknowledgement a crash destroyed), the state layer **refuses to record a new side-effecting mutation** — a typed `UnknownOutcomeMutationBlockedError` naming every blocking effect and the resolution command — until a reviewer explicitly resolves it with `agenc state resolve-tool-call <session-id> <tool-call-id>` (`poisoned → unknown_resolved`, terminal, no longer re-surfaced).

**Enforcement scope, stated precisely**: `checkUnknownOutcomeMutationGate` is the check the M3 admission kernel will consult pre-dispatch; `recordInFlightToolCallStart` enforces it by default for direct writers. The running daemon today only **flags** — its post-dispatch snapshot observer (and the progress backfill) record already-dispatched reality with the violation persisted into the session snapshot (round-trip tested). No live session can be blocked or bricked by this change.

## Adversarial review outcome (3 lenses, all holes confirmed with runnable probes, all fixed)

- **Review-lock**: poisoned/`unknown_resolved` rows are now immutable to everything except explicit review. Before the fix: a same-id re-record **laundered** `poisoned → running` through the `ON CONFLICT` upsert (lifting the gate with no review), an idempotent-relabel re-record rewrote the category so the next recovery would **auto-replay a possibly-executed side effect**, and a stale post-recovery completion silently resolved the uncertainty. All three are pinned by regression tests proven red against the unfixed source.
- **Backfill leak**: the progress-event lazy-start inherited enforce mode and threw inside the observer for orphan calls in poisoned sessions — defeating crash-durability exactly where it matters. Now flags.
- **Right-reason verdict**: pass is honest at the declared seam (same probe that honestly failed before, four required legs, real recovery poisons the row); docs reworded so the live-daemon flag-only scope is explicit.

## Scoreboard

**5/7 → 6/7 TRR.** `dependent_mutations_stopped` passes via: blocked while unresolved + blocker named + resolved by review + allowed after. Only cancellation (M3 admission/cascade) remains.

## Verification (local, Node v25.9.0, tested SHA b21fa0fd5)

- `npm run typecheck` clean; **full stable suite 1811/1811 files, 15,599 tests, 0 failures**.
- New gate suite: 9 tests (block/allow/lift/cross-session/flag/CLI/review-lock×2/orphan-backfill) — revert-sensitive both for the gate (7 red pre-feature) and the review-lock fixes (4 red pre-fix).
- Snapshot round-trip test for the persisted violation; state-cli contract suite green with the new command.
- Pre-commit hook: build + entrypoint/SDK/package-mode + PTY/TUI smoke — green.

https://claude.ai/code/session_01FS6MHf68F1H29F7kt5jJyM