### PR TITLE
fix(release): accept encoded npm attestation URLs

### DIFF
--- a/packages/agenc/test/npm-release.test.mjs
+++ b/packages/agenc/test/npm-release.test.mjs
@@ -445,6 +445,42 @@ test("publish uploads an immutable snapshot with provenance and no repack", asyn
   }
 });
 
+test("publish accepts npm's percent-encoded scoped attestation URL", async () => {
+  const work = await packedFixture();
+  try {
+    const reviewed = readFileSync(work.artifactPath);
+    const registryReceipt = exactRegistryReceipt(reviewed);
+    registryReceipt.attestations.url = registryReceipt.attestations.url.replace(
+      "@tetsuo-ai/agenc",
+      "@tetsuo-ai%2fagenc",
+    );
+    const runNpm = fakeNpm(() => {
+      throw new Error("matching existing versions must not be republished");
+    }, { registryReceipt });
+
+    const published = await publishRelease({
+      tarball: work.artifactPath,
+      receiptPath: work.receiptPath,
+      cwd: work.source,
+      packageRoot: work.source,
+      nodeVersion: releaseToolchain.nodeVersion,
+      git: fakeGit(),
+      runNpm,
+      validateManifest: skipManifestValidation,
+    });
+
+    assert.equal(published.published, false);
+    assert.equal(published.alreadyPublished, true);
+    assert.equal(runNpm.publishInvocations(), 0);
+    assert.equal(
+      published.registryReceipt.attestationUrl,
+      registryReceipt.attestations.url,
+    );
+  } finally {
+    rmSync(work.root, { recursive: true, force: true });
+  }
+});
+
 test("publish fails closed when the registry receipt does not match reviewed bytes", async () => {
   const work = await packedFixture();
   try {

--- a/scripts/npm-release.mjs
+++ b/scripts/npm-release.mjs
@@ -630,6 +630,20 @@ function canonicalAttestationUrl(identity) {
   return `${PUBLIC_REGISTRY}-/npm/v1/attestations/${identity.name}@${identity.version}`;
 }
 
+function matchesCanonicalAttestationUrl(value, identity) {
+  if (typeof value !== "string") return false;
+  try {
+    const actual = new URL(value);
+    const expected = new URL(canonicalAttestationUrl(identity));
+    return actual.origin === expected.origin &&
+      actual.username === "" && actual.password === "" &&
+      actual.search === "" && actual.hash === "" &&
+      decodeURIComponent(actual.pathname) === expected.pathname;
+  } catch {
+    return false;
+  }
+}
+
 function parseJson(stdout, label) {
   try {
     return JSON.parse(stdout);
@@ -644,7 +658,7 @@ function parseRegistryReceipt(dist, identity, bytes, receipt) {
   if (dist === null || typeof dist !== "object" || Array.isArray(dist) ||
       dist.shasum !== expectedSha1 || dist.integrity !== receipt.integrity ||
       dist.tarball !== expectedTarball ||
-      dist.attestations?.url !== canonicalAttestationUrl(identity) ||
+      !matchesCanonicalAttestationUrl(dist.attestations?.url, identity) ||
       dist.attestations?.provenance?.predicateType !== "https://slsa.dev/provenance/v1") {
     throw new Error(
       "npm registry receipt/provenance does not match the reviewed tarball bytes and identity",


### PR DESCRIPTION
Fix the npm 0.7.2 post-publication verifier to accept npm's canonical percent-encoded scoped package slash while preserving exact origin, path, query, fragment, identity, integrity, and provenance checks.

Verification:
- npm test: 1,848 files, 16,124 passed, 19 skipped
- npm-release regression suite: 17 passed
- live @tetsuo-ai/agenc@0.7.2 registry receipt verified idempotently; no publish invoked
- mandatory pre-commit build and PTY startup smoke passed