### PR TITLE
feat(state): M3 tree-scoped run.cancel cascade + spawn admission gate — TRR 7/7

### DIFF
--- a/docs/design/run-cancel-cascade-and-spawn-admission.md
+++ b/docs/design/run-cancel-cascade-and-spawn-admission.md
@@ -1,0 +1,215 @@
+# run.cancel cascade + spawn admission gate (M3 final slice)
+
+Status: DESIGN — implements the last red trust-conformance family
+(`cancel-parent-after-child-admission`: `descendant_admission_stopped`,
+`queued_and_running_descendants_cancelled`). Builds against the frozen
+Wave-B contract (`runtime/src/contracts/run-contracts.ts`,
+`docs/design/shared-run-contracts-v1.md`); the reserved method name
+`run.cancel` ("Tree-scoped cancel: parent + queued + running descendants")
+and the `allow | queue | deny | approval_required` admission vocabulary are
+binding. Extends existing seams; no second engine.
+
+## 1. The gap (verified against main @ 65c2d457f)
+
+- No production path writes `agent_runs.status = 'cancelled'`; the sole
+  production status writer is `recordAgentStatusTransition` →
+  `updateAgentRunStatus` (`state/snapshot-policy.ts:369`,
+  `agentRunStatusForTransition` has no `cancelled` arm).
+- The live interrupt cascade exists (`agents/control.ts:913` `interrupt`
+  recurses over `descendantsOf`; `background-agent-runner.ts:1977`
+  `interruptAgentTurn` cascades over `openThreadSpawnChildren`) but is
+  in-memory only and `interrupted` is deliberately non-final. Nothing
+  durable cascades; a crash forgets the cancel ever happened below the
+  parent row.
+- Startup recovery resurrects survivors: `loadRecoverableAgentRuns`
+  (`state/recovery.ts:156`) selects non-terminal runs FLAT — it never joins
+  `thread_spawn_edges` or checks ancestor status, and the restore loop
+  (`daemon-cli.ts:2455` `hydrateAgenCDaemonStartupRecovery`) calls
+  `restoreAgent` per run with no parent-cancelled guard.
+- Nothing refuses new admission under a cancelled parent. The durable
+  admission commit point for the spawn tree is
+  `ThreadSpawnEdgeRepository.create` (`state/spawn-edges.ts:34`) — the
+  production spawn path commits through it
+  (`control.ts:1789 persistThreadSpawnEdgeForSource` →
+  `rollout-store.ts:152 createThreadSpawnEdge` → the SQLite repo; the JSON
+  file is legacy-import-only since `loadThreadSpawnEdges`).
+- `run.cancel` is absent from `AGENC_DAEMON_METHODS` and the dispatcher.
+
+## 2. Design
+
+### 2.1 New state module: `runtime/src/state/run-cancellation.ts`
+
+Pattern-follows `state/unknown-outcome-gate.ts` (fail-closed check + typed
+`*BlockedError` with a `code` literal at the durable commit point; `"flag"`
+style opt-outs only where a caller demonstrably cannot refuse).
+
+Vocabulary:
+
+- `CANCEL_LOCKED_AGENT_RUN_STATUSES = ["cancelled", "unknown_outcome"]` —
+  the review/cancel-locked statuses. NOT all terminal statuses: a
+  `completed` background agent is legitimately revived by a follow-up
+  message (the snapshot writer always records `running`,
+  `agent-lifecycle.ts:2048`), so blanket terminal-stickiness would break a
+  real flow. `cancelled` is an explicit human decision; `unknown_outcome`
+  is review-locked by M4 semantics. Both are sticky.
+
+API:
+
+- `checkSpawnAdmissionGate(driver, { parentThreadId }): SpawnAdmissionDecision`
+  — resolves the nearest ancestor that has an `agent_runs` row: first
+  `parentThreadId` itself, else walk UP `thread_spawn_edges`
+  (`child_thread_id → parent_thread_id`, edges of ANY status — a closed
+  edge still defines ancestry) with a cycle guard and depth bound. If that
+  ancestor's status is cancel-locked → `{ allowed: false, decision: "deny",
+  reason: "parent_cancel_locked", parentRunId, parentStatus }` (reason is a
+  machine-readable member of the frozen `AdmissionDecision` shape, not
+  prose). No run row anywhere up the chain → allowed (nothing durable to
+  gate on).
+- `class SpawnAdmissionBlockedError extends Error` — `code =
+  "SPAWN_ADMISSION_BLOCKED"`, carries `childThreadId`, `parentRunId`,
+  `parentStatus`; message names the refused child, the cancel-locked
+  ancestor, and that the refusal maps to admission decision `deny`.
+- `cancelAgentRunTree(driver, { runId, reason, cancelledAt }):
+  CancelAgentRunTreeReport` — ONE SQLite transaction:
+  1. Subtree = `runId` + BFS over `thread_spawn_edges` (any edge status;
+     cycle-guarded).
+  2. Every subtree run whose status is non-terminal
+     (`pending/running/working/paused/blocked/suspended`) → status
+     `cancelled`, `last_active_at = cancelledAt`, metadata patch
+     `{ cancelReason, cancelledBy: runId, cancelledAt }`. Already-terminal
+     descendants keep their status — cancellation never rewrites history
+     (a `completed` child stays `completed`).
+  3. Every OPEN subtree edge → `closed` (existing CAS `setStatus`).
+  4. `in_flight_tool_calls` rows are NOT touched — partial evidence is
+     preserved; startup recovery later classifies them by the existing
+     category rules (side-effecting → `poisoned`, i.e. evidence retained
+     and review-gated, which is exactly the M4 semantics).
+  Report: `{ rootStatusBefore, cancelledRunIds, priorStatusById,
+  closedEdgeChildIds, alreadyTerminal, missing }`. Idempotent: cancelling
+  an already-cancelled tree returns `alreadyTerminal: true` and mutates
+  nothing. Unknown `runId` → `missing: true`, no throw (the daemon layer
+  maps it to a typed RPC error).
+- `repairCancelledSubtrees(driver, { now }): RepairReport` — recovery
+  interplay (crash-mid-cascade): find every non-terminal run whose ancestor
+  chain (via edges, any status) contains a `cancelled` run, and complete
+  the cascade on it (same write shape, `cancelReason:
+  "recovery_cascade_repair"`). Scoped to `cancelled` ancestors only —
+  descendants of a merely `completed`/`errored` parent are legitimate
+  survivors and stay recoverable.
+
+### 2.2 Enforcement at the durable seams (non-bypassable)
+
+- `ThreadSpawnEdgeRepository.create(edge, opts?)` consults
+  `checkSpawnAdmissionGate` on `edge.parentThreadId` inside the repo and
+  throws `SpawnAdmissionBlockedError` on refusal. Default mode `"enforce"`;
+  `opts.admissionGate: "import"` skips the check ONLY for the two
+  historical-topology writers, which are not admissions: the legacy JSON
+  import (`rollout-store.ts loadThreadSpawnEdges`) and
+  `state/export-import.ts` import. Same shape as
+  `recordInFlightToolCallStart`'s `unknownOutcomeGate: "enforce" | "flag"`.
+- `updateAgentRunStatus` gains cancel-lock stickiness: if the existing
+  status is cancel-locked and the incoming status differs, the write is a
+  guarded no-op returning `{ applied: false, reason:
+  "cancel_locked_status_sticky", existingStatus }` (return type goes from
+  `void` to a report — existing callers that ignore the return keep
+  compiling). Same-status writes still land (metadata patches on the
+  terminal record, e.g. recording a cancel reason twice, stay possible).
+  No-op instead of throw because the sole production caller is the
+  post-hoc snapshot observer relaying status from a dying agent — it
+  cannot un-die the agent; a late `errored` after `cancelled` must lose
+  silently, mirroring the observer "flag" rationale.
+- `upsertAgentRun` gains the same stickiness: existing cancel-locked row +
+  different incoming status → whole write skipped, `{ applied: false }`.
+  This closes the upsert-laundering hole (the same hole #1541 closed for
+  poisoned tool rows).
+- `recoverDaemonStateOnStartup` runs `repairCancelledSubtrees` inside its
+  existing transaction BEFORE `loadRecoverableAgentRuns`, so a
+  crash-orphaned descendant of a cancelled parent is finished off rather
+  than resurrected, and the restore loop never sees it.
+- `agentRunStatusForTransition` (`snapshot-policy.ts:1051`) gains a
+  `cancelled` passthrough arm so the production transition writer can
+  relay a cancel-shaped transition if one ever reaches it (stickiness
+  still guarantees it cannot revive).
+
+### 2.3 Daemon method `run.cancel`
+
+Frozen name, standard 10-step wiring (pattern: `session.applyConfig`):
+`AGENC_DAEMON_METHODS` + descriptor + `RunCancelParams { runId, reason? }`
+/ `RunCancelResult` + `AgenCDaemonResultByMethod` + capability entry
+(`hasMethod(agentManager, "cancelRunTree")`) + dispatcher `Pick` allowlist
++ validator + dispatch case + `agent-lifecycle.ts` manager method + runner
+seam + schema.json mirror + CLI/SDK stubs.
+
+Handler flow (manager `cancelRunTree`):
+
+1. **Durable first**: `cancelAgentRunTree` on the state DB. The durable
+   record is the authority; if the daemon dies after this step, recovery
+   repair finishes the job. Unknown run → typed `RUN_NOT_FOUND`-style RPC
+   error; `alreadyTerminal` → success result with `alreadyTerminal: true`
+   (idempotent).
+2. **Live propagation second**, reusing the contract-mandated primitive:
+   for each live agent in the subtree, the existing
+   `control.interrupt`/`interruptAgentTurn` cascade + `stopAgent` on the
+   root. Late status writes from dying agents are absorbed by stickiness
+   (`cancelled` wins, always).
+3. **Void reservations**: new additive `BudgetLedger.voidHoldsForAgent(
+   agentId): number` — deletes OPEN holds for that agent under the
+   existing disk lock WITHOUT touching spend/pause (unlike operator
+   `reset`). Called for every cancelled run id; total reported as
+   `voidedHolds`. This is the frozen `voided` resolution ("work cancelled
+   before any charge; full refund"). Cross-store atomicity with SQLite is
+   impossible (ledger is a file); ordering durable-cancel → void is safe
+   because an unvoided hold of a cancelled run only over-reserves (fails
+   closed) until voided, never under-reserves.
+
+Result: `{ runId, alreadyTerminal, cancelledRunIds, closedEdges,
+interruptedLive, voidedHolds }`.
+
+### 2.4 Trust-driver rewrite (`eval-executor/trust-run.ts`)
+
+`runCancelParentAfterChildAdmission` stops injecting the fault as a bare
+status write and drives the REAL primitives:
+
+- cancel_parent → `cancelAgentRunTree` (the production cascade seam).
+- `queued_and_running_descendants_cancelled` → read back both children's
+  statuses (`pending` child exercises the queued half, `running` child the
+  running half).
+- `descendant_admission_stopped` → attempt a late child admission through
+  the gated seams (`upsertAgentRun` of the child + `edges.create` under
+  the cancelled parent); PASS only if `edges.create` throws
+  `SpawnAdmissionBlockedError` (typed check — any other throw is rethrown
+  as infrastructure error, exactly the current honest-probe rule) AND no
+  edge row exists afterwards. Also probe resurrection: `upsertAgentRun`
+  flipping the cancelled parent back to `running` must be a no-op.
+- `partial_evidence_preserved` → unchanged (in-flight row still present).
+- Test `runtime/tests/eval/trust-conformance-executor.test.ts` flips the
+  pinned cancellation-family outcome to `passed` (both directions pinned,
+  revert-sensitivity proven by stashing the state-layer change).
+
+Expected scoreboard: TRR 7/7.
+
+## 3. Explicitly out of scope (follow-ups)
+
+- Pre-dispatch `BudgetEnforcer.admit({ kind: "spawn" })` wiring at
+  `AgentControl.spawn` and `checkUnknownOutcomeMutationGate` pre-dispatch
+  consultation (the admission-kernel consolidation; this slice adds the
+  durable deny seam it will sit on).
+- `run.status` / `run.result` / `run.replay` / `run.evidence` (M4/M5).
+- A production `pending → running` promoter (no production writer emits
+  `pending` today).
+- Gating the legacy JSON edge file itself (import-only; the SQLite repo is
+  the durable authority).
+
+## 4. Risks
+
+- **Legitimate revival flows**: mitigated by locking only
+  `cancelled`/`unknown_outcome`, never `completed`/`errored`/`stopped`.
+- **Shared project DB, multiple daemons**: cascade and repair run in
+  SQLite transactions; edge-close uses the existing CAS; stickiness makes
+  concurrent late writers converge on `cancelled`.
+- **Ancestor walk cost**: gate walk is depth-bounded (existing spawn depth
+  cap) and hits the `parent_thread_id` index; repair sweep runs once per
+  startup inside the existing recovery transaction.
+- **False refusal on unrelated trees**: gate only consults the ancestor
+  chain of the specific parent; runs with no `agent_runs` ancestor are
+  never refused.

--- a/docs/design/run-cancel-cascade-and-spawn-admission.md
+++ b/docs/design/run-cancel-cascade-and-spawn-admission.md
@@ -56,15 +56,17 @@ Vocabulary:
 API:
 
 - `checkSpawnAdmissionGate(driver, { parentThreadId }): SpawnAdmissionDecision`
-  — resolves the nearest ancestor that has an `agent_runs` row: first
-  `parentThreadId` itself, else walk UP `thread_spawn_edges`
-  (`child_thread_id → parent_thread_id`, edges of ANY status — a closed
-  edge still defines ancestry) with a cycle guard and depth bound. If that
-  ancestor's status is cancel-locked → `{ allowed: false, decision: "deny",
-  reason: "parent_cancel_locked", parentRunId, parentStatus }` (reason is a
-  machine-readable member of the frozen `AdmissionDecision` shape, not
-  prose). No run row anywhere up the chain → allowed (nothing durable to
-  gate on).
+  — walks the ENTIRE ancestor chain from `parentThreadId` (inclusive) UP
+  `thread_spawn_edges` (`child_thread_id → parent_thread_id`, edges of ANY
+  status — a closed edge still defines ancestry) with a cycle guard and
+  depth bound. If ANY ancestor with an `agent_runs` row is cancel-locked →
+  `{ allowed: false, decision: "deny", reason: "parent_cancel_locked",
+  parentRunId, parentStatus }` (reason is a machine-readable member of the
+  frozen `AdmissionDecision` shape, not prose). The walk deliberately does
+  NOT stop at the first run row found: a terminal-but-revivable
+  intermediate (a `completed` child of a cancelled root) must not shield
+  admissions below it. No cancel-locked row anywhere up the chain →
+  allowed.
 - `class SpawnAdmissionBlockedError extends Error` — `code =
   "SPAWN_ADMISSION_BLOCKED"`, carries `childThreadId`, `parentRunId`,
   `parentStatus`; message names the refused child, the cancel-locked
@@ -89,24 +91,35 @@ API:
   an already-cancelled tree returns `alreadyTerminal: true` and mutates
   nothing. Unknown `runId` → `missing: true`, no throw (the daemon layer
   maps it to a typed RPC error).
-- `repairCancelledSubtrees(driver, { now }): RepairReport` — recovery
-  interplay (crash-mid-cascade): find every non-terminal run whose ancestor
-  chain (via edges, any status) contains a `cancelled` run, and complete
-  the cascade on it (same write shape, `cancelReason:
-  "recovery_cascade_repair"`). Scoped to `cancelled` ancestors only —
-  descendants of a merely `completed`/`errored` parent are legitimate
-  survivors and stay recoverable.
+- `repairCancelledSubtrees(driver, { now }): RepairReport` — ONE-SHOT
+  recovery interplay. `cancelAgentRunTree` is a single transaction and
+  stamps `cascadeComplete: true` in the root's metadata, so
+  cascade-cancelled trees are never re-examined. Repair targets only
+  cancelled roots WITHOUT the stamp (a root cancelled by a non-cascade
+  writer, e.g. a relayed status transition): their surviving non-terminal
+  descendants are finished off once (`cancelReason:
+  "recovery_cascade_repair"`), then the root is stamped so later startups
+  never re-police the tree — a descendant legitimately revived afterwards
+  (completed → running via a follow-up message) is never re-killed.
+  Scoped to `cancelled` ancestors only — descendants of a merely
+  `completed`/`errored` parent are legitimate survivors and stay
+  recoverable.
 
 ### 2.2 Enforcement at the durable seams (non-bypassable)
 
 - `ThreadSpawnEdgeRepository.create(edge, opts?)` consults
   `checkSpawnAdmissionGate` on `edge.parentThreadId` inside the repo and
-  throws `SpawnAdmissionBlockedError` on refusal. Default mode `"enforce"`;
-  `opts.admissionGate: "import"` skips the check ONLY for the two
-  historical-topology writers, which are not admissions: the legacy JSON
-  import (`rollout-store.ts loadThreadSpawnEdges`) and
-  `state/export-import.ts` import. Same shape as
-  `recordInFlightToolCallStart`'s `unknownOutcomeGate: "enforce" | "flag"`.
+  throws `SpawnAdmissionBlockedError` on refusal. Gate check + INSERT run
+  under ONE `BEGIN IMMEDIATE` transaction
+  (`StateSqliteDriver.transactionImmediate`): the write lock is held
+  across the check, closing the cross-process TOCTOU where a concurrent
+  `run.cancel` commits between the admission decision and the edge landing
+  (the cascade would never have enumerated that child). Default mode
+  `"enforce"`; `opts.admissionGate: "import"` skips the check ONLY for the
+  legacy JSON edge import (`rollout-store.ts loadThreadSpawnEdges`), which
+  records historical topology rather than admitting new work. Same shape
+  as `recordInFlightToolCallStart`'s `unknownOutcomeGate: "enforce" |
+  "flag"`.
 - `updateAgentRunStatus` gains cancel-lock stickiness: if the existing
   status is cancel-locked and the incoming status differs, the write is a
   guarded no-op returning `{ applied: false, reason:
@@ -155,12 +168,18 @@ Handler flow (manager `cancelRunTree`):
 3. **Void reservations**: new additive `BudgetLedger.voidHoldsForAgent(
    agentId): number` — deletes OPEN holds for that agent under the
    existing disk lock WITHOUT touching spend/pause (unlike operator
-   `reset`). Called for every cancelled run id; total reported as
-   `voidedHolds`. This is the frozen `voided` resolution ("work cancelled
-   before any charge; full refund"). Cross-store atomicity with SQLite is
-   impossible (ledger is a file); ordering durable-cancel → void is safe
-   because an unvoided hold of a cancelled run only over-reserves (fails
-   closed) until voided, never under-reserves.
+   `reset`). `voided` is a FULL refund per the frozen contract: the day
+   debit is refunded when the hold's day window is current, and the month
+   debit whenever its month window is current — including holds whose day
+   already rolled (unlike `consumeHold`'s `window_rolled`, which keeps
+   the month debit because the usage is unknown, not cancelled). Called
+   over the FULL `subtreeRunIds` (not just freshly-cancelled ids) and
+   ALSO on an `alreadyTerminal` retry: a crash between a prior cancel's
+   durable cascade and its voiding leaves stranded holds that only a
+   retried `run.cancel` can release (voiding is idempotent). Cross-store
+   atomicity with SQLite is impossible (ledger is a file); ordering
+   durable-cancel → void is safe because an unvoided hold only
+   over-reserves (fails closed), never under-reserves.
 
 Result: `{ runId, alreadyTerminal, cancelledRunIds, closedEdges,
 interruptedLive, voidedHolds }`.
@@ -200,16 +219,27 @@ Expected scoreboard: TRR 7/7.
 - Gating the legacy JSON edge file itself (import-only; the SQLite repo is
   the durable authority).
 
-## 4. Risks
+## 4. Risks & known limitations
 
 - **Legitimate revival flows**: mitigated by locking only
-  `cancelled`/`unknown_outcome`, never `completed`/`errored`/`stopped`.
-- **Shared project DB, multiple daemons**: cascade and repair run in
-  SQLite transactions; edge-close uses the existing CAS; stickiness makes
-  concurrent late writers converge on `cancelled`.
+  `cancelled`/`unknown_outcome`, never `completed`/`errored`/`stopped`,
+  and by one-shot repair (`cascadeComplete` stamp) so revived descendants
+  are never re-killed on later startups.
+- **Shared project DB, multiple daemons**: the admission gate + edge
+  INSERT run under one `BEGIN IMMEDIATE` transaction; cascade and repair
+  run in SQLite transactions; edge-close uses the existing CAS; stickiness
+  makes concurrent late writers converge on `cancelled`. `agenc state
+  import` over a cancel-locked run fails atomically instead of
+  half-applying (run-row write dropped, session state replaced).
+- **Live agents in OTHER processes** (e.g. a CLI-local session whose tree
+  the daemon cancels): the durable record wins immediately — stickiness
+  rejects their late status writes, the gate refuses their new spawns —
+  but their in-flight work is NOT interrupted; it runs until its own
+  turn/loop checks fail or the next startup recovery. Cross-process live
+  interruption needs an IPC signal and is a deliberate follow-up.
 - **Ancestor walk cost**: gate walk is depth-bounded (existing spawn depth
-  cap) and hits the `parent_thread_id` index; repair sweep runs once per
-  startup inside the existing recovery transaction.
+  cap) and hits the `parent_thread_id` index; repair sweep visits only
+  unstamped cancelled roots inside the existing recovery transaction.
 - **False refusal on unrelated trees**: gate only consults the ancestor
-  chain of the specific parent; runs with no `agent_runs` ancestor are
-  never refused.
+  chain of the specific parent; runs with no cancel-locked `agent_runs`
+  ancestor are never refused.

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -35,6 +35,7 @@ export const AGENC_SDK_DAEMON_METHODS = [
   "agent.attach",
   "agent.stop",
   "agent.logs",
+  "run.cancel",
   "session.create",
   "session.list",
   "session.attach",
@@ -170,6 +171,11 @@ export interface AgentStopParams extends JsonObject {
 
 export interface AgentLogsParams extends JsonObject {
   readonly agentId: string;
+}
+
+export interface RunCancelParams extends JsonObject {
+  readonly runId: string;
+  readonly reason?: string;
 }
 
 export interface SessionCreateParams extends JsonObject {
@@ -383,6 +389,7 @@ export interface AgencParamsByMethod {
   readonly "agent.attach": AgentAttachParams;
   readonly "agent.stop": AgentStopParams;
   readonly "agent.logs": AgentLogsParams;
+  readonly "run.cancel": RunCancelParams;
   readonly "session.create": SessionCreateParams;
   readonly "session.list": SessionListParams;
   readonly "session.attach": SessionAttachParams;
@@ -506,6 +513,15 @@ export interface AgentLogsResult extends JsonObject {
   readonly transcript: string;
   readonly sessions: readonly AgentLogSession[];
   readonly toolOutputs?: readonly JsonObject[];
+}
+
+export interface RunCancelResult extends JsonObject {
+  readonly runId: string;
+  readonly alreadyTerminal: boolean;
+  readonly cancelledRunIds: readonly string[];
+  readonly closedEdgeChildIds: readonly string[];
+  readonly interruptedLiveAgentIds: readonly string[];
+  readonly voidedHolds: number;
 }
 
 export interface SessionCreateResult extends SessionSummary {}
@@ -682,6 +698,7 @@ export interface AgencResultByMethod {
   readonly "agent.attach": AgentAttachResult;
   readonly "agent.stop": AgentStopResult;
   readonly "agent.logs": AgentLogsResult;
+  readonly "run.cancel": RunCancelResult;
   readonly "session.create": SessionCreateResult;
   readonly "session.list": SessionListResult;
   readonly "session.attach": SessionAttachResult;

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -39,6 +39,8 @@ import type {
   MessageContent,
   PermissionListParams,
   PermissionListResult,
+  RunCancelParams,
+  RunCancelResult,
   SessionCancelTurnParams,
   SessionCancelTurnResult,
   SessionClearParams,
@@ -106,12 +108,15 @@ import {
 import type { Event } from "../session/event-log.js";
 import type { ResponseItem, RolloutItem } from "../session/rollout-item.js";
 import type { AgenCStateAgentRunRecord } from "../state/agent-runs.js";
+import type { CancelAgentRunTreeReport } from "../state/run-cancellation.js";
 
 export type AgenCDaemonAgentLifecycleErrorCode =
   | "AGENT_NOT_FOUND"
   | "BACKGROUND_RUNNER_UNAVAILABLE"
   | "INVALID_ARGUMENT"
-  | "INVALID_CURSOR";
+  | "INVALID_CURSOR"
+  | "RUN_NOT_FOUND"
+  | "RUN_CANCEL_UNAVAILABLE";
 
 export class AgenCDaemonAgentLifecycleError extends Error {
   readonly code: AgenCDaemonAgentLifecycleErrorCode;
@@ -161,6 +166,25 @@ export interface AgenCDaemonAgentManagerOptions {
   readonly onSnapshotError?: (error: unknown) => void;
   readonly permissionAuditLogger?: PermissionAuditLogger;
   readonly onPermissionAuditError?: PermissionAuditErrorHandler;
+  /**
+   * Durable tree-scoped cancel (run.cancel step 1). Applies
+   * `cancelAgentRunTree` against every project state DB that holds the run
+   * row; the daemon-cli wiring owns DB discovery. REQUIRED for run.cancel —
+   * the durable record is the authority, the live interrupt is second.
+   */
+  readonly cancelRunTreeDurable?: (params: {
+    readonly runId: string;
+    readonly reason: string;
+    readonly cancelledAt: string;
+  }) => CancelAgentRunTreeReport | Promise<CancelAgentRunTreeReport>;
+  /**
+   * Frozen `voided` reservation resolution for cancelled runs: release
+   * open budget holds for the given agent ids (spend history untouched).
+   * Returns the number of holds voided.
+   */
+  readonly voidBudgetHoldsForAgents?: (
+    agentIds: readonly string[],
+  ) => number | Promise<number>;
 }
 
 export interface AgenCDaemonAgentToolOutputReadParams {
@@ -312,6 +336,16 @@ export class AgenCDaemonAgentManager {
   readonly #onSnapshotError: (error: unknown) => void;
   readonly #permissionAuditLogger: PermissionAuditLogger | undefined;
   readonly #onPermissionAuditError: PermissionAuditErrorHandler | undefined;
+  readonly #cancelRunTreeDurable:
+    | ((params: {
+        readonly runId: string;
+        readonly reason: string;
+        readonly cancelledAt: string;
+      }) => CancelAgentRunTreeReport | Promise<CancelAgentRunTreeReport>)
+    | undefined;
+  readonly #voidBudgetHoldsForAgents:
+    | ((agentIds: readonly string[]) => number | Promise<number>)
+    | undefined;
   #shuttingDown = false;
   #activeCreates = 0;
   readonly #createWaiters = new Set<() => void>();
@@ -340,6 +374,8 @@ export class AgenCDaemonAgentManager {
     this.#onSnapshotError = options.onSnapshotError ?? (() => {});
     this.#permissionAuditLogger = options.permissionAuditLogger;
     this.#onPermissionAuditError = options.onPermissionAuditError;
+    this.#cancelRunTreeDurable = options.cancelRunTreeDurable;
+    this.#voidBudgetHoldsForAgents = options.voidBudgetHoldsForAgents;
   }
 
   async createAgent(params: AgentCreateParams): Promise<AgentCreateResult> {
@@ -910,6 +946,71 @@ export class AgenCDaemonAgentManager {
     );
     await this.#terminateAgentSessions(target.sessionIds, reason);
     return { agentId, stopped: true };
+  }
+
+  /**
+   * run.cancel (frozen Wave-B method): tree-scoped cancel of the run plus
+   * its queued and running descendants. Durable-first — the state-DB
+   * cascade is the authority and survives a daemon crash (startup recovery
+   * finishes an interrupted cascade); the live interrupt/stop is second
+   * and reuses the existing descendant-cascading primitives. Late status
+   * writes from dying agents lose to cancel-lock stickiness in the state
+   * layer. Idempotent: an already-terminal run reports `alreadyTerminal`.
+   */
+  async cancelRunTree(params: RunCancelParams): Promise<RunCancelResult> {
+    const runId = normalizeRequiredAgentId(params.runId, "run.cancel");
+    const reason = normalizeNonEmpty(params.reason) ?? "run.cancel";
+    const cancelDurable = this.#cancelRunTreeDurable;
+    if (cancelDurable === undefined) {
+      throw new AgenCDaemonAgentLifecycleError(
+        "RUN_CANCEL_UNAVAILABLE",
+        "run.cancel requires durable state wiring (cancelRunTreeDurable)",
+      );
+    }
+    const cancelledAt = this.#now();
+    const report = await cancelDurable({ runId, reason, cancelledAt });
+    if (report.missing) {
+      throw new AgenCDaemonAgentLifecycleError(
+        "RUN_NOT_FOUND",
+        `run.cancel: no agent run found for id: ${runId}`,
+      );
+    }
+
+    // Live propagation: interrupt cascades to descendants inside the
+    // runner (control.interrupt), then stop tears the root down. Both are
+    // best-effort — the durable cascade above already decided the outcome,
+    // and a dead/absent live agent is not an error for run.cancel.
+    const interruptedLiveAgentIds: string[] = [];
+    const runner = this.#runner;
+    if (runner !== undefined) {
+      try {
+        const interrupted =
+          (await runner.interruptAgentTurn?.(runId, reason)) ?? false;
+        await runner.stopAgent?.(runId, reason);
+        if (interrupted) interruptedLiveAgentIds.push(runId);
+      } catch {
+        // No live agent (or it died mid-stop): the durable record stands.
+      }
+    }
+
+    let voidedHolds = 0;
+    const voidHolds = this.#voidBudgetHoldsForAgents;
+    if (voidHolds !== undefined && report.cancelledRunIds.length > 0) {
+      try {
+        voidedHolds = await voidHolds(report.cancelledRunIds);
+      } catch (error) {
+        this.#onSnapshotError(error);
+      }
+    }
+
+    return {
+      runId,
+      alreadyTerminal: report.alreadyTerminal,
+      cancelledRunIds: report.cancelledRunIds,
+      closedEdgeChildIds: report.closedEdgeChildIds,
+      interruptedLiveAgentIds,
+      voidedHolds,
+    };
   }
 
   /**

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -983,21 +983,32 @@ export class AgenCDaemonAgentManager {
     const interruptedLiveAgentIds: string[] = [];
     const runner = this.#runner;
     if (runner !== undefined) {
+      // Interrupt and stop are independently best-effort: an interrupt
+      // throw must not skip the stop. No live agent (or one dying midway)
+      // is not an error — the durable record stands either way.
       try {
         const interrupted =
           (await runner.interruptAgentTurn?.(runId, reason)) ?? false;
-        await runner.stopAgent?.(runId, reason);
         if (interrupted) interruptedLiveAgentIds.push(runId);
       } catch {
-        // No live agent (or it died mid-stop): the durable record stands.
+        // best-effort
+      }
+      try {
+        await runner.stopAgent?.(runId, reason);
+      } catch {
+        // best-effort
       }
     }
 
+    // Void over the FULL subtree, and also when alreadyTerminal: a crash
+    // between a prior cancel's durable cascade and its hold voiding leaves
+    // stranded holds that only a retry can release (voiding is idempotent
+    // — an agent with no open holds voids zero).
     let voidedHolds = 0;
     const voidHolds = this.#voidBudgetHoldsForAgents;
-    if (voidHolds !== undefined && report.cancelledRunIds.length > 0) {
+    if (voidHolds !== undefined && report.subtreeRunIds.length > 0) {
       try {
-        voidedHolds = await voidHolds(report.cancelledRunIds);
+        voidedHolds = await voidHolds(report.subtreeRunIds);
       } catch (error) {
         this.#onSnapshotError(error);
       }

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -114,6 +114,11 @@ import {
 } from "../state/pruning.js";
 import { StateSqliteHealthStatsReader } from "../state/health-stats.js";
 import { upsertAgentRun } from "../state/agent-runs.js";
+import {
+  cancelAgentRunTree,
+  type CancelAgentRunTreeReport,
+} from "../state/run-cancellation.js";
+import { BudgetLedger } from "../budget/ledger.js";
 import { AgenCSessionSnapshotPolicy } from "../state/snapshot-policy.js";
 import { readRotatedToolOutputLog } from "../state/tool-output-rotation.js";
 import {
@@ -1511,6 +1516,20 @@ async function runAgenCDaemonForeground(
       io.stderr.write(
         `agenc: permission audit log failed: ${formatCleanupError(error)}\n`,
       ),
+    cancelRunTreeDurable: (params) =>
+      cancelRunTreeAcrossStateDatabases(
+        authStartup.daemonHome,
+        primaryCwd,
+        params,
+      ),
+    voidBudgetHoldsForAgents: (agentIds) => {
+      const ledger = new BudgetLedger({ agencHome: authStartup.daemonHome });
+      let voided = 0;
+      for (const agentId of agentIds) {
+        voided += ledger.voidHoldsForAgent(agentId);
+      }
+      return voided;
+    },
   });
   // Wire the runner's terminal-status hook into the lifecycle so a
   // completed/errored agent's status transitions out of `running` in
@@ -2134,6 +2153,64 @@ function recoverAgenCDaemonStartupState(
     recoveredToolCalls,
     warnings,
   };
+}
+
+/**
+ * Durable half of run.cancel: apply the tree-scoped cascade against every
+ * project state DB that holds the run row (a run lives in exactly one
+ * project DB in practice; the merge keeps the result honest if ids ever
+ * collide across projects). Missing everywhere → `missing: true`.
+ */
+function cancelRunTreeAcrossStateDatabases(
+  daemonHome: string,
+  cwd: string,
+  params: {
+    readonly runId: string;
+    readonly reason: string;
+    readonly cancelledAt: string;
+  },
+): CancelAgentRunTreeReport {
+  const paths = discoverAgenCDaemonStateDatabasePaths(daemonHome, cwd);
+  let merged: CancelAgentRunTreeReport | undefined;
+  for (const pathSet of paths) {
+    const driver = openStateDatabasePaths(pathSet);
+    try {
+      const report = cancelAgentRunTree(driver, params);
+      if (report.missing) continue;
+      if (merged === undefined) {
+        merged = report;
+        continue;
+      }
+      merged = {
+        runId: params.runId,
+        missing: false,
+        alreadyTerminal: merged.alreadyTerminal && report.alreadyTerminal,
+        rootStatusBefore: merged.rootStatusBefore ?? report.rootStatusBefore,
+        cancelledRunIds: [...merged.cancelledRunIds, ...report.cancelledRunIds],
+        priorStatusById: {
+          ...merged.priorStatusById,
+          ...report.priorStatusById,
+        },
+        closedEdgeChildIds: [
+          ...merged.closedEdgeChildIds,
+          ...report.closedEdgeChildIds,
+        ],
+      };
+    } finally {
+      driver.close();
+    }
+  }
+  return (
+    merged ?? {
+      runId: params.runId,
+      missing: true,
+      alreadyTerminal: false,
+      rootStatusBefore: null,
+      cancelledRunIds: [],
+      priorStatusById: {},
+      closedEdgeChildIds: [],
+    }
+  );
 }
 
 function discoverAgenCDaemonStateDatabasePaths(

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -2186,6 +2186,9 @@ function cancelRunTreeAcrossStateDatabases(
         missing: false,
         alreadyTerminal: merged.alreadyTerminal && report.alreadyTerminal,
         rootStatusBefore: merged.rootStatusBefore ?? report.rootStatusBefore,
+        subtreeRunIds: [
+          ...new Set([...merged.subtreeRunIds, ...report.subtreeRunIds]),
+        ],
         cancelledRunIds: [...merged.cancelledRunIds, ...report.cancelledRunIds],
         priorStatusById: {
           ...merged.priorStatusById,
@@ -2206,6 +2209,7 @@ function cancelRunTreeAcrossStateDatabases(
       missing: true,
       alreadyTerminal: false,
       rootStatusBefore: null,
+      subtreeRunIds: [],
       cancelledRunIds: [],
       priorStatusById: {},
       closedEdgeChildIds: [],

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -58,6 +58,7 @@ import {
   type AgentListParams,
   type AgentLogsParams,
   type AgentStopParams,
+  type RunCancelParams,
   type AgenCDaemonErrorCode,
   type AgenCDaemonErrorObject,
   type AgenCDaemonMethod,
@@ -173,6 +174,7 @@ function buildServerCapabilities(
     "agent.attach": hasMethod(agentManager, "attachAgent"),
     "agent.stop": hasMethod(agentManager, "stopAgent"),
     "agent.logs": hasMethod(agentManager, "getAgentLogs"),
+    "run.cancel": hasMethod(agentManager, "cancelRunTree"),
     "session.create": hasMethod(sessionManager, "createSession"),
     "session.list": hasMethod(sessionManager, "listSessions"),
     "session.attach": hasMethod(sessionManager, "attachSession"),
@@ -298,6 +300,7 @@ export interface AgenCDaemonDispatcherOptions {
     | "getAgentLogs"
     | "listAgents"
     | "stopAgent"
+    | "cancelRunTree"
     | "streamAgentMessage"
   > & {
     readonly listPermissions?: AgenCDaemonAgentManager["listPermissions"];
@@ -372,6 +375,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     | "getAgentLogs"
     | "listAgents"
     | "stopAgent"
+    | "cancelRunTree"
     | "streamAgentMessage"
   > & {
     readonly listPermissions?: AgenCDaemonAgentManager["listPermissions"];
@@ -617,6 +621,13 @@ export class AgenCDaemonJsonRpcDispatcher {
           id,
           await this.#agentManager.getAgentLogs(
             validateAgentLogsParams(params),
+          ),
+        );
+      case "run.cancel":
+        return successResponse(
+          id,
+          await this.#agentManager.cancelRunTree(
+            validateRunCancelParams(params),
           ),
         );
       case "session.create":
@@ -1640,6 +1651,15 @@ function validateAgentStopParams(params: JsonObject): AgentStopParams {
   });
   validateRequiredString(validated, "agent.stop", "agentId");
   return validated as AgentStopParams;
+}
+
+function validateRunCancelParams(params: JsonObject): RunCancelParams {
+  const validated = validateObjectShape(params, {
+    methodName: "run.cancel",
+    stringFields: ["runId", "reason"],
+  });
+  validateRequiredString(validated, "run.cancel", "runId");
+  return validated as RunCancelParams;
 }
 
 function validateAgentLogsParams(params: JsonObject): AgentLogsParams {

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -47,6 +47,7 @@ export const AGENC_DAEMON_METHODS = [
   "agent.attach",
   "agent.stop",
   "agent.logs",
+  "run.cancel",
   "session.create",
   "session.list",
   "session.attach",
@@ -239,6 +240,15 @@ export const AGENC_DAEMON_METHOD_SPECS = defineMethodSpecs({
     params: "required",
     result: "object",
     description: "Read the full local log and transcript for a daemon agent.",
+  },
+  "run.cancel": {
+    method: "run.cancel",
+    direction: "client-to-server",
+    params: "required",
+    result: "object",
+    description:
+      "Tree-scoped cancel: the run plus its queued and running descendants " +
+      "(frozen Wave-B contract). Durable cascade first, live interrupt second.",
   },
   "session.create": {
     method: "session.create",
@@ -796,6 +806,12 @@ export interface AgentStopParams extends JsonObject {
 
 export interface AgentLogsParams extends JsonObject {
   readonly agentId: string;
+}
+
+export interface RunCancelParams extends JsonObject {
+  /** Root run id (= root agent id, the agent_runs primary key). */
+  readonly runId: string;
+  readonly reason?: string;
 }
 
 export interface SessionCreateParams extends JsonObject {
@@ -1408,6 +1424,7 @@ export type AgenCDaemonRequest =
   | AgenCDaemonRequestWithParams<"agent.attach", AgentAttachParams>
   | AgenCDaemonRequestWithParams<"agent.stop", AgentStopParams>
   | AgenCDaemonRequestWithParams<"agent.logs", AgentLogsParams>
+  | AgenCDaemonRequestWithParams<"run.cancel", RunCancelParams>
   | AgenCDaemonRequestWithParams<"session.create", SessionCreateParams>
   | AgenCDaemonRequestWithParams<"session.list", SessionListParams>
   | AgenCDaemonRequestWithParams<"session.attach", SessionAttachParams>
@@ -1523,6 +1540,20 @@ export interface AgentAttachResult extends JsonObject {
 export interface AgentStopResult extends JsonObject {
   readonly agentId: string;
   readonly stopped: boolean;
+}
+
+export interface RunCancelResult extends JsonObject {
+  readonly runId: string;
+  /** True when the run was already terminal; nothing was written. */
+  readonly alreadyTerminal: boolean;
+  /** Runs moved to `cancelled` by this call (root included). */
+  readonly cancelledRunIds: readonly string[];
+  /** Open spawn edges closed by this call (child thread ids). */
+  readonly closedEdgeChildIds: readonly string[];
+  /** Live agents interrupted as the second, in-memory step. */
+  readonly interruptedLiveAgentIds: readonly string[];
+  /** Open budget holds voided across the cancelled subtree. */
+  readonly voidedHolds: number;
 }
 
 export interface AgentLogSession extends JsonObject {
@@ -1898,6 +1929,7 @@ export interface AgenCDaemonResultByMethod {
   readonly "agent.attach": AgentAttachResult;
   readonly "agent.stop": AgentStopResult;
   readonly "agent.logs": AgentLogsResult;
+  readonly "run.cancel": RunCancelResult;
   readonly "session.create": SessionCreateResult;
   readonly "session.list": SessionListResult;
   readonly "session.attach": SessionAttachResult;

--- a/runtime/src/app-server/protocol/schema.json
+++ b/runtime/src/app-server/protocol/schema.json
@@ -15,6 +15,7 @@
     "agent.attach",
     "agent.stop",
     "agent.logs",
+    "run.cancel",
     "session.create",
     "session.list",
     "session.attach",
@@ -289,6 +290,20 @@
         }
       },
       "required": ["agentId"]
+    },
+    "RunCancelParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": ["runId"]
     },
     "SessionCreateParams": {
       "type": "object",
@@ -1612,6 +1627,9 @@
           "$ref": "#/definitions/AgentLogsRequest"
         },
         {
+          "$ref": "#/definitions/RunCancelRequest"
+        },
+        {
           "$ref": "#/definitions/SessionCreateRequest"
         },
         {
@@ -2152,6 +2170,25 @@
         },
         "params": {
           "$ref": "#/definitions/AgentLogsParams"
+        }
+      },
+      "required": ["jsonrpc", "id", "method", "params"]
+    },
+    "RunCancelRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0"
+        },
+        "id": {
+          "$ref": "#/definitions/RequestId"
+        },
+        "method": {
+          "const": "run.cancel"
+        },
+        "params": {
+          "$ref": "#/definitions/RunCancelParams"
         }
       },
       "required": ["jsonrpc", "id", "method", "params"]

--- a/runtime/src/budget/ledger.ts
+++ b/runtime/src/budget/ledger.ts
@@ -289,6 +289,34 @@ export class BudgetLedger {
     });
   }
 
+  /**
+   * The frozen `voided` reservation resolution ("work cancelled before any
+   * charge; full refund"): under the disk lock, delete every open hold for
+   * `agentId` and refund its reserved debit from the current windows.
+   * Unlike operator `reset`, recorded spend, pause, and warn flags are
+   * untouched — only unresolved reservations are released. Holds whose day
+   * window already rolled are discarded without refund (the roll zeroed
+   * the debit). Returns the number of holds voided.
+   */
+  voidHoldsForAgent(agentId: string): number {
+    return this.#withDiskLock(() => {
+      let voided = 0;
+      for (const [holdId, hold] of Object.entries(this.#file.holds)) {
+        if (hold.agentId !== agentId) continue;
+        const state = this.#stateRolled(agentId);
+        if (hold.dayKey === state.day.key) {
+          state.day.usd -= hold.estimatedUsd;
+          state.day.tokens -= hold.estimatedTokens;
+          state.month.usd -= hold.estimatedUsd;
+          state.month.tokens -= hold.estimatedTokens;
+        }
+        delete this.#file.holds[holdId];
+        voided += 1;
+      }
+      return voided;
+    });
+  }
+
   /** Open (unresolved) holds, optionally filtered by agent. */
   listOpenHolds(agentId?: string): readonly PersistedBudgetHold[] {
     return Object.values(this.#file.holds)

--- a/runtime/src/budget/ledger.ts
+++ b/runtime/src/budget/ledger.ts
@@ -307,6 +307,13 @@ export class BudgetLedger {
         if (hold.dayKey === state.day.key) {
           state.day.usd -= hold.estimatedUsd;
           state.day.tokens -= hold.estimatedTokens;
+        }
+        // The month window outlives the day window: a hold whose day
+        // rolled still carries its debit in the current month, and
+        // `voided` means FULL refund (frozen contract) — unlike
+        // consumeHold's window_rolled, which deliberately keeps the
+        // month debit because the usage is unknown, not cancelled.
+        if (hold.monthKey === state.month.key) {
           state.month.usd -= hold.estimatedUsd;
           state.month.tokens -= hold.estimatedTokens;
         }

--- a/runtime/src/eval-executor/trust-run.ts
+++ b/runtime/src/eval-executor/trust-run.ts
@@ -65,8 +65,12 @@ import { BudgetLedger } from "../budget/ledger.js";
 import type { BudgetHold, BudgetPolicy } from "../budget/types.js";
 import { StateSqliteDriver } from "../state/sqlite-driver.js";
 import { recoverDaemonStateOnStartup } from "../state/recovery.js";
-import { upsertAgentRun, updateAgentRunStatus } from "../state/agent-runs.js";
+import { upsertAgentRun } from "../state/agent-runs.js";
 import { ThreadSpawnEdgeRepository } from "../state/spawn-edges.js";
+import {
+  cancelAgentRunTree,
+  SpawnAdmissionBlockedError,
+} from "../state/run-cancellation.js";
 import { recordInFlightToolCallStart } from "../state/tool-output-rotation.js";
 import {
   resolveUnknownOutcomeEffect,
@@ -741,6 +745,19 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
       },
       status: "open",
     });
+    // The queued (pending) child is part of the durable spawn tree too —
+    // the cascade walks edges, and a queued production spawn has one.
+    edges.create({
+      childThreadId: queuedChildId,
+      parentThreadId: parentId,
+      parentPath: "/root",
+      metadata: {
+        agentId: queuedChildId,
+        agentPath: `/root/${queuedChildId}`,
+        depth: 1,
+      },
+      status: "open",
+    });
     recordInFlightToolCallStart(driver, {
       sessionId: "trust-cancel-session",
       agentId: runningChildId,
@@ -761,18 +778,22 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
       toolCallId: "trust-cancel-tool-1",
     });
 
-    // cancel_parent: out-of-band fault injection — a direct terminal status
-    // write. (No production code path can write agent_runs.status
-    // 'cancelled' today; the FAIL verdicts below are insensitive to the
-    // specific terminal string because nothing cascades regardless.)
+    // cancel_parent through the REAL tree-scoped primitive (the durable
+    // half of run.cancel): one transaction cancels the parent plus every
+    // non-terminal descendant found via spawn edges and closes open edges.
     clock.advance(5);
     const injectedAtVirtualMs = clock.now();
-    updateAgentRunStatus(driver, {
-      id: parentId,
-      status: "cancelled",
-      lastActiveAt: nowIso(),
+    const cancelReport = cancelAgentRunTree(driver, {
+      runId: parentId,
+      reason: "trust-cancel-parent",
+      cancelledAt: nowIso(),
     });
-    const faultEvidenceDigest = evidence.record("run.cancelled", { parentId });
+    const faultEvidenceDigest = evidence.record("run.cancelled", {
+      parentId,
+      cancelledRunIds: [...cancelReport.cancelledRunIds],
+      priorStatusById: { ...cancelReport.priorStatusById },
+      closedEdgeChildIds: [...cancelReport.closedEdgeChildIds],
+    });
 
     // drain_descendants: observe what the durable layer actually does today.
     clock.advance(5);
@@ -786,28 +807,43 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
       runningChildStatus === "cancelled" && queuedChildStatus === "cancelled";
 
     // Probe: is a NEW child admission under a cancelled parent refused?
-    // Probed at BOTH durable admission seams (agent_runs upsert and the
-    // spawn-edge commit point). There is no admission kernel and no typed
-    // admission-denial error today, so a success means "not refused" and
-    // any throw is an unexpected infrastructure error (rethrown) — never
-    // counted as a refusal. Honest failure until M3 lands.
+    // The durable admission commit point is the spawn-edge create — an
+    // orphan agent_runs row is not tree membership. Refusal counts ONLY as
+    // the typed SpawnAdmissionBlockedError from the in-repo gate; any
+    // other throw is an unexpected infrastructure error (rethrown). The
+    // probe also demands the refused edge is truly absent AND that the
+    // cancelled parent cannot be revived by an upsert (status laundering).
     const lateChildId = "trust_cancel_child_late";
     upsertAgentRun(driver, {
       id: lateChildId, objective: "late child",
       status: "running", startedAt, lastActiveAt: startedAt,
     });
-    edges.create({
-      childThreadId: lateChildId,
-      parentThreadId: parentId,
-      parentPath: "/root",
-      metadata: {
-        agentId: lateChildId,
-        agentPath: `/root/${lateChildId}`,
-        depth: 1,
-      },
-      status: "open",
+    let admissionBlockedTyped = false;
+    try {
+      edges.create({
+        childThreadId: lateChildId,
+        parentThreadId: parentId,
+        parentPath: "/root",
+        metadata: {
+          agentId: lateChildId,
+          agentPath: `/root/${lateChildId}`,
+          depth: 1,
+        },
+        status: "open",
+      });
+    } catch (error) {
+      if (!(error instanceof SpawnAdmissionBlockedError)) throw error;
+      admissionBlockedTyped = true;
+    }
+    const lateEdgeAbsent = edges.get(lateChildId) === undefined;
+    const reviveOutcome = upsertAgentRun(driver, {
+      id: parentId, objective: "parent", status: "running",
+      startedAt, lastActiveAt: nowIso(),
     });
-    const newAdmissionRefused = false;
+    const reviveRejected =
+      reviveOutcome.applied === false && statusOf(parentId) === "cancelled";
+    const newAdmissionRefused =
+      admissionBlockedTyped && lateEdgeAbsent && reviveRejected;
 
     const evidenceRow = driver
       .prepareState<[string], { status?: string }>(
@@ -838,7 +874,14 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
       faultEvidenceDigest,
       invariantResults: [
         invariant(evidence, "descendant_admission_stopped", newAdmissionRefused, {
-          probes: ["post-cancel agent_runs upsert", "post-cancel spawn-edge create"],
+          probes: [
+            "post-cancel spawn-edge create (typed SpawnAdmissionBlockedError)",
+            "refused edge absent from thread_spawn_edges",
+            "post-cancel parent revive upsert rejected (cancel-lock sticky)",
+          ],
+          admissionBlockedTyped,
+          lateEdgeAbsent,
+          reviveRejected,
         }),
         invariant(
           evidence,

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -287,7 +287,8 @@ export class RolloutStore {
     for (const edge of this.readLegacyThreadSpawnEdges()) {
       if (persistedChildIds.has(edge.childThreadId)) continue;
       try {
-        this.threadSpawnEdgeRepo.create(edge);
+        // Historical topology, not a new admission — bypass the gate.
+        this.threadSpawnEdgeRepo.create(edge, { admissionGate: "import" });
         persistedChildIds.add(edge.childThreadId);
       } catch (error) {
         // Another process can win the create between list() and legacy import.

--- a/runtime/src/state/agent-runs.ts
+++ b/runtime/src/state/agent-runs.ts
@@ -1,6 +1,45 @@
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 import type { JsonObject } from "../app-server/protocol/index.js";
 import { asRecord } from "../utils/record.js";
+import { isCancelLockedAgentRunStatus } from "./run-cancellation.js";
+
+/**
+ * Outcome of a guarded agent-run write. `applied: false` with
+ * `cancel_locked_status_sticky` means the existing row carries a
+ * cancel-locked status (`cancelled` / `unknown_outcome`) and the incoming
+ * write tried to move it to a different status — the write is a no-op
+ * (never a throw: the sole production status writer is the post-hoc
+ * snapshot observer relaying a dying agent's late transition, which must
+ * lose silently to an explicit cancel). Same-status writes still land so
+ * metadata patches on the locked record remain possible.
+ */
+export interface AgentRunWriteOutcome {
+  readonly applied: boolean;
+  readonly reason?: "cancel_locked_status_sticky";
+  readonly existingStatus?: string;
+}
+
+const APPLIED: AgentRunWriteOutcome = { applied: true };
+
+function cancelLockedExistingStatus(
+  driver: StateSqliteDriver,
+  id: string,
+  incomingStatus: string,
+): string | undefined {
+  const existing = driver
+    .prepareState<[string], { status?: string }>(
+      "SELECT status FROM agent_runs WHERE id = ?",
+    )
+    .get(id)?.status;
+  if (
+    existing !== undefined &&
+    existing !== incomingStatus &&
+    isCancelLockedAgentRunStatus(existing)
+  ) {
+    return existing;
+  }
+  return undefined;
+}
 
 export interface AgenCStateAgentRunRecord {
   readonly id: string;
@@ -25,7 +64,15 @@ export interface AgenCStateAgentRunStatusUpdate {
 export function upsertAgentRun(
   driver: StateSqliteDriver,
   run: AgenCStateAgentRunRecord,
-): void {
+): AgentRunWriteOutcome {
+  const locked = cancelLockedExistingStatus(driver, run.id, run.status);
+  if (locked !== undefined) {
+    return {
+      applied: false,
+      reason: "cancel_locked_status_sticky",
+      existingStatus: locked,
+    };
+  }
   driver
     .prepareState(
       `INSERT INTO agent_runs (
@@ -60,12 +107,21 @@ export function upsertAgentRun(
       run.lastSnapshotAt ?? null,
       run.metadata === undefined ? null : JSON.stringify(run.metadata),
     );
+  return APPLIED;
 }
 
 export function updateAgentRunStatus(
   driver: StateSqliteDriver,
   update: AgenCStateAgentRunStatusUpdate,
-): void {
+): AgentRunWriteOutcome {
+  const locked = cancelLockedExistingStatus(driver, update.id, update.status);
+  if (locked !== undefined) {
+    return {
+      applied: false,
+      reason: "cancel_locked_status_sticky",
+      existingStatus: locked,
+    };
+  }
   const metadataJson =
     update.metadataPatch === undefined
       ? undefined
@@ -91,7 +147,7 @@ export function updateAgentRunStatus(
         metadataJson,
         update.id,
       );
-    return;
+    return APPLIED;
   }
   driver
     .prepareState<[string, string, string | null, string | null, string]>(
@@ -111,6 +167,7 @@ export function updateAgentRunStatus(
       update.currentSessionId ?? null,
       update.id,
     );
+  return APPLIED;
 }
 
 function mergedAgentRunMetadataJson(

--- a/runtime/src/state/export-import.ts
+++ b/runtime/src/state/export-import.ts
@@ -158,6 +158,18 @@ export function importAgentState(
   );
 
   driver.transaction(() => {
+    // The run-row write goes first and is checked: if the existing row is
+    // cancel-locked (cancelled/unknown_outcome) the upsert is a sticky
+    // no-op, and silently replacing the session state under it would be a
+    // half-applied import. Fail the whole transaction loudly instead.
+    const outcome = upsertAgentRun(driver, normalized.agentRun);
+    if (!outcome.applied) {
+      throw new AgenCStateExportImportError(
+        `state import refused: existing run ${normalized.agentRun.id} is ` +
+          `${outcome.existingStatus ?? "cancel-locked"} and its status is ` +
+          `review-locked; resolve or delete the run before importing over it`,
+      );
+    }
     for (const sessionId of sessionIdsToReplace) {
       driver
         .prepareState<[string]>(
@@ -170,7 +182,6 @@ export function importAgentState(
         )
         .run(sessionId);
     }
-    upsertAgentRun(driver, normalized.agentRun);
     insertSnapshots(driver, normalized.sessionStateSnapshots);
     insertToolCalls(driver, normalized.inFlightToolCalls, {
       agentId: normalized.agentRun.id,

--- a/runtime/src/state/recovery.ts
+++ b/runtime/src/state/recovery.ts
@@ -3,6 +3,7 @@ import type { JsonObject } from "../app-server/protocol/index.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
 import { sqlPlaceholders } from "./sql.js";
 import { normalizeToolRecoveryCategory } from "./tool-output-rotation.js";
+import { repairCancelledSubtrees } from "./run-cancellation.js";
 import { asRecord } from "../utils/record.js";
 
 const RECOVERABLE_AGENT_RUN_STATUSES = [
@@ -138,6 +139,10 @@ export function recoverDaemonStateOnStartup(
   const warnings: DaemonStartupRecoveryWarning[] = [];
   const recoveredAt = options.now?.() ?? new Date().toISOString();
   return driver.transaction(() => {
+    // Crash-mid-cascade repair MUST precede the recoverable-run load: a
+    // surviving descendant of a cancelled parent is finished off here so
+    // the restore loop never resurrects it.
+    repairCancelledSubtrees(driver, { now: recoveredAt });
     const recoveredToolCalls = recoverStaleToolCalls(driver, warnings);
     const recoveredRuns = loadRecoverableAgentRuns(
       driver,

--- a/runtime/src/state/run-cancellation.ts
+++ b/runtime/src/state/run-cancellation.ts
@@ -94,11 +94,13 @@ export class SpawnAdmissionBlockedError extends Error {
 }
 
 /**
- * Resolve the nearest ancestor of `parentThreadId` (inclusive) that has an
- * `agent_runs` row, walking UP `thread_spawn_edges` regardless of edge
- * status — a closed edge still defines ancestry. Refuse when that
- * ancestor's status is cancel-locked; allow when no run row exists
- * anywhere up the chain (nothing durable to gate on).
+ * Walk the ENTIRE ancestor chain of `parentThreadId` (inclusive) UP
+ * `thread_spawn_edges`, regardless of edge status — a closed edge still
+ * defines ancestry. Refuse when ANY ancestor with an `agent_runs` row is
+ * cancel-locked: cancellation poisons the whole tree for new admissions,
+ * so a terminal-but-revivable intermediate (e.g. a `completed` child of a
+ * cancelled root) must not shield spawns below it. Allow when no run row
+ * up the chain is cancel-locked (nothing durable forbids the admission).
  */
 export function checkSpawnAdmissionGate(
   driver: StateSqliteDriver,
@@ -118,17 +120,14 @@ export function checkSpawnAdmissionGate(
     if (seen.has(current)) break;
     seen.add(current);
     const status = runStatusStmt.get(current)?.status;
-    if (status !== undefined) {
-      if (isCancelLockedAgentRunStatus(status)) {
-        return {
-          allowed: false,
-          decision: "deny",
-          reason: "parent_cancel_locked",
-          parentRunId: current,
-          parentStatus: status,
-        };
-      }
-      return { allowed: true };
+    if (status !== undefined && isCancelLockedAgentRunStatus(status)) {
+      return {
+        allowed: false,
+        decision: "deny",
+        reason: "parent_cancel_locked",
+        parentRunId: current,
+        parentStatus: status,
+      };
     }
     current = parentEdgeStmt.get(current)?.parent_thread_id;
   }
@@ -142,6 +141,12 @@ export interface CancelAgentRunTreeReport {
   /** Root was already cancel-locked/terminal. Nothing was written. */
   readonly alreadyTerminal: boolean;
   readonly rootStatusBefore: string | null;
+  /**
+   * The full spawn subtree (root included), reported even when
+   * `alreadyTerminal` — a retried run.cancel after a crash between the
+   * cascade and hold voiding uses this to void the stranded holds.
+   */
+  readonly subtreeRunIds: readonly string[];
   /** Every run (root included) moved to `cancelled` by this call. */
   readonly cancelledRunIds: readonly string[];
   /** Prior status of each cancelled run (queued-vs-running evidence). */
@@ -189,24 +194,26 @@ function cancelSubtreeLocked(
       missing: true,
       alreadyTerminal: false,
       rootStatusBefore: null,
+      subtreeRunIds: [],
       cancelledRunIds: [],
       priorStatusById: {},
       closedEdgeChildIds: [],
     };
   }
+  const subtree = collectSubtreeThreadIds(driver, runId);
   if (isTerminalAgentRunStatus(rootStatus)) {
     return {
       runId,
       missing: false,
       alreadyTerminal: true,
       rootStatusBefore: rootStatus,
+      subtreeRunIds: subtree,
       cancelledRunIds: [],
       priorStatusById: {},
       closedEdgeChildIds: [],
     };
   }
 
-  const subtree = collectSubtreeThreadIds(driver, runId);
   const cancelledRunIds: string[] = [];
   const priorStatusById: Record<string, string> = {};
   const closedEdgeChildIds: string[] = [];
@@ -239,6 +246,11 @@ function cancelSubtreeLocked(
         cancelReason: reason,
         cancelledBy: runId,
         cancelledAt,
+        // The cascade is one transaction: when the root row says
+        // cascadeComplete, the whole subtree was handled — startup repair
+        // must never re-police this tree (it would re-kill descendants
+        // that were legitimately revived later).
+        ...(threadId === runId ? { cascadeComplete: true } : {}),
       });
       const result = cancelStmt.run(cancelledAt, merged, threadId, status);
       if (result.changes > 0) {
@@ -257,6 +269,7 @@ function cancelSubtreeLocked(
     missing: false,
     alreadyTerminal: false,
     rootStatusBefore: rootStatus,
+    subtreeRunIds: subtree,
     cancelledRunIds,
     priorStatusById,
     closedEdgeChildIds,
@@ -297,28 +310,40 @@ export interface RepairCancelledSubtreesReport {
 }
 
 /**
- * Crash-mid-cascade repair, run inside the startup-recovery transaction
- * BEFORE recoverable runs are loaded: any non-terminal run with a
- * `cancelled` ancestor (edges of any status) is finished off with the
- * same cascade write shape, so recovery completes an interrupted
- * `run.cancel` instead of resurrecting its survivors. Scoped to
- * `cancelled` ancestors only — descendants of completed/errored parents
- * are legitimate survivors.
+ * One-shot repair for cancelled roots whose cascade never ran, executed
+ * inside the startup-recovery transaction BEFORE recoverable runs are
+ * loaded. `cancelAgentRunTree` is a single transaction and stamps
+ * `cascadeComplete` on the root, so cascade-cancelled trees are never
+ * touched here. What remains is a root that became `cancelled` via a
+ * non-cascade writer (e.g. a relayed status transition): its surviving
+ * non-terminal descendants are finished off ONCE, then the root is
+ * stamped `cascadeComplete` so later startups never re-police the tree —
+ * a descendant legitimately revived afterwards (completed → running via a
+ * follow-up message) must not be re-killed forever. Scoped to `cancelled`
+ * ancestors only — descendants of completed/errored parents are
+ * legitimate survivors.
  */
 export function repairCancelledSubtrees(
   driver: StateSqliteDriver,
   options: { readonly now: string },
 ): RepairCancelledSubtreesReport {
   const cancelledRoots = driver
-    .prepareState<[], { id: string }>(
-      "SELECT id FROM agent_runs WHERE status = 'cancelled' ORDER BY id ASC",
+    .prepareState<[], { id: string; metadata_json: string | null }>(
+      `SELECT id, metadata_json FROM agent_runs
+       WHERE status = 'cancelled'
+       ORDER BY id ASC`,
     )
     .all();
   const repairedRunIds: string[] = [];
   const statusStmt = driver.prepareState<[string], { status?: string }>(
     "SELECT status FROM agent_runs WHERE id = ?",
   );
+  const stampStmt = driver.prepareState<[string, string]>(
+    "UPDATE agent_runs SET metadata_json = ? WHERE id = ? AND status = 'cancelled'",
+  );
   for (const root of cancelledRoots) {
+    const metadata = parseJsonObjectOrEmpty(root.metadata_json);
+    if (metadata.cascadeComplete === true) continue;
     const subtree = collectSubtreeThreadIds(driver, root.id);
     for (const threadId of subtree) {
       if (threadId === root.id) continue;
@@ -332,6 +357,10 @@ export function repairCancelledSubtrees(
       );
       repairedRunIds.push(...report.cancelledRunIds);
     }
+    stampStmt.run(
+      JSON.stringify({ ...metadata, cascadeComplete: true }),
+      root.id,
+    );
   }
   return { repairedRunIds };
 }

--- a/runtime/src/state/run-cancellation.ts
+++ b/runtime/src/state/run-cancellation.ts
@@ -1,0 +1,353 @@
+/**
+ * Tree-scoped run cancellation + spawn admission gate (M3 final slice;
+ * design: docs/design/run-cancel-cascade-and-spawn-admission.md).
+ *
+ * Cancellation is durable-first: `cancelAgentRunTree` walks the spawn tree
+ * in ONE transaction and moves every non-terminal descendant (queued AND
+ * running) to `cancelled`, closing open edges, without touching
+ * `in_flight_tool_calls` (partial evidence is preserved and later
+ * classified by the existing recovery category rules). Live interruption
+ * is the daemon's second step and reuses `control.interrupt`'s cascade —
+ * the frozen contract's single propagation primitive.
+ *
+ * Admission under a cancel-locked ancestor is refused fail-closed at the
+ * durable commit point (`ThreadSpawnEdgeRepository.create`) with
+ * {@link SpawnAdmissionBlockedError} — the same shape as the
+ * unknown-outcome mutation gate. The refusal maps to the frozen
+ * `AdmissionDecision` vocabulary as `deny` with a machine-readable reason.
+ *
+ * Only `cancelled` and `unknown_outcome` are cancel-locked. `completed`,
+ * `errored`, and `stopped` runs stay revivable on purpose: a follow-up
+ * message to a completed background agent legitimately flips its run back
+ * to `running` via the snapshot writer.
+ */
+
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+
+/**
+ * Statuses that stick: once a run carries one of these, no write may move
+ * it to a different status (same-status metadata patches still land).
+ */
+export const CANCEL_LOCKED_AGENT_RUN_STATUSES = [
+  "cancelled",
+  "unknown_outcome",
+] as const;
+
+/** Terminal statuses the cascade must never rewrite (history is history). */
+const TERMINAL_AGENT_RUN_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "unknown_outcome",
+  "errored",
+  "error",
+  "stopped",
+]);
+
+/** Hard bound on ancestor walks; matches any realistic spawn depth cap. */
+const MAX_ANCESTOR_WALK = 64;
+
+export function isCancelLockedAgentRunStatus(status: string): boolean {
+  return (CANCEL_LOCKED_AGENT_RUN_STATUSES as readonly string[]).includes(
+    status,
+  );
+}
+
+export function isTerminalAgentRunStatus(status: string): boolean {
+  return TERMINAL_AGENT_RUN_STATUSES.has(status);
+}
+
+export type SpawnAdmissionDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      /** Frozen AdmissionDecision vocabulary member. */
+      readonly decision: "deny";
+      /** Machine-readable refusal reason (no prose-only reasons). */
+      readonly reason: "parent_cancel_locked";
+      readonly parentRunId: string;
+      readonly parentStatus: string;
+    };
+
+export class SpawnAdmissionBlockedError extends Error {
+  readonly code = "SPAWN_ADMISSION_BLOCKED" as const;
+  readonly childThreadId: string;
+  readonly parentRunId: string;
+  readonly parentStatus: string;
+
+  constructor(
+    childThreadId: string,
+    parentRunId: string,
+    parentStatus: string,
+  ) {
+    super(
+      `spawn admission denied for child ${childThreadId}: ancestor run ` +
+        `${parentRunId} is ${parentStatus}; new descendants cannot be ` +
+        `admitted under a cancel-locked run (admission decision: deny, ` +
+        `reason: parent_cancel_locked)`,
+    );
+    this.name = "SpawnAdmissionBlockedError";
+    this.childThreadId = childThreadId;
+    this.parentRunId = parentRunId;
+    this.parentStatus = parentStatus;
+  }
+}
+
+/**
+ * Resolve the nearest ancestor of `parentThreadId` (inclusive) that has an
+ * `agent_runs` row, walking UP `thread_spawn_edges` regardless of edge
+ * status — a closed edge still defines ancestry. Refuse when that
+ * ancestor's status is cancel-locked; allow when no run row exists
+ * anywhere up the chain (nothing durable to gate on).
+ */
+export function checkSpawnAdmissionGate(
+  driver: StateSqliteDriver,
+  options: { readonly parentThreadId: string },
+): SpawnAdmissionDecision {
+  const runStatusStmt = driver.prepareState<[string], { status?: string }>(
+    "SELECT status FROM agent_runs WHERE id = ?",
+  );
+  const parentEdgeStmt = driver.prepareState<
+    [string],
+    { parent_thread_id?: string }
+  >("SELECT parent_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?");
+
+  const seen = new Set<string>();
+  let current: string | undefined = options.parentThreadId;
+  for (let hop = 0; current !== undefined && hop < MAX_ANCESTOR_WALK; hop++) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    const status = runStatusStmt.get(current)?.status;
+    if (status !== undefined) {
+      if (isCancelLockedAgentRunStatus(status)) {
+        return {
+          allowed: false,
+          decision: "deny",
+          reason: "parent_cancel_locked",
+          parentRunId: current,
+          parentStatus: status,
+        };
+      }
+      return { allowed: true };
+    }
+    current = parentEdgeStmt.get(current)?.parent_thread_id;
+  }
+  return { allowed: true };
+}
+
+export interface CancelAgentRunTreeReport {
+  readonly runId: string;
+  /** Root run row does not exist. Nothing was written. */
+  readonly missing: boolean;
+  /** Root was already cancel-locked/terminal. Nothing was written. */
+  readonly alreadyTerminal: boolean;
+  readonly rootStatusBefore: string | null;
+  /** Every run (root included) moved to `cancelled` by this call. */
+  readonly cancelledRunIds: readonly string[];
+  /** Prior status of each cancelled run (queued-vs-running evidence). */
+  readonly priorStatusById: Readonly<Record<string, string>>;
+  /** Open edges closed by this call (child thread ids). */
+  readonly closedEdgeChildIds: readonly string[];
+}
+
+/**
+ * Cancel `runId` and its whole spawn subtree in one transaction: every
+ * non-terminal run in the subtree becomes `cancelled` (terminal
+ * descendants keep their status — cancellation never rewrites history),
+ * every open subtree edge is closed, and `in_flight_tool_calls` rows are
+ * left untouched so partial evidence survives for review.
+ *
+ * Idempotent: an already-terminal root reports `alreadyTerminal` and
+ * mutates nothing; a missing root reports `missing` and mutates nothing.
+ */
+export function cancelAgentRunTree(
+  driver: StateSqliteDriver,
+  options: {
+    readonly runId: string;
+    readonly reason: string;
+    readonly cancelledAt: string;
+  },
+): CancelAgentRunTreeReport {
+  return driver.transaction(() =>
+    cancelSubtreeLocked(driver, options.runId, options.reason, options.cancelledAt),
+  );
+}
+
+function cancelSubtreeLocked(
+  driver: StateSqliteDriver,
+  runId: string,
+  reason: string,
+  cancelledAt: string,
+): CancelAgentRunTreeReport {
+  const runStatusStmt = driver.prepareState<[string], { status?: string }>(
+    "SELECT status FROM agent_runs WHERE id = ?",
+  );
+  const rootStatus = runStatusStmt.get(runId)?.status;
+  if (rootStatus === undefined) {
+    return {
+      runId,
+      missing: true,
+      alreadyTerminal: false,
+      rootStatusBefore: null,
+      cancelledRunIds: [],
+      priorStatusById: {},
+      closedEdgeChildIds: [],
+    };
+  }
+  if (isTerminalAgentRunStatus(rootStatus)) {
+    return {
+      runId,
+      missing: false,
+      alreadyTerminal: true,
+      rootStatusBefore: rootStatus,
+      cancelledRunIds: [],
+      priorStatusById: {},
+      closedEdgeChildIds: [],
+    };
+  }
+
+  const subtree = collectSubtreeThreadIds(driver, runId);
+  const cancelledRunIds: string[] = [];
+  const priorStatusById: Record<string, string> = {};
+  const closedEdgeChildIds: string[] = [];
+
+  const metadataStmt = driver.prepareState<
+    [string],
+    { metadata_json: string | null }
+  >("SELECT metadata_json FROM agent_runs WHERE id = ?");
+  // Status predicate is the CAS: the row is only cancelled from the exact
+  // non-terminal status read above, inside the same transaction.
+  const cancelStmt = driver.prepareState<[string, string, string, string]>(
+    `UPDATE agent_runs
+     SET status = 'cancelled',
+         last_active_at = ?,
+         metadata_json = ?
+     WHERE id = ? AND status = ?`,
+  );
+  const closeEdgeStmt = driver.prepareState<[string]>(
+    `UPDATE thread_spawn_edges
+     SET status = 'closed',
+         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+     WHERE child_thread_id = ? AND status = 'open'`,
+  );
+
+  for (const threadId of subtree) {
+    const status = runStatusStmt.get(threadId)?.status;
+    if (status !== undefined && !isTerminalAgentRunStatus(status)) {
+      const merged = JSON.stringify({
+        ...parseJsonObjectOrEmpty(metadataStmt.get(threadId)?.metadata_json),
+        cancelReason: reason,
+        cancelledBy: runId,
+        cancelledAt,
+      });
+      const result = cancelStmt.run(cancelledAt, merged, threadId, status);
+      if (result.changes > 0) {
+        cancelledRunIds.push(threadId);
+        priorStatusById[threadId] = status;
+      }
+    }
+    if (threadId !== runId) {
+      const closed = closeEdgeStmt.run(threadId);
+      if (closed.changes > 0) closedEdgeChildIds.push(threadId);
+    }
+  }
+
+  return {
+    runId,
+    missing: false,
+    alreadyTerminal: false,
+    rootStatusBefore: rootStatus,
+    cancelledRunIds,
+    priorStatusById,
+    closedEdgeChildIds,
+  };
+}
+
+/** BFS over thread_spawn_edges (any status), root first, cycle-guarded. */
+function collectSubtreeThreadIds(
+  driver: StateSqliteDriver,
+  rootThreadId: string,
+): readonly string[] {
+  const childrenStmt = driver.prepareState<
+    [string],
+    { child_thread_id: string }
+  >(
+    `SELECT child_thread_id FROM thread_spawn_edges
+     WHERE parent_thread_id = ?
+     ORDER BY child_thread_id ASC`,
+  );
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  const queue: string[] = [rootThreadId];
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    ordered.push(current);
+    for (const row of childrenStmt.all(current)) {
+      if (!seen.has(row.child_thread_id)) queue.push(row.child_thread_id);
+    }
+  }
+  return ordered;
+}
+
+export interface RepairCancelledSubtreesReport {
+  /** Runs moved to `cancelled` because a `cancelled` ancestor was found. */
+  readonly repairedRunIds: readonly string[];
+}
+
+/**
+ * Crash-mid-cascade repair, run inside the startup-recovery transaction
+ * BEFORE recoverable runs are loaded: any non-terminal run with a
+ * `cancelled` ancestor (edges of any status) is finished off with the
+ * same cascade write shape, so recovery completes an interrupted
+ * `run.cancel` instead of resurrecting its survivors. Scoped to
+ * `cancelled` ancestors only — descendants of completed/errored parents
+ * are legitimate survivors.
+ */
+export function repairCancelledSubtrees(
+  driver: StateSqliteDriver,
+  options: { readonly now: string },
+): RepairCancelledSubtreesReport {
+  const cancelledRoots = driver
+    .prepareState<[], { id: string }>(
+      "SELECT id FROM agent_runs WHERE status = 'cancelled' ORDER BY id ASC",
+    )
+    .all();
+  const repairedRunIds: string[] = [];
+  const statusStmt = driver.prepareState<[string], { status?: string }>(
+    "SELECT status FROM agent_runs WHERE id = ?",
+  );
+  for (const root of cancelledRoots) {
+    const subtree = collectSubtreeThreadIds(driver, root.id);
+    for (const threadId of subtree) {
+      if (threadId === root.id) continue;
+      const status = statusStmt.get(threadId)?.status;
+      if (status === undefined || isTerminalAgentRunStatus(status)) continue;
+      const report = cancelSubtreeLocked(
+        driver,
+        threadId,
+        "recovery_cascade_repair",
+        options.now,
+      );
+      repairedRunIds.push(...report.cancelledRunIds);
+    }
+  }
+  return { repairedRunIds };
+}
+
+function parseJsonObjectOrEmpty(
+  value: string | null | undefined,
+): Record<string, unknown> {
+  if (value === null || value === undefined || value.trim().length === 0) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -1061,6 +1061,7 @@ function agentRunStatusForTransition(
     case "completed":
     case "errored":
     case "stopped":
+    case "cancelled":
       return transition.runStatus;
   }
   switch (transition.status) {

--- a/runtime/src/state/spawn-edges.ts
+++ b/runtime/src/state/spawn-edges.ts
@@ -50,49 +50,56 @@ export class ThreadSpawnEdgeRepository {
     opts: { readonly admissionGate?: SpawnEdgeAdmissionGateMode } = {},
   ): IndexedThreadSpawnEdge {
     const normalized = normalizeIndexedThreadSpawnEdge(edge);
-    if ((opts.admissionGate ?? "enforce") === "enforce") {
-      const decision = checkSpawnAdmissionGate(this.driver, {
-        parentThreadId: normalized.parentThreadId,
-      });
-      if (!decision.allowed) {
-        throw new SpawnAdmissionBlockedError(
-          normalized.childThreadId,
-          decision.parentRunId,
-          decision.parentStatus,
-        );
+    // Gate check + INSERT run under ONE BEGIN IMMEDIATE transaction: the
+    // write lock is held across the check, so a concurrent cross-process
+    // run.cancel cannot commit between the admission decision and the edge
+    // landing (the TOCTOU that would admit a child under a cancelled
+    // parent that the cascade never enumerated).
+    return this.driver.transactionImmediate(() => {
+      if ((opts.admissionGate ?? "enforce") === "enforce") {
+        const decision = checkSpawnAdmissionGate(this.driver, {
+          parentThreadId: normalized.parentThreadId,
+        });
+        if (!decision.allowed) {
+          throw new SpawnAdmissionBlockedError(
+            normalized.childThreadId,
+            decision.parentRunId,
+            decision.parentStatus,
+          );
+        }
       }
-    }
-    const metadata = normalized.metadata;
-    const result = this.driver
-      .prepareState(
-        `INSERT INTO thread_spawn_edges (
-          child_thread_id,
-          parent_thread_id,
-          parent_path,
-          metadata_json,
-          agent_role_workspace_id,
-          agent_role_fingerprint,
-          status
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(child_thread_id) DO NOTHING`,
-      )
-      .run(
-        normalized.childThreadId,
-        normalized.parentThreadId,
-        normalized.parentPath,
-        JSON.stringify(metadata),
-        metadata.agentRoleWorkspaceId ?? null,
-        metadata.agentRoleFingerprint ?? null,
-        normalized.status,
-      );
-    if (result.changes === 0) {
-      throw new AgentIdExistsError(normalized.childThreadId);
-    }
-    const persisted = this.get(normalized.childThreadId);
-    if (!persisted) {
-      throw new Error("persisted thread-spawn edge could not be read back");
-    }
-    return persisted;
+      const metadata = normalized.metadata;
+      const result = this.driver
+        .prepareState(
+          `INSERT INTO thread_spawn_edges (
+            child_thread_id,
+            parent_thread_id,
+            parent_path,
+            metadata_json,
+            agent_role_workspace_id,
+            agent_role_fingerprint,
+            status
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(child_thread_id) DO NOTHING`,
+        )
+        .run(
+          normalized.childThreadId,
+          normalized.parentThreadId,
+          normalized.parentPath,
+          JSON.stringify(metadata),
+          metadata.agentRoleWorkspaceId ?? null,
+          metadata.agentRoleFingerprint ?? null,
+          normalized.status,
+        );
+      if (result.changes === 0) {
+        throw new AgentIdExistsError(normalized.childThreadId);
+      }
+      const persisted = this.get(normalized.childThreadId);
+      if (!persisted) {
+        throw new Error("persisted thread-spawn edge could not be read back");
+      }
+      return persisted;
+    });
   }
 
   setStatus(

--- a/runtime/src/state/spawn-edges.ts
+++ b/runtime/src/state/spawn-edges.ts
@@ -9,6 +9,20 @@ import {
 } from "../agents/registry.js";
 import type { ThreadSpawnEdgeStatus } from "../session/rollout-store.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
+import {
+  checkSpawnAdmissionGate,
+  SpawnAdmissionBlockedError,
+} from "./run-cancellation.js";
+
+/**
+ * Admission-gate mode for {@link ThreadSpawnEdgeRepository.create}.
+ * "enforce" (default) refuses a new edge whose nearest ancestor run is
+ * cancel-locked (SpawnAdmissionBlockedError). "import" skips the check —
+ * ONLY for historical-topology writers (legacy JSON edge import, state
+ * export/import), which record edges that were admitted in the past
+ * rather than admitting new work now.
+ */
+export type SpawnEdgeAdmissionGateMode = "enforce" | "import";
 
 export interface IndexedThreadSpawnEdge {
   readonly childThreadId: ThreadId;
@@ -31,8 +45,23 @@ interface SpawnEdgeRow {
 export class ThreadSpawnEdgeRepository {
   constructor(private readonly driver: StateSqliteDriver) {}
 
-  create(edge: IndexedThreadSpawnEdge): IndexedThreadSpawnEdge {
+  create(
+    edge: IndexedThreadSpawnEdge,
+    opts: { readonly admissionGate?: SpawnEdgeAdmissionGateMode } = {},
+  ): IndexedThreadSpawnEdge {
     const normalized = normalizeIndexedThreadSpawnEdge(edge);
+    if ((opts.admissionGate ?? "enforce") === "enforce") {
+      const decision = checkSpawnAdmissionGate(this.driver, {
+        parentThreadId: normalized.parentThreadId,
+      });
+      if (!decision.allowed) {
+        throw new SpawnAdmissionBlockedError(
+          normalized.childThreadId,
+          decision.parentRunId,
+          decision.parentStatus,
+        );
+      }
+    }
     const metadata = normalized.metadata;
     const result = this.driver
       .prepareState(

--- a/runtime/src/state/sqlite-driver.ts
+++ b/runtime/src/state/sqlite-driver.ts
@@ -94,6 +94,17 @@ export class StateSqliteDriver {
     return this.state.transaction(fn)();
   }
 
+  /**
+   * BEGIN IMMEDIATE transaction: acquires the write lock before the first
+   * read, so a read-then-write sequence (e.g. an admission-gate check
+   * followed by the gated INSERT) cannot interleave with another process's
+   * commit between the check and the write. Nested calls degrade to a
+   * savepoint inside the outer transaction (better-sqlite3 semantics).
+   */
+  transactionImmediate<T>(fn: () => T): T {
+    return this.state.transaction(fn).immediate();
+  }
+
   logsTransaction<T>(fn: () => T): T {
     return this.logs.transaction(fn)();
   }

--- a/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
@@ -28,6 +28,7 @@ function cancelledReport(runId: string): CancelAgentRunTreeReport {
     missing: false,
     alreadyTerminal: false,
     rootStatusBefore: "running",
+    subtreeRunIds: [runId, `${runId}_child`],
     cancelledRunIds: [runId, `${runId}_child`],
     priorStatusById: { [runId]: "running", [`${runId}_child`]: "pending" },
     closedEdgeChildIds: [`${runId}_child`],
@@ -106,7 +107,7 @@ describe("run.cancel dispatcher contract", () => {
       "operator",
     );
     expect(harness.stopAgent).toHaveBeenCalledWith("run_a", "operator");
-    // Voided holds cover every cancelled run in the subtree.
+    // Voided holds cover the FULL subtree (idempotent superset).
     expect(harness.voidHolds).toHaveBeenCalledWith(["run_a", "run_a_child"]);
     await harness.dispatcher.closeConnection(harness.connection);
   });
@@ -118,6 +119,7 @@ describe("run.cancel dispatcher contract", () => {
         missing: true,
         alreadyTerminal: false,
         rootStatusBefore: null,
+        subtreeRunIds: [],
         cancelledRunIds: [],
         priorStatusById: {},
         closedEdgeChildIds: [],
@@ -138,13 +140,14 @@ describe("run.cancel dispatcher contract", () => {
     await harness.dispatcher.closeConnection(harness.connection);
   });
 
-  it("reports an already-terminal run idempotently without live or budget action", async () => {
+  it("still voids subtree holds on an already-terminal retry (crash between cascade and voiding)", async () => {
     const harness = await dispatchRunCancel({
       report: {
         runId: "done_run",
         missing: false,
         alreadyTerminal: true,
         rootStatusBefore: "cancelled",
+        subtreeRunIds: ["done_run", "done_run_child"],
         cancelledRunIds: [],
         priorStatusById: {},
         closedEdgeChildIds: [],
@@ -154,9 +157,15 @@ describe("run.cancel dispatcher contract", () => {
       request("rc4", "run.cancel", { runId: "done_run" }),
     );
     expect(response).toMatchObject({
-      result: { runId: "done_run", alreadyTerminal: true, voidedHolds: 0 },
+      result: { runId: "done_run", alreadyTerminal: true, voidedHolds: 3 },
     });
-    expect(harness.voidHolds).not.toHaveBeenCalled();
+    // A crash between a prior cancel's durable cascade and its hold
+    // voiding must be recoverable by retry: voiding runs on the subtree
+    // even when nothing new was cancelled.
+    expect(harness.voidHolds).toHaveBeenCalledWith([
+      "done_run",
+      "done_run_child",
+    ]);
     await harness.dispatcher.closeConnection(harness.connection);
   });
 });

--- a/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
@@ -1,0 +1,162 @@
+// run.cancel (frozen Wave-B method): dispatcher routing, param validation,
+// capability advertisement, and the durable-first flow — the state-DB
+// cascade decides the outcome, the live interrupt/stop is best-effort
+// second, and voided budget holds are reported.
+
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
+import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
+import {
+  AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
+  JSON_RPC_VERSION,
+  type JsonObject,
+} from "./protocol/index.js";
+import type { CancelAgentRunTreeReport } from "../../src/state/run-cancellation.js";
+
+function request(id: string, method: string, params?: JsonObject): JsonObject {
+  return {
+    jsonrpc: JSON_RPC_VERSION,
+    id,
+    method,
+    ...(params !== undefined ? { params } : {}),
+  };
+}
+
+function cancelledReport(runId: string): CancelAgentRunTreeReport {
+  return {
+    runId,
+    missing: false,
+    alreadyTerminal: false,
+    rootStatusBefore: "running",
+    cancelledRunIds: [runId, `${runId}_child`],
+    priorStatusById: { [runId]: "running", [`${runId}_child`]: "pending" },
+    closedEdgeChildIds: [`${runId}_child`],
+  };
+}
+
+async function dispatchRunCancel(options: {
+  readonly report: CancelAgentRunTreeReport;
+  readonly interruptResult?: boolean;
+}) {
+  const cancelDurable = vi.fn().mockResolvedValue(options.report);
+  const voidHolds = vi.fn().mockResolvedValue(3);
+  const interruptAgentTurn = vi
+    .fn()
+    .mockResolvedValue(options.interruptResult ?? true);
+  const stopAgent = vi.fn().mockResolvedValue(undefined);
+  const agentManager = new AgenCDaemonAgentManager({
+    runner: {
+      startAgent: vi.fn(),
+      interruptAgentTurn,
+      stopAgent,
+    },
+    cancelRunTreeDurable: cancelDurable,
+    voidBudgetHoldsForAgents: voidHolds,
+  });
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager });
+  const connection = dispatcher.createConnection({
+    sendNotification: () => {},
+  });
+  const init = await connection.dispatch(
+    request("init", "initialize", { protocol: { version: "1.0.0" } }),
+  );
+  return {
+    connection,
+    dispatcher,
+    init,
+    cancelDurable,
+    voidHolds,
+    interruptAgentTurn,
+    stopAgent,
+  };
+}
+
+describe("run.cancel dispatcher contract", () => {
+  it("advertises the capability and routes to the tree-scoped cancel", async () => {
+    const harness = await dispatchRunCancel({
+      report: cancelledReport("run_a"),
+    });
+    const capabilities = (
+      harness.init.result as {
+        capabilities: Record<string, Record<string, boolean>>;
+      }
+    ).capabilities[AGENC_DAEMON_METHOD_CAPABILITIES_KEY];
+    expect(capabilities["run.cancel"]).toBe(true);
+
+    const response = await harness.connection.dispatch(
+      request("rc1", "run.cancel", { runId: "run_a", reason: "operator" }),
+    );
+    expect(response).toMatchObject({
+      result: {
+        runId: "run_a",
+        alreadyTerminal: false,
+        cancelledRunIds: ["run_a", "run_a_child"],
+        closedEdgeChildIds: ["run_a_child"],
+        interruptedLiveAgentIds: ["run_a"],
+        voidedHolds: 3,
+      },
+    });
+    // Durable first, with the caller's reason.
+    expect(harness.cancelDurable).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run_a", reason: "operator" }),
+    );
+    // Live propagation second (interrupt cascades in-runner, then stop).
+    expect(harness.interruptAgentTurn).toHaveBeenCalledWith(
+      "run_a",
+      "operator",
+    );
+    expect(harness.stopAgent).toHaveBeenCalledWith("run_a", "operator");
+    // Voided holds cover every cancelled run in the subtree.
+    expect(harness.voidHolds).toHaveBeenCalledWith(["run_a", "run_a_child"]);
+    await harness.dispatcher.closeConnection(harness.connection);
+  });
+
+  it("maps a missing run to RUN_NOT_FOUND and requires runId", async () => {
+    const harness = await dispatchRunCancel({
+      report: {
+        runId: "ghost",
+        missing: true,
+        alreadyTerminal: false,
+        rootStatusBefore: null,
+        cancelledRunIds: [],
+        priorStatusById: {},
+        closedEdgeChildIds: [],
+      },
+    });
+    const missing = await harness.connection.dispatch(
+      request("rc2", "run.cancel", { runId: "ghost" }),
+    );
+    expect(missing).toMatchObject({
+      error: { data: { code: "RUN_NOT_FOUND" } },
+    });
+    const invalid = await harness.connection.dispatch(
+      request("rc3", "run.cancel", {}),
+    );
+    expect(invalid).toMatchObject({
+      error: { data: { code: "INVALID_ARGUMENT" } },
+    });
+    await harness.dispatcher.closeConnection(harness.connection);
+  });
+
+  it("reports an already-terminal run idempotently without live or budget action", async () => {
+    const harness = await dispatchRunCancel({
+      report: {
+        runId: "done_run",
+        missing: false,
+        alreadyTerminal: true,
+        rootStatusBefore: "cancelled",
+        cancelledRunIds: [],
+        priorStatusById: {},
+        closedEdgeChildIds: [],
+      },
+    });
+    const response = await harness.connection.dispatch(
+      request("rc4", "run.cancel", { runId: "done_run" }),
+    );
+    expect(response).toMatchObject({
+      result: { runId: "done_run", alreadyTerminal: true, voidedHolds: 0 },
+    });
+    expect(harness.voidHolds).not.toHaveBeenCalled();
+    await harness.dispatcher.closeConnection(harness.connection);
+  });
+});

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -66,6 +66,7 @@ const expectedMethods = [
   "agent.attach",
   "agent.stop",
   "agent.logs",
+  "run.cancel",
   "session.create",
   "session.list",
   "session.attach",

--- a/runtime/tests/eval/trust-conformance-executor.test.ts
+++ b/runtime/tests/eval/trust-conformance-executor.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
@@ -83,35 +89,28 @@ describe("trust-conformance executor", () => {
     // markers, 5/7 -> 6/7 with the M4 unknown-outcome gate (a session with
     // an unresolved poisoned effect refuses new side-effecting mutations
     // until explicit review resolution, so dependent_mutations_stopped
-    // genuinely passes).
+    // genuinely passes), 6/7 -> 7/7 with the M3 tree-scoped cancel cascade
+    // + spawn admission gate (cancelAgentRunTree cancels queued AND running
+    // descendants durably; a new spawn edge under the cancelled parent is
+    // refused with the typed SpawnAdmissionBlockedError; the cancelled
+    // parent cannot be revived by an upsert).
     expect(summary.faultFamilyResults).toEqual({
       budget: "passed",
-      cancellation: "failed",
+      cancellation: "passed",
       event_loss: "passed",
       permission: "passed",
       reconnect: "passed",
       restart: "passed",
       uncertain_effect: "passed",
     });
-    expect(summary.passed).toBe(6);
-    expect(summary.failed).toBe(1);
-    expect(summary.trustRecoveryRate).toBeCloseTo(6 / 7, 10);
+    expect(summary.passed).toBe(7);
+    expect(summary.failed).toBe(0);
+    expect(summary.trustRecoveryRate).toBeCloseTo(7 / 7, 10);
   }, 120_000);
 
-  it("reports exactly the known capability-gap invariants as failed", async () => {
+  it("reports zero failed invariants now that every capability gap is closed", async () => {
     const { summary } = await runSuiteOnce();
-    const sortedFailures = [...summary.failedInvariants].sort((a, b) =>
-      `${a.scenarioId}:${a.invariant}`.localeCompare(`${b.scenarioId}:${b.invariant}`));
-    expect(sortedFailures).toEqual([
-      {
-        scenarioId: "cancel-parent-after-child-admission",
-        invariant: "descendant_admission_stopped",
-      },
-      {
-        scenarioId: "cancel-parent-after-child-admission",
-        invariant: "queued_and_running_descendants_cancelled",
-      },
-    ]);
+    expect(summary.failedInvariants).toEqual([]);
     expect(summary.zeroTolerance).toEqual({
       policyEscapeCount: 0,
       duplicatedUncertainMutationCount: 0,
@@ -171,11 +170,9 @@ describe("trust-conformance executor", () => {
     expect(summaryDoc.documentDigest).toMatch(/^sha256:/);
     expect(summaryDoc.summary?.total).toBe(7);
     // Failed attempts keep their forensic state (SQLite DBs, ledger, audit);
-    // passing attempts are cleaned. Only cancellation still fails.
-    const preserved = readdirSync(path.join(outputDir, "attempts"));
-    expect(preserved).toEqual([
-      "trust-cancel-parent-after-child-admission-slot0",
-    ]);
+    // passing attempts are cleaned. With 7/7 passing, no attempt dir is
+    // preserved — the attempts directory is never created.
+    expect(existsSync(path.join(outputDir, "attempts"))).toBe(false);
     // wx flags: a rerun into the same output dir must refuse to clobber.
     await expect(
       runTrustSuiteFromFiles({

--- a/runtime/tests/state/run-cancellation.test.ts
+++ b/runtime/tests/state/run-cancellation.test.ts
@@ -23,6 +23,10 @@ import {
 } from "../../src/state/agent-runs.js";
 import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
 import { recordInFlightToolCallStart } from "../../src/state/tool-output-rotation.js";
+import {
+  exportAgentState,
+  importAgentState,
+} from "../../src/state/export-import.js";
 import { recoverDaemonStateOnStartup } from "../../src/state/recovery.js";
 import { BudgetLedger } from "../../src/budget/ledger.js";
 import {
@@ -237,6 +241,24 @@ describe("spawn admission gate", () => {
     });
   });
 
+  it("refuses through a terminal-but-revivable intermediate run row (whole-chain walk)", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("cancelled_root", "running");
+    run("completed_mid", "completed");
+    edge(edges, "completed_mid", "cancelled_root", "/root");
+    cancelAgentRunTree(driver, {
+      runId: "cancelled_root",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    expect(statusOf("completed_mid")).toBe("completed");
+    // A `completed` intermediate must not shield admissions below it from
+    // the cancelled root: cancellation poisons the whole tree.
+    expect(() =>
+      edge(edges, "late_leaf", "completed_mid", "/root/completed_mid"),
+    ).toThrow(SpawnAdmissionBlockedError);
+  });
+
   it("walks up the spawn tree to the nearest ancestor with a run row", () => {
     const edges = new ThreadSpawnEdgeRepository(driver);
     run("root_run", "running");
@@ -343,6 +365,53 @@ describe("recovery interplay", () => {
     expect(report.recoveredRuns.map((r) => r.id)).not.toContain("parent");
   });
 
+  it("repair is one-shot: a later legitimately revived descendant is never re-killed", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("parent", "running");
+    run("done_child", "completed");
+    edge(edges, "done_child", "parent", "/root");
+    // Cascade cancel: parent stamped cascadeComplete, completed child kept.
+    cancelAgentRunTree(driver, { runId: "parent", reason: "r", cancelledAt: T1 });
+    // The completed child is later legitimately revived (follow-up message).
+    expect(
+      updateAgentRunStatus(driver, {
+        id: "done_child",
+        status: "running",
+        lastActiveAt: T1,
+      }).applied,
+    ).toBe(true);
+    // Startup repair must NOT re-kill it — the cascade already completed.
+    recoverDaemonStateOnStartup(driver, { now: () => T1 });
+    expect(statusOf("done_child")).toBe("running");
+  });
+
+  it("non-cascade cancels are repaired exactly once, then the tree is left alone", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("parent", "running");
+    run("survivor", "running");
+    run("done_child", "completed");
+    edge(edges, "survivor", "parent", "/root");
+    edge(edges, "done_child", "parent", "/root");
+    // Non-cascade cancel writer (e.g. relayed status transition).
+    updateAgentRunStatus(driver, {
+      id: "parent",
+      status: "cancelled",
+      lastActiveAt: T1,
+    });
+    // First startup: survivor finished off, root stamped.
+    recoverDaemonStateOnStartup(driver, { now: () => T1 });
+    expect(statusOf("survivor")).toBe("cancelled");
+    // Completed child revived after the one-shot repair...
+    updateAgentRunStatus(driver, {
+      id: "done_child",
+      status: "running",
+      lastActiveAt: T1,
+    });
+    // ...survives every subsequent startup.
+    recoverDaemonStateOnStartup(driver, { now: () => T1 });
+    expect(statusOf("done_child")).toBe("running");
+  });
+
   it("repairs only descendants of cancelled ancestors, not completed ones", () => {
     const edges = new ThreadSpawnEdgeRepository(driver);
     run("done_parent", "completed");
@@ -353,6 +422,23 @@ describe("recovery interplay", () => {
     expect(statusOf("legit_child")).toBe("running");
     const report = recoverDaemonStateOnStartup(driver, { now: () => T1 });
     expect(report.recoveredRuns.map((r) => r.id)).toContain("legit_child");
+  });
+});
+
+describe("state import over a cancel-locked run", () => {
+  it("refuses atomically instead of half-applying session-state replacement", () => {
+    run("locked_run", "running");
+    const payload = exportAgentState(driver, "locked_run", { now: () => T0 });
+    cancelAgentRunTree(driver, {
+      runId: "locked_run",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    expect(() => importAgentState(driver, payload, { agencHome: home })).toThrow(
+      /review-locked/,
+    );
+    // The refusal rolled the whole transaction back: run row untouched.
+    expect(statusOf("locked_run")).toBe("cancelled");
   });
 });
 
@@ -385,5 +471,31 @@ describe("BudgetLedger.voidHoldsForAgent", () => {
     expect(ledger.snapshot("worker").day.usd).toBeCloseTo(0.5, 10);
     // Voiding again is a no-op.
     expect(ledger.voidHoldsForAgent("worker")).toBe(0);
+  });
+
+  it("refunds the month window for a hold whose day already rolled (voided = full refund)", () => {
+    let now = new Date("2026-07-18T23:50:00.000Z");
+    const ledger = new BudgetLedger({ agencHome: home, now: () => now });
+    const reserved = ledger.tryReserve(
+      {
+        holdId: "hold-rolled-1",
+        agentId: "worker",
+        model: "test-model",
+        estimatedUsd: 4,
+        estimatedTokens: 8_000,
+        reservedAt: now.toISOString(),
+      },
+      () => null,
+    );
+    expect(reserved.reserved).toBe(true);
+    expect(ledger.snapshot("worker").month.usd).toBeCloseTo(4, 10);
+    // The day rolls (same month): the day debit is zeroed by the roll,
+    // but the month window still carries the hold's debit.
+    now = new Date("2026-07-19T00:10:00.000Z");
+    expect(ledger.voidHoldsForAgent("worker")).toBe(1);
+    expect(ledger.snapshot("worker").day.usd).toBeCloseTo(0, 10);
+    // `voided` is a FULL refund: the month debit is released too — unlike
+    // consumeHold's window_rolled, which keeps it (unknown usage).
+    expect(ledger.snapshot("worker").month.usd).toBeCloseTo(0, 10);
   });
 });

--- a/runtime/tests/state/run-cancellation.test.ts
+++ b/runtime/tests/state/run-cancellation.test.ts
@@ -1,0 +1,389 @@
+// M3 final slice: tree-scoped run cancellation cascade + spawn admission
+// gate. Cancelling a run moves every non-terminal descendant (queued AND
+// running) to `cancelled` in one transaction, closes open spawn edges, and
+// preserves in-flight tool-call evidence. A new spawn edge under a
+// cancel-locked ancestor is refused with the typed
+// SpawnAdmissionBlockedError; cancelled/unknown_outcome statuses are
+// sticky against upsert/update laundering; startup recovery finishes a
+// crash-interrupted cascade instead of resurrecting survivors.
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cancelAgentRunTree,
+  checkSpawnAdmissionGate,
+  repairCancelledSubtrees,
+  SpawnAdmissionBlockedError,
+} from "../../src/state/run-cancellation.js";
+import {
+  upsertAgentRun,
+  updateAgentRunStatus,
+} from "../../src/state/agent-runs.js";
+import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
+import { recordInFlightToolCallStart } from "../../src/state/tool-output-rotation.js";
+import { recoverDaemonStateOnStartup } from "../../src/state/recovery.js";
+import { BudgetLedger } from "../../src/budget/ledger.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+
+let home: string;
+let cwd: string;
+let driver: StateSqliteDriver;
+
+const T0 = "2026-07-18T00:00:00.000Z";
+const T1 = "2026-07-18T00:05:00.000Z";
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-run-cancel-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-run-cancel-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome: home });
+});
+
+afterEach(() => {
+  driver.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function run(id: string, status: string): void {
+  upsertAgentRun(driver, {
+    id,
+    objective: id,
+    status,
+    startedAt: T0,
+    lastActiveAt: T0,
+  });
+}
+
+function edge(
+  edges: ThreadSpawnEdgeRepository,
+  childId: string,
+  parentId: string,
+  parentPath: string,
+  opts?: { admissionGate?: "enforce" | "import" },
+): void {
+  const depth = `${parentPath}/${childId}`.split("/").length - 2;
+  edges.create(
+    {
+      childThreadId: childId,
+      parentThreadId: parentId,
+      parentPath,
+      metadata: { agentId: childId, agentPath: `${parentPath}/${childId}`, depth },
+      status: "open",
+    },
+    opts,
+  );
+}
+
+function statusOf(id: string): string | undefined {
+  return driver
+    .prepareState<[string], { status?: string }>(
+      "SELECT status FROM agent_runs WHERE id = ?",
+    )
+    .get(id)?.status;
+}
+
+function edgeStatusOf(childId: string): string | undefined {
+  return driver
+    .prepareState<[string], { status?: string }>(
+      "SELECT status FROM thread_spawn_edges WHERE child_thread_id = ?",
+    )
+    .get(childId)?.status;
+}
+
+describe("cancelAgentRunTree", () => {
+  it("cancels queued and running descendants transitively, closes open edges, preserves evidence", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("parent", "running");
+    run("child_running", "running");
+    run("child_queued", "pending");
+    run("grandchild", "working");
+    run("child_done", "completed");
+    edge(edges, "child_running", "parent", "/root");
+    edge(edges, "child_queued", "parent", "/root");
+    edge(edges, "grandchild", "child_running", "/root/child_running");
+    edge(edges, "child_done", "parent", "/root");
+    edges.setStatus("child_done", "closed");
+    recordInFlightToolCallStart(driver, {
+      sessionId: "cancel-session",
+      agentId: "child_running",
+      toolCallId: "cancel-tool-1",
+      toolName: "Bash",
+      args: { command: "echo partial" },
+      startedAt: T0,
+      recoveryCategory: "side-effecting",
+      agencHome: home,
+    });
+
+    const report = cancelAgentRunTree(driver, {
+      runId: "parent",
+      reason: "test-cancel",
+      cancelledAt: T1,
+    });
+
+    expect(report.missing).toBe(false);
+    expect(report.alreadyTerminal).toBe(false);
+    expect([...report.cancelledRunIds].sort()).toEqual([
+      "child_queued",
+      "child_running",
+      "grandchild",
+      "parent",
+    ]);
+    expect(report.priorStatusById).toEqual({
+      parent: "running",
+      child_running: "running",
+      child_queued: "pending",
+      grandchild: "working",
+    });
+    for (const id of ["parent", "child_running", "child_queued", "grandchild"]) {
+      expect(statusOf(id)).toBe("cancelled");
+    }
+    // Terminal history is never rewritten.
+    expect(statusOf("child_done")).toBe("completed");
+    // Open subtree edges are closed; the already-closed one is untouched.
+    expect(edgeStatusOf("child_running")).toBe("closed");
+    expect(edgeStatusOf("child_queued")).toBe("closed");
+    expect(edgeStatusOf("grandchild")).toBe("closed");
+    expect([...report.closedEdgeChildIds].sort()).toEqual([
+      "child_queued",
+      "child_running",
+      "grandchild",
+    ]);
+    // Partial evidence preserved: the in-flight row is untouched.
+    const evidenceRow = driver
+      .prepareState<[string], { status?: string }>(
+        "SELECT status FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .get("cancel-tool-1");
+    expect(evidenceRow).toBeDefined();
+    // Cancel metadata is recorded on each cancelled run.
+    const meta = driver
+      .prepareState<[string], { metadata_json?: string }>(
+        "SELECT metadata_json FROM agent_runs WHERE id = ?",
+      )
+      .get("grandchild")?.metadata_json;
+    expect(JSON.parse(meta ?? "{}")).toMatchObject({
+      cancelReason: "test-cancel",
+      cancelledBy: "parent",
+      cancelledAt: T1,
+    });
+  });
+
+  it("is idempotent and honest about missing runs", () => {
+    run("parent", "running");
+    const first = cancelAgentRunTree(driver, {
+      runId: "parent",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    expect(first.cancelledRunIds).toEqual(["parent"]);
+    const second = cancelAgentRunTree(driver, {
+      runId: "parent",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    expect(second.alreadyTerminal).toBe(true);
+    expect(second.cancelledRunIds).toEqual([]);
+    const missing = cancelAgentRunTree(driver, {
+      runId: "no_such_run",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    expect(missing.missing).toBe(true);
+  });
+
+  it("survives an edge cycle without hanging", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("a", "running");
+    run("b", "running");
+    edge(edges, "b", "a", "/root");
+    // A hostile/corrupt reverse edge forming a cycle (b -> a).
+    edge(edges, "a", "b", "/root/b");
+    const report = cancelAgentRunTree(driver, {
+      runId: "a",
+      reason: "cycle",
+      cancelledAt: T1,
+    });
+    expect([...report.cancelledRunIds].sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("spawn admission gate", () => {
+  it("refuses a new edge under a cancelled parent with the typed error, and only then", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("parent", "running");
+    edge(edges, "ok_child", "parent", "/root");
+    cancelAgentRunTree(driver, { runId: "parent", reason: "r", cancelledAt: T1 });
+
+    run("late_child", "running");
+    expect(() => edge(edges, "late_child", "parent", "/root")).toThrow(
+      SpawnAdmissionBlockedError,
+    );
+    expect(edgeStatusOf("late_child")).toBeUndefined();
+    const decision = checkSpawnAdmissionGate(driver, {
+      parentThreadId: "parent",
+    });
+    expect(decision).toEqual({
+      allowed: false,
+      decision: "deny",
+      reason: "parent_cancel_locked",
+      parentRunId: "parent",
+      parentStatus: "cancelled",
+    });
+  });
+
+  it("walks up the spawn tree to the nearest ancestor with a run row", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("root_run", "running");
+    // Middle thread has NO agent_runs row — only the edge chain links it.
+    edge(edges, "middle", "root_run", "/root");
+    edge(edges, "leaf", "middle", "/root/middle");
+    cancelAgentRunTree(driver, {
+      runId: "root_run",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    // Admitting under "middle" must find the cancelled root ancestor —
+    // even though middle's own edge is now closed (ancestry survives).
+    expect(() => edge(edges, "late", "middle", "/root/middle")).toThrow(
+      SpawnAdmissionBlockedError,
+    );
+  });
+
+  it("allows spawns under live parents, unknown parents, and in import mode", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("live_parent", "running");
+    edge(edges, "child_ok", "live_parent", "/root");
+    expect(edgeStatusOf("child_ok")).toBe("open");
+    // No run row anywhere up the chain: nothing durable to gate on.
+    edge(edges, "orphan_child", "unknown_thread", "/root");
+    expect(edgeStatusOf("orphan_child")).toBe("open");
+    // Import mode records historical topology even under a cancelled run.
+    cancelAgentRunTree(driver, {
+      runId: "live_parent",
+      reason: "r",
+      cancelledAt: T1,
+    });
+    edge(edges, "historic_child", "live_parent", "/root", {
+      admissionGate: "import",
+    });
+    expect(edgeStatusOf("historic_child")).toBe("open");
+  });
+});
+
+describe("cancel-lock stickiness", () => {
+  it("refuses to move a cancelled run to a different status via update or upsert", () => {
+    run("victim", "running");
+    cancelAgentRunTree(driver, { runId: "victim", reason: "r", cancelledAt: T1 });
+
+    const updated = updateAgentRunStatus(driver, {
+      id: "victim",
+      status: "running",
+      lastActiveAt: T1,
+    });
+    expect(updated).toEqual({
+      applied: false,
+      reason: "cancel_locked_status_sticky",
+      existingStatus: "cancelled",
+    });
+    const upserted = upsertAgentRun(driver, {
+      id: "victim",
+      objective: "victim",
+      status: "errored",
+      startedAt: T0,
+      lastActiveAt: T1,
+    });
+    expect(upserted.applied).toBe(false);
+    expect(statusOf("victim")).toBe("cancelled");
+
+    // Same-status writes still land (metadata patches on the record).
+    const sameStatus = updateAgentRunStatus(driver, {
+      id: "victim",
+      status: "cancelled",
+      lastActiveAt: T1,
+      metadataPatch: { note: "reviewed" },
+    });
+    expect(sameStatus.applied).toBe(true);
+  });
+
+  it("keeps completed runs revivable (follow-up-message flow)", () => {
+    run("finished", "completed");
+    const revived = updateAgentRunStatus(driver, {
+      id: "finished",
+      status: "running",
+      lastActiveAt: T1,
+    });
+    expect(revived.applied).toBe(true);
+    expect(statusOf("finished")).toBe("running");
+  });
+});
+
+describe("recovery interplay", () => {
+  it("finishes a crash-interrupted cascade instead of resurrecting survivors", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("parent", "running");
+    run("survivor", "running");
+    edge(edges, "survivor", "parent", "/root");
+    // Simulate a crash mid-cascade: parent cancelled, descendant missed.
+    updateAgentRunStatus(driver, {
+      id: "parent",
+      status: "cancelled",
+      lastActiveAt: T1,
+    });
+    expect(statusOf("survivor")).toBe("running");
+
+    const report = recoverDaemonStateOnStartup(driver, { now: () => T1 });
+    expect(statusOf("survivor")).toBe("cancelled");
+    expect(report.recoveredRuns.map((r) => r.id)).not.toContain("survivor");
+    expect(report.recoveredRuns.map((r) => r.id)).not.toContain("parent");
+  });
+
+  it("repairs only descendants of cancelled ancestors, not completed ones", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("done_parent", "completed");
+    run("legit_child", "running");
+    edge(edges, "legit_child", "done_parent", "/root");
+    const repair = repairCancelledSubtrees(driver, { now: T1 });
+    expect(repair.repairedRunIds).toEqual([]);
+    expect(statusOf("legit_child")).toBe("running");
+    const report = recoverDaemonStateOnStartup(driver, { now: () => T1 });
+    expect(report.recoveredRuns.map((r) => r.id)).toContain("legit_child");
+  });
+});
+
+describe("BudgetLedger.voidHoldsForAgent", () => {
+  it("releases open holds without touching recorded spend", () => {
+    const ledger = new BudgetLedger({
+      agencHome: home,
+      now: () => new Date("2026-07-18T00:10:00.000Z"),
+    });
+    ledger.addSpend("worker", 0.5, 1_000);
+    const reserved = ledger.tryReserve(
+      {
+        holdId: "hold-void-1",
+        agentId: "worker",
+        model: "test-model",
+        estimatedUsd: 2,
+        estimatedTokens: 4_000,
+        reservedAt: "2026-07-18T00:10:00.000Z",
+      },
+      () => null,
+    );
+    expect(reserved.reserved).toBe(true);
+    expect(ledger.listOpenHolds("worker")).toHaveLength(1);
+    expect(ledger.snapshot("worker").day.usd).toBeCloseTo(2.5, 10);
+
+    expect(ledger.voidHoldsForAgent("worker")).toBe(1);
+    expect(ledger.listOpenHolds("worker")).toHaveLength(0);
+    // Spend recorded before the hold is untouched; only the reservation
+    // debit was refunded.
+    expect(ledger.snapshot("worker").day.usd).toBeCloseTo(0.5, 10);
+    // Voiding again is a no-op.
+    expect(ledger.voidHoldsForAgent("worker")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The final trust-conformance scoreboard slice: closes the last red family (cancellation) — **TRR 6/7 → 7/7**.

- **`runtime/src/state/run-cancellation.ts`** — `cancelAgentRunTree` (one-transaction durable cascade over the spawn tree: queued + running descendants → `cancelled`, open edges closed, in-flight evidence preserved, root stamped `cascadeComplete`), `checkSpawnAdmissionGate` (whole-ancestor-chain walk; refuses under `cancelled`/`unknown_outcome`), typed `SpawnAdmissionBlockedError`, `repairCancelledSubtrees` (one-shot startup repair for non-cascade cancels — never re-kills later-revived descendants).
- **Gate enforced at the durable commit point**: `ThreadSpawnEdgeRepository.create` runs gate + INSERT under one `BEGIN IMMEDIATE` transaction (closes the cross-process TOCTOU); `"import"` mode only for the legacy JSON edge import.
- **Cancel-lock stickiness**: `cancelled`/`unknown_outcome` cannot be laundered away via `upsertAgentRun`/`updateAgentRunStatus`; `completed` runs stay revivable (follow-up-message flow). `importAgentState` fails atomically over a cancel-locked run.
- **`run.cancel` daemon method** (frozen Wave-B name): durable cascade first, live interrupt/stop second (independently best-effort), open budget holds voided across the full subtree — including on `alreadyTerminal` retries (crash recovery). `BudgetLedger.voidHoldsForAgent` = frozen `voided` resolution (full refund incl. month window for day-rolled holds; spend untouched). Full wiring: `AGENC_DAEMON_METHODS`, dispatcher + validator, capability table, schema.json, embedding-SDK mirror.
- **Recovery interplay**: `recoverDaemonStateOnStartup` repairs cancelled subtrees before loading recoverable runs — survivors of a non-cascade cancel are finished off instead of resurrected.
- **Trust executor**: cancellation driver now drives the real primitives; per-family pins flip to 7/7.

Design doc: `docs/design/run-cancel-cascade-and-spawn-admission.md` (constraints from the frozen `docs/design/shared-run-contracts-v1.md`).

## Review

3-lens adversarial review workflow (concurrency/durability, semantic bypass, regression/contract): 9 confirmed findings (2 HIGH) — all fixed in the follow-up commit; 2 refuted with evidence. Notable fixes: gate+INSERT TOCTOU (BEGIN IMMEDIATE), one-shot repair (`cascadeComplete` stamp), hold-void crash recovery via `subtreeRunIds`, month-window void refund.

## Verification

- Full runtime suite: 1813 files / 15,618 tests passed.
- New tests: `tests/state/run-cancellation.test.ts` (17), `tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts` (3); executor pins both directions.
- Revert-sensitive: with enforcement neutered, 9 tests go red.
- Cross-repo contracts green (sibling `agenc-protocol` schema + `agenc-sdk` daemon wrapper synced in their working trees — need commits in those repos).