### PR TITLE
feat(contracts): M5 verified-change workflow contract freeze (Phase 1/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ obj/
 !runtime/tests/fixtures/replay-cli/*.json
 !runtime/tests/fixtures/golden/*.json
 !/packages/agenc/test/fixtures/agenc-v0.7.2-legacy-manifest.json
+!/runtime/src/workflow/verified-change-record.schema.json
 !docs/api-baseline/*.json
 !docs/security/fender-medium-baseline.json
 !docs/security/fender-full-baseline.json

--- a/runtime/src/contracts/run-contracts.ts
+++ b/runtime/src/contracts/run-contracts.ts
@@ -235,5 +235,158 @@ export const RESERVED_RUN_METHODS = [
   "run.evidence",
   /** Tree-scoped cancel: parent + queued + running descendants. */
   "run.cancel",
+  /** Start the M5 verified-change workflow as a durable run (contract-change PR, additive). */
+  "run.start",
 ] as const;
 export type ReservedRunMethod = (typeof RESERVED_RUN_METHODS)[number];
+
+// ---------------------------------------------------------------------------
+// Verified-change workflow (M5)
+// ---------------------------------------------------------------------------
+
+/**
+ * The fixed verified-change pipeline. These are the durable `stepId` values
+ * recorded in `run_effects` for a workflow run (retried stages append an
+ * attempt suffix, e.g. `workflow.implement#2`; verification fan-out appends a
+ * command index, e.g. `workflow.verify.cmd.3`). A general DAG engine is
+ * deliberately out of contract — M5 ships exactly this pipeline.
+ */
+export const WORKFLOW_STEP_IDS = [
+  "workflow.intake",
+  "workflow.worktree",
+  "workflow.plan",
+  "workflow.implement",
+  "workflow.verify",
+  "workflow.review",
+  "workflow.finalize",
+] as const;
+export type WorkflowStepId = (typeof WORKFLOW_STEP_IDS)[number];
+
+/**
+ * Static prerequisite map for the fixed pipeline (a linear chain today).
+ * A stage may not begin until every prerequisite stage's effect is
+ * `committed` AND its in-evidence verdicts pass; failed verification,
+ * cancellation, budget exhaustion, and `unknown_outcome` all stop dependent
+ * unlocks (the unknown-outcome mutation gate and terminal-epoch refusal in
+ * the durability layer are the hard backstops).
+ */
+export const WORKFLOW_STEP_PREREQUISITES: Readonly<
+  Record<WorkflowStepId, readonly WorkflowStepId[]>
+> = Object.freeze({
+  "workflow.intake": [],
+  "workflow.worktree": ["workflow.intake"],
+  "workflow.plan": ["workflow.worktree"],
+  "workflow.implement": ["workflow.plan"],
+  "workflow.verify": ["workflow.implement"],
+  "workflow.review": ["workflow.verify"],
+  "workflow.finalize": ["workflow.review"],
+});
+
+/** Projected status of one workflow stage (derived from run_effects rows). */
+export const WORKFLOW_STEP_STATUSES = [
+  "pending",
+  "running",
+  "committed",
+  "failed",
+  "cancelled",
+  "unknown_outcome",
+  /** Prerequisites terminally failed; this stage can never start. */
+  "blocked",
+] as const;
+export type WorkflowStepStatus = (typeof WORKFLOW_STEP_STATUSES)[number];
+
+/**
+ * Machine-readable stop reasons for a workflow run that does not complete.
+ * Recorded as `RunTerminalResult.stopReason`; never prose-only.
+ */
+export const WORKFLOW_STOP_REASONS = [
+  "verification_failed",
+  "review_rejected",
+  "base_moved_conflict",
+  "budget_exhausted",
+  "policy_denied",
+  /**
+   * M5 approval semantics (frozen): the intake step resolves approvals up
+   * front and rejects specs that would require interactive approval. If a
+   * mid-pipeline admission still returns `approval_required`, the run
+   * terminates `failed` with this reason — durable, honest, replayable.
+   * There is NO approval-parking subsystem in M5; upgrading this to a
+   * parked-and-resumable step is an explicit future contract change.
+   */
+  "approval_required",
+  "unknown_outcome_effect",
+  "evidence_invalid",
+  "step_retries_exhausted",
+] as const;
+export type WorkflowStopReason = (typeof WORKFLOW_STOP_REASONS)[number];
+
+/**
+ * The workflow specification, frozen at intake. Persisted as the
+ * `workflow.intake` effect's evidence (canonical JSON); its canonical digest
+ * is the intake effect's intent digest and the spec's durable identity.
+ * Resolved fields (reviewerModel, baseCommit) are never re-resolved later —
+ * a moved base is detected against `baseCommit` and surfaced explicitly.
+ */
+export interface WorkflowSpec {
+  readonly runId: RunId;
+  /** The engineering goal / issue text driving the change. */
+  readonly goal: string;
+  /** Absolute git root of the target repository. */
+  readonly repoPath: string;
+  /** Exact base commit recorded before any work begins. */
+  readonly baseCommit: string;
+  /** Dirty-state summary of the user's checkout at intake (never mutated). */
+  readonly baseDirty: {
+    readonly dirty: boolean;
+    /** sha256 of `git status --porcelain=v1 -z` output at intake. */
+    readonly summaryDigest: string;
+    readonly fileCount: number;
+  };
+  readonly model?: string;
+  readonly provider?: string;
+  /** Pinned reviewer configuration; resolved at intake, never re-resolved. */
+  readonly reviewerModel: string;
+  readonly permissionMode:
+    | "default"
+    | "plan"
+    | "acceptEdits"
+    | "bypassPermissions";
+  readonly unattendedAllow?: readonly string[];
+  readonly unattendedDeny?: readonly string[];
+  readonly budget: {
+    readonly maxCostUsd?: number;
+    readonly maxTokens?: number;
+    readonly deadlineAt?: string;
+  };
+  /** Required verification commands; every one must exit 0 for completion. */
+  readonly requiredVerification: readonly {
+    readonly label: string;
+    readonly script: string;
+  }[];
+  /** Bounded re-implement attempts after failed verification (default 2). */
+  readonly maxImplementAttempts: number;
+}
+
+/**
+ * Durable pointer to a content-addressed artifact produced by a workflow
+ * step. Persisted in the producing step's effect evidence AND in the run's
+ * evidence ledger; `storagePath` is a portable `cas://sha256/<hex>` address
+ * within the ledger, never a host path.
+ */
+export interface RunArtifactPointer {
+  readonly step: RunStepIdentity;
+  readonly role:
+    | "patch"
+    | "changed_files"
+    | "test_result"
+    | "independent_review"
+    | "cost_usage"
+    | "effect_log"
+    | "risk_register"
+    | "base_state"
+    | "diagnostic";
+  readonly digest: `sha256:${string}`;
+  readonly bytes: number;
+  readonly storagePath: string;
+  readonly recordedAt: string;
+}

--- a/runtime/src/durability/failpoints.ts
+++ b/runtime/src/durability/failpoints.ts
@@ -78,9 +78,64 @@ export function hitM4DurabilityFailpoint(
   process.kill(process.pid, "SIGKILL");
 }
 
+/**
+ * M5 verified-change workflow failpoints — one per durable pipeline
+ * boundary. Same inert-unless-armed mechanism as M4, with a distinct token
+ * so an M4 harness can never trip an M5 boundary by accident.
+ */
+export const M5_WORKFLOW_FAILPOINTS = [
+  "before_intake_commit",
+  "after_intake_commit",
+  "before_worktree_provision",
+  "after_worktree_provision",
+  "after_spawn_before_effect_result",
+  "before_verify_commit",
+  "after_verify_commit",
+  "before_review_commit",
+  "after_review_commit",
+  "before_patch_export",
+  "after_patch_export_before_seal",
+  "after_seal_before_terminal",
+  "after_terminal_before_cleanup",
+] as const;
+
+export type M5WorkflowFailpoint = (typeof M5_WORKFLOW_FAILPOINTS)[number];
+
+const M5_FAILPOINT_TOKEN = "m5-workflow-child";
+
+export class M5WorkflowFailpointError extends Error {
+  readonly failpoint: M5WorkflowFailpoint;
+
+  constructor(failpoint: M5WorkflowFailpoint) {
+    super(`M5 workflow failpoint reached: ${failpoint}`);
+    this.name = "M5WorkflowFailpointError";
+    this.failpoint = failpoint;
+  }
+}
+
+/** Crash (default) or throw at one named M5 workflow boundary. */
+export function hitM5WorkflowFailpoint(
+  failpoint: M5WorkflowFailpoint,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env[FAILPOINT_ENV] !== failpoint) return;
+  if (env[FAILPOINT_TOKEN_ENV] !== M5_FAILPOINT_TOKEN) return;
+
+  const markerPath = env[FAILPOINT_MARKER_ENV];
+  if (markerPath !== undefined && markerPath.length > 0) {
+    writeMarkerDurably(markerPath, failpoint);
+  }
+
+  if (env[FAILPOINT_ACTION_ENV] === "throw") {
+    throw new M5WorkflowFailpointError(failpoint);
+  }
+
+  process.kill(process.pid, "SIGKILL");
+}
+
 function writeMarkerDurably(
   markerPath: string,
-  failpoint: M4DurabilityFailpoint,
+  failpoint: M4DurabilityFailpoint | M5WorkflowFailpoint,
 ): void {
   const fd = openSync(markerPath, "w", 0o600);
   try {

--- a/runtime/src/workflow/evidence-record.ts
+++ b/runtime/src/workflow/evidence-record.ts
@@ -1,0 +1,271 @@
+/**
+ * The M5 verified-change evidence record — document kind
+ * `agenc.run.verified-change-record.v1`.
+ *
+ * A NEW document kind on the eval-contract machinery (canonical JSON,
+ * sha256 document digests, content-addressed artifact pointers, and the
+ * kind-agnostic evidence ledger). It deliberately does NOT overload the
+ * frozen eval `run-record` kind: that document is suite/task-coupled and
+ * schema-frozen; the verified-change record describes one workflow run.
+ *
+ * Discipline (copied from the trust-conformance runner): a record is
+ * validated mechanically BEFORE it is emitted or a run may claim
+ * `completed` — never emit unvalidated evidence.
+ */
+
+import {
+  canonicalizeJson,
+  computeDocumentDigest,
+  sha256Digest,
+} from "../eval-contract/canonical-json.js";
+import type { Sha256Digest } from "../eval-contract/types.js";
+import type {
+  RunArtifactPointer,
+  RunTerminalStatus,
+  RunUsageTotals,
+  WorkflowSpec,
+  WorkflowStepId,
+  WorkflowStepStatus,
+  WorkflowStopReason,
+} from "../contracts/run-contracts.js";
+import {
+  RUN_TERMINAL_STATUSES,
+  WORKFLOW_STEP_IDS,
+  WORKFLOW_STEP_STATUSES,
+  WORKFLOW_STOP_REASONS,
+} from "../contracts/run-contracts.js";
+
+export const VERIFIED_CHANGE_RECORD_KIND =
+  "agenc.run.verified-change-record.v1" as const;
+
+/** Artifact roles the record REQUIRES for a `completed` terminal status. */
+export const COMPLETED_REQUIRED_ARTIFACT_ROLES = [
+  "patch",
+  "changed_files",
+  "test_result",
+  "independent_review",
+] as const;
+
+export interface VerifiedChangeStepRecord {
+  readonly stepId: string;
+  /** The base pipeline stage this step belongs to (attempt/fan-out aware). */
+  readonly stage: WorkflowStepId;
+  readonly status: WorkflowStepStatus;
+  readonly attempt: number;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  /** Machine verdict where the stage has one (verify/review). */
+  readonly verdict?: string;
+  readonly artifacts: readonly RunArtifactPointer[];
+}
+
+export interface VerifiedChangeCommandRecord {
+  readonly label: string;
+  readonly script: string;
+  readonly exitCode: number;
+  readonly timedOut: boolean;
+  readonly truncated: boolean;
+  readonly durationMs: number;
+  readonly stdoutDigest: Sha256Digest;
+  readonly stderrDigest: Sha256Digest;
+}
+
+export interface VerifiedChangeReviewRecord {
+  readonly reviewerModel: string;
+  readonly overallCorrectness: string;
+  readonly overallConfidenceScore: number;
+  readonly blockerCount: number;
+  readonly findingCount: number;
+  readonly artifact: RunArtifactPointer;
+}
+
+export interface VerifiedChangeRecord {
+  readonly kind: typeof VERIFIED_CHANGE_RECORD_KIND;
+  readonly recordVersion: 1;
+  readonly runId: string;
+  /** Canonical digest of the frozen WorkflowSpec (the intake intent digest). */
+  readonly specDigest: Sha256Digest;
+  readonly spec: WorkflowSpec;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly terminal: {
+    readonly status: RunTerminalStatus;
+    readonly stopReason: WorkflowStopReason | null;
+    readonly finalMessage: string | null;
+  };
+  readonly usage: RunUsageTotals | null;
+  readonly baseCommit: string;
+  readonly headCommit: string | null;
+  readonly steps: readonly VerifiedChangeStepRecord[];
+  readonly verificationCommands: readonly VerifiedChangeCommandRecord[];
+  readonly review: VerifiedChangeReviewRecord | null;
+  /** Honest unresolved risks; empty ONLY when genuinely none remain. */
+  readonly unresolvedRisks: readonly string[];
+  readonly evidenceLedger: {
+    readonly eventCount: number;
+    readonly headEventDigest: Sha256Digest;
+    readonly sealed: boolean;
+  };
+  readonly documentDigest: Sha256Digest;
+}
+
+export interface VerifiedChangeRecordValidation {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+}
+
+export function computeSpecDigest(spec: WorkflowSpec): Sha256Digest {
+  return sha256Digest(canonicalizeJson(spec));
+}
+
+export function assembleVerifiedChangeRecord(
+  input: Omit<VerifiedChangeRecord, "kind" | "recordVersion" | "documentDigest">,
+): VerifiedChangeRecord {
+  const withoutDigest = {
+    kind: VERIFIED_CHANGE_RECORD_KIND,
+    recordVersion: 1 as const,
+    ...input,
+  };
+  const documentDigest = computeDocumentDigest(withoutDigest);
+  const record: VerifiedChangeRecord = { ...withoutDigest, documentDigest };
+  const validation = validateVerifiedChangeRecord(record);
+  if (!validation.valid) {
+    throw new Error(
+      `verified-change record failed self-validation: ${validation.errors.join("; ")}`,
+    );
+  }
+  return record;
+}
+
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const CAS_PATH_PATTERN = /^cas:\/\/sha256\/[0-9a-f]{64}$/;
+const RFC3339_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+export function validateVerifiedChangeRecord(
+  value: unknown,
+): VerifiedChangeRecordValidation {
+  const errors: string[] = [];
+  const record = value as VerifiedChangeRecord;
+  if (record === null || typeof record !== "object" || Array.isArray(record)) {
+    return { valid: false, errors: ["record must be an object"] };
+  }
+  if (record.kind !== VERIFIED_CHANGE_RECORD_KIND) {
+    errors.push(`kind must be ${VERIFIED_CHANGE_RECORD_KIND}`);
+  }
+  if (record.recordVersion !== 1) errors.push("recordVersion must be 1");
+  if (typeof record.runId !== "string" || record.runId.length === 0) {
+    errors.push("runId must be a non-empty string");
+  }
+  if (!SHA256_PATTERN.test(String(record.specDigest))) {
+    errors.push("specDigest must be sha256:<64 hex>");
+  }
+  if (record.spec === null || typeof record.spec !== "object") {
+    errors.push("spec must be the frozen WorkflowSpec object");
+  } else if (computeSpecDigest(record.spec) !== record.specDigest) {
+    errors.push("specDigest does not match the canonical spec digest");
+  }
+  for (const [field, timestamp] of [
+    ["startedAt", record.startedAt],
+    ["finishedAt", record.finishedAt],
+  ] as const) {
+    if (!RFC3339_PATTERN.test(String(timestamp))) {
+      errors.push(`${field} must be an RFC 3339 timestamp`);
+    }
+  }
+  const terminal = record.terminal;
+  if (terminal === null || typeof terminal !== "object") {
+    errors.push("terminal must be an object");
+  } else {
+    if (!(RUN_TERMINAL_STATUSES as readonly string[]).includes(terminal.status)) {
+      errors.push("terminal.status must be a frozen run terminal status");
+    }
+    if (
+      terminal.stopReason !== null &&
+      !(WORKFLOW_STOP_REASONS as readonly string[]).includes(terminal.stopReason)
+    ) {
+      errors.push("terminal.stopReason must be a frozen workflow stop reason");
+    }
+    if (terminal.status !== "completed" && terminal.stopReason === null) {
+      errors.push("non-completed terminal status requires a stopReason");
+    }
+  }
+  if (!Array.isArray(record.steps) || record.steps.length === 0) {
+    errors.push("steps must be a non-empty array");
+  } else {
+    for (const step of record.steps) {
+      if (!(WORKFLOW_STEP_IDS as readonly string[]).includes(step.stage)) {
+        errors.push(`step ${step.stepId}: unknown stage ${String(step.stage)}`);
+      }
+      if (!(WORKFLOW_STEP_STATUSES as readonly string[]).includes(step.status)) {
+        errors.push(`step ${step.stepId}: unknown status ${String(step.status)}`);
+      }
+      for (const artifact of step.artifacts ?? []) {
+        if (!SHA256_PATTERN.test(String(artifact.digest))) {
+          errors.push(`step ${step.stepId}: artifact digest must be sha256:<64 hex>`);
+        }
+        if (!CAS_PATH_PATTERN.test(String(artifact.storagePath))) {
+          errors.push(
+            `step ${step.stepId}: artifact storagePath must be cas://sha256/<hex>`,
+          );
+        }
+        if (!Number.isSafeInteger(artifact.bytes) || artifact.bytes < 0) {
+          errors.push(`step ${step.stepId}: artifact bytes must be a non-negative integer`);
+        }
+      }
+    }
+  }
+  if (record.terminal?.status === "completed") {
+    const roles = new Set(
+      (record.steps ?? []).flatMap((step) =>
+        (step.artifacts ?? []).map((artifact) => artifact.role),
+      ),
+    );
+    for (const required of COMPLETED_REQUIRED_ARTIFACT_ROLES) {
+      if (!roles.has(required)) {
+        errors.push(`completed record is missing required artifact role: ${required}`);
+      }
+    }
+    if (record.review === null) {
+      errors.push("completed record requires the independent review block");
+    } else if (record.review.blockerCount !== 0) {
+      errors.push("completed record cannot carry unresolved review blockers");
+    }
+    for (const command of record.verificationCommands ?? []) {
+      if (command.exitCode !== 0 || command.timedOut) {
+        errors.push(
+          `completed record has a failing verification command: ${command.label}`,
+        );
+      }
+    }
+    if (record.headCommit === null) {
+      errors.push("completed record requires headCommit");
+    }
+  }
+  if (!Array.isArray(record.unresolvedRisks)) {
+    errors.push("unresolvedRisks must be an array (empty only when none remain)");
+  }
+  const ledger = record.evidenceLedger;
+  if (ledger === null || typeof ledger !== "object") {
+    errors.push("evidenceLedger must be an object");
+  } else {
+    if (!Number.isSafeInteger(ledger.eventCount) || ledger.eventCount < 1) {
+      errors.push("evidenceLedger.eventCount must be a positive integer");
+    }
+    if (!SHA256_PATTERN.test(String(ledger.headEventDigest))) {
+      errors.push("evidenceLedger.headEventDigest must be sha256:<64 hex>");
+    }
+    if (record.terminal?.status === "completed" && ledger.sealed !== true) {
+      errors.push("completed record requires a sealed evidence ledger");
+    }
+  }
+  if (typeof record.documentDigest === "string") {
+    const { documentDigest: _digest, ...body } = record;
+    if (computeDocumentDigest(body) !== record.documentDigest) {
+      errors.push("documentDigest does not match the canonical record body");
+    }
+  } else {
+    errors.push("documentDigest must be present");
+  }
+  return { valid: errors.length === 0, errors };
+}

--- a/runtime/src/workflow/verified-change-record.schema.json
+++ b/runtime/src/workflow/verified-change-record.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agenc.tech/schemas/verified-change-record-v1.json",
+  "title": "AgenC verified-change evidence record v1",
+  "type": "object",
+  "required": [
+    "kind", "recordVersion", "runId", "specDigest", "spec", "startedAt",
+    "finishedAt", "terminal", "usage", "baseCommit", "headCommit", "steps",
+    "verificationCommands", "review", "unresolvedRisks", "evidenceLedger",
+    "documentDigest"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "kind": { "const": "agenc.run.verified-change-record.v1" },
+    "recordVersion": { "const": 1 },
+    "runId": { "type": "string", "minLength": 1 },
+    "specDigest": { "$ref": "#/$defs/sha256" },
+    "spec": { "type": "object" },
+    "startedAt": { "$ref": "#/$defs/timestamp" },
+    "finishedAt": { "$ref": "#/$defs/timestamp" },
+    "terminal": {
+      "type": "object",
+      "required": ["status", "stopReason", "finalMessage"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "enum": ["completed", "failed", "cancelled", "unknown_outcome"] },
+        "stopReason": {
+          "oneOf": [
+            { "type": "null" },
+            { "enum": [
+              "verification_failed", "review_rejected", "base_moved_conflict",
+              "budget_exhausted", "policy_denied", "approval_required",
+              "unknown_outcome_effect", "evidence_invalid", "step_retries_exhausted"
+            ] }
+          ]
+        },
+        "finalMessage": { "type": ["string", "null"] }
+      }
+    },
+    "usage": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["inputTokens", "outputTokens", "totalTokens", "costUsd"],
+          "additionalProperties": false,
+          "properties": {
+            "inputTokens": { "type": "integer", "minimum": 0 },
+            "outputTokens": { "type": "integer", "minimum": 0 },
+            "totalTokens": { "type": "integer", "minimum": 0 },
+            "costUsd": { "type": "number", "minimum": 0 }
+          }
+        }
+      ]
+    },
+    "baseCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "headCommit": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+      ]
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["stepId", "stage", "status", "attempt", "startedAt", "finishedAt", "artifacts"],
+        "additionalProperties": false,
+        "properties": {
+          "stepId": { "type": "string", "minLength": 1 },
+          "stage": { "enum": [
+            "workflow.intake", "workflow.worktree", "workflow.plan",
+            "workflow.implement", "workflow.verify", "workflow.review",
+            "workflow.finalize"
+          ] },
+          "status": { "enum": [
+            "pending", "running", "committed", "failed", "cancelled",
+            "unknown_outcome", "blocked"
+          ] },
+          "attempt": { "type": "integer", "minimum": 1 },
+          "startedAt": { "oneOf": [ { "type": "null" }, { "$ref": "#/$defs/timestamp" } ] },
+          "finishedAt": { "oneOf": [ { "type": "null" }, { "$ref": "#/$defs/timestamp" } ] },
+          "verdict": { "type": "string" },
+          "artifacts": { "type": "array", "items": { "$ref": "#/$defs/artifactPointer" } }
+        }
+      }
+    },
+    "verificationCommands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "script", "exitCode", "timedOut", "truncated", "durationMs", "stdoutDigest", "stderrDigest"],
+        "additionalProperties": false,
+        "properties": {
+          "label": { "type": "string", "minLength": 1 },
+          "script": { "type": "string", "minLength": 1 },
+          "exitCode": { "type": "integer" },
+          "timedOut": { "type": "boolean" },
+          "truncated": { "type": "boolean" },
+          "durationMs": { "type": "integer", "minimum": 0 },
+          "stdoutDigest": { "$ref": "#/$defs/sha256" },
+          "stderrDigest": { "$ref": "#/$defs/sha256" }
+        }
+      }
+    },
+    "review": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["reviewerModel", "overallCorrectness", "overallConfidenceScore", "blockerCount", "findingCount", "artifact"],
+          "additionalProperties": false,
+          "properties": {
+            "reviewerModel": { "type": "string", "minLength": 1 },
+            "overallCorrectness": { "type": "string", "minLength": 1 },
+            "overallConfidenceScore": { "type": "number", "minimum": 0, "maximum": 1 },
+            "blockerCount": { "type": "integer", "minimum": 0 },
+            "findingCount": { "type": "integer", "minimum": 0 },
+            "artifact": { "$ref": "#/$defs/artifactPointer" }
+          }
+        }
+      ]
+    },
+    "unresolvedRisks": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "evidenceLedger": {
+      "type": "object",
+      "required": ["eventCount", "headEventDigest", "sealed"],
+      "additionalProperties": false,
+      "properties": {
+        "eventCount": { "type": "integer", "minimum": 1 },
+        "headEventDigest": { "$ref": "#/$defs/sha256" },
+        "sealed": { "type": "boolean" }
+      }
+    },
+    "documentDigest": { "$ref": "#/$defs/sha256" }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "artifactPointer": {
+      "type": "object",
+      "required": ["step", "role", "digest", "bytes", "storagePath", "recordedAt"],
+      "additionalProperties": false,
+      "properties": {
+        "step": {
+          "type": "object",
+          "required": ["runId", "stepId"],
+          "additionalProperties": false,
+          "properties": {
+            "runId": { "type": "string", "minLength": 1 },
+            "stepId": { "type": "string", "minLength": 1 },
+            "parentRunId": { "type": "string" }
+          }
+        },
+        "role": { "enum": [
+          "patch", "changed_files", "test_result", "independent_review",
+          "cost_usage", "effect_log", "risk_register", "base_state", "diagnostic"
+        ] },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "storagePath": { "type": "string", "pattern": "^cas://sha256/[0-9a-f]{64}$" },
+        "recordedAt": { "$ref": "#/$defs/timestamp" }
+      }
+    }
+  }
+}

--- a/runtime/tests/contracts/run-contracts.test.ts
+++ b/runtime/tests/contracts/run-contracts.test.ts
@@ -10,6 +10,10 @@ import {
   RESERVATION_RESOLUTIONS,
   RESERVED_RUN_METHODS,
   RUN_TERMINAL_STATUSES,
+  WORKFLOW_STEP_IDS,
+  WORKFLOW_STEP_PREREQUISITES,
+  WORKFLOW_STEP_STATUSES,
+  WORKFLOW_STOP_REASONS,
 } from "../../src/contracts/run-contracts.js";
 
 /**
@@ -45,9 +49,62 @@ describe("shared run contracts (frozen v1)", () => {
     ]);
   });
 
-  test("reserved run methods are frozen", () => {
+  test("reserved run methods are frozen (run.start added by the M5 contract change)", () => {
     expect(RESERVED_RUN_METHODS).toEqual([
       "run.status", "run.result", "run.replay", "run.evidence", "run.cancel",
+      "run.start",
+    ]);
+  });
+
+  test("workflow step vocabulary is frozen (M5)", () => {
+    expect(WORKFLOW_STEP_IDS).toEqual([
+      "workflow.intake",
+      "workflow.worktree",
+      "workflow.plan",
+      "workflow.implement",
+      "workflow.verify",
+      "workflow.review",
+      "workflow.finalize",
+    ]);
+    expect(WORKFLOW_STEP_STATUSES).toEqual([
+      "pending", "running", "committed", "failed", "cancelled",
+      "unknown_outcome", "blocked",
+    ]);
+  });
+
+  test("workflow prerequisites form the fixed linear pipeline", () => {
+    expect(WORKFLOW_STEP_PREREQUISITES).toEqual({
+      "workflow.intake": [],
+      "workflow.worktree": ["workflow.intake"],
+      "workflow.plan": ["workflow.worktree"],
+      "workflow.implement": ["workflow.plan"],
+      "workflow.verify": ["workflow.implement"],
+      "workflow.review": ["workflow.verify"],
+      "workflow.finalize": ["workflow.review"],
+    });
+    expect(Object.isFrozen(WORKFLOW_STEP_PREREQUISITES)).toBe(true);
+    // Every stage except intake has exactly one prerequisite and every
+    // prerequisite is itself a frozen stage — the chain has no cycles by
+    // construction, and this pins that shape.
+    for (const [step, prerequisites] of Object.entries(WORKFLOW_STEP_PREREQUISITES)) {
+      for (const prerequisite of prerequisites) {
+        expect(WORKFLOW_STEP_IDS).toContain(prerequisite);
+        expect(prerequisite).not.toBe(step);
+      }
+    }
+  });
+
+  test("workflow stop reasons are frozen and machine-readable", () => {
+    expect(WORKFLOW_STOP_REASONS).toEqual([
+      "verification_failed",
+      "review_rejected",
+      "base_moved_conflict",
+      "budget_exhausted",
+      "policy_denied",
+      "approval_required",
+      "unknown_outcome_effect",
+      "evidence_invalid",
+      "step_retries_exhausted",
     ]);
   });
 });

--- a/runtime/tests/durability/failpoints.test.ts
+++ b/runtime/tests/durability/failpoints.test.ts
@@ -5,8 +5,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   hitM4DurabilityFailpoint,
+  hitM5WorkflowFailpoint,
   M4DurabilityFailpointError,
   M4_DURABILITY_FAILPOINTS,
+  M5WorkflowFailpointError,
+  M5_WORKFLOW_FAILPOINTS,
 } from "../../src/durability/failpoints.js";
 
 describe("M4 durability failpoints", () => {
@@ -64,5 +67,41 @@ describe("M4 durability failpoints", () => {
       "before_terminal_commit",
       "after_terminal_commit",
     ]);
+  });
+});
+
+describe("M5 workflow failpoints", () => {
+  it("publishes the complete pipeline boundary matrix", () => {
+    expect(M5_WORKFLOW_FAILPOINTS).toEqual([
+      "before_intake_commit",
+      "after_intake_commit",
+      "before_worktree_provision",
+      "after_worktree_provision",
+      "after_spawn_before_effect_result",
+      "before_verify_commit",
+      "after_verify_commit",
+      "before_review_commit",
+      "after_review_commit",
+      "before_patch_export",
+      "after_patch_export_before_seal",
+      "after_seal_before_terminal",
+      "after_terminal_before_cleanup",
+    ]);
+  });
+
+  it("is inert without the M5 token and throws with it under the throw action", () => {
+    // The M4 token must NOT arm an M5 boundary.
+    hitM5WorkflowFailpoint("before_intake_commit", {
+      AGENC_TEST_DURABILITY_FAILPOINT: "before_intake_commit",
+      AGENC_TEST_DURABILITY_FAILPOINT_TOKEN: "m4-durability-child",
+      AGENC_TEST_DURABILITY_FAILPOINT_ACTION: "throw",
+    });
+    expect(() =>
+      hitM5WorkflowFailpoint("before_intake_commit", {
+        AGENC_TEST_DURABILITY_FAILPOINT: "before_intake_commit",
+        AGENC_TEST_DURABILITY_FAILPOINT_TOKEN: "m5-workflow-child",
+        AGENC_TEST_DURABILITY_FAILPOINT_ACTION: "throw",
+      }),
+    ).toThrow(M5WorkflowFailpointError);
   });
 });

--- a/runtime/tests/workflow/evidence-record.test.ts
+++ b/runtime/tests/workflow/evidence-record.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  assembleVerifiedChangeRecord,
+  computeSpecDigest,
+  validateVerifiedChangeRecord,
+  VERIFIED_CHANGE_RECORD_KIND,
+  type VerifiedChangeRecord,
+} from "../../src/workflow/evidence-record.js";
+import type {
+  RunArtifactPointer,
+  WorkflowSpec,
+} from "../../src/contracts/run-contracts.js";
+
+const HEX_40 = "a".repeat(40);
+const HEX_64 = "b".repeat(64);
+
+function goldenSpec(): WorkflowSpec {
+  return {
+    runId: "run-golden-1",
+    goal: "Fix the flaky retry counter in the sync worker.",
+    repoPath: "/repo/root",
+    baseCommit: HEX_40,
+    baseDirty: { dirty: false, summaryDigest: `sha256:${HEX_64}`, fileCount: 0 },
+    reviewerModel: "grok-4.5",
+    permissionMode: "acceptEdits",
+    budget: { maxCostUsd: 5 },
+    requiredVerification: [{ label: "unit", script: "npm test" }],
+    maxImplementAttempts: 2,
+  };
+}
+
+function artifact(
+  role: RunArtifactPointer["role"],
+  stepId: string,
+): RunArtifactPointer {
+  return {
+    step: { runId: "run-golden-1", stepId },
+    role,
+    digest: `sha256:${HEX_64}`,
+    bytes: 128,
+    storagePath: `cas://sha256/${HEX_64}`,
+    recordedAt: "2026-07-20T12:00:00Z",
+  };
+}
+
+function goldenInput() {
+  const spec = goldenSpec();
+  return {
+    runId: spec.runId,
+    specDigest: computeSpecDigest(spec),
+    spec,
+    startedAt: "2026-07-20T11:00:00Z",
+    finishedAt: "2026-07-20T12:00:00Z",
+    terminal: {
+      status: "completed" as const,
+      stopReason: null,
+      finalMessage: "Verified change ready for review.",
+    },
+    usage: { inputTokens: 1000, outputTokens: 500, totalTokens: 1500, costUsd: 0.42 },
+    baseCommit: HEX_40,
+    headCommit: HEX_40,
+    steps: [
+      {
+        stepId: "workflow.finalize",
+        stage: "workflow.finalize" as const,
+        status: "committed" as const,
+        attempt: 1,
+        startedAt: "2026-07-20T11:50:00Z",
+        finishedAt: "2026-07-20T12:00:00Z",
+        artifacts: [
+          artifact("patch", "workflow.finalize"),
+          artifact("changed_files", "workflow.finalize"),
+          artifact("test_result", "workflow.verify"),
+          artifact("independent_review", "workflow.review"),
+        ],
+      },
+    ],
+    verificationCommands: [
+      {
+        label: "unit",
+        script: "npm test",
+        exitCode: 0,
+        timedOut: false,
+        truncated: false,
+        durationMs: 12_000,
+        stdoutDigest: `sha256:${HEX_64}` as const,
+        stderrDigest: `sha256:${HEX_64}` as const,
+      },
+    ],
+    review: {
+      reviewerModel: "grok-4.5",
+      overallCorrectness: "correct",
+      overallConfidenceScore: 0.9,
+      blockerCount: 0,
+      findingCount: 1,
+      artifact: artifact("independent_review", "workflow.review"),
+    },
+    unresolvedRisks: [],
+    evidenceLedger: {
+      eventCount: 12,
+      headEventDigest: `sha256:${HEX_64}` as const,
+      sealed: true,
+    },
+  };
+}
+
+describe("verified-change evidence record (M5)", () => {
+  test("golden completed record assembles, self-validates, and is digest-stable", () => {
+    const record = assembleVerifiedChangeRecord(goldenInput());
+    expect(record.kind).toBe(VERIFIED_CHANGE_RECORD_KIND);
+    expect(validateVerifiedChangeRecord(record).valid).toBe(true);
+    // Reassembly of identical input yields an identical digest.
+    expect(assembleVerifiedChangeRecord(goldenInput()).documentDigest).toBe(
+      record.documentDigest,
+    );
+  });
+
+  test("completed without required artifact roles is rejected", () => {
+    const input = goldenInput();
+    const stripped = {
+      ...input,
+      steps: input.steps.map((step) => ({
+        ...step,
+        artifacts: step.artifacts.filter(
+          (candidate) =>
+            candidate.role !== "test_result" &&
+            candidate.role !== "independent_review",
+        ),
+      })),
+    };
+    expect(() => assembleVerifiedChangeRecord(stripped)).toThrow(
+      /missing required artifact role/,
+    );
+  });
+
+  test("completed with an unresolved review blocker is rejected", () => {
+    const input = goldenInput();
+    expect(() =>
+      assembleVerifiedChangeRecord({
+        ...input,
+        review: { ...input.review, blockerCount: 1 },
+      }),
+    ).toThrow(/unresolved review blockers/);
+  });
+
+  test("completed with a failing verification command is rejected", () => {
+    const input = goldenInput();
+    expect(() =>
+      assembleVerifiedChangeRecord({
+        ...input,
+        verificationCommands: [
+          { ...input.verificationCommands[0], exitCode: 1 },
+        ],
+      }),
+    ).toThrow(/failing verification command/);
+  });
+
+  test("completed with an unsealed ledger is rejected", () => {
+    const input = goldenInput();
+    expect(() =>
+      assembleVerifiedChangeRecord({
+        ...input,
+        evidenceLedger: { ...input.evidenceLedger, sealed: false },
+      }),
+    ).toThrow(/sealed evidence ledger/);
+  });
+
+  test("non-completed terminal status requires a machine-readable stopReason", () => {
+    const input = goldenInput();
+    expect(() =>
+      assembleVerifiedChangeRecord({
+        ...input,
+        terminal: { status: "failed", stopReason: null, finalMessage: null },
+      }),
+    ).toThrow(/requires a stopReason/);
+    const failed = assembleVerifiedChangeRecord({
+      ...input,
+      terminal: {
+        status: "failed",
+        stopReason: "verification_failed",
+        finalMessage: "unit tests failed",
+      },
+      review: null,
+      evidenceLedger: { ...input.evidenceLedger, sealed: false },
+      unresolvedRisks: ["unit suite failing on retry counter"],
+    });
+    expect(failed.terminal.stopReason).toBe("verification_failed");
+  });
+
+  test("tampered document digest is detected", () => {
+    const record = assembleVerifiedChangeRecord(goldenInput());
+    const tampered: VerifiedChangeRecord = {
+      ...record,
+      headCommit: "c".repeat(40),
+    };
+    const validation = validateVerifiedChangeRecord(tampered);
+    expect(validation.valid).toBe(false);
+    expect(validation.errors.join(" ")).toMatch(/documentDigest does not match/);
+  });
+
+  test("spec digest binding is enforced", () => {
+    const record = assembleVerifiedChangeRecord(goldenInput());
+    const alteredSpec = {
+      ...record,
+      spec: { ...record.spec, goal: "a different goal entirely" },
+    };
+    const validation = validateVerifiedChangeRecord(alteredSpec);
+    expect(validation.valid).toBe(false);
+    expect(validation.errors.join(" ")).toMatch(/specDigest does not match/);
+  });
+});


### PR DESCRIPTION
Phase 1 of the M5 verified-change workflow (plan: six PR-sized phases, contract freeze first, mirroring the M3/M4 Wave-B discipline). Types/tests only — no engine, no wire surface.

- `run-contracts.ts`: reserve `run.start`; frozen workflow vocabulary (7-stage pipeline ids, linear prerequisites, step statuses, machine-readable stop reasons incl. frozen M5 approval semantics), `WorkflowSpec`, `RunArtifactPointer`.
- `workflow/evidence-record.ts` + JSON schema: `agenc.run.verified-change-record.v1` — new document kind on eval-contract canonical-JSON machinery; assemble self-validates; `completed` mechanically requires patch/changed_files/test_result/independent_review artifacts, zero review blockers, all commands exit 0, sealed ledger, matching digests.
- `durability/failpoints.ts`: additive `M5_WORKFLOW_FAILPOINTS` (13 boundaries, distinct arm token).

## Verification (local, per required-gates)
- typecheck clean; full stable vitest: 1849 files, 16141 passed / 0 failed / 19 skipped
- build + TUI smoke via pre-commit hooks
- Revert-sensitive: contract pins proven red against reverted vocabulary (4 failures on stash, green restored)
- Tested SHA: 59ee5d4e1fc9fa7ae9c9454a1ac281b328be29db