### PR TITLE
fix: grok stream idle timeout + launcher deadlock/perms repair (0.7.3)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -125,11 +125,18 @@ base_url = "https://api.openai.com/v1"
 default_model = "gpt-5"
 context_window_tokens = 128000
 max_output_tokens = 16384
+timeout_ms = 120000
 fallback_models = ["gpt-4.1"]
 ```
 
 Optional: `capability_overrides`, nested `fallback` (`targets`, `models`,
 `max_failures`, `statuses`).
+
+`timeout_ms` is the provider request timeout. For streaming responses it is
+the **inter-chunk idle timeout** — how long the stream may go silent before
+it is aborted — not a cap on total stream duration; a long reasoning turn
+that keeps streaming is never cut off by elapsed time alone. `0` disables
+the timeout entirely. Unset uses the provider's built-in default (120s).
 
 ### `[permissions]`
 

--- a/docs/releases/0.7.3.md
+++ b/docs/releases/0.7.3.md
@@ -1,0 +1,49 @@
+# AgenC 0.7.3
+
+AgenC 0.7.3 is a fix-only release. It corrects a streaming timeout defect that
+broke long Grok 4.5 reasoning turns, and removes two launcher failure modes
+that could lock an installation out of the update that fixes it.
+
+## Fixes
+
+### Grok streaming: idle timeout instead of a total-stream deadline
+
+- The grok provider treated its request timeout (default 120s) as a wall-clock
+  deadline for the entire stream. Long reasoning turns that streamed past the
+  deadline were killed mid-flight while still healthy, retried from scratch,
+  and killed again — surfacing as `grok request timed out after 120000ms`
+  loops and collapsed effective token throughput.
+- The timeout now re-arms on every received chunk: it bounds how long a stream
+  may go **silent**, never how long a healthy stream may run. Silent-stall
+  protection is unchanged — a stream that stops producing chunks for the
+  timeout window still aborts.
+- New config knob: `[providers.<slug>] timeout_ms` in `config.toml` sets the
+  provider request timeout (inter-chunk idle for streams; `0` disables).
+  Previously the timeout was not configurable at all.
+
+### npm launcher: daemon failure no longer blocks unrelated commands
+
+- The npm launcher refused to run **any** command (except `agenc daemon ...`)
+  when daemon autostart failed — including `agenc update` and `--version`.
+  A stale binary whose daemon refused newer on-disk state therefore could not
+  be updated: a bootstrap deadlock. The launcher now reports the autostart
+  failure and continues; commands that genuinely need the daemon report the
+  precise failure themselves.
+
+### npm launcher: automatic repair of pre-hardening directory permissions
+
+- Installs created before the 0.6.2 private-directory hardening could have a
+  group-writable `<AGENC_HOME>/runtime` directory (umask `002` systems).
+  Since 0.6.2 every command failed with `protected directory chain permits
+  untrusted mutation` and required a manual `chmod`. The launcher now repairs
+  owner-owned directories in the runtime chain to `0700` automatically;
+  foreign-owned paths still fail closed with the precise assertion error.
+
+## Upgrading
+
+```sh
+agenc update            # standalone installs
+npm install -g @tetsuo-ai/agenc@latest   # npm installs
+```
+
+Restart the daemon after updating: `agenc daemon restart`.

--- a/packages/agenc/lib/runtime-manager.mjs
+++ b/packages/agenc/lib/runtime-manager.mjs
@@ -1143,7 +1143,36 @@ export async function ensureRuntime({
   const binRel = artifact?.bins?.agenc ?? "node_modules/@tetsuo-ai/runtime/bin/agenc";
   const versionDir = dirname(installDir);
   mkdirSync(versionDir, { recursive: true, mode: 0o700 });
-  chmodSync(versionDir, 0o700);
+  // Repair every owner-owned segment between the version dir and the home
+  // root, inclusive of the version dir. Pre-hardening launchers created
+  // <home>/runtime with the ambient umask, so an 002-umask install from
+  // before the 0.6.2 private-directory assertion is group-writable and every
+  // command since then fails with "permits untrusted mutation" and no
+  // automatic path out. Directories not owned by this uid are left alone —
+  // the assertion downstream reports those precisely, and chmod would throw
+  // EPERM anyway.
+  if (process.platform !== "win32" && typeof process.getuid === "function") {
+    for (
+      let current = versionDir;
+      current !== home && dirname(current) !== current;
+      current = dirname(current)
+    ) {
+      try {
+        const stats = lstatSync(current);
+        if (
+          stats.isDirectory() &&
+          !stats.isSymbolicLink() &&
+          stats.uid === process.getuid()
+        ) {
+          chmodSync(current, 0o700);
+        }
+      } catch {
+        /* leave it for the private-directory assertion */
+      }
+    }
+  } else {
+    chmodSync(versionDir, 0o700);
+  }
   const lockPath = `${installDir}.agenc-lock.sqlite`;
 
   if (

--- a/packages/agenc/src/launcher.mjs
+++ b/packages/agenc/src/launcher.mjs
@@ -231,12 +231,19 @@ export async function main(
   try {
     await ensureDaemonForLaunch({ argv, env, cwd, runtimeBin: resolvedBin, userHome });
   } catch (error) {
+    // The launcher is transport, not policy: a daemon that cannot start must
+    // not block daemon-independent commands. `agenc update` is the canonical
+    // case — a stale binary whose daemon refuses newer on-disk state made the
+    // fixing update itself unreachable (bootstrap deadlock, 2026-07-20). The
+    // runtime owns the per-command decision and reports the precise failure,
+    // including the daemon child's stderr tail, when a command truly needs
+    // the daemon.
     process.stderr.write(
       `agenc: daemon autostart failed: ${
         error instanceof Error ? error.message : String(error)
-      }\n`,
+      }\n` +
+        "agenc: continuing without the daemon; commands that require it will report the failure\n",
     );
-    return 1;
   }
   return spawnNodeScript(resolvedBin, argv, { env, cwd, stdio: "inherit" });
 }

--- a/packages/agenc/test/launcher.test.mjs
+++ b/packages/agenc/test/launcher.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
   ensureDaemonForLaunch,
+  main,
   readDaemonPid,
   resolveAgenCHome,
   resolveDaemonCookiePath,
@@ -132,5 +133,57 @@ test("ensureDaemonForLaunch starts daemon and waits for health check", async () 
     });
     assert.equal(result.status, "started");
     assert.deepEqual(calls, [1, undefined]);
+  });
+});
+
+test("main continues to the requested command when daemon autostart fails", async () => {
+  await withTempHome(async (home) => {
+    // Fake runtime: `daemon start` always fails; any other command records
+    // its argv and succeeds. Models the bootstrap deadlock where a broken
+    // daemon blocked `agenc update` — the command that would fix it.
+    const marker = join(home, "spawned-args.json");
+    const fakeRuntime = join(home, "fake-runtime.mjs");
+    await writeFile(
+      fakeRuntime,
+      [
+        'import { writeFileSync } from "node:fs";',
+        "const args = process.argv.slice(2);",
+        'if (args[0] === "daemon") process.exit(1);',
+        `writeFileSync(${JSON.stringify(marker)}, JSON.stringify(args));`,
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    const env = {
+      ...process.env,
+      AGENC_HOME: home,
+      AGENC_DAEMON_READY_TIMEOUT_MS: "25",
+    };
+    const stderrChunks = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (chunk, ...rest) => {
+      stderrChunks.push(String(chunk));
+      return originalWrite.call(process.stderr, chunk, ...rest);
+    };
+    let exitCode;
+    try {
+      exitCode = await main(["update"], {
+        env,
+        cwd: home,
+        runtimeBin: fakeRuntime,
+        userHome: home,
+      });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    // Revert guard: the pre-0.7.3 launcher returned 1 here and never spawned
+    // the runtime, so the marker file did not exist.
+    assert.equal(exitCode, 0);
+    assert.deepEqual(
+      JSON.parse(await readFile(marker, "utf8")),
+      ["update"],
+    );
+    const stderrText = stderrChunks.join("");
+    assert.match(stderrText, /daemon autostart failed/);
+    assert.match(stderrText, /continuing without the daemon/);
   });
 });

--- a/packages/agenc/test/runtime-manager.test.mjs
+++ b/packages/agenc/test/runtime-manager.test.mjs
@@ -12,6 +12,7 @@ import {
   readFileSync,
   readdirSync,
   renameSync,
+  statSync,
   rmSync,
   symlinkSync,
   unlinkSync,
@@ -684,6 +685,62 @@ test("ensureRuntime downloads (file://), verifies sha, extracts, and is idempote
       logs2.some((l) => l.includes("fetching")),
       false,
       "verified install must not re-download",
+    );
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+});
+
+test("ensureRuntime repairs a pre-hardening group-writable runtime dir instead of failing", {
+  skip: process.platform === "win32",
+}, async () => {
+  const work = mkdtempSync(join(tmpdir(), "agenc-perm-repair-"));
+  try {
+    const version = "9.9.9";
+    const { artifact, sha256: digest, bytes } = makeSyntheticArtifact(work, version);
+    const home = join(work, "home");
+    // Model an install created by an old launcher under umask 002: the
+    // intermediate runtime dir exists and is group-writable. Before the
+    // repair walk this made every ensureRuntime call fail the
+    // private-directory assertion with "permits untrusted mutation".
+    const runtimeDir = join(home, "runtime");
+    mkdirSync(runtimeDir, { recursive: true });
+    chmodSync(home, 0o700);
+    chmodSync(runtimeDir, 0o770);
+    const manifest = {
+      manifestVersion: 2,
+      runtimeVersion: version,
+      releaseRepository: "local/test",
+      releaseTag: `agenc-v${version}`,
+      artifacts: [
+        {
+          platform: platformSlug().os,
+          arch: platformSlug().arch,
+          runtimeVersion: version,
+          nodeMajor: Number(process.versions.node.split(".")[0]),
+          nodeModuleAbi: process.versions.modules,
+          nodeApiVersion: process.versions.napi,
+          ...compatibilityFields(platformSlug().os),
+          url: pathToFileURL(artifact).href,
+          sha256: digest,
+          bytes,
+          bins: { agenc: "node_modules/@tetsuo-ai/runtime/bin/agenc" },
+        },
+      ],
+    };
+
+    const bin = await ensureLocalRuntime({
+      env: { AGENC_HOME: home },
+      manifest,
+      log: () => {},
+      runtimeCompatibility: HOST_RUNTIME,
+    });
+    assert.ok(existsSync(bin), "runtime bin should be extracted");
+    const repairedMode = statSync(runtimeDir).mode & 0o777;
+    assert.equal(
+      repairedMode,
+      0o700,
+      `runtime dir should be repaired to 0700, got 0${repairedMode.toString(8)}`,
     );
   } finally {
     rmSync(work, { recursive: true, force: true });

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1183,6 +1183,9 @@ export async function bootstrapLocalRuntimeSession(
       apiKey: selectedApiKey,
       ...(selectedBaseURL ? { baseURL: selectedBaseURL } : {}),
       model: selectedProviderModel,
+      ...(providerSettings?.timeoutMs !== undefined
+        ? { timeoutMs: providerSettings.timeoutMs }
+        : {}),
       tools: registry.toLLMTools(),
       extra: {
         emitWarning: emitProviderWarning,

--- a/runtime/src/config/resolve-provider.ts
+++ b/runtime/src/config/resolve-provider.ts
@@ -39,6 +39,8 @@ export interface ResolvedProviderSettings {
   readonly defaultModel?: string;
   readonly contextWindowTokens?: number;
   readonly maxOutputTokens?: number;
+  /** Request timeout in ms; inter-chunk idle for streams. 0 disables. */
+  readonly timeoutMs?: number;
   readonly capabilityOverrides?: ProviderCapabilityOverrides;
   readonly fallbackTargets?: readonly ProviderFallbackTargetConfig[];
   readonly fallbackMaxFailures?: number;
@@ -122,6 +124,7 @@ export function resolveProviderSettings(
     providerConfig?.context_window_tokens,
   );
   const maxOutputTokens = positiveInteger(providerConfig?.max_output_tokens);
+  const timeoutMs = nonNegativeInteger(providerConfig?.timeout_ms);
   const fallbackTargets = normalizeProviderFallbackTargets(slug, providerConfig);
   const fallbackMaxFailures = positiveInteger(
     providerConfig?.fallback?.max_failures,
@@ -145,6 +148,7 @@ export function resolveProviderSettings(
     ...(maxOutputTokens !== undefined
       ? { maxOutputTokens }
       : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(providerConfig?.capability_overrides
       ? { capabilityOverrides: providerConfig.capability_overrides }
       : {}),
@@ -160,6 +164,14 @@ function positiveInteger(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   const normalized = Math.floor(value);
   return normalized > 0 ? normalized : undefined;
+}
+
+// 0 is meaningful for timeout_ms: it disables the timeout rather than being
+// dropped like an invalid value.
+function nonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const normalized = Math.floor(value);
+  return normalized >= 0 ? normalized : undefined;
 }
 
 function normalizePositiveIntegerArray(

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -483,6 +483,13 @@ export interface ProviderConfig {
   readonly default_model?: string;
   readonly context_window_tokens?: number;
   readonly max_output_tokens?: number;
+  /**
+   * Provider request timeout in milliseconds. For streaming responses this
+   * is the inter-chunk idle timeout, not a total-stream deadline. 0 disables
+   * the timeout entirely. Unset falls back to the provider's built-in
+   * default.
+   */
+  readonly timeout_ms?: number;
   readonly capability_overrides?: ProviderCapabilityOverrides;
   readonly fallback_models?: readonly string[];
   readonly fallback?: ProviderFallbackConfig;
@@ -1431,6 +1438,7 @@ const PROVIDER_KEYS: ReadonlySet<string> = new Set([
   "default_model",
   "context_window_tokens",
   "max_output_tokens",
+  "timeout_ms",
   "capability_overrides",
   "fallback_models",
   "fallback",
@@ -1622,6 +1630,12 @@ function validateSingleProviderConfig(raw: unknown, providerId: string): Provide
     (field, detail) => new InvalidProviderConfigError(field, detail),
   );
   if (maxOutput !== undefined) out.max_output_tokens = maxOutput;
+  const timeoutMs = optionalNonNegativeInteger(
+    record.timeout_ms,
+    fieldPath(providerId, "timeout_ms"),
+    (field, detail) => new InvalidProviderConfigError(field, detail),
+  );
+  if (timeoutMs !== undefined) out.timeout_ms = timeoutMs;
   const capabilities = validateProviderCapabilities(
     record.capability_overrides,
     fieldPath(providerId, "capability_overrides"),

--- a/runtime/src/llm/providers/grok/adapter.ts
+++ b/runtime/src/llm/providers/grok/adapter.ts
@@ -1250,10 +1250,15 @@ export class GrokProvider implements LLMProvider {
       this.configuredTimeoutMs,
       options?.timeoutMs,
     );
-    const streamDeadlineAt =
-      typeof streamTimeout.timeoutMs === "number"
-        ? Date.now() + streamTimeout.timeoutMs
-        : Number.POSITIVE_INFINITY;
+    // The resolved timeout is inter-chunk idle time, not a total-stream
+    // deadline. A healthy stream that keeps producing chunks must never be
+    // torn down by elapsed wall-clock time alone: long reasoning turns
+    // routinely stream for longer than any sane per-request timeout, and
+    // aborting them forces a full re-stream that repays the entire cost
+    // (tetsuo 2026-07-20: grok-4.5 turns died at the old 120s total deadline
+    // mid-stream, retried from zero, and looped). Silent-stall protection is
+    // preserved: each chunk wait re-arms the same timeout, so a stream that
+    // stops producing chunks for timeoutMs still aborts.
 
     let consecutiveFallbackFailures = 0;
     while (true) {
@@ -1280,13 +1285,10 @@ export class GrokProvider implements LLMProvider {
       // singleWireAttempt, so the in-band 401 retry never runs here — the
       // expiring bearer must be refreshed before the wire attempt.
       await this.refreshOAuthBearerIfExpiring();
-      const requestAttemptTimeout =
-        Number.isFinite(streamDeadlineAt)
-          ? {
-            ...streamTimeout,
-            timeoutMs: Math.max(1, streamDeadlineAt - Date.now()),
-          }
-          : streamTimeout;
+      // Each wire attempt gets the full resolved timeout for the open phase;
+      // a configured-fallback retry must not inherit a nearly-spent budget
+      // from the previous attempt.
+      const requestAttemptTimeout = streamTimeout;
       emitProviderTraceEvent(options, {
         kind: "request",
         transport: "chat_stream",
@@ -1390,21 +1392,12 @@ export class GrokProvider implements LLMProvider {
         if (options?.signal?.aborted) {
           throw createStreamAbortError(this.name);
         }
-        const remainingStreamMs = Number.isFinite(streamDeadlineAt)
-          ? Math.max(0, streamDeadlineAt - Date.now())
-          : undefined;
-        if (
-          typeof remainingStreamMs === "number" &&
-          remainingStreamMs <= 0
-        ) {
-          throw createStreamTimeoutError(
-            this.name,
-            streamTimeout.timeoutMs ?? options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          );
-        }
+        // Idle timeout: the full resolved timeout re-arms on every chunk wait.
+        // nextStreamChunkWithTimeout throws the stream-stalled error when no
+        // chunk arrives within the window.
         const iterResult = await nextStreamChunkWithTimeout(
           streamIterator,
-          remainingStreamMs,
+          streamTimeout.timeoutMs,
           this.name,
           options?.signal,
         );

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -1110,6 +1110,9 @@ async function providerFactoryOptionsFromSettings(params: {
   return {
     ...(apiKey ? { apiKey } : {}),
     ...(baseURL ? { baseURL } : {}),
+    ...(params.settings?.timeoutMs !== undefined
+      ? { timeoutMs: params.settings.timeoutMs }
+      : {}),
     ...(managedCredential?.baseURL !== undefined
       ? { extra: { ...extra, managedGateway: true } }
       : {}),

--- a/runtime/tests/config/config.test.ts
+++ b/runtime/tests/config/config.test.ts
@@ -590,6 +590,29 @@ describe("provider resolution (T13)", () => {
     });
   });
 
+  test("resolveProviderSettings maps [providers.<name>] timeout_ms including the 0 disable value", () => {
+    const configured = mergeConfigs(defaultConfig(), {
+      providers: { grok: { timeout_ms: 600_000 } },
+    });
+    expect(resolveProviderSettings("grok", configured, {})).toMatchObject({
+      provider: "grok",
+      timeoutMs: 600_000,
+    });
+
+    // 0 is meaningful (disable the timeout) and must not be dropped.
+    const disabled = mergeConfigs(defaultConfig(), {
+      providers: { grok: { timeout_ms: 0 } },
+    });
+    expect(resolveProviderSettings("grok", disabled, {})).toMatchObject({
+      provider: "grok",
+      timeoutMs: 0,
+    });
+
+    // Unset stays absent so the provider default applies.
+    const unset = resolveProviderSettings("grok", defaultConfig(), {});
+    expect(unset).not.toHaveProperty("timeoutMs");
+  });
+
   test("resolveProviderSettings lets OPENAI env configure local compatible endpoints", () => {
     const settings = resolveProviderSettings("openai-compatible", defaultConfig(), {
       OPENAI_API_KEY: "local-token",

--- a/runtime/tests/llm/providers/grok/adapter.test.ts
+++ b/runtime/tests/llm/providers/grok/adapter.test.ts
@@ -771,3 +771,119 @@ describe("GrokProvider incremental continuation", () => {
     });
   });
 });
+
+describe("GrokProvider stream timeout semantics", () => {
+  // Chunks arrive `gapMs` after the previous chunk is consumed, so the
+  // stream is never idle for longer than `gapMs` even though its total
+  // duration is `events.length * gapMs`.
+  function steadilyChunkingStream(
+    events: readonly Record<string, unknown>[],
+    gapMs: number,
+  ): AsyncIterable<Record<string, unknown>> {
+    return {
+      async *[Symbol.asyncIterator]() {
+        for (const event of events) {
+          await new Promise((resolve) => setTimeout(resolve, gapMs));
+          yield event;
+        }
+      },
+    };
+  }
+
+  test("healthy stream longer than timeoutMs completes — timeout is inter-chunk idle, not a total deadline", async () => {
+    // Revert guard: with the pre-0.7.3 streamDeadlineAt total-budget
+    // semantics this stream is killed at t=1000ms mid-flight and the call
+    // rejects; with idle semantics every chunk gap (600ms) is under the
+    // 1000ms window and the stream completes.
+    vi.useFakeTimers();
+    try {
+      const provider = new GrokProvider({
+        apiKey: "xai-test",
+        model: "grok-4-fast",
+        timeoutMs: 1000,
+      });
+      const create = vi.fn().mockImplementation(() =>
+        withResponse(
+          steadilyChunkingStream(
+            [
+              { type: "response.output_text.delta", delta: "one " },
+              { type: "response.output_text.delta", delta: "two " },
+              { type: "response.output_text.delta", delta: "three" },
+              {
+                type: "response.completed",
+                response: buildXaiResponse("resp_slow_stream", "one two three"),
+              },
+            ],
+            600,
+          ),
+        ),
+      );
+      (provider as any).client = { responses: { create } };
+
+      const deltas: string[] = [];
+      const resultPromise = provider.chatStream(
+        [{ role: "user", content: "hello" }],
+        (chunk) => {
+          if (typeof (chunk as { delta?: unknown }).delta === "string") {
+            deltas.push((chunk as { delta: string }).delta);
+          }
+        },
+      );
+      // Surface rejections through the assertion below instead of an
+      // unhandled-rejection crash while timers advance.
+      resultPromise.catch(() => {});
+      // 4 gaps x 600ms = 2400ms total stream time, well past the 1000ms
+      // timeout that the old code treated as a wall-clock deadline.
+      await vi.advanceTimersByTimeAsync(2600);
+      const result = await resultPromise;
+      expect(result.content).toBe("one two three");
+      expect(result.finishReason).toBe("stop");
+      expect(create).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("stream idle past timeoutMs still aborts with the stalled error", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new GrokProvider({
+        apiKey: "xai-test",
+        model: "grok-4-fast",
+        timeoutMs: 1000,
+      });
+      const create = vi.fn().mockImplementation(() =>
+        withResponse({
+          // Chunk two never arrives inside the idle window: the stream goes
+          // silent for far longer than timeoutMs after chunk one.
+          async *[Symbol.asyncIterator]() {
+            yield { type: "response.output_text.delta", delta: "one " };
+            await new Promise((resolve) => setTimeout(resolve, 60_000));
+            yield { type: "response.output_text.delta", delta: "two" };
+          },
+        }),
+      );
+      (provider as any).client = { responses: { create } };
+
+      const resultPromise = provider.chatStream(
+        [{ role: "user", content: "hello" }],
+        () => {},
+      );
+      resultPromise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(1100);
+      // The stalled abort retains admission until the pending physical read
+      // settles; advance past the hung read so teardown can complete.
+      await vi.advanceTimersByTimeAsync(60_000);
+      // The adapter captures the stall in the result rather than rejecting:
+      // partial content is preserved and the mapped timeout error is carried
+      // on finishReason "error".
+      const result = await resultPromise;
+      expect(result.content).toBe("one ");
+      expect(result.finishReason).toBe("error");
+      expect(result.error?.name).toBe("LLMTimeoutError");
+      expect(result.error).toMatchObject({ timeoutMs: 1000 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Fix-only batch for 0.7.3.

- **fix(llm):** grok stream timeout is inter-chunk idle, not a total-stream deadline; adds `[providers.<slug>] timeout_ms` config knob (0 disables). Long grok-4.5 reasoning turns no longer die at 120s mid-stream and retry-loop.
- **fix(launcher):** repair pre-hardening group-writable `<home>/runtime` perms automatically instead of failing every command with 'permits untrusted mutation'.
- **fix(launcher):** daemon autostart failure warns and continues instead of blocking daemon-independent commands ('agenc update' bootstrap deadlock).
- **docs:** timeout_ms reference, 0.7.3 release notes.

## Verification (local, per required-gates)
- typecheck clean
- full stable vitest: 1848 files, 16127 passed / 0 failed / 19 skipped
- build + SDK generated-types check + package modes clean
- packages/agenc: 138/138 (node --test via npm test)
- All three fixes have revert-sensitive tests, each proven red against the reverted source
- Empirical: 'agenc update' verified working against an unstartable daemon via runtime bin; npm-launcher path reproduced the deadlock pre-fix
- Tested SHA: 5c765585d590ca8f9aa2e30b1e5baecf66b7fd58