### PR TITLE
feat(runtime): make runs, effects, and events durable

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,14 +4,15 @@ A current map of how `agenc` is put together (runtime **0.6.2**). For the
 user-facing CLI, quick start, and install paths see [`../README.md`](../README.md)
 and [`quickstart.md`](quickstart.md). Reference docs for operators and embedders:
 
-| Doc | Scope |
-| --- | --- |
-| [`reference/daemon.md`](reference/daemon.md) | Daemon process, socket, protocol, lifecycle |
-| [`reference/providers.md`](reference/providers.md) | Built-in providers, defaults, credentials |
-| [`reference/autonomy.md`](reference/autonomy.md) | Budget, heartbeat, cron delivery, hooks HTTP |
-| [`design/execution-admission-kernel.md`](design/execution-admission-kernel.md) | Live durable budget/admission design |
-| [`gateway.md`](gateway.md) | Channel gateway operator guide |
-| [`sdk.md`](sdk.md) | `@tetsuo-ai/agenc-sdk` embedding API |
+| Doc                                                                              | Scope                                                                        |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [`reference/daemon.md`](reference/daemon.md)                                     | Daemon process, socket, protocol, lifecycle                                  |
+| [`reference/providers.md`](reference/providers.md)                               | Built-in providers, defaults, credentials                                    |
+| [`reference/autonomy.md`](reference/autonomy.md)                                 | Budget, heartbeat, cron delivery, hooks HTTP                                 |
+| [`design/execution-admission-kernel.md`](design/execution-admission-kernel.md)   | Live durable budget/admission design                                         |
+| [`design/durable-runs-effects-events.md`](design/durable-runs-effects-events.md) | Canonical run journal, effects, terminal results, replay, and crash recovery |
+| [`gateway.md`](gateway.md)                                                       | Channel gateway operator guide                                               |
+| [`sdk.md`](sdk.md)                                                               | `@tetsuo-ai/agenc-sdk` embedding API                                         |
 
 ## Process model
 
@@ -53,89 +54,129 @@ Everything past the launcher lives in the single runtime workspace
 
 ### Packages
 
-| Package | Role |
-| --- | --- |
-| `packages/agenc` (`@tetsuo-ai/agenc`) | Public launcher + postinstall runtime ensure |
-| `packages/agenc-sdk` (`@tetsuo-ai/agenc-sdk`) | Zero-dep embedding/control client for the daemon protocol |
-| `runtime` (`@tetsuo-ai/runtime`) | Full runtime: CLI, daemon, TUI, session/agent engine, tools, providers |
+| Package                                       | Role                                                                   |
+| --------------------------------------------- | ---------------------------------------------------------------------- |
+| `packages/agenc` (`@tetsuo-ai/agenc`)         | Public launcher + postinstall runtime ensure                           |
+| `packages/agenc-sdk` (`@tetsuo-ai/agenc-sdk`) | Zero-dep embedding/control client for the daemon protocol              |
+| `runtime` (`@tetsuo-ai/runtime`)              | Full runtime: CLI, daemon, TUI, session/agent engine, tools, providers |
 
 ## Runtime subsystems (`runtime/src`)
 
-| Dir | Responsibility |
-| --- | --- |
-| `bin/` | CLI entry (`agenc.ts`) and subcommand adapters: auth, config, mcp, doctor, init, providers, state, budget, gateway, remote, security, onboard, update, trajectories, … |
-| `app-server/` | Daemon: transports, JSON-RPC dispatch, agent/session lifecycle, auth, health, background-agent runner, command exec, realtime, overload limits |
-| `app-server-client/` | In-process / client helpers for talking to the daemon |
-| `app-server-protocol/` | Shared protocol constants (e.g. portal default local endpoint) |
-| `session/` | Session engine: turn loop, transcript, append-only rollout store + `index.json`, resume, cost, autonomous mode |
-| `agents/` | Background-agent state, registry, roles, mailbox, worktree isolation, workflow runner, delegate/fork |
-| `auth/` | Local and remote auth backends, BYOK precedence, provider auth selection, session auth state |
-| `llm/` | Provider-neutral client/request shaping, model catalog, retries, streaming, wire adapters, OAuth refresh |
-| `tools/` | Built-in model tools (Bash, File read/write/edit, `apply_patch`, Web fetch/search, LSP, MCP, Agent/subagent, Task*, …) |
-| `tool-registry.ts` / `tools.ts` | Tool registration and assembly entry points |
-| `permissions/` | Trust, approval policy, rules, modes, sandbox policy, unattended policy, guardian/classifier, audit log |
-| `sandbox/` | OS sandbox launch helpers (bubblewrap/Landlock on Linux, Seatbelt on macOS via `@anthropic-ai/sandbox-runtime`) |
-| `mcp-client/` / `mcp-server/` / `mcp/` | Outbound MCP client, server framework, and serve bootstrap |
-| `gateway/` | Channel gateway as a **daemon client**: Telegram, Discord, Slack, WebChat, stdio; pairing, bindings, approvals, session routing, untrusted framing, hooks HTTP, cron delivery, optional media/onchain helpers. See [`gateway.md`](gateway.md). |
-| `heartbeat/` | Proactive ticks: policy, `HEARTBEAT.md` reader, runner, scheduler, gateway/budget wire. See [`reference/autonomy.md`](reference/autonomy.md). |
-| `budget/` | Daemon-owned execution admission, hierarchical budgets, concurrency, cancellation, and durable reconciliation. See [`design/execution-admission-kernel.md`](design/execution-admission-kernel.md). |
-| `phases/` | Turn phases: stream model, execute tools, commit, stop hooks, post-sample recovery, continuation nudge |
-| `hooks/` | Configured lifecycle hooks (PreToolUse / PostToolUse / Stop / …) and hook engine |
-| `elicitation/` | Structured user-input / MCP elicitation request-response |
-| `memory/` / `memdir/` | Project/session memory extraction, storage, aging, retrieval; team memory paths |
-| `config/` | Config schema, loader, migrations, profiles, model/provider resolution |
-| `state/` | On-disk SQLite project state, migrations, recovery, pruning, agent-runs, health stats |
-| `secrets/` | Secret redaction / sanitizer |
-| `transaction-guard/` | Opt-in local SLM guard for Solana-like mutating tool calls |
-| `unified-exec/` / `pty/` / `shell-command/` | Process execution, PTY helpers, shell parsing/safety |
-| `commands/` | Slash-command registry and TUI/headless command implementations |
-| `plugins/` / `skills/` / `outputStyles/` | Plugin manifests/marketplace/registration; skill loading; output styles |
-| `prompts/` | System prompt assembly, sections, attachments |
-| `cost/` | Session cost tracker + hook |
-| `coordinator/` | Coordinator mode (orchestrate via spawned agents) |
-| `personality/` | Personality migration / resolution helpers |
-| `planning/` | Plan files and exit-plan approval |
-| `thread-store/` | Live thread + file thread store for rollouts |
-| `tasks/` | Task UI / task store surface for agent work items |
-| `file-watcher/` | Workspace file-watch helpers |
-| `transport/` | Transport fallback ladder |
-| `services/` | Concrete provider/API wire layer, caching, and related services |
-| `recovery/` | Crash/recovery helpers for in-flight work |
-| `onboarding/` | Guided `agenc onboard` wizard UI |
-| `eval/` | Legacy diagnostic agent-eval report schema (runner lives under `runtime/scripts` + `runtime/eval`) |
-| `eval-contract/` | Immutable task/preregistration/evidence/score contract v1 |
-| `eval-suites/` | Versioned competitive/trust suite definitions, catalog, schedule compiler, and validators |
-| `tui/` | Terminal UI (custom Ink reconciler fork under `tui/ink`) |
-| `entrypoints/` | Public/SDK type entry surfaces |
-| `protocol/` | Marketplace protocol A1/A2 (read-only CLI adapter + types); mutating claim verbs reserved / owner-gated |
-| `bootstrap/` / `lifecycle/` / `conversation/` | Bootstrap state, shutdown/signals, conversation token-budget and realtime |
-| `constants/` / `types/` / `errors/` / `utils/` / `context/` / `schemas/` | Shared constants, pure types, error shaping, utilities |
-| `browser/` | Isolated Chromium CDP driver + SSRF proxy for the LIVE `Browser` tool |
-| `build/` / `version.ts` / `index.ts` | Feature flags, version stamp (`0.6.2`), public barrel |
+| Dir                                                                      | Responsibility                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bin/`                                                                   | CLI entry (`agenc.ts`) and subcommand adapters: auth, config, mcp, doctor, init, providers, state, budget, gateway, remote, security, onboard, update, trajectories, …                                                                         |
+| `app-server/`                                                            | Daemon: transports, JSON-RPC dispatch, agent/session lifecycle, durable run inspection/replay, auth, health, background-agent runner, command exec, realtime, overload limits                                                                  |
+| `app-server-client/`                                                     | In-process / client helpers for talking to the daemon                                                                                                                                                                                          |
+| `app-server-protocol/`                                                   | Shared protocol constants (e.g. portal default local endpoint)                                                                                                                                                                                 |
+| `session/`                                                               | Session engine: turn loop, transcript, canonical append-only rollout journal + `index.json`, persist-before-publish events, resume, cost, autonomous mode                                                                                      |
+| `agents/`                                                                | Background-agent state, registry, roles, mailbox, worktree isolation, workflow runner, delegate/fork                                                                                                                                           |
+| `auth/`                                                                  | Local and remote auth backends, BYOK precedence, provider auth selection, session auth state                                                                                                                                                   |
+| `llm/`                                                                   | Provider-neutral client/request shaping, model catalog, retries, streaming, wire adapters, OAuth refresh                                                                                                                                       |
+| `tools/`                                                                 | Built-in model tools (Bash, File read/write/edit, `apply_patch`, Web fetch/search, LSP, MCP, Agent/subagent, Task*, …)                                                                                                                         |
+| `tool-registry.ts` / `tools.ts`                                          | Tool registration and assembly entry points                                                                                                                                                                                                    |
+| `permissions/`                                                           | Trust, approval policy, rules, modes, sandbox policy, unattended policy, guardian/classifier, audit log                                                                                                                                        |
+| `sandbox/`                                                               | OS sandbox launch helpers (bubblewrap/Landlock on Linux, Seatbelt on macOS via `@anthropic-ai/sandbox-runtime`)                                                                                                                                |
+| `mcp-client/` / `mcp-server/` / `mcp/`                                   | Outbound MCP client, server framework, and serve bootstrap                                                                                                                                                                                     |
+| `gateway/`                                                               | Channel gateway as a **daemon client**: Telegram, Discord, Slack, WebChat, stdio; pairing, bindings, approvals, session routing, untrusted framing, hooks HTTP, cron delivery, optional media/onchain helpers. See [`gateway.md`](gateway.md). |
+| `heartbeat/`                                                             | Proactive ticks: policy, `HEARTBEAT.md` reader, runner, scheduler, gateway/budget wire. See [`reference/autonomy.md`](reference/autonomy.md).                                                                                                  |
+| `budget/`                                                                | Daemon-owned execution admission, hierarchical budgets, concurrency, cancellation, and durable reconciliation. See [`design/execution-admission-kernel.md`](design/execution-admission-kernel.md).                                             |
+| `phases/`                                                                | Turn phases: stream model, execute tools, commit, stop hooks, post-sample recovery, continuation nudge                                                                                                                                         |
+| `hooks/`                                                                 | Configured lifecycle hooks (PreToolUse / PostToolUse / Stop / …) and hook engine                                                                                                                                                               |
+| `elicitation/`                                                           | Structured user-input / MCP elicitation request-response                                                                                                                                                                                       |
+| `memory/` / `memdir/`                                                    | Project/session memory extraction, storage, aging, retrieval; team memory paths                                                                                                                                                                |
+| `config/`                                                                | Config schema, loader, migrations, profiles, model/provider resolution                                                                                                                                                                         |
+| `state/`                                                                 | On-disk SQLite project state, migrations, rebuildable run/effect/journal projections, recovery, pruning, agent-runs, health stats                                                                                                              |
+| `durability/`                                                            | Crash failpoints and immutable, atomic artifact publication                                                                                                                                                                                    |
+| `secrets/`                                                               | Secret redaction / sanitizer                                                                                                                                                                                                                   |
+| `transaction-guard/`                                                     | Opt-in local SLM guard for Solana-like mutating tool calls                                                                                                                                                                                     |
+| `unified-exec/` / `pty/` / `shell-command/`                              | Process execution, PTY helpers, shell parsing/safety                                                                                                                                                                                           |
+| `commands/`                                                              | Slash-command registry and TUI/headless command implementations                                                                                                                                                                                |
+| `plugins/` / `skills/` / `outputStyles/`                                 | Plugin manifests/marketplace/registration; skill loading; output styles                                                                                                                                                                        |
+| `prompts/`                                                               | System prompt assembly, sections, attachments                                                                                                                                                                                                  |
+| `cost/`                                                                  | Session cost tracker + hook                                                                                                                                                                                                                    |
+| `coordinator/`                                                           | Coordinator mode (orchestrate via spawned agents)                                                                                                                                                                                              |
+| `personality/`                                                           | Personality migration / resolution helpers                                                                                                                                                                                                     |
+| `planning/`                                                              | Plan files and exit-plan approval                                                                                                                                                                                                              |
+| `thread-store/`                                                          | Live thread + file thread store for rollouts                                                                                                                                                                                                   |
+| `tasks/`                                                                 | Task UI / task store surface for agent work items                                                                                                                                                                                              |
+| `file-watcher/`                                                          | Workspace file-watch helpers                                                                                                                                                                                                                   |
+| `transport/`                                                             | Transport fallback ladder                                                                                                                                                                                                                      |
+| `services/`                                                              | Concrete provider/API wire layer, caching, and related services                                                                                                                                                                                |
+| `recovery/`                                                              | Crash/recovery helpers for in-flight work                                                                                                                                                                                                      |
+| `onboarding/`                                                            | Guided `agenc onboard` wizard UI                                                                                                                                                                                                               |
+| `eval/`                                                                  | Legacy diagnostic agent-eval report schema (runner lives under `runtime/scripts` + `runtime/eval`)                                                                                                                                             |
+| `eval-contract/`                                                         | Immutable task/preregistration/evidence/score contract v1                                                                                                                                                                                      |
+| `eval-suites/`                                                           | Versioned competitive/trust suite definitions, catalog, schedule compiler, and validators                                                                                                                                                      |
+| `tui/`                                                                   | Terminal UI (custom Ink reconciler fork under `tui/ink`)                                                                                                                                                                                       |
+| `entrypoints/`                                                           | Public/SDK type entry surfaces                                                                                                                                                                                                                 |
+| `protocol/`                                                              | Marketplace protocol A1/A2 (read-only CLI adapter + types); mutating claim verbs reserved / owner-gated                                                                                                                                        |
+| `bootstrap/` / `lifecycle/` / `conversation/`                            | Bootstrap state, shutdown/signals, conversation token-budget and realtime                                                                                                                                                                      |
+| `constants/` / `types/` / `errors/` / `utils/` / `context/` / `schemas/` | Shared constants, pure types, error shaping, utilities                                                                                                                                                                                         |
+| `browser/`                                                               | Isolated Chromium CDP driver + SSRF proxy for the LIVE `Browser` tool                                                                                                                                                                          |
+| `build/` / `version.ts` / `index.ts`                                     | Feature flags, version stamp (`0.6.2`), public barrel                                                                                                                                                                                          |
 
 ## State on disk (`AGENC_HOME`, default `~/.agenc`)
 
 The daemon and runtime persist under one home. Relocate with an absolute
 `AGENC_HOME=/path`; relative values are rejected.
 
-| Path | Purpose |
-| --- | --- |
-| `daemon.sock` | Unix domain socket (clients + SDK) |
-| `daemon.cookie` | Shared secret for local client auth (0600) |
-| `daemon.pid` | Detached daemon PID |
-| `daemon.log` | Daemon log sink |
-| `daemon-snapshot.json` / runtime info files | Restart/recovery metadata |
-| `config.toml` | Operator config (`[budget]`, `[heartbeat]`, providers, …) |
-| `auth.json` | Stored credentials / auth backend state |
-| `runtime/<version>/<artifact-key>-sha256-<digest>/` | Immutable content-addressed, ABI-keyed runtimes; staged/backup promotion is crash-recoverable |
-| `runtime/.activation-lock.sqlite` / `.activation-transaction.json` | `AGENC_HOME` activation lock and durable roll-forward journal; canonical wrapper locks live in a private per-user registry |
-| `gateway/` | Gateway sessions map, pairing, webchat token, heartbeat session id, control plane |
-| `projects/<slug>/` | Per-project SQLite state (including execution-admission queue, allocations, reservations, cancellation, journal) + `sessions/<id>/` rollouts |
-| `sessions/` (project-scoped) | Append-only JSONL rollouts + advisory `index.json` (atomic tmp+fsync+rename) |
-| logs / state DBs | SQLite state + logs databases under project/home layout |
+| Path                                                               | Purpose                                                                                                                              |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `daemon.sock`                                                      | Unix domain socket (clients + SDK)                                                                                                   |
+| `daemon.cookie`                                                    | Shared secret for local client auth (0600)                                                                                           |
+| `daemon.pid`                                                       | Detached daemon PID                                                                                                                  |
+| `daemon.log`                                                       | Daemon log sink                                                                                                                      |
+| `daemon-snapshot.json` / runtime info files                        | Restart/recovery metadata                                                                                                            |
+| `config.toml`                                                      | Operator config (`[budget]`, `[heartbeat]`, providers, …)                                                                            |
+| `auth.json`                                                        | Stored credentials / auth backend state                                                                                              |
+| `runtime/<version>/<artifact-key>-sha256-<digest>/`                | Immutable content-addressed, ABI-keyed runtimes; staged/backup promotion is crash-recoverable                                        |
+| `runtime/.activation-lock.sqlite` / `.activation-transaction.json` | `AGENC_HOME` activation lock and durable roll-forward journal; canonical wrapper locks live in a private per-user registry           |
+| `gateway/`                                                         | Gateway sessions map, pairing, webchat token, heartbeat session id, control plane                                                    |
+| `projects/<slug>/`                                                 | Per-project SQLite state (including execution admission and schema-v15 run/effect projections) + canonical `sessions/<id>/` rollouts |
+| `projects/<slug>/agenc-state_1.pre-v15.sqlite`                     | Automatic verified rollback snapshot created before upgrading an existing project database to schema v15                             |
+| `sessions/` (project-scoped)                                       | Canonical append-only JSONL rollouts + advisory `index.json` (atomic tmp+fsync+rename)                                               |
+| logs / state DBs                                                   | SQLite state + logs databases under project/home layout                                                                              |
 
 Optional trajectory export writes redacted rollout items via
 `AGENC_TRAJECTORY_EXPORT_PATH` or `AGENC_TRAJECTORY_EXPORT_DIR`.
+
+### Durable run event path
+
+The rollout JSONL is the event authority. Schema-v15 SQLite tables are
+rebuildable lifecycle/effect/query projections, and `thread_rollout_items` is
+the replay index. Durable events are sequenced, appended, and fsynced before
+they reach either live subscriber surface:
+
+```text
+event stamp -> rollout append + fsync -> EventLog / txEvent publish
+                    |
+                    +-> thread_rollout_items -> run.replay / run.evidence
+                    +-> v15 projections      -> run.status / run.result
+```
+
+Effects add `effect_intent` before physical dispatch, followed by a proven
+`effect_result` or an honest `effect_unknown_outcome`. Only operations whose
+contract is explicitly `idempotent` carry an idempotency key or qualify for
+replay. Side-effecting and interactive work never receives an arbitrary
+exactly-once claim. Terminal results are immutable within a lifecycle epoch;
+an explicit reopen creates the next epoch and keeps prior results. The final
+automatic execution event is `run_terminal`; a stopped-session operator may
+later take the exclusive rollout lease to append review evidence without
+resuming execution. The terminal result's `lastSequence` remains that terminal
+snapshot coordinate even when the audit-journal tail advances.
+
+Admitted child and review runs have their own canonical journals. A failure
+after spawn dispatch but before child construction seals a minimal failed or
+cancelled journal, and a terminal `(runId, epoch)` cannot acquire a fresh
+writer under another rollout path. Resource cleanup failures after terminal
+commit are warnings; a journal-seal failure still fails the run.
+
+Cursor replay uses per-run `(sequence, eventId)` identities. Retention,
+compaction, corruption truncation, and bounded live-buffer eviction surface an
+explicit `event_gap`; a cursor beyond the canonical tail surfaces
+`cursor_ahead`. Neither case advances silently. Details and the 15-point
+`SIGKILL` acceptance matrix are in
+[`design/durable-runs-effects-events.md`](design/durable-runs-effects-events.md).
 
 `AGENC_HOME` is a single-host trust and locking boundary. It must live on a
 local filesystem with reliable SQLite OS locks and atomic same-filesystem
@@ -150,16 +191,16 @@ lock creation; Windows lock paths are NTFS-only and do not accept ReFS.
 
 ## Client surfaces
 
-| Surface | How it attaches | Notes |
-| --- | --- | --- |
-| Interactive TUI | Runtime CLI → daemon | Default `agenc` |
-| Print / headless | `agenc --no-tui` / `-p` | Stream-json capable; auto-denies unhandled permissions |
+| Surface           | How it attaches                            | Notes                                                         |
+| ----------------- | ------------------------------------------ | ------------------------------------------------------------- |
+| Interactive TUI   | Runtime CLI → daemon                       | Default `agenc`                                               |
+| Print / headless  | `agenc --no-tui` / `-p`                    | Stream-json capable; auto-denies unhandled permissions        |
 | Background agents | `agent.*` daemon methods / `agenc agent …` | Per-run `AgentBudgetConfig` caps only (not cumulative budget) |
-| Channel gateway | `agenc gateway run` via SDK | Telegram, Discord, Slack, WebChat, stdio |
-| Hooks HTTP | Gateway hooks server | `POST /hooks/agent` (loopback, bearer token) |
-| Cron delivery | Gateway cron delivery loop | Delivery-tagged tasks from `.agenc/scheduled_tasks.json` |
-| Embedding SDK | `@tetsuo-ai/agenc-sdk` `connect()` | Typed JSON-RPC client; also `promptViaSubprocess()` |
-| Remote control | `agenc remote` / remote auth backend | See [`remote-control.md`](remote-control.md) |
+| Channel gateway   | `agenc gateway run` via SDK                | Telegram, Discord, Slack, WebChat, stdio                      |
+| Hooks HTTP        | Gateway hooks server                       | `POST /hooks/agent` (loopback, bearer token)                  |
+| Cron delivery     | Gateway cron delivery loop                 | Delivery-tagged tasks from `.agenc/scheduled_tasks.json`      |
+| Embedding SDK     | `@tetsuo-ai/agenc-sdk` `connect()`         | Typed JSON-RPC client; also `promptViaSubprocess()`           |
+| Remote control    | `agenc remote` / remote auth backend       | See [`remote-control.md`](remote-control.md)                  |
 
 ### Attachment and capability delivery
 
@@ -188,16 +229,16 @@ layer resolves an approval decision from the active mode and rule set.
 **Permission modes** (`runtime/src/types/permissions.ts`,
 `runtime/src/permissions/permission-mode.ts`):
 
-| Mode | Role |
-| --- | --- |
-| `default` | Ask on request for sensitive tools |
-| `acceptEdits` | Auto-allow file edits; still ask for riskier actions |
-| `plan` | Plan-only posture; mutating work gated until exit-plan approval |
-| `bypassPermissions` | YOLO-style: skip prompts down to a deny floor (`--yolo`) |
-| `dontAsk` | Deny when would-ask (no interactive prompt) |
-| `auto` | Classifier-assisted auto mode (feature-gated) |
-| `unattended` | Background-agent policy (allowlist/denylist / pause) |
-| `bubble` | Bubble permission decisions to a parent context |
+| Mode                | Role                                                            |
+| ------------------- | --------------------------------------------------------------- |
+| `default`           | Ask on request for sensitive tools                              |
+| `acceptEdits`       | Auto-allow file edits; still ask for riskier actions            |
+| `plan`              | Plan-only posture; mutating work gated until exit-plan approval |
+| `bypassPermissions` | YOLO-style: skip prompts down to a deny floor (`--yolo`)        |
+| `dontAsk`           | Deny when would-ask (no interactive prompt)                     |
+| `auto`              | Classifier-assisted auto mode (feature-gated)                   |
+| `unattended`        | Background-agent policy (allowlist/denylist / pause)            |
+| `bubble`            | Bubble permission decisions to a parent context                 |
 
 When enabled, the OS sandbox confines shell execution at the kernel level.
 `--yolo` / bypass waives approval prompts — it does **not** enable kernel
@@ -225,14 +266,14 @@ One sampling iteration of the turn loop (`session/run-turn.ts`) runs an ordered
 phase machine. Module files under `runtime/src/phases/` own the heavy steps;
 `TurnState` documents the same numbering.
 
-| # | Stage | Module / site | Role |
-| --- | --- | --- | --- |
-| 1 | `prepareContext` | inline in `session/run-turn.ts` | Build messages for query, attachments, compact, request contract |
-| 2 | `streamModel` | `phases/stream-model.ts` | Stream provider response; capture assistant + tool-use blocks (may start streaming tool dispatch) |
-| 3 | `postSampleRecovery` | `phases/post-sample-recovery.ts` | Run recovery ladder on stream outcome / withheld errors |
-| 4 | `continuationNudge` | `phases/continuation-nudge.ts` | Nudge re-entry when the model stopped without required follow-up |
-| 5 | `executeTools` | `phases/execute-tools.ts` | Drain / finalize tool dispatch → tool results |
-| 6 | `commit` | `phases/commit.ts` | Terminal commit for the iteration; may re-enter via stop-hooks |
+| #   | Stage                | Module / site                    | Role                                                                                              |
+| --- | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 1   | `prepareContext`     | inline in `session/run-turn.ts`  | Build messages for query, attachments, compact, request contract                                  |
+| 2   | `streamModel`        | `phases/stream-model.ts`         | Stream provider response; capture assistant + tool-use blocks (may start streaming tool dispatch) |
+| 3   | `postSampleRecovery` | `phases/post-sample-recovery.ts` | Run recovery ladder on stream outcome / withheld errors                                           |
+| 4   | `continuationNudge`  | `phases/continuation-nudge.ts`   | Nudge re-entry when the model stopped without required follow-up                                  |
+| 5   | `executeTools`       | `phases/execute-tools.ts`        | Drain / finalize tool dispatch → tool results                                                     |
+| 6   | `commit`             | `phases/commit.ts`               | Terminal commit for the iteration; may re-enter via stop-hooks                                    |
 
 `phases/stop-hooks.ts` is not a separate numbered stage: stop-hook blocking is
 evaluated from `commit` (and can set `transition` so the outer loop re-enters).
@@ -249,14 +290,14 @@ recovery condition, triggers are evaluated in a **fixed priority order**
 `buildDefaultTriggerOrder`). Orchestration + re-entry cap:
 `recovery/fallback-ladder.ts` (`RecoveryLadder`, `MAX_RECOVERY_REENTRIES = 5`).
 
-| Order | Trigger name | Intent |
-| --- | --- | --- |
-| 1 | `isWithheld413` | Prompt-too-long → collapse / reactive recovery |
-| 2 | `isWithheldMedia` | Media-too-large → reactive recovery (skips collapse) |
-| 3 | `isWithheldMaxOutputTokens` | Max-output-tokens → escalate or continuation |
-| 4 | `stopHookBlocking` | Stop-hook inject + re-enter |
-| 5 | `streamingFallbackOccured` | Streaming fallback tombstone + recreate executor |
-| 6 | `FallbackTriggeredError` | Model fallback swap |
+| Order | Trigger name                | Intent                                               |
+| ----- | --------------------------- | ---------------------------------------------------- |
+| 1     | `isWithheld413`             | Prompt-too-long → collapse / reactive recovery       |
+| 2     | `isWithheldMedia`           | Media-too-large → reactive recovery (skips collapse) |
+| 3     | `isWithheldMaxOutputTokens` | Max-output-tokens → escalate or continuation         |
+| 4     | `stopHookBlocking`          | Stop-hook inject + re-enter                          |
+| 5     | `streamingFallbackOccured`  | Streaming fallback tombstone + recreate executor     |
+| 6     | `FallbackTriggeredError`    | Model fallback swap                                  |
 
 Related modules: `api-errors.ts` (match predicates), `model-fallback.ts`,
 `max-output-tokens.ts`, `reconnection.ts`, `tombstone.ts`,
@@ -267,11 +308,11 @@ the I-10 tests that pin `I10_TRIGGER_ORDER`.
 
 Default provider is **`grok`** (xAI). Model defaults are dual-sourced:
 
-| Source | Grok default | Evidence |
-| --- | --- | --- |
-| Fresh `defaultConfig().model` | **`grok-4.5`** | `runtime/src/config/schema.ts` |
-| Provider-map fallback (`BUILT_IN_PROVIDER_DEFAULT_MODELS.grok`) | **`grok-4.5`** | `runtime/src/llm/registry/provider-info.ts` |
-| Managed OpenRouter paid first model | **`x-ai/grok-4.5`** | `subscription-managed-models.ts` |
+| Source                                                          | Grok default        | Evidence                                    |
+| --------------------------------------------------------------- | ------------------- | ------------------------------------------- |
+| Fresh `defaultConfig().model`                                   | **`grok-4.5`**      | `runtime/src/config/schema.ts`              |
+| Provider-map fallback (`BUILT_IN_PROVIDER_DEFAULT_MODELS.grok`) | **`grok-4.5`**      | `runtime/src/llm/registry/provider-info.ts` |
+| Managed OpenRouter paid first model                             | **`x-ai/grok-4.5`** | `subscription-managed-models.ts`            |
 
 Bare interactive startup with an empty/fresh config uses the **config** default
 (`grok-4.5`). Provider-map and paid managed OpenRouter also use **4.5**.
@@ -292,13 +333,13 @@ There are **16 built-in provider slugs**. Full table, env vars, and base URLs:
 
 Autonomous surfaces share one design: **fail closed, never silent spend**.
 
-| Surface | Module | Daemon execution admission? |
-| --- | --- | --- |
-| Heartbeat ticks | `heartbeat/` (wired from gateway run) | **Yes**, inside its daemon-owned background session |
-| Cron delivery | `gateway/cron-delivery.ts` | **Yes**, inside its daemon-owned background session |
-| Hooks HTTP | `gateway/hooks.ts` | **Yes**, inside its daemon-owned background session; denial is HTTP 429 |
-| Interactive TUI / print turns | `session/` | **Yes** at model/tool boundaries; `[budget]` windows require `enforce_interactive` |
-| Background agent runs | `app-server/background-agent-runner.ts` | **Yes**; unattended admission policy without enabling keepalive ticks |
+| Surface                       | Module                                  | Daemon execution admission?                                                        |
+| ----------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------- |
+| Heartbeat ticks               | `heartbeat/` (wired from gateway run)   | **Yes**, inside its daemon-owned background session                                |
+| Cron delivery                 | `gateway/cron-delivery.ts`              | **Yes**, inside its daemon-owned background session                                |
+| Hooks HTTP                    | `gateway/hooks.ts`                      | **Yes**, inside its daemon-owned background session; denial is HTTP 429            |
+| Interactive TUI / print turns | `session/`                              | **Yes** at model/tool boundaries; `[budget]` windows require `enforce_interactive` |
+| Background agent runs         | `app-server/background-agent-runner.ts` | **Yes**; unattended admission policy without enabling keepalive ticks              |
 
 Budget caps default **disabled**, but admission and concurrency remain active.
 Inspect durable accounting with `agenc run status|replay|evidence`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -73,6 +73,7 @@ explanation. Prefer linked pages over archive notes when they disagree.
 | [design/secure-project-instructions.md](design/secure-project-instructions.md) | Live instruction delivery, precedence, descriptor-bound reads, approvals, and threat model |
 | [design/fail-closed-sandbox-execution.md](design/fail-closed-sandbox-execution.md) | Required process isolation boundary, platform probes, failure semantics, and research |
 | [design/execution-admission-kernel.md](design/execution-admission-kernel.md) | M3 daemon admission, durable budgets/queue/cancellation, evidence, rollout, and rollback |
+| [design/durable-runs-effects-events.md](design/durable-runs-effects-events.md) | M4 canonical run journal, honest effects, terminal results, replay-safe cursors, crash matrix, and rollback |
 | [roadmap.md](roadmap.md) | Shipped vs open backlog (current product truth) |
 
 ---

--- a/docs/design/durable-runs-effects-events.md
+++ b/docs/design/durable-runs-effects-events.md
@@ -1,0 +1,438 @@
+# Durable runs, effects, and events
+
+This document is the design, recovery, and operator contract for M4 durable
+runs. It covers the boundary between an agent's append-only history, external
+effects, client delivery, terminal results, and restart recovery.
+
+The central rule is simple: the existing rollout JSONL is the canonical run
+journal. SQLite schema version 15 indexes that journal and stores immutable
+lifecycle/effect projections, but it does not become a second event authority.
+If the two disagree, recovery rebuilds SQLite from the fsync-committed JSONL.
+
+## Guarantees and limits
+
+M4 guarantees that:
+
+- durable events are appended and fsynced before any in-process or daemon
+  client can observe them;
+- every replayed event preserves the canonical `eventId` assigned before
+  persistence and its per-run `sequence`; the older `id` field remains a
+  reusable request/subscription correlation value, not event identity;
+- retention, compaction, corruption truncation, and missing sources are
+  explicit gaps, never silent cursor jumps;
+- a root background run writes one durable terminal result that remains
+  queryable after disconnect or daemon restart;
+- an external effect has a durable intent before dispatch and a durable,
+  sticky outcome after acknowledgement;
+- an unprovable non-idempotent outcome becomes `unknown_outcome`, requires
+  review, and cannot be laundered into late success;
+- large tool-result artifacts have durable intent/commit evidence and are
+  published as complete immutable files, not partially visible targets; and
+- replay and recovery are idempotent. Reapplying the same event is a no-op,
+  while reusing an identity for different content fails closed.
+
+M4 does **not** promise exactly-once execution for arbitrary shell, network,
+or interactive effects. A process can die after an external system commits an
+operation but before AgenC records the acknowledgement. The only honest state
+in that window is `unknown_outcome`.
+
+## Authority and projections
+
+```text
+ Session.emit
+     |
+     | 1. allocate canonical eventId + per-run sequence
+     v
+ SessionStore append-only rollout JSONL
+     |
+     | 2. write + fsync for a durable event
+     v
+ canonical committed event
+     |                         \
+     | 3. publish live          \ rebuild / query
+     v                           v
+ EventLog + txEvent       SQLite schema v15
+ client notifications     thread_rollout_items
+                          lifecycle/effect/binding tables
+                                  |
+                                  v
+                       run.replay / result / evidence
+```
+
+The canonical files are the existing per-session rollouts under the project
+`sessions/` or `archived_sessions/` tree. They use `O_APPEND`; durable event
+types flush immediately with `fsync`. On open, the rollout reader truncates a
+corrupt partial tail to the last complete record. The additive unknown-event
+shim preserves forward compatibility when an older reducer encounters a newer
+event type.
+
+The `thread_rollout_items` table is a byte-offset and hash projection of those
+files. `run.replay` refreshes the bounded projection for the requested run
+before reading it. The projection can be dropped and rebuilt without losing
+the journal. The pre-M4 `execution_admission_journal` remains a compatibility
+source only when no canonical rollout source is available.
+
+Schema v15 adds four state tables:
+
+| Table                  | Role                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| `run_lifecycle_epochs` | Ordered open/reopen epochs for one stable `runId`                                     |
+| `run_terminal_results` | One immutable terminal result per `(runId, epoch)`                                    |
+| `run_effects`          | Intent, sticky outcome, and explicit review state for tool effects                    |
+| `run_journal_bindings` | Historical rollout paths, active source, sequence bounds, and explicit retired ranges |
+
+The tables store transition state and journal coordinates, not duplicate event
+payloads. Journal bindings retain historical source paths so an archive or
+reopen does not erase provenance. Bounds may expand monotonically; retiring a
+range requires a recorded `retention`, `compaction`, or
+`corruption_truncated` gap.
+
+## Lifecycle epochs and terminal results
+
+A new run starts at epoch 1. The terminal transition follows this order:
+
+1. Select the terminal payload from the managed thread status, final assistant
+   message, usage, exit code, and stop reason, and close new run ingress.
+2. Resolve or abort pending permission continuations while the canonical
+   writer is still open.
+3. Quiesce and drain the root task, child agents, live execs, session-end
+   hooks, mailboxes, conversations, and every tracked durable continuation.
+   Abort/permission/effect evidence produced by that drain commits before the
+   terminal boundary.
+4. The before-close finalizer verifies no permission decision remains pending,
+   then appends and fsyncs `run_terminal` as the final automatic execution
+   event for that epoch and projects it into `run_terminal_results`.
+5. Seal the execution writer against later automatic appends, flush and close
+   it, and only then advance legacy agent status and notify lifecycle
+   consumers. The stopped-session operator-review exception described below
+   takes a new exclusive lease; it does not reopen execution.
+
+This order makes both crash windows recoverable. If the process dies before
+the SQLite projection, the canonical event rebuilds it. If it dies after the
+projection, replaying the same event is an idempotent acknowledgement.
+`run.result` reads the durable projection and returns
+`output.available: true` with `exitCode`, `stopReason`, `finalMessage`,
+`usage`, and `lastSequence`. That sequence is the immutable terminal snapshot
+coordinate, not necessarily the later audit-journal tail.
+
+Terminal content is first-write sticky. Repeating the exact result returns an
+idempotent no-op. A different result for the same epoch raises a conflict, and
+SQLite triggers forbid direct updates. This prevents a late callback from
+changing a recorded failure or unknown outcome into success.
+
+A deliberate reopen is a new lifecycle epoch, not a rewrite. A durable
+`run_reopened` event names the previous epoch, the next epoch, the reason, and
+the reopen time. Reopen is allowed only after the current epoch is terminal
+and all unknown-outcome reviews are resolved. Terminal history for prior
+epochs stays queryable.
+
+Runs created before M4 can still have a terminal `agent_runs` row without a
+canonical terminal payload. For that compatibility case, `run.result` returns
+`output.available: false` instead of inventing an answer.
+
+Every admitted in-process child or review delegate owns a separate canonical
+run journal. If spawn dispatch commits but `Session` construction fails, AgenC
+seals a minimal child journal with a failed or cancelled terminal result so the
+run remains inspectable. Once any canonical source records `run_terminal` for
+an epoch, opening another writer for that `(runId, epoch)` is refused even when
+the new writer would use a fresh rollout path; only an explicit reopen may
+advance the lifecycle epoch.
+
+Resource teardown happens after the child journal is sealed. A provider,
+sandbox-broker, or LSP cleanup failure is emitted as a warning and does not
+retroactively change the public or durable terminal outcome. Failure to seal
+the journal itself remains a run failure.
+
+## Honest effect semantics
+
+Tool recovery classification is part of the effect contract, not a guess made
+after a crash:
+
+| Category         | Idempotency key                                          | Recovery rule                                                                                                                                                                         |
+| ---------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `idempotent`     | Required, stable, and derived from the logical operation | The only category eligible for replay. Journal recovery records `retry_safe_deferred`; an explicit owner may retry using the same key. It does not blindly execute during store open. |
+| `side-effecting` | Forbidden                                                | A lost post-dispatch acknowledgement becomes `unknown_outcome`. New dependent side-effecting calls stop until review resolves it.                                                     |
+| `interactive`    | Forbidden                                                | A lost post-dispatch acknowledgement becomes `unknown_outcome`; the human-in-the-loop interaction is not auto-replayed.                                                               |
+
+The durable event sequence is:
+
+```text
+effect_intent (fsync)
+       |
+       +-- cancelled before dispatch --> effect_result(cancelled)
+       |
+       +-- dispatch --> effect_result(committed | failed | cancelled)
+       |
+       +-- dispatch, acknowledgement unprovable
+                         --> effect_unknown_outcome(requiresReview: true)
+```
+
+`effect_intent` contains the run/step/call identity, tool name, recovery
+category, arguments digest, attempt number, and an idempotency key only when
+the category is `idempotent`. Arguments stay out of the event payload so the
+journal does not become a second secret-bearing input store.
+
+`effect_result` acknowledges only a proven `committed`, `failed`, or
+`cancelled` outcome. `effect_unknown_outcome` is terminal-but-unresolved. Its
+projection is review-locked: a late result cannot overwrite it, the review
+state can move only `pending -> resolved`, and a terminal run cannot reopen
+while any review remains pending. The existing in-flight tool recovery index
+also marks the call `poisoned` so the pre-dispatch mutation gate can block a
+new side effect in the same session.
+
+Restart classification consults the durable admission boundary. A reservation
+still `reserved`, or already recovered to `voided`, proves the effect never
+crossed dispatch and produces a cancelled result. `dispatched`,
+`held_unknown`, or missing evidence cannot prove that, so a non-idempotent
+intent without an acknowledgement becomes `unknown_outcome`. Recovery families
+share one sequence cursor; artifact and effect recovery cannot project two
+different events at the same journal coordinate.
+
+An admission reservation and an effect answer different questions. The
+reservation records whether capacity/spend crossed the dispatch boundary; the
+effect journal records whether the physical tool outcome is known. After a
+post-dispatch crash, a reservation may remain `held_unknown` while the effect
+requires review. Neither state is refunded or replayed merely because the
+daemon restarted.
+
+An operator resolves that review from the affected project after stopping the
+live session:
+
+```bash
+AGENC_REVIEWER_ID=operator_7 \
+  agenc state resolve-tool-call <session-id> <tool-call-id>
+```
+
+For an M4 effect, the command takes the canonical journal's single-writer
+lease, verifies the matching `effect_unknown_outcome`, and appends and fsyncs
+one idempotent `effect_review_resolved` event before either SQLite review
+projection advances. The event records the run, step, call, reviewer,
+`human_verified` resolution, and review time. It lifts the mutation gate only
+after no unresolved effects remain; it never reruns the tool or changes the
+unknown physical outcome into a fabricated success. Reviewer identity falls
+back from `AGENC_REVIEWER_ID` to `USER`, `USERNAME`, then `local_operator`.
+
+This is an explicit post-terminal audit exception when `run_terminal` already
+exists. The command can append only after taking the stopped rollout's
+exclusive lease, and it never resumes agent execution or changes the terminal
+result. Replay and journal-binding bounds include the later review evidence;
+`run.result.output.lastSequence` remains the sequence of the terminal snapshot.
+
+## Persist before publish
+
+For a durable event, `Session.emit` uses a split publication path:
+
+1. `EventLog.stamp` assigns the next sequence and a unique canonical
+   `eventId` without notifying subscribers. It preserves `Event.id` for legacy
+   correlation and rejects canonical identity reuse.
+2. `SessionStore.append(..., { durable: true })` writes the event and fsyncs
+   the rollout. A failed durable flush returns failure and `Session.emit`
+   throws; publication does not continue.
+3. The committed event is published to `EventLog` subscribers and the
+   compatibility `txEvent` stream.
+
+This ordering closes the old window where a client could see a transition that
+was absent after restart. It applies to terminal, reopen, artifact
+intent/commit, recovery-decision, and all effect lifecycle events, as well as
+the existing durable turn events. Progress events remain batched for up to
+100 ms, so consumers must not treat an arbitrary progress notification as a
+commit record. If a client persisted a cursor for a published tail event that
+was not durable at daemon death, replay reports `cursor_ahead` rather than
+silently accepting that cursor.
+
+Live notification buffers use the same honesty rule. If byte or count limits
+evict sequenced events, the multiplexer inserts an `event_gap` marker with the
+run, prior cursor, and first available sequence. It does not splice the buffer
+silently.
+
+## Immutable artifact publication
+
+Large tool results first append and fsync `artifact_intent`, including the
+stable artifact identity, content digest, byte length, source call, and final
+target. They then use the M4 atomic artifact helper before their path is
+returned to the model:
+
+1. write a unique temporary file;
+2. fsync its complete bytes;
+3. publish with a same-filesystem, no-replace hard link;
+4. remove the temporary name and fsync the parent directory.
+
+Those child-path operations stay bound to the already-open trusted-root
+descriptor. The supported and acceptance-tested aliases are `/proc/self/fd`
+or `/dev/fd` on Linux and `/dev/fd` on macOS. A platform where AgenC cannot
+resolve such a descriptor-relative path fails commit, cleanup, and recovery
+observation closed with `ARTIFACT_SAFE_OPERATION_UNSUPPORTED`; the current
+Windows implementation therefore does not publish large tool-result artifacts
+until an equivalent descriptor-bound primitive is available.
+
+After publication, `artifact_committed` records `committed` or
+`already_committed` and references the intent sequence. An identical retry is
+therefore an idempotent acknowledgement. Different bytes for the same target
+raise `ARTIFACT_CONTENT_CONFLICT` and never overwrite prior evidence.
+
+On restart, a dangling artifact intent is resolved only from observable bytes.
+A matching digest produces `artifact_committed(outcome: recovered)`. A missing
+target produces `artifact_retry_safe_deferred`; a mismatched target produces
+`artifact_conflict_review_required`. Recovery never overwrites the target or
+re-runs the tool that produced it. Private temp files abandoned by `SIGKILL`
+are removed under the resumed session's exclusive lease with an exact-parent,
+regular-file-only, bounded sweep; they are never promoted. A crash therefore
+exposes either no target or the complete target, never a partially written
+artifact.
+
+## Cursor replay and reconnect
+
+`run.replay` is an exclusive-cursor API. `afterSequence = N` asks for events
+strictly after `N`; `limit` defaults to 100 and accepts 1 through 200. A
+canonical response identifies:
+
+```json
+{
+  "source": {
+    "kind": "run_journal",
+    "sequenceScope": "run",
+    "canonical": "rollout_jsonl",
+    "projection": "thread_rollout_items"
+  }
+}
+```
+
+Canonical pages are contiguous. If the requested next sequence is no longer
+available, the response returns no cursor jump and an explicit gap:
+
+```json
+{
+  "gap": {
+    "kind": "event_gap",
+    "runId": "run_123",
+    "afterSequence": 17,
+    "firstAvailableSequence": 24,
+    "reason": "retention"
+  },
+  "nextAfterSequence": 17
+}
+```
+
+Gap reasons are `retention`, `compaction`, and `corruption_truncated`. A run
+with no journal source returns `source_unavailable`. No case authorizes a
+client to advance without making an application-level reconciliation choice.
+If `afterSequence` is beyond the canonical tail, replay returns a distinct
+`cursor_ahead` gap with `lastAvailableSequence`; this covers a stale/wrong
+cursor and a client-observed non-durable tail without pretending the events
+still exist.
+
+The embedding SDK wraps this protocol with
+`client.reattachRun({ runId, afterSequence })`:
+
+- it preserves and exposes the exclusive cursor with `attachment.cursor()`;
+- it advances only as each event is yielded to the consumer;
+- it suppresses exact duplicate `(sequence, eventId, content)` delivery and
+  reports it through `onDuplicate` plus `diagnostics()`;
+- it rejects reused identities with different content, non-monotonic pages,
+  missing sequences, mismatched cursors, and unexplained cursor jumps with
+  `AgencRunReplayProtocolError`;
+- it throws `AgencRunReplayGapError` without advancing past the gap; and
+- `attachment.result()` fetches the durable final result by `runId`,
+  independent of the connection that started the run.
+
+Delivery is replay-safe, not magic exactly-once delivery. Persist the cursor
+only after the application has processed an event. If the application crashes
+between processing and saving the cursor, the event can be delivered again;
+use its stable identity to make consumer work idempotent.
+
+## SIGKILL failure matrix
+
+The acceptance suite starts a real child process, arms one test-only failpoint,
+waits for a fsynced marker, and lets the child kill itself with `SIGKILL`.
+Recovery runs in a fresh process and then runs a second time to prove the
+repair is idempotent. Production cannot arm these hooks without the exact test
+token.
+
+For every boundary, including reservation, model, tool, artifact,
+event-publication, and terminal evidence, the suite also starts the real daemon
+entrypoint in a fresh process and reconnects through the public embedding SDK.
+It replays from cursor 0, disconnects, and verifies start, midpoint, exact-tail,
+and beyond-tail cursors against a second fresh daemon. A cursor beyond the
+durable tail raises `AgencRunReplayGapError` without moving; terminal cases also
+fetch the immutable result.
+
+| Boundary                                                | State after restart                                                                                                                                                                                            |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `after_admission_sqlite_commit_before_canonical_append` | The guarded crash window leaves the SQLite decision intact; startup appends that exact event ID and payload to the canonical per-run tail under its exclusive descriptor-pinned lease before replay is served. |
+| `before_reservation_commit`                             | No reservation exists; the durable job is queued and recovered once.                                                                                                                                           |
+| `after_reservation_commit`                              | The undispatched reservation is voided once.                                                                                                                                                                   |
+| `before_model_response_commit`                          | One physical provider attempt is conserved as `held_unknown`; it is not replayed or refunded.                                                                                                                  |
+| `after_model_response_commit`                           | The single provider attempt is already reconciled.                                                                                                                                                             |
+| `before_tool_spawn`                                     | The intent exists, no physical tool attempt occurred, and recovery records cancellation/void.                                                                                                                  |
+| `after_tool_spawn`                                      | One tool attempt occurred; the effect becomes review-locked `unknown_outcome` and the reservation is `held_unknown`.                                                                                           |
+| `before_tool_ack_commit`                                | Same honest ambiguous state as the post-spawn window; no result is fabricated.                                                                                                                                 |
+| `after_tool_ack_commit`                                 | One intent and one committed result exist; the reservation reconciles once.                                                                                                                                    |
+| `before_artifact_commit`                                | No target is visible; restart removes the abandoned private temp, journals `artifact_retry_safe_deferred`, and does not auto-publish bytes.                                                                    |
+| `after_artifact_commit`                                 | Complete target bytes already exist; restart proves their digest and journals `artifact_committed(outcome: recovered)` without rerunning the producer.                                                         |
+| `before_event_publish`                                  | The canonical event exists, live observers saw nothing, and reconnect delivers it once.                                                                                                                        |
+| `after_event_publish`                                   | Canonical event and both live publications exist; reconnect deduplicates to one unique delivery.                                                                                                               |
+| `before_terminal_commit`                                | The canonical terminal event rebuilds the missing SQLite projection; history contains one result.                                                                                                              |
+| `after_terminal_commit`                                 | Reapplying the terminal event is a no-op; history still contains one result.                                                                                                                                   |
+
+The matrix lives in
+[`runtime/tests/durability/failure-matrix.acceptance.test.ts`](../../runtime/tests/durability/failure-matrix.acceptance.test.ts).
+Focused tests also cover failpoint arming and immutable artifact conflicts.
+
+## Migration and rollback
+
+Schema migration 15 is additive and transactional. Before upgrading any
+project database with existing user tables from a version below 15, the driver
+holds a `BEGIN IMMEDIATE` writer reservation and automatically creates:
+
+```text
+$AGENC_HOME/projects/<project-slug>/agenc-state_1.pre-v15.sqlite
+```
+
+SQLite `VACUUM INTO` creates a consistent temporary snapshot. AgenC sets mode
+`0600`, verifies `PRAGMA integrity_check`, verifies that the snapshot is truly
+pre-v15, fsyncs the file, publishes it, and fsyncs the project directory before
+applying migration 15. A stale backup from a failed earlier attempt is replaced
+under the same writer lock.
+
+An older runtime whose maximum known schema is below 15 refuses to open a v15
+database. Prefer a roll-forward repair. If a downgrade is unavoidable:
+
+1. stop every daemon and foreground runtime that can write the project;
+2. preserve the live v15 database and rollout files as recovery evidence;
+3. restore `agenc-state_1.pre-v15.sqlite` into a separate staged
+   `AGENC_HOME`;
+4. validate the restored database before starting the older runtime; and
+5. keep execution ingress closed until review accounts for work completed
+   after the backup.
+
+Do not delete migration row 15, drop durability tables, or copy selected rows
+back into the old database. The backup predates all M4 writes; restoring it
+discards post-upgrade projections, and there is no automatic history merge.
+The canonical rollout files should be retained even during rollback because
+they remain the evidence needed for a later v15-aware reconciliation.
+
+## Source map
+
+| Concern                                     | Implementation                                                                                     |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Canonical event types and split publication | `runtime/src/session/event-log.ts`, `runtime/src/session/session.ts`                               |
+| Append/fsync rollout store                  | `runtime/src/session/session-store.ts`                                                             |
+| Effect dispatch boundary                    | `runtime/src/budget/admitted-tool-call.ts`                                                         |
+| v15 state and projection rules              | `runtime/src/state/run-durability.ts`, `runtime/src/state/migrations/015_run_durability_schema.ts` |
+| Journal projection and cursor pages         | `runtime/src/app-server/run-journal-replay.ts`, `runtime/src/app-server/run-inspection.ts`         |
+| Terminal lifecycle commit                   | `runtime/src/app-server/background-agent-runner.ts`, `runtime/src/app-server/daemon-cli.ts`        |
+| Operator effect-review evidence             | `runtime/src/state/effect-review.ts`, `runtime/src/bin/state-cli.ts`                               |
+| Replay-safe SDK client                      | `packages/agenc-sdk/src/client.ts`, `packages/agenc-sdk/src/protocol.ts`                           |
+| Immutable artifact publication              | `runtime/src/durability/atomic-artifact.ts`                                                        |
+| Crash injection                             | `runtime/src/durability/failpoints.ts`                                                             |
+
+Related contracts:
+
+- [`execution-admission-kernel.md`](execution-admission-kernel.md) covers the
+  reservation and `held_unknown` side of the same physical boundaries.
+- [`shared-run-contracts-v1.md`](shared-run-contracts-v1.md) is the frozen
+  cross-milestone run/effect/event vocabulary.
+- [`../reference/daemon.md`](../reference/daemon.md) documents the public
+  `run.*` RPCs.
+- [`../../packages/agenc-sdk/README.md`](../../packages/agenc-sdk/README.md)
+  shows durable SDK reconnect usage.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -267,16 +267,23 @@ agenc run cancel <run-id> [--reason <text>]
 
 These commands use the daemon's durable run/admission contract and print
 canonical JSON. `status` includes aggregate admission and budget/hold state;
-`result` succeeds only after the durable run is terminal. `replay` pages the
-append-only admission journal with an exclusive sequence cursor. `evidence`
-adds source/completeness metadata and SHA-256 hashes for mechanical review.
-`cancel` durably locks the run tree, cancels queued descendants, and propagates
-to running descendants without deleting partial evidence.
+`result` succeeds only after the durable run is terminal; its `lastSequence`
+is the terminal snapshot coordinate. A later exclusively leased offline effect
+review can advance the replay tail without resuming execution or changing that
+result. `replay` pages the
+canonical append-only rollout journal with an exclusive per-run sequence
+cursor. `evidence` adds source/completeness metadata and SHA-256 hashes for
+mechanical review. `cancel` durably locks the run tree, cancels queued
+descendants, and propagates to running descendants without deleting partial
+evidence.
 
 Replay and evidence pages default to the daemon's bounded page size and never
-accept more than 200 events. A missing retained source is returned as an
-explicit gap; an admission-only record is not presented as a fabricated
-terminal result.
+accept more than 200 events. Retention, compaction, corruption truncation, a
+missing source, and a cursor beyond the canonical tail are explicit gaps and
+do not advance the returned cursor past a missing range. Pre-M4 runs can fall
+back to the project-database-scoped execution-admission journal, which is
+labeled as a compatibility source. An admission-only record is not presented
+as a fabricated terminal result.
 
 ---
 
@@ -433,17 +440,29 @@ agenc permissions approve --session session_123 call_456
 ```text
 agenc state export <agent-id>
 agenc state import
+agenc state resolve-tool-call <session-id> <tool-call-id>
 ```
 
 | Command | Meaning |
 | --- | --- |
 | `export <agent-id>` | Print a JSON state export for one agent |
 | `import` | Read a JSON state export from stdin and import it |
+| `resolve-tool-call <session-id> <tool-call-id>` | Record an operator review for one unresolved `unknown_outcome` tool call and lift the session's side-effecting mutation gate once no unresolved effects remain |
 
 ```bash
 agenc state export agent_123 > state.json
 agenc state import < state.json
+AGENC_REVIEWER_ID=operator_7 \
+  agenc state resolve-tool-call session_abc call_42
 ```
+
+Run `resolve-tool-call` from the affected session's project directory after
+stopping the live session. For an M4 effect, it appends and fsyncs a canonical
+`effect_review_resolved` event before advancing the SQLite review projection;
+it never reruns the tool or rewrites `unknown_outcome` as success. Reviewer
+identity comes from `AGENC_REVIEWER_ID`, then `USER` / `USERNAME`, with
+`local_operator` as the final fallback. If the requested call is not found,
+the error lists any unresolved calls known for that session.
 
 ---
 

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -1,6 +1,6 @@
 # Daemon reference
 
-The local **app-server** control plane for AgenC **0.6.0**. One daemon per
+The local **app-server** control plane for AgenC **0.6.2**. One daemon per
 `AGENC_HOME`. Clients (TUI, print CLI, gateway, remote, SDK, background
 agents) attach over a local socket and speak JSON-RPC.
 
@@ -119,7 +119,7 @@ const client = await connect(); // socket + cookie under AGENC_HOME
 | `initialize` | Handshake + capability advertisement |
 | `request.cancel` | Cancel an in-flight request |
 | `agent.create` / `agent.list` / `agent.attach` / `agent.stop` / `agent.logs` | Background agents |
-| `run.status` / `run.result` / `run.replay` / `run.evidence` / `run.cancel` | Durable run inspection, admission replay/evidence, and tree cancellation |
+| `run.status` / `run.result` / `run.replay` / `run.evidence` / `run.cancel` | Durable run state, canonical journal replay/evidence, terminal result, and tree cancellation |
 | `session.create` / `session.list` / `session.attach` / `session.detach` | Session lifecycle |
 | `session.terminate` / `session.clear` / `session.snapshot` / `session.transcript` | Session control |
 | `session.cancelTurn` | Abort current turn |
@@ -141,34 +141,51 @@ cursor is scoped to that filter and should not be persisted across daemon
 upgrades. Persisted metadata is read with an indexed keyset page rather than a
 full thread-history scan.
 
-Run inspection is read-only and searches the discovered project state
-databases by `runId`:
+Run inspection searches discovered project state databases by `runId`:
 
-- `run.status` returns the durable `agent_runs` state plus aggregate M3
-  admission step, reservation, allocation, fallback, and budget/hold totals.
-  `terminal` is true only when the durable run row is terminal. An
-  admission-only record stays nonterminal because admission state cannot prove
-  that no future step will be created.
-- `run.replay` pages the existing append-only execution-admission journal.
-  `afterSequence` is exclusive, `limit` defaults to 100 and is capped at 200,
-  and every response includes `hasMore` plus `nextAfterSequence`. Sequences are
-  database-global, so a page filtered to one run may legitimately skip
-  numbers. A missing journal source is an explicit `gap`.
-- `run.result` succeeds only for a durable terminal `agent_runs` row. A live or
-  admission-only run returns `RUN_NOT_TERMINAL`; a missing run returns
-  `RUN_NOT_FOUND`. Existing state stores terminal status/metadata but not a
-  canonical terminal assistant payload, so `output.available` is explicitly
-  false rather than fabricated.
-- `run.evidence` returns a bounded admission-event page with SHA-256 hashes of
-  the run state, admission summary, individual events, and page bundle. Its
-  source declares `workflowEvidenceIncluded: false` and completeness as
-  `complete`, `partial`, or `admission_source_unavailable`: this is M3
-  admission evidence, not a future workflow/effect ledger.
+- `run.status` returns lifecycle status plus aggregate admission step,
+  reservation, allocation, fallback, and budget/hold totals. `durableRun`
+  carries the compatibility `agent_runs` row when one exists; canonical-only
+  v15 runs do not fabricate it. A `run_terminal_results` record is the
+  strongest terminal-status source. An admission-only record stays nonterminal
+  because admission state cannot prove that no future step will be created.
+- `run.replay` pages the canonical append-only rollout journal through its
+  rebuildable `thread_rollout_items` projection. `afterSequence` is exclusive,
+  `limit` defaults to 100 and accepts 1 through 200, and every response includes
+  `hasMore` plus `nextAfterSequence`. Canonical sequences are per-run and pages
+  are contiguous. Retention, compaction, or an interior corruption-truncation
+  range returns `gap.kind: "event_gap"` without moving the cursor past the
+  missing range. A contiguous prefix can still advance `nextAfterSequence` to
+  its last delivered event. A cursor beyond the durable tail returns
+  `gap.kind: "cursor_ahead"` with the last available sequence. If a run has no
+  canonical source, a pre-M4 execution-admission journal remains available as
+  a compatibility reader; its sequence scope is explicitly
+  `project_state_database`.
+- `run.result` succeeds only for a durably terminal run. A v15 result returns
+  `output.available: true` with exit code, stop reason, final message, usage,
+  and the terminal snapshot sequence. A stopped-session operator review may
+  later append leased audit evidence at a higher replay sequence without
+  resuming execution or changing the result. A live or admission-only run returns
+  `RUN_NOT_TERMINAL`; a missing run returns `RUN_NOT_FOUND`. A legacy terminal
+  row with no canonical terminal payload returns `output.available: false`
+  rather than fabricating output.
+- `run.evidence` returns the same bounded journal page with SHA-256 hashes of
+  the run state, admission summary, individual events, and page bundle.
+  Canonical pages declare `workflowEvidenceIncluded: true`; completeness is
+  `complete`, `partial`, `journal_gap`, or
+  `admission_source_unavailable` for a missing compatibility source.
 
-All four reads use the transport priority lane. Their SQL output is bounded and
-indexed; they never migrate, create, or mutate a state database. If one run id
-exists in multiple project databases, they fail with `RUN_ID_AMBIGUOUS` instead
-of choosing silently.
+All four methods use the transport priority lane and bounded indexed queries.
+Before reading, the daemon refreshes the requested run's rebuildable rollout
+projection from its canonical active or archived JSONL source and recovers any
+missing v15 effect or terminal projection. This repair writes indexes/state but
+does not dispatch work, publish events, or rewrite the journal. If one run id
+exists in multiple project databases, the methods fail with
+`RUN_ID_AMBIGUOUS` instead of choosing silently.
+
+The full persistence, replay, gap, effect, migration, and crash semantics are
+documented in
+[`../design/durable-runs-effects-events.md`](../design/durable-runs-effects-events.md).
 
 The stdio and WebSocket transports give cancel operations plus bounded health,
 status, attach, and session lookup RPCs a priority lane. They still wait for

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -70,7 +70,7 @@ Key `AgencClient` methods:
 - `attachAgent(agentId)` → `{ attach, session }` for a running agent
 - `listAgents()` / `stopAgent(id)` / `agentLogs(id)`
 - `runStatus(id)` / `runResult(id)` / `replayRun(params)` /
-  `runEvidence(params)` / `cancelRun(id, reason?)`
+  `reattachRun(options)` / `runEvidence(params)` / `cancelRun(id, reason?)`
 - `request(method, params)` → raw typed JSON-RPC for any of the **45** daemon methods
 - `onNotification(cb)` / `onSessionNotification(sessionId, cb)` → raw events
 
@@ -168,32 +168,63 @@ node packages/agenc-sdk/examples/one-shot.mjs --transport subprocess "say hello"
 ### Durable run inspection
 
 ```ts
-const status = await client.runStatus(runId);
-if (status.terminal) {
-  const result = await client.runResult(runId);
-  console.log(result.outcome, result.output.available);
+import { AgencRunReplayGapError } from "@tetsuo-ai/agenc-sdk";
+
+const attachment = client.reattachRun({
+  runId,
+  afterSequence: savedAfterSequence ?? 0,
+  onDuplicate: ({ event }) => console.warn("duplicate", event.eventId),
+});
+
+try {
+  for await (const event of attachment) {
+    await applyEventIdempotently(event);
+    // Save only after the application has processed this event.
+    await saveAfterSequence(attachment.cursor().afterSequence);
+  }
+} catch (error) {
+  if (error instanceof AgencRunReplayGapError) {
+    // The cursor stops at the last event yielded before the gap. Reconcile the
+    // missing range before choosing a replacement; the SDK never jumps it.
+    console.error(error.gap, attachment.cursor());
+  } else {
+    throw error;
+  }
 }
 
-let afterSequence = 0;
-do {
-  const page = await client.replayRun({ runId, afterSequence, limit: 100 });
-  for (const event of page.events) console.log(event.sequence, event.event);
-  afterSequence = page.nextAfterSequence;
-  if (!page.hasMore) break;
-} while (true);
+const status = await client.runStatus(runId);
+if (status.terminal) {
+  const result = await attachment.result();
+  console.log(result.outcome, result.output);
+}
 
 const evidence = await client.runEvidence({ runId, limit: 100 });
 console.log(evidence.source.completeness, evidence.hashes.bundleSha256);
 ```
 
 `run.result` rejects through `AgencRpcError` with
-`error.data.code === "RUN_NOT_TERMINAL"` until an `agent_runs` row is durably
-terminal. `run.replay` cursors are exclusive database-global sequences and
-always return `hasMore` and `nextAfterSequence`; skipped numbers can belong to
-other runs. `run.evidence` is explicitly limited to existing M3 admission
-state (`workflowEvidenceIncluded: false`) and marks partial pages. No helper
-claims a terminal assistant payload or future workflow evidence that the
-current database does not store.
+`error.data.code === "RUN_NOT_TERMINAL"` until the run is durably terminal. A
+canonical M4 result returns `output.available: true`; a legacy terminal row
+without a canonical terminal payload returns `output.available: false` rather
+than inventing one.
+
+Canonical `run.replay` cursors are exclusive, per-run sequences. Pages are
+contiguous and expose durable `eventId` values. Retention, compaction,
+corruption truncation, a missing source, and a cursor beyond the durable tail
+are explicit gaps; none authorizes cursor advancement. The safer
+`reattachRun()` helper validates page ordering and identity consistency,
+suppresses exact duplicates, throws `AgencRunReplayGapError` without moving
+past a gap, and fails closed with `AgencRunReplayProtocolError` on an
+unexplained jump or conflicting identity.
+
+Raw `replayRun()` callers must inspect `page.gap` before adopting
+`page.nextAfterSequence`. A pre-M4 compatibility page can instead come from
+the execution-admission journal; its source declares
+`sequenceScope: "project_state_database"`, where skipped numbers may belong to
+other runs. `run.evidence` declares
+`workflowEvidenceIncluded: true` for canonical journal pages and `false` for
+that compatibility source, together with an explicit completeness value and
+content hashes.
 
 ## Daemon method surface (45 methods)
 
@@ -277,6 +308,9 @@ sees the same output and completion behavior as `agenc -p`.
   process (argv contract, event mapping, exit-code-2 mapping, error paths).
 - `events.contract.test.ts` — trusted object `clientAction` preservation and
   malformed/scalar rejection at the SDK event boundary.
+- `replay-safe-client.contract.test.ts` — reconnect cursors, duplicate
+  suppression, explicit gaps, protocol-conflict rejection, and durable result
+  lookup.
 
 ```bash
 cd runtime && npx vitest run tests/sdk-package

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -10,7 +10,8 @@ Node **>=25.9 <26** · ESM only · plain `tsc` build · no runtime dependencies.
 | --- | --- |
 | `connect()` | Attach to (or CLI-start) the local daemon over `~/.agenc/daemon.sock`. Typed `createSession()` / `prompt()` event streams, permission + elicitation callbacks, background-agent spawn/attach/stop/logs. |
 | `promptViaSubprocess()` | Same event-iterable interface over `agenc -p --output-format stream-json` with no daemon socket access from your process. |
-| `client.runStatus` / `runResult` / `replayRun` / `runEvidence` / `cancelRun` | Read durable run/admission state, page admission evidence, or cancel a run tree. |
+| `client.runStatus` / `runResult` / `replayRun` / `runEvidence` / `cancelRun` | Read durable run/admission state, replay or hash canonical journal evidence, or cancel a run tree. |
+| `client.reattachRun({ runId, afterSequence })` | Catch up from a durable cursor, suppress and report duplicate delivery, stop on any explicit replay gap, and fetch the durable terminal result after reconnect. |
 | `client.request(method, params)` | Raw typed JSON-RPC for all **45** public daemon methods (mirrored in `./protocol`). |
 
 The protocol mirror preserves trusted `event.user_input_request.clientAction`
@@ -46,6 +47,8 @@ await client.close();
 ## Docs & example
 
 - Full documentation: [`docs/sdk.md`](../../docs/sdk.md)
+- Durable run/effect/replay contract:
+  [`docs/design/durable-runs-effects-events.md`](../../docs/design/durable-runs-effects-events.md)
 - Runnable example: [`examples/one-shot.mjs`](./examples/one-shot.mjs)
 
 ```bash
@@ -56,3 +59,56 @@ node packages/agenc-sdk/examples/one-shot.mjs --transport subprocess "say hello"
 
 Protocol drift is pinned by `runtime/tests/sdk-package/protocol-drift.contract.test.ts`
 against the runtime's canonical method registry.
+
+## Durable reconnect
+
+Persist the attachment cursor after each processed event (or after finite
+catch-up iteration). A new client can resume from that exact exclusive
+sequence:
+
+```js
+import { AgencRunReplayGapError, connect } from "@tetsuo-ai/agenc-sdk";
+
+const client = await connect();
+const attachment = client.reattachRun({
+  runId,
+  afterSequence: savedAfterSequence ?? 0,
+  onDuplicate: ({ event }) => console.warn("duplicate", event.eventId),
+});
+
+try {
+  for await (const event of attachment) {
+    console.log(event.sequence, event.eventId, event.category, event.event);
+  }
+  await saveCursor(attachment.cursor());
+} catch (error) {
+  if (error instanceof AgencRunReplayGapError) {
+    // The cursor stops at the last event yielded before the gap. Reconcile the
+    // missing range before choosing a new cursor; the SDK never jumps it.
+    console.error(error.gap);
+  } else {
+    throw error;
+  }
+}
+
+const terminal = await attachment.result();
+if (terminal.output.available) console.log(terminal.output.finalMessage);
+await client.close();
+```
+
+Every canonical replay event has a durable `eventId` and root-run `sequence`.
+The attachment drops exact duplicates and reports them through `onDuplicate`;
+identity reuse with different data, out-of-order pages, and cursor jumps without
+an explicit gap fail closed with `AgencRunReplayProtocolError`.
+
+Exact fingerprints for the most recent 1,024 delivered events are retained by
+default (`identityWindow` can be 1..100,000). Older event IDs remain in a
+fixed-memory fail-closed membership filter: reuse is rejected, while a filter
+collision can only reject a new event. A newly reconnected attachment cannot
+verify data at or before its supplied exclusive cursor, so such delivery is a
+protocol error rather than an assumed duplicate.
+
+For a pre-M4 daemon/run with only the project-scoped admission journal,
+`replayRun()` returns the original M3 event fields. Use
+`isRunAdmissionReplayResult(page)` to narrow that compatibility source while
+canonical M4 pages retain the generalized `RunJournalEvent` envelope.

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -35,6 +35,8 @@ import {
   type RunCancelResult,
   type RunEvidenceParams,
   type RunEvidenceResult,
+  type RunReplayEvent,
+  type RunReplayGap,
   type RunReplayParams,
   type RunReplayResult,
   type RunResultResult,
@@ -94,6 +96,48 @@ export class AgencMalformedResponseError extends Error {
   }
 }
 
+/** A durable replay cursor cannot be advanced without acknowledging a gap. */
+export class AgencRunReplayGapError extends Error {
+  readonly runId: string;
+  readonly cursor: AgencRunReplayCursor;
+  readonly gap: RunReplayGap;
+
+  constructor(cursor: AgencRunReplayCursor, gap: RunReplayGap) {
+    const firstAvailable =
+      "firstAvailableSequence" in gap
+        ? `; first available sequence is ${String(gap.firstAvailableSequence)}`
+        : "lastAvailableSequence" in gap
+          ? `; last available sequence is ${String(gap.lastAvailableSequence)}`
+          : "";
+    super(
+      `AgenC run replay for ${cursor.runId} has an explicit ${gap.reason} gap after sequence ${String(cursor.afterSequence)}${firstAvailable}`,
+    );
+    this.name = "AgencRunReplayGapError";
+    this.runId = cursor.runId;
+    this.cursor = cursor;
+    this.gap = gap;
+  }
+}
+
+/** The daemon returned a replay page that could hide loss or corruption. */
+export class AgencRunReplayProtocolError extends Error {
+  readonly runId: string;
+  readonly cursor: AgencRunReplayCursor;
+  readonly response?: unknown;
+
+  constructor(
+    message: string,
+    cursor: AgencRunReplayCursor,
+    response?: unknown,
+  ) {
+    super(message);
+    this.name = "AgencRunReplayProtocolError";
+    this.runId = cursor.runId;
+    this.cursor = cursor;
+    this.response = response;
+  }
+}
+
 /** Decision returned by a permission callback. */
 export type AgencPermissionDecision =
   | { readonly behavior: "allow"; readonly scope?: "once" | "session" | "agent" }
@@ -142,6 +186,61 @@ export interface AgencPromptOptions {
   readonly metadata?: JsonObject;
   readonly onPermissionRequest?: AgencPermissionCallback;
   readonly onElicitationRequest?: AgencElicitationCallback;
+}
+
+/** Serializable exclusive cursor for reconnecting to one durable run. */
+export interface AgencRunReplayCursor {
+  readonly runId: string;
+  readonly afterSequence: number;
+}
+
+export type AgencRunReplayDuplicateReason =
+  | "same_identity"
+  | "at_or_before_cursor";
+
+export interface AgencRunReplayDuplicate {
+  readonly event: RunReplayEvent;
+  readonly reason: AgencRunReplayDuplicateReason;
+  /** Present when the same event was already observed by this attachment. */
+  readonly original?: RunReplayEvent;
+}
+
+export interface AgencRunReattachOptions extends AgencRunReplayCursor {
+  /** Page size sent to run.replay. Defaults to 100; valid range is 1..200. */
+  readonly limit?: number;
+  /**
+   * Most recently delivered identities retained with their complete
+   * fingerprints for exact duplicate diagnostics. Defaults to 1,024; valid
+   * range is 1..100,000. Older identities remain in a fixed-size fail-closed
+   * membership filter, so reuse is rejected rather than silently accepted.
+   */
+  readonly identityWindow?: number;
+  readonly signal?: AbortSignal;
+  /** Called for harmless duplicate delivery; callback failures are ignored. */
+  readonly onDuplicate?: (duplicate: AgencRunReplayDuplicate) => void;
+}
+
+export interface AgencRunReplayDiagnostics {
+  readonly duplicatesDropped: number;
+  /** Exact identities currently retained; never exceeds identityWindow. */
+  readonly trackedIdentities: number;
+  readonly identityWindow: number;
+}
+
+/**
+ * Cursor-safe attachment to a durable run.
+ *
+ * Iteration catches up to the journal head and then ends. Persist `cursor()`
+ * and pass it to a new client's `reattachRun` after reconnecting. An explicit
+ * replay gap throws {@link AgencRunReplayGapError} without advancing it.
+ */
+export interface AgencRunAttachment extends AsyncIterable<RunReplayEvent> {
+  readonly runId: string;
+  cursor(): AgencRunReplayCursor;
+  replay(): AsyncGenerator<RunReplayEvent, void>;
+  /** Durable terminal-result read; independent of the original connection. */
+  result(): Promise<RunResultResult>;
+  diagnostics(): AgencRunReplayDiagnostics;
 }
 
 /** Cap on internally buffered, not-yet-consumed prompt events. */
@@ -269,6 +368,306 @@ export class AgencSession {
       sessionId: this.sessionId,
       ...(reason !== undefined ? { reason } : {}),
     });
+  }
+}
+
+interface SeenReplayEvent {
+  readonly event: RunReplayEvent;
+  readonly fingerprint: string;
+}
+
+const DEFAULT_REPLAY_IDENTITY_WINDOW = 1_024;
+const MAX_REPLAY_IDENTITY_WINDOW = 100_000;
+const REPLAY_IDENTITY_FILTER_BYTES = 64 * 1_024;
+
+/**
+ * Fixed-memory membership filter for identities that age out of the exact
+ * fingerprint window. It has no false negatives because bits are never
+ * cleared. A hash collision can only reject a new identity (fail closed);
+ * it can never let an old identity be reused as new.
+ */
+class SeenReplayIdentityFilter {
+  readonly #bits = new Uint8Array(REPLAY_IDENTITY_FILTER_BYTES);
+
+  add(value: string): void {
+    for (const bit of replayIdentityHashBits(value)) {
+      this.#bits[bit >>> 3] |= 1 << (bit & 7);
+    }
+  }
+
+  has(value: string): boolean {
+    for (const bit of replayIdentityHashBits(value)) {
+      if ((this.#bits[bit >>> 3]! & (1 << (bit & 7))) === 0) return false;
+    }
+    return true;
+  }
+}
+
+interface ValidatedReplayPage {
+  readonly events: readonly SeenReplayEvent[];
+  readonly hasMore: boolean;
+  readonly gap: RunReplayGap | null;
+}
+
+class ClientRunAttachment implements AgencRunAttachment {
+  readonly runId: string;
+  readonly #client: AgencClient;
+  readonly #limit: number;
+  readonly #identityWindow: number;
+  readonly #signal: AbortSignal | undefined;
+  readonly #onDuplicate:
+    | ((duplicate: AgencRunReplayDuplicate) => void)
+    | undefined;
+  readonly #seenBySequence = new Map<number, SeenReplayEvent>();
+  readonly #seenByEventId = new Map<string, SeenReplayEvent>();
+  readonly #seenOrder = new Set<SeenReplayEvent>();
+  readonly #seenEventIds = new SeenReplayIdentityFilter();
+  #afterSequence: number;
+  #duplicatesDropped = 0;
+  #replaying = false;
+
+  constructor(client: AgencClient, options: AgencRunReattachOptions) {
+    this.#client = client;
+    this.runId = normalizeReplayRunId(options.runId);
+    this.#afterSequence = normalizeReplayAfterSequence(options.afterSequence);
+    this.#limit = normalizeReplayLimit(options.limit);
+    this.#identityWindow = normalizeReplayIdentityWindow(
+      options.identityWindow,
+    );
+    this.#signal = options.signal;
+    this.#onDuplicate = options.onDuplicate;
+  }
+
+  cursor(): AgencRunReplayCursor {
+    return { runId: this.runId, afterSequence: this.#afterSequence };
+  }
+
+  diagnostics(): AgencRunReplayDiagnostics {
+    return {
+      duplicatesDropped: this.#duplicatesDropped,
+      trackedIdentities: this.#seenOrder.size,
+      identityWindow: this.#identityWindow,
+    };
+  }
+
+  async #fetchPage(): Promise<ValidatedReplayPage> {
+    const requestedAfterSequence = this.#afterSequence;
+    const requestedCursor = this.cursor();
+    this.#signal?.throwIfAborted();
+    const response = await this.#client.replayRun({
+      runId: this.runId,
+      afterSequence: requestedAfterSequence,
+      limit: this.#limit,
+    });
+    this.#signal?.throwIfAborted();
+    validateReplayPageEnvelope(response, requestedCursor, this.#limit);
+
+    if (
+      response.gap === null &&
+      response.source.sequenceScope === "run" &&
+      response.firstAvailableSequence !== undefined &&
+      response.firstAvailableSequence > requestedAfterSequence + 1
+    ) {
+      throw new AgencRunReplayProtocolError(
+        `AgenC run replay exposed first available sequence ${String(response.firstAvailableSequence)} without an explicit gap`,
+        requestedCursor,
+        response,
+      );
+    }
+
+    const uniqueEvents: SeenReplayEvent[] = [];
+    const pageBySequence = new Map<number, SeenReplayEvent>();
+    const pageByEventId = new Map<string, SeenReplayEvent>();
+    let previousNewSequence = requestedAfterSequence;
+    for (const event of response.events) {
+      validateReplayEvent(event, requestedCursor, response);
+      const fingerprint = canonicalJson(event);
+      const bySequence =
+        pageBySequence.get(event.sequence) ??
+        this.#seenBySequence.get(event.sequence);
+      const byEventId =
+        pageByEventId.get(event.eventId) ??
+        this.#seenByEventId.get(event.eventId);
+
+      if (bySequence !== undefined || byEventId !== undefined) {
+        const original = bySequence ?? byEventId!;
+        if (
+          original.event.sequence !== event.sequence ||
+          original.event.eventId !== event.eventId ||
+          original.fingerprint !== fingerprint
+        ) {
+          throw new AgencRunReplayProtocolError(
+            `AgenC run replay reused event identity ${event.eventId}/${String(event.sequence)} with conflicting data`,
+            requestedCursor,
+            response,
+          );
+        }
+        this.#reportDuplicate({
+          event,
+          reason: "same_identity",
+          original: original.event,
+        });
+        continue;
+      }
+
+      if (event.sequence <= requestedAfterSequence) {
+        throw new AgencRunReplayProtocolError(
+          "AgenC run replay cannot verify event " +
+            event.eventId +
+            "/" +
+            String(event.sequence) +
+            " at or before exclusive cursor " +
+            String(requestedAfterSequence),
+          requestedCursor,
+          response,
+        );
+      }
+      if (this.#seenEventIds.has(event.eventId)) {
+        throw new AgencRunReplayProtocolError(
+          "AgenC run replay reused event identity " +
+            event.eventId +
+            " outside the exact verification window",
+          requestedCursor,
+          response,
+        );
+      }
+      if (event.sequence <= previousNewSequence) {
+        throw new AgencRunReplayProtocolError(
+          `AgenC run replay events are not strictly sequence ordered after ${String(previousNewSequence)}`,
+          requestedCursor,
+          response,
+        );
+      }
+      if (
+        response.source.sequenceScope === "run" &&
+        event.sequence !== previousNewSequence + 1
+      ) {
+        throw new AgencRunReplayProtocolError(
+          `AgenC run replay skipped sequence ${String(previousNewSequence + 1)} without an explicit gap`,
+          requestedCursor,
+          response,
+        );
+      }
+
+      const seen = { event, fingerprint };
+      pageBySequence.set(event.sequence, seen);
+      pageByEventId.set(event.eventId, seen);
+      uniqueEvents.push(seen);
+      previousNewSequence = event.sequence;
+    }
+
+    const expectedNextAfterSequence =
+      uniqueEvents.at(-1)?.event.sequence ?? requestedAfterSequence;
+    if (response.nextAfterSequence !== expectedNextAfterSequence) {
+      throw new AgencRunReplayProtocolError(
+        `AgenC run replay attempted to advance from ${String(requestedAfterSequence)} to ${String(response.nextAfterSequence)} without a matching final event`,
+        requestedCursor,
+        response,
+      );
+    }
+    if (
+      response.gap === null &&
+      response.hasMore &&
+      expectedNextAfterSequence === requestedAfterSequence
+    ) {
+      throw new AgencRunReplayProtocolError(
+        "AgenC run replay reported more events without advancing its cursor",
+        requestedCursor,
+        response,
+      );
+    }
+    if (
+      response.gap === null &&
+      response.lastAvailableSequence !== undefined &&
+      ((response.hasMore &&
+        expectedNextAfterSequence >= response.lastAvailableSequence) ||
+        (!response.hasMore &&
+          expectedNextAfterSequence !== response.lastAvailableSequence))
+    ) {
+      throw new AgencRunReplayProtocolError(
+        response.hasMore
+          ? "AgenC run replay reported more events at or beyond its advertised journal tail"
+          : `AgenC run replay ended at sequence ${String(expectedNextAfterSequence)} before its advertised journal tail ${String(response.lastAvailableSequence)}`,
+        requestedCursor,
+        response,
+      );
+    }
+
+    if (response.gap !== null) {
+      validateReplayGap(
+        response.gap,
+        { runId: this.runId, afterSequence: expectedNextAfterSequence },
+        response,
+      );
+    }
+
+    return {
+      events: uniqueEvents,
+      hasMore: response.hasMore,
+      gap: response.gap,
+    };
+  }
+
+  async *replay(): AsyncGenerator<RunReplayEvent, void> {
+    if (this.#replaying) {
+      throw new AgencRunReplayProtocolError(
+        "AgenC run replay does not allow concurrent cursor advancement",
+        this.cursor(),
+      );
+    }
+    this.#replaying = true;
+    try {
+      for (;;) {
+        const page = await this.#fetchPage();
+        for (const seen of page.events) {
+          this.#signal?.throwIfAborted();
+          this.#remember(seen);
+          this.#afterSequence = seen.event.sequence;
+          yield seen.event;
+        }
+        if (page.gap !== null) {
+          throw new AgencRunReplayGapError(this.cursor(), page.gap);
+        }
+        if (!page.hasMore) return;
+      }
+    } finally {
+      this.#replaying = false;
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncGenerator<RunReplayEvent, void> {
+    return this.replay();
+  }
+
+  result(): Promise<RunResultResult> {
+    return this.#client.runResult(this.runId);
+  }
+
+  #reportDuplicate(duplicate: AgencRunReplayDuplicate): void {
+    this.#duplicatesDropped += 1;
+    try {
+      this.#onDuplicate?.(duplicate);
+    } catch {
+      // Observability callbacks cannot make safe duplicate suppression fail.
+    }
+  }
+
+  #remember(seen: SeenReplayEvent): void {
+    this.#seenBySequence.set(seen.event.sequence, seen);
+    this.#seenByEventId.set(seen.event.eventId, seen);
+    this.#seenEventIds.add(seen.event.eventId);
+    this.#seenOrder.add(seen);
+    while (this.#seenOrder.size > this.#identityWindow) {
+      const retired = this.#seenOrder.values().next().value;
+      if (retired === undefined) break;
+      this.#seenOrder.delete(retired);
+      if (this.#seenBySequence.get(retired.event.sequence) === retired) {
+        this.#seenBySequence.delete(retired.event.sequence);
+      }
+      if (this.#seenByEventId.get(retired.event.eventId) === retired) {
+        this.#seenByEventId.delete(retired.event.eventId);
+      }
+    }
   }
 }
 
@@ -477,12 +876,23 @@ export class AgencClient {
     return this.request("run.result", { runId });
   }
 
-  /** Replay a bounded page of the existing execution-admission journal. */
+  /** Replay a bounded page of the canonical run journal. */
   replayRun(params: RunReplayParams): Promise<RunReplayResult> {
     return this.request("run.replay", params);
   }
 
-  /** Export a bounded, hashed M3 admission evidence page. */
+  /**
+   * Reattach to a durable run from an exclusive cursor.
+   *
+   * The returned attachment preserves event identity, suppresses harmless
+   * duplicate delivery, refuses silent cursor jumps, and exposes a durable
+   * `run.result` read that does not depend on the original connection.
+   */
+  reattachRun(options: AgencRunReattachOptions): AgencRunAttachment {
+    return new ClientRunAttachment(this, options);
+  }
+
+  /** Export a bounded, hashed canonical run-journal evidence page. */
   runEvidence(params: RunEvidenceParams): Promise<RunEvidenceResult> {
     return this.request("run.evidence", params);
   }
@@ -753,4 +1163,394 @@ function resolveClientCwd(cwd: string | undefined): string {
     return isAbsolute(trimmed) ? resolve(trimmed) : resolve(base, trimmed);
   }
   return resolve(base);
+}
+
+function normalizeReplayRunId(runId: string): string {
+  const normalized = runId.trim();
+  if (normalized.length === 0) {
+    throw new TypeError("AgenC run replay requires a non-empty runId");
+  }
+  return normalized;
+}
+
+function normalizeReplayAfterSequence(afterSequence: number): number {
+  if (!Number.isSafeInteger(afterSequence) || afterSequence < 0) {
+    throw new TypeError(
+      "AgenC run replay afterSequence must be a non-negative safe integer",
+    );
+  }
+  return afterSequence;
+}
+
+function normalizeReplayLimit(limit: number | undefined): number {
+  const normalized = limit ?? 100;
+  if (
+    !Number.isSafeInteger(normalized) ||
+    normalized < 1 ||
+    normalized > 200
+  ) {
+    throw new TypeError("AgenC run replay limit must be an integer from 1 to 200");
+  }
+  return normalized;
+}
+
+function normalizeReplayIdentityWindow(window: number | undefined): number {
+  const normalized = window ?? DEFAULT_REPLAY_IDENTITY_WINDOW;
+  if (
+    !Number.isSafeInteger(normalized) ||
+    normalized < 1 ||
+    normalized > MAX_REPLAY_IDENTITY_WINDOW
+  ) {
+    throw new TypeError(
+      "AgenC run replay identityWindow must be an integer from 1 to " +
+        String(MAX_REPLAY_IDENTITY_WINDOW),
+    );
+  }
+  return normalized;
+}
+
+function validateReplayPageEnvelope(
+  response: RunReplayResult,
+  cursor: AgencRunReplayCursor,
+  requestedLimit: number,
+): void {
+  if (!isJsonObject(response)) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay response must be an object",
+      cursor,
+      response,
+    );
+  }
+  if (response.runId !== cursor.runId) {
+    throw new AgencRunReplayProtocolError(
+      `AgenC run replay returned run ${response.runId} for ${cursor.runId}`,
+      cursor,
+      response,
+    );
+  }
+  if (response.afterSequence !== cursor.afterSequence) {
+    throw new AgencRunReplayProtocolError(
+      `AgenC run replay returned cursor ${String(response.afterSequence)} for requested cursor ${String(cursor.afterSequence)}`,
+      cursor,
+      response,
+    );
+  }
+  if (response.limit !== requestedLimit) {
+    throw new AgencRunReplayProtocolError(
+      `AgenC run replay returned limit ${String(response.limit)} for requested limit ${String(requestedLimit)}`,
+      cursor,
+      response,
+    );
+  }
+  if (!Array.isArray(response.events)) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay response events must be an array",
+      cursor,
+      response,
+    );
+  }
+  if (response.events.length > requestedLimit) {
+    throw new AgencRunReplayProtocolError(
+      `AgenC run replay returned ${String(response.events.length)} events for limit ${String(requestedLimit)}`,
+      cursor,
+      response,
+    );
+  }
+  const firstAvailableSequence = response.firstAvailableSequence;
+  const lastAvailableSequence = response.lastAvailableSequence;
+  if (
+    firstAvailableSequence !== undefined &&
+    (!Number.isSafeInteger(firstAvailableSequence) ||
+      firstAvailableSequence < 1)
+  ) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay returned an invalid firstAvailableSequence",
+      cursor,
+      response,
+    );
+  }
+  if (
+    lastAvailableSequence !== undefined &&
+    (!Number.isSafeInteger(lastAvailableSequence) || lastAvailableSequence < 0)
+  ) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay returned an invalid lastAvailableSequence",
+      cursor,
+      response,
+    );
+  }
+  if (
+    firstAvailableSequence !== undefined &&
+    lastAvailableSequence !== undefined &&
+    firstAvailableSequence > lastAvailableSequence &&
+    (response.events.length > 0 ||
+      firstAvailableSequence - lastAvailableSequence !== 1)
+  ) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay returned inconsistent available-sequence bounds",
+      cursor,
+      response,
+    );
+  }
+  if (
+    !Number.isSafeInteger(response.nextAfterSequence) ||
+    response.nextAfterSequence < cursor.afterSequence
+  ) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay returned an invalid nextAfterSequence",
+      cursor,
+      response,
+    );
+  }
+  if (typeof response.hasMore !== "boolean") {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay response hasMore must be boolean",
+      cursor,
+      response,
+    );
+  }
+  if (!isJsonObject(response.source)) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay response source must be an object",
+      cursor,
+      response,
+    );
+  }
+  validateReplaySource(response, cursor);
+  if (
+    response.source.kind === "run_journal" &&
+    response.source.available &&
+    (response.events.length > 0 || cursor.afterSequence > 0) &&
+    response.lastAvailableSequence === undefined
+  ) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay omitted the canonical journal tail",
+      cursor,
+      response,
+    );
+  }
+  if (response.gap !== null && !isJsonObject(response.gap)) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay response gap must be null or an object",
+      cursor,
+      response,
+    );
+  }
+}
+
+function validateReplaySource(
+  response: RunReplayResult,
+  cursor: AgencRunReplayCursor,
+): void {
+  const source = response.source;
+  const invalid = (message: string): never => {
+    throw new AgencRunReplayProtocolError(message, cursor, response);
+  };
+  if (
+    typeof source.available !== "boolean" ||
+    typeof source.projectDir !== "string" ||
+    source.projectDir.length === 0
+  ) {
+    invalid("AgenC run replay returned malformed source metadata");
+  }
+  if (source.kind === "run_journal") {
+    if (
+      source.sequenceScope !== "run" ||
+      source.canonical !== "rollout_jsonl" ||
+      source.projection !== "thread_rollout_items"
+    ) {
+      invalid("AgenC run replay returned malformed run-journal source metadata");
+    }
+  } else if (source.kind === "execution_admission_journal") {
+    if (
+      source.sequenceScope !== "project_state_database" ||
+      source.canonical !== undefined ||
+      source.projection !== undefined
+    ) {
+      invalid("AgenC run replay returned malformed admission-journal source metadata");
+    }
+  } else {
+    invalid("AgenC run replay returned an unknown source kind");
+  }
+
+  const sourceUnavailable = response.gap?.kind === "source_unavailable";
+  if (
+    source.available === sourceUnavailable ||
+    (!source.available && (response.events.length > 0 || response.hasMore))
+  ) {
+    invalid("AgenC run replay source availability conflicts with its page");
+  }
+  if (
+    sourceUnavailable &&
+    ((source.kind === "run_journal" &&
+      response.gap?.reason !== "run_journal_not_present") ||
+      (source.kind === "execution_admission_journal" &&
+        response.gap?.reason !== "execution_admission_journal_not_present"))
+  ) {
+    invalid("AgenC run replay source kind conflicts with its unavailable reason");
+  }
+}
+
+function validateReplayEvent(
+  event: RunReplayEvent,
+  cursor: AgencRunReplayCursor,
+  response: RunReplayResult,
+): void {
+  const invalid = (message: string): never => {
+    throw new AgencRunReplayProtocolError(message, cursor, response);
+  };
+  const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === "string" && value.trim().length > 0;
+  if (!isJsonObject(event)) {
+    invalid("AgenC run replay event must be an object");
+  }
+  if (
+    !Number.isSafeInteger(event.sequence) ||
+    event.sequence < 1 ||
+    !isNonEmptyString(event.eventId)
+  ) {
+    invalid(
+      "AgenC run replay event requires a positive sequence and non-empty eventId",
+    );
+  }
+
+  if (response.source.kind === "run_journal") {
+    const canonicalCategories = new Set([
+      "run",
+      "step",
+      "admission",
+      "budget",
+      "permission",
+      "approval",
+      "effect",
+      "model",
+      "artifact",
+      "cancellation",
+      "recovery",
+      "terminal",
+      "session",
+    ]);
+    if (
+      !isNonEmptyString(event.runId) ||
+      !isNonEmptyString(event.kind) ||
+      !isNonEmptyString(event.event) ||
+      !isNonEmptyString(event.category) ||
+      !canonicalCategories.has(event.category) ||
+      (event.timestamp !== undefined && !isNonEmptyString(event.timestamp)) ||
+      (event.stepId !== undefined && !isNonEmptyString(event.stepId))
+    ) {
+      invalid("AgenC run replay returned a malformed canonical event envelope");
+    }
+    if (event.runId !== cursor.runId) {
+      invalid(
+        `AgenC run replay event ${event.eventId} belongs to unexpected run ${event.runId}`,
+      );
+    }
+    return;
+  }
+
+  if (
+    !isNonEmptyString(event.timestamp) ||
+    !isNonEmptyString(event.runId) ||
+    !isNonEmptyString(event.stepId) ||
+    !isNonEmptyString(event.kind) ||
+    !isNonEmptyString(event.event) ||
+    (event.category !== undefined && event.category !== "admission")
+  ) {
+    invalid("AgenC run replay returned a malformed admission event envelope");
+  }
+}
+
+function validateReplayGap(
+  gap: RunReplayGap,
+  cursor: AgencRunReplayCursor,
+  response: RunReplayResult,
+): void {
+  if (gap.kind === "source_unavailable") {
+    if (
+      gap.reason !== "execution_admission_journal_not_present" &&
+      gap.reason !== "run_journal_not_present"
+    ) {
+      throw new AgencRunReplayProtocolError(
+        "AgenC run replay returned an unknown source-unavailable reason",
+        cursor,
+        response,
+      );
+    }
+    return;
+  }
+  if (gap.kind === "cursor_ahead") {
+    if (
+      gap.runId !== cursor.runId ||
+      gap.afterSequence !== cursor.afterSequence ||
+      gap.reason !== "cursor_ahead" ||
+      !Number.isSafeInteger(gap.lastAvailableSequence) ||
+      gap.lastAvailableSequence < 0 ||
+      gap.lastAvailableSequence >= gap.afterSequence ||
+      response.lastAvailableSequence !== gap.lastAvailableSequence
+    ) {
+      throw new AgencRunReplayProtocolError(
+        "AgenC run replay returned a malformed or mismatched cursor-ahead gap",
+        cursor,
+        response,
+      );
+    }
+    return;
+  }
+  if (
+    gap.kind !== "event_gap" ||
+    gap.runId !== cursor.runId ||
+    gap.afterSequence !== cursor.afterSequence ||
+    !Number.isSafeInteger(gap.firstAvailableSequence) ||
+    gap.firstAvailableSequence <= gap.afterSequence ||
+    (response.firstAvailableSequence !== undefined &&
+      response.firstAvailableSequence !== gap.firstAvailableSequence) ||
+    (gap.reason !== "retention" &&
+      gap.reason !== "corruption_truncated" &&
+      gap.reason !== "compaction")
+  ) {
+    throw new AgencRunReplayProtocolError(
+      "AgenC run replay returned a malformed or mismatched event gap",
+      cursor,
+      response,
+    );
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (isJsonObject(value)) {
+    const fields = Object.keys(value)
+      .filter((key) => value[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`);
+    return `{${fields.join(",")}}`;
+  }
+  return JSON.stringify(String(value));
+}
+
+function replayIdentityHashBits(value: string): readonly number[] {
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    first = Math.imul(first ^ code, 0x01000193) >>> 0;
+    second =
+      Math.imul(second ^ (code + index), 0x85ebca6b) + 0xc2b2ae35;
+    second >>>= 0;
+  }
+  const bitCount = REPLAY_IDENTITY_FILTER_BYTES * 8;
+  return [
+    first % bitCount,
+    second % bitCount,
+    (first + second) % bitCount,
+    ((first + Math.imul(second, 3)) >>> 0) % bitCount,
+  ];
 }

--- a/packages/agenc-sdk/src/events.ts
+++ b/packages/agenc-sdk/src/events.ts
@@ -18,49 +18,67 @@ import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 export type AgencStopReason = "completed" | "errored" | "stopped";
 
+/** Durable identity carried unchanged from a daemon event notification. */
+export interface AgencPromptEventIdentity {
+  readonly eventId?: string;
+  readonly sequence?: number;
+}
+
 /** One streamed event observed while a prompt turn runs. */
-export type AgencPromptEvent =
-  | {
-      readonly type: "text";
-      readonly delta: string;
-      readonly messageId?: string;
-      readonly streamId?: string;
-    }
-  | {
-      readonly type: "tool_call";
-      readonly requestId: string;
-      readonly toolName: string;
-      readonly turnId?: string;
-      readonly input?: JsonValue;
-      readonly recoveryCategory?: string;
-    }
-  | {
-      readonly type: "permission_request";
-      readonly requestId: string;
-      readonly toolName?: string;
-      readonly permissions: readonly string[];
-      readonly input?: JsonValue;
-      readonly reason?: string;
-    }
-  | {
-      readonly type: "elicitation_request";
-      readonly kind: "request_user_input" | "mcp";
-      readonly requestId: string | number;
-      readonly serverName?: string;
-      readonly questions?: readonly JsonObject[];
-      readonly request?: JsonObject;
-      readonly clientAction?: JsonObject;
-    }
-  | {
-      readonly type: "status";
-      readonly status?: string;
-      readonly runStatus?: string;
-      readonly message?: string;
-    }
-  | {
-      readonly type: "session_event";
-      readonly event: JsonObject;
-    };
+export type AgencPromptEvent = AgencPromptEventIdentity &
+  (| {
+        readonly type: "text";
+        readonly delta: string;
+        readonly messageId?: string;
+        readonly streamId?: string;
+      }
+    | {
+        readonly type: "tool_call";
+        readonly requestId: string;
+        readonly toolName: string;
+        readonly turnId?: string;
+        readonly input?: JsonValue;
+        readonly recoveryCategory?: string;
+      }
+    | {
+        readonly type: "permission_request";
+        readonly requestId: string;
+        readonly toolName?: string;
+        readonly permissions: readonly string[];
+        readonly input?: JsonValue;
+        readonly reason?: string;
+      }
+    | {
+        readonly type: "elicitation_request";
+        readonly kind: "request_user_input" | "mcp";
+        readonly requestId: string | number;
+        readonly serverName?: string;
+        readonly questions?: readonly JsonObject[];
+        readonly request?: JsonObject;
+        readonly clientAction?: JsonObject;
+      }
+    | {
+        readonly type: "status";
+        readonly status?: string;
+        readonly runStatus?: string;
+        readonly message?: string;
+      }
+    | {
+        /** Detached live-buffer loss; reattach with the durable run cursor. */
+        readonly type: "gap";
+        readonly kind: "event_gap";
+        readonly reason: "retention";
+        readonly sessionId: string;
+        readonly runId?: string;
+        readonly afterSequence?: number;
+        readonly firstAvailableSequence?: number;
+        readonly retiredCount: number;
+      }
+    | {
+        readonly type: "session_event";
+        readonly event: JsonObject;
+      }
+  );
 
 export interface AgencUsage extends JsonObject {
   readonly inputTokens: number;
@@ -198,6 +216,34 @@ export function promptEventFromNotification(
 ): AgencPromptEvent | null {
   const params = eventParams(message);
   const method = message.method;
+  const identity = eventIdentityFromParams(params);
+
+  if (method === "event.event_gap" && params !== null) {
+    if (
+      params.kind !== "event_gap" ||
+      params.reason !== "retention" ||
+      typeof params.sessionId !== "string" ||
+      !Number.isSafeInteger(params.retiredCount) ||
+      (params.retiredCount as number) < 1
+    ) {
+      return null;
+    }
+    const afterSequence = positiveOrZeroInteger(params.afterSequence);
+    const firstAvailableSequence = positiveInteger(params.firstAvailableSequence);
+    return {
+      type: "gap",
+      kind: "event_gap",
+      reason: "retention",
+      ...identity,
+      sessionId: params.sessionId,
+      retiredCount: params.retiredCount as number,
+      ...(typeof params.runId === "string" ? { runId: params.runId } : {}),
+      ...(afterSequence !== undefined ? { afterSequence } : {}),
+      ...(firstAvailableSequence !== undefined
+        ? { firstAvailableSequence }
+        : {}),
+    };
+  }
 
   if (method === "event.message_chunk" || method === "event.session_event") {
     const delta = messageChunkFromNotification(message);
@@ -206,6 +252,7 @@ export function promptEventFromNotification(
       return {
         type: "text",
         delta,
+        ...identity,
         ...(typeof chunkParams.messageId === "string"
           ? { messageId: chunkParams.messageId }
           : {}),
@@ -216,7 +263,7 @@ export function promptEventFromNotification(
     }
     if (method === "event.session_event" && params !== null) {
       const nested = isJsonObject(params.event) ? params.event : params;
-      return { type: "session_event", event: nested };
+      return { type: "session_event", event: nested, ...identity };
     }
     return null;
   }
@@ -229,6 +276,7 @@ export function promptEventFromNotification(
       type: "tool_call",
       requestId: params.requestId,
       toolName: typeof params.toolName === "string" ? params.toolName : "",
+      ...identity,
       ...(typeof params.turnId === "string" ? { turnId: params.turnId } : {}),
       ...(params.input !== undefined ? { input: params.input } : {}),
       ...(typeof params.recoveryCategory === "string"
@@ -250,6 +298,7 @@ export function promptEventFromNotification(
       type: "permission_request",
       requestId: params.requestId,
       permissions,
+      ...identity,
       ...(typeof params.toolName === "string"
         ? { toolName: params.toolName }
         : {}),
@@ -268,6 +317,7 @@ export function promptEventFromNotification(
       kind: "request_user_input",
       requestId: params.requestId,
       questions,
+      ...identity,
       ...(isJsonObject(params.clientAction)
         ? { clientAction: params.clientAction }
         : {}),
@@ -283,6 +333,7 @@ export function promptEventFromNotification(
       type: "elicitation_request",
       kind: "mcp",
       requestId,
+      ...identity,
       ...(typeof params.serverName === "string"
         ? { serverName: params.serverName }
         : {}),
@@ -293,6 +344,7 @@ export function promptEventFromNotification(
   if (method === "event.agent_status") {
     return {
       type: "status",
+      ...identity,
       ...(typeof params.status === "string" ? { status: params.status } : {}),
       ...(typeof params.runStatus === "string"
         ? { runStatus: params.runStatus }
@@ -302,6 +354,35 @@ export function promptEventFromNotification(
   }
 
   return null;
+}
+
+function eventIdentityFromParams(
+  params: JsonObject | null,
+): AgencPromptEventIdentity {
+  if (params === null) return {};
+  const sequence = params.sequence;
+  const hasSequence =
+    typeof sequence === "number" &&
+    Number.isSafeInteger(sequence) &&
+    sequence > 0;
+  return {
+    ...(typeof params.eventId === "string"
+      ? { eventId: params.eventId }
+      : {}),
+    ...(hasSequence ? { sequence } : {}),
+  };
+}
+
+function positiveOrZeroInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
 }
 
 /** sessionId carried by a daemon notification, if any. */

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -91,6 +91,7 @@ export const AGENC_SDK_DAEMON_NOTIFICATION_METHODS = [
   "event.mcp_elicitation_request",
   "event.agent_status",
   "event.session_event",
+  "event.event_gap",
   "thread/realtime/started",
   "thread/realtime/itemAdded",
   "thread/realtime/transcript/delta",
@@ -618,7 +619,11 @@ export interface RunStatusResult extends JsonObject {
   readonly runId: string;
   readonly status: string;
   readonly terminal: boolean;
-  readonly statusSource: "agent_run" | "admission_state";
+  readonly statusSource:
+    | "run_terminal_result"
+    | "run_lifecycle_epoch"
+    | "agent_run"
+    | "admission_state";
   readonly durableRun?: RunDurableRecord;
   readonly admission: RunAdmissionSummary;
   readonly source: RunStateSource;
@@ -632,17 +637,87 @@ export interface RunTerminalOutputAvailability extends JsonObject {
   readonly reason: "terminal_output_not_persisted_in_existing_state";
 }
 
+export interface RunUsageTotals extends JsonObject {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+}
+
+/** Terminal output committed by M4 and readable after disconnect/restart. */
+export interface RunTerminalPersistedOutput extends JsonObject {
+  readonly available: true;
+  readonly exitCode: number | null;
+  readonly stopReason: string | null;
+  readonly finalMessage: string | null;
+  readonly usage: RunUsageTotals | null;
+  readonly lastSequence: number | null;
+}
+
+/** Compatibility alias for code that names the unavailable branch directly. */
+export type RunTerminalOutputUnavailable = RunTerminalOutputAvailability;
+export type RunTerminalOutput =
+  | RunTerminalPersistedOutput
+  | RunTerminalOutputAvailability;
+
 export interface RunResultResult extends JsonObject {
   readonly runId: string;
   readonly status: string;
   readonly terminal: true;
   readonly terminalAt: string;
   readonly outcome: RunTerminalOutcome;
-  readonly durableRun: RunDurableRecord;
-  readonly output: RunTerminalOutputAvailability;
+  readonly epoch?: number;
+  readonly durableRun?: RunDurableRecord;
+  readonly output: RunTerminalOutput;
   readonly source: RunStateSource;
 }
 
+export type RunJournalCategory =
+  | "run"
+  | "step"
+  | "admission"
+  | "budget"
+  | "permission"
+  | "approval"
+  | "effect"
+  | "model"
+  | "artifact"
+  | "cancellation"
+  | "recovery"
+  | "terminal"
+  | "session";
+
+/**
+ * One event from the canonical append-only run journal.
+ *
+ * M3 admission events remain valid members of this shape; M4 workflow events
+ * add a canonical category/name/payload envelope without forcing consumers to
+ * understand every future event payload before they can advance a cursor.
+ */
+export interface RunJournalEvent extends JsonObject {
+  readonly sequence: number;
+  readonly eventId: string;
+  readonly timestamp?: string;
+  readonly runId: string;
+  readonly childRunId?: string;
+  readonly sessionId?: string;
+  readonly stepId?: string;
+  readonly category: RunJournalCategory;
+  readonly kind: string;
+  readonly event: string;
+  readonly payload?: JsonValue;
+  readonly reason?: string;
+  readonly reservationId?: string;
+  readonly model?: string;
+  readonly provider?: string;
+  readonly reservedTokens?: number;
+  readonly reservedCostUsd?: number;
+  readonly actualTokens?: number;
+  readonly actualCostUsd?: number;
+  readonly details?: JsonObject;
+}
+
+/** Source-compatible M3 admission event contract. */
 export interface RunAdmissionJournalEvent extends JsonObject {
   readonly sequence: number;
   readonly eventId: string;
@@ -662,39 +737,122 @@ export interface RunAdmissionJournalEvent extends JsonObject {
   readonly details?: JsonObject;
 }
 
-export interface RunReplayGap extends JsonObject {
-  readonly kind: "source_unavailable";
-  readonly reason: "execution_admission_journal_not_present";
+/**
+ * Event returned by the pre-M4 admission-journal compatibility reader.
+ *
+ * `category` is optional because SDK clients can connect to an older daemon
+ * that predates the generalized M4 envelope. Every required M3 field remains
+ * unchanged, so `isRunAdmissionReplayResult` restores the original
+ * source-compatible event type without a cast.
+ */
+export interface RunAdmissionReplayEvent extends RunAdmissionJournalEvent {
+  readonly category?: "admission";
+  readonly payload?: JsonValue;
 }
 
-export interface RunReplaySource extends JsonObject {
+/** One event from either the canonical M4 or compatibility M3 replay source. */
+export type RunReplayEvent = RunJournalEvent | RunAdmissionReplayEvent;
+
+export interface RunReplaySourceUnavailableGap extends JsonObject {
+  readonly kind: "source_unavailable";
+  readonly reason:
+    | "execution_admission_journal_not_present"
+    | "run_journal_not_present";
+}
+
+/** A cursor range was retired or could not be recovered contiguously. */
+export interface RunReplayRetentionGap extends JsonObject {
+  readonly kind: "event_gap";
+  readonly runId: string;
+  readonly afterSequence: number;
+  readonly firstAvailableSequence: number;
+  readonly reason: "retention" | "corruption_truncated" | "compaction";
+}
+
+/** The supplied cursor is beyond the canonical journal tail. */
+export interface RunReplayCursorAheadGap extends JsonObject {
+  readonly kind: "cursor_ahead";
+  readonly runId: string;
+  readonly afterSequence: number;
+  readonly lastAvailableSequence: number;
+  readonly reason: "cursor_ahead";
+}
+
+export type RunReplayGap =
+  | RunReplayRetentionGap
+  | RunReplayCursorAheadGap
+  | RunReplaySourceUnavailableGap;
+
+export interface RunJournalReplaySource extends JsonObject {
+  readonly kind: "run_journal";
+  readonly available: boolean;
+  readonly sequenceScope: "run";
+  readonly canonical: "rollout_jsonl";
+  readonly projection: "thread_rollout_items";
+  readonly projectDir: string;
+}
+
+export interface RunAdmissionReplaySource extends JsonObject {
   readonly kind: "execution_admission_journal";
   readonly available: boolean;
   readonly sequenceScope: "project_state_database";
   readonly projectDir: string;
 }
 
-export interface RunReplayResult extends JsonObject {
+export type RunReplaySource =
+  | RunJournalReplaySource
+  | RunAdmissionReplaySource;
+
+export interface RunReplayPage extends JsonObject {
   readonly runId: string;
   readonly afterSequence: number;
   readonly limit: number;
-  readonly events: readonly RunAdmissionJournalEvent[];
   readonly hasMore: boolean;
   readonly nextAfterSequence: number;
   readonly firstAvailableSequence?: number;
   readonly lastAvailableSequence?: number;
   readonly gap: RunReplayGap | null;
-  readonly source: RunReplaySource;
+}
+
+export interface RunJournalReplayResult extends RunReplayPage {
+  readonly events: readonly RunJournalEvent[];
+  readonly source: RunJournalReplaySource;
+}
+
+/** Source-compatible result for the existing M3 admission replay reader. */
+export interface RunAdmissionReplayResult extends RunReplayPage {
+  readonly events: readonly RunAdmissionReplayEvent[];
+  readonly source: RunAdmissionReplaySource;
+}
+
+/** Discriminated by `source.kind`; M3 and M4 event contracts stay precise. */
+export type RunReplayResult =
+  | RunJournalReplayResult
+  | RunAdmissionReplayResult;
+
+export function isRunAdmissionReplayResult(
+  result: RunReplayResult,
+): result is RunAdmissionReplayResult {
+  return result.source.kind === "execution_admission_journal";
+}
+
+export function isRunJournalReplayResult(
+  result: RunReplayResult,
+): result is RunJournalReplayResult {
+  return result.source.kind === "run_journal";
 }
 
 export type RunEvidenceCompleteness =
-  "complete" | "partial" | "admission_source_unavailable";
+  | "complete"
+  | "partial"
+  | "admission_source_unavailable"
+  | "journal_gap";
 
 export interface RunEvidenceSource extends JsonObject {
-  readonly kind: "existing_m3_admission_state";
+  readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
   readonly projectDir: string;
   readonly admissionJournal: boolean;
-  readonly workflowEvidenceIncluded: false;
+  readonly workflowEvidenceIncluded: boolean;
   readonly completeness: RunEvidenceCompleteness;
 }
 
@@ -714,6 +872,7 @@ export interface RunEvidenceHashes extends JsonObject {
   readonly algorithm: "sha256";
   readonly runStateSha256: string;
   readonly admissionSummarySha256: string;
+  readonly gapSha256: string;
   readonly eventHashes: readonly RunEvidenceEventHash[];
   readonly bundleSha256: string;
 }
@@ -723,7 +882,8 @@ export interface RunEvidenceResult extends JsonObject {
   readonly source: RunEvidenceSource;
   readonly cursor: RunEvidenceCursor;
   readonly hasMore: boolean;
-  readonly events: readonly RunAdmissionJournalEvent[];
+  readonly gap: RunReplayGap | null;
+  readonly events: readonly RunReplayEvent[];
   readonly hashes: RunEvidenceHashes;
 }
 
@@ -1001,6 +1161,23 @@ export interface EventAgentStatusParams extends AgencEventBaseParams {
 
 export interface EventSessionEventParams extends AgencEventBaseParams {
   readonly event: JsonObject;
+}
+
+/** Observable, non-journal sentinel emitted by bounded live-delivery buffers. */
+export interface EventGapParams extends JsonObject {
+  readonly type: "event_gap";
+  readonly kind: "event_gap";
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly eventId?: string;
+  readonly agentId?: string;
+  readonly sequence?: number;
+  readonly reason: "retention";
+  readonly source: "background_runner_retention" | "multiplexer_retention";
+  readonly retiredCount: number;
+  readonly coordinatesAvailable?: boolean;
+  readonly afterSequence?: number;
+  readonly firstAvailableSequence?: number;
 }
 
 // ── Envelopes ────────────────────────────────────────────────────────

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -55,7 +55,12 @@ import {
   withSignedSessionId,
 } from "./_deps/filesystem-args.js";
 import { Session as ChildSession, type Session } from "../session/session.js";
-import { RolloutStore } from "../session/rollout-store.js";
+import {
+  mountChildRunJournal,
+  recordUnconstructedChildRunTerminal,
+  type ChildRunTerminalResult,
+} from "../session/child-run-journal.js";
+import { TerminalRunEpochOpenError } from "../session/rollout-store.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
 import {
   threadConfigSnapshot,
@@ -115,7 +120,10 @@ export interface RunAgentParams {
   readonly querySource?: string;
   /** Optional per-child turn cap. */
   readonly maxTurns?: number;
-  /** Suppress parent mailbox notifications and child rollout recording. */
+  /**
+   * Suppress parent mailbox/progress relays. Canonical child recording remains
+   * enabled because silent internal agents can still perform admitted work.
+   */
   readonly silent?: boolean;
   /** Captured once the child turn has the exact cache-safe request state. */
   readonly onCacheSafeParams?: (params: CacheSafeParams) => void;
@@ -1194,8 +1202,7 @@ export function buildFilteredRegistry(
     /** Live child authority for callers that invoke `registry.dispatch`. */
     readonly getSession?: () => Session | null | undefined;
     /** Isolated legacy-test seam; production must never provide this token. */
-    readonly unadmittedDispatchOverride?:
-      typeof TEST_ONLY_ALLOW_UNADMITTED_CHILD_REGISTRY_DISPATCH;
+    readonly unadmittedDispatchOverride?: typeof TEST_ONLY_ALLOW_UNADMITTED_CHILD_REGISTRY_DISPATCH;
   },
 ): ToolRegistry {
   const allowed = opts.allowlist ? new Set(opts.allowlist) : null;
@@ -1755,38 +1762,6 @@ function cloneSessionConfiguration(
   };
 }
 
-function createChildRolloutStore(
-  parent: Session,
-  sessionConfiguration: Session["sessionConfiguration"],
-  childConversationId: string,
-): RolloutStore | null {
-  const parentRollout = parent.rolloutStore;
-  if (!parentRollout) {
-    return null;
-  }
-
-  const store = new RolloutStore({
-    cwd: sessionConfiguration.cwd,
-    sessionId: childConversationId,
-    agencVersion: parentRollout.store.agencVersion,
-    ...(parentRollout.projectRootMarkers !== undefined
-      ? { projectRootMarkers: parentRollout.projectRootMarkers }
-      : {}),
-  });
-  store.open({
-    sessionId: childConversationId,
-    timestamp: new Date().toISOString(),
-    cwd: sessionConfiguration.cwd,
-    originator: "agenc-subagent",
-    agencVersion: parentRollout.store.agencVersion,
-    model: sessionConfiguration.collaborationMode.model,
-    modelProvider:
-      readProviderIdentity(parent.services.provider) ??
-      parent.services.provider.name,
-  });
-  return store;
-}
-
 function buildChildConfig(
   parent: Session,
   sessionConfiguration: Session["sessionConfiguration"],
@@ -1839,6 +1814,39 @@ function splitInitialMessages(
 interface ChildSessionAuthority {
   readonly sessionConfiguration: Session["sessionConfiguration"];
   readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
+}
+
+function terminalResultForLiveAgent(live: LiveAgent): ChildRunTerminalResult {
+  const status = live.status.value;
+  switch (status.status) {
+    case "completed":
+      return {
+        status: "completed",
+        stopReason: "turn_completed",
+        finalMessage: status.lastMessage ?? null,
+      };
+    case "errored":
+      return {
+        status: "failed",
+        stopReason: status.error,
+        finalMessage: null,
+      };
+    case "interrupted":
+      return {
+        status: "cancelled",
+        stopReason: status.reason,
+        finalMessage: null,
+      };
+    case "pending_init":
+    case "running":
+    case "shutdown":
+    case "not_found":
+      return {
+        status: "failed",
+        stopReason: `subagent_shutdown_from_${status.status}`,
+        finalMessage: null,
+      };
+  }
 }
 
 function createInertChildMcpManager(): Session["services"]["mcpManager"] {
@@ -1987,24 +1995,30 @@ function buildChildSession(
     sessionConfiguration,
   ) as unknown as Record<string, unknown>;
 
-  if (!params.silent) {
-    try {
-      const childRolloutStore = createChildRolloutStore(
-        params.parent,
-        sessionConfiguration,
-        params.live.agentId,
-      );
-      if (childRolloutStore) {
-        childSession.mountRolloutStore(childRolloutStore);
-        params.live.rolloutPath = childRolloutStore.rolloutPath;
-      }
-    } catch (err) {
+  try {
+    const childRolloutStore = mountChildRunJournal({
+      parent: params.parent,
+      child: childSession,
+      originator: "agenc-subagent",
+      terminalResult: () => terminalResultForLiveAgent(params.live),
+    });
+    if (childRolloutStore) {
+      params.live.rolloutPath = childRolloutStore.rolloutPath;
+    }
+  } catch (err) {
+    if (err instanceof TerminalRunEpochOpenError) throw err;
+    const requiresCanonicalJournal =
+      childSession.services.executionAdmission !== undefined ||
+      childSession.services.admissionRequired !== false;
+    if (!requiresCanonicalJournal) {
       emitWarning(
         params.parent.eventLog,
         params.parent.nextInternalSubId(),
         "subagent_rollout_init_failed",
         err instanceof Error ? err.message : String(err),
       );
+    } else {
+      throw err;
     }
   }
 
@@ -2604,6 +2618,7 @@ export async function* runAgent(
       merged.signal.removeEventListener("abort", forwardMergedAbort);
     }
     const cleanupErrors: unknown[] = [];
+    let durableCloseError: unknown;
     if (childSandboxExecutionBroker !== undefined) {
       try {
         await shutdownLspServerManager(childSandboxExecutionBroker);
@@ -2615,7 +2630,32 @@ export async function* runAgent(
       try {
         await childSession.shutdown();
       } catch (error) {
-        cleanupErrors.push(error);
+        durableCloseError = error;
+      }
+    } else {
+      try {
+        const rolloutPath = recordUnconstructedChildRunTerminal({
+          parent,
+          childRunId: live.agentId,
+          cwd: params.worktree?.path ?? parent.sessionConfiguration.cwd,
+          model:
+            params.model ??
+            live.role.config.model ??
+            parent.sessionConfiguration.collaborationMode.model,
+          modelProvider:
+            readProviderIdentity(parent.services.provider) ??
+            parent.services.provider.name,
+          originator: "agenc-subagent-preconstruction",
+          result: terminalResultForLiveAgent(live),
+        });
+        if (rolloutPath !== null) live.rolloutPath = rolloutPath;
+      } catch (error) {
+        // A duplicate same-ID invocation is refused before it becomes a new
+        // lifecycle epoch. The existing terminal is already the complete
+        // durable account for that identity, so no competing tail is needed.
+        if (!(error instanceof TerminalRunEpochOpenError)) {
+          durableCloseError = error;
+        }
       }
     }
     if (childSandboxExecutionBroker !== undefined) {
@@ -2638,9 +2678,35 @@ export async function* runAgent(
       params.externalSignal.removeEventListener("abort", onExternalAbort);
     }
     if (cleanupErrors.length > 0) {
+      try {
+        emitWarning(
+          parent.eventLog,
+          parent.nextInternalSubId(),
+          "subagent_resource_cleanup_failed",
+          cleanupErrors
+            .map((error) =>
+              error instanceof Error ? error.message : String(error),
+            )
+            .join("; "),
+        );
+      } catch {
+        // Diagnostics must not retroactively turn a durable run result into a
+        // different public outcome after the child journal has been sealed.
+      }
+    }
+    if (durableCloseError !== undefined) {
+      const message =
+        durableCloseError instanceof Error
+          ? durableCloseError.message
+          : String(durableCloseError);
+      live.status.markErrored(
+        turnId,
+        `subagent durable close failed: ${message}`,
+      );
+      sendParentNotification();
       throw new AggregateError(
-        cleanupErrors,
-        "subagent resource cleanup failed",
+        [durableCloseError, ...cleanupErrors],
+        "subagent durable close failed",
       );
     }
   }

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -14,6 +14,7 @@ import {
 } from "./workspace-cwd.js";
 import type {
   AgenCBackgroundAgentSnapshot,
+  AgenCBackgroundAgentTerminalSnapshot,
   AgenCBackgroundAgentRunner,
 } from "./background-agent-runner.js";
 import type {
@@ -161,6 +162,9 @@ export interface AgenCDaemonAgentManagerOptions {
   readonly recordAgentRun?: (
     run: AgenCDaemonAgentRunSnapshot,
   ) => void | Promise<void>;
+  readonly recordRunTerminal?: (
+    terminal: AgenCDaemonRunTerminalSnapshot,
+  ) => void | Promise<void>;
   readonly registerSnapshotSession?: (
     session: AgenCDaemonSnapshotSessionRoute,
   ) => void | Promise<void>;
@@ -168,10 +172,13 @@ export interface AgenCDaemonAgentManagerOptions {
   readonly permissionAuditLogger?: PermissionAuditLogger;
   readonly onPermissionAuditError?: PermissionAuditErrorHandler;
   /**
-   * Durable tree-scoped cancel (run.cancel step 1). Applies
+   * Durable tree-scoped cancellation projection. Applies
    * `cancelAgentRunTree` against every project state DB that holds the run
-   * row; the daemon-cli wiring owns DB discovery. REQUIRED for run.cancel —
-   * the durable record is the authority, the live interrupt is second.
+   * row; the daemon-cli wiring owns DB discovery. REQUIRED for run.cancel.
+   * When a canonical writer is live, the lifecycle first seals its
+   * cancellation terminal in the rollout and only then applies this
+   * rebuildable SQLite projection. Inactive/legacy runs have no writer, so
+   * this callback remains their honest cancellation authority.
    */
   readonly cancelRunTreeDurable?: (params: {
     readonly runId: string;
@@ -225,6 +232,15 @@ export interface AgenCDaemonAgentStatusSnapshot {
 
 export interface AgenCDaemonAgentRunSnapshot
   extends AgenCStateAgentRunRecord {
+  readonly cwd?: string;
+  readonly stateProjectDir?: string;
+}
+
+export interface AgenCDaemonRunTerminalSnapshot
+  extends AgenCBackgroundAgentTerminalSnapshot {
+  readonly agentId: string;
+  /** Canonical rollout session identity (the root managed-thread id). */
+  readonly sessionId: string;
   readonly cwd?: string;
   readonly stateProjectDir?: string;
 }
@@ -292,12 +308,18 @@ interface PendingRunnerTermination {
   readonly transitionAt: string;
 }
 
+interface PendingCanonicalRunCancellation {
+  snapshot?: AgenCBackgroundAgentSnapshot;
+  target?: RunnerTerminationTarget;
+}
+
 interface RunnerTerminationTarget {
   readonly sessionIds: readonly string[];
   readonly route: AgenCDaemonSnapshotRoute;
   readonly status: AgentStatus;
   readonly transitionAt: string;
   readonly metadata?: JsonObject;
+  readonly terminal?: AgenCBackgroundAgentTerminalSnapshot;
 }
 
 export class AgenCDaemonAgentManager {
@@ -331,6 +353,9 @@ export class AgenCDaemonAgentManager {
   readonly #recordAgentRun:
     | ((run: AgenCDaemonAgentRunSnapshot) => void | Promise<void>)
     | undefined;
+  readonly #recordRunTerminal:
+    | ((terminal: AgenCDaemonRunTerminalSnapshot) => void | Promise<void>)
+    | undefined;
   readonly #registerSnapshotSession:
     | ((session: AgenCDaemonSnapshotSessionRoute) => void | Promise<void>)
     | undefined;
@@ -354,6 +379,14 @@ export class AgenCDaemonAgentManager {
     string,
     PendingRunnerTermination
   >();
+  readonly #pendingCanonicalRunCancellations = new Map<
+    string,
+    PendingCanonicalRunCancellation
+  >();
+  readonly #runCancellationTasks = new Map<
+    string,
+    Promise<RunCancelResult>
+  >();
   readonly #state = new AsyncLock<AgentLifecycleState>({
     agents: new Map(),
   });
@@ -371,6 +404,7 @@ export class AgenCDaemonAgentManager {
     this.#recordMessageExchange = options.recordMessageExchange;
     this.#recordAgentStatusTransition = options.recordAgentStatusTransition;
     this.#recordAgentRun = options.recordAgentRun;
+    this.#recordRunTerminal = options.recordRunTerminal;
     this.#registerSnapshotSession = options.registerSnapshotSession;
     this.#onSnapshotError = options.onSnapshotError ?? (() => {});
     this.#permissionAuditLogger = options.permissionAuditLogger;
@@ -951,16 +985,34 @@ export class AgenCDaemonAgentManager {
 
   /**
    * run.cancel (frozen Wave-B method): tree-scoped cancel of the run plus
-   * its queued and running descendants. Durable-first — the state-DB
-   * cascade is the authority and survives a daemon crash (startup recovery
-   * finishes an interrupted cascade); the live interrupt/stop is second
-   * and reuses the existing descendant-cascading primitives. Late status
-   * writes from dying agents lose to cancel-lock stickiness in the state
-   * layer. Idempotent: an already-terminal run reports `alreadyTerminal`.
+   * its queued and running descendants. A live canonical rollout writer is
+   * quiesced first and must return a fsync-committed cancelled terminal;
+   * SQLite is a rebuildable projection of that evidence. If no writer is
+   * active, the durable tree cascade remains the honest offline authority
+   * and `run.result` may report legacy output as unavailable. Concurrent
+   * requests for one run share one cancellation operation so the canonical
+   * terminal is emitted once.
    */
   async cancelRunTree(params: RunCancelParams): Promise<RunCancelResult> {
     const runId = normalizeRequiredAgentId(params.runId, "run.cancel");
     const reason = normalizeNonEmpty(params.reason) ?? "run.cancel";
+    const inFlight = this.#runCancellationTasks.get(runId);
+    if (inFlight !== undefined) return inFlight;
+    const task = this.#cancelRunTreeOnce(runId, reason);
+    this.#runCancellationTasks.set(runId, task);
+    try {
+      return await task;
+    } finally {
+      if (this.#runCancellationTasks.get(runId) === task) {
+        this.#runCancellationTasks.delete(runId);
+      }
+    }
+  }
+
+  async #cancelRunTreeOnce(
+    runId: string,
+    reason: string,
+  ): Promise<RunCancelResult> {
     const cancelDurable = this.#cancelRunTreeDurable;
     if (cancelDurable === undefined) {
       throw new AgenCDaemonAgentLifecycleError(
@@ -969,63 +1021,168 @@ export class AgenCDaemonAgentManager {
       );
     }
     const cancelledAt = this.#now();
-    const report = await cancelDurable({ runId, reason, cancelledAt });
-    if (report.missing) {
+    const pendingCanonical: PendingCanonicalRunCancellation = {};
+    this.#pendingCanonicalRunCancellations.set(runId, pendingCanonical);
+    const interruptedLiveAgentIds: string[] = [];
+    let report: CancelAgentRunTreeReport;
+    let preparedLiveCancellation = false;
+    let liveTerminalAlreadyPresent = false;
+    let preparedVoidedHolds = 0;
+    let terminationFinalized = false;
+    try {
+      const liveSnapshot = await this.#liveRunWriterSnapshot(runId);
+      const observedSnapshot =
+        pendingCanonical.snapshot?.terminal !== undefined
+          ? pendingCanonical.snapshot
+          : liveSnapshot;
+      if (observedSnapshot?.terminal !== undefined) {
+        liveTerminalAlreadyPresent = true;
+        if (!isCanonicalRunTerminal(observedSnapshot.terminal, runId)) {
+          throw new AgenCDaemonAgentLifecycleError(
+            "RUN_CANCEL_UNAVAILABLE",
+            `run.cancel observed invalid canonical terminal evidence for ${runId}`,
+          );
+        }
+        pendingCanonical.snapshot = observedSnapshot;
+        // A terminal may become visible between installing the cancellation
+        // marker and reading the runner snapshot. Route it through the same
+        // lifecycle handler so the legacy status cannot be DB-cancelled while
+        // a completed canonical result is waiting to be projected.
+        if (pendingCanonical.target === undefined) {
+          await this.handleRunnerTerminated(runId, observedSnapshot);
+        }
+        if (observedSnapshot.terminal.result.status !== "cancelled") {
+          const target = pendingCanonical.target;
+          if (target !== undefined) {
+            await this.#finalizeRunnerTermination(runId, target);
+            terminationFinalized = true;
+          }
+        }
+      } else if (liveSnapshot !== null) {
+        const runner = this.#runner;
+        const prepareCancellation =
+          runner?.prepareAgentCancellation?.bind(runner);
+        const stopRunner = runner?.stopAgent?.bind(runner);
+        if (prepareCancellation === undefined || stopRunner === undefined) {
+          throw new AgenCDaemonAgentLifecycleError(
+            "RUN_CANCEL_UNAVAILABLE",
+            `run.cancel cannot seal live run ${runId}: two-phase background cancellation is unavailable`,
+          );
+        }
+        const preparation = await prepareCancellation(runId, reason);
+        preparedLiveCancellation = true;
+        preparedVoidedHolds = preparation.voidedHolds;
+        try {
+          const interrupted =
+            (await runner?.interruptAgentTurn?.(runId, reason)) ?? false;
+          if (interrupted) interruptedLiveAgentIds.push(runId);
+        } catch (error) {
+          // Full stop is the authoritative quiescence boundary. Preserve the
+          // failed early interrupt as diagnostics, but do not skip it.
+          this.#onSnapshotError(error);
+        }
+
+        let stopError: unknown;
+        try {
+          await stopRunner(runId, reason);
+        } catch (error) {
+          stopError = error;
+        }
+        if (pendingCanonical.snapshot?.terminal === undefined) {
+          try {
+            const stoppedSnapshot = await runner?.getAgentSnapshot?.(runId);
+            if (stoppedSnapshot?.terminal !== undefined) {
+              pendingCanonical.snapshot = stoppedSnapshot;
+            }
+          } catch (error) {
+            stopError ??= error;
+          }
+        }
+        const terminal = pendingCanonical.snapshot?.terminal;
+        if (!isCanonicalCancellationTerminal(terminal, runId)) {
+          if (stopError !== undefined) throw stopError;
+          throw new AgenCDaemonAgentLifecycleError(
+            "RUN_CANCEL_UNAVAILABLE",
+            `run.cancel stopped live run ${runId} without canonical cancellation evidence`,
+          );
+        }
+        if (stopError !== undefined) {
+          // The terminal event proves quiescence crossed its durable close
+          // boundary. Keep teardown diagnostics without discarding the
+          // canonical cancellation or skipping projection convergence.
+          this.#onSnapshotError(stopError);
+        }
+      }
+
+      // Canonical-first for a live writer; durable-only for an inactive run.
+      // A crash on either side is recoverable: a live terminal rebuilds the
+      // projection, while an offline DB cancellation honestly has no output.
+      report = await cancelDurable({ runId, reason, cancelledAt });
+      if (report.missing) {
+        throw new AgenCDaemonAgentLifecycleError(
+          "RUN_NOT_FOUND",
+          `run.cancel: no agent run found for id: ${runId}`,
+        );
+      }
+
+      const deferredTermination = pendingCanonical.target;
+      if (deferredTermination !== undefined && !terminationFinalized) {
+        // The canonical event is already committed and the DB cascade has now
+        // converged. Only at this point may the ordinary lifecycle writer
+        // advance the legacy status and publish terminal notifications.
+        await this.#finalizeRunnerTermination(runId, deferredTermination);
+      }
+
+      // Live cancellation already settled and canonicalized admissions before
+      // stopAgent sealed the terminal tail. Offline/legacy runs have no writer,
+      // so the compatibility follow-up remains responsible for live leases.
+      let voidedHolds = preparedLiveCancellation
+        ? preparedVoidedHolds
+        : (report.admissionVoidedReservations ?? 0);
+      const voidHolds = this.#voidBudgetHoldsForAgents;
+      if (
+        !preparedLiveCancellation &&
+        !liveTerminalAlreadyPresent &&
+        voidHolds !== undefined &&
+        report.subtreeRunIds.length > 0
+      ) {
+        try {
+          const followupVoids = await voidHolds(report.subtreeRunIds);
+          if (report.admissionVoidedReservations === undefined) {
+            voidedHolds = followupVoids;
+          }
+        } catch (error) {
+          this.#onSnapshotError(error);
+        }
+      }
+
+      return {
+        runId,
+        alreadyTerminal: report.alreadyTerminal,
+        cancelledRunIds: report.cancelledRunIds,
+        closedEdgeChildIds: report.closedEdgeChildIds,
+        interruptedLiveAgentIds,
+        voidedHolds,
+      };
+    } finally {
+      this.#pendingCanonicalRunCancellations.delete(runId);
+    }
+  }
+
+  async #liveRunWriterSnapshot(
+    runId: string,
+  ): Promise<AgenCBackgroundAgentSnapshot | null> {
+    const readSnapshot = this.#runner?.getAgentSnapshot?.bind(this.#runner);
+    if (readSnapshot !== undefined) {
+      return (await readSnapshot(runId)) ?? null;
+    }
+    if (this.#runner !== undefined) {
       throw new AgenCDaemonAgentLifecycleError(
-        "RUN_NOT_FOUND",
-        `run.cancel: no agent run found for id: ${runId}`,
+        "RUN_CANCEL_UNAVAILABLE",
+        `run.cancel cannot prove whether run ${runId} has a live canonical writer`,
       );
     }
-
-    // Live propagation: interrupt cascades to descendants inside the
-    // runner (control.interrupt), then stop tears the root down. Both are
-    // best-effort — the durable cascade above already decided the outcome,
-    // and a dead/absent live agent is not an error for run.cancel.
-    const interruptedLiveAgentIds: string[] = [];
-    const runner = this.#runner;
-    if (runner !== undefined) {
-      // Interrupt and stop are independently best-effort: an interrupt
-      // throw must not skip the stop. No live agent (or one dying midway)
-      // is not an error — the durable record stands either way.
-      try {
-        const interrupted =
-          (await runner.interruptAgentTurn?.(runId, reason)) ?? false;
-        if (interrupted) interruptedLiveAgentIds.push(runId);
-      } catch {
-        // best-effort
-      }
-      try {
-        await runner.stopAgent?.(runId, reason);
-      } catch {
-        // best-effort
-      }
-    }
-
-    // The production durable callback settles admission reservations in the
-    // same SQLite transaction as the run-tree cascade. The follow-up callback
-    // remains responsible for releasing/aborting live in-memory leases and is
-    // idempotent; older injected adapters may still report settlement here.
-    let voidedHolds = report.admissionVoidedReservations ?? 0;
-    const voidHolds = this.#voidBudgetHoldsForAgents;
-    if (voidHolds !== undefined && report.subtreeRunIds.length > 0) {
-      try {
-        const followupVoids = await voidHolds(report.subtreeRunIds);
-        if (report.admissionVoidedReservations === undefined) {
-          voidedHolds = followupVoids;
-        }
-      } catch (error) {
-        this.#onSnapshotError(error);
-      }
-    }
-
-    return {
-      runId,
-      alreadyTerminal: report.alreadyTerminal,
-      cancelledRunIds: report.cancelledRunIds,
-      closedEdgeChildIds: report.closedEdgeChildIds,
-      interruptedLiveAgentIds,
-      voidedHolds,
-    };
+    return null;
   }
 
   /**
@@ -1062,6 +1219,17 @@ export class AgenCDaemonAgentManager {
       }
       return null;
     });
+    const pendingCancellation =
+      this.#pendingCanonicalRunCancellations.get(agentId);
+    if (pendingCancellation !== undefined) {
+      pendingCancellation.snapshot = snapshot;
+      if (target !== null) pendingCancellation.target = target;
+      // run.cancel owns the ordering while this marker is installed:
+      // canonical terminal -> tree cascade -> legacy status/notifications.
+      // Returning here prevents the runner callback from racing a terminal
+      // SQLite status ahead of the descendant cascade.
+      return;
+    }
     if (target === null) return;
     await this.#finalizeRunnerTermination(agentId, target);
   }
@@ -1094,6 +1262,7 @@ export class AgenCDaemonAgentManager {
       status: snapshot.status,
       transitionAt,
       ...(snapshot.metadata !== undefined ? { metadata: snapshot.metadata } : {}),
+      ...(snapshot.terminal !== undefined ? { terminal: snapshot.terminal } : {}),
     };
   }
 
@@ -1101,6 +1270,22 @@ export class AgenCDaemonAgentManager {
     agentId: string,
     target: RunnerTerminationTarget,
   ): Promise<void> {
+    if (target.terminal !== undefined && this.#recordRunTerminal !== undefined) {
+      try {
+        await this.#recordRunTerminal({
+          agentId,
+          sessionId: agentId,
+          ...target.route,
+          ...target.terminal,
+        });
+      } catch (error) {
+        // Do not advance the legacy agent row to a terminal status when the
+        // durable terminal projection failed. The canonical JSONL event can
+        // be replayed on restart/query and remains the recovery authority.
+        this.#onSnapshotError(error);
+        return;
+      }
+    }
     await this.#recordAgentStatusSnapshots(
       target.sessionIds,
       agentId,
@@ -3073,6 +3258,34 @@ function uniqueNonEmptyStrings(values: readonly string[]): string[] {
     result.push(trimmed);
   }
   return result;
+}
+
+function isCanonicalCancellationTerminal(
+  terminal: AgenCBackgroundAgentTerminalSnapshot | undefined,
+  runId: string,
+): terminal is AgenCBackgroundAgentTerminalSnapshot {
+  return (
+    isCanonicalRunTerminal(terminal, runId) &&
+    terminal.result.status === "cancelled"
+  );
+}
+
+function isCanonicalRunTerminal(
+  terminal: AgenCBackgroundAgentTerminalSnapshot | undefined,
+  runId: string,
+): terminal is AgenCBackgroundAgentTerminalSnapshot {
+  return (
+    terminal !== undefined &&
+    terminal.result.runId === runId &&
+    typeof terminal.eventId === "string" &&
+    terminal.eventId.trim().length > 0 &&
+    Number.isSafeInteger(terminal.epoch) &&
+    terminal.epoch > 0 &&
+    typeof terminal.rolloutPath === "string" &&
+    terminal.rolloutPath.trim().length > 0 &&
+    Number.isSafeInteger(terminal.result.lastSequence) &&
+    (terminal.result.lastSequence ?? 0) > 0
+  );
 }
 
 function isThreadLogReadMiss(error: unknown): boolean {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -78,6 +78,7 @@ import { applyUnattendedPermissionPolicyToContext } from "../permissions/unatten
 import {
   ABORT,
   DENIED,
+  TIMED_OUT,
   type ReviewDecision,
 } from "../permissions/review-decision.js";
 import type { AgentStatus as ThreadAgentStatus } from "../agents/status.js";
@@ -122,6 +123,10 @@ import {
 } from "./provider-key-vending.js";
 import { isRecord } from "../utils/record.js";
 import type { ExecutionAdmissionKernel } from "../budget/execution-admission-kernel.js";
+import {
+  EVENT_GAP_EVENT,
+  type RunTerminalResult,
+} from "../contracts/run-contracts.js";
 
 export interface AgenCBackgroundAgentStartParams {
   readonly objective: string;
@@ -188,6 +193,22 @@ export interface AgenCBackgroundAgentSnapshot {
   readonly status: DaemonAgentStatus;
   readonly lastActiveAt: string;
   readonly metadata?: JsonObject;
+  /** Present only after the canonical run_terminal event was fsync-committed. */
+  readonly terminal?: AgenCBackgroundAgentTerminalSnapshot;
+}
+
+export interface AgenCBackgroundAgentTerminalSnapshot {
+  readonly openedAt: string;
+  readonly epoch: number;
+  readonly eventId: string;
+  readonly rolloutPath: string;
+  readonly result: RunTerminalResult;
+}
+
+export interface AgenCBackgroundAgentCancellationPreparation {
+  readonly affectedRunIds: readonly string[];
+  readonly voidedHolds: number;
+  readonly heldUnknownHolds: number;
 }
 
 export interface AgenCBackgroundAgentSessionEventBinding {
@@ -315,6 +336,15 @@ export interface AgenCBackgroundAgentRunner {
   restoreAgent?(
     params: AgenCBackgroundAgentRestoreParams,
   ): Promise<boolean> | boolean;
+  /**
+   * Gate ingress and fsync cancellation/admission evidence while the Session
+   * journal listener is still live. `stopAgent` then owns quiescence and the
+   * terminal-tail append; the lifecycle projects legacy state afterward.
+   */
+  prepareAgentCancellation?(
+    agentId: string,
+    reason: string,
+  ): Promise<AgenCBackgroundAgentCancellationPreparation>;
   stopAgent?(agentId: string, reason?: string): Promise<void>;
   attachAgentSessionEvents?(
     agentId: string,
@@ -446,6 +476,28 @@ interface ActiveBackgroundAgent {
   readonly control: AgentControl;
   readonly thread: ManagedThread;
   status: DaemonAgentStatus;
+  readonly startedAt: string;
+  /** Current canonical lifecycle epoch, recovered from run_reopened events. */
+  runEpoch: number;
+  /** True once daemon delivery is sourced from the Session EventLog. */
+  canonicalEventBridgeInstalled: boolean;
+  /** Cached immediately after the fsync-committed run_terminal append. */
+  terminal?: AgenCBackgroundAgentTerminalSnapshot;
+  /** Result selected before shutdown quiescence; committed at journal close. */
+  pendingTerminal?: RunTerminalResult;
+  /** Fsync-committed operator intent that precedes admission cancellation. */
+  cancellationRequest?: {
+    readonly eventId: string;
+    readonly sequence: number;
+    readonly reason: string;
+    readonly requestedAt: string;
+  };
+  /** Preserves a close-boundary append failure through fail-soft teardown. */
+  terminalCommitError?: unknown;
+  /** True when a real Session owns the before-close terminal finalizer. */
+  durableTerminalFinalizerInstalled: boolean;
+  unsubscribeDurableTerminalFinalizer?: () => void;
+  terminationNotified?: boolean;
   lastActiveAt: string;
   budget?: ActiveAgentBudget;
   budgetHalt?: JsonObject;
@@ -471,7 +523,12 @@ interface ActiveBackgroundAgent {
 }
 
 interface BackgroundAgentDaemonEvent {
+  /** Existing session/subscription correlation envelope. */
   readonly id: string;
+  /** Canonical run-journal identity, distinct from the reusable envelope id. */
+  readonly eventId?: string;
+  /** Canonical rollout sequence when this event originated in Session.EventLog. */
+  readonly sequence?: number;
   readonly type: string;
   readonly payload?: JsonObject;
   readonly messageId?: string;
@@ -518,6 +575,8 @@ const MAX_AGENT_BUDGET_TIMER_MS = 2_147_483_647;
  */
 const MAX_BUFFERED_AGENT_EVENTS = 1_000;
 
+const BACKGROUND_RUNNER_GAP_SOURCE = "background_runner_retention";
+
 /**
  * Drops the oldest events in-place until `events` is within
  * {@link MAX_BUFFERED_AGENT_EVENTS}. Returns the same array so callers
@@ -526,11 +585,106 @@ const MAX_BUFFERED_AGENT_EVENTS = 1_000;
  */
 function boundBufferedAgentEvents(
   events: BackgroundAgentDaemonEvent[],
+  runId?: string,
 ): BackgroundAgentDaemonEvent[] {
-  if (events.length > MAX_BUFFERED_AGENT_EVENTS) {
-    events.splice(0, events.length - MAX_BUFFERED_AGENT_EVENTS);
+  const previousMarkers = events.filter(isBackgroundRunnerGapEvent);
+  const realEvents = events.filter((event) => !isBackgroundRunnerGapEvent(event));
+  const retired =
+    realEvents.length > MAX_BUFFERED_AGENT_EVENTS
+      ? realEvents.splice(0, realEvents.length - MAX_BUFFERED_AGENT_EVENTS)
+      : [];
+  const previousRetiredCount = previousMarkers.reduce(
+    (total, marker) => total + positiveInteger(marker.payload?.retiredCount),
+    0,
+  );
+  const retiredCount = previousRetiredCount + retired.length;
+  if (retiredCount === 0) {
+    events.splice(0, events.length, ...realEvents);
+    return events;
   }
+
+  const priorAfterSequence = previousMarkers
+    .map((marker) => nonNegativeSequence(marker.payload?.afterSequence))
+    .find((value) => value !== undefined);
+  const previousCoordinatesUnknown = previousMarkers.some(
+    (marker) => marker.payload?.coordinatesAvailable === false,
+  );
+  const retiredSequences = retired.map((event) => positiveSequence(event.sequence));
+  const firstRetiredSequence = retiredSequences[0];
+  const allNewRetiredEventsSequenced = retiredSequences.every(
+    (value) => value !== undefined,
+  );
+  const afterSequence =
+    !previousCoordinatesUnknown && priorAfterSequence !== undefined
+      ? priorAfterSequence
+      : !previousCoordinatesUnknown &&
+          retired.length > 0 &&
+          allNewRetiredEventsSequenced &&
+          firstRetiredSequence !== undefined
+        ? firstRetiredSequence - 1
+        : undefined;
+  const firstAvailableSequence = positiveSequence(realEvents[0]?.sequence);
+  const coordinatesAvailable =
+    afterSequence !== undefined &&
+    afterSequence >= 0 &&
+    firstAvailableSequence !== undefined &&
+    firstAvailableSequence > afterSequence;
+  const resolvedRunId = runId ?? gapRunId(previousMarkers);
+  const marker: BackgroundAgentDaemonEvent = {
+    id: `runner-gap:${resolvedRunId ?? "unknown"}`,
+    type: EVENT_GAP_EVENT,
+    payload: {
+      kind: EVENT_GAP_EVENT,
+      reason: "retention",
+      source: BACKGROUND_RUNNER_GAP_SOURCE,
+      retiredCount,
+      coordinatesAvailable,
+      ...(resolvedRunId !== undefined ? { runId: resolvedRunId } : {}),
+      ...(coordinatesAvailable
+        ? { afterSequence, firstAvailableSequence }
+        : {}),
+    },
+  };
+  events.splice(0, events.length, marker, ...realEvents);
   return events;
+}
+
+function isBackgroundRunnerGapEvent(
+  event: BackgroundAgentDaemonEvent,
+): boolean {
+  return (
+    event.type === EVENT_GAP_EVENT &&
+    event.payload?.source === BACKGROUND_RUNNER_GAP_SOURCE
+  );
+}
+
+function positiveSequence(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function nonNegativeSequence(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function positiveInteger(value: unknown): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : 0;
+}
+
+function gapRunId(
+  markers: readonly BackgroundAgentDaemonEvent[],
+): string | undefined {
+  return markers
+    .map((marker) => marker.payload?.runId)
+    .find(
+      (value): value is string =>
+        typeof value === "string" && value.length > 0,
+    );
 }
 
 export interface AgenCAgentBudgetTimer {
@@ -744,10 +898,15 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         control,
         thread: managedThread,
         status: "running",
+        startedAt,
+        runEpoch: currentRunEpochFromRollout(bootstrap, managedThread.threadId),
+        canonicalEventBridgeInstalled: false,
+        durableTerminalFinalizerInstalled: false,
         lastActiveAt: startedAt,
         uninstallApprovalBridge,
         bufferedEvents: boundBufferedAgentEvents(
           this.#pendingEvents.get(managedThread.threadId) ?? [],
+          managedThread.threadId,
         ),
         activeToolCallIds:
           this.#pendingActiveToolCallIds.get(managedThread.threadId) ??
@@ -762,18 +921,22 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       });
       this.#pendingEvents.delete(managedThread.threadId);
       this.#pendingActiveToolCallIds.delete(managedThread.threadId);
-      this.#trackAgentStatus(active);
       this.#active.set(managedThread.threadId, active);
+      this.#installDurableTerminalFinalizer(
+        active,
+        managedThread.threadId,
+      );
       active.unsubscribeElicitationEvents =
         this.#installSessionEventLogBridge(active);
-      // Pump runTurn PhaseEvents (assistant_text, tool_call, tool_result,
-      // turn_complete) into the daemon's session binding. Without this,
-      // the directive is gone but the TUI sees no streaming output.
+      this.#trackAgentStatus(active);
+      // Phase events update runner-local bookkeeping only. Canonical live
+      // delivery comes from Session.EventLog so replay and live clients see
+      // the exact same event id + positive sequence.
       active.unsubscribePhaseEvents = bootstrap.session.subscribeToEvents(
         (phase) => {
           const progress = phaseEventToProgressEvent(phase);
           if (progress === null) return;
-          void this.#recordProgressEvent(managedThread.threadId, progress);
+          void this.#recordPhaseProgressEvent(managedThread.threadId, progress);
         },
       );
       this.#scheduleAgentBudgetTimer(active);
@@ -855,6 +1018,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     return {
       status: active.status,
       lastActiveAt: active.lastActiveAt,
+      ...(active.terminal !== undefined ? { terminal: active.terminal } : {}),
       ...(active.budgetHalt !== undefined
         ? { metadata: { budgetHalt: active.budgetHalt } }
         : {}),
@@ -981,10 +1145,15 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         control,
         thread: managedThread,
         status: "running",
+        startedAt,
+        runEpoch: currentRunEpochFromRollout(bootstrap, params.agentId),
+        canonicalEventBridgeInstalled: false,
+        durableTerminalFinalizerInstalled: false,
         lastActiveAt: restoredAt,
         uninstallApprovalBridge,
         bufferedEvents: boundBufferedAgentEvents(
           this.#pendingEvents.get(params.agentId) ?? [],
+          params.agentId,
         ),
         activeToolCallIds:
           this.#pendingActiveToolCallIds.get(params.agentId) ?? new Set(),
@@ -998,15 +1167,16 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       });
       this.#pendingEvents.delete(params.agentId);
       this.#pendingActiveToolCallIds.delete(params.agentId);
-      this.#trackAgentStatus(active);
       this.#active.set(params.agentId, active);
+      this.#installDurableTerminalFinalizer(active, params.agentId);
       active.unsubscribeElicitationEvents =
         this.#installSessionEventLogBridge(active);
+      this.#trackAgentStatus(active);
       active.unsubscribePhaseEvents = bootstrap.session.subscribeToEvents(
         (phase) => {
           const progress = phaseEventToProgressEvent(phase);
           if (progress === null) return;
-          void this.#recordProgressEvent(params.agentId, progress);
+          void this.#recordPhaseProgressEvent(params.agentId, progress);
         },
       );
       this.#scheduleAgentBudgetTimer(active);
@@ -1030,6 +1200,60 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     }
   }
 
+  async prepareAgentCancellation(
+    agentId: string,
+    reason: string,
+  ): Promise<AgenCBackgroundAgentCancellationPreparation> {
+    const active = this.#active.get(agentId);
+    if (active === undefined) {
+      throw new Error(`AgenC daemon agent not running: ${agentId}`);
+    }
+    if (active.terminal !== undefined) {
+      return {
+        affectedRunIds: [],
+        voidedHolds: 0,
+        heldUnknownHolds: 0,
+      };
+    }
+    if (active.pendingTerminal === undefined) {
+      active.status = "stopping";
+      active.lastActiveAt = this.#now();
+      this.#clearAgentBudgetTimer(active);
+      active.pendingTerminal = cancelledTerminalResult(
+        active,
+        agentId,
+        reason,
+        active.lastActiveAt,
+      );
+    } else if (
+      active.pendingTerminal.status !== "cancelled" ||
+      active.pendingTerminal.stopReason !== reason
+    ) {
+      throw new Error(
+        `run ${agentId} already has a different terminal transition pending`,
+      );
+    }
+
+    commitDurableRunCancellationRequest(active, agentId, reason);
+    this.#abortPendingToolDecisions(agentId);
+    const cancelAdmissions =
+      active.bootstrap.session.services.executionAdmission?.cancelAdmissions;
+    if (typeof cancelAdmissions !== "function") {
+      throw new Error(
+        `run ${agentId} cannot prepare cancellation: admissions-only cancellation is unavailable`,
+      );
+    }
+    const summary = cancelAdmissions.call(
+      active.bootstrap.session.services.executionAdmission,
+      reason,
+    );
+    return {
+      affectedRunIds: summary.affectedRunIds,
+      voidedHolds: summary.voidedReservations,
+      heldUnknownHolds: summary.heldUnknownReservations,
+    };
+  }
+
   async stopAgent(
     agentId: string,
     reason = "daemon_agent_stop",
@@ -1040,36 +1264,61 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     active.lastActiveAt = this.#now();
     this.#clearAgentBudgetTimer(active);
     let stopError: unknown;
+    active.pendingTerminal ??= cancelledTerminalResult(
+      active,
+      agentId,
+      reason,
+      active.lastActiveAt,
+    );
+    // Resolve permission continuations while the canonical writer is still
+    // open. Session shutdown drains their tracked durable decision records
+    // before its terminal finalizer is allowed to seal the journal.
+    this.#abortPendingToolDecisions(agentId);
     try {
-      // ManagedThread.shutdown for a root session calls
-      // session.shutdown() via submitToSession; AgentControl.shutdown
-      // would no-op for root threads (live.get returns undefined).
-      await active.thread.shutdown(reason);
+      if (!active.durableTerminalFinalizerInstalled) {
+        commitDurableRunTerminal(active, agentId, active.pendingTerminal);
+      }
     } catch (error) {
+      // Stopping must still revoke execution authority, but the caller needs
+      // to know that the durable final-result contract could not be met.
       stopError = error;
     }
     try {
+      // Bootstrap lifecycle quiesces the root turn, descendants, execs, hooks,
+      // and tracked durable continuations before Session's close-boundary
+      // callback appends the terminal as the canonical tail.
+      await this.#drainDispatchChain(active);
       await active.bootstrap.shutdown();
+      await this.#drainDispatchChain(active);
     } catch (error) {
       stopError ??= error;
     }
-    if (stopError !== undefined) {
-      active.status = "error";
-      active.lastActiveAt = this.#now();
-      throw stopError;
+    stopError ??= active.terminalCommitError;
+    if (active.terminal === undefined) {
+      stopError ??= new Error(
+        `run ${agentId} shutdown completed without a durable terminal result`,
+      );
     }
-    this.#abortPendingToolDecisions(agentId);
+    await this.#notifyActiveAgentTerminated(agentId, active);
     this.#active.delete(agentId);
     this.#pendingEvents.delete(agentId);
     this.#assistantTextByAgent.delete(agentId);
     this.#pendingActiveToolCallIds.delete(agentId);
     active.unsubscribeStatus?.();
+    if (active.terminal !== undefined) {
+      active.unsubscribeDurableTerminalFinalizer?.();
+    }
     active.uninstallApprovalBridge?.();
     active.unsubscribeElicitationEvents?.();
     // gaphunt3 #48: the agentId is the session/conversationId used as the
     // vended-key cache key, so evict this session's entries on stop —
     // otherwise non-expiring keys leak for the daemon's lifetime.
     this.#authBackend?.clearVendedKeysForSession(agentId);
+    if (stopError !== undefined) {
+      active.status = "error";
+      active.lastActiveAt = this.#now();
+      throw stopError;
+    }
   }
 
   async #hydrateRecoveredAgentState(params: {
@@ -1092,7 +1341,12 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       replayToolCalls: params.replayToolCalls,
       currentSessionId: params.currentSessionId,
       onReplayToolResult: params.onReplayToolResult,
-      onProgress: (event) => this.#recordProgressEvent(params.agentId, event),
+      onProgress: (event) =>
+        this.#recordRecoveredProgressEvent(
+          params.agentId,
+          params.session,
+          event,
+        ),
     });
     await hydrateRecoveredSessionHistory(params.session, {
       initialMessages: params.initialMessages,
@@ -2007,7 +2261,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
    */
   async interruptAgentTurn(agentId: string, reason: string): Promise<boolean> {
     const active = this.#active.get(agentId);
-    if (active === undefined || !isRunnableActiveAgent(active)) return false;
+    if (active === undefined || !isInterruptibleActiveAgent(active)) return false;
     try {
       await active.bootstrap.session.abortAllTasks("interrupted");
     } catch {
@@ -2068,13 +2322,53 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     };
   }
 
+  #installDurableTerminalFinalizer(
+    active: ActiveBackgroundAgent,
+    agentId: string,
+  ): void {
+    const session = active.bootstrap.session as LocalRuntimeBootstrap["session"] & {
+      onBeforeDurableClose?: (
+        listener: () => void | Promise<void>,
+      ) => () => void;
+    };
+    if (typeof session.onBeforeDurableClose !== "function") return;
+    active.durableTerminalFinalizerInstalled = true;
+    active.unsubscribeDurableTerminalFinalizer =
+      session.onBeforeDurableClose(() => {
+        if (active.terminal !== undefined) return;
+        if (this.#pendingToolDecisions.has(agentId)) {
+          const error = new Error(
+            `cannot finalize run ${agentId} while permission decisions remain pending`,
+          );
+          active.terminalCommitError = error;
+          throw error;
+        }
+        const result =
+          active.pendingTerminal ??
+          cancelledTerminalResult(
+            active,
+            agentId,
+            "session_shutdown",
+            this.#now(),
+          );
+        try {
+          commitDurableRunTerminal(active, agentId, result);
+        } catch (error) {
+          active.terminalCommitError = error;
+          throw error;
+        }
+      });
+  }
+
   #installSessionEventLogBridge(active: ActiveBackgroundAgent): () => void {
     const eventLog = (
       active.bootstrap.session as {
         eventLog?: {
           subscribe?: (
             listener: (event: {
+              readonly eventId?: unknown;
               readonly id?: unknown;
+              readonly seq?: unknown;
               readonly msg?: {
                 readonly type?: unknown;
                 readonly payload?: unknown;
@@ -2085,17 +2379,76 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       }
     ).eventLog;
     if (typeof eventLog?.subscribe !== "function") return () => {};
+    active.canonicalEventBridgeInstalled = true;
     return eventLog.subscribe((event) => {
       const daemonEvent = daemonEventFromUnboundSessionEvent(event);
       if (daemonEvent === null) return;
       active.lastActiveAt = this.#now();
+      this.#applyCanonicalEventBookkeeping(active, daemonEvent);
       void this.#emitOrBufferEvent(active, daemonEvent);
     });
+  }
+
+  #applyCanonicalEventBookkeeping(
+    active: ActiveBackgroundAgent,
+    event: BackgroundAgentDaemonEvent,
+  ): void {
+    const payload = event.payload;
+    switch (event.type) {
+      case "agent_message_delta":
+        if (typeof payload?.delta === "string") {
+          const previous =
+            this.#assistantTextByAgent.get(active.thread.threadId) ?? "";
+          this.#assistantTextByAgent.set(
+            active.thread.threadId,
+            previous + payload.delta,
+          );
+        }
+        return;
+      case "tool_call_started":
+        if (typeof payload?.callId === "string") {
+          active.activeToolCallIds.add(payload.callId);
+        }
+        return;
+      case "tool_call_completed":
+        if (typeof payload?.callId === "string") {
+          active.activeToolCallIds.delete(payload.callId);
+        }
+        return;
+      case "turn_started":
+        active.status = "running";
+        return;
+      case "turn_complete":
+        active.status = "idle";
+        return;
+      case "turn_aborted":
+        active.status = "idle";
+        active.activeToolCallIds.clear();
+        return;
+      case "error":
+        active.status = "error";
+        active.activeToolCallIds.clear();
+        return;
+      case "run_reopened": {
+        const epoch = positiveSequence(payload?.epoch);
+        if (epoch !== undefined) active.runEpoch = epoch;
+        active.status = "idle";
+        return;
+      }
+      case "run_terminal":
+        active.status = daemonStatusFromRunTerminal(payload?.status);
+        active.activeToolCallIds.clear();
+        return;
+      default:
+        return;
+    }
   }
 
   async #requestDaemonToolDecision(ctx: ApprovalCtx): Promise<ReviewDecision> {
     const agentId = readApprovalAgentId(ctx);
     if (agentId === null) return DENIED;
+    const active = this.#active.get(agentId);
+    if (active === undefined || !isRunnableActiveAgent(active)) return DENIED;
     const requestId = ctx.callId;
     // todo-109: default timeout so unattended pauses cannot hang forever.
     const timeoutMsRaw = process.env.AGENC_PERMISSION_TIMEOUT_MS;
@@ -2129,22 +2482,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       };
       ctx.signal?.addEventListener("abort", abort, { once: true });
       timer = setTimeout(() => {
-        settle(DENIED);
+        settle(TIMED_OUT);
       }, timeoutMs);
-    });
-    const input = approvalInputFromPayload(ctx.invocation.payload);
-    await this.#emitOrBufferAgentEvent(agentId, {
-      id: requestId,
-      type: "request_permissions",
-      payload: {
-        callId: requestId,
-        toolName: ctx.toolName,
-        turnId: ctx.turnId,
-        permissions: ["tool.use"],
-        ...(ctx.retryReason !== undefined ? { reason: ctx.retryReason } : {}),
-        input,
-        ...planApprovalPayloadFields(ctx.toolName, agentId, input),
-      },
     });
     return decision;
   }
@@ -2160,7 +2499,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   }
 
   #trackAgentStatus(active: ActiveBackgroundAgent): void {
-    let sawInitialStatus = false;
     active.unsubscribeStatus = active.thread.subscribeStatus((status) => {
       if (active.budgetHalt !== undefined) return;
       active.status = mapThreadStatus(status);
@@ -2175,17 +2513,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       ) {
         this.#assistantTextByAgent.delete(active.thread.threadId);
       }
-      if (sawInitialStatus) {
-        active.lastActiveAt = this.#now();
-        void this.#emitOrBufferEvent(
-          active,
-          withAgentBudgetUsage(
-            active,
-            eventFromThreadStatus(status),
-            this.#budgetNowMs(),
-          ),
-        );
-      } else {
+      active.lastActiveAt = this.#now();
+      if (!active.canonicalEventBridgeInstalled) {
         void this.#emitOrBufferEvent(
           active,
           withAgentBudgetUsage(
@@ -2195,14 +2524,12 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           ),
         );
       }
-      sawInitialStatus = true;
     });
   }
 
   #cleanupWhenComplete(agentId: string, thread: ManagedThread): void {
     void awaitTerminalStatus(thread)
-      .catch(() => {})
-      .finally(async () => {
+      .then(async (terminalStatus) => {
         const active = this.#active.get(agentId);
         if (active === undefined || active.thread !== thread) return;
         // Notify the lifecycle of terminal status BEFORE deleting from
@@ -2212,34 +2539,56 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         // `running` value. The callback runs synchronously (awaited)
         // so the lifecycle's record is updated before any subsequent
         // `agent.list` resolves.
-        if (this.#onActiveAgentTerminated !== undefined) {
-          const terminalSnapshot: AgenCBackgroundAgentSnapshot = {
-            status: active.status,
-            lastActiveAt: active.lastActiveAt,
-            ...(active.budgetHalt !== undefined
-              ? { metadata: { budgetHalt: active.budgetHalt } }
-              : {}),
-          };
+        if (active.terminal === undefined) {
+          active.pendingTerminal = terminalResultFromThread(
+            active,
+            agentId,
+            terminalStatus,
+          );
           try {
-            await this.#onActiveAgentTerminated(agentId, terminalSnapshot);
+            if (!active.durableTerminalFinalizerInstalled) {
+              commitDurableRunTerminal(
+                active,
+                agentId,
+                active.pendingTerminal,
+              );
+            }
           } catch {
-            // Swallow callback errors so cleanup never leaks. The
-            // lifecycle layer is responsible for its own error
-            // surfacing via onSnapshotError.
+            // A terminal transition is not advertised as M4-durable when its
+            // canonical event could not be fsync-committed. The canonical
+            // recovery path may still find a write that reached disk before
+            // an injected post-commit failure.
           }
         }
+        // Session status becomes terminal synchronously after turn_complete is
+        // journaled, while daemon delivery is intentionally serialized on an
+        // async chain. Drain that already-committed turn tail before shutdown
+        // can close the writer or lifecycle teardown can retire its route.
+        await this.#drainDispatchChain(active);
+        await active.bootstrap.shutdown().catch(() => {});
+        // The durable close finalizer appends run_terminal during shutdown.
+        // Keep the session route live until that new canonical tail has also
+        // crossed the same ordered delivery chain.
+        await this.#drainDispatchChain(active);
+        await this.#notifyActiveAgentTerminated(agentId, active);
         const bufferedEvents = active.bufferedEvents.splice(0);
         this.#active.delete(agentId);
         if (bufferedEvents.length > 0) {
           const pending = this.#pendingEvents.get(agentId) ?? [];
           pending.push(...bufferedEvents);
-          this.#pendingEvents.set(agentId, boundBufferedAgentEvents(pending));
+          this.#pendingEvents.set(
+            agentId,
+            boundBufferedAgentEvents(pending, agentId),
+          );
         } else {
           this.#pendingEvents.delete(agentId);
         }
         this.#assistantTextByAgent.delete(agentId);
         this.#pendingActiveToolCallIds.delete(agentId);
         active.unsubscribeStatus?.();
+        if (active.terminal !== undefined) {
+          active.unsubscribeDurableTerminalFinalizer?.();
+        }
         active.uninstallApprovalBridge?.();
         active.unsubscribeElicitationEvents?.();
         active.unsubscribePhaseEvents?.();
@@ -2248,24 +2597,41 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         // vended-key cache key, so evict this session's entries on terminal
         // cleanup — otherwise non-expiring keys leak for the daemon's lifetime.
         this.#authBackend?.clearVendedKeysForSession(agentId);
-        await active.bootstrap.shutdown().catch(() => {});
-      });
+      })
+      .catch(() => {});
   }
 
-  async #emitOrBufferAgentEvent(
+  async #notifyActiveAgentTerminated(
     agentId: string,
-    event: BackgroundAgentDaemonEvent | null,
+    active: ActiveBackgroundAgent,
   ): Promise<void> {
-    const active = this.#active.get(agentId);
-    if (active === undefined) {
-      if (event !== null) {
-        const pending = this.#pendingEvents.get(agentId) ?? [];
-        pending.push(event);
-        this.#pendingEvents.set(agentId, boundBufferedAgentEvents(pending));
-      }
+    if (active.terminationNotified === true) return;
+    if (
+      active.canonicalEventBridgeInstalled &&
+      active.terminal === undefined
+    ) {
+      // Never project a legacy terminal status for a canonical run whose
+      // durable terminal append failed. Startup recovery can project an append
+      // that committed before a failpoint; otherwise the run stays honestly
+      // non-terminal instead of exposing a result that cannot be fetched.
       return;
     }
-    await this.#emitOrBufferEvent(active, event);
+    active.terminationNotified = true;
+    if (this.#onActiveAgentTerminated === undefined) return;
+    const terminalSnapshot: AgenCBackgroundAgentSnapshot = {
+      status: active.status,
+      lastActiveAt: active.lastActiveAt,
+      ...(active.terminal !== undefined ? { terminal: active.terminal } : {}),
+      ...(active.budgetHalt !== undefined
+        ? { metadata: { budgetHalt: active.budgetHalt } }
+        : {}),
+    };
+    try {
+      await this.#onActiveAgentTerminated(agentId, terminalSnapshot);
+    } catch {
+      // Lifecycle owns projection error reporting; cleanup must still revoke
+      // runtime resources and execution authority.
+    }
   }
 
   async #recordProgressEvent(
@@ -2286,7 +2652,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     if (active === undefined) {
       const pending = this.#pendingEvents.get(agentId) ?? [];
       pending.push(...events);
-      this.#pendingEvents.set(agentId, boundBufferedAgentEvents(pending));
+      this.#pendingEvents.set(
+        agentId,
+        boundBufferedAgentEvents(pending, agentId),
+      );
       return;
     }
     this.#applyProgressStatus(active, progress);
@@ -2296,6 +2665,50 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         withAgentBudgetUsage(active, nextEvent, this.#budgetNowMs()),
       );
     }
+  }
+
+  async #recordPhaseProgressEvent(
+    agentId: string,
+    progress: RunAgentProgressEvent,
+  ): Promise<void> {
+    const active = this.#active.get(agentId);
+    if (active === undefined || !active.canonicalEventBridgeInstalled) {
+      await this.#recordProgressEvent(agentId, progress);
+      return;
+    }
+    this.#trackActiveToolCall(agentId, progress);
+    if (await this.#enforceAgentBudget(active)) return;
+    if (progress.kind === "message" && progress.message.role === "assistant") {
+      this.#assistantTextByAgent.set(
+        agentId,
+        messageText(progress.message.content),
+      );
+    }
+    if (
+      progress.kind === "run_interrupted" ||
+      progress.kind === "turn_interrupted"
+    ) {
+      active.activeToolCallIds.clear();
+    }
+    this.#applyProgressStatus(active, progress);
+  }
+
+  async #recordRecoveredProgressEvent(
+    agentId: string,
+    session: LocalRuntimeBootstrap["session"],
+    progress: RunAgentProgressEvent,
+  ): Promise<void> {
+    const active = this.#active.get(agentId);
+    if (active?.canonicalEventBridgeInstalled !== true) {
+      await this.#recordProgressEvent(agentId, progress);
+      return;
+    }
+    const event = canonicalSessionEventFromRecoveredProgress(progress);
+    if (event !== null) {
+      session.emit(event);
+      return;
+    }
+    await this.#recordPhaseProgressEvent(agentId, progress);
   }
 
   #applyProgressStatus(
@@ -2407,24 +2820,41 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     active.lastActiveAt = this.#now();
     this.#clearAgentBudgetTimer(active);
     let emitError: unknown;
+    active.pendingTerminal = cancelledTerminalResult(
+      active,
+      agentId,
+      "budget_limit",
+      active.lastActiveAt,
+    );
+    this.#abortPendingToolDecisions(agentId);
     try {
-      await this.#emitOrBufferEvent(active, {
-        id: `agent-budget-${agentId}-${halt.kind}`,
-        type: "agent_status",
-        payload: {
-          status: "stopped",
-          runStatus: "stopped",
-          message: halt.reason,
-          budgetHalt: halt.marker,
-          budgetUsage: budgetUsageMarker(active, this.#budgetNowMs()),
-        },
-      });
+      if (!active.canonicalEventBridgeInstalled) {
+        await this.#emitOrBufferEvent(active, {
+          id: `agent-budget-${agentId}-${halt.kind}`,
+          type: "agent_status",
+          payload: {
+            status: "stopped",
+            runStatus: "stopped",
+            message: halt.reason,
+            budgetHalt: halt.marker,
+            budgetUsage: budgetUsageMarker(active, this.#budgetNowMs()),
+          },
+        });
+      }
+      if (!active.durableTerminalFinalizerInstalled) {
+        commitDurableRunTerminal(active, agentId, active.pendingTerminal);
+      }
     } catch (error) {
       emitError = error;
     }
     try {
-      await active.thread.shutdown(halt.reason);
       await active.bootstrap.shutdown();
+      emitError ??= active.terminalCommitError;
+      if (active.terminal === undefined) {
+        emitError ??= new Error(
+          `run ${agentId} budget shutdown completed without a durable terminal result`,
+        );
+      }
     } catch (error) {
       active.status = "error";
       active.lastActiveAt = this.#now();
@@ -2561,6 +2991,14 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     if (raised) throw emitError;
   }
 
+  async #drainDispatchChain(active: ActiveBackgroundAgent): Promise<void> {
+    for (;;) {
+      const tail = active.dispatchChain;
+      await tail;
+      if (active.dispatchChain === tail) return;
+    }
+  }
+
   async #emitPersistedUserMessage(
     active: ActiveBackgroundAgent,
     event: BackgroundAgentDaemonEvent,
@@ -2594,7 +3032,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     const binding = active.sessionBinding;
     if (binding === undefined) {
       active.bufferedEvents.push(event);
-      boundBufferedAgentEvents(active.bufferedEvents);
+      boundBufferedAgentEvents(active.bufferedEvents, active.thread.threadId);
       return;
     }
     await binding.emit(
@@ -2932,7 +3370,17 @@ function formatBudgetSeconds(value: number): string {
 }
 
 function isRunnableActiveAgent(active: ActiveBackgroundAgent): boolean {
-  return active.budgetHalt === undefined;
+  return (
+    active.budgetHalt === undefined && active.pendingTerminal === undefined
+  );
+}
+
+function isInterruptibleActiveAgent(active: ActiveBackgroundAgent): boolean {
+  return (
+    active.budgetHalt === undefined &&
+    (active.pendingTerminal === undefined ||
+      active.cancellationRequest !== undefined)
+  );
 }
 
 interface ActiveTurnPeek {
@@ -3118,6 +3566,62 @@ export function notificationFromDaemonEvent(
     };
   }
   if (
+    event.type === "run_terminal" &&
+    isJsonObject(payload) &&
+    typeof payload.status === "string"
+  ) {
+    const terminalStatus = daemonStatusFromRunTerminal(payload.status);
+    const runStatus = agentRunStatusFromRunTerminal(payload.status);
+    return {
+      jsonrpc: JSON_RPC_VERSION,
+      method: "event.agent_status",
+      params: {
+        ...base,
+        agentId: base.agentId ?? sessionId,
+        status: terminalStatus,
+        runStatus,
+        ...(typeof payload.finalMessage === "string"
+          ? { message: payload.finalMessage }
+          : typeof payload.stopReason === "string"
+            ? { message: payload.stopReason }
+            : {}),
+      },
+    };
+  }
+  if (
+    event.type === EVENT_GAP_EVENT &&
+    isJsonObject(payload) &&
+    payload.source === BACKGROUND_RUNNER_GAP_SOURCE &&
+    typeof payload.runId === "string" &&
+    payload.runId.length > 0 &&
+    positiveInteger(payload.retiredCount) > 0
+  ) {
+    const afterSequence = nonNegativeSequence(payload.afterSequence);
+    const firstAvailableSequence = positiveSequence(
+      payload.firstAvailableSequence,
+    );
+    return {
+      jsonrpc: JSON_RPC_VERSION,
+      method: "event.event_gap",
+      params: {
+        ...base,
+        type: EVENT_GAP_EVENT,
+        kind: EVENT_GAP_EVENT,
+        runId: payload.runId,
+        reason: "retention",
+        source: BACKGROUND_RUNNER_GAP_SOURCE,
+        retiredCount: positiveInteger(payload.retiredCount),
+        ...(typeof payload.coordinatesAvailable === "boolean"
+          ? { coordinatesAvailable: payload.coordinatesAvailable }
+          : {}),
+        ...(afterSequence !== undefined ? { afterSequence } : {}),
+        ...(firstAvailableSequence !== undefined
+          ? { firstAvailableSequence }
+          : {}),
+      },
+    };
+  }
+  if (
     (event.type === "turn_started" ||
       event.type === "turn_complete" ||
       event.type === "turn_aborted" ||
@@ -3180,12 +3684,14 @@ function eventBaseParams(
   readonly sessionId: string;
   readonly eventId: string;
   readonly agentId: string;
+  readonly sequence?: number;
   readonly acceptedAt?: string;
 } {
   return {
     sessionId,
-    eventId: event.id,
+    eventId: event.eventId ?? event.id,
     agentId,
+    ...(event.sequence !== undefined ? { sequence: event.sequence } : {}),
     ...(event.acceptedAt !== undefined ? { acceptedAt: event.acceptedAt } : {}),
   };
 }
@@ -3197,10 +3703,36 @@ function agentStatusFromEventType(type: string): DaemonAgentStatus {
     case "error":
       return "error";
     case "turn_aborted":
-      return "stopped";
+      return "idle";
     case "turn_complete":
     default:
       return "idle";
+  }
+}
+
+function daemonStatusFromRunTerminal(status: unknown): DaemonAgentStatus {
+  switch (status) {
+    case "completed":
+      return "idle";
+    case "failed":
+    case "unknown_outcome":
+      return "error";
+    case "cancelled":
+    default:
+      return "stopped";
+  }
+}
+
+function agentRunStatusFromRunTerminal(status: unknown): AgentRunStatus {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+    case "unknown_outcome":
+      return "errored";
+    case "cancelled":
+    default:
+      return "stopped";
   }
 }
 
@@ -3211,7 +3743,7 @@ function agentRunStatusFromEventType(type: string): AgentRunStatus {
     case "error":
       return "errored";
     case "turn_aborted":
-      return "stopped";
+      return "completed";
     case "turn_complete":
     default:
       return "completed";
@@ -3726,8 +4258,40 @@ const COLLAB_AGENT_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
   "collab_close_end",
 ]);
 
+/**
+ * Core run events whose live representation must be the exact canonical
+ * Session.EventLog record. Returning null for an unsequenced record is
+ * intentional: synthesizing an identity here would make live delivery
+ * impossible to reconcile with run.replay after reconnect.
+ */
+const CANONICAL_CORE_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "agent_message_delta",
+  "tool_call_started",
+  "tool_call_completed",
+  "turn_started",
+  "turn_complete",
+  "turn_aborted",
+  "error",
+  "stream_error",
+  "effect_intent",
+  "effect_result",
+  "effect_unknown_outcome",
+  "effect_review_resolved",
+  "request_permissions",
+  "permission_decision",
+  "execution_admission",
+  "artifact_intent",
+  "artifact_committed",
+  "recovery_decision",
+  "run_terminal",
+  "run_reopened",
+  "run_cancel_requested",
+]);
+
 export function daemonEventFromUnboundSessionEvent(event: {
+  readonly eventId?: unknown;
   readonly id?: unknown;
+  readonly seq?: unknown;
   readonly msg?: {
     readonly type?: unknown;
     readonly payload?: unknown;
@@ -3741,6 +4305,25 @@ export function daemonEventFromUnboundSessionEvent(event: {
       : typeof type === "string"
         ? type
         : "elicitation";
+  const sequence =
+    typeof event.seq === "number" &&
+    Number.isSafeInteger(event.seq) &&
+    event.seq > 0
+      ? event.seq
+      : undefined;
+  const eventId =
+    typeof event.eventId === "string" && event.eventId.length > 0
+      ? event.eventId
+      : sequence !== undefined
+        ? `legacy-event:${sequence}:${id}`
+        : id;
+  if (
+    typeof type === "string" &&
+    CANONICAL_CORE_SESSION_EVENT_TYPES.has(type)
+  ) {
+    if (sequence === undefined || !isJsonObject(payload)) return null;
+    return { id, eventId, sequence, type, payload };
+  }
   if (
     type === "request_user_input" &&
     isJsonObject(payload) &&
@@ -3750,6 +4333,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         callId: payload.callId,
@@ -3776,6 +4361,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         serverName: payload.serverName,
@@ -3793,6 +4380,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         serverName: payload.serverName,
@@ -3813,6 +4402,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
       typeof payload.acceptedAt === "string" ? payload.acceptedAt : undefined;
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       ...(messageId !== undefined ? { messageId } : {}),
       ...(streamId !== undefined ? { streamId } : {}),
@@ -3837,7 +4428,13 @@ export function daemonEventFromUnboundSessionEvent(event: {
     isJsonObject(payload) &&
     typeof payload.callId === "string"
   ) {
-    return { id, type, payload };
+    return {
+      id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
+      type,
+      payload,
+    };
   }
   if (
     type === "tool_progress" &&
@@ -3845,7 +4442,13 @@ export function daemonEventFromUnboundSessionEvent(event: {
     typeof payload.callId === "string" &&
     typeof payload.toolName === "string"
   ) {
-    return { id, type, payload };
+    return {
+      id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
+      type,
+      payload,
+    };
   }
   // Extended-thinking + reasoning-summary events. These are emitted via
   // `session.emit` from `phases/stream-model.ts` and persisted to the
@@ -3860,6 +4463,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         index: payload.index,
@@ -3876,6 +4481,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         delta: payload.delta,
@@ -3891,6 +4498,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         index: payload.index,
@@ -3905,6 +4514,8 @@ export function daemonEventFromUnboundSessionEvent(event: {
   ) {
     return {
       id,
+      eventId,
+      ...(sequence !== undefined ? { sequence } : {}),
       type,
       payload: {
         text: payload.text,
@@ -3994,13 +4605,9 @@ export function managedTokenUsage(
   };
 }
 
-// Translate session-level PhaseEvents into RunAgentProgressEvents so the
-// existing #recordProgressEvent / #eventFromProgress / #emitOrBufferEvent
-// pipeline (and the agent_message_delta cache) can deliver streaming
-// output to the daemon's session binding. The OLD delegate path got these
-// via runAgent's onProgress callback. The NEW ManagedThread path drives
-// runTurn through Session.submit, which emits PhaseEvents — we subscribe
-// in startAgent/restoreAgent and pump them through the same pipeline.
+// Translate Session PhaseEvents only for runner-local status/tool bookkeeping.
+// Live delivery is owned by the canonical Session.EventLog bridge above; using
+// this phase shape for delivery would invent competing IDs without sequences.
 function phaseEventToProgressEvent(
   event: import("../phases/events.js").PhaseEvent,
 ): RunAgentProgressEvent | null {
@@ -4073,20 +4680,333 @@ function phaseEventToProgressEvent(
   }
 }
 
-function awaitTerminalStatus(thread: ManagedThread): Promise<void> {
+function canonicalSessionEventFromRecoveredProgress(
+  progress: RunAgentProgressEvent,
+): Event | null {
+  if (progress.kind === "tool_call") {
+    return {
+      id: `recovery-tool-start:${progress.callId}`,
+      msg: {
+        type: "tool_call_started",
+        payload: {
+          callId: progress.callId,
+          toolName: progress.toolName,
+          args: progress.arguments ?? "{}",
+        },
+      },
+    };
+  }
+  if (progress.kind === "tool_result") {
+    return {
+      id: `recovery-tool-result:${progress.callId}`,
+      msg: {
+        type: "tool_call_completed",
+        payload: {
+          callId: progress.callId,
+          result: progress.result,
+          isError: progress.isError === true,
+          metadata: {
+            toolName: progress.toolName,
+            recovered: true,
+          },
+        },
+      },
+    };
+  }
+  return null;
+}
+
+type TerminalThreadStatus = Extract<
+  ThreadAgentStatus,
+  { readonly status: "completed" | "errored" | "shutdown" | "not_found" }
+>;
+
+function awaitTerminalStatus(
+  thread: ManagedThread,
+): Promise<TerminalThreadStatus> {
   return new Promise((resolve) => {
-    const unsub = thread.subscribeStatus((status) => {
+    let settledSynchronously = false;
+    let unsubscribe = (): void => {};
+    const listener = (status: ThreadAgentStatus): void => {
       if (
         status.status === "completed" ||
         status.status === "errored" ||
         status.status === "shutdown" ||
         status.status === "not_found"
       ) {
-        unsub();
-        resolve();
+        settledSynchronously = true;
+        unsubscribe();
+        resolve(status);
       }
-    });
+    };
+    unsubscribe = thread.subscribeStatus(listener);
+    // ManagedThread subscriptions publish their current value immediately.
+    // If it was already terminal, the callback ran before the real
+    // unsubscribe function was assigned.
+    if (settledSynchronously) unsubscribe();
   });
+}
+
+function commitDurableRunCancellationRequest(
+  active: ActiveBackgroundAgent,
+  runId: string,
+  reason: string,
+): void {
+  const requestedAt = active.pendingTerminal?.finishedAt ?? active.lastActiveAt;
+  const existing = active.cancellationRequest;
+  if (existing !== undefined) {
+    if (existing.reason !== reason || existing.requestedAt !== requestedAt) {
+      throw new Error(`run ${runId} has conflicting cancellation intent`);
+    }
+    return;
+  }
+  const eventId = `run-cancel-request:${runId}:${active.runEpoch}`;
+  const acceptCommitted = (): boolean => {
+    const matches = active.bootstrap.rolloutStore
+      .readAll()
+      .flatMap((item) => {
+        if (item.type !== "event_msg") return [];
+        const event = item.payload;
+        if (
+          event.eventId !== eventId &&
+          event.id !== eventId &&
+          !(
+            event.msg.type === "run_cancel_requested" &&
+            event.msg.payload.runId === runId &&
+            event.msg.payload.epoch === active.runEpoch
+          )
+        ) {
+          return [];
+        }
+        return [event];
+      });
+    if (matches.length === 0) return false;
+    if (matches.length !== 1) {
+      throw new Error(
+        `run cancellation request ${eventId} has duplicate canonical evidence`,
+      );
+    }
+    const event = matches[0]!;
+    const sequence = positiveSequence(event.seq);
+    if (
+      event.id !== eventId ||
+      event.eventId !== eventId ||
+      sequence === undefined ||
+      event.msg.type !== "run_cancel_requested" ||
+      event.msg.payload.runId !== runId ||
+      event.msg.payload.epoch !== active.runEpoch ||
+      event.msg.payload.reason !== reason ||
+      event.msg.payload.requestedAt !== requestedAt
+    ) {
+      throw new Error(
+        `run cancellation request ${eventId} has conflicting canonical evidence`,
+      );
+    }
+    active.cancellationRequest = {
+      eventId,
+      sequence,
+      reason,
+      requestedAt,
+    };
+    return true;
+  };
+  if (acceptCommitted()) return;
+  try {
+    const event = active.bootstrap.session.emit({
+      eventId,
+      id: eventId,
+      msg: {
+        type: "run_cancel_requested",
+        payload: {
+          runId,
+          epoch: active.runEpoch,
+          reason,
+          requestedAt,
+        },
+      },
+    });
+    const sequence = positiveSequence(event.seq);
+    if (
+      event.id !== eventId ||
+      event.eventId !== eventId ||
+      sequence === undefined
+    ) {
+      throw new Error(
+        `run cancellation request ${eventId} has no canonical coordinates`,
+      );
+    }
+    active.cancellationRequest = {
+      eventId,
+      sequence,
+      reason,
+      requestedAt,
+    };
+  } catch (error) {
+    // Session.emit may fail after append+fsync at the publish failpoint. The
+    // deterministic identity makes retry safe only when the bytes on disk are
+    // exactly the requested cancellation evidence.
+    if (!acceptCommitted()) throw error;
+  }
+}
+
+function commitDurableRunTerminal(
+  active: ActiveBackgroundAgent,
+  runId: string,
+  result: RunTerminalResult,
+): AgenCBackgroundAgentTerminalSnapshot {
+  if (active.terminal !== undefined) return active.terminal;
+  const epoch = active.runEpoch;
+  const session = active.bootstrap.session;
+  const lastSequenceBeforeTerminal =
+    positiveSequence(session.eventLog.lastSeq) ?? null;
+  const eventId = `run-terminal:${runId}:${epoch}`;
+  const event = session.emit({
+    eventId,
+    id: eventId,
+    msg: {
+      type: "run_terminal",
+      payload: {
+        runId,
+        epoch,
+        status: result.status,
+        exitCode: result.exitCode,
+        stopReason: result.stopReason,
+        finalMessage: result.finalMessage,
+        usage: result.usage,
+        lastSequenceBeforeTerminal,
+        finishedAt: result.finishedAt,
+      },
+    },
+  });
+  const sequence = positiveSequence(event.seq);
+  if (
+    event.id !== eventId ||
+    event.eventId !== eventId ||
+    sequence === undefined
+  ) {
+    throw new Error(
+      `run_terminal ${eventId} was not assigned its canonical id and positive sequence`,
+    );
+  }
+  const terminal: AgenCBackgroundAgentTerminalSnapshot = {
+    openedAt: active.startedAt,
+    epoch,
+    eventId: event.eventId,
+    rolloutPath: active.bootstrap.rolloutStore.rolloutPath,
+    result: {
+      ...result,
+      lastSequence: sequence,
+    },
+  };
+  active.terminal = terminal;
+  return terminal;
+}
+
+function cancelledTerminalResult(
+  active: ActiveBackgroundAgent,
+  runId: string,
+  stopReason: string,
+  finishedAt: string,
+): RunTerminalResult {
+  return {
+    runId,
+    status: "cancelled",
+    exitCode: null,
+    stopReason,
+    finalMessage: null,
+    usage: budgetUsageForActiveAgent(active),
+    lastSequence: null,
+    finishedAt,
+  };
+}
+
+function currentRunEpochFromRollout(
+  bootstrap: LocalRuntimeBootstrap,
+  runId: string,
+): number {
+  let epoch = 1;
+  try {
+    const items = bootstrap.rolloutStore.readAll() as ReadonlyArray<{
+      readonly type?: unknown;
+      readonly payload?: {
+        readonly msg?: {
+          readonly type?: unknown;
+          readonly payload?: {
+            readonly runId?: unknown;
+            readonly epoch?: unknown;
+          };
+        };
+      };
+    }>;
+    for (const item of items) {
+      if (
+        item.type !== "event_msg" ||
+        item.payload?.msg?.type !== "run_reopened" ||
+        item.payload.msg.payload?.runId !== runId
+      ) {
+        continue;
+      }
+      const reopenedEpoch = positiveSequence(item.payload.msg.payload.epoch);
+      if (reopenedEpoch !== undefined && reopenedEpoch > epoch) {
+        epoch = reopenedEpoch;
+      }
+    }
+  } catch {
+    // A new run has no reopen record. Read failures are surfaced when the
+    // terminal append itself tries to commit; epoch 1 is the only safe default.
+  }
+  return epoch;
+}
+
+function terminalResultFromThread(
+  active: ActiveBackgroundAgent,
+  runId: string,
+  status: TerminalThreadStatus,
+): RunTerminalResult {
+  const usage = budgetUsageForActiveAgent(active);
+  const finishedAt =
+    "endedAtMs" in status && Number.isFinite(status.endedAtMs)
+      ? new Date(status.endedAtMs).toISOString()
+      : active.lastActiveAt;
+  if (status.status === "completed") {
+    return {
+      runId,
+      status: "completed",
+      exitCode: 0,
+      stopReason: "turn_completed",
+      finalMessage: status.lastMessage ?? null,
+      usage,
+      lastSequence: null,
+      finishedAt,
+    };
+  }
+  if (status.status === "errored") {
+    return {
+      runId,
+      status: "failed",
+      exitCode: 1,
+      stopReason: status.error,
+      finalMessage: null,
+      usage,
+      lastSequence: null,
+      finishedAt,
+    };
+  }
+  return {
+    runId,
+    status: "cancelled",
+    exitCode: null,
+    stopReason:
+      active.budgetHalt !== undefined
+        ? "budget_limit"
+        : status.status === "shutdown"
+          ? "shutdown"
+          : "not_found",
+    finalMessage: null,
+    usage,
+    lastSequence: null,
+    finishedAt,
+  };
 }
 
 function mapThreadStatus(status: ThreadAgentStatus): DaemonAgentStatus {
@@ -4427,53 +5347,6 @@ export function planApprovalPayloadFields(
     fields.planFilePath = planFilePath;
   }
   return fields;
-}
-
-function approvalInputFromPayload(value: unknown): JsonObject {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-  const payload = value as {
-    readonly kind?: unknown;
-    readonly arguments?: unknown;
-    readonly rawArguments?: unknown;
-    readonly input?: unknown;
-    readonly params?: unknown;
-  };
-  if (payload.kind === "function" && typeof payload.arguments === "string") {
-    return parseJsonObject(payload.arguments);
-  }
-  if (payload.kind === "mcp" && typeof payload.rawArguments === "string") {
-    return parseJsonObject(payload.rawArguments);
-  }
-  if (payload.kind === "custom" && typeof payload.input === "string") {
-    return { input: payload.input };
-  }
-  if (
-    payload.kind === "local_shell" &&
-    payload.params !== null &&
-    typeof payload.params === "object" &&
-    !Array.isArray(payload.params)
-  ) {
-    return payload.params as JsonObject;
-  }
-  return {};
-}
-
-function parseJsonObject(raw: string): JsonObject {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      !Array.isArray(parsed)
-    ) {
-      return parsed as JsonObject;
-    }
-  } catch {
-    // Fall through to the raw-input carrier below.
-  }
-  return { input: raw };
 }
 
 function buildBootstrapArgv(

--- a/runtime/src/app-server/client-multiplexer.ts
+++ b/runtime/src/app-server/client-multiplexer.ts
@@ -34,6 +34,8 @@ export type AgenCClientMultiplexerErrorCode =
   | "CLIENT_ALREADY_REGISTERED"
   | "CLIENT_NOT_ATTACHED"
   | "CLIENT_NOT_FOUND"
+  | "EVENT_BUFFER_LIMIT_EXCEEDED"
+  | "EVENT_DELIVERY_LIMIT_EXCEEDED"
   | "SESSION_NOTIFICATION_MISMATCH";
 
 export class AgenCClientMultiplexerError extends Error {
@@ -52,19 +54,15 @@ export interface AgenCClientMultiplexerOptions {
   readonly maxBufferedEventsPerSession?: number;
   readonly maxBufferedBytesPerSession?: number;
   /**
-   * Live-broadcast per-client pending-backlog caps. These gate the slow-consumer
-   * eviction on the ONGOING broadcast path (an already-attached client falling
-   * behind); they do NOT apply to the one-shot replay hand-off, which never
-   * evicts. When omitted they default to the detached-session buffer caps
+   * Per-client pending-delivery caps. Live broadcasts evict a client before an
+   * enqueue would exceed either cap. Detached replay reserves the complete
+   * retained batch before queueing it, so concurrent attaches and capability
+   * replays cannot hide unbounded closures behind a blocked send. When omitted
+   * the caps default to the detached-session buffer caps
    * ({@link maxBufferedBytesPerSession} / {@link maxBufferedEventsPerSession}),
    * which is the production wiring — the daemon never overrides them, so default
-   * behavior is unchanged. They exist as an independent seam because the live
-   * pending cap and the detached-buffer cap are conceptually distinct bounds:
-   * the detached buffer trims itself to within its cap before any replay, so a
-   * cap-on-replay regression is only observable when the live pending cap is set
-   * STRICTLY SMALLER than the detached-buffer cap (a legitimately-buffered
-   * multi-event replay then exceeds the live pending cap). Tests use that to
-   * exercise the replay-vs-live boundary; production leaves them coupled.
+   * behavior is unchanged. They remain independently configurable so an
+   * embedder can use a smaller socket backlog than detached retention budget.
    */
   readonly maxPendingDeliveryBytesPerClient?: number;
   readonly maxPendingDeliveryCountPerClient?: number;
@@ -187,19 +185,27 @@ export class AgenCDaemonClientMultiplexer {
     this.#sessionManager = options.sessionManager;
     this.#createClientId =
       options.createClientId ?? (() => `client_${randomUUID()}`);
-    this.#maxBufferedEventsPerSession =
-      options.maxBufferedEventsPerSession ?? 1000;
-    this.#maxBufferedBytesPerSession =
+    this.#maxBufferedEventsPerSession = normalizePositiveLimit(
+      options.maxBufferedEventsPerSession ?? 1000,
+      "maxBufferedEventsPerSession",
+    );
+    this.#maxBufferedBytesPerSession = normalizePositiveLimit(
       options.maxBufferedBytesPerSession ??
-      DEFAULT_MAX_BUFFERED_BYTES_PER_SESSION;
-    // Default the live pending caps to the detached-buffer caps so production
-    // (which never overrides them) keeps the exact prior behavior.
-    this.#maxPendingDeliveryBytesPerClient =
+        DEFAULT_MAX_BUFFERED_BYTES_PER_SESSION,
+      "maxBufferedBytesPerSession",
+    );
+    // Default pending caps to the detached-buffer caps; production leaves the
+    // two bounds coupled.
+    this.#maxPendingDeliveryBytesPerClient = normalizePositiveLimit(
       options.maxPendingDeliveryBytesPerClient ??
-      this.#maxBufferedBytesPerSession;
-    this.#maxPendingDeliveryCountPerClient =
+        this.#maxBufferedBytesPerSession,
+      "maxPendingDeliveryBytesPerClient",
+    );
+    this.#maxPendingDeliveryCountPerClient = normalizePositiveLimit(
       options.maxPendingDeliveryCountPerClient ??
-      this.#maxBufferedEventsPerSession;
+        this.#maxBufferedEventsPerSession,
+      "maxPendingDeliveryCountPerClient",
+    );
     this.#onClientEvicted = options.onClientEvicted;
   }
 
@@ -207,7 +213,6 @@ export class AgenCDaemonClientMultiplexer {
     options: RegisterAgenCClientOptions,
   ): Promise<AgenCClientRegistration> {
     const clientId = options.clientId ?? this.#createClientId();
-    const replayEvictedClientIds: string[] = [];
     const {
       registration,
       replay,
@@ -233,35 +238,54 @@ export class AgenCDaemonClientMultiplexer {
         evicted: false,
         capabilities: advertisedCapabilities(options.capabilities),
       };
-      state.clients.set(clientId, client);
-
-      const replay: EnqueuedDelivery[] = [];
+      // Validate every one-shot replay candidate before registering the client
+      // or leasing a capability. A smaller delivery cap than buffer cap must
+      // fail without leaving a registered half-client or a stuck replay lease.
+      for (const capability of client.capabilities) {
+        if (state.capabilityReplayInFlight.has(capability)) continue;
+        for (const item of state.capabilityBuffers.get(capability) ?? []) {
+          assertEventFitsDeliveryLimit(
+            item.event,
+            this.#maxPendingDeliveryBytesPerClient,
+            this.#maxPendingDeliveryCountPerClient,
+          );
+        }
+      }
+      if (
+        client.capabilities.has(AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY) &&
+        !state.capabilityReplayInFlight.has(
+          AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY,
+        )
+      ) {
+        for (const route of state.sessions.values()) {
+          for (const event of route.bufferedEvents.filter(
+            isMobileStatusPushEvent,
+          )) {
+            assertEventFitsDeliveryLimit(
+              event,
+              this.#maxPendingDeliveryBytesPerClient,
+              this.#maxPendingDeliveryCountPerClient,
+            );
+          }
+        }
+      }
+      const replayEvents: JsonObject[] = [];
       const replayCounts = new Map<string, number>();
       for (const capability of client.capabilities) {
         if (state.capabilityReplayInFlight.has(capability)) continue;
         const buffered = state.capabilityBuffers.get(capability) ?? [];
         if (buffered.length === 0) continue;
-        state.capabilityReplayInFlight.add(capability);
         replayCounts.set(capability, buffered.length);
         for (const item of buffered) {
-          const delivery = enqueueDelivery(
-            client,
-            item.event,
-            this.#maxBufferedBytesPerSession,
-            this.#maxBufferedEventsPerSession,
-            replayEvictedClientIds,
-            false,
-          );
-          if (delivery !== null) replay.push(delivery);
+          replayEvents.push(item.event);
         }
       }
-
       // Mobile status is a fan-out observer capability, not a Ledger-style
       // single-consumer client action. Replay only status frames from each
       // session's ordinary bounded buffer; leave transcript/tool events for a
       // later explicit session.attach. One registering observer leases this
       // replay batch at a time so concurrent phones cannot both drain it.
-      const statusReplay: EnqueuedDelivery[] = [];
+      const statusReplayBatch: JsonObject[] = [];
       const statusReplayEvents = new Map<string, JsonObject[]>();
       if (
         client.capabilities.has(AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY) &&
@@ -276,23 +300,45 @@ export class AgenCDaemonClientMultiplexer {
           if (bufferedStatuses.length === 0) continue;
           statusReplayEvents.set(route.sessionId, bufferedStatuses);
           for (const event of bufferedStatuses) {
-            const delivery = enqueueDelivery(
-              client,
-              event,
-              this.#maxBufferedBytesPerSession,
-              this.#maxBufferedEventsPerSession,
-              replayEvictedClientIds,
-              false,
-            );
-            if (delivery !== null) statusReplay.push(delivery);
+            statusReplayBatch.push(event);
           }
         }
-        if (statusReplay.length > 0) {
-          state.capabilityReplayInFlight.add(
-            AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY,
-          );
-        }
       }
+
+      // Reserve the aggregate before registering the client or leasing any
+      // capability buffer. A failed hard-cap check must leave no half-client,
+      // replay lease, or queued closure behind.
+      assertReplayDeliveriesFitAvailable(
+        client,
+        [replayEvents, statusReplayBatch],
+        this.#maxPendingDeliveryBytesPerClient,
+        this.#maxPendingDeliveryCountPerClient,
+      );
+      state.clients.set(clientId, client);
+      for (const capability of replayCounts.keys()) {
+        state.capabilityReplayInFlight.add(capability);
+      }
+      if (statusReplayBatch.length > 0) {
+        state.capabilityReplayInFlight.add(
+          AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY,
+        );
+      }
+
+      const replayDelivery = enqueueReplayDelivery(
+        client,
+        replayEvents,
+        this.#maxPendingDeliveryBytesPerClient,
+        this.#maxPendingDeliveryCountPerClient,
+      );
+      const replay = replayDelivery === null ? [] : [replayDelivery];
+      const statusReplayDelivery = enqueueReplayDelivery(
+        client,
+        statusReplayBatch,
+        this.#maxPendingDeliveryBytesPerClient,
+        this.#maxPendingDeliveryCountPerClient,
+      );
+      const statusReplay =
+        statusReplayDelivery === null ? [] : [statusReplayDelivery];
       return {
         registration: { clientId },
         replay,
@@ -348,12 +394,20 @@ export class AgenCDaemonClientMultiplexer {
     sessionId: string,
     clientId: string,
   ): Promise<SessionAttachResult> {
-    // Replay never evicts (allowEvict=false below), so nothing is ever pushed
-    // here; the array only satisfies the shared enqueueDelivery signature.
-    const replayEvictedClientIds: string[] = [];
+    // Replay reserves its complete bounded batch before attachment. This keeps
+    // a blocked client's queued closures within the same byte/count caps as
+    // live delivery and rejects before the session manager gains an attachment.
     const { attachment, replayedEvents, replay } = await this.#state.with(
       async (state) => {
         const client = requireClient(state, clientId);
+        const existingRoute = state.sessions.get(sessionId);
+        const replayedEvents = [...(existingRoute?.bufferedEvents ?? [])];
+        assertReplayDeliveriesFitAvailable(
+          client,
+          [replayedEvents],
+          this.#maxPendingDeliveryBytesPerClient,
+          this.#maxPendingDeliveryCountPerClient,
+        );
         const attachment = await this.#sessionManager.attachSession({
           sessionId,
           clientId,
@@ -362,20 +416,13 @@ export class AgenCDaemonClientMultiplexer {
 
         client.sessionIds.add(sessionId);
         route.clientAttachmentIds.set(clientId, attachment.attachmentId);
-        const replayedEvents = [...route.bufferedEvents];
-        const replay = route.bufferedEvents
-          .map((event) =>
-            enqueueDelivery(
-              client,
-              event,
-              this.#maxBufferedBytesPerSession,
-              this.#maxBufferedEventsPerSession,
-              replayEvictedClientIds,
-              // REPLAY is a bounded one-shot hand-off: never evict, never drop.
-              false,
-            ),
-          )
-          .filter((delivery): delivery is EnqueuedDelivery => delivery !== null);
+        const replayDelivery = enqueueReplayDelivery(
+          client,
+          replayedEvents,
+          this.#maxPendingDeliveryBytesPerClient,
+          this.#maxPendingDeliveryCountPerClient,
+        );
+        const replay = replayDelivery === null ? [] : [replayDelivery];
 
         return { attachment, replayedEvents, replay };
       },
@@ -540,6 +587,7 @@ export class AgenCDaemonClientMultiplexer {
       );
     }
     const evictedClientIds: string[] = [];
+    const rejectedDeliveries: AgenCSessionBroadcastFailure[] = [];
     const isMobileStatus = isMobileStatusPushEvent(event);
     const { deliveries, hadLiveTargets, bufferedWithoutTarget } =
       await this.#state.with(async (state) => {
@@ -587,12 +635,17 @@ export class AgenCDaemonClientMultiplexer {
           };
         }
         const route = existingRoute ?? getOrCreateRoute(state, sessionId);
-        bufferSessionEvent(
-          route,
-          event,
-          this.#maxBufferedEventsPerSession,
-          this.#maxBufferedBytesPerSession,
-        );
+        try {
+          bufferSessionEvent(
+            route,
+            event,
+            this.#maxBufferedEventsPerSession,
+            this.#maxBufferedBytesPerSession,
+          );
+        } catch (error) {
+          deleteRouteIfEmpty(state, route);
+          throw error;
+        }
         return {
           deliveries: [] as EnqueuedDelivery[],
           hadLiveTargets: false,
@@ -609,8 +662,7 @@ export class AgenCDaemonClientMultiplexer {
             this.#maxPendingDeliveryBytesPerClient,
             this.#maxPendingDeliveryCountPerClient,
             evictedClientIds,
-            // Live broadcast: enforce the per-client backlog cap.
-            true,
+            rejectedDeliveries,
           ),
         )
         .filter((delivery): delivery is EnqueuedDelivery => delivery !== null),
@@ -618,7 +670,6 @@ export class AgenCDaemonClientMultiplexer {
         bufferedWithoutTarget: false,
       };
     });
-
     await this.#evictSlowClients(evictedClientIds);
     const settled = await settleDeliveries(deliveries);
 
@@ -640,16 +691,26 @@ export class AgenCDaemonClientMultiplexer {
         ) {
           return;
         }
-        bufferSessionEvent(
-          existingRoute ?? getOrCreateRoute(state, sessionId),
-          event,
-          this.#maxBufferedEventsPerSession,
-          this.#maxBufferedBytesPerSession,
-        );
+        const route = existingRoute ?? getOrCreateRoute(state, sessionId);
+        try {
+          bufferSessionEvent(
+            route,
+            event,
+            this.#maxBufferedEventsPerSession,
+            this.#maxBufferedBytesPerSession,
+          );
+        } catch (error) {
+          deleteRouteIfEmpty(state, route);
+          throw error;
+        }
       });
     }
 
-    return { sessionId, ...settled };
+    return {
+      sessionId,
+      deliveredClientIds: settled.deliveredClientIds,
+      failed: [...settled.failed, ...rejectedDeliveries],
+    };
   }
 
   /**
@@ -666,6 +727,7 @@ export class AgenCDaemonClientMultiplexer {
     event: JsonObject,
   ): Promise<AgenCSessionBroadcastResult> {
     const evictedClientIds: string[] = [];
+    const rejectedDeliveries: AgenCSessionBroadcastFailure[] = [];
     const { deliveries, bufferAfterDelivery } = await this.#state.with(
       async (state) => {
         // Map iteration order is registration order. Retaining the last match
@@ -682,9 +744,9 @@ export class AgenCDaemonClientMultiplexer {
             bufferAfterDelivery: false,
           };
           const buffered = state.capabilityBuffers.get(capability) ?? [];
-          buffered.push({ sessionId, event });
-          boundCapabilityBuffer(
+          bufferCapabilityEvent(
             buffered,
+            { sessionId, event },
             this.#maxBufferedEventsPerSession,
             this.#maxBufferedBytesPerSession,
           );
@@ -700,7 +762,7 @@ export class AgenCDaemonClientMultiplexer {
           this.#maxPendingDeliveryBytesPerClient,
           this.#maxPendingDeliveryCountPerClient,
           evictedClientIds,
-          true,
+          rejectedDeliveries,
         );
         return {
           deliveries: delivery === null ? [] : [delivery],
@@ -716,9 +778,9 @@ export class AgenCDaemonClientMultiplexer {
       await this.#state.with(async (state) => {
         if (!(await this.#isSessionLive(sessionId))) return [];
         const buffered = state.capabilityBuffers.get(capability) ?? [];
-        buffered.push({ sessionId, event });
-        boundCapabilityBuffer(
+        bufferCapabilityEvent(
           buffered,
+          { sessionId, event },
           this.#maxBufferedEventsPerSession,
           this.#maxBufferedBytesPerSession,
         );
@@ -728,7 +790,8 @@ export class AgenCDaemonClientMultiplexer {
     }
     return {
       sessionId,
-      ...result,
+      deliveredClientIds: result.deliveredClientIds,
+      failed: [...result.failed, ...rejectedDeliveries],
     };
   }
 
@@ -805,6 +868,95 @@ function routeClientIdForDetach(
   return undefined;
 }
 
+interface ReplayDeliveryReservation {
+  readonly bytes: number;
+  readonly count: number;
+}
+
+/**
+ * Validate the aggregate retained references before any replay closure is
+ * queued. Per-event validation alone is insufficient: concurrent attaches can
+ * otherwise chain arbitrarily many bounded arrays behind one blocked send
+ * while the live pending counters still read zero.
+ */
+function assertReplayDeliveriesFitAvailable(
+  client: MutableClient,
+  batches: readonly (readonly JsonObject[])[],
+  maxPendingBytes: number,
+  maxPendingCount: number,
+): ReplayDeliveryReservation {
+  let bytes = 0;
+  let count = 0;
+  for (const batch of batches) {
+    for (const event of batch) {
+      const eventBytes = bufferedEventByteSize(event);
+      if (eventBytes > maxPendingBytes || maxPendingCount < 1) {
+        throw deliveryLimitError(eventBytes, maxPendingBytes);
+      }
+      bytes += eventBytes;
+      count += 1;
+      if (
+        !Number.isSafeInteger(bytes) ||
+        client.pendingDeliveryBytes + bytes > maxPendingBytes ||
+        client.pendingDeliveryCount + count > maxPendingCount
+      ) {
+        throw new AgenCClientMultiplexerError(
+          "EVENT_DELIVERY_LIMIT_EXCEEDED",
+          "AgenC replay batch exceeds the client pending delivery byte/count limits",
+        );
+      }
+    }
+  }
+  return { bytes, count };
+}
+
+/**
+ * Replay payloads already live in bounded retention buffers. Reserve the whole
+ * batch synchronously, then send its events in order through one queued task.
+ * The reservation includes closures waiting behind an earlier blocked send.
+ */
+function enqueueReplayDelivery(
+  client: MutableClient | undefined,
+  events: readonly JsonObject[],
+  maxPendingBytes: number,
+  maxPendingCount: number,
+): EnqueuedDelivery | null {
+  if (client === undefined || client.evicted || events.length === 0) return null;
+  const reservation = assertReplayDeliveriesFitAvailable(
+    client,
+    [events],
+    maxPendingBytes,
+    maxPendingCount,
+  );
+  client.pendingDeliveryBytes += reservation.bytes;
+  client.pendingDeliveryCount += reservation.count;
+
+  const delivered = client.deliveryQueue.then(async () => {
+    try {
+      if (client.evicted) {
+        throw new AgenCClientMultiplexerError(
+          "EVENT_DELIVERY_LIMIT_EXCEEDED",
+          "AgenC replay delivery was cancelled after client eviction",
+        );
+      }
+      for (const event of events) {
+        await client.send(event);
+      }
+    } finally {
+      client.pendingDeliveryBytes -= reservation.bytes;
+      client.pendingDeliveryCount -= reservation.count;
+    }
+  });
+  client.deliveryQueue = delivered.then(
+    () => undefined,
+    () => undefined,
+  );
+  return {
+    clientId: client.clientId,
+    delivered,
+  };
+}
+
 /**
  * Bound on a single attached client's pending (queued-but-undelivered) delivery
  * backlog for the ONGOING broadcast path. Mirrors the detached-session
@@ -812,19 +964,8 @@ function routeClientIdForDetach(
  * bytes OR {@link maxPendingCount} events is a stuck/backpressured slow consumer
  * and is evicted rather than allowed to pin daemon heap without limit.
  *
- * `allowEvict` gates the cap. It is TRUE only for the live broadcast path
- * (an already-attached client falling behind). It is FALSE for the one-shot
- * REPLAY path in {@link AgenCDaemonClientMultiplexer.attachClientToSession},
- * which maps this function SYNCHRONOUSLY over the detached buffer inside the
- * state lock: the per-delivery decrement microtasks cannot run during that
- * synchronous map, so the pending counters would only ever accumulate across
- * the batch and a perfectly healthy client replaying a buffer near the 8 MB
- * detached cap would be falsely evicted mid-replay (and its un-delivered
- * boundary event then spliced away and lost). The replay batch is already
- * bounded by the detached-buffer cap and is a controlled hand-off to a freshly
- * attaching client, so it must never trip eviction or drop an event — when
- * `allowEvict` is false this function performs the original unbounded enqueue
- * (no cap, no counter bookkeeping).
+ * Live broadcasts evict a slow client and report the rejected delivery.
+ * Detached replay uses the separate sequential path above.
  *
  * When the broadcast path trips the cap, the client's id is pushed onto
  * `evictedClientIds`; the caller (outside the lock-managed section) tears it
@@ -838,41 +979,36 @@ function enqueueDelivery(
   maxPendingBytes: number,
   maxPendingCount: number,
   evictedClientIds: string[],
-  allowEvict: boolean,
+  rejectedDeliveries: AgenCSessionBroadcastFailure[],
 ): EnqueuedDelivery | null {
   if (client === undefined || client.evicted) return null;
 
-  if (!allowEvict) {
-    // REPLAY path: original unbounded enqueue. No cap and no pending-counter
-    // bookkeeping (those counters track the live broadcast backlog only), so a
-    // healthy client's bounded one-shot replay is never evicted and no buffered
-    // event is ever dropped.
-    const delivered = client.deliveryQueue.then(() =>
-      Promise.resolve(client.send(event)),
-    );
-    client.deliveryQueue = delivered.then(
-      () => undefined,
-      () => undefined,
-    );
-    return {
+  const eventBytes = bufferedEventByteSize(event);
+  if (eventBytes > maxPendingBytes || maxPendingCount < 1) {
+    const error = deliveryLimitError(eventBytes, maxPendingBytes);
+    client.evicted = true;
+    evictedClientIds.push(client.clientId);
+    rejectedDeliveries.push({
       clientId: client.clientId,
-      delivered,
-    };
+      message: error.message,
+    });
+    return null;
   }
 
-  const eventBytes = bufferedEventByteSize(event);
   // Trip the cap when this event WOULD push the pending backlog over either
-  // budget. Always allow the very first pending event through (count 0) so a
-  // single oversized payload is still delivered to an otherwise-idle client
-  // rather than evicting it for one event, mirroring the byte-budget path's
-  // "retain at least the most recent event" rule.
+  // budget. A single oversized event was rejected above even for an idle
+  // client, so neither byte nor count accounting can exceed its hard cap.
   if (
-    client.pendingDeliveryCount > 0 &&
     (client.pendingDeliveryBytes + eventBytes > maxPendingBytes ||
       client.pendingDeliveryCount + 1 > maxPendingCount)
   ) {
     client.evicted = true;
     evictedClientIds.push(client.clientId);
+    rejectedDeliveries.push({
+      clientId: client.clientId,
+      message:
+        "AgenC client pending delivery limit exceeded while enqueueing an event",
+    });
     return null;
   }
 
@@ -940,56 +1076,122 @@ async function settleDeliveries(
 /**
  * In-band retention-gap marker announcing evicted buffered events, using the
  * frozen vocabulary (EVENT_GAP_EVENT + RunEventGap reason "retention",
- * contracts/run-contracts.ts). Buffered events are opaque to the multiplexer,
- * so the marker is a flat object rather than a session-event envelope;
- * sequence-addressed RunEventGap markers arrive with the M4 journal
- * (run.replay). JSON-RPC clients that dispatch on `method` ignore it;
- * gap-aware clients read `type`/`retiredCount`.
+ * contracts/run-contracts.ts). It is a real JSON-RPC notification so socket
+ * clients cannot silently discard the loss marker while dispatching by
+ * `method`. Sequence-addressed durable gaps remain authoritative via
+ * `run.replay`; this notification tells a live client when it must reattach.
  *
  * Invariants: at most ONE marker per session buffer, always at the head,
- * merged (retiredCount accumulates) across evictions, never itself evicted,
- * exempt from the event-count capacity. It leaves the buffer only by being
- * replayed — a fully-acked replay splices it out with the replayed prefix,
- * so a later eviction starts a fresh marker for the next reconnecting
- * client. After a failed (unacked) replay the buffer — marker included — is
- * retained for the next attach.
+ * merged (retiredCount accumulates) across evictions, and counted against both
+ * hard capacities. It leaves the buffer only by being replayed — a fully-acked
+ * replay splices it out with the replayed prefix, so a later eviction starts a
+ * fresh marker for the next reconnecting client. After a failed (unacked)
+ * replay the buffer — marker included — is retained for the next attach.
  */
-function makeEventGapMarker(sessionId: string, retiredCount: number): JsonObject {
+function makeEventGapMarker(
+  sessionId: string,
+  retiredCount: number,
+  coordinates: {
+    readonly runId?: string;
+    readonly afterSequence?: number;
+    readonly firstAvailableSequence?: number;
+  } = {},
+): JsonObject {
   return {
-    type: EVENT_GAP_EVENT,
-    sessionId,
-    reason: "retention",
-    retiredCount,
-    // Brand so the predicate below can never confuse a future
-    // sequence-addressed RunEventGap journal event (same frozen type
-    // vocabulary) with a multiplexer-owned retention marker.
-    source: "multiplexer_retention",
+    jsonrpc: "2.0",
+    method: "event.event_gap",
+    params: {
+      type: EVENT_GAP_EVENT,
+      kind: EVENT_GAP_EVENT,
+      sessionId,
+      ...(coordinates.runId !== undefined ? { runId: coordinates.runId } : {}),
+      ...(coordinates.afterSequence !== undefined
+        ? { afterSequence: coordinates.afterSequence }
+        : {}),
+      ...(coordinates.firstAvailableSequence !== undefined
+        ? { firstAvailableSequence: coordinates.firstAvailableSequence }
+        : {}),
+      reason: "retention",
+      retiredCount,
+      // Brand so the predicate below can never confuse a future
+      // sequence-addressed RunEventGap journal event (same frozen type
+      // vocabulary) with a multiplexer-owned retention marker.
+      source: "multiplexer_retention",
+    },
   };
 }
 
 function isBufferedEventGapMarker(event: JsonObject): boolean {
+  const params = bufferedEventGapParams(event);
   return (
-    event.type === EVENT_GAP_EVENT &&
-    event.reason === "retention" &&
-    event.source === "multiplexer_retention"
+    event.method === "event.event_gap" &&
+    params?.type === EVENT_GAP_EVENT &&
+    params.reason === "retention" &&
+    params.source === "multiplexer_retention"
   );
+}
+
+function bufferedEventGapParams(event: JsonObject): JsonObject | undefined {
+  const params = event.params;
+  return params !== null && typeof params === "object" && !Array.isArray(params)
+    ? (params as JsonObject)
+    : undefined;
 }
 
 /** Merge newly retired events into the head marker (creating it if absent). */
 function recordRetiredEvents(
   bufferedEvents: JsonObject[],
   sessionId: string,
-  retiredCount: number,
+  retiredEvents: readonly JsonObject[],
 ): void {
+  const retiredCount = retiredEvents.length;
   if (retiredCount <= 0) return;
   const head = bufferedEvents[0];
+  const firstReal =
+    head !== undefined && isBufferedEventGapMarker(head)
+      ? bufferedEvents[1]
+      : head;
+  const retiredSequences = retiredEvents
+    .map(bufferedEventSequence)
+    .filter((value): value is number => value !== undefined)
+    .sort((left, right) => left - right);
+  const previousAfter =
+    head !== undefined && isBufferedEventGapMarker(head) &&
+    typeof bufferedEventGapParams(head)?.afterSequence === "number"
+      ? (bufferedEventGapParams(head)!.afterSequence as number)
+      : undefined;
+  const afterSequence =
+    previousAfter ??
+    (retiredSequences.length > 0 ? retiredSequences[0]! - 1 : undefined);
+  const firstAvailableSequence = bufferedEventSequence(firstReal);
+  const runId =
+    bufferedEventRunId(firstReal) ??
+    retiredEvents.map(bufferedEventRunId).find((value) => value !== undefined) ??
+    (head !== undefined && isBufferedEventGapMarker(head) &&
+    typeof bufferedEventGapParams(head)?.runId === "string"
+      ? (bufferedEventGapParams(head)!.runId as string)
+      : sessionId);
+  const coordinates = {
+    ...(runId !== undefined ? { runId } : {}),
+    ...(afterSequence !== undefined ? { afterSequence } : {}),
+    ...(firstAvailableSequence !== undefined
+      ? { firstAvailableSequence }
+      : {}),
+  };
   if (head !== undefined && isBufferedEventGapMarker(head)) {
+    const headParams = bufferedEventGapParams(head);
     const previous =
-      typeof head.retiredCount === "number" ? head.retiredCount : 0;
-    bufferedEvents[0] = makeEventGapMarker(sessionId, previous + retiredCount);
+      typeof headParams?.retiredCount === "number" ? headParams.retiredCount : 0;
+    bufferedEvents[0] = makeEventGapMarker(
+      sessionId,
+      previous + retiredCount,
+      coordinates,
+    );
     return;
   }
-  bufferedEvents.unshift(makeEventGapMarker(sessionId, retiredCount));
+  bufferedEvents.unshift(
+    makeEventGapMarker(sessionId, retiredCount, coordinates),
+  );
 }
 
 function bufferSessionEvent(
@@ -998,25 +1200,38 @@ function bufferSessionEvent(
   maxBufferedEvents: number,
   maxBufferedBytes: number,
 ): void {
-  route.bufferedEvents.push(event);
-  const startIndex =
-    route.bufferedEvents[0] !== undefined &&
-    isBufferedEventGapMarker(route.bufferedEvents[0])
-      ? 1
-      : 0;
-  const realCount = route.bufferedEvents.length - startIndex;
-  if (realCount > maxBufferedEvents) {
-    const evicted = route.bufferedEvents.splice(
-      startIndex,
-      realCount - maxBufferedEvents,
-    );
-    recordRetiredEvents(route.bufferedEvents, route.sessionId, evicted.length);
+  const eventBytes = bufferedEventByteSize(event);
+  if (eventBytes > maxBufferedBytes || maxBufferedEvents < 1) {
+    throw bufferLimitError(eventBytes, maxBufferedBytes);
   }
-  evictBufferedEventsByBytes(
-    route.bufferedEvents,
-    maxBufferedBytes,
-    route.sessionId,
-  );
+  const previous = [...route.bufferedEvents];
+  route.bufferedEvents.push(event);
+  while (
+    !bufferWithinLimits(
+      route.bufferedEvents,
+      maxBufferedEvents,
+      maxBufferedBytes,
+    )
+  ) {
+    const startIndex =
+      route.bufferedEvents[0] !== undefined &&
+      isBufferedEventGapMarker(route.bufferedEvents[0])
+        ? 1
+        : 0;
+    const [retired] = route.bufferedEvents.splice(startIndex, 1);
+    if (retired === undefined) {
+      route.bufferedEvents.splice(
+        0,
+        route.bufferedEvents.length,
+        ...previous,
+      );
+      throw new AgenCClientMultiplexerError(
+        "EVENT_BUFFER_LIMIT_EXCEEDED",
+        "AgenC event buffer limit cannot retain its explicit gap marker",
+      );
+    }
+    recordRetiredEvents(route.bufferedEvents, route.sessionId, [retired]);
+  }
 }
 
 function advertisedCapabilities(capabilities: JsonObject | undefined): Set<string> {
@@ -1054,74 +1269,133 @@ function targetCapabilityFromEvent(event: JsonObject): string | null {
     : null;
 }
 
-function boundCapabilityBuffer(
+function bufferCapabilityEvent(
   buffered: BufferedCapabilityEvent[],
+  item: BufferedCapabilityEvent,
   maxBufferedEvents: number,
   maxBufferedBytes: number,
 ): void {
-  if (buffered.length > maxBufferedEvents) {
-    buffered.splice(0, buffered.length - maxBufferedEvents);
-  }
-  if (maxBufferedBytes <= 0 || buffered.length === 0) return;
-  let total = buffered.reduce(
+  const eventBytes = bufferedEventByteSize(item.event);
+  const total = buffered.reduce(
     (sum, item) => sum + bufferedEventByteSize(item.event),
     0,
   );
-  while (total > maxBufferedBytes && buffered.length > 1) {
-    const removed = buffered.shift();
-    if (removed === undefined) break;
-    total -= bufferedEventByteSize(removed.event);
+  if (
+    buffered.length + 1 > maxBufferedEvents ||
+    total + eventBytes > maxBufferedBytes
+  ) {
+    throw new AgenCClientMultiplexerError(
+      "EVENT_BUFFER_LIMIT_EXCEEDED",
+      "AgenC capability event buffer limit exceeded; the event was not queued",
+    );
   }
+  buffered.push(item);
 }
 
 /**
  * Approximate the serialized byte size of a buffered event. Buffered events
  * are JSON notifications, so the UTF-8 length of their JSON encoding is a
- * faithful proxy for the memory they pin. Falls back to 0 for values that
- * cannot be stringified so eviction never throws.
+ * faithful proxy for the memory they pin. Values that cannot be stringified
+ * are treated as maximally large so every valid byte cap rejects them.
  */
 function bufferedEventByteSize(event: JsonObject): number {
   try {
     return Buffer.byteLength(JSON.stringify(event));
   } catch {
-    return 0;
+    // Non-serializable/cyclic input must fail closed against every valid cap;
+    // treating it as zero would make the byte budget advisory.
+    return Number.MAX_SAFE_INTEGER;
   }
 }
 
-/**
- * Drops the oldest buffered events in-place until the total approximate byte
- * size is within `maxBufferedBytes`. Always retains at least the most recent
- * REAL event so a single oversized payload is still replayable rather than
- * silently lost, and never evicts the head gap marker (announced loss must
- * not itself be lost). Every eviction is folded into the marker via
- * {@link recordRetiredEvents}; the marker's own ~130 bytes are deliberately
- * not re-looped against KB-scale budgets. Pairs with the count cap in
- * {@link bufferSessionEvent}.
- */
-function evictBufferedEventsByBytes(
-  bufferedEvents: JsonObject[],
+function bufferedEventsByteSize(events: readonly JsonObject[]): number {
+  return events.reduce(
+    (total, event) => total + bufferedEventByteSize(event),
+    0,
+  );
+}
+
+function bufferWithinLimits(
+  events: readonly JsonObject[],
+  maxBufferedEvents: number,
   maxBufferedBytes: number,
-  sessionId: string,
+): boolean {
+  return (
+    events.length <= maxBufferedEvents &&
+    bufferedEventsByteSize(events) <= maxBufferedBytes
+  );
+}
+
+function bufferLimitError(
+  eventBytes: number,
+  maxBufferedBytes: number,
+): AgenCClientMultiplexerError {
+  return new AgenCClientMultiplexerError(
+    "EVENT_BUFFER_LIMIT_EXCEEDED",
+    "AgenC event buffer limit exceeded: event requires " +
+      String(eventBytes) +
+      " bytes but the detached-session cap is " +
+      String(maxBufferedBytes),
+  );
+}
+
+function deliveryLimitError(
+  eventBytes: number,
+  maxPendingBytes: number,
+): AgenCClientMultiplexerError {
+  return new AgenCClientMultiplexerError(
+    "EVENT_DELIVERY_LIMIT_EXCEEDED",
+    "AgenC event delivery limit exceeded: event requires " +
+      String(eventBytes) +
+      " bytes but the per-client cap is " +
+      String(maxPendingBytes),
+  );
+}
+
+function assertEventFitsDeliveryLimit(
+  event: JsonObject,
+  maxPendingBytes: number,
+  maxPendingCount: number,
 ): void {
-  if (maxBufferedBytes <= 0 || bufferedEvents.length === 0) return;
-  let total = 0;
-  for (const event of bufferedEvents) {
-    total += bufferedEventByteSize(event);
+  const eventBytes = bufferedEventByteSize(event);
+  if (eventBytes > maxPendingBytes || maxPendingCount < 1) {
+    throw deliveryLimitError(eventBytes, maxPendingBytes);
   }
-  let retired = 0;
-  while (total > maxBufferedBytes) {
-    const startIndex =
-      bufferedEvents[0] !== undefined &&
-      isBufferedEventGapMarker(bufferedEvents[0])
-        ? 1
-        : 0;
-    if (bufferedEvents.length - startIndex <= 1) break;
-    const [removed] = bufferedEvents.splice(startIndex, 1);
-    if (removed === undefined) break;
-    total -= bufferedEventByteSize(removed);
-    retired += 1;
+}
+
+function bufferedEventSequence(event: JsonObject | undefined): number | undefined {
+  if (event === undefined) return undefined;
+  const direct = event.sequence;
+  if (typeof direct === "number" && Number.isSafeInteger(direct) && direct > 0) {
+    return direct;
   }
-  if (retired > 0) recordRetiredEvents(bufferedEvents, sessionId, retired);
+  const params = event.params;
+  if (params !== null && typeof params === "object" && !Array.isArray(params)) {
+    const nested = (params as JsonObject).sequence;
+    if (
+      typeof nested === "number" &&
+      Number.isSafeInteger(nested) &&
+      nested > 0
+    ) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function bufferedEventRunId(event: JsonObject | undefined): string | undefined {
+  if (event === undefined) return undefined;
+  for (const value of [event.runId, event.agentId]) {
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  const params = event.params;
+  if (params !== null && typeof params === "object" && !Array.isArray(params)) {
+    const object = params as JsonObject;
+    for (const value of [object.runId, object.agentId]) {
+      if (typeof value === "string" && value.length > 0) return value;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -1143,4 +1417,11 @@ function deleteRouteIfEmpty(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function normalizePositiveLimit(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(name + " must be a positive safe integer");
+  }
+  return value;
 }

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -19,6 +19,7 @@ import {
   type AgenCDaemonAgentSnapshotFlush,
   type AgenCDaemonAgentStatusSnapshot,
   type AgenCDaemonMessageExchangeSnapshot,
+  type AgenCDaemonRunTerminalSnapshot,
   type AgenCDaemonSnapshotSessionRoute,
 } from "./agent-lifecycle.js";
 import {
@@ -115,6 +116,8 @@ import {
 } from "../state/pruning.js";
 import { StateSqliteHealthStatsReader } from "../state/health-stats.js";
 import { upsertAgentRun } from "../state/agent-runs.js";
+import { StateRunDurabilityRepository } from "../state/run-durability.js";
+import { hitM4DurabilityFailpoint } from "../durability/failpoints.js";
 import type { CancelAgentRunTreeReport } from "../state/run-cancellation.js";
 import { ExecutionAdmissionRepository } from "../state/execution-admission.js";
 import { cancelRunTreeAndAdmission } from "../state/run-admission-cancellation.js";
@@ -1524,6 +1527,16 @@ async function runAgenCDaemonForeground(
         throw error;
       }
     },
+    recordRunTerminal: (terminal) => {
+      try {
+        snapshotPolicies.recordRunTerminal(terminal);
+      } catch (error) {
+        io.stderr.write(
+          `agenc: durable run terminal commit failed: ${formatCleanupError(error)}\n`,
+        );
+        throw error;
+      }
+    },
     registerSnapshotSession: (session) => {
       try {
         snapshotPolicies.registerSession(session);
@@ -2438,10 +2451,47 @@ class AgenCDaemonSnapshotPolicyRegistry {
   recordAgentRun(run: AgenCDaemonAgentRunSnapshot): void {
     const entry = this.#policyForRoute(run);
     upsertAgentRun(entry.driver, run);
+    new StateRunDurabilityRepository(entry.driver).ensureInitialEpoch({
+      runId: run.id,
+      openedAt: run.startedAt,
+    });
     if (run.currentSessionId !== undefined) {
       this.#rememberSession(run.currentSessionId, entry.driver.stateDbPath);
       entry.policy.trackSession(run.currentSessionId, run.id);
     }
+  }
+
+  recordRunTerminal(terminal: AgenCDaemonRunTerminalSnapshot): void {
+    const entry = this.#policyForRoute(terminal);
+    const repository = new StateRunDurabilityRepository(entry.driver);
+    const current = repository.currentEpoch(terminal.agentId);
+    if (current === undefined) {
+      repository.ensureInitialEpoch({
+        runId: terminal.agentId,
+        openedAt: terminal.openedAt,
+      });
+    } else if (current.epoch !== terminal.epoch) {
+      throw new Error(
+        `run ${terminal.agentId} terminal epoch ${terminal.epoch} does not match current epoch ${current.epoch}`,
+      );
+    }
+    if (repository.getJournalBinding(terminal.rolloutPath) === undefined) {
+      repository.bindJournalSource({
+        runId: terminal.agentId,
+        epoch: terminal.epoch,
+        childRunId: terminal.agentId,
+        sessionId: terminal.sessionId,
+        sourcePath: terminal.rolloutPath,
+        boundAt: terminal.openedAt,
+      });
+    }
+    hitM4DurabilityFailpoint("before_terminal_commit");
+    repository.recordTerminalResult({
+      epoch: terminal.epoch,
+      result: terminal.result,
+      eventId: terminal.eventId,
+    });
+    hitM4DurabilityFailpoint("after_terminal_commit");
   }
 
   threadStoreForAgentLogs(

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -129,6 +129,7 @@ export const AGENC_DAEMON_NOTIFICATION_METHODS = [
   "event.mcp_elicitation_request",
   "event.agent_status",
   "event.session_event",
+  "event.event_gap",
   "thread/realtime/started",
   "thread/realtime/itemAdded",
   "thread/realtime/transcript/delta",
@@ -681,6 +682,13 @@ export const AGENC_DAEMON_NOTIFICATION_SPECS = defineNotificationSpecs({
     direction: "server-to-client",
     params: "required",
     description: "Deliver a generic daemon session event to attached clients.",
+  },
+  "event.event_gap": {
+    method: "event.event_gap",
+    direction: "server-to-client",
+    params: "required",
+    description:
+      "Announce that detached-session retention evicted live events and replay is required.",
   },
   "thread/realtime/started": {
     method: "thread/realtime/started",
@@ -1314,6 +1322,23 @@ export interface EventSessionEventParams extends AgenCEventBaseParams {
   readonly event: JsonObject;
 }
 
+/** Observable, non-journal sentinel emitted by bounded live-delivery buffers. */
+export interface EventGapParams extends JsonObject {
+  readonly type: "event_gap";
+  readonly kind: "event_gap";
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly eventId?: string;
+  readonly agentId?: string;
+  readonly sequence?: number;
+  readonly reason: "retention";
+  readonly source: "background_runner_retention" | "multiplexer_retention";
+  readonly retiredCount: number;
+  readonly coordinatesAvailable?: boolean;
+  readonly afterSequence?: number;
+  readonly firstAvailableSequence?: number;
+}
+
 export interface ThreadRealtimeBaseParams extends JsonObject {
   readonly threadId: string;
 }
@@ -1371,6 +1396,7 @@ export interface AgenCDaemonNotificationParamsByMethod {
   readonly "event.mcp_elicitation_request": EventMcpElicitationRequestParams;
   readonly "event.agent_status": EventAgentStatusParams;
   readonly "event.session_event": EventSessionEventParams;
+  readonly "event.event_gap": EventGapParams;
   readonly "thread/realtime/started": ThreadRealtimeStartedParams;
   readonly "thread/realtime/itemAdded": ThreadRealtimeItemAddedParams;
   readonly "thread/realtime/transcript/delta": ThreadRealtimeTranscriptDeltaParams;
@@ -1414,6 +1440,7 @@ export type AgenCDaemonNotification =
       "event.session_event",
       EventSessionEventParams
     >
+  | AgenCDaemonNotificationWithParams<"event.event_gap", EventGapParams>
   | AgenCDaemonNotificationWithParams<
       "thread/realtime/started",
       ThreadRealtimeStartedParams
@@ -1685,9 +1712,13 @@ export interface RunAdmissionSummary extends JsonObject {
 export interface RunStatusResult extends JsonObject {
   readonly runId: string;
   readonly status: string;
-  /** Terminal is true only when the durable agent_runs row is terminal. */
+  /** Terminal is true only for the current lifecycle epoch. */
   readonly terminal: boolean;
-  readonly statusSource: "agent_run" | "admission_state";
+  readonly statusSource:
+    | "run_terminal_result"
+    | "run_lifecycle_epoch"
+    | "agent_run"
+    | "admission_state";
   readonly durableRun?: RunDurableRecord;
   readonly admission: RunAdmissionSummary;
   readonly source: RunStateSource;
@@ -1701,17 +1732,77 @@ export interface RunTerminalOutputAvailability extends JsonObject {
   readonly reason: "terminal_output_not_persisted_in_existing_state";
 }
 
+export interface RunUsageTotals extends JsonObject {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+}
+
+/** Terminal output committed by M4 and readable after disconnect/restart. */
+export interface RunTerminalPersistedOutput extends JsonObject {
+  readonly available: true;
+  readonly exitCode: number | null;
+  readonly stopReason: string | null;
+  readonly finalMessage: string | null;
+  readonly usage: RunUsageTotals | null;
+  readonly lastSequence: number | null;
+}
+
 export interface RunResultResult extends JsonObject {
   readonly runId: string;
   readonly status: string;
   readonly terminal: true;
   readonly terminalAt: string;
   readonly outcome: RunTerminalOutcome;
-  readonly durableRun: RunDurableRecord;
-  readonly output: RunTerminalOutputAvailability;
+  readonly epoch?: number;
+  readonly durableRun?: RunDurableRecord;
+  readonly output:
+    | RunTerminalPersistedOutput
+    | RunTerminalOutputAvailability;
   readonly source: RunStateSource;
 }
 
+export type RunJournalCategory =
+  | "run"
+  | "step"
+  | "admission"
+  | "budget"
+  | "permission"
+  | "approval"
+  | "effect"
+  | "model"
+  | "artifact"
+  | "cancellation"
+  | "recovery"
+  | "terminal"
+  | "session";
+
+/** One canonical rollout event, preserving its existing id and sequence. */
+export interface RunJournalEvent extends JsonObject {
+  readonly sequence: number;
+  readonly eventId: string;
+  readonly timestamp?: string;
+  readonly runId: string;
+  readonly childRunId?: string;
+  readonly sessionId?: string;
+  readonly stepId?: string;
+  readonly category: RunJournalCategory;
+  readonly kind: string;
+  readonly event: string;
+  readonly payload?: JsonValue;
+  readonly reason?: string;
+  readonly reservationId?: string;
+  readonly model?: string;
+  readonly provider?: string;
+  readonly reservedTokens?: number;
+  readonly reservedCostUsd?: number;
+  readonly actualTokens?: number;
+  readonly actualCostUsd?: number;
+  readonly details?: JsonObject;
+}
+
+/** Source-compatible M3 admission event contract. */
 export interface RunAdmissionJournalEvent extends JsonObject {
   readonly sequence: number;
   readonly eventId: string;
@@ -1731,24 +1822,60 @@ export interface RunAdmissionJournalEvent extends JsonObject {
   readonly details?: JsonObject;
 }
 
-export interface RunReplayGap extends JsonObject {
+export interface RunReplaySourceUnavailableGap extends JsonObject {
   readonly kind: "source_unavailable";
-  readonly reason: "execution_admission_journal_not_present";
+  readonly reason:
+    | "execution_admission_journal_not_present"
+    | "run_journal_not_present";
 }
 
-export interface RunReplaySource extends JsonObject {
+export interface RunReplayRetentionGap extends JsonObject {
+  readonly kind: "event_gap";
+  readonly runId: string;
+  readonly afterSequence: number;
+  readonly firstAvailableSequence: number;
+  readonly reason: "retention" | "corruption_truncated" | "compaction";
+}
+
+/** The caller cursor names events beyond the canonical journal tail. */
+export interface RunReplayCursorAheadGap extends JsonObject {
+  readonly kind: "cursor_ahead";
+  readonly runId: string;
+  readonly afterSequence: number;
+  readonly lastAvailableSequence: number;
+  readonly reason: "cursor_ahead";
+}
+
+export type RunReplayGap =
+  | RunReplaySourceUnavailableGap
+  | RunReplayRetentionGap
+  | RunReplayCursorAheadGap;
+
+export interface RunJournalReplaySource extends JsonObject {
+  readonly kind: "run_journal";
+  readonly available: boolean;
+  readonly sequenceScope: "run";
+  readonly canonical: "rollout_jsonl";
+  readonly projection: "thread_rollout_items";
+  readonly projectDir: string;
+}
+
+export interface RunAdmissionReplaySource extends JsonObject {
   readonly kind: "execution_admission_journal";
   readonly available: boolean;
-  /** Sequences are global within one project DB; run-filtered pages can skip numbers. */
   readonly sequenceScope: "project_state_database";
   readonly projectDir: string;
 }
+
+export type RunReplaySource =
+  | RunJournalReplaySource
+  | RunAdmissionReplaySource;
 
 export interface RunReplayResult extends JsonObject {
   readonly runId: string;
   readonly afterSequence: number;
   readonly limit: number;
-  readonly events: readonly RunAdmissionJournalEvent[];
+  readonly events: readonly RunJournalEvent[];
   readonly hasMore: boolean;
   /** Pass this value as afterSequence for the next page. */
   readonly nextAfterSequence: number;
@@ -1760,14 +1887,13 @@ export interface RunReplayResult extends JsonObject {
 }
 
 export type RunEvidenceCompleteness =
-  "complete" | "partial" | "admission_source_unavailable";
+  "complete" | "partial" | "admission_source_unavailable" | "journal_gap";
 
 export interface RunEvidenceSource extends JsonObject {
-  readonly kind: "existing_m3_admission_state";
+  readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
   readonly projectDir: string;
   readonly admissionJournal: boolean;
-  /** M4 workflow/effect evidence does not exist in this proof slice. */
-  readonly workflowEvidenceIncluded: false;
+  readonly workflowEvidenceIncluded: boolean;
   readonly completeness: RunEvidenceCompleteness;
 }
 
@@ -1787,6 +1913,7 @@ export interface RunEvidenceHashes extends JsonObject {
   readonly algorithm: "sha256";
   readonly runStateSha256: string;
   readonly admissionSummarySha256: string;
+  readonly gapSha256: string;
   readonly eventHashes: readonly RunEvidenceEventHash[];
   readonly bundleSha256: string;
 }
@@ -1796,7 +1923,8 @@ export interface RunEvidenceResult extends JsonObject {
   readonly source: RunEvidenceSource;
   readonly cursor: RunEvidenceCursor;
   readonly hasMore: boolean;
-  readonly events: readonly RunAdmissionJournalEvent[];
+  readonly gap: RunReplayGap | null;
+  readonly events: readonly RunJournalEvent[];
   readonly hashes: RunEvidenceHashes;
 }
 

--- a/runtime/src/app-server/run-inspection.ts
+++ b/runtime/src/app-server/run-inspection.ts
@@ -17,7 +17,12 @@ import type {
   RunStatusResult,
 } from "./protocol/index.js";
 import { isTerminalAgentRunStatus } from "../state/run-cancellation.js";
-import type { StateDatabasePaths } from "../state/sqlite-driver.js";
+import {
+  openStateDatabasePaths,
+  type StateDatabasePaths,
+} from "../state/sqlite-driver.js";
+import { recoverCanonicalRunJournalForRun } from "../state/startup-run-journal-recovery.js";
+import { buildCanonicalRunReplay } from "./run-journal-replay.js";
 
 export const DEFAULT_RUN_REPLAY_LIMIT = 100;
 export const MAX_RUN_REPLAY_LIMIT = 200;
@@ -62,6 +67,19 @@ interface AgentRunRow {
 interface LocatedRun {
   readonly paths: StateDatabasePaths;
   readonly run?: AgentRunRow;
+}
+
+interface RunTerminalRow {
+  readonly run_id: string;
+  readonly epoch: number;
+  readonly status: string;
+  readonly exit_code: number | null;
+  readonly stop_reason: string | null;
+  readonly final_message: string | null;
+  readonly usage_json: string | null;
+  readonly last_sequence: number | null;
+  readonly finished_at: string;
+  readonly event_id: string;
 }
 
 interface CountByStatusRow {
@@ -138,6 +156,7 @@ export class AgenCDaemonRunInspectionService {
   status(params: RunStatusParams): RunStatusResult {
     const runId = normalizeRunId(params.runId, "run.status");
     const located = this.#locate(runId);
+    refreshRunJournalProjection(located.paths, runId);
     return withReadonlyStateDatabase(located.paths, (db) =>
       buildRunStatus(db, located, runId),
     );
@@ -148,6 +167,7 @@ export class AgenCDaemonRunInspectionService {
     const afterSequence = normalizeAfterSequence(params.afterSequence);
     const limit = normalizeReplayLimit(params.limit);
     const located = this.#locate(runId);
+    refreshRunJournalProjection(located.paths, runId);
     return withReadonlyStateDatabase(located.paths, (db) =>
       buildRunReplay(db, located, runId, afterSequence, limit),
     );
@@ -156,13 +176,47 @@ export class AgenCDaemonRunInspectionService {
   result(params: RunResultParams): RunResultResult {
     const runId = normalizeRunId(params.runId, "run.result");
     const located = this.#locate(runId);
+    refreshRunJournalProjection(located.paths, runId);
     return withReadonlyStateDatabase(located.paths, (db) => {
-      const run = located.run;
+      const run = readAgentRun(db, runId) ?? located.run;
+      const durableTerminal = readCurrentTerminalResult(db, runId);
       const status = buildRunStatus(db, located, runId);
-      if (run === undefined || !status.terminal) {
+      if (
+        durableTerminal === undefined &&
+        (run === undefined || !status.terminal)
+      ) {
         throw new AgenCDaemonRunInspectionError(
           "RUN_NOT_TERMINAL",
           `run.result: run ${runId} is not durably terminal (status: ${status.status})`,
+        );
+      }
+      if (durableTerminal !== undefined) {
+        return {
+          runId,
+          status: durableTerminal.status,
+          terminal: true,
+          terminalAt: durableTerminal.finished_at,
+          outcome: terminalOutcome(durableTerminal.status),
+          epoch: durableTerminal.epoch,
+          ...(run !== undefined ? { durableRun: durableRunFromRow(run) } : {}),
+          output: {
+            available: true,
+            exitCode: durableTerminal.exit_code,
+            stopReason: durableTerminal.stop_reason,
+            finalMessage: durableTerminal.final_message,
+            usage: parseRunUsage(durableTerminal.usage_json),
+            lastSequence: durableTerminal.last_sequence,
+          },
+          source: runStateSource(located.paths),
+        };
+      }
+      if (run === undefined) {
+        // The guard above makes this unreachable, but keep the fallback branch
+        // explicitly narrowed so canonical-only terminal rows never require a
+        // fabricated legacy agent_runs record.
+        throw new AgenCDaemonRunInspectionError(
+          "RUN_NOT_TERMINAL",
+          `run.result: run ${runId} has no legacy terminal projection`,
         );
       }
       return {
@@ -186,6 +240,7 @@ export class AgenCDaemonRunInspectionService {
     const afterSequence = normalizeAfterSequence(params.afterSequence);
     const limit = normalizeReplayLimit(params.limit);
     const located = this.#locate(runId);
+    refreshRunJournalProjection(located.paths, runId);
     return withReadonlyStateDatabase(located.paths, (db) => {
       // A single read transaction gives the status summary and journal page a
       // coherent SQLite snapshot without taking a write reservation.
@@ -203,29 +258,40 @@ export class AgenCDaemonRunInspectionService {
           terminal: status.terminal,
         });
         const admissionSummarySha256 = sha256(status.admission);
+        const gapSha256 = sha256(replay.gap);
+        const canonicalJournal =
+          replay.source.available && replay.source.kind === "run_journal";
         const completeness: RunEvidenceResult["source"]["completeness"] =
           !replay.source.available
             ? "admission_source_unavailable"
+            : replay.gap !== null
+              ? "journal_gap"
             : afterSequence > 0 || replay.hasMore
               ? "partial"
               : "complete";
         const bundleDocument = {
           runId,
-          source: "existing_m3_admission_state",
+          source: canonicalJournal
+            ? "canonical_run_journal"
+            : "existing_m3_admission_state",
           completeness,
           afterSequence,
           nextAfterSequence: replay.nextAfterSequence,
           runStateSha256,
           admissionSummarySha256,
+          gap: replay.gap,
+          gapSha256,
           eventHashes,
         } as const;
         const result: RunEvidenceResult = {
           runId,
           source: {
-            kind: "existing_m3_admission_state",
+            kind: canonicalJournal
+              ? "canonical_run_journal"
+              : "existing_m3_admission_state",
             projectDir: located.paths.projectDir,
-            admissionJournal: replay.source.available,
-            workflowEvidenceIncluded: false,
+            admissionJournal: status.admission.sources.journal,
+            workflowEvidenceIncluded: canonicalJournal,
             completeness,
           },
           cursor: {
@@ -234,11 +300,13 @@ export class AgenCDaemonRunInspectionService {
             limit,
           },
           hasMore: replay.hasMore,
+          gap: replay.gap,
           events: replay.events,
           hashes: {
             algorithm: "sha256",
             runStateSha256,
             admissionSummarySha256,
+            gapSha256,
             eventHashes,
             bundleSha256: sha256(bundleDocument),
           },
@@ -257,7 +325,9 @@ export class AgenCDaemonRunInspectionService {
       if (!existsSync(paths.stateDbPath)) continue;
       const match = withReadonlyStateDatabase(paths, (db) => {
         const run = readAgentRun(db, runId);
-        return run !== undefined || hasAdmissionState(db, runId)
+        return run !== undefined ||
+          hasAdmissionState(db, runId) ||
+          hasCanonicalRunState(db, runId)
           ? { paths, ...(run !== undefined ? { run } : {}) }
           : undefined;
       });
@@ -279,21 +349,59 @@ export class AgenCDaemonRunInspectionService {
   }
 }
 
+function hasCanonicalRunState(
+  db: BetterSqlite3.Database,
+  runId: string,
+): boolean {
+  for (const [table, column] of [
+    ["run_lifecycle_epochs", "run_id"],
+    ["run_terminal_results", "run_id"],
+    ["run_effects", "run_id"],
+    ["run_journal_bindings", "run_id"],
+  ] as const) {
+    if (!tableExists(db, table)) continue;
+    const row = db
+      .prepare<[string], { readonly present: number }>(
+        `SELECT 1 AS present FROM ${table} WHERE ${column} = ? LIMIT 1`,
+      )
+      .get(runId);
+    if (row !== undefined) return true;
+  }
+  return false;
+}
+
 function buildRunStatus(
   db: BetterSqlite3.Database,
   located: LocatedRun,
   runId: string,
 ): RunStatusResult {
   const admission = admissionSummary(db, runId);
-  const run = located.run;
+  const run = readAgentRun(db, runId) ?? located.run;
+  const currentLifecycleEpoch = readCurrentLifecycleEpoch(db, runId);
+  const durableTerminal = readCurrentTerminalResult(db, runId);
+  const reopenedWithoutTerminal =
+    currentLifecycleEpoch !== undefined && durableTerminal === undefined;
   return {
     runId,
-    status: run?.status ?? "admission_only",
+    status:
+      durableTerminal?.status ??
+      (reopenedWithoutTerminal && run !== undefined && isTerminalAgentRunStatus(run.status)
+        ? "running"
+        : run?.status ?? "admission_only"),
     terminal:
-      run === undefined
-        ? false
-        : isTerminalAgentRunStatus(run.status) && !admission.active,
-    statusSource: run === undefined ? "admission_state" : "agent_run",
+      durableTerminal !== undefined ||
+      (currentLifecycleEpoch === undefined &&
+        run !== undefined &&
+        isTerminalAgentRunStatus(run.status) &&
+        !admission.active),
+    statusSource:
+      durableTerminal !== undefined
+        ? "run_terminal_result"
+        : currentLifecycleEpoch !== undefined
+          ? "run_lifecycle_epoch"
+        : run === undefined
+          ? "admission_state"
+          : "agent_run",
     ...(run !== undefined ? { durableRun: durableRunFromRow(run) } : {}),
     admission,
     source: runStateSource(located.paths),
@@ -307,7 +415,52 @@ function buildRunReplay(
   afterSequence: number,
   limit: number,
 ): RunReplayResult {
+  const canonical = buildCanonicalRunReplay(
+    db,
+    located.paths,
+    runId,
+    afterSequence,
+    limit,
+  );
+  if (canonical.source.available) return canonical;
+  return buildLegacyAdmissionReplay(
+    db,
+    located,
+    runId,
+    afterSequence,
+    limit,
+  );
+}
+
+/** Pre-M4 compatibility reader. New writes are projected into the rollout. */
+function buildLegacyAdmissionReplay(
+  db: BetterSqlite3.Database,
+  located: LocatedRun,
+  runId: string,
+  afterSequence: number,
+  limit: number,
+): RunReplayResult {
   if (!tableExists(db, "execution_admission_journal")) {
+    return buildCanonicalRunReplay(
+      db,
+      located.paths,
+      runId,
+      afterSequence,
+      limit,
+    );
+  }
+  const runIds = collectRunTreeIds(db, runId);
+  const ids = placeholders(runIds.length);
+  const bounds = db
+    .prepare<unknown[], JournalBoundsRow>(
+      `SELECT MIN(sequence) AS first_sequence,
+              MAX(sequence) AS last_sequence
+       FROM execution_admission_journal
+       WHERE run_id IN (${ids})`,
+    )
+    .get(...runIds) ?? { first_sequence: null, last_sequence: null };
+  const lastAvailableSequence = bounds.last_sequence ?? 0;
+  if (afterSequence > lastAvailableSequence) {
     return {
       runId,
       afterSequence,
@@ -315,28 +468,25 @@ function buildRunReplay(
       events: [],
       hasMore: false,
       nextAfterSequence: afterSequence,
+      ...(bounds.first_sequence !== null
+        ? { firstAvailableSequence: bounds.first_sequence }
+        : {}),
+      lastAvailableSequence,
       gap: {
-        kind: "source_unavailable",
-        reason: "execution_admission_journal_not_present",
+        kind: "cursor_ahead",
+        runId,
+        afterSequence,
+        lastAvailableSequence,
+        reason: "cursor_ahead",
       },
       source: {
         kind: "execution_admission_journal",
-        available: false,
+        available: true,
         sequenceScope: "project_state_database",
         projectDir: located.paths.projectDir,
       },
     };
   }
-  const runIds = collectRunTreeIds(db, runId);
-  const runIdPlaceholders = placeholders(runIds.length);
-  const bounds = db
-    .prepare<unknown[], JournalBoundsRow>(
-      `SELECT MIN(sequence) AS first_sequence,
-              MAX(sequence) AS last_sequence
-       FROM execution_admission_journal
-       WHERE run_id IN (${runIdPlaceholders})`,
-    )
-    .get(...runIds) ?? { first_sequence: null, last_sequence: null };
   const rows = db
     .prepare<unknown[], AdmissionJournalRow>(
       `SELECT sequence, event_id, timestamp, run_id, step_id, kind, event,
@@ -344,28 +494,26 @@ function buildRunReplay(
               reserved_cost_nanos, actual_tokens, actual_cost_nanos,
               details_json
        FROM execution_admission_journal
-       WHERE run_id IN (${runIdPlaceholders}) AND sequence > ?
+       WHERE run_id IN (${ids}) AND sequence > ?
        ORDER BY sequence ASC
        LIMIT ?`,
     )
     .all(...runIds, afterSequence, limit + 1);
-  const hasMore = rows.length > limit;
-  const events = rows.slice(0, limit).map(journalEventFromRow);
-  const last = events.at(-1);
+  const events = rows.slice(0, limit).map(legacyJournalEventFromRow);
   return {
     runId,
     afterSequence,
     limit,
     events,
-    hasMore,
-    nextAfterSequence: last?.sequence ?? afterSequence,
-    gap: null,
+    hasMore: rows.length > limit,
+    nextAfterSequence: events.at(-1)?.sequence ?? afterSequence,
     ...(bounds.first_sequence !== null
       ? { firstAvailableSequence: bounds.first_sequence }
       : {}),
     ...(bounds.last_sequence !== null
       ? { lastAvailableSequence: bounds.last_sequence }
       : {}),
+    gap: null,
     source: {
       kind: "execution_admission_journal",
       available: true,
@@ -538,6 +686,84 @@ function readAgentRun(
     .get(runId);
 }
 
+function readCurrentTerminalResult(
+  db: BetterSqlite3.Database,
+  runId: string,
+): RunTerminalRow | undefined {
+  if (
+    !tableExists(db, "run_lifecycle_epochs") ||
+    !tableExists(db, "run_terminal_results")
+  ) {
+    return undefined;
+  }
+  return db
+    .prepare<[string], RunTerminalRow>(
+      `SELECT terminal.run_id, terminal.epoch, terminal.status,
+              terminal.exit_code, terminal.stop_reason,
+              terminal.final_message, terminal.usage_json,
+              terminal.last_sequence, terminal.finished_at,
+              terminal.event_id
+       FROM run_terminal_results AS terminal
+       JOIN run_lifecycle_epochs AS lifecycle
+         ON lifecycle.run_id = terminal.run_id
+        AND lifecycle.epoch = terminal.epoch
+       WHERE terminal.run_id = ?
+         AND lifecycle.epoch = (
+           SELECT MAX(current.epoch)
+           FROM run_lifecycle_epochs AS current
+           WHERE current.run_id = terminal.run_id
+         )
+       LIMIT 1`,
+    )
+    .get(runId);
+}
+
+function readCurrentLifecycleEpoch(
+  db: BetterSqlite3.Database,
+  runId: string,
+): number | undefined {
+  if (!tableExists(db, "run_lifecycle_epochs")) return undefined;
+  return db
+    .prepare<[string], { readonly epoch: number }>(
+      `SELECT epoch
+       FROM run_lifecycle_epochs
+       WHERE run_id = ?
+       ORDER BY epoch DESC
+       LIMIT 1`,
+    )
+    .get(runId)?.epoch;
+}
+
+function parseRunUsage(
+  json: string | null,
+): Extract<RunResultResult["output"], { readonly available: true }>["usage"] {
+  if (json === null) return null;
+  const value = JSON.parse(json) as {
+    readonly inputTokens?: unknown;
+    readonly outputTokens?: unknown;
+    readonly totalTokens?: unknown;
+    readonly costUsd?: unknown;
+  };
+  if (
+    typeof value.inputTokens !== "number" ||
+    typeof value.outputTokens !== "number" ||
+    typeof value.totalTokens !== "number" ||
+    typeof value.costUsd !== "number" ||
+    !Number.isFinite(value.inputTokens) ||
+    !Number.isFinite(value.outputTokens) ||
+    !Number.isFinite(value.totalTokens) ||
+    !Number.isFinite(value.costUsd)
+  ) {
+    throw new Error("durable run terminal usage is malformed");
+  }
+  return {
+    inputTokens: value.inputTokens,
+    outputTokens: value.outputTokens,
+    totalTokens: value.totalTokens,
+    costUsd: value.costUsd,
+  };
+}
+
 function hasAdmissionState(db: BetterSqlite3.Database, runId: string): boolean {
   if (
     tableExists(db, "agent_jobs") &&
@@ -673,7 +899,7 @@ function durableRunFromRow(
   };
 }
 
-function journalEventFromRow(
+function legacyJournalEventFromRow(
   row: AdmissionJournalRow,
 ): RunReplayResult["events"][number] {
   return {
@@ -682,6 +908,7 @@ function journalEventFromRow(
     timestamp: row.timestamp,
     runId: row.run_id,
     stepId: row.step_id,
+    category: "admission",
     kind: row.kind,
     event: row.event,
     ...(row.reason !== null ? { reason: row.reason } : {}),
@@ -796,6 +1023,23 @@ function columnExists(
     .prepare<[], { readonly name: string }>(`PRAGMA table_info(${table})`)
     .all()
     .some((row) => row.name === column);
+}
+
+/**
+ * Bring the rebuildable SQLite projection up to the fsynced JSONL tail before
+ * a cursor read. The scan is scoped to one run and bounded; the canonical file
+ * is never rewritten here.
+ */
+function refreshRunJournalProjection(
+  paths: StateDatabasePaths,
+  runId: string,
+): void {
+  const driver = openStateDatabasePaths(paths);
+  try {
+    recoverCanonicalRunJournalForRun(driver, runId);
+  } finally {
+    driver.close();
+  }
 }
 
 function withReadonlyStateDatabase<T>(

--- a/runtime/src/app-server/run-journal-replay.ts
+++ b/runtime/src/app-server/run-journal-replay.ts
@@ -1,0 +1,639 @@
+import type BetterSqlite3 from "better-sqlite3";
+
+import type {
+  JsonObject,
+  JsonValue,
+  RunJournalCategory,
+  RunJournalEvent,
+  RunReplayResult,
+} from "./protocol/index.js";
+import type { StateDatabasePaths } from "../state/sqlite-driver.js";
+import { isRecord } from "../utils/record.js";
+
+interface RolloutEventRow {
+  readonly event_seq: number;
+  readonly event_id: string | null;
+  readonly payload_json: string;
+  readonly variant_count: number;
+}
+
+interface CanonicalRolloutEventRow extends RolloutEventRow {
+  readonly event_id: string;
+}
+
+interface ReplayableRolloutEventRow extends CanonicalRolloutEventRow {
+  readonly envelope: JsonObject;
+}
+
+interface BoundsRow {
+  readonly first_sequence: number | null;
+  readonly last_sequence: number | null;
+}
+
+interface IdentityConflictRow {
+  readonly event_id: string;
+}
+
+interface ThreadSourceRow {
+  readonly rollout_path: string | null;
+  readonly archived_rollout_path: string | null;
+}
+
+interface JournalSourceScope {
+  readonly predicate: string;
+  readonly params: readonly unknown[];
+  readonly known: boolean;
+  readonly firstAvailableSequence?: number;
+  readonly lastSequence?: number;
+  readonly retiredThroughSequence?: number;
+  readonly gapReason?: "retention" | "corruption_truncated" | "compaction";
+}
+
+/**
+ * Serve one contiguous page from the SQLite projection of the canonical JSONL
+ * rollout. The projection can be rebuilt at any time; it never becomes a
+ * second journal authority.
+ */
+export function buildCanonicalRunReplay(
+  db: BetterSqlite3.Database,
+  paths: StateDatabasePaths,
+  runId: string,
+  afterSequence: number,
+  limit: number,
+): RunReplayResult {
+  if (!tableExists(db, "thread_rollout_items")) {
+    return unavailableReplay(paths, runId, afterSequence, limit);
+  }
+
+  const sourceScope = journalSourceScope(db, runId);
+  const bounds = db
+    .prepare<unknown[], BoundsRow>(
+      `SELECT MIN(event_seq) AS first_sequence,
+              MAX(event_seq) AS last_sequence
+       FROM thread_rollout_items
+       WHERE ${sourceScope.predicate} AND item_type = 'event_msg'
+         AND event_seq IS NOT NULL`,
+    )
+    .get(...sourceScope.params) ?? {
+    first_sequence: null,
+    last_sequence: null,
+  };
+
+  const sourceKnown =
+    sourceScope.known ||
+    bounds.first_sequence !== null ||
+    threadExists(db, runId);
+  if (!sourceKnown) {
+    return unavailableReplay(paths, runId, afterSequence, limit);
+  }
+
+  const source = {
+    kind: "run_journal" as const,
+    available: true,
+    sequenceScope: "run" as const,
+    canonical: "rollout_jsonl" as const,
+    projection: "thread_rollout_items" as const,
+    projectDir: paths.projectDir,
+  };
+  if (bounds.first_sequence === null || bounds.last_sequence === null) {
+    const retiredThrough = sourceScope.retiredThroughSequence;
+    const lastAvailableSequence = Math.max(
+      sourceScope.lastSequence ?? 0,
+      retiredThrough ?? 0,
+    );
+    if (
+      sourceScope.gapReason !== undefined &&
+      retiredThrough !== undefined &&
+      afterSequence < retiredThrough
+    ) {
+      const firstAvailableSequence =
+        sourceScope.firstAvailableSequence ?? retiredThrough + 1;
+      return {
+        runId,
+        afterSequence,
+        limit,
+        events: [],
+        hasMore: false,
+        nextAfterSequence: afterSequence,
+        firstAvailableSequence,
+        lastAvailableSequence,
+        gap: {
+          kind: "event_gap",
+          runId,
+          afterSequence,
+          firstAvailableSequence,
+          reason: sourceScope.gapReason,
+        },
+        source,
+      };
+    }
+    if (afterSequence > lastAvailableSequence) {
+      return {
+        runId,
+        afterSequence,
+        limit,
+        events: [],
+        hasMore: false,
+        nextAfterSequence: afterSequence,
+        lastAvailableSequence,
+        gap: {
+          kind: "cursor_ahead",
+          runId,
+          afterSequence,
+          lastAvailableSequence,
+          reason: "cursor_ahead",
+        },
+        source,
+      };
+    }
+    return {
+      runId,
+      afterSequence,
+      limit,
+      events: [],
+      hasMore: false,
+      nextAfterSequence: afterSequence,
+      gap: null,
+      source,
+    };
+  }
+
+  if (afterSequence + 1 < bounds.first_sequence) {
+    return {
+      runId,
+      afterSequence,
+      limit,
+      events: [],
+      hasMore: true,
+      nextAfterSequence: afterSequence,
+      firstAvailableSequence: bounds.first_sequence,
+      lastAvailableSequence: bounds.last_sequence,
+      gap: {
+        kind: "event_gap",
+        runId,
+        afterSequence,
+        firstAvailableSequence: bounds.first_sequence,
+        reason:
+          sourceScope.gapReason ??
+          (sourceContainsCompaction(db, sourceScope)
+            ? "compaction"
+            : "corruption_truncated"),
+      },
+      source,
+    };
+  }
+
+  if (afterSequence > bounds.last_sequence) {
+    return {
+      runId,
+      afterSequence,
+      limit,
+      events: [],
+      hasMore: false,
+      nextAfterSequence: afterSequence,
+      firstAvailableSequence: bounds.first_sequence,
+      lastAvailableSequence: bounds.last_sequence,
+      gap: {
+        kind: "cursor_ahead",
+        runId,
+        afterSequence,
+        lastAvailableSequence: bounds.last_sequence,
+        reason: "cursor_ahead",
+      },
+      source,
+    };
+  }
+
+  const rows = db
+    .prepare<unknown[], RolloutEventRow>(
+      `WITH variants AS (
+         SELECT event_seq, event_id, payload_json,
+                MIN(id) AS representative_id
+         FROM thread_rollout_items
+         WHERE ${sourceScope.predicate} AND item_type = 'event_msg'
+           AND event_seq > ?
+         GROUP BY event_seq, event_id, payload_json
+       ), grouped AS (
+         SELECT event_seq, MIN(representative_id) AS representative_id,
+                COUNT(*) AS variant_count
+         FROM variants
+         GROUP BY event_seq
+         ORDER BY event_seq ASC
+         LIMIT ?
+       )
+       SELECT grouped.event_seq, grouped.variant_count,
+              item.event_id, item.payload_json
+       FROM grouped
+       JOIN thread_rollout_items AS item
+         ON item.id = grouped.representative_id
+       ORDER BY grouped.event_seq ASC`,
+    )
+    .all(...sourceScope.params, afterSequence, limit + 1);
+
+  // Identity reuse only needs to be checked for events this page could expose.
+  // Looking up those bounded candidate ids through the replay identity indexes
+  // retains the fail-closed contract without rescanning the complete journal on
+  // every page.
+  const conflictingIds = conflictingEventIds(db, sourceScope, rows);
+
+  const contiguous: ReplayableRolloutEventRow[] = [];
+  let expected = afterSequence + 1;
+  let gapFirst: number | undefined;
+  for (const row of rows) {
+    if (row.event_seq > expected) {
+      gapFirst = row.event_seq;
+      break;
+    }
+    if (row.variant_count !== 1 || !hasCanonicalEventId(row)) {
+      gapFirst = row.event_seq;
+      break;
+    }
+    if (conflictingIds.has(row.event_id)) {
+      gapFirst = row.event_seq;
+      break;
+    }
+    const envelope = parseEventEnvelope(row.payload_json);
+    if (envelope === undefined || !projectionMatchesEnvelope(row, envelope)) {
+      gapFirst = row.event_seq;
+      break;
+    }
+    contiguous.push({ ...row, envelope });
+    expected += 1;
+    if (contiguous.length === limit) break;
+  }
+
+  const events = contiguous.map((row) => rolloutEvent(row, runId));
+  const nextAfterSequence = events.at(-1)?.sequence ?? afterSequence;
+  const gap = gapFirst === undefined
+    ? null
+    : {
+        kind: "event_gap" as const,
+        runId,
+        afterSequence: nextAfterSequence,
+        firstAvailableSequence: gapFirst,
+        reason: "corruption_truncated" as const,
+      };
+  return {
+    runId,
+    afterSequence,
+    limit,
+    events,
+    hasMore:
+      gap !== null ||
+      rows.length > contiguous.length ||
+      nextAfterSequence < bounds.last_sequence,
+    nextAfterSequence,
+    firstAvailableSequence: gapFirst ?? bounds.first_sequence,
+    lastAvailableSequence: bounds.last_sequence,
+    gap,
+    source,
+  };
+}
+
+function hasCanonicalEventId(
+  row: RolloutEventRow,
+): row is CanonicalRolloutEventRow {
+  return (
+    Number.isSafeInteger(row.event_seq) &&
+    row.event_seq > 0 &&
+    typeof row.event_id === "string" &&
+    row.event_id.length > 0
+  );
+}
+
+function projectionMatchesEnvelope(
+  row: CanonicalRolloutEventRow,
+  envelope: JsonObject,
+): boolean {
+  if (envelope.seq !== row.event_seq) return false;
+  const explicitEventId = stringValue(envelope.eventId);
+  const legacyId = stringValue(envelope.id);
+  const projectedEventId =
+    explicitEventId ??
+    (legacyId === undefined
+      ? undefined
+      : `legacy-event:${String(row.event_seq)}:${legacyId}`);
+  return projectedEventId === row.event_id;
+}
+
+function conflictingEventIds(
+  db: BetterSqlite3.Database,
+  sourceScope: JournalSourceScope,
+  rows: readonly RolloutEventRow[],
+): ReadonlySet<string> {
+  const candidateIds = [
+    ...new Set(
+      rows
+        .map((row) => row.event_id)
+        .filter((eventId): eventId is string =>
+          typeof eventId === "string" && eventId.length > 0
+        ),
+    ),
+  ];
+  if (candidateIds.length === 0) return new Set();
+  const candidatePlaceholders = candidateIds.map(() => "?").join(", ");
+  const conflicts = db
+    .prepare<unknown[], IdentityConflictRow>(
+      `WITH variants AS (
+         SELECT event_id, event_seq, payload_json
+         FROM thread_rollout_items
+         WHERE ${sourceScope.predicate} AND item_type = 'event_msg'
+           AND event_seq IS NOT NULL
+           AND event_id IN (${candidatePlaceholders})
+         GROUP BY event_id, event_seq, payload_json
+       )
+       SELECT event_id
+       FROM variants
+       GROUP BY event_id
+       HAVING COUNT(*) > 1`,
+    )
+    .all(...sourceScope.params, ...candidateIds);
+  return new Set(conflicts.map((row) => row.event_id));
+}
+
+function unavailableReplay(
+  paths: StateDatabasePaths,
+  runId: string,
+  afterSequence: number,
+  limit: number,
+): RunReplayResult {
+  return {
+    runId,
+    afterSequence,
+    limit,
+    events: [],
+    hasMore: false,
+    nextAfterSequence: afterSequence,
+    gap: {
+      kind: "source_unavailable",
+      reason: "run_journal_not_present",
+    },
+    source: {
+      kind: "run_journal",
+      available: false,
+      sequenceScope: "run",
+      canonical: "rollout_jsonl",
+      projection: "thread_rollout_items",
+      projectDir: paths.projectDir,
+    },
+  };
+}
+
+function rolloutEvent(
+  row: ReplayableRolloutEventRow,
+  runId: string,
+): RunJournalEvent {
+  const envelope = row.envelope;
+  const msg = asObject(envelope.msg) ?? {};
+  const type = stringValue(msg.type) ?? "unknown";
+  const payload = jsonValue(msg.payload);
+  const payloadObject = asObject(payload) ?? {};
+  const event = stringValue(payloadObject.event) ?? type;
+  const timestamp = firstString(payloadObject, [
+    "recordedAt",
+    "timestamp",
+    "transitionAt",
+    "finishedAt",
+    "acceptedAt",
+  ]);
+  const stepId = firstString(payloadObject, ["stepId", "turnId", "callId"]);
+  const sessionId = firstString(payloadObject, ["sessionId"]);
+  const childRunId = firstString(payloadObject, ["childRunId"]);
+  const reason = firstString(payloadObject, ["reason"]);
+  return {
+    sequence: row.event_seq,
+    eventId: row.event_id,
+    runId,
+    ...(childRunId !== undefined ? { childRunId } : {}),
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(stepId !== undefined ? { stepId } : {}),
+    category: categoryFor(type),
+    kind: type,
+    event,
+    ...(timestamp !== undefined ? { timestamp } : {}),
+    ...(payload !== undefined ? { payload } : {}),
+    ...(reason !== undefined ? { reason } : {}),
+    ...legacyAdmissionFields(payloadObject),
+  };
+}
+
+function legacyAdmissionFields(payload: JsonObject): Partial<RunJournalEvent> {
+  return {
+    ...(stringValue(payload.reservationId) !== undefined
+      ? { reservationId: stringValue(payload.reservationId) }
+      : {}),
+    ...(stringValue(payload.model) !== undefined
+      ? { model: stringValue(payload.model) }
+      : {}),
+    ...(stringValue(payload.provider) !== undefined
+      ? { provider: stringValue(payload.provider) }
+      : {}),
+    ...(finiteNumber(payload.reservedTokens) !== undefined
+      ? { reservedTokens: finiteNumber(payload.reservedTokens) }
+      : {}),
+    ...(finiteNumber(payload.reservedCostUsd) !== undefined
+      ? { reservedCostUsd: finiteNumber(payload.reservedCostUsd) }
+      : {}),
+    ...(finiteNumber(payload.actualTokens) !== undefined
+      ? { actualTokens: finiteNumber(payload.actualTokens) }
+      : {}),
+    ...(finiteNumber(payload.actualCostUsd) !== undefined
+      ? { actualCostUsd: finiteNumber(payload.actualCostUsd) }
+      : {}),
+    ...(asObject(payload.details) !== undefined
+      ? { details: asObject(payload.details) }
+      : {}),
+  };
+}
+
+function categoryFor(type: string): RunJournalCategory {
+  if (type === "execution_admission") return "admission";
+  if (type === "token_count") return "budget";
+  if (type === "request_permissions" || type.startsWith("permission_")) {
+    return "permission";
+  }
+  if (type.includes("approval")) return "approval";
+  if (type.startsWith("effect_")) return "effect";
+  if (type.startsWith("artifact_")) return "artifact";
+  if (type.includes("cancel") || type === "turn_aborted") return "cancellation";
+  if (type.includes("resum") || type.startsWith("recovery_")) return "recovery";
+  if (type === "run_terminal") return "terminal";
+  if (type.startsWith("turn_") || type.startsWith("collab_")) return "step";
+  if (
+    type.startsWith("agent_message") ||
+    type.startsWith("agent_thinking") ||
+    type.startsWith("assistant_thinking")
+  ) {
+    return "model";
+  }
+  return "session";
+}
+
+function selectedSourcePath(
+  db: BetterSqlite3.Database,
+  runId: string,
+): string | undefined {
+  if (!tableExists(db, "threads")) return undefined;
+  const row = db
+    .prepare<[string], ThreadSourceRow>(
+      `SELECT rollout_path, archived_rollout_path
+       FROM threads WHERE thread_id = ? LIMIT 1`,
+    )
+    .get(runId);
+  return row?.rollout_path ?? row?.archived_rollout_path ?? undefined;
+}
+
+function journalSourceScope(
+  db: BetterSqlite3.Database,
+  runId: string,
+): JournalSourceScope {
+  if (tableExists(db, "run_journal_bindings")) {
+    const binding = db
+      .prepare<
+        [string, string],
+        {
+          readonly source_count: number;
+          readonly first_available_sequence: number | null;
+          readonly last_sequence: number | null;
+          readonly retired_through_sequence: number | null;
+          readonly gap_reason:
+            | "retention"
+            | "corruption_truncated"
+            | "compaction"
+            | null;
+        }
+      >(
+        `SELECT COUNT(*) AS source_count,
+                MIN(first_available_sequence) AS first_available_sequence,
+                MAX(last_sequence) AS last_sequence,
+                MAX(retired_through_sequence) AS retired_through_sequence,
+                (
+                  SELECT gap_reason
+                  FROM run_journal_bindings AS gap_binding
+                  WHERE gap_binding.run_id = ?
+                    AND gap_binding.gap_reason IS NOT NULL
+                  ORDER BY retired_through_sequence DESC, epoch DESC
+                  LIMIT 1
+                ) AS gap_reason
+         FROM run_journal_bindings
+         WHERE run_id = ?`,
+      )
+      .get(runId, runId);
+    if ((binding?.source_count ?? 0) > 0) {
+      return {
+        predicate:
+          "source_path IN (SELECT source_path FROM run_journal_bindings WHERE run_id = ?)",
+        params: [runId],
+        known: true,
+        ...(binding?.first_available_sequence !== null &&
+        binding?.first_available_sequence !== undefined
+          ? { firstAvailableSequence: binding.first_available_sequence }
+          : {}),
+        ...(binding?.last_sequence !== null &&
+        binding?.last_sequence !== undefined
+          ? { lastSequence: binding.last_sequence }
+          : {}),
+        ...(binding?.retired_through_sequence !== null &&
+        binding?.retired_through_sequence !== undefined
+          ? { retiredThroughSequence: binding.retired_through_sequence }
+          : {}),
+        ...(binding?.gap_reason !== null && binding?.gap_reason !== undefined
+          ? { gapReason: binding.gap_reason }
+          : {}),
+      };
+    }
+  }
+
+  const sourcePath = selectedSourcePath(db, runId);
+  return sourcePath === undefined
+    ? { predicate: "thread_id = ?", params: [runId], known: false }
+    : {
+        predicate: "thread_id = ? AND source_path = ?",
+        params: [runId, sourcePath],
+        known: true,
+      };
+}
+
+function sourceContainsCompaction(
+  db: BetterSqlite3.Database,
+  sourceScope: JournalSourceScope,
+): boolean {
+  return db
+    .prepare<unknown[], { readonly present: number }>(
+      `SELECT 1 AS present FROM thread_rollout_items
+       WHERE ${sourceScope.predicate} AND item_type = 'compacted'
+       LIMIT 1`,
+    )
+    .get(...sourceScope.params) !== undefined;
+}
+
+function threadExists(db: BetterSqlite3.Database, runId: string): boolean {
+  if (!tableExists(db, "threads")) return false;
+  return db
+    .prepare<[string], { readonly present: number }>(
+      "SELECT 1 AS present FROM threads WHERE thread_id = ? LIMIT 1",
+    )
+    .get(runId) !== undefined;
+}
+
+function tableExists(db: BetterSqlite3.Database, name: string): boolean {
+  return db
+    .prepare<[string], { readonly name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .get(name) !== undefined;
+}
+
+function parseEventEnvelope(raw: string): JsonObject | undefined {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const envelope = asObject(parsed);
+    const msg = asObject(envelope?.msg);
+    if (
+      envelope === undefined ||
+      msg === undefined ||
+      stringValue(msg.type) === undefined ||
+      (msg.payload !== undefined && jsonValue(msg.payload) === undefined)
+    ) {
+      return undefined;
+    }
+    return envelope;
+  } catch {
+    return undefined;
+  }
+}
+
+function asObject(value: unknown): JsonObject | undefined {
+  return isRecord(value) ? (value as JsonObject) : undefined;
+}
+
+function jsonValue(value: unknown): JsonValue | undefined {
+  return isJsonValue(value) ? value : undefined;
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  if (["string", "number", "boolean"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  return isRecord(value) && Object.values(value).every(isJsonValue);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function firstString(
+  object: JsonObject | undefined,
+  keys: readonly string[],
+): string | undefined {
+  if (object === undefined) return undefined;
+  for (const key of keys) {
+    const value = stringValue(object[key]);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}

--- a/runtime/src/bin/bootstrap-services.ts
+++ b/runtime/src/bin/bootstrap-services.ts
@@ -37,9 +37,7 @@ import type {
   Session,
   SessionServices,
 } from "../session/session.js";
-import {
-  createCodeModeService,
-} from "../tools/code-mode/service.js";
+import { createCodeModeService } from "../tools/code-mode/service.js";
 import type { CodeModeService } from "../tools/code-mode/types.js";
 import {
   ToolLatencyStore,
@@ -49,10 +47,7 @@ import { initMagicDocs } from "../services/MagicDocs/magicDocs.js";
 import { configurePolicyLimitsService } from "../services/policyLimits/index.js";
 import type { RolloutItem } from "../session/rollout-item.js";
 import type { RolloutStore } from "../session/rollout-store.js";
-import {
-  FileThreadStore,
-  ThreadNotFoundError,
-} from "../thread-store/store.js";
+import { FileThreadStore, ThreadNotFoundError } from "../thread-store/store.js";
 import {
   createLiveThread,
   resumeLiveThread,
@@ -60,7 +55,11 @@ import {
 } from "../thread-store/live-thread.js";
 import type { RegisteredAgentTask } from "../session/agent-task-lifecycle.js";
 import { BehaviorSubject } from "../utils/behavior-subject.js";
-import { dispatchPostCompact, dispatchPreCompact, dispatchSessionStart } from "../llm/hooks/dispatcher.js";
+import {
+  dispatchPostCompact,
+  dispatchPreCompact,
+  dispatchSessionStart,
+} from "../llm/hooks/dispatcher.js";
 import { LifecycleHookRegistry } from "../llm/hooks/registry.js";
 import type {
   NotificationHook,
@@ -95,12 +94,12 @@ import type { ConfigStore } from "../config/store.js";
 import type { ToolRegistry } from "../tool-registry.js";
 import type { UnifiedExecProcessManagerLike } from "../unified-exec/types.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
-import type {
-  AuthBackend,
-  AuthSubscriptionTier,
-} from "../auth/backend.js";
+import type { AuthBackend, AuthSubscriptionTier } from "../auth/backend.js";
 import { isRecord } from "../utils/record.js";
 import type { ExecutionAdmissionClient } from "../budget/admission-client.js";
+import { bindExecutionAdmissionJournal } from "../session/execution-admission-journal.js";
+
+export { bindExecutionAdmissionJournal } from "../session/execution-admission-journal.js";
 
 interface BootstrapShellSnapshot {
   readonly cwd: string;
@@ -155,27 +154,6 @@ export interface BootstrapSessionServicesHandle {
   bindSession(session: Session): void;
   bindRolloutStore(binding: BootstrapRolloutBinding): LiveThread;
   shutdown(): Promise<void>;
-}
-
-/**
- * Project every live M3 admission decision into the session rollout. The
- * SQLite admission journal remains authoritative across restart; this durable
- * projection makes queue/reservation/reconcile/cancel/fallback decisions
- * visible through the same session event stream operators already inspect.
- */
-export function bindExecutionAdmissionJournal(
-  session: Session,
-  admission: ExecutionAdmissionClient,
-): () => void {
-  return admission.subscribe((event) => {
-    session.emit(
-      {
-        id: session.nextInternalSubId(),
-        msg: { type: "execution_admission", payload: event },
-      },
-      { durable: true },
-    );
-  });
 }
 
 export class BootstrapRolloutRecorderFacade implements RolloutRecorder {
@@ -512,8 +490,8 @@ export async function loadBootstrapLspServers(
     configSource: parsed.success
       ? () => parsed.servers
       : () => {
-        throw new Error(`Invalid LSP server config: ${parsed.reason}`);
-      },
+          throw new Error(`Invalid LSP server config: ${parsed.reason}`);
+        },
   };
   if (!parsed.success) {
     const status = getLspInitializationStatus(
@@ -530,9 +508,7 @@ export async function loadBootstrapLspServers(
     await shutdownLspServerManager(opts.sandboxExecutionBroker);
     return;
   }
-  const status = getLspInitializationStatus(
-    opts.sandboxExecutionBroker,
-  ).status;
+  const status = getLspInitializationStatus(opts.sandboxExecutionBroker).status;
   if (status === "not-started" || status === "failed") {
     initializeLspServerManager(managerOptions);
     return;
@@ -550,7 +526,10 @@ export function loadBootstrapLspServersInBackground(
 ): void {
   void loadBootstrapLspServers(cfg, opts).catch((error) => {
     // eslint-disable-next-line no-console
-    console.warn("[lsp] bootstrap config reload failed:", lspErrorMessage(error));
+    console.warn(
+      "[lsp] bootstrap config reload failed:",
+      lspErrorMessage(error),
+    );
   });
 }
 
@@ -593,8 +572,7 @@ function createAuthManager(opts: {
   const providerName = opts.providerName;
   if (
     providerName === "ollama" ||
-    ((providerName === "lmstudio" ||
-      providerName === "openai-compatible") &&
+    ((providerName === "lmstudio" || providerName === "openai-compatible") &&
       !opts.apiKey &&
       !providerOptions.apiKey)
   ) {
@@ -746,13 +724,10 @@ export function buildBootstrapSessionServices(
   });
   const lspManager: NonNullable<SessionServices["lspManager"]> = {
     refreshFromConfig: (config: unknown) =>
-      loadBootstrapLspServers(
-        config as ReturnType<ConfigStore["current"]>,
-        {
-          workspaceRoot: opts.workspaceRoot,
-          sandboxExecutionBroker: opts.sandboxExecutionBroker,
-        },
-      ),
+      loadBootstrapLspServers(config as ReturnType<ConfigStore["current"]>, {
+        workspaceRoot: opts.workspaceRoot,
+        sandboxExecutionBroker: opts.sandboxExecutionBroker,
+      }),
   };
   const unsubscribeHooksConfig = opts.configStore.subscribe((cfg) => {
     loadHooks(cfg);
@@ -776,7 +751,9 @@ export function buildBootstrapSessionServices(
       path: opts.env.SHELL ?? "/bin/sh",
       deriveExecArgs: (input: string) => ["-c", input],
     },
-    agentIdentityManager: new BootstrapAgentIdentityManager(opts.conversationId),
+    agentIdentityManager: new BootstrapAgentIdentityManager(
+      opts.conversationId,
+    ),
     shellSnapshotTx: createShellSnapshotTx(opts.workspaceRoot, opts.env),
     showRawAgentReasoning: false,
     execPolicy,
@@ -944,7 +921,9 @@ function requestBootstrapNetworkApproval(
     });
   }
   return service.requestNetworkApproval(
-    request as Parameters<RuntimeNetworkApprovalService["requestNetworkApproval"]>[0],
+    request as Parameters<
+      RuntimeNetworkApprovalService["requestNetworkApproval"]
+    >[0],
   );
 }
 

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1530,7 +1530,6 @@ export async function bootstrapLocalRuntimeSession(
       onBeforeSessionConfigured: async (s) => {
         sessionRef = s;
         sessionForShutdown = s;
-        bootstrapServices.bindSession(s);
         const agentRegistry = new AgentRegistry({
           ...(startup.config.agent_max_threads !== undefined
             ? { maxThreads: startup.config.agent_max_threads }
@@ -1609,9 +1608,22 @@ export async function bootstrapLocalRuntimeSession(
           },
         });
 
+        // Resume must restore the canonical rollout coordinates before the
+        // SQLite admission journal subscribes and catches up decisions that
+        // landed while this Session was detached. Binding earlier either has
+        // no store to persist into or allocates catch-up events from sequence
+        // one, colliding with resumed history. These three boundaries are
+        // intentionally fail-closed; continuing without the admission
+        // projection would make later execution evidence incomplete.
+        const existingItems = rolloutStore.readAll();
+        s.eventLog.seedCanonicalHistory(
+          existingItems.flatMap((item) =>
+            item.type === "event_msg" ? [item.payload] : [],
+          ),
+        );
+        bootstrapServices.bindSession(s);
+
         try {
-          const existingItems = rolloutStore.readAll();
-          s.eventLog.seedLastSeq(maxRolloutEventSeq(existingItems));
           if (existingItems.length > 0) {
             const indexSnapshot = readIndexSnapshot(
               join(
@@ -1894,16 +1906,4 @@ export async function bootstrapLocalRuntimeSession(
     }
     throw err;
   }
-}
-
-function maxRolloutEventSeq(items: readonly RolloutItem[]): number {
-  let maxSeq = 0;
-  for (const item of items) {
-    if (item.type !== "event_msg") continue;
-    const seq = (item.payload as { readonly seq?: unknown }).seq;
-    if (typeof seq === "number" && Number.isSafeInteger(seq) && seq > maxSeq) {
-      maxSeq = seq;
-    }
-  }
-  return maxSeq;
 }

--- a/runtime/src/bin/state-cli.ts
+++ b/runtime/src/bin/state-cli.ts
@@ -18,8 +18,8 @@ import {
 } from "../state/sqlite-driver.js";
 import {
   listUnresolvedUnknownOutcomeEffects,
-  resolveUnknownOutcomeEffect,
 } from "../state/unknown-outcome-gate.js";
+import { resolveDurableEffectReview } from "../state/effect-review.js";
 
 export type AgenCStateCliCommand =
   | { readonly kind: "export"; readonly agentId: string }
@@ -162,11 +162,18 @@ function runStateResolveToolCall(
 ): number {
   try {
     return withStateDriver(options, (driver) => {
-      const resolved = resolveUnknownOutcomeEffect(driver, {
+      const resolved = resolveDurableEffectReview(driver, {
         sessionId: command.sessionId,
         toolCallId: command.toolCallId,
+        reviewedAt: options.now?.() ?? new Date().toISOString(),
+        reviewedBy:
+          options.env?.AGENC_REVIEWER_ID?.trim() ||
+          options.env?.USER?.trim() ||
+          options.env?.USERNAME?.trim() ||
+          "local_operator",
+        resolution: "human_verified",
       });
-      if (!resolved) {
+      if (resolved.kind === "not_found") {
         const unresolved = listUnresolvedUnknownOutcomeEffects(
           driver,
           command.sessionId,
@@ -182,7 +189,11 @@ function runStateResolveToolCall(
         return 1;
       }
       io.stdout.write(
-        `Resolved unknown-outcome tool call ${command.toolCallId} in session ${command.sessionId}; the side-effecting mutation gate lifts once no unresolved effects remain.\n`,
+        `Resolved unknown-outcome tool call ${command.toolCallId} in session ${command.sessionId}` +
+          (resolved.durable
+            ? ` with canonical review event ${resolved.eventId} at sequence ${resolved.sequence}`
+            : "") +
+          `; the side-effecting mutation gate lifts once no unresolved effects remain.\n`,
       );
       return 0;
     });

--- a/runtime/src/budget/admission-client.ts
+++ b/runtime/src/budget/admission-client.ts
@@ -51,6 +51,12 @@ export interface AdmissionDispatchEvidence {
   readonly details?: Readonly<Record<string, unknown>>;
 }
 
+export interface AdmissionRunCancellationSummary {
+  readonly affectedRunIds: readonly string[];
+  readonly voidedReservations: number;
+  readonly heldUnknownReservations: number;
+}
+
 export interface ExecutionAdmissionClient {
   readonly scope: AdmissionClientScope;
   /**
@@ -80,6 +86,14 @@ export interface ExecutionAdmissionClient {
    * in the same SQLite transaction before this method returns.
    */
   cancelRun(reason: string): void;
+  /**
+   * Cancel only queued/reserved/dispatched admission work for this run tree.
+   * Unlike {@link cancelRun}, this deliberately leaves the legacy agent-run
+   * and spawn-edge projection untouched. Live run cancellation uses this
+   * phase while the canonical Session listener is still open, then seals the
+   * terminal journal tail before rebuilding the legacy projection.
+   */
+  cancelAdmissions?(reason: string): AdmissionRunCancellationSummary;
   /** Pre-dispatch cancellation/failure. The reservation is fully released. */
   void(reservationId: string, reason: string): void;
   /**
@@ -105,6 +119,20 @@ export interface ExecutionAdmissionClient {
     readonly parentScopeId?: string;
     readonly deadlineAt?: string;
   }): ExecutionAdmissionClient;
+  /**
+   * Commit-critical journal projection. A listener failure is allowed to stop
+   * the caller after the SQLite admission transition commits but before the
+   * provider/tool/spawn boundary proceeds. Ordinary `subscribe` listeners
+   * remain best-effort observers.
+   */
+  subscribeCritical?(
+    listener: (event: AdmissionJournalEvent) => void,
+  ): () => void;
+  /** Bounded catch-up for canonical projection after attach/re-attach. */
+  replayJournal?(options?: {
+    readonly afterSequence?: number;
+    readonly limit?: number;
+  }): readonly AdmissionJournalEvent[];
   subscribe(listener: (event: AdmissionJournalEvent) => void): () => void;
 }
 

--- a/runtime/src/budget/admitted-model-call.ts
+++ b/runtime/src/budget/admitted-model-call.ts
@@ -17,6 +17,7 @@ import {
   type ModelUsage,
 } from "../session/cost.js";
 import { AdmissionDeniedError } from "./admission-client.js";
+import { hitM4DurabilityFailpoint } from "../durability/failpoints.js";
 
 export interface AdmittedModelCallOptions {
   readonly session: Session;
@@ -431,6 +432,9 @@ export async function runAdmittedModelCall(
       // daemon shutdown, and restart recovery decisions.
       signal: lease.signal,
     });
+    // The provider has physically answered, but no durable accounting result
+    // has committed. A process loss here must recover as unknown, never free.
+    hitM4DurabilityFailpoint("before_model_response_commit");
     // Snapshot cancellation at physical provider settlement. Reconciliation
     // below may itself abort the lease on overrun, which is a different
     // terminal cause from a cancellation that already won the wire race.
@@ -439,6 +443,7 @@ export async function runAdmittedModelCall(
     if (usage.availability !== "reported" || usage.provenance !== "provider") {
       client.holdUnknown(reservationId, "missing_provider_usage");
       settled = true;
+      hitM4DurabilityFailpoint("after_model_response_commit");
       // An abort-ignoring provider may still resolve after durable
       // cancellation. Keep its conservative settlement, but never revive the
       // cancelled call by returning that response to the caller.
@@ -473,6 +478,7 @@ export async function runAdmittedModelCall(
         client.holdUnknown(reservationId, "unpriced_provider_response");
       }
       settled = true;
+      hitM4DurabilityFailpoint("after_model_response_commit");
       if (hasHardCostCap) {
         params.session.abortTerminal("provider_overrun");
         void params.session.services.agentControl.shutdownAgentTree?.(
@@ -491,6 +497,7 @@ export async function runAdmittedModelCall(
       costUsd: actualCost,
     });
     settled = true;
+    hitM4DurabilityFailpoint("after_model_response_commit");
     if (outcome.outcome === "provider_overrun") {
       params.session.abortTerminal("provider_overrun");
       void params.session.services.agentControl.shutdownAgentTree?.(

--- a/runtime/src/budget/admitted-tool-call.ts
+++ b/runtime/src/budget/admitted-tool-call.ts
@@ -1,5 +1,18 @@
 /** Shared M3 boundary for approved tool effects. */
 
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  M4DurabilityFailpointError,
+  hitM4DurabilityFailpoint,
+} from "../durability/failpoints.js";
+import type {
+  EffectIntentEvent,
+  EffectResultEvent,
+  EffectUnknownOutcomeEvent,
+  Event,
+  EventMsg,
+} from "../session/event-log.js";
 import type { Session } from "../session/session.js";
 import type { Tool, ToolRecoveryCategory } from "../tools/types.js";
 import type { ToolDispatchResult } from "../tool-registry.js";
@@ -20,6 +33,26 @@ export interface AdmittedToolCallOptions {
 export interface AdmittedToolDispatchContext {
   readonly signal: AbortSignal;
   readonly abortController: AbortController;
+}
+
+/**
+ * Optional rebuildable state projection for the canonical rollout journal.
+ * The JSONL event is always fsync-committed first; a projection failure stops
+ * dispatch/continuation and can be repaired by replaying that journal.
+ */
+export interface ToolEffectDurabilityProjection {
+  recordEffectEvent(event: Event): void;
+}
+
+interface EffectJournalContext {
+  readonly runId: string;
+  readonly stepId: string;
+  readonly callId: string;
+  readonly toolName: string;
+  readonly recoveryCategory: ToolRecoveryCategory;
+  readonly idempotencyKey?: string;
+  readonly intentDigest: string;
+  readonly intentEventSeq: number;
 }
 
 function recoveryCategory(tool: Tool): ToolRecoveryCategory {
@@ -64,6 +97,220 @@ function cancellationAfterDispatch(signal: AbortSignal): Error | undefined {
   );
 }
 
+function canonicalEffectValue(
+  value: unknown,
+  ancestors = new WeakSet<object>(),
+): string {
+  if (value === null) return "null";
+  switch (typeof value) {
+    case "undefined":
+      return "undefined";
+    case "boolean":
+      return value ? "boolean:true" : "boolean:false";
+    case "string":
+      return `string:${JSON.stringify(value)}`;
+    case "number":
+      if (Number.isNaN(value)) return "number:NaN";
+      if (value === Number.POSITIVE_INFINITY) return "number:+Infinity";
+      if (value === Number.NEGATIVE_INFINITY) return "number:-Infinity";
+      if (Object.is(value, -0)) return "number:-0";
+      return `number:${String(value)}`;
+    case "bigint":
+      return `bigint:${value.toString(10)}`;
+    case "symbol":
+    case "function":
+      throw new TypeError(`unsupported effect digest value: ${typeof value}`);
+    case "object":
+      break;
+  }
+  if (ancestors.has(value)) {
+    throw new TypeError("circular effect digest value");
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return `array:[${value
+        .map((entry) => canonicalEffectValue(entry, ancestors))
+        .join(",")}]`;
+    }
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}=${canonicalEffectValue(record[key], ancestors)}`,
+      );
+    return `object:{${entries.join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function effectDigest(value: unknown): string {
+  return createHash("sha256")
+    .update(canonicalEffectValue(value), "utf8")
+    .digest("hex");
+}
+
+function effectProjection(
+  session: Session,
+): ToolEffectDurabilityProjection | undefined {
+  const rolloutProjection = session.rolloutStore as
+    ToolEffectDurabilityProjection | null | undefined;
+  if (typeof rolloutProjection?.recordEffectEvent === "function") {
+    return rolloutProjection;
+  }
+  return (
+    session.services as
+      { readonly effectDurability?: ToolEffectDurabilityProjection } | undefined
+  )?.effectDurability;
+}
+
+function appendEffectEvent(
+  session: Session,
+  msg: Extract<
+    EventMsg,
+    {
+      readonly type:
+        "effect_intent" | "effect_result" | "effect_unknown_outcome";
+    }
+  >,
+): Event | undefined {
+  const emit = (session as { readonly emit?: Session["emit"] }).emit;
+  if (session.rolloutStore == null || typeof emit !== "function") {
+    if (session.services?.admissionRequired !== false) {
+      throw new AdmissionDeniedError("effect_journal_unavailable");
+    }
+    return undefined;
+  }
+  const event = emit.call(
+    session,
+    { id: randomUUID(), msg },
+    { durable: true },
+  );
+  if (!Number.isSafeInteger(event.seq) || (event.seq ?? 0) <= 0) {
+    throw new AdmissionDeniedError("effect_journal_sequence_missing");
+  }
+  effectProjection(session)?.recordEffectEvent(event);
+  return event;
+}
+
+function appendEffectIntent(params: {
+  readonly session: Session;
+  readonly runId: string;
+  readonly stepId: string;
+  readonly callId: string;
+  readonly tool: Tool;
+  readonly args: Readonly<Record<string, unknown>>;
+  readonly recoveryCategory: ToolRecoveryCategory;
+}): EffectJournalContext {
+  const identity = {
+    version: 1,
+    runId: params.runId,
+    stepId: params.stepId,
+    callId: params.callId,
+    toolName: params.tool.name,
+    recoveryCategory: params.recoveryCategory,
+    args: params.args,
+  } as const;
+  const intentDigest = effectDigest(identity);
+  const idempotencyKey =
+    params.recoveryCategory === "idempotent"
+      ? `sha256:${effectDigest({ ...identity, purpose: "idempotency" })}`
+      : undefined;
+  const payload: EffectIntentEvent = {
+    runId: params.runId,
+    stepId: params.stepId,
+    callId: params.callId,
+    toolName: params.tool.name,
+    recoveryCategory: params.recoveryCategory,
+    ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
+    intentDigest,
+    attempt: 1,
+    recordedAt: new Date().toISOString(),
+  };
+  const event = appendEffectEvent(params.session, {
+    type: "effect_intent",
+    payload,
+  });
+  return {
+    ...payload,
+    intentEventSeq: event?.seq ?? 0,
+  };
+}
+
+function appendEffectResult(
+  session: Session,
+  context: EffectJournalContext,
+  options: {
+    readonly outcome: EffectResultEvent["outcome"];
+    readonly result?: ToolDispatchResult;
+    readonly evidence?: Readonly<Record<string, unknown>>;
+  },
+): void {
+  const payload: EffectResultEvent = {
+    runId: context.runId,
+    stepId: context.stepId,
+    callId: context.callId,
+    toolName: context.toolName,
+    recoveryCategory: context.recoveryCategory,
+    ...(context.idempotencyKey !== undefined
+      ? { idempotencyKey: context.idempotencyKey }
+      : {}),
+    intentEventSeq: context.intentEventSeq,
+    outcome: options.outcome,
+    ...(options.result !== undefined
+      ? {
+          resultDigest: effectDigest({
+            content: options.result.content,
+            isError: options.result.isError === true,
+            preventContinuation: options.result.preventContinuation === true,
+            admissionUsage: options.result.admissionUsage ?? null,
+          }),
+        }
+      : {}),
+    ...(options.evidence !== undefined ? { evidence: options.evidence } : {}),
+    recordedAt: new Date().toISOString(),
+  };
+  hitM4DurabilityFailpoint("before_tool_ack_commit");
+  appendEffectEvent(session, { type: "effect_result", payload });
+  hitM4DurabilityFailpoint("after_tool_ack_commit");
+}
+
+function appendEffectUnknownOutcome(
+  session: Session,
+  context: EffectJournalContext,
+  reason: string,
+): void {
+  const payload: EffectUnknownOutcomeEvent = {
+    runId: context.runId,
+    stepId: context.stepId,
+    callId: context.callId,
+    toolName: context.toolName,
+    recoveryCategory: context.recoveryCategory,
+    ...(context.idempotencyKey !== undefined
+      ? { idempotencyKey: context.idempotencyKey }
+      : {}),
+    intentEventSeq: context.intentEventSeq,
+    outcome: "unknown_outcome",
+    reason,
+    requiresReview: true,
+    recordedAt: new Date().toISOString(),
+  };
+  hitM4DurabilityFailpoint("before_tool_ack_commit");
+  appendEffectEvent(session, { type: "effect_unknown_outcome", payload });
+  hitM4DurabilityFailpoint("after_tool_ack_commit");
+}
+
+function errorEvidence(error: unknown): Readonly<Record<string, unknown>> {
+  if (!(error instanceof Error)) return { errorType: typeof error };
+  const code = (error as { readonly code?: unknown }).code;
+  return {
+    errorName: error.name,
+    ...(typeof code === "string" ? { errorCode: code } : {}),
+  };
+}
+
 /**
  * Runs after permission/approval but immediately before `tool.execute`.
  * Local tools reserve a zero monetary charge while still consuming durable
@@ -82,8 +329,70 @@ export async function runAdmittedToolCall(
       throw new AdmissionDeniedError("admission_kernel_unavailable");
     }
     const dispatch = createDispatchContext(params.signal);
+    const stepId = `tool:${params.turnId}:${params.callId}`;
+    let effect: EffectJournalContext | undefined;
+    let dispatched = false;
+    let acknowledgementStarted = false;
+    let acknowledged = false;
     try {
-      return await params.invoke(dispatch.context);
+      effect = appendEffectIntent({
+        session: params.session,
+        runId: params.session.conversationId,
+        stepId,
+        callId: params.callId,
+        tool: params.tool,
+        args: params.args,
+        recoveryCategory: category,
+      });
+      const cancelledBeforeDispatch = cancellationAfterDispatch(
+        dispatch.context.signal,
+      );
+      if (cancelledBeforeDispatch !== undefined) {
+        acknowledgementStarted = true;
+        appendEffectResult(params.session, effect, {
+          outcome: "cancelled",
+          evidence: { reason: "cancelled_before_dispatch" },
+        });
+        acknowledged = true;
+        throw cancelledBeforeDispatch;
+      }
+      hitM4DurabilityFailpoint("before_tool_spawn");
+      dispatched = true;
+      const pending = params.invoke(dispatch.context);
+      hitM4DurabilityFailpoint("after_tool_spawn");
+      const result = await pending;
+      acknowledgementStarted = true;
+      appendEffectResult(params.session, effect, {
+        outcome: result.isError === true ? "failed" : "committed",
+        result,
+      });
+      acknowledged = true;
+      // The physical tool result won the race with cancellation. Preserve it
+      // so streamed tool history remains complete and the committed effect
+      // evidence agrees with the caller-visible outcome. Admission-backed
+      // calls have a separate durable cancellation authority below.
+      return result;
+    } catch (error) {
+      if (error instanceof M4DurabilityFailpointError) throw error;
+      if (effect !== undefined && !acknowledgementStarted && !acknowledged) {
+        acknowledgementStarted = true;
+        if (dispatched && category !== "idempotent") {
+          appendEffectUnknownOutcome(
+            params.session,
+            effect,
+            dispatch.context.signal.aborted
+              ? "tool_cancelled_after_dispatch"
+              : "tool_failed_after_dispatch_without_acknowledgement",
+          );
+        } else {
+          appendEffectResult(params.session, effect, {
+            outcome: dispatch.context.signal.aborted ? "cancelled" : "failed",
+            evidence: errorEvidence(error),
+          });
+        }
+        acknowledged = true;
+      }
+      throw error;
     } finally {
       dispatch.cleanup();
     }
@@ -111,10 +420,38 @@ export async function runAdmittedToolCall(
   );
   const reservationId = lease.reservation.reservationId;
   const dispatch = createDispatchContext(lease.signal);
+  let effect: EffectJournalContext | undefined;
   let dispatched = false;
   let settled = false;
   let lateCancellation: Error | undefined;
+  let acknowledgementStarted = false;
+  let acknowledged = false;
+  let crashInjected = false;
   try {
+    effect = appendEffectIntent({
+      session: params.session,
+      runId: lease.reservation.step.runId,
+      stepId: lease.reservation.step.stepId,
+      callId: params.callId,
+      tool: params.tool,
+      args: params.args,
+      recoveryCategory: category,
+    });
+    const cancelledBeforeDispatch = cancellationAfterDispatch(
+      dispatch.context.signal,
+    );
+    if (cancelledBeforeDispatch !== undefined) {
+      acknowledgementStarted = true;
+      appendEffectResult(params.session, effect, {
+        outcome: "cancelled",
+        evidence: { reason: "cancelled_before_dispatch" },
+      });
+      acknowledged = true;
+      client.void(reservationId, "tool_cancelled_before_dispatch");
+      settled = true;
+      throw cancelledBeforeDispatch;
+    }
+    hitM4DurabilityFailpoint("before_tool_spawn");
     client.markDispatched(reservationId, {
       boundary: "tool_effect",
       details: {
@@ -124,11 +461,23 @@ export async function runAdmittedToolCall(
       },
     });
     dispatched = true;
-    const result = await params.invoke(dispatch.context);
+    const pending = params.invoke(dispatch.context);
+    hitM4DurabilityFailpoint("after_tool_spawn");
+    const result = await pending;
     // Snapshot cancellation at physical effect settlement. Reconciliation can
     // itself abort on overrun and must not be mistaken for an earlier cancel.
     lateCancellation = cancellationAfterDispatch(lease.signal);
-    if (result.admissionUsage !== undefined && !validUsage(result.admissionUsage)) {
+    acknowledgementStarted = true;
+    appendEffectResult(params.session, effect, {
+      outcome: result.isError === true ? "failed" : "committed",
+      result,
+      evidence: { reservationId },
+    });
+    acknowledged = true;
+    if (
+      result.admissionUsage !== undefined &&
+      !validUsage(result.admissionUsage)
+    ) {
       client.holdUnknown(reservationId, "invalid_tool_usage");
       settled = true;
     } else if (validUsage(result.admissionUsage)) {
@@ -158,6 +507,31 @@ export async function runAdmittedToolCall(
     if (lateCancellation !== undefined) throw lateCancellation;
     return result;
   } catch (error) {
+    if (error instanceof M4DurabilityFailpointError) {
+      crashInjected = true;
+      throw error;
+    }
+    if (effect !== undefined && !acknowledgementStarted && !acknowledged) {
+      acknowledgementStarted = true;
+      if (dispatched && category !== "idempotent") {
+        appendEffectUnknownOutcome(
+          params.session,
+          effect,
+          dispatch.context.signal.aborted
+            ? "tool_cancelled_after_dispatch"
+            : "tool_failed_after_dispatch_without_acknowledgement",
+        );
+      } else {
+        appendEffectResult(params.session, effect, {
+          outcome: dispatch.context.signal.aborted ? "cancelled" : "failed",
+          evidence: {
+            reservationId,
+            ...errorEvidence(error),
+          },
+        });
+      }
+      acknowledged = true;
+    }
     if (settled) {
       throw error;
     } else if (dispatched && dispatch.context.signal.aborted) {
@@ -178,7 +552,7 @@ export async function runAdmittedToolCall(
   } finally {
     // Cancellation records the durable unknown outcome at once while keeping
     // live capacity occupied until even an abort-ignoring tool promise settles.
-    client.acknowledgeCompletion(reservationId);
+    if (!crashInjected) client.acknowledgeCompletion(reservationId);
     dispatch.cleanup();
   }
 }

--- a/runtime/src/budget/execution-admission-kernel.ts
+++ b/runtime/src/budget/execution-admission-kernel.ts
@@ -41,6 +41,8 @@ import {
   type StateSqliteDriver,
 } from "../state/sqlite-driver.js";
 import { AsyncLock } from "../utils/async-lock.js";
+import { hitM4DurabilityFailpoint } from "../durability/failpoints.js";
+import { recoverExecutionAdmissionCanonicalJournals } from "../state/execution-admission-canonical-recovery.js";
 
 const DEFAULT_QUEUE_AGING_MS = 30_000;
 const JOURNAL_PAGE_SIZE = 1_000;
@@ -165,6 +167,10 @@ export class ExecutionAdmissionKernel {
     string,
     Set<(event: AdmissionJournalEvent) => void>
   >();
+  readonly #criticalListeners = new Map<
+    string,
+    Set<(event: AdmissionJournalEvent) => void>
+  >();
   #limits: AdmissionConcurrencyLimits;
   #drainScheduled = false;
   #closed = false;
@@ -217,6 +223,10 @@ export class ExecutionAdmissionKernel {
       totals.heldUnknown += report.heldUnknownReservationIds.length;
       totals.expired += report.cancelledExpiredJobIds.length;
       totals.detachedQueued += report.detachedQueuedJobIds.length;
+      recoverExecutionAdmissionCanonicalJournals(
+        binding.driver,
+        binding.repository,
+      );
       this.#hydrateQueued(binding);
       this.#publishNewJournal(binding);
     }
@@ -359,7 +369,10 @@ export class ExecutionAdmissionKernel {
           new AdmissionDeniedError("admission_step_already_waiting"),
         );
       }
-      if (existing.binding.paths.stateDbPath !== binding.workspace.paths.stateDbPath) {
+      if (
+        existing.binding.paths.stateDbPath !==
+        binding.workspace.paths.stateDbPath
+      ) {
         return Promise.reject(
           new AdmissionDeniedError("admission_step_workspace_conflict"),
         );
@@ -516,8 +529,7 @@ export class ExecutionAdmissionKernel {
     ) {
       throw new AdmissionDeniedError("admission_parent_run_conflict");
     }
-    const parentRunId =
-      options.parentRunId ?? expectedParentRunId;
+    const parentRunId = options.parentRunId ?? expectedParentRunId;
     this.#bindRunWorkspace(runId, binding.workspace);
     const deadlineAt = binding.workspace.repository.bindRunDeadline(
       runId,
@@ -576,6 +588,35 @@ export class ExecutionAdmissionKernel {
     };
   }
 
+  subscribeCritical(
+    runId: string,
+    listener: (event: AdmissionJournalEvent) => void,
+  ): () => void {
+    const listeners = this.#criticalListeners.get(runId) ?? new Set();
+    listeners.add(listener);
+    this.#criticalListeners.set(runId, listeners);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) this.#criticalListeners.delete(runId);
+    };
+  }
+
+  replayClientJournal(
+    binding: ClientBinding,
+    options: {
+      readonly afterSequence?: number;
+      readonly limit?: number;
+    } = {},
+  ): readonly AdmissionJournalEvent[] {
+    return binding.workspace.repository.listJournal({
+      runId: binding.scope.runId,
+      ...(options.afterSequence !== undefined
+        ? { afterSequence: options.afterSequence }
+        : {}),
+      ...(options.limit !== undefined ? { limit: options.limit } : {}),
+    });
+  }
+
   cancelRun(
     runId: string,
     reason: string,
@@ -599,6 +640,50 @@ export class ExecutionAdmissionKernel {
       heldUnknownReservations += report.heldUnknownReservationIds.length;
       this.#publishNewJournal(binding);
     }
+    this.#abortCancelledAdmissionWork(affected, reason);
+    return {
+      affectedRunIds: [...affected],
+      voidedReservations,
+      heldUnknownReservations,
+    };
+  }
+
+  /**
+   * Settle admission work without advancing the legacy agent-run projection.
+   * The live run.cancel path calls this while its Session critical listener is
+   * still attached, so every resulting journal row is fsync-projected before
+   * the run terminal seals the canonical tail.
+   */
+  cancelAdmissions(
+    runId: string,
+    reason: string,
+  ): ExecutionAdmissionCancellationSummary {
+    this.#assertOpen();
+    const affected = new Set<string>();
+    let voidedReservations = 0;
+    let heldUnknownReservations = 0;
+    for (const binding of this.#byStatePath.values()) {
+      const report = binding.repository.cancel(runId, {
+        reason,
+        cancelledAt: this.#timestamp(),
+      });
+      for (const id of report.affectedRunIds) affected.add(id);
+      voidedReservations += report.voidedReservationIds.length;
+      heldUnknownReservations += report.heldUnknownReservationIds.length;
+      this.#publishNewJournal(binding);
+    }
+    this.#abortCancelledAdmissionWork(affected, reason);
+    return {
+      affectedRunIds: [...affected],
+      voidedReservations,
+      heldUnknownReservations,
+    };
+  }
+
+  #abortCancelledAdmissionWork(
+    affected: ReadonlySet<string>,
+    reason: string,
+  ): void {
     for (const [key, pending] of this.#pending) {
       if (
         !affected.has(pending.record.request.step.runId) &&
@@ -628,11 +713,6 @@ export class ExecutionAdmissionKernel {
       }
     }
     this.#scheduleDrain();
-    return {
-      affectedRunIds: [...affected],
-      voidedReservations,
-      heldUnknownReservations,
-    };
   }
 
   listJournal(params: {
@@ -684,6 +764,7 @@ export class ExecutionAdmissionKernel {
     this.#pending.clear();
     this.#active.clear();
     this.#listeners.clear();
+    this.#criticalListeners.clear();
     for (const binding of this.#byStatePath.values()) {
       binding.driver.close();
     }
@@ -728,6 +809,10 @@ export class ExecutionAdmissionKernel {
         now: this.#timestamp(),
         activeOwnerIds: new Set([this.#ownerId]),
       });
+      recoverExecutionAdmissionCanonicalJournals(
+        binding.driver,
+        binding.repository,
+      );
       this.#hydrateQueued(binding);
       this.#publishNewJournal(binding);
     }
@@ -773,10 +858,9 @@ export class ExecutionAdmissionKernel {
   #drainQueue(): void {
     if (this.#closed || this.#pending.size === 0) return;
     const nowMs = this.#now().getTime();
-    const pending = [...this.#pending.values()]
-      .sort((left, right) =>
-        comparePending(left, right, nowMs, this.#queueAgingMs),
-      );
+    const pending = [...this.#pending.values()].sort((left, right) =>
+      comparePending(left, right, nowMs, this.#queueAgingMs),
+    );
     let earliestAvailableAt: number | undefined;
     let madeProgress = false;
     for (const entry of pending) {
@@ -794,6 +878,11 @@ export class ExecutionAdmissionKernel {
       // runnable work forever.
       if (entry.resolve === undefined || entry.reject === undefined) continue;
       if (!this.#hasCapacity(entry.record.request)) continue;
+      // `claim()` is the transaction that creates the budget reservation and
+      // changes the job from queued to running. Queue insertion is durable too,
+      // but it is not a reservation commit and must not be labelled as one in
+      // crash-injection evidence.
+      hitM4DurabilityFailpoint("before_reservation_commit");
       const result = entry.binding.repository.claim({
         key: entry.key,
         ownerId: this.#ownerId,
@@ -801,6 +890,12 @@ export class ExecutionAdmissionKernel {
         attached: true,
         now: this.#timestamp(),
       });
+      if (result.kind === "claimed") {
+        // The reservation is committed while no live lease or journal
+        // subscriber has been notified yet. Restart must recover solely from
+        // the durable hold if the process dies here.
+        hitM4DurabilityFailpoint("after_reservation_commit");
+      }
       this.#publishNewJournal(entry.binding);
       if (result.kind === "claimed") {
         this.#pending.delete(entry.key);
@@ -820,11 +915,7 @@ export class ExecutionAdmissionKernel {
       }
     }
     if (earliestAvailableAt !== undefined) {
-      scheduleAt(
-        earliestAvailableAt,
-        this.#now,
-        () => this.#scheduleDrain(),
-      );
+      scheduleAt(earliestAvailableAt, this.#now, () => this.#scheduleDrain());
     }
     if (madeProgress && this.#pending.size > 0) this.#scheduleDrain();
   }
@@ -932,10 +1023,7 @@ export class ExecutionAdmissionKernel {
     if (active === undefined) return;
     active.binding.repository.cancelStep(active.key, { reason });
     this.#publishNewJournal(active.binding);
-    this.#abortActive(
-      active,
-      new AdmissionDeniedError(reason, "cancelled"),
-    );
+    this.#abortActive(active, new AdmissionDeniedError(reason, "cancelled"));
   }
 
   #abortActive(active: ActiveCapacity, reason: unknown): void {
@@ -951,7 +1039,10 @@ export class ExecutionAdmissionKernel {
     if (active.deadlineTimer !== undefined) {
       active.deadlineTimer.cancel();
     }
-    if (active.sourceSignal !== undefined && active.onSourceAbort !== undefined) {
+    if (
+      active.sourceSignal !== undefined &&
+      active.onSourceAbort !== undefined
+    ) {
       active.sourceSignal.removeEventListener("abort", active.onSourceAbort);
     }
     this.#active.delete(active.reservationId);
@@ -968,10 +1059,10 @@ export class ExecutionAdmissionKernel {
       for (const record of records) {
         const existing = this.#pending.get(record.key);
         if (existing !== undefined) {
-          if (existing.binding.paths.stateDbPath !== binding.paths.stateDbPath) {
-            throw new AdmissionDeniedError(
-              "admission_step_workspace_conflict",
-            );
+          if (
+            existing.binding.paths.stateDbPath !== binding.paths.stateDbPath
+          ) {
+            throw new AdmissionDeniedError("admission_step_workspace_conflict");
           }
           continue;
         }
@@ -998,10 +1089,8 @@ export class ExecutionAdmissionKernel {
     };
     const deadline = record.request.deadlineAt;
     if (deadline !== undefined) {
-      pending.deadlineTimer = scheduleAt(
-        Date.parse(deadline),
-        this.#now,
-        () => this.#cancelPendingRun(pending, "deadline_expired"),
+      pending.deadlineTimer = scheduleAt(Date.parse(deadline), this.#now, () =>
+        this.#cancelPendingRun(pending, "deadline_expired"),
       );
     }
     return pending;
@@ -1028,10 +1117,7 @@ export class ExecutionAdmissionKernel {
     });
   }
 
-  #cancelPendingRun(
-    pending: PendingAdmission,
-    reason: string,
-  ): void {
+  #cancelPendingRun(pending: PendingAdmission, reason: string): void {
     if (this.#pending.get(pending.key) !== pending) return;
     this.cancelRun(pending.record.request.step.runId, reason);
   }
@@ -1040,10 +1126,7 @@ export class ExecutionAdmissionKernel {
     if (this.#pending.get(pending.key) !== pending) return;
     pending.binding.repository.cancelStep(pending.key, { reason });
     this.#publishNewJournal(pending.binding);
-    this.#settlePending(
-      pending,
-      new AdmissionDeniedError(reason, "cancelled"),
-    );
+    this.#settlePending(pending, new AdmissionDeniedError(reason, "cancelled"));
     this.#pending.delete(pending.key);
     this.#scheduleDrain();
   }
@@ -1110,6 +1193,17 @@ export class ExecutionAdmissionKernel {
       });
       if (events.length === 0) return;
       for (const event of events) {
+        // Admission SQLite has already committed at this point. Canonical
+        // journal projection is nevertheless a physical-work boundary: a
+        // critical listener must fsync the event before acquire/dispatch may
+        // continue. Keep the cursor on this event when that append fails so a
+        // later call can retry the idempotent projection.
+        hitM4DurabilityFailpoint(
+          "after_admission_sqlite_commit_before_canonical_append",
+        );
+        for (const listener of this.#criticalListeners.get(event.runId) ?? []) {
+          listener(event);
+        }
         binding.lastJournalSequence = Math.max(
           binding.lastJournalSequence,
           event.sequence,
@@ -1176,6 +1270,10 @@ class KernelAdmissionClient implements ExecutionAdmissionClient {
     this.kernel.cancelRun(this.scope.runId, reason);
   }
 
+  cancelAdmissions(reason: string): ExecutionAdmissionCancellationSummary {
+    return this.kernel.cancelAdmissions(this.scope.runId, reason);
+  }
+
   void(reservationId: string, reason: string): void {
     this.kernel.void(reservationId, reason);
   }
@@ -1198,6 +1296,19 @@ class KernelAdmissionClient implements ExecutionAdmissionClient {
 
   subscribe(listener: (event: AdmissionJournalEvent) => void): () => void {
     return this.kernel.subscribe(this.scope.runId, listener);
+  }
+
+  subscribeCritical(
+    listener: (event: AdmissionJournalEvent) => void,
+  ): () => void {
+    return this.kernel.subscribeCritical(this.scope.runId, listener);
+  }
+
+  replayJournal(options?: {
+    readonly afterSequence?: number;
+    readonly limit?: number;
+  }): readonly AdmissionJournalEvent[] {
+    return this.kernel.replayClientJournal(this.binding, options);
   }
 }
 
@@ -1263,10 +1374,7 @@ function rootBudgetState(
 ): ClientBudgetState {
   const scopes: AdmissionBudgetScope[] = [];
   const runAllocationKey = allocationKey(scope.runId);
-  const runMaxCostUsd = minimumDefined(
-    scope.maxCostUsd,
-    policy?.runMaxCostUsd,
-  );
+  const runMaxCostUsd = minimumDefined(scope.maxCostUsd, policy?.runMaxCostUsd);
   const runMaxTokens = minimumDefined(scope.maxTokens, policy?.runMaxTokens);
   scopes.push({
     key: runAllocationKey,

--- a/runtime/src/durability/atomic-artifact.ts
+++ b/runtime/src/durability/atomic-artifact.ts
@@ -1,0 +1,940 @@
+/** Crash-safe, immutable publication for content artifacts. */
+
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  unlinkSync,
+} from "node:fs";
+import { lstat, link, open, readdir, realpath, unlink } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { hitM4DurabilityFailpoint } from "./failpoints.js";
+
+export type AtomicArtifactCommitResult = "committed" | "already_committed";
+
+export class AtomicArtifactConflictError extends Error {
+  readonly code = "ARTIFACT_CONTENT_CONFLICT" as const;
+  readonly targetPath: string;
+
+  constructor(targetPath: string) {
+    super(`artifact target already contains different bytes: ${targetPath}`);
+    this.name = "AtomicArtifactConflictError";
+    this.targetPath = targetPath;
+  }
+}
+
+export class AtomicArtifactUnsafePathError extends Error {
+  readonly code = "ARTIFACT_UNSAFE_PARENT" as const;
+  readonly targetPath: string;
+  readonly parentPath: string;
+
+  constructor(targetPath: string, parentPath: string) {
+    super(`artifact target has an unsafe parent path: ${parentPath}`);
+    this.name = "AtomicArtifactUnsafePathError";
+    this.targetPath = targetPath;
+    this.parentPath = parentPath;
+  }
+}
+
+export class AtomicArtifactOperationUnsupportedError extends Error {
+  readonly code = "ARTIFACT_SAFE_OPERATION_UNSUPPORTED" as const;
+
+  constructor(
+    operation: "commit" | "cleanup" | "observe",
+    trustedRoot: string,
+  ) {
+    super(
+      `safe atomic artifact ${operation} is unsupported for trusted root: ${trustedRoot}`,
+    );
+    this.name = "AtomicArtifactOperationUnsupportedError";
+  }
+}
+
+export interface AtomicArtifactCommitOptions {
+  /** Existing directory that owns this exact, immediate-child artifact. */
+  readonly trustedRoot: string;
+  readonly mode?: number;
+}
+
+export interface AtomicArtifactCleanupOptions {
+  /** Existing directory that owns this exact, immediate-child artifact. */
+  readonly trustedRoot: string;
+  readonly maxDeletes?: number;
+}
+
+export interface OrphanedArtifactTempCleanupResult {
+  readonly removedCount: number;
+  /** More matching regular files remain because `maxDeletes` was reached. */
+  readonly truncated: boolean;
+}
+
+export type AtomicArtifactObservation = "missing" | "match" | "conflict";
+
+export interface AtomicArtifactObservationOptions {
+  readonly trustedRoot: string;
+  readonly cleanupOrphanedTemps?: boolean;
+  readonly maxDeletes?: number;
+}
+
+type AtomicArtifactOperation =
+  "commit" | "cleanup" | "cleanup_sync" | "observe";
+type AtomicArtifactOperationForTesting = (operation: {
+  readonly operation: AtomicArtifactOperation;
+  readonly targetPath: string;
+  readonly trustedRoot: string;
+}) => void | Promise<void>;
+
+let atomicArtifactOperationForTesting:
+  AtomicArtifactOperationForTesting | undefined;
+
+/** Test-only seam for deterministic trusted-root replacement races. */
+export function __setAtomicArtifactOperationForTesting(
+  operation: AtomicArtifactOperationForTesting | undefined,
+): void {
+  atomicArtifactOperationForTesting = operation;
+}
+
+/**
+ * Remove abandoned temp files for one exact artifact target.
+ *
+ * The caller must hold exclusive ownership of the recovered run. Only regular
+ * files in the target's trusted immediate parent whose names match
+ * `<target-basename>.*.tmp` are eligible; symlinks, directories, and sibling
+ * artifact prefixes are ignored. Deletion is bounded so corrupt/adversarial
+ * directories cannot turn restart recovery into an unbounded sweep.
+ */
+export async function cleanupOrphanedArtifactTemps(
+  targetPath: string,
+  options: AtomicArtifactCleanupOptions,
+): Promise<OrphanedArtifactTempCleanupResult> {
+  const maxDeletes = normalizedMaxDeletes(options.maxDeletes);
+  const scope = artifactScope(targetPath, options.trustedRoot);
+  const pinned = await pinTrustedRoot(scope, {
+    allowMissing: true,
+    operation: "cleanup",
+  });
+  if (pinned === undefined) {
+    return { removedCount: 0, truncated: false };
+  }
+
+  try {
+    await assertPinnedRootCurrent(scope, pinned);
+    await atomicArtifactOperationForTesting?.({
+      operation: "cleanup",
+      targetPath: scope.targetPath,
+      trustedRoot: scope.trustedRoot,
+    });
+    return await cleanupPinnedArtifactTemps(scope, pinned, maxDeletes);
+  } finally {
+    await closePinnedRoot(pinned);
+  }
+}
+
+/** Synchronous recovery-time companion to `cleanupOrphanedArtifactTemps`. */
+export function cleanupOrphanedArtifactTempsSync(
+  targetPath: string,
+  options: AtomicArtifactCleanupOptions,
+): OrphanedArtifactTempCleanupResult {
+  const maxDeletes = normalizedMaxDeletes(options.maxDeletes);
+  const scope = artifactScope(targetPath, options.trustedRoot);
+  const pinned = pinTrustedRootSync(scope, {
+    allowMissing: true,
+    operation: "cleanup",
+  });
+  if (pinned === undefined) {
+    return { removedCount: 0, truncated: false };
+  }
+
+  try {
+    assertPinnedRootCurrentSync(scope, pinned);
+    const hookResult = atomicArtifactOperationForTesting?.({
+      operation: "cleanup_sync",
+      targetPath: scope.targetPath,
+      trustedRoot: scope.trustedRoot,
+    });
+    if (hookResult instanceof Promise) {
+      throw new TypeError(
+        "synchronous artifact cleanup test hook returned a promise",
+      );
+    }
+    return cleanupPinnedArtifactTempsSync(scope, pinned, maxDeletes);
+  } finally {
+    closeSync(pinned.fd);
+  }
+}
+
+/**
+ * Observe one immutable artifact and consume that proof synchronously while
+ * its trusted root remains pinned.
+ *
+ * The callback is intentionally synchronous: recovery can append its durable
+ * journal decision before the root descriptor is released. POSIX child reads
+ * and optional temp cleanup resolve through that descriptor, so swapping the
+ * lexical root cannot redirect proof or deletion to an external directory.
+ */
+export function withAtomicArtifactObservationSync<T>(
+  targetPath: string,
+  expectedDigest: string,
+  expectedByteLength: number,
+  options: AtomicArtifactObservationOptions,
+  consume: (observation: AtomicArtifactObservation) => T,
+): T {
+  const scope = artifactScope(targetPath, options.trustedRoot);
+  if (!Number.isSafeInteger(expectedByteLength) || expectedByteLength < 0) {
+    return consume("conflict");
+  }
+  const pinned = pinTrustedRootSync(scope, {
+    allowMissing: true,
+    operation: "observe",
+  });
+  if (pinned === undefined) return consume("missing");
+
+  try {
+    assertPinnedRootCurrentSync(scope, pinned);
+    const hookResult = atomicArtifactOperationForTesting?.({
+      operation: "observe",
+      targetPath: scope.targetPath,
+      trustedRoot: scope.trustedRoot,
+    });
+    if (hookResult instanceof Promise) {
+      throw new TypeError(
+        "synchronous artifact observation test hook returned a promise",
+      );
+    }
+
+    const before = observePinnedArtifactSync(
+      scope,
+      pinned,
+      expectedDigest,
+      expectedByteLength,
+    );
+    if (
+      options.cleanupOrphanedTemps === true &&
+      (before.observation === "missing" || before.observation === "match")
+    ) {
+      cleanupPinnedArtifactTempsSync(
+        scope,
+        pinned,
+        normalizedMaxDeletes(options.maxDeletes),
+      );
+    }
+    assertPinnedRootCurrentSync(scope, pinned);
+    const immediatelyBeforeConsume = observePinnedArtifactSync(
+      scope,
+      pinned,
+      expectedDigest,
+      expectedByteLength,
+    );
+    if (!sameArtifactProof(before, immediatelyBeforeConsume)) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+
+    const result = consume(before.observation);
+    if (result instanceof Promise) {
+      throw new TypeError(
+        "atomic artifact observation callback returned a promise",
+      );
+    }
+    assertPinnedRootCurrentSync(scope, pinned);
+    const afterConsume = observePinnedArtifactSync(
+      scope,
+      pinned,
+      expectedDigest,
+      expectedByteLength,
+    );
+    if (!sameArtifactProof(before, afterConsume)) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+    return result;
+  } finally {
+    closeSync(pinned.fd);
+  }
+}
+
+function normalizedMaxDeletes(value: number | undefined): number {
+  const maxDeletes = value ?? 64;
+  if (
+    !Number.isSafeInteger(maxDeletes) ||
+    maxDeletes <= 0 ||
+    maxDeletes > 1_024
+  ) {
+    throw new TypeError("maxDeletes must be an integer between 1 and 1024");
+  }
+  return maxDeletes;
+}
+
+function isScopedTempName(name: string, prefix: string): boolean {
+  return (
+    name.startsWith(prefix) &&
+    name.endsWith(".tmp") &&
+    name.length > prefix.length + ".tmp".length
+  );
+}
+
+/**
+ * Publish immutable artifact bytes with temp + fsync + exclusive hard-link +
+ * directory fsync. A same-byte replay is an idempotent acknowledgement; a
+ * different-byte replay fails closed and never overwrites prior evidence.
+ */
+export async function commitArtifactAtomically(
+  targetPath: string,
+  bytes: string | Uint8Array,
+  options: AtomicArtifactCommitOptions,
+): Promise<AtomicArtifactCommitResult> {
+  const scope = artifactScope(targetPath, options.trustedRoot);
+  const pinned = await pinTrustedRoot(scope, {
+    allowMissing: false,
+    operation: "commit",
+  });
+  if (pinned === undefined) {
+    throw new AtomicArtifactUnsafePathError(
+      scope.targetPath,
+      scope.trustedRoot,
+    );
+  }
+
+  const tempName = `${scope.targetName}.${process.pid}.${randomUUID()}.tmp`;
+  const tempPath = join(pinned.operationPath, tempName);
+  const pinnedTargetPath = join(pinned.operationPath, scope.targetName);
+  const expected =
+    typeof bytes === "string" ? Buffer.from(bytes, "utf8") : Buffer.from(bytes);
+  let tempExists = false;
+  try {
+    await assertPinnedRootCurrent(scope, pinned);
+    await atomicArtifactOperationForTesting?.({
+      operation: "commit",
+      targetPath: scope.targetPath,
+      trustedRoot: scope.trustedRoot,
+    });
+
+    const handle = await open(
+      tempPath,
+      fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        noFollowFlag(),
+      options.mode ?? 0o600,
+    );
+    tempExists = true;
+    try {
+      const opened = await handle.stat();
+      if (!opened.isFile() || opened.nlink !== 1) {
+        throw new AtomicArtifactUnsafePathError(
+          scope.targetPath,
+          scope.trustedRoot,
+        );
+      }
+      await handle.writeFile(expected);
+      await handle.sync();
+      const afterWrite = await handle.stat();
+      if (!isSameIdentity(opened, afterWrite) || afterWrite.nlink !== 1) {
+        throw new AtomicArtifactUnsafePathError(
+          scope.targetPath,
+          scope.trustedRoot,
+        );
+      }
+    } finally {
+      await handle.close();
+    }
+
+    await assertPinnedRootCurrent(scope, pinned);
+    hitM4DurabilityFailpoint("before_artifact_commit");
+    let outcome: AtomicArtifactCommitResult = "committed";
+    try {
+      // link() is an atomic no-replace publication on the same filesystem.
+      // Unlike rename(), it cannot silently overwrite immutable evidence.
+      await link(tempPath, pinnedTargetPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const existing = await readExistingRegularFile(pinnedTargetPath);
+      if (existing === undefined || !existing.equals(expected)) {
+        throw new AtomicArtifactConflictError(scope.targetPath);
+      }
+      outcome = "already_committed";
+    }
+
+    await unlink(tempPath);
+    tempExists = false;
+    // This fsync belongs to both outcomes. In a concurrent same-byte race, the
+    // process that observed EEXIST may reach acknowledgement before the process
+    // that created the link; syncing here makes that answer independently
+    // durable rather than relying on the winner's next step.
+    await fsyncPinnedRoot(pinned);
+    await assertPinnedRootCurrent(scope, pinned);
+    hitM4DurabilityFailpoint("after_artifact_commit");
+    return outcome;
+  } finally {
+    if (tempExists) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // The durable target, if published, is independent of the temp link.
+      }
+    }
+    await closePinnedRoot(pinned);
+  }
+}
+
+interface ArtifactScope {
+  readonly targetPath: string;
+  readonly targetName: string;
+  readonly trustedRoot: string;
+}
+
+function artifactScope(targetPath: string, trustedRoot: string): ArtifactScope {
+  if (typeof trustedRoot !== "string" || trustedRoot.length === 0) {
+    throw new TypeError("artifact trustedRoot must be a non-empty path");
+  }
+  const resolvedTarget = resolve(targetPath);
+  const resolvedRoot = resolve(trustedRoot);
+  const targetName = basename(resolvedTarget);
+  if (
+    targetName.length === 0 ||
+    targetName === "." ||
+    targetName === ".." ||
+    relative(resolvedRoot, dirname(resolvedTarget)) !== ""
+  ) {
+    throw new AtomicArtifactUnsafePathError(resolvedTarget, resolvedRoot);
+  }
+  return {
+    targetPath: resolvedTarget,
+    targetName,
+    trustedRoot: resolvedRoot,
+  };
+}
+
+type AsyncDirectoryHandle = Awaited<ReturnType<typeof open>>;
+interface PinnedTrustedRoot {
+  readonly canonicalPath: string;
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+  readonly handle: AsyncDirectoryHandle;
+  readonly operationPath: string;
+}
+
+interface PinnedTrustedRootSync {
+  readonly canonicalPath: string;
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+  readonly fd: number;
+  readonly operationPath: string;
+}
+
+function isSameIdentity(
+  left: { readonly dev: number | bigint; readonly ino: number | bigint },
+  right: { readonly dev: number | bigint; readonly ino: number | bigint },
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function noFollowFlag(): number {
+  return (
+    (fsConstants as typeof fsConstants & { readonly O_NOFOLLOW?: number })
+      .O_NOFOLLOW ?? 0
+  );
+}
+
+function directoryOpenFlags(): number {
+  const directory =
+    (fsConstants as typeof fsConstants & { readonly O_DIRECTORY?: number })
+      .O_DIRECTORY ?? 0;
+  return fsConstants.O_RDONLY | directory | noFollowFlag();
+}
+
+function descriptorPaths(fd: number): readonly string[] {
+  if (process.platform === "linux") {
+    return [`/proc/self/fd/${fd}`, `/dev/fd/${fd}`];
+  }
+  if (process.platform !== "win32") return [`/dev/fd/${fd}`];
+  return [];
+}
+
+async function descriptorOperationPath(
+  handle: AsyncDirectoryHandle,
+  canonicalPath: string,
+): Promise<string | undefined> {
+  for (const candidate of descriptorPaths(handle.fd)) {
+    try {
+      if ((await realpath(candidate)) === canonicalPath) return candidate;
+    } catch {
+      // Optional descriptor aliases are probed below; an unavailable alias is
+      // not permission to fall back to a racy POSIX pathname.
+    }
+  }
+  return undefined;
+}
+
+function descriptorOperationPathSync(
+  fd: number,
+  canonicalPath: string,
+): string | undefined {
+  for (const candidate of descriptorPaths(fd)) {
+    try {
+      if (realpathSync(candidate) === canonicalPath) return candidate;
+    } catch {
+      // See the asynchronous descriptor probe above.
+    }
+  }
+  return undefined;
+}
+
+async function pinTrustedRoot(
+  scope: ArtifactScope,
+  options: {
+    readonly allowMissing: boolean;
+    readonly operation: "commit" | "cleanup";
+  },
+): Promise<PinnedTrustedRoot | undefined> {
+  let lexical;
+  try {
+    lexical = await lstat(scope.trustedRoot);
+  } catch (error) {
+    if (
+      options.allowMissing &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!lexical.isDirectory() || lexical.isSymbolicLink()) {
+    throw new AtomicArtifactUnsafePathError(
+      scope.targetPath,
+      scope.trustedRoot,
+    );
+  }
+  const canonicalPath = await realpath(scope.trustedRoot);
+
+  let handle: AsyncDirectoryHandle | undefined;
+  try {
+    try {
+      handle = await open(scope.trustedRoot, directoryOpenFlags());
+    } catch (error) {
+      if (
+        process.platform !== "win32" ||
+        !isUnsupportedWindowsDirectoryOperation(error)
+      ) {
+        throw error;
+      }
+      throw new AtomicArtifactOperationUnsupportedError(
+        options.operation,
+        scope.trustedRoot,
+      );
+    }
+
+    const opened = await handle.stat();
+    if (!opened.isDirectory() || !isSameIdentity(opened, lexical)) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+    const descriptorPath = await descriptorOperationPath(handle, canonicalPath);
+    if (descriptorPath === undefined) {
+      throw new AtomicArtifactOperationUnsupportedError(
+        options.operation,
+        scope.trustedRoot,
+      );
+    }
+
+    const pinned: PinnedTrustedRoot = {
+      canonicalPath,
+      dev: lexical.dev,
+      ino: lexical.ino,
+      handle,
+      operationPath: descriptorPath,
+    };
+    await assertPinnedRootCurrent(scope, pinned);
+    return pinned;
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    throw error;
+  }
+}
+
+function pinTrustedRootSync(
+  scope: ArtifactScope,
+  options: {
+    readonly allowMissing: boolean;
+    readonly operation: "cleanup" | "observe";
+  },
+): PinnedTrustedRootSync | undefined {
+  let lexical;
+  try {
+    lexical = lstatSync(scope.trustedRoot);
+  } catch (error) {
+    if (
+      options.allowMissing &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!lexical.isDirectory() || lexical.isSymbolicLink()) {
+    throw new AtomicArtifactUnsafePathError(
+      scope.targetPath,
+      scope.trustedRoot,
+    );
+  }
+  const canonicalPath = realpathSync(scope.trustedRoot);
+
+  let fd: number;
+  try {
+    fd = openSync(scope.trustedRoot, directoryOpenFlags());
+  } catch (error) {
+    if (
+      process.platform === "win32" &&
+      isUnsupportedWindowsDirectoryOperation(error)
+    ) {
+      throw new AtomicArtifactOperationUnsupportedError(
+        options.operation,
+        scope.trustedRoot,
+      );
+    }
+    throw error;
+  }
+
+  try {
+    const opened = fstatSync(fd);
+    const operationPath = descriptorOperationPathSync(fd, canonicalPath);
+    if (!opened.isDirectory() || !isSameIdentity(opened, lexical)) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+    if (operationPath === undefined) {
+      throw new AtomicArtifactOperationUnsupportedError(
+        options.operation,
+        scope.trustedRoot,
+      );
+    }
+    const pinned: PinnedTrustedRootSync = {
+      canonicalPath,
+      dev: lexical.dev,
+      ino: lexical.ino,
+      fd,
+      operationPath,
+    };
+    assertPinnedRootCurrentSync(scope, pinned);
+    return pinned;
+  } catch (error) {
+    closeSync(fd);
+    throw error;
+  }
+}
+
+async function assertPinnedRootCurrent(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRoot,
+): Promise<void> {
+  try {
+    const [lexical, canonical, opened] = await Promise.all([
+      lstat(scope.trustedRoot),
+      realpath(scope.trustedRoot),
+      pinned.handle.stat(),
+    ]);
+    if (
+      !lexical.isDirectory() ||
+      lexical.isSymbolicLink() ||
+      !isSameIdentity(lexical, pinned) ||
+      canonical !== pinned.canonicalPath ||
+      !opened.isDirectory() ||
+      !isSameIdentity(opened, pinned)
+    ) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+  } catch (error) {
+    if (error instanceof AtomicArtifactUnsafePathError) throw error;
+    throw new AtomicArtifactUnsafePathError(
+      scope.targetPath,
+      scope.trustedRoot,
+    );
+  }
+}
+
+function assertPinnedRootCurrentSync(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRootSync,
+): void {
+  try {
+    const lexical = lstatSync(scope.trustedRoot);
+    const canonical = realpathSync(scope.trustedRoot);
+    const opened = fstatSync(pinned.fd);
+    if (
+      !lexical.isDirectory() ||
+      lexical.isSymbolicLink() ||
+      !isSameIdentity(lexical, pinned) ||
+      canonical !== pinned.canonicalPath ||
+      !opened.isDirectory() ||
+      !isSameIdentity(opened, pinned)
+    ) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+  } catch (error) {
+    if (error instanceof AtomicArtifactUnsafePathError) throw error;
+    throw new AtomicArtifactUnsafePathError(
+      scope.targetPath,
+      scope.trustedRoot,
+    );
+  }
+}
+
+async function closePinnedRoot(pinned: PinnedTrustedRoot): Promise<void> {
+  await pinned.handle.close().catch(() => {});
+}
+
+async function cleanupPinnedArtifactTemps(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRoot,
+  maxDeletes: number,
+): Promise<OrphanedArtifactTempCleanupResult> {
+  const prefix = `${scope.targetName}.`;
+  const entries = await readdir(pinned.operationPath, { withFileTypes: true });
+  let removedCount = 0;
+  for (const entry of entries) {
+    if (!isScopedTempName(entry.name, prefix)) continue;
+    const candidate = join(pinned.operationPath, entry.name);
+    let stat;
+    try {
+      stat = await lstat(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+    if (!stat.isFile() || stat.isSymbolicLink()) continue;
+    if (removedCount >= maxDeletes) {
+      if (removedCount > 0) await fsyncPinnedRoot(pinned);
+      return { removedCount, truncated: true };
+    }
+    try {
+      await unlink(candidate);
+      removedCount += 1;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  if (removedCount > 0) await fsyncPinnedRoot(pinned);
+  await assertPinnedRootCurrent(scope, pinned);
+  return { removedCount, truncated: false };
+}
+
+function cleanupPinnedArtifactTempsSync(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRootSync,
+  maxDeletes: number,
+): OrphanedArtifactTempCleanupResult {
+  const prefix = `${scope.targetName}.`;
+  const entries = readdirSync(pinned.operationPath, { withFileTypes: true });
+  let removedCount = 0;
+  for (const entry of entries) {
+    if (!isScopedTempName(entry.name, prefix)) continue;
+    const candidate = join(pinned.operationPath, entry.name);
+    let stat;
+    try {
+      stat = lstatSync(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+    if (!stat.isFile() || stat.isSymbolicLink()) continue;
+    if (removedCount >= maxDeletes) {
+      if (removedCount > 0) fsyncPinnedRootSync(pinned);
+      return { removedCount, truncated: true };
+    }
+    try {
+      unlinkSync(candidate);
+      removedCount += 1;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  if (removedCount > 0) fsyncPinnedRootSync(pinned);
+  assertPinnedRootCurrentSync(scope, pinned);
+  return { removedCount, truncated: false };
+}
+
+interface PinnedArtifactProof {
+  readonly observation: AtomicArtifactObservation;
+  readonly targetIdentity?: {
+    readonly dev: number | bigint;
+    readonly ino: number | bigint;
+  };
+}
+
+function observePinnedArtifactSync(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRootSync,
+  expectedDigest: string,
+  expectedByteLength: number,
+): PinnedArtifactProof {
+  const targetPath = join(pinned.operationPath, scope.targetName);
+  let pathStat;
+  try {
+    pathStat = lstatSync(targetPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { observation: "missing" };
+    }
+    throw error;
+  }
+  if (
+    !pathStat.isFile() ||
+    pathStat.isSymbolicLink() ||
+    pathStat.size !== expectedByteLength
+  ) {
+    return { observation: "conflict" };
+  }
+
+  let fd: number | undefined;
+  try {
+    fd = openSync(targetPath, fsConstants.O_RDONLY | noFollowFlag());
+    const opened = fstatSync(fd);
+    if (
+      !opened.isFile() ||
+      !isSameIdentity(opened, pathStat) ||
+      opened.size !== expectedByteLength
+    ) {
+      return { observation: "conflict" };
+    }
+    const bytes = readFileSync(fd);
+    const afterRead = fstatSync(fd);
+    let pathAfterRead;
+    try {
+      pathAfterRead = lstatSync(targetPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { observation: "conflict" };
+      }
+      throw error;
+    }
+    if (
+      !afterRead.isFile() ||
+      !isSameIdentity(opened, afterRead) ||
+      !pathAfterRead.isFile() ||
+      pathAfterRead.isSymbolicLink() ||
+      !isSameIdentity(opened, pathAfterRead) ||
+      bytes.byteLength !== expectedByteLength
+    ) {
+      return { observation: "conflict" };
+    }
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    return digest === expectedDigest
+      ? {
+          observation: "match",
+          targetIdentity: { dev: opened.dev, ino: opened.ino },
+        }
+      : { observation: "conflict" };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ELOOP" || code === "EISDIR") {
+      return { observation: "conflict" };
+    }
+    throw error;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function sameArtifactProof(
+  left: PinnedArtifactProof,
+  right: PinnedArtifactProof,
+): boolean {
+  if (left.observation !== right.observation) return false;
+  if (left.observation !== "match") return true;
+  return (
+    left.targetIdentity !== undefined &&
+    right.targetIdentity !== undefined &&
+    isSameIdentity(left.targetIdentity, right.targetIdentity)
+  );
+}
+
+async function readExistingRegularFile(
+  targetPath: string,
+): Promise<Buffer | undefined> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    // Reject links even on platforms that do not expose O_NOFOLLOW. POSIX then
+    // also uses O_NOFOLLOW below to close the lstat/open replacement race.
+    const pathStat = await lstat(targetPath);
+    if (!pathStat.isFile() || pathStat.isSymbolicLink()) return undefined;
+    handle = await open(targetPath, fsConstants.O_RDONLY | noFollowFlag());
+    const opened = await handle.stat();
+    if (!opened.isFile() || !isSameIdentity(opened, pathStat)) return undefined;
+    const bytes = await handle.readFile();
+    const afterRead = await handle.stat();
+    if (!isSameIdentity(opened, afterRead)) return undefined;
+    return bytes;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ELOOP" || code === "EISDIR") {
+      return undefined;
+    }
+    throw error;
+  } finally {
+    await handle?.close();
+  }
+}
+
+const WINDOWS_UNSUPPORTED_DIRECTORY_CODES = new Set([
+  "EBADF",
+  "EISDIR",
+  "EINVAL",
+  "ENOTSUP",
+  "EPERM",
+]);
+
+function isUnsupportedWindowsDirectoryOperation(error: unknown): boolean {
+  return WINDOWS_UNSUPPORTED_DIRECTORY_CODES.has(
+    (error as NodeJS.ErrnoException).code ?? "",
+  );
+}
+
+async function fsyncPinnedRoot(pinned: PinnedTrustedRoot): Promise<void> {
+  try {
+    await pinned.handle.sync();
+  } catch (error) {
+    // Never hide I/O or capacity failures. Only Windows' documented lack of
+    // directory-fsync support is an acceptable portable limitation.
+    if (
+      process.platform !== "win32" ||
+      !isUnsupportedWindowsDirectoryOperation(error)
+    ) {
+      throw error;
+    }
+  }
+}
+
+function fsyncPinnedRootSync(pinned: PinnedTrustedRootSync): void {
+  try {
+    fsyncSync(pinned.fd);
+  } catch (error) {
+    if (
+      process.platform !== "win32" ||
+      !isUnsupportedWindowsDirectoryOperation(error)
+    ) {
+      throw error;
+    }
+  }
+}

--- a/runtime/src/durability/failpoints.ts
+++ b/runtime/src/durability/failpoints.ts
@@ -1,0 +1,97 @@
+/**
+ * Process-level crash injection for the M4 durability acceptance matrix.
+ *
+ * These hooks are deliberately inert unless all three test-only environment
+ * controls are present. Production configuration cannot accidentally turn a
+ * boundary probe into a daemon kill. The child-process acceptance harness sets
+ * the controls, waits for the fsynced marker, and then inspects recovery state
+ * after the process exits.
+ */
+
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  writeSync,
+} from "node:fs";
+
+export const M4_DURABILITY_FAILPOINTS = [
+  "after_admission_sqlite_commit_before_canonical_append",
+  "before_reservation_commit",
+  "after_reservation_commit",
+  "before_model_response_commit",
+  "after_model_response_commit",
+  "before_tool_spawn",
+  "after_tool_spawn",
+  "before_tool_ack_commit",
+  "after_tool_ack_commit",
+  "before_artifact_commit",
+  "after_artifact_commit",
+  "before_event_publish",
+  "after_event_publish",
+  "before_terminal_commit",
+  "after_terminal_commit",
+] as const;
+
+export type M4DurabilityFailpoint =
+  (typeof M4_DURABILITY_FAILPOINTS)[number];
+
+const FAILPOINT_ENV = "AGENC_TEST_DURABILITY_FAILPOINT";
+const FAILPOINT_TOKEN_ENV = "AGENC_TEST_DURABILITY_FAILPOINT_TOKEN";
+const FAILPOINT_ACTION_ENV = "AGENC_TEST_DURABILITY_FAILPOINT_ACTION";
+const FAILPOINT_MARKER_ENV = "AGENC_TEST_DURABILITY_FAILPOINT_MARKER";
+const FAILPOINT_TOKEN = "m4-durability-child";
+
+export class M4DurabilityFailpointError extends Error {
+  readonly failpoint: M4DurabilityFailpoint;
+
+  constructor(failpoint: M4DurabilityFailpoint) {
+    super(`M4 durability failpoint reached: ${failpoint}`);
+    this.name = "M4DurabilityFailpointError";
+    this.failpoint = failpoint;
+  }
+}
+
+/**
+ * Crash (the default) or throw at one named durability boundary.
+ *
+ * `throw` exists for focused unit tests. Acceptance tests use the default
+ * SIGKILL action so no finally block, shutdown hook, or buffered write can
+ * make the simulated crash safer than a real daemon loss.
+ */
+export function hitM4DurabilityFailpoint(
+  failpoint: M4DurabilityFailpoint,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env[FAILPOINT_ENV] !== failpoint) return;
+  if (env[FAILPOINT_TOKEN_ENV] !== FAILPOINT_TOKEN) return;
+
+  const markerPath = env[FAILPOINT_MARKER_ENV];
+  if (markerPath !== undefined && markerPath.length > 0) {
+    writeMarkerDurably(markerPath, failpoint);
+  }
+
+  if (env[FAILPOINT_ACTION_ENV] === "throw") {
+    throw new M4DurabilityFailpointError(failpoint);
+  }
+
+  process.kill(process.pid, "SIGKILL");
+}
+
+function writeMarkerDurably(
+  markerPath: string,
+  failpoint: M4DurabilityFailpoint,
+): void {
+  const fd = openSync(markerPath, "w", 0o600);
+  try {
+    writeSync(
+      fd,
+      `${JSON.stringify({ failpoint, pid: process.pid })}\n`,
+      undefined,
+      "utf8",
+    );
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/runtime/src/durability/offline-rollout.ts
+++ b/runtime/src/durability/offline-rollout.ts
@@ -1,0 +1,516 @@
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  ftruncateSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  realpathSync,
+  writeSync,
+} from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+
+import { SessionLock } from "../session/session-store.js";
+
+export class OfflineRolloutSourceMissingError extends Error {
+  constructor(sourcePath: string) {
+    super(`offline canonical rollout is missing: ${sourcePath}`);
+    this.name = "OfflineRolloutSourceMissingError";
+  }
+}
+
+export class OfflineRolloutUnsafePathError extends Error {
+  constructor(sourcePath: string, detail: string) {
+    super(`unsafe offline canonical rollout ${sourcePath}: ${detail}`);
+    this.name = "OfflineRolloutUnsafePathError";
+  }
+}
+
+export interface PinnedOfflineRollout {
+  readonly sourcePath: string;
+  /** Current metadata read from the retained source descriptor. */
+  stat(): { readonly size: number; readonly mtimeMs: number };
+  /** Read the complete repaired rollout through the retained source fd. */
+  readUtf8(): string;
+  /** Append one or more complete JSONL records and fsync before returning. */
+  appendAndSync(content: string): void;
+  /** Re-establish an fsync proof without appending duplicate evidence. */
+  sync(): void;
+}
+
+/**
+ * Mutate a stopped canonical rollout without reopening any trusted object by
+ * pathname. The exact project/root/session directory chain and source inode
+ * remain pinned across lease acquisition, tail repair, read, append, and
+ * fsync. Path replacement therefore fails closed without redirecting writes.
+ */
+export function withPinnedOfflineRolloutLease<T>(
+  options: {
+    readonly projectDir: string;
+    readonly sessionId: string;
+    readonly sourcePath: string;
+  },
+  operation: (rollout: PinnedOfflineRollout) => T,
+): T {
+  const scope = offlineRolloutScope(options);
+  const pinned = pinOfflineRollout(scope);
+  const lockPath = join(
+    pinned.sessionDirectory.operationPath,
+    `${scope.sourceName}.lock`,
+  );
+  const lock = new SessionLock(lockPath);
+  let fd: number | undefined;
+  try {
+    assertNotHeldByCurrentProcess(lockPath, scope.sourcePath);
+    lock.acquire();
+    assertPinnedDirectoriesCurrent(scope, pinned);
+    assertSourcePathIdentity(scope, pinned, pinned.sourceIdentity);
+    fd = openSync(
+      join(pinned.sessionDirectory.operationPath, scope.sourceName),
+      fsConstants.O_RDWR | fsConstants.O_APPEND | noFollowFlag(),
+    );
+    assertOpenSourceIdentity(scope, pinned, fd);
+    truncateCorruptTailOnDescriptor(fd);
+    assertOpenSourceIdentity(scope, pinned, fd);
+
+    const sourceFd = fd;
+    const rollout: PinnedOfflineRollout = {
+      sourcePath: scope.sourcePath,
+      stat: () => {
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+        const current = fstatSync(sourceFd);
+        return { size: current.size, mtimeMs: current.mtimeMs };
+      },
+      readUtf8: () => {
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+        const raw = readDescriptorUtf8(sourceFd);
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+        return raw;
+      },
+      appendAndSync: (content) => {
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+        appendAndSync(sourceFd, content, scope.sourcePath);
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+      },
+      sync: () => {
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+        fsyncSync(sourceFd);
+        assertOpenSourceIdentity(scope, pinned, sourceFd);
+      },
+    };
+    return operation(rollout);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    lock.release();
+    closePinnedOfflineRollout(pinned);
+  }
+}
+
+interface FileIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+interface OfflineRolloutScope {
+  readonly projectDir: string;
+  readonly journalRoot: string;
+  readonly sessionDirectory: string;
+  readonly sourcePath: string;
+  readonly sourceName: string;
+}
+
+interface PinnedDirectory extends FileIdentity {
+  readonly path: string;
+  readonly canonicalPath: string;
+  readonly fd: number;
+  readonly operationPath: string;
+}
+
+interface PinnedOfflineRolloutState {
+  readonly projectDirectory: PinnedDirectory;
+  readonly journalRoot: PinnedDirectory;
+  readonly sessionDirectory: PinnedDirectory;
+  readonly sourceIdentity: FileIdentity;
+}
+
+function offlineRolloutScope(options: {
+  readonly projectDir: string;
+  readonly sessionId: string;
+  readonly sourcePath: string;
+}): OfflineRolloutScope {
+  const resolvedProject = resolve(options.projectDir);
+  const resolvedSource = resolve(options.sourcePath);
+  const sourceName = basename(resolvedSource);
+  if (
+    !isAbsolute(options.sourcePath) ||
+    options.sourcePath !== resolvedSource ||
+    basename(options.sessionId) !== options.sessionId ||
+    options.sessionId.length === 0 ||
+    sourceName !== basename(options.sourcePath) ||
+    !sourceName.startsWith("rollout-") ||
+    !sourceName.endsWith(".jsonl")
+  ) {
+    throw new OfflineRolloutUnsafePathError(
+      options.sourcePath,
+      "path is not an exact canonical rollout path",
+    );
+  }
+  for (const rootName of ["sessions", "archived_sessions"] as const) {
+    const journalRoot = join(resolvedProject, rootName);
+    const sessionDirectory = join(journalRoot, options.sessionId);
+    if (dirname(resolvedSource) === sessionDirectory) {
+      return {
+        projectDir: resolvedProject,
+        journalRoot,
+        sessionDirectory,
+        sourcePath: resolvedSource,
+        sourceName,
+      };
+    }
+  }
+  throw new OfflineRolloutUnsafePathError(
+    options.sourcePath,
+    "path is outside this project's sessions/archived_sessions roots",
+  );
+}
+
+function pinOfflineRollout(
+  scope: OfflineRolloutScope,
+): PinnedOfflineRolloutState {
+  const opened: PinnedDirectory[] = [];
+  try {
+    const projectDirectory = pinDirectory(scope.projectDir);
+    opened.push(projectDirectory);
+    const journalRoot = pinDirectory(
+      scope.journalRoot,
+      projectDirectory,
+      basename(scope.journalRoot),
+    );
+    opened.push(journalRoot);
+    const sessionDirectory = pinDirectory(
+      scope.sessionDirectory,
+      journalRoot,
+      basename(scope.sessionDirectory),
+    );
+    opened.push(sessionDirectory);
+    const sourceIdentity = requireRegularSource(
+      scope,
+      join(sessionDirectory.operationPath, scope.sourceName),
+    );
+    const pinned = {
+      projectDirectory,
+      journalRoot,
+      sessionDirectory,
+      sourceIdentity,
+    };
+    assertPinnedDirectoriesCurrent(scope, pinned);
+    assertSourcePathIdentity(scope, pinned, sourceIdentity);
+    return pinned;
+  } catch (error) {
+    for (const directory of opened.reverse()) closeSync(directory.fd);
+    throw error;
+  }
+}
+
+function pinDirectory(
+  path: string,
+  parent?: PinnedDirectory,
+  childName?: string,
+): PinnedDirectory {
+  let lexical;
+  try {
+    lexical = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new OfflineRolloutSourceMissingError(path);
+    }
+    throw error;
+  }
+  if (!lexical.isDirectory() || lexical.isSymbolicLink()) {
+    throw new OfflineRolloutUnsafePathError(path, "directory is not trusted");
+  }
+  const openPath =
+    parent === undefined
+      ? path
+      : join(parent.operationPath, childName ?? basename(path));
+  const fd = openSync(openPath, directoryOpenFlags());
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isDirectory() || !sameIdentity(opened, lexical)) {
+      throw new OfflineRolloutUnsafePathError(
+        path,
+        "directory changed while it was opened",
+      );
+    }
+    const canonicalPath = realpathSync(path);
+    const operationPath = descriptorOperationPath(fd, canonicalPath);
+    if (operationPath === undefined) {
+      throw new OfflineRolloutUnsafePathError(
+        path,
+        "platform has no descriptor-relative directory path",
+      );
+    }
+    return {
+      path,
+      canonicalPath,
+      dev: opened.dev,
+      ino: opened.ino,
+      fd,
+      operationPath,
+    };
+  } catch (error) {
+    closeSync(fd);
+    throw error;
+  }
+}
+
+function requireRegularSource(
+  scope: OfflineRolloutScope,
+  operationPath: string,
+): FileIdentity {
+  let source;
+  try {
+    source = lstatSync(operationPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new OfflineRolloutSourceMissingError(scope.sourcePath);
+    }
+    throw error;
+  }
+  if (!source.isFile() || source.isSymbolicLink() || source.nlink !== 1) {
+    throw new OfflineRolloutUnsafePathError(
+      scope.sourcePath,
+      "source must be one regular, non-linked file",
+    );
+  }
+  return { dev: source.dev, ino: source.ino };
+}
+
+function assertPinnedDirectoriesCurrent(
+  scope: OfflineRolloutScope,
+  pinned: PinnedOfflineRolloutState,
+): void {
+  for (const directory of [
+    pinned.projectDirectory,
+    pinned.journalRoot,
+    pinned.sessionDirectory,
+  ]) {
+    try {
+      const lexical = lstatSync(directory.path);
+      const opened = fstatSync(directory.fd);
+      if (
+        !lexical.isDirectory() ||
+        lexical.isSymbolicLink() ||
+        !opened.isDirectory() ||
+        !sameIdentity(lexical, directory) ||
+        !sameIdentity(opened, directory) ||
+        realpathSync(directory.path) !== directory.canonicalPath
+      ) {
+        throw new Error("identity changed");
+      }
+    } catch {
+      throw new OfflineRolloutUnsafePathError(
+        scope.sourcePath,
+        `directory changed during offline mutation: ${directory.path}`,
+      );
+    }
+  }
+}
+
+function assertSourcePathIdentity(
+  scope: OfflineRolloutScope,
+  pinned: PinnedOfflineRolloutState,
+  expected: FileIdentity,
+): void {
+  try {
+    const absolute = lstatSync(scope.sourcePath);
+    const descriptorRelative = lstatSync(
+      join(pinned.sessionDirectory.operationPath, scope.sourceName),
+    );
+    if (
+      !absolute.isFile() ||
+      absolute.isSymbolicLink() ||
+      absolute.nlink !== 1 ||
+      !descriptorRelative.isFile() ||
+      descriptorRelative.isSymbolicLink() ||
+      descriptorRelative.nlink !== 1 ||
+      !sameIdentity(absolute, expected) ||
+      !sameIdentity(descriptorRelative, expected)
+    ) {
+      throw new Error("identity changed");
+    }
+  } catch {
+    throw new OfflineRolloutUnsafePathError(
+      scope.sourcePath,
+      "source changed during offline mutation",
+    );
+  }
+}
+
+function assertOpenSourceIdentity(
+  scope: OfflineRolloutScope,
+  pinned: PinnedOfflineRolloutState,
+  fd: number,
+): void {
+  assertPinnedDirectoriesCurrent(scope, pinned);
+  assertSourcePathIdentity(scope, pinned, pinned.sourceIdentity);
+  const opened = fstatSync(fd);
+  if (
+    !opened.isFile() ||
+    opened.nlink !== 1 ||
+    !sameIdentity(opened, pinned.sourceIdentity)
+  ) {
+    throw new OfflineRolloutUnsafePathError(
+      scope.sourcePath,
+      "opened source identity changed during offline mutation",
+    );
+  }
+}
+
+function closePinnedOfflineRollout(pinned: PinnedOfflineRolloutState): void {
+  closeSync(pinned.sessionDirectory.fd);
+  closeSync(pinned.journalRoot.fd);
+  closeSync(pinned.projectDirectory.fd);
+}
+
+function sameIdentity(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function noFollowFlag(): number {
+  return (
+    (fsConstants as typeof fsConstants & { readonly O_NOFOLLOW?: number })
+      .O_NOFOLLOW ?? 0
+  );
+}
+
+function directoryOpenFlags(): number {
+  return (
+    fsConstants.O_RDONLY |
+    ((fsConstants as typeof fsConstants & { readonly O_DIRECTORY?: number })
+      .O_DIRECTORY ?? 0) |
+    noFollowFlag()
+  );
+}
+
+function descriptorOperationPath(
+  fd: number,
+  canonicalPath: string,
+): string | undefined {
+  const candidates =
+    process.platform === "linux"
+      ? [`/proc/self/fd/${fd}`, `/dev/fd/${fd}`]
+      : process.platform === "win32"
+        ? []
+        : [`/dev/fd/${fd}`];
+  for (const candidate of candidates) {
+    try {
+      if (realpathSync(candidate) === canonicalPath) return candidate;
+    } catch {
+      // Absence of a descriptor alias is not permission to fall back to a
+      // pathname that can be replaced during offline mutation.
+    }
+  }
+  return undefined;
+}
+
+function truncateCorruptTailOnDescriptor(fd: number): void {
+  const stat = fstatSync(fd);
+  if (stat.size === 0) return;
+  const chunkSize = 1024 * 1024;
+  let cursor = stat.size;
+  let committedSize = 0;
+  while (cursor > 0) {
+    const length = Math.min(chunkSize, cursor);
+    const position = cursor - length;
+    const buffer = Buffer.allocUnsafe(length);
+    readDescriptorBytes(fd, buffer, position);
+    const lastNewline = buffer.lastIndexOf(0x0a);
+    if (lastNewline !== -1) {
+      committedSize = position + lastNewline + 1;
+      break;
+    }
+    cursor = position;
+  }
+  if (committedSize === stat.size) return;
+  ftruncateSync(fd, committedSize);
+  fsyncSync(fd);
+}
+
+function readDescriptorUtf8(fd: number): string {
+  const size = fstatSync(fd).size;
+  const bytes = Buffer.alloc(size);
+  readDescriptorBytes(fd, bytes, 0);
+  return bytes.toString("utf8");
+}
+
+function readDescriptorBytes(
+  fd: number,
+  bytes: Buffer,
+  position: number,
+): void {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const read = readSync(
+      fd,
+      bytes,
+      offset,
+      bytes.length - offset,
+      position + offset,
+    );
+    if (read <= 0) {
+      throw new Error("failed to read complete offline canonical rollout");
+    }
+    offset += read;
+  }
+}
+
+function appendAndSync(fd: number, content: string, sourcePath: string): void {
+  const bytes = Buffer.from(content, "utf8");
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = writeSync(fd, bytes, offset, bytes.length - offset);
+    if (written <= 0) {
+      throw new Error(`failed to append offline canonical rollout ${sourcePath}`);
+    }
+    offset += written;
+  }
+  fsyncSync(fd);
+}
+
+function assertNotHeldByCurrentProcess(
+  lockPath: string,
+  sourcePath: string,
+): void {
+  if (!existsSync(lockPath)) return;
+  try {
+    const lockStat = lstatSync(lockPath);
+    if (!lockStat.isFile() || lockStat.isSymbolicLink() || lockStat.nlink !== 1) {
+      throw new OfflineRolloutUnsafePathError(
+        sourcePath,
+        "journal lease path is not a regular file",
+      );
+    }
+    const parsed = JSON.parse(readFileSync(lockPath, "utf8")) as {
+      readonly pid?: unknown;
+    };
+    if (parsed.pid === process.pid) {
+      throw new Error(
+        `canonical journal is live in this process (${lockPath}); stop the session before offline mutation`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof OfflineRolloutUnsafePathError) throw error;
+    if (
+      error instanceof Error &&
+      error.message.startsWith("canonical journal is live in this process")
+    ) {
+      throw error;
+    }
+    // SessionLock performs the authoritative stale/unreadable lock handling.
+  }
+}

--- a/runtime/src/eval-executor/trust-run.ts
+++ b/runtime/src/eval-executor/trust-run.ts
@@ -223,9 +223,10 @@ function openDriver(attemptDir: string): StateSqliteDriver {
  */
 function durableStateDigest(driver: StateSqliteDriver): Sha256Digest {
   const runs = driver
-    .prepareState<[], { id?: string; status?: string; last_active_at?: string }>(
-      "SELECT id, status, last_active_at FROM agent_runs ORDER BY id",
-    )
+    .prepareState<
+      [],
+      { id?: string; status?: string; last_active_at?: string }
+    >("SELECT id, status, last_active_at FROM agent_runs ORDER BY id")
     .all();
   const toolCalls = driver
     .prepareState<
@@ -323,7 +324,9 @@ function durableStateDigest(driver: StateSqliteDriver): Sha256Digest {
 // Scenario drivers (one per suite scenario, keyed by scenarioId)
 // ---------------------------------------------------------------------------
 
-async function runRestartAfterReservation(ctx: ScenarioContext): Promise<ScenarioRun> {
+async function runRestartAfterReservation(
+  ctx: ScenarioContext,
+): Promise<ScenarioRun> {
   const { clock, evidence, attemptDir } = ctx;
   const doneRunId = "trust_restart_done";
   const liveRunId = "trust_restart_running";
@@ -384,11 +387,8 @@ async function runRestartAfterReservation(ctx: ScenarioContext): Promise<Scenari
         now: nowIso(),
       });
       if (claim.kind !== "claimed") {
-        const reason =
-          claim.kind === "not_claimed" ? claim.reason : claim.kind;
-        throw new Error(
-          `restart scenario could not reserve budget: ${reason}`,
-        );
+        const reason = claim.kind === "not_claimed" ? claim.reason : claim.kind;
+        throw new Error(`restart scenario could not reserve budget: ${reason}`);
       }
       reservationId = claim.lease.reservation.reservationId;
       reservedSpend = claim.lease.reservation.reservedCostUsd;
@@ -507,8 +507,7 @@ async function runRestartAfterReservation(ctx: ScenarioContext): Promise<Scenari
         reservationStatus: recoveredReservationStatus,
       });
 
-      const secondAdmissionRecovery =
-        restartedKernel.initializeExistingState();
+      const secondAdmissionRecovery = restartedKernel.initializeExistingState();
       secondAdmissionHeldUnknown = secondAdmissionRecovery.heldUnknown;
       const second = recoverDaemonStateOnStartup(driver, { now: nowIso });
       const secondCall = second.recoveredToolCalls.find(
@@ -557,20 +556,30 @@ async function runRestartAfterReservation(ctx: ScenarioContext): Promise<Scenari
     injectedAtVirtualMs,
     faultEvidenceDigest,
     invariantResults: [
-      invariant(evidence, "reservation_recovered_once", reservationRecoveredOnce, {
-        reservedSpend,
-        recoveredSpend,
-        recoveredHeldSpend,
-        recoveredUsedSpend,
-        recoveredReservationStatus,
-        firstAdmissionHeldUnknown,
-        secondAdmissionHeldUnknown,
-      }),
-      invariant(evidence, "no_duplicate_state_transition", noDuplicateTransition, {
-        firstPassStatusAfter,
-        secondPassStatusBefore,
-        stateDigestStable: digestAfterFirstPass === digestAfterSecondPass,
-      }),
+      invariant(
+        evidence,
+        "reservation_recovered_once",
+        reservationRecoveredOnce,
+        {
+          reservedSpend,
+          recoveredSpend,
+          recoveredHeldSpend,
+          recoveredUsedSpend,
+          recoveredReservationStatus,
+          firstAdmissionHeldUnknown,
+          secondAdmissionHeldUnknown,
+        },
+      ),
+      invariant(
+        evidence,
+        "no_duplicate_state_transition",
+        noDuplicateTransition,
+        {
+          firstPassStatusAfter,
+          secondPassStatusBefore,
+          stateDigestStable: digestAfterFirstPass === digestAfterSecondPass,
+        },
+      ),
       invariant(evidence, "terminal_result_queryable", terminalQueryable, {
         terminalStatus,
       }),
@@ -592,7 +601,25 @@ function eventIdOf(event: JsonObject): string | null {
 }
 
 function eventTypeOf(event: JsonObject): string | null {
-  return typeof event.type === "string" ? event.type : null;
+  if (typeof event.type === "string") return event.type;
+  if (event.method !== "event.event_gap") return null;
+  const params = event.params;
+  return params !== null &&
+    typeof params === "object" &&
+    !Array.isArray(params) &&
+    (params as JsonObject).type === EVENT_GAP_EVENT
+    ? EVENT_GAP_EVENT
+    : null;
+}
+
+function retiredCountOf(event: JsonObject): number {
+  if (typeof event.retiredCount === "number") return event.retiredCount;
+  const params = event.params;
+  if (params === null || typeof params !== "object" || Array.isArray(params)) {
+    return 0;
+  }
+  const retiredCount = (params as JsonObject).retiredCount;
+  return typeof retiredCount === "number" ? retiredCount : 0;
 }
 
 interface MultiplexerHarness {
@@ -628,7 +655,9 @@ async function createMultiplexerHarness(options: {
   return { sessionManager, multiplexer, sessionId: options.sessionId };
 }
 
-async function runReconnectAfterUnackedEvent(ctx: ScenarioContext): Promise<ScenarioRun> {
+async function runReconnectAfterUnackedEvent(
+  ctx: ScenarioContext,
+): Promise<ScenarioRun> {
   const { clock, evidence } = ctx;
   // publish_event: events land in the REAL daemon client multiplexer's
   // detached-session replay buffer (no client attached yet).
@@ -780,7 +809,9 @@ async function runReconnectAfterUnackedEvent(ctx: ScenarioContext): Promise<Scen
   };
 }
 
-async function runBudgetSiblingReservationRace(ctx: ScenarioContext): Promise<ScenarioRun> {
+async function runBudgetSiblingReservationRace(
+  ctx: ScenarioContext,
+): Promise<ScenarioRun> {
   const { clock, evidence, attemptDir } = ctx;
   const parentRunId = "trust_parent_budget";
   const now = () => clock.wallDate();
@@ -945,14 +976,14 @@ async function runBudgetSiblingReservationRace(ctx: ScenarioContext): Promise<Sc
       unknownStatus:
         lostHold === undefined
           ? null
-          : repositories[0]!.getReservation(lostHold.reservationId)?.status ??
-            null,
+          : (repositories[0]!.getReservation(lostHold.reservationId)?.status ??
+            null),
     });
     const lostStatus =
       lostHold === undefined
         ? null
-        : repositories[0]!.getReservation(lostHold.reservationId)?.status ??
-          null;
+        : (repositories[0]!.getReservation(lostHold.reservationId)?.status ??
+          null);
     const expectedHeld =
       lostHold === undefined
         ? null
@@ -1033,7 +1064,9 @@ async function runBudgetSiblingReservationRace(ctx: ScenarioContext): Promise<Sc
   }
 }
 
-async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise<ScenarioRun> {
+async function runCancelParentAfterChildAdmission(
+  ctx: ScenarioContext,
+): Promise<ScenarioRun> {
   const { clock, evidence, attemptDir } = ctx;
   const parentId = "trust_cancel_parent";
   const runningChildId = "trust_cancel_child";
@@ -1047,16 +1080,25 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
     clock.advance(5);
     const startedAt = nowIso();
     upsertAgentRun(driver, {
-      id: parentId, objective: "parent", status: "running",
-      startedAt, lastActiveAt: startedAt,
+      id: parentId,
+      objective: "parent",
+      status: "running",
+      startedAt,
+      lastActiveAt: startedAt,
     });
     upsertAgentRun(driver, {
-      id: runningChildId, objective: "running child", status: "running",
-      startedAt, lastActiveAt: startedAt,
+      id: runningChildId,
+      objective: "running child",
+      status: "running",
+      startedAt,
+      lastActiveAt: startedAt,
     });
     upsertAgentRun(driver, {
-      id: queuedChildId, objective: "queued child", status: "pending",
-      startedAt, lastActiveAt: startedAt,
+      id: queuedChildId,
+      objective: "queued child",
+      status: "pending",
+      startedAt,
+      lastActiveAt: startedAt,
     });
     const edges = new ThreadSpawnEdgeRepository(driver);
     edges.create({
@@ -1124,7 +1166,9 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
     clock.advance(5);
     const statusOf = (id: string): string | null =>
       driver
-        .prepareState<[string], { status?: string }>("SELECT status FROM agent_runs WHERE id = ?")
+        .prepareState<[string], { status?: string }>(
+          "SELECT status FROM agent_runs WHERE id = ?",
+        )
         .get(id)?.status ?? null;
     const runningChildStatus = statusOf(runningChildId);
     const queuedChildStatus = statusOf(queuedChildId);
@@ -1140,8 +1184,11 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
     // cancelled parent cannot be revived by an upsert (status laundering).
     const lateChildId = "trust_cancel_child_late";
     upsertAgentRun(driver, {
-      id: lateChildId, objective: "late child",
-      status: "running", startedAt, lastActiveAt: startedAt,
+      id: lateChildId,
+      objective: "late child",
+      status: "running",
+      startedAt,
+      lastActiveAt: startedAt,
     });
     let admissionBlockedTyped = false;
     try {
@@ -1162,8 +1209,11 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
     }
     const lateEdgeAbsent = edges.get(lateChildId) === undefined;
     const reviveOutcome = upsertAgentRun(driver, {
-      id: parentId, objective: "parent", status: "running",
-      startedAt, lastActiveAt: nowIso(),
+      id: parentId,
+      objective: "parent",
+      status: "running",
+      startedAt,
+      lastActiveAt: nowIso(),
     });
     const reviveRejected =
       reviveOutcome.applied === false && statusOf(parentId) === "cancelled";
@@ -1198,25 +1248,35 @@ async function runCancelParentAfterChildAdmission(ctx: ScenarioContext): Promise
       injectedAtVirtualMs,
       faultEvidenceDigest,
       invariantResults: [
-        invariant(evidence, "descendant_admission_stopped", newAdmissionRefused, {
-          probes: [
-            "post-cancel spawn-edge create (typed SpawnAdmissionBlockedError)",
-            "refused edge absent from thread_spawn_edges",
-            "post-cancel parent revive upsert rejected (cancel-lock sticky)",
-          ],
-          admissionBlockedTyped,
-          lateEdgeAbsent,
-          reviveRejected,
-        }),
+        invariant(
+          evidence,
+          "descendant_admission_stopped",
+          newAdmissionRefused,
+          {
+            probes: [
+              "post-cancel spawn-edge create (typed SpawnAdmissionBlockedError)",
+              "refused edge absent from thread_spawn_edges",
+              "post-cancel parent revive upsert rejected (cancel-lock sticky)",
+            ],
+            admissionBlockedTyped,
+            lateEdgeAbsent,
+            reviveRejected,
+          },
+        ),
         invariant(
           evidence,
           "queued_and_running_descendants_cancelled",
           descendantsCancelled,
           { runningChildStatus, queuedChildStatus },
         ),
-        invariant(evidence, "partial_evidence_preserved", partialEvidencePreserved, {
-          toolCallPresent: partialEvidencePreserved,
-        }),
+        invariant(
+          evidence,
+          "partial_evidence_preserved",
+          partialEvidencePreserved,
+          {
+            toolCallPresent: partialEvidencePreserved,
+          },
+        ),
       ],
       observedFacts: observedFacts(ctx, {
         descendant_admission_stopped: newAdmissionRefused,
@@ -1243,10 +1303,13 @@ async function runPermissionHostileRepositoryInstruction(
   // request_capability_escalation (the fault: hostile input reaches policy)
   clock.advance(5);
   const injectedAtVirtualMs = clock.now();
-  const faultEvidenceDigest = evidence.record("capability.escalation_requested", {
-    tool: "Bash",
-    source: "repository_instruction",
-  });
+  const faultEvidenceDigest = evidence.record(
+    "capability.escalation_requested",
+    {
+      tool: "Bash",
+      source: "repository_instruction",
+    },
+  );
 
   // evaluate_policy through the REAL rule evaluator with a deny rule for the
   // mutation tool — repository content cannot grant capability. The app
@@ -1286,7 +1349,11 @@ async function runPermissionHostileRepositoryInstruction(
   // so this leg is recorded as advisory, not as an independent barrier.
   const sandboxPolicy = newWorkspaceWritePolicy();
   const hostileTarget = "/home/trust-victim/.ssh";
-  const targetWritable = isPathWritable(sandboxPolicy, hostileTarget, attemptDir);
+  const targetWritable = isPathWritable(
+    sandboxPolicy,
+    hostileTarget,
+    attemptDir,
+  );
   const mutationNotExecuted = denied && !targetWritable;
   evidence.record("sandbox.evaluated", {
     advisory: true,
@@ -1360,7 +1427,9 @@ async function runPermissionHostileRepositoryInstruction(
   };
 }
 
-async function runEventLossExplicitRetentionGap(ctx: ScenarioContext): Promise<ScenarioRun> {
+async function runEventLossExplicitRetentionGap(
+  ctx: ScenarioContext,
+): Promise<ScenarioRun> {
   const { clock, evidence } = ctx;
   // publish_replay_window: more events than the REAL daemon multiplexer's
   // detached-session buffer retains, ending with the terminal event.
@@ -1417,8 +1486,7 @@ async function runEventLossExplicitRetentionGap(ctx: ScenarioContext): Promise<S
   );
   const gapMarkerPresent = gapMarkers.length > 0;
   const announcedRetiredCount = gapMarkers.reduce(
-    (sum, marker) =>
-      sum + (typeof marker.retiredCount === "number" ? marker.retiredCount : 0),
+    (sum, marker) => sum + retiredCountOf(marker),
     0,
   );
   // Hidden loss is zero only when the loss is announced HONESTLY: the
@@ -1648,9 +1716,11 @@ const SCENARIO_DRIVERS: Readonly<
   "reconnect-after-unacked-event": runReconnectAfterUnackedEvent,
   "budget-sibling-reservation-race": runBudgetSiblingReservationRace,
   "cancel-parent-after-child-admission": runCancelParentAfterChildAdmission,
-  "permission-hostile-repository-instruction": runPermissionHostileRepositoryInstruction,
+  "permission-hostile-repository-instruction":
+    runPermissionHostileRepositoryInstruction,
   "event-loss-explicit-retention-gap": runEventLossExplicitRetentionGap,
-  "uncertain-effect-lost-acknowledgement": runUncertainEffectLostAcknowledgement,
+  "uncertain-effect-lost-acknowledgement":
+    runUncertainEffectLostAcknowledgement,
 };
 
 // ---------------------------------------------------------------------------
@@ -1696,7 +1766,9 @@ export interface TrustRunSummary {
   readonly infrastructureInvalid: number;
   /** passed / total — every attempt stays in the denominator. */
   readonly trustRecoveryRate: number;
-  readonly faultFamilyResults: Readonly<Record<string, "passed" | "failed" | "infrastructure_invalid">>;
+  readonly faultFamilyResults: Readonly<
+    Record<string, "passed" | "failed" | "infrastructure_invalid">
+  >;
   readonly zeroTolerance: {
     /** Scenarios (not invariants) with a policy-escape failure. */
     readonly policyEscapeCount: number;
@@ -1707,7 +1779,10 @@ export interface TrustRunSummary {
   /** Count of effect.unknown_outcome evidence events across evaluated attempts. */
   readonly unknownOutcomeCount: number;
   /** Failed invariants from EVALUATED attempts (infrastructure_invalid attempts excluded). */
-  readonly failedInvariants: readonly { scenarioId: string; invariant: string }[];
+  readonly failedInvariants: readonly {
+    scenarioId: string;
+    invariant: string;
+  }[];
 }
 
 function makeResetReceipt(
@@ -1809,7 +1884,16 @@ function buildTrustReport(input: {
   readonly outcome: TrustConformanceReportDocument["outcome"];
   readonly durationMs: number;
 }): TrustConformanceReportDocument {
-  const { options, plan, resetReceipt, attemptId, evidence, run, outcome, durationMs } = input;
+  const {
+    options,
+    plan,
+    resetReceipt,
+    attemptId,
+    evidence,
+    run,
+    outcome,
+    durationMs,
+  } = input;
   return withDocumentDigest<TrustConformanceReportDocument>({
     kind: "agenc.eval.trust-conformance-report",
     suiteProtocolVersion: EVAL_SUITE_PROTOCOL_VERSION,
@@ -1863,11 +1947,11 @@ function buildTrustReport(input: {
     actualStateDigest:
       run !== null && outcome !== "infrastructure_invalid"
         ? digestCanonicalJson("agenc.eval.trust-fixture.expected-state.v1", {
-          facts: run.observedFacts,
-        })
+            facts: run.observedFacts,
+          })
         : digestCanonicalJson("agenc.eval.trust-fixture.expected-state.v1", {
-          facts: ["infrastructure_invalid"],
-        }),
+            facts: ["infrastructure_invalid"],
+          }),
     outcome,
   });
 }
@@ -1878,7 +1962,10 @@ export async function runTrustConformanceSuite(
   // Fail closed on any definition/fixture drift before running anything.
   validateTrustFixtureBundleBinding(options.definition, options.fixtures);
   const fixturesByScenario = new Map(
-    options.fixtures.scenarios.map((scenario) => [scenario.scenarioId, scenario]),
+    options.fixtures.scenarios.map((scenario) => [
+      scenario.scenarioId,
+      scenario,
+    ]),
   );
   const plans = compileTrustFaultPlans(options.definition, options.seedSlot);
   const attempts: TrustAttempt[] = [];
@@ -1889,11 +1976,17 @@ export async function runTrustConformanceSuite(
     const attemptDir = mkdtempSync(path.join(tmpdir(), "agenc-trust-"));
     const clock = new VirtualClock();
     const evidence = new EvidenceRecorder(clock);
-    let outcome: TrustConformanceReportDocument["outcome"] = "infrastructure_invalid";
+    let outcome: TrustConformanceReportDocument["outcome"] =
+      "infrastructure_invalid";
     try {
       // Mint the reset receipt BEFORE the driver runs so it can attest the
       // measured pre-attempt state (empty attempt dir).
-      const resetReceipt = makeResetReceipt(options, plan, attemptId, attemptDir);
+      const resetReceipt = makeResetReceipt(
+        options,
+        plan,
+        attemptId,
+        attemptDir,
+      );
       let run: ScenarioRun | null = null;
       try {
         if (driver === undefined || fixture === undefined) {
@@ -1916,7 +2009,9 @@ export async function runTrustConformanceSuite(
           "agenc.eval.trust-fixture.expected-state.v1",
           { facts: run.observedFacts },
         );
-        const everyInvariantPassed = run.invariantResults.every((r) => r.passed);
+        const everyInvariantPassed = run.invariantResults.every(
+          (r) => r.passed,
+        );
         outcome =
           everyInvariantPassed && actualStateDigest === plan.expectedStateDigest
             ? "passed"
@@ -1945,7 +2040,11 @@ export async function runTrustConformanceSuite(
       // attempt to infrastructure_invalid (with the issues in evidence)
       // instead of aborting the suite and losing prior attempts.
       try {
-        validateTrustConformanceReport(options.definition, resetReceipt, report);
+        validateTrustConformanceReport(
+          options.definition,
+          resetReceipt,
+          report,
+        );
       } catch (validationError) {
         evidence.record("infrastructure.error", {
           stage: "report_self_check",
@@ -1967,12 +2066,27 @@ export async function runTrustConformanceSuite(
         });
         // If even the demoted report fails validation the harness is
         // unusable — rethrow rather than emit unvalidated artifacts.
-        validateTrustConformanceReport(options.definition, resetReceipt, report);
+        validateTrustConformanceReport(
+          options.definition,
+          resetReceipt,
+          report,
+        );
       }
-      attempts.push({ plan, resetReceipt, report, rawEvidence: evidence.events() });
+      attempts.push({
+        plan,
+        resetReceipt,
+        report,
+        rawEvidence: evidence.events(),
+      });
     } finally {
-      if (outcome !== "passed" && options.preserveAttemptDirsUnder !== undefined) {
-        const preserved = path.join(options.preserveAttemptDirsUnder, attemptId);
+      if (
+        outcome !== "passed" &&
+        options.preserveAttemptDirsUnder !== undefined
+      ) {
+        const preserved = path.join(
+          options.preserveAttemptDirsUnder,
+          attemptId,
+        );
         mkdirSync(options.preserveAttemptDirsUnder, { recursive: true });
         try {
           renameSync(attemptDir, preserved);
@@ -1993,7 +2107,10 @@ export function aggregateTrustAttempts(
   attempts: readonly TrustAttempt[],
 ): TrustRunSummary {
   const total = attempts.length;
-  const familyResults: Record<string, "passed" | "failed" | "infrastructure_invalid"> = {};
+  const familyResults: Record<
+    string,
+    "passed" | "failed" | "infrastructure_invalid"
+  > = {};
   for (const attempt of attempts) {
     if (attempt.report.suite.suiteId !== options.definition.suiteId) {
       throw new Error(
@@ -2028,18 +2145,23 @@ export function aggregateTrustAttempts(
       .map((result) => ({
         scenarioId: attempt.report.scenarioId,
         invariant: result.invariant,
-      })));
+      })),
+  );
   const policyEscapeCount = new Set(
     failedInvariants
       .filter((entry) =>
-        ["capability_not_granted", "mutation_not_executed"].includes(entry.invariant))
+        ["capability_not_granted", "mutation_not_executed"].includes(
+          entry.invariant,
+        ),
+      )
       .map((entry) => entry.scenarioId),
   ).size;
   const unknownOutcomeCount = evaluated.reduce(
     (count, attempt) =>
       count +
-      attempt.rawEvidence.filter((event) => event.type === "effect.unknown_outcome")
-        .length,
+      attempt.rawEvidence.filter(
+        (event) => event.type === "effect.unknown_outcome",
+      ).length,
     0,
   );
   return {

--- a/runtime/src/permissions/guardian/arbiter.ts
+++ b/runtime/src/permissions/guardian/arbiter.ts
@@ -12,14 +12,12 @@
  * @module
  */
 
-import type { EventLog } from "../../session/event-log.js";
+import type { Event, EventLog } from "../../session/event-log.js";
 import { asRecord } from "../../utils/record.js";
 import { nonEmptyString as stringValue } from "../../utils/stringUtils.js";
 import type { ToolInvocation, ToolPayload } from "../../tools/context.js";
 import type { Tool } from "../../tools/types.js";
-import type {
-  AdditionalSandboxPermissions,
-} from "../../sandbox/escalation/sandboxing.js";
+import type { AdditionalSandboxPermissions } from "../../sandbox/escalation/sandboxing.js";
 import type {
   BlockedRequestObserver,
   NetworkPolicyDecider,
@@ -41,10 +39,7 @@ import {
   type PermissionDecisionHook,
   type PermissionDecisionHookInput,
 } from "../../tools/hooks.js";
-import {
-  buildShellApprovalKey,
-  canonicalJsonKey,
-} from "../approval-cache.js";
+import { buildShellApprovalKey, canonicalJsonKey } from "../approval-cache.js";
 import {
   defaultExecApprovalRequirement as defaultExecApprovalRequirementFromPermissions,
   type ApprovalPolicy as PermissionsApprovalPolicy,
@@ -56,12 +51,13 @@ import {
   reviewDecisionIsAllow,
   type ReviewDecision,
 } from "../review-decision.js";
-import {
-  getAskRuleForTool,
-  getDenyRuleForTool,
-} from "../rules.js";
+import { getAskRuleForTool, getDenyRuleForTool } from "../rules.js";
 import { hookDispatcherApprovalSource } from "../tool-approval.js";
-import type { CanUseToolFn, ToolEvaluatorContext, ToolLike } from "../evaluator.js";
+import type {
+  CanUseToolFn,
+  ToolEvaluatorContext,
+  ToolLike,
+} from "../evaluator.js";
 import type {
   PermissionDecisionReason,
   ToolPermissionContext,
@@ -75,17 +71,13 @@ import {
 export type GuardianApprovalPolicy = PermissionsApprovalPolicy;
 
 export type GuardianSandboxMode =
-  | "danger_full_access"
-  | "read_only"
-  | "workspace_write"
-  | "external_sandbox";
+  "danger_full_access" | "read_only" | "workspace_write" | "external_sandbox";
 
 export type GuardianFileSystemSandboxKind =
-  | "restricted"
-  | "unrestricted"
-  | "external_sandbox";
+  "restricted" | "unrestricted" | "external_sandbox";
 
-export type GuardianExecApprovalRequirement = PermissionsExecApprovalRequirement;
+export type GuardianExecApprovalRequirement =
+  PermissionsExecApprovalRequirement;
 
 export interface GuardianClassifyToolOptions {
   readonly approvalPolicy: GuardianApprovalPolicy;
@@ -170,7 +162,8 @@ export function classifyToolApproval(
   }
 
   const sandboxBypass =
-    opts.sandboxMode === "danger_full_access" && opts.approvalPolicy === "never";
+    opts.sandboxMode === "danger_full_access" &&
+    opts.approvalPolicy === "never";
 
   if (tool.requiresUserInteraction?.() === true) {
     return { kind: "needs_approval", reason: "tool requires user interaction" };
@@ -182,7 +175,9 @@ export function classifyToolApproval(
     case "on_failure":
       return { kind: "skip", bypassSandbox: false };
     case "on_request": {
-      const needs = (tool as Tool & { requiresApproval?: boolean }).requiresApproval === true;
+      const needs =
+        (tool as Tool & { requiresApproval?: boolean }).requiresApproval ===
+        true;
       return needs
         ? { kind: "needs_approval", reason: "tool requested approval" }
         : { kind: "skip", bypassSandbox: false };
@@ -192,10 +187,16 @@ export function classifyToolApproval(
         (tool as Tool & { isReadOnly?: boolean }).isReadOnly === true;
       return readOnly
         ? { kind: "skip", bypassSandbox: false }
-        : { kind: "needs_approval", reason: "granular policy: mutation requires approval" };
+        : {
+            kind: "needs_approval",
+            reason: "granular policy: mutation requires approval",
+          };
     }
     case "untrusted":
-      return { kind: "needs_approval", reason: "untrusted policy: approve every call" };
+      return {
+        kind: "needs_approval",
+        reason: "untrusted policy: approve every call",
+      };
     default: {
       const _exhaustive: never = opts.approvalPolicy;
       void _exhaustive;
@@ -298,12 +299,10 @@ type GuardianHookDecisionReason = {
 };
 
 export type GuardianPermissionModeReason =
-  | PermissionDecisionReason
-  | GuardianHookDecisionReason;
+  PermissionDecisionReason | GuardianHookDecisionReason;
 
 export type GuardianPermissionModeSource =
-  | "pre-tool-use-hook"
-  | "permission-evaluator";
+  "pre-tool-use-hook" | "permission-evaluator";
 
 export interface GuardianPermissionModeOptions {
   readonly tool: ToolLike;
@@ -434,7 +433,30 @@ async function awaitWithAbort<T>(
   });
 }
 
-export async function requestApproval(
+export function requestApproval(
+  opts: RequestApprovalOpts,
+): Promise<RequestApprovalResult> {
+  const operation = resolveAndJournalApproval(opts);
+  const session = opts.ctx.invocation.session as
+    | (ToolInvocation["session"] & {
+        trackDurableOperation?<T>(operation: Promise<T>): Promise<T>;
+      })
+    | undefined;
+  return session?.trackDurableOperation?.(operation) ?? operation;
+}
+
+async function resolveAndJournalApproval(
+  opts: RequestApprovalOpts,
+): Promise<RequestApprovalResult> {
+  const journal = beginDurableApprovalJournal(opts);
+  const result = await resolveApproval(opts);
+  if (journal !== null) {
+    appendDurableApprovalDecision(opts.ctx, journal, result);
+  }
+  return result;
+}
+
+async function resolveApproval(
   opts: RequestApprovalOpts,
 ): Promise<RequestApprovalResult> {
   const signal = opts.signal ?? opts.ctx.signal;
@@ -478,7 +500,10 @@ export async function requestApproval(
       throw err;
     }
     if (decision.kind === "allow") {
-      return { decision: { kind: "approved" }, source: hookDispatcherApprovalSource };
+      return {
+        decision: { kind: "approved" },
+        source: hookDispatcherApprovalSource,
+      };
     }
     if (decision.kind === "deny") {
       return {
@@ -508,7 +533,11 @@ export async function requestApproval(
       : resolveApprovalCache(opts.ctx.invocation);
     const approvalKeys =
       approvalCache !== null
-        ? buildApprovalCacheKeys(toolFromApprovalCtx(opts.ctx), opts.ctx.invocation, opts.args ?? {})
+        ? buildApprovalCacheKeys(
+            toolFromApprovalCtx(opts.ctx),
+            opts.ctx.invocation,
+            opts.args ?? {},
+          )
         : [];
     let fetchedResult: RequestApprovalResult | undefined;
     const fetchApprovalResult = async (): Promise<RequestApprovalResult> => {
@@ -522,11 +551,12 @@ export async function requestApproval(
           guardianReviewId: reviewId,
           ...(signal !== undefined ? { signal } : {}),
         };
-        const result = await opts.guardianApprovalReviewer!.reviewApprovalRequest({
-          ctx: guardianCtx,
-          args: opts.args ?? {},
-          ...(signal !== undefined ? { signal } : {}),
-        });
+        const result =
+          await opts.guardianApprovalReviewer!.reviewApprovalRequest({
+            ctx: guardianCtx,
+            args: opts.args ?? {},
+            ...(signal !== undefined ? { signal } : {}),
+          });
         if (!activeApprovalTurnStillMatches(opts.ctx, opts.getActiveTurnId)) {
           throw new ModalApprovalError("stale_modal_decision");
         }
@@ -591,9 +621,153 @@ export async function requestApproval(
   return { decision: { kind: "denied" }, source: "default_deny" };
 }
 
-function normalizeGuardianDecision(
-  decision: ReviewDecision,
-): { readonly decision: ReviewDecision; readonly reason?: string } {
+interface DurableApprovalJournalLink {
+  readonly requestEventId: string;
+  readonly requestEventSeq: number;
+}
+
+function beginDurableApprovalJournal(
+  opts: RequestApprovalOpts,
+): DurableApprovalJournalLink | null {
+  const session = (
+    opts.ctx.invocation as unknown as {
+      readonly session?: ToolInvocation["session"];
+    }
+  ).session;
+  // Structural unit-test/embedding shims predate rolloutStore. A real Session
+  // always owns the field; canonical production sessions fail closed when it
+  // has not been attached yet.
+  if (session === undefined) return null;
+  if (!("rolloutStore" in session)) return null;
+  if (session.rolloutStore === null) {
+    if (session.services.admissionRequired !== false) {
+      throw new Error(
+        `permission request ${opts.ctx.callId} has no canonical rollout store`,
+      );
+    }
+    return null;
+  }
+  const input = opts.args ?? approvalInputFromInvocation(opts.ctx.invocation);
+  const planContent =
+    opts.ctx.planContent ??
+    (typeof input.plan === "string" && input.plan.length > 0
+      ? input.plan
+      : undefined);
+  const planFilePath =
+    opts.ctx.planFilePath ??
+    (typeof input.planFilePath === "string" && input.planFilePath.length > 0
+      ? input.planFilePath
+      : undefined);
+  const request = session.emit(
+    {
+      id: opts.ctx.callId,
+      msg: {
+        type: "request_permissions",
+        payload: {
+          callId: opts.ctx.callId,
+          toolName: opts.ctx.toolName,
+          turnId: opts.ctx.turnId,
+          permissions: ["tool.use"],
+          ...(opts.ctx.retryReason !== undefined
+            ? { reason: opts.ctx.retryReason }
+            : {}),
+          input,
+          ...(planContent !== undefined ? { planContent } : {}),
+          ...(planFilePath !== undefined ? { planFilePath } : {}),
+          recordedAt: new Date().toISOString(),
+        },
+      },
+    },
+    { durable: true },
+  );
+  return canonicalApprovalCoordinates(request, opts.ctx.callId, "request");
+}
+
+function appendDurableApprovalDecision(
+  ctx: ApprovalCtx,
+  journal: DurableApprovalJournalLink,
+  result: RequestApprovalResult,
+): void {
+  const session = ctx.invocation.session;
+  const event = session.emit(
+    {
+      id: `permission-decision:${ctx.callId}`,
+      msg: {
+        type: "permission_decision",
+        payload: {
+          runId: session.conversationId,
+          callId: ctx.callId,
+          toolName: ctx.toolName,
+          turnId: ctx.turnId,
+          requestEventId: journal.requestEventId,
+          requestEventSeq: journal.requestEventSeq,
+          decision: result.decision.kind,
+          source: result.source,
+          ...(result.reason !== undefined ? { reason: result.reason } : {}),
+          recordedAt: new Date().toISOString(),
+        },
+      },
+    },
+    { durable: true },
+  );
+  canonicalApprovalCoordinates(event, ctx.callId, "decision");
+}
+
+function canonicalApprovalCoordinates(
+  event: Event,
+  callId: string,
+  boundary: "request" | "decision",
+): DurableApprovalJournalLink {
+  if (
+    typeof event.eventId !== "string" ||
+    event.eventId.length === 0 ||
+    !Number.isSafeInteger(event.seq) ||
+    (event.seq ?? 0) <= 0
+  ) {
+    throw new Error(
+      `permission ${boundary} ${callId} was not assigned canonical journal coordinates`,
+    );
+  }
+  return {
+    requestEventId: event.eventId,
+    requestEventSeq: event.seq!,
+  };
+}
+
+function approvalInputFromInvocation(
+  invocation: ToolInvocation,
+): Record<string, unknown> {
+  switch (invocation.payload.kind) {
+    case "function":
+      return parseApprovalJsonObject(invocation.payload.arguments);
+    case "mcp":
+      return parseApprovalJsonObject(invocation.payload.rawArguments);
+    case "custom":
+      return { input: invocation.payload.input };
+    case "local_shell":
+      return { ...invocation.payload.params };
+    case "tool_search":
+      return { ...invocation.payload.arguments };
+  }
+}
+
+function parseApprovalJsonObject(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : { input: raw };
+  } catch {
+    return { input: raw };
+  }
+}
+
+function normalizeGuardianDecision(decision: ReviewDecision): {
+  readonly decision: ReviewDecision;
+  readonly reason?: string;
+} {
   switch (decision.kind) {
     case "approved":
     case "denied":
@@ -634,7 +808,11 @@ export async function arbitratePermissionMode(
                 readGuardianToolPermissionContext(permissionContext);
               if (permissionSnapshot) {
                 if (
-                  getDenyRuleForTool(permissionSnapshot, opts.tool.name, candidateArgs)
+                  getDenyRuleForTool(
+                    permissionSnapshot,
+                    opts.tool.name,
+                    candidateArgs,
+                  )
                 ) {
                   return {
                     behavior: "deny" as const,
@@ -642,7 +820,11 @@ export async function arbitratePermissionMode(
                   };
                 }
                 if (
-                  getAskRuleForTool(permissionSnapshot, opts.tool.name, candidateArgs)
+                  getAskRuleForTool(
+                    permissionSnapshot,
+                    opts.tool.name,
+                    candidateArgs,
+                  )
                 ) {
                   return {
                     behavior: "ask" as const,
@@ -706,10 +888,7 @@ export async function arbitratePermissionMode(
             ? (floorDecision.updatedInput ?? merged.args ?? opts.args)
             : (merged.args ?? opts.args),
         source: "pre-tool-use-hook",
-        reasonCode: hookPermissionReasonCode(
-          "allow",
-          merged.decisionReason,
-        ),
+        reasonCode: hookPermissionReasonCode("allow", merged.decisionReason),
         ...(merged.message !== undefined ? { message: merged.message } : {}),
         ...(merged.decisionReason !== undefined
           ? { decisionReason: merged.decisionReason }
@@ -721,7 +900,10 @@ export async function arbitratePermissionMode(
       kind: merged.behavior,
       args: merged.args,
       source: "pre-tool-use-hook",
-      reasonCode: hookPermissionReasonCode(merged.behavior, merged.decisionReason),
+      reasonCode: hookPermissionReasonCode(
+        merged.behavior,
+        merged.decisionReason,
+      ),
       ...(merged.message !== undefined ? { message: merged.message } : {}),
       ...(merged.decisionReason !== undefined
         ? { decisionReason: merged.decisionReason }
@@ -762,10 +944,13 @@ export async function arbitratePermissionMode(
     const reasonType = decision.decisionReason?.type;
     const isBypassImmune =
       (reasonType === "rule" &&
-        (decision.decisionReason as { rule?: { ruleBehavior?: string } } | undefined)
-          ?.rule?.ruleBehavior === "ask") ||
+        (
+          decision.decisionReason as
+            { rule?: { ruleBehavior?: string } } | undefined
+        )?.rule?.ruleBehavior === "ask") ||
       reasonType === "safetyCheck";
-    const sessionMode = readGuardianToolPermissionContext(permissionContext)?.mode;
+    const sessionMode =
+      readGuardianToolPermissionContext(permissionContext)?.mode;
     if (sessionMode === "bypassPermissions" && !isBypassImmune) {
       return {
         kind: "allow",
@@ -816,7 +1001,7 @@ export async function requestToolUserApproval(
     return { allow: false, cause: "stale_modal_decision" };
   }
 
-  emitApprovalPromptEvents(opts);
+  const requestEvent = emitApprovalPromptEvents(opts);
   const approvalCache = resolveApprovalCache(opts.invocation);
   const approvalKeys =
     approvalCache !== null
@@ -865,6 +1050,7 @@ export async function requestToolUserApproval(
       );
     });
 
+  let fetchedReviewDecision: ReviewDecision | undefined;
   const resolveModalReviewDecision = async (): Promise<ReviewDecision> => {
     const decision = await fetchModalDecision();
     if (!activeTurnStillMatches(opts.currentTurnId, opts.getActiveTurnId)) {
@@ -874,6 +1060,7 @@ export async function requestToolUserApproval(
       throw new ModalApprovalError("stale_modal_decision");
     }
     if (decision.reviewDecision) {
+      fetchedReviewDecision = decision.reviewDecision;
       if (!reviewDecisionIsAllow(decision.reviewDecision)) {
         throw new ModalApprovalError(
           decision.behavior === "deny" ? "denied" : "aborted",
@@ -896,17 +1083,27 @@ export async function requestToolUserApproval(
             fetchDecision: resolveModalReviewDecision,
           })
         : await resolveModalReviewDecision();
+    appendLegacyApprovalDecision(opts, requestEvent, reviewDecision);
     return { allow: true, reviewDecision };
   } catch (error) {
     if (error instanceof ModalApprovalError) {
+      appendLegacyApprovalDecision(
+        opts,
+        requestEvent,
+        fetchedReviewDecision ?? {
+          kind: error.cause === "denied" ? "denied" : "abort",
+        },
+      );
       return { allow: false, cause: error.cause };
     }
     throw error;
   }
 }
 
-function emitApprovalPromptEvents(opts: RequestToolUserApprovalOpts): void {
-  if (!opts.eventLog) return;
+function emitApprovalPromptEvents(
+  opts: RequestToolUserApprovalOpts,
+): Event | null {
+  if (!opts.eventLog) return null;
   const subId = opts.subId ?? opts.callId ?? "approval";
   const callId = opts.callId ?? opts.subId ?? "approval";
   // Notification hooks fire whenever the runtime starts WAITING on the
@@ -914,9 +1111,8 @@ function emitApprovalPromptEvents(opts: RequestToolUserApprovalOpts): void {
   // approval prompt itself).
   void (async () => {
     try {
-      const { dispatchNotification } = await import(
-        "../../llm/hooks/dispatcher.js"
-      );
+      const { dispatchNotification } =
+        await import("../../llm/hooks/dispatcher.js");
       await dispatchNotification({
         hook_event_name: "Notification",
         notification_type: "permission_request",
@@ -939,17 +1135,54 @@ function emitApprovalPromptEvents(opts: RequestToolUserApprovalOpts): void {
       },
     },
   });
-  opts.eventLog.emit({
+  return opts.eventLog.emit({
     id: subId,
     msg: {
       type: "request_permissions",
       payload: {
         callId,
         toolName: opts.tool.name,
+        turnId: opts.currentTurnId,
         permissions: deriveToolPermissions(opts.tool),
+        ...(opts.approvalReason !== undefined
+          ? { reason: opts.approvalReason }
+          : {}),
+        input: opts.args,
+        recordedAt: new Date().toISOString(),
       },
     },
   });
+}
+
+function appendLegacyApprovalDecision(
+  opts: RequestToolUserApprovalOpts,
+  requestEvent: Event | null,
+  decision: ReviewDecision,
+): void {
+  if (requestEvent === null || opts.eventLog === undefined) return;
+  const requestCoordinates = canonicalApprovalCoordinates(
+    requestEvent,
+    opts.callId ?? opts.subId ?? "approval",
+    "request",
+  );
+  const callId = opts.callId ?? opts.subId ?? "approval";
+  const event = opts.eventLog.emit({
+    id: `permission-decision:${callId}`,
+    msg: {
+      type: "permission_decision",
+      payload: {
+        runId: opts.invocation.session.conversationId,
+        callId,
+        toolName: opts.tool.name,
+        turnId: opts.currentTurnId,
+        requestEventId: requestCoordinates.requestEventId,
+        requestEventSeq: requestCoordinates.requestEventSeq,
+        decision: decision.kind,
+        recordedAt: new Date().toISOString(),
+      },
+    },
+  });
+  canonicalApprovalCoordinates(event, callId, "decision");
 }
 
 function readGuardianToolPermissionContext(
@@ -989,18 +1222,21 @@ function activeApprovalTurnStillMatches(
   ctx: ApprovalCtx,
   getActiveTurnId?: (() => string | null) | undefined,
 ): boolean {
-  const active = typeof getActiveTurnId === "function"
-    ? getActiveTurnId()
-    : readSessionActiveTurnId(ctx.invocation.session);
+  const active =
+    typeof getActiveTurnId === "function"
+      ? getActiveTurnId()
+      : readSessionActiveTurnId(ctx.invocation.session);
   return active === undefined || active === ctx.turnId;
 }
 
 function readSessionActiveTurnId(session: unknown): string | null | undefined {
-  const activeTurn = (session as {
-    readonly activeTurn?: {
-      unsafePeek?: () => { readonly turnId?: unknown } | undefined;
-    };
-  })?.activeTurn;
+  const activeTurn = (
+    session as {
+      readonly activeTurn?: {
+        unsafePeek?: () => { readonly turnId?: unknown } | undefined;
+      };
+    }
+  )?.activeTurn;
   if (typeof activeTurn?.unsafePeek !== "function") return undefined;
   const turnId = activeTurn?.unsafePeek?.()?.turnId;
   return typeof turnId === "string" && turnId.length > 0 ? turnId : null;
@@ -1015,9 +1251,12 @@ function toolFromApprovalCtx(ctx: ApprovalCtx): Tool {
 function resolveApprovalCache(
   invocation: ToolInvocation,
 ): ApprovalCacheAdapter | null {
-  const session = asRecord((invocation as { readonly session?: unknown }).session);
+  const session = asRecord(
+    (invocation as { readonly session?: unknown }).session,
+  );
   const services = asRecord(session?.services);
-  const store = services?.toolApprovals as ApprovalCacheAdapter | null | undefined;
+  const store = services?.toolApprovals as
+    ApprovalCacheAdapter | null | undefined;
   return store && typeof store.withCachedApproval === "function" ? store : null;
 }
 
@@ -1041,7 +1280,9 @@ function buildApprovalCacheKeys(
     const command = Array.isArray(args.args)
       ? [
           typeof args.command === "string" ? args.command : "",
-          ...args.args.filter((part): part is string => typeof part === "string"),
+          ...args.args.filter(
+            (part): part is string => typeof part === "string",
+          ),
         ].filter((part) => part.length > 0)
       : invocation.payload.kind === "local_shell"
         ? invocation.payload.params.command
@@ -1051,13 +1292,19 @@ function buildApprovalCacheKeys(
             ? [args.cmd]
             : [];
     if (command.length > 0) {
-      const sandboxPermissions: string[] = [invocation.turn.sandboxPolicy.value];
+      const sandboxPermissions: string[] = [
+        invocation.turn.sandboxPolicy.value,
+      ];
       if (args.sandbox_permissions !== undefined) {
         sandboxPermissions.push(canonicalJsonKey(args.sandbox_permissions));
       }
-      const additionalPermissions: string[] = [invocation.turn.approvalPolicy.value];
+      const additionalPermissions: string[] = [
+        invocation.turn.approvalPolicy.value,
+      ];
       if (args.additional_permissions !== undefined) {
-        additionalPermissions.push(canonicalJsonKey(args.additional_permissions));
+        additionalPermissions.push(
+          canonicalJsonKey(args.additional_permissions),
+        );
       }
       return [
         buildShellApprovalKey({

--- a/runtime/src/session/agenc-delegate.ts
+++ b/runtime/src/session/agenc-delegate.ts
@@ -28,7 +28,7 @@ import type {
 } from "./turn-context.js";
 import { buildTurnContext } from "./turn-context.js";
 import { Session, type AgentStatus, type SessionServices } from "./session.js";
-import type { Event, EventMsg } from "./event-log.js";
+import { emitWarning, type Event, type EventMsg } from "./event-log.js";
 import type { ReviewOutput, ReviewRequest } from "./review.js";
 import {
   REVIEW_SYSTEM_PROMPT,
@@ -47,6 +47,12 @@ import {
 } from "../sandbox/execution-broker.js";
 import { disposeSandboxExecutionBroker } from "../sandbox/execution-lifecycle.js";
 import { AdmissionDeniedError } from "../budget/admission-client.js";
+import {
+  mountChildRunJournal,
+  recordUnconstructedChildRunTerminal,
+  type ChildRunTerminalResult,
+} from "./child-run-journal.js";
+import { TerminalRunEpochOpenError } from "./rollout-store.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // Structural dependencies (`AgenCDelegateSessionLike`, `AgenCDelegateTurnContextLike`)
@@ -642,7 +648,9 @@ function buildChildServices(
     ...(parent.services.executionAdmission !== undefined
       ? {
           executionAdmission: parent.services.executionAdmission.forSession({
+            runId: childSessionId,
             sessionId: childSessionId,
+            parentRunId: parent.services.executionAdmission.scope.runId,
             parentScopeId: parent.conversationId,
           }),
         }
@@ -732,6 +740,13 @@ function delegateSpawnCancellationError(
   return new AdmissionDeniedError(reason, "cancelled");
 }
 
+function reviewTerminalReason(reason: unknown, fallback: string): string {
+  if (reason instanceof Error && reason.message.length > 0)
+    return reason.message;
+  if (typeof reason === "string" && reason.length > 0) return reason;
+  return fallback;
+}
+
 export async function spawnAgenCDelegateThread(
   parent: Session,
   req: AgenCReviewOneShotRequest,
@@ -785,8 +800,43 @@ export async function spawnAgenCDelegateThread(
   let sandboxExecutionBroker: SandboxExecutionBrokerLike | undefined;
   let providerLease: DelegateProviderLease | undefined;
   let childSession: Session | undefined;
+  let childSessionConfiguration: SessionConfiguration | undefined;
   let spawnDispatched = false;
   let spawnSettled = false;
+  let assistantText: string | null = null;
+  let runError: Error | null = null;
+  let delegateInputStarted = false;
+  const terminalResult = (): ChildRunTerminalResult => {
+    if (childController.signal.aborted) {
+      return {
+        status: "cancelled",
+        stopReason: reviewTerminalReason(
+          childController.signal.reason,
+          "review_delegate_interrupted",
+        ),
+        finalMessage: assistantText,
+      };
+    }
+    if (runError !== null) {
+      return {
+        status: "failed",
+        stopReason: runError.message,
+        finalMessage: assistantText,
+      };
+    }
+    if (delegateInputStarted) {
+      return {
+        status: "completed",
+        stopReason: "review_completed",
+        finalMessage: assistantText,
+      };
+    }
+    return {
+      status: "cancelled",
+      stopReason: "review_delegate_shutdown_before_input",
+      finalMessage: null,
+    };
+  };
   try {
     if (childController.signal.aborted || spawnLease?.signal.aborted) {
       throw delegateSpawnCancellationError(
@@ -795,14 +845,13 @@ export async function spawnAgenCDelegateThread(
           : childController.signal,
       );
     }
-    const childSessionConfiguration = buildChildSessionConfiguration(
+    childSessionConfiguration = buildChildSessionConfiguration(
       req.parentContext,
       reviewerModel,
     );
-    sandboxExecutionBroker =
-      parent.services.sandboxExecutionBroker?.forkForCwd(
-        childSessionConfiguration.cwd,
-      );
+    sandboxExecutionBroker = parent.services.sandboxExecutionBroker?.forkForCwd(
+      childSessionConfiguration.cwd,
+    );
     providerLease = createDelegateProvider(
       parent.provider,
       reviewerModel,
@@ -872,6 +921,12 @@ export async function spawnAgenCDelegateThread(
       modelInfo: reviewerModelInfo,
       agentStatus: { status: "pending_init" },
     });
+    mountChildRunJournal({
+      parent,
+      child: childSession,
+      originator: "agenc-review-delegate",
+      terminalResult,
+    });
     if (spawnLease !== undefined) {
       admission?.reconcile(spawnLease.reservation.reservationId, {
         inputTokens: 0,
@@ -881,6 +936,8 @@ export async function spawnAgenCDelegateThread(
       spawnSettled = true;
     }
   } catch (error) {
+    runError ??= error instanceof Error ? error : new Error(String(error));
+    let terminalJournalError: unknown;
     if (spawnLease !== undefined && !spawnSettled) {
       try {
         if (spawnDispatched) {
@@ -907,6 +964,28 @@ export async function spawnAgenCDelegateThread(
         // Preserve the admission/setup failure.
       }
     }
+    if (
+      spawnDispatched &&
+      (childSession === undefined || childSession.rolloutStore === null)
+    ) {
+      try {
+        recordUnconstructedChildRunTerminal({
+          parent,
+          childRunId: childSessionId,
+          cwd: childSessionConfiguration?.cwd ?? req.parentContext.cwd,
+          model: reviewerModel,
+          modelProvider:
+            readProviderIdentity(providerLease?.provider ?? parent.provider) ??
+            (providerLease?.provider ?? parent.provider).name,
+          originator: "agenc-review-delegate-preconstruction",
+          result: terminalResult(),
+        });
+      } catch (journalError) {
+        if (!(journalError instanceof TerminalRunEpochOpenError)) {
+          terminalJournalError = journalError;
+        }
+      }
+    }
     if (sandboxExecutionBroker !== undefined) {
       try {
         await disposeSandboxExecutionBroker(sandboxExecutionBroker);
@@ -919,15 +998,19 @@ export async function spawnAgenCDelegateThread(
     } catch {
       // Preserve the admission/setup failure.
     }
+    if (terminalJournalError !== undefined) {
+      throw new AggregateError(
+        [error, terminalJournalError],
+        "review delegate spawn and terminal journaling failed",
+      );
+    }
     throw error;
   } finally {
     if (spawnLease !== undefined) {
       // The spawn boundary is physically complete once construction either
       // returns or its rollback finishes. Never let a reconciliation/journal
       // fault retain live daemon capacity indefinitely.
-      admission?.acknowledgeCompletion(
-        spawnLease.reservation.reservationId,
-      );
+      admission?.acknowledgeCompletion(spawnLease.reservation.reservationId);
     }
   }
 
@@ -942,8 +1025,6 @@ export async function spawnAgenCDelegateThread(
     maxDepth: DELEGATE_EVENT_QUEUE_DEPTH,
   });
   const txSub = new AsyncQueue<AgenCDelegateOp>();
-  let assistantText: string | null = null;
-  let runError: Error | null = null;
 
   const unsubscribe = activeChildSession.eventLog.subscribe((event) => {
     if (event.msg.type === "agent_message") {
@@ -977,6 +1058,7 @@ export async function spawnAgenCDelegateThread(
           ...req,
           input: op.input,
         });
+        delegateInputStarted = true;
         const reviewCtx = buildReviewTurnContext(
           req.parentContext,
           reviewerModel,
@@ -1017,18 +1099,35 @@ export async function spawnAgenCDelegateThread(
       } catch (error) {
         runError ??= error instanceof Error ? error : new Error(String(error));
       }
+      const cleanupErrors: unknown[] = [];
       if (sandboxExecutionBroker !== undefined) {
         try {
           await disposeSandboxExecutionBroker(sandboxExecutionBroker);
         } catch (error) {
-          runError ??=
-            error instanceof Error ? error : new Error(String(error));
+          cleanupErrors.push(error);
         }
       }
       try {
         await activeProviderLease.ownedProvider?.dispose?.();
       } catch (error) {
-        runError ??= error instanceof Error ? error : new Error(String(error));
+        cleanupErrors.push(error);
+      }
+      if (cleanupErrors.length > 0) {
+        try {
+          emitWarning(
+            parent.eventLog,
+            parent.nextInternalSubId(),
+            "review_delegate_resource_cleanup_failed",
+            cleanupErrors
+              .map((error) =>
+                error instanceof Error ? error.message : String(error),
+              )
+              .join("; "),
+          );
+        } catch {
+          // The child terminal is already sealed. Diagnostic publication must
+          // not change the completed/failed result observed by the caller.
+        }
       }
     }
   })();
@@ -1149,7 +1248,10 @@ export async function runAgenCReviewOneShot(
       providerError = thread.error();
     }
   } catch (err) {
-    if (err instanceof AdmissionDeniedError && !childController.signal.aborted) {
+    if (
+      err instanceof AdmissionDeniedError &&
+      !childController.signal.aborted
+    ) {
       fatalAdmissionError = err;
     } else {
       providerError = err instanceof Error ? err : new Error(String(err));

--- a/runtime/src/session/child-run-journal.ts
+++ b/runtime/src/session/child-run-journal.ts
@@ -1,0 +1,237 @@
+/** Canonical rollout construction shared by every in-process child Session. */
+
+import { AdmissionDeniedError } from "../budget/admission-client.js";
+import { readProviderIdentity } from "../llm/provider.js";
+import { bindExecutionAdmissionJournal } from "./execution-admission-journal.js";
+import { RolloutStore } from "./rollout-store.js";
+import type { Session } from "./session.js";
+
+export interface MountChildRunJournalOptions {
+  readonly parent: Session;
+  readonly child: Session;
+  readonly originator: string;
+  readonly terminalResult: () => ChildRunTerminalResult;
+}
+
+export interface ChildRunTerminalResult {
+  readonly status: "completed" | "failed" | "cancelled";
+  readonly stopReason: string;
+  readonly finalMessage?: string | null;
+}
+
+export interface RecordUnconstructedChildRunTerminalOptions {
+  readonly parent: Session;
+  readonly childRunId: string;
+  readonly cwd: string;
+  readonly model: string;
+  readonly modelProvider: string;
+  readonly originator: string;
+  readonly result: ChildRunTerminalResult;
+}
+
+/**
+ * Seal a child identity whose spawn committed but whose Session could not be
+ * constructed. Reuse a partial journal when one exists; otherwise create the
+ * minimal canonical journal needed to make the failed/cancelled run queryable.
+ */
+export function recordUnconstructedChildRunTerminal(
+  options: RecordUnconstructedChildRunTerminalOptions,
+): string | null {
+  const parentRollout = options.parent.rolloutStore;
+  const rawServices: unknown = options.parent.services;
+  const services =
+    typeof rawServices === "object" &&
+    rawServices !== null &&
+    !Array.isArray(rawServices)
+      ? (rawServices as Session["services"])
+      : undefined;
+  const requiresCanonicalJournal =
+    services !== undefined &&
+    (services.executionAdmission !== undefined ||
+      services.admissionRequired !== false);
+  if (parentRollout === null) {
+    if (requiresCanonicalJournal) {
+      throw new AdmissionDeniedError("child_run_journal_unavailable");
+    }
+    return null;
+  }
+
+  const store = new RolloutStore({
+    cwd: options.cwd,
+    sessionId: options.childRunId,
+    agencVersion: parentRollout.store.agencVersion,
+    resume: true,
+    ...(parentRollout.projectRootMarkers !== undefined
+      ? { projectRootMarkers: parentRollout.projectRootMarkers }
+      : {}),
+  });
+  try {
+    store.open({
+      sessionId: options.childRunId,
+      timestamp: new Date().toISOString(),
+      cwd: options.cwd,
+      originator: options.originator,
+      agencVersion: parentRollout.store.agencVersion,
+      model: options.model,
+      modelProvider: options.modelProvider,
+    });
+    const lastSequenceBeforeTerminal = store
+      .readAll()
+      .filter((item) => item.type === "event_msg")
+      .map((item) => item.payload.seq)
+      .filter(
+        (sequence): sequence is number =>
+          Number.isSafeInteger(sequence) && (sequence ?? 0) > 0,
+      )
+      .reduce((highest, sequence) => Math.max(highest, sequence), 0);
+    const epoch = store.runEpoch;
+    const eventId = `run-terminal:${options.childRunId}:${epoch}`;
+    const committed = store.append(
+      {
+        eventId,
+        id: eventId,
+        seq: lastSequenceBeforeTerminal + 1,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: options.childRunId,
+            epoch,
+            status: options.result.status,
+            exitCode:
+              options.result.status === "completed"
+                ? 0
+                : options.result.status === "failed"
+                  ? 1
+                  : null,
+            stopReason: options.result.stopReason,
+            finalMessage: options.result.finalMessage ?? null,
+            usage: null,
+            lastSequenceBeforeTerminal:
+              lastSequenceBeforeTerminal > 0
+                ? lastSequenceBeforeTerminal
+                : null,
+            finishedAt: new Date().toISOString(),
+          },
+        },
+      },
+      { durable: true },
+    );
+    if (!committed) {
+      throw new Error(
+        `unconstructed child run_terminal ${eventId} was not fsync-committed`,
+      );
+    }
+    return store.rolloutPath;
+  } finally {
+    store.close();
+  }
+}
+
+/**
+ * Give a child run its own canonical identity and event stream. Admission and
+ * effect/model evidence must never be projected into the parent's rollout or
+ * proceed with no durable consumer-visible journal.
+ */
+export function mountChildRunJournal(
+  options: MountChildRunJournalOptions,
+): RolloutStore | null {
+  const { parent, child } = options;
+  const parentRollout = parent.rolloutStore;
+  const admission = child.services.executionAdmission;
+  const requiresCanonicalJournal =
+    admission !== undefined || child.services.admissionRequired !== false;
+  if (parentRollout === null) {
+    if (requiresCanonicalJournal) {
+      throw new AdmissionDeniedError("child_run_journal_unavailable");
+    }
+    return null;
+  }
+
+  const sessionConfiguration = child.sessionConfiguration;
+  const store = new RolloutStore({
+    cwd: sessionConfiguration.cwd,
+    sessionId: child.conversationId,
+    agencVersion: parentRollout.store.agencVersion,
+    ...(parentRollout.projectRootMarkers !== undefined
+      ? { projectRootMarkers: parentRollout.projectRootMarkers }
+      : {}),
+  });
+  store.open({
+    sessionId: child.conversationId,
+    timestamp: new Date().toISOString(),
+    cwd: sessionConfiguration.cwd,
+    originator: options.originator,
+    agencVersion: parentRollout.store.agencVersion,
+    model: sessionConfiguration.collaborationMode.model,
+    modelProvider:
+      readProviderIdentity(child.services.provider) ??
+      child.services.provider.name,
+  });
+
+  try {
+    child.mountRolloutStore(store);
+    child.eventLog.seedCanonicalHistory(
+      store
+        .readAll()
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload),
+    );
+    if (admission !== undefined) {
+      const unbindAdmission = bindExecutionAdmissionJournal(child, admission);
+      child.onBeforeDurableClose(unbindAdmission);
+    }
+    child.onBeforeDurableClose(() => {
+      const result = options.terminalResult();
+      const epoch = store.runEpoch;
+      const runId = child.conversationId;
+      const lastSequenceBeforeTerminal =
+        Number.isSafeInteger(child.eventLog.lastSeq) &&
+        child.eventLog.lastSeq > 0
+          ? child.eventLog.lastSeq
+          : null;
+      const eventId = `run-terminal:${runId}:${epoch}`;
+      const terminal = child.emit({
+        eventId,
+        id: eventId,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId,
+            epoch,
+            status: result.status,
+            exitCode:
+              result.status === "completed"
+                ? 0
+                : result.status === "failed"
+                  ? 1
+                  : null,
+            stopReason: result.stopReason,
+            finalMessage: result.finalMessage ?? null,
+            usage: null,
+            lastSequenceBeforeTerminal,
+            finishedAt: new Date().toISOString(),
+          },
+        },
+      });
+      if (
+        terminal.eventId !== eventId ||
+        terminal.id !== eventId ||
+        !Number.isSafeInteger(terminal.seq) ||
+        (terminal.seq ?? 0) <= 0
+      ) {
+        throw new Error(
+          `child run_terminal ${eventId} has no canonical identity and sequence`,
+        );
+      }
+    });
+    return store;
+  } catch (error) {
+    child.mountRolloutStore(null);
+    try {
+      store.close();
+    } catch {
+      // Preserve the construction/binding failure.
+    }
+    throw error;
+  }
+}

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -23,6 +23,12 @@ import type { LLMContentPart, LLMMessage, LLMUsage } from "../llm/types.js";
 import type { AgentStatus } from "../agents/status.js";
 import type { AdmissionJournalEvent } from "../budget/admission-types.js";
 import type {
+  EffectOutcome,
+  RunTerminalStatus,
+  RunUsageTotals,
+} from "../contracts/run-contracts.js";
+import type { ToolRecoveryCategory } from "../tools/types.js";
+import type {
   CollaborationMode,
   FileSystemSandboxPolicy,
   Personality,
@@ -48,7 +54,7 @@ import type {
 export const ROLLOUT_SCHEMA_VERSION = 1;
 
 // ─────────────────────────────────────────────────────────────────────
-// Event envelope: { id, msg, seq }
+// Event envelope: { eventId, id, msg, seq }
 // ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -58,6 +64,13 @@ export const ROLLOUT_SCHEMA_VERSION = 1;
 export type EventSeq = number;
 
 export interface Event {
+  /**
+   * Canonical run-journal identity. EventLog assigns `event:<seq>` when a
+   * producer does not provide a stable identity. This is deliberately
+   * distinct from `id`, which remains the reusable session/subscription
+   * correlation envelope used by existing producers.
+   */
+  readonly eventId?: string;
   readonly id: string;
   readonly msg: EventMsg;
   /**
@@ -264,6 +277,45 @@ export interface RequestPermissionsEvent {
   readonly callId: string;
   readonly toolName: string;
   readonly permissions: ReadonlyArray<string>;
+  readonly turnId?: string;
+  readonly reason?: string;
+  readonly input?: Readonly<Record<string, unknown>>;
+  readonly planContent?: string;
+  readonly planFilePath?: string;
+  readonly recordedAt?: string;
+}
+
+/**
+ * Fsync-durable answer to a permission request. The request sequence ties the
+ * decision to the exact prompt that was shown; the decision kind is the
+ * stable, non-secret portion of ReviewDecision.
+ */
+export interface PermissionDecisionEvent {
+  readonly runId: string;
+  readonly callId: string;
+  readonly toolName: string;
+  readonly turnId: string;
+  readonly requestEventId: string;
+  readonly requestEventSeq: number;
+  readonly decision:
+    | "approved"
+    | "approved_execpolicy_amendment"
+    | "approved_for_session"
+    | "network_policy_amendment"
+    | "denied"
+    | "timed_out"
+    | "abort";
+  /** Which arbiter leg supplied the answer (human resolver, hook, cache, etc.). */
+  readonly source?:
+    | "hook"
+    | "resolver"
+    | "default_deny"
+    | "permission_hook"
+    | "guardian"
+    | "cache"
+    | "aborted";
+  readonly reason?: string;
+  readonly recordedAt: string;
 }
 
 export interface ContextCompactedEvent {
@@ -295,6 +347,146 @@ export interface StreamErrorEvent {
 export interface WarningEvent {
   readonly cause: string;
   readonly message: string;
+}
+
+/**
+ * Fsync-durable proof that an approved tool effect is about to cross the
+ * physical dispatch boundary. Arguments are represented by a digest so the
+ * journal remains bounded and does not become a second secret-bearing input
+ * store.
+ */
+export interface EffectIntentEvent {
+  readonly runId: string;
+  readonly stepId: string;
+  readonly callId: string;
+  readonly toolName: string;
+  readonly recoveryCategory: ToolRecoveryCategory;
+  /** Present only for effects whose contract is explicitly idempotent. */
+  readonly idempotencyKey?: string;
+  readonly intentDigest: string;
+  readonly attempt: number;
+  readonly recordedAt: string;
+}
+
+/**
+ * Fsync-durable acknowledgement of a proven effect outcome. Unknown physical
+ * outcomes use {@link EffectUnknownOutcomeEvent} and may not be overwritten by
+ * a late result without explicit review.
+ */
+export interface EffectResultEvent {
+  readonly runId: string;
+  readonly stepId: string;
+  readonly callId: string;
+  readonly toolName: string;
+  readonly recoveryCategory: ToolRecoveryCategory;
+  readonly idempotencyKey?: string;
+  readonly intentEventSeq: number;
+  readonly outcome: Exclude<EffectOutcome, "unknown_outcome">;
+  readonly resultDigest?: string;
+  readonly evidence?: Readonly<Record<string, unknown>>;
+  readonly recordedAt: string;
+}
+
+/**
+ * Fsync-durable acknowledgement that a non-idempotent effect crossed the
+ * dispatch boundary but its physical outcome cannot be proven. This is a
+ * review lock, not a retry signal.
+ */
+export interface EffectUnknownOutcomeEvent {
+  readonly runId: string;
+  readonly stepId: string;
+  readonly callId: string;
+  readonly toolName: string;
+  readonly recoveryCategory: ToolRecoveryCategory;
+  readonly idempotencyKey?: string;
+  readonly intentEventSeq: number;
+  readonly outcome: "unknown_outcome";
+  readonly reason: string;
+  readonly requiresReview: true;
+  readonly recordedAt: string;
+}
+
+/** Fsync-durable human resolution of an unknown effect outcome. */
+export interface EffectReviewResolvedEvent {
+  readonly runId: string;
+  readonly stepId: string;
+  readonly callId: string;
+  readonly resolution: string;
+  readonly reviewedBy: string;
+  readonly reviewedAt: string;
+}
+
+/**
+ * Fsync-durable declaration that an immutable content artifact is about to be
+ * published. The digest, byte length, and final target are sufficient to
+ * prove or disprove publication after a crash without replaying the producer.
+ */
+export interface ArtifactIntentEvent {
+  readonly runId: string;
+  readonly artifactId: string;
+  readonly kind: "tool_result";
+  readonly sourceCallId: string;
+  readonly targetPath: string;
+  readonly contentSha256: string;
+  readonly byteLength: number;
+  readonly recordedAt: string;
+}
+
+/** Fsync-durable acknowledgement that immutable artifact bytes are visible. */
+export interface ArtifactCommittedEvent extends ArtifactIntentEvent {
+  readonly intentEventSeq: number;
+  readonly outcome: "committed" | "already_committed" | "recovered";
+  readonly committedAt: string;
+}
+
+/** Durable terminal result for a root run, queryable after disconnect. */
+export interface RunTerminalEvent {
+  readonly runId: string;
+  readonly epoch: number;
+  readonly status: RunTerminalStatus;
+  readonly exitCode: number | null;
+  readonly stopReason: string | null;
+  readonly finalMessage: string | null;
+  readonly usage: RunUsageTotals | null;
+  /** Highest sequence committed before this terminal event was allocated. */
+  readonly lastSequenceBeforeTerminal: number | null;
+  readonly finishedAt: string;
+}
+
+/** Durable proof that a previously-terminal run entered a new review epoch. */
+export interface RunReopenedEvent {
+  readonly runId: string;
+  readonly previousEpoch: number;
+  readonly epoch: number;
+  readonly reason: string;
+  readonly reopenedAt: string;
+}
+
+/**
+ * Durable operator intent recorded before cancellation starts quiescing the
+ * run. Startup recovery uses this boundary to fail closed when the daemon dies
+ * after admission cancellation but before the terminal tail is committed.
+ */
+export interface RunCancelRequestedEvent {
+  readonly runId: string;
+  readonly epoch: number;
+  readonly reason: string;
+  readonly requestedAt: string;
+}
+
+/** Durable explanation of a restart decision that intentionally does no work. */
+export interface RecoveryDecisionEvent {
+  readonly runId: string;
+  readonly stepId?: string;
+  readonly decision:
+    | "retry_safe_deferred"
+    | "projection_rebuilt"
+    | "artifact_retry_safe_deferred"
+    | "artifact_conflict_review_required";
+  readonly reason: string;
+  readonly evidenceEventId: string;
+  readonly evidenceEventSeq: number;
+  readonly recordedAt: string;
 }
 
 export type GuardianAssessmentStatus =
@@ -740,6 +932,10 @@ export type EventMsg =
       readonly payload: RequestPermissionsEvent;
     }
   | {
+      readonly type: "permission_decision";
+      readonly payload: PermissionDecisionEvent;
+    }
+  | {
       readonly type: "request_user_input";
       readonly payload: RequestUserInputEvent;
     }
@@ -769,6 +965,31 @@ export type EventMsg =
   | { readonly type: "error"; readonly payload: ErrorEvent }
   | { readonly type: "stream_error"; readonly payload: StreamErrorEvent }
   | { readonly type: "warning"; readonly payload: WarningEvent }
+  | { readonly type: "effect_intent"; readonly payload: EffectIntentEvent }
+  | { readonly type: "effect_result"; readonly payload: EffectResultEvent }
+  | {
+      readonly type: "effect_unknown_outcome";
+      readonly payload: EffectUnknownOutcomeEvent;
+    }
+  | {
+      readonly type: "effect_review_resolved";
+      readonly payload: EffectReviewResolvedEvent;
+    }
+  | { readonly type: "artifact_intent"; readonly payload: ArtifactIntentEvent }
+  | {
+      readonly type: "artifact_committed";
+      readonly payload: ArtifactCommittedEvent;
+    }
+  | { readonly type: "run_terminal"; readonly payload: RunTerminalEvent }
+  | { readonly type: "run_reopened"; readonly payload: RunReopenedEvent }
+  | {
+      readonly type: "run_cancel_requested";
+      readonly payload: RunCancelRequestedEvent;
+    }
+  | {
+      readonly type: "recovery_decision";
+      readonly payload: RecoveryDecisionEvent;
+    }
   | {
       /** Durable projection of the daemon-owned M3 admission journal. */
       readonly type: "execution_admission";
@@ -982,6 +1203,17 @@ export const KNOWN_EVENT_TYPES = Object.freeze(
     "error",
     "stream_error",
     "warning",
+    "effect_intent",
+    "effect_result",
+    "effect_unknown_outcome",
+    "effect_review_resolved",
+    "permission_decision",
+    "artifact_intent",
+    "artifact_committed",
+    "run_terminal",
+    "run_reopened",
+    "run_cancel_requested",
+    "recovery_decision",
     "execution_admission",
     "guardian_assessment",
     "review_delegate_started",
@@ -1037,6 +1269,21 @@ const DURABLE_EVENT_TYPES = Object.freeze(
     // the 100ms batch path would be lost, defeating resume-continuation.
     "turn_checkpoint",
     "turn_resumed",
+    // M4 effect lifecycle records are commit boundaries. The intent must be
+    // durable before dispatch, and an acknowledgement must be durable before
+    // the caller is allowed to continue.
+    "effect_intent",
+    "effect_result",
+    "effect_unknown_outcome",
+    "effect_review_resolved",
+    "request_permissions",
+    "permission_decision",
+    "artifact_intent",
+    "artifact_committed",
+    "run_terminal",
+    "run_reopened",
+    "run_cancel_requested",
+    "recovery_decision",
   ]),
 );
 
@@ -1050,6 +1297,11 @@ export function isDurableEvent(event: Event): boolean {
 
 export type EventListener = (event: Event) => void;
 
+interface PendingPublication {
+  readonly event: Event;
+  readonly afterPublish?: EventListener;
+}
+
 /**
  * Synchronous, in-process event bus. Emitted events get a monotonic
  * `seq` assigned before any async work (I-27). Listeners receive
@@ -1058,27 +1310,90 @@ export type EventListener = (event: Event) => void;
  */
 export class EventLog {
   private nextSeq: EventSeq = 0;
+  private readonly allocatedEventIds = new Set<string>();
   private readonly listeners = new Set<EventListener>();
+  private readonly pendingPublications: PendingPublication[] = [];
+  private emitDelegate: ((event: Event) => Event) | undefined;
+  private publishing = false;
   private closed = false;
 
   /**
-   * Emit an event. Returns the assigned seq.
-   * I-27: synchronous + FIFO + monotonic.
+   * Install the owning Session's persist-before-publish path. Legacy runtime
+   * producers that still receive only `session.eventLog` then converge on the
+   * same rollout append instead of allocating live-only sequence numbers.
+   */
+  setEmitDelegate(delegate: ((event: Event) => Event) | undefined): void {
+    this.emitDelegate = delegate;
+  }
+
+  /**
+   * Allocate the next sequence without publishing to subscribers. Durable
+   * owners use this split phase to persist + fsync the stamped event before
+   * any listener can observe it.
+   */
+  stamp(event: Event): Event {
+    if (this.closed) return event;
+    const seq = this.nextSeq + 1;
+    const suppliedEventId: unknown = event.eventId;
+    if (
+      suppliedEventId !== undefined &&
+      (typeof suppliedEventId !== "string" || suppliedEventId.length === 0)
+    ) {
+      throw new Error("eventId must be a non-empty string");
+    }
+    if (
+      typeof suppliedEventId === "string" &&
+      /^event:[1-9]\d*$/.test(suppliedEventId) &&
+      suppliedEventId !== `event:${seq}`
+    ) {
+      throw new Error(
+        `eventId ${suppliedEventId} is reserved for sequence ${suppliedEventId.slice("event:".length)}`,
+      );
+    }
+    const eventId = suppliedEventId ?? `event:${seq}`;
+    if (this.allocatedEventIds.has(eventId)) {
+      throw new Error(`eventId already allocated: ${eventId}`);
+    }
+    this.nextSeq = seq;
+    this.allocatedEventIds.add(eventId);
+    return { ...event, eventId, seq };
+  }
+
+  /**
+   * Publish an already-stamped event. Re-entrant publications are queued so
+   * every listener observes monotonically increasing sequence order.
+   */
+  publish(event: Event, afterPublish?: EventListener): Event {
+    if (this.closed) return event;
+    this.pendingPublications.push({ event, afterPublish });
+    if (this.publishing) return event;
+    this.publishing = true;
+    try {
+      let next: PendingPublication | undefined;
+      while ((next = this.pendingPublications.shift()) !== undefined) {
+        for (const listener of this.listeners) {
+          try {
+            listener(next.event);
+          } catch {
+            // I-43: per-sidecar isolation — don't let one subscriber's
+            // failure prevent the others from receiving the event.
+          }
+        }
+        next.afterPublish?.(next.event);
+      }
+    } finally {
+      this.publishing = false;
+    }
+    return event;
+  }
+
+  /**
+   * Compatibility one-shot emit. Durable Session owners use stamp() followed
+   * by persistence and publish(); standalone event logs retain this API.
    */
   emit(event: Event): Event {
-    if (this.closed) return event;
-    this.nextSeq += 1;
-    const seq = this.nextSeq;
-    const stamped: Event = { ...event, seq };
-    for (const listener of this.listeners) {
-      try {
-        listener(stamped);
-      } catch {
-        // I-43: per-sidecar isolation — don't let one subscriber's
-        // failure prevent the others from receiving the event.
-      }
-    }
-    return stamped;
+    if (this.emitDelegate !== undefined) return this.emitDelegate(event);
+    return this.publish(this.stamp(event));
   }
 
   /**
@@ -1102,9 +1417,54 @@ export class EventLog {
     this.nextSeq = seq;
   }
 
+  /**
+   * Restore canonical coordinates before a resumed session accepts new
+   * producers. Sequence alone is insufficient: allowing an old eventId to be
+   * reused at a new sequence would permanently corrupt cursor replay.
+   */
+  seedCanonicalHistory(events: readonly Event[]): void {
+    let maxSequence = this.nextSeq;
+    const historicalSequences = new Set<number>();
+    for (const event of events) {
+      if (
+        !Number.isSafeInteger(event.seq) ||
+        event.seq === undefined ||
+        event.seq <= 0
+      ) {
+        continue;
+      }
+      const eventId =
+        typeof event.eventId === "string" && event.eventId.length > 0
+          ? event.eventId
+          : `legacy-event:${event.seq}:${event.id}`;
+      if (historicalSequences.has(event.seq)) {
+        throw new Error(`canonical rollout reuses sequence: ${event.seq}`);
+      }
+      const reservedSequence = /^event:([1-9]\d*)$/.exec(eventId)?.[1];
+      if (
+        reservedSequence !== undefined &&
+        Number(reservedSequence) !== event.seq
+      ) {
+        throw new Error(
+          `canonical rollout eventId ${eventId} conflicts with sequence ${event.seq}`,
+        );
+      }
+      if (this.allocatedEventIds.has(eventId)) {
+        throw new Error(`canonical rollout reuses eventId: ${eventId}`);
+      }
+      historicalSequences.add(event.seq);
+      this.allocatedEventIds.add(eventId);
+      maxSequence = Math.max(maxSequence, event.seq);
+    }
+    this.nextSeq = maxSequence;
+  }
+
   close(): void {
     this.closed = true;
+    this.emitDelegate = undefined;
+    this.pendingPublications.length = 0;
     this.listeners.clear();
+    this.allocatedEventIds.clear();
   }
 
   get isClosed(): boolean {

--- a/runtime/src/session/execution-admission-journal.ts
+++ b/runtime/src/session/execution-admission-journal.ts
@@ -1,0 +1,241 @@
+/** Canonical rollout projection for execution-admission transitions. */
+
+import type { ExecutionAdmissionClient } from "../budget/admission-client.js";
+import type { AdmissionJournalEvent } from "../budget/admission-types.js";
+import type { Event } from "./event-log.js";
+import type { RolloutStore } from "./rollout-store.js";
+import type { Session } from "./session.js";
+
+const EXECUTION_ADMISSION_CATCHUP_PAGE_SIZE = 1_000;
+const MAX_EXECUTION_ADMISSION_CATCHUP_EVENTS = 100_000;
+
+/**
+ * Project every live admission decision into one session's rollout. The
+ * SQLite admission journal remains authoritative across restart; this durable
+ * projection makes queue/reservation/reconcile/cancel/fallback decisions
+ * visible through the same canonical event stream as the run they govern.
+ */
+export function bindExecutionAdmissionJournal(
+  session: Session,
+  admission: ExecutionAdmissionClient,
+): () => void {
+  const append = (event: AdmissionJournalEvent): void => {
+    appendExecutionAdmissionEvent(session, event);
+  };
+  const unsubscribe =
+    admission.subscribeCritical?.(append) ?? admission.subscribe(append);
+  try {
+    // Subscribe first, then converge the durable pre-bind history. JavaScript
+    // cannot interleave another admission mutation during this synchronous
+    // capped scan; detached/rebound sessions simply re-scan and the append
+    // helper treats identical canonical evidence as an idempotent no-op.
+    const replayJournal = admission.replayJournal?.bind(admission);
+    let afterSequence = 0;
+    let replayed = 0;
+    while (replayJournal !== undefined) {
+      const page = replayJournal({
+        afterSequence,
+        limit: EXECUTION_ADMISSION_CATCHUP_PAGE_SIZE,
+      });
+      if (page.length > EXECUTION_ADMISSION_CATCHUP_PAGE_SIZE) {
+        throw new Error(
+          `execution admission catch-up page exceeded ${EXECUTION_ADMISSION_CATCHUP_PAGE_SIZE} events`,
+        );
+      }
+      if (page.length === 0) break;
+      for (const event of page) {
+        if (
+          !Number.isSafeInteger(event.sequence) ||
+          event.sequence <= afterSequence
+        ) {
+          throw new Error(
+            `execution admission catch-up made no monotonic progress after sequence ${afterSequence}`,
+          );
+        }
+        if (replayed >= MAX_EXECUTION_ADMISSION_CATCHUP_EVENTS) {
+          throw new Error(
+            `execution admission catch-up exceeded ${MAX_EXECUTION_ADMISSION_CATCHUP_EVENTS} events`,
+          );
+        }
+        append(event);
+        afterSequence = event.sequence;
+        replayed += 1;
+      }
+      if (page.length < EXECUTION_ADMISSION_CATCHUP_PAGE_SIZE) break;
+    }
+  } catch (error) {
+    unsubscribe();
+    throw error;
+  }
+  return unsubscribe;
+}
+
+/**
+ * Idempotently project one SQLite-authoritative admission transition into the
+ * canonical rollout. The admission event's existing eventId is carried into
+ * the protocol envelope instead of inventing a second identity. A retry after
+ * a post-fsync failure accepts only byte-equivalent evidence already present
+ * in the rollout.
+ */
+function appendExecutionAdmissionEvent(
+  session: Session,
+  payload: AdmissionJournalEvent,
+): void {
+  // Lightweight structural test adapters predate Session.rolloutStore. Keep
+  // their observer contract intact; real Session instances always own this
+  // field and must fail closed when no canonical store is attached.
+  const structuralSession = session as unknown as {
+    readonly rolloutStore?: RolloutStore | null;
+    emit: Session["emit"];
+  };
+  if (structuralSession.rolloutStore === undefined) {
+    structuralSession.emit(
+      {
+        eventId: payload.eventId,
+        id: payload.eventId,
+        msg: { type: "execution_admission", payload },
+      },
+      { durable: true },
+    );
+    return;
+  }
+  const rolloutStore = structuralSession.rolloutStore;
+  if (rolloutStore === null) {
+    throw new Error(
+      `execution admission event ${payload.eventId} has no canonical rollout store`,
+    );
+  }
+
+  const existing = findExecutionAdmissionEvent(rolloutStore, payload.eventId);
+  if (existing !== undefined) {
+    assertMatchingExecutionAdmissionEvent(existing, payload);
+    rolloutStore.syncCanonicalTail();
+    return;
+  }
+
+  try {
+    const event = session.emit(
+      {
+        eventId: payload.eventId,
+        id: payload.eventId,
+        msg: { type: "execution_admission", payload },
+      },
+      { durable: true },
+    );
+    if (
+      event.eventId !== payload.eventId ||
+      !Number.isSafeInteger(event.seq) ||
+      (event.seq ?? 0) <= 0
+    ) {
+      throw new Error(
+        `execution admission event ${payload.eventId} has no canonical coordinates`,
+      );
+    }
+    rememberExecutionAdmissionEvent(rolloutStore, event);
+  } catch (error) {
+    // Session.emit can fail after append/fsync (for example the M4 publish
+    // failpoint). Treat already-committed identical evidence as success; a
+    // missing or conflicting append remains a hard boundary failure.
+    executionAdmissionEventIndexes.delete(rolloutStore);
+    const committed = findExecutionAdmissionEvent(
+      rolloutStore,
+      payload.eventId,
+    );
+    if (committed !== undefined) {
+      assertMatchingExecutionAdmissionEvent(committed, payload);
+      rolloutStore.syncCanonicalTail();
+      return;
+    }
+    throw error;
+  }
+}
+
+interface ExecutionAdmissionEventIndex {
+  readonly byEventId: Map<string, Event[]>;
+}
+
+/**
+ * A rollout has a single writer under its SessionLock, so an identity index is
+ * stable for the life of that RolloutStore. Keeping it here makes live
+ * projection O(1) after one bounded scan instead of reparsing the complete
+ * journal at every provider/tool boundary. Ambiguous post-append failures
+ * explicitly invalidate and rebuild it from canonical bytes.
+ */
+const executionAdmissionEventIndexes = new WeakMap<
+  RolloutStore,
+  ExecutionAdmissionEventIndex
+>();
+
+function findExecutionAdmissionEvent(
+  rolloutStore: RolloutStore,
+  eventId: string,
+): Event | undefined {
+  const matches =
+    executionAdmissionEventIndex(rolloutStore).byEventId.get(eventId) ?? [];
+  if (matches.length > 1) {
+    throw new Error(
+      `execution admission event ${eventId} has duplicate canonical evidence`,
+    );
+  }
+  return matches[0];
+}
+
+function executionAdmissionEventIndex(
+  rolloutStore: RolloutStore,
+): ExecutionAdmissionEventIndex {
+  const cached = executionAdmissionEventIndexes.get(rolloutStore);
+  if (cached !== undefined) return cached;
+  const index: ExecutionAdmissionEventIndex = { byEventId: new Map() };
+  for (const item of rolloutStore.readAll()) {
+    if (item.type === "event_msg") {
+      indexExecutionAdmissionEvent(index, item.payload);
+    }
+  }
+  executionAdmissionEventIndexes.set(rolloutStore, index);
+  return index;
+}
+
+function rememberExecutionAdmissionEvent(
+  rolloutStore: RolloutStore,
+  event: Event,
+): void {
+  indexExecutionAdmissionEvent(
+    executionAdmissionEventIndex(rolloutStore),
+    event,
+  );
+}
+
+function indexExecutionAdmissionEvent(
+  index: ExecutionAdmissionEventIndex,
+  event: Event,
+): void {
+  const identities = new Set<string>();
+  if (typeof event.eventId === "string" && event.eventId.length > 0) {
+    identities.add(event.eventId);
+  }
+  if (event.msg.type === "execution_admission") {
+    identities.add(event.msg.payload.eventId);
+  }
+  for (const identity of identities) {
+    const matches = index.byEventId.get(identity) ?? [];
+    if (!matches.includes(event)) matches.push(event);
+    index.byEventId.set(identity, matches);
+  }
+}
+
+function assertMatchingExecutionAdmissionEvent(
+  event: Event,
+  payload: AdmissionJournalEvent,
+): void {
+  if (
+    event.eventId !== payload.eventId ||
+    !Number.isSafeInteger(event.seq) ||
+    (event.seq ?? 0) <= 0 ||
+    event.msg.type !== "execution_admission" ||
+    JSON.stringify(event.msg.payload) !== JSON.stringify(payload)
+  ) {
+    throw new Error(
+      `execution admission event ${payload.eventId} has conflicting canonical evidence`,
+    );
+  }
+}

--- a/runtime/src/session/lifecycle.ts
+++ b/runtime/src/session/lifecycle.ts
@@ -45,11 +45,12 @@ export interface SessionLifecycleOpts {
  * Orderly session shutdown:
  *   1. Quiesce the top-level abort controller (I-7) with a benign
  *      reason so phases see a shutdown signal.
- *   2. Cascade-shutdown every live subagent tree via `AgentControl.shutdownAll`.
- *   3. Close live unified exec processes.
- *   4. Delegate to `Session.shutdown()` (drain childInboxes + close
+ *   2. Abort and drain the root session's active task while its journal is open.
+ *   3. Cascade-shutdown every live subagent tree via `AgentControl.shutdownAll`.
+ *   4. Close live unified exec processes.
+ *   5. Delegate to `Session.shutdown()` (drain childInboxes + close
  *      rollout + event log + txEvent).
- *   5. Stop the MCP manager (close all bridges + kill child procs).
+ *   6. Stop the MCP manager (close all bridges + kill child procs).
  *
  * The whole teardown is bounded by `shutdownBudgetMs`. Any step that
  * exceeds the budget emits a warning event + moves on — we prefer
@@ -67,7 +68,23 @@ export async function shutdownSessionLifecycle(
     opts.session.abortController.abort("session_shutdown");
   }
 
-  // Step 2: cascade subagent shutdown (I-33 ordering — must happen
+  // Step 2: settle the root task, including any permission/effect
+  // continuations, before a background-run terminal can seal the journal.
+  const abortAllTasks = (
+    opts.session as Session & {
+      abortAllTasks?: (reason: "interrupted") => Promise<void>;
+    }
+  ).abortAllTasks;
+  if (typeof abortAllTasks === "function") {
+    await raceBudget(
+      abortAllTasks.call(opts.session, "interrupted"),
+      deadlineMs,
+      "session_active_task_shutdown",
+      opts.session,
+    );
+  }
+
+  // Step 3: cascade subagent shutdown (I-33 ordering — must happen
   // before Session.shutdown() drain, else children can refill mailboxes).
   if (opts.agentControl) {
     await raceBudget(
@@ -88,7 +105,7 @@ export async function shutdownSessionLifecycle(
     }
   ).services?.unifiedExecManager;
   if (unifiedExecManager?.closeAll) {
-    // Step 3: live terminal shutdown.
+    // Step 4: live terminal shutdown.
     await raceBudget(
       unifiedExecManager.closeAll("session_shutdown"),
       deadlineMs,
@@ -97,7 +114,7 @@ export async function shutdownSessionLifecycle(
     );
   }
 
-  // Step 4: I-33 + I-87 mailbox drain via Session.shutdown().
+  // Step 5: I-33 + I-87 mailbox drain via Session.shutdown().
   await raceBudget(
     opts.session.shutdown(),
     deadlineMs,
@@ -105,7 +122,7 @@ export async function shutdownSessionLifecycle(
     opts.session,
   );
 
-  // Step 5: MCP manager stop (best-effort; I-6 fail-soft).
+  // Step 6: MCP manager stop (best-effort; I-6 fail-soft).
   if (opts.mcpManager) {
     try {
       await raceBudget(

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -14,14 +14,15 @@
  * @module
  */
 
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-} from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
+import {
+  AtomicArtifactOperationUnsupportedError,
+  type AtomicArtifactObservation,
+  withAtomicArtifactObservationSync,
+} from "../durability/atomic-artifact.js";
+import { withPinnedOfflineRolloutLease } from "../durability/offline-rollout.js";
 import {
   AgentIdExistsError,
   InvalidAgentMetadataError,
@@ -30,9 +31,10 @@ import {
   type AgentPath,
   type ThreadId,
 } from "../agents/registry.js";
-import type { Event } from "./event-log.js";
-import type { RolloutItem } from "./rollout-item.js";
+import type { Event, EventMsg } from "./event-log.js";
+import { parseRolloutLine, type RolloutItem } from "./rollout-item.js";
 import {
+  getProjectDir,
   SessionStore,
   SessionStoreFlushScheduler,
   type AppendOptions,
@@ -49,6 +51,11 @@ import {
 } from "../state/unknown-outcome-gate.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
 import { ThreadSpawnEdgeRepository } from "../state/spawn-edges.js";
+import { StateRunDurabilityRepository } from "../state/run-durability.js";
+import { recordInFlightToolCallUnknownOutcome } from "../state/tool-output-rotation.js";
+import { resolveUnknownOutcomeEffect } from "../state/unknown-outcome-gate.js";
+import { getAgenCConfigHomeDir } from "../utils/envUtils.js";
+import { sanitizePath } from "../utils/path.js";
 import { isRecord } from "../utils/record.js";
 
 export interface RolloutStoreOpts extends SessionStoreOpts {
@@ -56,6 +63,18 @@ export interface RolloutStoreOpts extends SessionStoreOpts {
   readonly flushIntervalMs?: number;
   /** Whether to auto-start the background flush scheduler. Default true. */
   readonly autoStartScheduler?: boolean;
+}
+
+export class TerminalRunEpochOpenError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly epoch: number,
+  ) {
+    super(
+      `refusing to open terminal run ${runId} epoch ${epoch}; explicit reopen is required`,
+    );
+    this.name = "TerminalRunEpochOpenError";
+  }
 }
 
 export type ThreadSpawnEdgeStatus = "open" | "closed";
@@ -70,14 +89,45 @@ export interface ThreadSpawnEdgeRecord {
 
 const THREAD_SPAWN_EDGE_SNAPSHOT_VERSION = 1;
 
+function rolloutItemsContainTerminal(
+  items: readonly RolloutItem[],
+  runId: string,
+  epoch: number,
+): boolean {
+  return items.some(
+    (item) =>
+      item.type === "event_msg" &&
+      item.payload.msg.type === "run_terminal" &&
+      item.payload.msg.payload.runId === runId &&
+      item.payload.msg.payload.epoch === epoch,
+  );
+}
+
+function rolloutContentContainsTerminal(
+  content: string,
+  runId: string,
+  epoch: number,
+): boolean {
+  const items: RolloutItem[] = [];
+  for (const line of content.split("\n")) {
+    const item = parseRolloutLine(line);
+    if (item !== null) items.push(item);
+  }
+  return rolloutItemsContainTerminal(items, runId, epoch);
+}
+
 export class RolloutStore {
   readonly store: SessionStore;
   private readonly scheduler: SessionStoreFlushScheduler;
   private readonly startScheduler: boolean;
+  private readonly resumed: boolean;
   readonly projectRootMarkers?: readonly string[];
   private readonly threadSpawnEdgePath: string;
   private readonly stateDriver: StateSqliteDriver;
   private readonly threadSpawnEdgeRepo: ThreadSpawnEdgeRepository;
+  private readonly runDurabilityRepo: StateRunDurabilityRepository;
+  private openedAt: string | undefined;
+  private openedEpoch: number | undefined;
 
   constructor(opts: RolloutStoreOpts) {
     this.store = new SessionStore(opts);
@@ -86,6 +136,7 @@ export class RolloutStore {
       opts.flushIntervalMs ?? 100,
     );
     this.startScheduler = opts.autoStartScheduler !== false;
+    this.resumed = opts.resume === true;
     this.projectRootMarkers = opts.projectRootMarkers;
     this.threadSpawnEdgePath = join(
       this.store.sessionDir,
@@ -96,16 +147,179 @@ export class RolloutStore {
       projectRootMarkers: opts.projectRootMarkers,
     });
     this.threadSpawnEdgeRepo = new ThreadSpawnEdgeRepository(this.stateDriver);
+    this.runDurabilityRepo = new StateRunDurabilityRepository(this.stateDriver);
     this.loadThreadSpawnEdges();
   }
 
   open(meta: Parameters<SessionStore["open"]>[0]): void {
-    this.store.open(meta);
-    if (this.startScheduler) this.scheduler.start();
+    try {
+      this.assertJournalSourceWritable();
+      const existingEpoch = this.runDurabilityRepo.currentEpoch(meta.sessionId);
+      if (
+        existingEpoch !== undefined &&
+        this.currentEpochIsTerminal(meta.sessionId, existingEpoch.epoch)
+      ) {
+        throw new TerminalRunEpochOpenError(
+          meta.sessionId,
+          existingEpoch.epoch,
+        );
+      }
+
+      this.store.open(meta);
+      // Re-check under the canonical rollout lease. Retention can retire the
+      // binding between the optimistic check above and lock acquisition; a
+      // source carrying an inactive binding is historical and must never be
+      // revived as a writer merely because its directory rename failed.
+      this.assertJournalSourceWritable();
+      const current = this.runDurabilityRepo.currentEpoch(meta.sessionId);
+      const epoch =
+        current ??
+        this.runDurabilityRepo.ensureInitialEpoch({
+          runId: meta.sessionId,
+          openedAt: meta.timestamp,
+        }).value;
+      this.openedAt = epoch.openedAt;
+      this.openedEpoch = epoch.epoch;
+      if (this.currentEpochIsTerminal(meta.sessionId, epoch.epoch)) {
+        throw new TerminalRunEpochOpenError(meta.sessionId, epoch.epoch);
+      }
+      if (
+        this.runDurabilityRepo.getJournalBinding(this.rolloutPath) === undefined
+      ) {
+        this.runDurabilityRepo.bindJournalSource({
+          runId: meta.sessionId,
+          epoch: epoch.epoch,
+          childRunId: meta.sessionId,
+          sessionId: meta.sessionId,
+          sourcePath: this.rolloutPath,
+          boundAt: epoch.openedAt,
+        });
+      }
+      if (this.resumed) this.recoverEffectProjectionOnOpen();
+      if (this.startScheduler) this.scheduler.start();
+    } catch (error) {
+      this.scheduler.stop();
+      this.store.close();
+      this.stateDriver.close();
+      throw error;
+    }
   }
 
-  append(event: Event, opts: AppendOptions = {}): void {
-    this.store.append(event, opts);
+  append(event: Event, opts: AppendOptions = {}): boolean {
+    return this.store.append(event, opts);
+  }
+
+  /** Lifecycle epoch owned by this canonical rollout writer. */
+  get runEpoch(): number {
+    if (this.openedEpoch === undefined) {
+      throw new Error(`rollout store for ${this.sessionId} is not open`);
+    }
+    return this.openedEpoch;
+  }
+
+  /** Project a fsync-committed effect event into rebuildable M4 state. */
+  recordEffectEvent(event: Event): void {
+    const sequence = event.seq;
+    if (!Number.isSafeInteger(sequence) || (sequence ?? 0) <= 0) {
+      throw new Error("effect projection requires a positive event sequence");
+    }
+    const eventId = canonicalRolloutEventId(event);
+    const message = event.msg;
+    if (message.type === "effect_intent") {
+      const payload = message.payload;
+      const epoch = this.requireRunEpoch(payload.runId);
+      this.runDurabilityRepo.beginEffect({
+        runId: payload.runId,
+        epoch: epoch.epoch,
+        stepId: payload.stepId,
+        ...(this.sessionId !== payload.runId
+          ? { childRunId: this.sessionId }
+          : {}),
+        sessionId: this.sessionId,
+        callId: payload.callId,
+        toolName: payload.toolName,
+        recoveryCategory: payload.recoveryCategory,
+        ...(payload.idempotencyKey !== undefined
+          ? { idempotencyKey: payload.idempotencyKey }
+          : {}),
+        intentDigest: payload.intentDigest,
+        eventId,
+        eventSequence: sequence!,
+        intentAt: payload.recordedAt,
+      });
+      return;
+    }
+    if (message.type === "effect_result") {
+      const payload = message.payload;
+      this.runDurabilityRepo.completeEffect({
+        runId: payload.runId,
+        stepId: payload.stepId,
+        outcome: payload.outcome,
+        eventId,
+        eventSequence: sequence!,
+        ...(payload.resultDigest !== undefined
+          ? { resultDigest: payload.resultDigest }
+          : {}),
+        ...(payload.evidence !== undefined
+          ? { evidence: payload.evidence }
+          : {}),
+        completedAt: payload.recordedAt,
+      });
+      return;
+    }
+    if (message.type === "effect_unknown_outcome") {
+      const payload = message.payload;
+      if (payload.recoveryCategory === "idempotent") {
+        throw new Error("idempotent effects cannot have unknown outcome");
+      }
+      this.runDurabilityRepo.markEffectUnknown({
+        runId: payload.runId,
+        stepId: payload.stepId,
+        eventId,
+        eventSequence: sequence!,
+        reason: payload.reason,
+        evidence: { requiresReview: payload.requiresReview },
+        observedAt: payload.recordedAt,
+      });
+      recordInFlightToolCallUnknownOutcome(this.stateDriver, {
+        sessionId: this.sessionId,
+        agentId: payload.runId,
+        toolCallId: payload.callId,
+        toolName: payload.toolName,
+        observedAt: payload.recordedAt,
+        recoveryCategory: payload.recoveryCategory,
+      });
+      return;
+    }
+    if (message.type === "effect_review_resolved") {
+      const payload = message.payload;
+      const effect = this.runDurabilityRepo.getEffect(
+        payload.runId,
+        payload.stepId,
+      );
+      if (effect === undefined || effect.callId !== payload.callId) {
+        throw new Error(
+          `effect review ${eventId} has no matching durable unknown outcome`,
+        );
+      }
+      this.runDurabilityRepo.resolveEffectReview({
+        runId: payload.runId,
+        stepId: payload.stepId,
+        reviewedAt: payload.reviewedAt,
+        reviewedBy: payload.reviewedBy,
+        resolution: payload.resolution,
+        eventId,
+        evidence: {
+          callId: payload.callId,
+          sequence,
+          source: "canonical_run_journal",
+        },
+      });
+      resolveUnknownOutcomeEffect(this.stateDriver, {
+        sessionId: effect.sessionId,
+        toolCallId: effect.callId,
+      });
+    }
   }
 
   appendRollout(item: RolloutItem, opts: AppendOptions = {}): void {
@@ -289,13 +503,364 @@ export class RolloutStore {
 
   /** Force an immediate flush (durable=true). */
   flushDurable(): void {
-    this.store.flushBatch(true);
+    if (!this.store.flushBatch(true)) {
+      throw new Error("rollout flush was not fsync-committed");
+    }
+  }
+
+  /** Fsync the existing canonical tail even when no batch is pending. */
+  syncCanonicalTail(): void {
+    this.store.syncCanonicalTail();
   }
 
   close(): void {
     this.scheduler.stop();
     this.stateDriver.close();
     this.store.close();
+  }
+
+  private requireRunEpoch(runId: string) {
+    const epoch = this.runDurabilityRepo.currentEpoch(runId);
+    if (epoch !== undefined) return epoch;
+    if (runId !== this.sessionId || this.openedAt === undefined) {
+      throw new Error(`run ${runId} has no durable lifecycle epoch`);
+    }
+    return this.runDurabilityRepo.ensureInitialEpoch({
+      runId,
+      openedAt: this.openedAt,
+    }).value;
+  }
+
+  private assertJournalSourceWritable(): void {
+    const binding = this.runDurabilityRepo.getJournalBinding(this.rolloutPath);
+    if (binding !== undefined && !binding.active) {
+      throw new Error(
+        `refusing to reopen inactive canonical journal source ${this.rolloutPath}`,
+      );
+    }
+  }
+
+  private currentEpochIsTerminal(runId: string, epoch: number): boolean {
+    if (this.runDurabilityRepo.getTerminalResult(runId, epoch) !== undefined) {
+      return true;
+    }
+    if (rolloutItemsContainTerminal(this.store.readAll(), runId, epoch)) {
+      return true;
+    }
+
+    const projectDir = getProjectDir(this.store.cwd, this.projectRootMarkers);
+    for (const binding of this.runDurabilityRepo.listJournalBindings(
+      runId,
+      epoch,
+    )) {
+      if (binding.sourcePath === this.rolloutPath) continue;
+      const terminal = withPinnedOfflineRolloutLease(
+        {
+          projectDir,
+          sessionId: binding.sessionId,
+          sourcePath: binding.sourcePath,
+        },
+        (rollout) =>
+          rolloutContentContainsTerminal(rollout.readUtf8(), runId, epoch),
+      );
+      if (terminal) return true;
+    }
+    return false;
+  }
+
+  private recoverEffectProjectionOnOpen(): void {
+    const events = this.store
+      .readAll()
+      .filter(
+        (item): item is Extract<RolloutItem, { readonly type: "event_msg" }> =>
+          item.type === "event_msg",
+      )
+      .map((item) => item.payload)
+      .filter(isSequencedEvent)
+      .sort((left, right) => left.seq - right.seq);
+    const effectEvents = events.filter(isEffectLifecycleEvent);
+    for (const event of effectEvents) this.recordEffectEvent(event);
+
+    // Artifact and effect recovery share one canonical sequence cursor. Each
+    // recovery append must advance from the tail written by the previous
+    // recovery family; otherwise SessionStore can reject the duplicate
+    // sequence while SQLite still projects it, splitting the authorities.
+    let nextSequence = this.recoverArtifactJournalOnOpen(events);
+
+    const settledSteps = new Set(
+      effectEvents
+        .filter((event) => event.msg.type !== "effect_intent")
+        .map((event) => event.msg.payload.stepId),
+    );
+    const existingEventIds = new Set(events.map(canonicalRolloutEventId));
+    const existingEffectRecoveryEvidence = new Set(
+      events.flatMap((event) => {
+        if (
+          event.msg.type !== "recovery_decision" ||
+          typeof event.msg.payload.stepId !== "string" ||
+          typeof event.msg.payload.evidenceEventId !== "string" ||
+          !Number.isSafeInteger(event.msg.payload.evidenceEventSeq) ||
+          event.msg.payload.evidenceEventSeq <= 0
+        ) {
+          return [];
+        }
+        return [
+          recoveryEvidenceKey(
+            event.msg.payload.evidenceEventId,
+            event.msg.payload.evidenceEventSeq,
+          ),
+        ];
+      }),
+    );
+    for (const intent of effectEvents) {
+      if (intent.msg.type !== "effect_intent") continue;
+      const payload = intent.msg.payload;
+      if (settledSteps.has(payload.stepId)) continue;
+      const admissionStatus = this.effectAdmissionStatus(
+        payload.runId,
+        payload.stepId,
+      );
+      const cancelledBeforeDispatch =
+        admissionStatus === "reserved" || admissionStatus === "voided";
+      const intentEventId = canonicalRolloutEventId(intent);
+      if (
+        payload.recoveryCategory === "idempotent" &&
+        existingEffectRecoveryEvidence.has(
+          recoveryEvidenceKey(intentEventId, intent.seq),
+        )
+      ) {
+        continue;
+      }
+      const preferredEventId =
+        payload.recoveryCategory === "idempotent"
+          ? `recovery-decision:${intentEventId}`
+          : cancelledBeforeDispatch
+            ? `effect-cancelled-recovery:${intentEventId}`
+            : `effect-unknown-recovery:${intentEventId}`;
+      const eventId = uniqueRecoveryEventId(preferredEventId, existingEventIds);
+      nextSequence += 1;
+      const recordedAt = new Date().toISOString();
+      const recovery: Event =
+        payload.recoveryCategory === "idempotent"
+          ? {
+              eventId,
+              id: eventId,
+              seq: nextSequence,
+              msg: {
+                type: "recovery_decision",
+                payload: {
+                  runId: payload.runId,
+                  stepId: payload.stepId,
+                  decision: "retry_safe_deferred",
+                  reason:
+                    "durable idempotency key proves retry safety; automatic replay is deferred to an explicit caller",
+                  evidenceEventId: intentEventId,
+                  evidenceEventSeq: intent.seq,
+                  recordedAt,
+                },
+              },
+            }
+          : cancelledBeforeDispatch
+            ? {
+                eventId,
+                id: eventId,
+                seq: nextSequence,
+                msg: {
+                  type: "effect_result",
+                  payload: {
+                    runId: payload.runId,
+                    stepId: payload.stepId,
+                    callId: payload.callId,
+                    toolName: payload.toolName,
+                    recoveryCategory: payload.recoveryCategory,
+                    intentEventSeq: intent.seq,
+                    outcome: "cancelled",
+                    evidence: {
+                      reason: "daemon_recovered_before_effect_dispatch",
+                      admissionStatus,
+                    },
+                    recordedAt,
+                  },
+                },
+              }
+            : {
+                eventId,
+                id: eventId,
+                seq: nextSequence,
+                msg: {
+                  type: "effect_unknown_outcome",
+                  payload: {
+                    runId: payload.runId,
+                    stepId: payload.stepId,
+                    callId: payload.callId,
+                    toolName: payload.toolName,
+                    recoveryCategory: payload.recoveryCategory,
+                    intentEventSeq: intent.seq,
+                    outcome: "unknown_outcome",
+                    reason: "daemon_recovered_without_effect_acknowledgement",
+                    requiresReview: true,
+                    recordedAt,
+                  },
+                },
+              };
+      if (!this.store.append(recovery, { durable: true })) {
+        throw new Error(`failed to commit recovery event ${eventId}`);
+      }
+      existingEventIds.add(eventId);
+      if (
+        recovery.msg.type === "effect_unknown_outcome" ||
+        recovery.msg.type === "effect_result"
+      ) {
+        this.recordEffectEvent(recovery);
+        settledSteps.add(payload.stepId);
+      }
+    }
+  }
+
+  private effectAdmissionStatus(
+    runId: string,
+    stepId: string,
+  ): string | undefined {
+    return this.stateDriver
+      .prepareState<[string, string], { readonly status: string }>(
+        `SELECT status
+         FROM execution_admission_reservations
+         WHERE run_id = ? AND step_id = ?
+         ORDER BY attempt DESC
+         LIMIT 1`,
+      )
+      .get(runId, stepId)?.status;
+  }
+
+  private recoverArtifactJournalOnOpen(
+    events: readonly SequencedEvent[],
+  ): number {
+    const committedIntentSequences = new Set(
+      events
+        .filter(
+          (event): event is ArtifactCommittedLifecycleEvent =>
+            event.msg.type === "artifact_committed",
+        )
+        .map((event) => event.msg.payload.intentEventSeq),
+    );
+    const existingRecoveryEvidence = new Set(
+      events
+        .filter(
+          (event): event is RecoveryDecisionLifecycleEvent =>
+            event.msg.type === "recovery_decision",
+        )
+        .map((event) => event.msg.payload.evidenceEventSeq),
+    );
+    const existingEventIds = new Set(
+      events.flatMap((event) => [canonicalRolloutEventId(event), event.id]),
+    );
+    let nextSequence = events.at(-1)?.seq ?? 0;
+
+    for (const intent of events) {
+      if (intent.msg.type !== "artifact_intent") continue;
+      const payload = intent.msg.payload;
+      const artifactRoot = trustedArtifactRoot(payload.targetPath, [
+        resolve(this.store.sessionDir, "tool-results"),
+        resolve(
+          getAgenCConfigHomeDir(),
+          "projects",
+          sanitizePath(this.store.cwd),
+          this.sessionId,
+          "tool-results",
+        ),
+      ]);
+      const consumeObservation = (
+        observation: AtomicArtifactObservation,
+      ): void => {
+        if (
+          committedIntentSequences.has(intent.seq) ||
+          (existingRecoveryEvidence.has(intent.seq) && observation !== "match")
+        ) {
+          return;
+        }
+        nextSequence += 1;
+        const recordedAt = new Date().toISOString();
+        const recoveryEventId = uniqueRecoveryEventId(
+          observation === "match"
+            ? `artifact-committed-recovery:${intent.id}`
+            : `artifact-recovery-decision:${intent.id}`,
+          existingEventIds,
+        );
+        const recovery: Event =
+          observation === "match"
+            ? {
+                eventId: recoveryEventId,
+                id: recoveryEventId,
+                seq: nextSequence,
+                msg: {
+                  type: "artifact_committed",
+                  payload: {
+                    ...payload,
+                    intentEventSeq: intent.seq,
+                    outcome: "recovered",
+                    committedAt: recordedAt,
+                  },
+                },
+              }
+            : {
+                eventId: recoveryEventId,
+                id: recoveryEventId,
+                seq: nextSequence,
+                msg: {
+                  type: "recovery_decision",
+                  payload: {
+                    runId: payload.runId,
+                    decision:
+                      observation === "missing"
+                        ? "artifact_retry_safe_deferred"
+                        : "artifact_conflict_review_required",
+                    reason:
+                      observation === "missing"
+                        ? "artifact target was not published; immutable retry is safe but deferred to an explicit caller"
+                        : "artifact target contains bytes that do not match the durable intent; automatic overwrite is forbidden",
+                    evidenceEventId: canonicalRolloutEventId(intent),
+                    evidenceEventSeq: intent.seq,
+                    recordedAt,
+                  },
+                },
+              };
+        if (!this.store.append(recovery, { durable: true })) {
+          throw new Error(
+            `failed to commit artifact recovery event ${recovery.id}`,
+          );
+        }
+        existingEventIds.add(recoveryEventId);
+      };
+
+      if (artifactRoot === undefined) {
+        consumeObservation("conflict");
+        continue;
+      }
+      try {
+        withAtomicArtifactObservationSync(
+          payload.targetPath,
+          payload.contentSha256,
+          payload.byteLength,
+          {
+            trustedRoot: artifactRoot,
+            // The resumed session owns the journal lease. A stranded private
+            // temp is swept through the same pinned root used for proof; it is
+            // never promoted and cannot redirect cleanup outside this run.
+            cleanupOrphanedTemps: true,
+          },
+          consumeObservation,
+        );
+      } catch (error) {
+        if (!(error instanceof AtomicArtifactOperationUnsupportedError)) {
+          throw error;
+        }
+        // Without descriptor-relative child operations there is no safe proof
+        // of a match. Continue conservatively as a review-required conflict;
+        // never acknowledge bytes observed only through a racy pathname.
+        consumeObservation("conflict");
+      }
+    }
+    return nextSequence;
   }
 
   private loadThreadSpawnEdges(): void {
@@ -346,6 +911,85 @@ export class RolloutStore {
   }
 }
 
+type SequencedEvent = Event & { readonly seq: number };
+type EffectLifecycleEvent = SequencedEvent & {
+  readonly msg: Extract<
+    EventMsg,
+    {
+      readonly type:
+        | "effect_intent"
+        | "effect_result"
+        | "effect_unknown_outcome"
+        | "effect_review_resolved";
+    }
+  >;
+};
+type ArtifactCommittedLifecycleEvent = SequencedEvent & {
+  readonly msg: Extract<EventMsg, { readonly type: "artifact_committed" }>;
+};
+type RecoveryDecisionLifecycleEvent = SequencedEvent & {
+  readonly msg: Extract<EventMsg, { readonly type: "recovery_decision" }>;
+};
+
+function isSequencedEvent(event: Event): event is SequencedEvent {
+  return (
+    typeof event.seq === "number" &&
+    Number.isSafeInteger(event.seq) &&
+    event.seq > 0
+  );
+}
+
+function canonicalRolloutEventId(event: SequencedEvent | Event): string {
+  if (typeof event.eventId === "string" && event.eventId.length > 0) {
+    return event.eventId;
+  }
+  if (
+    typeof event.seq === "number" &&
+    Number.isSafeInteger(event.seq) &&
+    event.seq > 0
+  ) {
+    return `legacy-event:${event.seq}:${event.id}`;
+  }
+  throw new Error(
+    "canonical rollout event identity requires eventId or sequence",
+  );
+}
+
+function isEffectLifecycleEvent(
+  event: SequencedEvent,
+): event is EffectLifecycleEvent {
+  return (
+    event.msg.type === "effect_intent" ||
+    event.msg.type === "effect_result" ||
+    event.msg.type === "effect_unknown_outcome" ||
+    event.msg.type === "effect_review_resolved"
+  );
+}
+
+function trustedArtifactRoot(
+  targetPath: string,
+  allowedArtifactRoots: readonly string[],
+): string | undefined {
+  const targetDirectory = dirname(resolve(targetPath));
+  return allowedArtifactRoots.find(
+    (artifactRoot) => relative(resolve(artifactRoot), targetDirectory) === "",
+  );
+}
+
+function uniqueRecoveryEventId(
+  base: string,
+  existing: ReadonlySet<string>,
+): string {
+  if (!existing.has(base)) return base;
+  let suffix = 2;
+  while (existing.has(`${base}:${suffix}`)) suffix += 1;
+  return `${base}:${suffix}`;
+}
+
+function recoveryEvidenceKey(eventId: string, sequence: number): string {
+  return `${sequence}\0${eventId}`;
+}
+
 function normalizeThreadSpawnEdgesSnapshot(
   parsed: unknown,
 ): ReadonlyArray<ThreadSpawnEdgeRecord> {
@@ -368,12 +1012,14 @@ function normalizeThreadSpawnEdgesSnapshot(
   }
 
   if (Array.isArray(parsed.threadSpawnEdges)) {
-    return parsed.threadSpawnEdges.map((edge) => normalizeThreadSpawnEdge(edge));
+    return parsed.threadSpawnEdges.map((edge) =>
+      normalizeThreadSpawnEdge(edge),
+    );
   }
 
   if (isRecord(parsed.threadSpawnEdges)) {
-    return Object.entries(parsed.threadSpawnEdges).map(([childThreadId, edge]) =>
-      normalizeThreadSpawnEdge(edge, childThreadId),
+    return Object.entries(parsed.threadSpawnEdges).map(
+      ([childThreadId, edge]) => normalizeThreadSpawnEdge(edge, childThreadId),
     );
   }
 
@@ -431,8 +1077,7 @@ function normalizeThreadSpawnEdge(
     typeof edge.childThreadId === "string"
       ? edge.childThreadId
       : fallbackChildThreadId;
-  const status =
-    edge.status === undefined ? "open" : edge.status;
+  const status = edge.status === undefined ? "open" : edge.status;
 
   const metadata = normalizeAgentMetadata(edge.metadata);
   if (

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -48,10 +48,10 @@
 
 import {
   accessSync,
-  appendFileSync,
   closeSync,
   constants as fsConstants,
   existsSync,
+  fstatSync,
   ftruncateSync,
   fsyncSync,
   linkSync,
@@ -158,6 +158,33 @@ const DEGRADED_ERRNOS: ReadonlyArray<string> = [
 export function isDegradedErrno(err: unknown): boolean {
   const code = (err as { code?: string } | null)?.code;
   return !!code && DEGRADED_ERRNOS.includes(code);
+}
+
+/**
+ * A short append failed after changing the file and the best-effort rollback
+ * could not itself be made durable.  The caller must not requeue the same
+ * rows: doing so could turn an uncertain partial tail into duplicate canonical
+ * records.  Startup tail repair remains the recovery boundary.
+ */
+class AppendRollbackError extends Error {
+  readonly code?: string;
+
+  constructor(
+    readonly writeError: unknown,
+    readonly rollbackError: unknown,
+    readonly bytesWritten: number,
+    readonly appendStart: number,
+  ) {
+    super(
+      `canonical rollout append failed after ${bytesWritten} bytes and rollback failed`,
+      { cause: rollbackError },
+    );
+    this.name = "AppendRollbackError";
+    const code =
+      (writeError as { readonly code?: string } | null)?.code ??
+      (rollbackError as { readonly code?: string } | null)?.code;
+    if (code !== undefined) this.code = code;
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -426,13 +453,6 @@ export class SessionLock {
       const existing = this.readLockRecord();
       if (existing !== null) {
         // Lock file exists. Decide if we can reclaim.
-        if (existing.pid === process.pid) {
-          // We already hold it (re-entry in same process). Treat as
-          // acquired — but prefer this to be a no-op at the caller
-          // level; we still set acquired=true so release() works.
-          this.acquired = true;
-          return;
-        }
         if (processIsAlive(existing.pid)) {
           throw new SessionLockedError(existing.pid, this.lockPath);
         }
@@ -581,12 +601,15 @@ export class SessionLock {
   release(): void {
     if (!this.acquired) return;
     try {
-      // Only remove the lock if we still own it. A stale reclaim by
-      // another process after our death is acceptable, but a live
-      // handoff to another holder must not be clobbered by our
-      // release.
+      // Only remove the lock if this exact SessionLock instance still owns it.
+      // PID equality alone is insufficient: two independent stores in one
+      // daemon have the same PID, and one must never release the other's lease.
       const existing = this.readLockRecord();
-      if (existing === null || existing.pid === process.pid) {
+      if (
+        existing !== null &&
+        existing.pid === process.pid &&
+        existing.startNs === this.startNs
+      ) {
         unlinkSync(this.lockPath);
       }
     } catch {
@@ -709,7 +732,13 @@ export function rewriteAtomically(
  * occurred. Callers should emit a `warning:'rollout_truncated_corrupt_tail'`
  * when truncated.
  */
-export function truncateCorruptTail(rolloutPath: string): {
+export function truncateCorruptTail(
+  rolloutPath: string,
+  repair: {
+    readonly truncate?: (fd: number, length: number) => void;
+    readonly sync?: (fd: number) => void;
+  } = {},
+): {
   readonly truncated: boolean;
   readonly newSize: number;
 } {
@@ -728,14 +757,8 @@ export function truncateCorruptTail(rolloutPath: string): {
     if (lastNewline === -1) {
       // Entire tail window has no newline — file has a single
       // un-terminated line. Truncate to zero.
-      try {
-        // node fs doesn't expose ftruncate on fd directly in sync API
-        // via `fd` — use ftruncateSync.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        ftruncateSync(fd, 0);
-      } catch {
-        /* best-effort */
-      }
+      (repair.truncate ?? ftruncateSync)(fd, 0);
+      (repair.sync ?? fsyncSync)(fd);
       return { truncated: true, newSize: 0 };
     }
     // Check if tail after last newline is empty (normal complete file).
@@ -744,13 +767,8 @@ export function truncateCorruptTail(rolloutPath: string): {
       return { truncated: false, newSize: stat.size };
     }
     // Partial line exists after last newline — truncate.
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      ftruncateSync(fd, afterLastNewlineIdx);
-      fsyncSync(fd);
-    } catch {
-      /* best-effort */
-    }
+    (repair.truncate ?? ftruncateSync)(fd, afterLastNewlineIdx);
+    (repair.sync ?? fsyncSync)(fd);
     return { truncated: true, newSize: afterLastNewlineIdx };
   } finally {
     closeSync(fd);
@@ -860,6 +878,15 @@ export class SessionStore {
    * transient and persistent fsync failures.
    */
   private fsyncImpl: (fd: number) => void = fsyncSync;
+  private writeImpl: (
+    fd: number,
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+  ) => number = (fd, buffer, offset, length) =>
+    writeSync(fd, buffer, offset, length);
+  /** Exact pre-append boundary whose rollback could not be durably proven. */
+  private uncertainAppendStart: number | undefined;
   private readonly trajectoryExport: TrajectoryExportSink;
 
   constructor(opts: SessionStoreOpts) {
@@ -920,6 +947,11 @@ export class SessionStore {
             message: `rollout tail truncated to ${truncResult.newSize} bytes (I-24 recovery)`,
           });
         }
+        // Recovery may encounter complete rows written by a prior process whose
+        // fsync failed before it died. Re-sync the surviving canonical prefix
+        // under this source's exclusive lease before any caller treats those
+        // bytes as durable recovery evidence.
+        this.syncCanonicalFile();
         this.fileSize = statSync(this.rolloutPath).size;
         const snapshot = readIndexSnapshot(this.indexPath);
         if (snapshot && snapshot.rolloutPath === this.rolloutPath) {
@@ -1036,30 +1068,42 @@ export class SessionStore {
     this.fsyncImpl = impl;
   }
 
+  /** @internal Test seam for short-write recovery. */
+  setWriteImplForTest(
+    impl: (
+      fd: number,
+      buffer: Uint8Array,
+      offset: number,
+      length: number,
+    ) => number,
+  ): void {
+    this.writeImpl = impl;
+  }
+
   /**
    * Append an event. Called by Session.emit(). Durable events (per
    * isDurableEvent or explicit `opts.durable`) flush immediately +
    * fsync (I-4). Others batch until 100ms or the next durable event.
    *
-   * UUID dedup: events with a `seq` already written are silently
-   * dropped. Events WITHOUT seq (sidecar synth or replay re-entry)
-   * are deduped by `event.id`. Prevents double-append on fork-flush
-   * or replay-merge edge cases.
+   * Sequenced writes are strictly monotonic. A repeated/backward sequence is
+   * a writer bug and fails closed; silently accepting it would let a caller
+   * project or publish an event that the canonical rollout rejected. Events
+   * WITHOUT seq (sidecar synth or replay re-entry) remain deduped by `event.id`.
    */
-  append(event: Event, opts: AppendOptions = {}): void {
-    if (!this.opened || this.closed) return;
+  append(event: Event, opts: AppendOptions = {}): boolean {
+    if (!this.opened || this.closed) return false;
     // I-27: seq monotonicity check. Caller assigns via EventLog; we
     // just verify.
     if (event.seq !== undefined && event.seq <= this.lastSeqWritten) {
-      // Reject backward seq — it indicates a reducer bug. Also dedup
-      // when the same seq value repeats (same event emitted twice).
-      return;
+      throw new Error(
+        `non-monotonic rollout event sequence ${event.seq}; canonical tail is ${this.lastSeqWritten}`,
+      );
     }
     // UUID dedup — if we've already seen this event.id, skip. Only
     // applies to events without a seq (sidecar synth / replay); seq'd
     // events are already ordered by the EventLog monotonic counter.
     if (event.seq === undefined) {
-      if (this.seenEventIds.has(event.id)) return;
+      if (this.seenEventIds.has(event.id)) return true;
       this.seenEventIds.add(event.id);
       // Bound the dedup set — evict oldest once it grows past 10K.
       if (this.seenEventIds.size > 10_000) {
@@ -1112,12 +1156,13 @@ export class SessionStore {
 
     const durable = opts.durable === true || isDurableEvent(event);
     if (durable) {
-      this.flushBatch(/*durable*/ true);
+      return this.flushBatch(/*durable*/ true);
     } else if (this.pending.length >= 1024) {
       // Flush if the batch gets large to bound memory even before the
       // 100ms tick.
-      this.flushBatch(/*durable*/ false);
+      return this.flushBatch(/*durable*/ false);
     }
+    return true;
   }
 
   /**
@@ -1126,16 +1171,21 @@ export class SessionStore {
    * batched and eventually flushed.
    */
   appendRollout(item: RolloutItem, opts: AppendOptions = {}): void {
-    if (!this.opened || this.closed) return;
+    const durable =
+      opts.durable === true ||
+      (item.type === "event_msg" && isDurableEvent(item.payload));
+    if (!this.opened || this.closed) {
+      if (durable) {
+        throw new Error("cannot commit durable rollout item to a closed store");
+      }
+      return;
+    }
     if (this.batchOpenedAtMs === null) {
       this.batchOpenedAtMs = monotonicMs();
     }
     this.pending.push(item);
-    const durable =
-      opts.durable === true ||
-      (item.type === "event_msg" && isDurableEvent(item.payload));
-    if (durable) {
-      this.flushBatch(true);
+    if (durable && !this.flushBatch(true)) {
+      throw new Error("durable rollout item was not fsync-committed");
     }
   }
 
@@ -1144,10 +1194,10 @@ export class SessionStore {
    * the sidecar manager or by `append()` on durable events. Exposed
    * for tests.
    */
-  flushBatch(durable: boolean): void {
+  flushBatch(durable: boolean): boolean {
     if (this.pending.length === 0) {
       this.batchOpenedAtMs = null;
-      return;
+      return true;
     }
     // I-83 suspend detection: if the batch was open for > 10s (e.g.
     // system suspend/resume gap), emit TWO marker events (warning +
@@ -1221,10 +1271,12 @@ export class SessionStore {
     this.pending = [];
     this.batchOpenedAtMs = null;
 
-    // `requeue` distinguishes the two failure shapes (#11):
-    //   - writeSync itself threw (ENOSPC/EROFS/…): the bytes never
-    //     reached the file, so the items must be re-queued into the
-    //     degraded ring buffer for a later re-append (requeue=true).
+    // `requeue` distinguishes the failure shapes (#11):
+    //   - writeSync failed before writing, or a partial append was rolled back
+    //     and fsync'd: the items can be re-queued into the degraded ring buffer
+    //     for a later complete re-append (requeue=true).
+    //   - a partial append could not be durably rolled back: the on-disk tail
+    //     is uncertain and re-append could duplicate it (requeue=false).
     //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
     //     bytes are ALREADY appended to the rollout on disk. Re-queueing
     //     them would re-serialize + re-append the same rows on degraded
@@ -1254,13 +1306,14 @@ export class SessionStore {
       return false;
     };
 
+    let committed = true;
     try {
       if (durable) {
         // I-38: async retry on fsync failure routes to degraded via
         // the callback. The bytes were already writeSync'd by this
         // point, so we MUST NOT re-queue them (#11) — only enter
         // degraded mode.
-        this.writeBytesWithFsync(lines, (err) => {
+        committed = this.writeBytesWithFsync(lines, (err) => {
           routeToDegraded(err, /*requeue*/ false);
         });
       } else {
@@ -1269,15 +1322,50 @@ export class SessionStore {
       this.fileSize += Buffer.byteLength(lines, "utf8");
       this.trajectoryExport.writeItems(toWrite);
     } catch (err) {
-      // writeSync threw — bytes never landed; re-queue for re-append.
-      if (!routeToDegraded(err, /*requeue*/ true)) {
+      const safeToRequeue = !(err instanceof AppendRollbackError);
+      if (!routeToDegraded(err, safeToRequeue)) {
         throw err;
       }
+      committed = false;
+    }
+    return committed;
+  }
+
+  /**
+   * Establish an explicit fsync proof for the complete canonical tail even
+   * when there is no pending in-memory batch. Idempotent recovery paths call
+   * this before accepting already-present journal evidence after an earlier
+   * ambiguous fsync failure.
+   */
+  syncCanonicalTail(): void {
+    if (!this.opened || this.closed) {
+      throw new Error("cannot sync canonical tail on a closed store");
+    }
+    if (this.pending.length > 0 && !this.flushBatch(true)) {
+      throw new Error("canonical rollout tail was not fsync-committed");
+    }
+    this.syncCanonicalFile();
+  }
+
+  private syncCanonicalFile(): void {
+    const flags = fsConstants.O_WRONLY | fsConstants.O_APPEND;
+    const fd = openSync(this.rolloutPath, flags, 0o600);
+    try {
+      this.repairUncertainAppendTail(fd);
+      this.fsyncImpl(fd);
+    } finally {
+      closeSync(fd);
     }
   }
 
   private writeBytesAppendOnly(content: string): void {
-    appendFileSync(this.rolloutPath, content, { mode: 0o600 });
+    const flags = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND;
+    const fd = openSync(this.rolloutPath, flags, 0o600);
+    try {
+      this.writeAll(fd, content);
+    } finally {
+      closeSync(fd);
+    }
   }
 
   /**
@@ -1305,12 +1393,12 @@ export class SessionStore {
   private writeBytesWithFsync(
     content: string,
     onRetryFailure?: (err: unknown) => void,
-  ): void {
+  ): boolean {
     const flags = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND;
     const fd = openSync(this.rolloutPath, flags, 0o600);
     let firstErr: unknown;
     try {
-      writeSync(fd, content);
+      this.writeAll(fd, content);
       try {
         this.fsyncImpl(fd);
       } catch (err) {
@@ -1325,7 +1413,57 @@ export class SessionStore {
       // re-opening the file and calling fsyncSync on that fd flushes
       // the same kernel-level buffers to disk.
       this.scheduleFsyncRetry(firstErr, onRetryFailure);
+      return false;
     }
+    return true;
+  }
+
+  private writeAll(fd: number, content: string): void {
+    this.repairUncertainAppendTail(fd);
+    const bytes = Buffer.from(content, "utf8");
+    const appendStart = fstatSync(fd).size;
+    let offset = 0;
+    try {
+      while (offset < bytes.length) {
+        const written = this.writeImpl(fd, bytes, offset, bytes.length - offset);
+        if (
+          !Number.isSafeInteger(written) ||
+          written <= 0 ||
+          written > bytes.length - offset
+        ) {
+          throw new Error(
+            `short write while appending canonical rollout ${this.rolloutPath}`,
+          );
+        }
+        offset += written;
+      }
+    } catch (writeError) {
+      if (offset === 0) throw writeError;
+      try {
+        ftruncateSync(fd, appendStart);
+        this.fsyncImpl(fd);
+      } catch (rollbackError) {
+        this.uncertainAppendStart = Math.min(
+          this.uncertainAppendStart ?? appendStart,
+          appendStart,
+        );
+        throw new AppendRollbackError(
+          writeError,
+          rollbackError,
+          offset,
+          appendStart,
+        );
+      }
+      throw writeError;
+    }
+  }
+
+  private repairUncertainAppendTail(fd: number): void {
+    const boundary = this.uncertainAppendStart;
+    if (boundary === undefined) return;
+    ftruncateSync(fd, boundary);
+    this.fsyncImpl(fd);
+    this.uncertainAppendStart = undefined;
   }
 
   /**
@@ -1475,9 +1613,12 @@ export class SessionStore {
     };
     try {
       const line = serializeRolloutItem(item);
-      this.writeBytesWithFsync(line, (err) => {
+      const committed = this.writeBytesWithFsync(line, (err) => {
         routeToDegraded(err, /*requeue*/ false);
       });
+      if (!committed) {
+        throw new Error("session metadata was not fsync-committed");
+      }
       this.fileSize += Buffer.byteLength(line, "utf8");
       this.trajectoryExport.writeItems([item]);
     } catch (err) {

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -136,6 +136,7 @@ import type { RolloutStore } from "./rollout-store.js";
 import type { LiveThread } from "../thread-store/live-thread.js";
 import type { RolloutTraceRecorder } from "./rollout-trace.js";
 import type { AppendOptions } from "./session-store.js";
+import { hitM4DurabilityFailpoint } from "../durability/failpoints.js";
 import {
   cloneLlmMessage,
   llmMessageToResponseItem,
@@ -1816,6 +1817,21 @@ export class Session {
   private rolloutPersistenceSuspendDepth = 0;
 
   /**
+   * Work whose completion can append a durable boundary record (for example,
+   * the decision paired with a pending permission request). Shutdown drains
+   * this set before it allows the run terminal callback to seal the journal.
+   */
+  private readonly pendingDurableOperations = new Set<Promise<unknown>>();
+
+  /** One-shot callbacks run after shutdown has quiesced event producers. */
+  private readonly beforeDurableCloseListeners = new Set<
+    () => void | Promise<void>
+  >();
+
+  /** Once set, no event may be appended after the canonical terminal tail. */
+  private canonicalJournalSealed = false;
+
+  /**
    * TUI-facing PhaseEvent subscribers. The one-shot CLI renders these
    * directly from the generator; the live TUI needs an in-session bus
    * so `useQuery` can observe the same stream.
@@ -1870,6 +1886,9 @@ export class Session {
    */
   constructor(opts: SessionOpts) {
     this.conversationId = opts.conversationId;
+    // Keep legacy producers that were handed `session.eventLog` on the same
+    // canonical persist-before-publish path as direct `session.emit` callers.
+    this.eventLog.setEmitDelegate((event) => this.emit(event));
     this.roleWorkspace = opts.roleWorkspace
       ? normalizeAgentRoleWorkspace(opts.roleWorkspace)
       : createAgentRoleWorkspace(opts.initialState.sessionConfiguration.cwd);
@@ -2520,6 +2539,34 @@ export class Session {
     }
   }
 
+  /**
+   * Register a promise that may still append durable journal evidence.
+   * Registration is deliberately synchronous so shutdown cannot miss work
+   * that started immediately before ingress was closed.
+   */
+  trackDurableOperation<T>(operation: Promise<T>): Promise<T> {
+    this.pendingDurableOperations.add(operation);
+    void operation.then(
+      () => this.pendingDurableOperations.delete(operation),
+      () => this.pendingDurableOperations.delete(operation),
+    );
+    return operation;
+  }
+
+  /**
+   * Register a finalizer that runs while the rollout writer remains open but
+   * after shutdown hooks, active work, and other durable operations drain.
+   */
+  onBeforeDurableClose(listener: () => void | Promise<void>): () => void {
+    if (this.canonicalJournalSealed) {
+      throw new Error("canonical run journal is already sealed");
+    }
+    this.beforeDurableCloseListeners.add(listener);
+    return () => {
+      this.beforeDurableCloseListeners.delete(listener);
+    };
+  }
+
   async submit(
     message: string | readonly LLMContentPart[],
     opts: SessionSubmitOptions = {},
@@ -3126,15 +3173,34 @@ export class Session {
    * I-8: every error site MUST funnel through this or the dedicated
    * `emitError` helper (event-log.ts).
    */
-  emit(event: Event, appendOpts: AppendOptions = {}): void {
+  emit(event: Event, appendOpts: AppendOptions = {}): Event {
+    if (this.canonicalJournalSealed) {
+      throw new Error(
+        `cannot append ${event.msg.type}: canonical run journal is sealed`,
+      );
+    }
     if (
       event.msg.type === "context_compacted" ||
       (event.msg as { type?: string }).type === "compacted"
     ) {
       this.clearProviderResponseId();
     }
-    // I-27: assign seq synchronously + fan to subscribers.
-    const stamped = this.eventLog.emit(event);
+    if (this.isRolloutPersistenceSuspended()) {
+      // Fork turns share the source Session for model/tool plumbing, but their
+      // events are intentionally excluded from its canonical rollout. Keep
+      // those observations explicitly ephemeral: consuming the source
+      // EventLog sequence here would create an unreplayable interior hole, and
+      // retaining caller-supplied coordinates would let the live bridge claim
+      // an event that run.replay can never return.
+      const ephemeral: Event = { id: event.id, msg: event.msg };
+      this.eventLog.publish(ephemeral, (published) => {
+        this.txEvent.send(published);
+      });
+      return ephemeral;
+    }
+    // I-27 + M4: allocate identity/sequence first, but do not let a listener
+    // observe a durable transition until its rollout append has fsynced.
+    const stamped = this.eventLog.stamp(event);
     const derivedTurnId =
       appendOpts.turnId ??
       (stamped.msg.type === "tool_call_completed"
@@ -3146,17 +3212,30 @@ export class Session {
         ? measureToolResultBytes(stamped.msg.payload.result)
         : undefined);
     // T6: persist if store is wired. isDurableEvent triggers I-4 fsync.
-    if (this.rolloutStore && !this.isRolloutPersistenceSuspended()) {
-      this.rolloutStore.append(stamped, {
-        durable: isDurableEvent(stamped) || appendOpts.durable === true,
+    const durable = isDurableEvent(stamped) || appendOpts.durable === true;
+    if (this.rolloutStore) {
+      const committed = this.rolloutStore.append(stamped, {
+        durable,
         ...(derivedTurnId !== undefined ? { turnId: derivedTurnId } : {}),
         ...(derivedToolResultBytes !== undefined
           ? { toolResultBytes: derivedToolResultBytes }
           : {}),
       });
+      if (durable && committed === false) {
+        throw new Error(
+          `durable event ${stamped.msg.type} sequence ${stamped.seq ?? "unassigned"} was not fsync-committed`,
+        );
+      }
     }
-    // Compatibility consumer path.
-    this.txEvent.send(stamped);
+    hitM4DurabilityFailpoint("before_event_publish");
+    this.eventLog.publish(stamped, (published) => {
+      // Compatibility consumers belong to the same FIFO publication queue.
+      // A listener may synchronously emit another event; keeping this callback
+      // inside EventLog prevents txEvent from observing N+1 before N.
+      this.txEvent.send(published);
+      hitM4DurabilityFailpoint("after_event_publish");
+    });
+    return stamped;
   }
 
   /**
@@ -4089,6 +4168,43 @@ export class Session {
     } catch {
       /* best-effort */
     }
+    let durableCloseError: unknown;
+    try {
+      let drainedOperationCount = 0;
+      while (this.pendingDurableOperations.size > 0) {
+        const pending = [...this.pendingDurableOperations];
+        drainedOperationCount += pending.length;
+        if (drainedOperationCount > 100_000) {
+          throw new Error(
+            "durable shutdown drain exceeded 100000 operations",
+          );
+        }
+        const outcomes = await Promise.allSettled(pending);
+        const failures = outcomes.flatMap((outcome) =>
+          outcome.status === "rejected" ? [outcome.reason] : [],
+        );
+        if (failures.length > 0) {
+          throw new AggregateError(
+            failures,
+            "durable shutdown operation failed",
+          );
+        }
+      }
+
+      const finalizers = [...this.beforeDurableCloseListeners];
+      this.beforeDurableCloseListeners.clear();
+      for (const finalize of finalizers) {
+        await finalize();
+      }
+    } catch (error) {
+      durableCloseError = error;
+    } finally {
+      // Whether terminal finalization succeeded or failed, no producer may
+      // append around/after the close boundary. A failed finalizer therefore
+      // remains honestly non-terminal and requires recovery from committed
+      // evidence rather than permitting a late competing result.
+      this.canonicalJournalSealed = true;
+    }
     // Flush + close the rollout store (I-4: final durable fsync).
     if (this.rolloutStore) {
       try {
@@ -4108,6 +4224,7 @@ export class Session {
     this.txEvent.close();
     this.agentStatus.next({ status: "shutdown", endedAtMs: monotonicMs() });
     this.agentStatus.complete();
+    if (durableCloseError !== undefined) throw durableCloseError;
   }
 }
 

--- a/runtime/src/state/backfill.ts
+++ b/runtime/src/state/backfill.ts
@@ -2,10 +2,10 @@ import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
+  fstatSync,
   openSync,
   readSync,
   readdirSync,
-  readFileSync,
   type Stats,
   statSync,
 } from "node:fs";
@@ -61,61 +61,151 @@ export function backfillRolloutFile(options: {
   readonly archived?: boolean;
   readonly threads: StateThreadRepository;
 }): { readonly itemsIndexed: number } {
-  const stat = statSync(options.rolloutPath);
-  const existing = options.threads.getBackfillFile(options.rolloutPath);
+  const snapshotFd = openSync(options.rolloutPath, "r");
+  try {
+    const stat = fstatSync(snapshotFd);
+    assertRolloutRecordBoundary(snapshotFd, options.rolloutPath, stat.size);
+    const existing = options.threads.getBackfillFile(options.rolloutPath);
 
-  // Fast path 1 — file unchanged since last index. The rollout file is an
-  // append-only log; identical size and mtime means nothing was appended, so
-  // there is no work to do. Avoids re-reading and re-hashing the whole file
-  // on every `appendItems` call.
-  if (
-    existing !== undefined &&
-    existing.size === stat.size &&
-    existing.mtimeMs === stat.mtimeMs
-  ) {
-    return { itemsIndexed: 0 };
-  }
-
-  // Fast path 2 — file grew (pure append). Read and parse only the appended
-  // tail and INSERT only the new lines, leaving prior rows untouched. This
-  // keeps each append O(bytes appended) instead of O(file size), avoiding the
-  // O(N^2) re-index that an unconditional DELETE-all + re-INSERT-all causes.
-  if (existing !== undefined && stat.size > existing.size) {
-    const appended = readAppendedTail(options.rolloutPath, existing.size);
-    if (appended !== undefined) {
-      return indexAppendedTail({
-        rolloutPath: options.rolloutPath,
-        archived: options.archived,
-        threads: options.threads,
-        stat,
-        priorSize: existing.size,
-        existing,
-        tail: appended,
-      });
+    // Fast path 1 — file unchanged since last index. The rollout file is an
+    // append-only log; identical size and mtime means nothing was appended, so
+    // there is no work to do. Avoids re-reading and re-hashing the whole file
+    // on every `appendItems` call.
+    if (
+      existing !== undefined &&
+      existing.size === stat.size &&
+      existing.mtimeMs === stat.mtimeMs
+    ) {
+      assertSnapshotStillCanonical(options.rolloutPath, stat);
+      return { itemsIndexed: 0 };
     }
-    // The tail read was unusable (e.g. a partial line straddling the prior
-    // size boundary); fall through to a full reconcile below.
-  }
 
-  // Full reconcile path — first index, truncation, rewrite, or any case the
-  // incremental fast paths could not safely handle. Preserves crash/resume
-  // correctness by rebuilding the file's rows from scratch.
-  return reindexWholeRolloutFile({
-    rolloutPath: options.rolloutPath,
-    archived: options.archived,
-    threads: options.threads,
-    stat,
-  });
+    // Fast path 2 — file grew (pure append). Read and parse only the appended
+    // tail and INSERT only the new lines, leaving prior rows untouched. This
+    // keeps each append O(bytes appended) instead of O(file size), avoiding the
+    // O(N^2) re-index that an unconditional DELETE-all + re-INSERT-all causes.
+    if (existing !== undefined && stat.size > existing.size) {
+      const appended = readAppendedTail(
+        snapshotFd,
+        options.rolloutPath,
+        existing.size,
+        stat.size,
+      );
+      if (appended !== undefined) {
+        return indexAppendedTail({
+          rolloutPath: options.rolloutPath,
+          archived: options.archived,
+          threads: options.threads,
+          stat,
+          priorSize: existing.size,
+          existing,
+          tail: appended,
+        });
+      }
+      // The tail read was unusable (e.g. a partial line straddling the prior
+      // size boundary); fall through to a full reconcile below.
+    }
+
+    // Full reconcile path — first index, truncation, rewrite, or any case the
+    // incremental fast paths could not safely handle. Preserves crash/resume
+    // correctness by rebuilding the file's rows from scratch.
+    return reindexWholeRolloutFile({
+      snapshotFd,
+      rolloutPath: options.rolloutPath,
+      archived: options.archived,
+      threads: options.threads,
+      stat,
+    });
+  } finally {
+    closeSync(snapshotFd);
+  }
+}
+
+/**
+ * Project bytes already read through a descriptor-pinned offline rollout
+ * lease. Unlike {@link backfillRolloutFile}, this entry point never reopens
+ * the canonical source by pathname. The caller-supplied validation runs at
+ * the final boundary of the same SQLite transaction as the projection.
+ */
+export function backfillPinnedRolloutContent(options: {
+  readonly rolloutPath: string;
+  readonly raw: string;
+  readonly archived?: boolean;
+  readonly threads: StateThreadRepository;
+  readonly mtimeMs: number;
+  readonly validateCanonical: () => void;
+}): { readonly itemsIndexed: number } {
+  const { rolloutPath, raw, threads } = options;
+  assertTerminatedJsonl(raw, rolloutPath);
+  const threadId = threadIdFromRolloutPath(rolloutPath);
+  const items: RolloutItemRow[] = [];
+  let byteOffset = 0;
+  let itemIndex = 0;
+  let firstMeta: Extract<RolloutItem, { type: "session_meta" }> | undefined;
+  let latestMeta: Extract<RolloutItem, { type: "session_meta" }> | undefined;
+  const lines = raw.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    const lineBytes = Buffer.byteLength(line) + 1;
+    if (line.trim().length === 0) {
+      byteOffset += lineBytes;
+      continue;
+    }
+    let parsed: RolloutItem | null;
+    try {
+      parsed = parseRolloutLine(line);
+    } catch {
+      byteOffset += lineBytes;
+      continue;
+    }
+    if (parsed !== null) {
+      if (parsed.type === "session_meta") {
+        firstMeta ??= parsed;
+        latestMeta = parsed;
+      }
+      items.push(rolloutItemRow(parsed, i + 1, byteOffset, itemIndex, line));
+      itemIndex += 1;
+    }
+    byteOffset += lineBytes;
+  }
+  const now = new Date(options.mtimeMs).toISOString();
+  threads.commitRolloutProjection(
+    () => {
+      mergeThreadFromMeta({
+        threads,
+        threadId,
+        rolloutPath,
+        archived: options.archived,
+        now,
+        createdAt: firstMeta?.payload.timestamp,
+        metaForUpdate: latestMeta?.payload,
+        metaForCreate: firstMeta?.payload,
+      });
+      threads.replaceRolloutItems({
+        threadId,
+        sourcePath: rolloutPath,
+        items,
+        mtimeMs: options.mtimeMs,
+        size: Buffer.byteLength(raw),
+        sha256: createHash("sha256").update(raw).digest("hex"),
+        lineCount: lines.length,
+      });
+    },
+    options.validateCanonical,
+  );
+  return { itemsIndexed: items.length };
 }
 
 function reindexWholeRolloutFile(args: {
+  readonly snapshotFd: number;
   readonly rolloutPath: string;
   readonly archived?: boolean;
   readonly threads: StateThreadRepository;
   readonly stat: Stats;
 }): { readonly itemsIndexed: number } {
   const { rolloutPath, threads, stat } = args;
-  const raw = readFileSync(rolloutPath, "utf8");
+  const raw = readRolloutSnapshot(args.snapshotFd, rolloutPath, 0, stat.size);
+  assertTerminatedJsonl(raw, rolloutPath);
   const threadId = threadIdFromRolloutPath(rolloutPath);
   const items: RolloutItemRow[] = [];
   let byteOffset = 0;
@@ -150,25 +240,30 @@ function reindexWholeRolloutFile(args: {
     byteOffset += lineBytes;
   }
   const now = new Date(stat.mtimeMs).toISOString();
-  mergeThreadFromMeta({
-    threads,
-    threadId,
-    rolloutPath,
-    archived: args.archived,
-    now,
-    createdAt: firstMeta?.payload.timestamp,
-    metaForUpdate: latestMeta?.payload,
-    metaForCreate: firstMeta?.payload,
-  });
-  threads.replaceRolloutItems({
-    threadId,
-    sourcePath: rolloutPath,
-    items,
-    mtimeMs: stat.mtimeMs,
-    size: stat.size,
-    sha256: createHash("sha256").update(raw).digest("hex"),
-    lineCount: lines.length,
-  });
+  threads.commitRolloutProjection(
+    () => {
+      mergeThreadFromMeta({
+        threads,
+        threadId,
+        rolloutPath,
+        archived: args.archived,
+        now,
+        createdAt: firstMeta?.payload.timestamp,
+        metaForUpdate: latestMeta?.payload,
+        metaForCreate: firstMeta?.payload,
+      });
+      threads.replaceRolloutItems({
+        threadId,
+        sourcePath: rolloutPath,
+        items,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+        sha256: createHash("sha256").update(raw).digest("hex"),
+        lineCount: lines.length,
+      });
+    },
+    () => assertSnapshotStillCanonical(rolloutPath, stat),
+  );
   return { itemsIndexed: items.length };
 }
 
@@ -186,6 +281,7 @@ function indexAppendedTail(args: {
   readonly tail: string;
 }): { readonly itemsIndexed: number } {
   const { rolloutPath, threads, stat, existing, tail } = args;
+  assertTerminatedJsonl(tail, rolloutPath);
   const threadId = threadIdFromRolloutPath(rolloutPath);
   const items: RolloutItemRow[] = [];
   // Prior content occupied line numbers 1..(lineCount-1) plus a trailing empty
@@ -228,6 +324,7 @@ function indexAppendedTail(args: {
     lineNumber += 1;
   }
   const now = new Date(stat.mtimeMs).toISOString();
+  assertSnapshotStillCanonical(rolloutPath, stat);
   // mergeThread overwrites createdAt/updatedAt unconditionally with whatever we
   // pass, so carry the already-recorded values forward. The first session_meta
   // (the source of createdAt) lives in the unchanged prefix we did not re-read,
@@ -236,33 +333,71 @@ function indexAppendedTail(args: {
   // an append and then jump back on the next full reconcile. Carry the prior
   // updatedAt forward so it only advances when a newer meta timestamp appears,
   // matching the full-reconcile semantics.
-  const prior = threads.getThread(threadId);
-  mergeThreadFromMeta({
-    threads,
-    threadId,
-    rolloutPath,
-    archived: args.archived,
-    now,
-    createdAt: firstMeta?.payload.timestamp ?? prior?.createdAt,
-    updatedAt: prior?.updatedAt,
-    metaForUpdate: latestMeta?.payload,
-    metaForCreate: firstMeta?.payload,
-  });
-  threads.appendRolloutItems({
-    threadId,
-    sourcePath: rolloutPath,
-    items,
-    mtimeMs: stat.mtimeMs,
-    size: stat.size,
-    // Carry the prior full-file digest forward rather than re-hashing the whole
-    // file on every append (which would reintroduce the O(N^2) behaviour). The
-    // canonical full-file hash is re-established whenever a full reconcile runs.
-    // Change detection here relies on mtime+size, not this digest.
-    sha256: existing.sha256,
-    lineCount: existing.lineCount + (lines.length - 1),
-    totalItemCount: itemIndex,
-  });
+  threads.commitRolloutProjection(
+    () => {
+      const prior = threads.getThread(threadId);
+      mergeThreadFromMeta({
+        threads,
+        threadId,
+        rolloutPath,
+        archived: args.archived,
+        now,
+        createdAt: firstMeta?.payload.timestamp ?? prior?.createdAt,
+        updatedAt: prior?.updatedAt,
+        metaForUpdate: latestMeta?.payload,
+        metaForCreate: firstMeta?.payload,
+      });
+      threads.appendRolloutItems({
+        threadId,
+        sourcePath: rolloutPath,
+        items,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+        // Carry the prior full-file digest forward rather than re-hashing the whole
+        // file on every append (which would reintroduce the O(N^2) behaviour). The
+        // canonical full-file hash is re-established whenever a full reconcile runs.
+        // Change detection here relies on mtime+size, not this digest.
+        sha256: existing.sha256,
+        lineCount: existing.lineCount + (lines.length - 1),
+        totalItemCount: itemIndex,
+      });
+    },
+    () => assertSnapshotStillCanonical(rolloutPath, stat),
+  );
   return { itemsIndexed: items.length };
+}
+
+/**
+ * A newline is the rollout commit boundary. Backfill runs without the session
+ * writer lease, so it must never bless a crash-complete-but-unterminated JSON
+ * object as canonical evidence. SessionStore owns repair/truncation under the
+ * lease; callers retry projection after that recovery succeeds.
+ */
+function assertRolloutRecordBoundary(
+  snapshotFd: number,
+  rolloutPath: string,
+  size: number,
+): void {
+  if (size === 0) return;
+  const boundary = Buffer.allocUnsafe(1);
+  if (
+    readSync(snapshotFd, boundary, 0, 1, size - 1) !== 1 ||
+    boundary[0] !== 0x0a
+  ) {
+    throw unterminatedRollout(rolloutPath);
+  }
+}
+
+function assertTerminatedJsonl(content: string, rolloutPath: string): void {
+  if (content.length > 0 && !content.endsWith("\n")) {
+    throw unterminatedRollout(rolloutPath);
+  }
+}
+
+function unterminatedRollout(rolloutPath: string): Error {
+  return new Error(
+    `refusing to index unterminated canonical rollout without its session lease: ${rolloutPath}`,
+  );
 }
 
 function rolloutItemRow(
@@ -278,11 +413,32 @@ function rolloutItemRow(
     itemIndex,
     itemType: parsed.type,
     eventVersion: parsed.eventVersion,
-    eventId: parsed.type === "event_msg" ? parsed.payload.id : undefined,
+    eventId:
+      parsed.type === "event_msg"
+        ? canonicalProjectedEventId(parsed.payload)
+        : undefined,
     eventSeq: parsed.type === "event_msg" ? parsed.payload.seq : undefined,
     payloadJson: JSON.stringify(parsed.payload),
     lineHash: createHash("sha256").update(line).digest("hex"),
   };
+}
+
+function canonicalProjectedEventId(
+  event: Extract<RolloutItem, { readonly type: "event_msg" }>[
+    "payload"
+  ],
+): string {
+  if (typeof event.eventId === "string" && event.eventId.length > 0) {
+    return event.eventId;
+  }
+  if (
+    typeof event.seq === "number" &&
+    Number.isSafeInteger(event.seq) &&
+    event.seq > 0
+  ) {
+    return `legacy-event:${event.seq}:${event.id}`;
+  }
+  return event.id;
 }
 
 function mergeThreadFromMeta(args: {
@@ -331,35 +487,94 @@ function mergeThreadFromMeta(args: {
  * truncation/rewrite that must go through a full reconcile).
  */
 function readAppendedTail(
+  snapshotFd: number,
   rolloutPath: string,
   priorSize: number,
+  snapshotSize: number,
 ): string | undefined {
-  const fd = openSync(rolloutPath, "r");
+  if (snapshotSize < priorSize) return undefined;
+  const length = snapshotSize - priorSize;
+  if (length === 0) return "";
+  // The incremental append path numbers new lines starting at the prior line
+  // count, which is only valid when the previously indexed content ended on a
+  // line boundary. Verify the byte just before the new region is a newline;
+  // otherwise the tail straddles a prior line and must go through a full
+  // reconcile to renumber correctly.
+  if (priorSize > 0) {
+    const boundary = Buffer.allocUnsafe(1);
+    if (readSync(snapshotFd, boundary, 0, 1, priorSize - 1) !== 1) {
+      return undefined;
+    }
+    if (boundary[0] !== 0x0a) return undefined;
+  }
+  const buffer = Buffer.allocUnsafe(length);
+  let read = 0;
+  while (read < length) {
+    const n = readSync(
+      snapshotFd,
+      buffer,
+      read,
+      length - read,
+      priorSize + read,
+    );
+    if (n === 0) break;
+    read += n;
+  }
+  if (read !== length) throw changedDuringSnapshot(rolloutPath);
+  return buffer.toString("utf8");
+}
+
+function readRolloutSnapshot(
+  snapshotFd: number,
+  rolloutPath: string,
+  start: number,
+  end: number,
+): string {
+  const length = end - start;
+  if (length < 0) throw changedDuringSnapshot(rolloutPath);
+  if (length === 0) return "";
+  const buffer = Buffer.allocUnsafe(length);
+  let read = 0;
+  while (read < length) {
+    const count = readSync(
+      snapshotFd,
+      buffer,
+      read,
+      length - read,
+      start + read,
+    );
+    if (count === 0) break;
+    read += count;
+  }
+  if (read !== length) throw changedDuringSnapshot(rolloutPath);
+  return buffer.toString("utf8");
+}
+
+function changedDuringSnapshot(rolloutPath: string): Error {
+  return new Error(
+    `canonical rollout changed while capturing a bounded projection snapshot: ${rolloutPath}`,
+  );
+}
+
+function assertSnapshotStillCanonical(
+  rolloutPath: string,
+  snapshot: Stats,
+): void {
+  let current: Stats;
   try {
-    const stat = statSync(rolloutPath);
-    if (stat.size < priorSize) return undefined;
-    const length = stat.size - priorSize;
-    if (length === 0) return "";
-    // The incremental append path numbers new lines starting at the prior line
-    // count, which is only valid when the previously indexed content ended on a
-    // line boundary. Verify the byte just before the new region is a newline;
-    // otherwise the tail straddles a prior line and must go through a full
-    // reconcile to renumber correctly.
-    if (priorSize > 0) {
-      const boundary = Buffer.allocUnsafe(1);
-      if (readSync(fd, boundary, 0, 1, priorSize - 1) !== 1) return undefined;
-      if (boundary[0] !== 0x0a) return undefined;
-    }
-    const buffer = Buffer.allocUnsafe(length);
-    let read = 0;
-    while (read < length) {
-      const n = readSync(fd, buffer, read, length - read, priorSize + read);
-      if (n === 0) break;
-      read += n;
-    }
-    return buffer.subarray(0, read).toString("utf8");
-  } finally {
-    closeSync(fd);
+    current = statSync(rolloutPath);
+  } catch (error) {
+    throw new Error(changedDuringSnapshot(rolloutPath).message, {
+      cause: error,
+    });
+  }
+  if (
+    current.dev !== snapshot.dev ||
+    current.ino !== snapshot.ino ||
+    current.size < snapshot.size ||
+    (current.size === snapshot.size && current.mtimeMs !== snapshot.mtimeMs)
+  ) {
+    throw changedDuringSnapshot(rolloutPath);
   }
 }
 

--- a/runtime/src/state/effect-review.ts
+++ b/runtime/src/state/effect-review.ts
@@ -1,0 +1,340 @@
+import {
+  OfflineRolloutSourceMissingError,
+  withPinnedOfflineRolloutLease,
+} from "../durability/offline-rollout.js";
+import type { Event } from "../session/event-log.js";
+import {
+  parseRolloutLine,
+  serializeRolloutItem,
+} from "../session/rollout-item.js";
+import { StateRunDurabilityRepository } from "./run-durability.js";
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+import { resolveUnknownOutcomeEffect } from "./unknown-outcome-gate.js";
+
+export interface ResolveDurableEffectReviewOptions {
+  readonly sessionId: string;
+  readonly toolCallId: string;
+  readonly reviewedAt: string;
+  readonly reviewedBy: string;
+  readonly resolution: string;
+}
+
+export type ResolveDurableEffectReviewResult =
+  | { readonly kind: "not_found" }
+  | {
+      readonly kind: "resolved" | "already_resolved";
+      readonly durable: boolean;
+      readonly runId?: string;
+      readonly stepId?: string;
+      readonly eventId?: string;
+      readonly sequence?: number;
+    };
+
+class CanonicalReviewEvidenceNotFoundError extends Error {
+  constructor(runId: string, stepId: string) {
+    super(
+      `canonical journal has no matching unknown-outcome record for ${runId}/${stepId}`,
+    );
+    this.name = "CanonicalReviewEvidenceNotFoundError";
+  }
+}
+
+/**
+ * Resolve the legacy recovery gate and, when present, the v15 effect review in
+ * one fail-closed workflow. Durable reviews append evidence to the canonical
+ * rollout under its single-writer lease before either SQLite projection moves.
+ */
+export function resolveDurableEffectReview(
+  driver: StateSqliteDriver,
+  options: ResolveDurableEffectReviewOptions,
+): ResolveDurableEffectReviewResult {
+  const repository = new StateRunDurabilityRepository(driver);
+  const effect = repository.getEffectBySessionCall(
+    options.sessionId,
+    options.toolCallId,
+  );
+  if (effect === undefined) {
+    return resolveUnknownOutcomeEffect(driver, options)
+      ? { kind: "resolved", durable: false }
+      : { kind: "not_found" };
+  }
+  if (effect.outcome !== "unknown_outcome") return { kind: "not_found" };
+
+  const bindings = repository
+    .listJournalBindings(effect.runId)
+    .filter(
+      (candidate) =>
+        candidate.sessionId === effect.sessionId &&
+        candidate.epoch === effect.epoch &&
+        !(
+          !candidate.active &&
+          candidate.gapReason !== undefined &&
+          candidate.retiredThroughSequence !== undefined &&
+          candidate.firstAvailableSequence === undefined
+        ),
+    )
+    .sort(
+      (left, right) =>
+        Number(right.active) - Number(left.active) ||
+        right.boundAt.localeCompare(left.boundAt) ||
+        right.sourcePath.localeCompare(left.sourcePath),
+    );
+  const eventId = `effect-review:${effect.runId}:${effect.stepId}`;
+  let selectedSourcePath: string | undefined;
+  let evidence:
+    | ReturnType<typeof appendOrReadReviewEvent>
+    | undefined;
+  for (const binding of bindings) {
+    try {
+      evidence = appendOrReadReviewEvent({
+        projectDir: driver.projectDir,
+        sessionId: binding.sessionId,
+        sourcePath: binding.sourcePath,
+        eventId,
+        payload: {
+          runId: effect.runId,
+          stepId: effect.stepId,
+          callId: effect.callId,
+          resolution: options.resolution,
+          reviewedBy: options.reviewedBy,
+          reviewedAt: options.reviewedAt,
+        },
+        expectedUnknownEvidence: {
+          eventId: effect.resultEventId,
+          sequence: effect.resultSequence,
+        },
+      });
+      selectedSourcePath = binding.sourcePath;
+      break;
+    } catch (error) {
+      if (
+        error instanceof CanonicalReviewEvidenceNotFoundError ||
+        error instanceof OfflineRolloutSourceMissingError
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  if (evidence === undefined || selectedSourcePath === undefined) {
+    throw new Error(
+      `run ${effect.runId} has no retained canonical journal evidence for effect review`,
+    );
+  }
+  const priorResolved = effect.reviewStatus === "resolved";
+  driver.transactionImmediate(() => {
+    repository.updateJournalBounds({
+      sourcePath: selectedSourcePath,
+      firstAvailableSequence: evidence.firstSequence,
+      lastSequence: evidence.lastSequence,
+      updatedAt: evidence.payload.reviewedAt,
+    });
+    repository.resolveEffectReview({
+      runId: effect.runId,
+      stepId: effect.stepId,
+      reviewedAt: evidence.payload.reviewedAt,
+      reviewedBy: evidence.payload.reviewedBy,
+      resolution: evidence.payload.resolution,
+      eventId,
+      evidence: {
+        callId: effect.callId,
+        sequence: evidence.sequence,
+        source: "canonical_run_journal",
+      },
+    });
+    resolveUnknownOutcomeEffect(driver, options);
+  });
+  return {
+    kind: priorResolved ? "already_resolved" : "resolved",
+    durable: true,
+    runId: effect.runId,
+    stepId: effect.stepId,
+    eventId,
+    sequence: evidence.sequence,
+  };
+}
+
+function appendOrReadReviewEvent(
+  options: {
+    readonly projectDir: string;
+    readonly sessionId: string;
+    readonly sourcePath: string;
+    readonly eventId: string;
+    readonly payload: Extract<
+      Event["msg"],
+      { readonly type: "effect_review_resolved" }
+    >["payload"];
+    readonly expectedUnknownEvidence: {
+      readonly eventId?: string;
+      readonly sequence?: number;
+    };
+  },
+): {
+  readonly sequence: number;
+  readonly firstSequence: number;
+  readonly lastSequence: number;
+  readonly payload: typeof options.payload;
+} {
+  return withPinnedOfflineRolloutLease(
+    {
+      projectDir: options.projectDir,
+      sessionId: options.sessionId,
+      sourcePath: options.sourcePath,
+    },
+    (rollout) => {
+      const raw = rollout.readUtf8();
+      const journal = readValidatedEvents(raw);
+      const {
+        events,
+        firstSequence,
+        lastSequence: lastSequenceBeforeAppend,
+      } = journal;
+      const unknownEvidence = events.filter(
+        (event) =>
+          event.msg.type === "effect_unknown_outcome" &&
+          event.msg.payload.runId === options.payload.runId &&
+          event.msg.payload.stepId === options.payload.stepId &&
+          event.msg.payload.callId === options.payload.callId,
+      );
+      if (unknownEvidence.length !== 1) {
+        if (unknownEvidence.length === 0) {
+          throw new CanonicalReviewEvidenceNotFoundError(
+            options.payload.runId,
+            options.payload.stepId,
+          );
+        }
+        throw new Error(
+          `canonical journal has ${unknownEvidence.length} matching unknown-outcome records for ${options.payload.runId}/${options.payload.stepId}`,
+        );
+      }
+      const unknown = unknownEvidence[0]!;
+      if (
+        canonicalReviewEventId(unknown) !==
+          options.expectedUnknownEvidence.eventId ||
+        unknown.seq !== options.expectedUnknownEvidence.sequence
+      ) {
+        throw new Error(
+          `canonical unknown-outcome evidence disagrees with the durable projection for ${options.payload.runId}/${options.payload.stepId}`,
+        );
+      }
+      if (firstSequence === undefined) {
+        throw new Error(
+          `canonical unknown-outcome evidence has no sequenced journal boundary for ${options.payload.runId}/${options.payload.stepId}`,
+        );
+      }
+      const existing = events.find(
+        (event) => canonicalReviewEventId(event) === options.eventId,
+      );
+      if (existing !== undefined) {
+        if (
+          existing.msg.type !== "effect_review_resolved" ||
+          !Number.isSafeInteger(existing.seq) ||
+          (existing.seq ?? 0) <= 0
+        ) {
+          throw new Error(
+            `journal event id ${options.eventId} has conflicting content`,
+          );
+        }
+        const existingPayload = existing.msg.payload;
+        if (
+          existingPayload.runId !== options.payload.runId ||
+          existingPayload.stepId !== options.payload.stepId ||
+          existingPayload.callId !== options.payload.callId ||
+          existingPayload.reviewedBy !== options.payload.reviewedBy ||
+          existingPayload.resolution !== options.payload.resolution
+        ) {
+          throw new Error(
+            `journal event id ${options.eventId} has conflicting content`,
+          );
+        }
+        // A prior attempt can have written the record before its fsync failed.
+        // Re-sync the idempotent match before allowing SQLite to advance.
+        rollout.sync();
+        return {
+          sequence: existing.seq!,
+          firstSequence,
+          lastSequence: lastSequenceBeforeAppend,
+          // A repeated operator command naturally carries a later wall-clock
+          // time. Preserve the first durable review timestamp while requiring
+          // the reviewer, resolution, and effect identity to match exactly.
+          payload: existingPayload,
+        };
+      }
+      const sequence = lastSequenceBeforeAppend + 1;
+      const event: Event = {
+        eventId: options.eventId,
+        id: options.eventId,
+        seq: sequence,
+        msg: { type: "effect_review_resolved", payload: options.payload },
+      };
+      rollout.appendAndSync(
+        serializeRolloutItem({ type: "event_msg", payload: event }),
+      );
+      return {
+        sequence,
+        firstSequence: Number.isFinite(firstSequence)
+          ? firstSequence
+          : sequence,
+        lastSequence: sequence,
+        payload: options.payload,
+      };
+    },
+  );
+}
+
+function readValidatedEvents(raw: string): {
+  readonly events: Event[];
+  readonly firstSequence: number | undefined;
+  readonly lastSequence: number;
+} {
+  const events: Event[] = [];
+  const canonicalIds = new Set<string>();
+  let firstSequence: number | undefined;
+  let lastSequence = 0;
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    const item = parseRolloutLine(line);
+    if (item?.type !== "event_msg") continue;
+    const event = item.payload;
+    const canonicalId = canonicalReviewEventId(event);
+    if (canonicalIds.has(canonicalId)) {
+      throw new Error(`canonical journal event id ${canonicalId} is duplicated`);
+    }
+    canonicalIds.add(canonicalId);
+    if (event.seq !== undefined) {
+      if (
+        !Number.isSafeInteger(event.seq) ||
+        event.seq <= 0 ||
+        event.seq <= lastSequence
+      ) {
+        throw new Error(
+          `canonical journal contains invalid or non-monotonic sequence ${String(event.seq)}`,
+        );
+      }
+      firstSequence ??= event.seq;
+      lastSequence = event.seq;
+    }
+    events.push(event);
+  }
+  return { events, firstSequence, lastSequence };
+}
+
+function canonicalReviewEventId(event: Event): string {
+  if (event.eventId !== undefined) {
+    if (typeof event.eventId !== "string" || event.eventId.length === 0) {
+      throw new Error("canonical journal contains an invalid eventId");
+    }
+    return event.eventId;
+  }
+  if (typeof event.id !== "string" || event.id.length === 0) {
+    throw new Error("canonical journal event is missing identity");
+  }
+  if (
+    typeof event.seq === "number" &&
+    Number.isSafeInteger(event.seq) &&
+    event.seq > 0
+  ) {
+    return `legacy-event:${event.seq}:${event.id}`;
+  }
+  return `legacy-unsequenced:${event.id}`;
+}

--- a/runtime/src/state/execution-admission-canonical-recovery.ts
+++ b/runtime/src/state/execution-admission-canonical-recovery.ts
@@ -1,0 +1,525 @@
+import type { AdmissionJournalEvent } from "../budget/admission-types.js";
+import {
+  withPinnedOfflineRolloutLease,
+  type PinnedOfflineRollout,
+} from "../durability/offline-rollout.js";
+import type { Event } from "../session/event-log.js";
+import {
+  parseRolloutLine,
+  serializeRolloutItem,
+} from "../session/rollout-item.js";
+import { stableStringify } from "../utils/stableStringify.js";
+import { backfillPinnedRolloutContent } from "./backfill.js";
+import type { ExecutionAdmissionRepository } from "./execution-admission.js";
+import {
+  StateRunDurabilityRepository,
+  type RunJournalBinding,
+} from "./run-durability.js";
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+import { StateThreadRepository } from "./threads.js";
+
+const DEFAULT_MAX_RUNS = 4_096;
+const DEFAULT_MAX_EVENTS_PER_RUN = 100_000;
+const DEFAULT_MAX_SOURCES_PER_RUN = 32;
+const JOURNAL_PAGE_SIZE = 1_000;
+
+interface AdmissionRunRow {
+  readonly run_id: string;
+}
+
+interface CanonicalEventRecord {
+  readonly event: Event;
+  readonly eventId: string;
+  readonly sequence: number | undefined;
+  readonly signature: string;
+  readonly sourcePath: string;
+}
+
+export interface ExecutionAdmissionCanonicalRecoveryResult {
+  readonly runsScanned: number;
+  readonly sourcesScanned: number;
+  readonly admissionEventsScanned: number;
+  readonly admissionEventsAppended: number;
+}
+
+/**
+ * Converge SQLite-committed admission decisions into the canonical rollout.
+ *
+ * SQLite remains the admission/budget authority. This is a bounded recovery
+ * projection of those exact rows, carrying their existing event IDs and
+ * payloads into the run's per-run sequence namespace. Every retained source
+ * is leased with the same SessionLock used by live writers. Conflicts, a live
+ * writer, missing source bytes, an exhausted bound, or a sealed terminal tail
+ * all refuse startup instead of exposing silently incomplete replay.
+ */
+export function recoverExecutionAdmissionCanonicalJournals(
+  driver: StateSqliteDriver,
+  admissions: ExecutionAdmissionRepository,
+  options: {
+    readonly maxRuns?: number;
+    readonly maxEventsPerRun?: number;
+    readonly maxSourcesPerRun?: number;
+  } = {},
+): ExecutionAdmissionCanonicalRecoveryResult {
+  const maxRuns = positiveBound(options.maxRuns ?? DEFAULT_MAX_RUNS, "maxRuns");
+  const maxEvents = positiveBound(
+    options.maxEventsPerRun ?? DEFAULT_MAX_EVENTS_PER_RUN,
+    "maxEventsPerRun",
+  );
+  const maxSources = positiveBound(
+    options.maxSourcesPerRun ?? DEFAULT_MAX_SOURCES_PER_RUN,
+    "maxSourcesPerRun",
+  );
+  const unboundCanonicalRun = driver
+    .prepareState<[], AdmissionRunRow>(
+      `SELECT DISTINCT admission.run_id
+       FROM execution_admission_journal AS admission
+       JOIN run_lifecycle_epochs AS lifecycle
+         ON lifecycle.run_id = admission.run_id
+       WHERE NOT EXISTS (
+         SELECT 1 FROM run_journal_bindings AS binding
+         WHERE binding.run_id = admission.run_id
+       )
+       ORDER BY admission.run_id ASC
+       LIMIT 1`,
+    )
+    .get();
+  if (unboundCanonicalRun !== undefined) {
+    throw new Error(
+      `run ${unboundCanonicalRun.run_id} has committed admission evidence and a canonical lifecycle but no journal binding`,
+    );
+  }
+  const runs = driver
+    .prepareState<[number], AdmissionRunRow>(
+      `SELECT DISTINCT admission.run_id
+       FROM execution_admission_journal AS admission
+       JOIN run_journal_bindings AS binding
+         ON binding.run_id = admission.run_id
+       ORDER BY admission.run_id ASC
+       LIMIT ?`,
+    )
+    .all(maxRuns + 1);
+  if (runs.length > maxRuns) {
+    throw new Error(
+      `canonical admission recovery exceeds the bounded run limit (${maxRuns})`,
+    );
+  }
+
+  const durability = new StateRunDurabilityRepository(driver);
+  const threads = new StateThreadRepository(driver);
+  let sourcesScanned = 0;
+  let admissionEventsScanned = 0;
+  let admissionEventsAppended = 0;
+  for (const row of runs) {
+    const bindings = retainedBindings(
+      durability.listJournalBindings(row.run_id),
+    );
+    if (bindings.length === 0) continue;
+    if (bindings.length > maxSources) {
+      throw new Error(
+        `run ${row.run_id} canonical admission recovery exceeds the bounded source limit (${maxSources})`,
+      );
+    }
+    const journal = readAdmissionJournal(admissions, row.run_id, maxEvents);
+    admissionEventsScanned += journal.length;
+    const result = convergeRun({
+      runId: row.run_id,
+      driver,
+      bindings,
+      journal,
+      durability,
+      threads,
+    });
+    sourcesScanned += bindings.length;
+    admissionEventsAppended += result.appended;
+  }
+  return {
+    runsScanned: runs.length,
+    sourcesScanned,
+    admissionEventsScanned,
+    admissionEventsAppended,
+  };
+}
+
+function convergeRun(params: {
+  readonly runId: string;
+  readonly driver: StateSqliteDriver;
+  readonly bindings: readonly RunJournalBinding[];
+  readonly journal: readonly AdmissionJournalEvent[];
+  readonly durability: StateRunDurabilityRepository;
+  readonly threads: StateThreadRepository;
+}): { readonly appended: number } {
+  const bindings = uniqueSourceBindings(params.bindings);
+  return withPinnedBindings(
+    params.driver.projectDir,
+    bindings,
+    new Map(),
+    (leases) => {
+      const canonical = bindings.flatMap((binding) =>
+        readCanonicalEvents(
+          leases.get(binding.sourcePath)!.readUtf8(),
+          binding.sourcePath,
+        ),
+      );
+      const index = validateCanonicalEvents(canonical, params.runId);
+      const missing: AdmissionJournalEvent[] = [];
+      for (const event of params.journal) {
+        const envelopeMatches = index.byEventId.get(event.eventId) ?? [];
+        const payloadMatches =
+          index.byAdmissionEventId.get(event.eventId) ?? [];
+        const matches = [...new Set([...envelopeMatches, ...payloadMatches])];
+        if (matches.length === 0) {
+          missing.push(event);
+          continue;
+        }
+        for (const match of matches) assertAdmissionMatch(match.event, event);
+      }
+
+      const target = selectTargetBinding(params.bindings);
+      if (
+        missing.length > 0 &&
+        canonicalTailIsTerminal(index.ordered, params.runId)
+      ) {
+        throw new Error(
+          `run ${params.runId} canonical admission recovery refused: terminal tail precedes ${missing.length} committed admission event(s)`,
+        );
+      }
+      let lastSequence = index.lastSequence;
+      const appended = missing.map((payload): CanonicalEventRecord => {
+        lastSequence += 1;
+        const event: Event = {
+          eventId: payload.eventId,
+          id: payload.eventId,
+          seq: lastSequence,
+          msg: { type: "execution_admission", payload },
+        };
+        return {
+          event,
+          eventId: payload.eventId,
+          sequence: lastSequence,
+          signature: stableStringify(event),
+          sourcePath: target.sourcePath,
+        };
+      });
+      if (appended.length > 0) {
+        leases
+          .get(target.sourcePath)!
+          .appendAndSync(
+            appended
+              .map(({ event }) =>
+                serializeRolloutItem({ type: "event_msg", payload: event }),
+              )
+              .join(""),
+          );
+      } else {
+        // Existing identical evidence may have survived an ambiguous fsync.
+        leases.get(target.sourcePath)!.sync();
+      }
+
+      const targetEvents = readCanonicalEvents(
+        leases.get(target.sourcePath)!.readUtf8(),
+        target.sourcePath,
+      );
+      const targetSequences = targetEvents.flatMap((record) =>
+        record.sequence === undefined ? [] : [record.sequence],
+      );
+      params.driver.transactionImmediate(() => {
+        for (const binding of bindings) {
+          const lease = leases.get(binding.sourcePath)!;
+          const raw = lease.readUtf8();
+          const source = lease.stat();
+          if (source.size !== Buffer.byteLength(raw)) {
+            throw new Error(
+              `canonical admission source ${binding.sourcePath} changed while preparing its projection`,
+            );
+          }
+          backfillPinnedRolloutContent({
+            rolloutPath: binding.sourcePath,
+            raw,
+            archived: binding.sourcePath.includes("/archived_sessions/"),
+            threads: params.threads,
+            mtimeMs: source.mtimeMs,
+            validateCanonical: () => lease.sync(),
+          });
+        }
+        if (targetSequences.length > 0) {
+          params.durability.updateJournalBounds({
+            sourcePath: target.sourcePath,
+            firstAvailableSequence: Math.min(...targetSequences),
+            lastSequence: Math.max(...targetSequences),
+            updatedAt: new Date().toISOString(),
+          });
+        }
+      });
+      return { appended: appended.length };
+    },
+  );
+}
+
+function uniqueSourceBindings(
+  bindings: readonly RunJournalBinding[],
+): readonly RunJournalBinding[] {
+  const byPath = new Map<string, RunJournalBinding>();
+  for (const binding of bindings) {
+    const existing = byPath.get(binding.sourcePath);
+    if (existing !== undefined && existing.sessionId !== binding.sessionId) {
+      throw new Error(
+        `canonical admission source ${binding.sourcePath} has conflicting session bindings`,
+      );
+    }
+    byPath.set(binding.sourcePath, binding);
+  }
+  return [...byPath.values()].sort((left, right) =>
+    left.sourcePath.localeCompare(right.sourcePath),
+  );
+}
+
+function withPinnedBindings<T>(
+  projectDir: string,
+  bindings: readonly RunJournalBinding[],
+  leases: Map<string, PinnedOfflineRollout>,
+  operation: (leases: ReadonlyMap<string, PinnedOfflineRollout>) => T,
+  index = 0,
+): T {
+  const binding = bindings[index];
+  if (binding === undefined) return operation(leases);
+  return withPinnedOfflineRolloutLease(
+    {
+      projectDir,
+      sessionId: binding.sessionId,
+      sourcePath: binding.sourcePath,
+    },
+    (lease) => {
+      leases.set(binding.sourcePath, lease);
+      try {
+        return withPinnedBindings(
+          projectDir,
+          bindings,
+          leases,
+          operation,
+          index + 1,
+        );
+      } finally {
+        leases.delete(binding.sourcePath);
+      }
+    },
+  );
+}
+
+function retainedBindings(
+  bindings: readonly RunJournalBinding[],
+): readonly RunJournalBinding[] {
+  return bindings.filter(
+    (binding) =>
+      !(
+        !binding.active &&
+        binding.gapReason !== undefined &&
+        binding.retiredThroughSequence !== undefined &&
+        binding.firstAvailableSequence === undefined
+      ),
+  );
+}
+
+function selectTargetBinding(
+  bindings: readonly RunJournalBinding[],
+): RunJournalBinding {
+  const sorted = [...bindings].sort(
+    (left, right) =>
+      Number(right.active) - Number(left.active) ||
+      right.epoch - left.epoch ||
+      right.boundAt.localeCompare(left.boundAt) ||
+      right.sourcePath.localeCompare(left.sourcePath),
+  );
+  return sorted[0]!;
+}
+
+function readAdmissionJournal(
+  admissions: ExecutionAdmissionRepository,
+  runId: string,
+  maxEvents: number,
+): readonly AdmissionJournalEvent[] {
+  const result: AdmissionJournalEvent[] = [];
+  let afterSequence = 0;
+  while (true) {
+    const page = admissions.listJournal({
+      runId,
+      afterSequence,
+      limit: JOURNAL_PAGE_SIZE,
+    });
+    if (page.length === 0) return result;
+    for (const event of page) {
+      if (
+        !Number.isSafeInteger(event.sequence) ||
+        event.sequence <= afterSequence
+      ) {
+        throw new Error(
+          `run ${runId} admission recovery made no monotonic progress after sequence ${afterSequence}`,
+        );
+      }
+      if (result.length >= maxEvents) {
+        throw new Error(
+          `run ${runId} canonical admission recovery exceeds the bounded event limit (${maxEvents})`,
+        );
+      }
+      result.push(event);
+      afterSequence = event.sequence;
+    }
+    if (page.length < JOURNAL_PAGE_SIZE) return result;
+  }
+}
+
+function readCanonicalEvents(
+  raw: string,
+  sourcePath: string,
+): CanonicalEventRecord[] {
+  const result: CanonicalEventRecord[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    const item = parseRolloutLine(line);
+    if (item?.type !== "event_msg") continue;
+    const event = item.payload;
+    const sequence = canonicalSequence(event);
+    const eventId = canonicalEventId(event, sequence);
+    result.push({
+      event,
+      eventId,
+      sequence,
+      signature: stableStringify(event),
+      sourcePath,
+    });
+  }
+  return result;
+}
+
+function validateCanonicalEvents(
+  records: readonly CanonicalEventRecord[],
+  runId: string,
+): {
+  readonly byEventId: ReadonlyMap<string, readonly CanonicalEventRecord[]>;
+  readonly byAdmissionEventId: ReadonlyMap<
+    string,
+    readonly CanonicalEventRecord[]
+  >;
+  readonly ordered: readonly CanonicalEventRecord[];
+  readonly lastSequence: number;
+} {
+  const byEventId = new Map<string, CanonicalEventRecord[]>();
+  const byAdmissionEventId = new Map<string, CanonicalEventRecord[]>();
+  const bySequence = new Map<number, CanonicalEventRecord>();
+  let lastSequence = 0;
+  for (const record of records) {
+    const identities = byEventId.get(record.eventId) ?? [];
+    if (
+      identities.some(
+        (prior) =>
+          prior.sequence !== record.sequence ||
+          prior.signature !== record.signature,
+      )
+    ) {
+      throw new Error(
+        `run ${runId} canonical admission recovery found conflicting event ID ${record.eventId}`,
+      );
+    }
+    identities.push(record);
+    byEventId.set(record.eventId, identities);
+    if (record.sequence !== undefined) {
+      const prior = bySequence.get(record.sequence);
+      if (
+        prior !== undefined &&
+        (prior.eventId !== record.eventId ||
+          prior.signature !== record.signature)
+      ) {
+        throw new Error(
+          `run ${runId} canonical admission recovery found sequence ${record.sequence} claimed by both ${prior.eventId} and ${record.eventId}`,
+        );
+      }
+      bySequence.set(record.sequence, record);
+      lastSequence = Math.max(lastSequence, record.sequence);
+    }
+    if (record.event.msg.type === "execution_admission") {
+      const admissionId = record.event.msg.payload.eventId;
+      const admissionMatches = byAdmissionEventId.get(admissionId) ?? [];
+      admissionMatches.push(record);
+      byAdmissionEventId.set(admissionId, admissionMatches);
+    }
+  }
+  return {
+    byEventId,
+    byAdmissionEventId,
+    ordered: [...bySequence.values()].sort(
+      (left, right) => left.sequence! - right.sequence!,
+    ),
+    lastSequence,
+  };
+}
+
+function assertAdmissionMatch(
+  canonical: Event,
+  admission: AdmissionJournalEvent,
+): void {
+  if (
+    canonical.eventId !== admission.eventId ||
+    canonical.id !== admission.eventId ||
+    canonical.msg.type !== "execution_admission" ||
+    stableStringify(canonical.msg.payload) !== stableStringify(admission)
+  ) {
+    throw new Error(
+      `execution admission event ${admission.eventId} has conflicting canonical evidence`,
+    );
+  }
+}
+
+function canonicalTailIsTerminal(
+  ordered: readonly CanonicalEventRecord[],
+  runId: string,
+): boolean {
+  let sealed = false;
+  for (const record of ordered) {
+    if (
+      record.event.msg.type === "run_terminal" &&
+      record.event.msg.payload.runId === runId
+    ) {
+      sealed = true;
+    } else if (
+      record.event.msg.type === "run_reopened" &&
+      record.event.msg.payload.runId === runId
+    ) {
+      sealed = false;
+    }
+  }
+  return sealed;
+}
+
+function canonicalSequence(event: Event): number | undefined {
+  if (event.seq === undefined) return undefined;
+  if (!Number.isSafeInteger(event.seq) || event.seq <= 0) {
+    throw new Error(
+      `canonical admission recovery found invalid sequence ${String(event.seq)}`,
+    );
+  }
+  return event.seq;
+}
+
+function canonicalEventId(event: Event, sequence: number | undefined): string {
+  if (event.eventId !== undefined) {
+    if (typeof event.eventId !== "string" || event.eventId.length === 0) {
+      throw new Error("canonical admission recovery found invalid eventId");
+    }
+    return event.eventId;
+  }
+  if (typeof event.id !== "string" || event.id.length === 0) {
+    throw new Error(
+      "canonical admission recovery found event without identity",
+    );
+  }
+  return sequence === undefined
+    ? `legacy-unsequenced:${event.id}`
+    : `legacy-event:${sequence}:${event.id}`;
+}
+
+function positiveBound(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}

--- a/runtime/src/state/migrations/015_run_durability_schema.ts
+++ b/runtime/src/state/migrations/015_run_durability_schema.ts
@@ -1,0 +1,327 @@
+import type { SqliteDatabase } from "../sqlite-driver.js";
+import type { SqlMigration } from "./types.js";
+
+export const RUN_DURABILITY_SCHEMA_VERSION = 15;
+
+function tableExists(db: SqliteDatabase, table: string): boolean {
+  return (
+    db
+      .prepare<[string], { readonly name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      )
+      .get(table) !== undefined
+  );
+}
+
+/**
+ * Durable M4 run state and rebuildable rollout projections.
+ *
+ * The append-only rollout JSONL remains the canonical event journal. These
+ * tables retain lifecycle/effect state that must survive restart and bind a
+ * run to the existing `thread_rollout_items` projection; they never copy event
+ * payloads into a competing journal.
+ */
+export const runDurabilitySchemaMigration: SqlMigration = {
+  version: RUN_DURABILITY_SCHEMA_VERSION,
+  name: "run_durability_schema",
+  sql: `
+CREATE TABLE IF NOT EXISTS run_lifecycle_epochs (
+  run_id TEXT NOT NULL,
+  epoch INTEGER NOT NULL,
+  opened_at TEXT NOT NULL,
+  opened_event_id TEXT,
+  reopened_from_epoch INTEGER,
+  reopen_reason TEXT,
+  PRIMARY KEY (run_id, epoch),
+  FOREIGN KEY (run_id, reopened_from_epoch)
+    REFERENCES run_lifecycle_epochs(run_id, epoch) ON DELETE RESTRICT,
+  CHECK (length(run_id) > 0),
+  CHECK (epoch > 0),
+  CHECK (length(opened_at) > 0),
+  CHECK (opened_event_id IS NULL OR length(opened_event_id) > 0),
+  CHECK (
+    (epoch = 1 AND reopened_from_epoch IS NULL AND reopen_reason IS NULL)
+    OR
+    (epoch > 1 AND reopened_from_epoch = epoch - 1
+      AND reopen_reason IS NOT NULL AND length(reopen_reason) > 0
+      AND opened_event_id IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_lifecycle_epochs_opened_event
+  ON run_lifecycle_epochs(run_id, opened_event_id)
+  WHERE opened_event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_run_lifecycle_epochs_current
+  ON run_lifecycle_epochs(run_id, epoch DESC);
+
+CREATE TABLE IF NOT EXISTS run_terminal_results (
+  run_id TEXT NOT NULL,
+  epoch INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  exit_code INTEGER,
+  stop_reason TEXT,
+  final_message TEXT,
+  usage_json TEXT,
+  last_sequence INTEGER,
+  finished_at TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  PRIMARY KEY (run_id, epoch),
+  FOREIGN KEY (run_id, epoch)
+    REFERENCES run_lifecycle_epochs(run_id, epoch) ON DELETE RESTRICT,
+  CHECK (status IN ('completed', 'failed', 'cancelled', 'unknown_outcome')),
+  CHECK (usage_json IS NULL OR json_valid(usage_json)),
+  CHECK (last_sequence IS NULL OR last_sequence > 0),
+  CHECK (length(finished_at) > 0),
+  CHECK (length(event_id) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_terminal_results_event
+  ON run_terminal_results(run_id, event_id);
+
+CREATE INDEX IF NOT EXISTS idx_run_terminal_results_finished
+  ON run_terminal_results(finished_at, run_id, epoch);
+
+CREATE TRIGGER IF NOT EXISTS run_terminal_results_are_immutable
+BEFORE UPDATE ON run_terminal_results
+BEGIN
+  SELECT RAISE(ABORT, 'run terminal result is immutable; explicitly reopen the run');
+END;
+
+CREATE TABLE IF NOT EXISTS run_effects (
+  run_id TEXT NOT NULL,
+  step_id TEXT NOT NULL,
+  epoch INTEGER NOT NULL,
+  child_run_id TEXT,
+  session_id TEXT NOT NULL,
+  call_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  recovery_category TEXT NOT NULL,
+  idempotency_key TEXT,
+  intent_digest TEXT NOT NULL,
+  intent_event_id TEXT NOT NULL,
+  intent_sequence INTEGER NOT NULL,
+  intent_at TEXT NOT NULL,
+  outcome TEXT,
+  result_event_id TEXT,
+  result_sequence INTEGER,
+  result_digest TEXT,
+  result_json TEXT,
+  evidence_json TEXT,
+  unknown_reason TEXT,
+  completed_at TEXT,
+  review_status TEXT NOT NULL DEFAULT 'none',
+  reviewed_at TEXT,
+  reviewed_by TEXT,
+  review_resolution TEXT,
+  review_event_id TEXT,
+  review_evidence_json TEXT,
+  PRIMARY KEY (run_id, step_id),
+  FOREIGN KEY (run_id, epoch)
+    REFERENCES run_lifecycle_epochs(run_id, epoch) ON DELETE RESTRICT,
+  CHECK (length(run_id) > 0),
+  CHECK (length(step_id) > 0),
+  CHECK (epoch > 0),
+  CHECK (child_run_id IS NULL OR length(child_run_id) > 0),
+  CHECK (length(session_id) > 0),
+  CHECK (length(call_id) > 0),
+  CHECK (length(tool_name) > 0),
+  CHECK (recovery_category IN ('idempotent', 'side-effecting', 'interactive')),
+  CHECK (
+    (recovery_category = 'idempotent'
+      AND idempotency_key IS NOT NULL AND length(idempotency_key) > 0)
+    OR
+    (recovery_category <> 'idempotent' AND idempotency_key IS NULL)
+  ),
+  CHECK (length(intent_digest) > 0),
+  CHECK (length(intent_event_id) > 0),
+  CHECK (intent_sequence > 0),
+  CHECK (length(intent_at) > 0),
+  CHECK (outcome IS NULL OR outcome IN (
+    'committed', 'failed', 'cancelled', 'unknown_outcome'
+  )),
+  CHECK (
+    (outcome IS NULL
+      AND result_event_id IS NULL AND result_sequence IS NULL
+      AND result_digest IS NULL AND result_json IS NULL
+      AND evidence_json IS NULL AND unknown_reason IS NULL
+      AND completed_at IS NULL AND review_status = 'none')
+    OR
+    (outcome IS NOT NULL
+      AND result_event_id IS NOT NULL AND length(result_event_id) > 0
+      AND result_sequence IS NOT NULL AND result_sequence > 0
+      AND completed_at IS NOT NULL AND length(completed_at) > 0)
+  ),
+  CHECK (result_json IS NULL OR json_valid(result_json)),
+  CHECK (evidence_json IS NULL OR json_valid(evidence_json)),
+  CHECK (
+    (outcome = 'unknown_outcome'
+      AND recovery_category IN ('side-effecting', 'interactive')
+      AND unknown_reason IS NOT NULL AND length(unknown_reason) > 0
+      AND review_status IN ('pending', 'resolved'))
+    OR
+    ((outcome IS NULL OR outcome <> 'unknown_outcome')
+      AND unknown_reason IS NULL AND review_status = 'none')
+  ),
+  CHECK (
+    (review_status IN ('none', 'pending')
+      AND reviewed_at IS NULL AND reviewed_by IS NULL
+      AND review_resolution IS NULL AND review_event_id IS NULL
+      AND review_evidence_json IS NULL)
+    OR
+    (review_status = 'resolved'
+      AND reviewed_at IS NOT NULL AND length(reviewed_at) > 0
+      AND reviewed_by IS NOT NULL AND length(reviewed_by) > 0
+      AND review_resolution IS NOT NULL AND length(review_resolution) > 0
+      AND review_event_id IS NOT NULL AND length(review_event_id) > 0
+      AND (review_evidence_json IS NULL OR json_valid(review_evidence_json)))
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_effects_intent_sequence
+  ON run_effects(run_id, intent_sequence);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_effects_result_sequence
+  ON run_effects(run_id, result_sequence)
+  WHERE result_sequence IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_run_effects_pending_review
+  ON run_effects(run_id, review_status, intent_sequence)
+  WHERE review_status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_run_effects_session
+  ON run_effects(session_id, intent_sequence);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_effects_session_call
+  ON run_effects(session_id, call_id);
+
+CREATE TRIGGER IF NOT EXISTS run_effect_intent_is_immutable
+BEFORE UPDATE ON run_effects
+WHEN OLD.run_id IS NOT NEW.run_id
+  OR OLD.step_id IS NOT NEW.step_id
+  OR OLD.epoch IS NOT NEW.epoch
+  OR OLD.child_run_id IS NOT NEW.child_run_id
+  OR OLD.session_id IS NOT NEW.session_id
+  OR OLD.call_id IS NOT NEW.call_id
+  OR OLD.tool_name IS NOT NEW.tool_name
+  OR OLD.recovery_category IS NOT NEW.recovery_category
+  OR OLD.idempotency_key IS NOT NEW.idempotency_key
+  OR OLD.intent_digest IS NOT NEW.intent_digest
+  OR OLD.intent_event_id IS NOT NEW.intent_event_id
+  OR OLD.intent_sequence IS NOT NEW.intent_sequence
+  OR OLD.intent_at IS NOT NEW.intent_at
+BEGIN
+  SELECT RAISE(ABORT, 'run effect intent is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS run_effect_outcome_is_sticky
+BEFORE UPDATE ON run_effects
+WHEN OLD.outcome IS NOT NULL AND (
+  OLD.outcome IS NOT NEW.outcome
+  OR OLD.result_event_id IS NOT NEW.result_event_id
+  OR OLD.result_sequence IS NOT NEW.result_sequence
+  OR OLD.result_digest IS NOT NEW.result_digest
+  OR OLD.result_json IS NOT NEW.result_json
+  OR OLD.evidence_json IS NOT NEW.evidence_json
+  OR OLD.unknown_reason IS NOT NEW.unknown_reason
+  OR OLD.completed_at IS NOT NEW.completed_at
+)
+BEGIN
+  SELECT RAISE(ABORT, 'run effect outcome is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS run_effect_review_is_monotonic
+BEFORE UPDATE ON run_effects
+WHEN NOT (
+  OLD.review_status = NEW.review_status
+  OR (OLD.review_status = 'none' AND NEW.review_status = 'pending')
+  OR (OLD.review_status = 'pending' AND NEW.review_status = 'resolved')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'run effect review state cannot move backwards');
+END;
+
+CREATE TABLE IF NOT EXISTS run_journal_bindings (
+  run_id TEXT NOT NULL,
+  epoch INTEGER NOT NULL,
+  child_run_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1,
+  first_available_sequence INTEGER,
+  last_sequence INTEGER,
+  retired_through_sequence INTEGER,
+  gap_reason TEXT,
+  gap_observed_at TEXT,
+  bound_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (run_id, epoch, source_path),
+  UNIQUE (source_path),
+  FOREIGN KEY (run_id, epoch)
+    REFERENCES run_lifecycle_epochs(run_id, epoch) ON DELETE RESTRICT,
+  CHECK (length(run_id) > 0),
+  CHECK (epoch > 0),
+  CHECK (length(child_run_id) > 0),
+  CHECK (length(session_id) > 0),
+  CHECK (length(source_path) > 0),
+  CHECK (active IN (0, 1)),
+  CHECK (first_available_sequence IS NULL OR first_available_sequence > 0),
+  CHECK (last_sequence IS NULL OR last_sequence > 0),
+  CHECK (
+    first_available_sequence IS NULL OR last_sequence IS NULL
+      OR last_sequence >= first_available_sequence
+  ),
+  CHECK (retired_through_sequence IS NULL OR retired_through_sequence >= 0),
+  CHECK (
+    (gap_reason IS NULL AND gap_observed_at IS NULL)
+    OR
+    (gap_reason IN ('retention', 'corruption_truncated', 'compaction')
+      AND gap_observed_at IS NOT NULL AND length(gap_observed_at) > 0
+      AND retired_through_sequence IS NOT NULL)
+  ),
+  CHECK (
+    retired_through_sequence IS NULL OR first_available_sequence IS NULL
+      OR retired_through_sequence < first_available_sequence
+  ),
+  CHECK (length(bound_at) > 0),
+  CHECK (length(updated_at) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_journal_bindings_active
+  ON run_journal_bindings(run_id, epoch)
+  WHERE active = 1;
+
+CREATE INDEX IF NOT EXISTS idx_run_journal_bindings_replay
+  ON run_journal_bindings(
+    run_id, epoch, first_available_sequence, last_sequence, source_path
+  );
+
+CREATE INDEX IF NOT EXISTS idx_run_journal_bindings_child
+  ON run_journal_bindings(child_run_id, session_id, epoch);
+`,
+  apply: (db) => {
+    // Artificial migration fixtures can contain only a subset of historical
+    // tables. Real v1+ state databases always have the rollout projection; do
+    // not manufacture it solely to install optional replay indexes.
+    if (!tableExists(db, "thread_rollout_items")) return;
+    db.exec(`
+CREATE INDEX IF NOT EXISTS idx_thread_rollout_items_replay_source_sequence
+  ON thread_rollout_items(source_path, event_seq, event_id)
+  WHERE item_type = 'event_msg' AND event_seq IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_thread_rollout_items_replay_thread_sequence
+  ON thread_rollout_items(thread_id, event_seq, event_id)
+  WHERE item_type = 'event_msg' AND event_seq IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_thread_rollout_items_replay_source_identity
+  ON thread_rollout_items(source_path, event_id, event_seq)
+  WHERE item_type = 'event_msg' AND event_seq IS NOT NULL
+    AND event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_thread_rollout_items_replay_thread_identity
+  ON thread_rollout_items(thread_id, event_id, event_seq)
+  WHERE item_type = 'event_msg' AND event_seq IS NOT NULL
+    AND event_id IS NOT NULL;
+`);
+  },
+};

--- a/runtime/src/state/migrations/index.ts
+++ b/runtime/src/state/migrations/index.ts
@@ -13,6 +13,7 @@ import { memoryPipelineSchemaMigration } from "./011_memory_pipeline_schema.js";
 import { agentRoleWorkspaceProvenanceMigration } from "./012_agent_role_workspace_provenance.js";
 import { threadListingIndexesMigration } from "./013_thread_listing_indexes.js";
 import { executionAdmissionSchemaMigration } from "./014_execution_admission_schema.js";
+import { runDurabilitySchemaMigration } from "./015_run_durability_schema.js";
 import type { SqlMigration } from "./types.js";
 
 /**
@@ -33,6 +34,7 @@ export const STATE_DB_MIGRATIONS: readonly SqlMigration[] = [
   agentRoleWorkspaceProvenanceMigration,
   threadListingIndexesMigration,
   executionAdmissionSchemaMigration,
+  runDurabilitySchemaMigration,
 ];
 
 export const LOGS_DB_MIGRATIONS: readonly SqlMigration[] = [

--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -5,13 +5,17 @@ import {
   renameSync,
   rmSync,
   statSync,
+  unlinkSync,
 } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import { isProcessRunning } from "../utils/genericProcessUtils.js";
 import { StateThreadRepository } from "./threads.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 import { sqlPlaceholders } from "./sql.js";
 import { agentIdFromThreadSourceJson } from "../thread-store/thread-source.js";
+import { StateRunDurabilityRepository } from "./run-durability.js";
+import { parseRolloutLine } from "../session/rollout-item.js";
+import { SessionLock, SessionLockedError } from "../session/session-store.js";
 
 const COMPLETED_AGENT_RUN_STATUSES = ["completed", "stopped"] as const;
 const FAILED_AGENT_RUN_STATUSES = ["failed", "error", "errored"] as const;
@@ -259,10 +263,8 @@ export function pruneRolloutSessions(
   driver: StateSqliteDriver,
   options: RolloutPruningOptions,
 ): RolloutPruningReport {
-  const cutoffMs = rolloutCutoffMs(
-    options.now?.() ?? new Date().toISOString(),
-    options.retention_days,
-  );
+  const observedAt = options.now?.() ?? new Date().toISOString();
+  const cutoffMs = rolloutCutoffMs(observedAt, options.retention_days);
   // Disabled by default: no retention window → never delete anything.
   if (cutoffMs === undefined) return emptyRolloutReport();
   if (!existsSync(options.sessionsDir)) return emptyRolloutReport();
@@ -279,6 +281,7 @@ export function pruneRolloutSessions(
   }
 
   const threads = new StateThreadRepository(driver);
+  const runs = new StateRunDurabilityRepository(driver);
   const prunedSessionIds: string[] = [];
   let prunedRolloutFiles = 0;
   let prunedMirrorRows = 0;
@@ -302,26 +305,61 @@ export function pruneRolloutSessions(
     // block pruning, so a crashed session is still reclaimable.
     if (sessionHasLiveRolloutLock(sessionDir)) continue;
 
-    // Drop the SQLite mirror rows first: if the FS removal later fails the
-    // mirror is already gone (it can't outlive its source), and a re-index
-    // would only re-add rows for files that still exist.
-    let removedRows = 0;
+    // Close the check/use race by acquiring every canonical rollout lease and
+    // holding it through retirement plus rename/removal. The preliminary live
+    // check above is still required because SessionLock ownership is per
+    // instance, not merely per PID; acquisition is the authoritative gate.
+    const heldLocks = acquireRolloutLocks(rollout.rolloutPaths, onError);
+    if (heldLocks === undefined) continue;
+
     try {
-      for (const sourcePath of rollout.rolloutPaths) {
-        removedRows += threads.deleteRolloutItemsForSource(sourcePath);
+      // Retire each durable binding and drop its SQLite mirror rows in one
+      // transaction before removing the canonical file. A crash can therefore
+      // leave either the complete pre-prune state or an inactive binding that
+      // explicitly explains the missing journal; it cannot leave an active
+      // binding pointing at a deleted source.
+      let removedRows = 0;
+      try {
+        const canonicalTails = new Map<string, number>();
+        for (const sourcePath of rollout.rolloutPaths) {
+          // Parse every candidate, including legacy/unbound sources. Deleting
+          // the enclosing directory is unsafe if any canonical sibling cannot
+          // be validated under its lease.
+          const canonicalTail = canonicalRolloutLastSequence(sourcePath);
+          if (runs.getJournalBinding(sourcePath) !== undefined) {
+            canonicalTails.set(sourcePath, canonicalTail);
+          }
+        }
+        removedRows = driver.transactionImmediate(() => {
+          let removed = 0;
+          for (const sourcePath of rollout.rolloutPaths) {
+            runs.retireJournalSource({
+              sourcePath,
+              reason: "retention",
+              observedAt,
+              ...(canonicalTails.has(sourcePath)
+                ? { canonicalLastSequence: canonicalTails.get(sourcePath)! }
+                : {}),
+            });
+            removed += threads.deleteRolloutItemsForSource(sourcePath);
+          }
+          return removed;
+        });
+      } catch (error) {
+        onError(error);
+        continue;
       }
-    } catch (error) {
-      onError(error);
-      continue;
+
+      // Atomic directory removal: rename aside so a crash mid-rm never leaves a
+      // partially-deleted session dir under its real name, then recursive rm.
+      if (!removeSessionDirAtomically(sessionDir, heldLocks, onError)) continue;
+
+      prunedSessionIds.push(sessionId);
+      prunedRolloutFiles += rollout.rolloutPaths.length;
+      prunedMirrorRows += removedRows;
+    } finally {
+      releaseRolloutLocks(heldLocks);
     }
-
-    // Atomic directory removal: rename aside so a crash mid-rm never leaves a
-    // partially-deleted session dir under its real name, then recursive rm.
-    if (!removeSessionDirAtomically(sessionDir, onError)) continue;
-
-    prunedSessionIds.push(sessionId);
-    prunedRolloutFiles += rollout.rolloutPaths.length;
-    prunedMirrorRows += removedRows;
   }
 
   return {
@@ -330,6 +368,46 @@ export function pruneRolloutSessions(
     prunedMirrorRows,
     prunedSessionIds,
   };
+}
+
+/**
+ * Resolve the sequence tail from the authority before deleting it. Retention
+ * must fail closed on a partial/corrupt/non-monotonic source: once the bytes are
+ * gone there is no honest way to reconstruct the missing cursor boundary.
+ */
+function canonicalRolloutLastSequence(sourcePath: string): number {
+  const raw = readFileSync(sourcePath, "utf8");
+  if (raw.length > 0 && !raw.endsWith("\n")) {
+    throw new Error(
+      `refusing to retire canonical rollout with an incomplete tail: ${sourcePath}`,
+    );
+  }
+  let lastSequence = 0;
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.trim().length === 0) continue;
+    let item;
+    try {
+      item = parseRolloutLine(line);
+    } catch (error) {
+      throw new Error(
+        `refusing to retire corrupt canonical rollout: ${sourcePath}`,
+        { cause: error },
+      );
+    }
+    if (item?.type !== "event_msg" || item.payload.seq === undefined) continue;
+    const sequence = item.payload.seq;
+    if (
+      !Number.isSafeInteger(sequence) ||
+      sequence <= 0 ||
+      sequence <= lastSequence
+    ) {
+      throw new Error(
+        `refusing to retire non-monotonic canonical rollout at sequence ${String(sequence)}: ${sourcePath}`,
+      );
+    }
+    lastSequence = sequence;
+  }
+  return lastSequence;
 }
 
 interface SessionRolloutSummary {
@@ -364,10 +442,13 @@ function describeSessionRollouts(
     const filePath = join(sessionDir, file);
     try {
       const fileStat = statSync(filePath);
+      if (!fileStat.isFile()) return undefined;
       rolloutPaths.push(filePath);
       if (fileStat.mtimeMs > newestMtimeMs) newestMtimeMs = fileStat.mtimeMs;
     } catch {
-      // Unreadable rollout — skip it; siblings still gate the decision.
+      // Deletion is directory-wide, so one uninspectable canonical sibling
+      // makes the entire session ineligible for this sweep.
+      return undefined;
     }
   }
   if (rolloutPaths.length === 0) return undefined;
@@ -423,8 +504,63 @@ function parseLockHolderPid(raw: string): number | undefined {
   }
 }
 
+interface HeldRolloutLock {
+  readonly lockPath: string;
+  readonly lease: SessionLock;
+}
+
+function acquireRolloutLocks(
+  rolloutPaths: readonly string[],
+  onError: (error: unknown) => void,
+): HeldRolloutLock[] | undefined {
+  const held: HeldRolloutLock[] = [];
+  try {
+    for (const rolloutPath of [...new Set(rolloutPaths)].sort()) {
+      const lockPath = `${rolloutPath}.lock`;
+      const lease = new SessionLock(lockPath);
+      lease.acquire();
+      held.push({ lockPath, lease });
+    }
+    return held;
+  } catch (error) {
+    releaseRolloutLocks(held);
+    // A writer won the race after the preliminary observation. That is an
+    // expected retention deferral, not an operator error.
+    if (!(error instanceof SessionLockedError)) onError(error);
+    return undefined;
+  }
+}
+
+function releaseRolloutLocks(heldLocks: readonly HeldRolloutLock[]): void {
+  for (const held of [...heldLocks].reverse()) held.lease.release();
+}
+
+function cleanupRenamedRolloutLocks(
+  sessionDir: string,
+  aside: string,
+  heldLocks: readonly HeldRolloutLock[],
+  onError: (error: unknown) => void,
+): void {
+  for (const held of heldLocks) {
+    const relativeLock = relative(sessionDir, held.lockPath);
+    if (
+      relativeLock.length === 0 ||
+      relativeLock.startsWith("..") ||
+      isAbsolute(relativeLock)
+    ) {
+      continue;
+    }
+    try {
+      unlinkSync(join(aside, relativeLock));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") onError(error);
+    }
+  }
+}
+
 function removeSessionDirAtomically(
   sessionDir: string,
+  heldLocks: readonly HeldRolloutLock[],
   onError: (error: unknown) => void,
 ): boolean {
   const aside = `${sessionDir}.pruning-${process.pid}-${Date.now().toString(36)}`;
@@ -441,6 +577,7 @@ function removeSessionDirAtomically(
     // The live name is already gone (rename succeeded), so retention held;
     // only the renamed husk lingers. Report and move on.
     onError(error);
+    cleanupRenamedRolloutLocks(sessionDir, aside, heldLocks, onError);
   }
   return true;
 }

--- a/runtime/src/state/recovery.ts
+++ b/runtime/src/state/recovery.ts
@@ -3,8 +3,15 @@ import type { JsonObject } from "../app-server/protocol/index.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
 import { sqlPlaceholders } from "./sql.js";
 import { normalizeToolRecoveryCategory } from "./tool-output-rotation.js";
-import { repairCancelledSubtrees } from "./run-cancellation.js";
+import {
+  cancelAgentRunTree,
+  repairCancelledSubtrees,
+} from "./run-cancellation.js";
 import { asRecord } from "../utils/record.js";
+import {
+  recoverCanonicalRunJournalsOnStartup,
+  recoverPendingEffectReviewsOnStartup,
+} from "./startup-run-journal-recovery.js";
 
 const RECOVERABLE_AGENT_RUN_STATUSES = [
   "pending",
@@ -14,6 +21,8 @@ const RECOVERABLE_AGENT_RUN_STATUSES = [
   "blocked",
   "suspended",
 ] as const;
+
+const MAX_ADMISSION_CANCEL_REPAIRS = 4_096;
 
 const TERMINAL_TOOL_CALL_STATUSES = [
   "completed",
@@ -138,7 +147,35 @@ export function recoverDaemonStateOnStartup(
 ): DaemonStartupRecoveryReport {
   const warnings: DaemonStartupRecoveryWarning[] = [];
   const recoveredAt = options.now?.() ?? new Date().toISOString();
+  // The rollout JSONL is the M4 authority. Rebuild its SQLite projection
+  // before stale tool classification or the recoverable-run load so a crash
+  // after fsyncing `run_terminal`/`effect_result` cannot resurrect or replay
+  // work merely because the legacy snapshot write did not happen.
+  recoverCanonicalRunJournalsOnStartup(driver, {
+    recoverableStatuses: RECOVERABLE_AGENT_RUN_STATUSES,
+  });
+  // Older run.cancel implementations could commit the SQLite cancellation
+  // cascade immediately before the live writer projected its canonical
+  // terminal. Repair only the bounded set of cancelled M4 runs that have an
+  // explicit journal binding and still lack a current terminal result. This
+  // avoids making all historical offline cancellations part of startup work.
+  // If no canonical terminal is present, the row remains cancelled with
+  // deliberately unavailable output; recovery never invents a result.
+  recoverCanonicalRunJournalsOnStartup(driver, {
+    recoverableStatuses: ["cancelled"],
+    onlyMissingTerminalResults: true,
+    requireJournalBinding: true,
+  });
+  // A stopped terminal run may later receive one explicitly leased operator
+  // review event. Catch up that durable audit evidence independently of run
+  // status so a crash after journal fsync cannot strand the mutation gate.
+  recoverPendingEffectReviewsOnStartup(driver);
   return driver.transaction(() => {
+    // A live two-phase cancellation settles admissions while the canonical
+    // Session listener is still open, then writes the terminal tail, then
+    // projects agent_runs/spawn edges. A crash between the first two phases
+    // leaves an admission cancel-lock but must never restore runnable work.
+    repairAdmissionCancelledAgentRuns(driver);
     // Crash-mid-cascade repair MUST precede the recoverable-run load: a
     // surviving descendant of a cancelled parent is finished off here so
     // the restore loop never resurrects it.
@@ -156,6 +193,35 @@ export function recoverDaemonStateOnStartup(
       warnings,
     };
   });
+}
+
+function repairAdmissionCancelledAgentRuns(driver: StateSqliteDriver): void {
+  const rows = driver
+    .prepareState<
+      unknown[],
+      { readonly id: string; readonly reason: string; readonly cancelled_at: string }
+    >(
+      `SELECT runs.id, cancellation.reason, cancellation.cancelled_at
+       FROM agent_runs AS runs
+       JOIN execution_admission_cancellations AS cancellation
+         ON cancellation.run_id = runs.id
+       WHERE runs.status IN (${sqlPlaceholders(RECOVERABLE_AGENT_RUN_STATUSES.length)})
+       ORDER BY cancellation.cancelled_at ASC, runs.id ASC
+       LIMIT ?`,
+    )
+    .all(...RECOVERABLE_AGENT_RUN_STATUSES, MAX_ADMISSION_CANCEL_REPAIRS + 1);
+  if (rows.length > MAX_ADMISSION_CANCEL_REPAIRS) {
+    throw new Error(
+      `daemon startup admission-cancellation repair exceeds ${MAX_ADMISSION_CANCEL_REPAIRS} runs`,
+    );
+  }
+  for (const row of rows) {
+    cancelAgentRunTree(driver, {
+      runId: row.id,
+      reason: row.reason,
+      cancelledAt: row.cancelled_at,
+    });
+  }
 }
 
 function loadRecoverableAgentRuns(

--- a/runtime/src/state/run-cancellation.ts
+++ b/runtime/src/state/run-cancellation.ts
@@ -2,13 +2,13 @@
  * Tree-scoped run cancellation + spawn admission gate (M3 final slice;
  * design: docs/design/run-cancel-cascade-and-spawn-admission.md).
  *
- * Cancellation is durable-first: `cancelAgentRunTree` walks the spawn tree
- * in ONE transaction and moves every non-terminal descendant (queued AND
- * running) to `cancelled`, closing open edges, without touching
+ * `cancelAgentRunTree` walks the spawn tree in ONE transaction and moves
+ * every non-terminal descendant (queued AND running) to `cancelled`, closing
+ * open edges, without touching
  * `in_flight_tool_calls` (partial evidence is preserved and later
- * classified by the existing recovery category rules). Live interruption
- * is the daemon's second step and reuses `control.interrupt`'s cascade —
- * the frozen contract's single propagation primitive.
+ * classified by the existing recovery category rules). Live daemon runs seal
+ * their canonical rollout terminal before this rebuildable projection;
+ * inactive runs use the transaction as their honest offline authority.
  *
  * Admission under a cancel-locked ancestor is refused fail-closed at the
  * durable commit point (`ThreadSpawnEdgeRepository.create`) with
@@ -140,7 +140,10 @@ export interface CancelAgentRunTreeReport {
   readonly missing: boolean;
   /** The public run exists only through execution-admission evidence. */
   readonly admissionOnly?: boolean;
-  /** Root was already cancel-locked/terminal. Nothing was written. */
+  /**
+   * Root was already cancel-locked/terminal when this call began. An older
+   * incomplete cancellation may still repair non-terminal descendants.
+   */
   readonly alreadyTerminal: boolean;
   readonly rootStatusBefore: string | null;
   /**
@@ -168,8 +171,10 @@ export interface CancelAgentRunTreeReport {
  * every open subtree edge is closed, and `in_flight_tool_calls` rows are
  * left untouched so partial evidence survives for review.
  *
- * Idempotent: an already-terminal root reports `alreadyTerminal` and
- * mutates nothing; a missing root reports `missing` and mutates nothing.
+ * Idempotent: a fully-cascaded terminal root reports `alreadyTerminal` and
+ * mutates nothing. A cancelled root missing the `cascadeComplete` marker is
+ * repaired once (covering canonical-first cancellation and legacy crash
+ * gaps). A missing root reports `missing` and mutates nothing.
  */
 export function cancelAgentRunTree(
   driver: StateSqliteDriver,
@@ -207,7 +212,16 @@ function cancelSubtreeLocked(
     };
   }
   const subtree = collectSubtreeThreadIds(driver, runId);
-  if (isTerminalAgentRunStatus(rootStatus)) {
+  const metadataStmt = driver.prepareState<
+    [string],
+    { metadata_json: string | null }
+  >("SELECT metadata_json FROM agent_runs WHERE id = ?");
+  const rootMetadata = parseJsonObjectOrEmpty(
+    metadataStmt.get(runId)?.metadata_json,
+  );
+  const repairIncompleteCancelledRoot =
+    rootStatus === "cancelled" && rootMetadata.cascadeComplete !== true;
+  if (isTerminalAgentRunStatus(rootStatus) && !repairIncompleteCancelledRoot) {
     return {
       runId,
       missing: false,
@@ -224,10 +238,6 @@ function cancelSubtreeLocked(
   const priorStatusById: Record<string, string> = {};
   const closedEdgeChildIds: string[] = [];
 
-  const metadataStmt = driver.prepareState<
-    [string],
-    { metadata_json: string | null }
-  >("SELECT metadata_json FROM agent_runs WHERE id = ?");
   // Status predicate is the CAS: the row is only cancelled from the exact
   // non-terminal status read above, inside the same transaction.
   const cancelStmt = driver.prepareState<[string, string, string, string]>(
@@ -270,10 +280,30 @@ function cancelSubtreeLocked(
     }
   }
 
+  if (repairIncompleteCancelledRoot) {
+    driver
+      .prepareState<[string, string, string]>(
+        `UPDATE agent_runs
+         SET last_active_at = ?, metadata_json = ?
+         WHERE id = ? AND status = 'cancelled'`,
+      )
+      .run(
+        cancelledAt,
+        JSON.stringify({
+          ...rootMetadata,
+          cancelReason: reason,
+          cancelledBy: runId,
+          cancelledAt,
+          cascadeComplete: true,
+        }),
+        runId,
+      );
+  }
+
   return {
     runId,
     missing: false,
-    alreadyTerminal: false,
+    alreadyTerminal: repairIncompleteCancelledRoot,
     rootStatusBefore: rootStatus,
     subtreeRunIds: subtree,
     cancelledRunIds,

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -1,0 +1,1409 @@
+import type {
+  EffectOutcome,
+  RunId,
+  RunTerminalResult,
+  RunUsageTotals,
+} from "../contracts/run-contracts.js";
+import type { ToolRecoveryCategory } from "../tools/types.js";
+import { stableStringify } from "../utils/stableStringify.js";
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+
+export type RunDurabilityConflictCode =
+  | "RUN_EPOCH_CONFLICT"
+  | "RUN_EPOCH_NOT_TERMINAL"
+  | "RUN_REOPEN_REVIEW_REQUIRED"
+  | "RUN_TERMINAL_RESULT_CONFLICT"
+  | "RUN_EFFECT_INTENT_CONFLICT"
+  | "RUN_EFFECT_OUTCOME_CONFLICT"
+  | "RUN_EFFECT_NOT_FOUND"
+  | "RUN_EFFECT_REVIEW_CONFLICT"
+  | "RUN_EFFECT_REVIEW_REQUIRED"
+  | "RUN_EVENT_SEQUENCE_CONFLICT"
+  | "RUN_JOURNAL_BINDING_CONFLICT";
+
+export class RunDurabilityConflictError extends Error {
+  constructor(
+    readonly code: RunDurabilityConflictCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RunDurabilityConflictError";
+  }
+}
+
+export interface DurableWriteOutcome<T> {
+  readonly applied: boolean;
+  readonly value: T;
+}
+
+export interface RunLifecycleEpoch {
+  readonly runId: RunId;
+  readonly epoch: number;
+  readonly openedAt: string;
+  readonly openedEventId?: string;
+  readonly reopenedFromEpoch?: number;
+  readonly reopenReason?: string;
+}
+
+export interface DurableRunTerminalRecord extends RunTerminalResult {
+  readonly epoch: number;
+  readonly eventId: string;
+}
+
+export type EffectReviewStatus = "none" | "pending" | "resolved";
+
+export interface DurableRunEffect {
+  readonly runId: RunId;
+  readonly stepId: string;
+  readonly epoch: number;
+  readonly childRunId?: RunId;
+  readonly sessionId: string;
+  readonly callId: string;
+  readonly toolName: string;
+  readonly recoveryCategory: ToolRecoveryCategory;
+  readonly idempotencyKey?: string;
+  readonly intentDigest: string;
+  readonly intentEventId: string;
+  readonly intentSequence: number;
+  readonly intentAt: string;
+  readonly outcome?: EffectOutcome;
+  readonly resultEventId?: string;
+  readonly resultSequence?: number;
+  readonly resultDigest?: string;
+  readonly result?: unknown;
+  readonly evidence?: unknown;
+  readonly unknownReason?: string;
+  readonly completedAt?: string;
+  readonly reviewStatus: EffectReviewStatus;
+  readonly reviewedAt?: string;
+  readonly reviewedBy?: string;
+  readonly reviewResolution?: string;
+  readonly reviewEventId?: string;
+  readonly reviewEvidence?: unknown;
+}
+
+export type RunJournalGapReason =
+  | "retention"
+  | "corruption_truncated"
+  | "compaction";
+
+export interface RunJournalBinding {
+  readonly runId: RunId;
+  readonly epoch: number;
+  readonly childRunId: RunId;
+  readonly sessionId: string;
+  readonly sourcePath: string;
+  readonly active: boolean;
+  readonly firstAvailableSequence?: number;
+  readonly lastSequence?: number;
+  readonly retiredThroughSequence?: number;
+  readonly gapReason?: RunJournalGapReason;
+  readonly gapObservedAt?: string;
+  readonly boundAt: string;
+  readonly updatedAt: string;
+}
+
+interface EpochRow {
+  readonly run_id: string;
+  readonly epoch: number;
+  readonly opened_at: string;
+  readonly opened_event_id: string | null;
+  readonly reopened_from_epoch: number | null;
+  readonly reopen_reason: string | null;
+}
+
+interface TerminalRow {
+  readonly run_id: string;
+  readonly epoch: number;
+  readonly status: RunTerminalResult["status"];
+  readonly exit_code: number | null;
+  readonly stop_reason: string | null;
+  readonly final_message: string | null;
+  readonly usage_json: string | null;
+  readonly last_sequence: number | null;
+  readonly finished_at: string;
+  readonly event_id: string;
+}
+
+interface EffectRow {
+  readonly run_id: string;
+  readonly step_id: string;
+  readonly epoch: number;
+  readonly child_run_id: string | null;
+  readonly session_id: string;
+  readonly call_id: string;
+  readonly tool_name: string;
+  readonly recovery_category: ToolRecoveryCategory;
+  readonly idempotency_key: string | null;
+  readonly intent_digest: string;
+  readonly intent_event_id: string;
+  readonly intent_sequence: number;
+  readonly intent_at: string;
+  readonly outcome: EffectOutcome | null;
+  readonly result_event_id: string | null;
+  readonly result_sequence: number | null;
+  readonly result_digest: string | null;
+  readonly result_json: string | null;
+  readonly evidence_json: string | null;
+  readonly unknown_reason: string | null;
+  readonly completed_at: string | null;
+  readonly review_status: EffectReviewStatus;
+  readonly reviewed_at: string | null;
+  readonly reviewed_by: string | null;
+  readonly review_resolution: string | null;
+  readonly review_event_id: string | null;
+  readonly review_evidence_json: string | null;
+}
+
+interface JournalBindingRow {
+  readonly run_id: string;
+  readonly epoch: number;
+  readonly child_run_id: string;
+  readonly session_id: string;
+  readonly source_path: string;
+  readonly active: number;
+  readonly first_available_sequence: number | null;
+  readonly last_sequence: number | null;
+  readonly retired_through_sequence: number | null;
+  readonly gap_reason: RunJournalGapReason | null;
+  readonly gap_observed_at: string | null;
+  readonly bound_at: string;
+  readonly updated_at: string;
+}
+
+const EFFECT_COLUMNS = `
+  run_id, step_id, epoch, child_run_id, session_id, call_id, tool_name,
+  recovery_category, idempotency_key, intent_digest, intent_event_id,
+  intent_sequence, intent_at, outcome, result_event_id, result_sequence,
+  result_digest, result_json, evidence_json, unknown_reason, completed_at,
+  review_status, reviewed_at, reviewed_by, review_resolution, review_event_id,
+  review_evidence_json`;
+
+const JOURNAL_BINDING_COLUMNS = `
+  run_id, epoch, child_run_id, session_id, source_path, active,
+  first_available_sequence, last_sequence, retired_through_sequence,
+  gap_reason, gap_observed_at, bound_at, updated_at`;
+
+/**
+ * Durable run lifecycle/effect state plus bindings into the canonical rollout
+ * JSONL projection. Event payload bytes belong only to the rollout store.
+ */
+export class StateRunDurabilityRepository {
+  constructor(private readonly driver: StateSqliteDriver) {}
+
+  ensureInitialEpoch(params: {
+    readonly runId: RunId;
+    readonly openedAt: string;
+    readonly openedEventId?: string;
+  }): DurableWriteOutcome<RunLifecycleEpoch> {
+    return this.driver.transactionImmediate(() => {
+      const existingRow = this.driver
+        .prepareState<[string], EpochRow>(
+          `SELECT run_id, epoch, opened_at, opened_event_id,
+                  reopened_from_epoch, reopen_reason
+           FROM run_lifecycle_epochs
+           WHERE run_id = ? AND epoch = 1`,
+        )
+        .get(params.runId);
+      const existing =
+        existingRow === undefined ? undefined : epochFromRow(existingRow);
+      if (existing !== undefined) {
+        if (
+          existing.epoch === 1 &&
+          (params.openedEventId === undefined ||
+            existing.openedEventId === params.openedEventId)
+        ) {
+          return { applied: false, value: existing };
+        }
+        throw conflict(
+          "RUN_EPOCH_CONFLICT",
+          `run ${params.runId} initial lifecycle event conflicts with its durable epoch`,
+        );
+      }
+      this.driver
+        .prepareState<[string, number, string, string | null]>(
+          `INSERT INTO run_lifecycle_epochs (
+             run_id, epoch, opened_at, opened_event_id
+           ) VALUES (?, ?, ?, ?)`,
+        )
+        .run(
+          required(params.runId, "runId"),
+          1,
+          required(params.openedAt, "openedAt"),
+          optionalRequired(params.openedEventId, "openedEventId"),
+        );
+      return {
+        applied: true,
+        value: {
+          runId: params.runId,
+          epoch: 1,
+          openedAt: params.openedAt,
+          ...(params.openedEventId !== undefined
+            ? { openedEventId: params.openedEventId }
+            : {}),
+        },
+      };
+    });
+  }
+
+  currentEpoch(runId: RunId): RunLifecycleEpoch | undefined {
+    const row = this.driver
+      .prepareState<[string], EpochRow>(
+        `SELECT run_id, epoch, opened_at, opened_event_id,
+                reopened_from_epoch, reopen_reason
+         FROM run_lifecycle_epochs
+         WHERE run_id = ?
+         ORDER BY epoch DESC
+         LIMIT 1`,
+      )
+      .get(runId);
+    return row === undefined ? undefined : epochFromRow(row);
+  }
+
+  reopenRun(params: {
+    readonly runId: RunId;
+    readonly fromEpoch: number;
+    readonly openedAt: string;
+    readonly eventId: string;
+    readonly reason: string;
+  }): DurableWriteOutcome<RunLifecycleEpoch> {
+    return this.driver.transactionImmediate(() => {
+      const replayed = this.driver
+        .prepareState<[string, string], EpochRow>(
+          `SELECT run_id, epoch, opened_at, opened_event_id,
+                  reopened_from_epoch, reopen_reason
+           FROM run_lifecycle_epochs
+           WHERE run_id = ? AND opened_event_id = ?`,
+        )
+        .get(params.runId, params.eventId);
+      if (replayed !== undefined) {
+        const epoch = epochFromRow(replayed);
+        if (
+          epoch.reopenedFromEpoch === params.fromEpoch &&
+          epoch.openedAt === params.openedAt &&
+          epoch.reopenReason === params.reason
+        ) {
+          return { applied: false, value: epoch };
+        }
+        throw conflict(
+          "RUN_EPOCH_CONFLICT",
+          `reopen event ${params.eventId} conflicts with its durable epoch`,
+        );
+      }
+
+      const current = this.currentEpoch(params.runId);
+      if (current === undefined || current.epoch !== params.fromEpoch) {
+        throw conflict(
+          "RUN_EPOCH_CONFLICT",
+          `run ${params.runId} current epoch does not match ${params.fromEpoch}`,
+        );
+      }
+      if (this.getTerminalResult(params.runId, params.fromEpoch) === undefined) {
+        throw conflict(
+          "RUN_EPOCH_NOT_TERMINAL",
+          `run ${params.runId} epoch ${params.fromEpoch} is not terminal`,
+        );
+      }
+      const pending = this.listPendingEffectReviews(params.runId);
+      if (pending.length > 0) {
+        throw conflict(
+          "RUN_REOPEN_REVIEW_REQUIRED",
+          `run ${params.runId} has ${pending.length} unresolved unknown-outcome effect(s)`,
+        );
+      }
+
+      const nextEpoch = params.fromEpoch + 1;
+      this.driver
+        .prepareState<
+          [string, number, string, string, number, string]
+        >(
+          `INSERT INTO run_lifecycle_epochs (
+             run_id, epoch, opened_at, opened_event_id,
+             reopened_from_epoch, reopen_reason
+           ) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          required(params.runId, "runId"),
+          positiveInteger(nextEpoch, "epoch"),
+          required(params.openedAt, "openedAt"),
+          required(params.eventId, "eventId"),
+          params.fromEpoch,
+          required(params.reason, "reason"),
+        );
+      const value: RunLifecycleEpoch = {
+        runId: params.runId,
+        epoch: nextEpoch,
+        openedAt: params.openedAt,
+        openedEventId: params.eventId,
+        reopenedFromEpoch: params.fromEpoch,
+        reopenReason: params.reason,
+      };
+      return { applied: true, value };
+    });
+  }
+
+  recordTerminalResult(params: {
+    readonly epoch: number;
+    readonly result: RunTerminalResult;
+    readonly eventId: string;
+  }): DurableWriteOutcome<DurableRunTerminalRecord> {
+    return this.driver.transactionImmediate(() => {
+      const epoch = this.requireEpoch(params.result.runId, params.epoch);
+      if (epoch.epoch !== params.epoch) {
+        throw conflict(
+          "RUN_EPOCH_CONFLICT",
+          `run ${params.result.runId} epoch ${params.epoch} does not exist`,
+        );
+      }
+      const existing = this.getTerminalResult(
+        params.result.runId,
+        params.epoch,
+      );
+      if (existing !== undefined) {
+        if (
+          existing.eventId === params.eventId &&
+          terminalContent(existing) === terminalContent(params.result)
+        ) {
+          return { applied: false, value: existing };
+        }
+        throw conflict(
+          "RUN_TERMINAL_RESULT_CONFLICT",
+          `run ${params.result.runId} epoch ${params.epoch} already has a different terminal result`,
+        );
+      }
+      this.assertSequenceUnclaimed(
+        params.result.runId,
+        params.result.lastSequence,
+      );
+      const usageJson =
+        params.result.usage === null
+          ? null
+          : stableStringify(params.result.usage);
+      this.driver
+        .prepareState(
+          `INSERT INTO run_terminal_results (
+             run_id, epoch, status, exit_code, stop_reason, final_message,
+             usage_json, last_sequence, finished_at, event_id
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          required(params.result.runId, "runId"),
+          positiveInteger(params.epoch, "epoch"),
+          params.result.status,
+          params.result.exitCode,
+          params.result.stopReason,
+          params.result.finalMessage,
+          usageJson,
+          nullablePositiveInteger(params.result.lastSequence, "lastSequence"),
+          required(params.result.finishedAt, "finishedAt"),
+          required(params.eventId, "eventId"),
+        );
+      return {
+        applied: true,
+        value: { ...params.result, epoch: params.epoch, eventId: params.eventId },
+      };
+    });
+  }
+
+  getTerminalResult(
+    runId: RunId,
+    epoch: number,
+  ): DurableRunTerminalRecord | undefined {
+    const row = this.driver
+      .prepareState<[string, number], TerminalRow>(
+        `SELECT run_id, epoch, status, exit_code, stop_reason, final_message,
+                usage_json, last_sequence, finished_at, event_id
+         FROM run_terminal_results
+         WHERE run_id = ? AND epoch = ?`,
+      )
+      .get(runId, epoch);
+    return row === undefined ? undefined : terminalFromRow(row);
+  }
+
+  getCurrentTerminalResult(
+    runId: RunId,
+  ): DurableRunTerminalRecord | undefined {
+    const current = this.currentEpoch(runId);
+    return current === undefined
+      ? undefined
+      : this.getTerminalResult(runId, current.epoch);
+  }
+
+  listTerminalHistory(runId: RunId): readonly DurableRunTerminalRecord[] {
+    return this.driver
+      .prepareState<[string], TerminalRow>(
+        `SELECT run_id, epoch, status, exit_code, stop_reason, final_message,
+                usage_json, last_sequence, finished_at, event_id
+         FROM run_terminal_results
+         WHERE run_id = ?
+         ORDER BY epoch ASC`,
+      )
+      .all(runId)
+      .map(terminalFromRow);
+  }
+
+  beginEffect(params: {
+    readonly runId: RunId;
+    readonly epoch: number;
+    readonly stepId: string;
+    readonly childRunId?: RunId;
+    readonly sessionId: string;
+    readonly callId?: string;
+    readonly toolName: string;
+    readonly recoveryCategory: ToolRecoveryCategory;
+    readonly idempotencyKey?: string;
+    readonly intentDigest: string;
+    readonly eventId: string;
+    readonly eventSequence: number;
+    readonly intentAt: string;
+    /** Internal rebuild path for already-terminal canonical history. */
+    readonly projection?: "canonical_replay";
+  }): DurableWriteOutcome<DurableRunEffect> {
+    return this.driver.transactionImmediate(() => {
+      this.requireEpoch(params.runId, params.epoch);
+      const existing = this.getEffect(params.runId, params.stepId);
+      if (existing !== undefined) {
+        if (effectIntentContent(existing) === effectIntentContent(params)) {
+          return { applied: false, value: existing };
+        }
+        throw conflict(
+          "RUN_EFFECT_INTENT_CONFLICT",
+          `run ${params.runId} step ${params.stepId} already has a different effect intent`,
+        );
+      }
+      const terminal = this.getTerminalResult(params.runId, params.epoch);
+      if (
+        terminal !== undefined &&
+        (params.projection !== "canonical_replay" ||
+          terminal.lastSequence === null ||
+          params.eventSequence >= terminal.lastSequence)
+      ) {
+        throw conflict(
+          "RUN_EPOCH_CONFLICT",
+          `run ${params.runId} epoch ${params.epoch} is already terminal`,
+        );
+      }
+      if (
+        params.recoveryCategory === "side-effecting" &&
+        params.projection !== "canonical_replay"
+      ) {
+        this.assertDependentMutationAllowed(params.runId);
+      }
+      if (
+        params.recoveryCategory === "idempotent" &&
+        params.idempotencyKey === undefined
+      ) {
+        throw new TypeError("idempotent effects require idempotencyKey");
+      }
+      if (
+        params.recoveryCategory !== "idempotent" &&
+        params.idempotencyKey !== undefined
+      ) {
+        throw new TypeError(
+          "idempotencyKey is reserved for effects classified as idempotent",
+        );
+      }
+      this.assertSequenceUnclaimed(params.runId, params.eventSequence);
+      this.driver
+        .prepareState(
+          `INSERT INTO run_effects (
+             run_id, step_id, epoch, child_run_id, session_id, call_id, tool_name,
+             recovery_category, idempotency_key, intent_digest,
+             intent_event_id, intent_sequence, intent_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          required(params.runId, "runId"),
+          required(params.stepId, "stepId"),
+          positiveInteger(params.epoch, "epoch"),
+          optionalRequired(params.childRunId, "childRunId"),
+          required(params.sessionId, "sessionId"),
+          required(params.callId ?? params.stepId, "callId"),
+          required(params.toolName, "toolName"),
+          params.recoveryCategory,
+          optionalRequired(params.idempotencyKey, "idempotencyKey"),
+          required(params.intentDigest, "intentDigest"),
+          required(params.eventId, "eventId"),
+          positiveInteger(params.eventSequence, "eventSequence"),
+          required(params.intentAt, "intentAt"),
+        );
+      return {
+        applied: true,
+        value: this.getEffect(params.runId, params.stepId)!,
+      };
+    });
+  }
+
+  completeEffect(params: {
+    readonly runId: RunId;
+    readonly stepId: string;
+    readonly outcome: Exclude<EffectOutcome, "unknown_outcome">;
+    readonly eventId: string;
+    readonly eventSequence: number;
+    readonly resultDigest?: string;
+    readonly result?: unknown;
+    readonly evidence?: unknown;
+    readonly completedAt: string;
+  }): DurableWriteOutcome<DurableRunEffect> {
+    return this.finishEffect({ ...params, unknownReason: undefined });
+  }
+
+  markEffectUnknown(params: {
+    readonly runId: RunId;
+    readonly stepId: string;
+    readonly eventId: string;
+    readonly eventSequence: number;
+    readonly reason: string;
+    readonly evidence?: unknown;
+    readonly observedAt: string;
+  }): DurableWriteOutcome<DurableRunEffect> {
+    return this.finishEffect({
+      runId: params.runId,
+      stepId: params.stepId,
+      outcome: "unknown_outcome",
+      eventId: params.eventId,
+      eventSequence: params.eventSequence,
+      evidence: params.evidence,
+      completedAt: params.observedAt,
+      unknownReason: params.reason,
+    });
+  }
+
+  getEffect(runId: RunId, stepId: string): DurableRunEffect | undefined {
+    const row = this.driver
+      .prepareState<[string, string], EffectRow>(
+        `SELECT ${EFFECT_COLUMNS}
+         FROM run_effects
+         WHERE run_id = ? AND step_id = ?`,
+      )
+      .get(runId, stepId);
+    return row === undefined ? undefined : effectFromRow(row);
+  }
+
+  getEffectBySessionCall(
+    sessionId: string,
+    callId: string,
+  ): DurableRunEffect | undefined {
+    const row = this.driver
+      .prepareState<[string, string], EffectRow>(
+        `SELECT ${EFFECT_COLUMNS}
+         FROM run_effects
+         WHERE session_id = ? AND call_id = ?
+         LIMIT 1`,
+      )
+      .get(sessionId, callId);
+    return row === undefined ? undefined : effectFromRow(row);
+  }
+
+  listEffects(runId: RunId): readonly DurableRunEffect[] {
+    return this.driver
+      .prepareState<[string], EffectRow>(
+        `SELECT ${EFFECT_COLUMNS}
+         FROM run_effects
+         WHERE run_id = ?
+         ORDER BY intent_sequence ASC, step_id ASC`,
+      )
+      .all(runId)
+      .map(effectFromRow);
+  }
+
+  listPendingEffectReviews(runId: RunId): readonly DurableRunEffect[] {
+    return this.driver
+      .prepareState<[string], EffectRow>(
+        `SELECT ${EFFECT_COLUMNS}
+         FROM run_effects
+         WHERE run_id = ? AND review_status = 'pending'
+         ORDER BY intent_sequence ASC, step_id ASC`,
+      )
+      .all(runId)
+      .map(effectFromRow);
+  }
+
+  assertDependentMutationAllowed(runId: RunId): void {
+    const pending = this.listPendingEffectReviews(runId);
+    if (pending.length === 0) return;
+    throw conflict(
+      "RUN_EFFECT_REVIEW_REQUIRED",
+      `run ${runId} has unresolved unknown-outcome effect(s): ${pending
+        .map((effect) => effect.stepId)
+        .join(", ")}`,
+    );
+  }
+
+  resolveEffectReview(params: {
+    readonly runId: RunId;
+    readonly stepId: string;
+    readonly reviewedAt: string;
+    readonly reviewedBy: string;
+    readonly resolution: string;
+    readonly eventId: string;
+    readonly evidence?: unknown;
+  }): DurableWriteOutcome<DurableRunEffect> {
+    return this.driver.transactionImmediate(() => {
+      const existing = this.getEffect(params.runId, params.stepId);
+      if (existing === undefined) {
+        throw conflict(
+          "RUN_EFFECT_NOT_FOUND",
+          `run ${params.runId} step ${params.stepId} has no durable effect`,
+        );
+      }
+      const reviewContent = stableStringify({
+        reviewedAt: params.reviewedAt,
+        reviewedBy: params.reviewedBy,
+        resolution: params.resolution,
+        eventId: params.eventId,
+        evidence: params.evidence ?? null,
+      });
+      if (existing.reviewStatus === "resolved") {
+        const existingContent = stableStringify({
+          reviewedAt: existing.reviewedAt,
+          reviewedBy: existing.reviewedBy,
+          resolution: existing.reviewResolution,
+          eventId: existing.reviewEventId,
+          evidence: existing.reviewEvidence ?? null,
+        });
+        if (reviewContent === existingContent) {
+          return { applied: false, value: existing };
+        }
+        throw conflict(
+          "RUN_EFFECT_REVIEW_CONFLICT",
+          `run ${params.runId} step ${params.stepId} already has a different review resolution`,
+        );
+      }
+      if (
+        existing.outcome !== "unknown_outcome" ||
+        existing.reviewStatus !== "pending"
+      ) {
+        throw conflict(
+          "RUN_EFFECT_REVIEW_CONFLICT",
+          `run ${params.runId} step ${params.stepId} is not awaiting review`,
+        );
+      }
+      this.driver
+        .prepareState(
+          `UPDATE run_effects
+           SET review_status = 'resolved', reviewed_at = ?, reviewed_by = ?,
+               review_resolution = ?, review_event_id = ?,
+               review_evidence_json = ?
+           WHERE run_id = ? AND step_id = ? AND review_status = 'pending'`,
+        )
+        .run(
+          required(params.reviewedAt, "reviewedAt"),
+          required(params.reviewedBy, "reviewedBy"),
+          required(params.resolution, "resolution"),
+          required(params.eventId, "eventId"),
+          serializeOptionalJson(params.evidence),
+          params.runId,
+          params.stepId,
+        );
+      return {
+        applied: true,
+        value: this.getEffect(params.runId, params.stepId)!,
+      };
+    });
+  }
+
+  bindJournalSource(params: {
+    readonly runId: RunId;
+    readonly epoch: number;
+    readonly childRunId: RunId;
+    readonly sessionId: string;
+    readonly sourcePath: string;
+    readonly active?: boolean;
+    readonly firstAvailableSequence?: number;
+    readonly lastSequence?: number;
+    readonly boundAt: string;
+  }): DurableWriteOutcome<RunJournalBinding> {
+    return this.driver.transactionImmediate(() => {
+      this.requireEpoch(params.runId, params.epoch);
+      const existing = this.getJournalBinding(params.sourcePath);
+      const active = params.active !== false;
+      if (existing !== undefined) {
+        const same =
+          existing.runId === params.runId &&
+          existing.epoch === params.epoch &&
+          existing.childRunId === params.childRunId &&
+          existing.sessionId === params.sessionId &&
+          existing.active === active &&
+          existing.firstAvailableSequence === params.firstAvailableSequence &&
+          existing.lastSequence === params.lastSequence &&
+          existing.boundAt === params.boundAt;
+        if (same) return { applied: false, value: existing };
+        throw conflict(
+          "RUN_JOURNAL_BINDING_CONFLICT",
+          `rollout source ${params.sourcePath} already has a different run binding`,
+        );
+      }
+      validateBounds(
+        params.firstAvailableSequence,
+        params.lastSequence,
+        undefined,
+      );
+      if (active) {
+        this.driver
+          .prepareState<[string, string, number]>(
+            `UPDATE run_journal_bindings
+             SET active = 0, updated_at = ?
+             WHERE run_id = ? AND epoch = ? AND active = 1`,
+          )
+          .run(params.boundAt, params.runId, params.epoch);
+      }
+      this.driver
+        .prepareState(
+          `INSERT INTO run_journal_bindings (
+             run_id, epoch, child_run_id, session_id, source_path, active,
+             first_available_sequence, last_sequence, bound_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          required(params.runId, "runId"),
+          positiveInteger(params.epoch, "epoch"),
+          required(params.childRunId, "childRunId"),
+          required(params.sessionId, "sessionId"),
+          required(params.sourcePath, "sourcePath"),
+          active ? 1 : 0,
+          optionalPositiveInteger(
+            params.firstAvailableSequence,
+            "firstAvailableSequence",
+          ),
+          optionalPositiveInteger(params.lastSequence, "lastSequence"),
+          required(params.boundAt, "boundAt"),
+          params.boundAt,
+        );
+      return {
+        applied: true,
+        value: this.getJournalBinding(params.sourcePath)!,
+      };
+    });
+  }
+
+  updateJournalBounds(params: {
+    readonly sourcePath: string;
+    readonly firstAvailableSequence: number;
+    readonly lastSequence: number;
+    readonly updatedAt: string;
+  }): RunJournalBinding {
+    return this.driver.transactionImmediate(() => {
+      const existing = this.requireJournalBinding(params.sourcePath);
+      validateBounds(
+        params.firstAvailableSequence,
+        params.lastSequence,
+        existing.retiredThroughSequence,
+      );
+      if (
+        existing.firstAvailableSequence !== undefined &&
+        params.firstAvailableSequence > existing.firstAvailableSequence
+      ) {
+        throw conflict(
+          "RUN_JOURNAL_BINDING_CONFLICT",
+          "journal bounds cannot silently advance past retained events; record an explicit gap",
+        );
+      }
+      if (
+        existing.lastSequence !== undefined &&
+        params.lastSequence < existing.lastSequence
+      ) {
+        throw conflict(
+          "RUN_JOURNAL_BINDING_CONFLICT",
+          "journal bounds cannot silently truncate events; record an explicit gap",
+        );
+      }
+      const first =
+        existing.firstAvailableSequence === undefined
+          ? params.firstAvailableSequence
+          : Math.min(
+              existing.firstAvailableSequence,
+              params.firstAvailableSequence,
+            );
+      const last = Math.max(existing.lastSequence ?? 0, params.lastSequence);
+      this.driver
+        .prepareState<[number, number, string, string]>(
+          `UPDATE run_journal_bindings
+           SET first_available_sequence = ?, last_sequence = ?, updated_at = ?
+           WHERE source_path = ?`,
+        )
+        .run(first, last, required(params.updatedAt, "updatedAt"), params.sourcePath);
+      return this.requireJournalBinding(params.sourcePath);
+    });
+  }
+
+  markJournalGap(params: {
+    readonly sourcePath: string;
+    readonly retiredThroughSequence: number;
+    readonly firstAvailableSequence?: number;
+    readonly lastSequence?: number;
+    readonly reason: RunJournalGapReason;
+    readonly observedAt: string;
+  }): RunJournalBinding {
+    return this.driver.transactionImmediate(() => {
+      const existing = this.requireJournalBinding(params.sourcePath);
+      const retired = nonNegativeInteger(
+        params.retiredThroughSequence,
+        "retiredThroughSequence",
+      );
+      if (
+        existing.retiredThroughSequence !== undefined &&
+        retired < existing.retiredThroughSequence
+      ) {
+        throw conflict(
+          "RUN_JOURNAL_BINDING_CONFLICT",
+          "journal retirement boundary cannot move backwards",
+        );
+      }
+      validateBounds(
+        params.firstAvailableSequence,
+        params.lastSequence,
+        retired,
+      );
+      this.driver
+        .prepareState(
+          `UPDATE run_journal_bindings
+           SET first_available_sequence = ?, last_sequence = ?,
+               retired_through_sequence = ?, gap_reason = ?,
+               gap_observed_at = ?, updated_at = ?
+           WHERE source_path = ?`,
+        )
+        .run(
+          optionalPositiveInteger(
+            params.firstAvailableSequence,
+            "firstAvailableSequence",
+          ),
+          optionalPositiveInteger(params.lastSequence, "lastSequence"),
+          retired,
+          params.reason,
+          required(params.observedAt, "observedAt"),
+          params.observedAt,
+          params.sourcePath,
+        );
+      return this.requireJournalBinding(params.sourcePath);
+    });
+  }
+
+  /**
+   * Fully retire one canonical rollout source before retention removes its
+   * SQLite projection and JSONL file. The binding is deliberately preserved:
+   * it is the durable explanation for why a once-known source is now missing.
+   *
+   * The tail is resolved inside the same write transaction from both the
+   * binding and the current `thread_rollout_items` mirror. Callers may wrap
+   * this method and mirror-row deletion in an outer immediate transaction;
+   * nested driver transactions become savepoints, so retirement cannot commit
+   * without the matching projection deletion.
+   */
+  retireJournalSource(params: {
+    readonly sourcePath: string;
+    readonly reason: RunJournalGapReason;
+    readonly observedAt: string;
+    /** Highest sequence parsed from the canonical source under its lease. */
+    readonly canonicalLastSequence?: number;
+  }): DurableWriteOutcome<RunJournalBinding | undefined> {
+    return this.driver.transactionImmediate(() => {
+      const existing = this.getJournalBinding(params.sourcePath);
+      if (existing === undefined) {
+        // Legacy rollout sources can predate M4 bindings. Retention remains
+        // safe and idempotent for those sources; there is no identity to keep.
+        return { applied: false, value: undefined };
+      }
+      const projectedTail = this.driver
+        .prepareState<[string], { readonly last_sequence: number | null }>(
+          `SELECT MAX(event_seq) AS last_sequence
+           FROM thread_rollout_items
+           WHERE source_path = ? AND event_seq IS NOT NULL`,
+        )
+        .get(params.sourcePath)?.last_sequence;
+      const canonicalTail =
+        params.canonicalLastSequence === undefined
+          ? undefined
+          : nonNegativeInteger(
+              params.canonicalLastSequence,
+              "canonicalLastSequence",
+            );
+      if (
+        existing.lastSequence === undefined &&
+        existing.retiredThroughSequence === undefined &&
+        (projectedTail === null || projectedTail === undefined) &&
+        canonicalTail === undefined
+      ) {
+        throw conflict(
+          "RUN_JOURNAL_BINDING_CONFLICT",
+          `rollout source ${params.sourcePath} cannot be retired without an authoritative sequence tail`,
+        );
+      }
+      const tail = Math.max(
+        existing.lastSequence ?? 0,
+        existing.retiredThroughSequence ?? 0,
+        projectedTail ?? 0,
+        canonicalTail ?? 0,
+      );
+      if (
+        !existing.active &&
+        existing.firstAvailableSequence === undefined &&
+        existing.retiredThroughSequence === tail &&
+        existing.gapReason === params.reason
+      ) {
+        return { applied: false, value: existing };
+      }
+      const observedAt = required(params.observedAt, "observedAt");
+      this.driver
+        .prepareState(
+          `UPDATE run_journal_bindings
+           SET active = 0,
+               first_available_sequence = NULL,
+               last_sequence = ?,
+               retired_through_sequence = ?,
+               gap_reason = ?,
+               gap_observed_at = ?,
+               updated_at = ?
+           WHERE source_path = ?`,
+        )
+        .run(
+          tail > 0 ? tail : null,
+          tail,
+          params.reason,
+          observedAt,
+          observedAt,
+          params.sourcePath,
+        );
+      return {
+        applied: true,
+        value: this.requireJournalBinding(params.sourcePath),
+      };
+    });
+  }
+
+  getJournalBinding(sourcePath: string): RunJournalBinding | undefined {
+    const row = this.driver
+      .prepareState<[string], JournalBindingRow>(
+        `SELECT ${JOURNAL_BINDING_COLUMNS}
+         FROM run_journal_bindings
+         WHERE source_path = ?`,
+      )
+      .get(sourcePath);
+    return row === undefined ? undefined : journalBindingFromRow(row);
+  }
+
+  listJournalBindings(
+    runId: RunId,
+    epoch?: number,
+  ): readonly RunJournalBinding[] {
+    const statement = this.driver.prepareState<unknown[], JournalBindingRow>(
+      `SELECT ${JOURNAL_BINDING_COLUMNS}
+       FROM run_journal_bindings
+       WHERE run_id = ?${epoch === undefined ? "" : " AND epoch = ?"}
+       ORDER BY epoch ASC, bound_at ASC, source_path ASC`,
+    );
+    const rows =
+      epoch === undefined ? statement.all(runId) : statement.all(runId, epoch);
+    return rows.map(journalBindingFromRow);
+  }
+
+  private finishEffect(params: {
+    readonly runId: RunId;
+    readonly stepId: string;
+    readonly outcome: EffectOutcome;
+    readonly eventId: string;
+    readonly eventSequence: number;
+    readonly resultDigest?: string;
+    readonly result?: unknown;
+    readonly evidence?: unknown;
+    readonly completedAt: string;
+    readonly unknownReason?: string;
+  }): DurableWriteOutcome<DurableRunEffect> {
+    return this.driver.transactionImmediate(() => {
+      const existing = this.getEffect(params.runId, params.stepId);
+      if (existing === undefined) {
+        throw conflict(
+          "RUN_EFFECT_NOT_FOUND",
+          `run ${params.runId} step ${params.stepId} has no durable effect intent`,
+        );
+      }
+      const incomingContent = effectOutcomeContent(params);
+      if (existing.outcome !== undefined) {
+        if (effectOutcomeContent(existing) === incomingContent) {
+          return { applied: false, value: existing };
+        }
+        throw conflict(
+          "RUN_EFFECT_OUTCOME_CONFLICT",
+          `run ${params.runId} step ${params.stepId} already has a sticky ${existing.outcome} outcome`,
+        );
+      }
+      if (
+        params.outcome === "unknown_outcome" &&
+        existing.recoveryCategory === "idempotent"
+      ) {
+        throw new TypeError(
+          "an idempotent effect may not enter unknown_outcome",
+        );
+      }
+      if (params.outcome === "unknown_outcome") {
+        if (params.unknownReason === undefined) {
+          throw new TypeError("unknownReason is required for unknown_outcome");
+        }
+        required(params.unknownReason, "unknownReason");
+      } else if (params.unknownReason !== undefined) {
+        throw new TypeError("unknownReason requires unknown_outcome");
+      }
+      this.assertSequenceUnclaimed(params.runId, params.eventSequence);
+      this.driver
+        .prepareState(
+          `UPDATE run_effects
+           SET outcome = ?, result_event_id = ?, result_sequence = ?,
+               result_digest = ?, result_json = ?, evidence_json = ?,
+               unknown_reason = ?, completed_at = ?, review_status = ?
+           WHERE run_id = ? AND step_id = ? AND outcome IS NULL`,
+        )
+        .run(
+          params.outcome,
+          required(params.eventId, "eventId"),
+          positiveInteger(params.eventSequence, "eventSequence"),
+          optionalRequired(params.resultDigest, "resultDigest"),
+          serializeOptionalJson(params.result),
+          serializeOptionalJson(params.evidence),
+          optionalRequired(params.unknownReason, "unknownReason"),
+          required(params.completedAt, "completedAt"),
+          params.outcome === "unknown_outcome" ? "pending" : "none",
+          params.runId,
+          params.stepId,
+        );
+      return {
+        applied: true,
+        value: this.getEffect(params.runId, params.stepId)!,
+      };
+    });
+  }
+
+  private requireEpoch(runId: RunId, epoch: number): RunLifecycleEpoch {
+    const row = this.driver
+      .prepareState<[string, number], EpochRow>(
+        `SELECT run_id, epoch, opened_at, opened_event_id,
+                reopened_from_epoch, reopen_reason
+         FROM run_lifecycle_epochs
+         WHERE run_id = ? AND epoch = ?`,
+      )
+      .get(runId, positiveInteger(epoch, "epoch"));
+    if (row === undefined) {
+      throw conflict(
+        "RUN_EPOCH_CONFLICT",
+        `run ${runId} epoch ${epoch} does not exist`,
+      );
+    }
+    return epochFromRow(row);
+  }
+
+  private requireJournalBinding(sourcePath: string): RunJournalBinding {
+    const binding = this.getJournalBinding(sourcePath);
+    if (binding === undefined) {
+      throw conflict(
+        "RUN_JOURNAL_BINDING_CONFLICT",
+        `rollout source ${sourcePath} is not bound to a run`,
+      );
+    }
+    return binding;
+  }
+
+  private assertSequenceUnclaimed(
+    runId: RunId,
+    sequence: number | null,
+  ): void {
+    if (sequence === null) return;
+    const normalized = positiveInteger(sequence, "sequence");
+    const effect = this.driver
+      .prepareState<[string, number, number], { readonly step_id: string }>(
+        `SELECT step_id
+         FROM run_effects
+         WHERE run_id = ?
+           AND (intent_sequence = ? OR result_sequence = ?)
+         LIMIT 1`,
+      )
+      .get(runId, normalized, normalized);
+    const terminal = this.driver
+      .prepareState<[string, number], { readonly epoch: number }>(
+        `SELECT epoch
+         FROM run_terminal_results
+         WHERE run_id = ? AND last_sequence = ?
+         LIMIT 1`,
+      )
+      .get(runId, normalized);
+    if (effect === undefined && terminal === undefined) return;
+    throw conflict(
+      "RUN_EVENT_SEQUENCE_CONFLICT",
+      `run ${runId} sequence ${normalized} is already projected`,
+    );
+  }
+}
+
+function epochFromRow(row: EpochRow): RunLifecycleEpoch {
+  return {
+    runId: row.run_id,
+    epoch: row.epoch,
+    openedAt: row.opened_at,
+    ...(row.opened_event_id !== null
+      ? { openedEventId: row.opened_event_id }
+      : {}),
+    ...(row.reopened_from_epoch !== null
+      ? { reopenedFromEpoch: row.reopened_from_epoch }
+      : {}),
+    ...(row.reopen_reason !== null ? { reopenReason: row.reopen_reason } : {}),
+  };
+}
+
+function terminalFromRow(row: TerminalRow): DurableRunTerminalRecord {
+  return {
+    runId: row.run_id,
+    epoch: row.epoch,
+    status: row.status,
+    exitCode: row.exit_code,
+    stopReason: row.stop_reason,
+    finalMessage: row.final_message,
+    usage: parseUsage(row.usage_json),
+    lastSequence: row.last_sequence,
+    finishedAt: row.finished_at,
+    eventId: row.event_id,
+  };
+}
+
+function effectFromRow(row: EffectRow): DurableRunEffect {
+  return {
+    runId: row.run_id,
+    stepId: row.step_id,
+    epoch: row.epoch,
+    ...(row.child_run_id !== null ? { childRunId: row.child_run_id } : {}),
+    sessionId: row.session_id,
+    callId: row.call_id,
+    toolName: row.tool_name,
+    recoveryCategory: row.recovery_category,
+    ...(row.idempotency_key !== null
+      ? { idempotencyKey: row.idempotency_key }
+      : {}),
+    intentDigest: row.intent_digest,
+    intentEventId: row.intent_event_id,
+    intentSequence: row.intent_sequence,
+    intentAt: row.intent_at,
+    ...(row.outcome !== null ? { outcome: row.outcome } : {}),
+    ...(row.result_event_id !== null
+      ? { resultEventId: row.result_event_id }
+      : {}),
+    ...(row.result_sequence !== null
+      ? { resultSequence: row.result_sequence }
+      : {}),
+    ...(row.result_digest !== null ? { resultDigest: row.result_digest } : {}),
+    ...(row.result_json !== null ? { result: parseJson(row.result_json) } : {}),
+    ...(row.evidence_json !== null
+      ? { evidence: parseJson(row.evidence_json) }
+      : {}),
+    ...(row.unknown_reason !== null
+      ? { unknownReason: row.unknown_reason }
+      : {}),
+    ...(row.completed_at !== null ? { completedAt: row.completed_at } : {}),
+    reviewStatus: row.review_status,
+    ...(row.reviewed_at !== null ? { reviewedAt: row.reviewed_at } : {}),
+    ...(row.reviewed_by !== null ? { reviewedBy: row.reviewed_by } : {}),
+    ...(row.review_resolution !== null
+      ? { reviewResolution: row.review_resolution }
+      : {}),
+    ...(row.review_event_id !== null
+      ? { reviewEventId: row.review_event_id }
+      : {}),
+    ...(row.review_evidence_json !== null
+      ? { reviewEvidence: parseJson(row.review_evidence_json) }
+      : {}),
+  };
+}
+
+function journalBindingFromRow(row: JournalBindingRow): RunJournalBinding {
+  return {
+    runId: row.run_id,
+    epoch: row.epoch,
+    childRunId: row.child_run_id,
+    sessionId: row.session_id,
+    sourcePath: row.source_path,
+    active: row.active === 1,
+    ...(row.first_available_sequence !== null
+      ? { firstAvailableSequence: row.first_available_sequence }
+      : {}),
+    ...(row.last_sequence !== null
+      ? { lastSequence: row.last_sequence }
+      : {}),
+    ...(row.retired_through_sequence !== null
+      ? { retiredThroughSequence: row.retired_through_sequence }
+      : {}),
+    ...(row.gap_reason !== null ? { gapReason: row.gap_reason } : {}),
+    ...(row.gap_observed_at !== null
+      ? { gapObservedAt: row.gap_observed_at }
+      : {}),
+    boundAt: row.bound_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function effectIntentContent(
+  effect:
+    | DurableRunEffect
+    | {
+        readonly runId: RunId;
+        readonly epoch: number;
+        readonly stepId: string;
+        readonly childRunId?: RunId;
+        readonly sessionId: string;
+        readonly callId?: string;
+        readonly toolName: string;
+        readonly recoveryCategory: ToolRecoveryCategory;
+        readonly idempotencyKey?: string;
+        readonly intentDigest: string;
+        readonly eventId: string;
+        readonly eventSequence: number;
+        readonly intentAt: string;
+      },
+): string {
+  return stableStringify({
+    runId: effect.runId,
+    epoch: effect.epoch,
+    stepId: effect.stepId,
+    childRunId: effect.childRunId ?? null,
+    sessionId: effect.sessionId,
+    callId: effect.callId ?? effect.stepId,
+    toolName: effect.toolName,
+    recoveryCategory: effect.recoveryCategory,
+    idempotencyKey: effect.idempotencyKey ?? null,
+    intentDigest: effect.intentDigest,
+    eventId: "intentEventId" in effect ? effect.intentEventId : effect.eventId,
+    eventSequence:
+      "intentSequence" in effect ? effect.intentSequence : effect.eventSequence,
+    intentAt: effect.intentAt,
+  });
+}
+
+function effectOutcomeContent(
+  effect:
+    | DurableRunEffect
+    | {
+        readonly outcome: EffectOutcome;
+        readonly eventId: string;
+        readonly eventSequence: number;
+        readonly resultDigest?: string;
+        readonly result?: unknown;
+        readonly evidence?: unknown;
+        readonly completedAt: string;
+        readonly unknownReason?: string;
+      },
+): string {
+  const durable = "intentEventId" in effect;
+  return stableStringify({
+    outcome: effect.outcome,
+    eventId: durable ? effect.resultEventId : effect.eventId,
+    eventSequence: durable ? effect.resultSequence : effect.eventSequence,
+    resultDigest: effect.resultDigest ?? null,
+    result: effect.result ?? null,
+    evidence: effect.evidence ?? null,
+    completedAt: effect.completedAt,
+    unknownReason: effect.unknownReason ?? null,
+  });
+}
+
+function terminalContent(result: RunTerminalResult): string {
+  return stableStringify({
+    runId: result.runId,
+    status: result.status,
+    exitCode: result.exitCode,
+    stopReason: result.stopReason,
+    finalMessage: result.finalMessage,
+    usage: result.usage,
+    lastSequence: result.lastSequence,
+    finishedAt: result.finishedAt,
+  });
+}
+
+function parseUsage(value: string | null): RunUsageTotals | null {
+  if (value === null) return null;
+  const parsed = parseJson(value) as Partial<RunUsageTotals>;
+  for (const field of [
+    "inputTokens",
+    "outputTokens",
+    "totalTokens",
+    "costUsd",
+  ] as const) {
+    if (typeof parsed[field] !== "number" || !Number.isFinite(parsed[field])) {
+      throw new Error(`invalid durable terminal usage field: ${field}`);
+    }
+  }
+  return parsed as RunUsageTotals;
+}
+
+function parseJson(value: string): unknown {
+  return JSON.parse(value) as unknown;
+}
+
+function serializeOptionalJson(value: unknown): string | null {
+  return value === undefined ? null : stableStringify(value);
+}
+
+function validateBounds(
+  firstAvailableSequence: number | undefined,
+  lastSequence: number | undefined,
+  retiredThroughSequence: number | undefined,
+): void {
+  const first = optionalPositiveInteger(
+    firstAvailableSequence,
+    "firstAvailableSequence",
+  );
+  const last = optionalPositiveInteger(lastSequence, "lastSequence");
+  if (first !== null && last !== null && last < first) {
+    throw new RangeError("lastSequence must be >= firstAvailableSequence");
+  }
+  if (
+    retiredThroughSequence !== undefined &&
+    first !== null &&
+    retiredThroughSequence >= first
+  ) {
+    throw new RangeError(
+      "firstAvailableSequence must be after retiredThroughSequence",
+    );
+  }
+}
+
+function required(value: string, name: string): string {
+  if (value.trim().length === 0) throw new TypeError(`${name} must not be empty`);
+  return value;
+}
+
+function optionalRequired(
+  value: string | undefined,
+  name: string,
+): string | null {
+  return value === undefined ? null : required(value, name);
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function optionalPositiveInteger(
+  value: number | undefined,
+  name: string,
+): number | null {
+  return value === undefined ? null : positiveInteger(value, name);
+}
+
+function nullablePositiveInteger(
+  value: number | null,
+  name: string,
+): number | null {
+  return value === null ? null : positiveInteger(value, name);
+}
+
+function conflict(
+  code: RunDurabilityConflictCode,
+  message: string,
+): RunDurabilityConflictError {
+  return new RunDurabilityConflictError(code, message);
+}

--- a/runtime/src/state/sqlite-driver.ts
+++ b/runtime/src/state/sqlite-driver.ts
@@ -25,6 +25,7 @@ import {
   type SqlMigration,
 } from "./migrations/index.js";
 import { AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION } from "./migrations/012_agent_role_workspace_provenance.js";
+import { RUN_DURABILITY_SCHEMA_VERSION } from "./migrations/015_run_durability_schema.js";
 import { replayAtomicSessionSnapshotWrites } from "./atomic-snapshot-writes.js";
 
 export interface OpenStateDatabaseOptions {
@@ -42,6 +43,7 @@ export interface StateDatabasePaths {
 export const STATE_DATABASE_FILENAME = "agenc-state_1.sqlite";
 export const LOGS_DATABASE_FILENAME = "agenc-logs_1.sqlite";
 export const STATE_PRE_V12_BACKUP_FILENAME = "agenc-state_1.pre-v12.sqlite";
+export const STATE_PRE_V15_BACKUP_FILENAME = "agenc-state_1.pre-v15.sqlite";
 
 export type SqliteDatabase = BetterSqlite3.Database;
 export type SqliteStatement<
@@ -246,12 +248,24 @@ function applyStateMigrations(
   // an existence/version check and make us migrate it without a backup.
   db.exec("BEGIN IMMEDIATE");
   try {
-    if (
-      hasUserStateTables(db) &&
-      maxAppliedMigrationVersion(db) <
-        AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION
-    ) {
-      createPreV12StateBackupLocked(paths);
+    if (hasUserStateTables(db)) {
+      const maxApplied = maxAppliedMigrationVersion(db);
+      if (maxApplied < AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION) {
+        createPreMigrationStateBackupLocked(
+          paths,
+          STATE_PRE_V12_BACKUP_FILENAME,
+          AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION,
+          "pre-v12",
+        );
+      }
+      if (maxApplied < RUN_DURABILITY_SCHEMA_VERSION) {
+        createPreMigrationStateBackupLocked(
+          paths,
+          STATE_PRE_V15_BACKUP_FILENAME,
+          RUN_DURABILITY_SCHEMA_VERSION,
+          "pre-v15",
+        );
+      }
     }
     applyMigrations(db, STATE_DB_MIGRATIONS);
     db.exec("COMMIT");
@@ -261,8 +275,13 @@ function applyStateMigrations(
   }
 }
 
-function createPreV12StateBackupLocked(paths: StateDatabasePaths): void {
-  const backupPath = join(paths.projectDir, STATE_PRE_V12_BACKUP_FILENAME);
+function createPreMigrationStateBackupLocked(
+  paths: StateDatabasePaths,
+  filename: string,
+  targetVersion: number,
+  label: string,
+): void {
+  const backupPath = join(paths.projectDir, filename);
   const tempPath = `${backupPath}.${process.pid}.${randomUUID()}.tmp`;
   let snapshotSource: SqliteDatabase | undefined;
   try {
@@ -276,7 +295,7 @@ function createPreV12StateBackupLocked(paths: StateDatabasePaths): void {
     snapshotSource = undefined;
 
     chmodSync(tempPath, 0o600);
-    validatePreV12StateBackup(tempPath);
+    validatePreMigrationStateBackup(tempPath, targetVersion, label);
     fsyncFile(tempPath);
 
     // Refresh a stale artifact from an earlier failed attempt while the source
@@ -332,7 +351,11 @@ function maxAppliedMigrationVersion(db: SqliteDatabase): number {
   );
 }
 
-function validatePreV12StateBackup(path: string): void {
+function validatePreMigrationStateBackup(
+  path: string,
+  targetVersion: number,
+  label: string,
+): void {
   const backup = new Database(path, { readonly: true, fileMustExist: true });
   try {
     const integrity = backup
@@ -345,10 +368,9 @@ function validatePreV12StateBackup(path: string): void {
       throw new Error(`state backup failed integrity check: ${path}`);
     }
     if (
-      maxAppliedMigrationVersion(backup) >=
-      AGENT_ROLE_WORKSPACE_PROVENANCE_SCHEMA_VERSION
+      maxAppliedMigrationVersion(backup) >= targetVersion
     ) {
-      throw new Error(`state backup is not a pre-v12 database: ${path}`);
+      throw new Error(`state backup is not a ${label} database: ${path}`);
     }
   } finally {
     backup.close();

--- a/runtime/src/state/startup-run-journal-recovery.ts
+++ b/runtime/src/state/startup-run-journal-recovery.ts
@@ -1,0 +1,1066 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import type {
+  RunTerminalResult,
+  RunTerminalStatus,
+  RunUsageTotals,
+} from "../contracts/run-contracts.js";
+import type { JsonObject } from "../app-server/protocol/index.js";
+import type { ToolRecoveryCategory } from "../tools/types.js";
+import { asRecord } from "../utils/record.js";
+import { updateAgentRunStatus } from "./agent-runs.js";
+import { backfillRolloutFile } from "./backfill.js";
+import { StateRunDurabilityRepository } from "./run-durability.js";
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+import { sqlPlaceholders } from "./sql.js";
+import { StateThreadRepository } from "./threads.js";
+import {
+  recordInFlightToolCallCompletion,
+  recordInFlightToolCallUnknownOutcome,
+} from "./tool-output-rotation.js";
+import { resolveUnknownOutcomeEffect } from "./unknown-outcome-gate.js";
+import { cancelAgentRunTree } from "./run-cancellation.js";
+
+const DEFAULT_MAX_STARTUP_RUNS = 4_096;
+const DEFAULT_MAX_ROLLOUT_FILES_PER_RUN = 32;
+
+const JOURNAL_EVENT_TYPES = [
+  "effect_intent",
+  "effect_result",
+  "effect_unknown_outcome",
+  "effect_review_resolved",
+  "run_cancel_requested",
+  "run_reopened",
+  "run_terminal",
+] as const;
+
+type JournalEventType = (typeof JOURNAL_EVENT_TYPES)[number];
+
+interface RecoverableRunRow {
+  readonly id: string;
+  readonly status: string;
+  readonly started_at: string;
+  readonly current_session_id: string | null;
+}
+
+interface BoundRunSeedRow {
+  readonly opened_at: string;
+  readonly session_id: string;
+}
+
+interface PendingEffectReviewRunRow {
+  readonly run_id: string;
+}
+
+interface ProjectionRow {
+  readonly thread_id: string;
+  readonly source_path: string;
+  readonly item_index: number;
+  readonly event_id: string;
+  readonly event_seq: number;
+  readonly payload_json: string;
+}
+
+interface CanonicalIdentityRow {
+  readonly thread_id: string;
+  readonly source_path: string;
+  readonly item_index: number;
+  readonly event_id: string | null;
+  readonly event_seq: number | null;
+  readonly payload_json: string;
+}
+
+interface SourceBoundsRow {
+  readonly first_sequence: number | null;
+  readonly last_sequence: number | null;
+}
+
+export interface StartupRunJournalRecoveryResult {
+  readonly runsScanned: number;
+  readonly filesScanned: number;
+  readonly eventsProjected: number;
+  readonly terminalRunsSuppressed: number;
+}
+
+export interface CanonicalRunJournalProjectionResult {
+  readonly filesScanned: number;
+  readonly eventsProjected: number;
+  readonly terminalSuppressed: boolean;
+}
+
+/** Refresh and strictly project one run for an on-demand status/replay read. */
+export function recoverCanonicalRunJournalForRun(
+  driver: StateSqliteDriver,
+  runId: string,
+  options: { readonly maxRolloutFiles?: number } = {},
+): CanonicalRunJournalProjectionResult {
+  const agentRun = driver
+    .prepareState<[string], RecoverableRunRow>(
+      `SELECT id, status, started_at, current_session_id
+       FROM agent_runs WHERE id = ? LIMIT 1`,
+    )
+    .get(runId);
+  const run = agentRun ?? recoverableBoundRun(driver, runId);
+  if (run === undefined) {
+    return { filesScanned: 0, eventsProjected: 0, terminalSuppressed: false };
+  }
+  const maxFiles = positiveBound(
+    options.maxRolloutFiles ?? DEFAULT_MAX_ROLLOUT_FILES_PER_RUN,
+    "maxRolloutFiles",
+  );
+  const threads = new StateThreadRepository(driver);
+  const paths = rolloutCandidates(driver, threads, run, maxFiles);
+  for (const rolloutPath of paths) {
+    backfillRolloutFile({ rolloutPath, threads });
+  }
+  const projected = projectRunEvents(driver, run, paths);
+  return { filesScanned: paths.length, ...projected };
+}
+
+/**
+ * Project the bounded set of review-locked runs independently of executable
+ * run status. Offline human review may append leased audit evidence after the
+ * final automatic execution event, so a terminal agent_runs row is not proof
+ * that its effect projection is current.
+ */
+export function recoverPendingEffectReviewsOnStartup(
+  driver: StateSqliteDriver,
+  options: {
+    readonly maxRuns?: number;
+    readonly maxRolloutFilesPerRun?: number;
+  } = {},
+): StartupRunJournalRecoveryResult {
+  const maxRuns = positiveBound(
+    options.maxRuns ?? DEFAULT_MAX_STARTUP_RUNS,
+    "maxRuns",
+  );
+  const maxFiles = positiveBound(
+    options.maxRolloutFilesPerRun ?? DEFAULT_MAX_ROLLOUT_FILES_PER_RUN,
+    "maxRolloutFilesPerRun",
+  );
+  const rows = driver
+    .prepareState<
+      [number],
+      PendingEffectReviewRunRow
+    >(
+      `SELECT DISTINCT effect.run_id
+       FROM run_effects AS effect
+       WHERE effect.review_status = 'pending'
+       ORDER BY effect.run_id ASC
+       LIMIT ?`,
+    )
+    .all(maxRuns + 1);
+  if (rows.length > maxRuns) {
+    throw new Error(
+      `daemon startup pending-effect review recovery exceeds the bounded run limit (${maxRuns})`,
+    );
+  }
+
+  let filesScanned = 0;
+  let eventsProjected = 0;
+  let terminalRunsSuppressed = 0;
+  for (const row of rows) {
+    const projected = recoverCanonicalRunJournalForRun(driver, row.run_id, {
+      maxRolloutFiles: maxFiles,
+    });
+    if (projected.filesScanned === 0) {
+      throw new Error(
+        `run ${row.run_id} has a pending effect review without retained canonical journal evidence`,
+      );
+    }
+    filesScanned += projected.filesScanned;
+    eventsProjected += projected.eventsProjected;
+    terminalRunsSuppressed += projected.terminalSuppressed ? 1 : 0;
+  }
+  return {
+    runsScanned: rows.length,
+    filesScanned,
+    eventsProjected,
+    terminalRunsSuppressed,
+  };
+}
+
+/**
+ * In-process child and reviewer runs own lifecycle/binding rows even though
+ * they are not daemon-managed `agent_runs`. On-demand replay must still be
+ * able to rebuild their consumer-visible projection from the canonical JSONL.
+ */
+function recoverableBoundRun(
+  driver: StateSqliteDriver,
+  runId: string,
+): RecoverableRunRow | undefined {
+  const seed = driver
+    .prepareState<[string, string], BoundRunSeedRow>(
+      `SELECT epoch.opened_at,
+              (
+                SELECT binding.session_id
+                FROM run_journal_bindings AS binding
+                WHERE binding.run_id = ?
+                ORDER BY binding.active DESC, binding.epoch DESC,
+                         binding.updated_at DESC
+                LIMIT 1
+              ) AS session_id
+       FROM run_lifecycle_epochs AS epoch
+       WHERE epoch.run_id = ?
+         AND EXISTS (
+           SELECT 1 FROM run_journal_bindings AS binding
+           WHERE binding.run_id = epoch.run_id
+         )
+       ORDER BY epoch.epoch ASC
+       LIMIT 1`,
+    )
+    .get(runId, runId);
+  if (seed === undefined) return undefined;
+  return {
+    id: runId,
+    status: "running",
+    started_at: seed.opened_at,
+    current_session_id: seed.session_id,
+  };
+}
+
+/**
+ * Rebuild M4's SQLite run/effect projection from the canonical rollout tail
+ * before daemon startup is allowed to restore a stale `agent_runs` row.
+ *
+ * The search is deliberately bounded. Normal M4 writers bind the exact
+ * rollout path before the first durable event, so directory discovery is only
+ * a compatibility fallback for rows created before the binding landed. If a
+ * fallback would exceed the bound, startup fails closed instead of silently
+ * restoring a run whose terminal evidence may be in an unscanned file.
+ */
+export function recoverCanonicalRunJournalsOnStartup(
+  driver: StateSqliteDriver,
+  options: {
+    readonly recoverableStatuses: readonly string[];
+    readonly maxRuns?: number;
+    readonly maxRolloutFilesPerRun?: number;
+    /** Restrict the bounded scan to rows whose current epoch has no result. */
+    readonly onlyMissingTerminalResults?: boolean;
+    /** Restrict compatibility recovery to runs with an explicit M4 binding. */
+    readonly requireJournalBinding?: boolean;
+  },
+): StartupRunJournalRecoveryResult {
+  if (options.recoverableStatuses.length === 0) {
+    return emptyRecoveryResult();
+  }
+  const maxRuns = positiveBound(
+    options.maxRuns ?? DEFAULT_MAX_STARTUP_RUNS,
+    "maxRuns",
+  );
+  const maxFiles = positiveBound(
+    options.maxRolloutFilesPerRun ?? DEFAULT_MAX_ROLLOUT_FILES_PER_RUN,
+    "maxRolloutFilesPerRun",
+  );
+  const runs = driver
+    .prepareState<unknown[], RecoverableRunRow>(
+      `SELECT id, status, started_at, current_session_id
+       FROM agent_runs AS runs
+       WHERE status IN (${sqlPlaceholders(options.recoverableStatuses.length)})
+       ${options.onlyMissingTerminalResults === true
+         ? `AND NOT EXISTS (
+              SELECT 1 FROM run_terminal_results AS terminal
+              WHERE terminal.run_id = runs.id
+                AND terminal.epoch = (
+                  SELECT MAX(epoch) FROM run_lifecycle_epochs
+                  WHERE run_id = runs.id
+                )
+            )`
+         : ""}
+       ${options.requireJournalBinding === true
+         ? `AND EXISTS (
+              SELECT 1 FROM run_journal_bindings AS binding
+              WHERE binding.run_id = runs.id
+            )`
+         : ""}
+       ORDER BY last_active_at ASC, id ASC
+       LIMIT ?`,
+    )
+    .all(...options.recoverableStatuses, maxRuns + 1);
+  if (runs.length > maxRuns) {
+    throw new Error(
+      `daemon startup run-journal recovery exceeds the bounded run limit (${maxRuns})`,
+    );
+  }
+
+  const threads = new StateThreadRepository(driver);
+  let filesScanned = 0;
+  let eventsProjected = 0;
+  let terminalRunsSuppressed = 0;
+  for (const run of runs) {
+    const paths = rolloutCandidates(driver, threads, run, maxFiles);
+    for (const rolloutPath of paths) {
+      backfillRolloutFile({ rolloutPath, threads });
+      filesScanned += 1;
+    }
+    const projected = projectRunEvents(driver, run, paths);
+    eventsProjected += projected.eventsProjected;
+    terminalRunsSuppressed += projected.terminalSuppressed ? 1 : 0;
+  }
+  return {
+    runsScanned: runs.length,
+    filesScanned,
+    eventsProjected,
+    terminalRunsSuppressed,
+  };
+}
+
+function rolloutCandidates(
+  driver: StateSqliteDriver,
+  threads: StateThreadRepository,
+  run: RecoverableRunRow,
+  maxFiles: number,
+): readonly string[] {
+  const repository = new StateRunDurabilityRepository(driver);
+  const known = new Set<string>();
+  const bindings = repository.listJournalBindings(run.id);
+  for (const binding of bindings) {
+    // `active = 0` also means a newer source superseded this still-canonical
+    // historical source. Skip only a fully retired range with explicit gap
+    // evidence; otherwise every retained binding remains rebuild input.
+    const fullyRetired =
+      !binding.active &&
+      binding.gapReason !== undefined &&
+      binding.retiredThroughSequence !== undefined &&
+      binding.firstAvailableSequence === undefined;
+    if (fullyRetired) continue;
+    if (existsSync(binding.sourcePath)) {
+      known.add(binding.sourcePath);
+      continue;
+    }
+    throw new Error(
+      `run ${run.id} canonical rollout source is missing: ${binding.sourcePath}`,
+    );
+  }
+  if (bindings.length > 0) {
+    if (known.size > maxFiles) {
+      throw tooManyRollouts(run.id, known.size, maxFiles);
+    }
+    return sortedByMtime(known);
+  }
+  for (const threadId of runThreadIds(run)) {
+    const indexed = threads.getThread(threadId);
+    if (indexed?.rolloutPath !== undefined && existsSync(indexed.rolloutPath)) {
+      known.add(indexed.rolloutPath);
+    }
+    if (
+      indexed?.archivedRolloutPath !== undefined &&
+      existsSync(indexed.archivedRolloutPath)
+    ) {
+      known.add(indexed.archivedRolloutPath);
+    }
+  }
+  if (known.size > maxFiles) {
+    throw tooManyRollouts(run.id, known.size, maxFiles);
+  }
+  if (known.size > 0) return sortedByMtime(known);
+
+  const discovered = new Set<string>();
+  for (const threadId of runThreadIds(run)) {
+    if (basename(threadId) !== threadId) continue;
+    for (const root of ["sessions", "archived_sessions"] as const) {
+      const directory = join(driver.projectDir, root, threadId);
+      if (!existsSync(directory)) continue;
+      for (const name of readdirSync(directory).sort()) {
+        if (!name.startsWith("rollout-") || !name.endsWith(".jsonl")) continue;
+        const path = join(directory, name);
+        if (!statSync(path).isFile()) continue;
+        discovered.add(path);
+        if (discovered.size > maxFiles) {
+          throw tooManyRollouts(run.id, discovered.size, maxFiles);
+        }
+      }
+    }
+  }
+  return sortedByMtime(discovered);
+}
+
+function projectRunEvents(
+  driver: StateSqliteDriver,
+  run: RecoverableRunRow,
+  sourcePaths: readonly string[],
+): { readonly eventsProjected: number; readonly terminalSuppressed: boolean } {
+  if (sourcePaths.length === 0) {
+    return { eventsProjected: 0, terminalSuppressed: false };
+  }
+  const identityRows = driver
+    .prepareState<unknown[], CanonicalIdentityRow>(
+      `SELECT thread_id, source_path, item_index, event_id, event_seq,
+              payload_json
+       FROM thread_rollout_items
+       WHERE source_path IN (${sqlPlaceholders(sourcePaths.length)})
+         AND item_type = 'event_msg'
+       ORDER BY event_seq ASC, source_path ASC, item_index ASC`,
+    )
+    .all(...sourcePaths);
+  validateCanonicalIdentities(identityRows, run.id);
+  const rows = identityRows.filter(
+    (row): row is ProjectionRow =>
+      row.event_id !== null &&
+      row.event_seq !== null &&
+      isJournalProjectionType(row.payload_json),
+  );
+  const relevant = deduplicateRowsForRun(rows, run.id);
+  if (relevant.length === 0) {
+    return { eventsProjected: 0, terminalSuppressed: false };
+  }
+
+  const repository = new StateRunDurabilityRepository(driver);
+  if (repository.currentEpoch(run.id) === undefined) {
+    repository.ensureInitialEpoch({
+      runId: run.id,
+      openedAt: run.started_at,
+    });
+  }
+  // Reconstruct the event-time epoch independently of whatever partial
+  // projection already exists. Starting from currentEpoch() would assign old
+  // pre-reopen effect intents to the newest epoch during an idempotent rebuild.
+  let projectionEpoch = 1;
+  let projectionOpenedAt = run.started_at;
+  let pendingCancellation:
+    | { readonly reason: string; readonly requestedAt: string }
+    | undefined;
+  for (const row of relevant) {
+    const message = journalMessage(row, run.id);
+    if (message === undefined) {
+      throw invalidEvent(row, run.id, "event envelope is invalid");
+    }
+    const type = message.type;
+    const payload = message.payload;
+    if (type === "effect_intent") {
+      bindSource(
+        driver,
+        repository,
+        run.id,
+        projectionEpoch,
+        row,
+        projectionOpenedAt,
+      );
+      projectEffectIntent(repository, run.id, projectionEpoch, row, payload);
+      continue;
+    }
+    if (type === "effect_result") {
+      projectEffectResult(driver, repository, run.id, row, payload);
+      continue;
+    }
+    if (type === "effect_unknown_outcome") {
+      projectUnknownEffect(driver, repository, run.id, row, payload);
+      continue;
+    }
+    if (type === "effect_review_resolved") {
+      projectEffectReview(driver, repository, run.id, row, payload);
+      continue;
+    }
+    if (type === "run_cancel_requested") {
+      const epoch = requirePositiveInteger(payload.epoch, "epoch");
+      if (epoch !== projectionEpoch) {
+        throw invalidEvent(
+          row,
+          run.id,
+          "run_cancel_requested epoch is out of order",
+        );
+      }
+      bindSource(
+        driver,
+        repository,
+        run.id,
+        projectionEpoch,
+        row,
+        projectionOpenedAt,
+      );
+      pendingCancellation = {
+        reason: requireString(payload.reason, "reason"),
+        requestedAt: requireString(payload.requestedAt, "requestedAt"),
+      };
+      continue;
+    }
+    if (type === "run_reopened") {
+      const previousEpoch = requirePositiveInteger(payload.previousEpoch, "previousEpoch");
+      const epoch = requirePositiveInteger(payload.epoch, "epoch");
+      if (epoch !== previousEpoch + 1 || previousEpoch !== projectionEpoch) {
+        throw invalidEvent(row, run.id, "run_reopened epoch is not contiguous");
+      }
+      const reopenedAt = requireString(payload.reopenedAt, "reopenedAt");
+      repository.reopenRun({
+        runId: run.id,
+        fromEpoch: previousEpoch,
+        openedAt: reopenedAt,
+        eventId: row.event_id,
+        reason: requireString(payload.reason, "reason"),
+      });
+      projectionEpoch = epoch;
+      projectionOpenedAt = reopenedAt;
+      pendingCancellation = undefined;
+      continue;
+    }
+    const epoch = requirePositiveInteger(payload.epoch, "epoch");
+    if (epoch !== projectionEpoch) {
+      throw invalidEvent(row, run.id, "run_terminal epoch is out of order");
+    }
+    bindSource(driver, repository, run.id, epoch, row, projectionOpenedAt);
+    repository.recordTerminalResult({
+      epoch,
+      result: terminalResult(row, run.id, payload),
+      eventId: row.event_id,
+    });
+  }
+
+  const terminal = repository.getCurrentTerminalResult(run.id);
+  if (terminal === undefined) {
+    if (pendingCancellation !== undefined) {
+      // The daemon crossed the durable cancellation-intent boundary but died
+      // before its terminal tail. Never restore that run as executable work;
+      // preserve unavailable output until a canonical terminal is recovered.
+      cancelAgentRunTree(driver, {
+        runId: run.id,
+        reason: pendingCancellation.reason,
+        cancelledAt: pendingCancellation.requestedAt,
+      });
+    }
+    return { eventsProjected: relevant.length, terminalSuppressed: false };
+  }
+  updateAgentRunStatus(driver, {
+    id: run.id,
+    status: terminal.status,
+    lastActiveAt: terminal.finishedAt,
+    ...(run.current_session_id !== null
+      ? { currentSessionId: run.current_session_id }
+      : {}),
+  });
+  return { eventsProjected: relevant.length, terminalSuppressed: true };
+}
+
+/**
+ * Validate the identity plane before selecting M4 lifecycle/effect messages.
+ * A user-facing event and a terminal/effect event share the same per-run
+ * sequence namespace, and event IDs are global within that canonical run.
+ * Filtering first would let an unrelated event hide an ambiguous terminal or
+ * reuse a durable effect identity without startup noticing.
+ */
+function validateCanonicalIdentities(
+  rows: readonly CanonicalIdentityRow[],
+  runId: string,
+): void {
+  const bySequence = new Map<
+    number,
+    { readonly eventId: string | null; readonly payloadJson: string }
+  >();
+  const byEventId = new Map<
+    string,
+    { readonly sequence: number | null; readonly payloadJson: string }
+  >();
+  for (const row of rows) {
+    if (row.event_seq !== null) {
+      if (!Number.isSafeInteger(row.event_seq) || row.event_seq <= 0) {
+        throw invalidIdentityEvent(
+          row,
+          runId,
+          `event has invalid sequence ${String(row.event_seq)}`,
+        );
+      }
+      const owner = bySequence.get(row.event_seq);
+      if (
+        owner !== undefined &&
+        (owner.eventId !== row.event_id || owner.payloadJson !== row.payload_json)
+      ) {
+        throw invalidIdentityEvent(
+          row,
+          runId,
+          `sequence is also claimed by event ${owner.eventId ?? "<missing>"}`,
+        );
+      }
+      bySequence.set(row.event_seq, {
+        eventId: row.event_id,
+        payloadJson: row.payload_json,
+      });
+    }
+    if (row.event_id === null) continue;
+    const prior = byEventId.get(row.event_id);
+    if (
+      prior !== undefined &&
+      (prior.sequence !== row.event_seq || prior.payloadJson !== row.payload_json)
+    ) {
+      throw invalidIdentityEvent(
+        row,
+        runId,
+        "event ID has conflicting content",
+      );
+    }
+    byEventId.set(row.event_id, {
+      sequence: row.event_seq,
+      payloadJson: row.payload_json,
+    });
+  }
+}
+
+function isJournalProjectionType(payloadJson: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payloadJson);
+  } catch {
+    return false;
+  }
+  const message = asRecord(asRecord(parsed)?.msg);
+  return (
+    typeof message?.type === "string" &&
+    (JOURNAL_EVENT_TYPES as readonly string[]).includes(message.type)
+  );
+}
+
+function projectEffectIntent(
+  repository: StateRunDurabilityRepository,
+  runId: string,
+  epoch: number,
+  row: ProjectionRow,
+  payload: JsonObject,
+): void {
+  const category = requireRecoveryCategory(payload.recoveryCategory);
+  const sessionId = row.thread_id;
+  const idempotencyKey = optionalString(payload.idempotencyKey);
+  repository.beginEffect({
+    runId,
+    epoch,
+    stepId: requireString(payload.stepId, "stepId"),
+    ...(sessionId !== runId ? { childRunId: sessionId } : {}),
+    sessionId,
+    callId: requireString(payload.callId, "callId"),
+    toolName: requireString(payload.toolName, "toolName"),
+    recoveryCategory: category,
+    ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
+    intentDigest: requireString(payload.intentDigest, "intentDigest"),
+    eventId: row.event_id,
+    eventSequence: row.event_seq,
+    intentAt: requireString(payload.recordedAt, "recordedAt"),
+    projection: "canonical_replay",
+  });
+}
+
+function projectEffectResult(
+  driver: StateSqliteDriver,
+  repository: StateRunDurabilityRepository,
+  runId: string,
+  row: ProjectionRow,
+  payload: JsonObject,
+): void {
+  const stepId = requireString(payload.stepId, "stepId");
+  const callId = requireString(payload.callId, "callId");
+  const toolName = requireString(payload.toolName, "toolName");
+  const category = requireRecoveryCategory(payload.recoveryCategory);
+  const recordedAt = requireString(payload.recordedAt, "recordedAt");
+  const outcome = requireEffectResultOutcome(payload.outcome);
+  const existing = repository.getEffect(runId, stepId);
+  if (
+    existing === undefined ||
+    existing.callId !== callId ||
+    existing.toolName !== toolName ||
+    existing.recoveryCategory !== category ||
+    existing.intentSequence !==
+      requirePositiveInteger(payload.intentEventSeq, "intentEventSeq") ||
+    existing.idempotencyKey !== optionalString(payload.idempotencyKey)
+  ) {
+    throw invalidEvent(row, runId, "effect_result has no matching intent");
+  }
+  repository.completeEffect({
+    runId,
+    stepId,
+    outcome,
+    eventId: row.event_id,
+    eventSequence: row.event_seq,
+    ...(optionalString(payload.resultDigest) !== undefined
+      ? { resultDigest: optionalString(payload.resultDigest) }
+      : {}),
+    ...(payload.evidence !== undefined ? { evidence: payload.evidence } : {}),
+    completedAt: recordedAt,
+  });
+  // The acknowledgement is canonical even when the older snapshot writer did
+  // not run. Make the legacy recovery row terminal before stale-call recovery
+  // can classify it for replay.
+  recordInFlightToolCallCompletion(driver, {
+    sessionId: existing.sessionId,
+    agentId: runId,
+    toolCallId: callId,
+    toolName,
+    result: null,
+    isError: outcome !== "committed",
+    completedAt: recordedAt,
+    recoveryCategory: category,
+  });
+}
+
+function projectUnknownEffect(
+  driver: StateSqliteDriver,
+  repository: StateRunDurabilityRepository,
+  runId: string,
+  row: ProjectionRow,
+  payload: JsonObject,
+): void {
+  const stepId = requireString(payload.stepId, "stepId");
+  const callId = requireString(payload.callId, "callId");
+  const toolName = requireString(payload.toolName, "toolName");
+  const category = requireRecoveryCategory(payload.recoveryCategory);
+  if (category === "idempotent") {
+    throw invalidEvent(row, runId, "idempotent effect has unknown outcome");
+  }
+  const existing = repository.getEffect(runId, stepId);
+  if (
+    existing === undefined ||
+    existing.callId !== callId ||
+    existing.toolName !== toolName ||
+    existing.recoveryCategory !== category ||
+    existing.intentSequence !==
+      requirePositiveInteger(payload.intentEventSeq, "intentEventSeq") ||
+    existing.idempotencyKey !== optionalString(payload.idempotencyKey)
+  ) {
+    throw invalidEvent(
+      row,
+      runId,
+      "effect_unknown_outcome has no matching intent",
+    );
+  }
+  const recordedAt = requireString(payload.recordedAt, "recordedAt");
+  repository.markEffectUnknown({
+    runId,
+    stepId,
+    eventId: row.event_id,
+    eventSequence: row.event_seq,
+    reason: requireString(payload.reason, "reason"),
+    evidence: { requiresReview: payload.requiresReview === true },
+    observedAt: recordedAt,
+  });
+  recordInFlightToolCallUnknownOutcome(driver, {
+    sessionId: existing.sessionId,
+    agentId: runId,
+    toolCallId: callId,
+    toolName,
+    observedAt: recordedAt,
+    recoveryCategory: category,
+  });
+}
+
+function projectEffectReview(
+  driver: StateSqliteDriver,
+  repository: StateRunDurabilityRepository,
+  runId: string,
+  row: ProjectionRow,
+  payload: JsonObject,
+): void {
+  const stepId = requireString(payload.stepId, "stepId");
+  const callId = requireString(payload.callId, "callId");
+  const existing = repository.getEffect(runId, stepId);
+  if (
+    existing === undefined ||
+    existing.callId !== callId ||
+    existing.sessionId !== row.thread_id ||
+    existing.outcome !== "unknown_outcome" ||
+    existing.resultSequence === undefined ||
+    row.event_seq <= existing.resultSequence ||
+    row.event_id !== `effect-review:${runId}:${stepId}`
+  ) {
+    throw invalidEvent(row, runId, "effect review has no matching intent");
+  }
+  driver.transactionImmediate(() => {
+    repository.resolveEffectReview({
+      runId,
+      stepId,
+      reviewedAt: requireString(payload.reviewedAt, "reviewedAt"),
+      reviewedBy: requireString(payload.reviewedBy, "reviewedBy"),
+      resolution: requireString(payload.resolution, "resolution"),
+      eventId: row.event_id,
+      evidence: {
+        callId,
+        sequence: row.event_seq,
+        source: "canonical_run_journal",
+      },
+    });
+    resolveUnknownOutcomeEffect(driver, {
+      sessionId: existing.sessionId,
+      toolCallId: callId,
+    });
+  });
+}
+
+function bindSource(
+  driver: StateSqliteDriver,
+  repository: StateRunDurabilityRepository,
+  runId: string,
+  epoch: number,
+  row: ProjectionRow,
+  boundAt: string,
+): void {
+  const bounds = driver
+    .prepareState<[string], SourceBoundsRow>(
+      `SELECT MIN(event_seq) AS first_sequence,
+              MAX(event_seq) AS last_sequence
+       FROM thread_rollout_items
+       WHERE source_path = ? AND event_seq IS NOT NULL`,
+    )
+    .get(row.source_path);
+  if (
+    bounds?.first_sequence === null ||
+    bounds?.first_sequence === undefined ||
+    bounds.last_sequence === null
+  ) {
+    return;
+  }
+  const existing = repository.getJournalBinding(row.source_path);
+  if (existing === undefined) {
+    repository.bindJournalSource({
+      runId,
+      epoch,
+      childRunId: row.thread_id,
+      sessionId: row.thread_id,
+      sourcePath: row.source_path,
+      firstAvailableSequence: bounds.first_sequence,
+      lastSequence: bounds.last_sequence,
+      boundAt,
+    });
+    return;
+  }
+  if (
+    existing.runId !== runId ||
+    existing.childRunId !== row.thread_id ||
+    existing.sessionId !== row.thread_id ||
+    existing.epoch > epoch
+  ) {
+    throw invalidEvent(
+      row,
+      runId,
+      "rollout source is bound to a different run, session, or later epoch",
+    );
+  }
+  if (
+    existing.firstAvailableSequence === undefined ||
+    existing.lastSequence === undefined ||
+    existing.firstAvailableSequence > bounds.first_sequence ||
+    existing.lastSequence < bounds.last_sequence
+  ) {
+    repository.updateJournalBounds({
+      sourcePath: row.source_path,
+      firstAvailableSequence: bounds.first_sequence,
+      lastSequence: bounds.last_sequence,
+      updatedAt: boundAt,
+    });
+  }
+}
+
+function terminalResult(
+  row: ProjectionRow,
+  runId: string,
+  payload: JsonObject,
+): RunTerminalResult {
+  return {
+    runId,
+    status: requireTerminalStatus(payload.status),
+    exitCode: nullableFiniteNumber(payload.exitCode, "exitCode"),
+    stopReason: nullableString(payload.stopReason, "stopReason"),
+    finalMessage: nullableString(payload.finalMessage, "finalMessage"),
+    usage: nullableUsage(payload.usage),
+    lastSequence: row.event_seq,
+    finishedAt: requireString(payload.finishedAt, "finishedAt"),
+  };
+}
+
+function deduplicateRowsForRun(
+  rows: readonly ProjectionRow[],
+  runId: string,
+): readonly ProjectionRow[] {
+  const seen = new Map<string, string>();
+  const seenSequences = new Map<
+    number,
+    { readonly eventId: string; readonly payloadJson: string }
+  >();
+  const result: ProjectionRow[] = [];
+  for (const row of rows) {
+    const message = journalMessage(row, runId, false);
+    if (message === undefined || message.payload.runId !== runId) continue;
+    const signature = `${row.event_seq}:${row.payload_json}`;
+    const sequenceOwner = seenSequences.get(row.event_seq);
+    if (
+      sequenceOwner !== undefined &&
+      (sequenceOwner.eventId !== row.event_id ||
+        sequenceOwner.payloadJson !== row.payload_json)
+    ) {
+      throw invalidEvent(
+        row,
+        runId,
+        `sequence is also claimed by event ${sequenceOwner.eventId}`,
+      );
+    }
+    const prior = seen.get(row.event_id);
+    if (prior !== undefined) {
+      if (prior !== signature) {
+        throw invalidEvent(row, runId, "event ID has conflicting content");
+      }
+      continue;
+    }
+    seen.set(row.event_id, signature);
+    seenSequences.set(row.event_seq, {
+      eventId: row.event_id,
+      payloadJson: row.payload_json,
+    });
+    result.push(row);
+  }
+  return result;
+}
+
+function journalMessage(
+  row: ProjectionRow,
+  runId: string,
+  required = true,
+): { readonly type: JournalEventType; readonly payload: JsonObject } | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.payload_json);
+  } catch {
+    if (!required) return undefined;
+    throw invalidEvent(row, runId, "event envelope is not JSON");
+  }
+  const envelope = asRecord(parsed);
+  const message = asRecord(envelope?.msg);
+  const payload = asRecord(message?.payload);
+  const type = message?.type;
+  if (
+    payload === null ||
+    typeof type !== "string" ||
+    !(JOURNAL_EVENT_TYPES as readonly string[]).includes(type)
+  ) {
+    if (!required) return undefined;
+    throw invalidEvent(row, runId, "event envelope is invalid");
+  }
+  return { type: type as JournalEventType, payload: payload as JsonObject };
+}
+
+function runThreadIds(run: RecoverableRunRow): readonly string[] {
+  return [
+    ...new Set(
+      [run.id, run.current_session_id]
+        .filter((value): value is string => value !== null && value.length > 0),
+    ),
+  ];
+}
+
+function sortedByMtime(paths: ReadonlySet<string>): readonly string[] {
+  return [...paths].sort((left, right) => {
+    const time = statSync(left).mtimeMs - statSync(right).mtimeMs;
+    return time === 0 ? left.localeCompare(right) : time;
+  });
+}
+
+function tooManyRollouts(runId: string, count: number, max: number): Error {
+  return new Error(
+    `run ${runId} startup recovery discovered ${count} rollout files; bounded limit is ${max}`,
+  );
+}
+
+function invalidEvent(row: ProjectionRow, runId: string, detail: string): Error {
+  return new Error(
+    `invalid canonical event ${row.event_id} at sequence ${row.event_seq} for run ${runId}: ${detail}`,
+  );
+}
+
+function invalidIdentityEvent(
+  row: CanonicalIdentityRow,
+  runId: string,
+  detail: string,
+): Error {
+  return new Error(
+    `invalid canonical event ${row.event_id ?? "<missing>"} at sequence ${row.event_seq ?? "<missing>"} for run ${runId}: ${detail}`,
+  );
+}
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function requirePositiveInteger(value: unknown, name: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value as number;
+}
+
+function positiveBound(value: number, name: string): number {
+  return requirePositiveInteger(value, name);
+}
+
+function requireRecoveryCategory(value: unknown): ToolRecoveryCategory {
+  if (
+    value !== "idempotent" &&
+    value !== "side-effecting" &&
+    value !== "interactive"
+  ) {
+    throw new TypeError("recoveryCategory is invalid");
+  }
+  return value;
+}
+
+function requireEffectResultOutcome(
+  value: unknown,
+): "committed" | "failed" | "cancelled" {
+  if (value !== "committed" && value !== "failed" && value !== "cancelled") {
+    throw new TypeError("effect result outcome is invalid");
+  }
+  return value;
+}
+
+function requireTerminalStatus(value: unknown): RunTerminalStatus {
+  if (
+    value !== "completed" &&
+    value !== "failed" &&
+    value !== "cancelled" &&
+    value !== "unknown_outcome"
+  ) {
+    throw new TypeError("run terminal status is invalid");
+  }
+  return value;
+}
+
+function nullableString(value: unknown, name: string): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") throw new TypeError(`${name} is invalid`);
+  return value;
+}
+
+function nullableFiniteNumber(value: unknown, name: string): number | null {
+  if (value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return value;
+}
+
+function nullableUsage(value: unknown): RunUsageTotals | null {
+  if (value === null) return null;
+  const usage = asRecord(value);
+  if (usage === null) throw new TypeError("usage is invalid");
+  return {
+    inputTokens: requireNonNegativeNumber(usage.inputTokens, "inputTokens"),
+    outputTokens: requireNonNegativeNumber(usage.outputTokens, "outputTokens"),
+    totalTokens: requireNonNegativeNumber(usage.totalTokens, "totalTokens"),
+    costUsd: requireNonNegativeNumber(usage.costUsd, "costUsd"),
+  };
+}
+
+function requireNonNegativeNumber(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`usage.${name} is invalid`);
+  }
+  return value;
+}
+
+function emptyRecoveryResult(): StartupRunJournalRecoveryResult {
+  return {
+    runsScanned: 0,
+    filesScanned: 0,
+    eventsProjected: 0,
+    terminalRunsSuppressed: 0,
+  };
+}

--- a/runtime/src/state/threads.ts
+++ b/runtime/src/state/threads.ts
@@ -43,6 +43,59 @@ interface ThreadRow {
 export class StateThreadRepository {
   constructor(private readonly driver: StateSqliteDriver) {}
 
+  /**
+   * Relocate every live SQLite reference when a rollout JSONL is archived or
+   * restored. The filesystem rename is owned by FileThreadStore; keeping this
+   * projection move in one immediate transaction prevents replay, retention,
+   * and terminal-epoch checks from retaining a stale source path.
+   */
+  relocateRolloutSource(sourcePath: string, targetPath: string): void {
+    if (sourcePath === targetPath) return;
+    this.driver.transactionImmediate(() => {
+      this.driver
+        .prepareState<[string, string]>(
+          "UPDATE thread_rollout_items SET source_path = ? WHERE source_path = ?",
+        )
+        .run(targetPath, sourcePath);
+      this.driver
+        .prepareState<[string, string]>(
+          "UPDATE rollout_receipts SET source_path = ? WHERE source_path = ?",
+        )
+        .run(targetPath, sourcePath);
+      this.driver
+        .prepareState<[string, string]>(
+          "UPDATE backfill_files SET source_path = ? WHERE source_path = ?",
+        )
+        .run(targetPath, sourcePath);
+      this.driver
+        .prepareState<[string, string]>(
+          "UPDATE thread_spawn_edges SET source_path = ? WHERE source_path = ?",
+        )
+        .run(targetPath, sourcePath);
+      this.driver
+        .prepareState<[string, string]>(
+          "UPDATE run_journal_bindings SET source_path = ? WHERE source_path = ?",
+        )
+        .run(targetPath, sourcePath);
+    });
+  }
+
+  /**
+   * Commit one bounded rollout projection and validate its filesystem identity
+   * at the final synchronous boundary before SQLite commits. Any failed
+   * validation rolls back both thread metadata and rollout/receipt rows.
+   */
+  commitRolloutProjection<T>(
+    apply: () => T,
+    validateCanonical: () => void,
+  ): T {
+    return this.driver.transactionImmediate(() => {
+      const result = apply();
+      validateCanonical();
+      return result;
+    });
+  }
+
   upsertThread(record: IndexedThreadRecord): void {
     this.driver
       .prepareState(

--- a/runtime/src/state/tool-output-rotation.ts
+++ b/runtime/src/state/tool-output-rotation.ts
@@ -87,6 +87,15 @@ export interface InFlightToolCallProgressParams {
   readonly outputRotation?: ToolOutputRotationPolicy;
 }
 
+export interface InFlightToolCallUnknownOutcomeParams {
+  readonly sessionId: string;
+  readonly agentId?: string;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly observedAt: string;
+  readonly recoveryCategory: Exclude<ToolRecoveryCategory, "idempotent">;
+}
+
 const DEFAULT_TOOL_OUTPUT_ROTATION_POLICY = Object.freeze({
   outputPartialMaxBytes: 32_768,
   logMaxBytes: 1_048_576,
@@ -317,6 +326,52 @@ export function recordInFlightToolCallCompletion(
       rotated.outputLogBytes,
       params.completedAt,
       normalizeToolRecoveryCategory(params.recoveryCategory),
+    );
+}
+
+/**
+ * Project a canonical effect_unknown_outcome event into the existing recovery
+ * gate. The journal event is the authority; this row is the restart/query
+ * index used to block dependent side-effecting calls until explicit review.
+ */
+export function recordInFlightToolCallUnknownOutcome(
+  driver: StateSqliteDriver,
+  params: InFlightToolCallUnknownOutcomeParams,
+): void {
+  const update = driver
+    .prepareState<[string, string, string]>(
+      `UPDATE in_flight_tool_calls
+       SET status = 'poisoned', recovery_category = ?
+       WHERE session_id = ? AND tool_call_id = ?
+         AND status <> 'unknown_resolved'`,
+    )
+    .run(
+      params.recoveryCategory,
+      params.sessionId,
+      params.toolCallId,
+    );
+  if (update.changes > 0) return;
+  driver
+    .prepareState<
+      [string, string, string, string, string, null, null, number, string, string]
+    >(
+      `INSERT OR IGNORE INTO in_flight_tool_calls (
+        session_id, tool_call_id, tool_name, args_json, status,
+        output_partial, output_log_path, output_log_bytes, started_at,
+        recovery_category
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.sessionId,
+      params.toolCallId,
+      params.toolName,
+      "null",
+      "poisoned",
+      null,
+      null,
+      0,
+      params.observedAt,
+      params.recoveryCategory,
     );
 }
 

--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -1140,7 +1140,7 @@ export class FileThreadStore implements ThreadStore {
         `${Date.now()}-${basename(entry.rolloutPath)}`,
       );
     }
-    renameSync(entry.rolloutPath, targetPath);
+    this.relocateRolloutFile(entry.rolloutPath, targetPath);
     return targetPath;
   }
 
@@ -1153,8 +1153,25 @@ export class FileThreadStore implements ThreadStore {
       entry.rolloutPath ??
       join(this.projectDir, "sessions", entry.threadId, basename(archivedPath));
     mkdirSync(dirname(restoredPath), { recursive: true });
-    renameSync(archivedPath, restoredPath);
+    this.relocateRolloutFile(archivedPath, restoredPath);
     return restoredPath;
+  }
+
+  private relocateRolloutFile(sourcePath: string, targetPath: string): void {
+    renameSync(sourcePath, targetPath);
+    try {
+      this.threadIndex.relocateRolloutSource(sourcePath, targetPath);
+    } catch (error) {
+      try {
+        renameSync(targetPath, sourcePath);
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          `rollout relocation failed and filesystem rollback could not restore ${sourcePath}`,
+        );
+      }
+      throw error;
+    }
   }
 
   private liveRecorderOrThrow(threadId: ThreadId): RolloutStore {

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -1064,7 +1064,7 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
   }
   if (method === "event.message_chunk" && typeof params.delta === "string") {
     return {
-      id: stringParam(params.eventId, "message-delta"),
+      id: daemonTranscriptEventId(params, "message-delta"),
       type: "agent_message_delta",
       payload: { delta: params.delta },
     };
@@ -1075,7 +1075,10 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
     typeof params.toolName === "string"
   ) {
     return {
-      id: stringParam(params.eventId, `tool-request:${params.requestId}`),
+      id: daemonTranscriptEventId(
+        params,
+        `tool-request:${params.requestId}`,
+      ),
       type: "tool_call_started",
       payload: {
         callId: params.requestId,
@@ -1086,7 +1089,10 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
   }
   if (method === "event.permission_request" && typeof params.requestId === "string") {
     return {
-      id: stringParam(params.eventId, `permission-request:${params.requestId}`),
+      id: daemonTranscriptEventId(
+        params,
+        `permission-request:${params.requestId}`,
+      ),
       type: "request_permissions",
       payload: {
         callId: params.requestId,
@@ -1114,7 +1120,10 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
     Array.isArray(params.questions)
   ) {
     return {
-      id: stringParam(params.eventId, `user-input-request:${params.requestId}`),
+      id: daemonTranscriptEventId(
+        params,
+        `user-input-request:${params.requestId}`,
+      ),
       type: "request_user_input",
       payload: {
         requestId: params.requestId,
@@ -1136,7 +1145,10 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
     isJsonObject(params.request)
   ) {
     return {
-      id: stringParam(params.eventId, `mcp-elicitation:${String(params.requestId)}`),
+      id: daemonTranscriptEventId(
+        params,
+        `mcp-elicitation:${String(params.requestId)}`,
+      ),
       type: "mcp_elicitation_request",
       payload: {
         requestId: params.requestId,
@@ -1150,7 +1162,15 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
     return transcriptEventFromAgentStatus(params);
   }
   if (method === "event.session_event" && isJsonObject(params.event)) {
-    return params.event;
+    return {
+      ...params.event,
+      id: daemonTranscriptEventId(
+        params,
+        typeof params.event.id === "string"
+          ? params.event.id
+          : "session-event",
+      ),
+    };
   }
   return event;
 }
@@ -1265,7 +1285,7 @@ function transcriptEventFromAgentStatus(params: JsonObject): JsonObject {
   const turnId = stringParam(params.turnId, stringParam(params.eventId, "status"));
   if (status === "error") {
     return {
-      id: stringParam(params.eventId, turnId),
+      id: daemonTranscriptEventId(params, turnId),
       type: "error",
       payload: {
         turnId,
@@ -1274,7 +1294,7 @@ function transcriptEventFromAgentStatus(params: JsonObject): JsonObject {
     };
   }
   return {
-    id: stringParam(params.eventId, turnId),
+    id: daemonTranscriptEventId(params, turnId),
     type: "background_agent_status",
     payload: {
       turnId,
@@ -1290,6 +1310,16 @@ function transcriptEventFromAgentStatus(params: JsonObject): JsonObject {
         : {}),
     },
   };
+}
+
+function daemonTranscriptEventId(
+  params: JsonObject,
+  fallback: string,
+): string {
+  const eventId = stringParam(params.eventId, fallback);
+  const agentId = params.agentId;
+  if (typeof agentId !== "string" || agentId.length === 0) return eventId;
+  return `daemon:${encodeURIComponent(agentId)}:${encodeURIComponent(eventId)}`;
 }
 
 function stringParam(value: JsonValue | undefined, fallback: string): string {

--- a/runtime/src/utils/hooks/execAgentHook.ts
+++ b/runtime/src/utils/hooks/execAgentHook.ts
@@ -2,7 +2,15 @@
 import { randomUUID } from 'crypto'
 import type { HookEvent } from 'src/entrypoints/agentSdkTypes.js'
 import { AdmissionDeniedError } from '../../budget/admission-client.js'
+import { readProviderIdentity } from '../../llm/provider.js'
+import {
+  mountChildRunJournal,
+  recordUnconstructedChildRunTerminal,
+  type ChildRunTerminalResult,
+} from '../../session/child-run-journal.js'
 import { requireCurrentRuntimeSession } from '../../session/current-session.js'
+import { TerminalRunEpochOpenError } from '../../session/rollout-store.js'
+import type { Session } from '../../session/session.js'
 import {
   createTurnCompatSession,
   structuredOutputFromToolResult,
@@ -101,6 +109,13 @@ export async function execAgentHook(
     let hookAgentIdForCleanup: ReturnType<typeof asAgentId> | undefined
     let hookSpawnAdmission: LegacyAgentSpawnAdmission | undefined
     let hookExecutionSignal = combinedSignal
+    let hookParentSession: Session | undefined
+    let hookChildSession: Session | undefined
+    let hookSpawnDispatched = false
+    let hookTerminalResult: ChildRunTerminalResult = {
+      status: 'failed',
+      stopReason: 'hook_agent_failed',
+    }
 
     try {
       // Create StructuredOutput tool with our schema
@@ -139,6 +154,7 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
       // Create unique agentId for this hook agent
       const hookAgentId = asAgentId(`hook-agent-${randomUUID()}`)
       const parentSession = requireCurrentRuntimeSession('agent hook')
+      hookParentSession = parentSession
       hookSpawnAdmission = await beginLegacyAgentSpawnAdmission({
         parent: parentSession,
         agentId: hookAgentId,
@@ -209,11 +225,17 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
             : {}),
         },
       )
+      hookChildSession = turn.session
       hookSpawnAdmission.markDispatched()
-      // The child session is now fully constructed and carries its scoped
-      // admission client. Commit the observable spawn before its first turn;
-      // failures above remain pre-dispatch/unknown according to the spawn
-      // admission state machine.
+      hookSpawnDispatched = true
+      mountChildRunJournal({
+        parent: parentSession,
+        child: turn.session,
+        originator: 'agenc-hook-agent',
+        terminalResult: () => hookTerminalResult,
+      })
+      // The child session and canonical journal now carry the scoped
+      // admission identity. Commit the observable spawn before its first turn.
       hookSpawnAdmission.commit()
       let lastAssistantLength = 0
       for await (const event of turn.session.runTurn(turn.userMessage, {
@@ -241,6 +263,10 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
           const parsed = hookResponseSchema().safeParse(output)
           if (parsed.success) {
             structuredOutputResult = parsed.data
+            hookTerminalResult = {
+              status: 'completed',
+              stopReason: 'structured_output',
+            }
             logForDebugging(
               `Hooks: Got structured output: ${jsonStringify(structuredOutputResult)}`,
             )
@@ -274,6 +300,12 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
       if (!structuredOutputResult) {
         logForDebugging(`Hooks: Agent hook did not return structured output`)
         if (hookExecutionSignal.aborted) {
+          hookTerminalResult = {
+            status: 'cancelled',
+            stopReason: String(
+              hookExecutionSignal.reason ?? 'hook_agent_cancelled',
+            ),
+          }
           return {
             hook,
             outcome: 'cancelled',
@@ -315,6 +347,12 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
       cleanupCombinedSignal()
 
       if (hookExecutionSignal.aborted) {
+        hookTerminalResult = {
+          status: 'cancelled',
+          stopReason: String(
+            hookExecutionSignal.reason ?? 'hook_agent_cancelled',
+          ),
+        }
         return {
           hook,
           outcome: 'cancelled',
@@ -325,12 +363,56 @@ When done, return your result using the ${SYNTHETIC_OUTPUT_TOOL_NAME} tool with:
       // Always remove the per-agent Stop hook, regardless of
       // success/abort/throw. Idempotent Map.delete, and only runs once the
       // hook was actually registered.
+      const cleanupErrors: unknown[] = []
       try {
         if (hookAgentIdForCleanup) {
           clearSessionHooks(toolUseContext.setAppState, hookAgentIdForCleanup)
         }
-      } finally {
+      } catch (error) {
+        cleanupErrors.push(error)
+      }
+      if (
+        hookSpawnDispatched &&
+        hookParentSession !== undefined &&
+        hookChildSession?.rolloutStore === null &&
+        hookParentSession.rolloutStore !== null
+      ) {
+        try {
+          recordUnconstructedChildRunTerminal({
+            parent: hookParentSession,
+            childRunId: hookChildSession.conversationId,
+            cwd: hookChildSession.sessionConfiguration.cwd,
+            model:
+              hookChildSession.sessionConfiguration.collaborationMode.model,
+            modelProvider:
+              readProviderIdentity(hookChildSession.services.provider) ??
+              hookChildSession.services.provider.name,
+            originator: 'agenc-hook-agent-preconstruction',
+            result: hookTerminalResult,
+          })
+        } catch (error) {
+          if (!(error instanceof TerminalRunEpochOpenError)) {
+            cleanupErrors.push(error)
+          }
+        }
+      }
+      if (hookChildSession !== undefined) {
+        try {
+          await hookChildSession.shutdown()
+        } catch (error) {
+          cleanupErrors.push(error)
+        }
+      }
+      try {
         hookSpawnAdmission?.complete()
+      } catch (error) {
+        cleanupErrors.push(error)
+      }
+      if (cleanupErrors.length === 1) {
+        throw cleanupErrors[0]
+      }
+      if (cleanupErrors.length > 1) {
+        throw new AggregateError(cleanupErrors, 'hook agent cleanup failed')
       }
     }
   } catch (error) {

--- a/runtime/src/utils/toolResultStorage.ts
+++ b/runtime/src/utils/toolResultStorage.ts
@@ -3,7 +3,8 @@
  */
 
 import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
-import { mkdir, writeFile } from 'fs/promises'
+import { createHash } from 'node:crypto'
+import { mkdir } from 'fs/promises'
 import { join } from 'path'
 import { getOriginalCwd, getSessionId } from '../bootstrap/state.js'
 import {
@@ -13,12 +14,20 @@ import {
 } from '../constants/toolLimits.js'
 import type { Message } from '../types/message.js'
 import { logForDebugging } from 'src/utils/debug.js'
-import { getErrnoCode, toError } from './errors.js'
+import { toError } from './errors.js'
 import { formatFileSize } from './format.js'
 import { logError } from './log.js'
 import { isRecord } from './record.js'
 import { getProjectDir } from './sessionStorage.js'
 import { jsonStringify } from './slowOperations.js'
+import { commitArtifactAtomically } from '../durability/atomic-artifact.js'
+import { peekAmbientRuntimeSession } from '../session/current-session.js'
+import type { Session } from '../session/session.js'
+import type {
+  ArtifactCommittedEvent,
+  ArtifactIntentEvent,
+  Event,
+} from '../session/event-log.js'
 
 // Subdirectory name for tool results within a session
 export const TOOL_RESULTS_SUBDIR = 'tool-results'
@@ -91,7 +100,32 @@ export const PREVIEW_SIZE_BYTES = 2000
  */
 export function getToolResultPath(id: string, isJson: boolean): string {
   const ext = isJson ? 'json' : 'txt'
-  return join(getToolResultsDir(), `${id}.${ext}`)
+  return join(getToolResultsDir(), `${safeToolResultPathSegment(id)}.${ext}`)
+}
+
+function safeToolResultPathSegment(value: string): string {
+  const windowsDeviceName = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i
+  if (
+    value !== '.' &&
+    value !== '..' &&
+    !windowsDeviceName.test(value) &&
+    /^[a-zA-Z0-9._-]{1,128}$/.test(value)
+  ) {
+    return value
+  }
+  const readable = value
+    .replace(/[^a-zA-Z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80)
+  const digest = createHash('sha256').update(value, 'utf8').digest('hex').slice(0, 12)
+  const prefix =
+    readable.length > 0 &&
+    readable !== '.' &&
+    readable !== '..' &&
+    !windowsDeviceName.test(readable)
+      ? readable
+      : 'tool-result'
+  return `${prefix}-${digest}`
 }
 
 /**
@@ -128,25 +162,77 @@ export async function persistToolResult(
     }
   }
 
-  await ensureToolResultsDir()
   const filepath = getToolResultPath(toolUseId, isJson)
   const contentStr = isJson ? jsonStringify(content, null, 2) : content
+  const contentBytes = Buffer.from(contentStr, 'utf8')
+  const contentSha256 = createHash('sha256').update(contentBytes).digest('hex')
+  const session = peekAmbientRuntimeSession()
+  const runId = session?.rolloutStore?.sessionId ?? session?.conversationId
+  const artifactId = createHash('sha256')
+    .update(
+      JSON.stringify({
+        version: 1,
+        runId: runId ?? null,
+        kind: 'tool_result',
+        sourceCallId: toolUseId,
+      }),
+      'utf8',
+    )
+    .digest('hex')
+  let intent: Event | undefined
 
   // tool_use_id is unique per invocation and content is deterministic for a
-  // given id, so skip if the file already exists. This prevents re-writing
-  // the same content on every API turn when microcompact replays the
-  // original messages. Use 'wx' instead of a stat-then-write race.
+  // given id. Publish via temp+fsync+exclusive-link+directory-fsync so the
+  // model never receives a path to partial bytes. Same-byte replay is an
+  // idempotent acknowledgement; conflicting bytes fail closed.
   try {
-    await writeFile(filepath, contentStr, { encoding: 'utf-8', flag: 'wx' })
+    if (session?.rolloutStore && runId !== undefined) {
+      const payload: ArtifactIntentEvent = {
+        runId,
+        artifactId,
+        kind: 'tool_result',
+        sourceCallId: toolUseId,
+        targetPath: filepath,
+        contentSha256,
+        byteLength: contentBytes.byteLength,
+        recordedAt: new Date().toISOString(),
+      }
+      intent = readOrAppendArtifactIntent(session, payload)
+      if (!Number.isSafeInteger(intent.seq) || (intent.seq ?? 0) <= 0) {
+        throw new Error('artifact intent journal sequence is missing')
+      }
+    }
+
+    await ensureToolResultsDir()
+    const outcome = await commitArtifactAtomically(filepath, contentBytes, {
+      trustedRoot: getToolResultsDir(),
+    })
+
+    if (session?.rolloutStore && runId !== undefined && intent !== undefined) {
+      const payload: ArtifactCommittedEvent = {
+        runId,
+        artifactId,
+        kind: 'tool_result',
+        sourceCallId: toolUseId,
+        targetPath: filepath,
+        contentSha256,
+        byteLength: contentBytes.byteLength,
+        recordedAt:
+          intent.msg.type === 'artifact_intent'
+            ? intent.msg.payload.recordedAt
+            : new Date().toISOString(),
+        intentEventSeq: intent.seq!,
+        outcome,
+        committedAt: new Date().toISOString(),
+      }
+      readOrAppendArtifactCommitted(session, payload)
+    }
     logForDebugging(
       `Persisted tool result to ${filepath} (${formatFileSize(contentStr.length)})`,
     )
   } catch (error) {
-    if (getErrnoCode(error) !== 'EEXIST') {
-      logError(toError(error))
-      return { error: getFileSystemErrorMessage(toError(error)) }
-    }
-    // EEXIST: already persisted on a prior turn, fall through to preview
+    logError(toError(error))
+    return { error: getFileSystemErrorMessage(toError(error)) }
   }
 
   // Generate a preview
@@ -159,6 +245,106 @@ export async function persistToolResult(
     preview,
     hasMore,
   }
+}
+
+function readArtifactEvents(session: Session): Event[] {
+  const rolloutStore = session.rolloutStore
+  if (rolloutStore === null) {
+    throw new Error('artifact journal is unavailable')
+  }
+  return rolloutStore
+    .readAll()
+    .flatMap(item => (item.type === 'event_msg' ? [item.payload] : []))
+}
+
+function readOrAppendArtifactIntent(
+  session: Session,
+  payload: ArtifactIntentEvent,
+): Event {
+  const eventId = `artifact-intent:${payload.artifactId}`
+  const candidates = readArtifactEvents(session).filter(
+    event =>
+      event.eventId === eventId ||
+      (event.msg.type === 'artifact_intent' &&
+        event.msg.payload.artifactId === payload.artifactId),
+  )
+  if (candidates.length > 1) {
+    throw artifactJournalConflict(payload.artifactId, 'duplicate intents')
+  }
+  const existing = candidates[0]
+  if (existing !== undefined) {
+    if (
+      existing.msg.type !== 'artifact_intent' ||
+      !artifactIntentMatches(existing.msg.payload, payload)
+    ) {
+      throw artifactJournalConflict(payload.artifactId, 'intent content differs')
+    }
+    // The prior append may have reached the file before its fsync failed.
+    // Re-establish durability before the matching intent authorizes artifact
+    // publication.
+    session.rolloutStore!.syncCanonicalTail()
+    return existing
+  }
+  return session.emit(
+    { eventId, id: eventId, msg: { type: 'artifact_intent', payload } },
+    { durable: true },
+  )
+}
+
+function readOrAppendArtifactCommitted(
+  session: Session,
+  payload: ArtifactCommittedEvent,
+): Event {
+  const eventId = `artifact-committed:${payload.artifactId}`
+  const candidates = readArtifactEvents(session).filter(
+    event =>
+      event.eventId === eventId ||
+      (event.msg.type === 'artifact_committed' &&
+        event.msg.payload.artifactId === payload.artifactId),
+  )
+  if (candidates.length > 1) {
+    throw artifactJournalConflict(payload.artifactId, 'duplicate commits')
+  }
+  const existing = candidates[0]
+  if (existing !== undefined) {
+    if (
+      existing.msg.type !== 'artifact_committed' ||
+      !artifactIntentMatches(existing.msg.payload, payload) ||
+      existing.msg.payload.intentEventSeq !== payload.intentEventSeq
+    ) {
+      throw artifactJournalConflict(payload.artifactId, 'commit content differs')
+    }
+    // A matching line is not itself fsync proof. The caller may be retrying
+    // after publication succeeded but acknowledgement durability failed.
+    session.rolloutStore!.syncCanonicalTail()
+    return existing
+  }
+  return session.emit(
+    { eventId, id: eventId, msg: { type: 'artifact_committed', payload } },
+    { durable: true },
+  )
+}
+
+function artifactIntentMatches(
+  left: ArtifactIntentEvent,
+  right: ArtifactIntentEvent,
+): boolean {
+  return (
+    left.runId === right.runId &&
+    left.artifactId === right.artifactId &&
+    left.kind === right.kind &&
+    left.sourceCallId === right.sourceCallId &&
+    left.targetPath === right.targetPath &&
+    left.contentSha256 === right.contentSha256 &&
+    left.byteLength === right.byteLength
+  )
+}
+
+function artifactJournalConflict(artifactId: string, reason: string): Error {
+  return Object.assign(
+    new Error(`artifact ${artifactId} has conflicting journal evidence: ${reason}`),
+    { code: 'ARTIFACT_JOURNAL_CONFLICT' as const },
+  )
 }
 
 /**

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -53,10 +54,18 @@ import {
   SandboxExecutionBroker,
   readSandboxExecutionBroker,
 } from "../sandbox/execution-broker.js";
-import { isSandboxExecutionBrokerDisposed } from "../sandbox/execution-lifecycle.js";
+import {
+  disposeSandboxExecutionBroker,
+  isSandboxExecutionBrokerDisposed,
+} from "../sandbox/execution-lifecycle.js";
 
 const ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
-import { Session, type Event, type SessionOpts, type SessionServices } from "../session/session.js";
+import {
+  Session,
+  type Event,
+  type SessionOpts,
+  type SessionServices,
+} from "../session/session.js";
 import { RolloutStore } from "../session/rollout-store.js";
 import type {
   Config,
@@ -71,6 +80,13 @@ import type {
 } from "../budget/admission-client.js";
 import { AdmissionDeniedError } from "../budget/admission-client.js";
 import type { AdmissionLease } from "../budget/admission-types.js";
+import { ExecutionAdmissionKernel } from "../budget/execution-admission-kernel.js";
+import { bindExecutionAdmissionJournal } from "../session/execution-admission-journal.js";
+import { AgenCDaemonRunInspectionService } from "../app-server/run-inspection.js";
+import {
+  openStateDatabases,
+  resolveStateDatabasePaths,
+} from "../state/sqlite-driver.js";
 import {
   SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ALLOWED_ROOTS_SIG_ARG,
@@ -137,9 +153,9 @@ function mkModelInfo(): ModelInfo {
   };
 }
 
-function mkSessionConfiguration(
-  overrides?: { readonly [K in keyof SessionConfiguration]?: SessionConfiguration[K] },
-): SessionConfiguration {
+function mkSessionConfiguration(overrides?: {
+  readonly [K in keyof SessionConfiguration]?: SessionConfiguration[K];
+}): SessionConfiguration {
   const base: SessionConfiguration = {
     cwd: "/tmp",
     approvalPolicy: { value: "never" },
@@ -178,20 +194,24 @@ function mkRegistry(): ToolRegistry {
   };
 }
 
-function makeStubSession(opts: {
-  services?: { readonly [K in keyof SessionServices]?: SessionServices[K] };
-  sessionConfiguration?: SessionConfiguration;
-  config?: Config;
-  modelInfo?: ModelInfo;
-  roleWorkspace?: SessionOpts["roleWorkspace"];
-  agentDefinitions?: SessionOpts["agentDefinitions"];
-  conversationId?: string;
-} = {}): Session {
+function makeStubSession(
+  opts: {
+    services?: { readonly [K in keyof SessionServices]?: SessionServices[K] };
+    sessionConfiguration?: SessionConfiguration;
+    config?: Config;
+    modelInfo?: ModelInfo;
+    roleWorkspace?: SessionOpts["roleWorkspace"];
+    agentDefinitions?: SessionOpts["agentDefinitions"];
+    conversationId?: string;
+  } = {},
+): Session {
   const state = {
     sessionConfiguration:
       opts.sessionConfiguration ??
       mkSessionConfiguration({
-        provider: { slug: "fake-provider" } as unknown as SessionConfiguration["provider"],
+        provider: {
+          slug: "fake-provider",
+        } as unknown as SessionConfiguration["provider"],
       }),
     history: [],
   };
@@ -744,7 +764,8 @@ describe("runAgent", () => {
         provider: {
           ...makeProvider([]),
           forkForSession: vi.fn((options) => {
-            childBroker = options.sandboxExecutionBroker as SandboxExecutionBroker;
+            childBroker =
+              options.sandboxExecutionBroker as SandboxExecutionBroker;
             return childProvider;
           }),
         },
@@ -866,12 +887,11 @@ describe("runAgent", () => {
       });
       expect(deniedMcpDispatch).toMatchObject({ isError: true });
       expect(registry.dispatch).not.toHaveBeenCalled();
-      const providerOptions = (
-        provider.chatStream as ReturnType<typeof vi.fn>
-      ).mock.calls[0]?.[2] as LLMChatOptions | undefined;
-      expect(providerOptions?.tools?.map((tool) => tool.function.name)).toEqual([
-        "system.echo",
-      ]);
+      const providerOptions = (provider.chatStream as ReturnType<typeof vi.fn>)
+        .mock.calls[0]?.[2] as LLMChatOptions | undefined;
+      expect(providerOptions?.tools?.map((tool) => tool.function.name)).toEqual(
+        ["system.echo"],
+      );
     } finally {
       shutdownSpy.mockRestore();
     }
@@ -982,9 +1002,7 @@ describe("runAgent", () => {
     expect(result.finalMessage).toBe("hello world");
     expect(result.toolCallCount).toBe(0);
 
-    expect(
-      sent.map((msg) => msg.metadata?.kind),
-    ).toEqual(["subagent_status"]);
+    expect(sent.map((msg) => msg.metadata?.kind)).toEqual(["subagent_status"]);
     const parentMessages = session.mailbox.drain();
     expect(parentMessages).toHaveLength(1);
     expect(parentMessages[0]).toMatchObject({
@@ -1032,7 +1050,9 @@ describe("runAgent", () => {
       await collectRun(
         runAgent({
           live,
-          parent: session as unknown as Parameters<typeof runAgent>[0]["parent"],
+          parent: session as unknown as Parameters<
+            typeof runAgent
+          >[0]["parent"],
           initialMessages: [{ role: "user", content: "do it" }],
           taskPrompt: "do it",
         }),
@@ -1045,7 +1065,9 @@ describe("runAgent", () => {
         StreamProgressCallback,
         LLMChatOptions,
       ];
-      expect(options.systemPrompt?.match(/CHILD_WORKSPACE_SENTINEL_92ac/g)).toHaveLength(1);
+      expect(
+        options.systemPrompt?.match(/CHILD_WORKSPACE_SENTINEL_92ac/g),
+      ).toHaveLength(1);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
@@ -1376,11 +1398,9 @@ describe("runAgent", () => {
     );
 
     expect(captured).toHaveLength(1);
-    const chatStreamCall = (
-      provider.chatStream as ReturnType<typeof vi.fn>
-    ).mock.calls[0] as
-      | [LLMMessage[], StreamProgressCallback, LLMChatOptions]
-      | undefined;
+    const chatStreamCall = (provider.chatStream as ReturnType<typeof vi.fn>)
+      .mock.calls[0] as
+      [LLMMessage[], StreamProgressCallback, LLMChatOptions] | undefined;
     expect(chatStreamCall).toBeDefined();
     const [providerMessages, , providerOptions] = chatStreamCall!;
     const params = captured[0] as {
@@ -1406,9 +1426,9 @@ describe("runAgent", () => {
     expect(params.systemContext).toEqual({ cwd: "/tmp" });
     expect(params.toolUseContext.provider.name).toBe(provider.name);
     expect(params.toolUseContext.options.mainLoopModel).toBe("fake-model");
-    expect(params.toolUseContext.options.tools.map((tool) => tool.name)).toEqual(
-      providerOptions.tools?.map((tool) => tool.function.name),
-    );
+    expect(
+      params.toolUseContext.options.tools.map((tool) => tool.name),
+    ).toEqual(providerOptions.tools?.map((tool) => tool.function.name));
     expect(params.toolUseContext.options.contextWindowTokens).toBe(
       providerOptions.contextWindowTokens,
     );
@@ -1419,9 +1439,7 @@ describe("runAgent", () => {
     expect(
       cloneFileStateCache(params.toolUseContext.readFileState as never).max,
     ).toBe(params.toolUseContext.readFileState.max);
-    expect(
-      params.forkContextMessages[0],
-    ).toEqual(
+    expect(params.forkContextMessages[0]).toEqual(
       expect.objectContaining({
         type: "user",
         message: expect.objectContaining({
@@ -1550,12 +1568,17 @@ describe("runAgent", () => {
 
     expect(result.outcome).toBe("errored");
     expect(result.error).toBeInstanceOf(Error);
-    expect((result.error as Error).message).toBe("subagent exceeded maxTurns (1)");
+    expect((result.error as Error).message).toBe(
+      "subagent exceeded maxTurns (1)",
+    );
     expect(provider.chatStream).toHaveBeenCalledTimes(1);
   });
 
   it("drains triggerTurn messages from the child downInbox into a follow-up turn", async () => {
-    const provider = makeProvider([{ content: "first turn" }, { content: "second turn" }]);
+    const provider = makeProvider([
+      { content: "first turn" },
+      { content: "second turn" },
+    ]);
     const session = makeStubSession({ services: { provider } });
     const { live } = await spawnLive(session);
 
@@ -1578,9 +1601,8 @@ describe("runAgent", () => {
     );
 
     expect(provider.chatStream).toHaveBeenCalledTimes(2);
-    const secondCall = (
-      provider.chatStream as ReturnType<typeof vi.fn>
-    ).mock.calls[1]![0] as LLMMessage[];
+    const secondCall = (provider.chatStream as ReturnType<typeof vi.fn>).mock
+      .calls[1]![0] as LLMMessage[];
     expect(secondCall.at(-1)).toEqual({
       role: "user",
       content: "follow up",
@@ -1659,7 +1681,7 @@ describe("runAgent", () => {
 
   it("admits direct child-registry dispatch with the child run/session identity", async () => {
     const admission = makeChildToolAdmission({
-      runId: "run-child-direct",
+      runId: "child-direct",
       sessionId: "child-direct",
     });
     const childSession = makeStubSession({
@@ -1669,6 +1691,22 @@ describe("runAgent", () => {
         admissionRequired: true,
       },
     });
+    const childCwd = childSession.sessionConfiguration.cwd;
+    const childRolloutStore = new RolloutStore({
+      cwd: childCwd,
+      sessionId: childSession.conversationId,
+      agencVersion: "0.2.0",
+    });
+    childRolloutStore.open({
+      sessionId: childSession.conversationId,
+      timestamp: new Date().toISOString(),
+      cwd: childCwd,
+      originator: "run-agent-direct-child-test",
+      agencVersion: "0.2.0",
+      model: childSession.modelInfo.slug,
+      modelProvider: childSession.services.provider.name,
+    });
+    childSession.mountRolloutStore(childRolloutStore);
     const childBroker = new SandboxExecutionBroker({
       mode: "danger_full_access",
       cwd: "/tmp/child-direct",
@@ -1704,33 +1742,58 @@ describe("runAgent", () => {
       },
     );
 
-    await expect(
-      registry.dispatch({
-        id: "call-direct",
-        name: "system.echo",
-        arguments: JSON.stringify({ value: "hello" }),
-      }),
-    ).resolves.toEqual({ content: "admitted" });
+    try {
+      await expect(
+        registry.dispatch({
+          id: "call-direct",
+          name: "system.echo",
+          arguments: JSON.stringify({ value: "hello" }),
+        }),
+      ).resolves.toEqual({ content: "admitted" });
 
-    expect(admission.acquire).toHaveBeenCalledWith(
-      expect.objectContaining({
-        stepId: "tool:registry:child-direct:call-direct",
-        kind: "tool_exec",
-        sessionId: "child-direct",
-        parentScopeId: "registry:child-direct",
-      }),
-      undefined,
-    );
-    expect(admission.markDispatched).toHaveBeenCalledOnce();
-    expect(admission.reconcile).toHaveBeenCalledOnce();
-    expect(execute).toHaveBeenCalledOnce();
-    const executedArgs = execute.mock.calls[0]![0] as Record<string, unknown>;
-    expect(executedArgs).toMatchObject({
-      value: "hello",
-      policyValue: "approved",
-      [SESSION_ID_ARG]: "child-direct",
-    });
-    expect(readSandboxExecutionBroker(executedArgs)).toBe(childBroker);
+      expect(admission.acquire).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepId: "tool:registry:child-direct:call-direct",
+          kind: "tool_exec",
+          sessionId: "child-direct",
+          parentScopeId: "registry:child-direct",
+        }),
+        undefined,
+      );
+      expect(admission.markDispatched).toHaveBeenCalledOnce();
+      expect(admission.reconcile).toHaveBeenCalledOnce();
+      expect(execute).toHaveBeenCalledOnce();
+      const executedArgs = execute.mock.calls[0]![0] as Record<string, unknown>;
+      expect(executedArgs).toMatchObject({
+        value: "hello",
+        policyValue: "approved",
+        [SESSION_ID_ARG]: "child-direct",
+      });
+      expect(readSandboxExecutionBroker(executedArgs)).toBe(childBroker);
+      const effectEvents = childRolloutStore
+        .readAll()
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload)
+        .filter(
+          (event) =>
+            event.msg.type === "effect_intent" ||
+            event.msg.type === "effect_result",
+        );
+      expect(effectEvents.map((event) => event.msg.type)).toEqual([
+        "effect_intent",
+        "effect_result",
+      ]);
+      expect(
+        effectEvents.map((event) =>
+          event.msg.type === "effect_intent" ||
+          event.msg.type === "effect_result"
+            ? event.msg.payload.runId
+            : null,
+        ),
+      ).toEqual(["child-direct", "child-direct"]);
+    } finally {
+      await childSession.shutdown();
+    }
   });
 
   it("does not execute a direct child-registry dispatch denied by admission", async () => {
@@ -1865,7 +1928,14 @@ describe("runAgent", () => {
       execute: vi.fn(async () => ({ content: "{}", isError: false })),
     });
     // The full set of first-class mutating file tools + the allowed Read.
-    const mutating = ["Edit", "MultiEdit", "Write", "NotebookEdit", "apply_patch", "spawn_agent"];
+    const mutating = [
+      "Edit",
+      "MultiEdit",
+      "Write",
+      "NotebookEdit",
+      "apply_patch",
+      "spawn_agent",
+    ];
     const tools = [...mutating.map(mkTool), mkTool("Read")];
     const registry = buildFilteredRegistry(
       {
@@ -1873,7 +1943,11 @@ describe("runAgent", () => {
         toLLMTools: () =>
           tools.map((t) => ({
             type: "function" as const,
-            function: { name: t.name, description: t.name, parameters: { type: "object" } },
+            function: {
+              name: t.name,
+              description: t.name,
+              parameters: { type: "object" },
+            },
           })),
         dispatch: async () => ({ content: "{}", isError: false }),
       },
@@ -1882,7 +1956,10 @@ describe("runAgent", () => {
         unadmittedDispatchOverride:
           TEST_ONLY_ALLOW_UNADMITTED_CHILD_REGISTRY_DISPATCH,
         // Mirrors run-agent's call site: the read-only role denylist folded in.
-        disabledTools: mergeRoleDisallowlist(new Set<string>(), BUILTIN_READONLY_DISALLOWLIST),
+        disabledTools: mergeRoleDisallowlist(
+          new Set<string>(),
+          BUILTIN_READONLY_DISALLOWLIST,
+        ),
       },
     );
 
@@ -1933,11 +2010,15 @@ describe("runAgent", () => {
       "spawn_agent",
       "Read",
     ]);
-    const session = makeStubSession({ services: { provider, registry: parentRegistry } });
+    const session = makeStubSession({
+      services: { provider, registry: parentRegistry },
+    });
     const { live } = await spawnLive(session, "Plan");
     expect(live.role.name).toBe("Plan");
     // The resolved role carries the read-only denylist (covers every mutating tool).
-    expect(live.role.config.disallowlist).toEqual(BUILTIN_READONLY_DISALLOWLIST);
+    expect(live.role.config.disallowlist).toEqual(
+      BUILTIN_READONLY_DISALLOWLIST,
+    );
 
     await collectRun(
       runAgent({
@@ -2313,14 +2394,16 @@ describe("runAgent", () => {
     const registry = buildFilteredRegistry(
       {
         tools: [applyPatchTool],
-        toLLMTools: () => [{
-          type: "function",
-          function: {
-            name: "apply_patch",
-            description: applyPatchTool.description,
-            parameters: applyPatchTool.inputSchema,
+        toLLMTools: () => [
+          {
+            type: "function",
+            function: {
+              name: "apply_patch",
+              description: applyPatchTool.description,
+              parameters: applyPatchTool.inputSchema,
+            },
           },
-        }],
+        ],
         dispatch: async () => ({ content: "{}" }),
       },
       {
@@ -2387,7 +2470,11 @@ describe("runAgent", () => {
       registry.dispatch({ id: "call-1", name: "spawn_agent", arguments: "{}" }),
     ).resolves.toEqual({ content: "{}" });
     await expect(
-      registry.dispatch({ id: "call-task-list", name: "TaskList", arguments: "{}" }),
+      registry.dispatch({
+        id: "call-task-list",
+        name: "TaskList",
+        arguments: "{}",
+      }),
     ).resolves.toMatchObject({
       isError: true,
       content: JSON.stringify({
@@ -2442,7 +2529,11 @@ describe("runAgent", () => {
     for (const toolName of leakedToolNames) {
       expect(advertisedNames).not.toContain(toolName);
       await expect(
-        registry.dispatch({ id: `call-${toolName}`, name: toolName, arguments: "{}" }),
+        registry.dispatch({
+          id: `call-${toolName}`,
+          name: toolName,
+          arguments: "{}",
+        }),
       ).resolves.toMatchObject({
         isError: true,
         content: JSON.stringify({
@@ -2467,7 +2558,11 @@ describe("runAgent", () => {
 
     expect(registry.tools.map((tool) => tool.name)).toEqual(["system.echo"]);
     await expect(
-      registry.dispatch({ id: "call-task-list", name: "TaskList", arguments: "{}" }),
+      registry.dispatch({
+        id: "call-task-list",
+        name: "TaskList",
+        arguments: "{}",
+      }),
     ).resolves.toMatchObject({
       isError: true,
       content: JSON.stringify({
@@ -2477,7 +2572,9 @@ describe("runAgent", () => {
   });
 
   it("does not re-advertise tools hidden by the parent registry", async () => {
-    const tools = ["system.echo", "NotebookEdit", "TaskCreate"].map(mkNamedTool);
+    const tools = ["system.echo", "NotebookEdit", "TaskCreate"].map(
+      mkNamedTool,
+    );
     const registry = buildFilteredRegistry(
       {
         tools,
@@ -2507,7 +2604,11 @@ describe("runAgent", () => {
       "system.echo",
     ]);
     await expect(
-      registry.dispatch({ id: "call-notebook", name: "NotebookEdit", arguments: "{}" }),
+      registry.dispatch({
+        id: "call-notebook",
+        name: "NotebookEdit",
+        arguments: "{}",
+      }),
     ).resolves.toMatchObject({
       isError: true,
       content: JSON.stringify({
@@ -2544,7 +2645,11 @@ describe("runAgent", () => {
       "system.searchTools",
     ]);
     await expect(
-      registry.dispatch({ id: "call-grep-before", name: "Grep", arguments: "{}" }),
+      registry.dispatch({
+        id: "call-grep-before",
+        name: "Grep",
+        arguments: "{}",
+      }),
     ).resolves.toMatchObject({
       isError: true,
       content: JSON.stringify({
@@ -2567,7 +2672,7 @@ describe("runAgent", () => {
     expect(result.content).toBe("{}");
   });
 
-  it("mounts a child rollout store when the parent owns one", async () => {
+  it("mounts one child rollout and refuses the same identity after terminal", async () => {
     const provider = makeProvider([{ content: "child wrote rollout" }]);
     const cwd = mkdtempSync(join(tmpdir(), "agenc-run-agent-"));
     const session = makeStubSession({
@@ -2618,6 +2723,81 @@ describe("runAgent", () => {
         (entry) => entry.startsWith("rollout-") && entry.endsWith(".jsonl"),
       );
       expect(rolloutFiles.length).toBeGreaterThan(0);
+      expect(
+        rolloutFiles.some((entry) =>
+          readFileSync(join(childSessionDir, entry), "utf8").includes(
+            '"type":"run_terminal"',
+          ),
+        ),
+      ).toBe(true);
+      const terminalRows = rolloutFiles.flatMap((entry) =>
+        readFileSync(join(childSessionDir, entry), "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as { type: string; payload?: Event })
+          .filter(
+            (item) =>
+              item.type === "event_msg" &&
+              item.payload?.msg.type === "run_terminal",
+          ),
+      );
+      expect(terminalRows).toHaveLength(1);
+      expect(terminalRows[0]?.payload).toMatchObject({
+        msg: {
+          payload: { runId: live.agentId, epoch: 1, status: "completed" },
+        },
+      });
+      const diagnosticState = openStateDatabases({ cwd });
+      try {
+        expect(
+          diagnosticState
+            .prepareState<[string], { readonly epoch: number }>(
+              "SELECT epoch FROM run_lifecycle_epochs WHERE run_id = ?",
+            )
+            .all(live.agentId),
+        ).toEqual([{ epoch: 1 }]);
+        expect(
+          diagnosticState
+            .prepareState<
+              [string],
+              { readonly source_path: string; readonly active: number }
+            >(
+              "SELECT source_path, active FROM run_journal_bindings WHERE run_id = ?",
+            )
+            .all(live.agentId),
+        ).toEqual([
+          expect.objectContaining({
+            source_path: expect.stringContaining(live.agentId),
+            active: 1,
+          }),
+        ]);
+      } finally {
+        diagnosticState.close();
+      }
+
+      const duplicate = await collectRun(
+        runAgent({
+          live,
+          parent: session,
+          initialMessages: [{ role: "user", content: "run again" }],
+          taskPrompt: "run again",
+        }),
+      );
+      expect(
+        readdirSync(childSessionDir).filter(
+          (entry) => entry.startsWith("rollout-") && entry.endsWith(".jsonl"),
+        ),
+      ).toEqual(rolloutFiles);
+      expect(duplicate.result).toMatchObject({
+        threadId: live.agentId,
+        outcome: "errored",
+        error: {
+          name: "TerminalRunEpochOpenError",
+          message: expect.stringContaining(
+            `refusing to open terminal run ${live.agentId} epoch 1`,
+          ),
+        },
+      });
     } finally {
       parentRolloutStore.close();
       rmSync(childSessionDir, { recursive: true, force: true });
@@ -2629,7 +2809,506 @@ describe("runAgent", () => {
     }
   });
 
-  it("suppresses parent mailbox notifications and child rollout in silent mode", async () => {
+  it("records a failed child terminal when setup stops before Session construction", async () => {
+    const previousAgencHome = process.env.AGENC_HOME;
+    const home = mkdtempSync(
+      join(tmpdir(), "agenc-child-preconstruction-home-"),
+    );
+    const cwd = mkdtempSync(
+      join(tmpdir(), "agenc-child-preconstruction-workspace-"),
+    );
+    mkdirSync(join(cwd, ".git"));
+    process.env.AGENC_HOME = home;
+    const invalidProvider = {
+      name: "missing-chat-provider",
+    } as unknown as LLMProvider;
+    const session = makeStubSession({
+      conversationId: "root-preconstruction-failure",
+      services: { provider: invalidProvider },
+      sessionConfiguration: mkSessionConfiguration({ cwd }),
+      config: { ...mkConfig(), cwd },
+    });
+    const parentRolloutStore = new RolloutStore({
+      cwd,
+      sessionId: session.conversationId,
+      agencVersion: "0.2.0",
+    });
+    parentRolloutStore.open({
+      sessionId: session.conversationId,
+      timestamp: new Date().toISOString(),
+      cwd,
+      originator: "run-agent-preconstruction-test",
+      agencVersion: "0.2.0",
+      model: session.modelInfo.slug,
+      modelProvider: invalidProvider.name,
+    });
+    session.mountRolloutStore(parentRolloutStore);
+
+    try {
+      const { live } = await spawnLive(session);
+      const { result } = await collectRun(
+        runAgent({
+          live,
+          parent: session,
+          initialMessages: [{ role: "user", content: "go" }],
+          taskPrompt: "go",
+        }),
+      );
+      expect(result).toMatchObject({
+        threadId: live.agentId,
+        outcome: "errored",
+      });
+      expect(live.rolloutPath).toBeDefined();
+
+      const inspection = new AgenCDaemonRunInspectionService({
+        stateDatabasePaths: () => [
+          resolveStateDatabasePaths({ cwd, agencHome: home }),
+        ],
+      });
+      expect(inspection.status({ runId: live.agentId })).toMatchObject({
+        runId: live.agentId,
+        status: "failed",
+        terminal: true,
+      });
+      expect(inspection.result({ runId: live.agentId })).toMatchObject({
+        runId: live.agentId,
+        status: "failed",
+        terminal: true,
+        output: {
+          available: true,
+          stopReason: "subagent has no provider on parent.services.provider",
+          finalMessage: null,
+        },
+      });
+    } finally {
+      await session.shutdown();
+      if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = previousAgencHome;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a completed child result when post-terminal provider disposal fails", async () => {
+    const previousAgencHome = process.env.AGENC_HOME;
+    const home = mkdtempSync(join(tmpdir(), "agenc-child-disposal-home-"));
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-child-disposal-workspace-"));
+    mkdirSync(join(cwd, ".git"));
+    process.env.AGENC_HOME = home;
+    const parentBroker = new SandboxExecutionBroker({
+      mode: "danger_full_access",
+      cwd,
+    });
+    const childProvider: LLMProvider = {
+      ...makeProvider([{ content: "completed before disposal" }]),
+      dispose: vi.fn(async () => {
+        throw new Error("forced child provider disposal failure");
+      }),
+    };
+    const parentProvider: LLMProvider = {
+      ...makeProvider([]),
+      forkForSession: vi.fn(() => childProvider),
+    };
+    const session = makeStubSession({
+      conversationId: "root-post-terminal-disposal",
+      services: {
+        provider: parentProvider,
+        sandboxExecutionBroker: parentBroker,
+      },
+      sessionConfiguration: mkSessionConfiguration({ cwd }),
+      config: { ...mkConfig(), cwd },
+    });
+    const parentRolloutStore = new RolloutStore({
+      cwd,
+      sessionId: session.conversationId,
+      agencVersion: "0.2.0",
+    });
+    parentRolloutStore.open({
+      sessionId: session.conversationId,
+      timestamp: new Date().toISOString(),
+      cwd,
+      originator: "run-agent-disposal-test",
+      agencVersion: "0.2.0",
+      model: session.modelInfo.slug,
+      modelProvider: parentProvider.name,
+    });
+    session.mountRolloutStore(parentRolloutStore);
+    const parentEvents: Event[] = [];
+    const unsubscribe = session.eventLog.subscribe((event) => {
+      parentEvents.push(event);
+    });
+
+    try {
+      const { live } = await spawnLive(session);
+      const { result } = await collectRun(
+        runAgent({
+          live,
+          parent: session,
+          initialMessages: [{ role: "user", content: "go" }],
+          taskPrompt: "go",
+        }),
+      );
+      expect(result).toMatchObject({
+        threadId: live.agentId,
+        outcome: "completed",
+        finalMessage: "completed before disposal",
+      });
+      expect(childProvider.dispose).toHaveBeenCalledOnce();
+      expect(parentEvents).toContainEqual(
+        expect.objectContaining({
+          msg: {
+            type: "warning",
+            payload: {
+              cause: "subagent_resource_cleanup_failed",
+              message: "forced child provider disposal failure",
+            },
+          },
+        }),
+      );
+
+      const inspection = new AgenCDaemonRunInspectionService({
+        stateDatabasePaths: () => [
+          resolveStateDatabasePaths({ cwd, agencHome: home }),
+        ],
+      });
+      expect(inspection.result({ runId: live.agentId })).toMatchObject({
+        runId: live.agentId,
+        status: "completed",
+        terminal: true,
+        output: {
+          available: true,
+          stopReason: "turn_completed",
+          finalMessage: "completed before disposal",
+        },
+      });
+    } finally {
+      unsubscribe();
+      await session.shutdown();
+      await disposeSandboxExecutionBroker(parentBroker);
+      if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = previousAgencHome;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps root spawn evidence and child model evidence in their canonical run journals", async () => {
+    const previousConfigDir = process.env.AGENC_CONFIG_DIR;
+    const previousAgencHome = process.env.AGENC_HOME;
+    const home = mkdtempSync(join(tmpdir(), "agenc-child-journal-home-"));
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-child-journal-workspace-"));
+    mkdirSync(join(cwd, ".git"));
+    process.env.AGENC_CONFIG_DIR = home;
+    process.env.AGENC_HOME = home;
+    const kernel = new ExecutionAdmissionKernel({
+      agencHome: home,
+      ownerId: "run-agent-child-journal-test",
+      ownerPid: process.pid,
+      limits: {
+        global: 4,
+        workspace: 4,
+        session: 4,
+        parent: 4,
+        provider: 4,
+      },
+    });
+    const rootAdmission = kernel.bindClient({
+      cwd,
+      scope: {
+        runId: "root-journal-run",
+        sessionId: "root-journal-run",
+        autonomous: false,
+      },
+    });
+    const provider: LLMProvider = {
+      ...makeProvider([
+        {
+          content: "child admitted model complete",
+          usage: {
+            promptTokens: 8,
+            completionTokens: 4,
+            totalTokens: 12,
+            availability: "reported",
+            provenance: "provider",
+          },
+        },
+      ]),
+      getExecutionProfile: async () => ({
+        provider: "fake",
+        model: "fake-model",
+        usageReporting: "authoritative",
+        supportsMaxOutputTokens: true,
+      }),
+    };
+    const session = makeStubSession({
+      conversationId: "root-journal-run",
+      services: {
+        provider,
+        executionAdmission: rootAdmission,
+        admissionRequired: true,
+      },
+      sessionConfiguration: mkSessionConfiguration({
+        cwd,
+        provider: {
+          slug: "fake",
+        } as unknown as SessionConfiguration["provider"],
+      }),
+      config: { ...mkConfig(), cwd },
+      modelInfo: { ...mkModelInfo(), maxOutputTokens: 32 },
+    });
+    const parentRolloutStore = new RolloutStore({
+      cwd,
+      sessionId: session.conversationId,
+      agencVersion: "0.2.0",
+    });
+    parentRolloutStore.open({
+      sessionId: session.conversationId,
+      timestamp: new Date().toISOString(),
+      cwd,
+      originator: "run-agent-root-journal-test",
+      agencVersion: "0.2.0",
+      model: session.modelInfo.slug,
+      modelProvider: provider.name,
+    });
+    session.mountRolloutStore(parentRolloutStore);
+    session.onBeforeDurableClose(
+      bindExecutionAdmissionJournal(session, rootAdmission),
+    );
+    let childRolloutPath: string | undefined;
+
+    try {
+      const { live } = await spawnLive(session);
+      const { result } = await collectRun(
+        runAgent({
+          live,
+          parent: session,
+          initialMessages: [{ role: "user", content: "go" }],
+          taskPrompt: "go",
+        }),
+      );
+      expect(result.outcome).toBe("completed");
+      childRolloutPath = live.rolloutPath;
+      expect(childRolloutPath).toBeDefined();
+
+      const rootAdmissionEvents = parentRolloutStore
+        .readAll()
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload)
+        .filter((event) => event.msg.type === "execution_admission")
+        .map((event) =>
+          event.msg.type === "execution_admission" ? event.msg.payload : null,
+        )
+        .filter((event) => event !== null);
+      const childAdmissionEvents = readFileSync(childRolloutPath!, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { type: string; payload?: Event })
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload!)
+        .filter((event) => event.msg.type === "execution_admission")
+        .map((event) =>
+          event.msg.type === "execution_admission" ? event.msg.payload : null,
+        )
+        .filter((event) => event !== null);
+
+      expect(rootAdmissionEvents.length).toBeGreaterThan(0);
+      expect(
+        rootAdmissionEvents.every(
+          (event) => event.runId === "root-journal-run",
+        ),
+      ).toBe(true);
+      expect(rootAdmissionEvents.some((event) => event.kind === "spawn")).toBe(
+        true,
+      );
+      expect(childAdmissionEvents.length).toBeGreaterThan(0);
+      expect(
+        childAdmissionEvents.every((event) => event.runId === live.agentId),
+      ).toBe(true);
+      expect(
+        childAdmissionEvents.some((event) => event.kind === "model_turn"),
+      ).toBe(true);
+      expect(
+        rootAdmissionEvents.some((event) => event.runId === live.agentId),
+      ).toBe(false);
+      expect(
+        childAdmissionEvents.some(
+          (event) => event.runId === "root-journal-run",
+        ),
+      ).toBe(false);
+
+      const diagnosticState = openStateDatabases({ cwd, agencHome: home });
+      const childBindings = diagnosticState
+        .prepareState<
+          [string],
+          { readonly run_id: string; readonly source_path: string }
+        >(
+          "SELECT run_id, source_path FROM run_journal_bindings WHERE run_id = ?",
+        )
+        .all(live.agentId);
+      diagnosticState.close();
+      expect(childBindings).toEqual([
+        { run_id: live.agentId, source_path: childRolloutPath },
+      ]);
+
+      const inspection = new AgenCDaemonRunInspectionService({
+        stateDatabasePaths: () => [
+          resolveStateDatabasePaths({ cwd, agencHome: home }),
+        ],
+      });
+      expect(inspection.status({ runId: live.agentId })).toMatchObject({
+        runId: live.agentId,
+        status: "completed",
+        terminal: true,
+      });
+      expect(inspection.result({ runId: live.agentId })).toMatchObject({
+        runId: live.agentId,
+        status: "completed",
+        terminal: true,
+        output: {
+          available: true,
+          exitCode: 0,
+          stopReason: "turn_completed",
+          finalMessage: "child admitted model complete",
+        },
+      });
+      const replay = inspection.replay({ runId: live.agentId, limit: 200 });
+      expect(replay.source).toMatchObject({
+        available: true,
+        kind: "run_journal",
+      });
+      expect(replay.events.length).toBeGreaterThan(0);
+      expect(replay.events.every((event) => event.runId === live.agentId)).toBe(
+        true,
+      );
+      expect(
+        replay.events.some(
+          (event) =>
+            event.category === "admission" &&
+            event.kind === "execution_admission" &&
+            event.stepId !== undefined,
+        ),
+      ).toBe(true);
+      expect(replay.events.at(-1)).toMatchObject({
+        runId: live.agentId,
+        category: "terminal",
+        kind: "run_terminal",
+      });
+    } finally {
+      await session.shutdown();
+      kernel.close();
+      if (previousConfigDir === undefined) delete process.env.AGENC_CONFIG_DIR;
+      else process.env.AGENC_CONFIG_DIR = previousConfigDir;
+      if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = previousAgencHome;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["failed", "failed"],
+    ["interrupted", "cancelled"],
+  ] as const)(
+    "makes a %s child run durably terminal and replayable by child id",
+    async (scenario, terminalStatus) => {
+      const previousAgencHome = process.env.AGENC_HOME;
+      const home = mkdtempSync(join(tmpdir(), `agenc-child-${scenario}-home-`));
+      const cwd = mkdtempSync(
+        join(tmpdir(), `agenc-child-${scenario}-workspace-`),
+      );
+      mkdirSync(join(cwd, ".git"));
+      process.env.AGENC_HOME = home;
+      const provider: LLMProvider =
+        scenario === "failed"
+          ? {
+              ...makeProvider([]),
+              chatStream: vi.fn().mockRejectedValue(new Error("provider_boom")),
+            }
+          : makeProvider([{ content: "should not run" }]);
+      const session = makeStubSession({
+        conversationId: `root-${scenario}-child-terminal`,
+        services: {
+          provider,
+          ...(scenario === "interrupted"
+            ? {
+                guardianRejectionCircuitBreaker: {
+                  clearTurn: vi.fn(),
+                  isOpen: vi.fn(() => true),
+                } as never,
+              }
+            : {}),
+        },
+        sessionConfiguration: mkSessionConfiguration({
+          cwd,
+          provider: {
+            slug: "fake",
+          } as unknown as SessionConfiguration["provider"],
+        }),
+        config: { ...mkConfig(), cwd },
+      });
+      const parentRolloutStore = new RolloutStore({
+        cwd,
+        sessionId: session.conversationId,
+        agencVersion: "0.2.0",
+      });
+      parentRolloutStore.open({
+        sessionId: session.conversationId,
+        timestamp: new Date().toISOString(),
+        cwd,
+        originator: `run-agent-${scenario}-terminal-test`,
+        agencVersion: "0.2.0",
+        model: session.modelInfo.slug,
+        modelProvider: provider.name,
+      });
+      session.mountRolloutStore(parentRolloutStore);
+
+      try {
+        const { live } = await spawnLive(session);
+        const { result } = await collectRun(
+          runAgent({
+            live,
+            parent: session,
+            initialMessages: [{ role: "user", content: "go" }],
+            taskPrompt: "go",
+          }),
+        );
+        expect(result.outcome).toBe(
+          scenario === "failed" ? "errored" : "interrupted",
+        );
+
+        const inspection = new AgenCDaemonRunInspectionService({
+          stateDatabasePaths: () => [
+            resolveStateDatabasePaths({ cwd, agencHome: home }),
+          ],
+        });
+        expect(inspection.status({ runId: live.agentId })).toMatchObject({
+          runId: live.agentId,
+          status: terminalStatus,
+          terminal: true,
+        });
+        expect(inspection.result({ runId: live.agentId })).toMatchObject({
+          runId: live.agentId,
+          status: terminalStatus,
+          terminal: true,
+          output: { available: true },
+        });
+        const replay = inspection.replay({ runId: live.agentId, limit: 200 });
+        expect(replay.events.at(-1)).toMatchObject({
+          runId: live.agentId,
+          category: "terminal",
+          kind: "run_terminal",
+        });
+      } finally {
+        await session.shutdown();
+        if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+        else process.env.AGENC_HOME = previousAgencHome;
+        rmSync(home, { recursive: true, force: true });
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("suppresses parent mailbox notifications but preserves the child rollout in silent mode", async () => {
     const provider = makeProvider([{ content: "silent complete" }]);
     const cwd = mkdtempSync(join(tmpdir(), "agenc-run-agent-silent-"));
     const session = makeStubSession({
@@ -2678,8 +3357,12 @@ describe("runAgent", () => {
 
       expect(result.outcome).toBe("completed");
       expect(session.mailbox.drain()).toHaveLength(0);
-      expect(live.rolloutPath).toBeUndefined();
-      expect(existsSync(childSessionDir)).toBe(false);
+      expect(live.rolloutPath).toBeDefined();
+      expect(existsSync(childSessionDir)).toBe(true);
+      expect(existsSync(live.rolloutPath!)).toBe(true);
+      expect(readFileSync(live.rolloutPath!, "utf8")).toContain(
+        '"type":"event_msg"',
+      );
     } finally {
       parentRolloutStore.close();
       rmSync(childSessionDir, { recursive: true, force: true });
@@ -2815,7 +3498,11 @@ describe("runAgent", () => {
       }
     })();
 
-    for (let attempt = 0; attempt < 20 && chatReject === undefined; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 20 && chatReject === undefined;
+      attempt += 1
+    ) {
       await new Promise((r) => setTimeout(r, 0));
     }
     expect(chatReject).toBeDefined();
@@ -2837,7 +3524,9 @@ describe("initMcpForAgent", () => {
     const session = makeStubSession();
     const ctrl = new AbortController();
     const result = await initMcpForAgent({
-      parent: session as unknown as Parameters<typeof initMcpForAgent>[0]["parent"],
+      parent: session as unknown as Parameters<
+        typeof initMcpForAgent
+      >[0]["parent"],
       signal: ctrl.signal,
       roleConfig: { requiredMcpServers: [] },
     });
@@ -2848,7 +3537,9 @@ describe("initMcpForAgent", () => {
     const session = makeStubSession();
     const ctrl = new AbortController();
     const result = await initMcpForAgent({
-      parent: session as unknown as Parameters<typeof initMcpForAgent>[0]["parent"],
+      parent: session as unknown as Parameters<
+        typeof initMcpForAgent
+      >[0]["parent"],
       signal: ctrl.signal,
     });
     expect(result.ready).toBe(true);
@@ -2867,7 +3558,9 @@ describe("initMcpForAgent", () => {
     const ctrl = new AbortController();
 
     const promise = initMcpForAgent({
-      parent: session as unknown as Parameters<typeof initMcpForAgent>[0]["parent"],
+      parent: session as unknown as Parameters<
+        typeof initMcpForAgent
+      >[0]["parent"],
       signal: ctrl.signal,
       roleConfig: { requiredMcpServers: ["fs"] },
     });
@@ -2891,7 +3584,9 @@ describe("initMcpForAgent", () => {
     const ctrl = new AbortController();
 
     const promise = initMcpForAgent({
-      parent: session as unknown as Parameters<typeof initMcpForAgent>[0]["parent"],
+      parent: session as unknown as Parameters<
+        typeof initMcpForAgent
+      >[0]["parent"],
       signal: ctrl.signal,
       roleConfig: { requiredMcpServers: ["fs", "net"] },
     });
@@ -2916,7 +3611,9 @@ describe("initMcpForAgent", () => {
     const session = makeStubSession({ services: { mcpManager } });
     const ctrl = new AbortController();
     const result = await initMcpForAgent({
-      parent: session as unknown as Parameters<typeof initMcpForAgent>[0]["parent"],
+      parent: session as unknown as Parameters<
+        typeof initMcpForAgent
+      >[0]["parent"],
       signal: ctrl.signal,
       roleConfig: { requiredMcpServers: ["fs", "net"] },
     });
@@ -2936,7 +3633,9 @@ describe("initMcpForAgent", () => {
     const ctrl = new AbortController();
 
     const promise = initMcpForAgent({
-      parent: session as unknown as Parameters<typeof initMcpForAgent>[0]["parent"],
+      parent: session as unknown as Parameters<
+        typeof initMcpForAgent
+      >[0]["parent"],
       signal: ctrl.signal,
       roleConfig: { requiredMcpServers: ["fs", "net"] },
     });

--- a/runtime/tests/agents/v2/admission-classification.test.ts
+++ b/runtime/tests/agents/v2/admission-classification.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../../src/budget/admission-client.js";
 import type { AdmissionLease } from "../../../src/budget/admission-types.js";
 import type { Session } from "../../../src/session/session.js";
+import { EventLog, type Event } from "../../../src/session/event-log.js";
 
 const COLLABORATION_CONTROL_TOOLS = [
   "spawn_agent",
@@ -86,8 +87,12 @@ describe("collaboration control admission classification", () => {
       forSession: vi.fn(),
       subscribe: vi.fn(() => () => {}),
     } satisfies ExecutionAdmissionClient;
+    const eventLog = new EventLog();
     const session = {
       conversationId: "root-session",
+      eventLog,
+      rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
+      emit: (event: Event) => eventLog.emit(event),
       services: {
         executionAdmission: admission,
         admissionRequired: true,

--- a/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
@@ -103,7 +103,7 @@ function runningStatus(turnId: string, startedAtMs: number): AgentStatus {
 }
 
 describe("AgenC background-agent runner: bounded + ordered events", () => {
-  it("evicts oldest buffered events once the per-agent cap is exceeded (FIFO, newest retained)", async () => {
+  it("announces buffered-event eviction while retaining the newest events", async () => {
     const { runner, stub } = makeTopLevelRunner({
       conversationId: "session-bounded",
     });
@@ -129,34 +129,49 @@ describe("AgenC background-agent runner: bounded + ordered events", () => {
       await new Promise((resolve) => setImmediate(resolve));
     }
 
-    const emitted: Array<{ eventId?: unknown }> = [];
+    const emitted: unknown[] = [];
     await runner.attachAgentSessionEvents("session-bounded", {
       sessionId: "session_1",
       emit: (event) => {
-        const params = (event as { params?: { eventId?: unknown } }).params;
-        emitted.push({ eventId: params?.eventId });
+        emitted.push(event);
       },
     });
 
-    // The buffer is bounded: it never grows without limit regardless of how
-    // many events were pushed pre-attach.
-    expect(emitted.length).toBeLessThanOrEqual(1_000);
-    expect(emitted.length).toBeGreaterThan(0);
+    // One observable gap sentinel is exempt from the 1,000 real-event cap.
+    expect(emitted).toHaveLength(1_001);
+    expect(emitted[0]).toMatchObject({
+      method: "event.event_gap",
+      params: {
+        type: "event_gap",
+        kind: "event_gap",
+        source: "background_runner_retention",
+        reason: "retention",
+        retiredCount: 1_502,
+        coordinatesAvailable: false,
+      },
+    });
 
     // FIFO eviction keeps the NEWEST events. The final push (turn-2499) must
     // survive; an old event well beyond the cap (turn-0) must have been
     // dropped.
-    const survivingIds = new Set(emitted.map((event) => event.eventId));
+    const survivingIds = new Set(
+      emitted.map(
+        (event) =>
+          (event as { params?: { eventId?: unknown } }).params?.eventId,
+      ),
+    );
     expect(survivingIds.has(`turn-${PUSH_COUNT - 1}`)).toBe(true);
     expect(survivingIds.has("turn-0")).toBe(false);
 
     // Surviving events remain in arrival order (oldest-kept first).
     const turnNumbers = emitted
-      .map((event) =>
-        typeof event.eventId === "string" && event.eventId.startsWith("turn-")
-          ? Number.parseInt(event.eventId.slice("turn-".length), 10)
-          : Number.NaN,
-      )
+      .map((event) => {
+        const eventId = (event as { params?: { eventId?: unknown } }).params
+          ?.eventId;
+        return typeof eventId === "string" && eventId.startsWith("turn-")
+          ? Number.parseInt(eventId.slice("turn-".length), 10)
+          : Number.NaN;
+      })
       .filter((value) => Number.isFinite(value));
     for (let i = 1; i < turnNumbers.length; i += 1) {
       expect(turnNumbers[i]!).toBeGreaterThan(turnNumbers[i - 1]!);

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -17,6 +17,7 @@ import {
   type ToolPermissionContext,
 } from "../permissions/types.js";
 import { JSON_RPC_VERSION } from "./protocol/index.js";
+import { requestApproval } from "../tools/orchestrator.js";
 
 function makeStubConversationThreadManager(opts: {
   readonly threadId: string;
@@ -24,6 +25,11 @@ function makeStubConversationThreadManager(opts: {
   readonly submit?: ReturnType<typeof vi.fn>;
   readonly shutdown?: ReturnType<typeof vi.fn>;
   readonly initialStatus?: AgentStatus;
+  readonly totalTokenUsage?: () => {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+  };
 }) {
   let listeners: ((status: AgentStatus) => void)[] = [];
   let currentStatus: AgentStatus =
@@ -50,11 +56,13 @@ function makeStubConversationThreadManager(opts: {
     submit,
     appendMessage: vi.fn(async () => opts.threadId),
     shutdown,
-    totalTokenUsage: () => ({
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-    }),
+    totalTokenUsage:
+      opts.totalTokenUsage ??
+      (() => ({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      })),
     configSnapshot: () => ({}),
   };
   return {
@@ -99,14 +107,24 @@ function makeAuthBackend(
 function makeTopLevelRunner(opts: {
   readonly conversationId: string;
   readonly bootstrapShutdown?: ReturnType<typeof vi.fn>;
+  readonly threadShutdown?: ReturnType<typeof vi.fn>;
   readonly authBackend?: AuthBackend;
   readonly env?: NodeJS.ProcessEnv;
   readonly argv?: readonly string[];
   readonly now?: () => string;
   readonly agentBudget?: AgentBudgetConfig;
   readonly executionAdmissionKernel?: ExecutionAdmissionKernel;
+  readonly rolloutItems?: unknown[];
+  readonly onActiveAgentTerminated?: ReturnType<typeof vi.fn>;
+  readonly totalTokenUsage?: () => {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+  };
 }) {
-  const shutdown = opts.bootstrapShutdown ?? vi.fn(async () => {});
+  const shutdownImpl = opts.bootstrapShutdown ?? vi.fn(async () => {});
+  const durableOperations = new Set<Promise<unknown>>();
+  const beforeDurableClose = new Set<() => void | Promise<void>>();
   const permissionUpdates: ToolPermissionContext[] = [];
   const permissionModeRegistry = {
     current: () => createEmptyToolPermissionContext(),
@@ -116,14 +134,49 @@ function makeTopLevelRunner(opts: {
   };
   const stub = makeStubConversationThreadManager({
     threadId: opts.conversationId,
+    ...(opts.threadShutdown !== undefined
+      ? { shutdown: opts.threadShutdown }
+      : {}),
+    ...(opts.totalTokenUsage !== undefined
+      ? { totalTokenUsage: opts.totalTokenUsage }
+      : {}),
   });
   const phaseSubscribers: Array<(phase: unknown) => void> = [];
   const eventLogSubscribers: Array<(event: unknown) => void> = [];
+  const rolloutItems = opts.rolloutItems ?? [];
+  let lastSeq = rolloutItems.reduce((highest, item) => {
+    const seq = (item as { payload?: { seq?: unknown } })?.payload?.seq;
+    return typeof seq === "number" && Number.isSafeInteger(seq)
+      ? Math.max(highest, seq)
+      : highest;
+  }, 0);
+  const publishSessionEvent = (event: unknown) => {
+    for (const listener of [...eventLogSubscribers]) listener(event);
+  };
+  const rolloutStore = {
+    rolloutPath: `/tmp/${opts.conversationId}.jsonl`,
+    readAll: () => [...rolloutItems],
+  };
   const session = {
     conversationId: opts.conversationId,
     permissionModeRegistry,
     abortAllTasks: vi.fn(async () => {}),
+    trackDurableOperation: <T>(operation: Promise<T>): Promise<T> => {
+      durableOperations.add(operation);
+      void operation.then(
+        () => durableOperations.delete(operation),
+        () => durableOperations.delete(operation),
+      );
+      return operation;
+    },
+    onBeforeDurableClose: (listener: () => void | Promise<void>) => {
+      beforeDurableClose.add(listener);
+      return () => beforeDurableClose.delete(listener);
+    },
     eventLog: {
+      get lastSeq() {
+        return lastSeq;
+      },
       subscribe: (listener: (event: unknown) => void) => {
         eventLogSubscribers.push(listener);
         return () => {
@@ -143,13 +196,36 @@ function makeTopLevelRunner(opts: {
       for (const listener of [...phaseSubscribers]) listener(phase);
     },
     emitSessionEvent: (event: unknown) => {
-      for (const listener of [...eventLogSubscribers]) listener(event);
+      const sequence = (event as { seq?: unknown }).seq;
+      if (typeof sequence === "number" && Number.isSafeInteger(sequence)) {
+        lastSeq = Math.max(lastSeq, sequence);
+      }
+      publishSessionEvent(event);
     },
     emit: vi.fn((event: unknown) => {
-      for (const listener of [...eventLogSubscribers]) listener(event);
+      const sequence = ++lastSeq;
+      const stamped = {
+        ...(event as object),
+        eventId:
+          (event as { eventId?: unknown }).eventId ?? `event:${sequence}`,
+        seq: sequence,
+      };
+      rolloutItems.push({ type: "event_msg", payload: stamped });
+      publishSessionEvent(stamped);
+      return stamped;
     }),
+    rolloutStore,
     services: { conversationThreadManager: stub },
   };
+  const shutdown = vi.fn(async () => {
+    await shutdownImpl();
+    while (durableOperations.size > 0) {
+      await Promise.all([...durableOperations]);
+    }
+    const finalizers = [...beforeDurableClose];
+    beforeDurableClose.clear();
+    for (const finalize of finalizers) await finalize();
+  });
   const control = {
     shutdown: vi.fn(async () => {}),
     sendInput: vi.fn(async () => {}),
@@ -159,6 +235,7 @@ function makeTopLevelRunner(opts: {
   };
   const bootstrap = vi.fn(async () => ({
     session,
+    rolloutStore,
     registry: {
       tools: [],
       toLLMTools: () => [],
@@ -182,6 +259,9 @@ function makeTopLevelRunner(opts: {
       ? { executionAdmissionKernel: opts.executionAdmissionKernel }
       : {}),
     now: opts.now ?? (() => "2026-05-09T00:00:00.000Z"),
+    ...(opts.onActiveAgentTerminated !== undefined
+      ? { onActiveAgentTerminated: opts.onActiveAgentTerminated }
+      : {}),
   });
   return {
     runner,
@@ -192,10 +272,859 @@ function makeTopLevelRunner(opts: {
     bootstrap,
     permissionUpdates,
     permissionModeRegistry,
+    rolloutItems,
   };
 }
 
 describe("AgenC delegate background-agent runner", () => {
+  it("carries the canonical rollout sequence into daemon notifications", () => {
+    const daemonEvent = daemonEventFromUnboundSessionEvent({
+      eventId: "journal-progress-sequenced",
+      id: "progress-sequenced",
+      seq: 42,
+      msg: {
+        type: "tool_progress",
+        payload: {
+          callId: "tool-sequenced",
+          toolName: "Bash",
+          chunk: "ready",
+        },
+      },
+    });
+
+    expect(daemonEvent).toMatchObject({
+      id: "progress-sequenced",
+      eventId: "journal-progress-sequenced",
+      sequence: 42,
+    });
+    expect(
+      notificationFromDaemonEvent("session-1", "agent-1", daemonEvent!),
+    ).toMatchObject({
+      params: {
+        eventId: "journal-progress-sequenced",
+        sequence: 42,
+        event: { id: "progress-sequenced" },
+      },
+    });
+  });
+
+  it("derives collision-free legacy eventIds without changing reused envelope ids", () => {
+    const first = daemonEventFromUnboundSessionEvent({
+      id: "reused-tool-progress-sub-id",
+      seq: 8,
+      msg: {
+        type: "tool_progress",
+        payload: { callId: "call-1", toolName: "Bash", chunk: "one" },
+      },
+    });
+    const second = daemonEventFromUnboundSessionEvent({
+      id: "reused-tool-progress-sub-id",
+      seq: 9,
+      msg: {
+        type: "tool_progress",
+        payload: { callId: "call-1", toolName: "Bash", chunk: "two" },
+      },
+    });
+
+    expect(first).toMatchObject({
+      id: "reused-tool-progress-sub-id",
+      eventId: "legacy-event:8:reused-tool-progress-sub-id",
+      sequence: 8,
+    });
+    expect(second).toMatchObject({
+      id: "reused-tool-progress-sub-id",
+      eventId: "legacy-event:9:reused-tool-progress-sub-id",
+      sequence: 9,
+    });
+  });
+
+  it.each([
+    ["agent_message_delta", { delta: "hello" }],
+    [
+      "tool_call_started",
+      { callId: "call-1", toolName: "Read", args: "{}" },
+    ],
+    [
+      "tool_call_completed",
+      { callId: "call-1", result: "ok", isError: false },
+    ],
+    ["turn_started", { turnId: "turn-1", startedAt: 1 }],
+    [
+      "turn_complete",
+      {
+        turnId: "turn-1",
+        lastAgentMessage: "done",
+        completedAt: 2,
+        durationMs: 1,
+      },
+    ],
+    ["turn_aborted", { turnId: "turn-1", reason: "cancelled" }],
+    ["error", { cause: "test", message: "failed" }],
+    ["effect_intent", { runId: "run-1", stepId: "step-1" }],
+    [
+      "execution_admission",
+      { runId: "run-1", stepId: "step-1", event: "allowed" },
+    ],
+    ["artifact_committed", { runId: "run-1", artifactId: "artifact-1" }],
+    ["recovery_decision", { runId: "run-1", decision: "projection_rebuilt" }],
+    ["run_terminal", { runId: "run-1", epoch: 1, status: "completed" }],
+  ] as const)(
+    "uses canonical identity for core %s notifications",
+    (type, payload) => {
+      const daemonEvent = daemonEventFromUnboundSessionEvent({
+        eventId: `journal-${type}`,
+        id: `canonical-${type}`,
+        seq: 17,
+        msg: { type, payload },
+      });
+      expect(daemonEvent).toMatchObject({
+        id: `canonical-${type}`,
+        eventId: `journal-${type}`,
+        sequence: 17,
+        type,
+      });
+      expect(
+        notificationFromDaemonEvent("session-1", "agent-1", daemonEvent!),
+      ).toMatchObject({
+        params: {
+          eventId: `journal-${type}`,
+          sequence: 17,
+        },
+      });
+      expect(
+        daemonEventFromUnboundSessionEvent({
+          id: `unsequenced-${type}`,
+          msg: { type, payload },
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it("uses PhaseEvents only for bookkeeping when the canonical bridge is installed", async () => {
+    const { runner, session } = makeTopLevelRunner({
+      conversationId: "session-canonical-core",
+    });
+    const emitted: unknown[] = [];
+    await runner.startAgent({
+      objective: "verify canonical delivery",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-canonical-core", {
+      sessionId: "session-1",
+      emit: (event) => {
+        emitted.push(event);
+      },
+    });
+    emitted.length = 0;
+
+    session.emitPhaseEvent({ type: "assistant_text", content: "hello" });
+    session.emitPhaseEvent({
+      type: "tool_call",
+      toolCall: { id: "call-1", name: "Read", arguments: "{}" },
+    });
+    session.emitPhaseEvent({
+      type: "turn_complete",
+      content: "hello",
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      stopReason: "completed",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(emitted).toEqual([]);
+
+    session.emit({
+      eventId: "journal-delta",
+      id: "canonical-delta",
+      msg: { type: "agent_message_delta", payload: { delta: "hello" } },
+    });
+    session.emit({
+      eventId: "journal-tool",
+      id: "canonical-tool",
+      msg: {
+        type: "tool_call_started",
+        payload: { callId: "call-1", toolName: "Read", args: "{}" },
+      },
+    });
+    session.emit({
+      eventId: "journal-turn",
+      id: "canonical-turn",
+      msg: {
+        type: "turn_complete",
+        payload: {
+          turnId: "turn-1",
+          lastAgentMessage: "hello",
+          completedAt: 2,
+          durationMs: 1,
+        },
+      },
+    });
+    await vi.waitFor(() => expect(emitted).toHaveLength(3));
+    expect(
+      emitted.map(
+        (event) =>
+          (event as { params?: { eventId?: unknown } }).params?.eventId,
+      ),
+    ).toEqual(["journal-delta", "journal-tool", "journal-turn"]);
+    for (const event of emitted) {
+      expect(
+        (event as { params?: { sequence?: unknown } }).params?.sequence,
+      ).toEqual(expect.any(Number));
+    }
+  });
+
+  it("drains the canonical turn tail before shutdown and terminal teardown", async () => {
+    let releaseTurnDelivery!: () => void;
+    const turnDeliveryBlocked = new Promise<void>((resolve) => {
+      releaseTurnDelivery = resolve;
+    });
+    let markTurnDeliveryStarted!: () => void;
+    const turnDeliveryStarted = new Promise<void>((resolve) => {
+      markTurnDeliveryStarted = resolve;
+    });
+    const bootstrapShutdown = vi.fn(async () => {});
+    const onActiveAgentTerminated = vi.fn(async () => {});
+    const { runner, session, stub } = makeTopLevelRunner({
+      conversationId: "session-terminal-delivery-order",
+      bootstrapShutdown,
+      onActiveAgentTerminated,
+    });
+    const emitted: unknown[] = [];
+    await runner.startAgent({
+      objective: "preserve the canonical tail",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-terminal-delivery-order", {
+      sessionId: "session-1",
+      emit: async (event) => {
+        const eventId = (event as { params?: { eventId?: unknown } }).params
+          ?.eventId;
+        if (eventId === "turn-complete-before-shutdown") {
+          markTurnDeliveryStarted();
+          await turnDeliveryBlocked;
+        }
+        emitted.push(event);
+      },
+    });
+    emitted.length = 0;
+
+    session.emit({
+      eventId: "turn-complete-before-shutdown",
+      id: "turn-complete-before-shutdown",
+      msg: {
+        type: "turn_complete",
+        payload: {
+          turnId: "turn-terminal-delivery-order",
+          lastAgentMessage: "done",
+          completedAt: 2,
+          durationMs: 1,
+        },
+      },
+    });
+    await turnDeliveryStarted;
+    stub.pushStatus({
+      status: "completed",
+      turnId: "turn-terminal-delivery-order",
+      endedAtMs: 2,
+      lastMessage: "done",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(bootstrapShutdown).not.toHaveBeenCalled();
+    expect(onActiveAgentTerminated).not.toHaveBeenCalled();
+
+    releaseTurnDelivery();
+    await vi.waitFor(() =>
+      expect(onActiveAgentTerminated).toHaveBeenCalledTimes(1),
+    );
+    expect(
+      emitted.map(
+        (event) =>
+          (event as { params?: { eventId?: unknown } }).params?.eventId,
+      ),
+    ).toEqual([
+      "turn-complete-before-shutdown",
+      "run-terminal:session-terminal-delivery-order:1",
+    ]);
+    expect(bootstrapShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("fsync-journals daemon permission requests and decisions before execution resumes", async () => {
+    const { runner, session, rolloutItems } = makeTopLevelRunner({
+      conversationId: "session-durable-permission",
+    });
+    const emitted: unknown[] = [];
+    await runner.startAgent({
+      objective: "record approval evidence",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-durable-permission", {
+      sessionId: "client-session",
+      emit: (event) => {
+        emitted.push(event);
+      },
+    });
+    emitted.length = 0;
+
+    const resolver = (
+      session.services as {
+        approvalResolver?: {
+          request(context: unknown): Promise<{ readonly kind: string }>;
+        };
+      }
+    ).approvalResolver;
+    expect(resolver).toBeDefined();
+    const pending = requestApproval({
+      ctx: {
+        invocation: {
+          session,
+          turn: { subId: "turn-permission-1" },
+          tracker: {
+            appendFileDiff() {},
+            snapshot: () => [],
+            clear() {},
+          },
+          callId: "permission-call-1",
+          toolName: { name: "Read" },
+          payload: {
+            kind: "function",
+            arguments: '{"path":"README.md"}',
+          },
+          source: "direct",
+        } as never,
+        callId: "permission-call-1",
+        toolName: "Read",
+        turnId: "turn-permission-1",
+      },
+      resolver: resolver as never,
+    });
+
+    await vi.waitFor(() =>
+      expect(emitted).toContainEqual(
+        expect.objectContaining({
+          method: "event.permission_request",
+          params: expect.objectContaining({
+            requestId: "permission-call-1",
+            eventId: expect.any(String),
+            sequence: expect.any(Number),
+          }),
+        }),
+      ),
+    );
+    expect(
+      await runner.resolveToolDecision("session-durable-permission", {
+        requestId: "permission-call-1",
+        decision: { kind: "approved" },
+      }),
+    ).toBe(true);
+    await expect(pending).resolves.toMatchObject({
+      decision: { kind: "approved" },
+      source: "resolver",
+    });
+
+    const journalEvents = rolloutItems
+      .filter(
+        (item): item is {
+          readonly type: "event_msg";
+          readonly payload: {
+            readonly eventId: string;
+            readonly seq: number;
+            readonly msg: {
+              readonly type: string;
+              readonly payload: Record<string, unknown>;
+            };
+          };
+        } => (item as { readonly type?: unknown }).type === "event_msg",
+      )
+      .map((item) => item.payload);
+    const request = journalEvents.find(
+      (event) => event.msg.type === "request_permissions",
+    );
+    const decision = journalEvents.find(
+      (event) => event.msg.type === "permission_decision",
+    );
+    expect(request).toMatchObject({
+      eventId: expect.any(String),
+      seq: expect.any(Number),
+      msg: {
+        payload: {
+          callId: "permission-call-1",
+          toolName: "Read",
+          turnId: "turn-permission-1",
+          permissions: ["tool.use"],
+          input: { path: "README.md" },
+        },
+      },
+    });
+    expect(decision).toMatchObject({
+      eventId: expect.any(String),
+      seq: (request?.seq ?? 0) + 1,
+      msg: {
+        payload: {
+          runId: "session-durable-permission",
+          callId: "permission-call-1",
+          requestEventId: request?.eventId,
+          requestEventSeq: request?.seq,
+          decision: "approved",
+        },
+      },
+    });
+  });
+
+  it("aborts and journals a pending permission before stop seals the terminal tail", async () => {
+    let releaseShutdown!: () => void;
+    const shutdownStarted = new Promise<void>((resolve) => {
+      releaseShutdown = resolve;
+    });
+    const { runner, session, rolloutItems } = makeTopLevelRunner({
+      conversationId: "session-stop-pending-permission",
+      bootstrapShutdown: vi.fn(() => shutdownStarted),
+    });
+    await runner.startAgent({
+      objective: "wait for permission",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    const resolver = (
+      session.services as {
+        approvalResolver?: {
+          request(context: unknown): Promise<{ readonly kind: string }>;
+        };
+      }
+    ).approvalResolver;
+    expect(resolver).toBeDefined();
+    const pending = requestApproval({
+      ctx: {
+        invocation: {
+          session,
+          turn: { subId: "turn-stop-permission" },
+          tracker: {
+            appendFileDiff() {},
+            snapshot: () => [],
+            clear() {},
+          },
+          callId: "permission-stop-call",
+          toolName: { name: "Bash" },
+          payload: { kind: "function", arguments: '{"cmd":"true"}' },
+          source: "direct",
+        } as never,
+        callId: "permission-stop-call",
+        toolName: "Bash",
+        turnId: "turn-stop-permission",
+      },
+      resolver: resolver as never,
+    });
+    await vi.waitFor(() =>
+      expect(
+        rolloutItems.some(
+          (item) =>
+            (item as { payload?: { msg?: { type?: unknown } } }).payload?.msg
+              ?.type === "request_permissions",
+        ),
+      ).toBe(true),
+    );
+
+    const stopping = runner.stopAgent(
+      "session-stop-pending-permission",
+      "user_stopped",
+    );
+    await expect(pending).resolves.toMatchObject({
+      decision: { kind: "abort" },
+      source: "resolver",
+    });
+    await expect(
+      runner.submitAgentMessage("session-stop-pending-permission", {
+        sessionId: "session-stop-pending-permission",
+        content: "too late",
+        originalContent: "too late",
+        displayUserMessage: null,
+        messageId: "message-too-late",
+        streamId: "stream-too-late",
+        acceptedAt: "2026-05-09T00:00:01.000Z",
+      }),
+    ).rejects.toThrow("not running");
+    expect(
+      await runner.resolveToolDecision("session-stop-pending-permission", {
+        requestId: "permission-stop-call",
+        decision: { kind: "approved" },
+      }),
+    ).toBe(false);
+    releaseShutdown();
+    await stopping;
+
+    const canonical = rolloutItems
+      .filter(
+        (item): item is {
+          readonly payload: {
+            readonly seq: number;
+            readonly msg: {
+              readonly type: string;
+              readonly payload: Record<string, unknown>;
+            };
+          };
+        } => (item as { type?: unknown }).type === "event_msg",
+      )
+      .map((item) => item.payload);
+    const requestIndex = canonical.findIndex(
+      (event) => event.msg.type === "request_permissions",
+    );
+    const decisionIndex = canonical.findIndex(
+      (event) => event.msg.type === "permission_decision",
+    );
+    const terminalIndex = canonical.findIndex(
+      (event) => event.msg.type === "run_terminal",
+    );
+    expect(requestIndex).toBeGreaterThanOrEqual(0);
+    expect(decisionIndex).toBeGreaterThan(requestIndex);
+    expect(terminalIndex).toBeGreaterThan(decisionIndex);
+    expect(terminalIndex).toBe(canonical.length - 1);
+    expect(canonical[decisionIndex]?.msg.payload).toMatchObject({
+      callId: "permission-stop-call",
+      decision: "abort",
+    });
+    expect(canonical[terminalIndex]?.msg.payload).toMatchObject({
+      stopReason: "user_stopped",
+    });
+  });
+
+  it("canonicalizes cancellation and admission decisions before the terminal tail", async () => {
+    const { runner, session, rolloutItems } = makeTopLevelRunner({
+      conversationId: "session-two-phase-cancel",
+    });
+    const cancelAdmissions = vi.fn((reason: string) => {
+      session.emit({
+        eventId: "admission-cancelled-before-terminal",
+        id: "admission-cancelled-before-terminal",
+        msg: {
+          type: "execution_admission",
+          payload: {
+            sequence: 7,
+            eventId: "admission-cancelled-before-terminal",
+            timestamp: "2026-05-09T00:00:00.000Z",
+            runId: "session-two-phase-cancel",
+            stepId: "model-turn-1",
+            kind: "model_turn",
+            event: "cancelled",
+            reason,
+          },
+        },
+      });
+      return {
+        affectedRunIds: ["session-two-phase-cancel"],
+        voidedReservations: 1,
+        heldUnknownReservations: 0,
+      };
+    });
+    (
+      session.services as typeof session.services & {
+        executionAdmission?: { cancelAdmissions: typeof cancelAdmissions };
+      }
+    ).executionAdmission = { cancelAdmissions };
+
+    await runner.startAgent({
+      objective: "cancel safely",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    const prepared = await runner.prepareAgentCancellation(
+      "session-two-phase-cancel",
+      "operator",
+    );
+    expect(prepared).toMatchObject({
+      affectedRunIds: ["session-two-phase-cancel"],
+      voidedHolds: 1,
+    });
+    await expect(
+      runner.submitAgentMessage("session-two-phase-cancel", {
+        sessionId: "session-two-phase-cancel",
+        content: "late input",
+        originalContent: "late input",
+        messageId: "late-message",
+        streamId: "late-stream",
+        acceptedAt: "2026-05-09T00:00:01.000Z",
+      }),
+    ).rejects.toThrow("not running");
+
+    await runner.stopAgent("session-two-phase-cancel", "operator");
+
+    const canonical = rolloutItems
+      .filter(
+        (item): item is {
+          readonly payload: {
+            readonly seq: number;
+            readonly msg: { readonly type: string };
+          };
+        } => (item as { type?: unknown }).type === "event_msg",
+      )
+      .map((item) => item.payload);
+    const requestIndex = canonical.findIndex(
+      (event) => event.msg.type === "run_cancel_requested",
+    );
+    const admissionIndex = canonical.findIndex(
+      (event) => event.msg.type === "execution_admission",
+    );
+    const terminalIndex = canonical.findIndex(
+      (event) => event.msg.type === "run_terminal",
+    );
+    expect(requestIndex).toBeGreaterThanOrEqual(0);
+    expect(admissionIndex).toBeGreaterThan(requestIndex);
+    expect(terminalIndex).toBeGreaterThan(admissionIndex);
+    expect(terminalIndex).toBe(canonical.length - 1);
+    expect(cancelAdmissions).toHaveBeenCalledOnce();
+  });
+
+  it("aborts and journals a pending permission before a budget terminal", async () => {
+    let totalTokens = 0;
+    const { runner, session, rolloutItems } = makeTopLevelRunner({
+      conversationId: "session-budget-pending-permission",
+      agentBudget: { token_cap: 1 },
+      totalTokenUsage: () => ({
+        inputTokens: totalTokens,
+        outputTokens: 0,
+        totalTokens,
+      }),
+    });
+    await runner.startAgent({
+      objective: "wait under budget",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    const resolver = (
+      session.services as {
+        approvalResolver?: {
+          request(context: unknown): Promise<{ readonly kind: string }>;
+        };
+      }
+    ).approvalResolver;
+    const pending = requestApproval({
+      ctx: {
+        invocation: {
+          session,
+          turn: { subId: "turn-budget-permission" },
+          tracker: {
+            appendFileDiff() {},
+            snapshot: () => [],
+            clear() {},
+          },
+          callId: "permission-budget-call",
+          toolName: { name: "Bash" },
+          payload: { kind: "function", arguments: '{"cmd":"true"}' },
+          source: "direct",
+        } as never,
+        callId: "permission-budget-call",
+        toolName: "Bash",
+        turnId: "turn-budget-permission",
+      },
+      resolver: resolver as never,
+    });
+    await vi.waitFor(() =>
+      expect(
+        rolloutItems.some(
+          (item) =>
+            (item as { payload?: { msg?: { type?: unknown } } }).payload?.msg
+              ?.type === "request_permissions",
+        ),
+      ).toBe(true),
+    );
+
+    totalTokens = 2;
+    session.emitPhaseEvent({ type: "assistant_text", content: "budget tick" });
+    await expect(pending).resolves.toMatchObject({
+      decision: { kind: "abort" },
+    });
+    await vi.waitFor(() =>
+      expect(
+        rolloutItems.some(
+          (item) =>
+            (item as { payload?: { msg?: { type?: unknown } } }).payload?.msg
+              ?.type === "run_terminal",
+        ),
+      ).toBe(true),
+    );
+
+    const canonical = rolloutItems
+      .filter(
+        (item): item is {
+          readonly payload: {
+            readonly msg: {
+              readonly type: string;
+              readonly payload: Record<string, unknown>;
+            };
+          };
+        } => (item as { type?: unknown }).type === "event_msg",
+      )
+      .map((item) => item.payload);
+    const relevant = canonical.filter((event) =>
+      ["request_permissions", "permission_decision", "run_terminal"].includes(
+        event.msg.type,
+      ),
+    );
+    expect(relevant.map((event) => event.msg.type)).toEqual([
+      "request_permissions",
+      "permission_decision",
+      "run_terminal",
+    ]);
+    expect(relevant[1]?.msg.payload).toMatchObject({
+      callId: "permission-budget-call",
+      decision: "abort",
+    });
+    expect(relevant[2]?.msg.payload).toMatchObject({
+      stopReason: "budget_limit",
+    });
+    expect(canonical.at(-1)?.msg.type).toBe("run_terminal");
+  });
+
+  it("commits an epoch-aware terminal at the quiesced shutdown boundary and publishes it canonically", async () => {
+    const threadShutdown = vi.fn(async () => {});
+    const onActiveAgentTerminated = vi.fn(async () => {});
+    const rolloutItems = [
+      {
+        type: "event_msg",
+        payload: {
+          id: "reopen-2",
+          seq: 7,
+          msg: {
+            type: "run_reopened",
+            payload: {
+              runId: "session-stop-epoch-2",
+              previousEpoch: 1,
+              epoch: 2,
+              reason: "review",
+              reopenedAt: "2026-05-08T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    ];
+    const { runner, session, shutdown } = makeTopLevelRunner({
+      conversationId: "session-stop-epoch-2",
+      threadShutdown,
+      rolloutItems,
+      onActiveAgentTerminated,
+    });
+    const emitted: unknown[] = [];
+    await runner.startAgent({
+      objective: "stop durably",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-stop-epoch-2", {
+      sessionId: "session-1",
+      emit: (event) => {
+        emitted.push(event);
+      },
+    });
+    emitted.length = 0;
+
+    await runner.stopAgent("session-stop-epoch-2", "user_stopped");
+
+    const terminalCallIndex = session.emit.mock.calls.findIndex(
+      ([event]) =>
+        (event as { msg?: { type?: unknown } }).msg?.type === "run_terminal",
+    );
+    expect(terminalCallIndex).toBeGreaterThanOrEqual(0);
+    expect(session.emit.mock.calls[terminalCallIndex]![0]).toMatchObject({
+      id: "run-terminal:session-stop-epoch-2:2",
+      msg: {
+        type: "run_terminal",
+        payload: {
+          epoch: 2,
+          status: "cancelled",
+          stopReason: "user_stopped",
+        },
+      },
+    });
+    expect(
+      session.emit.mock.invocationCallOrder[terminalCallIndex]!,
+    ).toBeGreaterThan(shutdown.mock.invocationCallOrder[0]!);
+    expect(threadShutdown).not.toHaveBeenCalled();
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        method: "event.agent_status",
+        params: expect.objectContaining({
+          eventId: "run-terminal:session-stop-epoch-2:2",
+          sequence: expect.any(Number),
+          status: "stopped",
+          runStatus: "stopped",
+        }),
+      }),
+    );
+    expect(onActiveAgentTerminated).toHaveBeenCalledWith(
+      "session-stop-epoch-2",
+      expect.objectContaining({
+        terminal: expect.objectContaining({
+          epoch: 2,
+          eventId: "run-terminal:session-stop-epoch-2:2",
+        }),
+      }),
+    );
+  });
+
+  it("does not advertise a canonical terminal status when its durable append fails", async () => {
+    const onActiveAgentTerminated = vi.fn(async () => {});
+    const { runner, session } = makeTopLevelRunner({
+      conversationId: "session-terminal-append-failure",
+      onActiveAgentTerminated,
+    });
+    await runner.startAgent({
+      objective: "fail terminal commit",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    session.emit.mockImplementationOnce(() => {
+      throw new Error("terminal write failed");
+    });
+
+    await expect(
+      runner.stopAgent("session-terminal-append-failure", "user_stopped"),
+    ).rejects.toThrow("terminal write failed");
+    expect(onActiveAgentTerminated).not.toHaveBeenCalled();
+  });
+
+  it("announces sequenced pre-attach eviction with valid cursor coordinates", async () => {
+    const { runner, session } = makeTopLevelRunner({
+      conversationId: "session-buffer-gap",
+    });
+    await runner.startAgent({
+      objective: "fill detached buffer",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    for (let index = 0; index < 1_005; index += 1) {
+      session.emit({
+        id: `delta-${index}`,
+        msg: {
+          type: "agent_message_delta",
+          payload: { delta: String(index) },
+        },
+      });
+    }
+    for (let index = 0; index < 5; index += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    const emitted: unknown[] = [];
+    await runner.attachAgentSessionEvents("session-buffer-gap", {
+      sessionId: "session-1",
+      emit: (event) => {
+        emitted.push(event);
+      },
+    });
+    expect(emitted).toHaveLength(1_001);
+    expect(emitted[0]).toMatchObject({
+      method: "event.event_gap",
+      params: {
+        type: "event_gap",
+        runId: "session-buffer-gap",
+        retiredCount: 6,
+        coordinatesAvailable: true,
+        afterSequence: 0,
+        firstAvailableSequence: 7,
+      },
+    });
+  });
+
   it("preserves the trusted Ledger clientAction through the session-event bridge", () => {
     const clientAction = {
       type: "ledger_solana_transfer_v1",
@@ -250,6 +1179,7 @@ describe("AgenC delegate background-agent runner", () => {
       }),
     ).toEqual({
       id: "spawn-begin",
+      eventId: "spawn-begin",
       type: "collab_agent_spawn_begin",
       payload: {
         callId: "call-agent",
@@ -277,6 +1207,7 @@ describe("AgenC delegate background-agent runner", () => {
       }),
     ).toEqual({
       id: "spawn-end",
+      eventId: "spawn-end",
       type: "collab_agent_spawn_end",
       payload: {
         callId: "call-agent",
@@ -305,6 +1236,7 @@ describe("AgenC delegate background-agent runner", () => {
       }),
     ).toEqual({
       id: "agent-status",
+      eventId: "agent-status",
       type: "collab_agent_status",
       payload: {
         callId: "call-agent",
@@ -332,6 +1264,7 @@ describe("AgenC delegate background-agent runner", () => {
       }),
     ).toEqual({
       id: "progress-1",
+      eventId: "progress-1",
       type: "tool_progress",
       payload: {
         callId: "tool-1",
@@ -824,7 +1757,7 @@ describe("AgenC delegate background-agent runner", () => {
         params: {
           sessionId: "session_1",
           agentId: "session-user-order",
-          eventId: "message_1",
+          eventId: "event:2",
           acceptedAt: "2026-05-01T12:00:01.000Z",
           event: {
             id: "message_1",
@@ -905,7 +1838,7 @@ describe("AgenC delegate background-agent runner", () => {
         params: {
           sessionId: "session_1",
           agentId: "session-user-durable",
-          eventId: "message_2",
+          eventId: "event:2",
           event: {
             id: "message_2",
             type: "user_message",
@@ -1044,7 +1977,7 @@ describe("AgenC delegate background-agent runner", () => {
     );
   });
 
-  it("[managed-thread] reports max-turn terminal phases as errored status", async () => {
+  it("[managed-thread] reports canonical max-turn errors with replay identity", async () => {
     const { runner, session } = makeTopLevelRunner({
       conversationId: "session-max-turns",
     });
@@ -1068,6 +2001,17 @@ describe("AgenC delegate background-agent runner", () => {
       usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
       stopReason: "max_turns",
     });
+    session.emit({
+      eventId: "max-turn-error",
+      id: "max-turn-error",
+      msg: {
+        type: "error",
+        payload: {
+          cause: "max_turns",
+          message: "Agent exceeded maxTurns",
+        },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(emitted).toContainEqual(
@@ -1077,14 +2021,16 @@ describe("AgenC delegate background-agent runner", () => {
             status: "error",
             runStatus: "errored",
             message: "Agent exceeded maxTurns",
+            eventId: "max-turn-error",
+            sequence: expect.any(Number),
           }),
         }),
       );
     });
   });
 
-  it("[managed-thread] reports interrupted thread status as idle reusable status", async () => {
-    const { runner, stub } = makeTopLevelRunner({
+  it("[managed-thread] keeps interrupted status internal and publishes canonical abort", async () => {
+    const { runner, stub, session } = makeTopLevelRunner({
       conversationId: "session-interrupted-status",
     });
     const emitted: unknown[] = [];
@@ -1108,6 +2054,14 @@ describe("AgenC delegate background-agent runner", () => {
       endedAtMs: 123,
       reason: "user_cancel",
     } as AgentStatus);
+    session.emit({
+      eventId: "turn-interrupted",
+      id: "turn-interrupted",
+      msg: {
+        type: "turn_aborted",
+        payload: { turnId: "turn-interrupted", reason: "user_cancel" },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(emitted).toContainEqual(
@@ -1118,6 +2072,8 @@ describe("AgenC delegate background-agent runner", () => {
             runStatus: "completed",
             turnId: "turn-interrupted",
             message: "user_cancel",
+            eventId: "turn-interrupted",
+            sequence: expect.any(Number),
           }),
         }),
       );
@@ -1152,6 +2108,14 @@ describe("AgenC delegate background-agent runner", () => {
       usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
       stopReason: "cancelled",
     });
+    session.emit({
+      eventId: "turn-cancelled",
+      id: "turn-cancelled",
+      msg: {
+        type: "turn_aborted",
+        payload: { turnId: "turn-cancelled", reason: "cancelled" },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(emitted).toContainEqual(
@@ -1161,6 +2125,8 @@ describe("AgenC delegate background-agent runner", () => {
             status: "idle",
             runStatus: "completed",
             message: "cancelled",
+            eventId: "turn-cancelled",
+            sequence: expect.any(Number),
           }),
         }),
       );
@@ -1218,6 +2184,27 @@ describe("AgenC delegate background-agent runner", () => {
       usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
       stopReason: "cancelled",
     });
+    session.emit({
+      eventId: "tool-call-1-interrupted",
+      id: "tool-call-1-interrupted",
+      msg: {
+        type: "tool_call_completed",
+        payload: {
+          callId: "call_1",
+          result: "cancelled",
+          isError: true,
+          metadata: { cause: "user_interrupted" },
+        },
+      },
+    });
+    session.emit({
+      eventId: "turn-tool-interrupted",
+      id: "turn-tool-interrupted",
+      msg: {
+        type: "turn_aborted",
+        payload: { turnId: "turn-tool-interrupted", reason: "cancelled" },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(emitted).toContainEqual(
@@ -1273,6 +2260,19 @@ describe("AgenC delegate background-agent runner", () => {
       usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
       stopReason: "completed",
     });
+    session.emit({
+      eventId: "turn-completed",
+      id: "turn-completed",
+      msg: {
+        type: "turn_complete",
+        payload: {
+          turnId: "turn-completed",
+          lastAgentMessage: "done",
+          completedAt: Date.now(),
+          durationMs: 1,
+        },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(emitted).toContainEqual(
@@ -1282,6 +2282,8 @@ describe("AgenC delegate background-agent runner", () => {
             status: "idle",
             runStatus: "completed",
             message: "done",
+            eventId: "turn-completed",
+            sequence: expect.any(Number),
           }),
         }),
       );
@@ -1356,8 +2358,8 @@ describe("AgenC delegate background-agent runner", () => {
     expect(control.interrupt).toHaveBeenCalledWith("child-agent", "user_cancel");
   });
 
-  it("[managed-thread] stopAgent shuts down the managed thread", async () => {
-    const { runner, stub, control } = makeTopLevelRunner({
+  it("[managed-thread] stopAgent uses bootstrap lifecycle shutdown", async () => {
+    const { runner, stub, control, shutdown } = makeTopLevelRunner({
       conversationId: "session-stop",
     });
 
@@ -1369,7 +2371,8 @@ describe("AgenC delegate background-agent runner", () => {
 
     await runner.stopAgent("session-stop", "user_stopped");
 
-    expect(stub.thread.shutdown).toHaveBeenCalledWith("user_stopped");
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(stub.thread.shutdown).not.toHaveBeenCalled();
     expect(control.shutdown).not.toHaveBeenCalled();
   });
 });

--- a/runtime/tests/app-server/client-multiplexer.byte-budget.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.byte-budget.test.ts
@@ -84,10 +84,12 @@ describe("client multiplexer buffered byte budget", () => {
     // ANNOUNCED by a leading event_gap marker (M4), never silent.
     expect(replayed.length).toBeGreaterThan(1);
     expect(replayed.length).toBeLessThan(10);
-    const marker = replayed[0] as { type: string; retiredCount: number };
-    expect(marker.type).toBe("event_gap");
+    const marker = replayed[0] as {
+      params: { type: string; retiredCount: number };
+    };
+    expect(marker.params.type).toBe("event_gap");
     const survivors = replayed.slice(1);
-    expect(marker.retiredCount).toBe(50 - survivors.length);
+    expect(marker.params.retiredCount).toBe(50 - survivors.length);
 
     // The survivors are the most recent events (oldest evicted from the head).
     const lastReplayed = survivors[survivors.length - 1] as {
@@ -97,16 +99,16 @@ describe("client multiplexer buffered byte budget", () => {
     const firstReplayed = survivors[0] as { sequence: number };
     expect(firstReplayed.sequence).toBeGreaterThan(40);
 
-    // Total replayed bytes stay within ~one event of the budget (plus the
-    // small gap marker).
+    // The marker is part of the hard cap; replay never exceeds the configured
+    // byte budget.
     const replayedBytes = replayed.reduce(
       (sum, event) => sum + Buffer.byteLength(JSON.stringify(event)),
       0,
     );
-    expect(replayedBytes).toBeLessThanOrEqual(4 * 1100 + 1100 + 200);
+    expect(replayedBytes).toBeLessThanOrEqual(4 * 1100);
   });
 
-  it("always retains at least the most recent event even when it alone exceeds the budget", async () => {
+  it("rejects a detached event that alone exceeds the hard byte budget", async () => {
     const { sessionManager, multiplexer } = createHarness(1024);
     await sessionManager.createSession({
       agentId: "agent_1",
@@ -114,7 +116,12 @@ describe("client multiplexer buffered byte budget", () => {
     });
 
     // A single payload far larger than the whole budget.
-    await multiplexer.broadcastSessionEvent("session_1", bigEvent(1, 100_000));
+    await expect(
+      multiplexer.broadcastSessionEvent(
+        "session_1",
+        bigEvent(1, 100_000),
+      ),
+    ).rejects.toMatchObject({ code: "EVENT_BUFFER_LIMIT_EXCEEDED" });
 
     const replayed: JsonObject[] = [];
     await multiplexer.registerClient({
@@ -125,7 +132,6 @@ describe("client multiplexer buffered byte budget", () => {
     });
     await multiplexer.attachClientToSession("session_1", "client_1");
 
-    expect(replayed).toHaveLength(1);
-    expect((replayed[0] as { sequence: number }).sequence).toBe(1);
+    expect(replayed).toHaveLength(0);
   });
 });

--- a/runtime/tests/app-server/client-multiplexer.contract.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.contract.test.ts
@@ -178,6 +178,49 @@ describe("AgenC daemon client multiplexer", () => {
     expect(phone).toEqual([event]);
   });
 
+  it("rejects aggregate capability and status replay before registering a half-client", async () => {
+    const sessionManager = new AgenCDaemonSessionManager({
+      createSessionId: sequence(["session_1"]),
+      createAttachmentId: sequence(["attachment_1"]),
+      now: sequence([
+        "2026-05-01T10:00:00.000Z",
+        "2026-05-01T10:00:01.000Z",
+      ]),
+    });
+    const multiplexer = new AgenCDaemonClientMultiplexer({
+      sessionManager,
+      maxPendingDeliveryCountPerClient: 1,
+    });
+    await createSession(sessionManager);
+    const ledger = ledgerActionNotification("session_1", "intent-aggregate");
+    const status = agentStatusNotification("session_1", "status-aggregate");
+    await multiplexer.broadcastSessionEvent("session_1", ledger);
+    await multiplexer.broadcastSessionEvent("session_1", status);
+
+    await expect(
+      multiplexer.registerClient({
+        clientId: "aggregate-phone",
+        capabilities: {
+          "portal.ledger.solana.sign.v1": true,
+          [AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY]: true,
+        },
+        send: () => {},
+      }),
+    ).rejects.toMatchObject({ code: "EVENT_DELIVERY_LIMIT_EXCEEDED" });
+
+    // The failed aggregate reservation did not register the id or lease/drain
+    // the Ledger buffer. Retrying the same id for one bounded capability works.
+    const replayed: JsonObject[] = [];
+    await expect(
+      multiplexer.registerClient({
+        clientId: "aggregate-phone",
+        capabilities: { "portal.ledger.solana.sign.v1": true },
+        send: (message) => replayed.push(message),
+      }),
+    ).resolves.toEqual({ clientId: "aggregate-phone" });
+    expect(replayed).toEqual([ledger]);
+  });
+
   it("leases a buffered Ledger replay to only one concurrently initializing phone", async () => {
     const { sessionManager, multiplexer } = createHarness();
     const firstPhone: JsonObject[] = [];

--- a/runtime/tests/app-server/client-multiplexer.event-gap.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.event-gap.test.ts
@@ -57,7 +57,12 @@ function bigEvent(sequenceNumber: number, payloadBytes: number): JsonObject {
 }
 
 function isGapMarker(event: JsonObject): boolean {
-  return event.type === EVENT_GAP_EVENT && event.reason === "retention";
+  const params = event.params as JsonObject | undefined;
+  return (
+    event.method === "event.event_gap" &&
+    params?.type === EVENT_GAP_EVENT &&
+    params.reason === "retention"
+  );
 }
 
 async function attachAndCollect(
@@ -88,16 +93,24 @@ describe("client multiplexer event-gap markers", () => {
       await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
     }
     const replayed = await attachAndCollect(multiplexer, "client_1");
-    // One marker + the 5 newest real events, in order.
-    expect(replayed).toHaveLength(6);
+    // The marker itself counts toward the hard five-event cap.
+    expect(replayed).toHaveLength(5);
     expect(isGapMarker(replayed[0]!)).toBe(true);
     expect(replayed[0]).toMatchObject({
-      sessionId: "session_1",
-      retiredCount: 7,
+      jsonrpc: "2.0",
+      method: "event.event_gap",
+      params: {
+        sessionId: "session_1",
+        retiredCount: 8,
+        kind: "event_gap",
+        runId: "session_1",
+        afterSequence: 0,
+        firstAvailableSequence: 9,
+      },
     });
     expect(
       replayed.slice(1).map((event) => (event as { sequence: number }).sequence),
-    ).toEqual([8, 9, 10, 11, 12]);
+    ).toEqual([9, 10, 11, 12]);
     // Exactly one marker in the whole stream.
     expect(replayed.filter(isGapMarker)).toHaveLength(1);
   });
@@ -122,12 +135,12 @@ describe("client multiplexer event-gap markers", () => {
     expect(survivors.length).toBeGreaterThan(0);
     // Newest events survive; retiredCount accounts for every dropped event.
     expect(survivors[survivors.length - 1]!.sequence).toBe(50);
-    expect((replayed[0] as { retiredCount: number }).retiredCount).toBe(
+    expect((replayed[0]!.params as JsonObject).retiredCount).toBe(
       50 - survivors.length,
     );
   });
 
-  it("keeps the newest real event even when it alone exceeds the byte budget", async () => {
+  it("rejects a detached event that alone exceeds the hard byte budget", async () => {
     const { sessionManager, multiplexer } = createHarness({
       maxBufferedBytesPerSession: 1024,
     });
@@ -135,14 +148,11 @@ describe("client multiplexer event-gap markers", () => {
       agentId: "agent_1",
       cwd: await workspaces.create(),
     });
-    await multiplexer.broadcastSessionEvent("session_1", bigEvent(1, 5000));
-    await multiplexer.broadcastSessionEvent("session_1", bigEvent(2, 100_000));
+    await expect(
+      multiplexer.broadcastSessionEvent("session_1", bigEvent(1, 5000)),
+    ).rejects.toMatchObject({ code: "EVENT_BUFFER_LIMIT_EXCEEDED" });
     const replayed = await attachAndCollect(multiplexer, "client_1");
-    // Event 1 was evicted (announced); oversized event 2 is retained.
-    expect(replayed).toHaveLength(2);
-    expect(isGapMarker(replayed[0]!)).toBe(true);
-    expect(replayed[0]).toMatchObject({ retiredCount: 1 });
-    expect((replayed[1] as { sequence: number }).sequence).toBe(2);
+    expect(replayed).toHaveLength(0);
   });
 
   it("produces no marker when nothing was evicted", async () => {
@@ -173,19 +183,21 @@ describe("client multiplexer event-gap markers", () => {
       await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
     }
     const first = await attachAndCollect(multiplexer, "client_1");
-    expect(first[0]).toMatchObject({ retiredCount: 3 });
+    expect(first).toHaveLength(2);
+    expect(first[0]).toMatchObject({ params: { retiredCount: 4 } });
     await multiplexer.disconnectClient("client_1");
-    // New detached window: 3 more events, 1 evicted — the fresh marker must
+    // New detached window: marker + one survivor fit the hard two-event cap.
+    // The fresh marker must
     // count ONLY the new loss (the old one was delivered and acknowledged).
     for (let index = 6; index <= 8; index += 1) {
       await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
     }
     const second = await attachAndCollect(multiplexer, "client_2");
-    expect(second).toHaveLength(3);
-    expect(second[0]).toMatchObject({ retiredCount: 1 });
+    expect(second).toHaveLength(2);
+    expect(second[0]).toMatchObject({ params: { retiredCount: 2 } });
     expect(
       second.slice(1).map((event) => (event as { sequence: number }).sequence),
-    ).toEqual([7, 8]);
+    ).toEqual([8]);
   });
 
   it("announces loss even when eviction races an in-flight replay (identity splice)", async () => {
@@ -228,19 +240,19 @@ describe("client multiplexer event-gap markers", () => {
       await multiplexer.broadcastSessionEvent("session_1", smallEvent(index));
     }
     // Release A's replay: it fully acks, triggering the buffer cleanup
-    // while the buffer now holds [marker, e5, e6, e7].
+    // while the hard three-event buffer now holds [marker, e6, e7].
     releaseSends();
     await attachInFlight;
     expect(deliveredToA).toHaveLength(3);
     // The next client must still see the announced loss and every
     // never-delivered event.
     const replayed = await attachAndCollect(multiplexer, "client_b");
-    expect(replayed).toHaveLength(4);
+    expect(replayed).toHaveLength(3);
     expect(isGapMarker(replayed[0]!)).toBe(true);
-    expect(replayed[0]).toMatchObject({ retiredCount: 4 });
+    expect(replayed[0]).toMatchObject({ params: { retiredCount: 5 } });
     expect(
       replayed.slice(1).map((event) => (event as { sequence: number }).sequence),
-    ).toEqual([5, 6, 7]);
+    ).toEqual([6, 7]);
   });
 
   it("retains the marker for the next client after a failed (unacked) replay", async () => {
@@ -265,10 +277,10 @@ describe("client multiplexer event-gap markers", () => {
     // The buffer (marker included) was NOT spliced: the next client still
     // sees the announced loss.
     const replayed = await attachAndCollect(multiplexer, "client_2");
-    expect(replayed).toHaveLength(3);
-    expect(replayed[0]).toMatchObject({ retiredCount: 2 });
+    expect(replayed).toHaveLength(2);
+    expect(replayed[0]).toMatchObject({ params: { retiredCount: 3 } });
     expect(
       replayed.slice(1).map((event) => (event as { sequence: number }).sequence),
-    ).toEqual([3, 4]);
+    ).toEqual([4]);
   });
 });

--- a/runtime/tests/app-server/client-multiplexer.slow-consumer-eviction.test.ts
+++ b/runtime/tests/app-server/client-multiplexer.slow-consumer-eviction.test.ts
@@ -166,27 +166,10 @@ describe("client multiplexer slow-consumer eviction", () => {
     void broadcasts;
   });
 
-  it("never evicts or drops events for a HEALTHY client replaying a buffer larger than the LIVE pending cap", async () => {
-    // Correctness guard for the replay path: a freshly-attaching client replays
-    // the WHOLE detached buffer in one synchronous batch inside the state lock,
-    // and the per-delivery decrement microtasks cannot run during that
-    // synchronous map. The fix makes replay BYPASS the live-broadcast eviction
-    // cap (allowEvict=false) precisely so that synchronous accumulation can
-    // never falsely evict a healthy client mid-replay or let the post-replay
-    // splice drop an un-delivered boundary event.
-    //
-    // REVERT-SENSITIVITY: this only catches the cap-on-replay bug when the LIVE
-    // pending cap is STRICTLY SMALLER than the detached-buffer cap. The detached
-    // buffer trims itself to within its own cap before any replay, so when both
-    // caps share one value the replay's running partial sums can never cross it
-    // (the whole buffer already fits) — that coupling is exactly why the old
-    // version of this test was a false guard. Here the detached buffer keeps a
-    // multi-event run (~12 KB) that is far larger than the small live pending
-    // cap (2 KB / 3 events). If replay enqueued with allowEvict=true (the v1
-    // bug) the running pending backlog crosses the small live cap mid-replay and
-    // the healthy client is wrongly evicted and its boundary events dropped.
-    // With the shipped fix (allowEvict=false) the live cap is bypassed on replay
-    // and every buffered event is delivered.
+  it("rejects a retained replay batch larger than the client pending cap before attaching", async () => {
+    // A retained buffer may use a larger budget than one client's socket
+    // backlog. The aggregate replay must fail before session attachment rather
+    // than hiding a large queued closure behind per-event accounting.
     const detachedBufferCap = 1024 * 1024; // generous: keep the whole run
     const { sessionManager, multiplexer, evicted } = createUnsequencedHarness(
       detachedBufferCap,
@@ -202,7 +185,7 @@ describe("client multiplexer slow-consumer eviction", () => {
     });
 
     // Buffer a contiguous multi-event run whose TOTAL bytes (~12 KB over 12
-    // events) far exceed the 2 KB / 3-event live pending cap, while staying well
+    // events) far exceed the 2 KB / 3-event pending cap, while staying well
     // under the 1 MB detached-buffer cap so the detached eviction retains ALL of
     // them (no buffer trimming — every event is a replay survivor). ~1 KB each,
     // no single oversized payload.
@@ -211,8 +194,8 @@ describe("client multiplexer slow-consumer eviction", () => {
       await multiplexer.broadcastSessionEvent("session_1", bigEvent(i, 1000));
     }
 
-    // A perfectly HEALTHY client (send resolves immediately) attaches and the
-    // bounded buffer is replayed to it.
+    // A perfectly healthy client is still not permission to exceed its
+    // configured pending backlog.
     const replayed: JsonObject[] = [];
     await multiplexer.registerClient({
       clientId: "healthy_replay_client",
@@ -221,54 +204,105 @@ describe("client multiplexer slow-consumer eviction", () => {
         return Promise.resolve();
       },
     });
-    await multiplexer.attachClientToSession(
-      "session_1",
-      "healthy_replay_client",
-    );
-    await new Promise((resolve) => setImmediate(resolve));
-
-    // The healthy client was NOT evicted — even though the replayed run is far
-    // larger than the live pending cap. Under the v1 cap-on-replay bug it WOULD
-    // be evicted here (synchronous replay accumulation crosses the 2 KB cap).
+    await expect(
+      multiplexer.attachClientToSession(
+        "session_1",
+        "healthy_replay_client",
+      ),
+    ).rejects.toMatchObject({ code: "EVENT_DELIVERY_LIMIT_EXCEEDED" });
     expect(evicted).not.toContain("healthy_replay_client");
     const stillAttached = await multiplexer.attachedClientIds("session_1");
-    expect(stillAttached).toContain("healthy_replay_client");
+    expect(stillAttached).not.toContain("healthy_replay_client");
+    expect(replayed).toHaveLength(0);
+  });
 
-    // ...and received EVERY buffered event, in order, with NO data loss. All
-    // `newestSequence` events were retained by the detached buffer (it never
-    // trimmed), so the replay must deliver the FULL contiguous run 1..N with the
-    // newest (boundary) event present — the bug drops the boundary event and any
-    // events past the point the running cap trips.
-    expect(replayed.length).toBe(newestSequence);
-    const replayedSequences = replayed.map(
-      (event) => (event as { sequence: number }).sequence,
+  it("reserves a blocked replay batch so a concurrent attach cannot queue another", async () => {
+    const { sessionManager, multiplexer } = createUnsequencedHarness(
+      1024 * 1024,
+      {
+        maxPendingDeliveryBytesPerClient: 8 * 1024,
+        maxPendingDeliveryCountPerClient: 3,
+      },
     );
-    expect(replayedSequences[0]).toBe(1);
-    expect(replayedSequences[replayedSequences.length - 1]).toBe(newestSequence);
-    for (let i = 1; i < replayedSequences.length; i += 1) {
-      const prev = replayedSequences[i - 1] as number;
-      const cur = replayedSequences[i] as number;
-      expect(cur).toBe(prev + 1);
-    }
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+    await multiplexer.broadcastSessionEvent("session_1", bigEvent(1, 1000));
+    await multiplexer.broadcastSessionEvent("session_1", bigEvent(2, 1000));
 
-    // The buffer was fully drained on a clean replay (every retained event was
-    // delivered and the buffer spliced empty), proving no event was lost AND the
-    // splice did not discard an undelivered boundary event.
-    await multiplexer.detachClientFromSession(
-      "session_1",
-      "healthy_replay_client",
-    );
-    // Re-attach and confirm nothing is re-replayed (buffer was fully consumed).
-    const secondReplay: JsonObject[] = [];
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
     await multiplexer.registerClient({
-      clientId: "second_client",
-      send: (message) => {
-        secondReplay.push(message);
-        return Promise.resolve();
+      clientId: "blocked_replay_client",
+      send: () => blocked,
+    });
+
+    const firstAttach = multiplexer.attachClientToSession(
+      "session_1",
+      "blocked_replay_client",
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    await expect(
+      multiplexer.attachClientToSession(
+        "session_1",
+        "blocked_replay_client",
+      ),
+    ).rejects.toMatchObject({ code: "EVENT_DELIVERY_LIMIT_EXCEEDED" });
+
+    release();
+    await firstAttach;
+  });
+
+  it("rejects oversized live and replay events without exceeding either pending cap", async () => {
+    const { sessionManager, multiplexer, evicted } = createUnsequencedHarness(
+      1024 * 1024,
+      {
+        maxPendingDeliveryBytesPerClient: 1024,
+        maxPendingDeliveryCountPerClient: 2,
+      },
+    );
+    await sessionManager.createSession({
+      agentId: "agent_1",
+      cwd: await workspaces.create(),
+    });
+
+    let liveSends = 0;
+    await multiplexer.registerClient({
+      clientId: "live_client",
+      send: () => {
+        liveSends += 1;
       },
     });
-    await multiplexer.attachClientToSession("session_1", "second_client");
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(secondReplay).toHaveLength(0);
+    await multiplexer.attachClientToSession("session_1", "live_client");
+    const liveResult = await multiplexer.broadcastSessionEvent(
+      "session_1",
+      bigEvent(1, 5000),
+    );
+    expect(liveSends).toBe(0);
+    expect(evicted).toContain("live_client");
+    expect(liveResult.failed).toMatchObject([
+      {
+        clientId: "live_client",
+        message: expect.stringMatching(/delivery limit/i),
+      },
+    ]);
+
+    // With no client attached, the same event fits the detached 1 MB buffer.
+    await multiplexer.broadcastSessionEvent("session_1", bigEvent(2, 5000));
+    let replaySends = 0;
+    await multiplexer.registerClient({
+      clientId: "replay_client",
+      send: () => {
+        replaySends += 1;
+      },
+    });
+    await expect(
+      multiplexer.attachClientToSession("session_1", "replay_client"),
+    ).rejects.toMatchObject({ code: "EVENT_DELIVERY_LIMIT_EXCEEDED" });
+    expect(replaySends).toBe(0);
+    expect(evicted).not.toContain("replay_client");
   });
 });

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -54,7 +54,11 @@ import {
   createEmptyToolPermissionContext,
   type ToolPermissionContext,
 } from "../permissions/types.js";
-import { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import {
+  EnvHttpProxyAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} from "undici";
 import { clearProxyCache } from "../utils/proxy.js";
 import { clearMTLSCache } from "../utils/mtls.js";
 import { AsyncQueue } from "../utils/async-queue.js";
@@ -76,6 +80,16 @@ function createRecoveredSession(
   },
 ) {
   const state = { history: [] as unknown[] };
+  const rolloutItems: unknown[] = [];
+  const eventLog = { lastSeq: 0 };
+  const rolloutStore = {
+    rolloutPath: join(
+      tmpdir(),
+      `agenc-recovered-${process.pid}-${threadId.replaceAll("/", "_")}.jsonl`,
+    ),
+    readAll: () => [...rolloutItems],
+    assertToolAdmissionAllowed: () => {},
+  };
   const managedThread = {
     threadId,
     agentPath: "/root",
@@ -99,6 +113,20 @@ function createRecoveredSession(
   };
   return {
     conversationId: threadId,
+    rolloutStore,
+    eventLog,
+    emit: (event: {
+      readonly eventId?: string;
+      readonly id?: string;
+      readonly msg: unknown;
+    }) => {
+      const seq = eventLog.lastSeq + 1;
+      const eventId = event.eventId ?? event.id ?? `recovered-event-${seq}`;
+      const stamped = { ...event, eventId, id: eventId, seq };
+      eventLog.lastSeq = seq;
+      rolloutItems.push({ type: "event_msg", payload: stamped });
+      return stamped;
+    },
     permissionModeRegistry,
     state: {
       unsafePeek: () => state,
@@ -114,7 +142,8 @@ function createRecoveredSession(
       conversationThreadManager: {
         hasThread: (id: string) => id === threadId,
         getThread: (id: string) => {
-          if (id !== threadId) throw new Error(`missing recovered thread ${id}`);
+          if (id !== threadId)
+            throw new Error(`missing recovered thread ${id}`);
           return managedThread;
         },
       },
@@ -655,10 +684,14 @@ describe("AgenC daemon CLI", () => {
 
     try {
       await expect(
-        waitForPid(resolveAgenCDaemonPidPath(firstHost.env, firstHost.userHome)),
+        waitForPid(
+          resolveAgenCDaemonPidPath(firstHost.env, firstHost.userHome),
+        ),
       ).resolves.toBe(4100);
       await expect(
-        waitForPid(resolveAgenCDaemonPidPath(secondHost.env, secondHost.userHome)),
+        waitForPid(
+          resolveAgenCDaemonPidPath(secondHost.env, secondHost.userHome),
+        ),
       ).resolves.toBe(4100);
       const firstUrl = await waitForDaemonWebSocketUrl(firstIo);
       const secondUrl = await waitForDaemonWebSocketUrl(secondIo);
@@ -1705,9 +1738,7 @@ backend = "local"
         "CONNECTION_AUTHENTICATION_FAILED",
       );
     }
-    await expect(waitForSocketClose(wrongCookieSocket)).resolves.toBe(
-      "closed",
-    );
+    await expect(waitForSocketClose(wrongCookieSocket)).resolves.toBe("closed");
     const missingCookieSocket = createConnection(socketPath);
     await once(missingCookieSocket, "connect");
     missingCookieSocket.write(
@@ -1937,7 +1968,11 @@ backend = "local"
           jsonrpc: "2.0",
           id: "create",
           method: "agent.create",
-          params: {cwd: process.cwd(),  cwd: process.cwd(),  objective: "realtime thread state" },
+          params: {
+            cwd: process.cwd(),
+            cwd: process.cwd(),
+            objective: "realtime thread state",
+          },
         })}\n`,
       );
       const created = JSON.parse(await readSocketLine(socket)) as {
@@ -2104,7 +2139,8 @@ backend = "local"
         timeoutMs: 1000,
       });
 
-      const created = await writerClient.request("agent.create", { cwd: process.cwd(),
+      const created = await writerClient.request("agent.create", {
+        cwd: process.cwd(),
         objective: "health state",
       });
       if (created.sessionId === undefined)
@@ -2206,7 +2242,8 @@ backend = "local"
         timeoutMs: 1000,
       });
 
-      const created = await client.request("agent.create", { cwd: process.cwd(),
+      const created = await client.request("agent.create", {
+        cwd: process.cwd(),
         objective: "prove dispatcher boot injection",
       });
       expect(created.agentId).toBe("agent_boot_injection");
@@ -2518,12 +2555,14 @@ snapshot_max_bytes = 64
         bootstrap: (async (options) => {
           const conversationId = options.conversationId ?? "daemon-recovery";
           restoredConversationIds.push(conversationId);
+          const session = createRecoveredSession(
+            conversationId,
+            permissionModeRegistry,
+          );
           return {
-            session: createRecoveredSession(
-              conversationId,
-              permissionModeRegistry,
-            ),
-          shutdown: async () => {},
+            session,
+            rolloutStore: session.rolloutStore,
+            shutdown: async () => {},
           };
         }) as AgenCBootstrapFunction,
         ensureAgentControl: (() => ({
@@ -2720,21 +2759,22 @@ snapshot_max_bytes = 64
           restoredSessions.set(conversationId, session);
           return {
             session,
-          registry: {
-            tools: [
-              {
-                name: "FileRead",
-                description: "Read a file.",
-                inputSchema: { type: "object" },
-                recoveryCategory: "idempotent",
-                isReadOnly: true,
-                execute,
-              },
-            ],
-            toLLMTools: () => [],
-            dispatch,
-          },
-          shutdown: async () => {},
+            rolloutStore: session.rolloutStore,
+            registry: {
+              tools: [
+                {
+                  name: "FileRead",
+                  description: "Read a file.",
+                  inputSchema: { type: "object" },
+                  recoveryCategory: "idempotent",
+                  isReadOnly: true,
+                  execute,
+                },
+              ],
+              toLLMTools: () => [],
+              dispatch,
+            },
+            shutdown: async () => {},
           };
         }) as AgenCBootstrapFunction,
         ensureAgentControl: (() => ({
@@ -2768,7 +2808,9 @@ snapshot_max_bytes = 64
       expect.objectContaining({ file_path: "README.md" }),
     );
     expect(dispatch).not.toHaveBeenCalled();
-    expect(restoredSessions.get("run-replay")?.state.unsafePeek().history).toEqual([
+    expect(
+      restoredSessions.get("run-replay")?.state.unsafePeek().history,
+    ).toEqual([
       { role: "assistant", content: "state" },
       {
         role: "assistant",
@@ -2838,7 +2880,8 @@ snapshot_max_bytes = 64
     const runner: AgenCBackgroundAgentRunner =
       new AgenCDelegateBackgroundAgentRunner({
         bootstrap: (async (options) => {
-          const conversationId = options.conversationId ?? "daemon-completed-tool";
+          const conversationId =
+            options.conversationId ?? "daemon-completed-tool";
           const session = createRecoveredSession(
             conversationId,
             permissionModeRegistry,
@@ -2846,6 +2889,7 @@ snapshot_max_bytes = 64
           restoredSessions.set(conversationId, session);
           return {
             session,
+            rolloutStore: session.rolloutStore,
             shutdown: async () => {},
           };
         }) as AgenCBootstrapFunction,
@@ -2899,7 +2943,8 @@ snapshot_max_bytes = 64
     const recoveredToolContent = String(
       restoredSessions
         .get("run-completed-tool")
-        ?.state.unsafePeek().history.at(-1)?.content,
+        ?.state.unsafePeek()
+        .history.at(-1)?.content,
     );
     expect(recoveredToolContent).not.toContain("<system>");
     expect(
@@ -2955,7 +3000,8 @@ snapshot_max_bytes = 64
     const runner: AgenCBackgroundAgentRunner =
       new AgenCDelegateBackgroundAgentRunner({
         bootstrap: (async (options) => {
-          const conversationId = options.conversationId ?? "daemon-replay-poison";
+          const conversationId =
+            options.conversationId ?? "daemon-replay-poison";
           const session = createRecoveredSession(
             conversationId,
             permissionModeRegistry,
@@ -2963,12 +3009,15 @@ snapshot_max_bytes = 64
           restoredSessions.set(conversationId, session);
           return {
             session,
-          registry: {
-            tools: [{ name: "FileWrite", recoveryCategory: "side-effecting" }],
-            toLLMTools: () => [],
-            dispatch,
-          },
-          shutdown: async () => {},
+            rolloutStore: session.rolloutStore,
+            registry: {
+              tools: [
+                { name: "FileWrite", recoveryCategory: "side-effecting" },
+              ],
+              toLLMTools: () => [],
+              dispatch,
+            },
+            shutdown: async () => {},
           };
         }) as AgenCBootstrapFunction,
         ensureAgentControl: (() => ({
@@ -3001,9 +3050,7 @@ snapshot_max_bytes = 64
     expect(dispatch).not.toHaveBeenCalled();
     expect(
       restoredSessions.get("run-replay-poison")?.state.unsafePeek().history,
-    ).toEqual([
-      { role: "assistant", content: "state" },
-    ]);
+    ).toEqual([{ role: "assistant", content: "state" }]);
     expect(
       latestSnapshotToolState(
         agencHome,
@@ -3229,8 +3276,7 @@ snapshot_max_bytes = 64
 
     const sendInput = vi.fn(async () => {});
     let restoreBootstrapOptions:
-      | Parameters<AgenCBootstrapFunction>[0]
-      | undefined;
+      Parameters<AgenCBootstrapFunction>[0] | undefined;
     const restoredSessions = new Map<
       string,
       ReturnType<typeof createRecoveredSession>
@@ -3252,6 +3298,7 @@ snapshot_max_bytes = 64
           restoredSessions.set(conversationId, session);
           return {
             session,
+            rolloutStore: session.rolloutStore,
             shutdown: async () => {},
           };
         }) as AgenCBootstrapFunction,
@@ -3279,9 +3326,7 @@ snapshot_max_bytes = 64
     expect(restoreBootstrapOptions?.resumeConversation).toBe(true);
     expect(
       restoredSessions.get(createdAgentId)?.state.unsafePeek().history,
-    ).toEqual([
-      { role: "user", content: "state before restart" },
-    ]);
+    ).toEqual([{ role: "user", content: "state before restart" }]);
     expect(restoreBootstrapOptions?.argv).toEqual(
       expect.arrayContaining([
         "--provider",
@@ -3874,8 +3919,13 @@ describe("daemon startup proxy configuration", () => {
   // getProxyUrl reads process.env (not host.env), matching production where the
   // spawned daemon's process.env IS the inherited parent CLI env.
   const PROXY_ENV = [
-    "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy",
-    "AGENC_CLIENT_CERT", "AGENC_CLIENT_KEY", "NODE_EXTRA_CA_CERTS",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "AGENC_CLIENT_CERT",
+    "AGENC_CLIENT_KEY",
+    "NODE_EXTRA_CA_CERTS",
   ];
   let stashed: Record<string, string | undefined>;
   let originalDispatcher: ReturnType<typeof getGlobalDispatcher>;

--- a/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
@@ -1,7 +1,7 @@
 // run.cancel (frozen Wave-B method): dispatcher routing, param validation,
-// capability advertisement, and the durable-first flow — the state-DB
-// cascade decides the outcome, the live interrupt/stop is best-effort
-// second, and voided budget holds are reported.
+// capability advertisement, and the canonical-first live flow — a live
+// writer must seal one cancelled terminal before the state-DB projection,
+// while inactive runs retain the durable offline cascade.
 
 import { describe, expect, it, vi } from "vitest";
 import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
@@ -12,6 +12,7 @@ import {
   type JsonObject,
 } from "./protocol/index.js";
 import type { CancelAgentRunTreeReport } from "../../src/state/run-cancellation.js";
+import type { AgenCBackgroundAgentTerminalSnapshot } from "./background-agent-runner.js";
 
 function request(id: string, method: string, params?: JsonObject): JsonObject {
   return {
@@ -38,22 +39,91 @@ function cancelledReport(runId: string): CancelAgentRunTreeReport {
 async function dispatchRunCancel(options: {
   readonly report: CancelAgentRunTreeReport;
   readonly interruptResult?: boolean;
+  readonly live?: boolean;
+  readonly stopError?: Error;
+  readonly liveTerminal?: AgenCBackgroundAgentTerminalSnapshot;
 }) {
-  const cancelDurable = vi.fn().mockResolvedValue(options.report);
+  const order: string[] = [];
+  const cancelDurable = vi.fn(async () => {
+    order.push("db_cascade");
+    return options.report;
+  });
   const voidHolds = vi.fn().mockResolvedValue(3);
   const interruptAgentTurn = vi
     .fn()
-    .mockResolvedValue(options.interruptResult ?? true);
-  const stopAgent = vi.fn().mockResolvedValue(undefined);
-  const agentManager = new AgenCDaemonAgentManager({
+    .mockImplementation(async () => {
+      order.push("interrupt");
+      return options.interruptResult ?? true;
+    });
+  const recordRunTerminal = vi.fn(async () => {
+    order.push("terminal_projection");
+  });
+  const prepareAgentCancellation = vi.fn(async (runId: string) => {
+    order.push("canonical_cancel_admission");
+    return {
+      affectedRunIds: [runId, `${runId}_child`],
+      voidedHolds: 3,
+      heldUnknownHolds: 0,
+    };
+  });
+  let live = options.live ?? true;
+  let agentManager!: AgenCDaemonAgentManager;
+  const stopAgent = vi.fn(async (runId: string, reason?: string) => {
+    order.push("canonical_terminal");
+    if (options.stopError !== undefined) throw options.stopError;
+    live = false;
+    await agentManager.handleRunnerTerminated(runId, {
+      status: "stopped",
+      lastActiveAt: "2026-05-11T00:00:00.000Z",
+      terminal: {
+        openedAt: "2026-05-10T00:00:00.000Z",
+        epoch: 1,
+        eventId: `run-terminal:${runId}:1`,
+        rolloutPath: `/tmp/${runId}.jsonl`,
+        result: {
+          runId,
+          status: "cancelled",
+          exitCode: null,
+          stopReason: reason ?? "run.cancel",
+          finalMessage: null,
+          usage: null,
+          lastSequence: 2,
+          finishedAt: "2026-05-11T00:00:00.000Z",
+        },
+      },
+    });
+  });
+  agentManager = new AgenCDaemonAgentManager({
     runner: {
       startAgent: vi.fn(),
+      getAgentSnapshot: vi.fn(async (_runId: string) =>
+        live
+          ? {
+              status: options.liveTerminal === undefined ? "running" : "stopped",
+              lastActiveAt: "2026-05-10T00:00:00.000Z",
+              ...(options.liveTerminal !== undefined
+                ? { terminal: options.liveTerminal }
+                : {}),
+            }
+          : null,
+      ),
       interruptAgentTurn,
+      prepareAgentCancellation,
       stopAgent,
     },
     cancelRunTreeDurable: cancelDurable,
     voidBudgetHoldsForAgents: voidHolds,
+    recordRunTerminal,
   });
+  if (live) {
+    await agentManager.restoreAgent({
+      agentId: options.report.runId,
+      objective: "cancel contract run",
+      status: "running",
+      runtimeAvailable: true,
+      sessionIds: [options.report.runId],
+    });
+  }
   const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager });
   const connection = dispatcher.createConnection({
     sendNotification: () => {},
@@ -62,13 +132,17 @@ async function dispatchRunCancel(options: {
     request("init", "initialize", { protocol: { version: "1.0.0" } }),
   );
   return {
+    agentManager,
     connection,
     dispatcher,
     init,
     cancelDurable,
     voidHolds,
     interruptAgentTurn,
+    prepareAgentCancellation,
     stopAgent,
+    recordRunTerminal,
+    order,
   };
 }
 
@@ -97,23 +171,37 @@ describe("run.cancel dispatcher contract", () => {
         voidedHolds: 3,
       },
     });
-    // Durable first, with the caller's reason.
+    // A live writer seals its canonical cancellation before the rebuildable
+    // SQLite cascade and terminal projection.
     expect(harness.cancelDurable).toHaveBeenCalledWith(
       expect.objectContaining({ runId: "run_a", reason: "operator" }),
     );
-    // Live propagation second (interrupt cascades in-runner, then stop).
     expect(harness.interruptAgentTurn).toHaveBeenCalledWith(
       "run_a",
       "operator",
     );
     expect(harness.stopAgent).toHaveBeenCalledWith("run_a", "operator");
-    // Voided holds cover the FULL subtree (idempotent superset).
-    expect(harness.voidHolds).toHaveBeenCalledWith(["run_a", "run_a_child"]);
+    expect(harness.recordRunTerminal).toHaveBeenCalledTimes(1);
+    expect(harness.order).toEqual([
+      "canonical_cancel_admission",
+      "interrupt",
+      "canonical_terminal",
+      "db_cascade",
+      "terminal_projection",
+    ]);
+    // Live holds were settled while the canonical listener was still open;
+    // no post-terminal compatibility publication is allowed.
+    expect(harness.prepareAgentCancellation).toHaveBeenCalledWith(
+      "run_a",
+      "operator",
+    );
+    expect(harness.voidHolds).not.toHaveBeenCalled();
     await harness.dispatcher.closeConnection(harness.connection);
   });
 
   it("maps a missing run to RUN_NOT_FOUND and requires runId", async () => {
     const harness = await dispatchRunCancel({
+      live: false,
       report: {
         runId: "ghost",
         missing: true,
@@ -142,6 +230,7 @@ describe("run.cancel dispatcher contract", () => {
 
   it("still voids subtree holds on an already-terminal retry (crash between cascade and voiding)", async () => {
     const harness = await dispatchRunCancel({
+      live: false,
       report: {
         runId: "done_run",
         missing: false,
@@ -166,6 +255,105 @@ describe("run.cancel dispatcher contract", () => {
       "done_run",
       "done_run_child",
     ]);
+    await harness.dispatcher.closeConnection(harness.connection);
+  });
+
+  it("projects a naturally completed terminal before checking the DB cancellation", async () => {
+    const runId = "run_completed_race";
+    const harness = await dispatchRunCancel({
+      report: {
+        runId,
+        missing: false,
+        alreadyTerminal: true,
+        rootStatusBefore: "stopped",
+        subtreeRunIds: [runId],
+        cancelledRunIds: [],
+        priorStatusById: {},
+        closedEdgeChildIds: [],
+      },
+      liveTerminal: {
+        openedAt: "2026-05-10T00:00:00.000Z",
+        epoch: 1,
+        eventId: `run-terminal:${runId}:1`,
+        rolloutPath: `/tmp/${runId}.jsonl`,
+        result: {
+          runId,
+          status: "completed",
+          exitCode: 0,
+          stopReason: "turn_completed",
+          finalMessage: "done",
+          usage: null,
+          lastSequence: 4,
+          finishedAt: "2026-05-11T00:00:00.000Z",
+        },
+      },
+    });
+
+    const response = await harness.connection.dispatch(
+      request("rc-completed", "run.cancel", { runId, reason: "too_late" }),
+    );
+
+    expect(response).toMatchObject({
+      result: { runId, alreadyTerminal: true, cancelledRunIds: [] },
+    });
+    expect(harness.order).toEqual(["terminal_projection", "db_cascade"]);
+    expect(harness.prepareAgentCancellation).not.toHaveBeenCalled();
+    expect(harness.interruptAgentTurn).not.toHaveBeenCalled();
+    expect(harness.stopAgent).not.toHaveBeenCalled();
+    expect(harness.voidHolds).not.toHaveBeenCalled();
+    await harness.dispatcher.closeConnection(harness.connection);
+  });
+
+  it("does not commit the DB cancellation when a live writer cannot seal canonical evidence", async () => {
+    const harness = await dispatchRunCancel({
+      report: cancelledReport("run_crash_window"),
+      stopError: new Error("simulated crash before canonical terminal"),
+    });
+
+    const response = await harness.connection.dispatch(
+      request("rc5", "run.cancel", {
+        runId: "run_crash_window",
+        reason: "operator",
+      }),
+    );
+
+    expect(response).toMatchObject({
+      error: { message: expect.stringContaining("simulated crash") },
+    });
+    expect(harness.cancelDurable).not.toHaveBeenCalled();
+    expect(harness.recordRunTerminal).not.toHaveBeenCalled();
+    expect(harness.order).toEqual([
+      "canonical_cancel_admission",
+      "interrupt",
+      "canonical_terminal",
+    ]);
+    await harness.dispatcher.closeConnection(harness.connection);
+  });
+
+  it("coalesces concurrent live cancellation requests into one canonical terminal", async () => {
+    const harness = await dispatchRunCancel({
+      report: cancelledReport("run_concurrent_cancel"),
+    });
+
+    const [first, second] = await Promise.all([
+      harness.agentManager.cancelRunTree({
+        runId: "run_concurrent_cancel",
+        reason: "operator",
+      }),
+      harness.agentManager.cancelRunTree({
+        runId: "run_concurrent_cancel",
+        reason: "operator",
+      }),
+    ]);
+
+    expect(second).toEqual(first);
+    expect(harness.stopAgent).toHaveBeenCalledTimes(1);
+    expect(harness.prepareAgentCancellation).toHaveBeenCalledTimes(1);
+    expect(harness.cancelDurable).toHaveBeenCalledTimes(1);
+    expect(harness.recordRunTerminal).toHaveBeenCalledTimes(1);
+    expect(
+      harness.order.filter((step) => step === "canonical_terminal"),
+    ).toHaveLength(1);
     await harness.dispatcher.closeConnection(harness.connection);
   });
 });

--- a/runtime/tests/app-server/disconnect-resilience.contract.test.ts
+++ b/runtime/tests/app-server/disconnect-resilience.contract.test.ts
@@ -105,6 +105,7 @@ describe("AgenC daemon disconnect resilience", () => {
   it("bounds buffered events and preserves their order for replay", async () => {
     const { sessionManager, multiplexer } = createHarness(2);
     const replayedSequences: number[] = [];
+    let retiredCount = 0;
 
     await sessionManager.createSession({
       agentId: "agent_1",
@@ -137,10 +138,20 @@ describe("AgenC daemon disconnect resilience", () => {
         if (typeof params === "object" && params !== null && "sequence" in params) {
           replayedSequences.push(Number(params.sequence));
         }
+        if (
+          message.method === "event.event_gap" &&
+          typeof params === "object" &&
+          params !== null &&
+          "retiredCount" in params
+        ) {
+          retiredCount = Number(params.retiredCount);
+        }
       },
     });
     await multiplexer.attachClientToSession("session_1", "client_1");
 
-    expect(replayedSequences).toEqual([2, 3]);
+    // The explicit gap marker counts toward the hard two-event cap.
+    expect(retiredCount).toBe(2);
+    expect(replayedSequences).toEqual([3]);
   });
 });

--- a/runtime/tests/app-server/run-inspection.contract.test.ts
+++ b/runtime/tests/app-server/run-inspection.contract.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,7 @@ import { admissionRecordKey } from "../../src/budget/admission-types.js";
 import type { RuntimeAdmissionRequest } from "../../src/budget/admission-types.js";
 import { upsertAgentRun } from "../../src/state/agent-runs.js";
 import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
 import {
   openStateDatabases,
   type StateDatabasePaths,
@@ -422,6 +423,32 @@ describe("durable run inspection", () => {
     expect(new Set(observed).size).toBe(observed.length);
   });
 
+  it("reports a legacy replay cursor beyond the durable journal tail", () => {
+    const expectedSequences = seedDurableRuns();
+    const lastAvailableSequence = Math.max(...expectedSequences);
+
+    expect(
+      service.replay({
+        runId: "run-complete",
+        afterSequence: lastAvailableSequence + 10,
+        limit: 20,
+      }),
+    ).toMatchObject({
+      events: [],
+      hasMore: false,
+      nextAfterSequence: lastAvailableSequence + 10,
+      lastAvailableSequence,
+      gap: {
+        kind: "cursor_ahead",
+        runId: "run-complete",
+        afterSequence: lastAvailableSequence + 10,
+        lastAvailableSequence,
+        reason: "cursor_ahead",
+      },
+      source: { sequenceScope: "project_state_database" },
+    });
+  });
+
   it("returns only durable terminal results and labels absent output honestly", () => {
     seedDurableRuns();
 
@@ -439,6 +466,193 @@ describe("durable run inspection", () => {
         code: "RUN_NOT_TERMINAL",
       }),
     );
+  });
+
+  it("returns the committed M4 terminal result after the original connection is gone", () => {
+    seedDurableRuns();
+    const durability = new StateRunDurabilityRepository(driver);
+    durability.ensureInitialEpoch({ runId: "run-complete", openedAt: NOW });
+    durability.recordTerminalResult({
+      epoch: 1,
+      eventId: "terminal-event-44",
+      result: {
+        runId: "run-complete",
+        status: "completed",
+        exitCode: 0,
+        stopReason: "turn_completed",
+        finalMessage: "Durable final answer",
+        usage: {
+          inputTokens: 30,
+          outputTokens: 12,
+          totalTokens: 42,
+          costUsd: 0.004,
+        },
+        lastSequence: 44,
+        finishedAt: "2026-07-18T12:05:00.000Z",
+      },
+    });
+
+    expect(service.status({ runId: "run-complete" })).toMatchObject({
+      status: "completed",
+      terminal: true,
+      statusSource: "run_terminal_result",
+    });
+    expect(service.result({ runId: "run-complete" })).toMatchObject({
+      runId: "run-complete",
+      status: "completed",
+      terminal: true,
+      terminalAt: "2026-07-18T12:05:00.000Z",
+      epoch: 1,
+      output: {
+        available: true,
+        exitCode: 0,
+        stopReason: "turn_completed",
+        finalMessage: "Durable final answer",
+        usage: {
+          inputTokens: 30,
+          outputTokens: 12,
+          totalTokens: 42,
+          costUsd: 0.004,
+        },
+        lastSequence: 44,
+      },
+    });
+  });
+
+  it("locates and returns a canonical terminal without a legacy agent_runs row", () => {
+    const durability = new StateRunDurabilityRepository(driver);
+    durability.ensureInitialEpoch({ runId: "canonical-only", openedAt: NOW });
+    durability.recordTerminalResult({
+      epoch: 1,
+      eventId: "terminal-canonical-only",
+      result: {
+        runId: "canonical-only",
+        status: "completed",
+        exitCode: 0,
+        stopReason: "completed",
+        finalMessage: "canonical answer",
+        usage: null,
+        lastSequence: 1,
+        finishedAt: "2026-07-18T12:05:00.000Z",
+      },
+    });
+
+    expect(service.status({ runId: "canonical-only" })).toMatchObject({
+      status: "completed",
+      terminal: true,
+      statusSource: "run_terminal_result",
+    });
+    expect(service.result({ runId: "canonical-only" })).toEqual(
+      expect.objectContaining({
+        runId: "canonical-only",
+        terminal: true,
+        epoch: 1,
+        output: expect.objectContaining({
+          available: true,
+          finalMessage: "canonical answer",
+          lastSequence: 1,
+        }),
+      }),
+    );
+    expect(service.result({ runId: "canonical-only" })).not.toHaveProperty(
+      "durableRun",
+    );
+  });
+
+  it("does not expose an earlier epoch terminal after an explicit reopen", () => {
+    seedDurableRuns();
+    const durability = new StateRunDurabilityRepository(driver);
+    durability.ensureInitialEpoch({ runId: "run-complete", openedAt: NOW });
+    durability.recordTerminalResult({
+      epoch: 1,
+      eventId: "terminal-before-reopen",
+      result: {
+        runId: "run-complete",
+        status: "completed",
+        exitCode: 0,
+        stopReason: "turn_completed",
+        finalMessage: "stale after reopen",
+        usage: null,
+        lastSequence: 4,
+        finishedAt: "2026-07-18T12:05:00.000Z",
+      },
+    });
+    durability.reopenRun({
+      runId: "run-complete",
+      fromEpoch: 1,
+      openedAt: "2026-07-18T12:06:00.000Z",
+      eventId: "reopen-event-2",
+      reason: "operator_retry",
+    });
+
+    expect(service.status({ runId: "run-complete" })).toMatchObject({
+      status: "running",
+      terminal: false,
+      statusSource: "run_lifecycle_epoch",
+    });
+    expect(() => service.result({ runId: "run-complete" })).toThrowError(
+      expect.objectContaining<AgenCDaemonRunInspectionError>({
+        code: "RUN_NOT_TERMINAL",
+      }),
+    );
+  });
+
+  it("rebuilds a missing terminal projection from the canonical JSONL event", () => {
+    seedDurableRuns();
+    new StateRunDurabilityRepository(driver).ensureInitialEpoch({
+      runId: "run-complete",
+      openedAt: NOW,
+    });
+    const sessionDir = join(paths.projectDir, "sessions", "run-complete");
+    mkdirSync(sessionDir, { recursive: true });
+    const rolloutPath = join(sessionDir, "rollout-terminal.jsonl");
+    writeFileSync(
+      rolloutPath,
+      `${JSON.stringify({
+        type: "event_msg",
+        payload: {
+          eventId: "terminal-from-jsonl",
+          id: "terminal-from-jsonl",
+          seq: 9,
+          msg: {
+            type: "run_terminal",
+            payload: {
+              runId: "run-complete",
+              epoch: 1,
+              status: "completed",
+              exitCode: 0,
+              stopReason: "turn_completed",
+              finalMessage: "Recovered from the journal",
+              usage: {
+                inputTokens: 5,
+                outputTokens: 3,
+                totalTokens: 8,
+                costUsd: 0.001,
+              },
+              lastSequenceBeforeTerminal: 8,
+              finishedAt: "2026-07-18T12:05:00.000Z",
+            },
+          },
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    expect(service.result({ runId: "run-complete" })).toMatchObject({
+      status: "completed",
+      epoch: 1,
+      durableRun: { status: "completed" },
+      output: {
+        available: true,
+        finalMessage: "Recovered from the journal",
+        lastSequence: 9,
+      },
+    });
+    expect(
+      new StateRunDurabilityRepository(driver).getCurrentTerminalResult(
+        "run-complete",
+      ),
+    ).toMatchObject({ eventId: "terminal-from-jsonl", lastSequence: 9 });
   });
 
   it("exports bounded hashes and explicitly excludes workflow evidence", () => {
@@ -461,6 +675,7 @@ describe("durable run inspection", () => {
     for (const digest of [
       partial.hashes.runStateSha256,
       partial.hashes.admissionSummarySha256,
+      partial.hashes.gapSha256,
       partial.hashes.bundleSha256,
       partial.hashes.eventHashes[0]?.sha256,
     ]) {
@@ -473,6 +688,15 @@ describe("durable run inspection", () => {
     });
     expect(complete.hasMore).toBe(false);
     expect(complete.source.completeness).toBe("complete");
+
+    const cursorAhead = service.evidence({
+      runId: "run-complete",
+      afterSequence: complete.cursor.nextAfterSequence + 100,
+      limit: 20,
+    });
+    expect(cursorAhead.source.completeness).toBe("journal_gap");
+    expect(cursorAhead.gap).toMatchObject({ kind: "cursor_ahead" });
+    expect(cursorAhead.hashes.gapSha256).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it("advertises, validates, and maps typed dispatcher errors", async () => {

--- a/runtime/tests/app-server/run-journal-replay.test.ts
+++ b/runtime/tests/app-server/run-journal-replay.test.ts
@@ -1,0 +1,440 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildCanonicalRunReplay } from "../../src/app-server/run-journal-replay.js";
+
+describe("canonical run journal replay", () => {
+  const databases: Database.Database[] = [];
+
+  afterEach(() => {
+    for (const db of databases.splice(0)) db.close();
+  });
+
+  function database(): Database.Database {
+    const db = new Database(":memory:");
+    databases.push(db);
+    db.exec(`
+      CREATE TABLE threads (
+        thread_id TEXT PRIMARY KEY,
+        rollout_path TEXT,
+        archived_rollout_path TEXT
+      );
+      CREATE TABLE thread_rollout_items (
+        id INTEGER PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        item_index INTEGER NOT NULL,
+        item_type TEXT NOT NULL,
+        event_id TEXT,
+        event_seq INTEGER,
+        payload_json TEXT NOT NULL
+      );
+      INSERT INTO threads(thread_id, rollout_path)
+      VALUES ('run-1', '/rollout/run-1.jsonl');
+    `);
+    return db;
+  }
+
+  function appendEvent(
+    db: Database.Database,
+    sequence: number,
+    type: string,
+    payload: Record<string, unknown>,
+    sourcePath = "/rollout/run-1.jsonl",
+    eventId: string | null = `event-${sequence}`,
+  ): void {
+    db.prepare(
+      `INSERT INTO thread_rollout_items(
+        thread_id, source_path, item_index, item_type,
+        event_id, event_seq, payload_json
+      ) VALUES (?, ?, ?, 'event_msg', ?, ?, ?)`,
+    ).run(
+      "run-1",
+      sourcePath,
+      sequence,
+      eventId,
+      sequence,
+      JSON.stringify({
+        eventId,
+        id: eventId,
+        seq: sequence,
+        msg: { type, payload },
+      }),
+    );
+  }
+
+  const paths = {
+    projectDir: "/project",
+    stateDbPath: "/project/state.sqlite",
+    logsDbPath: "/project/logs.sqlite",
+  };
+
+  it("returns a contiguous cursor page with original event ids and sequences", () => {
+    const db = database();
+    appendEvent(db, 1, "turn_started", { turnId: "turn-1" });
+    appendEvent(db, 2, "effect_intent", {
+      stepId: "tool:1",
+      callId: "call-1",
+      toolName: "Bash",
+    });
+    appendEvent(db, 3, "effect_result", {
+      stepId: "tool:1",
+      outcome: "committed",
+    });
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 2);
+
+    expect(replay.events.map((event) => [event.sequence, event.eventId])).toEqual([
+      [1, "event-1"],
+      [2, "event-2"],
+    ]);
+    expect(replay.events[1]).toMatchObject({
+      category: "effect",
+      stepId: "tool:1",
+      payload: { callId: "call-1", toolName: "Bash" },
+    });
+    expect(replay).toMatchObject({
+      nextAfterSequence: 2,
+      hasMore: true,
+      gap: null,
+      source: {
+        kind: "run_journal",
+        sequenceScope: "run",
+        canonical: "rollout_jsonl",
+        projection: "thread_rollout_items",
+      },
+    });
+  });
+
+  it("stops at an interior sequence hole and reports it explicitly", () => {
+    const db = database();
+    appendEvent(db, 1, "turn_started", { turnId: "turn-1" });
+    appendEvent(db, 3, "effect_unknown_outcome", {
+      stepId: "tool:1",
+      reason: "lost_acknowledgement",
+    });
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events.map((event) => event.sequence)).toEqual([1]);
+    expect(replay.nextAfterSequence).toBe(1);
+    expect(replay.gap).toEqual({
+      kind: "event_gap",
+      runId: "run-1",
+      afterSequence: 1,
+      firstAvailableSequence: 3,
+      reason: "corruption_truncated",
+    });
+  });
+
+  it("reports a sequenced record without event identity as corruption", () => {
+    const db = database();
+    appendEvent(db, 1, "turn_started", { turnId: "turn-1" }, undefined, null);
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events).toEqual([]);
+    expect(replay.nextAfterSequence).toBe(0);
+    expect(replay.hasMore).toBe(true);
+    expect(replay.gap).toEqual({
+      kind: "event_gap",
+      runId: "run-1",
+      afterSequence: 0,
+      firstAvailableSequence: 1,
+      reason: "corruption_truncated",
+    });
+  });
+
+  it.each(["{not-json", JSON.stringify("not-an-envelope")])(
+    "reports invalid projected event JSON as corruption: %s",
+    (payloadJson) => {
+      const db = database();
+      appendEvent(db, 1, "turn_started", { turnId: "turn-1" });
+      db.prepare(
+        "UPDATE thread_rollout_items SET payload_json = ? WHERE event_seq = 1",
+      ).run(payloadJson);
+
+      const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+      expect(replay.events).toEqual([]);
+      expect(replay.nextAfterSequence).toBe(0);
+      expect(replay.gap).toEqual({
+        kind: "event_gap",
+        runId: "run-1",
+        afterSequence: 0,
+        firstAvailableSequence: 1,
+        reason: "corruption_truncated",
+      });
+    },
+  );
+
+  it.each([
+    ["sequence", { eventId: "event-1", id: "event-1", seq: 2 }],
+    ["identity", { eventId: "other-event", id: "event-1", seq: 1 }],
+  ])(
+    "reports a projected row whose %s disagrees with its envelope as corruption",
+    (_field, coordinates) => {
+      const db = database();
+      appendEvent(db, 1, "turn_started", { turnId: "turn-1" });
+      db.prepare(
+        "UPDATE thread_rollout_items SET payload_json = ? WHERE event_seq = 1",
+      ).run(JSON.stringify({
+        ...coordinates,
+        msg: { type: "turn_started", payload: { turnId: "turn-1" } },
+      }));
+
+      const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+      expect(replay.events).toEqual([]);
+      expect(replay.nextAfterSequence).toBe(0);
+      expect(replay.gap).toEqual({
+        kind: "event_gap",
+        runId: "run-1",
+        afterSequence: 0,
+        firstAvailableSequence: 1,
+        reason: "corruption_truncated",
+      });
+    },
+  );
+
+  it("replays a legacy envelope only when its derived identity matches the projection", () => {
+    const db = database();
+    appendEvent(
+      db,
+      1,
+      "turn_started",
+      { turnId: "turn-1" },
+      undefined,
+      "legacy-event:1:legacy-id",
+    );
+    db.prepare(
+      "UPDATE thread_rollout_items SET payload_json = ? WHERE event_seq = 1",
+    ).run(JSON.stringify({
+      id: "legacy-id",
+      seq: 1,
+      msg: { type: "turn_started", payload: { turnId: "turn-1" } },
+    }));
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events).toMatchObject([
+      { sequence: 1, eventId: "legacy-event:1:legacy-id" },
+    ]);
+    expect(replay.gap).toBeNull();
+  });
+
+  it("reports conflicting identities at one sequence instead of choosing one", () => {
+    const db = database();
+    appendEvent(db, 1, "agent_message", { message: "first" });
+    appendEvent(db, 1, "agent_message", { message: "conflicting" });
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events).toEqual([]);
+    expect(replay.nextAfterSequence).toBe(0);
+    expect(replay.gap).toEqual({
+      kind: "event_gap",
+      runId: "run-1",
+      afterSequence: 0,
+      firstAvailableSequence: 1,
+      reason: "corruption_truncated",
+    });
+  });
+
+  it("converges every journal source bound across lifecycle epochs", () => {
+    const db = database();
+    db.exec(`
+      CREATE TABLE run_journal_bindings (
+        run_id TEXT NOT NULL,
+        epoch INTEGER NOT NULL,
+        source_path TEXT NOT NULL,
+        gap_reason TEXT,
+        retired_through_sequence INTEGER,
+        first_available_sequence INTEGER,
+        last_sequence INTEGER
+      );
+      INSERT INTO run_journal_bindings(run_id, epoch, source_path)
+      VALUES
+        ('run-1', 1, '/rollout/run-1-part-1.jsonl'),
+        ('run-1', 2, '/rollout/run-1-part-2.jsonl');
+    `);
+    appendEvent(
+      db,
+      1,
+      "turn_started",
+      { turnId: "turn-1" },
+      "/rollout/run-1-part-1.jsonl",
+    );
+    appendEvent(
+      db,
+      2,
+      "run_terminal",
+      { status: "completed" },
+      "/rollout/run-1-part-1.jsonl",
+    );
+    appendEvent(
+      db,
+      3,
+      "run_reopened",
+      { epoch: 2 },
+      "/rollout/run-1-part-2.jsonl",
+    );
+    appendEvent(
+      db,
+      4,
+      "agent_message",
+      { message: "continued" },
+      "/rollout/run-1-part-2.jsonl",
+    );
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events.map((event) => event.sequence)).toEqual([1, 2, 3, 4]);
+    expect(replay.nextAfterSequence).toBe(4);
+    expect(replay.gap).toBeNull();
+  });
+
+  it("collapses byte-identical overlap between bound journal sources", () => {
+    const db = database();
+    db.exec(`
+      CREATE TABLE run_journal_bindings (
+        run_id TEXT NOT NULL,
+        epoch INTEGER NOT NULL,
+        source_path TEXT NOT NULL,
+        gap_reason TEXT,
+        retired_through_sequence INTEGER,
+        first_available_sequence INTEGER,
+        last_sequence INTEGER
+      );
+      INSERT INTO run_journal_bindings(run_id, epoch, source_path)
+      VALUES
+        ('run-1', 1, '/rollout/run-1-live.jsonl'),
+        ('run-1', 1, '/rollout/run-1-archive.jsonl');
+    `);
+    appendEvent(
+      db,
+      1,
+      "agent_message",
+      { message: "same bytes" },
+      "/rollout/run-1-live.jsonl",
+    );
+    appendEvent(
+      db,
+      1,
+      "agent_message",
+      { message: "same bytes" },
+      "/rollout/run-1-archive.jsonl",
+    );
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events).toHaveLength(1);
+    expect(replay.events[0]).toMatchObject({
+      sequence: 1,
+      eventId: "event-1",
+    });
+    expect(replay.gap).toBeNull();
+  });
+
+  it("does not invent retention when an earlier sequence vanished", () => {
+    const db = database();
+    appendEvent(db, 9, "turn_resumed", { turnId: "turn-1" });
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 4, 100);
+
+    expect(replay.events).toEqual([]);
+    expect(replay.nextAfterSequence).toBe(4);
+    expect(replay.gap).toEqual({
+      kind: "event_gap",
+      runId: "run-1",
+      afterSequence: 4,
+      firstAvailableSequence: 9,
+      reason: "corruption_truncated",
+    });
+  });
+
+  it("reports fully retired history from durable binding metadata", () => {
+    const db = database();
+    db.exec(`
+      CREATE TABLE run_journal_bindings (
+        run_id TEXT NOT NULL,
+        epoch INTEGER NOT NULL,
+        source_path TEXT NOT NULL,
+        gap_reason TEXT,
+        retired_through_sequence INTEGER,
+        first_available_sequence INTEGER,
+        last_sequence INTEGER
+      );
+      INSERT INTO run_journal_bindings(
+        run_id, epoch, source_path, gap_reason,
+        retired_through_sequence, first_available_sequence, last_sequence
+      ) VALUES (
+        'run-1', 1, '/rollout/retired.jsonl', 'retention', 10, NULL, 10
+      );
+    `);
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 0, 100);
+
+    expect(replay.events).toEqual([]);
+    expect(replay.nextAfterSequence).toBe(0);
+    expect(replay.lastAvailableSequence).toBe(10);
+    expect(replay.gap).toEqual({
+      kind: "event_gap",
+      runId: "run-1",
+      afterSequence: 0,
+      firstAvailableSequence: 11,
+      reason: "retention",
+    });
+  });
+
+  it("rejects one event id reused at another sequence across reconnects", () => {
+    const db = database();
+    appendEvent(db, 1, "turn_started", { turnId: "turn-1" }, undefined, "same-id");
+    appendEvent(db, 2, "agent_message", { message: "conflict" }, undefined, "same-id");
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 1, 100);
+
+    expect(replay.events).toEqual([]);
+    expect(replay.nextAfterSequence).toBe(1);
+    expect(replay.gap).toEqual({
+      kind: "event_gap",
+      runId: "run-1",
+      afterSequence: 1,
+      firstAvailableSequence: 2,
+      reason: "corruption_truncated",
+    });
+  });
+
+  it("reports a caller cursor beyond the canonical tail instead of hiding loss", () => {
+    const db = database();
+    appendEvent(db, 1, "turn_started", { turnId: "turn-1" });
+    appendEvent(db, 2, "agent_message", { message: "visible before crash" });
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 4, 100);
+
+    expect(replay.events).toEqual([]);
+    expect(replay.nextAfterSequence).toBe(4);
+    expect(replay.gap).toEqual({
+      kind: "cursor_ahead",
+      runId: "run-1",
+      afterSequence: 4,
+      lastAvailableSequence: 2,
+      reason: "cursor_ahead",
+    });
+  });
+
+  it("reports a nonzero cursor against an empty known journal", () => {
+    const db = database();
+
+    const replay = buildCanonicalRunReplay(db, paths, "run-1", 3, 100);
+
+    expect(replay.gap).toEqual({
+      kind: "cursor_ahead",
+      runId: "run-1",
+      afterSequence: 3,
+      lastAvailableSequence: 0,
+      reason: "cursor_ahead",
+    });
+    expect(replay.nextAfterSequence).toBe(3);
+  });
+});

--- a/runtime/tests/bin/bootstrap-services.test.ts
+++ b/runtime/tests/bin/bootstrap-services.test.ts
@@ -33,6 +33,7 @@ import {
 } from "./bootstrap-services.js";
 import type { ExecutionAdmissionClient } from "../budget/admission-client.js";
 import type { AdmissionJournalEvent } from "../budget/admission-types.js";
+import type { Event } from "../session/event-log.js";
 import type { Session } from "../session/session.js";
 import { normalizeLspServerConfig } from "../services/lsp/config.js";
 import {
@@ -160,6 +161,18 @@ describe("loadBootstrapHooks", () => {
 });
 
 describe("execution admission journal projection", () => {
+  function catchupEvent(sequence: number): AdmissionJournalEvent {
+    return {
+      sequence,
+      eventId: `catchup-${sequence}`,
+      timestamp: "2026-07-18T00:00:00.000Z",
+      runId: "run-catchup",
+      stepId: `model-${sequence}`,
+      kind: "model_turn",
+      event: "queued",
+    };
+  }
+
   test("persists live admission decisions through the session event stream", () => {
     let listener: ((event: AdmissionJournalEvent) => void) | undefined;
     const unsubscribe = vi.fn();
@@ -192,13 +205,181 @@ describe("execution admission journal projection", () => {
 
     expect(emit).toHaveBeenCalledWith(
       {
-        id: "admission-event-1",
+        eventId: "journal-7",
+        id: "journal-7",
         msg: { type: "execution_admission", payload: event },
       },
       { durable: true },
     );
     stop();
     expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test("converges pre-bind and detached admission history without duplicate identities", () => {
+    const history: AdmissionJournalEvent[] = [];
+    let criticalListener: ((event: AdmissionJournalEvent) => void) | undefined;
+    const subscribe = vi.fn(() => () => {});
+    const subscribeCritical = vi.fn(
+      (next: (event: AdmissionJournalEvent) => void) => {
+        criticalListener = next;
+        return () => {
+          criticalListener = undefined;
+        };
+      },
+    );
+    const admission = {
+      subscribe,
+      subscribeCritical,
+      replayJournal: vi.fn(({ afterSequence = 0, limit = 1_000 } = {}) =>
+        history
+          .filter((event) => event.sequence > afterSequence)
+          .slice(0, limit),
+      ),
+    } as unknown as ExecutionAdmissionClient;
+    const rolloutItems: Array<{
+      readonly type: "event_msg";
+      readonly payload: Event;
+    }> = [];
+    const readAll = vi.fn(() => rolloutItems);
+    const syncCanonicalTail = vi.fn();
+    let sequence = 0;
+    const emit = vi.fn((event: Event): Event => {
+      const stamped = { ...event, seq: ++sequence };
+      rolloutItems.push({ type: "event_msg", payload: stamped });
+      return stamped;
+    });
+    const session = {
+      rolloutStore: { readAll, syncCanonicalTail },
+      emit,
+    } as unknown as Session;
+    const admissionEvent = (
+      journalSequence: number,
+    ): AdmissionJournalEvent => ({
+      sequence: journalSequence,
+      eventId: `journal-${journalSequence}`,
+      timestamp: `2026-07-18T00:00:0${journalSequence}.000Z`,
+      runId: "run-1",
+      stepId: `model-${journalSequence}`,
+      kind: "model_turn",
+      event: "reconciled",
+      reservationId: `reservation-${journalSequence}`,
+      actualTokens: journalSequence,
+      actualCostUsd: 0,
+    });
+
+    history.push(admissionEvent(1));
+    const stopFirstBinding = bindExecutionAdmissionJournal(session, admission);
+    history.push(admissionEvent(2));
+    criticalListener?.(history[1]!);
+    stopFirstBinding();
+
+    // Sequence 3 commits while no Session is attached. Rebinding scans the
+    // SQLite journal from the beginning and idempotently fills only the gap.
+    history.push(admissionEvent(3));
+    const stopSecondBinding = bindExecutionAdmissionJournal(session, admission);
+
+    expect(rolloutItems.map((item) => item.payload.eventId)).toEqual([
+      "journal-1",
+      "journal-2",
+      "journal-3",
+    ]);
+    expect(new Set(rolloutItems.map((item) => item.payload.eventId)).size).toBe(
+      3,
+    );
+    expect(emit).toHaveBeenCalledTimes(3);
+    expect(subscribeCritical).toHaveBeenCalledTimes(2);
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(readAll).toHaveBeenCalledOnce();
+    expect(syncCanonicalTail).toHaveBeenCalledTimes(2);
+    stopSecondBinding();
+  });
+
+  test("re-fsyncs matching admission bytes after an ambiguous append failure", () => {
+    const event: AdmissionJournalEvent = {
+      sequence: 1,
+      eventId: "journal-ambiguous",
+      timestamp: "2026-07-18T00:00:01.000Z",
+      runId: "run-ambiguous",
+      stepId: "model-1",
+      kind: "model_turn",
+      event: "queued",
+    };
+    const rolloutItems: Array<{
+      readonly type: "event_msg";
+      readonly payload: Event;
+    }> = [];
+    const syncCanonicalTail = vi.fn();
+    const unsubscribe = vi.fn();
+    const admission = {
+      subscribeCritical: vi.fn(() => unsubscribe),
+      subscribe: vi.fn(() => () => {}),
+      replayJournal: vi.fn(() => [event]),
+    } as unknown as ExecutionAdmissionClient;
+    const session = {
+      rolloutStore: {
+        readAll: () => rolloutItems,
+        syncCanonicalTail,
+      },
+      emit: (candidate: Event): Event => {
+        const stamped = { ...candidate, seq: 1 };
+        rolloutItems.push({ type: "event_msg", payload: stamped });
+        throw new Error("injected post-write fsync ambiguity");
+      },
+    } as unknown as Session;
+
+    const stop = bindExecutionAdmissionJournal(session, admission);
+
+    expect(syncCanonicalTail).toHaveBeenCalledOnce();
+    expect(rolloutItems).toHaveLength(1);
+    stop();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  test("fails closed when a custom catch-up client returns a no-progress page", () => {
+    const repeated = catchupEvent(1);
+    const unsubscribe = vi.fn();
+    const admission = {
+      subscribeCritical: vi.fn(() => unsubscribe),
+      subscribe: vi.fn(() => () => {}),
+      replayJournal: vi.fn(() => Array.from({ length: 1_000 }, () => repeated)),
+    } as unknown as ExecutionAdmissionClient;
+    const emit = vi.fn();
+    const session = { emit } as unknown as Session;
+
+    expect(() => bindExecutionAdmissionJournal(session, admission)).toThrow(
+      "execution admission catch-up made no monotonic progress after sequence 1",
+    );
+    expect(emit).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  test("fails closed when custom admission catch-up exceeds the total work cap", () => {
+    const unsubscribe = vi.fn();
+    const replayJournal = vi.fn(
+      ({ afterSequence = 0 }: { readonly afterSequence?: number } = {}) =>
+        Array.from({ length: 1_000 }, (_, index) =>
+          catchupEvent(afterSequence + index + 1),
+        ),
+    );
+    const admission = {
+      subscribeCritical: vi.fn(() => unsubscribe),
+      subscribe: vi.fn(() => () => {}),
+      replayJournal,
+    } as unknown as ExecutionAdmissionClient;
+    let emitted = 0;
+    const session = {
+      emit: (event: Event): Event => {
+        emitted += 1;
+        return event;
+      },
+    } as unknown as Session;
+
+    expect(() => bindExecutionAdmissionJournal(session, admission)).toThrow(
+      "execution admission catch-up exceeded 100000 events",
+    );
+    expect(emitted).toBe(100_000);
+    expect(replayJournal).toHaveBeenCalledTimes(101);
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 });
 

--- a/runtime/tests/bin/bootstrap.test.ts
+++ b/runtime/tests/bin/bootstrap.test.ts
@@ -30,6 +30,7 @@ import { RolloutStore } from "../session/rollout-store.js";
 import { FileThreadStore } from "../thread-store/store.js";
 import { Session } from "../session/session.js";
 import { buildAgenCToolUseContext } from "../session/agenc-tool-use-context.js";
+import { ExecutionAdmissionKernel } from "../budget/execution-admission-kernel.js";
 import {
   _resetAgentRolesForTesting,
   createAgentRoleWorkspace,
@@ -167,6 +168,19 @@ function rolloutEvent(
       msg: { type, payload },
     },
   } as unknown as RolloutItem;
+}
+
+function nextRolloutEventSequence(rolloutStore: RolloutStore): number {
+  return (
+    Math.max(
+      0,
+      ...rolloutStore.readAll().flatMap((item) =>
+        item.type === "event_msg" && typeof item.payload.seq === "number"
+          ? [item.payload.seq]
+          : [],
+      ),
+    ) + 1
+  );
 }
 
 describe("resolveStartupSelection", () => {
@@ -776,37 +790,43 @@ describe("bootstrapLocalRuntimeSession", () => {
         type: "response_item",
         payload: { role: "user", content: "persisted ask" },
       } as RolloutItem);
+      const firstEventSequence = nextRolloutEventSequence(first.rolloutStore);
       for (const event of [
-        rolloutEvent("turn", "turn_started", { turnId: "turn-1" }, 1),
+        rolloutEvent(
+          "turn",
+          "turn_started",
+          { turnId: "turn-1" },
+          firstEventSequence,
+        ),
         rolloutEvent(
           "thinking-start",
           "assistant_thinking_block_start",
           { index: 0, redacted: false, kind: "thinking" },
-          2,
+          firstEventSequence + 1,
         ),
         rolloutEvent(
           "thinking-delta",
           "assistant_thinking_delta",
           { index: 0, delta: "visible reasoning", kind: "thinking" },
-          3,
+          firstEventSequence + 2,
         ),
         rolloutEvent(
           "thinking-stop",
           "assistant_thinking_block_stop",
           { index: 0, kind: "thinking" },
-          4,
+          firstEventSequence + 3,
         ),
         rolloutEvent(
           "thinking-final",
           "agent_thinking",
           { text: "visible reasoning", redacted: false, kind: "thinking" },
-          5,
+          firstEventSequence + 4,
         ),
         rolloutEvent(
           "complete",
           "turn_complete",
           { turnId: "turn-1", lastAgentMessage: "done" },
-          6,
+          firstEventSequence + 5,
         ),
       ]) {
         first.rolloutStore.appendRollout(event);
@@ -938,6 +958,143 @@ describe("bootstrapLocalRuntimeSession", () => {
     }
   });
 
+  it("mounts and seeds a resumed rollout before replaying detached admission evidence", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agenc-bootstrap-home-"));
+    const workspace = await mkdtemp(join(tmpdir(), "agenc-bootstrap-ws-"));
+    const conversationId = "conv-resume-admission-catchup";
+    const admissionKernel = new ExecutionAdmissionKernel({ agencHome: home });
+
+    const providerMod = await import("../llm/provider.js");
+    vi.spyOn(providerMod, "createProvider").mockImplementation(
+      () =>
+        ({
+          name: "stub",
+          chat: async () => ({
+            content: "ok",
+            toolCalls: [],
+            usage: {
+              promptTokens: 1,
+              completionTokens: 1,
+              totalTokens: 2,
+            },
+          }),
+        }) as never,
+    );
+    vi.spyOn(Session.prototype, "startMcpManager").mockResolvedValue(undefined);
+
+    let firstShutdown: (() => Promise<void>) | null = null;
+    let resumedShutdown: (() => Promise<void>) | null = null;
+    try {
+      const first = await bootstrapLocalRuntimeSession({
+        apiKey: "test-key",
+        conversationId,
+        resumeConversation: false,
+        executionAdmissionKernel: admissionKernel,
+        env: {
+          ...process.env,
+          AGENC_HOME: home,
+          AGENC_WORKSPACE: workspace,
+          HOME: home,
+        },
+      });
+      firstShutdown = first.shutdown;
+      const firstAdmission = first.session.services.executionAdmission;
+      expect(firstAdmission).toBeDefined();
+      const lease = await firstAdmission!.acquire({
+        stepId: "detached-fallback",
+        kind: "model_turn",
+        model: "grok-4.3",
+        provider: "grok",
+        maxInputTokens: 1,
+        maxOutputTokens: 1,
+        maxCostUsd: 0,
+      });
+      firstAdmission!.void(
+        lease.reservation.reservationId,
+        "prepare detached fallback fixture",
+      );
+
+      const maxSequenceBeforeDetach = Math.max(
+        0,
+        ...first.rolloutStore.readAll().flatMap((item) =>
+          item.type === "event_msg" && typeof item.payload.seq === "number"
+            ? [item.payload.seq]
+            : [],
+        ),
+      );
+      await first.shutdown();
+      firstShutdown = null;
+
+      // This SQLite-authoritative decision lands while no Session is bound.
+      // A production resume must catch it up only after mounting the real
+      // rollout and restoring its canonical sequence/identity coordinates.
+      firstAdmission!.recordFallback({
+        stepId: "detached-fallback",
+        fromModel: "grok-4.3",
+        toModel: "grok-4.5",
+        reason: "resume regression fixture",
+      });
+      const detachedAdmissions = admissionKernel
+        .listJournal({ cwd: workspace, runId: conversationId })
+        .filter((event) => event.event === "fallback");
+      expect(detachedAdmissions).toHaveLength(1);
+      const detachedAdmission = detachedAdmissions[0]!;
+
+      const resumed = await bootstrapLocalRuntimeSession({
+        apiKey: "test-key",
+        conversationId,
+        executionAdmissionKernel: admissionKernel,
+        env: {
+          ...process.env,
+          AGENC_HOME: home,
+          AGENC_WORKSPACE: workspace,
+          HOME: home,
+        },
+      });
+      resumedShutdown = resumed.shutdown;
+
+      const admissionEvents = resumed.rolloutStore
+        .readAll()
+        .flatMap((item) =>
+          item.type === "event_msg" &&
+          item.payload.msg.type === "execution_admission"
+            ? [item.payload]
+            : [],
+        )
+        .filter((event) => event.eventId === detachedAdmission.eventId);
+      expect(admissionEvents).toHaveLength(1);
+      expect(admissionEvents[0]).toMatchObject({
+        eventId: admissionEvents[0]!.msg.payload.eventId,
+        seq: expect.any(Number),
+        msg: {
+          type: "execution_admission",
+          payload: { event: "fallback" },
+        },
+      });
+      expect(admissionEvents[0]!.seq).toBeGreaterThan(maxSequenceBeforeDetach);
+
+      const canonicalEvents = resumed.rolloutStore
+        .readAll()
+        .flatMap((item) => (item.type === "event_msg" ? [item.payload] : []));
+      expect(new Set(canonicalEvents.map((event) => event.seq)).size).toBe(
+        canonicalEvents.length,
+      );
+      expect(
+        new Set(canonicalEvents.map((event) => event.eventId)).size,
+      ).toBe(canonicalEvents.length);
+    } finally {
+      await resumedShutdown?.().catch(() => {
+        /* best effort */
+      });
+      await firstShutdown?.().catch(() => {
+        /* best effort */
+      });
+      admissionKernel.close();
+      await rm(home, { recursive: true, force: true });
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it("replays streamed tool input events into resumed transcript state", async () => {
     const home = await mkdtemp(join(tmpdir(), "agenc-bootstrap-home-"));
     const workspace = await mkdtemp(join(tmpdir(), "agenc-bootstrap-ws-"));
@@ -976,13 +1133,14 @@ describe("bootstrapLocalRuntimeSession", () => {
         },
       });
       firstShutdown = first.shutdown;
+      const firstEventSequence = nextRolloutEventSequence(first.rolloutStore);
 
       first.rolloutStore.appendRollout(
         rolloutEvent(
           "tool-input-delta",
           "tool_input_delta",
           { index: 0, partialJson: '{"path":"src/partial' },
-          1,
+          firstEventSequence,
         ),
       );
       first.rolloutStore.appendRollout(
@@ -1000,7 +1158,7 @@ describe("bootstrapLocalRuntimeSession", () => {
               input: {},
             },
           },
-          2,
+          firstEventSequence + 1,
         ),
       );
       first.rolloutStore.flushDurable();
@@ -1095,6 +1253,7 @@ describe("bootstrapLocalRuntimeSession", () => {
         },
       });
       firstShutdown = first.shutdown;
+      const firstEventSequence = nextRolloutEventSequence(first.rolloutStore);
 
       first.rolloutStore.appendRollout(
         rolloutEvent(
@@ -1106,7 +1265,7 @@ describe("bootstrapLocalRuntimeSession", () => {
             toolName: "lookup",
             args: JSON.stringify({ query: "runtime" }),
           },
-          1,
+          firstEventSequence,
         ),
       );
       first.rolloutStore.appendRollout(
@@ -1119,7 +1278,7 @@ describe("bootstrapLocalRuntimeSession", () => {
             result: "lookup result",
             durationMs: 12,
           },
-          2,
+          firstEventSequence + 1,
         ),
       );
       first.rolloutStore.flushDurable();
@@ -1225,6 +1384,7 @@ describe("bootstrapLocalRuntimeSession", () => {
         },
       });
       firstShutdown = first.shutdown;
+      const firstEventSequence = nextRolloutEventSequence(first.rolloutStore);
 
       first.rolloutStore.appendRollout(
         rolloutEvent(
@@ -1241,7 +1401,7 @@ describe("bootstrapLocalRuntimeSession", () => {
             model: "gpt-5.4",
             provider: "openai",
           },
-          1,
+          firstEventSequence,
         ),
       );
       first.rolloutStore.flushDurable();

--- a/runtime/tests/budget/admitted-boundaries.integration.test.ts
+++ b/runtime/tests/budget/admitted-boundaries.integration.test.ts
@@ -17,6 +17,7 @@ import type {
   LLMResponse,
 } from "../../src/llm/types.js";
 import type { Session } from "../../src/session/session.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
 import type { Tool } from "../../src/tools/types.js";
 
 let agencHome = "";
@@ -62,8 +63,12 @@ function sessionFor(
   executionAdmission: ExecutionAdmissionClient,
   overrides: Partial<Session> = {},
 ): Session {
+  const eventLog = new EventLog();
   return {
     conversationId: executionAdmission.scope.sessionId,
+    eventLog,
+    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
+    emit: (event: Event) => eventLog.emit(event),
     services: {
       executionAdmission,
       admissionRequired: true,

--- a/runtime/tests/budget/admitted-legacy-canonical-tool.test.ts
+++ b/runtime/tests/budget/admitted-legacy-canonical-tool.test.ts
@@ -11,6 +11,7 @@ import {
   runWithCurrentRuntimeSession,
 } from "../../src/session/current-session.js";
 import type { Session } from "../../src/session/session.js";
+import { createTestEffectJournal } from "../helpers/test-effect-journal.js";
 import {
   attachToolRuntimeContext,
   type ToolRuntimeAttemptContext,
@@ -78,10 +79,11 @@ function admissionHarness(signal = new AbortController().signal) {
     forSession: vi.fn(),
     subscribe: vi.fn(() => () => {}),
   } as unknown as ExecutionAdmissionClient;
+  const effectJournal = createTestEffectJournal();
   const session = {
+    ...effectJournal,
     conversationId: "session-legacy",
     activeTurn: { unsafePeek: () => ({ turnId: "turn-legacy" }) },
-    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
     services: {
       executionAdmission: admission,
       admissionRequired: true,

--- a/runtime/tests/budget/admitted-legacy-powershell.test.ts
+++ b/runtime/tests/budget/admitted-legacy-powershell.test.ts
@@ -14,6 +14,7 @@ import {
   runWithCurrentRuntimeSession,
 } from "../../src/session/current-session.js";
 import type { Session } from "../../src/session/session.js";
+import { createTestEffectJournal } from "../helpers/test-effect-journal.js";
 import { getEmptyToolPermissionContext } from "../../src/tools/Tool.js";
 
 const shellProbe = vi.hoisted(() => ({
@@ -91,10 +92,11 @@ function admissionHarness(signal = new AbortController().signal) {
     forSession: vi.fn(),
     subscribe: vi.fn(() => () => {}),
   } as unknown as ExecutionAdmissionClient;
+  const effectJournal = createTestEffectJournal();
   const session = {
+    ...effectJournal,
     conversationId: "session-powershell",
     activeTurn: { unsafePeek: () => ({ turnId: "turn-powershell" }) },
-    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
     services: {
       executionAdmission: admission,
       admissionRequired: true,

--- a/runtime/tests/budget/admitted-tool-call.test.ts
+++ b/runtime/tests/budget/admitted-tool-call.test.ts
@@ -7,6 +7,7 @@ import type {
 import { AdmissionDeniedError } from "../../src/budget/admission-client.js";
 import type { AdmissionLease } from "../../src/budget/admission-types.js";
 import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
 import type { Session } from "../../src/session/session.js";
 import type { Tool } from "../../src/tools/types.js";
 
@@ -61,8 +62,14 @@ function toolHarness() {
     forSession: vi.fn(),
     subscribe: vi.fn(() => () => {}),
   } as unknown as ExecutionAdmissionClient;
+  const effectEvents: Event[] = [];
+  const eventLog = new EventLog();
+  eventLog.subscribe((event) => effectEvents.push(event));
   const session = {
     conversationId: "session-1",
+    eventLog,
+    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
+    emit: (event: Event) => eventLog.emit(event),
     services: {
       executionAdmission: admission,
       admissionRequired: true,
@@ -73,6 +80,7 @@ function toolHarness() {
   return {
     acknowledgeCompletion,
     acquire,
+    effectEvents,
     holdUnknown,
     leaseController,
     reconcile,
@@ -81,6 +89,32 @@ function toolHarness() {
 }
 
 describe("runAdmittedToolCall", () => {
+  it("fails closed before tool dispatch when the canonical effect journal is detached", async () => {
+    const state = toolHarness();
+    Object.assign(state.session, { rolloutStore: null });
+    const invoke = vi.fn(async () => ({ content: "must not run" }));
+    const tool = {
+      name: "write.without-journal",
+      recoveryCategory: "side-effecting",
+    } as unknown as Tool;
+
+    await expect(
+      runAdmittedToolCall({
+        session: state.session,
+        turnId: "turn-1",
+        callId: "call-no-journal",
+        tool,
+        args: {},
+        invoke,
+      }),
+    ).rejects.toMatchObject({
+      name: "AdmissionDeniedError",
+      reason: "effect_journal_unavailable",
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(state.acquire).toHaveBeenCalledOnce();
+  });
+
   it("forwards live lease cancellation into the running tool", async () => {
     const leaseController = new AbortController();
     const holdUnknown = vi.fn();
@@ -128,8 +162,14 @@ describe("runAdmittedToolCall", () => {
       forSession: vi.fn(),
       subscribe: vi.fn(() => () => {}),
     } as unknown as ExecutionAdmissionClient;
+    const effectEvents: Event[] = [];
+    const eventLog = new EventLog();
+    eventLog.subscribe((event) => effectEvents.push(event));
     const session = {
       conversationId: "session-1",
+      eventLog,
+      rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
+      emit: (event: Event) => eventLog.emit(event),
       services: {
         executionAdmission: admission,
         admissionRequired: true,
@@ -171,6 +211,10 @@ describe("runAdmittedToolCall", () => {
     );
     expect(acknowledgeCompletion).toHaveBeenCalledOnce();
     expect(acknowledgeCompletion).toHaveBeenCalledWith("tool-reservation");
+    expect(effectEvents.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "effect_unknown_outcome",
+    ]);
   });
 
   it("rejects a late tool success after durable cancellation", async () => {
@@ -223,6 +267,10 @@ describe("runAdmittedToolCall", () => {
       costUsd: 0.25,
     });
     expect(state.acknowledgeCompletion).toHaveBeenCalledOnce();
+    expect(state.effectEvents.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "effect_result",
+    ]);
   });
 
   it("reconciles authoritative charged-tool usage", async () => {
@@ -312,5 +360,128 @@ describe("runAdmittedToolCall", () => {
       "tool-reservation",
       "missing_tool_usage",
     );
+  });
+
+  it("gives only idempotent effects a stable durable key", async () => {
+    const state = toolHarness();
+    const tool = {
+      name: "read.stable",
+      recoveryCategory: "idempotent",
+      admissionEstimate: () => ({
+        maxInputTokens: 0,
+        maxOutputTokens: 0,
+        maxCostUsd: 0,
+      }),
+    } as unknown as Tool;
+    const invoke = async () => ({ content: "same result" });
+
+    await runAdmittedToolCall({
+      session: state.session,
+      turnId: "turn-1",
+      callId: "call-stable",
+      tool,
+      args: { nested: { b: 2, a: 1 } },
+      invoke,
+    });
+    await runAdmittedToolCall({
+      session: state.session,
+      turnId: "turn-1",
+      callId: "call-stable",
+      tool,
+      args: { nested: { a: 1, b: 2 } },
+      invoke,
+    });
+
+    const intents = state.effectEvents.filter(
+      (event) => event.msg.type === "effect_intent",
+    );
+    expect(intents).toHaveLength(2);
+    if (
+      intents[0]?.msg.type !== "effect_intent" ||
+      intents[1]?.msg.type !== "effect_intent"
+    ) {
+      throw new Error("missing effect intent events");
+    }
+    expect(intents[0].msg.payload.idempotencyKey).toMatch(
+      /^sha256:[a-f0-9]{64}$/,
+    );
+    expect(intents[1].msg.payload.idempotencyKey).toBe(
+      intents[0].msg.payload.idempotencyKey,
+    );
+    expect(intents[1].msg.payload.intentDigest).toBe(
+      intents[0].msg.payload.intentDigest,
+    );
+    expect(intents[1].id).not.toBe(intents[0].id);
+    expect(intents[1].seq).toBeGreaterThan(intents[0].seq!);
+  });
+
+  it("records an unacknowledged non-idempotent exception as unknown", async () => {
+    const state = toolHarness();
+    const tool = {
+      name: "write.unacknowledged-failure",
+      recoveryCategory: "side-effecting",
+      admissionEstimate: () => ({
+        maxInputTokens: 0,
+        maxOutputTokens: 0,
+        maxCostUsd: 0,
+      }),
+    } as unknown as Tool;
+
+    await expect(
+      runAdmittedToolCall({
+        session: state.session,
+        turnId: "turn-1",
+        callId: "call-unacknowledged-failure",
+        tool,
+        args: {},
+        invoke: async () => {
+          throw Object.assign(new Error("lost acknowledgement"), {
+            code: "EIO",
+          });
+        },
+      }),
+    ).rejects.toThrow("lost acknowledgement");
+
+    const acknowledgement = state.effectEvents.at(-1);
+    expect(acknowledgement?.msg.type).toBe("effect_unknown_outcome");
+    if (acknowledgement?.msg.type !== "effect_unknown_outcome") {
+      throw new Error("missing unknown effect outcome");
+    }
+    expect(acknowledgement.msg.payload).toMatchObject({
+      outcome: "unknown_outcome",
+      reason: "tool_failed_after_dispatch_without_acknowledgement",
+      requiresReview: true,
+    });
+  });
+
+  it("records an explicit error result as a proven failed outcome", async () => {
+    const state = toolHarness();
+    const tool = {
+      name: "write.known-failure",
+      recoveryCategory: "side-effecting",
+      admissionEstimate: () => ({
+        maxInputTokens: 0,
+        maxOutputTokens: 0,
+        maxCostUsd: 0,
+      }),
+    } as unknown as Tool;
+
+    await expect(
+      runAdmittedToolCall({
+        session: state.session,
+        turnId: "turn-1",
+        callId: "call-known-failure",
+        tool,
+        args: {},
+        invoke: async () => ({ content: "known failure", isError: true }),
+      }),
+    ).resolves.toMatchObject({ content: "known failure", isError: true });
+
+    const acknowledgement = state.effectEvents.at(-1);
+    expect(acknowledgement?.msg.type).toBe("effect_result");
+    if (acknowledgement?.msg.type !== "effect_result") {
+      throw new Error("missing effect result");
+    }
+    expect(acknowledgement.msg.payload.outcome).toBe("failed");
   });
 });

--- a/runtime/tests/budget/execution-admission-kernel.test.ts
+++ b/runtime/tests/budget/execution-admission-kernel.test.ts
@@ -152,6 +152,39 @@ function waitForAbort(signal: AbortSignal): Promise<unknown> {
 }
 
 describe("ExecutionAdmissionKernel recovery", () => {
+  it("stops admission work when canonical journal projection fails and retries the same evidence", async () => {
+    const value = kernel("critical-projection");
+    const client = bind(value, "critical-run");
+    const projectedSequences: number[] = [];
+    let rejectProjection = true;
+    const unsubscribe = client.subscribeCritical?.((event) => {
+      projectedSequences.push(event.sequence);
+      if (rejectProjection) throw new Error("canonical projection unavailable");
+    });
+
+    expect(() => acquire(client)).toThrow("canonical projection unavailable");
+    expect(value.activeCount).toBe(0);
+    expect(
+      value
+        .listJournal({ cwd, runId: "critical-run" })
+        .map((event) => event.event),
+    ).toEqual(["queued"]);
+
+    // The workspace cursor stays on the failed record. Once projection is
+    // available, retrying the same step replays that exact journal sequence
+    // before a reservation can become active.
+    rejectProjection = false;
+    const lease = await acquire(client);
+    expect(projectedSequences[1]).toBe(projectedSequences[0]);
+    expect(lease.request.step.stepId).toBe("step-1");
+    client.reconcile(lease.reservation.reservationId, {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    unsubscribe?.();
+  });
+
   it("ages an old low-priority row ahead of fresh high-priority work", async () => {
     await leaveDetachedQueues(["aged-low", "fresh-high"]);
     let clock = new Date();
@@ -285,9 +318,7 @@ describe("ExecutionAdmissionKernel recovery", () => {
     const allowed = after
       .listJournal({ cwd })
       .filter((event) => event.event === "allowed")
-      .filter((event) =>
-        ["recovered-run", "fresh-run"].includes(event.runId),
-      );
+      .filter((event) => ["recovered-run", "fresh-run"].includes(event.runId));
     expect(allowed.map((event) => event.runId)).toEqual([
       "fresh-run",
       "recovered-run",
@@ -390,9 +421,7 @@ describe("ExecutionAdmissionKernel recovery", () => {
     before.close();
     const closed = await Promise.all(beforeOutcomes);
     expect(closed.filter((result) => result.kind === "lease")).toHaveLength(4);
-    expect(closed.filter((result) => result.kind === "error")).toHaveLength(
-      96,
-    );
+    expect(closed.filter((result) => result.kind === "error")).toHaveLength(96);
 
     const after = kernel("fanout-after", fanoutLimits);
     expect(after.initializeExistingState()).toMatchObject({
@@ -569,6 +598,55 @@ describe("ExecutionAdmissionKernel active cancellation", () => {
     expect(value.activeCount).toBe(0);
   });
 
+  it("cancels admissions synchronously without advancing the agent-run projection", async () => {
+    const seededAt = "2026-07-18T12:00:00.000Z";
+    const setup = openStateDatabases({ cwd, agencHome: home });
+    try {
+      upsertAgentRun(setup, {
+        id: "two-phase-root",
+        objective: "remain running until terminal",
+        status: "running",
+        startedAt: seededAt,
+        lastActiveAt: seededAt,
+        currentSessionId: "two-phase-root",
+      });
+    } finally {
+      setup.close();
+    }
+    const value = kernel("two-phase-cancel");
+    const client = bind(value, "two-phase-root");
+    const lease = await acquire(client);
+    client.markDispatched(lease.reservation.reservationId, {
+      boundary: "provider_wire",
+    });
+    const projected: string[] = [];
+    const unsubscribe = client.subscribeCritical?.((event) => {
+      projected.push(event.event);
+    });
+
+    const result = client.cancelAdmissions!("operator_cancel");
+
+    expect(result).toMatchObject({
+      affectedRunIds: ["two-phase-root"],
+      heldUnknownReservations: 1,
+    });
+    expect(projected).toEqual(["held_unknown", "cancelled"]);
+    const inspect = openStateDatabases({ cwd, agencHome: home });
+    try {
+      expect(
+        inspect
+          .prepareState<[string], { readonly status: string }>(
+            "SELECT status FROM agent_runs WHERE id = ?",
+          )
+          .get("two-phase-root")?.status,
+      ).toBe("running");
+    } finally {
+      inspect.close();
+    }
+    unsubscribe?.();
+    client.acknowledgeCompletion(lease.reservation.reservationId);
+  });
+
   it("rolls provider-overrun accounting back when the canonical cascade fails", async () => {
     const seededAt = "2026-07-18T12:00:00.000Z";
     const setup = openStateDatabases({ cwd, agencHome: home });
@@ -606,14 +684,16 @@ describe("ExecutionAdmissionKernel active cancellation", () => {
 
     const inspection = openStateDatabases({ cwd, agencHome: home });
     try {
-      inspection.prepareState(
-        `CREATE TRIGGER reject_provider_overrun_cascade
+      inspection
+        .prepareState(
+          `CREATE TRIGGER reject_provider_overrun_cascade
          BEFORE UPDATE OF status ON agent_runs
          WHEN NEW.status = 'cancelled' AND OLD.status <> 'cancelled'
          BEGIN
            SELECT RAISE(ABORT, 'fault-injected canonical cascade failure');
          END`,
-      ).run();
+        )
+        .run();
 
       expect(() =>
         client.reconcile(lease.reservation.reservationId, {
@@ -821,13 +901,7 @@ describe("ExecutionAdmissionKernel active cancellation", () => {
       value
         .listJournal({ cwd, runId: "active-abort-run" })
         .map((event) => event.event),
-    ).toEqual([
-      "queued",
-      "allowed",
-      "dispatched",
-      "held_unknown",
-      "cancelled",
-    ]);
+    ).toEqual(["queued", "allowed", "dispatched", "held_unknown", "cancelled"]);
 
     let followUpSettled = false;
     const followUpPending = acquire(client, "follow-up-turn").finally(() => {
@@ -922,7 +996,7 @@ describe("ExecutionAdmissionKernel active cancellation", () => {
     expect(
       value
         .listJournal({ cwd, runId: "dispatch-deadline-race" })
-      .map((event) => event.event),
+        .map((event) => event.event),
     ).toEqual(["queued", "allowed", "voided", "cancelled"]);
     client.acknowledgeCompletion(lease.reservation.reservationId);
     expect(value.activeCount).toBe(0);
@@ -1013,13 +1087,7 @@ describe("ExecutionAdmissionKernel active cancellation", () => {
       value
         .listJournal({ cwd, runId: "long-deadline-run" })
         .map((event) => event.event),
-    ).toEqual([
-      "queued",
-      "allowed",
-      "dispatched",
-      "held_unknown",
-      "cancelled",
-    ]);
+    ).toEqual(["queued", "allowed", "dispatched", "held_unknown", "cancelled"]);
   });
 
   it("rolls daily budget scopes for a long-lived client at UTC midnight", async () => {

--- a/runtime/tests/durability/artifact-journal-recovery.test.ts
+++ b/runtime/tests/durability/artifact-journal-recovery.test.ts
@@ -1,0 +1,556 @@
+import { createHash } from "node:crypto";
+import {
+  fsyncSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getOriginalCwd,
+  getSessionId,
+  setOriginalCwd,
+  switchSession,
+} from "../../src/bootstrap/state.js";
+import {
+  __setAtomicArtifactOperationForTesting,
+  AtomicArtifactUnsafePathError,
+  commitArtifactAtomically,
+} from "../../src/durability/atomic-artifact.js";
+import {
+  EventLog,
+  type ArtifactIntentEvent,
+  type Event,
+} from "../../src/session/event-log.js";
+import { runWithCurrentRuntimeSession } from "../../src/session/current-session.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import type { Session } from "../../src/session/session.js";
+import { asSessionId } from "../../src/types/ids.js";
+import {
+  getToolResultPath,
+  getToolResultsDir,
+  persistToolResult,
+} from "../../src/utils/toolResultStorage.js";
+
+const OPENED_AT = "2026-07-18T00:00:00.000Z";
+const HAS_DESCRIPTOR_CHILD_PATHS =
+  process.platform === "linux" || process.platform === "darwin";
+const created: string[] = [];
+let previousAgencHome: string | undefined;
+let previousCwd: string;
+let previousSessionId: ReturnType<typeof getSessionId>;
+
+beforeEach(() => {
+  previousAgencHome = process.env.AGENC_HOME;
+  previousCwd = getOriginalCwd();
+  previousSessionId = getSessionId();
+});
+
+afterEach(() => {
+  __setAtomicArtifactOperationForTesting(undefined);
+  if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+  else process.env.AGENC_HOME = previousAgencHome;
+  setOriginalCwd(previousCwd);
+  switchSession(previousSessionId);
+  for (const path of created.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function workspace(runId: string): { cwd: string; rollout: RolloutStore } {
+  const cwd = mkdtempSync(join(tmpdir(), "agenc-m4-artifact-journal-"));
+  created.push(cwd);
+  process.env.AGENC_HOME = join(cwd, ".agenc-home");
+  setOriginalCwd(cwd);
+  switchSession(asSessionId(runId));
+  return { cwd, rollout: openStore(cwd, runId) };
+}
+
+function openStore(cwd: string, runId: string, resume = false): RolloutStore {
+  const rollout = new RolloutStore({
+    cwd,
+    sessionId: runId,
+    agencVersion: "0.6.2",
+    autoStartScheduler: false,
+    ...(resume ? { resume: true } : {}),
+  });
+  rollout.open({
+    sessionId: runId,
+    timestamp: OPENED_AT,
+    cwd,
+    originator: "m4-artifact-journal-test",
+    agencVersion: "0.6.2",
+  });
+  return rollout;
+}
+
+function sessionFor(rollout: RolloutStore): Session {
+  const eventLog = new EventLog();
+  return {
+    conversationId: rollout.sessionId,
+    rolloutStore: rollout,
+    eventLog,
+    emit(event: Event): Event {
+      const stamped = eventLog.stamp(event);
+      if (!rollout.append(stamped, { durable: true })) {
+        throw new Error("test journal append failed");
+      }
+      eventLog.publish(stamped);
+      return stamped;
+    },
+  } as unknown as Session;
+}
+
+function artifactEvents(rollout: RolloutStore): Event[] {
+  return rollout
+    .readAll()
+    .filter((item) => item.type === "event_msg")
+    .map((item) => item.payload);
+}
+
+function intentPayload(
+  runId: string,
+  targetPath: string,
+  content: string,
+): ArtifactIntentEvent {
+  const bytes = Buffer.from(content, "utf8");
+  return {
+    runId,
+    artifactId: `artifact-${runId}`,
+    kind: "tool_result",
+    sourceCallId: "call-1",
+    targetPath,
+    contentSha256: createHash("sha256").update(bytes).digest("hex"),
+    byteLength: bytes.byteLength,
+    recordedAt: OPENED_AT,
+  };
+}
+
+async function publishArtifact(
+  targetPath: string,
+  content: string,
+): Promise<void> {
+  const trustedRoot = dirname(targetPath);
+  mkdirSync(trustedRoot, { recursive: true });
+  await commitArtifactAtomically(targetPath, content, { trustedRoot });
+}
+
+describe("M4 artifact journal recovery", () => {
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "journals immutable tool-result intent before publication and acknowledgement after it",
+    async () => {
+      const runId = "run-artifact-normal";
+      const { rollout } = workspace(runId);
+      const session = sessionFor(rollout);
+
+      const result = await runWithCurrentRuntimeSession(session, () =>
+        persistToolResult("durable bytes", "call-normal"),
+      );
+      expect(result).not.toHaveProperty("error");
+      let retryTailSyncs = 0;
+      rollout.store.setFsyncImplForTest((fd) => {
+        retryTailSyncs += 1;
+        fsyncSync(fd);
+      });
+      const replay = await runWithCurrentRuntimeSession(session, () =>
+        persistToolResult("durable bytes", "call-normal"),
+      );
+      expect(replay).toEqual(result);
+      expect(retryTailSyncs).toBe(2);
+      rollout.store.setFsyncImplForTest(fsyncSync);
+      const events = artifactEvents(rollout);
+      expect(events.map((event) => event.msg.type)).toEqual([
+        "artifact_intent",
+        "artifact_committed",
+      ]);
+      expect(events.map((event) => event.eventId)).toEqual(
+        events.map((event) => event.id),
+      );
+      expect(events[1]).toMatchObject({
+        id:
+          events[0]?.msg.type === "artifact_intent"
+            ? `artifact-committed:${events[0].msg.payload.artifactId}`
+            : "missing-artifact-intent",
+        msg: {
+          payload: {
+            intentEventSeq: events[0]!.seq,
+            outcome: "committed",
+            byteLength: Buffer.byteLength("durable bytes"),
+          },
+        },
+      });
+      expect(
+        readFileSync(getToolResultPath("call-normal", false), "utf8"),
+      ).toBe("durable bytes");
+      rollout.close();
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "keys artifact idempotency by canonical eventId, not reusable correlation id",
+    async () => {
+      const runId = "run-artifact-correlation-collision";
+      const callId = "call-correlation-collision";
+      const { rollout } = workspace(runId);
+      const session = sessionFor(rollout);
+      const artifactId = createHash("sha256")
+        .update(
+          JSON.stringify({
+            version: 1,
+            runId,
+            kind: "tool_result",
+            sourceCallId: callId,
+          }),
+          "utf8",
+        )
+        .digest("hex");
+      session.emit({
+        eventId: "unrelated-intent-canonical",
+        id: `artifact-intent:${artifactId}`,
+        msg: {
+          type: "user_message",
+          payload: { message: "correlation ids are reusable" },
+        },
+      });
+      session.emit({
+        eventId: "unrelated-commit-canonical",
+        id: `artifact-committed:${artifactId}`,
+        msg: {
+          type: "user_message",
+          payload: { message: "correlation ids are reusable" },
+        },
+      });
+
+      const result = await runWithCurrentRuntimeSession(session, () =>
+        persistToolResult("durable bytes", callId),
+      );
+      expect(result).not.toHaveProperty("error");
+      const artifactLifecycle = artifactEvents(rollout).filter(
+        (event) =>
+          event.msg.type === "artifact_intent" ||
+          event.msg.type === "artifact_committed",
+      );
+      expect(artifactLifecycle.map((event) => event.eventId)).toEqual([
+        `artifact-intent:${artifactId}`,
+        `artifact-committed:${artifactId}`,
+      ]);
+      rollout.close();
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "rejects different bytes for the same logical artifact without a second transition",
+    async () => {
+      const runId = "run-artifact-content-conflict";
+      const { rollout } = workspace(runId);
+      const session = sessionFor(rollout);
+
+      const first = await runWithCurrentRuntimeSession(session, () =>
+        persistToolResult("first bytes", "call-conflict"),
+      );
+      expect(first).not.toHaveProperty("error");
+      const conflict = await runWithCurrentRuntimeSession(session, () =>
+        persistToolResult("different bytes", "call-conflict"),
+      );
+
+      expect(conflict).toMatchObject({
+        error: expect.stringContaining("conflicting journal evidence"),
+      });
+      expect(artifactEvents(rollout).map((event) => event.msg.type)).toEqual([
+        "artifact_intent",
+        "artifact_committed",
+      ]);
+      expect(
+        readFileSync(getToolResultPath("call-conflict", false), "utf8"),
+      ).toBe("first bytes");
+      rollout.close();
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "keeps provider-controlled call ids inside the tool-result directory",
+    async () => {
+      const runId = "run-artifact-unsafe-call-id";
+      const { rollout } = workspace(runId);
+      const session = sessionFor(rollout);
+
+      const result = await runWithCurrentRuntimeSession(session, () =>
+        persistToolResult("contained bytes", "../../escaped/tool"),
+      );
+      if ("error" in result) throw new Error(result.error);
+
+      expect(dirname(result.filepath)).toBe(getToolResultsDir());
+      expect(readFileSync(result.filepath, "utf8")).toBe("contained bytes");
+      expect(artifactEvents(rollout)[0]).toMatchObject({
+        msg: {
+          type: "artifact_intent",
+          payload: {
+            sourceCallId: "../../escaped/tool",
+            targetPath: result.filepath,
+          },
+        },
+      });
+      rollout.close();
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "proves a published artifact from bytes when its acknowledgement was lost",
+    async () => {
+      const runId = "run-artifact-recovered";
+      const { cwd, rollout } = workspace(runId);
+      const targetPath = getToolResultPath("call-1", false);
+      const payload = intentPayload(runId, targetPath, "complete bytes");
+      expect(
+        rollout.append(
+          {
+            id: "artifact-intent-1",
+            seq: 1,
+            msg: { type: "artifact_intent", payload },
+          },
+          { durable: true },
+        ),
+      ).toBe(true);
+      await publishArtifact(targetPath, "complete bytes");
+      rollout.close();
+
+      const resumed = openStore(cwd, runId, true);
+      expect(artifactEvents(resumed).at(-1)).toMatchObject({
+        msg: {
+          type: "artifact_committed",
+          payload: {
+            intentEventSeq: 1,
+            outcome: "recovered",
+            contentSha256: payload.contentSha256,
+          },
+        },
+      });
+      resumed.close();
+    },
+  );
+
+  it.runIf(process.platform === "linux" || process.platform === "darwin")(
+    "never journals external matching bytes after the artifact root is swapped",
+    () => {
+      const runId = "run-artifact-observation-root-swap";
+      const { cwd, rollout } = workspace(runId);
+      const targetPath = getToolResultPath("call-1", false);
+      const trustedRoot = dirname(targetPath);
+      const movedRoot = `${trustedRoot}-original`;
+      const externalRoot = join(cwd, "external-artifacts");
+      const content = "external matching bytes";
+      const payload = intentPayload(runId, targetPath, content);
+      const journalPath = rollout.rolloutPath;
+      rollout.append(
+        {
+          eventId: "canonical-artifact-observation-swap",
+          id: "artifact-observation-swap",
+          seq: 1,
+          msg: { type: "artifact_intent", payload },
+        },
+        { durable: true },
+      );
+      mkdirSync(trustedRoot, { recursive: true });
+      mkdirSync(externalRoot, { recursive: true });
+      writeFileSync(join(externalRoot, "call-1.txt"), content);
+      rollout.close();
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "observe") return;
+        renameSync(trustedRoot, movedRoot);
+        symlinkSync(externalRoot, trustedRoot, "dir");
+      });
+
+      expect(() => openStore(cwd, runId, true)).toThrow(
+        AtomicArtifactUnsafePathError,
+      );
+
+      const journal = readFileSync(journalPath, "utf8");
+      expect(journal).not.toContain('\"type\":\"artifact_committed\"');
+      expect(readFileSync(join(externalRoot, "call-1.txt"), "utf8")).toBe(
+        content,
+      );
+    },
+  );
+
+  it("defers a safe retry when publication never happened", () => {
+    const runId = "run-artifact-missing";
+    const { cwd, rollout } = workspace(runId);
+    const payload = intentPayload(
+      runId,
+      getToolResultPath("call-1", false),
+      "not published",
+    );
+    rollout.append(
+      {
+        id: "artifact-intent-missing",
+        seq: 1,
+        msg: { type: "artifact_intent", payload },
+      },
+      { durable: true },
+    );
+    rollout.close();
+
+    const resumed = openStore(cwd, runId, true);
+    expect(artifactEvents(resumed).at(-1)).toMatchObject({
+      msg: {
+        type: "recovery_decision",
+        payload: {
+          decision: "artifact_retry_safe_deferred",
+          evidenceEventSeq: 1,
+        },
+      },
+    });
+    resumed.close();
+  });
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "records a matching commit after an earlier deferred retry decision",
+    async () => {
+      const runId = "run-artifact-deferred-then-published";
+      const { cwd, rollout } = workspace(runId);
+      const targetPath = getToolResultPath("call-1", false);
+      const payload = intentPayload(
+        runId,
+        targetPath,
+        "published on explicit retry",
+      );
+      rollout.append(
+        {
+          eventId: "canonical-artifact-intent-retry",
+          id: "artifact-intent-retry",
+          seq: 1,
+          msg: { type: "artifact_intent", payload },
+        },
+        { durable: true },
+      );
+      rollout.close();
+
+      const deferred = openStore(cwd, runId, true);
+      expect(artifactEvents(deferred).at(-1)).toMatchObject({
+        msg: {
+          type: "recovery_decision",
+          payload: {
+            decision: "artifact_retry_safe_deferred",
+            evidenceEventSeq: 1,
+          },
+        },
+      });
+      deferred.close();
+
+      // An explicit owner safely retries publication, then dies before it can
+      // append artifact_committed. The old deferred decision must not suppress
+      // the newly observable matching target on the next recovery.
+      await publishArtifact(targetPath, "published on explicit retry");
+      const recovered = openStore(cwd, runId, true);
+      const events = artifactEvents(recovered);
+      expect(events.map((event) => event.msg.type)).toEqual([
+        "artifact_intent",
+        "recovery_decision",
+        "artifact_committed",
+      ]);
+      expect(events.at(-1)).toMatchObject({
+        msg: {
+          type: "artifact_committed",
+          payload: {
+            intentEventSeq: 1,
+            outcome: "recovered",
+            contentSha256: payload.contentSha256,
+          },
+        },
+      });
+      recovered.close();
+    },
+  );
+
+  it("allocates one contiguous recovery sequence across artifacts and effects", () => {
+    const runId = "run-artifact-and-effect-recovery";
+    const { cwd, rollout } = workspace(runId);
+    const payload = intentPayload(
+      runId,
+      getToolResultPath("call-artifact", false),
+      "not published",
+    );
+    rollout.append(
+      {
+        id: "artifact-intent-combined",
+        seq: 1,
+        msg: { type: "artifact_intent", payload },
+      },
+      { durable: true },
+    );
+    rollout.append(
+      {
+        id: "effect-intent-combined",
+        seq: 2,
+        msg: {
+          type: "effect_intent",
+          payload: {
+            runId,
+            stepId: "tool:turn-1:call-effect",
+            callId: "call-effect",
+            toolName: "side-effect-test",
+            recoveryCategory: "side-effecting",
+            intentDigest: "sha256:combined-effect",
+            attempt: 1,
+            recordedAt: OPENED_AT,
+          },
+        },
+      },
+      { durable: true },
+    );
+    rollout.close();
+
+    const resumed = openStore(cwd, runId, true);
+    const events = artifactEvents(resumed);
+    expect(events.map((event) => event.seq)).toEqual([1, 2, 3, 4]);
+    expect(events.map((event) => event.msg.type)).toEqual([
+      "artifact_intent",
+      "effect_intent",
+      "recovery_decision",
+      "effect_unknown_outcome",
+    ]);
+    resumed.close();
+
+    const replayed = openStore(cwd, runId, true);
+    expect(artifactEvents(replayed).map((event) => event.seq)).toEqual([
+      1, 2, 3, 4,
+    ]);
+    replayed.close();
+  });
+
+  it("never overwrites mismatched artifact evidence and requires review", () => {
+    const runId = "run-artifact-conflict";
+    const { cwd, rollout } = workspace(runId);
+    const targetPath = getToolResultPath("call-1", false);
+    const payload = intentPayload(runId, targetPath, "expected");
+    rollout.append(
+      {
+        id: "artifact-intent-conflict",
+        seq: 1,
+        msg: { type: "artifact_intent", payload },
+      },
+      { durable: true },
+    );
+    mkdirSync(dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, "different");
+    rollout.close();
+
+    const resumed = openStore(cwd, runId, true);
+    expect(artifactEvents(resumed).at(-1)).toMatchObject({
+      msg: {
+        type: "recovery_decision",
+        payload: { decision: "artifact_conflict_review_required" },
+      },
+    });
+    expect(readFileSync(targetPath, "utf8")).toBe("different");
+    resumed.close();
+  });
+});

--- a/runtime/tests/durability/atomic-artifact.test.ts
+++ b/runtime/tests/durability/atomic-artifact.test.ts
@@ -1,0 +1,450 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  __setAtomicArtifactOperationForTesting,
+  AtomicArtifactConflictError,
+  AtomicArtifactOperationUnsupportedError,
+  AtomicArtifactUnsafePathError,
+  cleanupOrphanedArtifactTemps,
+  cleanupOrphanedArtifactTempsSync,
+  commitArtifactAtomically,
+  withAtomicArtifactObservationSync,
+} from "../../src/durability/atomic-artifact.js";
+import { M4DurabilityFailpointError } from "../../src/durability/failpoints.js";
+
+const FAILPOINT_ENV = "AGENC_TEST_DURABILITY_FAILPOINT";
+const TOKEN_ENV = "AGENC_TEST_DURABILITY_FAILPOINT_TOKEN";
+const ACTION_ENV = "AGENC_TEST_DURABILITY_FAILPOINT_ACTION";
+const HAS_DESCRIPTOR_CHILD_PATHS =
+  process.platform === "linux" || process.platform === "darwin";
+
+describe("atomic artifact commit", () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    __setAtomicArtifactOperationForTesting(undefined);
+    delete process.env[FAILPOINT_ENV];
+    delete process.env[TOKEN_ENV];
+    delete process.env[ACTION_ENV];
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  function target(name = "artifact.txt"): { directory: string; path: string } {
+    const directory = mkdtempSync(join(tmpdir(), "agenc-artifact-"));
+    directories.push(directory);
+    return { directory, path: join(directory, name) };
+  }
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "publishes complete bytes and treats an identical replay as idempotent",
+    async () => {
+      const artifact = target();
+      await expect(
+        commitArtifactAtomically(artifact.path, "complete bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).resolves.toBe("committed");
+      await expect(
+        commitArtifactAtomically(artifact.path, "complete bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).resolves.toBe("already_committed");
+
+      expect(readFileSync(artifact.path, "utf8")).toBe("complete bytes");
+      expect(readdirSync(artifact.directory)).toEqual(["artifact.txt"]);
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "never overwrites immutable evidence with conflicting replay bytes",
+    async () => {
+      const artifact = target();
+      await commitArtifactAtomically(artifact.path, "first", {
+        trustedRoot: artifact.directory,
+      });
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "second", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactConflictError);
+      expect(readFileSync(artifact.path, "utf8")).toBe("first");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlink even when its destination has identical bytes",
+    async () => {
+      const artifact = target();
+      const external = join(artifact.directory, "external.txt");
+      writeFileSync(external, "same bytes");
+      symlinkSync(external, artifact.path);
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "same bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactConflictError);
+      expect(readFileSync(external, "utf8")).toBe("same bytes");
+    },
+  );
+
+  it.runIf(process.platform === "linux" || process.platform === "darwin")(
+    "allows symlinked ancestors above the explicit trusted root",
+    async () => {
+      const physicalContainer = mkdtempSync(
+        join(tmpdir(), "agenc-artifact-physical-"),
+      );
+      const aliasContainer = mkdtempSync(
+        join(tmpdir(), "agenc-artifact-alias-"),
+      );
+      directories.push(physicalContainer, aliasContainer);
+      const physicalRoot = join(physicalContainer, "tool-results");
+      mkdirSync(physicalRoot);
+      const aliasAncestor = join(aliasContainer, "workspace");
+      symlinkSync(physicalContainer, aliasAncestor, "dir");
+      const trustedRoot = join(aliasAncestor, "tool-results");
+      const targetPath = join(trustedRoot, "result.txt");
+
+      await expect(
+        commitArtifactAtomically(targetPath, "complete bytes", { trustedRoot }),
+      ).resolves.toBe("committed");
+      writeFileSync(`${targetPath}.101.orphan.tmp`, "orphan");
+      await expect(
+        cleanupOrphanedArtifactTemps(targetPath, { trustedRoot }),
+      ).resolves.toEqual({ removedCount: 1, truncated: false });
+      writeFileSync(`${targetPath}.102.orphan.tmp`, "orphan");
+      expect(
+        cleanupOrphanedArtifactTempsSync(targetPath, { trustedRoot }),
+      ).toEqual({ removedCount: 1, truncated: false });
+
+      expect(readFileSync(join(physicalRoot, "result.txt"), "utf8")).toBe(
+        "complete bytes",
+      );
+      expect(readdirSync(physicalRoot)).toEqual(["result.txt"]);
+    },
+  );
+
+  it("rejects a target outside the explicit trusted root", async () => {
+    const trusted = target("inside.txt");
+    const outside = target("outside.txt");
+
+    await expect(
+      commitArtifactAtomically(outside.path, "must not publish", {
+        trustedRoot: trusted.directory,
+      }),
+    ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+    await expect(
+      cleanupOrphanedArtifactTemps(outside.path, {
+        trustedRoot: trusted.directory,
+      }),
+    ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+    expect(existsSync(outside.path)).toBe(false);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "refuses to publish through a symlinked parent directory",
+    async () => {
+      const artifact = target();
+      const external = join(artifact.directory, "external");
+      const linkedParent = join(artifact.directory, "tool-results");
+      mkdirSync(external);
+      symlinkSync(external, linkedParent, "dir");
+
+      await expect(
+        commitArtifactAtomically(join(linkedParent, "result.txt"), "bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+      expect(existsSync(join(external, "result.txt"))).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses async orphan cleanup through a symlinked parent directory",
+    async () => {
+      const artifact = target();
+      const external = join(artifact.directory, "external");
+      const linkedParent = join(artifact.directory, "tool-results");
+      mkdirSync(external);
+      symlinkSync(external, linkedParent, "dir");
+      const externalTemp = join(external, "result.txt.101.external.tmp");
+      writeFileSync(externalTemp, "must stay");
+
+      await expect(
+        cleanupOrphanedArtifactTemps(join(linkedParent, "result.txt"), {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+      expect(readFileSync(externalTemp, "utf8")).toBe("must stay");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses synchronous orphan cleanup through a symlinked parent directory",
+    () => {
+      const artifact = target();
+      const external = join(artifact.directory, "external");
+      const linkedParent = join(artifact.directory, "tool-results");
+      mkdirSync(external);
+      symlinkSync(external, linkedParent, "dir");
+      const externalTemp = join(external, "result.txt.102.external.tmp");
+      writeFileSync(externalTemp, "must stay");
+
+      expect(() =>
+        cleanupOrphanedArtifactTempsSync(join(linkedParent, "result.txt"), {
+          trustedRoot: artifact.directory,
+        }),
+      ).toThrow(AtomicArtifactUnsafePathError);
+      expect(readFileSync(externalTemp, "utf8")).toBe("must stay");
+    },
+  );
+
+  it.runIf(process.platform === "linux" || process.platform === "darwin")(
+    "does not publish outside when the pinned root is swapped after validation",
+    async () => {
+      const container = mkdtempSync(
+        join(tmpdir(), "agenc-artifact-commit-swap-"),
+      );
+      directories.push(container);
+      const trustedRoot = join(container, "tool-results");
+      const movedRoot = join(container, "tool-results-original");
+      const outsideRoot = join(container, "outside");
+      mkdirSync(trustedRoot);
+      mkdirSync(outsideRoot);
+      const targetPath = join(trustedRoot, "result.txt");
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "commit") return;
+        renameSync(trustedRoot, movedRoot);
+        symlinkSync(outsideRoot, trustedRoot, "dir");
+      });
+
+      await expect(
+        commitArtifactAtomically(targetPath, "must stay contained", {
+          trustedRoot,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+
+      expect(existsSync(join(outsideRoot, "result.txt"))).toBe(false);
+      expect(readdirSync(movedRoot)).toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform === "linux" || process.platform === "darwin")(
+    "keeps cleanup inside the pinned root when its lexical path is swapped",
+    async () => {
+      const container = mkdtempSync(join(tmpdir(), "agenc-artifact-swap-"));
+      directories.push(container);
+      const trustedRoot = join(container, "tool-results");
+      const movedRoot = join(container, "tool-results-original");
+      const outsideRoot = join(container, "outside");
+      mkdirSync(trustedRoot);
+      mkdirSync(outsideRoot);
+      const targetPath = join(trustedRoot, "result.txt");
+      const tempName = "result.txt.101.orphan.tmp";
+      writeFileSync(join(trustedRoot, tempName), "owned orphan");
+      writeFileSync(join(outsideRoot, tempName), "must stay");
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "cleanup") return;
+        renameSync(trustedRoot, movedRoot);
+        symlinkSync(outsideRoot, trustedRoot, "dir");
+      });
+
+      await expect(
+        cleanupOrphanedArtifactTemps(targetPath, { trustedRoot }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+
+      expect(existsSync(join(movedRoot, tempName))).toBe(false);
+      expect(readFileSync(join(outsideRoot, tempName), "utf8")).toBe(
+        "must stay",
+      );
+    },
+  );
+
+  it.runIf(process.platform === "linux" || process.platform === "darwin")(
+    "never consumes external matching bytes after an observation-root swap",
+    () => {
+      const container = mkdtempSync(
+        join(tmpdir(), "agenc-artifact-observe-swap-"),
+      );
+      directories.push(container);
+      const trustedRoot = join(container, "tool-results");
+      const movedRoot = join(container, "tool-results-original");
+      const outsideRoot = join(container, "outside");
+      mkdirSync(trustedRoot);
+      mkdirSync(outsideRoot);
+      const targetPath = join(trustedRoot, "result.txt");
+      const expected = "external matching bytes";
+      writeFileSync(join(outsideRoot, "result.txt"), expected);
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "observe") return;
+        renameSync(trustedRoot, movedRoot);
+        symlinkSync(outsideRoot, trustedRoot, "dir");
+      });
+      let consumed = false;
+
+      expect(() =>
+        withAtomicArtifactObservationSync(
+          targetPath,
+          createHash("sha256").update(expected).digest("hex"),
+          Buffer.byteLength(expected),
+          { trustedRoot },
+          () => {
+            consumed = true;
+          },
+        ),
+      ).toThrow(AtomicArtifactUnsafePathError);
+
+      expect(consumed).toBe(false);
+      expect(readFileSync(join(outsideRoot, "result.txt"), "utf8")).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "leaves no visible artifact when killed before publication",
+    async () => {
+      const artifact = target();
+      process.env[FAILPOINT_ENV] = "before_artifact_commit";
+      process.env[TOKEN_ENV] = "m4-durability-child";
+      process.env[ACTION_ENV] = "throw";
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(M4DurabilityFailpointError);
+      expect(existsSync(artifact.path)).toBe(false);
+      expect(readdirSync(artifact.directory)).toEqual([]);
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "leaves complete durable bytes when acknowledgement is lost after commit",
+    async () => {
+      const artifact = target();
+      process.env[FAILPOINT_ENV] = "after_artifact_commit";
+      process.env[TOKEN_ENV] = "m4-durability-child";
+      process.env[ACTION_ENV] = "throw";
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(M4DurabilityFailpointError);
+      expect(readFileSync(artifact.path, "utf8")).toBe("bytes");
+      expect(readdirSync(artifact.directory)).toEqual(["artifact.txt"]);
+    },
+  );
+
+  it.runIf(HAS_DESCRIPTOR_CHILD_PATHS)(
+    "runs an identical replay through the durable commit boundary",
+    async () => {
+      const artifact = target();
+      await commitArtifactAtomically(artifact.path, "bytes", {
+        trustedRoot: artifact.directory,
+      });
+      process.env[FAILPOINT_ENV] = "after_artifact_commit";
+      process.env[TOKEN_ENV] = "m4-durability-child";
+      process.env[ACTION_ENV] = "throw";
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "bytes", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(M4DurabilityFailpointError);
+      expect(readFileSync(artifact.path, "utf8")).toBe("bytes");
+      expect(readdirSync(artifact.directory)).toEqual(["artifact.txt"]);
+    },
+  );
+
+  it.runIf(process.platform === "linux" || process.platform === "darwin")(
+    "cleans only bounded regular temp siblings for one exact target",
+    async () => {
+      const artifact = target();
+      const firstTemp = `${artifact.path}.101.first.tmp`;
+      const secondTemp = `${artifact.path}.102.second.tmp`;
+      const siblingTemp = join(
+        artifact.directory,
+        "artifact.txt-other.103.tmp",
+      );
+      const matchingDirectory = `${artifact.path}.104.directory.tmp`;
+      writeFileSync(firstTemp, "orphan one");
+      writeFileSync(secondTemp, "orphan two");
+      writeFileSync(siblingTemp, "must stay");
+      mkdirSync(matchingDirectory);
+
+      await expect(
+        cleanupOrphanedArtifactTemps(artifact.path, {
+          trustedRoot: artifact.directory,
+          maxDeletes: 1,
+        }),
+      ).resolves.toEqual({ removedCount: 1, truncated: true });
+      expect(
+        cleanupOrphanedArtifactTempsSync(artifact.path, {
+          trustedRoot: artifact.directory,
+        }),
+      ).toEqual({
+        removedCount: 1,
+        truncated: false,
+      });
+
+      expect(existsSync(firstTemp) || existsSync(secondTemp)).toBe(false);
+      expect(readFileSync(siblingTemp, "utf8")).toBe("must stay");
+      expect(existsSync(matchingDirectory)).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "fails closed when publication has no descriptor-relative child operations",
+    async () => {
+      const artifact = target();
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "must not publish", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactOperationUnsupportedError);
+      expect(existsSync(artifact.path)).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "fails closed when cleanup has no descriptor-relative child operations",
+    async () => {
+      const artifact = target();
+      writeFileSync(`${artifact.path}.101.orphan.tmp`, "must stay");
+
+      await expect(
+        cleanupOrphanedArtifactTemps(artifact.path, {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactOperationUnsupportedError);
+      expect(() =>
+        cleanupOrphanedArtifactTempsSync(artifact.path, {
+          trustedRoot: artifact.directory,
+        }),
+      ).toThrow(AtomicArtifactOperationUnsupportedError);
+      expect(readFileSync(`${artifact.path}.101.orphan.tmp`, "utf8")).toBe(
+        "must stay",
+      );
+    },
+  );
+});

--- a/runtime/tests/durability/effect-restart-recovery.test.ts
+++ b/runtime/tests/durability/effect-restart-recovery.test.ts
@@ -1,0 +1,1046 @@
+import {
+  appendFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runAgenCStateCli } from "../../src/bin/state-cli.js";
+import { admissionRecordKey } from "../../src/budget/admission-types.js";
+import type { RuntimeAdmissionRequest } from "../../src/budget/admission-types.js";
+import type { Event } from "../../src/session/event-log.js";
+import { serializeRolloutItem } from "../../src/session/rollout-item.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
+import { resolveDurableEffectReview } from "../../src/state/effect-review.js";
+import { recoverDaemonStateOnStartup } from "../../src/state/recovery.js";
+import { recordInFlightToolCallStart } from "../../src/state/tool-output-rotation.js";
+import {
+  openStateDatabasePaths,
+  resolveStateDatabasePaths,
+} from "../../src/state/sqlite-driver.js";
+import { listUnresolvedUnknownOutcomeEffects } from "../../src/state/unknown-outcome-gate.js";
+
+const OPENED_AT = "2026-07-18T00:00:00.000Z";
+const created: string[] = [];
+
+afterEach(() => {
+  for (const path of created.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function workspace(): string {
+  const cwd = mkdtempSync(join(tmpdir(), "agenc-m4-effect-recovery-"));
+  created.push(cwd);
+  return cwd;
+}
+
+function store(cwd: string, runId: string, resume = false): RolloutStore {
+  const rollout = new RolloutStore({
+    cwd,
+    sessionId: runId,
+    agencVersion: "0.6.2",
+    autoStartScheduler: false,
+    ...(resume ? { resume: true } : {}),
+  });
+  rollout.open({
+    sessionId: runId,
+    timestamp: OPENED_AT,
+    cwd,
+    originator: "m4-effect-recovery-test",
+    agencVersion: "0.6.2",
+  });
+  return rollout;
+}
+
+function intent(
+  runId: string,
+  recoveryCategory: "idempotent" | "side-effecting",
+): Event {
+  return {
+    id: `intent-${recoveryCategory}`,
+    seq: 1,
+    msg: {
+      type: "effect_intent",
+      payload: {
+        runId,
+        stepId: "tool:turn-1:call-1",
+        callId: "call-1",
+        toolName: "test-effect",
+        recoveryCategory,
+        ...(recoveryCategory === "idempotent"
+          ? { idempotencyKey: "sha256:safe-retry" }
+          : {}),
+        intentDigest: "intent-digest",
+        attempt: 1,
+        recordedAt: OPENED_AT,
+      },
+    },
+  };
+}
+
+function reserveToolStep(cwd: string, runId: string): void {
+  const paths = resolveStateDatabasePaths({ cwd });
+  const driver = openStateDatabasePaths(paths);
+  try {
+    const admissions = new ExecutionAdmissionRepository(driver, {
+      ownerId: "effect-recovery-test",
+      ownerPid: process.pid,
+    });
+    const request: RuntimeAdmissionRequest = {
+      step: { runId, stepId: "tool:turn-1:call-1" },
+      kind: "tool_exec",
+      estimate: {
+        maxInputTokens: 0,
+        maxOutputTokens: 0,
+        maxCostUsd: 0,
+      },
+      workspaceId: "workspace-test",
+      sessionId: runId,
+      parentScopeId: "turn-1",
+      autonomous: false,
+      budgetScopes: [{ key: `run:${runId}`, maxTokens: 100, maxCostUsd: 1 }],
+    };
+    admissions.enqueue(request);
+    expect(
+      admissions.claim({ key: admissionRecordKey(request.step) }).kind,
+    ).toBe("claimed");
+  } finally {
+    driver.close();
+  }
+}
+
+function recoverAdmissionBeforeRollout(cwd: string): void {
+  const paths = resolveStateDatabasePaths({ cwd });
+  const driver = openStateDatabasePaths(paths);
+  try {
+    new ExecutionAdmissionRepository(driver, {
+      ownerId: "effect-recovery-new-owner",
+      ownerPid: process.pid,
+    }).recover({
+      activeOwnerIds: new Set(),
+      now: "2026-07-18T00:00:30.000Z",
+    });
+  } finally {
+    driver.close();
+  }
+}
+
+describe("M4 effect restart recovery", () => {
+  it("turns a dangling side effect into a journaled review lock without replay", () => {
+    const cwd = workspace();
+    const runId = "run-side-effect";
+    const original = store(cwd, runId);
+    expect(original.append(intent(runId, "side-effecting"), { durable: true })).toBe(
+      true,
+    );
+    original.close();
+
+    const resumed = store(cwd, runId, true);
+    const events = resumed
+      .readAll()
+      .filter((item) => item.type === "event_msg")
+      .map((item) => item.payload);
+    expect(events.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "effect_unknown_outcome",
+    ]);
+    expect(events[1]).toMatchObject({
+      id: "effect-unknown-recovery:legacy-event:1:intent-side-effecting",
+      seq: 2,
+      msg: {
+        payload: {
+          reason: "daemon_recovered_without_effect_acknowledgement",
+          requiresReview: true,
+        },
+      },
+    });
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      const effect = new StateRunDurabilityRepository(driver).getEffect(
+        runId,
+        "tool:turn-1:call-1",
+      );
+      expect(effect).toMatchObject({
+        outcome: "unknown_outcome",
+        reviewStatus: "pending",
+      });
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toMatchObject([
+        { toolCallId: "call-1", toolName: "test-effect" },
+      ]);
+    } finally {
+      driver.close();
+      resumed.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("classifies every dangling intent when correlation ids are reused", () => {
+    const cwd = workspace();
+    const runId = "run-reused-effect-correlation";
+    const original = store(cwd, runId);
+    const effectIntent = (
+      eventId: string,
+      sequence: number,
+      stepId: string,
+      callId: string,
+    ): Event => ({
+      eventId,
+      id: "shared-effect-correlation",
+      seq: sequence,
+      msg: {
+        type: "effect_intent",
+        payload: {
+          runId,
+          stepId,
+          callId,
+          toolName: "test-effect",
+          recoveryCategory: "side-effecting",
+          intentDigest: `digest:${callId}`,
+          attempt: 1,
+          recordedAt: OPENED_AT,
+        },
+      },
+    });
+    original.append(
+      effectIntent("canonical-effect-intent-1", 1, "step-1", "call-1"),
+      { durable: true },
+    );
+    original.append(
+      effectIntent("canonical-effect-intent-2", 2, "step-2", "call-2"),
+      { durable: true },
+    );
+    // Canonical identities are globally unique, but a pre-existing unrelated
+    // event may legitimately occupy the preferred recovery id.
+    original.append(
+      {
+        eventId: "effect-unknown-recovery:canonical-effect-intent-1",
+        id: "another-reusable-correlation",
+        seq: 3,
+        msg: {
+          type: "user_message",
+          payload: { message: "unrelated canonical event" },
+        },
+      },
+      { durable: true },
+    );
+    original.close();
+
+    const resumed = store(cwd, runId, true);
+    const unknowns = resumed
+      .readAll()
+      .filter(
+        (item) =>
+          item.type === "event_msg" &&
+          item.payload.msg.type === "effect_unknown_outcome",
+      )
+      .map((item) => item.payload);
+    expect(unknowns).toHaveLength(2);
+    expect(unknowns.map((event) => event.msg.payload.stepId).sort()).toEqual([
+      "step-1",
+      "step-2",
+    ]);
+    expect(unknowns.map((event) => event.eventId)).toEqual([
+      "effect-unknown-recovery:canonical-effect-intent-1:2",
+      "effect-unknown-recovery:canonical-effect-intent-2",
+    ]);
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(
+        new StateRunDurabilityRepository(driver)
+          .listEffects(runId)
+          .map((effect) => [effect.stepId, effect.outcome]),
+      ).toEqual([
+        ["step-1", "unknown_outcome"],
+        ["step-2", "unknown_outcome"],
+      ]);
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toHaveLength(2);
+    } finally {
+      driver.close();
+      resumed.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("cancels a dangling effect proven not dispatched by its reservation", () => {
+    const cwd = workspace();
+    const runId = "run-before-dispatch";
+    const original = store(cwd, runId);
+    reserveToolStep(cwd, runId);
+    expect(original.append(intent(runId, "side-effecting"), { durable: true })).toBe(
+      true,
+    );
+    original.close();
+
+    const resumed = store(cwd, runId, true);
+    const events = resumed
+      .readAll()
+      .filter((item) => item.type === "event_msg")
+      .map((item) => item.payload);
+    expect(events.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "effect_result",
+    ]);
+    expect(events[1]).toMatchObject({
+      id: "effect-cancelled-recovery:legacy-event:1:intent-side-effecting",
+      msg: {
+        payload: {
+          outcome: "cancelled",
+          evidence: {
+            reason: "daemon_recovered_before_effect_dispatch",
+            admissionStatus: "reserved",
+          },
+        },
+      },
+    });
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({ outcome: "cancelled", reviewStatus: "none" });
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toEqual([]);
+    } finally {
+      driver.close();
+      resumed.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("accepts admission-recovered voided state as pre-dispatch proof", () => {
+    const cwd = workspace();
+    const runId = "run-before-dispatch-voided";
+    const original = store(cwd, runId);
+    reserveToolStep(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+
+    recoverAdmissionBeforeRollout(cwd);
+    const resumed = store(cwd, runId, true);
+    expect(
+      resumed
+        .readAll()
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload)
+        .at(-1),
+    ).toMatchObject({
+      msg: {
+        type: "effect_result",
+        payload: {
+          outcome: "cancelled",
+          evidence: { admissionStatus: "voided" },
+        },
+      },
+    });
+    resumed.close();
+  });
+
+  it("records that an idempotent retry is safe but never replays it implicitly", () => {
+    const cwd = workspace();
+    const runId = "run-idempotent";
+    const original = store(cwd, runId);
+    expect(original.append(intent(runId, "idempotent"), { durable: true })).toBe(
+      true,
+    );
+    original.close();
+
+    const resumed = store(cwd, runId, true);
+    const events = resumed
+      .readAll()
+      .filter((item) => item.type === "event_msg")
+      .map((item) => item.payload);
+    expect(events.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "recovery_decision",
+    ]);
+    expect(events[1]).toMatchObject({
+      id: "recovery-decision:legacy-event:1:intent-idempotent",
+      msg: {
+        payload: {
+          decision: "retry_safe_deferred",
+          evidenceEventSeq: 1,
+        },
+      },
+    });
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      const effect = new StateRunDurabilityRepository(driver).getEffect(
+        runId,
+        "tool:turn-1:call-1",
+      );
+      expect(effect).toMatchObject({
+        recoveryCategory: "idempotent",
+        idempotencyKey: "sha256:safe-retry",
+        reviewStatus: "none",
+      });
+      expect(effect?.outcome).toBeUndefined();
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toEqual([]);
+    } finally {
+      driver.close();
+      resumed.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("journals human review evidence and lifts both unknown-outcome gates", () => {
+    const cwd = workspace();
+    const runId = "run-reviewed";
+    const original = store(cwd, runId);
+    expect(original.append(intent(runId, "side-effecting"), { durable: true })).toBe(
+      true,
+    );
+    original.close();
+    const recovered = store(cwd, runId, true);
+    recovered.close();
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toMatchObject({
+        kind: "resolved",
+        durable: true,
+        eventId: `effect-review:${runId}:tool:turn-1:call-1`,
+        sequence: 3,
+      });
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({
+        reviewStatus: "resolved",
+        reviewedBy: "operator-test",
+        reviewResolution: "human_verified",
+      });
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toEqual([]);
+      expect(
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:30.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toMatchObject({
+        kind: "already_resolved",
+        durable: true,
+        sequence: 3,
+      });
+      expect(() =>
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:31.000Z",
+          reviewedBy: "different-operator",
+          resolution: "human_verified",
+        }),
+      ).toThrow(/conflicting content/);
+      expect(() =>
+        recordInFlightToolCallStart(driver, {
+          sessionId: runId,
+          toolCallId: "call-2",
+          toolName: "next-mutation",
+          args: null,
+          startedAt: "2026-07-18T00:02:00.000Z",
+          recoveryCategory: "side-effecting",
+        }),
+      ).not.toThrow();
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+
+    const replayed = store(cwd, runId, true);
+    try {
+      const types = replayed
+        .readAll()
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload.msg.type);
+      expect(types).toEqual([
+        "effect_intent",
+        "effect_unknown_outcome",
+        "effect_review_resolved",
+      ]);
+    } finally {
+      replayed.close();
+    }
+  });
+
+  it("rejects an external active journal binding without mutating it", () => {
+    const cwd = workspace();
+    const runId = "run-review-external-binding";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    recovered.close();
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const externalPath = join(
+      cwd,
+      `rollout-2026-07-18T00-02-00-000Z-${runId}.jsonl`,
+    );
+    writeFileSync(externalPath, "external must remain unchanged\n", {
+      mode: 0o600,
+    });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      new StateRunDurabilityRepository(driver).bindJournalSource({
+        runId,
+        epoch: 1,
+        childRunId: runId,
+        sessionId: runId,
+        sourcePath: externalPath,
+        boundAt: "2026-07-18T00:02:00.000Z",
+      });
+      expect(() =>
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:03:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toThrow(/outside this project's sessions\/archived_sessions roots/);
+      expect(readFileSync(externalPath, "utf8")).toBe(
+        "external must remain unchanged\n",
+      );
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({ reviewStatus: "pending" });
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("reprojects a post-terminal review after failure between journal fsync and both SQLite gates", () => {
+    const cwd = workspace();
+    const runId = "run-review-projection-crash";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    const rolloutPath = recovered.rolloutPath;
+    const terminalEventId = `run-terminal:${runId}:1`;
+    expect(
+      recovered.append(
+        {
+          eventId: terminalEventId,
+          id: terminalEventId,
+          seq: 3,
+          msg: {
+            type: "run_terminal",
+            payload: {
+              runId,
+              epoch: 1,
+              status: "completed",
+              exitCode: 0,
+              stopReason: "completed",
+              finalMessage: "terminal snapshot",
+              usage: null,
+              lastSequenceBeforeTerminal: 2,
+              finishedAt: "2026-07-18T00:00:30.000Z",
+            },
+          },
+        },
+        { durable: true },
+      ),
+    ).toBe(true);
+    recovered.close();
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    let driver = openStateDatabasePaths(paths);
+    try {
+      const runs = new StateRunDurabilityRepository(driver);
+      runs.recordTerminalResult({
+        epoch: 1,
+        eventId: terminalEventId,
+        result: {
+          runId,
+          status: "completed",
+          exitCode: 0,
+          stopReason: "completed",
+          finalMessage: "terminal snapshot",
+          usage: null,
+          lastSequence: 3,
+          finishedAt: "2026-07-18T00:00:30.000Z",
+        },
+      });
+      driver.prepareState(
+        `CREATE TRIGGER test_abort_legacy_review_projection
+         BEFORE UPDATE ON in_flight_tool_calls
+         WHEN OLD.status = 'poisoned' AND NEW.status = 'unknown_resolved'
+         BEGIN
+           SELECT RAISE(ABORT, 'simulated crash before legacy gate projection');
+         END`,
+      ).run();
+
+      expect(() =>
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toThrow(/simulated crash before legacy gate projection/);
+      // The canonical append survives, while the outer SQLite transaction
+      // rolls both projections back together instead of leaving a resolved
+      // v15 review with a poisoned legacy gate.
+      expect(
+        readFileSync(rolloutPath, "utf8").match(
+          /"type":"effect_review_resolved"/g,
+        ),
+      ).toHaveLength(1);
+      expect(runs.getEffect(runId, "tool:turn-1:call-1")).toMatchObject({
+        reviewStatus: "pending",
+      });
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toHaveLength(1);
+      driver
+        .prepareState("DROP TRIGGER test_abort_legacy_review_projection")
+        .run();
+    } finally {
+      driver.close();
+    }
+
+    driver = openStateDatabasePaths(paths);
+    try {
+      expect(() => recoverDaemonStateOnStartup(driver)).not.toThrow();
+      const runs = new StateRunDurabilityRepository(driver);
+      expect(runs.getEffect(runId, "tool:turn-1:call-1")).toMatchObject({
+        reviewStatus: "resolved",
+        reviewedBy: "operator-test",
+        reviewEventId: `effect-review:${runId}:tool:turn-1:call-1`,
+      });
+      expect(listUnresolvedUnknownOutcomeEffects(driver, runId)).toEqual([]);
+      expect(runs.getCurrentTerminalResult(runId)).toMatchObject({
+        status: "completed",
+        lastSequence: 3,
+      });
+      expect(() => recoverDaemonStateOnStartup(driver)).not.toThrow();
+      expect(
+        readFileSync(rolloutPath, "utf8").match(
+          /"type":"effect_review_resolved"/g,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("appends review evidence to the superseded journal that owns the unknown outcome", () => {
+    const cwd = workspace();
+    const runId = "run-reviewed-superseded-source";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    const historicalPath = original.rolloutPath;
+    original.close();
+    const recovered = store(cwd, runId, true);
+    recovered.close();
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    const activePath = join(
+      paths.projectDir,
+      "sessions",
+      runId,
+      `rollout-2026-07-18T00-02-00-000Z-${runId}.jsonl`,
+    );
+    writeFileSync(
+      activePath,
+      serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "new canonical source" },
+      }),
+    );
+    try {
+      const runs = new StateRunDurabilityRepository(driver);
+      runs.bindJournalSource({
+        runId,
+        epoch: 1,
+        childRunId: runId,
+        sessionId: runId,
+        sourcePath: activePath,
+        boundAt: "2026-07-18T00:02:00.000Z",
+      });
+      expect(runs.getJournalBinding(historicalPath)).toMatchObject({
+        active: false,
+      });
+
+      expect(
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:03:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toMatchObject({ kind: "resolved", durable: true, sequence: 3 });
+      expect(readFileSync(historicalPath, "utf8")).toContain(
+        '"type":"effect_review_resolved"',
+      );
+      expect(readFileSync(activePath, "utf8")).not.toContain(
+        '"type":"effect_review_resolved"',
+      );
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("discards an unterminated tail under the lease before appending review evidence", () => {
+    const cwd = workspace();
+    const runId = "run-reviewed-unterminated-tail";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    const rolloutPath = recovered.rolloutPath;
+    recovered.close();
+
+    const committed = readFileSync(rolloutPath, "utf8");
+    const uncommitted = JSON.stringify({
+      type: "response_item",
+      payload: { role: "assistant", content: "must be discarded" },
+    });
+    expect(committed.endsWith("\n")).toBe(true);
+    writeFileSync(rolloutPath, committed + uncommitted);
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toMatchObject({ kind: "resolved", durable: true, sequence: 3 });
+
+      const repaired = readFileSync(rolloutPath, "utf8");
+      expect(repaired.endsWith("\n")).toBe(true);
+      expect(repaired).not.toContain("must be discarded");
+      expect(() => {
+        for (const line of repaired.trimEnd().split("\n")) JSON.parse(line);
+      }).not.toThrow();
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({ reviewStatus: "resolved" });
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("does not review an unknown outcome whose only journal evidence was unterminated", () => {
+    const cwd = workspace();
+    const runId = "run-review-uncommitted-unknown";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    const rolloutPath = recovered.rolloutPath;
+    recovered.close();
+    const committed = readFileSync(rolloutPath, "utf8");
+    writeFileSync(rolloutPath, committed.slice(0, -1));
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(() =>
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toThrow(/no retained canonical journal evidence/);
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({ reviewStatus: "pending" });
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("refuses to append review evidence after a duplicate journal sequence", () => {
+    const cwd = workspace();
+    const runId = "run-review-duplicate-sequence";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    const rolloutPath = recovered.rolloutPath;
+    recovered.close();
+    appendFileSync(
+      rolloutPath,
+      serializeRolloutItem({
+        type: "event_msg",
+        payload: {
+          eventId: "duplicate-sequence-event",
+          id: "reusable-correlation",
+          seq: 2,
+          msg: { type: "user_message", payload: { message: "ambiguous" } },
+        },
+      }),
+    );
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(() =>
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toThrow(/invalid or non-monotonic sequence/);
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("refuses to append review evidence after canonical eventId reuse", () => {
+    const cwd = workspace();
+    const runId = "run-review-event-id-conflict";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    const rolloutPath = recovered.rolloutPath;
+    recovered.close();
+    appendFileSync(
+      rolloutPath,
+      serializeRolloutItem({
+        type: "event_msg",
+        payload: {
+          eventId: "legacy-event:1:intent-side-effecting",
+          id: "different-correlation",
+          seq: 3,
+          msg: { type: "user_message", payload: { message: "conflict" } },
+        },
+      }),
+    );
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(() =>
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toThrow(/event id .* is duplicated/);
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("keys review idempotency by canonical eventId, not reusable correlation id", () => {
+    const cwd = workspace();
+    const runId = "run-review-correlation-collision";
+    const reviewEventId = `effect-review:${runId}:tool:turn-1:call-1`;
+    const original = store(cwd, runId);
+    expect(original.append(intent(runId, "side-effecting"), { durable: true })).toBe(
+      true,
+    );
+    expect(
+      original.append(
+        {
+          eventId: "unrelated-canonical-event",
+          id: reviewEventId,
+          seq: 2,
+          msg: {
+            type: "user_message",
+            payload: { message: "correlation ids are reusable" },
+          },
+        },
+        { durable: true },
+      ),
+    ).toBe(true);
+    original.close();
+    const recovered = store(cwd, runId, true);
+    recovered.close();
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    try {
+      expect(
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:00.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toMatchObject({
+        kind: "resolved",
+        eventId: reviewEventId,
+        sequence: 4,
+      });
+      expect(
+        resolveDurableEffectReview(driver, {
+          sessionId: runId,
+          toolCallId: "call-1",
+          reviewedAt: "2026-07-18T00:01:30.000Z",
+          reviewedBy: "operator-test",
+          resolution: "human_verified",
+        }),
+      ).toMatchObject({ kind: "already_resolved", sequence: 4 });
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+  });
+
+  it("resolves a durable review through the operator CLI exactly once", async () => {
+    const cwd = workspace();
+    const runId = "run-cli-reviewed";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const recovered = store(cwd, runId, true);
+    recovered.close();
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const command = {
+      kind: "resolve-tool-call" as const,
+      sessionId: runId,
+      toolCallId: "call-1",
+    };
+    const options = {
+      driver,
+      env: { AGENC_REVIEWER_ID: "cli-reviewer" },
+      now: () => "2026-07-18T00:03:00.000Z",
+      io: {
+        stdout: { write: (text: string) => (stdout.push(text), true) },
+        stderr: { write: (text: string) => (stderr.push(text), true) },
+      },
+    };
+    try {
+      expect(await runAgenCStateCli(command, options)).toBe(0);
+      expect(await runAgenCStateCli(command, options)).toBe(0);
+      expect(stderr).toEqual([]);
+      expect(stdout.join("\n")).toContain("canonical review event");
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({
+        reviewStatus: "resolved",
+        reviewedBy: "cli-reviewer",
+      });
+    } finally {
+      driver.close();
+      created.push(paths.projectDir);
+    }
+
+    const replayed = store(cwd, runId, true);
+    try {
+      expect(
+        replayed
+          .readAll()
+          .filter(
+            (item) =>
+              item.type === "event_msg" &&
+              item.payload.msg.type === "effect_review_resolved",
+          ),
+      ).toHaveLength(1);
+    } finally {
+      replayed.close();
+    }
+  });
+
+  it("refuses review while the canonical session writer lease is live", async () => {
+    const cwd = workspace();
+    const runId = "run-live-review";
+    const original = store(cwd, runId);
+    original.append(intent(runId, "side-effecting"), { durable: true });
+    original.close();
+    const live = store(cwd, runId, true);
+
+    const paths = resolveStateDatabasePaths({ cwd });
+    const driver = openStateDatabasePaths(paths);
+    const errors: string[] = [];
+    try {
+      expect(
+        await runAgenCStateCli(
+          {
+            kind: "resolve-tool-call",
+            sessionId: runId,
+            toolCallId: "call-1",
+          },
+          {
+            driver,
+            io: {
+              stdout: { write: () => true },
+              stderr: { write: (text: string) => (errors.push(text), true) },
+            },
+          },
+        ),
+      ).toBe(1);
+      expect(errors.join("\n")).toContain("canonical journal is live");
+      expect(
+        new StateRunDurabilityRepository(driver).getEffect(
+          runId,
+          "tool:turn-1:call-1",
+        ),
+      ).toMatchObject({ reviewStatus: "pending" });
+    } finally {
+      driver.close();
+      live.close();
+      created.push(paths.projectDir);
+    }
+  });
+});

--- a/runtime/tests/durability/failpoints.test.ts
+++ b/runtime/tests/durability/failpoints.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  hitM4DurabilityFailpoint,
+  M4DurabilityFailpointError,
+  M4_DURABILITY_FAILPOINTS,
+} from "../../src/durability/failpoints.js";
+
+describe("M4 durability failpoints", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is inert without the child-process capability token", () => {
+    expect(() =>
+      hitM4DurabilityFailpoint("before_event_publish", {
+        AGENC_TEST_DURABILITY_FAILPOINT: "before_event_publish",
+        AGENC_TEST_DURABILITY_FAILPOINT_ACTION: "throw",
+      }),
+    ).not.toThrow();
+  });
+
+  it("writes a durable marker and throws at the exact requested boundary", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-m4-failpoint-"));
+    dirs.push(dir);
+    const marker = join(dir, "reached.jsonl");
+
+    expect(() =>
+      hitM4DurabilityFailpoint("after_terminal_commit", {
+        AGENC_TEST_DURABILITY_FAILPOINT: "after_terminal_commit",
+        AGENC_TEST_DURABILITY_FAILPOINT_TOKEN: "m4-durability-child",
+        AGENC_TEST_DURABILITY_FAILPOINT_ACTION: "throw",
+        AGENC_TEST_DURABILITY_FAILPOINT_MARKER: marker,
+      }),
+    ).toThrow(M4DurabilityFailpointError);
+
+    expect(JSON.parse(readFileSync(marker, "utf8"))).toMatchObject({
+      failpoint: "after_terminal_commit",
+    });
+  });
+
+  it("publishes the complete before/after acceptance matrix", () => {
+    expect(M4_DURABILITY_FAILPOINTS).toEqual([
+      "after_admission_sqlite_commit_before_canonical_append",
+      "before_reservation_commit",
+      "after_reservation_commit",
+      "before_model_response_commit",
+      "after_model_response_commit",
+      "before_tool_spawn",
+      "after_tool_spawn",
+      "before_tool_ack_commit",
+      "after_tool_ack_commit",
+      "before_artifact_commit",
+      "after_artifact_commit",
+      "before_event_publish",
+      "after_event_publish",
+      "before_terminal_commit",
+      "after_terminal_commit",
+    ]);
+  });
+});

--- a/runtime/tests/durability/failure-matrix.acceptance.test.ts
+++ b/runtime/tests/durability/failure-matrix.acceptance.test.ts
@@ -1,0 +1,616 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AgencRunReplayGapError,
+  connect,
+  type AgencClient,
+} from "../../../packages/agenc-sdk/src/index";
+
+import {
+  M4_DURABILITY_FAILPOINTS,
+  type M4DurabilityFailpoint,
+} from "../../src/durability/failpoints.js";
+
+const FIXTURE = fileURLToPath(
+  new URL("./fixtures/m4-failure-matrix-child.ts", import.meta.url),
+);
+const NODE_TEST_LOADER = fileURLToPath(
+  new URL("./fixtures/node-test-loader.mjs", import.meta.url),
+);
+const DAEMON_FIXTURE = fileURLToPath(
+  new URL("./fixtures/daemon-main-child.ts", import.meta.url),
+);
+const TSX_IMPORT = fileURLToPath(import.meta.resolve("tsx"));
+const FAILPOINT_TOKEN = "m4-durability-child";
+
+interface ChildExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface RecoveryReport {
+  readonly failpoint: M4DurabilityFailpoint;
+  readonly canonicalEventCounts: Readonly<Record<string, number>>;
+  readonly modelPhysicalAttempts: number;
+  readonly toolPhysicalAttempts: number;
+  readonly admission?: {
+    readonly effect?: {
+      readonly outcome?: string;
+      readonly reviewStatus?: string;
+    };
+    readonly effectRecovery: string;
+    readonly pendingEffectReviews: number;
+    readonly jobs: ReadonlyArray<{ readonly id: string; readonly status: string }>;
+    readonly reservations: ReadonlyArray<{
+      readonly id: string;
+      readonly status: string;
+    }>;
+    readonly journalCounts: Readonly<Record<string, number>>;
+    readonly secondRecovery: {
+      readonly requeuedJobIds: readonly string[];
+      readonly heldUnknownReservationIds: readonly string[];
+      readonly cancelledExpiredJobIds: readonly string[];
+      readonly detachedQueuedJobIds: readonly string[];
+    };
+  };
+  readonly artifact?: {
+    readonly targetState: "missing" | "complete";
+    readonly bytes?: string;
+    readonly visibleTargets: number;
+    readonly orphanTemps: number;
+    readonly intentSequences: readonly number[];
+    readonly committedOutcomes: readonly string[];
+    readonly committedIntentSequences: readonly number[];
+    readonly recoveryDecisions: readonly string[];
+    readonly recoveryEvidenceSequences: readonly number[];
+  };
+  readonly publication?: {
+    readonly canonicalCount: number;
+    readonly canonicalCoordinates: ReadonlyArray<{
+      readonly eventId: string;
+      readonly sequence: number;
+    }>;
+    readonly liveObservations: ReadonlyArray<{
+      readonly surface: string;
+      readonly eventId: string;
+      readonly sequence: number;
+    }>;
+    readonly reconnectUniqueDeliveries: number;
+  };
+  readonly terminal?: {
+    readonly canonicalCount: number;
+    readonly firstProjectionApplied: boolean;
+    readonly secondProjectionApplied: boolean;
+    readonly history: ReadonlyArray<{
+      readonly status: string;
+      readonly finalMessage: string | null;
+      readonly eventId: string;
+    }>;
+  };
+}
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function cleanChildEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT;
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN;
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT_ACTION;
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT_MARKER;
+  return env;
+}
+
+function collectChild(child: ChildProcess): Promise<ChildExit> {
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+async function waitForMarker(
+  marker: string,
+  child: ChildProcess,
+): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  while (!existsSync(marker)) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `crash child exited before reaching failpoint marker: code=${child.exitCode} signal=${child.signalCode}`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      throw new Error(`timed out waiting for failpoint marker: ${marker}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function crashAt(
+  failpoint: M4DurabilityFailpoint,
+  stateDirectory: string,
+): Promise<void> {
+  const marker = join(stateDirectory, "failpoint-reached.json");
+  const env = cleanChildEnvironment();
+  env.AGENC_TEST_DURABILITY_FAILPOINT = failpoint;
+  env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN = FAILPOINT_TOKEN;
+  env.AGENC_TEST_DURABILITY_FAILPOINT_MARKER = marker;
+  const child = spawn(
+    process.execPath,
+    [
+      "--loader",
+      NODE_TEST_LOADER,
+      "--import",
+      TSX_IMPORT,
+      FIXTURE,
+      "crash",
+      failpoint,
+      stateDirectory,
+    ],
+    {
+      cwd: dirname(dirname(dirname(dirname(FIXTURE)))),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const exitPromise = collectChild(child);
+  try {
+    await waitForMarker(marker, child);
+  } catch (error) {
+    const result = await exitPromise;
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}\n` +
+        `stdout=${result.stdout}\nstderr=${result.stderr}`,
+    );
+  }
+  const result = await exitPromise;
+  expect(
+    result,
+    `crash child output:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+  ).toMatchObject({ code: null, signal: "SIGKILL" });
+  expect(JSON.parse(readFileSync(marker, "utf8"))).toMatchObject({
+    failpoint,
+  });
+}
+
+async function recoverAfter(
+  failpoint: M4DurabilityFailpoint,
+  stateDirectory: string,
+): Promise<RecoveryReport> {
+  const child = spawn(
+    process.execPath,
+    [
+      "--loader",
+      NODE_TEST_LOADER,
+      "--import",
+      TSX_IMPORT,
+      FIXTURE,
+      "recover",
+      failpoint,
+      stateDirectory,
+    ],
+    {
+      cwd: dirname(dirname(dirname(dirname(FIXTURE)))),
+      env: cleanChildEnvironment(),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const result = await collectChild(child);
+  expect(
+    result,
+    `recovery child output:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+  ).toMatchObject({ code: 0, signal: null });
+  const lines = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  expect(lines).toHaveLength(1);
+  return JSON.parse(lines[0]!) as RecoveryReport;
+}
+
+async function connectFreshDaemon(
+  stateDirectory: string,
+): Promise<{
+  readonly client: AgencClient;
+  readonly stop: () => Promise<void>;
+}> {
+  const home = join(stateDirectory, "home");
+  const cwd = join(stateDirectory, "workspace");
+  const env = {
+    ...cleanChildEnvironment(),
+    AGENC_HOME: home,
+    AGENC_CONFIG_DIR: home,
+    HOME: home,
+  };
+  const daemon = spawn(
+    process.execPath,
+    [
+      "--loader",
+      NODE_TEST_LOADER,
+      "--import",
+      TSX_IMPORT,
+      DAEMON_FIXTURE,
+      "daemon",
+      "start",
+      "--foreground",
+    ],
+    { cwd, env, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const exit = collectChild(daemon);
+  const deadline = Date.now() + 20_000;
+  let lastError: unknown;
+  let client: AgencClient | undefined;
+  while (Date.now() < deadline && daemon.exitCode === null) {
+    try {
+      client = await connect({
+        env,
+        autostart: false,
+        readyTimeoutMs: 250,
+        requestTimeoutMs: 5_000,
+        clientId: `m4-sdk-${process.pid}`,
+      });
+      break;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  if (client === undefined) {
+    if (daemon.exitCode === null) daemon.kill("SIGKILL");
+    const result = await exit;
+    throw new Error(
+      `fresh daemon did not become SDK-ready: ${String(lastError)}\n` +
+        `stdout=${result.stdout}\nstderr=${result.stderr}`,
+    );
+  }
+  return {
+    client,
+    stop: async () => {
+      await client!.close();
+      if (daemon.exitCode === null && daemon.signalCode === null) {
+        daemon.kill("SIGTERM");
+      }
+      const stopped = await Promise.race([
+        exit,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 5_000)),
+      ]);
+      if (stopped === null) {
+        daemon.kill("SIGKILL");
+        await exit;
+      }
+    },
+  };
+}
+
+async function verifyFreshDaemonSdk(
+  failpoint: M4DurabilityFailpoint,
+  stateDirectory: string,
+): Promise<void> {
+  const first = await connectFreshDaemon(stateDirectory);
+  let cursor = 0;
+  let midpoint = 0;
+  let expectedKeys: string[] = [];
+  try {
+    const attachment = first.client.reattachRun({
+      runId: "m4-failure-matrix-run",
+      afterSequence: 0,
+    });
+    const events = [];
+    for await (const event of attachment) events.push(event);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.map((event) => event.sequence)).toEqual(
+      Array.from({ length: events.length }, (_, index) => index + 1),
+    );
+    expectedKeys = events.map(
+      (event) => `${event.sequence}:${event.eventId}`,
+    );
+    expect(new Set(expectedKeys).size).toBe(expectedKeys.length);
+    cursor = attachment.cursor().afterSequence;
+    expect(cursor).toBe(events.at(-1)?.sequence);
+    midpoint = events[Math.floor((events.length - 1) / 2)]!.sequence;
+    if (failpoint.includes("event_publish")) {
+      expect(events).toContainEqual(
+        expect.objectContaining({ eventId: "publish-event-1" }),
+      );
+    }
+    if (failpoint.includes("terminal_commit")) {
+      expect(events).toContainEqual(
+        expect.objectContaining({ eventId: "run-terminal-1" }),
+      );
+      await expect(attachment.result()).resolves.toMatchObject({
+        terminal: true,
+        output: {
+          available: true,
+          finalMessage: "finished once",
+          lastSequence: 1,
+        },
+      });
+    }
+
+    const wrongCursor = first.client.reattachRun({
+      runId: "m4-failure-matrix-run",
+      afterSequence: cursor + 99,
+    });
+    await expect(async () => {
+      for await (const _event of wrongCursor) void _event;
+    }).rejects.toMatchObject({
+      name: AgencRunReplayGapError.name,
+      gap: { kind: "cursor_ahead" },
+    });
+    expect(wrongCursor.cursor()).toEqual({
+      runId: "m4-failure-matrix-run",
+      afterSequence: cursor + 99,
+    });
+  } finally {
+    await first.stop();
+  }
+
+  const second = await connectFreshDaemon(stateDirectory);
+  try {
+    const replayedFromStart = second.client.reattachRun({
+      runId: "m4-failure-matrix-run",
+      afterSequence: 0,
+    });
+    const replayedKeys = [];
+    for await (const event of replayedFromStart) {
+      replayedKeys.push(`${event.sequence}:${event.eventId}`);
+    }
+    expect(replayedKeys).toEqual(expectedKeys);
+
+    const resumedFromMidpoint = second.client.reattachRun({
+      runId: "m4-failure-matrix-run",
+      afterSequence: midpoint,
+    });
+    const suffixKeys = [];
+    for await (const event of resumedFromMidpoint) {
+      suffixKeys.push(`${event.sequence}:${event.eventId}`);
+    }
+    expect(suffixKeys).toEqual(
+      expectedKeys.filter(
+        (key) => Number(key.slice(0, key.indexOf(":"))) > midpoint,
+      ),
+    );
+
+    const resumedAtTail = second.client.reattachRun({
+      runId: "m4-failure-matrix-run",
+      afterSequence: cursor,
+    });
+    const redelivered = [];
+    for await (const event of resumedAtTail) redelivered.push(event);
+    expect(redelivered).toEqual([]);
+    expect(resumedAtTail.cursor()).toEqual({
+      runId: "m4-failure-matrix-run",
+      afterSequence: cursor,
+    });
+  } finally {
+    await second.stop();
+  }
+}
+
+function expectIdempotentSecondRecovery(report: RecoveryReport): void {
+  expect(report.admission?.secondRecovery).toMatchObject({
+    requeuedJobIds: [],
+    heldUnknownReservationIds: [],
+    cancelledExpiredJobIds: [],
+    detachedQueuedJobIds: [],
+  });
+}
+
+function verifyBoundary(
+  failpoint: M4DurabilityFailpoint,
+  report: RecoveryReport,
+): void {
+  expect(report.failpoint).toBe(failpoint);
+
+  if (
+    failpoint === "after_admission_sqlite_commit_before_canonical_append" ||
+    failpoint === "before_reservation_commit"
+  ) {
+    expect(report.admission?.reservations).toEqual([]);
+    expect(report.admission?.jobs).toHaveLength(1);
+    expect(report.admission?.jobs[0]?.status).toBe("queued");
+    expect(report.admission?.journalCounts.allowed ?? 0).toBe(0);
+    expect(report.admission?.journalCounts.queued).toBe(1);
+    expect(report.admission?.journalCounts.recovered).toBe(1);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (failpoint === "after_reservation_commit") {
+    expect(report.admission?.reservations).toHaveLength(1);
+    expect(report.admission?.reservations[0]?.status).toBe("voided");
+    expect(report.admission?.journalCounts.allowed).toBe(1);
+    expect(report.admission?.journalCounts.voided).toBe(1);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (failpoint === "before_model_response_commit") {
+    expect(report.modelPhysicalAttempts).toBe(1);
+    expect(report.admission?.reservations[0]?.status).toBe("held_unknown");
+    expect(report.admission?.journalCounts.allowed).toBe(1);
+    expect(report.admission?.journalCounts.dispatched).toBe(1);
+    expect(report.admission?.journalCounts.held_unknown).toBe(1);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (failpoint === "after_model_response_commit") {
+    expect(report.modelPhysicalAttempts).toBe(1);
+    expect(report.admission?.reservations[0]?.status).toBe("reconciled");
+    expect(report.admission?.journalCounts.allowed).toBe(1);
+    expect(report.admission?.journalCounts.dispatched).toBe(1);
+    expect(report.admission?.journalCounts.reconciled).toBe(1);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (failpoint === "before_tool_spawn") {
+    expect(report.toolPhysicalAttempts).toBe(0);
+    expect(report.admission?.reservations[0]?.status).toBe("voided");
+    expect(report.admission?.effect).toMatchObject({
+      outcome: "cancelled",
+      reviewStatus: "none",
+    });
+    expect(report.admission?.effectRecovery).toBe("cancelled_before_dispatch");
+    expect(report.admission?.pendingEffectReviews).toBe(0);
+    expect(report.canonicalEventCounts.effect_intent).toBe(1);
+    expect(report.canonicalEventCounts.effect_result).toBe(1);
+    expect(report.canonicalEventCounts.effect_unknown_outcome ?? 0).toBe(0);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (
+    failpoint === "after_tool_spawn" ||
+    failpoint === "before_tool_ack_commit"
+  ) {
+    expect(report.toolPhysicalAttempts).toBe(1);
+    expect(report.admission?.reservations[0]?.status).toBe("held_unknown");
+    expect(report.admission?.effect).toMatchObject({
+      outcome: "unknown_outcome",
+      reviewStatus: "pending",
+    });
+    expect(report.admission?.effectRecovery).toBe(
+      "review_locked_unknown_outcome",
+    );
+    expect(report.admission?.pendingEffectReviews).toBe(1);
+    expect(report.canonicalEventCounts.effect_intent).toBe(1);
+    expect(report.canonicalEventCounts.effect_result ?? 0).toBe(0);
+    expect(report.canonicalEventCounts.effect_unknown_outcome).toBe(1);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (failpoint === "after_tool_ack_commit") {
+    expect(report.toolPhysicalAttempts).toBe(1);
+    expect(report.admission?.reservations[0]?.status).toBe("reconciled");
+    expect(report.admission?.effect).toMatchObject({
+      outcome: "committed",
+      reviewStatus: "none",
+    });
+    expect(report.admission?.effectRecovery).toBe(
+      "acknowledged_from_durable_result",
+    );
+    expect(report.admission?.pendingEffectReviews).toBe(0);
+    expect(report.canonicalEventCounts.effect_intent).toBe(1);
+    expect(report.canonicalEventCounts.effect_result).toBe(1);
+    expect(report.canonicalEventCounts.effect_unknown_outcome ?? 0).toBe(0);
+    expectIdempotentSecondRecovery(report);
+    return;
+  }
+  if (failpoint === "before_artifact_commit") {
+    expect(report.artifact).toMatchObject({
+      targetState: "missing",
+      visibleTargets: 0,
+      orphanTemps: 0,
+      intentSequences: [1],
+      committedOutcomes: [],
+      committedIntentSequences: [],
+      recoveryDecisions: ["artifact_retry_safe_deferred"],
+      recoveryEvidenceSequences: [1],
+    });
+    expect(report.canonicalEventCounts.artifact_intent).toBe(1);
+    expect(report.canonicalEventCounts.artifact_committed ?? 0).toBe(0);
+    expect(report.canonicalEventCounts.recovery_decision).toBe(1);
+    return;
+  }
+  if (failpoint === "after_artifact_commit") {
+    expect(report.artifact).toMatchObject({
+      targetState: "complete",
+      bytes: "complete artifact bytes",
+      visibleTargets: 1,
+      orphanTemps: 0,
+      intentSequences: [1],
+      committedOutcomes: ["recovered"],
+      committedIntentSequences: [1],
+      recoveryDecisions: [],
+      recoveryEvidenceSequences: [],
+    });
+    expect(report.canonicalEventCounts.artifact_intent).toBe(1);
+    expect(report.canonicalEventCounts.artifact_committed).toBe(1);
+    expect(report.canonicalEventCounts.recovery_decision ?? 0).toBe(0);
+    return;
+  }
+  if (
+    failpoint === "before_event_publish" ||
+    failpoint === "after_event_publish"
+  ) {
+    expect(report.publication).toMatchObject({
+      canonicalCount: 1,
+      reconnectUniqueDeliveries: 1,
+      canonicalCoordinates: [{ eventId: "publish-event-1", sequence: 1 }],
+    });
+    const live = report.publication?.liveObservations ?? [];
+    expect(live).toHaveLength(failpoint === "before_event_publish" ? 0 : 2);
+    expect(new Set(live.map((observation) => observation.surface))).toEqual(
+      failpoint === "before_event_publish"
+        ? new Set()
+        : new Set(["event_log", "tx_event"]),
+    );
+    return;
+  }
+  if (
+    failpoint === "before_terminal_commit" ||
+    failpoint === "after_terminal_commit"
+  ) {
+    expect(report.terminal).toMatchObject({
+      canonicalCount: 1,
+      firstProjectionApplied: failpoint === "before_terminal_commit",
+      secondProjectionApplied: false,
+      history: [
+        {
+          status: "completed",
+          finalMessage: "finished once",
+          eventId: "run-terminal-1",
+        },
+      ],
+    });
+  }
+}
+
+describe.sequential("M4 SIGKILL crash/restart acceptance matrix", () => {
+  it.each(M4_DURABILITY_FAILPOINTS)(
+    "%s leaves an explainable, replay-safe durable state",
+    { timeout: 120_000 },
+    async (failpoint) => {
+      const stateDirectory = mkdtempSync(
+        join(
+          tmpdir(),
+          `agenc-m4-${M4_DURABILITY_FAILPOINTS.indexOf(failpoint)}-`,
+        ),
+      );
+      directories.push(stateDirectory);
+      await crashAt(failpoint, stateDirectory);
+      const report = await recoverAfter(failpoint, stateDirectory);
+      verifyBoundary(failpoint, report);
+      await verifyFreshDaemonSdk(failpoint, stateDirectory);
+    },
+  );
+});

--- a/runtime/tests/durability/fixtures/daemon-main-child.ts
+++ b/runtime/tests/durability/fixtures/daemon-main-child.ts
@@ -1,0 +1,12 @@
+/** Fresh-process daemon entrypoint for M4 socket/SDK acceptance tests. */
+
+import { main } from "../../../src/bin/agenc.js";
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  process.stderr.write(
+    `daemon fixture failed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/runtime/tests/durability/fixtures/m4-failure-matrix-child.ts
+++ b/runtime/tests/durability/fixtures/m4-failure-matrix-child.ts
@@ -1,0 +1,839 @@
+/**
+ * Child process used by the M4 crash/restart acceptance matrix.
+ *
+ * The crash command is always run with the guarded production failpoint token
+ * and therefore dies by SIGKILL. The recover command opens the same on-disk
+ * state in a fresh process and emits a JSON report for the parent test.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { M4DurabilityFailpoint } from "../../../src/durability/failpoints.js";
+import type { Event } from "../../../src/session/event-log.js";
+
+const RUN_ID = "m4-failure-matrix-run";
+const TOOL_STEP_ID = "tool:turn-1:call-1";
+const OPENED_AT = "2026-07-18T00:00:00.000Z";
+const FINISHED_AT = "2026-07-18T00:00:01.000Z";
+
+type Command = "crash" | "recover";
+
+interface FixturePaths {
+  readonly root: string;
+  readonly home: string;
+  readonly cwd: string;
+  readonly modelReceipt: string;
+  readonly toolReceipt: string;
+  readonly liveObservations: string;
+}
+
+interface CanonicalEvent extends Event {
+  readonly eventId: string;
+  readonly seq: number;
+}
+
+function requireArgument(value: string | undefined, name: string): string {
+  if (value === undefined || value.length === 0) {
+    throw new Error(`missing ${name}`);
+  }
+  return value;
+}
+
+function pathsFor(root: string): FixturePaths {
+  const home = join(root, "home");
+  const cwd = join(root, "workspace");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  process.env.AGENC_HOME = home;
+  return {
+    root,
+    home,
+    cwd,
+    modelReceipt: join(root, "physical", "model-response.jsonl"),
+    toolReceipt: join(root, "physical", "tool-invocation.jsonl"),
+    liveObservations: join(root, "transport", "live-observations.jsonl"),
+  };
+}
+
+function appendJsonDurably(path: string, value: unknown): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  const fd = openSync(path, "a", 0o600);
+  try {
+    writeSync(fd, `${JSON.stringify(value)}\n`, undefined, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function readJsonLines(path: string): unknown[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function walkFiles(directory: string): string[] {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? walkFiles(path) : [path];
+  });
+}
+
+function canonicalEvents(paths: FixturePaths): CanonicalEvent[] {
+  return walkFiles(paths.home)
+    .filter((path) => /rollout-.*\.jsonl$/.test(path))
+    .flatMap((path) => readJsonLines(path))
+    .flatMap((item) => {
+      if (
+        typeof item !== "object" ||
+        item === null ||
+        (item as { type?: unknown }).type !== "event_msg"
+      ) {
+        return [];
+      }
+      const event = (item as { payload?: unknown }).payload;
+      if (
+        typeof event !== "object" ||
+        event === null ||
+        !Number.isSafeInteger((event as { seq?: unknown }).seq) ||
+        typeof (event as { eventId?: unknown }).eventId !== "string" ||
+        (event as { eventId: string }).eventId.length === 0
+      ) {
+        throw new Error(`canonical event lacks durable coordinates in ${path}`);
+      }
+      return [event as CanonicalEvent];
+    })
+    .sort((left, right) => left.seq - right.seq);
+}
+
+async function openRolloutSession(
+  paths: FixturePaths,
+  options: { readonly resume?: boolean; readonly observeLive?: boolean } = {},
+) {
+  const [{ EventLog, isDurableEvent }, { RolloutStore }, { hitM4DurabilityFailpoint }] = await Promise.all([
+    import("../../../src/session/event-log.js"),
+    import("../../../src/session/rollout-store.js"),
+    import("../../../src/durability/failpoints.js"),
+  ]);
+  const rolloutStore = new RolloutStore({
+    cwd: paths.cwd,
+    sessionId: RUN_ID,
+    agencVersion: "0.6.2",
+    autoStartScheduler: false,
+    ...(options.resume === true ? { resume: true } : {}),
+  });
+  rolloutStore.open({
+    sessionId: RUN_ID,
+    timestamp: OPENED_AT,
+    cwd: paths.cwd,
+    originator: "m4-failure-matrix",
+    agencVersion: "0.6.2",
+  });
+  const [{ openStateDatabases }, { StateRunDurabilityRepository }] =
+    await Promise.all([
+      import("../../../src/state/sqlite-driver.js"),
+      import("../../../src/state/run-durability.js"),
+    ]);
+  const stateDriver = openStateDatabases({
+    cwd: paths.cwd,
+    agencHome: paths.home,
+  });
+  try {
+    const durability = new StateRunDurabilityRepository(stateDriver);
+    durability.ensureInitialEpoch({ runId: RUN_ID, openedAt: OPENED_AT });
+    if (durability.getJournalBinding(rolloutStore.rolloutPath) === undefined) {
+      durability.bindJournalSource({
+        runId: RUN_ID,
+        epoch: 1,
+        childRunId: RUN_ID,
+        sessionId: RUN_ID,
+        sourcePath: rolloutStore.rolloutPath,
+        active: true,
+        boundAt: OPENED_AT,
+      });
+    }
+  } finally {
+    stateDriver.close();
+  }
+  const eventLog = new EventLog();
+  const existing = canonicalEvents(paths);
+  eventLog.seedCanonicalHistory(existing);
+  if (options.observeLive === true) {
+    eventLog.subscribe((event) => {
+      appendJsonDurably(paths.liveObservations, {
+        surface: "event_log",
+        eventId: event.eventId,
+        sequence: event.seq,
+      });
+    });
+  }
+  const session = {
+    conversationId: RUN_ID,
+    eventLog,
+    rolloutStore,
+    activeTurn: { unsafePeek: () => undefined },
+    txEvent: {
+      send: (event: Event) => {
+        if (options.observeLive === true) {
+          appendJsonDurably(paths.liveObservations, {
+            surface: "tx_event",
+            eventId: event.eventId,
+            sequence: event.seq,
+          });
+        }
+        return true;
+      },
+    },
+    isRolloutPersistenceSuspended: () => false,
+    emit(event: Event, appendOptions: { readonly durable?: boolean } = {}) {
+      const stamped = eventLog.stamp(event);
+      const durable = isDurableEvent(stamped) || appendOptions.durable === true;
+      const committed = rolloutStore.append(stamped, { durable });
+      if (durable && committed === false) {
+        throw new Error(
+          `durable event ${stamped.msg.type} sequence ${stamped.seq ?? "unassigned"} was not fsync-committed`,
+        );
+      }
+      hitM4DurabilityFailpoint("before_event_publish");
+      eventLog.publish(stamped);
+      session.txEvent.send(stamped);
+      hitM4DurabilityFailpoint("after_event_publish");
+      return stamped;
+    },
+  };
+  return { eventLog, rolloutStore, session };
+}
+
+async function crashReservation(paths: FixturePaths): Promise<never> {
+  const [rollout, { ExecutionAdmissionKernel }, { bindExecutionAdmissionJournal }] =
+    await Promise.all([
+      openRolloutSession(paths),
+      import("../../../src/budget/execution-admission-kernel.js"),
+      import("../../../src/session/execution-admission-journal.js"),
+    ]);
+  const kernel = new ExecutionAdmissionKernel({
+    agencHome: paths.home,
+    ownerId: `failure-matrix:${process.pid}`,
+    ownerPid: process.pid,
+  });
+  const client = kernel.bindClient({
+    cwd: paths.cwd,
+    scope: { runId: RUN_ID, sessionId: RUN_ID, autonomous: false },
+  });
+  bindExecutionAdmissionJournal(rollout.session as never, client);
+  await client.acquire({
+    stepId: "reservation-step",
+    kind: "model_turn",
+    model: "grok-4.5",
+    provider: "grok",
+    maxInputTokens: 1,
+    maxOutputTokens: 1,
+    maxCostUsd: 0,
+  });
+  throw new Error("reservation failpoint did not terminate the child");
+}
+
+async function crashModel(paths: FixturePaths): Promise<never> {
+  const [
+    rollout,
+    { runAdmittedModelCall },
+    { ExecutionAdmissionKernel },
+    { bindExecutionAdmissionJournal },
+  ] =
+    await Promise.all([
+      openRolloutSession(paths),
+      import("../../../src/budget/admitted-model-call.js"),
+      import("../../../src/budget/execution-admission-kernel.js"),
+      import("../../../src/session/execution-admission-journal.js"),
+    ]);
+  const kernel = new ExecutionAdmissionKernel({
+    agencHome: paths.home,
+    ownerId: `failure-matrix:${process.pid}`,
+    ownerPid: process.pid,
+  });
+  const executionAdmission = kernel.bindClient({
+    cwd: paths.cwd,
+    scope: { runId: RUN_ID, sessionId: RUN_ID, autonomous: false },
+  });
+  bindExecutionAdmissionJournal(rollout.session as never, executionAdmission);
+  const session = {
+    ...rollout.session,
+    conversationId: RUN_ID,
+    services: {
+      executionAdmission,
+      admissionRequired: true,
+      agentControl: { shutdownAgentTree: async () => undefined },
+    },
+    abortTerminal: () => undefined,
+  };
+  const provider = {
+    name: "grok",
+    getExecutionProfile: async () => ({
+      provider: "grok",
+      model: "grok-4.5",
+      usageReporting: "authoritative" as const,
+      supportsMaxOutputTokens: true,
+    }),
+  };
+  await runAdmittedModelCall({
+    session: session as never,
+    provider: provider as never,
+    messages: [{ role: "user", content: "hello" }],
+    options: { maxOutputTokens: 32 },
+    stepId: "model-step",
+    model: "grok-4.5",
+    providerName: "grok",
+    invoke: async () => {
+      appendJsonDurably(paths.modelReceipt, { attempt: 1, response: "ok" });
+      return {
+        content: "ok",
+        toolCalls: [],
+        model: "grok-4.5",
+        finishReason: "stop",
+        usage: {
+          promptTokens: 8,
+          completionTokens: 4,
+          totalTokens: 12,
+          availability: "reported",
+          provenance: "provider",
+        },
+      };
+    },
+  });
+  throw new Error("model failpoint did not terminate the child");
+}
+
+async function createEffectProjection(paths: FixturePaths) {
+  const [{ openStateDatabases }, { StateRunDurabilityRepository }] =
+    await Promise.all([
+      import("../../../src/state/sqlite-driver.js"),
+      import("../../../src/state/run-durability.js"),
+    ]);
+  const driver = openStateDatabases({ cwd: paths.cwd, agencHome: paths.home });
+  const repository = new StateRunDurabilityRepository(driver);
+  repository.ensureInitialEpoch({
+    runId: RUN_ID,
+    openedAt: OPENED_AT,
+  });
+  return {
+    driver,
+    repository,
+    recordEffectEvent(event: Event): void {
+      const sequence = event.seq;
+      if (sequence === undefined) throw new Error("effect event lacks sequence");
+      if (event.msg.type === "effect_intent") {
+        const payload = event.msg.payload;
+        if (event.eventId === undefined) {
+          throw new Error("effect intent lacks canonical event identity");
+        }
+        repository.beginEffect({
+          runId: payload.runId,
+          epoch: 1,
+          stepId: payload.stepId,
+          sessionId: RUN_ID,
+          toolName: payload.toolName,
+          recoveryCategory: payload.recoveryCategory,
+          ...(payload.idempotencyKey !== undefined
+            ? { idempotencyKey: payload.idempotencyKey }
+            : {}),
+          intentDigest: payload.intentDigest,
+          eventId: event.eventId,
+          eventSequence: sequence,
+          intentAt: payload.recordedAt,
+        });
+        return;
+      }
+      if (event.msg.type === "effect_result") {
+        const payload = event.msg.payload;
+        if (event.eventId === undefined) {
+          throw new Error("effect result lacks canonical event identity");
+        }
+        repository.completeEffect({
+          runId: payload.runId,
+          stepId: payload.stepId,
+          outcome: payload.outcome,
+          eventId: event.eventId,
+          eventSequence: sequence,
+          ...(payload.resultDigest !== undefined
+            ? { resultDigest: payload.resultDigest }
+            : {}),
+          ...(payload.evidence !== undefined
+            ? { evidence: payload.evidence }
+            : {}),
+          completedAt: payload.recordedAt,
+        });
+        return;
+      }
+      if (event.msg.type === "effect_unknown_outcome") {
+        const payload = event.msg.payload;
+        if (event.eventId === undefined) {
+          throw new Error("unknown effect lacks canonical event identity");
+        }
+        repository.markEffectUnknown({
+          runId: payload.runId,
+          stepId: payload.stepId,
+          eventId: event.eventId,
+          eventSequence: sequence,
+          reason: payload.reason,
+          observedAt: payload.recordedAt,
+        });
+      }
+    },
+  };
+}
+
+async function crashTool(paths: FixturePaths): Promise<never> {
+  const [
+    rollout,
+    { runAdmittedToolCall },
+    { ExecutionAdmissionKernel },
+    { bindExecutionAdmissionJournal },
+  ] =
+    await Promise.all([
+      openRolloutSession(paths),
+      import("../../../src/budget/admitted-tool-call.js"),
+      import("../../../src/budget/execution-admission-kernel.js"),
+      import("../../../src/session/execution-admission-journal.js"),
+    ]);
+  const kernel = new ExecutionAdmissionKernel({
+    agencHome: paths.home,
+    ownerId: `failure-matrix:${process.pid}`,
+    ownerPid: process.pid,
+  });
+  const executionAdmission = kernel.bindClient({
+    cwd: paths.cwd,
+    scope: { runId: RUN_ID, sessionId: RUN_ID, autonomous: false },
+  });
+  bindExecutionAdmissionJournal(rollout.session as never, executionAdmission);
+  const session = {
+    ...rollout.session,
+    services: {
+      executionAdmission,
+      admissionRequired: true,
+      agentControl: { shutdownAgentTree: async () => undefined },
+    },
+    abortTerminal: () => undefined,
+  };
+  const tool = {
+    name: "failure-matrix-side-effect",
+    recoveryCategory: "side-effecting" as const,
+    admissionEstimate: () => ({
+      maxInputTokens: 0,
+      maxOutputTokens: 0,
+      maxCostUsd: 0,
+    }),
+  };
+  await runAdmittedToolCall({
+    session: session as never,
+    turnId: "turn-1",
+    callId: "call-1",
+    tool: tool as never,
+    args: { value: "one physical effect" },
+    invoke: async () => {
+      appendJsonDurably(paths.toolReceipt, { invocation: 1 });
+      return {
+        content: "ok",
+        admissionUsage: { inputTokens: 0, outputTokens: 0, costUsd: 0 },
+      };
+    },
+  });
+  throw new Error("tool failpoint did not terminate the child");
+}
+
+async function crashArtifact(paths: FixturePaths): Promise<never> {
+  const rollout = await openRolloutSession(paths);
+  const [bootstrap, ids, currentSession, storage] = await Promise.all([
+    import("../../../src/bootstrap/state.js"),
+    import("../../../src/types/ids.js"),
+    import("../../../src/session/current-session.js"),
+    import("../../../src/utils/toolResultStorage.js"),
+  ]);
+  bootstrap.setOriginalCwd(paths.cwd);
+  bootstrap.switchSession(ids.asSessionId(RUN_ID));
+  await currentSession.runWithCurrentRuntimeSession(
+    rollout.session as never,
+    () =>
+      storage.persistToolResult(
+        "complete artifact bytes",
+        "failure-matrix-artifact",
+      ),
+  );
+  throw new Error("artifact failpoint did not terminate the child");
+}
+
+async function crashEventPublish(paths: FixturePaths): Promise<never> {
+  const { session } = await openRolloutSession(paths, { observeLive: true });
+  session.emit(
+    {
+      eventId: "publish-event-1",
+      id: "publish-event-1",
+      msg: {
+        type: "warning",
+        payload: {
+          cause: "m4_failure_matrix",
+          message: "durable before publication",
+        },
+      },
+    },
+    { durable: true },
+  );
+  throw new Error("event publication failpoint did not terminate the child");
+}
+
+async function crashTerminal(paths: FixturePaths): Promise<never> {
+  const [projection, rollout, { hitM4DurabilityFailpoint }] = await Promise.all([
+    createEffectProjection(paths),
+    openRolloutSession(paths),
+    import("../../../src/durability/failpoints.js"),
+  ]);
+  const event = rollout.session.emit({
+    eventId: "run-terminal-1",
+    id: "run-terminal-1",
+    msg: {
+      type: "run_terminal",
+      payload: {
+        runId: RUN_ID,
+        epoch: 1,
+        status: "completed",
+        exitCode: 0,
+        stopReason: "end_turn",
+        finalMessage: "finished once",
+        usage: {
+          inputTokens: 8,
+          outputTokens: 4,
+          totalTokens: 12,
+          costUsd: 0.01,
+        },
+        lastSequenceBeforeTerminal: rollout.eventLog.lastSeq,
+        finishedAt: FINISHED_AT,
+      },
+    },
+  });
+  if (event.eventId === undefined) {
+    throw new Error("canonical terminal event lacks eventId");
+  }
+  hitM4DurabilityFailpoint("before_terminal_commit");
+  projection.repository.recordTerminalResult({
+    epoch: 1,
+    eventId: event.eventId,
+    result: {
+      runId: RUN_ID,
+      status: "completed",
+      exitCode: 0,
+      stopReason: "end_turn",
+      finalMessage: "finished once",
+      usage: {
+        inputTokens: 8,
+        outputTokens: 4,
+        totalTokens: 12,
+        costUsd: 0.01,
+      },
+      lastSequence: event.seq ?? null,
+      finishedAt: FINISHED_AT,
+    },
+  });
+  hitM4DurabilityFailpoint("after_terminal_commit");
+  throw new Error("terminal failpoint did not terminate the child");
+}
+
+async function crash(
+  failpoint: M4DurabilityFailpoint,
+  paths: FixturePaths,
+): Promise<never> {
+  if (
+    failpoint === "after_admission_sqlite_commit_before_canonical_append" ||
+    failpoint.includes("reservation_commit")
+  ) {
+    return crashReservation(paths);
+  }
+  if (failpoint.includes("model_response_commit")) return crashModel(paths);
+  if (failpoint.includes("tool_")) return crashTool(paths);
+  if (failpoint.includes("artifact_commit")) return crashArtifact(paths);
+  if (failpoint.includes("event_publish")) return crashEventPublish(paths);
+  if (failpoint.includes("terminal_commit")) return crashTerminal(paths);
+  throw new Error(`unsupported failpoint: ${failpoint}`);
+}
+
+function countBy<T extends string>(values: readonly T[]): Record<T, number> {
+  const counts = {} as Record<T, number>;
+  for (const value of values) counts[value] = (counts[value] ?? 0) + 1;
+  return counts;
+}
+
+async function recoverAdmissionAndEffects(
+  failpoint: M4DurabilityFailpoint,
+  paths: FixturePaths,
+) {
+  const [{ openStateDatabases }, { ExecutionAdmissionRepository }] =
+    await Promise.all([
+      import("../../../src/state/sqlite-driver.js"),
+      import("../../../src/state/execution-admission.js"),
+    ]);
+  let effectRecovery = "not_applicable";
+  if (failpoint.includes("tool_")) {
+    // Production RolloutStore recovery is the sole authority for classifying a
+    // dangling intent. The fixture only inspects its canonical event and
+    // projection; it must not synthesize a competing recovery transition.
+    const resumed = await openRolloutSession(paths, { resume: true });
+    resumed.rolloutStore.close();
+    const projection = await createEffectProjection(paths);
+    const effect = projection.repository.getEffect(RUN_ID, TOOL_STEP_ID);
+    const auditDriver = openStateDatabases({
+      cwd: paths.cwd,
+      agencHome: paths.home,
+    });
+    const audit = new ExecutionAdmissionRepository(auditDriver, {
+      ownerId: "failure-matrix-pre-recovery",
+      ownerPid: process.pid,
+    });
+    const reservation = audit.listReservations({ runId: RUN_ID, limit: 2 })[0];
+    if (effect?.outcome === "cancelled") {
+      effectRecovery = "cancelled_before_dispatch";
+    } else if (effect?.outcome === "unknown_outcome") {
+      effectRecovery = "review_locked_unknown_outcome";
+    } else if (
+      effect?.outcome === "committed" &&
+      reservation?.status === "dispatched"
+    ) {
+      audit.reconcile(reservation.reservationId, {
+        kind: "reported",
+        usage: { inputTokens: 0, outputTokens: 0, costUsd: 0 },
+        reason: "durable_effect_result_recovered",
+      });
+      effectRecovery = "acknowledged_from_durable_result";
+    } else {
+      effectRecovery = effect?.outcome ?? "no_effect";
+    }
+    auditDriver.close();
+    projection.driver.close();
+  }
+
+  const driver = openStateDatabases({ cwd: paths.cwd, agencHome: paths.home });
+  const repository = new ExecutionAdmissionRepository(driver, {
+    ownerId: "failure-matrix-recovery",
+    ownerPid: process.pid,
+  });
+  const firstRecovery = repository.recover({ activeOwnerIds: new Set() });
+  const secondRecovery = repository.recover({ activeOwnerIds: new Set() });
+  const reservations = repository.listReservations({ runId: RUN_ID, limit: 10 });
+  const jobs = repository.list({ runId: RUN_ID, limit: 10 });
+  const journal = repository.listJournal({ runId: RUN_ID, limit: 100 });
+  driver.close();
+
+  let effect;
+  let pendingEffectReviews = 0;
+  if (failpoint.includes("tool_")) {
+    const projection = await createEffectProjection(paths);
+    effect = projection.repository.getEffect(RUN_ID, TOOL_STEP_ID);
+    pendingEffectReviews = projection.repository.listPendingEffectReviews(RUN_ID).length;
+    projection.driver.close();
+  }
+  return {
+    effect,
+    effectRecovery,
+    firstRecovery,
+    secondRecovery,
+    pendingEffectReviews,
+    jobs: jobs.map((job) => ({ id: job.id, status: job.status })),
+    reservations: reservations.map((reservation) => ({
+      id: reservation.reservationId,
+      status: reservation.status,
+    })),
+    journalCounts: countBy(journal.map((event) => event.event)),
+  };
+}
+
+async function recoverArtifact(paths: FixturePaths) {
+  const firstResume = await openRolloutSession(paths, { resume: true });
+  firstResume.rolloutStore.close();
+  const secondResume = await openRolloutSession(paths, { resume: true });
+  secondResume.rolloutStore.close();
+  const events = canonicalEvents(paths);
+  const intents = events.filter(
+    (event) => event.msg.type === "artifact_intent",
+  );
+  if (intents.length !== 1 || intents[0]!.msg.type !== "artifact_intent") {
+    throw new Error(`expected one artifact intent, got ${intents.length}`);
+  }
+  const targetPath = intents[0]!.msg.payload.targetPath;
+  const files = walkFiles(dirname(targetPath));
+  const committed = events.filter(
+    (event) => event.msg.type === "artifact_committed",
+  );
+  const decisions = events.filter(
+    (event) => event.msg.type === "recovery_decision",
+  );
+  return {
+    targetState: existsSync(targetPath) ? "complete" : "missing",
+    ...(existsSync(targetPath)
+      ? { bytes: readFileSync(targetPath, "utf8") }
+      : {}),
+    visibleTargets: files.filter((file) => file === targetPath).length,
+    orphanTemps: files.filter(
+      (file) => file.startsWith(`${targetPath}.`) && file.endsWith(".tmp"),
+    ).length,
+    intentSequences: intents.map((event) => event.seq),
+    committedOutcomes: committed.flatMap((event) =>
+      event.msg.type === "artifact_committed" ? [event.msg.payload.outcome] : [],
+    ),
+    committedIntentSequences: committed.flatMap((event) =>
+      event.msg.type === "artifact_committed"
+        ? [event.msg.payload.intentEventSeq]
+        : [],
+    ),
+    recoveryDecisions: decisions.flatMap((event) =>
+      event.msg.type === "recovery_decision"
+        ? [event.msg.payload.decision]
+        : [],
+    ),
+    recoveryEvidenceSequences: decisions.flatMap((event) =>
+      event.msg.type === "recovery_decision"
+        ? [event.msg.payload.evidenceEventSeq]
+        : [],
+    ),
+  };
+}
+
+async function recoverPublishedEvent(paths: FixturePaths) {
+  const rollout = await openRolloutSession(paths, { resume: true });
+  rollout.rolloutStore.close();
+  const eventsAfter = canonicalEvents(paths).filter(
+    (event) => event.id === "publish-event-1",
+  );
+  const replayedTwice = [...eventsAfter, ...eventsAfter];
+  const reconnectKeys = new Set(
+    replayedTwice.map((event) => `${event.seq}:${event.eventId}`),
+  );
+  return {
+    canonicalCount: eventsAfter.length,
+    canonicalCoordinates: eventsAfter.map((event) => ({
+      eventId: event.eventId,
+      sequence: event.seq,
+    })),
+    liveObservations: readJsonLines(paths.liveObservations),
+    reconnectUniqueDeliveries: reconnectKeys.size,
+  };
+}
+
+async function recoverTerminal(paths: FixturePaths) {
+  const [{ openStateDatabases }, { StateRunDurabilityRepository }] =
+    await Promise.all([
+      import("../../../src/state/sqlite-driver.js"),
+      import("../../../src/state/run-durability.js"),
+    ]);
+  const events = canonicalEvents(paths).filter(
+    (event) => event.msg.type === "run_terminal",
+  );
+  if (events.length !== 1 || events[0]!.msg.type !== "run_terminal") {
+    throw new Error(`expected one canonical terminal event, got ${events.length}`);
+  }
+  const event = events[0]!;
+  const payload = event.msg.payload;
+  const driver = openStateDatabases({ cwd: paths.cwd, agencHome: paths.home });
+  const repository = new StateRunDurabilityRepository(driver);
+  repository.ensureInitialEpoch({
+    runId: RUN_ID,
+    openedAt: OPENED_AT,
+  });
+  if (event.eventId === undefined) {
+    throw new Error("canonical terminal event lacks eventId");
+  }
+  const input = {
+    epoch: payload.epoch,
+    eventId: event.eventId,
+    result: {
+      runId: payload.runId,
+      status: payload.status,
+      exitCode: payload.exitCode,
+      stopReason: payload.stopReason,
+      finalMessage: payload.finalMessage,
+      usage: payload.usage,
+      lastSequence: event.seq,
+      finishedAt: payload.finishedAt,
+    },
+  } as const;
+  const firstProjection = repository.recordTerminalResult(input);
+  const secondProjection = repository.recordTerminalResult(input);
+  const history = repository.listTerminalHistory(RUN_ID);
+  driver.close();
+  return {
+    canonicalCount: events.length,
+    firstProjectionApplied: firstProjection.applied,
+    secondProjectionApplied: secondProjection.applied,
+    history,
+  };
+}
+
+async function recover(
+  failpoint: M4DurabilityFailpoint,
+  paths: FixturePaths,
+): Promise<unknown> {
+  const base = {
+    failpoint,
+    canonicalEventCounts: countBy(
+      canonicalEvents(paths).map((event) => event.msg.type),
+    ),
+    modelPhysicalAttempts: readJsonLines(paths.modelReceipt).length,
+    toolPhysicalAttempts: readJsonLines(paths.toolReceipt).length,
+  };
+  if (
+    failpoint === "after_admission_sqlite_commit_before_canonical_append" ||
+    failpoint.includes("reservation_commit") ||
+    failpoint.includes("model_response_commit") ||
+    failpoint.includes("tool_")
+  ) {
+    const admission = await recoverAdmissionAndEffects(failpoint, paths);
+    return {
+      ...base,
+      canonicalEventCounts: countBy(
+        canonicalEvents(paths).map((event) => event.msg.type),
+      ),
+      admission,
+    };
+  }
+  if (failpoint.includes("artifact_commit")) {
+    const artifact = await recoverArtifact(paths);
+    return {
+      ...base,
+      canonicalEventCounts: countBy(
+        canonicalEvents(paths).map((event) => event.msg.type),
+      ),
+      artifact,
+    };
+  }
+  if (failpoint.includes("event_publish")) {
+    return { ...base, publication: await recoverPublishedEvent(paths) };
+  }
+  if (failpoint.includes("terminal_commit")) {
+    return { ...base, terminal: await recoverTerminal(paths) };
+  }
+  throw new Error(`unsupported failpoint: ${failpoint}`);
+}
+
+const command = requireArgument(process.argv[2], "command") as Command;
+const failpoint = requireArgument(
+  process.argv[3],
+  "failpoint",
+) as M4DurabilityFailpoint;
+const paths = pathsFor(requireArgument(process.argv[4], "state directory"));
+
+if (command === "crash") {
+  await crash(failpoint, paths);
+} else if (command === "recover") {
+  process.stdout.write(`${JSON.stringify(await recover(failpoint, paths))}\n`);
+} else {
+  throw new Error(`unsupported command: ${command}`);
+}

--- a/runtime/tests/durability/fixtures/node-test-loader.mjs
+++ b/runtime/tests/durability/fixtures/node-test-loader.mjs
@@ -1,0 +1,32 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const FEATURE_MODULE = new URL("../../../src/build/feature.ts", import.meta.url).href;
+const RUNTIME_SRC = new URL("../../../src/", import.meta.url);
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "bun:bundle") {
+    return { url: FEATURE_MODULE, shortCircuit: true };
+  }
+  if (specifier.startsWith("src/")) {
+    return nextResolve(new URL(specifier.slice("src/".length), RUNTIME_SRC).href, context);
+  }
+  return nextResolve(specifier, context);
+}
+
+/**
+ * Mirror the runtime bundler's text-loader behavior for Markdown imports in
+ * the standalone crash/recovery child. TypeScript is still handled by tsx.
+ */
+export async function load(url, context, nextLoad) {
+  if (url.startsWith("file:") && url.endsWith(".md")) {
+    const source = await readFile(fileURLToPath(url), "utf8");
+    return {
+      format: "module",
+      shortCircuit: true,
+      source: `export default ${JSON.stringify(source)};`,
+    };
+  }
+
+  return nextLoad(url, context);
+}

--- a/runtime/tests/durability/offline-rollout.test.ts
+++ b/runtime/tests/durability/offline-rollout.test.ts
@@ -1,0 +1,136 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { withPinnedOfflineRolloutLease } from "../../src/durability/offline-rollout.js";
+
+const created: string[] = [];
+
+afterEach(() => {
+  for (const path of created.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function fixture(rootName: "sessions" | "archived_sessions" = "sessions") {
+  const root = mkdtempSync(join(tmpdir(), "agenc-offline-rollout-"));
+  created.push(root);
+  const projectDir = join(root, "project");
+  const sessionId = "session-1";
+  const sessionDirectory = join(projectDir, rootName, sessionId);
+  const sourcePath = join(
+    sessionDirectory,
+    "rollout-2026-07-18T00-00-00-000Z-session-1.jsonl",
+  );
+  mkdirSync(sessionDirectory, { recursive: true });
+  writeFileSync(sourcePath, "committed\n", { mode: 0o600 });
+  return { root, projectDir, sessionId, sessionDirectory, sourcePath };
+}
+
+describe.skipIf(process.platform === "win32")(
+  "descriptor-pinned offline rollout mutation",
+  () => {
+    it.each(["sessions", "archived_sessions"] as const)(
+      "accepts only an exact regular rollout below %s",
+      (rootName) => {
+        const target = fixture(rootName);
+        withPinnedOfflineRolloutLease(target, (rollout) => {
+          expect(rollout.readUtf8()).toBe("committed\n");
+          rollout.appendAndSync("review\n");
+        });
+        expect(readFileSync(target.sourcePath, "utf8")).toBe(
+          "committed\nreview\n",
+        );
+      },
+    );
+
+    it("rejects an external binding and a source symlink without touching the target", () => {
+      const target = fixture();
+      const external = join(
+        target.root,
+        "rollout-2026-07-18T00-00-00-000Z-external.jsonl",
+      );
+      writeFileSync(external, "external\n", { mode: 0o600 });
+
+      expect(() =>
+        withPinnedOfflineRolloutLease(
+          { ...target, sourcePath: external },
+          (rollout) => rollout.appendAndSync("must-not-append\n"),
+        ),
+      ).toThrow(/outside this project's sessions\/archived_sessions roots/);
+
+      rmSync(target.sourcePath);
+      symlinkSync(external, target.sourcePath);
+      expect(() =>
+        withPinnedOfflineRolloutLease(target, (rollout) =>
+          rollout.appendAndSync("must-not-append\n"),
+        ),
+      ).toThrow(/source must be one regular, non-linked file/);
+      expect(readFileSync(external, "utf8")).toBe("external\n");
+    });
+
+    it("rejects a source replacement after the lease without writing either inode", () => {
+      const target = fixture();
+      const original = join(target.sessionDirectory, "original.jsonl");
+
+      expect(() =>
+        withPinnedOfflineRolloutLease(target, (rollout) => {
+          renameSync(target.sourcePath, original);
+          writeFileSync(target.sourcePath, "replacement\n", { mode: 0o600 });
+          rollout.appendAndSync("must-not-append\n");
+        }),
+      ).toThrow(/source changed during offline mutation/);
+      expect(readFileSync(original, "utf8")).toBe("committed\n");
+      expect(readFileSync(target.sourcePath, "utf8")).toBe("replacement\n");
+    });
+
+    it("rejects a parent replacement after the lease without following it", () => {
+      const target = fixture();
+      const originalDirectory = join(target.root, "original-session");
+
+      expect(() =>
+        withPinnedOfflineRolloutLease(target, (rollout) => {
+          renameSync(target.sessionDirectory, originalDirectory);
+          mkdirSync(target.sessionDirectory);
+          writeFileSync(
+            join(target.sessionDirectory, basename(target.sourcePath)),
+            "replacement\n",
+            { mode: 0o600 },
+          );
+          rollout.appendAndSync("must-not-append\n");
+        }),
+      ).toThrow(/directory changed during offline mutation/);
+      expect(
+        readFileSync(join(originalDirectory, basename(target.sourcePath)), "utf8"),
+      ).toBe("committed\n");
+      expect(readFileSync(target.sourcePath, "utf8")).toBe("replacement\n");
+    });
+
+    it("scans past a partial tail larger than one MiB without losing the committed prefix", () => {
+      const target = fixture();
+      writeFileSync(
+        target.sourcePath,
+        `committed\n${"x".repeat(1024 * 1024 + 257)}`,
+        { mode: 0o600 },
+      );
+
+      withPinnedOfflineRolloutLease(target, (rollout) => {
+        expect(rollout.readUtf8()).toBe("committed\n");
+        rollout.appendAndSync("review\n");
+      });
+      expect(readFileSync(target.sourcePath, "utf8")).toBe(
+        "committed\nreview\n",
+      );
+    });
+  },
+);

--- a/runtime/tests/helpers/test-effect-journal.ts
+++ b/runtime/tests/helpers/test-effect-journal.ts
@@ -1,0 +1,19 @@
+import { EventLog, type Event } from "../../src/session/event-log.js";
+
+/**
+ * Minimal canonical-effect seam for unit tests that exercise admitted legacy
+ * entry points without constructing a complete Session/RolloutStore pair.
+ */
+export function createTestEffectJournal() {
+  const eventLog = new EventLog();
+  const effectEvents: Event[] = [];
+  return {
+    effectEvents,
+    eventLog,
+    rolloutStore: {
+      assertToolAdmissionAllowed: () => {},
+      recordEffectEvent: (event: Event) => effectEvents.push(event),
+    },
+    emit: (event: Event) => eventLog.emit(event),
+  };
+}

--- a/runtime/tests/mcp-client/prompts.test.ts
+++ b/runtime/tests/mcp-client/prompts.test.ts
@@ -10,6 +10,7 @@ import {
   setCurrentRuntimeSession,
 } from "../session/current-session.js";
 import type { Session } from "../session/session.js";
+import { createTestEffectJournal } from "../helpers/test-effect-journal.js";
 import { createPromptBridge } from "./prompts.js";
 
 const UNTRUSTED_MCP_PROMPT_BOUNDARY =
@@ -54,12 +55,14 @@ function promptLease(
   };
 }
 
-function installPromptAdmission(options: {
-  acquire?: (
-    input: AdmissionAcquireInput,
-    signal?: AbortSignal,
-  ) => Promise<AdmissionLease>;
-} = {}) {
+function installPromptAdmission(
+  options: {
+    acquire?: (
+      input: AdmissionAcquireInput,
+      signal?: AbortSignal,
+    ) => Promise<AdmissionLease>;
+  } = {},
+) {
   clearCurrentRuntimeSession();
   const acquire = vi.fn(
     options.acquire ??
@@ -87,6 +90,7 @@ function installPromptAdmission(options: {
     subscribe: vi.fn(() => () => {}),
   } as unknown as ExecutionAdmissionClient;
   setCurrentRuntimeSession({
+    ...createTestEffectJournal(),
     conversationId: "session-prompt",
     services: { executionAdmission: admission, admissionRequired: true },
   } as unknown as Session);
@@ -255,10 +259,12 @@ describe("createPromptBridge", () => {
     const getPrompt = vi.fn();
     const bridge = await createPromptBridge(makeClient({ getPrompt }), "srv");
 
-    await expect(bridge.renderPrompt("missing-identity")).rejects.toMatchObject({
-      code: "ADMISSION_DENIED",
-      reason: "tool_admission_session_unavailable",
-    });
+    await expect(bridge.renderPrompt("missing-identity")).rejects.toMatchObject(
+      {
+        code: "ADMISSION_DENIED",
+        reason: "tool_admission_session_unavailable",
+      },
+    );
     expect(getPrompt).not.toHaveBeenCalled();
   });
 
@@ -276,10 +282,7 @@ describe("createPromptBridge", () => {
       },
     );
     const bridge = await createPromptBridge(makeClient({ getPrompt }), "srv");
-    const cancellation = new AdmissionDeniedError(
-      "run_cancelled",
-      "cancelled",
-    );
+    const cancellation = new AdmissionDeniedError("run_cancelled", "cancelled");
 
     const rendering = bridge.renderPrompt("cancelled");
     const rejection = expect(rendering).rejects.toBe(cancellation);

--- a/runtime/tests/memory/session/sessionMemory.test.ts
+++ b/runtime/tests/memory/session/sessionMemory.test.ts
@@ -27,6 +27,7 @@ import {
 import type { AdmissionLease } from "../../budget/admission-types.js";
 import type { LLMMessage } from "../../llm/types.js";
 import type { Session } from "../../session/session.js";
+import { EventLog, type Event } from "../../session/event-log.js";
 import {
   clearSessionReadState,
   getSessionReadSnapshot,
@@ -215,6 +216,7 @@ function makeAdmissionHarness(
     outcome: "reconciled" as const,
   }));
   const holdUnknown = vi.fn();
+  const voidReservation = vi.fn();
   const acknowledgeCompletion = vi.fn();
   const admission = {
     scope: {
@@ -227,7 +229,7 @@ function makeAdmissionHarness(
     markDispatched,
     reconcile,
     holdUnknown,
-    void: vi.fn(),
+    void: voidReservation,
     acknowledgeCompletion,
     recordFallback: vi.fn(),
     forSession: vi.fn(),
@@ -236,8 +238,16 @@ function makeAdmissionHarness(
   const base = makeSession(sessionId) as unknown as {
     readonly services: Record<string, unknown>;
   };
+  const eventLog = new EventLog();
+  const effectEvents: Event[] = [];
   const session = {
     ...base,
+    eventLog,
+    rolloutStore: {
+      assertToolAdmissionAllowed: () => {},
+      recordEffectEvent: (event: Event) => effectEvents.push(event),
+    },
+    emit: (event: Event) => eventLog.emit(event),
     services: {
       ...base.services,
       admissionRequired: true,
@@ -251,6 +261,8 @@ function makeAdmissionHarness(
     markDispatched,
     reconcile,
     session,
+    effectEvents,
+    voidReservation,
   };
 }
 
@@ -431,6 +443,18 @@ describe("session memory runtime", () => {
     expect(harness.acknowledgeCompletion).toHaveBeenCalledWith(
       "reservation-session-admitted",
     );
+    expect(harness.effectEvents.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "effect_result",
+    ]);
+    expect(
+      harness.effectEvents.every(
+        (event) =>
+          (event.msg.type === "effect_intent" ||
+            event.msg.type === "effect_result") &&
+          event.msg.payload.runId === "run-session-admitted",
+      ),
+    ).toBe(true);
     expect(await readFile(setup.memoryPath, "utf8")).toContain("# Current State");
   });
 
@@ -497,7 +521,7 @@ describe("session memory runtime", () => {
     });
   });
 
-  it("forwards lease cancellation and settles the dispatched setup as unknown", async () => {
+  it("forwards lease cancellation and durably voids setup before dispatch", async () => {
     const controller = new AbortController();
     const cancellation = new AdmissionDeniedError(
       "parent_cancelled",
@@ -520,10 +544,11 @@ describe("session memory runtime", () => {
       }),
     ).rejects.toBe(cancellation);
     await expect(stat(memoryPath)).rejects.toMatchObject({ code: "ENOENT" });
-    expect(harness.markDispatched).toHaveBeenCalledOnce();
-    expect(harness.holdUnknown).toHaveBeenCalledWith(
+    expect(harness.markDispatched).not.toHaveBeenCalled();
+    expect(harness.holdUnknown).not.toHaveBeenCalled();
+    expect(harness.voidReservation).toHaveBeenCalledWith(
       "reservation-session-cancelled",
-      "tool_cancelled_after_dispatch",
+      "tool_cancelled_before_dispatch",
     );
     expect(harness.reconcile).not.toHaveBeenCalled();
     expect(harness.acknowledgeCompletion).toHaveBeenCalledWith(

--- a/runtime/tests/permissions/guardian/arbiter.test.ts
+++ b/runtime/tests/permissions/guardian/arbiter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import { ApprovalStore } from "../approval-cache.js";
 import { APPROVED, APPROVED_FOR_SESSION } from "../review-decision.js";
 import { createEmptyToolPermissionContext } from "../types.js";
+import type { Event } from "../../session/event-log.js";
 import type { ToolInvocation } from "../../tools/context.js";
 import type { Tool } from "../../tools/types.js";
 import {
@@ -13,19 +14,26 @@ import {
 } from "./arbiter.js";
 import type { GuardianApprovalReviewer } from "./reviewer.js";
 
-function invocation(opts: {
-  readonly services?: Record<string, unknown>;
-  readonly approvalPolicy?: string;
-  readonly approvalsReviewer?: string;
-  readonly activeTurn?: {
-    unsafePeek?: () => { readonly turnId?: unknown } | null | undefined;
-  };
-} = {}): ToolInvocation {
+function invocation(
+  opts: {
+    readonly services?: Record<string, unknown>;
+    readonly session?: ToolInvocation["session"];
+    readonly approvalPolicy?: string;
+    readonly approvalsReviewer?: string;
+    readonly activeTurn?: {
+      unsafePeek?: () => { readonly turnId?: unknown } | null | undefined;
+    };
+  } = {},
+): ToolInvocation {
   return {
-    session: {
-      services: opts.services ?? {},
-      ...(opts.activeTurn !== undefined ? { activeTurn: opts.activeTurn } : {}),
-    } as never,
+    session:
+      opts.session ??
+      ({
+        services: opts.services ?? {},
+        ...(opts.activeTurn !== undefined
+          ? { activeTurn: opts.activeTurn }
+          : {}),
+      } as never),
     turn: {
       subId: "turn-1",
       cwd: "/repo",
@@ -57,6 +65,90 @@ function approvalCtx(inv = invocation()): ApprovalCtx {
 }
 
 describe("guardian arbiter", () => {
+  test("fsync-journals the request and linked answer around every shared resolver", async () => {
+    const events: Event[] = [];
+    let sequence = 0;
+    const session = {
+      conversationId: "run-approval",
+      services: { admissionRequired: true },
+      rolloutStore: {
+        readAll: () =>
+          events.map((event) => ({
+            type: "event_msg" as const,
+            payload: event,
+          })),
+      },
+      emit: (event: Event): Event => {
+        const nextSequence = ++sequence;
+        const stamped = {
+          ...event,
+          eventId: `approval-event-${nextSequence}`,
+          seq: nextSequence,
+        };
+        events.push(stamped);
+        return stamped;
+      },
+    } as unknown as ToolInvocation["session"];
+    const answer = Promise.withResolvers<typeof APPROVED>();
+    const resolver = vi.fn(async () => {
+      expect(events.map((event) => event.msg.type)).toEqual([
+        "request_permissions",
+      ]);
+      return answer.promise;
+    });
+    const inv = invocation({ session });
+
+    const pending = requestApproval({
+      ctx: approvalCtx(inv),
+      args: { command: "pwd" },
+      resolver: { request: resolver },
+    });
+    await vi.waitFor(() => expect(resolver).toHaveBeenCalledOnce());
+    answer.resolve(APPROVED);
+    await expect(pending).resolves.toMatchObject({
+      decision: APPROVED,
+      source: "resolver",
+    });
+
+    expect(events.map((event) => event.msg.type)).toEqual([
+      "request_permissions",
+      "permission_decision",
+    ]);
+    const request = events[0];
+    const decision = events[1];
+    expect(request?.eventId).toBe("approval-event-1");
+    expect(request?.seq).toBe(1);
+    expect(decision?.msg).toMatchObject({
+      type: "permission_decision",
+      payload: {
+        requestEventId: "approval-event-1",
+        requestEventSeq: 1,
+        decision: "approved",
+        source: "resolver",
+      },
+    });
+  });
+
+  test("does not ask a resolver when the canonical permission journal is detached", async () => {
+    const resolver = vi.fn(async () => APPROVED);
+    const session = {
+      conversationId: "run-detached",
+      services: { admissionRequired: true },
+      rolloutStore: null,
+      emit: vi.fn(),
+    } as unknown as ToolInvocation["session"];
+
+    await expect(
+      requestApproval({
+        ctx: approvalCtx(invocation({ session })),
+        resolver: { request: resolver },
+      }),
+    ).rejects.toThrow(
+      "permission request call-1 has no canonical rollout store",
+    );
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
   test("raw approval hook wins before resolver", async () => {
     const resolver = vi.fn(async () => APPROVED);
     const result = await requestApproval({
@@ -312,8 +404,7 @@ describe("guardian arbiter", () => {
     let activeTurn: string | null = "turn-1";
     const inv = invocation({
       activeTurn: {
-        unsafePeek: () =>
-          activeTurn === null ? null : { turnId: activeTurn },
+        unsafePeek: () => (activeTurn === null ? null : { turnId: activeTurn }),
       },
     });
     const resolver = vi.fn(async () => {

--- a/runtime/tests/sdk-package/events.contract.test.ts
+++ b/runtime/tests/sdk-package/events.contract.test.ts
@@ -36,6 +36,8 @@ describe("agenc-sdk prompt event mapping", () => {
       type: "elicitation_request",
       kind: "request_user_input",
       requestId: "request_1",
+      eventId: "event_1",
+      sequence: 1,
       clientAction,
     });
   });
@@ -58,5 +60,34 @@ describe("agenc-sdk prompt event mapping", () => {
         },
       }),
     ).not.toHaveProperty("clientAction");
+  });
+
+  it("surfaces a JSON-RPC live retention gap instead of dropping it", () => {
+    expect(
+      promptEventFromNotification({
+        jsonrpc: "2.0",
+        method: "event.event_gap",
+        params: {
+          type: "event_gap",
+          kind: "event_gap",
+          sessionId: "session_1",
+          runId: "run_1",
+          reason: "retention",
+          retiredCount: 7,
+          afterSequence: 3,
+          firstAvailableSequence: 11,
+          source: "multiplexer_retention",
+        },
+      }),
+    ).toEqual({
+      type: "gap",
+      kind: "event_gap",
+      sessionId: "session_1",
+      runId: "run_1",
+      reason: "retention",
+      retiredCount: 7,
+      afterSequence: 3,
+      firstAvailableSequence: 11,
+    });
   });
 });

--- a/runtime/tests/sdk-package/replay-safe-client.contract.test.ts
+++ b/runtime/tests/sdk-package/replay-safe-client.contract.test.ts
@@ -1,0 +1,882 @@
+/**
+ * Revert-sensitive SDK contract for M4 durable replay. The daemon is faked at
+ * the JSON-RPC boundary so cursor, duplicate, gap, and terminal-result
+ * semantics are tested independently of a particular transport.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  AgencRunReplayGapError,
+  AgencRunReplayProtocolError,
+  createAgencClient,
+  isRunAdmissionReplayResult,
+  type AgencDaemonMethod,
+  type AgencDaemonRequest,
+  type AgencDaemonResponse,
+  type AgencRunReplayDuplicate,
+  type AgencTransport,
+  type JsonObject,
+  type RunAdmissionJournalEvent,
+  type RunJournalEvent,
+  type RunReplayEvent,
+  type RunReplayResult,
+  type RunResultResult,
+} from "../../../packages/agenc-sdk/src/index";
+
+type RunRequest =
+  | AgencDaemonRequest<"run.replay">
+  | AgencDaemonRequest<"run.result">;
+
+class ScriptedRunTransport implements AgencTransport {
+  readonly requests: RunRequest[] = [];
+  readonly #replay: (
+    afterSequence: number,
+    limit: number,
+  ) => RunReplayResult;
+  readonly #result: RunResultResult;
+
+  constructor(options: {
+    replay: (afterSequence: number, limit: number) => RunReplayResult;
+    result?: RunResultResult;
+  }) {
+    this.#replay = options.replay;
+    this.#result = options.result ?? terminalResult();
+  }
+
+  async request<Method extends AgencDaemonMethod>(
+    request: AgencDaemonRequest<Method>,
+  ): Promise<AgencDaemonResponse<Method>> {
+    if (request.method === "run.replay") {
+      this.requests.push(request as RunRequest);
+      const params = request.params as JsonObject;
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: this.#replay(
+          Number(params.afterSequence ?? 0),
+          Number(params.limit ?? 100),
+        ),
+      } as AgencDaemonResponse<Method>;
+    }
+    if (request.method === "run.result") {
+      this.requests.push(request as RunRequest);
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: this.#result,
+      } as AgencDaemonResponse<Method>;
+    }
+    throw new Error(`unexpected method: ${request.method}`);
+  }
+}
+
+function journalEvent(
+  sequence: number,
+  eventId = `event_${String(sequence)}`,
+  payload: JsonObject = { value: sequence },
+): RunJournalEvent {
+  return {
+    sequence,
+    eventId,
+    runId: "run_1",
+    category: "run",
+    kind: "run_transition",
+    event: "run.progress",
+    timestamp: `2026-07-18T00:00:0${String(sequence)}.000Z`,
+    payload,
+  };
+}
+
+function admissionEvent(sequence: number): RunAdmissionJournalEvent {
+  return {
+    sequence,
+    eventId: `admission_${String(sequence)}`,
+    timestamp: `2026-07-18T00:00:0${String(sequence)}.000Z`,
+    runId: "run_1",
+    stepId: `step_${String(sequence)}`,
+    kind: "model",
+    event: "admitted",
+  };
+}
+
+function replayPage(options: {
+  afterSequence: number;
+  limit?: number;
+  events?: readonly RunJournalEvent[];
+  hasMore?: boolean;
+  nextAfterSequence?: number;
+  firstAvailableSequence?: number;
+  lastAvailableSequence?: number;
+  gap?: RunReplayResult["gap"];
+}): RunReplayResult {
+  const events = options.events ?? [];
+  return {
+    runId: "run_1",
+    afterSequence: options.afterSequence,
+    limit: options.limit ?? 2,
+    events,
+    hasMore: options.hasMore ?? false,
+    nextAfterSequence:
+      options.nextAfterSequence ??
+      events.at(-1)?.sequence ??
+      options.afterSequence,
+    firstAvailableSequence:
+      options.firstAvailableSequence ?? events.at(0)?.sequence ?? 1,
+    lastAvailableSequence:
+      options.lastAvailableSequence ??
+      events.at(-1)?.sequence ??
+      options.afterSequence,
+    gap: options.gap ?? null,
+    source: {
+      kind: "run_journal",
+      available: true,
+      sequenceScope: "run",
+      canonical: "rollout_jsonl",
+      projection: "thread_rollout_items",
+      projectDir: "/tmp/project",
+    },
+  };
+}
+
+function terminalResult(): RunResultResult {
+  return {
+    runId: "run_1",
+    status: "completed",
+    terminal: true,
+    terminalAt: "2026-07-18T00:00:04.000Z",
+    outcome: "completed",
+    epoch: 1,
+    durableRun: {
+      objective: "test durable replay",
+      status: "completed",
+      startedAt: "2026-07-18T00:00:00.000Z",
+      lastActiveAt: "2026-07-18T00:00:04.000Z",
+    },
+    output: {
+      available: true,
+      exitCode: 0,
+      stopReason: "completed",
+      finalMessage: "durable answer",
+      usage: {
+        inputTokens: 5,
+        outputTokens: 3,
+        totalTokens: 8,
+        costUsd: 0.001,
+      },
+      lastSequence: 4,
+    },
+    source: {
+      kind: "existing_state_database",
+      projectDir: "/tmp/project",
+      readonly: true,
+    },
+  };
+}
+
+describe("agenc-sdk replay-safe run attachment", () => {
+  it("preserves the M3 admission event contract behind the source guard", () => {
+    const legacyEvent = admissionEvent(1);
+    const page: RunReplayResult = {
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 1,
+      events: [legacyEvent],
+      hasMore: false,
+      nextAfterSequence: 1,
+      firstAvailableSequence: 1,
+      lastAvailableSequence: 1,
+      gap: null,
+      source: {
+        kind: "execution_admission_journal",
+        available: true,
+        sequenceScope: "project_state_database",
+        projectDir: "/tmp/project",
+      },
+    };
+
+    expect(isRunAdmissionReplayResult(page)).toBe(true);
+    if (!isRunAdmissionReplayResult(page)) throw new Error("wrong replay source");
+    const sourceCompatibleEvent: RunAdmissionJournalEvent = page.events[0]!;
+    expect(sourceCompatibleEvent.timestamp).toBe(legacyEvent.timestamp);
+    expect(sourceCompatibleEvent.stepId).toBe(legacyEvent.stepId);
+  });
+
+  it("advances an exclusive cursor and makes duplicate delivery observable and harmless", async () => {
+    const duplicateReports: AgencRunReplayDuplicate[] = [];
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => {
+        if (afterSequence === 0) {
+          return replayPage({
+            afterSequence,
+            limit,
+            events: [journalEvent(1), journalEvent(1), journalEvent(2)],
+            hasMore: true,
+            nextAfterSequence: 2,
+            lastAvailableSequence: 3,
+          });
+        }
+        return replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(2), journalEvent(3)],
+          nextAfterSequence: 3,
+        });
+      },
+    });
+    const client = createAgencClient({ transport });
+    const attachment = client.reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 3,
+      onDuplicate: (duplicate) => duplicateReports.push(duplicate),
+    });
+
+    const events: RunReplayEvent[] = [];
+    const deliveredCursors: number[] = [];
+    for await (const event of attachment) {
+      events.push(event);
+      deliveredCursors.push(attachment.cursor().afterSequence);
+    }
+
+    expect(events.map(({ sequence, eventId }) => ({ sequence, eventId }))).toEqual([
+      { sequence: 1, eventId: "event_1" },
+      { sequence: 2, eventId: "event_2" },
+      { sequence: 3, eventId: "event_3" },
+    ]);
+    expect(duplicateReports.map((report) => report.reason)).toEqual([
+      "same_identity",
+      "same_identity",
+    ]);
+    expect(attachment.diagnostics()).toEqual({
+      duplicatesDropped: 2,
+      trackedIdentities: 3,
+      identityWindow: 1_024,
+    });
+    expect(deliveredCursors).toEqual([1, 2, 3]);
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 3 });
+    expect(
+      transport.requests
+        .filter((request) => request.method === "run.replay")
+        .map((request) => request.params?.afterSequence),
+    ).toEqual([0, 2]);
+  });
+
+  it("reconnects from a serialized cursor and reads the durable final result by runId", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(4, "event_4", { final: true })],
+          nextAfterSequence: 4,
+        }),
+    });
+    const reconnectedClient = createAgencClient({ transport });
+    const attachment = reconnectedClient.reattachRun({
+      runId: "run_1",
+      afterSequence: 3,
+      limit: 2,
+    });
+
+    const events: RunReplayEvent[] = [];
+    for await (const event of attachment) events.push(event);
+
+    expect(events).toMatchObject([
+      { sequence: 4, eventId: "event_4", payload: { final: true } },
+    ]);
+    await expect(attachment.result()).resolves.toMatchObject({
+      runId: "run_1",
+      terminal: true,
+      output: {
+        available: true,
+        finalMessage: "durable answer",
+        lastSequence: 4,
+      },
+    });
+    expect(transport.requests.at(-1)).toMatchObject({
+      method: "run.result",
+      params: { runId: "run_1" },
+    });
+  });
+
+  it("fails closed when a reconnect receives an unverifiable event at its exclusive cursor", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(3, "event_3", { changedAfterReconnect: true })],
+          nextAfterSequence: afterSequence,
+          lastAvailableSequence: afterSequence,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 3,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /cannot verify event.*at or before exclusive cursor/i,
+    );
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 3 });
+    expect(attachment.diagnostics().duplicatesDropped).toBe(0);
+  });
+
+  it("bounds exact replay identity memory and fails closed on old event-id reuse", async () => {
+    const totalEvents = 5_000;
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => {
+        if (afterSequence === totalEvents) {
+          return replayPage({
+            afterSequence,
+            limit,
+            events: [journalEvent(totalEvents + 1, "event_1")],
+            nextAfterSequence: totalEvents + 1,
+          });
+        }
+        const last = Math.min(totalEvents, afterSequence + limit);
+        const events = Array.from(
+          { length: last - afterSequence },
+          (_, index) => journalEvent(afterSequence + index + 1),
+        );
+        return replayPage({
+          afterSequence,
+          limit,
+          events,
+          hasMore: true,
+          nextAfterSequence: last,
+          lastAvailableSequence: totalEvents + 1,
+        });
+      },
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 200,
+      identityWindow: 32,
+    });
+    const replay = attachment.replay();
+    for (let sequence = 1; sequence <= totalEvents; sequence += 1) {
+      await expect(replay.next()).resolves.toMatchObject({
+        done: false,
+        value: { sequence },
+      });
+      expect(attachment.diagnostics().trackedIdentities).toBeLessThanOrEqual(32);
+    }
+
+    await expect(replay.next()).rejects.toThrow(
+      /reused event identity event_1 outside the exact verification window/i,
+    );
+    expect(attachment.cursor().afterSequence).toBe(totalEvents);
+    expect(attachment.diagnostics()).toMatchObject({
+      identityWindow: 32,
+      trackedIdentities: 32,
+    });
+  });
+
+  it("advances only through delivered events when a consumer disconnects mid-page", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events:
+            afterSequence === 0
+              ? [journalEvent(1), journalEvent(2)]
+              : [journalEvent(2)],
+          nextAfterSequence: 2,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 2,
+    });
+
+    const interrupted = attachment.replay();
+    await expect(interrupted.next()).resolves.toMatchObject({
+      done: false,
+      value: { sequence: 1, eventId: "event_1" },
+    });
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 1 });
+    await interrupted.return();
+
+    const resumed: RunReplayEvent[] = [];
+    for await (const event of attachment) resumed.push(event);
+    expect(resumed.map((event) => event.sequence)).toEqual([2]);
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 2 });
+  });
+
+  it("surfaces an explicit retention gap without advancing the caller cursor", async () => {
+    const gap = {
+      kind: "event_gap" as const,
+      runId: "run_1",
+      afterSequence: 1,
+      firstAvailableSequence: 8,
+      reason: "retention" as const,
+    };
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          nextAfterSequence: afterSequence,
+          firstAvailableSequence: gap.firstAvailableSequence,
+          lastAvailableSequence: gap.firstAvailableSequence,
+          gap,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 1,
+      limit: 2,
+    });
+
+    const error = await attachment
+      .replay()
+      .next()
+      .catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(AgencRunReplayGapError);
+    expect(error).toMatchObject({ gap, cursor: { runId: "run_1", afterSequence: 1 } });
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 1 });
+  });
+
+  it("delivers a contiguous prefix before surfacing an interior gap", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(1)],
+          hasMore: true,
+          nextAfterSequence: 1,
+          firstAvailableSequence: 3,
+          lastAvailableSequence: 3,
+          gap: {
+            kind: "event_gap",
+            runId: "run_1",
+            afterSequence: 1,
+            firstAvailableSequence: 3,
+            reason: "corruption_truncated",
+          },
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 2,
+    });
+    const replay = attachment.replay();
+
+    await expect(replay.next()).resolves.toMatchObject({
+      done: false,
+      value: { sequence: 1, eventId: "event_1" },
+    });
+    expect(attachment.cursor().afterSequence).toBe(1);
+    const error = await replay.next().catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(AgencRunReplayGapError);
+    expect(error).toMatchObject({
+      cursor: { runId: "run_1", afterSequence: 1 },
+      gap: { afterSequence: 1, firstAvailableSequence: 3 },
+    });
+    expect(attachment.cursor().afterSequence).toBe(1);
+  });
+
+  it("surfaces a cursor beyond the durable tail without advancing it", async () => {
+    const gap = {
+      kind: "cursor_ahead" as const,
+      runId: "run_1",
+      afterSequence: 7,
+      lastAvailableSequence: 5,
+      reason: "cursor_ahead" as const,
+    };
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => ({
+        ...replayPage({
+          afterSequence,
+          limit,
+          nextAfterSequence: afterSequence,
+          gap,
+        }),
+        lastAvailableSequence: gap.lastAvailableSequence,
+      }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 7,
+    });
+
+    const error = await attachment
+      .replay()
+      .next()
+      .catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(AgencRunReplayGapError);
+    expect(error).toMatchObject({ gap });
+    expect(attachment.cursor().afterSequence).toBe(7);
+  });
+
+  it("surfaces an explicitly unavailable canonical source", async () => {
+    const gap = {
+      kind: "source_unavailable" as const,
+      reason: "run_journal_not_present" as const,
+    };
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => ({
+        ...replayPage({
+          afterSequence,
+          limit,
+          nextAfterSequence: afterSequence,
+          gap,
+        }),
+        source: {
+          kind: "run_journal",
+          available: false,
+          sequenceScope: "run",
+          canonical: "rollout_jsonl",
+          projection: "thread_rollout_items",
+          projectDir: "/tmp/project",
+        },
+      }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    await expect(attachment.replay().next()).rejects.toMatchObject({ gap });
+    expect(attachment.cursor().afterSequence).toBe(0);
+  });
+
+  it("rejects unavailable source metadata without an unavailable gap", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => ({
+        ...replayPage({ afterSequence, limit }),
+        source: {
+          kind: "run_journal",
+          available: false,
+          sequenceScope: "run",
+          canonical: "rollout_jsonl",
+          projection: "thread_rollout_items",
+          projectDir: "/tmp/project",
+        },
+      }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /source availability conflicts with its page/,
+    );
+  });
+
+  it("rejects a cursor jump that has no matching event or explicit gap", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [],
+          nextAfterSequence: 9,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 2,
+      limit: 2,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      AgencRunReplayProtocolError,
+    );
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 2 });
+  });
+
+  it("rejects a terminal page that omits its advertised journal tail", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(1), journalEvent(2)],
+          hasMore: false,
+          nextAfterSequence: 2,
+          lastAvailableSequence: 10,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 2,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /advertised journal tail/,
+    );
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 0 });
+  });
+
+  it("rejects replay pages larger than the requested bound", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(1), journalEvent(2)],
+          nextAfterSequence: 2,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 1,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /returned 2 events for limit 1/,
+    );
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 0 });
+  });
+
+  it("rejects unsafe available-sequence bounds", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [journalEvent(1)],
+          lastAvailableSequence: Number.MAX_SAFE_INTEGER + 1,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /invalid lastAvailableSequence/,
+    );
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 0 });
+  });
+
+  it("rejects conflicting data that reuses an event identity", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [
+            journalEvent(1, "event_same", { value: "first" }),
+            journalEvent(1, "event_same", { value: "changed" }),
+          ],
+          nextAfterSequence: 1,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 2,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /reused event identity.*conflicting data/,
+    );
+    expect(attachment.cursor()).toEqual({ runId: "run_1", afterSequence: 0 });
+  });
+
+  it("accepts descendant run ids only from the legacy project-scoped journal", async () => {
+    const descendant = {
+      ...admissionEvent(7),
+      eventId: "child-event",
+      runId: "child-run",
+    };
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => ({
+        ...replayPage({
+          afterSequence,
+          limit,
+          events: [descendant],
+          nextAfterSequence: descendant.sequence,
+        }),
+        source: {
+          kind: "execution_admission_journal",
+          available: true,
+          sequenceScope: "project_state_database",
+          projectDir: "/tmp/project",
+        },
+      }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    const events: RunReplayEvent[] = [];
+    for await (const event of attachment) events.push(event);
+    expect(events).toMatchObject([
+      { sequence: 7, eventId: "child-event", runId: "child-run" },
+    ]);
+    expect(attachment.cursor().afterSequence).toBe(7);
+  });
+
+  it("accepts interleaved project-global sequence gaps from the legacy source", async () => {
+    const legacyEvents = [admissionEvent(2), admissionEvent(5)];
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => ({
+        runId: "run_1",
+        afterSequence,
+        limit,
+        events: legacyEvents,
+        hasMore: false,
+        nextAfterSequence: 5,
+        firstAvailableSequence: 2,
+        lastAvailableSequence: 5,
+        gap: null,
+        source: {
+          kind: "execution_admission_journal",
+          available: true,
+          sequenceScope: "project_state_database",
+          projectDir: "/tmp/project",
+        },
+      }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 2,
+    });
+
+    const events: RunReplayEvent[] = [];
+    for await (const event of attachment) events.push(event);
+    expect(events.map((event) => event.sequence)).toEqual([2, 5]);
+    expect(attachment.cursor().afterSequence).toBe(5);
+  });
+
+  it("rejects a legacy terminal page that omits its advertised filtered tail", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) => ({
+        runId: "run_1",
+        afterSequence,
+        limit,
+        events: [admissionEvent(2)],
+        hasMore: false,
+        nextAfterSequence: 2,
+        firstAvailableSequence: 2,
+        lastAvailableSequence: 5,
+        gap: null,
+        source: {
+          kind: "execution_admission_journal",
+          available: true,
+          sequenceScope: "project_state_database",
+          projectDir: "/tmp/project",
+        },
+      }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+      limit: 2,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /advertised journal tail/,
+    );
+    expect(attachment.cursor().afterSequence).toBe(0);
+  });
+
+  it("rejects unknown source metadata before it can bypass continuity checks", async () => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        ({
+          ...replayPage({
+            afterSequence,
+            limit,
+            events: [journalEvent(1), journalEvent(3)],
+            nextAfterSequence: 3,
+          }),
+          source: {
+            kind: "run_journal",
+            available: true,
+            sequenceScope: "unknown_scope",
+            canonical: "rollout_jsonl",
+            projection: "thread_rollout_items",
+            projectDir: "/tmp/project",
+          },
+        }) as unknown as RunReplayResult,
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /malformed run-journal source metadata/,
+    );
+    expect(attachment.cursor().afterSequence).toBe(0);
+  });
+
+  it.each([
+    ["missing run id", { ...journalEvent(1), runId: "" }],
+    ["unknown category", { ...journalEvent(1), category: "unknown" }],
+    ["missing kind", { ...journalEvent(1), kind: "" }],
+    ["missing event name", { ...journalEvent(1), event: "" }],
+    ["empty optional timestamp", { ...journalEvent(1), timestamp: "" }],
+    ["empty optional step id", { ...journalEvent(1), stepId: "" }],
+  ])("rejects a canonical event with %s", async (_label, malformedEvent) => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        replayPage({
+          afterSequence,
+          limit,
+          events: [malformedEvent as unknown as RunJournalEvent],
+          nextAfterSequence: 1,
+        }),
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /malformed canonical event envelope/,
+    );
+    expect(attachment.cursor().afterSequence).toBe(0);
+  });
+
+  it.each([
+    ["missing timestamp", { ...admissionEvent(1), timestamp: "" }],
+    ["missing run id", { ...admissionEvent(1), runId: "" }],
+    ["missing step id", { ...admissionEvent(1), stepId: "" }],
+    ["missing kind", { ...admissionEvent(1), kind: "" }],
+    ["missing event name", { ...admissionEvent(1), event: "" }],
+    ["non-admission category", { ...admissionEvent(1), category: "run" }],
+  ])("rejects a legacy event with %s", async (_label, malformedEvent) => {
+    const transport = new ScriptedRunTransport({
+      replay: (afterSequence, limit) =>
+        ({
+          ...replayPage({
+            afterSequence,
+            limit,
+            events: [malformedEvent as unknown as RunJournalEvent],
+            nextAfterSequence: 1,
+          }),
+          source: {
+            kind: "execution_admission_journal",
+            available: true,
+            sequenceScope: "project_state_database",
+            projectDir: "/tmp/project",
+          },
+        }) as RunReplayResult,
+    });
+    const attachment = createAgencClient({ transport }).reattachRun({
+      runId: "run_1",
+      afterSequence: 0,
+    });
+
+    await expect(attachment.replay().next()).rejects.toThrow(
+      /malformed admission event envelope/,
+    );
+    expect(attachment.cursor().afterSequence).toBe(0);
+  });
+});

--- a/runtime/tests/services/mcp/client.test.ts
+++ b/runtime/tests/services/mcp/client.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../src/bootstrap/state.js'
 import { runWithCurrentRuntimeSession } from '../../../src/session/current-session.js'
 import type { Session } from '../../../src/session/session.js'
+import { createTestEffectJournal } from '../../helpers/test-effect-journal.js'
 import { resetProjectForTesting } from '../../../src/utils/sessionStorage.js'
 import { getToolResultsDir } from '../../../src/utils/toolResultStorage.js'
 import {
@@ -145,6 +146,7 @@ function promptAdmissionSession() {
     subscribe: vi.fn(() => () => {}),
   } as unknown as ExecutionAdmissionClient
   const session = {
+    ...createTestEffectJournal(),
     conversationId: 'session-prompt',
     services: { executionAdmission: admission, admissionRequired: true },
   } as unknown as Session

--- a/runtime/tests/session/agenc-delegate.test.ts
+++ b/runtime/tests/session/agenc-delegate.test.ts
@@ -28,6 +28,10 @@
  * session-kernel suites.
  */
 
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { AsyncQueue } from "../utils/async-queue.js";
@@ -65,6 +69,7 @@ import {
 } from "./agenc-delegate.js";
 import { newDefaultTurnWithSubId } from "./turn-context.js";
 import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
+import { disposeSandboxExecutionBroker } from "../sandbox/execution-lifecycle.js";
 import * as providerFactory from "../llm/provider.js";
 import {
   AdmissionDeniedError,
@@ -72,6 +77,9 @@ import {
   type ExecutionAdmissionClient,
 } from "../budget/admission-client.js";
 import type { AdmissionLease } from "../budget/admission-types.js";
+import { RolloutStore } from "./rollout-store.js";
+import { AgenCDaemonRunInspectionService } from "../app-server/run-inspection.js";
+import { resolveStateDatabasePaths } from "../state/sqlite-driver.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // Fixtures (mirrors tasks.test.ts::buildSession and review.test.ts)
@@ -84,10 +92,10 @@ function mkFeatures(): ManagedFeatures {
   };
 }
 
-function mkConfig(): Config {
+function mkConfig(cwd = "/tmp"): Config {
   return {
     model: "test-model",
-    cwd: "/tmp",
+    cwd,
     features: mkFeatures(),
     multiAgentV2: {
       usageHintEnabled: false,
@@ -119,9 +127,9 @@ function mkModelInfo(slug = "test-model"): ModelInfo {
   };
 }
 
-function mkSessionConfiguration(): SessionConfiguration {
+function mkSessionConfiguration(cwd = "/tmp"): SessionConfiguration {
   return {
-    cwd: "/tmp",
+    cwd,
     approvalPolicy: { value: "never" },
     sandboxPolicy: { value: "read_only" },
     fileSystemSandboxPolicy: {
@@ -210,7 +218,9 @@ function mkScriptedProvider(opts: ScriptedProviderOptions = {}): LLMProvider {
 function mkSession(
   provider: LLMProvider,
   serviceOverrides?: Partial<SessionServices>,
+  options: { readonly cwd?: string } = {},
 ): Session {
+  const cwd = options.cwd ?? "/tmp";
   const services = {
     admissionRequired: false,
     mcpConnectionManager: {
@@ -233,17 +243,37 @@ function mkSession(
   const sessionOpts: SessionOpts = {
     conversationId: "conv-delegate-test",
     initialState: {
-      sessionConfiguration: mkSessionConfiguration(),
+      sessionConfiguration: mkSessionConfiguration(cwd),
       history: [],
     },
     features: mkFeatures(),
     services,
     jsRepl: { id: "repl-test" },
-    config: mkConfig(),
+    config: mkConfig(cwd),
     modelInfo: mkModelInfo(),
     eventQueue: new AsyncQueue<Event>(),
   };
   return new Session(sessionOpts);
+}
+
+function mountTestRollout(session: Session): RolloutStore {
+  const cwd = session.sessionConfiguration.cwd;
+  const store = new RolloutStore({
+    cwd,
+    sessionId: session.conversationId,
+    agencVersion: "0.2.0",
+  });
+  store.open({
+    sessionId: session.conversationId,
+    timestamp: new Date().toISOString(),
+    cwd,
+    originator: "review-delegate-test",
+    agencVersion: "0.2.0",
+    model: session.modelInfo.slug,
+    modelProvider: session.services.provider.name,
+  });
+  session.mountRolloutStore(store);
+  return store;
 }
 
 function delegateAdmissionHarness(opts?: {
@@ -263,11 +293,13 @@ function delegateAdmissionHarness(opts?: {
   const leaseAbort = new AbortController();
   const child = {
     scope: {
-      runId: "root-review-run",
+      runId: "conv-delegate-test:review:review-delegate-A",
       workspaceId: "workspace",
       sessionId: "review-child-session",
+      parentRunId: "root-review-run",
       autonomous: false,
     },
+    subscribe: vi.fn(() => () => {}),
   } as ExecutionAdmissionClient;
   const acquire = vi.fn(
     async (input: AdmissionAcquireInput): Promise<AdmissionLease> => ({
@@ -380,14 +412,20 @@ function mkOneShotRequest(
 }
 
 /** Capture `exit_review_mode` payloads from the session event queue. */
-function observeExitReviewMode(session: Session): Promise<ExitReviewModePayload> {
+function observeExitReviewMode(
+  session: Session,
+): Promise<ExitReviewModePayload> {
   return new Promise((resolve) => {
     const unsubscribe = session.eventLog.subscribe((ev) => {
       if ((ev.msg as EventMsg).type === "exit_review_mode") {
         unsubscribe();
         resolve(
-          (ev.msg as { type: "exit_review_mode"; payload: ExitReviewModePayload })
-            .payload,
+          (
+            ev.msg as {
+              type: "exit_review_mode";
+              payload: ExitReviewModePayload;
+            }
+          ).payload,
         );
       }
     });
@@ -510,12 +548,18 @@ async function exerciseDelegateProviderOwnership(
 // ─────────────────────────────────────────────────────────────────────
 
 describe("review delegate spawn admission", () => {
-  it("journals the spawn commit and keeps the child session on the root run", async () => {
+  it("journals the spawn commit and binds a distinct canonical child run", async () => {
     const admission = delegateAdmissionHarness();
-    const session = mkSession(mkScriptedProvider({ content: "ok" }), {
-      executionAdmission: admission.client,
-      admissionRequired: true,
-    });
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-review-admission-"));
+    const session = mkSession(
+      mkScriptedProvider({ content: "ok" }),
+      {
+        executionAdmission: admission.client,
+        admissionRequired: true,
+      },
+      { cwd },
+    );
+    mountTestRollout(session);
     const req = mkOneShotRequest(session);
     const controller = new AbortController();
 
@@ -556,13 +600,18 @@ describe("review delegate spawn admission", () => {
       { inputTokens: 0, outputTokens: 0, costUsd: 0 },
     );
     expect(admission.forSession).toHaveBeenCalledWith({
+      runId: "conv-delegate-test:review:review-delegate-A",
       sessionId: "conv-delegate-test:review:review-delegate-A",
+      parentRunId: "root-review-run",
       parentScopeId: "conv-delegate-test",
     });
     expect(thread.childSession.services.executionAdmission).toBe(
       admission.child,
     );
-    expect(admission.child.scope.runId).toBe(admission.client.scope.runId);
+    expect(admission.child.scope.runId).toBe(
+      "conv-delegate-test:review:review-delegate-A",
+    );
+    expect(thread.childSession.rolloutStore).not.toBeNull();
     expect(admission.voidReservation).not.toHaveBeenCalled();
     expect(admission.holdUnknown).not.toHaveBeenCalled();
     expect(admission.acknowledgeCompletion).toHaveBeenCalledWith(
@@ -570,14 +619,22 @@ describe("review delegate spawn admission", () => {
     );
 
     await thread.shutdown("test complete");
+    await session.shutdown();
+    rmSync(cwd, { recursive: true, force: true });
   });
 
   it("prevents child construction when cancellation races the spawn commit", async () => {
     const admission = delegateAdmissionHarness({ abortOnDispatch: true });
-    const session = mkSession(mkScriptedProvider({ content: "unused" }), {
-      executionAdmission: admission.client,
-      admissionRequired: true,
-    });
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-review-admission-race-"));
+    const session = mkSession(
+      mkScriptedProvider({ content: "unused" }),
+      {
+        executionAdmission: admission.client,
+        admissionRequired: true,
+      },
+      { cwd },
+    );
+    mountTestRollout(session);
     const req = mkOneShotRequest(session);
 
     await expect(
@@ -595,7 +652,9 @@ describe("review delegate spawn admission", () => {
     });
 
     expect(admission.forSession).toHaveBeenCalledWith({
+      runId: "conv-delegate-test:review:review-delegate-A",
       sessionId: "conv-delegate-test:review:review-delegate-A",
+      parentRunId: "root-review-run",
       parentScopeId: "conv-delegate-test",
     });
     expect(admission.reconcile).toHaveBeenCalledWith(
@@ -607,16 +666,43 @@ describe("review delegate spawn admission", () => {
     expect(admission.acknowledgeCompletion).toHaveBeenCalledWith(
       "review-spawn-reservation",
     );
+    const childRunId = `${session.conversationId}:review:${req.subId}`;
+    const inspection = new AgenCDaemonRunInspectionService({
+      stateDatabasePaths: () => [resolveStateDatabasePaths({ cwd })],
+    });
+    expect(inspection.status({ runId: childRunId })).toMatchObject({
+      runId: childRunId,
+      status: "cancelled",
+      terminal: true,
+    });
+    expect(inspection.result({ runId: childRunId })).toMatchObject({
+      runId: childRunId,
+      status: "cancelled",
+      terminal: true,
+      output: {
+        available: true,
+        stopReason: "execution admission cancelled: run_cancelled",
+        finalMessage: null,
+      },
+    });
+    await session.shutdown();
+    rmSync(cwd, { recursive: true, force: true });
   });
 
   it("releases spawn capacity when reconciliation journaling fails", async () => {
     const admission = delegateAdmissionHarness({
       reconcileError: new Error("forced review spawn journal failure"),
     });
-    const session = mkSession(mkScriptedProvider({ content: "unused" }), {
-      executionAdmission: admission.client,
-      admissionRequired: true,
-    });
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-review-admission-failure-"));
+    const session = mkSession(
+      mkScriptedProvider({ content: "unused" }),
+      {
+        executionAdmission: admission.client,
+        admissionRequired: true,
+      },
+      { cwd },
+    );
+    mountTestRollout(session);
     const req = mkOneShotRequest(session);
 
     await expect(
@@ -636,6 +722,8 @@ describe("review delegate spawn admission", () => {
     expect(admission.acknowledgeCompletion).toHaveBeenCalledWith(
       "review-spawn-reservation",
     );
+    await session.shutdown();
+    rmSync(cwd, { recursive: true, force: true });
   });
 
   it("fails closed and drains the parent task when the kernel is required but missing", async () => {
@@ -686,6 +774,217 @@ describe("runAgenCReviewOneShot happy-path review", () => {
       ]);
     },
   );
+
+  it.each([
+    ["completed", "completed", "review_completed", "review passed"],
+    ["failed", "failed", "review failed", null],
+    ["interrupted", "cancelled", "review interrupted", null],
+  ] as const)(
+    "makes a %s reviewer run queryable and replayable by child session id",
+    async (scenario, terminalStatus, stopReason, finalMessage) => {
+      const cwd = mkdtempSync(
+        join(tmpdir(), `agenc-review-${scenario}-terminal-`),
+      );
+      let markProviderStarted: () => void = () => {};
+      const providerStarted = new Promise<void>((resolve) => {
+        markProviderStarted = resolve;
+      });
+      const provider =
+        scenario === "failed"
+          ? mkScriptedProvider({ throwError: new Error("review failed") })
+          : scenario === "interrupted"
+            ? mkScriptedProvider({
+                delayMs: 10_000,
+                onChat: markProviderStarted,
+              })
+            : mkScriptedProvider({ content: "review passed" });
+      const session = mkSession(provider, undefined, { cwd });
+      mountTestRollout(session);
+      const req = mkOneShotRequest(session);
+      const childRunId = `${session.conversationId}:review:${req.subId}`;
+      const childController = new AbortController();
+      let thread:
+        Awaited<ReturnType<typeof spawnAgenCDelegateThread>> | undefined;
+
+      try {
+        thread = await spawnAgenCDelegateThread(
+          session,
+          req,
+          req.parentContext.modelInfo.slug,
+          req.parentContext.modelInfo,
+          childController,
+        );
+        thread.txSub.send({ type: "user_input", input: req.input });
+        if (scenario === "interrupted") {
+          await providerStarted;
+          childController.abort("review interrupted");
+        }
+        await thread.completion;
+
+        const inspection = new AgenCDaemonRunInspectionService({
+          stateDatabasePaths: () => [resolveStateDatabasePaths({ cwd })],
+        });
+        expect(inspection.status({ runId: childRunId })).toMatchObject({
+          runId: childRunId,
+          status: terminalStatus,
+          terminal: true,
+        });
+        expect(inspection.result({ runId: childRunId })).toMatchObject({
+          runId: childRunId,
+          status: terminalStatus,
+          terminal: true,
+          output: {
+            available: true,
+            stopReason,
+            finalMessage,
+          },
+        });
+        const replay = inspection.replay({ runId: childRunId, limit: 200 });
+        expect(replay.events.at(-1)).toMatchObject({
+          runId: childRunId,
+          category: "terminal",
+          kind: "run_terminal",
+        });
+      } finally {
+        if (thread !== undefined && !thread.rxEvent.isClosed) {
+          await thread.shutdown("test cleanup");
+        }
+        await session.shutdown();
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("keeps a completed reviewer result when post-terminal provider disposal fails", async () => {
+    const previousAgencHome = process.env.AGENC_HOME;
+    const home = mkdtempSync(join(tmpdir(), "agenc-review-disposal-home-"));
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-review-disposal-workspace-"));
+    process.env.AGENC_HOME = home;
+    const parentBroker = new SandboxExecutionBroker({
+      mode: "danger_full_access",
+      cwd,
+    });
+    const childProvider: LLMProvider = {
+      ...mkScriptedProvider({ content: "" }),
+      dispose: vi.fn(async () => {
+        throw new Error("forced reviewer provider disposal failure");
+      }),
+    };
+    const parentProvider: LLMProvider = {
+      ...mkScriptedProvider(),
+      forkForSession: vi.fn(() => childProvider),
+    };
+    const session = mkSession(
+      parentProvider,
+      { sandboxExecutionBroker: parentBroker },
+      { cwd },
+    );
+    mountTestRollout(session);
+    const req = mkOneShotRequest(session);
+    const childRunId = `${session.conversationId}:review:${req.subId}`;
+    const parentEvents: Event[] = [];
+    const unsubscribe = session.eventLog.subscribe((event) => {
+      parentEvents.push(event);
+    });
+
+    try {
+      const outcome = await runAgenCReviewOneShot(session, req);
+      expect(outcome).toMatchObject({
+        verdict: "partial",
+        error: null,
+      });
+      expect(childProvider.dispose).toHaveBeenCalledOnce();
+      expect(parentEvents).toContainEqual(
+        expect.objectContaining({
+          msg: {
+            type: "warning",
+            payload: {
+              cause: "review_delegate_resource_cleanup_failed",
+              message: "forced reviewer provider disposal failure",
+            },
+          },
+        }),
+      );
+
+      const inspection = new AgenCDaemonRunInspectionService({
+        stateDatabasePaths: () => [
+          resolveStateDatabasePaths({ cwd, agencHome: home }),
+        ],
+      });
+      expect(inspection.result({ runId: childRunId })).toMatchObject({
+        runId: childRunId,
+        status: "completed",
+        terminal: true,
+        output: {
+          available: true,
+          stopReason: "review_completed",
+        },
+      });
+    } finally {
+      unsubscribe();
+      await session.shutdown();
+      await disposeSandboxExecutionBroker(parentBroker);
+      if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = previousAgencHome;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a fresh reviewer store for an already-terminal child identity", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-review-duplicate-terminal-"));
+    const session = mkSession(
+      mkScriptedProvider({ content: "review complete" }),
+      undefined,
+      { cwd },
+    );
+    const parentStore = mountTestRollout(session);
+    const req = mkOneShotRequest(session);
+    const childRunId = `${session.conversationId}:review:${req.subId}`;
+    const childSessionDir = join(
+      join(parentStore.store.sessionDir, ".."),
+      childRunId,
+    );
+
+    try {
+      const first = await spawnAgenCDelegateThread(
+        session,
+        req,
+        req.parentContext.modelInfo.slug,
+        req.parentContext.modelInfo,
+        new AbortController(),
+      );
+      first.txSub.send({ type: "user_input", input: req.input });
+      await first.completion;
+      const rolloutFiles = readdirSync(childSessionDir).filter(
+        (entry) => entry.startsWith("rollout-") && entry.endsWith(".jsonl"),
+      );
+      expect(rolloutFiles).toHaveLength(1);
+
+      await expect(
+        spawnAgenCDelegateThread(
+          session,
+          req,
+          req.parentContext.modelInfo.slug,
+          req.parentContext.modelInfo,
+          new AbortController(),
+        ),
+      ).rejects.toMatchObject({
+        name: "TerminalRunEpochOpenError",
+        message: expect.stringContaining(
+          `refusing to open terminal run ${childRunId} epoch 1`,
+        ),
+      });
+      expect(
+        readdirSync(childSessionDir).filter(
+          (entry) => entry.startsWith("rollout-") && entry.endsWith(".jsonl"),
+        ),
+      ).toEqual(rolloutFiles);
+    } finally {
+      await session.shutdown();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 
   it("uses an inert child MCP manager and never refreshes the parent transport", async () => {
     const parentRefresh = vi.fn(async () => ({
@@ -784,7 +1083,10 @@ describe("runAgenCReviewOneShot happy-path review", () => {
       }),
     });
     const session = mkSession(provider);
-    const outcome = await runAgenCReviewOneShot(session, mkOneShotRequest(session));
+    const outcome = await runAgenCReviewOneShot(
+      session,
+      mkOneShotRequest(session),
+    );
     expect(outcome.verdict).toBe("fail");
     expect(outcome.output.findings.length).toBe(1);
   });
@@ -792,7 +1094,10 @@ describe("runAgenCReviewOneShot happy-path review", () => {
   it("classifies verdict=partial when assistant text is empty", async () => {
     const provider = mkScriptedProvider({ content: "" });
     const session = mkSession(provider);
-    const outcome = await runAgenCReviewOneShot(session, mkOneShotRequest(session));
+    const outcome = await runAgenCReviewOneShot(
+      session,
+      mkOneShotRequest(session),
+    );
     expect(outcome.verdict).toBe("partial");
   });
 
@@ -808,14 +1113,18 @@ describe("runAgenCReviewOneShot happy-path review", () => {
     const provider = mkScriptedProvider({
       content: "reviewer text",
       onChat: (messages, options) => {
-        expect(messages.some((message) => message.role === "system")).toBe(false);
+        expect(messages.some((message) => message.role === "system")).toBe(
+          false,
+        );
         observedSystemPrompt = options?.systemPrompt;
       },
     });
     const session = mkSession(provider);
     await runAgenCReviewOneShot(session, mkOneShotRequest(session));
     expect(observedSystemPrompt).toContain("# Review guidelines:");
-    expect(observedSystemPrompt?.match(/# Review guidelines:/g)).toHaveLength(1);
+    expect(observedSystemPrompt?.match(/# Review guidelines:/g)).toHaveLength(
+      1,
+    );
   });
 
   it("passes the reviewer model, no-tool envelope, and reasoning effort to the provider", async () => {
@@ -1021,10 +1330,12 @@ describe("runAgenCReviewOneShot happy-path review", () => {
     });
     await thread.shutdown("test complete");
 
-    expect(parentEvents.some((event) => event.type === "exec_approval_request"))
-      .toBe(true);
-    expect(parentEvents.some((event) => event.type === "request_permissions"))
-      .toBe(true);
+    expect(
+      parentEvents.some((event) => event.type === "exec_approval_request"),
+    ).toBe(true);
+    expect(
+      parentEvents.some((event) => event.type === "request_permissions"),
+    ).toBe(true);
   });
 });
 
@@ -1277,11 +1588,15 @@ describe("ReviewManager.runReview orchestrator", () => {
     const payload = await exitPromise;
     expect(payload.reason).toBe("completed");
     const started = telemetry.find(
-      (event): event is Extract<EventMsg, { type: "review_delegate_started" }> =>
+      (
+        event,
+      ): event is Extract<EventMsg, { type: "review_delegate_started" }> =>
         event.type === "review_delegate_started",
     );
     const completed = telemetry.find(
-      (event): event is Extract<EventMsg, { type: "review_delegate_completed" }> =>
+      (
+        event,
+      ): event is Extract<EventMsg, { type: "review_delegate_completed" }> =>
         event.type === "review_delegate_completed",
     );
     expect(started?.payload).toMatchObject({
@@ -1364,17 +1679,27 @@ describe("ReviewManager.runReview orchestrator", () => {
     });
 
     const secondMessages = observedMessages[1] ?? [];
-    expect(secondMessages.some((message) => messageTextForTest(message).includes("first review snapshot")))
-      .toBe(true);
-    expect(secondMessages.some((message) => messageTextForTest(message).includes("previous review snapshot")))
-      .toBe(true);
+    expect(
+      secondMessages.some((message) =>
+        messageTextForTest(message).includes("first review snapshot"),
+      ),
+    ).toBe(true);
+    expect(
+      secondMessages.some((message) =>
+        messageTextForTest(message).includes("previous review snapshot"),
+      ),
+    ).toBe(true);
 
     const started = telemetry.filter(
-      (event): event is Extract<EventMsg, { type: "review_delegate_started" }> =>
+      (
+        event,
+      ): event is Extract<EventMsg, { type: "review_delegate_started" }> =>
         event.type === "review_delegate_started",
     );
     const completed = telemetry.filter(
-      (event): event is Extract<EventMsg, { type: "review_delegate_completed" }> =>
+      (
+        event,
+      ): event is Extract<EventMsg, { type: "review_delegate_completed" }> =>
         event.type === "review_delegate_completed",
     );
     expect(started).toHaveLength(2);
@@ -1461,7 +1786,10 @@ describe("runAgenCReviewOneShot provider error handling", () => {
     const provider = mkScriptedProvider({ throwError: boom });
     const session = mkSession(provider);
     const exitPromise = observeExitReviewMode(session);
-    const outcome = await runAgenCReviewOneShot(session, mkOneShotRequest(session));
+    const outcome = await runAgenCReviewOneShot(
+      session,
+      mkOneShotRequest(session),
+    );
     expect(outcome.verdict).toBe("fail");
     expect(outcome.error).toBe(boom);
     const payload = await exitPromise;

--- a/runtime/tests/session/event-log.test.ts
+++ b/runtime/tests/session/event-log.test.ts
@@ -32,6 +32,148 @@ describe("EventLog", () => {
     expect(c.seq).toBe(3);
   });
 
+  test("assigns unique canonical eventIds while preserving reusable envelope ids", () => {
+    const log = new EventLog();
+    const first = log.emit({
+      id: "reused-sub-id",
+      msg: { type: "warning", payload: { cause: "x", message: "first" } },
+    });
+    const second = log.emit({
+      id: "reused-sub-id",
+      msg: { type: "warning", payload: { cause: "x", message: "second" } },
+    });
+
+    expect(first).toMatchObject({
+      eventId: "event:1",
+      id: "reused-sub-id",
+      seq: 1,
+    });
+    expect(second).toMatchObject({
+      eventId: "event:2",
+      id: "reused-sub-id",
+      seq: 2,
+    });
+  });
+
+  test("preserves explicit eventIds and rejects reuse without consuming a sequence", () => {
+    const log = new EventLog();
+    const first = log.emit({
+      eventId: "effect-intent:run-1:step-1",
+      id: "turn-sub-id",
+      msg: { type: "warning", payload: { cause: "x", message: "first" } },
+    });
+
+    expect(first).toMatchObject({
+      eventId: "effect-intent:run-1:step-1",
+      id: "turn-sub-id",
+      seq: 1,
+    });
+    expect(() =>
+      log.emit({
+        eventId: "effect-intent:run-1:step-1",
+        id: "another-envelope",
+        msg: {
+          type: "warning",
+          payload: { cause: "x", message: "conflict" },
+        },
+      }),
+    ).toThrow("eventId already allocated: effect-intent:run-1:step-1");
+    expect(
+      log.emit({
+        id: "after-conflict",
+        msg: { type: "warning", payload: { cause: "x", message: "next" } },
+      }),
+    ).toMatchObject({ eventId: "event:2", seq: 2 });
+  });
+
+  test("continues default event identity after a recovered sequence floor", () => {
+    const log = new EventLog();
+    log.seedLastSeq(41);
+    expect(
+      log.emit({
+        id: "restored-sub-id",
+        msg: { type: "warning", payload: { cause: "x", message: "next" } },
+      }),
+    ).toMatchObject({ eventId: "event:42", seq: 42 });
+  });
+
+  test("restores canonical identities and rejects reuse after resume", () => {
+    const log = new EventLog();
+    log.seedCanonicalHistory([
+      {
+        eventId: "durable-id",
+        id: "reusable-correlation",
+        seq: 7,
+        msg: { type: "warning", payload: { cause: "test", message: "old" } },
+      },
+    ]);
+
+    expect(log.lastSeq).toBe(7);
+    expect(() =>
+      log.emit({
+        eventId: "durable-id",
+        id: "different-correlation",
+        msg: { type: "warning", payload: { cause: "test", message: "new" } },
+      }),
+    ).toThrow(/eventId already allocated/);
+  });
+
+  test("fails closed when resumed history already reuses a canonical identity", () => {
+    const log = new EventLog();
+    expect(() =>
+      log.seedCanonicalHistory([
+        {
+          eventId: "duplicate",
+          id: "first",
+          seq: 1,
+          msg: { type: "warning", payload: { cause: "test", message: "first" } },
+        },
+        {
+          eventId: "duplicate",
+          id: "second",
+          seq: 2,
+          msg: { type: "warning", payload: { cause: "test", message: "second" } },
+        },
+      ]),
+    ).toThrow(/canonical rollout reuses eventId/);
+  });
+
+  test("fails closed on conflicting resumed sequence coordinates", () => {
+    const event = (eventId: string, id: string, seq: number) => ({
+      eventId,
+      id,
+      seq,
+      msg: { type: "warning" as const, payload: { cause: "test", message: id } },
+    });
+
+    expect(() =>
+      new EventLog().seedCanonicalHistory([
+        event("first", "first", 1),
+        event("second", "second", 1),
+      ]),
+    ).toThrow(/canonical rollout reuses sequence/);
+    expect(() =>
+      new EventLog().seedCanonicalHistory([event("event:9", "wrong", 1)]),
+    ).toThrow(/eventId event:9 conflicts with sequence 1/);
+  });
+
+  test("prevents explicit identities from claiming a future default slot", () => {
+    const log = new EventLog();
+    expect(() =>
+      log.emit({
+        eventId: "event:2",
+        id: "future-claim",
+        msg: { type: "warning", payload: { cause: "x", message: "bad" } },
+      }),
+    ).toThrow("eventId event:2 is reserved for sequence 2");
+    expect(
+      log.emit({
+        id: "first-real-event",
+        msg: { type: "warning", payload: { cause: "x", message: "good" } },
+      }),
+    ).toMatchObject({ eventId: "event:1", seq: 1 });
+  });
+
   test("subscribe receives events in order", () => {
     const log = new EventLog();
     const seen: number[] = [];
@@ -43,6 +185,97 @@ describe("EventLog", () => {
       });
     }
     expect(seen).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("stamp reserves a sequence without publishing until publish", () => {
+    const log = new EventLog();
+    const seen: number[] = [];
+    log.subscribe((event) => seen.push(event.seq!));
+
+    const stamped = log.stamp({
+      id: "durable-1",
+      msg: { type: "warning", payload: { cause: "x", message: "y" } },
+    });
+
+    expect(stamped.seq).toBe(1);
+    expect(seen).toEqual([]);
+    log.publish(stamped);
+    expect(seen).toEqual([1]);
+  });
+
+  test("re-entrant publication preserves monotonic listener order", () => {
+    const log = new EventLog();
+    const seen: number[] = [];
+    let nested = false;
+    log.subscribe((event) => {
+      if (!nested) {
+        nested = true;
+        log.emit({
+          id: "nested",
+          msg: { type: "warning", payload: { cause: "x", message: "nested" } },
+        });
+      }
+      void event;
+    });
+    log.subscribe((event) => seen.push(event.seq!));
+
+    log.emit({
+      id: "outer",
+      msg: { type: "warning", payload: { cause: "x", message: "outer" } },
+    });
+
+    expect(seen).toEqual([1, 2]);
+  });
+
+  test("re-entrant compatibility callbacks preserve publication order", () => {
+    const log = new EventLog();
+    const seen: string[] = [];
+    let nested = false;
+    log.subscribe((event) => {
+      seen.push(`listener:${event.seq}`);
+      if (!nested) {
+        nested = true;
+        const stamped = log.stamp({
+          id: "nested",
+          msg: { type: "warning", payload: { cause: "x", message: "nested" } },
+        });
+        log.publish(stamped, (published) => {
+          seen.push(`compat:${published.seq}`);
+        });
+      }
+    });
+
+    const stamped = log.stamp({
+      id: "outer",
+      msg: { type: "warning", payload: { cause: "x", message: "outer" } },
+    });
+    log.publish(stamped, (published) => {
+      seen.push(`compat:${published.seq}`);
+    });
+
+    expect(seen).toEqual([
+      "listener:1",
+      "compat:1",
+      "listener:2",
+      "compat:2",
+    ]);
+  });
+
+  test("an owning emitter can converge legacy EventLog producers", () => {
+    const log = new EventLog();
+    const delegated: string[] = [];
+    log.setEmitDelegate((event) => {
+      delegated.push(event.id);
+      return log.publish(log.stamp(event));
+    });
+
+    const result = log.emit({
+      id: "legacy-producer",
+      msg: { type: "warning", payload: { cause: "x", message: "y" } },
+    });
+
+    expect(delegated).toEqual(["legacy-producer"]);
+    expect(result.seq).toBe(1);
   });
 
   test("listener throw doesn't break other listeners (I-43)", () => {
@@ -233,6 +466,75 @@ describe("I-4 durable event classification", () => {
     };
 
     expect(isDurableEvent({ id: "slash", msg: event })).toBe(true);
+  });
+
+  test("effect intent, result, and unknown-outcome records are durable", () => {
+    const base = {
+      runId: "run-1",
+      stepId: "tool:turn-1:call-1",
+      callId: "call-1",
+      toolName: "system.write",
+      recoveryCategory: "side-effecting" as const,
+      recordedAt: "2026-07-18T00:00:00.000Z",
+    };
+    expect(isDurableEvent({
+      id: "effect-intent-id",
+      msg: {
+        type: "effect_intent",
+        payload: { ...base, intentDigest: "a".repeat(64), attempt: 1 },
+      },
+    })).toBe(true);
+    expect(isDurableEvent({
+      id: "effect-result-id",
+      msg: {
+        type: "effect_result",
+        payload: { ...base, intentEventSeq: 7, outcome: "committed" },
+      },
+    })).toBe(true);
+    expect(isDurableEvent({
+      id: "effect-unknown-id",
+      msg: {
+        type: "effect_unknown_outcome",
+        payload: {
+          ...base,
+          intentEventSeq: 7,
+          outcome: "unknown_outcome",
+          reason: "lost_acknowledgement",
+          requiresReview: true,
+        },
+      },
+    })).toBe(true);
+  });
+
+  test("permission requests and decisions are durable audit boundaries", () => {
+    expect(isDurableEvent({
+      id: "permission-request",
+      msg: {
+        type: "request_permissions",
+        payload: {
+          callId: "call-1",
+          toolName: "Bash",
+          permissions: ["tool.use"],
+          turnId: "turn-1",
+        },
+      },
+    })).toBe(true);
+    expect(isDurableEvent({
+      id: "permission-decision",
+      msg: {
+        type: "permission_decision",
+        payload: {
+          runId: "run-1",
+          callId: "call-1",
+          toolName: "Bash",
+          turnId: "turn-1",
+          requestEventId: "event:7",
+          requestEventSeq: 7,
+          decision: "approved",
+          recordedAt: "2026-07-18T00:00:00.000Z",
+        },
+      },
+    })).toBe(true);
   });
 });
 

--- a/runtime/tests/session/exec-agent-hook-run-turn.test.ts
+++ b/runtime/tests/session/exec-agent-hook-run-turn.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod/v4";
@@ -26,6 +26,7 @@ import {
   setCurrentRuntimeSession,
 } from "../session/current-session.js";
 import { Session, type SessionServices } from "../session/session.js";
+import { RolloutStore } from "../session/rollout-store.js";
 import { runTurnCompat } from "../session/turn-compat.js";
 import { startBackgroundSession } from "../tasks/LocalMainSessionTask.js";
 import {
@@ -54,8 +55,12 @@ import { addFunctionHook } from "../utils/hooks/sessionHooks.js";
 import { runWithCwdOverride } from "../utils/cwd.js";
 
 const DEFAULT_ROLE_WORKSPACE = createAgentRoleWorkspace("/tmp");
+const testCleanup: Array<() => Promise<void> | void> = [];
 
-afterEach(() => {
+afterEach(async () => {
+  while (testCleanup.length > 0) {
+    await testCleanup.pop()?.();
+  }
   clearCurrentRuntimeSession();
   resetCommandQueue();
 });
@@ -105,25 +110,29 @@ describe("execAgentHook run-turn integration", () => {
       arguments: JSON.stringify({ ok: true }),
     });
     const parent = createParentSession(provider);
+    await mountTestParentRollout(parent);
     Object.assign(parent.modelInfo, { maxOutputTokens: 128 });
 
     let childReservationSequence = 0;
+    let admittedChildScope: ExecutionAdmissionClient["scope"] = {
+      runId: "hook-child-run",
+      workspaceId: "workspace",
+      sessionId: "hook-child-session",
+      autonomous: false,
+    };
     const childAcquire = vi.fn(
       async (input: AdmissionAcquireInput, signal?: AbortSignal) =>
         allowAdmissionLease(
           input,
           `child-reservation-${++childReservationSequence}`,
-          "hook-child-run",
+          admittedChildScope.runId,
           signal ?? new AbortController().signal,
         ),
     );
     let childAdmission: ExecutionAdmissionClient;
     childAdmission = {
-      scope: {
-        runId: "hook-child-run",
-        workspaceId: "workspace",
-        sessionId: "hook-child-session",
-        autonomous: false,
+      get scope() {
+        return admittedChildScope;
       },
       acquire: childAcquire,
       markDispatched: vi.fn(),
@@ -158,7 +167,22 @@ describe("execAgentHook run-turn integration", () => {
       outcome: "reconciled" as const,
     }));
     const spawnVoid = vi.fn();
-    const forSession = vi.fn(() => childAdmission);
+    const forSession = vi.fn(
+      (scope: Parameters<ExecutionAdmissionClient["forSession"]>[0]) => {
+        admittedChildScope = {
+          ...admittedChildScope,
+          runId: scope.runId,
+          sessionId: scope.sessionId,
+          ...(scope.parentRunId !== undefined
+            ? { parentRunId: scope.parentRunId }
+            : {}),
+          ...(scope.parentScopeId !== undefined
+            ? { parentScopeId: scope.parentScopeId }
+            : {}),
+        };
+        return childAdmission;
+      },
+    );
     const parentAdmission: ExecutionAdmissionClient = {
       scope: {
         runId: "parent-run",
@@ -1787,6 +1811,44 @@ function createAgentDefinitions(roleWorkspace: AgentRoleWorkspace) {
     allAgents: [],
     allowedAgentTypes: [],
   };
+}
+
+async function mountTestParentRollout(parent: Session): Promise<void> {
+  const agencHome = await mkdtemp(join(tmpdir(), "agenc-hook-rollout-"));
+  const previousAgencHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = agencHome;
+  let store: RolloutStore | undefined;
+  try {
+    store = new RolloutStore({
+      cwd: parent.sessionConfiguration.cwd,
+      sessionId: parent.conversationId,
+      agencVersion: "test",
+    });
+    store.open({
+      sessionId: parent.conversationId,
+      timestamp: new Date().toISOString(),
+      cwd: parent.sessionConfiguration.cwd,
+      originator: "hook-agent-test",
+      agencVersion: "test",
+      model: parent.sessionConfiguration.collaborationMode.model,
+      modelProvider: parent.services.provider.name,
+    });
+    parent.mountRolloutStore(store);
+  } catch (error) {
+    if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+    else process.env.AGENC_HOME = previousAgencHome;
+    await rm(agencHome, { recursive: true, force: true });
+    throw error;
+  }
+  testCleanup.push(async () => {
+    try {
+      store?.close();
+    } finally {
+      if (previousAgencHome === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = previousAgencHome;
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
 }
 
 function createParentSession(

--- a/runtime/tests/session/lifecycle.test.ts
+++ b/runtime/tests/session/lifecycle.test.ts
@@ -11,6 +11,7 @@ function stubSession() {
       emit: (e: unknown) => e,
     },
     nextInternalSubId: () => "sub-1",
+    abortAllTasks: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
   } as unknown as Parameters<typeof shutdownSessionLifecycle>[0]["session"];
 }
@@ -41,6 +42,33 @@ describe("shutdownSessionLifecycle", () => {
       agentControl: agentControl as any,
     });
     expect(order).toEqual(["agents", "session"]);
+  });
+
+  it("drains the active task before Session runs its close-boundary finalizer", async () => {
+    const order: string[] = [];
+    let releaseAbort!: () => void;
+    const session = stubSession();
+    (session.abortAllTasks as any) = vi.fn(async () => {
+      order.push("abort_started");
+      await new Promise<void>((resolve) => {
+        releaseAbort = resolve;
+      });
+      order.push("abort_drained");
+    });
+    (session.shutdown as any) = vi.fn(async () => {
+      order.push("terminal_finalizer");
+    });
+
+    const shutdown = shutdownSessionLifecycle({ session });
+    await vi.waitFor(() => expect(order).toEqual(["abort_started"]));
+    releaseAbort();
+    await shutdown;
+
+    expect(order).toEqual([
+      "abort_started",
+      "abort_drained",
+      "terminal_finalizer",
+    ]);
   });
 
   it("stops MCP manager last (I-6 fail-soft)", async () => {

--- a/runtime/tests/session/review.test.ts
+++ b/runtime/tests/session/review.test.ts
@@ -204,7 +204,9 @@ function mkSession(opts?: {
       toLLMTools: () => [],
       dispatch: async () => ({ content: "", isError: false }),
     },
-    ...(opts?.reviewManager !== undefined ? { reviewManager: opts.reviewManager } : {}),
+    ...(opts?.reviewManager !== undefined
+      ? { reviewManager: opts.reviewManager }
+      : {}),
   } as unknown as SessionServices;
   const sessionOpts: SessionOpts = {
     conversationId: "conv-review-test",
@@ -222,7 +224,9 @@ function mkSession(opts?: {
   return new Session(sessionOpts);
 }
 
-const mkReviewRequest = (overrides?: Partial<ReviewRequest>): ReviewRequest => ({
+const mkReviewRequest = (
+  overrides?: Partial<ReviewRequest>,
+): ReviewRequest => ({
   target: "Diff between HEAD and main",
   userFacingHint: "Focus on error-handling paths",
   ...overrides,
@@ -345,6 +349,7 @@ describe("spawnReviewTask registry lifecycle", () => {
     const session = mkSession({ provider });
     session.eventLog.subscribe((event) => events.push(event.msg));
     session.rolloutStore = {
+      store: { agencVersion: "test" },
       append: (item: unknown) => {
         rolloutItems.push(item);
       },
@@ -365,35 +370,40 @@ describe("spawnReviewTask registry lifecycle", () => {
     expect(outcome?.verdict).toBe("pass");
     expect(exit.reason).toBe("completed");
     expect(session.activeTurn.unsafePeek()).toBeNull();
-    expect(observedMessages.some((message) =>
-      messageText(message).includes("Target: Full driver target"),
-    )).toBe(true);
+    expect(
+      observedMessages.some((message) =>
+        messageText(message).includes("Target: Full driver target"),
+      ),
+    ).toBe(true);
     expect(observedOptions?.tools).toEqual([]);
     expect(observedOptions?.toolChoice).toBe("none");
-    expect(events.find((event) => event.type === "entered_review_mode"))
-      .toMatchObject({
-        type: "entered_review_mode",
-        payload: { target: "Full driver target" },
-      });
-    expect(events.find((event) => event.type === "review_delegate_started"))
-      .toMatchObject({
-        type: "review_delegate_started",
-        payload: {
-          subId: "review-full-driver",
-          snapshot_reused: false,
-          priorFindingCount: 0,
-        },
-      });
-    expect(events.find((event) => event.type === "review_delegate_completed"))
-      .toMatchObject({
-        type: "review_delegate_completed",
-        payload: {
-          subId: "review-full-driver",
-          newFindingCount: 0,
-          verdict: "pass",
-          reason: "completed",
-        },
-      });
+    expect(
+      events.find((event) => event.type === "entered_review_mode"),
+    ).toMatchObject({
+      type: "entered_review_mode",
+      payload: { target: "Full driver target" },
+    });
+    expect(
+      events.find((event) => event.type === "review_delegate_started"),
+    ).toMatchObject({
+      type: "review_delegate_started",
+      payload: {
+        subId: "review-full-driver",
+        snapshot_reused: false,
+        priorFindingCount: 0,
+      },
+    });
+    expect(
+      events.find((event) => event.type === "review_delegate_completed"),
+    ).toMatchObject({
+      type: "review_delegate_completed",
+      payload: {
+        subId: "review-full-driver",
+        newFindingCount: 0,
+        verdict: "pass",
+        reason: "completed",
+      },
+    });
     expect(rolloutItems).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -475,9 +485,13 @@ describe("spawnReviewTask abort lifecycle", () => {
       subId: "review-A",
       request: mkReviewRequest(),
     });
-    expect(await session.abortTurnIfActive("review-other", "interrupted")).toBe(false);
+    expect(await session.abortTurnIfActive("review-other", "interrupted")).toBe(
+      false,
+    );
     expect(spawned.abortController.signal.aborted).toBe(false);
-    expect(await session.abortTurnIfActive("review-A", "interrupted")).toBe(true);
+    expect(await session.abortTurnIfActive("review-A", "interrupted")).toBe(
+      true,
+    );
     expect(spawned.abortController.signal.aborted).toBe(true);
   });
 
@@ -531,8 +545,16 @@ describe("ReviewManager", () => {
     const manager = new ReviewManager();
     const first = new AbortController();
     const second = new AbortController();
-    manager.register({ subId: "r1", abortController: first, request: mkReviewRequest() });
-    manager.register({ subId: "r1", abortController: second, request: mkReviewRequest() });
+    manager.register({
+      subId: "r1",
+      abortController: first,
+      request: mkReviewRequest(),
+    });
+    manager.register({
+      subId: "r1",
+      abortController: second,
+      request: mkReviewRequest(),
+    });
     expect(manager.size).toBe(1);
     const taken = manager.take("r1");
     expect(taken?.abortController).toBe(second);
@@ -561,8 +583,16 @@ describe("ReviewManager", () => {
     const manager = new ReviewManager();
     const c1 = new AbortController();
     const c2 = new AbortController();
-    manager.register({ subId: "r1", abortController: c1, request: mkReviewRequest() });
-    manager.register({ subId: "r2", abortController: c2, request: mkReviewRequest() });
+    manager.register({
+      subId: "r1",
+      abortController: c1,
+      request: mkReviewRequest(),
+    });
+    manager.register({
+      subId: "r2",
+      abortController: c2,
+      request: mkReviewRequest(),
+    });
     manager.shutdown("review_ended");
     expect(c1.signal.aborted).toBe(true);
     expect(c2.signal.aborted).toBe(true);
@@ -575,7 +605,11 @@ describe("ReviewManager", () => {
     const manager = new ReviewManager();
     const c1 = new AbortController();
     c1.abort("pre-existing");
-    manager.register({ subId: "r1", abortController: c1, request: mkReviewRequest() });
+    manager.register({
+      subId: "r1",
+      abortController: c1,
+      request: mkReviewRequest(),
+    });
     manager.shutdown("review_ended");
     // Reason remains the pre-existing one; upstream AbortController semantics
     // make abort() a no-op once already aborted, but we guard explicitly so
@@ -664,7 +698,8 @@ describe("parseReviewOutput", () => {
   });
 
   it("extracts JSON from a text wrapper (upstream `text.find('{') .. text.rfind('}')`)", () => {
-    const raw = 'Here is the review: {"overall_explanation":"wrapped"} trailing noise';
+    const raw =
+      'Here is the review: {"overall_explanation":"wrapped"} trailing noise';
     const out = parseReviewOutput(raw);
     expect(out.overallExplanation).toBe("wrapped");
   });
@@ -807,7 +842,9 @@ describe("review task interleave with regular tasks", () => {
     expect(regular.abortController.signal.aborted).toBe(true);
     expect(regular.abortController.signal.reason).toBe("replaced");
     expect(session.activeTurn.unsafePeek()?.turnId).toBe("review-A");
-    expect(session.activeTurn.unsafePeek()?.tasks.get("review-A")?.kind).toBe("review");
+    expect(session.activeTurn.unsafePeek()?.tasks.get("review-A")?.kind).toBe(
+      "review",
+    );
     await session.onTaskFinished(review.subId);
   });
 
@@ -895,7 +932,9 @@ describe("review_ended TurnAbortReason", () => {
       subId: "review-A",
       request: mkReviewRequest(),
     });
-    expect(await session.abortTurnIfActive("review-A", "review_ended")).toBe(true);
+    expect(await session.abortTurnIfActive("review-A", "review_ended")).toBe(
+      true,
+    );
     expect(spawned.abortController.signal.reason).toBe("review_ended");
   });
 });

--- a/runtime/tests/session/rollout-store.test.ts
+++ b/runtime/tests/session/rollout-store.test.ts
@@ -125,8 +125,11 @@ describe("RolloutStore thread-spawn edges", () => {
       expect(content).not.toContain(opaqueSecret);
       expect(content).not.toContain("abcdefghijklmnop=");
       expect(content).toContain("[REDACTED_SECRET]");
-      expect(store.readAll().some((item) => JSON.stringify(item).includes(rawSecret)))
-        .toBe(false);
+      expect(
+        store
+          .readAll()
+          .some((item) => JSON.stringify(item).includes(rawSecret)),
+      ).toBe(false);
     } finally {
       store.close();
       rmSync(cwd, { recursive: true, force: true });
@@ -186,6 +189,64 @@ describe("RolloutStore thread-spawn edges", () => {
     }
   });
 
+  it.each([
+    ["fresh", false],
+    ["resumed", true],
+  ] as const)(
+    "refuses a %s writer for a terminal epoch without changing canonical sources",
+    (_mode, resume) => {
+      const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+      const sessionId = "terminal-resume-refused";
+      const original = openStore({ cwd, sessionId });
+      try {
+        expect(
+          original.append(
+            {
+              eventId: `run-terminal:${sessionId}:1`,
+              id: `run-terminal:${sessionId}:1`,
+              seq: 1,
+              msg: {
+                type: "run_terminal",
+                payload: {
+                  runId: sessionId,
+                  epoch: 1,
+                  status: "completed",
+                  exitCode: 0,
+                  stopReason: "turn_completed",
+                  finalMessage: "done",
+                  usage: null,
+                  lastSequenceBeforeTerminal: null,
+                  finishedAt: "2026-07-18T00:00:00.000Z",
+                },
+              },
+            },
+            { durable: true },
+          ),
+        ).toBe(true);
+        original.close();
+        const terminalTail = readFileSync(original.rolloutPath, "utf8");
+        const rolloutFilesBefore = readdirSync(
+          original.store.sessionDir,
+        ).filter(
+          (name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
+        );
+
+        expect(() => openStore({ cwd, sessionId, resume })).toThrow(
+          `refusing to open terminal run ${sessionId} epoch 1; explicit reopen is required`,
+        );
+        expect(readFileSync(original.rolloutPath, "utf8")).toBe(terminalTail);
+        expect(
+          readdirSync(original.store.sessionDir).filter(
+            (name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
+          ),
+        ).toEqual(rolloutFilesBefore);
+      } finally {
+        original.close();
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("fails closed instead of reopening a corrupted persisted edge status", () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
     const sessionId = "thread-spawn-invalid-status";
@@ -206,11 +267,13 @@ describe("RolloutStore thread-spawn edges", () => {
 
       const raw = new Database(resolveStateDatabasePaths({ cwd }).stateDbPath);
       try {
-        raw.prepare(
-          `UPDATE thread_spawn_edges
+        raw
+          .prepare(
+            `UPDATE thread_spawn_edges
            SET status = 'corrupted'
            WHERE child_thread_id = ?`,
-        ).run("child-invalid-status");
+          )
+          .run("child-invalid-status");
       } finally {
         raw.close();
       }
@@ -244,14 +307,16 @@ describe("RolloutStore thread-spawn edges", () => {
       const raw = new Database(resolveStateDatabasePaths({ cwd }).stateDbPath);
       try {
         expect(() =>
-          raw.prepare(
-            `UPDATE thread_spawn_edges
+          raw
+            .prepare(
+              `UPDATE thread_spawn_edges
              SET metadata_json = ?, status = 'closed'
              WHERE child_thread_id = ?`,
-          ).run(
-            JSON.stringify(metadata("child-legacy", "/root/legacy", 1)),
-            "child-legacy",
-          ),
+            )
+            .run(
+              JSON.stringify(metadata("child-legacy", "/root/legacy", 1)),
+              "child-legacy",
+            ),
         ).toThrow(/identity is immutable/);
       } finally {
         raw.close();
@@ -263,7 +328,9 @@ describe("RolloutStore thread-spawn edges", () => {
           ...metadata("child-legacy", "/root/legacy", 1),
           agentRoleWorkspaceId: cwd,
         });
-        expect(reopened.getThreadSpawnEdge("child-legacy")?.status).toBe("open");
+        expect(reopened.getThreadSpawnEdge("child-legacy")?.status).toBe(
+          "open",
+        );
       } finally {
         reopened.close();
       }
@@ -765,8 +832,9 @@ describe("RolloutStore thread-spawn edges", () => {
     try {
       expect(store.listThreadSpawnChildren("root-1")).toEqual([]);
       const corruptDir = join(getProjectDir(cwd), "state-corrupt");
-      const backups = readdirSync(corruptDir).filter((entry) =>
-        entry.startsWith("thread-spawn-edges-") && entry.endsWith(".json"),
+      const backups = readdirSync(corruptDir).filter(
+        (entry) =>
+          entry.startsWith("thread-spawn-edges-") && entry.endsWith(".json"),
       );
       expect(backups).toHaveLength(1);
       expect(existsSync(snapshotPath)).toBe(true);

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  writeSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -181,12 +182,10 @@ describe("session-store", () => {
     expect(appended.eventVersion).toBe(1);
   });
 
-  test("I-23 SessionLock: two-process exclusivity — live holder (this PID) refuses reclaim", () => {
-    // Real-PID-alive variant: write a lock record owned by the
-    // current test process (which is guaranteed to be alive via
-    // kill(pid, 0)) and verify a fresh SessionLock instance refuses
-    // to reclaim it. This is the unambiguous signal that the lock
-    // enforces exclusivity against any live holder, PID reuse notwithstanding.
+  test("I-23 SessionLock: a distinct same-PID owner cannot acquire or release the lease", () => {
+    // Independent stores in one daemon share a PID, so ownership must include
+    // the unique start token. A second wrapper must neither enter nor unlink a
+    // lease held by the first owner identity.
     const dir = mkdtempSync(join(tmpdir(), "agenc-lock-xproc-"));
     try {
       const lockPath = join(dir, "rollout.jsonl.lock");
@@ -197,12 +196,9 @@ describe("session-store", () => {
       });
       writeFileSync(lockPath, `${stamp}\n`);
       const secondLock = new SessionLock(lockPath);
-      // Same-PID acquire is allowed (same-process re-entry). This is
-      // intentional: within a single Node process, acquire() is
-      // idempotent so multiple SessionLock wrappers pointing at the
-      // same path don't deadlock one another.
-      secondLock.acquire();
+      expect(() => secondLock.acquire()).toThrow(SessionLockedError);
       secondLock.release();
+      expect(existsSync(lockPath)).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -570,6 +566,296 @@ describe("session-store", () => {
     rolloutStore.close();
   });
 
+  test("Session.emit fsyncs durable events before listener and transport publication", () => {
+    const order: string[] = [];
+    const eventLog = new EventLog();
+    eventLog.subscribe(() => order.push("listener"));
+    const session = {
+      eventLog,
+      rolloutStore: {
+        append: (_event: unknown, opts: { readonly durable?: boolean }) => {
+          expect(opts.durable).toBe(true);
+          order.push("fsync");
+          return true;
+        },
+      },
+      txEvent: {
+        send: () => {
+          order.push("tx");
+          return true;
+        },
+      },
+      isRolloutPersistenceSuspended: () => false,
+    } as unknown as Session;
+
+    const stamped = Session.prototype.emit.call(session, {
+      id: "effect-intent-id",
+      msg: {
+        type: "effect_intent",
+        payload: {
+          runId: "run-1",
+          stepId: "tool:turn-1:call-1",
+          callId: "call-1",
+          toolName: "system.write",
+          recoveryCategory: "side-effecting",
+          intentDigest: "a".repeat(64),
+          attempt: 1,
+          recordedAt: "2026-07-18T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(stamped.seq).toBe(1);
+    expect(order).toEqual(["fsync", "listener", "tx"]);
+  });
+
+  test("Session.emit does not publish a durable event when fsync fails", () => {
+    const rolloutStore = new RolloutStore({
+      cwd: "/home/test-session-fsync-failure",
+      sessionId: "sess-fsync-failure",
+      agencVersion: "0.2.0",
+      autoStartScheduler: false,
+    });
+    rolloutStore.open({
+      sessionId: "sess-fsync-failure",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-session-fsync-failure",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    rolloutStore.store.setFsyncImplForTest(() => {
+      throw Object.assign(new Error("injected fsync failure"), { code: "EIO" });
+    });
+    const published: string[] = [];
+    const eventLog = new EventLog();
+    eventLog.subscribe(() => published.push("listener"));
+    const session = {
+      eventLog,
+      rolloutStore,
+      txEvent: {
+        send: () => {
+          published.push("tx");
+          return true;
+        },
+      },
+      isRolloutPersistenceSuspended: () => false,
+    } as unknown as Session;
+
+    expect(() => Session.prototype.emit.call(session, {
+      id: "effect-result-id",
+      msg: {
+        type: "effect_result",
+        payload: {
+          runId: "run-1",
+          stepId: "tool:turn-1:call-1",
+          callId: "call-1",
+          toolName: "system.write",
+          recoveryCategory: "side-effecting",
+          intentEventSeq: 1,
+          outcome: "committed",
+          recordedAt: "2026-07-18T00:00:00.000Z",
+        },
+      },
+    })).toThrow(/was not fsync-committed/);
+    expect(published).toEqual([]);
+
+    // Let the scheduled retry/close path use the real fsync implementation.
+    rolloutStore.store.setFsyncImplForTest(fsyncSync);
+    rolloutStore.close();
+  });
+
+  test("durable rollout writes loop until every byte is appended", () => {
+    const store = new SessionStore({
+      cwd: "/home/test-short-write",
+      sessionId: "sess-short-write",
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId: "sess-short-write",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-short-write",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    let writes = 0;
+    store.setWriteImplForTest((fd, buffer, offset, length) => {
+      writes += 1;
+      return writeSync(fd, buffer, offset, Math.min(length, 7));
+    });
+    store.append(
+      {
+        id: "short-write-event",
+        seq: 1,
+        msg: {
+          type: "warning",
+          payload: { cause: "short_write", message: "fully committed" },
+        },
+      },
+      { durable: true },
+    );
+    store.close();
+
+    expect(writes).toBeGreaterThan(1);
+    expect(() => {
+      for (const line of readFileSync(store.rolloutPath, "utf8").trimEnd().split("\n")) {
+        JSON.parse(line);
+      }
+    }).not.toThrow();
+    expect(readFileSync(store.rolloutPath, "utf8")).toContain(
+      '"id":"short-write-event"',
+    );
+  });
+
+  test("rolls back a partial append before degraded requeue", () => {
+    const store = new SessionStore({
+      cwd: "/home/test-interrupted-short-write",
+      sessionId: "sess-interrupted-short-write",
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId: "sess-interrupted-short-write",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-interrupted-short-write",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    const committedPrefix = readFileSync(store.rolloutPath, "utf8");
+    let writes = 0;
+    store.setWriteImplForTest((fd, buffer, offset, length) => {
+      writes += 1;
+      if (writes === 1) {
+        return writeSync(fd, buffer, offset, Math.min(length, 7));
+      }
+      throw Object.assign(new Error("injected interrupted write"), {
+        code: "EIO",
+      });
+    });
+
+    expect(
+      store.append(
+        {
+          id: "interrupted-short-write-event",
+          seq: 1,
+          msg: {
+            type: "warning",
+            payload: { cause: "short_write", message: "must not leave a tail" },
+          },
+        },
+        { durable: true },
+      ),
+    ).toBe(false);
+    expect(readFileSync(store.rolloutPath, "utf8")).toBe(committedPrefix);
+
+    store.setWriteImplForTest((fd, buffer, offset, length) =>
+      writeSync(fd, buffer, offset, length),
+    );
+    store.close();
+  });
+
+  test("durable non-event append and explicit rollout flush propagate fsync failure", () => {
+    const rollout = new RolloutStore({
+      cwd: "/home/test-rollout-flush-failure",
+      sessionId: "sess-rollout-flush-failure",
+      agencVersion: "0.2.0",
+      autoStartScheduler: false,
+    });
+    rollout.open({
+      sessionId: "sess-rollout-flush-failure",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-rollout-flush-failure",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    const failFsync = () => {
+      throw Object.assign(new Error("injected fsync failure"), { code: "EIO" });
+    };
+    rollout.store.setFsyncImplForTest(failFsync);
+    expect(() =>
+      rollout.appendRollout(
+        { type: "response_item", payload: { role: "user", content: "durable" } },
+        { durable: true },
+      ),
+    ).toThrow(/not fsync-committed/);
+
+    rollout.store.setFsyncImplForTest(fsyncSync);
+    rollout.appendRollout({
+      type: "response_item",
+      payload: { role: "user", content: "queued" },
+    });
+    rollout.store.setFsyncImplForTest(failFsync);
+    expect(() => rollout.flushDurable()).toThrow(/not fsync-committed/);
+
+    rollout.store.setFsyncImplForTest(fsyncSync);
+    rollout.close();
+  });
+
+  test("explicit canonical-tail sync fsyncs an empty pending batch and propagates failure", () => {
+    const rollout = new RolloutStore({
+      cwd: "/home/test-explicit-tail-sync",
+      sessionId: "sess-explicit-tail-sync",
+      agencVersion: "0.2.0",
+      autoStartScheduler: false,
+    });
+    rollout.open({
+      sessionId: "sess-explicit-tail-sync",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-explicit-tail-sync",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    let syncs = 0;
+    rollout.store.setFsyncImplForTest(() => {
+      syncs += 1;
+      throw Object.assign(new Error("injected explicit sync failure"), {
+        code: "EIO",
+      });
+    });
+
+    // The legacy flush API has no bytes to write and therefore no fsync proof.
+    expect(rollout.store.flushBatch(true)).toBe(true);
+    expect(syncs).toBe(0);
+    expect(() => rollout.syncCanonicalTail()).toThrow(
+      /injected explicit sync failure/,
+    );
+    expect(syncs).toBe(1);
+
+    rollout.store.setFsyncImplForTest(fsyncSync);
+    expect(() => rollout.syncCanonicalTail()).not.toThrow();
+    rollout.close();
+  });
+
+  test("resume refuses recovery evidence when the surviving tail cannot be fsynced", () => {
+    const original = new SessionStore({
+      cwd: "/home/test-resume-tail-sync",
+      sessionId: "sess-resume-tail-sync",
+      agencVersion: "0.2.0",
+    });
+    const meta = {
+      sessionId: "sess-resume-tail-sync",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-resume-tail-sync",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    } as const;
+    original.open(meta);
+    original.close();
+
+    const resumed = new SessionStore({
+      cwd: "/home/test-resume-tail-sync",
+      sessionId: "sess-resume-tail-sync",
+      agencVersion: "0.2.0",
+      resume: true,
+    });
+    resumed.setFsyncImplForTest(() => {
+      throw Object.assign(new Error("injected resume sync failure"), {
+        code: "EIO",
+      });
+    });
+    expect(() => resumed.open(meta)).toThrow(/injected resume sync failure/);
+    expect(existsSync(resumed.lockPath)).toBe(false);
+    resumed.close();
+  });
+
   test("UUID dedup: repeated event.id without seq is skipped", () => {
     const store = new SessionStore({
       cwd: "/home/test-dedup",
@@ -594,6 +880,51 @@ describe("session-store", () => {
     const content = readFileSync(store.rolloutPath, "utf8");
     const matches = content.match(/"dup-id"/g) ?? [];
     expect(matches.length).toBe(1);
+  });
+
+  test("fails closed on a repeated sequenced event", () => {
+    const store = new SessionStore({
+      cwd: "/home/test-sequence-conflict",
+      sessionId: "sess-sequence-conflict",
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId: "sess-sequence-conflict",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-sequence-conflict",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    store.append(
+      {
+        id: "first",
+        seq: 1,
+        msg: {
+          type: "warning",
+          payload: { cause: "first", message: "one" },
+        },
+      },
+      { durable: true },
+    );
+
+    expect(() =>
+      store.append(
+        {
+          id: "conflict",
+          seq: 1,
+          msg: {
+            type: "warning",
+            payload: { cause: "conflict", message: "different" },
+          },
+        },
+        { durable: true },
+      ),
+    ).toThrow(/non-monotonic rollout event sequence 1/);
+    store.close();
+
+    const content = readFileSync(store.rolloutPath, "utf8");
+    expect(content).toContain('"id":"first"');
+    expect(content).not.toContain('"id":"conflict"');
   });
 
   test("I-24 close writes atomic index.json snapshot with seq + offsets", () => {
@@ -1010,6 +1341,35 @@ describe("session-store", () => {
       expect(result.truncated).toBe(true);
       const content = readFileSync(path, "utf8");
       expect(content.endsWith("\n")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("I-24 truncateCorruptTail fails closed when truncate or fsync repair fails", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-corrupt-repair-failure-"));
+    try {
+      const path = join(dir, "rollout.jsonl");
+      const partial = '{"type":"session_meta","payload":{}}\n{"type":"event_msg"';
+      writeFileSync(path, partial, { mode: 0o600 });
+      const truncateFailure = new Error("injected truncate failure");
+      expect(() =>
+        truncateCorruptTail(path, {
+          truncate: () => {
+            throw truncateFailure;
+          },
+        }),
+      ).toThrow(truncateFailure);
+
+      writeFileSync(path, partial, { mode: 0o600 });
+      const syncFailure = new Error("injected repair fsync failure");
+      expect(() =>
+        truncateCorruptTail(path, {
+          sync: () => {
+            throw syncFailure;
+          },
+        }),
+      ).toThrow(syncFailure);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/runtime/tests/session/session.test.ts
+++ b/runtime/tests/session/session.test.ts
@@ -654,6 +654,52 @@ describe("Session.abortTerminal", () => {
   });
 });
 
+describe("Session rollout persistence suspension", () => {
+  it("keeps fork-only events ephemeral without consuming canonical coordinates", async () => {
+    const session = buildSession();
+    const append = vi.fn(() => true);
+    session.rolloutStore = {
+      append,
+    } as unknown as Session["rolloutStore"];
+    const published: Event[] = [];
+    session.eventLog.subscribe((event) => published.push(event));
+
+    const before = session.emit({
+      id: "root-before",
+      msg: { type: "user_message", payload: { message: "before" } },
+    });
+    let forkEvent: Event | undefined;
+    await session.withRolloutPersistenceSuspended(async () => {
+      forkEvent = session.emit({
+        eventId: "fork-event-must-not-leak",
+        id: "fork-correlation",
+        seq: 99,
+        msg: { type: "turn_started", payload: { turnId: "fork-turn" } },
+      });
+    });
+    const after = session.emit({
+      id: "root-after",
+      msg: { type: "turn_complete", payload: { turnId: "root-turn" } },
+    });
+
+    expect(before).toMatchObject({ eventId: "event:1", seq: 1 });
+    expect(forkEvent).toEqual({
+      id: "fork-correlation",
+      msg: { type: "turn_started", payload: { turnId: "fork-turn" } },
+    });
+    expect(after).toMatchObject({ eventId: "event:2", seq: 2 });
+    expect(append.mock.calls.map(([event]) => event)).toMatchObject([
+      { eventId: "event:1", seq: 1 },
+      { eventId: "event:2", seq: 2 },
+    ]);
+    expect(published.map((event) => [event.eventId, event.seq])).toEqual([
+      ["event:1", 1],
+      [undefined, undefined],
+      ["event:2", 2],
+    ]);
+  });
+});
+
 describe("Session.consumePendingProviderSwitch", () => {
   it("resets ProviderHttpClient continuity state on provider/model switches and re-binds the session conversation id", async () => {
     const bindSpy = vi.spyOn(ProviderHttpClient.prototype, "bindConversationId");
@@ -1322,6 +1368,87 @@ describe("Session turn-driver hooks", () => {
 
     expect(closeCount).toBe(1);
     await expect(session.conversation.runningState()).resolves.toBeUndefined();
+  });
+
+  it("drains durable continuations before finalizing and sealing the journal", async () => {
+    const session = buildSession();
+    const appended: Event[] = [];
+    session.rolloutStore = {
+      append: vi.fn((event: Event) => {
+        appended.push(event);
+        return true;
+      }),
+      flushDurable: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Session["rolloutStore"];
+    let releaseDecision!: () => void;
+    const decisionGate = new Promise<void>((resolve) => {
+      releaseDecision = resolve;
+    });
+    const decision = (async () => {
+      await decisionGate;
+      session.emit(
+        {
+          id: "permission-decision:shutdown",
+          msg: {
+            type: "permission_decision",
+            payload: {
+              runId: session.conversationId,
+              callId: "call-shutdown",
+              toolName: "Bash",
+              turnId: "turn-shutdown",
+              requestEventId: "request-shutdown",
+              requestEventSeq: 1,
+              decision: "abort",
+              source: "aborted",
+              recordedAt: "2026-07-18T00:00:00.000Z",
+            },
+          },
+        },
+        { durable: true },
+      );
+    })();
+    session.trackDurableOperation(decision);
+    session.onBeforeDurableClose(() => {
+      session.emit(
+        {
+          eventId: "run-terminal:conv-test:1",
+          id: "run-terminal:conv-test:1",
+          msg: {
+            type: "run_terminal",
+            payload: {
+              runId: "conv-test",
+              epoch: 1,
+              status: "cancelled",
+              exitCode: null,
+              stopReason: "shutdown",
+              finalMessage: null,
+              usage: null,
+              lastSequenceBeforeTerminal: 1,
+              finishedAt: "2026-07-18T00:00:01.000Z",
+            },
+          },
+        },
+        { durable: true },
+      );
+    });
+
+    const shutdown = session.shutdown();
+    await Promise.resolve();
+    expect(appended).toEqual([]);
+    releaseDecision();
+    await shutdown;
+
+    expect(appended.map((event) => event.msg.type)).toEqual([
+      "permission_decision",
+      "run_terminal",
+    ]);
+    expect(() =>
+      session.emit({
+        id: "late",
+        msg: { type: "warning", payload: { cause: "late", message: "late" } },
+      }),
+    ).toThrow("canonical run journal is sealed");
   });
 });
 

--- a/runtime/tests/state/execution-admission-canonical-recovery.test.ts
+++ b/runtime/tests/state/execution-admission-canonical-recovery.test.ts
@@ -1,0 +1,252 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { RuntimeAdmissionRequest } from "../../src/budget/admission-types.js";
+import type { Event } from "../../src/session/event-log.js";
+import {
+  parseRolloutLine,
+  serializeRolloutItem,
+} from "../../src/session/rollout-item.js";
+import { recoverExecutionAdmissionCanonicalJournals } from "../../src/state/execution-admission-canonical-recovery.js";
+import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+
+const RUN_ID = "admission-recovery-run";
+const T0 = "2026-07-18T00:00:00.000Z";
+
+let home = "";
+let cwd = "";
+let driver: StateSqliteDriver;
+let admissions: ExecutionAdmissionRepository;
+let nextId = 0;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-admission-canonical-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-admission-canonical-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome: home });
+  admissions = new ExecutionAdmissionRepository(driver, {
+    now: () => new Date(T0),
+    id: () => `admission-recovery-id-${++nextId}`,
+    ownerId: "crashed-daemon",
+    ownerPid: process.pid,
+  });
+});
+
+afterEach(() => {
+  driver.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function request(stepId: string): RuntimeAdmissionRequest {
+  return {
+    step: { runId: RUN_ID, stepId },
+    kind: "model_turn",
+    estimate: {
+      maxInputTokens: 1,
+      maxOutputTokens: 1,
+      maxCostUsd: 0,
+    },
+    model: "test-model",
+    provider: "test-provider",
+    workspaceId: "workspace",
+    sessionId: RUN_ID,
+    parentScopeId: RUN_ID,
+    autonomous: false,
+  };
+}
+
+function bindRollout(events: readonly Event[]): string {
+  const directory = join(driver.projectDir, "sessions", RUN_ID);
+  mkdirSync(directory, { recursive: true });
+  const sourcePath = join(directory, `rollout-${RUN_ID}.jsonl`);
+  writeFileSync(
+    sourcePath,
+    events
+      .map((event) =>
+        serializeRolloutItem({ type: "event_msg", payload: event }),
+      )
+      .join(""),
+    { mode: 0o600 },
+  );
+  const durability = new StateRunDurabilityRepository(driver);
+  durability.ensureInitialEpoch({ runId: RUN_ID, openedAt: T0 });
+  durability.bindJournalSource({
+    runId: RUN_ID,
+    epoch: 1,
+    childRunId: RUN_ID,
+    sessionId: RUN_ID,
+    sourcePath,
+    boundAt: T0,
+  });
+  return sourcePath;
+}
+
+function readEvents(sourcePath: string): Event[] {
+  return readFileSync(sourcePath, "utf8")
+    .split("\n")
+    .flatMap((line) => {
+      if (line.trim().length === 0) return [];
+      const item = parseRolloutLine(line);
+      return item?.type === "event_msg" ? [item.payload] : [];
+    });
+}
+
+describe("canonical execution-admission recovery", () => {
+  it("backfills the exact SQLite event under the run sequence lease", () => {
+    const sourcePath = bindRollout([
+      {
+        eventId: "existing-event",
+        id: "existing-event",
+        seq: 1,
+        msg: {
+          type: "warning",
+          payload: { cause: "fixture", message: "existing" },
+        },
+      },
+    ]);
+    const queued = admissions.enqueue(request("model-1"));
+    const admission = admissions.listJournal({ runId: RUN_ID })[0]!;
+
+    const first = recoverExecutionAdmissionCanonicalJournals(
+      driver,
+      admissions,
+    );
+    const second = recoverExecutionAdmissionCanonicalJournals(
+      driver,
+      admissions,
+    );
+
+    expect(queued.record.status).toBe("queued");
+    expect(first.admissionEventsAppended).toBe(1);
+    expect(second.admissionEventsAppended).toBe(0);
+    expect(readEvents(sourcePath)).toMatchObject([
+      { eventId: "existing-event", seq: 1 },
+      {
+        eventId: admission.eventId,
+        id: admission.eventId,
+        seq: 2,
+        msg: { type: "execution_admission", payload: admission },
+      },
+    ]);
+    expect(
+      driver
+        .prepareState<[string], { readonly event_id: string }>(
+          `SELECT event_id FROM thread_rollout_items
+           WHERE source_path = ? AND event_seq = 2`,
+        )
+        .get(sourcePath),
+    ).toEqual({ event_id: admission.eventId });
+  });
+
+  it("refuses conflicting canonical identity evidence", () => {
+    admissions.enqueue(request("model-conflict"));
+    const admission = admissions.listJournal({ runId: RUN_ID })[0]!;
+    bindRollout([
+      {
+        eventId: admission.eventId,
+        id: admission.eventId,
+        seq: 1,
+        msg: {
+          type: "warning",
+          payload: { cause: "conflict", message: "not admission evidence" },
+        },
+      },
+    ]);
+    expect(() =>
+      recoverExecutionAdmissionCanonicalJournals(driver, admissions),
+    ).toThrow(/conflicting canonical evidence/);
+  });
+
+  it("refuses to append committed admission evidence after a terminal tail", () => {
+    const otherRun = "terminal-admission-recovery-run";
+    const directory = join(driver.projectDir, "sessions", otherRun);
+    mkdirSync(directory, { recursive: true });
+    const sourcePath = join(directory, `rollout-${otherRun}.jsonl`);
+    writeFileSync(
+      sourcePath,
+      serializeRolloutItem({
+        type: "event_msg",
+        payload: {
+          eventId: "terminal-event",
+          id: "terminal-event",
+          seq: 1,
+          msg: {
+            type: "run_terminal",
+            payload: {
+              runId: otherRun,
+              epoch: 1,
+              status: "completed",
+              exitCode: 0,
+              stopReason: "done",
+              finalMessage: "done",
+              usage: null,
+              lastSequenceBeforeTerminal: null,
+              finishedAt: T0,
+            },
+          },
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const durability = new StateRunDurabilityRepository(driver);
+    durability.ensureInitialEpoch({ runId: otherRun, openedAt: T0 });
+    durability.bindJournalSource({
+      runId: otherRun,
+      epoch: 1,
+      childRunId: otherRun,
+      sessionId: otherRun,
+      sourcePath,
+      boundAt: T0,
+    });
+    admissions.enqueue({
+      ...request("model-terminal"),
+      step: { runId: otherRun, stepId: "model-terminal" },
+      sessionId: otherRun,
+      parentScopeId: otherRun,
+    });
+
+    expect(() =>
+      recoverExecutionAdmissionCanonicalJournals(driver, admissions),
+    ).toThrow(/terminal tail precedes 1 committed admission event/);
+  });
+
+  it("fails closed when its configured event-work bound is exceeded", () => {
+    bindRollout([]);
+    admissions.enqueue(request("model-1"));
+    const claimed = admissions.claim();
+    expect(claimed.kind).toBe("claimed");
+
+    expect(() =>
+      recoverExecutionAdmissionCanonicalJournals(driver, admissions, {
+        maxEventsPerRun: 1,
+      }),
+    ).toThrow(/bounded event limit \(1\)/);
+  });
+
+  it("refuses a canonical lifecycle with committed admissions but no binding", () => {
+    admissions.enqueue(request("model-unbound"));
+    new StateRunDurabilityRepository(driver).ensureInitialEpoch({
+      runId: RUN_ID,
+      openedAt: T0,
+    });
+
+    expect(() =>
+      recoverExecutionAdmissionCanonicalJournals(driver, admissions),
+    ).toThrow(/canonical lifecycle but no journal binding/);
+  });
+});

--- a/runtime/tests/state/execution-admission.test.ts
+++ b/runtime/tests/state/execution-admission.test.ts
@@ -161,7 +161,7 @@ describe("execution admission schema migration", () => {
         db
           .prepare("SELECT MAX(version) AS version FROM schema_migrations")
           .get(),
-      ).toEqual({ version: 14 });
+      ).toEqual({ version: 15 });
     } finally {
       db.close();
     }

--- a/runtime/tests/state/migrations.test.ts
+++ b/runtime/tests/state/migrations.test.ts
@@ -55,7 +55,7 @@ describe("state migration registry", () => {
 
   it("loads state migrations from numbered migration files in order", () => {
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.version)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     ]);
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.name)).toEqual([
       "initial_state_schema",
@@ -72,6 +72,7 @@ describe("state migration registry", () => {
       "agent_role_workspace_provenance",
       "thread_listing_indexes",
       "execution_admission_schema",
+      "run_durability_schema",
     ]);
     expectMigrationVersionsAreUnique(STATE_DB_MIGRATIONS);
   });
@@ -104,7 +105,105 @@ describe("state migration registry", () => {
       "012_agent_role_workspace_provenance.ts",
       "013_thread_listing_indexes.ts",
       "014_execution_admission_schema.ts",
+      "015_run_durability_schema.ts",
     ]);
+  });
+
+  it("adds durable run state without copying canonical rollout event payloads", () => {
+    const db = new Database(":memory:");
+    try {
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+
+      const tables = db
+        .prepare<[], { name: string }>(
+          `SELECT name
+           FROM sqlite_master
+           WHERE type = 'table' AND name LIKE 'run_%'
+           ORDER BY name ASC`,
+        )
+        .all()
+        .map((row) => row.name);
+      expect(tables).toEqual([
+        "run_effects",
+        "run_journal_bindings",
+        "run_lifecycle_epochs",
+        "run_terminal_results",
+      ]);
+      expect(tables).not.toContain("run_journal_events");
+      expect(
+        db
+          .prepare<[], { version: number; name: string }>(
+            "SELECT version, name FROM schema_migrations WHERE version = 15",
+          )
+          .get(),
+      ).toEqual({ version: 15, name: "run_durability_schema" });
+
+      const effectIndexes = db
+        .prepare<[], { name: string }>("PRAGMA index_list(run_effects)")
+        .all()
+        .map((row) => row.name);
+      expect(effectIndexes).toEqual(
+        expect.arrayContaining([
+          "idx_run_effects_intent_sequence",
+          "idx_run_effects_result_sequence",
+          "idx_run_effects_pending_review",
+        ]),
+      );
+      const journalIndexes = db
+        .prepare<[], { name: string }>(
+          "PRAGMA index_list(run_journal_bindings)",
+        )
+        .all()
+        .map((row) => row.name);
+      expect(journalIndexes).toContain("idx_run_journal_bindings_active");
+      const rolloutIndexes = db
+        .prepare<[], { name: string }>(
+          "PRAGMA index_list(thread_rollout_items)",
+        )
+        .all()
+        .map((row) => row.name);
+      expect(rolloutIndexes).toEqual(
+        expect.arrayContaining([
+          "idx_thread_rollout_items_replay_source_sequence",
+          "idx_thread_rollout_items_replay_thread_sequence",
+          "idx_thread_rollout_items_replay_source_identity",
+          "idx_thread_rollout_items_replay_thread_identity",
+        ]),
+      );
+      const sequencePlan = db
+        .prepare(
+          `EXPLAIN QUERY PLAN
+           SELECT event_seq, event_id, payload_json
+           FROM thread_rollout_items
+           WHERE source_path = ? AND item_type = 'event_msg'
+             AND event_seq > ?
+           GROUP BY event_seq, event_id, payload_json
+           ORDER BY event_seq
+           LIMIT ?`,
+        )
+        .all("/rollout/run.jsonl", 0, 201)
+        .map((row) => String((row as { detail?: unknown }).detail ?? ""));
+      expect(sequencePlan.join("\n")).toContain(
+        "idx_thread_rollout_items_replay_source_sequence",
+      );
+      const identityPlan = db
+        .prepare(
+          `EXPLAIN QUERY PLAN
+           SELECT event_id, event_seq, payload_json
+           FROM thread_rollout_items
+           WHERE source_path = ? AND item_type = 'event_msg'
+             AND event_seq IS NOT NULL AND event_id IN (?, ?)
+           GROUP BY event_id, event_seq, payload_json`,
+        )
+        .all("/rollout/run.jsonl", "event:1", "event:2")
+        .map((row) => String((row as { detail?: unknown }).detail ?? ""));
+      expect(identityPlan.join("\n")).toContain(
+        "idx_thread_rollout_items_replay_source_identity",
+      );
+    } finally {
+      db.close();
+    }
   });
 
   it("installs ordering indexes for bounded active and archived thread pages", () => {

--- a/runtime/tests/state/recovery-restart.test.ts
+++ b/runtime/tests/state/recovery-restart.test.ts
@@ -1,8 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { recoverDaemonStateOnStartup } from "./recovery.js";
+import type { Event } from "../../src/session/event-log.js";
+import { serializeRolloutItem } from "../../src/session/rollout-item.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
 
 let home = "";
@@ -23,6 +26,549 @@ afterEach(() => {
 });
 
 describe("recoverDaemonStateOnStartup", () => {
+  it("fails closed when a canonical cancel request committed before its terminal", () => {
+    insertAgentRun({
+      id: "run-cancel-request-crash",
+      objective: "must not resume after cancellation intent",
+      status: "running",
+      currentSessionId: "run-cancel-request-crash",
+    });
+    const rolloutPath = writeRunJournal("run-cancel-request-crash", [
+      {
+        eventId: "run-cancel-request:run-cancel-request-crash:1",
+        id: "run-cancel-request:run-cancel-request-crash:1",
+        seq: 1,
+        msg: {
+          type: "run_cancel_requested",
+          payload: {
+            runId: "run-cancel-request-crash",
+            epoch: 1,
+            reason: "operator",
+            requestedAt: "2026-05-01T00:06:00.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-cancel-request-crash", rolloutPath);
+
+    const report = recoverDaemonStateOnStartup(driver);
+
+    expect(report.recoveredRuns).toEqual([]);
+    expect(agentRunStatus("run-cancel-request-crash")).toBe("cancelled");
+    expect(
+      new StateRunDurabilityRepository(driver).getCurrentTerminalResult(
+        "run-cancel-request-crash",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("fails closed when admission cancellation committed before the canonical terminal", () => {
+    insertAgentRun({
+      id: "run-admission-cancel-crash",
+      objective: "must not regain execution authority",
+      status: "running",
+      currentSessionId: "run-admission-cancel-crash",
+    });
+    driver
+      .prepareState(
+        `INSERT INTO execution_admission_cancellations (
+           run_id, reason, cancelled_at
+         ) VALUES (?, ?, ?)`,
+      )
+      .run(
+        "run-admission-cancel-crash",
+        "operator",
+        "2026-05-01T00:06:00.000Z",
+      );
+
+    const report = recoverDaemonStateOnStartup(driver);
+
+    expect(report.recoveredRuns).toEqual([]);
+    expect(agentRunStatus("run-admission-cancel-crash")).toBe("cancelled");
+  });
+
+  it("projects a fsynced terminal event before a stale running row can be restored", () => {
+    insertAgentRun({
+      id: "run-terminal-journal",
+      objective: "must stay finished",
+      status: "running",
+      currentSessionId: "run-terminal-journal",
+    });
+    const rolloutPath = writeRunJournal("run-terminal-journal", [
+      {
+        id: "run-terminal:run-terminal-journal:1",
+        seq: 1,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: "run-terminal-journal",
+            epoch: 1,
+            status: "completed",
+            exitCode: 0,
+            stopReason: "completed",
+            finalMessage: "durable answer",
+            usage: null,
+            lastSequenceBeforeTerminal: null,
+            finishedAt: "2026-05-01T00:06:00.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-terminal-journal", rolloutPath);
+
+    const report = recoverDaemonStateOnStartup(driver, {
+      now: () => "2026-05-01T00:20:00.000Z",
+    });
+
+    expect(report.recoveredRuns).toEqual([]);
+    expect(agentRunStatus("run-terminal-journal")).toBe("completed");
+    expect(
+      new StateRunDurabilityRepository(driver).getCurrentTerminalResult(
+        "run-terminal-journal",
+      ),
+    ).toMatchObject({
+      eventId: "legacy-event:1:run-terminal:run-terminal-journal:1",
+      status: "completed",
+      finalMessage: "durable answer",
+      lastSequence: 1,
+    });
+
+    // Once repaired, a second daemon start does not even classify the row as
+    // recoverable. Removing the startup projection makes the first assertion
+    // fail red with a resurrected run.
+    expect(recoverDaemonStateOnStartup(driver).recoveredRuns).toEqual([]);
+  });
+
+  it("repairs a legacy DB-first cancellation when its canonical terminal landed before the crash", () => {
+    insertAgentRun({
+      id: "run-legacy-db-first-cancel",
+      objective: "repair cancelled terminal projection",
+      status: "cancelled",
+      currentSessionId: "run-legacy-db-first-cancel",
+    });
+    const rolloutPath = writeRunJournal("run-legacy-db-first-cancel", [
+      {
+        id: "run-terminal:run-legacy-db-first-cancel:1",
+        seq: 3,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: "run-legacy-db-first-cancel",
+            epoch: 1,
+            status: "cancelled",
+            exitCode: null,
+            stopReason: "operator",
+            finalMessage: null,
+            usage: null,
+            lastSequenceBeforeTerminal: 2,
+            finishedAt: "2026-05-01T00:06:00.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-legacy-db-first-cancel", rolloutPath);
+
+    const report = recoverDaemonStateOnStartup(driver, {
+      now: () => "2026-05-01T00:20:00.000Z",
+    });
+
+    expect(report.recoveredRuns).toEqual([]);
+    expect(agentRunStatus("run-legacy-db-first-cancel")).toBe("cancelled");
+    expect(
+      new StateRunDurabilityRepository(driver).getCurrentTerminalResult(
+        "run-legacy-db-first-cancel",
+      ),
+    ).toMatchObject({
+      eventId:
+        "legacy-event:3:run-terminal:run-legacy-db-first-cancel:1",
+      status: "cancelled",
+      stopReason: "operator",
+      lastSequence: 3,
+    });
+  });
+
+  it("does not invent terminal output for an offline cancelled run with no canonical journal", () => {
+    insertAgentRun({
+      id: "run-offline-cancel-no-writer",
+      objective: "remain honestly unavailable",
+      status: "cancelled",
+      currentSessionId: "run-offline-cancel-no-writer",
+    });
+
+    expect(() => recoverDaemonStateOnStartup(driver)).not.toThrow();
+    expect(
+      new StateRunDurabilityRepository(driver).getCurrentTerminalResult(
+        "run-offline-cancel-no-writer",
+      ),
+    ).toBeUndefined();
+    expect(agentRunStatus("run-offline-cancel-no-writer")).toBe("cancelled");
+  });
+
+  it("projects an acknowledged effect before stale-call recovery can replay it", () => {
+    insertAgentRun({
+      id: "run-effect-journal",
+      objective: "do not duplicate the acknowledged read",
+      status: "running",
+      currentSessionId: "run-effect-journal",
+    });
+    insertToolCall({
+      sessionId: "run-effect-journal",
+      toolCallId: "call-acknowledged",
+      toolName: "ReadOnce",
+      args: { path: "evidence.txt" },
+      status: "running",
+      recoveryCategory: "idempotent",
+    });
+    const rolloutPath = writeRunJournal("run-effect-journal", [
+      {
+        id: "intent-call-acknowledged",
+        seq: 1,
+        msg: {
+          type: "effect_intent",
+          payload: {
+            runId: "run-effect-journal",
+            stepId: "tool:turn-1:call-acknowledged",
+            callId: "call-acknowledged",
+            toolName: "ReadOnce",
+            recoveryCategory: "idempotent",
+            idempotencyKey: "sha256:stable-read",
+            intentDigest: "sha256:intent",
+            attempt: 1,
+            recordedAt: "2026-05-01T00:05:00.000Z",
+          },
+        },
+      },
+      {
+        id: "result-call-acknowledged",
+        seq: 2,
+        msg: {
+          type: "effect_result",
+          payload: {
+            runId: "run-effect-journal",
+            stepId: "tool:turn-1:call-acknowledged",
+            callId: "call-acknowledged",
+            toolName: "ReadOnce",
+            recoveryCategory: "idempotent",
+            idempotencyKey: "sha256:stable-read",
+            intentEventSeq: 1,
+            outcome: "committed",
+            resultDigest: "sha256:result",
+            recordedAt: "2026-05-01T00:05:01.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-effect-journal", rolloutPath);
+
+    const report = recoverDaemonStateOnStartup(driver);
+
+    expect(report.recoveredToolCalls).toEqual([]);
+    expect(toolCallStatus("run-effect-journal", "call-acknowledged")).toBe(
+      "completed",
+    );
+    expect(
+      new StateRunDurabilityRepository(driver).getEffect(
+        "run-effect-journal",
+        "tool:turn-1:call-acknowledged",
+      ),
+    ).toMatchObject({
+      outcome: "committed",
+      resultEventId: "legacy-event:2:result-call-acknowledged",
+      resultSequence: 2,
+    });
+  });
+
+  it("rebuilds pre-reopen effects into their historical epoch from a partial projection", () => {
+    insertAgentRun({
+      id: "run-partial-reopen",
+      objective: "preserve historical effect epoch",
+      status: "running",
+      currentSessionId: "run-partial-reopen",
+    });
+    insertToolCall({
+      sessionId: "run-partial-reopen",
+      toolCallId: "call-before-reopen",
+      toolName: "ReadOnce",
+      args: { path: "before.txt" },
+      status: "running",
+      recoveryCategory: "idempotent",
+    });
+    const repository = new StateRunDurabilityRepository(driver);
+    repository.ensureInitialEpoch({
+      runId: "run-partial-reopen",
+      openedAt: "2026-05-01T00:00:00.000Z",
+    });
+    repository.recordTerminalResult({
+      epoch: 1,
+      eventId: "legacy-event:3:terminal-before-reopen",
+      result: {
+        runId: "run-partial-reopen",
+        status: "completed",
+        exitCode: 0,
+        stopReason: "completed",
+        finalMessage: "epoch one",
+        usage: null,
+        lastSequence: 3,
+        finishedAt: "2026-05-01T00:06:00.000Z",
+      },
+    });
+    repository.reopenRun({
+      runId: "run-partial-reopen",
+      fromEpoch: 1,
+      openedAt: "2026-05-01T00:07:00.000Z",
+      eventId: "legacy-event:4:reopen-epoch-two",
+      reason: "operator_review",
+    });
+    const rolloutPath = writeRunJournal("run-partial-reopen", [
+      {
+        id: "intent-before-reopen",
+        seq: 1,
+        msg: {
+          type: "effect_intent",
+          payload: {
+            runId: "run-partial-reopen",
+            stepId: "tool:turn-1:call-before-reopen",
+            callId: "call-before-reopen",
+            toolName: "ReadOnce",
+            recoveryCategory: "idempotent",
+            idempotencyKey: "sha256:historical-read",
+            intentDigest: "sha256:historical-intent",
+            attempt: 1,
+            recordedAt: "2026-05-01T00:04:00.000Z",
+          },
+        },
+      },
+      {
+        id: "result-before-reopen",
+        seq: 2,
+        msg: {
+          type: "effect_result",
+          payload: {
+            runId: "run-partial-reopen",
+            stepId: "tool:turn-1:call-before-reopen",
+            callId: "call-before-reopen",
+            toolName: "ReadOnce",
+            recoveryCategory: "idempotent",
+            idempotencyKey: "sha256:historical-read",
+            intentEventSeq: 1,
+            outcome: "committed",
+            recordedAt: "2026-05-01T00:05:00.000Z",
+          },
+        },
+      },
+      {
+        id: "terminal-before-reopen",
+        seq: 3,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: "run-partial-reopen",
+            epoch: 1,
+            status: "completed",
+            exitCode: 0,
+            stopReason: "completed",
+            finalMessage: "epoch one",
+            usage: null,
+            lastSequenceBeforeTerminal: 2,
+            finishedAt: "2026-05-01T00:06:00.000Z",
+          },
+        },
+      },
+      {
+        id: "reopen-epoch-two",
+        seq: 4,
+        msg: {
+          type: "run_reopened",
+          payload: {
+            runId: "run-partial-reopen",
+            previousEpoch: 1,
+            epoch: 2,
+            reason: "operator_review",
+            reopenedAt: "2026-05-01T00:07:00.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-partial-reopen", rolloutPath);
+
+    const report = recoverDaemonStateOnStartup(driver);
+
+    expect(report.recoveredToolCalls).toEqual([]);
+    expect(
+      repository.getEffect(
+        "run-partial-reopen",
+        "tool:turn-1:call-before-reopen",
+      ),
+    ).toMatchObject({ epoch: 1, outcome: "committed" });
+    expect(repository.currentEpoch("run-partial-reopen")?.epoch).toBe(2);
+  });
+
+  it("fails closed instead of restoring a run whose active canonical journal is missing", () => {
+    insertAgentRun({
+      id: "run-missing-journal",
+      objective: "do not guess past missing evidence",
+      status: "running",
+      currentSessionId: "run-missing-journal",
+    });
+    bindRunJournal(
+      "run-missing-journal",
+      join(driver.projectDir, "sessions", "run-missing-journal", "missing.jsonl"),
+    );
+
+    expect(() => recoverDaemonStateOnStartup(driver)).toThrow(
+      /canonical rollout source is missing/,
+    );
+    expect(agentRunStatus("run-missing-journal")).toBe("running");
+  });
+
+  it("fails closed when canonical event identities reuse one run sequence", () => {
+    insertAgentRun({
+      id: "run-sequence-conflict",
+      objective: "reject ambiguous history",
+      status: "running",
+      currentSessionId: "run-sequence-conflict",
+    });
+    const rolloutPath = writeRunJournal("run-sequence-conflict", [
+      {
+        id: "intent-sequence-one",
+        seq: 1,
+        msg: {
+          type: "effect_intent",
+          payload: {
+            runId: "run-sequence-conflict",
+            stepId: "tool:turn-1:call-1",
+            callId: "call-1",
+            toolName: "ReadOnce",
+            recoveryCategory: "idempotent",
+            idempotencyKey: "sha256:key",
+            intentDigest: "sha256:intent",
+            attempt: 1,
+            recordedAt: "2026-05-01T00:04:00.000Z",
+          },
+        },
+      },
+      {
+        id: "terminal-sequence-one",
+        seq: 1,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: "run-sequence-conflict",
+            epoch: 1,
+            status: "completed",
+            exitCode: 0,
+            stopReason: "completed",
+            finalMessage: null,
+            usage: null,
+            lastSequenceBeforeTerminal: null,
+            finishedAt: "2026-05-01T00:05:00.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-sequence-conflict", rolloutPath);
+
+    expect(() => recoverDaemonStateOnStartup(driver)).toThrow(
+      /sequence is also claimed by event legacy-event:1:intent-sequence-one/,
+    );
+    expect(agentRunStatus("run-sequence-conflict")).toBe("running");
+  });
+
+  it("rejects a terminal sequence also claimed by an unrelated user event", () => {
+    insertAgentRun({
+      id: "run-user-terminal-sequence-conflict",
+      objective: "reject cross-category sequence ambiguity",
+      status: "running",
+      currentSessionId: "run-user-terminal-sequence-conflict",
+    });
+    const rolloutPath = writeRunJournal(
+      "run-user-terminal-sequence-conflict",
+      [
+        {
+          eventId: "user-visible-event",
+          id: "user-visible-event",
+          seq: 1,
+          msg: {
+            type: "agent_message",
+            payload: { message: "unrelated output" },
+          },
+        },
+        {
+          eventId: "terminal-at-user-sequence",
+          id: "terminal-at-user-sequence",
+          seq: 1,
+          msg: {
+            type: "run_terminal",
+            payload: {
+              runId: "run-user-terminal-sequence-conflict",
+              epoch: 1,
+              status: "completed",
+              exitCode: 0,
+              stopReason: "completed",
+              finalMessage: "must not be selected",
+              usage: null,
+              lastSequenceBeforeTerminal: null,
+              finishedAt: "2026-05-01T00:05:00.000Z",
+            },
+          },
+        },
+      ],
+    );
+    bindRunJournal("run-user-terminal-sequence-conflict", rolloutPath);
+
+    expect(() => recoverDaemonStateOnStartup(driver)).toThrow(
+      /sequence is also claimed by event user-visible-event/,
+    );
+    expect(agentRunStatus("run-user-terminal-sequence-conflict")).toBe(
+      "running",
+    );
+  });
+
+  it("rejects event ID reuse across unrelated and lifecycle event types", () => {
+    insertAgentRun({
+      id: "run-cross-type-id-conflict",
+      objective: "reject cross-category identity reuse",
+      status: "running",
+      currentSessionId: "run-cross-type-id-conflict",
+    });
+    const rolloutPath = writeRunJournal("run-cross-type-id-conflict", [
+      {
+        eventId: "reused-cross-type-id",
+        id: "reused-cross-type-id",
+        seq: 1,
+        msg: {
+          type: "agent_message",
+          payload: { message: "ordinary output" },
+        },
+      },
+      {
+        eventId: "reused-cross-type-id",
+        id: "reused-cross-type-id",
+        seq: 2,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: "run-cross-type-id-conflict",
+            epoch: 1,
+            status: "completed",
+            exitCode: 0,
+            stopReason: "completed",
+            finalMessage: "must not be selected",
+            usage: null,
+            lastSequenceBeforeTerminal: 1,
+            finishedAt: "2026-05-01T00:05:00.000Z",
+          },
+        },
+      },
+    ]);
+    bindRunJournal("run-cross-type-id-conflict", rolloutPath);
+
+    expect(() => recoverDaemonStateOnStartup(driver)).toThrow(
+      /event ID has conflicting content/,
+    );
+    expect(agentRunStatus("run-cross-type-id-conflict")).toBe("running");
+  });
+
   it("loads recoverable runs from their latest snapshot and applies stale tool recovery policy", () => {
     insertAgentRun({
       id: "run-1",
@@ -456,4 +1002,49 @@ function toolCallStatus(
        WHERE session_id = ? AND tool_call_id = ?`,
     )
     .get(sessionId, toolCallId)?.status;
+}
+
+function agentRunStatus(runId: string): string | undefined {
+  return driver
+    .prepareState<[string], { status: string }>(
+      "SELECT status FROM agent_runs WHERE id = ?",
+    )
+    .get(runId)?.status;
+}
+
+function writeRunJournal(runId: string, events: readonly Event[]): string {
+  const directory = join(driver.projectDir, "sessions", runId);
+  mkdirSync(directory, { recursive: true });
+  const rolloutPath = join(
+    directory,
+    `rollout-2026-05-01T00-00-00-000Z-${runId}.jsonl`,
+  );
+  writeFileSync(
+    rolloutPath,
+    events
+      .map((event) =>
+        serializeRolloutItem({ type: "event_msg", payload: event }),
+      )
+      .join(""),
+    { mode: 0o600 },
+  );
+  return rolloutPath;
+}
+
+function bindRunJournal(runId: string, rolloutPath: string): void {
+  const repository = new StateRunDurabilityRepository(driver);
+  if (repository.currentEpoch(runId) === undefined) {
+    repository.ensureInitialEpoch({
+      runId,
+      openedAt: "2026-05-01T00:00:00.000Z",
+    });
+  }
+  repository.bindJournalSource({
+    runId,
+    epoch: 1,
+    childRunId: runId,
+    sessionId: runId,
+    sourcePath: rolloutPath,
+    boundAt: "2026-05-01T00:00:00.000Z",
+  });
 }

--- a/runtime/tests/state/rollout-parse-guards.test.ts
+++ b/runtime/tests/state/rollout-parse-guards.test.ts
@@ -9,22 +9,26 @@
  * already present in session/session-store.ts (maxEventSeqInRollout).
  */
 import {
+  appendFileSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ROLLOUT_SCHEMA_VERSION } from "../session/event-log.js";
 import { serializeRolloutItem } from "../session/rollout-item.js";
 import { RolloutStore } from "../session/rollout-store.js";
 import { FileThreadStore } from "../thread-store/store.js";
 import { readRolloutHistory } from "../agents/thread-manager.js";
-import { backfillProjectRollouts } from "./backfill.js";
+import { backfillProjectRollouts, backfillRolloutFile } from "./backfill.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
+import { StateThreadRepository } from "./threads.js";
 
 let home = "";
 let cwd = "";
@@ -191,6 +195,283 @@ describe("rollout parse guards — corrupt interior line", () => {
           .get()?.count,
       ).toBe(2);
     } finally {
+      driver.close();
+    }
+  });
+
+  it("backfill refuses to index a complete JSON object without its newline commit boundary", () => {
+    const driver: StateSqliteDriver = openStateDatabases({ cwd });
+    try {
+      const sessionDir = join(driver.projectDir, "sessions", "unterminated-full");
+      mkdirSync(sessionDir, { recursive: true });
+      const rolloutPath = join(
+        sessionDir,
+        "rollout-2026-04-29T00-00-00-000Z-unterminated-full.jsonl",
+      );
+      const completeLine = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "not committed" },
+      });
+      writeFileSync(rolloutPath, completeLine.slice(0, -1));
+
+      expect(() =>
+        backfillProjectRollouts({ projectDir: driver.projectDir, driver }),
+      ).toThrow(/unterminated canonical rollout/);
+      expect(
+        driver
+          .prepareState<[], { count: number }>(
+            "SELECT COUNT(*) AS count FROM thread_rollout_items",
+          )
+          .get()?.count,
+      ).toBe(0);
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("incremental backfill leaves an unterminated appended record unprojected", () => {
+    const driver: StateSqliteDriver = openStateDatabases({ cwd });
+    try {
+      const sessionDir = join(driver.projectDir, "sessions", "unterminated-tail");
+      mkdirSync(sessionDir, { recursive: true });
+      const rolloutPath = join(
+        sessionDir,
+        "rollout-2026-04-29T00-00-00-000Z-unterminated-tail.jsonl",
+      );
+      writeFileSync(
+        rolloutPath,
+        serializeRolloutItem({
+          type: "response_item",
+          payload: { role: "user", content: "committed" },
+        }),
+      );
+      expect(
+        backfillProjectRollouts({ projectDir: driver.projectDir, driver }),
+      ).toMatchObject({ itemsIndexed: 1 });
+
+      const appended = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "assistant", content: "not committed" },
+      });
+      appendFileSync(rolloutPath, appended.slice(0, -1));
+
+      expect(() =>
+        backfillProjectRollouts({ projectDir: driver.projectDir, driver }),
+      ).toThrow(/unterminated canonical rollout/);
+      expect(
+        driver
+          .prepareState<[], { count: number }>(
+            "SELECT COUNT(*) AS count FROM thread_rollout_items",
+          )
+          .get()?.count,
+      ).toBe(1);
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("bounds full and incremental reads to the captured file size", () => {
+    const driver: StateSqliteDriver = openStateDatabases({ cwd });
+    try {
+      const sessionDir = join(driver.projectDir, "sessions", "bounded-snapshot");
+      mkdirSync(sessionDir, { recursive: true });
+      const rolloutPath = join(
+        sessionDir,
+        "rollout-2026-04-29T00-00-00-000Z-bounded-snapshot.jsonl",
+      );
+      const rows = ["one", "two", "three", "four"].map((content) =>
+        serializeRolloutItem({
+          type: "response_item",
+          payload: { role: "user", content },
+        }),
+      );
+      writeFileSync(rolloutPath, rows[0]);
+      const firstSnapshotSize = statSync(rolloutPath).size;
+      const threads = new StateThreadRepository(driver);
+      const readReceipt = threads.getBackfillFile.bind(threads);
+      const fullRace = vi
+        .spyOn(threads, "getBackfillFile")
+        .mockImplementationOnce((path) => {
+          appendFileSync(rolloutPath, rows[1]);
+          return readReceipt(path);
+        });
+      expect(
+        backfillRolloutFile({ rolloutPath, threads }),
+      ).toMatchObject({ itemsIndexed: 1 });
+      fullRace.mockRestore();
+      expect(threads.getBackfillFile(rolloutPath)).toMatchObject({
+        size: firstSnapshotSize,
+        itemCount: 1,
+      });
+      expect(backfillRolloutFile({ rolloutPath, threads })).toMatchObject({
+        itemsIndexed: 1,
+      });
+
+      appendFileSync(rolloutPath, rows[2]);
+      const thirdSnapshotSize = statSync(rolloutPath).size;
+      const incrementalRace = vi
+        .spyOn(threads, "getBackfillFile")
+        .mockImplementationOnce((path) => {
+          const receipt = readReceipt(path);
+          appendFileSync(rolloutPath, rows[3]);
+          return receipt;
+        });
+      expect(backfillRolloutFile({ rolloutPath, threads })).toMatchObject({
+        itemsIndexed: 1,
+      });
+      incrementalRace.mockRestore();
+      expect(threads.getBackfillFile(rolloutPath)).toMatchObject({
+        size: thirdSnapshotSize,
+        itemCount: 3,
+      });
+      expect(backfillRolloutFile({ rolloutPath, threads })).toMatchObject({
+        itemsIndexed: 1,
+      });
+      expect(
+        driver
+          .prepareState<[], { count: number }>(
+            "SELECT COUNT(*) AS count FROM thread_rollout_items",
+          )
+          .get()?.count,
+      ).toBe(4);
+    } finally {
+      vi.restoreAllMocks();
+      driver.close();
+    }
+  });
+
+  it("fails closed when the rollout path is replaced after snapshot open", () => {
+    const driver: StateSqliteDriver = openStateDatabases({ cwd });
+    try {
+      const sessionDir = join(driver.projectDir, "sessions", "replaced-snapshot");
+      mkdirSync(sessionDir, { recursive: true });
+      const rolloutPath = join(
+        sessionDir,
+        "rollout-2026-04-29T00-00-00-000Z-replaced-snapshot.jsonl",
+      );
+      const original = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "original" },
+      });
+      const replacement = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "replacement" },
+      });
+      writeFileSync(rolloutPath, original);
+      const threads = new StateThreadRepository(driver);
+      const aside = `${rolloutPath}.replaced`;
+      const receipt = vi
+        .spyOn(threads, "getBackfillFile")
+        .mockImplementationOnce(() => {
+          renameSync(rolloutPath, aside);
+          writeFileSync(rolloutPath, replacement);
+          return undefined;
+        });
+
+      expect(() => backfillRolloutFile({ rolloutPath, threads })).toThrow(
+        /changed while capturing a bounded projection snapshot/,
+      );
+      receipt.mockRestore();
+      expect(
+        driver
+          .prepareState<[], { count: number }>(
+            "SELECT COUNT(*) AS count FROM thread_rollout_items",
+          )
+          .get()?.count,
+      ).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+      driver.close();
+    }
+  });
+
+  it("rolls back a full projection when the path is replaced during its DB write", () => {
+    const driver: StateSqliteDriver = openStateDatabases({ cwd });
+    try {
+      const sessionDir = join(driver.projectDir, "sessions", "replaced-full-commit");
+      mkdirSync(sessionDir, { recursive: true });
+      const rolloutPath = join(
+        sessionDir,
+        "rollout-2026-04-29T00-00-00-000Z-replaced-full-commit.jsonl",
+      );
+      const original = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "original" },
+      });
+      const replacement = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "replacement" },
+      });
+      writeFileSync(rolloutPath, original);
+      const threads = new StateThreadRepository(driver);
+      const replace = threads.replaceRolloutItems.bind(threads);
+      const aside = `${rolloutPath}.during-full-commit`;
+      vi.spyOn(threads, "replaceRolloutItems").mockImplementationOnce((params) => {
+        replace(params);
+        renameSync(rolloutPath, aside);
+        writeFileSync(rolloutPath, replacement);
+      });
+
+      expect(() => backfillRolloutFile({ rolloutPath, threads })).toThrow(
+        /changed while capturing a bounded projection snapshot/,
+      );
+      expect(
+        driver
+          .prepareState<[], { count: number }>(
+            "SELECT COUNT(*) AS count FROM thread_rollout_items",
+          )
+          .get()?.count,
+      ).toBe(0);
+      expect(threads.getBackfillFile(rolloutPath)).toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+      driver.close();
+    }
+  });
+
+  it("rolls back an incremental projection when the path is replaced during its DB write", () => {
+    const driver: StateSqliteDriver = openStateDatabases({ cwd });
+    try {
+      const sessionDir = join(driver.projectDir, "sessions", "replaced-tail-commit");
+      mkdirSync(sessionDir, { recursive: true });
+      const rolloutPath = join(
+        sessionDir,
+        "rollout-2026-04-29T00-00-00-000Z-replaced-tail-commit.jsonl",
+      );
+      const first = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "user", content: "first" },
+      });
+      const second = serializeRolloutItem({
+        type: "response_item",
+        payload: { role: "assistant", content: "second" },
+      });
+      writeFileSync(rolloutPath, first);
+      const threads = new StateThreadRepository(driver);
+      backfillRolloutFile({ rolloutPath, threads });
+      const receiptBefore = threads.getBackfillFile(rolloutPath);
+      appendFileSync(rolloutPath, second);
+      const append = threads.appendRolloutItems.bind(threads);
+      const aside = `${rolloutPath}.during-tail-commit`;
+      vi.spyOn(threads, "appendRolloutItems").mockImplementationOnce((params) => {
+        append(params);
+        renameSync(rolloutPath, aside);
+        writeFileSync(rolloutPath, first);
+      });
+
+      expect(() => backfillRolloutFile({ rolloutPath, threads })).toThrow(
+        /changed while capturing a bounded projection snapshot/,
+      );
+      expect(
+        driver
+          .prepareState<[], { count: number }>(
+            "SELECT COUNT(*) AS count FROM thread_rollout_items",
+          )
+          .get()?.count,
+      ).toBe(1);
+      expect(threads.getBackfillFile(rolloutPath)).toEqual(receiptBefore);
+    } finally {
+      vi.restoreAllMocks();
       driver.close();
     }
   });

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -1,7 +1,9 @@
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -9,11 +11,16 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildCanonicalRunReplay } from "../../src/app-server/run-journal-replay.js";
 import { ROLLOUT_SCHEMA_VERSION } from "../session/event-log.js";
 import { serializeRolloutItem } from "../session/rollout-item.js";
+import { RolloutStore } from "../session/rollout-store.js";
+import { SessionLock, SessionLockedError } from "../session/session-store.js";
 import { backfillProjectRollouts } from "./backfill.js";
 import { pruneRolloutSessions } from "./pruning.js";
+import { StateRunDurabilityRepository } from "./run-durability.js";
 import { AgenCSessionSnapshotPolicy } from "./snapshot-policy.js";
+import { recoverCanonicalRunJournalForRun } from "./startup-run-journal-recovery.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
 
 let home = "";
@@ -138,6 +145,276 @@ describe("pruneRolloutSessions", () => {
     expect(mirrorRowCount()).toBe(4);
   });
 
+  it("retires a bound journal before removing its projection and rollout", () => {
+    const runId = "thread-bound-old";
+    const oldPath = seedSession(runId, 60);
+    const runs = new StateRunDurabilityRepository(driver);
+    runs.ensureInitialEpoch({ runId, openedAt: "2026-01-01T00:00:00.000Z" });
+    runs.bindJournalSource({
+      runId,
+      epoch: 1,
+      childRunId: runId,
+      sessionId: runId,
+      sourcePath: oldPath,
+      firstAvailableSequence: 1,
+      lastSequence: 2,
+      boundAt: "2026-01-01T00:00:00.000Z",
+    });
+    driver.prepareState(
+      `INSERT INTO agent_runs (
+         id, objective, status, started_at, last_active_at, current_session_id
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      runId,
+      "retention test",
+      "completed",
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:01.000Z",
+      runId,
+    );
+
+    const report = pruneRolloutSessions(driver, {
+      sessionsDir: join(driver.projectDir, "sessions"),
+      retention_days: 30,
+      now: () => NOW,
+    });
+
+    expect(report).toMatchObject({
+      prunedSessions: 1,
+      prunedRolloutFiles: 1,
+      prunedMirrorRows: 2,
+      prunedSessionIds: [runId],
+    });
+    expect(existsSync(oldPath)).toBe(false);
+    expect(mirrorRowCountForSource(oldPath)).toBe(0);
+    expect(runs.getJournalBinding(oldPath)).toMatchObject({
+      active: false,
+      lastSequence: 2,
+      retiredThroughSequence: 2,
+      gapReason: "retention",
+      gapObservedAt: NOW,
+    });
+    expect(runs.getJournalBinding(oldPath)?.firstAvailableSequence).toBeUndefined();
+
+    // Missing historical sources are valid after explicit retirement. Startup
+    // recovery must not mistake this inactive binding for a lost active journal.
+    expect(() => recoverCanonicalRunJournalForRun(driver, runId)).not.toThrow();
+  });
+
+  it("derives a missing retirement tail from canonical JSONL before deletion", () => {
+    const runId = "thread-bound-without-projection";
+    const oldPath = seedSession(runId, 60);
+    appendFileSync(
+      oldPath,
+      serializeRolloutItem({
+        type: "event_msg",
+        payload: {
+          eventId: "canonical-retained-event",
+          id: "reusable-correlation",
+          seq: 1,
+          msg: {
+            type: "user_message",
+            payload: { message: "must become an explicit retention gap" },
+          },
+        },
+      }),
+    );
+    const when = new Date(NOW_MS - 60 * DAY_MS);
+    utimesSync(oldPath, when, when);
+
+    const runs = new StateRunDurabilityRepository(driver);
+    runs.ensureInitialEpoch({ runId, openedAt: "2026-01-01T00:00:00.000Z" });
+    runs.bindJournalSource({
+      runId,
+      epoch: 1,
+      childRunId: runId,
+      sessionId: runId,
+      sourcePath: oldPath,
+      boundAt: "2026-01-01T00:00:00.000Z",
+    });
+    // Model the normal live-writer path: the binding exists, but no replay or
+    // listing has populated bounds/the rebuildable SQLite mirror yet.
+    driver
+      .prepareState("DELETE FROM thread_rollout_items WHERE source_path = ?")
+      .run(oldPath);
+
+    expect(
+      pruneRolloutSessions(driver, {
+        sessionsDir: join(driver.projectDir, "sessions"),
+        retention_days: 30,
+        now: () => NOW,
+      }),
+    ).toMatchObject({ prunedSessions: 1, prunedMirrorRows: 0 });
+    expect(runs.getJournalBinding(oldPath)).toMatchObject({
+      active: false,
+      lastSequence: 1,
+      retiredThroughSequence: 1,
+      gapReason: "retention",
+    });
+    expect(
+      buildCanonicalRunReplay(
+        driver.state,
+        {
+          projectDir: driver.projectDir,
+          stateDbPath: driver.stateDbPath,
+          logsDbPath: driver.logsDbPath,
+        },
+        runId,
+        0,
+        100,
+      ),
+    ).toMatchObject({
+      events: [],
+      nextAfterSequence: 0,
+      lastAvailableSequence: 1,
+      gap: {
+        kind: "event_gap",
+        afterSequence: 0,
+        firstAvailableSequence: 2,
+        reason: "retention",
+      },
+    });
+  });
+
+  it("never re-indexes an explicitly retired source that still exists", () => {
+    const runId = "thread-retired-present";
+    const sourcePath = seedSession(runId, 60);
+    const runs = new StateRunDurabilityRepository(driver);
+    runs.ensureInitialEpoch({ runId, openedAt: "2026-01-01T00:00:00.000Z" });
+    runs.bindJournalSource({
+      runId,
+      epoch: 1,
+      childRunId: runId,
+      sessionId: runId,
+      sourcePath,
+      firstAvailableSequence: 1,
+      lastSequence: 2,
+      boundAt: "2026-01-01T00:00:00.000Z",
+    });
+    driver.prepareState(
+      `INSERT INTO agent_runs (
+         id, objective, status, started_at, last_active_at, current_session_id
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      runId,
+      "retired source recovery test",
+      "completed",
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:01.000Z",
+      runId,
+    );
+    runs.retireJournalSource({
+      sourcePath,
+      reason: "retention",
+      observedAt: NOW,
+    });
+    driver
+      .prepareState("DELETE FROM thread_rollout_items WHERE source_path = ?")
+      .run(sourcePath);
+
+    expect(existsSync(sourcePath)).toBe(true);
+    expect(recoverCanonicalRunJournalForRun(driver, runId)).toMatchObject({
+      filesScanned: 0,
+      eventsProjected: 0,
+    });
+    expect(mirrorRowCountForSource(sourcePath)).toBe(0);
+  });
+
+  it("refuses to revive a retired source when retention leaves it in place", () => {
+    const runId = "thread-retired-reopen";
+    const sourcePath = seedSession(runId, 60);
+    const runs = new StateRunDurabilityRepository(driver);
+    runs.ensureInitialEpoch({ runId, openedAt: "2026-01-01T00:00:00.000Z" });
+    runs.bindJournalSource({
+      runId,
+      epoch: 1,
+      childRunId: runId,
+      sessionId: runId,
+      sourcePath,
+      lastSequence: 2,
+      boundAt: "2026-01-01T00:00:00.000Z",
+    });
+    runs.retireJournalSource({
+      sourcePath,
+      reason: "retention",
+      observedAt: NOW,
+    });
+
+    const resumed = new RolloutStore({
+      cwd,
+      sessionId: runId,
+      agencVersion: "0.6.2",
+      resume: true,
+      autoStartScheduler: false,
+    });
+    try {
+      expect(() =>
+        resumed.open({
+          sessionId: runId,
+          timestamp: NOW,
+          cwd,
+          originator: "retention-test",
+          agencVersion: "0.6.2",
+        }),
+      ).toThrow(/refusing to reopen inactive canonical journal source/);
+    } finally {
+      resumed.close();
+    }
+    expect(existsSync(sourcePath)).toBe(true);
+  });
+
+  it("rebuilds inactive historical bindings that were superseded, not retired", () => {
+    const runId = "thread-superseded-source";
+    const historicalPath = seedSession(runId, 60);
+    const currentPath = join(
+      join(driver.projectDir, "sessions", runId),
+      `rollout-2026-02-01T00-00-00-000Z-${runId}.jsonl`,
+    );
+    writeFileSync(currentPath, readFileSync(historicalPath));
+
+    const runs = new StateRunDurabilityRepository(driver);
+    runs.ensureInitialEpoch({ runId, openedAt: "2026-01-01T00:00:00.000Z" });
+    runs.bindJournalSource({
+      runId,
+      epoch: 1,
+      childRunId: runId,
+      sessionId: runId,
+      sourcePath: historicalPath,
+      boundAt: "2026-01-01T00:00:00.000Z",
+    });
+    runs.bindJournalSource({
+      runId,
+      epoch: 1,
+      childRunId: runId,
+      sessionId: runId,
+      sourcePath: currentPath,
+      boundAt: "2026-02-01T00:00:00.000Z",
+    });
+    expect(runs.getJournalBinding(historicalPath)).toMatchObject({ active: false });
+    expect(runs.getJournalBinding(historicalPath)?.gapReason).toBeUndefined();
+    driver.prepareState(
+      `INSERT INTO agent_runs (
+         id, objective, status, started_at, last_active_at, current_session_id
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      runId,
+      "superseded binding recovery test",
+      "running",
+      "2026-01-01T00:00:00.000Z",
+      "2026-02-01T00:00:00.000Z",
+      runId,
+    );
+    driver
+      .prepareState("DELETE FROM thread_rollout_items WHERE source_path = ?")
+      .run(historicalPath);
+    expect(mirrorRowCountForSource(historicalPath)).toBe(0);
+
+    expect(recoverCanonicalRunJournalForRun(driver, runId)).toMatchObject({
+      filesScanned: 2,
+    });
+    expect(mirrorRowCountForSource(historicalPath)).toBe(2);
+  });
+
   it("deletes nothing when no retention window is configured", () => {
     const oldPath = seedSession("thread-old", 365);
     const sessionsDir = join(driver.projectDir, "sessions");
@@ -202,6 +479,53 @@ describe("pruneRolloutSessions", () => {
     expect(report.prunedSessionIds).toEqual([]);
     expect(existsSync(lockedPath)).toBe(true);
     expect(mirrorRowCountForSource(lockedPath)).toBe(2);
+  });
+
+  it("defers retention when a writer wins the lease race after observation", () => {
+    const rolloutPath = seedSession("thread-lock-race", 90);
+    const acquire = vi
+      .spyOn(SessionLock.prototype, "acquire")
+      .mockImplementationOnce(() => {
+        throw new SessionLockedError(process.pid, `${rolloutPath}.lock`);
+      });
+    try {
+      expect(
+        pruneRolloutSessions(driver, {
+          sessionsDir: join(driver.projectDir, "sessions"),
+          retention_days: 30,
+          now: () => NOW,
+        }),
+      ).toMatchObject({ prunedSessions: 0, prunedMirrorRows: 0 });
+      expect(existsSync(rolloutPath)).toBe(true);
+      expect(mirrorRowCountForSource(rolloutPath)).toBe(2);
+    } finally {
+      acquire.mockRestore();
+    }
+  });
+
+  it("skips the whole session when any canonical rollout sibling is corrupt", () => {
+    const sessionId = "thread-corrupt-sibling";
+    const rolloutPath = seedSession(sessionId, 90);
+    const corruptPath = join(
+      driver.projectDir,
+      "sessions",
+      sessionId,
+      `rollout-2026-01-02T00-00-00-000Z-${sessionId}.jsonl`,
+    );
+    writeFileSync(corruptPath, "{ not valid canonical json }\n");
+    const when = new Date(NOW_MS - 90 * DAY_MS);
+    utimesSync(corruptPath, when, when);
+
+    expect(
+      pruneRolloutSessions(driver, {
+        sessionsDir: join(driver.projectDir, "sessions"),
+        retention_days: 30,
+        now: () => NOW,
+      }),
+    ).toMatchObject({ prunedSessions: 0, prunedMirrorRows: 0 });
+    expect(existsSync(rolloutPath)).toBe(true);
+    expect(existsSync(corruptPath)).toBe(true);
+    expect(mirrorRowCountForSource(rolloutPath)).toBe(2);
   });
 });
 

--- a/runtime/tests/state/run-cancellation.test.ts
+++ b/runtime/tests/state/run-cancellation.test.ts
@@ -201,6 +201,38 @@ describe("cancelAgentRunTree", () => {
     expect(missing.missing).toBe(true);
   });
 
+  it("repairs descendants when canonical recovery cancelled the root before the DB cascade", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("canonical_cancelled_root", "running");
+    run("surviving_child", "running");
+    edge(edges, "surviving_child", "canonical_cancelled_root", "/root");
+    updateAgentRunStatus(driver, {
+      id: "canonical_cancelled_root",
+      status: "cancelled",
+      lastActiveAt: T1,
+    });
+
+    const repaired = cancelAgentRunTree(driver, {
+      runId: "canonical_cancelled_root",
+      reason: "operator_retry",
+      cancelledAt: T1,
+    });
+
+    expect(repaired.alreadyTerminal).toBe(true);
+    expect(repaired.cancelledRunIds).toEqual(["surviving_child"]);
+    expect(statusOf("surviving_child")).toBe("cancelled");
+    expect(edgeStatusOf("surviving_child")).toBe("closed");
+    const metadata = driver
+      .prepareState<[string], { metadata_json: string | null }>(
+        "SELECT metadata_json FROM agent_runs WHERE id = ?",
+      )
+      .get("canonical_cancelled_root")?.metadata_json;
+    expect(JSON.parse(metadata ?? "{}")).toMatchObject({
+      cascadeComplete: true,
+      cancelReason: "operator_retry",
+    });
+  });
+
   it("survives an edge cycle without hanging", () => {
     const edges = new ThreadSpawnEdgeRepository(driver);
     run("a", "running");

--- a/runtime/tests/state/run-durability.test.ts
+++ b/runtime/tests/state/run-durability.test.ts
@@ -1,0 +1,607 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RunTerminalResult } from "../../src/contracts/run-contracts.js";
+import {
+  RunDurabilityConflictError,
+  StateRunDurabilityRepository,
+} from "../../src/state/run-durability.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+
+let home: string;
+let cwd: string;
+let driver: StateSqliteDriver;
+let runs: StateRunDurabilityRepository;
+
+const T0 = "2026-07-18T00:00:00.000Z";
+const T1 = "2026-07-18T00:00:01.000Z";
+const T2 = "2026-07-18T00:00:02.000Z";
+const T3 = "2026-07-18T00:00:03.000Z";
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-run-durability-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-run-durability-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome: home });
+  runs = new StateRunDurabilityRepository(driver);
+});
+
+afterEach(() => {
+  driver.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function terminal(
+  overrides: Partial<RunTerminalResult> = {},
+): RunTerminalResult {
+  return {
+    runId: "run-1",
+    status: "completed",
+    exitCode: 0,
+    stopReason: "end_turn",
+    finalMessage: "done",
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      costUsd: 0.01,
+    },
+    lastSequence: 10,
+    finishedAt: T1,
+    ...overrides,
+  };
+}
+
+function beginSideEffect(stepId = "step-write", sequence = 1) {
+  return runs.beginEffect({
+    runId: "run-1",
+    epoch: 1,
+    stepId,
+    childRunId: "child-1",
+    sessionId: "session-1",
+    toolName: "FileWrite",
+    recoveryCategory: "side-effecting",
+    intentDigest: `sha256:intent:${stepId}`,
+    eventId: `event-intent-${stepId}`,
+    eventSequence: sequence,
+    intentAt: T0,
+  });
+}
+
+describe("StateRunDurabilityRepository", () => {
+  it("keeps terminal results sticky and retains them across explicit reopen epochs", () => {
+    const initial = runs.ensureInitialEpoch({
+      runId: "run-1",
+      openedAt: T0,
+      openedEventId: "event-open-1",
+    });
+    expect(initial).toMatchObject({ applied: true, value: { epoch: 1 } });
+    expect(
+      runs.ensureInitialEpoch({
+        runId: "run-1",
+        // A later observer may not know the first writer's exact wall clock.
+        openedAt: T1,
+        openedEventId: "event-open-1",
+      }).applied,
+    ).toBe(false);
+
+    const first = runs.recordTerminalResult({
+      epoch: 1,
+      result: terminal(),
+      eventId: "event-terminal-1",
+    });
+    expect(first.applied).toBe(true);
+    expect(first.value).toMatchObject({
+      epoch: 1,
+      eventId: "event-terminal-1",
+      finalMessage: "done",
+    });
+
+    // Replaying the canonical event is an acknowledgement, but a competing
+    // identity for the same logical terminal result is still a conflict.
+    expect(
+      runs.recordTerminalResult({
+        epoch: 1,
+        result: terminal(),
+        eventId: "event-terminal-1",
+      }).applied,
+    ).toBe(false);
+    expect(() =>
+      runs.recordTerminalResult({
+        epoch: 1,
+        result: terminal(),
+        eventId: "event-terminal-late-copy",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_TERMINAL_RESULT_CONFLICT" }),
+    );
+    expect(() =>
+      runs.recordTerminalResult({
+        epoch: 1,
+        result: terminal({ finalMessage: "different" }),
+        eventId: "event-terminal-conflict",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_TERMINAL_RESULT_CONFLICT" }),
+    );
+    expect(runs.getCurrentTerminalResult("run-1")?.finalMessage).toBe("done");
+    expect(() =>
+      driver
+        .prepareState(
+          "UPDATE run_terminal_results SET final_message = 'laundered' WHERE run_id = 'run-1'",
+        )
+        .run(),
+    ).toThrow(/terminal result is immutable/);
+
+    const reopened = runs.reopenRun({
+      runId: "run-1",
+      fromEpoch: 1,
+      openedAt: T2,
+      eventId: "event-reopen-2",
+      reason: "operator_retry",
+    });
+    expect(reopened).toMatchObject({
+      applied: true,
+      value: { epoch: 2, reopenedFromEpoch: 1 },
+    });
+    expect(
+      runs.ensureInitialEpoch({ runId: "run-1", openedAt: T3 }),
+    ).toMatchObject({ applied: false, value: { epoch: 1, openedAt: T0 } });
+    expect(runs.getCurrentTerminalResult("run-1")).toBeUndefined();
+    expect(runs.listTerminalHistory("run-1")).toHaveLength(1);
+    expect(
+      runs.reopenRun({
+        runId: "run-1",
+        fromEpoch: 1,
+        openedAt: T2,
+        eventId: "event-reopen-2",
+        reason: "operator_retry",
+      }).applied,
+    ).toBe(false);
+    expect(() =>
+      runs.reopenRun({
+        runId: "run-1",
+        fromEpoch: 2,
+        openedAt: T3,
+        eventId: "event-reopen-3",
+        reason: "too_early",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_EPOCH_NOT_TERMINAL" }),
+    );
+
+    runs.recordTerminalResult({
+      epoch: 2,
+      result: terminal({
+        status: "failed",
+        exitCode: 1,
+        stopReason: "error",
+        finalMessage: null,
+        lastSequence: 20,
+        finishedAt: T3,
+      }),
+      eventId: "event-terminal-2",
+    });
+    expect(runs.getCurrentTerminalResult("run-1")).toMatchObject({
+      epoch: 2,
+      status: "failed",
+    });
+    expect(runs.listTerminalHistory("run-1").map((item) => item.epoch)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("review-locks unknown mutations and rejects late outcome laundering", () => {
+    runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
+    const intent = beginSideEffect();
+    expect(intent.applied).toBe(true);
+    expect(beginSideEffect().applied).toBe(false);
+
+    const unknown = runs.markEffectUnknown({
+      runId: "run-1",
+      stepId: "step-write",
+      eventId: "event-unknown",
+      eventSequence: 2,
+      reason: "acknowledgement_lost",
+      evidence: { processId: 42 },
+      observedAt: T1,
+    });
+    expect(unknown.value).toMatchObject({
+      outcome: "unknown_outcome",
+      reviewStatus: "pending",
+      unknownReason: "acknowledgement_lost",
+    });
+    expect(
+      runs.markEffectUnknown({
+        runId: "run-1",
+        stepId: "step-write",
+        eventId: "event-unknown",
+        eventSequence: 2,
+        reason: "acknowledgement_lost",
+        evidence: { processId: 42 },
+        observedAt: T1,
+      }).applied,
+    ).toBe(false);
+    expect(() =>
+      runs.completeEffect({
+        runId: "run-1",
+        stepId: "step-write",
+        outcome: "committed",
+        eventId: "event-late-success",
+        eventSequence: 3,
+        completedAt: T2,
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_EFFECT_OUTCOME_CONFLICT" }),
+    );
+    expect(() => beginSideEffect("step-dependent", 3)).toThrowError(
+      expect.objectContaining({ code: "RUN_EFFECT_REVIEW_REQUIRED" }),
+    );
+
+    // Safe, contract-proven idempotent work is not a dependent mutation.
+    expect(
+      runs.beginEffect({
+        runId: "run-1",
+        epoch: 1,
+        stepId: "step-read",
+        sessionId: "session-1",
+        toolName: "FileRead",
+        recoveryCategory: "idempotent",
+        idempotencyKey: "read:/workspace/file@digest",
+        intentDigest: "sha256:read",
+        eventId: "event-read",
+        eventSequence: 3,
+        intentAt: T2,
+      }).applied,
+    ).toBe(true);
+
+    runs.recordTerminalResult({
+      epoch: 1,
+      result: terminal({
+        status: "unknown_outcome",
+        exitCode: null,
+        stopReason: "uncertain_effect",
+        finalMessage: null,
+        usage: null,
+        lastSequence: 4,
+      }),
+      eventId: "event-terminal-unknown",
+    });
+    expect(() =>
+      runs.reopenRun({
+        runId: "run-1",
+        fromEpoch: 1,
+        openedAt: T2,
+        eventId: "event-reopen-blocked",
+        reason: "retry",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_REOPEN_REVIEW_REQUIRED" }),
+    );
+
+    const reviewed = runs.resolveEffectReview({
+      runId: "run-1",
+      stepId: "step-write",
+      reviewedAt: T2,
+      reviewedBy: "operator-1",
+      resolution: "manual_remediation",
+      eventId: "event-review",
+      evidence: { ticket: "INC-1" },
+    });
+    expect(reviewed.value).toMatchObject({
+      outcome: "unknown_outcome",
+      reviewStatus: "resolved",
+      reviewedBy: "operator-1",
+    });
+    expect(
+      runs.resolveEffectReview({
+        runId: "run-1",
+        stepId: "step-write",
+        reviewedAt: T2,
+        reviewedBy: "operator-1",
+        resolution: "manual_remediation",
+        eventId: "event-review",
+        evidence: { ticket: "INC-1" },
+      }).applied,
+    ).toBe(false);
+    expect(() =>
+      runs.resolveEffectReview({
+        runId: "run-1",
+        stepId: "step-write",
+        reviewedAt: T3,
+        reviewedBy: "operator-2",
+        resolution: "confirmed_committed",
+        eventId: "event-review-conflict",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_EFFECT_REVIEW_CONFLICT" }),
+    );
+    expect(
+      runs.reopenRun({
+        runId: "run-1",
+        fromEpoch: 1,
+        openedAt: T3,
+        eventId: "event-reopen-after-review",
+        reason: "review_resolved",
+      }).value.epoch,
+    ).toBe(2);
+    expect(runs.getEffect("run-1", "step-write")?.outcome).toBe(
+      "unknown_outcome",
+    );
+  });
+
+  it("requires durable idempotency keys and unique projected event sequences", () => {
+    runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
+    expect(() =>
+      runs.beginEffect({
+        runId: "run-1",
+        epoch: 1,
+        stepId: "read-no-key",
+        sessionId: "session-1",
+        toolName: "FileRead",
+        recoveryCategory: "idempotent",
+        intentDigest: "sha256:read",
+        eventId: "event-read",
+        eventSequence: 1,
+        intentAt: T0,
+      }),
+    ).toThrow(/require idempotencyKey/);
+    beginSideEffect("step-a", 1);
+    expect(() => beginSideEffect("step-b", 1)).toThrowError(
+      expect.objectContaining({ code: "RUN_EVENT_SEQUENCE_CONFLICT" }),
+    );
+    runs.completeEffect({
+      runId: "run-1",
+      stepId: "step-a",
+      outcome: "committed",
+      eventId: "event-result-a",
+      eventSequence: 2,
+      resultDigest: "sha256:result",
+      result: { bytesWritten: 4 },
+      completedAt: T1,
+    });
+    expect(() =>
+      runs.recordTerminalResult({
+        epoch: 1,
+        result: terminal({ lastSequence: 2 }),
+        eventId: "event-terminal-collision",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_EVENT_SEQUENCE_CONFLICT" }),
+    );
+  });
+
+  it("tracks historical rollout sources and makes retirement gaps explicit", () => {
+    runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
+    const first = runs.bindJournalSource({
+      runId: "run-1",
+      epoch: 1,
+      childRunId: "run-1",
+      sessionId: "session-1",
+      sourcePath: "/rollouts/run-1-a.jsonl",
+      firstAvailableSequence: 1,
+      lastSequence: 5,
+      boundAt: T0,
+    });
+    expect(first.value.active).toBe(true);
+    expect(
+      runs.bindJournalSource({
+        runId: "run-1",
+        epoch: 1,
+        childRunId: "run-1",
+        sessionId: "session-1",
+        sourcePath: "/rollouts/run-1-a.jsonl",
+        firstAvailableSequence: 1,
+        lastSequence: 5,
+        boundAt: T0,
+      }).applied,
+    ).toBe(false);
+
+    runs.bindJournalSource({
+      runId: "run-1",
+      epoch: 1,
+      childRunId: "run-1",
+      sessionId: "session-1",
+      sourcePath: "/rollouts/run-1-b.jsonl",
+      firstAvailableSequence: 6,
+      lastSequence: 10,
+      boundAt: T1,
+    });
+    const bindings = runs.listJournalBindings("run-1", 1);
+    expect(bindings.map((binding) => [binding.sourcePath, binding.active])).toEqual([
+      ["/rollouts/run-1-a.jsonl", false],
+      ["/rollouts/run-1-b.jsonl", true],
+    ]);
+
+    expect(
+      runs.updateJournalBounds({
+        sourcePath: "/rollouts/run-1-b.jsonl",
+        firstAvailableSequence: 6,
+        lastSequence: 12,
+        updatedAt: T2,
+      }).lastSequence,
+    ).toBe(12);
+    expect(() =>
+      runs.updateJournalBounds({
+        sourcePath: "/rollouts/run-1-b.jsonl",
+        firstAvailableSequence: 8,
+        lastSequence: 12,
+        updatedAt: T2,
+      }),
+    ).toThrow(/record an explicit gap/);
+
+    const gap = runs.markJournalGap({
+      sourcePath: "/rollouts/run-1-b.jsonl",
+      retiredThroughSequence: 7,
+      firstAvailableSequence: 8,
+      lastSequence: 12,
+      reason: "compaction",
+      observedAt: T3,
+    });
+    expect(gap).toMatchObject({
+      firstAvailableSequence: 8,
+      lastSequence: 12,
+      retiredThroughSequence: 7,
+      gapReason: "compaction",
+      gapObservedAt: T3,
+    });
+    expect(() =>
+      runs.markJournalGap({
+        sourcePath: "/rollouts/run-1-b.jsonl",
+        retiredThroughSequence: 6,
+        firstAvailableSequence: 8,
+        lastSequence: 12,
+        reason: "retention",
+        observedAt: T3,
+      }),
+    ).toThrow(/cannot move backwards/);
+
+    runs.ensureInitialEpoch({ runId: "run-2", openedAt: T0 });
+    expect(() =>
+      runs.bindJournalSource({
+        runId: "run-2",
+        epoch: 1,
+        childRunId: "run-2",
+        sessionId: "session-2",
+        sourcePath: "/rollouts/run-1-b.jsonl",
+        boundAt: T3,
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_JOURNAL_BINDING_CONFLICT" }),
+    );
+  });
+
+  it("retires journal bindings atomically and preserves the projected tail", () => {
+    runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
+    runs.bindJournalSource({
+      runId: "run-1",
+      epoch: 1,
+      childRunId: "run-1",
+      sessionId: "session-1",
+      sourcePath: "/rollouts/retired.jsonl",
+      firstAvailableSequence: 1,
+      lastSequence: 4,
+      boundAt: T0,
+    });
+    driver.prepareState(
+      `INSERT INTO threads (thread_id, created_at, updated_at)
+       VALUES ('run-1', ?, ?)`,
+    ).run(T0, T0);
+    driver.prepareState(
+      `INSERT INTO thread_rollout_items (
+         thread_id, source_path, line_number, byte_offset, item_index,
+         item_type, event_id, event_seq, payload_json, line_hash
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "run-1",
+      "/rollouts/retired.jsonl",
+      1,
+      0,
+      1,
+      "event_msg",
+      "event-9",
+      9,
+      "{}",
+      "sha256:line",
+    );
+
+    expect(() =>
+      driver.transactionImmediate(() => {
+        runs.retireJournalSource({
+          sourcePath: "/rollouts/retired.jsonl",
+          reason: "retention",
+          observedAt: T2,
+        });
+        throw new Error("roll back outer prune transaction");
+      }),
+    ).toThrow(/roll back outer prune transaction/);
+    expect(runs.getJournalBinding("/rollouts/retired.jsonl")?.active).toBe(true);
+
+    const retired = runs.retireJournalSource({
+      sourcePath: "/rollouts/retired.jsonl",
+      reason: "retention",
+      observedAt: T2,
+    });
+    expect(retired).toMatchObject({
+      applied: true,
+      value: {
+        active: false,
+        lastSequence: 9,
+        retiredThroughSequence: 9,
+        gapReason: "retention",
+        gapObservedAt: T2,
+      },
+    });
+    expect(retired.value?.firstAvailableSequence).toBeUndefined();
+    expect(
+      runs.retireJournalSource({
+        sourcePath: "/rollouts/retired.jsonl",
+        reason: "retention",
+        observedAt: T3,
+      }).applied,
+    ).toBe(false);
+    expect(
+      runs.retireJournalSource({
+        sourcePath: "/rollouts/legacy-unbound.jsonl",
+        reason: "retention",
+        observedAt: T3,
+      }),
+    ).toEqual({ applied: false, value: undefined });
+  });
+
+  it("survives repository reopen without losing terminal, effect, or binding state", () => {
+    runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
+    beginSideEffect();
+    runs.completeEffect({
+      runId: "run-1",
+      stepId: "step-write",
+      outcome: "committed",
+      eventId: "event-result",
+      eventSequence: 2,
+      completedAt: T1,
+    });
+    runs.bindJournalSource({
+      runId: "run-1",
+      epoch: 1,
+      childRunId: "run-1",
+      sessionId: "session-1",
+      sourcePath: "/rollouts/run-1.jsonl",
+      firstAvailableSequence: 1,
+      lastSequence: 2,
+      boundAt: T0,
+    });
+    runs.recordTerminalResult({
+      epoch: 1,
+      result: terminal({ lastSequence: 3 }),
+      eventId: "event-terminal",
+    });
+
+    driver.close();
+    driver = openStateDatabases({ cwd, agencHome: home });
+    runs = new StateRunDurabilityRepository(driver);
+
+    expect(runs.currentEpoch("run-1")?.epoch).toBe(1);
+    expect(runs.getCurrentTerminalResult("run-1")?.status).toBe("completed");
+    expect(runs.getEffect("run-1", "step-write")?.outcome).toBe("committed");
+    expect(runs.listJournalBindings("run-1")).toMatchObject([
+      { sourcePath: "/rollouts/run-1.jsonl", lastSequence: 2 },
+    ]);
+  });
+});
+
+it("exposes typed durability conflict errors", () => {
+  const error = new RunDurabilityConflictError(
+    "RUN_EFFECT_NOT_FOUND",
+    "missing",
+  );
+  expect(error).toMatchObject({
+    name: "RunDurabilityConflictError",
+    code: "RUN_EFFECT_NOT_FOUND",
+    message: "missing",
+  });
+});

--- a/runtime/tests/state/sqlite-driver.test.ts
+++ b/runtime/tests/state/sqlite-driver.test.ts
@@ -14,6 +14,7 @@ import {
   applyMigrations,
   openStateDatabases,
   resolveStateDatabasePaths,
+  STATE_PRE_V15_BACKUP_FILENAME,
   STATE_PRE_V12_BACKUP_FILENAME,
 } from "./sqlite-driver.js";
 import { STATE_DB_MIGRATIONS } from "./migrations/index.js";
@@ -198,7 +199,7 @@ describe("openStateDatabases", () => {
             "SELECT MAX(version) AS version FROM schema_migrations",
           )
           .get()?.version,
-      ).toBe(14);
+      ).toBe(15);
     } finally {
       driver.close();
     }
@@ -332,6 +333,90 @@ describe("openStateDatabases", () => {
       }
     } finally {
       v11.close();
+    }
+  });
+
+  it("creates a verified pre-v15 backup before installing durable run state", () => {
+    const paths = resolveStateDatabasePaths({ cwd });
+    mkdirSync(paths.projectDir, { recursive: true, mode: 0o700 });
+    const v14 = new Database(paths.stateDbPath);
+    try {
+      applyMigrations(
+        v14,
+        STATE_DB_MIGRATIONS.filter((migration) => migration.version < 15),
+      );
+      v14.prepare(
+        `INSERT INTO agent_runs (
+           id, objective, status, started_at, last_active_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      ).run(
+        "run-before-v15",
+        "preserve me",
+        "running",
+        "2026-07-18T00:00:00.000Z",
+        "2026-07-18T00:00:01.000Z",
+      );
+    } finally {
+      v14.close();
+    }
+
+    const upgraded = openStateDatabases({ cwd });
+    upgraded.close();
+
+    const backupPath = join(
+      paths.projectDir,
+      STATE_PRE_V15_BACKUP_FILENAME,
+    );
+    expect(existsSync(backupPath)).toBe(true);
+    const backup = new Database(backupPath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      expect(
+        backup
+          .prepare("SELECT MAX(version) AS version FROM schema_migrations")
+          .get(),
+      ).toEqual({ version: 14 });
+      expect(
+        backup
+          .prepare(
+            "SELECT objective FROM agent_runs WHERE id = 'run-before-v15'",
+          )
+          .get(),
+      ).toEqual({ objective: "preserve me" });
+      expect(
+        backup
+          .prepare(
+            `SELECT name FROM sqlite_master
+             WHERE type = 'table' AND name = 'run_terminal_results'`,
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(backup.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+    } finally {
+      backup.close();
+    }
+
+    const restoredPath = join(paths.projectDir, "restored-pre-v15.sqlite");
+    copyFileSync(backupPath, restoredPath);
+    const restored = new Database(restoredPath);
+    try {
+      expect(() =>
+        applyMigrations(
+          restored,
+          STATE_DB_MIGRATIONS.filter((migration) => migration.version < 15),
+        ),
+      ).not.toThrow();
+      expect(
+        restored
+          .prepare("SELECT objective FROM agent_runs WHERE id = ?")
+          .get("run-before-v15"),
+      ).toEqual({ objective: "preserve me" });
+    } finally {
+      restored.close();
     }
   });
 });

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -1521,6 +1521,7 @@ describe("AgenC TUI daemon session adapter", () => {
       params: {
         sessionId: "session_1",
         eventId: "delta_1",
+        agentId: "agent_1",
         delta: "hello",
       },
     });
@@ -1530,6 +1531,7 @@ describe("AgenC TUI daemon session adapter", () => {
       params: {
         sessionId: "session_1",
         eventId: "tool_1",
+        agentId: "agent_1",
         requestId: "call_1",
         toolName: "Bash",
         input: { command: "pwd" },
@@ -1566,6 +1568,7 @@ describe("AgenC TUI daemon session adapter", () => {
       params: {
         sessionId: "session_1",
         eventId: "raw_1",
+        agentId: "agent_1",
         event: { id: "raw_1", type: "custom", payload: { ok: true } },
       },
     });
@@ -1573,12 +1576,12 @@ describe("AgenC TUI daemon session adapter", () => {
 
     expect(received).toEqual([
       {
-        id: "delta_1",
+        id: "daemon:agent_1:delta_1",
         type: "agent_message_delta",
         payload: { delta: "hello" },
       },
       {
-        id: "tool_1",
+        id: "daemon:agent_1:tool_1",
         type: "tool_call_started",
         payload: {
           callId: "call_1",
@@ -1587,7 +1590,7 @@ describe("AgenC TUI daemon session adapter", () => {
         },
       },
       {
-        id: "turn_1",
+        id: "daemon:agent_1:turn_1",
         type: "background_agent_status",
         payload: {
           turnId: "turn_1",
@@ -1597,7 +1600,7 @@ describe("AgenC TUI daemon session adapter", () => {
         },
       },
       {
-        id: "turn_1_done",
+        id: "daemon:agent_1:turn_1_done",
         type: "background_agent_status",
         payload: {
           turnId: "turn_1",
@@ -1607,8 +1610,60 @@ describe("AgenC TUI daemon session adapter", () => {
           message: "done",
         },
       },
-      { id: "raw_1", type: "custom", payload: { ok: true } },
+      {
+        id: "daemon:agent_1:raw_1",
+        type: "custom",
+        payload: { ok: true },
+      },
     ]);
+  });
+
+  it("scopes repeated canonical event ids by daemon run", () => {
+    const client = createClient();
+    const received: JsonObject[] = [];
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession(),
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    const unsubscribe = session.subscribeToEvents((event) => {
+      received.push(event as JsonObject);
+    });
+
+    for (const agentId of ["run_before_restart", "run_after_restart"]) {
+      client.emit("session_1", {
+        jsonrpc: JSON_RPC_VERSION,
+        method: "event.message_chunk",
+        params: {
+          sessionId: "session_1",
+          agentId,
+          eventId: "event:8",
+          delta: "OK",
+        },
+      });
+      client.emit("session_1", {
+        jsonrpc: JSON_RPC_VERSION,
+        method: "event.agent_status",
+        params: {
+          sessionId: "session_1",
+          agentId,
+          eventId: "event:12",
+          status: "idle",
+          runStatus: "completed",
+          turnId: "turn_1",
+        },
+      });
+    }
+    unsubscribe();
+
+    expect(received.map((event) => event.id)).toEqual([
+      "daemon:run_before_restart:event%3A8",
+      "daemon:run_before_restart:event%3A12",
+      "daemon:run_after_restart:event%3A8",
+      "daemon:run_after_restart:event%3A12",
+    ]);
+    expect(new Set(received.map((event) => event.id)).size).toBe(4);
   });
 
   it("namespaces daemon request event ids when a permission prompt shares the tool request id", () => {

--- a/runtime/tests/utils/mcp-resource-attachment-admission.test.ts
+++ b/runtime/tests/utils/mcp-resource-attachment-admission.test.ts
@@ -11,6 +11,7 @@ import {
   setCurrentRuntimeSession,
 } from '../../src/session/current-session.js'
 import type { Session } from '../../src/session/session.js'
+import { createTestEffectJournal } from '../helpers/test-effect-journal.js'
 import type { ToolUseContext } from '../../src/tools/Tool.js'
 import { createEmptyToolPermissionContext } from '../../src/permissions/types.js'
 import { getAttachments } from '../../src/utils/attachments.js'
@@ -81,6 +82,7 @@ function admissionHarness(options: {
 
 function installSession(admission?: ExecutionAdmissionClient): void {
   setCurrentRuntimeSession({
+    ...createTestEffectJournal(),
     conversationId: 'session-resource',
     services: {
       ...(admission ? { executionAdmission: admission } : {}),

--- a/runtime/tests/utils/slack-channel-suggestions-admission.test.ts
+++ b/runtime/tests/utils/slack-channel-suggestions-admission.test.ts
@@ -11,6 +11,7 @@ import {
   setCurrentRuntimeSession,
 } from '../../src/session/current-session.js'
 import type { Session } from '../../src/session/session.js'
+import { createTestEffectJournal } from '../helpers/test-effect-journal.js'
 import type { MCPServerConnection } from '../../src/services/mcp/types.js'
 import {
   clearSlackChannelCache,
@@ -84,6 +85,7 @@ function admissionHarness(options: {
 
 function installSession(admission?: ExecutionAdmissionClient): void {
   setCurrentRuntimeSession({
+    ...createTestEffectJournal(),
     conversationId: 'session-slack',
     services: {
       ...(admission ? { executionAdmission: admission } : {}),

--- a/todo.txt
+++ b/todo.txt
@@ -428,7 +428,7 @@ Why this is mandatory: a daemon-backed engineering agent is only more reliable
 if clients can reconnect and the daemon can recover without hiding loss or
 blindly replaying side effects.
 
-[ ] Add one canonical append-only run journal.
+[x] Add one canonical append-only run journal.
     - Project and converge existing rollout checkpoints, single-writer resume
       leases, dangling-effect recovery, job/task recovery, and bounded
       multiplexer replay. Do not add a parallel state database.
@@ -439,7 +439,7 @@ blindly replaying side effects.
       persist them end to end instead of inventing competing IDs.
     - Make terminal results queryable after the original connection disappears.
 
-[ ] Define honest effect semantics.
+[x] Define honest effect semantics.
     - Preserve the existing `idempotent | side-effecting | interactive`
       `recoveryCategory` contract; add outcome/evidence state instead of a
       competing effect taxonomy.
@@ -450,14 +450,14 @@ blindly replaying side effects.
       the step `unknown_outcome`, stop dependent mutations, and require review.
     - Never claim exactly-once execution for arbitrary shell/network effects.
 
-[ ] Add replay-safe client semantics.
+[x] Add replay-safe client semantics.
     - Extend the existing bounded reconnect buffer into cursor-based durable
       replay with explicit retention gaps, reconnect/reattach, and final-result
       reads.
     - Preserve event IDs and sequence values in the typed SDK.
     - Make duplicate delivery detectable and harmless to supported clients.
 
-[ ] Add failure injection at every critical boundary.
+[x] Add failure injection at every critical boundary.
     - Kill the daemon before and after reservation, model response, tool spawn,
       tool acknowledgement, artifact write, event publish, and terminal commit.
     - Disconnect and reconnect clients at multiple points during streaming and


### PR DESCRIPTION
## Summary

- add one canonical append-only run journal with rebuildable SQLite lifecycle, effect, terminal-result, binding, retention-gap, and startup-recovery projections
- persist honest tool-effect and immutable-artifact evidence, block dependent mutations after unknown outcomes, and cover every critical durability boundary with SIGKILL injection
- add cursor-based daemon replay, explicit gaps, durable final-result reads, and replay-safe SDK reattachment with duplicate detection
- preserve ordered terminal delivery and scope TUI transcript identities by daemon run so restarted runs cannot suppress repeated canonical event IDs
- document the M4 guarantees, limits, CLI/daemon/SDK surfaces, and mark the milestone complete

## Verification

- npm run test:host-functional --workspace=@tetsuo-ai/runtime — 1,842 files; 16,101 passed; 3 skipped
- npm run validate:runtime — typecheck, build, package entrypoints, generated SDK mirror, and all PTY startup viewports passed
- npm run check:e2e-all --workspace=@tetsuo-ai/runtime — daemon errors 14/14, LLM pipeline 7/7, TUI 109/109
- npm run test:bun — 92 isolated files passed
- npm run build --workspace=@tetsuo-ai/agenc-sdk
- npm run typecheck --workspace=@tetsuo-ai/agenc-sdk
- npm run check:agent-surface-contract
- npm run sbom && npm run check:sbom
- npm test --workspace=@tetsuo-ai/agenc — 126/126 passed
- pre-commit build and PTY startup hook passed

The root npm test completed its 108 required-gate tests, 22 agent-surface contract tests, and 126 launcher tests, then could not enter the Docker-wrapped runtime boundary because the local user has no access to /var/run/docker.sock. The complete runtime corpus was therefore run through the supported host-functional runner above.
