### PR TITLE
fix(release): validate recovered tagged checkout

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -135,7 +135,7 @@ jobs:
           if [[ "$RECOVERY_MODE" = true ]]; then
             test "$GITHUB_REF" = refs/heads/main
             test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
-            for path in package-lock.json release-toolchain.json packages/agenc/scripts/check-package-ready.mjs; do
+            for path in package-lock.json release-toolchain.json; do
               git show "${SOURCE_SHA}:${path}" > "$RUNNER_TEMP/tagged-$(basename "$path")"
               cmp "$path" "$RUNNER_TEMP/tagged-$(basename "$path")"
             done

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -782,7 +782,7 @@ while dispatching the repaired workflow from current `main`. In that mode,
 `tested_sha` must equal the immutable recovery tag commit rather than the
 workflow tooling commit. The workflow still requires the exact-tag evidence,
 clean tagged source, `main` ancestry, and matching lockfile/toolchain/manifest
-validator; the produced receipt remains bound to `tested_sha`. The workflow
+identity; the produced receipt remains bound to `tested_sha`. The workflow
 attestations and npm provenance bind the separate reviewed `main` tooling
 commit. Runtime publication has no recovery exception and still requires
 `tested_sha == GITHUB_SHA`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -484,10 +484,10 @@ resolved package inventory is stored at
 
    Recovery mode requires the workflow checkout to equal current `main`,
    resolves `tested_sha` from the immutable `recovery_tag`, requires that
-   source to remain in `main`, and compares the lockfile, release-toolchain
-   pins, and launcher manifest validator with the tag. It executes the reviewed
-   repaired packer outside a clean detached checkout of the tagged source, so
-   the tarball and receipt remain bound to the original tag commit. The
+   source to remain in `main`, and compares the lockfile and release-toolchain
+   pins with the tag. It executes the reviewed repaired packer and manifest
+   validator against a clean detached checkout of the tagged source, so the
+   tarball and receipt remain bound to the original tag commit. The
    workflow-run attestations and npm provenance identify the reviewed recovery
    tooling commit. This exception is only for downstream npm recovery after an
    immutable matching runtime release; identity drift still requires a new

--- a/packages/agenc/scripts/check-package-ready.mjs
+++ b/packages/agenc/scripts/check-package-ready.mjs
@@ -101,6 +101,7 @@ export function validateLauncherManifest({
     V2_MANIFEST_FILENAME,
   ),
   allowTestPartial = false,
+  repositoryRoot,
 } = {}) {
   if (!existsSync(manifestPath)) fail(`missing ${manifestPath}`);
   const manifestMetadata = lstatSync(manifestPath);
@@ -124,7 +125,9 @@ export function validateLauncherManifest({
     fail(`manifest exceeds ${MAX_RUNTIME_MANIFEST_BYTES} bytes`);
   }
   const manifest = JSON.parse(manifestBytes.toString("utf8"));
-  const repoRoot = resolve(launcherDir, "..", "..");
+  const repoRoot = repositoryRoot === undefined
+    ? resolve(launcherDir, "..", "..")
+    : resolve(repositoryRoot);
   const releaseToolchain = JSON.parse(
     readFileSync(resolve(repoRoot, "release-toolchain.json"), "utf8"),
   );

--- a/packages/agenc/test/npm-release.test.mjs
+++ b/packages/agenc/test/npm-release.test.mjs
@@ -247,6 +247,8 @@ test("pack writes a deterministic receipt bound to exact tarball bytes", async (
 
 test("pack accepts lifecycle output before npm's terminal JSON document", async () => {
   const work = fixture();
+  const validationRepositoryRoot = join(work.root, "reviewed-source");
+  let observedValidationRoot;
   try {
     const packagePath = join(work.source, "package.json");
     const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
@@ -263,8 +265,12 @@ test("pack accepts lifecycle output before npm's terminal JSON document", async 
       args: ["--silent", "--pack-destination", work.output],
       git: fakeGit(),
       nodeVersion: releaseToolchain.nodeVersion,
-      validateManifest: skipManifestValidation,
+      validationRepositoryRoot,
+      validateManifest({ repositoryRoot }) {
+        observedValidationRoot = repositoryRoot;
+      },
     });
+    assert.equal(observedValidationRoot, validationRepositoryRoot);
     assert.ok(readFileSync(packed.artifactPath).length > 0);
     assert.ok(readFileSync(packed.receiptPath).length > 0);
   } finally {

--- a/scripts/npm-release.mjs
+++ b/scripts/npm-release.mjs
@@ -450,6 +450,7 @@ export async function packRelease({
   git = gitDefault,
   nodeVersion = process.versions.node,
   lockfilePath = join(repoRoot, "package-lock.json"),
+  validationRepositoryRoot = repoRoot,
   validateManifest = validateLauncherManifest,
 } = {}) {
   const packOptions = parsePackOptions(args, cwd);
@@ -464,6 +465,7 @@ export async function packRelease({
   validateManifest({
     launcherPackagePath: join(packageRoot, "package.json"),
     manifestPath: join(packageRoot, RUNTIME_MANIFEST_PATH),
+    repositoryRoot: validationRepositoryRoot,
   });
   const source = assertExactTaggedSource({ cwd, git, version: packageIdentity.version });
   const preflight = parsePackJson(runNpm([
@@ -868,6 +870,7 @@ async function inspectRelease({
   nodeVersion = process.versions.node,
   lockfilePath = join(repoRoot, "package-lock.json"),
   packageRoot: suppliedPackageRoot,
+  validationRepositoryRoot = repoRoot,
   validateManifest = validateLauncherManifest,
 } = {}) {
   if (typeof tarball !== "string" || !tarball.endsWith(".tgz")) {
@@ -908,6 +911,7 @@ async function inspectRelease({
     validateManifest({
       launcherPackagePath: embeddedPackagePath,
       manifestPath: embeddedManifestPath,
+      repositoryRoot: validationRepositoryRoot,
     });
     const receipt = JSON.parse(readFileSync(resolvedReceipt, "utf8"));
     const identity = validateReceipt(
@@ -1092,20 +1096,30 @@ async function main(argv) {
   // npm's tar writer applies the parent process umask to archive member modes.
   if (process.platform !== "win32") process.umask(0o022);
   if (command === "pack") {
-    const result = await packRelease({ args });
+    const result = await packRelease({
+      args,
+      validationRepositoryRoot: process.cwd(),
+    });
     process.stderr.write(`wrote immutable release receipt ${result.receiptPath}\n`);
     process.stdout.write(`${result.filename}\n`);
     return;
   }
   if (command === "publish") {
     const [tarball, ...publishArgs] = args;
-    await publishRelease({ tarball, args: publishArgs });
+    await publishRelease({
+      tarball,
+      args: publishArgs,
+      validationRepositoryRoot: process.cwd(),
+    });
     return;
   }
   if (command === "verify") {
     const [tarball, ...unexpected] = args;
     if (unexpected.length > 0) throw new Error(usage());
-    const result = await verifyRelease({ tarball });
+    const result = await verifyRelease({
+      tarball,
+      validationRepositoryRoot: process.cwd(),
+    });
     process.stdout.write(`${JSON.stringify(result)}\n`);
     return;
   }


### PR DESCRIPTION
Fixes the recovery packer so manifest validation uses the immutable tagged source checkout rather than the separate main-branch tooling checkout.

Verification:
- exact agenc-v0.7.2 external-tool pack and verify; tarball remains byte-identical
- npm run typecheck
- npm test (1,848 files; 16,124 passed; 19 skipped)
- mandatory build and TUI startup hook