### PR TITLE
fix(runtime): support clean SDK-independent typecheck

### DIFF
--- a/runtime/src/gateway/agenc-sdk-module.d.ts
+++ b/runtime/src/gateway/agenc-sdk-module.d.ts
@@ -1,0 +1,8 @@
+/**
+ * The SDK workspace publishes generated declarations from dist/, which is not
+ * present in a clean source checkout. The gateway validates the dynamically
+ * imported module against its local SdkModule boundary, so typechecking only
+ * needs the module's compile-time presence; the runtime build still builds and
+ * bundles the real SDK workspace.
+ */
+declare module "@tetsuo-ai/agenc-sdk" {}


### PR DESCRIPTION
## Summary

- declare the optional SDK module at the gateway compile-time boundary
- keep clean source typechecking independent of ignored SDK `dist/` output
- preserve the existing production build path that builds and bundles the real SDK

## Root cause

The exact detached-tag release gate exposed that a pristine checkout has no `packages/agenc-sdk/dist`, while TypeScript resolves the gateway's literal dynamic import before the runtime test suite starts. Earlier local runs inherited generated SDK declarations.

## Validation

- [x] clean SDK-dist-absent runtime typecheck
- [x] SDK-dist-absent gateway adapter tests (11/11)
- [x] production runtime build and generated-type checks
- [x] runtime PTY startup smoke (six launches)
- [x] `npm test` (1,848 files; 16,124 passed; 19 skipped)
- [x] independent review: no findings
