### PR TITLE
feat(workflow): M5 exit proofs — durable child adoption, session policy, evidence reconstruction (Phase 6/6)

### DIFF
--- a/docs/design/verified-change-workflow-m5.md
+++ b/docs/design/verified-change-workflow-m5.md
@@ -59,7 +59,19 @@ Effect classification drives restart recovery:
   effect from its durable result, a live child is re-awaited, an unknowable
   child marks the effect `unknown_outcome` and the run terminates
   `unknown_outcome` with review pending. No mutation is ever silently
-  replayed.
+  replayed. Adoption survives daemon restarts: when a spawned child settles,
+  its terminal outcome is durably recorded through the EXISTING run
+  machinery (its own `run_lifecycle_epochs` + immutable
+  `run_terminal_results` rows, keyed by the deterministic child run id the
+  effect intent already carries) BEFORE the parent `effect_result` can
+  commit. A post-restart `inspect(childRunId)` therefore adopts the durable
+  terminal — this closes exactly the
+  `after_spawn_before_effect_result` crash window when the child finished
+  first. A child that genuinely died mid-flight with the daemon recorded no
+  terminal and honestly stays "unknown" → `unknown_outcome`. (The
+  independent-review child settles inside its own effect execution and does
+  not yet record a separate durable terminal; a crash mid-review still
+  resolves `unknown_outcome` — an explicit M6 candidate.)
 
 Dependency unlocks stop on failed verification, cancellation, budget
 exhaustion, and `unknown_outcome` — enforced first by the controller's
@@ -71,6 +83,16 @@ A failed verification earns one bounded re-implement attempt
 (`workflow.implement#2`, fresh verify sub-steps) when the spec's
 `maxImplementAttempts` and remaining budget allow; otherwise the run
 terminates `failed/verification_failed`.
+
+## Session policy
+
+The frozen spec's `permissionMode` and unattended allow/deny lists govern the
+run's daemon session, applied when the session is bootstrapped for the run —
+the exact background-agent mechanism (`--yolo`/`--permission-mode` bootstrap
+argv plus the unattended permission-policy install on the session's
+permission-mode registry). Resumed runs re-resolve the same policy from the
+durable intake spec, so a restarted daemon never silently downgrades a run to
+its default policy.
 
 ## Checkout protection
 
@@ -135,3 +157,14 @@ digests, review output, spec digest, terminal status, and unresolved risks
 are all re-derivable and re-verifiable from the exported bytes alone —
 reconstructing what happened requires no daemon, no SQLite, and no trust in
 the final prose summary.
+
+`reconstructVerifiedChange(bundleDir)`
+(`runtime/src/workflow/evidence-reconstruction.ts`) is the mechanical form of
+that claim: it re-validates the record (canonical document digest + spec
+binding), verifies the sealed hash chain via `verifyEvidenceLedger` — pinned
+by the `evidenceLedger.sealDigest` the completed record now carries and the
+bundle's local anchor material — recomputes every artifact digest from the
+exact CAS bytes, re-derives the review blockers from the
+`independent_review` artifact, and cross-checks the recorded verification
+commands against a `test_result` artifact. Any tampered byte fails loudly
+with a typed error; a summary is never produced from unverified bytes.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -258,22 +258,50 @@ Design: [`../design/execution-admission-kernel.md`](../design/execution-admissio
 ## `run`
 
 ```text
-agenc run status <run-id>
+agenc run start --goal <text> [--goal-file <path>] [--cwd <dir>]
+                [--model <model>] [--reviewer-model <model>]
+                [--max-cost <usd>] [--permission-mode <mode>]
+                [--verify "label=script"]... [--json] [--follow]
+agenc run status <run-id> [--json]
 agenc run result <run-id>
 agenc run replay <run-id> [--after <sequence>] [--limit <1-200>]
 agenc run evidence <run-id> [--after <sequence>] [--limit <1-200>]
 agenc run cancel <run-id> [--reason <text>]
 ```
 
-These commands use the daemon's durable run/admission contract and print
+`run start` launches the M5 **verified-change workflow** as a durable daemon
+run: intake freezes the spec (goal, base commit, pinned reviewer model,
+permission policy, required verification commands) and the fixed pipeline
+`intake → worktree → plan → implement → verify → review → finalize` continues
+in the daemon. At least one `--verify "label=script"` command is required —
+`completed` mechanically demands every required command exit 0, an
+adversarial-verification `VERDICT: PASS`, and an independent review with zero
+blockers. The frozen spec's `--permission-mode` and unattended allow/deny
+lists are applied to the run's daemon session, so pipeline children execute
+under the declared policy rather than the daemon default. The command returns
+after the durable intake commit (`runId`, `specDigest`, `baseCommit`);
+`--follow` then tails the run journal until the terminal result.
+
+The other commands use the daemon's durable run/admission contract and print
 canonical JSON. `status` includes aggregate admission and budget/hold state;
+for workflow runs it also carries a `workflow` block — one entry per pipeline
+stage with attempts, machine verdicts, and content-addressed artifact
+pointers, plus a machine-readable `stopReason` on failure (and the CLI renders
+a step table unless `--json`).
 `result` succeeds only after the durable run is terminal; its `lastSequence`
 is the terminal snapshot coordinate. A later exclusively leased offline effect
 review can advance the replay tail without resuming execution or changing that
 result. `replay` pages the
 canonical append-only rollout journal with an exclusive per-run sequence
 cursor. `evidence` adds source/completeness metadata and SHA-256 hashes for
-mechanical review. `cancel` durably locks the run tree, cancels queued
+mechanical review; for workflow runs it also includes a `bundle` block
+describing the sealed per-run evidence ledger
+(`<agencHome>/run-evidence/<run-id>/`): `sealed`, the verified-change
+`recordDigest`, the ledger path, and every artifact pointer
+(`cas://sha256/...`). The exported bundle is self-contained — hash chain,
+per-command records, patch/changed-file digests, review output, and terminal
+status are re-verifiable offline from the exported bytes alone.
+`cancel` durably locks the run tree, cancels queued
 descendants, and propagates to running descendants without deleting partial
 evidence.
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -69,9 +69,12 @@ Key `AgencClient` methods:
 - `spawnAgent(params)` → background agent (`agent.create`)
 - `attachAgent(agentId)` → `{ attach, session }` for a running agent
 - `listAgents()` / `stopAgent(id)` / `agentLogs(id)`
+- `startRun(params)` → start the M5 verified-change workflow as a durable
+  daemon run (`run.start`; resolves after the intake commit with
+  `{ runId, specDigest, baseCommit, baseDirty }`)
 - `runStatus(id)` / `runResult(id)` / `replayRun(params)` /
   `reattachRun(options)` / `runEvidence(params)` / `cancelRun(id, reason?)`
-- `request(method, params)` → raw typed JSON-RPC for any of the **45** daemon methods
+- `request(method, params)` → raw typed JSON-RPC for any of the **46** daemon methods
 - `onNotification(cb)` / `onSessionNotification(sessionId, cb)` → raw events
 
 Permission requests with no registered handler are **denied** (never granted)
@@ -165,6 +168,29 @@ node packages/agenc-sdk/examples/one-shot.mjs "say hello in one word"
 node packages/agenc-sdk/examples/one-shot.mjs --transport subprocess "say hello"
 ```
 
+### Starting a verified-change workflow
+
+```ts
+const started = await client.startRun({
+  goal: "Fix the flaky retry counter in the sync worker.",
+  cwd: "/abs/path/to/repo",
+  reviewerModel: "grok-4.5",
+  permissionMode: "acceptEdits",
+  requiredVerification: [{ label: "unit", script: "npm test" }],
+});
+// started: { runId, specDigest, baseCommit, baseDirty }
+```
+
+`startRun` resolves after the durable intake commit; the fixed pipeline
+continues in the daemon. Follow it by run id with the existing cursor
+contract: `runStatus` adds a `workflow` step projection (stage statuses,
+attempts, verdicts, artifact pointers, stop reason), `runResult` returns the
+durable terminal, and `runEvidence` adds the sealed evidence `bundle`
+(verified-change record digest, ledger path, `cas://sha256/...` artifact
+pointers). The workflow demands at least one required verification command;
+`completed` is refused without passing commands, a `VERDICT: PASS`
+verification agent, and a zero-blocker independent review.
+
 ### Durable run inspection
 
 ```ts
@@ -226,7 +252,7 @@ other runs. `run.evidence` declares
 that compatibility source, together with an explicit completeness value and
 content hashes.
 
-## Daemon method surface (45 methods)
+## Daemon method surface (46 methods)
 
 Mirrored in `packages/agenc-sdk/src/protocol.ts` as `AGENC_SDK_DAEMON_METHODS`
 (order pinned to the runtime registry):
@@ -235,7 +261,7 @@ Mirrored in `packages/agenc-sdk/src/protocol.ts` as `AGENC_SDK_DAEMON_METHODS`
 | --- | --- |
 | lifecycle | `initialize`, `request.cancel` |
 | agents | `agent.create`, `agent.list`, `agent.attach`, `agent.stop`, `agent.logs` |
-| runs | `run.status`, `run.result`, `run.replay`, `run.evidence`, `run.cancel` |
+| runs | `run.start`, `run.status`, `run.result`, `run.replay`, `run.evidence`, `run.cancel` |
 | sessions | `session.create`, `session.list`, `session.attach`, `session.detach`, `session.terminate`, `session.clear`, `session.snapshot`, `session.transcript`, `session.cancelTurn`, `session.mcp.addServer` |
 | messaging | `message.send`, `message.stream` |
 | realtime | `thread/realtime/start`, `thread/realtime/appendAudio`, `thread/realtime/appendText`, `thread/realtime/stop`, `thread/realtime/listVoices` |

--- a/runtime/src/app-server/workflow/daemon-wiring.ts
+++ b/runtime/src/app-server/workflow/daemon-wiring.ts
@@ -38,7 +38,10 @@ import {
 } from "../../eval-contract/evidence-ledger.js";
 import { sha256Digest } from "../../eval-contract/canonical-json.js";
 import { canonicalizeJson } from "../../eval-contract/canonical-json.js";
-import type { Sha256Digest } from "../../eval-contract/types.js";
+import {
+  WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME,
+  workflowLocalAnchorProvider,
+} from "../../workflow/local-anchor.js";
 import {
   openStateDatabasePaths,
   resolveStateDatabasePaths,
@@ -56,6 +59,7 @@ import {
   VerifiedChangeWorkflowController,
   type WorkflowDurabilityContext,
   type WorkflowEvidenceLedger,
+  type WorkflowRunSessionPolicy,
 } from "./verified-change-controller.js";
 import { readWorkflowStepEvidence } from "./steps.js";
 import {
@@ -83,13 +87,17 @@ function sanitizeIdentifierPart(value: string): string {
  * Integrity-only local anchor for the per-run workflow evidence ledger.
  * Keyed by a per-daemon-home secret so a seal cannot be silently reforged
  * by editing ledger files, but NOT externally anchored — external anchoring
- * remains an explicit later concern.
+ * remains an explicit later concern. The crypto construction is shared with
+ * offline evidence reconstruction (`workflow/local-anchor.ts`).
  */
 async function loadLocalAnchorProvider(
   evidenceRoot: string,
 ): Promise<EvidenceAnchorProvider> {
   await mkdir(evidenceRoot, { recursive: true, mode: 0o700 });
-  const secretPath = path.join(evidenceRoot, "local-anchor-secret");
+  const secretPath = path.join(
+    evidenceRoot,
+    WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME,
+  );
   let secret: Uint8Array;
   try {
     secret = await readFile(secretPath);
@@ -101,38 +109,7 @@ async function loadLocalAnchorProvider(
       },
     );
   }
-  const anchorPolicyDigest = sha256Digest("agenc.workflow.m5.local-anchor.v1");
-  const verifierDigest = sha256Digest("agenc.workflow.m5.local-anchor-verifier.v1");
-  const verificationMaterialDigest = sha256Digest(secret);
-  const signatureFor = (bytes: Uint8Array): Sha256Digest => {
-    const joined = new Uint8Array(secret.byteLength + bytes.byteLength);
-    joined.set(secret, 0);
-    joined.set(bytes, secret.byteLength);
-    return sha256Digest(joined);
-  };
-  return {
-    anchorPolicyDigest,
-    verifierDigest,
-    async anchor(statementBytes, statementDigest) {
-      return {
-        statementDigest,
-        anchorPolicyDigest,
-        signatureAlgorithm: "ed25519",
-        signatureDigest: signatureFor(statementBytes),
-        verificationMaterialDigest,
-        // The seal schema requires an https URI; the reserved `.invalid`
-        // TLD makes the local-only (non-fetchable) anchoring explicit.
-        anchorUri: `https://local-anchor.agenc-daemon.invalid/${statementDigest.slice("sha256:".length)}`,
-        signerIdentity: "agenc-daemon-local-anchor",
-      };
-    },
-    verify(statementBytes, receipt) {
-      return (
-        receipt.signatureDigest === signatureFor(statementBytes) &&
-        receipt.verificationMaterialDigest === verificationMaterialDigest
-      );
-    },
-  };
+  return workflowLocalAnchorProvider(secret);
 }
 
 /**
@@ -404,13 +381,27 @@ export function createDaemonWorkflowController(options: {
     }
     return repoForPaths(activeResumePaths ?? primaryPaths);
   };
-  const resolveRunRepoPath = (runId: string): string | undefined => {
+  const resolveRunSpec = (runId: string): WorkflowSpec | undefined => {
     const intake = durability({ runId }).getEffect(runId, "workflow.intake");
     if (intake === undefined) return undefined;
-    const spec = readWorkflowStepEvidence(intake).spec as
-      | WorkflowSpec
-      | undefined;
-    return spec?.repoPath;
+    return readWorkflowStepEvidence(intake).spec as WorkflowSpec | undefined;
+  };
+  const resolveRunRepoPath = (runId: string): string | undefined =>
+    resolveRunSpec(runId)?.repoPath;
+  const resolveRunPolicy = (
+    runId: string,
+  ): WorkflowRunSessionPolicy | undefined => {
+    const spec = resolveRunSpec(runId);
+    if (spec === undefined) return undefined;
+    return {
+      permissionMode: spec.permissionMode,
+      ...(spec.unattendedAllow !== undefined
+        ? { unattendedAllow: spec.unattendedAllow }
+        : {}),
+      ...(spec.unattendedDeny !== undefined
+        ? { unattendedDeny: spec.unattendedDeny }
+        : {}),
+    };
   };
   const seams =
     options.sessionSeams ??
@@ -422,6 +413,7 @@ export function createDaemonWorkflowController(options: {
       kernel: options.kernel,
       durability,
       resolveRunRepoPath,
+      resolveRunPolicy,
       fallbackCwd: options.primaryCwd,
       warn: options.warn,
       ...(options.bootstrap !== undefined

--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -54,6 +54,8 @@ import {
 } from "../../session/agenc-delegate.js";
 import type { SandboxExecutionBrokerLike } from "../../sandbox/execution-broker.js";
 import { runSupervisedProcess } from "../../utils/supervisedProcess.js";
+import { applyUnattendedPermissionPolicyToContext } from "../../permissions/unattended-policy.js";
+import type { PermissionModeRegistry } from "../../permissions/permission-mode.js";
 import type { StateRunDurabilityRepository } from "../../state/run-durability.js";
 import type { ReviewerInvoker } from "../../workflow/independent-review.js";
 import type {
@@ -74,6 +76,7 @@ import type {
   WorkflowChildOutcome,
   WorkflowJournalWriter,
   WorkflowRunJournal,
+  WorkflowRunSessionPolicy,
   WorkflowTerminalJournalIntent,
   WorkflowWorktreeBroker,
 } from "./verified-change-controller.js";
@@ -108,6 +111,16 @@ export interface WorkflowSessionSeamsOptions {
    * `fallbackCwd` so the failure diagnostic itself stays journalable).
    */
   readonly resolveRunRepoPath: (runId: string) => string | undefined;
+  /**
+   * Resolve a resumable run's frozen permission policy from its durable
+   * intake spec so a restarted daemon re-applies the SAME policy the run
+   * was admitted under. `undefined` = no durable spec (the session keeps
+   * the daemon default, which only ever happens for runs that are about to
+   * be fail-closed anyway).
+   */
+  readonly resolveRunPolicy: (
+    runId: string,
+  ) => WorkflowRunSessionPolicy | undefined;
   readonly fallbackCwd: string;
   readonly warn: (message: string) => void;
   /** Test seam — production uses {@link bootstrapLocalRuntimeSession}. */
@@ -177,6 +190,133 @@ function sessionBroker(
 function ownerRunIdOfChild(childRunId: string): string | undefined {
   const separator = childRunId.lastIndexOf(":");
   return separator > 0 ? childRunId.slice(0, separator) : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// A1 — durable child terminals for cross-restart adoption
+// ---------------------------------------------------------------------------
+
+/** Deterministic event id for a child's durable terminal record. */
+export const WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX = "workflow-child-terminal:";
+
+/**
+ * Durably record a workflow child's terminal outcome in the owning run's
+ * state database, keyed by the deterministic child run id that the parent
+ * effect intent already carries. This honestly extends the EXISTING run
+ * machinery — the child gets its own `run_lifecycle_epochs` row and its own
+ * immutable `run_terminal_results` row (no new store, no parallel table) —
+ * so a post-restart `spawner.inspect(childRunId)` can adopt the outcome
+ * instead of reporting "unknown".
+ *
+ * Idempotent: re-recording an existing terminal is a no-op; the sticky
+ * per-(run, epoch) terminal-conflict rules of the repository still apply to
+ * genuinely conflicting content.
+ */
+export function recordWorkflowChildTerminal(
+  repo: StateRunDurabilityRepository,
+  childRunId: string,
+  outcome: WorkflowChildOutcome,
+  now: () => Date = () => new Date(),
+): void {
+  const at = now().toISOString();
+  repo.ensureInitialEpoch({ runId: childRunId, openedAt: at });
+  const epoch = repo.currentEpoch(childRunId)?.epoch ?? 1;
+  if (repo.getTerminalResult(childRunId, epoch) !== undefined) return;
+  repo.recordTerminalResult({
+    epoch,
+    eventId: `${WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX}${childRunId}`,
+    result: {
+      runId: childRunId,
+      status: outcome.status,
+      exitCode: outcome.status === "completed" ? 0 : 1,
+      stopReason: null,
+      finalMessage: outcome.finalMessage,
+      usage: outcome.usage,
+      lastSequence: null,
+      finishedAt: at,
+    },
+  });
+}
+
+/**
+ * D3 adoption source of truth after a daemon restart: the child's durable
+ * terminal, if one was recorded before the crash. A child that genuinely
+ * died mid-flight with the daemon recorded nothing and stays `undefined`
+ * (the caller reports "unknown" → the run terminates `unknown_outcome`).
+ */
+export function inspectWorkflowChildTerminal(
+  repo: StateRunDurabilityRepository,
+  childRunId: string,
+): WorkflowChildOutcome | undefined {
+  const terminal = repo.getCurrentTerminalResult(childRunId);
+  if (terminal === undefined) return undefined;
+  return {
+    status: terminal.status,
+    finalMessage: terminal.finalMessage,
+    usage: terminal.usage,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// A2 — spec permission policy on the run session
+// ---------------------------------------------------------------------------
+
+/**
+ * Bootstrap argv for the spec's frozen permission mode — the exact
+ * background-agent-runner mechanism (`buildBootstrapArgv`):
+ * `bypassPermissions` rides `--yolo` (startup-selection wires the full
+ * bypass semantics off that flag); every other mode rides
+ * `--permission-mode <mode>`. Duplicate flags already present on the
+ * daemon's argv are never doubled.
+ */
+export function workflowPermissionModeArgv(
+  permissionMode: WorkflowRunSessionPolicy["permissionMode"],
+  baseArgv: readonly string[] = process.argv,
+): readonly string[] {
+  const argv = [...baseArgv];
+  if (
+    permissionMode === "bypassPermissions" &&
+    !argv.includes("--yolo") &&
+    !argv.includes("--dangerously-bypass-approvals-and-sandbox") &&
+    !argv.includes("--allow-dangerously-skip-permissions")
+  ) {
+    argv.push("--yolo");
+  }
+  if (
+    permissionMode !== "bypassPermissions" &&
+    !argv.includes("--permission-mode")
+  ) {
+    argv.push("--permission-mode", permissionMode);
+  }
+  return argv;
+}
+
+/**
+ * Install the spec's unattended allow/deny lists on the run session —
+ * mirrors the runner's `installUnattendedPermissionPolicy`. Explicit modes
+ * (`bypassPermissions`/`plan`/`acceptEdits`) are preserved by
+ * `applyUnattendedPermissionPolicyToContext`; `default` becomes
+ * `unattended` with the declared lists.
+ */
+async function installWorkflowUnattendedPolicy(
+  registry: PermissionModeRegistry,
+  policy: WorkflowRunSessionPolicy,
+): Promise<void> {
+  if (
+    policy.unattendedAllow === undefined &&
+    policy.unattendedDeny === undefined
+  ) {
+    return;
+  }
+  const next = applyUnattendedPermissionPolicyToContext(registry.current(), {
+    ...(policy.unattendedAllow !== undefined
+      ? { allowlist: policy.unattendedAllow }
+      : {}),
+    ...(policy.unattendedDeny !== undefined
+      ? { denylist: policy.unattendedDeny }
+      : {}),
+  });
+  await registry.update(next);
 }
 
 interface StepJournalContext {
@@ -425,12 +565,16 @@ export function createWorkflowSessionSeams(
   const openEntry = (
     runId: string,
     repoPath?: string,
+    policy?: WorkflowRunSessionPolicy,
   ): Promise<RunSessionEntry> => {
     const existing = entries.get(runId);
     if (existing !== undefined) return existing;
     const pending = (async (): Promise<RunSessionEntry> => {
       const resolvedRepoPath =
         repoPath ?? options.resolveRunRepoPath(runId) ?? options.fallbackCwd;
+      // A2: the frozen spec's policy governs the run session — explicit on
+      // start, re-resolved from the durable intake spec on resume.
+      const resolvedPolicy = policy ?? options.resolveRunPolicy(runId);
       const boot = await bootstrap({
         ...(options.env !== undefined ? { env: options.env } : {}),
         ...(options.authBackend !== undefined
@@ -441,10 +585,19 @@ export function createWorkflowSessionSeams(
         // rollout it journaled before the restart.
         resumeConversation: repoPath === undefined,
         cwd: resolvedRepoPath,
+        ...(resolvedPolicy !== undefined
+          ? { argv: workflowPermissionModeArgv(resolvedPolicy.permissionMode) }
+          : {}),
         executionAdmissionAutonomous: true,
         executionAdmissionKernel: options.kernel,
         executionAdmissionBudgetIdentity: runId,
       });
+      if (resolvedPolicy !== undefined) {
+        await installWorkflowUnattendedPolicy(
+          boot.session.permissionModeRegistry,
+          resolvedPolicy,
+        );
+      }
       return {
         runId,
         repoPath: resolvedRepoPath,
@@ -495,7 +648,7 @@ export function createWorkflowSessionSeams(
 
   const journal: WorkflowJournalWriter = {
     open: async (runId, context) => {
-      const entry = await openEntry(runId, context?.repoPath);
+      const entry = await openEntry(runId, context?.repoPath, context?.policy);
       return new SessionWorkflowJournal(entry, () => closeEntry(runId));
     },
   };
@@ -661,6 +814,18 @@ export function createWorkflowSessionSeams(
       entry.liveChildren.set(input.childRunId, pending);
       try {
         const outcome = await pending;
+        // A1: make the child's terminal durable BEFORE the parent effect
+        // result can commit, keyed by the deterministic child run id the
+        // effect intent recorded. This is exactly the window the M5 exit
+        // criterion exercises — child finished, daemon dies before the
+        // parent `effect_result` — and adoption recovers it after restart.
+        try {
+          recordWorkflowChildTerminal(entry.repo, input.childRunId, outcome);
+        } catch (error) {
+          options.warn(
+            `workflow child ${input.childRunId} terminal was not durably recorded: ${errorMessage(error)}`,
+          );
+        }
         rememberSettled(entry, input.childRunId, outcome);
         return outcome;
       } finally {
@@ -669,22 +834,38 @@ export function createWorkflowSessionSeams(
     },
     inspect: async (childRunId): Promise<WorkflowChildInspection> => {
       const ownerRunId = ownerRunIdOfChild(childRunId);
-      const pending =
-        ownerRunId === undefined ? undefined : entries.get(ownerRunId);
-      if (pending === undefined) return { state: "unknown" };
-      const entry = await pending;
-      const settled = entry.settledChildren.get(childRunId);
-      if (settled !== undefined) {
-        return { state: "terminal", outcome: settled };
+      if (ownerRunId === undefined) return { state: "unknown" };
+      const pending = entries.get(ownerRunId);
+      const entry = pending === undefined ? undefined : await pending;
+      if (entry !== undefined) {
+        const settled = entry.settledChildren.get(childRunId);
+        if (settled !== undefined) {
+          return { state: "terminal", outcome: settled };
+        }
+        const live = entry.liveChildren.get(childRunId);
+        if (live !== undefined) {
+          return { state: "live", outcome: live };
+        }
       }
-      const live = entry.liveChildren.get(childRunId);
-      if (live !== undefined) {
-        return { state: "live", outcome: live };
+      // A1 cross-restart adoption: a child from a previous daemon process
+      // died with that process, but its terminal outcome may have been
+      // durably recorded (keyed by this child id) before the crash. Adopt
+      // that durable terminal. A child with NO durable terminal genuinely
+      // has an unknowable outcome — the only honest answer stays `unknown`
+      // (D3: the run terminates unknown_outcome with review pending, never
+      // a silent respawn).
+      try {
+        const repo =
+          entry?.repo ?? options.durability({ runId: ownerRunId });
+        const durable = inspectWorkflowChildTerminal(repo, childRunId);
+        if (durable !== undefined) {
+          return { state: "terminal", outcome: durable };
+        }
+      } catch (error) {
+        options.warn(
+          `workflow child ${childRunId} durable-terminal inspection failed: ${errorMessage(error)}`,
+        );
       }
-      // A delegate child from a previous daemon process died with that
-      // process and left no durable terminal keyed by this child id. The
-      // only honest durable answer is `unknown` (D3: the run terminates
-      // unknown_outcome with review pending, never a silent respawn).
       return { state: "unknown" };
     },
   };

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -187,10 +187,27 @@ export interface WorkflowDurabilityContext {
   readonly repoPath?: string;
 }
 
+/**
+ * The frozen spec's execution policy, applied to the run's bootstrapped
+ * session (Phase 6): the session-backed journal writer mirrors the
+ * background-agent runner (`--permission-mode`/`--yolo` bootstrap argv +
+ * `installUnattendedPermissionPolicy`) so children never run under the
+ * daemon's default policy. Resumed runs re-resolve it from the durable
+ * intake spec.
+ */
+export interface WorkflowRunSessionPolicy {
+  readonly permissionMode: WorkflowSpec["permissionMode"];
+  readonly unattendedAllow?: readonly string[];
+  readonly unattendedDeny?: readonly string[];
+}
+
 export interface WorkflowJournalWriter {
   open(
     runId: string,
-    context?: { readonly repoPath?: string },
+    context?: {
+      readonly repoPath?: string;
+      readonly policy?: WorkflowRunSessionPolicy;
+    },
   ): Promise<WorkflowRunJournal>;
 }
 
@@ -333,6 +350,7 @@ export class WorkflowIntakeError extends Error {
 }
 
 const DEFAULT_MAX_IMPLEMENT_ATTEMPTS = 2;
+const DEFAULT_PERMISSION_MODE: WorkflowSpec["permissionMode"] = "acceptEdits";
 /** Bounded per-stage retry budget for stage-level (non-verdict) failures. */
 const MAX_STAGE_ATTEMPTS = 2;
 const ZERO_ESTIMATE = {
@@ -487,6 +505,15 @@ export class VerifiedChangeWorkflowController {
     const repo = this.#deps.durability({ runId, repoPath: params.repoPath });
     const journal = await this.#deps.journal.open(runId, {
       repoPath: params.repoPath,
+      policy: {
+        permissionMode: params.permissionMode ?? DEFAULT_PERMISSION_MODE,
+        ...(params.unattendedAllow !== undefined
+          ? { unattendedAllow: params.unattendedAllow }
+          : {}),
+        ...(params.unattendedDeny !== undefined
+          ? { unattendedDeny: params.unattendedDeny }
+          : {}),
+      },
     });
     const base = await this.#deps.worktrees.captureBaseState(params.repoPath, {
       runId,
@@ -1342,6 +1369,7 @@ export class VerifiedChangeWorkflowController {
         headCommit: exported.headCommit,
         risks,
         ledgerHead: head,
+        sealDigest,
       });
     } catch (error) {
       throw new WorkflowHaltError({
@@ -1410,6 +1438,8 @@ export class VerifiedChangeWorkflowController {
       readonly headCommit: string;
       readonly risks: readonly string[];
       readonly ledgerHead: WorkflowEvidenceLedgerHead;
+      /** Ledger seal digest — pins the exported bundle's seal in the record. */
+      readonly sealDigest: string;
     },
   ): VerifiedChangeRecord {
     const effects = ctx.repo.listEffects(ctx.runId);
@@ -1468,6 +1498,7 @@ export class VerifiedChangeWorkflowController {
         eventCount: input.ledgerHead.eventCount,
         headEventDigest: input.ledgerHead.headEventDigest,
         sealed: input.ledgerHead.sealed,
+        sealDigest: input.sealDigest as Sha256Digest,
       },
     });
   }
@@ -2130,7 +2161,7 @@ function freezeWorkflowSpec(
     ...(params.provider !== undefined ? { provider: params.provider } : {}),
     reviewerModel:
       params.reviewerModel ?? params.model ?? "default-reviewer",
-    permissionMode: params.permissionMode ?? "acceptEdits",
+    permissionMode: params.permissionMode ?? DEFAULT_PERMISSION_MODE,
     ...(params.unattendedAllow !== undefined
       ? { unattendedAllow: params.unattendedAllow }
       : {}),

--- a/runtime/src/workflow/evidence-reconstruction.ts
+++ b/runtime/src/workflow/evidence-reconstruction.ts
@@ -1,0 +1,393 @@
+/**
+ * M5 Phase 6 — evidence-only reconstruction of a verified change.
+ *
+ * `reconstructVerifiedChange(bundleDir)` takes ONLY an exported bundle
+ * directory — the run's evidence-ledger root (hash-chained ledger, CAS
+ * payloads, seal receipt, local anchor secret) plus the persisted
+ * `verified-change-record.json` — and mechanically re-derives what
+ * happened. No daemon, no SQLite, no rollout files, no trust in prose:
+ *
+ *   1. re-validate the record (`validateVerifiedChangeRecord`, including
+ *      the canonical document digest and spec-digest binding),
+ *   2. verify the sealed hash chain (`verifyEvidenceLedger`, pinned by the
+ *      seal digest the record carries and the bundle's local anchor
+ *      material),
+ *   3. cross-check the record's ledger head against the verified
+ *      inspection,
+ *   4. recompute EVERY artifact digest from the exact CAS bytes and check
+ *      each pointer is present in the hash-chained event set,
+ *   5. re-derive the review blockers from the `independent_review`
+ *      artifact bytes and cross-check the recorded verification commands
+ *      against a `test_result` artifact.
+ *
+ * Every failure throws {@link EvidenceReconstructionError} loudly — a
+ * tampered byte anywhere (ledger, seal, CAS payload, record) can never
+ * produce a summary.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import { sha256Digest } from "../eval-contract/canonical-json.js";
+import { verifyEvidenceLedger } from "../eval-contract/evidence-ledger.js";
+import type { Sha256Digest } from "../eval-contract/types.js";
+import type {
+  RunArtifactPointer,
+  RunTerminalStatus,
+  WorkflowStopReason,
+} from "../contracts/run-contracts.js";
+import {
+  validateVerifiedChangeRecord,
+  type VerifiedChangeCommandRecord,
+  type VerifiedChangeRecord,
+} from "./evidence-record.js";
+import { extractBlockers } from "./independent-review.js";
+import type { ReviewOutput } from "../session/review.js";
+import {
+  readWorkflowLocalAnchorSecret,
+  workflowLocalAnchorVerifier,
+} from "./local-anchor.js";
+
+export const VERIFIED_CHANGE_RECORD_FILENAME = "verified-change-record.json";
+
+export type EvidenceReconstructionFailure =
+  | "record_missing"
+  | "record_invalid"
+  | "seal_unpinned"
+  | "anchor_material_missing"
+  | "ledger_verification_failed"
+  | "ledger_mismatch"
+  | "artifact_missing"
+  | "artifact_digest_mismatch"
+  | "artifact_unchained"
+  | "review_artifact_invalid"
+  | "test_result_mismatch";
+
+export class EvidenceReconstructionError extends Error {
+  readonly failure: EvidenceReconstructionFailure;
+
+  constructor(failure: EvidenceReconstructionFailure, message: string) {
+    super(`evidence reconstruction failed (${failure}): ${message}`);
+    this.name = "EvidenceReconstructionError";
+    this.failure = failure;
+  }
+}
+
+export interface ReconstructedArtifact {
+  readonly stepId: string;
+  readonly role: RunArtifactPointer["role"];
+  readonly digest: Sha256Digest;
+  readonly bytes: number;
+  readonly storagePath: string;
+}
+
+export interface ReconstructedVerifiedChange {
+  readonly runId: string;
+  readonly specDigest: Sha256Digest;
+  readonly goal: string;
+  readonly baseCommit: string;
+  readonly headCommit: string | null;
+  readonly terminal: {
+    readonly status: RunTerminalStatus;
+    readonly stopReason: WorkflowStopReason | null;
+    readonly finalMessage: string | null;
+  };
+  readonly verificationCommands: readonly VerifiedChangeCommandRecord[];
+  readonly review: {
+    readonly reviewerModel: string;
+    readonly overallCorrectness: string;
+    readonly overallConfidenceScore: number;
+    readonly blockerCount: number;
+    readonly findingCount: number;
+  } | null;
+  /** Re-derived from the independent_review artifact bytes, not the record. */
+  readonly reviewBlockers: readonly string[];
+  readonly unresolvedRisks: readonly string[];
+  readonly ledger: {
+    readonly eventCount: number;
+    readonly headEventDigest: Sha256Digest;
+    readonly sealDigest: Sha256Digest;
+    readonly sealedAt: string;
+  };
+  /** Every pointer digest re-computed from the exact CAS bytes. */
+  readonly artifacts: readonly ReconstructedArtifact[];
+}
+
+/** Read one content-addressed payload from the bundle's CAS directories. */
+export async function readBundleArtifact(
+  bundleDir: string,
+  digest: string,
+): Promise<Uint8Array> {
+  const hex = digest.startsWith("sha256:")
+    ? digest.slice("sha256:".length)
+    : digest;
+  let entries: readonly string[];
+  try {
+    entries = await readdir(bundleDir);
+  } catch (error) {
+    throw new EvidenceReconstructionError(
+      "artifact_missing",
+      `bundle directory is unreadable: ${String(error)}`,
+    );
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".payloads")) continue;
+    try {
+      return await readFile(path.join(bundleDir, entry, `sha256-${hex}.bin`));
+    } catch {
+      // try the next payloads directory
+    }
+  }
+  throw new EvidenceReconstructionError(
+    "artifact_missing",
+    `no CAS payload for sha256:${hex} in ${bundleDir}`,
+  );
+}
+
+function uniqueArtifactPointers(
+  record: VerifiedChangeRecord,
+): readonly RunArtifactPointer[] {
+  const pointers = new Map<string, RunArtifactPointer>();
+  const add = (pointer: RunArtifactPointer): void => {
+    pointers.set(
+      `${pointer.step.stepId}:${pointer.role}:${pointer.digest}`,
+      pointer,
+    );
+  };
+  for (const step of record.steps) {
+    for (const pointer of step.artifacts) add(pointer);
+  }
+  if (record.review !== null) add(record.review.artifact);
+  return [...pointers.values()];
+}
+
+function parseJsonBytes(bytes: Uint8Array, what: string): unknown {
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (error) {
+    throw new EvidenceReconstructionError(
+      "review_artifact_invalid",
+      `${what} is not valid JSON: ${String(error)}`,
+    );
+  }
+}
+
+function stable(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  const record = value as Readonly<Record<string, unknown>>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stable(record[key])}`)
+    .join(",")}}`;
+}
+
+/**
+ * Reconstruct a verified change from an exported bundle directory alone.
+ * See the module doc for the exact mechanical checks.
+ */
+export async function reconstructVerifiedChange(
+  bundleDir: string,
+): Promise<ReconstructedVerifiedChange> {
+  // 1. The record — the only non-ledger file the reconstruction trusts as
+  // an INPUT, and only after it survives full mechanical re-validation.
+  let recordBytes: Uint8Array;
+  try {
+    recordBytes = await readFile(
+      path.join(bundleDir, VERIFIED_CHANGE_RECORD_FILENAME),
+    );
+  } catch (error) {
+    throw new EvidenceReconstructionError(
+      "record_missing",
+      `${VERIFIED_CHANGE_RECORD_FILENAME} is absent from ${bundleDir}: ${String(error)}`,
+    );
+  }
+  let record: VerifiedChangeRecord;
+  try {
+    record = JSON.parse(
+      new TextDecoder().decode(recordBytes),
+    ) as VerifiedChangeRecord;
+  } catch (error) {
+    throw new EvidenceReconstructionError(
+      "record_invalid",
+      `record is not valid JSON: ${String(error)}`,
+    );
+  }
+  const validation = validateVerifiedChangeRecord(record);
+  if (!validation.valid) {
+    throw new EvidenceReconstructionError(
+      "record_invalid",
+      validation.errors.join("; "),
+    );
+  }
+
+  // 2. The sealed hash chain, pinned by the record's seal digest and the
+  // bundle's local anchor material. No local seal discovery.
+  const sealDigest = record.evidenceLedger.sealDigest;
+  if (sealDigest === undefined) {
+    throw new EvidenceReconstructionError(
+      "seal_unpinned",
+      "the record does not pin an evidenceLedger.sealDigest",
+    );
+  }
+  const secret = await readWorkflowLocalAnchorSecret(bundleDir);
+  if (secret === undefined) {
+    throw new EvidenceReconstructionError(
+      "anchor_material_missing",
+      "no local-anchor-secret in the bundle (or its parent directory); the seal signature cannot be verified",
+    );
+  }
+  let verified;
+  try {
+    verified = await verifyEvidenceLedger({
+      root: bundleDir,
+      runId: record.runId,
+      expectedSealDigest: sealDigest,
+      anchorVerifier: workflowLocalAnchorVerifier(secret),
+    });
+  } catch (error) {
+    throw new EvidenceReconstructionError(
+      "ledger_verification_failed",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  const inspection = verified.inspection;
+
+  // 3. The record's ledger head must be the verified ledger's head.
+  if (
+    inspection.eventCount !== record.evidenceLedger.eventCount ||
+    inspection.headEventDigest !== record.evidenceLedger.headEventDigest ||
+    !inspection.terminal
+  ) {
+    throw new EvidenceReconstructionError(
+      "ledger_mismatch",
+      `record ledger head (${record.evidenceLedger.eventCount} events, ` +
+        `${record.evidenceLedger.headEventDigest}) does not match the ` +
+        `verified ledger (${inspection.eventCount} events, ` +
+        `${inspection.headEventDigest ?? "no head"}, terminal=${inspection.terminal})`,
+    );
+  }
+
+  // 4. Every artifact: exact CAS bytes → recomputed digest → chained event.
+  const chainedPayloadDigests = new Set(
+    inspection.events.map((event) => event.payload.digest),
+  );
+  const pointers = uniqueArtifactPointers(record);
+  const artifacts: ReconstructedArtifact[] = [];
+  const bytesByDigest = new Map<string, Uint8Array>();
+  for (const pointer of pointers) {
+    if (!chainedPayloadDigests.has(pointer.digest)) {
+      throw new EvidenceReconstructionError(
+        "artifact_unchained",
+        `artifact ${pointer.step.stepId}/${pointer.role} (${pointer.digest}) is not present in the hash-chained event set`,
+      );
+    }
+    const bytes = await readBundleArtifact(bundleDir, pointer.digest);
+    const recomputed = sha256Digest(bytes);
+    if (recomputed !== pointer.digest || bytes.byteLength !== pointer.bytes) {
+      throw new EvidenceReconstructionError(
+        "artifact_digest_mismatch",
+        `artifact ${pointer.step.stepId}/${pointer.role}: recorded ` +
+          `${pointer.digest} (${pointer.bytes} bytes) but CAS bytes are ` +
+          `${recomputed} (${bytes.byteLength} bytes)`,
+      );
+    }
+    bytesByDigest.set(pointer.digest, bytes);
+    artifacts.push({
+      stepId: pointer.step.stepId,
+      role: pointer.role,
+      digest: pointer.digest,
+      bytes: pointer.bytes,
+      storagePath: pointer.storagePath,
+    });
+  }
+
+  // 5a. Re-derive review blockers from the independent_review bytes.
+  let reviewBlockers: readonly string[] = [];
+  if (record.review !== null) {
+    const reviewBytes = bytesByDigest.get(record.review.artifact.digest);
+    if (reviewBytes === undefined) {
+      throw new EvidenceReconstructionError(
+        "review_artifact_invalid",
+        "the review artifact bytes were not reconstructed",
+      );
+    }
+    const parsed = parseJsonBytes(reviewBytes, "independent_review artifact");
+    const review = (parsed as { review?: ReviewOutput }).review;
+    if (
+      review === undefined ||
+      !Array.isArray(review.findings) ||
+      typeof review.overallCorrectness !== "string"
+    ) {
+      throw new EvidenceReconstructionError(
+        "review_artifact_invalid",
+        "independent_review artifact does not contain a ReviewOutput",
+      );
+    }
+    reviewBlockers = extractBlockers(review);
+    if (reviewBlockers.length !== record.review.blockerCount) {
+      throw new EvidenceReconstructionError(
+        "review_artifact_invalid",
+        `record claims ${record.review.blockerCount} blocker(s) but the ` +
+          `review artifact re-derives ${reviewBlockers.length}`,
+      );
+    }
+  }
+
+  // 5b. The recorded verification commands must match a test_result
+  // artifact byte-for-byte (canonical JSON equality).
+  const testResults = artifacts.filter(
+    (artifact) => artifact.role === "test_result",
+  );
+  if (record.verificationCommands.length > 0) {
+    const expected = stable({ commands: record.verificationCommands });
+    const matched = testResults.some((artifact) => {
+      const bytes = bytesByDigest.get(artifact.digest);
+      if (bytes === undefined) return false;
+      try {
+        return stable(parseJsonBytes(bytes, "test_result artifact")) === expected;
+      } catch {
+        return false;
+      }
+    });
+    if (!matched) {
+      throw new EvidenceReconstructionError(
+        "test_result_mismatch",
+        "no test_result artifact reproduces the record's verification command set",
+      );
+    }
+  }
+
+  return {
+    runId: record.runId,
+    specDigest: record.specDigest,
+    goal: record.spec.goal,
+    baseCommit: record.baseCommit,
+    headCommit: record.headCommit,
+    terminal: {
+      status: record.terminal.status,
+      stopReason: record.terminal.stopReason,
+      finalMessage: record.terminal.finalMessage,
+    },
+    verificationCommands: record.verificationCommands,
+    review:
+      record.review === null
+        ? null
+        : {
+            reviewerModel: record.review.reviewerModel,
+            overallCorrectness: record.review.overallCorrectness,
+            overallConfidenceScore: record.review.overallConfidenceScore,
+            blockerCount: record.review.blockerCount,
+            findingCount: record.review.findingCount,
+          },
+    reviewBlockers,
+    unresolvedRisks: record.unresolvedRisks,
+    ledger: {
+      eventCount: inspection.eventCount,
+      headEventDigest: record.evidenceLedger.headEventDigest,
+      sealDigest,
+      sealedAt: verified.seal.statement.sealedAt,
+    },
+    artifacts,
+  };
+}

--- a/runtime/src/workflow/evidence-record.ts
+++ b/runtime/src/workflow/evidence-record.ts
@@ -105,6 +105,13 @@ export interface VerifiedChangeRecord {
     readonly eventCount: number;
     readonly headEventDigest: Sha256Digest;
     readonly sealed: boolean;
+    /**
+     * The ledger seal's own digest (sha256 of the exact seal-document
+     * bytes). Required for `completed` records: it is the external pin an
+     * offline reconstruction hands to `verifyEvidenceLedger`, making the
+     * exported bundle self-verifiable without local seal discovery.
+     */
+    readonly sealDigest?: Sha256Digest;
   };
   readonly documentDigest: Sha256Digest;
 }
@@ -255,8 +262,20 @@ export function validateVerifiedChangeRecord(
     if (!SHA256_PATTERN.test(String(ledger.headEventDigest))) {
       errors.push("evidenceLedger.headEventDigest must be sha256:<64 hex>");
     }
+    if (
+      ledger.sealDigest !== undefined &&
+      !SHA256_PATTERN.test(String(ledger.sealDigest))
+    ) {
+      errors.push("evidenceLedger.sealDigest must be sha256:<64 hex>");
+    }
     if (record.terminal?.status === "completed" && ledger.sealed !== true) {
       errors.push("completed record requires a sealed evidence ledger");
+    }
+    if (
+      record.terminal?.status === "completed" &&
+      ledger.sealDigest === undefined
+    ) {
+      errors.push("completed record requires evidenceLedger.sealDigest");
     }
   }
   if (typeof record.documentDigest === "string") {

--- a/runtime/src/workflow/local-anchor.ts
+++ b/runtime/src/workflow/local-anchor.ts
@@ -1,0 +1,128 @@
+/**
+ * M5 local integrity-only anchor crypto for per-run workflow evidence
+ * ledgers.
+ *
+ * One shared construction with two consumers:
+ *   - the daemon evidence-ledger factory (`daemon-wiring.ts`) uses it to
+ *     ANCHOR seals (it owns the per-daemon-home secret and may create it),
+ *   - the offline evidence reconstruction (`evidence-reconstruction.ts`)
+ *     uses it to VERIFY a seal from an exported bundle (read-only; the
+ *     secret must already exist in the bundle).
+ *
+ * The signature is sha256(secret || statementBytes) keyed by a per-home
+ * random secret, so a seal cannot be silently reforged by editing ledger
+ * files. It is NOT an external anchor — the trust statement stays
+ * "integrity_only" and external anchoring remains an explicit later
+ * concern. The policy/verifier digest strings below are part of every
+ * recorded seal receipt; changing them invalidates existing seals.
+ */
+
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import { sha256Digest } from "../eval-contract/canonical-json.js";
+import type {
+  EvidenceAnchorProvider,
+  EvidenceAnchorVerifier,
+} from "../eval-contract/evidence-ledger.js";
+import type { Sha256Digest } from "../eval-contract/types.js";
+
+export const WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME = "local-anchor-secret";
+
+export const WORKFLOW_LOCAL_ANCHOR_POLICY_DIGEST: Sha256Digest = sha256Digest(
+  "agenc.workflow.m5.local-anchor.v1",
+);
+export const WORKFLOW_LOCAL_ANCHOR_VERIFIER_DIGEST: Sha256Digest = sha256Digest(
+  "agenc.workflow.m5.local-anchor-verifier.v1",
+);
+
+export interface WorkflowLocalAnchorCrypto {
+  readonly anchorPolicyDigest: Sha256Digest;
+  readonly verifierDigest: Sha256Digest;
+  readonly verificationMaterialDigest: Sha256Digest;
+  signatureFor(bytes: Uint8Array): Sha256Digest;
+}
+
+/** Deterministic keyed-signature construction over the exact secret bytes. */
+export function createWorkflowLocalAnchorCrypto(
+  secret: Uint8Array,
+): WorkflowLocalAnchorCrypto {
+  const verificationMaterialDigest = sha256Digest(secret);
+  return {
+    anchorPolicyDigest: WORKFLOW_LOCAL_ANCHOR_POLICY_DIGEST,
+    verifierDigest: WORKFLOW_LOCAL_ANCHOR_VERIFIER_DIGEST,
+    verificationMaterialDigest,
+    signatureFor(bytes: Uint8Array): Sha256Digest {
+      const joined = new Uint8Array(secret.byteLength + bytes.byteLength);
+      joined.set(secret, 0);
+      joined.set(bytes, secret.byteLength);
+      return sha256Digest(joined);
+    },
+  };
+}
+
+/** Anchor provider over an existing secret (creation is the caller's job). */
+export function workflowLocalAnchorProvider(
+  secret: Uint8Array,
+): EvidenceAnchorProvider {
+  const crypto = createWorkflowLocalAnchorCrypto(secret);
+  return {
+    anchorPolicyDigest: crypto.anchorPolicyDigest,
+    verifierDigest: crypto.verifierDigest,
+    async anchor(statementBytes, statementDigest) {
+      return {
+        statementDigest,
+        anchorPolicyDigest: crypto.anchorPolicyDigest,
+        signatureAlgorithm: "ed25519",
+        signatureDigest: crypto.signatureFor(statementBytes),
+        verificationMaterialDigest: crypto.verificationMaterialDigest,
+        // The seal schema requires an https URI; the reserved `.invalid`
+        // TLD makes the local-only (non-fetchable) anchoring explicit.
+        anchorUri: `https://local-anchor.agenc-daemon.invalid/${statementDigest.slice("sha256:".length)}`,
+        signerIdentity: "agenc-daemon-local-anchor",
+      };
+    },
+    verify(statementBytes, receipt) {
+      return (
+        receipt.signatureDigest === crypto.signatureFor(statementBytes) &&
+        receipt.verificationMaterialDigest === crypto.verificationMaterialDigest
+      );
+    },
+  };
+}
+
+/** Verifier-only view for offline reconstruction. */
+export function workflowLocalAnchorVerifier(
+  secret: Uint8Array,
+): EvidenceAnchorVerifier {
+  const provider = workflowLocalAnchorProvider(secret);
+  return {
+    anchorPolicyDigest: provider.anchorPolicyDigest,
+    verifierDigest: provider.verifierDigest,
+    verify: (statementBytes, receipt) =>
+      provider.verify(statementBytes, receipt),
+  };
+}
+
+/**
+ * Locate the anchor secret for an exported bundle directory: inside the
+ * bundle itself first (self-contained export), then the parent directory
+ * (a bundle pointed at the live `<agencHome>/run-evidence/<runId>` layout).
+ * Returns undefined when no secret is present — callers must fail loudly,
+ * never silently downgrade verification.
+ */
+export async function readWorkflowLocalAnchorSecret(
+  bundleDir: string,
+): Promise<Uint8Array | undefined> {
+  for (const candidate of [
+    path.join(bundleDir, WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME),
+    path.join(path.dirname(bundleDir), WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME),
+  ]) {
+    try {
+      return await readFile(candidate);
+    } catch {
+      // try the next location
+    }
+  }
+  return undefined;
+}

--- a/runtime/tests/llm/providers/grok/adapter.test.ts
+++ b/runtime/tests/llm/providers/grok/adapter.test.ts
@@ -536,7 +536,11 @@ describe("GrokProvider incremental continuation", () => {
     );
 
     expect(result.content).toBe("stream done");
-    expect(chunks).toEqual([]);
+    // Since the stream-resilience change (bbf85192f), a completed response
+    // whose stream produced no output_text.delta emits its envelope text as
+    // one streaming chunk too — a delta-less xAI stream must not render a
+    // successful-but-blank turn.
+    expect(chunks).toEqual(["stream done"]);
     expect(requestBodies[0]?.previous_response_id).toBe("resp_prev_stream");
     expect(JSON.stringify(requestBodies[0]?.input)).toContain("follow up");
     expect(JSON.stringify(requestBodies[0]?.input)).not.toContain("hello");

--- a/runtime/tests/workflow/evidence-record.test.ts
+++ b/runtime/tests/workflow/evidence-record.test.ts
@@ -101,6 +101,7 @@ function goldenInput() {
       eventCount: 12,
       headEventDigest: `sha256:${HEX_64}` as const,
       sealed: true,
+      sealDigest: `sha256:${HEX_64}` as const,
     },
   };
 }
@@ -164,6 +165,17 @@ describe("verified-change evidence record (M5)", () => {
         evidenceLedger: { ...input.evidenceLedger, sealed: false },
       }),
     ).toThrow(/sealed evidence ledger/);
+  });
+
+  test("completed without the pinned ledger sealDigest is rejected", () => {
+    const input = goldenInput();
+    const { sealDigest: _dropped, ...withoutSealDigest } = input.evidenceLedger;
+    expect(() =>
+      assembleVerifiedChangeRecord({
+        ...input,
+        evidenceLedger: withoutSealDigest,
+      }),
+    ).toThrow(/requires evidenceLedger.sealDigest/);
   });
 
   test("non-completed terminal status requires a machine-readable stopReason", () => {

--- a/runtime/tests/workflow/fixtures/m5-exit-child.ts
+++ b/runtime/tests/workflow/fixtures/m5-exit-child.ts
@@ -1,0 +1,202 @@
+/**
+ * Child process for the M5 exit proofs (hermetic + acceptance lanes).
+ *
+ * `crash <mode> <stateDir>`:
+ *   Runs the verified-change pipeline against the fixture repository. The
+ *   scripted implement child applies the real fix in the worktree and its
+ *   terminal is durably recorded (A1); IMMEDIATELY after that durable
+ *   record — and before the parent effect_result can commit — the harness
+ *   arms the `after_spawn_before_effect_result` failpoint, which fsyncs the
+ *   marker file and SIGKILLs this process. The kill window therefore
+ *   objectively contains a durable child terminal and NO parent result.
+ *
+ * `resume <mode> <stateDir>`:
+ *   Fresh process over the same on-disk state: runs admission recovery
+ *   (daemon-startup mirror), `resumeOpenWorkflows()`, awaits the run, and
+ *   prints a single-line JSON report for the parent test.
+ *
+ * `<mode>` is `controller` (bare controller assembly) or `wiring` (through
+ * `createDaemonWorkflowController`, the acceptance lane).
+ */
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { buildM5Harness, M5_EXIT_RUN_ID } from "./m5-harness.js";
+
+const FAILPOINT = "after_spawn_before_effect_result";
+const FAILPOINT_TOKEN = "m5-workflow-child";
+
+type Command = "crash" | "resume";
+type Mode = "controller" | "wiring";
+
+function requireArgument(value: string | undefined, name: string): string {
+  if (value === undefined || value.length === 0) {
+    throw new Error(`missing ${name}`);
+  }
+  return value;
+}
+
+const command = requireArgument(process.argv[2], "command") as Command;
+const mode = requireArgument(process.argv[3], "mode") as Mode;
+const stateDir = requireArgument(process.argv[4], "state directory");
+
+const home = join(stateDir, "home");
+const repoPath = join(stateDir, "repo");
+const receiptsDir = join(stateDir, "receipts");
+mkdirSync(home, { recursive: true, mode: 0o700 });
+process.env.AGENC_HOME = home;
+
+const IMPLEMENT_FIX = {
+  file: "lib/add.js",
+  contents: "module.exports.add = (a, b) => a + b;\n",
+} as const;
+
+function buildHarness(withCrashArming: boolean) {
+  return buildM5Harness({
+    home,
+    repoPath,
+    receiptsDir,
+    implementFix: IMPLEMENT_FIX,
+    throughDaemonWiring: mode === "wiring",
+    ...(withCrashArming
+      ? {
+          onImplementSettled: () => {
+            // Arm the production failpoint ONLY now: the child terminal is
+            // already durable, the parent effect_result is not yet
+            // journaled. hitM5WorkflowFailpoint reads process.env at call
+            // time, fsyncs the marker, and SIGKILLs the process.
+            process.env.AGENC_TEST_DURABILITY_FAILPOINT = FAILPOINT;
+            process.env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN = FAILPOINT_TOKEN;
+          },
+        }
+      : {}),
+  });
+}
+
+async function crash(): Promise<never> {
+  const harness = buildHarness(true);
+  const started = await harness.controller.start({
+    goal: "lib/add.js returns the wrong value: add(2, 3) must equal 5. Fix the arithmetic bug so the required script passes.",
+    repoPath,
+    reviewerModel: "scripted-reviewer",
+    permissionMode: "acceptEdits",
+    requiredVerification: [{ label: "unit", script: "bash test.sh" }],
+    maxImplementAttempts: 2,
+    runId: M5_EXIT_RUN_ID,
+  });
+  await harness.controller.awaitRun(started.runId);
+  throw new Error("the M5 exit failpoint did not terminate the crash child");
+}
+
+async function resume(): Promise<void> {
+  // Daemon-startup mirror: admission recovery BEFORE workflow resume, so a
+  // reservation left `dispatched` by the kill is held (never silently
+  // freed).
+  const { openStateDatabases } = await import(
+    "../../../src/state/sqlite-driver.js"
+  );
+  const { ExecutionAdmissionRepository } = await import(
+    "../../../src/state/execution-admission.js"
+  );
+  {
+    const driver = openStateDatabases({ cwd: repoPath, agencHome: home });
+    try {
+      const admission = new ExecutionAdmissionRepository(driver, {
+        ownerId: "m5-exit-recovery",
+        ownerPid: process.pid,
+      });
+      admission.recover({ activeOwnerIds: new Set() });
+    } finally {
+      driver.close();
+    }
+  }
+
+  const harness = buildHarness(false);
+  const preResume = {
+    implementOutcome:
+      harness.repo.getEffect(M5_EXIT_RUN_ID, "workflow.implement")?.outcome ??
+      null,
+    implementChildTerminal:
+      harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:implement#1`)
+        ?.status ?? null,
+    terminal:
+      harness.repo.getCurrentTerminalResult(M5_EXIT_RUN_ID)?.status ?? null,
+  };
+
+  const resumed = await harness.resumeOpenWorkflows();
+  await harness.controller.awaitRun(M5_EXIT_RUN_ID);
+
+  const effects = harness.repo.listEffects(M5_EXIT_RUN_ID).map((effect) => ({
+    stepId: effect.stepId,
+    outcome: effect.outcome ?? null,
+    childRunId: effect.childRunId ?? null,
+  }));
+  const terminal = harness.repo.getCurrentTerminalResult(M5_EXIT_RUN_ID);
+
+  const readReceipts = (name: string): unknown[] => {
+    const path = join(receiptsDir, name);
+    if (!existsSync(path)) return [];
+    return readFileSync(path, "utf8")
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as unknown);
+  };
+
+  // Reservation states via a fresh repository view.
+  const driver = openStateDatabases({ cwd: repoPath, agencHome: home });
+  let reservations: { readonly id: string; readonly status: string }[];
+  try {
+    const admission = new ExecutionAdmissionRepository(driver, {
+      ownerId: "m5-exit-report",
+      ownerPid: process.pid,
+    });
+    reservations = admission
+      .listReservations({ runId: M5_EXIT_RUN_ID, limit: 50 })
+      .map((reservation) => ({
+        id: reservation.reservationId,
+        status: reservation.status,
+      }));
+  } finally {
+    driver.close();
+  }
+
+  const report = {
+    mode,
+    preResume,
+    resumed,
+    terminal:
+      terminal === undefined
+        ? null
+        : {
+            status: terminal.status,
+            stopReason: terminal.stopReason,
+            finalMessage: terminal.finalMessage,
+          },
+    effects,
+    implementReceipts: readReceipts("implement-attempts.jsonl"),
+    worktreeProvisions: readReceipts("worktree-provisions.jsonl"),
+    implementChildTerminals: {
+      attempt1:
+        harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:implement#1`)
+          ?.status ?? null,
+      attempt2:
+        harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:implement#2`)
+          ?.status ?? null,
+    },
+    resumeSpawnKinds: harness.spawnKinds,
+    reservations,
+    warnings: harness.warnings,
+    bundleDir: join(home, "run-evidence", M5_EXIT_RUN_ID),
+  };
+  harness.close();
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+
+if (command === "crash") {
+  await crash();
+} else if (command === "resume") {
+  await resume();
+} else {
+  throw new Error(`unsupported command: ${String(command)}`);
+}

--- a/runtime/tests/workflow/fixtures/m5-exit-shared.ts
+++ b/runtime/tests/workflow/fixtures/m5-exit-shared.ts
@@ -1,0 +1,344 @@
+/**
+ * Shared driver for the M5 exit proofs: fixture-repo seeding, the
+ * crash/resume child-process phases, and the common assertion blocks.
+ * Used by the hermetic lane (default PR suite) and the env-gated
+ * acceptance lane.
+ */
+
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+
+import {
+  readBundleArtifact,
+  reconstructVerifiedChange,
+} from "../../../src/workflow/evidence-reconstruction.js";
+import { M5_EXIT_RUN_ID } from "./m5-harness.js";
+
+const FIXTURE = fileURLToPath(new URL("./m5-exit-child.ts", import.meta.url));
+const NODE_TEST_LOADER = fileURLToPath(
+  new URL("../../durability/fixtures/node-test-loader.mjs", import.meta.url),
+);
+const TSX_IMPORT = fileURLToPath(import.meta.resolve("tsx"));
+
+export const M5_EXIT_FAILPOINT = "after_spawn_before_effect_result";
+
+const HIDDEN_VERIFIER = `#!/usr/bin/env bash
+# HIDDEN verifier: never present in the fixture repo, any prompt, or the
+# spec. Proves the exported patch is the real fix, not output shaped to the
+# visible test.
+set -euo pipefail
+cd "$1"
+node -e "
+const { add } = require('./lib/add.js');
+if (add(2, 3) !== 5) process.exit(1);
+if (add(-7, 7) !== 0) process.exit(1);
+if (add(1000, 234) !== 1234) process.exit(1);
+"
+`;
+
+export type M5ExitMode = "controller" | "wiring";
+
+interface ChildExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface M5ExitReport {
+  readonly mode: string;
+  readonly preResume: {
+    readonly implementOutcome: string | null;
+    readonly implementChildTerminal: string | null;
+    readonly terminal: string | null;
+  };
+  readonly resumed: readonly string[];
+  readonly terminal: {
+    readonly status: string;
+    readonly stopReason: string | null;
+    readonly finalMessage: string | null;
+  } | null;
+  readonly effects: readonly {
+    readonly stepId: string;
+    readonly outcome: string | null;
+    readonly childRunId: string | null;
+  }[];
+  readonly implementReceipts: readonly unknown[];
+  readonly worktreeProvisions: readonly {
+    readonly path: string;
+    readonly created: boolean;
+  }[];
+  readonly implementChildTerminals: {
+    readonly attempt1: string | null;
+    readonly attempt2: string | null;
+  };
+  readonly resumeSpawnKinds: readonly string[];
+  readonly reservations: readonly {
+    readonly id: string;
+    readonly status: string;
+  }[];
+  readonly warnings: readonly string[];
+  readonly bundleDir: string;
+}
+
+const directories: string[] = [];
+
+/** Remove every state dir minted since the last cleanup (afterEach hook). */
+export function cleanupM5ExitStateDirs(): void {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function cleanChildEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT;
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN;
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT_ACTION;
+  delete env.AGENC_TEST_DURABILITY_FAILPOINT_MARKER;
+  return env;
+}
+
+function collectChild(child: ChildProcess): Promise<ChildExit> {
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+export function seedFixtureRepo(repo: string): string {
+  mkdirSync(join(repo, "lib"), { recursive: true });
+  git(repo, "init");
+  git(repo, "config", "user.email", "m5-exit@example.com");
+  git(repo, "config", "user.name", "M5 Exit");
+  // The seeded bug: subtraction instead of addition.
+  writeFileSync(
+    join(repo, "lib", "add.js"),
+    "module.exports.add = (a, b) => a - b;\n",
+  );
+  // The REAL runnable required-verification script.
+  writeFileSync(
+    join(repo, "test.sh"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'node -e "const { add } = require(\'./lib/add.js\'); process.exit(add(2, 3) === 5 ? 0 : 1)"',
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  git(repo, "add", "-A");
+  git(repo, "commit", "-m", "seed: broken add + runnable test");
+  return git(repo, "rev-parse", "HEAD").trim();
+}
+
+export function makeStateDir(prefix: string): string {
+  const stateDir = mkdtempSync(join(tmpdir(), prefix));
+  directories.push(stateDir);
+  // The evidence ledger enforces a private directory chain; a group-writable
+  // umask (e.g. 007) must not leak into the daemon home.
+  mkdirSync(join(stateDir, "home"), { recursive: true, mode: 0o700 });
+  const repo = join(stateDir, "repo");
+  mkdirSync(repo, { recursive: true });
+  seedFixtureRepo(repo);
+  // The hidden verifier lives OUTSIDE the repo/worktree and never enters
+  // any prompt or spec.
+  writeFileSync(join(stateDir, "hidden-verifier.sh"), HIDDEN_VERIFIER, {
+    mode: 0o755,
+  });
+  return stateDir;
+}
+
+function spawnFixture(
+  command: "crash" | "resume",
+  mode: M5ExitMode,
+  stateDir: string,
+  env: NodeJS.ProcessEnv,
+): ChildProcess {
+  return spawn(
+    process.execPath,
+    [
+      "--loader",
+      NODE_TEST_LOADER,
+      "--import",
+      TSX_IMPORT,
+      FIXTURE,
+      command,
+      mode,
+      stateDir,
+    ],
+    { cwd: stateDir, env, stdio: ["ignore", "pipe", "pipe"] },
+  );
+}
+
+export async function crashPhase(
+  mode: M5ExitMode,
+  stateDir: string,
+): Promise<void> {
+  const marker = join(stateDir, "failpoint-reached.json");
+  const env = cleanChildEnvironment();
+  // Only the marker path is armed from outside; the child arms the
+  // failpoint NAME itself, strictly after the implement child's terminal is
+  // durable — that engineered ordering IS the exit-criterion window.
+  env.AGENC_TEST_DURABILITY_FAILPOINT_MARKER = marker;
+  const child = spawnFixture("crash", mode, stateDir, env);
+  const exitPromise = collectChild(child);
+  const deadline = Date.now() + 120_000;
+  while (!existsSync(marker)) {
+    if (child.exitCode !== null || child.signalCode !== null) break;
+    if (Date.now() >= deadline) {
+      child.kill("SIGKILL");
+      const result = await exitPromise;
+      throw new Error(
+        `timed out waiting for the M5 failpoint marker\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const result = await exitPromise;
+  expect(
+    result,
+    `crash child output:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+  ).toMatchObject({ code: null, signal: "SIGKILL" });
+  expect(JSON.parse(readFileSync(marker, "utf8"))).toMatchObject({
+    failpoint: M5_EXIT_FAILPOINT,
+  });
+}
+
+export async function resumePhase(
+  mode: M5ExitMode,
+  stateDir: string,
+): Promise<M5ExitReport> {
+  const child = spawnFixture("resume", mode, stateDir, cleanChildEnvironment());
+  const result = await collectChild(child);
+  expect(
+    result,
+    `resume child output:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+  ).toMatchObject({ code: 0, signal: null });
+  const lines = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return JSON.parse(lines.at(-1)!) as M5ExitReport;
+}
+
+export function assertExitReport(report: M5ExitReport, runId: string): void {
+  // The engineered kill window: child terminal durable, parent result not.
+  expect(report.preResume).toEqual({
+    implementOutcome: null,
+    implementChildTerminal: "completed",
+    terminal: null,
+  });
+  expect(report.resumed).toContain(runId);
+  // Terminal `completed` after restart + resume.
+  expect(report.terminal?.status).toBe("completed");
+  expect(report.terminal?.finalMessage).toContain("verified change completed");
+  // Exactly ONE implementer child ever ran: one physical receipt, one
+  // durable child-terminal row, one durable implement effect, and NO
+  // implement respawn during resume (adoption, never respawn).
+  expect(report.implementReceipts).toHaveLength(1);
+  expect(report.implementChildTerminals).toEqual({
+    attempt1: "completed",
+    attempt2: null,
+  });
+  expect(
+    report.effects.filter((effect) =>
+      effect.stepId.startsWith("workflow.implement"),
+    ),
+  ).toEqual([
+    {
+      stepId: "workflow.implement",
+      outcome: "committed",
+      childRunId: `${runId}:implement#1`,
+    },
+  ]);
+  expect(report.resumeSpawnKinds).not.toContain("implement");
+  expect(report.resumeSpawnKinds).toContain("verify_agent");
+  // Exactly one worktree ever existed: every provision resolved the same
+  // path and only the first created it.
+  const paths = new Set(report.worktreeProvisions.map((entry) => entry.path));
+  expect(paths.size).toBe(1);
+  expect(
+    report.worktreeProvisions.filter((entry) => entry.created),
+  ).toHaveLength(1);
+  // Budget: every reservation reconciled-or-held; the reservation the kill
+  // orphaned mid-dispatch is HELD, never silently freed.
+  expect(report.reservations.length).toBeGreaterThan(0);
+  for (const reservation of report.reservations) {
+    expect(["reconciled", "held_unknown", "voided"]).toContain(
+      reservation.status,
+    );
+  }
+  expect(
+    report.reservations.filter(
+      (reservation) => reservation.status === "held_unknown",
+    ).length,
+  ).toBeGreaterThanOrEqual(1);
+}
+
+export async function assertBundleAndHiddenVerifier(
+  stateDir: string,
+  bundleDir: string,
+): Promise<void> {
+  const repo = join(stateDir, "repo");
+  // Evidence-only reconstruction of the exported bundle.
+  const reconstruction = await reconstructVerifiedChange(bundleDir);
+  expect(reconstruction.runId).toBe(M5_EXIT_RUN_ID);
+  expect(reconstruction.terminal.status).toBe("completed");
+  expect(reconstruction.reviewBlockers).toEqual([]);
+  expect(reconstruction.verificationCommands).toHaveLength(1);
+  expect(reconstruction.verificationCommands[0]).toMatchObject({
+    label: "unit",
+    exitCode: 0,
+    timedOut: false,
+  });
+  // The hidden verifier is invisible to the recorded spec and prompts.
+  const recordText = readFileSync(
+    join(bundleDir, "verified-change-record.json"),
+    "utf8",
+  );
+  expect(recordText).not.toContain("hidden-verifier");
+  // The exported patch applies cleanly to a FRESH clone at the recorded
+  // base commit, and the hidden verifier passes against the patched clone.
+  const patchArtifact = reconstruction.artifacts.find(
+    (artifact) => artifact.role === "patch",
+  );
+  expect(patchArtifact).toBeDefined();
+  const patchBytes = await readBundleArtifact(bundleDir, patchArtifact!.digest);
+  const cloneDir = join(stateDir, "fresh-clone");
+  execFileSync("git", ["clone", repo, cloneDir], { encoding: "utf8" });
+  git(cloneDir, "checkout", "--detach", reconstruction.baseCommit);
+  const patchFile = join(stateDir, "exported.patch");
+  writeFileSync(patchFile, patchBytes);
+  git(cloneDir, "apply", patchFile);
+  execFileSync("bash", [join(stateDir, "hidden-verifier.sh"), cloneDir], {
+    encoding: "utf8",
+  });
+}

--- a/runtime/tests/workflow/fixtures/m5-harness.ts
+++ b/runtime/tests/workflow/fixtures/m5-harness.ts
@@ -1,0 +1,454 @@
+/**
+ * Shared M5 exit-proof harness.
+ *
+ * A daemon-like assembly of the verified-change workflow with REAL durable
+ * machinery and scripted model seams only:
+ *
+ *   - real per-project SQLite state database + StateRunDurabilityRepository,
+ *   - real execution-admission kernel (reservations, admission journal),
+ *   - real per-run evidence ledger (hash chain, CAS payloads, local anchor
+ *     seal) via the daemon factory,
+ *   - real git worktree lifecycle over a SandboxExecutionBroker,
+ *   - real verification-command execution (`bash -lc` in the worktree),
+ *   - SCRIPTED plan/implement/verify-agent children and reviewer (no model,
+ *     no network). The "implement" child applies a real fix in the worktree
+ *     and its terminal outcome is durably recorded through the PRODUCTION
+ *     A1 helper (`recordWorkflowChildTerminal`); post-restart adoption goes
+ *     through the production durable inspection helper.
+ *
+ * Used by the hermetic exit test's crash/resume child process, by the
+ * evidence-reconstruction test (in-process, no crash), and by the opt-in
+ * acceptance lane (through the real daemon wiring).
+ */
+
+import { execFile } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createDaemonWorkflowController,
+  createDaemonWorkflowEvidenceLedgerFactory,
+  type DaemonWorkflowWiring,
+} from "../../../src/app-server/workflow/daemon-wiring.js";
+import {
+  VerifiedChangeWorkflowController,
+  type WorkflowAgentSpawner,
+  type WorkflowChildInspection,
+  type WorkflowChildOutcome,
+  type WorkflowRunJournal,
+  type WorkflowSpawnKind,
+  type WorkflowWorktreeBroker,
+} from "../../../src/app-server/workflow/verified-change-controller.js";
+import {
+  inspectWorkflowChildTerminal,
+  recordWorkflowChildTerminal,
+  type WorkflowSessionSeams,
+} from "../../../src/app-server/workflow/session-adapters.js";
+import { ExecutionAdmissionKernel } from "../../../src/budget/execution-admission-kernel.js";
+import { SandboxExecutionBroker } from "../../../src/sandbox/execution-broker.js";
+import { StateRunDurabilityRepository } from "../../../src/state/run-durability.js";
+import {
+  openStateDatabases,
+  resolveStateDatabasePaths,
+  type StateSqliteDriver,
+} from "../../../src/state/sqlite-driver.js";
+import type { ReviewerInvoker } from "../../../src/workflow/independent-review.js";
+import type {
+  WorkflowCommandResult,
+  WorkflowCommandRunner,
+} from "../../../src/workflow/verification.js";
+import {
+  captureBaseState,
+  checkBaseMovement,
+  cleanupAfterEvidence,
+  exportPatchArtifacts,
+  provisionWorkflowWorktree,
+} from "../../../src/workflow/worktree-lifecycle.js";
+
+export const M5_EXIT_RUN_ID = "wf-m5-exit";
+export const M5_APPROVING_REVIEW = JSON.stringify({
+  findings: [],
+  overallCorrectness: "correct",
+  overallExplanation: "the one-line fix is exactly what the goal demands",
+  overallConfidenceScore: 0.92,
+});
+
+/** Test journal writer projecting straight into the real repository. */
+class HarnessJournal implements WorkflowRunJournal {
+  readonly sessionId: string;
+  readonly epoch: number;
+  #seq: number;
+
+  constructor(
+    private readonly repo: StateRunDurabilityRepository,
+    readonly runId: string,
+  ) {
+    this.sessionId = `${runId}-session`;
+    this.repo.ensureInitialEpoch({
+      runId,
+      openedAt: new Date().toISOString(),
+    });
+    this.epoch = this.repo.currentEpoch(runId)!.epoch;
+    let max = 0;
+    for (const effect of this.repo.listEffects(runId)) {
+      max = Math.max(max, effect.intentSequence, effect.resultSequence ?? 0);
+    }
+    this.#seq = max;
+  }
+
+  #next(): { eventId: string; sequence: number } {
+    this.#seq += 1;
+    return { eventId: `evt-${this.runId}-${this.#seq}`, sequence: this.#seq };
+  }
+
+  appendIntent(input: Parameters<WorkflowRunJournal["appendIntent"]>[0]) {
+    const ref = this.#next();
+    this.repo.beginEffect({
+      runId: this.runId,
+      epoch: this.epoch,
+      stepId: input.stepId,
+      ...(input.childRunId !== undefined
+        ? { childRunId: input.childRunId }
+        : {}),
+      sessionId: this.sessionId,
+      callId: input.callId ?? input.stepId,
+      toolName: input.toolName,
+      recoveryCategory: input.recoveryCategory,
+      ...(input.idempotencyKey !== undefined
+        ? { idempotencyKey: input.idempotencyKey }
+        : {}),
+      intentDigest: input.intentDigest,
+      eventId: ref.eventId,
+      eventSequence: ref.sequence,
+      intentAt: input.intentAt,
+    });
+    return ref;
+  }
+
+  appendResult(input: Parameters<WorkflowRunJournal["appendResult"]>[0]) {
+    const ref = this.#next();
+    this.repo.completeEffect({
+      runId: this.runId,
+      stepId: input.stepId,
+      outcome: input.outcome,
+      eventId: ref.eventId,
+      eventSequence: ref.sequence,
+      ...(input.resultDigest !== undefined
+        ? { resultDigest: input.resultDigest }
+        : {}),
+      ...(input.evidence !== undefined ? { evidence: input.evidence } : {}),
+      completedAt: input.completedAt,
+    });
+    return ref;
+  }
+
+  appendUnknown(input: Parameters<WorkflowRunJournal["appendUnknown"]>[0]) {
+    const ref = this.#next();
+    this.repo.markEffectUnknown({
+      runId: this.runId,
+      stepId: input.stepId,
+      eventId: ref.eventId,
+      eventSequence: ref.sequence,
+      reason: input.reason,
+      ...(input.evidence !== undefined ? { evidence: input.evidence } : {}),
+      observedAt: input.observedAt,
+    });
+    return ref;
+  }
+
+  appendTerminal() {
+    return this.#next();
+  }
+
+  async close(): Promise<void> {}
+}
+
+function runBash(
+  script: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<WorkflowCommandResult> {
+  const startedAt = performance.now();
+  return new Promise((resolvePromise) => {
+    execFile(
+      "bash",
+      ["-lc", script],
+      { cwd, timeout: timeoutMs, encoding: "buffer", maxBuffer: 8 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const durationMs = Math.round(performance.now() - startedAt);
+        const killed =
+          error !== null && (error as { killed?: boolean }).killed === true;
+        const code =
+          error === null
+            ? 0
+            : typeof (error as { code?: unknown }).code === "number"
+              ? ((error as { code: number }).code)
+              : 1;
+        resolvePromise({
+          exitCode: code,
+          stdout: new Uint8Array(stdout),
+          stderr: new Uint8Array(stderr),
+          timedOut: killed,
+          truncated: false,
+          durationMs,
+        });
+      },
+    );
+  });
+}
+
+export interface M5HarnessOptions {
+  /** AGENC home for state DBs, admission kernel, and evidence ledgers. */
+  readonly home: string;
+  /** Fixture git repository (the "user checkout"). */
+  readonly repoPath: string;
+  /** Physical receipts directory (spawn/provision counters survive kills). */
+  readonly receiptsDir: string;
+  /** Relative file + contents the scripted implement child writes. */
+  readonly implementFix: { readonly file: string; readonly contents: string };
+  /** Build through the real daemon wiring instead of a bare controller. */
+  readonly throughDaemonWiring?: boolean;
+  /**
+   * Called synchronously right AFTER the implement child's terminal is
+   * durably recorded and right BEFORE the spawner returns to the
+   * controller — i.e. immediately before the parent effect_result would
+   * commit. The exit test arms the SIGKILL failpoint here so the crash
+   * window objectively contains a durable child terminal and no parent
+   * result.
+   */
+  readonly onImplementSettled?: () => void;
+}
+
+export interface M5Harness {
+  readonly controller: VerifiedChangeWorkflowController;
+  readonly repo: StateRunDurabilityRepository;
+  readonly kernel: ExecutionAdmissionKernel;
+  readonly warnings: readonly string[];
+  /** Spawn kinds dispatched by THIS process (physical receipts persist). */
+  readonly spawnKinds: readonly WorkflowSpawnKind[];
+  resumeOpenWorkflows(): Promise<readonly string[]>;
+  close(): void;
+}
+
+export function buildM5Harness(options: M5HarnessOptions): M5Harness {
+  mkdirSync(options.receiptsDir, { recursive: true });
+  const implementReceipt = join(options.receiptsDir, "implement-attempts.jsonl");
+  const provisionReceipt = join(options.receiptsDir, "worktree-provisions.jsonl");
+
+  const driver: StateSqliteDriver = openStateDatabases({
+    cwd: options.repoPath,
+    agencHome: options.home,
+  });
+  const repo = new StateRunDurabilityRepository(driver);
+  const kernel = new ExecutionAdmissionKernel({
+    agencHome: options.home,
+    ownerId: `m5-exit-harness:${process.pid}`,
+    ownerPid: process.pid,
+  });
+  const broker = new SandboxExecutionBroker({
+    mode: "danger_full_access",
+    cwd: options.repoPath,
+  });
+  const warnings: string[] = [];
+  const spawnKinds: WorkflowSpawnKind[] = [];
+
+  const worktrees: WorkflowWorktreeBroker = {
+    captureBaseState: async (repoPath) => captureBaseState(repoPath, broker),
+    provision: async (spec) => {
+      const handle = await provisionWorkflowWorktree(spec, broker);
+      appendFileSync(
+        provisionReceipt,
+        `${JSON.stringify({ path: handle.path, created: handle.created })}\n`,
+      );
+      return handle;
+    },
+    exportPatch: async (input) =>
+      exportPatchArtifacts({
+        handle: input.handle,
+        baseCommit: input.baseCommit,
+        step: input.step,
+        sink: input.sink,
+        broker,
+      }),
+    checkBaseMovement: async (input) =>
+      checkBaseMovement({
+        spec: input.spec,
+        patchBytes: input.patchBytes,
+        broker,
+      }),
+    cleanup: async (input) =>
+      cleanupAfterEvidence({
+        proof: input.proof,
+        handle: input.handle,
+        broker,
+        warn: (message) => warnings.push(message),
+      }),
+  };
+
+  const commands: WorkflowCommandRunner = {
+    run: (input) => runBash(input.script, input.cwd, input.timeoutMs),
+  };
+
+  const spawner: WorkflowAgentSpawner = {
+    spawn: async (input): Promise<WorkflowChildOutcome> => {
+      spawnKinds.push(input.kind);
+      let outcome: WorkflowChildOutcome;
+      if (input.kind === "plan") {
+        outcome = {
+          status: "completed",
+          finalMessage: "PLAN: apply the one-line fix and re-run the script.",
+          usage: null,
+        };
+      } else if (input.kind === "implement") {
+        // The implement child performs a REAL side effect in the worktree.
+        const { writeFileSync } = await import("node:fs");
+        writeFileSync(
+          join(input.worktreePath, options.implementFix.file),
+          options.implementFix.contents,
+        );
+        appendFileSync(
+          implementReceipt,
+          `${JSON.stringify({ childRunId: input.childRunId, pid: process.pid })}\n`,
+        );
+        outcome = {
+          status: "completed",
+          finalMessage: `applied the fix to ${options.implementFix.file}`,
+          usage: null,
+        };
+      } else {
+        outcome = {
+          status: "completed",
+          finalMessage: "re-ran the required script in the worktree\nVERDICT: PASS",
+          usage: null,
+        };
+      }
+      // A1: the child's terminal becomes durable through the PRODUCTION
+      // helper BEFORE the controller can journal the parent effect_result.
+      recordWorkflowChildTerminal(repo, input.childRunId, outcome);
+      if (input.kind === "implement") options.onImplementSettled?.();
+      return outcome;
+    },
+    inspect: async (childRunId): Promise<WorkflowChildInspection> => {
+      // Post-restart adoption goes through the PRODUCTION durable
+      // inspection: terminal when recorded, honestly unknown otherwise.
+      const durable = inspectWorkflowChildTerminal(repo, childRunId);
+      if (durable !== undefined) return { state: "terminal", outcome: durable };
+      return { state: "unknown" };
+    },
+  };
+
+  const reviewer: ReviewerInvoker = {
+    invoke: async () => M5_APPROVING_REVIEW,
+  };
+
+  const warn = (message: string): void => {
+    warnings.push(message);
+  };
+
+  /**
+   * Open the run journal AND bind a canonical journal source for the run —
+   * the invariant the daemon's RolloutStore maintains in production. The
+   * admission kernel's canonical recovery refuses a run that holds
+   * committed admission evidence and a lifecycle epoch without a journal
+   * binding, and it converges the SQLite admission journal into this bound
+   * source so `run.replay` serves a canonical journal after restart.
+   */
+  const openJournal = (runId: string): HarnessJournal => {
+    const journal = new HarnessJournal(repo, runId);
+    // Canonical rollout sources must live at the exact daemon layout
+    // (<projectDir>/sessions/<sessionId>/rollout-*.jsonl) or the offline
+    // rollout safety checks refuse them.
+    const paths = resolveStateDatabasePaths({
+      cwd: options.repoPath,
+      agencHome: options.home,
+    });
+    const sessionDir = join(paths.projectDir, "sessions", journal.sessionId);
+    const sourcePath = join(sessionDir, `rollout-${runId}.jsonl`);
+    if (repo.getJournalBinding(sourcePath) === undefined) {
+      mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+      if (!existsSync(sourcePath)) {
+        writeFileSync(sourcePath, "", { mode: 0o600 });
+      }
+      repo.bindJournalSource({
+        runId,
+        epoch: journal.epoch,
+        childRunId: runId,
+        sessionId: journal.sessionId,
+        sourcePath,
+        active: true,
+        boundAt: new Date().toISOString(),
+      });
+    }
+    return journal;
+  };
+
+  if (options.throughDaemonWiring === true) {
+    const seams: WorkflowSessionSeams = {
+      journal: {
+        open: async (runId) => openJournal(runId),
+      },
+      worktrees,
+      commands,
+      spawner,
+      reviewer,
+      close: async () => {},
+    };
+    const wiring: DaemonWorkflowWiring = createDaemonWorkflowController({
+      agencHome: options.home,
+      primaryCwd: options.repoPath,
+      kernel,
+      warn,
+      stateDatabasePaths: () => [
+        resolveStateDatabasePaths({
+          cwd: options.repoPath,
+          agencHome: options.home,
+        }),
+      ],
+      sessionSeams: seams,
+    });
+    return {
+      controller: wiring.controller,
+      repo,
+      kernel,
+      warnings,
+      spawnKinds,
+      resumeOpenWorkflows: () => wiring.resumeOpenWorkflows(),
+      close: () => {
+        wiring.close();
+        kernel.close();
+        driver.close();
+      },
+    };
+  }
+
+  const controller = new VerifiedChangeWorkflowController({
+    durability: () => repo,
+    journal: { open: async (runId) => openJournal(runId) },
+    admission: ({ runId, sessionId, spec }) =>
+      kernel.bindClient({
+        cwd: spec.repoPath,
+        budgetIdentity: runId,
+        scope: { runId, sessionId, autonomous: true },
+      }),
+    worktrees,
+    commands,
+    spawner,
+    reviewer,
+    evidenceLedger: createDaemonWorkflowEvidenceLedgerFactory({
+      agencHome: options.home,
+    }),
+    warn,
+  });
+  return {
+    controller,
+    repo,
+    kernel,
+    warnings,
+    spawnKinds,
+    resumeOpenWorkflows: () => controller.resumeOpenWorkflows(),
+    close: () => {
+      kernel.close();
+      driver.close();
+    },
+  };
+}

--- a/runtime/tests/workflow/m5-evidence-reconstruction.test.ts
+++ b/runtime/tests/workflow/m5-evidence-reconstruction.test.ts
@@ -1,0 +1,207 @@
+/**
+ * M5 exit proof — evidence-only reconstruction.
+ *
+ * Runs a complete verified-change workflow through the scripted harness
+ * (real ledger, real git, real admission), copies the exported bundle
+ * directory elsewhere, and reconstructs the run from those bytes alone —
+ * no daemon, no SQLite, no rollout files. The reconstruction must agree
+ * with what the run reported, and a single tampered CAS byte must make it
+ * fail loudly.
+ */
+
+import {
+  chmodSync,
+  cpSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  EvidenceReconstructionError,
+  readBundleArtifact,
+  reconstructVerifiedChange,
+} from "../../src/workflow/evidence-reconstruction.js";
+import { WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME } from "../../src/workflow/local-anchor.js";
+import { buildM5Harness, type M5Harness } from "./fixtures/m5-harness.js";
+import { seedFixtureRepo } from "./fixtures/m5-exit-shared.js";
+
+const RUN_ID = "wf-m5-reconstruct";
+
+let stateDir: string;
+let harness: M5Harness | undefined;
+
+afterEach(() => {
+  harness?.close();
+  harness = undefined;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+async function runCompletedWorkflow(): Promise<{
+  readonly home: string;
+  readonly bundleDir: string;
+}> {
+  stateDir = mkdtempSync(join(tmpdir(), "agenc-m5-reconstruct-"));
+  const home = join(stateDir, "home");
+  mkdirSync(home, { recursive: true, mode: 0o700 });
+  const repo = join(stateDir, "repo");
+  mkdirSync(repo, { recursive: true });
+  seedFixtureRepo(repo);
+  harness = buildM5Harness({
+    home,
+    repoPath: repo,
+    receiptsDir: join(stateDir, "receipts"),
+    implementFix: {
+      file: "lib/add.js",
+      contents: "module.exports.add = (a, b) => a + b;\n",
+    },
+  });
+  const started = await harness.controller.start({
+    goal: "Fix the arithmetic bug in lib/add.js so the required script passes.",
+    repoPath: repo,
+    reviewerModel: "scripted-reviewer",
+    requiredVerification: [{ label: "unit", script: "bash test.sh" }],
+    maxImplementAttempts: 2,
+    runId: RUN_ID,
+  });
+  await harness.controller.awaitRun(started.runId);
+  expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+    status: "completed",
+  });
+  return { home, bundleDir: join(home, "run-evidence", RUN_ID) };
+}
+
+/** Self-contained export: the bundle dir plus its anchor material. */
+function exportBundle(home: string, bundleDir: string): string {
+  const exported = join(stateDir, "exported-bundle");
+  mkdirSync(exported, { recursive: true, mode: 0o700 });
+  cpSync(bundleDir, exported, { recursive: true });
+  copyFileSync(
+    join(home, "run-evidence", WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME),
+    join(exported, WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME),
+  );
+  // cpSync creates directories under the ambient umask; the ledger's
+  // private-chain checks demand 0700/0600 exactly like the live export.
+  restrictModes(exported);
+  return exported;
+}
+
+function restrictModes(root: string): void {
+  chmodSync(root, 0o700);
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const target = join(root, entry.name);
+    if (entry.isDirectory()) {
+      restrictModes(target);
+    } else {
+      chmodSync(target, 0o600);
+    }
+  }
+}
+
+describe("M5 evidence-only reconstruction", () => {
+  it("reconstructs a completed run from the exported bundle bytes alone", async () => {
+    const { home, bundleDir } = await runCompletedWorkflow();
+    const terminal = harness!.repo.getCurrentTerminalResult(RUN_ID)!;
+    const record = JSON.parse(
+      readFileSync(join(bundleDir, "verified-change-record.json"), "utf8"),
+    ) as { documentDigest: string; specDigest: string; baseCommit: string };
+
+    const exported = exportBundle(home, bundleDir);
+    const reconstruction = await reconstructVerifiedChange(exported);
+
+    // The summary matches what the run reported.
+    expect(reconstruction.runId).toBe(RUN_ID);
+    expect(reconstruction.specDigest).toBe(record.specDigest);
+    expect(reconstruction.baseCommit).toBe(record.baseCommit);
+    expect(reconstruction.terminal.status).toBe("completed");
+    expect(reconstruction.terminal.stopReason).toBeNull();
+    expect(terminal.finalMessage).toContain(
+      reconstruction.ledger.sealDigest,
+    );
+    expect(terminal.finalMessage).toContain(record.documentDigest);
+    expect(reconstruction.verificationCommands).toEqual([
+      expect.objectContaining({
+        label: "unit",
+        script: "bash test.sh",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    ]);
+    expect(reconstruction.review).toMatchObject({
+      reviewerModel: "scripted-reviewer",
+      overallCorrectness: "correct",
+      blockerCount: 0,
+    });
+    expect(reconstruction.reviewBlockers).toEqual([]);
+    expect(reconstruction.unresolvedRisks).toEqual([]);
+    const roles = new Set(
+      reconstruction.artifacts.map((artifact) => artifact.role),
+    );
+    for (const required of [
+      "patch",
+      "changed_files",
+      "test_result",
+      "independent_review",
+    ]) {
+      expect(roles.has(required as never)).toBe(true);
+    }
+    // The reconstructed patch bytes carry the real fix.
+    const patch = reconstruction.artifacts.find(
+      (artifact) => artifact.role === "patch",
+    )!;
+    const patchText = new TextDecoder().decode(
+      await readBundleArtifact(exported, patch.digest),
+    );
+    expect(patchText).toContain("a + b");
+  });
+
+  it("fails loudly when one CAS byte is tampered", async () => {
+    const { home, bundleDir } = await runCompletedWorkflow();
+    const exported = exportBundle(home, bundleDir);
+    const clean = await reconstructVerifiedChange(exported);
+    const patch = clean.artifacts.find(
+      (artifact) => artifact.role === "patch",
+    )!;
+    // Locate and tamper the patch payload file: flip exactly one byte.
+    const hex = patch.digest.slice("sha256:".length);
+    const payloadDir = readdirSync(exported).find((entry) =>
+      entry.endsWith(".payloads"),
+    )!;
+    const payloadPath = join(exported, payloadDir, `sha256-${hex}.bin`);
+    const bytes = readFileSync(payloadPath);
+    bytes[Math.floor(bytes.length / 2)]! ^= 0x01;
+    writeFileSync(payloadPath, bytes);
+
+    // The eval-contract ledger inspection verifies payload bytes against
+    // the chained payload digests, so a flipped CAS byte already fails the
+    // hash-chain verification; the reconstruction's own digest recompute is
+    // defense-in-depth behind it. Either way: loud, typed failure.
+    const failure = await reconstructVerifiedChange(exported).then(
+      () => {
+        throw new Error("tampered bundle must not reconstruct");
+      },
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(EvidenceReconstructionError);
+    expect([
+      "ledger_verification_failed",
+      "artifact_digest_mismatch",
+    ]).toContain((failure as EvidenceReconstructionError).failure);
+  });
+
+  it("refuses a bundle whose anchor material is absent", async () => {
+    const { home, bundleDir } = await runCompletedWorkflow();
+    const exported = exportBundle(home, bundleDir);
+    rmSync(join(exported, WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME));
+    await expect(reconstructVerifiedChange(exported)).rejects.toMatchObject({
+      failure: "anchor_material_missing",
+    });
+  });
+});

--- a/runtime/tests/workflow/m5-exit.acceptance.test.ts
+++ b/runtime/tests/workflow/m5-exit.acceptance.test.ts
@@ -1,0 +1,84 @@
+/**
+ * M5 exit proof — opt-in acceptance lane.
+ *
+ * Skipped unless `AGENC_M5_ACCEPTANCE=1` (the M4 matrix-style opt-in
+ * gating convention for heavier acceptance runs). Same SIGKILL-at-
+ * `after_spawn_before_effect_result` crash/restart flow as the hermetic
+ * lane, but assembled through the REAL daemon wiring
+ * (`createDaemonWorkflowController`: per-run durability resolution,
+ * multi-project resume sweep, real daemon evidence-ledger factory) —
+ * model seams stay scripted by default; a real-model mode is a deliberate
+ * non-goal for the default suite. Finishes with the B2 evidence-only
+ * reconstruction over the exported bundle.
+ */
+
+import { copyFileSync, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, it } from "vitest";
+
+import { WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME } from "../../src/workflow/local-anchor.js";
+import {
+  assertBundleAndHiddenVerifier,
+  assertExitReport,
+  cleanupM5ExitStateDirs,
+  crashPhase,
+  makeStateDir,
+  resumePhase,
+} from "./fixtures/m5-exit-shared.js";
+import { M5_EXIT_RUN_ID } from "./fixtures/m5-harness.js";
+
+const ACCEPTANCE_ENABLED = process.env.AGENC_M5_ACCEPTANCE === "1";
+
+afterEach(() => {
+  cleanupM5ExitStateDirs();
+});
+
+describe.sequential.skipIf(!ACCEPTANCE_ENABLED)(
+  "M5 exit proof — acceptance lane (AGENC_M5_ACCEPTANCE=1)",
+  () => {
+    it(
+      "crash/restart through the real daemon wiring completes by adoption and reconstructs from evidence alone",
+      { timeout: 300_000 },
+      async () => {
+        const stateDir = makeStateDir("agenc-m5-exit-acceptance-");
+        await crashPhase("wiring", stateDir);
+        const report = await resumePhase("wiring", stateDir);
+        assertExitReport(report, M5_EXIT_RUN_ID);
+        // B1-style bundle checks (patch onto a fresh clone + hidden
+        // verifier) — includes the B2 reconstruction of the live bundle.
+        await assertBundleAndHiddenVerifier(stateDir, report.bundleDir);
+        // And the B2 reconstruction again over a SELF-CONTAINED copy of
+        // the exported bundle (anchor material embedded).
+        const exported = join(stateDir, "exported-bundle");
+        mkdirSync(exported, { recursive: true, mode: 0o700 });
+        const { cpSync, chmodSync } = await import("node:fs");
+        cpSync(report.bundleDir, exported, { recursive: true });
+        copyFileSync(
+          join(
+            join(stateDir, "home", "run-evidence"),
+            WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME,
+          ),
+          join(exported, WORKFLOW_LOCAL_ANCHOR_SECRET_FILENAME),
+        );
+        const restrict = (root: string): void => {
+          chmodSync(root, 0o700);
+          for (const entry of readdirSync(root, { withFileTypes: true })) {
+            const target = join(root, entry.name);
+            if (entry.isDirectory()) restrict(target);
+            else chmodSync(target, 0o600);
+          }
+        };
+        restrict(exported);
+        const { reconstructVerifiedChange } = await import(
+          "../../src/workflow/evidence-reconstruction.js"
+        );
+        const reconstruction = await reconstructVerifiedChange(exported);
+        if (reconstruction.terminal.status !== "completed") {
+          throw new Error(
+            `acceptance reconstruction expected completed, got ${reconstruction.terminal.status}`,
+          );
+        }
+      },
+    );
+  },
+);

--- a/runtime/tests/workflow/m5-exit.hermetic.test.ts
+++ b/runtime/tests/workflow/m5-exit.hermetic.test.ts
@@ -1,0 +1,126 @@
+/**
+ * M5 exit proof — hermetic crash/restart acceptance for the verified-change
+ * workflow (runs in the default PR suite; no network, no real model).
+ *
+ * A child-process daemon-like harness (real SQLite durability, real
+ * execution-admission kernel, real evidence ledger, real git worktree,
+ * scripted model seams) is SIGKILLed at `after_spawn_before_effect_result`
+ * with the implement child's terminal ALREADY durably recorded (A1) and the
+ * parent effect_result NOT yet journaled. Any attached client dies with the
+ * process — the "disconnect". A fresh process then resumes:
+ *
+ *   - the run reaches terminal `completed` by ADOPTING the durable child
+ *     terminal (never respawning the implementer),
+ *   - exactly ONE implementer child ever ran (physical receipts + durable
+ *     rows), exactly one worktree existed,
+ *   - the crashed step's budget reservation is held (never silently freed),
+ *   - reattach-by-cursor works through the run inspection/replay path,
+ *   - `run.result`/`run.evidence` serve the durable terminal + sealed
+ *     bundle,
+ *   - the exported patch applies cleanly to a FRESH clone of the fixture
+ *     repo, and a HIDDEN verifier script — kept outside the worktree and
+ *     never present in any prompt or spec — passes against the patched
+ *     clone.
+ */
+
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AgenCDaemonRunInspectionService } from "../../src/app-server/run-inspection.js";
+import { resolveStateDatabasePaths } from "../../src/state/sqlite-driver.js";
+import {
+  assertBundleAndHiddenVerifier,
+  assertExitReport,
+  cleanupM5ExitStateDirs,
+  crashPhase,
+  makeStateDir,
+  resumePhase,
+} from "./fixtures/m5-exit-shared.js";
+import { M5_EXIT_RUN_ID } from "./fixtures/m5-harness.js";
+
+afterEach(() => {
+  cleanupM5ExitStateDirs();
+});
+
+describe.sequential("M5 exit proof — hermetic SIGKILL crash/restart", () => {
+  it(
+    "completes after a kill at after_spawn_before_effect_result by adopting the durable child terminal",
+    { timeout: 240_000 },
+    async () => {
+      const stateDir = makeStateDir("agenc-m5-exit-");
+      await crashPhase("controller", stateDir);
+      const report = await resumePhase("controller", stateDir);
+      assertExitReport(report, M5_EXIT_RUN_ID);
+
+      // "Disconnect": the SIGKILL dropped any attached client with the
+      // process. After restart, run inspection serves the durable terminal
+      // and the sealed bundle, and reattach-by-cursor pages the journal.
+      const home = join(stateDir, "home");
+      const repo = join(stateDir, "repo");
+      const inspection = new AgenCDaemonRunInspectionService({
+        stateDatabasePaths: () => [
+          resolveStateDatabasePaths({ cwd: repo, agencHome: home }),
+        ],
+        agencHome: home,
+      });
+
+      const result = inspection.result({ runId: M5_EXIT_RUN_ID });
+      expect(result.terminal).toBe(true);
+      expect(result.status).toBe("completed");
+      expect(result.output).toMatchObject({ available: true, exitCode: 0 });
+
+      const evidence = inspection.evidence({ runId: M5_EXIT_RUN_ID });
+      expect(evidence.bundle).toBeDefined();
+      expect(evidence.bundle!.sealed).toBe(true);
+      expect(evidence.bundle!.recordDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(evidence.bundle!.artifacts.length).toBeGreaterThan(0);
+
+      // The durable workflow projection is served through run.status too.
+      const status = inspection.status({ runId: M5_EXIT_RUN_ID });
+      expect(status.workflow).toBeDefined();
+      expect(
+        status.workflow!.steps.every((step) => step.status === "committed"),
+      ).toBe(true);
+
+      // Reattach-by-cursor: page, continue from the returned cursor with
+      // no overlap, and observe a clean empty tail.
+      const first = inspection.replay({
+        runId: M5_EXIT_RUN_ID,
+        afterSequence: 0,
+        limit: 5,
+      });
+      expect(first.gap).toBeNull();
+      expect(first.events.length).toBeGreaterThan(0);
+      const seenKeys = new Set(
+        first.events.map((event) => `${event.sequence}:${event.eventId}`),
+      );
+      let cursor = first.nextAfterSequence;
+      let hasMore = first.hasMore;
+      while (hasMore) {
+        const page = inspection.replay({
+          runId: M5_EXIT_RUN_ID,
+          afterSequence: cursor,
+          limit: 5,
+        });
+        expect(page.gap).toBeNull();
+        for (const event of page.events) {
+          expect(event.sequence).toBeGreaterThan(cursor);
+          const key = `${event.sequence}:${event.eventId}`;
+          expect(seenKeys.has(key)).toBe(false);
+          seenKeys.add(key);
+        }
+        cursor = page.nextAfterSequence;
+        hasMore = page.hasMore;
+      }
+      const tail = inspection.replay({
+        runId: M5_EXIT_RUN_ID,
+        afterSequence: cursor,
+        limit: 5,
+      });
+      expect(tail.events).toEqual([]);
+      expect(tail.gap).toBeNull();
+
+      await assertBundleAndHiddenVerifier(stateDir, report.bundleDir);
+    },
+  );
+});

--- a/runtime/tests/workflow/session-adapters.policy.test.ts
+++ b/runtime/tests/workflow/session-adapters.policy.test.ts
@@ -1,0 +1,284 @@
+/**
+ * M5 Phase 6 — A1/A2 unit coverage for the session adapters.
+ *
+ * A2: the frozen spec's permissionMode/unattendedAllow/unattendedDeny are
+ * applied to the run's bootstrapped session exactly like the
+ * background-agent runner applies them (`--permission-mode`/`--yolo`
+ * bootstrap argv + unattended-policy install on the permission-mode
+ * registry) — on start (explicit policy) AND on resume (policy re-resolved
+ * from the durable intake spec).
+ *
+ * A1: workflow child terminals are durably recorded/inspected through the
+ * existing run machinery keyed by the deterministic child run id, and
+ * `spawner.inspect` adopts a durable terminal after the in-memory maps are
+ * gone — while a child with no durable terminal stays honestly "unknown".
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AgenCBootstrapFunction } from "../../src/app-server/background-agent-runner.js";
+import {
+  createWorkflowSessionSeams,
+  inspectWorkflowChildTerminal,
+  recordWorkflowChildTerminal,
+  workflowPermissionModeArgv,
+  type WorkflowSessionSeams,
+} from "../../src/app-server/workflow/session-adapters.js";
+import type { WorkflowRunSessionPolicy } from "../../src/app-server/workflow/verified-change-controller.js";
+import type { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
+import type { ToolPermissionContext } from "../../src/permissions/types.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+
+const RUN_ID = "wf-policy-run";
+
+interface FakeBootstrapCall {
+  readonly argv: readonly string[] | undefined;
+  readonly registry: PermissionModeRegistry;
+  readonly conversationId: string | undefined;
+  readonly resumeConversation: boolean | undefined;
+}
+
+let home: string;
+let cwd: string;
+let driver: StateSqliteDriver;
+let repo: StateRunDurabilityRepository;
+let bootstrapCalls: FakeBootstrapCall[];
+let resolvedPolicies: (WorkflowRunSessionPolicy | undefined)[];
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-m5-policy-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-m5-policy-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome: home });
+  repo = new StateRunDurabilityRepository(driver);
+  bootstrapCalls = [];
+  resolvedPolicies = [];
+});
+
+afterEach(() => {
+  driver.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function baseContext(mode: ToolPermissionContext["mode"]): ToolPermissionContext {
+  return {
+    mode,
+    additionalWorkingDirectories: new Map(),
+    alwaysAllowRules: {},
+    alwaysDenyRules: {},
+    alwaysAskRules: {},
+    isBypassPermissionsModeAvailable: true,
+  };
+}
+
+/**
+ * Minimal bootstrap double: derives the session's initial permission mode
+ * from the argv the adapters hand it — the exact contract the real
+ * bootstrap implements via startup-selection.
+ */
+const fakeBootstrap: AgenCBootstrapFunction = async (options) => {
+  const argv = options.argv;
+  let mode: ToolPermissionContext["mode"] = "default";
+  if (argv !== undefined) {
+    if (argv.includes("--yolo")) mode = "bypassPermissions";
+    const flag = argv.indexOf("--permission-mode");
+    if (flag >= 0 && typeof argv[flag + 1] === "string") {
+      mode = argv[flag + 1] as ToolPermissionContext["mode"];
+    }
+  }
+  const registry = new PermissionModeRegistry(baseContext(mode));
+  bootstrapCalls.push({
+    argv,
+    registry,
+    conversationId: options.conversationId,
+    resumeConversation: options.resumeConversation,
+  });
+  return {
+    session: {
+      conversationId: options.conversationId ?? RUN_ID,
+      permissionModeRegistry: registry,
+      services: {},
+    },
+    rolloutStore: { runEpoch: 1 },
+    shutdown: async () => {},
+  } as never;
+};
+
+function makeSeams(
+  resolveRunPolicy: (runId: string) => WorkflowRunSessionPolicy | undefined = () =>
+    undefined,
+): WorkflowSessionSeams {
+  return createWorkflowSessionSeams({
+    kernel: {} as ExecutionAdmissionKernel,
+    durability: () => repo,
+    resolveRunRepoPath: () => cwd,
+    resolveRunPolicy: (runId) => {
+      const policy = resolveRunPolicy(runId);
+      resolvedPolicies.push(policy);
+      return policy;
+    },
+    fallbackCwd: cwd,
+    warn: () => {},
+    bootstrap: fakeBootstrap,
+  });
+}
+
+describe("A2 — spec permission policy on the run session", () => {
+  it("bypassPermissions rides --yolo on the bootstrap argv", async () => {
+    const seams = makeSeams();
+    await seams.journal.open(RUN_ID, {
+      repoPath: cwd,
+      policy: { permissionMode: "bypassPermissions" },
+    });
+    expect(bootstrapCalls).toHaveLength(1);
+    expect(bootstrapCalls[0].argv).toContain("--yolo");
+    expect(bootstrapCalls[0].argv).not.toContain("--permission-mode");
+    expect(bootstrapCalls[0].registry.current().mode).toBe(
+      "bypassPermissions",
+    );
+    await seams.close();
+  });
+
+  it("non-bypass modes ride --permission-mode and unattended lists install on the registry", async () => {
+    const seams = makeSeams();
+    await seams.journal.open(RUN_ID, {
+      repoPath: cwd,
+      policy: {
+        permissionMode: "acceptEdits",
+        unattendedAllow: ["Bash", "FileRead"],
+        unattendedDeny: ["Edit"],
+      },
+    });
+    const call = bootstrapCalls[0];
+    const argv = call.argv!;
+    expect(argv[argv.indexOf("--permission-mode") + 1]).toBe("acceptEdits");
+    const context = call.registry.current();
+    // Explicit acceptEdits is preserved; the declared lists are installed
+    // (canonicalized: bash → system.bash).
+    expect(context.mode).toBe("acceptEdits");
+    expect(context.unattendedPolicy).toMatchObject({
+      allowlist: ["system.bash", "FileRead"],
+      denylist: ["Edit"],
+    });
+    await seams.close();
+  });
+
+  it("default mode with declared lists becomes unattended", async () => {
+    const seams = makeSeams();
+    await seams.journal.open(RUN_ID, {
+      repoPath: cwd,
+      policy: { permissionMode: "default", unattendedAllow: ["Grep"] },
+    });
+    const context = bootstrapCalls[0].registry.current();
+    expect(context.mode).toBe("unattended");
+    expect(context.unattendedPolicy).toMatchObject({ allowlist: ["Grep"] });
+    await seams.close();
+  });
+
+  it("a resumed run re-resolves the policy from the durable intake spec", async () => {
+    const seams = makeSeams(() => ({
+      permissionMode: "plan",
+      unattendedDeny: ["Bash"],
+    }));
+    // No explicit policy → the resume path (journal.open without context).
+    await seams.journal.open(RUN_ID);
+    expect(resolvedPolicies).toEqual([
+      { permissionMode: "plan", unattendedDeny: ["Bash"] },
+    ]);
+    const call = bootstrapCalls[0];
+    expect(call.resumeConversation).toBe(true);
+    const argv = call.argv!;
+    expect(argv[argv.indexOf("--permission-mode") + 1]).toBe("plan");
+    const context = call.registry.current();
+    expect(context.mode).toBe("plan");
+    expect(context.unattendedPolicy).toMatchObject({
+      denylist: ["system.bash"],
+    });
+    await seams.close();
+  });
+
+  it("workflowPermissionModeArgv never duplicates flags already present", () => {
+    expect(
+      workflowPermissionModeArgv("bypassPermissions", ["node", "agenc", "--yolo"]),
+    ).toEqual(["node", "agenc", "--yolo"]);
+    expect(
+      workflowPermissionModeArgv("acceptEdits", [
+        "node",
+        "agenc",
+        "--permission-mode",
+        "plan",
+      ]),
+    ).toEqual(["node", "agenc", "--permission-mode", "plan"]);
+    expect(workflowPermissionModeArgv("plan", ["node", "agenc"])).toEqual([
+      "node",
+      "agenc",
+      "--permission-mode",
+      "plan",
+    ]);
+  });
+});
+
+describe("A1 — durable child terminals for cross-restart adoption", () => {
+  it("records and inspects a child terminal through the existing run machinery", () => {
+    const childRunId = `${RUN_ID}:implement#1`;
+    expect(inspectWorkflowChildTerminal(repo, childRunId)).toBeUndefined();
+    recordWorkflowChildTerminal(repo, childRunId, {
+      status: "completed",
+      finalMessage: "applied the fix",
+      usage: null,
+    });
+    // Idempotent re-record.
+    recordWorkflowChildTerminal(repo, childRunId, {
+      status: "completed",
+      finalMessage: "applied the fix",
+      usage: null,
+    });
+    expect(inspectWorkflowChildTerminal(repo, childRunId)).toEqual({
+      status: "completed",
+      finalMessage: "applied the fix",
+      usage: null,
+    });
+    // The durable record IS the existing run terminal machinery.
+    expect(repo.getCurrentTerminalResult(childRunId)).toMatchObject({
+      status: "completed",
+      exitCode: 0,
+      stopReason: null,
+    });
+  });
+
+  it("spawner.inspect adopts a durable child terminal after the in-memory maps are gone", async () => {
+    const seams = makeSeams();
+    // Open the run session (as resume does) so the owner entry exists, but
+    // with no live/settled children — the previous process died.
+    await seams.journal.open(RUN_ID, { repoPath: cwd });
+    const adopted = `${RUN_ID}:implement#1`;
+    recordWorkflowChildTerminal(repo, adopted, {
+      status: "failed",
+      finalMessage: "implementer errored",
+      usage: null,
+    });
+    await expect(seams.spawner.inspect(adopted)).resolves.toEqual({
+      state: "terminal",
+      outcome: {
+        status: "failed",
+        finalMessage: "implementer errored",
+        usage: null,
+      },
+    });
+    // A child that died mid-flight left no durable terminal: honestly
+    // unknown, never a respawn.
+    await expect(
+      seams.spawner.inspect(`${RUN_ID}:verify-agent#1`),
+    ).resolves.toEqual({ state: "unknown" });
+    await seams.close();
+  });
+});

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,5 @@
 AgenC MUST-DO TODO
-Updated: 2026-07-14
+Updated: 2026-07-20
 
 PURPOSE
 -------
@@ -483,7 +483,7 @@ Why this is mandatory: the competitive product is the completed, verified
 engineering outcome. A generic DAG, Kanban board, or collection of primitives is
 not the product.
 
-[ ] Converge existing machinery into this fixed first workflow:
+[x] Converge existing machinery into this fixed first workflow:
 
         intake and policy check
         -> isolated worktree
@@ -493,14 +493,14 @@ not the product.
         -> independent fresh-context review
         -> finalize evidence and patch
 
-[ ] Build on what already exists.
+[x] Build on what already exists.
     - Extend `runtime/src/agents/workflow-runner.ts`, the job orchestrator, task
       store, worktree helpers, durable rollout state, daemon protocol, and SDK.
     - Do not create a parallel WorkGraph database or a second task engine.
     - Persist workflow/step state, dependencies, leases, attempts, worktree and
       artifact pointers, verifier results, and terminal status.
 
-[ ] Protect the user's source checkout and patch integrity.
+[x] Protect the user's source checkout and patch integrity.
     - Record the exact base commit and dirty-state summary before work begins.
     - Never clean or modify the user's source checkout or unrelated dirty files;
       all agent changes happen in the isolated worktree.
@@ -508,14 +508,14 @@ not the product.
     - Detect base movement and patch conflicts. Rebase/reverify safely or return
       an explicit conflict instead of overwriting newer work.
 
-[ ] Make steps transactional where possible and explicit where not.
+[x] Make steps transactional where possible and explicit where not.
     - Use idempotency keys for supported effects.
     - Retry only safe steps.
     - Run independent steps in parallel within M3 limits.
     - Stop dependency unlocks after failed verification, cancellation, budget
       exhaustion, or `unknown_outcome`.
 
-[ ] Make verification part of completion, not optional metadata.
+[x] Make verification part of completion, not optional metadata.
     - Capture commands, exit codes, relevant output, and artifact hashes.
     - Run a reviewer in a fresh context that sees the task, diff, and evidence,
       not the implementer's hidden chain of thought.
@@ -525,7 +525,7 @@ not the product.
       reviewer reports an unresolved blocker.
     - Return unresolved risks honestly; do not convert them into success text.
 
-[ ] Expose one stable run across CLI/TUI/SDK.
+[x] Expose one stable run across CLI/TUI/SDK.
     - Starting the same workflow through any surface must create the same kind of
       durable run ID and policy/evidence contract.
     - Support start, status, attach/replay, cancel, terminal-result fetch, and
@@ -539,6 +539,25 @@ M5 DONE WHEN:
   platform-issued mutation or silently replayed uncertain effect.
 - A reviewer can reconstruct what happened from the exported evidence without
   reading daemon logs or trusting the final prose summary.
+
+M5 SHIPPED 2026-07-20 (PRs #1556-#1560, six phases):
+- Contract freeze (run.start + frozen workflow vocabulary), worktree/patch
+  integrity lib, verification + fresh-context review executors, the durable
+  controller over the M3/M4 spine (no new store; step state = run_effects
+  projection), run.start across protocol/CLI/SDK with real session adapters,
+  and the exit proofs.
+- DONE-WHEN evidence: hermetic exit test SIGKILLs the daemon harness at
+  after_spawn_before_effect_result (+ disconnect), restarts, adopts the
+  durably-recorded child terminal (never respawns), completes, and a hidden
+  verifier absent from every prompt passes against the exported patch on a
+  fresh clone; reservations reconciled-or-held; evidence-only reconstruction
+  re-derives the run from the exported bundle alone and detects single-byte
+  tampering. Revert-sensitivity observed (disabling child-terminal recording
+  turns the exit test red).
+- Honest M6 residuals: crash mid-independent-review still terminates
+  unknown_outcome (reviewer has no durable child terminal); local anchor is
+  integrity-only; child usage rollup undercounts for real delegate spawns;
+  docs/design/verified-change-workflow-m5.md records the full semantics.
 
 
 M6 -- PRODUCTIZE, DOGFOOD, COMPARE, AND RELEASE-GATE THE WIN


### PR DESCRIPTION
Final phase of M5 — closes the milestone.

- **Durable cross-restart child adoption**: workflow children record their terminal outcome as durable runs (existing `ensureInitialEpoch` + `run_terminal_results`, keyed by the deterministic childRunId) strictly before the parent effect result can commit; post-restart `inspect` adopts the terminal — never respawns. A child that genuinely died mid-flight stays honestly `unknown_outcome`.
- **Spec session policy**: the frozen spec's permissionMode + unattended lists are applied to the run's bootstrapped session (mirroring the background runner's argv + `applyUnattendedPermissionPolicyToContext` path), on start and on resume.
- **Hermetic exit test** (default PR suite): real git fixture with a seeded bug, SIGKILL of a child-process daemon harness at `after_spawn_before_effect_result` with the child terminal already durable, restart → `resumeOpenWorkflows` → terminal `completed`; exactly one implementer/worktree; reservations reconciled-or-held; cursor reattach clean; exported patch applies to a fresh clone and a **hidden verifier absent from every prompt and the recorded spec** passes.
- **Evidence-only reconstruction**: `reconstructVerifiedChange(bundleDir)` re-derives the whole run from the exported bundle alone (hash chain via seal-pinned digest, record + spec binding, CAS recompute per artifact, blocker re-derivation) and fails loudly on single-byte tamper. Env-gated acceptance lane combines both over the real daemon wiring.
- Docs: CLI/SDK references + design doc updated; todo.txt marks M5 SHIPPED with DONE-WHEN evidence and honest M6 residuals.
- Also aligns the grok continuation test with bbf85192f's intentional envelope-fallback chunk contract (stale pin went red in the full suite).

## Verification (local)
- typecheck clean; **full stable vitest: 1862 files / 16234 passed / 0 failed (SUITE-EXIT:0)**
- Four-suite battery from runtime/: 72 files / 756 tests green incl. the hermetic exit test; acceptance lane verified green under AGENC_M5_ACCEPTANCE=1
- Revert-sensitivity observed: disabling durable child-terminal recording turns the hermetic exit test red
- Tested SHA: 7f33ce64e6ece8c50a69e5e30522d45ed7ca0a08