### PR TITLE
feat(workflow): M5 verified-change workflow controller (Phase 4/6)

### DIFF
--- a/docs/design/verified-change-workflow-m5.md
+++ b/docs/design/verified-change-workflow-m5.md
@@ -1,0 +1,137 @@
+# The Verified-Change Workflow (M5)
+
+The verified-change workflow is AgenC's fixed pipeline for producing a
+review-ready, evidence-backed patch from an engineering goal:
+
+```
+intake + policy check
+  -> isolated worktree
+  -> inspect and plan
+  -> implement
+  -> run targeted and required verification
+  -> independent fresh-context review
+  -> finalize evidence and patch
+```
+
+It is deliberately one workflow, not a workflow engine. The pipeline shape,
+step vocabulary, statuses, and stop reasons are frozen in
+`runtime/src/contracts/run-contracts.ts` (`WORKFLOW_STEP_IDS`,
+`WORKFLOW_STEP_PREREQUISITES`, `WORKFLOW_STEP_STATUSES`,
+`WORKFLOW_STOP_REASONS`); a general DAG engine is out of contract.
+
+## One run, one spine
+
+A workflow run is an ordinary daemon agent run: `run.start` registers a root
+run (durable `agent_runs` row, lifecycle epoch, canonical rollout journal),
+and every surface addresses it by the same durable `RunId` through the
+existing `run.*` method family — `status`, `result`, `replay`, `evidence`,
+`cancel` all work unchanged.
+
+There is no workflow database. Durable facts live where M3/M4 already put
+them:
+
+| Fact | Where it lives |
+|---|---|
+| The frozen `WorkflowSpec` | the `workflow.intake` effect's evidence (canonical JSON; its digest is the intake intent digest) |
+| Step state, attempts, dependencies | projection of `run_effects` rows (`workflow.<stage>` step ids; retries append `#<attempt>`) |
+| Worktree pointer | deterministic slug `m5-<runId[0:12]>` + the `workflow.worktree` effect evidence |
+| Artifact pointers | producing step's effect evidence + the run's evidence ledger (`cas://sha256/...`) |
+| Budget holds / reconciliation | the M3 admission journal and reservation tables |
+| Terminal status | the immutable `run_terminal_results` record |
+
+## Step semantics and recovery
+
+Every step passes through the same durable driver: admission `acquire` →
+`effect_intent` journaled under the rollout lease → dispatch at the correct
+boundary → execute → `effect_result` → budget reconcile. Crash-injection
+hooks (`M5_WORKFLOW_FAILPOINTS`) sit at every commit boundary.
+
+Effect classification drives restart recovery:
+
+- **Idempotent steps** (intake, worktree provisioning, verification
+  commands, finalize) carry content-derived idempotency keys (spec digest,
+  `slug@baseCommit`, `sha256(script+treeHash)`,
+  `sha256(patchDigest+baseCommit)`). On resume they re-execute under the
+  same key; the durability layer replays the intent as a no-op.
+- **Side-effecting steps** (plan, implement, the adversarial verification
+  agent, review — all agent spawns) are **adopted, never respawned**: resume
+  looks up the recorded child run; a terminal child completes the parent
+  effect from its durable result, a live child is re-awaited, an unknowable
+  child marks the effect `unknown_outcome` and the run terminates
+  `unknown_outcome` with review pending. No mutation is ever silently
+  replayed.
+
+Dependency unlocks stop on failed verification, cancellation, budget
+exhaustion, and `unknown_outcome` — enforced first by the controller's
+prerequisite gate, and structurally by the durability layer (the
+unknown-outcome mutation gate and the terminal-epoch refusal in
+`beginEffect`).
+
+A failed verification earns one bounded re-implement attempt
+(`workflow.implement#2`, fresh verify sub-steps) when the spec's
+`maxImplementAttempts` and remaining budget allow; otherwise the run
+terminates `failed/verification_failed`.
+
+## Checkout protection
+
+The user's checkout is recorded (exact base commit + a digest of the dirty
+state) at intake and never touched afterward. All agent changes happen in
+the workflow worktree; the reviewable patch and changed-file list are
+exported and content-addressed into the evidence ledger BEFORE any cleanup —
+`cleanupAfterEvidence` requires the branded proof token minted only by a
+sealed ledger, so cleanup-before-evidence cannot compile.
+
+Base movement is detected against the frozen base commit and classified by a
+real `git apply --3way` in a disposable probe worktree (never the checkout):
+`unmoved`, `rebase_clean`, or `conflict` with the conflicting files —
+surfaced explicitly, never overwritten.
+
+## Verification and review are completion, not metadata
+
+`completed` is computed at one choke point and requires, mechanically:
+
+- every required verification command exited 0 (captured with exit codes,
+  durations, and output digests),
+- the adversarial verification agent's terminal `VERDICT: PASS` (a missing
+  or malformed verdict is a failure, never an implicit pass),
+- an independent review with zero blockers, produced in a fresh context that
+  saw ONLY the task, the diff, and the verification evidence — the
+  implementer's conversation cannot reach the reviewer by construction, and
+  the reviewer model is pinned in the spec at intake,
+- a self-validated `agenc.run.verified-change-record.v1` evidence document
+  (schema + digests + required artifacts) and a sealed, hash-chained
+  evidence ledger.
+
+Anything else terminates `failed`, `cancelled`, or `unknown_outcome` with a
+machine-readable stop reason from `WORKFLOW_STOP_REASONS`. Non-blocking
+reviewer findings are preserved as a `risk_register` artifact and in the
+terminal message — surfaced honestly, never converted into success text.
+
+## Approvals (M5 semantics, frozen)
+
+The intake step resolves approvals up front: a spec that would require
+interactive approval under the declared policy is rejected before any work
+or spend. If a mid-pipeline admission still returns `approval_required`, the
+run terminates `failed/approval_required`. There is no approval-parking
+subsystem in M5; upgrading that to a parked-and-resumable step is an
+explicit future contract change.
+
+## Surfaces
+
+- CLI: `agenc run start --goal <text> [--cwd] [--model] [--reviewer-model]
+  [--max-cost] [--permission-mode] [--verify "label=script"]... [--json]
+  [--follow]`; `agenc run status` renders the step table; `agenc run
+  evidence` exports the machine-readable bundle.
+- SDK: `client.startRun(params)`; attach/replay/result/evidence by run id
+  with the existing cursor contract.
+- TUI: the run appears on the agents rail like any daemon-owned run.
+
+## Evidence bundle
+
+`agenc run evidence <run-id>` exports the verified-change record and the
+ledger artifact set alongside the existing admission evidence. The bundle is
+self-contained: hash chain, per-command records, patch and changed-file
+digests, review output, spec digest, terminal status, and unresolved risks
+are all re-derivable and re-verifiable from the exported bytes alone —
+reconstructing what happened requires no daemon, no SQLite, and no trust in
+the final prose summary.

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -7,6 +7,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { createDaemonWorkflowController } from "./workflow/daemon-wiring.js";
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync } from "node:fs";
 import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection, isIP } from "node:net";
@@ -1630,6 +1631,27 @@ async function runAgenCDaemonForeground(
         }),
     },
   );
+  // M5 verified-change workflow controller (Phase 4). Constructed over the
+  // shared admission kernel + durable state; open workflow runs are resumed
+  // (D3 recovery) after admission recovery and startup journal recovery so
+  // adopted/re-executed effects observe fully recovered budget state. The
+  // run.start dispatcher and session-backed seams land in Phase 5; until
+  // then resume warn-skips runs it cannot drive without touching their
+  // durable state (see workflow/daemon-wiring.ts).
+  const workflowWiring = createDaemonWorkflowController({
+    agencHome: authStartup.daemonHome,
+    primaryCwd,
+    kernel: executionAdmissionKernel,
+    warn: (message) => io.stderr.write(`agenc: ${message}\n`),
+  });
+  cleanup.register("daemon-workflow-controller", () => {
+    workflowWiring.close();
+  });
+  void workflowWiring.controller.resumeOpenWorkflows().catch((error) => {
+    io.stderr.write(
+      `agenc: workflow startup recovery failed: ${formatCleanupError(error)}\n`,
+    );
+  });
   const health = new AgenCDaemonHealthService({
     sessionCounter: sessionManager,
     stateCounter: new StateSqliteHealthStatsReader(

--- a/runtime/src/app-server/workflow/daemon-wiring.ts
+++ b/runtime/src/app-server/workflow/daemon-wiring.ts
@@ -1,0 +1,372 @@
+/**
+ * M5 Phase 4 — daemon-side wiring for the verified-change workflow
+ * controller.
+ *
+ * Wires the seams that are clean to back today:
+ *   - the REAL durability repository (daemon-home + primary-cwd state DB),
+ *   - the REAL execution-admission kernel (`bindClient` per workflow run),
+ *   - a REAL per-run evidence ledger over the eval-contract ledger
+ *     (`<agencHome>/run-evidence/<runId>/`, `artifact.recorded` events,
+ *     local integrity-only anchoring).
+ *
+ * TODO(M5 Phase 5 — run.start dispatcher): the session-coupled seams
+ * (rollout-journal writer, plan/implement/verify-agent spawner, reviewer
+ * invoker, sandbox-brokered worktree/command execution) must be backed by a
+ * `bootstrapLocalRuntimeSession`-owned daemon session, exactly as
+ * `app-server/background-agent-runner.ts` owns its bootstrap. Until that
+ * dispatcher lands they throw {@link WorkflowSeamPendingError}; the
+ * controller itself is complete and fully tested through injected seams,
+ * and `resumeOpenWorkflows()` warn-skips any run it cannot yet drive
+ * (durable state is left untouched for the Phase 5 daemon to resume).
+ */
+
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import * as path from "node:path";
+
+import type { ExecutionAdmissionKernel } from "../../budget/execution-admission-kernel.js";
+import {
+  appendEvidenceEvent,
+  EvidenceLedgerError,
+  initializeEvidenceLedger,
+  inspectEvidenceLedger,
+  sealEvidenceLedger,
+  type EvidenceAnchorProvider,
+} from "../../eval-contract/evidence-ledger.js";
+import { sha256Digest } from "../../eval-contract/canonical-json.js";
+import { canonicalizeJson } from "../../eval-contract/canonical-json.js";
+import type { Sha256Digest } from "../../eval-contract/types.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../state/sqlite-driver.js";
+import { StateRunDurabilityRepository } from "../../state/run-durability.js";
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+  WorkflowSpec,
+} from "../../contracts/run-contracts.js";
+import { computeSpecDigest } from "../../workflow/evidence-record.js";
+import {
+  VerifiedChangeWorkflowController,
+  type WorkflowEvidenceLedger,
+} from "./verified-change-controller.js";
+
+/** A workflow seam whose daemon adapter lands with the Phase 5 dispatcher. */
+export class WorkflowSeamPendingError extends Error {
+  constructor(readonly seam: string) {
+    super(
+      `verified-change workflow seam "${seam}" is not wired yet ` +
+        "(lands with the M5 Phase 5 run.start dispatcher)",
+    );
+    this.name = "WorkflowSeamPendingError";
+  }
+}
+
+const WORKFLOW_TASK_ID = "verified-change";
+const WORKFLOW_SYSTEM_ID = "agenc.workflow.m5";
+const WORKFLOW_PRODUCER = {
+  identity: "agenc-daemon-workflow",
+  version: "1",
+  binaryDigest: sha256Digest("agenc-daemon-workflow.v1"),
+} as const;
+const REDACTION_POLICY_DIGEST = sha256Digest(
+  "agenc.workflow.m5.no-redaction.v1",
+);
+
+function sanitizeIdentifierPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._:-]/g, "-");
+}
+
+/**
+ * Integrity-only local anchor for the per-run workflow evidence ledger.
+ * Keyed by a per-daemon-home secret so a seal cannot be silently reforged
+ * by editing ledger files, but NOT externally anchored — external anchoring
+ * remains an explicit later concern.
+ */
+async function loadLocalAnchorProvider(
+  evidenceRoot: string,
+): Promise<EvidenceAnchorProvider> {
+  await mkdir(evidenceRoot, { recursive: true, mode: 0o700 });
+  const secretPath = path.join(evidenceRoot, "local-anchor-secret");
+  let secret: Uint8Array;
+  try {
+    secret = await readFile(secretPath);
+  } catch {
+    secret = randomBytes(32);
+    await writeFile(secretPath, secret, { mode: 0o600, flag: "wx" }).catch(
+      async () => {
+        secret = await readFile(secretPath);
+      },
+    );
+  }
+  const anchorPolicyDigest = sha256Digest("agenc.workflow.m5.local-anchor.v1");
+  const verifierDigest = sha256Digest("agenc.workflow.m5.local-anchor-verifier.v1");
+  const verificationMaterialDigest = sha256Digest(secret);
+  const signatureFor = (bytes: Uint8Array): Sha256Digest => {
+    const joined = new Uint8Array(secret.byteLength + bytes.byteLength);
+    joined.set(secret, 0);
+    joined.set(bytes, secret.byteLength);
+    return sha256Digest(joined);
+  };
+  return {
+    anchorPolicyDigest,
+    verifierDigest,
+    async anchor(statementBytes, statementDigest) {
+      return {
+        statementDigest,
+        anchorPolicyDigest,
+        signatureAlgorithm: "ed25519",
+        signatureDigest: signatureFor(statementBytes),
+        verificationMaterialDigest,
+        anchorUri: `local://agenc-daemon/${statementDigest.slice("sha256:".length)}`,
+        signerIdentity: "agenc-daemon-local-anchor",
+      };
+    },
+    verify(statementBytes, receipt) {
+      return (
+        receipt.signatureDigest === signatureFor(statementBytes) &&
+        receipt.verificationMaterialDigest === verificationMaterialDigest
+      );
+    },
+  };
+}
+
+/**
+ * Real per-run workflow evidence ledger over the eval-contract ledger.
+ * Artifacts are `artifact.recorded` events with the payload bytes in the
+ * ledger's CAS; append and seal are crash-idempotent (dedupe by derived
+ * event id; seal reuses a persisted `sealedAt` and the ledger's stored
+ * seal recovery).
+ */
+export function createDaemonWorkflowEvidenceLedgerFactory(options: {
+  readonly agencHome: string;
+}): (spec: WorkflowSpec) => Promise<WorkflowEvidenceLedger> {
+  const evidenceRoot = path.join(options.agencHome, "run-evidence");
+  return async (spec: WorkflowSpec): Promise<WorkflowEvidenceLedger> => {
+    const root = path.join(evidenceRoot, sanitizeIdentifierPart(spec.runId));
+    await mkdir(root, { recursive: true, mode: 0o700 });
+    const access = { root };
+    const context = {
+      runId: spec.runId,
+      contractDigest: computeSpecDigest(spec),
+      taskId: WORKFLOW_TASK_ID,
+      systemId: WORKFLOW_SYSTEM_ID,
+    };
+    try {
+      await initializeEvidenceLedger(access, spec.runId);
+    } catch (error) {
+      if (
+        !(error instanceof EvidenceLedgerError) ||
+        error.code !== "EVIDENCE_ALREADY_EXISTS"
+      ) {
+        throw error;
+      }
+    }
+    let inspection = await inspectEvidenceLedger(access, spec.runId);
+    const state = {
+      eventCount: inspection.eventCount,
+      headEventDigest:
+        inspection.headEventDigest ?? sha256Digest("empty-ledger"),
+      sealed: inspection.terminal,
+      lastOccurredAt:
+        inspection.events.at(-1)?.occurredAt ?? new Date(0).toISOString(),
+      knownEvents: new Map(
+        inspection.events.map((event) => [event.eventId, event]),
+      ),
+    };
+    const nextOccurredAt = (): string => {
+      const now = new Date().toISOString();
+      return now >= state.lastOccurredAt ? now : state.lastOccurredAt;
+    };
+    const append = async (input: {
+      eventId: string;
+      type: "run.started" | "artifact.recorded";
+      mediaType: string;
+      payloadBytes: Uint8Array;
+    }) => {
+      const known = state.knownEvents.get(input.eventId);
+      if (known !== undefined) return known;
+      const result = await appendEvidenceEvent({
+        ...access,
+        event: {
+          ...context,
+          eventId: input.eventId,
+          occurredAt: nextOccurredAt(),
+          producer: WORKFLOW_PRODUCER,
+          type: input.type,
+          mediaType: input.mediaType,
+          redactionPolicyDigest: REDACTION_POLICY_DIGEST,
+        },
+        payloadBytes: input.payloadBytes,
+      });
+      state.knownEvents.set(result.event.eventId, result.event);
+      if (result.status === "appended") {
+        state.eventCount += 1;
+        state.headEventDigest = result.event.eventDigest;
+        state.lastOccurredAt = result.event.occurredAt;
+      }
+      return result.event;
+    };
+    if (state.eventCount === 0) {
+      await append({
+        eventId: "run.started",
+        type: "run.started",
+        mediaType: "application/json",
+        payloadBytes: new TextEncoder().encode(canonicalizeJson(spec)),
+      });
+    }
+    const sealedAtPath = path.join(root, "workflow-sealed-at");
+    return {
+      async recordArtifact(input: {
+        readonly step: RunStepIdentity;
+        readonly role: RunArtifactPointer["role"];
+        readonly bytes: Uint8Array;
+        readonly mediaType: string;
+      }): Promise<RunArtifactPointer> {
+        const digest = sha256Digest(input.bytes);
+        const hex = digest.slice("sha256:".length);
+        const eventId = sanitizeIdentifierPart(
+          `artifact.${input.step.stepId}.${input.role}.${hex.slice(0, 24)}`,
+        );
+        const event = await append({
+          eventId,
+          type: "artifact.recorded",
+          mediaType: input.mediaType,
+          payloadBytes: input.bytes,
+        });
+        return {
+          step: input.step,
+          role: input.role,
+          digest: digest as `sha256:${string}`,
+          bytes: input.bytes.byteLength,
+          storagePath: event.payload.uri,
+          recordedAt: event.occurredAt,
+        };
+      },
+      head() {
+        return {
+          eventCount: state.eventCount,
+          headEventDigest: state.headEventDigest,
+          sealed: state.sealed,
+        };
+      },
+      async readArtifact(pointer: RunArtifactPointer): Promise<Uint8Array> {
+        const hex = pointer.digest.slice("sha256:".length);
+        for (const entry of await readdir(root)) {
+          if (!entry.endsWith(".payloads")) continue;
+          return readFile(path.join(root, entry, `sha256-${hex}.bin`));
+        }
+        throw new Error(`workflow evidence payload not found: ${pointer.digest}`);
+      },
+      async seal(sealedAt: string): Promise<{ sealDigest: string }> {
+        // Reuse the first chosen sealedAt so a crash-resumed seal converges
+        // on the identical frozen statement.
+        let effectiveSealedAt = sealedAt;
+        try {
+          effectiveSealedAt = (await readFile(sealedAtPath, "utf8")).trim();
+        } catch {
+          await writeFile(sealedAtPath, `${sealedAt}\n`, { mode: 0o600 });
+        }
+        const anchorProvider = await loadLocalAnchorProvider(evidenceRoot);
+        const seal = await sealEvidenceLedger({
+          ...access,
+          context,
+          sealedAt: effectiveSealedAt,
+          anchorProvider,
+        });
+        state.sealed = true;
+        inspection = await inspectEvidenceLedger(access, spec.runId);
+        state.eventCount = inspection.eventCount;
+        state.headEventDigest =
+          inspection.headEventDigest ?? state.headEventDigest;
+        return { sealDigest: seal.sealDigest };
+      },
+      async persistRecord(record): Promise<void> {
+        await writeFile(
+          path.join(root, "verified-change-record.json"),
+          `${canonicalizeJson(record)}\n`,
+          { mode: 0o600 },
+        );
+      },
+    };
+  };
+}
+
+export interface DaemonWorkflowWiring {
+  readonly controller: VerifiedChangeWorkflowController;
+  close(): void;
+}
+
+export function createDaemonWorkflowController(options: {
+  readonly agencHome: string;
+  readonly primaryCwd: string;
+  readonly kernel: ExecutionAdmissionKernel;
+  readonly warn: (message: string) => void;
+}): DaemonWorkflowWiring {
+  let driver: StateSqliteDriver | undefined;
+  let repository: StateRunDurabilityRepository | undefined;
+  const durability = (): StateRunDurabilityRepository => {
+    if (repository === undefined) {
+      driver = openStateDatabases({
+        cwd: options.primaryCwd,
+        agencHome: options.agencHome,
+      });
+      repository = new StateRunDurabilityRepository(driver);
+    }
+    return repository;
+  };
+  const pending = (seam: string): never => {
+    throw new WorkflowSeamPendingError(seam);
+  };
+  const controller = new VerifiedChangeWorkflowController({
+    durability,
+    admission: ({ runId, sessionId, workspaceId, spec }) =>
+      options.kernel.bindClient({
+        cwd: spec.repoPath,
+        budgetIdentity: runId,
+        ...(workspaceId !== undefined ? { workspaceId } : {}),
+        scope: {
+          runId,
+          sessionId,
+          autonomous: true,
+          ...(spec.budget.maxCostUsd !== undefined
+            ? { maxCostUsd: spec.budget.maxCostUsd, hasHardCostCap: true }
+            : {}),
+          ...(spec.budget.maxTokens !== undefined
+            ? { maxTokens: spec.budget.maxTokens, hasHardTokenCap: true }
+            : {}),
+          ...(spec.budget.deadlineAt !== undefined
+            ? { deadlineAt: spec.budget.deadlineAt }
+            : {}),
+        },
+      }),
+    evidenceLedger: createDaemonWorkflowEvidenceLedgerFactory({
+      agencHome: options.agencHome,
+    }),
+    // -- Phase 5 session seams (see the module TODO above). -----------------
+    journal: { open: async () => pending("journal") },
+    worktrees: {
+      captureBaseState: async () => pending("worktrees.captureBaseState"),
+      provision: async () => pending("worktrees.provision"),
+      exportPatch: async () => pending("worktrees.exportPatch"),
+      checkBaseMovement: async () => pending("worktrees.checkBaseMovement"),
+      cleanup: async () => pending("worktrees.cleanup"),
+    },
+    commands: { run: async () => pending("commands.run") },
+    spawner: {
+      spawn: async () => pending("spawner.spawn"),
+      inspect: async () => pending("spawner.inspect"),
+    },
+    reviewer: { invoke: async () => pending("reviewer.invoke") },
+    warn: options.warn,
+  });
+  return {
+    controller,
+    close: () => {
+      driver?.close();
+      driver = undefined;
+      repository = undefined;
+    },
+  };
+}

--- a/runtime/src/app-server/workflow/status-projection.ts
+++ b/runtime/src/app-server/workflow/status-projection.ts
@@ -1,0 +1,127 @@
+/**
+ * M5 Phase 4 — pure workflow status projection.
+ *
+ * `run_effects` rows plus the durable terminal record ARE the workflow's
+ * step state (D2: no parallel state store). This module folds them into the
+ * `RunStatusResult.workflow` shape the daemon's `run.status` method serves:
+ * one entry per fixed pipeline stage with attempt counts, machine verdicts,
+ * and content-addressed artifact pointers.
+ */
+
+import {
+  WORKFLOW_STEP_IDS,
+  WORKFLOW_STEP_PREREQUISITES,
+  WORKFLOW_STOP_REASONS,
+  type RunArtifactPointer,
+  type RunTerminalStatus,
+  type WorkflowStepId,
+  type WorkflowStepStatus,
+  type WorkflowStopReason,
+} from "../../contracts/run-contracts.js";
+import type {
+  DurableRunEffect,
+  DurableRunTerminalRecord,
+} from "../../state/run-durability.js";
+import { deriveAllStageProjections } from "./steps.js";
+
+export interface WorkflowStatusStep {
+  readonly stepId: string;
+  readonly stage: WorkflowStepId;
+  readonly status: WorkflowStepStatus;
+  readonly attempts: number;
+  readonly verdict?: string;
+  readonly artifacts?: readonly RunArtifactPointer[];
+}
+
+export interface WorkflowRunStatus {
+  readonly runId: string;
+  readonly steps: readonly WorkflowStatusStep[];
+  readonly terminal?: {
+    readonly status: RunTerminalStatus;
+    readonly stopReason: string | null;
+    readonly finalMessage: string | null;
+    readonly finishedAt: string;
+  };
+  /** Present when the run terminated with a frozen workflow stop reason. */
+  readonly stopReason?: WorkflowStopReason;
+}
+
+const BAD_STAGE_STATUSES: readonly WorkflowStepStatus[] = [
+  "failed",
+  "cancelled",
+  "unknown_outcome",
+  "blocked",
+];
+
+/**
+ * Fold durable rows + terminal record into the workflow status shape.
+ *
+ * `blocked` derivation: a stage that never began is `blocked` (never
+ * `pending`) once the run is terminal, or once a prerequisite stage is in a
+ * terminally-bad state while the run is terminal. While the run is still
+ * live, a not-yet-started stage stays `pending` — a failed prerequisite may
+ * still be retried under a new attempt id.
+ */
+export function projectWorkflowStatus(input: {
+  readonly runId: string;
+  readonly effects: readonly DurableRunEffect[];
+  readonly terminal?: DurableRunTerminalRecord;
+}): WorkflowRunStatus {
+  const projections = deriveAllStageProjections(input.effects);
+  const steps: WorkflowStatusStep[] = [];
+  for (const stage of WORKFLOW_STEP_IDS) {
+    const projection = projections.get(stage)!;
+    let status = projection.status;
+    if (status === "pending" && input.terminal !== undefined) {
+      const prerequisitesBad = WORKFLOW_STEP_PREREQUISITES[stage].some(
+        (prerequisite) => {
+          const parent = projections.get(prerequisite)!;
+          return (
+            BAD_STAGE_STATUSES.includes(parent.status) ||
+            parent.status === "pending" ||
+            (parent.status === "committed" && parent.verdictPassed === false)
+          );
+        },
+      );
+      status =
+        input.terminal.status === "completed" && !prerequisitesBad
+          ? "pending"
+          : "blocked";
+    }
+    steps.push({
+      stepId: projection.latestStepId,
+      stage,
+      status,
+      attempts: projection.attempts,
+      ...(projection.verdict !== undefined
+        ? { verdict: projection.verdict }
+        : {}),
+      ...(projection.artifacts.length > 0
+        ? { artifacts: projection.artifacts }
+        : {}),
+    });
+  }
+  const stopReason =
+    input.terminal?.stopReason !== undefined &&
+    input.terminal?.stopReason !== null &&
+    (WORKFLOW_STOP_REASONS as readonly string[]).includes(
+      input.terminal.stopReason,
+    )
+      ? (input.terminal.stopReason as WorkflowStopReason)
+      : undefined;
+  return {
+    runId: input.runId,
+    steps,
+    ...(input.terminal !== undefined
+      ? {
+          terminal: {
+            status: input.terminal.status,
+            stopReason: input.terminal.stopReason,
+            finalMessage: input.terminal.finalMessage,
+            finishedAt: input.terminal.finishedAt,
+          },
+        }
+      : {}),
+    ...(stopReason !== undefined ? { stopReason } : {}),
+  };
+}

--- a/runtime/src/app-server/workflow/steps.ts
+++ b/runtime/src/app-server/workflow/steps.ts
@@ -1,0 +1,368 @@
+/**
+ * M5 Phase 4 — pure step-id and projection helpers for the verified-change
+ * workflow controller.
+ *
+ * Everything in this module is a pure function over the frozen contract
+ * vocabulary (`WORKFLOW_STEP_IDS`) and durable `run_effects` rows. The
+ * controller and the status projection both derive step/stage state from
+ * here so there is exactly one interpretation of the durable rows.
+ *
+ * Step-id grammar (frozen in contracts/run-contracts.ts):
+ *   - `workflow.<stage>`            first attempt of a pipeline stage
+ *   - `workflow.<stage>#N`          Nth attempt (N >= 2); run_effects
+ *                                   outcomes are sticky per (run_id, step_id),
+ *                                   so a retried stage always gets a NEW id.
+ *   - `workflow.verify.cmd.<i>`     verification command fan-out (1-based)
+ *   - `workflow.verify.agent`       the adversarial verification agent spawn
+ *   both verify forms accept the same `#N` attempt suffix.
+ */
+
+import { createHash } from "node:crypto";
+
+import {
+  WORKFLOW_STEP_IDS,
+  WORKFLOW_STEP_PREREQUISITES,
+  type RunArtifactPointer,
+  type WorkflowStepId,
+  type WorkflowStepStatus,
+} from "../../contracts/run-contracts.js";
+import type { DurableRunEffect } from "../../state/run-durability.js";
+import type { VerifiedChangeCommandRecord } from "../../workflow/evidence-record.js";
+
+export const WORKFLOW_VERIFY_COMMAND_PREFIX = "workflow.verify.cmd." as const;
+export const WORKFLOW_VERIFY_AGENT_BASE = "workflow.verify.agent" as const;
+
+export type WorkflowStepRole = "stage" | "verify_command" | "verify_agent";
+
+export interface ParsedWorkflowStepId {
+  readonly stage: WorkflowStepId;
+  readonly attempt: number;
+  readonly role: WorkflowStepRole;
+  /** 1-based index into the spec's requiredVerification list. */
+  readonly commandIndex?: number;
+}
+
+function assertAttempt(attempt: number): void {
+  if (!Number.isSafeInteger(attempt) || attempt < 1) {
+    throw new RangeError(`workflow step attempt must be >= 1, got ${attempt}`);
+  }
+}
+
+function attemptSuffix(attempt: number): string {
+  assertAttempt(attempt);
+  return attempt === 1 ? "" : `#${attempt}`;
+}
+
+/** `workflow.implement`, `workflow.implement#2`, ... */
+export function stageStepId(stage: WorkflowStepId, attempt: number): string {
+  return `${stage}${attemptSuffix(attempt)}`;
+}
+
+/** `workflow.verify.cmd.3`, `workflow.verify.cmd.3#2`, ... (1-based index). */
+export function verifyCommandStepId(index: number, attempt: number): string {
+  if (!Number.isSafeInteger(index) || index < 1) {
+    throw new RangeError(`verify command index must be >= 1, got ${index}`);
+  }
+  return `${WORKFLOW_VERIFY_COMMAND_PREFIX}${index}${attemptSuffix(attempt)}`;
+}
+
+/** `workflow.verify.agent`, `workflow.verify.agent#2`, ... */
+export function verifyAgentStepId(attempt: number): string {
+  return `${WORKFLOW_VERIFY_AGENT_BASE}${attemptSuffix(attempt)}`;
+}
+
+export function parseWorkflowStepId(
+  stepId: string,
+): ParsedWorkflowStepId | undefined {
+  let base = stepId;
+  let attempt = 1;
+  const hash = stepId.lastIndexOf("#");
+  if (hash >= 0) {
+    const suffix = stepId.slice(hash + 1);
+    if (!/^[0-9]+$/.test(suffix)) return undefined;
+    attempt = Number.parseInt(suffix, 10);
+    if (!Number.isSafeInteger(attempt) || attempt < 2) return undefined;
+    base = stepId.slice(0, hash);
+  }
+  if (base === WORKFLOW_VERIFY_AGENT_BASE) {
+    return { stage: "workflow.verify", attempt, role: "verify_agent" };
+  }
+  if (base.startsWith(WORKFLOW_VERIFY_COMMAND_PREFIX)) {
+    const rest = base.slice(WORKFLOW_VERIFY_COMMAND_PREFIX.length);
+    if (!/^[0-9]+$/.test(rest)) return undefined;
+    const commandIndex = Number.parseInt(rest, 10);
+    if (!Number.isSafeInteger(commandIndex) || commandIndex < 1) {
+      return undefined;
+    }
+    return {
+      stage: "workflow.verify",
+      attempt,
+      role: "verify_command",
+      commandIndex,
+    };
+  }
+  if ((WORKFLOW_STEP_IDS as readonly string[]).includes(base)) {
+    return { stage: base as WorkflowStepId, attempt, role: "stage" };
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Content-derived idempotency keys (D3)
+// ---------------------------------------------------------------------------
+
+function sha256Key(domain: string, parts: readonly string[]): string {
+  const hash = createHash("sha256");
+  hash.update(domain, "utf8");
+  for (const part of parts) {
+    hash.update("\0", "utf8");
+    hash.update(part, "utf8");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+/** The intake key IS the canonical spec digest — the spec's durable identity. */
+export function intakeIdempotencyKey(specDigest: string): string {
+  return specDigest;
+}
+
+/** Deterministic worktree pointer: `slug@baseCommit`. */
+export function worktreeIdempotencyKey(
+  slug: string,
+  baseCommit: string,
+): string {
+  return `${slug}@${baseCommit}`;
+}
+
+/** sha256(script + treeHash) — same tree + same script = same command. */
+export function verifyCommandIdempotencyKey(
+  script: string,
+  treeHash: string,
+): string {
+  return sha256Key("m5.verify.cmd", [script, treeHash]);
+}
+
+/** sha256(patchDigest + baseCommit) — same patch onto the same base. */
+export function finalizeIdempotencyKey(
+  patchDigest: string,
+  baseCommit: string,
+): string {
+  return sha256Key("m5.finalize", [patchDigest, baseCommit]);
+}
+
+// ---------------------------------------------------------------------------
+// Effect evidence — the single serialized shape the controller writes and
+// every projection reads back
+// ---------------------------------------------------------------------------
+
+export interface WorkflowChildEvidence {
+  readonly childRunId: string;
+  readonly status: string;
+  readonly finalMessage?: string;
+}
+
+export interface WorkflowReviewEvidence {
+  readonly blockerCount: number;
+  readonly findingCount: number;
+  readonly overallCorrectness: string;
+  readonly overallConfidenceScore: number;
+  readonly blockers: readonly string[];
+  readonly nonBlockingFindings: readonly string[];
+  readonly reviewerModel: string;
+}
+
+export interface WorkflowFinalizeEvidence {
+  readonly headCommit: string;
+  readonly treeHash: string;
+  readonly sealDigest?: string;
+  readonly baseMovement: string;
+  readonly conflictFiles?: readonly string[];
+  readonly recordDigest?: string;
+}
+
+export interface WorkflowStepEvidence {
+  readonly stage?: WorkflowStepId;
+  readonly attempt?: number;
+  readonly spec?: unknown;
+  readonly specDigest?: string;
+  readonly worktree?: {
+    readonly slug: string;
+    readonly branch: string;
+    readonly path: string;
+    readonly baseCommit: string;
+    readonly created: boolean;
+  };
+  readonly child?: WorkflowChildEvidence;
+  readonly command?: VerifiedChangeCommandRecord;
+  readonly excerpts?: { readonly stdout: string; readonly stderr: string };
+  readonly verdict?: string;
+  readonly review?: WorkflowReviewEvidence;
+  readonly finalize?: WorkflowFinalizeEvidence;
+  readonly artifacts?: readonly RunArtifactPointer[];
+  readonly failure?: { readonly reason: string; readonly message?: string };
+}
+
+export function readWorkflowStepEvidence(
+  effect: DurableRunEffect,
+): WorkflowStepEvidence {
+  const evidence = effect.evidence;
+  if (
+    evidence !== null &&
+    typeof evidence === "object" &&
+    !Array.isArray(evidence)
+  ) {
+    return evidence as WorkflowStepEvidence;
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Stage projection over durable run_effects rows
+// ---------------------------------------------------------------------------
+
+export interface WorkflowStageProjection {
+  readonly stage: WorkflowStepId;
+  /** Aggregated status of the LATEST attempt ("pending" when never begun). */
+  readonly status: WorkflowStepStatus;
+  /** Highest attempt number recorded for the stage (0 = never begun). */
+  readonly attempts: number;
+  /** The representative step id of the latest attempt (base id when pending). */
+  readonly latestStepId: string;
+  /** Machine verdict where the stage has one (verify/review). */
+  readonly verdict?: string;
+  /**
+   * Committed stages only: whether the stage's in-evidence verdicts pass
+   * (verification exit codes + agent VERDICT; review blocker count).
+   * `undefined` until the stage commits; non-verdict stages commit as `true`.
+   */
+  readonly verdictPassed?: boolean;
+  readonly artifacts: readonly RunArtifactPointer[];
+}
+
+interface ParsedRow {
+  readonly effect: DurableRunEffect;
+  readonly parsed: ParsedWorkflowStepId;
+}
+
+function aggregateStatus(rows: readonly ParsedRow[]): WorkflowStepStatus {
+  if (rows.some((row) => row.effect.outcome === undefined)) return "running";
+  if (rows.some((row) => row.effect.outcome === "unknown_outcome")) {
+    return "unknown_outcome";
+  }
+  if (rows.some((row) => row.effect.outcome === "cancelled")) return "cancelled";
+  if (rows.some((row) => row.effect.outcome === "failed")) return "failed";
+  return "committed";
+}
+
+function commandPassed(evidence: WorkflowStepEvidence): boolean {
+  const record = evidence.command;
+  return record !== undefined && record.exitCode === 0 && !record.timedOut;
+}
+
+/** Derive one stage's projection from ALL of the run's effect rows. */
+export function deriveStageProjection(
+  stage: WorkflowStepId,
+  effects: readonly DurableRunEffect[],
+): WorkflowStageProjection {
+  const rows: ParsedRow[] = [];
+  for (const effect of effects) {
+    const parsed = parseWorkflowStepId(effect.stepId);
+    if (parsed !== undefined && parsed.stage === stage) {
+      rows.push({ effect, parsed });
+    }
+  }
+  if (rows.length === 0) {
+    return {
+      stage,
+      status: "pending",
+      attempts: 0,
+      latestStepId: stage,
+      artifacts: [],
+    };
+  }
+  const attempts = Math.max(...rows.map((row) => row.parsed.attempt));
+  const latest = rows.filter((row) => row.parsed.attempt === attempts);
+  let status = aggregateStatus(latest);
+
+  const artifacts: RunArtifactPointer[] = [];
+  for (const row of latest) {
+    const evidence = readWorkflowStepEvidence(row.effect);
+    if (Array.isArray(evidence.artifacts)) artifacts.push(...evidence.artifacts);
+  }
+
+  let verdict: string | undefined;
+  let verdictPassed: boolean | undefined;
+  let latestStepId = latest[latest.length - 1].effect.stepId;
+
+  if (stage === "workflow.verify") {
+    const agent = latest.find((row) => row.parsed.role === "verify_agent");
+    const commands = latest.filter(
+      (row) => row.parsed.role === "verify_command",
+    );
+    // The verify stage is only complete once its agent row exists; committed
+    // command rows without the agent are still mid-stage.
+    if (status === "committed" && agent === undefined) status = "running";
+    const commandsPassed =
+      commands.length > 0 &&
+      commands.every(
+        (row) =>
+          row.effect.outcome === "committed" &&
+          commandPassed(readWorkflowStepEvidence(row.effect)),
+      );
+    const agentVerdict =
+      agent === undefined
+        ? undefined
+        : readWorkflowStepEvidence(agent.effect).verdict;
+    verdict = agentVerdict ?? (status === "committed" ? "FAIL" : undefined);
+    if (status === "committed") {
+      verdictPassed = commandsPassed && agentVerdict === "PASS";
+    }
+    if (agent !== undefined) latestStepId = agent.effect.stepId;
+    else latestStepId = verifyAgentStepId(attempts);
+  } else if (stage === "workflow.review") {
+    if (status === "committed") {
+      const review = readWorkflowStepEvidence(latest[0].effect).review;
+      verdictPassed = review !== undefined && review.blockerCount === 0;
+      verdict = verdictPassed ? "approved" : "rejected";
+    }
+  } else if (status === "committed") {
+    verdictPassed = true;
+  }
+
+  return {
+    stage,
+    status,
+    attempts,
+    latestStepId,
+    ...(verdict !== undefined ? { verdict } : {}),
+    ...(verdictPassed !== undefined ? { verdictPassed } : {}),
+    artifacts,
+  };
+}
+
+/** Projection of every pipeline stage, in fixed pipeline order. */
+export function deriveAllStageProjections(
+  effects: readonly DurableRunEffect[],
+): ReadonlyMap<WorkflowStepId, WorkflowStageProjection> {
+  const map = new Map<WorkflowStepId, WorkflowStageProjection>();
+  for (const stage of WORKFLOW_STEP_IDS) {
+    map.set(stage, deriveStageProjection(stage, effects));
+  }
+  return map;
+}
+
+/**
+ * A stage may begin only when every prerequisite stage is committed AND its
+ * in-evidence verdicts pass (frozen contract semantics).
+ */
+export function stagePrerequisitesMet(
+  stage: WorkflowStepId,
+  effects: readonly DurableRunEffect[],
+): boolean {
+  return WORKFLOW_STEP_PREREQUISITES[stage].every((prerequisite) => {
+    const projection = deriveStageProjection(prerequisite, effects);
+    return (
+      projection.status === "committed" && projection.verdictPassed !== false
+    );
+  });
+}

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -1,0 +1,2169 @@
+/**
+ * M5 Phase 4 — the durable verified-change workflow controller.
+ *
+ * Drives the fixed pipeline
+ *   intake → worktree → plan → implement → verify → review → finalize
+ * as durable effects over the EXISTING M3/M4 stack:
+ *
+ * - The workflow run IS a daemon agent run (D1). Its canonical journal is
+ *   the run's rollout store; the controller writes effect intents/results
+ *   exclusively through the injected {@link WorkflowJournalWriter}, whose
+ *   contract is journal-append-then-project (mirroring
+ *   `RolloutStore.recordEffectEvent`). The controller NEVER writes effect
+ *   rows around the journal.
+ * - No new tables (D2). The frozen WorkflowSpec persists as the
+ *   `workflow.intake` effect's evidence; step state is a projection of
+ *   `run_effects`; the worktree pointer is the deterministic slug plus the
+ *   `workflow.worktree` effect evidence; artifact pointers ride evidence.
+ * - Effect classification (D3): intake/worktree/finalize and each
+ *   verification command are `idempotent` with content-derived idempotency
+ *   keys; plan/implement/review and the verification agent are
+ *   `side-effecting` spawns. Recovery: idempotent intent-without-outcome
+ *   re-executes under the same key; side-effecting intent-without-outcome
+ *   ADOPTS the child's durable terminal result (never respawns); an
+ *   unknowable child marks the effect `unknown_outcome` and the run
+ *   terminates `unknown_outcome` / `unknown_outcome_effect`.
+ * - Approvals resolve at intake (D5): a mid-pipeline
+ *   `AdmissionDeniedError` with decision `approval_required` terminates the
+ *   run `failed`/`approval_required`. There is no parking.
+ * - ONE terminal choke point (D6): `completed` demands all stages
+ *   committed, every required command exit 0, verification agent
+ *   `VERDICT: PASS`, a reviewer with zero blockers, a self-validated
+ *   evidence record, and a sealed ledger. `recordTerminalResult` runs on
+ *   every exit path, including resume.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import {
+  type AdmissionKind,
+  type RunArtifactPointer,
+  type RunStepIdentity,
+  type RunTerminalStatus,
+  type RunUsageTotals,
+  type WorkflowSpec,
+  type WorkflowStepId,
+  type WorkflowStopReason,
+} from "../../contracts/run-contracts.js";
+import {
+  AdmissionDeniedError,
+  type ExecutionAdmissionClient,
+} from "../../budget/admission-client.js";
+import type {
+  AdmissionLease,
+  AdmissionUsage,
+} from "../../budget/admission-types.js";
+import {
+  hitM5WorkflowFailpoint,
+  M5WorkflowFailpointError,
+  type M5WorkflowFailpoint,
+} from "../../durability/failpoints.js";
+import {
+  canonicalizeJson,
+  sha256Digest,
+} from "../../eval-contract/canonical-json.js";
+import type { Sha256Digest } from "../../eval-contract/types.js";
+import type {
+  DurableRunEffect,
+  StateRunDurabilityRepository,
+} from "../../state/run-durability.js";
+import type { ToolRecoveryCategory } from "../../tools/types.js";
+import type { WorktreeHandle } from "../../agents/worktree.js";
+import {
+  assembleVerifiedChangeRecord,
+  computeSpecDigest,
+  type VerifiedChangeCommandRecord,
+  type VerifiedChangeRecord,
+  type VerifiedChangeReviewRecord,
+  type VerifiedChangeStepRecord,
+} from "../../workflow/evidence-record.js";
+import {
+  ReviewParseError,
+  runIndependentReview,
+  type ReviewerInvoker,
+} from "../../workflow/independent-review.js";
+import {
+  DEFAULT_VERIFICATION_TIMEOUT_MS,
+  parseVerificationVerdict,
+  type WorkflowCommandRunner,
+} from "../../workflow/verification.js";
+import {
+  mintSealedEvidenceProof,
+  workflowWorktreeSlug,
+  type BaseMovementCheck,
+  type BaseState,
+  type EvidenceArtifactSink,
+  type ExportedPatchArtifacts,
+  type SealedEvidenceProof,
+} from "../../workflow/worktree-lifecycle.js";
+import { projectWorkflowStatus, type WorkflowRunStatus } from "./status-projection.js";
+import {
+  deriveStageProjection,
+  finalizeIdempotencyKey,
+  intakeIdempotencyKey,
+  parseWorkflowStepId,
+  readWorkflowStepEvidence,
+  stagePrerequisitesMet,
+  stageStepId,
+  verifyAgentStepId,
+  verifyCommandIdempotencyKey,
+  verifyCommandStepId,
+  worktreeIdempotencyKey,
+  type WorkflowStepEvidence,
+} from "./steps.js";
+
+// ---------------------------------------------------------------------------
+// Injected seams
+// ---------------------------------------------------------------------------
+
+export interface WorkflowEffectEventRef {
+  readonly eventId: string;
+  readonly sequence: number;
+}
+
+/**
+ * The run's canonical journal handle. Implementations MUST fsync-append the
+ * effect event to the run's rollout journal BEFORE projecting it into the
+ * durability repository (the `RolloutStore.recordEffectEvent` contract);
+ * test writers assign sequences from a counter and call the repository
+ * directly, which preserves the same observable projection semantics.
+ */
+export interface WorkflowRunJournal {
+  readonly runId: string;
+  /** Subordinate daemon session identity — never substitutes for runId. */
+  readonly sessionId: string;
+  /** Current durable lifecycle epoch (initial epoch ensured on open). */
+  readonly epoch: number;
+  appendIntent(input: {
+    readonly stepId: string;
+    readonly callId?: string;
+    readonly toolName: string;
+    readonly recoveryCategory: ToolRecoveryCategory;
+    readonly idempotencyKey?: string;
+    readonly intentDigest: string;
+    readonly childRunId?: string;
+    readonly intentAt: string;
+  }): WorkflowEffectEventRef;
+  appendResult(input: {
+    readonly stepId: string;
+    readonly outcome: "committed" | "failed" | "cancelled";
+    readonly resultDigest?: string;
+    readonly evidence?: unknown;
+    readonly completedAt: string;
+  }): WorkflowEffectEventRef;
+  appendUnknown(input: {
+    readonly stepId: string;
+    readonly reason: string;
+    readonly evidence?: unknown;
+    readonly observedAt: string;
+  }): WorkflowEffectEventRef;
+  /** Journal the terminal event; its sequence becomes the replay upper bound. */
+  appendTerminal(): WorkflowEffectEventRef;
+  close(): Promise<void>;
+}
+
+export interface WorkflowJournalWriter {
+  open(runId: string): Promise<WorkflowRunJournal>;
+}
+
+export type WorkflowSpawnKind = "plan" | "implement" | "verify_agent" | "review";
+
+export interface WorkflowChildOutcome {
+  readonly status: RunTerminalStatus;
+  readonly finalMessage: string | null;
+  readonly usage: RunUsageTotals | null;
+}
+
+export type WorkflowChildInspection =
+  | { readonly state: "terminal"; readonly outcome: WorkflowChildOutcome }
+  | { readonly state: "live"; readonly outcome: Promise<WorkflowChildOutcome> }
+  | { readonly state: "unknown" };
+
+/** Spawn seam for the side-effecting pipeline stages. */
+export interface WorkflowAgentSpawner {
+  spawn(input: {
+    readonly kind: WorkflowSpawnKind;
+    readonly childRunId: string;
+    readonly spec: WorkflowSpec;
+    readonly worktreePath: string;
+    readonly prompt: string;
+    readonly signal: AbortSignal;
+  }): Promise<WorkflowChildOutcome>;
+  /** D3 adoption: durable inspection of a previously dispatched child run. */
+  inspect(childRunId: string): Promise<WorkflowChildInspection>;
+}
+
+/** Worktree/git seam over the Phase 2 worktree-lifecycle library. */
+export interface WorkflowWorktreeBroker {
+  captureBaseState(repoPath: string): Promise<BaseState>;
+  provision(
+    spec: Pick<WorkflowSpec, "runId" | "repoPath" | "baseCommit">,
+  ): Promise<WorktreeHandle>;
+  exportPatch(input: {
+    readonly handle: WorktreeHandle;
+    readonly baseCommit: string;
+    readonly step: RunStepIdentity;
+    readonly sink: EvidenceArtifactSink;
+  }): Promise<ExportedPatchArtifacts>;
+  checkBaseMovement(input: {
+    readonly spec: Pick<WorkflowSpec, "runId" | "repoPath" | "baseCommit">;
+    readonly patchBytes: Uint8Array;
+  }): Promise<BaseMovementCheck>;
+  cleanup(input: {
+    readonly proof: SealedEvidenceProof;
+    readonly handle: WorktreeHandle;
+  }): Promise<void>;
+}
+
+export interface WorkflowEvidenceLedgerHead {
+  readonly eventCount: number;
+  readonly headEventDigest: Sha256Digest;
+  readonly sealed: boolean;
+}
+
+/**
+ * Narrow per-run evidence ledger seam the controller drives. The daemon
+ * adapter backs it with the eval-contract evidence ledger
+ * (`appendEvidenceEvent` with `artifact.recorded` payloads under
+ * `<agencHome>/run-evidence/<runId>/`); tests use an in-memory ledger.
+ * `recordArtifact` and `seal` must be idempotent for crash-resume.
+ */
+export interface WorkflowEvidenceLedger extends EvidenceArtifactSink {
+  head(): WorkflowEvidenceLedgerHead;
+  readArtifact(pointer: RunArtifactPointer): Promise<Uint8Array>;
+  seal(sealedAt: string): Promise<{ readonly sealDigest: string }>;
+  /** Persist the final record OUTSIDE the sealed ledger (best-effort). */
+  persistRecord?(record: VerifiedChangeRecord): Promise<void>;
+}
+
+export interface VerifiedChangeWorkflowControllerDeps {
+  readonly durability: () => StateRunDurabilityRepository;
+  readonly journal: WorkflowJournalWriter;
+  readonly admission: (input: {
+    readonly runId: string;
+    readonly sessionId: string;
+    readonly workspaceId?: string;
+    readonly spec: WorkflowSpec;
+  }) => ExecutionAdmissionClient;
+  readonly worktrees: WorkflowWorktreeBroker;
+  readonly commands: WorkflowCommandRunner;
+  readonly spawner: WorkflowAgentSpawner;
+  readonly reviewer: ReviewerInvoker;
+  readonly evidenceLedger: (spec: WorkflowSpec) => Promise<WorkflowEvidenceLedger>;
+  readonly warn: (message: string) => void;
+  readonly now?: () => Date;
+  readonly newRunId?: () => string;
+}
+
+// ---------------------------------------------------------------------------
+// Public parameter/result types
+// ---------------------------------------------------------------------------
+
+export interface WorkflowStartParams {
+  readonly goal: string;
+  readonly repoPath: string;
+  readonly model?: string;
+  readonly provider?: string;
+  readonly reviewerModel?: string;
+  readonly permissionMode?: WorkflowSpec["permissionMode"];
+  readonly unattendedAllow?: readonly string[];
+  readonly unattendedDeny?: readonly string[];
+  readonly budget?: WorkflowSpec["budget"];
+  readonly requiredVerification: readonly {
+    readonly label: string;
+    readonly script: string;
+  }[];
+  readonly maxImplementAttempts?: number;
+  readonly workspaceId?: string;
+  /** Deterministic run id (tests / dispatcher-minted ids). */
+  readonly runId?: string;
+}
+
+export interface WorkflowStartResult {
+  readonly runId: string;
+  readonly specDigest: Sha256Digest;
+  readonly baseCommit: string;
+  readonly baseDirty: WorkflowSpec["baseDirty"];
+}
+
+/** Intake failed before the pipeline began; the terminal result is durable. */
+export class WorkflowIntakeError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly stopReason: WorkflowStopReason | null,
+    message: string,
+  ) {
+    super(`workflow ${runId} intake failed: ${message}`);
+    this.name = "WorkflowIntakeError";
+  }
+}
+
+const DEFAULT_MAX_IMPLEMENT_ATTEMPTS = 2;
+/** Bounded per-stage retry budget for stage-level (non-verdict) failures. */
+const MAX_STAGE_ATTEMPTS = 2;
+const ZERO_ESTIMATE = {
+  maxInputTokens: 0,
+  maxOutputTokens: 0,
+  maxCostUsd: 0,
+} as const;
+const SPAWN_ESTIMATE_INPUT_TOKENS = 1_000_000;
+const SPAWN_ESTIMATE_OUTPUT_TOKENS = 200_000;
+const EVIDENCE_MESSAGE_LIMIT = 20_000;
+
+// ---------------------------------------------------------------------------
+// Internal control flow
+// ---------------------------------------------------------------------------
+
+interface WorkflowTerminalIntent {
+  readonly status: RunTerminalStatus;
+  readonly stopReason: WorkflowStopReason | null;
+  readonly finalMessage: string | null;
+}
+
+/** Planned pipeline stop; the single carrier into the terminal choke point. */
+class WorkflowHaltError extends Error {
+  constructor(readonly terminal: WorkflowTerminalIntent) {
+    super(
+      `workflow halt: ${terminal.status}` +
+        (terminal.stopReason === null ? "" : ` (${terminal.stopReason})`),
+    );
+    this.name = "WorkflowHaltError";
+  }
+}
+
+/** Gates the terminal choke point demands before it will record `completed`. */
+interface CompletedGates {
+  readonly record: VerifiedChangeRecord;
+  readonly allCommandsPassed: boolean;
+  readonly verificationVerdict: string | undefined;
+  readonly reviewBlockerCount: number;
+  readonly ledgerSealed: boolean;
+}
+
+interface EffectExecution {
+  readonly outcome: "committed" | "failed" | "cancelled";
+  readonly evidence: WorkflowStepEvidence;
+  readonly usage?: AdmissionUsage;
+}
+
+interface EffectStepPlan {
+  readonly stepId: string;
+  readonly stage: WorkflowStepId;
+  readonly attempt: number;
+  readonly toolName: string;
+  readonly kind: AdmissionKind;
+  readonly recoveryCategory: "idempotent" | "side-effecting";
+  readonly idempotencyKey?: string;
+  readonly intentDigest: string;
+  readonly childRunId?: string;
+  readonly estimate: {
+    readonly maxInputTokens: number;
+    readonly maxOutputTokens: number;
+    readonly maxCostUsd: number | null;
+  };
+  readonly model?: string;
+  readonly provider?: string;
+  readonly beforeExecuteFailpoint?: M5WorkflowFailpoint;
+  readonly beforeCommitFailpoints?: readonly M5WorkflowFailpoint[];
+  readonly afterCommitFailpoint?: M5WorkflowFailpoint;
+  readonly execute: (signal: AbortSignal) => Promise<EffectExecution>;
+  /**
+   * D3 adoption for side-effecting steps: resolve a previously dispatched
+   * child's durable outcome. `undefined` = unknowable.
+   */
+  readonly adopt?: (
+    existing: DurableRunEffect,
+  ) => Promise<EffectExecution | undefined>;
+}
+
+interface EffectStepResult {
+  readonly outcome: "committed" | "failed" | "cancelled" | "unknown_outcome";
+  readonly evidence: WorkflowStepEvidence;
+  readonly replayed: boolean;
+}
+
+interface RunContext {
+  readonly runId: string;
+  readonly spec: WorkflowSpec;
+  readonly specDigest: Sha256Digest;
+  readonly repo: StateRunDurabilityRepository;
+  readonly journal: WorkflowRunJournal;
+  readonly admission: ExecutionAdmissionClient;
+  readonly startedAt: string;
+  ledger?: WorkflowEvidenceLedger;
+  handle?: WorktreeHandle;
+  planText?: string;
+  verification?: {
+    readonly records: readonly VerifiedChangeCommandRecord[];
+    readonly allPassed: boolean;
+    readonly testResult: RunArtifactPointer;
+  };
+  verifyVerdict?: string;
+  review?: VerifiedChangeReviewRecord;
+  reviewNonBlocking?: readonly string[];
+  export?: ExportedPatchArtifacts;
+  usage: { input: number; output: number; cost: number; any: boolean };
+  terminalized: boolean;
+}
+
+function truncate(text: string | null | undefined): string | undefined {
+  if (text === null || text === undefined) return undefined;
+  return text.length > EVIDENCE_MESSAGE_LIMIT
+    ? `${text.slice(0, EVIDENCE_MESSAGE_LIMIT)}…[truncated]`
+    : text;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
+
+export class VerifiedChangeWorkflowController {
+  readonly #deps: VerifiedChangeWorkflowControllerDeps;
+  readonly #now: () => Date;
+  readonly #newRunId: () => string;
+  readonly #active = new Map<string, Promise<void>>();
+
+  constructor(deps: VerifiedChangeWorkflowControllerDeps) {
+    this.#deps = deps;
+    this.#now = deps.now ?? (() => new Date());
+    this.#newRunId = deps.newRunId ?? (() => `wf-${randomUUID()}`);
+  }
+
+  #nowIso(): string {
+    return this.#now().toISOString();
+  }
+
+  /**
+   * Intake: freeze the spec against the captured base state, resolve
+   * policy/budget through admission, and durably commit the intake effect.
+   * Returns after the intake commit; the rest of the pipeline continues
+   * asynchronously (track it with {@link awaitRun}).
+   */
+  async start(params: WorkflowStartParams): Promise<WorkflowStartResult> {
+    if (params.requiredVerification.length === 0) {
+      throw new TypeError(
+        "verified-change workflow requires at least one verification command",
+      );
+    }
+    const runId = params.runId ?? this.#newRunId();
+    const repo = this.#deps.durability();
+    const journal = await this.#deps.journal.open(runId);
+    const base = await this.#deps.worktrees.captureBaseState(params.repoPath);
+    const spec = freezeWorkflowSpec(runId, params, base);
+    const specDigest = computeSpecDigest(spec);
+    const admission = this.#deps.admission({
+      runId,
+      sessionId: journal.sessionId,
+      ...(params.workspaceId !== undefined
+        ? { workspaceId: params.workspaceId }
+        : {}),
+      spec,
+    });
+    const ctx: RunContext = {
+      runId,
+      spec,
+      specDigest,
+      repo,
+      journal,
+      admission,
+      startedAt: this.#nowIso(),
+      usage: { input: 0, output: 0, cost: 0, any: false },
+      terminalized: false,
+    };
+    try {
+      await this.#stageIntake(ctx);
+    } catch (error) {
+      if (error instanceof M5WorkflowFailpointError) throw error;
+      const terminal =
+        error instanceof WorkflowHaltError
+          ? error.terminal
+          : ({
+              status: "failed",
+              stopReason: null,
+              finalMessage: `workflow intake error: ${errorMessage(error)}`,
+            } satisfies WorkflowTerminalIntent);
+      await this.#terminalize(ctx, terminal);
+      await this.#closeJournal(ctx);
+      throw new WorkflowIntakeError(
+        runId,
+        terminal.stopReason,
+        terminal.finalMessage ?? terminal.status,
+      );
+    }
+    const pipeline = this.#continue(ctx);
+    this.#active.set(runId, pipeline);
+    return {
+      runId,
+      specDigest,
+      baseCommit: spec.baseCommit,
+      baseDirty: spec.baseDirty,
+    };
+  }
+
+  /** Await the asynchronous pipeline for a started/resumed run (test hook). */
+  awaitRun(runId: string): Promise<void> {
+    return this.#active.get(runId) ?? Promise.resolve();
+  }
+
+  /** Durable status projection — works after restart, no live state needed. */
+  status(runId: string): WorkflowRunStatus | undefined {
+    const repo = this.#deps.durability();
+    const effects = repo.listEffects(runId);
+    const terminal = repo.getCurrentTerminalResult(runId);
+    if (effects.length === 0 && terminal === undefined) return undefined;
+    return projectWorkflowStatus({
+      runId,
+      effects,
+      ...(terminal !== undefined ? { terminal } : {}),
+    });
+  }
+
+  /**
+   * D3 startup recovery: rebuild every open workflow run from its durable
+   * rows and continue it. Idempotent steps re-execute under their recorded
+   * keys; side-effecting steps adopt their child's durable outcome; an
+   * unknowable child terminates the run `unknown_outcome`. A run whose
+   * intake intent never committed lost its (never-durable, read-only) spec
+   * and is terminalized `failed` with a diagnostic.
+   */
+  async resumeOpenWorkflows(): Promise<readonly string[]> {
+    const repo = this.#deps.durability();
+    const resumed: string[] = [];
+    for (const runId of repo.listRunIdsWithStep("workflow.intake")) {
+      if (repo.getCurrentTerminalResult(runId) !== undefined) continue;
+      try {
+        const started = await this.#resumeRun(repo, runId);
+        if (started) resumed.push(runId);
+      } catch (error) {
+        if (error instanceof M5WorkflowFailpointError) throw error;
+        this.#deps.warn(
+          `workflow resume failed for ${runId}: ${errorMessage(error)}`,
+        );
+      }
+    }
+    return resumed;
+  }
+
+  async #resumeRun(
+    repo: StateRunDurabilityRepository,
+    runId: string,
+  ): Promise<boolean> {
+    const journal = await this.#deps.journal.open(runId);
+    const intake = repo.getEffect(runId, "workflow.intake");
+    if (intake === undefined) {
+      await journal.close();
+      return false;
+    }
+    if (intake.outcome === undefined) {
+      // The spec only becomes durable in the intake result evidence; an
+      // intent-only intake is unrecoverable. Intake is read-only, so failing
+      // closed loses nothing — the caller re-submits.
+      journal.appendResult({
+        stepId: "workflow.intake",
+        outcome: "failed",
+        evidence: {
+          stage: "workflow.intake",
+          attempt: 1,
+          failure: {
+            reason: "intake_interrupted",
+            message: "spec was not durably committed before the interruption",
+          },
+        } satisfies WorkflowStepEvidence,
+        completedAt: this.#nowIso(),
+      });
+      const ctx = this.#bareContext(runId, repo, journal);
+      await this.#terminalize(ctx, {
+        status: "failed",
+        stopReason: null,
+        finalMessage:
+          "workflow interrupted before the intake commit; the spec was never durable — re-submit the request",
+      });
+      await this.#closeJournal(ctx);
+      return true;
+    }
+    const evidence = readWorkflowStepEvidence(intake);
+    const spec = evidence.spec as WorkflowSpec | undefined;
+    if (intake.outcome !== "committed" || spec === undefined) {
+      const ctx = this.#bareContext(runId, repo, journal);
+      await this.#terminalize(ctx, {
+        status: intake.outcome === "cancelled" ? "cancelled" : "failed",
+        stopReason: null,
+        finalMessage: `workflow intake terminally ${intake.outcome}; nothing to resume`,
+      });
+      await this.#closeJournal(ctx);
+      return true;
+    }
+    const specDigest = (evidence.specDigest ?? computeSpecDigest(spec)) as Sha256Digest;
+    const admission = this.#deps.admission({
+      runId,
+      sessionId: journal.sessionId,
+      spec,
+    });
+    const ctx: RunContext = {
+      runId,
+      spec,
+      specDigest,
+      repo,
+      journal,
+      admission,
+      startedAt: intake.intentAt,
+      usage: { input: 0, output: 0, cost: 0, any: false },
+      terminalized: false,
+    };
+    ctx.ledger = await this.#deps.evidenceLedger(spec);
+    // Rebuild derived in-memory context from committed evidence.
+    const effects = repo.listEffects(runId);
+    const plan = deriveStageProjection("workflow.plan", effects);
+    if (plan.status === "committed") {
+      const planEffect = repo.getEffect(runId, plan.latestStepId);
+      ctx.planText =
+        planEffect === undefined
+          ? undefined
+          : readWorkflowStepEvidence(planEffect).child?.finalMessage;
+    }
+    const pipeline = this.#continue(ctx);
+    this.#active.set(runId, pipeline);
+    return true;
+  }
+
+  #bareContext(
+    runId: string,
+    repo: StateRunDurabilityRepository,
+    journal: WorkflowRunJournal,
+  ): RunContext {
+    return {
+      runId,
+      spec: undefined as unknown as WorkflowSpec,
+      specDigest: "sha256:" as Sha256Digest,
+      repo,
+      journal,
+      admission: undefined as unknown as ExecutionAdmissionClient,
+      startedAt: this.#nowIso(),
+      usage: { input: 0, output: 0, cost: 0, any: false },
+      terminalized: false,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Pipeline
+  // -------------------------------------------------------------------------
+
+  async #continue(ctx: RunContext): Promise<void> {
+    try {
+      await this.#stageWorktree(ctx);
+      await this.#stagePlan(ctx);
+      await this.#implementVerifyLoop(ctx);
+      await this.#stageReview(ctx);
+      await this.#stageFinalize(ctx);
+    } catch (error) {
+      if (error instanceof M5WorkflowFailpointError) throw error;
+      const terminal =
+        error instanceof WorkflowHaltError
+          ? error.terminal
+          : ({
+              status: "failed",
+              stopReason: null,
+              finalMessage: `workflow internal error: ${errorMessage(error)}`,
+            } satisfies WorkflowTerminalIntent);
+      if (!(error instanceof WorkflowHaltError)) {
+        this.#deps.warn(
+          `workflow ${ctx.runId} internal error: ${errorMessage(error)}`,
+        );
+      }
+      await this.#terminalize(ctx, terminal);
+    } finally {
+      this.#active.delete(ctx.runId);
+      await this.#closeJournal(ctx);
+    }
+  }
+
+  async #closeJournal(ctx: RunContext): Promise<void> {
+    try {
+      await ctx.journal.close();
+    } catch (error) {
+      this.#deps.warn(
+        `workflow ${ctx.runId} journal close failed: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  async #stageIntake(ctx: RunContext): Promise<void> {
+    const result = await this.#driveEffect(ctx, {
+      stepId: "workflow.intake",
+      stage: "workflow.intake",
+      attempt: 1,
+      toolName: "workflow.intake",
+      kind: "tool_exec",
+      recoveryCategory: "idempotent",
+      idempotencyKey: intakeIdempotencyKey(ctx.specDigest),
+      intentDigest: ctx.specDigest,
+      estimate: ZERO_ESTIMATE,
+      beforeCommitFailpoints: ["before_intake_commit"],
+      afterCommitFailpoint: "after_intake_commit",
+      execute: async () => {
+        ctx.ledger = await this.#deps.evidenceLedger(ctx.spec);
+        return {
+          outcome: "committed",
+          evidence: {
+            stage: "workflow.intake",
+            attempt: 1,
+            spec: ctx.spec,
+            specDigest: ctx.specDigest,
+          },
+        };
+      },
+    });
+    if (result.outcome !== "committed") {
+      throw new WorkflowHaltError({
+        status: result.outcome === "cancelled" ? "cancelled" : "failed",
+        stopReason: null,
+        finalMessage: `workflow intake ${result.outcome}`,
+      });
+    }
+    if (ctx.ledger === undefined) {
+      ctx.ledger = await this.#deps.evidenceLedger(ctx.spec);
+    }
+  }
+
+  async #stageWorktree(ctx: RunContext): Promise<void> {
+    const slug = workflowWorktreeSlug(ctx.runId);
+    const { result } = await this.#runStageWithRetries(ctx, {
+      stage: "workflow.worktree",
+      maxAttempts: MAX_STAGE_ATTEMPTS,
+      makePlan: (attempt) => ({
+        stepId: stageStepId("workflow.worktree", attempt),
+        stage: "workflow.worktree",
+        attempt,
+        toolName: "workflow.worktree",
+        kind: "tool_exec",
+        recoveryCategory: "idempotent",
+        idempotencyKey: worktreeIdempotencyKey(slug, ctx.spec.baseCommit),
+        intentDigest: sha256Digest(
+          canonicalizeJson({ slug, baseCommit: ctx.spec.baseCommit }),
+        ),
+        estimate: ZERO_ESTIMATE,
+        beforeExecuteFailpoint: "before_worktree_provision",
+        afterCommitFailpoint: "after_worktree_provision",
+        execute: async () => {
+          try {
+            const handle = await this.#deps.worktrees.provision(ctx.spec);
+            ctx.handle = handle;
+            return {
+              outcome: "committed",
+              evidence: {
+                stage: "workflow.worktree",
+                attempt,
+                worktree: {
+                  slug,
+                  branch: handle.branch,
+                  path: handle.path,
+                  baseCommit: ctx.spec.baseCommit,
+                  created: handle.created,
+                },
+              },
+            };
+          } catch (error) {
+            return {
+              outcome: "failed",
+              evidence: {
+                stage: "workflow.worktree",
+                attempt,
+                failure: {
+                  reason: "worktree_provision_failed",
+                  message: errorMessage(error),
+                },
+              },
+            };
+          }
+        },
+      }),
+    });
+    if (result.replayed || ctx.handle === undefined) {
+      // Idempotent fast-resume of the deterministic slug rebuilds the handle.
+      ctx.handle = await this.#deps.worktrees.provision(ctx.spec);
+    }
+  }
+
+  async #stagePlan(ctx: RunContext): Promise<void> {
+    const { result } = await this.#runStageWithRetries(ctx, {
+      stage: "workflow.plan",
+      maxAttempts: MAX_STAGE_ATTEMPTS,
+      makePlan: (attempt) =>
+        this.#spawnPlan(ctx, {
+          stage: "workflow.plan",
+          stepId: stageStepId("workflow.plan", attempt),
+          attempt,
+          spawnKind: "plan",
+          childRunId: `${ctx.runId}:plan#${attempt}`,
+          prompt: buildPlanPrompt(ctx.spec),
+        }),
+    });
+    ctx.planText = result.evidence.child?.finalMessage;
+  }
+
+  async #implementVerifyLoop(ctx: RunContext): Promise<void> {
+    const spec = ctx.spec;
+    let attempt = Math.max(
+      1,
+      deriveStageProjection(
+        "workflow.implement",
+        ctx.repo.listEffects(ctx.runId),
+      ).attempts,
+    );
+    for (;;) {
+      const implement = await this.#driveEffect(
+        ctx,
+        this.#spawnPlan(ctx, {
+          stage: "workflow.implement",
+          stepId: stageStepId("workflow.implement", attempt),
+          attempt,
+          spawnKind: "implement",
+          childRunId: `${ctx.runId}:implement#${attempt}`,
+          prompt: buildImplementPrompt(ctx, attempt),
+        }),
+      );
+      if (implement.outcome === "cancelled") {
+        throw new WorkflowHaltError({
+          status: "cancelled",
+          stopReason: null,
+          finalMessage: "workflow cancelled during implement",
+        });
+      }
+      if (implement.outcome === "unknown_outcome") {
+        throw new WorkflowHaltError({
+          status: "unknown_outcome",
+          stopReason: "unknown_outcome_effect",
+          finalMessage: `implement step ${stageStepId("workflow.implement", attempt)} has an unresolved unknown outcome`,
+        });
+      }
+      if (implement.outcome === "failed") {
+        if (attempt >= spec.maxImplementAttempts) {
+          throw new WorkflowHaltError({
+            status: "failed",
+            stopReason: "step_retries_exhausted",
+            finalMessage: `implement failed terminally after ${attempt} attempt(s)`,
+          });
+        }
+        attempt += 1;
+        continue;
+      }
+      const passed = await this.#stageVerify(ctx, attempt);
+      if (passed) return;
+      if (attempt >= spec.maxImplementAttempts) {
+        throw new WorkflowHaltError({
+          status: "failed",
+          stopReason: "verification_failed",
+          finalMessage:
+            `verification did not pass after ${attempt} implement attempt(s): ` +
+            `commands ${ctx.verification?.allPassed === true ? "passed" : "failed"}, ` +
+            `agent verdict ${ctx.verifyVerdict ?? "missing"}`,
+        });
+      }
+      attempt += 1;
+    }
+  }
+
+  /** Returns true when every required command exits 0 AND the agent says PASS. */
+  async #stageVerify(ctx: RunContext, attempt: number): Promise<boolean> {
+    const spec = ctx.spec;
+    const handle = this.#requireHandle(ctx);
+    const ledger = this.#requireLedger(ctx);
+    // Export the reviewable patch for this tree; re-export of an unchanged
+    // worktree is byte-identical, so this is safe on every resume.
+    const exported = await this.#deps.worktrees.exportPatch({
+      handle,
+      baseCommit: spec.baseCommit,
+      step: { runId: ctx.runId, stepId: stageStepId("workflow.verify", attempt) },
+      sink: ledger,
+    });
+    ctx.export = exported;
+
+    const records: VerifiedChangeCommandRecord[] = [];
+    for (const [index, command] of spec.requiredVerification.entries()) {
+      const stepId = verifyCommandStepId(index + 1, attempt);
+      const result = await this.#driveEffect(ctx, {
+        stepId,
+        stage: "workflow.verify",
+        attempt,
+        toolName: "workflow.verify.cmd",
+        kind: "tool_exec",
+        recoveryCategory: "idempotent",
+        idempotencyKey: verifyCommandIdempotencyKey(
+          command.script,
+          exported.treeHash,
+        ),
+        intentDigest: sha256Digest(
+          canonicalizeJson({
+            script: command.script,
+            treeHash: exported.treeHash,
+          }),
+        ),
+        estimate: ZERO_ESTIMATE,
+        execute: async () =>
+          this.#executeVerificationCommand(ctx, command, attempt),
+      });
+      const record = result.evidence.command;
+      if (result.outcome === "committed" && record !== undefined) {
+        records.push(record);
+      } else {
+        // A durable command row without a usable record can never pass.
+        records.push({
+          label: command.label,
+          script: command.script,
+          exitCode: 127,
+          timedOut: false,
+          truncated: false,
+          durationMs: 0,
+          stdoutDigest: sha256Digest(new Uint8Array(0)),
+          stderrDigest: sha256Digest(new Uint8Array(0)),
+        });
+      }
+    }
+    const allPassed = records.every(
+      (record) => record.exitCode === 0 && !record.timedOut,
+    );
+    const testResult = await ledger.recordArtifact({
+      step: { runId: ctx.runId, stepId: verifyAgentStepId(attempt) },
+      role: "test_result",
+      bytes: new TextEncoder().encode(canonicalizeJson({ commands: records })),
+      mediaType: "application/json",
+    });
+
+    const agent = await this.#driveEffect(
+      ctx,
+      this.#spawnPlan(ctx, {
+        stage: "workflow.verify",
+        stepId: verifyAgentStepId(attempt),
+        attempt,
+        spawnKind: "verify_agent",
+        childRunId: `${ctx.runId}:verify-agent#${attempt}`,
+        prompt: buildVerifyAgentPrompt(ctx.spec, records),
+        decorate: (outcome) => {
+          const verdict = parseVerificationVerdict(outcome.finalMessage ?? "");
+          return {
+            // A missing/malformed verdict is a FAIL, never an implicit pass.
+            verdict: verdict ?? "FAIL",
+            artifacts: [testResult],
+          };
+        },
+        beforeCommitFailpoints: [
+          "after_spawn_before_effect_result",
+          "before_verify_commit",
+        ],
+        afterCommitFailpoint: "after_verify_commit",
+      }),
+    );
+    if (agent.outcome === "cancelled") {
+      throw new WorkflowHaltError({
+        status: "cancelled",
+        stopReason: null,
+        finalMessage: "workflow cancelled during verification",
+      });
+    }
+    if (agent.outcome === "unknown_outcome") {
+      throw new WorkflowHaltError({
+        status: "unknown_outcome",
+        stopReason: "unknown_outcome_effect",
+        finalMessage: `verification agent ${verifyAgentStepId(attempt)} has an unresolved unknown outcome`,
+      });
+    }
+    if (agent.outcome === "failed") {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "step_retries_exhausted",
+        finalMessage: "adversarial verification agent run failed terminally",
+      });
+    }
+    const verdict = agent.evidence.verdict ?? "FAIL";
+    ctx.verification = { records, allPassed, testResult };
+    ctx.verifyVerdict = verdict;
+    return allPassed && verdict === "PASS";
+  }
+
+  async #executeVerificationCommand(
+    ctx: RunContext,
+    command: { readonly label: string; readonly script: string },
+    attempt: number,
+  ): Promise<EffectExecution> {
+    const handle = this.#requireHandle(ctx);
+    const startedAt = performance.now();
+    let exitCode: number;
+    let stdout: Uint8Array;
+    let stderr: Uint8Array;
+    let timedOut = false;
+    let truncated = false;
+    let durationMs: number;
+    try {
+      const result = await this.#deps.commands.run({
+        script: command.script,
+        cwd: handle.path,
+        timeoutMs: DEFAULT_VERIFICATION_TIMEOUT_MS,
+      });
+      exitCode = result.exitCode;
+      stdout = result.stdout;
+      stderr = result.stderr;
+      timedOut = result.timedOut;
+      truncated = result.truncated;
+      durationMs = result.durationMs;
+    } catch (error) {
+      // A runner crash is a failing command with diagnostic stderr, never a
+      // silently missing record (verification.ts discipline).
+      exitCode = 127;
+      stdout = new Uint8Array(0);
+      stderr = new TextEncoder().encode(errorMessage(error));
+      durationMs = Math.round(performance.now() - startedAt);
+    }
+    const record: VerifiedChangeCommandRecord = {
+      label: command.label,
+      script: command.script,
+      exitCode,
+      timedOut,
+      truncated,
+      durationMs,
+      stdoutDigest: sha256Digest(stdout),
+      stderrDigest: sha256Digest(stderr),
+    };
+    const decoder = new TextDecoder("utf8", { fatal: false });
+    return {
+      outcome: "committed",
+      evidence: {
+        stage: "workflow.verify",
+        attempt,
+        command: record,
+        excerpts: {
+          stdout: decoder.decode(stdout.subarray(0, 4096)).replace(/�/g, ""),
+          stderr: decoder.decode(stderr.subarray(0, 4096)).replace(/�/g, ""),
+        },
+      },
+    };
+  }
+
+  async #stageReview(ctx: RunContext): Promise<void> {
+    const ledger = this.#requireLedger(ctx);
+    const { result } = await this.#runStageWithRetries(ctx, {
+      stage: "workflow.review",
+      maxAttempts: MAX_STAGE_ATTEMPTS,
+      makePlan: (attempt) => {
+        const stepId = stageStepId("workflow.review", attempt);
+        const childRunId = `${ctx.runId}:review#${attempt}`;
+        return {
+          stepId,
+          stage: "workflow.review",
+          attempt,
+          toolName: "workflow.review",
+          kind: "spawn",
+          recoveryCategory: "side-effecting",
+          intentDigest: sha256Digest(
+            canonicalizeJson({ stepId, childRunId, reviewer: ctx.spec.reviewerModel }),
+          ),
+          childRunId,
+          estimate: {
+            maxInputTokens: SPAWN_ESTIMATE_INPUT_TOKENS,
+            maxOutputTokens: SPAWN_ESTIMATE_OUTPUT_TOKENS,
+            maxCostUsd: ctx.spec.budget.maxCostUsd ?? null,
+          },
+          ...(ctx.spec.reviewerModel !== undefined
+            ? { model: ctx.spec.reviewerModel }
+            : {}),
+          beforeCommitFailpoints: ["before_review_commit"] as const,
+          afterCommitFailpoint: "after_review_commit" as const,
+          execute: async (): Promise<EffectExecution> => {
+            const exported = this.#requireExport(ctx);
+            const verification = ctx.verification;
+            if (verification === undefined) {
+              throw new Error("review started without verification evidence");
+            }
+            const patchText = new TextDecoder().decode(exported.patchBytes);
+            const changedFilesText = new TextDecoder().decode(
+              await ledger.readArtifact(exported.changedFiles),
+            );
+            try {
+              const review = await runIndependentReview({
+                spec: ctx.spec,
+                patchText,
+                changedFilesText,
+                verification: verification.records,
+                verificationVerdict: ctx.verifyVerdict,
+                invoker: this.#deps.reviewer,
+                sink: ledger,
+                step: { runId: ctx.runId, stepId },
+              });
+              const nonBlocking = review.review.findings
+                .map((finding) => finding.title)
+                .filter((title) => !review.blockers.includes(title));
+              return {
+                outcome: "committed",
+                evidence: {
+                  stage: "workflow.review",
+                  attempt,
+                  review: {
+                    blockerCount: review.blockers.length,
+                    findingCount: review.review.findings.length,
+                    overallCorrectness: review.review.overallCorrectness,
+                    overallConfidenceScore:
+                      review.review.overallConfidenceScore,
+                    blockers: review.blockers,
+                    nonBlockingFindings: nonBlocking,
+                    reviewerModel: ctx.spec.reviewerModel,
+                  },
+                  artifacts: [review.artifact],
+                },
+              };
+            } catch (error) {
+              if (error instanceof ReviewParseError) {
+                return {
+                  outcome: "failed",
+                  evidence: {
+                    stage: "workflow.review",
+                    attempt,
+                    failure: {
+                      reason: "review_unparseable",
+                      message: error.message,
+                    },
+                  },
+                };
+              }
+              throw error;
+            }
+          },
+          adopt: async (existing) => this.#adoptChild(ctx, existing),
+        } satisfies EffectStepPlan;
+      },
+    });
+    const review = result.evidence.review;
+    if (review === undefined) {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "evidence_invalid",
+        finalMessage: "review committed without durable review evidence",
+      });
+    }
+    const artifact = (result.evidence.artifacts ?? [])[0];
+    if (artifact === undefined) {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "evidence_invalid",
+        finalMessage: "review committed without its independent_review artifact",
+      });
+    }
+    ctx.review = {
+      reviewerModel: review.reviewerModel,
+      overallCorrectness: review.overallCorrectness,
+      overallConfidenceScore: review.overallConfidenceScore,
+      blockerCount: review.blockerCount,
+      findingCount: review.findingCount,
+      artifact,
+    };
+    ctx.reviewNonBlocking = review.nonBlockingFindings;
+    if (review.blockerCount > 0) {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "review_rejected",
+        finalMessage: `independent review raised ${review.blockerCount} blocker(s): ${review.blockers.join("; ")}`,
+      });
+    }
+  }
+
+  async #stageFinalize(ctx: RunContext): Promise<void> {
+    const spec = ctx.spec;
+    const handle = this.#requireHandle(ctx);
+    const ledger = this.#requireLedger(ctx);
+    hitM5WorkflowFailpoint("before_patch_export");
+    const exported = await this.#deps.worktrees.exportPatch({
+      handle,
+      baseCommit: spec.baseCommit,
+      step: { runId: ctx.runId, stepId: "workflow.finalize" },
+      sink: ledger,
+    });
+    ctx.export = exported;
+    const movement = await this.#deps.worktrees.checkBaseMovement({
+      spec,
+      patchBytes: exported.patchBytes,
+    });
+
+    const risks: string[] = [];
+    if (movement.kind === "rebase_clean") {
+      risks.push(
+        `base moved to ${movement.newBaseCommit} after intake; the patch applies cleanly (3-way)`,
+      );
+    }
+    if (spec.baseDirty.dirty) {
+      risks.push(
+        `user checkout was dirty at intake (${spec.baseDirty.fileCount} file(s)); the change was built from the clean base commit`,
+      );
+    }
+    for (const finding of ctx.reviewNonBlocking ?? []) {
+      risks.push(`non-blocking review finding: ${finding}`);
+    }
+
+    const finalizeStep = await this.#driveEffect(ctx, {
+      stepId: "workflow.finalize",
+      stage: "workflow.finalize",
+      attempt: 1,
+      toolName: "workflow.finalize",
+      kind: "tool_exec",
+      recoveryCategory: "idempotent",
+      idempotencyKey: finalizeIdempotencyKey(
+        exported.patch.digest,
+        spec.baseCommit,
+      ),
+      intentDigest: sha256Digest(
+        canonicalizeJson({
+          patchDigest: exported.patch.digest,
+          baseCommit: spec.baseCommit,
+        }),
+      ),
+      estimate: ZERO_ESTIMATE,
+      execute: async (): Promise<EffectExecution> => {
+        if (movement.kind === "conflict") {
+          return {
+            outcome: "failed",
+            evidence: {
+              stage: "workflow.finalize",
+              attempt: 1,
+              finalize: {
+                headCommit: exported.headCommit,
+                treeHash: exported.treeHash,
+                baseMovement: movement.kind,
+                conflictFiles: movement.conflictFiles,
+              },
+            },
+          };
+        }
+        let riskRegister: RunArtifactPointer | undefined;
+        if (risks.length > 0) {
+          riskRegister = await ledger.recordArtifact({
+            step: { runId: ctx.runId, stepId: "workflow.finalize" },
+            role: "risk_register",
+            bytes: new TextEncoder().encode(canonicalizeJson({ risks })),
+            mediaType: "application/json",
+          });
+        }
+        hitM5WorkflowFailpoint("after_patch_export_before_seal");
+        const seal = await ledger.seal(this.#nowIso());
+        return {
+          outcome: "committed",
+          evidence: {
+            stage: "workflow.finalize",
+            attempt: 1,
+            finalize: {
+              headCommit: exported.headCommit,
+              treeHash: exported.treeHash,
+              sealDigest: seal.sealDigest,
+              baseMovement: movement.kind,
+            },
+            artifacts: [
+              exported.patch,
+              exported.changedFiles,
+              ...(riskRegister !== undefined ? [riskRegister] : []),
+            ],
+          },
+        };
+      },
+    });
+    if (finalizeStep.outcome !== "committed") {
+      if (movement.kind === "conflict") {
+        throw new WorkflowHaltError({
+          status: "failed",
+          stopReason: "base_moved_conflict",
+          finalMessage:
+            `base moved to ${movement.newBaseCommit} and the patch conflicts: ` +
+            movement.conflictFiles.join(", "),
+        });
+      }
+      throw new WorkflowHaltError({
+        status: finalizeStep.outcome === "cancelled" ? "cancelled" : "failed",
+        stopReason:
+          finalizeStep.outcome === "unknown_outcome"
+            ? "unknown_outcome_effect"
+            : finalizeStep.evidence.finalize?.baseMovement === "conflict"
+              ? "base_moved_conflict"
+              : "evidence_invalid",
+        finalMessage: `workflow finalize ${finalizeStep.outcome}`,
+      });
+    }
+    const sealDigest = finalizeStep.evidence.finalize?.sealDigest;
+    if (sealDigest === undefined) {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "evidence_invalid",
+        finalMessage: "finalize committed without a sealed-ledger digest",
+      });
+    }
+
+    // Assemble + self-validate the verified-change record (D6). All durable
+    // rows — including the just-committed finalize — feed the record.
+    let record: VerifiedChangeRecord;
+    const head = ledger.head();
+    try {
+      record = this.#assembleRecord(ctx, {
+        headCommit: exported.headCommit,
+        risks,
+        ledgerHead: head,
+      });
+    } catch (error) {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "evidence_invalid",
+        finalMessage: `verified-change record failed self-validation: ${errorMessage(error)}`,
+      });
+    }
+    if (ledger.persistRecord !== undefined) {
+      try {
+        await ledger.persistRecord(record);
+      } catch (error) {
+        this.#deps.warn(
+          `workflow ${ctx.runId} record persistence failed: ${errorMessage(error)}`,
+        );
+      }
+    }
+    hitM5WorkflowFailpoint("after_seal_before_terminal");
+    const verification = ctx.verification;
+    const review = ctx.review;
+    if (verification === undefined || review === undefined) {
+      throw new WorkflowHaltError({
+        status: "failed",
+        stopReason: "evidence_invalid",
+        finalMessage: "finalize reached without verification/review context",
+      });
+    }
+    const riskSuffix =
+      risks.length > 0
+        ? ` Non-blocking risks recorded in the risk register: ${risks.join(" | ")}`
+        : "";
+    await this.#terminalize(
+      ctx,
+      {
+        status: "completed",
+        stopReason: null,
+        finalMessage:
+          `verified change completed at ${exported.headCommit} ` +
+          `(record ${record.documentDigest}, ledger seal ${sealDigest}).` +
+          riskSuffix,
+      },
+      {
+        record,
+        allCommandsPassed: verification.allPassed,
+        verificationVerdict: ctx.verifyVerdict,
+        reviewBlockerCount: review.blockerCount,
+        ledgerSealed: head.sealed,
+      },
+    );
+    hitM5WorkflowFailpoint("after_terminal_before_cleanup");
+    try {
+      await this.#deps.worktrees.cleanup({
+        proof: mintSealedEvidenceProof({ runId: ctx.runId, sealDigest }),
+        handle,
+      });
+    } catch (error) {
+      this.#deps.warn(
+        `workflow ${ctx.runId} worktree cleanup failed after sealed evidence: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  #assembleRecord(
+    ctx: RunContext,
+    input: {
+      readonly headCommit: string;
+      readonly risks: readonly string[];
+      readonly ledgerHead: WorkflowEvidenceLedgerHead;
+    },
+  ): VerifiedChangeRecord {
+    const effects = ctx.repo.listEffects(ctx.runId);
+    const steps: VerifiedChangeStepRecord[] = [];
+    for (const effect of effects) {
+      const evidence = readWorkflowStepEvidence(effect);
+      const stage = evidence.stage;
+      if (stage === undefined) continue;
+      const status =
+        effect.outcome === undefined
+          ? "running"
+          : effect.outcome === "committed"
+            ? "committed"
+            : effect.outcome;
+      steps.push({
+        stepId: effect.stepId,
+        stage,
+        status,
+        attempt: evidence.attempt ?? 1,
+        startedAt: effect.intentAt,
+        finishedAt: effect.completedAt ?? null,
+        ...(evidence.verdict !== undefined
+          ? { verdict: evidence.verdict }
+          : {}),
+        artifacts: evidence.artifacts ?? [],
+      });
+    }
+    const verification = ctx.verification;
+    const review = ctx.review;
+    if (verification === undefined || review === undefined) {
+      throw new Error("record assembly requires verification and review context");
+    }
+    const usage = ctx.usage.any
+      ? {
+          inputTokens: ctx.usage.input,
+          outputTokens: ctx.usage.output,
+          totalTokens: ctx.usage.input + ctx.usage.output,
+          costUsd: ctx.usage.cost,
+        }
+      : null;
+    return assembleVerifiedChangeRecord({
+      runId: ctx.runId,
+      specDigest: ctx.specDigest,
+      spec: ctx.spec,
+      startedAt: ctx.startedAt,
+      finishedAt: this.#nowIso(),
+      terminal: { status: "completed", stopReason: null, finalMessage: null },
+      usage,
+      baseCommit: ctx.spec.baseCommit,
+      headCommit: input.headCommit,
+      steps,
+      verificationCommands: verification.records,
+      review,
+      unresolvedRisks: input.risks,
+      evidenceLedger: {
+        eventCount: input.ledgerHead.eventCount,
+        headEventDigest: input.ledgerHead.headEventDigest,
+        sealed: input.ledgerHead.sealed,
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Spawn-step plan builder (plan / implement / verify agent / review adopt)
+  // -------------------------------------------------------------------------
+
+  #spawnPlan(
+    ctx: RunContext,
+    input: {
+      readonly stage: WorkflowStepId;
+      readonly stepId: string;
+      readonly attempt: number;
+      readonly spawnKind: WorkflowSpawnKind;
+      readonly childRunId: string;
+      readonly prompt: string;
+      readonly decorate?: (
+        outcome: WorkflowChildOutcome,
+      ) => Partial<WorkflowStepEvidence>;
+      readonly beforeCommitFailpoints?: readonly M5WorkflowFailpoint[];
+      readonly afterCommitFailpoint?: M5WorkflowFailpoint;
+    },
+  ): EffectStepPlan {
+    const spec = ctx.spec;
+    const toEvidence = (outcome: WorkflowChildOutcome): EffectExecution => {
+      const decorated = input.decorate?.(outcome) ?? {};
+      const evidence: WorkflowStepEvidence = {
+        stage: input.stage,
+        attempt: input.attempt,
+        child: {
+          childRunId: input.childRunId,
+          status: outcome.status,
+          ...(truncate(outcome.finalMessage) !== undefined
+            ? { finalMessage: truncate(outcome.finalMessage)! }
+            : {}),
+        },
+        ...decorated,
+      };
+      const mapped: "committed" | "failed" | "cancelled" =
+        outcome.status === "completed"
+          ? "committed"
+          : outcome.status === "cancelled"
+            ? "cancelled"
+            : "failed";
+      const usage =
+        outcome.usage === null
+          ? undefined
+          : {
+              inputTokens: outcome.usage.inputTokens,
+              outputTokens: outcome.usage.outputTokens,
+              costUsd: outcome.usage.costUsd,
+            };
+      return {
+        outcome: mapped,
+        evidence,
+        ...(usage !== undefined ? { usage } : {}),
+      };
+    };
+    return {
+      stepId: input.stepId,
+      stage: input.stage,
+      attempt: input.attempt,
+      toolName: `workflow.${input.spawnKind}`,
+      kind: "spawn",
+      recoveryCategory: "side-effecting",
+      intentDigest: sha256Digest(
+        canonicalizeJson({
+          stepId: input.stepId,
+          childRunId: input.childRunId,
+          promptDigest: sha256Digest(input.prompt),
+        }),
+      ),
+      childRunId: input.childRunId,
+      estimate: {
+        maxInputTokens: SPAWN_ESTIMATE_INPUT_TOKENS,
+        maxOutputTokens: SPAWN_ESTIMATE_OUTPUT_TOKENS,
+        maxCostUsd: spec.budget.maxCostUsd ?? null,
+      },
+      ...(spec.model !== undefined ? { model: spec.model } : {}),
+      ...(spec.provider !== undefined ? { provider: spec.provider } : {}),
+      beforeCommitFailpoints: input.beforeCommitFailpoints ?? [
+        "after_spawn_before_effect_result",
+      ],
+      ...(input.afterCommitFailpoint !== undefined
+        ? { afterCommitFailpoint: input.afterCommitFailpoint }
+        : {}),
+      execute: async (signal) => {
+        const handle = this.#requireHandle(ctx);
+        const outcome = await this.#deps.spawner.spawn({
+          kind: input.spawnKind,
+          childRunId: input.childRunId,
+          spec,
+          worktreePath: handle.path,
+          prompt: input.prompt,
+          signal,
+        });
+        if (outcome.status === "unknown_outcome") {
+          // The child itself is durably unresolved; the parent effect is
+          // unknowable by construction.
+          throw new Error(
+            `child run ${input.childRunId} terminated unknown_outcome`,
+          );
+        }
+        return toEvidence(outcome);
+      },
+      adopt: async (existing) => {
+        const adopted = await this.#adoptChild(ctx, existing);
+        if (adopted === undefined) return undefined;
+        // Re-decorate verdict-bearing evidence from the adopted message.
+        const child = adopted.evidence.child;
+        if (input.decorate !== undefined && child !== undefined) {
+          return toEvidence({
+            status: child.status as RunTerminalStatus,
+            finalMessage: child.finalMessage ?? null,
+            usage: null,
+          });
+        }
+        return adopted;
+      },
+    };
+  }
+
+  async #adoptChild(
+    _ctx: RunContext,
+    existing: DurableRunEffect,
+  ): Promise<EffectExecution | undefined> {
+    const childRunId = existing.childRunId;
+    if (childRunId === undefined) return undefined;
+    const inspection = await this.#deps.spawner.inspect(childRunId);
+    if (inspection.state === "unknown") return undefined;
+    const outcome =
+      inspection.state === "terminal"
+        ? inspection.outcome
+        : await inspection.outcome;
+    if (outcome.status === "unknown_outcome") return undefined;
+    // Intent-only rows carry no evidence yet; derive stage/attempt from the
+    // durable step id itself.
+    const parsed = parseWorkflowStepId(existing.stepId);
+    const mapped: "committed" | "failed" | "cancelled" =
+      outcome.status === "completed"
+        ? "committed"
+        : outcome.status === "cancelled"
+          ? "cancelled"
+          : "failed";
+    return {
+      outcome: mapped,
+      evidence: {
+        ...(parsed !== undefined
+          ? { stage: parsed.stage, attempt: parsed.attempt }
+          : {}),
+        child: {
+          childRunId,
+          status: outcome.status,
+          ...(truncate(outcome.finalMessage) !== undefined
+            ? { finalMessage: truncate(outcome.finalMessage)! }
+            : {}),
+        },
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Per-step durable driver
+  // -------------------------------------------------------------------------
+
+  async #runStageWithRetries(
+    ctx: RunContext,
+    input: {
+      readonly stage: WorkflowStepId;
+      readonly maxAttempts: number;
+      readonly makePlan: (attempt: number) => EffectStepPlan;
+    },
+  ): Promise<{ readonly result: EffectStepResult; readonly attempt: number }> {
+    let attempt = Math.max(
+      1,
+      deriveStageProjection(input.stage, ctx.repo.listEffects(ctx.runId))
+        .attempts,
+    );
+    for (;;) {
+      const result = await this.#driveEffect(ctx, input.makePlan(attempt));
+      if (result.outcome === "committed") return { result, attempt };
+      if (result.outcome === "cancelled") {
+        throw new WorkflowHaltError({
+          status: "cancelled",
+          stopReason: null,
+          finalMessage: `workflow cancelled during ${input.stage}`,
+        });
+      }
+      if (result.outcome === "unknown_outcome") {
+        throw new WorkflowHaltError({
+          status: "unknown_outcome",
+          stopReason: "unknown_outcome_effect",
+          finalMessage: `${input.stage} attempt ${attempt} has an unresolved unknown outcome`,
+        });
+      }
+      if (attempt >= input.maxAttempts) {
+        throw new WorkflowHaltError({
+          status: "failed",
+          stopReason: "step_retries_exhausted",
+          finalMessage: `${input.stage} failed terminally after ${attempt} attempt(s)`,
+        });
+      }
+      attempt += 1;
+    }
+  }
+
+  /**
+   * The durable per-step driver: replay short-circuit → D3 recovery →
+   * admission acquire → intent journal → dispatch → execute → result
+   * journal → budget reconcile, with failpoints at every boundary.
+   */
+  async #driveEffect(
+    ctx: RunContext,
+    plan: EffectStepPlan,
+  ): Promise<EffectStepResult> {
+    const existing = ctx.repo.getEffect(ctx.runId, plan.stepId);
+    if (existing?.outcome !== undefined) {
+      // Sticky durable outcome — replay, never re-execute.
+      return {
+        outcome: existing.outcome,
+        evidence: readWorkflowStepEvidence(existing),
+        replayed: true,
+      };
+    }
+    if (existing !== undefined && plan.recoveryCategory === "side-effecting") {
+      // D3: ADOPT, never respawn.
+      const adopted = plan.adopt === undefined
+        ? undefined
+        : await plan.adopt(existing);
+      if (adopted === undefined) {
+        ctx.journal.appendUnknown({
+          stepId: plan.stepId,
+          reason: "child_outcome_unknowable_after_recovery",
+          evidence: {
+            stage: plan.stage,
+            attempt: plan.attempt,
+            ...(existing.childRunId !== undefined
+              ? { childRunId: existing.childRunId }
+              : {}),
+          },
+          observedAt: this.#nowIso(),
+        });
+        return {
+          outcome: "unknown_outcome",
+          evidence: readWorkflowStepEvidence(
+            ctx.repo.getEffect(ctx.runId, plan.stepId)!,
+          ),
+          replayed: false,
+        };
+      }
+      return this.#commitResult(ctx, plan, adopted, false);
+    }
+    // Fresh execution (or idempotent re-execution under the same durable
+    // key). Admission gates EVERY execution.
+    if (existing === undefined && plan.stage !== "workflow.intake") {
+      const effects = ctx.repo.listEffects(ctx.runId);
+      if (!stagePrerequisitesMet(plan.stage, effects)) {
+        throw new WorkflowHaltError({
+          status: "failed",
+          stopReason: null,
+          finalMessage: `internal prerequisite violation: ${plan.stage} attempted before its prerequisites committed`,
+        });
+      }
+    }
+    let lease: AdmissionLease;
+    try {
+      lease = await ctx.admission.acquire({
+        stepId: plan.stepId,
+        kind: plan.kind,
+        sessionId: ctx.journal.sessionId,
+        maxInputTokens: plan.estimate.maxInputTokens,
+        maxOutputTokens: plan.estimate.maxOutputTokens,
+        maxCostUsd: plan.estimate.maxCostUsd,
+        ...(plan.model !== undefined ? { model: plan.model } : {}),
+        ...(plan.provider !== undefined ? { provider: plan.provider } : {}),
+        ...(ctx.spec.budget.deadlineAt !== undefined
+          ? { deadlineAt: ctx.spec.budget.deadlineAt }
+          : {}),
+      });
+    } catch (error) {
+      if (error instanceof AdmissionDeniedError) {
+        throw this.#admissionHalt(plan, error);
+      }
+      throw error;
+    }
+    const reservationId = lease.reservation.reservationId;
+    let crashInjected = false;
+    let settled = false;
+    let dispatched = false;
+    try {
+      if (existing === undefined) {
+        ctx.journal.appendIntent({
+          stepId: plan.stepId,
+          callId: plan.stepId,
+          toolName: plan.toolName,
+          recoveryCategory: plan.recoveryCategory,
+          ...(plan.idempotencyKey !== undefined
+            ? { idempotencyKey: plan.idempotencyKey }
+            : {}),
+          intentDigest: plan.intentDigest,
+          ...(plan.childRunId !== undefined
+            ? { childRunId: plan.childRunId }
+            : {}),
+          intentAt: this.#nowIso(),
+        });
+      }
+      if (lease.signal.aborted) {
+        const result = this.#commitResult(
+          ctx,
+          plan,
+          {
+            outcome: "cancelled",
+            evidence: {
+              stage: plan.stage,
+              attempt: plan.attempt,
+              failure: { reason: "cancelled_before_dispatch" },
+            },
+          },
+          false,
+        );
+        ctx.admission.void(reservationId, "workflow_cancelled_before_dispatch");
+        settled = true;
+        return result;
+      }
+      if (plan.beforeExecuteFailpoint !== undefined) {
+        hitM5WorkflowFailpoint(plan.beforeExecuteFailpoint);
+      }
+      ctx.admission.markDispatched(reservationId, {
+        boundary: plan.kind === "spawn" ? "spawn_commit" : "tool_effect",
+        details: { toolName: plan.toolName, stepId: plan.stepId },
+      });
+      dispatched = true;
+      const execution = await plan.execute(lease.signal);
+      for (const failpoint of plan.beforeCommitFailpoints ?? []) {
+        hitM5WorkflowFailpoint(failpoint);
+      }
+      const result = this.#commitResult(ctx, plan, execution, false);
+      if (plan.afterCommitFailpoint !== undefined) {
+        hitM5WorkflowFailpoint(plan.afterCommitFailpoint);
+      }
+      if (execution.usage !== undefined) {
+        ctx.admission.reconcile(reservationId, execution.usage);
+        this.#accumulateUsage(ctx, execution.usage);
+      } else {
+        ctx.admission.reconcile(reservationId, {
+          inputTokens: 0,
+          outputTokens: 0,
+          costUsd: 0,
+        });
+      }
+      settled = true;
+      return result;
+    } catch (error) {
+      if (error instanceof M5WorkflowFailpointError) {
+        crashInjected = true;
+        throw error;
+      }
+      if (error instanceof WorkflowHaltError) {
+        if (!settled) {
+          if (dispatched) {
+            ctx.admission.holdUnknown(reservationId, "workflow_halt_after_dispatch");
+          } else {
+            ctx.admission.void(reservationId, "workflow_halt_before_dispatch");
+          }
+          settled = true;
+        }
+        throw error;
+      }
+      if (!settled) {
+        if (dispatched && lease.signal.aborted) {
+          this.#commitResult(
+            ctx,
+            plan,
+            {
+              outcome: "cancelled",
+              evidence: {
+                stage: plan.stage,
+                attempt: plan.attempt,
+                failure: {
+                  reason: "cancelled_after_dispatch",
+                  message: errorMessage(error),
+                },
+              },
+            },
+            true,
+          );
+          ctx.admission.holdUnknown(reservationId, "workflow_cancelled_after_dispatch");
+          settled = true;
+          throw new WorkflowHaltError({
+            status: "cancelled",
+            stopReason: null,
+            finalMessage: `workflow cancelled during ${plan.stepId}`,
+          });
+        }
+        if (dispatched && plan.recoveryCategory === "side-effecting") {
+          // The physical spawn may or may not have taken effect: the ONLY
+          // honest durable state is unknown_outcome (D3).
+          ctx.journal.appendUnknown({
+            stepId: plan.stepId,
+            reason: "spawn_failed_after_dispatch_without_acknowledgement",
+            evidence: {
+              stage: plan.stage,
+              attempt: plan.attempt,
+              failure: { reason: "spawn_error", message: errorMessage(error) },
+            },
+            observedAt: this.#nowIso(),
+          });
+          ctx.admission.holdUnknown(reservationId, "workflow_spawn_unknown");
+          settled = true;
+          throw new WorkflowHaltError({
+            status: "unknown_outcome",
+            stopReason: "unknown_outcome_effect",
+            finalMessage: `${plan.stepId} failed after dispatch without acknowledgement: ${errorMessage(error)}`,
+          });
+        }
+        // Idempotent execution failure is a KNOWN failure: durable, retryable
+        // under a new attempt id.
+        this.#commitResult(
+          ctx,
+          plan,
+          {
+            outcome: "failed",
+            evidence: {
+              stage: plan.stage,
+              attempt: plan.attempt,
+              failure: {
+                reason: "step_execution_failed",
+                message: errorMessage(error),
+              },
+            },
+          },
+          true,
+        );
+        if (dispatched) {
+          ctx.admission.reconcile(reservationId, {
+            inputTokens: 0,
+            outputTokens: 0,
+            costUsd: 0,
+          });
+        } else {
+          ctx.admission.void(reservationId, "workflow_step_failed_before_dispatch");
+        }
+        settled = true;
+        return {
+          outcome: "failed",
+          evidence: readWorkflowStepEvidence(
+            ctx.repo.getEffect(ctx.runId, plan.stepId)!,
+          ),
+          replayed: false,
+        };
+      }
+      throw error;
+    } finally {
+      if (!crashInjected) {
+        ctx.admission.acknowledgeCompletion(reservationId);
+      }
+    }
+  }
+
+  #commitResult(
+    ctx: RunContext,
+    plan: EffectStepPlan,
+    execution: EffectExecution,
+    swallowJournalErrors: boolean,
+  ): EffectStepResult {
+    try {
+      ctx.journal.appendResult({
+        stepId: plan.stepId,
+        outcome: execution.outcome,
+        resultDigest: sha256Digest(canonicalizeJson(execution.evidence)),
+        evidence: execution.evidence,
+        completedAt: this.#nowIso(),
+      });
+    } catch (error) {
+      if (error instanceof M5WorkflowFailpointError || !swallowJournalErrors) {
+        throw error;
+      }
+      this.#deps.warn(
+        `workflow ${ctx.runId} failed to journal ${plan.stepId} ${execution.outcome}: ${errorMessage(error)}`,
+      );
+    }
+    return {
+      outcome: execution.outcome,
+      evidence: execution.evidence,
+      replayed: false,
+    };
+  }
+
+  #admissionHalt(
+    plan: EffectStepPlan,
+    error: AdmissionDeniedError,
+  ): WorkflowHaltError {
+    if (error.decision === "cancelled") {
+      return new WorkflowHaltError({
+        status: "cancelled",
+        stopReason: null,
+        finalMessage: `workflow cancelled at ${plan.stepId}: ${error.reason}`,
+      });
+    }
+    if (error.decision === "approval_required") {
+      // D5: approvals resolve at intake; a mid-pipeline approval requirement
+      // terminates the run — durable, honest, replayable. No parking.
+      return new WorkflowHaltError({
+        status: "failed",
+        stopReason: "approval_required",
+        finalMessage: `admission requires approval at ${plan.stepId}: ${error.reason}`,
+      });
+    }
+    return new WorkflowHaltError({
+      status: "failed",
+      stopReason:
+        plan.stage === "workflow.intake" ? "policy_denied" : "budget_exhausted",
+      finalMessage: `admission denied at ${plan.stepId}: ${error.reason}`,
+    });
+  }
+
+  #accumulateUsage(ctx: RunContext, usage: AdmissionUsage): void {
+    ctx.usage.input += usage.inputTokens;
+    ctx.usage.output += usage.outputTokens;
+    ctx.usage.cost += usage.costUsd ?? 0;
+    ctx.usage.any = true;
+  }
+
+  // -------------------------------------------------------------------------
+  // D6 — the single terminal choke point
+  // -------------------------------------------------------------------------
+
+  async #terminalize(
+    ctx: RunContext,
+    terminal: WorkflowTerminalIntent,
+    gates?: CompletedGates,
+  ): Promise<void> {
+    if (ctx.terminalized) return;
+    const existing = ctx.repo.getCurrentTerminalResult(ctx.runId);
+    if (existing !== undefined) {
+      ctx.terminalized = true;
+      return;
+    }
+    if (terminal.status === "completed") {
+      const failures: string[] = [];
+      if (gates === undefined) failures.push("completed gates missing");
+      else {
+        if (!gates.allCommandsPassed) {
+          failures.push("a required verification command did not exit 0");
+        }
+        if (gates.verificationVerdict !== "PASS") {
+          failures.push(
+            `verification agent verdict is ${gates.verificationVerdict ?? "missing"}, not PASS`,
+          );
+        }
+        if (gates.reviewBlockerCount !== 0) {
+          failures.push(
+            `independent review holds ${gates.reviewBlockerCount} blocker(s)`,
+          );
+        }
+        if (!gates.ledgerSealed) failures.push("evidence ledger is not sealed");
+        // gates.record already passed assembleVerifiedChangeRecord's
+        // mechanical self-validation or we would never have gotten here.
+      }
+      if (failures.length > 0) {
+        this.#deps.warn(
+          `workflow ${ctx.runId} refused a completed terminal: ${failures.join("; ")}`,
+        );
+        await this.#terminalize(ctx, {
+          status: "failed",
+          stopReason: "evidence_invalid",
+          finalMessage: `completed gates failed: ${failures.join("; ")}`,
+        });
+        return;
+      }
+    }
+    try {
+      const terminalEvent = ctx.journal.appendTerminal();
+      const usage = ctx.usage.any
+        ? {
+            inputTokens: ctx.usage.input,
+            outputTokens: ctx.usage.output,
+            totalTokens: ctx.usage.input + ctx.usage.output,
+            costUsd: ctx.usage.cost,
+          }
+        : null;
+      ctx.repo.recordTerminalResult({
+        epoch: ctx.journal.epoch,
+        eventId: terminalEvent.eventId,
+        result: {
+          runId: ctx.runId,
+          status: terminal.status,
+          exitCode: terminal.status === "completed" ? 0 : 1,
+          stopReason: terminal.stopReason,
+          finalMessage: terminal.finalMessage,
+          usage,
+          lastSequence: terminalEvent.sequence,
+          finishedAt: this.#nowIso(),
+        },
+      });
+      ctx.terminalized = true;
+    } catch (error) {
+      if (error instanceof M5WorkflowFailpointError) throw error;
+      // Terminal recording must never take the daemon down; the run stays
+      // open and startup recovery terminalizes it on the next resume.
+      this.#deps.warn(
+        `workflow ${ctx.runId} failed to record its terminal result: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Context guards
+  // -------------------------------------------------------------------------
+
+  #requireHandle(ctx: RunContext): WorktreeHandle {
+    if (ctx.handle === undefined) {
+      throw new Error("workflow worktree handle is not provisioned");
+    }
+    return ctx.handle;
+  }
+
+  #requireLedger(ctx: RunContext): WorkflowEvidenceLedger {
+    if (ctx.ledger === undefined) {
+      throw new Error("workflow evidence ledger is not initialized");
+    }
+    return ctx.ledger;
+  }
+
+  #requireExport(ctx: RunContext): ExportedPatchArtifacts {
+    if (ctx.export === undefined) {
+      throw new Error("workflow patch export is not available");
+    }
+    return ctx.export;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Spec freeze + prompts
+// ---------------------------------------------------------------------------
+
+function freezeWorkflowSpec(
+  runId: string,
+  params: WorkflowStartParams,
+  base: BaseState,
+): WorkflowSpec {
+  return {
+    runId,
+    goal: params.goal,
+    repoPath: params.repoPath,
+    baseCommit: base.baseCommit,
+    baseDirty: {
+      dirty: base.dirty,
+      summaryDigest: base.summaryDigest,
+      fileCount: base.fileCount,
+    },
+    ...(params.model !== undefined ? { model: params.model } : {}),
+    ...(params.provider !== undefined ? { provider: params.provider } : {}),
+    reviewerModel:
+      params.reviewerModel ?? params.model ?? "default-reviewer",
+    permissionMode: params.permissionMode ?? "acceptEdits",
+    ...(params.unattendedAllow !== undefined
+      ? { unattendedAllow: params.unattendedAllow }
+      : {}),
+    ...(params.unattendedDeny !== undefined
+      ? { unattendedDeny: params.unattendedDeny }
+      : {}),
+    budget: params.budget ?? {},
+    requiredVerification: params.requiredVerification,
+    maxImplementAttempts:
+      params.maxImplementAttempts ?? DEFAULT_MAX_IMPLEMENT_ATTEMPTS,
+  };
+}
+
+function buildPlanPrompt(spec: WorkflowSpec): string {
+  return [
+    "You are the planning stage of a verified-change workflow.",
+    "Produce a concrete, minimal implementation plan for the goal below.",
+    "Do NOT modify any files — respond with the plan only.",
+    "",
+    "## Goal",
+    spec.goal,
+    "",
+    "## Required verification (every command must exit 0)",
+    ...spec.requiredVerification.map(
+      (command) => `- ${command.label}: ${command.script}`,
+    ),
+  ].join("\n");
+}
+
+function buildImplementPrompt(ctx: RunContext, attempt: number): string {
+  const lines = [
+    "You are the implementation stage of a verified-change workflow.",
+    "Implement the goal below inside the current worktree.",
+    "",
+    "## Goal",
+    ctx.spec.goal,
+    "",
+    "## Plan",
+    ctx.planText ?? "(no plan text recorded)",
+  ];
+  if (attempt > 1 && ctx.verification !== undefined) {
+    lines.push(
+      "",
+      `## Previous verification failure (attempt ${attempt - 1})`,
+      `Agent verdict: ${ctx.verifyVerdict ?? "missing"}`,
+      ...ctx.verification.records.map(
+        (record) =>
+          `- ${record.label}: exit ${record.exitCode}` +
+          (record.timedOut ? " (timed out)" : ""),
+      ),
+      "",
+      "Fix the failures above, then stop.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function buildVerifyAgentPrompt(
+  spec: WorkflowSpec,
+  records: readonly VerifiedChangeCommandRecord[],
+): string {
+  return [
+    "You are an ADVERSARIAL verification agent for a proposed code change.",
+    "Independently verify the change in the current worktree against the goal.",
+    "Re-run spot checks; do not trust the implementer's claims.",
+    "",
+    "## Goal",
+    spec.goal,
+    "",
+    "## Required command results",
+    ...records.map(
+      (record) =>
+        `- ${record.label}: exit ${record.exitCode}` +
+        (record.timedOut ? " (timed out)" : ""),
+    ),
+    "",
+    "End your final message with exactly one line:",
+    "VERDICT: PASS | FAIL | PARTIAL",
+  ].join("\n");
+}

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -595,6 +595,23 @@ export class StateRunDurabilityRepository {
     return row === undefined ? undefined : effectFromRow(row);
   }
 
+  /**
+   * Runs that recorded a specific durable step (e.g. `workflow.intake`).
+   * Additive M5 helper: lets the workflow controller enumerate workflow runs
+   * without a parallel registry table (D2).
+   */
+  listRunIdsWithStep(stepId: string): readonly RunId[] {
+    return this.driver
+      .prepareState<[string], { readonly run_id: string }>(
+        `SELECT DISTINCT run_id
+         FROM run_effects
+         WHERE step_id = ?
+         ORDER BY run_id ASC`,
+      )
+      .all(stepId)
+      .map((row) => row.run_id);
+  }
+
   listEffects(runId: RunId): readonly DurableRunEffect[] {
     return this.driver
       .prepareState<[string], EffectRow>(

--- a/runtime/tests/workflow/status-projection.test.ts
+++ b/runtime/tests/workflow/status-projection.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  DurableRunEffect,
+  DurableRunTerminalRecord,
+} from "../../src/state/run-durability.js";
+import { projectWorkflowStatus } from "../../src/app-server/workflow/status-projection.js";
+
+let seq = 0;
+function effect(
+  stepId: string,
+  outcome: DurableRunEffect["outcome"] | undefined,
+  evidence?: unknown,
+): DurableRunEffect {
+  seq += 1;
+  return {
+    runId: "run-1",
+    stepId,
+    epoch: 1,
+    sessionId: "session-1",
+    callId: stepId,
+    toolName: stepId,
+    recoveryCategory: "idempotent",
+    intentDigest: `sha256:${stepId}`,
+    intentEventId: `evt-${seq}`,
+    intentSequence: seq,
+    intentAt: "2026-07-20T00:00:00.000Z",
+    ...(outcome !== undefined ? { outcome } : {}),
+    ...(evidence !== undefined ? { evidence } : {}),
+    reviewStatus: "none",
+  };
+}
+
+function terminal(
+  status: DurableRunTerminalRecord["status"],
+  stopReason: string | null,
+): DurableRunTerminalRecord {
+  return {
+    runId: "run-1",
+    epoch: 1,
+    status,
+    exitCode: status === "completed" ? 0 : 1,
+    stopReason,
+    finalMessage: null,
+    usage: null,
+    lastSequence: 99,
+    finishedAt: "2026-07-20T01:00:00.000Z",
+    eventId: "evt-terminal",
+  };
+}
+
+const ARTIFACT = {
+  step: { runId: "run-1", stepId: "workflow.finalize" },
+  role: "patch" as const,
+  digest: `sha256:${"a".repeat(64)}` as const,
+  bytes: 10,
+  storagePath: `cas://sha256/${"a".repeat(64)}`,
+  recordedAt: "2026-07-20T00:30:00.000Z",
+};
+
+describe("projectWorkflowStatus", () => {
+  it("emits one entry per fixed pipeline stage, in order", () => {
+    const status = projectWorkflowStatus({ runId: "run-1", effects: [] });
+    expect(status.steps.map((step) => step.stage)).toEqual([
+      "workflow.intake",
+      "workflow.worktree",
+      "workflow.plan",
+      "workflow.implement",
+      "workflow.verify",
+      "workflow.review",
+      "workflow.finalize",
+    ]);
+    expect(status.steps.every((step) => step.status === "pending")).toBe(true);
+    expect(status.terminal).toBeUndefined();
+    expect(status.stopReason).toBeUndefined();
+  });
+
+  it("keeps downstream stages pending while a live run may still retry", () => {
+    const status = projectWorkflowStatus({
+      runId: "run-1",
+      effects: [
+        effect("workflow.intake", "committed"),
+        effect("workflow.worktree", "committed"),
+        effect("workflow.plan", "failed"),
+      ],
+    });
+    expect(status.steps[2]).toMatchObject({ status: "failed", attempts: 1 });
+    expect(status.steps[3].status).toBe("pending");
+  });
+
+  it("marks never-started stages blocked once a non-completed terminal exists", () => {
+    const status = projectWorkflowStatus({
+      runId: "run-1",
+      effects: [
+        effect("workflow.intake", "committed"),
+        effect("workflow.worktree", "committed"),
+        effect("workflow.plan", "failed"),
+      ],
+      terminal: terminal("failed", "step_retries_exhausted"),
+    });
+    expect(status.steps[3].status).toBe("blocked");
+    expect(status.steps[6].status).toBe("blocked");
+    expect(status.stopReason).toBe("step_retries_exhausted");
+    expect(status.terminal).toMatchObject({
+      status: "failed",
+      stopReason: "step_retries_exhausted",
+    });
+  });
+
+  it("surfaces attempts, verdicts, and artifact pointers", () => {
+    const status = projectWorkflowStatus({
+      runId: "run-1",
+      effects: [
+        effect("workflow.intake", "committed"),
+        effect("workflow.worktree", "committed"),
+        effect("workflow.plan", "committed"),
+        effect("workflow.implement", "committed"),
+        effect("workflow.verify.cmd.1", "committed", {
+          command: { exitCode: 1, timedOut: false },
+        }),
+        effect("workflow.verify.agent", "committed", { verdict: "FAIL" }),
+        effect("workflow.implement#2", "committed"),
+        effect("workflow.verify.cmd.1#2", "committed", {
+          command: { exitCode: 0, timedOut: false },
+        }),
+        effect("workflow.verify.agent#2", "committed", {
+          verdict: "PASS",
+          artifacts: [ARTIFACT],
+        }),
+      ],
+    });
+    const implement = status.steps[3];
+    expect(implement).toMatchObject({
+      stepId: "workflow.implement#2",
+      attempts: 2,
+      status: "committed",
+    });
+    const verify = status.steps[4];
+    expect(verify).toMatchObject({
+      stepId: "workflow.verify.agent#2",
+      attempts: 2,
+      status: "committed",
+      verdict: "PASS",
+    });
+    expect(verify.artifacts).toEqual([ARTIFACT]);
+  });
+
+  it("passes only frozen workflow stop reasons through stopReason", () => {
+    const custom = projectWorkflowStatus({
+      runId: "run-1",
+      effects: [effect("workflow.intake", "committed")],
+      terminal: terminal("failed", "something_else"),
+    });
+    expect(custom.stopReason).toBeUndefined();
+    expect(custom.terminal?.stopReason).toBe("something_else");
+  });
+
+  it("reports running for an intent-without-result step", () => {
+    const status = projectWorkflowStatus({
+      runId: "run-1",
+      effects: [
+        effect("workflow.intake", "committed"),
+        effect("workflow.worktree", undefined),
+      ],
+    });
+    expect(status.steps[1].status).toBe("running");
+  });
+});

--- a/runtime/tests/workflow/steps.test.ts
+++ b/runtime/tests/workflow/steps.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import type { DurableRunEffect } from "../../src/state/run-durability.js";
+import {
+  deriveStageProjection,
+  finalizeIdempotencyKey,
+  intakeIdempotencyKey,
+  parseWorkflowStepId,
+  stagePrerequisitesMet,
+  stageStepId,
+  verifyAgentStepId,
+  verifyCommandIdempotencyKey,
+  verifyCommandStepId,
+  worktreeIdempotencyKey,
+} from "../../src/app-server/workflow/steps.js";
+
+let seq = 0;
+function effect(
+  stepId: string,
+  outcome: DurableRunEffect["outcome"] | undefined,
+  evidence?: unknown,
+): DurableRunEffect {
+  seq += 1;
+  return {
+    runId: "run-1",
+    stepId,
+    epoch: 1,
+    sessionId: "session-1",
+    callId: stepId,
+    toolName: stepId,
+    recoveryCategory: "idempotent",
+    intentDigest: `sha256:${stepId}`,
+    intentEventId: `evt-${seq}`,
+    intentSequence: seq,
+    intentAt: "2026-07-20T00:00:00.000Z",
+    ...(outcome !== undefined ? { outcome } : {}),
+    ...(evidence !== undefined ? { evidence } : {}),
+    reviewStatus: "none",
+  };
+}
+
+describe("workflow step ids", () => {
+  it("suffixes attempts and keeps the first attempt bare", () => {
+    expect(stageStepId("workflow.implement", 1)).toBe("workflow.implement");
+    expect(stageStepId("workflow.implement", 2)).toBe("workflow.implement#2");
+    expect(verifyCommandStepId(3, 1)).toBe("workflow.verify.cmd.3");
+    expect(verifyCommandStepId(3, 2)).toBe("workflow.verify.cmd.3#2");
+    expect(verifyAgentStepId(1)).toBe("workflow.verify.agent");
+    expect(verifyAgentStepId(4)).toBe("workflow.verify.agent#4");
+  });
+
+  it("rejects invalid attempts and indexes", () => {
+    expect(() => stageStepId("workflow.plan", 0)).toThrow(RangeError);
+    expect(() => verifyCommandStepId(0, 1)).toThrow(RangeError);
+  });
+
+  it("round-trips every generated id through the parser", () => {
+    expect(parseWorkflowStepId("workflow.implement#2")).toEqual({
+      stage: "workflow.implement",
+      attempt: 2,
+      role: "stage",
+    });
+    expect(parseWorkflowStepId("workflow.verify.cmd.3#2")).toEqual({
+      stage: "workflow.verify",
+      attempt: 2,
+      role: "verify_command",
+      commandIndex: 3,
+    });
+    expect(parseWorkflowStepId("workflow.verify.agent")).toEqual({
+      stage: "workflow.verify",
+      attempt: 1,
+      role: "verify_agent",
+    });
+    expect(parseWorkflowStepId("workflow.intake")).toEqual({
+      stage: "workflow.intake",
+      attempt: 1,
+      role: "stage",
+    });
+  });
+
+  it("returns undefined for foreign or malformed step ids", () => {
+    expect(parseWorkflowStepId("tool:turn-1:call-1")).toBeUndefined();
+    expect(parseWorkflowStepId("workflow.unknown")).toBeUndefined();
+    expect(parseWorkflowStepId("workflow.implement#1")).toBeUndefined();
+    expect(parseWorkflowStepId("workflow.implement#x")).toBeUndefined();
+    expect(parseWorkflowStepId("workflow.verify.cmd.x")).toBeUndefined();
+  });
+});
+
+describe("workflow idempotency keys", () => {
+  it("derives content-addressed keys per D3", () => {
+    expect(intakeIdempotencyKey("sha256:abc")).toBe("sha256:abc");
+    expect(worktreeIdempotencyKey("m5-run1", "deadbeef")).toBe(
+      "m5-run1@deadbeef",
+    );
+    const commandKey = verifyCommandIdempotencyKey("npm test", "tree-1");
+    expect(commandKey).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(commandKey).toBe(verifyCommandIdempotencyKey("npm test", "tree-1"));
+    expect(commandKey).not.toBe(
+      verifyCommandIdempotencyKey("npm test", "tree-2"),
+    );
+    const finalizeKey = finalizeIdempotencyKey("sha256:p", "base");
+    expect(finalizeKey).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(finalizeKey).not.toBe(finalizeIdempotencyKey("sha256:q", "base"));
+  });
+
+  it("separates key domains so identical inputs cannot collide", () => {
+    expect(verifyCommandIdempotencyKey("a", "b")).not.toBe(
+      finalizeIdempotencyKey("a", "b"),
+    );
+  });
+});
+
+describe("deriveStageProjection", () => {
+  it("is pending with zero attempts when the stage never began", () => {
+    const projection = deriveStageProjection("workflow.plan", []);
+    expect(projection).toMatchObject({
+      status: "pending",
+      attempts: 0,
+      latestStepId: "workflow.plan",
+    });
+  });
+
+  it("reports intent-without-result as running", () => {
+    const projection = deriveStageProjection("workflow.plan", [
+      effect("workflow.plan", undefined),
+    ]);
+    expect(projection.status).toBe("running");
+    expect(projection.attempts).toBe(1);
+  });
+
+  it("projects only the latest attempt and counts attempts", () => {
+    const projection = deriveStageProjection("workflow.implement", [
+      effect("workflow.implement", "failed"),
+      effect("workflow.implement#2", "committed", {
+        stage: "workflow.implement",
+        attempt: 2,
+      }),
+    ]);
+    expect(projection.status).toBe("committed");
+    expect(projection.attempts).toBe(2);
+    expect(projection.latestStepId).toBe("workflow.implement#2");
+    expect(projection.verdictPassed).toBe(true);
+  });
+
+  it("keeps the verify stage running until its agent row exists", () => {
+    const projection = deriveStageProjection("workflow.verify", [
+      effect("workflow.verify.cmd.1", "committed", {
+        command: { exitCode: 0, timedOut: false },
+      }),
+    ]);
+    expect(projection.status).toBe("running");
+  });
+
+  it("passes the verify verdict only for exit-0 commands plus VERDICT PASS", () => {
+    const passing = deriveStageProjection("workflow.verify", [
+      effect("workflow.verify.cmd.1", "committed", {
+        command: { exitCode: 0, timedOut: false },
+      }),
+      effect("workflow.verify.agent", "committed", { verdict: "PASS" }),
+    ]);
+    expect(passing.status).toBe("committed");
+    expect(passing.verdict).toBe("PASS");
+    expect(passing.verdictPassed).toBe(true);
+
+    const failingCommand = deriveStageProjection("workflow.verify", [
+      effect("workflow.verify.cmd.1", "committed", {
+        command: { exitCode: 1, timedOut: false },
+      }),
+      effect("workflow.verify.agent", "committed", { verdict: "PASS" }),
+    ]);
+    expect(failingCommand.verdictPassed).toBe(false);
+
+    const failingVerdict = deriveStageProjection("workflow.verify", [
+      effect("workflow.verify.cmd.1", "committed", {
+        command: { exitCode: 0, timedOut: false },
+      }),
+      effect("workflow.verify.agent", "committed", { verdict: "FAIL" }),
+    ]);
+    expect(failingVerdict.verdictPassed).toBe(false);
+  });
+
+  it("maps review blockers to a rejected verdict", () => {
+    const rejected = deriveStageProjection("workflow.review", [
+      effect("workflow.review", "committed", {
+        review: { blockerCount: 2 },
+      }),
+    ]);
+    expect(rejected.verdict).toBe("rejected");
+    expect(rejected.verdictPassed).toBe(false);
+
+    const approved = deriveStageProjection("workflow.review", [
+      effect("workflow.review", "committed", {
+        review: { blockerCount: 0 },
+      }),
+    ]);
+    expect(approved.verdict).toBe("approved");
+    expect(approved.verdictPassed).toBe(true);
+  });
+
+  it("dominance order: running > unknown > cancelled > failed", () => {
+    expect(
+      deriveStageProjection("workflow.verify", [
+        effect("workflow.verify.cmd.1", "failed"),
+        effect("workflow.verify.agent", undefined),
+      ]).status,
+    ).toBe("running");
+    expect(
+      deriveStageProjection("workflow.verify", [
+        effect("workflow.verify.cmd.1", "unknown_outcome"),
+        effect("workflow.verify.agent", "failed"),
+      ]).status,
+    ).toBe("unknown_outcome");
+  });
+});
+
+describe("stagePrerequisitesMet", () => {
+  it("gates verify on a committed implement", () => {
+    const withoutImplement = [
+      effect("workflow.intake", "committed"),
+      effect("workflow.worktree", "committed"),
+      effect("workflow.plan", "committed"),
+      effect("workflow.implement", "failed"),
+    ];
+    expect(stagePrerequisitesMet("workflow.verify", withoutImplement)).toBe(
+      false,
+    );
+    const withImplement = [
+      ...withoutImplement,
+      effect("workflow.implement#2", "committed"),
+    ];
+    expect(stagePrerequisitesMet("workflow.verify", withImplement)).toBe(true);
+  });
+
+  it("gates review on a PASSING verify verdict, not just a committed one", () => {
+    const base = [
+      effect("workflow.intake", "committed"),
+      effect("workflow.worktree", "committed"),
+      effect("workflow.plan", "committed"),
+      effect("workflow.implement", "committed"),
+      effect("workflow.verify.cmd.1", "committed", {
+        command: { exitCode: 0, timedOut: false },
+      }),
+    ];
+    expect(
+      stagePrerequisitesMet("workflow.review", [
+        ...base,
+        effect("workflow.verify.agent", "committed", { verdict: "FAIL" }),
+      ]),
+    ).toBe(false);
+    expect(
+      stagePrerequisitesMet("workflow.review", [
+        ...base,
+        effect("workflow.verify.agent", "committed", { verdict: "PASS" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("intake has no prerequisites", () => {
+    expect(stagePrerequisitesMet("workflow.intake", [])).toBe(true);
+  });
+});

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -1,0 +1,1033 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  VerifiedChangeWorkflowController,
+  WorkflowIntakeError,
+  type WorkflowAgentSpawner,
+  type WorkflowChildInspection,
+  type WorkflowChildOutcome,
+  type WorkflowEvidenceLedger,
+  type WorkflowRunJournal,
+  type WorkflowSpawnKind,
+  type WorkflowStartParams,
+  type WorkflowWorktreeBroker,
+} from "../../src/app-server/workflow/verified-change-controller.js";
+import { AdmissionDeniedError, type ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
+import type { AdmissionLease } from "../../src/budget/admission-types.js";
+import type {
+  RunArtifactPointer,
+  RunStepIdentity,
+  WorkflowSpec,
+} from "../../src/contracts/run-contracts.js";
+import { sha256Digest } from "../../src/eval-contract/canonical-json.js";
+import type { Sha256Digest } from "../../src/eval-contract/types.js";
+import {
+  StateRunDurabilityRepository,
+} from "../../src/state/run-durability.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+import type { ReviewerInvoker } from "../../src/workflow/independent-review.js";
+import type {
+  WorkflowCommandResult,
+  WorkflowCommandRunner,
+} from "../../src/workflow/verification.js";
+import type {
+  BaseMovementCheck,
+  EvidenceArtifactSink,
+  SealedEvidenceProof,
+} from "../../src/workflow/worktree-lifecycle.js";
+import type { WorktreeHandle } from "../../src/agents/worktree.js";
+import { validateVerifiedChangeRecord, type VerifiedChangeRecord } from "../../src/workflow/evidence-record.js";
+
+// ---------------------------------------------------------------------------
+// Failpoint arming (throw action — simulated crash, nothing may be recorded)
+// ---------------------------------------------------------------------------
+
+function armFailpoint(name: string): void {
+  process.env.AGENC_TEST_DURABILITY_FAILPOINT = name;
+  process.env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN = "m5-workflow-child";
+  process.env.AGENC_TEST_DURABILITY_FAILPOINT_ACTION = "throw";
+}
+
+function disarmFailpoint(): void {
+  delete process.env.AGENC_TEST_DURABILITY_FAILPOINT;
+  delete process.env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN;
+  delete process.env.AGENC_TEST_DURABILITY_FAILPOINT_ACTION;
+}
+
+// ---------------------------------------------------------------------------
+// Scripted seams
+// ---------------------------------------------------------------------------
+
+/**
+ * Test journal writer: assigns event sequences from a per-run counter and
+ * projects straight into the REAL StateRunDurabilityRepository, mirroring
+ * RolloutStore.recordEffectEvent's journal-then-project contract.
+ */
+class TestJournal implements WorkflowRunJournal {
+  readonly sessionId: string;
+  readonly epoch: number;
+  #seq: number;
+
+  constructor(
+    private readonly repo: StateRunDurabilityRepository,
+    readonly runId: string,
+  ) {
+    this.sessionId = `${runId}-session`;
+    this.repo.ensureInitialEpoch({
+      runId,
+      openedAt: new Date().toISOString(),
+    });
+    this.epoch = this.repo.currentEpoch(runId)!.epoch;
+    let max = 0;
+    for (const effect of this.repo.listEffects(runId)) {
+      max = Math.max(max, effect.intentSequence, effect.resultSequence ?? 0);
+    }
+    this.#seq = max;
+  }
+
+  #next(): { eventId: string; sequence: number } {
+    this.#seq += 1;
+    return { eventId: `evt-${this.runId}-${this.#seq}`, sequence: this.#seq };
+  }
+
+  appendIntent(input: Parameters<WorkflowRunJournal["appendIntent"]>[0]) {
+    const ref = this.#next();
+    this.repo.beginEffect({
+      runId: this.runId,
+      epoch: this.epoch,
+      stepId: input.stepId,
+      ...(input.childRunId !== undefined
+        ? { childRunId: input.childRunId }
+        : {}),
+      sessionId: this.sessionId,
+      callId: input.callId ?? input.stepId,
+      toolName: input.toolName,
+      recoveryCategory: input.recoveryCategory,
+      ...(input.idempotencyKey !== undefined
+        ? { idempotencyKey: input.idempotencyKey }
+        : {}),
+      intentDigest: input.intentDigest,
+      eventId: ref.eventId,
+      eventSequence: ref.sequence,
+      intentAt: input.intentAt,
+    });
+    return ref;
+  }
+
+  appendResult(input: Parameters<WorkflowRunJournal["appendResult"]>[0]) {
+    const ref = this.#next();
+    this.repo.completeEffect({
+      runId: this.runId,
+      stepId: input.stepId,
+      outcome: input.outcome,
+      eventId: ref.eventId,
+      eventSequence: ref.sequence,
+      ...(input.resultDigest !== undefined
+        ? { resultDigest: input.resultDigest }
+        : {}),
+      ...(input.evidence !== undefined ? { evidence: input.evidence } : {}),
+      completedAt: input.completedAt,
+    });
+    return ref;
+  }
+
+  appendUnknown(input: Parameters<WorkflowRunJournal["appendUnknown"]>[0]) {
+    const ref = this.#next();
+    this.repo.markEffectUnknown({
+      runId: this.runId,
+      stepId: input.stepId,
+      eventId: ref.eventId,
+      eventSequence: ref.sequence,
+      reason: input.reason,
+      ...(input.evidence !== undefined ? { evidence: input.evidence } : {}),
+      observedAt: input.observedAt,
+    });
+    return ref;
+  }
+
+  appendTerminal() {
+    return this.#next();
+  }
+
+  async close(): Promise<void> {}
+}
+
+class FakeAdmission implements ExecutionAdmissionClient {
+  readonly scope = {
+    runId: "unbound",
+    workspaceId: "ws",
+    sessionId: "session",
+    budgetIdentity: "budget",
+    autonomous: true,
+  };
+  readonly acquired: string[] = [];
+  readonly reconciled: string[] = [];
+  readonly heldUnknown: { id: string; reason: string }[] = [];
+  readonly voided: { id: string; reason: string }[] = [];
+  readonly denials: {
+    match: (stepId: string) => boolean;
+    error: AdmissionDeniedError;
+  }[] = [];
+  readonly abort = new AbortController();
+  #n = 0;
+
+  async acquire(input: { stepId: string }): Promise<AdmissionLease> {
+    for (const denial of this.denials) {
+      if (denial.match(input.stepId)) throw denial.error;
+    }
+    this.#n += 1;
+    this.acquired.push(input.stepId);
+    return {
+      decision: "allow",
+      reservation: {
+        reservationId: `res-${this.#n}`,
+        step: { runId: this.scope.runId, stepId: input.stepId },
+        reservedCostUsd: 0,
+        reservedTokens: 0,
+        reservedAt: new Date().toISOString(),
+      },
+      request: {} as AdmissionLease["request"],
+      signal: this.abort.signal,
+    };
+  }
+
+  markDispatched(): void {}
+  reconcile(reservationId: string) {
+    this.reconciled.push(reservationId);
+    return { applied: true, outcome: "reconciled" } as const;
+  }
+  holdUnknown(reservationId: string, reason: string): void {
+    this.heldUnknown.push({ id: reservationId, reason });
+  }
+  cancelRun(): void {}
+  void(reservationId: string, reason: string): void {
+    this.voided.push({ id: reservationId, reason });
+  }
+  acknowledgeCompletion(): void {}
+  recordFallback(): void {}
+  forSession(): ExecutionAdmissionClient {
+    return this;
+  }
+  subscribe(): () => void {
+    return () => {};
+  }
+}
+
+class MemoryLedger implements WorkflowEvidenceLedger {
+  readonly payloads = new Map<string, Uint8Array>();
+  readonly recordedRoles: string[] = [];
+  readonly records: VerifiedChangeRecord[] = [];
+  #eventIds = new Set<string>();
+  #eventCount = 1;
+  #headDigest: Sha256Digest;
+  sealed = false;
+  sealDigest?: string;
+  corruptHead = false;
+
+  constructor(runId: string) {
+    this.#headDigest = sha256Digest(`genesis:${runId}`);
+  }
+
+  async recordArtifact(input: {
+    step: RunStepIdentity;
+    role: RunArtifactPointer["role"];
+    bytes: Uint8Array;
+    mediaType: string;
+  }): Promise<RunArtifactPointer> {
+    const digest = sha256Digest(input.bytes);
+    const hex = digest.slice("sha256:".length);
+    this.payloads.set(hex, input.bytes);
+    const eventId = `${input.step.stepId}:${input.role}:${hex}`;
+    if (!this.#eventIds.has(eventId)) {
+      this.#eventIds.add(eventId);
+      this.#eventCount += 1;
+      this.#headDigest = sha256Digest(`${this.#headDigest}|${eventId}`);
+      this.recordedRoles.push(input.role);
+    }
+    return {
+      step: input.step,
+      role: input.role,
+      digest: digest as `sha256:${string}`,
+      bytes: input.bytes.byteLength,
+      storagePath: `cas://sha256/${hex}`,
+      recordedAt: new Date().toISOString(),
+    };
+  }
+
+  head() {
+    return {
+      eventCount: this.corruptHead ? 0 : this.#eventCount,
+      headEventDigest: this.#headDigest,
+      sealed: this.sealed,
+    };
+  }
+
+  async readArtifact(pointer: RunArtifactPointer): Promise<Uint8Array> {
+    const bytes = this.payloads.get(pointer.digest.slice("sha256:".length));
+    if (bytes === undefined) throw new Error(`missing payload ${pointer.digest}`);
+    return bytes;
+  }
+
+  async seal(): Promise<{ sealDigest: string }> {
+    this.sealed = true;
+    this.sealDigest ??= sha256Digest(`seal:${this.#headDigest}`);
+    return { sealDigest: this.sealDigest };
+  }
+
+  async persistRecord(record: VerifiedChangeRecord): Promise<void> {
+    this.records.push(record);
+  }
+}
+
+const BASE_COMMIT = "c".repeat(40);
+const HEAD_COMMIT = "d".repeat(40);
+
+class FakeWorktrees implements WorkflowWorktreeBroker {
+  dirty = false;
+  movement: BaseMovementCheck = { kind: "unmoved" };
+  patchText = "diff --git a/f b/f\n--- a/f\n+++ b/f\n+x\n";
+  provisions = 0;
+  readonly cleanups: { proof: SealedEvidenceProof; handle: WorktreeHandle }[] =
+    [];
+
+  async captureBaseState() {
+    return {
+      baseCommit: BASE_COMMIT,
+      dirty: this.dirty,
+      fileCount: this.dirty ? 3 : 0,
+      summaryDigest: sha256Digest("status") as `sha256:${string}`,
+    };
+  }
+
+  async provision(
+    spec: Pick<WorkflowSpec, "runId" | "repoPath" | "baseCommit">,
+  ): Promise<WorktreeHandle> {
+    this.provisions += 1;
+    return {
+      path: `/wt/${spec.runId}`,
+      branch: "agenc/m5",
+      gitRoot: spec.repoPath,
+      created: this.provisions === 1,
+    };
+  }
+
+  async exportPatch(input: {
+    handle: WorktreeHandle;
+    baseCommit: string;
+    step: RunStepIdentity;
+    sink: EvidenceArtifactSink;
+  }) {
+    const patchBytes = new TextEncoder().encode(this.patchText);
+    const patch = await input.sink.recordArtifact({
+      step: input.step,
+      role: "patch",
+      bytes: patchBytes,
+      mediaType: "text/x-patch",
+    });
+    const changedFiles = await input.sink.recordArtifact({
+      step: input.step,
+      role: "changed_files",
+      bytes: new TextEncoder().encode("M\tf\n"),
+      mediaType: "text/plain",
+    });
+    return {
+      patch,
+      changedFiles,
+      headCommit: HEAD_COMMIT,
+      treeHash: sha256Digest(this.patchText).slice("sha256:".length),
+      patchBytes,
+    };
+  }
+
+  async checkBaseMovement() {
+    return this.movement;
+  }
+
+  async cleanup(input: {
+    proof: SealedEvidenceProof;
+    handle: WorktreeHandle;
+  }): Promise<void> {
+    this.cleanups.push(input);
+  }
+}
+
+const DEFAULT_USAGE = {
+  inputTokens: 100,
+  outputTokens: 50,
+  totalTokens: 150,
+  costUsd: 0.02,
+};
+
+class FakeSpawner implements WorkflowAgentSpawner {
+  readonly spawns: {
+    kind: WorkflowSpawnKind;
+    childRunId: string;
+    prompt: string;
+  }[] = [];
+  readonly queues = new Map<WorkflowSpawnKind, WorkflowChildOutcome[]>();
+  readonly inspections = new Map<string, WorkflowChildInspection>();
+  beforeReturn?: (input: { kind: WorkflowSpawnKind }) => void;
+
+  queue(kind: WorkflowSpawnKind, outcome: WorkflowChildOutcome): void {
+    const queue = this.queues.get(kind) ?? [];
+    queue.push(outcome);
+    this.queues.set(kind, queue);
+  }
+
+  #default(kind: WorkflowSpawnKind): WorkflowChildOutcome {
+    const finalMessage =
+      kind === "plan"
+        ? "PLAN: make the edit"
+        : kind === "verify_agent"
+          ? "checked everything\nVERDICT: PASS"
+          : "done";
+    return { status: "completed", finalMessage, usage: DEFAULT_USAGE };
+  }
+
+  async spawn(input: {
+    kind: WorkflowSpawnKind;
+    childRunId: string;
+    prompt: string;
+  }): Promise<WorkflowChildOutcome> {
+    this.spawns.push({
+      kind: input.kind,
+      childRunId: input.childRunId,
+      prompt: input.prompt,
+    });
+    const queue = this.queues.get(input.kind);
+    const outcome =
+      queue !== undefined && queue.length > 0
+        ? queue.shift()!
+        : this.#default(input.kind);
+    this.beforeReturn?.(input);
+    return outcome;
+  }
+
+  async inspect(childRunId: string): Promise<WorkflowChildInspection> {
+    return this.inspections.get(childRunId) ?? { state: "unknown" };
+  }
+}
+
+const APPROVING_REVIEW = JSON.stringify({
+  findings: [],
+  overallCorrectness: "correct",
+  overallExplanation: "clean change",
+  overallConfidenceScore: 0.9,
+});
+
+class FakeReviewer implements ReviewerInvoker {
+  readonly invocations: { reviewerModel: string; userMessage: string }[] = [];
+  readonly responses: string[] = [];
+
+  async invoke(input: {
+    reviewerModel: string;
+    userMessage: string;
+  }): Promise<string> {
+    this.invocations.push({
+      reviewerModel: input.reviewerModel,
+      userMessage: input.userMessage,
+    });
+    return this.responses.shift() ?? APPROVING_REVIEW;
+  }
+}
+
+class FakeCommands implements WorkflowCommandRunner {
+  readonly byScript = new Map<string, Partial<WorkflowCommandResult>>();
+  readonly executed: string[] = [];
+
+  async run(input: { script: string }): Promise<WorkflowCommandResult> {
+    this.executed.push(input.script);
+    return {
+      exitCode: 0,
+      stdout: new TextEncoder().encode("ok\n"),
+      stderr: new Uint8Array(0),
+      timedOut: false,
+      truncated: false,
+      durationMs: 3,
+      ...this.byScript.get(input.script),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  home: string;
+  cwd: string;
+  driver: StateSqliteDriver;
+  repo: StateRunDurabilityRepository;
+  admission: FakeAdmission;
+  worktrees: FakeWorktrees;
+  spawner: FakeSpawner;
+  reviewer: FakeReviewer;
+  commands: FakeCommands;
+  ledgers: Map<string, MemoryLedger>;
+  warnings: string[];
+  controller: VerifiedChangeWorkflowController;
+  cleanup(): void;
+}
+
+const RUN_ID = "run-wf-1";
+
+function makeHarness(): Harness {
+  const home = mkdtempSync(join(tmpdir(), "agenc-m5-controller-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "agenc-m5-controller-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  const driver = openStateDatabases({ cwd, agencHome: home });
+  const repo = new StateRunDurabilityRepository(driver);
+  const admission = new FakeAdmission();
+  const worktrees = new FakeWorktrees();
+  const spawner = new FakeSpawner();
+  const reviewer = new FakeReviewer();
+  const commands = new FakeCommands();
+  const ledgers = new Map<string, MemoryLedger>();
+  const warnings: string[] = [];
+  const controller = new VerifiedChangeWorkflowController({
+    durability: () => repo,
+    journal: { open: async (runId) => new TestJournal(repo, runId) },
+    admission: ({ runId }) => {
+      admission.scope.runId = runId;
+      return admission;
+    },
+    worktrees,
+    commands,
+    spawner,
+    reviewer,
+    evidenceLedger: async (spec) => {
+      let ledger = ledgers.get(spec.runId);
+      if (ledger === undefined) {
+        ledger = new MemoryLedger(spec.runId);
+        ledgers.set(spec.runId, ledger);
+      }
+      return ledger;
+    },
+    warn: (message) => warnings.push(message),
+  });
+  return {
+    home,
+    cwd,
+    driver,
+    repo,
+    admission,
+    worktrees,
+    spawner,
+    reviewer,
+    commands,
+    ledgers,
+    warnings,
+    controller,
+    cleanup: () => {
+      driver.close();
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+function startParams(
+  harness: Harness,
+  overrides: Partial<WorkflowStartParams> = {},
+): WorkflowStartParams {
+  return {
+    goal: "Fix the reported bug",
+    repoPath: harness.cwd,
+    model: "test-model",
+    reviewerModel: "test-reviewer",
+    requiredVerification: [{ label: "unit", script: "run-tests" }],
+    maxImplementAttempts: 2,
+    runId: RUN_ID,
+    ...overrides,
+  };
+}
+
+async function runToTerminal(
+  harness: Harness,
+  overrides: Partial<WorkflowStartParams> = {},
+): Promise<void> {
+  const result = await harness.controller.start(startParams(harness, overrides));
+  await harness.controller.awaitRun(result.runId);
+}
+
+let harness: Harness;
+
+beforeEach(() => {
+  harness = makeHarness();
+});
+
+afterEach(() => {
+  disarmFailpoint();
+  harness.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VerifiedChangeWorkflowController — happy path", () => {
+  it("drives the full pipeline to a completed terminal with sealed evidence", async () => {
+    // One non-blocking finding: it must land in the risk register and the
+    // final message, never block completion (D6).
+    harness.reviewer.responses.push(
+      JSON.stringify({
+        findings: [
+          {
+            title: "Consider renaming",
+            body: "cosmetic",
+            confidenceScore: 0.8,
+            priority: 3,
+            codeLocation: {
+              absolutePath: "/f",
+              lineRange: { start: 1, end: 1 },
+            },
+          },
+        ],
+        overallCorrectness: "correct",
+        overallExplanation: "good",
+        overallConfidenceScore: 0.9,
+      }),
+    );
+    const started = await harness.controller.start(startParams(harness));
+    expect(started.runId).toBe(RUN_ID);
+    expect(started.baseCommit).toBe(BASE_COMMIT);
+    expect(started.specDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    await harness.controller.awaitRun(RUN_ID);
+
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID);
+    expect(terminal).toMatchObject({
+      status: "completed",
+      exitCode: 0,
+      stopReason: null,
+    });
+    expect(terminal!.finalMessage).toContain(HEAD_COMMIT);
+    expect(terminal!.finalMessage).toContain("Consider renaming");
+    expect(terminal!.usage).not.toBeNull();
+
+    // Admission gated EVERY step, exactly once each.
+    expect(harness.admission.acquired).toEqual([
+      "workflow.intake",
+      "workflow.worktree",
+      "workflow.plan",
+      "workflow.implement",
+      "workflow.verify.cmd.1",
+      "workflow.verify.agent",
+      "workflow.review",
+      "workflow.finalize",
+    ]);
+
+    // The evidence record self-validated, was persisted, and is complete.
+    const ledger = harness.ledgers.get(RUN_ID)!;
+    expect(ledger.sealed).toBe(true);
+    expect(ledger.records).toHaveLength(1);
+    const record = ledger.records[0];
+    expect(validateVerifiedChangeRecord(record).valid).toBe(true);
+    expect(record.terminal.status).toBe("completed");
+    expect(record.unresolvedRisks).toEqual([
+      "non-blocking review finding: Consider renaming",
+    ]);
+    expect(ledger.recordedRoles).toContain("patch");
+    expect(ledger.recordedRoles).toContain("changed_files");
+    expect(ledger.recordedRoles).toContain("test_result");
+    expect(ledger.recordedRoles).toContain("independent_review");
+    expect(ledger.recordedRoles).toContain("risk_register");
+
+    // Cleanup ran only after the seal, with the minted proof.
+    expect(harness.worktrees.cleanups).toHaveLength(1);
+    expect(harness.worktrees.cleanups[0].proof.sealDigest).toBe(
+      ledger.sealDigest,
+    );
+
+    // Status projection: every stage committed, verify verdict PASS.
+    const status = harness.controller.status(RUN_ID)!;
+    expect(status.steps.every((step) => step.status === "committed")).toBe(
+      true,
+    );
+    expect(status.steps[4].verdict).toBe("PASS");
+    expect(status.terminal?.status).toBe("completed");
+
+    // The reviewer saw the pinned model and the exported patch.
+    expect(harness.reviewer.invocations[0].reviewerModel).toBe("test-reviewer");
+    expect(harness.reviewer.invocations[0].userMessage).toContain(
+      harness.worktrees.patchText.trim(),
+    );
+  });
+
+  it("resumeOpenWorkflows skips runs that are already terminal", async () => {
+    await runToTerminal(harness);
+    await expect(harness.controller.resumeOpenWorkflows()).resolves.toEqual([]);
+  });
+});
+
+describe("VerifiedChangeWorkflowController — stop reasons", () => {
+  it("verification_failed after the bounded re-implement budget is exhausted", async () => {
+    harness.commands.byScript.set("run-tests", { exitCode: 1 });
+    await runToTerminal(harness);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal).toMatchObject({
+      status: "failed",
+      stopReason: "verification_failed",
+    });
+    // Two implement attempts, two verify attempts, all durably recorded.
+    const stepIds = harness.repo.listEffects(RUN_ID).map((e) => e.stepId);
+    expect(stepIds).toContain("workflow.implement");
+    expect(stepIds).toContain("workflow.implement#2");
+    expect(stepIds).toContain("workflow.verify.cmd.1");
+    expect(stepIds).toContain("workflow.verify.cmd.1#2");
+    expect(stepIds).toContain("workflow.verify.agent#2");
+    expect(stepIds).not.toContain("workflow.review");
+    // The re-implement prompt carried the failure evidence forward.
+    const implementSpawns = harness.spawner.spawns.filter(
+      (spawn) => spawn.kind === "implement",
+    );
+    expect(implementSpawns).toHaveLength(2);
+    expect(implementSpawns[1].prompt).toContain("Previous verification failure");
+  });
+
+  it("review_rejected on blocking findings, with the review durably committed", async () => {
+    harness.reviewer.responses.push(
+      JSON.stringify({
+        findings: [
+          {
+            title: "Breaks the API contract",
+            body: "bad",
+            confidenceScore: 0.9,
+            priority: 0,
+            codeLocation: {
+              absolutePath: "/f",
+              lineRange: { start: 1, end: 2 },
+            },
+          },
+        ],
+        overallCorrectness: "correct",
+        overallExplanation: "found a blocker",
+        overallConfidenceScore: 0.8,
+      }),
+    );
+    await runToTerminal(harness);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal).toMatchObject({
+      status: "failed",
+      stopReason: "review_rejected",
+    });
+    expect(terminal.finalMessage).toContain("Breaks the API contract");
+    const review = harness.repo.getEffect(RUN_ID, "workflow.review")!;
+    expect(review.outcome).toBe("committed");
+    // finalize never started.
+    expect(harness.repo.getEffect(RUN_ID, "workflow.finalize")).toBeUndefined();
+  });
+
+  it("base_moved_conflict when the base moved and the patch conflicts", async () => {
+    harness.worktrees.movement = {
+      kind: "conflict",
+      newBaseCommit: "e".repeat(40),
+      conflictFiles: ["src/f.ts"],
+    };
+    await runToTerminal(harness);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal).toMatchObject({
+      status: "failed",
+      stopReason: "base_moved_conflict",
+    });
+    expect(terminal.finalMessage).toContain("src/f.ts");
+    const finalize = harness.repo.getEffect(RUN_ID, "workflow.finalize")!;
+    expect(finalize.outcome).toBe("failed");
+    // No cleanup without sealed evidence.
+    expect(harness.worktrees.cleanups).toHaveLength(0);
+  });
+
+  it("budget_exhausted on a mid-pipeline admission deny", async () => {
+    harness.admission.denials.push({
+      match: (stepId) => stepId.startsWith("workflow.implement"),
+      error: new AdmissionDeniedError("run budget ceiling reached", "deny"),
+    });
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "budget_exhausted",
+    });
+  });
+
+  it("policy_denied at intake terminates before any pipeline step", async () => {
+    harness.admission.denials.push({
+      match: (stepId) => stepId === "workflow.intake",
+      error: new AdmissionDeniedError("policy refused unattended writes", "deny"),
+    });
+    await expect(
+      harness.controller.start(startParams(harness)),
+    ).rejects.toBeInstanceOf(WorkflowIntakeError);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "policy_denied",
+    });
+    expect(harness.repo.listEffects(RUN_ID)).toHaveLength(0);
+    expect(harness.spawner.spawns).toHaveLength(0);
+  });
+
+  it("approval_required mid-pipeline terminates failed — no parking (D5)", async () => {
+    harness.admission.denials.push({
+      match: (stepId) => stepId.startsWith("workflow.review"),
+      error: new AdmissionDeniedError(
+        "reviewer spawn needs interactive approval",
+        "approval_required",
+      ),
+    });
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "approval_required",
+    });
+  });
+
+  it("evidence_invalid when the record fails mechanical self-validation", async () => {
+    const ledger = new MemoryLedger(RUN_ID);
+    ledger.corruptHead = true;
+    harness.ledgers.set(RUN_ID, ledger);
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "evidence_invalid",
+    });
+    // Sealed but never completed, never cleaned up.
+    expect(harness.worktrees.cleanups).toHaveLength(0);
+  });
+
+  it("step_retries_exhausted when a stage fails terminally past its retry budget", async () => {
+    harness.spawner.queue("plan", {
+      status: "failed",
+      finalMessage: "planner crashed",
+      usage: null,
+    });
+    harness.spawner.queue("plan", {
+      status: "failed",
+      finalMessage: "planner crashed again",
+      usage: null,
+    });
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "step_retries_exhausted",
+    });
+    const stepIds = harness.repo.listEffects(RUN_ID).map((e) => e.stepId);
+    expect(stepIds).toContain("workflow.plan");
+    expect(stepIds).toContain("workflow.plan#2");
+  });
+
+  it("cancellation observed mid-pipeline terminalizes cancelled", async () => {
+    harness.admission.denials.push({
+      match: (stepId) => stepId.startsWith("workflow.implement"),
+      error: new AdmissionDeniedError("run.cancel cascade", "cancelled"),
+    });
+    await runToTerminal(harness);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal.status).toBe("cancelled");
+    expect(terminal.exitCode).toBe(1);
+  });
+});
+
+describe("VerifiedChangeWorkflowController — prerequisite gating", () => {
+  it("verify never starts when implement failed terminally", async () => {
+    harness.spawner.queue("implement", {
+      status: "failed",
+      finalMessage: "no",
+      usage: null,
+    });
+    harness.spawner.queue("implement", {
+      status: "failed",
+      finalMessage: "still no",
+      usage: null,
+    });
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "step_retries_exhausted",
+    });
+    const stepIds = harness.repo.listEffects(RUN_ID).map((e) => e.stepId);
+    expect(stepIds.some((id) => id.startsWith("workflow.verify"))).toBe(false);
+    expect(harness.commands.executed).toHaveLength(0);
+    expect(
+      harness.spawner.spawns.filter((s) => s.kind === "verify_agent"),
+    ).toHaveLength(0);
+  });
+});
+
+describe("VerifiedChangeWorkflowController — crash recovery (D3)", () => {
+  it("an interrupted idempotent step re-executes under the same durable key", async () => {
+    armFailpoint("before_worktree_provision");
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    const interrupted = harness.repo.getEffect(RUN_ID, "workflow.worktree")!;
+    expect(interrupted.outcome).toBeUndefined();
+    expect(interrupted.recoveryCategory).toBe("idempotent");
+    const key = interrupted.idempotencyKey;
+    expect(key).toContain(`@${BASE_COMMIT}`);
+
+    disarmFailpoint();
+    const resumed = await harness.controller.resumeOpenWorkflows();
+    expect(resumed).toEqual([RUN_ID]);
+    await harness.controller.awaitRun(RUN_ID);
+
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    const recovered = harness.repo.getEffect(RUN_ID, "workflow.worktree")!;
+    expect(recovered.outcome).toBe("committed");
+    expect(recovered.idempotencyKey).toBe(key);
+    // Same step id — re-execution, not a new attempt.
+    expect(
+      harness.repo
+        .listEffects(RUN_ID)
+        .filter((e) => e.stepId.startsWith("workflow.worktree")),
+    ).toHaveLength(1);
+  });
+
+  it("an interrupted side-effecting spawn ADOPTS its terminal child, never respawns", async () => {
+    harness.spawner.beforeReturn = (input) => {
+      if (input.kind === "implement") {
+        armFailpoint("after_spawn_before_effect_result");
+      }
+    };
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    harness.spawner.beforeReturn = undefined as never;
+    disarmFailpoint();
+
+    const interrupted = harness.repo.getEffect(RUN_ID, "workflow.implement")!;
+    expect(interrupted.outcome).toBeUndefined();
+    expect(interrupted.childRunId).toBe(`${RUN_ID}:implement#1`);
+
+    harness.spawner.inspections.set(`${RUN_ID}:implement#1`, {
+      state: "terminal",
+      outcome: { status: "completed", finalMessage: "done", usage: null },
+    });
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    const adopted = harness.repo.getEffect(RUN_ID, "workflow.implement")!;
+    expect(adopted.outcome).toBe("committed");
+    // Exactly ONE implement spawn ever happened.
+    expect(
+      harness.spawner.spawns.filter((s) => s.kind === "implement"),
+    ).toHaveLength(1);
+  });
+
+  it("a live child is re-awaited during adoption", async () => {
+    harness.spawner.beforeReturn = (input) => {
+      if (input.kind === "implement") {
+        armFailpoint("after_spawn_before_effect_result");
+      }
+    };
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    harness.spawner.beforeReturn = undefined as never;
+    disarmFailpoint();
+
+    harness.spawner.inspections.set(`${RUN_ID}:implement#1`, {
+      state: "live",
+      outcome: Promise.resolve({
+        status: "completed",
+        finalMessage: "late finish",
+        usage: null,
+      }),
+    });
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    expect(
+      harness.spawner.spawns.filter((s) => s.kind === "implement"),
+    ).toHaveLength(1);
+  });
+
+  it("an unknowable child marks the effect unknown and terminalizes unknown_outcome", async () => {
+    harness.spawner.beforeReturn = (input) => {
+      if (input.kind === "implement") {
+        armFailpoint("after_spawn_before_effect_result");
+      }
+    };
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    harness.spawner.beforeReturn = undefined as never;
+    disarmFailpoint();
+
+    // No inspection registered → the child's outcome is unknowable.
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal).toMatchObject({
+      status: "unknown_outcome",
+      stopReason: "unknown_outcome_effect",
+    });
+    const effect = harness.repo.getEffect(RUN_ID, "workflow.implement")!;
+    expect(effect.outcome).toBe("unknown_outcome");
+    expect(effect.reviewStatus).toBe("pending");
+    // Never respawned.
+    expect(
+      harness.spawner.spawns.filter((s) => s.kind === "implement"),
+    ).toHaveLength(1);
+  });
+
+  it("an intake interrupted before its commit fails closed on resume", async () => {
+    armFailpoint("before_intake_commit");
+    await expect(
+      harness.controller.start(startParams(harness)),
+    ).rejects.toThrow(/failpoint/);
+    disarmFailpoint();
+    expect(
+      harness.repo.getEffect(RUN_ID, "workflow.intake")?.outcome,
+    ).toBeUndefined();
+
+    const resumed = await harness.controller.resumeOpenWorkflows();
+    expect(resumed).toEqual([RUN_ID]);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal.status).toBe("failed");
+    expect(terminal.finalMessage).toContain("re-submit");
+    expect(harness.repo.getEffect(RUN_ID, "workflow.intake")?.outcome).toBe(
+      "failed",
+    );
+  });
+
+  it("a crash after the verify commit resumes into review without re-running verification", async () => {
+    armFailpoint("after_verify_commit");
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    disarmFailpoint();
+    expect(harness.commands.executed).toHaveLength(1);
+    expect(harness.repo.getEffect(RUN_ID, "workflow.verify.agent")?.outcome).toBe(
+      "committed",
+    );
+
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    // Commands and the verify agent were replayed from durable rows, not
+    // re-executed: sticky (run_id, step_id) outcomes.
+    expect(harness.commands.executed).toHaveLength(1);
+    expect(
+      harness.spawner.spawns.filter((s) => s.kind === "verify_agent"),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Phase 4 of the M5 verified-change workflow: the durable controller driving the fixed pipeline as effects over the M3/M4 spine. No new tables (one additive repo query, `listRunIdsWithStep`); step state is a pure projection of `run_effects`.

- Per-step driver: admission acquire → intent journal → markDispatched → execute → result journal → reconcile, with armed M5 failpoints at every boundary and `acknowledgeCompletion` in `finally`.
- D3 recovery on resume: idempotent steps re-execute under content-derived keys; side-effecting spawns are ADOPTED never respawned (deterministic child run ids recorded in the intent; terminal child completes the parent effect, unknowable child → `unknown_outcome`).
- D6 terminal choke point: `completed` re-verifies all gates (commands exit 0, VERDICT: PASS, zero review blockers, sealed self-validated evidence record) and demotes to `failed/evidence_invalid` otherwise; `recordTerminalResult` on every path.
- Daemon wiring beside the admission kernel; session-coupled adapters are a marked `WorkflowSeamPendingError` seam until Phase 5's `run.start` lands; startup resume warn-skips undrivable runs without touching durable state.
- Design doc: `docs/design/verified-change-workflow-m5.md`.

## Verification (local)
- typecheck clean; full stable vitest green (exit 0)
- tests/workflow: 66 passed (40 new: 18 controller over the REAL StateRunDurabilityRepository on temp SQLite, 14 steps, 8 projection) — all 9 stop-reason paths, prerequisite gating, cancellation, resume at 4 interruption points with real armed failpoints
- tests/state: 198 passed; daemon-cli suites green
- Adoption-path revert check: breaking adoption fails 2 recovery tests
- Tested SHA: 9f4015a9146bc9b0cae6c63d0fa52443502d6f03