### PR TITLE
fix(release): recover npm publication from tagged source

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,9 +3,11 @@
 # `npm-production` environment, allow `npm publish`, and do not provide an npm
 # token. This is an artifact-publish workflow, not a test workflow. Before
 # dispatch, the operator must complete and retain the exact-tag local release
-# evidence defined in docs/ci-required-gates.md. Dispatch only at the matching
-# immutable source tag, after the runtime release in tetsuo-ai/agenc-releases
-# has been published and made immutable.
+# evidence defined in docs/ci-required-gates.md. Normally dispatch at the
+# matching immutable source tag. If that immutable tag's publish tooling fails
+# before upload, a reviewed main-branch tooling repair may set recovery_tag to
+# package the unchanged tagged source. In either mode, the runtime release in
+# tetsuo-ai/agenc-releases must already be published and immutable.
 
 name: publish-npm
 
@@ -19,6 +21,11 @@ on:
       local_evidence_sha256:
         description: SHA-256 of the reviewed local release evidence record
         required: true
+        type: string
+      recovery_tag:
+        description: Immutable agenc-vX.Y.Z source tag for a reviewed tooling-only recovery
+        required: false
+        default: ""
         type: string
 
 concurrency:
@@ -39,6 +46,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.source.outputs.version }}
+      release-tag: ${{ steps.source.outputs.release-tag }}
+      source-sha: ${{ steps.source.outputs.source-sha }}
+      recovery-mode: ${{ steps.source.outputs.recovery-mode }}
     steps:
       - name: Check out the exact release SHA
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,8 +59,10 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: Bind the run to the reviewed source tag
+        id: source
         env:
           LOCAL_EVIDENCE_SHA256: ${{ inputs.local_evidence_sha256 }}
+          RECOVERY_TAG: ${{ inputs.recovery_tag }}
           REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
           TESTED_SHA: ${{ inputs.tested_sha }}
         shell: bash
@@ -56,18 +70,35 @@ jobs:
           set -euo pipefail
           [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$LOCAL_EVIDENCE_SHA256" =~ ^[0-9a-f]{64}$ ]]
-          test "$TESTED_SHA" = "$GITHUB_SHA"
           test "$GITHUB_REPOSITORY" = tetsuo-ai/agenc-core
           test "$REPOSITORY_VISIBILITY" = public
-          test "$GITHUB_REF_TYPE" = tag
-          version="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
-          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          expected_ref="refs/tags/agenc-v${version}"
-          test "$GITHUB_REF" = "$expected_ref"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"
-          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          if [[ -z "$RECOVERY_TAG" ]]; then
+            test "$TESTED_SHA" = "$GITHUB_SHA"
+            test "$GITHUB_REF_TYPE" = tag
+            release_tag="$GITHUB_REF_NAME"
+            recovery_mode=false
+          else
+            [[ "$RECOVERY_TAG" =~ ^agenc-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+            test "$GITHUB_REF" = refs/heads/main
+            test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+            release_tag="$RECOVERY_TAG"
+            recovery_mode=true
+          fi
+          source_sha="$(git rev-parse --verify "refs/tags/${release_tag}^{commit}")"
+          test "$source_sha" = "$TESTED_SHA"
+          version="$(git show "${source_sha}:package.json" | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])')"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          test "$release_tag" = "agenc-v${version}"
+          if [[ "$recovery_mode" = false ]]; then
+            test "$GITHUB_REF" = "refs/tags/${release_tag}"
+          fi
+          git merge-base --is-ancestor "$source_sha" refs/remotes/origin/main
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'release-tag=%s\n' "$release_tag" >> "$GITHUB_OUTPUT"
+          printf 'source-sha=%s\n' "$source_sha" >> "$GITHUB_OUTPUT"
+          printf 'recovery-mode=%s\n' "$recovery_mode" >> "$GITHUB_OUTPUT"
   pack:
     needs: release-source
     runs-on: ubuntu-24.04
@@ -88,20 +119,35 @@ jobs:
       - name: Bind the run to the reviewed source tag
         id: source
         env:
+          RECOVERY_MODE: ${{ needs.release-source.outputs.recovery-mode }}
+          RELEASE_TAG: ${{ needs.release-source.outputs.release-tag }}
           REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          SOURCE_SHA: ${{ needs.release-source.outputs.source-sha }}
         shell: bash
         run: |
           set -euo pipefail
           test "$GITHUB_REPOSITORY" = tetsuo-ai/agenc-core
           test "$REPOSITORY_VISIBILITY" = public
-          test "$GITHUB_REF_TYPE" = tag
-          version="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
-          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          expected_ref="refs/tags/agenc-v${version}"
-          test "$GITHUB_REF" = "$expected_ref"
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RELEASE_TAG" =~ ^agenc-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"
-          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
+          test "$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")" = "$SOURCE_SHA"
+          if [[ "$RECOVERY_MODE" = true ]]; then
+            test "$GITHUB_REF" = refs/heads/main
+            test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+            for path in package-lock.json release-toolchain.json packages/agenc/scripts/check-package-ready.mjs; do
+              git show "${SOURCE_SHA}:${path}" > "$RUNNER_TEMP/tagged-$(basename "$path")"
+              cmp "$path" "$RUNNER_TEMP/tagged-$(basename "$path")"
+            done
+          else
+            test "$RECOVERY_MODE" = false
+            test "$GITHUB_REF" = "refs/tags/${RELEASE_TAG}"
+            test "$GITHUB_SHA" = "$SOURCE_SHA"
+          fi
+          version="$(git show "${SOURCE_SHA}:package.json" | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])')"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          test "$RELEASE_TAG" = "agenc-v${version}"
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
@@ -157,7 +203,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_PROMPT_DISABLED: "true"
           GH_NO_UPDATE_NOTIFIER: "true"
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ needs.release-source.outputs.release-tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -194,7 +240,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_PROMPT_DISABLED: "true"
           GH_NO_UPDATE_NOTIFIER: "true"
-          RELEASE_TAG: ${{ github.ref_name }}
+          RECOVERY_MODE: ${{ needs.release-source.outputs.recovery-mode }}
+          RELEASE_TAG: ${{ needs.release-source.outputs.release-tag }}
+          SOURCE_SHA: ${{ needs.release-source.outputs.source-sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -211,17 +259,25 @@ jobs:
           trap cleanup EXIT INT TERM
           cleanup
           mkdir -m 700 "$owned_root" "$artifacts"
-          git worktree add --detach "$source" "$GITHUB_SHA"
-          test "$(git -C "$source" rev-parse HEAD)" = "$GITHUB_SHA"
+          git worktree add --detach "$source" "$SOURCE_SHA"
+          test "$(git -C "$source" rev-parse HEAD)" = "$SOURCE_SHA"
           test -z "$(git -C "$source" status --porcelain=v1 --untracked-files=all)"
           npm ci --prefix "$source" --cache "$owned_root/npm-cache" \
             --ignore-scripts --no-audit --no-fund
+          release_tool="$source/scripts/npm-release.mjs"
+          if [[ "$RECOVERY_MODE" = true ]]; then
+            npm ci --prefix "$source_root" --cache "$owned_root/npm-tooling-cache" \
+              --ignore-scripts --no-audit --no-fund
+            release_tool="$source_root/scripts/npm-release.mjs"
+          else
+            test "$RECOVERY_MODE" = false
+          fi
           install -m 0644 "$RUNNER_TEMP/runtime-release/agenc-runtime-manifest-v2.json" \
             "$source/packages/agenc/generated/agenc-runtime-manifest-v2.json"
           source_epoch="$(git -C "$source" show -s --format=%ct HEAD)"
           (
             cd "$source"
-            export AGENC_BUILD_COMMIT="$GITHUB_SHA"
+            export AGENC_BUILD_COMMIT="$SOURCE_SHA"
             export SOURCE_DATE_EPOCH="$source_epoch"
             npm run sbom -- --output "$owned_root/agenc-core.spdx.json"
             node packages/agenc/scripts/prepare-release-assets.mjs \
@@ -239,7 +295,7 @@ jobs:
               --prepared-root "$owned_root/verified-release" \
               --tag "$RELEASE_TAG"
             node packages/agenc/scripts/check-package-ready.mjs
-            node scripts/npm-release.mjs pack --silent \
+            node "$release_tool" pack --silent \
               --pack-destination "$artifacts" --workspace=@tetsuo-ai/agenc
           )
           test "$(find "$artifacts" -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 1
@@ -289,7 +345,7 @@ jobs:
           PY
 
   publish:
-    needs: pack
+    needs: [release-source, pack]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: npm-production
@@ -307,18 +363,30 @@ jobs:
       - name: Revalidate the approved source tag
         env:
           PACKAGE_VERSION: ${{ needs.pack.outputs.package-version }}
+          RECOVERY_MODE: ${{ needs.release-source.outputs.recovery-mode }}
+          RELEASE_TAG: ${{ needs.release-source.outputs.release-tag }}
           REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          SOURCE_SHA: ${{ needs.release-source.outputs.source-sha }}
         shell: bash
         run: |
           set -euo pipefail
           test "$GITHUB_REPOSITORY" = tetsuo-ai/agenc-core
           test "$REPOSITORY_VISIBILITY" = public
-          test "$GITHUB_REF_TYPE" = tag
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RELEASE_TAG" =~ ^agenc-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          test "$GITHUB_REF" = "refs/tags/agenc-v${PACKAGE_VERSION}"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          test "$(git rev-parse --verify "${GITHUB_REF}^{commit}")" = "$GITHUB_SHA"
-          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
+          test "$RELEASE_TAG" = "agenc-v${PACKAGE_VERSION}"
+          test "$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")" = "$SOURCE_SHA"
+          if [[ "$RECOVERY_MODE" = true ]]; then
+            test "$GITHUB_REF" = refs/heads/main
+            test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+          else
+            test "$RECOVERY_MODE" = false
+            test "$GITHUB_REF" = "refs/tags/${RELEASE_TAG}"
+            test "$GITHUB_SHA" = "$SOURCE_SHA"
+          fi
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
 
       - name: Install digest-pinned Node and npm
@@ -369,11 +437,26 @@ jobs:
           echo "$gh_root/bin" >> "$GITHUB_PATH"
 
       - name: Install the release verifier dependencies
+        env:
+          RECOVERY_MODE: ${{ needs.release-source.outputs.recovery-mode }}
+          SOURCE_SHA: ${{ needs.release-source.outputs.source-sha }}
         shell: bash
         run: |
           set -euo pipefail
           npm ci --ignore-scripts --no-audit --no-fund
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          source_root="$(pwd -P)"
+          if [[ "$RECOVERY_MODE" = true ]]; then
+            release_source="$RUNNER_TEMP/npm-release-source"
+            git worktree add --detach "$release_source" "$SOURCE_SHA"
+          else
+            test "$RECOVERY_MODE" = false
+            release_source="$source_root"
+          fi
+          test "$(git -C "$release_source" rev-parse HEAD)" = "$SOURCE_SHA"
+          test -z "$(git -C "$release_source" status --porcelain=v1 --untracked-files=all)"
+          printf 'NPM_RELEASE_SOURCE=%s\n' "$release_source" >> "$GITHUB_ENV"
+          printf 'NPM_RELEASE_TOOL=%s\n' "$source_root/scripts/npm-release.mjs" >> "$GITHUB_ENV"
 
       - name: Download the exact reviewed npm bytes
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -397,7 +480,10 @@ jobs:
           test -n "$tarball"
           test -f "$tarball.release.json"
           test "$(find "$artifacts" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 2
-          node scripts/npm-release.mjs verify "$tarball"
+          (
+            cd "$NPM_RELEASE_SOURCE"
+            node "$NPM_RELEASE_TOOL" verify "$tarball"
+          )
 
       - name: Attest the approved npm tarball and receipt
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
@@ -434,4 +520,7 @@ jobs:
           done
           test -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
           test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
-          node scripts/npm-release.mjs publish "$tarball" --tag=latest
+          (
+            cd "$NPM_RELEASE_SOURCE"
+            node "$NPM_RELEASE_TOOL" publish "$tarball" --tag=latest
+          )

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -769,10 +769,23 @@ use GitHub-hosted jobs to produce release artifacts. They do not run tests.
 Before artifact work starts, each workflow:
 
 1. requires typed `tested_sha` and `local_evidence_sha256` dispatch inputs;
-2. requires `tested_sha` to equal the workflow's exact `GITHUB_SHA`;
-3. binds dispatch to the matching `agenc-v<version>` tag and `main` ancestry;
-   and
+2. normally requires `tested_sha` to equal the workflow's exact
+   `GITHUB_SHA`;
+3. binds dispatch to the matching `agenc-v<version>` tag and `main`
+   ancestry; and
 4. requires the checked-out tree to be clean before artifact work.
+
+The npm workflow has one reviewed partial-release exception. If an immutable
+runtime release already exists but the tagged npm workflow failed before
+upload because its release tooling was defective, `recovery_tag` may be set
+while dispatching the repaired workflow from current `main`. In that mode,
+`tested_sha` must equal the immutable recovery tag commit rather than the
+workflow tooling commit. The workflow still requires the exact-tag evidence,
+clean tagged source, `main` ancestry, and matching lockfile/toolchain/manifest
+validator; the produced receipt remains bound to `tested_sha`. The workflow
+attestations and npm provenance bind the separate reviewed `main` tooling
+commit. Runtime publication has no recovery exception and still requires
+`tested_sha == GITHUB_SHA`.
 
 They run no tests and do not read a GitHub App check. The operator must first
 complete and retain the exact-tag local evidence defined above. A PR-head test

--- a/docs/install.md
+++ b/docs/install.md
@@ -465,6 +465,34 @@ resolved package inventory is stored at
      -f local_evidence_sha256="$evidence_sha256"
    ```
 
+   If the immutable tag's npm workflow fails before upload because of a
+   release-tooling defect, do not move the tag, rebuild runtime assets, or
+   publish locally. Land a reviewed tooling repair on `main`, reverify the
+   immutable runtime release and unchanged evidence digest, then use the
+   workflow's explicit recovery mode:
+
+   ```bash
+   git fetch origin main --tags
+   test "$(git rev-parse "${tag}^{commit}")" = "$tested_sha"
+   git merge-base --is-ancestor "$tested_sha" origin/main
+   gh workflow run publish-npm.yml --repo tetsuo-ai/agenc-core \
+     --ref main \
+     -f tested_sha="$tested_sha" \
+     -f local_evidence_sha256="$evidence_sha256" \
+     -f recovery_tag="$tag"
+   ```
+
+   Recovery mode requires the workflow checkout to equal current `main`,
+   resolves `tested_sha` from the immutable `recovery_tag`, requires that
+   source to remain in `main`, and compares the lockfile, release-toolchain
+   pins, and launcher manifest validator with the tag. It executes the reviewed
+   repaired packer outside a clean detached checkout of the tagged source, so
+   the tarball and receipt remain bound to the original tag commit. The
+   workflow-run attestations and npm provenance identify the reviewed recovery
+   tooling commit. This exception is only for downstream npm recovery after an
+   immutable matching runtime release; identity drift still requires a new
+   version.
+
 5. `https://get.agenc.ag/{install.sh,install.ps1,manifest-v2.json,manifest.json}`
    307-redirect to the release assets. The site root serves the versioned
    installer landing page. Vercel project `agenc-get` has its complete tracked

--- a/packages/agenc/test/npm-release.test.mjs
+++ b/packages/agenc/test/npm-release.test.mjs
@@ -245,6 +245,33 @@ test("pack writes a deterministic receipt bound to exact tarball bytes", async (
   }
 });
 
+test("pack accepts lifecycle output before npm's terminal JSON document", async () => {
+  const work = fixture();
+  try {
+    const packagePath = join(work.source, "package.json");
+    const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+    pkg.scripts = { prepack: "node prepack-output.mjs" };
+    writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+    writeFileSync(
+      join(work.source, "prepack-output.mjs"),
+      "process.stdout.write('[launcher package] verified 5 runtime artifact(s)\\n' +\n" +
+        "  '[package modes] files=0644 dirs/bins=0755\\n');\n",
+    );
+
+    const packed = await packRelease({
+      cwd: work.source,
+      args: ["--silent", "--pack-destination", work.output],
+      git: fakeGit(),
+      nodeVersion: releaseToolchain.nodeVersion,
+      validateManifest: skipManifestValidation,
+    });
+    assert.ok(readFileSync(packed.artifactPath).length > 0);
+    assert.ok(readFileSync(packed.receiptPath).length > 0);
+  } finally {
+    rmSync(work.root, { recursive: true, force: true });
+  }
+});
+
 test("pack rejects an incomplete launcher manifest before invoking npm pack", async () => {
   const work = fixture();
   let packCalls = 0;

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -411,16 +411,18 @@ describe("reproducible install and release contract", () => {
     expect(packJob).not.toContain("id-token: write");
     expect(packJob).not.toContain("actions/attest@");
     expect(workflow).toContain('test "$GITHUB_REF_TYPE" = tag');
-    expect(workflow).toContain('expected_ref="refs/tags/agenc-v${version}"');
+    expect(workflow).toContain("recovery_tag:");
+    expect(workflow).toContain('test "$GITHUB_REF" = refs/heads/main');
+    expect(workflow).toContain(
+      'test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"',
+    );
     expect(workflow).toContain('test "$REPOSITORY_VISIBILITY" = public');
     expect(releaseSourceJob).not.toContain("checks: read");
     expect(releaseSourceJob).not.toContain("AGENC_LOCAL_GATE_APP_ID");
     expect(releaseSourceJob).not.toContain("scripts/verify-required-gate-check.mjs");
     expect(releaseSourceJob).toContain("LOCAL_EVIDENCE_SHA256");
     expect(releaseSourceJob).toContain('test "$TESTED_SHA" = "$GITHUB_SHA"');
-    expect(releaseSourceJob).toContain(
-      'test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"',
-    );
+    expect(releaseSourceJob).toContain('test "$source_sha" = "$TESTED_SHA"');
     expect(workflow).not.toContain("required-gates:");
     expectArtifactWorkflowWithoutHostedTests(workflow);
     for (const job of [releaseSourceJob, packJob, publishJob]) {
@@ -441,7 +443,7 @@ describe("reproducible install and release contract", () => {
     expect(workflow).toContain("--legacy-manifest");
     expect(workflow).not.toContain("npm test --workspace=@tetsuo-ai/agenc");
     expect(workflow).toContain("git worktree add --detach");
-    expect(workflow).toMatch(/\(\n\s+cd \"\$source\"[\s\S]+node scripts\/npm-release\.mjs pack/);
+    expect(workflow).toMatch(/\(\n\s+cd \"\$source\"[\s\S]+node \"\$release_tool\" pack/);
     expect(workflow).toContain("--workspace=@tetsuo-ai/agenc");
     expect(workflow).toContain("*.tgz.release.json");
     expect(workflow).toContain("gh attestation verify \"$asset\"");
@@ -478,9 +480,9 @@ describe("reproducible install and release contract", () => {
       expect(pin.sha256).toMatch(/^[0-9a-f]{64}$/);
       expect(pin.bytes).toBeGreaterThan(0);
     }
-    expect(workflow).toContain('node scripts/npm-release.mjs verify "$tarball"');
+    expect(workflow).toContain('node "$NPM_RELEASE_TOOL" verify "$tarball"');
     expect(workflow).toContain(
-      'node scripts/npm-release.mjs publish "$tarball" --tag=latest',
+      'node "$NPM_RELEASE_TOOL" publish "$tarball" --tag=latest',
     );
     expect(workflow).toContain('NODE_AUTH_TOKEN: ""');
     expect(workflow).toContain('NPM_TOKEN: ""');
@@ -493,11 +495,11 @@ describe("reproducible install and release contract", () => {
     expect(workflow.indexOf("environment: npm-production")).toBeLessThan(
       workflow.indexOf("actions/attest@"),
     );
-    expect(workflow.indexOf("npm-release.mjs verify")).toBeLessThan(
+    expect(workflow.indexOf('node "$NPM_RELEASE_TOOL" verify')).toBeLessThan(
       workflow.indexOf("actions/attest@"),
     );
     expect(workflow.indexOf("actions/attest@")).toBeLessThan(
-      workflow.indexOf("npm-release.mjs publish"),
+      workflow.indexOf('node "$NPM_RELEASE_TOOL" publish'),
     );
   });
 

--- a/scripts/npm-release.mjs
+++ b/scripts/npm-release.mjs
@@ -417,9 +417,24 @@ function writeReceiptAtomic(path, receipt) {
 
 function parsePackJson(stdout) {
   let value;
-  try {
-    value = JSON.parse(stdout);
-  } catch {
+  let parsed = false;
+  // npm forwards successful lifecycle-script stdout before the JSON requested
+  // by --json. Parse only a terminal JSON document so those reviewed messages
+  // are allowed without accepting trailing non-JSON output.
+  for (
+    let offset = stdout.lastIndexOf("[");
+    offset >= 0;
+    offset = stdout.lastIndexOf("[", offset - 1)
+  ) {
+    try {
+      value = JSON.parse(stdout.slice(offset));
+      parsed = true;
+      break;
+    } catch {
+      // Nested arrays and non-JSON lifecycle messages are not document starts.
+    }
+  }
+  if (!parsed) {
     throw new Error(`npm pack did not emit valid JSON: ${stdout.slice(0, 500)}`);
   }
   if (!Array.isArray(value) || value.length !== 1) {


### PR DESCRIPTION
Repairs npm 11 pack JSON parsing when successful lifecycle output precedes the terminal JSON document.

Adds a tightly bound recovery mode for an already-immutable source tag: current main supplies reviewed release tooling while the launcher tarball and receipt remain bound to the original tested tag commit.

Verification:
- npm run typecheck
- npm test (1,848 files; 16,124 passed; 19 skipped)
- full hook build and TUI startup smoke
- exact agenc-v0.7.2 pack/verify twice with byte-identical tarballs