### PR TITLE
feat(workflow): M5 worktree lifecycle + verification/review executors (Phases 2-3/6)

### DIFF
--- a/runtime/src/agents/worktree.ts
+++ b/runtime/src/agents/worktree.ts
@@ -72,8 +72,14 @@ export interface GitResult {
   readonly stderr: string;
 }
 
-/** Run `git <args>` under `cwd`. Does NOT throw; returns a result. */
-function runGit(
+/**
+ * Run `git <args>` under `cwd`. Does NOT throw; returns a result.
+ *
+ * Exported for the M5 worktree-lifecycle library so every workflow git
+ * invocation shares this hardened path (broker spawn, scrubbed child env,
+ * argument hardening, bounded output) instead of growing a second one.
+ */
+export function runGit(
   args: ReadonlyArray<string>,
   cwd: string,
   sandboxExecutionBroker: SandboxExecutionBrokerLike,
@@ -106,7 +112,7 @@ function runGit(
   }));
 }
 
-function runGitMutation(
+export function runGitMutation(
   args: ReadonlyArray<string>,
   cwd: string,
   sandboxExecutionBroker: SandboxExecutionBrokerLike,

--- a/runtime/src/workflow/independent-review.ts
+++ b/runtime/src/workflow/independent-review.ts
@@ -1,0 +1,177 @@
+/**
+ * M5 independent fresh-context review executor.
+ *
+ * Pure library: the reviewer invocation is injected (`ReviewerInvoker`),
+ * which the controller backs with the session one-shot review delegate
+ * (`runAgenCReviewOneShot`) using the spec's PINNED reviewer model, and
+ * tests back with scripts.
+ *
+ * Context hygiene is the load-bearing property: the reviewer prompt is
+ * built HERE, exclusively from the task goal, the exported patch, and the
+ * verification evidence summary. The implementer's conversation never
+ * enters — `buildReviewerMessages` is the single prompt assembly point and
+ * the context-hygiene test locks it.
+ */
+
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+  WorkflowSpec,
+} from "../contracts/run-contracts.js";
+import {
+  parseReviewOutput,
+  REVIEW_SYSTEM_PROMPT,
+  type ReviewOutput,
+} from "../session/review.js";
+import type { VerifiedChangeCommandRecord } from "./evidence-record.js";
+import type { EvidenceArtifactSink } from "./worktree-lifecycle.js";
+import { canonicalizeJson } from "../eval-contract/canonical-json.js";
+
+export interface ReviewerInvoker {
+  invoke(input: {
+    readonly systemPrompt: string;
+    readonly userMessage: string;
+    readonly reviewerModel: string;
+    readonly timeoutMs: number;
+  }): Promise<string>;
+}
+
+export class ReviewParseError extends Error {
+  constructor(detail: string) {
+    super(`independent review output was not parseable: ${detail}`);
+    this.name = "ReviewParseError";
+  }
+}
+
+export const DEFAULT_REVIEW_TIMEOUT_MS = 600_000;
+
+/**
+ * A finding blocks completion when the reviewer marked it high priority
+ * with real confidence. Priority follows the P0/P1 convention (lower is
+ * more severe); the threshold and floor are pinned in the spec digest via
+ * the workflow evidence, not tunable per run after the fact.
+ */
+export const BLOCKER_PRIORITY_THRESHOLD = 1;
+export const BLOCKER_CONFIDENCE_FLOOR = 0.5;
+
+export function extractBlockers(review: ReviewOutput): readonly string[] {
+  const blockers: string[] = [];
+  for (const finding of review.findings) {
+    if (
+      finding.priority <= BLOCKER_PRIORITY_THRESHOLD &&
+      finding.confidenceScore >= BLOCKER_CONFIDENCE_FLOOR
+    ) {
+      blockers.push(finding.title);
+    }
+  }
+  if (review.overallCorrectness.toLowerCase() === "incorrect") {
+    blockers.push(
+      `reviewer overall verdict: incorrect — ${review.overallExplanation.slice(0, 200)}`,
+    );
+  }
+  return blockers;
+}
+
+export interface ReviewerPromptInput {
+  readonly goal: string;
+  readonly patchText: string;
+  readonly changedFilesText: string;
+  readonly verification: readonly VerifiedChangeCommandRecord[];
+  readonly verificationVerdict: string | undefined;
+}
+
+/**
+ * THE single reviewer prompt assembly point. Takes ONLY task + diff +
+ * verification evidence; adding any other parameter is a contract change
+ * the context-hygiene test exists to catch.
+ */
+export function buildReviewerMessages(input: ReviewerPromptInput): {
+  readonly systemPrompt: string;
+  readonly userMessage: string;
+} {
+  const verificationSummary = input.verification
+    .map(
+      (record) =>
+        `- ${record.label}: exit ${record.exitCode}` +
+        `${record.timedOut ? " (timed out)" : ""} in ${record.durationMs}ms`,
+    )
+    .join("\n");
+  const userMessage = [
+    "You are reviewing a proposed code change produced for the task below.",
+    "You have NO other context: judge only what is in this message.",
+    "",
+    "## Task",
+    input.goal,
+    "",
+    "## Changed files",
+    input.changedFilesText.trim() || "(none reported)",
+    "",
+    "## Verification evidence",
+    verificationSummary || "(no commands recorded)",
+    `Adversarial verification verdict: ${input.verificationVerdict ?? "missing"}`,
+    "",
+    "## Unified diff",
+    "```diff",
+    input.patchText,
+    "```",
+    "",
+    "Respond with a single JSON object matching ReviewOutput:",
+    '{"findings":[{"title","body","confidenceScore":0..1,"priority":0..3,',
+    '"codeLocation":{"absolutePath","lineRange":{"start","end"}}}],',
+    '"overallCorrectness":"correct"|"incorrect",',
+    '"overallExplanation":"...","overallConfidenceScore":0..1}',
+    "Priority 0-1 findings are release blockers; reserve them for defects",
+    "that make the change wrong, unsafe, or untested.",
+  ].join("\n");
+  return { systemPrompt: REVIEW_SYSTEM_PROMPT, userMessage };
+}
+
+export interface IndependentReviewResult {
+  readonly review: ReviewOutput;
+  readonly artifact: RunArtifactPointer;
+  readonly blockers: readonly string[];
+}
+
+export async function runIndependentReview(opts: {
+  readonly spec: Pick<WorkflowSpec, "goal" | "reviewerModel">;
+  readonly patchText: string;
+  readonly changedFilesText: string;
+  readonly verification: readonly VerifiedChangeCommandRecord[];
+  readonly verificationVerdict: string | undefined;
+  readonly invoker: ReviewerInvoker;
+  readonly sink: EvidenceArtifactSink;
+  readonly step: RunStepIdentity;
+  readonly timeoutMs?: number;
+}): Promise<IndependentReviewResult> {
+  const prompt = buildReviewerMessages({
+    goal: opts.spec.goal,
+    patchText: opts.patchText,
+    changedFilesText: opts.changedFilesText,
+    verification: opts.verification,
+    verificationVerdict: opts.verificationVerdict,
+  });
+  const raw = await opts.invoker.invoke({
+    systemPrompt: prompt.systemPrompt,
+    userMessage: prompt.userMessage,
+    reviewerModel: opts.spec.reviewerModel,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_REVIEW_TIMEOUT_MS,
+  });
+  const review = parseReviewOutput(raw);
+  // parseReviewOutput's plain-text fallback has this exact shape; a review
+  // that did not produce structured output FAILS the step — it is never
+  // treated as an approval.
+  if (review.overallCorrectness === "" && review.findings.length === 0) {
+    throw new ReviewParseError(
+      `no structured ReviewOutput in reviewer response (${raw.length} chars)`,
+    );
+  }
+  const artifact = await opts.sink.recordArtifact({
+    step: opts.step,
+    role: "independent_review",
+    bytes: new TextEncoder().encode(
+      canonicalizeJson({ review, reviewerModel: opts.spec.reviewerModel }),
+    ),
+    mediaType: "application/json",
+  });
+  return { review, artifact, blockers: extractBlockers(review) };
+}

--- a/runtime/src/workflow/verification.ts
+++ b/runtime/src/workflow/verification.ts
@@ -1,0 +1,169 @@
+/**
+ * M5 verification executor — runs the spec's required verification commands
+ * in the workflow worktree and captures evidence.
+ *
+ * Pure library: command execution is injected (`WorkflowCommandRunner`), so
+ * the controller can back it with the sandbox execution broker and tests
+ * can script it. Capture is PreflightCommandRecord-shaped (full output is
+ * digested; bounded excerpts kept for triage; the complete record set is a
+ * `test_result` artifact in the evidence sink).
+ *
+ * This is the only genuinely parallel stage of the fixed pipeline:
+ * independent commands run concurrently bounded by `parallelism` (the
+ * controller passes the run's admitted session limit).
+ */
+
+import { createHash } from "node:crypto";
+
+import type { RunStepIdentity } from "../contracts/run-contracts.js";
+import type { VerifiedChangeCommandRecord } from "./evidence-record.js";
+import type { EvidenceArtifactSink } from "./worktree-lifecycle.js";
+import { canonicalizeJson } from "../eval-contract/canonical-json.js";
+import type { RunArtifactPointer } from "../contracts/run-contracts.js";
+
+export interface WorkflowCommandResult {
+  readonly exitCode: number;
+  readonly stdout: Uint8Array;
+  readonly stderr: Uint8Array;
+  readonly timedOut: boolean;
+  readonly truncated: boolean;
+  readonly durationMs: number;
+}
+
+export interface WorkflowCommandRunner {
+  run(input: {
+    readonly script: string;
+    readonly cwd: string;
+    readonly timeoutMs: number;
+  }): Promise<WorkflowCommandResult>;
+}
+
+export const DEFAULT_VERIFICATION_TIMEOUT_MS = 900_000;
+const EXCERPT_BYTES = 4_096;
+
+function sha256(bytes: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function excerpt(bytes: Uint8Array): string {
+  return new TextDecoder("utf8", { fatal: false })
+    .decode(bytes.subarray(0, EXCERPT_BYTES))
+    .replace(/�/g, "");
+}
+
+export interface RunRequiredVerificationResult {
+  readonly records: readonly VerifiedChangeCommandRecord[];
+  /** Bounded excerpts per label for diagnostics (not part of the record). */
+  readonly excerpts: Readonly<Record<string, { stdout: string; stderr: string }>>;
+  readonly testResult: RunArtifactPointer;
+  readonly allPassed: boolean;
+}
+
+/**
+ * Run every required verification command; never short-circuits — a later
+ * command's failure evidence is captured even when an earlier one failed.
+ */
+export async function runRequiredVerification(opts: {
+  readonly worktreePath: string;
+  readonly commands: readonly { readonly label: string; readonly script: string }[];
+  readonly runner: WorkflowCommandRunner;
+  readonly sink: EvidenceArtifactSink;
+  readonly step: RunStepIdentity;
+  readonly parallelism: number;
+  readonly timeoutMsPerCommand?: number;
+}): Promise<RunRequiredVerificationResult> {
+  const {
+    worktreePath, commands, runner, sink, step,
+  } = opts;
+  if (commands.length === 0) {
+    throw new Error("required verification demands at least one command");
+  }
+  const labels = new Set<string>();
+  for (const command of commands) {
+    if (labels.has(command.label)) {
+      throw new Error(`duplicate verification label: ${command.label}`);
+    }
+    labels.add(command.label);
+  }
+  const parallelism = Math.max(1, Math.floor(opts.parallelism));
+  const timeoutMs = opts.timeoutMsPerCommand ?? DEFAULT_VERIFICATION_TIMEOUT_MS;
+
+  const records: VerifiedChangeCommandRecord[] = new Array(commands.length);
+  const excerpts: Record<string, { stdout: string; stderr: string }> = {};
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < commands.length) {
+      const index = next;
+      next += 1;
+      const command = commands[index];
+      const startedAt = performance.now();
+      let result: WorkflowCommandResult;
+      try {
+        result = await runner.run({
+          script: command.script,
+          cwd: worktreePath,
+          timeoutMs,
+        });
+      } catch (error) {
+        // A runner crash is a failing command with diagnostic stderr, never
+        // a silently missing record.
+        const message = error instanceof Error ? error.message : String(error);
+        result = {
+          exitCode: 127,
+          stdout: new Uint8Array(0),
+          stderr: new TextEncoder().encode(message),
+          timedOut: false,
+          truncated: false,
+          durationMs: Math.round(performance.now() - startedAt),
+        };
+      }
+      records[index] = {
+        label: command.label,
+        script: command.script,
+        exitCode: result.exitCode,
+        timedOut: result.timedOut,
+        truncated: result.truncated,
+        durationMs: result.durationMs,
+        stdoutDigest: sha256(result.stdout),
+        stderrDigest: sha256(result.stderr),
+      };
+      excerpts[command.label] = {
+        stdout: excerpt(result.stdout),
+        stderr: excerpt(result.stderr),
+      };
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(parallelism, commands.length) }, worker),
+  );
+
+  const testResult = await sink.recordArtifact({
+    step,
+    role: "test_result",
+    bytes: new TextEncoder().encode(canonicalizeJson({ commands: records })),
+    mediaType: "application/json",
+  });
+  const allPassed = records.every(
+    (record) => record.exitCode === 0 && !record.timedOut,
+  );
+  return { records, excerpts, testResult, allPassed };
+}
+
+export type VerificationVerdict = "PASS" | "FAIL" | "PARTIAL";
+
+/**
+ * Parse the adversarial verification agent's terminal `VERDICT:` line
+ * (VERIFICATION_SYSTEM_PROMPT contract). The LAST verdict line wins; a
+ * missing or malformed verdict is `undefined` and callers MUST treat it as
+ * a failure — never as an implicit pass.
+ */
+export function parseVerificationVerdict(
+  text: string,
+): VerificationVerdict | undefined {
+  let verdict: VerificationVerdict | undefined;
+  for (const line of text.split("\n")) {
+    const match = /^\s*VERDICT:\s*(PASS|FAIL|PARTIAL)\b/.exec(line.trim());
+    if (match !== null) verdict = match[1] as VerificationVerdict;
+  }
+  return verdict;
+}

--- a/runtime/src/workflow/worktree-lifecycle.ts
+++ b/runtime/src/workflow/worktree-lifecycle.ts
@@ -1,0 +1,352 @@
+/**
+ * M5 worktree lifecycle — checkout protection and patch integrity for the
+ * verified-change workflow.
+ *
+ * Pure library over `agents/worktree.ts` and the sandbox execution broker.
+ * Invariants it owns:
+ *
+ * - The user's source checkout is NEVER mutated. All agent changes happen in
+ *   the workflow worktree; base-movement checks run in a separate TEMPORARY
+ *   worktree; only worktrees this library created are ever removed.
+ * - The worktree slug is a pure function of the run id, so a crash between
+ *   provisioning and the durable effect commit is recoverable from the run
+ *   id alone (idempotent re-provision fast-resumes the same worktree).
+ * - Patch and changed-file artifacts are exported and content-addressed
+ *   BEFORE any cleanup: `cleanupAfterEvidence` demands the branded proof
+ *   token minted only by the finalize step's sealed evidence ledger, making
+ *   cleanup-before-evidence a compile error, not a code-review catch.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+  WorkflowSpec,
+} from "../contracts/run-contracts.js";
+import {
+  getOrCreateWorktree,
+  removeAgentWorktree,
+  runGit,
+  type WorktreeHandle,
+} from "../agents/worktree.js";
+
+/**
+ * Narrow artifact sink the controller implements over the evidence ledger
+ * (`appendEvidenceEvent` with payload bytes → CAS). Keeping the library
+ * decoupled from ledger ceremony keeps it testable with an in-memory sink.
+ */
+export interface EvidenceArtifactSink {
+  recordArtifact(input: {
+    readonly step: RunStepIdentity;
+    readonly role: RunArtifactPointer["role"];
+    readonly bytes: Uint8Array;
+    readonly mediaType: string;
+  }): Promise<RunArtifactPointer>;
+}
+
+/**
+ * Proof that the run's evidence ledger has been sealed. Only the finalize
+ * step mints this (from `sealEvidenceLedger`); `cleanupAfterEvidence`
+ * requires it.
+ */
+declare const sealedEvidenceProofBrand: unique symbol;
+export interface SealedEvidenceProof {
+  readonly runId: string;
+  readonly sealDigest: string;
+  readonly [sealedEvidenceProofBrand]: true;
+}
+
+/** Minted exclusively by the finalize step after a successful seal. */
+export function mintSealedEvidenceProof(input: {
+  readonly runId: string;
+  readonly sealDigest: string;
+}): SealedEvidenceProof {
+  return {
+    runId: input.runId,
+    sealDigest: input.sealDigest,
+  } as SealedEvidenceProof;
+}
+
+export interface BaseState {
+  readonly baseCommit: string;
+  readonly dirty: boolean;
+  readonly fileCount: number;
+  /** sha256 over the exact `git status --porcelain=v1 -z` output. */
+  readonly summaryDigest: `sha256:${string}`;
+}
+
+export class WorkflowGitError extends Error {
+  readonly operation: string;
+
+  constructor(operation: string, detail: string) {
+    super(`workflow git ${operation} failed: ${detail}`);
+    this.name = "WorkflowGitError";
+    this.operation = operation;
+  }
+}
+
+function sha256Hex(bytes: Uint8Array | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Deterministic worktree slug — a pure function of the run id. */
+export function workflowWorktreeSlug(runId: string): string {
+  const compact = runId.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 12);
+  if (compact.length === 0) {
+    throw new WorkflowGitError("slug", `run id yields an empty slug: ${runId}`);
+  }
+  return `m5-${compact}`;
+}
+
+/**
+ * Record the exact state of the user's checkout before any work begins.
+ * Read-only: two porcelain git reads, nothing else.
+ */
+export async function captureBaseState(
+  gitRoot: string,
+  broker: SandboxExecutionBrokerLike,
+): Promise<BaseState> {
+  const head = await runGit(["rev-parse", "HEAD"], gitRoot, broker);
+  if (head.code !== 0) {
+    throw new WorkflowGitError("rev-parse", head.stderr.trim() || "no HEAD");
+  }
+  const status = await runGit(
+    ["status", "--porcelain=v1", "-z"],
+    gitRoot,
+    broker,
+  );
+  if (status.code !== 0) {
+    throw new WorkflowGitError("status", status.stderr.trim());
+  }
+  const entries = status.stdout.split("\0").filter((line) => line.length > 0);
+  return {
+    baseCommit: head.stdout.trim(),
+    dirty: entries.length > 0,
+    fileCount: entries.length,
+    summaryDigest: `sha256:${sha256Hex(status.stdout)}`,
+  };
+}
+
+/**
+ * Create (or crash-resume) the workflow worktree at the spec's frozen base
+ * commit. Idempotent: the slug is derived from the run id and
+ * `getOrCreateWorktree` fast-resumes an existing worktree.
+ */
+export async function provisionWorkflowWorktree(
+  spec: Pick<WorkflowSpec, "runId" | "repoPath" | "baseCommit">,
+  broker: SandboxExecutionBrokerLike,
+): Promise<WorktreeHandle> {
+  return getOrCreateWorktree({
+    gitRoot: spec.repoPath,
+    slug: workflowWorktreeSlug(spec.runId),
+    base: spec.baseCommit,
+    sandboxExecutionBroker: broker,
+  });
+}
+
+export interface ExportedPatchArtifacts {
+  readonly patch: RunArtifactPointer;
+  readonly changedFiles: RunArtifactPointer;
+  readonly headCommit: string;
+  readonly treeHash: string;
+  readonly patchBytes: Uint8Array;
+}
+
+/**
+ * Commit any uncommitted worktree changes, then export the reviewable patch
+ * and changed-file list into the evidence sink. Re-export of an unchanged
+ * worktree yields byte-identical artifacts (stable digests).
+ */
+export async function exportPatchArtifacts(opts: {
+  readonly handle: WorktreeHandle;
+  readonly baseCommit: string;
+  readonly step: RunStepIdentity;
+  readonly sink: EvidenceArtifactSink;
+  readonly broker: SandboxExecutionBrokerLike;
+}): Promise<ExportedPatchArtifacts> {
+  const { handle, baseCommit, step, sink, broker } = opts;
+  const status = await runGit(["status", "--porcelain"], handle.path, broker);
+  if (status.code !== 0) {
+    throw new WorkflowGitError("status", status.stderr.trim());
+  }
+  if (status.stdout.trim().length > 0) {
+    const add = await runGit(["add", "-A"], handle.path, broker);
+    if (add.code !== 0) throw new WorkflowGitError("add", add.stderr.trim());
+    const commit = await runGit(
+      [
+        "-c", "user.name=agenc-workflow",
+        "-c", "user.email=workflow@agenc.invalid",
+        "commit", "--no-verify", "--allow-empty-message",
+        "-m", "agenc verified-change workflow snapshot",
+      ],
+      handle.path,
+      broker,
+    );
+    if (commit.code !== 0) {
+      throw new WorkflowGitError("commit", commit.stderr.trim());
+    }
+  }
+  const head = await runGit(["rev-parse", "HEAD"], handle.path, broker);
+  if (head.code !== 0) throw new WorkflowGitError("rev-parse", head.stderr.trim());
+  const headCommit = head.stdout.trim();
+  const tree = await runGit(["rev-parse", "HEAD^{tree}"], handle.path, broker);
+  if (tree.code !== 0) throw new WorkflowGitError("rev-parse", tree.stderr.trim());
+
+  // --full-index + no color/ext-diff keeps patch bytes deterministic.
+  const diff = await runGit(
+    ["diff", "--full-index", "--no-color", "--no-ext-diff", `${baseCommit}..HEAD`],
+    handle.path,
+    broker,
+  );
+  if (diff.code !== 0) throw new WorkflowGitError("diff", diff.stderr.trim());
+  const nameStatus = await runGit(
+    ["diff", "--name-status", "--no-color", `${baseCommit}..HEAD`],
+    handle.path,
+    broker,
+  );
+  if (nameStatus.code !== 0) {
+    throw new WorkflowGitError("diff --name-status", nameStatus.stderr.trim());
+  }
+
+  const patchBytes = new TextEncoder().encode(diff.stdout);
+  const patch = await sink.recordArtifact({
+    step,
+    role: "patch",
+    bytes: patchBytes,
+    mediaType: "text/x-patch",
+  });
+  const changedFiles = await sink.recordArtifact({
+    step,
+    role: "changed_files",
+    bytes: new TextEncoder().encode(nameStatus.stdout),
+    mediaType: "text/plain",
+  });
+  return {
+    patch,
+    changedFiles,
+    headCommit,
+    treeHash: tree.stdout.trim(),
+    patchBytes,
+  };
+}
+
+export type BaseMovementCheck =
+  | { readonly kind: "unmoved" }
+  | {
+      /** Patch applies cleanly onto the moved base (3-way, temp worktree). */
+      readonly kind: "rebase_clean";
+      readonly newBaseCommit: string;
+    }
+  | {
+      readonly kind: "conflict";
+      readonly newBaseCommit: string;
+      readonly conflictFiles: readonly string[];
+    };
+
+/**
+ * Detect base movement and classify the patch against the moved base.
+ * All probing happens in a TEMPORARY worktree that is always removed; the
+ * user checkout and the workflow worktree are never touched.
+ */
+export async function checkBaseMovement(opts: {
+  readonly spec: Pick<WorkflowSpec, "runId" | "repoPath" | "baseCommit">;
+  readonly patchBytes: Uint8Array;
+  readonly broker: SandboxExecutionBrokerLike;
+}): Promise<BaseMovementCheck> {
+  const { spec, patchBytes, broker } = opts;
+  const head = await runGit(["rev-parse", "HEAD"], spec.repoPath, broker);
+  if (head.code !== 0) {
+    throw new WorkflowGitError("rev-parse", head.stderr.trim());
+  }
+  const newBaseCommit = head.stdout.trim();
+  if (newBaseCommit === spec.baseCommit) return { kind: "unmoved" };
+  if (patchBytes.byteLength === 0) return { kind: "rebase_clean", newBaseCommit };
+
+  const probeSlug = `${workflowWorktreeSlug(spec.runId)}-rebase`;
+  const probe = await getOrCreateWorktree({
+    gitRoot: spec.repoPath,
+    slug: probeSlug,
+    base: newBaseCommit,
+    sandboxExecutionBroker: broker,
+  });
+  try {
+    const patchPath = `${probe.path}/.agenc-m5-rebase.patch`;
+    const { writeFile, rm } = await import("node:fs/promises");
+    await writeFile(patchPath, patchBytes, { mode: 0o600 });
+    try {
+      // A REAL 3-way apply in the disposable probe worktree is the only
+      // honest classifier: `git apply --3way --check` reports success for
+      // patches that would land with conflict markers. Exit 0 = clean;
+      // anything else = conflict, with unmerged paths enumerated from the
+      // index and the apply error output.
+      const apply = await runGit(
+        ["apply", "--3way", ".agenc-m5-rebase.patch"],
+        probe.path,
+        broker,
+      );
+      if (apply.code === 0) return { kind: "rebase_clean", newBaseCommit };
+      const conflicts = new Set<string>();
+      const diffFiles = await runGit(
+        ["diff", "--name-only", "--diff-filter=U"],
+        probe.path,
+        broker,
+      );
+      for (const file of diffFiles.stdout.split("\n")) {
+        if (file.trim().length > 0) conflicts.add(file.trim());
+      }
+      for (const line of apply.stderr.split("\n")) {
+        const match =
+          /(?:error|warning): (?:patch failed: |could not apply |applied patch to ')?([^':]+?)'?(?::\d+)?(?: does not| with conflicts|: patch does not apply|\.$)/.exec(
+            line,
+          );
+        if (match?.[1] !== undefined && match[1].includes("/")) {
+          conflicts.add(match[1].trim());
+        }
+      }
+      return {
+        kind: "conflict",
+        newBaseCommit,
+        conflictFiles: [...conflicts].sort(),
+      };
+    } finally {
+      await rm(patchPath, { force: true });
+    }
+  } finally {
+    await removeAgentWorktree({
+      gitRoot: spec.repoPath,
+      path: probe.path,
+      branch: probe.branch,
+      sandboxExecutionBroker: broker,
+    });
+  }
+}
+
+/**
+ * Remove the workflow worktree. Only callable with the sealed-evidence
+ * proof (minted by finalize) — patch and artifacts are provably exported
+ * and sealed before any cleanup. Failures are surfaced to `warn`, never
+ * thrown: a leftover worktree is a nuisance, a thrown cleanup after a
+ * sealed run would mask success.
+ */
+export async function cleanupAfterEvidence(opts: {
+  readonly proof: SealedEvidenceProof;
+  readonly handle: WorktreeHandle;
+  readonly broker: SandboxExecutionBrokerLike;
+  readonly warn: (message: string) => void;
+}): Promise<void> {
+  try {
+    await removeAgentWorktree({
+      gitRoot: opts.handle.gitRoot,
+      path: opts.handle.path,
+      branch: opts.handle.branch,
+      sandboxExecutionBroker: opts.broker,
+    });
+  } catch (error) {
+    opts.warn(
+      `workflow worktree cleanup failed after sealed evidence (${opts.proof.sealDigest}): ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/runtime/tests/workflow/independent-review.test.ts
+++ b/runtime/tests/workflow/independent-review.test.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReviewerMessages,
+  extractBlockers,
+  ReviewParseError,
+  runIndependentReview,
+  type ReviewerInvoker,
+} from "../../src/workflow/independent-review.js";
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+} from "../../src/contracts/run-contracts.js";
+import type { EvidenceArtifactSink } from "../../src/workflow/worktree-lifecycle.js";
+import type { VerifiedChangeCommandRecord } from "../../src/workflow/evidence-record.js";
+
+const STEP: RunStepIdentity = { runId: "run-r", stepId: "workflow.review" };
+const HEX = "e".repeat(64);
+
+const COMMANDS: VerifiedChangeCommandRecord[] = [
+  {
+    label: "unit",
+    script: "npm test",
+    exitCode: 0,
+    timedOut: false,
+    truncated: false,
+    durationMs: 900,
+    stdoutDigest: `sha256:${HEX}`,
+    stderrDigest: `sha256:${HEX}`,
+  },
+];
+
+class MemorySink implements EvidenceArtifactSink {
+  readonly artifacts: Array<{ role: string; text: string }> = [];
+
+  async recordArtifact(input: {
+    step: RunStepIdentity;
+    role: RunArtifactPointer["role"];
+    bytes: Uint8Array;
+    mediaType: string;
+  }): Promise<RunArtifactPointer> {
+    const hex = createHash("sha256").update(input.bytes).digest("hex");
+    this.artifacts.push({ role: input.role, text: new TextDecoder().decode(input.bytes) });
+    return {
+      step: input.step,
+      role: input.role,
+      digest: `sha256:${hex}`,
+      bytes: input.bytes.byteLength,
+      storagePath: `cas://sha256/${hex}`,
+      recordedAt: "2026-07-20T12:00:00Z",
+    };
+  }
+}
+
+function reviewJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    findings: [],
+    overallCorrectness: "correct",
+    overallExplanation: "looks right",
+    overallConfidenceScore: 0.8,
+    ...overrides,
+  });
+}
+
+function finding(priority: number, confidenceScore: number, title: string) {
+  return {
+    title,
+    body: "detail",
+    confidenceScore,
+    priority,
+    codeLocation: {
+      absolutePath: "/wt/src/index.ts",
+      lineRange: { start: 1, end: 2 },
+    },
+  };
+}
+
+const SPEC = { goal: "Fix the retry counter.", reviewerModel: "grok-4.5" };
+
+describe("M5 independent review", () => {
+  it("parses a structured review, records the artifact, and extracts no blockers for a clean pass", async () => {
+    const sink = new MemorySink();
+    const invoker: ReviewerInvoker = {
+      invoke: async () => reviewJson({ findings: [finding(2, 0.9, "style nit")] }),
+    };
+    const result = await runIndependentReview({
+      spec: SPEC,
+      patchText: "diff --git a/x b/x",
+      changedFilesText: "M\tsrc/index.ts",
+      verification: COMMANDS,
+      verificationVerdict: "PASS",
+      invoker,
+      sink,
+      step: STEP,
+    });
+    expect(result.blockers).toEqual([]);
+    expect(result.review.findings).toHaveLength(1);
+    expect(sink.artifacts).toEqual([
+      expect.objectContaining({ role: "independent_review" }),
+    ]);
+    expect(sink.artifacts[0].text).toContain('"reviewerModel":"grok-4.5"');
+  });
+
+  it("high-priority high-confidence findings and incorrect verdicts are blockers", () => {
+    expect(
+      extractBlockers({
+        findings: [
+          finding(0, 0.9, "breaks rollback"),
+          finding(1, 0.5, "unguarded null"),
+          finding(1, 0.3, "low confidence guess"),
+          finding(2, 1.0, "important but not blocking"),
+        ],
+        overallCorrectness: "correct",
+        overallExplanation: "",
+        overallConfidenceScore: 0.7,
+      }),
+    ).toEqual(["breaks rollback", "unguarded null"]);
+    expect(
+      extractBlockers({
+        findings: [],
+        overallCorrectness: "incorrect",
+        overallExplanation: "patch does not fix the issue",
+        overallConfidenceScore: 0.9,
+      })[0],
+    ).toMatch(/reviewer overall verdict: incorrect/);
+  });
+
+  it("a free-text (unparseable) reviewer response fails the step — never a silent approval", async () => {
+    const invoker: ReviewerInvoker = {
+      invoke: async () => "LGTM! Great work, ship it.",
+    };
+    await expect(
+      runIndependentReview({
+        spec: SPEC,
+        patchText: "diff",
+        changedFilesText: "",
+        verification: COMMANDS,
+        verificationVerdict: "PASS",
+        invoker,
+        sink: new MemorySink(),
+        step: STEP,
+      }),
+    ).rejects.toThrow(ReviewParseError);
+  });
+
+  it("context hygiene: the invoker receives exactly the assembled prompt and nothing else", async () => {
+    const captured: Array<Record<string, unknown>> = [];
+    const invoker: ReviewerInvoker = {
+      invoke: async (input) => {
+        captured.push({ ...input });
+        return reviewJson();
+      },
+    };
+    const inputs = {
+      spec: SPEC,
+      patchText: "diff --git a/src/index.ts b/src/index.ts\n-41\n+42",
+      changedFilesText: "M\tsrc/index.ts",
+      verification: COMMANDS,
+      verificationVerdict: "PASS" as const,
+    };
+    await runIndependentReview({
+      ...inputs,
+      invoker,
+      sink: new MemorySink(),
+      step: STEP,
+    });
+    expect(captured).toHaveLength(1);
+    // The transport contract is closed: exactly these four fields, so no
+    // future call site can smuggle implementer context alongside them.
+    expect(Object.keys(captured[0]).sort()).toEqual([
+      "reviewerModel", "systemPrompt", "timeoutMs", "userMessage",
+    ]);
+    // And the user message is byte-identical to the single assembly point's
+    // output for the same task+diff+evidence inputs.
+    const expected = buildReviewerMessages({
+      goal: inputs.spec.goal,
+      patchText: inputs.patchText,
+      changedFilesText: inputs.changedFilesText,
+      verification: inputs.verification,
+      verificationVerdict: inputs.verificationVerdict,
+    });
+    expect(captured[0].userMessage).toBe(expected.userMessage);
+    expect(captured[0].systemPrompt).toBe(expected.systemPrompt);
+    expect(String(captured[0].userMessage)).toContain("Fix the retry counter.");
+    expect(String(captured[0].userMessage)).toContain("+42");
+  });
+});

--- a/runtime/tests/workflow/verification.test.ts
+++ b/runtime/tests/workflow/verification.test.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  parseVerificationVerdict,
+  runRequiredVerification,
+  type WorkflowCommandResult,
+  type WorkflowCommandRunner,
+} from "../../src/workflow/verification.js";
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+} from "../../src/contracts/run-contracts.js";
+import type { EvidenceArtifactSink } from "../../src/workflow/worktree-lifecycle.js";
+
+const STEP: RunStepIdentity = { runId: "run-v", stepId: "workflow.verify" };
+
+class MemorySink implements EvidenceArtifactSink {
+  readonly artifacts: Array<{ role: string; text: string }> = [];
+
+  async recordArtifact(input: {
+    step: RunStepIdentity;
+    role: RunArtifactPointer["role"];
+    bytes: Uint8Array;
+    mediaType: string;
+  }): Promise<RunArtifactPointer> {
+    const hex = createHash("sha256").update(input.bytes).digest("hex");
+    this.artifacts.push({
+      role: input.role,
+      text: new TextDecoder().decode(input.bytes),
+    });
+    return {
+      step: input.step,
+      role: input.role,
+      digest: `sha256:${hex}`,
+      bytes: input.bytes.byteLength,
+      storagePath: `cas://sha256/${hex}`,
+      recordedAt: "2026-07-20T12:00:00Z",
+    };
+  }
+}
+
+function ok(stdout = "ok\n"): WorkflowCommandResult {
+  return {
+    exitCode: 0,
+    stdout: new TextEncoder().encode(stdout),
+    stderr: new Uint8Array(0),
+    timedOut: false,
+    truncated: false,
+    durationMs: 5,
+  };
+}
+
+describe("M5 required verification", () => {
+  it("runs every command bounded by parallelism and never short-circuits", async () => {
+    let live = 0;
+    let peak = 0;
+    const seen: string[] = [];
+    const runner: WorkflowCommandRunner = {
+      async run({ script }) {
+        live += 1;
+        peak = Math.max(peak, live);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        live -= 1;
+        seen.push(script);
+        if (script === "exit 1") {
+          return { ...ok(), exitCode: 1, stderr: new TextEncoder().encode("boom") };
+        }
+        return ok(script);
+      },
+    };
+    const sink = new MemorySink();
+    const result = await runRequiredVerification({
+      worktreePath: "/wt",
+      commands: [
+        { label: "a", script: "echo a" },
+        { label: "fails", script: "exit 1" },
+        { label: "b", script: "echo b" },
+        { label: "c", script: "echo c" },
+      ],
+      runner,
+      sink,
+      step: STEP,
+      parallelism: 2,
+    });
+    expect(peak).toBeLessThanOrEqual(2);
+    expect(seen).toHaveLength(4);
+    expect(result.allPassed).toBe(false);
+    expect(result.records.map((record) => record.exitCode)).toEqual([0, 1, 0, 0]);
+    expect(result.records[1].stderrDigest).toBe(
+      `sha256:${createHash("sha256").update("boom").digest("hex")}`,
+    );
+    expect(sink.artifacts).toHaveLength(1);
+    expect(sink.artifacts[0].role).toBe("test_result");
+    expect(sink.artifacts[0].text).toContain('"label":"fails"');
+    expect(result.excerpts.fails.stderr).toBe("boom");
+  });
+
+  it("treats a runner crash as a failing command with diagnostic stderr", async () => {
+    const runner: WorkflowCommandRunner = {
+      async run() {
+        throw new Error("sandbox exploded");
+      },
+    };
+    const result = await runRequiredVerification({
+      worktreePath: "/wt",
+      commands: [{ label: "only", script: "echo hi" }],
+      runner,
+      sink: new MemorySink(),
+      step: STEP,
+      parallelism: 4,
+    });
+    expect(result.allPassed).toBe(false);
+    expect(result.records[0].exitCode).toBe(127);
+    expect(result.excerpts.only.stderr).toContain("sandbox exploded");
+  });
+
+  it("a timed-out command can never pass", async () => {
+    const runner: WorkflowCommandRunner = {
+      async run() {
+        return { ...ok(), timedOut: true };
+      },
+    };
+    const result = await runRequiredVerification({
+      worktreePath: "/wt",
+      commands: [{ label: "hang", script: "sleep 999" }],
+      runner,
+      sink: new MemorySink(),
+      step: STEP,
+      parallelism: 1,
+    });
+    expect(result.allPassed).toBe(false);
+  });
+
+  it("rejects duplicate labels and empty command sets", async () => {
+    const runner: WorkflowCommandRunner = { run: async () => ok() };
+    await expect(
+      runRequiredVerification({
+        worktreePath: "/wt",
+        commands: [],
+        runner,
+        sink: new MemorySink(),
+        step: STEP,
+        parallelism: 1,
+      }),
+    ).rejects.toThrow(/at least one command/);
+    await expect(
+      runRequiredVerification({
+        worktreePath: "/wt",
+        commands: [
+          { label: "dup", script: "a" },
+          { label: "dup", script: "b" },
+        ],
+        runner,
+        sink: new MemorySink(),
+        step: STEP,
+        parallelism: 1,
+      }),
+    ).rejects.toThrow(/duplicate verification label/);
+  });
+});
+
+describe("verification agent verdict parsing", () => {
+  it("parses the terminal VERDICT line, last one winning", () => {
+    expect(parseVerificationVerdict("...\nVERDICT: PASS\n")).toBe("PASS");
+    expect(
+      parseVerificationVerdict("VERDICT: PASS\nre-ran suite\nVERDICT: FAIL"),
+    ).toBe("FAIL");
+    expect(parseVerificationVerdict("  VERDICT: PARTIAL (2 checks skipped)")).toBe(
+      "PARTIAL",
+    );
+  });
+
+  it("a missing or malformed verdict is undefined — callers treat it as failure", () => {
+    expect(parseVerificationVerdict("all good, ship it")).toBeUndefined();
+    expect(parseVerificationVerdict("VERDICT: SHIP")).toBeUndefined();
+    expect(parseVerificationVerdict("the VERDICT: PASS came earlier")).toBeUndefined();
+    expect(parseVerificationVerdict("")).toBeUndefined();
+  });
+});

--- a/runtime/tests/workflow/worktree-lifecycle.test.ts
+++ b/runtime/tests/workflow/worktree-lifecycle.test.ts
@@ -1,0 +1,257 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  captureBaseState,
+  checkBaseMovement,
+  cleanupAfterEvidence,
+  exportPatchArtifacts,
+  mintSealedEvidenceProof,
+  provisionWorkflowWorktree,
+  workflowWorktreeSlug,
+  type EvidenceArtifactSink,
+} from "../../src/workflow/worktree-lifecycle.js";
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+} from "../../src/contracts/run-contracts.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
+
+const broker = explicitDangerBroker;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+function initRepo(repo: string): string {
+  mkdirSync(repo, { recursive: true });
+  git(repo, "init");
+  git(repo, "config", "user.email", "tests@example.com");
+  git(repo, "config", "user.name", "Tests");
+  writeFileSync(join(repo, "README.md"), "hello\n");
+  mkdirSync(join(repo, "src"), { recursive: true });
+  writeFileSync(join(repo, "src", "index.ts"), "export const answer = 41;\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-m", "init");
+  return git(repo, "rev-parse", "HEAD").trim();
+}
+
+/**
+ * Snapshot of the user checkout: HEAD + porcelain status. The
+ * `.agenc-worktrees/` workspace dir is the worktree library's documented
+ * home under the repo root — untracked, never touching tracked content —
+ * so it is excluded from the "checkout untouched" fingerprint.
+ */
+function checkoutFingerprint(repo: string): string {
+  const status = git(repo, "status", "--porcelain=v1")
+    .split("\n")
+    .filter((line) => line.length > 0 && !line.includes(".agenc-worktrees"))
+    .join("\n");
+  return git(repo, "rev-parse", "HEAD") + status;
+}
+
+class MemorySink implements EvidenceArtifactSink {
+  readonly recorded: Array<{ role: string; digest: string; bytes: number }> = [];
+
+  async recordArtifact(input: {
+    step: RunStepIdentity;
+    role: RunArtifactPointer["role"];
+    bytes: Uint8Array;
+    mediaType: string;
+  }): Promise<RunArtifactPointer> {
+    const hex = createHash("sha256").update(input.bytes).digest("hex");
+    const pointer: RunArtifactPointer = {
+      step: input.step,
+      role: input.role,
+      digest: `sha256:${hex}`,
+      bytes: input.bytes.byteLength,
+      storagePath: `cas://sha256/${hex}`,
+      recordedAt: "2026-07-20T12:00:00Z",
+    };
+    this.recorded.push({ role: input.role, digest: pointer.digest, bytes: pointer.bytes });
+    return pointer;
+  }
+}
+
+const STEP: RunStepIdentity = { runId: "conv-m5test01", stepId: "workflow.finalize" };
+
+let work: string;
+const cleanups: Array<() => void> = [];
+
+function tempWork(): string {
+  work = mkdtempSync(join(tmpdir(), "agenc-m5-worktree-"));
+  cleanups.push(() => rmSync(work, { recursive: true, force: true }));
+  return work;
+}
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+describe("M5 worktree lifecycle", () => {
+  it("derives a deterministic slug from the run id alone", () => {
+    expect(workflowWorktreeSlug("conv-m5test01")).toBe("m5-convm5test01".slice(0, 15));
+    expect(workflowWorktreeSlug("conv-m5test01")).toBe(workflowWorktreeSlug("conv-m5test01"));
+    expect(workflowWorktreeSlug("run-A"),).not.toBe(workflowWorktreeSlug("run-B"));
+  });
+
+  it("captures base commit and dirty summary without touching the checkout", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    writeFileSync(join(repo, "uncommitted.txt"), "dirty\n");
+    const before = checkoutFingerprint(repo);
+
+    const state = await captureBaseState(repo, broker);
+    expect(state.baseCommit).toBe(base);
+    expect(state.dirty).toBe(true);
+    expect(state.fileCount).toBe(1);
+    expect(state.summaryDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(checkoutFingerprint(repo)).toBe(before);
+  });
+
+  it("provisions at the frozen base and crash-resumes idempotently", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    // The user moves forward AFTER intake froze the base.
+    writeFileSync(join(repo, "later.txt"), "later\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-m", "user moves on");
+    const before = checkoutFingerprint(repo);
+
+    const spec = { runId: "conv-m5test01", repoPath: repo, baseCommit: base };
+    const first = await provisionWorkflowWorktree(spec, broker);
+    expect(first.created).toBe(true);
+    expect(git(first.path, "rev-parse", "HEAD").trim()).toBe(base);
+
+    // Simulated crash between provision and effect commit: re-provision
+    // resumes the SAME worktree.
+    const second = await provisionWorkflowWorktree(spec, broker);
+    expect(second.created).toBe(false);
+    expect(second.path).toBe(first.path);
+    expect(checkoutFingerprint(repo)).toBe(before);
+  });
+
+  it("exports stable patch artifacts and re-export is byte-identical", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    const before = checkoutFingerprint(repo);
+    const spec = { runId: "conv-m5test01", repoPath: repo, baseCommit: base };
+    const handle = await provisionWorkflowWorktree(spec, broker);
+
+    writeFileSync(join(handle.path, "src", "index.ts"), "export const answer = 42;\n");
+    writeFileSync(join(handle.path, "src", "new-file.ts"), "export const created = true;\n");
+
+    const sink = new MemorySink();
+    const first = await exportPatchArtifacts({
+      handle, baseCommit: base, step: STEP, sink, broker,
+    });
+    expect(first.patch.digest).toMatch(/^sha256:/);
+    expect(first.changedFiles.digest).toMatch(/^sha256:/);
+    expect(new TextDecoder().decode(first.patchBytes)).toContain("answer = 42");
+    expect(first.headCommit).not.toBe(base);
+
+    const again = await exportPatchArtifacts({
+      handle, baseCommit: base, step: STEP, sink: new MemorySink(), broker,
+    });
+    expect(again.patch.digest).toBe(first.patch.digest);
+    expect(again.changedFiles.digest).toBe(first.changedFiles.digest);
+    expect(again.headCommit).toBe(first.headCommit);
+    expect(checkoutFingerprint(repo)).toBe(before);
+
+    // The exported patch applies cleanly to a fresh clone at base.
+    const clone = join(work, "clone");
+    git(work, "clone", repo, "clone");
+    git(clone, "checkout", base);
+    const patchFile = join(work, "exported.patch");
+    writeFileSync(patchFile, first.patchBytes);
+    execFileSync("git", ["apply", patchFile], { cwd: clone });
+  });
+
+  it("detects unmoved base", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    const result = await checkBaseMovement({
+      spec: { runId: "conv-m5test01", repoPath: repo, baseCommit: base },
+      patchBytes: new TextEncoder().encode("anything"),
+      broker,
+    });
+    expect(result).toEqual({ kind: "unmoved" });
+  });
+
+  it("classifies a moved base with a clean 3-way apply", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    const spec = { runId: "conv-m5test01", repoPath: repo, baseCommit: base };
+    const handle = await provisionWorkflowWorktree(spec, broker);
+    writeFileSync(join(handle.path, "src", "index.ts"), "export const answer = 42;\n");
+    const sink = new MemorySink();
+    const exported = await exportPatchArtifacts({
+      handle, baseCommit: base, step: STEP, sink, broker,
+    });
+
+    // Base moves in an UNRELATED file.
+    writeFileSync(join(repo, "README.md"), "hello moved\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-m", "unrelated movement");
+    const before = checkoutFingerprint(repo);
+
+    const result = await checkBaseMovement({
+      spec, patchBytes: exported.patchBytes, broker,
+    });
+    expect(result.kind).toBe("rebase_clean");
+    expect(checkoutFingerprint(repo)).toBe(before);
+  });
+
+  it("classifies a conflicting moved base with the conflicting files", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    const spec = { runId: "conv-m5test01", repoPath: repo, baseCommit: base };
+    const handle = await provisionWorkflowWorktree(spec, broker);
+    writeFileSync(join(handle.path, "src", "index.ts"), "export const answer = 42;\n");
+    const exported = await exportPatchArtifacts({
+      handle, baseCommit: base, step: STEP, sink: new MemorySink(), broker,
+    });
+
+    // Base moves in the SAME line of the SAME file.
+    writeFileSync(join(repo, "src", "index.ts"), "export const answer = 43;\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-m", "conflicting movement");
+    const before = checkoutFingerprint(repo);
+
+    const result = await checkBaseMovement({
+      spec, patchBytes: exported.patchBytes, broker,
+    });
+    expect(result.kind).toBe("conflict");
+    if (result.kind === "conflict") {
+      expect(result.conflictFiles).toContain("src/index.ts");
+    }
+    expect(checkoutFingerprint(repo)).toBe(before);
+  });
+
+  it("cleanup requires the sealed-evidence proof and removes only the workflow worktree", async () => {
+    const repo = join(tempWork(), "repo");
+    const base = initRepo(repo);
+    const spec = { runId: "conv-m5test01", repoPath: repo, baseCommit: base };
+    const handle = await provisionWorkflowWorktree(spec, broker);
+    const before = checkoutFingerprint(repo);
+
+    const warnings: string[] = [];
+    await cleanupAfterEvidence({
+      proof: mintSealedEvidenceProof({
+        runId: spec.runId,
+        sealDigest: `sha256:${"d".repeat(64)}`,
+      }),
+      handle,
+      broker,
+      warn: (message) => warnings.push(message),
+    });
+    expect(warnings).toEqual([]);
+    expect(checkoutFingerprint(repo)).toBe(before);
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(handle.path)).toBe(false);
+  });
+});


### PR DESCRIPTION
Phases 2 and 3 of the M5 verified-change workflow: pure, dependency-injected libraries with no daemon wiring (the Phase 4 controller drives them).

**Phase 2 — `workflow/worktree-lifecycle.ts`:** deterministic run-id-derived slugs (crash-resumable), read-only base capture (commit + dirty digest), byte-stable patch/changed-files export through an `EvidenceArtifactSink` seam, base-movement classification via a REAL `git apply --3way` in a disposable probe worktree (`--check` reports success for conflicting patches — proven red in development), cleanup gated on a branded `SealedEvidenceProof` (cleanup-before-evidence is a compile error). Exports `runGit`/`runGitMutation` from `agents/worktree.ts` so workflow git shares the one hardened path.

**Phase 3 — `workflow/verification.ts` + `workflow/independent-review.ts`:** bounded-parallel required-command execution with PreflightCommandRecord-shaped capture (no short-circuit; runner crash = exit-127 record), `VERDICT:` parsing (missing = failure), single-point reviewer prompt assembly from task+diff+evidence only, blocker extraction, `ReviewParseError` on unparseable reviews.

## Verification (local)
- typecheck clean; full stable vitest green over the branch tip (exit 0, ~16.1k tests)
- 26 workflow tests incl. real-git-repo scenarios with checkout-untouched fingerprints and the context-hygiene transport lock
- Conflict-classifier revert-sensitivity proven during development (test red against the `--check` implementation)
- Tested SHA: 57f76a4b36082ba2885d94217ed4bb415bcdffeb